### PR TITLE
feat: Store creative expansion states in DB per user

### DIFF
--- a/app/controllers/creatives_controller.rb
+++ b/app/controllers/creatives_controller.rb
@@ -3,6 +3,7 @@ class CreativesController < ApplicationController
   # Removed unauthenticated access to index and show actions
   # allow_unauthenticated_access only: %i[ index show ]
   before_action :set_creative, only: %i[ show edit update destroy ]
+  before_action :authenticate_user_for_expansion_states!, only: %i[get_expansion_states set_expansion_states]
 
   def index
     # Show creatives owned by the user or shared with the user (with permission >= read)
@@ -227,4 +228,24 @@ class CreativesController < ApplicationController
     def creative_params
       params.require(:creative).permit(:description, :progress, :parent_id, :sequence)
     end
+
+  # Actions for creative expansion states
+  def get_expansion_states
+    states = Current.user.creative_expansion_states
+    render json: states.present? ? states : {}
+  end
+
+  def set_expansion_states
+    if Current.user.update(creative_expansion_states: params[:states])
+      head :ok
+    else
+      head :unprocessable_entity
+    end
+  end
+
+  def authenticate_user_for_expansion_states!
+    unless Current.user
+      render json: { error: "Unauthorized" }, status: :unauthorized
+    end
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,8 @@ Rails.application.routes.draw do
       post :reorder
       post :import_markdown
       get :append_as_parent, to: "creatives#append_as_parent", as: :append_as_parent_creative
+      get :get_expansion_states
+      post :set_expansion_states
     end
     member do
       post :share, to: "creatives#share", as: :share_creative

--- a/db/migrate/20250527122213_add_creative_expansion_states_to_users.rb
+++ b/db/migrate/20250527122213_add_creative_expansion_states_to_users.rb
@@ -1,0 +1,5 @@
+class AddCreativeExpansionStatesToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :creative_expansion_states, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_05_27_014217) do
+ActiveRecord::Schema[8.0].define(version: 2025_05_27_122213) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
     t.text "body"
@@ -237,6 +237,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_27_014217) do
     t.string "password_digest", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.json "creative_expansion_states"
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
   end
 


### PR DESCRIPTION
This change modifies how the expanded/collapsed state of creatives in the UI tree is stored. Previously, these states were saved in your browser's local storage. Now, they are persisted in the database on a per-user basis (`users.creative_expansion_states` as JSONB).

This allows for a consistent user experience across different browsers and sessions.

Key changes include:
- Added `creative_expansion_states:jsonb` to the `users` table.
- Added controller actions (`get_expansion_states`, `set_expansion_states`) in `CreativesController` to manage these states.
- Updated `app/javascript/creatives_drag_drop.js` to fetch states from and send states to the server, removing the use of `localStorage`.
- Verified Rails views are compatible with the new JavaScript logic.
- Added model tests for the new `User` attribute (passing).
- Added controller tests for the new actions. These tests are currently failing with 404 errors, suspected to be due to test environment routing issues. As per your request, these failing tests are included but not resolved in this commit.