### PR TITLE
Add invitation workflow for sharing

### DIFF
--- a/app/controllers/creative_shares_controller.rb
+++ b/app/controllers/creative_shares_controller.rb
@@ -3,7 +3,9 @@ class CreativeSharesController < ApplicationController
     @creative = Creative.find(params[:creative_id]).effective_origin
     user = User.find_by(email: params[:user_email])
     unless user
-      flash[:alert] = "User not found"
+      invitation = Invitation.create!(email: params[:user_email], inviter: Current.user, creative: @creative, permission: params[:permission])
+      InvitationMailer.with(invitation: invitation).invite.deliver_later
+      flash[:notice] = t("invites.invite_sent")
       redirect_back(fallback_location: creatives_path) and return
     end
 

--- a/app/controllers/creative_shares_controller.rb
+++ b/app/controllers/creative_shares_controller.rb
@@ -20,7 +20,7 @@ class CreativeSharesController < ApplicationController
       share = CreativeShare.find_or_initialize_by(creative: @creative, user: user)
       share.permission = permission
       if share.save
-        create_linked_creative_for_user user, @creative
+        @creative.create_linked_creative_for_user(user)
         flash[:notice] = t("creatives.share.shared")
       else
         flash[:alert] = share.errors.full_messages.to_sentence
@@ -47,16 +47,5 @@ class CreativeSharesController < ApplicationController
 
     def all_descendants(creative)
       creative.children.flat_map { |child| [ child ] + all_descendants(child) }
-    end
-
-    def create_linked_creative_for_user(user, to_creative)
-      # 만약 creative 가 이미 Linked Creative 면, origin 을 사용해야 함.
-      creative = to_creative.effective_origin
-      return if creative.user_id == user.id
-      # 이미 Linked Creative가 있으면 생성하지 않음
-      linked = Creative.find_by(origin_id: creative.id, user_id: user.id)
-      return if linked
-      linked = Creative.new(origin_id: creative.id, user_id: user.id, parent_id: nil)
-      linked.save!
     end
 end

--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -1,0 +1,18 @@
+class InvitesController < ApplicationController
+  allow_unauthenticated_access
+  before_action :set_invitation
+
+  def show
+    @invitation.update(clicked_at: Time.current) unless @invitation.clicked_at
+    @user = User.new(email: @invitation.email)
+    render "users/new"
+  end
+
+  private
+
+  def set_invitation
+    @invitation = Invitation.find_by_token_for(:invite, params[:token])
+  rescue ActiveSupport::MessageVerifier::InvalidSignature
+    redirect_to new_user_path, alert: t("invites.invalid")
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -18,6 +18,7 @@ class UsersController < ApplicationController
         if invitation
           invitation.update(accepted_at: Time.current)
           CreativeShare.create!(creative: invitation.creative, user: @user, permission: invitation.permission)
+          invitation.creative.create_linked_creative_for_user(@user)
         end
         session.delete(:return_to_after_authenticating)
         redirect_to new_session_path, notice: t("users.new.success_sign_up")

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,6 +11,7 @@ class UsersController < ApplicationController
       if params[:invite_token].present?
         invitation = Invitation.find_by_token_for(:invite, params[:invite_token])
         if invitation
+          @invitation = invitation
           @user.email = invitation.email
         end
       end

--- a/app/javascript/controllers/share_invite_controller.js
+++ b/app/javascript/controllers/share_invite_controller.js
@@ -1,0 +1,15 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["email", "submit"]
+
+  check() {
+    const email = this.emailTarget.value
+    if (!email) return
+    fetch(`/users/exists?email=${encodeURIComponent(email)}`)
+      .then(r => r.json())
+      .then(data => {
+        this.submitTarget.textContent = data.exists ? this.submitTarget.dataset.share : this.submitTarget.dataset.invite
+      })
+  }
+}

--- a/app/mailers/invitation_mailer.rb
+++ b/app/mailers/invitation_mailer.rb
@@ -1,0 +1,6 @@
+class InvitationMailer < ApplicationMailer
+  def invite
+    @invitation = params[:invitation]
+    mail to: @invitation.email, subject: t("invitation_mailer.invite.subject")
+  end
+end

--- a/app/models/creative.rb
+++ b/app/models/creative.rb
@@ -106,6 +106,16 @@ class Creative < ApplicationRecord
     end
   end
 
+  # 공유 대상 사용자를 위해 Linked Creative를 생성합니다.
+  # 이미 존재하거나 원본 작성자에게는 생성하지 않습니다.
+  def create_linked_creative_for_user(user)
+    original = effective_origin
+    return if original.user_id == user.id
+    Creative.find_or_create_by!(origin_id: original.id, user_id: user.id) do |c|
+      c.parent_id = nil
+    end
+  end
+
   def update_parent_progress
     # 참조 하는 모든 Linked Creative 도 업데이트
     linked_creatives.update_all(progress: self[:progress])

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -2,7 +2,7 @@ class Invitation < ApplicationRecord
   belongs_to :inviter, class_name: "User"
   belongs_to :creative
 
-  enum permission: CreativeShare.permissions
+  enum :permission, CreativeShare.permissions
 
   generates_token_for :invite, expires_in: 15.days
 

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -1,0 +1,19 @@
+class Invitation < ApplicationRecord
+  belongs_to :inviter, class_name: "User"
+  belongs_to :creative
+
+  enum permission: CreativeShare.permissions
+
+  generates_token_for :invite, expires_in: 15.days
+
+  validates :email, presence: true
+  validates :expires_at, presence: true
+
+  before_validation :set_default_expires_at, on: :create
+
+  private
+
+  def set_default_expires_at
+    self.expires_at ||= 15.days.from_now
+  end
+end

--- a/app/views/creatives/_share_button.html.erb
+++ b/app/views/creatives/_share_button.html.erb
@@ -17,11 +17,11 @@
         </ul>
       </div>
     <% end %>
-    <form id="share-creative-form" action="<%= creative_creative_shares_path(@parent_creative || @creative) %>" method="post">
+    <form id="share-creative-form" action="<%= creative_creative_shares_path(@parent_creative || @creative) %>" method="post" data-controller="share-invite">
       <%= csrf_meta_tags %>
       <div style="margin-bottom:1em;">
         <label for="share-user-email"><%= t('creatives.index.user_email') %></label>
-        <input type="email" name="user_email" id="share-user-email" required style="width:100%;" />
+        <input type="email" name="user_email" id="share-user-email" required style="width:100%;" data-share-invite-target="email" data-action="blur->share-invite#check" />
       </div>
       <div style="margin-bottom:1em;">
         <label for="share-permission"><%= t('creatives.index.permission') %></label>
@@ -32,7 +32,7 @@
           <option value="write_tree"><%= t('creatives.index.permission_write_tree') %></option>
         </select>
       </div>
-      <button type="submit" class="btn btn-primary"><%= t('creatives.index.share') %></button>
+      <button type="submit" class="btn btn-primary" data-share-invite-target="submit" data-share="<%= t('creatives.index.share') %>" data-invite="<%= t('creatives.index.invite') %>"><%= t('creatives.index.share') %></button>
     </form>
   </div>
 </div>

--- a/app/views/invitation_mailer/invite.html.erb
+++ b/app/views/invitation_mailer/invite.html.erb
@@ -1,6 +1,6 @@
 <p>
   You have been invited to collaborate on
-  "<%= @invitation.creative.description %>".
+  "<%= @invitation.creative.description.to_plain_text %>".
   Click <%= link_to 'here', invite_url(token: @invitation.generate_token_for(:invite)) %>
   to accept within 15 days.
 </p>

--- a/app/views/invitation_mailer/invite.html.erb
+++ b/app/views/invitation_mailer/invite.html.erb
@@ -1,0 +1,6 @@
+<p>
+  You have been invited to collaborate on
+  "<%= @invitation.creative.description %>".
+  Click <%= link_to 'here', invite_url(token: @invitation.generate_token_for(:invite)) %>
+  to accept within 15 days.
+</p>

--- a/app/views/invitation_mailer/invite.text.erb
+++ b/app/views/invitation_mailer/invite.text.erb
@@ -1,0 +1,3 @@
+You have been invited to collaborate on "<%= @invitation.creative.description %>".
+Join using this link:
+<%= invite_url(token: @invitation.generate_token_for(:invite)) %>

--- a/app/views/invitation_mailer/invite.text.erb
+++ b/app/views/invitation_mailer/invite.text.erb
@@ -1,3 +1,3 @@
-You have been invited to collaborate on "<%= @invitation.creative.description %>".
+You have been invited to collaborate on "<%= @invitation.creative.description.to_plain_text %>".
 Join using this link:
 <%= invite_url(token: @invitation.generate_token_for(:invite)) %>

--- a/app/views/users/_id_pwd_fields.html.erb
+++ b/app/views/users/_id_pwd_fields.html.erb
@@ -1,2 +1,8 @@
-<%= form.email_field :email, required: true, autofocus: true, autocomplete: "username", placeholder: t('users.new.enter_your_email'), value: params[:email] %><br/>
+<%= form.email_field :email,
+                     required: true,
+                     autofocus: true,
+                     autocomplete: "username",
+                     placeholder: t('users.new.enter_your_email'),
+                     value: form.object.email.presence || params[:email],
+                     readonly: local_assigns[:disable_email] %><br/>
 <%= form.password_field :password, required: true, autocomplete: "current-password", placeholder: t('users.new.enter_your_password'), maxlength: 72 %><br/>

--- a/app/views/users/_id_pwd_fields.html.erb
+++ b/app/views/users/_id_pwd_fields.html.erb
@@ -3,6 +3,6 @@
                      autofocus: true,
                      autocomplete: "username",
                      placeholder: t('users.new.enter_your_email'),
-                     value: form.object.email.presence || params[:email],
+                     value: (form.object.respond_to?(:email) && form.object.email.presence) || params[:email],
                      readonly: local_assigns[:disable_email] %><br/>
 <%= form.password_field :password, required: true, autocomplete: "current-password", placeholder: t('users.new.enter_your_password'), maxlength: 72 %><br/>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -11,7 +11,7 @@
   <% if defined?(@invitation) && @invitation.present? %>
     <%= hidden_field_tag :invite_token, params[:token] %>
   <% end %>
-  <%= render 'users/id_pwd_fields', form: form %>
+  <%= render 'users/id_pwd_fields', form: form, disable_email: defined?(@invitation) && @invitation.present? %>
 
   <%= form.password_field :password_confirmation, required: true, autocomplete: "new-password", placeholder: t('.confirm_your_password'), maxlength: 72 %><br/>
   <%= form.submit t('.sign_up') %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -3,7 +3,7 @@
 <% if defined?(@invitation) && @invitation.present? %>
   <p>
     <strong><%= t('creatives.index.share_creative') %>:</strong>
-    <%= @invitation.creative.description %>
+    <%= @invitation.creative.description.to_plain_text %>
   </p>
 <% end %>
 

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -9,7 +9,7 @@
 
 <%= form_with model: @user, url: users_path do |form| %>
   <% if defined?(@invitation) && @invitation.present? %>
-    <%= hidden_field_tag :invite_token, params[:token] %>
+    <%= hidden_field_tag :invite_token, params[:invite_token] || params[:token] %>
   <% end %>
   <%= render 'users/id_pwd_fields', form: form, disable_email: defined?(@invitation) && @invitation.present? %>
 

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,6 +1,16 @@
 <%= render 'users/app_header' %>
 
+<% if defined?(@invitation) && @invitation.present? %>
+  <p>
+    <strong><%= t('creatives.index.share_creative') %>:</strong>
+    <%= @invitation.creative.description %>
+  </p>
+<% end %>
+
 <%= form_with model: @user, url: users_path do |form| %>
+  <% if defined?(@invitation) && @invitation.present? %>
+    <%= hidden_field_tag :invite_token, params[:token] %>
+  <% end %>
   <%= render 'users/id_pwd_fields', form: form %>
 
   <%= form.password_field :password_confirmation, required: true, autocomplete: "new-password", placeholder: t('.confirm_your_password'), maxlength: 72 %><br/>

--- a/config/locales/creatives.en.yml
+++ b/config/locales/creatives.en.yml
@@ -34,6 +34,7 @@ en:
       permission_write: "Write"
       permission_write_tree: "Write Tree"
       share: "Share"
+      invite: "Invite"
       plan_tags_applied: "Plan tags applied to selected creatives."
       plan_tag_failed: "Please select a plan and at least one creative."
       plan_tags_removed: "Plan tag removed from selected creatives."

--- a/config/locales/creatives.ko.yml
+++ b/config/locales/creatives.ko.yml
@@ -34,6 +34,7 @@ ko:
       permission_write: "쓰기"
       permission_write_tree: "쓰기(트리)"
       share: "공유하기"
+      invite: "초대하기"
       plan_tags_applied: "선택한 크리에이티브에 플랜 태그가 적용되었습니다."
       plan_tag_failed: "플랜과 하나 이상의 크리에이티브를 선택하세요."
       plan_tags_removed: "선택한 크리에이티브에서 플랜 태그가 제거되었습니다."

--- a/config/locales/invites.en.yml
+++ b/config/locales/invites.en.yml
@@ -1,0 +1,7 @@
+en:
+  invites:
+    invalid: "Invitation link is invalid or has expired."
+    invite_sent: "Invitation email sent."
+  invitation_mailer:
+    invite:
+      subject: "You're invited to Plan42"

--- a/config/locales/invites.ko.yml
+++ b/config/locales/invites.ko.yml
@@ -1,0 +1,7 @@
+ko:
+  invites:
+    invalid: "초대 링크가 잘못되었거나 만료되었습니다."
+    invite_sent: "초대 이메일을 보냈습니다."
+  invitation_mailer:
+    invite:
+      subject: "Plan42에 초대되었습니다"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,9 @@ Rails.application.routes.draw do
       get :edit_password
       patch :update_password
     end
+    collection do
+      get :exists
+    end
   end
 
   resources :creatives do
@@ -44,6 +47,7 @@ Rails.application.routes.draw do
   resources :plans, only: [ :create, :destroy ]
 
   resource :unsubscribe, only: [ :show ]
+  resource :invite, only: [ :show ]
 
-  post '/creative_expanded_states/toggle', to: 'creative_expanded_states#toggle'
+  post "/creative_expanded_states/toggle", to: "creative_expanded_states#toggle"
 end

--- a/db/migrate/20250610142000_create_creative_expanded_states.rb
+++ b/db/migrate/20250610142000_create_creative_expanded_states.rb
@@ -6,6 +6,6 @@ class CreateCreativeExpandedStates < ActiveRecord::Migration[8.0]
       t.json :expanded_status, null: false, default: {}
       t.timestamps
     end
-    add_index :creative_expanded_states, [:creative_id, :user_id], unique: true
+    add_index :creative_expanded_states, [ :creative_id, :user_id ], unique: true
   end
 end

--- a/db/migrate/20250611030138_create_invitations.rb
+++ b/db/migrate/20250611030138_create_invitations.rb
@@ -1,0 +1,15 @@
+class CreateInvitations < ActiveRecord::Migration[8.0]
+  def change
+    create_table :invitations do |t|
+      t.string :email
+      t.references :inviter, null: false, foreign_key: { to_table: :users }
+      t.references :creative, null: false, foreign_key: true
+      t.integer :permission
+      t.datetime :expires_at
+      t.datetime :clicked_at
+      t.datetime :accepted_at
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_10_142000) do
+ActiveRecord::Schema[8.0].define(version: 2025_06_11_030138) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
     t.text "body"
@@ -102,6 +102,20 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_142000) do
     t.index ["origin_id"], name: "index_creatives_on_origin_id"
     t.index ["parent_id"], name: "index_creatives_on_parent_id"
     t.index ["user_id"], name: "index_creatives_on_user_id"
+  end
+
+  create_table "invitations", force: :cascade do |t|
+    t.string "email"
+    t.integer "inviter_id", null: false
+    t.integer "creative_id", null: false
+    t.integer "permission"
+    t.datetime "expires_at"
+    t.datetime "clicked_at"
+    t.datetime "accepted_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["creative_id"], name: "index_invitations_on_creative_id"
+    t.index ["inviter_id"], name: "index_invitations_on_inviter_id"
   end
 
   create_table "labels", force: :cascade do |t|
@@ -302,6 +316,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_142000) do
   add_foreign_key "creatives", "creatives", column: "origin_id"
   add_foreign_key "creatives", "creatives", column: "parent_id"
   add_foreign_key "creatives", "users"
+  add_foreign_key "invitations", "creatives"
+  add_foreign_key "invitations", "users", column: "inviter_id"
   add_foreign_key "labels", "users", column: "owner_id"
   add_foreign_key "sessions", "users"
   add_foreign_key "solid_queue_blocked_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade

--- a/test/integration/invitation_flow_test.rb
+++ b/test/integration/invitation_flow_test.rb
@@ -26,5 +26,6 @@ class InvitationFlowTest < ActionDispatch::IntegrationTest
     invitation.reload
     assert_not_nil invitation.clicked_at
     assert_select "input[name=invite_token][value=?]", token
+    assert_select "input[name='user[email]'][readonly][value=?]", "invitee@example.com"
   end
 end

--- a/test/integration/invitation_flow_test.rb
+++ b/test/integration/invitation_flow_test.rb
@@ -1,0 +1,30 @@
+require "test_helper"
+require "cgi"
+
+class InvitationFlowTest < ActionDispatch::IntegrationTest
+  test "invitation link resolves to invitation" do
+    inviter = User.create!(email: "inviter@example.com", password: "secret")
+    creative = Creative.create!(user: inviter, description: "Test creative")
+
+    invitation = Invitation.create!(email: "invitee@example.com",
+                                    inviter: inviter,
+                                    creative: creative,
+                                    permission: :read)
+
+    ActionMailer::Base.deliveries.clear
+    InvitationMailer.with(invitation: invitation).invite.deliver_now
+
+    mail = ActionMailer::Base.deliveries.last
+    body = mail.text_part ? mail.text_part.body.decoded : mail.body.decoded
+    token = CGI.unescape(body[/token=([^"\s]+)/, 1])
+    assert token.present?, "token should be present in email"
+
+    assert_nil invitation.clicked_at
+    get invite_path(token: token)
+    assert_response :success
+
+    invitation.reload
+    assert_not_nil invitation.clicked_at
+    assert_select "input[name=invite_token][value=?]", token
+  end
+end


### PR DESCRIPTION
## Summary
- add invitation table and model
- send invitation email when sharing with unknown user
- expose invites controller and users exists endpoint
- render creative description on sign up from invitation
- change share modal button dynamically to invite

## Testing
- `bundle exec rails db:migrate`
- `bin/rubocop`
- `bundle exec rspec` *(fails: Selenium manager cannot download Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_6848f0d329248326af769f3d493794a8