### PR TITLE
Add plan timeline view

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem "importmap-rails"
 gem "turbo-rails"
 # Hotwire's modest JavaScript framework [https://stimulus.hotwired.dev]
 gem "stimulus-rails"
+gem "view_component"
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 gem "jbuilder"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,6 +167,7 @@ GEM
       net-smtp
     marcel (1.0.4)
     matrix (0.4.2)
+    method_source (1.1.0)
     mini_magick (5.2.0)
       benchmark
       logger
@@ -377,6 +378,10 @@ GEM
     unicode-emoji (4.0.4)
     uri (1.0.3)
     useragent (0.16.11)
+    view_component (3.23.2)
+      activesupport (>= 5.2.0, < 8.1)
+      concurrent-ruby (~> 1)
+      method_source (~> 1.0)
     web-console (4.2.1)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -431,6 +436,7 @@ DEPENDENCIES
   thruster
   turbo-rails
   tzinfo-data
+  view_component
   web-console
 
 BUNDLED WITH

--- a/app/components/plan_timeline_component.html.erb
+++ b/app/components/plan_timeline_component.html.erb
@@ -1,0 +1,21 @@
+<style>
+#plan-timeline{position:relative;overflow-x:auto;white-space:nowrap;padding-top:2em;border-top:1px solid #ccc;}
+#plan-timeline .month-label{position:absolute;top:0;font-weight:bold;background:white;padding:0 4px;}
+#plan-timeline .month-left{left:0;}
+#plan-timeline .month-right{right:0;}
+#plan-timeline .days{display:flex;}
+#plan-timeline .day{width:80px;text-align:center;min-height:4em;}
+#plan-timeline .day.has-plan{border-left:2px solid #333;padding-left:4px;}
+#plan-timeline .day-num{font-size:0.9em;margin-bottom:0.5em;}
+#plan-timeline .nav-button{position:absolute;top:50%;transform:translateY(-50%);background:white;border:1px solid #ccc;cursor:pointer;padding:0 4px;}
+#plan-timeline .nav-left{left:0;}
+#plan-timeline .nav-right{right:0;}
+</style>
+<div id="plan-timeline">
+  <div class="month-label month-left"></div>
+  <div class="month-label month-right"></div>
+  <button class="nav-button nav-left" type="button">◀</button>
+  <div class="days"></div>
+  <button class="nav-button nav-right" type="button">▶</button>
+</div>
+<%= javascript_include_tag 'plan_timeline', defer: true %>

--- a/app/components/plan_timeline_component.rb
+++ b/app/components/plan_timeline_component.rb
@@ -1,0 +1,2 @@
+class PlanTimelineComponent < ViewComponent::Base
+end

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -1,4 +1,17 @@
 class PlansController < ApplicationController
+  def index
+    respond_to do |format|
+      format.html
+      format.json do
+        start_date = params[:start]&.to_date
+        end_date = params[:end]&.to_date
+        plans = Plan.where(owner: Current.user).or(Plan.where(owner: nil))
+        plans = plans.where(target_date: start_date..end_date) if start_date && end_date
+        render json: plans.group_by(&:target_date).transform_values { |ps| ps.map(&:name) }
+      end
+    end
+  end
+
   def create
     @plan = Plan.new(plan_params)
     @plan.owner = Current.user

--- a/app/javascript/plan_timeline.js
+++ b/app/javascript/plan_timeline.js
@@ -7,6 +7,8 @@ if (!window.planTimelineInitialized) {
     const daysWrapper = container.querySelector('.days');
     const monthLeft = container.querySelector('.month-left');
     const monthRight = container.querySelector('.month-right');
+    const navLeft = container.querySelector('.nav-left');
+    const navRight = container.querySelector('.nav-right');
     const DAY_WIDTH = 80;
 
     function formatDate(d) {
@@ -68,6 +70,14 @@ if (!window.planTimelineInitialized) {
       if (first) monthLeft.textContent = first.slice(0,7);
       if (last) monthRight.textContent = last.slice(0,7);
     }
+
+    navLeft.addEventListener('click', function() {
+      container.scrollBy({left: -7 * DAY_WIDTH, behavior: 'smooth'});
+    });
+
+    navRight.addEventListener('click', function() {
+      container.scrollBy({left: 7 * DAY_WIDTH, behavior: 'smooth'});
+    });
 
     container.addEventListener('scroll', function() {
       updateMonths();

--- a/app/javascript/plan_timeline.js
+++ b/app/javascript/plan_timeline.js
@@ -1,0 +1,92 @@
+if (!window.planTimelineInitialized) {
+  window.planTimelineInitialized = true;
+
+  document.addEventListener('turbo:load', function() {
+    const container = document.getElementById('plan-timeline');
+    if (!container) return;
+    const daysWrapper = container.querySelector('.days');
+    const monthLeft = container.querySelector('.month-left');
+    const monthRight = container.querySelector('.month-right');
+    const DAY_WIDTH = 80;
+
+    function formatDate(d) {
+      return d.toISOString().slice(0,10);
+    }
+    function addDays(d, n) {
+      const nd = new Date(d);
+      nd.setDate(nd.getDate() + n);
+      return nd;
+    }
+
+    function loadRange(start, end, prepend=false) {
+      fetch(`/plans.json?start=${formatDate(start)}&end=${formatDate(end)}`)
+        .then(r => r.json())
+        .then(data => {
+          const fragment = document.createDocumentFragment();
+          for (let d = new Date(start); d <= end; d = addDays(d, 1)) {
+            const iso = formatDate(d);
+            const div = document.createElement('div');
+            div.className = 'day';
+            div.dataset.date = iso;
+            div.style.width = DAY_WIDTH + 'px';
+            div.innerHTML = `<div class='day-num'>${('0'+d.getDate()).slice(-2)}</div>`;
+            const plans = data[iso] || [];
+            if (plans.length) {
+              div.classList.add('has-plan');
+              const list = document.createElement('div');
+              plans.forEach(name => {
+                const item = document.createElement('div');
+                item.textContent = name;
+                list.appendChild(item);
+              });
+              div.appendChild(list);
+            }
+            if (prepend) {
+              fragment.prepend(div);
+            } else {
+              fragment.appendChild(div);
+            }
+          }
+          if (prepend) {
+            daysWrapper.prepend(fragment);
+            container.scrollLeft += (Math.ceil((end-start)/86400000)+1) * DAY_WIDTH;
+          } else {
+            daysWrapper.appendChild(fragment);
+          }
+          updateMonths();
+        });
+    }
+
+    function updateMonths() {
+      const rect = container.getBoundingClientRect();
+      let first = null, last = null;
+      daysWrapper.querySelectorAll('.day').forEach(el => {
+        const r = el.getBoundingClientRect();
+        if (r.right >= rect.left && first === null) first = el.dataset.date;
+        if (r.left <= rect.right) last = el.dataset.date;
+      });
+      if (first) monthLeft.textContent = first.slice(0,7);
+      if (last) monthRight.textContent = last.slice(0,7);
+    }
+
+    container.addEventListener('scroll', function() {
+      updateMonths();
+      if (container.scrollLeft < 50) {
+        const firstDate = new Date(daysWrapper.firstElementChild.dataset.date);
+        const s = addDays(firstDate, -30);
+        const e = addDays(firstDate, -1);
+        loadRange(s, e, true);
+      }
+      if (container.scrollWidth - container.clientWidth - container.scrollLeft < 50) {
+        const lastDate = new Date(daysWrapper.lastElementChild.dataset.date);
+        const s = addDays(lastDate, 1);
+        const e = addDays(lastDate, 30);
+        loadRange(s, e, false);
+      }
+    });
+
+    const start = addDays(new Date(), -15);
+    const end = addDays(new Date(), 15);
+    loadRange(start, end, false);
+  });
+}

--- a/app/views/plans/index.html.erb
+++ b/app/views/plans/index.html.erb
@@ -1,17 +1,2 @@
 <h1><%= t('app.plans') %></h1>
-<style>
-#plan-timeline{position:relative;overflow-x:auto;white-space:nowrap;padding-top:2em;border-top:1px solid #ccc;}
-#plan-timeline .month-label{position:absolute;top:0;font-weight:bold;background:white;padding:0 4px;}
-#plan-timeline .month-left{left:0;}
-#plan-timeline .month-right{right:0;}
-#plan-timeline .days{display:flex;}
-#plan-timeline .day{width:80px;text-align:center;min-height:4em;}
-#plan-timeline .day.has-plan{border-left:2px solid #333;padding-left:4px;}
-#plan-timeline .day-num{font-size:0.9em;margin-bottom:0.5em;}
-</style>
-<div id="plan-timeline">
-  <div class="month-label month-left"></div>
-  <div class="month-label month-right"></div>
-  <div class="days"></div>
-</div>
-<%= javascript_include_tag 'plan_timeline', defer: true %>
+<%= render PlanTimelineComponent.new %>

--- a/app/views/plans/index.html.erb
+++ b/app/views/plans/index.html.erb
@@ -1,0 +1,17 @@
+<h1><%= t('app.plans') %></h1>
+<style>
+#plan-timeline{position:relative;overflow-x:auto;white-space:nowrap;padding-top:2em;border-top:1px solid #ccc;}
+#plan-timeline .month-label{position:absolute;top:0;font-weight:bold;background:white;padding:0 4px;}
+#plan-timeline .month-left{left:0;}
+#plan-timeline .month-right{right:0;}
+#plan-timeline .days{display:flex;}
+#plan-timeline .day{width:80px;text-align:center;min-height:4em;}
+#plan-timeline .day.has-plan{border-left:2px solid #333;padding-left:4px;}
+#plan-timeline .day-num{font-size:0.9em;margin-bottom:0.5em;}
+</style>
+<div id="plan-timeline">
+  <div class="month-label month-left"></div>
+  <div class="month-label month-right"></div>
+  <div class="days"></div>
+</div>
+<%= javascript_include_tag 'plan_timeline', defer: true %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,7 +44,7 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :plans, only: [ :create, :destroy ]
+  resources :plans, only: [ :index, :create, :destroy ]
 
   resource :unsubscribe, only: [ :show ]
   resource :invite, only: [ :show ]


### PR DESCRIPTION
## Summary
- add index route for plans
- implement PlansController#index with HTML and JSON support
- create a horizontally scrollable timeline view for plans
- add JavaScript to load plans by date and update month headers

## Testing
- `bundle exec rspec --format documentation` *(fails: Selenium unable to download chrome)*

------
https://chatgpt.com/codex/tasks/task_e_684924356f10832691a0124dbe350031