### PR TITLE
Add inbox feature

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -79,3 +79,29 @@ button {
     max-width: 1024px;
     margin: 0.5em auto;
 }
+
+#inbox-panel.slide-panel {
+    position: fixed;
+    top: 0;
+    right: -300px;
+    width: 300px;
+    height: 100%;
+    background: var(--color-bg, white);
+    box-shadow: -2px 0 5px rgba(0,0,0,0.2);
+    overflow-y: auto;
+    transition: right 0.3s;
+    z-index: 1000;
+}
+
+#inbox-panel.open {
+    right: 0;
+}
+
+.inbox-item {
+    border-bottom: 1px solid #eee;
+    padding: 0.5em;
+}
+
+.inbox-item .actions button {
+    margin-right: 0.5em;
+}

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -97,6 +97,22 @@ button {
     right: 0;
 }
 
+.inbox-panel-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.5em;
+    border-bottom: 1px solid #eee;
+}
+
+#close-inbox {
+    background: none;
+    border: none;
+    font-size: 1.2em;
+    line-height: 1;
+    cursor: pointer;
+}
+
 .inbox-item {
     border-bottom: 1px solid #eee;
     padding: 0.5em;

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -121,3 +121,17 @@ button {
 .inbox-item .actions button {
     margin-right: 0.5em;
 }
+
+#inbox-menu-btn {
+    position: relative;
+}
+
+#inbox-badge {
+    background: red;
+    color: white;
+    border-radius: 10px;
+    padding: 0 4px;
+    font-size: 0.75em;
+    margin-left: 4px;
+    display: none;
+}

--- a/app/assets/stylesheets/comments_popup.css
+++ b/app/assets/stylesheets/comments_popup.css
@@ -70,3 +70,12 @@
     }
 }
 
+.comment-item.highlight-flash {
+    animation: comment-flash 2s ease-out;
+}
+
+@keyframes comment-flash {
+    from { background: #ffff99; }
+    to { background: transparent; }
+}
+

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,6 +1,6 @@
 class CommentsController < ApplicationController
   before_action :set_creative
-  before_action :set_comment, only: [:destroy, :show]
+  before_action :set_comment, only: [ :destroy, :show ]
 
   def index
     @comments = @creative.comments.order(created_at: :desc)

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,5 +1,6 @@
 class CommentsController < ApplicationController
   before_action :set_creative
+  before_action :set_comment, only: [:destroy, :show]
 
   def index
     @comments = @creative.comments.order(created_at: :desc)
@@ -17,7 +18,7 @@ class CommentsController < ApplicationController
   end
 
   def destroy
-    @comment = @creative.comments.find(params[:id])
+    # @comment is set by before_action
     if @comment.user == Current.user
       @comment.destroy
       head :no_content
@@ -26,10 +27,18 @@ class CommentsController < ApplicationController
     end
   end
 
+  def show
+    redirect_to creative_path(@creative, comment_id: @comment.id)
+  end
+
   private
 
   def set_creative
     @creative = Creative.find(params[:creative_id]).effective_origin
+  end
+
+  def set_comment
+    @comment = @creative.comments.find(params[:id])
   end
 
   def comment_params

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -30,7 +30,9 @@ module Authentication
     end
 
     def request_authentication
-      session[:return_to_after_authenticating] = request.url
+      unless request.path.start_with?("/inbox")
+        session[:return_to_after_authenticating] = request.url
+      end
       redirect_to new_session_path
     end
 

--- a/app/controllers/inbox_items_controller.rb
+++ b/app/controllers/inbox_items_controller.rb
@@ -8,6 +8,11 @@ class InboxItemsController < ApplicationController
     render partial: "inbox_items/list", locals: { items: @inbox_items }
   end
 
+  def count
+    c = InboxItem.where(owner: Current.user, state: 'new').count
+    render json: { count: c }
+  end
+
   def update
     if @inbox_item.owner == Current.user
       @inbox_item.update(state: params[:state])

--- a/app/controllers/inbox_items_controller.rb
+++ b/app/controllers/inbox_items_controller.rb
@@ -1,0 +1,32 @@
+class InboxItemsController < ApplicationController
+  before_action :set_inbox_item, only: [:update, :destroy]
+
+  def index
+    @inbox_items = InboxItem.where(owner: Current.user).order(created_at: :desc)
+    render partial: "inbox_items/list", locals: { items: @inbox_items }
+  end
+
+  def update
+    if @inbox_item.owner == Current.user
+      @inbox_item.update(state: params[:state])
+      head :no_content
+    else
+      head :forbidden
+    end
+  end
+
+  def destroy
+    if @inbox_item.owner == Current.user
+      @inbox_item.destroy
+      head :no_content
+    else
+      head :forbidden
+    end
+  end
+
+  private
+
+  def set_inbox_item
+    @inbox_item = InboxItem.find(params[:id])
+  end
+end

--- a/app/controllers/inbox_items_controller.rb
+++ b/app/controllers/inbox_items_controller.rb
@@ -1,15 +1,15 @@
 class InboxItemsController < ApplicationController
-  before_action :set_inbox_item, only: [:update, :destroy]
+  before_action :set_inbox_item, only: [ :update, :destroy ]
 
   def index
     scope = InboxItem.where(owner: Current.user).order(created_at: :desc)
-    scope = scope.new_items unless params[:show] == 'all'
+    scope = scope.new_items unless params[:show] == "all"
     @inbox_items = scope
     render partial: "inbox_items/list", locals: { items: @inbox_items }
   end
 
   def count
-    c = InboxItem.where(owner: Current.user, state: 'new').count
+    c = InboxItem.where(owner: Current.user, state: "new").count
     render json: { count: c }
   end
 

--- a/app/controllers/inbox_items_controller.rb
+++ b/app/controllers/inbox_items_controller.rb
@@ -2,7 +2,9 @@ class InboxItemsController < ApplicationController
   before_action :set_inbox_item, only: [:update, :destroy]
 
   def index
-    @inbox_items = InboxItem.where(owner: Current.user).order(created_at: :desc)
+    scope = InboxItem.where(owner: Current.user).order(created_at: :desc)
+    scope = scope.new_items unless params[:show] == 'all'
+    @inbox_items = scope
     render partial: "inbox_items/list", locals: { items: @inbox_items }
   end
 

--- a/app/javascript/comments.js
+++ b/app/javascript/comments.js
@@ -27,10 +27,19 @@ if (!window.commentsInitialized) {
                 };
             });
             closeBtn.onclick = function() { popup.style.display = 'none'; };
-            function fetchComments() {
+            function fetchComments(highlightId) {
                 list.innerHTML = popup.dataset.loadingText;
                 fetch(`/creatives/${popup.dataset.creativeId}/comments`)
-                    .then(r => r.text()).then(html => { list.innerHTML = html; });
+                    .then(r => r.text()).then(html => {
+                        list.innerHTML = html;
+                        if (highlightId) {
+                            var el = document.getElementById('comment-' + highlightId);
+                            if (el) {
+                                el.classList.add('highlight-flash');
+                                setTimeout(function(){ el.classList.remove('highlight-flash'); }, 2000);
+                            }
+                        }
+                    });
             }
             form.onsubmit = function(e) {
                 e.preventDefault();
@@ -67,6 +76,28 @@ if (!window.commentsInitialized) {
                     });
                 }
             });
+
+            function openFromUrl() {
+                var params = new URLSearchParams(window.location.search);
+                var commentId = params.get('comment_id');
+                var match = window.location.pathname.match(/\/creatives\/(\d+)/);
+                if (commentId && match) {
+                    var creativeId = match[1];
+                    var btn = document.querySelector('[name="show-comments-btn"][data-creative-id="' + creativeId + '"]');
+                    if (btn) {
+                        var rect = btn.getBoundingClientRect();
+                        var scrollY = window.scrollY || window.pageYOffset;
+                        popup.dataset.creativeId = creativeId;
+                        popup.style.top = (rect.bottom + scrollY + 4) + 'px';
+                        popup.style.right = (window.innerWidth - rect.right) + 'px';
+                        popup.style.left = '';
+                        popup.style.display = 'block';
+                        fetchComments(commentId);
+                    }
+                }
+            }
+
+            openFromUrl();
         }
     });
 }

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -3,4 +3,18 @@ class Comment < ApplicationRecord
   belongs_to :user, optional: true
 
   validates :content, presence: true
+
+  after_create_commit :notify_creative_owner
+
+  private
+
+  def notify_creative_owner
+    return unless creative.user && user && creative.user != user
+
+    InboxItem.create!(
+      owner: creative.user,
+      message: I18n.t('inbox.comment_added', user: user.email),
+      link: Rails.application.routes.url_helpers.creative_path(creative)
+    )
+  end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -13,7 +13,7 @@ class Comment < ApplicationRecord
 
     InboxItem.create!(
       owner: creative.user,
-      message: I18n.t('inbox.comment_added', user: user.email, comment: content),
+      link: Rails.application.routes.url_helpers.creative_comment_path(creative, self)
       link: Rails.application.routes.url_helpers.creative_path(creative)
     )
   end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -13,7 +13,7 @@ class Comment < ApplicationRecord
 
     InboxItem.create!(
       owner: creative.user,
-      message: I18n.t('inbox.comment_added', user: user.email, comment: content),
+      message: I18n.t("inbox.comment_added", user: user.email, comment: content),
       link: Rails.application.routes.url_helpers.creative_comment_path(creative, self)
     )
   end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -13,8 +13,8 @@ class Comment < ApplicationRecord
 
     InboxItem.create!(
       owner: creative.user,
+      message: I18n.t('inbox.comment_added', user: user.email, comment: content),
       link: Rails.application.routes.url_helpers.creative_comment_path(creative, self)
-      link: Rails.application.routes.url_helpers.creative_path(creative)
     )
   end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -13,7 +13,7 @@ class Comment < ApplicationRecord
 
     InboxItem.create!(
       owner: creative.user,
-      message: I18n.t('inbox.comment_added', user: user.email),
+      message: I18n.t('inbox.comment_added', user: user.email, comment: content),
       link: Rails.application.routes.url_helpers.creative_path(creative)
     )
   end

--- a/app/models/inbox_item.rb
+++ b/app/models/inbox_item.rb
@@ -1,0 +1,12 @@
+class InboxItem < ApplicationRecord
+  belongs_to :owner, class_name: "User"
+
+  attribute :state, :string, default: "new"
+  validates :state, inclusion: { in: %w[new read archived] }
+  validates :message, presence: true
+
+  scope :new_items, -> { where(state: "new") }
+  scope :read_items, -> { where(state: "read") }
+  scope :archived_items, -> { where(state: "archived") }
+end
+

--- a/app/models/inbox_item.rb
+++ b/app/models/inbox_item.rb
@@ -7,6 +7,8 @@ class InboxItem < ApplicationRecord
 
   scope :new_items, -> { where(state: "new") }
   scope :read_items, -> { where(state: "read") }
-  scope :archived_items, -> { where(state: "archived") }
-end
 
+  def read?
+    state == "read"
+  end
+end

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,4 +1,4 @@
-<div class="comment-item">
+<div class="comment-item" id="comment-<%= comment.id %>">
   <div>
     <strong><%= comment.user&.email || t('comments.anonymous') %></strong>
     <span>· <%= t('datetime.ago', time: time_ago_in_words(comment.created_at)) %></span>

--- a/app/views/inbox_items/_item.html.erb
+++ b/app/views/inbox_items/_item.html.erb
@@ -1,8 +1,14 @@
 <div class="inbox-item" data-id="<%= item.id %>">
-  <div class="message"><%= h item.message %></div>
+  <div class="message">
+    <% if item.link.present? %>
+      <%= link_to item.message, item.link, class: 'item-link' %>
+    <% else %>
+      <%= h item.message %>
+    <% end %>
+  </div>
   <div class="time"><%= time_ago_in_words(item.created_at) %></div>
   <div class="actions">
-    <% unless item.read? %>
+    <% unless item.state == 'read' %>
       <button class="mark-read" data-id="<%= item.id %>"><%= t('inbox.mark_read') %></button>
     <% end %>
     <button class="delete-item" data-id="<%= item.id %>"><%= t('inbox.delete') %></button>

--- a/app/views/inbox_items/_item.html.erb
+++ b/app/views/inbox_items/_item.html.erb
@@ -8,7 +8,9 @@
   </div>
   <div class="time"><%= time_ago_in_words(item.created_at) %></div>
   <div class="actions">
-    <% unless item.state == 'read' %>
+    <% if item.state == 'read' %>
+      <button class="mark-unread" data-id="<%= item.id %>"><%= t('inbox.mark_unread') %></button>
+    <% else %>
       <button class="mark-read" data-id="<%= item.id %>"><%= t('inbox.mark_read') %></button>
     <% end %>
     <button class="delete-item" data-id="<%= item.id %>"><%= t('inbox.delete') %></button>

--- a/app/views/inbox_items/_item.html.erb
+++ b/app/views/inbox_items/_item.html.erb
@@ -1,0 +1,11 @@
+<div class="inbox-item" data-id="<%= item.id %>">
+  <div class="message"><%= h item.message %></div>
+  <div class="time"><%= time_ago_in_words(item.created_at) %></div>
+  <div class="actions">
+    <% unless item.read? %>
+      <button class="mark-read" data-id="<%= item.id %>"><%= t('inbox.mark_read') %></button>
+    <% end %>
+    <button class="mark-archived" data-id="<%= item.id %>"><%= t('inbox.archive') %></button>
+    <button class="delete-item" data-id="<%= item.id %>"><%= t('inbox.delete') %></button>
+  </div>
+</div>

--- a/app/views/inbox_items/_item.html.erb
+++ b/app/views/inbox_items/_item.html.erb
@@ -5,7 +5,6 @@
     <% unless item.read? %>
       <button class="mark-read" data-id="<%= item.id %>"><%= t('inbox.mark_read') %></button>
     <% end %>
-    <button class="mark-archived" data-id="<%= item.id %>"><%= t('inbox.archive') %></button>
     <button class="delete-item" data-id="<%= item.id %>"><%= t('inbox.delete') %></button>
   </div>
 </div>

--- a/app/views/inbox_items/_list.html.erb
+++ b/app/views/inbox_items/_list.html.erb
@@ -1,0 +1,9 @@
+<div id="inbox-items">
+  <% if items.any? %>
+    <% items.each do |item| %>
+      <%= render partial: 'inbox_items/item', locals: { item: item } %>
+    <% end %>
+  <% else %>
+    <div><%= t('inbox.no_messages') %></div>
+  <% end %>
+</div>

--- a/app/views/inbox_items/index.html.erb
+++ b/app/views/inbox_items/index.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: 'inbox_items/list', locals: { items: @inbox_items } %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -76,6 +76,10 @@
     </div>
 
     <div id="inbox-panel" class="slide-panel">
+      <div class="inbox-panel-header">
+        <button id="close-inbox" type="button">&times;</button>
+        <label><input type="checkbox" id="toggle-inbox-read"> <%= t('inbox.show_read') %></label>
+      </div>
       <div id="inbox-list" data-loading-text="<%= t('app.loading') %>"></div>
     </div>
 
@@ -106,13 +110,18 @@
           var btn = document.getElementById('inbox-menu-btn');
           var panel = document.getElementById('inbox-panel');
           var list = document.getElementById('inbox-list');
+          var closeBtn = document.getElementById('close-inbox');
+          var toggle = document.getElementById('toggle-inbox-read');
+
           function loadInbox() {
             if (!list) return;
             list.innerHTML = list.dataset.loadingText;
-            fetch('/inbox')
+            var showRead = toggle && toggle.checked;
+            fetch('/inbox' + (showRead ? '?show=all' : ''))
               .then(r => r.text())
               .then(html => { list.innerHTML = html; attachActions(); });
           }
+
           function attachActions() {
             document.querySelectorAll('.inbox-item .mark-read').forEach(function(b) {
               b.onclick = function() {
@@ -134,12 +143,41 @@
                 }).then(loadInbox);
               };
             });
+            document.querySelectorAll('.inbox-item .item-link').forEach(function(a) {
+              a.addEventListener('click', function() {
+                localStorage.setItem('inboxOpen', '1');
+              });
+            });
           }
+
+          function openPanel() {
+            if (!panel) return;
+            panel.classList.add('open');
+            localStorage.setItem('inboxOpen', '1');
+            loadInbox();
+          }
+
+          function closePanel() {
+            if (!panel) return;
+            panel.classList.remove('open');
+            localStorage.removeItem('inboxOpen');
+          }
+
           if (btn && panel) {
             btn.addEventListener('click', function() {
-              panel.classList.toggle('open');
-              if (panel.classList.contains('open')) { loadInbox(); }
+              if (panel.classList.contains('open')) {
+                closePanel();
+              } else {
+                openPanel();
+              }
             });
+          }
+          if (closeBtn) { closeBtn.addEventListener('click', closePanel); }
+          if (toggle) { toggle.addEventListener('change', loadInbox); }
+
+          if (panel && localStorage.getItem('inboxOpen') === '1') {
+            panel.classList.add('open');
+            loadInbox();
           }
         });
       }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -126,18 +126,6 @@
                 }).then(loadInbox);
               };
             });
-            document.querySelectorAll('.inbox-item .mark-archived').forEach(function(b) {
-              b.onclick = function() {
-                fetch('/inbox/' + b.dataset.id, {
-                  method: 'PATCH',
-                  headers: {
-                    'Content-Type': 'application/json',
-                    'X-CSRF-Token': document.querySelector('meta[name=csrf-token]').content
-                  },
-                  body: JSON.stringify({ state: 'archived' })
-                }).then(loadInbox);
-              };
-            });
             document.querySelectorAll('.inbox-item .delete-item').forEach(function(b) {
               b.onclick = function() {
                 fetch('/inbox/' + b.dataset.id, {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -151,6 +151,18 @@
                 }).then(loadInbox);
               };
             });
+            document.querySelectorAll('.inbox-item .mark-unread').forEach(function(b) {
+              b.onclick = function() {
+                fetch('/inbox/' + b.dataset.id, {
+                  method: 'PATCH',
+                  headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRF-Token': document.querySelector('meta[name=csrf-token]').content
+                  },
+                  body: JSON.stringify({ state: 'new' })
+                }).then(loadInbox);
+              };
+            });
             document.querySelectorAll('.inbox-item .delete-item').forEach(function(b) {
               b.onclick = function() {
                 fetch('/inbox/' + b.dataset.id, {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -43,6 +43,7 @@
       <% end %>
       <% if Current.user %>
         <%= link_to Current.user.email, user_path(Current.user) %>
+        <button id="inbox-menu-btn" type="button"><%= t('app.inbox') %></button>
       <% end %>
       <%= link_to t('app.sign_in'), new_session_path unless authenticated? %>
       <%= button_to t('app.sign_out'), session_path, method: :delete if authenticated? %>
@@ -74,6 +75,10 @@
       <% end %>
     </div>
 
+    <div id="inbox-panel" class="slide-panel">
+      <div id="inbox-list" data-loading-text="<%= t('app.loading') %>"></div>
+    </div>
+
     <div id="creative-guide-popover" style="display:none; position:fixed; top:60px; left:50%; transform:translateX(-50%); background:white; border:1px solid #ccc; box-shadow:0 2px 8px rgba(0,0,0,0.12); padding:1.2em; max-width:400px; z-index:1000; border-radius:8px;">
       <span style="float:right; cursor:pointer; font-weight:bold;" id="close-creative-guide">&times;</span>
       <div style="margin-top:0.5em; color:#444; font-size:1em; line-height:1.5;">
@@ -90,6 +95,64 @@
           btn.addEventListener('click', function() {
             area.style.display = (area.style.display === 'none') ? 'block' : 'none';
           });
+        });
+      }
+    </script>
+
+    <script>
+      if (!window.isInboxMenuInitialized) {
+        window.isInboxMenuInitialized = true;
+        document.addEventListener('turbo:load', function() {
+          var btn = document.getElementById('inbox-menu-btn');
+          var panel = document.getElementById('inbox-panel');
+          var list = document.getElementById('inbox-list');
+          function loadInbox() {
+            if (!list) return;
+            list.innerHTML = list.dataset.loadingText;
+            fetch('/inbox')
+              .then(r => r.text())
+              .then(html => { list.innerHTML = html; attachActions(); });
+          }
+          function attachActions() {
+            document.querySelectorAll('.inbox-item .mark-read').forEach(function(b) {
+              b.onclick = function() {
+                fetch('/inbox/' + b.dataset.id, {
+                  method: 'PATCH',
+                  headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRF-Token': document.querySelector('meta[name=csrf-token]').content
+                  },
+                  body: JSON.stringify({ state: 'read' })
+                }).then(loadInbox);
+              };
+            });
+            document.querySelectorAll('.inbox-item .mark-archived').forEach(function(b) {
+              b.onclick = function() {
+                fetch('/inbox/' + b.dataset.id, {
+                  method: 'PATCH',
+                  headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRF-Token': document.querySelector('meta[name=csrf-token]').content
+                  },
+                  body: JSON.stringify({ state: 'archived' })
+                }).then(loadInbox);
+              };
+            });
+            document.querySelectorAll('.inbox-item .delete-item').forEach(function(b) {
+              b.onclick = function() {
+                fetch('/inbox/' + b.dataset.id, {
+                  method: 'DELETE',
+                  headers: { 'X-CSRF-Token': document.querySelector('meta[name=csrf-token]').content }
+                }).then(loadInbox);
+              };
+            });
+          }
+          if (btn && panel) {
+            btn.addEventListener('click', function() {
+              panel.classList.toggle('open');
+              if (panel.classList.contains('open')) { loadInbox(); }
+            });
+          }
         });
       }
     </script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -43,7 +43,7 @@
       <% end %>
       <% if Current.user %>
         <%= link_to Current.user.email, user_path(Current.user) %>
-        <button id="inbox-menu-btn" type="button"><%= t('app.inbox') %></button>
+        <button id="inbox-menu-btn" type="button"><%= t('app.inbox') %><span id="inbox-badge"></span></button>
       <% end %>
       <%= link_to t('app.sign_in'), new_session_path unless authenticated? %>
       <%= button_to t('app.sign_out'), session_path, method: :delete if authenticated? %>
@@ -112,6 +112,22 @@
           var list = document.getElementById('inbox-list');
           var closeBtn = document.getElementById('close-inbox');
           var toggle = document.getElementById('toggle-inbox-read');
+          var badge = document.getElementById('inbox-badge');
+
+          function updateInboxBadge() {
+            if (!badge) return;
+            fetch('/inbox/count')
+              .then(r => r.json())
+              .then(data => {
+                if (data.count > 0) {
+                  badge.textContent = data.count;
+                  badge.style.display = 'inline-block';
+                } else {
+                  badge.textContent = '';
+                  badge.style.display = 'none';
+                }
+              });
+          }
 
           function loadInbox() {
             if (!list) return;
@@ -119,7 +135,7 @@
             var showRead = toggle && toggle.checked;
             fetch('/inbox' + (showRead ? '?show=all' : ''))
               .then(r => r.text())
-              .then(html => { list.innerHTML = html; attachActions(); });
+              .then(html => { list.innerHTML = html; attachActions(); updateInboxBadge(); });
           }
 
           function attachActions() {
@@ -174,6 +190,8 @@
           }
           if (closeBtn) { closeBtn.addEventListener('click', closePanel); }
           if (toggle) { toggle.addEventListener('change', loadInbox); }
+
+          updateInboxBadge();
 
           if (panel && localStorage.getItem('inboxOpen') === '1') {
             panel.classList.add('open');

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -205,9 +205,11 @@
 
           updateInboxBadge();
 
-          if (panel && localStorage.getItem('inboxOpen') === '1') {
+          if (panel && btn && localStorage.getItem('inboxOpen') === '1') {
             panel.classList.add('open');
             loadInbox();
+          } else if (!btn) {
+            localStorage.removeItem('inboxOpen');
           }
         });
       }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -47,3 +47,10 @@ en:
     expand_all: "Expand All"
     save: "Save"
     filter_comments: "Comments"
+    inbox: "Inbox"
+
+  inbox:
+    mark_read: "Read"
+    archive: "Archive"
+    delete: "Delete"
+    no_messages: "No messages"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -52,4 +52,5 @@ en:
   inbox:
     mark_read: "Read"
     delete: "Delete"
+    show_read: "Show read"
     no_messages: "No messages"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -55,3 +55,4 @@ en:
     delete: "Delete"
     show_read: "Show read"
     no_messages: "No messages"
+    comment_added: "%{user} added a comment."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -55,4 +55,4 @@ en:
     delete: "Delete"
     show_read: "Show read"
     no_messages: "No messages"
-    comment_added: "%{user} added a comment."
+    comment_added: "%{user} added \"%{comment}\"."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,6 +51,7 @@ en:
 
   inbox:
     mark_read: "Read"
+    mark_unread: "Unread"
     delete: "Delete"
     show_read: "Show read"
     no_messages: "No messages"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,6 +51,5 @@ en:
 
   inbox:
     mark_read: "Read"
-    archive: "Archive"
     delete: "Delete"
     no_messages: "No messages"

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -22,6 +22,7 @@ ko:
 
   inbox:
     mark_read: "읽음"
+    mark_unread: "안읽음"
     delete: "삭제"
     show_read: "읽은 메세지 포함"
     no_messages: "메세지가 없습니다"

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -26,4 +26,4 @@ ko:
     delete: "삭제"
     show_read: "읽은 메세지 포함"
     no_messages: "메세지가 없습니다"
-    comment_added: "%{user} 가 \"comment\" 를 추가했습니다."
+    comment_added: "%{user} 가 \"%{comment}\" 를 추가했습니다."

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -23,4 +23,5 @@ ko:
   inbox:
     mark_read: "읽음"
     delete: "삭제"
+    show_read: "읽은 메세지 포함"
     no_messages: "메세지가 없습니다"

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -18,3 +18,10 @@ ko:
     expand_all: "모두 펼치기"
     save: "저장"
     filter_comments: "코멘트"
+    inbox: "인박스"
+
+  inbox:
+    mark_read: "읽음"
+    archive: "보관"
+    delete: "삭제"
+    no_messages: "메세지가 없습니다"

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -26,3 +26,4 @@ ko:
     delete: "삭제"
     show_read: "읽은 메세지 포함"
     no_messages: "메세지가 없습니다"
+    comment_added: "%{user} 가 \"comment\" 를 추가했습니다."

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -22,6 +22,5 @@ ko:
 
   inbox:
     mark_read: "읽음"
-    archive: "보관"
     delete: "삭제"
     no_messages: "메세지가 없습니다"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,7 +46,9 @@ Rails.application.routes.draw do
 
   resources :plans, only: [ :create, :destroy ]
 
-  resources :inbox_items, path: 'inbox', only: [ :index, :update, :destroy ]
+  resources :inbox_items, path: 'inbox', only: [ :index, :update, :destroy ] do
+    get :count, on: :collection
+  end
 
   resource :unsubscribe, only: [ :show ]
   resource :invite, only: [ :show ]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,7 +46,7 @@ Rails.application.routes.draw do
 
   resources :plans, only: [ :create, :destroy ]
 
-  resources :inbox_items, path: 'inbox', only: [ :index, :update, :destroy ] do
+  resources :inbox_items, path: "inbox", only: [ :index, :update, :destroy ] do
     get :count, on: :collection
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,6 +46,8 @@ Rails.application.routes.draw do
 
   resources :plans, only: [ :create, :destroy ]
 
+  resources :inbox_items, path: 'inbox', only: [ :index, :update, :destroy ]
+
   resource :unsubscribe, only: [ :show ]
   resource :invite, only: [ :show ]
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,7 +29,7 @@ Rails.application.routes.draw do
   resources :creatives do
     resources :subscribers, only: [ :create ]
     resources :creative_shares, only: [ :create, :destroy ]
-    resources :comments, only: [ :index, :create, :destroy ]
+    resources :comments, only: [ :index, :create, :destroy, :show ]
     collection do
       post :recalculate_progress
       post :reorder

--- a/db/migrate/20250611105524_create_inbox_items.rb
+++ b/db/migrate/20250611105524_create_inbox_items.rb
@@ -1,0 +1,14 @@
+class CreateInboxItems < ActiveRecord::Migration[8.0]
+  def change
+    create_table :inbox_items do |t|
+      t.text :message
+      t.references :owner, null: false, foreign_key: { to_table: :users }
+      t.string :link
+      t.string :state, default: "new", null: false
+
+      t.timestamps
+    end
+
+    add_index :inbox_items, :state
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_11_030138) do
+ActiveRecord::Schema[8.0].define(version: 2025_06_11_105524) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
     t.text "body"
@@ -102,6 +102,17 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_11_030138) do
     t.index ["origin_id"], name: "index_creatives_on_origin_id"
     t.index ["parent_id"], name: "index_creatives_on_parent_id"
     t.index ["user_id"], name: "index_creatives_on_user_id"
+  end
+
+  create_table "inbox_items", force: :cascade do |t|
+    t.text "message"
+    t.integer "owner_id", null: false
+    t.string "link"
+    t.string "state", default: "new", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["owner_id"], name: "index_inbox_items_on_owner_id"
+    t.index ["state"], name: "index_inbox_items_on_state"
   end
 
   create_table "invitations", force: :cascade do |t|
@@ -316,6 +327,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_11_030138) do
   add_foreign_key "creatives", "creatives", column: "origin_id"
   add_foreign_key "creatives", "creatives", column: "parent_id"
   add_foreign_key "creatives", "users"
+  add_foreign_key "inbox_items", "users", column: "owner_id"
   add_foreign_key "invitations", "creatives"
   add_foreign_key "invitations", "users", column: "inviter_id"
   add_foreign_key "labels", "users", column: "owner_id"

--- a/test/integration/inbox_access_test.rb
+++ b/test/integration/inbox_access_test.rb
@@ -1,0 +1,9 @@
+require "test_helper"
+
+class InboxAccessTest < ActionDispatch::IntegrationTest
+  test "unauthenticated inbox request does not store return location" do
+    get inbox_items_path
+    assert_redirected_to new_session_path
+    assert_nil session[:return_to_after_authenticating]
+  end
+end

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -1,0 +1,17 @@
+require "test_helper"
+
+class CommentTest < ActiveSupport::TestCase
+  test "creating a comment notifies creative owner" do
+    creative = creatives(:tshirt)
+    commenter = users(:two)
+
+    assert_difference("InboxItem.count", 1) do
+      Comment.create!(creative: creative, user: commenter, content: "hi")
+    end
+
+    item = InboxItem.last
+    assert_equal creative.user, item.owner
+    assert_includes item.message, commenter.email
+  end
+end
+

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -12,6 +12,8 @@ class CommentTest < ActiveSupport::TestCase
     item = InboxItem.last
     assert_equal creative.user, item.owner
     assert_includes item.message, commenter.email
+    expected_link = Rails.application.routes.url_helpers.creative_comment_path(creative, Comment.last)
+    assert_equal expected_link, item.link
   end
 end
 

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -16,4 +16,3 @@ class CommentTest < ActiveSupport::TestCase
     assert_equal expected_link, item.link
   end
 end
-

--- a/test/models/inbox_item_test.rb
+++ b/test/models/inbox_item_test.rb
@@ -6,4 +6,10 @@ class InboxItemTest < ActiveSupport::TestCase
     assert item.save
     assert_equal "new", item.state
   end
+
+  test "read item can be marked unread" do
+    item = InboxItem.create!(message: "Hi", owner: users(:one), state: "read")
+    item.update!(state: "new")
+    assert_equal "new", item.state
+  end
 end

--- a/test/models/inbox_item_test.rb
+++ b/test/models/inbox_item_test.rb
@@ -1,0 +1,9 @@
+require "test_helper"
+
+class InboxItemTest < ActiveSupport::TestCase
+  test "default state is new" do
+    item = InboxItem.new(message: "Hi", owner: users(:one))
+    assert item.save
+    assert_equal "new", item.state
+  end
+end


### PR DESCRIPTION
## Summary
- create `InboxItem` model and table for user inbox messages
- expose `/inbox` routes for listing and managing inbox items
- show inbox menu next to the user link
- render a slide-out inbox panel with JS actions
- localise inbox strings
- add model test for inbox items

## Testing
- `bin/rails db:migrate`
- `bin/rails test`

------
https://chatgpt.com/codex/tasks/task_e_68495ffe36988326a2e45f63dbb117e5