### PR TITLE
Fix creative user inheritance and add tests

### DIFF
--- a/app/controllers/creatives_controller.rb
+++ b/app/controllers/creatives_controller.rb
@@ -62,7 +62,11 @@ class CreativesController < ApplicationController
 
   def create
     @creative = Creative.new(creative_params)
-    @creative.user = Current.user
+    if @creative.parent
+      @creative.user = @creative.parent.user
+    else
+      @creative.user = Current.user
+    end
 
     # Rebuild @child_creative from params if present
     if params[:child_id].present?

--- a/app/models/creative.rb
+++ b/app/models/creative.rb
@@ -21,6 +21,8 @@ class Creative < ApplicationRecord
   validates :progress, numericality: { greater_than_or_equal_to: 0.0, less_than_or_equal_to: 1.0 }, unless: -> { origin_id.present? }
   validates :description, presence: true, unless: -> { origin_id.present? }
 
+  before_validation :assign_default_user, on: :create
+
   after_save :update_parent_progress
   after_destroy :update_parent_progress
 
@@ -126,6 +128,15 @@ class Creative < ApplicationRecord
   end
 
   private
+
+  def assign_default_user
+    return if user.present?
+    if parent_id.present? && parent
+      self.user = parent.user
+    else
+      self.user = Current.user
+    end
+  end
 
   def has_permission_impl(user, required_permission = :read)
     return true if self.user_id == user&.id

--- a/spec/models/creative_user_spec.rb
+++ b/spec/models/creative_user_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+require 'ostruct'
+
+RSpec.describe Creative, type: :model do
+  let(:owner) do
+    user = User.create!(email: 'owner@example.com', password: 'pw')
+    Current.session = OpenStruct.new(user: user)
+    user
+  end
+
+  before do
+    Current.session = OpenStruct.new(user: owner)
+  end
+
+  it 'assigns parent user when parent_id is present' do
+    parent = Creative.create!(user: owner, description: 'Parent')
+    other_user = User.create!(email: 'other@example.com', password: 'pw')
+    Current.session = OpenStruct.new(user: other_user)
+    child = Creative.create!(parent: parent, description: 'Child')
+    expect(child.user).to eq(parent.user)
+  end
+
+  it 'assigns Current.user when parent is nil' do
+    creative = Creative.create!(description: 'Root')
+    expect(creative.user).to eq(owner)
+  end
+end


### PR DESCRIPTION
## Summary
- ensure new creatives inherit user from parent if parent exists
- fallback to current user only when no parent is present
- update controller create logic
- test new behavior

## Testing
- `bundle exec rspec spec/models/creative_user_spec.rb spec/models/creative_linked_spec.rb`

------
https://chatgpt.com/codex/tasks/task_e_684975fa3620832688343c4bbbda56a5