### PR TITLE
Add inbox notification for creative shares

### DIFF
--- a/app/models/creative_share.rb
+++ b/app/models/creative_share.rb
@@ -14,7 +14,21 @@ class CreativeShare < ApplicationRecord
   validates :permission, presence: true
   validates :user_id, uniqueness: { scope: :creative_id }
 
+  after_create_commit :notify_recipient
+
   private
+
+  def notify_recipient
+    return unless Current.user && user
+    desc = creative.effective_description
+    title = ActionController::Base.helpers.strip_tags(desc)
+    short_title = ActionController::Base.helpers.truncate(title, length: 30)
+    InboxItem.create!(
+      owner: user,
+      message: I18n.t("inbox.creative_shared", user: Current.user.email, short_title: short_title),
+      link: Rails.application.routes.url_helpers.creative_path(creative)
+    )
+  end
 
   def linked_creative_exists?
     Creative.exists?(origin_id: creative.id, user_id: user.id)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -56,3 +56,4 @@ en:
     show_read: "Show read"
     no_messages: "No messages"
     comment_added: "%{user} added \"%{comment}\"."
+    creative_shared: "%{user} shared \"%{short_title}\"."

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -27,3 +27,4 @@ ko:
     show_read: "읽은 메세지 포함"
     no_messages: "메세지가 없습니다"
     comment_added: "%{user} 가 \"%{comment}\" 를 추가했습니다."
+    creative_shared: "%{user} 가 \"%{short_title}\" 을 공유했습니다."

--- a/test/models/creative_share_test.rb
+++ b/test/models/creative_share_test.rb
@@ -1,0 +1,24 @@
+require "test_helper"
+
+class CreativeShareTest < ActiveSupport::TestCase
+  test "creating a share notifies recipient" do
+    creative = creatives(:tshirt)
+    sharer = users(:one)
+    recipient = users(:two)
+
+    Current.session = OpenStruct.new(user: sharer)
+
+    assert_difference("InboxItem.count", 1) do
+      CreativeShare.create!(creative: creative, user: recipient, permission: :read)
+    end
+
+    item = InboxItem.last
+    assert_equal recipient, item.owner
+    assert_includes item.message, sharer.email
+    assert_includes item.message, "T-Shirt"
+    expected_link = Rails.application.routes.url_helpers.creative_path(creative)
+    assert_equal expected_link, item.link
+
+    Current.reset
+  end
+end


### PR DESCRIPTION
## Summary
- notify recipients when a creative is shared
- translate new inbox message in English and Korean
- test creative share inbox notifications

## Testing
- `bundle exec rails test -v`

------
https://chatgpt.com/codex/tasks/task_e_6849835f9eec8326bd54aa24cbfbce41