### PR TITLE
Implement basic inline editing

### DIFF
--- a/app/controllers/creatives_controller.rb
+++ b/app/controllers/creatives_controller.rb
@@ -99,6 +99,9 @@ class CreativesController < ApplicationController
   end
 
   def edit
+    if params[:inline]
+      render partial: "form", locals: { creative: @creative }
+    end
   end
 
   def update

--- a/app/controllers/creatives_controller.rb
+++ b/app/controllers/creatives_controller.rb
@@ -84,17 +84,21 @@ class CreativesController < ApplicationController
       @child_creative = Creative.find_by(id: params[:child_id])
     end
 
-    if @creative.save
-      @child_creative.update(parent: @creative) if @child_creative
-      # Propagate all shares from the parent to the new child
-      if @creative.parent
-        CreativeShare.where(creative: @creative.parent).find_each do |parent_share|
-          CreativeShare.create!(creative: @creative, user: parent_share.user, permission: parent_share.permission)
+    respond_to do |format|
+      if @creative.save
+        @child_creative.update(parent: @creative) if @child_creative
+        # Propagate all shares from the parent to the new child
+        if @creative.parent
+          CreativeShare.where(creative: @creative.parent).find_each do |parent_share|
+            CreativeShare.create!(creative: @creative, user: parent_share.user, permission: parent_share.permission)
+          end
         end
+        format.html { redirect_to @creative }
+        format.json { render json: { id: @creative.id } }
+      else
+        format.html { render :new, status: :unprocessable_entity }
+        format.json { render json: { errors: @creative.errors.full_messages }, status: :unprocessable_entity }
       end
-      redirect_to @creative
-    else
-      render :new, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/creatives_controller.rb
+++ b/app/controllers/creatives_controller.rb
@@ -109,10 +109,14 @@ class CreativesController < ApplicationController
   end
 
   def update
-    if @creative.update(creative_params)
-      redirect_to @creative
-    else
-      render :edit, status: :unprocessable_entity
+    respond_to do |format|
+      if @creative.update(creative_params)
+        format.html { redirect_to @creative }
+        format.json { head :ok }
+      else
+        format.html { render :edit, status: :unprocessable_entity }
+        format.json { render json: { errors: @creative.errors.full_messages }, status: :unprocessable_entity }
+      end
     end
   end
 

--- a/app/javascript/controllers/inline_editor_controller.js
+++ b/app/javascript/controllers/inline_editor_controller.js
@@ -54,8 +54,12 @@ export default class extends Controller {
       if (!form) return
       fetch(this.updateUrlValue, {
         method: "PATCH",
-        headers: { "X-CSRF-Token": document.querySelector('meta[name="csrf-token"]').content },
-        body: new FormData(form)
+        headers: {
+          "X-CSRF-Token": document.querySelector('meta[name="csrf-token"]').content,
+          "Accept": "application/json"
+        },
+        body: new FormData(form),
+        credentials: "same-origin"
       })
     }, 400)
   }

--- a/app/javascript/controllers/inline_editor_controller.js
+++ b/app/javascript/controllers/inline_editor_controller.js
@@ -1,0 +1,93 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["display", "form"]
+  static values = { editUrl: String, updateUrl: String, parentId: Number }
+
+  connect() {
+    this.isLoaded = false
+  }
+
+  showForm(event) {
+    if (event) event.preventDefault()
+    if (this.isLoaded) {
+      this.toggleVisibility()
+      this.focusEditor()
+      return
+    }
+    fetch(this.editUrlValue + "?inline=1")
+      .then(r => r.text())
+      .then(html => {
+        this.formTarget.innerHTML = html
+        this.isLoaded = true
+        this.toggleVisibility()
+        this.setupAutoSave()
+        this.focusEditor()
+      })
+  }
+
+  toggleVisibility() {
+    this.displayTarget.style.display = this.displayTarget.style.display === "none" ? "" : "none"
+    this.formTarget.style.display = this.formTarget.style.display === "none" ? "" : "none"
+  }
+
+  setupAutoSave() {
+    const form = this.formTarget.querySelector("form")
+    if (!form) return
+    form.addEventListener("trix-change", () => this.autoSave())
+    form.addEventListener("change", () => this.autoSave())
+    form.addEventListener("keydown", e => this.handleKey(e))
+  }
+
+  focusEditor() {
+    const editor = this.formTarget.querySelector("trix-editor")
+    if (editor) editor.focus()
+  }
+
+  autoSave() {
+    clearTimeout(this.saveTimer)
+    this.saveTimer = setTimeout(() => {
+      const form = this.formTarget.querySelector("form")
+      if (!form) return
+      fetch(this.updateUrlValue, {
+        method: "PATCH",
+        headers: { "X-CSRF-Token": document.querySelector('meta[name="csrf-token"]').content },
+        body: new FormData(form)
+      })
+    }, 400)
+  }
+
+  handleKey(e) {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault()
+      this.moveToNext()
+    } else if (e.key === "Enter" && e.shiftKey) {
+      e.preventDefault()
+      this.addChild()
+    }
+  }
+
+  moveToNext() {
+    const next = this.element.nextElementSibling
+    if (!next) return
+    const btn = next.querySelector('[data-action="inline-editor#showForm"]')
+    if (btn) btn.click()
+  }
+
+  addChild() {
+    fetch('/creatives', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').content
+      },
+      body: JSON.stringify({ creative: { description: 'New Creative', parent_id: this.parentIdValue } })
+    })
+      .then(r => r.json())
+      .then(data => {
+        if (data.id) {
+          window.location.href = `/creatives/${data.id}`
+        }
+      })
+  }
+}

--- a/app/javascript/controllers/inline_editor_controller.js
+++ b/app/javascript/controllers/inline_editor_controller.js
@@ -36,7 +36,10 @@ export default class extends Controller {
     if (!form) return
     form.addEventListener("trix-change", () => this.autoSave())
     form.addEventListener("change", () => this.autoSave())
-    form.addEventListener("keydown", e => this.handleKey(e))
+    const editor = form.querySelector("trix-editor")
+    if (editor) {
+      editor.addEventListener("keydown", e => this.handleKey(e))
+    }
   }
 
   focusEditor() {
@@ -60,14 +63,17 @@ export default class extends Controller {
   handleKey(e) {
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault()
+      this.autoSave()
       this.moveToNext()
     } else if (e.key === "Enter" && e.shiftKey) {
       e.preventDefault()
+      this.autoSave()
       this.addChild()
     }
   }
 
   moveToNext() {
+    this.toggleVisibility()
     const next = this.element.nextElementSibling
     if (!next) return
     const btn = next.querySelector('[data-action="inline-editor#showForm"]')
@@ -79,6 +85,7 @@ export default class extends Controller {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
+        'Accept': 'application/json',
         'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').content
       },
       body: JSON.stringify({ creative: { description: 'New Creative', parent_id: this.parentIdValue } })
@@ -86,7 +93,7 @@ export default class extends Controller {
       .then(r => r.json())
       .then(data => {
         if (data.id) {
-          window.location.href = `/creatives/${data.id}`
+          window.location.href = `/creatives/${data.id}?edit=1`
         }
       })
   }

--- a/app/views/creatives/index.html.erb
+++ b/app/views/creatives/index.html.erb
@@ -12,9 +12,8 @@
   <% end %>
 
   <% if authenticated? && @parent_creative && @parent_creative.has_permission?(Current.user, :write) %>
-    <%= link_to t('.edit'), edit_creative_path(@parent_creative) %>
+    <%= link_to t('.edit'), edit_creative_path(@parent_creative), data: { action: "inline-editor#showForm" }  %>
     <%= render 'delete_button' %>
-
   <% end %>
   <button id="set-plan-btn" class="set-plan-btn" style="display:none;"><%= t('app.set_plan') %></button>
   <input type="checkbox" id="select-all-creatives" style="display:none;margin-left:1em;vertical-align:middle;" />
@@ -48,10 +47,11 @@
 </div>
 
 <% if @parent_creative %>
-  <div class="creative-row" id="creative-markdown-block">
-    <h1 class="page-title" style="display:flex;align-items:center;gap:1em;">
+  <div class="creative-row" id="creative-markdown-block" data-controller="inline-editor" data-inline-editor-edit-url-value="<%= edit_creative_path(@parent_creative) %>" data-inline-editor-update-url-value="<%= creative_path(@parent_creative) %>" data-inline-editor-parent-id-value="<%= @parent_creative.id %>">
+    <h1 class="page-title" style="display:flex;align-items:center;gap:1em;" data-inline-editor-target="display">
       <%= @parent_creative.effective_description %>
     </h1>
+    <div data-inline-editor-target="form" style="display:none"></div>
     <div>
       <h1 style="display: flex; align-items: center; gap: 1em;">
         <%= render_creative_progress(@parent_creative) %>

--- a/app/views/creatives/index.html.erb
+++ b/app/views/creatives/index.html.erb
@@ -1,4 +1,8 @@
 <%= tag.div(flash[:alert], class: "flash-alert") if flash[:alert] %>
+<% if @parent_creative %>
+<div data-controller="inline-editor" data-inline-editor-edit-url-value="<%= edit_creative_path(@parent_creative) %>" data-inline-editor-update-url-value="<%= creative_path(@parent_creative) %>" data-inline-editor-parent-id-value="<%= @parent_creative.id %>">
+<% end %>
+
 <div class="creative-actions-row">
   <% if @parent_creative&.parent_id.present? %>
     <%= link_to t('.up'), creative_path(@parent_creative.owning_parent), class: "back-link" %>
@@ -47,7 +51,7 @@
 </div>
 
 <% if @parent_creative %>
-  <div class="creative-row" id="creative-markdown-block" data-controller="inline-editor" data-inline-editor-edit-url-value="<%= edit_creative_path(@parent_creative) %>" data-inline-editor-update-url-value="<%= creative_path(@parent_creative) %>" data-inline-editor-parent-id-value="<%= @parent_creative.id %>">
+  <div class="creative-row" id="creative-markdown-block">
     <h1 class="page-title" style="display:flex;align-items:center;gap:1em;" data-inline-editor-target="display">
       <%= @parent_creative.effective_description %>
     </h1>
@@ -77,6 +81,9 @@
       </h1>
     </div>
   </div>
+<% end %>
+<% if @parent_creative %>
+</div>
 <% end %>
 
 <div id="creatives">

--- a/app/views/creatives/show.html.erb
+++ b/app/views/creatives/show.html.erb
@@ -2,15 +2,18 @@
 <p><%= link_to "Back", creatives_path %></p>
 
 <section class="creative">
-  
-  <section class="creative-info">
+
+  <section class="creative-info" data-controller="inline-editor" data-inline-editor-edit-url-value="<%= edit_creative_path(@creative) %>" data-inline-editor-update-url-value="<%= creative_path(@creative) %>" data-inline-editor-parent-id-value="<%= @creative.id %>">
     <% cache @creative do %>
       <% if @creative.parent %>
         <h1>
           <%= @creative.parent.description %>
         </h1>
       <% end %>
-      <%= @creative.description %>
+      <div data-inline-editor-target="display">
+        <%= @creative.description %>
+      </div>
+      <div data-inline-editor-target="form" style="display:none"></div>
     <% end %>
 
     <%= render "inventory", creative: @creative %>

--- a/app/views/creatives/show.html.erb
+++ b/app/views/creatives/show.html.erb
@@ -18,7 +18,7 @@
     <div class="creative-actions-row">
       <% if authenticated? %>
         <%= link_to "New sub-creative", @creative&.id ? new_creative_path(parent_id: @creative.id) : new_creative_path %>
-        <%= link_to "Edit", edit_creative_path(@creative) %>
+        <%= link_to "Edit", edit_creative_path(@creative), data: { action: "inline-editor#showForm" } %>
         <%= button_to "Delete", @creative, method: :delete, data: { turbo_confirm: "Are you sure?" } %>
       <% end %>
     </div>

--- a/app/views/creatives/show.html.erb
+++ b/app/views/creatives/show.html.erb
@@ -25,5 +25,14 @@
         <%= button_to "Delete", @creative, method: :delete, data: { turbo_confirm: "Are you sure?" } %>
       <% end %>
     </div>
+
+    <% if params[:edit] %>
+      <script>
+        document.addEventListener('turbo:load', function() {
+          const btn = document.querySelector('[data-action="inline-editor#showForm"]');
+          if (btn) { btn.click(); }
+        });
+      </script>
+    <% end %>
   </section>
 </section>


### PR DESCRIPTION
## Summary
- introduce `inline_editor` Stimulus controller
- hook into parent creative title to allow inline editing
- auto-save via AJAX while editing
- enable Edit buttons to open inline editor

## Testing
- `bundle exec rake spec` *(fails: Selenium can't download Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_68498c3338088326a477aba8e7bd4662