### PR TITLE
Add print stylesheet

### DIFF
--- a/app/assets/stylesheets/print.css
+++ b/app/assets/stylesheets/print.css
@@ -2,6 +2,8 @@
   nav,
   #plans-list-area,
   #inbox-panel,
+  .creative-actions-row,
+  .creative-row-actions,
   #creative-guide-popover,
   #creative-guide-link,
   #inbox-menu-btn,

--- a/app/assets/stylesheets/print.css
+++ b/app/assets/stylesheets/print.css
@@ -1,0 +1,19 @@
+@media print {
+  nav,
+  #plans-list-area,
+  #inbox-panel,
+  #creative-guide-popover,
+  #creative-guide-link,
+  #inbox-menu-btn,
+  #plans-menu-btn,
+  button,
+  input[type="button"],
+  input[type="submit"],
+  form {
+    display: none !important;
+  }
+
+  main {
+    margin: 0;
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,6 +20,7 @@
     <%# Includes all stylesheet files in app/assets/stylesheets %>
     <%= stylesheet_link_tag :app, "data-turbo-track": "reload" %>
     <%= stylesheet_link_tag :dark_mode %>
+    <%= stylesheet_link_tag :print, media: 'print' %>
 
     <%= javascript_include_tag 'dark_mode_toggle', defer: true %>
     <%= javascript_include_tag 'creatives', defer: true %>


### PR DESCRIPTION
## Summary
- add `print.css` to hide navigation and action controls when printing
- link the print stylesheet from the layout

## Testing
- `bundle exec rubocop`
- `bundle exec rspec` *(fails: WebDriverError)*

------
https://chatgpt.com/codex/tasks/task_e_6849a20936ac8326ae7217156ea956ef