### PR TITLE
Fix invite email host

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -58,7 +58,7 @@ Rails.application.configure do
   # config.action_mailer.raise_delivery_errors = false
 
   # Set host to be used by links generated in mailer templates.
-  config.action_mailer.default_url_options = { host: "example.com" }
+  config.action_mailer.default_url_options = { host: "plan42.vrerv.com" }
 
   # Specify outgoing SMTP server. Remember to add smtp/* credentials via rails credentials:edit.
   # config.action_mailer.smtp_settings = {


### PR DESCRIPTION
## Summary
- update production mailer host to plan42.vrerv.com

## Testing
- `./bin/rubocop -a`
- `bundle exec rails test`
- `bundle exec rspec` *(fails: Selenium not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684a31254b8c8326b231fcd4f51381c6