### PR TITLE
Fix ancestor creation when adding parent creative

### DIFF
--- a/app/controllers/creatives_controller.rb
+++ b/app/controllers/creatives_controller.rb
@@ -71,11 +71,10 @@ class CreativesController < ApplicationController
     # Rebuild @child_creative from params if present
     if params[:child_id].present?
       @child_creative = Creative.find_by(id: params[:child_id])
-      @child_creative.parent = @creative if @child_creative
     end
 
     if @creative.save
-      @child_creative.save if @child_creative
+      @child_creative.update(parent: @creative) if @child_creative
       # Propagate all shares from the parent to the new child
       if @creative.parent
         CreativeShare.where(creative: @creative.parent).find_each do |parent_share|

--- a/spec/models/creative_ancestor_spec.rb
+++ b/spec/models/creative_ancestor_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+require 'ostruct'
+
+RSpec.describe 'Creative ancestor updates', type: :model do
+  let(:user) { User.create!(email: 'owner1@example.com', password: 'pw') }
+
+  before do
+    Current.session = OpenStruct.new(user: user)
+  end
+
+  it 'updates ancestors when a new parent is inserted' do
+    root = Creative.create!(user: user, description: 'Root')
+    child = Creative.create!(user: user, parent: root, description: 'Child')
+
+    new_parent = Creative.new(user: user, description: 'New Parent')
+    new_parent.parent = root
+    new_parent.save!
+
+    child.update!(parent: new_parent)
+
+    expect(new_parent.ancestor_ids).to eq [ root.id ]
+    expect(child.ancestor_ids).to eq [ new_parent.id, root.id ]
+  end
+end


### PR DESCRIPTION
## Summary
- ensure child node is reparented after new parent is saved
- add regression test for closure_tree ancestor updates

## Testing
- `bundle exec rspec spec/models/creative_ancestor_spec.rb --format doc`
- `bundle exec rspec --format doc` *(fails: Selenium WebDriver error)*

------
https://chatgpt.com/codex/tasks/task_e_684a3b0889388326be204e1587422c1f