### PR TITLE
Implement tag-filtered progress

### DIFF
--- a/app/helpers/creatives_helper.rb
+++ b/app/helpers/creatives_helper.rb
@@ -19,6 +19,13 @@ module CreativesHelper
   end
 
   def render_creative_progress(creative)
+    progress_value = if params[:tags].present?
+      tag_ids = Array(params[:tags]).map(&:to_s)
+      creative.progress_for_tags(tag_ids) || 0
+    else
+      creative.progress
+    end
+
     content_tag(:div, class: "creative-row-end") do
       comment_part = if creative.has_permission?(Current.user, :feedback)
         button_tag("(#{creative.effective_origin.comments.size})", name: "show-comments-btn",
@@ -27,7 +34,7 @@ module CreativesHelper
       else
         ""
       end
-      content_tag(:span, number_to_percentage(creative.progress * 100, precision: 0), class: "creative-progress-#{creative.progress == 1 ? "complete" : "incomplete"}") + comment_part
+      content_tag(:span, number_to_percentage(progress_value * 100, precision: 0), class: "creative-progress-#{progress_value == 1 ? "complete" : "incomplete"}") + comment_part
     end
   end
 

--- a/app/models/creative.rb
+++ b/app/models/creative.rb
@@ -108,6 +108,22 @@ class Creative < ApplicationRecord
     end
   end
 
+  def progress_for_tags(tag_ids, user = Current.user)
+    return progress if tag_ids.blank?
+
+    tag_ids = Array(tag_ids).map(&:to_s)
+    child_values = children_with_permission(user).map do |child|
+      child.progress_for_tags(tag_ids, user)
+    end.compact
+
+    if child_values.any?
+      child_values.sum.to_f / child_values.size
+    else
+      own_label_ids = tags.pluck(:label_id).map(&:to_s)
+      (own_label_ids & tag_ids).any? ? progress : nil
+    end
+  end
+
   # 공유 대상 사용자를 위해 Linked Creative를 생성합니다.
   # 이미 존재하거나 원본 작성자에게는 생성하지 않습니다.
   def create_linked_creative_for_user(user)

--- a/test/models/creative_test.rb
+++ b/test/models/creative_test.rb
@@ -23,14 +23,19 @@ class CreativeTest < ActiveSupport::TestCase
 
     parent = Creative.create!(user: user, description: "Parent")
     Creative.create!(user: user, parent: parent, description: "Child 1", progress: 0.2)
-    tagged_child = Creative.create!(user: user, parent: parent, description: "Child 2", progress: 0.8)
+    tagged_child1 = Creative.create!(user: user, parent: parent, description: "Child 2", progress: 0.8)
+    tagged_child2 = Creative.create!(user: user, parent: parent, description: "Child 3", progress: 0.6)
 
     label = Label.create!(name: "Plan", owner: user)
-    Tag.create!(creative_id: tagged_child.id, label: label)
+    Tag.create!(creative_id: tagged_child1.id, label: label)
+    Tag.create!(creative_id: tagged_child2.id, label: label)
 
-    assert_in_delta tagged_child.progress,
+    parent.reload
+
+    assert_in_delta((0.2 + 0.8 + 0.6) / 3.0, parent.progress, 0.001)
+    assert_in_delta((0.8 + 0.6) / 2.0,
                     parent.progress_for_tags([ label.id ], user),
-                    0.001
+                    0.001)
 
     Current.reset
   end


### PR DESCRIPTION
## Summary
- add `progress_for_tags` to calculate progress within tag filters
- show recalculated progress when filtering creatives by tags

## Testing
- `./bin/rubocop -a`
- `bundle exec rails test`


------
https://chatgpt.com/codex/tasks/task_e_684a572ca1108326a72337cbf21aa478