### PR TITLE
Add none permission level

### DIFF
--- a/app/controllers/creatives_controller.rb
+++ b/app/controllers/creatives_controller.rb
@@ -40,7 +40,10 @@ class CreativesController < ApplicationController
       # linked creative(복제본)이면 origin 사용
       base_creative = @shared_creative.origin_id.present? ? @shared_creative.origin : @shared_creative
       ancestor_ids = [ base_creative.id ] + base_creative.ancestors.pluck(:id)
-      @shared_list = CreativeShare.where(creative_id: ancestor_ids).includes(:user)
+      @shared_list = CreativeShare
+        .where(creative_id: ancestor_ids)
+        .where.not(permission: :none)
+        .includes(:user)
     end
   end
 

--- a/app/models/creative_share.rb
+++ b/app/models/creative_share.rb
@@ -3,10 +3,11 @@ class CreativeShare < ApplicationRecord
   belongs_to :user
 
   enum :permission, {
-    read: 0,
-    feedback: 1,
-    write: 2
-  }
+    none: 0,
+    read: 1,
+    feedback: 2,
+    write: 3
+  }, scopes: false
 
   validates :creative_id, presence: true
   validates :user_id, presence: true

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -2,7 +2,7 @@ class Invitation < ApplicationRecord
   belongs_to :inviter, class_name: "User"
   belongs_to :creative
 
-  enum :permission, CreativeShare.permissions
+  enum :permission, CreativeShare.permissions, scopes: false
 
   generates_token_for :invite, expires_in: 15.days
 

--- a/app/views/creatives/_share_button.html.erb
+++ b/app/views/creatives/_share_button.html.erb
@@ -26,6 +26,7 @@
       <div style="margin-bottom:1em;">
         <label for="share-permission"><%= t('creatives.index.permission') %></label>
         <select name="permission" id="share-permission" style="width:100%;">
+          <option value="none"><%= t('creatives.index.permission_none') %></option>
           <option value="read"><%= t('creatives.index.permission_read') %></option>
           <option value="feedback"><%= t('creatives.index.permission_feedback') %></option>
           <option value="write"><%= t('creatives.index.permission_write') %></option>

--- a/config/locales/creatives.en.yml
+++ b/config/locales/creatives.en.yml
@@ -29,6 +29,7 @@ en:
       unknown_user: "Unknown user"
       user_email: "User Email"
       permission: "Permission"
+      permission_none: "None"
       permission_read: "Read"
       permission_write: "Write"
       permission_feedback: "Feedback"

--- a/config/locales/creatives.en.yml
+++ b/config/locales/creatives.en.yml
@@ -48,6 +48,7 @@ en:
     share:
       shared: "Creative shared successfully."
       already_shared_in_parent: "Creative already shared in parent creative."
+      parent_share_required: "Cannot set to none without a parent share."
     notices:
       progress_recalculated: "All parent progress recalculated."
     errors:

--- a/config/locales/creatives.ko.yml
+++ b/config/locales/creatives.ko.yml
@@ -29,6 +29,7 @@ ko:
       unknown_user: "알 수 없는 사용자"
       user_email: "사용자 이메일"
       permission: "권한"
+      permission_none: "없음"
       permission_read: "읽기"
       permission_write: "쓰기"
       permission_feedback: "피드백"

--- a/config/locales/creatives.ko.yml
+++ b/config/locales/creatives.ko.yml
@@ -48,6 +48,7 @@ ko:
     share:
       shared: "크리에이티브가 성공적으로 공유되었습니다."
       already_shared_in_parent: "크리에이티브가 상위 크리에이티브에 이미 공유되었습니다."
+      parent_share_required: "상위에서 권한이 있는 경우에만 none 설정이 가능합니다."
     notices:
       progress_recalculated: "진행률을 다시 계산 했습니다."
     errors:

--- a/db/migrate/20250613000000_add_none_permission.rb
+++ b/db/migrate/20250613000000_add_none_permission.rb
@@ -1,0 +1,19 @@
+class AddNonePermission < ActiveRecord::Migration[6.1]
+  def up
+    execute <<~SQL
+      UPDATE creative_shares SET permission = permission + 1;
+    SQL
+    execute <<~SQL
+      UPDATE invitations SET permission = permission + 1 WHERE permission IS NOT NULL;
+    SQL
+  end
+
+  def down
+    execute <<~SQL
+      UPDATE creative_shares SET permission = permission - 1;
+    SQL
+    execute <<~SQL
+      UPDATE invitations SET permission = permission - 1 WHERE permission IS NOT NULL;
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_12_150000) do
+ActiveRecord::Schema[8.0].define(version: 2025_06_13_000000) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
     t.text "body"


### PR DESCRIPTION
## Summary
- allow a `none` permission level for shares/invites
- expose the new permission option in the share dropdown
- migrate existing permissions up by one

## Testing
- `./bin/rubocop -a`
- `bundle exec rails test`


------
https://chatgpt.com/codex/tasks/task_e_684aaea55fb48326a8e80259a81c1678