### PR TITLE
Refactor CSS into ChatGPT-like theme

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -9,18 +9,23 @@
  * Consider organizing styles into separate files for maintainability.
  */
 body {
-    font-family: Arial, Helvetica, sans-serif;
+    font-family: var(--font-sans);
     padding: 0;
+    line-height: 1.6;
+    background: var(--color-bg);
+    color: var(--color-text);
 }
 
 nav {
-    justify-content: flex-end;
     display: flex;
+    justify-content: flex-end;
     font-size: 0.875em;
-    gap: 0.5rem;
-    max-width: 1024px;
+    gap: 0.75rem;
+    max-width: 960px;
     margin: 0 auto;
     padding: 1rem;
+    background: var(--color-nav-bg);
+    border-bottom: 1px solid var(--color-border);
 }
 
 nav a {
@@ -28,8 +33,10 @@ nav a {
 }
 
 main {
-    max-width: 1024px;
-    margin: 0 auto;
+    max-width: 960px;
+    margin: 1rem auto;
+    padding: 0 1rem;
+    background: var(--color-section-bg);
 }
 
 .notice {
@@ -63,6 +70,7 @@ section.creative img {
     transition: background 0.15s;
 }
 
+
 .drag-over-top {
     border-top: 3px solid var(--color-drag-over-edge) !important;
 }
@@ -76,7 +84,7 @@ button {
 }
 
 #plans-list-area {
-    max-width: 1024px;
+    max-width: 960px;
     margin: 0.5em auto;
 }
 
@@ -86,7 +94,7 @@ button {
     right: -300px;
     width: 300px;
     height: 100%;
-    background: var(--color-bg, white);
+    background: var(--color-section-bg);
     box-shadow: -2px 0 5px rgba(0,0,0,0.2);
     overflow-y: auto;
     transition: right 0.3s;
@@ -102,7 +110,7 @@ button {
     justify-content: space-between;
     align-items: center;
     padding: 0.5em;
-    border-bottom: 1px solid #eee;
+    border-bottom: 1px solid var(--color-border);
 }
 
 #close-inbox {
@@ -114,7 +122,7 @@ button {
 }
 
 .inbox-item {
-    border-bottom: 1px solid #eee;
+    border-bottom: 1px solid var(--color-border);
     padding: 0.5em;
 }
 

--- a/app/assets/stylesheets/comments_popup.css
+++ b/app/assets/stylesheets/comments_popup.css
@@ -4,8 +4,8 @@
   right: 2em;
   /* top: 10em; */
   z-index: 1000;
-  background: var(--color-bg);
-  border: 1px solid #ccc;
+  background: var(--color-section-bg);
+  border: 1px solid var(--color-border);
   padding: 1em;
   width: 350px;
   max-height: 400px;
@@ -27,7 +27,7 @@
   width: 94%;
   resize: vertical;
   border-radius: 6px;
-  border: 1px solid #ddd;
+  border: 1px solid var(--color-border);
   padding: 0.5em;
 }
 
@@ -37,7 +37,7 @@
 }
 
 .comment-item {
-    border-top: 1px solid #eee;
+    border-top: 1px solid var(--color-border);
     padding: 0.5em 0;
     position: relative;
 }

--- a/app/assets/stylesheets/creatives.css
+++ b/app/assets/stylesheets/creatives.css
@@ -25,10 +25,10 @@
     display: none;
     position: absolute;
     z-index: 10;
-    background: #fff;
-    border: 1px solid #ccc;
+    background: var(--color-section-bg);
+    border: 1px solid var(--color-border);
     padding: 0.5em;
-    box-shadow: 0 2px 8px #ccc;
+    box-shadow: 0 2px 8px var(--color-border);
     min-width: 220px;
 }
 .delete-one {
@@ -65,7 +65,7 @@
 
 .creative-row-end {
     margin-left: 10px;
-    color: #888;
+    color: var(--color-muted);
     font-size: 0.9em;
     white-space: nowrap;
 }
@@ -120,7 +120,7 @@
 }
 
 .creative-progress {
-    color: #888;
+    color: var(--color-muted);
     font-size: 0.9em;
     margin-left: 10px;
 }

--- a/app/assets/stylesheets/dark_mode.css
+++ b/app/assets/stylesheets/dark_mode.css
@@ -16,17 +16,17 @@
 }
 
 body.dark-mode {
-  --color-bg: #343541;
-  --color-text: #ececf1;
-  --color-link: #5891ff;
-  --color-nav-bg: #3c3f44;
-  --color-section-bg: #444654;
-  --color-btn-bg: #565869;
-  --color-btn-text: #ececf1;
-  --color-border: #555;
-  --color-muted: #9a9a9a;
-  --color-drag-over: #3c3d43;
-  --color-drag-over-edge: #656565;
+  --color-bg: #212121;
+  --color-text: #eaeaea;
+  --color-link: #6a9eff;
+  --color-nav-bg: #181818;
+  --color-section-bg: #181818;
+  --color-btn-bg: #333543;
+  --color-btn-text: #eaeaea;
+  --color-border: #333333;
+  --color-muted: #aaaaaa;
+  --color-drag-over: #383a40;
+  --color-drag-over-edge: #777;
 }
 
 body {

--- a/app/assets/stylesheets/dark_mode.css
+++ b/app/assets/stylesheets/dark_mode.css
@@ -1,26 +1,32 @@
 /* 다크모드 변수 및 스타일 */
 :root {
-  --color-bg: #fff;
-  --color-text: #222;
-  --color-link: #1a73e8;
-  --color-nav-bg: #fff;
-  --color-section-bg: #fff;
-  --color-btn-bg: #eee;
-  --color-btn-text: #000;
-  --color-drag-over: #ffe082;
-  --color-drag-over-edge: #ffb300;
+  --font-sans: "Inter", system-ui, -apple-system, "Segoe UI", Helvetica, Arial,
+    sans-serif;
+  --color-bg: #f7f7f8;
+  --color-text: #202123;
+  --color-link: #0a83d7;
+  --color-nav-bg: #ffffff;
+  --color-section-bg: #ffffff;
+  --color-btn-bg: #f1f2f4;
+  --color-btn-text: #202123;
+  --color-border: #e0e0e0;
+  --color-muted: #666;
+  --color-drag-over: #e0e0e0;
+  --color-drag-over-edge: #bbb;
 }
 
 body.dark-mode {
-  --color-bg: #181a1b;
-  --color-text: #e8eaed;
-  --color-link: #8ab4f8;
-  --color-nav-bg: #181a1b;
-  --color-section-bg: #181a1b;
-  --color-btn-bg: #000;
-  --color-btn-text: #fff;
-  --color-drag-over: #3a3b3c;
-  --color-drag-over-edge: #4a4b4c;
+  --color-bg: #343541;
+  --color-text: #ececf1;
+  --color-link: #5891ff;
+  --color-nav-bg: #3c3f44;
+  --color-section-bg: #444654;
+  --color-btn-bg: #565869;
+  --color-btn-text: #ececf1;
+  --color-border: #555;
+  --color-muted: #9a9a9a;
+  --color-drag-over: #3c3d43;
+  --color-drag-over-edge: #656565;
 }
 
 body {


### PR DESCRIPTION
## Summary
- update CSS variables for a cleaner ChatGPT style
- restructure `application.css` for modern layout
- tweak creatives and comments popup styles to use new variables

## Testing
- `./bin/rubocop -a`
- `bundle exec rake spec` *(fails: Selenium cannot download Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_684ad10fe41c8326bbc6efd1df57a381