### PR TITLE
Improve tag filtered progress

### DIFF
--- a/app/controllers/creatives_controller.rb
+++ b/app/controllers/creatives_controller.rb
@@ -46,14 +46,11 @@ class CreativesController < ApplicationController
     if params[:tags].present?
       tag_ids = Array(params[:tags]).map(&:to_s)
       roots = @creatives || []
-      progress_values = roots.select do |creative|
-        creative_label_ids = creative.tags.pluck(:label_id).map(&:to_s)
-        (creative_label_ids & tag_ids).any?
-      end.map { |c| c.progress_for_tags(tag_ids) }.compact
+      progress_values = roots.map { |c| c.progress_for_tags(tag_ids) }.compact
       if progress_values.any?
         @overall_progress = progress_values.sum.to_f / progress_values.size
       else
-        @overall_progress = nil
+        @overall_progress = 0
       end
     end
   end

--- a/app/controllers/creatives_controller.rb
+++ b/app/controllers/creatives_controller.rb
@@ -42,6 +42,20 @@ class CreativesController < ApplicationController
       ancestor_ids = [ base_creative.id ] + base_creative.ancestors.pluck(:id)
       @shared_list = CreativeShare.where(creative_id: ancestor_ids).includes(:user)
     end
+
+    if params[:tags].present?
+      tag_ids = Array(params[:tags]).map(&:to_s)
+      roots = @creatives || []
+      progress_values = roots.select do |creative|
+        creative_label_ids = creative.tags.pluck(:label_id).map(&:to_s)
+        (creative_label_ids & tag_ids).any?
+      end.map { |c| c.progress_for_tags(tag_ids) }.compact
+      if progress_values.any?
+        @overall_progress = progress_values.sum.to_f / progress_values.size
+      else
+        @overall_progress = nil
+      end
+    end
   end
 
   def show

--- a/app/helpers/creatives_helper.rb
+++ b/app/helpers/creatives_helper.rb
@@ -34,7 +34,7 @@ module CreativesHelper
       else
         ""
       end
-      content_tag(:span, number_to_percentage(progress_value * 100, precision: 0), class: "creative-progress-#{progress_value == 1 ? "complete" : "incomplete"}") + comment_part
+      render_progress_value(progress_value) + comment_part
     end
   end
 

--- a/app/helpers/creatives_helper.rb
+++ b/app/helpers/creatives_helper.rb
@@ -38,6 +38,14 @@ module CreativesHelper
     end
   end
 
+  def render_progress_value(value)
+    content_tag(
+      :span,
+      number_to_percentage(value * 100, precision: 0),
+      class: "creative-progress-#{value == 1 ? 'complete' : 'incomplete'}"
+    )
+  end
+
   def render_creative_tree(creatives, level = 1, select_mode: false)
     safe_join(
       creatives.map do |creative|

--- a/app/models/creative.rb
+++ b/app/models/creative.rb
@@ -112,7 +112,8 @@ class Creative < ApplicationRecord
     return progress if tag_ids.blank?
 
     tag_ids = Array(tag_ids).map(&:to_s)
-    child_values = children_with_permission(user).map do |child|
+    visible_children = children_with_permission(user)
+    child_values = visible_children.map do |child|
       child.progress_for_tags(tag_ids, user)
     end.compact
 
@@ -120,7 +121,11 @@ class Creative < ApplicationRecord
       child_values.sum.to_f / child_values.size
     else
       own_label_ids = tags.pluck(:label_id).map(&:to_s)
-      (own_label_ids & tag_ids).any? ? progress : nil
+      if (own_label_ids & tag_ids).any?
+        visible_children.any? ? 1.0 : progress
+      else
+        nil
+      end
     end
   end
 

--- a/app/views/creatives/index.html.erb
+++ b/app/views/creatives/index.html.erb
@@ -62,9 +62,15 @@
   </div>
 <% else %>
   <div class="creative-row" id="creative-markdown-block">
-    <h1 class="page-title"><%= t('.creatives') %>
-      <% if params[:tags].present? %>
-      (<%= render_tags(params[:tags]&.map { |tag_id| Label.find(tag_id) }, 'unstyled-link') %>)
+    <h1 class="page-title" style="display:flex;align-items:center;gap:1em;">
+      <span>
+        <%= t('.creatives') %>
+        <% if params[:tags].present? %>
+        (<%= render_tags(params[:tags]&.map { |tag_id| Label.find(tag_id) }, 'unstyled-link') %>)
+        <% end %>
+      </span>
+      <% if @overall_progress %>
+        <%= render_progress_value(@overall_progress) %>
       <% end %>
     </h1>
   </div>

--- a/app/views/creatives/index.html.erb
+++ b/app/views/creatives/index.html.erb
@@ -69,10 +69,14 @@
         (<%= render_tags(params[:tags]&.map { |tag_id| Label.find(tag_id) }, 'unstyled-link') %>)
         <% end %>
       </span>
-      <% unless @overall_progress.nil? %>
-        <%= render_progress_value(@overall_progress) %>
-      <% end %>
     </h1>
+    <div>
+      <h1 style="display: flex; align-items: center; gap: 1em;">
+        <% unless @overall_progress.nil? %>
+          <%= render_progress_value(@overall_progress) %>
+        <% end %>
+      </h1>
+    </div>
   </div>
 <% end %>
 

--- a/app/views/creatives/index.html.erb
+++ b/app/views/creatives/index.html.erb
@@ -69,7 +69,7 @@
         (<%= render_tags(params[:tags]&.map { |tag_id| Label.find(tag_id) }, 'unstyled-link') %>)
         <% end %>
       </span>
-      <% if @overall_progress %>
+      <% unless @overall_progress.nil? %>
         <%= render_progress_value(@overall_progress) %>
       <% end %>
     </h1>

--- a/test/models/creative_test.rb
+++ b/test/models/creative_test.rb
@@ -39,4 +39,19 @@ class CreativeTest < ActiveSupport::TestCase
 
     Current.reset
   end
+
+  test "progress_for_tags returns 1 when children filtered out" do
+    user = users(:one)
+    Current.session = OpenStruct.new(user: user)
+
+    parent = Creative.create!(user: user, description: "Parent", progress: 0.2)
+    Creative.create!(user: user, parent: parent, description: "Child", progress: 0.5)
+
+    label = Label.create!(name: "Tag", owner: user)
+    Tag.create!(creative_id: parent.id, label: label)
+
+    assert_equal 1.0, parent.progress_for_tags([ label.id ], user)
+
+    Current.reset
+  end
 end


### PR DESCRIPTION
## Summary
- show overall progress when tags filter is active
- treat creatives with all children filtered out as complete
- add helper for rendering arbitrary progress value
- test progress_for_tags behavior when children are filtered out

## Testing
- `./bin/rubocop -a`
- `bundle exec rails test`

------
https://chatgpt.com/codex/tasks/task_e_684b61a7141883269b5a05b7e2d32973