### PR TITLE
Implement email verification on signup

### DIFF
--- a/app/controllers/email_verifications_controller.rb
+++ b/app/controllers/email_verifications_controller.rb
@@ -1,0 +1,11 @@
+class EmailVerificationsController < ApplicationController
+  allow_unauthenticated_access
+
+  def show
+    user = User.find_by_token_for(:email_verification, params[:token])
+    user.update!(email_verified_at: Time.current) unless user.email_verified_at?
+    redirect_to new_session_path, notice: t("users.email_verified")
+  rescue ActiveSupport::MessageVerifier::InvalidSignature
+    redirect_to new_user_path, alert: t("users.verification_invalid")
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -7,8 +7,12 @@ class SessionsController < ApplicationController
 
   def create
     if user = User.authenticate_by(params.permit(:email, :password))
-      start_new_session_for user
-      redirect_to after_authentication_url
+      if user.email_verified?
+        start_new_session_for user
+        redirect_to after_authentication_url
+      else
+        redirect_to new_session_path, alert: I18n.t("users.sessions.new.email_not_verified")
+      end
     else
       redirect_to new_session_path, alert: I18n.t("users.sessions.new.try_another_email_or_password")
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -21,6 +21,7 @@ class UsersController < ApplicationController
           CreativeShare.create!(creative: invitation.creative, user: @user, permission: invitation.permission)
           invitation.creative.create_linked_creative_for_user(@user)
         end
+        UserMailer.email_verification(@user).deliver_now
         session.delete(:return_to_after_authenticating)
         redirect_to new_session_path, notice: t("users.new.success_sign_up")
       else

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,0 +1,6 @@
+class UserMailer < ApplicationMailer
+  def email_verification(user)
+    @user = user
+    mail to: user.email, subject: t("user_mailer.email_verification.subject")
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,15 @@ class User < ApplicationRecord
   has_many :labels, foreign_key: :owner_id
 
   normalizes :email, with: ->(e) { e.strip.downcase }
+
+  validates :email, presence: true, uniqueness: true,
+                    format: { with: URI::MailTo::EMAIL_REGEXP }
+
+  generates_token_for :email_verification, expires_in: 1.day do
+    email
+  end
+
+  def email_verified?
+    email_verified_at.present?
+  end
 end

--- a/app/views/user_mailer/email_verification.html.erb
+++ b/app/views/user_mailer/email_verification.html.erb
@@ -1,0 +1,3 @@
+<p>
+  Please verify your email by clicking <%= link_to 'here', verify_url(token: @user.generate_token_for(:email_verification)) %>.
+</p>

--- a/app/views/user_mailer/email_verification.text.erb
+++ b/app/views/user_mailer/email_verification.text.erb
@@ -1,0 +1,2 @@
+Please verify your email by visiting the following link:
+<%= verify_url(token: @user.generate_token_for(:email_verification)) %>

--- a/config/locales/users.en.yml
+++ b/config/locales/users.en.yml
@@ -9,12 +9,13 @@ en:
       confirm_your_password: "Confirm your password"
       sign_up: "Sign Up"
       back_to_sign_in: "Back to Sign In"
-      success_sign_up: "Account created successfully! Please sign in."
+      success_sign_up: "Account created successfully! Please check your email to verify."
     sessions:
       new:
         forgot_password: "Forgot password?"
         try_again_later: "Try again later."
         try_another_email_or_password: "Try another email address or password."
+        email_not_verified: "You must verify your email before signing in."
     details: "User Details"
     email: "Email"
     change_password: "Change password"
@@ -27,3 +28,8 @@ en:
     current_password_incorrect: "Current password is incorrect."
     forgot_password: "Forgot your password?"
     send_password_reset_instructions: "Email reset instructions"
+    email_verified: "Email verified successfully."
+    verification_invalid: "Verification link is invalid or has expired."
+  user_mailer:
+    email_verification:
+      subject: "Verify your email"

--- a/config/locales/users.ko.yml
+++ b/config/locales/users.ko.yml
@@ -9,12 +9,13 @@ ko:
       confirm_your_password: "비밀번호를 다시 입력하세요"
       sign_up: "회원가입"
       back_to_sign_in: "로그인 화면으로 돌아가기"
-      success_sign_up: "회원가입이 완료되었습니다. 로그인해주세요."
+      success_sign_up: "회원가입이 완료되었습니다. 이메일을 확인해 인증해주세요."
     sessions:
       new:
         forgot_password: "비밀번호를 잊으셨나요?"
         try_again_later: "잠시 후 다시 시도하세요."
         try_another_email_or_password: "이메일 주소나 비밀번호를 다시 확인하세요."
+        email_not_verified: "이메일 인증 후에 로그인할 수 있습니다."
     details: "사용자 정보"
     email: "이메일"
     change_password: "비밀번호 변경"
@@ -27,3 +28,8 @@ ko:
     back: "뒤로가기"
     forgot_password: "비밀번호를 잊으셨나요?"
     send_password_reset_instructions: "비밀번호 재설정 이메일 보내기"
+    email_verified: "이메일 인증이 완료되었습니다."
+    verification_invalid: "인증 링크가 유효하지 않거나 만료되었습니다."
+  user_mailer:
+    email_verification:
+      subject: "이메일 인증"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,6 +52,7 @@ Rails.application.routes.draw do
 
   resource :unsubscribe, only: [ :show ]
   resource :invite, only: [ :show ]
+  resource :verify, controller: "email_verifications", only: [ :show ]
 
   post "/creative_expanded_states/toggle", to: "creative_expanded_states#toggle"
 end

--- a/db/migrate/20250612232913_add_email_verified_at_to_users.rb
+++ b/db/migrate/20250612232913_add_email_verified_at_to_users.rb
@@ -1,0 +1,5 @@
+class AddEmailVerifiedAtToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :email_verified_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_12_150000) do
+ActiveRecord::Schema[8.0].define(version: 2025_06_12_232913) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
     t.text "body"
@@ -313,6 +313,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_12_150000) do
     t.string "password_digest", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "email_verified_at"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/test/integration/email_verification_flow_test.rb
+++ b/test/integration/email_verification_flow_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+require "cgi"
+
+class EmailVerificationFlowTest < ActionDispatch::IntegrationTest
+  test "verification link verifies user" do
+    ActionMailer::Base.deliveries.clear
+    post users_path, params: { user: { email: "verify@example.com", password: "secret", password_confirmation: "secret" } }
+    user = User.find_by(email: "verify@example.com")
+    assert_not_nil user
+    assert_nil user.email_verified_at
+
+    mail = ActionMailer::Base.deliveries.last
+    body = mail.text_part ? mail.text_part.body.decoded : mail.body.decoded
+    token = CGI.unescape(body[/token=([^"\s]+)/, 1])
+    assert token.present?, "token should be present in email"
+
+    get verify_path(token: token)
+    assert_redirected_to new_session_path
+    follow_redirect!
+    assert_match I18n.t("users.email_verified"), response.body
+
+    user.reload
+    assert_not_nil user.email_verified_at
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,7 +1,16 @@
 require "test_helper"
 
 class UserTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "requires valid email" do
+    user = User.new(email: "bad", password: "secret", password_confirmation: "secret")
+    assert_not user.valid?
+    assert_includes user.errors[:email], "is invalid"
+  end
+
+  test "requires unique email" do
+    User.create!(email: "taken@example.com", password: "secret")
+    user = User.new(email: "taken@example.com", password: "secret")
+    assert_not user.valid?
+    assert_includes user.errors[:email], "has already been taken"
+  end
 end


### PR DESCRIPTION
## Summary
- add `email_verified_at` column and model validations
- send verification email after signup and block login if not verified
- provide controller and routes for email verification
- document I18n strings for verification flow
- test verification flow and user model validations

## Testing
- `./bin/rubocop -A`
- `bundle exec rails test`
- `bundle exec rspec` *(fails: Selenium unable to download Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_684b61c74f748326865cfcca8ec6224f