### PR TITLE
Enable realtime comment updates

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -4,7 +4,7 @@ class CommentsController < ApplicationController
 
   def index
     @comments = @creative.comments.order(created_at: :desc)
-    render partial: "comments/list", locals: { comments: @comments }
+    render partial: "comments/list", locals: { comments: @comments, creative: @creative }
   end
 
   def create

--- a/app/javascript/comments.js
+++ b/app/javascript/comments.js
@@ -38,7 +38,7 @@ if (!window.commentsInitialized) {
                     .then(r => r.text()).then(html => {
                         list.innerHTML = html;
                         if (highlightId) {
-                            var el = document.getElementById('comment-' + highlightId);
+                            var el = document.getElementById('comment_' + highlightId);
                             if (el) {
                                 el.classList.add('highlight-flash');
                                 setTimeout(function(){ el.classList.remove('highlight-flash'); }, 2000);

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -4,9 +4,23 @@ class Comment < ApplicationRecord
 
   validates :content, presence: true
 
-  after_create_commit :notify_creative_owner
+  after_create_commit :broadcast_create, :notify_creative_owner
+  after_update_commit :broadcast_update
+  after_destroy_commit :broadcast_destroy
 
   private
+
+  def broadcast_create
+    broadcast_prepend_later_to([ creative, :comments ], target: "comments_list")
+  end
+
+  def broadcast_update
+    broadcast_replace_later_to([ creative, :comments ])
+  end
+
+  def broadcast_destroy
+    broadcast_remove_to([ creative, :comments ])
+  end
 
   def notify_creative_owner
     return unless creative.user && user && creative.user != user

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,4 +1,4 @@
-<div class="comment-item" id="comment-<%= comment.id %>">
+<div class="comment-item" id="<%= dom_id(comment) %>">
   <div>
     <strong><%= comment.user&.email || t('comments.anonymous') %></strong>
     <span>· <%= t('datetime.ago', time: time_ago_in_words(comment.created_at)) %></span>

--- a/app/views/comments/_list.html.erb
+++ b/app/views/comments/_list.html.erb
@@ -1,4 +1,5 @@
-<div class="comments-list">
+<div class="comments-list" id="comments_list">
+  <%= turbo_stream_from [creative, :comments] %>
   <% if comments.any? %>
     <% comments.each do |comment| %>
       <%= render partial: 'comments/comment', locals: { comment: comment } %>


### PR DESCRIPTION
## Summary
- broadcast comment changes with Turbo Streams
- subscribe comment list partial to stream
- add DOM ids for each comment item
- adjust JS highlight to new DOM ids
- pass creative to comment list partial for streaming

## Testing
- `./bin/rubocop -a`

------
https://chatgpt.com/codex/tasks/task_e_684ba3763a388326b330ea251e0986f6