### PR TITLE
Update comment display

### DIFF
--- a/app/assets/stylesheets/creatives.css
+++ b/app/assets/stylesheets/creatives.css
@@ -153,3 +153,17 @@
 .indent3 {
     margin-left: 0.4em;
 }
+
+.comments-btn.no-comments {
+    visibility: hidden;
+}
+
+.creative-row:hover .comments-btn.no-comments {
+    visibility: visible;
+}
+
+@media (max-width: 768px) {
+    .comments-btn.no-comments {
+        visibility: visible;
+    }
+}

--- a/app/helpers/creatives_helper.rb
+++ b/app/helpers/creatives_helper.rb
@@ -28,9 +28,16 @@ module CreativesHelper
 
     content_tag(:div, class: "creative-row-end") do
       comment_part = if creative.has_permission?(Current.user, :feedback)
-        button_tag("(#{creative.effective_origin.comments.size})", name: "show-comments-btn",
-                   "data-creative-id": creative.id,
-                   "data-can-comment": true)
+        comments_count = creative.effective_origin.comments.size
+        btn_text = comments_count.zero? ? "\u{1F4AC}" : "(#{comments_count})"
+        classes = [ "comments-btn" ]
+        classes << "no-comments" if comments_count.zero?
+        button_tag(
+          btn_text,
+          name: "show-comments-btn",
+          data: { creative_id: creative.id, can_comment: true },
+          class: classes.join(" ")
+        )
       else
         ""
       end


### PR DESCRIPTION
## Summary
- show 💬 icon when there are no comments
- hide the icon until hover on desktop, but always show it on mobile

## Testing
- `bin/rails db:test:prepare test test:system`
- `./bin/rubocop -a`


------
https://chatgpt.com/codex/tasks/task_e_684be1fc50308326a781fe2d16602ca1