### PR TITLE
Implement Turbo inbox badge

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem "turbo-rails"
 gem "stimulus-rails"
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 gem "jbuilder"
+gem "view_component"
 
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 gem "bcrypt", "~> 3.1.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,6 +167,7 @@ GEM
       net-smtp
     marcel (1.0.4)
     matrix (0.4.2)
+    method_source (1.1.0)
     mini_magick (5.2.0)
       benchmark
       logger
@@ -377,6 +378,10 @@ GEM
     unicode-emoji (4.0.4)
     uri (1.0.3)
     useragent (0.16.11)
+    view_component (3.23.2)
+      activesupport (>= 5.2.0, < 8.1)
+      concurrent-ruby (~> 1)
+      method_source (~> 1.0)
     web-console (4.2.1)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -431,6 +436,7 @@ DEPENDENCIES
   thruster
   turbo-rails
   tzinfo-data
+  view_component
   web-console
 
 BUNDLED WITH

--- a/app/components/inbox/badge_component.html.erb
+++ b/app/components/inbox/badge_component.html.erb
@@ -1,0 +1,2 @@
+
+<%= render 'inbox/badge_component/count', count: count %>

--- a/app/components/inbox/badge_component.rb
+++ b/app/components/inbox/badge_component.rb
@@ -1,0 +1,11 @@
+module Inbox
+  class BadgeComponent < ViewComponent::Base
+    def initialize(user:)
+      @user = user
+    end
+
+    def count
+      InboxItem.where(owner: @user, state: "new").count
+    end
+  end
+end

--- a/app/models/inbox_item.rb
+++ b/app/models/inbox_item.rb
@@ -1,6 +1,8 @@
 class InboxItem < ApplicationRecord
   belongs_to :owner, class_name: "User"
 
+  after_commit :broadcast_badge_update, on: %i[create update destroy] # adjust callbacks as needed
+
   attribute :state, :string, default: "new"
   validates :state, inclusion: { in: %w[new read archived] }
   validates :message, presence: true
@@ -10,5 +12,20 @@ class InboxItem < ApplicationRecord
 
   def read?
     state == "read"
+  end
+
+  private
+
+  def broadcast_badge_update
+    # Recompute the new count for this owner:
+    new_count = InboxItem.where(owner: owner, state: "new").count
+
+    # Use Turbo::StreamsChannel to broadcast replace to that user’s inbox stream:
+    Turbo::StreamsChannel.broadcast_replace_to(
+      [ "inbox", owner ],
+      target: "inbox-badge",
+      partial: "inbox/badge_component/count",
+      locals: { count: new_count }
+    )
   end
 end

--- a/app/views/inbox/badge_component/_count.html.erb
+++ b/app/views/inbox/badge_component/_count.html.erb
@@ -1,0 +1,2 @@
+<% display = count.positive? ? 'inline-block' : 'none' %>
+<span id="inbox-badge" style="display:<%= display %>"><%= count if count.positive? %></span>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,6 +27,7 @@
     <%= javascript_importmap_tags %>
   </head>
   <body>
+    <%= turbo_stream_from ["inbox", Current.user] if Current.user %>
     <div class="notice"><%= notice %></div>
 
     <nav style="display: flex; flex-wrap: wrap;">
@@ -45,7 +46,7 @@
       <% if Current.user %>
         <%= link_to Current.user.email, user_path(Current.user) %>
         <form id="inbox_button_to">
-          <button id="inbox-menu-btn" type="button"><%= t('app.inbox') %><span id="inbox-badge"></span></button>
+          <button id="inbox-menu-btn" type="button"><%= t('app.inbox') %><%= render Inbox::BadgeComponent.new(user: Current.user) %></button>
         </form>
       <% end %>
       <%= link_to t('app.sign_in'), new_session_path unless authenticated? %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,6 +15,8 @@ module Plan42
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 8.0
 
+    config.autoload_paths << Rails.root.join("app/components")
+
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.


### PR DESCRIPTION
## Summary
- add `view_component` gem
- add `Inbox::BadgeComponent` for the inbox badge
- render component in layout
- broadcast badge updates from InboxItem
- autoload components path

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: Selenium couldn't download Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_684be2a01b388326afb4dc09ebf0f92b