### PR TITLE
Fix scrolling of page when popups open

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -18,6 +18,12 @@ body {
     margin: 0;
 }
 
+/* Prevent background scrolling when popups or panels are open */
+.no-scroll {
+    overflow: hidden !important;
+    height: 100%;
+}
+
 nav {
     display: flex;
     justify-content: flex-end;

--- a/app/javascript/comments.js
+++ b/app/javascript/comments.js
@@ -10,6 +10,7 @@ if (!window.commentsInitialized) {
             if (isMobile()) {
                 popup.style.display = 'block';
                 popup.classList.add('open');
+                document.body.classList.add('no-scroll');
             } else {
                 var rect = btn.getBoundingClientRect();
                 var scrollY = window.scrollY || window.pageYOffset;
@@ -17,6 +18,7 @@ if (!window.commentsInitialized) {
                 popup.style.right = (window.innerWidth - rect.right) + 'px';
                 popup.style.left = '';
                 popup.style.display = 'block';
+                document.body.classList.add('no-scroll');
             }
             fetchComments();
         }
@@ -27,6 +29,7 @@ if (!window.commentsInitialized) {
             } else {
                 popup.style.display = 'none';
             }
+            document.body.classList.remove('no-scroll');
         }
         var popup = document.getElementById('comments-popup');
         var closeBtn = document.getElementById('close-comments-btn');

--- a/app/javascript/set_plan_modal.js
+++ b/app/javascript/set_plan_modal.js
@@ -9,9 +9,20 @@ if (!window.isSetPlanModalInitialized) {
         var idsInput = document.getElementById('selected-creative-ids-input');
         var removeBtn = document.getElementById('remove-plan-btn');
         if (setPlanBtn && modal && closeBtn) {
-            setPlanBtn.onclick = function() { modal.style.display = 'flex'; };
-            closeBtn.onclick = function() { modal.style.display = 'none'; };
-            modal.onclick = function(e) { if (e.target === modal) modal.style.display = 'none'; };
+            setPlanBtn.onclick = function() {
+                modal.style.display = 'flex';
+                document.body.classList.add('no-scroll');
+            };
+            closeBtn.onclick = function() {
+                modal.style.display = 'none';
+                document.body.classList.remove('no-scroll');
+            };
+            modal.onclick = function(e) {
+                if (e.target === modal) {
+                    modal.style.display = 'none';
+                    document.body.classList.remove('no-scroll');
+                }
+            };
         }
         if (form && idsInput) {
             form.onsubmit = function() {

--- a/app/views/creatives/_share_button.html.erb
+++ b/app/views/creatives/_share_button.html.erb
@@ -42,9 +42,20 @@
         const modal = document.getElementById('share-creative-modal');
         const closeBtn = document.getElementById('close-share-modal');
         if (shareBtn && modal && closeBtn) {
-            shareBtn.onclick = function() { modal.style.display = 'flex'; };
-            closeBtn.onclick = function() { modal.style.display = 'none'; };
-            modal.onclick = function(e) { if (e.target === modal) modal.style.display = 'none'; };
+            shareBtn.onclick = function() {
+                modal.style.display = 'flex';
+                document.body.classList.add('no-scroll');
+            };
+            closeBtn.onclick = function() {
+                modal.style.display = 'none';
+                document.body.classList.remove('no-scroll');
+            };
+            modal.onclick = function(e) {
+                if (e.target === modal) {
+                    modal.style.display = 'none';
+                    document.body.classList.remove('no-scroll');
+                }
+            };
         }
     });
 </script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -187,12 +187,14 @@
             panel.classList.add('open');
             localStorage.setItem('inboxOpen', '1');
             loadInbox();
+            document.body.classList.add('no-scroll');
           }
 
           function closePanel() {
             if (!panel) return;
             panel.classList.remove('open');
             localStorage.removeItem('inboxOpen');
+            document.body.classList.remove('no-scroll');
           }
 
           if (btn && panel) {


### PR DESCRIPTION
## Summary
- prevent page scrolling when inbox panel or popups are visible
- add `.no-scroll` style
- lock body scroll in Comments popup, Plan modal, Share modal and Inbox panel

## Testing
- `./bin/rubocop -a`
- `bundle exec rails test`

------
https://chatgpt.com/codex/tasks/task_e_684f92352f3083269b99c0572ec916a4