### PR TITLE
Improve share popup layout

### DIFF
--- a/app/assets/stylesheets/popup.css
+++ b/app/assets/stylesheets/popup.css
@@ -7,6 +7,19 @@
   position: relative;
 }
 
+.share-grid {
+  list-style: none;
+  padding: 0;
+}
+
+.share-grid li {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 0.5em;
+  align-items: center;
+  margin-bottom: 0.5em;
+}
+
 .popup-close-btn {
   position: absolute;
   top: 0.5em;

--- a/app/views/creatives/_share_button.html.erb
+++ b/app/views/creatives/_share_button.html.erb
@@ -5,19 +5,6 @@
   <div class="popup-box" style="min-width:320px;max-width:90vw;">
     <button id="close-share-modal" class="popup-close-btn">&times;</button>
     <h2><%= t('creatives.index.share_creative') %></h2>
-    <% if @shared_list.any? %>
-      <div style="margin-bottom:1em;">
-        <strong><%= t('creatives.index.shared_with') %>:</strong>
-        <ul style="padding-left:1.5em;">
-          <% @shared_list.each do |share| %>
-            <li>
-              <%= share.user&.email || t('creatives.index.unknown_user') %> - <%= t(".permission_#{share.permission}") %>
-              <%= button_to '×', creative_creative_share_path(@parent_creative || @creative, share), method: :delete, form: { data: { turbo_confirm: t('creatives.index.are_you_sure_delete_share') } }, class: 'delete-share-btn', style: 'margin-left:0.5em;padding:0 0.5em;' %>
-            </li>
-          <% end %>
-        </ul>
-      </div>
-    <% end %>
     <form id="share-creative-form" action="<%= creative_creative_shares_path(@parent_creative || @creative) %>" method="post" data-controller="share-invite">
       <%= csrf_meta_tags %>
       <div style="margin-bottom:1em;">
@@ -25,7 +12,6 @@
         <input type="email" name="user_email" id="share-user-email" required style="width:100%;" data-share-invite-target="email" data-action="blur->share-invite#check" />
       </div>
       <div style="margin-bottom:1em;">
-        <label for="share-permission"><%= t('creatives.index.permission') %></label>
         <select name="permission" id="share-permission" style="width:100%;">
           <option value="read"><%= t('creatives.index.permission_read') %></option>
           <option value="feedback"><%= t('creatives.index.permission_feedback') %></option>
@@ -34,6 +20,22 @@
       </div>
       <button type="submit" class="btn btn-primary" data-share-invite-target="submit" data-share="<%= t('creatives.index.share') %>" data-invite="<%= t('creatives.index.invite') %>"><%= t('creatives.index.share') %></button>
     </form>
+    <% if @shared_list.any? %>
+      <div style="margin-top:1em;">
+        <strong><%= t('creatives.index.shared_with') %>:</strong>
+        <ul class="share-grid">
+          <% @shared_list.each do |share| %>
+            <li>
+              <span><%= share.user&.email || t('creatives.index.unknown_user') %></span>
+              <span><%= t(".permission_#{share.permission}") %></span>
+              <span>
+                <%= button_to '×', creative_creative_share_path(@parent_creative || @creative, share), method: :delete, form: { data: { turbo_confirm: t('creatives.index.are_you_sure_delete_share') } }, class: 'delete-share-btn', style: 'padding:0 0.5em;' %>
+              </span>
+            </li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
   </div>
 </div>
 <script>

--- a/app/views/creatives/_share_button.html.erb
+++ b/app/views/creatives/_share_button.html.erb
@@ -27,7 +27,7 @@
           <% @shared_list.each do |share| %>
             <li>
               <span><%= share.user&.email || t('creatives.index.unknown_user') %></span>
-              <span><%= t(".permission_#{share.permission}") %></span>
+              <span><%= t("creatives.index.permission_#{share.permission}") %></span>
               <span>
                 <%= button_to '×', creative_creative_share_path(@parent_creative || @creative, share), method: :delete, form: { data: { turbo_confirm: t('creatives.index.are_you_sure_delete_share') } }, class: 'delete-share-btn', style: 'padding:0 0.5em;' %>
               </span>


### PR DESCRIPTION
## Summary
- rearrange share popup layout to place form above list
- style share list in a CSS grid
- remove permission label in popup

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: error sending request for url https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json)*

------
https://chatgpt.com/codex/tasks/task_e_684f971d7aec8326b2759e1755877c7b