### PR TITLE
Fix missing popup stylesheet in production

### DIFF
--- a/app/views/creatives/_share_button.html.erb
+++ b/app/views/creatives/_share_button.html.erb
@@ -1,4 +1,3 @@
-<%= stylesheet_link_tag 'popup', media: 'all' %>
 <button id="share-creative-btn" class="btn btn-primary"><%= t('creatives.index.share') %></button>
 <!-- Share Creative Modal -->
 <div id="share-creative-modal" style="display:none;position:fixed;top:0;left:0;width:100vw;height:100vh;z-index:1000;align-items:center;justify-content:center;">


### PR DESCRIPTION
## Summary
- remove redundant popup stylesheet link

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: error sending request for url https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json)*

------
https://chatgpt.com/codex/tasks/task_e_684f976b4fc88326b8d66a03c7846487