### PR TITLE
Limit share popup size and make list scrollable

### DIFF
--- a/app/assets/stylesheets/popup.css
+++ b/app/assets/stylesheets/popup.css
@@ -7,6 +7,17 @@
   position: relative;
 }
 
+/* Share popup specific tweaks */
+#share-creative-modal .popup-box {
+  max-height: 80vh;
+  overflow-y: auto;
+}
+
+#share-creative-modal .share-grid {
+  max-height: 40vh;
+  overflow-y: auto;
+}
+
 .share-grid {
   list-style: none;
   padding: 0;

--- a/spec/system/creative_share_spec.rb
+++ b/spec/system/creative_share_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Creative 공유 리스트', type: :system do
-  let!(:user) { User.create!(email: 'user1@example.com', password: 'password', :email_verified_at => Time.now) }
+  let!(:user) { User.create!(email: 'user1@example.com', password: 'password', email_verified_at: Time.now) }
   let!(:creative) { Creative.create!(description: '테스트', user: user) }
   let!(:share) { CreativeShare.create!(creative: creative, user: user, permission: 'read') }
 


### PR DESCRIPTION
## Summary
- keep share popup from getting taller than 80% of the screen
- allow the share list to scroll
- clean up hash syntax in creative_share_spec via rubocop

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: Selenium cannot download Chrome)*
- `bundle exec rails test`

------
https://chatgpt.com/codex/tasks/task_e_684fa3fd50e883269d672bdab9b86dfa