### PR TITLE
Hide comment controls during selection

### DIFF
--- a/app/javascript/select_mode.js
+++ b/app/javascript/select_mode.js
@@ -14,6 +14,9 @@ if (!window.isSelectModeInitialized) {
             Array.from(document.getElementsByClassName("creative-tags")).forEach(function(element) {
                 element.style.display = element.style.display === 'none' ? '' : 'none';
             });
+            Array.from(document.getElementsByClassName("comments-btn")).forEach(function(element) {
+                element.style.display = element.style.display === 'none' ? '' : 'none';
+            });
             const selectAllBtn = document.getElementById('select-all-creatives')
             if (selectAllBtn) {
                 selectAllBtn.style.display = selectAllBtn.style.display === 'none' ? '' : 'none';


### PR DESCRIPTION
## Summary
- hide comment button and count when toggle Select mode

## Testing
- `./bin/rubocop -a`
- `bundle exec rake` *(fails: Selenium couldn't download Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_684fba4234b483269ab969a9f0c093a6