### PR TITLE
Add AvatarComponent

### DIFF
--- a/app/assets/stylesheets/user_menu.css
+++ b/app/assets/stylesheets/user_menu.css
@@ -4,6 +4,15 @@
   border-radius: 50%;
 }
 
+.avatar {
+  border-radius: 50%;
+  vertical-align: middle;
+}
+
+.comment-avatar {
+  margin-right: 0.4em;
+}
+
 #user-menu {
   display: none;
   position: absolute;

--- a/app/components/avatar_component.html.erb
+++ b/app/components/avatar_component.html.erb
@@ -1,0 +1,7 @@
+<%= image_tag avatar_url,
+              alt: '',
+              width: size,
+              height: size,
+              class: classes,
+              title: email,
+              style: 'border-radius:50%;vertical-align:middle;' %>

--- a/app/components/avatar_component.rb
+++ b/app/components/avatar_component.rb
@@ -1,0 +1,21 @@
+class AvatarComponent < ViewComponent::Base
+  def initialize(user:, size: 32, classes: "")
+    @user = user
+    @size = size
+    @classes = classes
+  end
+
+  attr_reader :size, :classes
+
+  def avatar_url
+    if @user
+      helpers.user_avatar_url(@user, size: @size)
+    else
+      helpers.asset_path("default_avatar.svg")
+    end
+  end
+
+  def email
+    @user&.email || I18n.t("comments.anonymous")
+  end
+end

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,5 +1,6 @@
 <div class="comment-item" id="<%= dom_id(comment) %>">
   <div>
+    <%= render AvatarComponent.new(user: comment.user, size: 20, classes: 'avatar comment-avatar') %>
     <strong><%= comment.user&.email || t('comments.anonymous') %></strong>
     <span>· <%= t('datetime.ago', time: time_ago_in_words(comment.created_at)) %></span>
     <% if comment.user == Current.user %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -51,7 +51,7 @@
         </form>
         <form id="user_menu_button_to">
           <button id="user-menu-btn" type="button">
-            <%= image_tag user_avatar_url(Current.user), class: 'nav-avatar' %>
+            <%= render AvatarComponent.new(user: Current.user, size: 32, classes: 'nav-avatar avatar') %>
           </button>
         </form>
         <div id="user-menu" class="popup-box">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -6,7 +6,7 @@
 </p>
 
 <div>
-  <%= image_tag user_avatar_url(@user, size: 80), style: 'width:80px;height:80px;border-radius:40px;' %>
+  <%= render AvatarComponent.new(user: @user, size: 80, classes: 'avatar') %>
 </div>
 
 <%= form_with model: @user, url: user_path(@user), method: :patch, local: true, html: { multipart: true } do |f| %>


### PR DESCRIPTION
## Summary
- introduce a reusable `AvatarComponent`
- show the avatar in comments and the user profile page
- replace navigation avatar with `AvatarComponent`
- add CSS helpers for avatars

## Testing
- `./bin/rubocop -a`
- `bundle exec rake test`
- `bundle exec rspec` *(fails: unable to download chrome driver)*

------
https://chatgpt.com/codex/tasks/task_e_684fc54135bc8326a8bc697e7aae38bf