### PR TITLE
Add avatars to share popup

### DIFF
--- a/app/assets/stylesheets/popup.css
+++ b/app/assets/stylesheets/popup.css
@@ -25,10 +25,14 @@
 
 .share-grid li {
   display: grid;
-  grid-template-columns: 1fr auto auto;
+  grid-template-columns: auto 1fr auto auto;
   gap: 0.5em;
   align-items: center;
   margin-bottom: 0.5em;
+}
+
+.share-avatar {
+  margin-right: 0.4em;
 }
 
 .popup-close-btn {

--- a/app/views/creatives/_share_button.html.erb
+++ b/app/views/creatives/_share_button.html.erb
@@ -25,6 +25,9 @@
         <ul class="share-grid">
           <% @shared_list.each do |share| %>
             <li>
+              <span>
+                <%= render AvatarComponent.new(user: share.user, size: 20, classes: 'avatar share-avatar') %>
+              </span>
               <span><%= share.user&.email || t('creatives.index.unknown_user') %></span>
               <span><%= t("creatives.index.permission_#{share.permission}") %></span>
               <span>


### PR DESCRIPTION
## Summary
- show user avatars in the share popup, like comments do
- update styles for new avatar column

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: error sending request for url https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json)*

------
https://chatgpt.com/codex/tasks/task_e_684fd68bd09483269f25599659a13da6