### PR TITLE
Add user mention popup for comments

### DIFF
--- a/app/assets/stylesheets/mention_menu.css
+++ b/app/assets/stylesheets/mention_menu.css
@@ -1,0 +1,24 @@
+.mention-popup {
+  position: absolute;
+  z-index: 1000;
+  background: var(--color-section-bg);
+  border: 1px solid var(--color-border);
+  box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+  border-radius: 4px;
+  padding: 0.25em;
+}
+
+.mention-popup ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.mention-item {
+  padding: 0.3em 0.5em;
+  cursor: pointer;
+}
+
+.mention-item:hover {
+  background: var(--color-drag-over);
+}

--- a/app/components/user_mention_menu_component.html.erb
+++ b/app/components/user_mention_menu_component.html.erb
@@ -1,0 +1,3 @@
+<div id="<%= menu_id %>" class="mention-popup" style="display:none;">
+  <ul class="mention-results"></ul>
+</div>

--- a/app/components/user_mention_menu_component.rb
+++ b/app/components/user_mention_menu_component.rb
@@ -1,0 +1,6 @@
+class UserMentionMenuComponent < ViewComponent::Base
+  def initialize(menu_id: "mention-menu")
+    @menu_id = menu_id
+  end
+  attr_reader :menu_id
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -38,6 +38,12 @@ class UsersController < ApplicationController
     render json: { exists: user.present? }
   end
 
+  def search
+    term = params[:q].to_s.strip.downcase
+    users = User.where("email LIKE ?", "#{term}%").limit(5)
+    render json: users.map { |u| { email: u.email, avatar_url: view_context.user_avatar_url(u, size: 20) } }
+  end
+
   # List all users
   def index
     @users = User.all

--- a/app/javascript/mention_menu.js
+++ b/app/javascript/mention_menu.js
@@ -1,0 +1,74 @@
+if (!window.mentionMenuInitialized) {
+  window.mentionMenuInitialized = true;
+
+  document.addEventListener('turbo:load', function () {
+    var textarea = document.querySelector('#new-comment-form textarea');
+    var menu = document.getElementById('mention-menu');
+    if (!textarea || !menu) return;
+
+    var list = menu.querySelector('.mention-results');
+    var fetchTimer;
+
+    function position() {
+      var rect = textarea.getBoundingClientRect();
+      menu.style.top = rect.bottom + window.scrollY + 'px';
+      menu.style.left = rect.left + window.scrollX + 'px';
+    }
+
+    function hide() {
+      menu.style.display = 'none';
+    }
+
+    function insert(email) {
+      var pos = textarea.selectionStart;
+      var before = textarea.value.slice(0, pos).replace(/@[^@\s]*$/, '@' + email);
+      textarea.value = before + textarea.value.slice(pos);
+    }
+
+    function show(users) {
+      list.innerHTML = '';
+      users.forEach(function (u) {
+        var li = document.createElement('li');
+        li.className = 'mention-item';
+        li.innerHTML = '<img src="' + u.avatar_url + '" width="20" height="20" class="avatar" /> ' + u.email;
+        li.addEventListener('click', function () {
+          insert(u.email);
+          hide();
+          textarea.focus();
+        });
+        list.appendChild(li);
+      });
+      if (users.length > 0) {
+        position();
+        menu.style.display = 'block';
+      } else {
+        hide();
+      }
+    }
+
+    textarea.addEventListener('input', function () {
+      var pos = textarea.selectionStart;
+      var before = textarea.value.slice(0, pos);
+      var m = before.match(/@([\w.\-+@]*)$/);
+      if (m) {
+        var q = m[1];
+        if (q.length === 0) { hide(); return; }
+        clearTimeout(fetchTimer);
+        fetchTimer = setTimeout(function () {
+          fetch('/users/search?q=' + encodeURIComponent(q))
+            .then(function (r) { return r.ok ? r.json() : []; })
+            .then(show)
+            .catch(function () { });
+        }, 200);
+      } else {
+        hide();
+      }
+    });
+
+    document.addEventListener('click', function (e) {
+      if (!menu.contains(e.target) && e.target !== textarea) {
+        hide();
+      }
+    });
+  });
+}

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -4,7 +4,7 @@ class Comment < ApplicationRecord
 
   validates :content, presence: true
 
-  after_create_commit :broadcast_create, :notify_creative_owner
+  after_create_commit :broadcast_create, :notify_creative_owner, :notify_mentions
   after_update_commit :broadcast_update
   after_destroy_commit :broadcast_destroy
 
@@ -30,5 +30,19 @@ class Comment < ApplicationRecord
       message: I18n.t("inbox.comment_added", user: user.email, comment: content),
       link: Rails.application.routes.url_helpers.creative_comment_path(creative, self)
     )
+  end
+
+  def notify_mentions
+    return unless user
+    emails = content.scan(/@([\w.\-+]+@[a-zA-Z0-9\-.]+\.[a-zA-Z]{2,})/).flatten
+    emails.each do |email|
+      mentioned = User.find_by(email: email.downcase)
+      next unless mentioned && mentioned != user
+      InboxItem.create!(
+        owner: mentioned,
+        message: I18n.t("inbox.user_mentioned", user: user.email, comment: content),
+        link: Rails.application.routes.url_helpers.creative_comment_path(creative, self)
+      )
+    end
   end
 end

--- a/app/views/creatives/index.html.erb
+++ b/app/views/creatives/index.html.erb
@@ -32,6 +32,7 @@
 <%#= button_to t('.recalculate_progress'), recalculate_progress_creatives_path, method: :post, form: { data: { turbo_confirm: t('.recalculate_all_parent_progress') } } if authenticated? %>
 
 <%= stylesheet_link_tag 'comments_popup', media: 'all' %>
+<%= stylesheet_link_tag 'mention_menu', media: 'all' %>
 
 <div class="tags">
   <% labels = @parent_creative&.tags&.map { |tag| tag.label } %>
@@ -100,6 +101,7 @@
     <textarea name="comment[content]" rows="2" required></textarea>
     <button type="submit"><%= t('comments.add_comment') %></button>
   </form>
+  <%= render UserMentionMenuComponent.new(menu_id: 'mention-menu') %>
   <br/>
   <div id="comments-list"><%= t('app.loading') %></div>
 </div>
@@ -111,5 +113,6 @@
 <%= javascript_include_tag 'creatives_expansion', defer: true %>
 <%= javascript_include_tag 'select_mode', defer: true %>
 <%= javascript_include_tag 'comments', defer: true %>
+<%= javascript_include_tag 'mention_menu', defer: true %>
 <%= javascript_include_tag 'action_text_attachment_link', defer: true %>
 <%= javascript_include_tag 'export_to_markdown', defer: true %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -57,6 +57,7 @@ en:
     no_messages: "No messages"
     comment_added: "%{user} added \"%{comment}\"."
     creative_shared: "%{user} shared \"%{short_title}\"."
+    user_mentioned: "%{user} mentioned you: \"%{comment}\""
 
   inbox_mailer:
     daily_summary:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -28,6 +28,7 @@ ko:
     no_messages: "메세지가 없습니다"
     comment_added: "%{user} 가 \"%{comment}\" 를 추가했습니다."
     creative_shared: "%{user} 가 \"%{short_title}\" 을 공유했습니다."
+    user_mentioned: "%{user} 님이 당신을 언급했습니다: \"%{comment}\""
 
   inbox_mailer:
     daily_summary:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,7 @@ Rails.application.routes.draw do
     end
     collection do
       get :exists
+      get :search
     end
   end
 

--- a/spec/models/comment_mentions_spec.rb
+++ b/spec/models/comment_mentions_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+require 'ostruct'
+
+describe Comment, type: :model do
+  it 'creates inbox item for mentioned users' do
+    owner = User.create!(email: 'owner@example.com', password: 'pw')
+    commenter = User.create!(email: 'commenter@example.com', password: 'pw')
+    mentioned = User.create!(email: 'mentioned@example.com', password: 'pw')
+    creative = Creative.create!(user: owner, description: 'root')
+
+    comment = Comment.create!(creative: creative, user: commenter, content: "hi @#{mentioned.email}")
+
+    item = InboxItem.find_by(owner: mentioned)
+    expect(item).not_to be_nil
+    expect(item.message).to include(commenter.email)
+  end
+end


### PR DESCRIPTION
## Summary
- add `/users/search` endpoint
- create `UserMentionMenuComponent` for reusable mention popup
- support mentions in comments to notify users
- add JS/CSS for mention autocomplete
- render mention popup in comments area
- add tests for mention notifications

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec spec/models/comment_mentions_spec.rb`
- `bin/rails test`


------
https://chatgpt.com/codex/tasks/task_e_684fe7fa01b883269e7acd2560b516ff