### PR TITLE
Allow closing inbox panel with swipe gesture

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -206,6 +206,22 @@
             document.body.classList.remove('no-scroll');
           }
 
+          var startX = null;
+          if (panel) {
+            panel.addEventListener('touchstart', function(e) {
+              startX = e.touches[0].clientX;
+            });
+            panel.addEventListener('touchend', function(e) {
+              if (startX !== null) {
+                var diffX = e.changedTouches[0].clientX - startX;
+                if (diffX > 50) {
+                  closePanel();
+                }
+              }
+              startX = null;
+            });
+          }
+
           if (btn && panel) {
             btn.addEventListener('click', function() {
               if (panel.classList.contains('open')) {


### PR DESCRIPTION
## Summary
- support swipe gesture to close the inbox panel
- run rubocop and tests

## Testing
- `./bin/rubocop -a`
- `bin/rails test`


------
https://chatgpt.com/codex/tasks/task_e_685001bfe91c83268c6266f494b16e88