### PR TITLE
Implement lazy creative loading

### DIFF
--- a/app/components/creative_component.html.erb
+++ b/app/components/creative_component.html.erb
@@ -1,0 +1,25 @@
+<div class="creative-tree" id="creative-<%= creative.id %>" draggable="true" ondragstart="handleDragStart(event)" ondragover="handleDragOver(event)" ondrop="handleDrop(event)">
+  <div class="creative-row">
+    <div class="creative-row-start">
+      <div class="creative-row-actions">
+        <div class="before-link creative-toggle-btn" data-creative-id="<%= creative.id %>" data-load-url="<%= load_url %>">
+          <% if level <= 3 && children.any? %>
+            <%= toggle_button_symbol(expanded: expanded?) %>
+          <% end %>
+        </div>
+        <%= check_box_tag 'selected_creative_ids[]', creative.id, false, class: 'select-creative-checkbox', style: select_mode ? '' : 'display: none' %>
+        <%= link_to '+', new_creative_path(parent_id: creative.id), class: 'add-creative-btn', style: (' visibility: hidden;' unless creative.has_permission?(Current.user, :write)), title: t('creatives.help.add_child_creative') %>
+      </div>
+      <% heading_tag = (level <= 3 && (children.any? || creative.parent.nil?)) ? "h#{level}" : 'div' %>
+      <%= content_tag heading_tag.to_sym, class: "indent#{level}" do %>
+        <%= link_to creative.effective_description(params[:tags]&.first), creative, class: 'unstyled-link' %>
+      <% end %>
+    </div>
+    <%= render_creative_progress(creative, select_mode: select_mode) %>
+  </div>
+  <div id="creative-children-<%= creative.id %>" class="creative-children" data-expanded="<%= expanded? %>" data-loaded="<%= expanded? %>" data-load-url="<%= load_url %>" style="<%= expanded? ? '' : 'display:none;' %>">
+    <% if expanded? %>
+      <%= safe_join(children.map { |c| render CreativeComponent.new(creative: c, level: level + 1, expanded_state_map: expanded_state_map, select_mode: select_mode) }) %>
+    <% end %>
+  </div>
+</div>

--- a/app/components/creative_component.html.erb
+++ b/app/components/creative_component.html.erb
@@ -10,9 +10,21 @@
         <%= check_box_tag 'selected_creative_ids[]', creative.id, false, class: 'select-creative-checkbox', style: select_mode ? '' : 'display: none' %>
         <%= link_to '+', new_creative_path(parent_id: creative.id), class: 'add-creative-btn', style: (' visibility: hidden;' unless creative.has_permission?(Current.user, :write)), title: t('creatives.help.add_child_creative') %>
       </div>
-      <% heading_tag = (level <= 3 && (children.any? || creative.parent.nil?)) ? "h#{level}" : 'div' %>
-      <%= content_tag heading_tag.to_sym, class: "indent#{level}" do %>
-        <%= link_to creative.effective_description(params[:tags]&.first), creative, class: 'unstyled-link' %>
+      <% bullet_starting_level = 3 %>
+      <% desc = creative.effective_description(params[:tags]&.first) %>
+      <% if level <= bullet_starting_level %>
+        <% heading_tag = (children.any? || creative.parent.nil?) ? "h#{level}" : 'div' %>
+        <%= content_tag heading_tag.to_sym, class: "indent#{level}" do %>
+          <%= link_to desc, creative, class: 'unstyled-link' %>
+        <% end %>
+      <% else %>
+        <% margin = "margin-left: #{(level - bullet_starting_level) * 20}px;" %>
+        <div class="creative-tree-li" style="<%= margin %>">
+          <% unless desc.include?("<li>") %>
+            <div class="creative-tree-bullet"></div>
+          <% end %>
+          <%= link_to desc, creative, class: 'unstyled-link' %>
+        </div>
       <% end %>
     </div>
     <%= render_creative_progress(creative, select_mode: select_mode) %>

--- a/app/components/creative_component.rb
+++ b/app/components/creative_component.rb
@@ -1,0 +1,26 @@
+class CreativeComponent < ViewComponent::Base
+  include CreativesHelper
+
+  def initialize(creative:, level:, expanded_state_map:, select_mode: false)
+    @creative = creative
+    @level = level
+    @expanded_state_map = expanded_state_map
+    @select_mode = select_mode
+  end
+
+  private
+
+  attr_reader :creative, :level, :expanded_state_map, :select_mode
+
+  def children
+    creative.children_with_permission(Current.user)
+  end
+
+  def expanded?
+    expanded_from_expanded_state(creative.id, expanded_state_map)
+  end
+
+  def load_url
+    Rails.application.routes.url_helpers.children_creative_path(creative, level: level + 1)
+  end
+end

--- a/app/components/creative_component.rb
+++ b/app/components/creative_component.rb
@@ -13,7 +13,7 @@ class CreativeComponent < ViewComponent::Base
   attr_reader :creative, :level, :expanded_state_map, :select_mode
 
   def children
-    creative.children_with_permission(Current.user)
+    filter_creatives(creative.children_with_permission(Current.user))
   end
 
   def expanded?

--- a/app/controllers/creatives_controller.rb
+++ b/app/controllers/creatives_controller.rb
@@ -130,6 +130,16 @@ class CreativesController < ApplicationController
     end
   end
 
+  def children
+    @creative = Creative.find(params[:id])
+    @children = @creative.children_with_permission(Current.user)
+    @level = params[:level].to_i
+    @expanded_state_map = CreativeExpandedState.where(user_id: Current.user.id, creative_id: @creative.id).first&.expanded_status || {}
+    respond_to do |format|
+      format.turbo_stream
+    end
+  end
+
   def recalculate_progress
     Creative.recalculate_all_progress!
     redirect_to creatives_path, notice: t("creatives.notices.progress_recalculated")

--- a/app/controllers/creatives_controller.rb
+++ b/app/controllers/creatives_controller.rb
@@ -132,7 +132,7 @@ class CreativesController < ApplicationController
 
   def children
     @creative = Creative.find(params[:id])
-    @children = @creative.children_with_permission(Current.user)
+    @children = helpers.filter_creatives(@creative.children_with_permission(Current.user))
     @level = params[:level].to_i
     @expanded_state_map = CreativeExpandedState.where(user_id: Current.user.id, creative_id: @creative.id).first&.expanded_status || {}
     respond_to do |format|

--- a/app/javascript/creatives_expansion.js
+++ b/app/javascript/creatives_expansion.js
@@ -2,6 +2,15 @@ if (!window.creativesExpansionInitialized) {
     window.creativesExpansionInitialized = true;
 
     function expand(childrenDiv, btn) {
+        if (childrenDiv.dataset.loaded !== "true") {
+            const url = childrenDiv.dataset.loadUrl;
+            if (url) {
+                fetch(url, { headers: { Accept: 'text/vnd.turbo-stream.html' } })
+                    .then(r => r.text())
+                    .then(html => { Turbo.renderStreamMessage(html); });
+                childrenDiv.dataset.loaded = "true";
+            }
+        }
         childrenDiv.style.display = "";
         btn.textContent = "▼";
     }
@@ -22,9 +31,11 @@ if (!window.creativesExpansionInitialized) {
                 const childrenDiv = document.getElementById(`creative-children-${creativeId}`);
                 if (childrenDiv) {
                     const isHidden = childrenDiv.style.display === "none";
-                    childrenDiv.style.display = isHidden ? "" : "none";
-                    btn.textContent = isHidden ? "▼" : "▶";
-                    // Store expansion state in DB, scoped by currentCreativeId and node_id
+                    if (isHidden) {
+                        expand(childrenDiv, btn);
+                    } else {
+                        collapse(childrenDiv, btn);
+                    }
                     let url = `/creative_expanded_states/toggle`;
                     fetch(url, {
                       method: 'POST',

--- a/app/javascript/creatives_expansion.js
+++ b/app/javascript/creatives_expansion.js
@@ -7,7 +7,10 @@ if (!window.creativesExpansionInitialized) {
             if (url) {
                 fetch(url, { headers: { Accept: 'text/vnd.turbo-stream.html' } })
                     .then(r => r.text())
-                    .then(html => { Turbo.renderStreamMessage(html); });
+                    .then(html => {
+                        Turbo.renderStreamMessage(html);
+                        setupCreativeToggles();
+                    });
                 childrenDiv.dataset.loaded = "true";
             }
         }
@@ -26,6 +29,8 @@ if (!window.creativesExpansionInitialized) {
         let match = window.location.pathname.match(/\/creatives\/(\d+)/);
         const currentCreativeId = match ? match[1] : null;
         document.querySelectorAll(".creative-toggle-btn").forEach(function(btn) {
+            if (btn.dataset.initialized === "true") return;
+            btn.dataset.initialized = "true";
             btn.addEventListener("click", function(e) {
                 const creativeId = btn.dataset.creativeId;
                 const childrenDiv = document.getElementById(`creative-children-${creativeId}`);

--- a/app/views/creatives/children.turbo_stream.erb
+++ b/app/views/creatives/children.turbo_stream.erb
@@ -1,0 +1,5 @@
+<%= turbo_stream.replace "creative-children-#{@creative.id}" do %>
+  <div id="creative-children-<%= @creative.id %>" class="creative-children" data-expanded="true" data-loaded="true" data-load-url="<%= children_creative_path(@creative, level: @level + 1) %>">
+    <%= safe_join(@children.map { |child| render CreativeComponent.new(creative: child, level: @level, expanded_state_map: @expanded_state_map) }) %>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,7 @@ Rails.application.routes.draw do
     end
     member do
       post :share, to: "creatives#share", as: :share_creative
+      get :children
     end
   end
 


### PR DESCRIPTION
## Summary
- render each Creative with a new `CreativeComponent`
- fetch children with Turbo Streams via new `children` action
- update routes and expansion JS to load children on demand

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: error sending request for url https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json)*

------
https://chatgpt.com/codex/tasks/task_e_6850bb1cc86883269798eabf95980b95