### PR TITLE
Add progress filter toggle

### DIFF
--- a/app/javascript/progress_filter_toggle.js
+++ b/app/javascript/progress_filter_toggle.js
@@ -1,0 +1,25 @@
+if (!window.progressFilterToggleInitialized) {
+  window.progressFilterToggleInitialized = true;
+
+  document.addEventListener('turbo:load', function() {
+    var btn = document.getElementById('progress-filter-toggle');
+    if (!btn) return;
+
+    btn.addEventListener('click', function() {
+      var state = btn.dataset.state;
+      var states = ['complete', 'incomplete', 'all'];
+      var nextState = states[(states.indexOf(state) + 1) % states.length];
+      var url = new URL(window.location.href);
+      url.searchParams.delete('min_progress');
+      url.searchParams.delete('max_progress');
+      if (nextState === 'complete') {
+        url.searchParams.set('min_progress', '1');
+        url.searchParams.set('max_progress', '1');
+      } else if (nextState === 'incomplete') {
+        url.searchParams.set('min_progress', '0');
+        url.searchParams.set('max_progress', '0.99');
+      }
+      window.location.href = url.pathname + (url.searchParams.toString() ? '?' + url.searchParams.toString() : '');
+    });
+  });
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,6 +27,7 @@
     <%= javascript_include_tag 'dark_mode_toggle', defer: true %>
     <%= javascript_include_tag 'creatives', defer: true %>
     <%= javascript_include_tag 'popup_menu', defer: true %>
+    <%= javascript_include_tag 'progress_filter_toggle', defer: true %>
     <%= javascript_importmap_tags %>
   </head>
   <body>
@@ -42,8 +43,20 @@
         <form id="button_to">
           <button id="plans-menu-btn" type="button"><%= t('app.plans') %></button>
         </form>
-        <%= link_to t('app.filter_complete'), creatives_path(params.permit!.to_h.merge(min_progress: 1, max_progress: 1)) %>
-        <%= link_to t('app.filter_incomplete'), creatives_path(params.permit!.to_h.merge(min_progress: 0, max_progress: 0.99)) %>
+        <% progress_state = if params[:min_progress] == '1' && params[:max_progress] == '1'
+                              :complete
+                            elsif params[:min_progress] == '0' && params[:max_progress] == '0.99'
+                              :incomplete
+                            else
+                              :all
+                            end %>
+        <button id="progress-filter-toggle"
+                data-state="<%= progress_state %>"
+                data-complete-text="<%= t('app.filter_complete') %>"
+                data-incomplete-text="<%= t('app.filter_incomplete') %>"
+                data-all-text="<%= t('app.filter_all') %>">
+          <%= t("app.filter_#{progress_state}") %>
+        </button>
         <%= link_to t('app.filter_comments'), creatives_path(params.permit!.to_h.merge(comment: true)) %>
       <% end %>
       <% if Current.user %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,6 +42,7 @@ en:
     cancel_select: "Cancel Select"
     filter_complete: "Completed"
     filter_incomplete: "Incomplete"
+    filter_all: "All"
     loading: "Loading..."
     collapse_all: "Collapse All"
     expand_all: "Expand All"

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -13,6 +13,7 @@ ko:
     cancel_select: "선택 취소"
     filter_complete: "완료"
     filter_incomplete: "미완료"
+    filter_all: "전체"
     loading: "로딩 중..."
     collapse_all: "모두 접기"
     expand_all: "모두 펼치기"


### PR DESCRIPTION
## Summary
- introduce a single progress filter button cycling complete/incomplete/all
- support new filter state translations in English and Korean
- hook a new JS file to update query parameters when clicking

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: Selenium tries to download Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_685201771e848326b6232320aa20b093