### PR TITLE
Add creative actions popup menu

### DIFF
--- a/app/views/creatives/_add_button.html.erb
+++ b/app/views/creatives/_add_button.html.erb
@@ -1,0 +1,11 @@
+<%= render PopupMenuComponent.new(
+      button_content: t('creatives.index.new_creative'),
+      menu_id: 'add-creative-menu') do %>
+  <% if authenticated? && !params[:id] %>
+    <%= link_to t('creatives.index.new_creative'), new_creative_path, class: 'popup-menu-item' %>
+  <% end %>
+  <% if authenticated? && @parent_creative && @parent_creative.has_permission?(Current.user, :write) %>
+    <%= link_to t('creatives.index.new_sub_creative'), new_creative_path(parent_id: @parent_creative.id), class: 'popup-menu-item' %>
+    <%= link_to t('creatives.index.append_as_parent_creative'), append_as_parent_creative_creatives_path(parent_id: @parent_creative.id), class: 'popup-menu-item' %>
+  <% end %>
+<% end %>

--- a/app/views/creatives/index.html.erb
+++ b/app/views/creatives/index.html.erb
@@ -6,16 +6,13 @@
     <%= link_to t('.up'), creatives_path, class: "up-link" %>
   <% end %>
   
-  <%= link_to t('.new_creative'), new_creative_path if authenticated? and not params[:id] %>
+  <%= render 'add_button' if authenticated? && (!params[:id] || (@parent_creative && @parent_creative.has_permission?(Current.user, :write))) %>
   <% if (@parent_creative || @creative) && (@parent_creative || @creative).has_permission?(Current.user, :write) %>
     <%= render 'share_button' %>
   <% end %>
-  
-  <% if authenticated? && @parent_creative && @parent_creative.has_permission?(Current.user, :write) %>
-    <%= link_to t('.new_sub_creative'), @parent_creative&.id ? new_creative_path(parent_id: @parent_creative.id) : new_creative_path %>
-    <%= link_to t('.edit'), edit_creative_path(@parent_creative) %>
-    <%= link_to t('.append_as_parent_creative'), append_as_parent_creative_creatives_path(parent_id: @parent_creative&.id), class: 'btn btn-secondary' %>
 
+  <% if authenticated? && @parent_creative && @parent_creative.has_permission?(Current.user, :write) %>
+    <%= link_to t('.edit'), edit_creative_path(@parent_creative) %>
     <%= render 'delete_button' %>
 
   <% end %>


### PR DESCRIPTION
## Summary
- consolidate new creative buttons into a popup menu

## Testing
- `./bin/rubocop -a`
- `bundle exec rake test`


------
https://chatgpt.com/codex/tasks/task_e_68520287725883269154bfff3d32c099