### PR TITLE
Improve mobile creative actions

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -24,6 +24,22 @@ body {
     height: 100%;
 }
 
+/* Responsive visibility helpers */
+.desktop-only {
+    display: inline-block;
+}
+.mobile-only {
+    display: none;
+}
+@media (max-width: 768px) {
+    .desktop-only {
+        display: none;
+    }
+    .mobile-only {
+        display: inline-block;
+    }
+}
+
 nav {
     display: flex;
     justify-content: flex-end;

--- a/app/javascript/mobile_actions.js
+++ b/app/javascript/mobile_actions.js
@@ -1,0 +1,18 @@
+if (!window.mobileActionsInitialized) {
+  window.mobileActionsInitialized = true;
+
+  document.addEventListener('turbo:load', function () {
+    document.querySelectorAll('[data-click-target]').forEach(function (btn) {
+      btn.addEventListener('click', function () {
+        var target = document.getElementById(btn.dataset.clickTarget);
+        if (target) {
+          target.click();
+        }
+        var menu = btn.closest('.popup-menu');
+        if (menu) {
+          menu.style.display = 'none';
+        }
+      });
+    });
+  });
+}

--- a/app/views/creatives/_mobile_actions_menu.html.erb
+++ b/app/views/creatives/_mobile_actions_menu.html.erb
@@ -1,0 +1,13 @@
+<div class="mobile-only">
+  <%= render PopupMenuComponent.new(
+        button_content: '...',
+        menu_id: 'mobile-actions-menu',
+        align: :right
+      ) do %>
+    <% if (@parent_creative || @creative) && (@parent_creative || @creative).has_permission?(Current.user, :write) %>
+      <button type="button" class="popup-menu-item" data-click-target="share-creative-btn"><%= t('creatives.index.share') %></button>
+    <% end %>
+    <button type="button" class="popup-menu-item" data-click-target="import-markdown-btn"><%= t('creatives.index.import_markdown') %></button>
+    <button type="button" class="popup-menu-item" data-click-target="export-markdown-btn"><%= t('creatives.index.export_markdown') %></button>
+  <% end %>
+</div>

--- a/app/views/creatives/_share_button.html.erb
+++ b/app/views/creatives/_share_button.html.erb
@@ -1,4 +1,4 @@
-<button id="share-creative-btn" class="btn btn-primary"><%= t('creatives.index.share') %></button>
+<button id="share-creative-btn" class="btn btn-primary desktop-only"><%= t('creatives.index.share') %></button>
 <!-- Share Creative Modal -->
 <div id="share-creative-modal" style="display:none;position:fixed;top:0;left:0;width:100vw;height:100vh;z-index:1000;align-items:center;justify-content:center;">
   <div class="popup-box" style="min-width:320px;max-width:90vw;">

--- a/app/views/creatives/index.html.erb
+++ b/app/views/creatives/index.html.erb
@@ -20,8 +20,9 @@
   <input type="checkbox" id="select-all-creatives" style="display:none;margin-left:1em;vertical-align:middle;" />
   <button id="select-creative-btn" class="select-btn" data-select-text="<%= t('app.select') %>" data-cancel-text="<%= t('app.cancel_select') %>"><%= t('app.select') %></button>
   <button id="expand-all-btn" class="expand-btn" data-collapse-text="<%= t('app.collapse_all') %>" data-expand-text="<%= t('app.expand_all') %>" ><%= t('app.expand_all') %></button>
-  <button id="import-markdown-btn" class="import-btn"><%= t('.import_markdown') %></button>
-  <button id="export-markdown-btn" class="export-btn" data-parent-creative-id="<%= @parent_creative&.id %>" ><%= t('.export_markdown') %></button>
+  <button id="import-markdown-btn" class="import-btn desktop-only"><%= t('.import_markdown') %></button>
+  <button id="export-markdown-btn" class="export-btn desktop-only" data-parent-creative-id="<%= @parent_creative&.id %>" ><%= t('.export_markdown') %></button>
+  <%= render 'mobile_actions_menu' %>
 </div>
 <%= render 'import_upload_zone' %>
 
@@ -113,3 +114,4 @@
 <%= javascript_include_tag 'mention_menu', defer: true %>
 <%= javascript_include_tag 'action_text_attachment_link', defer: true %>
 <%= javascript_include_tag 'export_to_markdown', defer: true %>
+<%= javascript_include_tag 'mobile_actions', defer: true %>

--- a/config/locales/creatives.en.yml
+++ b/config/locales/creatives.en.yml
@@ -2,7 +2,7 @@ en:
   creatives:
     index:
       up: "Up"
-      new_creative: "New Creative"
+      new_creative: "Add"
       new_sub_creative: "New sub-creative"
       edit: "Edit"
       append_as_parent_creative: "New upper-creative"

--- a/config/locales/creatives.ko.yml
+++ b/config/locales/creatives.ko.yml
@@ -2,7 +2,7 @@ ko:
   creatives:
     index:
       up: "위로"
-      new_creative: "새 크리에이티브"
+      new_creative: "추가"
       new_sub_creative: "하위에 추가"
       edit: "수정"
       append_as_parent_creative: "상위에 추가"


### PR DESCRIPTION
## Summary
- add mobile-only popup menu for share/import/export actions
- hide individual action buttons on mobile
- change "New Creative" label to shorter "Add"
- include helper classes for mobile visibility
- support new mobile actions via JavaScript

## Testing
- `./bin/rubocop -a`

------
https://chatgpt.com/codex/tasks/task_e_68520bed8ba08326899c593e742ad180