### PR TITLE
Implement mobile popup menu

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -218,3 +218,21 @@ button {
     margin-left: 4px;
     display: none;
 }
+
+/* Responsive visibility helpers */
+.mobile-only {
+    display: none;
+}
+
+.desktop-only {
+    display: inline-block;
+}
+
+@media (max-width: 768px) {
+    .desktop-only {
+        display: none !important;
+    }
+    .mobile-only {
+        display: inline-block !important;
+    }
+}

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -24,6 +24,22 @@ body {
     height: 100%;
 }
 
+/* Responsive visibility helpers */
+.desktop-only {
+    display: inline-block;
+}
+.mobile-only {
+    display: none;
+}
+@media (max-width: 768px) {
+    .desktop-only {
+        display: none;
+    }
+    .mobile-only {
+        display: inline-block;
+    }
+}
+
 nav {
     display: flex;
     justify-content: flex-end;

--- a/app/javascript/mobile_actions.js
+++ b/app/javascript/mobile_actions.js
@@ -1,0 +1,18 @@
+if (!window.mobileActionsInitialized) {
+  window.mobileActionsInitialized = true;
+
+  document.addEventListener('turbo:load', function () {
+    document.querySelectorAll('[data-click-target]').forEach(function (btn) {
+      btn.addEventListener('click', function () {
+        var target = document.getElementById(btn.dataset.clickTarget);
+        if (target) {
+          target.click();
+        }
+        var menu = btn.closest('.popup-menu');
+        if (menu) {
+          menu.style.display = 'none';
+        }
+      });
+    });
+  });
+}

--- a/app/javascript/progress_filter_toggle.js
+++ b/app/javascript/progress_filter_toggle.js
@@ -2,16 +2,14 @@ if (!window.progressFilterToggleInitialized) {
   window.progressFilterToggleInitialized = true;
 
   document.addEventListener('turbo:load', function() {
-    var btn = document.getElementById('progress-filter-toggle');
-    if (!btn) return;
-
-    btn.addEventListener('click', function() {
-      var state = btn.dataset.state;
-      var states = ['complete', 'incomplete', 'all'];
-      var nextState = states[(states.indexOf(state) + 1) % states.length];
-      var url = new URL(window.location.href);
-      url.searchParams.delete('min_progress');
-      url.searchParams.delete('max_progress');
+    document.querySelectorAll('.progress-filter-toggle').forEach(function(btn) {
+      btn.addEventListener('click', function() {
+        var state = btn.dataset.state;
+        var states = ['complete', 'incomplete', 'all'];
+        var nextState = states[(states.indexOf(state) + 1) % states.length];
+        var url = new URL(window.location.href);
+        url.searchParams.delete('min_progress');
+        url.searchParams.delete('max_progress');
       if (nextState === 'complete') {
         url.searchParams.set('min_progress', '1');
         url.searchParams.set('max_progress', '1');
@@ -19,7 +17,8 @@ if (!window.progressFilterToggleInitialized) {
         url.searchParams.set('min_progress', '0');
         url.searchParams.set('max_progress', '0.99');
       }
-      window.location.href = url.pathname + (url.searchParams.toString() ? '?' + url.searchParams.toString() : '');
+        window.location.href = url.pathname + (url.searchParams.toString() ? '?' + url.searchParams.toString() : '');
+      });
     });
   });
 }

--- a/app/views/creatives/_mobile_actions_menu.html.erb
+++ b/app/views/creatives/_mobile_actions_menu.html.erb
@@ -1,0 +1,13 @@
+<div class="mobile-only">
+  <%= render PopupMenuComponent.new(
+        button_content: '...',
+        menu_id: 'mobile-actions-menu',
+        align: :right
+      ) do %>
+    <% if (@parent_creative || @creative) && (@parent_creative || @creative).has_permission?(Current.user, :write) %>
+      <button type="button" class="popup-menu-item" data-click-target="share-creative-btn"><%= t('creatives.index.share') %></button>
+    <% end %>
+    <button type="button" class="popup-menu-item" data-click-target="import-markdown-btn"><%= t('creatives.index.import_markdown') %></button>
+    <button type="button" class="popup-menu-item" data-click-target="export-markdown-btn"><%= t('creatives.index.export_markdown') %></button>
+  <% end %>
+</div>

--- a/app/views/creatives/_share_button.html.erb
+++ b/app/views/creatives/_share_button.html.erb
@@ -1,4 +1,4 @@
-<button id="share-creative-btn" class="btn btn-primary"><%= t('creatives.index.share') %></button>
+<button id="share-creative-btn" class="btn btn-primary desktop-only"><%= t('creatives.index.share') %></button>
 <!-- Share Creative Modal -->
 <div id="share-creative-modal" style="display:none;position:fixed;top:0;left:0;width:100vw;height:100vh;z-index:1000;align-items:center;justify-content:center;">
   <div class="popup-box" style="min-width:320px;max-width:90vw;">

--- a/app/views/creatives/index.html.erb
+++ b/app/views/creatives/index.html.erb
@@ -20,8 +20,9 @@
   <input type="checkbox" id="select-all-creatives" style="display:none;margin-left:1em;vertical-align:middle;" />
   <button id="select-creative-btn" class="select-btn" data-select-text="<%= t('app.select') %>" data-cancel-text="<%= t('app.cancel_select') %>"><%= t('app.select') %></button>
   <button id="expand-all-btn" class="expand-btn" data-collapse-text="<%= t('app.collapse_all') %>" data-expand-text="<%= t('app.expand_all') %>" ><%= t('app.expand_all') %></button>
-  <button id="import-markdown-btn" class="import-btn"><%= t('.import_markdown') %></button>
-  <button id="export-markdown-btn" class="export-btn" data-parent-creative-id="<%= @parent_creative&.id %>" ><%= t('.export_markdown') %></button>
+  <button id="import-markdown-btn" class="import-btn desktop-only"><%= t('.import_markdown') %></button>
+  <button id="export-markdown-btn" class="export-btn desktop-only" data-parent-creative-id="<%= @parent_creative&.id %>" ><%= t('.export_markdown') %></button>
+  <%= render 'mobile_actions_menu' %>
 </div>
 <%= render 'import_upload_zone' %>
 
@@ -113,3 +114,4 @@
 <%= javascript_include_tag 'mention_menu', defer: true %>
 <%= javascript_include_tag 'action_text_attachment_link', defer: true %>
 <%= javascript_include_tag 'export_to_markdown', defer: true %>
+<%= javascript_include_tag 'mobile_actions', defer: true %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -38,31 +38,76 @@
       <form action="<%= creatives_path %>" method="get" style="display:inline; margin-right:1em;">
         <input type="text" id="search" name="search" value="<%= params[:search] %>" placeholder="<%= t('app.search_placeholder') %>" />
       </form>
-      <%= link_to t('app.home'), root_path %>
-      <% if authenticated? %>
-        <form id="button_to">
-          <button id="plans-menu-btn" type="button"><%= t('app.plans') %></button>
-        </form>
-        <% progress_state = if params[:min_progress] == '1' && params[:max_progress] == '1'
-                              :complete
-                            elsif params[:min_progress] == '0' && params[:max_progress] == '0.99'
-                              :incomplete
-                            else
-                              :all
-                            end %>
-        <button id="progress-filter-toggle"
-                data-state="<%= progress_state %>"
-                data-complete-text="<%= t('app.filter_complete') %>"
-                data-incomplete-text="<%= t('app.filter_incomplete') %>"
-                data-all-text="<%= t('app.filter_all') %>">
-          <%= t("app.filter_#{progress_state}") %>
-        </button>
-        <%= link_to t('app.filter_comments'), creatives_path(params.permit!.to_h.merge(comment: true)) %>
+
+      <div class="desktop-only">
+        <%= link_to t('app.home'), root_path %>
+        <% if authenticated? %>
+          <form id="button_to">
+            <button id="plans-menu-btn" class="plans-menu-btn" type="button"><%= t('app.plans') %></button>
+          </form>
+          <% progress_state = if params[:min_progress] == '1' && params[:max_progress] == '1'
+                                :complete
+                              elsif params[:min_progress] == '0' && params[:max_progress] == '0.99'
+                                :incomplete
+                              else
+                                :all
+                              end %>
+          <button id="progress-filter-toggle" class="progress-filter-toggle"
+                  data-state="<%= progress_state %>"
+                  data-complete-text="<%= t('app.filter_complete') %>"
+                  data-incomplete-text="<%= t('app.filter_incomplete') %>"
+                  data-all-text="<%= t('app.filter_all') %>">
+            <%= t("app.filter_#{progress_state}") %>
+          </button>
+          <%= link_to t('app.filter_comments'), creatives_path(params.permit!.to_h.merge(comment: true)) %>
+        <% end %>
+        <% if Current.user %>
+          <form id="inbox_button_to">
+            <button id="inbox-menu-btn" class="inbox-menu-btn" type="button"><%= t('app.inbox') %><%= render Inbox::BadgeComponent.new(user: Current.user) %></button>
+          </form>
+        <% end %>
+        <%= link_to t('app.sign_in'), new_session_path unless authenticated? %>
+        <a href="#" id="creative-guide-link" class="creative-guide-link" style="margin-left: 1em; font-size: 1.2em; text-decoration: none;">?</a>
+      </div>
+
+      <%= render PopupMenuComponent.new(
+            button_content: '...',
+            button_classes: 'mobile-only',
+            menu_id: 'mobile-more-menu'
+          ) do %>
+        <div><%= link_to t('app.home'), root_path %></div>
+        <% if authenticated? %>
+          <div>
+            <button class="plans-menu-btn" type="button"><%= t('app.plans') %></button>
+          </div>
+          <% progress_state = if params[:min_progress] == '1' && params[:max_progress] == '1'
+                                :complete
+                              elsif params[:min_progress] == '0' && params[:max_progress] == '0.99'
+                                :incomplete
+                              else
+                                :all
+                              end %>
+          <div>
+            <button class="progress-filter-toggle"
+                    data-state="<%= progress_state %>"
+                    data-complete-text="<%= t('app.filter_complete') %>"
+                    data-incomplete-text="<%= t('app.filter_incomplete') %>"
+                    data-all-text="<%= t('app.filter_all') %>">
+              <%= t("app.filter_#{progress_state}") %>
+            </button>
+          </div>
+          <div><%= link_to t('app.filter_comments'), creatives_path(params.permit!.to_h.merge(comment: true)) %></div>
+        <% end %>
+        <% if Current.user %>
+          <div>
+            <button class="inbox-menu-btn" type="button"><%= t('app.inbox') %><%= render Inbox::BadgeComponent.new(user: Current.user) %></button>
+          </div>
+        <% end %>
+        <div><%= link_to t('app.sign_in'), new_session_path unless authenticated? %></div>
+        <div><a href="#" class="creative-guide-link" style="margin-left: 1em; font-size: 1.2em; text-decoration: none;">?</a></div>
       <% end %>
+
       <% if Current.user %>
-        <form id="inbox_button_to">
-          <button id="inbox-menu-btn" type="button"><%= t('app.inbox') %><%= render Inbox::BadgeComponent.new(user: Current.user) %></button>
-        </form>
         <%= render PopupMenuComponent.new(
           button_content: render(AvatarComponent.new(user: Current.user, size: 32, classes: 'nav-avatar avatar')),
           menu_id: 'user-menu',
@@ -72,8 +117,6 @@
           <div><%= button_to t('app.sign_out'), session_path, method: :delete %></div>
         <% end %>
       <% end %>
-      <%= link_to t('app.sign_in'), new_session_path unless authenticated? %>
-      <a href="#" id="creative-guide-link" style="margin-left: 1em; font-size: 1.2em; text-decoration: none;">?</a>
     </nav>
 
     <div id="plans-list-area" style="display:none;">
@@ -120,10 +163,12 @@
       if (!window.isPlansMenuInitialized) {
         window.isPlansMenuInitialized = true;
         document.addEventListener('turbo:load', function() {
-          var btn = document.getElementById('plans-menu-btn');
+          var btns = document.querySelectorAll('.plans-menu-btn');
           var area = document.getElementById('plans-list-area');
-          btn.addEventListener('click', function() {
-            area.style.display = (area.style.display === 'none') ? 'block' : 'none';
+          btns.forEach(function(btn) {
+            btn.addEventListener('click', function() {
+              area.style.display = (area.style.display === 'none') ? 'block' : 'none';
+            });
           });
         });
       }
@@ -133,7 +178,7 @@
       if (!window.isInboxMenuInitialized) {
         window.isInboxMenuInitialized = true;
         document.addEventListener('turbo:load', function() {
-          var btn = document.getElementById('inbox-menu-btn');
+          var btns = document.querySelectorAll('.inbox-menu-btn');
           var panel = document.getElementById('inbox-panel');
           var list = document.getElementById('inbox-list');
           var closeBtn = document.getElementById('close-inbox');
@@ -235,24 +280,26 @@
             });
           }
 
-          if (btn && panel) {
-            btn.addEventListener('click', function() {
-              if (panel.classList.contains('open')) {
-                closePanel();
-              } else {
-                openPanel();
-              }
-            });
-          }
+          btns.forEach(function(btn) {
+            if (panel) {
+              btn.addEventListener('click', function() {
+                if (panel.classList.contains('open')) {
+                  closePanel();
+                } else {
+                  openPanel();
+                }
+              });
+            }
+          });
           if (closeBtn) { closeBtn.addEventListener('click', closePanel); }
           if (toggle) { toggle.addEventListener('change', loadInbox); }
 
           updateInboxBadge();
 
-          if (panel && btn && localStorage.getItem('inboxOpen') === '1') {
+          if (panel && btns.length > 0 && localStorage.getItem('inboxOpen') === '1') {
             panel.classList.add('open');
             loadInbox();
-          } else if (!btn) {
+          } else if (btns.length === 0) {
             localStorage.removeItem('inboxOpen');
           }
         });
@@ -265,19 +312,21 @@
 
     <script>
       document.addEventListener('turbo:load', function() {
-        var link = document.getElementById('creative-guide-link');
+        var links = document.querySelectorAll('.creative-guide-link');
         var popover = document.getElementById('creative-guide-popover');
         var close = document.getElementById('close-creative-guide');
-        if (link && popover && close) {
-          link.addEventListener('click', function(e) {
-            e.preventDefault();
-            popover.style.display = 'block';
+        if (links.length && popover && close) {
+          links.forEach(function(link) {
+            link.addEventListener('click', function(e) {
+              e.preventDefault();
+              popover.style.display = 'block';
+            });
           });
           close.addEventListener('click', function() {
             popover.style.display = 'none';
           });
           document.addEventListener('click', function(e) {
-            if (!popover.contains(e.target) && e.target !== link) {
+            if (!popover.contains(e.target) && !Array.from(links).includes(e.target)) {
               popover.style.display = 'none';
             }
           });

--- a/config/locales/creatives.en.yml
+++ b/config/locales/creatives.en.yml
@@ -2,7 +2,7 @@ en:
   creatives:
     index:
       up: "Up"
-      new_creative: "New Creative"
+      new_creative: "Add"
       new_sub_creative: "New sub-creative"
       edit: "Edit"
       append_as_parent_creative: "New upper-creative"

--- a/config/locales/creatives.ko.yml
+++ b/config/locales/creatives.ko.yml
@@ -2,7 +2,7 @@ ko:
   creatives:
     index:
       up: "위로"
-      new_creative: "새 크리에이티브"
+      new_creative: "추가"
       new_sub_creative: "하위에 추가"
       edit: "수정"
       append_as_parent_creative: "상위에 추가"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -49,6 +49,7 @@ en:
     save: "Save"
     filter_comments: "Comments"
     inbox: "Inbox"
+    more: "More"
 
   inbox:
     mark_read: "Read"

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -20,6 +20,7 @@ ko:
     save: "저장"
     filter_comments: "코멘트"
     inbox: "인박스"
+    more: "더보기"
 
   inbox:
     mark_read: "읽음"


### PR DESCRIPTION
## Summary
- hide desktop nav elements on mobile screens
- show '...' popup menu on mobile with nav links
- support multiple triggers for nav JS actions
- add responsive helpers and Korean/English translations for more menu

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: error sending request for chrome driver)*

------
https://chatgpt.com/codex/tasks/task_e_68520baca3308326b62d939484bee01e