### PR TITLE
Implement mobile popup menu

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -24,22 +24,6 @@ body {
     height: 100%;
 }
 
-/* Responsive visibility helpers */
-.desktop-only {
-    display: inline-block;
-}
-.mobile-only {
-    display: none;
-}
-@media (max-width: 768px) {
-    .desktop-only {
-        display: none;
-    }
-    .mobile-only {
-        display: inline-block;
-    }
-}
-
 nav {
     display: flex;
     justify-content: flex-end;

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -225,7 +225,9 @@ button {
 }
 
 .desktop-only {
-    display: inline-block;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
 }
 
 @media (max-width: 768px) {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -73,7 +73,8 @@
       <%= render PopupMenuComponent.new(
             button_content: '...',
             button_classes: 'mobile-only',
-            menu_id: 'mobile-more-menu'
+            menu_id: 'mobile-more-menu',
+            align: :right
           ) do %>
         <div><%= link_to t('app.home'), root_path %></div>
         <% if authenticated? %>


### PR DESCRIPTION
## Summary
- hide desktop nav elements on mobile screens
- show '...' popup menu on mobile with nav links
- support multiple triggers for nav JS actions
- add responsive helpers and Korean/English translations for more menu
- fix desktop nav layout
- align mobile popup with screen edge

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: error sending request for chrome driver)*

------
https://chatgpt.com/codex/tasks/task_e_68520baca3308326b62d939484bee01e