### PR TITLE
Move delete to mobile popup

### DIFF
--- a/app/components/popup_menu_component.html.erb
+++ b/app/components/popup_menu_component.html.erb
@@ -1,5 +1,5 @@
 <div class="popup-menu-wrapper">
-  <button type="button" class="popup-menu-toggle <%= button_classes %>" data-menu-id="<%= menu_id %>">
+  <button type="button" class="popup-menu-toggle <%= button_classes %>" data-menu-id="<%= menu_id %>" <%= "id=\"#{button_id}\"" if button_id.present? %>>
     <%= raw button_content %>
   </button>
   <div id="<%= menu_id %>" class="popup-menu <%= 'popup-menu-right' if align.to_sym == :right %>">

--- a/app/components/popup_menu_component.rb
+++ b/app/components/popup_menu_component.rb
@@ -1,10 +1,11 @@
 class PopupMenuComponent < ViewComponent::Base
-  def initialize(button_content:, button_classes: "", menu_id: nil, align: :left)
+  def initialize(button_content:, button_classes: "", menu_id: nil, align: :left, button_id: nil)
     @button_content = button_content
     @button_classes = button_classes
     @menu_id = menu_id || "popup-menu-#{SecureRandom.hex(4)}"
     @align = align
+    @button_id = button_id
   end
 
-  attr_reader :button_content, :button_classes, :menu_id, :align
+  attr_reader :button_content, :button_classes, :menu_id, :align, :button_id
 end

--- a/app/views/creatives/_delete_button.html.erb
+++ b/app/views/creatives/_delete_button.html.erb
@@ -1,7 +1,8 @@
 <%= render PopupMenuComponent.new(
       button_content: t('creatives.index.delete'),
-      button_classes: 'danger-link',
-      menu_id: 'delete-options-popup') do %>
+      button_classes: 'danger-link desktop-only',
+      menu_id: 'delete-options-popup',
+      button_id: 'delete-options-btn') do %>
   <%= button_to t('creatives.index.delete_only_this'), @parent_creative, method: :delete,
       form: { data: { turbo_confirm: t('creatives.index.are_you_sure_delete_only_this') } },
       params: {}, class: 'danger-link popup-menu-item' %>

--- a/app/views/creatives/_mobile_actions_menu.html.erb
+++ b/app/views/creatives/_mobile_actions_menu.html.erb
@@ -6,6 +6,7 @@
       ) do %>
     <% if (@parent_creative || @creative) && (@parent_creative || @creative).has_permission?(Current.user, :write) %>
       <button type="button" class="popup-menu-item" data-click-target="share-creative-btn"><%= t('creatives.index.share') %></button>
+      <button type="button" class="popup-menu-item" data-click-target="delete-options-btn"><%= t('creatives.index.delete') %></button>
     <% end %>
     <button type="button" class="popup-menu-item" data-click-target="import-markdown-btn"><%= t('creatives.index.import_markdown') %></button>
     <button type="button" class="popup-menu-item" data-click-target="export-markdown-btn"><%= t('creatives.index.export_markdown') %></button>


### PR DESCRIPTION
## Summary
- allow PopupMenuComponent to set an id on the toggle button
- hide delete button on mobile and trigger it from the '...' menu

## Testing
- `./bin/rubocop -a`
- `bundle exec rake` *(fails: error sending request for url https://googlechromelabs.github.io/...)*

------
https://chatgpt.com/codex/tasks/task_e_6852400d621c8326bb65d77f95638101