### PR TITLE
Support link conversion in Markdown import/export

### DIFF
--- a/app/controllers/creatives_controller.rb
+++ b/app/controllers/creatives_controller.rb
@@ -221,7 +221,7 @@ class CreativesController < ApplicationController
       line = lines[i]
       if line =~ /^(#+)\s+(.*)$/ # Heading
         level = $1.length # 1 for h1, 2 for h2, etc.
-        desc = $2.strip
+        desc = helpers.markdown_links_to_html($2.strip)
         while stack.any? && stack.last[0] >= level
           stack.pop
         end
@@ -232,7 +232,7 @@ class CreativesController < ApplicationController
         i += 1
       elsif line =~ /^([ \t]*)([-*+])\s+(.*)$/ # Bullet list
         indent = $1.length
-        desc = $3.strip
+        desc = helpers.markdown_links_to_html($3.strip)
         bullet_level = 10 + indent / 2
         while stack.any? && stack.last[0] >= bullet_level
           stack.pop
@@ -243,7 +243,7 @@ class CreativesController < ApplicationController
         stack << [ bullet_level, c ]
         i += 1
       elsif !line.strip.empty? # Paragraph/content under a heading
-        desc = line.strip
+        desc = helpers.markdown_links_to_html(line.strip)
         new_parent = stack.any? ? stack.last[1] : root_creative
         c = Creative.create(user: Current.user, parent: new_parent, description: desc)
         created << c

--- a/test/helpers/creatives_helper_test.rb
+++ b/test/helpers/creatives_helper_test.rb
@@ -1,0 +1,15 @@
+require "test_helper"
+
+class CreativesHelperTest < ActionView::TestCase
+  test "markdown_links_to_html converts markdown link to HTML" do
+    input = "Check [link](https://example.com)"
+    expected = "Check <a href=\"https://example.com\">link</a>"
+    assert_equal expected, markdown_links_to_html(input)
+  end
+
+  test "html_links_to_markdown converts HTML link to markdown" do
+    input = "See <a href=\"https://example.com\">example</a> for details"
+    expected = "See [example](https://example.com) for details"
+    assert_equal expected, html_links_to_markdown(input)
+  end
+end


### PR DESCRIPTION
## Summary
- convert HTML links to Markdown on export
- convert Markdown links to HTML on import

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec --format doc -fd` *(fails: Selenium can't download Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_6854af4bab708326a7d7db450c4f1f07