### PR TITLE
Refactor progress filter component

### DIFF
--- a/app/assets/stylesheets/popup.css
+++ b/app/assets/stylesheets/popup.css
@@ -83,8 +83,8 @@
         min-width: 100%;
         text-align: left;
     }
-    #mobile-more-menu .progress-filter-group button {
+    #mobile-more-menu .progress-filter-group {
         display: block;
-        min-width: 33%;
+        min-width: 100%;
     }
 }

--- a/app/components/progress_filter_component.html.erb
+++ b/app/components/progress_filter_component.html.erb
@@ -1,5 +1,5 @@
 <div class="progress-filter-group">
-  <button class="progress-filter-btn<%= ' active' if progress_state == :complete %>" data-filter="complete"><%= t('app.filter_complete') %></button>
-  <button class="progress-filter-btn<%= ' active' if progress_state == :incomplete %>" data-filter="incomplete"><%= t('app.filter_incomplete') %></button>
-  <button class="progress-filter-btn<%= ' active' if progress_state == :all %>" data-filter="all"><%= t('app.filter_all') %></button>
+  <% states.each do |state| %>
+    <button class="progress-filter-btn<%= ' active' if current_state.to_s == state[:value].to_s %>" data-filter="<%= state[:value] %>"><%= state[:name] %></button>
+  <% end %>
 </div>

--- a/app/components/progress_filter_component.rb
+++ b/app/components/progress_filter_component.rb
@@ -1,7 +1,8 @@
 class ProgressFilterComponent < ViewComponent::Base
-  def initialize(progress_state: :all)
-    @progress_state = progress_state.to_sym
+  def initialize(current_state:, states: [])
+    @current_state = current_state&.to_sym
+    @states = states
   end
 
-  attr_reader :progress_state
+  attr_reader :current_state, :states
 end

--- a/app/javascript/progress_filter_toggle.js
+++ b/app/javascript/progress_filter_toggle.js
@@ -6,15 +6,25 @@ if (!window.progressFilterToggleInitialized) {
       btn.addEventListener('click', function() {
         var filter = btn.dataset.filter;
         var url = new URL(window.location.href);
-        url.searchParams.delete('min_progress');
-        url.searchParams.delete('max_progress');
-        if (filter === 'complete') {
-          url.searchParams.set('min_progress', '1');
-          url.searchParams.set('max_progress', '1');
-        } else if (filter === 'incomplete') {
-          url.searchParams.set('min_progress', '0');
-          url.searchParams.set('max_progress', '0.99');
+
+        if (filter === 'comment') {
+          if (url.searchParams.get('comment') === 'true') {
+            url.searchParams.delete('comment');
+          } else {
+            url.searchParams.set('comment', 'true');
+          }
+        } else {
+          url.searchParams.delete('min_progress');
+          url.searchParams.delete('max_progress');
+          if (filter === 'complete') {
+            url.searchParams.set('min_progress', '1');
+            url.searchParams.set('max_progress', '1');
+          } else if (filter === 'incomplete') {
+            url.searchParams.set('min_progress', '0');
+            url.searchParams.set('max_progress', '0.99');
+          }
         }
+
         window.location.href =
           url.pathname + (url.searchParams.toString() ? '?' + url.searchParams.toString() : '');
       });

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -52,11 +52,21 @@
                               else
                                 :all
                               end %>
-          <%= render ProgressFilterComponent.new(progress_state: progress_state) %>
-          <%= button_to t('app.filter_comments'),
-                        creatives_path,
-                        method: :get,
-                        params: params.permit(:min_progress, :max_progress, :tags, :search, :comment, :select_mode).to_h.except(:controller, :action).merge(comment: true) %>
+          <% comment_state = params[:comment] == 'true' ? :comment : nil %>
+          <%= render ProgressFilterComponent.new(
+                current_state: progress_state,
+                states: [
+                  { name: t('app.filter_complete'), value: :complete },
+                  { name: t('app.filter_incomplete'), value: :incomplete },
+                  { name: t('app.filter_all'), value: :all }
+                ]
+              ) %>
+          <%= render ProgressFilterComponent.new(
+                current_state: comment_state,
+                states: [
+                  { name: t('app.filter_comments'), value: :comment }
+                ]
+              ) %>
         <% end %>
         <% if Current.user %>
           <form id="inbox_button_to">
@@ -85,11 +95,21 @@
                               else
                                 :all
                               end %>
-          <%= render ProgressFilterComponent.new(progress_state: progress_state) %>
-          <div><%= button_to t('app.filter_comments'),
-                             creatives_path,
-                             method: :get,
-                             params: params.permit(:min_progress, :max_progress, :tags, :search, :comment, :select_mode).to_h.except(:controller, :action).merge(comment: true) %></div>
+          <% comment_state = params[:comment] == 'true' ? :comment : nil %>
+          <%= render ProgressFilterComponent.new(
+                current_state: progress_state,
+                states: [
+                  { name: t('app.filter_complete'), value: :complete },
+                  { name: t('app.filter_incomplete'), value: :incomplete },
+                  { name: t('app.filter_all'), value: :all }
+                ]
+              ) %>
+          <%= render ProgressFilterComponent.new(
+                current_state: comment_state,
+                states: [
+                  { name: t('app.filter_comments'), value: :comment }
+                ]
+              ) %>
         <% end %>
         <% if Current.user %>
           <div>


### PR DESCRIPTION
## Summary
- make `ProgressFilterComponent` generic by accepting state lists
- handle comment toggle in `progress_filter_toggle.js`
- use the new generic component for progress and comment filters

## Testing
- `./bin/rubocop -a`
- `bundle exec rake test`
- `bundle exec rspec` *(fails: error sending request for url https://googlechromelabs.github.io/...)*

------
https://chatgpt.com/codex/tasks/task_e_6854d4c787888326b3aa753996a6ce04