### PR TITLE
Show notice when new comments are added

### DIFF
--- a/app/components/creative_component.html.erb
+++ b/app/components/creative_component.html.erb
@@ -1,4 +1,5 @@
 <%= content_tag :div, class: 'creative-tree', data: { id: creative.id, parent_id: creative.parent_id }, **drag_attrs do %>
+  <%= helpers.turbo_stream_from [creative, :comments_notice] %>
   <div class="creative-row">
     <div class="creative-row-start">
       <div class="creative-row-actions">

--- a/app/helpers/creatives_helper.rb
+++ b/app/helpers/creatives_helper.rb
@@ -37,7 +37,7 @@ module CreativesHelper
       creative.progress
     end
 
-    row = content_tag(:div, class: "creative-row-end") do
+    content_tag(:div, class: "creative-row-end") do
       comment_part = if creative.has_permission?(Current.user, :feedback)
         origin = creative.effective_origin
         comments_count = origin.comments.size
@@ -71,8 +71,6 @@ module CreativesHelper
       end
       render_progress_value(progress_value) + comment_part + "<br />".html_safe + (creative.tags ? render_creative_tags(creative) : "".html_safe)
     end
-
-    safe_join([ row, turbo_stream_from([ creative, :comments_notice ]) ])
   end
 
   def render_progress_value(value)

--- a/app/helpers/creatives_helper.rb
+++ b/app/helpers/creatives_helper.rb
@@ -37,7 +37,7 @@ module CreativesHelper
       creative.progress
     end
 
-    content_tag(:div, class: "creative-row-end") do
+    row = content_tag(:div, class: "creative-row-end") do
       comment_part = if creative.has_permission?(Current.user, :feedback)
         origin = creative.effective_origin
         comments_count = origin.comments.size
@@ -71,6 +71,8 @@ module CreativesHelper
       end
       render_progress_value(progress_value) + comment_part + "<br />".html_safe + (creative.tags ? render_creative_tags(creative) : "".html_safe)
     end
+
+    safe_join([ row, turbo_stream_from([ creative, :comments_notice ]) ])
   end
 
   def render_progress_value(value)

--- a/app/javascript/notice.js
+++ b/app/javascript/notice.js
@@ -5,11 +5,17 @@ if (!window.noticeInitialized) {
     if (!noticeBox) return;
     var timer = null;
     var clear = function() { noticeBox.innerHTML = ''; };
-    noticeBox.addEventListener('DOMNodeInserted', function() {
+    noticeBox.addEventListener('DOMNodeInserted', function(e) {
       if (timer) clearTimeout(timer);
-      if (noticeBox.innerHTML.trim() !== '') {
-        timer = setTimeout(clear, 5000);
+      if (noticeBox.innerHTML.trim() === '') return;
+      var popup = document.getElementById('comments-popup');
+      var inserted = e.target;
+      var creativeId = inserted.dataset ? inserted.dataset.creativeId : null;
+      if (popup && popup.style.display === 'block' && popup.dataset.creativeId === creativeId) {
+        clear();
+        return;
       }
+      timer = setTimeout(clear, 5000);
     });
   });
 }

--- a/app/javascript/notice.js
+++ b/app/javascript/notice.js
@@ -1,0 +1,15 @@
+if (!window.noticeInitialized) {
+  window.noticeInitialized = true;
+  document.addEventListener('turbo:load', function() {
+    var noticeBox = document.getElementById('notice-box');
+    if (!noticeBox) return;
+    var timer = null;
+    var clear = function() { noticeBox.innerHTML = ''; };
+    noticeBox.addEventListener('DOMNodeInserted', function() {
+      if (timer) clearTimeout(timer);
+      if (noticeBox.innerHTML.trim() !== '') {
+        timer = setTimeout(clear, 5000);
+      }
+    });
+  });
+}

--- a/app/views/comments/_new_comment_notice.html.erb
+++ b/app/views/comments/_new_comment_notice.html.erb
@@ -1,2 +1,4 @@
-<%= t('comments.new_comment_notice_html',
-       link: link_to(t('comments.go_to_comment'), creative_comment_path(creative, comment))) %>
+<div data-creative-id="<%= creative.id %>">
+  <%= t('comments.new_comment_notice_html',
+         link: link_to(t('comments.go_to_comment'), creative_comment_path(creative, comment))) %>
+</div>

--- a/app/views/comments/_new_comment_notice.html.erb
+++ b/app/views/comments/_new_comment_notice.html.erb
@@ -1,0 +1,2 @@
+<%= t('comments.new_comment_notice_html',
+       link: link_to(t('comments.go_to_comment'), creative_comment_path(creative, comment))) %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -39,11 +39,12 @@
     <%= javascript_include_tag 'progress_filter_toggle', defer: true %>
     <%= javascript_include_tag 'plans_timeline', defer: true %>
     <%= javascript_include_tag 'actioncable', defer: true %>
+    <%= javascript_include_tag 'notice', defer: true %>
     <%= javascript_importmap_tags %>
   </head>
   <body class="<%= 'dark-mode' if Current.user&.theme == 'dark' %><%= ' light-mode' if Current.user&.theme == 'light' %>">
     <%= turbo_stream_from ["inbox", Current.user] if Current.user %>
-    <div class="notice"><%= notice %></div>
+    <div class="notice" id="notice-box"><%= notice %></div>
 
     <nav>
       <form action="<%= creatives_path %>" method="get">

--- a/config/locales/comments.en.yml
+++ b/config/locales/comments.en.yml
@@ -11,3 +11,6 @@ en:
     delete_button: "Delete"
     not_owner: "Only the comment owner can modify this."
     no_permission: "You do not have permission to comment."
+
+    new_comment_notice_html: "A new comment has been added. %{link}"
+    go_to_comment: "Go to comment"

--- a/config/locales/comments.ko.yml
+++ b/config/locales/comments.ko.yml
@@ -11,3 +11,6 @@ ko:
     delete_button: "삭제"
     not_owner: "댓글 소유자만 수정할 수 있습니다."
     no_permission: "댓글을 추가할 권한이 없습니다."
+
+    new_comment_notice_html: "새로운 댓글이 추가되었습니다. %{link}"
+    go_to_comment: "댓글로 이동"


### PR DESCRIPTION
## Summary
- broadcast notice when a new comment is created
- subscribe creatives to new comment notice stream
- show notice box in layout and auto-hide after a few seconds
- add translations and helper partial
- include JS for notice handling

## Testing
- `./bin/rubocop -a`
- `bundle exec rails test`


------
https://chatgpt.com/codex/tasks/task_e_6854eb0cbed483268a70de14ddd314d8