### PR TITLE
Propagate tag filters when adding creatives

### DIFF
--- a/app/components/creative_component.html.erb
+++ b/app/components/creative_component.html.erb
@@ -6,7 +6,7 @@
           <%= level <= 3 && filtered_children.any? ? helpers.toggle_button_symbol(expanded: expanded) : '' %>
         </div>
         <%= check_box_tag('selected_creative_ids[]', creative.id, false, class: 'select-creative-checkbox', style: select_mode ? '' : 'display: none') %>
-        <%= link_to('+', new_creative_path(parent_id: creative.id),
+        <%= link_to('+', new_creative_path(parent_id: creative.id, tags: params[:tags]),
                     class: 'add-creative-btn',
                     style: (' visibility: hidden;' unless creative.has_permission?(Current.user, :write)),
                     title: t('creatives.help.add_child_creative')) %>

--- a/app/controllers/creatives_controller.rb
+++ b/app/controllers/creatives_controller.rb
@@ -93,6 +93,11 @@ class CreativesController < ApplicationController
             CreativeShare.create!(creative: @creative, user: parent_share.user, permission: parent_share.permission)
           end
         end
+        if params[:tags].present?
+          Array(params[:tags]).each do |tag_id|
+            @creative.tags.create(label_id: tag_id)
+          end
+        end
         format.html { redirect_to @creative }
         format.json { render json: { id: @creative.id } }
       else
@@ -259,10 +264,10 @@ class CreativesController < ApplicationController
     end
   end
 
-  def append_as_parent
-    @parent_creative = Creative.find_by(id: params[:parent_id]).parent
-    redirect_to new_creative_path(parent_id: @parent_creative&.id, child_id: params[:parent_id])
-  end
+    def append_as_parent
+      @parent_creative = Creative.find_by(id: params[:parent_id]).parent
+      redirect_to new_creative_path(parent_id: @parent_creative&.id, child_id: params[:parent_id], tags: params[:tags])
+    end
 
   def set_plan
     plan_id = params[:plan_id]

--- a/app/views/creatives/_add_button.html.erb
+++ b/app/views/creatives/_add_button.html.erb
@@ -1,13 +1,13 @@
 <%
   menu_items = []
   if authenticated? && !params[:id]
-    new_creative_link = link_to(t('creatives.index.new_creative'), new_creative_path)
-    menu_items << link_to(t('creatives.index.new_creative'), new_creative_path, class: 'popup-menu-item')
+    new_creative_link = link_to(t('creatives.index.new_creative'), new_creative_path(tags: params[:tags]))
+    menu_items << link_to(t('creatives.index.new_creative'), new_creative_path(tags: params[:tags]), class: 'popup-menu-item')
   end
 
   if authenticated? && @parent_creative && @parent_creative.has_permission?(Current.user, :write)
-    menu_items << link_to(t('creatives.index.new_sub_creative'), new_creative_path(parent_id: @parent_creative.id), class: 'popup-menu-item')
-    menu_items << link_to(t('creatives.index.append_as_parent_creative'), append_as_parent_creative_creatives_path(parent_id: @parent_creative.id), class: 'popup-menu-item')
+    menu_items << link_to(t('creatives.index.new_sub_creative'), new_creative_path(parent_id: @parent_creative.id, tags: params[:tags]), class: 'popup-menu-item')
+    menu_items << link_to(t('creatives.index.append_as_parent_creative'), append_as_parent_creative_creatives_path(parent_id: @parent_creative.id, tags: params[:tags]), class: 'popup-menu-item')
   end
 %>
 

--- a/app/views/creatives/_form.html.erb
+++ b/app/views/creatives/_form.html.erb
@@ -22,6 +22,12 @@
     <%= hidden_field_tag :child_id, params[:child_id] %>
   <% end %>
 
+  <% if params[:tags].present? %>
+    <% Array(params[:tags]).each do |tag_id| %>
+      <%= hidden_field_tag 'tags[]', tag_id %>
+    <% end %>
+  <% end %>
+
   <div>
     <%= form.label :description, t('.description'), style: "display: block" %>
     <%= form.rich_text_area :description %>

--- a/app/views/creatives/show.html.erb
+++ b/app/views/creatives/show.html.erb
@@ -20,7 +20,7 @@
 
     <div class="creative-actions-row">
       <% if authenticated? %>
-        <%= link_to "New sub-creative", @creative&.id ? new_creative_path(parent_id: @creative.id) : new_creative_path %>
+        <%= link_to "New sub-creative", @creative&.id ? new_creative_path(parent_id: @creative.id, tags: params[:tags]) : new_creative_path(tags: params[:tags]) %>
         <%= link_to "Edit", edit_creative_path(@creative), data: { action: "inline-editor#showForm" } %>
         <%= button_to "Delete", @creative, method: :delete, data: { turbo_confirm: "Are you sure?" } %>
       <% end %>


### PR DESCRIPTION
## Summary
- propagate `tags` query param through add buttons
- include hidden tag fields in the creative form
- add tags to newly-created creatives when the page is filtered by tags

## Testing
- `./bin/rubocop -a`
- `bundle exec rake test`


------
https://chatgpt.com/codex/tasks/task_e_685500eb2b1c8326887fabe27db7b533