### PR TITLE
Switch comments to chat layout

### DIFF
--- a/app/assets/stylesheets/comments_popup.css
+++ b/app/assets/stylesheets/comments_popup.css
@@ -6,12 +6,15 @@
   z-index: 1000;
   width: 350px;
   max-height: 400px;
-  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
   transition: all 0.2s;
 }
 
 #comments-list {
   margin-top: 0.5em;
+  overflow-y: auto;
+  flex-grow: 1;
 }
 
 #new-comment-form textarea {
@@ -73,6 +76,8 @@
         border-radius: 10px 10px 0 0;
         transform: translateY(100%);
         transition: transform 0.3s;
+        display: flex;
+        flex-direction: column;
     }
 
     #comments-popup.open {

--- a/app/assets/stylesheets/comments_popup.css
+++ b/app/assets/stylesheets/comments_popup.css
@@ -5,7 +5,7 @@
   /* top: 10em; */
   z-index: 1000;
   width: 350px;
-  max-height: 400px;
+  height: 400px;
   display: flex;
   flex-direction: column;
   transition: all 0.2s;
@@ -71,7 +71,7 @@
         width: auto;
         min-width: 0;
         max-width: none;
-        max-height: 70vh;
+        height: 70vh;
         padding: 0.5em;
         border-radius: 10px 10px 0 0;
         transform: translateY(100%);

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -3,7 +3,7 @@ class CommentsController < ApplicationController
   before_action :set_comment, only: [ :destroy, :show, :update ]
 
   def index
-    @comments = @creative.comments.order(created_at: :desc)
+    @comments = @creative.comments.order(created_at: :asc)
     render partial: "comments/list", locals: { comments: @comments, creative: @creative }
   end
 

--- a/app/javascript/comments.js
+++ b/app/javascript/comments.js
@@ -84,6 +84,7 @@ if (!window.commentsInitialized) {
                     .then(r => r.text()).then(html => {
                         list.innerHTML = html;
                         updatePosition();
+                        list.scrollTop = list.scrollHeight;
                         if (highlightId) {
                             var el = document.getElementById('comment_' + highlightId);
                             if (el) {
@@ -114,9 +115,9 @@ if (!window.commentsInitialized) {
                     body: formData
                 })
                     .then(r => r.ok ? r.text() : r.json().then(j => { throw new Error(j.errors.join(', ')); }))
-                    .then(html => {
+                    .then(() => {
                         resetForm();
-                        fetchComments(editingId);
+                        setTimeout(function() { list.scrollTop = list.scrollHeight; }, 100);
                     })
                     .catch(e => { alert(e.message); });
             };
@@ -133,7 +134,7 @@ if (!window.commentsInitialized) {
                         headers: { 'X-CSRF-Token': document.querySelector('meta[name=csrf-token]').content }
                     }).then(function(r) {
                         if (r.ok) {
-                            fetchComments();
+                            setTimeout(function() { list.scrollTop = list.scrollHeight; }, 100);
                         } else {
                             // TODO: handle error
                         }

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -13,7 +13,7 @@ class Comment < ApplicationRecord
   private
 
   def broadcast_create
-    broadcast_prepend_later_to([ creative, :comments ], target: "comments_list")
+    broadcast_append_later_to([ creative, :comments ], target: "comments_list")
   end
 
   def broadcast_update

--- a/app/views/creatives/index.html.erb
+++ b/app/views/creatives/index.html.erb
@@ -102,13 +102,12 @@
      data-update-comment-text="<%= t('comments.update_comment') %>">
   <button id="close-comments-btn" class="popup-close-btn">&times;</button>
   <h3 style="margin-top:0;"><%= t('comments.comments') %></h3>
+  <div id="comments-list"><%= t('app.loading') %></div>
   <form id="new-comment-form" style="display:none;">
     <textarea name="comment[content]" rows="2" required></textarea>
     <button type="submit"><%= t('comments.add_comment') %></button>
   </form>
   <%= render UserMentionMenuComponent.new(menu_id: 'mention-menu') %>
-  <br/>
-  <div id="comments-list"><%= t('app.loading') %></div>
 </div>
 
 <%= render 'set_plan_modal' %>


### PR DESCRIPTION
## Summary
- move comment form below list for chat feel
- sort comments chronologically
- append new comments via Turbo streams
- adjust comment popup layout and behaviour to match chat UX

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: error sending request for URL https://googlechromelabs.github.io)*

------
https://chatgpt.com/codex/tasks/task_e_68550229b6948326a092ea962c92d329