### PR TITLE
Display comment count using badge component

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -217,7 +217,8 @@ button {
     position: relative;
 }
 
-#inbox-badge {
+#inbox-badge,
+.badge {
     background: red;
     color: white;
     border-radius: 10px;

--- a/app/components/inbox/badge_component.html.erb
+++ b/app/components/inbox/badge_component.html.erb
@@ -1,2 +1,2 @@
 
-<%= render 'inbox/badge_component/count', count: count %>
+<%= render 'inbox/badge_component/count', count: count, badge_id: badge_id %>

--- a/app/components/inbox/badge_component.rb
+++ b/app/components/inbox/badge_component.rb
@@ -1,11 +1,15 @@
 module Inbox
   class BadgeComponent < ViewComponent::Base
-    def initialize(user:)
+    attr_reader :badge_id
+
+    def initialize(user: nil, count: nil, badge_id: "inbox-badge")
       @user = user
+      @count = count
+      @badge_id = badge_id
     end
 
     def count
-      InboxItem.where(owner: @user, state: "new").count
+      @count || InboxItem.where(owner: @user, state: "new").count
     end
   end
 end

--- a/app/helpers/creatives_helper.rb
+++ b/app/helpers/creatives_helper.rb
@@ -37,11 +37,11 @@ module CreativesHelper
     content_tag(:div, class: "creative-row-end") do
       comment_part = if creative.has_permission?(Current.user, :feedback)
         comments_count = creative.effective_origin.comments.size
-        btn_text = comments_count.zero? ? "\u{1F4AC}" : "(#{comments_count})"
         classes = [ "comments-btn" ]
         classes << "no-comments" if comments_count.zero?
+        badge = render(Inbox::BadgeComponent.new(count: comments_count, badge_id: "comment-badge-#{creative.id}"))
         button_tag(
-          btn_text,
+          "\u{1F4AC}".html_safe + badge,
           name: "show-comments-btn",
           data: { creative_id: creative.id, can_comment: true },
           class: classes.join(" ")

--- a/app/views/inbox/badge_component/_count.html.erb
+++ b/app/views/inbox/badge_component/_count.html.erb
@@ -1,2 +1,2 @@
 <% display = count.positive? ? 'inline-block' : 'none' %>
-<span id="inbox-badge" style="display:<%= display %>"><%= count if count.positive? %></span>
+<span id="<%= badge_id %>" class="badge" style="display:<%= display %>"><%= count if count.positive? %></span>


### PR DESCRIPTION
## Summary
- reuse Inbox badge component with customizable ID
- add generic `.badge` CSS class
- show comment count with badge next to each creative

## Testing
- `./bin/rubocop -a`
- `bundle exec rake spec` *(fails: error sending request for chromedriver)*

------
https://chatgpt.com/codex/tasks/task_e_68552294f24c8326b66e04a0fd6d5474