### PR TITLE
Implement per-user comment read tracking

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -11,6 +11,7 @@ class CommentsController < ApplicationController
     scope = @creative.comments.order(created_at: :desc)
     @comments = scope.offset((page - 1) * per_page).limit(per_page).to_a
 
+    CommentRead.where(comment: @comments, user: Current.user).update_all(read: true)
     if page <= 1
       render partial: "comments/list", locals: { comments: @comments.reverse, creative: @creative }
     else

--- a/app/helpers/creatives_helper.rb
+++ b/app/helpers/creatives_helper.rb
@@ -39,11 +39,11 @@ module CreativesHelper
 
     content_tag(:div, class: "creative-row-end") do
       comment_part = if creative.has_permission?(Current.user, :feedback)
-        comments_count = creative.effective_origin.comments.size
+        unread_count = creative.effective_origin.comments.joins(:comment_reads).where(comment_reads: { user_id: Current.user.id, read: false }).count
         classes = [ "comments-btn" ]
-        classes << "no-comments" if comments_count.zero?
-        comment_label = comments_count.zero? ? "\u{1F4AC}" : ""
-        badge = render(Inbox::BadgeComponent.new(count: comments_count, badge_id: "comment-badge-#{creative.id}"))
+        classes << "no-comments" if unread_count.zero?
+        comment_label = unread_count.zero? ? "\u{1F4AC}" : ""
+        badge = render(Inbox::BadgeComponent.new(count: unread_count, badge_id: "comment-badge-#{creative.id}"))
         button_tag(
           comment_label.html_safe + badge,
           name: "show-comments-btn",

--- a/app/models/comment_read.rb
+++ b/app/models/comment_read.rb
@@ -1,0 +1,8 @@
+class CommentRead < ApplicationRecord
+  belongs_to :comment
+  belongs_to :user
+
+  scope :unread, -> { where(read: false) }
+
+  validates :comment_id, uniqueness: { scope: :user_id }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ApplicationRecord
   has_secure_password
   has_many :sessions, dependent: :destroy
   has_many :creatives
+  has_many :comment_reads, dependent: :destroy
   has_many :labels, foreign_key: :owner_id
 
   has_one_attached :avatar

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -3,6 +3,9 @@
     <%= render AvatarComponent.new(user: comment.user, size: 20, classes: 'avatar comment-avatar') %>
     <strong><%= comment.user&.email || t('comments.anonymous') %></strong>
     <span>· <%= t('datetime.ago', time: time_ago_in_words(comment.created_at)) %></span>
+    <% if comment.unread_by?(Current.user) %>
+      <span class="comment-unread"><%= t('comments.unread') %></span>
+    <% end %>
     <% if comment.user == Current.user %>
       <button class="edit-comment-btn" data-comment-id="<%= comment.id %>" data-comment-content="<%= comment.content %>" title="<%= t('comments.update_comment') %>">
         <%= t('comments.edit_button') %>

--- a/config/locales/comments.en.yml
+++ b/config/locales/comments.en.yml
@@ -11,3 +11,4 @@ en:
     delete_button: "Delete"
     not_owner: "Only the comment owner can modify this."
     no_permission: "You do not have permission to comment."
+    unread: "new"

--- a/config/locales/comments.ko.yml
+++ b/config/locales/comments.ko.yml
@@ -11,3 +11,4 @@ ko:
     delete_button: "삭제"
     not_owner: "댓글 소유자만 수정할 수 있습니다."
     no_permission: "댓글을 추가할 권한이 없습니다."
+    unread: "새"

--- a/db/migrate/20250618000000_create_comment_reads.rb
+++ b/db/migrate/20250618000000_create_comment_reads.rb
@@ -1,0 +1,11 @@
+class CreateCommentReads < ActiveRecord::Migration[8.0]
+  def change
+    create_table :comment_reads do |t|
+      t.references :comment, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+      t.boolean :read, null: false, default: false
+      t.timestamps
+    end
+    add_index :comment_reads, [ :comment_id, :user_id ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -49,6 +49,17 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_20_004558) do
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
+  create_table "comment_reads", force: :cascade do |t|
+    t.integer "comment_id", null: false
+    t.integer "user_id", null: false
+    t.boolean "read", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["comment_id", "user_id"], name: "index_comment_reads_on_comment_id_and_user_id", unique: true
+    t.index ["comment_id"], name: "index_comment_reads_on_comment_id"
+    t.index ["user_id"], name: "index_comment_reads_on_user_id"
+  end
+
   create_table "comments", force: :cascade do |t|
     t.integer "creative_id", null: false
     t.integer "user_id"
@@ -332,6 +343,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_20_004558) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "comment_reads", "comments"
+  add_foreign_key "comment_reads", "users"
   add_foreign_key "comments", "creatives"
   add_foreign_key "comments", "users"
   add_foreign_key "creative_expanded_states", "creatives"

--- a/test/models/comment_read_test.rb
+++ b/test/models/comment_read_test.rb
@@ -1,0 +1,17 @@
+require "test_helper"
+
+class CommentReadTest < ActiveSupport::TestCase
+  test "mark comment as read" do
+    creative = creatives(:tshirt)
+    commenter = users(:two)
+    Comment.skip_callback(:commit, :after, :initialize_comment_reads, on: :create)
+    comment = Comment.create!(creative: creative, user: commenter, content: "hi")
+    comment.send(:initialize_comment_reads)
+    Comment.set_callback(:commit, :after, :initialize_comment_reads, on: :create)
+    owner = creative.user
+    record = CommentRead.find_by(comment: comment, user: owner)
+    assert_not record.read
+    CommentRead.where(comment: comment, user: owner).update_all(read: true)
+    assert CommentRead.find_by(comment: comment, user: owner).read
+  end
+end


### PR DESCRIPTION
## Summary
- track per-user read status for comments
- show unread badge on creative comment button
- mark comments read when listing them
- display unread label on each comment
- test comment read behaviour

## Testing
- `./bin/rubocop -a`
- `bin/rails test`

------
https://chatgpt.com/codex/tasks/task_e_68557b65d1c483269665774f95d6300a