### PR TITLE
Enhance markdown import/export

### DIFF
--- a/app/helpers/creatives_helper.rb
+++ b/app/helpers/creatives_helper.rb
@@ -166,11 +166,10 @@ module CreativesHelper
     md
   end
 
-  def markdown_links_to_html(text)
+  def markdown_links_to_html(text, image_refs = {})
     return "" if text.nil?
     html = text.dup
 
-    image_refs = {}
     html.gsub!(/^\s*\[([^\]]+)\]:\s*<\s*(data:image\/[^>]+)\s*>\s*$/) do
       image_refs[$1] = $2.strip
       ""

--- a/app/helpers/creatives_helper.rb
+++ b/app/helpers/creatives_helper.rb
@@ -192,7 +192,7 @@ module CreativesHelper
     html.gsub!(/(?<!\\)(\*\*|__)(.+?)\1/) do
       "<strong>#{$2}</strong>"
     end
-    html.gsub!(/\\([\\*_\[\]()!#~\-])/, '\\1')
+    html.gsub!(/\\([\\*_\[\]()!#~+\-])/, '\\1')
     html.gsub!(/\\\\/, "\\")
     html.strip!
     html
@@ -237,7 +237,7 @@ module CreativesHelper
       placeholders[token] = "**#{$2.strip}**"
       token
     end
-    markdown.gsub!(/([\\*\[\]()!#~-])/) { "\\#{$1}" }
+    markdown.gsub!(/([\\*\[\]()!#~+\-])/) { "\\#{$1}" }
     placeholders.each { |k, v| markdown.gsub!(k, v) }
     markdown
   end

--- a/app/helpers/creatives_helper.rb
+++ b/app/helpers/creatives_helper.rb
@@ -169,6 +169,21 @@ module CreativesHelper
   def markdown_links_to_html(text)
     return "" if text.nil?
     html = text.dup
+
+    image_refs = {}
+    html.gsub!(/^\s*\[([^\]]+)\]:\s*<\s*(data:image\/[^>]+)\s*>\s*$/) do
+      image_refs[$1] = $2.strip
+      ""
+    end
+
+    html.gsub!(/(?<!\\)!\[([^\]]*)\]\[([^\]]+)\]/) do
+      if (data_url = image_refs[$2])
+        convert_data_image_to_attachment(data_url, $1)
+      else
+        "![#{$1}][#{$2}]"
+      end
+    end
+
     html.gsub!(/(?<!\\)!\[([^\]]*)\]\((data:image\/[^)]+)\)/) do
       convert_data_image_to_attachment($2, $1)
     end
@@ -178,8 +193,10 @@ module CreativesHelper
     html.gsub!(/(?<!\\)(\*\*|__)(.+?)\1/) do
       "<strong>#{$2}</strong>"
     end
-    html.gsub!(/\\([\\*_\[\]()!#~\-])/, '\1')
-    html.gsub(/\\\\/, "\\")
+    html.gsub!(/\\([\\*_\[\]()!#~\-])/, '\\1')
+    html.gsub!(/\\\\/, "\\")
+    html.strip!
+    html
   end
 
   def html_links_to_markdown(text)

--- a/app/helpers/creatives_helper.rb
+++ b/app/helpers/creatives_helper.rb
@@ -175,7 +175,7 @@ module CreativesHelper
     html.gsub!(/(?<!\\)(\*\*|__)(.+?)\1/) do
       "<strong>#{$2}</strong>"
     end
-    html.gsub!(/\\([\\*_\[\]()!])/, '\1')
+    html.gsub!(/\\([\\*_\[\]()!#~\-])/, '\1')
     html.gsub(/\\\\/, "\\")
   end
 
@@ -205,7 +205,7 @@ module CreativesHelper
       placeholders[token] = "**#{$2.strip}**"
       token
     end
-    markdown.gsub!(/([\\*\[\]()!])/) { "\\#{$1}" }
+    markdown.gsub!(/([\\*\[\]()!#~-])/) { "\\#{$1}" }
     placeholders.each { |k, v| markdown.gsub!(k, v) }
     markdown
   end

--- a/test/helpers/creatives_helper_test.rb
+++ b/test/helpers/creatives_helper_test.rb
@@ -30,11 +30,11 @@ class CreativesHelperTest < ActionView::TestCase
   end
 
   test "escaped characters round trip" do
-    md = "A \\*star\\* example"
+    md = "A \\*star\\* \\-dash\\- \\#hash\\# \\~tilde\\~ example"
     html = markdown_links_to_html(md)
-    assert_equal "A *star* example", html
+    assert_equal "A *star* -dash- #hash# ~tilde~ example", html
     back = html_links_to_markdown(html)
-    assert_equal "A \\*star\\* example", back
+    assert_equal md, back
   end
 
   test "base64 image link converts" do

--- a/test/helpers/creatives_helper_test.rb
+++ b/test/helpers/creatives_helper_test.rb
@@ -30,9 +30,9 @@ class CreativesHelperTest < ActionView::TestCase
   end
 
   test "escaped characters round trip" do
-    md = "A \\*star\\* \\-dash\\- \\#hash\\# \\~tilde\\~ example"
+    md = "A \\*star\\* \\-dash\\- \\#hash\\# \\~tilde\\~ \\+plus\\+ example"
     html = markdown_links_to_html(md)
-    assert_equal "A *star* -dash- #hash# ~tilde~ example", html
+    assert_equal "A *star* -dash- #hash# ~tilde~ +plus+ example", html
     back = html_links_to_markdown(html)
     assert_equal md, back
   end

--- a/test/helpers/creatives_helper_test.rb
+++ b/test/helpers/creatives_helper_test.rb
@@ -20,4 +20,28 @@ class CreativesHelperTest < ActionView::TestCase
     markdown = render_creative_tree_markdown([ creative ], 5)
     assert_equal "* Item\n", markdown
   end
+
+  test "bold markdown converts to html and back" do
+    md = "This is **bold** text"
+    html = markdown_links_to_html(md)
+    assert_equal "This is <strong>bold</strong> text", html
+    back = html_links_to_markdown(html)
+    assert_equal "This is **bold** text", back
+  end
+
+  test "escaped characters round trip" do
+    md = "A \\*star\\* example"
+    html = markdown_links_to_html(md)
+    assert_equal "A *star* example", html
+    back = html_links_to_markdown(html)
+    assert_equal "A \\*star\\* example", back
+  end
+
+  test "base64 image link converts" do
+    md = "Image: ![alt](data:image/png;base64,AAA)"
+    html = markdown_links_to_html(md)
+    assert_equal "Image: <img src=\"data:image/png;base64,AAA\" alt=\"alt\" />", html
+    back = html_links_to_markdown(html)
+    assert_equal "Image: ![alt](data:image/png;base64,AAA)", back
+  end
 end

--- a/test/helpers/creatives_helper_test.rb
+++ b/test/helpers/creatives_helper_test.rb
@@ -44,4 +44,12 @@ class CreativesHelperTest < ActionView::TestCase
     back = html_links_to_markdown(html)
     assert_equal md, back
   end
+
+  test "reference style base64 image converts" do
+    md = "Look ![][img1]\n\n[img1]: <data:image/png;base64,aGk=>"
+    html = markdown_links_to_html(md)
+    assert_match(/<action-text-attachment[^>]+content-type=\"image\/png\"[^>]*>/, html)
+    back = html_links_to_markdown(html)
+    assert_equal "Look ![](data:image/png;base64,aGk=)", back
+  end
 end

--- a/test/helpers/creatives_helper_test.rb
+++ b/test/helpers/creatives_helper_test.rb
@@ -38,10 +38,10 @@ class CreativesHelperTest < ActionView::TestCase
   end
 
   test "base64 image link converts" do
-    md = "Image: ![alt](data:image/png;base64,AAA)"
+    md = "Image: ![alt](data:image/png;base64,aGk=)"
     html = markdown_links_to_html(md)
-    assert_equal "Image: <img src=\"data:image/png;base64,AAA\" alt=\"alt\" />", html
+    assert_match(/<action-text-attachment[^>]+content-type=\"image\/png\"[^>]+caption=\"alt\"[^>]*>/, html)
     back = html_links_to_markdown(html)
-    assert_equal "Image: ![alt](data:image/png;base64,AAA)", back
+    assert_equal md, back
   end
 end


### PR DESCRIPTION
## Summary
- support bold, backslash escapes, and base64 images when converting markdown
- preserve these features when converting back from HTML
- test conversions for links, bold, escapes and images

## Testing
- `./bin/rubocop -a`
- `bundle exec rake test TEST=test/helpers/creatives_helper_test.rb`

------
https://chatgpt.com/codex/tasks/task_e_6858e8c0c7608326a1236580f7d28979