### PR TITLE
Add append below creative option

### DIFF
--- a/app/views/creatives/_add_button.html.erb
+++ b/app/views/creatives/_add_button.html.erb
@@ -6,8 +6,10 @@
   end
 
   if authenticated? && @parent_creative && @parent_creative.has_permission?(Current.user, :write)
-    menu_items << link_to(t('creatives.index.new_sub_creative'), new_creative_path(parent_id: @parent_creative.id, tags: params[:tags]), class: 'popup-menu-item')
     menu_items << link_to(t('creatives.index.append_as_parent_creative'), append_as_parent_creative_creatives_path(parent_id: @parent_creative.id, tags: params[:tags]), class: 'popup-menu-item')
+    menu_items << link_to(t('creatives.index.append_below_creative'), append_below_creative_creatives_path(creative_id: @parent_creative.id, tags: params[:tags]), class: 'popup-menu-item')
+    menu_items << tag.br
+    menu_items << link_to(t('creatives.index.new_sub_creative'), new_creative_path(parent_id: @parent_creative.id, tags: params[:tags]), class: 'popup-menu-item')
   end
 %>
 

--- a/app/views/creatives/_form.html.erb
+++ b/app/views/creatives/_form.html.erb
@@ -22,6 +22,10 @@
     <%= hidden_field_tag :child_id, params[:child_id] %>
   <% end %>
 
+  <% if params[:after_id].present? %>
+    <%= hidden_field_tag :after_id, params[:after_id] %>
+  <% end %>
+
   <% if params[:tags].present? %>
     <% Array(params[:tags]).each do |tag_id| %>
       <%= hidden_field_tag 'tags[]', tag_id %>

--- a/config/locales/creatives.en.yml
+++ b/config/locales/creatives.en.yml
@@ -6,6 +6,7 @@ en:
       new_sub_creative: "New sub-creative"
       edit: "Edit"
       append_as_parent_creative: "New upper-creative"
+      append_below_creative: "Add below"
       delete: "Delete"
       delete_only_this: "Delete only this Creative"
       delete_with_children: "Delete this Creative and all its children"

--- a/config/locales/creatives.ko.yml
+++ b/config/locales/creatives.ko.yml
@@ -6,6 +6,7 @@ ko:
       new_sub_creative: "하위에 추가"
       edit: "수정"
       append_as_parent_creative: "상위에 추가"
+      append_below_creative: "아래에 추가"
       delete: "삭제"
       delete_only_this: "이 항목만 삭제"
       delete_with_children: "이 항목과 모든 하위 항목 삭제"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,7 @@ Rails.application.routes.draw do
       post :set_plan
       post :remove_plan
       get :append_as_parent, to: "creatives#append_as_parent", as: :append_as_parent_creative
+      get :append_below, to: "creatives#append_below", as: :append_below_creative
       get :export_markdown
     end
     member do


### PR DESCRIPTION
## Summary
- add `append_below_creative` route and controller action
- support `after_id` when creating a creative
- show hidden field for `after_id` in creative form
- include `Add below` option in add popup menu
- update English and Korean translations

## Testing
- `./bin/rubocop -a`
- `bundle exec rake spec` *(fails: Selenium download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685aa644b134832689f3ea597ebcd91f