### PR TITLE
Add vertical divider next to add button

### DIFF
--- a/app/assets/stylesheets/creatives.css
+++ b/app/assets/stylesheets/creatives.css
@@ -1,16 +1,6 @@
-.creative-row-actions {
-  visibility: hidden;
-  display: flex;
-  align-items: center;
-}
+
 .creative-row:hover .creative-row-actions {
   visibility: visible;
-}
-
-@media (max-width: 768px) {
-  .creative-row-actions {
-    visibility: visible !important;
-  }
 }
 
 .creative-actions-row {
@@ -91,6 +81,8 @@
 .creative-row-start {
     display: flex;
     align-items: center;
+    width: 100%;
+    /* background-color: var(--color-btn-bg); */
 }
 
 .creative-toggle-btn {
@@ -112,6 +104,46 @@
     font-weight: bold;
     text-decoration: none;
     cursor: pointer;
+}
+
+.creative-row-actions {
+    visibility: hidden;
+    display: flex;
+    align-items: center;
+    align-self: stretch;
+}
+
+@media (max-width: 768px) {
+    .creative-row-actions {
+        visibility: visible !important;
+    }
+}
+
+.creative-divider {
+    position: relative;
+    /* width: 6px; */
+    margin-right: 2px;
+    background-color: var(--color-border);
+    display: flex;
+    align-items: center;
+    align-self: stretch;
+}
+
+/* to prevent border height from affecting layout, add virtual border */
+.creative-divider::before,
+.creative-divider::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    width: 100%;
+    height: 6px; /* border thickness */
+    background: var(--color-bg);
+}
+.creative-divider::before {
+    top: 0;
+}
+.creative-divider::after {
+    bottom: 0;
 }
 
 .select-creative-checkbox {

--- a/app/assets/stylesheets/creatives.css
+++ b/app/assets/stylesheets/creatives.css
@@ -81,8 +81,6 @@
 .creative-row-start {
     display: flex;
     align-items: center;
-    width: 100%;
-    /* background-color: var(--color-btn-bg); */
 }
 
 .creative-toggle-btn {

--- a/app/components/creative_component.html.erb
+++ b/app/components/creative_component.html.erb
@@ -6,10 +6,12 @@
           <%= level <= 3 && filtered_children.any? ? helpers.toggle_button_symbol(expanded: expanded) : '' %>
         </div>
         <%= check_box_tag('selected_creative_ids[]', creative.id, false, class: 'select-creative-checkbox', style: select_mode ? '' : 'display: none') %>
+        <div class="creative-divider">
         <%= link_to('+', new_creative_path(parent_id: creative.id, tags: params[:tags]),
                     class: 'add-creative-btn',
                     style: (' visibility: hidden;' unless creative.has_permission?(Current.user, :write)),
                     title: t('creatives.help.add_child_creative')) %>
+        </div>
       </div>
       <%= content %>
     </div>


### PR DESCRIPTION
## Summary
- add divider bar after the '+' button in creative row
- style the divider in creatives stylesheet

## Testing
- `./bin/rubocop -a`
- `bin/rails test`

------
https://chatgpt.com/codex/tasks/task_e_685bc9ea344883269f2d83610d400f42