### PR TITLE
Fix comment popup layout

### DIFF
--- a/app/assets/stylesheets/comments_popup.css
+++ b/app/assets/stylesheets/comments_popup.css
@@ -2,16 +2,25 @@
   display: none;
   position: absolute;
   right: 2em;
-  /* top: 10em; */
   z-index: 1000;
   width: 350px;
   max-height: 400px;
-  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
   transition: all 0.2s;
 }
 
 #comments-list {
   margin-top: 0.5em;
+  flex-grow: 1;
+  overflow-y: auto;
+}
+
+#new-comment-form {
+  border-top: 1px solid var(--color-border);
+  padding-top: 0.5em;
+  background: var(--color-section-bg);
 }
 
 #new-comment-form textarea {
@@ -69,6 +78,9 @@
         min-width: 0;
         max-width: none;
         max-height: 70vh;
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
         padding: 0.5em;
         border-radius: 10px 10px 0 0;
         transform: translateY(100%);

--- a/app/views/comments/_comments_popup.html.erb
+++ b/app/views/comments/_comments_popup.html.erb
@@ -6,11 +6,10 @@
      data-update-comment-text="<%= t('comments.update_comment') %>">
   <button id="close-comments-btn" class="popup-close-btn">&times;</button>
   <h3 style="margin-top:0;"><%= t('comments.comments') %></h3>
+  <div id="comments-list"><%= t('app.loading') %></div>
   <form id="new-comment-form" style="display:none;">
     <textarea name="comment[content]" rows="2" required></textarea>
     <button type="submit"><%= t('comments.add_comment') %></button>
   </form>
   <%= render UserMentionMenuComponent.new(menu_id: 'mention-menu') %>
-  <br/>
-  <div id="comments-list"><%= t('app.loading') %></div>
 </div>


### PR DESCRIPTION
## Summary
- move comment form to bottom of comments popup
- keep popup layout fixed with scrollable comments list

## Testing
- `./bin/rubocop -a`
- `bundle exec rake` *(fails: Selenium could not download Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_685d0790140483269488ccf92e751b0a