### PR TITLE
Fix comment popup position for mobile keyboard

### DIFF
--- a/app/assets/stylesheets/comments_popup.css
+++ b/app/assets/stylesheets/comments_popup.css
@@ -75,7 +75,6 @@
         width: auto;
         min-width: 0;
         max-width: none;
-        max-height: calc(70dvh - env(keyboard-inset-height, 0));
         padding: 0.5em;
         border-radius: 10px 10px 0 0;
         transform: translateY(100%);

--- a/app/assets/stylesheets/comments_popup.css
+++ b/app/assets/stylesheets/comments_popup.css
@@ -71,11 +71,11 @@
         right: 0;
         left: 0;
         top: auto;
-        bottom: 0;
+        bottom: env(keyboard-inset-height, 0);
         width: auto;
         min-width: 0;
         max-width: none;
-        max-height: 70vh;
+        max-height: calc(70dvh - env(keyboard-inset-height, 0));
         padding: 0.5em;
         border-radius: 10px 10px 0 0;
         transform: translateY(100%);

--- a/app/javascript/comments.js
+++ b/app/javascript/comments.js
@@ -51,6 +51,27 @@ if (!window.commentsInitialized) {
         var textarea = form.querySelector('textarea');
         var editingId = null;
         if (popup) {
+            function adjustForKeyboard() {
+                if (!isMobile()) return;
+                var inset = 0;
+                if (window.visualViewport) {
+                    inset = window.innerHeight - window.visualViewport.height;
+                    if (inset < 0) inset = 0;
+                }
+                popup.style.bottom = inset + 'px';
+            }
+            textarea.addEventListener('focus', function() {
+                adjustForKeyboard();
+                if (window.visualViewport) {
+                    window.visualViewport.addEventListener('resize', adjustForKeyboard);
+                }
+            });
+            textarea.addEventListener('blur', function() {
+                popup.style.bottom = '';
+                if (window.visualViewport) {
+                    window.visualViewport.removeEventListener('resize', adjustForKeyboard);
+                }
+            });
             const buttons = document.getElementsByName('show-comments-btn');
             buttons.forEach(function(btn) {
                 btn.onclick = function() {


### PR DESCRIPTION
## Summary
- use dynamic viewport units for mobile comments popup
- adjust popup position when the keyboard opens

## Testing
- `./bin/rubocop -a`
- `bin/rails test`


------
https://chatgpt.com/codex/tasks/task_e_685d40a7f2008326bd1c259375dd6461