### PR TITLE
Fix email message storage

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,17 @@
 class ApplicationMailer < ActionMailer::Base
   default from: "soonoh.jung@vrerv.com"
   layout "mailer"
+
+  private
+
+  # Returns the decoded body of the email. For multipart emails, prefer the text
+  # part when available, falling back to the HTML part.
+  def extract_body(email)
+    if email.multipart?
+      part = email.text_part || email.html_part
+      part&.body&.decoded.to_s
+    else
+      email.body.decoded
+    end
+  end
 end

--- a/app/mailers/inbox_mailer.rb
+++ b/app/mailers/inbox_mailer.rb
@@ -7,7 +7,7 @@ class InboxMailer < ApplicationMailer
       user: @user,
       email: @user.email,
       subject: email.subject,
-      body: email.body.raw_source,
+      body: extract_body(email),
       event: :inbox_summary
     )
   end

--- a/app/mailers/invitation_mailer.rb
+++ b/app/mailers/invitation_mailer.rb
@@ -5,7 +5,7 @@ class InvitationMailer < ApplicationMailer
     Email.create!(
       email: @invitation.email,
       subject: email.subject,
-      body: email.body.raw_source,
+      body: extract_body(email),
       event: :invitation
     )
   end

--- a/test/integration/invitation_flow_test.rb
+++ b/test/integration/invitation_flow_test.rb
@@ -15,6 +15,8 @@ class InvitationFlowTest < ActionDispatch::IntegrationTest
     InvitationMailer.with(invitation: invitation).invite.deliver_now
 
     mail = ActionMailer::Base.deliveries.last
+    email_record = Email.order(:created_at).last
+    assert email_record.body.present?, "email body should be saved"
     body = mail.text_part ? mail.text_part.body.decoded : mail.body.decoded
     token = CGI.unescape(body[/token=([^"\s]+)/, 1])
     assert token.present?, "token should be present in email"

--- a/test/jobs/inbox_summary_job_test.rb
+++ b/test/jobs/inbox_summary_job_test.rb
@@ -14,6 +14,7 @@ class InboxSummaryJobTest < ActiveJob::TestCase
     assert_emails 1 do
       InboxSummaryJob.perform_now
     end
+    assert Email.order(:created_at).last.body.present?, "email body should be saved"
   end
 
   test "does not send email when user has no new items" do


### PR DESCRIPTION
## Summary
- keep the mail body when recording sent emails
- test that body is persisted for invitation and inbox summary emails

## Testing
- `./bin/rubocop -A`
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_685d5ce31d90832681b1793e7e92e22e