### PR TITLE
Add live comment popup presence

### DIFF
--- a/app/assets/stylesheets/comments_popup.css
+++ b/app/assets/stylesheets/comments_popup.css
@@ -95,3 +95,15 @@
     to { background: transparent; }
 }
 
+#comment-participants {
+  margin-bottom: 0.3em;
+}
+
+.comment-presence-avatar {
+  margin-right: 0.2em;
+}
+
+.comment-presence-avatar.inactive {
+  opacity: 0.4;
+  filter: grayscale(1);
+}

--- a/app/channels/application_cable/channel.rb
+++ b/app/channels/application_cable/channel.rb
@@ -1,0 +1,4 @@
+module ApplicationCable
+  class Channel < ActionCable::Channel::Base
+  end
+end

--- a/app/channels/comments_presence_channel.rb
+++ b/app/channels/comments_presence_channel.rb
@@ -1,8 +1,9 @@
 class CommentsPresenceChannel < ApplicationCable::Channel
   def subscribed
+    Rails.logger.info "User #{current_user&.email} subscribed to comments presence for creative #{params[:creative_id]}"
     return unless params[:creative_id].present? && current_user
 
-    @creative_id = params[:creative_id].to_i
+    @creative_id = Creative.find(params[:creative_id].to_i).effective_origin.id
     stream_from stream_name
     CommentPresenceStore.add(@creative_id, current_user.id)
     broadcast_presence
@@ -23,10 +24,11 @@ class CommentsPresenceChannel < ApplicationCable::Channel
 
   def broadcast_presence
     ids = CommentPresenceStore.list(@creative_id)
+    Rails.logger.info "Broadcasting presence for creative #{@creative_id} to #{stream_name}, users: #{ids.join(', ')}"
     html = ApplicationController.render(
       partial: "comments/presence_avatars",
       locals: { creative: Creative.find(@creative_id), present_ids: ids }
     )
-    ActionCable.server.broadcast(stream_name, html: html)
+    ActionCable.server.broadcast(stream_name, { html: html })
   end
 end

--- a/app/channels/comments_presence_channel.rb
+++ b/app/channels/comments_presence_channel.rb
@@ -1,0 +1,32 @@
+class CommentsPresenceChannel < ApplicationCable::Channel
+  def subscribed
+    return unless params[:creative_id].present? && current_user
+
+    @creative_id = params[:creative_id].to_i
+    stream_from stream_name
+    CommentPresenceStore.add(@creative_id, current_user.id)
+    broadcast_presence
+  end
+
+  def unsubscribed
+    if @creative_id && current_user
+      CommentPresenceStore.remove(@creative_id, current_user.id)
+      broadcast_presence
+    end
+  end
+
+  private
+
+  def stream_name
+    "comments_presence:#{@creative_id}"
+  end
+
+  def broadcast_presence
+    ids = CommentPresenceStore.list(@creative_id)
+    html = ApplicationController.render(
+      partial: "comments/presence_avatars",
+      locals: { creative: Creative.find(@creative_id), present_ids: ids }
+    )
+    ActionCable.server.broadcast(stream_name, html: html)
+  end
+end

--- a/app/controllers/creatives_controller.rb
+++ b/app/controllers/creatives_controller.rb
@@ -37,10 +37,7 @@ class CreativesController < ApplicationController
     end
     # 공유 리스트 로직: 자신과 모든 ancestor에서 공유된 사용자 수집
     if (@shared_creative = @parent_creative || @creatives&.first)
-      # linked creative(복제본)이면 origin 사용
-      base_creative = @shared_creative.origin_id.present? ? @shared_creative.origin : @shared_creative
-      ancestor_ids = [ base_creative.id ] + base_creative.ancestors.pluck(:id)
-      @shared_list = CreativeShare.where(creative_id: ancestor_ids).includes(:user)
+      @shared_list = @shared_creative.all_shared_users
     end
 
     if params[:tags].present?

--- a/app/javascript/comments.js
+++ b/app/javascript/comments.js
@@ -32,6 +32,7 @@ if (!window.commentsInitialized) {
                 document.body.classList.add('no-scroll');
                 updatePosition();
             }
+            subscribePresence();
             loadInitialComments();
         }
         function closePopup() {
@@ -42,14 +43,30 @@ if (!window.commentsInitialized) {
                 popup.style.display = 'none';
             }
             document.body.classList.remove('no-scroll');
+            unsubscribePresence();
         }
         var popup = document.getElementById('comments-popup');
         var closeBtn = document.getElementById('close-comments-btn');
         var list = document.getElementById('comments-list');
         var form = document.getElementById('new-comment-form');
+        var participants = document.getElementById('comment-participants');
         var submitBtn = form.querySelector('button[type="submit"]');
         var textarea = form.querySelector('textarea');
         var editingId = null;
+        var presenceSubscription = null;
+
+        function subscribePresence() {
+            if (!popup.dataset.creativeId) return;
+            if (presenceSubscription) { presenceSubscription.unsubscribe(); }
+            presenceSubscription = ActionCable.createConsumer().subscriptions.create(
+                { channel: 'CommentsPresenceChannel', creative_id: popup.dataset.creativeId },
+                { received: function(data) { if (data.html && participants) { participants.innerHTML = data.html; } } }
+            );
+        }
+
+        function unsubscribePresence() {
+            if (presenceSubscription) { presenceSubscription.unsubscribe(); presenceSubscription = null; }
+        }
         if (popup) {
             function adjustForKeyboard() {
                 if (!isMobile()) return;

--- a/app/models/comment_presence_store.rb
+++ b/app/models/comment_presence_store.rb
@@ -1,0 +1,28 @@
+class CommentPresenceStore
+  KEY_PREFIX = "comment_presence:"
+
+  def self.add(creative_id, user_id)
+    ids = list(creative_id)
+    unless ids.include?(user_id)
+      ids << user_id
+      Rails.cache.write(key(creative_id), ids)
+    end
+    ids
+  end
+
+  def self.remove(creative_id, user_id)
+    ids = list(creative_id)
+    if ids.delete(user_id)
+      Rails.cache.write(key(creative_id), ids)
+    end
+    ids
+  end
+
+  def self.list(creative_id)
+    Rails.cache.read(key(creative_id)) || []
+  end
+
+  def self.key(creative_id)
+    "#{KEY_PREFIX}#{creative_id}"
+  end
+end

--- a/app/models/creative.rb
+++ b/app/models/creative.rb
@@ -148,6 +148,14 @@ class Creative < ApplicationRecord
     parent.update(progress: new_progress)
   end
 
+  def all_shared_users(required_permission = :read)
+    base_creative = effective_origin
+    ancestor_ids = [ base_creative.id ] + base_creative.ancestors.pluck(:id)
+    CreativeShare.where(creative_id: ancestor_ids)
+                 .where("permission >= ?", CreativeShare.permissions[required_permission.to_s])
+                 .includes(:user)
+  end
+
   private
 
   def assign_default_user

--- a/app/views/comments/_comments_popup.html.erb
+++ b/app/views/comments/_comments_popup.html.erb
@@ -6,6 +6,7 @@
      data-update-comment-text="<%= t('comments.update_comment') %>">
   <button id="close-comments-btn" class="popup-close-btn">&times;</button>
   <h3 style="margin-top:0;"><%= t('comments.comments') %></h3>
+  <div id="comment-participants"></div>
   <%= render UserMentionMenuComponent.new(menu_id: 'mention-menu') %>
   <br/>
   <div id="comments-list"><%= t('app.loading') %></div>

--- a/app/views/comments/_presence_avatars.html.erb
+++ b/app/views/comments/_presence_avatars.html.erb
@@ -1,5 +1,5 @@
 <div id="comment-participants">
-  <% accessible_users = [creative.user].compact + creative.creative_shares.includes(:user).map(&:user) %>
+  <% accessible_users = [creative.user].compact + creative.all_shared_users(:feedback).map(&:user) %>
   <% accessible_users.uniq.each do |u| %>
     <% classes = 'avatar comment-presence-avatar' %>
     <% classes += ' inactive' unless present_ids.include?(u.id) %>

--- a/app/views/comments/_presence_avatars.html.erb
+++ b/app/views/comments/_presence_avatars.html.erb
@@ -1,0 +1,8 @@
+<div id="comment-participants">
+  <% accessible_users = [creative.user].compact + creative.creative_shares.includes(:user).map(&:user) %>
+  <% accessible_users.uniq.each do |u| %>
+    <% classes = 'avatar comment-presence-avatar' %>
+    <% classes += ' inactive' unless present_ids.include?(u.id) %>
+    <%= render AvatarComponent.new(user: u, size: 20, classes: classes) %>
+  <% end %>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,7 +28,7 @@
     <%= javascript_include_tag 'creatives', defer: true %>
     <%= javascript_include_tag 'popup_menu', defer: true %>
     <%= javascript_include_tag 'progress_filter_toggle', defer: true %>
-    <%= javascript_include_tag 'action_cable', defer: true %>
+    <%= javascript_include_tag 'actioncable', defer: true %>
     <%= javascript_importmap_tags %>
   </head>
   <body>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,6 +28,7 @@
     <%= javascript_include_tag 'creatives', defer: true %>
     <%= javascript_include_tag 'popup_menu', defer: true %>
     <%= javascript_include_tag 'progress_filter_toggle', defer: true %>
+    <%= javascript_include_tag 'action_cable', defer: true %>
     <%= javascript_importmap_tags %>
   </head>
   <body>


### PR DESCRIPTION
## Summary
- show avatars for users with access to a creative
- mark avatars inactive when the user isn't in the comment popup
- broadcast popup presence via `CommentsPresenceChannel`
- subscribe/unsubscribe to the channel from `comments.js`
- style participant avatars in the popup

## Testing
- `./bin/rubocop -a`

------
https://chatgpt.com/codex/tasks/task_e_685d5f345ef48326b1e2b4b8c9a7c060