### PR TITLE
Fix summary email links

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -16,7 +16,11 @@ class Comment < ApplicationRecord
     InboxItem.create!(
       owner: owner,
       message: message,
-      link: Rails.application.routes.url_helpers.creative_comment_path(creative, self)
+      link: Rails.application.routes.url_helpers.creative_comment_url(
+        creative,
+        self,
+        Rails.application.config.action_mailer.default_url_options
+      )
     )
   end
 

--- a/app/models/creative_share.rb
+++ b/app/models/creative_share.rb
@@ -25,7 +25,10 @@ class CreativeShare < ApplicationRecord
     InboxItem.create!(
       owner: user,
       message: I18n.t("inbox.creative_shared", user: Current.user.email, short_title: short_title),
-      link: Rails.application.routes.url_helpers.creative_path(creative)
+      link: Rails.application.routes.url_helpers.creative_url(
+        creative,
+        Rails.application.config.action_mailer.default_url_options
+      )
     )
   end
 

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -12,7 +12,11 @@ class CommentTest < ActiveSupport::TestCase
     item = InboxItem.last
     assert_equal creative.user, item.owner
     assert_includes item.message, commenter.email
-    expected_link = Rails.application.routes.url_helpers.creative_comment_path(creative, Comment.last)
+    expected_link = Rails.application.routes.url_helpers.creative_comment_url(
+      creative,
+      Comment.last,
+      host: "example.com"
+    )
     assert_equal expected_link, item.link
   end
 end

--- a/test/models/creative_share_test.rb
+++ b/test/models/creative_share_test.rb
@@ -16,7 +16,10 @@ class CreativeShareTest < ActiveSupport::TestCase
     assert_equal recipient, item.owner
     assert_includes item.message, sharer.email
     assert_includes item.message, "T-Shirt"
-    expected_link = Rails.application.routes.url_helpers.creative_path(creative)
+    expected_link = Rails.application.routes.url_helpers.creative_url(
+      creative,
+      host: "example.com"
+    )
     assert_equal expected_link, item.link
 
     Current.reset


### PR DESCRIPTION
## Summary
- include full host in inbox links
- update tests for new URLs

## Testing
- `bin/rails test`
- `bundle exec rspec` *(fails: error sending request for url)*

------
https://chatgpt.com/codex/tasks/task_e_685deed6fb2883269bc6bdff20b2271d