### PR TITLE
Fix iOS keyboard positioning for comment popup

### DIFF
--- a/app/assets/stylesheets/comments_popup.css
+++ b/app/assets/stylesheets/comments_popup.css
@@ -71,7 +71,7 @@
         right: 0;
         left: 0;
         top: auto;
-        bottom: env(keyboard-inset-height, 0);
+        bottom: 0;
         width: auto;
         min-width: 0;
         max-width: none;


### PR DESCRIPTION
## Summary
- avoid double bottom offset on iOS comment popup

## Testing
- `./bin/rubocop -a`
- `bundle exec rails test`

------
https://chatgpt.com/codex/tasks/task_e_685df60e65688326a3abcec79cc0bd41