### PR TITLE
Add markdown service and table conversion

### DIFF
--- a/app/controllers/creatives_controller.rb
+++ b/app/controllers/creatives_controller.rb
@@ -210,76 +210,11 @@ class CreativesController < ApplicationController
       render json: { error: "Invalid file type" }, status: :unprocessable_entity and return
     end
     parent = params[:parent_id].present? ? Creative.find_by(id: params[:parent_id]) : nil
-    file = params[:markdown]
-    content = file.read.force_encoding("UTF-8")
-    lines = content.lines
-    image_refs = {}
-    lines.reject! do |ln|
-      if ln =~ /^\s*\[([^\]]+)\]:\s*<\s*(data:image\/[^>]+)\s*>\s*$/
-        image_refs[$1] = $2.strip
-        true
-      else
-        false
-      end
-    end
-    created = []
-
-    # Find page title (first non-empty, non-heading, non-list line)
-    i = 0
-    while i < lines.size && lines[i].strip.empty?
-      i += 1
-    end
-    root_creative = nil
-    if i < lines.size && lines[i] !~ /^\s*#/ && lines[i] !~ /^\s*[-*+]/
-      page_title = lines[i].strip
-      root_creative = Creative.create(user: Current.user, parent: parent, description: page_title)
-      created << root_creative
-      i += 1
-    end
-    # If no page title, use parent as root
-    root_creative ||= parent
-
-    # Now, stack always starts with root_creative
-    stack = [ [ 0, root_creative ] ]
-    while i < lines.size
-      line = lines[i]
-      if line =~ /^(#+)\s+(.*)$/ # Heading
-        level = $1.length # 1 for h1, 2 for h2, etc.
-        desc = helpers.markdown_links_to_html($2.strip, image_refs)
-        while stack.any? && stack.last[0] >= level
-          stack.pop
-        end
-        new_parent = stack.any? ? stack.last[1] : root_creative
-        c = Creative.create(user: Current.user, parent: new_parent, description: desc)
-        created << c
-        stack << [ level, c ]
-        i += 1
-      elsif line =~ /^([ \t]*)([-*+])\s+(.*)$/ # Bullet list
-        indent = $1.length
-        desc = helpers.markdown_links_to_html($3.strip, image_refs)
-        bullet_level = 10 + indent / 2
-        while stack.any? && stack.last[0] >= bullet_level
-          stack.pop
-        end
-        new_parent = stack.any? ? stack.last[1] : root_creative
-        c = Creative.create(user: Current.user, parent: new_parent, description: desc)
-        created << c
-        stack << [ bullet_level, c ]
-        i += 1
-      elsif !line.strip.empty? # Paragraph/content under a heading
-        desc = helpers.markdown_links_to_html(line.strip, image_refs)
-        new_parent = stack.any? ? stack.last[1] : root_creative
-        c = Creative.create(user: Current.user, parent: new_parent, description: desc)
-        created << c
-        i += 1
-      else
-        i += 1
-      end
-    end
-    if created.any?
-      render json: { success: true, created: created.map(&:id) }
+    result = CreativeMarkdownService.import(file: params[:markdown], parent: parent, user: Current.user)
+    if result[:success]
+      render json: result
     else
-      render json: { error: "No creatives created" }, status: :unprocessable_entity
+      render json: result, status: :unprocessable_entity
     end
   end
 
@@ -325,12 +260,7 @@ class CreativesController < ApplicationController
   end
 
   def export_markdown
-    creatives = if params[:parent_id]
-      Creative.where(id: params[:parent_id])&.map(&:effective_origin) || []
-    else
-      Creative.where(parent_id: nil)
-    end
-    markdown = helpers.render_creative_tree_markdown(creatives)
+    markdown = CreativeMarkdownService.export(parent_id: params[:parent_id])
     send_data markdown, filename: "creatives.md", type: "text/markdown"
   end
 

--- a/app/helpers/creatives_helper.rb
+++ b/app/helpers/creatives_helper.rb
@@ -141,7 +141,7 @@ module CreativesHelper
     return "" if creatives.blank?
     md = ""
     creatives.each do |creative|
-      desc = creative.effective_description(nil, false)
+      desc = creative.effective_description(nil, true)
       html = desc.to_s.gsub(/<!--.*?-->/m, "").strip
       html = html_links_to_markdown(html)
       if level <= 4

--- a/app/models/creative.rb
+++ b/app/models/creative.rb
@@ -79,7 +79,7 @@ class Creative < ApplicationRecord
       description = origin.rich_text_description&.body
     end
     if html
-      description&.respond_to?(:to_html) ? description.to_html : description.to_s
+      description&.to_s || ""
     else
       description
     end

--- a/app/models/creative.rb
+++ b/app/models/creative.rb
@@ -79,7 +79,7 @@ class Creative < ApplicationRecord
       description = origin.rich_text_description&.body
     end
     if html
-      description&.to_s || ""
+      description&.respond_to?(:to_html) ? description.to_html : description.to_s
     else
       description
     end

--- a/app/services/creative_markdown_service.rb
+++ b/app/services/creative_markdown_service.rb
@@ -18,7 +18,7 @@ class CreativeMarkdownService
         i += 1
       end
       root_creative = nil
-      if i < lines.size && lines[i] !~ /^\s*#/ && lines[i] !~ /^\s*[-*+]/
+      if i < lines.size && lines[i] !~ /^\s*#/ && lines[i] !~ /^\s*[-*+]/ && lines[i] !~ /^\s*\|.*\|\s*$/
         page_title = lines[i].strip
         root_creative = Creative.create(user: user, parent: parent, description: page_title)
         created << root_creative
@@ -85,11 +85,13 @@ class CreativeMarkdownService
       return nil unless lines[index] =~ /^\s*\|.*\|\s*$/
       return nil if index + 1 >= lines.size
       return nil unless lines[index + 1] =~ /^\s*\|[-:| ]+\|\s*$/
-      headers = lines[index].strip.split("|")[1..-1].map { |h| h.strip }
+      header_line = lines[index].strip.sub(/^\|/, "").sub(/\|$/, "")
+      headers = header_line.split("|").map { |h| h.strip }
       i = index + 2
       rows = []
       while i < lines.size && lines[i] =~ /^\s*\|.*\|\s*$/
-        rows << lines[i].strip.split("|")[1..-1].map { |c| c.strip }
+        row_line = lines[i].strip.sub(/^\|/, "").sub(/\|$/, "")
+        rows << row_line.split("|").map { |c| c.strip }
         i += 1
       end
       html = "<table><thead><tr>" +

--- a/app/services/creative_markdown_service.rb
+++ b/app/services/creative_markdown_service.rb
@@ -1,0 +1,103 @@
+class CreativeMarkdownService
+  class << self
+    def import(file:, parent: nil, user:)
+      content = file.read.force_encoding("UTF-8")
+      lines = content.lines
+      image_refs = {}
+      lines.reject! do |ln|
+        if ln =~ /^\s*\[([^\]]+)\]:\s*<\s*(data:image\/[^>]+)\s*>\s*$/
+          image_refs[$1] = $2.strip
+          true
+        else
+          false
+        end
+      end
+      created = []
+      i = 0
+      while i < lines.size && lines[i].strip.empty?
+        i += 1
+      end
+      root_creative = nil
+      if i < lines.size && lines[i] !~ /^\s*#/ && lines[i] !~ /^\s*[-*+]/
+        page_title = lines[i].strip
+        root_creative = Creative.create(user: user, parent: parent, description: page_title)
+        created << root_creative
+        i += 1
+      end
+      root_creative ||= parent
+      stack = [ [ 0, root_creative ] ]
+      helpers = ApplicationController.helpers
+      while i < lines.size
+        line = lines[i]
+        if (table_result = markdown_table_to_html(lines, i, image_refs, helpers))
+          html, i = table_result
+          new_parent = stack.any? ? stack.last[1] : root_creative
+          c = Creative.create(user: user, parent: new_parent, description: html)
+          created << c
+        elsif line =~ /^(#+)\s+(.*)$/
+          level = $1.length
+          desc = helpers.markdown_links_to_html($2.strip, image_refs)
+          stack.pop while stack.any? && stack.last[0] >= level
+          new_parent = stack.any? ? stack.last[1] : root_creative
+          c = Creative.create(user: user, parent: new_parent, description: desc)
+          created << c
+          stack << [ level, c ]
+          i += 1
+        elsif line =~ /^([ \t]*)([-*+])\s+(.*)$/
+          indent = $1.length
+          desc = helpers.markdown_links_to_html($3.strip, image_refs)
+          bullet_level = 10 + indent / 2
+          stack.pop while stack.any? && stack.last[0] >= bullet_level
+          new_parent = stack.any? ? stack.last[1] : root_creative
+          c = Creative.create(user: user, parent: new_parent, description: desc)
+          created << c
+          stack << [ bullet_level, c ]
+          i += 1
+        elsif !line.strip.empty?
+          desc = helpers.markdown_links_to_html(line.strip, image_refs)
+          new_parent = stack.any? ? stack.last[1] : root_creative
+          c = Creative.create(user: user, parent: new_parent, description: desc)
+          created << c
+          i += 1
+        else
+          i += 1
+        end
+      end
+      if created.any?
+        { success: true, created: created.map(&:id) }
+      else
+        { error: "No creatives created" }
+      end
+    end
+
+    def export(parent_id: nil)
+      creatives = if parent_id
+        Creative.where(id: parent_id)&.map(&:effective_origin) || []
+      else
+        Creative.where(parent_id: nil)
+      end
+      ApplicationController.helpers.render_creative_tree_markdown(creatives)
+    end
+
+    private
+
+    def markdown_table_to_html(lines, index, image_refs, helpers)
+      return nil unless lines[index] =~ /^\s*\|.*\|\s*$/
+      return nil if index + 1 >= lines.size
+      return nil unless lines[index + 1] =~ /^\s*\|[-:| ]+\|\s*$/
+      headers = lines[index].strip.split("|")[1..-1].map { |h| h.strip }
+      i = index + 2
+      rows = []
+      while i < lines.size && lines[i] =~ /^\s*\|.*\|\s*$/
+        rows << lines[i].strip.split("|")[1..-1].map { |c| c.strip }
+        i += 1
+      end
+      html = "<table><thead><tr>" +
+             headers.map { |h| "<th>#{helpers.markdown_links_to_html(h, image_refs)}</th>" }.join +
+             "</tr></thead><tbody>" +
+             rows.map { |r| "<tr>" + r.map { |c| "<td>#{helpers.markdown_links_to_html(c, image_refs)}</td>" }.join + "</tr>" }.join +
+             "</tbody></table>"
+      [ html, i ]
+    end
+  end
+end

--- a/test/helpers/creatives_helper_test.rb
+++ b/test/helpers/creatives_helper_test.rb
@@ -52,4 +52,10 @@ class CreativesHelperTest < ActionView::TestCase
     back = html_links_to_markdown(html)
     assert_equal "Look ![](data:image/png;base64,aGk=)", back
   end
+
+  test "html table converts to markdown" do
+    html = "<table><thead><tr><th>A</th><th>B</th></tr></thead><tbody><tr><td>1</td><td>2</td></tr></tbody></table>"
+    expected = "|A | B|\n|--- | ---|\n|1 | 2|\n"
+    assert_equal expected, html_table_to_markdown(html)
+  end
 end

--- a/test/services/creative_markdown_service_test.rb
+++ b/test/services/creative_markdown_service_test.rb
@@ -30,4 +30,21 @@ class CreativeMarkdownServiceTest < ActiveSupport::TestCase
 
     Current.reset
   end
+
+  test "import handles table with trailing pipes" do
+    user = users(:one)
+    Current.session = OpenStruct.new(user: user)
+
+    data = "| A | B | C |\n| --- | --- | --- |\n| 1 | 2 | 3 |\n"
+    result = CreativeMarkdownService.import(file: StringIO.new(data), parent: nil, user: user)
+
+    assert result[:success]
+    creative = Creative.find(result[:created].last)
+    html = creative.rich_text_description.body.to_html
+    assert_includes html, "<th>A</th>"
+    assert_includes html, "<th>B</th>"
+    assert_includes html, "<th>C</th>"
+
+    Current.reset
+  end
 end

--- a/test/services/creative_markdown_service_test.rb
+++ b/test/services/creative_markdown_service_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+
+class CreativeMarkdownServiceTest < ActiveSupport::TestCase
+  test "import parses markdown table into html creative" do
+    user = users(:one)
+    Current.session = OpenStruct.new(user: user)
+
+    data = "# Title\n| A | B |\n| --- | --- |\n| 1 | 2 |\n"
+    result = CreativeMarkdownService.import(file: StringIO.new(data), parent: nil, user: user)
+
+    assert result[:success]
+    assert_equal 2, result[:created].size
+    creative = Creative.find(result[:created].last)
+    assert_match %r{<table>.*<th>A</th>.*<th>B</th>}m, creative.rich_text_description.body.to_html
+
+    Current.reset
+  end
+
+  test "export converts html table to markdown" do
+    user = users(:one)
+    Current.session = OpenStruct.new(user: user)
+
+    html = "<table><thead><tr><th>A</th><th>B</th></tr></thead><tbody><tr><td>1</td><td>2</td></tr></tbody></table>"
+    creative = Creative.create!(user: user, description: html)
+
+    md = CreativeMarkdownService.export(parent_id: creative.id)
+
+    assert_includes md, "|A | B|"
+    assert_includes md, "|1 | 2|"
+
+    Current.reset
+  end
+end


### PR DESCRIPTION
## Summary
- extract markdown import/export into new `CreativeMarkdownService`
- add table parsing when importing markdown
- convert HTML tables to markdown when exporting
- use new service in controller

## Testing
- `./bin/rubocop -a`
- `bundle exec rake test`
- `bundle exec rspec` *(fails: could not download chrome driver)*

------
https://chatgpt.com/codex/tasks/task_e_685df51d41808326a15251477fa5b717