### PR TITLE
Fix comment popup position on iOS

### DIFF
--- a/app/javascript/comments.js
+++ b/app/javascript/comments.js
@@ -72,7 +72,8 @@ if (!window.commentsInitialized) {
                 if (!isMobile()) return;
                 var inset = 0;
                 if (window.visualViewport) {
-                    inset = window.innerHeight - window.visualViewport.height;
+                    var vv = window.visualViewport;
+                    inset = window.innerHeight - (vv.height + vv.offsetTop);
                     if (inset < 0) inset = 0;
                 }
                 popup.style.bottom = inset + 'px';


### PR DESCRIPTION
## Summary
- tweak keyboard inset calculation for comments popup on mobile

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: Selenium unable to download chromedriver)*

------
https://chatgpt.com/codex/tasks/task_e_685e08d032208326ae8323c0818acf32