### PR TITLE
Fix iOS zoom in comment popup

### DIFF
--- a/app/assets/stylesheets/comments_popup.css
+++ b/app/assets/stylesheets/comments_popup.css
@@ -27,6 +27,7 @@
   border-radius: 6px;
   border: 1px solid var(--color-border);
   padding: 0.5em;
+  font-size: 16px; /* Prevent iOS zoom on focus */
 }
 
 #new-comment-form button[type="submit"] {


### PR DESCRIPTION
## Summary
- prevent Safari text zoom on comment textarea

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: Selenium could not download Chrome driver)*

------
https://chatgpt.com/codex/tasks/task_e_685e3d2584648326b3c4c4c03d25d9c1