### PR TITLE
Implement comment read pointer

### DIFF
--- a/app/assets/stylesheets/comments_popup.css
+++ b/app/assets/stylesheets/comments_popup.css
@@ -40,6 +40,10 @@
     position: relative;
 }
 
+.comment-item.last-read {
+    border-bottom: 2px solid var(--color-border);
+}
+
 .comment-content {
     margin-top:0.2em;
     white-space:pre-line;

--- a/app/channels/comments_presence_channel.rb
+++ b/app/channels/comments_presence_channel.rb
@@ -12,6 +12,10 @@ class CommentsPresenceChannel < ApplicationCable::Channel
   def unsubscribed
     if @creative_id && current_user
       CommentPresenceStore.remove(@creative_id, current_user.id)
+      creative = Creative.find(@creative_id)
+      pointer = CommentReadPointer.find_or_initialize_by(user: current_user, creative: creative)
+      pointer.last_read_comment_id = creative.comments.maximum(:id)
+      pointer.save!
       broadcast_presence
     end
   end

--- a/app/components/inbox/badge_component.html.erb
+++ b/app/components/inbox/badge_component.html.erb
@@ -1,2 +1,2 @@
 
-<%= render 'inbox/badge_component/count', count: count, badge_id: badge_id %>
+<%= render 'inbox/badge_component/count', count: count, badge_id: badge_id, show_zero: show_zero %>

--- a/app/components/inbox/badge_component.rb
+++ b/app/components/inbox/badge_component.rb
@@ -1,11 +1,12 @@
 module Inbox
   class BadgeComponent < ViewComponent::Base
-    attr_reader :badge_id
+    attr_reader :badge_id, :show_zero
 
-    def initialize(user: nil, count: nil, badge_id: "inbox-badge")
+    def initialize(user: nil, count: nil, badge_id: "inbox-badge", show_zero: false)
       @user = user
       @count = count
       @badge_id = badge_id
+      @show_zero = show_zero
     end
 
     def count

--- a/app/controllers/comment_read_pointers_controller.rb
+++ b/app/controllers/comment_read_pointers_controller.rb
@@ -1,0 +1,10 @@
+class CommentReadPointersController < ApplicationController
+  def update
+    creative = Creative.find(params[:creative_id]).effective_origin
+    last_id = creative.comments.maximum(:id)
+    pointer = CommentReadPointer.find_or_initialize_by(user: Current.user, creative: creative)
+    pointer.last_read_comment_id = last_id
+    pointer.save!
+    render json: { success: true }
+  end
+end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -10,9 +10,11 @@ class CommentsController < ApplicationController
 
     scope = @creative.comments.order(created_at: :desc)
     @comments = scope.offset((page - 1) * per_page).limit(per_page).to_a
+    pointer = CommentReadPointer.find_by(user: Current.user, creative: @creative)
+    last_read_comment_id = pointer&.last_read_comment_id
 
     if page <= 1
-      render partial: "comments/list", locals: { comments: @comments.reverse, creative: @creative }
+      render partial: "comments/list", locals: { comments: @comments.reverse, creative: @creative, last_read_comment_id: last_read_comment_id }
     else
       render partial: "comments/comment", collection: @comments, as: :comment
     end

--- a/app/helpers/creatives_helper.rb
+++ b/app/helpers/creatives_helper.rb
@@ -39,11 +39,15 @@ module CreativesHelper
 
     content_tag(:div, class: "creative-row-end") do
       comment_part = if creative.has_permission?(Current.user, :feedback)
-        comments_count = creative.effective_origin.comments.size
+        origin = creative.effective_origin
+        comments_count = origin.comments.size
+        pointer = CommentReadPointer.find_by(user: Current.user, creative: origin)
+        last_read_id = pointer&.last_read_comment_id
+        unread_count = last_read_id ? origin.comments.where("id > ?", last_read_id).count : comments_count
         classes = [ "comments-btn" ]
         classes << "no-comments" if comments_count.zero?
         comment_label = comments_count.zero? ? "\u{1F4AC}" : ""
-        badge = render(Inbox::BadgeComponent.new(count: comments_count, badge_id: "comment-badge-#{creative.id}"))
+        badge = render(Inbox::BadgeComponent.new(count: unread_count, badge_id: "comment-badge-#{creative.id}", show_zero: comments_count.positive?))
         button_tag(
           comment_label.html_safe + badge,
           name: "show-comments-btn",

--- a/app/helpers/creatives_helper.rb
+++ b/app/helpers/creatives_helper.rb
@@ -44,6 +44,9 @@ module CreativesHelper
         pointer = CommentReadPointer.find_by(user: Current.user, creative: origin)
         last_read_id = pointer&.last_read_comment_id
         unread_count = last_read_id ? origin.comments.where("id > ?", last_read_id).count : comments_count
+        if CommentPresenceStore.list(origin.id).include?(Current.user.id)
+          unread_count = 0
+        end
         classes = [ "comments-btn" ]
         classes << "no-comments" if comments_count.zero?
         comment_label = comments_count.zero? ? "\u{1F4AC}" : ""

--- a/app/javascript/comments.js
+++ b/app/javascript/comments.js
@@ -43,6 +43,7 @@ if (!window.commentsInitialized) {
                 popup.style.display = 'none';
             }
             document.body.classList.remove('no-scroll');
+            markCommentsRead();
             unsubscribePresence();
         }
         var popup = document.getElementById('comments-popup');

--- a/app/javascript/comments.js
+++ b/app/javascript/comments.js
@@ -134,6 +134,17 @@ if (!window.commentsInitialized) {
                     .then(r => r.text());
             }
 
+            function markCommentsRead() {
+                fetch('/comment_read_pointers/update', {
+                    method: 'POST',
+                    headers: {
+                        'X-CSRF-Token': document.querySelector('meta[name=csrf-token]').content,
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify({ creative_id: popup.dataset.creativeId })
+                });
+            }
+
             function loadInitialComments(highlightId) {
                 currentPage = 1;
                 allLoaded = false;
@@ -153,6 +164,7 @@ if (!window.commentsInitialized) {
                     if ((html.match(/class="comment-item"/g) || []).length < 10) {
                         allLoaded = true;
                     }
+                    markCommentsRead();
                 });
             }
 

--- a/app/models/comment_read_pointer.rb
+++ b/app/models/comment_read_pointer.rb
@@ -1,0 +1,7 @@
+class CommentReadPointer < ApplicationRecord
+  belongs_to :user
+  belongs_to :creative
+  belongs_to :last_read_comment, class_name: "Comment", optional: true
+
+  validates :user_id, uniqueness: { scope: :creative_id }
+end

--- a/app/models/inbox_item.rb
+++ b/app/models/inbox_item.rb
@@ -26,7 +26,7 @@ class InboxItem < ApplicationRecord
       [ "inbox", owner ],
       target: "inbox-badge",
       partial: "inbox/badge_component/count",
-      locals: { count: new_count, badge_id: "inbox-badge" }
+      locals: { count: new_count, badge_id: "inbox-badge", show_zero: false }
     )
   end
 end

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,4 +1,4 @@
-<div class="comment-item" id="<%= dom_id(comment) %>">
+<div class="comment-item <%= 'last-read' if defined?(last_read_comment_id) && last_read_comment_id && comment.id == last_read_comment_id %>" id="<%= dom_id(comment) %>">
   <div>
     <%= render AvatarComponent.new(user: comment.user, size: 20, classes: 'avatar comment-avatar') %>
     <strong><%= comment.user&.email || t('comments.anonymous') %></strong>

--- a/app/views/comments/_list.html.erb
+++ b/app/views/comments/_list.html.erb
@@ -2,7 +2,7 @@
   <%= turbo_stream_from [creative, :comments] %>
   <% if comments.any? %>
     <% comments.each do |comment| %>
-      <%= render partial: 'comments/comment', locals: { comment: comment } %>
+      <%= render partial: 'comments/comment', locals: { comment: comment, last_read_comment_id: last_read_comment_id } %>
     <% end %>
   <% else %>
     <div><%= t('comments.no_comments') %></div>

--- a/app/views/inbox/badge_component/_count.html.erb
+++ b/app/views/inbox/badge_component/_count.html.erb
@@ -1,2 +1,2 @@
-<% display = count.positive? ? 'inline-block' : 'none' %>
-<span id="<%= badge_id %>" class="badge" style="display:<%= display %>"><%= count if count.positive? %></span>
+<% display = (count.positive? || show_zero) ? 'inline-block' : 'none' %>
+<span id="<%= badge_id %>" class="badge" style="display:<%= display %>"><%= count if count.positive? || show_zero %></span>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,4 +59,5 @@ Rails.application.routes.draw do
   resource :verify, controller: "email_verifications", only: [ :show ]
 
   post "/creative_expanded_states/toggle", to: "creative_expanded_states#toggle"
+  post "/comment_read_pointers/update", to: "comment_read_pointers#update"
 end

--- a/db/migrate/20250621000000_create_comment_read_pointers.rb
+++ b/db/migrate/20250621000000_create_comment_read_pointers.rb
@@ -1,0 +1,11 @@
+class CreateCommentReadPointers < ActiveRecord::Migration[8.0]
+  def change
+    create_table :comment_read_pointers do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :creative, null: false, foreign_key: true
+      t.integer :last_read_comment_id
+      t.timestamps
+    end
+    add_index :comment_read_pointers, [ :user_id, :creative_id ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_20_004558) do
+ActiveRecord::Schema[8.0].define(version: 2025_06_21_000000) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
     t.text "body"
@@ -47,6 +47,17 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_20_004558) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "comment_read_pointers", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "creative_id", null: false
+    t.integer "last_read_comment_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["creative_id"], name: "index_comment_read_pointers_on_creative_id"
+    t.index ["user_id", "creative_id"], name: "index_comment_read_pointers_on_user_id_and_creative_id", unique: true
+    t.index ["user_id"], name: "index_comment_read_pointers_on_user_id"
   end
 
   create_table "comments", force: :cascade do |t|
@@ -332,6 +343,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_20_004558) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "comment_read_pointers", "creatives"
+  add_foreign_key "comment_read_pointers", "users"
   add_foreign_key "comments", "creatives"
   add_foreign_key "comments", "users"
   add_foreign_key "creative_expanded_states", "creatives"

--- a/spec/models/comment_read_pointer_spec.rb
+++ b/spec/models/comment_read_pointer_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe CommentReadPointer, type: :model do
+  it 'enforces user and creative uniqueness' do
+    user = User.create!(email: 'user@example.com', password: 'pw')
+    creative = Creative.create!(user: user, description: 'c')
+    CommentReadPointer.create!(user: user, creative: creative)
+
+    dup = CommentReadPointer.new(user: user, creative: creative)
+    expect(dup.valid?).to be false
+  end
+end


### PR DESCRIPTION
## Summary
- track last read comment for each creative
- expose update action for comment read pointers
- show unread comment count based on pointer
- display separator under last read comment row
- tweak badge component to allow showing zero
- include migration and model specs

## Testing
- `./bin/rubocop -A`
- `bundle exec rspec` *(fails: WebDriverError due to blocked network)*

------
https://chatgpt.com/codex/tasks/task_e_685e43cfbc208326b5ec4263ea8f8f49