### PR TITLE
Add completion mark setting

### DIFF
--- a/app/assets/stylesheets/creatives.css
+++ b/app/assets/stylesheets/creatives.css
@@ -71,7 +71,6 @@
 
 .creative-progress-complete {
     color: green;
-    display: none;
 }
 
 .creative-progress-incomplete {

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -92,6 +92,6 @@ class UsersController < ApplicationController
   end
 
   def profile_params
-    params.require(:user).permit(:avatar, :avatar_url, :display_level)
+    params.require(:user).permit(:avatar, :avatar_url, :display_level, :completion_mark)
   end
 end

--- a/app/helpers/creatives_helper.rb
+++ b/app/helpers/creatives_helper.rb
@@ -65,9 +65,13 @@ module CreativesHelper
   end
 
   def render_progress_value(value)
+    text = number_to_percentage(value * 100, precision: 0)
+    if value == 1 && Current.user&.completion_mark.present?
+      text += " #{Current.user.completion_mark}"
+    end
     content_tag(
       :span,
-      number_to_percentage(value * 100, precision: 0),
+      text,
       class: "creative-progress-#{value == 1 ? 'complete' : 'incomplete'}"
     )
   end

--- a/app/helpers/creatives_helper.rb
+++ b/app/helpers/creatives_helper.rb
@@ -67,7 +67,7 @@ module CreativesHelper
   def render_progress_value(value)
     text = number_to_percentage(value * 100, precision: 0)
     if value == 1 && Current.user&.completion_mark.present?
-      text += " #{Current.user.completion_mark}"
+      text = Current.user.completion_mark
     end
     content_tag(
       :span,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,7 @@ class User < ApplicationRecord
   has_one_attached :avatar
 
   attribute :display_level, :integer, default: DEFAULT_DISPLAY_LEVEL
+  attribute :completion_mark, :string, default: ""
 
   normalizes :email, with: ->(e) { e.strip.downcase }
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -20,6 +20,10 @@
     <%= f.label :display_level, t('users.display_level') %>
     <%= f.number_field :display_level, min: 1 %>
   </div>
+  <div>
+    <%= f.label :completion_mark, t('users.completion_mark') %>
+    <%= f.text_field :completion_mark %>
+  </div>
   <%= f.submit t('users.update_profile') %>
 <% end %>
 

--- a/config/locales/users.en.yml
+++ b/config/locales/users.en.yml
@@ -24,6 +24,7 @@ en:
     update_profile: "Update Profile"
     index_title: "Users"
     display_level: "Max Display Level"
+    completion_mark: "Completion Mark"
     profile_updated: "Profile updated successfully."
     avatar_updated: "Avatar updated successfully."
     password_updated: "Password updated successfully."

--- a/config/locales/users.ko.yml
+++ b/config/locales/users.ko.yml
@@ -24,6 +24,7 @@ ko:
     update_profile: "프로파일 업데이트"
     index_title: "사용자 목록"
     display_level: "최대 표시 레벨"
+    completion_mark: "완료 표시 문자"
     profile_updated: "프로파일이 업데이트되었습니다."
     avatar_updated: "아바타가 변경되었습니다."
     password_updated: "비밀번호가 성공적으로 변경되었습니다."

--- a/db/migrate/20250622000000_add_completion_mark_to_users.rb
+++ b/db/migrate/20250622000000_add_completion_mark_to_users.rb
@@ -1,0 +1,5 @@
+class AddCompletionMarkToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :completion_mark, :string, default: "", null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_21_000000) do
+ActiveRecord::Schema[8.0].define(version: 2025_06_22_000000) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
     t.text "body"
@@ -338,6 +338,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_21_000000) do
     t.datetime "email_verified_at"
     t.string "avatar_url"
     t.integer "display_level", default: 6, null: false
+    t.string "completion_mark", default: "", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/test/integration/completion_mark_update_test.rb
+++ b/test/integration/completion_mark_update_test.rb
@@ -1,0 +1,16 @@
+require "test_helper"
+
+class CompletionMarkUpdateTest < ActionDispatch::IntegrationTest
+  test "user can update completion mark" do
+    user = users(:one)
+    user.update!(email_verified_at: Time.current)
+    post session_path, params: { email: user.email, password: "password" }
+    assert_response :redirect
+
+    patch user_path(user), params: { user: { completion_mark: "✓" } }
+    assert_redirected_to user_path(user)
+
+    user.reload
+    assert_equal "✓", user.completion_mark
+  end
+end


### PR DESCRIPTION
## Summary
- allow `users.completion_mark` field and default to empty string
- permit completion mark in user profile updates
- show completion mark when progress reaches 100%
- add translations for completion mark
- add migration and schema update

## Testing
- `./bin/rubocop -a`
- `bundle exec rake` *(fails: unable to fetch chrome driver)*

------
https://chatgpt.com/codex/tasks/task_e_685ecff011f08326a37391d281a85df9