### PR TITLE
Rename service to Collavre

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Plan42
+# Collavre
 
 A tracker of your creatives.
 

--- a/app/controllers/creatives_controller.rb
+++ b/app/controllers/creatives_controller.rb
@@ -1,5 +1,5 @@
 class CreativesController < ApplicationController
-  # TODO: for not for security reasons for this Plan42 app, we don't expose to public, later it should be controlled by roles for each Creatives
+  # TODO: for not for security reasons for this Collavre app, we don't expose to public, later it should be controlled by roles for each Creatives
   # Removed unauthenticated access to index and show actions
   # allow_unauthenticated_access only: %i[ index show ]
   before_action :set_creative, only: %i[ show edit update destroy ]

--- a/app/views/pwa/manifest.json.erb
+++ b/app/views/pwa/manifest.json.erb
@@ -1,5 +1,5 @@
 {
-  "name": "Plan42",
+  "name": "Collavre",
   "icons": [
     {
       "src": "/icon.png",
@@ -16,7 +16,7 @@
   "start_url": "/",
   "display": "standalone",
   "scope": "/",
-  "description": "Plan42.",
+  "description": "Collavre.",
   "theme_color": "red",
   "background_color": "red"
 }

--- a/config/application.rb
+++ b/config/application.rb
@@ -6,7 +6,7 @@ require "rails/all"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-module Plan42
+module Collavre
   class Application < Rails::Application
     # closure_tree uses lock file if db is not MySQL or PostgreSQL. set FLOCK_DIR to tmp dir.
     config.before_initialize do

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -1,8 +1,8 @@
 # Name of your application. Used to uniquely configure containers.
-service: plan42
+service: collavre
 
 # Name of the container image.
-image: soonoh/plan42
+image: soonoh/collavre
 
 # Deploy to these servers.
 servers:
@@ -67,7 +67,7 @@ aliases:
 # Use a persistent storage volume for sqlite database files and local Active Storage files.
 # Recommended to change this to a mounted volume path that is backed up off server.
 volumes:
-  - "plan42_storage:/rails/storage"
+  - "collavre_storage:/rails/storage"
 
 
 # Bridge fingerprinted assets, like JS and CSS, between versions to avoid

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -67,7 +67,7 @@ aliases:
 # Use a persistent storage volume for sqlite database files and local Active Storage files.
 # Recommended to change this to a mounted volume path that is backed up off server.
 volumes:
-  - "collavre_storage:/rails/storage"
+  - "plan42_storage:/rails/storage"
 
 
 # Bridge fingerprinted assets, like JS and CSS, between versions to avoid

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -28,7 +28,7 @@ Rails.application.configure do
   # Change to :null_store to avoid any caching.
   config.cache_store = :memory_store
 
-  # Plan42 uploaded files on the local file system (see config/storage.yml for options).
+  # Collavre uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
 
   # Don't care if the mailer can't send.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -58,7 +58,7 @@ Rails.application.configure do
   # config.action_mailer.raise_delivery_errors = false
 
   # Set host to be used by links generated in mailer templates.
-  config.action_mailer.default_url_options = { host: "collavre.vrerv.com" }
+  config.action_mailer.default_url_options = { host: "plan42.vrerv.com" }
 
   # Specify outgoing SMTP server. Remember to add smtp/* credentials via rails credentials:edit.
   # config.action_mailer.smtp_settings = {

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -21,7 +21,7 @@ Rails.application.configure do
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"
 
-  # Plan42 uploaded files on the local file system (see config/storage.yml for options).
+  # Collavre uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
 
   # Assume all access to the app is happening through a SSL-terminating reverse proxy.
@@ -58,7 +58,7 @@ Rails.application.configure do
   # config.action_mailer.raise_delivery_errors = false
 
   # Set host to be used by links generated in mailer templates.
-  config.action_mailer.default_url_options = { host: "plan42.vrerv.com" }
+  config.action_mailer.default_url_options = { host: "collavre.vrerv.com" }
 
   # Specify outgoing SMTP server. Remember to add smtp/* credentials via rails credentials:edit.
   # config.action_mailer.smtp_settings = {

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -28,7 +28,7 @@ Rails.application.configure do
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false
 
-  # Plan42 uploaded files on the local file system in a temporary directory.
+  # Collavre uploaded files on the local file system in a temporary directory.
   config.active_storage.service = :test
 
   # Tell Action Mailer not to deliver emails to the real world.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,7 +29,7 @@
 
 en:
   app:
-    name: "Plan42"
+    name: "Collavre"
     home: "Home"
     sign_in: "Sign in"
     sign_out: "Sign out"

--- a/config/locales/invites.en.yml
+++ b/config/locales/invites.en.yml
@@ -4,6 +4,6 @@ en:
     invite_sent: "Invitation email sent."
   invitation_mailer:
     invite:
-      subject: "You're invited to Plan42"
+      subject: "You're invited to Collavre"
       message_html: "You have been invited to collaborate on \"%{creative}\". Click %{link} to accept within 15 days."
       message_text: "You have been invited to collaborate on \"%{creative}\". Join using this link: %{link}"

--- a/config/locales/invites.ko.yml
+++ b/config/locales/invites.ko.yml
@@ -4,6 +4,6 @@ ko:
     invite_sent: "초대 이메일을 보냈습니다."
   invitation_mailer:
     invite:
-      subject: "Plan42에 초대되었습니다"
+      subject: "콜라브에 초대되었습니다"
       message_html: "\"%{creative}\" 협업에 초대되었습니다. %{link} 링크를 클릭해 15일 이내에 수락하세요."
       message_text: "\"%{creative}\" 협업에 초대되었습니다. 이 링크로 참여하세요: %{link}"

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -1,6 +1,6 @@
 ko:
   app:
-    name: "플랜42"
+    name: "콜라브"
     home: "홈"
     sign_in: "로그인"
     sign_out: "로그아웃"

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -19,7 +19,7 @@
 
 ### show docker volume path
 
-`docker volume inspect plan42_storage`
+`docker volume inspect collavre_storage`
 
 ### send data to javascript
 

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -19,7 +19,7 @@
 
 ### show docker volume path
 
-`docker volume inspect collavre_storage`
+`docker volume inspect plan42_storage`
 
 ### send data to javascript
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,6 +1,6 @@
-# Plan42 Features
+# Collavre Features
 
 ## Creative
 
-* A Creative in Plan42 is a block of content with states.
+* A Creative in Collavre is a block of content with states.
 * It can be used as of a block of documentation or a task.


### PR DESCRIPTION
## Summary
- rename service Plan42 to Collavre (콜라브)
- update docs and configs with new name
- switch PWA manifest, locales, and environment comments
- update deployment and host settings

## Testing
- `./bin/rubocop -a`
- `bin/rails test`


------
https://chatgpt.com/codex/tasks/task_e_685ed0493a388326bbbd3dc0ad5cd592