### PR TITLE
Fix linked creative description edit

### DIFF
--- a/app/controllers/creatives_controller.rb
+++ b/app/controllers/creatives_controller.rb
@@ -125,7 +125,7 @@ class CreativesController < ApplicationController
 
   def update
     respond_to do |format|
-      if @creative.update(creative_params)
+      if @creative.effective_origin.update(creative_params)
         format.html { redirect_to @creative }
         format.json { head :ok }
       else

--- a/app/views/creatives/_form.html.erb
+++ b/app/views/creatives/_form.html.erb
@@ -34,7 +34,8 @@
 
   <div>
     <%= form.label :description, t('.description'), style: "display: block" %>
-    <%= form.rich_text_area :description %>
+    <% value = creative.effective_origin.rich_text_description %>
+    <%= form.rich_text_area :description, value: value %>
   </div>
 
   <br/>


### PR DESCRIPTION
## Summary
- use `effective_origin` rich text as default when editing a linked creative

## Testing
- `./bin/rubocop -a`
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_6861e2926ff88326a93c067865385ec9