### PR TITLE
Enable avatar mentions in chat popup

### DIFF
--- a/app/components/avatar_component.html.erb
+++ b/app/components/avatar_component.html.erb
@@ -4,4 +4,5 @@
               height: size,
               class: classes,
               title: email,
-              style: 'border-radius:50%;vertical-align:middle;' %>
+              style: 'border-radius:50%;vertical-align:middle;',
+              data: data %>

--- a/app/components/avatar_component.rb
+++ b/app/components/avatar_component.rb
@@ -1,11 +1,12 @@
 class AvatarComponent < ViewComponent::Base
-  def initialize(user:, size: 32, classes: "")
+  def initialize(user:, size: 32, classes: "", data: {})
     @user = user
     @size = size
     @classes = classes
+    @data = data
   end
 
-  attr_reader :size, :classes
+  attr_reader :size, :classes, :data
 
   def avatar_url
     if @user

--- a/app/javascript/comments.js
+++ b/app/javascript/comments.js
@@ -56,6 +56,26 @@ if (!window.commentsInitialized) {
         var editingId = null;
         var presenceSubscription = null;
 
+        function insertMention(email) {
+            var start = textarea.selectionStart;
+            var end = textarea.selectionEnd;
+            var mentionText = `@${email} `;
+            
+            if (start !== end) {
+                // 선택영역이 있는 경우: 선택영역을 '@' + email로 바꿈
+                var before = textarea.value.slice(0, start);
+                var after = textarea.value.slice(end);
+                textarea.value = before + mentionText + after;
+                textarea.setSelectionRange(start + mentionText.length, start + mentionText.length);
+            } else {
+                // 선택영역이 없는 경우: '@' + email을 현재 커서에 삽입
+                var before = textarea.value.slice(0, start);
+                var after = textarea.value.slice(start);
+                textarea.value = before + mentionText + after;
+                textarea.setSelectionRange(start + mentionText.length, start + mentionText.length);
+            }
+        }
+
         function subscribePresence() {
             if (!popup.dataset.creativeId) return;
             if (presenceSubscription) { presenceSubscription.unsubscribe(); }
@@ -117,6 +137,14 @@ if (!window.commentsInitialized) {
                     }
                 }
                 startY = null;
+            });
+
+            participants.addEventListener('click', function(e) {
+                var avatar = e.target.closest('.comment-presence-avatar');
+                if (avatar && avatar.dataset.email) {
+                    insertMention(avatar.dataset.email);
+                    textarea.focus();
+                }
             });
 
             list.addEventListener('scroll', function() {

--- a/app/javascript/mention_menu.js
+++ b/app/javascript/mention_menu.js
@@ -22,7 +22,7 @@ if (!window.mentionMenuInitialized) {
 
     function insert(email) {
       var pos = textarea.selectionStart;
-      var before = textarea.value.slice(0, pos).replace(/@[^@\s]*$/, '@' + email);
+      var before = textarea.value.slice(0, pos).replace(/@[^@\s]*$/, `@${email} `);
       textarea.value = before + textarea.value.slice(pos);
     }
 

--- a/app/views/comments/_presence_avatars.html.erb
+++ b/app/views/comments/_presence_avatars.html.erb
@@ -3,6 +3,6 @@
   <% accessible_users.uniq.each do |u| %>
     <% classes = 'avatar comment-presence-avatar' %>
     <% classes += ' inactive' unless present_ids.include?(u.id) %>
-    <%= render AvatarComponent.new(user: u, size: 20, classes: classes) %>
+    <%= render AvatarComponent.new(user: u, size: 20, classes: classes, data: { email: u.email }) %>
   <% end %>
 </div>


### PR DESCRIPTION
## Summary
- allow passing extra `data` attrs to `AvatarComponent`
- include each user's email in the presence avatars list
- insert mentions when avatars are clicked in the comment popup

## Testing
- `./bin/rubocop -a`
- `bundle exec rake test`


------
https://chatgpt.com/codex/tasks/task_e_68625f8844ac8326b8b73f0c4267c685