### PR TITLE
Implement lazy loading for creative tree expansion

### DIFF
--- a/app/helpers/creatives_helper.rb
+++ b/app/helpers/creatives_helper.rb
@@ -85,9 +85,27 @@ module CreativesHelper
         expanded = expanded_from_expanded_state(creative.id, @expanded_state_map)
         render_next_block = ->(level) {
           filters = params.to_unsafe_h.except(:id).present?
-          ((filtered_children.any?) ? content_tag(:div, id: "creative-children-#{creative.id}", class: "creative-children", style: "#{filters || expanded ? "" : "display: none;"}", data: { expanded: expanded }) {
-            render_creative_tree(filtered_children, level, select_mode: select_mode, max_level: max_level)
-          }: "".html_safe)
+          if filtered_children.any?
+            content_tag(
+              :div,
+              id: "creative-children-#{creative.id}",
+              class: "creative-children",
+              style: "#{filters || expanded ? "" : "display: none;"}",
+              data: {
+                expanded: expanded,
+                loaded: (filters || expanded),
+                load_url: children_creative_path(creative, level: level, select_mode: select_mode ? 1 : 0)
+              }
+            ) do
+              if filters || expanded
+                render_creative_tree(filtered_children, level, select_mode: select_mode, max_level: max_level)
+              else
+                "".html_safe
+              end
+            end
+          else
+            "".html_safe
+          end
         }
 
         skip = false

--- a/app/helpers/creatives_helper.rb
+++ b/app/helpers/creatives_helper.rb
@@ -84,7 +84,7 @@ module CreativesHelper
         filtered_children = params[:comment] == "true" ? [] : creative.children_with_permission(Current.user)
         expanded = expanded_from_expanded_state(creative.id, @expanded_state_map)
         render_next_block = ->(level) {
-          filters = params.to_unsafe_h.except(:id).present?
+          filters = params.to_unsafe_h.except(:id, :controller, :action).present?
           if filtered_children.any?
             content_tag(
               :div,

--- a/app/javascript/creatives_expansion.js
+++ b/app/javascript/creatives_expansion.js
@@ -2,6 +2,14 @@ if (!window.creativesExpansionInitialized) {
     window.creativesExpansionInitialized = true;
 
     function expand(childrenDiv, btn) {
+        if (childrenDiv.dataset.loaded !== "true") {
+            fetch(childrenDiv.dataset.loadUrl)
+                .then(r => r.text())
+                .then(html => {
+                    childrenDiv.innerHTML = html;
+                    childrenDiv.dataset.loaded = "true";
+                });
+        }
         childrenDiv.style.display = "";
         btn.textContent = "▼";
     }
@@ -22,8 +30,11 @@ if (!window.creativesExpansionInitialized) {
                 const childrenDiv = document.getElementById(`creative-children-${creativeId}`);
                 if (childrenDiv) {
                     const isHidden = childrenDiv.style.display === "none";
-                    childrenDiv.style.display = isHidden ? "" : "none";
-                    btn.textContent = isHidden ? "▼" : "▶";
+                    if (isHidden) {
+                        expand(childrenDiv, btn);
+                    } else {
+                        collapse(childrenDiv, btn);
+                    }
                     // Store expansion state in DB, scoped by currentCreativeId and node_id
                     let url = `/creative_expanded_states/toggle`;
                     fetch(url, {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,7 @@ Rails.application.routes.draw do
       get :export_markdown
     end
     member do
+      get :children
       post :share, to: "creatives#share", as: :share_creative
     end
   end


### PR DESCRIPTION
## Summary
- implement `children` member endpoint for creatives
- output children HTML on demand via new controller action
- adjust `render_creative_tree` helper to not render subtrees until expanded and supply load URL
- update JS to fetch subtree when expanding
- add route for new endpoint

## Testing
- `./bin/rubocop -a`
- `bundle exec rails test`
- `bundle exec rspec` *(fails: WebDriver unable to download Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_686391af1c2c832681f89acb3c41b442