### PR TITLE
Fix creative deletion with comments

### DIFF
--- a/app/models/creative.rb
+++ b/app/models/creative.rb
@@ -5,6 +5,7 @@ class Creative < ApplicationRecord
   has_many :subscribers, dependent: :destroy
   has_rich_text :description
   has_many :comments, dependent: :destroy
+  has_many :comment_read_pointers, dependent: :delete_all
 
   has_closure_tree order: :sequence, name_column: :description
 

--- a/test/models/creative_test.rb
+++ b/test/models/creative_test.rb
@@ -54,4 +54,21 @@ class CreativeTest < ActiveSupport::TestCase
 
     Current.reset
   end
+
+  test "destroying creative removes comment read pointers" do
+    user = users(:one)
+    Current.session = OpenStruct.new(user: user)
+
+    creative = Creative.create!(user: user, description: "Parent")
+    Comment.create!(creative: creative, user: user, content: "hi")
+    CommentReadPointer.create!(user: user, creative: creative)
+
+    assert_difference("Creative.count", -1) do
+      assert_nothing_raised { creative.destroy }
+    end
+
+    assert_empty CommentReadPointer.where(creative_id: creative.id)
+
+    Current.reset
+  end
 end


### PR DESCRIPTION
## Summary
- remove leftover comment read pointers when destroying creatives
- test destroying creative with comments and pointers

## Testing
- `./bin/rubocop -a`
- `rails test`

------
https://chatgpt.com/codex/tasks/task_e_6863acc2c9608326b700dc75ca9dd639