### PR TITLE
Show plan list as timeline component

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -171,6 +171,43 @@ button {
     border-top: 1px solid var(--color-border);
 }
 
+.timeline {
+    position: relative;
+    padding-left: 1.5em;
+}
+
+.timeline::before {
+    content: '';
+    position: absolute;
+    left: 0.5em;
+    top: 0;
+    bottom: 0;
+    width: 2px;
+    background: var(--color-border);
+}
+
+.timeline-date {
+    font-weight: bold;
+    margin: 0.5em 0 0.25em;
+}
+
+.timeline-item {
+    position: relative;
+    margin-bottom: 0.5em;
+    padding-left: 1em;
+}
+
+.timeline-item::before {
+    content: '';
+    position: absolute;
+    left: -0.5em;
+    top: 0.45em;
+    width: 0.6em;
+    height: 0.6em;
+    background: var(--color-btn-bg);
+    border-radius: 50%;
+}
+
 #inbox-panel.slide-panel {
     position: fixed;
     top: 0;

--- a/app/components/plans_timeline_component.html.erb
+++ b/app/components/plans_timeline_component.html.erb
@@ -1,0 +1,26 @@
+<div class="timeline">
+  <% grouped_plans.each do |date, date_plans| %>
+    <div class="timeline-date"><%= l date %></div>
+    <% date_plans.each do |plan| %>
+      <div class="timeline-item">
+        <% path = params[:id].present? ? creatives_path(params[:id], tags: [plan.id]) : creatives_path(tags: [plan.id]) %>
+        <%= link_to(plan.name.presence || l(plan.target_date), path) %>
+        <% if plan.owner == Current.user %>
+          <%= button_to 'X', plan_path(plan), method: :delete, data: { confirm: t('plans.delete_confirm', default: 'Are you sure?') }, form: { style: 'display:inline;' }, class: 'delete-plan-btn' %>
+        <% end %>
+      </div>
+    <% end %>
+  <% end %>
+  <hr>
+  <%= form_with(model: Plan.new, url: plans_path, local: true) do |form| %>
+    <div>
+      <%= form.text_field :name, placeholder: t('plans.plan_name') %>
+    </div>
+    <div>
+      <%= form.date_field :target_date, placeholder: t('plans.target_date') %>
+    </div>
+    <div>
+      <%= form.submit t('plans.add_plan') %>
+    </div>
+  <% end %>
+</div>

--- a/app/components/plans_timeline_component.rb
+++ b/app/components/plans_timeline_component.rb
@@ -1,0 +1,11 @@
+class PlansTimelineComponent < ViewComponent::Base
+  def initialize(plans:)
+    @plans = plans.order(:target_date)
+  end
+
+  attr_reader :plans
+
+  def grouped_plans
+    @grouped_plans ||= @plans.group_by(&:target_date)
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -134,28 +134,7 @@
     </nav>
 
     <div id="plans-list-area" style="display:none;">
-      <% Plan.where(owner: Current.user).or(Plan.where(owner: nil)).each do |plan| %>
-        <div style="padding: 4px 0;">
-          <% path = params[:id].present? ? creatives_path(params[:id], tags: [plan.id]) : creatives_path(tags: [plan.id]) %>
-          <%= link_to (plan.name.presence || plan.target_date), path %>
-          <%= plan.target_date %>
-          <% if plan.owner == Current.user %>
-            <%= button_to 'X', plan_path(plan), method: :delete, data: { confirm: t('plans.delete_confirm', default: 'Are you sure?') }, form: { style: 'display:inline;' }, class: 'delete-plan-btn' %>
-          <% end %>
-        </div>
-      <% end %>
-      <hr>
-      <%= form_with(model: Plan.new, url: plans_path, local: true) do |form| %>
-        <div>
-          <%= form.text_field :name, placeholder: t("plans.plan_name") %>
-        </div>
-        <div>
-          <%= form.date_field :target_date, placeholder: t("plans.target_date") %>
-        </div>
-        <div>
-          <%= form.submit t("plans.add_plan") %>
-        </div>
-      <% end %>
+      <%= render PlansTimelineComponent.new(plans: Plan.where(owner: Current.user).or(Plan.where(owner: nil))) %>
     </div>
 
     <div id="inbox-panel" class="slide-panel">

--- a/config/locales/datetime.ko.yml
+++ b/config/locales/datetime.ko.yml
@@ -1,4 +1,7 @@
 ko:
+  date:
+    formats:
+      default: "%Y-%m-%d"
   time:
     formats:
       long: "%Y년 %m월 %d일 %H:%M:%S"


### PR DESCRIPTION
## Summary
- create `PlansTimelineComponent` for rendering plans grouped by date
- use the new component in the layout instead of plain list
- add basic timeline styling

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: error sending request for Chrome driver)*

------
https://chatgpt.com/codex/tasks/task_e_6863f086a1bc83268dfa608acd7dda46