### PR TITLE
Mark inbox link as read when clicked

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -237,6 +237,18 @@
             document.querySelectorAll('.inbox-item .item-link').forEach(function(a) {
               a.addEventListener('click', function() {
                 localStorage.setItem('inboxOpen', '1');
+                var item = a.closest('.inbox-item');
+                if (item && item.dataset.id) {
+                  fetch('/inbox/' + item.dataset.id, {
+                    method: 'PATCH',
+                    headers: {
+                      'Content-Type': 'application/json',
+                      'X-CSRF-Token': document.querySelector('meta[name=csrf-token]').content
+                    },
+                    body: JSON.stringify({ state: 'read' }),
+                    keepalive: true
+                  });
+                }
               });
             });
           }


### PR DESCRIPTION
## Summary
- update JS to mark an inbox item as read when its link is clicked

## Testing
- `./bin/rubocop -a`
- `bundle exec rake test`


------
https://chatgpt.com/codex/tasks/task_e_68647c69a6c483269ee66e593bca67f6