### PR TITLE
Implement inline creative editor

### DIFF
--- a/app/assets/stylesheets/creatives.css
+++ b/app/assets/stylesheets/creatives.css
@@ -102,6 +102,13 @@
     text-decoration: none;
     cursor: pointer;
 }
+.edit-inline-btn {
+    margin-left: 6px;
+    font-size: 12px;
+    cursor: pointer;
+    background: none;
+    border: none;
+}
 
 .creative-row-actions {
     visibility: hidden;

--- a/app/assets/stylesheets/creatives.css
+++ b/app/assets/stylesheets/creatives.css
@@ -109,6 +109,13 @@
     background: none;
     border: none;
 }
+#inline-add {
+    margin-left: 6px;
+    font-size: 12px;
+    cursor: pointer;
+    background: none;
+    border: none;
+}
 
 .creative-row-actions {
     visibility: hidden;

--- a/app/components/creative_component.html.erb
+++ b/app/components/creative_component.html.erb
@@ -11,6 +11,9 @@
                     class: 'add-creative-btn',
                     style: (' visibility: hidden;' unless creative.has_permission?(Current.user, :write)),
                     title: t('creatives.help.add_child_creative')) %>
+        <% if creative.has_permission?(Current.user, :write) %>
+          <button type="button" class="edit-inline-btn" data-creative-id="<%= creative.id %>">✎</button>
+        <% end %>
         </div>
       </div>
       <%= content %>

--- a/app/controllers/creatives_controller.rb
+++ b/app/controllers/creatives_controller.rb
@@ -54,7 +54,16 @@ class CreativesController < ApplicationController
 
   def show
     index
-    render :index
+    respond_to do |format|
+      format.html { render :index }
+      format.json do
+        render json: {
+          id: @creative.id,
+          description: @creative.effective_description,
+          progress: @creative.progress
+        }
+      end
+    end
   end
 
   def new

--- a/app/javascript/creative_row_editor.js
+++ b/app/javascript/creative_row_editor.js
@@ -45,10 +45,10 @@ if (!window.creativeRowEditorInitialized) {
 
     function move(delta) {
       if (!currentTree) return;
-      let target = delta < 0 ? currentTree.previousElementSibling : currentTree.nextElementSibling;
-      while (target && !target.classList.contains('creative-tree')) {
-        target = delta < 0 ? target.previousElementSibling : target.nextElementSibling;
-      }
+      const trees = Array.from(document.querySelectorAll('.creative-tree'));
+      const index = trees.indexOf(currentTree);
+      if (index === -1) return;
+      const target = trees[index + delta];
       if (!target) return;
       currentTree = target;
       target.appendChild(template);

--- a/app/javascript/creative_row_editor.js
+++ b/app/javascript/creative_row_editor.js
@@ -136,6 +136,24 @@ if (!window.creativeRowEditorInitialized) {
     });
     editor.addEventListener('trix-change', scheduleSave);
 
+    editor.addEventListener('keydown', function(e) {
+      if (e.key !== 'ArrowUp' && e.key !== 'ArrowDown') return;
+      const range = editor.editor.getSelectedRange();
+      if (!range) return;
+      const start = range[0];
+      const end = range[1];
+      const length = editor.editor.getDocument().toString().length;
+      if (e.key === 'ArrowUp' && start === 0 && end === 0) {
+        e.preventDefault();
+        if (pendingSave) saveForm();
+        move(-1);
+      } else if (e.key === 'ArrowDown' && start === length && end === length) {
+        e.preventDefault();
+        if (pendingSave) saveForm();
+        move(1);
+      }
+    });
+
     if (closeBtn) {
       closeBtn.addEventListener('click', hideCurrent);
     }

--- a/app/javascript/creative_row_editor.js
+++ b/app/javascript/creative_row_editor.js
@@ -12,7 +12,12 @@ if (!window.creativeRowEditorInitialized) {
     const progressValue = document.getElementById('inline-progress-value');
     const upBtn = document.getElementById('inline-move-up');
     const downBtn = document.getElementById('inline-move-down');
+    const addBtn = document.getElementById('inline-add');
     const closeBtn = document.getElementById('inline-close');
+
+    const methodInput = document.getElementById('inline-method');
+    const parentInput = document.getElementById('inline-parent-id');
+    const afterInput = document.getElementById('inline-after-id');
 
     let currentTree = null;
     let saveTimer = null;
@@ -44,29 +49,64 @@ if (!window.creativeRowEditorInitialized) {
         });
     }
 
+    function refreshChildren(tree) {
+      const container = tree.querySelector('.creative-children');
+      if (!container) { location.reload(); return; }
+      const url = container.dataset.loadUrl;
+      if (!url) { location.reload(); return; }
+      fetch(url)
+        .then(r => r.text())
+        .then(html => {
+          container.innerHTML = html;
+          attachButtons();
+        });
+    }
+
     function saveForm() {
       clearTimeout(saveTimer);
+      const method = methodInput.value === 'patch' ? 'PATCH' : 'POST';
       pendingSave = false;
       if (!form.action) return Promise.resolve();
       return fetch(form.action, {
-        method: 'PATCH',
+        method: method,
         headers: {
           'Accept': 'application/json',
           'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').content
         },
         body: new FormData(form),
         credentials: 'same-origin'
+      }).then(function(r) {
+        if (!r.ok) return r;
+        return r.json().then(function(data) {
+          if (method === 'POST' && data.id) {
+            form.action = `/creatives/${data.id}`;
+            methodInput.value = 'patch';
+            form.dataset.creativeId = data.id;
+            if (currentTree) currentTree.id = `creative-${data.id}`;
+            const parentTree = parentInput.value ? document.getElementById(`creative-${parentInput.value}`) : null;
+            if (parentTree) refreshChildren(parentTree); else location.reload();
+          } else if (method === 'PATCH') {
+            const tree = document.getElementById(`creative-${form.dataset.creativeId}`);
+            if (tree) refreshRow(tree);
+          }
+        });
       });
     }
 
     function hideCurrent() {
       if (!currentTree) return;
       const tree = currentTree;
+      const wasNew = !form.dataset.creativeId;
       currentTree = null;
       template.style.display = 'none';
-      saveForm().then(() => {
-        showRow(tree);
-        refreshRow(tree);
+      const p = pendingSave ? saveForm() : Promise.resolve();
+      p.then(() => {
+        if (wasNew && !form.dataset.creativeId) {
+          tree.remove();
+        } else {
+          showRow(tree);
+          refreshRow(tree);
+        }
       });
     }
 
@@ -118,11 +158,57 @@ if (!window.creativeRowEditorInitialized) {
       hideRow(target);
       target.appendChild(template);
       template.style.display = 'block';
-      saveForm().then(() => {
+      const wasNew = !form.dataset.creativeId;
+      const p = pendingSave ? saveForm() : Promise.resolve();
+      p.then(() => {
+        if (wasNew && !form.dataset.creativeId) {
+          prev.remove();
+        } else {
+          showRow(prev);
+          refreshRow(prev);
+        }
+      });
+      loadCreative(target.id.replace('creative-', ''));
+    }
+
+    function addNew() {
+      if (!currentTree) return;
+      const prev = currentTree;
+      const childContainer = prev.querySelector('.creative-children');
+      const firstChild = childContainer && childContainer.querySelector('.creative-tree');
+      let parentTree, container, insertBefore, afterId = '';
+      if (firstChild) {
+        parentTree = prev;
+        container = childContainer;
+        insertBefore = firstChild;
+      } else {
+        parentTree = prev.parentElement.closest('.creative-tree');
+        container = prev.parentNode;
+        afterId = prev.id.replace('creative-', '');
+        insertBefore = prev.nextSibling;
+      }
+      const p = pendingSave ? saveForm() : Promise.resolve();
+      p.then(() => {
         showRow(prev);
         refreshRow(prev);
       });
-      loadCreative(target.id.replace('creative-', ''));
+      const newTree = document.createElement('div');
+      newTree.className = 'creative-tree';
+      if (insertBefore) container.insertBefore(newTree, insertBefore); else container.appendChild(newTree);
+      currentTree = newTree;
+      newTree.appendChild(template);
+      template.style.display = 'block';
+      form.action = '/creatives';
+      methodInput.value = '';
+      form.dataset.creativeId = '';
+      parentInput.value = parentTree ? parentTree.id.replace('creative-', '') : '';
+      afterInput.value = afterId;
+      descriptionInput.value = '';
+      editor.editor.loadHTML('');
+      progressInput.value = 0;
+      progressValue.textContent = 0;
+      pendingSave = false;
+      editor.focus();
     }
 
     function scheduleSave() {
@@ -167,6 +253,10 @@ if (!window.creativeRowEditorInitialized) {
       if (pendingSave) saveForm();
       move(1);
     });
+
+    if (addBtn) {
+      addBtn.addEventListener('click', addNew);
+    }
 
     attachButtons();
   });

--- a/app/javascript/creative_row_editor.js
+++ b/app/javascript/creative_row_editor.js
@@ -15,6 +15,7 @@ if (!window.creativeRowEditorInitialized) {
 
     let currentTree = null;
     let saveTimer = null;
+    let pendingSave = false;
 
     function attachButtons() {
       document.querySelectorAll('.edit-inline-btn').forEach(function(btn) {
@@ -56,12 +57,14 @@ if (!window.creativeRowEditorInitialized) {
     }
 
     function scheduleSave() {
+      pendingSave = true;
       clearTimeout(saveTimer);
       saveTimer = setTimeout(saveForm, 5000);
     }
 
     function saveForm() {
       clearTimeout(saveTimer);
+      pendingSave = false;
       if (!form.action) return;
       fetch(form.action, {
         method: 'PATCH',
@@ -81,11 +84,11 @@ if (!window.creativeRowEditorInitialized) {
     editor.addEventListener('trix-change', scheduleSave);
 
     upBtn.addEventListener('click', function() {
-      scheduleSave();
+      if (pendingSave) saveForm();
       move(-1);
     });
     downBtn.addEventListener('click', function() {
-      scheduleSave();
+      if (pendingSave) saveForm();
       move(1);
     });
 

--- a/app/javascript/creative_row_editor.js
+++ b/app/javascript/creative_row_editor.js
@@ -1,0 +1,94 @@
+if (!window.creativeRowEditorInitialized) {
+  window.creativeRowEditorInitialized = true;
+
+  document.addEventListener('turbo:load', function() {
+    const template = document.getElementById('inline-edit-form');
+    if (!template) return;
+
+    const form = document.getElementById('inline-edit-form-element');
+    const descriptionInput = document.getElementById('inline-creative-description');
+    const editor = template.querySelector('trix-editor');
+    const progressInput = document.getElementById('inline-creative-progress');
+    const progressValue = document.getElementById('inline-progress-value');
+    const upBtn = document.getElementById('inline-move-up');
+    const downBtn = document.getElementById('inline-move-down');
+
+    let currentTree = null;
+    let saveTimer = null;
+
+    function attachButtons() {
+      document.querySelectorAll('.edit-inline-btn').forEach(function(btn) {
+        const tree = btn.closest('.creative-tree');
+        if (!tree) return;
+        btn.addEventListener('click', function(e) {
+          e.preventDefault();
+          currentTree = tree;
+          tree.appendChild(template);
+          template.style.display = 'block';
+          loadCreative(tree.id.replace('creative-', ''));
+        });
+      });
+    }
+
+    function loadCreative(id) {
+      fetch(`/creatives/${id}.json`)
+        .then(r => r.json())
+        .then(data => {
+          form.action = `/creatives/${data.id}`;
+          form.dataset.creativeId = data.id;
+          descriptionInput.value = data.description || '';
+          editor.editor.loadHTML(data.description || '');
+          progressInput.value = data.progress || 0;
+          progressValue.textContent = data.progress || 0;
+        });
+    }
+
+    function move(delta) {
+      if (!currentTree) return;
+      let target = delta < 0 ? currentTree.previousElementSibling : currentTree.nextElementSibling;
+      while (target && !target.classList.contains('creative-tree')) {
+        target = delta < 0 ? target.previousElementSibling : target.nextElementSibling;
+      }
+      if (!target) return;
+      currentTree = target;
+      target.appendChild(template);
+      loadCreative(target.id.replace('creative-', ''));
+    }
+
+    function scheduleSave() {
+      clearTimeout(saveTimer);
+      saveTimer = setTimeout(saveForm, 5000);
+    }
+
+    function saveForm() {
+      clearTimeout(saveTimer);
+      if (!form.action) return;
+      fetch(form.action, {
+        method: 'PATCH',
+        headers: {
+          'Accept': 'application/json',
+          'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').content
+        },
+        body: new FormData(form),
+        credentials: 'same-origin'
+      });
+    }
+
+    progressInput.addEventListener('input', function() {
+      progressValue.textContent = progressInput.value;
+      scheduleSave();
+    });
+    editor.addEventListener('trix-change', scheduleSave);
+
+    upBtn.addEventListener('click', function() {
+      scheduleSave();
+      move(-1);
+    });
+    downBtn.addEventListener('click', function() {
+      scheduleSave();
+      move(1);
+    });
+
+    attachButtons();
+  });
+}

--- a/app/javascript/creative_row_editor.js
+++ b/app/javascript/creative_row_editor.js
@@ -102,6 +102,7 @@ if (!window.creativeRowEditorInitialized) {
           editor.editor.loadHTML(data.description || '');
           progressInput.value = data.progress || 0;
           progressValue.textContent = data.progress || 0;
+          editor.focus();
         });
     }
 
@@ -147,7 +148,7 @@ if (!window.creativeRowEditorInitialized) {
         e.preventDefault();
         if (pendingSave) saveForm();
         move(-1);
-      } else if (e.key === 'ArrowDown' && start === length && end === length) {
+      } else if (e.key === 'ArrowDown' && start >= length - 1 && end >= length - 1) {
         e.preventDefault();
         if (pendingSave) saveForm();
         move(1);

--- a/app/views/creatives/_inline_edit_form.html.erb
+++ b/app/views/creatives/_inline_edit_form.html.erb
@@ -1,0 +1,16 @@
+<div id="inline-edit-form" style="display:none;">
+  <form id="inline-edit-form-element" method="post">
+    <input type="hidden" name="_method" value="patch" />
+    <input type="hidden" name="authenticity_token" value="<%= form_authenticity_token %>" />
+    <input type="hidden" id="inline-creative-description" name="creative[description]" />
+    <trix-editor input="inline-creative-description"></trix-editor>
+    <div style="margin-top:0.5em;display:flex;align-items:center;gap:0.5em;">
+      <input type="range" id="inline-creative-progress" name="creative[progress]" min="0" max="1" step="0.01">
+      <span id="inline-progress-value">0</span>
+    </div>
+    <div style="margin-top:0.5em;">
+      <button type="button" id="inline-move-up">▲</button>
+      <button type="button" id="inline-move-down">▼</button>
+    </div>
+  </form>
+</div>

--- a/app/views/creatives/_inline_edit_form.html.erb
+++ b/app/views/creatives/_inline_edit_form.html.erb
@@ -11,6 +11,7 @@
     <div style="margin-top:0.5em;">
       <button type="button" id="inline-move-up">▲</button>
       <button type="button" id="inline-move-down">▼</button>
+      <button type="button" id="inline-close">✖</button>
     </div>
   </form>
 </div>

--- a/app/views/creatives/_inline_edit_form.html.erb
+++ b/app/views/creatives/_inline_edit_form.html.erb
@@ -1,8 +1,10 @@
 <div id="inline-edit-form" style="display:none;">
   <form id="inline-edit-form-element" method="post">
-    <input type="hidden" name="_method" value="patch" />
+    <input type="hidden" id="inline-method" name="_method" value="patch" />
     <input type="hidden" name="authenticity_token" value="<%= form_authenticity_token %>" />
     <input type="hidden" id="inline-creative-description" name="creative[description]" />
+    <input type="hidden" id="inline-parent-id" name="creative[parent_id]" />
+    <input type="hidden" id="inline-after-id" name="after_id" />
     <trix-editor input="inline-creative-description"></trix-editor>
     <div style="margin-top:0.5em;display:flex;align-items:center;gap:0.5em;">
       <input type="range" id="inline-creative-progress" name="creative[progress]" min="0" max="1" step="0.01">
@@ -11,6 +13,7 @@
     <div style="margin-top:0.5em;">
       <button type="button" id="inline-move-up">▲</button>
       <button type="button" id="inline-move-down">▼</button>
+      <button type="button" id="inline-add">＋</button>
       <button type="button" id="inline-close">✖</button>
     </div>
   </form>

--- a/app/views/creatives/index.html.erb
+++ b/app/views/creatives/index.html.erb
@@ -96,6 +96,7 @@
 </div>
 
 <%= render 'comments/comments_popup' %>
+<%= render 'inline_edit_form' %>
 
 <%= render 'set_plan_modal' %>
 
@@ -108,3 +109,4 @@
 <%= javascript_include_tag 'action_text_attachment_link', defer: true %>
 <%= javascript_include_tag 'export_to_markdown', defer: true %>
 <%= javascript_include_tag 'mobile_actions', defer: true %>
+<%= javascript_include_tag 'creative_row_editor', defer: true %>


### PR DESCRIPTION
## Summary
- add inline edit button to each creative row
- provide hidden inline edit form and new JS for editing
- show creative info as JSON for the inline editor
- include new script and styles

## Testing
- `./bin/rubocop -a`

------
https://chatgpt.com/codex/tasks/task_e_6864bc51a4dc832696bcabc2de34ea9c