### PR TITLE
Center timeline on today with quick jump

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -240,6 +240,10 @@ button {
     font-size: 0.8em;
 }
 
+.plan-form-container {
+    padding: 0.5em;
+}
+
 .plan-bar {
     position: absolute;
     height: 20px;

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -208,6 +208,59 @@ button {
     border-radius: 50%;
 }
 
+.horizontal-timeline {
+    overflow-x: auto;
+    position: relative;
+    padding-bottom: 1em;
+}
+
+.plans-timeline-wrapper {
+    position: relative;
+}
+
+.plans-timeline-wrapper #timeline-today-btn {
+    position: absolute;
+    top: 0;
+    right: 0;
+    z-index: 1;
+}
+
+.horizontal-timeline .timeline-scroll {
+    position: relative;
+    white-space: nowrap;
+    height: 120px;
+}
+
+.horizontal-timeline .timeline-day {
+    display: inline-block;
+    width: 80px;
+    box-sizing: border-box;
+    border-right: 1px solid var(--color-border);
+    text-align: center;
+    font-size: 0.8em;
+}
+
+.plan-bar {
+    position: absolute;
+    height: 20px;
+    background: var(--color-border);
+    border-radius: 4px;
+    overflow: hidden;
+}
+
+.plan-bar .plan-progress {
+    background: var(--color-btn-bg);
+    height: 100%;
+}
+
+.plan-bar .plan-label {
+    position: absolute;
+    left: 2px;
+    top: 2px;
+    font-size: 0.75em;
+    color: var(--color-bg);
+}
+
 #inbox-panel.slide-panel {
     position: fixed;
     top: 0;

--- a/app/components/plans_timeline_component.html.erb
+++ b/app/components/plans_timeline_component.html.erb
@@ -1,26 +1,16 @@
-<div class="timeline">
-  <% grouped_plans.each do |date, date_plans| %>
-    <div class="timeline-date"><%= l date %></div>
-    <% date_plans.each do |plan| %>
-      <div class="timeline-item">
-        <% path = params[:id].present? ? creatives_path(params[:id], tags: [plan.id]) : creatives_path(tags: [plan.id]) %>
-        <%= link_to(plan.name.presence || l(plan.target_date), path) %>
-        <% if plan.owner == Current.user %>
-          <%= button_to 'X', plan_path(plan), method: :delete, data: { confirm: t('plans.delete_confirm', default: 'Are you sure?') }, form: { style: 'display:inline;' }, class: 'delete-plan-btn' %>
-        <% end %>
-      </div>
-    <% end %>
-  <% end %>
-  <hr>
-  <%= form_with(model: Plan.new, url: plans_path, local: true) do |form| %>
-    <div>
-      <%= form.text_field :name, placeholder: t('plans.plan_name') %>
-    </div>
-    <div>
-      <%= form.date_field :target_date, placeholder: t('plans.target_date') %>
-    </div>
-    <div>
-      <%= form.submit t('plans.add_plan') %>
-    </div>
-  <% end %>
+<div class="plans-timeline-wrapper">
+  <button id="timeline-today-btn" type="button"><%= t('plans.today', default: '오늘') %></button>
+  <div id="plans-timeline" class="horizontal-timeline" data-plans="<%= raw plan_data.to_json %>" data-start-date="<%= @start_date %>" data-end-date="<%= @end_date %>"></div>
 </div>
+<hr>
+<%= form_with(model: Plan.new, url: plans_path, local: true) do |form| %>
+  <div>
+    <%= form.text_field :name, placeholder: t('plans.plan_name') %>
+  </div>
+  <div>
+    <%= form.date_field :target_date, placeholder: t('plans.target_date') %>
+  </div>
+  <div>
+    <%= form.submit t('plans.add_plan') %>
+  </div>
+<% end %>

--- a/app/components/plans_timeline_component.html.erb
+++ b/app/components/plans_timeline_component.html.erb
@@ -1,8 +1,9 @@
 <div class="plans-timeline-wrapper">
   <button id="timeline-today-btn" type="button"><%= t('plans.today', default: '오늘') %></button>
-  <div id="plans-timeline" class="horizontal-timeline" data-plans="<%= raw plan_data.to_json %>" data-start-date="<%= @start_date %>" data-end-date="<%= @end_date %>"></div>
+  <div id="plans-timeline" class="horizontal-timeline" data-plans='<%= raw plan_data.to_json %>' data-start-date="<%= @start_date %>" data-end-date="<%= @end_date %>"></div>
 </div>
 <hr>
+<div class="plan-form-container">
 <%= form_with(model: Plan.new, url: plans_path, local: true) do |form| %>
   <div>
     <%= form.text_field :name, placeholder: t('plans.plan_name') %>
@@ -14,3 +15,4 @@
     <%= form.submit t('plans.add_plan') %>
   </div>
 <% end %>
+</div>

--- a/app/components/plans_timeline_component.rb
+++ b/app/components/plans_timeline_component.rb
@@ -1,11 +1,23 @@
 class PlansTimelineComponent < ViewComponent::Base
   def initialize(plans:)
-    @plans = plans.order(:target_date)
+    @start_date = Date.current - 30
+    @end_date = Date.current + 30
+    @plans = plans
+      .where("target_date >= ? AND created_at <= ?", @start_date, @end_date)
+      .order(:created_at)
   end
 
-  attr_reader :plans
+  attr_reader :plans, :start_date, :end_date
 
-  def grouped_plans
-    @grouped_plans ||= @plans.group_by(&:target_date)
+  def plan_data
+    @plan_data ||= @plans.map do |plan|
+      {
+        id: plan.id,
+        name: plan.name.presence || I18n.l(plan.target_date),
+        created_at: plan.created_at.to_date,
+        target_date: plan.target_date,
+        progress: plan.progress
+      }
+    end
   end
 end

--- a/app/javascript/plans_timeline.js
+++ b/app/javascript/plans_timeline.js
@@ -1,0 +1,151 @@
+if (!window.plansTimelineInitialized) {
+  window.plansTimelineInitialized = true;
+
+  document.addEventListener('turbo:load', function() {
+    var container = document.getElementById('plans-timeline');
+    if (!container) return;
+
+    var plans = [];
+    try { plans = JSON.parse(container.dataset.plans || '[]'); } catch(e) {}
+    plans = plans.map(function(p) {
+      p.created_at = new Date(p.created_at);
+      p.target_date = new Date(p.target_date);
+      return p;
+    });
+
+    var dayWidth = 80; // pixels per day
+    var rowHeight = 26;
+    var startDate = new Date(container.dataset.startDate || new Date());
+    var endDate = new Date(container.dataset.endDate || new Date());
+
+    var scroll = document.createElement('div');
+    scroll.className = 'timeline-scroll';
+    container.appendChild(scroll);
+
+    function dayDiff(d1, d2) {
+      return Math.round((d1 - d2) / 86400000);
+    }
+
+    function createDay(date) {
+      var el = document.createElement('div');
+      el.className = 'timeline-day';
+      el.dataset.date = date.toISOString().slice(0,10);
+      el.innerHTML = '<div class="day-label">' + (date.getMonth()+1) + '/' + date.getDate() + '</div>';
+      return el;
+    }
+
+    function renderDays(from, to, prepend) {
+      var date = new Date(from);
+      while (date <= to) {
+        var el = createDay(new Date(date));
+        if (prepend) {
+          scroll.insertBefore(el, scroll.firstChild);
+        } else {
+          scroll.appendChild(el);
+        }
+        date.setDate(date.getDate() + 1);
+      }
+    }
+
+    var planEls = [];
+    function renderPlans() {
+      plans.forEach(function(plan, idx) {
+        var el = document.createElement('div');
+        el.className = 'plan-bar';
+        var left = dayDiff(plan.created_at, startDate) * dayWidth;
+        var width = (dayDiff(plan.target_date, plan.created_at) + 1) * dayWidth;
+        el.style.left = left + 'px';
+        el.style.top = (idx * rowHeight + 40) + 'px';
+        el.style.width = width + 'px';
+
+        var prog = document.createElement('div');
+        prog.className = 'plan-progress';
+        prog.style.width = (plan.progress * 100) + '%';
+        el.appendChild(prog);
+
+        var label = document.createElement('span');
+        label.className = 'plan-label';
+        label.textContent = plan.name + ' ' + Math.round(plan.progress * 100) + '%';
+        el.appendChild(label);
+
+        scroll.appendChild(el);
+        planEls.push({ el: el, plan: plan });
+      });
+    }
+
+    function updatePlanPositions() {
+      var visibleWidth = dayDiff(endDate, startDate) * dayWidth;
+      planEls.forEach(function(item, idx) {
+        var plan = item.plan;
+        var left = dayDiff(plan.created_at, startDate) * dayWidth;
+        var width = (dayDiff(plan.target_date, plan.created_at) + 1) * dayWidth;
+        var right = left + width;
+
+        if (right < 0 || left > visibleWidth) {
+          item.el.style.display = 'none';
+          return;
+        }
+
+        item.el.style.display = '';
+        item.el.style.left = left + 'px';
+        item.el.style.top = (idx * rowHeight + 40) + 'px';
+        item.el.style.width = width + 'px';
+
+        var label = item.el.querySelector('.plan-label');
+        var viewLeft = container.scrollLeft;
+        var labelLeft = Math.max(viewLeft, left) - left + 2;
+        label.style.left = labelLeft + 'px';
+      });
+    }
+
+    function extendLeft(n) {
+      startDate.setDate(startDate.getDate() - n);
+      renderDays(startDate, new Date(startDate.getTime() + (n-1)*86400000), true);
+      updatePlanPositions();
+      container.scrollLeft += n * dayWidth;
+    }
+
+    function extendRight(n) {
+      var from = new Date(endDate.getTime() + 86400000);
+      endDate.setDate(endDate.getDate() + n);
+      renderDays(from, endDate, false);
+      updatePlanPositions();
+    }
+
+    renderDays(startDate, endDate, false);
+    renderPlans();
+    updatePlanPositions();
+
+    function ensureDateVisible(date) {
+      if (date < startDate) {
+        extendLeft(dayDiff(startDate, date));
+      } else if (date > endDate) {
+        extendRight(dayDiff(date, endDate));
+      }
+    }
+
+    function scrollToDate(date) {
+      ensureDateVisible(date);
+      var offset = dayDiff(date, startDate) * dayWidth - container.clientWidth / 2 + dayWidth / 2;
+      container.scrollLeft = offset;
+      updatePlanPositions();
+    }
+
+    var todayBtn = document.getElementById('timeline-today-btn');
+    if (todayBtn) {
+      todayBtn.addEventListener('click', function() { scrollToDate(new Date()); });
+    }
+
+    scrollToDate(new Date());
+
+    container.addEventListener('scroll', function() {
+      if (container.scrollLeft < 50) {
+        extendLeft(30);
+      }
+      if (container.scrollLeft + container.clientWidth > scroll.scrollWidth - 50) {
+        extendRight(30);
+      }
+      updatePlanPositions();
+    });
+  });
+}

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -1,3 +1,11 @@
 class Plan < Label
   validates :target_date, presence: true
+
+  def progress(user = Current.user)
+    roots = Creative.where(user: user).roots
+    values = roots.map { |c| c.progress_for_tags(id, user) }.compact
+    return 0 if values.empty?
+
+    values.sum.to_f / values.size
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,6 +27,7 @@
     <%= javascript_include_tag 'creatives', defer: true %>
     <%= javascript_include_tag 'popup_menu', defer: true %>
     <%= javascript_include_tag 'progress_filter_toggle', defer: true %>
+    <%= javascript_include_tag 'plans_timeline', defer: true %>
     <%= javascript_include_tag 'actioncable', defer: true %>
     <%= javascript_importmap_tags %>
   </head>

--- a/config/locales/plans.en.yml
+++ b/config/locales/plans.en.yml
@@ -5,3 +5,4 @@ en:
     plan_name: "Plan Name"
     created: "Plan was successfully created."
     deleted: "Plan deleted."
+    today: "Today"

--- a/config/locales/plans.ko.yml
+++ b/config/locales/plans.ko.yml
@@ -5,3 +5,4 @@ ko:
     plan_name: "계획 이름"
     created: "계획이 성공적으로 생성되었습니다."
     deleted: "계획이 삭제되었습니다."
+    today: "오늘"


### PR DESCRIPTION
## Summary
- add `today` translation keys
- wrap timeline with a Today button
- style timeline wrapper and button
- allow jumping to today and keep it centered

## Testing
- `./bin/rubocop -A`
- `bundle exec rake test`


------
https://chatgpt.com/codex/tasks/task_e_68650250a20c83268911fcc7855aee04