### PR TITLE
Add plan timeline links and delete buttons

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -265,6 +265,17 @@ button {
     color: var(--color-bg);
 }
 
+.plan-bar .delete-plan-btn {
+    position: absolute;
+    top: 2px;
+    right: 2px;
+    border: none;
+    background: none;
+    font-weight: bold;
+    cursor: pointer;
+    color: var(--color-bg);
+}
+
 #inbox-panel.slide-panel {
     position: fixed;
     top: 0;

--- a/app/components/plans_timeline_component.html.erb
+++ b/app/components/plans_timeline_component.html.erb
@@ -1,6 +1,6 @@
 <div class="plans-timeline-wrapper">
   <button id="timeline-today-btn" type="button"><%= t('plans.today', default: '오늘') %></button>
-  <div id="plans-timeline" class="horizontal-timeline" data-plans='<%= raw plan_data.to_json %>' data-start-date="<%= @start_date %>" data-end-date="<%= @end_date %>"></div>
+  <div id="plans-timeline" class="horizontal-timeline" data-plans='<%= raw plan_data.to_json %>' data-start-date="<%= @start_date %>" data-end-date="<%= @end_date %>" data-delete-confirm="<%= t('plans.delete_confirm', default: 'Are you sure?') %>"></div>
 </div>
 <hr>
 <div class="plan-form-container">

--- a/app/components/plans_timeline_component.rb
+++ b/app/components/plans_timeline_component.rb
@@ -16,8 +16,20 @@ class PlansTimelineComponent < ViewComponent::Base
         name: plan.name.presence || I18n.l(plan.target_date),
         created_at: plan.created_at.to_date,
         target_date: plan.target_date,
-        progress: plan.progress
+        progress: plan.progress,
+        path: plan_creatives_path(plan),
+        deletable: plan.owner_id == Current.user&.id
       }
+    end
+  end
+
+  private
+
+  def plan_creatives_path(plan)
+    if helpers.params[:id].present?
+      helpers.creative_path(helpers.params[:id], tags: [ plan.id ])
+    else
+      helpers.creatives_path(tags: [ plan.id ])
     end
   end
 end

--- a/app/javascript/plans_timeline.js
+++ b/app/javascript/plans_timeline.js
@@ -52,6 +52,8 @@ if (!window.plansTimelineInitialized) {
       plans.forEach(function(plan, idx) {
         var el = document.createElement('div');
         el.className = 'plan-bar';
+        el.dataset.path = plan.path;
+        el.dataset.id = plan.id;
         var left = dayDiff(plan.created_at, startDate) * dayWidth;
         var width = (dayDiff(plan.target_date, plan.created_at) + 1) * dayWidth;
         el.style.left = left + 'px';
@@ -67,6 +69,28 @@ if (!window.plansTimelineInitialized) {
         label.className = 'plan-label';
         label.textContent = plan.name + ' ' + Math.round(plan.progress * 100) + '%';
         el.appendChild(label);
+
+        if (plan.deletable) {
+          var del = document.createElement('button');
+          del.type = 'button';
+          del.textContent = '×';
+          del.className = 'delete-plan-btn';
+          el.appendChild(del);
+          del.addEventListener('click', function(e) {
+            e.stopPropagation();
+            if (!confirm(container.dataset.deleteConfirm)) return;
+            fetch('/plans/' + plan.id, {
+              method: 'DELETE',
+              headers: { 'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').content }
+            }).then(function() { window.location.reload(); });
+          });
+        }
+
+        el.addEventListener('click', function() {
+          if (plan.path) {
+            window.location.href = plan.path;
+          }
+        });
 
         scroll.appendChild(el);
         planEls.push({ el: el, plan: plan });


### PR DESCRIPTION
## Summary
- link plan bars to creatives filtered by the plan
- allow deleting a plan from the timeline
- style delete button

## Testing
- `./bin/rubocop -a`
- `bundle exec rake test`


------
https://chatgpt.com/codex/tasks/task_e_68660c157c5c832690f2d802c2b57432