### PR TITLE
Fix timeline label color by theme

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -262,7 +262,7 @@ button {
     left: 2px;
     top: 2px;
     font-size: 0.75em;
-    color: var(--color-bg);
+    color: var(--color-text);
 }
 
 #inbox-panel.slide-panel {


### PR DESCRIPTION
## Summary
- adjust plan timeline label color to use theme text color

## Testing
- `./bin/rubocop -a`

------
https://chatgpt.com/codex/tasks/task_e_68660cf7717c83269a7d9c0bc9d05964