### PR TITLE
Add plan timeline links and delete buttons

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -265,6 +265,17 @@ button {
     color: var(--color-bg);
 }
 
+.plan-bar .delete-plan-btn {
+    position: absolute;
+    top: 2px;
+    right: 2px;
+    border: none;
+    background: none;
+    font-weight: bold;
+    cursor: pointer;
+    color: var(--color-bg);
+}
+
 #inbox-panel.slide-panel {
     position: fixed;
     top: 0;

--- a/app/components/plans_timeline_component.html.erb
+++ b/app/components/plans_timeline_component.html.erb
@@ -4,7 +4,7 @@
 </div>
 <hr>
 <div class="plan-form-container">
-<%= form_with(model: Plan.new, url: plans_path, local: true) do |form| %>
+<%= form_with(model: Plan.new, url: plans_path, local: true, id: 'new-plan-form') do |form| %>
   <div>
     <%= form.text_field :name, placeholder: t('plans.plan_name') %>
   </div>

--- a/app/components/plans_timeline_component.html.erb
+++ b/app/components/plans_timeline_component.html.erb
@@ -1,6 +1,6 @@
 <div class="plans-timeline-wrapper">
   <button id="timeline-today-btn" type="button"><%= t('plans.today', default: '오늘') %></button>
-  <div id="plans-timeline" class="horizontal-timeline" data-plans='<%= raw plan_data.to_json %>' data-start-date="<%= @start_date %>" data-end-date="<%= @end_date %>"></div>
+  <div id="plans-timeline" class="horizontal-timeline" data-plans='<%= raw plan_data.to_json %>' data-start-date="<%= @start_date %>" data-end-date="<%= @end_date %>" data-delete-confirm="<%= t('plans.delete_confirm', default: 'Are you sure?') %>"></div>
 </div>
 <hr>
 <div class="plan-form-container">

--- a/app/components/plans_timeline_component.rb
+++ b/app/components/plans_timeline_component.rb
@@ -16,8 +16,20 @@ class PlansTimelineComponent < ViewComponent::Base
         name: plan.name.presence || I18n.l(plan.target_date),
         created_at: plan.created_at.to_date,
         target_date: plan.target_date,
-        progress: plan.progress
+        progress: plan.progress,
+        path: plan_creatives_path(plan),
+        deletable: plan.owner_id == Current.user&.id
       }
+    end
+  end
+
+  private
+
+  def plan_creatives_path(plan)
+    if helpers.params[:id].present?
+      helpers.creative_path(helpers.params[:id], tags: [ plan.id ])
+    else
+      helpers.creatives_path(tags: [ plan.id ])
     end
   end
 end

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -13,7 +13,13 @@ class PlansController < ApplicationController
   def destroy
     @plan = Plan.find(params[:id])
     @plan.destroy
-    redirect_back fallback_location: root_path, notice: t("plans.deleted", default: "Plan deleted.")
+    respond_to do |format|
+      format.html do
+        redirect_back fallback_location: root_path,
+                      notice: t("plans.deleted", default: "Plan deleted.")
+      end
+      format.json { head :no_content }
+    end
   end
 
   private

--- a/app/javascript/plans_timeline.js
+++ b/app/javascript/plans_timeline.js
@@ -52,6 +52,8 @@ if (!window.plansTimelineInitialized) {
       plans.forEach(function(plan, idx) {
         var el = document.createElement('div');
         el.className = 'plan-bar';
+        el.dataset.path = plan.path;
+        el.dataset.id = plan.id;
         var left = dayDiff(plan.created_at, startDate) * dayWidth;
         var width = (dayDiff(plan.target_date, plan.created_at) + 1) * dayWidth;
         el.style.left = left + 'px';
@@ -67,6 +69,28 @@ if (!window.plansTimelineInitialized) {
         label.className = 'plan-label';
         label.textContent = plan.name + ' ' + Math.round(plan.progress * 100) + '%';
         el.appendChild(label);
+
+        if (plan.deletable) {
+          var del = document.createElement('button');
+          del.type = 'button';
+          del.textContent = '×';
+          del.className = 'delete-plan-btn';
+          el.appendChild(del);
+          del.addEventListener('click', function(e) {
+            e.stopPropagation();
+            if (!confirm(container.dataset.deleteConfirm)) return;
+            fetch('/plans/' + plan.id, {
+              method: 'DELETE',
+              headers: { 'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').content }
+            }).then(function() { window.location.reload(); });
+          });
+        }
+
+        el.addEventListener('click', function() {
+          if (plan.path) {
+            window.location.href = plan.path;
+          }
+        });
 
         scroll.appendChild(el);
         planEls.push({ el: el, plan: plan });

--- a/app/javascript/plans_timeline.js
+++ b/app/javascript/plans_timeline.js
@@ -81,8 +81,23 @@ if (!window.plansTimelineInitialized) {
             if (!confirm(container.dataset.deleteConfirm)) return;
             fetch('/plans/' + plan.id, {
               method: 'DELETE',
-              headers: { 'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').content }
-            }).then(function() { window.location.reload(); });
+              headers: {
+                'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').content,
+                Accept: 'application/json'
+              }
+            }).then(function(r) {
+              if (r.ok) {
+                var idx = planEls.findIndex(function(item) { return item.plan.id === plan.id; });
+                if (idx > -1) {
+                  planEls[idx].el.remove();
+                  planEls.splice(idx, 1);
+                }
+                plans = plans.filter(function(p) { return p.id !== plan.id; });
+                updatePlanPositions();
+              } else {
+                window.location.reload();
+              }
+            });
           });
         }
 


### PR DESCRIPTION
## Summary
- link plan bars to creatives filtered by the plan
- allow deleting a plan from the timeline
- style delete button

## Testing
- `./bin/rubocop -a`
- `bundle exec rake test`


------
https://chatgpt.com/codex/tasks/task_e_68660c157c5c832690f2d802c2b57432