### PR TITLE
Improve Plan progress calculation and load timeline lazily

### DIFF
--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -7,7 +7,7 @@ class PlansController < ApplicationController
                  .order(:created_at)
     respond_to do |format|
       format.html do
-        render html: render_to_string(PlansTimelineComponent.new(plans: @plans)).html_safe
+        render html: render_to_string(PlansTimelineComponent.new(plans: @plans), layout: false)
       end
       format.json do
         render json: @plans.map { |p| plan_json(p) }

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -1,4 +1,19 @@
 class PlansController < ApplicationController
+  def index
+    start_date = Date.current - 30
+    end_date = Date.current + 30
+    @plans = Plan.where(owner: Current.user).or(Plan.where(owner: nil))
+                 .where("target_date >= ? AND created_at <= ?", start_date, end_date)
+                 .order(:created_at)
+    respond_to do |format|
+      format.html do
+        render html: render_to_string(PlansTimelineComponent.new(plans: @plans)).html_safe
+      end
+      format.json do
+        render json: @plans.map { |p| plan_json(p) }
+      end
+    end
+  end
   def create
     @plan = Plan.new(plan_params)
     @plan.owner = Current.user

--- a/app/javascript/plans_timeline.js
+++ b/app/javascript/plans_timeline.js
@@ -1,8 +1,7 @@
-if (!window.plansTimelineInitialized) {
-  window.plansTimelineInitialized = true;
+if (!window.plansTimelineScriptInitialized) {
+  window.plansTimelineScriptInitialized = true;
 
-  document.addEventListener('turbo:load', function() {
-    var container = document.getElementById('plans-timeline');
+  function initPlansTimeline(container) {
     if (!container) return;
 
     var plans = [];
@@ -230,5 +229,11 @@ if (!window.plansTimelineInitialized) {
         });
       });
     }
+  }
+
+  window.initPlansTimeline = initPlansTimeline;
+
+  document.addEventListener('turbo:load', function() {
+    initPlansTimeline(document.getElementById('plans-timeline'));
   });
 }

--- a/app/models/creative.rb
+++ b/app/models/creative.rb
@@ -130,6 +130,20 @@ class Creative < ApplicationRecord
     end
   end
 
+  # Calculate progress for the subtree ignoring permission checks.
+  # `tagged_ids` should be a Set of creative IDs that are tagged with the plan.
+  def progress_for_plan(tagged_ids)
+    child_values = children.map { |child| child.progress_for_plan(tagged_ids) }.compact
+
+    if child_values.any?
+      child_values.sum.to_f / child_values.size
+    elsif tagged_ids.include?(id)
+      children.any? ? 1.0 : progress
+    else
+      nil
+    end
+  end
+
   # 공유 대상 사용자를 위해 Linked Creative를 생성합니다.
   # 이미 존재하거나 원본 작성자에게는 생성하지 않습니다.
   def create_linked_creative_for_user(user)

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -1,9 +1,16 @@
+require "set"
+
 class Plan < Label
   validates :target_date, presence: true
 
-  def progress(user = Current.user)
-    roots = Creative.where(user: user).roots
-    values = roots.map { |c| c.progress_for_tags(id, user) }.compact
+  def progress(_user = nil)
+    tagged_ids = Tag.where(label_id: id).pluck(:creative_id)
+    return 0 if tagged_ids.empty?
+
+    root_ids = Creative.where(id: tagged_ids).map { |c| c.root.id }.uniq
+    roots = Creative.where(id: root_ids)
+    tagged_set = tagged_ids.to_set
+    values = roots.map { |c| c.progress_for_plan(tagged_set) }.compact
     return 0 if values.empty?
 
     values.sum.to_f / values.size

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -133,9 +133,7 @@
       <% end %>
     </nav>
 
-    <div id="plans-list-area" style="display:none;">
-      <%= render PlansTimelineComponent.new(plans: Plan.where(owner: Current.user).or(Plan.where(owner: nil))) %>
-    </div>
+    <div id="plans-list-area" style="display:none;"></div>
 
     <div id="inbox-panel" class="slide-panel">
       <div class="inbox-panel-header">
@@ -158,9 +156,25 @@
         document.addEventListener('turbo:load', function() {
           var btns = document.querySelectorAll('.plans-menu-btn');
           var area = document.getElementById('plans-list-area');
+          var loaded = false;
           btns.forEach(function(btn) {
             btn.addEventListener('click', function() {
-              area.style.display = (area.style.display === 'none') ? 'block' : 'none';
+              if (area.style.display === 'none') {
+                area.style.display = 'block';
+                if (!loaded) {
+                  fetch('/plans', { headers: { Accept: 'text/html' } })
+                    .then(function(r) { return r.text(); })
+                    .then(function(html) {
+                      area.innerHTML = html;
+                      if (window.initPlansTimeline) {
+                        window.initPlansTimeline(document.getElementById('plans-timeline'));
+                      }
+                      loaded = true;
+                    });
+                }
+              } else {
+                area.style.display = 'none';
+              }
             });
           });
         });

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,7 +47,7 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :plans, only: [ :create, :destroy ]
+  resources :plans, only: [ :create, :destroy, :index ]
 
   resources :inbox_items, path: "inbox", only: [ :index, :update, :destroy ] do
     get :count, on: :collection

--- a/test/models/plan_test.rb
+++ b/test/models/plan_test.rb
@@ -1,0 +1,24 @@
+require "test_helper"
+
+class PlanTest < ActiveSupport::TestCase
+  test "progress averages tagged trees" do
+    user = users(:one)
+    Current.session = OpenStruct.new(user: user)
+
+    root1 = Creative.create!(user: user, description: "Root1", progress: 0)
+    child1 = Creative.create!(user: user, parent: root1, description: "Child1", progress: 0.2)
+    child2 = Creative.create!(user: user, parent: root1, description: "Child2", progress: 0.8)
+
+    root2 = Creative.create!(user: user, description: "Root2", progress: 0)
+    child3 = Creative.create!(user: user, parent: root2, description: "Child3", progress: 0.7)
+
+    plan = Plan.create!(name: "P", target_date: Date.today, owner: user)
+    Tag.create!(creative_id: child1.id, label: plan)
+    Tag.create!(creative_id: child2.id, label: plan)
+    Tag.create!(creative_id: child3.id, label: plan)
+
+    assert_in_delta 0.6, plan.progress, 0.001
+
+    Current.reset
+  end
+end


### PR DESCRIPTION
## Summary
- optimize `Plan.progress` to aggregate tagged creative trees without permission checks
- add `progress_for_plan` in `Creative` for permissionless recursion
- provide plans list via AJAX and load timeline on demand
- expose `initPlansTimeline` for dynamic initialization
- add test case for new plan progress logic

## Testing
- `./bin/rubocop -a`
- `bin/rails test`


------
https://chatgpt.com/codex/tasks/task_e_6866291b9744832693429bc444bfcc14