### PR TITLE
Fix plans timeline duplicate loading

### DIFF
--- a/app/javascript/plans_timeline.js
+++ b/app/javascript/plans_timeline.js
@@ -2,7 +2,8 @@ if (!window.plansTimelineScriptInitialized) {
   window.plansTimelineScriptInitialized = true;
 
   function initPlansTimeline(container) {
-    if (!container) return;
+    if (!container || container.dataset.initialized) return;
+    container.dataset.initialized = 'true';
 
     var plans = [];
     try { plans = JSON.parse(container.dataset.plans || '[]'); } catch(e) {}
@@ -232,8 +233,4 @@ if (!window.plansTimelineScriptInitialized) {
   }
 
   window.initPlansTimeline = initPlansTimeline;
-
-  document.addEventListener('turbo:load', function() {
-    initPlansTimeline(document.getElementById('plans-timeline'));
-  });
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -133,7 +133,9 @@
       <% end %>
     </nav>
 
-    <div id="plans-list-area" style="display:none;"></div>
+    <div id="plans-list-area" style="display:none;">
+      <%= render PlansTimelineComponent.new(plans: Plan.none) %>
+    </div>
 
     <div id="inbox-panel" class="slide-panel">
       <div class="inbox-panel-header">
@@ -157,17 +159,18 @@
           var btns = document.querySelectorAll('.plans-menu-btn');
           var area = document.getElementById('plans-list-area');
           var loaded = false;
+          var timeline = document.getElementById('plans-timeline');
           btns.forEach(function(btn) {
             btn.addEventListener('click', function() {
               if (area.style.display === 'none') {
                 area.style.display = 'block';
                 if (!loaded) {
-                  fetch('/plans', { headers: { Accept: 'text/html' } })
-                    .then(function(r) { return r.text(); })
-                    .then(function(html) {
-                      area.innerHTML = html;
-                      if (window.initPlansTimeline) {
-                        window.initPlansTimeline(document.getElementById('plans-timeline'));
+                  fetch('/plans.json')
+                    .then(function(r) { return r.json(); })
+                    .then(function(plans) {
+                      if (timeline) { timeline.dataset.plans = JSON.stringify(plans); }
+                      if (window.initPlansTimeline && timeline) {
+                        window.initPlansTimeline(timeline);
                       }
                       loaded = true;
                     });


### PR DESCRIPTION
## Summary
- render an empty Plans timeline in layout instead of fetching markup
- only load plan data on demand and initialize the timeline once

## Testing
- `./bin/rubocop -a`
- `bundle exec rake test`


------
https://chatgpt.com/codex/tasks/task_e_6867364af12c83268ccbd1e0fabbb366