### PR TITLE
Change plan timeline progress color

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -330,7 +330,7 @@ button {
     padding: 0 4px;
     font-size: 0.75em;
     line-height: 1.2;
-    margin-left: 4px;
+    margin-left: 0px;
     display: none;
 }
 

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -104,6 +104,18 @@ nav button:hover,
     padding:0.3em; border-radius:4px; border:1px solid var(--color-border);
 }
 
+input[type="text"],
+input[type="number"],
+input[type="url"],
+input[type="date"],
+textarea {
+    background: var(--color-bg);
+    color: var(--color-btn-text);
+    padding: 0.3em;
+    border-radius: 4px;
+    border: 1px solid var(--color-border);
+}
+
 main {
     max-width: 960px;
     margin: 0rem auto;

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -279,14 +279,16 @@ button {
 #inbox-panel.slide-panel {
     position: fixed;
     top: 0;
-    right: -300px;
-    width: 300px;
+    right: -360px;
+    width: 360px;
     height: 100%;
     background: var(--color-section-bg);
-    box-shadow: -2px 0 5px rgba(0,0,0,0.2);
+    border-left: 1px solid var(--color-border);
+    box-shadow: -2px 0 8px rgba(0,0,0,0.15);
     overflow-y: auto;
     transition: right 0.3s;
     z-index: 1000;
+    border-radius: 8px 0 0 8px;
 }
 
 #inbox-panel.open {
@@ -297,7 +299,8 @@ button {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: 0.5em;
+    padding: 0.75em;
+    background: var(--color-nav-bg);
     border-bottom: 1px solid var(--color-border);
 }
 
@@ -311,7 +314,11 @@ button {
 
 .inbox-item {
     border-bottom: 1px solid var(--color-border);
-    padding: 0.5em;
+    padding: 0.75em;
+}
+
+.inbox-item:last-child {
+    border-bottom: none;
 }
 
 .inbox-item .actions button {

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -265,7 +265,7 @@ button {
 }
 
 .plan-bar .plan-progress {
-    background: var(--color-btn-bg);
+    background: var(--color-complete);
     height: 100%;
 }
 

--- a/app/assets/stylesheets/creatives.css
+++ b/app/assets/stylesheets/creatives.css
@@ -70,7 +70,7 @@
 }
 
 .creative-progress-complete {
-    color: green;
+    color: var(--color-complete);
 }
 
 .creative-progress-incomplete {

--- a/app/assets/stylesheets/dark_mode.css
+++ b/app/assets/stylesheets/dark_mode.css
@@ -11,6 +11,7 @@
   --color-btn-text: #202123;
   --color-border: #e0e0e0;
   --color-muted: #666;
+  --color-complete: green;
   --color-drag-over: #e0e0e0;
   --color-drag-over-edge: #bbb;
   --hover-brightness: 90%;
@@ -26,6 +27,7 @@ body.dark-mode {
   --color-btn-text: #eaeaea;
   --color-border: #333333;
   --color-muted: #aaaaaa;
+  --color-complete: green;
   --color-drag-over: #383a40;
   --color-drag-over-edge: #777;
   --hover-brightness: 110%;
@@ -42,6 +44,7 @@ body.dark-mode {
     --color-btn-text: #eaeaea;
     --color-border: #333333;
     --color-muted: #aaaaaa;
+    --color-complete: green;
     --color-drag-over: #383a40;
     --color-drag-over-edge: #777;
     --hover-brightness: 110%;

--- a/app/javascript/popup_menu.js
+++ b/app/javascript/popup_menu.js
@@ -33,9 +33,9 @@ if (!window.popupMenuInitialized) {
         }
       });
 
-      /* Close menu on button click */
+      /* Close menu when interacting with menu items */
       menu.addEventListener('click', function(e) {
-        if (e.target.closest('button[type="button"]')) {
+        if (e.target.closest('button, a')) {
           menu.style.display = 'none';
         }
       });

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -193,6 +193,9 @@
           var list = document.getElementById('inbox-list');
           var closeBtn = document.getElementById('close-inbox');
           var toggle = document.getElementById('toggle-inbox-read');
+          if (toggle && localStorage.getItem('inboxShowRead') === '1') {
+            toggle.checked = true;
+          }
           var badge = document.getElementById('inbox-badge');
 
           function updateInboxBadge() {
@@ -314,7 +317,12 @@
             }
           });
           if (closeBtn) { closeBtn.addEventListener('click', closePanel); }
-          if (toggle) { toggle.addEventListener('change', loadInbox); }
+          if (toggle) {
+            toggle.addEventListener('change', function() {
+              localStorage.setItem('inboxShowRead', toggle.checked ? '1' : '0');
+              loadInbox();
+            });
+          }
 
           updateInboxBadge();
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -127,7 +127,7 @@
           menu_id: 'user-menu',
           align: :right
         ) do %>
-          <div><%= button_to t('users.profile'), user_path(Current.user), method: :get %></div>
+          <div><%= link_to t('users.profile'), user_path(Current.user), class: 'popup-menu-item' %></div>
           <div><%= button_to t('app.sign_out'), session_path, method: :delete %></div>
         <% end %>
       <% end %>


### PR DESCRIPTION
## Summary
- add `--color-complete` CSS variable in dark mode stylesheet
- use the completion color variable for plan progress bar fill
- use the same variable for creative progress complete state

## Testing
- `./bin/rubocop -a`
- `bin/rails test`

------
https://chatgpt.com/codex/tasks/task_e_6867fabb3390832691be706b866d43ff