### PR TITLE
Implement AJAX creative adds

### DIFF
--- a/app/assets/stylesheets/creatives.css
+++ b/app/assets/stylesheets/creatives.css
@@ -101,6 +101,8 @@
     font-weight: bold;
     text-decoration: none;
     cursor: pointer;
+    background: none;
+    border: none;
 }
 .edit-inline-btn {
     margin-left: 0px;

--- a/app/components/creative_component.html.erb
+++ b/app/components/creative_component.html.erb
@@ -7,10 +7,11 @@
         </div>
         <%= check_box_tag('selected_creative_ids[]', creative.id, false, class: 'select-creative-checkbox', style: select_mode ? '' : 'display: none') %>
 
-        <%= link_to('+', new_creative_path(parent_id: creative.id, tags: params[:tags]),
-                    class: 'add-creative-btn',
-                    style: (' visibility: hidden;' unless creative.has_permission?(Current.user, :write)),
-                    title: t('creatives.help.add_child_creative')) %>
+        <%= button_tag('+', type: 'button',
+                       class: 'add-creative-btn',
+                       data: { parent_id: creative.id },
+                       style: (' visibility: hidden;' unless creative.has_permission?(Current.user, :write)),
+                       title: t('creatives.help.add_child_creative')) %>
         <% if creative.has_permission?(Current.user, :write) %>
           <button type="button" class="edit-inline-btn" data-creative-id="<%= creative.id %>">✎</button>
         <% end %>

--- a/app/views/creatives/_add_button.html.erb
+++ b/app/views/creatives/_add_button.html.erb
@@ -1,24 +1,7 @@
 <%
-  menu_items = []
   if authenticated? && !params[:id]
-    new_creative_button = button_tag(t('creatives.index.new_creative'), type: 'button', class: 'popup-menu-item new-root-creative-btn')
-    menu_items << new_creative_button
-  end
-
-  if authenticated? && @parent_creative && @parent_creative.has_permission?(Current.user, :write)
-    menu_items << button_tag(t('creatives.index.append_as_parent_creative'), type: 'button', class: 'popup-menu-item append-parent-btn', data: { child_id: @parent_creative.id })
-    menu_items << button_tag(t('creatives.index.append_below_creative'), type: 'button', class: 'popup-menu-item append-below-btn', data: { target_id: @parent_creative.id })
-    menu_items << tag.br
-    menu_items << button_tag(t('creatives.index.new_sub_creative'), type: 'button', class: 'popup-menu-item add-creative-btn', data: { parent_id: @parent_creative.id })
+%>
+  <%= button_tag(t('creatives.index.new_creative'), type: 'button', class: 'popup-menu-item new-root-creative-btn') %>
+<%
   end
 %>
-
-<% if menu_items.one? %>
-  <%= new_creative_button %>
-<% elsif menu_items.any? %>
-  <%= render PopupMenuComponent.new(
-        button_content: t('creatives.index.new_creative'),
-        menu_id: 'add-creative-menu') do %>
-    <%= safe_join(menu_items) %>
-  <% end %>
-<% end %>

--- a/app/views/creatives/_add_button.html.erb
+++ b/app/views/creatives/_add_button.html.erb
@@ -1,20 +1,20 @@
 <%
   menu_items = []
   if authenticated? && !params[:id]
-    new_creative_link = link_to(t('creatives.index.new_creative'), new_creative_path(tags: params[:tags]))
-    menu_items << link_to(t('creatives.index.new_creative'), new_creative_path(tags: params[:tags]), class: 'popup-menu-item')
+    new_creative_button = button_tag(t('creatives.index.new_creative'), type: 'button', class: 'popup-menu-item new-root-creative-btn')
+    menu_items << new_creative_button
   end
 
   if authenticated? && @parent_creative && @parent_creative.has_permission?(Current.user, :write)
-    menu_items << link_to(t('creatives.index.append_as_parent_creative'), append_as_parent_creative_creatives_path(parent_id: @parent_creative.id, tags: params[:tags]), class: 'popup-menu-item')
-    menu_items << link_to(t('creatives.index.append_below_creative'), append_below_creative_creatives_path(creative_id: @parent_creative.id, tags: params[:tags]), class: 'popup-menu-item')
+    menu_items << button_tag(t('creatives.index.append_as_parent_creative'), type: 'button', class: 'popup-menu-item append-parent-btn', data: { child_id: @parent_creative.id })
+    menu_items << button_tag(t('creatives.index.append_below_creative'), type: 'button', class: 'popup-menu-item append-below-btn', data: { target_id: @parent_creative.id })
     menu_items << tag.br
-    menu_items << link_to(t('creatives.index.new_sub_creative'), new_creative_path(parent_id: @parent_creative.id, tags: params[:tags]), class: 'popup-menu-item')
+    menu_items << button_tag(t('creatives.index.new_sub_creative'), type: 'button', class: 'popup-menu-item add-creative-btn', data: { parent_id: @parent_creative.id })
   end
 %>
 
 <% if menu_items.one? %>
-  <%= new_creative_link %>
+  <%= new_creative_button %>
 <% elsif menu_items.any? %>
   <%= render PopupMenuComponent.new(
         button_content: t('creatives.index.new_creative'),

--- a/app/views/creatives/_inline_edit_form.html.erb
+++ b/app/views/creatives/_inline_edit_form.html.erb
@@ -6,6 +6,7 @@
     <input type="hidden" id="inline-parent-id" name="creative[parent_id]" />
     <input type="hidden" id="inline-before-id" name="before_id" />
     <input type="hidden" id="inline-after-id" name="after_id" />
+    <input type="hidden" id="inline-child-id" name="child_id" />
     <trix-editor input="inline-creative-description"></trix-editor>
     <div style="margin-top:0.5em;display:flex;align-items:center;gap:0.5em;">
       <input type="range" id="inline-creative-progress" name="creative[progress]" min="0" max="1" step="0.01">


### PR DESCRIPTION
## Summary
- switch add creative buttons to use AJAX-based buttons
- update inline edit form for append-parent logic
- handle creative creation via new JS helpers
- respond with JSON on create without redirect
- tweak add creative button style

## Testing
- `./bin/rubocop -a`
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_686b3f89c5308326ae395c373a473dd1