### PR TITLE
Implement drag-selection in select mode

### DIFF
--- a/app/assets/stylesheets/creatives.css
+++ b/app/assets/stylesheets/creatives.css
@@ -180,6 +180,10 @@
     align-items: center;
 }
 
+.creative-row.selected {
+    background-color: var(--color-drag-over);
+}
+
 .creative-row:hover {
     background-color: var(--color-border);
 }

--- a/app/components/creative_component.rb
+++ b/app/components/creative_component.rb
@@ -10,12 +10,16 @@ class CreativeComponent < ViewComponent::Base
   attr_reader :creative, :filtered_children, :level, :select_mode, :expanded
 
   def drag_attrs
-    {
-      draggable: true,
-      id: "creative-#{creative.id}",
-      ondragstart: "handleDragStart(event)",
-      ondragover: "handleDragOver(event)",
-      ondrop: "handleDrop(event)"
-    }
+    if select_mode
+      { id: "creative-#{creative.id}" }
+    else
+      {
+        draggable: true,
+        id: "creative-#{creative.id}",
+        ondragstart: "handleDragStart(event)",
+        ondragover: "handleDragOver(event)",
+        ondrop: "handleDrop(event)"
+      }
+    end
   end
 end

--- a/app/javascript/select_mode.js
+++ b/app/javascript/select_mode.js
@@ -33,6 +33,7 @@ if (!window.isSelectModeInitialized) {
             row.dataset.selectHandlerAttached = 'true';
             row.addEventListener('mousedown', function(e) {
                 if (!selectModeActive) return;
+                if (e.target.closest('.select-creative-checkbox')) return;
                 dragging = true;
                 dragMode = e.altKey ? 'remove' : (e.shiftKey ? 'add' : 'toggle');
                 applySelection(row);

--- a/app/javascript/select_mode.js
+++ b/app/javascript/select_mode.js
@@ -2,7 +2,7 @@ if (!window.isSelectModeInitialized) {
     window.isSelectModeInitialized = true;
     let selectModeActive = false;
     let dragging = false;
-    let dragMode = 'replace';
+    let dragMode = 'toggle';
 
     function applySelection(row) {
         var cb = row.querySelector('.select-creative-checkbox');
@@ -10,9 +10,12 @@ if (!window.isSelectModeInitialized) {
         if (dragMode === 'remove') {
             cb.checked = false;
             row.classList.remove('selected');
-        } else {
+        } else if (dragMode === 'add') {
             cb.checked = true;
             row.classList.add('selected');
+        } else {
+            cb.checked = !cb.checked;
+            row.classList.toggle('selected');
         }
     }
 
@@ -31,8 +34,7 @@ if (!window.isSelectModeInitialized) {
             row.addEventListener('mousedown', function(e) {
                 if (!selectModeActive) return;
                 dragging = true;
-                dragMode = e.altKey ? 'remove' : (e.shiftKey ? 'add' : 'replace');
-                if (dragMode === 'replace') clearAllSelection();
+                dragMode = e.altKey ? 'remove' : (e.shiftKey ? 'add' : 'toggle');
                 applySelection(row);
                 e.preventDefault();
             });


### PR DESCRIPTION
## Summary
- disable drag and drop when select mode is active
- highlight selected creative rows
- support drag-selection with shift/alt modifiers

## Testing
- `./bin/rubocop -a`
- `bundle exec rake` *(fails: error sending request for chrome driver)*

------
https://chatgpt.com/codex/tasks/task_e_686b5c96568c8326ad6a32350ccfe905