### PR TITLE
Ensure reparenting only moves linked creative

### DIFF
--- a/app/controllers/creatives_controller.rb
+++ b/app/controllers/creatives_controller.rb
@@ -140,7 +140,18 @@ class CreativesController < ApplicationController
 
   def update
     respond_to do |format|
-      if @creative.effective_origin.update(creative_params)
+      permitted = creative_params.to_h
+      base = @creative.effective_origin
+      success = true
+
+      if @creative.origin_id.present? && permitted.key?("parent_id")
+        parent_id = permitted.delete("parent_id")
+        success &&= @creative.update(parent_id: parent_id)
+      end
+
+      success &&= base.update(permitted)
+
+      if success
         format.html { redirect_to @creative }
         format.json { head :ok }
       else

--- a/spec/requests/linked_creative_parent_spec.rb
+++ b/spec/requests/linked_creative_parent_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+require 'ostruct'
+
+RSpec.describe 'Linked Creative parent update', type: :request do
+  let(:owner) { User.create!(email: 'owner@example.com', password: 'pw') }
+  let(:shared_user) { User.create!(email: 'shared@example.com', password: 'pw') }
+  let(:parent) { Creative.create!(user: owner, description: 'Parent') }
+  let(:creative) { Creative.create!(user: owner, parent: parent, description: 'Original') }
+  let(:new_parent) { Creative.create!(user: shared_user, description: 'New Parent') }
+
+  before do
+    allow_any_instance_of(CreativesController).to receive(:require_authentication).and_return(true)
+    Current.session = OpenStruct.new(user: owner)
+    CreativeShare.create!(creative: creative, user: shared_user, permission: :read)
+    creative.create_linked_creative_for_user(shared_user)
+    @linked = Creative.find_by(origin_id: creative.id, user_id: shared_user.id)
+    Current.session = OpenStruct.new(user: shared_user)
+  end
+
+  it 'changes only the linked creative parent' do
+    patch "/creatives/#{@linked.id}", params: { creative: { parent_id: new_parent.id } }
+    expect(response).to redirect_to(@linked)
+    @linked.reload
+    creative.reload
+    expect(@linked.parent).to eq new_parent
+    expect(creative.parent).to eq parent
+  end
+end


### PR DESCRIPTION
## Summary
- handle linked creative parent change without modifying origin
- test that linked creative reparenting leaves origin intact

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec spec/requests/linked_creative_parent_spec.rb --format doc --no-color`
- `bundle exec rspec` *(fails: Selenium chromedriver not available)*

------
https://chatgpt.com/codex/tasks/task_e_686cd052fc248326b9bf872dd10a70cd