### PR TITLE
Resize window in creative share system test

### DIFF
--- a/spec/system/creative_share_spec.rb
+++ b/spec/system/creative_share_spec.rb
@@ -5,7 +5,14 @@ RSpec.describe 'Creative 공유 리스트', type: :system do
   let!(:creative) { Creative.create!(description: '테스트', user: user) }
   let!(:share) { CreativeShare.create!(creative: creative, user: user, permission: 'read') }
 
+  def resize_window_to_pc
+    page.current_window.resize_to(1200, 800)
+  rescue Capybara::NotSupportedByDriverError
+    # ignore if driver does not support resizing
+  end
+
   it '공유 리스트가 정상적으로 표시된다' do
+    resize_window_to_pc
     visit new_session_path
     fill_in placeholder: I18n.t('users.new.enter_your_email'), with: user.email
     fill_in placeholder: I18n.t('users.new.enter_your_password'), with: 'password'


### PR DESCRIPTION
## Summary
- resize the browser window for the creative share system test

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec spec/system/creative_share_spec.rb:8 -fd` *(fails: error sending request for url)*

------
https://chatgpt.com/codex/tasks/task_e_686cdd05b6f08326afa1277e5713a10d