### PR TITLE
Add required names and migrate existing users

### DIFF
--- a/app/components/avatar_component.rb
+++ b/app/components/avatar_component.rb
@@ -17,6 +17,10 @@ class AvatarComponent < ViewComponent::Base
   end
 
   def email
-    @user&.email || I18n.t("comments.anonymous")
+    if @user
+      @user.display_name
+    else
+      I18n.t("comments.anonymous")
+    end
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -88,10 +88,10 @@ class UsersController < ApplicationController
 
   private
   def user_params
-    params.require(:user).permit(:email, :password, :password_confirmation)
+    params.require(:user).permit(:email, :password, :password_confirmation, :name)
   end
 
   def profile_params
-    params.require(:user).permit(:avatar, :avatar_url, :display_level, :completion_mark, :theme)
+    params.require(:user).permit(:avatar, :avatar_url, :display_level, :completion_mark, :theme, :name)
   end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -54,7 +54,7 @@ class Comment < ApplicationRecord
     return unless creative.user && user && creative.user != user
     create_inbox_item(
       creative.user,
-      I18n.t("inbox.comment_added", user: user.email, comment: content)
+      I18n.t("inbox.comment_added", user: user.display_name, comment: content)
     )
   end
 
@@ -62,7 +62,7 @@ class Comment < ApplicationRecord
     mentioned_users.each do |mentioned|
       create_inbox_item(
         mentioned,
-        I18n.t("inbox.user_mentioned", user: user.email, comment: content)
+        I18n.t("inbox.user_mentioned", user: user.display_name, comment: content)
       )
     end
   end

--- a/app/models/creative_share.rb
+++ b/app/models/creative_share.rb
@@ -24,7 +24,7 @@ class CreativeShare < ApplicationRecord
     short_title = ActionController::Base.helpers.truncate(title, length: 30)
     InboxItem.create!(
       owner: user,
-      message: I18n.t("inbox.creative_shared", user: Current.user.email, short_title: short_title),
+      message: I18n.t("inbox.creative_shared", user: Current.user.display_name, short_title: short_title),
       link: Rails.application.routes.url_helpers.creative_url(
         creative,
         Rails.application.config.action_mailer.default_url_options

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,11 +11,13 @@ class User < ApplicationRecord
   attribute :display_level, :integer, default: DEFAULT_DISPLAY_LEVEL
   attribute :completion_mark, :string, default: ""
   attribute :theme, :string
+  attribute :name, :string
 
   normalizes :email, with: ->(e) { e.strip.downcase }
 
   validates :email, presence: true, uniqueness: true,
                     format: { with: URI::MailTo::EMAIL_REGEXP }
+  validates :name, presence: true
   validates :display_level, numericality: { only_integer: true, greater_than: 0 }
   validates :theme, inclusion: { in: [ "", "light", "dark" ] }, allow_nil: true
 
@@ -25,5 +27,9 @@ class User < ApplicationRecord
 
   def email_verified?
     email_verified_at.present?
+  end
+
+  def display_name
+    name.presence || email
   end
 end

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,7 +1,7 @@
 <div class="comment-item <%= 'last-read' if defined?(last_read_comment_id) && last_read_comment_id && comment.id == last_read_comment_id %>" id="<%= dom_id(comment) %>">
   <div>
     <%= render AvatarComponent.new(user: comment.user, size: 20, classes: 'avatar comment-avatar') %>
-    <strong><%= comment.user&.email || t('comments.anonymous') %></strong>
+    <strong><%= comment.user&.display_name || t('comments.anonymous') %></strong>
     <span>· <%= t('datetime.ago', time: time_ago_in_words(comment.created_at)) %></span>
     <% if comment.user == Current.user %>
       <button class="edit-comment-btn" data-comment-id="<%= comment.id %>" data-comment-content="<%= comment.content %>" title="<%= t('comments.update_comment') %>">

--- a/app/views/creatives/_share_button.html.erb
+++ b/app/views/creatives/_share_button.html.erb
@@ -28,7 +28,7 @@
               <span>
                 <%= render AvatarComponent.new(user: share.user, size: 20, classes: 'avatar share-avatar') %>
               </span>
-              <span><%= share.user&.email || t('creatives.index.unknown_user') %></span>
+              <span><%= share.user&.display_name || t('creatives.index.unknown_user') %></span>
               <span><%= t("creatives.index.permission_#{share.permission}") %></span>
               <span>
                 <%= button_to '×', creative_creative_share_path(@parent_creative || @creative, share), method: :delete, form: { data: { turbo_confirm: t('creatives.index.are_you_sure_delete_share') } }, class: 'delete-share-btn', style: 'padding:0 0.5em;' %>

--- a/app/views/users/_id_pwd_fields.html.erb
+++ b/app/views/users/_id_pwd_fields.html.erb
@@ -1,6 +1,9 @@
+<%= form.text_field :name,
+                    autofocus: true,
+                    required: true,
+                    placeholder: t('users.new.enter_your_name') %><br/>
 <%= form.email_field :email,
                      required: true,
-                     autofocus: true,
                      autocomplete: "username",
                      placeholder: t('users.new.enter_your_email'),
                      value: (form.object.respond_to?(:email) && form.object.email.presence) || params[:email],

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -2,6 +2,6 @@
 
 <ul>
   <% @users.each do |user| %>
-    <li><%= user.email %></li>
+    <li><%= user.display_name %></li>
   <% end %>
 </ul>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,6 +1,11 @@
 <h1><%= t('users.details') %></h1>
 
 <p>
+  <strong><%= t('users.name') %>:</strong>
+  <%= @user.name %>
+</p>
+
+<p>
   <strong><%= t('users.email') %>:</strong>
   <%= @user.email %>
 </p>
@@ -12,6 +17,10 @@
 <%= form_with model: @user, url: user_path(@user), method: :patch, local: true, html: { multipart: true } do |f| %>
   <div>
     <%= f.file_field :avatar %>
+  </div>
+  <div>
+    <%= f.label :name, t('users.name') %>
+    <%= f.text_field :name, required: true %>
   </div>
   <div>
     <%= f.text_field :avatar_url, placeholder: t('users.avatar_url') %>

--- a/config/locales/users.en.yml
+++ b/config/locales/users.en.yml
@@ -4,6 +4,7 @@ en:
       your_creativeness_is_coming: "Your Creativeness Is Coming!"
       a_tracker_of_your_creatives: "Document the specs. Watch progress unfold."
     new:
+      enter_your_name: "Enter your name"
       enter_your_email: "Enter your email"
       enter_your_password: "Enter your password"
       confirm_your_password: "Confirm your password"
@@ -17,6 +18,7 @@ en:
         try_another_email_or_password: "Try another email address or password."
         email_not_verified: "You must verify your email before signing in."
     details: "User Details"
+    name: "Name"
     email: "Email"
     change_password: "Change password"
     profile: "Profile"

--- a/config/locales/users.ko.yml
+++ b/config/locales/users.ko.yml
@@ -4,6 +4,7 @@ ko:
       your_creativeness_is_coming: "당신의 창작물이 실현됩니다!"
       a_tracker_of_your_creatives: "문서처럼 작업 트리 리스트를 보면서 완료여부를 확인하세요."
     new:
+      enter_your_name: "이름을 입력하세요"
       enter_your_email: "이메일을 입력하세요"
       enter_your_password: "비밀번호를 입력하세요"
       confirm_your_password: "비밀번호를 다시 입력하세요"
@@ -17,6 +18,7 @@ ko:
         try_another_email_or_password: "이메일 주소나 비밀번호를 다시 확인하세요."
         email_not_verified: "이메일 인증 후에 로그인할 수 있습니다."
     details: "사용자 정보"
+    name: "이름"
     email: "이메일"
     change_password: "비밀번호 변경"
     profile: "프로파일"

--- a/db/migrate/20250624000000_add_name_to_users.rb
+++ b/db/migrate/20250624000000_add_name_to_users.rb
@@ -1,0 +1,18 @@
+class AddNameToUsers < ActiveRecord::Migration[7.1]
+  class User < ActiveRecord::Base; end
+
+  def up
+    add_column :users, :name, :string
+
+    User.reset_column_information
+    User.find_each do |user|
+      user.update_columns(name: user.email.to_s.split('@').first)
+    end
+
+    change_column_null :users, :name, false
+  end
+
+  def down
+    remove_column :users, :name
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_23_000000) do
+ActiveRecord::Schema[8.0].define(version: 2025_06_24_000000) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
     t.text "body"
@@ -340,6 +340,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_23_000000) do
     t.integer "display_level", default: 6, null: false
     t.string "completion_mark", default: "", null: false
     t.string "theme"
+    t.string "name", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -3,7 +3,9 @@
 one:
   email: one@example.com
   password_digest: <%= password_digest %>
+  name: One
 
 two:
   email: two@example.com
   password_digest: <%= password_digest %>
+  name: Two

--- a/test/integration/email_verification_flow_test.rb
+++ b/test/integration/email_verification_flow_test.rb
@@ -4,7 +4,7 @@ require "cgi"
 class EmailVerificationFlowTest < ActionDispatch::IntegrationTest
   test "verification link verifies user" do
     ActionMailer::Base.deliveries.clear
-    post users_path, params: { user: { email: "verify@example.com", password: "secret", password_confirmation: "secret" } }
+    post users_path, params: { user: { email: "verify@example.com", password: "secret", password_confirmation: "secret", name: "Verify" } }
     user = User.find_by(email: "verify@example.com")
     assert_not_nil user
     assert_nil user.email_verified_at

--- a/test/integration/invitation_flow_test.rb
+++ b/test/integration/invitation_flow_test.rb
@@ -3,7 +3,7 @@ require "cgi"
 
 class InvitationFlowTest < ActionDispatch::IntegrationTest
   test "invitation link resolves to invitation" do
-    inviter = User.create!(email: "inviter@example.com", password: "secret")
+    inviter = User.create!(email: "inviter@example.com", password: "secret", name: "Inviter")
     creative = Creative.create!(user: inviter, description: "Test creative")
 
     invitation = Invitation.create!(email: "invitee@example.com",

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -11,7 +11,7 @@ class CommentTest < ActiveSupport::TestCase
 
     item = InboxItem.last
     assert_equal creative.user, item.owner
-    assert_includes item.message, commenter.email
+    assert_includes item.message, commenter.name
     expected_link = Rails.application.routes.url_helpers.creative_comment_url(
       creative,
       Comment.last,

--- a/test/models/creative_share_test.rb
+++ b/test/models/creative_share_test.rb
@@ -14,7 +14,7 @@ class CreativeShareTest < ActiveSupport::TestCase
 
     item = InboxItem.last
     assert_equal recipient, item.owner
-    assert_includes item.message, sharer.email
+    assert_includes item.message, sharer.name
     assert_includes item.message, "T-Shirt"
     expected_link = Rails.application.routes.url_helpers.creative_url(
       creative,

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -2,14 +2,14 @@ require "test_helper"
 
 class UserTest < ActiveSupport::TestCase
   test "requires valid email" do
-    user = User.new(email: "bad", password: "secret", password_confirmation: "secret")
+    user = User.new(email: "bad", password: "secret", password_confirmation: "secret", name: "Bad")
     assert_not user.valid?
     assert_includes user.errors[:email], "is invalid"
   end
 
   test "requires unique email" do
-    User.create!(email: "taken@example.com", password: "secret")
-    user = User.new(email: "taken@example.com", password: "secret")
+    User.create!(email: "taken@example.com", password: "secret", name: "Taken")
+    user = User.new(email: "taken@example.com", password: "secret", name: "Taken")
     assert_not user.valid?
     assert_includes user.errors[:email], "has already been taken"
   end


### PR DESCRIPTION
## Summary
- require `name` for users
- auto-populate `name` from email during migration
- show name fields as required in forms

## Testing
- `./bin/rubocop -a`
- `bin/rails test`


------
https://chatgpt.com/codex/tasks/task_e_686e21422b3483268bc644a762a71c0b