### PR TITLE
Move delete buttons into inline editor

### DIFF
--- a/app/javascript/creative_row_editor.js
+++ b/app/javascript/creative_row_editor.js
@@ -14,6 +14,8 @@ if (!window.creativeRowEditorInitialized) {
     const downBtn = document.getElementById('inline-move-down');
     const addBtn = document.getElementById('inline-add');
     const closeBtn = document.getElementById('inline-close');
+    const deleteBtn = document.getElementById('inline-delete');
+    const deleteChildrenBtn = document.getElementById('inline-delete-with-children');
 
     const methodInput = document.getElementById('inline-method');
     const parentInput = document.getElementById('inline-parent-id');
@@ -229,6 +231,8 @@ if (!window.creativeRowEditorInitialized) {
         .then(data => {
           form.action = `/creatives/${data.id}`;
           form.dataset.creativeId = data.id;
+          if (deleteBtn) deleteBtn.style.display = '';
+          if (deleteChildrenBtn) deleteChildrenBtn.style.display = '';
           descriptionInput.value = data.description || '';
           editor.editor.loadHTML(data.description || '');
           progressInput.value = data.progress || 0;
@@ -329,6 +333,8 @@ if (!window.creativeRowEditorInitialized) {
       form.action = '/creatives';
       methodInput.value = '';
       form.dataset.creativeId = '';
+      if (deleteBtn) deleteBtn.style.display = 'none';
+      if (deleteChildrenBtn) deleteChildrenBtn.style.display = 'none';
       parentInput.value = parentId || '';
       beforeInput.value = beforeId || '';
       afterInput.value = afterId || '';
@@ -386,6 +392,28 @@ if (!window.creativeRowEditorInitialized) {
 
     if (addBtn) {
       addBtn.addEventListener('click', addNew);
+    }
+
+    if (deleteBtn) {
+      deleteBtn.addEventListener('click', function() {
+        if (!form.dataset.creativeId) return;
+        if (!confirm(deleteBtn.dataset.confirm)) return;
+        fetch(`/creatives/${form.dataset.creativeId}`, {
+          method: 'DELETE',
+          headers: { 'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').content }
+        }).then(function() { location.reload(); });
+      });
+    }
+
+    if (deleteChildrenBtn) {
+      deleteChildrenBtn.addEventListener('click', function() {
+        if (!form.dataset.creativeId) return;
+        if (!confirm(deleteChildrenBtn.dataset.confirm)) return;
+        fetch(`/creatives/${form.dataset.creativeId}?delete_with_children=true`, {
+          method: 'DELETE',
+          headers: { 'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').content }
+        }).then(function() { location.reload(); });
+      });
     }
 
     attachButtons();

--- a/app/javascript/creative_row_editor.js
+++ b/app/javascript/creative_row_editor.js
@@ -398,10 +398,22 @@ if (!window.creativeRowEditorInitialized) {
       deleteBtn.addEventListener('click', function() {
         if (!form.dataset.creativeId) return;
         if (!confirm(deleteBtn.dataset.confirm)) return;
+        const parentId = parentInput.value || '';
+        const container = currentTree.parentNode;
+        const insertBefore = currentTree.nextSibling;
+        const beforeId = insertBefore ? insertBefore.id.replace('creative-', '') : '';
+        const prev = currentTree.previousSibling;
+        const afterId = !beforeId && prev ? prev.id.replace('creative-', '') : '';
         fetch(`/creatives/${form.dataset.creativeId}`, {
           method: 'DELETE',
           headers: { 'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').content }
-        }).then(function() { location.reload(); });
+        }).then(function(r) {
+          if (!r.ok) return;
+          const parentTree = parentId ? document.getElementById(`creative-${parentId}`) : null;
+          currentTree.remove();
+          startNew(parentId, container, insertBefore, beforeId, afterId);
+          if (parentTree) refreshRow(parentTree);
+        });
       });
     }
 
@@ -409,10 +421,22 @@ if (!window.creativeRowEditorInitialized) {
       deleteChildrenBtn.addEventListener('click', function() {
         if (!form.dataset.creativeId) return;
         if (!confirm(deleteChildrenBtn.dataset.confirm)) return;
+        const parentId = parentInput.value || '';
+        const container = currentTree.parentNode;
+        const insertBefore = currentTree.nextSibling;
+        const beforeId = insertBefore ? insertBefore.id.replace('creative-', '') : '';
+        const prev = currentTree.previousSibling;
+        const afterId = !beforeId && prev ? prev.id.replace('creative-', '') : '';
         fetch(`/creatives/${form.dataset.creativeId}?delete_with_children=true`, {
           method: 'DELETE',
           headers: { 'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').content }
-        }).then(function() { location.reload(); });
+        }).then(function(r) {
+          if (!r.ok) return;
+          const parentTree = parentId ? document.getElementById(`creative-${parentId}`) : null;
+          currentTree.remove();
+          startNew(parentId, container, insertBefore, beforeId, afterId);
+          if (parentTree) refreshRow(parentTree);
+        });
       });
     }
 

--- a/app/views/creatives/_inline_edit_form.html.erb
+++ b/app/views/creatives/_inline_edit_form.html.erb
@@ -18,5 +18,15 @@
       <button type="button" id="inline-add">＋</button>
       <button type="button" id="inline-close">✖</button>
     </div>
+    <div style="margin-top:0.5em;">
+      <button type="button" id="inline-delete"
+              data-confirm="<%= t('creatives.index.are_you_sure_delete_only_this') %>">
+        <%= t('creatives.index.delete_only_this') %>
+      </button>
+      <button type="button" id="inline-delete-with-children"
+              data-confirm="<%= t('creatives.index.are_you_sure_delete_with_children') %>">
+        <%= t('creatives.index.delete_with_children') %>
+      </button>
+    </div>
   </form>
 </div>


### PR DESCRIPTION
## Summary
- show delete controls in inline editor instead of row actions
- handle delete via AJAX in `creative_row_editor.js`

## Testing
- `./bin/rubocop -a`
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_686f024545e8832683200744c5e3cfbd