### PR TITLE
Fix comment button overlap

### DIFF
--- a/app/assets/stylesheets/comments_popup.css
+++ b/app/assets/stylesheets/comments_popup.css
@@ -49,20 +49,16 @@
     white-space:pre-line;
 }
 
-.delete-comment-btn {
+.comment-action-container {
     position: absolute;
     bottom: 0.2em;
     right: 0.2em;
-    border: none;
-    background: none;
-    font-weight: bold;
-    cursor: pointer;
+    display: flex;
+    gap: 0.2em;
 }
 
+.delete-comment-btn,
 .edit-comment-btn {
-    position: absolute;
-    bottom: 0.2em;
-    right: 5em; /* ensure enough spacing for translated text */
     border: none;
     background: none;
     font-weight: bold;

--- a/app/assets/stylesheets/comments_popup.css
+++ b/app/assets/stylesheets/comments_popup.css
@@ -62,7 +62,7 @@
 .edit-comment-btn {
     position: absolute;
     bottom: 0.2em;
-    right: 2.5em;
+    right: 5em; /* ensure enough spacing for translated text */
     border: none;
     background: none;
     font-weight: bold;

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -4,12 +4,14 @@
     <strong><%= comment.user&.display_name || t('comments.anonymous') %></strong>
     <span>· <%= t('datetime.ago', time: time_ago_in_words(comment.created_at)) %></span>
     <% if comment.user == Current.user %>
-      <button class="edit-comment-btn" data-comment-id="<%= comment.id %>" data-comment-content="<%= comment.content %>" title="<%= t('comments.update_comment') %>">
-        <%= t('comments.edit_button') %>
-      </button>
-      <button class="delete-comment-btn" data-comment-id="<%= comment.id %>" title="<%= t('comments.delete') %>">
-        <%= t('comments.delete_button') %>
-      </button>
+      <div class="comment-action-container">
+        <button class="edit-comment-btn" data-comment-id="<%= comment.id %>" data-comment-content="<%= comment.content %>" title="<%= t('comments.update_comment') %>">
+          <%= t('comments.edit_button') %>
+        </button>
+        <button class="delete-comment-btn" data-comment-id="<%= comment.id %>" title="<%= t('comments.delete') %>">
+          <%= t('comments.delete_button') %>
+        </button>
+      </div>
     <% end %>
   </div>
   <div class="comment-content">


### PR DESCRIPTION
## Summary
- space out edit/delete comment buttons so they don't overlap in English UI

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: 13 examples)*

------
https://chatgpt.com/codex/tasks/task_e_686f3a8cb97c832696c67f793dcda4d1