### PR TITLE
Fix specs for User.name requirement

### DIFF
--- a/spec/models/comment_mentions_spec.rb
+++ b/spec/models/comment_mentions_spec.rb
@@ -3,15 +3,15 @@ require 'ostruct'
 
 describe Comment, type: :model do
   it 'creates inbox item for mentioned users' do
-    owner = User.create!(email: 'owner@example.com', password: 'pw')
-    commenter = User.create!(email: 'commenter@example.com', password: 'pw')
-    mentioned = User.create!(email: 'mentioned@example.com', password: 'pw')
+    owner = User.create!(email: 'owner@example.com', password: 'pw', name: 'Owner')
+    commenter = User.create!(email: 'commenter@example.com', password: 'pw', name: 'Commenter')
+    mentioned = User.create!(email: 'mentioned@example.com', password: 'pw', name: 'Mentioned')
     creative = Creative.create!(user: owner, description: 'root')
 
     comment = Comment.create!(creative: creative, user: commenter, content: "hi @#{mentioned.email}")
 
     item = InboxItem.find_by(owner: mentioned)
     expect(item).not_to be_nil
-    expect(item.message).to include(commenter.email)
+    expect(item.message).to include(commenter.name)
   end
 end

--- a/spec/models/comment_read_pointer_spec.rb
+++ b/spec/models/comment_read_pointer_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe CommentReadPointer, type: :model do
   it 'enforces user and creative uniqueness' do
-    user = User.create!(email: 'user@example.com', password: 'pw')
+    user = User.create!(email: 'user@example.com', password: 'pw', name: 'User')
     creative = Creative.create!(user: user, description: 'c')
     CommentReadPointer.create!(user: user, creative: creative)
 

--- a/spec/models/comment_user_spec.rb
+++ b/spec/models/comment_user_spec.rb
@@ -3,8 +3,8 @@ require 'ostruct'
 
 RSpec.describe Comment, type: :model do
   it 'defaults user to Current.user on create' do
-    owner = User.create!(email: 'creative_owner@example.com', password: 'pw')
-    user = User.create!(email: 'test@example.com', password: 'pw')
+    owner = User.create!(email: 'creative_owner@example.com', password: 'pw', name: 'Owner')
+    user = User.create!(email: 'test@example.com', password: 'pw', name: 'User')
     Current.session = OpenStruct.new(user: user)
     creative = Creative.create!(user: owner, description: 'creative')
 

--- a/spec/models/creative_ancestor_spec.rb
+++ b/spec/models/creative_ancestor_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 require 'ostruct'
 
 RSpec.describe 'Creative ancestor updates', type: :model do
-  let(:user) { User.create!(email: 'owner1@example.com', password: 'pw') }
+  let(:user) { User.create!(email: 'owner1@example.com', password: 'pw', name: 'Owner1') }
 
   before do
     Current.session = OpenStruct.new(user: user)

--- a/spec/models/creative_linked_spec.rb
+++ b/spec/models/creative_linked_spec.rb
@@ -2,11 +2,11 @@ require 'rails_helper'
 require 'ostruct'
 
 RSpec.describe 'Linked Creative', type: :model do
-  let(:owner) { user = User.create!(email: 'owner@example.com', password: 'pw')
+  let(:owner) { user = User.create!(email: 'owner@example.com', password: 'pw', name: 'Owner')
     Current.session = OpenStruct.new(user: user)
     user
   }
-  let(:shared_user) { User.create!(email: 'shared@example.com', password: 'pw') }
+  let(:shared_user) { User.create!(email: 'shared@example.com', password: 'pw', name: 'Shared') }
   let(:parent) { Creative.create!(user: owner, description: 'Parent') }
   let(:creative) { Creative.create!(user: owner, parent: parent, description: 'Original', progress: 1.0) }
 
@@ -43,7 +43,7 @@ RSpec.describe 'Linked Creative', type: :model do
     it 'owner 또는 CreativeShare가 있으면 has_permission?이 true' do
       expect(creative.has_permission?(owner)).to be true
       expect(creative.has_permission?(shared_user)).to be true
-      expect(creative.has_permission?(User.new(email: 'other@example.com', password: 'pw'))).to be false
+      expect(creative.has_permission?(User.new(email: 'other@example.com', password: 'pw', name: 'Other'))).to be false
     end
   end
 end

--- a/spec/models/creative_user_spec.rb
+++ b/spec/models/creative_user_spec.rb
@@ -3,7 +3,7 @@ require 'ostruct'
 
 RSpec.describe Creative, type: :model do
   let(:owner) do
-    user = User.create!(email: 'owner@example.com', password: 'pw')
+    user = User.create!(email: 'owner@example.com', password: 'pw', name: 'Owner')
     Current.session = OpenStruct.new(user: user)
     user
   end
@@ -14,7 +14,7 @@ RSpec.describe Creative, type: :model do
 
   it 'assigns parent user when parent_id is present' do
     parent = Creative.create!(user: owner, description: 'Parent')
-    other_user = User.create!(email: 'other@example.com', password: 'pw')
+    other_user = User.create!(email: 'other@example.com', password: 'pw', name: 'Other')
     Current.session = OpenStruct.new(user: other_user)
     child = Creative.create!(parent: parent, description: 'Child')
     expect(child.user).to eq(parent.user)

--- a/spec/requests/linked_creative_parent_spec.rb
+++ b/spec/requests/linked_creative_parent_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 require 'ostruct'
 
 RSpec.describe 'Linked Creative parent update', type: :request do
-  let(:owner) { User.create!(email: 'owner@example.com', password: 'pw') }
-  let(:shared_user) { User.create!(email: 'shared@example.com', password: 'pw') }
+  let(:owner) { User.create!(email: 'owner@example.com', password: 'pw', name: 'Owner') }
+  let(:shared_user) { User.create!(email: 'shared@example.com', password: 'pw', name: 'Shared') }
   let(:parent) { Creative.create!(user: owner, description: 'Parent') }
   let(:creative) { Creative.create!(user: owner, parent: parent, description: 'Original') }
   let(:new_parent) { Creative.create!(user: shared_user, description: 'New Parent') }

--- a/spec/system/creative_share_spec.rb
+++ b/spec/system/creative_share_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Creative 공유 리스트', type: :system do
-  let!(:user) { User.create!(email: 'user1@example.com', password: 'password', email_verified_at: Time.now) }
+  let!(:user) { User.create!(email: 'user1@example.com', password: 'password', name: 'User1', email_verified_at: Time.now) }
   let!(:creative) { Creative.create!(description: '테스트', user: user) }
   let!(:share) { CreativeShare.create!(creative: creative, user: user, permission: 'read') }
 
@@ -20,7 +20,7 @@ RSpec.describe 'Creative 공유 리스트', type: :system do
     expect(page).not_to have_content(I18n.t('users.sessions.new.try_another_email_or_password'))
     visit creative_path(creative)
     expect(page).to have_css('#share-creative-modal', text: I18n.t('creatives.index.shared_with'), visible: :all)
-    expect(page).to have_css('#share-creative-modal', text: 'user1@example.com', visible: :all)
+    expect(page).to have_css('#share-creative-modal', text: 'User1', visible: :all)
     expect(page).to have_css('#share-creative-modal', text: 'Read', visible: :all)
   end
 end

--- a/spec/system/user_signup_spec.rb
+++ b/spec/system/user_signup_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 describe 'User sign up', type: :system do
   it 'creates a new user' do
     visit new_user_path
+    fill_in placeholder: I18n.t('users.new.enter_your_name'), with: 'Test User'
     fill_in placeholder: I18n.t('users.new.enter_your_email'), with: 'testuser@example.com'
     fill_in placeholder: I18n.t('users.new.enter_your_password'), with: 'password123'
     fill_in placeholder: I18n.t('users.new.confirm_your_password'), with: 'password123'


### PR DESCRIPTION
## Summary
- update specs to use `name` when creating users
- adjust expectations to match new display name usage

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec`

------
https://chatgpt.com/codex/tasks/task_e_687077c85abc8326927c9fe63efc70fe