### PR TITLE
Remove name field from login form

### DIFF
--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,7 +1,7 @@
 <%= render 'users/app_header' %>
 
 <%= form_with url: session_path do |form| %>
-  <%= render 'users/id_pwd_fields', form: form %>
+  <%= render 'users/id_pwd_fields', form: form, skip_name_field: true %>
   <%= tag.div(flash[:alert], class: "flash-alert") if flash[:alert] %>
   <%= form.submit t('app.sign_in'), id: 'sign-in-submit' %>
 <% end %>

--- a/app/views/users/_id_pwd_fields.html.erb
+++ b/app/views/users/_id_pwd_fields.html.erb
@@ -1,7 +1,9 @@
-<%= form.text_field :name,
-                    autofocus: true,
-                    required: true,
-                    placeholder: t('users.new.enter_your_name') %><br/>
+<% unless local_assigns[:skip_name_field] %>
+  <%= form.text_field :name,
+                      autofocus: true,
+                      required: true,
+                      placeholder: t('users.new.enter_your_name') %><br/>
+<% end %>
 <%= form.email_field :email,
                      required: true,
                      autocomplete: "username",

--- a/spec/system/creative_share_spec.rb
+++ b/spec/system/creative_share_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe 'Creative 공유 리스트', type: :system do
   it '공유 리스트가 정상적으로 표시된다' do
     resize_window_to_pc
     visit new_session_path
+    expect(page).not_to have_field(placeholder: I18n.t('users.new.enter_your_name'))
     fill_in placeholder: I18n.t('users.new.enter_your_email'), with: user.email
     fill_in placeholder: I18n.t('users.new.enter_your_password'), with: 'password'
     find('#sign-in-submit').click


### PR DESCRIPTION
## Summary
- hide the name input when signing in
- update login form partial to conditionally show name field
- test login page doesn't show the name field

## Testing
- `bundle exec rspec`
- `./bin/rubocop -a`


------
https://chatgpt.com/codex/tasks/task_e_6875386d80348326b661ae0a7e7ae68a