### PR TITLE
Expose Firebase config

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,12 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
+    <% if Rails.application.config.x.firebase_config.present? %>
+      <script>
+        window.firebaseConfig = <%= Rails.application.config.x.firebase_config.to_json.html_safe %>
+      </script>
+    <% end %>
+
     <%= yield :head %>
 
     <%# Enable PWA manifest for installable apps (make sure to enable in config/routes.rb too!) %>

--- a/config/initializers/fcm.rb
+++ b/config/initializers/fcm.rb
@@ -1,3 +1,5 @@
-if ENV["FCM_SERVER_KEY"].present?
-  Rails.application.config.x.fcm_client = FCM.new(ENV.fetch("FCM_SERVER_KEY"))
+server_key = Rails.application.credentials.dig(:fcm, :server_key) || ENV["FCM_SERVER_KEY"]
+
+if server_key.present?
+  Rails.application.config.x.fcm_client = FCM.new(server_key)
 end

--- a/config/initializers/firebase_config.rb
+++ b/config/initializers/firebase_config.rb
@@ -1,0 +1,10 @@
+firebase_settings = {
+  apiKey: Rails.application.credentials.dig(:firebase, :api_key),
+  authDomain: Rails.application.credentials.dig(:firebase, :auth_domain),
+  projectId: Rails.application.credentials.dig(:firebase, :project_id),
+  appId: Rails.application.credentials.dig(:firebase, :app_id),
+  messagingSenderId: Rails.application.credentials.dig(:fcm, :sender_id),
+  vapidKey: Rails.application.credentials.dig(:fcm, :vapid_key)
+}.compact
+
+Rails.application.config.x.firebase_config = firebase_settings if firebase_settings.present?

--- a/docs/fcm-setup.md
+++ b/docs/fcm-setup.md
@@ -12,14 +12,20 @@
 1. **Cloud Messaging** 탭에서 `웹 푸시 인증서` 섹션의 **키 생성** 버튼을 눌러 VAPID 키 쌍을 발급받습니다.
 2. 생성된 `공개 키`를 프론트엔드 애플리케이션에서 사용하도록 저장합니다.
 
-## 3. 백엔드 환경 변수 설정
+## 3. 백엔드 설정
 
-Rails 애플리케이션에서 FCM을 사용하려면 환경 변수에 다음 값을 등록합니다.
+Rails 애플리케이션에서 FCM을 사용하려면 `rails credentials:edit` 명령어로 다음 값들을 추가합니다.
 
-```bash
-FCM_SERVER_KEY=your_server_key
-FCM_SENDER_ID=your_sender_id
-FCM_VAPID_KEY=generated_vapid_public_key
+```yaml
+firebase:
+  api_key: your_api_key
+  auth_domain: your_auth_domain
+  project_id: your_project_id
+  app_id: your_app_id
+fcm:
+  server_key: your_server_key
+  sender_id: your_sender_id
+  vapid_key: generated_vapid_public_key
 ```
 
 ## 4. 클라이언트 설정
@@ -30,18 +36,12 @@ FCM_VAPID_KEY=generated_vapid_public_key
 import { initializeApp } from "firebase/app";
 import { getMessaging, getToken, onMessage } from "firebase/messaging";
 
-const firebaseConfig = {
-  apiKey: "<YOUR_API_KEY>",
-  authDomain: "<YOUR_AUTH_DOMAIN>",
-  projectId: "<YOUR_PROJECT_ID>",
-  messagingSenderId: process.env.FCM_SENDER_ID,
-  appId: "<YOUR_APP_ID>"
-};
+const firebaseConfig = window.firebaseConfig;
 
 const app = initializeApp(firebaseConfig);
 const messaging = getMessaging(app);
 
-getToken(messaging, { vapidKey: process.env.FCM_VAPID_KEY }).then((currentToken) => {
+getToken(messaging, { vapidKey: firebaseConfig.vapidKey }).then((currentToken) => {
   if (currentToken) {
     // 서버로 토큰 전송
   }
@@ -59,7 +59,7 @@ FCM 서버 키를 사용하여 알림을 전송할 수 있습니다. `fcm` gem�
 ```ruby
 require "fcm"
 
-fcm = FCM.new(ENV.fetch("FCM_SERVER_KEY"))
+fcm = FCM.new(Rails.application.credentials.dig(:fcm, :server_key))
 
 response = fcm.send(registration_ids, {
   notification: {


### PR DESCRIPTION
## Summary
- set Firebase config from encrypted credentials
- use encrypted credential in FCM initializer
- update FCM setup guide for credentials-based config

## Testing
- `./bin/rubocop -a`


------
https://chatgpt.com/codex/tasks/task_e_6875ec7d89dc8326bb1e8eb78f924c5c