### PR TITLE
Update timeline fetching behavior

### DIFF
--- a/app/components/plans_timeline_component.html.erb
+++ b/app/components/plans_timeline_component.html.erb
@@ -1,6 +1,6 @@
 <div class="plans-timeline-wrapper">
   <button id="timeline-today-btn" type="button"><%= t('plans.today', default: '오늘') %></button>
-  <div id="plans-timeline" class="horizontal-timeline" data-plans='<%= raw plan_data.to_json %>' data-start-date="<%= @start_date %>" data-end-date="<%= @end_date %>" data-delete-confirm="<%= t('plans.delete_confirm', default: 'Are you sure?') %>"></div>
+  <div id="plans-timeline" class="horizontal-timeline" data-plans='<%= raw plan_data.to_json %>' data-start-date="<%= @start_date %>" data-end-date="<%= @end_date %>" data-center-date="<%= @center_date %>" data-delete-confirm="<%= t('plans.delete_confirm', default: 'Are you sure?') %>"></div>
 </div>
 <hr>
 <div class="plan-form-container">

--- a/app/components/plans_timeline_component.rb
+++ b/app/components/plans_timeline_component.rb
@@ -1,13 +1,14 @@
 class PlansTimelineComponent < ViewComponent::Base
-  def initialize(plans:)
-    @start_date = Date.current - 30
-    @end_date = Date.current + 30
+  def initialize(plans:, center_date: Date.current)
+    @center_date = center_date.to_date
+    @start_date = @center_date - 30
+    @end_date = @center_date + 30
     @plans = plans
       .where("target_date >= ? AND created_at <= ?", @start_date, @end_date)
       .order(:created_at)
   end
 
-  attr_reader :plans, :start_date, :end_date
+  attr_reader :plans, :start_date, :end_date, :center_date
 
   def plan_data
     @plan_data ||= @plans.map do |plan|

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -1,13 +1,24 @@
 class PlansController < ApplicationController
   def index
-    start_date = Date.current - 30
-    end_date = Date.current + 30
+    center_date =
+      begin
+        params[:center_date].present? ? Date.parse(params[:center_date]) : Date.current
+      rescue ArgumentError
+        Date.current
+      end
+
+    start_date = center_date - 30
+    end_date = center_date + 30
+
     @plans = Plan.where(owner: Current.user).or(Plan.where(owner: nil))
                  .where("target_date >= ? AND created_at <= ?", start_date, end_date)
                  .order(:created_at)
     respond_to do |format|
       format.html do
-        render html: render_to_string(PlansTimelineComponent.new(plans: @plans), layout: false)
+        render html: render_to_string(
+          PlansTimelineComponent.new(plans: @plans, center_date: center_date),
+          layout: false
+        )
       end
       format.json do
         render json: @plans.map { |p| plan_json(p) }

--- a/app/javascript/plans_timeline.js
+++ b/app/javascript/plans_timeline.js
@@ -231,9 +231,15 @@ if (!window.plansTimelineScriptInitialized) {
       updatePlanPositions();
       clearTimeout(scrollTimer);
       scrollTimer = setTimeout(function() {
-        var offsetDays = (container.scrollLeft + container.clientWidth / 2) / dayWidth;
-        var date = new Date(startDate.getTime() + Math.round(offsetDays) * 86400000);
-        reloadPlans(date);
+        var offsetDays =
+          (container.scrollLeft + container.clientWidth / 2 - dayWidth / 2) /
+          dayWidth;
+        var date = new Date(
+          startDate.getTime() + Math.round(offsetDays) * 86400000
+        );
+        if (date.toISOString().slice(0, 10) !== container.dataset.centerDate) {
+          reloadPlans(date);
+        }
       }, 300);
     });
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -172,7 +172,13 @@
               if (area.style.display === 'none') {
                 area.style.display = 'block';
                 if (!loaded) {
-                  fetch('/plans.json')
+                  var center = new Date();
+                  if (timeline) {
+                    timeline.dataset.centerDate = center.toISOString().slice(0,10);
+                    timeline.dataset.startDate = new Date(center.getTime() - 30*86400000).toISOString().slice(0,10);
+                    timeline.dataset.endDate = new Date(center.getTime() + 30*86400000).toISOString().slice(0,10);
+                  }
+                  fetch('/plans.json?center_date=' + center.toISOString().slice(0,10))
                     .then(function(r) { return r.json(); })
                     .then(function(plans) {
                       if (timeline) { timeline.dataset.plans = JSON.stringify(plans); }


### PR DESCRIPTION
## Summary
- make plans fetch and rendering centered around chosen date
- record center date in component and update start/end dates
- fetch plans when timeline scroll stops

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec`

------
https://chatgpt.com/codex/tasks/task_e_688838c79d588326af96ce1f2ea7a01e