### PR TITLE
Fetch plans after scrolling timeline

### DIFF
--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -1,7 +1,12 @@
 class PlansController < ApplicationController
   def index
-    start_date = Date.current - 30
-    end_date = Date.current + 30
+    center = if params[:date].present?
+                Date.parse(params[:date]) rescue Date.current
+    else
+                Date.current
+    end
+    start_date = center - 30
+    end_date = center + 30
     @plans = Plan.where(owner: Current.user).or(Plan.where(owner: nil))
                  .where("target_date >= ? AND created_at <= ?", start_date, end_date)
                  .order(:created_at)


### PR DESCRIPTION
## Summary
- center timeline queries in `PlansController`
- automatically reload plans after scrolling stops

## Testing
- `./bin/rubocop -a`
- `bundle exec rake test`


------
https://chatgpt.com/codex/tasks/task_e_688843b452608326aab6af233d569b7a