### PR TITLE
Update mobile navigation

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -127,6 +127,9 @@ main {
     main {
         padding: 0 0.3rem;
     }
+    #search {
+        width: 8em;
+    }
 }
 
 .notice {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -46,6 +46,9 @@
       <form action="<%= creatives_path %>" method="get" style="display:inline; margin-right:0.2em;">
         <input type="text" id="search" name="search" value="<%= params[:search] %>" placeholder="<%= t('app.search_placeholder') %>" />
       </form>
+      <% if authenticated? %>
+        <button class="plans-menu-btn mobile-only" type="button"><%= t('app.plans') %></button>
+      <% end %>
 
       <div class="desktop-only">
         <%= button_to t('app.home'), root_path, method: :get %>
@@ -93,9 +96,6 @@
           ) do %>
         <div><%= button_to t('app.home'), root_path, method: :get %></div>
         <% if authenticated? %>
-          <div>
-            <button class="plans-menu-btn" type="button"><%= t('app.plans') %></button>
-          </div>
           <% progress_state = if params[:min_progress] == '1' && params[:max_progress] == '1'
                                 :complete
                               elsif params[:min_progress] == '0' && params[:max_progress] == '0.99'


### PR DESCRIPTION
## Summary
- shorten the search bar on small screens
- show `Plans` button directly on mobile instead of in the popup menu

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec`

------
https://chatgpt.com/codex/tasks/task_e_68885a3d60948326bf44dfc9d2402d34