### PR TITLE
Add initials overlay for default avatars

### DIFF
--- a/app/assets/stylesheets/user_menu.css
+++ b/app/assets/stylesheets/user_menu.css
@@ -13,3 +13,22 @@
   margin-right: 0.4em;
 }
 
+.avatar-wrapper {
+  position: relative;
+  display: inline-block;
+}
+
+.avatar-initial {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: bold;
+  color: #fff;
+  pointer-events: none;
+}
+

--- a/app/components/avatar_component.html.erb
+++ b/app/components/avatar_component.html.erb
@@ -1,8 +1,15 @@
-<%= image_tag avatar_url,
-              alt: '',
-              width: size,
-              height: size,
-              class: classes,
-              title: email,
-              style: 'border-radius:50%;vertical-align:middle;',
-              data: data %>
+<div class="avatar-wrapper" style="width: <%= size %>px; height: <%= size %>px;">
+  <%= image_tag avatar_url,
+                alt: '',
+                width: size,
+                height: size,
+                class: classes,
+                title: email,
+                style: 'border-radius:50%;vertical-align:middle;',
+                data: data %>
+  <% if default_avatar? %>
+    <span class="avatar-initial" style="font-size: <%= (size / 2.0).round %>px;">
+      <%= initial %>
+    </span>
+  <% end %>
+</div>

--- a/app/components/avatar_component.rb
+++ b/app/components/avatar_component.rb
@@ -16,6 +16,14 @@ class AvatarComponent < ViewComponent::Base
     end
   end
 
+  def default_avatar?
+    @user && !@user.avatar.attached? && @user.avatar_url.blank?
+  end
+
+  def initial
+    @user.display_name[0].upcase
+  end
+
   def email
     if @user
       @user.display_name


### PR DESCRIPTION
## Summary
- overlay first letter on default avatar images
- style avatar wrapper and text overlay

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec`

------
https://chatgpt.com/codex/tasks/task_e_688860a0a29883268e7f35cc1672f50f