### PR TITLE
Fix Plan Timeline date order when prepending days

### DIFF
--- a/app/javascript/plans_timeline.js
+++ b/app/javascript/plans_timeline.js
@@ -37,14 +37,21 @@ if (!window.plansTimelineScriptInitialized) {
 
     function renderDays(from, to, prepend) {
       var date = new Date(from);
-      while (date <= to) {
-        var el = createDay(new Date(date));
-        if (prepend) {
-          scroll.insertBefore(el, scroll.firstChild);
-        } else {
-          scroll.appendChild(el);
+      if (prepend) {
+        var days = [];
+        while (date <= to) {
+          days.push(createDay(new Date(date)));
+          date.setDate(date.getDate() + 1);
         }
-        date.setDate(date.getDate() + 1);
+        for (var i = days.length - 1; i >= 0; i--) {
+          scroll.insertBefore(days[i], scroll.firstChild);
+        }
+      } else {
+        while (date <= to) {
+          var el = createDay(new Date(date));
+          scroll.appendChild(el);
+          date.setDate(date.getDate() + 1);
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- fix ordering of day cells when scrolling left in Plan Timeline

## Testing
- `./bin/rubocop -a`
- `bin/rails test`
- `bundle exec rspec`


------
https://chatgpt.com/codex/tasks/task_e_68888acfba0c83269c1ba273b588551f