### PR TITLE
Improve inline creative editing UX

### DIFF
--- a/app/javascript/creative_row_editor.js
+++ b/app/javascript/creative_row_editor.js
@@ -24,6 +24,7 @@ if (!window.creativeRowEditorInitialized) {
     let currentTree = null;
     let saveTimer = null;
     let pendingSave = false;
+    let needsReload = false;
 
     function hideRow(tree) {
       const row = tree.querySelector('.creative-row');
@@ -91,7 +92,7 @@ if (!window.creativeRowEditorInitialized) {
             if (parentTree) {
               refreshChildren(parentTree);
             } else {
-              location.reload();
+              needsReload = true;
             }
           } else if (method === 'PATCH') {
             if (tree) refreshRow(tree);
@@ -100,7 +101,7 @@ if (!window.creativeRowEditorInitialized) {
       });
     }
 
-    function hideCurrent() {
+    function hideCurrent(reload = false) {
       if (!currentTree) return;
       const tree = currentTree;
       const wasNew = !form.dataset.creativeId;
@@ -113,6 +114,9 @@ if (!window.creativeRowEditorInitialized) {
         } else {
           showRow(tree);
           refreshRow(tree);
+        }
+        if (reload && needsReload) {
+          location.reload();
         }
       });
     }
@@ -354,7 +358,7 @@ if (!window.creativeRowEditorInitialized) {
     });
 
     if (closeBtn) {
-      closeBtn.addEventListener('click', hideCurrent);
+      closeBtn.addEventListener('click', function() { hideCurrent(true); });
     }
 
     upBtn.addEventListener('click', function() {


### PR DESCRIPTION
## Summary
- tweak inline creative JS to postpone page reloads until editor is closed
- reload page only when editor closes and root creatives were added

## Testing
- `./bin/rubocop -a`
- `bin/rake test`

------
https://chatgpt.com/codex/tasks/task_e_6889909706408326a4577f28f864fa29