### PR TITLE
Fix offline user initials style

### DIFF
--- a/app/assets/stylesheets/comments_popup.css
+++ b/app/assets/stylesheets/comments_popup.css
@@ -107,3 +107,7 @@
   opacity: 0.4;
   filter: grayscale(1);
 }
+.comment-presence-avatar.inactive + .avatar-initial {
+  opacity: 0.4;
+  filter: grayscale(1);
+}


### PR DESCRIPTION
## Summary
- apply offline opacity/grayscale style to avatar initials

## Testing
- `./bin/rubocop -a`
- `bundle exec rake`

------
https://chatgpt.com/codex/tasks/task_e_6889a581cd1c8326842b2646969d1101