### PR TITLE
Show email in users list page

### DIFF
--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -2,6 +2,6 @@
 
 <ul>
   <% @users.each do |user| %>
-    <li><%= user.display_name %></li>
+    <li><%= user.display_name %> (<%= user.email %>)</li>
   <% end %>
 </ul>

--- a/spec/requests/users_index_spec.rb
+++ b/spec/requests/users_index_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe 'Users index', type: :request do
+  before do
+    allow_any_instance_of(UsersController).to receive(:require_authentication).and_return(true)
+  end
+
+  it 'displays user email' do
+    user = User.create!(email: 'test@example.com', password: 'pw', name: 'Test User')
+    get users_path
+    expect(response.body).to include(user.email)
+  end
+end


### PR DESCRIPTION
## Summary
- display each user's email alongside their name on the users index page
- cover users index page with request spec verifying emails are shown

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: NoMethodError: undefined method `has_closure_tree` for Creative:Class)*
- `bundle exec rspec spec/requests/users_index_spec.rb`


------
https://chatgpt.com/codex/tasks/task_e_6891abfcf2588326ae7b1de85f47115c