### PR TITLE
Show avatars and last login on user list

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -46,7 +46,7 @@ class UsersController < ApplicationController
 
   # List all users
   def index
-    @users = User.all
+    @users = User.includes(:sessions)
   end
 
   # Show a single user

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,7 +1,21 @@
+<% content_for :head do %>
+  <%= stylesheet_link_tag 'comments_popup', media: 'all' %>
+<% end %>
+
 <h1><%= t('users.index_title') %></h1>
 
 <ul>
   <% @users.each do |user| %>
-    <li><%= user.display_name %> (<%= user.email %>)</li>
+    <% last_login_at = user.sessions.max_by(&:created_at)&.created_at %>
+    <li>
+      <%= render AvatarComponent.new(
+            user: user,
+            size: 20,
+            classes: "avatar comment-presence-avatar#{' inactive' if user.sessions.empty?}" ) %>
+      <%= user.display_name %> (<%= user.email %>)
+      <% if last_login_at %>
+        - <%= t('users.last_login_at', time: I18n.l(last_login_at, format: :short)) %>
+      <% end %>
+    </li>
   <% end %>
 </ul>

--- a/config/locales/users.en.yml
+++ b/config/locales/users.en.yml
@@ -26,6 +26,7 @@ en:
     avatar_url: "Avatar URL"
     update_profile: "Update Profile"
     index_title: "Users"
+    last_login_at: "Last login: %{time}"
     display_level: "Max Display Level"
     completion_mark: "Completion Mark"
     theme: "Theme"

--- a/config/locales/users.ko.yml
+++ b/config/locales/users.ko.yml
@@ -26,6 +26,7 @@ ko:
     avatar_url: "아바타 URL"
     update_profile: "프로파일 업데이트"
     index_title: "사용자 목록"
+    last_login_at: "마지막 로그인: %{time}"
     display_level: "최대 표시 레벨"
     completion_mark: "완료 표시 문자"
     theme: "테마"

--- a/spec/requests/users_index_spec.rb
+++ b/spec/requests/users_index_spec.rb
@@ -10,4 +10,15 @@ RSpec.describe 'Users index', type: :request do
     get users_path
     expect(response.body).to include(user.email)
   end
+
+  it 'shows last login time and avatar state' do
+    active = User.create!(email: 'active@example.com', password: 'pw', name: 'Active User')
+    session = active.sessions.create!(ip_address: '127.0.0.1', user_agent: 'test')
+    _inactive = User.create!(email: 'inactive@example.com', password: 'pw', name: 'Inactive User')
+
+    get users_path
+
+    expect(response.body).to include(I18n.l(session.created_at, format: :short))
+    expect(response.body.scan('comment-presence-avatar inactive').size).to eq(1)
+  end
 end


### PR DESCRIPTION
## Summary
- show avatars and last login time on user index
- indicate login status with active/inactive avatar styles
- test user index for avatar state and last login display

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: undefined method `has_closure_tree` for Creative:Class)*
- `bundle exec rspec spec/requests/users_index_spec.rb`


------
https://chatgpt.com/codex/tasks/task_e_6891c100d8c88326a0e809b578b40c29