### PR TITLE
Add permission request workflow for creatives

### DIFF
--- a/app/views/creatives/_share_button.html.erb
+++ b/app/views/creatives/_share_button.html.erb
@@ -45,6 +45,7 @@
         const shareBtn = document.getElementById('share-creative-btn');
         const modal = document.getElementById('share-creative-modal');
         const closeBtn = document.getElementById('close-share-modal');
+        const emailInput = document.getElementById('share-user-email');
         if (shareBtn && modal && closeBtn) {
             shareBtn.onclick = function() {
                 modal.style.display = 'flex';
@@ -60,6 +61,15 @@
                     document.body.classList.remove('no-scroll');
                 }
             };
+            const params = new URLSearchParams(window.location.search);
+            const reqEmail = params.get('share_request');
+            if (reqEmail) {
+                shareBtn.click();
+                if (emailInput) {
+                    emailInput.value = reqEmail;
+                    emailInput.dispatchEvent(new Event('blur'));
+                }
+            }
         }
     });
 </script>

--- a/app/views/creatives/index.html.erb
+++ b/app/views/creatives/index.html.erb
@@ -83,7 +83,14 @@
   <% if @creatives %>
     <%= render_creative_tree(@creatives, 1, select_mode: false, max_level: Current.user&.display_level || User::DEFAULT_DISPLAY_LEVEL) %>
   <% else %>
-    <p style="text-align: center;"><%= params[:id] ? t('.no_sub_creatives') : t('.no_creatives') %></p>
+    <% if params[:id] && @creative && !@creative.has_permission?(Current.user, :read) %>
+      <p style="text-align: center;"><%= t('.no_permission') %></p>
+      <div style="text-align: center;">
+        <%= button_to t('.request_permission'), request_permission_creative_path(@creative), method: :post %>
+      </div>
+    <% else %>
+      <p style="text-align: center;"><%= params[:id] ? t('.no_sub_creatives') : t('.no_creatives') %></p>
+    <% end %>
   <% end %>
 </div>
 

--- a/config/locales/creatives.en.yml
+++ b/config/locales/creatives.en.yml
@@ -26,6 +26,8 @@ en:
       only_markdown: "Only markdown (.md) files are allowed."
       drop_or_click_markdown: "Drop or click here to select a markdown file"
       import_markdown: "Import Markdown"
+      request_permission: "Request Access"
+      no_permission: "You do not have permission to view this Creative."
       share_creative: "Share Creative"
       shared_with: "Shared With"
       unknown_user: "Unknown user"

--- a/config/locales/creatives.ko.yml
+++ b/config/locales/creatives.ko.yml
@@ -26,6 +26,8 @@ ko:
       only_markdown: "마크다운(.md) 파일만 가능합니다."
       drop_or_click_markdown: "여기에 파일을 드롭하거나 클릭하여 마크다운 파일을 선택하세요"
       import_markdown: "마크다운 가져오기"
+      request_permission: "권한 요청"
+      no_permission: "이 크리에이티브를 볼 권한이 없습니다."
       share_creative: "크리에이티브 공유"
       shared_with: "공유 대상"
       unknown_user: "알 수 없는 사용자"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -65,6 +65,7 @@ en:
     comment_added: "%{user} added \"%{comment}\"."
     creative_shared: "%{user} shared \"%{short_title}\"."
     user_mentioned: "%{user} mentioned you: \"%{comment}\""
+    permission_requested: "%{user} requested access to \"%{short_title}\"."
 
   inbox_mailer:
     daily_summary:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -36,6 +36,7 @@ ko:
     comment_added: "%{user} 가 \"%{comment}\" 를 추가했습니다."
     creative_shared: "%{user} 가 \"%{short_title}\" 을 공유했습니다."
     user_mentioned: "%{user} 님이 당신을 언급했습니다: \"%{comment}\""
+    permission_requested: "%{user} 이 크리에이티브 \"%{short_title}\" 에 대한 권한 요청을 했습니다."
 
   inbox_mailer:
     daily_summary:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,6 +45,7 @@ Rails.application.routes.draw do
     member do
       get :children
       post :share, to: "creatives#share", as: :share_creative
+      post :request_permission, to: "creatives#request_permission"
     end
   end
 

--- a/spec/requests/permission_request_spec.rb
+++ b/spec/requests/permission_request_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+require 'ostruct'
+require 'cgi'
+
+RSpec.describe 'Permission request', type: :request do
+  let(:owner) { User.create!(email: 'owner@example.com', password: 'pw', name: 'Owner') }
+  let(:requester) { User.create!(email: 'req@example.com', password: 'pw', name: 'Requester') }
+  let(:creative) { Creative.create!(user: owner, description: 'Secret Creative Plan') }
+
+  before do
+    allow_any_instance_of(CreativesController).to receive(:require_authentication).and_return(true)
+    Current = OpenStruct.new(user: requester)
+  end
+
+  it 'creates inbox item for owner' do
+    post "/creatives/#{creative.id}/request_permission"
+    expect(response).to have_http_status(:ok)
+    item = InboxItem.last
+    expect(item.owner).to eq owner
+    expect(item.message).to include('Requester')
+    expect(item.message).to include('Secret Creative Plan'.truncate(10))
+    expect(item.link).to include("share_request=#{CGI.escape(requester.email)}")
+  end
+end


### PR DESCRIPTION
## Summary
- allow users without access to request permission for a Creative
- notify Creative owners via Inbox with link to open share popup
- prefill requested user's email when owner follows link

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec spec/requests/permission_request_spec.rb` *(fails: Could not find closure_tree-9.1.1, with_advisory_lock-7.0.1 in locally installed gems)*
- `bin/rails test test/models/inbox_item_test.rb` *(fails: Could not find closure_tree-9.1.1, with_advisory_lock-7.0.1 in locally installed gems)*

------
https://chatgpt.com/codex/tasks/task_e_6891beb87d488326891d8f2a63261290