### PR TITLE
Fix redirect after login for device registration

### DIFF
--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -30,7 +30,7 @@ module Authentication
     end
 
     def request_authentication
-      unless request.path.start_with?("/inbox")
+      if request.get? && !request.path.start_with?("/inbox")
         session[:return_to_after_authenticating] = request.url
       end
       redirect_to new_session_path

--- a/test/integration/devices_access_test.rb
+++ b/test/integration/devices_access_test.rb
@@ -1,0 +1,9 @@
+require "test_helper"
+
+class DevicesAccessTest < ActionDispatch::IntegrationTest
+  test "unauthenticated device create does not store return location" do
+    post devices_path, params: { device: { client_id: "abc", device_type: "browser" } }
+    assert_redirected_to new_session_path
+    assert_nil session[:return_to_after_authenticating]
+  end
+end


### PR DESCRIPTION
## Summary
- avoid storing POST paths for redirect during authentication
- add test ensuring unauthenticated device creation doesn't set return path

## Testing
- `./bin/rubocop -a`
- `bin/rails test` *(fails: NoMethodError: undefined method `has_closure_tree` for Creative:Class)*

------
https://chatgpt.com/codex/tasks/task_e_68956233c8a483268874496956eb4b5b