### PR TITLE
Fix push notification link handling

### DIFF
--- a/app/views/pwa/service-worker.js
+++ b/app/views/pwa/service-worker.js
@@ -7,7 +7,7 @@ self.addEventListener('push', async (event) => {
   event.waitUntil(
     self.registration.showNotification(title, {
       body,
-      data: payload.notification.data || {}
+      data: payload.data || {}
     })
   )
 })
@@ -15,6 +15,7 @@ self.addEventListener('push', async (event) => {
 self.addEventListener('notificationclick', function(event) {
   event.notification.close()
   const path = event.notification.data.path
+  if (!path) return
   event.waitUntil(
     clients.matchAll({ type: 'window' }).then((clientList) => {
       for (let i = 0; i < clientList.length; i++) {

--- a/docs/send-fcm-test.rb
+++ b/docs/send-fcm-test.rb
@@ -112,11 +112,13 @@ def send_v1(service, project_id, token, message, link)
   webpush = Google::Apis::FcmV1::WebpushConfig.new(
     fcm_options: Google::Apis::FcmV1::WebpushFcmOptions.new(link: link)
   )
+  data = link ? { path: link } : nil
 
   msg = Google::Apis::FcmV1::Message.new(
     token: token,
     notification: notification,
-    webpush: webpush
+    webpush: webpush,
+    data: data
   )
 
   request = Google::Apis::FcmV1::SendMessageRequest.new(message: msg)


### PR DESCRIPTION
## Summary
- Attach navigation path to FCM messages and expose it via service worker
- Safely ignore notification clicks without valid paths
- Update FCM test script to include path data

## Testing
- `./bin/rubocop -a`
- `bundle exec rake test` *(fails: undefined method `has_closure_tree` for Creative:Class)*

------
https://chatgpt.com/codex/tasks/task_e_689594036b8483269970849138f7bdff