### PR TITLE
Use theme text color for avatar initials

### DIFF
--- a/app/assets/stylesheets/user_menu.css
+++ b/app/assets/stylesheets/user_menu.css
@@ -28,7 +28,7 @@
   align-items: center;
   justify-content: center;
   font-weight: bold;
-  color: #fff;
+  color: var(--color-text);
   pointer-events: none;
 }
 


### PR DESCRIPTION
## Summary
- Use theme font color for avatar initial overlay to respect light and dark modes

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: Could not find closure_tree-9.1.1, with_advisory_lock-7.0.1)*

------
https://chatgpt.com/codex/tasks/task_e_689c97cbd38c8326aeb6c8cd13833aac