### PR TITLE
Add notification permission popup and user setting

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -63,6 +63,14 @@ class UsersController < ApplicationController
     end
   end
 
+  def notification_settings
+    if Current.user.update(notification_settings_params)
+      head :no_content
+    else
+      render json: { errors: Current.user.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
   # GET /users/:id/edit_password
   def edit_password
     @user = User.find(params[:id])
@@ -92,6 +100,10 @@ class UsersController < ApplicationController
   end
 
   def profile_params
-    params.require(:user).permit(:avatar, :avatar_url, :display_level, :completion_mark, :theme, :name)
+    params.require(:user).permit(:avatar, :avatar_url, :display_level, :completion_mark, :theme, :name, :notifications_enabled)
+  end
+
+  def notification_settings_params
+    params.require(:user).permit(:notifications_enabled)
   end
 end

--- a/app/javascript/register_service_worker.js
+++ b/app/javascript/register_service_worker.js
@@ -20,31 +20,91 @@ function registerDevice(token) {
   })
 }
 
+function updatePreference(enabled) {
+  fetch('/users/notification_settings', {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-CSRF-Token': document.querySelector('meta[name=csrf-token]').content
+    },
+    body: JSON.stringify({ user: { notifications_enabled: enabled } })
+  })
+}
+
+function initMessaging(registration) {
+  const config = window.firebaseConfig
+  if (!config) {
+    console.warn('No firebase config found')
+    return
+  }
+  const app = initializeApp(config)
+  const messaging = getMessaging(app)
+  getToken(messaging, { vapidKey: config.vapidKey, serviceWorkerRegistration: registration })
+    .then((currentToken) => {
+      if (currentToken) {
+        registerDevice(currentToken)
+      }
+    })
+    .catch((err) => console.error('Failed to get FCM token', err))
+}
+
+function showPermissionPrompt(registration) {
+  const modal = document.getElementById('notification-permission-modal')
+  if (!modal) {
+    Notification.requestPermission().then((permission) => {
+      updatePreference(permission === 'granted')
+      if (permission === 'granted') {
+        initMessaging(registration)
+      }
+    })
+    return
+  }
+  modal.style.display = 'flex'
+  document.body.classList.add('no-scroll')
+  const allowBtn = document.getElementById('allow-notifications')
+  const denyBtn = document.getElementById('deny-notifications')
+
+  allowBtn.onclick = () => {
+    modal.style.display = 'none'
+    document.body.classList.remove('no-scroll')
+    Notification.requestPermission().then((permission) => {
+      updatePreference(permission === 'granted')
+      if (permission === 'granted') {
+        initMessaging(registration)
+      }
+    })
+  }
+
+  denyBtn.onclick = () => {
+    const confirmText = denyBtn.dataset.confirmMessage
+    if (confirm(confirmText)) {
+      modal.style.display = 'none'
+      document.body.classList.remove('no-scroll')
+      updatePreference(false)
+    }
+  }
+}
+
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
     navigator.serviceWorker
       .register('/service-worker.js')
       .then((registration) => {
-        if (Notification.permission === 'default') {
-          Notification.requestPermission()
+        const meta = document.querySelector('meta[name=notifications-enabled]')
+        if (!meta) {
+          return
+        }
+        const enabled = meta.content !== 'false'
+        if (!enabled) {
+          return
         }
 
-        const config = window.firebaseConfig
-        if (!config) {
-            console.warn('No firebase config found')
-            return
+        if (Notification.permission === 'granted') {
+          updatePreference(true)
+          initMessaging(registration)
+        } else if (Notification.permission === 'default') {
+          showPermissionPrompt(registration)
         }
-
-        const app = initializeApp(config)
-        const messaging = getMessaging(app)
-
-        getToken(messaging, { vapidKey: config.vapidKey, serviceWorkerRegistration: registration })
-          .then((currentToken) => {
-            if (currentToken) {
-              registerDevice(currentToken)
-            }
-          })
-          .catch((err) => console.error('Failed to get FCM token', err))
       })
       .catch((error) => {
         console.error('Service worker registration failed:', error)

--- a/app/javascript/register_service_worker.js
+++ b/app/javascript/register_service_worker.js
@@ -94,15 +94,28 @@ if ('serviceWorker' in navigator) {
         if (!meta) {
           return
         }
-        const enabled = meta.content !== 'false'
-        if (!enabled) {
+        const pref = meta.content
+
+        if (pref === 'false') {
+          return
+        }
+
+        if (pref === 'true') {
+          if (Notification.permission === 'granted') {
+            updatePreference(true)
+            initMessaging(registration)
+          } else if (Notification.permission === 'default') {
+            showPermissionPrompt(registration)
+          }
           return
         }
 
         if (Notification.permission === 'granted') {
           updatePreference(true)
           initMessaging(registration)
-        } else if (Notification.permission === 'default') {
+        } else if (Notification.permission === 'denied') {
+          updatePreference(false)
+        } else {
           showPermissionPrompt(registration)
         }
       })

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,7 +13,7 @@ class User < ApplicationRecord
   attribute :completion_mark, :string, default: ""
   attribute :theme, :string
   attribute :name, :string
-  attribute :notifications_enabled, :boolean, default: true
+  attribute :notifications_enabled, :boolean
 
   normalizes :email, with: ->(e) { e.strip.downcase }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,6 +13,7 @@ class User < ApplicationRecord
   attribute :completion_mark, :string, default: ""
   attribute :theme, :string
   attribute :name, :string
+  attribute :notifications_enabled, :boolean, default: true
 
   normalizes :email, with: ->(e) { e.strip.downcase }
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,9 @@
     <meta name="app-version" content="<%= Rails.application.config.app_version %>">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
+    <% if Current.user %>
+      <meta name="notifications-enabled" content="<%= Current.user.notifications_enabled %>">
+    <% end %>
 
     <% if Rails.application.config.x.firebase_config.present? %>
       <script>
@@ -156,6 +159,16 @@
       <span style="float:right; cursor:pointer; font-weight:bold;" id="close-creative-guide">&times;</span>
       <div style="margin-top:0.5em; color:#444; font-size:1em; line-height:1.5;">
         <%= t('app.creative_guide') %>
+      </div>
+    </div>
+
+    <div id="notification-permission-modal" style="display:none;position:fixed;top:0;left:0;width:100vw;height:100vh;z-index:1000;align-items:center;justify-content:center;">
+      <div class="popup-box" style="max-width:400px;">
+        <p><%= t('notifications.permission_prompt') %></p>
+        <div style="margin-top:1em;text-align:right;">
+          <button id="deny-notifications" data-confirm-message="<%= t('notifications.confirm_deny') %>"><%= t('notifications.deny') %></button>
+          <button id="allow-notifications"><%= t('notifications.allow') %></button>
+        </div>
       </div>
     </div>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -37,6 +37,10 @@
     <%= f.label :theme, t('users.theme') %>
     <%= f.select :theme, options_for_select([[t('app.system_mode'), nil], [t('app.light_mode'), 'light'], [t('app.dark_mode'), 'dark']], @user.theme) %>
   </div>
+  <div>
+    <%= f.label :notifications_enabled, t('users.notifications_enabled') %>
+    <%= f.check_box :notifications_enabled %>
+  </div>
   <%= f.submit t('users.update_profile') %>
 <% end %>
 

--- a/config/locales/notifications.en.yml
+++ b/config/locales/notifications.en.yml
@@ -1,0 +1,7 @@
+en:
+  notifications:
+    permission_prompt: "We would like to send you notifications about updates."
+    allow: "Allow"
+    deny: "Don't allow"
+    confirm_deny: "Are you sure you do not want to allow notifications?"
+

--- a/config/locales/notifications.ko.yml
+++ b/config/locales/notifications.ko.yml
@@ -1,0 +1,7 @@
+ko:
+  notifications:
+    permission_prompt: "업데이트에 대한 알림을 보내드려도 될까요?"
+    allow: "허용"
+    deny: "허용 안 함"
+    confirm_deny: "알림을 허용하지 않겠습니까?"
+

--- a/config/locales/users.en.yml
+++ b/config/locales/users.en.yml
@@ -30,6 +30,7 @@ en:
     display_level: "Max Display Level"
     completion_mark: "Completion Mark"
     theme: "Theme"
+    notifications_enabled: "Enable notifications"
     profile_updated: "Profile updated successfully."
     avatar_updated: "Avatar updated successfully."
     password_updated: "Password updated successfully."

--- a/config/locales/users.ko.yml
+++ b/config/locales/users.ko.yml
@@ -30,6 +30,7 @@ ko:
     display_level: "최대 표시 레벨"
     completion_mark: "완료 표시 문자"
     theme: "테마"
+    notifications_enabled: "알림 사용"
     profile_updated: "프로파일이 업데이트되었습니다."
     avatar_updated: "아바타가 변경되었습니다."
     password_updated: "비밀번호가 성공적으로 변경되었습니다."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,7 @@ Rails.application.routes.draw do
     collection do
       get :exists
       get :search
+      patch :notification_settings
     end
   end
 

--- a/db/migrate/20250715120000_add_notifications_enabled_to_users.rb
+++ b/db/migrate/20250715120000_add_notifications_enabled_to_users.rb
@@ -1,5 +1,5 @@
 class AddNotificationsEnabledToUsers < ActiveRecord::Migration[8.0]
   def change
-    add_column :users, :notifications_enabled, :boolean, default: true, null: false
+    add_column :users, :notifications_enabled, :boolean
   end
 end

--- a/db/migrate/20250715120000_add_notifications_enabled_to_users.rb
+++ b/db/migrate/20250715120000_add_notifications_enabled_to_users.rb
@@ -1,0 +1,5 @@
+class AddNotificationsEnabledToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :notifications_enabled, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -355,7 +355,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_15_120000) do
     t.string "completion_mark", default: "", null: false
     t.string "theme"
     t.string "name", null: false
-    t.boolean "notifications_enabled", default: true, null: false
+    t.boolean "notifications_enabled"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_14_190000) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_15_120000) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
     t.text "body"
@@ -355,6 +355,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_14_190000) do
     t.string "completion_mark", default: "", null: false
     t.string "theme"
     t.string "name", null: false
+    t.boolean "notifications_enabled", default: true, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 


### PR DESCRIPTION
## Summary
- prompt users to allow notifications with custom modal and server-side preference
- store notification preference on users and expose checkbox in profile
- add endpoint for updating notification settings
- internationalize notification permission modal and confirmation message

## Testing
- `./bin/rubocop -a`
- `bin/rails test` *(fails: NoMethodError: undefined method `has_closure_tree` for Creative:Class)*

------
https://chatgpt.com/codex/tasks/task_e_689d230eaa4c8326b9cc176c6d9be8bd