### PR TITLE
Refactor inline creative row editor for dynamic additions

### DIFF
--- a/app/javascript/creative_row_editor.js
+++ b/app/javascript/creative_row_editor.js
@@ -317,10 +317,11 @@ if (!window.creativeRowEditorInitialized) {
       beforeNewOrMove(wasNew, prev, prevParent).then(() => {
         const prevCreativeId = prev.dataset.id;
         const childContainer = document.getElementById('creative-children-' + prevCreativeId);
+        const isCollapsed = childContainer && childContainer.style.display === 'none';
         const firstChild = childContainer && childContainer.querySelector('.creative-tree');
         let parentId, container, insertBefore,
             beforeId = '', afterId = '';
-        if (firstChild) {
+        if (firstChild && !isCollapsed) {
           parentId = prevCreativeId;
           container = childContainer;
           insertBefore = firstChild;

--- a/app/javascript/creative_row_editor.js
+++ b/app/javascript/creative_row_editor.js
@@ -314,23 +314,23 @@ if (!window.creativeRowEditorInitialized) {
       const prev = currentTree;
       const wasNew = !form.dataset.creativeId;
       const prevParent = parentInput.value;
-      const prevCreativeId = prev.dataset.id;
-      const childContainer = prev.parentElement.querySelector('#creative-children-' + prevCreativeId);
-      const firstChild = childContainer && childContainer.querySelector('.creative-tree');
-      let parentId, container, insertBefore,
-          beforeId = '', afterId = '';
-      if (firstChild) {
-        parentId = prevCreativeId;
-        container = childContainer;
-        insertBefore = firstChild;
-        beforeId = firstChild.dataset.id;
-      } else {
-        parentId = prev.dataset.parentId;
-        container = prev.parentNode;
-        afterId = prev.dataset.id;
-        insertBefore = prev.nextSibling;
-      }
       beforeNewOrMove(wasNew, prev, prevParent).then(() => {
+        const prevCreativeId = prev.dataset.id;
+        const childContainer = document.getElementById('creative-children-' + prevCreativeId);
+        const firstChild = childContainer && childContainer.querySelector('.creative-tree');
+        let parentId, container, insertBefore,
+            beforeId = '', afterId = '';
+        if (firstChild) {
+          parentId = prevCreativeId;
+          container = childContainer;
+          insertBefore = firstChild;
+          beforeId = firstChild.dataset.id;
+        } else {
+          parentId = prev.dataset.parentId;
+          container = prev.parentNode;
+          afterId = prev.dataset.id;
+          insertBefore = prev.nextSibling;
+        }
         startNew(parentId, container, insertBefore, beforeId, afterId);
       });
     }

--- a/spec/system/creative_inline_edit_spec.rb
+++ b/spec/system/creative_inline_edit_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe 'Creative inline editing', type: :system, js: true do
+  let!(:user) { User.create!(email: 'user@example.com', password: 'password', name: 'User', email_verified_at: Time.current) }
+  let!(:root_creative) { Creative.create!(description: 'Root', user: user) }
+
+  def resize_window_to_pc
+    page.current_window.resize_to(1200, 800)
+  rescue Capybara::NotSupportedByDriverError
+  end
+
+  before do
+    driven_by(:selenium, using: :headless_chrome)
+    resize_window_to_pc
+    visit new_session_path
+    fill_in placeholder: I18n.t('users.new.enter_your_email'), with: user.email
+    fill_in placeholder: I18n.t('users.new.enter_your_password'), with: 'password'
+    find('#sign-in-submit').click
+  end
+
+  it 'shows saved row when starting another addition' do
+    visit creative_path(root_creative)
+
+    find("#creative-#{root_creative.id} .add-creative-btn").click
+    expect(page).not_to have_css("#creative-children-#{root_creative.id} .creative-row")
+
+    fill_in 'inline-creative-description', with: 'First child'
+    find('#inline-add').click
+
+    expect(page).to have_css("#creative-children-#{root_creative.id} .creative-row", text: 'First child')
+    fill_in 'inline-creative-description', with: 'Second child'
+    find('#inline-close').click
+
+    expect(page).to have_css("#creative-children-#{root_creative.id} > .creative-tree:nth-child(1) .creative-row", text: 'First child')
+    expect(page).to have_css("#creative-children-#{root_creative.id} > .creative-tree:nth-child(2) .creative-row", text: 'Second child')
+  end
+end

--- a/spec/system/creative_inline_edit_spec.rb
+++ b/spec/system/creative_inline_edit_spec.rb
@@ -27,11 +27,13 @@ RSpec.describe 'Creative inline editing', type: :system, js: true do
     fill_in 'inline-creative-description', with: 'First child'
     find('#inline-add').click
 
-    expect(page).to have_css("#creative-children-#{root_creative.id} .creative-row", text: 'First child')
+    expect(page).to have_css("#creative-children-#{root_creative.id} .creative-row", text: 'First child', count: 1)
     fill_in 'inline-creative-description', with: 'Second child'
     find('#inline-close').click
 
+    expect(page).to have_css("#creative-children-#{root_creative.id} > .creative-tree", count: 2)
     expect(page).to have_css("#creative-children-#{root_creative.id} > .creative-tree:nth-child(1) .creative-row", text: 'First child')
     expect(page).to have_css("#creative-children-#{root_creative.id} > .creative-tree:nth-child(2) .creative-row", text: 'Second child')
+    expect(Creative.where(description: 'First child').count).to eq(1)
   end
 end

--- a/spec/system/creative_inline_edit_spec.rb
+++ b/spec/system/creative_inline_edit_spec.rb
@@ -55,4 +55,20 @@ RSpec.describe 'Creative inline editing', type: :system, js: true do
     expect(page).to have_css("#creative-children-#{root_creative.id} > .creative-tree:nth-child(3) .creative-row", text: 'C')
     expect(page).to have_css("#creative-children-#{root_creative.id} > .creative-tree:nth-child(4) .creative-row", text: 'D')
   end
+  it 'adds as sibling when current node is collapsed' do
+    child = Creative.create!(description: 'Child', user: user, parent: root_creative)
+    Creative.create!(description: 'Grandchild', user: user, parent: child)
+
+    visit creative_path(root_creative)
+
+    find("#creative-#{child.id} .creative-toggle-btn").click
+    find("#creative-#{child.id} .edit-inline-btn").click
+    find('#inline-add').click
+    fill_in 'inline-creative-description', with: 'Sibling'
+    find('#inline-close').click
+
+    expect(page).to have_css("#creative-children-#{root_creative.id} > .creative-tree:nth-child(1) .creative-row", text: 'Child')
+    expect(page).to have_css("#creative-children-#{root_creative.id} > .creative-tree:nth-child(2) .creative-row", text: 'Sibling')
+    expect(page).not_to have_css("#creative-children-#{child.id} .creative-row", text: 'Sibling', visible: :all)
+  end
 end

--- a/spec/system/creative_inline_edit_spec.rb
+++ b/spec/system/creative_inline_edit_spec.rb
@@ -36,4 +36,23 @@ RSpec.describe 'Creative inline editing', type: :system, js: true do
     expect(page).to have_css("#creative-children-#{root_creative.id} > .creative-tree:nth-child(2) .creative-row", text: 'Second child')
     expect(Creative.where(description: 'First child').count).to eq(1)
   end
+
+  it 'maintains order when adding multiple creatives after the last node' do
+    child_a = Creative.create!(description: 'A', user: user, parent: root_creative)
+    child_b = Creative.create!(description: 'B', user: user, parent: root_creative)
+
+    visit creative_path(root_creative)
+
+    find("#creative-#{child_b.id} .edit-inline-btn").click
+    fill_in 'inline-creative-description', with: 'C'
+    find('#inline-add').click
+    fill_in 'inline-creative-description', with: 'D'
+    find('#inline-add').click
+    find('#inline-close').click
+
+    expect(page).to have_css("#creative-children-#{root_creative.id} > .creative-tree:nth-child(1) .creative-row", text: 'A')
+    expect(page).to have_css("#creative-children-#{root_creative.id} > .creative-tree:nth-child(2) .creative-row", text: 'B')
+    expect(page).to have_css("#creative-children-#{root_creative.id} > .creative-tree:nth-child(3) .creative-row", text: 'C')
+    expect(page).to have_css("#creative-children-#{root_creative.id} > .creative-tree:nth-child(4) .creative-row", text: 'D')
+  end
 end


### PR DESCRIPTION
## Summary
- factor out shared logic to insert new creative rows dynamically
- add system spec for inline creative row addition behaviour

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec spec/system/creative_inline_edit_spec.rb` *(fails: uninitialized constant ClosureTree::Model::ActiveSupport)*

------
https://chatgpt.com/codex/tasks/task_e_68a087c852b48326a7f04fe1efb76b9d