### PR TITLE
Fetch Google avatar for new users

### DIFF
--- a/app/controllers/google_auth_controller.rb
+++ b/app/controllers/google_auth_controller.rb
@@ -1,3 +1,5 @@
+require "open-uri"
+
 class GoogleAuthController < ApplicationController
   allow_unauthenticated_access only: :callback
 
@@ -12,6 +14,15 @@ class GoogleAuthController < ApplicationController
       user.email_verified_at = Time.current
       user.save!
     end
+
+    if auth.info.image.present? && !user.avatar.attached?
+      begin
+        user.avatar.attach(io: URI.open(auth.info.image), filename: "avatar")
+      rescue => e
+        Rails.logger.error("Failed to fetch Google profile image: #{e.message}")
+      end
+    end
+
     start_new_session_for(user)
     redirect_to after_authentication_url
   end

--- a/app/controllers/google_auth_controller.rb
+++ b/app/controllers/google_auth_controller.rb
@@ -1,5 +1,3 @@
-require "open-uri"
-
 class GoogleAuthController < ApplicationController
   allow_unauthenticated_access only: :callback
 
@@ -12,16 +10,13 @@ class GoogleAuthController < ApplicationController
       user.password = random_password
       user.password_confirmation = random_password
       user.email_verified_at = Time.current
-      user.save!
     end
 
-    if auth.info.image.present? && !user.avatar.attached?
-      begin
-        user.avatar.attach(io: URI.open(auth.info.image), filename: "avatar")
-      rescue => e
-        Rails.logger.error("Failed to fetch Google profile image: #{e.message}")
-      end
+    if auth.info.image.present? && !user.avatar.attached? && user.avatar_url.blank?
+      user.avatar_url = auth.info.image
     end
+
+    user.save! if user.new_record? || user.changed?
 
     start_new_session_for(user)
     redirect_to after_authentication_url

--- a/spec/requests/google_auth_spec.rb
+++ b/spec/requests/google_auth_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+require 'stringio'
+
+RSpec.describe 'Google authentication', type: :request do
+  describe 'POST /auth/google_oauth2/callback' do
+    before { OmniAuth.config.test_mode = true }
+    after { OmniAuth.config.test_mode = false }
+
+    it 'sets avatar from Google when user lacks avatar' do
+      image_url = 'https://example.com/avatar.jpg'
+      auth_hash = OmniAuth::AuthHash.new(
+        provider: 'google_oauth2',
+        uid: '12345',
+        info: OmniAuth::AuthHash.new(
+          email: 'user@example.com',
+          name: 'Test User',
+          image: image_url
+        )
+      )
+
+      allow(URI).to receive(:open).with(image_url).and_return(StringIO.new('avatar'))
+
+      post '/auth/google_oauth2/callback', env: { 'omniauth.auth' => auth_hash }
+
+      user = User.last
+      expect(user.avatar).to be_attached
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- fetch profile image from Google OAuth when user has no avatar
- cover Google avatar assignment with a request spec

## Testing
- `./bin/rubocop app/controllers/google_auth_controller.rb spec/requests/google_auth_spec.rb -a`
- `bundle exec rspec` *(fails: undefined method `has_closure_tree` for Creative:Class)*

------
https://chatgpt.com/codex/tasks/task_e_68a264ad54e08326bf06af41734196e9