### PR TITLE
Prompt permission when re-enabling notifications

### DIFF
--- a/app/javascript/register_service_worker.js
+++ b/app/javascript/register_service_worker.js
@@ -110,7 +110,7 @@ if ('serviceWorker' in navigator) {
             console.log('Notifications granted')
             updatePreference(true)
             initMessaging(registration)
-          } else if (Notification.permission === 'default') {
+          } else {
             showPermissionPrompt(registration)
           }
           return


### PR DESCRIPTION
## Summary
- Ask users to re-authorize notifications if browser permission isn't granted when notification preference is re-enabled

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: NoMethodError: undefined method `has_closure_tree' for Creative:Class)*
- `bundle exec rails test` *(fails: NoMethodError: undefined method `has_closure_tree' for Creative:Class)*

------
https://chatgpt.com/codex/tasks/task_e_68a269c3fc588326b552fecb1ac8f3f7