### PR TITLE
Unify add button styling

### DIFF
--- a/app/assets/stylesheets/creatives.css
+++ b/app/assets/stylesheets/creatives.css
@@ -111,13 +111,6 @@
     background: none;
     border: none;
 }
-#inline-add {
-    margin-left: 6px;
-    font-size: 12px;
-    cursor: pointer;
-    background: none;
-    border: none;
-}
 
 .creative-row-actions {
     visibility: hidden;

--- a/app/views/creatives/_inline_edit_form.html.erb
+++ b/app/views/creatives/_inline_edit_form.html.erb
@@ -18,7 +18,7 @@
     <div style="margin-top:0.5em;">
       <button type="button" id="inline-move-up">▲</button>
       <button type="button" id="inline-move-down">▼</button>
-      <button type="button" id="inline-add">＋</button>
+      <button type="button" id="inline-add" class="add-creative-btn">+</button>
       <button type="button" id="inline-close">✖</button>
     </div>
   </form>

--- a/config/initializers/fcm.rb
+++ b/config/initializers/fcm.rb
@@ -6,21 +6,21 @@ service_account = "firebase-adminsdk-fbsvc@collavre.iam.gserviceaccount.com"
 # Use service account JSON for local development
 FCM_CREDENTIALS = ENV["GOOGLE_APPLICATION_CREDENTIALS"]
 if FCM_CREDENTIALS.present? && File.exist?(FCM_CREDENTIALS)
-  
+
   # Use default application credentials (reads from GOOGLE_APPLICATION_CREDENTIALS env var)
   credentials = Google::Auth.get_application_default(
     scope: [ Google::Apis::FcmV1::AUTH_FIREBASE_MESSAGING ]
   )
-  
+
   service = Google::Apis::FcmV1::FirebaseCloudMessagingService.new
   service.authorization = credentials
-  
+
   Rails.application.config.x.fcm_service = service
   Rails.application.config.x.fcm_project_id = project_id
 
   Rails.logger.info "FCM initialized with service account credentials from #{FCM_CREDENTIALS}"
   puts "FCM initialized with service account credentials from #{FCM_CREDENTIALS}"
-  
+
 elsif project_id.present? && Rails.env.production?
   # Use Workload Identity Federation for production (AWS EC2)
   audience = "//iam.googleapis.com/projects/#{project_number}/locations/global/workloadIdentityPools/aws-pool/providers/aws-provider"


### PR DESCRIPTION
## Summary
- make inline editor add button use the shared `add-creative-btn` class and ASCII plus
- drop duplicate `#inline-add` CSS so all add buttons share the same style

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: Could not find closure_tree-9.1.1, with_advisory_lock-7.0.1)*
- `bundle exec rails test` *(fails: Could not find closure_tree-9.1.1, with_advisory_lock-7.0.1)*

------
https://chatgpt.com/codex/tasks/task_e_68a2aa9754b88326a7134aea4ff6cae9