### PR TITLE
Refactor system spec login and handle notification popup

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -29,7 +29,7 @@ end
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Rails.root.glob('spec/support/**/*.rb').sort_by(&:to_s).each { |f| require f }
+Rails.root.glob('spec/support/**/*.rb').sort_by(&:to_s).each { |f| require f }
 
 # Ensures that the test database schema matches the current schema file.
 # If there are pending migrations it will invoke `db:test:prepare` to

--- a/spec/support/system_login_helper.rb
+++ b/spec/support/system_login_helper.rb
@@ -1,0 +1,25 @@
+module SystemLoginHelper
+  def resize_window_to_pc
+    page.current_window.resize_to(1200, 800)
+  rescue Capybara::NotSupportedByDriverError
+  end
+
+  def sign_in(user, password: 'password')
+    resize_window_to_pc
+    visit new_session_path
+    fill_in placeholder: I18n.t('users.new.enter_your_email'), with: user.email
+    fill_in placeholder: I18n.t('users.new.enter_your_password'), with: password
+    find('#sign-in-submit').click
+    allow_push_notifications
+  end
+
+  private
+
+  def allow_push_notifications
+    find('#allow-notifications').click if page.has_css?('#allow-notifications', wait: 1)
+  end
+end
+
+RSpec.configure do |config|
+  config.include SystemLoginHelper, type: :system
+end

--- a/spec/system/creative_inline_edit_spec.rb
+++ b/spec/system/creative_inline_edit_spec.rb
@@ -4,18 +4,9 @@ RSpec.describe 'Creative inline editing', type: :system, js: true do
   let!(:user) { User.create!(email: 'user@example.com', password: 'password', name: 'User', email_verified_at: Time.current) }
   let!(:root_creative) { Creative.create!(description: 'Root', user: user) }
 
-  def resize_window_to_pc
-    page.current_window.resize_to(1200, 800)
-  rescue Capybara::NotSupportedByDriverError
-  end
-
   before do
     driven_by(:selenium, using: :headless_chrome)
-    resize_window_to_pc
-    visit new_session_path
-    fill_in placeholder: I18n.t('users.new.enter_your_email'), with: user.email
-    fill_in placeholder: I18n.t('users.new.enter_your_password'), with: 'password'
-    find('#sign-in-submit').click
+    sign_in(user)
   end
 
   it 'shows saved row when starting another addition' do

--- a/spec/system/creative_share_spec.rb
+++ b/spec/system/creative_share_spec.rb
@@ -5,20 +5,8 @@ RSpec.describe 'Creative 공유 리스트', type: :system do
   let!(:creative) { Creative.create!(description: '테스트', user: user) }
   let!(:share) { CreativeShare.create!(creative: creative, user: user, permission: 'read') }
 
-  def resize_window_to_pc
-    page.current_window.resize_to(1200, 800)
-  rescue Capybara::NotSupportedByDriverError
-    # ignore if driver does not support resizing
-  end
-
   it '공유 리스트가 정상적으로 표시된다' do
-    resize_window_to_pc
-    visit new_session_path
-    expect(page).not_to have_field(placeholder: I18n.t('users.new.enter_your_name'))
-    fill_in placeholder: I18n.t('users.new.enter_your_email'), with: user.email
-    fill_in placeholder: I18n.t('users.new.enter_your_password'), with: 'password'
-    find('#sign-in-submit').click
-    expect(page).not_to have_content(I18n.t('users.sessions.new.try_another_email_or_password'))
+    sign_in(user)
     visit creative_path(creative)
     expect(page).to have_css('#share-creative-modal', text: I18n.t('creatives.index.shared_with'), visible: :all)
     expect(page).to have_css('#share-creative-modal', text: 'User1', visible: :all)


### PR DESCRIPTION
## Summary
- Add shared `sign_in` helper for system specs that resizes window and dismisses notification prompt
- Auto-require spec support files via `rails_helper`
- Use shared helper in system specs for consistent login logic

## Testing
- `./bin/rubocop -a` *(fails: Could not find closure_tree-9.1.1, with_advisory_lock-7.0.1)*
- `bundle exec rspec spec/system/creative_share_spec.rb` *(fails: undefined method `has_closure_tree' for Creative:Class)*

------
https://chatgpt.com/codex/tasks/task_e_68a2b9403fec83269703b96505f23f06