### PR TITLE
Add shared styling class for creative buttons

### DIFF
--- a/app/assets/stylesheets/creatives.css
+++ b/app/assets/stylesheets/creatives.css
@@ -88,7 +88,7 @@
     cursor: pointer;
     background: none;
     border: none;
-    display: flex;
+    display: inline-flex;
     align-items: center;
     justify-content: center;
     line-height: 1;

--- a/app/assets/stylesheets/creatives.css
+++ b/app/assets/stylesheets/creatives.css
@@ -82,35 +82,30 @@
     align-items: center;
 }
 
-.creative-toggle-btn {
-    width: 9px;
-    height: 9px;
-    font-size: 9px;
-    margin-right: 6px;
+.creative-action-btn {
+    margin-left: 0px;
+    font-size: 12px;
+    cursor: pointer;
+    background: none;
+    border: none;
     display: flex;
     align-items: center;
     justify-content: center;
     line-height: 1;
-    cursor: pointer;
+}
+
+.creative-toggle-btn {
+    width: 12px;
+    height: 12px;
+    margin-right: 6px;
 }
 
 .add-creative-btn {
-    margin-left: 0px;
-    font-size: 12px;
     width: 12px;
     font-weight: bold;
     text-decoration: none;
-    cursor: pointer;
-    background: none;
-    border: none;
 }
-.edit-inline-btn {
-    margin-left: 0px;
-    font-size: 12px;
-    cursor: pointer;
-    background: none;
-    border: none;
-}
+
 
 .creative-row-actions {
     visibility: hidden;

--- a/app/assets/stylesheets/creatives.css
+++ b/app/assets/stylesheets/creatives.css
@@ -84,7 +84,7 @@
 
 .creative-action-btn {
     margin-left: 0px;
-    font-size: 12px;
+    font-size: 16px;
     cursor: pointer;
     background: none;
     border: none;
@@ -95,13 +95,14 @@
 }
 
 .creative-toggle-btn {
-    width: 12px;
-    height: 12px;
-    margin-right: 6px;
+    width: 16px;
+    height: 16px;
+    font-size: 14px;
+    margin-left: 6px;
 }
 
 .add-creative-btn {
-    width: 12px;
+    font-size: 18px;
     font-weight: bold;
     text-decoration: none;
 }
@@ -213,6 +214,9 @@
     margin-left: 0.4em;
 }
 
+.comments-btn {
+    width: 24px;
+}
 .comments-btn.no-comments {
     visibility: hidden;
 }

--- a/app/components/creative_component.html.erb
+++ b/app/components/creative_component.html.erb
@@ -2,18 +2,18 @@
   <div class="creative-row">
     <div class="creative-row-start">
       <div class="creative-row-actions">
-        <div class="before-link creative-toggle-btn" data-creative-id="<%= creative.id %>">
+        <div class="before-link creative-toggle-btn creative-action-btn" data-creative-id="<%= creative.id %>">
           <%= level <= 3 && filtered_children.any? ? helpers.toggle_button_symbol(expanded: expanded) : '' %>
         </div>
         <%= check_box_tag('selected_creative_ids[]', creative.id, false, class: 'select-creative-checkbox', style: select_mode ? '' : 'display: none') %>
 
         <%= button_tag('+', type: 'button',
-                       class: 'add-creative-btn',
+                       class: 'creative-action-btn add-creative-btn',
                        data: { parent_id: creative.id },
                        style: (' visibility: hidden;' unless creative.has_permission?(Current.user, :write)),
                        title: t('creatives.help.add_child_creative')) %>
         <% if creative.has_permission?(Current.user, :write) %>
-          <button type="button" class="edit-inline-btn" data-creative-id="<%= creative.id %>">✎</button>
+          <button type="button" class="creative-action-btn edit-inline-btn" data-creative-id="<%= creative.id %>">✎</button>
         <% end %>
         <div class="creative-divider" style="width: 6px;">
         </div>

--- a/app/helpers/creatives_helper.rb
+++ b/app/helpers/creatives_helper.rb
@@ -47,7 +47,7 @@ module CreativesHelper
         if CommentPresenceStore.list(origin.id).include?(Current.user.id)
           unread_count = 0
         end
-        classes = [ "comments-btn" ]
+        classes = [ "comments-btn", "creative-action-btn" ]
         classes << "no-comments" if comments_count.zero?
         comment_label = comments_count.zero? ? "\u{1F4AC}" : ""
         badge = render(Inbox::BadgeComponent.new(count: unread_count, badge_id: "comment-badge-#{creative.id}", show_zero: comments_count.positive?))

--- a/app/javascript/creative_row_editor.js
+++ b/app/javascript/creative_row_editor.js
@@ -45,8 +45,8 @@ if (!window.creativeRowEditorInitialized) {
       row.innerHTML = `
   <div class="creative-row-start">
     <div class="creative-row-actions">
-      <button type="button" class="add-creative-btn">+</button>
-      <button type="button" class="edit-inline-btn" data-creative-id="${data.id}">✎</button>
+      <button type="button" class="creative-action-btn add-creative-btn">+</button>
+      <button type="button" class="creative-action-btn edit-inline-btn" data-creative-id="${data.id}">✎</button>
       <div class="creative-divider" style="width: 6px;"></div>
     </div>
     <a class="unstyled-link" href="/creatives/${data.id}">${data.description || ''}</a>

--- a/app/views/creatives/_inline_edit_form.html.erb
+++ b/app/views/creatives/_inline_edit_form.html.erb
@@ -16,10 +16,10 @@
       <span id="inline-progress-value">0</span>
     </div>
     <div style="margin-top:0.5em;">
-      <button type="button" id="inline-move-up">▲</button>
-      <button type="button" id="inline-move-down">▼</button>
-      <button type="button" id="inline-add" class="add-creative-btn">+</button>
-      <button type="button" id="inline-close">✖</button>
+      <button type="button" id="inline-move-up" class="creative-action-btn">▲</button>
+      <button type="button" id="inline-move-down" class="creative-action-btn">▼</button>
+      <button type="button" id="inline-add" class="creative-action-btn add-creative-btn">+</button>
+      <button type="button" id="inline-close" class="creative-action-btn">✖</button>
     </div>
   </form>
 </div>


### PR DESCRIPTION
## Summary
- unify creative row action buttons under `.creative-action-btn`
- apply shared class to inline editor controls and comments button
- streamline CSS to centralize button styling

## Testing
- `./bin/rubocop -a` *(fails: Could not find closure_tree-9.1.1, with_advisory_lock-7.0.1 in locally installed gems)*
- `bundle exec rspec` *(fails: Could not find closure_tree-9.1.1, with_advisory_lock-7.0.1 in locally installed gems)*

------
https://chatgpt.com/codex/tasks/task_e_68a2d78e8bc883268152ff0c3f8f1ebd