### PR TITLE
Add keyboard shortcuts for creative inline editor

### DIFF
--- a/app/javascript/creative_row_editor.js
+++ b/app/javascript/creative_row_editor.js
@@ -373,6 +373,16 @@ if (!window.creativeRowEditorInitialized) {
     editor.addEventListener('trix-change', scheduleSave);
 
     editor.addEventListener('keydown', function(e) {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        hideCurrent();
+        return;
+      }
+      if (e.key === 'Enter' && e.shiftKey) {
+        e.preventDefault();
+        addNew();
+        return;
+      }
       if (e.key !== 'ArrowUp' && e.key !== 'ArrowDown') return;
       const range = editor.editor.getSelectedRange();
       if (!range) return;

--- a/spec/system/creative_inline_edit_spec.rb
+++ b/spec/system/creative_inline_edit_spec.rb
@@ -37,6 +37,23 @@ RSpec.describe 'Creative inline editing', type: :system, js: true do
     expect(Creative.where(description: 'First child').count).to eq(1)
   end
 
+  it 'supports keyboard shortcuts for add and close' do
+    visit creative_path(root_creative)
+
+    find("#creative-#{root_creative.id} .add-creative-btn").click
+    fill_in 'inline-creative-description', with: 'First child'
+    find('trix-editor').send_keys([:shift, :enter])
+
+    expect(page).to have_css("#creative-children-#{root_creative.id} .creative-row", text: 'First child', count: 1)
+
+    fill_in 'inline-creative-description', with: 'Second child'
+    find('trix-editor').send_keys(:escape)
+
+    expect(page).to have_css("#creative-children-#{root_creative.id} > .creative-tree", count: 2)
+    expect(page).to have_css("#creative-children-#{root_creative.id} > .creative-tree:nth-child(1) .creative-row", text: 'First child')
+    expect(page).to have_css("#creative-children-#{root_creative.id} > .creative-tree:nth-child(2) .creative-row", text: 'Second child')
+  end
+
   it 'maintains order when adding multiple creatives after the last node' do
     child_a = Creative.create!(description: 'A', user: user, parent: root_creative)
     child_b = Creative.create!(description: 'B', user: user, parent: root_creative)


### PR DESCRIPTION
## Summary
- add Escape shortcut to close inline creative editor
- add Shift+Enter shortcut to create a new creative inline
- test keyboard shortcuts for add and close actions

## Testing
- `./bin/rubocop -a` *(fails: Could not find closure_tree-9.1.1, with_advisory_lock-7.0.1)*
- `bundle exec rspec spec/system/creative_inline_edit_spec.rb` *(fails: Could not find closure_tree-9.1.1, with_advisory_lock-7.0.1)*

------
https://chatgpt.com/codex/tasks/task_e_68a3ea08303c83269418bda9693548a1