### PR TITLE
Remove row add button and add child creation control

### DIFF
--- a/app/components/creative_component.html.erb
+++ b/app/components/creative_component.html.erb
@@ -7,11 +7,6 @@
         </div>
         <%= check_box_tag('selected_creative_ids[]', creative.id, false, class: 'select-creative-checkbox', style: select_mode ? '' : 'display: none') %>
 
-        <%= button_tag('+', type: 'button',
-                       class: 'creative-action-btn add-creative-btn',
-                       data: { parent_id: creative.id },
-                       style: (' visibility: hidden;' unless creative.has_permission?(Current.user, :write)),
-                       title: t('creatives.help.add_child_creative')) %>
         <% if creative.has_permission?(Current.user, :write) %>
           <button type="button" class="creative-action-btn edit-inline-btn" data-creative-id="<%= creative.id %>">✎</button>
         <% end %>

--- a/app/javascript/creative_row_editor.js
+++ b/app/javascript/creative_row_editor.js
@@ -13,6 +13,7 @@ if (!window.creativeRowEditorInitialized) {
     const upBtn = document.getElementById('inline-move-up');
     const downBtn = document.getElementById('inline-move-down');
     const addBtn = document.getElementById('inline-add');
+    const addChildBtn = document.getElementById('inline-add-child');
     const closeBtn = document.getElementById('inline-close');
 
     const methodInput = document.getElementById('inline-method');
@@ -45,7 +46,6 @@ if (!window.creativeRowEditorInitialized) {
       row.innerHTML = `
   <div class="creative-row-start">
     <div class="creative-row-actions">
-      <button type="button" class="creative-action-btn add-creative-btn">+</button>
       <button type="button" class="creative-action-btn edit-inline-btn" data-creative-id="${data.id}">✎</button>
       <div class="creative-divider" style="width: 6px;"></div>
     </div>
@@ -174,11 +174,13 @@ if (!window.creativeRowEditorInitialized) {
         });
       });
 
-      document.querySelectorAll('.add-creative-btn').forEach(function(btn) {
-        btn.addEventListener('click', function(e) {
-          e.preventDefault();
-          const tree = btn.closest('.creative-tree');
-          let parentId, container, insertBefore, beforeId = '';
+      document
+        .querySelectorAll('.add-creative-btn:not(#inline-add):not(#inline-add-child)')
+        .forEach(function(btn) {
+          btn.addEventListener('click', function(e) {
+            e.preventDefault();
+            const tree = btn.closest('.creative-tree');
+            let parentId, container, insertBefore, beforeId = '';
           if (tree) {
             parentId = tree.dataset.id;
             container = tree.querySelector('.creative-children');
@@ -336,6 +338,26 @@ if (!window.creativeRowEditorInitialized) {
       });
     }
 
+    function addChild() {
+      if (!currentTree) return;
+      const prev = currentTree;
+      const wasNew = !form.dataset.creativeId;
+      const prevParent = parentInput.value;
+      beforeNewOrMove(wasNew, prev, prevParent).then(() => {
+        const parentId = prev.dataset.id;
+        let container = document.getElementById('creative-children-' + parentId);
+        if (!container) {
+          container = document.createElement('div');
+          container.className = 'creative-children';
+          container.id = 'creative-children-' + parentId;
+          prev.appendChild(container);
+        }
+        const insertBefore = container.firstElementChild;
+        const beforeId = insertBefore ? insertBefore.dataset.id : '';
+        startNew(parentId, container, insertBefore, beforeId);
+      });
+    }
+
     function startNew(parentId, container, insertBefore, beforeId = '', afterId = '', childId = '') {
       if (currentTree) hideCurrent(false);
       const newTree = document.createElement('div');
@@ -405,6 +427,10 @@ if (!window.creativeRowEditorInitialized) {
 
     if (addBtn) {
       addBtn.addEventListener('click', addNew);
+    }
+
+    if (addChildBtn) {
+      addChildBtn.addEventListener('click', addChild);
     }
 
     attachButtons();

--- a/app/views/creatives/_inline_edit_form.html.erb
+++ b/app/views/creatives/_inline_edit_form.html.erb
@@ -19,6 +19,7 @@
       <button type="button" id="inline-move-up" class="creative-action-btn">▲</button>
       <button type="button" id="inline-move-down" class="creative-action-btn">▼</button>
       <button type="button" id="inline-add" class="creative-action-btn add-creative-btn">+</button>
+      <button type="button" id="inline-add-child" class="creative-action-btn add-creative-btn">↳ +</button>
       <button type="button" id="inline-close" class="creative-action-btn">✖</button>
     </div>
   </form>

--- a/spec/system/creative_inline_edit_spec.rb
+++ b/spec/system/creative_inline_edit_spec.rb
@@ -21,7 +21,8 @@ RSpec.describe 'Creative inline editing', type: :system, js: true do
   it 'shows saved row when starting another addition' do
     visit creative_path(root_creative)
 
-    find("#creative-#{root_creative.id} .add-creative-btn").click
+    find("#creative-#{root_creative.id} .edit-inline-btn").click
+    find('#inline-add-child').click
     expect(page).not_to have_css("#creative-children-#{root_creative.id} .creative-row")
 
     fill_in 'inline-creative-description', with: 'First child'


### PR DESCRIPTION
## Summary
- remove inline row add button
- add `↳ +` button in inline editor for adding child creatives
- update spec for new child creation flow

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec spec/system/creative_inline_edit_spec.rb` *(fails: undefined method `has_closure_tree` for Creative:Class)*

------
https://chatgpt.com/codex/tasks/task_e_68a3e9558da483268468c590ccd84dda