### PR TITLE
Autolink URLs in creative inline editor

### DIFF
--- a/app/javascript/creative_row_editor.js
+++ b/app/javascript/creative_row_editor.js
@@ -391,7 +391,8 @@ if (!window.creativeRowEditorInitialized) {
     function autoLinkUrls(event) {
       const element = event.target;
       const html = element.innerHTML;
-      const linkedHtml = html.replace(/(^|\s)(https?:\/\/[^\s<]+)/g, function(_match, prefix, url) {
+      const unlinkedHtml = html.replace(/<a[^>]*>(.*?)<\/a>/g, '$1');
+      const linkedHtml = unlinkedHtml.replace(/(^|\s)(https?:\/\/[^\s<]+)/g, function(_match, prefix, url) {
         return `${prefix}<a href="${url}" target="_blank" rel="noopener">${url}</a>`;
       });
       if (linkedHtml !== html) {

--- a/app/javascript/creative_row_editor.js
+++ b/app/javascript/creative_row_editor.js
@@ -388,11 +388,27 @@ if (!window.creativeRowEditorInitialized) {
       saveTimer = setTimeout(saveForm, 5000);
     }
 
+    function autoLinkUrls(event) {
+      const element = event.target;
+      const html = element.innerHTML;
+      const linkedHtml = html.replace(/(^|\s)(https?:\/\/[^\s<]+)/g, function(_match, prefix, url) {
+        return `${prefix}<a href="${url}" target="_blank" rel="noopener">${url}</a>`;
+      });
+      if (linkedHtml !== html) {
+        const selection = element.editor.getSelectedRange();
+        element.editor.loadHTML(linkedHtml);
+        element.editor.setSelectedRange(selection);
+      }
+    }
+
     progressInput.addEventListener('input', function() {
       progressValue.textContent = progressInput.value;
       scheduleSave();
     });
-    editor.addEventListener('trix-change', scheduleSave);
+    editor.addEventListener('trix-change', function(event) {
+      autoLinkUrls(event);
+      scheduleSave();
+    });
 
     editor.addEventListener('keydown', function(e) {
       if (e.key === 'Escape') {

--- a/spec/system/creative_inline_edit_spec.rb
+++ b/spec/system/creative_inline_edit_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe 'Creative inline editing', type: :system, js: true do
 
     find("#creative-#{root_creative.id} .add-creative-btn").click
     fill_in 'inline-creative-description', with: 'First child'
-    find('trix-editor').send_keys([:shift, :enter])
+    find('trix-editor').send_keys([ :shift, :enter ])
 
     expect(page).to have_css("#creative-children-#{root_creative.id} .creative-row", text: 'First child', count: 1)
 
@@ -53,6 +53,16 @@ RSpec.describe 'Creative inline editing', type: :system, js: true do
     expect(page).to have_css("#creative-children-#{root_creative.id} > .creative-tree", count: 2)
     expect(page).to have_css("#creative-children-#{root_creative.id} > .creative-tree:nth-child(1) .creative-row", text: 'First child')
     expect(page).to have_css("#creative-children-#{root_creative.id} > .creative-tree:nth-child(2) .creative-row", text: 'Second child')
+  end
+
+  it 'auto links URLs as you type' do
+    visit creative_path(root_creative)
+
+    find("#creative-#{root_creative.id} .add-creative-btn").click
+    editor = find('trix-editor')
+    editor.send_keys('http://example.com ')
+
+    expect(page).to have_css('trix-editor a[href="http://example.com"]', text: 'http://example.com')
   end
 
   it 'maintains order when adding multiple creatives after the last node' do

--- a/spec/system/creative_inline_edit_spec.rb
+++ b/spec/system/creative_inline_edit_spec.rb
@@ -60,9 +60,10 @@ RSpec.describe 'Creative inline editing', type: :system, js: true do
 
     find("#creative-#{root_creative.id} .add-creative-btn").click
     editor = find('trix-editor')
-    editor.send_keys('http://example.com ')
-
+    editor.send_keys('http://example.com')
     expect(page).to have_css('trix-editor a[href="http://example.com"]', text: 'http://example.com')
+    editor.send_keys('/path')
+    expect(page).to have_css('trix-editor a[href="http://example.com/path"]', text: 'http://example.com/path')
   end
 
   it 'maintains order when adding multiple creatives after the last node' do


### PR DESCRIPTION
## Summary
- Autolink http(s) URLs typed in creative inline editor
- Test that URLs become links while editing

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: undefined method `has_closure_tree' for Creative:Class)*

------
https://chatgpt.com/codex/tasks/task_e_68a3e98a04488326ac96a7e7fc7c9605