### PR TITLE
Move delete controls to inline editor

### DIFF
--- a/app/controllers/creatives_controller.rb
+++ b/app/controllers/creatives_controller.rb
@@ -175,11 +175,6 @@ class CreativesController < ApplicationController
     end
     CreativeShare.where(creative: @creative).destroy_all
     @creative.destroy
-    if parent
-      redirect_to creative_path(parent)
-    else
-      redirect_to creatives_path
-    end
   end
 
   def request_permission

--- a/app/javascript/creative_row_editor.js
+++ b/app/javascript/creative_row_editor.js
@@ -374,34 +374,16 @@ if (!window.creativeRowEditorInitialized) {
         credentials: 'same-origin'
       }).then(() => {
         const parentTree = parentId ? document.getElementById(`creative-${parentId}`) : null;
-        tree.remove();
-        if (!withChildren && parentTree) {
+        const childrenTree = document.getElementById("creative-children-" + id)
+        if (!withChildren && childrenTree && parentTree) {
           refreshChildren(parentTree).then(() => {
-            const nextTree = nextId ? document.getElementById(`creative-${nextId}`) : null;
-            if (nextTree) {
-              currentTree = nextTree;
-              hideRow(nextTree);
-              nextTree.appendChild(template);
-              template.style.display = 'block';
-              loadCreative(nextTree.dataset.id);
-            } else {
-              hideCurrent();
-            }
             if (parentTree) refreshRow(parentTree);
           });
         } else {
-          const nextTree = nextId ? document.getElementById(`creative-${nextId}`) : null;
-          if (parentTree) refreshRow(parentTree);
-          if (nextTree) {
-            currentTree = nextTree;
-            hideRow(nextTree);
-            nextTree.appendChild(template);
-            template.style.display = 'block';
-            loadCreative(nextTree.dataset.id);
-          } else {
-            hideCurrent();
-          }
+          document.getElementById("creative-children-" + id)?.remove();
         }
+        move(1);
+        tree.remove();
       });
     }
 

--- a/app/javascript/select_mode.js
+++ b/app/javascript/select_mode.js
@@ -61,6 +61,28 @@ if (!window.isSelectModeInitialized) {
     document.addEventListener('turbo:load', function() {
         attachRowHandlers();
         var selectBtn = document.getElementById('select-creative-btn');
+        var deleteSelectedBtn = document.getElementById('delete-selection-btn');
+        if (deleteSelectedBtn) {
+            deleteSelectedBtn.addEventListener('click', function() {
+                var ids = Array.from(document.querySelectorAll('.select-creative-checkbox:checked')).map(cb => cb.value);
+                if (ids.length === 0) return;
+                if (!confirm(deleteSelectedBtn.dataset.confirm)) return;
+                var token = document.querySelector('meta[name="csrf-token"]').content;
+                Promise.all(ids.map(function(id) {
+                    return fetch('/creatives/' + id + '?delete_with_children=true', {
+                        method: 'DELETE',
+                        headers: { 'X-CSRF-Token': token },
+                        credentials: 'same-origin'
+                    });
+                })).then(function() {
+                    ids.forEach(function(id) {
+                        var tree = document.getElementById('creative-' + id);
+                        if (tree) tree.remove();
+                    });
+                    clearAllSelection();
+                });
+            });
+        }
         if (!selectBtn) return;
         selectBtn.addEventListener('click', function() {
             Array.from(document.getElementsByClassName("select-creative-checkbox")).forEach(function(element) {
@@ -82,6 +104,9 @@ if (!window.isSelectModeInitialized) {
             const setPlanBtn = document.getElementById('set-plan-btn');
             if (setPlanBtn) {
                 setPlanBtn.style.display = setPlanBtn.style.display === 'none' ? '' : 'none';
+            }
+            if (deleteSelectedBtn) {
+                deleteSelectedBtn.style.display = deleteSelectedBtn.style.display === 'none' ? '' : 'none';
             }
             selectModeActive = !selectModeActive;
             if (selectModeActive) {

--- a/app/javascript/select_mode.js
+++ b/app/javascript/select_mode.js
@@ -69,7 +69,7 @@ if (!window.isSelectModeInitialized) {
                 if (!confirm(deleteSelectedBtn.dataset.confirm)) return;
                 var token = document.querySelector('meta[name="csrf-token"]').content;
                 Promise.all(ids.map(function(id) {
-                    return fetch('/creatives/' + id + '?delete_with_children=true', {
+                    return fetch('/creatives/' + id + '?delete_with_children=false', {
                         method: 'DELETE',
                         headers: { 'X-CSRF-Token': token },
                         credentials: 'same-origin'

--- a/app/views/creatives/_inline_edit_form.html.erb
+++ b/app/views/creatives/_inline_edit_form.html.erb
@@ -20,6 +20,8 @@
       <button type="button" id="inline-move-down" class="creative-action-btn">▼</button>
       <button type="button" id="inline-add" class="creative-action-btn add-creative-btn">+</button>
       <button type="button" id="inline-add-child" class="creative-action-btn add-creative-btn">↳ +</button>
+      <button type="button" id="inline-delete" class="creative-action-btn danger-link" title="<%= t('creatives.index.delete_only_this') %>" data-confirm="<%= t('creatives.index.are_you_sure_delete_only_this') %>">🗑</button>
+      <button type="button" id="inline-delete-with-children" class="creative-action-btn danger-link" title="<%= t('creatives.index.delete_with_children') %>" data-confirm="<%= t('creatives.index.are_you_sure_delete_with_children') %>">🗑+</button>
       <button type="button" id="inline-close" class="creative-action-btn">✖</button>
     </div>
   </form>

--- a/app/views/creatives/_mobile_actions_menu.html.erb
+++ b/app/views/creatives/_mobile_actions_menu.html.erb
@@ -4,9 +4,6 @@
         menu_id: 'mobile-actions-menu',
         align: :right
       ) do %>
-    <% if authenticated? && @parent_creative && @parent_creative.has_permission?(Current.user, :write) %>
-      <%= render 'delete_button' %>
-    <% end %>
     <% if (@parent_creative || @creative) && (@parent_creative || @creative).has_permission?(Current.user, :write) %>
       <button type="button" class="popup-menu-item" data-click-target="share-creative-btn"><%= t('creatives.index.share') %></button>
     <% end %>

--- a/app/views/creatives/index.html.erb
+++ b/app/views/creatives/index.html.erb
@@ -12,12 +12,10 @@
     <%= render 'share_button' %>
   <% end %>
 
-  <% if authenticated? && @parent_creative && @parent_creative.has_permission?(Current.user, :write) %>
-    <%= render 'delete_button', extra_button_classes: 'desktop-only' %>
-  <% end %>
   <button id="set-plan-btn" class="set-plan-btn" style="display:none;"><%= t('app.set_plan') %></button>
   <input type="checkbox" id="select-all-creatives" style="display:none;vertical-align:middle;" />
   <button id="select-creative-btn" class="select-btn" data-select-text="<%= t('app.select') %>" data-cancel-text="<%= t('app.cancel_select') %>"><%= t('app.select') %></button>
+  <button id="delete-selection-btn" class="danger-link" style="display:none;" data-confirm="<%= t('creatives.index.are_you_sure_delete_selection') %>"><%= t('creatives.index.delete_selection') %></button>
   <button id="expand-all-btn" class="expand-btn" data-collapse-text="<%= t('app.collapse_all') %>" data-expand-text="<%= t('app.expand_all') %>" ><%= t('app.expand_all') %></button>
   <button id="import-markdown-btn" class="import-btn desktop-only"><%= t('.import_markdown') %></button>
   <button id="export-markdown-btn" class="export-btn desktop-only" data-parent-creative-id="<%= @parent_creative&.id %>" data-error="<%= t('creatives.index.export_failed') %>"><%= t('.export_markdown') %></button>

--- a/config/locales/creatives.en.yml
+++ b/config/locales/creatives.en.yml
@@ -13,6 +13,8 @@ en:
       are_you_sure: "Are you sure?"
       are_you_sure_delete_only_this: "Are you sure you want to delete only this Creative? Its children will be preserved and re-linked."
       are_you_sure_delete_with_children: "Are you sure you want to delete this Creative and ALL its children? This cannot be undone."
+      delete_selection: "Delete selected"
+      are_you_sure_delete_selection: "Are you sure you want to delete selected Creatives? This cannot be undone."
       creatives: "Creatives"
       recalculate_progress: "Recalculate Progress"
       recalculate_all_parent_progress: "Recalculate all parent progress?"

--- a/config/locales/creatives.ko.yml
+++ b/config/locales/creatives.ko.yml
@@ -13,6 +13,8 @@ ko:
       are_you_sure: "정말 삭제하시겠습니까?"
       are_you_sure_delete_only_this: "이 항목만 삭제하시겠습니까? 하위 항목은 보존되고 부모에 연결됩니다."
       are_you_sure_delete_with_children: "이 항목과 모든 하위 항목을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+      delete_selection: "선택 항목 삭제"
+      are_you_sure_delete_selection: "선택된 크리에이티브를 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
       creatives: "크리에이티브 목록"
       recalculate_progress: "진행률 다시 계산"
       recalculate_all_parent_progress: "모든 상위 진행률을 다시 계산하시겠습니까?"


### PR DESCRIPTION
## Summary
- remove delete buttons from top actions row and add bulk delete
- add delete buttons to creative inline editor with navigation after removal
- enable selection mode bulk delete with confirmation

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: closure_tree-9.1.1 requires Ruby >= 3.3.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a4086d186c8326b1bff63019763aa9