### PR TITLE
Use page title for markdown export filenames

### DIFF
--- a/app/javascript/export_to_markdown.js
+++ b/app/javascript/export_to_markdown.js
@@ -16,7 +16,10 @@ if (!window.isExportMarkdownEnabled) {
                         const url = URL.createObjectURL(blob);
                         const a = document.createElement('a');
                         a.href = url;
-                        a.download = 'creatives.md';
+                        const titleElement = document.querySelector('.page-title');
+                        const pageTitle = titleElement ? titleElement.textContent.trim() : document.title;
+                        const safeTitle = pageTitle.replace(/[\\/:*?"<>|]+/g, '_') || 'creatives';
+                        a.download = safeTitle + '.md';
                         document.body.appendChild(a);
                         a.click();
                         setTimeout(() => {


### PR DESCRIPTION
## Summary
- Use the page title to name exported Markdown files and sanitize invalid characters

## Testing
- `./bin/rubocop -a`
- `bin/rails test` *(fails: NoMethodError: undefined method `has_closure_tree` for Creative:Class)*

------
https://chatgpt.com/codex/tasks/task_e_68a445a7f8208326bd7c152c65d99d3c