### PR TITLE
Refine layout styling

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -24,18 +24,20 @@ body {
     height: 100%;
 }
 
-nav {
-    display: flex;
-    justify-content: flex-end;
-    align-items: center;
-    font-size: 0.875em;
-    gap: 0.2rem;
-    max-width: 960px;
-    margin: 0 auto;
-    padding: 1rem;
-    background: var(--color-nav-bg);
-    border-bottom: 1px solid var(--color-border);
-}
+ nav {
+     display: flex;
+     justify-content: flex-end;
+     align-items: center;
+     flex-wrap: wrap;
+     font-size: 0.875em;
+     gap: 0.2rem;
+     max-width: 960px;
+     margin: 0 auto;
+     padding: 1rem;
+     background: var(--color-nav-bg);
+     border-bottom: 1px solid var(--color-border);
+     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+ }
 
 nav a,
 nav button{
@@ -102,6 +104,7 @@ nav button:hover,
     background: var(--color-bg);
     color: var(--color-btn-text);
     padding:0.3em; border-radius:4px; border:1px solid var(--color-border);
+    margin-right: 0.2em;
 }
 
 input[type="text"],

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -45,8 +45,8 @@
     <%= turbo_stream_from ["inbox", Current.user] if Current.user %>
     <div class="notice"><%= notice %></div>
 
-    <nav style="display: flex; flex-wrap: wrap;">
-      <form action="<%= creatives_path %>" method="get" style="display:inline; margin-right:0.2em;">
+    <nav>
+      <form action="<%= creatives_path %>" method="get">
         <input type="text" id="search" name="search" value="<%= params[:search] %>" placeholder="<%= t('app.search_placeholder') %>" />
       </form>
       <% if authenticated? %>


### PR DESCRIPTION
## Summary
- streamline nav and search form markup by removing inline styles
- add flex wrapping and subtle shadow to navigation bar for cleaner appearance

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: NoMethodError: undefined method `has_closure_tree` for Creative:Class)*

------
https://chatgpt.com/codex/tasks/task_e_68a47ffc58c08326ad9c1ca26cc51682