### PR TITLE
Align Trix color picker button height with toolbar

### DIFF
--- a/app/assets/stylesheets/actiontext.css
+++ b/app/assets/stylesheets/actiontext.css
@@ -444,16 +444,23 @@ trix-editor .attachment__metadata {
 trix-toolbar .trix-color-button,
 trix-toolbar .trix-bgcolor-button {
   width: 2.6em;
-  height: 2.6em;
+  height: 1.6em;
   padding: 0;
   display: flex;
   align-items: center;
   justify-content: center;
 }
 
+@media (max-width: 768px) {
+  trix-toolbar .trix-color-button,
+  trix-toolbar .trix-bgcolor-button {
+    height: 2em;
+  }
+}
+
 trix-toolbar .trix-color-button svg,
 trix-toolbar .trix-bgcolor-button svg {
-  width: 100%;
+  width: auto;
   height: 100%;
   opacity: 0.6;
 }


### PR DESCRIPTION
## Summary
- Fix text and background color picker buttons to match toolbar button height
- Ensure icons maintain aspect ratio and scale on mobile

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: `NoMethodError: undefined method 'has_closure_tree' for Creative:Class`)*

------
https://chatgpt.com/codex/tasks/task_e_68a51e7fb5a08326bf8e90e452971b27