### PR TITLE
Embed toggle button within indented creative nodes

### DIFF
--- a/app/assets/stylesheets/creatives.css
+++ b/app/assets/stylesheets/creatives.css
@@ -88,17 +88,19 @@
     cursor: pointer;
     background: none;
     border: none;
-    display: inline-flex;
     align-items: center;
     justify-content: center;
     line-height: 1;
+    display: inline-flex;
+    flex-shrink: 0;
+    visibility: hidden;
 }
 
 .creative-toggle-btn {
     width: 16px;
     height: 16px;
     font-size: 14px;
-    margin-left: 6px;
+    margin-right: 2px;
 }
 
 .add-creative-btn {
@@ -119,8 +121,15 @@
     visibility: visible;
 }
 
+.creative-row:hover .creative-action-btn {
+    visibility: visible;
+}
+
 @media (max-width: 768px) {
     .creative-row-actions {
+        visibility: visible !important;
+    }
+    .creative-action-btn {
         visibility: visible !important;
     }
 }
@@ -200,6 +209,13 @@
 
 .creative-row-start h3 {
     font-size: 1.1em;
+}
+
+.indent1,
+.indent2,
+.indent3 {
+    display: flex;
+    align-items: center;
 }
 
 .indent1 {

--- a/app/assets/stylesheets/print.css
+++ b/app/assets/stylesheets/print.css
@@ -3,6 +3,7 @@
   #plans-list-area,
   #inbox-panel,
   .creative-actions-row,
+  .creative-action-btn,
   .creative-row-actions,
   #creative-guide-popover,
   #creative-guide-link,

--- a/app/components/creative_component.html.erb
+++ b/app/components/creative_component.html.erb
@@ -2,9 +2,6 @@
   <div class="creative-row">
     <div class="creative-row-start">
       <div class="creative-row-actions">
-        <div class="before-link creative-toggle-btn creative-action-btn" data-creative-id="<%= creative.id %>">
-          <%= level <= 3 && filtered_children.any? ? helpers.toggle_button_symbol(expanded: expanded) : '' %>
-        </div>
         <%= check_box_tag('selected_creative_ids[]', creative.id, false, class: 'select-creative-checkbox', style: select_mode ? '' : 'display: none') %>
 
         <% if creative.has_permission?(Current.user, :write) %>

--- a/app/helpers/creatives_helper.rb
+++ b/app/helpers/creatives_helper.rb
@@ -128,19 +128,25 @@ module CreativesHelper
         else
           bullet_starting_level = 3
           renderer = ->(&block) {
+            toggle_btn = if filtered_children.any?
+              content_tag(:div, toggle_button_symbol(expanded: expanded), class: "before-link creative-toggle-btn creative-action-btn", data: { creative_id: creative.id })
+            else # dummy for space alignment
+              content_tag(:div, "", class: "before-link creative-toggle-btn creative-action-btn", style: "visibility: hidden;", data: { creative_id: creative.id })
+            end
             if level <= bullet_starting_level
               heading_tag = (filtered_children.any? or creative.parent.nil?) ? "h#{level}" : "div"
               content_tag(heading_tag, class: "indent#{level}") do
-                block.call
+                toggle_btn + block.call
               end
             else # low level creative render as li
               margin = level > 0 ? "margin-left: #{(level - bullet_starting_level) * 20}px;" : ""
               content_tag(:div, class: "creative-tree-li", style: "#{margin}") do
-                if creative.effective_description.include?("<li>")
+                bullet = if creative.effective_description.include?("<li>")
                   "".html_safe
                 else
                   content_tag(:div, "", class: "creative-tree-bullet")
-                end + block.call
+                end
+                toggle_btn + bullet + block.call
               end
             end
           }


### PR DESCRIPTION
## Summary
- Place `creative-toggle-btn` inside `indent1`, `indent2`, `indent3`, and `creative-tree-li` containers
- Align indented containers with flex layout and adjust toggle button spacing

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: undefined method `has_closure_tree` for Creative:Class)*

------
https://chatgpt.com/codex/tasks/task_e_68a5510cf61483269b888ffe606ba7c6