### PR TITLE
Use SVG icon for creative edit buttons

### DIFF
--- a/app/components/creative_component.html.erb
+++ b/app/components/creative_component.html.erb
@@ -5,7 +5,12 @@
         <%= check_box_tag('selected_creative_ids[]', creative.id, false, class: 'select-creative-checkbox', style: select_mode ? '' : 'display: none') %>
 
         <% if creative.has_permission?(Current.user, :write) %>
-          <button type="button" class="creative-action-btn edit-inline-btn" data-creative-id="<%= creative.id %>">✎</button>
+          <button type="button" class="creative-action-btn edit-inline-btn" data-creative-id="<%= creative.id %>">
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" class="icon-edit">
+              <path d="M12.146.854a.5.5 0 0 1 .708 0l2.292 2.292a.5.5 0 0 1 0 .708L4.207 14.793l-4 1 1-4L12.146.854z" />
+              <path d="M11.207 3L2 12.207V13h.793L13 3.793 11.207 3z" />
+            </svg>
+          </button>
         <% end %>
         <div class="creative-divider" style="width: 6px;">
         </div>

--- a/app/javascript/creative_row_editor.js
+++ b/app/javascript/creative_row_editor.js
@@ -48,7 +48,12 @@ if (!window.creativeRowEditorInitialized) {
       row.innerHTML = `
   <div class="creative-row-start">
     <div class="creative-row-actions">
-      <button type="button" class="creative-action-btn edit-inline-btn" data-creative-id="${data.id}">✎</button>
+      <button type="button" class="creative-action-btn edit-inline-btn" data-creative-id="${data.id}">
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" class="icon-edit">
+          <path d="M12.146.854a.5.5 0 0 1 .708 0l2.292 2.292a.5.5 0 0 1 0 .708L4.207 14.793l-4 1 1-4L12.146.854z" />
+          <path d="M11.207 3L2 12.207V13h.793L13 3.793 11.207 3z" />
+        </svg>
+      </button>
       <div class="creative-divider" style="width: 6px;"></div>
     </div>
     <a class="unstyled-link" href="/creatives/${data.id}">${data.description || ''}</a>


### PR DESCRIPTION
## Summary
- replace text edit buttons with inline SVG pencil icons

## Testing
- `./bin/rubocop -a` *(fails: Could not find closure_tree-9.1.1)*
- `bin/rake test` *(fails: NoMethodError: undefined method `has_closure_tree` for Creative:Class)*
- `bin/rake spec` *(fails: undefined method `has_closure_tree` for Creative:Class)*

------
https://chatgpt.com/codex/tasks/task_e_68a5845a4de483268ea86cb9a19538a6