### PR TITLE
Add SVG comment icon for chat button

### DIFF
--- a/app/assets/images/comment.svg
+++ b/app/assets/images/comment.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M3 5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H8l-5 4V5z"/>
+</svg>

--- a/app/assets/stylesheets/creatives.css
+++ b/app/assets/stylesheets/creatives.css
@@ -232,17 +232,17 @@
 
 .comments-btn {
     width: 24px;
-}
-.comments-btn.no-comments {
-    visibility: hidden;
-}
-
-.creative-row:hover .comments-btn.no-comments {
-    visibility: visible;
+    height: 24px;
+    position: relative;
 }
 
-@media (max-width: 768px) {
-    .comments-btn.no-comments {
-        visibility: visible;
-    }
+.comment-icon {
+    width: 100%;
+    height: 100%;
+}
+
+.comments-btn .badge {
+    position: absolute;
+    top: -4px;
+    right: -4px;
 }

--- a/app/assets/stylesheets/creatives.css
+++ b/app/assets/stylesheets/creatives.css
@@ -231,14 +231,30 @@
 }
 
 .comments-btn {
-    width: 24px;
-    height: 24px;
+    width: 28px;
+    height: 28px;
     position: relative;
+    color: var(--color-text);
 }
 
 .comment-icon {
     width: 100%;
     height: 100%;
+    color: var(--color-text);
+}
+
+.comments-btn.no-comments {
+    visibility: hidden;
+}
+
+.creative-row:hover .comments-btn.no-comments {
+    visibility: visible;
+}
+
+@media (max-width: 768px) {
+    .comments-btn.no-comments {
+        visibility: visible;
+    }
 }
 
 .comments-btn .badge {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,4 +8,24 @@ module ApplicationHelper
       asset_path("default_avatar.svg")
     end
   end
+
+  def svg_tag(name, options = {})
+    # Resolve path (looks in app/assets/images by default)
+    file_path = Rails.root.join("app", "assets", "images", "#{name.end_with?('.svg') ? name : "#{name}.svg"}")
+
+    if File.exist?(file_path)
+      # Read the SVG
+      svg = File.read(file_path)
+
+      # Add class or other options if passed
+      if options[:class].present?
+        # inject class into the <svg ...> tag
+        svg.sub!('<svg', "<svg class=\"#{options[:class]}\"")
+      end
+
+      raw(svg) # mark as HTML safe
+    else
+      "<div>(missing svg: #{name})</div>"
+    end
+  end
 end

--- a/app/helpers/creatives_helper.rb
+++ b/app/helpers/creatives_helper.rb
@@ -48,11 +48,21 @@ module CreativesHelper
           unread_count = 0
         end
         classes = [ "comments-btn", "creative-action-btn" ]
-        classes << "no-comments" if comments_count.zero?
-        comment_label = comments_count.zero? ? "\u{1F4AC}" : ""
-        badge = render(Inbox::BadgeComponent.new(count: unread_count, badge_id: "comment-badge-#{creative.id}", show_zero: comments_count.positive?))
+        comment_icon = image_tag(
+          "comment.svg",
+          size: "16x16",
+          alt: t("comments.comments"),
+          class: "comment-icon"
+        )
+        badge = render(
+          Inbox::BadgeComponent.new(
+            count: unread_count,
+            badge_id: "comment-badge-#{creative.id}",
+            show_zero: comments_count.positive?
+          )
+        )
         button_tag(
-          comment_label.html_safe + badge,
+          comment_icon + badge,
           name: "show-comments-btn",
           data: { creative_id: creative.id, can_comment: true },
           class: classes.join(" ")

--- a/app/helpers/creatives_helper.rb
+++ b/app/helpers/creatives_helper.rb
@@ -48,10 +48,9 @@ module CreativesHelper
           unread_count = 0
         end
         classes = [ "comments-btn", "creative-action-btn" ]
-        comment_icon = image_tag(
+        classes << "no-comments" if comments_count.zero?
+        comment_icon = svg_tag(
           "comment.svg",
-          size: "16x16",
-          alt: t("comments.comments"),
           class: "comment-icon"
         )
         badge = render(


### PR DESCRIPTION
## Summary
- add simple comment bubble SVG
- display SVG-based comment button with unread badge
- style comment button for icon and badge positioning

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: NoMethodError: undefined method `has_closure_tree` for Creative:Class)*

------
https://chatgpt.com/codex/tasks/task_e_68a590dd51e083268a952efd07a37ff2