### PR TITLE
Add simple 'Add comment' SVG button

### DIFF
--- a/app/assets/images/add_comment_button.svg
+++ b/app/assets/images/add_comment_button.svg
@@ -1,0 +1,5 @@
+<svg width="120" height="40" viewBox="0 0 120 40" xmlns="http://www.w3.org/2000/svg">
+  <rect width="120" height="40" rx="6" fill="#4A90E2"/>
+  <text x="18" y="24" font-family="Arial, sans-serif" font-size="14" fill="white">댓글 추가</text>
+  <polygon points="95,20 75,10 75,30" fill="white"/>
+</svg>

--- a/app/assets/images/add_comment_button.svg
+++ b/app/assets/images/add_comment_button.svg
@@ -1,5 +1,4 @@
-<svg width="120" height="40" viewBox="0 0 120 40" xmlns="http://www.w3.org/2000/svg">
-  <rect width="120" height="40" rx="6" fill="#4A90E2"/>
-  <text x="18" y="24" font-family="Arial, sans-serif" font-size="14" fill="white">댓글 추가</text>
-  <polygon points="95,20 75,10 75,30" fill="white"/>
+<svg width="40" height="40" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg">
+  <path d="M5 20 L35 10 L20 35 L5 20" fill="none" stroke="#4A90E2" stroke-width="2" stroke-linejoin="round"/>
+  <path d="M5 20 L20 20" stroke="#4A90E2" stroke-width="2" stroke-linecap="round"/>
 </svg>

--- a/app/assets/stylesheets/comments_popup.css
+++ b/app/assets/stylesheets/comments_popup.css
@@ -33,6 +33,9 @@
 #new-comment-form button[type="submit"] {
   margin-top: 0.5em;
   float: right;
+  background: none;
+  border: none;
+  padding: 0;
 }
 
 .comment-item {

--- a/app/views/comments/_comments_popup.html.erb
+++ b/app/views/comments/_comments_popup.html.erb
@@ -12,6 +12,8 @@
   <div id="comments-list"><%= t('app.loading') %></div>
   <form id="new-comment-form" style="display:none;">
     <textarea name="comment[content]" rows="2" required></textarea>
-    <button type="submit"><%= t('comments.add_comment') %></button>
+    <button type="submit" class="add-comment-btn">
+      <%= image_tag('add_comment_button.svg', alt: t('comments.add_comment')) %>
+    </button>
   </form>
 </div>


### PR DESCRIPTION
## Summary
- add simple send-themed `댓글 추가` button SVG
- apply new SVG image to comment popup submit button

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: NoMethodError: undefined method `has_closure_tree` for Creative:Class)*

------
https://chatgpt.com/codex/tasks/task_e_68a5907f4dfc8326a702893ca292858c