### PR TITLE
Hide last-read bar when comments are up to date

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -12,6 +12,9 @@ class CommentsController < ApplicationController
     @comments = scope.offset((page - 1) * per_page).limit(per_page).to_a
     pointer = CommentReadPointer.find_by(user: Current.user, creative: @creative)
     last_read_comment_id = pointer&.last_read_comment_id
+    if last_read_comment_id && last_read_comment_id == @creative.comments.maximum(:id)
+      last_read_comment_id = nil
+    end
 
     if page <= 1
       render partial: "comments/list", locals: { comments: @comments.reverse, creative: @creative, last_read_comment_id: last_read_comment_id }

--- a/spec/requests/comments_read_marker_spec.rb
+++ b/spec/requests/comments_read_marker_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+require 'ostruct'
+
+RSpec.describe 'Comments read marker', type: :request do
+  let(:user) { User.create!(email: 'user@example.com', password: 'pw', name: 'User') }
+  let(:creative) { Creative.create!(user: user, description: 'Some creative') }
+
+  before do
+    allow_any_instance_of(CommentsController).to receive(:require_authentication).and_return(true)
+    Current.session = OpenStruct.new(user: user)
+  end
+
+  it 'does not show last-read bar when pointer at latest comment' do
+    creative.comments.create!(user: user, content: 'First')
+    last = creative.comments.create!(user: user, content: 'Second')
+    CommentReadPointer.create!(user: user, creative: creative, last_read_comment: last)
+    get "/creatives/#{creative.id}/comments"
+    expect(response.body).not_to include('last-read')
+  end
+end


### PR DESCRIPTION
## Summary
- Avoid rendering the last-read marker when the latest comment has already been read
- Add request spec to ensure the marker is omitted when the user is up to date

## Testing
- `./bin/rubocop spec/requests/comments_read_marker_spec.rb app/controllers/comments_controller.rb`
- `bundle exec rspec spec/requests/comments_read_marker_spec.rb`
- `bundle exec rspec` *(fails: error sending request for Chrome downloads)*

------
https://chatgpt.com/codex/tasks/task_e_68a658b3e5fc8326b9f695dd734aca8e