### PR TITLE
Reveal edit button with swipe on mobile creative rows

### DIFF
--- a/app/assets/stylesheets/creatives.css
+++ b/app/assets/stylesheets/creatives.css
@@ -133,10 +133,18 @@
         visibility: visible !important;
     }
     .edit-inline-btn {
-        display: none;
+        max-width: 0;
+        opacity: 0;
+        overflow: hidden;
+        pointer-events: none;
+        transform: translateX(10px);
+        transition: max-width 0.3s ease, opacity 0.3s ease, transform 0.3s ease;
     }
     .creative-row.show-edit .edit-inline-btn {
-        display: inline-flex;
+        max-width: 40px;
+        opacity: 1;
+        transform: translateX(0);
+        pointer-events: auto;
     }
 }
 

--- a/app/assets/stylesheets/creatives.css
+++ b/app/assets/stylesheets/creatives.css
@@ -132,6 +132,12 @@
     .creative-toggle-btn {
         visibility: visible !important;
     }
+    .edit-inline-btn {
+        display: none;
+    }
+    .creative-row.show-edit .edit-inline-btn {
+        display: inline-flex;
+    }
 }
 
 .creative-divider {

--- a/app/javascript/creative_row_swipe.js
+++ b/app/javascript/creative_row_swipe.js
@@ -1,0 +1,32 @@
+if (!window.creativeRowSwipeInitialized) {
+  window.creativeRowSwipeInitialized = true;
+
+  document.addEventListener('turbo:load', function() {
+    var startX = null;
+    var activeRow = null;
+
+    document.addEventListener('touchstart', function(e) {
+      activeRow = e.target.closest('.creative-row');
+      if (activeRow) {
+        startX = e.touches[0].clientX;
+      } else {
+        startX = null;
+      }
+    }, { passive: true });
+
+    document.addEventListener('touchend', function(e) {
+      if (!activeRow || startX === null) return;
+      var diffX = e.changedTouches[0].clientX - startX;
+      if (diffX > 50) {
+        document.querySelectorAll('.creative-row.show-edit').forEach(function(row) {
+          if (row !== activeRow) row.classList.remove('show-edit');
+        });
+        activeRow.classList.add('show-edit');
+      } else {
+        activeRow.classList.remove('show-edit');
+      }
+      activeRow = null;
+      startX = null;
+    });
+  });
+}

--- a/app/javascript/creative_row_swipe.js
+++ b/app/javascript/creative_row_swipe.js
@@ -22,7 +22,7 @@ if (!window.creativeRowSwipeInitialized) {
           if (row !== activeRow) row.classList.remove('show-edit');
         });
         activeRow.classList.add('show-edit');
-      } else {
+      } else if (diffX < -50) {
         activeRow.classList.remove('show-edit');
       }
       activeRow = null;

--- a/app/javascript/creative_row_swipe.js
+++ b/app/javascript/creative_row_swipe.js
@@ -4,8 +4,24 @@ if (!window.creativeRowSwipeInitialized) {
   document.addEventListener('turbo:load', function() {
     var startX = null;
     var activeRow = null;
+    var allEditVisible = false;
+
+    var toggleBtn = document.getElementById('toggle-edit-btn');
+    if (toggleBtn) {
+      toggleBtn.addEventListener('click', function() {
+        allEditVisible = !allEditVisible;
+        document.querySelectorAll('.creative-row').forEach(function(row) {
+          if (allEditVisible) {
+            row.classList.add('show-edit');
+          } else {
+            row.classList.remove('show-edit');
+          }
+        });
+      });
+    }
 
     document.addEventListener('touchstart', function(e) {
+      if (allEditVisible) return;
       activeRow = e.target.closest('.creative-row');
       if (activeRow) {
         startX = e.touches[0].clientX;
@@ -15,7 +31,7 @@ if (!window.creativeRowSwipeInitialized) {
     }, { passive: true });
 
     document.addEventListener('touchend', function(e) {
-      if (!activeRow || startX === null) return;
+      if (allEditVisible || !activeRow || startX === null) return;
       var diffX = e.changedTouches[0].clientX - startX;
       if (diffX > 50) {
         document.querySelectorAll('.creative-row.show-edit').forEach(function(row) {

--- a/app/views/creatives/index.html.erb
+++ b/app/views/creatives/index.html.erb
@@ -17,6 +17,7 @@
   <button id="select-creative-btn" class="select-btn" data-select-text="<%= t('app.select') %>" data-cancel-text="<%= t('app.cancel_select') %>"><%= t('app.select') %></button>
   <button id="delete-selection-btn" class="danger-link" style="display:none;" data-confirm="<%= t('creatives.index.are_you_sure_delete_selection') %>"><%= t('creatives.index.delete_selection') %></button>
   <button id="expand-all-btn" class="expand-btn" data-collapse-text="<%= t('app.collapse_all') %>" data-expand-text="<%= t('app.expand_all') %>" ><%= t('app.expand_all') %></button>
+  <button id="toggle-edit-btn" class="edit-toggle-btn">Edit</button>
   <button id="import-markdown-btn" class="import-btn desktop-only"><%= t('.import_markdown') %></button>
   <button id="export-markdown-btn" class="export-btn desktop-only" data-parent-creative-id="<%= @parent_creative&.id %>" data-error="<%= t('creatives.index.export_failed') %>"><%= t('.export_markdown') %></button>
   <%= render 'mobile_actions_menu' %>

--- a/app/views/creatives/index.html.erb
+++ b/app/views/creatives/index.html.erb
@@ -17,7 +17,7 @@
   <button id="select-creative-btn" class="select-btn" data-select-text="<%= t('app.select') %>" data-cancel-text="<%= t('app.cancel_select') %>"><%= t('app.select') %></button>
   <button id="delete-selection-btn" class="danger-link" style="display:none;" data-confirm="<%= t('creatives.index.are_you_sure_delete_selection') %>"><%= t('creatives.index.delete_selection') %></button>
   <button id="expand-all-btn" class="expand-btn" data-collapse-text="<%= t('app.collapse_all') %>" data-expand-text="<%= t('app.expand_all') %>" ><%= t('app.expand_all') %></button>
-  <button id="toggle-edit-btn" class="edit-toggle-btn">Edit</button>
+  <button id="toggle-edit-btn" class="edit-toggle-btn mobile-only"><%= t('.edit') %></button>
   <button id="import-markdown-btn" class="import-btn desktop-only"><%= t('.import_markdown') %></button>
   <button id="export-markdown-btn" class="export-btn desktop-only" data-parent-creative-id="<%= @parent_creative&.id %>" data-error="<%= t('creatives.index.export_failed') %>"><%= t('.export_markdown') %></button>
   <%= render 'mobile_actions_menu' %>

--- a/app/views/creatives/index.html.erb
+++ b/app/views/creatives/index.html.erb
@@ -107,3 +107,4 @@
 <%= javascript_include_tag 'export_to_markdown', defer: true %>
 <%= javascript_include_tag 'mobile_actions', defer: true %>
 <%= javascript_include_tag 'creative_row_editor', defer: true %>
+<%= javascript_include_tag 'creative_row_swipe', defer: true %>


### PR DESCRIPTION
## Summary
- Hide edit button on mobile creative rows until user swipes right
- Detect touch swipe and show edit button when swiping right
- Include new script on creatives index page and adjust CSS

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: undefined method `has_closure_tree` for Creative:Class)*

------
https://chatgpt.com/codex/tasks/task_e_68a6592951708326b909f8163a0afa74