### PR TITLE
Handle anonymous access for creatives

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -2,6 +2,12 @@ class ApplicationMailer < ActionMailer::Base
   default from: "soonoh.jung@vrerv.com"
   layout "mailer"
 
+  def mail(headers = {}, &block)
+    recipients = Array(headers[:to]).compact - [ User::ANONYMOUS_EMAIL ]
+    return if recipients.empty?
+    super(headers.merge(to: recipients), &block)
+  end
+
   private
 
   # Returns the decoded body of the email. For multipart emails, prefer the text

--- a/app/mailers/inbox_mailer.rb
+++ b/app/mailers/inbox_mailer.rb
@@ -6,6 +6,7 @@ class InboxMailer < ApplicationMailer
     email = I18n.with_locale(locale) do
       mail to: @user.email, subject: t("inbox_mailer.daily_summary.subject")
     end
+    return unless email
     Email.create!(
       user: @user,
       email: @user.email,

--- a/app/mailers/invitation_mailer.rb
+++ b/app/mailers/invitation_mailer.rb
@@ -2,6 +2,7 @@ class InvitationMailer < ApplicationMailer
   def invite
     @invitation = params[:invitation]
     email = mail to: @invitation.email, subject: t("invitation_mailer.invite.subject")
+    return unless email
     Email.create!(
       email: @invitation.email,
       subject: email.subject,

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,6 +1,6 @@
 class Current < ActiveSupport::CurrentAttributes
   attribute :session
-  attribute :creative_share_cache
+  attribute :creative_share_cache, :user
 
   def user
     session&.user || User.anonymous

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,5 +1,8 @@
 class Current < ActiveSupport::CurrentAttributes
   attribute :session
   attribute :creative_share_cache
-  delegate :user, to: :session, allow_nil: true
+
+  def user
+    session&.user || User.anonymous
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -53,12 +53,14 @@ class User < ApplicationRecord
   end
 
   def self.anonymous
-    user = find_or_create_by!(email: ANONYMOUS_EMAIL) do |u|
-      u.name = "Anonymous"
-      u.password = SecureRandom.hex(16)
-      u.notifications_enabled = false
+    @@anonymous_user ||= begin
+      user = find_or_create_by!(email: ANONYMOUS_EMAIL) do |u|
+        u.name = "Anonymous"
+        u.password = SecureRandom.hex(16)
+        u.notifications_enabled = false
+      end
+      user.update!(notifications_enabled: false) if user.notifications_enabled
+      user
     end
-    user.update!(notifications_enabled: false) if user.notifications_enabled
-    user
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
   DEFAULT_DISPLAY_LEVEL = 6
+  ANONYMOUS_EMAIL = "anonymous@example.com"
 
   has_secure_password
   has_many :sessions, dependent: :destroy
@@ -49,5 +50,12 @@ class User < ApplicationRecord
 
   def display_name
     name.presence || email
+  end
+
+  def self.anonymous
+    find_or_create_by!(email: ANONYMOUS_EMAIL) do |user|
+      user.name = "Anonymous"
+      user.password = SecureRandom.hex(16)
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -53,9 +53,12 @@ class User < ApplicationRecord
   end
 
   def self.anonymous
-    find_or_create_by!(email: ANONYMOUS_EMAIL) do |user|
-      user.name = "Anonymous"
-      user.password = SecureRandom.hex(16)
+    user = find_or_create_by!(email: ANONYMOUS_EMAIL) do |u|
+      u.name = "Anonymous"
+      u.password = SecureRandom.hex(16)
+      u.notifications_enabled = false
     end
+    user.update!(notifications_enabled: false) if user.notifications_enabled
+    user
   end
 end

--- a/app/views/creatives/index.html.erb
+++ b/app/views/creatives/index.html.erb
@@ -1,5 +1,6 @@
 <%= tag.div(flash[:alert], class: "flash-alert") if flash[:alert] %>
 
+<% if authenticated? %>
 <div class="creative-actions-row">
   <%= render 'add_button' if authenticated? && (!params[:id] || (@parent_creative && @parent_creative.has_permission?(Current.user, :write))) %>
   <% if @parent_creative&.parent_id.present? %>
@@ -36,6 +37,7 @@
   <%= render 'mobile_actions_menu' %>
 </div>
 <%= render 'import_upload_zone' %>
+<% end %>
 
 <%#= TODO: remove this later completely recalculate progress you need to remove route, and controller also %>
 <%#= button_to t('.recalculate_progress'), recalculate_progress_creatives_path, method: :post, form: { data: { turbo_confirm: t('.recalculate_all_parent_progress') } } if authenticated? %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -86,7 +86,7 @@
                 ]
               ) %>
         <% end %>
-        <% if Current.user %>
+        <% if authenticated? %>
           <form id="inbox_button_to">
             <button id="inbox-menu-btn" class="inbox-menu-btn" type="button"><%= t('app.inbox') %><%= render Inbox::BadgeComponent.new(user: Current.user, badge_id: 'desktop-inbox-badge') %></button>
           </form>
@@ -96,7 +96,7 @@
       </div>
 
       <%= render PopupMenuComponent.new(
-            button_content: safe_join(['...', (render(Inbox::BadgeComponent.new(user: Current.user, badge_id: 'mobile-inbox-badge')) if Current.user)]),
+            button_content: safe_join(['...', (render(Inbox::BadgeComponent.new(user: Current.user, badge_id: 'mobile-inbox-badge')) if authenticated?)]),
             button_classes: 'mobile-only',
             menu_id: 'mobile-more-menu',
             align: :right
@@ -126,7 +126,7 @@
                 ]
               ) %>
         <% end %>
-        <% if Current.user %>
+        <% if authenticated? %>
           <div>
             <button class="inbox-menu-btn" type="button"><%= t('app.inbox') %><%= render Inbox::BadgeComponent.new(user: Current.user, badge_id: 'mobile-inbox-badge') %></button>
           </div>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -13,3 +13,6 @@ unless User.exists?(email: default_email)
   )
   puts "Created default user with email: #{default_email}"
 end
+
+# Ensure Anonymous user exists
+User.anonymous

--- a/spec/mailers/anonymous_email_filter_spec.rb
+++ b/spec/mailers/anonymous_email_filter_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe 'Anonymous email filtering' do
+  it 'does not send emails to the anonymous user' do
+    user = User.anonymous
+    ActionMailer::Base.deliveries.clear
+    expect {
+      UserMailer.email_verification(user)&.deliver_now
+    }.not_to change { ActionMailer::Base.deliveries.size }
+  end
+
+  it 'does not create Email records for the anonymous user' do
+    user = User.anonymous
+    expect {
+      InboxMailer.with(user: user, items: []).daily_summary&.deliver_now
+    }.not_to change { Email.count }
+  end
+end

--- a/spec/models/anonymous_user_spec.rb
+++ b/spec/models/anonymous_user_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+RSpec.describe User, '.anonymous' do
+  it 'has notifications disabled' do
+    user = described_class.anonymous
+    expect(user.notifications_enabled).to be(false)
+  end
+end

--- a/spec/requests/creatives_anonymous_spec.rb
+++ b/spec/requests/creatives_anonymous_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe 'Creatives access for anonymous users', type: :request do
+  it 'shows creatives shared with the Anonymous user' do
+    owner = User.create!(email: 'owner@example.com', password: 'pw', name: 'Owner')
+    creative = Creative.create!(user: owner, description: 'Anonymous viewable')
+    CreativeShare.create!(creative: creative, user: User.anonymous, permission: :read)
+    creative.create_linked_creative_for_user(User.anonymous)
+
+    get creatives_path
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include('Anonymous viewable')
+  end
+end


### PR DESCRIPTION
## Summary
- Treat unauthenticated visitors as an Anonymous user
- Allow viewing creatives shared with the Anonymous user without login
- Seed default Anonymous user and request spec for anonymous access

## Testing
- `./bin/rubocop -a app/models/current.rb app/models/user.rb app/controllers/creatives_controller.rb db/seeds.rb spec/requests/creatives_anonymous_spec.rb` *(fails: Could not find closure_tree-9.1.1, with_advisory_lock-7.0.1 in locally installed gems)*
- `bundle exec rspec spec/requests/creatives_anonymous_spec.rb` *(fails: Could not find closure_tree-9.1.1, with_advisory_lock-7.0.1 in locally installed gems)*

------
https://chatgpt.com/codex/tasks/task_e_68a6a8f819c08326b80ecd1fe1040cdc