### PR TITLE
Optimize creative tree loading

### DIFF
--- a/test/models/creative_test.rb
+++ b/test/models/creative_test.rb
@@ -71,4 +71,22 @@ class CreativeTest < ActiveSupport::TestCase
 
     Current.reset
   end
+
+  test "tree_for_user preloads children" do
+    user = users(:one)
+    Current.session = OpenStruct.new(user: user)
+
+    parent = Creative.create!(user: user, description: "Parent")
+    Creative.create!(user: user, parent: parent, description: "Child 1")
+    Creative.create!(user: user, parent: parent, description: "Child 2")
+
+    tree = Creative.tree_for_user(user)
+    root = tree.find { |c| c == parent }
+
+    assert_queries(0) do
+      root.children_with_permission(user)
+    end
+
+    Current.reset
+  end
 end


### PR DESCRIPTION
## Summary
- build creative tree in one query using `hash_tree` and memoize
- reuse preloaded tree to skip N+1 child lookups
- test tree loader avoids extra queries

## Testing
- `./bin/rubocop -a`
- `bin/rails test` *(fails: Could not find closure_tree-9.1.1, with_advisory_lock-7.0.1 in locally installed gems)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d0363a5483269c32983d30a0e608