### PR TITLE
Add Google Analytics tracking

### DIFF
--- a/app/views/creatives/show.html.erb
+++ b/app/views/creatives/show.html.erb
@@ -27,3 +27,15 @@
 
   </section>
 </section>
+<% if Rails.env.production? && Rails.application.config.x.google_analytics_id.present? %>
+  <script>
+    document.addEventListener('turbo:load', function() {
+      if (typeof gtag === 'function') {
+        gtag('event', 'creative.description visited', {
+          'event_category': 'creative',
+          'event_label': '<%= j @creative.description.to_plain_text %>'
+        });
+      }
+    });
+  </script>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,6 +35,37 @@
     <%= stylesheet_link_tag 'popup' %>
 
     <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true, type: "module" %>
+
+    <% if Rails.env.production? && Rails.application.config.x.google_analytics_id.present? %>
+      <!-- Google tag (gtag.js) -->
+      <script async src="https://www.googletagmanager.com/gtag/js?id=<%= Rails.application.config.x.google_analytics_id %>"></script>
+      <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        <% if Current.user %>
+          gtag('config', '<%= Rails.application.config.x.google_analytics_id %>', { 'user_id': '<%= Current.user.id %>' });
+        <% else %>
+          gtag('config', '<%= Rails.application.config.x.google_analytics_id %>');
+        <% end %>
+        document.addEventListener('turbo:load', function() {
+          var buttons = document.querySelectorAll('button, input[type=button], input[type=submit]');
+          buttons.forEach(function(btn) {
+            btn.addEventListener('click', function() {
+              var label = btn.innerText || btn.value || '';
+              var params = {
+                'event_category': 'button',
+                'event_label': label
+              };
+              if (btn.id) {
+                params['event_id'] = btn.id;
+              }
+              gtag('event', 'button_click', params);
+            });
+          });
+        });
+      </script>
+    <% end %>
   </head>
   <body class="<%= 'dark-mode' if Current.user&.theme == 'dark' %><%= ' light-mode' if Current.user&.theme == 'light' %>" data-current-user-id="<%= Current.user&.id %>" data-controller="action-text-attachment-link" data-action="click->action-text-attachment-link#download">
     <%= render 'shared/link_creative_modal' %>

--- a/config/initializers/google_analytics.rb
+++ b/config/initializers/google_analytics.rb
@@ -1,0 +1,2 @@
+ga_id = Rails.application.credentials.dig(:google, :analytics_id) || ENV["GOOGLE_ANALYTICS_ID"]
+Rails.application.config.x.google_analytics_id = ga_id if ga_id.present?


### PR DESCRIPTION
## Summary
- support Google Analytics configuration via initializer
- embed conditional GA tracking snippet in application layout
- track signed-in user, button clicks (using button text and existing id), and creative description views

## Testing
- `./bin/rubocop -a` *(fails: Could not find closure_tree-9.1.1, with_advisory_lock-7.0.1)*
- `bundle exec rspec` *(fails: Could not find closure_tree-9.1.1, with_advisory_lock-7.0.1)*
- `bin/rails test` *(fails: Could not find closure_tree-9.1.1, with_advisory_lock-7.0.1)*

------
https://chatgpt.com/codex/tasks/task_e_68a408fed3388326b78e6202eb1c8545