### PR TITLE
Preserve links when editing in Trix editor

### DIFF
--- a/app/javascript/creative_row_editor.js
+++ b/app/javascript/creative_row_editor.js
@@ -408,8 +408,7 @@ if (!window.creativeRowEditorInitialized) {
     function autoLinkUrls(event) {
       const element = event.target;
       const html = element.innerHTML;
-      const unlinkedHtml = html.replace(/<a[^>]*>(.*?)<\/a>/g, '$1');
-      const linkedHtml = unlinkedHtml.replace(/(^|\s)(https?:\/\/[^\s<]+)/g, function(_match, prefix, url) {
+      const linkedHtml = html.replace(/(^|\s)(https?:\/\/[^\s<]+)/g, function(_match, prefix, url) {
         return `${prefix}<a href="${url}" target="_blank" rel="noopener">${url}</a>`;
       });
       if (linkedHtml !== html) {
@@ -417,6 +416,11 @@ if (!window.creativeRowEditorInitialized) {
         element.editor.loadHTML(linkedHtml);
         element.editor.setSelectedRange(selection);
       }
+
+      element.querySelectorAll('a').forEach(function(anchor) {
+        anchor.setAttribute('target', '_blank');
+        anchor.setAttribute('rel', 'noopener');
+      });
     }
 
     progressInput.addEventListener('input', function() {

--- a/spec/system/creative_inline_edit_spec.rb
+++ b/spec/system/creative_inline_edit_spec.rb
@@ -66,6 +66,25 @@ RSpec.describe 'Creative inline editing', type: :system, js: true do
     expect(page).to have_css('trix-editor a[href="http://example.com/path"]', text: 'http://example.com/path')
   end
 
+  it 'preserves links when link text is edited' do
+    visit creative_path(root_creative)
+
+    find("#creative-#{root_creative.id} .add-creative-btn").click
+    editor = find('trix-editor')
+    editor.send_keys('http://example.com')
+
+    expect(page).to have_css('trix-editor a[href="http://example.com"]', text: 'http://example.com')
+
+    page.execute_script(
+      "var editor = document.querySelector('trix-editor');" +
+      "var a = editor.querySelector('a');" +
+      "a.textContent = 'Example';" +
+      "editor.dispatchEvent(new Event('trix-change'));"
+    )
+
+    expect(page).to have_css('trix-editor a[href="http://example.com"]', text: 'Example')
+  end
+
   it 'maintains order when adding multiple creatives after the last node' do
     child_a = Creative.create!(description: 'A', user: user, parent: root_creative)
     child_b = Creative.create!(description: 'B', user: user, parent: root_creative)


### PR DESCRIPTION
## Summary
- avoid stripping existing anchors in Trix auto-link logic
- ensure Trix links retain target and rel attributes
- test that editing link text keeps anchor

## Testing
- `./bin/rubocop -a spec/system/creative_inline_edit_spec.rb`
- `bundle exec rspec spec/system/creative_inline_edit_spec.rb` *(fails: undefined method `has_closure_tree` for Creative:Class)*

------
https://chatgpt.com/codex/tasks/task_e_68a80accfaa48326a7ef73a80b0baa3d