### PR TITLE
style: tidy profile form layout

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -396,3 +396,33 @@ button {
 input[type="password"] {
     max-width: 80%;
 }
+
+/* Profile form styling */
+.profile-form div {
+    margin-bottom: 0.75em;
+}
+
+.profile-form label {
+    display: block;
+    margin-bottom: 0.25em;
+}
+
+.profile-form .checkbox-field {
+    display: flex;
+    align-items: center;
+    gap: 0.5em;
+}
+
+.profile-form .checkbox-field label {
+    display: inline;
+    margin: 0;
+}
+
+.profile-form input[type="text"],
+.profile-form input[type="number"],
+.profile-form input[type="url"],
+.profile-form input[type="file"],
+.profile-form select {
+    width: 100%;
+    max-width: 320px;
+}

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -14,8 +14,9 @@
   <%= render AvatarComponent.new(user: @user, size: 80, classes: 'avatar') %>
 </div>
 
-<%= form_with model: @user, url: user_path(@user), method: :patch, local: true, html: { multipart: true } do |f| %>
+<%= form_with model: @user, url: user_path(@user), method: :patch, local: true, html: { multipart: true, class: 'profile-form' } do |f| %>
   <div>
+    <%= f.label :avatar, t('users.avatar') %>
     <%= f.file_field :avatar %>
   </div>
   <div>
@@ -23,6 +24,7 @@
     <%= f.text_field :name, required: true %>
   </div>
   <div>
+    <%= f.label :avatar_url, t('users.avatar_url') %>
     <%= f.text_field :avatar_url, placeholder: t('users.avatar_url') %>
   </div>
   <div>
@@ -37,9 +39,9 @@
     <%= f.label :theme, t('users.theme') %>
     <%= f.select :theme, options_for_select([[t('app.system_mode'), nil], [t('app.light_mode'), 'light'], [t('app.dark_mode'), 'dark']], @user.theme) %>
   </div>
-  <div>
-    <%= f.label :notifications_enabled, t('users.notifications_enabled') %>
+  <div class="checkbox-field">
     <%= f.check_box :notifications_enabled %>
+    <%= f.label :notifications_enabled, t('users.notifications_enabled') %>
   </div>
   <%= f.submit t('users.update_profile') %>
 <% end %>

--- a/config/locales/users.en.yml
+++ b/config/locales/users.en.yml
@@ -23,6 +23,7 @@ en:
     email: "Email"
     change_password: "Change password"
     profile: "Profile"
+    avatar: "Avatar"
     avatar_url: "Avatar URL"
     update_profile: "Update Profile"
     index_title: "Users"

--- a/config/locales/users.ko.yml
+++ b/config/locales/users.ko.yml
@@ -23,6 +23,7 @@ ko:
     email: "이메일"
     change_password: "비밀번호 변경"
     profile: "프로파일"
+    avatar: "아바타"
     avatar_url: "아바타 URL"
     update_profile: "프로파일 업데이트"
     index_title: "사용자 목록"


### PR DESCRIPTION
## Summary
- clean up profile form layout with block labels and spacing
- add profile-form stylesheet rules for consistent spacing and checkbox alignment
- add avatar translation key for profile form

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: Could not find closure_tree-9.1.1, with_advisory_lock-7.0.1)*

------
https://chatgpt.com/codex/tasks/task_e_68a81b744d0c8326902f2cc2bd546ddf