### PR TITLE
Fetch share list via API in share popup

### DIFF
--- a/app/javascript/controllers/share_modal_controller.js
+++ b/app/javascript/controllers/share_modal_controller.js
@@ -1,0 +1,78 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["modal", "form", "list", "listContainer", "email", "permission"]
+  static values = { creativeId: Number }
+
+  open() {
+    this.modalTarget.style.display = "flex"
+    document.body.classList.add("no-scroll")
+    this.load()
+    const params = new URLSearchParams(window.location.search)
+    const reqEmail = params.get("share_request")
+    if (reqEmail && this.hasEmailTarget) {
+      this.emailTarget.value = reqEmail
+      this.emailTarget.dispatchEvent(new Event("blur"))
+    }
+  }
+
+  close() {
+    this.modalTarget.style.display = "none"
+    document.body.classList.remove("no-scroll")
+  }
+
+  overlay(e) {
+    if (e.target === this.modalTarget) {
+      this.close()
+    }
+  }
+
+  load() {
+    fetch(`/creatives/${this.creativeIdValue}/creative_shares.json`)
+      .then(r => r.json())
+      .then(shares => {
+        this.listTarget.innerHTML = ""
+        shares.forEach(share => {
+          const li = document.createElement("li")
+          li.innerHTML = `
+            <span>${share.user_name}</span>
+            <span>${share.permission_name}</span>
+            <span><a href="${share.creative.link}">${share.creative.title}</a></span>
+            <span>${new Date(share.created_at).toLocaleString()}</span>
+            <span><button data-action="share-modal#remove" data-share-id="${share.id}" class="delete-share-btn" style="padding:0 0.5em;">×</button></span>
+          `
+          this.listTarget.appendChild(li)
+        })
+        this.listContainerTarget.style.display = shares.length ? "block" : "none"
+      })
+  }
+
+  submit(e) {
+    e.preventDefault()
+    const formData = new FormData(this.formTarget)
+    fetch(this.formTarget.action, {
+      method: "POST",
+      headers: { Accept: "application/json" },
+      body: formData
+    })
+      .then(r => r.json())
+      .then(resp => {
+        if (resp.error) {
+          alert(resp.error)
+        } else {
+          if (resp.message) alert(resp.message)
+          if (!resp.invited) this.load()
+        }
+        this.formTarget.reset()
+      })
+  }
+
+  remove(e) {
+    const id = e.target.dataset.shareId
+    fetch(`/creatives/${this.creativeIdValue}/creative_shares/${id}`, {
+      method: "DELETE",
+      headers: { Accept: "application/json" }
+    }).then(() => this.load())
+  }
+}
+

--- a/app/javascript/controllers/share_modal_controller.js
+++ b/app/javascript/controllers/share_modal_controller.js
@@ -28,8 +28,9 @@ export default class extends Controller {
   }
 
   load() {
-    fetch(`/creatives/${this.creativeIdValue}/creative_shares.json`)
-      .then(r => r.json())
+    const url = `/creatives/${this.creativeIdValue}/creative_shares.json?t=${Date.now()}`
+    fetch(url, { headers: { Accept: "application/json" }, cache: "no-store" })
+      .then(r => (r.ok ? r.json() : []))
       .then(shares => {
         this.listTarget.innerHTML = ""
         shares.forEach(share => {

--- a/app/views/creatives/_share_button.html.erb
+++ b/app/views/creatives/_share_button.html.erb
@@ -1,76 +1,31 @@
-<button id="share-creative-btn" class="btn btn-primary desktop-only"><%= t('creatives.index.share') %></button>
-<!-- Share Creative Modal -->
-<div id="share-creative-modal" style="display:none;position:fixed;top:0;left:0;width:100vw;height:100vh;z-index:1000;align-items:center;justify-content:center;">
-  <div class="popup-box" style="min-width:320px;max-width:90vw;">
-    <button id="close-share-modal" class="popup-close-btn">&times;</button>
-    <h2><%= t('creatives.index.share_creative') %></h2>
-    <form id="share-creative-form" action="<%= creative_creative_shares_path(@parent_creative || @creative) %>" method="post" data-controller="share-invite">
-      <%= csrf_meta_tags %>
-      <div style="margin-bottom:1em;">
-        <label for="share-user-email"><%= t('creatives.index.user_email') %></label>
-        <input type="email" name="user_email" id="share-user-email" required style="width:100%;" data-share-invite-target="email" data-action="blur->share-invite#check" />
-      </div>
-      <div style="margin-bottom:1em;">
-        <select name="permission" id="share-permission" style="width:100%;">
-          <option value="no_access"><%= t('creatives.index.permission_no_access') %></option>
-          <option value="read"><%= t('creatives.index.permission_read') %></option>
-          <option value="feedback"><%= t('creatives.index.permission_feedback') %></option>
-          <option value="write"><%= t('creatives.index.permission_write') %></option>
-        </select>
-      </div>
-      <button type="submit" class="btn btn-primary" data-share-invite-target="submit" data-share="<%= t('creatives.index.share') %>" data-invite="<%= t('creatives.index.invite') %>"><%= t('creatives.index.share') %></button>
-    </form>
-    <% if @shared_list.any? %>
-      <div style="margin-top:1em;">
+<div data-controller="share-modal" data-share-modal-creative-id="<%= (@parent_creative || @creative).id %>">
+  <button id="share-creative-btn" class="btn btn-primary desktop-only" data-action="share-modal#open"><%= t('creatives.index.share') %></button>
+  <!-- Share Creative Modal -->
+  <div id="share-creative-modal" data-share-modal-target="modal" data-action="click->share-modal#overlay" style="display:none;position:fixed;top:0;left:0;width:100vw;height:100vh;z-index:1000;align-items:center;justify-content:center;">
+    <div class="popup-box" style="min-width:320px;max-width:90vw;">
+      <button id="close-share-modal" class="popup-close-btn" data-action="share-modal#close">&times;</button>
+      <h2><%= t('creatives.index.share_creative') %></h2>
+      <form id="share-creative-form" action="<%= creative_creative_shares_path(@parent_creative || @creative) %>" method="post" data-controller="share-invite" data-share-modal-target="form" data-action="submit->share-modal#submit">
+        <%= csrf_meta_tags %>
+        <div style="margin-bottom:1em;">
+          <label for="share-user-email"><%= t('creatives.index.user_email') %></label>
+          <input type="email" name="user_email" id="share-user-email" required style="width:100%;" data-share-invite-target="email" data-share-modal-target="email" data-action="blur->share-invite#check" />
+        </div>
+        <div style="margin-bottom:1em;">
+          <select name="permission" id="share-permission" style="width:100%;" data-share-modal-target="permission">
+            <option value="no_access"><%= t('creatives.index.permission_no_access') %></option>
+            <option value="read"><%= t('creatives.index.permission_read') %></option>
+            <option value="feedback"><%= t('creatives.index.permission_feedback') %></option>
+            <option value="write"><%= t('creatives.index.permission_write') %></option>
+          </select>
+        </div>
+        <button type="submit" class="btn btn-primary" data-share-invite-target="submit" data-share="<%= t('creatives.index.share') %>" data-invite="<%= t('creatives.index.invite') %>"><%= t('creatives.index.share') %></button>
+      </form>
+      <div id="share-list-container" data-share-modal-target="listContainer" style="margin-top:1em;display:none;">
         <strong><%= t('creatives.index.shared_with') %>:</strong>
-        <ul class="share-grid">
-          <% @shared_list.each do |share| %>
-            <li>
-              <span>
-                <%= render AvatarComponent.new(user: share.user, size: 20, classes: 'avatar share-avatar') %>
-              </span>
-              <span><%= share.user&.display_name || t('creatives.index.unknown_user') %></span>
-              <span><%= t("creatives.index.permission_#{share.permission}") %></span>
-              <span>
-                <%= button_to '×', creative_creative_share_path(@parent_creative || @creative, share), method: :delete, form: { data: { turbo_confirm: t('creatives.index.are_you_sure_delete_share') } }, class: 'delete-share-btn', style: 'padding:0 0.5em;' %>
-              </span>
-            </li>
-          <% end %>
-        </ul>
+        <ul class="share-grid" data-share-modal-target="list"></ul>
       </div>
-    <% end %>
+    </div>
   </div>
 </div>
-<script>
-    document.addEventListener('turbo:load', function() {
-        const shareBtn = document.getElementById('share-creative-btn');
-        const modal = document.getElementById('share-creative-modal');
-        const closeBtn = document.getElementById('close-share-modal');
-        const emailInput = document.getElementById('share-user-email');
-        if (shareBtn && modal && closeBtn) {
-            shareBtn.onclick = function() {
-                modal.style.display = 'flex';
-                document.body.classList.add('no-scroll');
-            };
-            closeBtn.onclick = function() {
-                modal.style.display = 'none';
-                document.body.classList.remove('no-scroll');
-            };
-            modal.onclick = function(e) {
-                if (e.target === modal) {
-                    modal.style.display = 'none';
-                    document.body.classList.remove('no-scroll');
-                }
-            };
-            const params = new URLSearchParams(window.location.search);
-            const reqEmail = params.get('share_request');
-            if (reqEmail) {
-                shareBtn.click();
-                if (emailInput) {
-                    emailInput.value = reqEmail;
-                    emailInput.dispatchEvent(new Event('blur'));
-                }
-            }
-        }
-    });
-</script>
+

--- a/app/views/creatives/_share_button.html.erb
+++ b/app/views/creatives/_share_button.html.erb
@@ -1,4 +1,4 @@
-<div data-controller="share-modal" data-share-modal-creative-id="<%= (@parent_creative || @creative).id %>">
+<div data-controller="share-modal" data-share-modal-creative-id-value="<%= (@parent_creative || @creative).id %>">
   <button id="share-creative-btn" class="btn btn-primary desktop-only" data-action="share-modal#open"><%= t('creatives.index.share') %></button>
   <!-- Share Creative Modal -->
   <div id="share-creative-modal" data-share-modal-target="modal" data-action="click->share-modal#overlay" style="display:none;position:fixed;top:0;left:0;width:100vw;height:100vh;z-index:1000;align-items:center;justify-content:center;">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,7 +31,7 @@ Rails.application.routes.draw do
 
   resources :creatives do
     resources :subscribers, only: [ :create ]
-    resources :creative_shares, only: [ :create, :destroy ]
+    resources :creative_shares, only: [ :index, :create, :destroy ]
     resources :comments, only: [ :index, :create, :destroy, :show, :update ]
     collection do
       post :recalculate_progress

--- a/spec/system/creative_share_spec.rb
+++ b/spec/system/creative_share_spec.rb
@@ -11,6 +11,10 @@ RSpec.describe 'Creative 공유 리스트', type: :system do
     # ignore if driver does not support resizing
   end
 
+  before do
+    driven_by(:selenium, using: :headless_chrome)
+  end
+
   it '공유 리스트가 정상적으로 표시된다' do
     resize_window_to_pc
     visit new_session_path
@@ -20,8 +24,10 @@ RSpec.describe 'Creative 공유 리스트', type: :system do
     find('#sign-in-submit').click
     expect(page).not_to have_content(I18n.t('users.sessions.new.try_another_email_or_password'))
     visit creative_path(creative)
-    expect(page).to have_css('#share-creative-modal', text: I18n.t('creatives.index.shared_with'), visible: :all)
-    expect(page).to have_css('#share-creative-modal', text: 'User1', visible: :all)
-    expect(page).to have_css('#share-creative-modal', text: 'Read', visible: :all)
+    find('#share-creative-btn').click
+    expect(page).to have_css('#share-list-container', text: I18n.t('creatives.index.shared_with'))
+    expect(page).to have_css('#share-list-container', text: 'User1')
+    expect(page).to have_css('#share-list-container', text: 'Read')
+    expect(page).to have_css('#share-list-container', text: '테스트')
   end
 end


### PR DESCRIPTION
## Summary
- Load creative share list through a new API endpoint when opening the share popup
- Handle share additions and deletions with fetch requests and show linked creative with timestamp
- Introduce Stimulus controller to manage share modal interactions

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec spec/system/creative_share_spec.rb` *(fails: undefined method `has_closure_tree` for Creative:Class)*


------
https://chatgpt.com/codex/tasks/task_e_68aa5db3c9c08326bb6ba55032c9f35e