### PR TITLE
Remove expanded states when deleting creatives

### DIFF
--- a/app/models/creative.rb
+++ b/app/models/creative.rb
@@ -18,6 +18,7 @@ class Creative < ApplicationRecord
 
   has_many :creative_shares, dependent: :destroy
   has_many :tags, dependent: :destroy
+  has_many :creative_expanded_states, dependent: :delete_all
 
   validates :progress, numericality: { greater_than_or_equal_to: 0.0, less_than_or_equal_to: 1.0 }, unless: -> { origin_id.present? }
   validates :description, presence: true, unless: -> { origin_id.present? }

--- a/test/models/creative_test.rb
+++ b/test/models/creative_test.rb
@@ -71,4 +71,20 @@ class CreativeTest < ActiveSupport::TestCase
 
     Current.reset
   end
+
+  test "destroying creative removes expanded states" do
+    user = users(:one)
+    Current.session = OpenStruct.new(user: user)
+
+    creative = Creative.create!(user: user, description: "Parent")
+    CreativeExpandedState.create!(creative: creative, user: user, expanded_status: { "1" => true })
+
+    assert_difference("Creative.count", -1) do
+      assert_nothing_raised { creative.destroy }
+    end
+
+    assert_empty CreativeExpandedState.where(creative_id: creative.id)
+
+    Current.reset
+  end
 end


### PR DESCRIPTION
## Summary
- delete associated CreativeExpandedState records when a Creative is destroyed
- cover deletion of expanded states with a new unit test

## Testing
- `./bin/rubocop -a`
- `bin/rails test` *(fails: `NoMethodError: undefined method 'has_closure_tree' for Creative:Class`)*
- `bundle exec rspec` *(fails: `NoMethodError: undefined method 'has_closure_tree' for Creative:Class`)*

------
https://chatgpt.com/codex/tasks/task_e_68ab1a47a4ac8326ad12df0008084f09