### PR TITLE
Prune docker resources after deploy

### DIFF
--- a/.kamal/hooks/post-deploy
+++ b/.kamal/hooks/post-deploy
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# Clean up unused Docker resources on all hosts after deployment
+for host in $(echo "$KAMAL_HOSTS" | tr ',' ' '); do
+  ssh "$host" "docker system prune -a --volumes --force"
+done


### PR DESCRIPTION
## Summary
- clean up unused Docker resources on deployment completion

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: NoMethodError: undefined method `has_closure_tree` for Creative:Class)*

------
https://chatgpt.com/codex/tasks/task_e_68abeae6f34883269b10316c0f593698