### PR TITLE
Add placeholder for missing edit button in creative row

### DIFF
--- a/app/assets/stylesheets/creatives.css
+++ b/app/assets/stylesheets/creatives.css
@@ -95,6 +95,11 @@
     flex-shrink: 0;
 }
 
+.edit-inline-btn-placeholder {
+    width: 16px;
+    height: 16px;
+}
+
 .creative-toggle-btn {
     width: 16px;
     height: 16px;

--- a/app/components/creative_component.html.erb
+++ b/app/components/creative_component.html.erb
@@ -6,8 +6,10 @@
 
         <% if creative.has_permission?(Current.user, :write) %>
           <button type="button" class="creative-action-btn edit-inline-btn" data-creative-id="<%= creative.id %>">
-            <%= svg_tag 'edit.svg',class: 'icon-edit' %>
+            <%= svg_tag 'edit.svg', class: 'icon-edit' %>
           </button>
+        <% else %>
+          <span class="creative-action-btn edit-inline-btn-placeholder"></span>
         <% end %>
         <div class="creative-divider" style="width: 6px;">
         </div>


### PR DESCRIPTION
## Summary
- add placeholder element when creative row lacks edit button to maintain vertical alignment
- style placeholder to match edit button dimensions

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: NoMethodError: undefined method `has_closure_tree` for Creative:Class)*

------
https://chatgpt.com/codex/tasks/task_e_68ac036658b0832689b70fdf9ed0ed9b