### PR TITLE
Fix Trix code block visibility in dark mode

### DIFF
--- a/app/assets/stylesheets/actiontext.css
+++ b/app/assets/stylesheets/actiontext.css
@@ -372,7 +372,8 @@ trix-editor .attachment__metadata {
     font-size: 0.9em;
     padding: 0.5em;
     white-space: pre;
-    background-color: #eee;
+    background-color: var(--color-btn-bg);
+    color: var(--color-text);
     overflow-x: auto; }
   .trix-content img {
     max-width: 100%;


### PR DESCRIPTION
## Summary
- ensure code blocks in Trix editor use theme variables for color and background

## Testing
- `./bin/rubocop -a`

------
https://chatgpt.com/codex/tasks/task_e_68ac045661d08326a88b2176cf9bf5b7