### PR TITLE
Switch comment presence to client-side rendering

### DIFF
--- a/app/channels/comments_presence_channel.rb
+++ b/app/channels/comments_presence_channel.rb
@@ -29,10 +29,6 @@ class CommentsPresenceChannel < ApplicationCable::Channel
   def broadcast_presence
     ids = CommentPresenceStore.list(@creative_id)
     Rails.logger.info "Broadcasting presence for creative #{@creative_id} to #{stream_name}, users: #{ids.join(', ')}"
-    html = ApplicationController.render(
-      partial: "comments/presence_avatars",
-      locals: { creative: Creative.find(@creative_id), present_ids: ids }
-    )
-    ActionCable.server.broadcast(stream_name, { html: html })
+    ActionCable.server.broadcast(stream_name, { ids: ids })
   end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -62,6 +62,22 @@ class CommentsController < ApplicationController
     redirect_to creative_path(@creative, comment_id: @comment.id)
   end
 
+  def participants
+    users = [ @creative.user ].compact + @creative.all_shared_users(:feedback).map(&:user)
+    users = users.uniq
+    data = users.map do |u|
+      {
+        id: u.id,
+        email: u.email,
+        name: u.display_name,
+        avatar_url: view_context.user_avatar_url(u, size: 20),
+        default_avatar: !u.avatar.attached? && u.avatar_url.blank?,
+        initial: u.display_name[0].upcase
+      }
+    end
+    render json: data
+  end
+
   private
 
   def set_creative

--- a/app/javascript/comment_participants_component.js
+++ b/app/javascript/comment_participants_component.js
@@ -1,0 +1,23 @@
+Jails.component('comment-participants', function(element) {
+  var users = [];
+  var present = [];
+  function avatarHtml(u) {
+    var inactive = present.indexOf(u.id) === -1;
+    var emailAttr = u.email ? (' data-email="' + u.email + '"') : '';
+    var span = u.default_avatar ? ('<span class="avatar-initial" style="font-size:' + Math.round(20 / 2) + 'px">' + u.initial + '</span>') : '';
+    return '<div class="avatar-wrapper" style="width:20px;height:20px">' +
+      '<img src="' + u.avatar_url + '" alt="" width="20" height="20" class="avatar comment-presence-avatar' + (inactive ? ' inactive' : '') + '" title="' + u.name + '" style="border-radius:50%;vertical-align:middle"' + emailAttr + '>' +
+      span +
+      '</div>';
+  }
+  function render() {
+    element.innerHTML = users.map(avatarHtml).join('');
+  }
+  return {
+    mount: render,
+    setUsers: function(data) { users = data; render(); },
+    setPresent: function(ids) { present = ids; render(); }
+  };
+});
+
+document.addEventListener('DOMContentLoaded', function() { Jails.mount(); });

--- a/app/javascript/comments.js
+++ b/app/javascript/comments.js
@@ -32,6 +32,9 @@ if (!window.commentsInitialized) {
                 document.body.classList.add('no-scroll');
                 updatePosition();
             }
+            participantsData = null;
+            currentPresentIds = [];
+            loadParticipants();
             subscribePresence();
             loadInitialComments();
         }
@@ -55,6 +58,8 @@ if (!window.commentsInitialized) {
         var textarea = form.querySelector('textarea');
         var editingId = null;
         var presenceSubscription = null;
+        var participantsData = null;
+        var currentPresentIds = [];
 
         function insertMention(email) {
             var start = textarea.selectionStart;
@@ -76,12 +81,64 @@ if (!window.commentsInitialized) {
             }
         }
 
+        function renderParticipants(presentIds) {
+            if (!participants || !participantsData) return;
+            participants.innerHTML = '';
+            participantsData.forEach(function(u) {
+                var wrapper = document.createElement('div');
+                wrapper.className = 'avatar-wrapper';
+                wrapper.style.width = '20px';
+                wrapper.style.height = '20px';
+
+                var img = document.createElement('img');
+                img.src = u.avatar_url;
+                img.alt = '';
+                img.width = 20;
+                img.height = 20;
+                var classes = 'avatar comment-presence-avatar';
+                if (presentIds.indexOf(u.id) === -1) {
+                    classes += ' inactive';
+                }
+                img.className = classes;
+                img.title = u.name;
+                img.style.borderRadius = '50%';
+                img.style.verticalAlign = 'middle';
+                if (u.email) { img.dataset.email = u.email; }
+                wrapper.appendChild(img);
+
+                if (u.default_avatar) {
+                    var span = document.createElement('span');
+                    span.className = 'avatar-initial';
+                    span.textContent = u.initial;
+                    span.style.fontSize = Math.round(20 / 2) + 'px';
+                    wrapper.appendChild(span);
+                }
+
+                participants.appendChild(wrapper);
+            });
+        }
+
+        function loadParticipants() {
+            if (!popup.dataset.creativeId) return;
+            fetch(`/creatives/${popup.dataset.creativeId}/comments/participants`)
+                .then(function(r) { return r.json(); })
+                .then(function(data) {
+                    participantsData = data;
+                    renderParticipants(currentPresentIds);
+                });
+        }
+
         function subscribePresence() {
             if (!popup.dataset.creativeId) return;
             if (presenceSubscription) { presenceSubscription.unsubscribe(); }
             presenceSubscription = ActionCable.createConsumer().subscriptions.create(
                 { channel: 'CommentsPresenceChannel', creative_id: popup.dataset.creativeId },
-                { received: function(data) { if (data.html && participants) { participants.innerHTML = data.html; } } }
+                { received: function(data) {
+                    if (data.ids) {
+                        currentPresentIds = data.ids.map(function(id) { return parseInt(id, 10); });
+                        renderParticipants(currentPresentIds);
+                    }
+                } }
             );
         }
 

--- a/app/javascript/comments.js
+++ b/app/javascript/comments.js
@@ -60,6 +60,11 @@ if (!window.commentsInitialized) {
         var presenceSubscription = null;
         var participantsData = null;
         var currentPresentIds = [];
+        var participantsComponent = null;
+
+        document.addEventListener('DOMContentLoaded', function() {
+            participantsComponent = Jails.get('comment-participants');
+        });
 
         function insertMention(email) {
             var start = textarea.selectionStart;
@@ -81,50 +86,16 @@ if (!window.commentsInitialized) {
             }
         }
 
-        function renderParticipants(presentIds) {
-            if (!participants || !participantsData) return;
-            participants.innerHTML = '';
-            participantsData.forEach(function(u) {
-                var wrapper = document.createElement('div');
-                wrapper.className = 'avatar-wrapper';
-                wrapper.style.width = '20px';
-                wrapper.style.height = '20px';
-
-                var img = document.createElement('img');
-                img.src = u.avatar_url;
-                img.alt = '';
-                img.width = 20;
-                img.height = 20;
-                var classes = 'avatar comment-presence-avatar';
-                if (presentIds.indexOf(u.id) === -1) {
-                    classes += ' inactive';
-                }
-                img.className = classes;
-                img.title = u.name;
-                img.style.borderRadius = '50%';
-                img.style.verticalAlign = 'middle';
-                if (u.email) { img.dataset.email = u.email; }
-                wrapper.appendChild(img);
-
-                if (u.default_avatar) {
-                    var span = document.createElement('span');
-                    span.className = 'avatar-initial';
-                    span.textContent = u.initial;
-                    span.style.fontSize = Math.round(20 / 2) + 'px';
-                    wrapper.appendChild(span);
-                }
-
-                participants.appendChild(wrapper);
-            });
-        }
-
         function loadParticipants() {
             if (!popup.dataset.creativeId) return;
             fetch(`/creatives/${popup.dataset.creativeId}/comments/participants`)
                 .then(function(r) { return r.json(); })
                 .then(function(data) {
                     participantsData = data;
-                    renderParticipants(currentPresentIds);
+                    if (participantsComponent) {
+                        participantsComponent.setUsers(participantsData);
+                        participantsComponent.setPresent(currentPresentIds);
+                    }
                 });
         }
 
@@ -136,7 +107,9 @@ if (!window.commentsInitialized) {
                 { received: function(data) {
                     if (data.ids) {
                         currentPresentIds = data.ids.map(function(id) { return parseInt(id, 10); });
-                        renderParticipants(currentPresentIds);
+                        if (participantsComponent) {
+                            participantsComponent.setPresent(currentPresentIds);
+                        }
                     }
                 } }
             );

--- a/app/javascript/jails.js
+++ b/app/javascript/jails.js
@@ -1,0 +1,23 @@
+window.Jails = {
+  components: {},
+  instances: {},
+  component: function(name, factory) {
+    this.components[name] = factory;
+  },
+  mount: function() {
+    var self = this;
+    document.querySelectorAll('[data-component]').forEach(function(el) {
+      var name = el.dataset.component;
+      var factory = self.components[name];
+      if (factory) {
+        var instance = factory(el) || {};
+        self.instances[name] = instance;
+        if (typeof instance.mount === 'function') { instance.mount(); }
+        else if (typeof instance.init === 'function') { instance.init(); }
+      }
+    });
+  },
+  get: function(name) {
+    return this.instances[name];
+  }
+};

--- a/app/views/creatives/index.html.erb
+++ b/app/views/creatives/index.html.erb
@@ -102,6 +102,8 @@
 <%= javascript_include_tag 'creatives_import', defer: true %>
 <%= javascript_include_tag 'creatives_expansion', defer: true %>
 <%= javascript_include_tag 'select_mode', defer: true %>
+<%= javascript_include_tag 'jails', defer: true %>
+<%= javascript_include_tag 'comment_participants_component', defer: true %>
 <%= javascript_include_tag 'comments', defer: true %>
 <%= javascript_include_tag 'mention_menu', defer: true %>
 <%= javascript_include_tag 'action_text_attachment_link', defer: true %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,7 +32,11 @@ Rails.application.routes.draw do
   resources :creatives do
     resources :subscribers, only: [ :create ]
     resources :creative_shares, only: [ :create, :destroy ]
-    resources :comments, only: [ :index, :create, :destroy, :show, :update ]
+    resources :comments, only: [ :index, :create, :destroy, :show, :update ] do
+      collection do
+        get :participants
+      end
+    end
     collection do
       post :recalculate_progress
       post :reorder


### PR DESCRIPTION
## Summary
- Replace server-rendered comment presence HTML with broadcasted user ID list
- Add `comments/participants` endpoint to supply avatar data for client rendering
- Render comment participant avatars in the browser and update activity state via ActionCable

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: undefined method `has_closure_tree' for Creative:Class)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1e46869c8326b2d94d449d52d307