### PR TITLE
Render creative descriptions in readonly Trix editor

### DIFF
--- a/app/assets/stylesheets/creatives.css
+++ b/app/assets/stylesheets/creatives.css
@@ -194,6 +194,20 @@
     align-items: center;
 }
 
+#creative-markdown-block {
+    display: block;
+}
+
+#creative-markdown-block::after {
+    content: "";
+    display: block;
+    clear: both;
+}
+
+#creative-markdown-block .creative-row-end {
+    float: right;
+}
+
 .creative-row.selected {
     background-color: var(--color-drag-over);
 }

--- a/app/views/creatives/index.html.erb
+++ b/app/views/creatives/index.html.erb
@@ -49,7 +49,7 @@
 <% if @parent_creative %>
   <div class="creative-row" id="creative-markdown-block">
     <h1 class="page-title" style="display:flex;align-items:center;gap:1em;">
-      <%= @parent_creative.effective_description %>
+      <%= trix_view_only(@parent_creative.effective_description(nil, false)) %>
     </h1>
     <div>
       <h1 style="display: flex; align-items: center; gap: 1em;">

--- a/app/views/creatives/index.html.erb
+++ b/app/views/creatives/index.html.erb
@@ -48,17 +48,18 @@
 
 <% if @parent_creative %>
   <div class="creative-row" id="creative-markdown-block">
+    <%= render_creative_progress(@parent_creative) %>
     <h1 class="page-title" style="display:flex;align-items:center;gap:1em;">
       <%= trix_view_only(@parent_creative.effective_description(nil, false)) %>
     </h1>
-    <div>
-      <h1 style="display: flex; align-items: center; gap: 1em;">
-        <%= render_creative_progress(@parent_creative) %>
-      </h1>
-    </div>
   </div>
 <% else %>
   <div class="creative-row" id="creative-markdown-block">
+    <% unless @overall_progress.nil? %>
+      <div class="creative-row-end">
+        <%= render_progress_value(@overall_progress) %>
+      </div>
+    <% end %>
     <h1 class="page-title" style="display:flex;align-items:center;gap:1em;">
       <span>
         <% if params[:tags].present? %>
@@ -68,13 +69,6 @@
         <% end %>
       </span>
     </h1>
-    <div>
-      <h1 style="display: flex; align-items: center; gap: 1em;">
-        <% unless @overall_progress.nil? %>
-          <%= render_progress_value(@overall_progress) %>
-        <% end %>
-      </h1>
-    </div>
   </div>
 <% end %>
 

--- a/app/views/creatives/show.html.erb
+++ b/app/views/creatives/show.html.erb
@@ -7,11 +7,11 @@
     <% cache @creative do %>
       <% if @creative.parent %>
         <h1>
-          <%= @creative.parent.description %>
+          <%= trix_view_only(@creative.parent.description) %>
         </h1>
       <% end %>
       <div>
-        <%= @creative.description %>
+        <%= trix_view_only(@creative.description) %>
       </div>
     <% end %>
 

--- a/test/helpers/creatives_helper_test.rb
+++ b/test/helpers/creatives_helper_test.rb
@@ -52,4 +52,11 @@ class CreativesHelperTest < ActionView::TestCase
     back = html_links_to_markdown(html)
     assert_equal "Look ![](data:image/png;base64,aGk=)", back
   end
+
+  test "trix_view_only renders readonly trix editor" do
+    creative = Creative.create!(user: users(:one), description: "<div>Example</div>")
+    html = trix_view_only(creative.effective_description(nil, false))
+    assert_includes html, "<trix-editor"
+    assert_includes html, "readonly"
+  end
 end


### PR DESCRIPTION
## Summary
- render creative descriptions through read-only Trix editor for consistent display
- adjust creative index and show views to use the new viewer helper
- cover helper with a unit test

## Testing
- `./bin/rubocop -a`
- `bundle exec rails test`
- `bundle exec rspec --exclude-pattern 'spec/system/**/*'`
- ⚠️ `bundle exec rspec` *(fails: error sending request for url (https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json))*

------
https://chatgpt.com/codex/tasks/task_e_68ad12a375d08326984d75785cba7e67