### PR TITLE
Align creative rows with CSS grid

### DIFF
--- a/app/assets/stylesheets/creatives.css
+++ b/app/assets/stylesheets/creatives.css
@@ -82,6 +82,13 @@
     align-items: center;
 }
 
+.creative-row-content {
+    min-width: 0;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+}
+
 .creative-action-btn {
     margin-left: 0px;
     font-size: 16px;
@@ -189,8 +196,8 @@
 }
 
 .creative-row {
-    display: flex;
-    justify-content: space-between;
+    display: grid;
+    grid-template-columns: auto 1fr auto;
     align-items: center;
 }
 
@@ -213,16 +220,22 @@
     font-size: 1.4em;
 }
 
-.creative-row-start h1 {
+.creative-row-content h1 {
     font-size: 1.3em;
 }
 
-.creative-row-start h2 {
+.creative-row-content h2 {
     font-size: 1.2em;
 }
 
-.creative-row-start h3 {
+.creative-row-content h3 {
     font-size: 1.1em;
+}
+
+.creative-row-content pre,
+.creative-row-content img {
+    max-width: 100%;
+    overflow: hidden;
 }
 
 .indent1,

--- a/app/components/creative_component.html.erb
+++ b/app/components/creative_component.html.erb
@@ -12,6 +12,8 @@
         <div class="creative-divider" style="width: 6px;">
         </div>
       </div>
+    </div>
+    <div class="creative-row-content">
       <%= content %>
     </div>
     <%= helpers.render_creative_progress(creative, select_mode: select_mode) %>

--- a/app/javascript/creative_row_editor.js
+++ b/app/javascript/creative_row_editor.js
@@ -54,8 +54,8 @@ if (!window.creativeRowEditorInitialized) {
       </button>
       <div class="creative-divider" style="width: 6px;"></div>
     </div>
-    <a class="unstyled-link" href="/creatives/${data.id}">${data.description || ''}</a>
   </div>
+  <div class="creative-row-content"><a class="unstyled-link" href="/creatives/${data.id}">${data.description || ''}</a></div>
   <div class="creative-row-end"><span class="creative-progress-incomplete">0%</span></div>`;
       tree.insertBefore(row, tree.firstChild);
       attachButtons();


### PR DESCRIPTION
## Summary
- align creative rows using CSS grid to keep actions, content, and progress lined up
- handle oversized content by constraining images and pre blocks
- update inline editor template for new row structure

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: undefined method `has_closure_tree` for Creative:Class)*

------
https://chatgpt.com/codex/tasks/task_e_68ad3099c9d08326a4645e44820b125d