### PR TITLE
Refactor creative-row layout using CSS grid

### DIFF
--- a/app/assets/stylesheets/creatives.css
+++ b/app/assets/stylesheets/creatives.css
@@ -189,9 +189,23 @@
 }
 
 .creative-row {
-    display: flex;
-    justify-content: space-between;
+    /* Grid layout: start | content | end */
+    display: grid;
+    grid-template-columns: auto 1fr auto;
     align-items: center;
+    column-gap: 0;
+}
+
+.creative-row-content {
+    /* Allow content to shrink without overflow */
+    min-width: 0;
+    overflow-wrap: break-word;
+}
+
+.creative-row-content img {
+    max-width: 100%;
+    height: auto;
+    display: block;
 }
 
 .creative-row.selected {

--- a/app/components/creative_component.html.erb
+++ b/app/components/creative_component.html.erb
@@ -12,6 +12,8 @@
         <div class="creative-divider" style="width: 6px;">
         </div>
       </div>
+    </div>
+    <div class="creative-row-content">
       <%= content %>
     </div>
     <%= helpers.render_creative_progress(creative, select_mode: select_mode) %>

--- a/app/javascript/creative_row_editor.js
+++ b/app/javascript/creative_row_editor.js
@@ -54,6 +54,8 @@ if (!window.creativeRowEditorInitialized) {
       </button>
       <div class="creative-divider" style="width: 6px;"></div>
     </div>
+  </div>
+  <div class="creative-row-content">
     <a class="unstyled-link" href="/creatives/${data.id}">${data.description || ''}</a>
   </div>
   <div class="creative-row-end"><span class="creative-progress-incomplete">0%</span></div>`;

--- a/app/views/creatives/index.html.erb
+++ b/app/views/creatives/index.html.erb
@@ -48,27 +48,29 @@
 
 <% if @parent_creative %>
   <div class="creative-row" id="creative-markdown-block">
-    <h1 class="page-title" style="display:flex;align-items:center;gap:1em;">
-      <%= @parent_creative.effective_description %>
-    </h1>
-    <div>
-      <h1 style="display: flex; align-items: center; gap: 1em;">
-        <%= render_creative_progress(@parent_creative) %>
+    <div class="creative-row-start">
+      <h1 class="page-title" style="display:flex;align-items:center;gap:1em;">
+        <%= @parent_creative.effective_description %>
       </h1>
     </div>
+    <div class="creative-row-content"></div>
+    <%= render_creative_progress(@parent_creative) %>
   </div>
 <% else %>
   <div class="creative-row" id="creative-markdown-block">
-    <h1 class="page-title" style="display:flex;align-items:center;gap:1em;">
-      <span>
-        <% if params[:tags].present? %>
-          <%= render_tags(params[:tags]&.map { |tag_id| Label.find(tag_id) }, 'unstyled-link') %>
-        <% else %>
-          <%= t('.creatives') %>
-        <% end %>
-      </span>
-    </h1>
-    <div>
+    <div class="creative-row-start">
+      <h1 class="page-title" style="display:flex;align-items:center;gap:1em;">
+        <span>
+          <% if params[:tags].present? %>
+            <%= render_tags(params[:tags]&.map { |tag_id| Label.find(tag_id) }, 'unstyled-link') %>
+          <% else %>
+            <%= t('.creatives') %>
+          <% end %>
+        </span>
+      </h1>
+    </div>
+    <div class="creative-row-content"></div>
+    <div class="creative-row-end">
       <h1 style="display: flex; align-items: center; gap: 1em;">
         <% unless @overall_progress.nil? %>
           <%= render_progress_value(@overall_progress) %>


### PR DESCRIPTION
## Summary
- Split creative-row into start, content, and end sections using CSS Grid
- Ensure middle content shrinks and wraps to prevent overflow
- Update creative row templates and editors for new structure

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: undefined method `has_closure_tree` for Creative:Class)*

------
https://chatgpt.com/codex/tasks/task_e_68ad3784812c8326879286077adf169f