### PR TITLE
Download non-image Trix attachments

### DIFF
--- a/app/javascript/action_text_attachment_link.js
+++ b/app/javascript/action_text_attachment_link.js
@@ -1,5 +1,3 @@
-
-
 if (!window.isTrixAttachmentDownloadEnabled) {
   window.isTrixAttachmentDownloadEnabled = true;
 
@@ -8,6 +6,9 @@ if (!window.isTrixAttachmentDownloadEnabled) {
     document.addEventListener('click', function (e) {
       const element = e.target.closest('action-text-attachment');
       if (!element) return;
+
+      // Skip attachments inside editors so they can be edited and saved
+      if (element.closest('trix-editor')) return;
 
       const contentType = element.getAttribute('content-type') || '';
       if (contentType.startsWith('image/')) return;

--- a/app/javascript/action_text_attachment_link.js
+++ b/app/javascript/action_text_attachment_link.js
@@ -1,31 +1,33 @@
 
 
 if (!window.isTrixAttachmentDownloadEnabled) {
-    window.isTrixAttachmentDownloadEnabled = true;
+  window.isTrixAttachmentDownloadEnabled = true;
 
-    // To prevent infinite turbo progress bar issue, use javascript to hand attachment downloads.
-    document.addEventListener('turbo:load', function () {
-        const actionTextAttachments = document.getElementsByTagName('action-text-attachment');
-        if (actionTextAttachments) {
-            Array.from(actionTextAttachments).forEach(function (element) {
-                element.addEventListener('click', function (e) {
-                    e.preventDefault();
+  // To prevent infinite turbo progress bar issue, use javascript to handle attachment downloads.
+  document.addEventListener('turbo:load', function () {
+    document.addEventListener('click', function (e) {
+      const element = e.target.closest('action-text-attachment');
+      if (!element) return;
 
-                    const url = element.getAttribute('url');
-                    const filename = element.getAttribute('filename') || 'download';
+      const contentType = element.getAttribute('content-type') || '';
+      if (contentType.startsWith('image/')) return;
 
-                    if (!url) return;
+      e.preventDefault();
+      e.stopPropagation();
 
-                    // Create a temporary anchor element for download attachment.
-                    const a = document.createElement('a');
-                    a.href = url;
-                    a.download = filename;
-                    a.style.display = 'none';
-                    document.body.appendChild(a);
-                    a.click();
-                    document.body.removeChild(a);
-                });
-            });
-        }
+      const url = element.getAttribute('url');
+      const filename = element.getAttribute('filename') || 'download';
+
+      if (!url) return;
+
+      // Create a temporary anchor element for download attachment.
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = filename;
+      a.style.display = 'none';
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
     });
+  });
 }


### PR DESCRIPTION
## Summary
- Handle Trix attachment clicks via delegated listener
- Skip image attachments and download other files
- Stop event propagation to avoid navigating to creative page

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: undefined method `has_closure_tree` for Creative:Class)*

------
https://chatgpt.com/codex/tasks/task_e_68ad5951a27c83268b29113cc8bcb68c