### PR TITLE
Add Google Calendar /calendar command

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,7 @@ gem "closure_tree"
 gem "fcm"
 gem "google-apis-fcm_v1"
 gem "google-apis-calendar_v3"
+gem "googleauth"
 
 # Google OAuth
 gem "omniauth-google-oauth2"

--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ gem "image_processing", "~> 1.14"
 gem "closure_tree"
 gem "fcm"
 gem "google-apis-fcm_v1"
+gem "google-apis-calendar_v3"
 
 # Google OAuth
 gem "omniauth-google-oauth2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,6 +136,8 @@ GEM
       raabro (~> 1.4)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    google-apis-calendar_v3 (0.48.0)
+      google-apis-core (>= 0.15.0, < 2.a)
     google-apis-core (0.18.0)
       addressable (~> 2.5, >= 2.5.1)
       googleauth (~> 1.9)
@@ -144,8 +146,6 @@ GEM
       mutex_m
       representable (~> 3.0)
       retriable (>= 2.0, < 4.a)
-    google-apis-calendar_v3 (0.48.0)
-      google-apis-core (>= 0.15.0, < 2.a)
     google-apis-fcm_v1 (0.34.0)
       google-apis-core (>= 0.15.0, < 2.a)
     google-cloud-env (2.3.1)
@@ -514,6 +514,7 @@ DEPENDENCIES
   fcm
   google-apis-calendar_v3
   google-apis-fcm_v1
+  googleauth
   image_processing (~> 1.14)
   importmap-rails
   jbuilder

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -144,6 +144,8 @@ GEM
       mutex_m
       representable (~> 3.0)
       retriable (>= 2.0, < 4.a)
+    google-apis-calendar_v3 (0.48.0)
+      google-apis-core (>= 0.15.0, < 2.a)
     google-apis-fcm_v1 (0.34.0)
       google-apis-core (>= 0.15.0, < 2.a)
     google-cloud-env (2.3.1)
@@ -510,6 +512,7 @@ DEPENDENCIES
   closure_tree
   debug
   fcm
+  google-apis-calendar_v3
   google-apis-fcm_v1
   image_processing (~> 1.14)
   importmap-rails

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -30,6 +30,7 @@ class CommentsController < ApplicationController
       render json: { error: I18n.t("comments.no_permission") }, status: :forbidden and return
     end
     if @comment.save
+      handle_comment_commands(@comment)
       render partial: "comments/comment", locals: { comment: @comment }, status: :created
     else
       render json: { errors: @comment.errors.full_messages }, status: :unprocessable_entity
@@ -90,5 +91,39 @@ class CommentsController < ApplicationController
 
   def comment_params
     params.require(:comment).permit(:content)
+  end
+
+  def handle_comment_commands(comment)
+    content = comment.content.to_s.strip
+    return unless content.start_with?("/calendar")
+
+    args = content.sub("/calendar", "").strip
+    match = args.match(/\A(\d{4}-\d{2}-\d{2})(?:@(\d{2}:\d{2}))?(?:\s+(.*))?\z/)
+    return unless match
+
+    date_str = match[1]
+    time_str = match[2]
+    memo = match[3]
+
+    if time_str
+      start_time = Time.zone.parse("#{date_str} #{time_str}")
+      end_time = start_time + 1.hour
+    else
+      start_time = Date.parse(date_str)
+      end_time = start_time + 1.day
+    end
+
+    base_summary = comment.creative.effective_description(false)
+    summary = memo.presence || base_summary&.to_plain_text
+    calendar_id = comment.user&.calendar_id.presence || "primary"
+
+    GoogleCalendarService.new.create_event(
+      calendar_id: calendar_id,
+      start_time: start_time,
+      end_time: end_time,
+      summary: summary
+    )
+  rescue StandardError => e
+    Rails.logger.error("Calendar command failed: #{e.message}")
   end
 end

--- a/app/controllers/google_auth_controller.rb
+++ b/app/controllers/google_auth_controller.rb
@@ -24,6 +24,13 @@ class GoogleAuthController < ApplicationController
 
     user.save! if user.new_record? || user.changed?
 
+    # Ensure app calendar exists if the granted scope allows creating an app calendar
+    begin
+      GoogleCalendarService.new(user: user).ensure_app_calendar!
+    rescue => e
+      Rails.logger.error("Post-login calendar setup failed: #{e.message}")
+    end
+
     start_new_session_for(user)
     redirect_to after_authentication_url
   end

--- a/app/controllers/google_auth_controller.rb
+++ b/app/controllers/google_auth_controller.rb
@@ -16,6 +16,12 @@ class GoogleAuthController < ApplicationController
       user.avatar_url = auth.info.image
     end
 
+    # for personal google service (like google calendar)
+    user.google_uid = auth.uid
+    user.google_access_token = auth.credentials.token
+    user.google_refresh_token = auth.credentials.refresh_token || user.google_refresh_token
+    user.google_token_expires_at = Time.at(auth.credentials.expires_at) if auth.credentials.expires_at
+
     user.save! if user.new_record? || user.changed?
 
     start_new_session_for(user)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -100,7 +100,7 @@ class UsersController < ApplicationController
   end
 
   def profile_params
-    params.require(:user).permit(:avatar, :avatar_url, :display_level, :completion_mark, :theme, :name, :notifications_enabled)
+    params.require(:user).permit(:avatar, :avatar_url, :display_level, :completion_mark, :theme, :name, :notifications_enabled, :calendar_id)
   end
 
   def notification_settings_params

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,7 @@ class User < ApplicationRecord
   attribute :display_level, :integer, default: DEFAULT_DISPLAY_LEVEL
   attribute :completion_mark, :string, default: ""
   attribute :theme, :string
+  attribute :calendar_id, :string
   attribute :name, :string
   attribute :notifications_enabled, :boolean
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,6 +16,11 @@ class User < ApplicationRecord
   attribute :name, :string
   attribute :notifications_enabled, :boolean
 
+  attribute :google_uid, :string
+  attribute :google_access_token, :string
+  attribute :google_refresh_token, :string
+  attribute :google_token_expires_at, :datetime
+
   normalizes :email, with: ->(e) { e.strip.downcase }
 
   validates :email, presence: true, uniqueness: true,

--- a/app/services/google_calendar_service.rb
+++ b/app/services/google_calendar_service.rb
@@ -1,31 +1,94 @@
 require "google/apis/calendar_v3"
+require "googleauth"
 
 class GoogleCalendarService
-  def initialize
+  def initialize(user:)
+    @user = user
     @service = Google::Apis::CalendarV3::CalendarService.new
-    @service.authorization = authorization
+    @service.client_options.application_name = "Collavre"
+    @service.authorization = user_credentials
   end
 
-  def create_event(calendar_id:, start_time:, end_time:, summary:)
-    event = Google::Apis::CalendarV3::Event.new(
-      summary: summary,
-      start: build_event_time(start_time),
-      end: build_event_time(end_time)
-    )
+  # Creates a Google Calendar event.
+  # Optional params supported: location, recurrence (array), attendees (array of emails or attendee hashes),
+  # reminders (hash: { use_default: true/false, overrides: [{ method: 'email'|'popup', minutes: Integer }, ...] })
+  def create_event(
+    calendar_id: "primary",
+    start_time:,
+    end_time:,
+    summary:,
+    description: nil,
+    timezone: "Asia/Seoul",
+    location: nil,
+    recurrence: nil,
+    attendees: nil,
+    reminders: nil,
+    all_day: false
+  )
+    event_args = { summary: summary, description: description }
+
+    if all_day
+      # All-day events must use date (no time or timezone). End date is exclusive per Google Calendar API.
+      start_date = start_time.to_date
+      end_date_exclusive = end_time.to_date + 1
+      event_args[:start] = { date: start_date.iso8601 }
+      event_args[:end]   = { date: end_date_exclusive.iso8601 }
+    else
+      event_args[:start] = { date_time: start_time.iso8601, time_zone: timezone }
+      event_args[:end]   = { date_time: end_time.iso8601,   time_zone: timezone }
+    end
+
+    event_args[:location] = location if location.present?
+    event_args[:recurrence] = recurrence if recurrence.present?
+
+    if attendees.present?
+      event_args[:attendees] = Array(attendees).map do |a|
+        if a.is_a?(String)
+          Google::Apis::CalendarV3::EventAttendee.new(email: a)
+        elsif a.is_a?(Hash)
+          # Support keys like :email, :response_status, etc.
+          Google::Apis::CalendarV3::EventAttendee.new(**a.symbolize_keys)
+        else
+          nil
+        end
+      end.compact
+    end
+
+    if reminders.present?
+      use_default = reminders[:use_default]
+      overrides = Array(reminders[:overrides]).map do |r|
+        # IMPORTANT: Ruby client uses method_prop instead of method
+        meth = r[:method] || r[:method_prop]
+        mins = r[:minutes]
+        Google::Apis::CalendarV3::EventReminder.new(method_prop: meth, minutes: mins)
+      end
+      event_args[:reminders] = Google::Apis::CalendarV3::Event::Reminders.new(use_default: !!use_default, overrides: overrides)
+    end
+
+    event = Google::Apis::CalendarV3::Event.new(**event_args)
+
+    Rails.logger.info("### Creating Google Calendar event: #{event.to_json}")
+
     @service.insert_event(calendar_id, event)
+  rescue Google::Apis::ClientError => e
+    # Surface helpful error info to aid debugging 400 errors
+    Rails.logger.error("Google Calendar insert_event 4xx: #{e.class} #{e.status_code} - #{e.message} body=#{e.body}")
+    raise
+  end
+
+  def list_calendars
+    @service.list_calendar_lists.items.map { |c| [ c.summary, c.id ] }.to_h
   end
 
   private
 
-  def authorization
-    Google::Auth.get_application_default([ Google::Apis::CalendarV3::AUTH_CALENDAR ])
-  end
-
-  def build_event_time(time)
-    if time.is_a?(Date)
-      Google::Apis::CalendarV3::EventDateTime.new(date: time.iso8601)
-    else
-      Google::Apis::CalendarV3::EventDateTime.new(date_time: time.iso8601, time_zone: time.zone.name)
-    end
+  def user_credentials
+    Google::Auth::UserRefreshCredentials.new(
+      client_id:     Rails.application.credentials.dig(:google, :client_id),
+      client_secret: Rails.application.credentials.dig(:google, :client_secret),
+      scope:         [ Google::Apis::CalendarV3::AUTH_CALENDAR ],
+      refresh_token: @user.google_refresh_token
+    ).tap(&:fetch_access_token!)
   end
 end
+

--- a/app/services/google_calendar_service.rb
+++ b/app/services/google_calendar_service.rb
@@ -94,7 +94,7 @@ class GoogleCalendarService
   end
 
   def create_app_calendar
-    calendar = @service.insert_calendar(Google::Apis::CalendarV3::Calendar.new(summary: "Collavre"))
+    calendar = @service.insert_calendar(Google::Apis::CalendarV3::Calendar.new(summary: @service.client_options.application_name))
     # save calendar id to user profile
     @user.update(calendar_id: calendar.id)
     calendar.id

--- a/app/services/google_calendar_service.rb
+++ b/app/services/google_calendar_service.rb
@@ -1,0 +1,31 @@
+require "google/apis/calendar_v3"
+
+class GoogleCalendarService
+  def initialize
+    @service = Google::Apis::CalendarV3::CalendarService.new
+    @service.authorization = authorization
+  end
+
+  def create_event(calendar_id:, start_time:, end_time:, summary:)
+    event = Google::Apis::CalendarV3::Event.new(
+      summary: summary,
+      start: build_event_time(start_time),
+      end: build_event_time(end_time)
+    )
+    @service.insert_event(calendar_id, event)
+  end
+
+  private
+
+  def authorization
+    Google::Auth.get_application_default([ Google::Apis::CalendarV3::AUTH_CALENDAR ])
+  end
+
+  def build_event_time(time)
+    if time.is_a?(Date)
+      Google::Apis::CalendarV3::EventDateTime.new(date: time.iso8601)
+    else
+      Google::Apis::CalendarV3::EventDateTime.new(date_time: time.iso8601, time_zone: time.zone.name)
+    end
+  end
+end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -39,6 +39,10 @@
     <%= f.label :theme, t('users.theme') %>
     <%= f.select :theme, options_for_select([[t('app.system_mode'), nil], [t('app.light_mode'), 'light'], [t('app.dark_mode'), 'dark']], @user.theme) %>
   </div>
+  <div>
+    <%= f.label :calendar_id, t('users.calendar_id') %>
+    <%= f.text_field :calendar_id, placeholder: t('users.calendar_id') %>
+  </div>
   <div class="checkbox-field">
     <%= f.check_box :notifications_enabled %>
     <%= f.label :notifications_enabled, t('users.notifications_enabled') %>

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -4,7 +4,7 @@ Rails.application.config.middleware.use OmniAuth::Builder do
            Rails.application.credentials.dig(:google, :client_secret),
            scope: %w[
              https://www.googleapis.com/auth/userinfo.email
-             https://www.googleapis.com/auth/calendar
+             https://www.googleapis.com/auth/calendar.app.created
            ].join(" "),
            access_type: "offline",
            prompt: "consent",

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -2,7 +2,13 @@ Rails.application.config.middleware.use OmniAuth::Builder do
   provider :google_oauth2,
            Rails.application.credentials.dig(:google, :client_id),
            Rails.application.credentials.dig(:google, :client_secret),
-           scope: "email,profile"
+           scope: %w[
+             https://www.googleapis.com/auth/userinfo.email
+             https://www.googleapis.com/auth/calendar
+           ].join(" "),
+           access_type: "offline",
+           prompt: "consent",
+           include_granted_scopes: "true"
 end
 
 OmniAuth.config.allowed_request_methods = %i[post]

--- a/config/locales/users.en.yml
+++ b/config/locales/users.en.yml
@@ -31,6 +31,7 @@ en:
     display_level: "Max Display Level"
     completion_mark: "Completion Mark"
     theme: "Theme"
+    calendar_id: "Calendar ID"
     notifications_enabled: "Enable notifications"
     profile_updated: "Profile updated successfully."
     avatar_updated: "Avatar updated successfully."

--- a/config/locales/users.ko.yml
+++ b/config/locales/users.ko.yml
@@ -31,6 +31,7 @@ ko:
     display_level: "최대 표시 레벨"
     completion_mark: "완료 표시 문자"
     theme: "테마"
+    calendar_id: "캘린더 ID"
     notifications_enabled: "알림 사용"
     profile_updated: "프로파일이 업데이트되었습니다."
     avatar_updated: "아바타가 변경되었습니다."

--- a/db/migrate/20250826000000_add_calendar_id_to_users.rb
+++ b/db/migrate/20250826000000_add_calendar_id_to_users.rb
@@ -1,0 +1,5 @@
+class AddCalendarIdToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :calendar_id, :string
+  end
+end

--- a/db/migrate/20250827000000_add_google_oauth_tokens_to_users.rb
+++ b/db/migrate/20250827000000_add_google_oauth_tokens_to_users.rb
@@ -1,0 +1,8 @@
+class AddGoogleOauthTokensToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :google_uid, :string
+    add_column :users, :google_access_token, :string
+    add_column :users, :google_refresh_token, :string
+    add_column :users, :google_token_expires_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_26_000000) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_27_000000) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
     t.text "body"
@@ -355,8 +355,12 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_26_000000) do
     t.string "completion_mark", default: "", null: false
     t.string "theme"
     t.string "name", null: false
-    t.string "calendar_id"
     t.boolean "notifications_enabled"
+    t.string "calendar_id"
+    t.string "google_uid"
+    t.string "google_access_token"
+    t.string "google_refresh_token"
+    t.datetime "google_token_expires_at"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_23_000000) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_26_000000) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
     t.text "body"
@@ -355,6 +355,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_23_000000) do
     t.string "completion_mark", default: "", null: false
     t.string "theme"
     t.string "name", null: false
+    t.string "calendar_id"
     t.boolean "notifications_enabled"
     t.index ["email"], name: "index_users_on_email", unique: true
   end

--- a/docs/google-auth.md
+++ b/docs/google-auth.md
@@ -25,3 +25,10 @@ Run `bin/rails credentials:edit` to add them.
 On the sign in or sign up pages click **Sign in with Google**. If an account
 with the returned email does not exist, a new user is created automatically with
 the email and name from Google.
+
+## Scopes
+
+The default scope is `https://www.googleapis.com/auth/userinfo.email`. 
+To request access to Google Calendar,
+* add `https://www.googleapis.com/auth/calendar` (but this needs verification for production).
+* or add `https://www.googleapis.com/auth/calendar.app.created` without verification. (this app will create app calendar)


### PR DESCRIPTION
## Summary
- allow users to store a Google Calendar ID in their profile
- add `/calendar` chat command that schedules creatives in Google Calendar
- integrate Google Calendar API via `google-apis-calendar_v3`

## Testing
- `./bin/rubocop -a`
- `bin/rails db:migrate` *(fails: table "comments" already exists)*

------
https://chatgpt.com/codex/tasks/task_e_68ad899973448326999583c848afcdba