### PR TITLE
Convert URLs in comments to links

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -28,4 +28,10 @@ module ApplicationHelper
       "<div>(missing svg: #{name})</div>"
     end
   end
+
+  def linkify_urls(text)
+    ERB::Util.html_escape(text.to_s).gsub(%r{https?://[^\s]+}) do |url|
+      link_to(url, url, target: "_blank", rel: "noopener")
+    end.html_safe
+  end
 end

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -15,6 +15,6 @@
     <% end %>
   </div>
   <div class="comment-content">
-    <%= h comment.content %>
+    <%= linkify_urls(comment.content) %>
   </div>
 </div>

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+
+class ApplicationHelperTest < ActionView::TestCase
+  include ApplicationHelper
+
+  test "linkify_urls converts URLs to links" do
+    text = "Visit http://example.com"
+    expected = 'Visit <a href="http://example.com" target="_blank" rel="noopener">http://example.com</a>'
+    assert_equal expected, linkify_urls(text)
+  end
+
+  test "linkify_urls escapes html" do
+    text = "<script>alert('x')</script> https://example.com"
+    result = linkify_urls(text)
+    assert_includes result, "&lt;script&gt;alert('x')&lt;/script&gt;"
+    assert_includes result, '<a href="https://example.com" target="_blank" rel="noopener">https://example.com</a>'
+  end
+end


### PR DESCRIPTION
## Summary
- Render comment text with URL auto-linking
- Add helper method and tests for URL linkification

## Testing
- `./bin/rubocop -a`
- `bin/rails test` *(fails: NoMethodError: undefined method `has_closure_tree' for Creative:Class)*
- `bundle exec rspec` *(fails: NoMethodError: undefined method `has_closure_tree' for Creative:Class)*

------
https://chatgpt.com/codex/tasks/task_e_68ae98fe8e608326a39992087f2dbf95