### PR TITLE
Store calendar events and display on timeline

### DIFF
--- a/app/components/plans_timeline_component.rb
+++ b/app/components/plans_timeline_component.rb
@@ -6,6 +6,7 @@ class PlansTimelineComponent < ViewComponent::Base
       .where("target_date >= ? AND created_at <= ?", @start_date, @end_date)
       .order(:created_at)
     @calendar_events = calendar_events
+      .includes(:creative)
       .where("DATE(start_time) <= ? AND DATE(end_time) >= ?", @end_date, @start_date)
       .order(:start_time)
   end
@@ -31,8 +32,8 @@ class PlansTimelineComponent < ViewComponent::Base
           name: event.summary.presence || I18n.l(event.start_time.to_date),
           created_at: event.start_time.to_date,
           target_date: event.end_time.to_date,
-          progress: 1,
-          path: event.html_link,
+          progress: event.creative&.progress || 0,
+          path: event.creative ? helpers.creative_path(event.creative) : event.html_link,
           deletable: false
         }
       end

--- a/app/components/plans_timeline_component.rb
+++ b/app/components/plans_timeline_component.rb
@@ -1,25 +1,42 @@
 class PlansTimelineComponent < ViewComponent::Base
-  def initialize(plans:)
+  def initialize(plans:, calendar_events: CalendarEvent.none)
     @start_date = Date.current - 30
     @end_date = Date.current + 30
     @plans = plans
       .where("target_date >= ? AND created_at <= ?", @start_date, @end_date)
       .order(:created_at)
+    @calendar_events = calendar_events
+      .where("DATE(start_time) <= ? AND DATE(end_time) >= ?", @end_date, @start_date)
+      .order(:start_time)
   end
 
-  attr_reader :plans, :start_date, :end_date
+  attr_reader :plans, :start_date, :end_date, :calendar_events
 
   def plan_data
-    @plan_data ||= @plans.map do |plan|
-      {
-        id: plan.id,
-        name: plan.name.presence || I18n.l(plan.target_date),
-        created_at: plan.created_at.to_date,
-        target_date: plan.target_date,
-        progress: plan.progress,
-        path: plan_creatives_path(plan),
-        deletable: plan.owner_id == Current.user&.id
-      }
+    @plan_data ||= begin
+      plan_items = @plans.map do |plan|
+        {
+          id: plan.id,
+          name: plan.name.presence || I18n.l(plan.target_date),
+          created_at: plan.created_at.to_date,
+          target_date: plan.target_date,
+          progress: plan.progress,
+          path: plan_creatives_path(plan),
+          deletable: plan.owner_id == Current.user&.id
+        }
+      end
+      event_items = @calendar_events.map do |event|
+        {
+          id: "calendar_event_#{event.id}",
+          name: event.summary.presence || I18n.l(event.start_time.to_date),
+          created_at: event.start_time.to_date,
+          target_date: event.end_time.to_date,
+          progress: 1,
+          path: event.html_link,
+          deletable: false
+        }
+      end
+      plan_items + event_items
     end
   end
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -127,14 +127,15 @@ class CommentsController < ApplicationController
     summary = memo.presence || base_summary&.to_plain_text
     calendar_id = comment.user&.calendar_id.presence || "primary"
 
-    event =GoogleCalendarService.new(user: Current.user).create_event(
+    event = GoogleCalendarService.new(user: Current.user).create_event(
       calendar_id: calendar_id,
       start_time: start_time,
       end_time: end_time,
       summary: summary,
       description: creative_url(@creative, comment_id: comment.id),
       timezone: timezone.tzinfo.name,
-      all_day: time_str.nil?
+      all_day: time_str.nil?,
+      creative: @creative
     )
     "event created: #{event.html_link}"
   rescue StandardError => e

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -11,6 +11,7 @@ class PlansController < ApplicationController
                  .where("target_date >= ? AND created_at <= ?", start_date, end_date)
                  .order(:created_at)
       @calendar_events = CalendarEvent.where(user: Current.user)
+                               .includes(:creative)
                                .where("DATE(start_time) <= ? AND DATE(end_time) >= ?", end_date, start_date)
                                .order(:start_time)
     respond_to do |format|
@@ -86,8 +87,8 @@ class PlansController < ApplicationController
       name: event.summary.presence || I18n.l(event.start_time.to_date),
       created_at: event.start_time.to_date,
       target_date: event.end_time.to_date,
-      progress: 1,
-      path: event.html_link,
+      progress: event.creative&.progress || 0,
+      path: event.creative ? creative_path(event.creative) : event.html_link,
       deletable: false
     }
   end

--- a/app/models/calendar_event.rb
+++ b/app/models/calendar_event.rb
@@ -1,0 +1,5 @@
+class CalendarEvent < ApplicationRecord
+  belongs_to :user
+
+  validates :google_event_id, :start_time, :end_time, presence: true
+end

--- a/app/models/calendar_event.rb
+++ b/app/models/calendar_event.rb
@@ -1,5 +1,6 @@
 class CalendarEvent < ApplicationRecord
   belongs_to :user
+  belongs_to :creative, optional: true
 
   validates :google_event_id, :start_time, :end_time, presence: true
 end

--- a/app/services/google_calendar_service.rb
+++ b/app/services/google_calendar_service.rb
@@ -71,7 +71,16 @@ class GoogleCalendarService
       @user.calendar_id ||= create_app_calendar
       calendar_id = @user.calendar_id
     end
-    @service.insert_event(calendar_id, event)
+    result = @service.insert_event(calendar_id, event)
+    CalendarEvent.create!(
+      user: @user,
+      google_event_id: result.id,
+      summary: result.summary,
+      start_time: result.start.date_time || Time.zone.parse(result.start.date),
+      end_time: result.end.date_time || Time.zone.parse(result.end.date),
+      html_link: result.html_link
+    )
+    result
   rescue Google::Apis::ClientError => e
     # Surface helpful error info to aid debugging 400 errors
     Rails.logger.error("Google Calendar insert_event 4xx: #{e.class} #{e.status_code} - #{e.message} body=#{e.body}")

--- a/app/services/google_calendar_service.rb
+++ b/app/services/google_calendar_service.rb
@@ -23,7 +23,8 @@ class GoogleCalendarService
     recurrence: nil,
     attendees: nil,
     reminders: nil,
-    all_day: false
+    all_day: false,
+    creative: nil
   )
     event_args = { summary: summary, description: description }
 
@@ -74,6 +75,7 @@ class GoogleCalendarService
     result = @service.insert_event(calendar_id, event)
     CalendarEvent.create!(
       user: @user,
+      creative: creative,
       google_event_id: result.id,
       summary: result.summary,
       start_time: result.start.date_time || Time.zone.parse(result.start.date),

--- a/db/migrate/20250828000000_create_calendar_events.rb
+++ b/db/migrate/20250828000000_create_calendar_events.rb
@@ -1,0 +1,16 @@
+class CreateCalendarEvents < ActiveRecord::Migration[8.0]
+  def change
+    create_table :calendar_events do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :google_event_id, null: false
+      t.string :summary
+      t.datetime :start_time, null: false
+      t.datetime :end_time, null: false
+      t.string :html_link
+
+      t.timestamps
+    end
+
+    add_index :calendar_events, :google_event_id, unique: true
+  end
+end

--- a/db/migrate/20250828060000_add_creative_to_calendar_events.rb
+++ b/db/migrate/20250828060000_add_creative_to_calendar_events.rb
@@ -1,0 +1,5 @@
+class AddCreativeToCalendarEvents < ActiveRecord::Migration[8.0]
+  def change
+    add_reference :calendar_events, :creative, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_28_000000) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_28_060000) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
     t.text "body"
@@ -56,10 +56,12 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_28_000000) do
     t.datetime "start_time", null: false
     t.datetime "end_time", null: false
     t.string "html_link"
+    t.integer "creative_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["google_event_id"], name: "index_calendar_events_on_google_event_id", unique: true
     t.index ["user_id"], name: "index_calendar_events_on_user_id"
+    t.index ["creative_id"], name: "index_calendar_events_on_creative_id"
   end
 
   create_table "comment_read_pointers", force: :cascade do |t|
@@ -380,6 +382,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_28_000000) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "calendar_events", "users"
+  add_foreign_key "calendar_events", "creatives"
   add_foreign_key "comment_read_pointers", "creatives"
   add_foreign_key "comment_read_pointers", "users"
   add_foreign_key "comments", "creatives"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_27_000000) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_28_000000) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
     t.text "body"
@@ -47,6 +47,19 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_27_000000) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "calendar_events", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.string "google_event_id", null: false
+    t.string "summary"
+    t.datetime "start_time", null: false
+    t.datetime "end_time", null: false
+    t.string "html_link"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["google_event_id"], name: "index_calendar_events_on_google_event_id", unique: true
+    t.index ["user_id"], name: "index_calendar_events_on_user_id"
   end
 
   create_table "comment_read_pointers", force: :cascade do |t|
@@ -366,6 +379,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_27_000000) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "calendar_events", "users"
   add_foreign_key "comment_read_pointers", "creatives"
   add_foreign_key "comment_read_pointers", "users"
   add_foreign_key "comments", "creatives"


### PR DESCRIPTION
## Summary
- create CalendarEvent model and migration
- save Google Calendar events locally and add to plan timeline

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: Could not find closure_tree-9.1.1, with_advisory_lock-7.0.1 in locally installed gems)*

------
https://chatgpt.com/codex/tasks/task_e_68ae9cc7f42c8326a2984e0ac1ee6ae6