### PR TITLE
Add Gemini-based parent suggestion for new creatives

### DIFF
--- a/.kamal/secrets
+++ b/.kamal/secrets
@@ -19,3 +19,4 @@ RAILS_MASTER_KEY=$(cat config/master.key)
 # DATABASE_URL=$VRERV_COLLAVRE_NEON_DB_URL
 DATABASE_URL=sqlite3:storage/production-primary.sqlite3
 PORT=80
+GEMINI_API_KEY=$GEMINI_API_KEY

--- a/app/controllers/creatives_controller.rb
+++ b/app/controllers/creatives_controller.rb
@@ -120,7 +120,11 @@ class CreativesController < ApplicationController
           @creative.tags.create(label_id: tag_id)
         end
       end
-      render json: { id: @creative.id }
+      suggestions = []
+      if @creative.parent_id.nil?
+        suggestions = GeminiParentRecommender.new.recommend(@creative)
+      end
+      render json: { id: @creative.id, parent_suggestions: suggestions }
     else
       render json: { errors: @creative.errors.full_messages }, status: :unprocessable_entity
     end

--- a/app/controllers/creatives_controller.rb
+++ b/app/controllers/creatives_controller.rb
@@ -2,7 +2,7 @@ class CreativesController < ApplicationController
   # TODO: for not for security reasons for this Collavre app, we don't expose to public, later it should be controlled by roles for each Creatives
   # Removed unauthenticated access to index and show actions
   # allow_unauthenticated_access only: %i[ index show ]
-  before_action :set_creative, only: %i[ show edit update destroy request_permission ]
+  before_action :set_creative, only: %i[ show edit update destroy request_permission parent_suggestions ]
 
   def index
     # 권한 캐시: 요청 내 CreativeShare 모두 메모리에 올림
@@ -120,14 +120,15 @@ class CreativesController < ApplicationController
           @creative.tags.create(label_id: tag_id)
         end
       end
-      suggestions = []
-      if @creative.parent_id.nil?
-        suggestions = GeminiParentRecommender.new.recommend(@creative)
-      end
-      render json: { id: @creative.id, parent_suggestions: suggestions }
+      render json: { id: @creative.id }
     else
       render json: { errors: @creative.errors.full_messages }, status: :unprocessable_entity
     end
+  end
+
+  def parent_suggestions
+    suggestions = GeminiParentRecommender.new.recommend(@creative)
+    render json: suggestions
   end
 
   def edit

--- a/app/javascript/creative_row_editor.js
+++ b/app/javascript/creative_row_editor.js
@@ -18,6 +18,7 @@ if (!window.creativeRowEditorInitialized) {
     const deleteWithChildrenBtn = document.getElementById('inline-delete-with-children');
     const closeBtn = document.getElementById('inline-close');
     const parentSuggestions = document.getElementById('parent-suggestions');
+    const parentSuggestBtn = document.getElementById('inline-recommend-parent');
 
     const methodInput = document.getElementById('inline-method');
     const parentInput = document.getElementById('inline-parent-id');
@@ -117,16 +118,6 @@ if (!window.creativeRowEditorInitialized) {
             }
             const parentTree = parentId ? document.getElementById(`creative-${parentId}`) : null;
             if (parentTree) refreshRow(parentTree);
-            if (data.parent_suggestions && data.parent_suggestions.length && parentSuggestions) {
-              parentSuggestions.innerHTML = '';
-              data.parent_suggestions.forEach(function(s) {
-                const opt = document.createElement('option');
-                opt.value = s.id;
-                opt.textContent = s.path;
-                parentSuggestions.appendChild(opt);
-              });
-              parentSuggestions.style.display = 'block';
-            }
           } else if (method === 'PATCH') {
             if (tree) refreshRow(tree);
           }
@@ -483,6 +474,29 @@ if (!window.creativeRowEditorInitialized) {
         move(1);
       }
     });
+
+    if (parentSuggestBtn && parentSuggestions) {
+      parentSuggestBtn.addEventListener('click', function() {
+        saveForm().then(function() {
+          const id = form.dataset.creativeId;
+          if (!id) return;
+          window.creativesApi.parentSuggestions(id).then(function(data) {
+            parentSuggestions.innerHTML = '';
+            if (data && data.length) {
+              data.forEach(function(s) {
+                const opt = document.createElement('option');
+                opt.value = s.id;
+                opt.textContent = s.path;
+                parentSuggestions.appendChild(opt);
+              });
+              parentSuggestions.style.display = 'block';
+            } else {
+              parentSuggestions.style.display = 'none';
+            }
+          });
+        });
+      });
+    }
 
     if (parentSuggestions) {
       parentSuggestions.addEventListener('change', function() {

--- a/app/javascript/creative_row_editor.js
+++ b/app/javascript/creative_row_editor.js
@@ -502,7 +502,10 @@ if (!window.creativeRowEditorInitialized) {
       parentSuggestions.addEventListener('change', function() {
         if (!this.value) return;
         parentInput.value = this.value;
-        saveForm().then(function() { window.location.reload(); });
+        const targetId = this.value;
+        saveForm().then(function() {
+          window.location.href = `/creatives/${targetId}`;
+        });
       });
     }
 

--- a/app/javascript/creative_row_editor.js
+++ b/app/javascript/creative_row_editor.js
@@ -17,6 +17,7 @@ if (!window.creativeRowEditorInitialized) {
     const deleteBtn = document.getElementById('inline-delete');
     const deleteWithChildrenBtn = document.getElementById('inline-delete-with-children');
     const closeBtn = document.getElementById('inline-close');
+    const parentSuggestions = document.getElementById('parent-suggestions');
 
     const methodInput = document.getElementById('inline-method');
     const parentInput = document.getElementById('inline-parent-id');
@@ -116,6 +117,16 @@ if (!window.creativeRowEditorInitialized) {
             }
             const parentTree = parentId ? document.getElementById(`creative-${parentId}`) : null;
             if (parentTree) refreshRow(parentTree);
+            if (data.parent_suggestions && data.parent_suggestions.length && parentSuggestions) {
+              parentSuggestions.innerHTML = '';
+              data.parent_suggestions.forEach(function(s) {
+                const opt = document.createElement('option');
+                opt.value = s.id;
+                opt.textContent = s.path;
+                parentSuggestions.appendChild(opt);
+              });
+              parentSuggestions.style.display = 'block';
+            }
           } else if (method === 'PATCH') {
             if (tree) refreshRow(tree);
           }
@@ -406,6 +417,10 @@ if (!window.creativeRowEditorInitialized) {
       progressValue.textContent = 0;
       pendingSave = false;
       editor.focus();
+      if (parentSuggestions) {
+        parentSuggestions.style.display = 'none';
+        parentSuggestions.innerHTML = '';
+      }
     }
 
     function scheduleSave() {
@@ -468,6 +483,14 @@ if (!window.creativeRowEditorInitialized) {
         move(1);
       }
     });
+
+    if (parentSuggestions) {
+      parentSuggestions.addEventListener('change', function() {
+        if (!this.value) return;
+        parentInput.value = this.value;
+        saveForm().then(function() { window.location.reload(); });
+      });
+    }
 
     if (closeBtn) {
       closeBtn.addEventListener('click', hideCurrent);

--- a/app/javascript/creatives_api.js
+++ b/app/javascript/creatives_api.js
@@ -3,6 +3,9 @@ if (!window.creativesApi) {
     get(id) {
       return fetch(`/creatives/${id}.json`).then(r => r.json());
     },
+    parentSuggestions(id) {
+      return fetch(`/creatives/${id}/parent_suggestions.json`).then(r => r.json());
+    },
     loadChildren(url) {
       return fetch(url).then(r => r.text());
     },

--- a/app/services/gemini_client.rb
+++ b/app/services/gemini_client.rb
@@ -13,6 +13,7 @@ class GeminiClient
     lines = categories.map { |c| "#{c[:id]}, \"#{c[:path]}\"" }.join("\n")
     prompt = "#{lines}\n\nGiven the above categories (id, path), which ids are the best parents for \"#{description}\"? " \
              "Reply with up to 5 ids separated by commas in descending order of relevance."
+    Rails.logger.info("### prompt=#{prompt}")
     uri = URI("#{GEMINI_URL}?key=#{@api_key}")
     body = { contents: [ { role: "user", parts: [ { text: prompt } ] } ] }
     response = Net::HTTP.post(uri, body.to_json, "Content-Type" => "application/json")

--- a/app/services/gemini_client.rb
+++ b/app/services/gemini_client.rb
@@ -1,0 +1,26 @@
+require "net/http"
+require "json"
+
+class GeminiClient
+  GEMINI_URL = "https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent"
+
+  def initialize(api_key: ENV["GEMINI_API_KEY"])
+    @api_key = api_key
+  end
+
+  def recommend_parent_ids(categories, description)
+    return [] if @api_key.blank?
+    lines = categories.map { |c| "#{c[:id]}, \"#{c[:path]}\"" }.join("\n")
+    prompt = "#{lines}\n\nGiven the above categories (id, path), which ids are the best parents for \"#{description}\"? " \
+             "Reply with up to 5 ids separated by commas in descending order of relevance."
+    uri = URI("#{GEMINI_URL}?key=#{@api_key}")
+    body = { contents: [ { role: "user", parts: [ { text: prompt } ] } ] }
+    response = Net::HTTP.post(uri, body.to_json, "Content-Type" => "application/json")
+    json = JSON.parse(response.body)
+    text = json.dig("candidates", 0, "content", "parts", 0, "text")
+    return [] unless text
+    text.split(/[\s,]+/).map(&:to_i).reject(&:zero?).first(5)
+  rescue StandardError
+    []
+  end
+end

--- a/app/services/gemini_parent_recommender.rb
+++ b/app/services/gemini_parent_recommender.rb
@@ -16,7 +16,7 @@ class GeminiParentRecommender
     categories = categories.uniq
     paths = {}
     categories.each do |c|
-      path_sequences = c.ancestors.reverse + [c]
+      path_sequences = c.ancestors.reverse + [ c ]
       path = path_sequences.map { |node| node.rich_text_description&.to_plain_text }.join(" > ")
       paths[path_sequences.last.id] = path unless path_sequences.empty?
     end

--- a/app/services/gemini_parent_recommender.rb
+++ b/app/services/gemini_parent_recommender.rb
@@ -16,8 +16,9 @@ class GeminiParentRecommender
     categories = categories.uniq
     paths = {}
     categories.each do |c|
-      path = (c.ancestors + [ c ]).map { |node| node.rich_text_description&.to_plain_text }.join(" > ")
-      paths[c.id] = path
+      path_sequences = c.ancestors.reverse + [c]
+      path = path_sequences.map { |node| node.rich_text_description&.to_plain_text }.join(" > ")
+      paths[path_sequences.last.id] = path unless path_sequences.empty?
     end
     ids = @client.recommend_parent_ids(paths.map { |id, path| { id: id, path: path } },
                                        creative.rich_text_description&.to_plain_text.to_s)

--- a/app/services/gemini_parent_recommender.rb
+++ b/app/services/gemini_parent_recommender.rb
@@ -9,6 +9,11 @@ class GeminiParentRecommender
                    .joins(:children)
                    .distinct
                    .select { |c| c.has_permission?(user, :write) }
+    parent = creative.parent
+    if parent&.has_permission?(user, :write)
+      categories << parent
+    end
+    categories = categories.uniq
     paths = {}
     categories.each do |c|
       path = (c.ancestors + [ c ]).map { |node| node.rich_text_description&.to_plain_text }.join(" > ")

--- a/app/services/gemini_parent_recommender.rb
+++ b/app/services/gemini_parent_recommender.rb
@@ -1,0 +1,18 @@
+class GeminiParentRecommender
+  def initialize(client: GeminiClient.new)
+    @client = client
+  end
+
+  def recommend(creative)
+    user = creative.user
+    categories = Creative.where(user: user).joins(:children).distinct
+    paths = {}
+    categories.each do |c|
+      path = (c.ancestors.where(user: user) + [ c ]).map(&:description).join(" > ")
+      paths[c.id] = path
+    end
+    ids = @client.recommend_parent_ids(paths.map { |id, path| { id: id, path: path } },
+                                       creative.rich_text_description&.to_plain_text.to_s)
+    ids.map { |id| { id: id, path: paths[id] } }.compact
+  end
+end

--- a/app/views/creatives/_inline_edit_form.html.erb
+++ b/app/views/creatives/_inline_edit_form.html.erb
@@ -24,7 +24,7 @@
       <button type="button" id="inline-delete-with-children" class="creative-action-btn danger-link" title="<%= t('creatives.index.delete_with_children') %>" data-confirm="<%= t('creatives.index.are_you_sure_delete_with_children') %>">🗑+</button>
       <button type="button" id="inline-close" class="creative-action-btn">✖</button>
     </div>
-    <button type="button" id="inline-recommend-parent" class="creative-action-btn" style="margin-top:0.5em;">카테고리 추천</button>
+    <button type="button" id="inline-recommend-parent" class="creative-action-btn" style="margin-top:0.5em;"><%= t('creatives.index.recommend_parent') %></button>
     <select id="parent-suggestions" size="5" style="display:none;margin-top:0.5em;"></select>
   </form>
 </div>

--- a/app/views/creatives/_inline_edit_form.html.erb
+++ b/app/views/creatives/_inline_edit_form.html.erb
@@ -15,8 +15,6 @@
       <input type="range" id="inline-creative-progress" name="creative[progress]" min="0" max="1" step="0.01">
       <span id="inline-progress-value">0</span>
     </div>
-    <button type="button" id="inline-recommend-parent" class="creative-action-btn" style="margin-top:0.5em;">카테고리 추천</button>
-    <select id="parent-suggestions" size="5" style="display:none;margin-top:0.5em;"></select>
     <div style="margin-top:0.5em;">
       <button type="button" id="inline-move-up" class="creative-action-btn">▲</button>
       <button type="button" id="inline-move-down" class="creative-action-btn">▼</button>
@@ -26,5 +24,7 @@
       <button type="button" id="inline-delete-with-children" class="creative-action-btn danger-link" title="<%= t('creatives.index.delete_with_children') %>" data-confirm="<%= t('creatives.index.are_you_sure_delete_with_children') %>">🗑+</button>
       <button type="button" id="inline-close" class="creative-action-btn">✖</button>
     </div>
+    <button type="button" id="inline-recommend-parent" class="creative-action-btn" style="margin-top:0.5em;">카테고리 추천</button>
+    <select id="parent-suggestions" size="5" style="display:none;margin-top:0.5em;"></select>
   </form>
 </div>

--- a/app/views/creatives/_inline_edit_form.html.erb
+++ b/app/views/creatives/_inline_edit_form.html.erb
@@ -15,6 +15,7 @@
       <input type="range" id="inline-creative-progress" name="creative[progress]" min="0" max="1" step="0.01">
       <span id="inline-progress-value">0</span>
     </div>
+    <button type="button" id="inline-recommend-parent" class="creative-action-btn" style="margin-top:0.5em;">카테고리 추천</button>
     <select id="parent-suggestions" size="5" style="display:none;margin-top:0.5em;"></select>
     <div style="margin-top:0.5em;">
       <button type="button" id="inline-move-up" class="creative-action-btn">▲</button>

--- a/app/views/creatives/_inline_edit_form.html.erb
+++ b/app/views/creatives/_inline_edit_form.html.erb
@@ -15,6 +15,7 @@
       <input type="range" id="inline-creative-progress" name="creative[progress]" min="0" max="1" step="0.01">
       <span id="inline-progress-value">0</span>
     </div>
+    <select id="parent-suggestions" size="5" style="display:none;margin-top:0.5em;"></select>
     <div style="margin-top:0.5em;">
       <button type="button" id="inline-move-up" class="creative-action-btn">▲</button>
       <button type="button" id="inline-move-down" class="creative-action-btn">▼</button>

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -43,6 +43,7 @@ env:
     - RAILS_MASTER_KEY
     - DATABASE_URL
     - PORT
+    - GEMINI_API_KEY
   clear:
     # Run the Solid Queue Supervisor inside the web server's Puma process to do jobs.
     # When you start using multiple servers, you should split out job processing to a dedicated machine.

--- a/config/locales/creatives.en.yml
+++ b/config/locales/creatives.en.yml
@@ -20,6 +20,7 @@ en:
       recalculate_all_parent_progress: "Recalculate all parent progress?"
       no_creatives: "No creatives found."
       no_sub_creatives: "No sub-creatives found."
+      recommend_parent: "Recommend Category"
       import_uploading: "Uploading..."
       import_success: "Import successful! Reloading..."
       import_failed: "Import failed."

--- a/config/locales/creatives.ko.yml
+++ b/config/locales/creatives.ko.yml
@@ -20,6 +20,7 @@ ko:
       recalculate_all_parent_progress: "모든 상위 진행률을 다시 계산하시겠습니까?"
       no_creatives: "크리에이티브가 없습니다."
       no_sub_creatives: "하위 크리에이티브가 없습니다."
+      recommend_parent: "카테고리 추천"
       import_uploading: "업로드 중..."
       import_success: "가져오기 성공! 새로고침 중..."
       import_failed: "가져오기 실패"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,6 +51,7 @@ Rails.application.routes.draw do
       get :children
       post :share, to: "creatives#share", as: :share_creative
       post :request_permission, to: "creatives#request_permission"
+      get :parent_suggestions
     end
   end
 


### PR DESCRIPTION
## Summary
- suggest potential parent creatives via Gemini when creating a root creative
- show recommended parents in inline editor with a 5-line select box
- allow choosing a suggestion to set the creative's parent

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: undefined method `has_closure_tree` for Creative:Class)*

------
https://chatgpt.com/codex/tasks/task_e_68aebdaf522c8326bf4a90d4baa9cac5