### PR TITLE
Delete linked Google events when removing calendar events

### DIFF
--- a/app/components/plans_timeline_component.rb
+++ b/app/components/plans_timeline_component.rb
@@ -34,7 +34,7 @@ class PlansTimelineComponent < ViewComponent::Base
           target_date: event.end_time.to_date,
           progress: event.creative&.progress || 0,
           path: event.creative ? helpers.creative_path(event.creative) : event.html_link,
-          deletable: false
+          deletable: event.user_id == Current.user&.id
         }
       end
       plan_items + event_items

--- a/app/controllers/calendar_events_controller.rb
+++ b/app/controllers/calendar_events_controller.rb
@@ -1,0 +1,13 @@
+class CalendarEventsController < ApplicationController
+  def destroy
+    event = CalendarEvent.where(user: Current.user).find(params[:id])
+    event.destroy
+    respond_to do |format|
+      format.html do
+        redirect_back fallback_location: root_path,
+                      notice: t('calendar_events.deleted', default: 'Event deleted.')
+      end
+      format.json { head :no_content }
+    end
+  end
+end

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -89,7 +89,7 @@ class PlansController < ApplicationController
       target_date: event.end_time.to_date,
       progress: event.creative&.progress || 0,
       path: event.creative ? creative_path(event.creative) : event.html_link,
-      deletable: false
+      deletable: event.user_id == Current.user&.id
     }
   end
   def plan_creatives_path(plan)

--- a/app/javascript/plans_timeline.js
+++ b/app/javascript/plans_timeline.js
@@ -87,7 +87,13 @@ if (!window.plansTimelineScriptInitialized) {
         del.addEventListener('click', function(e) {
           e.stopPropagation();
           if (!confirm(container.dataset.deleteConfirm)) return;
-          fetch('/plans/' + plan.id, {
+          var deleteUrl;
+          if (String(plan.id).indexOf('calendar_event_') === 0) {
+            deleteUrl = '/calendar_events/' + String(plan.id).replace('calendar_event_', '');
+          } else {
+            deleteUrl = '/plans/' + plan.id;
+          }
+          fetch(deleteUrl, {
             method: 'DELETE',
             headers: {
               'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').content,

--- a/app/models/calendar_event.rb
+++ b/app/models/calendar_event.rb
@@ -3,4 +3,14 @@ class CalendarEvent < ApplicationRecord
   belongs_to :creative, optional: true
 
   validates :google_event_id, :start_time, :end_time, presence: true
+
+  after_commit :delete_google_event, on: :destroy
+
+  private
+
+  def delete_google_event
+    GoogleCalendarService.new(user: user).delete_event(google_event_id)
+  rescue StandardError => e
+    Rails.logger.error("Failed to delete Google event #{google_event_id}: #{e.message}")
+  end
 end

--- a/app/services/google_calendar_service.rb
+++ b/app/services/google_calendar_service.rb
@@ -89,6 +89,17 @@ class GoogleCalendarService
     raise
   end
 
+  # Deletes a Google Calendar event.
+  def delete_event(event_id, calendar_id: "primary")
+    if @service.authorization.scope.include?(Google::Apis::CalendarV3::AUTH_CALENDAR_APP_CREATED)
+      @user.calendar_id ||= create_app_calendar
+      calendar_id = @user.calendar_id
+    end
+    @service.delete_event(calendar_id, event_id)
+  rescue Google::Apis::ClientError => e
+    raise unless e.status_code == 404
+  end
+
   def list_calendars
     @service.list_calendar_lists.items.map { |c| [ c.summary, c.id ] }.to_h
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,6 +57,8 @@ Rails.application.routes.draw do
 
   resources :plans, only: [ :create, :destroy, :index ]
 
+  resources :calendar_events, only: [ :destroy ]
+
   resources :inbox_items, path: "inbox", only: [ :index, :update, :destroy ] do
     get :count, on: :collection
   end

--- a/spec/models/calendar_event_spec.rb
+++ b/spec/models/calendar_event_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+describe CalendarEvent, type: :model do
+  it 'deletes Google Calendar event when destroyed' do
+    user = User.create!(email: 'user@example.com', password: 'pw', name: 'User')
+    event = CalendarEvent.create!(user: user, google_event_id: 'abc123', start_time: Time.current, end_time: 1.hour.from_now)
+
+    service = instance_double(GoogleCalendarService)
+    expect(GoogleCalendarService).to receive(:new).with(user: user).and_return(service)
+    expect(service).to receive(:delete_event).with('abc123')
+
+    event.destroy
+  end
+end


### PR DESCRIPTION
## Summary
- remove Google Calendar entry when a calendar event is deleted
- add service support for deleting events from Google Calendar
- test removing Google events on calendar event destroy

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: undefined method `has_closure_tree` for Creative:Class)*

------
https://chatgpt.com/codex/tasks/task_e_68afb0def1dc8326a059a1b349d8b3d4