### PR TITLE
feat: highlight read comment badge

### DIFF
--- a/app/assets/stylesheets/creatives.css
+++ b/app/assets/stylesheets/creatives.css
@@ -285,3 +285,7 @@
     top: -4px;
     right: -4px;
 }
+
+.comments-btn .badge[data-count="0"] {
+    background: var(--color-complete);
+}

--- a/app/views/inbox/badge_component/_count.html.erb
+++ b/app/views/inbox/badge_component/_count.html.erb
@@ -1,2 +1,2 @@
 <% display = (count.positive? || show_zero) ? 'inline-block' : 'none' %>
-<span id="<%= badge_id %>" class="badge" style="display:<%= display %>"><%= count if count.positive? || show_zero %></span>
+<span id="<%= badge_id %>" class="badge" style="display:<%= display %>" data-count="<%= count %>"><%= count if count.positive? || show_zero %></span>


### PR DESCRIPTION
## Summary
- show zero-count comment badges with progress green background
- expose badge counts via `data-count`

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: undefined method `has_closure_tree` for Creative:Class)*

------
https://chatgpt.com/codex/tasks/task_e_68afc51539908326aaedf903223a2871