### PR TITLE
Show loading state for parent suggestions

### DIFF
--- a/app/javascript/creative_row_editor.js
+++ b/app/javascript/creative_row_editor.js
@@ -477,24 +477,38 @@ if (!window.creativeRowEditorInitialized) {
 
     if (parentSuggestBtn && parentSuggestions) {
       parentSuggestBtn.addEventListener('click', function() {
-        saveForm().then(function() {
-          const id = form.dataset.creativeId;
-          if (!id) return;
-          window.creativesApi.parentSuggestions(id).then(function(data) {
-            parentSuggestions.innerHTML = '';
-            if (data && data.length) {
-              data.forEach(function(s) {
-                const opt = document.createElement('option');
-                opt.value = s.id;
-                opt.textContent = s.path;
-                parentSuggestions.appendChild(opt);
-              });
-              parentSuggestions.style.display = 'block';
-            } else {
+        const originalLabel = parentSuggestBtn.textContent;
+        parentSuggestBtn.disabled = true;
+        parentSuggestBtn.textContent = `${originalLabel}...`;
+        parentSuggestions.innerHTML = '<option>...</option>';
+        parentSuggestions.style.display = 'block';
+
+        saveForm()
+          .then(function() {
+            const id = form.dataset.creativeId;
+            if (!id) {
               parentSuggestions.style.display = 'none';
+              return;
             }
+            return window.creativesApi.parentSuggestions(id).then(function(data) {
+              parentSuggestions.innerHTML = '';
+              if (data && data.length) {
+                data.forEach(function(s) {
+                  const opt = document.createElement('option');
+                  opt.value = s.id;
+                  opt.textContent = s.path;
+                  parentSuggestions.appendChild(opt);
+                });
+                parentSuggestions.style.display = 'block';
+              } else {
+                parentSuggestions.style.display = 'none';
+              }
+            });
+          })
+          .finally(function() {
+            parentSuggestBtn.textContent = originalLabel;
+            parentSuggestBtn.disabled = false;
           });
-        });
       });
     }
 

--- a/app/views/creatives/_inline_edit_form.html.erb
+++ b/app/views/creatives/_inline_edit_form.html.erb
@@ -25,6 +25,6 @@
       <button type="button" id="inline-close" class="creative-action-btn">✖</button>
     </div>
     <button type="button" id="inline-recommend-parent" class="creative-action-btn" style="margin-top:0.5em;"><%= t('creatives.index.recommend_parent') %></button>
-    <select id="parent-suggestions" size="5" style="display:none;margin-top:0.5em;"></select>
+    <select id="parent-suggestions" size="5" style="display:none;margin-top:0.5em;min-width:12em;"></select>
   </form>
 </div>


### PR DESCRIPTION
## Summary
- Disable parent suggestion button and show ellipsis while fetching suggestions
- Display temporary ellipsis option in suggestions select during loading

## Testing
- `./bin/rubocop -a`


------
https://chatgpt.com/codex/tasks/task_e_68afcd9fbb9883269aa9b11ce4ebf09f