### PR TITLE
Style select boxes for dark mode

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -118,6 +118,7 @@ input[type="text"],
 input[type="number"],
 input[type="url"],
 input[type="date"],
+select,
 textarea {
     background: var(--color-bg);
     color: var(--color-btn-text);
@@ -125,6 +126,11 @@ textarea {
     border-radius: 4px;
     border: 1px solid var(--color-border);
     font-size: 16px; /* Prevent iOS zoom on focus */
+}
+
+select option {
+    background: var(--color-bg);
+    color: var(--color-btn-text);
 }
 input[type="email"],
 input[type="password"] {


### PR DESCRIPTION
## Summary
- ensure select inputs inherit theme variables for consistent dark mode appearance

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: undefined method `has_closure_tree` for Creative:Class)*

------
https://chatgpt.com/codex/tasks/task_e_68afd05c57e88326b9a3b526b4165d9f