### PR TITLE
Allow dragging to center to nest creatives

### DIFF
--- a/app/assets/stylesheets/creatives.css
+++ b/app/assets/stylesheets/creatives.css
@@ -34,6 +34,21 @@
     align-items: center;
 }
 
+.creative-tree {
+    position: relative;
+}
+
+.creative-tree.child-drop-indicator-active::after {
+    content: '↳';
+    position: absolute;
+    top: 50%;
+    margin-left: 12px;
+    color: #2196f3;
+    font-size: 1.3em;
+    transform: translateY(-50%);
+    pointer-events: none;
+}
+
 .creative-tree-li {
     display: flex;
     align-items: center;

--- a/app/javascript/creatives_drag_drop.js
+++ b/app/javascript/creatives_drag_drop.js
@@ -3,7 +3,7 @@ if (!window.creativesDragDropInitialized) {
 
   console.log('creatives_drag_drop.js loaded');
 
-  const rightZoneRatio = 0.2;
+  const childZoneRatio = 0.3;
   const draggableClassName = '.creative-tree';
   // Drag and Drop for Creative Tree
   let draggedCreativeId = null;
@@ -27,9 +27,21 @@ if (!window.creativesDragDropInitialized) {
     }
     if (row) {
       const rect = row.getBoundingClientRect();
-      const rightZone = rect.left + rect.width * rightZoneRatio;
-      const midpoint = rect.top + rect.height / 2;
-      if (event.clientX > rightZone) {
+      const topZone = rect.top + rect.height * childZoneRatio;
+      const bottomZone = rect.bottom - rect.height * childZoneRatio;
+      if (event.clientY < topZone) {
+        // Insert before target
+        row.classList.add('drag-over-top');
+        row.classList.remove('drag-over-bottom', 'drag-over-child');
+        const childIndicator = row.querySelector('.child-drop-indicator');
+        if (childIndicator) childIndicator.remove();
+      } else if (event.clientY > bottomZone) {
+        // Insert after target
+        row.classList.add('drag-over-bottom');
+        row.classList.remove('drag-over-top', 'drag-over-child');
+        const childIndicator = row.querySelector('.child-drop-indicator');
+        if (childIndicator) childIndicator.remove();
+      } else {
         // Child drop indication
         row.classList.add('drag-over-child');
         row.classList.remove('drag-over-top', 'drag-over-bottom');
@@ -41,18 +53,6 @@ if (!window.creativesDragDropInitialized) {
           indicator.style.color = '#2196f3';
           indicator.style.fontSize = '1.3em';
           row.appendChild(indicator);
-        }
-      } else {
-        // Up/Down drop indication
-        row.classList.remove('drag-over-child');
-        const childIndicator = row.querySelector('.child-drop-indicator');
-        if (childIndicator) childIndicator.remove();
-        if (event.clientY < midpoint) {
-          row.classList.add('drag-over-top');
-          row.classList.remove('drag-over-bottom');
-        } else {
-          row.classList.add('drag-over-bottom');
-          row.classList.remove('drag-over-top');
         }
       }
       row.classList.add('drag-over');
@@ -73,13 +73,13 @@ if (!window.creativesDragDropInitialized) {
       const draggedChildren = document.getElementById(`creative-children-${draggedCreativeId.replace('creative-', '')}`);
       const targetElem = document.getElementById(targetId);
       const rect = targetElem.getBoundingClientRect();
-      const rightZone = rect.left + rect.width * rightZoneRatio;
-      const midpoint = rect.top + rect.height / 2;
+      const topZone = rect.top + rect.height * childZoneRatio;
+      const bottomZone = rect.bottom - rect.height * childZoneRatio;
       let direction = null;
       // Save original position
       const originalParent = draggedElem.parentNode;
       const originalNextSibling = draggedChildren ? draggedChildren.nextSibling : draggedElem.nextSibling;
-      if (event.clientX > rightZone) {
+      if (event.clientY >= topZone && event.clientY <= bottomZone) {
         // Append as child
         const targetNum = targetId.replace('creative-', '');
         let childrenContainer = document.getElementById(`creative-children-${targetNum}`);
@@ -92,7 +92,7 @@ if (!window.creativesDragDropInitialized) {
         childrenContainer.appendChild(draggedElem);
         if (draggedChildren) childrenContainer.appendChild(draggedChildren);
         direction = 'child';
-      } else if (event.clientY < midpoint) {
+      } else if (event.clientY < topZone) {
         // Insert before target
         targetElem.parentNode.insertBefore(draggedElem, targetElem);
         if (draggedChildren) targetElem.parentNode.insertBefore(draggedChildren, targetElem);

--- a/app/javascript/creatives_drag_drop.js
+++ b/app/javascript/creatives_drag_drop.js
@@ -21,9 +21,13 @@ if (!window.creativesDragDropInitialized) {
     event.dataTransfer.dropEffect = 'move';
     const row = event.target.closest(draggableClassName);
     if (lastDragOverRow && lastDragOverRow !== row) {
-      lastDragOverRow.classList.remove('drag-over', 'drag-over-top', 'drag-over-bottom', 'drag-over-child');
-      const childIndicator = lastDragOverRow.querySelector('.child-drop-indicator');
-      if (childIndicator) childIndicator.remove();
+      lastDragOverRow.classList.remove(
+        'drag-over',
+        'drag-over-top',
+        'drag-over-bottom',
+        'drag-over-child',
+        'child-drop-indicator-active'
+      );
     }
     if (row) {
       const rect = row.getBoundingClientRect();
@@ -31,22 +35,11 @@ if (!window.creativesDragDropInitialized) {
       const midpoint = rect.top + rect.height / 2;
       if (event.clientX > rightZone) {
         // Child drop indication
-        row.classList.add('drag-over-child');
+        row.classList.add('drag-over-child', 'child-drop-indicator-active');
         row.classList.remove('drag-over-top', 'drag-over-bottom');
-        if (!row.querySelector('.child-drop-indicator')) {
-          const indicator = document.createElement('span');
-          indicator.className = 'child-drop-indicator';
-          indicator.innerHTML = '↳';
-          indicator.style.marginLeft = '12px';
-          indicator.style.color = '#2196f3';
-          indicator.style.fontSize = '1.3em';
-          row.appendChild(indicator);
-        }
       } else {
         // Up/Down drop indication
-        row.classList.remove('drag-over-child');
-        const childIndicator = row.querySelector('.child-drop-indicator');
-        if (childIndicator) childIndicator.remove();
+        row.classList.remove('drag-over-child', 'child-drop-indicator-active');
         if (event.clientY < midpoint) {
           row.classList.add('drag-over-top');
           row.classList.remove('drag-over-bottom');
@@ -64,10 +57,24 @@ if (!window.creativesDragDropInitialized) {
     event.preventDefault();
     const targetRow = event.target.closest(draggableClassName);
     const targetId = targetRow ? targetRow.id : '';
-    if (targetRow) targetRow.classList.remove('drag-over', 'drag-over-top', 'drag-over-bottom', 'drag-over-child');
-    if (lastDragOverRow) lastDragOverRow.classList.remove('drag-over', 'drag-over-top', 'drag-over-bottom', 'drag-over-child');
-    const childIndicator = targetRow ? targetRow.querySelector('.child-drop-indicator') : null;
-    if (childIndicator) childIndicator.remove();
+    if (targetRow) {
+      targetRow.classList.remove(
+        'drag-over',
+        'drag-over-top',
+        'drag-over-bottom',
+        'drag-over-child',
+        'child-drop-indicator-active'
+      );
+    }
+    if (lastDragOverRow) {
+      lastDragOverRow.classList.remove(
+        'drag-over',
+        'drag-over-top',
+        'drag-over-bottom',
+        'drag-over-child',
+        'child-drop-indicator-active'
+      );
+    }
     if (draggedCreativeId && targetId && draggedCreativeId !== targetId) {
       const draggedElem = document.getElementById(draggedCreativeId);
       const draggedChildren = document.getElementById(`creative-children-${draggedCreativeId.replace('creative-', '')}`);
@@ -135,9 +142,13 @@ if (!window.creativesDragDropInitialized) {
   window.handleDragLeave = function(event) {
     const row = event.target.closest(draggableClassName);
     if (row) {
-      row.classList.remove('drag-over', 'drag-over-top', 'drag-over-bottom', 'drag-over-child');
-      const childIndicator = row.querySelector('.child-drop-indicator');
-      if (childIndicator) childIndicator.remove();
+      row.classList.remove(
+        'drag-over',
+        'drag-over-top',
+        'drag-over-bottom',
+        'drag-over-child',
+        'child-drop-indicator-active'
+      );
     }
   };
 


### PR DESCRIPTION
## Summary
- Switch child placement to use center zone rather than right-side in drag & drop

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: Could not find closure_tree-9.1.1, with_advisory_lock-7.0.1)*
- `bundle exec rails test` *(fails: Could not find closure_tree-9.1.1, with_advisory_lock-7.0.1)*

------
https://chatgpt.com/codex/tasks/task_e_68b00b79b1248326b28fdbb4220c0257