### PR TITLE
Display push token status on user list

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -46,7 +46,7 @@ class UsersController < ApplicationController
 
   # List all users
   def index
-    @users = User.includes(:sessions)
+    @users = User.includes(:sessions, :devices)
   end
 
   # Show a single user

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -16,6 +16,7 @@
       <% if last_login_at %>
         - <%= t('users.last_login_at', time: I18n.l(last_login_at, format: :short)) %>
       <% end %>
+      - <%= user.devices.any? ? t('users.push_token_present') : t('users.push_token_absent') %>
     </li>
   <% end %>
 </ul>

--- a/config/locales/users.en.yml
+++ b/config/locales/users.en.yml
@@ -28,6 +28,8 @@ en:
     update_profile: "Update Profile"
     index_title: "Users"
     last_login_at: "Last login: %{time}"
+    push_token_present: "Push token present"
+    push_token_absent: "No push token"
     display_level: "Max Display Level"
     completion_mark: "Completion Mark"
     theme: "Theme"

--- a/config/locales/users.ko.yml
+++ b/config/locales/users.ko.yml
@@ -28,6 +28,8 @@ ko:
     update_profile: "프로파일 업데이트"
     index_title: "사용자 목록"
     last_login_at: "마지막 로그인: %{time}"
+    push_token_present: "푸시 토큰 있음"
+    push_token_absent: "푸시 토큰 없음"
     display_level: "최대 표시 레벨"
     completion_mark: "완료 표시 문자"
     theme: "테마"


### PR DESCRIPTION
## Summary
- show whether each user has a push token on the users index
- add translations for push token status

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: Could not find closure_tree-9.1.1, with_advisory_lock-7.0.1)*


------
https://chatgpt.com/codex/tasks/task_e_68b146c691808326a1cb4ead003ada68