### PR TITLE
Show pointer cursor on plan items

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -286,6 +286,7 @@ button {
     background: var(--color-border);
     border-radius: 4px;
     overflow: hidden;
+    cursor: pointer;
 }
 
 .plan-bar .plan-progress {


### PR DESCRIPTION
## Summary
- Display pointer cursor when hovering over plan bars to indicate clickability

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: Could not find closure_tree-9.1.1, with_advisory_lock-7.0.1; syntax error in creatives_helper.rb)*

------
https://chatgpt.com/codex/tasks/task_e_68b1692188f083269ad1b000c06b931a