### PR TITLE
Restrict creative sharing to admins

### DIFF
--- a/app/controllers/creative_shares_controller.rb
+++ b/app/controllers/creative_shares_controller.rb
@@ -1,6 +1,10 @@
 class CreativeSharesController < ApplicationController
   def create
     @creative = Creative.find(params[:creative_id]).effective_origin
+    unless @creative.has_permission?(Current.user, :admin)
+      flash[:alert] = t("creatives.errors.no_permission")
+      redirect_back(fallback_location: creatives_path) and return
+    end
     user = User.find_by(email: params[:user_email])
     unless user
       invitation = Invitation.create!(email: params[:user_email], inviter: Current.user, creative: @creative, permission: params[:permission])
@@ -45,6 +49,10 @@ class CreativeSharesController < ApplicationController
 
   def destroy
     @creative_share = CreativeShare.find(params[:id])
+    unless @creative_share.creative.has_permission?(Current.user, :admin)
+      flash[:alert] = t("creatives.errors.no_permission")
+      redirect_back(fallback_location: creatives_path) and return
+    end
     @creative_share.destroy
     # remove linked creative if it exists
     linked_creative = Creative.find_by(origin_id: @creative_share.creative_id, user_id: @creative_share.user_id)

--- a/app/helpers/creatives_helper.rb
+++ b/app/helpers/creatives_helper.rb
@@ -75,7 +75,7 @@ module CreativesHelper
 
   def render_progress_value(value)
     text = number_to_percentage(value * 100, precision: 0)
-    if value == 1 && not Current.user&.completion_mark.nil?
+    if value == 1 && Current.user&.completion_mark.present?
       text = Current.user.completion_mark
     end
     content_tag(

--- a/app/models/creative.rb
+++ b/app/models/creative.rb
@@ -1,4 +1,5 @@
 require "ostruct"
+require "closure_tree"
 class Creative < ApplicationRecord
   include Notifications
 

--- a/app/models/creative_share.rb
+++ b/app/models/creative_share.rb
@@ -6,7 +6,8 @@ class CreativeShare < ApplicationRecord
     no_access: 0,
     read: 1,
     feedback: 2,
-    write: 3
+    write: 3,
+    admin: 4
   }
 
   validates :creative_id, presence: true

--- a/app/views/creatives/_share_button.html.erb
+++ b/app/views/creatives/_share_button.html.erb
@@ -1,25 +1,29 @@
+<% can_manage_shares = (@parent_creative || @creative).has_permission?(Current.user, :admin) %>
 <button id="share-creative-btn" class="btn btn-primary desktop-only"><%= t('creatives.index.share') %></button>
 <!-- Share Creative Modal -->
 <div id="share-creative-modal" style="display:none;position:fixed;top:0;left:0;width:100vw;height:100vh;z-index:1000;align-items:center;justify-content:center;">
   <div class="popup-box" style="min-width:320px;max-width:90vw;">
     <button id="close-share-modal" class="popup-close-btn">&times;</button>
     <h2><%= t('creatives.index.share_creative') %></h2>
-    <form id="share-creative-form" action="<%= creative_creative_shares_path(@parent_creative || @creative) %>" method="post" data-controller="share-invite">
-      <%= csrf_meta_tags %>
-      <div style="margin-bottom:1em;">
-        <label for="share-user-email"><%= t('creatives.index.user_email') %></label>
-        <input type="email" name="user_email" id="share-user-email" required style="width:100%;" data-share-invite-target="email" data-action="blur->share-invite#check" />
-      </div>
-      <div style="margin-bottom:1em;">
-        <select name="permission" id="share-permission" style="width:100%;">
-          <option value="no_access"><%= t('creatives.index.permission_no_access') %></option>
-          <option value="read"><%= t('creatives.index.permission_read') %></option>
-          <option value="feedback"><%= t('creatives.index.permission_feedback') %></option>
-          <option value="write"><%= t('creatives.index.permission_write') %></option>
-        </select>
-      </div>
-      <button type="submit" class="btn btn-primary" data-share-invite-target="submit" data-share="<%= t('creatives.index.share') %>" data-invite="<%= t('creatives.index.invite') %>"><%= t('creatives.index.share') %></button>
-    </form>
+    <% if can_manage_shares %>
+      <form id="share-creative-form" action="<%= creative_creative_shares_path(@parent_creative || @creative) %>" method="post" data-controller="share-invite">
+        <%= csrf_meta_tags %>
+        <div style="margin-bottom:1em;">
+          <label for="share-user-email"><%= t('creatives.index.user_email') %></label>
+          <input type="email" name="user_email" id="share-user-email" required style="width:100%;" data-share-invite-target="email" data-action="blur->share-invite#check" />
+        </div>
+        <div style="margin-bottom:1em;">
+          <select name="permission" id="share-permission" style="width:100%;">
+            <option value="no_access"><%= t('creatives.index.permission_no_access') %></option>
+            <option value="read"><%= t('creatives.index.permission_read') %></option>
+            <option value="feedback"><%= t('creatives.index.permission_feedback') %></option>
+            <option value="write"><%= t('creatives.index.permission_write') %></option>
+            <option value="admin"><%= t('creatives.index.permission_admin') %></option>
+          </select>
+        </div>
+        <button type="submit" class="btn btn-primary" data-share-invite-target="submit" data-share="<%= t('creatives.index.share') %>" data-invite="<%= t('creatives.index.invite') %>"><%= t('creatives.index.share') %></button>
+      </form>
+    <% end %>
     <% if @shared_list.any? %>
       <div style="margin-top:1em;">
         <strong><%= t('creatives.index.shared_with') %>:</strong>
@@ -31,9 +35,11 @@
               </span>
               <span><%= share.user&.display_name || t('creatives.index.unknown_user') %></span>
               <span><%= t("creatives.index.permission_#{share.permission}") %></span>
-              <span>
-                <%= button_to '×', creative_creative_share_path(@parent_creative || @creative, share), method: :delete, form: { data: { turbo_confirm: t('creatives.index.are_you_sure_delete_share') } }, class: 'delete-share-btn', style: 'padding:0 0.5em;' %>
-              </span>
+              <% if can_manage_shares %>
+                <span>
+                  <%= button_to '×', creative_creative_share_path(@parent_creative || @creative, share), method: :delete, form: { data: { turbo_confirm: t('creatives.index.are_you_sure_delete_share') } }, class: 'delete-share-btn', style: 'padding:0 0.5em;' %>
+                </span>
+              <% end %>
             </li>
           <% end %>
         </ul>

--- a/config/locales/creatives.en.yml
+++ b/config/locales/creatives.en.yml
@@ -40,6 +40,7 @@ en:
       permission_write: "Write"
       permission_feedback: "Feedback"
       permission_no_access: "No access"
+      permission_admin: "Admin"
       share: "Share"
       invite: "Invite"
       plan_tags_applied: "Plan tags applied to selected creatives."

--- a/config/locales/creatives.ko.yml
+++ b/config/locales/creatives.ko.yml
@@ -40,6 +40,7 @@ ko:
       permission_write: "쓰기"
       permission_feedback: "피드백"
       permission_no_access: "접근 금지"
+      permission_admin: "관리자"
       share: "공유하기"
       invite: "초대하기"
       plan_tags_applied: "선택한 크리에이티브에 플랜 태그가 적용되었습니다."

--- a/spec/models/creative_permission_spec.rb
+++ b/spec/models/creative_permission_spec.rb
@@ -24,4 +24,9 @@ RSpec.describe Creative, type: :model do
     expect(child.has_permission?(shared_user, :read)).to be false
     expect(grandchild.has_permission?(shared_user, :read)).to be false
   end
+
+  it 'treats admin as higher than write' do
+    CreativeShare.create!(creative: root, user: shared_user, permission: :admin)
+    expect(root.has_permission?(shared_user, :write)).to be true
+  end
 end

--- a/spec/requests/creative_shares_permissions_spec.rb
+++ b/spec/requests/creative_shares_permissions_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+require 'ostruct'
+
+RSpec.describe 'Creative share permissions', type: :request do
+  let(:owner) { User.create!(email: 'owner@example.com', password: 'pw', name: 'Owner') }
+  let(:writer) { User.create!(email: 'writer@example.com', password: 'pw', name: 'Writer') }
+  let(:admin_user) { User.create!(email: 'admin@example.com', password: 'pw', name: 'Admin') }
+  let(:other) { User.create!(email: 'other@example.com', password: 'pw', name: 'Other') }
+  let(:creative) { Creative.create!(user: owner, description: 'Root') }
+
+  before do
+    allow_any_instance_of(CreativeSharesController).to receive(:require_authentication).and_return(true)
+  end
+
+  context 'writer permission' do
+    before do
+      CreativeShare.create!(creative: creative, user: writer, permission: :write)
+      Current.session = OpenStruct.new(user: writer)
+    end
+
+    it 'cannot create or destroy shares' do
+      post creative_creative_shares_path(creative), params: { user_email: other.email, permission: :read }
+      expect(CreativeShare.find_by(creative: creative, user: other)).to be_nil
+
+      share = CreativeShare.create!(creative: creative, user: other, permission: :read)
+      delete creative_creative_share_path(creative, share)
+      expect(CreativeShare.exists?(share.id)).to be true
+    end
+  end
+
+  context 'admin permission' do
+    before do
+      CreativeShare.create!(creative: creative, user: admin_user, permission: :admin)
+      Current.session = OpenStruct.new(user: admin_user)
+    end
+
+    it 'can create and destroy shares' do
+      post creative_creative_shares_path(creative), params: { user_email: other.email, permission: :read }
+      share = CreativeShare.find_by(creative: creative, user: other)
+      expect(share).to be_present
+
+      delete creative_creative_share_path(creative, share)
+      expect(CreativeShare.exists?(share.id)).to be false
+    end
+  end
+end

--- a/spec/system/creative_share_permissions_spec.rb
+++ b/spec/system/creative_share_permissions_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe 'Share popup permissions', type: :system do
+  let!(:owner) { User.create!(email: 'owner@example.com', password: 'password', name: 'Owner', email_verified_at: Time.now) }
+  let!(:writer) { User.create!(email: 'writer@example.com', password: 'password', name: 'Writer', email_verified_at: Time.now) }
+  let!(:creative) { Creative.create!(description: 'Test', user: owner) }
+
+  def sign_in(email)
+    visit new_session_path
+    fill_in placeholder: I18n.t('users.new.enter_your_email'), with: email
+    fill_in placeholder: I18n.t('users.new.enter_your_password'), with: 'password'
+    find('#sign-in-submit').click
+  end
+
+  it 'writer can view but not modify shares' do
+    CreativeShare.create!(creative: creative, user: writer, permission: :write)
+    sign_in(writer.email)
+    visit creative_path(creative)
+    find('#share-creative-btn').click
+    expect(page).to have_css('#share-creative-modal', visible: true)
+    expect(page).not_to have_css('#share-creative-form', visible: :all)
+  end
+end


### PR DESCRIPTION
## Summary
- add `admin` permission above `write`
- allow share creation and deletion only for admins
- cover admin-only sharing with request/system tests

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec spec/models/creative_permission_spec.rb spec/requests/creative_shares_permissions_spec.rb spec/system/creative_share_spec.rb spec/system/creative_share_permissions_spec.rb` *(fails: undefined method `has_closure_tree` for Creative:Class)*


------
https://chatgpt.com/codex/tasks/task_e_68b172a0c2648326b00ed3e57a3911d5