### PR TITLE
Fix inbox badge not updating on mobile

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -378,7 +378,6 @@ button {
     position: relative;
 }
 
-#inbox-badge,
 .badge {
     background: var(--color-badge-bg, red);
     color: var(--color-badge-text, white);

--- a/app/components/inbox/badge_component.rb
+++ b/app/components/inbox/badge_component.rb
@@ -2,7 +2,7 @@ module Inbox
   class BadgeComponent < ViewComponent::Base
     attr_reader :badge_id, :show_zero
 
-    def initialize(user: nil, count: nil, badge_id: "inbox-badge", show_zero: false)
+      def initialize(user: nil, count: nil, badge_id: "desktop-inbox-badge", show_zero: false)
       @user = user
       @count = count
       @badge_id = badge_id

--- a/app/models/inbox_item.rb
+++ b/app/models/inbox_item.rb
@@ -22,13 +22,15 @@ class InboxItem < ApplicationRecord
     # Recompute the new count for this owner:
     new_count = InboxItem.where(owner: owner, state: "new").count
 
-    # Use Turbo::StreamsChannel to broadcast replace to that user’s inbox stream:
-    Turbo::StreamsChannel.broadcast_replace_to(
-      [ "inbox", owner ],
-      target: "inbox-badge",
-      partial: "inbox/badge_component/count",
-      locals: { count: new_count, badge_id: "inbox-badge", show_zero: false }
-    )
+      # Use Turbo::StreamsChannel to broadcast replace to that user’s inbox stream:
+      %w[desktop-inbox-badge mobile-inbox-badge].each do |target_id|
+        Turbo::StreamsChannel.broadcast_replace_to(
+          [ "inbox", owner ],
+          target: target_id,
+          partial: "inbox/badge_component/count",
+          locals: { count: new_count, badge_id: target_id, show_zero: false }
+        )
+      end
   end
 
   def enqueue_push_notification

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -92,7 +92,7 @@
       </div>
 
       <%= render PopupMenuComponent.new(
-            button_content: '...',
+            button_content: safe_join(['...', (render(Inbox::BadgeComponent.new(user: Current.user, badge_id: 'mobile-inbox-badge')) if Current.user)]),
             button_classes: 'mobile-only',
             menu_id: 'mobile-more-menu',
             align: :right

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -84,7 +84,7 @@
         <% end %>
         <% if Current.user %>
           <form id="inbox_button_to">
-            <button id="inbox-menu-btn" class="inbox-menu-btn" type="button"><%= t('app.inbox') %><%= render Inbox::BadgeComponent.new(user: Current.user) %></button>
+            <button id="inbox-menu-btn" class="inbox-menu-btn" type="button"><%= t('app.inbox') %><%= render Inbox::BadgeComponent.new(user: Current.user, badge_id: 'desktop-inbox-badge') %></button>
           </form>
         <% end %>
         <%= button_to t('app.sign_in'), new_session_path, method: :get unless authenticated? %>
@@ -124,7 +124,7 @@
         <% end %>
         <% if Current.user %>
           <div>
-            <button class="inbox-menu-btn" type="button"><%= t('app.inbox') %><%= render Inbox::BadgeComponent.new(user: Current.user) %></button>
+            <button class="inbox-menu-btn" type="button"><%= t('app.inbox') %><%= render Inbox::BadgeComponent.new(user: Current.user, badge_id: 'mobile-inbox-badge') %></button>
           </div>
         <% end %>
         <div><%= button_to t('app.sign_in'), new_session_path, method: :get unless authenticated? %></div>
@@ -216,20 +216,23 @@
           if (toggle && localStorage.getItem('inboxShowRead') === '1') {
             toggle.checked = true;
           }
-          var badge = document.getElementById('inbox-badge');
-
           function updateInboxBadge() {
-            if (!badge) return;
+            var badges = ['desktop-inbox-badge', 'mobile-inbox-badge']
+              .map(function(id) { return document.getElementById(id); })
+              .filter(function(el) { return el; });
+            if (badges.length === 0) return;
             fetch('/inbox/count')
               .then(r => r.json())
               .then(data => {
-                if (data.count > 0) {
-                  badge.textContent = data.count;
-                  badge.style.display = 'inline-block';
-                } else {
-                  badge.textContent = '';
-                  badge.style.display = 'none';
-                }
+                badges.forEach(function(badge) {
+                  if (data.count > 0) {
+                    badge.textContent = data.count;
+                    badge.style.display = 'inline-block';
+                  } else {
+                    badge.textContent = '';
+                    badge.style.display = 'none';
+                  }
+                });
               });
           }
 


### PR DESCRIPTION
## Summary
- Give desktop and mobile inbox badges distinct IDs
- Broadcast inbox count updates to both badges
- Update JS to refresh both badge elements

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: Could not find closure_tree-9.1.1, with_advisory_lock-7.0.1 in locally installed gems)*

------
https://chatgpt.com/codex/tasks/task_e_68b175e03cd88326b69ac35e5a03031c