### PR TITLE
Move creative tree rendering to client

### DIFF
--- a/app/javascript/creative_tree.js
+++ b/app/javascript/creative_tree.js
@@ -1,0 +1,28 @@
+if (!window.creativeTreeInitialized) {
+  window.creativeTreeInitialized = true;
+
+  document.addEventListener('turbo:load', function () {
+    const container = document.getElementById('creative-tree');
+    if (!container) return;
+
+    const url = window.location.pathname + '.json' + window.location.search;
+    fetch(url)
+      .then(r => r.json())
+      .then(data => {
+        container.appendChild(buildList(data));
+      });
+
+    function buildList(nodes) {
+      const ul = document.createElement('ul');
+      nodes.forEach(node => {
+        const li = document.createElement('li');
+        li.innerHTML = node.description || '';
+        if (node.children && node.children.length > 0) {
+          li.appendChild(buildList(node.children));
+        }
+        ul.appendChild(li);
+      });
+      return ul;
+    }
+  });
+}

--- a/app/views/creatives/index.html.erb
+++ b/app/views/creatives/index.html.erb
@@ -82,7 +82,7 @@
 
 <div id="creatives">
   <% if @creatives %>
-    <%= render_creative_tree(@creatives, 1, select_mode: false, max_level: Current.user&.display_level || User::DEFAULT_DISPLAY_LEVEL) %>
+    <div id="creative-tree"></div>
   <% else %>
     <% if params[:id] && @creative && !@creative.has_permission?(Current.user, :read) %>
       <p style="text-align: center;"><%= t('.no_permission') %></p>
@@ -112,3 +112,4 @@
 <%= javascript_include_tag 'creatives_api', defer: true %>
 <%= javascript_include_tag 'creative_row_editor', defer: true %>
 <%= javascript_include_tag 'creative_row_swipe', defer: true %>
+<%= javascript_include_tag 'creative_tree', defer: true %>


### PR DESCRIPTION
## Summary
- expose creative tree as JSON and render on the client
- drop server-side creative tree helper logic
- add simple JS renderer for creative tree

## Testing
- `./bin/rubocop -a`
- `bundle exec rake test` *(fails: NoMethodError: undefined method `has_closure_tree' for Creative:Class)*

------
https://chatgpt.com/codex/tasks/task_e_68b29543e43083268c8bcaa76494abd7