### PR TITLE
Skip linked creative when parent shared

### DIFF
--- a/app/models/creative.rb
+++ b/app/models/creative.rb
@@ -150,6 +150,13 @@ class Creative < ApplicationRecord
   def create_linked_creative_for_user(user)
     original = effective_origin
     return if original.user_id == user.id
+    ancestor_ids = original.ancestors.pluck(:id)
+    has_ancestor_share = CreativeShare.where(creative_id: ancestor_ids, user_id: user.id)
+                                      .where.not(permission: :no_access)
+                                      .exists?
+    has_owning_ancestors = Creative.where(id: ancestor_ids, user_id: user.id)
+                                        .exists?
+    return if has_ancestor_share or has_owning_ancestors
     Creative.find_or_create_by!(origin_id: original.id, user_id: user.id) do |c|
       c.parent_id = nil
     end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -51,4 +51,8 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions.
   config.action_controller.raise_on_missing_callback_actions = true
+
+  # set logger for test
+  # config.logger = ActiveSupport::TaggedLogging.new(Logger.new(STDOUT))
+  # config.logger.level = Logger::DEBUG
 end

--- a/spec/requests/creative_share_linked_creative_spec.rb
+++ b/spec/requests/creative_share_linked_creative_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+require 'ostruct'
+
+RSpec.describe 'Creative shares linked creatives', type: :request do
+  let(:owner) { User.create!(email: 'owner@example.com', password: 'pw', name: 'Owner') }
+  let(:shared_user) { User.create!(email: 'shared@example.com', password: 'pw', name: 'Shared') }
+  let(:parent) { Creative.create!(user: owner, description: 'Parent') }
+  let(:child) { Creative.create!(user: owner, parent: parent, description: 'Child') }
+
+  before do
+    allow_any_instance_of(CreativeSharesController).to receive(:require_authentication).and_return(true)
+    Current.session = OpenStruct.new(user: owner)
+    CreativeShare.create!(creative: parent, user: shared_user, permission: :read)
+    parent.create_linked_creative_for_user(shared_user)
+  end
+
+  it 'does not create a linked creative when parent already shared' do
+    post "/creatives/#{child.id}/creative_shares", params: { creative_id: child.id, user_email: shared_user.email, permission: :write }
+    expect(response).to redirect_to(creatives_path)
+    expect(Creative.find_by(origin_id: child.id, user_id: shared_user.id)).to be_nil
+    share = CreativeShare.find_by(creative: child, user: shared_user)
+    expect(share.permission).to eq('write')
+  end
+end

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -34,4 +34,3 @@ class CommentTest < ActiveSupport::TestCase
     Rails.cache.delete(CommentPresenceStore.key(creative.id))
   end
 end
-


### PR DESCRIPTION
## Summary
- avoid creating redundant linked creatives when parent already shared
- test that child sharing skips linked creative creation

## Testing
- `./bin/rubocop -a app/models/creative.rb spec/requests/creative_share_linked_creative_spec.rb`
- `bundle exec rspec` *(fails: `syntax error, unexpected constant` in `app/helpers/creatives_helper.rb`)*

------
https://chatgpt.com/codex/tasks/task_e_68b2ed22fa788326bf8716d4cc74f6e5