### PR TITLE
Add locale-aware inbox messaging

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,16 +7,21 @@ class ApplicationController < ActionController::Base
   around_action :set_time_zone
 
   def switch_locale(&action)
-    locale = params[:locale] ||
+    locale = Current.user&.locale ||
+             params[:locale] ||
              extract_locale_from_accept_language_header ||
-             I18n.default_locale
-    I18n.with_locale(locale, &action)
+             "en-US"
+    I18n.with_locale(normalize_locale(locale), &action)
   end
 
   private
 
   def extract_locale_from_accept_language_header
-    request.env["HTTP_ACCEPT_LANGUAGE"]&.scan(/^[a-z]{2}/)&.first
+    request.env["HTTP_ACCEPT_LANGUAGE"]&.split(",")&.first
+  end
+
+  def normalize_locale(locale)
+    locale.to_s.split("-").first
   end
 
   def set_time_zone(&action)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,6 +11,12 @@ class ApplicationController < ActionController::Base
              params[:locale] ||
              extract_locale_from_accept_language_header ||
              "en-US"
+
+    if Current.user && Current.user.locale.blank?
+      detected = extract_locale_from_accept_language_header || "en-US"
+      Current.user.update(locale: detected)
+    end
+
     I18n.with_locale(normalize_locale(locale), &action)
   end
 

--- a/app/controllers/creatives_controller.rb
+++ b/app/controllers/creatives_controller.rb
@@ -186,7 +186,8 @@ class CreativesController < ApplicationController
 
     InboxItem.create!(
       owner: creative.user,
-      message: I18n.t("inbox.permission_requested", user: Current.user.display_name, short_title: short_title),
+      message_key: "inbox.permission_requested",
+      message_params: { user: Current.user.display_name, short_title: short_title },
       link: Rails.application.routes.url_helpers.creative_url(
         creative,
         Rails.application.config.action_mailer.default_url_options.merge(share_request: Current.user.email)

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -12,6 +12,10 @@ class SessionsController < ApplicationController
         start_new_session_for user
         tz = params[:timezone]
         user.update(timezone: tz) if tz.present? && user.timezone != tz
+        if user.locale.blank?
+          detected = extract_locale_from_accept_language_header || "en-US"
+          user.update(locale: detected)
+        end
         redirect_to after_authentication_url
       else
         redirect_to new_session_path, alert: I18n.t("users.sessions.new.email_not_verified")

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -12,10 +12,6 @@ class SessionsController < ApplicationController
         start_new_session_for user
         tz = params[:timezone]
         user.update(timezone: tz) if tz.present? && user.timezone != tz
-        if user.locale.blank?
-          detected = extract_locale_from_accept_language_header || "en-US"
-          user.update(locale: detected)
-        end
         redirect_to after_authentication_url
       else
         redirect_to new_session_path, alert: I18n.t("users.sessions.new.email_not_verified")

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -100,7 +100,18 @@ class UsersController < ApplicationController
   end
 
   def profile_params
-    params.require(:user).permit(:avatar, :avatar_url, :display_level, :completion_mark, :theme, :name, :notifications_enabled, :calendar_id, :timezone)
+    params.require(:user).permit(
+      :avatar,
+      :avatar_url,
+      :display_level,
+      :completion_mark,
+      :theme,
+      :name,
+      :notifications_enabled,
+      :calendar_id,
+      :timezone,
+      :locale
+    )
   end
 
   def notification_settings_params

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -111,7 +111,9 @@ class UsersController < ApplicationController
       :calendar_id,
       :timezone,
       :locale
-    )
+    ).tap do |p|
+      p[:locale] = normalize_supported_locale(p[:locale]) if p.key?(:locale)
+    end
   end
 
   def notification_settings_params

--- a/app/helpers/creatives_helper.rb
+++ b/app/helpers/creatives_helper.rb
@@ -75,7 +75,7 @@ module CreativesHelper
 
   def render_progress_value(value)
     text = number_to_percentage(value * 100, precision: 0)
-    if value == 1 && not Current.user&.completion_mark.nil?
+    if value == 1 && !Current.user&.completion_mark.nil?
       text = Current.user.completion_mark
     end
     content_tag(

--- a/app/mailers/inbox_mailer.rb
+++ b/app/mailers/inbox_mailer.rb
@@ -2,7 +2,10 @@ class InboxMailer < ApplicationMailer
   def daily_summary
     @user = params[:user]
     @items = params[:items]
-    email = mail to: @user.email, subject: t("inbox_mailer.daily_summary.subject")
+    locale = @user.locale || "en-US"
+    email = I18n.with_locale(locale.to_s.split("-").first) do
+      mail to: @user.email, subject: t("inbox_mailer.daily_summary.subject")
+    end
     Email.create!(
       user: @user,
       email: @user.email,

--- a/app/mailers/inbox_mailer.rb
+++ b/app/mailers/inbox_mailer.rb
@@ -2,8 +2,8 @@ class InboxMailer < ApplicationMailer
   def daily_summary
     @user = params[:user]
     @items = params[:items]
-    locale = @user.locale || "en-US"
-    email = I18n.with_locale(locale.to_s.split("-").first) do
+    locale = @user.locale.presence || I18n.default_locale.to_s
+    email = I18n.with_locale(locale) do
       mail to: @user.email, subject: t("inbox_mailer.daily_summary.subject")
     end
     Email.create!(

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -12,10 +12,11 @@ class Comment < ApplicationRecord
 
   private
 
-  def create_inbox_item(owner, message)
+  def create_inbox_item(owner, key, params = {})
     InboxItem.create!(
       owner: owner,
-      message: message,
+      message_key: key,
+      message_params: params,
       link: Rails.application.routes.url_helpers.creative_comment_url(
         creative,
         self,
@@ -63,7 +64,8 @@ class Comment < ApplicationRecord
     recipients.each do |recipient|
       create_inbox_item(
         recipient,
-        I18n.t("inbox.comment_added", user: user.display_name, comment: content)
+        "inbox.comment_added",
+        { user: user.display_name, comment: content }
       )
     end
   end
@@ -72,7 +74,8 @@ class Comment < ApplicationRecord
     mentioned_users.each do |mentioned|
       create_inbox_item(
         mentioned,
-        I18n.t("inbox.user_mentioned", user: user.display_name, comment: content)
+        "inbox.user_mentioned",
+        { user: user.display_name, comment: content }
       )
     end
   end

--- a/app/models/creative_share.rb
+++ b/app/models/creative_share.rb
@@ -31,7 +31,8 @@ class CreativeShare < ApplicationRecord
     short_title = ActionController::Base.helpers.truncate(title, length: 30)
     InboxItem.create!(
       owner: user,
-      message: I18n.t("inbox.creative_shared", user: Current.user.display_name, short_title: short_title),
+      message_key: "inbox.creative_shared",
+      message_params: { user: Current.user.display_name, short_title: short_title },
       link: Rails.application.routes.url_helpers.creative_url(
         creative,
         Rails.application.config.action_mailer.default_url_options

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,6 +16,7 @@ class User < ApplicationRecord
   attribute :name, :string
   attribute :notifications_enabled, :boolean
   attribute :timezone, :string
+  attribute :locale, :string
 
   attribute :google_uid, :string
   attribute :google_access_token, :string

--- a/app/views/inbox_items/_item.html.erb
+++ b/app/views/inbox_items/_item.html.erb
@@ -1,9 +1,9 @@
 <div class="inbox-item" data-id="<%= item.id %>">
   <div class="message">
     <% if item.link.present? %>
-      <%= link_to item.message, item.link, class: 'item-link unstyled-link' %>
+      <%= link_to item.localized_message, item.link, class: 'item-link unstyled-link' %>
     <% else %>
-      <%= h item.message %>
+      <%= h item.localized_message %>
     <% end %>
   </div>
   <div class="time"><%= time_ago_in_words(item.created_at) %></div>

--- a/app/views/inbox_mailer/daily_summary.html.erb
+++ b/app/views/inbox_mailer/daily_summary.html.erb
@@ -2,7 +2,7 @@
 <ul>
   <% @items.each do |item| %>
     <li>
-      <%= item.message %>
+      <%= item.localized_message %>
       <% if item.link.present? %>
         (<a href="<%= item.link %>"><%= t('inbox_mailer.daily_summary.view') %></a>)
       <% end %>

--- a/app/views/inbox_mailer/daily_summary.text.erb
+++ b/app/views/inbox_mailer/daily_summary.text.erb
@@ -1,7 +1,7 @@
 <%= t('inbox_mailer.daily_summary.greeting') %>
 
 <% @items.each do |item| %>
-* <%= item.message %>
+* <%= item.localized_message %>
   <% if item.link.present? %>
     <%= item.link %>
   <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -43,7 +43,7 @@
   </div>
   <div>
     <%= f.label :locale, t('users.locale') %>
-    <%= f.select :locale, [[t('users.locales.en-US'), 'en-US'], [t('users.locales.ko'), 'ko']] %>
+    <%= f.select :locale, I18n.available_locales.map { |loc| [t("users.locales.#{loc}"), loc] } %>
   </div>
   <div>
     <%= f.label :timezone, t('users.timezone') %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -42,6 +42,10 @@
     <%= f.label :notifications_enabled, t('users.notifications_enabled') %>
   </div>
   <div>
+    <%= f.label :locale, t('users.locale') %>
+    <%= f.select :locale, [[t('users.locales.en-US'), 'en-US'], [t('users.locales.ko'), 'ko']] %>
+  </div>
+  <div>
     <%= f.label :timezone, t('users.timezone') %>
     <%= f.select :timezone, ActiveSupport::TimeZone.all.map { |tz| [tz.to_s, tz.tzinfo.name] } %>
   </div>

--- a/config/locales/users.en.yml
+++ b/config/locales/users.en.yml
@@ -37,7 +37,7 @@ en:
     notifications_enabled: "Enable notifications"
     locale: "Language"
     locales:
-      en-US: "English"
+      en: "English"
       ko: "Korean"
     timezone: "Timezone"
     profile_updated: "Profile updated successfully."

--- a/config/locales/users.en.yml
+++ b/config/locales/users.en.yml
@@ -35,6 +35,10 @@ en:
     theme: "Theme"
     calendar_id: "Calendar ID"
     notifications_enabled: "Enable notifications"
+    locale: "Language"
+    locales:
+      en-US: "English"
+      ko: "Korean"
     timezone: "Timezone"
     profile_updated: "Profile updated successfully."
     avatar_updated: "Avatar updated successfully."

--- a/config/locales/users.ko.yml
+++ b/config/locales/users.ko.yml
@@ -35,6 +35,10 @@ ko:
     theme: "테마"
     calendar_id: "캘린더 ID"
     notifications_enabled: "알림 사용"
+    locale: "언어"
+    locales:
+      en-US: "영어"
+      ko: "한국어"
     timezone: "시간대"
     profile_updated: "프로파일이 업데이트되었습니다."
     avatar_updated: "아바타가 변경되었습니다."

--- a/config/locales/users.ko.yml
+++ b/config/locales/users.ko.yml
@@ -37,7 +37,7 @@ ko:
     notifications_enabled: "알림 사용"
     locale: "언어"
     locales:
-      en-US: "영어"
+      en: "영어"
       ko: "한국어"
     timezone: "시간대"
     profile_updated: "프로파일이 업데이트되었습니다."

--- a/db/migrate/20250830141052_add_locale_to_users.rb
+++ b/db/migrate/20250830141052_add_locale_to_users.rb
@@ -1,0 +1,5 @@
+class AddLocaleToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :locale, :string
+  end
+end

--- a/db/migrate/20250830141101_add_message_key_to_inbox_items.rb
+++ b/db/migrate/20250830141101_add_message_key_to_inbox_items.rb
@@ -1,0 +1,6 @@
+class AddMessageKeyToInboxItems < ActiveRecord::Migration[8.0]
+  def change
+    add_column :inbox_items, :message_key, :string
+    add_column :inbox_items, :message_params, :jsonb, default: {}, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_28_060000) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_30_141101) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
     t.text "body"
@@ -162,6 +162,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_28_060000) do
     t.string "state", default: "new", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "message_key"
+    t.json "message_params", default: {}, null: false
     t.index ["owner_id"], name: "index_inbox_items_on_owner_id"
     t.index ["state"], name: "index_inbox_items_on_state"
   end
@@ -377,6 +379,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_28_060000) do
     t.string "google_refresh_token"
     t.datetime "google_token_expires_at"
     t.string "timezone"
+    t.string "locale"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/spec/models/comment_mentions_spec.rb
+++ b/spec/models/comment_mentions_spec.rb
@@ -12,6 +12,7 @@ describe Comment, type: :model do
 
     item = InboxItem.find_by(owner: mentioned)
     expect(item).not_to be_nil
-    expect(item.message).to include(commenter.name)
+    expect(item.message_key).to eq('inbox.user_mentioned')
+    expect(item.localized_message).to include(commenter.name)
   end
 end

--- a/spec/requests/permission_request_spec.rb
+++ b/spec/requests/permission_request_spec.rb
@@ -17,8 +17,10 @@ RSpec.describe 'Permission request', type: :request do
     expect(response).to have_http_status(:ok)
     item = InboxItem.last
     expect(item.owner).to eq owner
-    expect(item.message).to include('Requester')
-    expect(item.message).to include('Secret Creative Plan'.truncate(10))
+    expect(item.message_key).to eq('inbox.permission_requested')
+    msg = item.localized_message
+    expect(msg).to include('Requester')
+    expect(msg).to include('Secret Creative Plan'.truncate(10))
     expect(item.link).to include("share_request=#{CGI.escape(requester.email)}")
   end
 end

--- a/test/fixtures/inbox_items.yml
+++ b/test/fixtures/inbox_items.yml
@@ -1,9 +1,11 @@
 one_new:
-  message: "Hi"
+  message_key: inbox.no_messages
+  message_params: {}
   owner: one
   state: new
 
 one_read:
-  message: "Old"
+  message_key: inbox.no_messages
+  message_params: {}
   owner: one
   state: read

--- a/test/integration/locale_update_test.rb
+++ b/test/integration/locale_update_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+
+class LocaleUpdateTest < ActionDispatch::IntegrationTest
+  test "user can update locale" do
+    user = users(:one)
+    user.update!(email_verified_at: Time.current)
+    post session_path, params: { email: user.email, password: "password" }
+    assert_response :redirect
+
+    patch user_path(user), params: { user: { locale: "ko" } }
+    assert_redirected_to user_path(user)
+
+    assert_equal "ko", user.reload.locale
+  end
+
+  test "preselects saved locale on profile form" do
+    user = users(:one)
+    user.update!(email_verified_at: Time.current, locale: "ko")
+    post session_path, params: { email: user.email, password: "password" }
+    assert_response :redirect
+
+    get user_path(user)
+    assert_match /option selected=\"selected\" value=\"ko\"/, response.body
+  end
+end

--- a/test/jobs/inbox_summary_job_test.rb
+++ b/test/jobs/inbox_summary_job_test.rb
@@ -9,7 +9,7 @@ class InboxSummaryJobTest < ActiveJob::TestCase
 
   test "sends summary email when user has new inbox items" do
     user = users(:one)
-    InboxItem.create!(message: "hi", owner: user)
+    InboxItem.create!(message_key: "inbox.no_messages", message_params: {}, owner: user)
 
     assert_emails 1 do
       InboxSummaryJob.perform_now

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -14,7 +14,8 @@ class CommentTest < ActiveSupport::TestCase
 
     [ creative.user, writer ].each do |recipient|
       item = InboxItem.where(owner: recipient).last
-      assert_includes item.message, commenter.name
+      assert_equal "inbox.comment_added", item.message_key
+      assert_includes item.localized_message, commenter.name
     end
   end
 

--- a/test/models/creative_share_test.rb
+++ b/test/models/creative_share_test.rb
@@ -14,8 +14,10 @@ class CreativeShareTest < ActiveSupport::TestCase
 
     item = InboxItem.last
     assert_equal recipient, item.owner
-    assert_includes item.message, sharer.name
-    assert_includes item.message, "T-Shirt"
+    assert_equal "inbox.creative_shared", item.message_key
+    msg = item.localized_message
+    assert_includes msg, sharer.name
+    assert_includes msg, "T-Shirt"
     expected_link = Rails.application.routes.url_helpers.creative_url(
       creative,
       host: "example.com"

--- a/test/models/inbox_item_test.rb
+++ b/test/models/inbox_item_test.rb
@@ -2,13 +2,13 @@ require "test_helper"
 
 class InboxItemTest < ActiveSupport::TestCase
   test "default state is new" do
-    item = InboxItem.new(message: "Hi", owner: users(:one))
+    item = InboxItem.new(message_key: "inbox.no_messages", owner: users(:one), message_params: {})
     assert item.save
     assert_equal "new", item.state
   end
 
   test "read item can be marked unread" do
-    item = InboxItem.create!(message: "Hi", owner: users(:one), state: "read")
+    item = InboxItem.create!(message_key: "inbox.no_messages", owner: users(:one), state: "read", message_params: {})
     item.update!(state: "new")
     assert_equal "new", item.state
   end


### PR DESCRIPTION
## Summary
- store inbox message keys and params for translation per user language
- detect and persist browser locale for new logins
- render inbox and summary emails with user-specific locale

## Testing
- `./bin/rubocop -a` *(fails: Could not find closure_tree-9.1.1, with_advisory_lock-7.0.1)*
- `bin/rails test` *(fails: Could not find closure_tree-9.1.1, with_advisory_lock-7.0.1)*

------
https://chatgpt.com/codex/tasks/task_e_68b305ba8f2c83268dd4a6b1c6523763