### PR TITLE
Handle duplicate inbox messages for mentions

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -60,6 +60,7 @@ class Comment < ApplicationRecord
     recipients.compact!
     recipients.uniq!
     recipients.delete(user)
+    recipients -= mentioned_users.to_a
     recipients.reject! { |u| present_ids.include?(u.id) }
     recipients.each do |recipient|
       create_inbox_item(

--- a/spec/models/comment_mentions_spec.rb
+++ b/spec/models/comment_mentions_spec.rb
@@ -2,17 +2,29 @@ require 'rails_helper'
 require 'ostruct'
 
 describe Comment, type: :model do
-  it 'creates inbox item for mentioned users' do
+  it 'creates a single inbox item for mentioned users' do
     owner = User.create!(email: 'owner@example.com', password: 'pw', name: 'Owner')
     commenter = User.create!(email: 'commenter@example.com', password: 'pw', name: 'Commenter')
     mentioned = User.create!(email: 'mentioned@example.com', password: 'pw', name: 'Mentioned')
     creative = Creative.create!(user: owner, description: 'root')
 
-    comment = Comment.create!(creative: creative, user: commenter, content: "hi @#{mentioned.email}")
+    Comment.create!(creative: creative, user: commenter, content: "hi @#{mentioned.email}")
 
-    item = InboxItem.find_by(owner: mentioned)
-    expect(item).not_to be_nil
-    expect(item.message_key).to eq('inbox.user_mentioned')
-    expect(item.localized_message).to include(commenter.name)
+    items = InboxItem.where(owner: mentioned)
+    expect(items.count).to eq(1)
+    expect(items.first.message_key).to eq('inbox.user_mentioned')
+    expect(items.first.localized_message).to include(commenter.name)
+  end
+
+  it 'does not create duplicate inbox items when mentioning an existing recipient' do
+    owner = User.create!(email: 'owner@example.com', password: 'pw', name: 'Owner')
+    commenter = User.create!(email: 'commenter@example.com', password: 'pw', name: 'Commenter')
+    creative = Creative.create!(user: owner, description: 'root')
+
+    Comment.create!(creative: creative, user: commenter, content: "hi @#{owner.email}")
+
+    items = InboxItem.where(owner: owner)
+    expect(items.count).to eq(1)
+    expect(items.first.message_key).to eq('inbox.user_mentioned')
   end
 end


### PR DESCRIPTION
## Summary
- ensure users mentioned in comments only get a single "mentioned you" inbox item
- test for duplicate inbox items when mentioning existing recipients

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: undefined method `has_closure_tree' for Creative:Class)*
- `bundle exec rake test` *(fails: undefined method `has_closure_tree' for Creative:Class)*

------
https://chatgpt.com/codex/tasks/task_e_68b31812ae3c8326813894d4fdfc005c