### PR TITLE
Sanitize non-breaking spaces in inbox messages

### DIFF
--- a/app/models/inbox_item.rb
+++ b/app/models/inbox_item.rb
@@ -17,12 +17,15 @@ class InboxItem < ApplicationRecord
   end
 
   def localized_message(locale: I18n.locale)
-    if message_key.present?
-      params = message_params || {}
-      I18n.t(message_key, **params.symbolize_keys, locale: locale)
-    else
-      message
-    end
+    msg =
+      if message_key.present?
+        params = message_params || {}
+        I18n.t(message_key, **params.symbolize_keys, locale: locale)
+      else
+        message
+      end
+
+    msg&.gsub("&nbsp;", " ")&.gsub("\u00A0", " ")
   end
 
   private

--- a/test/models/inbox_item_test.rb
+++ b/test/models/inbox_item_test.rb
@@ -12,4 +12,10 @@ class InboxItemTest < ActiveSupport::TestCase
     item.update!(state: "new")
     assert_equal "new", item.state
   end
+
+  test "localized message replaces non-breaking spaces" do
+    I18n.backend.store_translations(:en, inbox: { nbsp_test: "hello&nbsp;world\u00A0!" })
+    item = InboxItem.new(message_key: "inbox.nbsp_test", owner: users(:one), message_params: {})
+    assert_equal "hello world !", item.localized_message(locale: :en)
+  end
 end


### PR DESCRIPTION
## Summary
- replace `&nbsp;` and Unicode non-breaking spaces in inbox messages with regular spaces
- add unit test ensuring localized messages strip HTML non-breaking spaces

## Testing
- `./bin/rubocop -a`
- `bin/rails test` *(fails: NoMethodError: undefined method `has_closure_tree' for Creative:Class)*

------
https://chatgpt.com/codex/tasks/task_e_68b3bd2fff3083268a4c4c364530f204