### PR TITLE
Build ARM64 Docker image for Graviton servers

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -84,7 +84,7 @@ asset_path: /rails/public/assets
 
 # Configure the image builder.
 builder:
-  arch: amd64
+  arch: arm64
   dockerfile: Dockerfile
 
   # # Build image via remote server (useful for faster amd64 builds on arm64 computers)

--- a/docs/deploy_to_ec2.md
+++ b/docs/deploy_to_ec2.md
@@ -37,6 +37,13 @@ ssh:
   keys: [ "~/.ssh/id.pem" ] # set ec2 private key
 ```
 
+If you're deploying to an ARM-based instance like a Graviton `t4g.small`, set the builder architecture in `config/deploy.yml`:
+
+```yaml
+builder:
+  arch: arm64
+```
+
 run deploy
 
 ```bash


### PR DESCRIPTION
## Summary
- build Docker image for `arm64` architecture
- document ARM-based deployment requirements

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: NoMethodError: has_closure_tree)*
- `bin/rails test` *(fails: NoMethodError: has_closure_tree)*

------
https://chatgpt.com/codex/tasks/task_e_68b3d40d03f88326bdb08da29b38220c