### PR TITLE
Disable drag and drop when inline editor active

### DIFF
--- a/app/javascript/creative_row_editor.js
+++ b/app/javascript/creative_row_editor.js
@@ -135,6 +135,7 @@ if (!window.creativeRowEditorInitialized) {
       const parentId = parentInput.value;
       const wasNew = !form.dataset.creativeId;
       currentTree = null;
+      tree.draggable = true;
       template.style.display = 'none';
       const p = (pendingSave || saving) ? saveForm() : Promise.resolve();
       p.then(() => {
@@ -170,6 +171,7 @@ if (!window.creativeRowEditorInitialized) {
           }
           currentTree = tree;
           hideRow(tree);
+          tree.draggable = false;
           tree.appendChild(template);
           template.style.display = 'block';
           loadCreative(tree.dataset.id);

--- a/app/javascript/creatives_drag_drop.js
+++ b/app/javascript/creatives_drag_drop.js
@@ -14,13 +14,12 @@ if (!window.creativesDragDropInitialized) {
 
   window.handleDragStart = function(event) {
     const row = event.target.closest(draggableClassName);
-    draggedCreativeId = row ? row.id : '';
+    if (!row || row.draggable === false) return;
+    draggedCreativeId = row.id;
     event.dataTransfer.effectAllowed = 'move';
   };
 
   window.handleDragOver = function(event) {
-    event.preventDefault();
-    event.dataTransfer.dropEffect = 'move';
     const row = event.target.closest(draggableClassName);
     if (lastDragOverRow && lastDragOverRow !== row) {
       lastDragOverRow.classList.remove(
@@ -31,6 +30,9 @@ if (!window.creativesDragDropInitialized) {
         'child-drop-indicator-active'
       );
     }
+    if (!row || row.draggable === false) return;
+    event.preventDefault();
+    event.dataTransfer.dropEffect = 'move';
     if (row) {
       const rect = row.getBoundingClientRect();
       const topZone = relaxedCoord(rect.top + rect.height * childZoneRatio);
@@ -59,7 +61,6 @@ if (!window.creativesDragDropInitialized) {
   };
 
   window.handleDrop = function(event) {
-    event.preventDefault();
     const targetRow = event.target.closest(draggableClassName);
     const targetId = targetRow ? targetRow.id : '';
     if (targetRow) {
@@ -80,6 +81,12 @@ if (!window.creativesDragDropInitialized) {
         'child-drop-indicator-active'
       );
     }
+    if (!targetRow || targetRow.draggable === false) {
+      draggedCreativeId = null;
+      lastDragOverRow = null;
+      return;
+    }
+    event.preventDefault();
     if (draggedCreativeId && targetId && draggedCreativeId !== targetId) {
       const draggedElem = document.getElementById(draggedCreativeId);
       const draggedChildren = document.getElementById(`creative-children-${draggedCreativeId.replace('creative-', '')}`);
@@ -147,15 +154,14 @@ if (!window.creativesDragDropInitialized) {
 
   window.handleDragLeave = function(event) {
     const row = event.target.closest(draggableClassName);
-    if (row) {
-      row.classList.remove(
-        'drag-over',
-        'drag-over-top',
-        'drag-over-bottom',
-        'drag-over-child',
-        'child-drop-indicator-active'
-      );
-    }
+    if (!row || row.draggable === false) return;
+    row.classList.remove(
+      'drag-over',
+      'drag-over-top',
+      'drag-over-bottom',
+      'drag-over-child',
+      'child-drop-indicator-active'
+    );
   };
 
   function sendNewOrder(draggedId, targetId, direction, onErrorRevert) {


### PR DESCRIPTION
## Summary
- prevent drag and drop for creative rows while the inline editor is open
- ignore non-draggable rows in drag/drop handlers

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: NoMethodError: undefined method `has_closure_tree`)*

------
https://chatgpt.com/codex/tasks/task_e_68b402a58b948326aae461e336edd24d