### PR TITLE
Broadcast comment badge updates

### DIFF
--- a/app/channels/comments_presence_channel.rb
+++ b/app/channels/comments_presence_channel.rb
@@ -4,8 +4,10 @@ class CommentsPresenceChannel < ApplicationCable::Channel
     return unless params[:creative_id].present? && current_user
 
     @creative_id = Creative.find(params[:creative_id].to_i).effective_origin.id
+    creative = Creative.find(@creative_id)
     stream_from stream_name
     CommentPresenceStore.add(@creative_id, current_user.id)
+    Comment.broadcast_badge(creative, current_user)
     broadcast_presence
   end
 
@@ -16,6 +18,7 @@ class CommentsPresenceChannel < ApplicationCable::Channel
       pointer = CommentReadPointer.find_or_initialize_by(user: current_user, creative: creative)
       pointer.last_read_comment_id = creative.comments.maximum(:id)
       pointer.save!
+      Comment.broadcast_badge(creative, current_user)
       broadcast_presence
     end
   end

--- a/app/controllers/comment_read_pointers_controller.rb
+++ b/app/controllers/comment_read_pointers_controller.rb
@@ -5,6 +5,7 @@ class CommentReadPointersController < ApplicationController
     pointer = CommentReadPointer.find_or_initialize_by(user: Current.user, creative: creative)
     pointer.last_read_comment_id = last_id
     pointer.save!
+    Comment.broadcast_badge(creative, Current.user)
     render json: { success: true }
   end
 end

--- a/app/helpers/creatives_helper.rb
+++ b/app/helpers/creatives_helper.rb
@@ -53,14 +53,16 @@ module CreativesHelper
           "comment.svg",
           class: "comment-icon"
         )
+        badge_id = "comment-badge-#{creative.id}"
+        stream = turbo_stream_from [ Current.user, origin, :comment_badge ]
         badge = render(
           Inbox::BadgeComponent.new(
             count: unread_count,
-            badge_id: "comment-badge-#{creative.id}",
+            badge_id: badge_id,
             show_zero: comments_count.positive?
           )
         )
-        button_tag(
+        stream + button_tag(
           comment_icon + badge,
           name: "show-comments-btn",
           data: { creative_id: creative.id, can_comment: true },

--- a/app/helpers/creatives_helper.rb
+++ b/app/helpers/creatives_helper.rb
@@ -53,7 +53,7 @@ module CreativesHelper
           "comment.svg",
           class: "comment-icon"
         )
-        badge_id = "comment-badge-#{creative.id}"
+        badge_id = "comment-badge-#{origin.id}"
         stream = turbo_stream_from [ Current.user, origin, :comment_badge ]
         badge = render(
           Inbox::BadgeComponent.new(


### PR DESCRIPTION
## Summary
- Stream comment badge updates to creative rows for real-time unread counts
- Broadcast comment badge changes on comment create/destroy and when read markers update
- Refresh badge when users join or leave comment presence channel

## Testing
- `./bin/rubocop -a`
- `bin/rails test` *(fails: NoMethodError: undefined method `has_closure_tree' for Creative:Class)*

------
https://chatgpt.com/codex/tasks/task_e_68b43d984a848326be8dbbdf4369da7b