### PR TITLE
Ensure creative expand rebinds edit and comment buttons

### DIFF
--- a/app/javascript/comments.js
+++ b/app/javascript/comments.js
@@ -169,13 +169,20 @@ if (!window.commentsInitialized) {
                     window.visualViewport.removeEventListener('resize', adjustForKeyboard);
                 }
             });
-            const buttons = document.getElementsByName('show-comments-btn');
-            buttons.forEach(function(btn) {
-                btn.onclick = function() {
-                    if (popup.style.display === 'block') { closePopup(); return; }
-                    openPopup(btn);
-                };
-            });
+            function attachCommentButtons() {
+                const buttons = document.getElementsByName('show-comments-btn');
+                buttons.forEach(function(btn) {
+                    btn.onclick = function() {
+                        if (popup.style.display === 'block' && popup.dataset.creativeId === btn.dataset.creativeId) {
+                            closePopup();
+                            return;
+                        }
+                        openPopup(btn);
+                    };
+                });
+            }
+            attachCommentButtons();
+            window.attachCommentButtons = attachCommentButtons;
             closeBtn.onclick = closePopup;
             var startY = null;
             popup.addEventListener('touchstart', function(e) {

--- a/app/javascript/creative_row_editor.js
+++ b/app/javascript/creative_row_editor.js
@@ -263,7 +263,9 @@ if (!window.creativeRowEditorInitialized) {
           );
         });
       });
+      if (window.attachCommentButtons) window.attachCommentButtons();
     }
+    window.attachCreativeRowEditorButtons = attachButtons;
 
     function loadCreative(id) {
       window.creativesApi.get(id)

--- a/app/javascript/creatives_expansion.js
+++ b/app/javascript/creatives_expansion.js
@@ -92,6 +92,8 @@ if (!window.creativesExpansionInitialized) {
                     }
                 });
                 expandBtn.textContent = allExpanded ? expandBtn.dataset.collapseText : expandBtn.dataset.expandText;
+                if (window.attachCreativeRowEditorButtons) window.attachCreativeRowEditorButtons();
+                if (window.attachCommentButtons) window.attachCommentButtons();
             });
         }
     }

--- a/app/javascript/creatives_expansion.js
+++ b/app/javascript/creatives_expansion.js
@@ -12,8 +12,10 @@ if (!window.creativesExpansionInitialized) {
                     childrenDiv.dataset.loaded = "true";
 
                     addToggleEvent(childrenDiv);
+                    if (window.attachCreativeRowEditorButtons) window.attachCreativeRowEditorButtons();
+                    if (window.attachCommentButtons) window.attachCommentButtons();
                 });
-        }
+            }
         childrenDiv.style.display = "";
         btn.textContent = "▼"
     }

--- a/spec/system/creative_expansion_actions_spec.rb
+++ b/spec/system/creative_expansion_actions_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe 'Creative expansion actions', type: :system, js: true do
+  let!(:user) { User.create!(email: 'user@example.com', password: 'password', name: 'User', email_verified_at: Time.current) }
+  let!(:root_creative) { Creative.create!(description: 'Root', user: user) }
+  let!(:child) { Creative.create!(description: 'Child', user: user, parent: root_creative) }
+
+  def resize_window_to_pc
+    page.current_window.resize_to(1200, 800)
+  rescue Capybara::NotSupportedByDriverError
+  end
+
+  before do
+    driven_by(:selenium, using: :headless_chrome)
+    resize_window_to_pc
+    visit new_session_path
+    fill_in placeholder: I18n.t('users.new.enter_your_email'), with: user.email
+    fill_in placeholder: I18n.t('users.new.enter_your_password'), with: 'password'
+    find('#sign-in-submit').click
+  end
+
+  it 'binds edit and comment buttons for loaded children' do
+    visit creative_path(root_creative)
+    find("#creative-#{root_creative.id} .creative-toggle-btn").click
+    expect(page).to have_css("#creative-#{child.id} .edit-inline-btn")
+
+    find("#creative-#{child.id} .edit-inline-btn").click
+    expect(page).to have_css('#inline-edit-form-element', visible: :visible)
+    find('#inline-close').click
+
+    find("#creative-#{child.id} [name='show-comments-btn']").click
+    expect(page).to have_css('#comments-popup', visible: :visible)
+  end
+end

--- a/spec/system/creative_expansion_actions_spec.rb
+++ b/spec/system/creative_expansion_actions_spec.rb
@@ -31,4 +31,17 @@ RSpec.describe 'Creative expansion actions', type: :system, js: true do
     find("#creative-#{child.id} [name='show-comments-btn']").click
     expect(page).to have_css('#comments-popup', visible: :visible)
   end
+
+  it 'binds edit and comment buttons after using expand all' do
+    visit creative_path(root_creative)
+    find('#expand-all-btn').click
+    expect(page).to have_css("#creative-#{child.id} .edit-inline-btn")
+
+    find("#creative-#{child.id} .edit-inline-btn").click
+    expect(page).to have_css('#inline-edit-form-element', visible: :visible)
+    find('#inline-close').click
+
+    find("#creative-#{child.id} [name='show-comments-btn']").click
+    expect(page).to have_css('#comments-popup', visible: :visible)
+  end
 end


### PR DESCRIPTION
## Summary
- reattach comment button handlers so popup works after loading creatives
- expose and reuse edit button binding when tree nodes are added dynamically
- cover expansion interaction with a system spec

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec spec/system/creative_expansion_actions_spec.rb` (fails: Could not find closure_tree-9.1.1, with_advisory_lock-7.0.1)


------
https://chatgpt.com/codex/tasks/task_e_68b455e6bb90832681e06f49a5f2048c