### PR TITLE
Add creative linking from inline editor

### DIFF
--- a/app/controllers/creatives_controller.rb
+++ b/app/controllers/creatives_controller.rb
@@ -67,6 +67,13 @@ class CreativesController < ApplicationController
         @overall_progress = 0
       end
     end
+
+    respond_to do |format|
+      format.html
+      format.json do
+        render json: @creatives.map { |c| { id: c.id, description: c.effective_description } }
+      end
+    end
   end
 
   def show
@@ -414,7 +421,7 @@ class CreativesController < ApplicationController
     end
 
     def creative_params
-      params.require(:creative).permit(:description, :progress, :parent_id, :sequence)
+      params.require(:creative).permit(:description, :progress, :parent_id, :sequence, :origin_id)
     end
 
     # Recursively destroy all descendants the user can delete

--- a/app/javascript/creative_row_editor.js
+++ b/app/javascript/creative_row_editor.js
@@ -395,7 +395,7 @@ if (!window.creativeRowEditorInitialized) {
       if (!currentTree || !form.dataset.creativeId) return;
       const query = prompt('Search creative');
       if (!query) return;
-      fetch(`/creatives.json?search=${encodeURIComponent(query)}`)
+      fetch(`/creatives.json?search=${encodeURIComponent(query)}&simple=true`)
         .then(r => r.json())
         .then(results => {
           if (!Array.isArray(results) || results.length === 0) {

--- a/app/views/creatives/_inline_edit_form.html.erb
+++ b/app/views/creatives/_inline_edit_form.html.erb
@@ -27,6 +27,7 @@
       <button type="button" id="inline-delete-with-children" class="creative-action-btn danger-link" title="<%= t('creatives.index.delete_with_children') %>" data-confirm="<%= t('creatives.index.are_you_sure_delete_with_children') %>">
         ↳<%= svg_tag 'trash-bold-outline.svg',class: 'icon-trash' %>
       </button>
+      <button type="button" id="inline-link" class="creative-action-btn" title="<%= t('creatives.index.link') %>">🔗</button>
       <button type="button" id="inline-close" class="creative-action-btn">✖</button>
     </div>
     <button type="button" id="inline-recommend-parent" class="creative-action-btn" style="margin-top:0.5em;">✨<%= t('creatives.index.recommend_parent') %></button>

--- a/config/locales/creatives.en.yml
+++ b/config/locales/creatives.en.yml
@@ -13,6 +13,7 @@ en:
       are_you_sure: "Are you sure?"
       are_you_sure_delete_only_this: "Are you sure you want to delete only this Creative? Its children will be preserved and re-linked."
       are_you_sure_delete_with_children: "Are you sure you want to delete this Creative and ALL its children? This cannot be undone."
+      link: "Link"
       delete_selection: "Delete selected"
       are_you_sure_delete_selection: "Are you sure you want to delete selected Creatives? This cannot be undone."
       creatives: "Creatives"

--- a/config/locales/creatives.ko.yml
+++ b/config/locales/creatives.ko.yml
@@ -13,6 +13,7 @@ ko:
       are_you_sure: "정말 삭제하시겠습니까?"
       are_you_sure_delete_only_this: "이 항목만 삭제하시겠습니까? 하위 항목은 보존되고 부모에 연결됩니다."
       are_you_sure_delete_with_children: "이 항목과 모든 하위 항목을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+      link: "링크"
       delete_selection: "선택 항목 삭제"
       are_you_sure_delete_selection: "선택된 크리에이티브를 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
       creatives: "크리에이티브 목록"


### PR DESCRIPTION
## Summary
- add link button next to delete controls in inline editor
- allow searching creatives and linking selected creative as child
- support origin_id in controller and JSON search endpoint

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: NoMethodError: undefined method `has_closure_tree' for Creative:Class)*

------
https://chatgpt.com/codex/tasks/task_e_68b4def95de483268f26132f7b266260