### PR TITLE
Fix creative_id missing in expansion toggle API

### DIFF
--- a/app/javascript/creatives_expansion.js
+++ b/app/javascript/creatives_expansion.js
@@ -27,7 +27,11 @@ if (!window.creativesExpansionInitialized) {
     function addToggleEvent(div) {
         // Get current creative id from path, e.g. /creatives/10 or /creatives
         let match = window.location.pathname.match(/\/creatives\/(\d+)/);
-        const currentCreativeId = match ? match[1] : null;
+        let currentCreativeId = match ? match[1] : null;
+        if (!currentCreativeId) {
+            const params = new URLSearchParams(window.location.search);
+            currentCreativeId = params.get('id');
+        }
         div.querySelectorAll(".creative-toggle-btn").forEach(function(btn) {
             btn.addEventListener("click", function(e) {
                 const creativeId = btn.dataset.creativeId;

--- a/spec/system/creative_expansion_actions_spec.rb
+++ b/spec/system/creative_expansion_actions_spec.rb
@@ -44,4 +44,12 @@ RSpec.describe 'Creative expansion actions', type: :system, js: true do
     find("#creative-#{child.id} [name='show-comments-btn']").click
     expect(page).to have_css('#comments-popup', visible: :visible)
   end
+  it 'sends current creative id when toggling expansion' do
+    visit creative_path(root_creative)
+    find("#creative-#{root_creative.id} .creative-toggle-btn").click
+    find("#creative-#{root_creative.id} .creative-toggle-btn").click
+    state = CreativeExpandedState.find_by(user: user, creative: root_creative)
+    expect(state).not_to be_nil
+    expect(state.expanded_status).to include(root_creative.id.to_s => false)
+  end
 end


### PR DESCRIPTION
## Summary
- capture current creative id from query string when not present in path
- test creative expansion toggle to ensure creative id is stored

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec spec/system/creative_expansion_actions_spec.rb` *(fails: undefined method `has_closure_tree` for Creative:Class)*
- `bundle exec rails test` *(fails: undefined method `has_closure_tree` for Creative:Class)*

------
https://chatgpt.com/codex/tasks/task_e_68b4fc7443a88326838a59666d20790d