### PR TITLE
feat: show add button at top of creative list

### DIFF
--- a/app/views/creatives/index.html.erb
+++ b/app/views/creatives/index.html.erb
@@ -81,6 +81,7 @@
 <% end %>
 
 <div id="creatives">
+  <button type="button" class="creative-action-btn add-creative-btn" data-parent-id="<%= @parent_creative&.id %>">+</button>
   <% if @creatives %>
     <%= render_creative_tree(@creatives, 1, select_mode: false, max_level: Current.user&.display_level || User::DEFAULT_DISPLAY_LEVEL) %>
   <% else %>


### PR DESCRIPTION
## Summary
- display add button at top of creatives section so new items appear above current children

## Testing
- `./bin/rubocop -a` *(fails: Could not find closure_tree-9.1.1, with_advisory_lock-7.0.1 in locally installed gems)*

------
https://chatgpt.com/codex/tasks/task_e_68b63fe537648326bd1b7aa2f5ba99b1