### PR TITLE
Always show Add button in creative actions

### DIFF
--- a/app/javascript/creative_row_editor.js
+++ b/app/javascript/creative_row_editor.js
@@ -200,19 +200,9 @@ if (!window.creativeRowEditorInitialized) {
             beforeId = insertBefore ? insertBefore.dataset.id : '';
           } else {
             parentId = btn.dataset.parentId || '';
-            const parentTree = parentId ? document.getElementById('creative-' + parentId) : null;
-            container = parentId ? document.getElementById('creative-children-' + parentId) : document.getElementById('creatives');
-            if (!container) {
-              container = document.createElement('div');
-              container.className = parentTree ? 'creative-children' : '';
-              if (parentTree) {
-                container.id = 'creative-children-' + parentId;
-                parentTree.appendChild(container);
-              } else {
-                document.getElementById('creatives').appendChild(container);
-              }
-            }
-            insertBefore = container.firstElementChild;
+            const rootContainer = document.getElementById('creatives');
+            container = rootContainer;
+            insertBefore = rootContainer.firstElementChild;
             beforeId = insertBefore ? insertBefore.dataset.id : '';
           }
           startNew(parentId, container, insertBefore, beforeId);

--- a/app/views/creatives/_add_button.html.erb
+++ b/app/views/creatives/_add_button.html.erb
@@ -1,7 +1,14 @@
-<%
-  if authenticated? && !params[:id]
-%>
-  <%= button_tag(t('creatives.index.new_creative'), type: 'button', class: 'popup-menu-item new-root-creative-btn') %>
-<%
-  end
-%>
+<% if @parent_creative %>
+  <%= button_tag(
+        t('creatives.index.new_creative'),
+        type: 'button',
+        class: 'popup-menu-item add-creative-btn',
+        data: { parent_id: @parent_creative.id }
+      ) %>
+<% else %>
+  <%= button_tag(
+        t('creatives.index.new_creative'),
+        type: 'button',
+        class: 'popup-menu-item new-root-creative-btn'
+      ) %>
+<% end %>

--- a/spec/system/creative_inline_edit_spec.rb
+++ b/spec/system/creative_inline_edit_spec.rb
@@ -119,4 +119,19 @@ RSpec.describe 'Creative inline editing', type: :system, js: true do
     expect(page).to have_css("#creative-children-#{root_creative.id} > .creative-tree:nth-child(2) .creative-row", text: 'Sibling')
     expect(page).not_to have_css("#creative-children-#{child.id} .creative-row", text: 'Sibling', visible: :all)
   end
+
+  it 'shows editor at top and saves as first child when parent context exists' do
+    existing_child = Creative.create!(description: 'Existing', user: user, parent: root_creative)
+
+    visit creative_path(root_creative)
+
+    find('.creative-actions-row .add-creative-btn').click
+    expect(page).to have_css('#creatives > .creative-tree:first-child #inline-creative-description')
+
+    fill_in 'inline-creative-description', with: 'New child'
+    find('#inline-close').click
+
+    expect(page).to have_css("#creative-children-#{root_creative.id} > .creative-tree:nth-child(1) .creative-row", text: 'New child')
+    expect(page).to have_css("#creative-children-#{root_creative.id} > .creative-tree:nth-child(2) .creative-row", text: 'Existing')
+  end
 end


### PR DESCRIPTION
## Summary
- Always render the add button in the creative actions row
- Add creatives under the current context when a parent creative is present

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: undefined method `has_closure_tree` for Creative:Class)*

------
https://chatgpt.com/codex/tasks/task_e_68b64db7d3e48326b7ad6efc99607259