### PR TITLE
Default collapsed creative tree

### DIFF
--- a/app/controllers/creative_expanded_states_controller.rb
+++ b/app/controllers/creative_expanded_states_controller.rb
@@ -7,8 +7,8 @@ class CreativeExpandedStatesController < ApplicationController
     record = CreativeExpandedState.find_or_initialize_by(creative_id: creative_id, user_id: Current.user.id)
     state = record.expanded_status || {}
 
-    if expanded == false
-      state[node_id] = false
+    if expanded
+      state[node_id] = true
     else
       state.delete(node_id)
     end

--- a/app/helpers/creatives_helper.rb
+++ b/app/helpers/creatives_helper.rb
@@ -181,7 +181,7 @@ module CreativesHelper
 
   # parent_creative.expandedState[creative.id] 값 사용, parent_creative가 nil이면 controller에서 내려준 expanded_state_map[nil] 사용
   def expanded_from_expanded_state(creative_id, expanded_state_map)
-    !(expanded_state_map and expanded_state_map[creative_id.to_s] == false)
+    !!(expanded_state_map && expanded_state_map[creative_id.to_s])
   end
 
   # 트리 구조를 마크다운으로 변환하는 헬퍼

--- a/app/javascript/creatives_expansion.js
+++ b/app/javascript/creatives_expansion.js
@@ -37,12 +37,15 @@ if (!window.creativesExpansionInitialized) {
                 const creativeId = btn.dataset.creativeId;
                 const childrenDiv = document.getElementById(`creative-children-${creativeId}`);
                 if (childrenDiv) {
-                    const isHidden = childrenDiv.style.display === "none";
-                    if (isHidden) {
+                    const wasHidden = childrenDiv.style.display === "none";
+                    if (wasHidden) {
                         expand(childrenDiv, btn);
                     } else {
                         collapse(childrenDiv, btn);
                     }
+                    const expanded = wasHidden;
+                    childrenDiv.dataset.expanded = expanded;
+
                     // Store expansion state in DB, scoped by currentCreativeId and node_id
                     let url = `/creative_expanded_states/toggle`;
                     fetch(url, {
@@ -54,7 +57,7 @@ if (!window.creativesExpansionInitialized) {
                         body: JSON.stringify({
                             creative_id: currentCreativeId,
                             node_id: creativeId,
-                            expanded: isHidden
+                            expanded: expanded
                         })
                     });
                 }

--- a/test/controllers/creative_expanded_states_controller_test.rb
+++ b/test/controllers/creative_expanded_states_controller_test.rb
@@ -1,0 +1,24 @@
+require "test_helper"
+require "ostruct"
+
+class CreativeExpandedStatesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:one)
+    @creative = creatives(:one)
+    Current.session = OpenStruct.new(user: @user)
+  end
+
+  test "toggle stores expanded state" do
+    post "/creative_expanded_states/toggle", params: { creative_id: @creative.id, node_id: @creative.id, expanded: true }
+    assert_response :success
+    record = CreativeExpandedState.find_by(creative_id: @creative.id, user_id: @user.id)
+    assert_equal({ @creative.id.to_s => true }, record.expanded_status)
+  end
+
+  test "toggle removes state when collapsed" do
+    CreativeExpandedState.create!(creative_id: @creative.id, user_id: @user.id, expanded_status: { @creative.id.to_s => true })
+    post "/creative_expanded_states/toggle", params: { creative_id: @creative.id, node_id: @creative.id, expanded: false }
+    assert_response :success
+    assert_nil CreativeExpandedState.find_by(creative_id: @creative.id, user_id: @user.id)
+  end
+end

--- a/test/helpers/creatives_helper_test.rb
+++ b/test/helpers/creatives_helper_test.rb
@@ -52,4 +52,12 @@ class CreativesHelperTest < ActionView::TestCase
     back = html_links_to_markdown(html)
     assert_equal "Look ![](data:image/png;base64,aGk=)", back
   end
+
+  test "expanded_from_expanded_state defaults to collapsed" do
+    assert_not expanded_from_expanded_state(1, {})
+  end
+
+  test "expanded_from_expanded_state returns true when expanded" do
+    assert expanded_from_expanded_state(1, { "1" => true })
+  end
 end


### PR DESCRIPTION
## Summary
- collapse creative tree by default when expanded state isn't set
- test collapsed and expanded states

## Testing
- `./bin/rubocop -a` *(fails: Could not find closure_tree-9.1.1, with_advisory_lock-7.0.1 in locally installed gems)*
- `bundle exec rake test` *(fails: Could not find closure_tree-9.1.1, with_advisory_lock-7.0.1 in locally installed gems)*

------
https://chatgpt.com/codex/tasks/task_e_68b69494c21883268960db12093b1151