### PR TITLE
Add Gemini chat integration for comments

### DIFF
--- a/app/services/gemini_chat_client.rb
+++ b/app/services/gemini_chat_client.rb
@@ -2,7 +2,7 @@ require "net/http"
 require "json"
 
 class GeminiChatClient
-  STREAM_URL = "https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:streamGenerateContent"
+  STREAM_URL = "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:streamGenerateContent"
 
   def initialize(api_key: ENV["GEMINI_API_KEY"])
     @api_key = api_key
@@ -12,19 +12,85 @@ class GeminiChatClient
     return if @api_key.blank?
     uri = URI("#{STREAM_URL}?key=#{@api_key}")
     request = Net::HTTP::Post.new(uri, "Content-Type" => "application/json")
-    request.body = { contents: contents }.to_json
+    system_instruction = {
+      parts: [
+        {
+          text: <<~PROMPT.strip
+            You are a senior expert teammate. Respond:
+            - Be concise and focus on the essentials (avoid unnecessary verbosity).
+            - Use short bullet points only when helpful.
+            - State only what you're confident about; briefly note any uncertainty.
+            - Respond in the asker's language (prefer the latest user message). Keep code and error messages in their original form.
+          PROMPT
+        }
+      ]
+    }
+    request.body = { contents: contents, systemInstruction: system_instruction }.to_json
     Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
       http.request(request) do |response|
         response.read_body do |chunk|
-          chunk.strip!
-          next if chunk.blank?
-          json = JSON.parse(chunk)
-          text = json.dig("candidates", 0, "content", "parts", 0, "text")
-          yield text if block_given? && text
+          Rails.logger.info("### Gemini chunk: #{chunk}")
+          begin
+            chunk = chunk.to_s.strip
+            next if chunk.blank?
+
+            # Some streaming endpoints prefix lines with "data: "
+            chunk = chunk.sub(/^data:\s*/, "")
+
+            json = JSON.parse(chunk)
+
+            # Some transports may wrap multiple payloads in an array per chunk
+            if json.is_a?(Array)
+              json.each do |item|
+                text = extract_text_from(item)
+                yield text if block_given? && text.present?
+              end
+              next
+            end
+
+            text = extract_text_from(json)
+            yield text if block_given? && text.present?
+          rescue JSON::ParserError
+            # Ignore non-JSON keepalive or [DONE] style lines
+            next
+          rescue StandardError => inner_e
+            Rails.logger.warn("Gemini chunk parse error: #{inner_e.class}: #{inner_e.message}")
+            next
+          end
         end
       end
     end
   rescue StandardError => e
     Rails.logger.error("Gemini chat error: #{e.message}")
+  end
+
+  private
+
+  def extract_text_from(json)
+    return nil unless json.is_a?(Hash)
+
+    # Prefer candidates[0].content.parts[0].text
+    candidates = json["candidates"]
+    if candidates.is_a?(Array) && (first = candidates.first).is_a?(Hash)
+      content = first["content"]
+      if content.is_a?(Hash)
+        parts = content["parts"]
+        if parts.is_a?(Array)
+          first_part = parts.first
+          return first_part["text"] if first_part.is_a?(Hash) && first_part["text"].is_a?(String)
+          return first_part if first_part.is_a?(String)
+        end
+      end
+    end
+
+    # Some responses may put text directly in top-level (fallback)
+    return json["text"] if json["text"].is_a?(String)
+
+    # If there's an error message, log it for visibility
+    if json["error"].is_a?(Hash) && json["error"]["message"].is_a?(String)
+      Rails.logger.warn("Gemini API error: #{json["error"]["message"]}")
+    end
+
+    nil
   end
 end

--- a/app/services/gemini_chat_client.rb
+++ b/app/services/gemini_chat_client.rb
@@ -1,0 +1,30 @@
+require "net/http"
+require "json"
+
+class GeminiChatClient
+  STREAM_URL = "https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:streamGenerateContent"
+
+  def initialize(api_key: ENV["GEMINI_API_KEY"])
+    @api_key = api_key
+  end
+
+  def chat(contents)
+    return if @api_key.blank?
+    uri = URI("#{STREAM_URL}?key=#{@api_key}")
+    request = Net::HTTP::Post.new(uri, "Content-Type" => "application/json")
+    request.body = { contents: contents }.to_json
+    Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
+      http.request(request) do |response|
+        response.read_body do |chunk|
+          chunk.strip!
+          next if chunk.blank?
+          json = JSON.parse(chunk)
+          text = json.dig("candidates", 0, "content", "parts", 0, "text")
+          yield text if block_given? && text
+        end
+      end
+    end
+  rescue StandardError => e
+    Rails.logger.error("Gemini chat error: #{e.message}")
+  end
+end

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,7 +1,7 @@
 <div class="comment-item <%= 'last-read' if defined?(last_read_comment_id) && last_read_comment_id && comment.id == last_read_comment_id %>" id="<%= dom_id(comment) %>">
   <div>
     <%= render AvatarComponent.new(user: comment.user, size: 20, classes: 'avatar comment-avatar') %>
-    <strong><%= comment.user&.display_name || t('comments.anonymous') %></strong>
+    <strong><%= comment.user&.display_name || t('comments.gemini') %></strong>
     <span>· <%= t('datetime.ago', time: time_ago_in_words(comment.created_at)) %></span>
     <% if comment.user == Current.user %>
       <div class="comment-action-container">

--- a/config/locales/comments.en.yml
+++ b/config/locales/comments.en.yml
@@ -11,3 +11,4 @@ en:
     delete_button: "Delete"
     not_owner: "Only the comment owner can modify this."
     no_permission: "You do not have permission to comment."
+    gemini: "Gemini"

--- a/config/locales/comments.ko.yml
+++ b/config/locales/comments.ko.yml
@@ -11,3 +11,4 @@ ko:
     delete_button: "삭제"
     not_owner: "댓글 소유자만 수정할 수 있습니다."
     no_permission: "댓글을 추가할 권한이 없습니다."
+    gemini: "Gemini"


### PR DESCRIPTION
## Summary
- allow @gemini mentions in comments to stream Gemini responses
- render Gemini as author when AI replies

## Testing
- `./bin/rubocop -a` *(fails: Could not find closure_tree-9.1.1, with_advisory_lock-7.0.1 in locally installed gems)*
- `bundle exec rails test` *(fails: NoMethodError: undefined method `has_closure_tree' for Creative:Class)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b4ad5ad48326964d884e56f907c5