### PR TITLE
Enable resizing comment popup from top corners

### DIFF
--- a/app/assets/stylesheets/comments_popup.css
+++ b/app/assets/stylesheets/comments_popup.css
@@ -5,7 +5,27 @@
   /* top: 10em; */
   z-index: 1000;
   width: 350px;
+  min-width: 200px;
+  min-height: 200px;
   transition: all 0.2s;
+}
+
+#comments-popup .resize-handle {
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  top: -5px;
+  z-index: 1001;
+}
+
+#comments-popup .resize-handle-left {
+  left: -5px;
+  cursor: nwse-resize;
+}
+
+#comments-popup .resize-handle-right {
+  right: -5px;
+  cursor: nesw-resize;
 }
 
 #comments-list {

--- a/app/assets/stylesheets/comments_popup.css
+++ b/app/assets/stylesheets/comments_popup.css
@@ -4,7 +4,7 @@
   right: 2em;
   /* top: 10em; */
   z-index: 1000;
-  width: 350px;
+  width: 420px;
   min-width: 200px;
   min-height: 200px;
   transition: all 0.2s;

--- a/app/javascript/comments.js
+++ b/app/javascript/comments.js
@@ -3,6 +3,12 @@ if (!window.commentsInitialized) {
 
     document.addEventListener('turbo:load', function() {
         function isMobile() { return window.innerWidth <= 600; }
+        var sizeKey = 'commentsPopupSize';
+        document.querySelectorAll('form[action="/session"]').forEach(function(form) {
+            form.addEventListener('submit', function() {
+                localStorage.removeItem(sizeKey);
+            });
+        });
         var currentBtn = null;
         function updatePosition() {
             if (!currentBtn || isMobile() || popup.dataset.resized === 'true') return;
@@ -28,6 +34,18 @@ if (!window.commentsInitialized) {
             popup.style.left = '';
             popup.style.right = '';
             list.style.height = '';
+            reservedHeight = popup.offsetHeight - list.offsetHeight;
+            var storedSize = localStorage.getItem(sizeKey);
+            if (storedSize) {
+                try {
+                    var sz = JSON.parse(storedSize);
+                    if (sz.width) { popup.style.width = sz.width; }
+                    if (sz.height) {
+                        popup.style.height = sz.height;
+                        list.style.height = (parseInt(sz.height, 10) - reservedHeight) + 'px';
+                    }
+                } catch (e) {}
+            }
             form.style.display = (popup.dataset.canComment === 'true') ? '' : 'none';
             if (isMobile()) {
                 popup.style.display = 'block';
@@ -126,6 +144,12 @@ if (!window.commentsInitialized) {
         }
 
         function stopResize() {
+            if (resizing) {
+                localStorage.setItem(sizeKey, JSON.stringify({
+                    width: popup.style.width,
+                    height: popup.style.height
+                }));
+            }
             resizing = null;
             window.removeEventListener('mousemove', doResize);
             window.removeEventListener('mouseup', stopResize);

--- a/app/views/comments/_comments_popup.html.erb
+++ b/app/views/comments/_comments_popup.html.erb
@@ -3,6 +3,8 @@
      data-loading-text="<%= t('app.loading') %>"
      data-delete-confirm-text="<%= t("comments.delete_confirm") %>"
      data-update-comment-text="<%= t('comments.update_comment') %>">
+  <div class="resize-handle resize-handle-left"></div>
+  <div class="resize-handle resize-handle-right"></div>
   <button id="close-comments-btn" class="popup-close-btn">&times;</button>
   <h3 style="margin-top:0;"><%= t('comments.comments') %></h3>
   <div id="comment-participants"></div>


### PR DESCRIPTION
## Summary
- add resize handles to comment popup markup
- style popup and handles with min dimensions
- implement JavaScript to resize popup by dragging top-left or top-right corners

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: Could not find closure_tree-9.1.1, with_advisory_lock-7.0.1)*

------
https://chatgpt.com/codex/tasks/task_e_68b6c0f06fa083269f41e9ae67b224d4