### PR TITLE
Allow converting comments to sub creatives

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,6 +1,6 @@
 class CommentsController < ApplicationController
   before_action :set_creative
-  before_action :set_comment, only: [ :destroy, :show, :update ]
+  before_action :set_comment, only: [ :destroy, :show, :update, :convert ]
 
   def index
     per_page = params[:per_page].to_i
@@ -54,6 +54,16 @@ class CommentsController < ApplicationController
   def destroy
     # @comment is set by before_action
     if @comment.user == Current.user
+      @comment.destroy
+      head :no_content
+    else
+      render json: { error: I18n.t("comments.not_owner") }, status: :forbidden
+    end
+  end
+
+  def convert
+    if @comment.user == Current.user
+      @creative.children.create!(description: @comment.content, user: @comment.user)
       @comment.destroy
       head :no_content
     else

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -61,15 +61,15 @@ class CommentsController < ApplicationController
     end
   end
 
-  def convert
-    if @comment.user == Current.user
-      @creative.children.create!(description: @comment.content, user: @comment.user)
-      @comment.destroy
-      head :no_content
-    else
-      render json: { error: I18n.t("comments.not_owner") }, status: :forbidden
+    def convert
+      if @comment.user == Current.user
+        MarkdownImporter.import(@comment.content, parent: @creative, user: @comment.user, create_root: true)
+        @comment.destroy
+        head :no_content
+      else
+        render json: { error: I18n.t("comments.not_owner") }, status: :forbidden
+      end
     end
-  end
 
   def show
     redirect_to creative_path(@creative, comment_id: @comment.id)

--- a/app/javascript/comments.js
+++ b/app/javascript/comments.js
@@ -337,7 +337,7 @@ if (!window.commentsInitialized) {
                         headers: { 'X-CSRF-Token': document.querySelector('meta[name=csrf-token]').content }
                     }).then(function(r) {
                         if (r.ok) {
-                            window.location.reload();
+                            loadInitialComments();
                         }
                     });
                 } else if (e.target.classList.contains('edit-comment-btn')) {

--- a/app/javascript/comments.js
+++ b/app/javascript/comments.js
@@ -327,6 +327,19 @@ if (!window.commentsInitialized) {
                             // TODO: handle error
                         }
                     });
+                } else if (e.target.classList.contains('convert-comment-btn')) {
+                    e.preventDefault();
+                    var btn = e.target;
+                    var commentId = btn.getAttribute('data-comment-id');
+                    var creativeId = popup.dataset.creativeId;
+                    fetch(`/creatives/${creativeId}/comments/${commentId}/convert`, {
+                        method: 'POST',
+                        headers: { 'X-CSRF-Token': document.querySelector('meta[name=csrf-token]').content }
+                    }).then(function(r) {
+                        if (r.ok) {
+                            window.location.reload();
+                        }
+                    });
                 } else if (e.target.classList.contains('edit-comment-btn')) {
                     e.preventDefault();
                     var btn = e.target;

--- a/app/services/markdown_importer.rb
+++ b/app/services/markdown_importer.rb
@@ -1,0 +1,61 @@
+class MarkdownImporter
+  def self.import(content, parent:, user:, create_root: false)
+    lines = content.to_s.lines
+    image_refs = {}
+    lines.reject! do |ln|
+      if ln =~ /^\s*\[([^\]]+)\]:\s*<\s*(data:image\/[^>]+)\s*>\s*$/
+        image_refs[$1] = $2.strip
+        true
+      else
+        false
+      end
+    end
+    created = []
+    root = parent
+    i = 0
+    if create_root
+      while i < lines.size && lines[i].strip.empty?
+        i += 1
+      end
+      if i < lines.size && lines[i] !~ /^\s*#/ && lines[i] !~ /^\s*[-*+]/
+        page_title = lines[i].strip
+        root = Creative.create(user: user, parent: parent, description: page_title)
+        created << root
+        i += 1
+      end
+    end
+    stack = [ [ 0, root ] ]
+    while i < lines.size
+      line = lines[i]
+      if line =~ /^(#+)\s+(.*)$/
+        level = $1.length
+        desc = ApplicationController.helpers.markdown_links_to_html($2.strip, image_refs)
+        stack.pop while stack.any? && stack.last[0] >= level
+        new_parent = stack.any? ? stack.last[1] : root
+        c = Creative.create(user: user, parent: new_parent, description: desc)
+        created << c
+        stack << [ level, c ]
+        i += 1
+      elsif line =~ /^([ \t]*)([-*+])\s+(.*)$/
+        indent = $1.length
+        desc = ApplicationController.helpers.markdown_links_to_html($3.strip, image_refs)
+        bullet_level = 10 + indent / 2
+        stack.pop while stack.any? && stack.last[0] >= bullet_level
+        new_parent = stack.any? ? stack.last[1] : root
+        c = Creative.create(user: user, parent: new_parent, description: desc)
+        created << c
+        stack << [ bullet_level, c ]
+        i += 1
+      elsif !line.strip.empty?
+        desc = ApplicationController.helpers.markdown_links_to_html(line.strip, image_refs)
+        new_parent = stack.any? ? stack.last[1] : root
+        c = Creative.create(user: user, parent: new_parent, description: desc)
+        created << c
+        i += 1
+      else
+        i += 1
+      end
+    end
+    created
+  end
+end

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -5,6 +5,9 @@
     <span>· <%= t('datetime.ago', time: time_ago_in_words(comment.created_at)) %></span>
     <% if comment.user == Current.user %>
       <div class="comment-action-container">
+        <button class="convert-comment-btn" data-comment-id="<%= comment.id %>" title="<%= t('comments.convert_to_creative') %>">
+          <%= t('comments.convert_button') %>
+        </button>
         <button class="edit-comment-btn" data-comment-id="<%= comment.id %>" data-comment-content="<%= comment.content %>" title="<%= t('comments.update_comment') %>">
           <%= t('comments.edit_button') %>
         </button>

--- a/config/locales/comments.en.yml
+++ b/config/locales/comments.en.yml
@@ -12,3 +12,5 @@ en:
     not_owner: "Only the comment owner can modify this."
     no_permission: "You do not have permission to comment."
     gemini: "Gemini"
+    convert_button: "Convert"
+    convert_to_creative: "Convert to Creative"

--- a/config/locales/comments.ko.yml
+++ b/config/locales/comments.ko.yml
@@ -12,3 +12,5 @@ ko:
     not_owner: "댓글 소유자만 수정할 수 있습니다."
     no_permission: "댓글을 추가할 권한이 없습니다."
     gemini: "Gemini"
+    convert_button: "전환"
+    convert_to_creative: "하위 크리에이티브로 전환"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,11 +32,14 @@ Rails.application.routes.draw do
   resources :creatives do
     resources :subscribers, only: [ :create ]
     resources :creative_shares, only: [ :create, :destroy ]
-    resources :comments, only: [ :index, :create, :destroy, :show, :update ] do
-      collection do
-        get :participants
+      resources :comments, only: [ :index, :create, :destroy, :show, :update ] do
+        member do
+          post :convert
+        end
+        collection do
+          get :participants
+        end
       end
-    end
     collection do
       post :recalculate_progress
       post :reorder

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+
+class CommentsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:one)
+    @creative = creatives(:tshirt)
+    @user.update!(email_verified_at: Time.current)
+    post session_path, params: { email: @user.email, password: "password" }
+  end
+
+  test "convert comment to sub creative" do
+    comment = @creative.comments.create!(content: "New idea", user: @user)
+    assert_difference("Creative.count", 1) do
+      assert_difference("Comment.count", -1) do
+        post convert_creative_comment_path(@creative, comment)
+      end
+    end
+    assert_response :no_content
+    new_creative = @creative.children.last
+    assert_equal "New idea", new_creative.description.to_plain_text.strip
+  end
+end

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -8,15 +8,15 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
     post session_path, params: { email: @user.email, password: "password" }
   end
 
-  test "convert comment to sub creative" do
-    comment = @creative.comments.create!(content: "New idea", user: @user)
-    assert_difference("Creative.count", 1) do
+  test "convert markdown comment to sub creatives" do
+    comment = @creative.comments.create!(content: "- First\n- Second", user: @user)
+    assert_difference("Creative.count", 2) do
       assert_difference("Comment.count", -1) do
         post convert_creative_comment_path(@creative, comment)
       end
     end
     assert_response :no_content
-    new_creative = @creative.children.last
-    assert_equal "New idea", new_creative.description.to_plain_text.strip
+    titles = @creative.children.order(:id).map { |c| c.description.to_plain_text.strip }
+    assert_equal [ "First", "Second" ], titles
   end
 end


### PR DESCRIPTION
## Summary
- add button to convert a comment into a child creative
- handle conversion in controller and routes
- provide translations and a regression test

## Testing
- `./bin/rubocop -a`
- `bin/rails test` *(fails: NoMethodError: undefined method `has_closure_tree' for Creative:Class)*

------
https://chatgpt.com/codex/tasks/task_e_68b6c7822f18832682c846a882eb0122