### PR TITLE
Display Gemini API errors in chat

### DIFF
--- a/app/services/gemini_chat_client.rb
+++ b/app/services/gemini_chat_client.rb
@@ -62,6 +62,7 @@ class GeminiChatClient
     end
   rescue StandardError => e
     Rails.logger.error("Gemini chat error: #{e.message}")
+    yield "Gemini API error: #{e.message}" if block_given?
   end
 
   private
@@ -88,7 +89,9 @@ class GeminiChatClient
 
     # If there's an error message, log it for visibility
     if json["error"].is_a?(Hash) && json["error"]["message"].is_a?(String)
-      Rails.logger.warn("Gemini API error: #{json["error"]["message"]}")
+      message = "Gemini API error: #{json["error"]["message"]}"
+      Rails.logger.warn(message)
+      return message
     end
 
     nil


### PR DESCRIPTION
## Summary
- Yield Gemini API error messages back to the caller so chat comments show service issues
- Surface JSON error payloads directly in chat output

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: Could not find closure_tree-9.1.1)*

------
https://chatgpt.com/codex/tasks/task_e_68b7a63e00f483268ae01f06d3d4740f