### PR TITLE
Block emails to example.com users

### DIFF
--- a/config/initializers/example_domain_interceptor.rb
+++ b/config/initializers/example_domain_interceptor.rb
@@ -1,0 +1,17 @@
+class ExampleDomainInterceptor
+  EXCLUDED_DOMAIN = "example.com".freeze
+
+  def self.delivering_email(message)
+    [ :to, :cc, :bcc ].each do |field|
+      emails = Array(message.public_send(field))
+      filtered = emails.reject { |email| email.to_s.downcase.end_with?("@#{EXCLUDED_DOMAIN}") }
+      message.public_send("#{field}=", filtered.presence)
+    end
+
+    if message.to.blank? && message.cc.blank? && message.bcc.blank?
+      message.perform_deliveries = false
+    end
+  end
+end
+
+ActionMailer::Base.register_interceptor(ExampleDomainInterceptor)

--- a/spec/mailers/example_domain_interceptor_spec.rb
+++ b/spec/mailers/example_domain_interceptor_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe ExampleDomainInterceptor do
+  before { ActionMailer::Base.deliveries.clear }
+
+  it 'does not deliver emails to example.com addresses' do
+    user = User.create!(email: 'blocked@example.com', password: 'secret', name: 'Blocked')
+    UserMailer.email_verification(user).deliver_now
+    expect(ActionMailer::Base.deliveries).to be_empty
+  end
+
+  it 'delivers emails to other domains' do
+    user = User.create!(email: 'allowed@domain.com', password: 'secret', name: 'Allowed')
+    UserMailer.email_verification(user).deliver_now
+    expect(ActionMailer::Base.deliveries.size).to eq(1)
+  end
+end


### PR DESCRIPTION
## Summary
- prevent delivering any emails to example.com addresses via interceptor
- add tests ensuring example.com recipients are filtered out

## Testing
- `./bin/rubocop config/initializers/example_domain_interceptor.rb spec/mailers/example_domain_interceptor_spec.rb`
- `bundle exec rspec` *(fails: NoMethodError: undefined method `has_closure_tree' for Creative:Class)*
- `bin/rails test` *(fails: Could not find closure_tree-9.1.1, with_advisory_lock-7.0.1)*

------
https://chatgpt.com/codex/tasks/task_e_68b7e8413d708326b7b30ace815d2038