### PR TITLE
Fix inline editor placement after expanding all creatives

### DIFF
--- a/app/javascript/creative_row_editor.js
+++ b/app/javascript/creative_row_editor.js
@@ -174,7 +174,12 @@ if (!window.creativeRowEditorInitialized) {
           currentTree = tree;
           hideRow(tree);
           tree.draggable = false;
-          tree.appendChild(template);
+          const children = tree.querySelector('.creative-children');
+          if (children) {
+            tree.insertBefore(template, children);
+          } else {
+            tree.appendChild(template);
+          }
           template.style.display = 'block';
           loadCreative(tree.dataset.id);
         });

--- a/spec/system/creative_expansion_actions_spec.rb
+++ b/spec/system/creative_expansion_actions_spec.rb
@@ -39,6 +39,8 @@ RSpec.describe 'Creative expansion actions', type: :system, js: true do
 
     find("#creative-#{child.id} .edit-inline-btn").click
     expect(page).to have_css('#inline-edit-form-element', visible: :visible)
+    prev_id = page.evaluate_script("document.getElementById('creative-children-#{child.id}').previousElementSibling.id")
+    expect(prev_id).to eq('inline-edit-form')
     find('#inline-close').click
 
     find("#creative-#{child.id} [name='show-comments-btn']").click


### PR DESCRIPTION
## Summary
- ensure inline editor appears before child nodes when editing after expanding all
- test expanded editing to confirm editor renders before children

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec spec/system/creative_expansion_actions_spec.rb:33` *(fails: Could not find closure_tree-9.1.1, with_advisory_lock-7.0.1)*

------
https://chatgpt.com/codex/tasks/task_e_68b936138e1c8326ace7d4bd236142d3