### PR TITLE
Confirm comment conversion to creative

### DIFF
--- a/app/javascript/comments.js
+++ b/app/javascript/comments.js
@@ -424,14 +424,15 @@ if (!window.commentsInitialized) {
                             // TODO: handle error
                         }
                     });
-                } else if (e.target.classList.contains('convert-comment-btn')) {
-                    e.preventDefault();
-                    var btn = e.target;
-                    var commentId = btn.getAttribute('data-comment-id');
-                    var creativeId = popup.dataset.creativeId;
-                    fetch(`/creatives/${creativeId}/comments/${commentId}/convert`, {
-                        method: 'POST',
-                        headers: { 'X-CSRF-Token': document.querySelector('meta[name=csrf-token]').content }
+               } else if (e.target.classList.contains('convert-comment-btn')) {
+                   e.preventDefault();
+                    if (!confirm(popup.dataset.convertConfirmText)) return;
+                   var btn = e.target;
+                   var commentId = btn.getAttribute('data-comment-id');
+                   var creativeId = popup.dataset.creativeId;
+                   fetch(`/creatives/${creativeId}/comments/${commentId}/convert`, {
+                       method: 'POST',
+                       headers: { 'X-CSRF-Token': document.querySelector('meta[name=csrf-token]').content }
                     }).then(function(r) {
                         if (r.ok) {
                             loadInitialComments();

--- a/app/views/comments/_comments_popup.html.erb
+++ b/app/views/comments/_comments_popup.html.erb
@@ -2,7 +2,8 @@
 <div id="comments-popup" class="popup-box"
      data-loading-text="<%= t('app.loading') %>"
      data-delete-confirm-text="<%= t("comments.delete_confirm") %>"
-     data-update-comment-text="<%= t('comments.update_comment') %>">
+     data-update-comment-text="<%= t('comments.update_comment') %>"
+     data-convert-confirm-text="<%= t('comments.convert_confirm') %>">
   <div class="resize-handle resize-handle-left"></div>
   <div class="resize-handle resize-handle-right"></div>
   <button id="close-comments-btn" class="popup-close-btn">&times;</button>

--- a/config/locales/comments.en.yml
+++ b/config/locales/comments.en.yml
@@ -14,3 +14,4 @@ en:
     gemini: "Gemini"
     convert_button: "Convert"
     convert_to_creative: "Convert to Creative"
+    convert_confirm: "This will add the comment content as a child creative of the current creative. Continue?"

--- a/config/locales/comments.ko.yml
+++ b/config/locales/comments.ko.yml
@@ -14,3 +14,4 @@ ko:
     gemini: "Gemini"
     convert_button: "전환"
     convert_to_creative: "하위 크리에이티브로 전환"
+    convert_confirm: "현재 크리에이티브 하위에 해당 댓글의 내용이 추가됩니다. 진행하시겠습니까?"


### PR DESCRIPTION
## Summary
- prompt user before converting a comment into a child creative
- add translation strings for the new confirmation message

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: NoMethodError: undefined method `has_closure_tree` for Creative:Class)*

------
https://chatgpt.com/codex/tasks/task_e_68b96c35b5b08326b84a77b0e4148968