### PR TITLE
Embed YouTube videos in creatives

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -22,7 +22,7 @@ module ApplicationHelper
         svg.sub!(/<svg\b([^>]*)>/) do |match|
           attrs = Regexp.last_match(1)
 
-          [:class, :width, :height].each do |attr|
+          [ :class, :width, :height ].each do |attr|
             next unless options[attr].present?
 
             if attr == :class
@@ -53,6 +53,15 @@ module ApplicationHelper
   def linkify_urls(text)
     ERB::Util.html_escape(text.to_s).gsub(%r{https?://[^\s]+}) do |url|
       link_to(url, url, target: "_blank", rel: "noopener")
+    end.html_safe
+  end
+
+  def embed_youtube_iframe(html)
+    return html if html.blank?
+    html = html.to_s
+    html.gsub(%r{<a[^>]+href=["']https?://(?:www\.)?(?:youtube\.com/watch\?v=|youtu\.be/)([\w-]{11})[^"']*["'][^>]*>.*?</a>}i) do
+      video_id = Regexp.last_match(1)
+      %(<iframe width="560" height="315" src="https://www.youtube.com/embed/#{video_id}" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>)
     end.html_safe
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -61,7 +61,15 @@ module ApplicationHelper
     html = html.to_s
     html.gsub(%r{<a[^>]+href=["']https?://(?:www\.)?(?:youtube\.com/watch\?v=|youtu\.be/)([\w-]{11})[^"']*["'][^>]*>.*?</a>}i) do
       video_id = Regexp.last_match(1)
-      %(<iframe width="560" height="315" src="https://www.youtube.com/embed/#{video_id}" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>)
+      tag.iframe(
+        "",
+        src: "https://www.youtube.com/embed/#{video_id}",
+        title: "YouTube video player",
+        frameborder: 0,
+        allow: "accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share",
+        allowfullscreen: true,
+        style: "width: 60vw; aspect-ratio: 16 / 9;"
+      )
     end.html_safe
   end
 end

--- a/app/helpers/creatives_helper.rb
+++ b/app/helpers/creatives_helper.rb
@@ -170,7 +170,8 @@ module CreativesHelper
           )) do
             renderer.call do
               content_tag(:div, class: "creative-content") do
-                link_to(creative.effective_description(params[:tags]&.first), creative, class: "unstyled-link")
+                desc = embed_youtube_iframe(creative.effective_description(params[:tags]&.first))
+                link_to(desc, creative, class: "unstyled-link")
               end
             end
           end + render_next_block.call(level + 1)

--- a/app/views/creatives/show.html.erb
+++ b/app/views/creatives/show.html.erb
@@ -11,7 +11,7 @@
         </h1>
       <% end %>
       <div>
-        <%= @creative.description %>
+        <%= embed_youtube_iframe(@creative.description) %>
       </div>
     <% end %>
 


### PR DESCRIPTION
## Summary
- add helper to convert YouTube links into embedded iframes
- render creatives with embedded YouTube videos in tree and show views

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: undefined method `has_closure_tree` for Creative:Class)*

------
https://chatgpt.com/codex/tasks/task_e_68b96e9ec1cc8326b740fa7c90e8f3fa