### PR TITLE
Reset expand-all state after navigation

### DIFF
--- a/app/javascript/creatives_expansion.js
+++ b/app/javascript/creatives_expansion.js
@@ -80,10 +80,17 @@ if (!window.creativesExpansionInitialized) {
     function setupCreativeToggles() {
         console.log("Setting up creative toggles");
 
+        allExpanded = false;
+
+        var expandBtn = document.getElementById('expand-all-btn');
+        if (expandBtn) {
+            expandBtn.ariaLabel = expandBtn.dataset.expandText;
+            expandBtn.firstChild.textContent = "▼";
+        }
+
         addToggleEvent(document);
 
         // Toggle Expand/Collapse All Creatives
-        var expandBtn = document.getElementById('expand-all-btn');
         if (expandBtn) {
             expandBtn.addEventListener('click', function () {
                 var toggles = document.querySelectorAll('.creative-toggle-btn');

--- a/spec/system/creative_expansion_actions_spec.rb
+++ b/spec/system/creative_expansion_actions_spec.rb
@@ -44,6 +44,16 @@ RSpec.describe 'Creative expansion actions', type: :system, js: true do
     find("#creative-#{child.id} [name='show-comments-btn']").click
     expect(page).to have_css('#comments-popup', visible: :visible)
   end
+
+  it 'resets expand all state after navigation' do
+    visit creative_path(root_creative)
+    find('#expand-all-btn').click
+    expect(page).to have_css("#creative-#{child.id}")
+
+    visit root_path
+    visit creative_path(root_creative)
+    expect(page).not_to have_css("#creative-#{child.id}")
+  end
   it 'sends current creative id when toggling expansion' do
     visit creative_path(root_creative)
     find("#creative-#{root_creative.id} .creative-toggle-btn").click


### PR DESCRIPTION
## Summary
- Reset global expand-all flag and button label on each page load
- Add system spec confirming expand-all state resets after navigation

## Testing
- `./bin/rubocop -a spec/system/creative_expansion_actions_spec.rb`
- `bundle exec rspec spec/system/creative_expansion_actions_spec.rb` *(fails: undefined method `has_closure_tree` for Creative:Class)*

------
https://chatgpt.com/codex/tasks/task_e_68b9244cbec88326ba187bc0355ff39e