### PR TITLE
Add Open Graph tags for creative pages

### DIFF
--- a/app/views/creatives/index.html.erb
+++ b/app/views/creatives/index.html.erb
@@ -52,6 +52,9 @@
 </div>
 
 <% if @parent_creative %>
+  <% content_for :head do %>
+    <meta property="og:title" content="<%= @parent_creative.effective_origin.description.to_plain_text %>">
+  <% end %>
   <div class="creative-row" id="creative-markdown-block">
     <h1 class="page-title" style="display:flex;align-items:center;gap:1em;">
       <div class="creative-content">


### PR DESCRIPTION
## Summary
- add Open Graph meta tags to creative show page using creative origin description

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: Could not find closure_tree-9.1.1, with_advisory_lock-7.0.1 in locally installed gems)*

------
https://chatgpt.com/codex/tasks/task_e_68ba5d57551c8326b4127bba4f1a5187