### PR TITLE
Fix inline editor placement after expand all

### DIFF
--- a/app/javascript/creative_row_editor.js
+++ b/app/javascript/creative_row_editor.js
@@ -44,6 +44,15 @@ if (!window.creativeRowEditorInitialized) {
       if (row) row.style.display = '';
     }
 
+    function placeTemplate(tree) {
+      const children = tree.querySelector('.creative-children');
+      if (children) {
+        tree.insertBefore(template, children);
+      } else {
+        tree.appendChild(template);
+      }
+    }
+
     function insertRow(tree, data) {
       if (tree.querySelector('.creative-row')) return;
       const row = document.createElement('div');
@@ -174,7 +183,7 @@ if (!window.creativeRowEditorInitialized) {
           currentTree = tree;
           hideRow(tree);
           tree.draggable = false;
-          tree.appendChild(template);
+          placeTemplate(tree);
           template.style.display = 'block';
           loadCreative(tree.dataset.id);
         });
@@ -315,7 +324,7 @@ if (!window.creativeRowEditorInitialized) {
       const prevParent = parentInput.value;
       currentTree = target;
       hideRow(target);
-      target.appendChild(template);
+      placeTemplate(target);
       template.style.display = 'block';
       beforeNewOrMove(wasNew, prev, prevParent).then(() => {
         loadCreative(target.dataset.id);
@@ -430,7 +439,7 @@ if (!window.creativeRowEditorInitialized) {
       newTree.dataset.parentId = parentId || '';
       if (insertBefore) container.insertBefore(newTree, insertBefore); else container.appendChild(newTree);
       currentTree = newTree;
-      newTree.appendChild(template);
+      placeTemplate(newTree);
       template.style.display = 'block';
       form.action = '/creatives';
       methodInput.value = '';

--- a/spec/system/creative_expansion_actions_spec.rb
+++ b/spec/system/creative_expansion_actions_spec.rb
@@ -45,6 +45,15 @@ RSpec.describe 'Creative expansion actions', type: :system, js: true do
     expect(page).to have_css('#comments-popup', visible: :visible)
   end
 
+  it 'shows inline editor before children when editing a parent after expand all' do
+    visit creative_path(root_creative)
+    find('#expand-all-btn').click
+    find("#creative-#{root_creative.id} .edit-inline-btn").click
+    expect(page).to have_css('#inline-edit-form-element', visible: :visible)
+    order = page.evaluate_script("Array.from(document.getElementById('creative-#{root_creative.id}').children).map(e => e.id)")
+    expect(order.index('inline-edit-form')).to be < order.index('creative-children-#{root_creative.id}')
+  end
+
   it 'resets expand all state after navigation' do
     visit creative_path(root_creative)
     find('#expand-all-btn').click


### PR DESCRIPTION
## Summary
- ensure inline editor stays with its creative when expanded
- test inline editor placement for parent creative

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec spec/system/creative_expansion_actions_spec.rb` *(fails: undefined method `has_closure_tree` for Creative:Class)*

------
https://chatgpt.com/codex/tasks/task_e_68baa5fc11e48326b788388228bea6fe