### PR TITLE
Allow scrolling of long slides

### DIFF
--- a/app/assets/stylesheets/slide_view.css
+++ b/app/assets/stylesheets/slide_view.css
@@ -1,14 +1,16 @@
 #slide-view {
   height: 100vh;
   display: flex;
-  align-items: center;
-  justify-content: center;
-  overflow-x: auto;
+  overflow: auto;
+  padding: 2rem;
+  box-sizing: border-box;
+}
+
+#slide-content {
+  margin: auto;
   font-size: 150%;
 }
-#slide-content {
-  padding: 2rem;
-}
+
 #slide-content .trix-content {
     line-height: 1.8;
 }

--- a/app/javascript/slide_view.js
+++ b/app/javascript/slide_view.js
@@ -40,6 +40,7 @@ document.addEventListener('DOMContentLoaded', function() {
         contentEl.appendChild(el);
         requestAnimationFrame(function() {
           container.scrollLeft = 0;
+          container.scrollTop = 0;
           lastScrollLeft = 0;
         });
       });


### PR DESCRIPTION
## Summary
- ensure slide view content can scroll vertically and horizontally with padding
- reset scroll position when switching slides

## Testing
- `bundle install`
- `./bin/rubocop -a`
- `bundle exec rails test` *(fails: Could not find closure_tree-9.1.1, with_advisory_lock-7.0.1 in locally installed gems)*

------
https://chatgpt.com/codex/tasks/task_e_68bc4152296c8326bb9b4e63a901731b