### PR TITLE
Preserve slide position in slide view URLs

### DIFF
--- a/app/javascript/slide_view.js
+++ b/app/javascript/slide_view.js
@@ -12,9 +12,22 @@ document.addEventListener('DOMContentLoaded', function() {
   var slideSubscription = null;
   var lastScrollLeft = 0;
 
+  if (index > 0) {
+    load(index, false);
+  } else {
+    updateUrl(index);
+  }
+
+  function updateUrl(idx) {
+    var url = new URL(window.location);
+    url.searchParams.set('slide', idx);
+    history.replaceState(null, '', url);
+  }
+
   function load(idx, broadcast) {
     if (idx < 0 || idx >= ids.length) return;
     index = idx;
+    updateUrl(index);
     if (counterEl) {
       counterEl.textContent = (index + 1) + ' / ' + ids.length;
     }

--- a/app/views/creatives/slide_view.html.erb
+++ b/app/views/creatives/slide_view.html.erb
@@ -5,8 +5,9 @@
              when 3 then 'h3'
              else 'div'
              end %>
-<div id="slide-view" data-slide-ids="<%= @slide_ids.join(',') %>" data-initial-index="0" data-root-id="<%= @creative.id %>">
+<% initial_index = params[:slide].to_i.clamp(0, @slide_ids.length - 1) %>
+<div id="slide-view" data-slide-ids="<%= @slide_ids.join(',') %>" data-initial-index="<%= initial_index %>" data-root-id="<%= @creative.id %>">
   <div id="slide-content"><%= content_tag(tag_name, @creative.effective_description.html_safe) %></div>
-  <div id="slide-counter">1 / <%= @slide_ids.length %></div>
+  <div id="slide-counter"><%= initial_index + 1 %> / <%= @slide_ids.length %></div>
 </div>
 <div id="slide-swipe"></div>


### PR DESCRIPTION
## Summary
- Track slide index in slide view URL so links open to the same slide
- Initialize slide view based on `slide` query parameter for direct navigation

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: undefined method `has_closure_tree' for Creative:Class)*
- `gem install closure_tree -v 9.1.1` *(fails: requires Ruby version >= 3.3.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bc423b5a50832698283531cef2718b