### PR TITLE
Add quick navigation to current creative in slide view

### DIFF
--- a/app/assets/images/arrow-left.svg
+++ b/app/assets/images/arrow-left.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+stroke-linecap="round" stroke-linejoin="round">
+  <path d="M19 12H5M12 19l-7-7 7-7"/>
+</svg>

--- a/app/assets/images/arrow-right.svg
+++ b/app/assets/images/arrow-right.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+stroke-linecap="round" stroke-linejoin="round">
+  <path d="M5 12h14M12 5l7 7-7 7"/>
+</svg>

--- a/app/assets/stylesheets/slide_view.css
+++ b/app/assets/stylesheets/slide_view.css
@@ -15,13 +15,23 @@
     line-height: 1.8;
 }
 
-#slide-counter {
+#slide-controls {
   position: fixed;
   bottom: 0.5rem;
   left: 50%;
   transform: translateX(-50%);
-  pointer-events: none;
   z-index: 10;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+#slide-counter {
+  pointer-events: none;
+}
+
+#slide-goto {
+  text-decoration: none;
 }
 
 #slide-swipe {

--- a/app/javascript/slide_view.js
+++ b/app/javascript/slide_view.js
@@ -8,6 +8,7 @@ document.addEventListener('DOMContentLoaded', function() {
   var contentEl = document.getElementById('slide-content');
   var swipeArea = document.getElementById('slide-swipe');
   var counterEl = document.getElementById('slide-counter');
+  var linkEl = document.getElementById('slide-goto');
   var startX = null;
   var slideSubscription = null;
   var lastScrollLeft = 0;
@@ -30,6 +31,9 @@ document.addEventListener('DOMContentLoaded', function() {
     updateUrl(index);
     if (counterEl) {
       counterEl.textContent = (index + 1) + ' / ' + ids.length;
+    }
+    if (linkEl) {
+      linkEl.href = '/creatives/' + ids[index];
     }
     var url = '/creatives/' + ids[index] + '.json';
     if (rootId) {
@@ -98,6 +102,9 @@ document.addEventListener('DOMContentLoaded', function() {
 
   if (counterEl) {
     counterEl.textContent = (index + 1) + ' / ' + ids.length;
+  }
+  if (linkEl) {
+    linkEl.href = '/creatives/' + ids[index];
   }
 
   window.addEventListener('keydown', function(e) {

--- a/app/views/creatives/slide_view.html.erb
+++ b/app/views/creatives/slide_view.html.erb
@@ -8,6 +8,9 @@
 <% initial_index = params[:slide].to_i.clamp(0, @slide_ids.length - 1) %>
 <div id="slide-view" data-slide-ids="<%= @slide_ids.join(',') %>" data-initial-index="<%= initial_index %>" data-root-id="<%= @creative.id %>">
   <div id="slide-content"><%= content_tag(tag_name, @creative.effective_description.html_safe) %></div>
+</div>
+<div id="slide-controls">
   <div id="slide-counter"><%= initial_index + 1 %> / <%= @slide_ids.length %></div>
+  <%= link_to '↗', creative_path(@creative), id: 'slide-goto', aria: { label: t('creatives.slide_view.go_to_creative') } %>
 </div>
 <div id="slide-swipe"></div>

--- a/app/views/creatives/slide_view.html.erb
+++ b/app/views/creatives/slide_view.html.erb
@@ -11,6 +11,6 @@
 </div>
 <div id="slide-controls">
   <div id="slide-counter"><%= initial_index + 1 %> / <%= @slide_ids.length %></div>
-  <%= link_to '↗', creative_path(@creative), id: 'slide-goto', aria: { label: t('creatives.slide_view.go_to_creative') } %>
+  <%= link_to '→', creative_path(@creative), id: 'slide-goto', aria: { label: t('creatives.slide_view.go_to_creative') } %>
 </div>
 <div id="slide-swipe"></div>

--- a/config/locales/creatives.en.yml
+++ b/config/locales/creatives.en.yml
@@ -83,6 +83,8 @@ en:
       notify_me: "Email me when is progressing."
       placeholder_email: "you@example.com"
       submit: "Submit"
+    slide_view:
+      go_to_creative: "Go to Creative"
   creative_mailer:
     in_stock:
       subject: "Good news!"

--- a/config/locales/creatives.ko.yml
+++ b/config/locales/creatives.ko.yml
@@ -83,6 +83,8 @@ ko:
       notify_me: "진행 상황을 이메일로 알려주세요."
       placeholder_email: "you@example.com"
       submit: "제출"
+    slide_view:
+      go_to_creative: "현재 크리에이티브로 이동"
   creative_mailer:
     in_stock:
       subject: "좋은 소식!"


### PR DESCRIPTION
## Summary
- add "go to creative" button beside slide counter
- update slide view JS to keep button link in sync
- style slide controls and add translations

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: Could not find closure_tree-9.1.1, with_advisory_lock-7.0.1)*

------
https://chatgpt.com/codex/tasks/task_e_68bc426ff878832682af980f4fcb509f