### PR TITLE
Add invite link generation and invitation landing page

### DIFF
--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -1,11 +1,18 @@
 class InvitesController < ApplicationController
-  allow_unauthenticated_access
-  before_action :set_invitation
+  allow_unauthenticated_access only: :show
+  before_action :set_invitation, only: :show
+
+  def create
+    creative = Creative.find(params[:creative_id])
+    permission = params[:permission] || :read
+    invitation = Invitation.create!(inviter: Current.user,
+                                    creative: creative,
+                                    permission: permission)
+    render json: { url: invite_url(token: invitation.generate_token_for(:invite)) }
+  end
 
   def show
     @invitation.update(clicked_at: Time.current) unless @invitation.clicked_at
-    @user = User.new(email: @invitation.email)
-    render "users/new"
   end
 
   private

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -6,7 +6,6 @@ class Invitation < ApplicationRecord
 
   generates_token_for :invite, expires_in: 15.days
 
-  validates :email, presence: true
   validates :expires_at, presence: true
 
   before_validation :set_default_expires_at, on: :create

--- a/app/views/creatives/_share_button.html.erb
+++ b/app/views/creatives/_share_button.html.erb
@@ -54,6 +54,11 @@
             inviteLinkBtn.onclick = function() {
                 const creativeId = inviteLinkBtn.dataset.creativeId;
                 const permission = permissionSelect ? permissionSelect.value : 'read';
+                const permissionLabel = permissionSelect ? permissionSelect.options[permissionSelect.selectedIndex].text : '';
+                if (permission === 'no_access') {
+                    alert('<%= t('creatives.index.invite_link_no_access') %>');
+                    return;
+                }
                 fetch('/invite', {
                     method: 'POST',
                     headers: {
@@ -63,7 +68,8 @@
                     body: JSON.stringify({ creative_id: creativeId, permission: permission })
                 }).then(r => r.json()).then(data => {
                     navigator.clipboard.writeText(data.url).then(function() {
-                        alert('<%= t('creatives.index.invite_link_copied') %>');
+                        const template = '<%= j t('creatives.index.invite_link_copied_permission', permission: '__PERMISSION__') %>';
+                        alert(template.replace('__PERMISSION__', permissionLabel));
                     });
                 });
             };

--- a/app/views/creatives/_share_button.html.erb
+++ b/app/views/creatives/_share_button.html.erb
@@ -4,6 +4,7 @@
   <div class="popup-box" style="min-width:320px;max-width:90vw;">
     <button id="close-share-modal" class="popup-close-btn">&times;</button>
     <h2><%= t('creatives.index.share_creative') %></h2>
+    <button type="button" id="creative-invite-link" class="btn btn-secondary" data-creative-id="<%= (@parent_creative || @creative).id %>"><%= t('creatives.index.invite_link') %></button>
     <form id="share-creative-form" action="<%= creative_creative_shares_path(@parent_creative || @creative) %>" method="post" data-controller="share-invite">
       <%= csrf_meta_tags %>
       <div style="margin-bottom:1em;">
@@ -47,6 +48,26 @@
         const modal = document.getElementById('share-creative-modal');
         const closeBtn = document.getElementById('close-share-modal');
         const emailInput = document.getElementById('share-user-email');
+        const inviteLinkBtn = document.getElementById('creative-invite-link');
+        const permissionSelect = document.getElementById('share-permission');
+        if (inviteLinkBtn) {
+            inviteLinkBtn.onclick = function() {
+                const creativeId = inviteLinkBtn.dataset.creativeId;
+                const permission = permissionSelect ? permissionSelect.value : 'read';
+                fetch('/invite', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').content
+                    },
+                    body: JSON.stringify({ creative_id: creativeId, permission: permission })
+                }).then(r => r.json()).then(data => {
+                    navigator.clipboard.writeText(data.url).then(function() {
+                        alert('<%= t('creatives.index.invite_link_copied') %>');
+                    });
+                });
+            };
+        }
         if (shareBtn && modal && closeBtn) {
             shareBtn.onclick = function() {
                 modal.style.display = 'flex';

--- a/app/views/creatives/_share_button.html.erb
+++ b/app/views/creatives/_share_button.html.erb
@@ -4,7 +4,6 @@
   <div class="popup-box" style="min-width:320px;max-width:90vw;">
     <button id="close-share-modal" class="popup-close-btn">&times;</button>
     <h2><%= t('creatives.index.share_creative') %></h2>
-    <button type="button" id="creative-invite-link" class="btn btn-secondary" data-creative-id="<%= (@parent_creative || @creative).id %>"><%= t('creatives.index.invite_link') %></button>
     <form id="share-creative-form" action="<%= creative_creative_shares_path(@parent_creative || @creative) %>" method="post" data-controller="share-invite">
       <%= csrf_meta_tags %>
       <div style="margin-bottom:1em;">
@@ -20,6 +19,7 @@
         </select>
       </div>
       <button type="submit" class="btn btn-primary" data-share-invite-target="submit" data-share="<%= t('creatives.index.share') %>" data-invite="<%= t('creatives.index.invite') %>"><%= t('creatives.index.share') %></button>
+      <button type="button" id="creative-invite-link" class="btn btn-secondary" data-creative-id="<%= (@parent_creative || @creative).id %>"><%= t('creatives.index.invite_link') %></button>
     </form>
     <% if @shared_list.any? %>
       <div style="margin-top:1em;">

--- a/app/views/invites/show.html.erb
+++ b/app/views/invites/show.html.erb
@@ -1,0 +1,6 @@
+<p><%= t('invites.show.invited_by', inviter: @invitation.inviter.display_name, email: @invitation.inviter.email, creative: @invitation.creative.description.to_plain_text) %></p>
+<p><%= t('invites.show.prompt') %></p>
+<p>
+  <%= link_to t('invites.show.login'), new_session_path(invite_token: params[:token]) %> |
+  <%= link_to t('invites.show.sign_up'), new_user_path(invite_token: params[:token]) %>
+</p>

--- a/app/views/invites/show.html.erb
+++ b/app/views/invites/show.html.erb
@@ -1,6 +1,8 @@
+<h1 class="no-top-margin"><%= t('.title') %></h1>
 <p><%= t('invites.show.invited_by', inviter: @invitation.inviter.display_name, email: @invitation.inviter.email, creative: @invitation.creative.description.to_plain_text) %></p>
 <p><%= t('invites.show.prompt') %></p>
 <p>
   <%= link_to t('invites.show.login'), new_session_path(invite_token: params[:token]) %> |
   <%= link_to t('invites.show.sign_up'), new_user_path(invite_token: params[:token]) %>
 </p>
+</div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -4,6 +4,7 @@
   <%= render 'users/id_pwd_fields', form: form, skip_name_field: true %>
   <%= tag.div(flash[:alert], class: "flash-alert") if flash[:alert] %>
   <%= form.hidden_field :timezone, id: 'login-timezone' %>
+  <%= form.hidden_field :invite_token, value: params[:invite_token] if params[:invite_token] %>
   <%= form.submit t('app.sign_in'), id: 'sign-in-submit' %>
 <% end %>
 <%= button_to t('users.sessions.new.sign_in_with_google'), '/auth/google_oauth2', method: :post, params: { timezone: '' }, data: { turbo: false } %>
@@ -11,7 +12,7 @@
 
 <%= link_to t('users.sessions.new.forgot_password'), new_password_path %>
 <br>
-<%= link_to t("users.new.sign_up"), new_user_path, class: "sign-up-link" %>
+<%= link_to t("users.new.sign_up"), params[:invite_token] ? new_user_path(invite_token: params[:invite_token]) : new_user_path, class: "sign-up-link" %>
 
 <script>
   document.addEventListener('turbo:load', () => {

--- a/config/locales/creatives.en.yml
+++ b/config/locales/creatives.en.yml
@@ -46,6 +46,8 @@ en:
       permission_no_access: "No access"
       share: "Share"
       invite: "Invite"
+      invite_link: "Invite Link"
+      invite_link_copied: "Invite link copied."
       plan_tags_applied: "Plan tags applied to selected creatives."
       plan_tag_failed: "Please select a plan and at least one creative."
       plan_tags_removed: "Plan tag removed from selected creatives."

--- a/config/locales/creatives.en.yml
+++ b/config/locales/creatives.en.yml
@@ -48,6 +48,8 @@ en:
       invite: "Invite"
       invite_link: "Invite Link"
       invite_link_copied: "Invite link copied."
+      invite_link_copied_permission: "Invite link copied with %{permission} permission."
+      invite_link_no_access: "Cannot create invitation for No access permission."
       plan_tags_applied: "Plan tags applied to selected creatives."
       plan_tag_failed: "Please select a plan and at least one creative."
       plan_tags_removed: "Plan tag removed from selected creatives."

--- a/config/locales/creatives.ko.yml
+++ b/config/locales/creatives.ko.yml
@@ -48,6 +48,8 @@ ko:
       invite: "초대하기"
       invite_link: "초대 링크"
       invite_link_copied: "초대 링크가 복사되었습니다."
+      invite_link_copied_permission: "%{permission} 권한으로 초대 링크가 복사되었습니다."
+      invite_link_no_access: "접근 금지 권한으로는 초대할 수 없습니다."
       plan_tags_applied: "선택한 크리에이티브에 플랜 태그가 적용되었습니다."
       plan_tag_failed: "플랜과 하나 이상의 크리에이티브를 선택하세요."
       plan_tags_removed: "선택한 크리에이티브에서 플랜 태그가 제거되었습니다."

--- a/config/locales/creatives.ko.yml
+++ b/config/locales/creatives.ko.yml
@@ -46,6 +46,8 @@ ko:
       permission_no_access: "접근 금지"
       share: "공유하기"
       invite: "초대하기"
+      invite_link: "초대 링크"
+      invite_link_copied: "초대 링크가 복사되었습니다."
       plan_tags_applied: "선택한 크리에이티브에 플랜 태그가 적용되었습니다."
       plan_tag_failed: "플랜과 하나 이상의 크리에이티브를 선택하세요."
       plan_tags_removed: "선택한 크리에이티브에서 플랜 태그가 제거되었습니다."

--- a/config/locales/invites.en.yml
+++ b/config/locales/invites.en.yml
@@ -2,6 +2,11 @@ en:
   invites:
     invalid: "Invitation link is invalid or has expired."
     invite_sent: "Invitation email sent."
+    show:
+      invited_by: "%{inviter} (%{email}) invited you to the \"%{creative}\" creative."
+      prompt: "To accept the invitation, please log in or sign up."
+      login: "Log in"
+      sign_up: "Sign up"
   invitation_mailer:
     invite:
       subject: "You're invited to Collavre"

--- a/config/locales/invites.en.yml
+++ b/config/locales/invites.en.yml
@@ -3,6 +3,7 @@ en:
     invalid: "Invitation link is invalid or has expired."
     invite_sent: "Invitation email sent."
     show:
+      title: "Invitation"
       invited_by: "%{inviter} (%{email}) invited you to the \"%{creative}\" creative."
       prompt: "To accept the invitation, please log in or sign up."
       login: "Log in"

--- a/config/locales/invites.ko.yml
+++ b/config/locales/invites.ko.yml
@@ -2,6 +2,11 @@ ko:
   invites:
     invalid: "초대 링크가 잘못되었거나 만료되었습니다."
     invite_sent: "초대 이메일을 보냈습니다."
+    show:
+      invited_by: "%{inviter} (%{email})님이 \"%{creative}\" 크리에이티브에 초대했습니다."
+      prompt: "초대를 수락하려면 로그인하거나 회원 가입을 해주세요."
+      login: "로그인"
+      sign_up: "회원 가입"
   invitation_mailer:
     invite:
       subject: "콜라브에 초대되었습니다"

--- a/config/locales/invites.ko.yml
+++ b/config/locales/invites.ko.yml
@@ -3,6 +3,7 @@ ko:
     invalid: "초대 링크가 잘못되었거나 만료되었습니다."
     invite_sent: "초대 이메일을 보냈습니다."
     show:
+      title: "초대"
       invited_by: "%{inviter} (%{email})님이 \"%{creative}\" 크리에이티브에 초대했습니다."
       prompt: "초대를 수락하려면 로그인하거나 회원 가입을 해주세요."
       login: "로그인"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -72,7 +72,7 @@ Rails.application.routes.draw do
   resources :emails, only: [ :index, :show ]
 
   resource :unsubscribe, only: [ :show ]
-  resource :invite, only: [ :show ]
+  resource :invite, only: [ :show, :create ]
   resource :verify, controller: "email_verifications", only: [ :show ]
 
   post "/creative_expanded_states/toggle", to: "creative_expanded_states#toggle"

--- a/test/integration/invitation_flow_test.rb
+++ b/test/integration/invitation_flow_test.rb
@@ -35,4 +35,23 @@ class InvitationFlowTest < ActionDispatch::IntegrationTest
     assert_select "a[href=?]", new_user_path(invite_token: token),
                   text: I18n.t("invites.show.sign_up")
   end
+
+  test "existing user accepts invitation by logging in" do
+    inviter = User.create!(email: "inviter@example.com", password: "secret", name: "Inviter")
+    creative = Creative.create!(user: inviter, description: "Test creative")
+    invitee = User.create!(email: "invitee@example.com", password: "secret", name: "Invitee")
+    invitee.update!(email_verified_at: Time.current)
+
+    invitation = Invitation.create!(inviter: inviter, creative: creative, permission: :read)
+    token = invitation.generate_token_for(:invite)
+
+    post session_path, params: { email: invitee.email, password: "secret", invite_token: token }
+    assert_redirected_to root_path
+
+    invitation.reload
+    assert_not_nil invitation.accepted_at
+    share = CreativeShare.find_by(creative: creative, user: invitee)
+    assert share
+    assert_equal "read", share.permission
+  end
 end

--- a/test/integration/invitation_flow_test.rb
+++ b/test/integration/invitation_flow_test.rb
@@ -27,7 +27,12 @@ class InvitationFlowTest < ActionDispatch::IntegrationTest
 
     invitation.reload
     assert_not_nil invitation.clicked_at
-    assert_select "input[name=invite_token][value=?]", token
-    assert_select "input[name='user[email]'][readonly][value=?]", "invitee@example1.com"
+    assert_match inviter.display_name, response.body
+    assert_match inviter.email, response.body
+    assert_match creative.description.to_plain_text, response.body
+    assert_select "a[href=?]", new_session_path(invite_token: token),
+                  text: I18n.t("invites.show.login")
+    assert_select "a[href=?]", new_user_path(invite_token: token),
+                  text: I18n.t("invites.show.sign_up")
   end
 end


### PR DESCRIPTION
## Summary
- Add "Invite Link" button to share popup that generates a shareable invitation URL and copies it to the clipboard
- Provide endpoint and routing to create invitation links and expose invite landing page showing inviter and creative info
- Localize new invite link texts and update invitation flow test

## Testing
- `./bin/rubocop -a`
- `bin/rails test` *(fails: NoMethodError: undefined method `has_closure_tree` for Creative:Class)*

------
https://chatgpt.com/codex/tasks/task_e_68bc57fbb2188326a04a33a44c9e48bf