### PR TITLE
Render Markdown in chat comments

### DIFF
--- a/app/assets/stylesheets/comments_popup.css
+++ b/app/assets/stylesheets/comments_popup.css
@@ -67,7 +67,6 @@
 
 .comment-content {
     margin-top:0.2em;
-    white-space:pre-line;
 }
 
 .comment-action-container {

--- a/app/javascript/comments.js
+++ b/app/javascript/comments.js
@@ -101,9 +101,7 @@ if (!window.commentsInitialized) {
             if (!window.marked) return;
             container.querySelectorAll('.comment-content').forEach(function(el) {
                 if (el.dataset.rendered === 'true') return;
-                var text = el.textContent;
-                var html = text.includes('\n') ? window.marked.parse(text).trim() : window.marked.parseInline(text).trim();
-                el.innerHTML = html;
+                el.innerHTML = window.marked.parse(el.textContent);
                 el.dataset.rendered = 'true';
             });
         }

--- a/app/javascript/comments.js
+++ b/app/javascript/comments.js
@@ -108,6 +108,10 @@ if (!window.commentsInitialized) {
             });
         }
 
+        document.addEventListener('turbo:after-stream-render', function() {
+            renderMarkdown(document);
+        });
+
         function startResize(e, dir) {
             e.preventDefault();
             var rect = popup.getBoundingClientRect();

--- a/app/javascript/comments.js
+++ b/app/javascript/comments.js
@@ -101,7 +101,9 @@ if (!window.commentsInitialized) {
             if (!window.marked) return;
             container.querySelectorAll('.comment-content').forEach(function(el) {
                 if (el.dataset.rendered === 'true') return;
-                el.innerHTML = window.marked.parse(el.textContent);
+                var text = el.textContent;
+                var html = text.includes('\n') ? window.marked.parse(text).trim() : window.marked.parseInline(text).trim();
+                el.innerHTML = html;
                 el.dataset.rendered = 'true';
             });
         }

--- a/app/javascript/comments.js
+++ b/app/javascript/comments.js
@@ -97,6 +97,15 @@ if (!window.commentsInitialized) {
         var startBottom = 0;
         var reservedHeight = 0;
 
+        function renderMarkdown(container) {
+            if (!window.marked) return;
+            container.querySelectorAll('.comment-content').forEach(function(el) {
+                if (el.dataset.rendered === 'true') return;
+                el.innerHTML = window.marked.parse(el.textContent);
+                el.dataset.rendered = 'true';
+            });
+        }
+
         function startResize(e, dir) {
             e.preventDefault();
             var rect = popup.getBoundingClientRect();
@@ -348,6 +357,7 @@ if (!window.commentsInitialized) {
                 list.innerHTML = popup.dataset.loadingText;
                 fetchCommentsPage(1).then(function(html) {
                     list.innerHTML = html;
+                    renderMarkdown(list);
                     updatePosition();
                     if (highlightId) {
                         var el = document.getElementById('comment_' + highlightId);
@@ -372,6 +382,7 @@ if (!window.commentsInitialized) {
                         allLoaded = true;
                     } else {
                         list.insertAdjacentHTML('beforeend', html);
+                        renderMarkdown(list);
                         currentPage += 1;
                         checkAllLoaded(html);
                     }

--- a/app/javascript/controllers/comment_controller.js
+++ b/app/javascript/controllers/comment_controller.js
@@ -1,0 +1,27 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="comment"
+export default class extends Controller {
+  static targets = [ "actions" ]
+
+  connect() {
+    // Render Markdown
+    if (window.marked) {
+      const contentElement = this.element.querySelector('.comment-content');
+      if (contentElement && contentElement.dataset.rendered !== 'true') {
+        const text = contentElement.textContent;
+        const html = text.includes('\n') ? window.marked.parse(text).trim() : window.marked.parseInline(text).trim();
+        contentElement.innerHTML = html;
+        contentElement.dataset.rendered = 'true';
+      }
+    }
+
+    // Show actions for the comment owner
+    const currentUserId = document.body.dataset.currentUserId;
+    const commentAuthorId = this.element.dataset.userId;
+
+    if (currentUserId && commentAuthorId && currentUserId === commentAuthorId) {
+      this.actionsTarget.style.display = 'inline-flex'; // Use inline-flex for better alignment
+    }
+  }
+}

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -44,7 +44,7 @@ class Comment < ApplicationRecord
   end
 
   def broadcast_update
-    broadcast_replace_later_to([ creative, :comments ])
+    broadcast_update_later_to([ creative, :comments ])
   end
 
   def broadcast_destroy

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,21 +1,19 @@
-<div class="comment-item <%= 'last-read' if defined?(last_read_comment_id) && last_read_comment_id && comment.id == last_read_comment_id %>" id="<%= dom_id(comment) %>">
+<div class="comment-item <%= 'last-read' if defined?(last_read_comment_id) && last_read_comment_id && comment.id == last_read_comment_id %>" id="<%= dom_id(comment) %>" data-controller="comment" data-user-id="<%= comment.user&.id %>">
   <div>
     <%= render AvatarComponent.new(user: comment.user, size: 20, classes: 'avatar comment-avatar') %>
     <strong><%= comment.user&.display_name || t('comments.gemini') %></strong>
     <span>· <%= t('datetime.ago', time: time_ago_in_words(comment.created_at)) %></span>
-    <% if comment.user == Current.user %>
-      <div class="comment-action-container">
-        <button class="convert-comment-btn" data-comment-id="<%= comment.id %>" title="<%= t('comments.convert_to_creative') %>">
-          <%= t('comments.convert_button') %>
-        </button>
-        <button class="edit-comment-btn" data-comment-id="<%= comment.id %>" data-comment-content="<%= comment.content %>" title="<%= t('comments.update_comment') %>">
-          <%= t('comments.edit_button') %>
-        </button>
-        <button class="delete-comment-btn" data-comment-id="<%= comment.id %>" title="<%= t('comments.delete') %>">
-          <%= t('comments.delete_button') %>
-        </button>
-      </div>
-    <% end %>
+    <div class="comment-action-container" data-comment-target="actions" style="display: none;">
+      <button class="convert-comment-btn" data-comment-id="<%= comment.id %>" title="<%= t('comments.convert_to_creative') %>">
+        <%= t('comments.convert_button') %>
+      </button>
+      <button class="edit-comment-btn" data-comment-id="<%= comment.id %>" data-comment-content="<%= comment.content %>" title="<%= t('comments.update_comment') %>">
+        <%= t('comments.edit_button') %>
+      </button>
+      <button class="delete-comment-btn" data-comment-id="<%= comment.id %>" title="<%= t('comments.delete') %>">
+        <%= t('comments.delete_button') %>
+      </button>
+    </div>
   </div>
   <div class="comment-content"><%= comment.content %></div>
 </div>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -17,7 +17,5 @@
       </div>
     <% end %>
   </div>
-  <div class="comment-content">
-    <%= linkify_urls(comment.content) %>
-  </div>
+  <div class="comment-content"><%= comment.content %></div>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -42,7 +42,7 @@
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js" defer></script>
     <%= javascript_importmap_tags %>
   </head>
-  <body class="<%= 'dark-mode' if Current.user&.theme == 'dark' %><%= ' light-mode' if Current.user&.theme == 'light' %>">
+  <body class="<%= 'dark-mode' if Current.user&.theme == 'dark' %><%= ' light-mode' if Current.user&.theme == 'light' %>" data-current-user-id="<%= Current.user&.id %>">
     <%= turbo_stream_from ["inbox", Current.user] if Current.user %>
     <div class="notice"><%= notice %></div>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -39,6 +39,7 @@
     <%= javascript_include_tag 'progress_filter_toggle', defer: true %>
     <%= javascript_include_tag 'plans_timeline', defer: true %>
     <%= javascript_include_tag 'actioncable', defer: true %>
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js" defer></script>
     <%= javascript_importmap_tags %>
   </head>
   <body class="<%= 'dark-mode' if Current.user&.theme == 'dark' %><%= ' light-mode' if Current.user&.theme == 'light' %>">


### PR DESCRIPTION
## Summary
- Render comment messages using Marked.js to convert Markdown to HTML
- Load Marked.js library globally in the layout
- Remove server-side linkification so messages are parsed client-side

## Testing
- `./bin/rubocop`
- `bin/rails test` *(fails: NoMethodError: undefined method `has_closure_tree` for Creative:Class)*

------
https://chatgpt.com/codex/tasks/task_e_68bc64f2d58083268bd72a6f1c3b3581