### PR TITLE
Fix comment URL redirect to open highlighted comment

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -72,7 +72,7 @@ class CommentsController < ApplicationController
     end
 
   def show
-    redirect_to creative_path(@creative, comment_id: @comment.id)
+    redirect_to creatives_path(id: @creative.id, comment_id: @comment.id)
   end
 
   def participants

--- a/spec/requests/comment_show_spec.rb
+++ b/spec/requests/comment_show_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+require 'ostruct'
+
+RSpec.describe 'Comment show redirect', type: :request do
+  let(:user) { User.create!(email: 'user2@example.com', password: 'pw', name: 'User2') }
+  let(:creative) { Creative.create!(user: user, description: 'Creative with comments') }
+  let!(:comment) { creative.comments.create!(user: user, content: 'My comment') }
+
+  before do
+    allow_any_instance_of(CommentsController).to receive(:require_authentication).and_return(true)
+    Current.session = OpenStruct.new(user: user)
+  end
+
+  it 'redirects to creatives index with comment_id param' do
+    get "/creatives/#{creative.id}/comments/#{comment.id}"
+    expect(response).to redirect_to("/creatives?id=#{creative.id}&comment_id=#{comment.id}")
+  end
+end


### PR DESCRIPTION
## Summary
- redirect comment show URL directly to `creatives` index with comment highlight
- add request spec for comment show redirect

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: undefined method `has_closure_tree` for Creative:Class)*

------
https://chatgpt.com/codex/tasks/task_e_68bca60cc7208326969e656ed66306be