### PR TITLE
Add Alt+Enter shortcut for child creatives

### DIFF
--- a/app/javascript/creative_row_editor.js
+++ b/app/javascript/creative_row_editor.js
@@ -485,6 +485,11 @@ if (!window.creativeRowEditorInitialized) {
         hideCurrent();
         return;
       }
+      if (e.key === 'Enter' && e.altKey) {
+        e.preventDefault();
+        addChild();
+        return;
+      }
       if (e.key === 'Enter' && e.shiftKey) {
         e.preventDefault();
         addNew();


### PR DESCRIPTION
## Summary
- support creating a child creative in the row editor with Alt+Enter

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: undefined method `has_closure_tree` for Creative:Class)*
- `bin/rails test` *(fails: undefined method `has_closure_tree` for Creative:Class)*

------
https://chatgpt.com/codex/tasks/task_e_68bcde0d018c83269612ba805a60eca5