### PR TITLE
Load comment badges via Turbo

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,6 +52,7 @@ Rails.application.routes.draw do
     end
     member do
       get :children
+      get :comment_badge
       post :share, to: "creatives#share", as: :share_creative
       post :request_permission, to: "creatives#request_permission"
       get :parent_suggestions

--- a/spec/requests/comment_badge_spec.rb
+++ b/spec/requests/comment_badge_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+require 'ostruct'
+
+RSpec.describe 'Comment badge', type: :request do
+  let(:user) { User.create!(email: 'user@example.com', password: 'pw', name: 'User') }
+  let(:creative) { Creative.create!(user: user, description: 'Some creative') }
+
+  before do
+    allow_any_instance_of(CreativesController).to receive(:require_authentication).and_return(true)
+    Current.session = OpenStruct.new(user: user)
+  end
+
+  it 'renders unread comment count' do
+    creative.comments.create!(user: user, content: 'First')
+    get "/creatives/#{creative.id}/comment_badge"
+    expect(response.body).to include('data-count="1"')
+  end
+end


### PR DESCRIPTION
## Summary
- Load creative comment badges via Turbo frames and keep them updated through Turbo Streams
- Add endpoint to serve unread comment counts for each creative
- Cover comment badge endpoint with a request spec

## Testing
- `./bin/rubocop -a app/controllers/creatives_controller.rb app/helpers/creatives_helper.rb config/routes.rb spec/requests/comment_badge_spec.rb`
- `bundle exec rspec` *(fails: Could not find closure_tree-9.1.1, with_advisory_lock-7.0.1 in locally installed gems)*

------
https://chatgpt.com/codex/tasks/task_e_68bcd32058588326be950a2d370784f3