### PR TITLE
Use colon format for user mentions

### DIFF
--- a/app/javascript/comments.js
+++ b/app/javascript/comments.js
@@ -183,7 +183,7 @@ if (!window.commentsInitialized) {
         function insertMention(user) {
             var start = textarea.selectionStart;
             var end = textarea.selectionEnd;
-            var mentionText = '@"' + user.name + '" ';
+            var mentionText = '@' + user.name + ': ';
 
             if (start !== end) {
                 // 선택영역이 있는 경우: 선택영역을 멘션으로 바꿈

--- a/app/javascript/mention_menu.js
+++ b/app/javascript/mention_menu.js
@@ -22,7 +22,7 @@ if (!window.mentionMenuInitialized) {
 
     function insert(user) {
       var pos = textarea.selectionStart;
-      var before = textarea.value.slice(0, pos).replace(/@[^@\s]*$/, '@"' + user.name + '" ');
+        var before = textarea.value.slice(0, pos).replace(/@[^@\s]*$/, '@' + user.name + ': ');
       textarea.value = before + textarea.value.slice(pos);
     }
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -35,7 +35,7 @@ class Comment < ApplicationRecord
 
   def mentioned_names
     return [] unless content
-    content.scan(/@"([^\"]+)"/)
+    content.scan(/@([^:]+):/)
            .flatten
            .map(&:downcase)
            .uniq

--- a/spec/models/comment_mentions_spec.rb
+++ b/spec/models/comment_mentions_spec.rb
@@ -8,7 +8,7 @@ describe Comment, type: :model do
     mentioned = User.create!(email: 'mentioned@example.com', password: 'pw', name: 'Mentioned')
     creative = Creative.create!(user: owner, description: 'root')
 
-    Comment.create!(creative: creative, user: commenter, content: "hi @\"#{mentioned.name}\"")
+    Comment.create!(creative: creative, user: commenter, content: "hi @#{mentioned.name}:")
 
     items = InboxItem.where(owner: mentioned)
     expect(items.count).to eq(1)
@@ -21,7 +21,7 @@ describe Comment, type: :model do
     commenter = User.create!(email: 'commenter@example.com', password: 'pw', name: 'Commenter')
     creative = Creative.create!(user: owner, description: 'root')
 
-    Comment.create!(creative: creative, user: commenter, content: "hi @\"#{owner.name}\"")
+    Comment.create!(creative: creative, user: commenter, content: "hi @#{owner.name}:")
 
     items = InboxItem.where(owner: owner)
     expect(items.count).to eq(1)


### PR DESCRIPTION
## Summary
- replace quoted user mentions with colon-suffixed format in comment UI and parsing
- update Comment model and tests for new mention syntax

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: Unable to obtain chromedriver and missing Google OAuth token)*

------
https://chatgpt.com/codex/tasks/task_e_68bfbb2d375c8326b9c7d6aeabf10472