### PR TITLE
Reset send icon after editing chat comments

### DIFF
--- a/app/javascript/comments.js
+++ b/app/javascript/comments.js
@@ -26,6 +26,7 @@ if (!window.commentsInitialized) {
         }
         function openPopup(btn) {
             currentBtn = btn;
+            resetForm();
             popup.dataset.creativeId = btn.dataset.creativeId;
             popup.dataset.canComment = btn.dataset.canComment;
             popup.dataset.resized = 'false';
@@ -68,6 +69,7 @@ if (!window.commentsInitialized) {
             if (presenceSubscription) { presenceSubscription.perform('stopped_typing'); }
             clearTimeout(typingTimeout);
             typingTimeout = null;
+            resetForm();
             if (isMobile()) {
                 popup.classList.remove('open');
                 setTimeout(function() { popup.style.display = 'none'; }, 300);
@@ -85,6 +87,7 @@ if (!window.commentsInitialized) {
         var participants = document.getElementById('comment-participants');
         var typingIndicator = document.getElementById('typing-indicator');
         var submitBtn = form.querySelector('button[type="submit"]');
+        var defaultSubmitBtnHTML = submitBtn.innerHTML;
         var textarea = form.querySelector('textarea');
         var leftHandle = popup.querySelector('.resize-handle-left');
         var rightHandle = popup.querySelector('.resize-handle-right');
@@ -477,6 +480,7 @@ if (!window.commentsInitialized) {
             function resetForm() {
                 form.reset();
                 editingId = null;
+                submitBtn.innerHTML = defaultSubmitBtnHTML;
             }
 
             form.onsubmit = function(e) {


### PR DESCRIPTION
## Summary
- Ensure the comment form's submit button restores its original send icon after editing
- Reset comment form state when the popup opens or closes to avoid lingering edit state

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: error sending request for url (https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json))*

------
https://chatgpt.com/codex/tasks/task_e_68bfdd31395c832693deecb215e90eae