### PR TITLE
Add private comments with typing indicator suppression

### DIFF
--- a/app/assets/stylesheets/comments_popup.css
+++ b/app/assets/stylesheets/comments_popup.css
@@ -151,3 +151,22 @@
   opacity: 0.4;
   filter: grayscale(1);
 }
+
+.private-comment-prompt {
+  display: none;
+  position: fixed;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  padding: 0.4em 0.8em;
+  border-radius: 6px;
+  font-size: 0.9em;
+  z-index: 1001;
+}
+
+@media (max-width: 600px) {
+  .private-comment-prompt {
+    bottom: calc(env(keyboard-inset-height, 0) + 3.2em);
+  }
+}

--- a/app/assets/stylesheets/comments_popup.css
+++ b/app/assets/stylesheets/comments_popup.css
@@ -151,22 +151,3 @@
   opacity: 0.4;
   filter: grayscale(1);
 }
-
-.private-comment-prompt {
-  display: none;
-  position: fixed;
-  left: 50%;
-  transform: translateX(-50%);
-  background: var(--color-bg);
-  border: 1px solid var(--color-border);
-  padding: 0.4em 0.8em;
-  border-radius: 6px;
-  font-size: 0.9em;
-  z-index: 1001;
-}
-
-@media (max-width: 600px) {
-  .private-comment-prompt {
-    bottom: calc(env(keyboard-inset-height, 0) + 3.2em);
-  }
-}

--- a/app/helpers/creatives_helper.rb
+++ b/app/helpers/creatives_helper.rb
@@ -43,7 +43,7 @@ module CreativesHelper
         comments_count = origin.comments.size
         pointer = CommentReadPointer.find_by(user: Current.user, creative: origin)
         last_read_id = pointer&.last_read_comment_id
-        unread_count = last_read_id ? origin.comments.where("id > ?", last_read_id).count : comments_count
+        unread_count = last_read_id ? origin.comments.where("id > ? and private = ?", last_read_id, false).count : comments_count
         if CommentPresenceStore.list(origin.id).include?(Current.user.id)
           unread_count = 0
         end

--- a/app/javascript/comments.js
+++ b/app/javascript/comments.js
@@ -87,6 +87,7 @@ if (!window.commentsInitialized) {
         var submitBtn = form.querySelector('button[type="submit"]');
         var textarea = form.querySelector('textarea');
         var privateCheckbox = form.querySelector('#comment-private');
+        var privatePrompt = document.getElementById('private-comment-prompt');
         var leftHandle = popup.querySelector('.resize-handle-left');
         var rightHandle = popup.querySelector('.resize-handle-right');
         var editingId = null;
@@ -97,6 +98,15 @@ if (!window.commentsInitialized) {
         var typingTimers = {};
         var typingTimeout = null;
 
+        function updatePrivatePrompt() {
+            if (!privatePrompt) return;
+            if (isMobile() && privateCheckbox && privateCheckbox.checked) {
+                privatePrompt.style.display = 'block';
+            } else {
+                privatePrompt.style.display = 'none';
+            }
+        }
+
         if (privateCheckbox) {
             privateCheckbox.addEventListener('change', function() {
                 if (presenceSubscription && privateCheckbox.checked) {
@@ -104,8 +114,12 @@ if (!window.commentsInitialized) {
                 }
                 clearTimeout(typingTimeout);
                 typingTimeout = null;
+                updatePrivatePrompt();
             });
         }
+
+        updatePrivatePrompt();
+        window.addEventListener('resize', updatePrivatePrompt);
 
         var resizing = null;
         var resizeStartX = 0;
@@ -494,6 +508,7 @@ if (!window.commentsInitialized) {
             function resetForm() {
                 form.reset();
                 editingId = null;
+                updatePrivatePrompt();
             }
 
             form.onsubmit = function(e) {

--- a/app/javascript/comments.js
+++ b/app/javascript/comments.js
@@ -65,7 +65,7 @@ if (!window.commentsInitialized) {
             loadInitialComments();
         }
         function closePopup() {
-            if (presenceSubscription) { presenceSubscription.perform('stopped_typing'); }
+            if (presenceSubscription && (!privateCheckbox || !privateCheckbox.checked)) { presenceSubscription.perform('stopped_typing'); }
             clearTimeout(typingTimeout);
             typingTimeout = null;
             if (isMobile()) {
@@ -86,6 +86,7 @@ if (!window.commentsInitialized) {
         var typingIndicator = document.getElementById('typing-indicator');
         var submitBtn = form.querySelector('button[type="submit"]');
         var textarea = form.querySelector('textarea');
+        var privateCheckbox = form.querySelector('#comment-private');
         var leftHandle = popup.querySelector('.resize-handle-left');
         var rightHandle = popup.querySelector('.resize-handle-right');
         var editingId = null;
@@ -95,6 +96,16 @@ if (!window.commentsInitialized) {
         var typingUsers = {};
         var typingTimers = {};
         var typingTimeout = null;
+
+        if (privateCheckbox) {
+            privateCheckbox.addEventListener('change', function() {
+                if (presenceSubscription && privateCheckbox.checked) {
+                    presenceSubscription.perform('stopped_typing');
+                }
+                clearTimeout(typingTimeout);
+                typingTimeout = null;
+            });
+        }
 
         var resizing = null;
         var resizeStartX = 0;
@@ -337,6 +348,12 @@ if (!window.commentsInitialized) {
             }
             textarea.addEventListener('input', function() {
                 if (!presenceSubscription) return;
+                if (privateCheckbox && privateCheckbox.checked) {
+                    presenceSubscription.perform('stopped_typing');
+                    clearTimeout(typingTimeout);
+                    typingTimeout = null;
+                    return;
+                }
                 presenceSubscription.perform('typing');
                 clearTimeout(typingTimeout);
                 typingTimeout = setTimeout(function() {
@@ -350,7 +367,7 @@ if (!window.commentsInitialized) {
                 }
             });
             textarea.addEventListener('blur', function() {
-                if (presenceSubscription) { presenceSubscription.perform('stopped_typing'); }
+                if (presenceSubscription && (!privateCheckbox || !privateCheckbox.checked)) { presenceSubscription.perform('stopped_typing'); }
                 clearTimeout(typingTimeout);
                 typingTimeout = null;
                 popup.style.bottom = '';
@@ -481,7 +498,7 @@ if (!window.commentsInitialized) {
 
             form.onsubmit = function(e) {
                 e.preventDefault();
-                if (presenceSubscription) { presenceSubscription.perform('stopped_typing'); }
+                if (presenceSubscription && (!privateCheckbox || !privateCheckbox.checked)) { presenceSubscription.perform('stopped_typing'); }
                 clearTimeout(typingTimeout);
                 typingTimeout = null;
                 var formData = new FormData(form);

--- a/app/javascript/comments.js
+++ b/app/javascript/comments.js
@@ -87,7 +87,6 @@ if (!window.commentsInitialized) {
         var submitBtn = form.querySelector('button[type="submit"]');
         var textarea = form.querySelector('textarea');
         var privateCheckbox = form.querySelector('#comment-private');
-        var privatePrompt = document.getElementById('private-comment-prompt');
         var leftHandle = popup.querySelector('.resize-handle-left');
         var rightHandle = popup.querySelector('.resize-handle-right');
         var editingId = null;
@@ -98,15 +97,6 @@ if (!window.commentsInitialized) {
         var typingTimers = {};
         var typingTimeout = null;
 
-        function updatePrivatePrompt() {
-            if (!privatePrompt) return;
-            if (isMobile() && privateCheckbox && privateCheckbox.checked) {
-                privatePrompt.style.display = 'block';
-            } else {
-                privatePrompt.style.display = 'none';
-            }
-        }
-
         if (privateCheckbox) {
             privateCheckbox.addEventListener('change', function() {
                 if (presenceSubscription && privateCheckbox.checked) {
@@ -114,12 +104,8 @@ if (!window.commentsInitialized) {
                 }
                 clearTimeout(typingTimeout);
                 typingTimeout = null;
-                updatePrivatePrompt();
             });
         }
-
-        updatePrivatePrompt();
-        window.addEventListener('resize', updatePrivatePrompt);
 
         var resizing = null;
         var resizeStartX = 0;
@@ -508,7 +494,6 @@ if (!window.commentsInitialized) {
             function resetForm() {
                 form.reset();
                 editingId = null;
-                updatePrivatePrompt();
             }
 
             form.onsubmit = function(e) {

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -3,6 +3,9 @@
     <%= render AvatarComponent.new(user: comment.user, size: 20, classes: 'avatar comment-avatar') %>
     <strong><%= comment.user&.display_name || t('comments.gemini') %></strong>
     <span>· <%= t('datetime.ago', time: time_ago_in_words(comment.created_at)) %></span>
+    <% if comment.private? %>
+      <span class="private-label">[<%= t('comments.private') %>]</span>
+    <% end %>
     <div class="comment-action-container" data-comment-target="actions" style="display: none;">
       <button class="convert-comment-btn" data-comment-id="<%= comment.id %>" title="<%= t('comments.convert_to_creative') %>">
         <%= t('comments.convert_button') %>

--- a/app/views/comments/_comments_popup.html.erb
+++ b/app/views/comments/_comments_popup.html.erb
@@ -18,4 +18,5 @@
     <label><input type="checkbox" id="comment-private" name="comment[private]" /> <%= t('comments.private') %></label>
     <button class="creative-action-btn" type="submit"><%= svg_tag 'send.svg', class: 'send-icon' %></button>
   </form>
+  <div id="private-comment-prompt" class="private-comment-prompt"><%= t('comments.private_prompt') %></div>
 </div>

--- a/app/views/comments/_comments_popup.html.erb
+++ b/app/views/comments/_comments_popup.html.erb
@@ -15,6 +15,7 @@
   <div id="typing-indicator"></div>
   <form id="new-comment-form" style="display:none;">
     <textarea name="comment[content]" rows="2" required></textarea>
+    <label><input type="checkbox" id="comment-private" name="comment[private]" /> <%= t('comments.private') %></label>
     <button class="creative-action-btn" type="submit"><%= svg_tag 'send.svg', class: 'send-icon' %></button>
   </form>
 </div>

--- a/app/views/comments/_comments_popup.html.erb
+++ b/app/views/comments/_comments_popup.html.erb
@@ -18,5 +18,4 @@
     <label><input type="checkbox" id="comment-private" name="comment[private]" /> <%= t('comments.private') %></label>
     <button class="creative-action-btn" type="submit"><%= svg_tag 'send.svg', class: 'send-icon' %></button>
   </form>
-  <div id="private-comment-prompt" class="private-comment-prompt"><%= t('comments.private_prompt') %></div>
 </div>

--- a/config/locales/comments.en.yml
+++ b/config/locales/comments.en.yml
@@ -16,3 +16,4 @@ en:
     convert_to_creative: "Convert to Creative"
     convert_confirm: "This will add the comment content as a child creative of the current creative. Continue?"
     private: "Private"
+    private_prompt: "This message will only be visible to you."

--- a/config/locales/comments.en.yml
+++ b/config/locales/comments.en.yml
@@ -15,3 +15,4 @@ en:
     convert_button: "Convert"
     convert_to_creative: "Convert to Creative"
     convert_confirm: "This will add the comment content as a child creative of the current creative. Continue?"
+    private: "Private"

--- a/config/locales/comments.en.yml
+++ b/config/locales/comments.en.yml
@@ -16,4 +16,3 @@ en:
     convert_to_creative: "Convert to Creative"
     convert_confirm: "This will add the comment content as a child creative of the current creative. Continue?"
     private: "Private"
-    private_prompt: "This message will only be visible to you."

--- a/config/locales/comments.ko.yml
+++ b/config/locales/comments.ko.yml
@@ -15,3 +15,4 @@ ko:
     convert_button: "전환"
     convert_to_creative: "하위 크리에이티브로 전환"
     convert_confirm: "현재 크리에이티브 하위에 해당 댓글의 내용이 추가됩니다. 진행하시겠습니까?"
+    private: "비밀"

--- a/config/locales/comments.ko.yml
+++ b/config/locales/comments.ko.yml
@@ -16,3 +16,4 @@ ko:
     convert_to_creative: "하위 크리에이티브로 전환"
     convert_confirm: "현재 크리에이티브 하위에 해당 댓글의 내용이 추가됩니다. 진행하시겠습니까?"
     private: "비밀"
+    private_prompt: "이 메시지는 작성자에게만 보입니다."

--- a/config/locales/comments.ko.yml
+++ b/config/locales/comments.ko.yml
@@ -16,4 +16,3 @@ ko:
     convert_to_creative: "하위 크리에이티브로 전환"
     convert_confirm: "현재 크리에이티브 하위에 해당 댓글의 내용이 추가됩니다. 진행하시겠습니까?"
     private: "비밀"
-    private_prompt: "이 메시지는 작성자에게만 보입니다."

--- a/db/migrate/20250910000000_add_private_to_comments.rb
+++ b/db/migrate/20250910000000_add_private_to_comments.rb
@@ -1,0 +1,5 @@
+class AddPrivateToComments < ActiveRecord::Migration[7.0]
+  def change
+    add_column :comments, :private, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_02_025423) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_10_000000) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
     t.text "body"
@@ -81,6 +81,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_02_025423) do
     t.text "content", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "private", default: false, null: false
     t.index ["creative_id"], name: "index_comments_on_creative_id"
     t.index ["user_id"], name: "index_comments_on_user_id"
   end

--- a/spec/requests/comments_private_spec.rb
+++ b/spec/requests/comments_private_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+require 'ostruct'
+
+RSpec.describe 'Private comments', type: :request do
+  let(:user1) { User.create!(email: 'user1@example.com', password: 'pw', name: 'User1') }
+  let(:user2) { User.create!(email: 'user2@example.com', password: 'pw', name: 'User2') }
+  let(:creative) { Creative.create!(user: user1, description: 'Some creative') }
+
+  before do
+    allow_any_instance_of(CommentsController).to receive(:require_authentication).and_return(true)
+  end
+
+  it 'only shows private comments to their author' do
+    creative.comments.create!(user: user1, content: 'public')
+    creative.comments.create!(user: user1, content: 'secret', private: true)
+
+    allow(Current).to receive(:user).and_return(user1)
+    get "/creatives/#{creative.id}/comments"
+    expect(response.body).to include('public')
+    expect(response.body).to include('secret')
+
+    allow(Current).to receive(:user).and_return(user2)
+    get "/creatives/#{creative.id}/comments"
+    expect(response.body).to include('public')
+    expect(response.body).not_to include('secret')
+  end
+end


### PR DESCRIPTION
## Summary
- allow marking comments as private to show only to the author
- hide typing indicator when composing a private message
- add regression test for private comment visibility

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: Unable to obtain chromedriver)*

------
https://chatgpt.com/codex/tasks/task_e_68bfe05600e48326a695d1dee4d76bbe