### PR TITLE
feat: submit comments popup on shift enter

### DIFF
--- a/app/javascript/comments.js
+++ b/app/javascript/comments.js
@@ -346,6 +346,16 @@ if (!window.commentsInitialized) {
                     if (presenceSubscription) { presenceSubscription.perform('stopped_typing'); }
                 }, 3000);
             });
+            textarea.addEventListener('keydown', function(e) {
+                if (e.key === 'Enter' && e.shiftKey) {
+                    e.preventDefault();
+                    if (form.requestSubmit) {
+                        form.requestSubmit(submitBtn);
+                    } else {
+                        submitBtn.click();
+                    }
+                }
+            });
             textarea.addEventListener('focus', function() {
                 adjustForKeyboard();
                 if (window.visualViewport) {


### PR DESCRIPTION
## Summary
- allow users to send comments from the popup with Shift+Enter

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec spec/system/creative_inline_edit_spec.rb:21` *(fails: Unable to obtain chromedriver)*

------
https://chatgpt.com/codex/tasks/task_e_68bff7b3cc2c83268fd0233706994bce