### PR TITLE
Add cancel button and privacy auto-check in comment editor

### DIFF
--- a/app/assets/stylesheets/comments_popup.css
+++ b/app/assets/stylesheets/comments_popup.css
@@ -55,6 +55,12 @@
   float: right;
 }
 
+#new-comment-form #cancel-edit-btn {
+  margin-top: 0.5em;
+  float: right;
+  margin-right: 0.5em;
+}
+
 .comment-item {
     border-top: 1px solid var(--color-border);
     padding: 0.5em 0 1.5em 0;

--- a/app/javascript/comments.js
+++ b/app/javascript/comments.js
@@ -90,6 +90,7 @@ if (!window.commentsInitialized) {
         var defaultSubmitBtnHTML = submitBtn.innerHTML;
         var textarea = form.querySelector('textarea');
         var privateCheckbox = form.querySelector('#comment-private');
+        var cancelBtn = form.querySelector('#cancel-edit-btn');
         var leftHandle = popup.querySelector('.resize-handle-left');
         var rightHandle = popup.querySelector('.resize-handle-right');
         var editingId = null;
@@ -107,6 +108,12 @@ if (!window.commentsInitialized) {
                 }
                 clearTimeout(typingTimeout);
                 typingTimeout = null;
+            });
+        }
+
+        if (cancelBtn) {
+            cancelBtn.addEventListener('click', function() {
+                resetForm();
             });
         }
 
@@ -508,6 +515,7 @@ if (!window.commentsInitialized) {
                 form.reset();
                 editingId = null;
                 submitBtn.innerHTML = defaultSubmitBtnHTML;
+                if (cancelBtn) { cancelBtn.style.display = 'none'; }
             }
 
             form.onsubmit = function(e) {
@@ -572,6 +580,11 @@ if (!window.commentsInitialized) {
                     editingId = btn.getAttribute('data-comment-id');
                     textarea.value = btn.getAttribute('data-comment-content');
                     submitBtn.textContent = popup.dataset.updateCommentText;
+                    if (privateCheckbox) {
+                        privateCheckbox.checked = btn.getAttribute('data-comment-private') === 'true';
+                        privateCheckbox.dispatchEvent(new Event('change'));
+                    }
+                    if (cancelBtn) { cancelBtn.style.display = ''; }
                     textarea.focus();
                 }
             });

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -10,7 +10,7 @@
       <button class="convert-comment-btn" data-comment-id="<%= comment.id %>" title="<%= t('comments.convert_to_creative') %>">
         <%= t('comments.convert_button') %>
       </button>
-      <button class="edit-comment-btn" data-comment-id="<%= comment.id %>" data-comment-content="<%= comment.content %>" title="<%= t('comments.update_comment') %>">
+      <button class="edit-comment-btn" data-comment-id="<%= comment.id %>" data-comment-content="<%= comment.content %>" data-comment-private="<%= comment.private? %>" title="<%= t('comments.update_comment') %>">
         <%= t('comments.edit_button') %>
       </button>
       <button class="delete-comment-btn" data-comment-id="<%= comment.id %>" title="<%= t('comments.delete') %>">

--- a/app/views/comments/_comments_popup.html.erb
+++ b/app/views/comments/_comments_popup.html.erb
@@ -17,5 +17,6 @@
     <textarea name="comment[content]" rows="2" required></textarea>
     <label><input type="checkbox" id="comment-private" name="comment[private]" /> <%= t('comments.private') %></label>
     <button class="creative-action-btn" type="submit"><%= svg_tag 'send.svg', class: 'send-icon' %></button>
+    <button class="creative-action-btn" id="cancel-edit-btn" type="button" style="display:none;"><%= t('app.cancel') %></button>
   </form>
 </div>


### PR DESCRIPTION
## Summary
- Auto-check the private box when editing a private comment
- Add cancel button for comment editing with styles and reset handling

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: Selenium manager cannot download Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_68bffe490ad4832698fe04ee44c6fd18