### PR TITLE
Restrict Creative deletion to admin role

### DIFF
--- a/app/controllers/creatives_controller.rb
+++ b/app/controllers/creatives_controller.rb
@@ -212,7 +212,7 @@ class CreativesController < ApplicationController
 
   def destroy
     parent = @creative.parent
-    unless @creative.has_permission?(Current.user, :write)
+    unless @creative.has_permission?(Current.user, :admin)
       redirect_to @creative, alert: t("creatives.errors.no_permission") and return
     end
     if params[:delete_with_children]
@@ -399,7 +399,7 @@ class CreativesController < ApplicationController
 
     # Recursively destroy all descendants the user can delete
     def destroy_descendants_recursively(creative, user)
-      deletable_children = creative.children_with_permission(user, :write)
+      deletable_children = creative.children_with_permission(user, :admin)
       deletable_children.each do |child|
         destroy_descendants_recursively(child, user)
         CreativeShare.where(creative: child).destroy_all

--- a/app/models/creative_share.rb
+++ b/app/models/creative_share.rb
@@ -6,7 +6,8 @@ class CreativeShare < ApplicationRecord
     no_access: 0,
     read: 1,
     feedback: 2,
-    write: 3
+    write: 3,
+    admin: 4
   }
 
   validates :creative_id, presence: true

--- a/app/views/creatives/_share_button.html.erb
+++ b/app/views/creatives/_share_button.html.erb
@@ -18,6 +18,7 @@
           <option value="read"><%= t('creatives.index.permission_read') %></option>
           <option value="feedback"><%= t('creatives.index.permission_feedback') %></option>
           <option value="write"><%= t('creatives.index.permission_write') %></option>
+          <option value="admin"><%= t('creatives.index.permission_admin') %></option>
         </select>
       </div>
       <button type="submit" class="btn btn-primary" data-share-invite-target="submit" data-share="<%= t('creatives.index.share') %>" data-invite="<%= t('creatives.index.invite') %>"><%= t('creatives.index.share') %></button>

--- a/app/views/creatives/index.html.erb
+++ b/app/views/creatives/index.html.erb
@@ -25,7 +25,9 @@
   <button id="set-plan-btn" class="set-plan-btn" style="display:none;"><%= t('app.set_plan') %></button>
   <input type="checkbox" id="select-all-creatives" style="display:none;vertical-align:middle;" />
   <button id="select-creative-btn" class="select-btn" data-select-text="<%= t('app.select') %>" data-cancel-text="<%= t('app.cancel_select') %>"><%= t('app.select') %></button>
-  <button id="delete-selection-btn" class="danger-link" style="display:none;" data-confirm="<%= t('creatives.index.are_you_sure_delete_selection') %>"><%= t('creatives.index.delete_selection') %></button>
+  <% if (@parent_creative || @creative)&.has_permission?(Current.user, :admin) %>
+    <button id="delete-selection-btn" class="danger-link" style="display:none;" data-confirm="<%= t('creatives.index.are_you_sure_delete_selection') %>"><%= t('creatives.index.delete_selection') %></button>
+  <% end %>
   <button id="expand-all-btn" class="expand-btn" style="width: 36px;" data-expand-text="<%= t('app.expand_all') %>" data-collapse-text="<%= t('app.collapse_all') %>" ><span aria-hidden="true">▼</span></button>
   <button id="toggle-edit-btn" class="edit-toggle-btn mobile-only" aria-label="<%= t('.edit') %>" title="<%= t('.edit') %>">
     <span aria-hidden="true"><%= svg_tag 'edit.svg', class: 'icon-edit', width: 16, height: 16 %></span></button>

--- a/config/locales/creatives.en.yml
+++ b/config/locales/creatives.en.yml
@@ -44,6 +44,7 @@ en:
       permission_write: "Write"
       permission_feedback: "Feedback"
       permission_no_access: "No access"
+      permission_admin: "Admin"
       share: "Share"
       invite: "Invite"
       invite_link: "Invite Link"

--- a/config/locales/creatives.ko.yml
+++ b/config/locales/creatives.ko.yml
@@ -44,6 +44,7 @@ ko:
       permission_write: "쓰기"
       permission_feedback: "피드백"
       permission_no_access: "접근 금지"
+      permission_admin: "관리자"
       share: "공유하기"
       invite: "초대하기"
       invite_link: "초대 링크"

--- a/db/migrate/20250910105640_migrate_write_permissions_to_admin.rb
+++ b/db/migrate/20250910105640_migrate_write_permissions_to_admin.rb
@@ -1,0 +1,17 @@
+class MigrateWritePermissionsToAdmin < ActiveRecord::Migration[8.0]
+  def up
+    write = CreativeShare.permissions[:write]
+    admin = CreativeShare.permissions[:admin]
+
+    CreativeShare.where(permission: write).update_all(permission: admin)
+    Invitation.where(permission: write).update_all(permission: admin)
+  end
+
+  def down
+    write = CreativeShare.permissions[:write]
+    admin = CreativeShare.permissions[:admin]
+
+    CreativeShare.where(permission: admin).update_all(permission: write)
+    Invitation.where(permission: admin).update_all(permission: write)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_10_000000) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_10_105640) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
     t.text "body"


### PR DESCRIPTION
## Summary
- add new `admin` permission level
- require admin permission to delete creatives
- migrate existing `write` shares and invitations to `admin`

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: error sending request for url (https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json))*
- `bin/rails test`


------
https://chatgpt.com/codex/tasks/task_e_68c0070ff58c8326a02bbe42be862c3f