### PR TITLE
Enable caption editing in slide view

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -35,7 +35,11 @@ class CommentsController < ApplicationController
     @comment.content = "#{@comment.content}\n\n#{response}" if response.present?
     if @comment.save
       trigger_gemini_response(@comment) if @comment.content.match?(/\A@gemini\b/i)
-      render partial: "comments/comment", locals: { comment: @comment }, status: :created
+      if request.format.json?
+        render json: { id: @comment.id, content: @comment.content }, status: :created
+      else
+        render partial: "comments/comment", locals: { comment: @comment }, status: :created
+      end
     else
       render json: { errors: @comment.errors.full_messages }, status: :unprocessable_entity
     end
@@ -44,7 +48,11 @@ class CommentsController < ApplicationController
   def update
     if @comment.user == Current.user
       if @comment.update(comment_params)
-        render partial: "comments/comment", locals: { comment: @comment }
+        if request.format.json?
+          render json: { id: @comment.id, content: @comment.content }
+        else
+          render partial: "comments/comment", locals: { comment: @comment }
+        end
       else
         render json: { errors: @comment.errors.full_messages }, status: :unprocessable_entity
       end

--- a/app/controllers/creatives_controller.rb
+++ b/app/controllers/creatives_controller.rb
@@ -104,7 +104,8 @@ class CreativesController < ApplicationController
           parent_id: @creative.parent_id,
           progress: @creative.progress,
           depth: depth,
-          prompt: @creative.prompt_for(Current.user)
+          prompt: @creative.prompt_for(Current.user),
+          prompt_comment_id: @creative.prompt_comment_for(Current.user)&.id
         }
       end
     end

--- a/app/models/creative.rb
+++ b/app/models/creative.rb
@@ -122,12 +122,16 @@ class Creative < ApplicationRecord
     end
   end
 
-  def prompt_for(user)
+  def prompt_comment_for(user)
     comments
       .where(private: true, user: user)
       .where("content LIKE ?", "> %")
       .order(created_at: :desc)
       .first
+  end
+
+  def prompt_for(user)
+    prompt_comment_for(user)
       &.content
       &.sub(/\A>\s*/i, "")
   end

--- a/app/views/creatives/slide_view.html.erb
+++ b/app/views/creatives/slide_view.html.erb
@@ -7,7 +7,8 @@
              end %>
 <% initial_index = params[:slide].to_i.clamp(0, @slide_ids.length - 1) %>
 <% initial_prompt = @creative.prompt_for(Current.user) %>
-<div id="slide-view" data-slide-ids="<%= @slide_ids.join(',') %>" data-initial-index="<%= initial_index %>" data-root-id="<%= @creative.id %>">
+<% initial_prompt_id = @creative.prompt_comment_for(Current.user)&.id %>
+<div id="slide-view" data-slide-ids="<%= @slide_ids.join(',') %>" data-initial-index="<%= initial_index %>" data-root-id="<%= @creative.id %>" data-initial-prompt-id="<%= initial_prompt_id %>">
   <div id="slide-content"><%= content_tag(tag_name, @creative.effective_description.html_safe) %></div>
 </div>
 <div id="slide-controls">
@@ -16,4 +17,10 @@
 </div>
 <div id="slide-swipe">
   <div id="slide-caption"><%= initial_prompt %></div>
+</div>
+
+<div id="caption-popup" class="popup-box" style="display:none;">
+  <button id="close-caption-btn" class="popup-close-btn">&times;</button>
+  <div id="caption-display"></div>
+  <textarea id="caption-input" style="display:none;"></textarea>
 </div>

--- a/app/views/layouts/slide.html.erb
+++ b/app/views/layouts/slide.html.erb
@@ -7,6 +7,7 @@
     <%= csp_meta_tag %>
     <%= stylesheet_link_tag :app, "data-turbo-track": "reload" %>
     <%= stylesheet_link_tag 'slide_view', media: 'all' %>
+    <%= stylesheet_link_tag 'popup', media: 'all' %>
     <%= javascript_include_tag 'actioncable', defer: true %>
     <%= javascript_include_tag 'slide_view', defer: true %>
   </head>

--- a/spec/models/creative_prompt_spec.rb
+++ b/spec/models/creative_prompt_spec.rb
@@ -9,6 +9,11 @@ RSpec.describe Creative, type: :model do
     expect(creative.prompt_for(user)).to eq('Hello world')
   end
 
+  it 'returns comment for prompt_comment_for' do
+    comment = creative.comments.create!(user: user, content: '> Hi', private: true)
+    expect(creative.prompt_comment_for(user)).to eq(comment)
+  end
+
   it 'returns nil when no prompt' do
     expect(creative.prompt_for(user)).to be_nil
   end


### PR DESCRIPTION
## Summary
- Allow slides to expose and edit private caption comments via keyboard shortcuts
- Store captions as private comments beginning with "> " and update existing ones
- Support JSON comment responses and expose caption comment id in creative JSON

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec spec/models/creative_prompt_spec.rb spec/requests/creative_prompt_spec.rb`
- `bundle exec rspec` *(fails: Unable to obtain chromedriver)*

------
https://chatgpt.com/codex/tasks/task_e_68c007ed4a5483268b851b1250368f26