### PR TITLE
feat: add creative link popup search

### DIFF
--- a/app/assets/stylesheets/popup.css
+++ b/app/assets/stylesheets/popup.css
@@ -49,7 +49,12 @@
 }
 
 #link-creative-results li:hover {
-  border-color: var(--color-border);
+  background-color: var(--color-border);
+}
+
+#link-creative-results li:focus {
+  background-color: var(--color-border);
+  outline: none;
 }
 
 .popup-close-btn {

--- a/app/assets/stylesheets/popup.css
+++ b/app/assets/stylesheets/popup.css
@@ -35,6 +35,12 @@
   margin-right: 0.4em;
 }
 
+#link-creative-modal .popup-box {
+  width: 90vw;
+  max-width: 90vw;
+  min-width: 320px;
+}
+
 #link-creative-results li {
   cursor: pointer;
   padding: 0.25em 0.5em;

--- a/app/assets/stylesheets/popup.css
+++ b/app/assets/stylesheets/popup.css
@@ -35,6 +35,17 @@
   margin-right: 0.4em;
 }
 
+#link-creative-results li {
+  cursor: pointer;
+  padding: 0.25em 0.5em;
+  border: 1px solid transparent;
+  border-radius: 4px;
+}
+
+#link-creative-results li:hover {
+  border-color: var(--color-border);
+}
+
 .popup-close-btn {
   position: absolute;
   top: 0.5em;

--- a/app/javascript/creative_row_editor.js
+++ b/app/javascript/creative_row_editor.js
@@ -419,15 +419,15 @@ if (!window.creativeRowEditorInitialized) {
               const li = document.createElement('li');
               li.textContent = c.description;
               li.dataset.id = c.id;
+              li.tabIndex = 0;
+              li.setAttribute('role', 'button');
               linkResults.appendChild(li);
             });
           }
         });
     }
 
-    function handleLinkResultClick(e) {
-      const li = e.target.closest('li');
-      if (!li) return;
+    function linkCreativeFromLi(li) {
       const fd = new FormData();
       fd.append('creative[parent_id]', form.dataset.creativeId);
       fd.append('creative[origin_id]', li.dataset.id);
@@ -441,6 +441,20 @@ if (!window.creativeRowEditorInitialized) {
         closeLinkModal();
         refreshChildren(currentTree).then(() => refreshRow(currentTree));
       });
+    }
+
+    function handleLinkResultClick(e) {
+      const li = e.target.closest('li');
+      if (!li) return;
+      linkCreativeFromLi(li);
+    }
+
+    function handleLinkResultKeydown(e) {
+      if (e.key !== 'Enter') return;
+      const li = e.target.closest('li');
+      if (!li) return;
+      e.preventDefault();
+      linkCreativeFromLi(li);
     }
 
     function startNew(parentId, container, insertBefore, beforeId = '', afterId = '', childId = '') {
@@ -630,6 +644,7 @@ if (!window.creativeRowEditorInitialized) {
 
       if (linkResults) {
         linkResults.addEventListener('click', handleLinkResultClick);
+        linkResults.addEventListener('keydown', handleLinkResultKeydown);
       }
 
       if (linkCloseBtn && linkModal) {

--- a/app/javascript/creative_row_editor.js
+++ b/app/javascript/creative_row_editor.js
@@ -419,7 +419,6 @@ if (!window.creativeRowEditorInitialized) {
               const li = document.createElement('li');
               li.textContent = c.description;
               li.dataset.id = c.id;
-              li.style.cursor = 'pointer';
               linkResults.appendChild(li);
             });
           }

--- a/app/views/creatives/_inline_edit_form.html.erb
+++ b/app/views/creatives/_inline_edit_form.html.erb
@@ -54,7 +54,7 @@
 </div>
 
 <div id="link-creative-modal" style="display:none;position:fixed;top:0;left:0;width:100vw;height:100vh;z-index:1000;align-items:center;justify-content:center;">
-  <div class="popup-box" style="min-width:320px;max-width:90vw;">
+  <div class="popup-box">
     <button type="button" id="close-link-creative-modal" class="popup-close-btn">&times;</button>
     <h2><%= t('creatives.index.link', default: 'Link') %></h2>
     <input type="text" id="link-creative-search" style="width:100%;margin-bottom:0.5em;" placeholder="<%= t('creatives.index.search_placeholder', default: 'Search creative') %>">

--- a/app/views/creatives/_inline_edit_form.html.erb
+++ b/app/views/creatives/_inline_edit_form.html.erb
@@ -52,3 +52,12 @@
     <select id="parent-suggestions" size="5" style="display:none;margin-top:0.5em;width:100%;"></select>
   </form>
 </div>
+
+<div id="link-creative-modal" style="display:none;position:fixed;top:0;left:0;width:100vw;height:100vh;z-index:1000;align-items:center;justify-content:center;">
+  <div class="popup-box" style="min-width:320px;max-width:90vw;">
+    <button type="button" id="close-link-creative-modal" class="popup-close-btn">&times;</button>
+    <h2><%= t('creatives.index.link', default: 'Link') %></h2>
+    <input type="text" id="link-creative-search" style="width:100%;margin-bottom:0.5em;" placeholder="<%= t('creatives.index.search_placeholder', default: 'Search creative') %>">
+    <ul id="link-creative-results" style="list-style:none;padding:0;margin:0;max-height:300px;overflow-y:auto;"></ul>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- replace prompt-based creative linking with popup search modal
- search existing creatives and select from results to link

## Testing
- `./bin/rubocop -a`
- `bundle exec rspec` *(fails: error sending request for url (https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json))*

------
https://chatgpt.com/codex/tasks/task_e_68c0c1285b088326aca73285a070d331