### PR TITLE
Display creative snippet in comment notifications

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -106,7 +106,7 @@ class Comment < ApplicationRecord
   end
 
   def creative_snippet
-    creative.effective_origin.description.to_plain_text.truncate(24, omission: "")
+    creative.effective_origin.description.to_plain_text.truncate(24, omission: "...")
   end
 
   def self.broadcast_badges(creative)

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -85,7 +85,7 @@ class Comment < ApplicationRecord
       create_inbox_item(
         recipient,
         "inbox.comment_added",
-        { user: user.display_name, comment: content }
+        { user: user.display_name, comment: content, creative: creative_snippet }
       )
     end
   end
@@ -96,13 +96,17 @@ class Comment < ApplicationRecord
       create_inbox_item(
         mentioned,
         "inbox.user_mentioned",
-        { user: user.display_name, comment: content }
+        { user: user.display_name, comment: content, creative: creative_snippet }
       )
     end
   end
 
   def assign_default_user
     self.user ||= Current.user
+  end
+
+  def creative_snippet
+    creative.effective_origin.description.to_plain_text.truncate(24, omission: "")
   end
 
   def self.broadcast_badges(creative)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -62,9 +62,9 @@ en:
     delete: "Delete"
     show_read: "Show read"
     no_messages: "No messages"
-    comment_added: "%{user} added \"%{comment}\"."
+    comment_added: "%{user} added \"%{comment}\" to \"%{creative}\"."
     creative_shared: "%{user} shared \"%{short_title}\"."
-    user_mentioned: "%{user} mentioned you: \"%{comment}\""
+    user_mentioned: "%{user} mentioned you in \"%{creative}\": \"%{comment}\""
     permission_requested: "%{user} requested access to \"%{short_title}\"."
 
   inbox_mailer:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -33,9 +33,9 @@ ko:
     delete: "삭제"
     show_read: "읽은 메세지 포함"
     no_messages: "메세지가 없습니다"
-    comment_added: "%{user} 가 \"%{comment}\" 를 추가했습니다."
+    comment_added: "%{user} 가 \"%{comment}\" 를 \"%{creative}\" 에 추가했습니다."
     creative_shared: "%{user} 가 \"%{short_title}\" 을 공유했습니다."
-    user_mentioned: "%{user} 님이 당신을 언급했습니다: \"%{comment}\""
+    user_mentioned: "%{user} 님이 \"%{creative}\" 에서 당신을 언급했습니다: \"%{comment}\""
     permission_requested: "%{user} 이 크리에이티브 \"%{short_title}\" 에 대한 권한 요청을 했습니다."
 
   inbox_mailer:

--- a/db/migrate/20250911084338_backfill_creative_in_comment_inbox_items.rb
+++ b/db/migrate/20250911084338_backfill_creative_in_comment_inbox_items.rb
@@ -1,0 +1,24 @@
+class BackfillCreativeInCommentInboxItems < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def up
+    InboxItem.where(message_key: [ "inbox.comment_added", "inbox.user_mentioned" ]).find_each do |item|
+      params = item.message_params || {}
+      next if params["creative"].present?
+
+      comment_id = item.link.to_s[%r{/comments/(\d+)}, 1]
+      next unless comment_id
+
+      comment = Comment.find_by(id: comment_id)
+      next unless comment
+
+      snippet = comment.creative.effective_origin.description.to_plain_text.truncate(24, omission: "")
+      params["creative"] = snippet
+      item.update_columns(message_params: params)
+    end
+  end
+
+  def down
+    # no-op
+  end
+end

--- a/db/migrate/20250911084338_backfill_creative_in_comment_inbox_items.rb
+++ b/db/migrate/20250911084338_backfill_creative_in_comment_inbox_items.rb
@@ -1,4 +1,4 @@
-class BackfillCreativeInCommentInboxItems < ActiveRecord::Migration[7.0]
+class BackfillCreativeInCommentInboxItems < ActiveRecord::Migration[8.0]
   disable_ddl_transaction!
 
   def up
@@ -10,10 +10,13 @@ class BackfillCreativeInCommentInboxItems < ActiveRecord::Migration[7.0]
       next unless comment_id
 
       comment = Comment.find_by(id: comment_id)
-      next unless comment
+      if comment.blank? || comment.creative.blank?
+        params["creative"] = ""
+      else
+        snippet = comment.creative_snippet
+        params["creative"] = snippet
+      end
 
-      snippet = comment.creative.effective_origin.description.to_plain_text.truncate(24, omission: "")
-      params["creative"] = snippet
       item.update_columns(message_params: params)
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_10_105640) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_11_084338) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
     t.text "body"

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -16,6 +16,7 @@ class CommentTest < ActiveSupport::TestCase
       item = InboxItem.where(owner: recipient).last
       assert_equal "inbox.comment_added", item.message_key
       assert_includes item.localized_message, commenter.name
+      assert_includes item.localized_message, creative.description.to_plain_text
     end
   end
 


### PR DESCRIPTION
## Summary
- include first 24 characters of creative description in comment alert notifications
- localize notifications to mention the creative
- test notification now includes creative description

## Testing
- `./bin/rubocop -a`
- `bundle exec rails test`


------
https://chatgpt.com/codex/tasks/task_e_68c12f6663488326a6319d494f960413