### PR TITLE
Ensure comment send button works with mobile keyboards

### DIFF
--- a/app/javascript/comments.js
+++ b/app/javascript/comments.js
@@ -87,7 +87,7 @@ if (!window.commentsInitialized) {
         var form = document.getElementById('new-comment-form');
         var participants = document.getElementById('comment-participants');
         var typingIndicator = document.getElementById('typing-indicator');
-        var submitBtn = form.querySelector('button[type="submit"]');
+        var submitBtn = form.querySelector('#submit-comment-btn');
         var defaultSubmitBtnHTML = submitBtn.innerHTML;
         var textarea = form.querySelector('textarea');
         var privateCheckbox = form.querySelector('#comment-private');
@@ -102,6 +102,15 @@ if (!window.commentsInitialized) {
         var typingTimers = {};
         var typingTimeout = null;
         var hasPresenceConnected = false;
+
+        submitBtn.addEventListener('click', function(e) {
+            e.preventDefault();
+            if (form.requestSubmit) {
+                form.requestSubmit();
+            } else {
+                form.dispatchEvent(new Event('submit', { cancelable: true }));
+            }
+        });
 
         if (privateCheckbox) {
             privateCheckbox.addEventListener('change', function() {
@@ -383,11 +392,7 @@ if (!window.commentsInitialized) {
             textarea.addEventListener('keydown', function(e) {
                 if (e.key === 'Enter' && e.shiftKey) {
                     e.preventDefault();
-                    if (form.requestSubmit) {
-                        form.requestSubmit(submitBtn);
-                    } else {
-                        submitBtn.click();
-                    }
+                    submitBtn.click();
                 }
             });
             textarea.addEventListener('focus', function() {

--- a/app/views/comments/_comments_popup.html.erb
+++ b/app/views/comments/_comments_popup.html.erb
@@ -16,7 +16,7 @@
   <form id="new-comment-form" style="display:none;">
     <textarea name="comment[content]" rows="2" required></textarea>
     <label><input type="checkbox" id="comment-private" name="comment[private]" /> <%= t('comments.private') %></label>
-    <button class="creative-action-btn" type="submit"><%= svg_tag 'send.svg', class: 'send-icon' %></button>
+    <button class="creative-action-btn" id="submit-comment-btn" type="button"><%= svg_tag 'send.svg', class: 'send-icon' %></button>
     <button class="creative-action-btn" id="cancel-edit-btn" type="button" style="display:none;"><%= t('app.cancel') %></button>
   </form>
 </div>

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -1,5 +1,4 @@
 module SystemHelpers
-
   PASSWORD = 'P4ssW0rd!'
 
   def sign_in(user)

--- a/spec/system/creative_inline_edit_spec.rb
+++ b/spec/system/creative_inline_edit_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe 'Creative inline editing', type: :system, js: true do
   end
 
   it 'shows saved row when starting another addition' do
-
     find("#creative-#{root_creative.id}").hover
     find("#creative-#{root_creative.id} .edit-inline-btn").click
     find('#inline-add-child').click
@@ -44,7 +43,6 @@ RSpec.describe 'Creative inline editing', type: :system, js: true do
   end
 
   it 'supports keyboard shortcuts for add and close' do
-
     find("#creative-#{root_creative.id}").hover
     find("#creative-#{root_creative.id} .edit-inline-btn").click
     find('trix-editor').send_keys([ :alt, :enter ])


### PR DESCRIPTION
## Summary
- Prevent the soft keyboard from absorbing the first tap by changing the comment send button to `type="button"`
- Add a JavaScript click handler that submits the form programmatically so messages send immediately, and adjust key handler
- RuboCop auto-corrected minor style issues in test files

## Testing
- `./bin/rubocop`
- `rails test`
- `./bin/bundle exec rspec --exclude-pattern "spec/system/**/*"`


------
https://chatgpt.com/codex/tasks/task_e_68c22b6579d48326bc83edf3b1c559f2