### PR TITLE
Fix duplicate chat message submissions

### DIFF
--- a/app/javascript/comments.js
+++ b/app/javascript/comments.js
@@ -528,9 +528,11 @@ if (!window.commentsInitialized) {
                 if (cancelBtn) { cancelBtn.style.display = 'none'; }
             }
 
+            let sending = false;
             const send = function(e) {
                 e.preventDefault();
-                if (!textarea.value) return;
+                if (sending || !textarea.value) return;
+                sending = true;
                 if (presenceSubscription && (!privateCheckbox || !privateCheckbox.checked)) { presenceSubscription.perform('stopped_typing'); }
                 clearTimeout(typingTimeout);
                 typingTimeout = null;
@@ -551,7 +553,8 @@ if (!window.commentsInitialized) {
                         resetForm();
                         loadInitialComments(editingId);
                     })
-                    .catch(e => { alert(e.message); });
+                    .catch(e => { alert(e.message); })
+                    .finally(() => { sending = false; });
             }
 
             submitBtn.addEventListener('click', send);


### PR DESCRIPTION
## Summary
- prevent multiple sends by guarding the chat submit handler

## Testing
- `./bin/rubocop -a`
- `rails test`
- `./bin/bundle exec rspec --exclude-pattern "spec/system/**/*"`


------
https://chatgpt.com/codex/tasks/task_e_68c28b227e388326a3e3392660ab62bc