### PR TITLE
Enable editing of creative page title

### DIFF
--- a/app/assets/stylesheets/creatives.css
+++ b/app/assets/stylesheets/creatives.css
@@ -245,6 +245,11 @@
     font-size: 1.3em;
 }
 
+.creative-row-start h1.page-title {
+    margin-left: 0;
+    font-size: 1.4em;
+}
+
 .creative-row-start h2 {
     font-size: 1.2em;
 }

--- a/app/views/creatives/index.html.erb
+++ b/app/views/creatives/index.html.erb
@@ -63,18 +63,13 @@
   <% content_for :head do %>
     <meta property="og:title" content="<%= @parent_creative.effective_origin.description.to_plain_text %>">
   <% end %>
-  <div class="creative-row" id="creative-markdown-block">
+  <%= render CreativeComponent.new(creative: @parent_creative, filtered_children: [], level: 1, select_mode: false, expanded: true) do %>
     <h1 class="page-title" style="display:flex;align-items:center;gap:1em;">
       <div class="creative-content">
         <%= @parent_creative.effective_description %>
       </div>
     </h1>
-    <div>
-      <h1 style="display: flex; align-items: center; gap: 1em;">
-        <%= render_creative_progress(@parent_creative) %>
-      </h1>
-    </div>
-  </div>
+  <% end %>
 <% else %>
   <div class="creative-row" id="creative-markdown-block">
     <h1 class="page-title" style="display:flex;align-items:center;gap:1em;">

--- a/spec/system/creative_inline_edit_spec.rb
+++ b/spec/system/creative_inline_edit_spec.rb
@@ -15,6 +15,22 @@ RSpec.describe 'Creative inline editing', type: :system, js: true do
     visit creatives_path
   end
 
+  it 'allows editing page title and shows actions' do
+    visit creative_path(root_creative)
+
+    find("#creative-#{root_creative.id}").hover
+    expect(page).to have_css("#creative-#{root_creative.id} .edit-inline-btn")
+    expect(page).to have_css("#creative-#{root_creative.id} .comments-btn")
+    expect(page).to have_css("#creative-#{root_creative.id} .creative-progress-incomplete", text: '0%')
+
+    find("#creative-#{root_creative.id} .edit-inline-btn").click
+    find('trix-editor[input="inline-creative-description"]').click.set('Updated Title')
+    find('#inline-close').click
+    wait_for_ajax
+
+    expect(page).to have_css("#creative-#{root_creative.id} .creative-content", text: 'Updated Title')
+  end
+
   it 'shows saved row when starting another addition' do
     find("#creative-#{root_creative.id}").hover
     find("#creative-#{root_creative.id} .edit-inline-btn").click


### PR DESCRIPTION
## Summary
- allow page title to use CreativeComponent with edit button, comments, and progress
- adjust h1 styling for page title within creative row
- test that page title can be edited and shows actions

## Testing
- `./bin/rubocop -a`
- `rails test`
- `./bin/bundle exec rspec --exclude-pattern "spec/system/**/*"`
- `./bin/bundle exec rspec spec/system/creative_inline_edit_spec.rb` *(fails: Unable to obtain chromedriver)*


------
https://chatgpt.com/codex/tasks/task_e_68c3819801288326a188bdccd9337e53