### PR TITLE
Send comments with Enter key

### DIFF
--- a/app/javascript/comments.js
+++ b/app/javascript/comments.js
@@ -381,13 +381,8 @@ if (!window.commentsInitialized) {
                 }, 3000);
             });
             textarea.addEventListener('keydown', function(e) {
-                if (e.key === 'Enter' && e.shiftKey) {
-                    e.preventDefault();
-                    if (form.requestSubmit) {
-                        form.requestSubmit(submitBtn);
-                    } else {
-                        submitBtn.click();
-                    }
+                if (e.key === 'Enter' && !e.shiftKey) {
+                    send(e);
                 }
             });
             textarea.addEventListener('focus', function() {
@@ -562,12 +557,6 @@ if (!window.commentsInitialized) {
             submitBtn.addEventListener('pointerup', (e)=>{ if (e.pointerType !== 'mouse') send(e); });
             submitBtn.addEventListener('touchend', (e)=>{ e.preventDefault(); send(e); }, {passive:false});
 
-            if (isMobile()) { // mobile 에선 쉽프트 엔터킬로 보내는 건 무의미
-                // 키보드의 엔터(‘보내기’ 표시)로도 보낼 수 있게
-                textarea.addEventListener('keydown', (e)=>{
-                    if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); send(e); }
-                });
-            }
             form.onsubmit = send;
             // 이벤트 위임 방식으로 삭제 버튼 처리
             list.addEventListener('click', function(e) {

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -1,5 +1,4 @@
 module SystemHelpers
-
   PASSWORD = 'P4ssW0rd!'
 
   def sign_in(user)

--- a/spec/system/creative_inline_edit_spec.rb
+++ b/spec/system/creative_inline_edit_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe 'Creative inline editing', type: :system, js: true do
   end
 
   it 'shows saved row when starting another addition' do
-
     find("#creative-#{root_creative.id}").hover
     find("#creative-#{root_creative.id} .edit-inline-btn").click
     find('#inline-add-child').click
@@ -44,7 +43,6 @@ RSpec.describe 'Creative inline editing', type: :system, js: true do
   end
 
   it 'supports keyboard shortcuts for add and close' do
-
     find("#creative-#{root_creative.id}").hover
     find("#creative-#{root_creative.id} .edit-inline-btn").click
     find('trix-editor').send_keys([ :alt, :enter ])


### PR DESCRIPTION
## Summary
- Send chat comments when pressing Enter
- Allow Shift+Enter to insert a newline in comment box
- Rubocop auto-correct

## Testing
- `./bin/rubocop -a`
- `rails test`
- `./bin/bundle exec rspec --exclude-pattern "spec/system/**/*"`


------
https://chatgpt.com/codex/tasks/task_e_68c39ee3c33c832680275acb6948c318