### PR TITLE
Append comments without reloading entire list

### DIFF
--- a/app/javascript/comments.js
+++ b/app/javascript/comments.js
@@ -545,8 +545,19 @@ if (!window.commentsInitialized) {
                 })
                     .then(r => r.ok ? r.text() : r.json().then(j => { throw new Error(j.errors.join(', ')); }))
                     .then(html => {
+                        const wasEditing = editingId;
                         resetForm();
-                        loadInitialComments(editingId);
+                        if (wasEditing) {
+                            var existing = document.getElementById(`comment_${wasEditing}`);
+                            if (existing) {
+                                existing.outerHTML = html;
+                            }
+                        } else {
+                            list.insertAdjacentHTML('beforeend', html);
+                            list.scrollTop = list.scrollHeight;
+                        }
+                        renderMarkdown(list);
+                        markCommentsRead();
                     })
                     .catch(e => { alert(e.message); })
                     .finally(() => { sending = false; });


### PR DESCRIPTION
## Summary
- Append newly created comments to the chat list instead of reloading everything
- Replace updated comments inline for smoother editing and mark them as read

## Testing
- `./bin/rubocop -a`
- `rails test`
- `./bin/bundle exec rspec --exclude-pattern "spec/system/**/*"`


------
https://chatgpt.com/codex/tasks/task_e_68c3a1061f2c8326a04106e9822df4b6