### PR TITLE
Fix duplicate chat messages

### DIFF
--- a/app/javascript/comments.js
+++ b/app/javascript/comments.js
@@ -551,12 +551,13 @@ if (!window.commentsInitialized) {
                             var existing = document.getElementById(`comment_${wasEditing}`);
                             if (existing) {
                                 existing.outerHTML = html;
+                                renderMarkdown(list);
                             }
                         } else {
-                            list.insertAdjacentHTML('beforeend', html);
+                            // The new comment will be appended via Turbo Stream broadcast.
+                            // Scroll to the bottom to keep the view anchored.
                             list.scrollTop = list.scrollHeight;
                         }
-                        renderMarkdown(list);
                         markCommentsRead();
                     })
                     .catch(e => { alert(e.message); })


### PR DESCRIPTION
## Summary
- rely on Turbo Stream broadcast instead of manually inserting new comments
- keep comment list scrolled to bottom after sending

## Testing
- `./bin/rubocop -a`
- `rails test`
- `./bin/bundle exec rspec --exclude-pattern "spec/system/**/*"`


------
https://chatgpt.com/codex/tasks/task_e_68c3d8b633bc8326bab2aaa70a94be32