### PR TITLE
Restore Trix toolbar styles

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -33,6 +33,7 @@
     <%= stylesheet_link_tag :print, media: 'print' %>
     <%= stylesheet_link_tag 'user_menu' %>
     <%= stylesheet_link_tag 'popup' %>
+    <%= stylesheet_link_tag 'actiontext', "data-turbo-track": "reload" %>
 
     <%= javascript_include_tag 'creatives', defer: true %>
     <%= javascript_include_tag 'popup_menu', defer: true %>

--- a/spec/system/creative_expansion_actions_spec.rb
+++ b/spec/system/creative_expansion_actions_spec.rb
@@ -32,6 +32,21 @@ RSpec.describe 'Creative expansion actions', type: :system, js: true do
     expect(page).to have_css('#comments-popup', visible: :visible)
   end
 
+  it 'shows the trix toolbar when editing inline' do
+    find("#creative-#{root_creative.id}").hover
+    find("#creative-#{root_creative.id} .creative-toggle-btn").click
+
+    find("#creative-#{child.id}").hover
+    find("#creative-#{child.id} .edit-inline-btn").click
+
+    expect(page).to have_css('#inline-edit-form-element trix-toolbar', visible: :visible)
+    within '#inline-edit-form-element trix-toolbar' do
+      expect(page).to have_css('button', minimum: 3)
+    end
+
+    find('#inline-close').click
+  end
+
   it 'binds edit and comment buttons after using expand all' do
     find('#expand-all-btn').click
     find("#creative-#{child.id}").hover


### PR DESCRIPTION
## Summary
- include the Action Text stylesheet in the main layout so the Trix toolbar renders again
- add a system spec that opens the inline editor and asserts the toolbar buttons are visible

## Testing
- ./bin/rubocop -a
- bundle exec rails test *(fails: closure_tree 9.1.1 requires Ruby >= 3.3; environment installs 3.6.9 without has_closure_tree)*
- ./bin/bundle exec rspec --exclude-pattern "spec/system/**/*" *(fails: closure_tree fallback missing has_closure_tree method)*

------
https://chatgpt.com/codex/tasks/task_e_68c8b87e1920832682a27233da7b8871