### PR TITLE
Add link preview formatting for comments

### DIFF
--- a/app/services/comment_link_formatter.rb
+++ b/app/services/comment_link_formatter.rb
@@ -1,0 +1,58 @@
+require "uri"
+
+class CommentLinkFormatter
+  URL_REGEX = URI::DEFAULT_PARSER.make_regexp(%w[http https])
+  TRAILING_PUNCTUATION = ".,!?;:".freeze
+
+  def initialize(content, metadata_fetcher: nil, logger: Rails.logger)
+    @content = content.to_s
+    @metadata_fetcher = metadata_fetcher || method(:default_fetch_metadata)
+    @logger = logger
+  end
+
+  def format
+    return @content if @content.blank?
+
+    @content.gsub(URL_REGEX) do |match|
+      match_data = Regexp.last_match
+      url, trailing = strip_trailing_punctuation(match)
+      next match if markdown_link?(match_data.pre_match)
+
+      metadata = fetch_metadata(url)
+      title = metadata[:title].presence
+      next match if title.blank?
+
+      "[#{title}](#{url})#{trailing}"
+    end
+  end
+
+  private
+
+  def strip_trailing_punctuation(url)
+    trailing = ""
+    while url.length.positive? && TRAILING_PUNCTUATION.include?(url[-1])
+      trailing = url[-1] + trailing
+      url = url[0...-1]
+    end
+    [ url, trailing ]
+  end
+
+  def markdown_link?(pre_match)
+    return false unless pre_match
+    pre_match =~ /\[[^\]]*\]\([^)]*$/
+  end
+
+  def fetch_metadata(url)
+    @metadata_cache ||= {}
+    return @metadata_cache[url] if @metadata_cache.key?(url)
+
+    @metadata_cache[url] = @metadata_fetcher.call(url)
+  rescue StandardError => e
+    @logger&.warn("Failed to fetch link metadata for #{url}: #{e.class} #{e.message}")
+    @metadata_cache[url] = {}
+  end
+
+  def default_fetch_metadata(url)
+    LinkPreviewFetcher.fetch(url)
+  end
+end

--- a/app/services/link_preview_fetcher.rb
+++ b/app/services/link_preview_fetcher.rb
@@ -1,17 +1,32 @@
 require "open-uri"
 require "nokogiri"
 require "uri"
+require "ipaddr"
+require "resolv"
 
 class LinkPreviewFetcher
   USER_AGENT = "Plan42LinkPreview/1.0".freeze
   OPEN_TIMEOUT = 5
   READ_TIMEOUT = 5
   MAX_BYTES = 200_000
+  MAX_REDIRECTS = 3
   HTML_CONTENT_TYPES = [ "text/html", "application/xhtml+xml" ].freeze
   REQUEST_OPTIONS = {
     "User-Agent" => USER_AGENT,
     "Accept" => "text/html,application/xhtml+xml"
   }.freeze
+  DISALLOWED_IPV4_RANGES = [
+    IPAddr.new("0.0.0.0/8"),
+    IPAddr.new("100.64.0.0/10"),
+    IPAddr.new("192.0.0.0/24"),
+    IPAddr.new("198.18.0.0/15"),
+    IPAddr.new("224.0.0.0/4"),
+    IPAddr.new("240.0.0.0/4")
+  ].freeze
+  DISALLOWED_IPV6_RANGES = [
+    IPAddr.new("::/128"),
+    IPAddr.new("ff00::/8")
+  ].freeze
 
   def self.fetch(url)
     new(url).fetch
@@ -24,9 +39,10 @@ class LinkPreviewFetcher
   end
 
   def fetch
-    return {} unless valid_http_url?
+    uri = safe_http_uri
+    return {} unless uri
 
-    html, base_uri = read_html
+    html, base_uri = read_html(uri)
     return {} if html.blank?
 
     document = Nokogiri::HTML(html)
@@ -38,29 +54,94 @@ class LinkPreviewFetcher
 
   private
 
-  def valid_http_url?
-    uri = URI.parse(@url)
-    %w[http https].include?(uri.scheme)
-  rescue URI::InvalidURIError
-    false
-  end
-
-  def read_html
+  def read_html(uri, redirect_limit = MAX_REDIRECTS)
     html = nil
     base_uri = nil
-    options = REQUEST_OPTIONS.merge(read_timeout: READ_TIMEOUT, open_timeout: OPEN_TIMEOUT)
-    @io_opener.open(@url, options) do |io|
+    options = REQUEST_OPTIONS.merge(read_timeout: READ_TIMEOUT, open_timeout: OPEN_TIMEOUT, redirect: false)
+    @io_opener.open(uri.to_s, options) do |io|
       content_type = io.respond_to?(:content_type) ? io.content_type : nil
       if content_type && HTML_CONTENT_TYPES.none? { |type| content_type.include?(type) }
         return [ nil, nil ]
       end
-      base_uri = io.respond_to?(:base_uri) ? io.base_uri : URI.parse(@url)
+      base_uri = io.respond_to?(:base_uri) ? io.base_uri : uri
       html = io.read(MAX_BYTES)
     end
     [ html, base_uri ]
+  rescue OpenURI::HTTPRedirect => e
+    return [ nil, nil ] if redirect_limit <= 0
+
+    redirected_uri = safe_redirect_uri(uri, e.uri)
+    return [ nil, nil ] unless redirected_uri
+
+    read_html(redirected_uri, redirect_limit - 1)
   rescue OpenURI::HTTPError, SocketError, IOError, SystemCallError, URI::InvalidURIError => e
     @logger&.info("Link preview fetch skipped for #{@url}: #{e.class} #{e.message}")
     [ nil, nil ]
+  end
+
+  def safe_http_uri
+    uri = parse_http_uri(@url)
+    return unless uri
+    return unless allowed_destination?(uri)
+
+    uri
+  end
+
+  def safe_redirect_uri(current_uri, redirected)
+    new_uri = normalize_redirect_uri(current_uri, redirected)
+    return unless new_uri
+    return unless allowed_destination?(new_uri)
+
+    new_uri
+  end
+
+  def normalize_redirect_uri(current_uri, redirected)
+    target_uri = redirected.is_a?(URI) ? redirected : URI.parse(redirected.to_s)
+    target_uri = current_uri.merge(target_uri) if target_uri.relative?
+    return unless %w[http https].include?(target_uri.scheme)
+
+    target_uri
+  rescue URI::InvalidURIError
+    nil
+  end
+
+  def parse_http_uri(url)
+    uri = URI.parse(url)
+    return unless %w[http https].include?(uri.scheme)
+    return unless uri.hostname && !uri.hostname.empty?
+
+    uri
+  rescue URI::InvalidURIError
+    nil
+  end
+
+  def allowed_destination?(uri)
+    host = uri.hostname
+    return false if host.nil? || host.empty?
+
+    addresses = resolve_addresses(host)
+    return false if addresses.empty?
+    return false if addresses.any? { |address| unsafe_ip?(address) }
+
+    true
+  end
+
+  def resolve_addresses(host)
+    Resolv.getaddresses(host).uniq
+  rescue Resolv::ResolvError, SocketError, ArgumentError
+    []
+  end
+
+  def unsafe_ip?(address)
+    ip = IPAddr.new(address)
+    ip = ip.native if ip.ipv4_mapped?
+
+    return true if ip.loopback? || ip.link_local? || ip.private?
+
+    ranges = ip.ipv4? ? DISALLOWED_IPV4_RANGES : DISALLOWED_IPV6_RANGES
+    ranges.any? { |range| range.include?(ip) }
+  rescue IPAddr::InvalidAddressError
+    true
   end
 
   def build_metadata(document, base_uri)

--- a/app/services/link_preview_fetcher.rb
+++ b/app/services/link_preview_fetcher.rb
@@ -1,0 +1,147 @@
+require "open-uri"
+require "nokogiri"
+require "uri"
+
+class LinkPreviewFetcher
+  USER_AGENT = "Plan42LinkPreview/1.0".freeze
+  OPEN_TIMEOUT = 5
+  READ_TIMEOUT = 5
+  MAX_BYTES = 200_000
+  HTML_CONTENT_TYPES = [ "text/html", "application/xhtml+xml" ].freeze
+  REQUEST_OPTIONS = {
+    "User-Agent" => USER_AGENT,
+    "Accept" => "text/html,application/xhtml+xml"
+  }.freeze
+
+  def self.fetch(url)
+    new(url).fetch
+  end
+
+  def initialize(url, io_opener: URI, logger: Rails.logger)
+    @url = url
+    @io_opener = io_opener
+    @logger = logger
+  end
+
+  def fetch
+    return {} unless valid_http_url?
+
+    html, base_uri = read_html
+    return {} if html.blank?
+
+    document = Nokogiri::HTML(html)
+    build_metadata(document, base_uri)
+  rescue StandardError => e
+    @logger&.warn("Link preview fetch failed for #{@url}: #{e.class} #{e.message}")
+    {}
+  end
+
+  private
+
+  def valid_http_url?
+    uri = URI.parse(@url)
+    %w[http https].include?(uri.scheme)
+  rescue URI::InvalidURIError
+    false
+  end
+
+  def read_html
+    html = nil
+    base_uri = nil
+    options = REQUEST_OPTIONS.merge(read_timeout: READ_TIMEOUT, open_timeout: OPEN_TIMEOUT)
+    @io_opener.open(@url, options) do |io|
+      content_type = io.respond_to?(:content_type) ? io.content_type : nil
+      if content_type && HTML_CONTENT_TYPES.none? { |type| content_type.include?(type) }
+        return [ nil, nil ]
+      end
+      base_uri = io.respond_to?(:base_uri) ? io.base_uri : URI.parse(@url)
+      html = io.read(MAX_BYTES)
+    end
+    [ html, base_uri ]
+  rescue OpenURI::HTTPError, SocketError, IOError, SystemCallError, URI::InvalidURIError => e
+    @logger&.info("Link preview fetch skipped for #{@url}: #{e.class} #{e.message}")
+    [ nil, nil ]
+  end
+
+  def build_metadata(document, base_uri)
+    title = extract_title(document)
+    description = extract_description(document)
+    image_url = extract_image(document, base_uri)
+    site_name = extract_site_name(document)
+
+    metadata = {}
+    metadata[:title] = title if title.present?
+    metadata[:description] = description if description.present?
+    metadata[:image_url] = image_url if image_url.present?
+    metadata[:site_name] = site_name if site_name.present?
+    metadata
+  end
+
+  def extract_title(document)
+    [
+      [ "property", "og:title" ],
+      [ "name", "og:title" ],
+      [ "name", "twitter:title" ],
+      [ "name", "title" ]
+    ].each do |attr, value|
+      node = document.at_css(%(meta[#{attr}="#{value}"]))
+      content = node&.[]("content")
+      return normalize_text(content) if content.present?
+    end
+    title_tag = document.at_css("title")&.text
+    normalize_text(title_tag)
+  end
+
+  def extract_description(document)
+    [
+      [ "property", "og:description" ],
+      [ "name", "og:description" ],
+      [ "name", "description" ],
+      [ "name", "twitter:description" ]
+    ].each do |attr, value|
+      node = document.at_css(%(meta[#{attr}="#{value}"]))
+      content = node&.[]("content")
+      return normalize_text(content) if content.present?
+    end
+    nil
+  end
+
+  def extract_site_name(document)
+    node = document.at_css('meta[property="og:site_name"]')
+    normalize_text(node&.[]("content"))
+  end
+
+  def extract_image(document, base_uri)
+    [
+      [ "property", "og:image" ],
+      [ "name", "og:image" ],
+      [ "name", "twitter:image" ],
+      [ "property", "og:image:url" ]
+    ].each do |attr, value|
+      node = document.at_css(%(meta[#{attr}="#{value}"]))
+      url = node&.[]("content")
+      next if url.blank?
+
+      resolved = resolve_url(url, base_uri)
+      return resolved if resolved.present?
+    end
+    nil
+  end
+
+  def resolve_url(url, base_uri)
+    uri = URI.parse(url)
+    if uri.scheme.blank? && base_uri
+      URI.join(base_uri.to_s, url).to_s
+    else
+      uri.to_s
+    end
+  rescue URI::InvalidURIError
+    nil
+  end
+
+  def normalize_text(text)
+    return if text.blank?
+
+    text.to_s.gsub(/\s+/, " ").strip
+  end
+end

--- a/spec/models/comment_link_formatting_spec.rb
+++ b/spec/models/comment_link_formatting_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe Comment, type: :model do
+  describe "link preview formatting" do
+    it "formats content before saving" do
+      user = User.create!(email: "user@example.com", password: "password", name: "User")
+      creative = Creative.create!(user: user, description: "Root")
+      formatter = instance_double(CommentLinkFormatter)
+
+      expect(CommentLinkFormatter).to receive(:new).and_return(formatter)
+      expect(formatter).to receive(:format).and_return("formatted content")
+
+      comment = Comment.create!(creative: creative, user: user, content: "https://example.com")
+      expect(comment.content).to eq("formatted content")
+    end
+  end
+end

--- a/spec/services/comment_link_formatter_spec.rb
+++ b/spec/services/comment_link_formatter_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.describe CommentLinkFormatter do
+  describe "#format" do
+    let(:logger) { instance_double(Logger, warn: nil) }
+
+    it "replaces plain URLs with markdown links using fetched titles" do
+      fetcher = ->(_url) { { title: "Example Domain" } }
+      formatter = described_class.new("Check https://example.com", metadata_fetcher: fetcher, logger: logger)
+
+      expect(formatter.format).to eq("Check [Example Domain](https://example.com)")
+    end
+
+    it "preserves trailing punctuation outside the link" do
+      fetcher = ->(_url) { { title: "Example" } }
+      formatter = described_class.new("Visit https://example.com.", metadata_fetcher: fetcher, logger: logger)
+
+      expect(formatter.format).to eq("Visit [Example](https://example.com).")
+    end
+
+    it "does not alter existing markdown links" do
+      fetcher = double("metadata fetcher")
+      expect(fetcher).to receive(:call).once.and_return({ title: "Another" })
+
+      content = "Already [Saved](https://example.com) and https://another.example"
+      formatter = described_class.new(content, metadata_fetcher: fetcher, logger: logger)
+
+      expect(formatter.format).to eq("Already [Saved](https://example.com) and [Another](https://another.example)")
+    end
+
+    it "returns original content when metadata is missing" do
+      fetcher = ->(_url) { {} }
+      formatter = described_class.new("https://example.com", metadata_fetcher: fetcher, logger: logger)
+
+      expect(formatter.format).to eq("https://example.com")
+    end
+
+    it "swallows errors from the metadata fetcher" do
+      fetcher = lambda do |_url|
+        raise StandardError, "boom"
+      end
+
+      formatter = described_class.new("https://example.com", metadata_fetcher: fetcher, logger: logger)
+
+      expect(formatter.format).to eq("https://example.com")
+    end
+  end
+end

--- a/spec/services/link_preview_fetcher_spec.rb
+++ b/spec/services/link_preview_fetcher_spec.rb
@@ -1,6 +1,7 @@
 require "rails_helper"
 require "open-uri"
 require "stringio"
+require "uri"
 
 RSpec.describe LinkPreviewFetcher do
   let(:logger) { instance_double(Logger, warn: nil, info: nil) }
@@ -20,9 +21,11 @@ RSpec.describe LinkPreviewFetcher do
   end
 
   def build_io(body, content_type: "text/html")
+    base_uri = URI.parse(url)
+
     StringIO.new(body).tap do |io|
       io.define_singleton_method(:content_type) { content_type }
-      io.define_singleton_method(:base_uri) { URI(url) }
+      io.define_singleton_method(:base_uri) { base_uri }
     end
   end
 

--- a/spec/services/link_preview_fetcher_spec.rb
+++ b/spec/services/link_preview_fetcher_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+require "open-uri"
+require "stringio"
+
+RSpec.describe LinkPreviewFetcher do
+  let(:logger) { instance_double(Logger, warn: nil, info: nil) }
+  let(:url) { "https://example.com/article" }
+  let(:html) do
+    <<~HTML
+      <html>
+        <head>
+          <meta property="og:title" content="Example Title" />
+          <meta property="og:description" content="An example description." />
+          <meta property="og:image" content="/image.png" />
+          <meta property="og:site_name" content="Example" />
+        </head>
+        <body></body>
+      </html>
+    HTML
+  end
+
+  def build_io(body, content_type: "text/html")
+    StringIO.new(body).tap do |io|
+      io.define_singleton_method(:content_type) { content_type }
+      io.define_singleton_method(:base_uri) { URI(url) }
+    end
+  end
+
+  it "extracts metadata from the HTML head" do
+    io = build_io(html)
+    expect(URI).to receive(:open).with(url, hash_including("User-Agent" => described_class::USER_AGENT)).and_yield(io)
+
+    metadata = described_class.new(url, io_opener: URI, logger: logger).fetch
+
+    expect(metadata[:title]).to eq("Example Title")
+    expect(metadata[:description]).to eq("An example description.")
+    expect(metadata[:image_url]).to eq("https://example.com/image.png")
+    expect(metadata[:site_name]).to eq("Example")
+  end
+
+  it "falls back to the <title> tag when og:title is missing" do
+    io = build_io("<html><head><title>Fallback Title</title></head><body></body></html>")
+    expect(URI).to receive(:open).and_yield(io)
+
+    metadata = described_class.new(url, io_opener: URI, logger: logger).fetch
+
+    expect(metadata[:title]).to eq("Fallback Title")
+  end
+
+  it "returns an empty hash when the content type is not HTML" do
+    io = build_io("binary data", content_type: "image/png")
+    expect(URI).to receive(:open).and_yield(io)
+
+    metadata = described_class.new(url, io_opener: URI, logger: logger).fetch
+
+    expect(metadata).to eq({})
+  end
+
+  it "handles network errors gracefully" do
+    expect(URI).to receive(:open).and_raise(OpenURI::HTTPError.new("500", nil))
+
+    metadata = described_class.new(url, io_opener: URI, logger: logger).fetch
+
+    expect(metadata).to eq({})
+  end
+end


### PR DESCRIPTION
## Summary
- replace bare URLs in comments with markdown links using fetched metadata before saving
- add a CommentLinkFormatter service that pulls link titles via a LinkPreviewFetcher
- cover the new formatting and fetcher behavior with unit tests and a callback spec

## Testing
- ./bin/rubocop -a
- bundle exec rails test *(fails: closure_tree gem is missing `has_closure_tree` in this environment)*
- ./bin/bundle exec rspec --exclude-pattern "spec/system/**/*" *(fails: closure_tree gem is missing `has_closure_tree` in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca4b831b9c83268ae2bf569c6ce415