### PR TITLE
Enable editing from creative title row

### DIFF
--- a/app/javascript/components/creative_tree_row.js
+++ b/app/javascript/components/creative_tree_row.js
@@ -184,11 +184,17 @@ class CreativeTreeRow extends LitElement {
         data-parent-id=${this.parentId ?? nothing}
       >
         <div class="creative-row">
-          <h1 class="page-title" style="display:flex;align-items:center;gap:1em;">
-            <div class="creative-content">
-              ${unsafeHTML(this.descriptionHtml || "")}
-            </div>
-          </h1>
+          <div class="creative-row-start">
+            <h1 class="page-title" style="display:flex;align-items:center;gap:1em;">
+              <div class="creative-row-actions">
+                ${this._renderCheckbox()}
+                ${this._renderActionButton()}
+              </div>
+              <div class="creative-content">
+                ${unsafeHTML(this.descriptionHtml || "")}
+              </div>
+            </h1>
+          </div>
           <div>
             <h1 style="display:flex;align-items:center;gap:1em;">
               ${unsafeHTML(this.progressHtml || "")}

--- a/app/views/creatives/index.html.erb
+++ b/app/views/creatives/index.html.erb
@@ -65,12 +65,17 @@
   <% end %>
   <%= content_tag(
         "creative-tree-row",
-        content_tag(:template, data: { part: "description" }) { @parent_creative.effective_description } +
-        content_tag(:template, data: { part: "progress" }) { render_creative_progress(@parent_creative) },
+        safe_join([
+          content_tag(:template, data: { part: "description" }) { @parent_creative.effective_description },
+          content_tag(:template, data: { part: "progress" }) { render_creative_progress(@parent_creative) },
+          content_tag(:template, data: { part: "edit-icon" }) { svg_tag("edit.svg", class: "icon-edit") },
+          content_tag(:template, data: { part: "edit-off-icon" }) { svg_tag("edit-off.svg", class: "icon-edit") }
+        ]),
         "dom-id": "creative-markdown-block",
         "creative-id": @parent_creative.id,
         "parent-id": @parent_creative.parent_id,
-        "is-title": ""
+        "is-title": "",
+        "can-write": (@parent_creative.has_permission?(Current.user, :write) ? "" : nil)
       ) %>
 <% else %>
   <%= content_tag(


### PR DESCRIPTION
## Summary
- show the inline edit controls when rendering the creative title row in the tree component
- include the edit button icons and write-permission flag when building the parent creative title row

## Testing
- ./bin/rubocop -a *(fails: closure_tree 9.1.1 requires Ruby \>= 3.3 but the container provides Ruby 3.2.3)*
- rails test *(fails: closure_tree 9.1.1 requires Ruby \>= 3.3 but the container provides Ruby 3.2.3)*
- ./bin/bundle exec rspec --exclude-pattern "spec/system/**/*" *(fails: closure_tree 9.1.1 requires Ruby \>= 3.3 but the container provides Ruby 3.2.3)*

------
https://chatgpt.com/codex/tasks/task_e_68ccefc3f3d883268207553368d559b6