### PR TITLE
Refine creative permission traversal

### DIFF
--- a/test/models/creative_test.rb
+++ b/test/models/creative_test.rb
@@ -87,4 +87,24 @@ class CreativeTest < ActiveSupport::TestCase
 
     Current.reset
   end
+
+  test "ids_with_permission skips descendants blocked by no access share" do
+    Current.reset
+
+    owner = users(:one)
+    recipient = users(:two)
+
+    parent = Creative.create!(user: owner, description: "Parent")
+    child = Creative.create!(user: owner, parent: parent, description: "Child")
+
+    CreativeShare.create!(creative: parent, user: recipient, permission: :write)
+    CreativeShare.create!(creative: child, user: recipient, permission: :no_access)
+
+    ids = Creative.ids_with_permission(recipient, :write)
+
+    assert_includes ids, parent.id
+    refute_includes ids, child.id
+
+    Current.reset
+  end
 end


### PR DESCRIPTION
## Summary
- implement Creative.ids_with_permission so it walks descendants, respects per-node shares, and avoids no-access entries
- preload and reuse share cache during traversal while restoring the previous cache when finished
- add a regression test ensuring a descendant with a no-access share is excluded from writeable IDs

## Testing
- `./bin/rubocop -a`
- `bundle exec rails test`
- `./bin/bundle exec rspec --exclude-pattern "spec/system/**/*"` *(fails: request specs expect creatives created via link_drop to have a user assigned; existing issue)*

------
https://chatgpt.com/codex/tasks/task_e_68cd145339188326941fbc042f3c87ac