### PR TITLE
Add system conversion message to chat comments

### DIFF
--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,7 +1,16 @@
 <div class="comment-item <%= 'last-read' if defined?(last_read_comment_id) && last_read_comment_id && comment.id == last_read_comment_id %>" id="<%= dom_id(comment) %>" data-controller="comment" data-user-id="<%= comment.user&.id %>">
   <div>
     <%= render AvatarComponent.new(user: comment.user, size: 20, classes: 'avatar comment-avatar') %>
-    <strong><%= comment.user&.display_name || t('comments.gemini') %></strong>
+    <% system_prefix = "#{t('comments.system_user')}:" %>
+    <% display_name =
+         if comment.user.present?
+           comment.user.display_name
+         elsif comment.content.to_s.strip.start_with?(system_prefix)
+           t('comments.system_user')
+         else
+           t('comments.gemini')
+         end %>
+    <strong><%= display_name %></strong>
     <span>· <%= t('datetime.ago', time: time_ago_in_words(comment.created_at)) %></span>
     <% if comment.private? %>
       <span class="private-label">[<%= t('comments.private') %>]</span>

--- a/config/locales/comments.en.yml
+++ b/config/locales/comments.en.yml
@@ -16,3 +16,6 @@ en:
     convert_to_creative: "Convert to Creative"
     convert_confirm: "This will add the comment content as a child creative of the current creative. Continue?"
     private: "Private"
+    convert_system_message: "System: Comment was converted to the [%{title}](%{url}) creative."
+    convert_system_message_default_title: "Untitled"
+    system_user: "System"

--- a/config/locales/comments.ko.yml
+++ b/config/locales/comments.ko.yml
@@ -16,3 +16,6 @@ ko:
     convert_to_creative: "하위 크리에이티브로 전환"
     convert_confirm: "현재 크리에이티브 하위에 해당 댓글의 내용이 추가됩니다. 진행하시겠습니까?"
     private: "비밀"
+    convert_system_message: "System: 메세지가 [%{title}](%{url}) 크리에이티브로 변환되었습니다"
+    convert_system_message_default_title: "제목 없음"
+    system_user: "System"

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -11,12 +11,24 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
   test "convert markdown comment to sub creatives" do
     comment = @creative.comments.create!(content: "- First\n- Second", user: @user)
     assert_difference("Creative.count", 2) do
-      assert_difference("Comment.count", -1) do
+      assert_no_difference("Comment.count") do
         post convert_creative_comment_path(@creative, comment)
       end
     end
     assert_response :no_content
+    @creative.reload
     titles = @creative.children.order(:id).map { |c| c.description.to_plain_text.strip }
     assert_equal [ "First", "Second" ], titles
+
+    system_comment = @creative.comments.order(:id).last
+    assert_nil system_comment.user
+    first_child = @creative.children.order(:id).first
+    expected_title = first_child.description.to_plain_text.strip
+    expected_message = I18n.t(
+      "comments.convert_system_message",
+      title: expected_title,
+      url: creative_path(first_child)
+    )
+    assert_equal expected_message, system_comment.content
   end
 end


### PR DESCRIPTION
## Summary
- add a system chat comment after converting feedback into a creative
- show "System" as the author label for those system comments and provide translations
- extend the controller test to verify the system message content

## Testing
- ./bin/rubocop -a
- rails test *(fails: NoMethodError: undefined method `has_closure_tree' for Creative:Class)*
- bin/rails test *(fails: NoMethodError: undefined method `has_closure_tree' for Creative:Class)*
- ./bin/bundle exec rspec --exclude-pattern "spec/system/**/*" *(fails: NoMethodError: undefined method `has_closure_tree' for Creative:Class)*

------
https://chatgpt.com/codex/tasks/task_e_68d1297b440083268965bfaabd51ce6e