### PR TITLE
Deduplicate FCM tokens for devices

### DIFF
--- a/app/controllers/devices_controller.rb
+++ b/app/controllers/devices_controller.rb
@@ -1,7 +1,10 @@
 class DevicesController < ApplicationController
   def create
-    device = Current.user.devices.find_or_initialize_by(client_id: device_params[:client_id])
+    device = Device.find_by(fcm_token: device_params[:fcm_token]) ||
+             Current.user.devices.find_or_initialize_by(client_id: device_params[:client_id])
+
     device.assign_attributes(device_params)
+    device.user = Current.user
     device.save!
     head :no_content
   end

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -5,5 +5,5 @@ class Device < ApplicationRecord
 
   validates :client_id, presence: true, uniqueness: true
   validates :device_type, presence: true
-  validates :fcm_token, presence: true
+  validates :fcm_token, presence: true, uniqueness: true
 end

--- a/db/migrate/20250923002959_deduplicate_device_fcm_tokens.rb
+++ b/db/migrate/20250923002959_deduplicate_device_fcm_tokens.rb
@@ -1,0 +1,25 @@
+class DeduplicateDeviceFcmTokens < ActiveRecord::Migration[8.0]
+  class DeviceRecord < ApplicationRecord
+    self.table_name = "devices"
+  end
+
+  def up
+    DeviceRecord.reset_column_information
+
+    DeviceRecord.group(:fcm_token).having("COUNT(*) > 1").pluck(:fcm_token).each do |token|
+      ids = DeviceRecord.where(fcm_token: token).order(updated_at: :desc, id: :desc).pluck(:id)
+      duplicate_ids = ids.drop(1)
+      next if duplicate_ids.empty?
+
+      DeviceRecord.where(id: duplicate_ids).delete_all
+    end
+
+    remove_index :devices, :fcm_token if index_exists?(:devices, :fcm_token)
+    add_index :devices, :fcm_token, unique: true
+  end
+
+  def down
+    remove_index :devices, :fcm_token if index_exists?(:devices, :fcm_token)
+    add_index :devices, :fcm_token unless index_exists?(:devices, :fcm_token)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_11_084338) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_23_002959) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
     t.text "body"
@@ -139,7 +139,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_11_084338) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["client_id"], name: "index_devices_on_client_id", unique: true
-    t.index ["fcm_token"], name: "index_devices_on_fcm_token"
+    t.index ["fcm_token"], name: "index_devices_on_fcm_token", unique: true
     t.index ["user_id"], name: "index_devices_on_user_id"
   end
 

--- a/test/controllers/devices_controller_test.rb
+++ b/test/controllers/devices_controller_test.rb
@@ -1,0 +1,49 @@
+require "test_helper"
+
+class DevicesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    Device.delete_all
+  end
+
+  test "creating a device with an existing token updates the record" do
+    original_user = users(:one)
+    current_user = users(:two)
+
+    device = Device.create!(
+      user: original_user,
+      client_id: "existing-client",
+      device_type: :web,
+      app_id: "com.example.app",
+      app_version: "1.0.0",
+      fcm_token: "shared-token"
+    )
+
+    login_as(current_user)
+
+    post devices_path, params: {
+      device: {
+        client_id: "updated-client",
+        device_type: "web",
+        app_id: "com.example.app.updated",
+        app_version: "2.0.0",
+        fcm_token: "shared-token"
+      }
+    }
+
+    assert_response :no_content
+
+    device.reload
+    assert_equal current_user, device.user
+    assert_equal "updated-client", device.client_id
+    assert_equal "com.example.app.updated", device.app_id
+    assert_equal "2.0.0", device.app_version
+    assert_equal 1, Device.where(fcm_token: "shared-token").count
+  end
+
+  private
+
+  def login_as(user)
+    user.update!(email_verified_at: Time.current)
+    post session_path, params: { email: user.email, password: "password" }
+  end
+end


### PR DESCRIPTION
## Summary
- add a migration that removes duplicate device rows sharing an FCM token and enforces a unique index
- update device creation to reuse an existing record when the FCM token already exists and validate the token uniqueness
- add a controller integration test covering the update behaviour when re-registering a token

## Testing
- ./bin/rubocop -a
- rails test *(fails: `has_closure_tree` is undefined for Creative; pre-existing environment issue)*
- ./bin/bundle exec rspec --exclude-pattern "spec/system/**/*" *(fails: `has_closure_tree` is undefined for Creative; pre-existing environment issue)*

------
https://chatgpt.com/codex/tasks/task_e_68d1e8f3a7e483269774f453f6ea5a82