### PR TITLE
refactor: creatives controller for simplicity

### DIFF
--- a/app/controllers/creative_imports_controller.rb
+++ b/app/controllers/creative_imports_controller.rb
@@ -1,0 +1,21 @@
+class CreativeImportsController < ApplicationController
+  allow_unauthenticated_access only: :create
+  def create
+    unless authenticated?
+      render json: { error: "Unauthorized" }, status: :unauthorized and return
+    end
+
+    parent = params[:parent_id].present? ? Creative.find_by(id: params[:parent_id]) : nil
+    created = Creatives::Importer.new(file: params[:markdown], user: Current.user, parent: parent).call
+
+    if created.any?
+      render json: { success: true, created: created.map(&:id) }
+    else
+      render json: { error: "No creatives created" }, status: :unprocessable_entity
+    end
+  rescue Creatives::Importer::UnsupportedFile
+    render json: { error: "Invalid file type" }, status: :unprocessable_entity
+  rescue Creatives::Importer::Error => e
+    render json: { error: e.message }, status: :unprocessable_entity
+  end
+end

--- a/app/controllers/creative_plans_controller.rb
+++ b/app/controllers/creative_plans_controller.rb
@@ -1,0 +1,45 @@
+class CreativePlansController < ApplicationController
+  before_action :require_authentication
+
+  def create
+    result = tagger.apply
+    flash[result.success? ? :notice : :alert] = translate_message(
+      result,
+      success_key: "creatives.index.plan_tags_applied",
+      success_default: "Plan tags applied to selected creatives.",
+      failure_key: "creatives.index.plan_tag_failed",
+      failure_default: "Please select a plan and at least one creative."
+    )
+    redirect_back fallback_location: creatives_path(select_mode: 1)
+  end
+
+  def destroy
+    result = tagger.remove
+    flash[result.success? ? :notice : :alert] = translate_message(
+      result,
+      success_key: "creatives.index.plan_tags_removed",
+      success_default: "Plan tag removed from selected creatives.",
+      failure_key: "creatives.index.plan_tag_remove_failed",
+      failure_default: "Please select a plan and at least one creative."
+    )
+    redirect_back fallback_location: creatives_path(select_mode: 1)
+  end
+
+  private
+
+  def tagger
+    Creatives::PlanTagger.new(plan_id: params[:plan_id], creative_ids: parsed_creative_ids)
+  end
+
+  def parsed_creative_ids
+    params[:creative_ids].to_s.split(",").map(&:strip).reject(&:blank?)
+  end
+
+  def translate_message(result, success_key:, success_default:, failure_key:, failure_default:)
+    if result.success?
+      I18n.t(success_key, default: success_default)
+    else
+      I18n.t(failure_key, default: failure_default)
+    end
+  end
+end

--- a/app/controllers/creatives_controller.rb
+++ b/app/controllers/creatives_controller.rb
@@ -8,79 +8,17 @@ class CreativesController < ApplicationController
     # 권한 캐시: 요청 내 CreativeShare 모두 메모리에 올림
     Current.creative_share_cache = CreativeShare.where(user: Current.user).index_by(&:creative_id)
     @expanded_state_map = CreativeExpandedState.where(user_id: Current.user.id, creative_id: params[:id]).first&.expanded_status || {}
-    if params[:comment] == "true"
-      # 코멘트가 있는 creative만, 코멘트 최신 업데이트 순
-      @creatives = Creative
-        .joins(:comments)
-        .where.not(comments: { id: nil })
-        .select { |c| c.user == Current.user || c.has_permission?(Current.user, :read) }
-        .uniq(&:id)
-      @creatives = @creatives.sort_by { |c| c.comments.maximum(:updated_at) || c.updated_at }.reverse
-      @parent_creative = nil
-    elsif params[:search].present?
-      if params[:simple].present?
-        @creatives = Creative
-                       .joins(:rich_text_description)
-                       .where("action_text_rich_texts.body LIKE :q", q: "%#{params[:search]}%")
-                       .select { |c| c.user == Current.user || c.has_permission?(Current.user, :read) }
-      elsif params[:id].present?
-        base_creative = Creative.find_by(id: params[:id]).effective_origin
-        if base_creative
-          subtree_ids = base_creative.subtree_ids
-          @creatives = Creative
-                        .joins(:rich_text_description)
-                        .left_joins(:comments) # Include comments to allow searching in them
-                        .where(id: subtree_ids)
-                        .where("action_text_rich_texts.body LIKE :q OR comments.content LIKE :q", q: "%#{params[:search]}%")
-                        .select { |c| c.user == Current.user || c.has_permission?(Current.user, :read) }
-          @parent_creative = base_creative
-        else
-          @creatives = []
-          @parent_creative = nil
-        end
-      else
-        @creatives = Creative.joins(:rich_text_description)
-                             .left_joins(:comments) # Include comments to allow searching in them
-                             .where("action_text_rich_texts.body LIKE :q OR comments.content LIKE :q", q: "%#{params[:search]}%")
-                             .where(origin_id: nil)
-                             .select { |c| c.user == Current.user || c.has_permission?(Current.user, :read) }
-        @parent_creative = nil
-      end
-    elsif params[:id]
-      creative = Creative.where(id: params[:id])
-                   .order(:sequence)
-                          .select { |c| c.user == Current.user || c.has_permission?(Current.user, :read) }
-                           .first
-      @parent_creative = creative
-      @creatives = creative.children_with_permission(Current.user, :read) if creative
-    else
-      @creatives = Creative.where(user: Current.user).roots
-      @parent_creative = nil
-    end
-    # 공유 리스트 로직: 자신과 모든 ancestor에서 공유된 사용자 수집
-    if (@shared_creative = @parent_creative || @creatives&.first)
-      @shared_list = @shared_creative.all_shared_users
-    end
-
-    if params[:tags].present?
-      tag_ids = Array(params[:tags]).map(&:to_s)
-      roots = @creatives || []
-      progress_values = roots.map { |c| c.progress_for_tags(tag_ids) }.compact
-      if progress_values.any?
-        @overall_progress = progress_values.sum.to_f / progress_values.size
-      else
-        @overall_progress = 0
-      end
-    end
+    index_result = Creatives::IndexQuery.new(user: Current.user, params: params.to_unsafe_h).call
+    @creatives = index_result.creatives || []
+    @parent_creative = index_result.parent_creative
+    @shared_creative = index_result.shared_creative
+    @shared_list = index_result.shared_list
+    @overall_progress = index_result.overall_progress if params[:tags].present?
 
     respond_to do |format|
       format.html
       format.json do
-        if params[:simple].present?
-          render json: @creatives.map { |c| { id: c.id, description: c.effective_origin.description.to_plain_text } }
-        else
-          render json: @creatives.map { |c| { id: c.id, description: c.effective_description } }
-        end
+        render json: serialize_creatives(@creatives)
       end
     end
   end
@@ -253,86 +191,24 @@ class CreativesController < ApplicationController
   end
 
   def reorder
-    dragged = Creative.find_by(id: params[:dragged_id])
-    target = Creative.find_by(id: params[:target_id])
-    direction = params[:direction]
-    return head :unprocessable_entity unless dragged && target && %w[up down child].include?(direction)
-
-    if direction == "child"
-      # Make dragged a child of target, append to end of children
-      dragged.parent = target
-      dragged.save!
-      siblings = target.children.order(:sequence).to_a
-      siblings.delete(dragged)
-      siblings << dragged
-      siblings.each_with_index do |creative, idx|
-        creative.update_column(:sequence, idx)
-      end
-      head :ok
-      return
-    end
-
-    # Up/down logic
-    # Change parent if needed
-    if dragged.parent != target.parent
-      dragged.parent = target.parent
-      dragged.save!
-    end
-
-    siblings = dragged.parent ? dragged.parent.children.order(:sequence).to_a : Creative.roots.order(:sequence).to_a
-    siblings.delete(dragged)
-    target_index = siblings.index(target)
-    new_index = direction == "up" ? target_index : target_index + 1
-    siblings.insert(new_index, dragged)
-
-    # Reassign sequence values
-    siblings.each_with_index do |creative, idx|
-      creative.update_column(:sequence, idx)
-    end
-
+    reorderer.reorder(
+      dragged_id: params[:dragged_id],
+      target_id: params[:target_id],
+      direction: params[:direction]
+    )
     head :ok
+  rescue Creatives::Reorderer::Error
+    head :unprocessable_entity
   end
 
   def link_drop
-    dragged = Creative.find_by(id: params[:dragged_id])
-    target = Creative.find_by(id: params[:target_id])
-    direction = params[:direction]
-    return head :unprocessable_entity unless dragged && target && %w[up down child].include?(direction)
-
-    origin = dragged.effective_origin
-    new_parent = direction == "child" ? target : target.parent
-
-    new_creative = Creative.new(
-      origin_id: origin.id,
-      parent: new_parent,
-      user: new_parent.user || Current.user
+    result = reorderer.link_drop(
+      dragged_id: params[:dragged_id],
+      target_id: params[:target_id],
+      direction: params[:direction]
     )
 
-    Creative.transaction do
-      new_creative.save!
-
-      siblings = if new_parent
-        new_parent.children.order(:sequence).to_a
-      else
-        Creative.roots.order(:sequence).to_a
-      end
-
-      siblings.delete(new_creative)
-
-      if direction == "child"
-        siblings << new_creative
-      else
-        target_index = siblings.index(target) || 0
-        insert_index = direction == "up" ? target_index : target_index + 1
-        insert_index = [ [ insert_index, 0 ].max, siblings.size ].min
-        siblings.insert(insert_index, new_creative)
-      end
-
-      siblings.each_with_index do |creative, idx|
-        creative.update_column(:sequence, idx)
-      end
-    end
-
+    new_creative = result.new_creative
     level = new_creative.ancestors.count + 1
     html = helpers.render_creative_tree(
       [ new_creative ],
@@ -344,39 +220,11 @@ class CreativesController < ApplicationController
     render json: {
       html: html,
       creative_id: new_creative.id,
-      parent_id: new_parent&.id,
-      direction: direction
+      parent_id: result.parent&.id,
+      direction: result.direction
     }
-  rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotSaved
+  rescue Creatives::Reorderer::Error
     head :unprocessable_entity
-  end
-
-  def import_markdown
-    unless authenticated?
-      render json: { error: "Unauthorized" }, status: :unauthorized and return
-    end
-    if params[:markdown].blank?
-      render json: { error: "Invalid file type" }, status: :unprocessable_entity and return
-    end
-    parent = params[:parent_id].present? ? Creative.find_by(id: params[:parent_id]) : nil
-    file = params[:markdown]
-    created =
-      case file.content_type
-      when "text/markdown", "text/x-markdown", "application/octet-stream"
-        content = file.read.force_encoding("UTF-8")
-        MarkdownImporter.import(content, parent: parent, user: Current.user, create_root: true)
-      when "application/vnd.ms-powerpoint",
-           "application/vnd.openxmlformats-officedocument.presentationml.presentation"
-        PptImporter.import(file.tempfile, parent: parent, user: Current.user,
-                           create_root: true, filename: file.original_filename)
-      else
-        render json: { error: "Invalid file type" }, status: :unprocessable_entity and return
-      end
-    if created.any?
-      render json: { success: true, created: created.map(&:id) }
-    else
-      render json: { error: "No creatives created" }, status: :unprocessable_entity
-    end
   end
 
   def append_as_parent
@@ -387,37 +235,6 @@ class CreativesController < ApplicationController
   def append_below
     target = Creative.find_by(id: params[:creative_id])
     redirect_to new_creative_path(parent_id: target&.parent_id, after_id: target&.id, tags: params[:tags])
-  end
-
-  def set_plan
-    plan_id = params[:plan_id]
-    creative_ids = params[:creative_ids].to_s.split(",").map(&:strip).reject(&:blank?)
-    plan = Plan.find_by(id: plan_id)
-    if plan && creative_ids.any?
-      Creative.where(id: creative_ids).find_each do |creative|
-        creative.tags.find_or_create_by(label: plan, creative_id: creative.id)
-      end
-      flash[:notice] = t("creatives.index.plan_tags_applied", default: "Plan tags applied to selected creatives.")
-    else
-      flash[:alert] = t("creatives.index.plan_tag_failed", default: "Please select a plan and at least one creative.")
-    end
-    redirect_back fallback_location: creatives_path(select_mode: 1)
-  end
-
-  def remove_plan
-    plan_id = params[:plan_id]
-    creative_ids = params[:creative_ids].to_s.split(",").map(&:strip).reject(&:blank?)
-    plan = Plan.find_by(id: plan_id)
-    if plan && creative_ids.any?
-      Creative.where(id: creative_ids).find_each do |creative|
-        tag = creative.tags.find_by(label: plan, creative_id: creative.id)
-        tag&.destroy
-      end
-      flash[:notice] = t("creatives.index.plan_tags_removed", default: "Plan tag removed from selected creatives.")
-    else
-      flash[:alert] = t("creatives.index.plan_tag_remove_failed", default: "Please select a plan and at least one creative.")
-    end
-    redirect_back fallback_location: creatives_path(select_mode: 1)
   end
 
   def children
@@ -463,6 +280,18 @@ class CreativesController < ApplicationController
         children = (children + linked_children).uniq.sort_by(&:sequence)
       end
       children.each { |child| build_slide_ids(child) }
+    end
+
+    def serialize_creatives(collection)
+      if params[:simple].present?
+        collection.map { |c| { id: c.id, description: c.effective_origin.description.to_plain_text } }
+      else
+        collection.map { |c| { id: c.id, description: c.effective_description } }
+      end
+    end
+
+    def reorderer
+      @reorderer ||= Creatives::Reorderer.new(user: Current.user)
     end
 
     # Recursively destroy all descendants the user can delete

--- a/app/javascript/creatives_import.js
+++ b/app/javascript/creatives_import.js
@@ -71,7 +71,7 @@ if (!window.creativesImportInitialized) {
             const parentId = importArea.dataset.parentCreativeId;
             if (parentId) formData.append('parent_id', parentId);
 
-            fetch('/creatives/import_markdown', {
+            fetch('/creative_imports', {
                 method: 'POST',
                 headers: {
                     'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]')?.content

--- a/app/javascript/set_plan_modal.js
+++ b/app/javascript/set_plan_modal.js
@@ -53,7 +53,7 @@ if (!window.isSetPlanModalInitialized) {
                     alert(selectPlanText);
                     return;
                 }
-                // Submit via POST to /creatives/remove_plan
+                // Submit via DELETE to creative_plan_path
                 var f = document.createElement('form');
                 f.method = 'POST';
                 f.action = removeBtn.dataset.removePath;
@@ -66,6 +66,11 @@ if (!window.isSetPlanModalInitialized) {
                     csrfInput.value = csrf.content;
                     f.appendChild(csrfInput);
                 }
+                var methodField = document.createElement('input');
+                methodField.type = 'hidden';
+                methodField.name = '_method';
+                methodField.value = 'delete';
+                f.appendChild(methodField);
                 var idsField = document.createElement('input');
                 idsField.type = 'hidden';
                 idsField.name = 'creative_ids';

--- a/app/services/creatives/importer.rb
+++ b/app/services/creatives/importer.rb
@@ -1,0 +1,45 @@
+module Creatives
+  class Importer
+    class Error < StandardError; end
+    class UnsupportedFile < Error; end
+
+    MARKDOWN_MIME_TYPES = %w[text/markdown text/x-markdown application/octet-stream].freeze
+    PPT_MIME_TYPES = %w[
+      application/vnd.ms-powerpoint
+      application/vnd.openxmlformats-officedocument.presentationml.presentation
+    ].freeze
+
+    def initialize(file:, user:, parent: nil)
+      @file = file
+      @user = user
+      @parent = parent
+    end
+
+    def call
+      raise Error, "File required" if file.blank?
+
+      case mime_type
+      when *MARKDOWN_MIME_TYPES
+        content = read_file_content
+        MarkdownImporter.import(content, parent: parent, user: user, create_root: true)
+      when *PPT_MIME_TYPES
+        PptImporter.import(file.tempfile, parent: parent, user: user, create_root: true, filename: file.original_filename)
+      else
+        raise UnsupportedFile, "Invalid file type"
+      end
+    end
+
+    private
+
+    attr_reader :file, :user, :parent
+
+    def mime_type
+      file.content_type.presence || Rack::Mime.mime_type(File.extname(file.original_filename.to_s))
+    end
+
+    def read_file_content
+      file.rewind
+      file.read.to_s.force_encoding("UTF-8")
+    end
+  end
+end

--- a/app/services/creatives/index_query.rb
+++ b/app/services/creatives/index_query.rb
@@ -1,0 +1,100 @@
+module Creatives
+  class IndexQuery
+    Result = Struct.new(
+      :creatives,
+      :parent_creative,
+      :shared_creative,
+      :shared_list,
+      :overall_progress,
+      keyword_init: true
+    )
+
+    def initialize(user:, params: {})
+      @user = user
+      @params = params.with_indifferent_access
+    end
+
+    def call
+      creatives, parent = resolve_creatives
+      shared_creative = parent || creatives&.first
+      shared_list = shared_creative ? shared_creative.all_shared_users : []
+      overall_progress = calculate_progress(creatives)
+
+      Result.new(
+        creatives: creatives,
+        parent_creative: parent,
+        shared_creative: shared_creative,
+        shared_list: shared_list,
+        overall_progress: overall_progress
+      )
+    end
+
+    private
+
+    attr_reader :user, :params
+
+    def resolve_creatives
+      if params[:comment] == "true"
+        creatives = Creative
+                      .joins(:comments)
+                      .where.not(comments: { id: nil })
+                      .select { |c| readable?(c) }
+                      .uniq(&:id)
+        creatives = creatives.sort_by { |c| c.comments.maximum(:updated_at) || c.updated_at }.reverse
+        [ creatives, nil ]
+      elsif params[:search].present?
+        search_creatives
+      elsif params[:id]
+        creative = Creative.where(id: params[:id])
+                            .order(:sequence)
+                            .detect { |c| readable?(c) }
+        [ creative&.children_with_permission(user, :read), creative ]
+      else
+        [ Creative.where(user: user).roots, nil ]
+      end
+    end
+
+    def search_creatives
+      query = "%#{params[:search]}%"
+      if params[:simple].present?
+        creatives = Creative
+                      .joins(:rich_text_description)
+                      .where("action_text_rich_texts.body LIKE :q", q: query)
+                      .select { |c| readable?(c) }
+        [ creatives, nil ]
+      elsif params[:id].present?
+        base_creative = Creative.find_by(id: params[:id])&.effective_origin
+        return [ [], nil ] unless base_creative
+
+        subtree_ids = base_creative.subtree_ids
+        creatives = Creative
+                      .joins(:rich_text_description)
+                      .left_joins(:comments)
+                      .where(id: subtree_ids)
+                      .where("action_text_rich_texts.body LIKE :q OR comments.content LIKE :q", q: query)
+                      .select { |c| readable?(c) }
+        [ creatives, base_creative ]
+      else
+        creatives = Creative
+                      .joins(:rich_text_description)
+                      .left_joins(:comments)
+                      .where("action_text_rich_texts.body LIKE :q OR comments.content LIKE :q", q: query)
+                      .where(origin_id: nil)
+                      .select { |c| readable?(c) }
+        [ creatives, nil ]
+      end
+    end
+
+    def calculate_progress(creatives)
+      return unless params[:tags].present?
+      tag_ids = Array(params[:tags]).map(&:to_s)
+      roots = creatives || []
+      progress_values = roots.map { |c| c.progress_for_tags(tag_ids, user) }.compact
+      progress_values.any? ? progress_values.sum.to_f / progress_values.size : 0
+    end
+
+    def readable?(creative)
+      creative.user == user || creative.has_permission?(user, :read)
+    end
+  end
+end

--- a/app/services/creatives/plan_tagger.rb
+++ b/app/services/creatives/plan_tagger.rb
@@ -1,0 +1,51 @@
+module Creatives
+  class PlanTagger
+    Result = Struct.new(:success?, :message, keyword_init: true)
+
+    def initialize(plan_id:, creative_ids: [])
+      @plan = Plan.find_by(id: plan_id)
+      @creative_ids = Array(creative_ids).map(&:presence).compact
+    end
+
+    def apply
+      return failure("Please select a plan and at least one creative.") unless valid?
+
+      creatives.find_each do |creative|
+        creative.tags.find_or_create_by(label: plan, creative_id: creative.id)
+      end
+
+      success("Plan tags applied to selected creatives.")
+    end
+
+    def remove
+      return failure("Please select a plan and at least one creative.") unless valid?
+
+      creatives.find_each do |creative|
+        tag = creative.tags.find_by(label: plan, creative_id: creative.id)
+        tag&.destroy
+      end
+
+      success("Plan tag removed from selected creatives.")
+    end
+
+    private
+
+    attr_reader :plan, :creative_ids
+
+    def creatives
+      Creative.where(id: creative_ids)
+    end
+
+    def valid?
+      plan.present? && creative_ids.any?
+    end
+
+    def success(message)
+      Result.new(success?: true, message: message)
+    end
+
+    def failure(message)
+      Result.new(success?: false, message: message)
+    end
+  end
+end

--- a/app/services/creatives/reorderer.rb
+++ b/app/services/creatives/reorderer.rb
@@ -1,0 +1,104 @@
+module Creatives
+  class Reorderer
+    class Error < StandardError; end
+
+    LinkDropResult = Struct.new(:new_creative, :parent, :direction, keyword_init: true)
+
+    def initialize(user:)
+      @user = user
+    end
+
+    def reorder(dragged_id:, target_id:, direction:)
+      dragged, target = fetch_creatives(dragged_id, target_id)
+      validate_direction!(direction)
+      raise Error, "Invalid creatives" unless dragged && target
+
+      if direction == "child"
+        reorder_as_child(dragged, target)
+      else
+        reorder_as_sibling(dragged, target, direction)
+      end
+
+      true
+    end
+
+    def link_drop(dragged_id:, target_id:, direction:)
+      dragged, target = fetch_creatives(dragged_id, target_id)
+      validate_direction!(direction)
+      raise Error, "Invalid creatives" unless dragged && target
+
+      origin = dragged.effective_origin
+      new_parent = direction == "child" ? target : target.parent
+
+      new_creative = nil
+      Creative.transaction do
+        new_creative = Creative.create!(
+          origin_id: origin.id,
+          parent: new_parent,
+          user: new_parent&.user || user
+        )
+
+        siblings = sibling_scope(new_parent)
+        siblings.delete(new_creative)
+
+        if direction == "child"
+          siblings << new_creative
+        else
+          target_index = siblings.index(target) || 0
+          insert_index = direction == "up" ? target_index : target_index + 1
+          insert_index = [ [ insert_index, 0 ].max, siblings.size ].min
+          siblings.insert(insert_index, new_creative)
+        end
+
+        resequence!(siblings)
+      end
+
+      LinkDropResult.new(new_creative: new_creative, parent: new_parent, direction: direction)
+    rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotSaved => e
+      raise Error, e.message
+    end
+
+    private
+
+    attr_reader :user
+
+    def fetch_creatives(dragged_id, target_id)
+      [ Creative.find_by(id: dragged_id), Creative.find_by(id: target_id) ]
+    end
+
+    def validate_direction!(direction)
+      raise Error, "Invalid direction" unless %w[up down child].include?(direction)
+    end
+
+    def reorder_as_child(dragged, target)
+      dragged.update!(parent: target)
+      siblings = target.children.order(:sequence).to_a
+      siblings.delete(dragged)
+      siblings << dragged
+      resequence!(siblings)
+    end
+
+    def reorder_as_sibling(dragged, target, direction)
+      if dragged.parent != target.parent
+        dragged.update!(parent: target.parent)
+      end
+
+      siblings = sibling_scope(dragged.parent)
+      siblings.delete(dragged)
+      target_index = siblings.index(target)
+      new_index = direction == "up" ? target_index : target_index.to_i + 1
+      siblings.insert(new_index, dragged)
+      resequence!(siblings)
+    end
+
+    def sibling_scope(parent)
+      parent ? parent.children.order(:sequence).to_a : Creative.roots.order(:sequence).to_a
+    end
+
+    def resequence!(creatives)
+      creatives.each_with_index do |creative, idx|
+        creative.update_column(:sequence, idx)
+      end
+    end
+  end
+end

--- a/app/views/creatives/_set_plan_modal.html.erb
+++ b/app/views/creatives/_set_plan_modal.html.erb
@@ -2,7 +2,7 @@
   <div class="popup-box" style="min-width:320px;max-width:90vw;">
     <button id="close-set-plan-modal" class="popup-close-btn">&times;</button>
     <h2><%= t('creatives.index.set_plan_title', default: 'Set Plan for Selected Creatives') %></h2>
-    <form id="set-plan-form" method="post" action="<%= set_plan_creatives_path %>">
+    <form id="set-plan-form" method="post" action="<%= creative_plan_path %>">
       <%= csrf_meta_tags %>
       <div style="margin-bottom:1em;">
         <label for="plan-id-select"><%= t('creatives.index.select_plan', default: 'Select Plan') %></label>
@@ -15,7 +15,7 @@
       <!-- Hidden field for creative IDs, filled by JS -->
       <input type="hidden" name="creative_ids" id="selected-creative-ids-input" />
       <div style="display:flex; gap:1em; align-items:center;">
-        <button type="button" id="remove-plan-btn" data-remove-path="<%= remove_plan_creatives_path %>" class="btn btn-danger" style="margin-right:0.5em;">
+        <button type="button" id="remove-plan-btn" data-remove-path="<%= creative_plan_path %>" class="btn btn-danger" style="margin-right:0.5em;">
           <%= t('creatives.index.remove_plan', default: 'Remove Plan') %>
         </button>
         <button type="submit" class="btn btn-primary"><%= t('creatives.index.add_plan', default: 'Add Plan') %></button>
@@ -23,4 +23,3 @@
     </form>
   </div>
 </div>
-

--- a/config/locales/plans.ko.yml
+++ b/config/locales/plans.ko.yml
@@ -6,3 +6,10 @@ ko:
     created: "계획이 성공적으로 생성되었습니다."
     deleted: "계획이 삭제되었습니다."
     today: "오늘"
+  activerecord:
+    errors:
+      models:
+        plan:
+          attributes:
+            target_date:
+              blank: "목표 날짜를 입력하세요."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,9 +44,6 @@ Rails.application.routes.draw do
       post :recalculate_progress
       post :reorder
       post :link_drop
-      post :import_markdown
-      post :set_plan
-      post :remove_plan
       get :append_as_parent, to: "creatives#append_as_parent", as: :append_as_parent_creative
       get :append_below, to: "creatives#append_below", as: :append_below_creative
       get :export_markdown
@@ -59,6 +56,9 @@ Rails.application.routes.draw do
       get :slide_view
     end
   end
+
+  resources :creative_imports, only: [ :create ]
+  resource :creative_plan, only: [ :create, :destroy ], controller: "creative_plans"
 
   resources :plans, only: [ :create, :destroy, :index ]
 

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,6 +1,7 @@
 require "test_helper"
 require_relative "support/system_helpers"
 require "tmpdir"
+require "fileutils"
 
 Capybara.register_driver :custom_headless_chrome do |app|
   options = Selenium::WebDriver::Chrome::Options.new
@@ -9,7 +10,11 @@ Capybara.register_driver :custom_headless_chrome do |app|
   options.add_argument "--no-sandbox"
   options.add_argument "--disable-dev-shm-usage"
   options.add_argument "--window-size=1920,1080"
-  options.add_argument "--user-data-dir=#{Dir.mktmpdir("chrome-profile-#{Process.pid}-")}"
+  user_data_dir = Dir.mktmpdir("chrome-profile-#{Process.pid}-")
+  options.add_argument "--user-data-dir=#{user_data_dir}"
+  at_exit do
+    FileUtils.remove_entry(user_data_dir) if File.exist?(user_data_dir)
+  end
 
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
 end

--- a/test/controllers/creative_imports_controller_test.rb
+++ b/test/controllers/creative_imports_controller_test.rb
@@ -1,0 +1,41 @@
+require "test_helper"
+
+class CreativeImportsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = User.create!(email: "import@example.com", password: "pw", name: "Importer", email_verified_at: Time.current)
+    sign_in_as(@user)
+  end
+
+  test "imports markdown files" do
+    file = fixture_file_upload("sample.md", "text/markdown")
+
+    before_count = Creative.count
+    post creative_imports_path, params: { markdown: file }
+
+    assert_response :success
+    json = JSON.parse(response.body)
+    assert json["success"]
+    assert json["created"].present?
+    assert_operator Creative.count, :>, before_count
+  end
+
+  test "rejects unsupported file types" do
+    file = fixture_file_upload("invalid.txt", "text/plain")
+
+    assert_no_difference("Creative.count") do
+      post creative_imports_path, params: { markdown: file }
+    end
+
+    assert_response :unprocessable_entity
+    json = JSON.parse(response.body)
+    assert_equal "Invalid file type", json["error"]
+  end
+
+  test "returns unauthorized when user not signed in" do
+    delete session_path
+
+    post creative_imports_path, params: { markdown: fixture_file_upload("sample.md", "text/markdown") }
+
+    assert_response :unauthorized
+  end
+end

--- a/test/controllers/creative_plans_controller_test.rb
+++ b/test/controllers/creative_plans_controller_test.rb
@@ -1,0 +1,35 @@
+require "test_helper"
+
+class CreativePlansControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = User.create!(email: "plan@example.com", password: "pw", name: "Planner", email_verified_at: Time.current)
+    @plan = Plan.create!(name: "Launch", owner: @user, target_date: Date.today)
+    @creative = Creative.create!(user: @user, description: "Root")
+    sign_in_as(@user)
+  end
+
+  test "applies plan tags to creatives" do
+    post creative_plan_path, params: { plan_id: @plan.id, creative_ids: @creative.id }
+
+    assert_redirected_to creatives_path(select_mode: 1)
+    assert_equal 1, @creative.tags.where(label: @plan).count
+    assert_equal I18n.t("creatives.index.plan_tags_applied", default: "Plan tags applied to selected creatives."), flash[:notice]
+  end
+
+  test "removes plan tags from creatives" do
+    @creative.tags.create!(label: @plan)
+
+    delete creative_plan_path, params: { plan_id: @plan.id, creative_ids: @creative.id }
+
+    assert_redirected_to creatives_path(select_mode: 1)
+    assert_not @creative.tags.exists?(label: @plan)
+    assert_equal I18n.t("creatives.index.plan_tags_removed", default: "Plan tag removed from selected creatives."), flash[:notice]
+  end
+
+  test "returns alert when parameters are missing" do
+    post creative_plan_path, params: { plan_id: nil, creative_ids: "" }
+
+    assert_redirected_to creatives_path(select_mode: 1)
+    assert_equal I18n.t("creatives.index.plan_tag_failed", default: "Please select a plan and at least one creative."), flash[:alert]
+  end
+end

--- a/test/fixtures/files/invalid.txt
+++ b/test/fixtures/files/invalid.txt
@@ -1,0 +1,1 @@
+Just a plain text file.

--- a/test/fixtures/files/sample.md
+++ b/test/fixtures/files/sample.md
@@ -1,0 +1,4 @@
+# Sample Creative
+
+- Item one
+- Item two

--- a/test/system/plans_system_test.rb
+++ b/test/system/plans_system_test.rb
@@ -1,0 +1,51 @@
+require "application_system_test_case"
+
+class PlansSystemTest < ApplicationSystemTestCase
+  setup do
+    @user = User.create!(
+      email: "plans-user@example.com",
+      password: SystemHelpers::PASSWORD,
+      name: "Planner",
+      email_verified_at: Time.current,
+      notifications_enabled: false,
+      )
+
+    resize_window_to
+    sign_in_via_ui(@user)
+  end
+
+  test "user can create a plan and see it on the timeline" do
+    find_all(".plans-menu-btn").first.click
+
+    within "#plans-list-area" do
+      fill_in "plan_name", with: "Launch Plan"
+      fill_in "plan_target_date", with: Date.current
+      click_button I18n.t("plans.add_plan")
+    end
+
+    within "#plans-list-area" do
+      assert_selector ".plan-label", text: /Launch Plan/, wait: 5
+    end
+  end
+
+  test "user can delete a plan" do
+    find_all(".plans-menu-btn").first.click
+
+    within "#plans-list-area" do
+      fill_in "plan_name", with: "Plan to be deleted"
+      fill_in "plan_target_date", with: Date.current
+      click_button I18n.t("plans.add_plan")
+    end
+
+    within "#plans-list-area" do
+      assert_selector ".plan-label", text: /Plan to be deleted/, wait: 5
+      find(".plan-label", text: /Plan to be deleted/).find(:xpath, "..").find(".delete-plan-btn").click
+    end
+
+    accept_alert
+
+    within "#plans-list-area" do
+      assert_no_selector ".plan-label", text: /Plan to be deleted/, wait: 5
+    end
+  end
+end


### PR DESCRIPTION
CreativesController 모듈화부터 착수하기

하나의 컨트롤러가 목록·검색, 공유 정보 계산, 순서 변경, 마크다운/PPT 임포트, 플랜 태깅까지 모두 처리하면서 400줄이 넘는 거대한 클래스로 커졌습니다. 이 상태에서는 변경 영향 범위를 파악하기 어렵고, 테스트를 세분화하기도 힘듭니다.

첫 단계로는 index 필터링 로직을 쿼리 객체/서비스로 분리하고, reorder·link_drop을 전담하는 도메인 서비스(예: Creatives::Reorderer)로 분리해 컨트롤러를 가볍게 만드세요.

파일 임포트(import_markdown)와 플랜 태그 설정(set_plan/remove_plan)은 HTTP 엔드포인트가 다르고 트랜잭션 경계도 달라 별도 컨트롤러나 서비스 계층으로 분리하면 책임이 명확해집니다.