### PR TITLE
refactor: creatives model

### DIFF
--- a/app/services/creatives/permission_checker.rb
+++ b/app/services/creatives/permission_checker.rb
@@ -1,0 +1,44 @@
+module Creatives
+  class PermissionChecker
+    def initialize(creative, user)
+      @creative = creative
+      @user = user
+      @cache = Current.respond_to?(:creative_share_cache) ? Current.creative_share_cache : nil
+    end
+
+    def allowed?(required_permission = :read)
+      base = creative.origin_id.nil? ? creative : creative.origin
+      allowed_on_tree?(base, required_permission)
+    end
+
+    private
+
+    attr_reader :creative, :user, :cache
+
+    def allowed_on_tree?(node, required_permission)
+      return true if node.user_id == user&.id
+
+      current = node
+      while current
+        share = share_for(current)
+        if share
+          return false if share.permission.to_s == "no_access"
+
+          if permission_rank(share.permission) >= permission_rank(required_permission)
+            return true
+          end
+        end
+        current = current.parent
+      end
+      false
+    end
+
+    def share_for(node)
+      cache ? cache[node.id] : CreativeShare.find_by(user: user, creative: node)
+    end
+
+    def permission_rank(value)
+      CreativeShare.permissions[value.to_s]
+    end
+  end
+end

--- a/app/services/creatives/progress_service.rb
+++ b/app/services/creatives/progress_service.rb
@@ -1,0 +1,74 @@
+require "set"
+
+module Creatives
+  class ProgressService
+    def self.recalculate_all!
+      Creative.roots.find_each { |root| new(root).recalculate_subtree! }
+    end
+
+    def initialize(creative)
+      @creative = creative
+    end
+
+    def recalculate_subtree!
+      if creative.origin_id.nil?
+        creative.children.each { |child| self.class.new(child).recalculate_subtree! }
+        if creative.children.any?
+          creative.update(progress: creative.children.average(:progress) || 0)
+        end
+      else
+        self.class.new(creative.origin).recalculate_subtree!
+      end
+    end
+
+    def update_parent_progress!
+      creative.linked_creatives.update_all(progress: creative[:progress])
+      parent = creative.parent
+      return unless parent
+
+      parent.reload
+      new_progress = if parent.children.any?
+                       parent.children.map(&:progress).sum.to_f / parent.children.size
+      else
+                       0
+      end
+      parent.update(progress: new_progress)
+    end
+
+    def progress_for_tags(tag_ids, user)
+      return creative.progress if tag_ids.blank?
+
+      tag_ids = Array(tag_ids).map(&:to_s)
+      visible_children = creative.children_with_permission(user)
+      child_values = visible_children.map do |child|
+        self.class.new(child).progress_for_tags(tag_ids, user)
+      end.compact
+
+      if child_values.any?
+        child_values.sum.to_f / child_values.size
+      else
+        own_label_ids = creative.tags.pluck(:label_id).map(&:to_s)
+        if (own_label_ids & tag_ids).any?
+          visible_children.any? ? 1.0 : creative.progress
+        end
+      end
+    end
+
+    # `tagged_ids` should be a Set of creative IDs tagged with the plan.
+    def progress_for_plan(tagged_ids)
+      child_values = creative.children.map do |child|
+        self.class.new(child).progress_for_plan(tagged_ids)
+      end.compact
+
+      if child_values.any?
+        child_values.sum.to_f / child_values.size
+      elsif tagged_ids.include?(creative.id)
+        creative.children.any? ? 1.0 : creative.progress
+      end
+    end
+
+    private
+
+    attr_reader :creative
+  end
+end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -19,10 +19,15 @@ Capybara.register_driver :custom_headless_chrome do |app|
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
 end
 
+DRIVER_ENV_KEY = "SYSTEM_TEST_DRIVER".freeze
+
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   include SystemHelpers
 
-  # for local development test with chrome
-  # driven_by :selenium, using: :chrome, screen_size: [ 1920, 1080 ]
-  driven_by :custom_headless_chrome
+  driver_name = ENV.fetch(DRIVER_ENV_KEY, "custom_headless_chrome")
+  if driver_name == "chrome"
+    driven_by :selenium, using: :chrome, screen_size: [ 1920, 1080 ]
+  else
+    driven_by driver_name.to_sym
+  end
 end


### PR DESCRIPTION
Creative 모델의 도메인 책임 분리

현재 모델은 진행률 재계산, 권한 판정, 링크드 크리에이티브 생성, 구독자·태그 관리까지 모두 포함한 거대한 도메인 객체입니다.

진행률/태그 관련 계산(recalculate_subtree_progress!, progress_for_tags, progress_for_plan)은 별도 서비스나 Concern으로 옮겨 테스트하기 쉬운 순수 로직으로 만들고, 권한 판정(has_permission?)도 캐시 전략과 분리된 정책 객체로 빼면 각 책임이 명확해집니다.

이렇게 모델을 슬림하게 만든 뒤 컨트롤러에서 호출하던 비즈니스 로직을 새 서비스 계층으로 대체하면 CreativesController 정리 작업과도 시너지를 낼 수 있습니다.