### PR TITLE
Show localized timestamp tooltip on comments

### DIFF
--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -10,8 +10,16 @@
          else
            t('comments.gemini')
          end %>
+    <% timestamp = comment.created_at.in_time_zone %>
     <strong><%= display_name %></strong>
-    <span>· <%= t('datetime.ago', time: time_ago_in_words(comment.created_at)) %></span>
+    <span>
+      · <%= content_tag(
+        :time,
+        t('datetime.ago', time: time_ago_in_words(timestamp)),
+        title: l(timestamp, format: :chat_timestamp),
+        datetime: timestamp.iso8601
+      ) %>
+    </span>
     <% if comment.private? %>
       <span class="private-label">[<%= t('comments.private') %>]</span>
     <% end %>

--- a/config/locales/datetime.en.yml
+++ b/config/locales/datetime.en.yml
@@ -1,3 +1,6 @@
 en:
+  time:
+    formats:
+      chat_timestamp: "%Y-%m-%d %H:%M:%S"
   datetime:
-    ago: "%{time} age"
+    ago: "%{time} ago"

--- a/config/locales/datetime.ko.yml
+++ b/config/locales/datetime.ko.yml
@@ -6,6 +6,7 @@ ko:
     formats:
       long: "%Y년 %m월 %d일 %H:%M:%S"
       short: "%Y-%m-%d %H:%M:%S"
+      chat_timestamp: "%Y-%m-%d %H:%M:%S"
   datetime:
     ago: "%{time} 전"
     distance_in_words:


### PR DESCRIPTION
## Summary
- render comment timestamps inside a `<time>` tag with a localized tooltip formatted for each locale
- add a dedicated `chat_timestamp` time format for English and Korean locales to support the tooltip display

## Testing
- ./bin/rubocop -a
- bundle exec rails test *(fails: `NoMethodError: undefined method 'has_closure_tree' for class Creative` during test setup)*
- bundle exec rails test:system *(fails: `NoMethodError: undefined method 'has_closure_tree' for class Creative` during test setup)*

------
https://chatgpt.com/codex/tasks/task_e_68d4bb51eb48832687f1574ff166c6c7