### PR TITLE
Display user list as table with notification info

### DIFF
--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -4,19 +4,48 @@
 
 <h1 class="no-top-margin"><%= t('users.index_title') %></h1>
 
-<ul>
-  <% @users.each do |user| %>
-    <% last_login_at = user.sessions.max_by(&:updated_at)&.updated_at %>
-    <li>
-      <%= render AvatarComponent.new(
-            user: user,
-            size: 20,
-            classes: "avatar comment-presence-avatar#{' inactive' if user.sessions.empty?}" ) %>
-      <%= user.display_name %> (<%= user.email %>)
-      <% if last_login_at %>
-        - <%= t('users.last_login_at', time: I18n.l(last_login_at, format: :short)) %>
-      <% end %>
-      - <%= user.devices.any? ? t('users.push_token_present') : t('users.push_token_absent') %>
-    </li>
-  <% end %>
-</ul>
+<table>
+  <thead>
+    <tr>
+      <th><%= t('users.table.avatar') %></th>
+      <th><%= t('users.table.name') %></th>
+      <th><%= t('users.table.email') %></th>
+      <th><%= t('users.table.last_login_at') %></th>
+      <th><%= t('users.table.push_token') %></th>
+      <th><%= t('users.table.notifications') %></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @users.each do |user| %>
+      <% last_login_at = user.sessions.max_by(&:updated_at)&.updated_at %>
+      <tr>
+        <td>
+          <%= render AvatarComponent.new(
+                user: user,
+                size: 20,
+                classes: "avatar comment-presence-avatar#{' inactive' if user.sessions.empty?}" ) %>
+        </td>
+        <td><%= user.display_name %></td>
+        <td><%= user.email %></td>
+        <td>
+          <% if last_login_at %>
+            <%= I18n.l(last_login_at, format: :short) %>
+          <% else %>
+            <%= t('users.table.last_login_unknown') %>
+          <% end %>
+        </td>
+        <td><%= user.devices.any? ? t('users.push_token_present') : t('users.push_token_absent') %></td>
+        <td>
+          <% case user.notifications_enabled %>
+          <% when true %>
+            <%= t('users.table.notifications_enabled') %>
+          <% when false %>
+            <%= t('users.table.notifications_disabled') %>
+          <% else %>
+            <%= t('users.table.notifications_unset') %>
+          <% end %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/config/locales/users.en.yml
+++ b/config/locales/users.en.yml
@@ -27,7 +27,6 @@ en:
     avatar_url: "Avatar URL"
     update_profile: "Update Profile"
     index_title: "Users"
-    last_login_at: "Last login: %{time}"
     push_token_present: "Push token present"
     push_token_absent: "No push token"
     display_level: "Max Display Level"
@@ -53,6 +52,17 @@ en:
     send_password_reset_instructions: "Email reset instructions"
     email_verified: "Email verified successfully."
     verification_invalid: "Verification link is invalid or has expired."
+    table:
+      avatar: "Avatar"
+      name: "Name"
+      email: "Email"
+      last_login_at: "Last login"
+      last_login_unknown: "Never"
+      push_token: "Push token"
+      notifications: "Notifications"
+      notifications_enabled: "Enabled"
+      notifications_disabled: "Disabled"
+      notifications_unset: "Not configured"
   user_mailer:
     email_verification:
       subject: "Verify your email"

--- a/config/locales/users.ko.yml
+++ b/config/locales/users.ko.yml
@@ -27,7 +27,6 @@ ko:
     avatar_url: "아바타 URL"
     update_profile: "프로파일 업데이트"
     index_title: "사용자 목록"
-    last_login_at: "마지막 로그인: %{time}"
     push_token_present: "푸시 토큰 있음"
     push_token_absent: "푸시 토큰 없음"
     display_level: "최대 표시 레벨"
@@ -53,6 +52,17 @@ ko:
     send_password_reset_instructions: "비밀번호 재설정 이메일 보내기"
     email_verified: "이메일 인증이 완료되었습니다."
     verification_invalid: "인증 링크가 유효하지 않거나 만료되었습니다."
+    table:
+      avatar: "아바타"
+      name: "이름"
+      email: "이메일"
+      last_login_at: "마지막 로그인"
+      last_login_unknown: "로그인 기록 없음"
+      push_token: "푸시 토큰"
+      notifications: "알림 설정"
+      notifications_enabled: "사용"
+      notifications_disabled: "사용 안 함"
+      notifications_unset: "설정되지 않음"
   user_mailer:
     email_verification:
       subject: "이메일 인증"


### PR DESCRIPTION
## Summary
- present the users index as a table that shows avatar, contact details, last login, push token, and notification state
- add English and Korean translations for the new table headers and notification status labels

## Testing
- ./bin/rubocop -a
- ./bin/rails test
- ./bin/rails test:system *(fails: Selenium cannot download chromedriver in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4ca187e708326a55f269dc38e071d