### PR TITLE
Add system admin flag and gated user deletion

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -38,4 +38,10 @@ class ApplicationController < ActionController::Base
     zone = Current.user&.timezone
     zone.present? ? Time.use_zone(zone, &action) : action.call
   end
+
+  def require_system_admin!
+    return if Current.user&.system_admin?
+
+    redirect_to root_path, alert: t("users.admin_required")
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   allow_unauthenticated_access only: [ :new, :create, :exists ]
-  before_action :require_system_admin!, only: [ :index, :destroy ]
+  before_action :require_system_admin!, only: [ :index, :destroy, :grant_system_admin ]
 
   def new
     @user = User.new
@@ -67,6 +67,16 @@ class UsersController < ApplicationController
       redirect_to users_path, notice: t("users.destroy.success")
     else
       redirect_to users_path, alert: t("users.destroy.failure")
+    end
+  end
+
+  def grant_system_admin
+    @user = User.find(params[:id])
+
+    if @user.update(system_admin: true)
+      redirect_to users_path, notice: t("users.system_admin.granted")
+    else
+      redirect_to users_path, alert: t("users.system_admin.failed")
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   allow_unauthenticated_access only: [ :new, :create, :exists ]
-  before_action :require_system_admin!, only: [ :index, :destroy, :grant_system_admin ]
+  before_action :require_system_admin!, only: [ :index, :destroy, :grant_system_admin, :revoke_system_admin ]
 
   def new
     @user = User.new
@@ -75,6 +75,16 @@ class UsersController < ApplicationController
 
     if @user.update(system_admin: true)
       redirect_to users_path, notice: t("users.system_admin.granted")
+    else
+      redirect_to users_path, alert: t("users.system_admin.failed")
+    end
+  end
+
+  def revoke_system_admin
+    @user = User.find(params[:id])
+
+    if @user.update(system_admin: false)
+      redirect_to users_path, notice: t("users.system_admin.revoked")
     else
       redirect_to users_path, alert: t("users.system_admin.failed")
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,6 @@
 class UsersController < ApplicationController
   allow_unauthenticated_access only: [ :new, :create, :exists ]
+  before_action :require_system_admin!, only: [ :index, :destroy ]
 
   def new
     @user = User.new
@@ -52,6 +53,21 @@ class UsersController < ApplicationController
   # Show a single user
   def show
     @user = User.find(params[:id])
+  end
+
+  def destroy
+    @user = User.find(params[:id])
+
+    if @user == Current.user
+      redirect_to users_path, alert: t("users.destroy.cannot_delete_self")
+      return
+    end
+
+    if @user.destroy
+      redirect_to users_path, notice: t("users.destroy.success")
+    else
+      redirect_to users_path, alert: t("users.destroy.failure")
+    end
   end
 
   def update

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,9 +3,17 @@ class User < ApplicationRecord
 
   has_secure_password
   has_many :sessions, dependent: :destroy
-  has_many :creatives
-  has_many :labels, foreign_key: :owner_id
+  has_many :calendar_events, dependent: :destroy
+  has_many :creatives, dependent: :destroy
+  has_many :labels, foreign_key: :owner_id, dependent: :destroy
   has_many :devices, dependent: :destroy
+  has_many :comment_read_pointers, dependent: :destroy
+  has_many :creative_expanded_states, dependent: :destroy
+  has_many :creative_shares, dependent: :destroy
+  has_many :comments, dependent: :destroy
+  has_many :emails, dependent: :destroy
+  has_many :inbox_items, foreign_key: :owner_id, dependent: :destroy, inverse_of: :owner
+  has_many :invitations, foreign_key: :inviter_id, dependent: :destroy, inverse_of: :inviter
 
   has_one_attached :avatar
 
@@ -17,6 +25,7 @@ class User < ApplicationRecord
   attribute :notifications_enabled, :boolean
   attribute :timezone, :string
   attribute :locale, :string
+  attribute :system_admin, :boolean, default: false
 
   attribute :google_uid, :string
   attribute :google_access_token, :string

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -13,6 +13,7 @@
       <th><%= t('users.table.last_login_at') %></th>
       <th><%= t('users.table.push_token') %></th>
       <th><%= t('users.table.notifications') %></th>
+      <th><%= t('users.table.actions') %></th>
     </tr>
   </thead>
   <tbody>
@@ -43,6 +44,16 @@
             <%= t('users.table.notifications_disabled') %>
           <% else %>
             <%= t('users.table.notifications_unset') %>
+          <% end %>
+        </td>
+        <td>
+          <% if user != Current.user %>
+            <%= button_to t('users.delete'),
+                          user_path(user),
+                          method: :delete,
+                          form: { data: { turbo_confirm: t('users.confirm_destroy') } } %>
+          <% else %>
+            <span class="text-muted"><%= t('users.table.current_user') %></span>
           <% end %>
         </td>
       </tr>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -48,6 +48,14 @@
         </td>
         <td>
           <% if user != Current.user %>
+            <% if user.system_admin? %>
+              <span class="text-muted"><%= t('users.table.system_admin') %></span>
+            <% else %>
+              <%= button_to t('users.make_system_admin'),
+                            grant_system_admin_user_path(user),
+                            method: :patch,
+                            form: { data: { turbo_confirm: t('users.confirm_grant_system_admin') } } %>
+            <% end %>
             <%= button_to t('users.delete'),
                           user_path(user),
                           method: :delete,

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -49,7 +49,9 @@
         <td>
           <% if user != Current.user %>
             <% if user.system_admin? %>
-              <span class="text-muted"><%= t('users.table.system_admin') %></span>
+              <%= button_to t('users.make_normal_user'),
+                            revoke_system_admin_user_path(user),
+                            method: :patch %>
             <% else %>
               <%= button_to t('users.make_system_admin'),
                             grant_system_admin_user_path(user),

--- a/config/locales/users.en.yml
+++ b/config/locales/users.en.yml
@@ -28,6 +28,7 @@ en:
     update_profile: "Update Profile"
     delete: "Delete"
     make_system_admin: "Make system admin"
+    make_normal_user: "Make normal user"
     confirm_grant_system_admin: "Grant system admin access to this user?"
     confirm_destroy: "Are you sure you want to delete all of this user's data?"
     index_title: "Users"
@@ -59,6 +60,7 @@ en:
     admin_required: "You must be a system administrator to access that page."
     system_admin:
       granted: "System admin access granted."
+      revoked: "System admin access removed."
       failed: "Could not update the user's system admin status."
     destroy:
       success: "The user and all associated data have been deleted."

--- a/config/locales/users.en.yml
+++ b/config/locales/users.en.yml
@@ -27,6 +27,8 @@ en:
     avatar_url: "Avatar URL"
     update_profile: "Update Profile"
     delete: "Delete"
+    make_system_admin: "Make system admin"
+    confirm_grant_system_admin: "Grant system admin access to this user?"
     confirm_destroy: "Are you sure you want to delete all of this user's data?"
     index_title: "Users"
     push_token_present: "Push token present"
@@ -55,6 +57,9 @@ en:
     email_verified: "Email verified successfully."
     verification_invalid: "Verification link is invalid or has expired."
     admin_required: "You must be a system administrator to access that page."
+    system_admin:
+      granted: "System admin access granted."
+      failed: "Could not update the user's system admin status."
     destroy:
       success: "The user and all associated data have been deleted."
       failure: "Could not delete the user."
@@ -72,6 +77,7 @@ en:
       notifications_unset: "Not configured"
       actions: "Actions"
       current_user: "This is you"
+      system_admin: "System admin"
   user_mailer:
     email_verification:
       subject: "Verify your email"

--- a/config/locales/users.en.yml
+++ b/config/locales/users.en.yml
@@ -26,6 +26,8 @@ en:
     avatar: "Avatar"
     avatar_url: "Avatar URL"
     update_profile: "Update Profile"
+    delete: "Delete"
+    confirm_destroy: "Are you sure you want to delete all of this user's data?"
     index_title: "Users"
     push_token_present: "Push token present"
     push_token_absent: "No push token"
@@ -52,6 +54,11 @@ en:
     send_password_reset_instructions: "Email reset instructions"
     email_verified: "Email verified successfully."
     verification_invalid: "Verification link is invalid or has expired."
+    admin_required: "You must be a system administrator to access that page."
+    destroy:
+      success: "The user and all associated data have been deleted."
+      failure: "Could not delete the user."
+      cannot_delete_self: "You cannot delete your own account."
     table:
       avatar: "Avatar"
       name: "Name"
@@ -63,6 +70,8 @@ en:
       notifications_enabled: "Enabled"
       notifications_disabled: "Disabled"
       notifications_unset: "Not configured"
+      actions: "Actions"
+      current_user: "This is you"
   user_mailer:
     email_verification:
       subject: "Verify your email"

--- a/config/locales/users.ko.yml
+++ b/config/locales/users.ko.yml
@@ -28,6 +28,7 @@ ko:
     update_profile: "프로파일 업데이트"
     delete: "삭제"
     make_system_admin: "시스템 관리자 지정"
+    make_normal_user: "일반 사용자로 변경"
     confirm_grant_system_admin: "이 사용자에게 시스템 관리자 권한을 부여할까요?"
     confirm_destroy: "사용자의 모든 정보를 삭제하시겠습니까?"
     index_title: "사용자 목록"
@@ -59,6 +60,7 @@ ko:
     admin_required: "시스템 관리자만 접근할 수 있습니다."
     system_admin:
       granted: "시스템 관리자 권한이 부여되었습니다."
+      revoked: "시스템 관리자 권한이 해제되었습니다."
       failed: "사용자의 시스템 관리자 상태를 변경하지 못했습니다."
     destroy:
       success: "사용자와 모든 관련 데이터가 삭제되었습니다."

--- a/config/locales/users.ko.yml
+++ b/config/locales/users.ko.yml
@@ -27,6 +27,8 @@ ko:
     avatar_url: "아바타 URL"
     update_profile: "프로파일 업데이트"
     delete: "삭제"
+    make_system_admin: "시스템 관리자 지정"
+    confirm_grant_system_admin: "이 사용자에게 시스템 관리자 권한을 부여할까요?"
     confirm_destroy: "사용자의 모든 정보를 삭제하시겠습니까?"
     index_title: "사용자 목록"
     push_token_present: "푸시 토큰 있음"
@@ -55,6 +57,9 @@ ko:
     email_verified: "이메일 인증이 완료되었습니다."
     verification_invalid: "인증 링크가 유효하지 않거나 만료되었습니다."
     admin_required: "시스템 관리자만 접근할 수 있습니다."
+    system_admin:
+      granted: "시스템 관리자 권한이 부여되었습니다."
+      failed: "사용자의 시스템 관리자 상태를 변경하지 못했습니다."
     destroy:
       success: "사용자와 모든 관련 데이터가 삭제되었습니다."
       failure: "사용자를 삭제하지 못했습니다."
@@ -72,6 +77,7 @@ ko:
       notifications_unset: "설정되지 않음"
       actions: "작업"
       current_user: "현재 사용자"
+      system_admin: "시스템 관리자"
   user_mailer:
     email_verification:
       subject: "이메일 인증"

--- a/config/locales/users.ko.yml
+++ b/config/locales/users.ko.yml
@@ -26,6 +26,8 @@ ko:
     avatar: "아바타"
     avatar_url: "아바타 URL"
     update_profile: "프로파일 업데이트"
+    delete: "삭제"
+    confirm_destroy: "사용자의 모든 정보를 삭제하시겠습니까?"
     index_title: "사용자 목록"
     push_token_present: "푸시 토큰 있음"
     push_token_absent: "푸시 토큰 없음"
@@ -52,6 +54,11 @@ ko:
     send_password_reset_instructions: "비밀번호 재설정 이메일 보내기"
     email_verified: "이메일 인증이 완료되었습니다."
     verification_invalid: "인증 링크가 유효하지 않거나 만료되었습니다."
+    admin_required: "시스템 관리자만 접근할 수 있습니다."
+    destroy:
+      success: "사용자와 모든 관련 데이터가 삭제되었습니다."
+      failure: "사용자를 삭제하지 못했습니다."
+      cannot_delete_self: "자신의 계정은 삭제할 수 없습니다."
     table:
       avatar: "아바타"
       name: "이름"
@@ -63,6 +70,8 @@ ko:
       notifications_enabled: "사용"
       notifications_disabled: "사용 안 함"
       notifications_unset: "설정되지 않음"
+      actions: "작업"
+      current_user: "현재 사용자"
   user_mailer:
     email_verification:
       subject: "이메일 인증"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
     member do
       get :edit_password
       patch :update_password
+      patch :grant_system_admin
     end
     collection do
       get :exists

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,7 @@ Rails.application.routes.draw do
       get :edit_password
       patch :update_password
       patch :grant_system_admin
+      patch :revoke_system_admin
     end
     collection do
       get :exists

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,7 @@ Rails.application.routes.draw do
 
   root "creatives#index"
 
-  resources :users, only: [ :new, :create, :index, :show, :update ] do
+  resources :users, only: [ :new, :create, :index, :show, :update, :destroy ] do
     member do
       get :edit_password
       patch :update_password

--- a/db/migrate/20250924000000_add_system_admin_to_users.rb
+++ b/db/migrate/20250924000000_add_system_admin_to_users.rb
@@ -1,0 +1,6 @@
+class AddSystemAdminToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :system_admin, :boolean, null: false, default: false
+    add_index :users, :system_admin
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_23_002959) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_24_000000) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
     t.text "body"
@@ -379,7 +379,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_23_002959) do
     t.datetime "google_token_expires_at"
     t.string "timezone"
     t.string "locale"
+    t.boolean "system_admin", default: false, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["system_admin"], name: "index_users_on_system_admin"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,7 +9,8 @@ unless User.exists?(email: default_email)
   User.create!(
     email: default_email,
     password: ENV.fetch('DEFAULT_USER_PASSWORD', 'password123'),
-    password_confirmation: ENV.fetch('DEFAULT_USER_PASSWORD', 'password123')
+    password_confirmation: ENV.fetch('DEFAULT_USER_PASSWORD', 'password123'),
+    system_admin: true
   )
   puts "Created default user with email: #{default_email}"
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -32,6 +32,15 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_not @regular_user.reload.system_admin?
   end
 
+  test "non admin cannot revoke system admin" do
+    sign_in_as(@regular_user, password: "password")
+
+    patch revoke_system_admin_user_path(@admin)
+
+    assert_redirected_to root_path
+    assert @admin.reload.system_admin?
+  end
+
   test "system admin can grant system admin" do
     sign_in_as(@admin, password: "password")
 
@@ -43,6 +52,19 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_equal I18n.t("users.system_admin.granted"), flash[:notice]
     assert @regular_user.reload.system_admin?
+  end
+
+  test "system admin can revoke system admin" do
+    sign_in_as(@admin, password: "password")
+
+    @regular_user.update!(system_admin: true)
+
+    patch revoke_system_admin_user_path(@regular_user)
+
+    assert_redirected_to users_path
+    follow_redirect!
+    assert_equal I18n.t("users.system_admin.revoked"), flash[:notice]
+    refute @regular_user.reload.system_admin?
   end
 
   test "system admin cannot delete themselves" do

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,0 +1,97 @@
+require "test_helper"
+
+class UsersControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @admin = users(:one)
+    @regular_user = users(:two)
+  end
+
+  test "non admin cannot access user index" do
+    sign_in_as(@regular_user, password: "password")
+
+    get users_path
+    assert_redirected_to root_path
+    follow_redirect!
+    assert_equal I18n.t("users.admin_required"), flash[:alert]
+  end
+
+  test "system admin can access user index" do
+    sign_in_as(@admin, password: "password")
+
+    get users_path
+    assert_response :success
+    assert_includes response.body, @regular_user.email
+  end
+
+  test "system admin cannot delete themselves" do
+    sign_in_as(@admin, password: "password")
+
+    assert_no_difference("User.count") do
+      delete user_path(@admin)
+    end
+
+    assert_redirected_to users_path
+    follow_redirect!
+    assert_equal I18n.t("users.destroy.cannot_delete_self"), flash[:alert]
+  end
+
+  test "system admin can delete a user and all associated data" do
+    sign_in_as(@admin, password: "password")
+
+    user_to_delete = @regular_user
+    creative = Creative.create!(user: user_to_delete, description: "Test creative")
+    comment = Comment.create!(creative: creative, user: user_to_delete, content: "Test comment")
+    pointer = CommentReadPointer.create!(user: user_to_delete, creative: creative, last_read_comment: comment)
+    expanded_state = CreativeExpandedState.create!(user: user_to_delete, creative: creative, expanded_status: { creative.id => true })
+    share = CreativeShare.create!(creative: creative, user: user_to_delete, permission: :read)
+    calendar_event = CalendarEvent.create!(
+      user: user_to_delete,
+      creative: creative,
+      google_event_id: "evt-123",
+      start_time: Time.current,
+      end_time: 1.hour.from_now
+    )
+    device = Device.create!(
+      user: user_to_delete,
+      client_id: "client-#{SecureRandom.uuid}",
+      device_type: :web,
+      fcm_token: "fcm-#{SecureRandom.uuid}"
+    )
+    email = Email.create!(user: user_to_delete, email: user_to_delete.email, subject: "Test", event: :invitation)
+    inbox_item = InboxItem.create!(owner: user_to_delete, message_key: "test.key", message_params: {})
+    invitation = Invitation.create!(inviter: user_to_delete, creative: creative, permission: :read)
+    plan = Plan.create!(owner: user_to_delete, name: "Sample Plan", target_date: Date.current)
+    tag = Tag.create!(label: plan, creative_id: creative.id)
+    session = user_to_delete.sessions.create!(user_agent: "TestAgent", ip_address: "127.0.0.1")
+
+    fake_calendar_service = Minitest::Mock.new
+    fake_calendar_service.expect(:delete_event, true, [ calendar_event.google_event_id ])
+
+    GoogleCalendarService.stub :new, fake_calendar_service do
+      assert_difference("User.count", -1) do
+        delete user_path(user_to_delete)
+      end
+    end
+
+    fake_calendar_service.verify
+
+    assert_redirected_to users_path
+    follow_redirect!
+    assert_equal I18n.t("users.destroy.success"), flash[:notice]
+
+    refute User.exists?(user_to_delete.id)
+    refute Creative.exists?(creative.id)
+    refute Comment.exists?(comment.id)
+    refute CommentReadPointer.exists?(pointer.id)
+    refute CreativeExpandedState.exists?(expanded_state.id)
+    refute CreativeShare.exists?(share.id)
+    refute CalendarEvent.exists?(calendar_event.id)
+    refute Device.exists?(device.id)
+    refute Email.exists?(email.id)
+    refute InboxItem.exists?(inbox_item.id)
+    refute Invitation.exists?(invitation.id)
+    refute Plan.exists?(plan.id)
+    refute Tag.exists?(tag.id)
+    refute Session.exists?(session.id)
+  end
+end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -23,6 +23,28 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_includes response.body, @regular_user.email
   end
 
+  test "non admin cannot grant system admin" do
+    sign_in_as(@regular_user, password: "password")
+
+    patch grant_system_admin_user_path(@regular_user)
+
+    assert_redirected_to root_path
+    assert_not @regular_user.reload.system_admin?
+  end
+
+  test "system admin can grant system admin" do
+    sign_in_as(@admin, password: "password")
+
+    refute @regular_user.system_admin?
+
+    patch grant_system_admin_user_path(@regular_user)
+
+    assert_redirected_to users_path
+    follow_redirect!
+    assert_equal I18n.t("users.system_admin.granted"), flash[:notice]
+    assert @regular_user.reload.system_admin?
+  end
+
   test "system admin cannot delete themselves" do
     sign_in_as(@admin, password: "password")
 

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -4,8 +4,10 @@ one:
   email: one@example1.com
   password_digest: <%= password_digest %>
   name: One
+  system_admin: true
 
 two:
   email: two@example1.com
   password_digest: <%= password_digest %>
   name: Two
+  system_admin: false

--- a/test/integration/users_index_test.rb
+++ b/test/integration/users_index_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class UsersIndexTest < ActionDispatch::IntegrationTest
   setup do
-    @viewer = User.create!(email: "viewer@example.com", password: "pw", name: "Viewer")
+    @viewer = User.create!(email: "viewer@example.com", password: "pw", name: "Viewer", system_admin: true)
     sign_in_as(@viewer)
   end
 


### PR DESCRIPTION
## Summary
- add a `system_admin` flag on users and cascade removal of related records when an account is deleted
- gate the user index behind system-admin access and add a destroy action with self-delete protection and flash messaging
- surface a delete control on the user list with Korean/English i18n plus controller and integration coverage

## Testing
- ./bin/rubocop -a
- bin/rails test
- bin/rails test:system *(fails: Selenium could not download chromedriver in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4d0fa68e48326957eada734d75c70