### PR TITLE
Skip inbox summary email when notifications disabled

### DIFF
--- a/app/jobs/inbox_summary_job.rb
+++ b/app/jobs/inbox_summary_job.rb
@@ -4,6 +4,11 @@ class InboxSummaryJob < ApplicationJob
   def perform
     Rails.logger.info("Running InboxSummaryJob")
     User.find_each do |user|
+      if user.notifications_enabled == false
+        Rails.logger.info("Skipping inbox summary for #{user.email} because notifications are disabled")
+        next
+      end
+
       items = InboxItem.where(owner: user, state: "new").order(created_at: :desc).limit(10)
       if items.empty?
         Rails.logger.info("No new inbox items for #{user.email}")

--- a/test/jobs/inbox_summary_job_test.rb
+++ b/test/jobs/inbox_summary_job_test.rb
@@ -17,6 +17,16 @@ class InboxSummaryJobTest < ActiveJob::TestCase
     assert Email.order(:created_at).last.body.present?, "email body should be saved"
   end
 
+  test "does not send email when user has notifications disabled" do
+    user = users(:one)
+    user.update!(notifications_enabled: false)
+    InboxItem.create!(message_key: "inbox.no_messages", message_params: {}, owner: user)
+
+    assert_emails 0 do
+      InboxSummaryJob.perform_now
+    end
+  end
+
   test "does not send email when user has no new items" do
     assert_emails 0 do
       InboxSummaryJob.perform_now


### PR DESCRIPTION
## Summary
- avoid sending inbox summary email to users who have notifications disabled and log the skip
- add a regression test confirming email is suppressed when notifications are turned off

## Testing
- ./bin/rubocop -a
- bundle exec rails test *(fails: NoMethodError from closure_tree gem: `has_closure_tree` undefined for Creative)*
- bundle exec rails test:system *(fails: same NoMethodError from closure_tree gem)*

------
https://chatgpt.com/codex/tasks/task_e_68d4e9cbb2e88326997ab7b18ccb8df7