### PR TITLE
Show message when creative search is empty

### DIFF
--- a/app/views/creatives/index.html.erb
+++ b/app/views/creatives/index.html.erb
@@ -107,10 +107,12 @@
 <% end %>
 
 <div id="creatives">
-  <% if @creatives %>
+  <% if @creatives.present? %>
     <%= render_creative_tree(@creatives, 1, select_mode: false, max_level: Current.user&.display_level || User::DEFAULT_DISPLAY_LEVEL) %>
   <% else %>
-    <% if params[:id] && @creative && !@creative.has_permission?(Current.user, :read) %>
+    <% if params[:search].present? %>
+      <p style="text-align: center;"><%= t('.no_search_results') %></p>
+    <% elsif params[:id] && @creative && !@creative.has_permission?(Current.user, :read) %>
       <p style="text-align: center;"><%= t('.no_permission') %></p>
       <div style="text-align: center;">
         <%= button_to t('.request_permission'), request_permission_creative_path(@creative), method: :post %>

--- a/config/locales/creatives.en.yml
+++ b/config/locales/creatives.en.yml
@@ -24,6 +24,7 @@ en:
       recalculate_all_parent_progress: "Recalculate all parent progress?"
       no_creatives: "No creatives found."
       no_sub_creatives: "No sub-creatives found."
+      no_search_results: "No creatives match your search."
       recommend_parent: "Recommend Category"
       import_uploading: "Uploading..."
       import_success: "Import successful! Reloading..."

--- a/config/locales/creatives.ko.yml
+++ b/config/locales/creatives.ko.yml
@@ -24,6 +24,7 @@ ko:
       recalculate_all_parent_progress: "모든 상위 진행률을 다시 계산하시겠습니까?"
       no_creatives: "크리에이티브가 없습니다."
       no_sub_creatives: "하위 크리에이티브가 없습니다."
+      no_search_results: "검색 결과가 없습니다."
       recommend_parent: "카테고리 추천"
       import_uploading: "업로드 중..."
       import_success: "가져오기 성공! 새로고침 중..."


### PR DESCRIPTION
## Summary
- show an empty-state message when creative search returns no results
- add English and Korean translations for the new empty-state message

## Testing
- ./bin/rubocop -a
- bundle exec rails test *(fails: "NoMethodError: undefined method 'has_closure_tree' for class Creative" occurs before tests run)*
- bundle exec rails test:system *(fails: "NoMethodError: undefined method 'has_closure_tree' for class Creative" occurs before tests run)*

------
https://chatgpt.com/codex/tasks/task_e_68d5dab010ec8326a4440ed0ee8f2fc4