### PR TITLE
Include commit info in PR analyzer prompt

### DIFF
--- a/app/services/github/pull_request_processor.rb
+++ b/app/services/github/pull_request_processor.rb
@@ -37,7 +37,19 @@ module Github
       paths = Creatives::PathExporter.new(creative).paths
       return if paths.blank?
 
-      analyzer = Github::PullRequestAnalyzer.new(payload: payload, creative: creative, paths: paths)
+      repo_full_name = payload.dig("repository", "full_name")
+      pr = payload["pull_request"]
+      client = Github::Client.new(link.github_account)
+      commit_messages = client.pull_request_commit_messages(repo_full_name, pr["number"])
+      diff = client.pull_request_diff(repo_full_name, pr["number"])
+
+      analyzer = Github::PullRequestAnalyzer.new(
+        payload: payload,
+        creative: creative,
+        paths: paths,
+        commit_messages: commit_messages,
+        diff: diff
+      )
       result = analyzer.call
       return unless result
 

--- a/test/services/github/pull_request_analyzer_test.rb
+++ b/test/services/github/pull_request_analyzer_test.rb
@@ -1,0 +1,52 @@
+require "test_helper"
+
+module Github
+  class PullRequestAnalyzerTest < ActiveSupport::TestCase
+    test "builds prompt with commit messages and diff" do
+      payload = {
+        "pull_request" => {
+          "title" => "Improve feature",
+          "body" => "Adds improvements"
+        }
+      }
+
+      analyzer = Github::PullRequestAnalyzer.new(
+        payload: payload,
+        creative: creatives(:tshirt),
+        paths: [ "Root > Child" ],
+        commit_messages: [ "Refactor module", "Add tests" ],
+        diff: "diff --git a/file.rb b/file.rb\n+change"
+      )
+
+      messages = analyzer.send(:build_messages)
+      prompt = messages.dig(0, :parts, 0, :text)
+
+      assert_includes prompt, "1. Refactor module"
+      assert_includes prompt, "2. Add tests"
+      assert_includes prompt, "diff --git a/file.rb b/file.rb"
+    end
+
+    test "handles missing commit messages and diff" do
+      payload = {
+        "pull_request" => {
+          "title" => "Improve feature",
+          "body" => "Adds improvements"
+        }
+      }
+
+      analyzer = Github::PullRequestAnalyzer.new(
+        payload: payload,
+        creative: creatives(:tshirt),
+        paths: [ "Root > Child" ],
+        commit_messages: [],
+        diff: nil
+      )
+
+      messages = analyzer.send(:build_messages)
+      prompt = messages.dig(0, :parts, 0, :text)
+
+      assert_includes prompt, "No commit messages available."
+      assert_includes prompt, "(No diff available)"
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- fetch pull request commit messages and diffs from GitHub when processing repository links
- expand the Gemini analyzer prompt to include commit history and diff context, truncating large diffs
- cover the new behavior with unit tests for the analyzer and processor

## Testing
- ./bin/rubocop -a
- bundle exec rails test *(fails: `has_closure_tree` undefined for Creative in test environment)*
- bundle exec rails test:system *(fails: `has_closure_tree` undefined for Creative in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d610966b108326a87581e5b8c4128c