### PR TITLE
Hide integration menu trigger on mobile

### DIFF
--- a/app/views/creatives/index.html.erb
+++ b/app/views/creatives/index.html.erb
@@ -21,7 +21,8 @@
     <%= render PopupMenuComponent.new(
           button_content: t('creatives.index.integrations', default: '연동'),
           menu_id: 'creative-integrations-menu',
-          align: :left
+          align: :left,
+          button_classes: 'desktop-only'
         ) do %>
       <button type="button" class="popup-menu-item" data-click-target="github-integration-btn">Github</button>
     <% end %>


### PR DESCRIPTION
## Summary
- add a desktop-only class to the integrations popup trigger so it only appears on larger screens

## Testing
- ./bin/rubocop -a *(fails: missing gems in the environment)*
- bundle exec rails test *(fails: missing gems in the environment)*
- bundle exec rails test:system *(fails: missing gems in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d62d467ad88326b09ed39599f8be2c