### PR TITLE
Auto-provision GitHub webhooks for linked repositories

### DIFF
--- a/app/controllers/creatives/github_integrations_controller.rb
+++ b/app/controllers/creatives/github_integrations_controller.rb
@@ -50,6 +50,12 @@ module Creatives
         links = linked_repository_links(account).to_a
       end
 
+      Github::WebhookProvisioner.ensure_for_links(
+        account: account,
+        links: links,
+        webhook_url: github_webhook_url
+      ) if links.present?
+
       render json: {
         success: true,
         selected_repositories: links.map(&:repository_full_name),

--- a/app/services/github/client.rb
+++ b/app/services/github/client.rb
@@ -59,6 +59,46 @@ module Github
       nil
     end
 
+    def repository_hooks(repo_full_name)
+      client.hooks(repo_full_name)
+    rescue Octokit::Error => e
+      Rails.logger.warn("GitHub hooks fetch failed for #{repo_full_name}: #{e.message}")
+      []
+    end
+
+    def create_repository_webhook(repo_full_name, url:, secret:, events:, content_type: "json")
+      client.create_hook(
+        repo_full_name,
+        "web",
+        {
+          url: url,
+          content_type: content_type,
+          secret: secret
+        },
+        {
+          events: events,
+          active: true
+        }
+      )
+    end
+
+    def update_repository_webhook(repo_full_name, hook_id, url:, secret:, events:, content_type: "json")
+      client.edit_hook(
+        repo_full_name,
+        hook_id,
+        "web",
+        {
+          url: url,
+          content_type: content_type,
+          secret: secret
+        },
+        {
+          events: events,
+          active: true
+        }
+      )
+    end
+
     private
 
     attr_reader :client

--- a/app/services/github/webhook_provisioner.rb
+++ b/app/services/github/webhook_provisioner.rb
@@ -1,0 +1,79 @@
+module Github
+  class WebhookProvisioner
+    EVENTS = %w[pull_request].freeze
+    CONTENT_TYPE = "json".freeze
+
+    def self.ensure_for_links(account:, links:, webhook_url:)
+      new(account: account, webhook_url: webhook_url).ensure_for_links(Array(links))
+    end
+
+    def initialize(account:, webhook_url:, client: Github::Client.new(account))
+      @client = client
+      @webhook_url = webhook_url
+    end
+
+    def ensure_for_links(links)
+      links.each do |link|
+        ensure_webhook(link.repository_full_name, link.webhook_secret)
+      end
+    end
+
+    private
+
+    attr_reader :client, :webhook_url
+
+    def ensure_webhook(repository_full_name, secret)
+      hook = find_existing_hook(repository_full_name)
+
+      if hook
+        update_webhook(repository_full_name, hook.id, secret)
+      else
+        create_webhook(repository_full_name, secret)
+      end
+    rescue Octokit::Error => e
+      Rails.logger.warn(
+        "GitHub webhook provisioning failed for #{repository_full_name}: #{e.message}"
+      )
+    end
+
+    def find_existing_hook(repository_full_name)
+      client.repository_hooks(repository_full_name).find do |hook|
+        config = normalize_config(hook.config)
+        config["url"] == webhook_url
+      end
+    end
+
+    def create_webhook(repository_full_name, secret)
+      client.create_repository_webhook(
+        repository_full_name,
+        url: webhook_url,
+        secret: secret,
+        events: EVENTS,
+        content_type: CONTENT_TYPE
+      )
+    end
+
+    def update_webhook(repository_full_name, hook_id, secret)
+      client.update_repository_webhook(
+        repository_full_name,
+        hook_id,
+        url: webhook_url,
+        secret: secret,
+        events: EVENTS,
+        content_type: CONTENT_TYPE
+      )
+    end
+
+    def normalize_config(config)
+      hash =
+        case config
+        when Hash
+          config
+        else
+          config.respond_to?(:to_h) ? config.to_h : {}
+        end
+
+      hash.with_indifferent_access
+    end
+  end
+end

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -16,7 +16,7 @@ Rails.application.config.middleware.use OmniAuth::Builder do
     provider :github,
              github_client_id,
              github_client_secret,
-             scope: "repo read:org",
+             scope: "repo read:org admin:repo_hook",
              allow_signup: false
   end
 end

--- a/config/locales/creatives.en.yml
+++ b/config/locales/creatives.en.yml
@@ -59,7 +59,7 @@ en:
       github_integration_choose_org: "Select the organization that owns the repositories."
       github_integration_choose_repo: "Select repositories to link. You can choose multiple."
       github_integration_summary: "The following repositories will be linked to this Creative:"
-      github_integration_webhook_instructions: "Configure the webhook for each repository using the details below."
+      github_integration_webhook_instructions: "Webhooks are created automatically. Use the details below if you ever need to configure them manually."
       github_integration_webhook_url_label: "Webhook URL"
       github_integration_webhook_secret_label: "Webhook secret"
       github_integration_summary_empty: "No repositories selected."

--- a/config/locales/creatives.ko.yml
+++ b/config/locales/creatives.ko.yml
@@ -59,7 +59,7 @@ ko:
       github_integration_choose_org: "연동할 Organization을 선택하세요."
       github_integration_choose_repo: "연동할 Repository를 선택하세요. 여러 개 선택할 수 있습니다."
       github_integration_summary: "다음 Repository가 현재 Creative와 연동됩니다:"
-      github_integration_webhook_instructions: "각 Repository에 아래의 Webhook 정보를 설정하세요."
+      github_integration_webhook_instructions: "Webhook은 자동으로 생성됩니다. 문제가 생겨 수동으로 설정해야 할 때 아래 정보를 참고하세요."
       github_integration_webhook_url_label: "Webhook URL"
       github_integration_webhook_secret_label: "Webhook 비밀값"
       github_integration_summary_empty: "선택된 Repository가 없습니다."

--- a/docs/github_integration.md
+++ b/docs/github_integration.md
@@ -30,7 +30,9 @@ production host and a second for local testing.
    - Or set the environment variables `GITHUB_CLIENT_ID` and
      `GITHUB_CLIENT_SECRET` in your hosting platform.
 6. Restart the app. OmniAuth only registers the GitHub strategy when both values
-   are present.
+   are present. The OAuth flow requests the `repo`, `read:org`, and
+   `admin:repo_hook` scopes so Plan42 can read repository metadata and manage
+   webhooks on your behalf.
 
 ### Localhost (`localhost:3000`)
 1. Create another OAuth app with **Authorization callback URL**
@@ -49,22 +51,23 @@ production host and a second for local testing.
 > `github.client_id` and `github.client_secret` keys instead of exporting
 > environment variables.
 
-## 2. Configure the GitHub webhook
+## 2. Webhook automation and manual fallback
 
 The webhook notifies Plan42 when pull requests change so Gemini can analyse the
-creative paths linked to the repository.
+creative paths linked to the repository. When you link a repository in the
+integration modal, Plan42 now calls the GitHub API to create (or update) a
+webhook pointing at `/github/webhook` with a repository-specific secret. No
+additional setup is required in the GitHub UI during normal operation.
 
-### Choose where to add the webhook
-* **Single repository:** `Repository` → `Settings` → `Webhooks` → `Add webhook`.
-* **Organization wide:** `Organization` → `Settings` → `Webhooks` → `Add webhook`.
+If automation fails or you need to recreate the hook manually, use the
+configuration below as a reference.
 
-### Required settings
+### Required settings for manual setup
 1. **Payload URL:**
    * Production: `https://YOUR_PRODUCTION_HOST/github/webhook`
    * Local testing (via tunnel): e.g. `https://<random>.ngrok.app/github/webhook`
 2. **Content type:** `application/json`.
-3. **Secret:** Generate a long random string. Store the same value for the app
-   so incoming requests can be verified (see next section).
+3. **Secret:** Use the per-repository secret shown in the integration modal.
 4. **Events:** Select **Let me select individual events** and check **Pull
    requests**. All other events can remain unchecked.
 5. Save the webhook and click **Recent Deliveries** to confirm GitHub receives a

--- a/test/services/github/webhook_provisioner_test.rb
+++ b/test/services/github/webhook_provisioner_test.rb
@@ -1,0 +1,118 @@
+require "test_helper"
+
+class FakeGithubClient
+  attr_reader :hooks_called_with, :create_calls, :update_calls
+
+  def initialize(hooks: [])
+    @hooks = hooks
+    @create_calls = []
+    @update_calls = []
+    @hooks_called_with = []
+    @error_to_raise = nil
+  end
+
+  def repository_hooks(repo_full_name)
+    @hooks_called_with << repo_full_name
+    @hooks
+  end
+
+  def create_repository_webhook(repo_full_name, **kwargs)
+    raise @error_to_raise if @error_to_raise
+
+    @create_calls << [ repo_full_name, kwargs ]
+  end
+
+  def update_repository_webhook(repo_full_name, hook_id, **kwargs)
+    @update_calls << [ repo_full_name, hook_id, kwargs ]
+  end
+
+  def simulate_error!(error)
+    @error_to_raise = error
+  end
+end
+
+class Github::WebhookProvisionerTest < ActiveSupport::TestCase
+  setup do
+    @creative = creatives(:tshirt)
+    @user = users(:one)
+    @account = GithubAccount.create!(
+      user: @user,
+      github_uid: "webhook-account",
+      login: "webhook-user",
+      name: "Webhook User",
+      token: "token"
+    )
+  end
+
+  test "creates webhook when none exists" do
+    link = GithubRepositoryLink.create!(
+      creative: @creative,
+      github_account: @account,
+      repository_full_name: "example/repo"
+    )
+
+    webhook_url = "https://example.com/github/webhook"
+    client = FakeGithubClient.new(hooks: [])
+
+    provisioner = Github::WebhookProvisioner.new(account: @account, webhook_url: webhook_url, client: client)
+    provisioner.ensure_for_links([ link ])
+
+    assert_equal [ "example/repo" ], client.hooks_called_with
+    assert_equal 1, client.create_calls.size
+    repo, options = client.create_calls.first
+    assert_equal "example/repo", repo
+    assert_equal webhook_url, options[:url]
+    assert_equal link.webhook_secret, options[:secret]
+    assert_equal [ "pull_request" ], options[:events]
+    assert_equal "json", options[:content_type]
+  end
+
+  test "updates webhook when existing hook matches url" do
+    link = GithubRepositoryLink.create!(
+      creative: @creative,
+      github_account: @account,
+      repository_full_name: "example/repo"
+    )
+
+    webhook_url = "https://example.com/github/webhook"
+    hook = OpenStruct.new(
+      id: 123,
+      config: { "url" => webhook_url },
+      events: [ "pull_request" ],
+      active: true
+    )
+
+    client = FakeGithubClient.new(hooks: [ hook ])
+
+    provisioner = Github::WebhookProvisioner.new(account: @account, webhook_url: webhook_url, client: client)
+    provisioner.ensure_for_links([ link ])
+
+    assert_equal [], client.create_calls
+    assert_equal 1, client.update_calls.size
+    repo, hook_id, options = client.update_calls.first
+    assert_equal "example/repo", repo
+    assert_equal 123, hook_id
+    assert_equal webhook_url, options[:url]
+    assert_equal link.webhook_secret, options[:secret]
+    assert_equal [ "pull_request" ], options[:events]
+    assert_equal "json", options[:content_type]
+  end
+
+  test "ignores errors raised by github client" do
+    link = GithubRepositoryLink.create!(
+      creative: @creative,
+      github_account: @account,
+      repository_full_name: "example/repo"
+    )
+
+    webhook_url = "https://example.com/github/webhook"
+    client = FakeGithubClient.new(hooks: [])
+    client.simulate_error!(Octokit::Error.new(response: { status: 500, body: "" }))
+
+    provisioner = Github::WebhookProvisioner.new(account: @account, webhook_url: webhook_url, client: client)
+
+    assert_nothing_raised do
+      provisioner.ensure_for_links([ link ])
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- automatically create or update per-repository GitHub webhooks when creatives link repositories
- extend the GitHub client with helper methods and request admin:repo_hook scope during OAuth so webhook provisioning can succeed
- refresh integration copy and docs to explain the new automation while keeping manual fallback guidance, and add tests for the new webhook provisioner

## Testing
- ./bin/rubocop -a
- bundle exec rails test
- bundle exec rails test:system

------
https://chatgpt.com/codex/tasks/task_e_68d64eec05508326895c29766d0bf1e4