### PR TITLE
Analyze only merged GitHub PRs

### DIFF
--- a/app/services/github/pull_request_processor.rb
+++ b/app/services/github/pull_request_processor.rb
@@ -1,6 +1,6 @@
 module Github
   class PullRequestProcessor
-    HANDLED_ACTIONS = %w[opened reopened synchronize ready_for_review].freeze
+    HANDLED_ACTIONS = %w[closed].freeze
 
     def initialize(payload:, logger: Rails.logger)
       @payload = payload
@@ -13,7 +13,7 @@ module Github
 
       pr = payload["pull_request"]
       return unless pr
-      return if pr["merged"]
+      return unless pr["merged"]
 
       repo_full_name = payload.dig("repository", "full_name")
       return unless repo_full_name

--- a/test/services/github/pull_request_processor_test.rb
+++ b/test/services/github/pull_request_processor_test.rb
@@ -10,12 +10,13 @@ module Github
       GithubRepositoryLink.create!(creative: creative, github_account: account, repository_full_name: "org/repo")
 
       payload = {
-        "action" => "opened",
+        "action" => "closed",
         "pull_request" => {
           "title" => "Add feature",
           "number" => 12,
           "html_url" => "https://github.com/org/repo/pull/12",
-          "body" => "Implements feature"
+          "body" => "Implements feature",
+          "merged" => true
         },
         "repository" => { "full_name" => "org/repo" }
       }
@@ -54,7 +55,7 @@ module Github
       assert_includes comment.content, "Gemini 응답"
     end
 
-    test "ignores merged pull requests" do
+    test "ignores unmerged pull requests" do
       user = users(:one)
       creative = Creative.create!(user: user, description: "Root")
       account = GithubAccount.create!(user: user, github_uid: "1", login: "tester", token: "token")
@@ -67,7 +68,7 @@ module Github
           "number" => 13,
           "html_url" => "https://github.com/org/repo/pull/13",
           "body" => "Implements feature",
-          "merged" => true
+          "merged" => false
         },
         "repository" => { "full_name" => "org/repo" }
       }


### PR DESCRIPTION
## Summary
- update the GitHub pull request processor to handle only closed PR webhooks that were merged
- require merged PRs in the analyzer test fixture and ensure unmerged PRs are ignored in tests

## Testing
- ./bin/rubocop -a *(fails: missing gems in the environment)*
- bundle exec rails test *(fails: bundler could not find rails executable without installing gems)*
- bundle exec rails test:system *(fails: bundler could not find rails executable without installing gems)*
- bundle exec ruby -Itest test/services/github/pull_request_processor_test.rb *(fails: missing gems in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7546ac7648326b12e3ed15821597e