### PR TITLE
Include progress metadata in GitHub PR analysis prompt

### DIFF
--- a/app/services/github/pull_request_analyzer.rb
+++ b/app/services/github/pull_request_analyzer.rb
@@ -70,7 +70,7 @@ module Github
         Pull request diff:
         #{diff_text}
 
-        Creative task paths (each line is a single task path from root to leaf). Each node is shown as "[ID] Title":
+        Creative task paths (each line is a single task path from root to leaf). Each node is shown as "[ID] Title (progress XX%)" when progress is known:
         #{tree_lines}
 
         #{language_instructions}
@@ -78,6 +78,8 @@ module Github
         Return a JSON object with two keys:
         - "completed": array of objects representing tasks finished by this PR. Each object must include "creative_id" (from the IDs above). Optionally include "progress" (0.0 to 1.0), "note", or "path" for context.
         - "additional": array of objects for follow-up work. Each object must include "parent_id" (from the IDs above) and "description" (the new creative text). Optionally include "progress" (0.0 to 1.0), "note", or "path".
+
+        Do not add tasks to "completed" if they already show 100% progress in the tree above unless this PR clearly made new changes that justify marking them complete.
 
         Use only IDs present in the tree. Respond with valid JSON only.
       PROMPT

--- a/app/services/github/pull_request_processor.rb
+++ b/app/services/github/pull_request_processor.rb
@@ -37,7 +37,7 @@ module Github
     def process_link(link)
       creative = link.creative.effective_origin
       path_exporter = Creatives::PathExporter.new(creative)
-      paths = path_exporter.paths_with_ids
+      paths = path_exporter.full_paths_with_ids_and_progress
       return if paths.blank?
 
       repo_full_name = payload.dig("repository", "full_name")

--- a/test/services/creatives/path_exporter_test.rb
+++ b/test/services/creatives/path_exporter_test.rb
@@ -9,6 +9,9 @@ module Creatives
       Creative.create!(user: user, parent: child, description: "Grandchild")
       Creative.create!(user: user, parent: root, description: "Second")
 
+      root.update_column(:progress, 0.25)
+      child.update_column(:progress, 1.0)
+
       exporter = PathExporter.new(root)
       paths = exporter.paths
 
@@ -22,13 +25,29 @@ module Creatives
       assert_includes paths_with_ids, "[#{root.id}] Root"
       assert_includes paths_with_ids, "[#{child.id}] Child"
 
+      paths_with_ids_and_progress = exporter.paths_with_ids_and_progress
+      assert_includes paths_with_ids_and_progress, "[#{root.id}] Root (progress 25%)"
+      assert_includes paths_with_ids_and_progress, "[#{child.id}] Child (progress 100%)"
+
       full_paths_with_ids = exporter.full_paths_with_ids
       assert_includes full_paths_with_ids, "[#{root.id}] Root"
       assert_includes full_paths_with_ids, "[#{root.id}] Root > [#{child.id}] Child"
 
+      full_paths_with_ids_and_progress = exporter.full_paths_with_ids_and_progress
+      assert_includes full_paths_with_ids_and_progress, "[#{root.id}] Root (progress 25%)"
+      assert_includes(
+        full_paths_with_ids_and_progress,
+        "[#{root.id}] Root (progress 25%) > [#{child.id}] Child (progress 100%)"
+      )
+
       assert_equal "Root > Child", exporter.path_for(child.id)
       assert_equal "[#{child.id}] Child", exporter.path_with_ids_for(child.id)
+      assert_equal "[#{child.id}] Child (progress 100%)", exporter.path_with_ids_and_progress_for(child.id)
       assert_equal "[#{root.id}] Root > [#{child.id}] Child", exporter.full_path_with_ids_for(child.id)
+      assert_equal(
+        "[#{root.id}] Root (progress 25%) > [#{child.id}] Child (progress 100%)",
+        exporter.full_path_with_ids_and_progress_for(child.id)
+      )
     end
   end
 end

--- a/test/services/github/pull_request_analyzer_test.rb
+++ b/test/services/github/pull_request_analyzer_test.rb
@@ -24,7 +24,8 @@ module Github
       assert_includes prompt, "1. Refactor module"
       assert_includes prompt, "2. Add tests"
       assert_includes prompt, "diff --git a/file.rb b/file.rb"
-      assert_includes prompt, "Each node is shown as \"[ID] Title\""
+      assert_includes prompt, "Each node is shown as \"[ID] Title (progress XX%)\" when progress is known"
+      assert_includes prompt, "Do not add tasks to \"completed\" if they already show 100% progress"
       assert_includes prompt, '"creative_id"'
       assert_includes prompt, '"parent_id"'
     end

--- a/test/services/github/pull_request_processor_test.rb
+++ b/test/services/github/pull_request_processor_test.rb
@@ -57,7 +57,7 @@ module Github
 
       assert_equal [ "Initial commit" ], analyzer_args[:commit_messages]
       assert_equal "diff --git a/file.rb b/file.rb\n+change", analyzer_args[:diff]
-      assert_equal Creatives::PathExporter.new(creative).paths_with_ids, analyzer_args[:paths]
+      assert_equal Creatives::PathExporter.new(creative).full_paths_with_ids_and_progress, analyzer_args[:paths]
 
       comment = creative.comments.last
       assert comment.present?


### PR DESCRIPTION
## Summary
- include per-node progress in exported creative path strings to support PR analysis
- update the GitHub PR analyzer prompt to mention progress details and avoid marking already completed items again
- adjust processor and test coverage to exercise the new progress-enriched paths and messaging

## Testing
- ./bin/rubocop -a
- bin/rails test
- bin/rails test:system *(fails: unable to download Chrome/Chromedriver in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7af57ad848326bfb697e24cc7b2bd