### PR TITLE
Annotate creative tree leaves in PR analyzer prompt

### DIFF
--- a/app/services/creatives/path_exporter.rb
+++ b/app/services/creatives/path_exporter.rb
@@ -8,6 +8,7 @@ module Creatives
       :path_with_ids_and_progress,
       :full_path_with_ids,
       :full_path_with_ids_and_progress,
+      :leaf,
       keyword_init: true
     )
 
@@ -55,6 +56,15 @@ module Creatives
       entry_map[id.to_i]&.full_path_with_ids_and_progress
     end
 
+    def full_paths_with_ids_and_progress_with_leaf
+      entries.map do |entry|
+        {
+          path: entry.full_path_with_ids_and_progress,
+          leaf: entry.leaf
+        }
+      end
+    end
+
     private
 
     def entries
@@ -77,6 +87,8 @@ module Creatives
       current_path_with_ids = (ancestors_with_ids + [ label_with_id ]).join(" > ")
       current_path_with_ids_and_progress = (ancestors_with_ids_and_progress + [ label_with_progress ]).join(" > ")
 
+      children = node.children.order(:sequence).to_a
+
       results << Entry.new(
         creative_id: node.id,
         progress: node.progress,
@@ -84,10 +96,11 @@ module Creatives
         path_with_ids: label_with_id,
         path_with_ids_and_progress: label_with_progress,
         full_path_with_ids: current_path_with_ids,
-        full_path_with_ids_and_progress: current_path_with_ids_and_progress
+        full_path_with_ids_and_progress: current_path_with_ids_and_progress,
+        leaf: children.empty?
       )
 
-      node.children.order(:sequence).each do |child|
+      children.each do |child|
         traverse(
           child,
           ancestors + [ label ],

--- a/app/services/github/pull_request_processor.rb
+++ b/app/services/github/pull_request_processor.rb
@@ -37,8 +37,8 @@ module Github
     def process_link(link)
       creative = link.creative.effective_origin
       path_exporter = Creatives::PathExporter.new(creative)
-      paths = path_exporter.full_paths_with_ids_and_progress
-      return if paths.blank?
+      tree_entries = path_exporter.full_paths_with_ids_and_progress_with_leaf
+      return if tree_entries.blank?
 
       repo_full_name = payload.dig("repository", "full_name")
       pr = payload["pull_request"]
@@ -49,7 +49,7 @@ module Github
       analyzer = Github::PullRequestAnalyzer.new(
         payload: payload,
         creative: creative,
-        paths: paths,
+        paths: tree_entries,
         commit_messages: commit_messages,
         diff: diff
       )

--- a/test/services/creatives/path_exporter_test.rb
+++ b/test/services/creatives/path_exporter_test.rb
@@ -55,7 +55,7 @@ module Creatives
       assert_includes(
         paths_with_leaf,
         {
-          path: "[#{root.id}] Root (progress 25%) > [#{child.id}] Child (progress 100%) > [#{grandchild.id}] Grandchild",
+          path: "[#{root.id}] Root (progress 25%) > [#{child.id}] Child (progress 100%) > [#{grandchild.id}] Grandchild (progress 0%)",
           leaf: true
         }
       )

--- a/test/services/creatives/path_exporter_test.rb
+++ b/test/services/creatives/path_exporter_test.rb
@@ -6,7 +6,7 @@ module Creatives
       user = users(:one)
       root = Creative.create!(user: user, description: "Root")
       child = Creative.create!(user: user, parent: root, description: "Child")
-      Creative.create!(user: user, parent: child, description: "Grandchild")
+      grandchild = Creative.create!(user: user, parent: child, description: "Grandchild")
       Creative.create!(user: user, parent: root, description: "Second")
 
       root.update_column(:progress, 0.25)
@@ -38,6 +38,26 @@ module Creatives
       assert_includes(
         full_paths_with_ids_and_progress,
         "[#{root.id}] Root (progress 25%) > [#{child.id}] Child (progress 100%)"
+      )
+
+      paths_with_leaf = exporter.full_paths_with_ids_and_progress_with_leaf
+      assert_includes(
+        paths_with_leaf,
+        { path: "[#{root.id}] Root (progress 25%)", leaf: false }
+      )
+      assert_includes(
+        paths_with_leaf,
+        {
+          path: "[#{root.id}] Root (progress 25%) > [#{child.id}] Child (progress 100%)",
+          leaf: false
+        }
+      )
+      assert_includes(
+        paths_with_leaf,
+        {
+          path: "[#{root.id}] Root (progress 25%) > [#{child.id}] Child (progress 100%) > [#{grandchild.id}] Grandchild",
+          leaf: true
+        }
       )
 
       assert_equal "Root > Child", exporter.path_for(child.id)

--- a/test/services/github/pull_request_analyzer_test.rb
+++ b/test/services/github/pull_request_analyzer_test.rb
@@ -13,7 +13,7 @@ module Github
       analyzer = Github::PullRequestAnalyzer.new(
         payload: payload,
         creative: creatives(:tshirt),
-        paths: [ "[1] Root > [2] Child" ],
+        paths: [ { path: "[1] Root > [2] Child", leaf: true } ],
         commit_messages: [ "Refactor module", "Add tests" ],
         diff: "diff --git a/file.rb b/file.rb\n+change"
       )
@@ -25,9 +25,15 @@ module Github
       assert_includes prompt, "2. Add tests"
       assert_includes prompt, "diff --git a/file.rb b/file.rb"
       assert_includes prompt, "Each node is shown as \"[ID] Title (progress XX%)\" when progress is known"
+      assert_includes prompt, "Leaf creatives are marked with [LEAF]"
+      assert_includes prompt, "[1] Root > [2] Child"
+      assert_includes prompt, "[LEAF]"
       assert_includes prompt, "Do not add tasks to \"completed\" if they already show 100% progress"
       assert_includes prompt, '"creative_id"'
       assert_includes prompt, '"parent_id"'
+      assert_includes prompt, "Use only creatives marked [LEAF]"
+      assert_includes prompt, "new creatives that are not already represented"
+      assert_includes prompt, "Do not use this list for follow-up tasks"
     end
 
     test "handles missing commit messages and diff" do
@@ -41,7 +47,7 @@ module Github
       analyzer = Github::PullRequestAnalyzer.new(
         payload: payload,
         creative: creatives(:tshirt),
-        paths: [ "[1] Root > [2] Child" ],
+        paths: [ { path: "[1] Root > [2] Child", leaf: false } ],
         commit_messages: [],
         diff: nil
       )
@@ -59,7 +65,7 @@ module Github
       analyzer = Github::PullRequestAnalyzer.new(
         payload: payload,
         creative: creative,
-        paths: [ "[#{creative.id}] Root" ]
+        paths: [ { path: "[#{creative.id}] Root", leaf: true } ]
       )
 
       response = '{"completed":[{"creative_id":123,"progress":0.75,"note":"partial","path":"Root > Child"}],"additional":[{"parent_id":123,"description":"Add docs","progress":0.1}]}'

--- a/test/services/github/pull_request_processor_test.rb
+++ b/test/services/github/pull_request_processor_test.rb
@@ -57,7 +57,10 @@ module Github
 
       assert_equal [ "Initial commit" ], analyzer_args[:commit_messages]
       assert_equal "diff --git a/file.rb b/file.rb\n+change", analyzer_args[:diff]
-      assert_equal Creatives::PathExporter.new(creative).full_paths_with_ids_and_progress, analyzer_args[:paths]
+      assert_equal(
+        Creatives::PathExporter.new(creative).full_paths_with_ids_and_progress_with_leaf,
+        analyzer_args[:paths]
+      )
 
       comment = creative.comments.last
       assert comment.present?


### PR DESCRIPTION
## Summary
- add leaf metadata to exported creative paths so Gemini can see which nodes terminate the tree
- update the GitHub PR analysis prompt to highlight [LEAF] creatives and restrict completed/additional guidance accordingly
- adjust the processor and tests to pass the enriched path data and cover the new instructions

## Testing
- ./bin/rubocop -a
- bundle exec rails test *(fails: NoMethodError: undefined method 'has_closure_tree' for class Creative)*
- bundle exec rails test:system *(fails: NoMethodError: undefined method 'has_closure_tree' for class Creative)*

------
https://chatgpt.com/codex/tasks/task_e_68d7b71782548326bcac90d29d6778f1