### PR TITLE
Display approved status on executed comments

### DIFF
--- a/app/assets/stylesheets/comments_popup.css
+++ b/app/assets/stylesheets/comments_popup.css
@@ -75,6 +75,12 @@
     margin-top:0.2em;
 }
 
+.comment-status-label {
+    margin-left: 0.4em;
+    font-size: 0.85em;
+    color: var(--color-muted);
+}
+
 .comment-action-container {
     position: absolute;
     bottom: 0.2em;

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -23,6 +23,9 @@
     <% if comment.private? %>
       <span class="private-label">[<%= t('comments.private') %>]</span>
     <% end %>
+    <% if comment.action_executed_at.present? %>
+      <span class="comment-status-label approved-label">[<%= t('comments.approved_label') %>]</span>
+    <% end %>
     <div class="comment-action-container">
       <button class="convert-comment-btn comment-owner-only" data-comment-target="ownerButton" data-comment-id="<%= comment.id %>" title="<%= t('comments.convert_to_creative') %>">
         <%= t('comments.convert_button') %>

--- a/config/locales/comments.en.yml
+++ b/config/locales/comments.en.yml
@@ -33,6 +33,7 @@ en:
     approve_invalid_creative: "Comment action targets an invalid creative."
     approve_invalid_progress: "Comment action progress must be a number."
     approve_invalid_description: "Comment action description must be text."
+    approved_label: "Approved"
     private: "Private"
     convert_system_message: "System: Comment was converted to the [%{title}](%{url}) creative."
     convert_system_message_default_title: "Untitled"

--- a/config/locales/comments.ko.yml
+++ b/config/locales/comments.ko.yml
@@ -33,6 +33,7 @@ ko:
     approve_invalid_creative: "댓글 작업이 잘못된 크리에이티브를 대상으로 하고 있습니다."
     approve_invalid_progress: "댓글 작업 진행률은 숫자여야 합니다."
     approve_invalid_description: "댓글 작업 설명은 텍스트여야 합니다."
+    approved_label: "승인됨"
     private: "비밀"
     convert_system_message: "System: 메세지가 [%{title}](%{url}) 크리에이티브로 변환되었습니다"
     convert_system_message_default_title: "제목 없음"

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -49,6 +49,7 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
     post approve_creative_comment_path(@creative, comment)
 
     assert_response :success
+    assert_includes @response.body, I18n.t("comments.approved_label")
     comment.reload
     assert_equal action_payload, JSON.parse(comment.action)
     assert_equal @user, comment.approver


### PR DESCRIPTION
## Summary
- display an approved status badge in the comments popup when an action has been executed
- add styling and locale strings for the new approved indicator
- cover the behaviour with a controller test assertion

## Testing
- ./bin/rubocop -a *(fails: missing gems in container)*
- bin/rails test *(fails: missing gems in container)*
- bin/rails test:system *(fails: missing gems in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d7b816854883269586ec82379eeab0