### PR TITLE
Add editable Gemini prompt to GitHub integration wizard

### DIFF
--- a/app/views/creatives/_github_integration_modal.html.erb
+++ b/app/views/creatives/_github_integration_modal.html.erb
@@ -37,6 +37,20 @@
       <p id="github-summary-empty" style="display:none;color:#777;"><%= t('creatives.index.github_integration_summary_empty', default: '선택된 Repository가 없습니다.') %></p>
     </div>
 
+    <div class="github-wizard-step" id="github-step-prompt" style="display:none;">
+      <p><%= t('creatives.index.github_integration_prompt_title', default: 'Gemini 분석 프롬프트를 검토하고 필요하다면 수정하세요.') %></p>
+      <textarea id="github-gemini-prompt" style="width:100%;min-height:220px;padding:0.75em;border:1px solid #ccc;border-radius:4px;font-family:monospace;font-size:0.95em;"></textarea>
+      <p style="margin-top:0.75em;color:#555;font-size:0.9em;">
+        <%= t('creatives.index.github_integration_prompt_help', default: '필요한 정보를 런타임에 삽입하기 위해 아래 자리표시자를 사용할 수 있습니다:') %>
+        <code>#{pr_title}</code>,
+        <code>#{pr_body}</code>,
+        <code>#{commit_messages}</code>,
+        <code>#{diff}</code>,
+        <code>#{creative_tree}</code>,
+        <code>#{language_instructions}</code>
+      </p>
+    </div>
+
     <div id="github-wizard-error" style="display:none;margin:0.5em 0;color:#c0392b;font-weight:bold;"></div>
 
     <div class="github-wizard-footer" style="display:flex;justify-content:space-between;gap:0.5em;margin-top:1.5em;">

--- a/db/migrate/20250928105957_add_github_gemini_prompt_to_creatives.rb
+++ b/db/migrate/20250928105957_add_github_gemini_prompt_to_creatives.rb
@@ -1,0 +1,5 @@
+class AddGithubGeminiPromptToCreatives < ActiveRecord::Migration[8.0]
+  def change
+    add_column :creatives, :github_gemini_prompt, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_28_010000) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_28_105957) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
     t.text "body"
@@ -130,6 +130,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_28_010000) do
     t.integer "sequence", default: 0, null: false
     t.integer "user_id", null: false
     t.integer "origin_id"
+    t.text "github_gemini_prompt"
     t.index ["origin_id"], name: "index_creatives_on_origin_id"
     t.index ["parent_id"], name: "index_creatives_on_parent_id"
     t.index ["user_id"], name: "index_creatives_on_user_id"

--- a/test/services/github/pull_request_analyzer_test.rb
+++ b/test/services/github/pull_request_analyzer_test.rb
@@ -92,7 +92,7 @@ module Github
       assert_includes prompt, "Body: Adds improvements"
       assert_includes prompt, "Commits: 1. Refactor module"
       assert_includes prompt, "Diff: diff --git a/file.rb b/file.rb"
-      assert_includes prompt, "Tree: [1] Root > [2] Child"
+      assert_includes prompt, "Tree: - [1] Root > [2] Child [LEAF]"
       assert_includes prompt, "Lang: Preferred response language:"
     end
 

--- a/test/services/github/pull_request_analyzer_test.rb
+++ b/test/services/github/pull_request_analyzer_test.rb
@@ -59,6 +59,43 @@ module Github
       assert_includes prompt, "(No diff available)"
     end
 
+    test "uses creative github gemini prompt template with placeholders" do
+      creative = creatives(:tshirt)
+      creative.update!(github_gemini_prompt: <<~PROMPT)
+        Title: \#{pr_title}
+        Body: \#{pr_body}
+        Commits: \#{commit_messages}
+        Diff: \#{diff}
+        Tree: \#{creative_tree}
+        Lang: \#{language_instructions}
+      PROMPT
+
+      payload = {
+        "pull_request" => {
+          "title" => "Improve feature",
+          "body" => "Adds improvements"
+        }
+      }
+
+      analyzer = Github::PullRequestAnalyzer.new(
+        payload: payload,
+        creative: creative,
+        paths: [ { path: "[1] Root > [2] Child", leaf: true } ],
+        commit_messages: [ "Refactor module" ],
+        diff: "diff --git a/file.rb b/file.rb\n+change"
+      )
+
+      messages = analyzer.send(:build_messages)
+      prompt = messages.dig(0, :parts, 0, :text)
+
+      assert_includes prompt, "Title: Improve feature"
+      assert_includes prompt, "Body: Adds improvements"
+      assert_includes prompt, "Commits: 1. Refactor module"
+      assert_includes prompt, "Diff: diff --git a/file.rb b/file.rb"
+      assert_includes prompt, "Tree: [1] Root > [2] Child"
+      assert_includes prompt, "Lang: Preferred response language:"
+    end
+
     test "parses structured response into tasks" do
       payload = { "pull_request" => { "title" => "Feature" } }
       creative = creatives(:tshirt)


### PR DESCRIPTION
## Summary
- add a `github_gemini_prompt` column with default template helpers so creatives can persist Gemini review instructions
- expose the stored prompt via the GitHub integration API and extend the modal wizard with a final editing step
- render Gemini requests from the saved template and cover the new flow with controller and analyzer tests

## Testing
- ./bin/rubocop -a
- bundle exec bin/rails test *(fails: NoMethodError `has_closure_tree` for class Creative in test environment)*
- bundle exec bin/rails test:system *(fails: NoMethodError `has_closure_tree` for class Creative in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7c1fe5320832698e1eb90dd9df21c