### PR TITLE
Filter PR analysis prompt to leaf creatives

### DIFF
--- a/app/services/github/pull_request_analyzer.rb
+++ b/app/services/github/pull_request_analyzer.rb
@@ -51,10 +51,10 @@ module Github
 
     def build_messages
       pr = payload["pull_request"]
-      tree_lines = paths.map do |entry|
-        status = entry[:leaf] ? "[LEAF]" : "[BRANCH]"
-        "- #{entry[:path]} #{status}"
-      end.join("\n")
+      tree_lines = paths
+        .select { |entry| entry[:leaf] }
+        .map { |entry| "- #{entry[:path]} [LEAF]" }
+        .join("\n")
       pr_body = pr["body"].to_s
       commit_lines = formatted_commit_messages
       diff_text = formatted_diff


### PR DESCRIPTION
## Summary
- filter the creative tree lines used for GitHub PR analysis so only leaf creatives are included in the prompt

## Testing
- ./bin/rubocop -a *(fails: missing gem dependencies in the environment)*
- bundle exec rails test *(fails: missing gem dependencies in the environment)*
- bundle exec rails test:system *(fails: missing gem dependencies in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7d31e6a6083268ed4428ad41d05e5