### PR TITLE
Add Gemini prompt details to GitHub PR analysis comments

### DIFF
--- a/app/services/github/pull_request_processor.rb
+++ b/app/services/github/pull_request_processor.rb
@@ -93,6 +93,17 @@ module Github
         lines << "#### 승인 시 자동 적용"
         lines << "- 이 댓글을 승인하면 완료된 Creative의 진행률이 업데이트되고 제안된 Creative가 생성됩니다."
       end
+      if result.prompt.present?
+        lines << ""
+        lines << "<details><summary>Gemini 전송 메시지</summary>"
+        lines << ""
+        lines << "```"
+        lines << result.prompt.strip
+        lines << "```"
+        lines << ""
+        lines << "</details>"
+      end
+
       lines << ""
       lines << "<details><summary>Gemini 응답 원문</summary>"
       lines << ""

--- a/test/services/github/pull_request_processor_test.rb
+++ b/test/services/github/pull_request_processor_test.rb
@@ -32,10 +32,12 @@ module Github
         description: "Follow up",
         progress: nil
       )
+      prompt_text = "PR prompt contents"
       result = Github::PullRequestAnalyzer::Result.new(
         completed: [ completed_task ],
         additional: [ suggestion ],
-        raw_response: "{\"completed\":[{\"creative_id\":#{completed_task.creative_id}}],\"additional\":[{\"parent_id\":#{suggestion.parent_id},\"description\":\"Follow up\"}]}"
+        raw_response: "{\"completed\":[{\"creative_id\":#{completed_task.creative_id}}],\"additional\":[{\"parent_id\":#{suggestion.parent_id},\"description\":\"Follow up\"}]}",
+        prompt: prompt_text
       )
 
       fake_analyzer = Minitest::Mock.new
@@ -67,6 +69,8 @@ module Github
       assert_includes comment.content, "#12"
       assert_includes comment.content, "[#{completed_task.creative_id}]"
       assert_includes comment.content, "Follow up"
+      assert_includes comment.content, "Gemini 전송 메시지"
+      assert_includes comment.content, prompt_text
       assert_includes comment.content, "Gemini 응답"
       assert comment.action.present?
       assert_equal account.user, comment.approver


### PR DESCRIPTION
## Summary
- capture the Gemini prompt used for PR analysis responses
- render the sent prompt above the Gemini raw response in PR analysis comments
- extend the processor test to cover the new prompt output

## Testing
- ./bin/rubocop -a *(fails: missing gems in the environment)*
- bundle exec rails test *(fails: rails executable missing without bundle install)*
- bundle exec rails test:system *(fails: rails executable missing without bundle install)*

------
https://chatgpt.com/codex/tasks/task_e_68d7d8b596b88326b2a4b225e2a716bf