### PR TITLE
Show loading indicator when fetching GitHub repositories

### DIFF
--- a/app/javascript/github_integration.js
+++ b/app/javascript/github_integration.js
@@ -187,6 +187,9 @@ if (!window.githubIntegrationInitialized) {
     function loadRepositories() {
       if (!selectedOrg) return;
       clearError();
+      if (repoList) {
+        repoList.textContent = '...';
+      }
       const params = new URLSearchParams({ organization: selectedOrg });
       if (creativeId) params.append('creative_id', creativeId);
       fetch(`/github/account/repositories?${params.toString()}`, { headers: { Accept: 'application/json' } })
@@ -195,6 +198,7 @@ if (!window.githubIntegrationInitialized) {
           renderRepositories(data.repositories || []);
         })
         .catch(function () {
+          if (repoList) repoList.textContent = '';
           showError('Repository 목록을 불러오지 못했습니다.');
         });
     }


### PR DESCRIPTION
## Summary
- show a placeholder while the GitHub integration wizard loads repositories
- clear the loading placeholder when the repository request fails

## Testing
- ./bin/rubocop -a *(fails: missing gems)*
- bundle exec rails test *(fails: missing gem executables)*

------
https://chatgpt.com/codex/tasks/task_e_68d7dd2fd584832691711ceb8a051891