### PR TITLE
Fix preferred language selection for GitHub PR analyzer

### DIFF
--- a/app/services/github/pull_request_processor.rb
+++ b/app/services/github/pull_request_processor.rb
@@ -51,7 +51,8 @@ module Github
         creative: creative,
         paths: tree_entries,
         commit_messages: commit_messages,
-        diff: diff
+        diff: diff,
+        user: link.github_account.user
       )
       result = analyzer.call
       return unless result


### PR DESCRIPTION
## Summary
- prefer the GitHub-linked user's locale when building Gemini PR analysis prompts
- normalize locales and ensure we look up localized language labels for the instructions
- cover the locale preference behavior with a new analyzer test

## Testing
- ./bin/rubocop -a *(fails: missing gems in the environment)*
- bundle exec rails test *(fails: bundler could not find the `rails` executable; run `bundle install`)*
- bundle exec rails test:system *(fails: bundler could not find the `rails` executable; run `bundle install`)*

------
https://chatgpt.com/codex/tasks/task_e_68d7e25c4dac83269dcfd1b58800334f