### PR TITLE
Add origin link button for linked creatives

### DIFF
--- a/app/assets/stylesheets/creatives.css
+++ b/app/assets/stylesheets/creatives.css
@@ -257,6 +257,25 @@
     font-size: 1.4em;
 }
 
+.creative-origin-link {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 4px;
+    border-radius: 999px;
+    transition: background-color 0.2s ease;
+}
+
+.creative-origin-link:hover,
+.creative-origin-link:focus {
+    background-color: var(--color-border);
+}
+
+.creative-origin-link-icon {
+    width: 16px;
+    height: 16px;
+}
+
 .creative-row-start h1 {
     font-size: 1.3em;
 }

--- a/app/javascript/components/creative_tree_row.js
+++ b/app/javascript/components/creative_tree_row.js
@@ -19,6 +19,7 @@ class CreativeTreeRow extends LitElement {
     progressHtml: { state: true },
     editIconHtml: { state: true },
     editOffIconHtml: { state: true },
+    originLinkHtml: { state: true },
     isTitle: { type: Boolean, attribute: "is-title", reflect: true }
   };
 
@@ -38,6 +39,7 @@ class CreativeTreeRow extends LitElement {
     this.progressHtml = "";
     this.editIconHtml = "";
     this.editOffIconHtml = "";
+    this.originLinkHtml = "";
     this.isTitle = false;
     this._templatesExtracted = false;
 
@@ -81,6 +83,7 @@ class CreativeTreeRow extends LitElement {
       if (hasCached("progressHtml")) this.progressHtml = this.dataset.progressHtml;
       if (hasCached("editIconHtml")) this.editIconHtml = this.dataset.editIconHtml;
       if (hasCached("editOffIconHtml")) this.editOffIconHtml = this.dataset.editOffIconHtml;
+      if (hasCached("originLinkHtml")) this.originLinkHtml = this.dataset.originLinkHtml;
 
       // If we lack cached markup (older snapshots), attempt to extract from the existing DOM.
       if (!hasCached("descriptionHtml") && existingTree) {
@@ -111,6 +114,10 @@ class CreativeTreeRow extends LitElement {
           case "edit-off-icon":
             this.editOffIconHtml = markup;
             this.dataset.editOffIconHtml = markup;
+            break;
+          case "origin-link":
+            this.originLinkHtml = markup;
+            this.dataset.originLinkHtml = markup;
             break;
           default:
             break;
@@ -188,6 +195,7 @@ class CreativeTreeRow extends LitElement {
             <div class="creative-content">
               ${unsafeHTML(this.descriptionHtml || "")}
             </div>
+            ${this.originLinkHtml ? unsafeHTML(this.originLinkHtml) : nothing}
           </h1>
           <div>
             <h1 style="display:flex;align-items:center;gap:1em;">

--- a/app/views/creatives/index.html.erb
+++ b/app/views/creatives/index.html.erb
@@ -76,10 +76,23 @@
   <% content_for :head do %>
     <meta property="og:title" content="<%= @parent_creative.effective_origin.description.to_plain_text %>">
   <% end %>
+  <% title_templates = [
+        content_tag(:template, data: { part: "description" }) { @parent_creative.effective_description },
+        content_tag(:template, data: { part: "progress" }) { render_creative_progress(@parent_creative) }
+      ] %>
+  <% if @parent_creative.origin_id.present? %>
+    <% title_templates << content_tag(:template, data: { part: "origin-link" }) do %>
+      <%= link_to creative_path(@parent_creative.origin),
+                  class: "creative-origin-link creative-action-btn unstyled-link",
+                  title: t("creatives.index.view_origin"),
+                  aria: { label: t("creatives.index.view_origin") } do %>
+        <%= svg_tag "arrow-right.svg", class: "creative-origin-link-icon", width: 16, height: 16 %>
+      <% end %>
+    <% end %>
+  <% end %>
   <%= content_tag(
         "creative-tree-row",
-        content_tag(:template, data: { part: "description" }) { @parent_creative.effective_description } +
-        content_tag(:template, data: { part: "progress" }) { render_creative_progress(@parent_creative) },
+        safe_join(title_templates),
         "dom-id": "creative-markdown-block",
         "creative-id": @parent_creative.id,
         "parent-id": @parent_creative.parent_id,

--- a/config/locales/creatives.en.yml
+++ b/config/locales/creatives.en.yml
@@ -36,6 +36,7 @@ en:
       import_markdown: "Import Markdown/PPT"
       request_permission: "Request Access"
       no_permission: "You do not have permission to view this Creative."
+      view_origin: "Open origin creative"
       share_creative: "Share Creative"
       shared_with: "Shared With"
       unknown_user: "Unknown user"

--- a/config/locales/creatives.ko.yml
+++ b/config/locales/creatives.ko.yml
@@ -36,6 +36,7 @@ ko:
       import_markdown: "마크다운/PPT 가져오기"
       request_permission: "권한 요청"
       no_permission: "이 크리에이티브를 볼 권한이 없습니다."
+      view_origin: "원본 크리에이티브로 이동"
       share_creative: "크리에이티브 공유"
       shared_with: "공유 대상"
       unknown_user: "알 수 없는 사용자"


### PR DESCRIPTION
## Summary
- add an origin-link template to the creative title so linked creatives expose a jump-to-origin action
- extend the creative tree row web component to cache and render the origin link markup for titles
- style the origin arrow button and provide localized tooltip text

## Testing
- ./bin/rubocop -a *(fails: missing required gems in the container environment)*
- bundle exec rails test *(fails: `rails` executable not available because gems are not installed)*
- bundle exec rails test:system *(fails: `rails` executable not available because gems are not installed)*

## Original User's Requirements
- Linked Creative 인 경우 title 에 표시될때, "->"(right arrow svg 이미지 이용) 를 표시해서 origin 으로 이동 할 수 있도록 링크 버튼 제공해줘

------
https://chatgpt.com/codex/tasks/task_e_68da14a7b6488326a7f51fc9c8a13e3e