### PR TITLE
Add hover cue for creative progress navigation

### DIFF
--- a/app/assets/stylesheets/creatives.css
+++ b/app/assets/stylesheets/creatives.css
@@ -252,6 +252,59 @@
     margin-left: 10px;
 }
 
+.creative-progress-container {
+    display: inline-flex;
+    align-items: center;
+    margin-right: 8px;
+}
+
+.creative-progress-link {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25em;
+    padding: 4px 32px 4px 12px;
+    border-radius: 999px;
+    color: inherit;
+    text-decoration: none;
+    transition: background-color 0.2s ease;
+}
+
+.creative-progress-link:hover,
+.creative-progress-link:focus-visible,
+.creative-row:hover .creative-progress-link {
+    background-color: var(--color-border);
+}
+
+.creative-progress-label {
+    display: inline-flex;
+    align-items: center;
+    position: relative;
+    z-index: 1;
+}
+
+.creative-progress-arrow {
+    position: absolute;
+    top: 50%;
+    right: 12px;
+    transform: translateY(-50%) scale(0.9);
+    opacity: 0;
+    transition: opacity 0.2s ease, transform 0.2s ease;
+    pointer-events: none;
+}
+
+.creative-row:hover .creative-progress-arrow,
+.creative-progress-link:focus-visible .creative-progress-arrow {
+    opacity: 1;
+    transform: translateY(-50%) scale(1);
+}
+
+.creative-progress-arrow-icon {
+    width: 16px;
+    height: 16px;
+    display: block;
+}
+
 .page-title {
     margin-left: 1.5em;
     font-size: 1.4em;

--- a/app/assets/stylesheets/creatives.css
+++ b/app/assets/stylesheets/creatives.css
@@ -255,25 +255,10 @@
 .creative-progress-container {
     display: inline-flex;
     align-items: center;
-    margin-right: 8px;
-}
-
-.creative-progress-link {
-    position: relative;
-    display: inline-flex;
-    align-items: center;
     gap: 0.25em;
     padding: 4px 32px 4px 12px;
     border-radius: 999px;
-    color: inherit;
-    text-decoration: none;
     transition: background-color 0.2s ease;
-}
-
-.creative-progress-link:hover,
-.creative-progress-link:focus-visible,
-.creative-row:hover .creative-progress-link {
-    background-color: var(--color-border);
 }
 
 .creative-progress-label {
@@ -283,20 +268,47 @@
     z-index: 1;
 }
 
-.creative-progress-arrow {
-    position: absolute;
-    top: 50%;
-    right: 12px;
-    transform: translateY(-50%) scale(0.9);
-    opacity: 0;
-    transition: opacity 0.2s ease, transform 0.2s ease;
-    pointer-events: none;
+.creative-progress-float-wrapper {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    margin-right: 8px;
 }
 
-.creative-row:hover .creative-progress-arrow,
-.creative-progress-link:focus-visible .creative-progress-arrow {
+.creative-progress-float-wrapper:hover .creative-progress-container,
+.creative-progress-float-wrapper:focus-within .creative-progress-container {
+    background-color: var(--color-border);
+}
+
+.creative-progress-float-link {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    padding-right: 8px;
+    border-radius: 999px;
+    color: inherit;
+    text-decoration: none;
+}
+
+.creative-progress-float-link:focus-visible {
+    outline: 2px solid var(--color-accent, #4c9aff);
+    outline-offset: 2px;
+}
+
+.creative-progress-float-icon {
+    display: inline-flex;
+    pointer-events: none;
+    opacity: 0;
+    transform: translateX(-4px) scale(0.9);
+    transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.creative-progress-float-wrapper:hover .creative-progress-float-icon,
+.creative-progress-float-link:focus-visible .creative-progress-float-icon {
     opacity: 1;
-    transform: translateY(-50%) scale(1);
+    transform: translateX(0) scale(1);
 }
 
 .creative-progress-arrow-icon {
@@ -327,6 +339,16 @@
 .creative-origin-link-icon {
     width: 16px;
     height: 16px;
+}
+
+.creative-title-progress {
+    display: flex;
+    align-items: center;
+}
+
+.creative-title-progress .creative-row-end {
+    display: flex;
+    align-items: center;
 }
 
 .creative-row-start h1 {

--- a/app/helpers/creatives_helper.rb
+++ b/app/helpers/creatives_helper.rb
@@ -38,6 +38,18 @@ module CreativesHelper
     end
 
     content_tag(:div, class: "creative-row-end") do
+      progress_link = link_to(creative_path(creative), class: "creative-progress-link") do
+        content_tag(:span, render_progress_value(progress_value), class: "creative-progress-label") +
+          content_tag(
+            :span,
+            svg_tag("arrow-right.svg", class: "creative-progress-arrow-icon"),
+            class: "creative-progress-arrow",
+            aria: { hidden: true }
+          )
+      end
+
+      progress_section = content_tag(:div, progress_link, class: "creative-progress-container")
+
       comment_part = if creative.has_permission?(Current.user, :feedback)
         origin = creative.effective_origin
         comments_count = origin.comments.size
@@ -71,7 +83,10 @@ module CreativesHelper
       else
         "".html_safe
       end
-      render_progress_value(progress_value) + comment_part + "<br />".html_safe + (creative.tags ? render_creative_tags(creative) : "".html_safe)
+      progress_section +
+        comment_part +
+        "<br />".html_safe +
+        (creative.tags ? render_creative_tags(creative) : "".html_safe)
     end
   end
 

--- a/app/javascript/creative_row_editor.js
+++ b/app/javascript/creative_row_editor.js
@@ -656,7 +656,9 @@ if (!window.creativeRowEditorInitialized) {
       rowComponent.expanded = true;
       rowComponent.setAttribute('expanded', '');
       rowComponent.dataset.descriptionHtml = '';
-      rowComponent.dataset.progressHtml = '';
+      rowComponent.dataset.progressDisplayHtml = '';
+      rowComponent.dataset.progressMetaHtml = '';
+      rowComponent.dataset.progressArrowHtml = '';
 
       if (referenceNode) {
         targetContainer.insertBefore(rowComponent, referenceNode);

--- a/app/views/creatives/index.html.erb
+++ b/app/views/creatives/index.html.erb
@@ -76,9 +76,14 @@
   <% content_for :head do %>
     <meta property="og:title" content="<%= @parent_creative.effective_origin.description.to_plain_text %>">
   <% end %>
-  <% title_templates = [
+  <% progress_parts = creative_progress_parts(@parent_creative)
+     title_templates = [
         content_tag(:template, data: { part: "description" }) { @parent_creative.effective_description },
-        content_tag(:template, data: { part: "progress" }) { render_creative_progress(@parent_creative) }
+        content_tag(:template, data: { part: "progress-display" }) { progress_parts.display },
+        content_tag(:template, data: { part: "progress-meta" }) { progress_parts.meta },
+        content_tag(:template, data: { part: "progress-arrow" }) do
+          content_tag(:span, svg_tag("arrow-right.svg", class: "creative-progress-arrow-icon"), class: "creative-progress-float-icon", aria: { hidden: true })
+        end
       ] %>
   <% if @parent_creative.origin_id.present? %>
     <% title_templates << content_tag(:template, data: { part: "origin-link" }) do %>
@@ -96,7 +101,8 @@
         "dom-id": "creative-markdown-block",
         "creative-id": @parent_creative.id,
         "parent-id": @parent_creative.parent_id,
-        "is-title": ""
+        "is-title": "",
+        "progress-link-label": t('creatives.index.open_creative', default: 'Open creative')
       ) %>
 <% else %>
   <%= content_tag(
@@ -108,15 +114,22 @@
             t('.creatives')
           end
         end +
-        content_tag(:template, data: { part: "progress" }) do
+        content_tag(:template, data: { part: "progress-display" }) do
           if @overall_progress.nil?
             "".html_safe
           else
-            render_progress_value(@overall_progress)
+            content_tag(:div, class: "creative-progress-container") do
+              content_tag(:span, render_progress_value(@overall_progress), class: "creative-progress-label")
+            end
           end
+        end +
+        content_tag(:template, data: { part: "progress-meta" }) { "".html_safe } +
+        content_tag(:template, data: { part: "progress-arrow" }) do
+          content_tag(:span, svg_tag("arrow-right.svg", class: "creative-progress-arrow-icon"), class: "creative-progress-float-icon", aria: { hidden: true })
         end,
         "dom-id": "creative-markdown-block",
-        "is-title": ""
+        "is-title": "",
+        "progress-link-label": t('creatives.index.open_creative', default: 'Open creative')
       ) %>
 <% end %>
 

--- a/config/locales/creatives.en.yml
+++ b/config/locales/creatives.en.yml
@@ -37,6 +37,7 @@ en:
       request_permission: "Request Access"
       no_permission: "You do not have permission to view this Creative."
       view_origin: "Open origin creative"
+      open_creative: "Open creative"
       share_creative: "Share Creative"
       shared_with: "Shared With"
       unknown_user: "Unknown user"

--- a/config/locales/creatives.ko.yml
+++ b/config/locales/creatives.ko.yml
@@ -37,6 +37,7 @@ ko:
       request_permission: "권한 요청"
       no_permission: "이 크리에이티브를 볼 권한이 없습니다."
       view_origin: "원본 크리에이티브로 이동"
+      open_creative: "크리에이티브로 이동"
       share_creative: "크리에이티브 공유"
       shared_with: "공유 대상"
       unknown_user: "알 수 없는 사용자"


### PR DESCRIPTION
## Summary
- wrap the creative progress display in a link that navigates to the creative
- overlay an arrow icon on hover so users discover the navigation affordance
- style the new hover state while keeping the area clickable even without the cue

## Testing
- ./bin/rubocop -a *(fails: missing gems in the container image)*
- bin/rails test *(fails: missing gems in the container image)*
- bin/rails test:system *(fails: missing gems in the container image)*

## Original User's Requirements
- 정확한 사용자의 UX 를 위해, 크리에이티브를 클릭하면 이동하는 현재 로직을 다음과 같이 바꾼다.
- 크리에이티브를 hover 하면, progress 표시 영역 위에 "->" (SVG 이미지) 버튼이 표시되어 이동 클릭하여 이동할 수 있음을 알린다.
- 해당 영역은 hover 하지 않을때는 보이지 않지만, 그 여역을 클릭하면 이동할 수 있다. (즉, 이미 학습한 사용자는 한번에 이동할 수 있다.)

------
https://chatgpt.com/codex/tasks/task_e_68da1d035fb48326abb5872931cd0f2d