### PR TITLE
Add hover progress navigation overlay

### DIFF
--- a/app/assets/stylesheets/creatives.css
+++ b/app/assets/stylesheets/creatives.css
@@ -252,6 +252,33 @@
     margin-left: 10px;
 }
 
+.creative-progress-value {
+    position: relative;
+    display: inline-block;
+}
+
+.creative-progress-link {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    color: inherit;
+    text-decoration: none;
+    opacity: 0;
+    transition: opacity 0.2s ease;
+}
+
+.creative-progress-link-icon {
+    width: 16px;
+    height: 16px;
+}
+
+.creative-row:hover .creative-progress-link,
+.creative-progress-link:focus-visible {
+    opacity: 1;
+}
+
 .page-title {
     margin-left: 1.5em;
     font-size: 1.4em;

--- a/app/assets/stylesheets/creatives.css
+++ b/app/assets/stylesheets/creatives.css
@@ -267,6 +267,7 @@
     text-decoration: none;
     opacity: 0;
     transition: opacity 0.2s ease;
+    background-color: var(--color-bg);
 }
 
 .creative-progress-link-icon {

--- a/app/assets/stylesheets/creatives.css
+++ b/app/assets/stylesheets/creatives.css
@@ -253,8 +253,25 @@
 }
 
 .creative-progress-value {
+    display: inline-flex;
+    align-items: center;
     position: relative;
-    display: inline-block;
+}
+
+.creative-progress-value--linked {
+    padding: 4px 36px 4px 12px;
+    border-radius: 999px;
+    transition: background-color 0.2s ease;
+}
+
+.creative-progress-value--linked:hover,
+.creative-row:hover .creative-progress-value--linked {
+    background-color: var(--color-border);
+}
+
+.creative-progress-label {
+    position: relative;
+    z-index: 1;
 }
 
 .creative-progress-link {
@@ -265,8 +282,28 @@
     justify-content: flex-end;
     color: inherit;
     text-decoration: none;
+    padding-right: 4px;
+}
+
+.creative-progress-link:focus-visible {
+    outline: 2px solid var(--color-accent, #1a73e8);
+    outline-offset: 2px;
+    border-radius: inherit;
+}
+
+.creative-progress-link-pill {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 24px;
+    border-radius: 999px;
+    background-color: var(--color-section-bg);
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
     opacity: 0;
-    transition: opacity 0.2s ease;
+    transform: translateX(6px);
+    transition: opacity 0.2s ease, transform 0.2s ease, background-color 0.2s ease;
+    pointer-events: none;
 }
 
 .creative-progress-link-icon {
@@ -274,9 +311,12 @@
     height: 16px;
 }
 
-.creative-row:hover .creative-progress-link,
-.creative-progress-link:focus-visible {
+.creative-row:hover .creative-progress-link-pill,
+.creative-progress-value--linked:hover .creative-progress-link-pill,
+.creative-progress-link:focus-visible .creative-progress-link-pill {
     opacity: 1;
+    transform: translateX(0);
+    background-color: var(--color-border);
 }
 
 .page-title {

--- a/app/assets/stylesheets/creatives.css
+++ b/app/assets/stylesheets/creatives.css
@@ -253,25 +253,8 @@
 }
 
 .creative-progress-value {
-    display: inline-flex;
-    align-items: center;
     position: relative;
-}
-
-.creative-progress-value--linked {
-    padding: 4px 36px 4px 12px;
-    border-radius: 999px;
-    transition: background-color 0.2s ease;
-}
-
-.creative-progress-value--linked:hover,
-.creative-row:hover .creative-progress-value--linked {
-    background-color: var(--color-border);
-}
-
-.creative-progress-label {
-    position: relative;
-    z-index: 1;
+    display: inline-block;
 }
 
 .creative-progress-link {
@@ -282,28 +265,8 @@
     justify-content: flex-end;
     color: inherit;
     text-decoration: none;
-    padding-right: 4px;
-}
-
-.creative-progress-link:focus-visible {
-    outline: 2px solid var(--color-accent, #1a73e8);
-    outline-offset: 2px;
-    border-radius: inherit;
-}
-
-.creative-progress-link-pill {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 28px;
-    height: 24px;
-    border-radius: 999px;
-    background-color: var(--color-section-bg);
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
     opacity: 0;
-    transform: translateX(6px);
-    transition: opacity 0.2s ease, transform 0.2s ease, background-color 0.2s ease;
-    pointer-events: none;
+    transition: opacity 0.2s ease;
 }
 
 .creative-progress-link-icon {
@@ -311,12 +274,9 @@
     height: 16px;
 }
 
-.creative-row:hover .creative-progress-link-pill,
-.creative-progress-value--linked:hover .creative-progress-link-pill,
-.creative-progress-link:focus-visible .creative-progress-link-pill {
+.creative-row:hover .creative-progress-link,
+.creative-progress-link:focus-visible {
     opacity: 1;
-    transform: translateX(0);
-    background-color: var(--color-border);
 }
 
 .page-title {

--- a/app/helpers/creatives_helper.rb
+++ b/app/helpers/creatives_helper.rb
@@ -71,52 +71,20 @@ module CreativesHelper
       else
         "".html_safe
       end
-      render_progress_value(
-        progress_value,
-        link_url: creative_path(creative),
-        aria_label: t("creatives.progress_link.aria_label", default: "Open creative"),
-        tooltip: t("creatives.progress_link.tooltip", default: "Open creative")
-      ) + comment_part + "<br />".html_safe + (creative.tags ? render_creative_tags(creative) : "".html_safe)
+      render_progress_value(progress_value) + comment_part + "<br />".html_safe + (creative.tags ? render_creative_tags(creative) : "".html_safe)
     end
   end
 
-  def render_progress_value(value, link_url: nil, aria_label: nil, tooltip: nil)
+  def render_progress_value(value)
     text = number_to_percentage(value * 100, precision: 0)
     if value == 1 && !Current.user&.completion_mark.nil?
       text = Current.user.completion_mark
     end
-
-    progress_classes = [
-      "creative-progress-value",
-      "creative-progress-#{value == 1 ? 'complete' : 'incomplete'}"
-    ]
-
-    progress_classes << "creative-progress-value--linked" if link_url.present?
-
-    label = content_tag(:span, text, class: "creative-progress-label")
-
-    return content_tag(:span, label, class: progress_classes.join(" ")) unless link_url.present?
-
-    aria_label ||= I18n.t("creatives.progress_link.aria_label", default: "Open creative")
-    tooltip ||= I18n.t("creatives.progress_link.tooltip", default: "Open creative")
-
-    arrow = content_tag(
+    content_tag(
       :span,
-      svg_tag("arrow-right.svg", class: "creative-progress-link-icon", width: 16, height: 16),
-      class: "creative-progress-link-pill",
-      aria: { hidden: true }
+      text,
+      class: "creative-progress-#{value == 1 ? 'complete' : 'incomplete'}"
     )
-
-    link = content_tag(
-      :a,
-      arrow,
-      href: link_url,
-      class: "creative-progress-link",
-      aria: { label: aria_label },
-      title: tooltip
-    )
-
-    content_tag(:span, safe_join([label, link]), class: progress_classes.join(" "))
   end
 
   def render_creative_tree(creatives, level = 1, select_mode: false, max_level: User::DEFAULT_DISPLAY_LEVEL)

--- a/app/helpers/creatives_helper.rb
+++ b/app/helpers/creatives_helper.rb
@@ -71,20 +71,52 @@ module CreativesHelper
       else
         "".html_safe
       end
-      render_progress_value(progress_value) + comment_part + "<br />".html_safe + (creative.tags ? render_creative_tags(creative) : "".html_safe)
+      render_progress_value(
+        progress_value,
+        link_url: creative_path(creative),
+        aria_label: t("creatives.progress_link.aria_label", default: "Open creative"),
+        tooltip: t("creatives.progress_link.tooltip", default: "Open creative")
+      ) + comment_part + "<br />".html_safe + (creative.tags ? render_creative_tags(creative) : "".html_safe)
     end
   end
 
-  def render_progress_value(value)
+  def render_progress_value(value, link_url: nil, aria_label: nil, tooltip: nil)
     text = number_to_percentage(value * 100, precision: 0)
     if value == 1 && !Current.user&.completion_mark.nil?
       text = Current.user.completion_mark
     end
-    content_tag(
+
+    progress_classes = [
+      "creative-progress-value",
+      "creative-progress-#{value == 1 ? 'complete' : 'incomplete'}"
+    ]
+
+    progress_classes << "creative-progress-value--linked" if link_url.present?
+
+    label = content_tag(:span, text, class: "creative-progress-label")
+
+    return content_tag(:span, label, class: progress_classes.join(" ")) unless link_url.present?
+
+    aria_label ||= I18n.t("creatives.progress_link.aria_label", default: "Open creative")
+    tooltip ||= I18n.t("creatives.progress_link.tooltip", default: "Open creative")
+
+    arrow = content_tag(
       :span,
-      text,
-      class: "creative-progress-#{value == 1 ? 'complete' : 'incomplete'}"
+      svg_tag("arrow-right.svg", class: "creative-progress-link-icon", width: 16, height: 16),
+      class: "creative-progress-link-pill",
+      aria: { hidden: true }
     )
+
+    link = content_tag(
+      :a,
+      arrow,
+      href: link_url,
+      class: "creative-progress-link",
+      aria: { label: aria_label },
+      title: tooltip
+    )
+
+    content_tag(:span, safe_join([label, link]), class: progress_classes.join(" "))
   end
 
   def render_creative_tree(creatives, level = 1, select_mode: false, max_level: User::DEFAULT_DISPLAY_LEVEL)

--- a/app/javascript/components/creative_tree_row.js
+++ b/app/javascript/components/creative_tree_row.js
@@ -63,7 +63,6 @@ class CreativeTreeRow extends LitElement {
 
   updated() {
     this._attachHandlers();
-    this._ensureProgressLinkOverlay();
   }
 
   _extractTemplates() {
@@ -131,16 +130,21 @@ class CreativeTreeRow extends LitElement {
     this._templatesExtracted = true;
   }
 
-  _ensureProgressLinkOverlay() {
-    if (!this.linkUrl) return;
+  _renderProgress() {
+    if (!this.progressHtml) return nothing;
 
-    const progressContainer = this.querySelector(".creative-row-end");
-    if (!progressContainer) return;
+    return unsafeHTML(this.linkUrl ? this._progressHtmlWithOverlay() : this.progressHtml);
+  }
 
-    const progressValue = progressContainer.querySelector(
+  _progressHtmlWithOverlay() {
+    const template = document.createElement("template");
+    template.innerHTML = this.progressHtml;
+
+    const progressValue = template.content.querySelector(
       ".creative-progress-complete, .creative-progress-incomplete"
     );
-    if (!progressValue) return;
+
+    if (!progressValue) return this.progressHtml;
 
     progressValue.classList.add("creative-progress-value");
 
@@ -148,26 +152,23 @@ class CreativeTreeRow extends LitElement {
     if (!progressLink) {
       progressLink = document.createElement("a");
       progressLink.className = "creative-progress-link";
-      progressLink.setAttribute("aria-label", this._progressLinkAriaLabel());
-      progressLink.setAttribute("title", this._progressLinkTooltip());
       progressValue.appendChild(progressLink);
-
-      const svgNS = "http://www.w3.org/2000/svg";
-      const svg = document.createElementNS(svgNS, "svg");
-      svg.setAttribute("class", "creative-progress-link-icon");
-      svg.setAttribute("viewBox", "0 0 16 16");
-      svg.setAttribute("aria-hidden", "true");
-      const path = document.createElementNS(svgNS, "path");
-      path.setAttribute("fill", "currentColor");
-      path.setAttribute(
-        "d",
-        "M5.22 3.97a.75.75 0 0 1 1.06 0L10.53 8l-4.25 4.03a.75.75 0 1 1-1.04-1.08L8.44 8 5.22 5.03a.75.75 0 0 1 0-1.06z"
-      );
-      svg.appendChild(path);
-      progressLink.appendChild(svg);
     }
 
-    progressLink.href = this.linkUrl;
+    progressLink.setAttribute("href", this.linkUrl);
+    progressLink.setAttribute("aria-label", this._progressLinkAriaLabel());
+    progressLink.setAttribute("title", this._progressLinkTooltip());
+    progressLink.innerHTML = CreativeTreeRow._progressLinkIconSvg;
+
+    return template.innerHTML;
+  }
+
+  static get _progressLinkIconSvg() {
+    return (
+      '<svg class="creative-progress-link-icon" viewBox="0 0 16 16" aria-hidden="true">' +
+      '<path fill="currentColor" d="M5.22 3.97a.75.75 0 0 1 1.06 0L10.53 8l-4.25 4.03a.75.75 0 1 1-1.04-1.08L8.44 8 5.22 5.03a.75.75 0 0 1 0-1.06z"></path>' +
+      "</svg>"
+    );
   }
 
   _progressLinkAriaLabel() {
@@ -224,7 +225,7 @@ class CreativeTreeRow extends LitElement {
             </div>
             ${this._renderContent()}
           </div>
-          ${unsafeHTML(this.progressHtml || "")}
+          ${this._renderProgress()}
         </div>
       </div>
     `;
@@ -247,7 +248,7 @@ class CreativeTreeRow extends LitElement {
           </h1>
           <div>
             <h1 style="display:flex;align-items:center;gap:1em;">
-              ${unsafeHTML(this.progressHtml || "")}
+              ${this._renderProgress()}
             </h1>
           </div>
         </div>

--- a/app/javascript/components/creative_tree_row.js
+++ b/app/javascript/components/creative_tree_row.js
@@ -132,40 +132,31 @@ class CreativeTreeRow extends LitElement {
   }
 
   _ensureProgressLinkOverlay() {
+    if (!this.linkUrl) return;
+
     const progressContainer = this.querySelector(".creative-row-end");
     if (!progressContainer) return;
 
-    const progressValue = progressContainer.querySelector(".creative-progress-value");
+    const progressValue = progressContainer.querySelector(
+      ".creative-progress-complete, .creative-progress-incomplete"
+    );
     if (!progressValue) return;
 
+    progressValue.classList.add("creative-progress-value");
+
     let progressLink = progressValue.querySelector(".creative-progress-link");
-
-    if (!this.linkUrl) {
-      progressLink?.removeAttribute("href");
-      progressValue.classList.remove("creative-progress-value--linked");
-      return;
-    }
-
     if (!progressLink) {
-      const fallbackTarget = progressValue.querySelector(
-        ".creative-progress-complete, .creative-progress-incomplete, .creative-progress-label"
-      );
-      const wrapper = fallbackTarget ?? progressValue;
-      wrapper.classList.add("creative-progress-value");
-
       progressLink = document.createElement("a");
       progressLink.className = "creative-progress-link";
       progressLink.setAttribute("aria-label", this._progressLinkAriaLabel());
       progressLink.setAttribute("title", this._progressLinkTooltip());
-
-      const pill = document.createElement("span");
-      pill.className = "creative-progress-link-pill";
-      pill.setAttribute("aria-hidden", "true");
+      progressValue.appendChild(progressLink);
 
       const svgNS = "http://www.w3.org/2000/svg";
       const svg = document.createElementNS(svgNS, "svg");
       svg.setAttribute("class", "creative-progress-link-icon");
       svg.setAttribute("viewBox", "0 0 16 16");
+      svg.setAttribute("aria-hidden", "true");
       const path = document.createElementNS(svgNS, "path");
       path.setAttribute("fill", "currentColor");
       path.setAttribute(
@@ -173,19 +164,10 @@ class CreativeTreeRow extends LitElement {
         "M5.22 3.97a.75.75 0 0 1 1.06 0L10.53 8l-4.25 4.03a.75.75 0 1 1-1.04-1.08L8.44 8 5.22 5.03a.75.75 0 0 1 0-1.06z"
       );
       svg.appendChild(path);
-      pill.appendChild(svg);
-      progressLink.appendChild(pill);
-      progressValue.appendChild(progressLink);
+      progressLink.appendChild(svg);
     }
 
-    progressValue.classList.add("creative-progress-value--linked");
     progressLink.href = this.linkUrl;
-    if (!progressLink.hasAttribute("aria-label")) {
-      progressLink.setAttribute("aria-label", this._progressLinkAriaLabel());
-    }
-    if (!progressLink.hasAttribute("title")) {
-      progressLink.setAttribute("title", this._progressLinkTooltip());
-    }
   }
 
   _progressLinkAriaLabel() {

--- a/app/javascript/components/creative_tree_row.js
+++ b/app/javascript/components/creative_tree_row.js
@@ -132,31 +132,40 @@ class CreativeTreeRow extends LitElement {
   }
 
   _ensureProgressLinkOverlay() {
-    if (!this.linkUrl) return;
-
     const progressContainer = this.querySelector(".creative-row-end");
     if (!progressContainer) return;
 
-    const progressValue = progressContainer.querySelector(
-      ".creative-progress-complete, .creative-progress-incomplete"
-    );
+    const progressValue = progressContainer.querySelector(".creative-progress-value");
     if (!progressValue) return;
 
-    progressValue.classList.add("creative-progress-value");
-
     let progressLink = progressValue.querySelector(".creative-progress-link");
+
+    if (!this.linkUrl) {
+      progressLink?.removeAttribute("href");
+      progressValue.classList.remove("creative-progress-value--linked");
+      return;
+    }
+
     if (!progressLink) {
+      const fallbackTarget = progressValue.querySelector(
+        ".creative-progress-complete, .creative-progress-incomplete, .creative-progress-label"
+      );
+      const wrapper = fallbackTarget ?? progressValue;
+      wrapper.classList.add("creative-progress-value");
+
       progressLink = document.createElement("a");
       progressLink.className = "creative-progress-link";
       progressLink.setAttribute("aria-label", this._progressLinkAriaLabel());
       progressLink.setAttribute("title", this._progressLinkTooltip());
-      progressValue.appendChild(progressLink);
+
+      const pill = document.createElement("span");
+      pill.className = "creative-progress-link-pill";
+      pill.setAttribute("aria-hidden", "true");
 
       const svgNS = "http://www.w3.org/2000/svg";
       const svg = document.createElementNS(svgNS, "svg");
       svg.setAttribute("class", "creative-progress-link-icon");
       svg.setAttribute("viewBox", "0 0 16 16");
-      svg.setAttribute("aria-hidden", "true");
       const path = document.createElementNS(svgNS, "path");
       path.setAttribute("fill", "currentColor");
       path.setAttribute(
@@ -164,10 +173,19 @@ class CreativeTreeRow extends LitElement {
         "M5.22 3.97a.75.75 0 0 1 1.06 0L10.53 8l-4.25 4.03a.75.75 0 1 1-1.04-1.08L8.44 8 5.22 5.03a.75.75 0 0 1 0-1.06z"
       );
       svg.appendChild(path);
-      progressLink.appendChild(svg);
+      pill.appendChild(svg);
+      progressLink.appendChild(pill);
+      progressValue.appendChild(progressLink);
     }
 
+    progressValue.classList.add("creative-progress-value--linked");
     progressLink.href = this.linkUrl;
+    if (!progressLink.hasAttribute("aria-label")) {
+      progressLink.setAttribute("aria-label", this._progressLinkAriaLabel());
+    }
+    if (!progressLink.hasAttribute("title")) {
+      progressLink.setAttribute("title", this._progressLinkTooltip());
+    }
   }
 
   _progressLinkAriaLabel() {

--- a/app/javascript/components/creative_tree_row.js
+++ b/app/javascript/components/creative_tree_row.js
@@ -63,6 +63,7 @@ class CreativeTreeRow extends LitElement {
 
   updated() {
     this._attachHandlers();
+    this._ensureProgressLinkOverlay();
   }
 
   _extractTemplates() {
@@ -128,6 +129,53 @@ class CreativeTreeRow extends LitElement {
 
     if (existingTree) existingTree.remove();
     this._templatesExtracted = true;
+  }
+
+  _ensureProgressLinkOverlay() {
+    if (!this.linkUrl) return;
+
+    const progressContainer = this.querySelector(".creative-row-end");
+    if (!progressContainer) return;
+
+    const progressValue = progressContainer.querySelector(
+      ".creative-progress-complete, .creative-progress-incomplete"
+    );
+    if (!progressValue) return;
+
+    progressValue.classList.add("creative-progress-value");
+
+    let progressLink = progressValue.querySelector(".creative-progress-link");
+    if (!progressLink) {
+      progressLink = document.createElement("a");
+      progressLink.className = "creative-progress-link";
+      progressLink.setAttribute("aria-label", this._progressLinkAriaLabel());
+      progressLink.setAttribute("title", this._progressLinkTooltip());
+      progressValue.appendChild(progressLink);
+
+      const svgNS = "http://www.w3.org/2000/svg";
+      const svg = document.createElementNS(svgNS, "svg");
+      svg.setAttribute("class", "creative-progress-link-icon");
+      svg.setAttribute("viewBox", "0 0 16 16");
+      svg.setAttribute("aria-hidden", "true");
+      const path = document.createElementNS(svgNS, "path");
+      path.setAttribute("fill", "currentColor");
+      path.setAttribute(
+        "d",
+        "M5.22 3.97a.75.75 0 0 1 1.06 0L10.53 8l-4.25 4.03a.75.75 0 1 1-1.04-1.08L8.44 8 5.22 5.03a.75.75 0 0 1 0-1.06z"
+      );
+      svg.appendChild(path);
+      progressLink.appendChild(svg);
+    }
+
+    progressLink.href = this.linkUrl;
+  }
+
+  _progressLinkAriaLabel() {
+    return this.getAttribute("link-aria-label") || "Open creative";
+  }
+
+  _progressLinkTooltip() {
+    return this.getAttribute("link-tooltip") || "Open creative";
   }
 
   _attachHandlers() {


### PR DESCRIPTION
## Summary
- create a LitElement overlay that attaches a hidden link on each creative progress indicator and renders a right-arrow svg when hovered
- add styles so the arrow button remains clickable at all times while only becoming visible when the creative row or link is hovered or focused

## Testing
- `./bin/rubocop -a`
- `bundle exec rails test` *(fails: NoMethodError: undefined method 'has_closure_tree' for class Creative)*
- `bundle exec rails test:system` *(fails: NoMethodError: undefined method 'has_closure_tree' for class Creative)*

## Original User's Requirements
- 정확한 사용자의 UX 를 위해, 크리에이티브를 클릭하면 이동하는 현재 로직을 다음과 같이 바꾼다.
- 크리에이티브를 hover 하면, progress 표시 영역 위에 "->" (SVG 이미지) 버튼이 표시되어 이동 클릭하여 이동할 수 있음을 알린다.
- 해당 영역은 hover 하지 않을때는 보이지 않지만, 그 영역을 클릭하면 이동할 수 있다. (즉, 이미 학습한 사용자는 한번에 이동할 수 있다.)
- 해당 영역은 progress element 위치 영역위에 겹쳐서 표시되고 Lit element 에서 만들고, 기존의 레이아웃은 건드리지 않는다. 단지 Link 버튼은 hover 시에만 보이기 아닐때는 invisible 한 상태로 클릭은 가능하다.

------
https://chatgpt.com/codex/tasks/task_e_68da2330cf1c83268a893e0f416a4881