### PR TITLE
Allow dragging multiple selected creatives

### DIFF
--- a/app/controllers/creatives_controller.rb
+++ b/app/controllers/creatives_controller.rb
@@ -191,11 +191,23 @@ class CreativesController < ApplicationController
   end
 
   def reorder
-    reorderer.reorder(
-      dragged_id: params[:dragged_id],
-      target_id: params[:target_id],
-      direction: params[:direction]
-    )
+    dragged_ids = Array(params[:dragged_ids]).map(&:presence).compact
+    target_id = params[:target_id]
+    direction = params[:direction]
+
+    if dragged_ids.any?
+      reorderer.reorder_multiple(
+        dragged_ids: dragged_ids,
+        target_id: target_id,
+        direction: direction
+      )
+    else
+      reorderer.reorder(
+        dragged_id: params[:dragged_id],
+        target_id: target_id,
+        direction: direction
+      )
+    end
     head :ok
   rescue Creatives::Reorderer::Error
     head :unprocessable_entity

--- a/app/javascript/api/drag_drop.api.js
+++ b/app/javascript/api/drag_drop.api.js
@@ -2,14 +2,21 @@ function csrfToken() {
   return document.querySelector('meta[name="csrf-token"]')?.content;
 }
 
-export function sendNewOrder({ draggedId, targetId, direction }) {
+export function sendNewOrder({ draggedId, draggedIds, targetId, direction }) {
+  const payload = { target_id: targetId, direction };
+  if (Array.isArray(draggedIds) && draggedIds.length > 0) {
+    payload.dragged_ids = draggedIds;
+  } else {
+    payload.dragged_id = draggedId;
+  }
+
   return fetch('/creatives/reorder', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
       'X-CSRF-Token': csrfToken(),
     },
-    body: JSON.stringify({ dragged_id: draggedId, target_id: targetId, direction }),
+    body: JSON.stringify(payload),
   });
 }
 

--- a/app/javascript/components/creative_tree_row.js
+++ b/app/javascript/components/creative_tree_row.js
@@ -149,7 +149,7 @@ class CreativeTreeRow extends LitElement {
       return this._renderTitle();
     }
 
-    const dragEnabled = !this.selectMode;
+    const dragEnabled = !this.selectMode || this.canWrite;
     const draggableAttr = dragEnabled ? "true" : nothing;
     const dragStartAttr = dragEnabled ? "handleDragStart(event)" : nothing;
     const dragOverAttr = dragEnabled ? "handleDragOver(event)" : nothing;

--- a/app/javascript/creatives/drag_drop/event_handlers.js
+++ b/app/javascript/creatives/drag_drop/event_handlers.js
@@ -665,20 +665,32 @@ function handleDrop(event) {
   }
 
   if (event.shiftKey) {
-    if (isMultiDrag) {
-      resetDrag();
-      console.warn('Linking multiple creatives at once is not supported.');
-      return;
-    }
     const snapshot = { ...draggedState };
     resetDrag();
-    sendLinkedCreative({
-      draggedId: snapshot.creativeId,
-      targetId: targetId.replace('creative-', ''),
-      direction,
-    })
-      .then(() => window.location.reload())
-      .catch((error) => console.error('Failed to create linked creative', error));
+    
+    if (isMultiDrag) {
+      // Handle multiple linked creatives
+      const promises = draggedIds.map(draggedId => 
+        sendLinkedCreative({
+          draggedId,
+          targetId: targetId.replace('creative-', ''),
+          direction,
+        })
+      );
+      
+      Promise.all(promises)
+        .then(() => window.location.reload())
+        .catch((error) => console.error('Failed to create linked creatives', error));
+    } else {
+      // Handle single linked creative
+      sendLinkedCreative({
+        draggedId: snapshot.creativeId,
+        targetId: targetId.replace('creative-', ''),
+        direction,
+      })
+        .then(() => window.location.reload())
+        .catch((error) => console.error('Failed to create linked creative', error));
+    }
     return;
   }
 

--- a/app/javascript/select_mode.js
+++ b/app/javascript/select_mode.js
@@ -34,10 +34,16 @@ if (!window.isSelectModeInitialized) {
             row.addEventListener('mousedown', function(e) {
                 if (!selectModeActive) return;
                 if (e.target.closest('.select-creative-checkbox')) return;
-                dragging = true;
+                const tree = row.closest('.creative-tree');
+                const isDraggable = tree && tree.getAttribute('draggable') !== 'false';
+                const alreadySelected = row.classList.contains('selected');
+                const shouldToggle = !isDraggable || !alreadySelected || e.altKey || e.shiftKey;
+                dragging = shouldToggle;
                 dragMode = e.altKey ? 'remove' : (e.shiftKey ? 'add' : 'toggle');
-                applySelection(row);
-                e.preventDefault();
+                if (shouldToggle) {
+                    applySelection(row);
+                    e.preventDefault();
+                }
             });
             row.addEventListener('mouseenter', function() {
                 if (dragging && selectModeActive) {

--- a/test/services/creatives/reorderer_test.rb
+++ b/test/services/creatives/reorderer_test.rb
@@ -1,0 +1,72 @@
+require "test_helper"
+
+module Creatives
+  class ReordererTest < ActiveSupport::TestCase
+    setup do
+      @user = User.create!(
+        email: "reorderer@example.com",
+        password: "password123",
+        name: "Reorderer",
+        email_verified_at: Time.current,
+        notifications_enabled: false
+      )
+
+      @root = Creative.create!(description: "Root", user: @user)
+      @child_a = Creative.create!(description: "A", user: @user, parent: @root, sequence: 0)
+      @child_b = Creative.create!(description: "B", user: @user, parent: @root, sequence: 1)
+      @child_c = Creative.create!(description: "C", user: @user, parent: @root, sequence: 2)
+      @child_d = Creative.create!(description: "D", user: @user, parent: @root, sequence: 3)
+
+      @reorderer = Reorderer.new(user: @user)
+    end
+
+    test "reorder_multiple inserts selected creatives as siblings in original order" do
+      @reorderer.reorder_multiple(
+        dragged_ids: [ @child_c.id, @child_a.id ],
+        target_id: @child_b.id,
+        direction: "up"
+      )
+
+      order = @root.reload.children.order(:sequence).map { |creative| creative.description.to_plain_text }
+      assert_equal [ "C", "A", "B", "D" ], order
+    end
+
+    test "reorder_multiple appends creatives as children preserving order" do
+      new_parent = Creative.create!(description: "Parent", user: @user)
+
+      @reorderer.reorder_multiple(
+        dragged_ids: [ @child_a.id, @child_b.id ],
+        target_id: new_parent.id,
+        direction: "child"
+      )
+
+      root_order = @root.reload.children.order(:sequence).map { |creative| creative.description.to_plain_text }
+      assert_equal [ "C", "D" ], root_order
+
+      child_order = new_parent.reload.children.order(:sequence).map { |creative| creative.description.to_plain_text }
+      assert_equal [ "A", "B" ], child_order
+    end
+
+    test "reorder_multiple raises when target is within selection" do
+      assert_raises(Reorderer::Error) do
+        @reorderer.reorder_multiple(
+          dragged_ids: [ @child_a.id, @child_b.id ],
+          target_id: @child_a.id,
+          direction: "down"
+        )
+      end
+    end
+
+    test "reorder_multiple raises when target is descendant of dragged creative" do
+      descendant = Creative.create!(description: "Child", user: @user, parent: @child_a)
+
+      assert_raises(Reorderer::Error) do
+        @reorderer.reorder_multiple(
+          dragged_ids: [ @child_a.id, @child_b.id ],
+          target_id: descendant.id,
+          direction: "up"
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- allow bulk reorder requests in the controller/service and add safety checks for invalid multi-node moves【F:app/controllers/creatives_controller.rb†L200-L214】【F:app/services/creatives/reorderer.rb†L25-L163】
- update the drag-and-drop UI to carry the entire selection, permit dragging while select mode is on, and send multi-id payloads to the backend【F:app/javascript/components/creative_tree_row.js†L152-L169】【F:app/javascript/select_mode.js†L34-L65】【F:app/javascript/api/drag_drop.api.js†L5-L20】【F:app/javascript/creatives/drag_drop/event_handlers.js†L77-L763】
- cover the new multi-reorder logic with service tests to confirm ordering and validation behaviour【F:test/services/creatives/reorderer_test.rb†L1-L70】

## Original User's Requirements
- 선택된 크리에이티브 전체를 드래그해서 드롭할 수 있게해줘

## Testing
- `./bin/rubocop -a`
- `bundle exec rails test`
- `bundle exec rails test:system` *(fails: chromedriver download blocked in container)*

------
https://chatgpt.com/codex/tasks/task_e_68da50ba78bc83269beba5b69d1fcf1e