### PR TITLE
Use effective origin descriptions in invite flows

### DIFF
--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -3,7 +3,7 @@ class InvitesController < ApplicationController
   before_action :set_invitation, only: :show
 
   def create
-    creative = Creative.find(params[:creative_id])
+    creative = Creative.find(params[:creative_id]).effective_origin
     permission = params[:permission] || :read
     invitation = Invitation.create!(inviter: Current.user,
                                     creative: creative,

--- a/app/views/invitation_mailer/invite.html.erb
+++ b/app/views/invitation_mailer/invite.html.erb
@@ -1,5 +1,5 @@
 <p>
   <%= t('invitation_mailer.invite.message_html',
-         creative: @invitation.creative.description.to_plain_text,
+         creative: @invitation.creative.effective_origin.description.to_plain_text,
          link: link_to(t('app.here'), invite_url(token: @invitation.generate_token_for(:invite)))) %>
 </p>

--- a/app/views/invitation_mailer/invite.text.erb
+++ b/app/views/invitation_mailer/invite.text.erb
@@ -1,3 +1,3 @@
 <%= t('invitation_mailer.invite.message_text',
-       creative: @invitation.creative.description.to_plain_text,
+       creative: @invitation.creative.effective_origin.description.to_plain_text,
        link: invite_url(token: @invitation.generate_token_for(:invite))) %>

--- a/app/views/invites/show.html.erb
+++ b/app/views/invites/show.html.erb
@@ -1,5 +1,5 @@
 <h1 class="no-top-margin"><%= t('.title') %></h1>
-<p><%= t('invites.show.invited_by', inviter: @invitation.inviter.display_name, email: @invitation.inviter.email, creative: @invitation.creative.description.to_plain_text) %></p>
+<p><%= t('invites.show.invited_by', inviter: @invitation.inviter.display_name, email: @invitation.inviter.email, creative: @invitation.creative.effective_origin.description.to_plain_text) %></p>
 <p><%= t('invites.show.prompt') %></p>
 <p>
   <%= link_to t('invites.show.login'), new_session_path(invite_token: params[:token]) %> |

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -3,7 +3,7 @@
 <% if defined?(@invitation) && @invitation.present? %>
   <p>
     <strong><%= t('creatives.index.share_creative') %>:</strong>
-    <%= @invitation.creative.description.to_plain_text %>
+    <%= @invitation.creative.effective_origin.description.to_plain_text %>
   </p>
 <% end %>
 


### PR DESCRIPTION
## Summary
- ensure invite creation uses the creative's effective origin when generating share invitations
- update invitation mailers and related views to render descriptions from the effective origin

## Testing
- `./bin/rubocop -a` *(fails: missing gems in the environment)*
- `bundle exec rails test` *(fails: `rails` executable unavailable; run `bundle install`)*
- `bundle exec rails test:system` *(fails: `rails` executable unavailable; run `bundle install`)*

## Original User's Requirements
- share 팝업창에서 초대 링크를 생성시, Creative description 을 표시할때 effective_origin.description 을 사용해야 한다.


------
https://chatgpt.com/codex/tasks/task_e_68db6924c26883268bcbc49d40d150d7