### PR TITLE
Move creative guidance into default prompt

### DIFF
--- a/app/models/creative.rb
+++ b/app/models/creative.rb
@@ -21,6 +21,8 @@ class Creative < ApplicationRecord
 
       \#{language_instructions}
 
+      When describing creatives, write from an end-user perspective similar to a user manual. Avoid unnecessary technical detail, and keep sentences concise.
+
       Return a JSON object with two keys:
       - "completed": array of objects representing tasks finished by this PR. Each object must include "creative_id" (from the IDs above). Use only creatives marked [LEAF] in the list above. Optionally include "progress" (0.0 to 1.0), "note", or "path" for context.
       - "additional": array of objects for new creatives that are not already represented in the tree above. Each object must include "parent_id" (from the IDs above) and "description" (the new creative text). Do not use this list for follow-up tasks on existing creatives—only describe brand new creatives. Optionally include "progress" (0.0 to 1.0), "note", or "path".


### PR DESCRIPTION
## Summary
- move the end-user creative description guidance into the default GitHub Gemini prompt template
- keep preferred language instructions focused on locale-specific output requirements
- refresh analyzer tests to assert the relocated creative guidance text

## Testing
- `./bin/rubocop -a` *(fails: missing gems in execution environment)*
- `bundle exec rails test` *(fails: rails executable unavailable because gems are not installed)*
- `bundle exec rails test:system` *(fails: rails executable unavailable because gems are not installed)*

## Original User's Requirements
- Github PR 분석시 prompt 에 크리에이티브 작성시에는 사용자 매뉴얼을 작성하듯이 엔드 유저 관점에서 작성해야 하고, 불필요한 기술적인 내용은 되도록 배제하고 최소한의 문장으로 간결하게 작성한다. 는 부분을 업데이트해줘.


------
https://chatgpt.com/codex/tasks/task_e_68db6b0a21608326a8d673930053e0c7