### PR TITLE
Restrict GitHub integration access to admins

### DIFF
--- a/app/controllers/creatives/github_integrations_controller.rb
+++ b/app/controllers/creatives/github_integrations_controller.rb
@@ -2,6 +2,7 @@ module Creatives
   class GithubIntegrationsController < ApplicationController
     before_action :set_creative
     before_action :ensure_read_permission
+    before_action :ensure_admin_permission, only: [ :show, :update ]
 
     def show
       account = Current.user.github_account
@@ -21,11 +22,6 @@ module Creatives
     end
 
     def update
-      unless @creative.has_permission?(Current.user, :write)
-        render json: { error: "forbidden" }, status: :forbidden
-        return
-      end
-
       account = Current.user.github_account
       unless account
         render json: { error: "not_connected" }, status: :unprocessable_entity
@@ -81,6 +77,12 @@ module Creatives
 
     def ensure_read_permission
       return if @creative.has_permission?(Current.user, :read)
+
+      render json: { error: "forbidden" }, status: :forbidden
+    end
+
+    def ensure_admin_permission
+      return if @creative.has_permission?(Current.user, :admin)
 
       render json: { error: "forbidden" }, status: :forbidden
     end

--- a/app/views/creatives/_mobile_actions_menu.html.erb
+++ b/app/views/creatives/_mobile_actions_menu.html.erb
@@ -4,8 +4,12 @@
         menu_id: 'mobile-actions-menu',
         align: :right
       ) do %>
-    <% if (@parent_creative || @creative) && (@parent_creative || @creative).has_permission?(Current.user, :write) %>
+    <% current_creative = local_assigns[:current_creative] || @parent_creative || @creative %>
+    <% can_manage_integrations = local_assigns.fetch(:can_manage_integrations, current_creative&.has_permission?(Current.user, :admin)) %>
+    <% if current_creative&.has_permission?(Current.user, :write) %>
       <button type="button" class="popup-menu-item" data-click-target="share-creative-btn"><%= t('creatives.index.share') %></button>
+    <% end %>
+    <% if can_manage_integrations %>
       <button type="button" class="popup-menu-item" data-click-target="github-integration-btn"><%= t('creatives.index.integrations', default: '연동') %> - Github</button>
     <% end %>
     <% if @parent_creative.present? %>

--- a/app/views/creatives/index.html.erb
+++ b/app/views/creatives/index.html.erb
@@ -12,12 +12,13 @@
     <% end %>
   <% end %>
 
+  <% current_creative = @parent_creative || @creative %>
+  <% can_manage_integrations = current_creative&.has_permission?(Current.user, :admin) %>
   <% if (@parent_creative || @creative) && (@parent_creative || @creative).has_permission?(Current.user, :write) %>
     <%= render 'share_button' %>
   <% end %>
 
-  <% current_creative = @parent_creative || @creative %>
-  <% if current_creative&.has_permission?(Current.user, :write) %>
+  <% if can_manage_integrations %>
     <%= render PopupMenuComponent.new(
           button_content: t('creatives.index.integrations', default: '연동'),
           menu_id: 'creative-integrations-menu',
@@ -45,10 +46,12 @@
     <span aria-hidden="true"><%= svg_tag 'edit.svg', class: 'icon-edit', width: 16, height: 16 %></span></button>
   <button id="import-markdown-btn" class="import-btn desktop-only"><%= t('.import_markdown') %></button>
   <button id="export-markdown-btn" class="export-btn desktop-only" data-parent-creative-id="<%= @parent_creative&.id %>" data-error="<%= t('creatives.index.export_failed') %>"><%= t('.export_markdown') %></button>
-  <%= render 'mobile_actions_menu' %>
+  <%= render 'mobile_actions_menu', current_creative: current_creative, can_manage_integrations: can_manage_integrations %>
 </div>
 <%= render 'import_upload_zone' %>
-<button id="github-integration-btn" data-creative-id="<%= current_creative&.id %>" style="display:none;"></button>
+<% if can_manage_integrations %>
+  <button id="github-integration-btn" data-creative-id="<%= current_creative&.id %>" style="display:none;"></button>
+<% end %>
 
 <%#= TODO: remove this later completely recalculate progress you need to remove route, and controller also %>
 <%#= button_to t('.recalculate_progress'), recalculate_progress_creatives_path, method: :post, form: { data: { turbo_confirm: t('.recalculate_all_parent_progress') } } if authenticated? %>
@@ -141,4 +144,6 @@
 <%= render 'inline_edit_form' %>
 
 <%= render 'set_plan_modal' %>
-<%= render 'github_integration_modal', creative: current_creative %>
+<% if can_manage_integrations %>
+  <%= render 'github_integration_modal', creative: current_creative %>
+<% end %>

--- a/test/controllers/creatives/github_integrations_controller_test.rb
+++ b/test/controllers/creatives/github_integrations_controller_test.rb
@@ -75,4 +75,19 @@ class Creatives::GithubIntegrationsControllerTest < ActionDispatch::IntegrationT
     assert_equal 'Updated prompt: #{pr_title} #{diff}', body["github_gemini_prompt"]
     assert_equal 'Updated prompt: #{pr_title} #{diff}', @creative.reload.github_gemini_prompt
   end
+
+  test "non admin users cannot manage github integration" do
+    other_user = users(:two)
+    CreativeShare.create!(creative: @creative, user: other_user, permission: :write)
+
+    sign_out
+    sign_in_as(other_user, password: "password")
+
+    get creative_github_integration_path(@creative), as: :json
+    assert_response :forbidden
+
+    payload = { repositories: [ "sample-user/example" ] }
+    patch creative_github_integration_path(@creative), params: payload, as: :json
+    assert_response :forbidden
+  end
 end


### PR DESCRIPTION
## Summary
- hide the GitHub integration menu and modal unless the current user has admin permission on the creative
- ensure the GitHub integration controller requires admin access for viewing or updating integration settings
- add a regression test confirming non-admin users cannot access the integration endpoints

## Testing
- `./bin/rubocop -a`
- `bin/rails test`
- `bin/rails test:system` *(fails: Selenium cannot download Chrome driver in the container environment)*

## Original User's Requirements
- integration 메뉴는 관리자 권한만 표시하고 설정할 수 있다.

------
https://chatgpt.com/codex/tasks/task_e_68db693ac340832688760e0a78d5f5bd