### PR TITLE
Show existing GitHub integration status and allow removal

### DIFF
--- a/app/views/creatives/_github_integration_modal.html.erb
+++ b/app/views/creatives/_github_integration_modal.html.erb
@@ -4,6 +4,10 @@
      data-no-creative="<%= t('creatives.index.github_integration_missing_creative', default: '연동할 Creative가 선택되지 않았습니다.') %>"
      data-webhook-url-label="<%= t('creatives.index.github_integration_webhook_url_label', default: 'Webhook URL') %>"
      data-webhook-secret-label="<%= t('creatives.index.github_integration_webhook_secret_label', default: 'Webhook 비밀값') %>"
+     data-existing-message="<%= t('creatives.index.github_integration_existing_message', default: '이미 아래 Repository와 연동 중입니다.') %>"
+     data-delete-confirm="<%= t('creatives.index.github_integration_delete_confirm', default: 'Github 연동을 삭제하시겠습니까?') %>"
+     data-delete-success="<%= t('creatives.index.github_integration_delete_success', default: 'Github 연동이 삭제되었습니다.') %>"
+     data-delete-error="<%= t('creatives.index.github_integration_delete_error', default: 'Github 연동을 삭제하지 못했습니다.') %>"
      style="display:none;position:fixed;top:0;left:0;width:100vw;height:100vh;z-index:1000;align-items:center;justify-content:center;">
   <div class="popup-box" style="min-width:360px;max-width:90vw;">
     <button type="button" id="close-github-modal" class="popup-close-btn">&times;</button>
@@ -18,6 +22,13 @@
       <button type="button" id="github-login-btn" class="btn btn-primary" data-window-width="620" data-window-height="720">
         <%= t('creatives.index.github_login_button', default: 'Github 계정으로 로그인') %>
       </button>
+      <div id="github-existing-connections" style="display:none;margin-top:1.25em;">
+        <p style="margin-bottom:0.5em;"><%= t('creatives.index.github_integration_existing_intro', default: '이미 연동된 Repository 목록입니다:') %></p>
+        <ul id="github-existing-repo-list" style="padding-left:1.2em;margin-bottom:0.75em;color:#333;"></ul>
+        <button type="button" id="github-delete-btn" class="btn btn-danger" style="display:none;">
+          <%= t('creatives.index.github_integration_delete_button', default: '연동 삭제') %>
+        </button>
+      </div>
     </div>
 
     <div class="github-wizard-step" id="github-step-organization" style="display:none;">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,7 +33,7 @@ Rails.application.routes.draw do
   end
 
   resources :creatives do
-    resource :github_integration, only: [ :show, :update ], module: :creatives
+    resource :github_integration, only: [ :show, :update, :destroy ], module: :creatives
     resources :subscribers, only: [ :create ]
     resources :creative_shares, only: [ :create, :destroy ]
       resources :comments, only: [ :index, :create, :destroy, :show, :update ] do

--- a/test/controllers/creatives/github_integrations_controller_test.rb
+++ b/test/controllers/creatives/github_integrations_controller_test.rb
@@ -90,4 +90,18 @@ class Creatives::GithubIntegrationsControllerTest < ActionDispatch::IntegrationT
     patch creative_github_integration_path(@creative), params: payload, as: :json
     assert_response :forbidden
   end
+
+  test "destroy removes repository links for creative" do
+    assert_difference("GithubRepositoryLink.count", -1) do
+      delete creative_github_integration_path(@creative), as: :json
+    end
+
+    assert_response :success
+    body = JSON.parse(response.body)
+
+    assert body["success"], "Expected success flag in response"
+    assert_equal [], body["selected_repositories"], "Expected no repositories after deletion"
+    assert_equal({}, body["webhooks"])
+    assert_empty @creative.github_repository_links.where(github_account: @github_account)
+  end
 end


### PR DESCRIPTION
## Summary
- surface dataset-backed strings and UI in the GitHub integration modal so existing repository links are shown immediately after loading
- add a destructive action that clears linked repositories for a creative and expose it through both the API and UI
- cover the new removal workflow with a controller test and update routing accordingly

## Testing
- `./bin/rubocop -a` *(fails: missing required gems in container environment)*
- `bundle exec rails test` *(fails: missing `rails` executable because gems are not installed)*
- `bundle exec rails test:system` *(fails: missing `rails` executable because gems are not installed)*

## Original User's Requirements
- github 연동시 이미 연동되었으면 연동된 repository 를 표시하고 이미 연동된 것이 있다는 것으로 처음에 표시하고 다음 기능을 추가해.
- 연동을 삭제 - 연동 삭제 버튼을 두어 연동을 삭제할 수 있도록 해줘

------
https://chatgpt.com/codex/tasks/task_e_68db6b5bf78083268b493e4d0cdc5fa6