### PR TITLE
Link creative IDs in PR analysis comments

### DIFF
--- a/app/services/github/pull_request_processor.rb
+++ b/app/services/github/pull_request_processor.rb
@@ -161,7 +161,7 @@ module Github
     def format_completed_task(task, path_exporter)
       label = task.path.presence || path_exporter.path_for(task.creative_id) || "Creative ##{task.creative_id}"
       parts = []
-      parts << "[#{task.creative_id}] #{label}"
+      parts << "#{creative_link(task.creative_id)} #{label}"
       if task.progress && task.progress < 1.0
         percentage = (task.progress * 100).round
         parts << "(progress #{percentage}%)"
@@ -173,7 +173,7 @@ module Github
     def format_suggestion(suggestion, path_exporter)
       parent_label = path_exporter.path_for(suggestion.parent_id) || "Creative ##{suggestion.parent_id}"
       parts = []
-      parts << "[#{suggestion.parent_id}] #{parent_label}"
+      parts << "#{creative_link(suggestion.parent_id)} #{parent_label}"
       parts << "→ #{suggestion.description}"
       if suggestion.progress
         percentage = (suggestion.progress * 100).round
@@ -181,6 +181,18 @@ module Github
       end
       parts << "- #{suggestion.note}" if suggestion.note.present?
       parts.join(" ")
+    end
+
+    def creative_link(id)
+      path = url_helpers.creative_path(id)
+      "[#%<id>d](%<path>s)" % { id: id, path: path }
+    rescue StandardError => e
+      logger.warn("Failed to build creative link for ##{id}: #{e.message}")
+      "##{id}"
+    end
+
+    def url_helpers
+      @url_helpers ||= Rails.application.routes.url_helpers
     end
   end
 end

--- a/test/services/github/pull_request_processor_test.rb
+++ b/test/services/github/pull_request_processor_test.rb
@@ -67,7 +67,11 @@ module Github
       comment = creative.comments.last
       assert comment.present?
       assert_includes comment.content, "#12"
-      assert_includes comment.content, "[#{completed_task.creative_id}]"
+      url_helpers = Rails.application.routes.url_helpers
+      child_path = url_helpers.creative_path(completed_task.creative_id)
+      parent_path = url_helpers.creative_path(suggestion.parent_id)
+      assert_includes comment.content, "[##{completed_task.creative_id}](#{child_path})"
+      assert_includes comment.content, "[##{suggestion.parent_id}](#{parent_path})"
       assert_includes comment.content, "Follow up"
       assert_includes comment.content, "Gemini 전송 메시지"
       assert_includes comment.content, prompt_text


### PR DESCRIPTION
## Summary
- render creative identifiers in GitHub PR analysis comments as markdown links to the creative page
- add helper for building creative links with graceful fallback logging
- extend the pull request processor test to cover the new link formatting

## Testing
- ./bin/rubocop -a *(fails: missing gems in container environment)*
- bin/rails test *(fails: missing gems in container environment)*
- bin/rails test:system *(fails: missing gems in container environment)*

## Original User's Requirements
- github PR 분석 결과를 채팅 메세지에 보여줄때, creative id 에 대한 링크를 표시하도록 해

------
https://chatgpt.com/codex/tasks/task_e_68db7b33f0c08326838e1f63f940380c