### PR TITLE
Remove GitHub webhooks when integrations are deleted

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -476,7 +476,7 @@ GEM
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    with_advisory_lock (7.0.1)
+    with_advisory_lock (7.0.2)
       activerecord (>= 7.2)
       zeitwerk (>= 2.7)
     xpath (3.2.0)

--- a/app/services/github/client.rb
+++ b/app/services/github/client.rb
@@ -99,6 +99,10 @@ module Github
       )
     end
 
+    def delete_repository_webhook(repo_full_name, hook_id)
+      client.remove_hook(repo_full_name, hook_id)
+    end
+
     private
 
     attr_reader :client

--- a/app/services/github/webhook_provisioner.rb
+++ b/app/services/github/webhook_provisioner.rb
@@ -7,6 +7,10 @@ module Github
       new(account: account, webhook_url: webhook_url).ensure_for_links(Array(links))
     end
 
+    def self.remove_for_repositories(account:, repositories:, webhook_url:)
+      new(account: account, webhook_url: webhook_url).remove_for_repositories(Array(repositories))
+    end
+
     def initialize(account:, webhook_url:, client: Github::Client.new(account))
       @client = client
       @webhook_url = webhook_url
@@ -15,6 +19,14 @@ module Github
     def ensure_for_links(links)
       links.each do |link|
         ensure_webhook(link)
+      end
+    end
+
+    def remove_for_repositories(repositories)
+      repositories.each do |repository_full_name|
+        next if GithubRepositoryLink.where(repository_full_name: repository_full_name).exists?
+
+        remove_webhook(repository_full_name)
       end
     end
 
@@ -46,6 +58,17 @@ module Github
     rescue Octokit::Error => e
       Rails.logger.warn(
         "GitHub webhook provisioning failed for #{repository_full_name}: #{e.message}"
+      )
+    end
+
+    def remove_webhook(repository_full_name)
+      hook = find_existing_hook(repository_full_name)
+      return unless hook
+
+      client.delete_repository_webhook(repository_full_name, hook.id)
+    rescue Octokit::Error => e
+      Rails.logger.warn(
+        "GitHub webhook removal failed for #{repository_full_name}: #{e.message}"
       )
     end
 


### PR DESCRIPTION
## Summary
- delete GitHub repository links and remove associated webhooks when a creative disconnects its GitHub integration
- extend the webhook provisioner/client to support webhook deletion and add coverage for the new behavior
- update controller tests and helper fakes to verify webhook cleanup and bump the with_advisory_lock dependency to the latest patch version

## Testing
- ./bin/rubocop -a
- rails test
- rails test:system (fails: Unable to obtain chromedriver in the container)

## Original User's Requirements
- github PR 연동 팝업에서 "연동삭제" 시 webhook 도 같이 자동 삭제해야 한다

------
https://chatgpt.com/codex/tasks/task_e_68db7ec79ee083268df290808d880ca4