### PR TITLE
Allow deleting individual GitHub repository links

### DIFF
--- a/app/controllers/creatives/github_integrations_controller.rb
+++ b/app/controllers/creatives/github_integrations_controller.rb
@@ -95,7 +95,7 @@ module Creatives
         end
 
         GithubRepositoryLink.transaction do
-          removed_repositories = [link.repository_full_name]
+          removed_repositories = [ link.repository_full_name ]
           link.destroy!
         end
       else

--- a/app/views/creatives/_github_integration_modal.html.erb
+++ b/app/views/creatives/_github_integration_modal.html.erb
@@ -8,6 +8,7 @@
      data-delete-confirm="<%= t('creatives.index.github_integration_delete_confirm', default: 'Do you want to remove the Github integration?') %>"
      data-delete-success="<%= t('creatives.index.github_integration_delete_success', default: 'Github integration removed successfully.') %>"
      data-delete-error="<%= t('creatives.index.github_integration_delete_error', default: 'Failed to remove the Github integration.') %>"
+     data-delete-button-label="<%= t('creatives.index.github_integration_delete_button', default: 'Remove integration') %>"
      style="display:none;position:fixed;top:0;left:0;width:100vw;height:100vh;z-index:1000;align-items:center;justify-content:center;">
   <div class="popup-box" style="min-width:360px;max-width:90vw;">
     <button type="button" id="close-github-modal" class="popup-close-btn">&times;</button>
@@ -22,11 +23,9 @@
       <button type="button" id="github-login-btn" class="btn btn-primary" data-window-width="620" data-window-height="720">
         <%= t('creatives.index.github_login_button', default: 'Sign in with Github') %>
       </button>
-      <div id="github-existing-connections" class="github-existing-connections" style="display:none;">
-        <ul id="github-existing-repo-list" class="github-modal-list"></ul>
-        <button type="button" id="github-delete-btn" class="btn btn-danger" style="display:none;">
-          <%= t('creatives.index.github_integration_delete_button', default: 'Remove integration') %>
-        </button>
+      <div id="github-existing-connections" style="display:none;margin-top:1.25em;">
+        <p style="margin-bottom:0.5em;"><%= t('creatives.index.github_integration_existing_intro', default: '이미 연동된 Repository 목록입니다:') %></p>
+        <ul id="github-existing-repo-list" style="padding-left:1.2em;margin-bottom:0.75em;color:#333;"></ul>
       </div>
     </div>
 

--- a/app/views/creatives/_github_integration_modal.html.erb
+++ b/app/views/creatives/_github_integration_modal.html.erb
@@ -26,6 +26,9 @@
       <div id="github-existing-connections" style="display:none;margin-top:1.25em;">
         <p style="margin-bottom:0.5em;"><%= t('creatives.index.github_integration_existing_intro', default: '이미 연동된 Repository 목록입니다:') %></p>
         <ul id="github-existing-repo-list" style="padding-left:1.2em;margin-bottom:0.75em;color:#333;"></ul>
+        <button type="button" id="github-delete-btn" class="btn btn-danger" style="display:none;">
+          <%= t('creatives.index.github_integration_delete_button', default: '연동 삭제') %>
+        </button>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- allow the GitHub integration modal to show a delete button for each existing repository link and handle removal via AJAX
- accept an optional repository parameter on the destroy endpoint so individual links can be deleted and return the updated state
- add controller coverage for per-repository deletion

## Testing
- `./bin/rubocop -a`
- `DISABLE_SPRING=1 bundle exec rails test`
- `DISABLE_SPRING=1 bundle exec rails test:system` *(fails: Selenium cannot download Chrome/driver in this environment)*

## Original User's Requirements
- github PR 연동 팝업에서 이미 연동된 repository 리스트에서 "연동 삭제" 는 개별 repository 마다 할 수 있어야 한다.


------
https://chatgpt.com/codex/tasks/task_e_68db7f171bfc8326b726958e9f95c076