### PR TITLE
Allow approvers to edit GitHub PR analysis comments

### DIFF
--- a/app/javascript/controllers/comment_controller.js
+++ b/app/javascript/controllers/comment_controller.js
@@ -19,8 +19,16 @@ export default class extends Controller {
     // Show actions for the comment owner
     const currentUserId = document.body.dataset.currentUserId;
     const commentAuthorId = this.element.dataset.userId;
+    const commentApproverId = this.element.dataset.approverId;
 
-    if (currentUserId && commentAuthorId && currentUserId === commentAuthorId) {
+    const canManageComment = () => {
+      if (!currentUserId) return false;
+      if (commentAuthorId && currentUserId === commentAuthorId) return true;
+      if (commentApproverId && currentUserId === commentApproverId) return true;
+      return false;
+    };
+
+    if (canManageComment()) {
       this.ownerButtonTargets.forEach((button) => {
         button.classList.remove('comment-owner-only')
       })

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,4 +1,4 @@
-<div class="comment-item <%= 'last-read' if defined?(last_read_comment_id) && last_read_comment_id && comment.id == last_read_comment_id %>" id="<%= dom_id(comment) %>" data-controller="comment" data-user-id="<%= comment.user&.id %>">
+<div class="comment-item <%= 'last-read' if defined?(last_read_comment_id) && last_read_comment_id && comment.id == last_read_comment_id %>" id="<%= dom_id(comment) %>" data-controller="comment" data-user-id="<%= comment.user&.id %>" data-approver-id="<%= comment.approver_id %>">
   <div>
     <%= render AvatarComponent.new(user: comment.user, size: 20, classes: 'avatar comment-avatar') %>
     <% system_prefix = "#{t('comments.system_user')}:" %>


### PR DESCRIPTION
## Summary
- expose the comment approver id to the Stimulus controller so approvers can use owner-only actions
- allow approvers to see the edit controls on GitHub PR analysis chat messages by including the approver id in the comment markup

## Testing
- ./bin/rubocop -a *(fails: missing gems in the execution environment)*
- bin/rails test *(fails: missing gems in the execution environment)*
- bin/rails test:system *(fails: missing gems in the execution environment)*

## Original User's Requirements
- github PR 분석 결과로 추가된 채팅 메세지에 승인자 에게 "수정" 버튼이 표시되어야 하는데, 표시되지 않는다. 수정해줘.


------
https://chatgpt.com/codex/tasks/task_e_68db93cd14908326a1e2b0159ab12df7