### PR TITLE
Use theme text color for GitHub repository lists

### DIFF
--- a/app/views/creatives/_github_integration_modal.html.erb
+++ b/app/views/creatives/_github_integration_modal.html.erb
@@ -25,7 +25,7 @@
       </button>
       <div id="github-existing-connections" style="display:none;margin-top:1.25em;">
         <p style="margin-bottom:0.5em;"><%= t('creatives.index.github_integration_existing_intro', default: '이미 연동된 Repository 목록입니다:') %></p>
-        <ul id="github-existing-repo-list" style="padding-left:1.2em;margin-bottom:0.75em;color:#333;"></ul>
+        <ul id="github-existing-repo-list" style="padding-left:1.2em;margin-bottom:0.75em;color:var(--color-text);"></ul>
         <button type="button" id="github-delete-btn" class="btn btn-danger" style="display:none;">
           <%= t('creatives.index.github_integration_delete_button', default: '연동 삭제') %>
         </button>
@@ -45,7 +45,7 @@
     <div class="github-wizard-step" id="github-step-summary" style="display:none;">
       <p class="github-modal-subtext"><%= t('creatives.index.github_integration_summary', default: 'The following repositories will be linked to this Creative:') %></p>
       <p id="github-webhook-instructions" class="github-modal-subtext" style="display:none;margin-bottom:0.5em;"><%= t('creatives.index.github_integration_webhook_instructions', default: 'Configure each repository with the webhook details below.') %></p>
-      <ul id="github-selected-repos" style="padding-left:1.2em;"></ul>
+      <ul id="github-selected-repos" style="padding-left:1.2em;color:var(--color-text);"></ul>
       <p id="github-summary-empty" class="github-modal-empty" style="display:none;"><%= t('creatives.index.github_integration_summary_empty', default: 'No repositories selected.') %></p>
     </div>
 


### PR DESCRIPTION
## Summary
- ensure existing and selected repository lists in the GitHub integration modal read theme text color variables so they stay legible in dark mode

## Testing
- ./bin/rubocop -a *(fails: missing gems in the environment)*
- bundle exec rails test *(fails: bundler could not find the `rails` executable; missing gems in the environment)*
- bundle exec rails test:system *(fails: bundler could not find the `rails` executable; missing gems in the environment)*

## Original User's Requirements
- Github 연동된 repository text 가 다크모드에서 어둡게 보여. 개선해줘.


------
https://chatgpt.com/codex/tasks/task_e_68db9986146883269a8e56409d8f7923