### PR TITLE
Add mobile timer to slide view

### DIFF
--- a/app/assets/stylesheets/slide_view.css
+++ b/app/assets/stylesheets/slide_view.css
@@ -42,6 +42,10 @@
   display: none;
 }
 
+#slide-timer {
+  display: none;
+}
+
 @media (max-width: 768px) {
   #slide-view {
     height: 80vh;
@@ -65,5 +69,11 @@
     padding: 0.5rem;
     text-align: center;
     white-space: pre-wrap;
+  }
+
+  #slide-timer {
+    display: block;
+    margin-top: 0.5rem;
+    font-variant-numeric: tabular-nums;
   }
 }

--- a/app/javascript/slide_view.js
+++ b/app/javascript/slide_view.js
@@ -10,9 +10,12 @@ document.addEventListener('DOMContentLoaded', function() {
   var counterEl = document.getElementById('slide-counter');
   var linkEl = document.getElementById('slide-goto');
   var captionEl = document.getElementById('slide-caption');
+  var timerEl = document.getElementById('slide-timer');
   var startX = null;
   var slideSubscription = null;
   var lastScrollLeft = 0;
+  var timerStart = null;
+  var timerInterval = null;
 
   if (index > 0) {
     load(index, false);
@@ -70,6 +73,26 @@ document.addEventListener('DOMContentLoaded', function() {
     }
   }
 
+  function updateTimer() {
+    if (!timerEl || timerStart === null) return;
+    var elapsedSeconds = Math.floor((Date.now() - timerStart) / 1000);
+    var minutes = Math.floor(elapsedSeconds / 60);
+    var seconds = elapsedSeconds % 60;
+    var formattedMinutes = minutes.toString().padStart(2, '0');
+    var formattedSeconds = seconds.toString().padStart(2, '0');
+    timerEl.textContent = formattedMinutes + ':' + formattedSeconds;
+  }
+
+  function startTimer() {
+    if (!timerEl) return;
+    timerStart = Date.now();
+    updateTimer();
+    if (timerInterval) {
+      clearInterval(timerInterval);
+    }
+    timerInterval = setInterval(updateTimer, 1000);
+  }
+
   if (window.ActionCable && rootId) {
     slideSubscription = ActionCable.createConsumer().subscriptions.create(
       { channel: 'SlideViewChannel', root_id: rootId },
@@ -110,6 +133,8 @@ document.addEventListener('DOMContentLoaded', function() {
   if (linkEl) {
     linkEl.href = '/creatives/' + ids[index];
   }
+
+  startTimer();
 
   window.addEventListener('keydown', function(e) {
     var key = e.key || e.keyCode;

--- a/app/views/creatives/slide_view.html.erb
+++ b/app/views/creatives/slide_view.html.erb
@@ -16,4 +16,5 @@
 </div>
 <div id="slide-swipe">
   <div id="slide-caption"><%= initial_prompt %></div>
+  <div id="slide-timer" aria-live="polite">00:00</div>
 </div>


### PR DESCRIPTION
## Summary
- add a slide timer element to the mobile slide view layout
- show and style the timer only on small screens and keep desktop unaffected
- start and update the timer in the slide view JavaScript when the view loads

## Testing
- ./bin/rubocop -a
- bundle exec rails test
- bundle exec rails test:system *(fails: unable to obtain chromedriver because Selenium Manager cannot download Chrome binaries in the CI environment)*

## Original User's Requirements
- 슬라이드 뷰 에서 모바일인 경우 아래에 timer 를 표시한다. "00:00" 으로 분/초 단위로 표시한다. 슬라이드 뷰에 들어가면 시작된다.


------
https://chatgpt.com/codex/tasks/task_e_68dbc15754008326a85e9202c1db374f