### PR TITLE
Handle table conversion for markdown import/export

### DIFF
--- a/app/helpers/creatives_helper.rb
+++ b/app/helpers/creatives_helper.rb
@@ -191,7 +191,7 @@ module CreativesHelper
     return "" if creatives.blank?
     md = ""
     creatives.each do |creative|
-      desc = creative.effective_description(nil, false).to_s
+      desc = creative.effective_description(nil, false).to_html
       # Append progress as a percentage if available (progress is 0.0..1.0)
       if with_progress && creative.respond_to?(:progress) && !creative.progress.nil?
         pct = (creative.progress.to_f * 100).round
@@ -201,7 +201,16 @@ module CreativesHelper
       markdown_content = html_links_to_markdown(raw_html)
       cleaned_markdown = markdown_content.strip
       rendered_table_block = false
-      if level <= 4 && markdown_table_block?(cleaned_markdown)
+
+      # Extract table content from within divs if present
+      table_match = cleaned_markdown.match(/^<div[^>]*>\s*<div[^>]*>\s*(\|.*?\|(?:\n\|.*?\|)*)\s*<\/div>\s*<\/div>$/m)
+      if level <= 4 && table_match
+        table_content = table_match[1].strip
+        if markdown_table_block?(table_content)
+          md += "#{table_content}\n\n"
+          rendered_table_block = true
+        end
+      elsif level <= 4 && markdown_table_block?(cleaned_markdown)
         md += "#{cleaned_markdown}\n\n"
         rendered_table_block = true
       elsif level <= 4

--- a/app/helpers/creatives_helper.rb
+++ b/app/helpers/creatives_helper.rb
@@ -346,7 +346,7 @@ module CreativesHelper
     header_line = "| #{headers.map(&:strip).join(' | ')} |"
     alignment_line = "| #{alignment_cells.join(' | ')} |"
 
-    ([header_line, alignment_line] + body_lines).join("\n")
+    ([ header_line, alignment_line ] + body_lines).join("\n")
   end
 
   def alignment_from_html_cell(cell)

--- a/app/helpers/creatives_helper.rb
+++ b/app/helpers/creatives_helper.rb
@@ -326,7 +326,7 @@ module CreativesHelper
     return "" unless header_row
 
     header_cells = header_row.css("th,td")
-    headers = header_cells.map { |cell| html_links_to_markdown(cell.inner_html).strip }
+    headers = header_cells.map { |cell| escape_markdown_table_cell(html_links_to_markdown(cell.inner_html).strip) }
 
     alignments = header_cells.map { |cell| alignment_from_html_cell(cell) }
 
@@ -337,7 +337,7 @@ module CreativesHelper
     end
 
     body_lines = body_rows.map do |row|
-      cells = row.css("th,td").map { |cell| html_links_to_markdown(cell.inner_html).strip }
+      cells = row.css("th,td").map { |cell| escape_markdown_table_cell(html_links_to_markdown(cell.inner_html).strip) }
       normalized = normalize_row_cells(cells, headers.length)
       "| #{normalized.join(' | ')} |"
     end
@@ -347,6 +347,10 @@ module CreativesHelper
     alignment_line = "| #{alignment_cells.join(' | ')} |"
 
     ([ header_line, alignment_line ] + body_lines).join("\n")
+  end
+
+  def escape_markdown_table_cell(text)
+    text.to_s.gsub(/(?<!\\)\|/, '\\|')
   end
 
   def alignment_from_html_cell(cell)

--- a/app/services/markdown_importer.rb
+++ b/app/services/markdown_importer.rb
@@ -27,7 +27,13 @@ class MarkdownImporter
     stack = [ [ 0, root ] ]
     while i < lines.size
       line = lines[i]
-      if line =~ /^(#+)\s+(.*)$/
+      if (table_data = parse_markdown_table(lines, i))
+        table_html = build_table_html(table_data, image_refs)
+        new_parent = stack.any? ? stack.last[1] : root
+        c = Creative.create(user: user, parent: new_parent, description: table_html)
+        created << c
+        i = table_data[:next_index]
+      elsif line =~ /^(#+)\s+(.*)$/
         level = $1.length
         desc = ApplicationController.helpers.markdown_links_to_html($2.strip, image_refs)
         stack.pop while stack.any? && stack.last[0] >= level
@@ -57,5 +63,126 @@ class MarkdownImporter
       end
     end
     created
+  end
+
+  def self.parse_markdown_table(lines, index)
+    return nil if index >= lines.length
+    header_line = lines[index]
+    return nil unless table_row?(header_line)
+
+    align_index = index + 1
+    return nil if align_index >= lines.length
+    alignment_line = lines[align_index]
+    return nil unless alignment_row?(alignment_line)
+
+    header_cells = split_markdown_table_row(header_line)
+    alignments = parse_alignment_row(alignment_line, header_cells.length)
+
+    rows = []
+    data_index = align_index + 1
+    while data_index < lines.length && table_row?(lines[data_index])
+      rows << split_markdown_table_row(lines[data_index])
+      data_index += 1
+    end
+
+    {
+      header: header_cells,
+      alignments: alignments,
+      rows: rows,
+      next_index: data_index
+    }
+  end
+
+  def self.table_row?(line)
+    return false if line.nil?
+    stripped = line.strip
+    return false if stripped.empty?
+    stripped.include?("|") && split_markdown_table_row(line).any?
+  end
+
+  def self.alignment_row?(line)
+    return false unless table_row?(line)
+    split_markdown_table_row(line).all? do |cell|
+      cell.strip =~ /^:?-{3,}:?$/
+    end
+  end
+
+  def self.split_markdown_table_row(line)
+    body = line.strip
+    body = body.sub(/^\|/, "").sub(/\|\s*$/, "")
+    return [] if body.strip.empty?
+    body.split(/(?<!\\)\|/).map { |cell| cell.gsub(/\\\|/, "|").strip }
+  end
+
+  def self.parse_alignment_row(line, expected_count)
+    cells = split_markdown_table_row(line)
+    cells = cells.first(expected_count)
+    cells.fill("", cells.length...expected_count)
+    cells.map do |cell|
+      trimmed = cell.strip
+      left = trimmed.start_with?(":")
+      right = trimmed.end_with?(":")
+      if left && right
+        :center
+      elsif right
+        :right
+      elsif left
+        :left
+      else
+        nil
+      end
+    end
+  end
+
+  def self.build_table_html(table_data, image_refs)
+    helper = ApplicationController.helpers
+    header_cells = table_data[:header]
+    alignments = table_data[:alignments]
+    rows = table_data[:rows]
+
+    header_html = header_cells.map { |cell| helper.markdown_links_to_html(cell, image_refs) }
+    max_row_length = rows.map(&:length).max || 0
+    column_count = [header_html.length, max_row_length].max
+
+    row_html = rows.map do |row|
+      normalized = row.first(column_count)
+      normalized.fill("", normalized.length...column_count)
+      normalized.map { |cell| helper.markdown_links_to_html(cell, image_refs) }
+    end
+
+    column_count = [column_count, alignments.length].max
+    alignments = alignments.first(column_count)
+    alignments.fill(nil, alignments.length...column_count)
+
+    build_html_table(header_html, row_html, alignments)
+  end
+
+  def self.build_html_table(header_html, rows_html, alignments)
+    table = +"<table>\n"
+    table << "  <thead>\n"
+    table << "    <tr>"
+    header_html.each_with_index do |cell, idx|
+      table << table_cell_tag("th", cell, alignments[idx])
+    end
+    table << "</tr>\n"
+    table << "  </thead>\n"
+    unless rows_html.empty?
+      table << "  <tbody>\n"
+      rows_html.each do |row|
+        table << "    <tr>"
+        row.each_with_index do |cell, idx|
+          table << table_cell_tag("td", cell, alignments[idx])
+        end
+        table << "</tr>\n"
+      end
+      table << "  </tbody>\n"
+    end
+    table << "</table>"
+    table
+  end
+
+  def self.table_cell_tag(tag_name, content, alignment)
+    align_attr = alignment ? " style=\"text-align: #{alignment};\"" : ""
+    "<#{tag_name}#{align_attr}>#{content}</#{tag_name}>"
   end
 end

--- a/app/services/markdown_importer.rb
+++ b/app/services/markdown_importer.rb
@@ -142,7 +142,7 @@ class MarkdownImporter
 
     header_html = header_cells.map { |cell| helper.markdown_links_to_html(cell, image_refs) }
     max_row_length = rows.map(&:length).max || 0
-    column_count = [header_html.length, max_row_length].max
+    column_count = [ header_html.length, max_row_length ].max
 
     row_html = rows.map do |row|
       normalized = row.first(column_count)
@@ -150,7 +150,7 @@ class MarkdownImporter
       normalized.map { |cell| helper.markdown_links_to_html(cell, image_refs) }
     end
 
-    column_count = [column_count, alignments.length].max
+    column_count = [ column_count, alignments.length ].max
     alignments = alignments.first(column_count)
     alignments.fill(nil, alignments.length...column_count)
 

--- a/test/helpers/creatives_helper_test.rb
+++ b/test/helpers/creatives_helper_test.rb
@@ -103,7 +103,7 @@ class CreativesHelperTest < ActionView::TestCase
     expected = <<~MD.strip
       | Expression | Description |
       | --- | --- |
-      | A \| B | Either A or B |
+      | A \\| B | Either A or B |
     MD
     assert_equal expected, html_links_to_markdown(html.strip)
   end
@@ -132,7 +132,7 @@ class CreativesHelperTest < ActionView::TestCase
     HTML
     creative = Creative.create!(user: user, description: description)
 
-    markdown = render_creative_tree_markdown([creative])
+    markdown = render_creative_tree_markdown([ creative ])
 
     expected = <<~MD
       | Name | Count |

--- a/test/helpers/creatives_helper_test.rb
+++ b/test/helpers/creatives_helper_test.rb
@@ -83,6 +83,31 @@ class CreativesHelperTest < ActionView::TestCase
     assert_equal expected, html_links_to_markdown(html.strip)
   end
 
+  test "html table escapes pipe characters in cells" do
+    html = <<~HTML
+      <table>
+        <thead>
+          <tr>
+            <th>Expression</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>A | B</td>
+            <td>Either A or B</td>
+          </tr>
+        </tbody>
+      </table>
+    HTML
+    expected = <<~MD.strip
+      | Expression | Description |
+      | --- | --- |
+      | A \| B | Either A or B |
+    MD
+    assert_equal expected, html_links_to_markdown(html.strip)
+  end
+
   test "expanded_from_expanded_state defaults to collapsed" do
     assert_not expanded_from_expanded_state(1, {})
   end

--- a/test/helpers/creatives_helper_test.rb
+++ b/test/helpers/creatives_helper_test.rb
@@ -108,6 +108,42 @@ class CreativesHelperTest < ActionView::TestCase
     assert_equal expected, html_links_to_markdown(html.strip)
   end
 
+  test "render_creative_tree_markdown exports tables without heading prefix" do
+    user = users(:one)
+    description = <<~HTML
+      <div class="trix-content">
+        <div>
+          <table>
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Count</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Alice</td>
+                <td>3</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    HTML
+    creative = Creative.create!(user: user, description: description)
+
+    markdown = render_creative_tree_markdown([creative])
+
+    expected = <<~MD
+      | Name | Count |
+      | --- | --- |
+      | Alice | 3 |
+    MD
+    expected << "\n"
+
+    assert_equal expected, markdown
+  end
+
   test "expanded_from_expanded_state defaults to collapsed" do
     assert_not expanded_from_expanded_state(1, {})
   end

--- a/test/helpers/creatives_helper_test.rb
+++ b/test/helpers/creatives_helper_test.rb
@@ -53,6 +53,36 @@ class CreativesHelperTest < ActionView::TestCase
     assert_equal "Look ![](data:image/png;base64,aGk=)", back
   end
 
+  test "html table converts to markdown" do
+    html = <<~HTML
+      <table>
+        <thead>
+          <tr>
+            <th style="text-align: left;">Name</th>
+            <th style="text-align: center;">Count</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Alice</td>
+            <td>3</td>
+          </tr>
+          <tr>
+            <td>Bob</td>
+            <td>5</td>
+          </tr>
+        </tbody>
+      </table>
+    HTML
+    expected = <<~MD.strip
+      | Name | Count |
+      | :--- | :---: |
+      | Alice | 3 |
+      | Bob | 5 |
+    MD
+    assert_equal expected, html_links_to_markdown(html.strip)
+  end
+
   test "expanded_from_expanded_state defaults to collapsed" do
     assert_not expanded_from_expanded_state(1, {})
   end

--- a/test/services/markdown_importer_test.rb
+++ b/test/services/markdown_importer_test.rb
@@ -20,4 +20,29 @@ class MarkdownImporterTest < ActiveSupport::TestCase
     assert_includes html, "<td>Alice</td>"
     assert_includes html, "<td>5</td>"
   end
+
+  test "does not convert table syntax inside fenced code blocks" do
+    user = users(:one)
+    parent = Creative.create!(user: user, description: "Parent")
+    markdown = <<~MD
+      ```
+      | key | value |
+      | --- | ----- |
+      ```
+
+      | Name | Count |
+      | ---- | ----- |
+      | Alice | 3 |
+    MD
+
+    created = MarkdownImporter.import(markdown, parent: parent, user: user)
+
+    html_fragments = created.map { |creative| creative.reload.rich_text_description.body.to_html }
+
+    code_block_html = html_fragments.find { |html| html.include?("| key | value |") }
+    assert_not_nil code_block_html, "Expected code block content to be preserved"
+
+    table_htmls = html_fragments.select { |html| html.include?("<table>") }
+    assert_equal 1, table_htmls.size, "Only actual tables should be converted to HTML"
+  end
 end

--- a/test/services/markdown_importer_test.rb
+++ b/test/services/markdown_importer_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+class MarkdownImporterTest < ActiveSupport::TestCase
+  test "imports markdown tables as html" do
+    user = users(:one)
+    parent = Creative.create!(user: user, description: "Parent")
+    markdown = <<~MD
+      | Name | Count |
+      | ---- | ----- |
+      | Alice | 3 |
+      | Bob | 5 |
+    MD
+
+    created = MarkdownImporter.import(markdown, parent: parent, user: user)
+    table_creative = created.last
+    table_creative.reload
+
+    html = table_creative.rich_text_description.body.to_html
+    assert_includes html, "<table>"
+    assert_includes html, "<td>Alice</td>"
+    assert_includes html, "<td>5</td>"
+  end
+end


### PR DESCRIPTION
## Summary
- convert markdown tables to HTML during import so they render correctly in creatives
- translate HTML tables back into markdown during export using Nokogiri parsing
- add regression tests covering table import and export behaviour

## Testing
- ./bin/rubocop -a *(fails: missing gem dependencies in environment)*
- bundle exec rails test *(fails: rails executable unavailable without bundle install)*
- bundle exec rails test:system *(fails: rails executable unavailable without bundle install)*

## Original User's Requirements
- import from markdown file 에서 table 을 변환하여 제대로 표시하도록 처리한다.
- 반대로 export 할때 table 도 변환되어 보내지도록 한다.


------
https://chatgpt.com/codex/tasks/task_e_68dbc1b678088326bfb983b7b24b3ad0