### PR TITLE
Prevent linked creative cycles

### DIFF
--- a/app/services/creatives/reorderer.rb
+++ b/app/services/creatives/reorderer.rb
@@ -63,13 +63,14 @@ module Creatives
       new_parent = direction == "child" ? target : target.parent
 
       if new_parent.present?
-        if new_parent.self_and_ancestors.where(id: origin.id).exists?
-          raise Error, "Invalid creatives"
-        end
+        origin_descendant_ids = origin.self_and_descendants.pluck(:id)
 
-        parent_origin = new_parent.effective_origin
-        if parent_origin.self_and_ancestors.where(id: origin.id).exists?
-          raise Error, "Invalid creatives"
+        new_parent.self_and_ancestors.each do |ancestor|
+          ancestor_origin_id = ancestor.origin_id.presence || ancestor.id
+
+          if origin_descendant_ids.include?(ancestor_origin_id)
+            raise Error, "Invalid creatives"
+          end
         end
       end
 

--- a/app/services/creatives/reorderer.rb
+++ b/app/services/creatives/reorderer.rb
@@ -62,6 +62,17 @@ module Creatives
       origin = dragged.effective_origin
       new_parent = direction == "child" ? target : target.parent
 
+      if new_parent.present?
+        if new_parent.self_and_ancestors.where(id: origin.id).exists?
+          raise Error, "Invalid creatives"
+        end
+
+        parent_origin = new_parent.effective_origin
+        if parent_origin.self_and_ancestors.where(id: origin.id).exists?
+          raise Error, "Invalid creatives"
+        end
+      end
+
       new_creative = nil
       Creative.transaction do
         new_creative = Creative.create!(

--- a/test/integration/creatives_link_drop_test.rb
+++ b/test/integration/creatives_link_drop_test.rb
@@ -53,39 +53,42 @@ class CreativesLinkDropTest < ActionDispatch::IntegrationTest
   end
 
   test "returns 422 when linking would create a cycle under descendant" do
-    post link_drop_creatives_path, params: {
-      dragged_id: @root.id,
-      target_id: @target.id,
-      direction: "child"
-    }, as: :json
+    assert_no_difference -> { Creative.count } do
+      post link_drop_creatives_path, params: {
+        dragged_id: @root.id,
+        target_id: @target.id,
+        direction: "child"
+      }, as: :json
 
-    assert_response :unprocessable_entity
-    assert_equal 4, Creative.count
+      assert_response :unprocessable_entity
+    end
   end
 
   test "returns 422 when linking near descendant would create a cycle" do
     grandchild = Creative.create!(user: @user, parent: @target, description: "Grandchild", sequence: 0)
 
-    post link_drop_creatives_path, params: {
-      dragged_id: @root.id,
-      target_id: grandchild.id,
-      direction: "down"
-    }, as: :json
+    assert_no_difference -> { Creative.count } do
+      post link_drop_creatives_path, params: {
+        dragged_id: @root.id,
+        target_id: grandchild.id,
+        direction: "down"
+      }, as: :json
 
-    assert_response :unprocessable_entity
-    assert_equal 5, Creative.count
+      assert_response :unprocessable_entity
+    end
   end
 
   test "returns 422 when linking to descendant's linked creative" do
     linked_target = Creative.create!(origin_id: @target.id, user: @user, description: "Linked target")
 
-    post link_drop_creatives_path, params: {
-      dragged_id: @root.id,
-      target_id: linked_target.id,
-      direction: "child"
-    }, as: :json
+    assert_no_difference -> { Creative.count } do
+      post link_drop_creatives_path, params: {
+        dragged_id: @root.id,
+        target_id: linked_target.id,
+        direction: "child"
+      }, as: :json
 
-    assert_response :unprocessable_entity
-    assert_equal 5, Creative.count
+      assert_response :unprocessable_entity
+    end
   end
 end

--- a/test/integration/creatives_link_drop_test.rb
+++ b/test/integration/creatives_link_drop_test.rb
@@ -51,4 +51,41 @@ class CreativesLinkDropTest < ActionDispatch::IntegrationTest
     post link_drop_creatives_path, params: { dragged_id: 0, target_id: 0, direction: "up" }, as: :json
     assert_response :unprocessable_entity
   end
+
+  test "returns 422 when linking would create a cycle under descendant" do
+    post link_drop_creatives_path, params: {
+      dragged_id: @root.id,
+      target_id: @target.id,
+      direction: "child"
+    }, as: :json
+
+    assert_response :unprocessable_entity
+    assert_equal 4, Creative.count
+  end
+
+  test "returns 422 when linking near descendant would create a cycle" do
+    grandchild = Creative.create!(user: @user, parent: @target, description: "Grandchild", sequence: 0)
+
+    post link_drop_creatives_path, params: {
+      dragged_id: @root.id,
+      target_id: grandchild.id,
+      direction: "down"
+    }, as: :json
+
+    assert_response :unprocessable_entity
+    assert_equal 5, Creative.count
+  end
+
+  test "returns 422 when linking to descendant's linked creative" do
+    linked_target = Creative.create!(origin_id: @target.id, user: @user, description: "Linked target")
+
+    post link_drop_creatives_path, params: {
+      dragged_id: @root.id,
+      target_id: linked_target.id,
+      direction: "child"
+    }, as: :json
+
+    assert_response :unprocessable_entity
+    assert_equal 5, Creative.count
+  end
 end


### PR DESCRIPTION
## Summary
- prevent link drops that would place a linked creative under its origin or origin descendants
- add integration coverage to ensure cyclic link attempts return an error response

## Testing
- `./bin/rubocop -a` *(fails: missing gems in container environment)*
- `bundle exec rails test` *(fails: bundler could not find the rails executable without installing gems)*
- `bundle exec rails test:system` *(fails: bundler could not find the rails executable without installing gems)*

## Original User's Requirements
- Linked Creative 생성시 A=>B=>A 또는  A=>B=>C=>A 형태의 사이클링 되면 오류를 만들어서 생성되지 않게 해줘.


------
https://chatgpt.com/codex/tasks/task_e_68dbc774971c8326b59c203b3291407e