### PR TITLE
Add comment popup search action

### DIFF
--- a/app/views/comments/_comments_popup.html.erb
+++ b/app/views/comments/_comments_popup.html.erb
@@ -9,7 +9,8 @@
      data-approve-success-text="<%= t('comments.approve_success') %>"
      data-approve-error-text="<%= t('comments.approve_error') %>"
      data-action-update-success-text="<%= t('comments.action_update_success') %>"
-     data-action-update-error-text="<%= t('comments.action_update_error') %>">
+     data-action-update-error-text="<%= t('comments.action_update_error') %>"
+     data-search-empty-text="<%= t('comments.search_empty_prompt') %>">
   <div class="resize-handle resize-handle-left"></div>
   <div class="resize-handle resize-handle-right"></div>
   <button id="close-comments-btn" class="popup-close-btn">&times;</button>
@@ -23,6 +24,7 @@
     <textarea name="comment[content]" rows="2" required enterkeyhint="send"></textarea>
     <label><input type="checkbox" id="comment-private" name="comment[private]" /> <%= t('comments.private') %></label>
     <button class="creative-action-btn" type="submit"><%= svg_tag 'send.svg', class: 'send-icon' %></button>
+    <button class="creative-action-btn" id="search-comments-btn" type="button"><%= t('comments.search_button') %></button>
     <button class="creative-action-btn" id="cancel-edit-btn" type="button" style="display:none;"><%= t('app.cancel') %></button>
   </form>
 </div>

--- a/config/locales/comments.en.yml
+++ b/config/locales/comments.en.yml
@@ -42,3 +42,5 @@ en:
     convert_system_message: "System: Comment was converted to the [%{title}](%{url}) creative."
     convert_system_message_default_title: "Untitled"
     system_user: "System"
+    search_button: "Search"
+    search_empty_prompt: "Please enter a search term in the chat message field."

--- a/config/locales/comments.ko.yml
+++ b/config/locales/comments.ko.yml
@@ -42,3 +42,5 @@ ko:
     convert_system_message: "System: 메세지가 [%{title}](%{url}) 크리에이티브로 변환되었습니다"
     convert_system_message_default_title: "제목 없음"
     system_user: "System"
+    search_button: "검색"
+    search_empty_prompt: "검색어 를 채팅 메세지 입력폼에 입력하시오"


### PR DESCRIPTION
## Summary
- add a search button to the comments popup form and expose the empty search prompt via data attributes
- implement client-side filtering for popup comments and surface manual typing indicator guidance when no query is provided
- localize the search button label and empty search prompt in both English and Korean

## Testing
- ./bin/rubocop -a
- bundle exec rails test *(fails: jsbundling-rails requires npm in the container)*
- bundle exec rails test:system *(fails: jsbundling-rails requires npm in the container)*

## Original User's Requirements
- 채팅 팝업에서 "전송" 버튼 옆에 "검색" 버튼을 두고 검색을 누르면 채팅 메세지에 있는 내용으로 검색해서 현재 채팅메세지 리스트를 업데이트해줘. 만약 채팅 메세지 입력폼에 검색어를 입력하지 않으면 "검색어 를 채팅 메세지 입력폼에 입력하시오"를 typing indicator 에 표시해줘.


------
https://chatgpt.com/codex/tasks/task_e_68dbc97c16908326a52e758301ef3c1a