### PR TITLE
Fix unconvert to move entire creative tree

### DIFF
--- a/app/controllers/creatives_controller.rb
+++ b/app/controllers/creatives_controller.rb
@@ -284,12 +284,13 @@ class CreativesController < ApplicationController
       render json: { error: t("creatives.index.unconvert_no_children") }, status: :unprocessable_entity and return
     end
 
-    markdown = helpers.render_creative_tree_markdown(children)
+    markdown = helpers.render_creative_tree_markdown([ base_creative ])
     comment = nil
 
     ActiveRecord::Base.transaction do
       comment = parent.effective_origin.comments.create!(content: markdown, user: Current.user)
-      children.each(&:destroy!)
+      base_creative.descendants.each(&:destroy!)
+      base_creative.destroy!
     end
 
     render json: { comment_id: comment.id }, status: :created

--- a/app/controllers/creatives_controller.rb
+++ b/app/controllers/creatives_controller.rb
@@ -289,7 +289,6 @@ class CreativesController < ApplicationController
 
     ActiveRecord::Base.transaction do
       comment = parent.effective_origin.comments.create!(content: markdown, user: Current.user)
-      base_creative.descendants.each(&:destroy!)
       base_creative.destroy!
     end
 

--- a/app/controllers/creatives_controller.rb
+++ b/app/controllers/creatives_controller.rb
@@ -289,6 +289,7 @@ class CreativesController < ApplicationController
 
     ActiveRecord::Base.transaction do
       comment = parent.effective_origin.comments.create!(content: markdown, user: Current.user)
+      base_creative.descendants.each(&:destroy!)
       base_creative.destroy!
     end
 

--- a/config/locales/creatives.en.yml
+++ b/config/locales/creatives.en.yml
@@ -17,7 +17,7 @@ en:
       unlink: "Unlink"
       are_you_sure_unlink: "Are you sure you want to unlink this Creative?"
       unconvert: "Unconvert"
-      unconvert_confirm: "Convert this Creative's children into a markdown comment on the parent? Children will be deleted."
+      unconvert_confirm: "Convert this Creative and its descendants into a markdown comment on the parent? This Creative and its descendants will be deleted."
       unconvert_failed: "Failed to unconvert this Creative."
       unconvert_no_parent: "Cannot unconvert because this Creative has no parent."
       unconvert_no_children: "Cannot unconvert because this Creative has no children."

--- a/config/locales/creatives.ko.yml
+++ b/config/locales/creatives.ko.yml
@@ -17,7 +17,7 @@ ko:
       unlink: "링크 해제"
       are_you_sure_unlink: "링크된 크리에이티브를 삭제하시겠습니까?"
       unconvert: "역전환"
-      unconvert_confirm: "현재 크리에이티브의 하위 항목을 마크다운 코멘트로 변환하고 삭제할까요?"
+      unconvert_confirm: "현재 크리에이티브와 모든 하위 항목을 마크다운 코멘트로 변환해 상위 크리에이티브에 추가하고 삭제할까요?"
       unconvert_failed: "역전환에 실패했습니다."
       unconvert_no_parent: "상위 크리에이티브가 없어 역전환할 수 없습니다."
       unconvert_no_children: "하위 크리에이티브가 없어 역전환할 수 없습니다."

--- a/test/controllers/creatives_controller_test.rb
+++ b/test/controllers/creatives_controller_test.rb
@@ -8,6 +8,7 @@ class CreativesControllerTest < ActionDispatch::IntegrationTest
   test "unconvert moves creative tree into parent comment" do
     creative = creatives(:unconvert_target)
     parent = creative.parent
+    grandchild = creatives(:unconvert_grandchild)
     expected_markdown = ApplicationController.helpers.render_creative_tree_markdown([ creative ])
 
     assert_difference -> { parent.comments.count }, 1 do
@@ -21,6 +22,7 @@ class CreativesControllerTest < ActionDispatch::IntegrationTest
     comment = parent.comments.order(:created_at).last
     assert_equal expected_markdown, comment.content
     assert_raises(ActiveRecord::RecordNotFound) { creative.reload }
+    assert_raises(ActiveRecord::RecordNotFound) { grandchild.reload }
   end
 
   test "unconvert without children returns error" do

--- a/test/controllers/creatives_controller_test.rb
+++ b/test/controllers/creatives_controller_test.rb
@@ -5,14 +5,13 @@ class CreativesControllerTest < ActionDispatch::IntegrationTest
     sign_in_as(users(:one), password: "password")
   end
 
-  test "unconvert moves children into parent comment" do
+  test "unconvert moves creative tree into parent comment" do
     creative = creatives(:unconvert_target)
     parent = creative.parent
-    children = creative.children.order(:sequence).to_a
-    expected_markdown = ApplicationController.helpers.render_creative_tree_markdown(children)
+    expected_markdown = ApplicationController.helpers.render_creative_tree_markdown([ creative ])
 
     assert_difference -> { parent.comments.count }, 1 do
-      assert_difference -> { creative.children.count }, -children.count do
+      assert_difference -> { parent.children.count }, -1 do
         post unconvert_creative_path(creative), headers: { "ACCEPT" => "application/json" }
       end
     end
@@ -21,8 +20,7 @@ class CreativesControllerTest < ActionDispatch::IntegrationTest
     parent.reload
     comment = parent.comments.order(:created_at).last
     assert_equal expected_markdown, comment.content
-    creative.reload
-    assert_equal 0, creative.children.count
+    assert_raises(ActiveRecord::RecordNotFound) { creative.reload }
   end
 
   test "unconvert without children returns error" do

--- a/test/fixtures/action_text_rich_texts.yml
+++ b/test/fixtures/action_text_rich_texts.yml
@@ -30,6 +30,14 @@ unconvert_child_one_description:
   created_at: <%= Time.now %>
   updated_at: <%= Time.now %>
 
+unconvert_grandchild_description:
+  record_type: Creative
+  record_id: <%= ActiveRecord::FixtureSet.identify(:unconvert_grandchild, :creatives) %>
+  name: description
+  body: <div>Grandchild task</div>
+  created_at: <%= Time.now %>
+  updated_at: <%= Time.now %>
+
 unconvert_child_two_description:
   record_type: Creative
   record_id: <%= ActiveRecord::FixtureSet.identify(:unconvert_child_two, :creatives) %>

--- a/test/fixtures/creatives.yml
+++ b/test/fixtures/creatives.yml
@@ -18,6 +18,11 @@ unconvert_child_one:
   parent: unconvert_target
   progress: 0.1
 
+unconvert_grandchild:
+  user: one
+  parent: unconvert_child_one
+  progress: 0.0
+
 unconvert_child_two:
   user: one
   parent: unconvert_target


### PR DESCRIPTION
## Summary
- render markdown for the target creative and its descendants during unconvert and remove the entire subtree
- adjust the controller test to expect the creative tree to be converted into the parent comment
- update English and Korean confirmation text to describe converting the creative and all descendants

## Testing
- ./bin/rubocop -a *(fails: missing required gems in the environment)*
- rails test *(fails: `rails` command not found in PATH)*
- rails test:system *(fails: `rails` command not found in PATH)*

## Original User's Requirements
- 역전환(unconvert) 는 자신의 하위 크리에이티브부터 하는 것이 아니라, 자신부터 하위의 모든 것을 마크다운으로 변환해서 자신의 상위 크리에이티브의 채팅 메세지로 넣는다. 현재는 하위를 상위로 넣도록 잘못 구현되어 있다. 

------
https://chatgpt.com/codex/tasks/task_e_68dbd8f3e4ac8326ab746bd3aa833214