### PR TITLE
Add shared creative listings to user profile

### DIFF
--- a/app/controllers/users/shared_creatives_controller.rb
+++ b/app/controllers/users/shared_creatives_controller.rb
@@ -1,0 +1,33 @@
+module Users
+  class SharedCreativesController < ApplicationController
+    before_action :set_user
+    before_action :authorize_user!
+    before_action :set_creative
+
+    def show
+      @creative_shares = @creative.creative_shares
+                                   .includes(:user)
+                                   .where.not(permission: CreativeShare.permissions[:no_access])
+                                   .references(:users)
+                                   .order("users.name ASC")
+    end
+
+    private
+
+    def set_user
+      @user = User.find(params[:user_id])
+    end
+
+    def authorize_user!
+      return if Current.user == @user || Current.user&.system_admin?
+
+      head :not_found
+    end
+
+    def set_creative
+      @creative = @user.creatives.find(params[:id]).effective_origin
+    rescue ActiveRecord::RecordNotFound
+      head :not_found
+    end
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -53,6 +53,21 @@ class UsersController < ApplicationController
   # Show a single user
   def show
     @user = User.find(params[:id])
+    if Current.user == @user
+      @shared_creatives = @user.creatives
+                                .joins(:creative_shares)
+                                .where.not(creative_shares: { permission: CreativeShare.permissions[:no_access] })
+                                .distinct
+                                .order(created_at: :desc)
+      share_counts = CreativeShare.where(creative_id: @shared_creatives.map(&:id))
+                                  .where.not(permission: CreativeShare.permissions[:no_access])
+                                  .group(:creative_id)
+                                  .count
+      @shared_creative_counts = Hash.new(0).merge(share_counts)
+    else
+      @shared_creatives = []
+      @shared_creative_counts = {}
+    end
   end
 
   def destroy

--- a/app/views/users/shared_creatives/show.html.erb
+++ b/app/views/users/shared_creatives/show.html.erb
@@ -1,0 +1,32 @@
+<h1 class="no-top-margin"><%= t("users.shared_creatives.show_title") %></h1>
+
+<% description_text = @creative.effective_description(nil, false)&.to_plain_text.to_s.strip %>
+<p>
+  <strong><%= t("users.shared_creatives.creative_label") %>:</strong>
+  <%= link_to(description_text.presence || t("users.shared_creatives.untitled"), creative_path(@creative)) %>
+</p>
+
+<% if @creative_shares.any? %>
+  <table class="shared-creatives-table">
+    <thead>
+      <tr>
+        <th><%= t("users.shared_creatives.table.shared_with") %></th>
+        <th><%= t("users.shared_creatives.table.permission") %></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @creative_shares.each do |share| %>
+        <tr>
+          <td><%= share.user.display_name %> (<%= share.user.email %>)</td>
+          <td><%= t("users.shared_creatives.permissions.#{share.permission}") %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <p><%= t("users.shared_creatives.no_active_shares") %></p>
+<% end %>
+
+<p>
+  <%= link_to t("users.shared_creatives.back_to_profile"), user_path(@user) %>
+</p>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -52,4 +52,33 @@
   <%= f.submit t('users.update_profile') %>
 <% end %>
 
+<% if Current.user == @user %>
+  <section class="shared-creatives">
+    <h2><%= t('users.shared_creatives.title') %></h2>
+    <% if @shared_creatives.any? %>
+      <table class="shared-creatives-table">
+        <thead>
+          <tr>
+            <th><%= t('users.shared_creatives.table.creative') %></th>
+            <th><%= t('users.shared_creatives.table.shared_with_count') %></th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @shared_creatives.each do |creative| %>
+            <% description_text = creative.effective_description(nil, false)&.to_plain_text.to_s.strip %>
+            <tr>
+              <td>
+                <%= link_to(description_text.presence || t('users.shared_creatives.untitled'), user_shared_creative_path(@user, creative)) %>
+              </td>
+              <td><%= @shared_creative_counts[creative.id] %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    <% else %>
+      <p><%= t('users.shared_creatives.none') %></p>
+    <% end %>
+  </section>
+<% end %>
+
 <%= link_to t('users.change_password'), edit_password_user_path %>

--- a/config/locales/users.en.yml
+++ b/config/locales/users.en.yml
@@ -80,6 +80,24 @@ en:
       actions: "Actions"
       current_user: "This is you"
       system_admin: "System admin"
+    shared_creatives:
+      title: "Creatives you've shared"
+      none: "You haven't shared any creatives yet."
+      show_title: "Shared creative details"
+      creative_label: "Creative"
+      untitled: "Untitled creative"
+      no_active_shares: "This creative is not currently shared with anyone."
+      back_to_profile: "Back to your profile"
+      table:
+        creative: "Creative"
+        shared_with_count: "People shared"
+        shared_with: "Shared with"
+        permission: "Permission"
+      permissions:
+        read: "Read"
+        feedback: "Feedback"
+        write: "Write"
+        admin: "Admin"
   user_mailer:
     email_verification:
       subject: "Verify your email"

--- a/config/locales/users.ko.yml
+++ b/config/locales/users.ko.yml
@@ -80,6 +80,24 @@ ko:
       actions: "작업"
       current_user: "현재 사용자"
       system_admin: "시스템 관리자"
+    shared_creatives:
+      title: "내가 공유한 크리에이티브"
+      none: "아직 다른 사람과 공유한 크리에이티브가 없습니다."
+      show_title: "공유 상세"
+      creative_label: "크리에이티브"
+      untitled: "제목 없는 크리에이티브"
+      no_active_shares: "현재 이 크리에이티브를 공유한 사람이 없습니다."
+      back_to_profile: "프로파일로 돌아가기"
+      table:
+        creative: "크리에이티브"
+        shared_with_count: "공유 대상 수"
+        shared_with: "공유 대상"
+        permission: "권한"
+      permissions:
+        read: "읽기"
+        feedback: "피드백"
+        write: "쓰기"
+        admin: "관리자"
   user_mailer:
     email_verification:
       subject: "이메일 인증"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,7 @@ Rails.application.routes.draw do
       get :search
       patch :notification_settings
     end
+    resources :shared_creatives, only: [ :show ], module: :users
   end
 
   resources :creatives do

--- a/test/controllers/users/shared_creatives_controller_test.rb
+++ b/test/controllers/users/shared_creatives_controller_test.rb
@@ -1,0 +1,26 @@
+require "test_helper"
+
+class Users::SharedCreativesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @owner = users(:one)
+    @recipient = users(:two)
+    @creative = creatives(:tshirt)
+    CreativeShare.create!(creative: @creative, user: @recipient, permission: :read)
+  end
+
+  test "owner can view shared creative details" do
+    sign_in_as(@owner, password: "password")
+
+    get user_shared_creative_path(@owner, @creative)
+    assert_response :success
+    assert_includes response.body, @recipient.display_name
+    assert_includes response.body, I18n.t("users.shared_creatives.permissions.read")
+  end
+
+  test "other users cannot view shared creative details" do
+    sign_in_as(@recipient, password: "password")
+
+    get user_shared_creative_path(@owner, @creative)
+    assert_response :not_found
+  end
+end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -67,6 +67,19 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     refute @regular_user.reload.system_admin?
   end
 
+  test "current user sees shared creatives section" do
+    sign_in_as(@regular_user, password: "password")
+
+    creative = Creative.create!(user: @regular_user, description: "Profile shared creative")
+    CreativeShare.create!(creative: creative, user: @admin, permission: :read)
+
+    get user_path(@regular_user)
+
+    assert_response :success
+    assert_includes response.body, I18n.t("users.shared_creatives.title")
+    assert_includes response.body, "Profile shared creative"
+  end
+
   test "system admin cannot delete themselves" do
     sign_in_as(@admin, password: "password")
 


### PR DESCRIPTION
## Summary
- display a table of creatives the signed-in user has shared on the profile page with links to detail pages
- add a dedicated shared creative detail view showing recipients, permissions, and a link to the creative itself
- translate new UI labels and cover the new flow with controller tests

## Testing
- `./bin/rubocop -a` *(fails: missing gems in the container environment)*
- `bundle exec rails test` *(fails: bundler cannot find the rails executable without installing gems)*
- `bundle exec rails test:system` *(fails: bundler cannot find the rails executable without installing gems)*

## Original User's Requirements
- 사용자 프로파일 페이지에 내가 공유한 모든 Creative 리스트를 보여주는 페이지를 만들어서 링크를 누르면 해당 페이지로 이동하도록 해줘. 해당 페이지에서는 누구한테 어떤 권한으로 공유했는지 해당 Creative 리스트만 표시하고 해당 Creative 로 갈 수 있도록 크리에이티브 Description 을 링크로 걸어줘. 리스트는 테이블 형식으로 보여줘.


------
https://chatgpt.com/codex/tasks/task_e_68dca4b600a483269c079b9cfe3b116f