### PR TITLE
Ensure push devices use stable unique IDs

### DIFF
--- a/app/javascript/register_service_worker.js
+++ b/app/javascript/register_service_worker.js
@@ -91,14 +91,21 @@ function initMessaging(registration) {
   getToken(messaging, { vapidKey: config.vapidKey, serviceWorkerRegistration: registration })
     .then((currentToken) => {
       if (currentToken) {
-          if (storage && storage.getItem('fcm_token') === currentToken) {
-              // ok
-          } else {
-              registerDevice(currentToken)
-              if (storage) {
-                storage.setItem('fcm_token', currentToken)
-              }
+        let shouldRegister = true
+
+        if (storage) {
+          const storedToken = storage.getItem('fcm_token')
+          const storedClientId = storage.getItem('device_client_id')
+
+          shouldRegister = storedToken !== currentToken || !storedClientId
+        }
+
+        if (shouldRegister) {
+          registerDevice(currentToken)
+          if (storage) {
+            storage.setItem('fcm_token', currentToken)
           }
+        }
       }
     })
     .catch((err) => console.error('Failed to get FCM token', err))


### PR DESCRIPTION
## Summary
- generate a persistent client identifier using local storage and crypto APIs for push device registration
- guard localStorage access to avoid runtime errors and reuse stored FCM tokens only when available

## Testing
- ./bin/rubocop -a
- bundle exec rails test
- bundle exec rails test:system

## Original User's Requirements
- 푸시 토큰이 안올라오는 폰이 있다 다시 설치해도 알람을 허용해도 안올라온다 이유를 찾아서 수정해봐

------
https://chatgpt.com/codex/tasks/task_e_68dd0da395408326b52316f841d9f16b