### PR TITLE
Track Notion block IDs for incremental sync

### DIFF
--- a/app/models/creative.rb
+++ b/app/models/creative.rb
@@ -53,6 +53,7 @@ class Creative < ApplicationRecord
   has_many :invitations, dependent: :delete_all
   has_many :github_repository_links, dependent: :destroy
   has_many :notion_page_links, dependent: :destroy
+  has_many :notion_block_links, dependent: :destroy
 
   validates :progress, numericality: { greater_than_or_equal_to: 0.0, less_than_or_equal_to: 1.0 }, unless: -> { origin_id.present? }
   validates :description, presence: true, unless: -> { origin_id.present? }

--- a/app/models/notion_block_link.rb
+++ b/app/models/notion_block_link.rb
@@ -1,0 +1,8 @@
+class NotionBlockLink < ApplicationRecord
+  belongs_to :notion_page_link
+  belongs_to :creative
+
+  validates :block_id, presence: true
+  validates :creative_id, uniqueness: { scope: :notion_page_link_id }
+  validates :block_id, uniqueness: { scope: :notion_page_link_id }
+end

--- a/app/models/notion_block_link.rb
+++ b/app/models/notion_block_link.rb
@@ -3,6 +3,5 @@ class NotionBlockLink < ApplicationRecord
   belongs_to :creative
 
   validates :block_id, presence: true
-  validates :creative_id, uniqueness: { scope: :notion_page_link_id }
   validates :block_id, uniqueness: { scope: :notion_page_link_id }
 end

--- a/app/models/notion_page_link.rb
+++ b/app/models/notion_page_link.rb
@@ -1,6 +1,7 @@
 class NotionPageLink < ApplicationRecord
   belongs_to :creative
   belongs_to :notion_account
+  has_many :notion_block_links, dependent: :destroy
 
   validates :page_id, :page_title, presence: true
   validates :page_id, uniqueness: true

--- a/app/services/notion_service.rb
+++ b/app/services/notion_service.rb
@@ -1,3 +1,5 @@
+require "digest"
+
 class NotionService
   def initialize(user:)
     @user = user
@@ -31,6 +33,14 @@ class NotionService
 
   def replace_page_blocks(page_id, blocks)
     with_token_refresh { client.replace_page_blocks(page_id, blocks) }
+  end
+
+  def append_blocks(parent_id, blocks)
+    with_token_refresh { client.append_blocks(parent_id, blocks) }
+  end
+
+  def delete_block(block_id)
+    with_token_refresh { client.delete_block(block_id) }
   end
 
   def get_workspace
@@ -87,7 +97,8 @@ class NotionService
     children = creative.children.to_a
     Rails.logger.info("NotionService: Exporting creative #{creative.id} as page title with #{children.count} children as blocks")
 
-    blocks = children.any? ? NotionCreativeExporter.new(creative).export_tree_blocks(children, 1, 0) : []
+    exporter = NotionCreativeExporter.new(creative)
+    blocks = []
 
     # If no parent specified, search for a suitable workspace page
     parent_page_id ||= find_default_parent_page
@@ -105,6 +116,8 @@ class NotionService
       parent_page_id: parent_page_id
     )
 
+    sync_child_blocks(notion_link, creative, children, exporter)
+
     response
   end
 
@@ -115,7 +128,7 @@ class NotionService
     children = creative.children.to_a
     Rails.logger.info("NotionService: Updating creative #{creative.id} as page title with #{children.count} children as blocks")
 
-    blocks = children.any? ? NotionCreativeExporter.new(creative).export_tree_blocks(children, 1, 0) : []
+    exporter = NotionCreativeExporter.new(creative)
 
     properties = {
       title: {
@@ -123,13 +136,91 @@ class NotionService
       }
     }
 
-    update_page(notion_link.page_id, properties: properties, blocks: blocks)
+    update_page(notion_link.page_id, properties: properties)
     notion_link.update!(page_title: title)
+
+    sync_child_blocks(notion_link, creative, children, exporter)
   end
 
   def find_default_parent_page
     # Search for pages in the workspace to find a suitable parent
     pages = search_pages(page_size: 1)
     pages.dig("results")&.first&.dig("id") || raise(NotionError, "No accessible pages found in workspace")
+  end
+
+  def sync_child_blocks(notion_link, creative, children, exporter)
+    child_ids = children.map(&:id)
+    existing_links = notion_link.notion_block_links.index_by(&:creative_id)
+
+    if existing_links.empty?
+      fetch_all_page_blocks(notion_link.page_id).each do |block|
+        begin
+          delete_block(block["id"])
+        rescue NotionError => e
+          Rails.logger.warn("NotionService: Failed to clear existing block #{block['id']} during initial sync: #{e.message}")
+        end
+      end
+    end
+
+    # Delete removed creatives
+    (existing_links.keys - child_ids).each do |removed_id|
+      link = existing_links[removed_id]
+      begin
+        delete_block(link.block_id)
+      rescue NotionError => e
+        Rails.logger.warn("NotionService: Failed to delete Notion block #{link.block_id} for creative #{removed_id}: #{e.message}")
+      ensure
+        link.destroy
+      end
+    end
+
+    children.each do |child|
+      exported_blocks = exporter.export_tree_blocks([ child ], 1, 0)
+      next if exported_blocks.empty?
+
+      content_hash = Digest::SHA256.hexdigest(exported_blocks.to_json)
+      link = existing_links[child.id]
+
+      next if link.present? && link.content_hash == content_hash
+
+      if link.present?
+        begin
+          delete_block(link.block_id)
+        rescue NotionError => e
+          Rails.logger.warn("NotionService: Failed to delete stale Notion block #{link.block_id} for creative #{child.id}: #{e.message}")
+        ensure
+          link.destroy
+        end
+      end
+
+      response = append_blocks(notion_link.page_id, exported_blocks)
+      new_block_id = response.dig("results", 0, "id")
+      if new_block_id.blank?
+        Rails.logger.warn("NotionService: Unable to determine new block id for creative #{child.id}")
+        next
+      end
+
+      link = notion_link.notion_block_links.create!(
+        creative: child,
+        block_id: new_block_id,
+        content_hash: content_hash
+      )
+      existing_links[child.id] = link
+    end
+  end
+
+  def fetch_all_page_blocks(page_id)
+    blocks = []
+    cursor = nil
+
+    loop do
+      response = get_page_blocks(page_id, start_cursor: cursor)
+      blocks.concat(response.fetch("results", []))
+      break unless response["has_more"]
+
+      cursor = response["next_cursor"]
+    end
+
+    blocks
   end
 end

--- a/app/services/notion_service.rb
+++ b/app/services/notion_service.rb
@@ -211,7 +211,8 @@ class NotionService
         next if exported_blocks.empty?
 
         response = append_blocks(notion_link.page_id, exported_blocks)
-        new_block_ids = response.fetch("results", []).filter_map { |result| result["id"] }
+        response_results = response.is_a?(Hash) ? response.fetch("results", []) : []
+        new_block_ids = response_results.filter_map { |result| result["id"] }
 
         if new_block_ids.empty?
           Rails.logger.warn("NotionService: Unable to determine new block ids for creative #{data[:child].id}")

--- a/db/migrate/20250312000000_create_notion_block_links.rb
+++ b/db/migrate/20250312000000_create_notion_block_links.rb
@@ -10,7 +10,7 @@ class CreateNotionBlockLinks < ActiveRecord::Migration[8.0]
 
     add_index :notion_block_links, :notion_page_link_id, name: "index_notion_block_links_on_notion_page_link_id"
     add_index :notion_block_links, :creative_id
-    add_index :notion_block_links, [:notion_page_link_id, :creative_id], unique: true, name: "index_notion_block_links_on_page_link_and_creative"
-    add_index :notion_block_links, [:notion_page_link_id, :block_id], unique: true, name: "index_notion_block_links_on_page_link_and_block"
+    add_index :notion_block_links, [ :notion_page_link_id, :creative_id ], unique: true, name: "index_notion_block_links_on_page_link_and_creative"
+    add_index :notion_block_links, [ :notion_page_link_id, :block_id ], unique: true, name: "index_notion_block_links_on_page_link_and_block"
   end
 end

--- a/db/migrate/20250312000000_create_notion_block_links.rb
+++ b/db/migrate/20250312000000_create_notion_block_links.rb
@@ -1,0 +1,16 @@
+class CreateNotionBlockLinks < ActiveRecord::Migration[8.0]
+  def change
+    create_table :notion_block_links do |t|
+      t.references :notion_page_link, null: false, foreign_key: true, index: false
+      t.references :creative, null: false, foreign_key: true, index: false
+      t.string :block_id, null: false
+      t.string :content_hash
+      t.timestamps
+    end
+
+    add_index :notion_block_links, :notion_page_link_id, name: "index_notion_block_links_on_notion_page_link_id"
+    add_index :notion_block_links, :creative_id
+    add_index :notion_block_links, [:notion_page_link_id, :creative_id], unique: true, name: "index_notion_block_links_on_page_link_and_creative"
+    add_index :notion_block_links, [:notion_page_link_id, :block_id], unique: true, name: "index_notion_block_links_on_page_link_and_block"
+  end
+end

--- a/db/migrate/20250312010000_allow_multiple_notion_blocks_per_creative.rb
+++ b/db/migrate/20250312010000_allow_multiple_notion_blocks_per_creative.rb
@@ -1,0 +1,5 @@
+class AllowMultipleNotionBlocksPerCreative < ActiveRecord::Migration[8.0]
+  def change
+    remove_index :notion_block_links, name: "index_notion_block_links_on_page_link_and_creative"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -250,7 +250,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_28_105957) do
     t.datetime "updated_at", null: false
     t.index ["creative_id"], name: "index_notion_block_links_on_creative_id"
     t.index ["notion_page_link_id", "block_id"], name: "index_notion_block_links_on_page_link_and_block", unique: true
-    t.index ["notion_page_link_id", "creative_id"], name: "index_notion_block_links_on_page_link_and_creative", unique: true
     t.index ["notion_page_link_id"], name: "index_notion_block_links_on_notion_page_link_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -241,6 +241,19 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_28_105957) do
     t.index ["user_id"], name: "index_notion_accounts_on_user_id", unique: true
   end
 
+  create_table "notion_block_links", force: :cascade do |t|
+    t.integer "notion_page_link_id", null: false
+    t.integer "creative_id", null: false
+    t.string "block_id", null: false
+    t.string "content_hash"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["creative_id"], name: "index_notion_block_links_on_creative_id"
+    t.index ["notion_page_link_id", "block_id"], name: "index_notion_block_links_on_page_link_and_block", unique: true
+    t.index ["notion_page_link_id", "creative_id"], name: "index_notion_block_links_on_page_link_and_creative", unique: true
+    t.index ["notion_page_link_id"], name: "index_notion_block_links_on_notion_page_link_id"
+  end
+
   create_table "notion_page_links", force: :cascade do |t|
     t.integer "creative_id", null: false
     t.integer "notion_account_id", null: false

--- a/test/models/notion_block_link_test.rb
+++ b/test/models/notion_block_link_test.rb
@@ -1,0 +1,34 @@
+require "test_helper"
+
+class NotionBlockLinkTest < ActiveSupport::TestCase
+  def setup
+    account = NotionAccount.create!(
+      user: users(:one),
+      notion_uid: "user-123",
+      workspace_id: "workspace-123",
+      workspace_name: "Workspace",
+      token: "token"
+    )
+
+    @page_link = NotionPageLink.create!(
+      creative: creatives(:root_parent),
+      notion_account: account,
+      page_id: "page-123",
+      page_title: "Test Page"
+    )
+  end
+
+  test "requires block id" do
+    link = NotionBlockLink.new(notion_page_link: @page_link, creative: creatives(:root_parent))
+    assert_not link.valid?
+    assert_includes link.errors[:block_id], "can't be blank"
+  end
+
+  test "enforces uniqueness per page link" do
+    NotionBlockLink.create!(notion_page_link: @page_link, creative: creatives(:root_parent), block_id: "block-1")
+
+    duplicate = NotionBlockLink.new(notion_page_link: @page_link, creative: creatives(:root_parent), block_id: "block-2")
+    assert_not duplicate.valid?
+    assert_includes duplicate.errors[:creative_id], "has already been taken"
+  end
+end

--- a/test/models/notion_block_link_test.rb
+++ b/test/models/notion_block_link_test.rb
@@ -24,11 +24,18 @@ class NotionBlockLinkTest < ActiveSupport::TestCase
     assert_includes link.errors[:block_id], "can't be blank"
   end
 
-  test "enforces uniqueness per page link" do
+  test "allows multiple blocks for a single creative" do
     NotionBlockLink.create!(notion_page_link: @page_link, creative: creatives(:root_parent), block_id: "block-1")
 
-    duplicate = NotionBlockLink.new(notion_page_link: @page_link, creative: creatives(:root_parent), block_id: "block-2")
+    additional = NotionBlockLink.new(notion_page_link: @page_link, creative: creatives(:root_parent), block_id: "block-2")
+    assert additional.valid?
+  end
+
+  test "enforces unique block ids per page link" do
+    NotionBlockLink.create!(notion_page_link: @page_link, creative: creatives(:root_parent), block_id: "block-1")
+
+    duplicate = NotionBlockLink.new(notion_page_link: @page_link, creative: creatives(:root_parent), block_id: "block-1")
     assert_not duplicate.valid?
-    assert_includes duplicate.errors[:creative_id], "has already been taken"
+    assert_includes duplicate.errors[:block_id], "has already been taken"
   end
 end


### PR DESCRIPTION
## Summary
- add a NotionBlockLink model and migration to persist the association between creatives and Notion block identifiers
- update the NotionService to sync child creatives incrementally by hashing rendered block content and appending only changed blocks
- document the new mapping with schema changes and a model test to enforce basic validations

## Testing
- `./bin/rubocop -a` *(fails: missing gems in the container; run `bundle install` first)*
- `bundle exec rails test` *(fails: `rails` executable unavailable until dependencies are installed)*
- `bundle exec rails test:system` *(fails: `rails` executable unavailable until dependencies are installed)*

## Original User's Requirements
- get the page, all blocks
- compare existing blocks and only update updated blocks and only delete deleted blocks and only add appended blocks. record notion's block id for future synchonisation.


------
https://chatgpt.com/codex/tasks/task_e_68e7d078357c83268643e5e7a794d93b