### PR TITLE
Ensure ActionText attachments stay downloadable

### DIFF
--- a/app/javascript/controllers/action_text_attachment_link_controller.js
+++ b/app/javascript/controllers/action_text_attachment_link_controller.js
@@ -5,12 +5,22 @@ export default class extends Controller {
     const attachment = event.target.closest('action-text-attachment')
     if (!attachment) return
 
-    const url = attachment.getAttribute('url')
+    let url = attachment.getAttribute('url')
+    let filename = attachment.getAttribute('filename')
+
+    const anchor = attachment.querySelector('a[download]') || attachment.querySelector('a[href]')
+    const image = attachment.querySelector('img[src]')
+
+    if (!url && anchor) url = anchor.href
+    if (!url && image) url = image.src
     if (!url) return
+
+    if (!filename && anchor) filename = anchor.getAttribute('download') || anchor.textContent?.trim()
+    if (!filename && image) filename = image.getAttribute('alt')
+    if (!filename) filename = 'download'
 
     event.preventDefault()
 
-    const filename = attachment.getAttribute('filename') || 'download'
     const link = document.createElement('a')
     link.href = url
     link.download = filename

--- a/app/javascript/controllers/action_text_attachment_link_controller.js
+++ b/app/javascript/controllers/action_text_attachment_link_controller.js
@@ -2,11 +2,17 @@ import { Controller } from '@hotwired/stimulus'
 
 export default class extends Controller {
   download(event) {
-    const attachment = event.target.closest('action-text-attachment')
+    const attachment = event.target.closest('action-text-attachment, figure.attachment')
     if (!attachment) return
 
-    let url = attachment.getAttribute('url')
-    let filename = attachment.getAttribute('filename')
+    const metadata = this.parseMetadata(attachment)
+
+    let url = attachment.getAttribute('url') || attachment.dataset?.url || metadata?.url || metadata?.href
+    let filename =
+      attachment.getAttribute('filename') ||
+      attachment.dataset?.filename ||
+      metadata?.filename ||
+      metadata?.name
 
     const anchor = attachment.querySelector('a[download]') || attachment.querySelector('a[href]')
     const image = attachment.querySelector('img[src]')
@@ -17,6 +23,12 @@ export default class extends Controller {
 
     if (!filename && anchor) filename = anchor.getAttribute('download') || anchor.textContent?.trim()
     if (!filename && image) filename = image.getAttribute('alt')
+
+    if (!filename) {
+      const captionName = attachment.querySelector('.attachment__name')
+      if (captionName) filename = captionName.textContent?.trim()
+    }
+
     if (!filename) filename = 'download'
 
     event.preventDefault()
@@ -28,5 +40,22 @@ export default class extends Controller {
     document.body.appendChild(link)
     link.click()
     document.body.removeChild(link)
+  }
+
+  parseMetadata(attachment) {
+    const sources = [attachment.dataset?.trixAttachment, attachment.dataset?.trixAttributes]
+
+    for (const source of sources) {
+      if (!source) continue
+
+      try {
+        const data = JSON.parse(source)
+        if (data && typeof data === 'object') return data
+      } catch (error) {
+        // Ignore parse errors and continue to the next source
+      }
+    }
+
+    return null
   }
 }

--- a/app/views/action_text/active_storage/blobs/_blob.html.erb
+++ b/app/views/action_text/active_storage/blobs/_blob.html.erb
@@ -1,6 +1,10 @@
-<figure class="attachment attachment--<%= blob.representable? ? "preview" : "file" %> attachment--<%= blob.filename.extension %>">
-  <% download_url = rails_blob_path(blob, disposition: :attachment) %>
+<% download_url = rails_blob_path(blob, disposition: :attachment) %>
 
+<figure
+  class="attachment attachment--<%= blob.representable? ? "preview" : "file" %> attachment--<%= blob.filename.extension %>"
+  data-url="<%= download_url %>"
+  data-filename="<%= blob.filename %>"
+>
   <% if blob.representable? %>
     <%= link_to download_url, download: blob.filename.to_s, class: "attachment__preview-link" do %>
       <%= image_tag blob.representation(resize_to_limit: local_assigns[:in_gallery] ? [ 800, 600 ] : [ 1024, 768 ]) %>

--- a/app/views/active_storage/blobs/_blob.html.erb
+++ b/app/views/active_storage/blobs/_blob.html.erb
@@ -1,13 +1,19 @@
 <figure class="attachment attachment--<%= blob.representable? ? "preview" : "file" %> attachment--<%= blob.filename.extension %>">
+  <% download_url = rails_blob_path(blob, disposition: :attachment) %>
+
   <% if blob.representable? %>
-    <%= image_tag blob.representation(resize_to_limit: local_assigns[:in_gallery] ? [ 800, 600 ] : [ 1024, 768 ]) %>
+    <%= link_to download_url, download: blob.filename.to_s, class: "attachment__preview-link" do %>
+      <%= image_tag blob.representation(resize_to_limit: local_assigns[:in_gallery] ? [ 800, 600 ] : [ 1024, 768 ]) %>
+    <% end %>
   <% end %>
 
   <figcaption class="attachment__caption">
     <% if caption = blob.try(:caption) %>
       <%= caption %>
     <% else %>
-      <span class="attachment__name"><%= blob.filename %></span>
+      <span class="attachment__name">
+        <%= link_to blob.filename, download_url, download: blob.filename.to_s, class: "attachment__name-link" %>
+      </span>
       <span class="attachment__size"><%= number_to_human_size blob.byte_size %></span>
     <% end %>
   </figcaption>


### PR DESCRIPTION
## Summary
- wrap ActionText blob previews and filenames with download links so saved attachments keep working
- enhance the attachment link Stimulus controller to fall back to rendered anchors or images when url metadata is missing

## Testing
- `./bin/rubocop -a`
- `bin/rails test`
- `bin/rails test:system`

## Original User's Requirements
- Trix editor에서 첨부 파일을 저장하고 다시 오면 다운로드가 안되고 링크 정보가 사라져. 다만, 이미지만 링크 정보가 유지되고 있어.
- 이미지든 일반 파일이든 링크 정보를 그대로 유지해야해.
- 이미지 파일이든 일반 파일이든 클릭시 다운로드 되도록 해줘.

------
https://chatgpt.com/codex/tasks/task_e_6901b7e3b6f08326ab069cd19c698797