### PR TITLE
Fix inline creative link button to display linking modal

### DIFF
--- a/app/javascript/creative_row_editor.js
+++ b/app/javascript/creative_row_editor.js
@@ -248,6 +248,14 @@ export function initializeCreativeRowEditor() {
           );
           return; // Event handled
         }
+
+        // Delegated event for #inline-link button inside inline editor
+        const inlineLinkBtn = e.target.closest('#inline-link');
+        if (inlineLinkBtn) {
+          e.preventDefault();
+          linkExistingCreative();
+          return; // Event handled
+        }
       });
     }
 


### PR DESCRIPTION
## Summary
- add a delegated click handler so the inline link button always opens the creative linking modal

## Testing
- Not Run (missing gems): ./bin/rubocop -a
- Not Run (missing gems): bundle exec rails test
- Not Run (missing gems): bundle exec rails test:system

## Original User's Requirements
- inline editor 하단 버튼중에 id="inline-link" 이 버튼을 클릭했을때 링크할 크리에이티브를 검색하는 팝업이 표시되어야 하는데 표시되지 않고 있어 이전에 click handler 처리를 바꾼 리팩토링 제대로 안된것 같아 수정해줘.


------
https://chatgpt.com/codex/tasks/task_e_6902e27810488326bf1534a4f14c6457