### PR TITLE
Fix Turbo progress bar overlay in Android PWA

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -18,6 +18,23 @@ body {
     margin: 0;
 }
 
+.turbo-progress-bar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 3px;
+    background: var(--color-link);
+    z-index: 1200;
+    pointer-events: none;
+}
+
+@supports (top: env(safe-area-inset-top)) {
+    .turbo-progress-bar {
+        top: env(safe-area-inset-top);
+    }
+}
+
 .no-top-margin {
     margin-block-start: 0;
     margin-block-end: 0.5em;


### PR DESCRIPTION
## Summary
- ensure the Turbo progress bar stays fixed at the very top of the viewport so it no longer overlaps the navigation
- reuse the existing link color tokens for the indicator and respect safe area insets on supported browsers

## Testing
- ./bin/rubocop -a *(fails: required gems are not installed in the environment)*

## Original User's Requirements
- 안드로이드 PWA 앱에서 Pull To Refresh 하면 기존에는 상단에 pregress bar 하나가 작동되었는데, 지금은 top menu 중간에 가로로 오버랩 되서 보이는 오류가 있어 수정해줘.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690db47d4e1c8326a27e9a2561b652ce)