### PR TITLE
Prevent linked creative recursion in children lookup

### DIFF
--- a/app/models/creative.rb
+++ b/app/models/creative.rb
@@ -80,7 +80,9 @@ class Creative < ApplicationRecord
   # Returns only children for which the user has at least the given permission (default: :read)
   def children_with_permission(user = nil, min_permission = :read)
     user ||= Current.user
-    effective_origin.children.reject { |child| child.id == id }.select do |child|
+    effective_origin.children
+                    .reject { |child| child.id == id || child.origin_id == effective_origin.id }
+                    .select do |child|
       child.has_permission?(user, min_permission)
     end
   end

--- a/app/models/creative.rb
+++ b/app/models/creative.rb
@@ -80,7 +80,7 @@ class Creative < ApplicationRecord
   # Returns only children for which the user has at least the given permission (default: :read)
   def children_with_permission(user = nil, min_permission = :read)
     user ||= Current.user
-    effective_origin.children.select do |child|
+    effective_origin.children.reject { |child| child.id == id }.select do |child|
       child.has_permission?(user, min_permission)
     end
   end

--- a/test/models/creative_linked_test.rb
+++ b/test/models/creative_linked_test.rb
@@ -59,4 +59,16 @@ class CreativeLinkedTest < ActiveSupport::TestCase
 
     refute_includes children, linked
   end
+
+  test "origin children do not include linked clones" do
+    CreativeShare.create!(creative: @creative, user: @shared_user, permission: :read)
+    @creative.create_linked_creative_for_user(@shared_user)
+
+    linked = Creative.find_by!(origin_id: @creative.id, user_id: @shared_user.id)
+    linked.update!(parent: @creative)
+
+    origin_children = @creative.children_with_permission(@owner)
+
+    refute_includes origin_children, linked
+  end
 end

--- a/test/models/creative_linked_test.rb
+++ b/test/models/creative_linked_test.rb
@@ -47,4 +47,16 @@ class CreativeLinkedTest < ActiveSupport::TestCase
     other_user = User.create!(email: "linked-other@example.com", password: "secret", name: "Other")
     refute @creative.has_permission?(other_user)
   end
+
+  test "linked creative children do not include the linked record itself" do
+    CreativeShare.create!(creative: @creative, user: @shared_user, permission: :read)
+    @creative.create_linked_creative_for_user(@shared_user)
+
+    linked = Creative.find_by!(origin_id: @creative.id, user_id: @shared_user.id)
+    linked.update!(parent: @creative)
+
+    children = linked.children_with_permission(@shared_user)
+
+    refute_includes children, linked
+  end
 end


### PR DESCRIPTION
## Summary
- skip the current record when collecting permission-filtered children so linked creatives no longer recurse on themselves
- add a regression test ensuring linked creatives do not list themselves among their children

## Testing
- ./bin/rubocop -a
- bundle exec rails test
- bundle exec rails test:system (fails: Selenium::WebDriver::Error::NoSuchDriverError: Unable to obtain chromedriver; cannot reach googlechromelabs.github.io)

## Original User's Requirements
- this is part of when I enter 'tag' in search field. it keeps looping.
- when something shared with other user, it has linked creative and it affects when rendering the searched creatives. fix the loop

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911a35289908326b2f04aa6af583dbd)