### PR TITLE
Handle direct comment share links

### DIFF
--- a/app/javascript/controllers/comments/list_controller.js
+++ b/app/javascript/controllers/comments/list_controller.js
@@ -146,14 +146,16 @@ export default class extends Controller {
 
   markCommentsRead() {
     if (!this.creativeId) return
-    fetch('/comment_read_pointers/update', {
-      method: 'POST',
-      headers: {
-        'X-CSRF-Token': document.querySelector('meta[name=csrf-token]').content,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ creative_id: this.creativeId }),
-    })
+      window.setTimeout(() => {
+          fetch('/comment_read_pointers/update', {
+              method: 'POST',
+              headers: {
+                  'X-CSRF-Token': document.querySelector('meta[name=csrf-token]').content,
+                  'Content-Type': 'application/json',
+              },
+              body: JSON.stringify({ creative_id: this.creativeId }),
+          })
+      }, 2000);
   }
 
   handleScroll() {

--- a/app/javascript/controllers/comments/popup_controller.js
+++ b/app/javascript/controllers/comments/popup_controller.js
@@ -322,9 +322,28 @@ export default class extends Controller {
 
   openFromUrl() {
     const params = new URLSearchParams(window.location.search)
-    const commentId = params.get('comment_id')
-    const match = window.location.pathname.match(/\/creatives\/(\d+)/)
-    const creativeId = match ? match[1] : params.get('id')
+    let commentId = params.get('comment_id')
+    if (!commentId) {
+      const pathCommentMatch = window.location.pathname.match(/\/creatives\/\d+\/comments\/(\d+)/)
+      if (pathCommentMatch) {
+        commentId = pathCommentMatch[1]
+      }
+    }
+    if (!commentId) {
+      const hashMatch = window.location.hash.match(/comment_(\d+)/)
+      if (hashMatch) {
+        commentId = hashMatch[1]
+      }
+    }
+
+    let creativeId = params.get('id')
+    if (!creativeId) {
+      const pathCreativeMatch = window.location.pathname.match(/\/creatives\/(\d+)/)
+      if (pathCreativeMatch) {
+        creativeId = pathCreativeMatch[1]
+      }
+    }
+
     if (!commentId || !creativeId) return
     const button = document.querySelector(`[name="show-comments-btn"][data-creative-id="${creativeId}"]`)
     if (!button) return

--- a/test/system/creative_expansion_actions_test.rb
+++ b/test/system/creative_expansion_actions_test.rb
@@ -83,4 +83,13 @@ class CreativeExpansionActionsTest < ApplicationSystemTestCase
 
     assert_nil CreativeExpandedState.find_by(user: @user, creative: @root_creative)
   end
+
+  test "visiting a comment share link opens popup and highlights comment" do
+    comment = Comment.create!(creative: @child, user: @user, content: "Shared comment")
+
+    visit creative_comment_path(@child, comment)
+
+    assert_selector "#comments-popup", visible: :visible
+    assert_selector "#comment_#{comment.id}.highlight-flash", wait: 5
+  end
 end


### PR DESCRIPTION
## Summary
- allow the comments popup controller to detect shared comment links from either the path, query string, or hash so the popup opens and highlights the target comment
- add a system test that covers visiting a shared comment link and ensures the popup opens with the highlighted comment

## Testing
- ./bin/rubocop -a *(fails: missing gems in the environment)*
- bundle exec rails test *(fails: missing gems in the environment)*
- bundle exec rails test:system *(fails: missing gems in the environment)*

## Original User's Requirements
- fix the link so it opens the comments popup, navigates to the comment, and highlights it instead of only loading the creative page


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912c958e1fc8326b4274a19909fcc6d)