### PR TITLE
Use RubyLLM for Gemini recommendations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,8 +7,9 @@ This document captures best practices for integrating Anthropic's Claude models 
 - Verify API access and keys are stored using the team's standard secrets management approach.
 - Note any environment variables required to initialize Claude clients.
 - Link to reusable prompts or templates that Claude-based workflows should follow.
-- Gemini-based parent recommendations now use the [`ruby_llm`](https://github.com/crmne/ruby_llm) client. Ensure `GEMINI_API_KEY`
-  is present so `RubyLLM` can configure the shared Gemini chat session via `config/initializers/ruby_llm.rb`.
+- Gemini-based parent recommendations and streaming responses (PR analysis, `@gemini` replies) now use the
+  [`ruby_llm`](https://github.com/crmne/ruby_llm) client. Ensure `GEMINI_API_KEY` is present so `RubyLLM` can configure the
+  shared Gemini chat session via `config/initializers/ruby_llm.rb`.
 
 ## Collaboration Tips
 - Keep dialogue transcripts or prompt iterations in version control when they inform product behavior.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,8 @@ This document captures best practices for integrating Anthropic's Claude models 
 - Verify API access and keys are stored using the team's standard secrets management approach.
 - Note any environment variables required to initialize Claude clients.
 - Link to reusable prompts or templates that Claude-based workflows should follow.
+- Gemini-based parent recommendations now use the [`ruby_llm`](https://github.com/crmne/ruby_llm) client. Ensure `GEMINI_API_KEY`
+  is present so `RubyLLM` can configure the shared Gemini chat session via `config/initializers/ruby_llm.rb`.
 
 ## Collaboration Tips
 - Keep dialogue transcripts or prompt iterations in version control when they inform product behavior.

--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,7 @@ gem "omniauth-rails_csrf_protection"
 gem "omniauth-github"
 gem "httparty"
 gem "octokit"
+gem "ruby_llm"
 
 gem "dotenv", groups: [ :development, :test ]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,6 +119,7 @@ GEM
     erubi (1.13.1)
     et-orbi (1.4.0)
       tzinfo
+    event_stream_parser (1.0.0)
     faraday (2.14.0)
       faraday-net_http (>= 2.0, < 3.5)
       json
@@ -127,6 +128,10 @@ GEM
       faraday (>= 1, < 3)
     faraday-net_http (3.4.2)
       net-http (~> 0.5)
+    faraday-multipart (1.1.1)
+      multipart-post (~> 2.0)
+    faraday-retry (2.3.2)
+      faraday (~> 2.0)
     fcm (2.0.1)
       faraday (>= 1.0.0, < 3.0)
       googleauth (~> 1)
@@ -224,7 +229,8 @@ GEM
     multi_xml (0.7.2)
       bigdecimal (~> 3.1)
     net-http (0.7.0)
-      uri
+    multipart-post (2.4.1)
+    mutex_m (0.3.0)
     net-imap (0.5.12)
       date
       net-protocol
@@ -400,6 +406,17 @@ GEM
     ruby-vips (2.2.3)
       ffi (~> 1.12)
       logger
+    ruby_llm (1.9.1)
+      base64
+      event_stream_parser (~> 1)
+      faraday (>= 1.10.0)
+      faraday-multipart (>= 1)
+      faraday-net_http (>= 1)
+      faraday-retry (>= 1)
+      marcel (~> 1.0)
+      ruby_llm-schema (~> 0.2.1)
+      zeitwerk (~> 2)
+    ruby_llm-schema (0.2.1)
     rubyzip (3.2.1)
     sawyer (0.9.2)
       addressable (>= 2.3.5)
@@ -530,6 +547,7 @@ DEPENDENCIES
   puma (>= 5.0)
   rails (~> 8.1.1)
   rubocop-rails-omakase
+  ruby_llm
   selenium-webdriver
   solid_cable
   solid_cache

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,10 +126,10 @@ GEM
       logger
     faraday-follow_redirects (0.4.0)
       faraday (>= 1, < 3)
-    faraday-net_http (3.4.2)
-      net-http (~> 0.5)
     faraday-multipart (1.1.1)
       multipart-post (~> 2.0)
+    faraday-net_http (3.4.2)
+      net-http (~> 0.5)
     faraday-retry (2.3.2)
       faraday (~> 2.0)
     fcm (2.0.1)
@@ -228,9 +228,9 @@ GEM
     multi_json (1.17.0)
     multi_xml (0.7.2)
       bigdecimal (~> 3.1)
-    net-http (0.7.0)
     multipart-post (2.4.1)
     mutex_m (0.3.0)
+    net-http (0.7.0)
     net-imap (0.5.12)
       date
       net-protocol

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -229,8 +229,8 @@ GEM
     multi_xml (0.7.2)
       bigdecimal (~> 3.1)
     multipart-post (2.4.1)
-    mutex_m (0.3.0)
-    net-http (0.7.0)
+    net-http (0.8.0)
+      uri (>= 0.11.1)
     net-imap (0.5.12)
       date
       net-protocol

--- a/app/services/gemini_chat_client.rb
+++ b/app/services/gemini_chat_client.rb
@@ -1,115 +1,87 @@
-require "net/http"
-require "json"
-
 class GeminiChatClient
-  STREAM_URL = "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:streamGenerateContent"
+  DEFAULT_MODEL = "gemini-2.5-flash".freeze
+  SYSTEM_INSTRUCTIONS = <<~PROMPT.freeze
+    You are a senior expert teammate. Respond:
+    - Be concise and focus on the essentials (avoid unnecessary verbosity).
+    - Use short bullet points only when helpful.
+    - State only what you're confident about; briefly note any uncertainty.
+    - Respond in the asker's language (prefer the latest user message). Keep code and error messages in their original form.
+  PROMPT
 
-  def initialize(api_key: ENV["GEMINI_API_KEY"])
+  def initialize(api_key: ENV["GEMINI_API_KEY"], model: DEFAULT_MODEL, chat_factory: ->(model_id) { RubyLLM.chat(model: model_id) })
     @api_key = api_key
+    @model = model
+    @chat_factory = chat_factory
   end
 
-  def chat(contents)
-    return if @api_key.blank?
-    uri = URI(STREAM_URL)
-    params = { alt: "sse", key: @api_key }
-    uri.query = [ uri.query, URI.encode_www_form(params) ].compact.join("&") # preserve any existing query
+  def chat(contents, &block)
+    return if api_key.blank?
 
-    req = Net::HTTP::Post.new(uri, "Content-Type" => "application/json")
-    system_instruction = {
-      parts: [
-        {
-          text: <<~PROMPT.strip
-            You are a senior expert teammate. Respond:
-            - Be concise and focus on the essentials (avoid unnecessary verbosity).
-            - Use short bullet points only when helpful.
-            - State only what you're confident about; briefly note any uncertainty.
-            - Respond in the asker's language (prefer the latest user message). Keep code and error messages in their original form.
-          PROMPT
-        }
-      ]
-    }
-    req.body = { contents: contents, systemInstruction: system_instruction }.to_json
-    Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
-      # inside your Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
-      http.request(req) do |res|
-        unless res.is_a?(Net::HTTPSuccess)
-          # Try to surface server error payload to the room
-          body = +""
-          res.read_body { |c| body << c rescue nil }
-          yield "[ERROR] HTTP #{res.code} #{res.message}#{body.empty? ? '' : " — #{body[0, 400]}"}"
-          next
-        end
+    conversation = build_conversation
+    add_messages(conversation, contents)
 
-        # --- Rock-solid SSE parsing (CRLF-safe, partial-safe) ---
-        line_buf    = +""
-        event_lines = []
+    response = conversation.complete do |chunk|
+      delta = extract_chunk_content(chunk)
+      next if delta.blank?
 
-        # tiny helper to process one complete SSE event
-        process_event = lambda do
-          return if event_lines.empty?
-
-          # Rebuild data payload from one SSE event (can include multiple data: lines)
-          data = event_lines
-                   .select { |l| l.start_with?("data:") }
-                   .map    { |l| l.sub(/\Adata:\s?/, "") }
-                   .join("\n")
-
-          event_lines.clear
-          return if data.empty? || data == "[DONE]"
-
-          begin
-            obj = JSON.parse(data)
-          rescue JSON::ParserError => e
-            Rails.logger.warn("SSE JSON parse error: #{e.message}")
-            # Yield a short error so chat users can see it (and we keep streaming)
-            yield "[ERROR] Invalid JSON chunk (continuing): #{data[0, 200]}"
-            return
-          end
-
-          # If API returns structured error in the stream, surface it
-          if obj.is_a?(Hash) && obj["error"]
-            msg = obj.dig("error", "message") || obj["error"].to_s
-            yield "[ERROR] #{msg}"
-            return
-          end
-
-          # Normal token emission
-          parts = obj.dig("candidates", 0, "content", "parts") || []
-          parts.each do |p|
-            t = p["text"]
-            yield t if t && !t.empty?
-          end
-        end
-
-        begin
-          res.read_body do |chunk|
-            line_buf << chunk
-
-            # Extract COMPLETE lines regardless of \n or \r\n
-            while (newline = line_buf.index(/\r?\n/))
-              # one full line without its newline
-              line = line_buf.slice!(0..newline).sub(/\r?\n\z/, "")
-              Rails.logger.debug { "### SSE line: #{line.inspect}" }
-
-              if line.empty?
-                # Blank line => end of event
-                process_event.call
-              else
-                event_lines << line
-              end
-            end
-          end
-        rescue => e
-          # Network/stream error: show to users
-          yield "[ERROR] Stream error: #{e.class}: #{e.message}"
-        ensure
-          # If stream ended without a trailing blank line, flush the last event
-          process_event.call if event_lines.any?
-        end
-      end
+      yield delta if block_given?
     end
+
+    response&.content
   rescue StandardError => e
     Rails.logger.error("Gemini chat error: #{e.message}")
     yield "Gemini error: #{e.message}" if block_given?
+    nil
+  end
+
+  private
+
+  attr_reader :api_key, :model, :chat_factory
+
+  def build_conversation
+    chat_factory.call(model).tap do |chat|
+      chat.with_instructions(SYSTEM_INSTRUCTIONS)
+    end
+  end
+
+  def add_messages(conversation, contents)
+    Array(contents).each do |message|
+      role = normalize_role(message)
+      next unless role
+
+      text = extract_message_text(message)
+      next if text.blank?
+
+      conversation.add_message(role:, content: text)
+    end
+  end
+
+  def normalize_role(message)
+    value = message[:role] || message["role"]
+    case value.to_s
+    when "user" then :user
+    when "model", "assistant" then :assistant
+    when "system" then :system
+    when "function", "tool" then :tool
+    else
+      nil
+    end
+  end
+
+  def extract_message_text(message)
+    parts = message[:parts] || message["parts"]
+    return message[:text] || message["text"] if parts.nil?
+
+    Array(parts).map { |part| part[:text] || part["text"] }.compact.join("\n")
+  end
+
+  def extract_chunk_content(chunk)
+    return if chunk.nil?
+
+    if chunk.respond_to?(:content)
+      chunk.content
+    else
+      chunk.to_s
+    end
   end
 end

--- a/app/services/gemini_client.rb
+++ b/app/services/gemini_client.rb
@@ -1,27 +1,43 @@
-require "net/http"
-require "json"
-
 class GeminiClient
-  GEMINI_URL = "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent"
+  DEFAULT_MODEL = "gemini-2.5-flash".freeze
 
-  def initialize(api_key: ENV["GEMINI_API_KEY"])
+  def initialize(api_key: ENV["GEMINI_API_KEY"], model: DEFAULT_MODEL, chat_factory: ->(model_id) { RubyLLM.chat(model: model_id) })
     @api_key = api_key
+    @model = model
+    @chat_factory = chat_factory
   end
 
   def recommend_parent_ids(categories, description)
     return [] if @api_key.blank?
-    lines = categories.map { |c| "#{c[:id]}, \"#{c[:path]}\"" }.join("\n")
-    prompt = "#{lines}\n\nGiven the above categories (id, path), which ids are the best parents for \"#{description}\"? " \
-             "Reply with up to 5 ids separated by commas in descending order of relevance."
+
+    prompt = build_prompt(categories, description)
     Rails.logger.info("### prompt=#{prompt}")
-    uri = URI("#{GEMINI_URL}?key=#{@api_key}")
-    body = { contents: [ { role: "user", parts: [ { text: prompt } ] } ] }
-    response = Net::HTTP.post(uri, body.to_json, "Content-Type" => "application/json")
-    json = JSON.parse(response.body)
-    text = json.dig("candidates", 0, "content", "parts", 0, "text")
-    return [] unless text
-    text.split(/[\s,]+/).map(&:to_i).reject(&:zero?).first(5)
-  rescue StandardError
+
+    response = chat.ask(prompt)
+    parse_response(response&.content)
+  rescue StandardError => e
+    Rails.logger.error("GeminiClient recommendation failed: #{e.class} #{e.message}")
     []
+  end
+
+  private
+
+  def chat
+    @chat ||= @chat_factory.call(@model)
+  end
+
+  def build_prompt(categories, description)
+    lines = categories.map { |category| "#{category[:id]}, \"#{category[:path]}\"" }.join("\n")
+    "#{lines}\n\nGiven the above categories (id, path), which ids are the best parents for \"#{description}\"? " \
+      "Reply with up to 5 ids separated by commas in descending order of relevance."
+  end
+
+  def parse_response(content)
+    return [] if content.blank?
+
+    content.to_s.split(/[\s,]+/)
+           .filter_map { |value| Integer(value, exception: false) }
+           .reject(&:zero?)
+           .first(5)
   end
 end

--- a/config/initializers/ruby_llm.rb
+++ b/config/initializers/ruby_llm.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+return unless defined?(RubyLLM)
+
+RubyLLM.configure do |config|
+  config.gemini_api_key = ENV["GEMINI_API_KEY"]
+end


### PR DESCRIPTION
## Summary
- add the ruby_llm gem and initializer so Gemini runs through the shared AI client
- switch the GeminiClient parent recommendation flow to call RubyLLM instead of manual HTTP requests
- document the Gemini configuration change for other agents

## Testing
- ./bin/rubocop -a
- bin/rails test
- bin/rails test:system *(fails: Selenium cannot download chromedriver in the container)*

## Original User's Requirements
- use https://github.com/crmne/ruby_llm for ai call

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912d1bff9208326bfc3609f4728efdc)