### PR TITLE
Refactor creative link API usage

### DIFF
--- a/app/javascript/creative_row_editor.js
+++ b/app/javascript/creative_row_editor.js
@@ -624,8 +624,8 @@ export function initializeCreativeRowEditor() {
         linkResults.innerHTML = '';
         return;
       }
-      fetch(`/creatives.json?search=${encodeURIComponent(query)}&simple=true`)
-        .then(r => r.json())
+      creativesApi
+        .search(query, { simple: true })
         .then(results => {
           linkResults.innerHTML = '';
           if (Array.isArray(results)) {
@@ -653,16 +653,7 @@ export function initializeCreativeRowEditor() {
         closeLinkModal();
         return;
       }
-      const fd = new FormData();
-      fd.append('creative[parent_id]', form.dataset.creativeId);
-      fd.append('creative[origin_id]', li.dataset.id);
-      fd.append('authenticity_token', document.querySelector('meta[name="csrf-token"]').content);
-      fetch('/creatives', {
-        method: 'POST',
-        headers: { 'Accept': 'application/json' },
-        body: fd,
-        credentials: 'same-origin'
-      }).then(() => {
+      creativesApi.linkExisting(form.dataset.creativeId, li.dataset.id).then(() => {
         closeLinkModal();
         refreshChildren(currentTree).then(() => refreshRow(currentTree));
       });

--- a/app/javascript/lib/api/creatives.js
+++ b/app/javascript/lib/api/creatives.js
@@ -18,11 +18,36 @@ export function loadChildren(url) {
   return csrfFetch(url).then((response) => response.text())
 }
 
+export function search(query, { simple = false } = {}) {
+  const params = new URLSearchParams()
+  if (query != null) params.set('search', query)
+  if (simple) params.set('simple', 'true')
+
+  const queryString = params.toString()
+  const url = queryString ? `/creatives.json?${queryString}` : '/creatives.json'
+
+  return csrfFetch(url, {
+    headers: JSON_HEADERS,
+  }).then((response) => response.json())
+}
+
 export function save(action, method, form) {
   return csrfFetch(action, {
     method,
     headers: JSON_HEADERS,
     body: new FormData(form),
+  })
+}
+
+export function linkExisting(parentId, originId) {
+  const body = new FormData()
+  if (parentId != null) body.append('creative[parent_id]', parentId)
+  if (originId != null) body.append('creative[origin_id]', originId)
+
+  return csrfFetch('/creatives', {
+    method: 'POST',
+    headers: JSON_HEADERS,
+    body,
   })
 }
 
@@ -44,7 +69,9 @@ const creativesApi = {
   get,
   parentSuggestions,
   loadChildren,
+  search,
   save,
+  linkExisting,
   destroy,
   unconvert,
 }


### PR DESCRIPTION
## Summary
- add reusable creative search and link helpers to the API library
- update the creative row editor to call the shared API helpers instead of inline fetch logic

## Testing
- not run (not requested)

## Original User's Requirements
- separate api call to api lib js file by refactoring

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912ead0deb083269d3426ffc7535e28)