### PR TITLE
Fix inline editor placement above child creatives

### DIFF
--- a/app/javascript/creative_row_editor.js
+++ b/app/javascript/creative_row_editor.js
@@ -186,6 +186,16 @@ export function initializeCreativeRowEditor() {
       }
     }
 
+    function attachTemplate(tree) {
+      if (!tree) return;
+      const childrenContainer = tree.querySelector('.creative-children');
+      if (childrenContainer && childrenContainer.parentNode === tree) {
+        tree.insertBefore(template, childrenContainer);
+      } else {
+        tree.appendChild(template);
+      }
+    }
+
     async function handleEditButtonClick(tree) {
       if (!tree) return;
 
@@ -200,7 +210,7 @@ export function initializeCreativeRowEditor() {
       currentRowElement = treeRowElement(tree);
       hideRow(tree);
       tree.draggable = false;
-      tree.appendChild(template);
+      attachTemplate(tree);
       template.style.display = 'block';
       loadCreative(tree.dataset.id);
     }
@@ -523,7 +533,7 @@ export function initializeCreativeRowEditor() {
       currentTree = target;
       currentRowElement = treeRowElement(target);
       hideRow(target);
-      target.appendChild(template);
+      attachTemplate(target);
       template.style.display = 'block';
       beforeNewOrMove(wasNew, prev, prevParent).then(() => {
         loadCreative(target.dataset.id);
@@ -750,7 +760,7 @@ export function initializeCreativeRowEditor() {
           }
           currentTree = newTree;
           currentRowElement = rowComponent;
-          newTree.appendChild(template);
+          attachTemplate(newTree);
           template.style.display = 'block';
           form.action = '/creatives';
           methodInput.value = '';


### PR DESCRIPTION
## Summary
- ensure the inline editor template is inserted before a creative's child container so children remain listed below the editor
- reuse the same placement helper when moving between creatives or creating a new inline row

## Testing
- ./bin/rubocop -a
- bundle exec rails test
- bundle exec rails test:system *(fails: unable to obtain chromedriver in this environment)*

## Original User's Requirements
- A 크리에이티브 아래에 A-1 을 그 아래에 A-1-1 을 추가한 후 에디터에서 위로 이동하면, A-1 이 편집 상태이고, A-1-1 이 아래에 표시되어야 하는데, 위에 표시되는 오류가 있어. 수정해줘.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912eea03dec8326a97d660b3f57d0b1)