### PR TITLE
Prevent linking linked creatives

### DIFF
--- a/app/javascript/creative_row_editor.js
+++ b/app/javascript/creative_row_editor.js
@@ -693,10 +693,20 @@ export function initializeCreativeRowEditor() {
         closeLinkModal();
         return;
       }
-      creativesApi.linkExisting(form.dataset.creativeId, li.dataset.id).then(() => {
-        closeLinkModal();
-        refreshChildren(currentTree).then(() => refreshRow(currentTree));
-      });
+      creativesApi
+        .linkExisting(form.dataset.creativeId, li.dataset.id)
+        .then(() => {
+          closeLinkModal();
+          refreshChildren(currentTree).then(() => refreshRow(currentTree));
+        })
+        .catch((error) => {
+          const data = error?.data;
+          const message = (data?.errors && data.errors[0])
+            || data?.error
+            || linkModal?.dataset?.error
+            || 'Failed to link creative.';
+          alert(message);
+        });
     }
 
     function handleLinkResultClick(e) {

--- a/app/javascript/lib/api/creatives.js
+++ b/app/javascript/lib/api/creatives.js
@@ -48,6 +48,20 @@ export function linkExisting(parentId, originId) {
     method: 'POST',
     headers: JSON_HEADERS,
     body,
+  }).then(async (response) => {
+    if (!response.ok) {
+      let data = null
+      try {
+        data = await response.json()
+      } catch (error) {
+        data = null
+      }
+      const err = new Error('Failed to link creative')
+      err.response = response
+      if (data != null) err.data = data
+      throw err
+    }
+    return response.json()
   })
 }
 

--- a/app/models/creative.rb
+++ b/app/models/creative.rb
@@ -57,6 +57,7 @@ class Creative < ApplicationRecord
 
   validates :progress, numericality: { greater_than_or_equal_to: 0.0, less_than_or_equal_to: 1.0 }, unless: -> { origin_id.present? }
   validates :description, presence: true, unless: -> { origin_id.present? }
+  validate :origin_must_be_original, if: -> { origin_id.present? }
 
   before_validation :assign_default_user, on: :create
 
@@ -214,6 +215,13 @@ class Creative < ApplicationRecord
   end
 
   private
+
+  def origin_must_be_original
+    return if origin.blank?
+    return if origin.origin_id.blank?
+
+    errors.add(:base, I18n.t("creatives.errors.linked_origin", default: "Linked creatives cannot be linked again. Please link the original Creative."))
+  end
 
   def clear_permission_cache_on_parent_change
     return unless saved_change_to_parent_id?

--- a/app/views/creatives/_inline_edit_form.html.erb
+++ b/app/views/creatives/_inline_edit_form.html.erb
@@ -64,7 +64,7 @@
   </form>
 </div>
 
-<div id="link-creative-modal" style="display:none;position:fixed;top:0;left:0;width:100vw;height:100vh;z-index:1000;align-items:center;justify-content:center;">
+<div id="link-creative-modal" style="display:none;position:fixed;top:0;left:0;width:100vw;height:100vh;z-index:1000;align-items:center;justify-content:center;" data-error="<%= t('creatives.index.link_failed') %>">
   <div class="popup-box">
     <button type="button" id="close-link-creative-modal" class="popup-close-btn">&times;</button>
     <h2><%= t('creatives.index.link', default: 'Link') %></h2>

--- a/config/locales/creatives.en.yml
+++ b/config/locales/creatives.en.yml
@@ -15,6 +15,7 @@ en:
       are_you_sure_delete_with_children: "Are you sure you want to delete this Creative and ALL its children? This cannot be undone."
       link: "Link"
       unlink: "Unlink"
+      link_failed: "Failed to link Creative."
       are_you_sure_unlink: "Are you sure you want to unlink this Creative?"
       unconvert: "Unconvert"
       unconvert_confirm: "Convert this Creative and its descendants into a markdown comment on the parent? This Creative and its descendants will be deleted."
@@ -93,6 +94,7 @@ en:
       progress_recalculated: "All parent progress recalculated."
     errors:
       no_permission: "You do not have permission to perform this action."
+      linked_origin: "Linked creatives cannot be linked again. Please link the original Creative."
     inline_editor:
       placeholder: "Describe the creative…"
     edit_title: "Edit creative"

--- a/config/locales/creatives.ko.yml
+++ b/config/locales/creatives.ko.yml
@@ -15,6 +15,7 @@ ko:
       are_you_sure_delete_with_children: "이 항목과 모든 하위 항목을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
       link: "링크"
       unlink: "링크 해제"
+      link_failed: "크리에이티브를 링크하지 못했습니다."
       are_you_sure_unlink: "링크된 크리에이티브를 삭제하시겠습니까?"
       unconvert: "역전환"
       unconvert_confirm: "현재 크리에이티브와 모든 하위 항목을 마크다운 코멘트로 변환해 상위 크리에이티브에 추가하고 삭제할까요?"
@@ -93,6 +94,7 @@ ko:
       progress_recalculated: "진행률을 다시 계산 했습니다."
     errors:
       no_permission: "이 작업을 수행할 권한이 없습니다."
+      linked_origin: "링크된 크리에이티브는 다시 링크할 수 없습니다. 원본을 링크해주세요."
     inline_editor:
       placeholder: "크리에이티브를 설명해주세요…"
     edit_title: "크리에이티브 수정"


### PR DESCRIPTION
## Summary
- prevent creating a linked creative from another linked creative with a model validation and localized error message
- surface link failures in the inline editor by surfacing API errors and using a translated fallback alert
- add UI metadata so the inline link dialog can show a helpful default error message

## Testing
- ./bin/rubocop -a
- bin/rails test
- bin/rails test:system *(fails: Selenium cannot download Chrome/Chromedriver in the sandboxed environment)*

## Original User's Requirements
- Linked Creative 를 다시 Link 하려고 하면 허용하지 않고, "링크된 크리에이티브는 다시 링크할 수 없습니다. 원본을 링크해주세요." alert 메세지를 표시한다.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915295d4e5c8326aa87e23f669cf90f)