### PR TITLE
Add ctrl+p and ctrl+n navigation shortcuts to inline editor

### DIFF
--- a/app/javascript/creative_row_editor.js
+++ b/app/javascript/creative_row_editor.js
@@ -1224,7 +1224,13 @@ function formatProgressDisplay(value) {
         levelUp();
         return;
       }
-      if (event.key !== 'ArrowUp' && event.key !== 'ArrowDown') return;
+      const normalizedKey = typeof event.key === 'string' ? event.key.toLowerCase() : '';
+      const isArrowUp = event.key === 'ArrowUp';
+      const isArrowDown = event.key === 'ArrowDown';
+      const isCtrlP = normalizedKey === 'p' && (event.ctrlKey || event.metaKey);
+      const isCtrlN = normalizedKey === 'n' && (event.ctrlKey || event.metaKey);
+
+      if (!(isArrowUp || isArrowDown || isCtrlP || isCtrlN)) return;
 
       let atStart = false;
       let atEnd = false;
@@ -1236,7 +1242,7 @@ function formatProgressDisplay(value) {
         atEnd = isSelectionAtDocumentEnd(selection);
       });
 
-      if (event.key === 'ArrowUp' && atStart) {
+      if ((isArrowUp || isCtrlP) && atStart) {
         event.preventDefault();
         if (pendingSave) saveForm();
         move(-1);
@@ -1244,7 +1250,7 @@ function formatProgressDisplay(value) {
         return;
       }
 
-      if (event.key === 'ArrowDown' && atEnd) {
+      if ((isArrowDown || isCtrlN) && atEnd) {
         event.preventDefault();
         if (pendingSave) saveForm();
         move(1);


### PR DESCRIPTION
## Summary
- treat Ctrl+P/Cmd+P and Ctrl+N/Cmd+N as navigation shortcuts alongside the arrow keys in the inline Lexical editor
- ensure the shortcuts only trigger when the caret is at the start or end of the document, mirroring the existing arrow key behavior

## Testing
- `./bin/rubocop -a` *(fails: missing bundled gems in the container environment)*
- `bin/rails test` *(fails: missing bundled gems in the container environment)*
- `bin/rails test:system` *(fails: missing bundled gems in the container environment)*

## Original User's Requirements
- inline editor 의 Lexical edtior 안에서 커서가 처음에 있을때 위쪽 화살표 키 뿐만 아니라 ctrl+p 를 눌러도 작동되도록 하고 마찬가지로 커서가 마지막에 있을때 아래쪽 화살표 키 뿐만 아니라 ctrl+n 을 눌러도 작동되도록 해.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691da7d05770832686af194e7a9b4715)