### PR TITLE
Unify inline editor delete flow into confirmation modal

### DIFF
--- a/app/views/creatives/_inline_edit_form.html.erb
+++ b/app/views/creatives/_inline_edit_form.html.erb
@@ -36,13 +36,8 @@
           &nbsp;
           <%= svg_tag 'hierarchy-parent.svg',class: 'icon-svg', width: 24, height: 24 %>
         </button>
-        <button type="button" id="inline-delete" class="creative-action-btn danger-link" title="<%= t('creatives.index.delete_only_this') %>" data-confirm="<%= t('creatives.index.are_you_sure_delete_only_this') %>">
+        <button type="button" id="inline-delete" class="creative-action-btn danger-link" title="<%= t('creatives.index.delete_only_this') %>">
           &nbsp;<%= svg_tag 'trash-bold-outline.svg',class: 'icon-svg', width: 24, height: 24 %>
-        </button>
-        <button type="button" id="inline-delete-with-children" class="creative-action-btn danger-link" title="<%= t('creatives.index.delete_with_children') %>" data-confirm="<%= t('creatives.index.are_you_sure_delete_with_children') %>">
-          &nbsp;
-          <%= svg_tag 'hierarchy-child.svg',class: 'icon-svg', width: 16, height: 16 %>
-          <%= svg_tag 'trash-bold-outline.svg',class: 'icon-svg', width: 24, height: 24 %>
         </button>
         <button type="button" id="inline-link" class="creative-action-btn" title="<%= t('creatives.index.link') %>">
           &nbsp;<%= svg_tag 'link.svg',class: 'icon-svg', width: 24, height: 24 %>
@@ -75,5 +70,26 @@
     <h2><%= t('creatives.index.link', default: 'Link') %></h2>
     <input type="text" id="link-creative-search" class="shared-input-surface" style="width:100%;margin-bottom:0.5em;" placeholder="<%= t('creatives.index.search_placeholder', default: 'Search creative') %>">
     <ul id="link-creative-results" style="list-style:none;padding:0;margin:0;max-height:300px;overflow-y:auto;"></ul>
+  </div>
+</div>
+
+<div id="inline-delete-modal"
+     data-message-template="<%= t('creatives.inline_editor.delete_modal.message', name: '__NAME__') %>"
+     data-name-placeholder="__NAME__"
+     data-default-name="<%= t('creatives.inline_editor.delete_modal.default_name') %>"
+     style="display:none;position:fixed;top:0;left:0;width:100vw;height:100vh;z-index:1000;align-items:center;justify-content:center;">
+  <div class="popup-box" style="min-width:320px;max-width:90vw;">
+    <p id="inline-delete-message" style="margin:0 0 1.5em 0;font-size:1.05em;line-height:1.6;"></p>
+    <div style="display:flex;justify-content:flex-end;gap:0.5em;">
+      <button type="button" id="inline-delete-cancel" class="btn btn-secondary">
+        <%= t('creatives.inline_editor.delete_modal.cancel') %>
+      </button>
+      <button type="button" id="inline-delete-with-children-confirm" class="btn btn-danger">
+        <%= t('creatives.inline_editor.delete_modal.delete_with_children') %>
+      </button>
+      <button type="button" id="inline-delete-only-confirm" class="btn btn-primary">
+        <%= t('creatives.inline_editor.delete_modal.delete_only_this') %>
+      </button>
+    </div>
   </div>
 </div>

--- a/config/locales/creatives.en.yml
+++ b/config/locales/creatives.en.yml
@@ -95,6 +95,12 @@ en:
       no_permission: "You do not have permission to perform this action."
     inline_editor:
       placeholder: "Describe the creative…"
+      delete_modal:
+        message: "Are you sure you want to delete \"__NAME__\"?"
+        default_name: "this Creative"
+        cancel: "Cancel"
+        delete_with_children: "Delete sub-creatives too"
+        delete_only_this: "Delete only this Creative"
     edit_title: "Edit creative"
     edit:
       inline_editor_only_html: "Editing creatives now happens directly in the inline editor."

--- a/config/locales/creatives.ko.yml
+++ b/config/locales/creatives.ko.yml
@@ -95,6 +95,12 @@ ko:
       no_permission: "이 작업을 수행할 권한이 없습니다."
     inline_editor:
       placeholder: "크리에이티브를 설명해주세요…"
+      delete_modal:
+        message: '"__NAME__" 을 정말 삭제하시겠습니까?'
+        default_name: "이 크리에이티브"
+        cancel: "취소"
+        delete_with_children: "하위 모두 삭제"
+        delete_only_this: "이 크리에이티브만 삭제"
     edit_title: "크리에이티브 수정"
     edit:
       inline_editor_only_html: "크리에이티브 수정은 인라인 편집기에서 바로 진행하세요."


### PR DESCRIPTION
## Summary
- merge the separate inline editor delete buttons into a single entry point that launches a confirmation modal with cancel, delete-only, and delete-with-children actions
- update `creative_row_editor.js` so the modal text reflects the current creative name and the buttons invoke the existing destroy paths
- add localized strings for the new modal content in both English and Korean

## Testing
- `./bin/rubocop -a`
- `bin/rails test`
- `bin/rails test:system` *(fails: Selenium cannot download Chrome/chromedriver inside the container)*

## Original User's Requirements
- inline editor 에서 현재 크리에이티브만 삭제하는 버튼과 하위 크리에이티브 모두 삭제 하는 버튼을 하나로 합친다.
- 합쳐진 그 삭제 버튼을 눌렀을때, 삭제 팝얼을 띄운다.
- "{크리에이티브 이름}" 을 정말 삭제하시겠습니까? 라는 메세지를 표시한다.
- "취소", "하위 모두 삭제", "이 크리에이티브만 삭제" 세개의 버튼을 하단에 오른쪽 정렬로 표시한다.
- 각 버튼을 눌렀을때 해당 기능을 한다.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dacebc4e88326a03f4c10aefcac73)