### PR TITLE
Add popup menu delete actions in inline editor

### DIFF
--- a/app/views/creatives/_inline_edit_form.html.erb
+++ b/app/views/creatives/_inline_edit_form.html.erb
@@ -36,14 +36,29 @@
           &nbsp;
           <%= svg_tag 'hierarchy-parent.svg',class: 'icon-svg', width: 24, height: 24 %>
         </button>
-        <button type="button" id="inline-delete" class="creative-action-btn danger-link" title="<%= t('creatives.index.delete_only_this') %>" data-confirm="<%= t('creatives.index.are_you_sure_delete_only_this') %>">
-          &nbsp;<%= svg_tag 'trash-bold-outline.svg',class: 'icon-svg', width: 24, height: 24 %>
-        </button>
-        <button type="button" id="inline-delete-with-children" class="creative-action-btn danger-link" title="<%= t('creatives.index.delete_with_children') %>" data-confirm="<%= t('creatives.index.are_you_sure_delete_with_children') %>">
-          &nbsp;
-          <%= svg_tag 'hierarchy-child.svg',class: 'icon-svg', width: 16, height: 16 %>
-          <%= svg_tag 'trash-bold-outline.svg',class: 'icon-svg', width: 24, height: 24 %>
-        </button>
+        <% inline_delete_button_content = capture do %>
+          &nbsp;<%= svg_tag 'trash-bold-outline.svg', class: 'icon-svg', width: 24, height: 24 %>
+        <% end %>
+        <%= render PopupMenuComponent.new(
+              button_content: inline_delete_button_content,
+              button_classes: 'creative-action-btn danger-link',
+              menu_id: 'inline-delete-popup-menu'
+            ) do %>
+          <button type="button"
+                  id="inline-delete"
+                  class="popup-menu-item danger-link"
+                  title="<%= t('creatives.index.delete_only_this') %>"
+                  data-confirm="<%= t('creatives.index.are_you_sure_delete_only_this') %>">
+            <%= t('creatives.index.delete_only_this') %>
+          </button>
+          <button type="button"
+                  id="inline-delete-with-children"
+                  class="popup-menu-item danger-link"
+                  title="<%= t('creatives.index.delete_with_children') %>"
+                  data-confirm="<%= t('creatives.index.are_you_sure_delete_with_children') %>">
+            <%= t('creatives.index.delete_with_children') %>
+          </button>
+        <% end %>
         <button type="button" id="inline-link" class="creative-action-btn" title="<%= t('creatives.index.link') %>">
           &nbsp;<%= svg_tag 'link.svg',class: 'icon-svg', width: 24, height: 24 %>
         </button>


### PR DESCRIPTION
## Summary
- replace the two inline editor delete buttons with a single PopupMenu-based action so users can choose whether to delete only the current creative or include children.

## Testing
- `./bin/rubocop -a`
- `bundle exec rails test`
- `bundle exec rails test:system` *(fails: Unable to obtain chromedriver; Selenium manager cannot download Chrome binaries in this environment)*

## Original User's Requirements
- inline editor 에서 현재 크리에이티브만 삭제하는 버튼과 하위 크리에이티브 모두 삭제 하는 버튼을 하나로 합친다.
- 합쳐진 그 삭제 버튼을 눌렀을때,
- "하위 모두 삭제", "이 크리에이티브만 삭제" 팝업메뉴가 버튼 하단에 나타난다. 팝업메뉴는 이미 있는 컴포넌트를 사용한다.
- 각 버튼을 눌렀을때 해당 기능을 한다.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dbc0adae48326ac9af0e55da558ca)