### PR TITLE
Top align creative row controls

### DIFF
--- a/app/assets/stylesheets/creatives.css
+++ b/app/assets/stylesheets/creatives.css
@@ -131,7 +131,7 @@
 
 .creative-row-start {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
 }
 
 .creative-loading-indicator {
@@ -213,7 +213,7 @@
     visibility: hidden;
     display: flex;
     align-items: center;
-    align-self: stretch;
+    align-self: flex-start;
 }
 
 .creative-row:hover .creative-row-actions {
@@ -290,7 +290,7 @@
 .creative-row {
     display: flex;
     justify-content: space-between;
-    align-items: center;
+    align-items: flex-start;
 }
 
 .creative-row.selected {

--- a/app/assets/stylesheets/creatives.css
+++ b/app/assets/stylesheets/creatives.css
@@ -200,6 +200,7 @@
     font-size: 14px;
     margin-right: 4px;
     visibility: hidden;
+    align-self: flex-start;
 }
 
 .add-creative-btn {
@@ -212,7 +213,7 @@
 .creative-row-actions {
     visibility: hidden;
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     align-self: flex-start;
 }
 
@@ -291,6 +292,7 @@
     display: flex;
     justify-content: space-between;
     align-items: flex-start;
+    padding-top: 4px; /* keep buttons visually centered with the first line */
 }
 
 .creative-row.selected {


### PR DESCRIPTION
## Summary
- align the creative row container, start section, and action column so that controls stay pinned to the top when the creative text wraps across multiple lines
- keep the action buttons from stretching to the row height by pinning them to the top of the flex layout

## Testing
- `./bin/rubocop -a`
- `bundle exec rails test`
- `bundle exec rails test:system` *(fails: Selenium cannot download ChromeDriver in this environment)*

## Original User's Requirements
- Clreative 가 매우 긴 경우, creative-row 의 앞에 edit 버튼과 expand 버튼, creative-row 뒤쪽의 코멘트 버튼은 수직적으로 중간으로 정렬된다. 그렇게 하지 않고, 해당 버튼 모두 상단에 정렬되도록 한다.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dbfa176b88326b6989353e50cb7d7)