### PR TITLE
Implement comment search pagination

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -15,8 +15,8 @@ class CommentsController < ApplicationController
       Current.user.id
     )
     if params[:search].present?
-      search_term = ActiveRecord::Base.sanitize_sql_like(params[:search].to_s.strip)
-      scope = scope.where("comments.content ILIKE ?", "%#{search_term}%")
+      search_term = ActiveRecord::Base.sanitize_sql_like(params[:search].to_s.strip.downcase)
+      scope = scope.where("LOWER(comments.content) LIKE ?", "%#{search_term}%")
     end
     scope = scope.order(created_at: :desc)
     @comments = scope.offset((page - 1) * per_page).limit(per_page).to_a

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -14,7 +14,11 @@ class CommentsController < ApplicationController
       Current.user.id,
       Current.user.id
     )
-                              .order(created_at: :desc)
+    if params[:search].present?
+      search_term = ActiveRecord::Base.sanitize_sql_like(params[:search].to_s.strip)
+      scope = scope.where("comments.content ILIKE ?", "%#{search_term}%")
+    end
+    scope = scope.order(created_at: :desc)
     @comments = scope.offset((page - 1) * per_page).limit(per_page).to_a
     pointer = CommentReadPointer.find_by(user: Current.user, creative: @creative)
     last_read_comment_id = pointer&.last_read_comment_id

--- a/app/javascript/controllers/comments/form_controller.js
+++ b/app/javascript/controllers/comments/form_controller.js
@@ -92,7 +92,6 @@ export default class extends Controller {
     this.submitTarget.innerHTML = this.defaultSubmitHTML
     if (this.cancelTarget) this.cancelTarget.style.display = 'none'
     this.presenceController?.clearManualTypingMessage()
-    this.listController?.clearSearchFilter()
   }
 
   handleSubmit(event) {
@@ -171,13 +170,7 @@ export default class extends Controller {
   handleSearch(event) {
     event.preventDefault()
     const query = this.textareaTarget.value.trim()
-    if (!query) {
-      this.listController?.clearSearchFilter()
-      this.presenceController?.setManualTypingMessage(this.element.dataset.searchEmptyText)
-      return
-    }
     this.presenceController?.clearManualTypingMessage()
-    this.listController?.filterCommentsByQuery(query)
-    this.listController?.listTarget.scrollTo({ top: 0 })
+    this.listController?.applySearchQuery(query || null)
   }
 }


### PR DESCRIPTION
## Summary
- add server-side filtering for comments when a search term is provided
- refresh the chat list through a shared search entry point so pagination respects the current query
- allow clearing the search to reload the full chat without prompting for a search term

## Testing
- `./bin/rubocop -a` *(fails: missing bundle dependencies in the environment)*
- `bundle exec rails test` *(fails: rails executable missing before bundling)*
- `bundle exec rails test:system` *(fails: rails executable missing before bundling)*

## Original User's Requirements
- 채팅 창에서 검색어를 입력하고 "검색" 버튼을 누르면 해당 채팅에서 해당 검색어로 입력되어서 보여야 해.
- 그리고 검색어를 다 지우고 "검색"을 누르면 다시 일반 채팅이 보여야 해.
- 검색상태에서 채팅창을 위로 스크롤하면 해당 검색어로 검색된 결과만 로딩되어야 해.
- 검색어를 입력하지 않은 상태에서는 일반모드로 넘어가니까 "검색"을 눌렀을때 검색어를 입력하라는 메세지는 안보여줘도 되기 때문에 삭제해줘.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ea18afaac832687a282e9654bf1c9)