### PR TITLE
Fix background color application in Lexical editor

### DIFF
--- a/app/javascript/components/InlineLexicalEditor.jsx
+++ b/app/javascript/components/InlineLexicalEditor.jsx
@@ -633,11 +633,11 @@ function Toolbar({onPromptForLink}) {
         color={bgColor}
         onChange={(value) => {
           setBgColor(value)
-          applyTextStyle({backgroundColor: value})
+          applyTextStyle({"background-color": value})
         }}
         onClear={() => {
           setBgColor(DEFAULT_BG_COLOR)
-          applyTextStyle({backgroundColor: ""})
+          applyTextStyle({"background-color": ""})
         }}
       />
       <span className="lexical-toolbar-separator" aria-hidden="true" />


### PR DESCRIPTION
## Summary
- ensure the Lexical toolbar applies text background colors using the correct CSS property name

## Testing
- not run (not requested)

## Original User's Requirements
- Lexical Editor 에서 Text 배경색 지정하는 것이 작동되지 않아. 수정해줘.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ec7ae8a4083269154f7c35f7c565d)