### PR TITLE
Add image attachment support to chat comments

### DIFF
--- a/app/assets/stylesheets/comments_popup.css
+++ b/app/assets/stylesheets/comments_popup.css
@@ -155,6 +155,7 @@
 #move-comments-btn,
 #search-comments-btn,
 #voice-comments-btn,
+#attach-image-btn,
 #cancel-edit-btn,
 #new-comment-form button[type="submit"] {
     margin-top: 0.5em;
@@ -163,6 +164,7 @@
 #move-comments-btn,
 #search-comments-btn,
 #voice-comments-btn,
+#attach-image-btn,
 #cancel-edit-btn {
     float: right;
     margin-right: 0.5em;
@@ -204,6 +206,42 @@
     transform: translateY(4px);
     transition: opacity 0.2s ease, transform 0.2s ease;
     pointer-events: none;
+}
+
+.comment-attachment-list {
+    clear: both;
+    margin-top: 0.25em;
+    font-size: 0.9em;
+    color: var(--color-muted);
+}
+
+.comment-attachment-item {
+    display: inline-block;
+    background: var(--color-section-bg);
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    padding: 0.2em 0.4em;
+    margin-right: 0.25em;
+    margin-top: 0.2em;
+}
+
+.comment-attachments {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4em;
+    margin-top: 0.5em;
+}
+
+.comment-attachment-link {
+    display: inline-block;
+    max-width: 100%;
+}
+
+.comment-attachment-image {
+    max-width: 100%;
+    height: auto;
+    border-radius: 4px;
+    border: 1px solid var(--color-border);
 }
 
 .comment-copy-notice.visible {

--- a/app/assets/stylesheets/comments_popup.css
+++ b/app/assets/stylesheets/comments_popup.css
@@ -216,13 +216,25 @@
 }
 
 .comment-attachment-item {
-    display: inline-block;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35em;
     background: var(--color-section-bg);
     border: 1px solid var(--color-border);
     border-radius: 4px;
     padding: 0.2em 0.4em;
     margin-right: 0.25em;
     margin-top: 0.2em;
+}
+
+.comment-attachment-remove {
+    border: none;
+    background: transparent;
+    color: var(--color-muted);
+    cursor: pointer;
+    font-size: 1em;
+    line-height: 1;
+    padding: 0 0.1em;
 }
 
 .comment-attachments {

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -47,6 +47,7 @@ class CommentsController < ApplicationController
       if @comment.content.match?(/\A@gemini\b/i)
         Comments::GeminiResponderJob.perform_later(@comment.id, @creative.id)
       end
+      @comment = Comment.with_attached_images.find(@comment.id)
       render partial: "comments/comment", locals: { comment: @comment }, status: :created
     else
       render json: { errors: @comment.errors.full_messages }, status: :unprocessable_entity
@@ -56,6 +57,7 @@ class CommentsController < ApplicationController
   def update
     if @comment.user == Current.user
       if @comment.update(comment_params)
+        @comment = Comment.with_attached_images.find(@comment.id)
         render partial: "comments/comment", locals: { comment: @comment }
       else
         render json: { errors: @comment.errors.full_messages }, status: :unprocessable_entity

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -14,6 +14,7 @@ class CommentsController < ApplicationController
       Current.user.id,
       Current.user.id
     )
+    scope = scope.with_attached_images
     if params[:search].present?
       search_term = ActiveRecord::Base.sanitize_sql_like(params[:search].to_s.strip.downcase)
       scope = scope.where("LOWER(comments.content) LIKE ?", "%#{search_term}%")
@@ -244,7 +245,7 @@ class CommentsController < ApplicationController
   end
 
   def comment_params
-    params.require(:comment).permit(:content, :private)
+    params.require(:comment).permit(:content, :private, images: [])
   end
 
   def broadcast_move_removal(comment, original_creative)

--- a/app/javascript/controllers/comments/form_controller.js
+++ b/app/javascript/controllers/comments/form_controller.js
@@ -20,7 +20,7 @@ export default class extends Controller {
     this.creativeId = null
     this.editingId = null
     this.sending = false
-    this.cachedImageFiles = []
+    this.cachedImageFiles = null
 
     this.handleSubmit = this.handleSubmit.bind(this)
     this.handleSend = this.handleSend.bind(this)
@@ -346,9 +346,9 @@ export default class extends Controller {
   handleImageChange() {
     if (!this.imageInputTarget) return
     const newFiles = Array.from(this.imageInputTarget.files || [])
-    const existingFiles = this.cachedImageFiles?.length ? this.cachedImageFiles : this.currentImageFiles()
+    const existingFiles = this.cachedImageFiles ?? []
     this.setImageFiles([ ...existingFiles, ...newFiles ])
-    this.cachedImageFiles = []
+    this.cachedImageFiles = null
     this.updateAttachmentList()
   }
 
@@ -393,7 +393,7 @@ export default class extends Controller {
   }
 
   clearImageAttachments() {
-    this.cachedImageFiles = []
+    this.cachedImageFiles = null
     this.setImageFiles([])
     this.updateAttachmentList()
   }

--- a/app/javascript/controllers/comments/form_controller.js
+++ b/app/javascript/controllers/comments/form_controller.js
@@ -123,6 +123,7 @@ export default class extends Controller {
       this.privateCheckboxTarget.checked = !!isPrivate
       this.privateCheckboxTarget.dispatchEvent(new Event('change'))
     }
+    this.clearImageAttachments()
     this.submitTarget.textContent = this.element.dataset.updateCommentText
     if (this.cancelTarget) this.cancelTarget.style.display = ''
     this.focusTextarea()
@@ -134,9 +135,7 @@ export default class extends Controller {
     this.submitTarget.innerHTML = this.defaultSubmitHTML
     if (this.cancelTarget) this.cancelTarget.style.display = 'none'
     this.presenceController?.clearManualTypingMessage()
-    this.cachedImageFiles = []
-    this.setImageFiles([])
-    this.updateAttachmentList()
+    this.clearImageAttachments()
   }
 
   handleSubmit(event) {
@@ -398,6 +397,18 @@ export default class extends Controller {
     return Array.from(this.imageInputTarget.files || [])
   }
 
+  clearImageAttachments() {
+    this.cachedImageFiles = []
+    this.setImageFiles([])
+    this.updateAttachmentList()
+  }
+
+  removeImageAttachment(index) {
+    const files = this.currentImageFiles().filter((_, fileIndex) => fileIndex !== index)
+    this.setImageFiles(files)
+    this.updateAttachmentList()
+  }
+
   updateAttachmentList() {
     if (!this.attachmentListTarget) return
     const files = this.currentImageFiles()
@@ -408,10 +419,19 @@ export default class extends Controller {
     }
 
     this.attachmentListTarget.style.display = ''
-    files.forEach((file) => {
+    files.forEach((file, index) => {
       const item = document.createElement('span')
       item.className = 'comment-attachment-item'
       item.textContent = file.name
+
+      const removeButton = document.createElement('button')
+      removeButton.type = 'button'
+      removeButton.className = 'comment-attachment-remove'
+      removeButton.setAttribute('aria-label', `Remove ${file.name}`)
+      removeButton.textContent = '×'
+      removeButton.addEventListener('click', () => this.removeImageAttachment(index))
+
+      item.appendChild(removeButton)
       this.attachmentListTarget.appendChild(item)
     })
   }

--- a/app/javascript/controllers/comments/form_controller.js
+++ b/app/javascript/controllers/comments/form_controller.js
@@ -152,6 +152,8 @@ export default class extends Controller {
     this.sending = true
     this.presenceController?.stoppedTyping()
 
+    const wasPrivate = this.privateCheckboxTarget?.checked ?? false
+
     const formData = new FormData(this.formTarget)
     let url = `/creatives/${this.creativeId}/comments`
     let method = 'POST'
@@ -174,7 +176,11 @@ export default class extends Controller {
       .then((html) => {
         const wasEditing = this.editingId
         this.resetForm()
-        this.renderCommentHtml(html, { replaceExisting: wasEditing })
+        if (wasPrivate || wasEditing) {
+          this.renderCommentHtml(html, { replaceExisting: wasEditing })
+        } else {
+          this.removePlaceholder()
+        }
         this.listController?.scrollToBottom()
         this.listController?.updateStickiness()
         this.listController?.markCommentsRead()
@@ -440,8 +446,7 @@ export default class extends Controller {
     const commentElement = doc.querySelector('.comment-item')
     if (!commentElement) return
 
-    const placeholder = listElement.querySelector('#no-comments')
-    if (placeholder) placeholder.remove()
+    this.removePlaceholder()
 
     const existing = listElement.querySelector(`#${commentElement.id}`)
     if (existing) {
@@ -454,5 +459,11 @@ export default class extends Controller {
     if (replaceExisting) {
       this.listController?.markCommentsRead()
     }
+  }
+
+  removePlaceholder() {
+    const listElement = document.getElementById('comments_list')
+    const placeholder = listElement?.querySelector('#no-comments')
+    if (placeholder) placeholder.remove()
   }
 }

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -4,10 +4,12 @@ class Comment < ApplicationRecord
   belongs_to :approver, class_name: "User", optional: true
   belongs_to :action_executed_by, class_name: "User", optional: true
 
+  has_many_attached :images, dependent: :purge_later
+
   before_validation :assign_default_user, on: :create
   before_save :apply_link_previews, if: :should_apply_link_previews?
 
-  validates :content, presence: true
+  validates :content, presence: true, unless: -> { images.attached? }
 
   after_create_commit :broadcast_create, :notify_write_users, :notify_mentions, :broadcast_badges
   after_update_commit :broadcast_update

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -57,8 +57,14 @@
     <div class="comment-attachments">
       <% comment.images.each do |image| %>
         <% preview_image = image.variable? ? image.variant(resize_to_limit: [ 800, 800 ]) : image %>
-        <%= link_to url_for(image, only_path: true), target: '_blank', rel: 'noopener', class: 'comment-attachment-link' do %>
-          <%= image_tag url_for(preview_image, only_path: true), class: 'comment-attachment-image', alt: '', loading: 'lazy' %>
+        <% preview_image_path =
+             if preview_image.respond_to?(:processed)
+               rails_representation_path(preview_image, only_path: true)
+             else
+               rails_blob_path(preview_image, only_path: true)
+             end %>
+        <%= link_to rails_blob_path(image, only_path: true), target: '_blank', rel: 'noopener', class: 'comment-attachment-link' do %>
+          <%= image_tag preview_image_path, class: 'comment-attachment-image', alt: '', loading: 'lazy' %>
         <% end %>
       <% end %>
     </div>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -53,6 +53,16 @@
     </div>
   </div>
   <div class="comment-content"><%= comment.content %></div>
+  <% if comment.images.attached? %>
+    <div class="comment-attachments">
+      <% comment.images.each do |image| %>
+        <% preview_image = image.variable? ? image.variant(resize_to_limit: [ 800, 800 ]) : image %>
+        <%= link_to url_for(image), target: '_blank', rel: 'noopener', class: 'comment-attachment-link' do %>
+          <%= image_tag preview_image, class: 'comment-attachment-image', alt: '', loading: 'lazy' %>
+        <% end %>
+      <% end %>
+    </div>
+  <% end %>
   <% if comment.action.present? %>
     <div class="comment-action-block" data-comment-id="<%= comment.id %>">
       <details class="comment-action-details">

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -57,8 +57,8 @@
     <div class="comment-attachments">
       <% comment.images.each do |image| %>
         <% preview_image = image.variable? ? image.variant(resize_to_limit: [ 800, 800 ]) : image %>
-        <%= link_to url_for(image), target: '_blank', rel: 'noopener', class: 'comment-attachment-link' do %>
-          <%= image_tag preview_image, class: 'comment-attachment-image', alt: '', loading: 'lazy' %>
+        <%= link_to url_for(image, only_path: true), target: '_blank', rel: 'noopener', class: 'comment-attachment-link' do %>
+          <%= image_tag url_for(preview_image, only_path: true), class: 'comment-attachment-image', alt: '', loading: 'lazy' %>
         <% end %>
       <% end %>
     </div>

--- a/app/views/comments/_comments_popup.html.erb
+++ b/app/views/comments/_comments_popup.html.erb
@@ -26,12 +26,15 @@
   <div id="comments-list" data-comments--popup-target="list" data-comments--list-target="list"><%= t('app.loading') %></div>
   <div id="typing-indicator" data-comments--presence-target="typingIndicator"></div>
   <form id="new-comment-form" data-comments--popup-target="form" data-comments--form-target="form" style="display:none;">
-    <textarea class="shared-input-surface" name="comment[content]" data-comments--form-target="textarea" data-comments--presence-target="textarea" data-comments--mention-menu-target="textarea" rows="2" required enterkeyhint="send"></textarea>
+    <textarea class="shared-input-surface" name="comment[content]" data-comments--form-target="textarea" data-comments--presence-target="textarea" data-comments--mention-menu-target="textarea" rows="2" enterkeyhint="send"></textarea>
+    <input type="file" id="comment-images" name="comment[images][]" accept="image/*" multiple data-comments--form-target="imageInput" style="display:none;" />
     <label><input type="checkbox" id="comment-private" data-comments--form-target="privateCheckbox" data-comments--presence-target="privateCheckbox" name="comment[private]" /> <%= t('comments.private') %></label>
     <button class="creative-action-btn" type="submit" data-comments--form-target="submit"><%= svg_tag 'send.svg', class: 'send-icon' %></button>
     <button class="creative-action-btn" id="move-comments-btn" data-comments--form-target="moveButton" type="button" disabled><%= t('comments.move_button') %></button>
     <button class="creative-action-btn" id="search-comments-btn" data-comments--form-target="searchButton" type="button"><%= t('comments.search_button') %></button>
     <button class="creative-action-btn" id="voice-comments-btn" data-comments--form-target="voiceButton" type="button" data-voice-state="idle"><%= t('comments.voice_button') %></button>
+    <button class="creative-action-btn" id="attach-image-btn" data-comments--form-target="imageButton" type="button"><%= t('comments.image_button') %></button>
     <button class="creative-action-btn" id="cancel-edit-btn" data-comments--form-target="cancel" type="button" style="display:none;"><%= t('app.cancel') %></button>
+    <div class="comment-attachment-list" data-comments--form-target="attachmentList" aria-live="polite"></div>
   </form>
 </div>

--- a/config/locales/comments.en.yml
+++ b/config/locales/comments.en.yml
@@ -43,6 +43,7 @@ en:
     convert_system_message_default_title: "Untitled"
     system_user: "System"
     search_button: "Search"
+    image_button: "Image"
     search_empty_prompt: "Please enter a search term in the chat message field."
     voice_button: "Voice"
     voice_stop: "Stop"

--- a/config/locales/comments.ko.yml
+++ b/config/locales/comments.ko.yml
@@ -43,6 +43,7 @@ ko:
     convert_system_message_default_title: "제목 없음"
     system_user: "System"
     search_button: "검색"
+    image_button: "이미지"
     search_empty_prompt: "검색어 를 채팅 메세지 입력폼에 입력하시오"
     voice_button: "음성"
     voice_stop: "중지"

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -161,6 +161,22 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
     assert_nil comment.approver_id
   end
 
+  test "user can attach images to a comment" do
+    assert_difference -> { ActiveStorage::Attachment.where(record_type: "Comment").count }, 1 do
+      post creative_comments_path(@creative), params: {
+        comment: {
+          content: "",
+          images: [ fixture_file_upload(file_fixture("small.png"), "image/png") ]
+        }
+      }
+
+      assert_response :created
+    end
+
+    comment = @creative.comments.order(:id).last
+    assert comment.images.attached?
+  end
+
   test "commenters cannot set approval attributes when updating" do
     comment = @creative.comments.create!(content: "Needs approval", user: @user)
 

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -177,6 +177,22 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
     assert comment.images.attached?
   end
 
+  test "rejects non-image attachments on comments" do
+    assert_no_difference [ "Comment.count", "ActiveStorage::Attachment.count", "ActiveStorage::Blob.count" ] do
+      post creative_comments_path(@creative), params: {
+        comment: {
+          content: "",
+          images: [ fixture_file_upload(file_fixture("invalid.txt"), "text/plain") ]
+        }
+      }
+
+      assert_response :unprocessable_entity
+    end
+
+    errors = JSON.parse(@response.body)["errors"]
+    assert_includes errors, "Images must be an image"
+  end
+
   test "commenters cannot set approval attributes when updating" do
     comment = @creative.comments.create!(content: "Needs approval", user: @user)
 

--- a/test/system/creative_inline_edit_test.rb
+++ b/test/system/creative_inline_edit_test.rb
@@ -73,7 +73,11 @@ class CreativeInlineEditTest < ApplicationSystemTestCase
   end
 
   def attach_inline_image(file_path)
-    input = find("input[type='file'][accept='image/*']", visible: false, wait: 5)
+    input = inline_editor_container.find(
+      "input[type='file'][accept='image/*']",
+      visible: false,
+      wait: 5
+    )
     input.attach_file(file_path)
     assert_selector ".lexical-attachment", wait: 10
     assert_selector ".lexical-attachment.is-uploading", count: 0, wait: 10


### PR DESCRIPTION
## Summary
- allow comments to include image attachments from drag-and-drop or the new image button in the chat popup
- show selected image names before sending and render uploaded images inside comment threads
- permit comments to save image attachments on the backend and cover the workflow with a controller test

## Testing
- ./bin/rubocop -a
- bundle exec rails test
- bundle exec rails test:system *(fails: Selenium manager cannot download Chrome/chromedriver in this environment)*

## Original User's Requirements
- 채팅창에 이미지 파일을 첨부 할 수 있게 해줘.
  - 이미지를 긁어 와서 텍스트 입력 상자가 있는 영역에 떨어뜨려도 첨부가 돼
  - 검색 버튼 옆에 "이미지" 버튼을 넣어서 그것을 눌러서 첨부할 수도 있어

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ed12197d88326a71c7d8bec4f5ce8)