### PR TITLE
Reduce Lexical editor line height

### DIFF
--- a/app/assets/stylesheets/actiontext.css
+++ b/app/assets/stylesheets/actiontext.css
@@ -122,6 +122,7 @@
 .lexical-content-editable {
   min-height: 6rem;
   outline: none;
+  line-height: 1.5;
   white-space: pre-wrap;
   word-break: break-word;
 }
@@ -136,6 +137,7 @@
 
 .lexical-paragraph {
   margin: 0 0 0.65rem 0;
+  line-height: 1.5;
 }
 
 .lexical-heading-h1,
@@ -164,6 +166,7 @@
 
 .lexical-list-item {
   margin: 0.35rem 0;
+  line-height: 1.5;
 }
 
 .lexical-link {


### PR DESCRIPTION
## Summary
- set consistent 1.5 line height for Lexical content, paragraphs, and list items to reduce spacing

## Testing
- ./bin/rubocop -a
- rails test
- rails test:system (fails: chromedriver could not be obtained in the environment)

## Original User's Requirements
- Lexical Text editor 의 line height 를 일반적인 수준으로 줄여줘.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ed306e0c0832693332cc2f85db173)