### PR TITLE
Add spacing to empty inbox message

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -407,9 +407,13 @@ button {
     cursor: pointer;
 }
 
+#inbox-panel {
+    --inbox-spacing: 0.75em;
+}
+
 .inbox-item {
     border-bottom: 1px solid var(--color-border);
-    padding: 0.75em;
+    padding: var(--inbox-spacing);
 }
 
 .inbox-item:last-child {
@@ -418,6 +422,10 @@ button {
 
 .inbox-item .actions button {
     margin-right: 0.5em;
+}
+
+.inbox-empty {
+    padding: var(--inbox-spacing);
 }
 
 #inbox-menu-btn {


### PR DESCRIPTION
## Summary
- add a shared inbox spacing custom property scoped to the inbox panel
- apply the shared spacing to inbox items and the empty state message for consistent padding

## Testing
- Not run (not requested)

## Original User's Requirements
- inbox 리스트에 메세지가 없을 경우, 메세지가 없습니다를 인박스 메세지 상자에 적용된 패딩(또는 마진)만큼 여백을 줘야 일관성이 있어 보여. 추가해줘. 해당 값은 동일한 하나의 값을 사용할 수 있도록 해줘.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fd1baf74c8326a4183aa577722052)