### PR TITLE
Add spacing between plan form inputs

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -326,6 +326,13 @@ button {
     padding: 0.5em;
 }
 
+.plan-form-container form {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    max-width: min(28rem, 100%);
+}
+
 .plan-bar {
     position: absolute;
     height: 20px;


### PR DESCRIPTION
## Summary
- add vertical spacing to the plan creation form to mirror the stacked layout used on the sign-up page

## Testing
- not run (not requested)

## Original User's Requirements
- 계획을 눌렀을때 표시되는 계획입력 폼의 각 항목들을 SignUp 페이지처럼 위아래 약간의 여백을 추가해.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fd249ccec8326a8d5a0524c70ba63)