### PR TITLE
Define shared paragraph spacing variable

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -138,7 +138,7 @@ textarea:focus-visible {
 .stacked-form {
     display: flex;
     flex-direction: column;
-    gap: 0.75rem;
+    gap: var(--paragraph-space-1);
     max-width: min(28rem, 100%);
 }
 
@@ -329,7 +329,7 @@ button {
 .plan-form-container form {
     display: flex;
     flex-direction: column;
-    gap: 0.75rem;
+    gap: var(--paragraph-space-1);
     max-width: min(28rem, 100%);
 }
 
@@ -415,7 +415,7 @@ button {
 }
 
 #inbox-panel {
-    --inbox-spacing: 0.75em;
+    --inbox-spacing: var(--paragraph-space-1);
 }
 
 .inbox-item {

--- a/app/assets/stylesheets/dark_mode.css
+++ b/app/assets/stylesheets/dark_mode.css
@@ -18,6 +18,7 @@
   --color-badge-bg: red;
   --color-badge-text: white;
   --max-width: 960px;
+  --paragraph-space-1: 0.75rem;
 }
 
 body.dark-mode {


### PR DESCRIPTION
## Summary
- add a paragraph-space-1 spacing token to the global CSS variables
- reuse the shared spacing variable for stacked authentication forms, the plan form, and inbox spacing

## Testing
- Not run (not requested)

## Original User's Requirements
- unify plan form gap, inbox-space var, user sign-in/sign-up form gap into a system-wide paragraph-space-1


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fd466e01c832683c46e2d3a5c88c2)