### PR TITLE
Add user contact management tab

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -506,3 +506,118 @@ input[type="password"] {
     max-width: 320px;
 }
 
+.profile-actions {
+    margin-top: 1em;
+}
+
+/* Tabs */
+.tab-list {
+    display: flex;
+    gap: 0.5em;
+    margin: 1em 0;
+    flex-wrap: wrap;
+}
+
+.tab-button {
+    border: 1px solid var(--border-color, #ddd);
+    background: #f7f7f7;
+    padding: 0.5em 1em;
+    border-radius: 6px;
+    cursor: pointer;
+}
+
+.tab-button.active {
+    background: var(--color-accent, #4f46e5);
+    color: #fff;
+    border-color: var(--color-accent, #4f46e5);
+}
+
+.tab-panels {
+    margin-top: 1em;
+}
+
+.tab-panel {
+    display: none;
+}
+
+.tab-panel.active {
+    display: block;
+}
+
+/* Contact management */
+.contact-add-form {
+    margin: 1em 0;
+}
+
+.contact-add-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1em;
+    align-items: flex-end;
+}
+
+.contact-field label {
+    display: block;
+    margin-bottom: 0.25em;
+}
+
+.contact-field input[type="email"] {
+    min-width: 240px;
+}
+
+.table-scroll {
+    overflow-x: auto;
+}
+
+.contacts-table {
+    width: 100%;
+    min-width: 720px;
+    border-collapse: collapse;
+}
+
+.contacts-table th,
+.contacts-table td {
+    padding: 0.5em;
+    text-align: left;
+    border-bottom: 1px solid #e5e7eb;
+    vertical-align: top;
+}
+
+.creative-cell {
+    min-width: 200px;
+}
+
+.creative-chip {
+    display: inline-block;
+    background: #f3f4f6;
+    border-radius: 999px;
+    padding: 0.2em 0.6em;
+    margin: 0 0.25em 0.25em 0;
+    white-space: nowrap;
+    color: inherit;
+    text-decoration: none;
+    border: 1px solid #e5e7eb;
+}
+
+.contact-pagination {
+    margin-top: 1em;
+    display: flex;
+    align-items: center;
+    gap: 0.75em;
+}
+
+.pagination-link {
+    color: var(--color-accent, #4f46e5);
+    text-decoration: none;
+}
+
+.pagination-status {
+    color: #6b7280;
+}
+
+@media (max-width: 768px) {
+    .contacts-table {
+        min-width: 600px;
+    }
+}
+

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -513,23 +513,35 @@ input[type="password"] {
 /* Tabs */
 .tab-list {
     display: flex;
-    gap: 0.5em;
-    margin: 1em 0;
+    gap: 0.25em;
+    margin: 1.25em 0 0;
     flex-wrap: wrap;
+    border-bottom: 1px solid var(--color-border);
+    padding: 0 0.25em;
 }
 
 .tab-button {
-    border: 1px solid var(--border-color, #ddd);
-    background: #f7f7f7;
+    border: 1px solid var(--color-border);
+    background: var(--color-bg);
+    color: var(--color-text);
     padding: 0.5em 1em;
-    border-radius: 6px;
+    border-radius: 8px 8px 0 0;
     cursor: pointer;
+    font-weight: 600;
+    border-bottom: none;
+    box-shadow: inset 0 -1px 0 var(--color-border);
 }
 
 .tab-button.active {
-    background: var(--color-accent, #4f46e5);
-    color: #fff;
-    border-color: var(--color-accent, #4f46e5);
+    background: var(--color-section-bg, var(--color-bg));
+    color: var(--color-text);
+    box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.05);
+}
+
+.tab-button:hover,
+.tab-button:focus-visible {
+    filter: brightness(var(--hover-brightness));
+    outline: none;
 }
 
 .tab-panels {
@@ -589,14 +601,20 @@ input[type="password"] {
 
 .creative-chip {
     display: inline-block;
-    background: #f3f4f6;
+    background: var(--color-chip-bg, var(--color-complete));
+    color: var(--color-text);
     border-radius: 999px;
     padding: 0.2em 0.6em;
     margin: 0 0.25em 0.25em 0;
     white-space: nowrap;
-    color: inherit;
     text-decoration: none;
-    border: 1px solid #e5e7eb;
+    border: 1px solid var(--color-border);
+}
+
+.creative-chip:hover,
+.creative-chip:focus-visible {
+    filter: brightness(var(--hover-brightness));
+    outline: none;
 }
 
 .contact-pagination {
@@ -606,9 +624,20 @@ input[type="password"] {
     gap: 0.75em;
 }
 
-.pagination-link {
-    color: var(--color-accent, #4f46e5);
+.pagination-button {
+    color: var(--color-text);
+    background: var(--color-bg);
     text-decoration: none;
+    padding: 0.35em 0.75em;
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    font-weight: 600;
+}
+
+.pagination-button:hover,
+.pagination-button:focus-visible {
+    filter: brightness(var(--hover-brightness));
+    outline: none;
 }
 
 .pagination-status {

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -557,26 +557,6 @@ input[type="password"] {
 }
 
 /* Contact management */
-.contact-add-form {
-    margin: 1em 0;
-}
-
-.contact-add-row {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 1em;
-    align-items: flex-end;
-}
-
-.contact-field label {
-    display: block;
-    margin-bottom: 0.25em;
-}
-
-.contact-field input[type="email"] {
-    min-width: 240px;
-}
-
 .table-scroll {
     overflow-x: auto;
 }

--- a/app/assets/stylesheets/dark_mode.css
+++ b/app/assets/stylesheets/dark_mode.css
@@ -12,6 +12,7 @@
   --color-border: #e0e0e0;
   --color-muted: #666;
   --color-complete: green;
+  --color-chip-bg: var(--color-complete);
   --color-drag-over: #e0e0e0;
   --color-drag-over-edge: #bbb;
   --hover-brightness: 90%;
@@ -32,6 +33,7 @@ body.dark-mode {
   --color-border: #333333;
   --color-muted: #aaaaaa;
   --color-complete: green;
+  --color-chip-bg: var(--color-complete);
   --color-drag-over: #383a40;
   --color-drag-over-edge: #777;
   --hover-brightness: 110%;
@@ -51,6 +53,7 @@ body.dark-mode {
     --color-border: #333333;
     --color-muted: #aaaaaa;
     --color-complete: green;
+    --color-chip-bg: var(--color-complete);
     --color-drag-over: #383a40;
     --color-drag-over-edge: #777;
     --hover-brightness: 110%;

--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -1,0 +1,41 @@
+class ContactsController < ApplicationController
+  def create
+    email = contact_params[:email].to_s.strip.downcase
+
+    if email.blank?
+      redirect_back fallback_location: user_path(Current.user, tab: "contacts"), alert: t("contacts.errors.email_required")
+      return
+    end
+
+    contact_user = User.find_by("LOWER(email) = ?", email)
+
+    unless contact_user
+      redirect_back fallback_location: user_path(Current.user, tab: "contacts"), alert: t("contacts.errors.not_found")
+      return
+    end
+
+    if contact_user == Current.user
+      redirect_back fallback_location: user_path(Current.user, tab: "contacts"), alert: t("contacts.errors.self_add")
+      return
+    end
+
+    contact = Contact.find_or_initialize_by(user: Current.user, contact_user: contact_user)
+    if contact.persisted? || contact.save
+      redirect_to user_path(Current.user, tab: "contacts"), notice: t("contacts.notices.added", name: contact_user.display_name)
+    else
+      redirect_back fallback_location: user_path(Current.user, tab: "contacts"), alert: contact.errors.full_messages.to_sentence
+    end
+  end
+
+  def destroy
+    contact = Current.user.contacts.find(params[:id])
+    contact.destroy
+    redirect_to user_path(Current.user, tab: "contacts", contact_page: params[:contact_page]), notice: t("contacts.notices.removed")
+  end
+
+  private
+
+  def contact_params
+    params.require(:contact).permit(:email)
+  end
+end

--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -1,41 +1,7 @@
 class ContactsController < ApplicationController
-  def create
-    email = contact_params[:email].to_s.strip.downcase
-
-    if email.blank?
-      redirect_back fallback_location: user_path(Current.user, tab: "contacts"), alert: t("contacts.errors.email_required")
-      return
-    end
-
-    contact_user = User.find_by("LOWER(email) = ?", email)
-
-    unless contact_user
-      redirect_back fallback_location: user_path(Current.user, tab: "contacts"), alert: t("contacts.errors.not_found")
-      return
-    end
-
-    if contact_user == Current.user
-      redirect_back fallback_location: user_path(Current.user, tab: "contacts"), alert: t("contacts.errors.self_add")
-      return
-    end
-
-    contact = Contact.find_or_initialize_by(user: Current.user, contact_user: contact_user)
-    if contact.persisted? || contact.save
-      redirect_to user_path(Current.user, tab: "contacts"), notice: t("contacts.notices.added", name: contact_user.display_name)
-    else
-      redirect_back fallback_location: user_path(Current.user, tab: "contacts"), alert: contact.errors.full_messages.to_sentence
-    end
-  end
-
   def destroy
     contact = Current.user.contacts.find(params[:id])
     contact.destroy
     redirect_to user_path(Current.user, tab: "contacts", contact_page: params[:contact_page]), notice: t("contacts.notices.removed")
-  end
-
-  private
-
-  def contact_params
-    params.require(:contact).permit(:email)
   end
 end

--- a/app/controllers/creative_shares_controller.rb
+++ b/app/controllers/creative_shares_controller.rb
@@ -36,6 +36,8 @@ class CreativeSharesController < ApplicationController
     share.permission = permission
     if share.save and not is_param_no_access
       @creative.create_linked_creative_for_user(user)
+      Contact.ensure(user: Current.user, contact_user: user)
+      Contact.ensure(user: @creative.user, contact_user: user)
       flash[:notice] = t("creatives.share.shared")
     else
       flash[:alert] = share.errors.full_messages.to_sentence

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -72,4 +72,27 @@ module ApplicationHelper
       )
     end.html_safe
   end
+
+  def creative_title_for_display(creative, length: 12)
+    return "" unless creative
+
+    description_body = creative.effective_origin.rich_text_description&.body
+    title = description_body ? description_body.to_plain_text : ""
+    title.strip.truncate(length, omission: "...")
+  end
+
+  def render_contact_creatives(creatives)
+    return content_tag(:span, t("contacts.none"), class: "text-muted") if creatives.blank?
+
+    safe_join(creatives.map do |creative|
+      link_to(creative_title_for_display(creative), creative_path(creative), class: "creative-chip")
+    end)
+  end
+
+  def render_last_login_for(user, last_login_map)
+    timestamp = last_login_map[user.id]
+    return t("users.table.last_login_unknown") unless timestamp
+
+    I18n.l(timestamp, format: :short)
+  end
 end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -16,6 +16,7 @@ import CommentsPopupController from "./comments/popup_controller"
 import ClickTargetController from "./click_target_controller"
 import CreativesSetPlanModalController from "./creatives/set_plan_modal_controller"
 import AvatarPreviewController from "./avatar_preview_controller"
+import TabsController from "./tabs_controller"
 
 import CommentController from "./comment_controller"
 import ShareInviteController from "./share_invite_controller"
@@ -39,3 +40,4 @@ application.register("comments--popup", CommentsPopupController)
 application.register("click-target", ClickTargetController)
 application.register("creatives--set-plan-modal", CreativesSetPlanModalController)
 application.register("avatar-preview", AvatarPreviewController)
+application.register("tabs", TabsController)

--- a/app/javascript/controllers/tabs_controller.js
+++ b/app/javascript/controllers/tabs_controller.js
@@ -1,0 +1,43 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = [ "panel", "tabButton" ]
+  static values = { activeTab: String }
+
+  connect() {
+    if (!this.hasActiveTabValue) {
+      this.activeTabValue = "profile"
+    }
+    this.showActive()
+  }
+
+  switch(event) {
+    event.preventDefault()
+    const tab = event.params?.tab || event.currentTarget.dataset.tabsTabParam
+    if (!tab) return
+
+    this.activeTabValue = tab
+    this.showActive()
+    this.updateUrl(tab)
+  }
+
+  showActive() {
+    this.panelTargets.forEach((panel) => {
+      panel.classList.toggle("active", panel.dataset.tabName === this.activeTabValue)
+    })
+
+    this.tabButtonTargets.forEach((button) => {
+      button.classList.toggle("active", button.dataset.tabsTabParam === this.activeTabValue)
+    })
+  }
+
+  updateUrl(tab) {
+    if (typeof window === "undefined") return
+    const url = new URL(window.location)
+    url.searchParams.set("tab", tab)
+    if (tab !== "contacts") {
+      url.searchParams.delete("contact_page")
+    }
+    window.history.replaceState({}, "", url)
+  }
+}

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -1,0 +1,19 @@
+class Contact < ApplicationRecord
+  belongs_to :user
+  belongs_to :contact_user, class_name: "User"
+
+  validates :user_id, uniqueness: { scope: :contact_user_id }
+  validate :cannot_add_self
+
+  def self.ensure(user:, contact_user:)
+    return if user.nil? || contact_user.nil? || user == contact_user
+
+    find_or_create_by!(user: user, contact_user: contact_user)
+  end
+
+  private
+
+  def cannot_add_self
+    errors.add(:contact_user, :invalid) if user_id.present? && contact_user_id.present? && user_id == contact_user_id
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,6 +14,9 @@ class User < ApplicationRecord
   has_many :emails, dependent: :destroy
   has_many :inbox_items, foreign_key: :owner_id, dependent: :destroy, inverse_of: :owner
   has_many :invitations, foreign_key: :inviter_id, dependent: :destroy, inverse_of: :inviter
+  has_many :contacts, dependent: :destroy
+  has_many :contact_users, through: :contacts
+  has_many :contact_memberships, class_name: "Contact", foreign_key: :contact_user_id, dependent: :destroy, inverse_of: :contact_user
   has_one :github_account, dependent: :destroy
   has_one :notion_account, dependent: :destroy
 

--- a/app/views/users/_contact_management.html.erb
+++ b/app/views/users/_contact_management.html.erb
@@ -1,0 +1,71 @@
+<div class="contact-management">
+  <p class="text-muted"><%= t('contacts.description') %></p>
+
+  <%= form_with url: contacts_path, method: :post, scope: :contact, local: true, class: 'contact-add-form' do |f| %>
+    <div class="contact-add-row">
+      <div class="contact-field">
+        <%= f.label :email, t('contacts.add_label') %>
+        <%= f.email_field :email, placeholder: t('contacts.add_placeholder'), required: true %>
+      </div>
+      <div class="contact-actions">
+        <%= f.submit t('contacts.add_button'), class: 'btn btn-primary' %>
+      </div>
+    </div>
+  <% end %>
+
+  <% if contacts.present? %>
+    <div class="table-scroll">
+      <table class="contacts-table">
+        <thead>
+          <tr>
+            <th><%= t('users.table.avatar') %></th>
+            <th><%= t('users.table.name') %></th>
+            <th><%= t('users.table.email') %></th>
+            <th><%= t('users.table.last_login_at') %></th>
+            <th><%= t('contacts.table.shared_creatives') %></th>
+            <th><%= t('contacts.table.shared_with_me') %></th>
+          </tr>
+        </thead>
+        <tbody>
+          <% contacts.each do |contact| %>
+            <% contact_user = contact.contact_user %>
+            <tr>
+              <td>
+                <%= render AvatarComponent.new(
+                  user: contact_user,
+                  size: 32,
+                  classes: "avatar"
+                ) %>
+              </td>
+              <td><%= contact_user.display_name %></td>
+              <td><%= contact_user.email %></td>
+              <td><%= render_last_login_for(contact_user, last_login_map || {}) %></td>
+              <td class="creative-cell">
+                <%= render_contact_creatives(shared_by_me.fetch(contact_user.id, [])) %>
+              </td>
+              <td class="creative-cell">
+                <%= render_contact_creatives(shared_with_me.fetch(contact_user.id, [])) %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% else %>
+    <p class="text-muted"><%= t('contacts.empty_state') %></p>
+  <% end %>
+
+  <% if total_contact_pages.to_i > 1 %>
+    <nav class="contact-pagination">
+      <% prev_page = contact_page.to_i - 1 %>
+      <% next_page = contact_page.to_i + 1 %>
+      <% if contact_page.to_i > 1 %>
+        <%= link_to t('contacts.pagination.prev'), user_path(Current.user, tab: 'contacts', contact_page: prev_page), class: 'pagination-link' %>
+      <% end %>
+      <span class="pagination-status"><%= t('contacts.pagination.page_info', current: contact_page, total: total_contact_pages) %></span>
+      <% if contact_page.to_i < total_contact_pages.to_i %>
+        <%= link_to t('contacts.pagination.next'), user_path(Current.user, tab: 'contacts', contact_page: next_page), class: 'pagination-link' %>
+      <% end %>
+    </nav>
+  <% end %>
+</div>

--- a/app/views/users/_contact_management.html.erb
+++ b/app/views/users/_contact_management.html.erb
@@ -1,18 +1,6 @@
 <div class="contact-management">
   <p class="text-muted"><%= t('contacts.description') %></p>
 
-  <%= form_with url: contacts_path, method: :post, scope: :contact, local: true, class: 'contact-add-form' do |f| %>
-    <div class="contact-add-row">
-      <div class="contact-field">
-        <%= f.label :email, t('contacts.add_label') %>
-        <%= f.email_field :email, placeholder: t('contacts.add_placeholder'), required: true %>
-      </div>
-      <div class="contact-actions">
-        <%= f.submit t('contacts.add_button'), class: 'btn btn-primary' %>
-      </div>
-    </div>
-  <% end %>
-
   <% if contacts.present? %>
     <div class="table-scroll">
       <table class="contacts-table">

--- a/app/views/users/_contact_management.html.erb
+++ b/app/views/users/_contact_management.html.erb
@@ -60,11 +60,11 @@
       <% prev_page = contact_page.to_i - 1 %>
       <% next_page = contact_page.to_i + 1 %>
       <% if contact_page.to_i > 1 %>
-        <%= link_to t('contacts.pagination.prev'), user_path(Current.user, tab: 'contacts', contact_page: prev_page), class: 'pagination-link' %>
+        <%= link_to t('contacts.pagination.prev'), user_path(Current.user, tab: 'contacts', contact_page: prev_page), class: 'pagination-button' %>
       <% end %>
       <span class="pagination-status"><%= t('contacts.pagination.page_info', current: contact_page, total: total_contact_pages) %></span>
       <% if contact_page.to_i < total_contact_pages.to_i %>
-        <%= link_to t('contacts.pagination.next'), user_path(Current.user, tab: 'contacts', contact_page: next_page), class: 'pagination-link' %>
+        <%= link_to t('contacts.pagination.next'), user_path(Current.user, tab: 'contacts', contact_page: next_page), class: 'pagination-button' %>
       <% end %>
     </nav>
   <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -2,14 +2,15 @@
 
 <h1 class="no-top-margin"><%= t('users.details') %></h1>
 
-<div class="tab-list" data-controller="tabs" data-tabs-active-tab-value="<%= active_tab %>">
-  <button class="tab-button <%= 'active' if active_tab == 'profile' %>" data-action="click->tabs#switch" data-tabs-tab-param="profile" data-tabs-target="tabButton">
-    <%= t('users.tabs.profile') %>
-  </button>
-  <button class="tab-button <%= 'active' if active_tab == 'contacts' %>" data-action="click->tabs#switch" data-tabs-tab-param="contacts" data-tabs-target="tabButton">
-    <%= t('users.tabs.user_management') %>
-  </button>
-</div>
+<div data-controller="tabs" data-tabs-active-tab-value="<%= active_tab %>">
+  <div class="tab-list">
+    <button class="tab-button <%= 'active' if active_tab == 'profile' %>" data-action="click->tabs#switch" data-tabs-tab-param="profile" data-tabs-target="tabButton">
+      <%= t('users.tabs.profile') %>
+    </button>
+    <button class="tab-button <%= 'active' if active_tab == 'contacts' %>" data-action="click->tabs#switch" data-tabs-tab-param="contacts" data-tabs-target="tabButton">
+      <%= t('users.tabs.user_management') %>
+    </button>
+  </div>
 
 <div class="tab-panels">
   <section class="tab-panel <%= 'active' if active_tab == 'profile' %>" data-tabs-target="panel" data-tab-name="profile">
@@ -26,76 +27,76 @@
           <span class="avatar-preview-label"><%= t('users.new_avatar_preview') %></span>
           <div class="avatar-preview-frame">
             <%= image_tag '',
-                alt: t('users.new_avatar_preview'),
-                class: 'avatar-preview-image avatar-preview-hidden',
-                data: { avatar_preview_target: 'previewImage' } %>
+                          alt: t('users.new_avatar_preview'),
+                          class: 'avatar-preview-image avatar-preview-hidden',
+                          data: { avatar_preview_target: 'previewImage' } %>
           </div>
         </div>
       </div>
 
-      <%= form_with model: @user, url: user_path(@user), method: :patch, local: true, html: { multipart: true, class: 'profile-form' } do |f| %>
-        <div>
-          <%= f.label :avatar, t('users.avatar') %>
-          <%= f.file_field :avatar, data: { avatar_preview_target: 'input', action: 'change->avatar-preview#update' } %>
-        </div>
-        <div>
-          <%= f.label :name, t('users.name') %>
-          <%= f.text_field :name, required: true %>
-        </div>
-        <div>
-          <%= f.label :email, t('users.email') %>
-          <%= f.text_field :email, required: true, disabled: true %>
-        </div>
-        <div>
-          <%= f.label :avatar_url, t('users.avatar_url') %>
-          <%= f.text_field :avatar_url, placeholder: t('users.avatar_url'), data: { avatar_preview_target: 'urlInput', action: 'input->avatar-preview#updateFromUrl' } %>
-        </div>
-        <div>
-          <%= f.label :display_level, t('users.display_level') %>
-          <%= f.number_field :display_level, min: 1 %>
-        </div>
-        <div>
-          <%= f.label :completion_mark, t('users.completion_mark') %>
-          <%= f.text_field :completion_mark %>
-        </div>
-        <div>
-          <%= f.label :theme, t('users.theme') %>
-          <%= f.select :theme, options_for_select([[t('app.system_mode'), nil], [t('app.light_mode'), 'light'], [t('app.dark_mode'), 'dark']], @user.theme) %>
-        </div>
-        <div>
-          <%= f.label :calendar_id, t('users.calendar_id') %>
-          <%= f.text_field :calendar_id, placeholder: t('users.calendar_id') %>
-        </div>
-        <div class="checkbox-field">
-          <%= f.check_box :notifications_enabled %>
-          <%= f.label :notifications_enabled, t('users.notifications_enabled') %>
-        </div>
-        <div>
-          <%= f.label :locale, t('users.locale') %>
-          <%= f.select :locale, I18n.available_locales.map { |loc| [t("users.locales.#{loc}"), loc] } %>
-        </div>
-        <div>
-          <%= f.label :timezone, t('users.timezone') %>
-          <%= f.select :timezone, ActiveSupport::TimeZone.all.map { |tz| [tz.to_s, tz.tzinfo.name] } %>
-        </div>
-        <%= f.submit t('users.update_profile') %>
-      <% end %>
-
-      <div class="profile-actions">
-        <%= link_to t('users.change_password'), edit_password_user_path %>
+    <%= form_with model: @user, url: user_path(@user), method: :patch, local: true, html: { multipart: true, class: 'profile-form' } do |f| %>
+      <div>
+        <%= f.label :avatar, t('users.avatar') %>
+        <%= f.file_field :avatar %>
       </div>
+      <div>
+        <%= f.label :name, t('users.name') %>
+        <%= f.text_field :name, required: true %>
+      </div>
+      <div>
+        <%= f.label :email, t('users.email') %>
+        <%= f.text_field :email, required: true, disabled: true %>
+      </div>
+      <div>
+        <%= f.label :avatar_url, t('users.avatar_url') %>
+        <%= f.text_field :avatar_url, placeholder: t('users.avatar_url') %>
+      </div>
+      <div>
+        <%= f.label :display_level, t('users.display_level') %>
+        <%= f.number_field :display_level, min: 1 %>
+      </div>
+      <div>
+        <%= f.label :completion_mark, t('users.completion_mark') %>
+        <%= f.text_field :completion_mark %>
+      </div>
+      <div>
+        <%= f.label :theme, t('users.theme') %>
+        <%= f.select :theme, options_for_select([[t('app.system_mode'), nil], [t('app.light_mode'), 'light'], [t('app.dark_mode'), 'dark']], @user.theme) %>
+      </div>
+      <div>
+        <%= f.label :calendar_id, t('users.calendar_id') %>
+        <%= f.text_field :calendar_id, placeholder: t('users.calendar_id') %>
+      </div>
+      <div class="checkbox-field">
+        <%= f.check_box :notifications_enabled %>
+        <%= f.label :notifications_enabled, t('users.notifications_enabled') %>
+      </div>
+      <div>
+        <%= f.label :locale, t('users.locale') %>
+        <%= f.select :locale, I18n.available_locales.map { |loc| [t("users.locales.#{loc}"), loc] } %>
+      </div>
+      <div>
+        <%= f.label :timezone, t('users.timezone') %>
+        <%= f.select :timezone, ActiveSupport::TimeZone.all.map { |tz| [tz.to_s, tz.tzinfo.name] } %>
+      </div>
+      <%= f.submit t('users.update_profile') %>
+    <% end %>
+
+    <div class="profile-actions">
+      <%= link_to t('users.change_password'), edit_password_user_path %>
     </div>
-
+    </div>
   </section>
 
-  <section class="tab-panel <%= 'active' if active_tab == 'contacts' %>" data-tabs-target="panel" data-tab-name="contacts">
-    <%= render partial: 'contact_management', locals: {
-      contacts: @contacts,
-      last_login_map: @last_login_map,
-      shared_by_me: @shared_by_me,
-      shared_with_me: @shared_with_me,
-      contact_page: @contact_page,
-      total_contact_pages: @total_contact_pages
-    } %>
-  </section>
+    <section class="tab-panel <%= 'active' if active_tab == 'contacts' %>" data-tabs-target="panel" data-tab-name="contacts">
+      <%= render partial: 'contact_management', locals: {
+        contacts: @contacts,
+        last_login_map: @last_login_map,
+        shared_by_me: @shared_by_me,
+        shared_with_me: @shared_with_me,
+        contact_page: @contact_page,
+        total_contact_pages: @total_contact_pages
+      } %>
+    </section>
+  </div>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,70 +1,101 @@
-<div data-controller="avatar-preview">
-  <h1 class="no-top-margin"><%= t('users.details') %></h1>
+<% active_tab = @active_tab || "profile" %>
 
-  <div class="avatar-preview-row">
-    <div class="avatar-preview-pane avatar-preview-current">
-      <span class="avatar-preview-label"><%= t('users.current_avatar') %></span>
-      <%= render AvatarComponent.new(user: @user, size: 80, classes: 'avatar') %>
-    </div>
+<h1 class="no-top-margin"><%= t('users.details') %></h1>
 
-    <div class="avatar-preview-pane avatar-preview-container" data-avatar-preview-target="previewContainer">
-      <span class="avatar-preview-label"><%= t('users.new_avatar_preview') %></span>
-      <div class="avatar-preview-frame">
-        <%= image_tag '',
-            alt: t('users.new_avatar_preview'),
-            class: 'avatar-preview-image avatar-preview-hidden',
-            data: { avatar_preview_target: 'previewImage' } %>
+<div class="tab-list" data-controller="tabs" data-tabs-active-tab-value="<%= active_tab %>">
+  <button class="tab-button <%= 'active' if active_tab == 'profile' %>" data-action="click->tabs#switch" data-tabs-tab-param="profile" data-tabs-target="tabButton">
+    <%= t('users.tabs.profile') %>
+  </button>
+  <button class="tab-button <%= 'active' if active_tab == 'contacts' %>" data-action="click->tabs#switch" data-tabs-tab-param="contacts" data-tabs-target="tabButton">
+    <%= t('users.tabs.user_management') %>
+  </button>
+</div>
+
+<div class="tab-panels">
+  <section class="tab-panel <%= 'active' if active_tab == 'profile' %>" data-tabs-target="panel" data-tab-name="profile">
+
+    <div data-controller="avatar-preview">
+
+      <div class="avatar-preview-row">
+        <div class="avatar-preview-pane avatar-preview-current">
+          <span class="avatar-preview-label"><%= t('users.current_avatar') %></span>
+          <%= render AvatarComponent.new(user: @user, size: 80, classes: 'avatar') %>
+        </div>
+
+        <div class="avatar-preview-pane avatar-preview-container" data-avatar-preview-target="previewContainer">
+          <span class="avatar-preview-label"><%= t('users.new_avatar_preview') %></span>
+          <div class="avatar-preview-frame">
+            <%= image_tag '',
+                alt: t('users.new_avatar_preview'),
+                class: 'avatar-preview-image avatar-preview-hidden',
+                data: { avatar_preview_target: 'previewImage' } %>
+          </div>
+        </div>
+      </div>
+
+      <%= form_with model: @user, url: user_path(@user), method: :patch, local: true, html: { multipart: true, class: 'profile-form' } do |f| %>
+        <div>
+          <%= f.label :avatar, t('users.avatar') %>
+          <%= f.file_field :avatar, data: { avatar_preview_target: 'input', action: 'change->avatar-preview#update' } %>
+        </div>
+        <div>
+          <%= f.label :name, t('users.name') %>
+          <%= f.text_field :name, required: true %>
+        </div>
+        <div>
+          <%= f.label :email, t('users.email') %>
+          <%= f.text_field :email, required: true, disabled: true %>
+        </div>
+        <div>
+          <%= f.label :avatar_url, t('users.avatar_url') %>
+          <%= f.text_field :avatar_url, placeholder: t('users.avatar_url'), data: { avatar_preview_target: 'urlInput', action: 'input->avatar-preview#updateFromUrl' } %>
+        </div>
+        <div>
+          <%= f.label :display_level, t('users.display_level') %>
+          <%= f.number_field :display_level, min: 1 %>
+        </div>
+        <div>
+          <%= f.label :completion_mark, t('users.completion_mark') %>
+          <%= f.text_field :completion_mark %>
+        </div>
+        <div>
+          <%= f.label :theme, t('users.theme') %>
+          <%= f.select :theme, options_for_select([[t('app.system_mode'), nil], [t('app.light_mode'), 'light'], [t('app.dark_mode'), 'dark']], @user.theme) %>
+        </div>
+        <div>
+          <%= f.label :calendar_id, t('users.calendar_id') %>
+          <%= f.text_field :calendar_id, placeholder: t('users.calendar_id') %>
+        </div>
+        <div class="checkbox-field">
+          <%= f.check_box :notifications_enabled %>
+          <%= f.label :notifications_enabled, t('users.notifications_enabled') %>
+        </div>
+        <div>
+          <%= f.label :locale, t('users.locale') %>
+          <%= f.select :locale, I18n.available_locales.map { |loc| [t("users.locales.#{loc}"), loc] } %>
+        </div>
+        <div>
+          <%= f.label :timezone, t('users.timezone') %>
+          <%= f.select :timezone, ActiveSupport::TimeZone.all.map { |tz| [tz.to_s, tz.tzinfo.name] } %>
+        </div>
+        <%= f.submit t('users.update_profile') %>
+      <% end %>
+
+      <div class="profile-actions">
+        <%= link_to t('users.change_password'), edit_password_user_path %>
       </div>
     </div>
-  </div>
 
-  <%= form_with model: @user, url: user_path(@user), method: :patch, local: true, html: { multipart: true, class: 'profile-form' } do |f| %>
-    <div>
-      <%= f.label :avatar, t('users.avatar') %>
-      <%= f.file_field :avatar, data: { avatar_preview_target: 'input', action: 'change->avatar-preview#update' } %>
-    </div>
-    <div>
-      <%= f.label :name, t('users.name') %>
-      <%= f.text_field :name, required: true %>
-    </div>
-    <div>
-      <%= f.label :email, t('users.email') %>
-      <%= f.text_field :email, required: true, disabled: true %>
-    </div>
-    <div>
-      <%= f.label :avatar_url, t('users.avatar_url') %>
-      <%= f.text_field :avatar_url, placeholder: t('users.avatar_url'), data: { avatar_preview_target: 'urlInput', action: 'input->avatar-preview#updateFromUrl' } %>
-    </div>
-    <div>
-      <%= f.label :display_level, t('users.display_level') %>
-      <%= f.number_field :display_level, min: 1 %>
-    </div>
-    <div>
-      <%= f.label :completion_mark, t('users.completion_mark') %>
-      <%= f.text_field :completion_mark %>
-    </div>
-    <div>
-      <%= f.label :theme, t('users.theme') %>
-      <%= f.select :theme, options_for_select([[t('app.system_mode'), nil], [t('app.light_mode'), 'light'], [t('app.dark_mode'), 'dark']], @user.theme) %>
-    </div>
-    <div>
-      <%= f.label :calendar_id, t('users.calendar_id') %>
-      <%= f.text_field :calendar_id, placeholder: t('users.calendar_id') %>
-    </div>
-    <div class="checkbox-field">
-      <%= f.check_box :notifications_enabled %>
-      <%= f.label :notifications_enabled, t('users.notifications_enabled') %>
-    </div>
-    <div>
-      <%= f.label :locale, t('users.locale') %>
-      <%= f.select :locale, I18n.available_locales.map { |loc| [t("users.locales.#{loc}"), loc] } %>
-    </div>
-    <div>
-      <%= f.label :timezone, t('users.timezone') %>
-      <%= f.select :timezone, ActiveSupport::TimeZone.all.map { |tz| [tz.to_s, tz.tzinfo.name] } %>
-    </div>
-    <%= f.submit t('users.update_profile') %>
-  <% end %>
+  </section>
 
-  <%= link_to t('users.change_password'), edit_password_user_path %>
+  <section class="tab-panel <%= 'active' if active_tab == 'contacts' %>" data-tabs-target="panel" data-tab-name="contacts">
+    <%= render partial: 'contact_management', locals: {
+      contacts: @contacts,
+      last_login_map: @last_login_map,
+      shared_by_me: @shared_by_me,
+      shared_with_me: @shared_with_me,
+      contact_page: @contact_page,
+      total_contact_pages: @total_contact_pages
+    } %>
+  </section>
 </div>

--- a/config/locales/contacts.en.yml
+++ b/config/locales/contacts.en.yml
@@ -1,0 +1,22 @@
+en:
+  contacts:
+    description: "Manage users you have invited or share creatives with."
+    add_label: "Add user by email"
+    add_placeholder: "user@example.com"
+    add_button: "Add to list"
+    empty_state: "No managed users yet."
+    none: "None"
+    table:
+      shared_creatives: "Creatives you shared"
+      shared_with_me: "Creatives shared with you"
+    pagination:
+      prev: "Previous"
+      next: "Next"
+      page_info: "Page %{current} of %{total}"
+    notices:
+      added: "%{name} was added to your managed users."
+      removed: "User removed from your managed users."
+    errors:
+      not_found: "Could not find a user with that email."
+      self_add: "You cannot add yourself."
+      email_required: "Please enter an email to add a user."

--- a/config/locales/contacts.en.yml
+++ b/config/locales/contacts.en.yml
@@ -1,9 +1,6 @@
 en:
   contacts:
     description: "Manage users you have invited or share creatives with."
-    add_label: "Add user by email"
-    add_placeholder: "user@example.com"
-    add_button: "Add to list"
     empty_state: "No managed users yet."
     none: "None"
     table:
@@ -14,9 +11,4 @@ en:
       next: "Next"
       page_info: "Page %{current} of %{total}"
     notices:
-      added: "%{name} was added to your managed users."
       removed: "User removed from your managed users."
-    errors:
-      not_found: "Could not find a user with that email."
-      self_add: "You cannot add yourself."
-      email_required: "Please enter an email to add a user."

--- a/config/locales/contacts.ko.yml
+++ b/config/locales/contacts.ko.yml
@@ -1,0 +1,22 @@
+ko:
+  contacts:
+    description: "초대했거나 크리에이티브를 공유한 사용자를 관리합니다."
+    add_label: "이메일로 사용자 추가"
+    add_placeholder: "user@example.com"
+    add_button: "목록에 추가"
+    empty_state: "아직 관리할 사용자가 없습니다."
+    none: "없음"
+    table:
+      shared_creatives: "공유한 크리에이티브"
+      shared_with_me: "공유된 크리에이티브"
+    pagination:
+      prev: "이전"
+      next: "다음"
+      page_info: "%{current}/%{total} 페이지"
+    notices:
+      added: "%{name} 님을 사용자 관리 목록에 추가했습니다."
+      removed: "사용자 관리 목록에서 제거했습니다."
+    errors:
+      not_found: "해당 이메일의 사용자를 찾을 수 없습니다."
+      self_add: "자기 자신은 추가할 수 없습니다."
+      email_required: "추가할 이메일을 입력해주세요."

--- a/config/locales/contacts.ko.yml
+++ b/config/locales/contacts.ko.yml
@@ -1,9 +1,6 @@
 ko:
   contacts:
     description: "초대했거나 크리에이티브를 공유한 사용자를 관리합니다."
-    add_label: "이메일로 사용자 추가"
-    add_placeholder: "user@example.com"
-    add_button: "목록에 추가"
     empty_state: "아직 관리할 사용자가 없습니다."
     none: "없음"
     table:
@@ -14,9 +11,4 @@ ko:
       next: "다음"
       page_info: "%{current}/%{total} 페이지"
     notices:
-      added: "%{name} 님을 사용자 관리 목록에 추가했습니다."
       removed: "사용자 관리 목록에서 제거했습니다."
-    errors:
-      not_found: "해당 이메일의 사용자를 찾을 수 없습니다."
-      self_add: "자기 자신은 추가할 수 없습니다."
-      email_required: "추가할 이메일을 입력해주세요."

--- a/config/locales/users.en.yml
+++ b/config/locales/users.en.yml
@@ -22,6 +22,9 @@ en:
     name: "Name"
     email: "Email"
     change_password: "Change password"
+    tabs:
+      profile: "Profile"
+      user_management: "User management"
     profile: "Profile"
     avatar: "Avatar"
     avatar_url: "Avatar URL"

--- a/config/locales/users.ko.yml
+++ b/config/locales/users.ko.yml
@@ -22,6 +22,9 @@ ko:
     name: "이름"
     email: "이메일"
     change_password: "비밀번호 변경"
+    tabs:
+      profile: "프로파일"
+      user_management: "사용자 관리"
     profile: "프로파일"
     avatar: "아바타"
     avatar_url: "아바타 URL"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,6 +79,8 @@ Rails.application.routes.draw do
     get :count, on: :collection
   end
 
+  resources :contacts, only: [ :create, :destroy ]
+
   resources :devices, only: [ :create ]
 
   resources :emails, only: [ :index, :show ]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,7 +79,7 @@ Rails.application.routes.draw do
     get :count, on: :collection
   end
 
-  resources :contacts, only: [ :create, :destroy ]
+  resources :contacts, only: [ :destroy ]
 
   resources :devices, only: [ :create ]
 

--- a/db/migrate/20251001000001_create_contacts.rb
+++ b/db/migrate/20251001000001_create_contacts.rb
@@ -1,0 +1,71 @@
+require "set"
+
+class CreateContacts < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def up
+    create_table :contacts do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :contact_user, null: false, foreign_key: { to_table: :users }
+
+      t.timestamps
+    end
+
+    add_index :contacts, [ :user_id, :contact_user_id ], unique: true
+
+    backfill_contacts
+  end
+
+  def down
+    drop_table :contacts
+  end
+
+  private
+
+  def backfill_contacts
+    say_with_time "Backfilling contacts from invitations and shares" do
+      contact_rows = []
+      timestamp = Time.current
+
+      existing_contacts = Set.new
+
+      invitation_pairs.each do |inviter_id, invitee_id|
+        next if inviter_id == invitee_id
+        key = [ inviter_id, invitee_id ]
+        next if existing_contacts.include?(key)
+        existing_contacts << key
+        contact_rows << { user_id: inviter_id, contact_user_id: invitee_id, created_at: timestamp, updated_at: timestamp }
+      end
+
+      share_pairs.each do |owner_id, shared_user_id|
+        next if owner_id == shared_user_id
+        key = [ owner_id, shared_user_id ]
+        next if existing_contacts.include?(key)
+        existing_contacts << key
+        contact_rows << { user_id: owner_id, contact_user_id: shared_user_id, created_at: timestamp, updated_at: timestamp }
+      end
+
+      return if contact_rows.empty?
+
+      MigrationContact.insert_all(contact_rows)
+    end
+  end
+
+  def invitation_pairs
+    Invitation
+      .joins("INNER JOIN users ON LOWER(users.email) = LOWER(invitations.email)")
+      .pluck(:inviter_id, "users.id")
+  end
+
+  def share_pairs
+    no_access = CreativeShare.permissions[:no_access]
+    CreativeShare
+      .joins(:creative)
+      .where.not(permission: no_access)
+      .pluck("creatives.user_id", :user_id)
+  end
+
+  class MigrationContact < ActiveRecord::Base
+    self.table_name = "contacts"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_09_29_000000) do
+ActiveRecord::Schema[8.1].define(version: 2025_10_01_000001) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false
@@ -90,6 +90,16 @@ ActiveRecord::Schema[8.1].define(version: 2025_09_29_000000) do
     t.index ["approver_id"], name: "index_comments_on_approver_id"
     t.index ["creative_id"], name: "index_comments_on_creative_id"
     t.index ["user_id"], name: "index_comments_on_user_id"
+  end
+
+  create_table "contacts", force: :cascade do |t|
+    t.integer "contact_user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "user_id", null: false
+    t.index ["contact_user_id"], name: "index_contacts_on_contact_user_id"
+    t.index ["user_id", "contact_user_id"], name: "index_contacts_on_user_id_and_contact_user_id", unique: true
+    t.index ["user_id"], name: "index_contacts_on_user_id"
   end
 
   create_table "creative_expanded_states", force: :cascade do |t|
@@ -477,6 +487,8 @@ ActiveRecord::Schema[8.1].define(version: 2025_09_29_000000) do
   add_foreign_key "comments", "users"
   add_foreign_key "comments", "users", column: "action_executed_by_id"
   add_foreign_key "comments", "users", column: "approver_id"
+  add_foreign_key "contacts", "users"
+  add_foreign_key "contacts", "users", column: "contact_user_id"
   add_foreign_key "creative_expanded_states", "creatives"
   add_foreign_key "creative_expanded_states", "users"
   add_foreign_key "creative_shares", "creatives"

--- a/test/controllers/contacts_controller_test.rb
+++ b/test/controllers/contacts_controller_test.rb
@@ -3,31 +3,12 @@ require "test_helper"
 class ContactsControllerTest < ActionDispatch::IntegrationTest
   setup do
     @user = users(:one)
-    @contact_user = users(:three)
   end
 
-  test "adds user to contacts by email" do
-    sign_in_as(@user, password: "password")
-
-    assert_difference("Contact.count", 1) do
-      post contacts_path, params: { contact: { email: @contact_user.email } }
+  test "does not expose contact creation route" do
+    assert_raises(ActionController::RoutingError) do
+      Rails.application.routes.recognize_path("/contacts", method: :post)
     end
-
-    assert_redirected_to user_path(@user, tab: "contacts")
-    follow_redirect!
-    assert_equal I18n.t("contacts.notices.added", name: @contact_user.display_name), flash[:notice]
-  end
-
-  test "does not add self" do
-    sign_in_as(@user, password: "password")
-
-    assert_no_difference("Contact.count") do
-      post contacts_path, params: { contact: { email: @user.email } }
-    end
-
-    assert_redirected_to user_path(@user, tab: "contacts")
-    follow_redirect!
-    assert_equal I18n.t("contacts.errors.self_add"), flash[:alert]
   end
 
   test "removes contact" do

--- a/test/controllers/contacts_controller_test.rb
+++ b/test/controllers/contacts_controller_test.rb
@@ -1,0 +1,45 @@
+require "test_helper"
+
+class ContactsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:one)
+    @contact_user = users(:three)
+  end
+
+  test "adds user to contacts by email" do
+    sign_in_as(@user, password: "password")
+
+    assert_difference("Contact.count", 1) do
+      post contacts_path, params: { contact: { email: @contact_user.email } }
+    end
+
+    assert_redirected_to user_path(@user, tab: "contacts")
+    follow_redirect!
+    assert_equal I18n.t("contacts.notices.added", name: @contact_user.display_name), flash[:notice]
+  end
+
+  test "does not add self" do
+    sign_in_as(@user, password: "password")
+
+    assert_no_difference("Contact.count") do
+      post contacts_path, params: { contact: { email: @user.email } }
+    end
+
+    assert_redirected_to user_path(@user, tab: "contacts")
+    follow_redirect!
+    assert_equal I18n.t("contacts.errors.self_add"), flash[:alert]
+  end
+
+  test "removes contact" do
+    sign_in_as(@user, password: "password")
+    contact = contacts(:one_two)
+
+    assert_difference("Contact.count", -1) do
+      delete contact_path(contact), params: { contact_page: 2 }
+    end
+
+    assert_redirected_to user_path(@user, tab: "contacts", contact_page: 2)
+    follow_redirect!
+    assert_equal I18n.t("contacts.notices.removed"), flash[:notice]
+  end
+end

--- a/test/controllers/creative_shares_controller_test.rb
+++ b/test/controllers/creative_shares_controller_test.rb
@@ -1,0 +1,19 @@
+require "test_helper"
+
+class CreativeSharesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @owner = users(:one)
+    @creative = creatives(:tshirt)
+    @target_user = users(:three)
+  end
+
+  test "creating a share adds the target to contacts" do
+    sign_in_as(@owner, password: "password")
+
+    assert_difference([ "CreativeShare.count", "Contact.count" ], 1) do
+      post creative_creative_shares_path(@creative), params: { user_email: @target_user.email, permission: :read }
+    end
+
+    assert Contact.exists?(user: @owner, contact_user: @target_user)
+  end
+end

--- a/test/fixtures/contacts.yml
+++ b/test/fixtures/contacts.yml
@@ -1,0 +1,3 @@
+one_two:
+  user: one
+  contact_user: two

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -11,3 +11,9 @@ two:
   password_digest: <%= password_digest %>
   name: Two
   system_admin: false
+
+three:
+  email: three@example1.com
+  password_digest: <%= password_digest %>
+  name: Three
+  system_admin: false

--- a/test/models/contact_test.rb
+++ b/test/models/contact_test.rb
@@ -1,0 +1,28 @@
+require "test_helper"
+
+class ContactTest < ActiveSupport::TestCase
+  test "valid contact" do
+    contact = Contact.new(user: users(:one), contact_user: users(:three))
+    assert contact.valid?
+  end
+
+  test "rejects duplicates" do
+    contact = Contact.new(user: users(:one), contact_user: users(:two))
+    refute contact.valid?
+  end
+
+  test "rejects self contact" do
+    contact = Contact.new(user: users(:one), contact_user: users(:one))
+    refute contact.valid?
+  end
+
+  test "ensure helper creates missing record" do
+    assert_difference("Contact.count", 1) do
+      Contact.ensure(user: users(:two), contact_user: users(:three))
+    end
+
+    assert_no_difference("Contact.count") do
+      Contact.ensure(user: users(:two), contact_user: users(:three))
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add a tabbed layout to the user details page with a dedicated user management view
- introduce contacts to track managed users, including backfill from invitations and creative shares
- display and paginate managed users with shared creative links, helper utilities, and supporting styles/scripts

## Testing
- ./bin/rubocop -a
- bin/rails test
- bin/rails test:system *(fails: Chrome/Chromedriver unavailable in the container environment)*

## Original User's Requirements
- 현재 보이는 페이지는 "프로파일" 페이지로 첫번째 탭으로 한다.
- 두번째 탭을 추가해서 "사용자 관리" 를 추가한다.
- 새로 추가된 "사용자 관리" 에 현재 로그인된 사용자가 관리할 수 있는 사용자 리스트가 나온다.
- 사용자가 관리할 수 있는 사용자는 자신이 초대했거나, 자신의 크리에이티브에 어떤 권한이 있는 사용자 또는 그냥 자신이 사용자를 추가한 사용자이다.
- 사용자 관리를 위해 Contact DB 를 만들어서 추가한다.
- Contact 최초에 DB 를 채우기 위해, DB Migration 이 필요하다. 처음 만들면서 채워야 되는 사용자는 해당 사용자가 초대한 사용자, 해당 사용자가 접근할 수 있는 크리에이티브에 아무 권한이라도 있는 사람.
- 사용자 관리에 사용자는는 테이블로 표시되고 페이징된다.
- 아바타 이름 이메일 마지막 로그인, 공유한 크리에이티브, 공유된 크리에이티브 를 표시한다. 테이블은 모바일에서 가로 스크롤되도록 한다.
- 크리에이티브는 링크로 표시되며 이름은 12자 이내료 제한되어 표시됙 "..." 으로 줄였음을 표시환다. 링크를 누르면 해당 크리에이티브로 이동한다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fe164de2c8326937440ad08300215)