### PR TITLE
Refine creative row tree layout

### DIFF
--- a/app/assets/stylesheets/creatives.css
+++ b/app/assets/stylesheets/creatives.css
@@ -144,17 +144,6 @@
     flex: 1 1 auto;
     position: relative;
     min-width: 0;
-    padding-left: calc(var(--tree-indent-level, 0) * var(--tree-indent-step));
-    background-image: repeating-linear-gradient(
-        to right,
-        transparent 0,
-        transparent calc(var(--tree-indent-step) - 1px),
-        var(--color-border) calc(var(--tree-indent-step) - 1px),
-        var(--color-border) var(--tree-indent-step)
-    );
-    background-size: calc(var(--tree-indent-level, 0) * var(--tree-indent-step)) 100%;
-    background-repeat: no-repeat;
-    background-position: left top;
 }
 
 .creative-loading-indicator {
@@ -331,6 +320,19 @@
     gap: 12px;
 }
 
+@media (max-width: 768px) {
+    .creative-row {
+        --tree-indent-step: 18px;
+    }
+    .creative-line,
+    .creative-line-body {
+        gap: 6px;
+    }
+    .creative-row-start {
+        gap: 6px;
+    }
+}
+
 .creative-row.selected {
     background-color: var(--color-drag-over);
 }
@@ -407,6 +409,36 @@
     gap: 8px;
     line-height: var(--row-line-height, 24px);
     min-height: var(--row-line-height, 24px);
+}
+
+.creative-line-body {
+    position: relative;
+    display: inline-flex;
+    align-items: flex-start;
+    gap: 8px;
+    padding-left: calc(var(--tree-indent-level, 0) * var(--tree-indent-step));
+    line-height: var(--row-line-height, 24px);
+    min-height: var(--row-line-height, 24px);
+}
+
+.creative-tree-lines {
+    position: absolute;
+    inset: 0 auto 0 0;
+    width: calc(var(--tree-indent-level, 0) * var(--tree-indent-step));
+    background-image: repeating-linear-gradient(
+        to right,
+        transparent 0,
+        transparent calc(var(--tree-indent-step) - 1px),
+        var(--color-border) calc(var(--tree-indent-step) - 1px),
+        var(--color-border) var(--tree-indent-step)
+    );
+    background-repeat: no-repeat;
+    background-size: 100% 100%;
+    pointer-events: none;
+}
+
+.creative-line-body > *:not(.creative-tree-lines) {
+    position: relative;
 }
 
 .creative-line-leading {

--- a/app/assets/stylesheets/creatives.css
+++ b/app/assets/stylesheets/creatives.css
@@ -111,6 +111,13 @@
     color: var(--color-muted);
     font-size: 0.9em;
     white-space: nowrap;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    align-self: flex-start;
+    flex-wrap: wrap;
+    row-gap: 2px;
+    padding-top: calc((var(--row-line-height, 24px) - var(--control-size, 24px)) / 2);
 }
 
 .creative-tags {
@@ -131,7 +138,22 @@
 
 .creative-row-start {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
+    gap: 8px;
+    flex: 1 1 auto;
+    position: relative;
+    min-width: 0;
+    padding-left: calc(var(--tree-indent-level, 0) * var(--tree-indent-step));
+    background-image: repeating-linear-gradient(
+        to right,
+        transparent 0,
+        transparent calc(var(--tree-indent-step) - 1px),
+        var(--color-border) calc(var(--tree-indent-step) - 1px),
+        var(--color-border) var(--tree-indent-step)
+    );
+    background-size: calc(var(--tree-indent-level, 0) * var(--tree-indent-step)) 100%;
+    background-repeat: no-repeat;
+    background-position: left top;
 }
 
 .creative-loading-indicator {
@@ -220,7 +242,9 @@
     visibility: hidden;
     display: flex;
     align-items: center;
-    align-self: stretch;
+    gap: 6px;
+    align-self: flex-start;
+    padding-top: calc((var(--row-line-height, 24px) - var(--control-size, 24px)) / 2);
 }
 
 .creative-row:hover .creative-row-actions {
@@ -287,7 +311,7 @@
 }
 
 .select-creative-checkbox {
-    margin-left: 6px;
+    margin-left: 0;
     width: 16px;
     height: 16px;
     cursor: pointer;
@@ -295,9 +319,12 @@
 }
 
 .creative-row {
+    --tree-indent-step: 22px;
+    --control-size: 24px;
     display: flex;
     justify-content: space-between;
-    align-items: center;
+    align-items: flex-start;
+    gap: 12px;
 }
 
 .creative-row.selected {
@@ -311,7 +338,7 @@
 .creative-progress {
     color: var(--color-muted);
     font-size: 0.9em;
-    margin-left: 10px;
+    margin-left: 0;
 }
 
 .page-title {
@@ -355,18 +382,36 @@
 .indent3 {
     display: flex;
     align-items: center;
+    gap: 8px;
 }
 
 .indent1 {
-    margin-left: 0.0em;
+    margin-left: 0;
 }
 
 .indent2 {
-    margin-left: 0.2em;
+    margin-left: 0;
 }
 
 .indent3 {
-    margin-left: 0.4em;
+    margin-left: 0;
+}
+
+.creative-line {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    line-height: var(--row-line-height, 24px);
+    min-height: var(--row-line-height, 24px);
+}
+
+.creative-line.level-1,
+.creative-line.level-2,
+.creative-line.level-3,
+.creative-line.level-4,
+.creative-line.level-5,
+.creative-line.level-6 {
+    width: 100%;
 }
 
 .comments-btn {

--- a/app/assets/stylesheets/creatives.css
+++ b/app/assets/stylesheets/creatives.css
@@ -71,7 +71,7 @@
 
 .creative-tree-li {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
 }
 .creative-content {
     min-width: min(50vw, var(--max-width) / 2);
@@ -117,7 +117,8 @@
     align-self: flex-start;
     flex-wrap: wrap;
     row-gap: 2px;
-    padding-top: calc((var(--row-line-height, 24px) - var(--control-size, 24px)) / 2);
+    line-height: var(--row-line-height, 24px);
+    min-height: var(--row-line-height, 24px);
 }
 
 .creative-tags {
@@ -224,11 +225,15 @@
 }
 
 .creative-toggle-btn {
-    width: 16px;
-    height: 16px;
+    --toggle-size: 16px;
+    width: var(--toggle-size);
+    height: var(--row-line-height, 24px);
     font-size: 14px;
     margin-right: 4px;
     visibility: hidden;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
 }
 
 .add-creative-btn {
@@ -240,11 +245,10 @@
 
 .creative-row-actions {
     visibility: hidden;
-    display: flex;
+    display: inline-flex;
     align-items: center;
     gap: 6px;
-    align-self: flex-start;
-    padding-top: calc((var(--row-line-height, 24px) - var(--control-size, 24px)) / 2);
+    height: var(--row-line-height, 24px);
 }
 
 .creative-row:hover .creative-row-actions {
@@ -399,10 +403,17 @@
 
 .creative-line {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     gap: 8px;
     line-height: var(--row-line-height, 24px);
     min-height: var(--row-line-height, 24px);
+}
+
+.creative-line-leading {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    height: var(--row-line-height, 24px);
 }
 
 .creative-line.level-1,

--- a/app/javascript/components/creative_tree_row.js
+++ b/app/javascript/components/creative_tree_row.js
@@ -167,7 +167,11 @@ class CreativeTreeRow extends LitElement {
         draggable=${draggableAttr}
         data-action=${dragActions}
       >
-        <div class="creative-row" data-creatives--select-mode-target="row">
+        <div
+          class="creative-row"
+          style=${this._rowStyle()}
+          data-creatives--select-mode-target="row"
+        >
           <div class="creative-row-start">
             <div class="creative-row-actions">
               ${this._renderCheckbox()}
@@ -189,7 +193,11 @@ class CreativeTreeRow extends LitElement {
         data-id=${this.creativeId ?? nothing}
         data-parent-id=${this.parentId ?? nothing}
       >
-        <div class="creative-row" style="background-color: transparent;" data-creatives--select-mode-target="row">
+        <div
+          class="creative-row"
+          style=${`background-color: transparent; ${this._rowStyle()}`}
+          data-creatives--select-mode-target="row"
+        >
           <h1 class="page-title" style="display:flex;align-items:center;gap:1em;">
             <div class="creative-title-content">
               ${unsafeHTML(this.descriptionHtml || "")}
@@ -252,9 +260,9 @@ class CreativeTreeRow extends LitElement {
     const indicator = this.loadingChildren ? this._renderLoadingIndicator() : nothing;
 
     if (level <= BULLET_STARTING_LEVEL) {
-      const headingClass = `indent${level}`;
+      const headingLevel = Math.max(1, Math.min(level, 6));
+      const headingClass = `indent${level} creative-line level-${headingLevel}`;
       if (this.hasChildren || this.isRoot) {
-        const headingLevel = Math.max(1, Math.min(level, 6));
         switch (headingLevel) {
           case 1:
             return html`<h1 class=${headingClass}>${toggle}${content}${indicator}</h1>`;
@@ -273,13 +281,10 @@ class CreativeTreeRow extends LitElement {
       return html`<div class=${headingClass}>${toggle}${content}${indicator}</div>`;
     }
 
-    const margin = level > BULLET_STARTING_LEVEL
-      ? `margin-left: ${(level - BULLET_STARTING_LEVEL) * 20}px;`
-      : "";
     const needsBullet = !((this.descriptionHtml || "").includes("<li>"));
     const bullet = needsBullet ? html`<div class="creative-tree-bullet"></div>` : nothing;
     return html`
-      <div class="creative-tree-li" style=${margin}>
+      <div class="creative-tree-li creative-line level-6">
         ${toggle}${bullet}${content}${indicator}
       </div>
     `;
@@ -318,6 +323,23 @@ class CreativeTreeRow extends LitElement {
 
   _toggleSymbol() {
     return this.expanded ? "▼" : "▶";
+  }
+
+  _rowLineHeight() {
+    const level = Number(this.level) || 1;
+    if (level <= 1) return 30;
+    if (level === 2) return 28;
+    if (level === 3) return 26;
+    return 24;
+  }
+
+  _indentLevel() {
+    const level = Number(this.level) || 1;
+    return Math.max(level - 1, 0);
+  }
+
+  _rowStyle() {
+    return `--row-line-height: ${this._rowLineHeight()}px; --tree-indent-level: ${this._indentLevel()};`;
   }
 
   _handleToggleClick(event) {

--- a/app/javascript/components/creative_tree_row.js
+++ b/app/javascript/components/creative_tree_row.js
@@ -252,6 +252,15 @@ class CreativeTreeRow extends LitElement {
   _renderContent() {
     const level = Number(this.level) || 1;
     const toggle = this._renderToggle();
+    const leading = (bullet = nothing) => html`
+      <div class="creative-line-leading">
+        <div class="creative-row-actions">
+          ${this._renderCheckbox()}
+          ${this._renderActionButton()}
+        </div>
+        ${toggle}${bullet}
+      </div>
+    `;
     const content = html`
       <div class="creative-content">
         <a class="unstyled-link" href=${this.linkUrl || "#"}>${unsafeHTML(this.descriptionHtml || "")}</a>
@@ -262,30 +271,32 @@ class CreativeTreeRow extends LitElement {
     if (level <= BULLET_STARTING_LEVEL) {
       const headingLevel = Math.max(1, Math.min(level, 6));
       const headingClass = `indent${level} creative-line level-${headingLevel}`;
+      const line = html`${leading()}${content}${indicator}`;
       if (this.hasChildren || this.isRoot) {
         switch (headingLevel) {
           case 1:
-            return html`<h1 class=${headingClass}>${toggle}${content}${indicator}</h1>`;
+            return html`<h1 class=${headingClass}>${line}</h1>`;
           case 2:
-            return html`<h2 class=${headingClass}>${toggle}${content}${indicator}</h2>`;
+            return html`<h2 class=${headingClass}>${line}</h2>`;
           case 3:
-            return html`<h3 class=${headingClass}>${toggle}${content}${indicator}</h3>`;
+            return html`<h3 class=${headingClass}>${line}</h3>`;
           case 4:
-            return html`<h4 class=${headingClass}>${toggle}${content}${indicator}</h4>`;
+            return html`<h4 class=${headingClass}>${line}</h4>`;
           case 5:
-            return html`<h5 class=${headingClass}>${toggle}${content}${indicator}</h5>`;
+            return html`<h5 class=${headingClass}>${line}</h5>`;
           default:
-            return html`<h6 class=${headingClass}>${toggle}${content}${indicator}</h6>`;
+            return html`<h6 class=${headingClass}>${line}</h6>`;
         }
       }
-      return html`<div class=${headingClass}>${toggle}${content}${indicator}</div>`;
+      return html`<div class=${headingClass}>${line}</div>`;
     }
 
     const needsBullet = !((this.descriptionHtml || "").includes("<li>"));
     const bullet = needsBullet ? html`<div class="creative-tree-bullet"></div>` : nothing;
+    const line = html`${leading(bullet)}${content}${indicator}`;
     return html`
       <div class="creative-tree-li creative-line level-6">
-        ${toggle}${bullet}${content}${indicator}
+        ${line}
       </div>
     `;
   }

--- a/app/javascript/components/creative_tree_row.js
+++ b/app/javascript/components/creative_tree_row.js
@@ -255,6 +255,12 @@ class CreativeTreeRow extends LitElement {
         ${toggle}${bullet}
       </div>
     `;
+    const lineBody = (contentSlot) => html`
+      <div class="creative-line-body">
+        <div class="creative-tree-lines" aria-hidden="true"></div>
+        ${contentSlot}
+      </div>
+    `;
     const content = html`
       <div class="creative-content">
         <a class="unstyled-link" href=${this.linkUrl || "#"}>${unsafeHTML(this.descriptionHtml || "")}</a>
@@ -265,7 +271,7 @@ class CreativeTreeRow extends LitElement {
     if (level <= BULLET_STARTING_LEVEL) {
       const headingLevel = Math.max(1, Math.min(level, 6));
       const headingClass = `indent${level} creative-line level-${headingLevel}`;
-      const line = html`${leading()}${content}${indicator}`;
+      const line = html`${leading()}${lineBody(html`${content}${indicator}`)}`;
       if (this.hasChildren || this.isRoot) {
         switch (headingLevel) {
           case 1:
@@ -287,7 +293,7 @@ class CreativeTreeRow extends LitElement {
 
     const needsBullet = !((this.descriptionHtml || "").includes("<li>"));
     const bullet = needsBullet ? html`<div class="creative-tree-bullet"></div>` : nothing;
-    const line = html`${leading(bullet)}${content}${indicator}`;
+    const line = html`${leading(bullet)}${lineBody(html`${content}${indicator}`)}`;
     return html`
       <div class="creative-tree-li creative-line level-6">
         ${line}

--- a/app/javascript/components/creative_tree_row.js
+++ b/app/javascript/components/creative_tree_row.js
@@ -172,13 +172,7 @@ class CreativeTreeRow extends LitElement {
           style=${this._rowStyle()}
           data-creatives--select-mode-target="row"
         >
-          <div class="creative-row-start">
-            <div class="creative-row-actions">
-              ${this._renderCheckbox()}
-              ${this._renderActionButton()}
-            </div>
-            ${this._renderContent()}
-          </div>
+          <div class="creative-row-start">${this._renderContent()}</div>
           ${unsafeHTML(this.progressHtml || "")}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add vertical tree guide styling with indent-aware spacing on creative rows
- align creative row actions and progress/comment controls to the first-line baseline via shared line-height styling

## Testing
- not run (not requested)

## Original User's Requirements
- creative-row 의 구조를 전체적으로 바꾼다.
- 들여쓰기가 명확하게 보이는 Tree-lines(세로 가이드 라인 - 가늘게) 추가
- 크리에이티브 앞에 선택박스, 수정버튼, 토글버튼 이 세개는 세로로 중앙 정렬이 아니라 첫번째 줄의 중앙 정렬이 되어야 한다. 크리에이티브는 레벨에 따라 한라인의 크기가 다르므로, 그것에 맞게 되어야 한다!
- 마찬가지로 끝(오른쪽) 부분의 진행률표시, 채팅(코멘트) 팝업 열기 버튼도 첫번째 줄의 중앙 정렬이 되어야 한다.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fe2de26608326a45f8a5262e11372)