### PR TITLE
Show all sharing contacts in user management

### DIFF
--- a/app/controllers/creative_shares_controller.rb
+++ b/app/controllers/creative_shares_controller.rb
@@ -33,6 +33,7 @@ class CreativeSharesController < ApplicationController
     end
 
     share = CreativeShare.find_or_initialize_by(creative: @creative, user: user)
+    share.shared_by ||= Current.user
     share.permission = permission
     if share.save and not is_param_no_access
       @creative.create_linked_creative_for_user(user)

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -39,7 +39,12 @@ class SessionsController < ApplicationController
     Invitation.transaction do
       invitation = Invitation.find_by_token_for(:invite, params[:invite_token])
       invitation.update(accepted_at: Time.current, email: user.email)
-      CreativeShare.create!(creative: invitation.creative, user: user, permission: invitation.permission)
+      CreativeShare.create!(
+        creative: invitation.creative,
+        user: user,
+        permission: invitation.permission,
+        shared_by: invitation.inviter
+      )
       invitation.creative.create_linked_creative_for_user(user)
     end
   rescue ActiveSupport::MessageVerifier::InvalidSignature

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -147,21 +147,42 @@ class UsersController < ApplicationController
     per_page = 10
     @contact_page = [ params[:contact_page].to_i, 1 ].max
 
-    scope = Current.user.contacts
-                      .joins(:contact_user)
-                      .includes(contact_user: [ avatar_attachment: :blob ])
-                      .order("users.name ASC")
+    # Collect all relevant user ids (contacts, people I've shared with, people who shared with me)
+    direct_contact_ids = Current.user.contacts.pluck(:contact_user_id)
 
-    @total_contacts = scope.count
+    shared_by_me_ids = CreativeShare
+      .joins(:creative)
+      .where(creatives: { user_id: Current.user.id })
+      .where.not(permission: CreativeShare.permissions[:no_access])
+      .pluck(:user_id)
+
+    shared_with_me_ids = CreativeShare
+      .joins(:creative)
+      .where(user_id: Current.user.id)
+      .where.not(permission: CreativeShare.permissions[:no_access])
+      .pluck("creatives.user_id")
+
+    contact_user_ids = (direct_contact_ids + shared_by_me_ids + shared_with_me_ids).uniq
+
+    users_relation = User
+      .where(id: contact_user_ids)
+      .includes(avatar_attachment: :blob)
+      .order(:name)
+
+    @total_contacts = contact_user_ids.size
     @total_contact_pages = [ (@total_contacts.to_f / per_page).ceil, 1 ].max
-    @contacts = scope.offset((@contact_page - 1) * per_page).limit(per_page)
+    paged_users = users_relation.offset((@contact_page - 1) * per_page).limit(per_page)
 
-    contact_user_ids = @contacts.map(&:contact_user_id)
-    @last_login_map = Session.where(user_id: contact_user_ids).group(:user_id).maximum(:updated_at)
+    existing_contacts = Current.user.contacts.includes(contact_user: [ avatar_attachment: :blob ]).index_by(&:contact_user_id)
+    @contacts = paged_users.map do |user|
+      existing_contacts[user.id] || Contact.new(user: Current.user, contact_user: user)
+    end
+
+    @last_login_map = Session.where(user_id: paged_users.map(&:id)).group(:user_id).maximum(:updated_at)
 
     shares_from_me = CreativeShare
       .joins(:creative)
-      .where(user_id: contact_user_ids, creatives: { user_id: Current.user.id })
+      .where(user_id: paged_users.map(&:id), creatives: { user_id: Current.user.id })
       .where.not(permission: CreativeShare.permissions[:no_access])
       .includes(creative: :rich_text_description)
 
@@ -169,7 +190,7 @@ class UsersController < ApplicationController
 
     shares_to_me = CreativeShare
       .joins(:creative)
-      .where(user_id: Current.user.id, creatives: { user_id: contact_user_ids })
+      .where(user_id: Current.user.id, creatives: { user_id: paged_users.map(&:id) })
       .where.not(permission: CreativeShare.permissions[:no_access])
       .includes(creative: :rich_text_description)
 

--- a/app/models/creative_share.rb
+++ b/app/models/creative_share.rb
@@ -1,6 +1,7 @@
 class CreativeShare < ApplicationRecord
   belongs_to :creative
   belongs_to :user
+  belongs_to :shared_by, class_name: "User", optional: true
 
   enum :permission, {
     no_access: 0,
@@ -23,6 +24,10 @@ class CreativeShare < ApplicationRecord
   # in the ancestors. If there is no ancestor share, returns nil.
   def self.closest_parent_share(ancestor_ids, ancestor_shares)
     ancestor_shares.to_a.min_by { |s| ancestor_ids.index(s.creative_id) || Float::INFINITY }
+  end
+
+  def sharer_id
+    shared_by_id || creative.user_id
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,8 @@ class User < ApplicationRecord
   has_many :comment_read_pointers, dependent: :destroy
   has_many :creative_expanded_states, dependent: :destroy
   has_many :creative_shares, dependent: :destroy
+  has_many :shared_creative_shares, class_name: "CreativeShare", foreign_key: :shared_by_id,
+                                    dependent: :nullify, inverse_of: :shared_by
   has_many :comments, dependent: :destroy
   has_many :emails, dependent: :destroy
   has_many :inbox_items, foreign_key: :owner_id, dependent: :destroy, inverse_of: :owner

--- a/db/migrate/20251002000000_add_shared_by_to_creative_shares.rb
+++ b/db/migrate/20251002000000_add_shared_by_to_creative_shares.rb
@@ -1,6 +1,6 @@
 class AddSharedByToCreativeShares < ActiveRecord::Migration[7.1]
   def change
-    add_reference :creative_shares, :shared_by, foreign_key: { to_table: :users }
+    add_reference :creative_shares, :shared_by, foreign_key: { to_table: :users, on_delete: :nullify }
 
     reversible do |dir|
       dir.up do

--- a/db/migrate/20251002000000_add_shared_by_to_creative_shares.rb
+++ b/db/migrate/20251002000000_add_shared_by_to_creative_shares.rb
@@ -1,0 +1,14 @@
+class AddSharedByToCreativeShares < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :creative_shares, :shared_by, foreign_key: { to_table: :users }
+
+    reversible do |dir|
+      dir.up do
+        CreativeShare.reset_column_information
+        CreativeShare.includes(:creative).find_each do |share|
+          share.update_column(:shared_by_id, share.creative.user_id)
+        end
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_10_01_000001) do
+ActiveRecord::Schema[8.1].define(version: 2025_10_02_000000) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false
@@ -125,10 +125,12 @@ ActiveRecord::Schema[8.1].define(version: 2025_10_01_000001) do
     t.datetime "created_at", null: false
     t.integer "creative_id", null: false
     t.integer "permission", default: 0, null: false
+    t.integer "shared_by_id"
     t.datetime "updated_at", null: false
     t.integer "user_id", null: false
     t.index ["creative_id", "user_id"], name: "index_creative_shares_on_creative_id_and_user_id", unique: true
     t.index ["creative_id"], name: "index_creative_shares_on_creative_id"
+    t.index ["shared_by_id"], name: "index_creative_shares_on_shared_by_id"
     t.index ["user_id"], name: "index_creative_shares_on_user_id"
   end
 
@@ -493,6 +495,7 @@ ActiveRecord::Schema[8.1].define(version: 2025_10_01_000001) do
   add_foreign_key "creative_expanded_states", "users"
   add_foreign_key "creative_shares", "creatives"
   add_foreign_key "creative_shares", "users"
+  add_foreign_key "creative_shares", "users", column: "shared_by_id"
   add_foreign_key "creatives", "creatives", column: "origin_id"
   add_foreign_key "creatives", "creatives", column: "parent_id"
   add_foreign_key "creatives", "users"

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -13,4 +13,15 @@ class UserTest < ActiveSupport::TestCase
     assert_not user.valid?
     assert_includes user.errors[:email], "has already been taken"
   end
+
+  test "nullifies shares created by user as sharer when destroyed" do
+    sharer = users(:two)
+    recipient = users(:three)
+    creative = creatives(:tshirt)
+
+    share = CreativeShare.create!(creative: creative, user: recipient, shared_by: sharer, permission: :read)
+
+    assert_nothing_raised { sharer.destroy! }
+    assert_nil share.reload.shared_by_id
+  end
 end


### PR DESCRIPTION
## Summary
- include anyone who shared creatives with the current user or received shares from the current user in contact management, alongside direct contacts
- create contact entries for non-contact users while preserving pagination, last-login display, and shared creative lists for each row

## Testing
- ./bin/rubocop -a
- bundle exec rails test
- bundle exec rails test:system *(fails: unable to download Chrome driver in this environment)*

## Original User's Requirements
- 지금 사용자 관리에서 내가 크리에이티브를 공유한 사람들, 크리에이티브를 나한테 공유한 사람, 내가 초대한 사람이 모두 표시되어야 하는데, 모두 표시할 수 있도록 수정해줘.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692007c35de48326991d95753acc3f93)