### PR TITLE
Handle creative id from event details when opening comments

### DIFF
--- a/app/javascript/controllers/comments/popup_controller.js
+++ b/app/javascript/controllers/comments/popup_controller.js
@@ -82,37 +82,41 @@ export default class extends Controller {
 
   handleCreativeClick(event) {
     const button = event.detail?.button
+    const creativeId = event.detail?.creativeId
     if (!button) return
-    if (this.element.style.display === 'block' && this.element.dataset.creativeId === button.dataset.creativeId) {
+    if (
+      this.element.style.display === 'block' &&
+      this.element.dataset.creativeId === (creativeId || button.dataset.creativeId)
+    ) {
       this.close()
       return
     }
-    this.open(button)
+    this.open(button, { creativeId })
   }
 
-  open(button, { highlightId } = {}) {
+  open(button, { creativeId, highlightId } = {}) {
     this.currentButton = button
-    const creativeId = button.dataset.creativeId
+    const resolvedCreativeId = creativeId || button?.dataset.creativeId
     const canComment = button.dataset.canComment === 'true'
     const snippet = button.dataset.creativeSnippet || ''
 
-    this.element.dataset.creativeId = creativeId || ''
+    this.element.dataset.creativeId = resolvedCreativeId || ''
     this.element.dataset.canComment = canComment ? 'true' : 'false'
     this.titleTarget.textContent = snippet
 
     this.prepareSize()
 
     if (this.formController) {
-      this.formController.onPopupOpened({ creativeId, canComment })
+      this.formController.onPopupOpened({ creativeId: resolvedCreativeId, canComment })
     }
     if (this.listController) {
-      this.listController.onPopupOpened({ creativeId, highlightId })
+      this.listController.onPopupOpened({ creativeId: resolvedCreativeId, highlightId })
     }
     if (this.presenceController) {
-      this.presenceController.onPopupOpened({ creativeId })
+      this.presenceController.onPopupOpened({ creativeId: resolvedCreativeId })
     }
     if (this.mentionMenuController) {
-      this.mentionMenuController.onPopupOpened({ creativeId })
+      this.mentionMenuController.onPopupOpened({ creativeId: resolvedCreativeId })
     }
 
     this.showPopup()


### PR DESCRIPTION
## Summary
- use the creative id provided in the creative click event when opening the comments popup so requests use the correct path
- propagate the resolved creative id to dependent comment controllers when the popup opens

## Testing
- ./bin/rubocop -a
- bundle exec rails test
- bundle exec rails test:system *(fails: unable to download/locate chromedriver in this environment)*

## Original User's Requirements
- Fix the issue where clicking approve immediately after opening a chat sends a request to `/creatives/undefined/...`, causing a 404.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920169fdd8c8326b8ceacef42aa4f82)