### PR TITLE
Patch OmniAuth token verifier to avoid Configurable deprecation

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -3,6 +3,10 @@ require_relative "boot"
 require "rails/all"
 require_relative "../lib/collavre/version"
 
+lib_path = File.expand_path("../lib", __dir__)
+$LOAD_PATH.unshift(lib_path) unless $LOAD_PATH.include?(lib_path)
+require "omniauth/rails_csrf_protection/token_verifier"
+
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)

--- a/lib/omniauth/rails_csrf_protection/token_verifier.rb
+++ b/lib/omniauth/rails_csrf_protection/token_verifier.rb
@@ -1,0 +1,45 @@
+require "action_controller"
+
+module OmniAuth
+  module RailsCsrfProtection
+    # Provides a callable method that verifies Cross-Site Request Forgery
+    # protection token. This implementation mirrors the omniauth-rails_csrf_protection
+    # behavior without relying on the deprecated ActiveSupport::Configurable module.
+    class TokenVerifier
+      class << self
+        def config
+          ActionController::Base.config
+        end
+      end
+
+      include ActionController::RequestForgeryProtection
+
+      def self.configure_from_action_controller!
+        config.to_h.keys.each do |configuration_name|
+          remove_method(configuration_name) if method_defined?(configuration_name)
+
+          define_method(configuration_name) do
+            config[configuration_name]
+          end
+        end
+      end
+
+      configure_from_action_controller!
+
+      def call(env)
+        dup._call(env)
+      end
+
+      def _call(env)
+        @request = ActionDispatch::Request.new(env.dup)
+
+        raise ActionController::InvalidAuthenticityToken unless verified_request?
+      end
+
+      private
+
+        attr_reader :request
+        delegate :params, :session, to: :request
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- preload the application lib path and custom OmniAuth token verifier before bundling gems
- provide a local TokenVerifier implementation that mirrors omniauth-rails_csrf_protection without using ActiveSupport::Configurable
- ensure CSRF token configuration delegates to ActionController settings while avoiding the deprecated API

## Testing
- bundle exec rubocop -a
- bundle exec rails test
- bundle exec rails test:system *(fails: Selenium manager could not download Chrome/chromedriver in the sandboxed environment)*

## Original User's Requirements
- Address the warning: "DEPRECATION WARNING: ActiveSupport::Configurable is deprecated without replacement, and will be removed in Rails 8.2."

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692021e197b08326ba2bf058b42a0ea9)