### PR TITLE
refactor(creative-row): improve layout, alignment, and typography

### DIFF
--- a/app/assets/stylesheets/creatives.css
+++ b/app/assets/stylesheets/creatives.css
@@ -1,6 +1,4 @@
-
-#creatives {
-}
+/* #creatives {} - removed empty rule */
 
 .creative-actions-row {
     margin: 0.0em 1.0em;
@@ -26,6 +24,7 @@
     box-shadow: 0 2px 8px var(--color-border);
     min-width: 220px;
 }
+
 .delete-one {
     margin-bottom: 0.5em;
 }
@@ -71,12 +70,42 @@
 
 .creative-tree-li {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
+    /* Changed from center to flex-start */
+    position: relative;
 }
+
+/* Tree Lines */
+.tree-line {
+    width: 10px;
+    /* Indentation width matching toggle button */
+    min-width: 10px;
+    display: flex;
+    justify-content: center;
+    position: relative;
+    align-self: stretch;
+    /* Stretch to full height of the row */
+}
+
+.tree-line::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 50%;
+    width: 1px;
+    background-color: var(--color-border);
+    /* Thin guide line */
+    opacity: 0.5;
+}
+
 .creative-content {
     min-width: min(50vw, var(--max-width) / 2);
     max-width: calc(min(100vw, var(--max-width)) - 160px);
+    padding-top: 2px;
+    /* Slight adjustment for text baseline */
 }
+
 .creative-row:hover .creative-content {
     text-decoration: underline;
     text-decoration-color: var(--color-link);
@@ -104,6 +133,8 @@
     margin-left: 4px;
     margin-right: 8px;
     flex: 0 0 5px;
+    margin-top: 10px;
+    /* Align with first line of text (approx) */
 }
 
 .creative-row-end {
@@ -111,6 +142,10 @@
     color: var(--color-muted);
     font-size: 0.9em;
     white-space: nowrap;
+    display: flex;
+    align-items: flex-start;
+    /* Top align */
+    /* padding-top: 4px; - Removed to align comments button with edit button */
 }
 
 .creative-tags {
@@ -119,19 +154,28 @@
     white-space: nowrap;
     display: flex;
     flex-wrap: wrap;
+    padding-top: 4px;
+    /* Restore baseline alignment */
 }
 
-.creative-progress-complete {
+.creative-progress-complete,
+.creative-progress-incomplete {
     color: var(--color-complete);
+    padding-top: 4px;
+    /* Restore baseline alignment */
 }
 
 .creative-progress-incomplete {
-    /* ok */
+    color: var(--color-muted);
 }
+
+/* .creative-progress-incomplete {} - removed empty rule */
 
 .creative-row-start {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
+    /* Changed from center to flex-start */
+    flex-grow: 1;
 }
 
 .creative-loading-indicator {
@@ -158,9 +202,13 @@
 }
 
 @keyframes creative-loading-ellipsis {
-    0%, 60%, 100% {
+
+    0%,
+    60%,
+    100% {
         opacity: 0.2;
     }
+
     30% {
         opacity: 1;
     }
@@ -192,6 +240,8 @@
     line-height: 1;
     display: inline-flex;
     flex-shrink: 0;
+    padding-top: 4px;
+    /* Align with text */
 }
 
 .voice-input-active {
@@ -206,7 +256,15 @@
     height: 16px;
     font-size: 14px;
     margin-right: 4px;
+    margin-top: 4px;
+    /* Align with text */
     visibility: hidden;
+    /* Hidden by default on desktop */
+    /* Total width is 20px (16 + 4) */
+}
+
+.creative-row:hover .creative-toggle-btn {
+    visibility: visible;
 }
 
 .add-creative-btn {
@@ -216,28 +274,25 @@
 }
 
 
-.creative-row-actions {
+/* Replaced creative-row-actions visibility logic with direct targeting */
+.edit-inline-btn {
     visibility: hidden;
-    display: flex;
-    align-items: center;
-    align-self: stretch;
+    opacity: 0;
+    transition: opacity 0.2s ease;
+    width: 20px;
+    /* Fixed width for alignment */
 }
 
-.creative-row:hover .creative-row-actions {
+.creative-row:hover .edit-inline-btn {
     visibility: visible;
-}
-
-.creative-row:hover .creative-toggle-btn {
-    visibility: visible;
+    opacity: 1;
 }
 
 @media (max-width: 768px) {
-    .creative-row-actions {
-        visibility: visible !important;
-    }
     .creative-toggle-btn {
         visibility: visible !important;
     }
+
     .edit-inline-btn {
         max-width: 0;
         opacity: 0;
@@ -246,11 +301,13 @@
         transform: translateX(10px);
         transition: max-width 0.3s ease, opacity 0.3s ease, transform 0.3s ease;
     }
+
     .creative-row.show-edit .edit-inline-btn {
         max-width: 40px;
         opacity: 1;
         transform: translateX(0);
         pointer-events: auto;
+        visibility: visible;
     }
 }
 
@@ -273,7 +330,8 @@
         position: absolute;
         left: 0;
         width: 100%;
-        height: 6px; /* border thickness */
+        height: 6px;
+        /* border thickness */
         background: var(--color-bg);
     }
 
@@ -292,12 +350,17 @@
     height: 16px;
     cursor: pointer;
     visibility: visible;
+    margin-top: 6px;
+    /* Align with text */
 }
 
 .creative-row {
     display: flex;
     justify-content: space-between;
-    align-items: center;
+    align-items: flex-start;
+    /* Changed from center to flex-start */
+    padding: 2px 0;
+    /* Add some vertical padding */
 }
 
 .creative-row.selected {
@@ -312,6 +375,8 @@
     color: var(--color-muted);
     font-size: 0.9em;
     margin-left: 10px;
+    padding-top: 4px;
+    /* Align with text */
 }
 
 .page-title {
@@ -340,21 +405,51 @@
 
 .creative-row-start h1 {
     font-size: 1.3em;
+    margin: 0;
 }
 
 .creative-row-start h2 {
     font-size: 1.2em;
+    margin: 0;
 }
 
 .creative-row-start h3 {
     font-size: 1.1em;
+    margin: 0;
 }
+
+.creative-row-start h4,
+.creative-row-start h5,
+.creative-row-start h6 {
+    margin: 0;
+}
+
+/* Headings need specific alignment adjustments */
+.level-1 .creative-action-btn,
+.level-1 .select-creative-checkbox,
+.level-1 .creative-toggle-btn {
+    margin-top: 8px;
+}
+
+.level-2 .creative-action-btn,
+.level-2 .select-creative-checkbox,
+.level-2 .creative-toggle-btn {
+    margin-top: 7px;
+}
+
+.level-3 .creative-action-btn,
+.level-3 .select-creative-checkbox,
+.level-3 .creative-toggle-btn {
+    margin-top: 6px;
+}
+
 
 .indent1,
 .indent2,
 .indent3 {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
+    /* Changed from center to flex-start */
 }
 
 .indent1 {
@@ -374,6 +469,23 @@
     height: 28px;
     position: relative;
     color: var(--color-text);
+    margin-top: -2px;
+    /* Move higher as requested */
+}
+
+/* Ensure comments button stays high for headings, overriding generic action button margin */
+.level-1 .comments-btn,
+.level-2 .comments-btn,
+.level-3 .comments-btn {
+    margin-top: -2px;
+}
+
+/* Add spacing for headings via row padding to preserve alignment */
+.creative-row.level-1,
+.creative-row.level-2,
+.creative-row.level-3 {
+    padding-top: 6px;
+    padding-bottom: 6px;
 }
 
 .comment-icon {

--- a/app/javascript/components/creative_tree_row.js
+++ b/app/javascript/components/creative_tree_row.js
@@ -175,9 +175,7 @@ class CreativeTreeRow extends LitElement {
             ${this._renderToggle()}
             ${this._renderContent()}
           </div>
-          <div class="creative-row-end">
-             ${unsafeHTML(this.progressHtml || "")}
-          </div>
+            ${unsafeHTML(this.progressHtml || "")}
         </div>
       </div>
     `;

--- a/app/javascript/components/creative_tree_row.js
+++ b/app/javascript/components/creative_tree_row.js
@@ -167,15 +167,17 @@ class CreativeTreeRow extends LitElement {
         draggable=${draggableAttr}
         data-action=${dragActions}
       >
-        <div class="creative-row" data-creatives--select-mode-target="row">
+        <div class="creative-row level-${this.level}" data-creatives--select-mode-target="row">
           <div class="creative-row-start">
-            <div class="creative-row-actions">
-              ${this._renderCheckbox()}
-              ${this._renderActionButton()}
-            </div>
+            ${this._renderCheckbox()}
+            ${this._renderActionButton()}
+            ${this._renderTreeLines()}
+            ${this._renderToggle()}
             ${this._renderContent()}
           </div>
-          ${unsafeHTML(this.progressHtml || "")}
+          <div class="creative-row-end">
+             ${unsafeHTML(this.progressHtml || "")}
+          </div>
         </div>
       </div>
     `;
@@ -204,6 +206,16 @@ class CreativeTreeRow extends LitElement {
         </div>
       </div>
     `;
+  }
+
+  _renderTreeLines() {
+    const level = Number(this.level) || 1;
+    const lines = [];
+    // Render a tree line for each level of depth minus 1 (since level 1 is root-ish)
+    for (let i = 1; i < level; i++) {
+      lines.push(html`<div class="tree-line"></div>`);
+    }
+    return lines;
   }
 
   _renderCheckbox() {
@@ -243,7 +255,7 @@ class CreativeTreeRow extends LitElement {
 
   _renderContent() {
     const level = Number(this.level) || 1;
-    const toggle = this._renderToggle();
+    // Toggle is now rendered outside
     const content = html`
       <div class="creative-content">
         <a class="unstyled-link" href=${this.linkUrl || "#"}>${unsafeHTML(this.descriptionHtml || "")}</a>
@@ -253,34 +265,37 @@ class CreativeTreeRow extends LitElement {
 
     if (level <= BULLET_STARTING_LEVEL) {
       const headingClass = `indent${level}`;
-      if (this.hasChildren || this.isRoot) {
-        const headingLevel = Math.max(1, Math.min(level, 6));
-        switch (headingLevel) {
-          case 1:
-            return html`<h1 class=${headingClass}>${toggle}${content}${indicator}</h1>`;
-          case 2:
-            return html`<h2 class=${headingClass}>${toggle}${content}${indicator}</h2>`;
-          case 3:
-            return html`<h3 class=${headingClass}>${toggle}${content}${indicator}</h3>`;
-          case 4:
-            return html`<h4 class=${headingClass}>${toggle}${content}${indicator}</h4>`;
-          case 5:
-            return html`<h5 class=${headingClass}>${toggle}${content}${indicator}</h5>`;
-          default:
-            return html`<h6 class=${headingClass}>${toggle}${content}${indicator}</h6>`;
-        }
+
+      // If no children, render as div instead of heading to avoid large font size
+      if (!this.hasChildren) {
+        return html`<div class=${headingClass}>${content}${indicator}</div>`;
       }
-      return html`<div class=${headingClass}>${toggle}${content}${indicator}</div>`;
+
+      // We wrap content in heading tags for semantics
+      const headingLevel = Math.max(1, Math.min(level, 6));
+      switch (headingLevel) {
+        case 1:
+          return html`<h1 class=${headingClass}>${content}${indicator}</h1>`;
+        case 2:
+          return html`<h2 class=${headingClass}>${content}${indicator}</h2>`;
+        case 3:
+          return html`<h3 class=${headingClass}>${content}${indicator}</h3>`;
+        case 4:
+          return html`<h4 class=${headingClass}>${content}${indicator}</h4>`;
+        case 5:
+          return html`<h5 class=${headingClass}>${content}${indicator}</h5>`;
+        default:
+          return html`<h6 class=${headingClass}>${content}${indicator}</h6>`;
+      }
     }
 
-    const margin = level > BULLET_STARTING_LEVEL
-      ? `margin-left: ${(level - BULLET_STARTING_LEVEL) * 20}px;`
-      : "";
+    // For deeper levels, we use div. But we don't need margin-left anymore because we have tree lines.
+    // We still keep the bullet if needed.
     const needsBullet = !((this.descriptionHtml || "").includes("<li>"));
     const bullet = needsBullet ? html`<div class="creative-tree-bullet"></div>` : nothing;
     return html`
-      <div class="creative-tree-li" style=${margin}>
-        ${toggle}${bullet}${content}${indicator}
+      <div class="creative-tree-li">
+        ${bullet}${content}${indicator}
       </div>
     `;
   }

--- a/app/javascript/creative_row_editor.js
+++ b/app/javascript/creative_row_editor.js
@@ -599,20 +599,6 @@ export function initializeCreativeRowEditor() {
           return; // Event handled
         }
 
-        // Handle inline-level-down (create child)
-        const levelDownBtn = e.target.closest('#inline-level-down');
-        if (levelDownBtn) {
-          e.preventDefault();
-          if (!currentTree) return;
-
-          const parentId = currentTree.dataset.id;
-          saveForm().then(() => {
-            const container = ensureChildrenContainer(currentTree);
-            expandChildrenContainer(container);
-            startNew(parentId, container, container.firstElementChild, '');
-          });
-          return;
-        }
 
         // Delegated event for .new-root-creative-btn
         const newRootBtn = e.target.closest('.new-root-creative-btn');

--- a/app/javascript/creative_row_editor.js
+++ b/app/javascript/creative_row_editor.js
@@ -14,7 +14,7 @@ export function initializeCreativeRowEditor() {
   if (initialized) return;
   initialized = true;
 
-  document.addEventListener('turbo:load', function() {
+  document.addEventListener('turbo:load', function () {
     const template = document.getElementById('inline-edit-form');
     if (!template) return;
 
@@ -66,15 +66,15 @@ export function initializeCreativeRowEditor() {
     let saving = false;
     let savePromise = Promise.resolve();
     let uploadsPending = false;
-let uploadCompletionPromise = null;
-let resolveUploadCompletion = null;
+    let uploadCompletionPromise = null;
+    let resolveUploadCompletion = null;
 
-function formatProgressDisplay(value) {
-  const numeric = Number(value);
-  if (Number.isNaN(numeric)) return '0%';
-  const percentage = Math.round(numeric * 100);
-  return `${percentage}%`;
-}
+    function formatProgressDisplay(value) {
+      const numeric = Number(value);
+      if (Number.isNaN(numeric)) return '0%';
+      const percentage = Math.round(numeric * 100);
+      return `${percentage}%`;
+    }
 
     function treeRowElement(node) {
       return node && node.closest ? node.closest('creative-tree-row') : null;
@@ -547,7 +547,7 @@ function formatProgressDisplay(value) {
 
     function initializeEventListeners() {
       if (!creativeEditClickHandler) {
-        creativeEditClickHandler = function(e) {
+        creativeEditClickHandler = function (e) {
           const tree = e.detail?.treeElement || e.detail?.button?.closest('.creative-tree');
           if (!tree) return;
           e.preventDefault();
@@ -556,7 +556,7 @@ function formatProgressDisplay(value) {
         document.addEventListener('creative-edit-click', creativeEditClickHandler);
       }
 
-      document.body.addEventListener('click', function(e) {
+      document.body.addEventListener('click', function (e) {
         // Delegated event for .edit-inline-btn
         const editBtn = e.target.closest('.edit-inline-btn');
         if (editBtn) {
@@ -597,6 +597,21 @@ function formatProgressDisplay(value) {
           }
           startNew(parentId, container, insertBefore, beforeId);
           return; // Event handled
+        }
+
+        // Handle inline-level-down (create child)
+        const levelDownBtn = e.target.closest('#inline-level-down');
+        if (levelDownBtn) {
+          e.preventDefault();
+          if (!currentTree) return;
+
+          const parentId = currentTree.dataset.id;
+          saveForm().then(() => {
+            const container = ensureChildrenContainer(currentTree);
+            expandChildrenContainer(container);
+            startNew(parentId, container, container.firstElementChild, '');
+          });
+          return;
         }
 
         // Delegated event for .new-root-creative-btn
@@ -714,18 +729,18 @@ function formatProgressDisplay(value) {
     }
 
     function saveForm(tree = currentTree, parentId = parentInput.value) {
-      return waitForUploads().then(function() {
+      return waitForUploads().then(function () {
         if (saving) return savePromise;
         clearTimeout(saveTimer);
         const method = methodInput.value === 'patch' ? 'PATCH' : 'POST';
         pendingSave = false;
         if (!form.action) return Promise.resolve();
         saving = true;
-        savePromise = creativesApi.save(form.action, method, form).then(function(r) {
+        savePromise = creativesApi.save(form.action, method, form).then(function (r) {
           if (!r.ok) return r;
-          return r.text().then(function(text) {
+          return r.text().then(function (text) {
             try { return text ? JSON.parse(text) : {}; } catch (e) { return {}; }
-          }).then(function(data) {
+          }).then(function (data) {
             if (method === 'POST' && data.id) {
               form.action = `/creatives/${data.id}`;
               methodInput.value = 'patch';
@@ -766,7 +781,7 @@ function formatProgressDisplay(value) {
               if (tree) refreshRow(tree);
             }
           });
-        }).finally(function() {
+        }).finally(function () {
           saving = false;
         });
         return savePromise;
@@ -785,7 +800,7 @@ function formatProgressDisplay(value) {
       currentRowElement = null;
       tree.draggable = true;
 
-      const finalizeHide = function() {
+      const finalizeHide = function () {
         template.style.display = 'none';
         const p = (pendingSave || saving) ? saveForm(tree, parentId) : Promise.resolve();
         return p.then(() => {
@@ -827,16 +842,16 @@ function formatProgressDisplay(value) {
     }
 
     function beforeNewOrMove(wasNew, prev, prevParent) {
-        const needsSave = pendingSave || wasNew || saving;
-        const p = needsSave ? saveForm(prev, prevParent) : Promise.resolve();
-        return p.then(() => {
-            if (wasNew && !form.dataset.creativeId) {
-                removeTreeElement(prev);
-            } else {
-                showRow(prev);
-                refreshRow(prev);
-            }
-        });
+      const needsSave = pendingSave || wasNew || saving;
+      const p = needsSave ? saveForm(prev, prevParent) : Promise.resolve();
+      return p.then(() => {
+        if (wasNew && !form.dataset.creativeId) {
+          removeTreeElement(prev);
+        } else {
+          showRow(prev);
+          refreshRow(prev);
+        }
+      });
     }
 
     function move(delta) {
@@ -871,7 +886,7 @@ function formatProgressDisplay(value) {
         const isCollapsed = childContainer && childContainer.style.display === 'none';
         const firstChild = childContainer && childContainer.querySelector('.creative-tree');
         let parentId, container, insertBefore,
-            beforeId = '', afterId = '';
+          beforeId = '', afterId = '';
         if (firstChild && !isCollapsed) {
           parentId = prevCreativeId;
           container = childContainer;
@@ -1035,7 +1050,7 @@ function formatProgressDisplay(value) {
         .then(results => {
           linkResults.innerHTML = '';
           if (Array.isArray(results)) {
-            results.forEach(function(c) {
+            results.forEach(function (c) {
               const li = document.createElement('li');
               li.textContent = c.description;
               li.dataset.id = c.id;
@@ -1284,13 +1299,13 @@ function formatProgressDisplay(value) {
       return !!node && $isRootOrShadowRoot(node);
     }
 
-    progressInput.addEventListener('input', function() {
+    progressInput.addEventListener('input', function () {
       progressValue.textContent = formatProgressDisplay(progressInput.value);
       scheduleSave();
     });
 
     if (parentSuggestBtn && parentSuggestions) {
-      parentSuggestBtn.addEventListener('click', function() {
+      parentSuggestBtn.addEventListener('click', function () {
         const originalLabel = parentSuggestBtn.textContent;
         parentSuggestBtn.disabled = true;
         parentSuggestBtn.textContent = `${originalLabel}...`;
@@ -1298,16 +1313,16 @@ function formatProgressDisplay(value) {
         parentSuggestions.style.display = 'block';
 
         saveForm()
-          .then(function() {
+          .then(function () {
             const id = form.dataset.creativeId;
             if (!id) {
               parentSuggestions.style.display = 'none';
               return;
             }
-            return creativesApi.parentSuggestions(id).then(function(data) {
+            return creativesApi.parentSuggestions(id).then(function (data) {
               parentSuggestions.innerHTML = '';
               if (data && data.length) {
-                data.forEach(function(s) {
+                data.forEach(function (s) {
                   const opt = document.createElement('option');
                   opt.value = s.id;
                   opt.textContent = s.path;
@@ -1319,7 +1334,7 @@ function formatProgressDisplay(value) {
               }
             });
           })
-          .finally(function() {
+          .finally(function () {
             parentSuggestBtn.textContent = originalLabel;
             parentSuggestBtn.disabled = false;
           });
@@ -1327,11 +1342,11 @@ function formatProgressDisplay(value) {
     }
 
     if (parentSuggestions) {
-      parentSuggestions.addEventListener('change', function() {
+      parentSuggestions.addEventListener('change', function () {
         if (!this.value) return;
         parentInput.value = this.value;
         const targetId = this.value;
-        saveForm().then(function() {
+        saveForm().then(function () {
           window.location.href = `/creatives/${targetId}`;
         });
       });
@@ -1341,11 +1356,11 @@ function formatProgressDisplay(value) {
       closeBtn.addEventListener('click', hideCurrent);
     }
 
-    upBtn.addEventListener('click', function() {
+    upBtn.addEventListener('click', function () {
       if (pendingSave) saveForm();
       move(-1);
     });
-    downBtn.addEventListener('click', function() {
+    downBtn.addEventListener('click', function () {
       if (pendingSave) saveForm();
       move(1);
     });
@@ -1363,86 +1378,86 @@ function formatProgressDisplay(value) {
     }
 
     if (deleteBtn) {
-      deleteBtn.addEventListener('click', function() {
+      deleteBtn.addEventListener('click', function () {
         if (confirm(deleteBtn.dataset.confirm)) deleteCurrent(false);
       });
     }
 
-      if (deleteWithChildrenBtn) {
-        deleteWithChildrenBtn.addEventListener('click', function() {
-          if (confirm(deleteWithChildrenBtn.dataset.confirm)) deleteCurrent(true);
-        });
-      }
+    if (deleteWithChildrenBtn) {
+      deleteWithChildrenBtn.addEventListener('click', function () {
+        if (confirm(deleteWithChildrenBtn.dataset.confirm)) deleteCurrent(true);
+      });
+    }
 
-      if (linkBtn) {
-        linkBtn.addEventListener('click', linkExistingCreative);
-      }
+    if (linkBtn) {
+      linkBtn.addEventListener('click', linkExistingCreative);
+    }
 
-      if (linkSearchInput) {
-        linkSearchInput.addEventListener('input', searchLinkCreatives);
-      }
+    if (linkSearchInput) {
+      linkSearchInput.addEventListener('input', searchLinkCreatives);
+    }
 
-      if (linkResults) {
-        linkResults.addEventListener('click', handleLinkResultClick);
-        linkResults.addEventListener('keydown', handleLinkResultKeydown);
-      }
+    if (linkResults) {
+      linkResults.addEventListener('click', handleLinkResultClick);
+      linkResults.addEventListener('keydown', handleLinkResultKeydown);
+    }
 
-      if (linkCloseBtn && linkModal) {
-        linkCloseBtn.addEventListener('click', closeLinkModal);
-        linkModal.addEventListener('click', function(e) {
-          if (e.target === linkModal) closeLinkModal();
-        });
-      }
+    if (linkCloseBtn && linkModal) {
+      linkCloseBtn.addEventListener('click', closeLinkModal);
+      linkModal.addEventListener('click', function (e) {
+        if (e.target === linkModal) closeLinkModal();
+      });
+    }
 
-      if (unlinkBtn) {
-        unlinkBtn.addEventListener('click', function() {
-          if (confirm(unlinkBtn.dataset.confirm)) deleteCurrent(false);
-        });
-      }
+    if (unlinkBtn) {
+      unlinkBtn.addEventListener('click', function () {
+        if (confirm(unlinkBtn.dataset.confirm)) deleteCurrent(false);
+      });
+    }
 
-      if (unconvertBtn) {
-        unconvertBtn.addEventListener('click', function() {
-          const creativeId = form.dataset.creativeId;
-          if (!creativeId) return;
-          const confirmText = unconvertBtn.dataset.confirm;
-          if (confirmText && !confirm(confirmText)) return;
-          const errorMessage = unconvertBtn.dataset.error || 'Failed to unconvert.';
-          unconvertBtn.disabled = true;
-          saveForm()
-            .then(function(saveResponse) {
-              if (saveResponse && saveResponse.ok === false) {
-                return saveResponse
-                  .json()
-                  .catch(function() { return {}; })
-                  .then(function(data) {
-                    alert(data && data.error ? data.error : errorMessage);
-                    const error = new Error('Save failed');
-                    error._handled = true;
-                    throw error;
-                  });
-              }
-              return creativesApi.unconvert(creativeId);
-            })
-            .then(function(response) {
-              if (response.ok) {
-                location.reload();
-                return;
-              }
-              return response
+    if (unconvertBtn) {
+      unconvertBtn.addEventListener('click', function () {
+        const creativeId = form.dataset.creativeId;
+        if (!creativeId) return;
+        const confirmText = unconvertBtn.dataset.confirm;
+        if (confirmText && !confirm(confirmText)) return;
+        const errorMessage = unconvertBtn.dataset.error || 'Failed to unconvert.';
+        unconvertBtn.disabled = true;
+        saveForm()
+          .then(function (saveResponse) {
+            if (saveResponse && saveResponse.ok === false) {
+              return saveResponse
                 .json()
-                .catch(function() { return {}; })
-                .then(function(data) {
+                .catch(function () { return {}; })
+                .then(function (data) {
                   alert(data && data.error ? data.error : errorMessage);
+                  const error = new Error('Save failed');
+                  error._handled = true;
+                  throw error;
                 });
-            })
-            .catch(function(error) {
-              if (error && error._handled) return;
-              alert(errorMessage);
-            })
-            .finally(function() {
-              unconvertBtn.disabled = false;
-            });
-        });
-      }
-    });
-  }
+            }
+            return creativesApi.unconvert(creativeId);
+          })
+          .then(function (response) {
+            if (response.ok) {
+              location.reload();
+              return;
+            }
+            return response
+              .json()
+              .catch(function () { return {}; })
+              .then(function (data) {
+                alert(data && data.error ? data.error : errorMessage);
+              });
+          })
+          .catch(function (error) {
+            if (error && error._handled) return;
+            alert(errorMessage);
+          })
+          .finally(function () {
+            unconvertBtn.disabled = false;
+          });
+      });
+    }
+  });
+}


### PR DESCRIPTION
- Align all row elements to `flex-start` to ensure controls align with the first line of text.
- Add explicit `.tree-line` elements for visual indentation guides.
- Update `.creative-toggle-btn` to be visible only on hover for desktop, reducing clutter.
- Refactor `CreativeTreeRow` to render leaf nodes (Level 1-3 without children) as `div`s instead of headings to improve readability.
- Replace heading margins with row padding to increase vertical spacing while maintaining button alignment.
- Fix editor action button sizing and child creation workflow.
- Adjust comments button position for better vertical alignment with text.