### PR TITLE
Fix Korean IME empty creative bug with debounce guard

### DIFF
--- a/app/javascript/creative_row_editor.js
+++ b/app/javascript/creative_row_editor.js
@@ -68,6 +68,7 @@ export function initializeCreativeRowEditor() {
     let uploadsPending = false;
     let uploadCompletionPromise = null;
     let resolveUploadCompletion = null;
+    let addNewInProgress = false;
 
     function formatProgressDisplay(value) {
       const numeric = Number(value);
@@ -863,11 +864,21 @@ export function initializeCreativeRowEditor() {
 
     function addNew() {
       if (!currentTree) return;
+
+      // Prevent multiple simultaneous calls to addNew (e.g., from Lexical onChange + keyboard event)
+      if (addNewInProgress) {
+        return;
+      }
+      addNewInProgress = true;
+      setTimeout(() => { addNewInProgress = false; }, 300);
+
       const prev = currentTree;
       const wasNew = !form.dataset.creativeId;
       const prevParent = parentInput.value;
+
       beforeNewOrMove(wasNew, prev, prevParent).then(() => {
         const prevCreativeId = prev.dataset.id;
+
         const childContainer = document.getElementById('creative-children-' + prevCreativeId);
         const isCollapsed = childContainer && childContainer.style.display === 'none';
         const firstChild = childContainer && childContainer.querySelector('.creative-tree');
@@ -885,6 +896,8 @@ export function initializeCreativeRowEditor() {
           insertBefore = nodeAfterTreeBlock(prev);
         }
         startNew(parentId, container, insertBefore, beforeId, afterId);
+      }).finally(() => {
+        addNewInProgress = false;
       });
     }
 


### PR DESCRIPTION
- Added debounce guard to prevent addNew() from being called multiple times
- Fixes issue where typing Korean text and pressing Shift+Enter would create empty creative
- Root cause: Shift+Enter triggered both keyboard event and Lexical onChange event
- Solution: addNewInProgress flag prevents duplicate calls within 300ms window