### PR TITLE
Disable inline editor actions when unavailable

### DIFF
--- a/app/assets/stylesheets/creatives.css
+++ b/app/assets/stylesheets/creatives.css
@@ -256,6 +256,25 @@ creative-tree-row.show-edit .creative-row {
     /* Align with text */
 }
 
+.creative-action-btn:disabled,
+.popup-menu-toggle:disabled,
+.popup-menu .popup-menu-item:disabled {
+    opacity: 0.4;
+    color: var(--color-muted);
+    cursor: not-allowed;
+    filter: grayscale(100%);
+}
+
+.creative-action-btn:disabled .icon-svg,
+.popup-menu-toggle:disabled .icon-svg,
+.popup-menu .popup-menu-item:disabled .icon-svg {
+    opacity: 0.75;
+}
+
+.popup-menu-toggle:disabled {
+    pointer-events: none;
+}
+
 .voice-input-active {
     background-color: #2ecc71;
     color: #ffffff;

--- a/app/components/popup_menu_component.html.erb
+++ b/app/components/popup_menu_component.html.erb
@@ -1,9 +1,5 @@
 <div class="popup-menu-wrapper" data-controller="popup-menu">
-  <button type="button"
-          <%= "id=\"#{button_id}\"" if button_id.present? %>
-          class="popup-menu-toggle <%= button_classes %>"
-          data-action="click->popup-menu#toggle"
-          data-popup-menu-target="button">
+  <button type="button" class="popup-menu-toggle <%= button_classes %>" data-action="click->popup-menu#toggle" data-popup-menu-target="button">
     <%= raw button_content %>
   </button>
   <div id="<%= menu_id %>" class="popup-menu <%= 'popup-menu-right' if align.to_sym == :right %>" data-popup-menu-target="menu" data-action="click->popup-menu#menuClick">

--- a/app/components/popup_menu_component.html.erb
+++ b/app/components/popup_menu_component.html.erb
@@ -1,5 +1,9 @@
 <div class="popup-menu-wrapper" data-controller="popup-menu">
-  <button type="button" class="popup-menu-toggle <%= button_classes %>" data-action="click->popup-menu#toggle" data-popup-menu-target="button">
+  <button type="button"
+          <%= "id=\"#{button_id}\"" if button_id.present? %>
+          class="popup-menu-toggle <%= button_classes %>"
+          data-action="click->popup-menu#toggle"
+          data-popup-menu-target="button">
     <%= raw button_content %>
   </button>
   <div id="<%= menu_id %>" class="popup-menu <%= 'popup-menu-right' if align.to_sym == :right %>" data-popup-menu-target="menu" data-action="click->popup-menu#menuClick">

--- a/app/components/popup_menu_component.html.erb
+++ b/app/components/popup_menu_component.html.erb
@@ -1,7 +1,5 @@
 <div class="popup-menu-wrapper" data-controller="popup-menu">
-  <button type="button" class="popup-menu-toggle <%= button_classes %>" data-action="click->popup-menu#toggle" data-popup-menu-target="button">
-    <%= raw button_content %>
-  </button>
+  <%= button_tag raw(button_content), button_options %>
   <div id="<%= menu_id %>" class="popup-menu <%= 'popup-menu-right' if align.to_sym == :right %>" data-popup-menu-target="menu" data-action="click->popup-menu#menuClick">
     <%= content %>
   </div>

--- a/app/components/popup_menu_component.rb
+++ b/app/components/popup_menu_component.rb
@@ -1,10 +1,28 @@
 class PopupMenuComponent < ViewComponent::Base
-  def initialize(button_content:, button_classes: "", menu_id: nil, align: :left)
+  def initialize(button_content:, button_classes: "", menu_id: nil, align: :left, button_attributes: {})
     @button_content = button_content
     @button_classes = button_classes
     @menu_id = menu_id || "popup-menu-#{SecureRandom.hex(4)}"
     @align = align
+    @button_attributes = button_attributes
   end
 
-  attr_reader :button_content, :button_classes, :menu_id, :align
+  attr_reader :button_content, :button_classes, :menu_id, :align, :button_attributes
+
+  def button_options
+    defaults = {
+      type: "button",
+      class: ["popup-menu-toggle", button_classes.presence].compact.join(" "),
+      data: {
+        action: "click->popup-menu#toggle",
+        popup_menu_target: "button"
+      }
+    }
+
+    return defaults if button_attributes.blank?
+
+    defaults.deep_merge(button_attributes) do |key, this_val, other_val|
+      key == :class ? [this_val, other_val].compact.join(" ") : other_val
+    end
+  end
 end

--- a/app/components/popup_menu_component.rb
+++ b/app/components/popup_menu_component.rb
@@ -1,10 +1,11 @@
 class PopupMenuComponent < ViewComponent::Base
-  def initialize(button_content:, button_classes: "", menu_id: nil, align: :left)
+  def initialize(button_content:, button_classes: "", menu_id: nil, align: :left, button_id: nil)
     @button_content = button_content
     @button_classes = button_classes
     @menu_id = menu_id || "popup-menu-#{SecureRandom.hex(4)}"
     @align = align
+    @button_id = button_id
   end
 
-  attr_reader :button_content, :button_classes, :menu_id, :align
+  attr_reader :button_content, :button_classes, :menu_id, :align, :button_id
 end

--- a/app/components/popup_menu_component.rb
+++ b/app/components/popup_menu_component.rb
@@ -1,11 +1,10 @@
 class PopupMenuComponent < ViewComponent::Base
-  def initialize(button_content:, button_classes: "", menu_id: nil, align: :left, button_id: nil)
+  def initialize(button_content:, button_classes: "", menu_id: nil, align: :left)
     @button_content = button_content
     @button_classes = button_classes
     @menu_id = menu_id || "popup-menu-#{SecureRandom.hex(4)}"
     @align = align
-    @button_id = button_id
   end
 
-  attr_reader :button_content, :button_classes, :menu_id, :align, :button_id
+  attr_reader :button_content, :button_classes, :menu_id, :align
 end

--- a/app/components/popup_menu_component.rb
+++ b/app/components/popup_menu_component.rb
@@ -12,7 +12,7 @@ class PopupMenuComponent < ViewComponent::Base
   def button_options
     defaults = {
       type: "button",
-      class: ["popup-menu-toggle", button_classes.presence].compact.join(" "),
+      class: [ "popup-menu-toggle", button_classes.presence ].compact.join(" "),
       data: {
         action: "click->popup-menu#toggle",
         popup_menu_target: "button"
@@ -22,7 +22,7 @@ class PopupMenuComponent < ViewComponent::Base
     return defaults if button_attributes.blank?
 
     defaults.deep_merge(button_attributes) do |key, this_val, other_val|
-      key == :class ? [this_val, other_val].compact.join(" ") : other_val
+      key == :class ? [ this_val, other_val ].compact.join(" ") : other_val
     end
   end
 end

--- a/app/javascript/creative_row_editor.js
+++ b/app/javascript/creative_row_editor.js
@@ -41,6 +41,7 @@ export function initializeCreativeRowEditor() {
     const addBtn = document.getElementById('inline-add');
     const levelDownBtn = document.getElementById('inline-level-down');
     const levelUpBtn = document.getElementById('inline-level-up');
+    const deletePopupToggle = document.getElementById('inline-delete-popup-toggle');
     const deleteBtn = document.getElementById('inline-delete');
     const deleteWithChildrenBtn = document.getElementById('inline-delete-with-children');
     const linkBtn = document.getElementById('inline-link');
@@ -548,6 +549,7 @@ export function initializeCreativeRowEditor() {
       }
       if (levelUpBtn) levelUpBtn.disabled = !canLevelUp;
 
+      if (deletePopupToggle) deletePopupToggle.disabled = !hasCreativeId;
       if (deleteBtn) deleteBtn.disabled = !hasCreativeId;
       if (deleteWithChildrenBtn) deleteWithChildrenBtn.disabled = !hasCreativeId;
       if (linkBtn) linkBtn.disabled = !hasCreativeId || linkBtn.style.display === 'none';

--- a/app/javascript/creative_row_editor.js
+++ b/app/javascript/creative_row_editor.js
@@ -43,8 +43,6 @@ export function initializeCreativeRowEditor() {
     const levelUpBtn = document.getElementById('inline-level-up');
     const deleteBtn = document.getElementById('inline-delete');
     const deleteWithChildrenBtn = document.getElementById('inline-delete-with-children');
-    const deleteToggleBtn = document.getElementById('inline-delete-toggle');
-    const deleteMenu = document.getElementById('inline-delete-popup-menu');
     const linkBtn = document.getElementById('inline-link');
     const unlinkBtn = document.getElementById('inline-unlink');
     const unconvertBtn = document.getElementById('inline-unconvert');
@@ -550,10 +548,8 @@ export function initializeCreativeRowEditor() {
       }
       if (levelUpBtn) levelUpBtn.disabled = !canLevelUp;
 
-      if (deleteToggleBtn) {
-        deleteToggleBtn.disabled = !hasCreativeId;
-        if (deleteToggleBtn.disabled && deleteMenu) deleteMenu.style.display = 'none';
-      }
+      if (deleteBtn) deleteBtn.disabled = !hasCreativeId;
+      if (deleteWithChildrenBtn) deleteWithChildrenBtn.disabled = !hasCreativeId;
       if (linkBtn) linkBtn.disabled = !hasCreativeId || linkBtn.style.display === 'none';
       if (unlinkBtn) unlinkBtn.disabled = !hasCreativeId || unlinkBtn.style.display === 'none';
       if (unconvertBtn) {

--- a/app/javascript/creative_row_editor.js
+++ b/app/javascript/creative_row_editor.js
@@ -43,6 +43,8 @@ export function initializeCreativeRowEditor() {
     const levelUpBtn = document.getElementById('inline-level-up');
     const deleteBtn = document.getElementById('inline-delete');
     const deleteWithChildrenBtn = document.getElementById('inline-delete-with-children');
+    const deleteToggleBtn = document.getElementById('inline-delete-toggle');
+    const deleteMenu = document.getElementById('inline-delete-popup-menu');
     const linkBtn = document.getElementById('inline-link');
     const unlinkBtn = document.getElementById('inline-unlink');
     const unconvertBtn = document.getElementById('inline-unconvert');
@@ -548,8 +550,10 @@ export function initializeCreativeRowEditor() {
       }
       if (levelUpBtn) levelUpBtn.disabled = !canLevelUp;
 
-      if (deleteBtn) deleteBtn.disabled = !hasCreativeId;
-      if (deleteWithChildrenBtn) deleteWithChildrenBtn.disabled = !hasCreativeId;
+      if (deleteToggleBtn) {
+        deleteToggleBtn.disabled = !hasCreativeId;
+        if (deleteToggleBtn.disabled && deleteMenu) deleteMenu.style.display = 'none';
+      }
       if (linkBtn) linkBtn.disabled = !hasCreativeId || linkBtn.style.display === 'none';
       if (unlinkBtn) unlinkBtn.disabled = !hasCreativeId || unlinkBtn.style.display === 'none';
       if (unconvertBtn) {

--- a/app/views/creatives/_inline_edit_form.html.erb
+++ b/app/views/creatives/_inline_edit_form.html.erb
@@ -42,6 +42,7 @@
         <%= render PopupMenuComponent.new(
               button_content: inline_delete_button_content,
               button_classes: 'creative-action-btn danger-link',
+              button_id: 'inline-delete-toggle',
               menu_id: 'inline-delete-popup-menu'
             ) do %>
           <button type="button"

--- a/app/views/creatives/_inline_edit_form.html.erb
+++ b/app/views/creatives/_inline_edit_form.html.erb
@@ -42,7 +42,6 @@
         <%= render PopupMenuComponent.new(
               button_content: inline_delete_button_content,
               button_classes: 'creative-action-btn danger-link',
-              button_id: 'inline-delete-toggle',
               menu_id: 'inline-delete-popup-menu'
             ) do %>
           <button type="button"

--- a/app/views/creatives/_inline_edit_form.html.erb
+++ b/app/views/creatives/_inline_edit_form.html.erb
@@ -42,6 +42,7 @@
         <%= render PopupMenuComponent.new(
               button_content: inline_delete_button_content,
               button_classes: 'creative-action-btn danger-link',
+              button_attributes: { id: 'inline-delete-popup-toggle' },
               menu_id: 'inline-delete-popup-menu'
             ) do %>
           <button type="button"

--- a/test/system/creative_inline_edit_test.rb
+++ b/test/system/creative_inline_edit_test.rb
@@ -214,7 +214,6 @@ class CreativeInlineEditTest < ApplicationSystemTestCase
     assert_selector "#inline-move-up[disabled]", wait: 5
     assert_selector "#inline-level-down[disabled]", wait: 5
     assert_selector "#inline-level-up[disabled]", wait: 5
-    assert_no_selector "#inline-delete-toggle[disabled]", wait: 5
     assert_no_selector "#inline-move-down[disabled]", wait: 5
 
     find("#inline-move-down", wait: 5).click
@@ -227,10 +226,5 @@ class CreativeInlineEditTest < ApplicationSystemTestCase
     wait_for_network_idle(timeout: 10)
 
     assert_no_selector "#inline-level-up[disabled]", wait: 5
-
-    find("#inline-add", wait: 5).click
-    wait_for_network_idle(timeout: 10)
-
-    assert_selector "#inline-delete-toggle[disabled]", wait: 5
   end
 end

--- a/test/system/creative_inline_edit_test.rb
+++ b/test/system/creative_inline_edit_test.rb
@@ -203,4 +203,28 @@ class CreativeInlineEditTest < ApplicationSystemTestCase
                     wait: 5,
                     visible: :all
   end
+
+  test "disables inline actions when unavailable" do
+    Creative.create!(description: "Second root", user: @user)
+
+    visit creatives_path
+
+    open_inline_editor(@root_creative)
+
+    assert_selector "#inline-move-up[disabled]", wait: 5
+    assert_selector "#inline-level-down[disabled]", wait: 5
+    assert_selector "#inline-level-up[disabled]", wait: 5
+    assert_no_selector "#inline-move-down[disabled]", wait: 5
+
+    find("#inline-move-down", wait: 5).click
+    wait_for_network_idle(timeout: 10)
+
+    assert_no_selector "#inline-move-up[disabled]", wait: 5
+    assert_no_selector "#inline-level-down[disabled]", wait: 5
+
+    find("#inline-level-down", wait: 5).click
+    wait_for_network_idle(timeout: 10)
+
+    assert_no_selector "#inline-level-up[disabled]", wait: 5
+  end
 end

--- a/test/system/creative_inline_edit_test.rb
+++ b/test/system/creative_inline_edit_test.rb
@@ -214,6 +214,7 @@ class CreativeInlineEditTest < ApplicationSystemTestCase
     assert_selector "#inline-move-up[disabled]", wait: 5
     assert_selector "#inline-level-down[disabled]", wait: 5
     assert_selector "#inline-level-up[disabled]", wait: 5
+    assert_no_selector "#inline-delete-toggle[disabled]", wait: 5
     assert_no_selector "#inline-move-down[disabled]", wait: 5
 
     find("#inline-move-down", wait: 5).click
@@ -226,5 +227,10 @@ class CreativeInlineEditTest < ApplicationSystemTestCase
     wait_for_network_idle(timeout: 10)
 
     assert_no_selector "#inline-level-up[disabled]", wait: 5
+
+    find("#inline-add", wait: 5).click
+    wait_for_network_idle(timeout: 10)
+
+    assert_selector "#inline-delete-toggle[disabled]", wait: 5
   end
 end


### PR DESCRIPTION
## Summary
- add state tracking to disable inline editor action buttons when their actions are unavailable and re-enable them as context changes
- call the action state updater during inline editor lifecycle events, moves, and indent changes to keep buttons accurate
- add a system test to confirm inline action buttons toggle disabled state based on availability

## Testing
- ./bin/rubocop -a
- bundle exec rails test
- bundle exec rails test:system *(fails: chromedriver download blocked in environment)*

## Original User's Requirements
- creative inline editor 하단 액션 버튼에서, 지금 당장 사용할 수 없는 버튼은 비활성화 처리되어야 하고, 다시 사용할 수 있는 상태가 되면 활성화 되어야 한다.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69257e731a5c8326b08e3a1e0ddd5198)