### PR TITLE
Add keyboard navigation for mention popup

### DIFF
--- a/app/assets/stylesheets/mention_menu.css
+++ b/app/assets/stylesheets/mention_menu.css
@@ -22,3 +22,7 @@
 .mention-item:hover {
   background: var(--color-drag-over);
 }
+
+.mention-item.active {
+  background: var(--color-drag-over);
+}

--- a/app/javascript/controllers/comments/form_controller.js
+++ b/app/javascript/controllers/comments/form_controller.js
@@ -61,11 +61,17 @@ export default class extends Controller {
 
     this.textareaTarget.addEventListener('keydown', (event) => {
       if (event.key === 'Enter' && !event.shiftKey) {
+        if (this.isMentionMenuVisible()) return
         this.handleSend(event)
       }
     })
 
     this.updateAttachmentList()
+  }
+
+  isMentionMenuVisible() {
+    const menu = document.getElementById('mention-menu')
+    return menu?.style.display === 'block'
   }
 
   disconnect() {

--- a/app/javascript/mention_menu.js
+++ b/app/javascript/mention_menu.js
@@ -93,21 +93,15 @@ if (!mentionMenuInitialized) {
 
       var key = event.key;
       var isCtrl = event.ctrlKey || event.metaKey;
-      if (key === 'Tab') {
+      if (key === 'Tab' || key === 'Enter') {
         event.preventDefault();
-        if (list.children.length > 0) {
-          setActiveIndex(0);
-          selectActive();
-        }
+        selectActive();
       } else if (key === 'ArrowDown' || (isCtrl && key.toLowerCase() === 'n')) {
         event.preventDefault();
         setActiveIndex(activeIndex + 1);
       } else if (key === 'ArrowUp' || (isCtrl && key.toLowerCase() === 'p')) {
         event.preventDefault();
         setActiveIndex(activeIndex - 1);
-      } else if (key === 'Enter') {
-        event.preventDefault();
-        selectActive();
       }
     });
 

--- a/app/javascript/mention_menu.js
+++ b/app/javascript/mention_menu.js
@@ -3,14 +3,19 @@ let mentionMenuInitialized = false;
 if (!mentionMenuInitialized) {
   mentionMenuInitialized = true;
 
-    document.addEventListener('turbo:load', function () {
-      var textarea = document.querySelector('#new-comment-form textarea');
-      var menu = document.getElementById('mention-menu');
-      var popup = document.getElementById('comments-popup');
-      if (!textarea || !menu) return;
+  document.addEventListener('turbo:load', function () {
+    var textarea = document.querySelector('#new-comment-form textarea');
+    var menu = document.getElementById('mention-menu');
+    var popup = document.getElementById('comments-popup');
+    if (!textarea || !menu) return;
 
-      var list = menu.querySelector('.mention-results');
-      var fetchTimer;
+    var list = menu.querySelector('.mention-results');
+    var fetchTimer;
+    var activeIndex = -1;
+
+    function isVisible() {
+      return menu.style.display === 'block';
+    }
 
     function position() {
       var rect = textarea.getBoundingClientRect();
@@ -21,19 +26,51 @@ if (!mentionMenuInitialized) {
 
     function hide() {
       menu.style.display = 'none';
+      activeIndex = -1;
+      updateActive();
     }
 
     function insert(user) {
       var pos = textarea.selectionStart;
-        var before = textarea.value.slice(0, pos).replace(/@[^@\s]*$/, '@' + user.name + ': ');
+      var before = textarea.value.slice(0, pos).replace(/@[^@\s]*$/, '@' + user.name + ': ');
       textarea.value = before + textarea.value.slice(pos);
+      textarea.setSelectionRange(before.length, before.length);
+    }
+
+    function updateActive() {
+      var items = list.children;
+      Array.from(items).forEach(function (item, index) {
+        item.classList.toggle('active', index === activeIndex);
+      });
+    }
+
+    function setActiveIndex(index) {
+      var items = list.children;
+      if (items.length === 0) return;
+      if (index < 0) {
+        activeIndex = items.length - 1;
+      } else {
+        activeIndex = index % items.length;
+      }
+      updateActive();
+      var activeItem = items[activeIndex];
+      if (activeItem && activeItem.scrollIntoView) {
+        activeItem.scrollIntoView({ block: 'nearest' });
+      }
+    }
+
+    function selectActive() {
+      if (activeIndex < 0) return;
+      var item = list.children[activeIndex];
+      if (item) item.click();
     }
 
     function show(users) {
       list.innerHTML = '';
-      users.forEach(function (u) {
+      activeIndex = users.length > 0 ? 0 : -1;
+      users.forEach(function (u, index) {
         var li = document.createElement('li');
-        li.className = 'mention-item';
+        li.className = 'mention-item' + (index === activeIndex ? ' active' : '');
         li.innerHTML = '<img src="' + u.avatar_url + '" width="20" height="20" class="avatar" /> ' + u.name;
         li.addEventListener('click', function () {
           insert(u);
@@ -43,12 +80,36 @@ if (!mentionMenuInitialized) {
         list.appendChild(li);
       });
       if (users.length > 0) {
-          menu.style.display = 'block';
-          position();
+        menu.style.display = 'block';
+        position();
+        updateActive();
       } else {
         hide();
       }
     }
+
+    textarea.addEventListener('keydown', function (event) {
+      if (!isVisible()) return;
+
+      var key = event.key;
+      var isCtrl = event.ctrlKey || event.metaKey;
+      if (key === 'Tab') {
+        event.preventDefault();
+        if (list.children.length > 0) {
+          setActiveIndex(0);
+          selectActive();
+        }
+      } else if (key === 'ArrowDown' || (isCtrl && key.toLowerCase() === 'n')) {
+        event.preventDefault();
+        setActiveIndex(activeIndex + 1);
+      } else if (key === 'ArrowUp' || (isCtrl && key.toLowerCase() === 'p')) {
+        event.preventDefault();
+        setActiveIndex(activeIndex - 1);
+      } else if (key === 'Enter') {
+        event.preventDefault();
+        selectActive();
+      }
+    });
 
     textarea.addEventListener('input', function () {
       var pos = textarea.selectionStart;


### PR DESCRIPTION
## Summary
- add active state handling so mention popup items support keyboard navigation and insertion
- ensure tab selects the first mention, arrows/Ctrl+N/Ctrl+P change selection, and enter inserts the highlighted user
- highlight the active mention item for clarity

## Testing
- `./bin/rubocop -a`
- `rails test`
- `rails test:system` *(fails: chromedriver download blocked by network restrictions via selenium-manager)*

## Original User's Requirements
- 채팅 입력폼에서 사용자 멘션 팝업이 표시될때 탭키를 누르면, 첫번째가 자동 선택된다
- 멘션 팝업에서 위/아래 키 또는 Ctrl+P, Ctrl+N 을 누르면 리스트에서 위 아래로 움직인다
- 멘션 팝업에서 엔터키를 누르면 현재 선택된 사용자로 멘션이 자동완성된다


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926488f87e08326af07b4697ad0e27c)