### PR TITLE
Ensure popup menu stays within viewport

### DIFF
--- a/app/javascript/controllers/popup_menu_controller.js
+++ b/app/javascript/controllers/popup_menu_controller.js
@@ -31,18 +31,26 @@ export default class extends Controller {
     menu.style.display = 'block'
     menu.style.transform = ''
 
+    const transforms = []
+    const viewportPadding = 4
+
     this.buttonTarget?.setAttribute('aria-expanded', 'true')
 
     requestAnimationFrame(() => {
       const rect = menu.getBoundingClientRect()
-      let shift = 0
       if (rect.right > window.innerWidth) {
-        shift = rect.right - window.innerWidth + 4
-        menu.style.transform = `translateX(-${shift}px)`
+        transforms.push(`translateX(-${rect.right - window.innerWidth + viewportPadding}px)`)
       } else if (rect.left < 0) {
-        shift = -rect.left + 4
-        menu.style.transform = `translateX(${shift}px)`
+        transforms.push(`translateX(${Math.abs(rect.left) + viewportPadding}px)`)
       }
+
+      if (rect.bottom > window.innerHeight) {
+        transforms.push(`translateY(-${rect.bottom - window.innerHeight + viewportPadding}px)`)
+      } else if (rect.top < 0) {
+        transforms.push(`translateY(${Math.abs(rect.top) + viewportPadding}px)`)
+      }
+
+      menu.style.transform = transforms.join(' ')
     })
 
     this.addOutsideClickListener()


### PR DESCRIPTION
## Summary
- adjust popup menu controller to translate the menu horizontally and vertically to stay within the viewport when opened

## Testing
- ./bin/rubocop -a
- bundle exec rails test
- bundle exec rails test:system *(fails: chromedriver unavailable in environment)*

## Original User's Requirements
- PopupMenuComponent 에서 팝업이 나타날때는 현재 윈도우 화면을 벗어나면 안된다.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927a26b474c83268292c4a1f4390d57)