### PR TITLE
Add inline add button to creative tree rows

### DIFF
--- a/app/assets/stylesheets/creatives.css
+++ b/app/assets/stylesheets/creatives.css
@@ -256,6 +256,11 @@ creative-tree-row.show-edit .creative-row {
     /* Align with text */
 }
 
+.add-inline-btn .icon-add {
+    width: 16px;
+    height: 16px;
+}
+
 .creative-action-btn:disabled,
 .popup-menu-toggle:disabled,
 .popup-menu .popup-menu-item:disabled {
@@ -312,6 +317,7 @@ creative-tree-row.show-edit .creative-row {
     opacity: 0;
     transition: opacity 0.2s ease;
     width: 20px;
+    height: 22px;
     /* Fixed width for alignment */
 }
 

--- a/app/assets/stylesheets/creatives.css
+++ b/app/assets/stylesheets/creatives.css
@@ -306,7 +306,8 @@ creative-tree-row.show-edit .creative-row {
 
 
 /* Replaced creative-row-actions visibility logic with direct targeting */
-.edit-inline-btn {
+.edit-inline-btn,
+.add-inline-btn {
     visibility: hidden;
     opacity: 0;
     transition: opacity 0.2s ease;
@@ -314,7 +315,8 @@ creative-tree-row.show-edit .creative-row {
     /* Fixed width for alignment */
 }
 
-.creative-row:hover .edit-inline-btn {
+.creative-row:hover .edit-inline-btn,
+.creative-row:hover .add-inline-btn {
     visibility: visible;
     opacity: 1;
 }
@@ -334,6 +336,23 @@ creative-tree-row.show-edit .creative-row {
     }
 
     .creative-row.show-edit .edit-inline-btn {
+        max-width: 40px;
+        opacity: 1;
+        transform: translateX(0);
+        pointer-events: auto;
+        visibility: visible;
+    }
+
+    .add-inline-btn {
+        max-width: 0;
+        opacity: 0;
+        overflow: hidden;
+        pointer-events: none;
+        transform: translateX(10px);
+        transition: max-width 0.3s ease, opacity 0.3s ease, transform 0.3s ease;
+    }
+
+    .creative-row.show-edit .add-inline-btn {
         max-width: 40px;
         opacity: 1;
         transform: translateX(0);

--- a/app/javascript/components/creative_tree_row.js
+++ b/app/javascript/components/creative_tree_row.js
@@ -18,6 +18,7 @@ class CreativeTreeRow extends LitElement {
     linkUrl: { attribute: "link-url" },
     descriptionHtml: { state: true },
     progressHtml: { state: true },
+    addIconHtml: { state: true },
     editIconHtml: { state: true },
     editOffIconHtml: { state: true },
     originLinkHtml: { state: true },
@@ -39,6 +40,7 @@ class CreativeTreeRow extends LitElement {
     this.linkUrl = "#";
     this.descriptionHtml = "";
     this.progressHtml = "";
+    this.addIconHtml = "";
     this.editIconHtml = "";
     this.editOffIconHtml = "";
     this.originLinkHtml = "";
@@ -47,10 +49,12 @@ class CreativeTreeRow extends LitElement {
     this.loadingChildren = false;
 
     this._toggleBtn = null;
+    this._addBtn = null;
     this._editBtn = null;
     this._commentsBtn = null;
 
     this._handleToggleClick = this._handleToggleClick.bind(this);
+    this._handleAddClick = this._handleAddClick.bind(this);
     this._handleEditClick = this._handleEditClick.bind(this);
     this._handleCommentsClick = this._handleCommentsClick.bind(this);
   }
@@ -90,6 +94,7 @@ class CreativeTreeRow extends LitElement {
       // have template nodes, so fall back to any cached markup stored in data attributes.
       if (hasCached("descriptionHtml")) this._setDescriptionHtml(this.dataset.descriptionHtml);
       if (hasCached("progressHtml")) this.progressHtml = this.dataset.progressHtml;
+      if (hasCached("addIconHtml")) this.addIconHtml = this.dataset.addIconHtml;
       if (hasCached("editIconHtml")) this.editIconHtml = this.dataset.editIconHtml;
       if (hasCached("editOffIconHtml")) this.editOffIconHtml = this.dataset.editOffIconHtml;
       if (hasCached("originLinkHtml")) this.originLinkHtml = this.dataset.originLinkHtml;
@@ -114,6 +119,10 @@ class CreativeTreeRow extends LitElement {
           case "progress":
             this.progressHtml = markup;
             this.dataset.progressHtml = markup;
+            break;
+          case "add-icon":
+            this.addIconHtml = markup;
+            this.dataset.addIconHtml = markup;
             break;
           case "edit-icon":
             this.editIconHtml = markup;
@@ -140,14 +149,17 @@ class CreativeTreeRow extends LitElement {
 
   _attachHandlers() {
     this._toggleBtn?.removeEventListener("click", this._handleToggleClick);
+    this._addBtn?.removeEventListener("click", this._handleAddClick);
     this._editBtn?.removeEventListener("click", this._handleEditClick);
     this._commentsBtn?.removeEventListener("click", this._handleCommentsClick);
 
     this._toggleBtn = this.querySelector(".creative-toggle-btn");
+    this._addBtn = this.querySelector(".add-inline-btn");
     this._editBtn = this.querySelector(".edit-inline-btn");
     this._commentsBtn = this.querySelector(".comments-btn");
 
     if (this._toggleBtn) this._toggleBtn.addEventListener("click", this._handleToggleClick, { passive: false });
+    if (this._addBtn) this._addBtn.addEventListener("click", this._handleAddClick, { passive: false });
     if (this._editBtn) this._editBtn.addEventListener("click", this._handleEditClick, { passive: false });
     if (this._commentsBtn) this._commentsBtn.addEventListener("click", this._handleCommentsClick, { passive: false });
   }
@@ -176,7 +188,7 @@ class CreativeTreeRow extends LitElement {
         <div class="creative-row level-${this.level}" data-creatives--select-mode-target="row">
           <div class="creative-row-start">
             ${this._renderCheckbox()}
-            ${this._renderActionButton()}
+            ${this._renderActionButtons()}
             ${this._renderTreeLines()}
             ${this._renderToggle()}
             ${this._renderContent()}
@@ -237,15 +249,26 @@ class CreativeTreeRow extends LitElement {
     `;
   }
 
-  _renderActionButton() {
+  _renderActionButtons() {
     if (this.canWrite) {
       return html`
+        <button type="button" class="creative-action-btn add-creative-btn add-inline-btn" data-creative-id=${this.creativeId}>
+          ${unsafeHTML(this.addIconHtml || "")}
+        </button>
         <button type="button" class="creative-action-btn edit-inline-btn" data-creative-id=${this.creativeId}>
           ${unsafeHTML(this.editIconHtml || "")}
         </button>
       `;
     }
     return html`
+      <button
+        type="button"
+        class="creative-action-btn add-creative-btn add-inline-btn"
+        data-creative-id=${this.creativeId}
+        style="visibility: hidden"
+      >
+        ${unsafeHTML(this.addIconHtml || "")}
+      </button>
       <button
         type="button"
         class="creative-action-btn edit-inline-btn"
@@ -363,6 +386,21 @@ class CreativeTreeRow extends LitElement {
     event.preventDefault();
     event.stopPropagation();
     this.dispatchEvent(new CustomEvent("creative-edit-click", {
+      detail: {
+        creativeId: this.creativeId ?? this.getAttribute("creative-id"),
+        component: this,
+        button: event.currentTarget,
+        treeElement: this.querySelector(".creative-tree")
+      },
+      bubbles: true,
+      composed: true
+    }));
+  }
+
+  _handleAddClick(event) {
+    event.preventDefault();
+    event.stopPropagation();
+    this.dispatchEvent(new CustomEvent("creative-add-click", {
       detail: {
         creativeId: this.creativeId ?? this.getAttribute("creative-id"),
         component: this,

--- a/app/javascript/creatives/tree_renderer.js
+++ b/app/javascript/creatives/tree_renderer.js
@@ -84,6 +84,11 @@ function applyRowProperties(row, node) {
     setDatasetValue(row, 'progressHtml', templates.progress_html)
     dirty = true
   }
+  if (templates.add_icon_html != null && row.addIconHtml !== templates.add_icon_html) {
+    row.addIconHtml = templates.add_icon_html
+    setDatasetValue(row, 'addIconHtml', templates.add_icon_html)
+    dirty = true
+  }
   if (templates.edit_icon_html != null && row.editIconHtml !== templates.edit_icon_html) {
     row.editIconHtml = templates.edit_icon_html
     setDatasetValue(row, 'editIconHtml', templates.edit_icon_html)

--- a/app/services/creatives/tree_builder.rb
+++ b/app/services/creatives/tree_builder.rb
@@ -110,6 +110,7 @@ module Creatives
       {
         description_html: description_html,
         progress_html: progress_html,
+        add_icon_html: add_icon_html,
         edit_icon_html: edit_icon_html,
         edit_off_icon_html: edit_off_icon_html,
         origin_link_html: origin_link_html_for(creative)
@@ -143,6 +144,10 @@ module Creatives
 
     def edit_icon_html
       @edit_icon_html ||= view_context.svg_tag("edit.svg", className: "icon-edit")
+    end
+
+    def add_icon_html
+      @add_icon_html ||= view_context.svg_tag("add.svg", className: "icon-add")
     end
 
     def edit_off_icon_html


### PR DESCRIPTION
## Summary
- add an inline add button before the edit control in creative tree rows and wire it to start child creation
- propagate add icon markup through tree builder, renderer, and inline editor setup for new rows
- align hover and mobile swipe behaviors so add/edit controls appear together

## Testing
- ./bin/rubocop -a
- bundle exec rails test
- bundle exec rails test:system *(fails: chromedriver could not be obtained in the environment)*

## Original User's Requirements
- creative inline editor 에서 start action 에 edit 버튼 앞에 add 버튼을 추가로 둔다. add 버튼을 누르면 하위 노드로 바로 추가되는 기능이다. 이 버튼은 edit 와 마찬가지로 hover 시에만 표시된다. 모바일에서는 오른쪽으로 스와이프시 된다.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927a21a9264832687abc333a566f027)