### PR TITLE
Make creative toggle visible on desktop

### DIFF
--- a/app/assets/stylesheets/creatives.css
+++ b/app/assets/stylesheets/creatives.css
@@ -289,13 +289,9 @@ creative-tree-row.show-edit .creative-row {
     margin-right: 4px;
     margin-top: 4px;
     /* Align with text */
-    visibility: hidden;
-    /* Hidden by default on desktop */
-    /* Total width is 20px (16 + 4) */
-}
-
-.creative-row:hover .creative-toggle-btn {
     visibility: visible;
+    /* Always visible to show expansion affordance */
+    /* Total width is 20px (16 + 4) */
 }
 
 .add-creative-btn {

--- a/app/assets/stylesheets/creatives.css
+++ b/app/assets/stylesheets/creatives.css
@@ -289,9 +289,20 @@ creative-tree-row.show-edit .creative-row {
     margin-right: 4px;
     margin-top: 4px;
     /* Align with text */
-    visibility: visible;
-    /* Always visible to show expansion affordance */
+    visibility: hidden;
+    opacity: 0;
+    transition: opacity 0.2s ease, visibility 0.2s ease;
     /* Total width is 20px (16 + 4) */
+}
+
+creative-tree-row:not([expanded]) .creative-toggle-btn {
+    visibility: visible;
+    opacity: 1;
+}
+
+creative-tree-row[expanded] .creative-row:hover .creative-toggle-btn {
+    visibility: visible;
+    opacity: 1;
 }
 
 .add-creative-btn {
@@ -318,6 +329,7 @@ creative-tree-row.show-edit .creative-row {
 @media (max-width: 768px) {
     .creative-toggle-btn {
         visibility: visible !important;
+        opacity: 1 !important;
     }
 
     .edit-inline-btn {


### PR DESCRIPTION
## Summary
- ensure creative tree toggle buttons stay visible on desktop to match mobile behavior and highlight expandable items

## Testing
- ./bin/rubocop
- bundle exec rails test
- bundle exec rails test:system (fails: chromedriver could not be downloaded in the environment)

## Original User's Requirements
- 접혀 있는 크리에이티브는 펼치기 토글 버튼을 항상 표시한다. (지금 모바일 화면에서는 항상 표시함으로, 데스크탑에서도 항상 표시)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927a6cda8908326b462da3d2eab570e)