### PR TITLE
Fix mobile edit toggle binding

### DIFF
--- a/app/javascript/creative_row_swipe.js
+++ b/app/javascript/creative_row_swipe.js
@@ -1,22 +1,24 @@
 let initialized = false;
+let startX = null;
+let activeRow = null;
+let allEditVisible = false;
+
+function toggleAllEdits() {
+  allEditVisible = !allEditVisible;
+  document.querySelectorAll('.creative-row').forEach(function(row) {
+    row.classList.toggle('show-edit', allEditVisible);
+  });
+}
 
 document.addEventListener('turbo:load', function() {
+  const toggleBtn = document.getElementById('toggle-edit-btn');
+  if (toggleBtn && !toggleBtn.dataset.editToggleBound) {
+    toggleBtn.addEventListener('click', toggleAllEdits);
+    toggleBtn.dataset.editToggleBound = 'true';
+  }
+
   if (initialized) return;
   initialized = true;
-
-  let startX = null;
-  let activeRow = null;
-  let allEditVisible = false;
-
-  const toggleBtn = document.getElementById('toggle-edit-btn');
-  if (toggleBtn) {
-    toggleBtn.addEventListener('click', function() {
-      allEditVisible = !allEditVisible;
-      document.querySelectorAll('.creative-row').forEach(function(row) {
-        row.classList.toggle('show-edit', allEditVisible);
-      });
-    });
-  }
 
   document.addEventListener('touchstart', function(event) {
     if (allEditVisible) return;


### PR DESCRIPTION
## Summary
- bind the mobile edit toggle button on every Turbo load so it works without a manual refresh
- keep swipe gesture handlers single-bound while allowing the toggle to be re-attached when the DOM changes

## Testing
- ./bin/rubocop -a
- bundle exec rails test
- bundle exec rails test:system *(fails: chromedriver download blocked by network when Selenium manager tries to fetch Chrome for testing)*

## Original User's Requirements
- 모바일에서 크리에이티브 목록 상단 수정 버튼이 작동이 안돼. 페이지를 항상 리플레쉬해야 작동이 되는데 수정해줘

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927e22e36c083269fe13b63ace6d99a)