### PR TITLE
feat: Implement MCP tool registration and management

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -84,7 +84,7 @@ end
 gem "doorkeeper", "~> 5.8"
 
 if File.exist?(File.expand_path("../rails_mcp_engine", __FILE__))
-  gem "rails_mcp_engine", "~> 0.2.0", path: "../rails_mcp_engine"
+  gem "rails_mcp_engine", "~> 0.4.0", path: "../rails_mcp_engine"
 else
-  gem "rails_mcp_engine", "~> 0.2.0"
+  gem "rails_mcp_engine", "~> 0.4.0"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -393,7 +393,7 @@ GEM
     rails-html-sanitizer (1.6.2)
       loofah (~> 2.21)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
-    rails_mcp_engine (0.2.0)
+    rails_mcp_engine (0.4.0)
       fast-mcp (~> 1.6)
       rails (>= 7.1, < 8.2)
       ruby_llm (~> 1.9)
@@ -596,7 +596,7 @@ DEPENDENCIES
   propshaft
   puma (>= 5.0)
   rails (~> 8.1.1)
-  rails_mcp_engine (~> 0.2.0)
+  rails_mcp_engine (~> 0.4.0)
   rubocop-rails-omakase
   ruby_llm
   selenium-webdriver

--- a/app/models/creative.rb
+++ b/app/models/creative.rb
@@ -54,6 +54,7 @@ class Creative < ApplicationRecord
   has_many :github_repository_links, dependent: :destroy
   has_many :notion_page_links, dependent: :destroy
   has_many :notion_block_links, dependent: :destroy
+  has_many :mcp_tools, dependent: :destroy
 
   validates :progress, numericality: { greater_than_or_equal_to: 0.0, less_than_or_equal_to: 1.0 }, unless: -> { origin_id.present? }
   validates :description, presence: true, unless: -> { origin_id.present? }
@@ -66,6 +67,7 @@ class Creative < ApplicationRecord
   after_save :clear_permission_cache_on_user_change
   after_destroy :update_parent_progress
   after_destroy_commit :purge_description_attachments
+  after_save :update_mcp_tools
 
   def self.recalculate_all_progress!
     Creatives::ProgressService.recalculate_all!
@@ -358,5 +360,9 @@ class Creative < ApplicationRecord
     if parent&.origin_id.present?
       self.parent = parent.origin
     end
+  end
+
+  def update_mcp_tools
+    McpService.new.update_from_creative(self)
   end
 end

--- a/app/models/mcp_tool.rb
+++ b/app/models/mcp_tool.rb
@@ -1,0 +1,26 @@
+class McpTool < ApplicationRecord
+  belongs_to :creative
+
+  validates :name, presence: true, uniqueness: true
+  validates :source_code, presence: true
+
+  after_destroy :unregister_tool
+
+  scope :active, -> { where.not(approved_at: nil) }
+
+  def active?
+    approved_at.present?
+  end
+
+  def approve!
+    update!(approved_at: Time.current)
+    # Register the tool immediately upon approval
+    McpService.register_tool_from_source(source_code)
+  end
+
+  private
+
+  def unregister_tool
+    McpService.delete_tool(name)
+  end
+end

--- a/app/models/mcp_tool.rb
+++ b/app/models/mcp_tool.rb
@@ -13,9 +13,9 @@ class McpTool < ApplicationRecord
   end
 
   def approve!
-    update!(approved_at: Time.current)
     # Register the tool immediately upon approval
     McpService.register_tool_from_source(source_code)
+    update!(approved_at: Time.current)
   end
 
   private

--- a/app/services/comments/action_executor.rb
+++ b/app/services/comments/action_executor.rb
@@ -62,7 +62,8 @@ module Comments
 
       SUPPORTED_ACTIONS = {
         "create_creative" => :create_creative,
-        "update_creative" => :update_creative
+        "update_creative" => :update_creative,
+        "approve_tool" => :approve_tool
       }.freeze
 
       CREATIVE_ATTRIBUTES = %w[description progress].freeze
@@ -136,6 +137,16 @@ module Comments
         creative.save!
       rescue ActiveRecord::RecordInvalid => e
         raise InvalidActionError, e.record.errors.full_messages.to_sentence
+      end
+
+      def approve_tool(payload)
+        tool_name = payload["tool_name"]
+        raise InvalidActionError, "Tool name is required" if tool_name.blank?
+
+        tool = McpTool.find_by(creative: comment.creative, name: tool_name)
+        raise InvalidActionError, "Tool '#{tool_name}' not found" unless tool
+
+        tool.approve!
       end
 
       def process_action(payload)

--- a/app/services/mcp_service.rb
+++ b/app/services/mcp_service.rb
@@ -7,10 +7,13 @@ class McpService
     result = Tools::MetaToolWriteService.new.register_tool_from_source(source: source_code)
 
     if result[:error]
-      Rails.logger.error("Failed to register tool #{source_code}: #{result[:error]}")
+      error_msg = "Failed to register tool: #{result[:error]}"
+      Rails.logger.error(error_msg)
+      raise error_msg
     end
   rescue => e
     Rails.logger.error("Failed to register tool from source: #{e.message}")
+    raise e
   end
 
   def self.load_active_tools

--- a/app/services/mcp_service.rb
+++ b/app/services/mcp_service.rb
@@ -68,7 +68,10 @@ class McpService
 
     tool_name = tool_name_match[1]
 
-    mcp_tool = McpTool.find_or_initialize_by(creative: creative, name: tool_name)
+    # Ensure tool is attached to the origin creative so approvals work correctly
+    # even when editing a linked creative
+    target_creative = creative.effective_origin
+    mcp_tool = McpTool.find_or_initialize_by(creative: target_creative, name: tool_name)
 
     # Calculate checksum to detect changes
     new_checksum = Digest::SHA256.hexdigest(code)

--- a/app/services/mcp_service.rb
+++ b/app/services/mcp_service.rb
@@ -1,3 +1,5 @@
+require "digest"
+
 class McpService
   # --- Registration Logic (from MetaToolService) ---
 

--- a/app/services/mcp_service.rb
+++ b/app/services/mcp_service.rb
@@ -71,6 +71,11 @@ class McpService
     new_checksum = Digest::SHA256.hexdigest(code)
 
     if mcp_tool.new_record? || mcp_tool.checksum != new_checksum
+      # Unregister old tool if it exists (source changed)
+      if !mcp_tool.new_record?
+        McpService.delete_tool(tool_name)
+      end
+
       mcp_tool.source_code = code
       mcp_tool.checksum = new_checksum
       mcp_tool.approved_at = nil # Reset approval status on change

--- a/app/services/mcp_service.rb
+++ b/app/services/mcp_service.rb
@@ -1,0 +1,106 @@
+class McpService
+  # --- Registration Logic (from MetaToolService) ---
+
+  def self.register_tool_from_source(source_code)
+    # Use the engine's service to register the tool
+    # Note: We use Tools::MetaToolWriteService from rails_mcp_engine
+    result = Tools::MetaToolWriteService.new.register_tool_from_source(source: source_code)
+
+    if result[:error]
+      Rails.logger.error("Failed to register tool #{source_code}: #{result[:error]}")
+    end
+  rescue => e
+    Rails.logger.error("Failed to register tool from source: #{e.message}")
+  end
+
+  def self.load_active_tools
+    McpTool.active.find_each do |tool|
+      register_tool_from_source(tool.source_code)
+    end
+  end
+
+  def self.delete_tool(tool_name)
+    result = Tools::MetaToolWriteService.new.delete_tool(tool_name)
+
+    if result[:error]
+      Rails.logger.error("Failed to delete tool #{tool_name}: #{result[:error]}")
+    end
+  rescue => e
+    Rails.logger.error("Failed to delete tool #{tool_name}: #{e.message}")
+  end
+
+  # --- Creative Parsing Logic (from MetaToolWriteService) ---
+
+  def update_from_creative(creative)
+    return unless creative.description.present?
+
+    # Parse HTML to find code blocks
+    doc = Nokogiri::HTML.fragment(creative.description)
+
+    # Find all code blocks.
+    # Lexical uses <pre class="lexical-code-block">.
+    # Standard markdown often uses <code>.
+    doc.css("pre.lexical-code-block, code").each do |node|
+      # Create a copy to manipulate
+      working_node = node.dup
+
+      # Replace <br> tags with newlines
+      working_node.search("br").each { |br| br.replace("\n") }
+
+      code = working_node.text
+
+      # Check if it looks like a tool definition
+      if code.include?("extend ToolMeta")
+        process_tool_definition(creative, code)
+      end
+    end
+  end
+
+  private
+
+  def process_tool_definition(creative, code)
+    # Extract tool name using regex
+    tool_name_match = code.match(/tool_name\s+["'](.+?)["']/)
+    return unless tool_name_match
+
+    tool_name = tool_name_match[1]
+
+    mcp_tool = McpTool.find_or_initialize_by(creative: creative, name: tool_name)
+
+    # Calculate checksum to detect changes
+    new_checksum = Digest::SHA256.hexdigest(code)
+
+    if mcp_tool.new_record? || mcp_tool.checksum != new_checksum
+      mcp_tool.source_code = code
+      mcp_tool.checksum = new_checksum
+      mcp_tool.approved_at = nil # Reset approval status on change
+
+      # Extract description
+      desc_match = code.match(/tool_description\s+["'](.+?)["']/)
+      mcp_tool.description = desc_match[1] if desc_match
+
+      if mcp_tool.save
+        notify_approval_needed(creative, mcp_tool)
+      end
+    end
+  end
+
+  def notify_approval_needed(creative, tool)
+    message = I18n.t("inbox.tool_approval_needed", tool_name: tool.name)
+
+    # Create a comment with action payload for approval
+    action_payload = {
+      action: "approve_tool",
+      tool_name: tool.name
+    }
+
+    Comment.create(
+      creative: creative,
+      content: message,
+      user: nil, # System message
+      approver: creative.user, # The creative owner should approve
+      action: JSON.pretty_generate(action_payload),
+      private: false
+    )
+  end
+end

--- a/config/initializers/mcp_tools.rb
+++ b/config/initializers/mcp_tools.rb
@@ -1,0 +1,11 @@
+Rails.application.config.to_prepare do
+  begin
+    if ActiveRecord::Base.connection.table_exists?(:mcp_tools)
+      McpService.load_active_tools
+    end
+  rescue ActiveRecord::NoDatabaseError, PG::ConnectionBad
+    # Ignore database errors during initialization (e.g. assets:precompile)
+  end
+rescue => e
+  Rails.logger.error("Failed to load MCP tools: #{e.message}")
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -67,6 +67,7 @@ en:
     user_mentioned: "%{user} mentioned you in \"%{creative}\": \"%{comment}\""
     permission_requested: "%{user} requested access to \"%{short_title}\"."
     comment_deleted_by_admin: "%{admin_name} deleted your comment in \"%{creative_snippet}\"."
+    tool_approval_needed: "Tool '%{tool_name}' has been detected/updated. Please approve it to activate."
 
   inbox_mailer:
     daily_summary:

--- a/db/migrate/20251202062715_create_mcp_tools.rb
+++ b/db/migrate/20251202062715_create_mcp_tools.rb
@@ -1,0 +1,16 @@
+class CreateMcpTools < ActiveRecord::Migration[8.1]
+  def change
+    create_table :mcp_tools do |t|
+      t.references :creative, null: false, foreign_key: true
+      t.string :name, null: false
+      t.text :description
+      t.text :source_code
+      t.json :definition, default: {}
+      t.string :checksum
+      t.datetime :approved_at
+
+      t.timestamps
+    end
+    add_index :mcp_tools, :name, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_12_01_073823) do
+ActiveRecord::Schema[8.1].define(version: 2025_12_02_062715) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false
@@ -143,7 +143,7 @@ ActiveRecord::Schema[8.1].define(version: 2025_12_01_073823) do
     t.float "progress", default: 0.0
     t.integer "sequence", default: 0, null: false
     t.datetime "updated_at", null: false
-    t.integer "user_id", null: false
+    t.integer "user_id"
     t.index ["origin_id"], name: "index_creatives_on_origin_id"
     t.index ["parent_id"], name: "index_creatives_on_parent_id"
     t.index ["user_id"], name: "index_creatives_on_user_id"
@@ -242,6 +242,20 @@ ActiveRecord::Schema[8.1].define(version: 2025_12_01_073823) do
     t.datetime "updated_at", null: false
     t.string "value"
     t.index ["owner_id"], name: "index_labels_on_owner_id"
+  end
+
+  create_table "mcp_tools", force: :cascade do |t|
+    t.datetime "approved_at"
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.integer "creative_id", null: false
+    t.json "definition", default: {}
+    t.text "description"
+    t.string "name", null: false
+    t.text "source_code"
+    t.datetime "updated_at", null: false
+    t.index ["creative_id"], name: "index_mcp_tools_on_creative_id"
+    t.index ["name"], name: "index_mcp_tools_on_name", unique: true
   end
 
   create_table "notion_accounts", force: :cascade do |t|
@@ -547,7 +561,7 @@ ActiveRecord::Schema[8.1].define(version: 2025_12_01_073823) do
   add_foreign_key "creative_expanded_states", "users"
   add_foreign_key "creative_shares", "creatives"
   add_foreign_key "creative_shares", "users"
-  add_foreign_key "creative_shares", "users", column: "shared_by_id"
+  add_foreign_key "creative_shares", "users", column: "shared_by_id", on_delete: :nullify
   add_foreign_key "creatives", "creatives", column: "origin_id"
   add_foreign_key "creatives", "creatives", column: "parent_id"
   add_foreign_key "creatives", "users"
@@ -562,6 +576,7 @@ ActiveRecord::Schema[8.1].define(version: 2025_12_01_073823) do
   add_foreign_key "invitations", "creatives"
   add_foreign_key "invitations", "users", column: "inviter_id"
   add_foreign_key "labels", "users", column: "owner_id"
+  add_foreign_key "mcp_tools", "creatives"
   add_foreign_key "notion_accounts", "users"
   add_foreign_key "notion_block_links", "creatives"
   add_foreign_key "notion_block_links", "notion_page_links"

--- a/test/models/creative_test.rb
+++ b/test/models/creative_test.rb
@@ -194,4 +194,20 @@ class CreativeTest < ActiveSupport::TestCase
   ensure
     Current.reset
   end
+  test "destroying creative destroys associated mcp_tools" do
+    user = users(:one)
+    creative = Creative.create!(user: user, description: "Tool Creative")
+
+    # Create a tool manually
+    tool = McpTool.create!(creative: creative, name: "cascade_tool", source_code: "class Cascade; end")
+
+    # Mock the unregistration to avoid actual engine interaction
+    McpService.stub :delete_tool, nil do
+      assert_difference("McpTool.count", -1) do
+        creative.destroy
+      end
+    end
+
+    assert_empty McpTool.where(id: tool.id)
+  end
 end

--- a/test/models/mcp_tool_test.rb
+++ b/test/models/mcp_tool_test.rb
@@ -16,6 +16,20 @@ class McpToolTest < ActiveSupport::TestCase
     assert_not_nil tool.approved_at
   end
 
+  test "approve! does not set approved_at if registration fails" do
+    creative = Creative.create!(user: users(:one), description: "Test")
+    tool = McpTool.create!(creative: creative, name: "fail_tool", source_code: "invalid")
+
+    McpService.stub :register_tool_from_source, ->(_) { raise "Registration failed" } do
+      assert_raises(RuntimeError) do
+        tool.approve!
+      end
+    end
+
+    tool.reload
+    assert_nil tool.approved_at
+  end
+
   test "destroy unregisters tool via McpService" do
     creative = Creative.create!(user: users(:one), description: "Test")
     tool = McpTool.create!(creative: creative, name: "test_tool", source_code: "class Foo; end")

--- a/test/models/mcp_tool_test.rb
+++ b/test/models/mcp_tool_test.rb
@@ -1,0 +1,32 @@
+require "test_helper"
+
+class McpToolTest < ActiveSupport::TestCase
+  test "approve! registers tool via McpService" do
+    creative = Creative.create!(user: users(:one), description: "Test")
+    tool = McpTool.create!(creative: creative, name: "test_tool", source_code: "class Foo; end")
+
+    mock_service = Minitest::Mock.new
+    mock_service.expect :register_tool_from_source, nil, [ "class Foo; end" ]
+
+    McpService.stub :register_tool_from_source, ->(s) { mock_service.register_tool_from_source(s) } do
+      tool.approve!
+    end
+
+    mock_service.verify
+    assert_not_nil tool.approved_at
+  end
+
+  test "destroy unregisters tool via McpService" do
+    creative = Creative.create!(user: users(:one), description: "Test")
+    tool = McpTool.create!(creative: creative, name: "test_tool", source_code: "class Foo; end")
+
+    mock_service = Minitest::Mock.new
+    mock_service.expect :delete_tool, nil, [ "test_tool" ]
+
+    McpService.stub :delete_tool, ->(n) { mock_service.delete_tool(n) } do
+      tool.destroy
+    end
+
+    mock_service.verify
+  end
+end

--- a/test/services/mcp_service_test.rb
+++ b/test/services/mcp_service_test.rb
@@ -1,0 +1,80 @@
+require "test_helper"
+
+class McpServiceTest < ActiveSupport::TestCase
+  test "register_tool_from_source delegates to engine service" do
+    source_code = <<~RUBY
+      class Tools::TestTool
+        extend T::Sig
+        extend ToolMeta
+        tool_name "test_tool"
+        tool_description "Test Tool"
+      end
+    RUBY
+
+    mock_service = Minitest::Mock.new
+    mock_service.expect :register_tool_from_source, { status: "registered" }, [], source: source_code
+
+    Tools::MetaToolWriteService.stub :new, mock_service do
+      McpService.register_tool_from_source(source_code)
+    end
+
+    mock_service.verify
+  end
+
+  test "delete_tool delegates to engine service" do
+    tool_name = "test_tool"
+
+    mock_service = Minitest::Mock.new
+    mock_service.expect :delete_tool, { success: "Tool deleted successfully" }, [ tool_name ]
+
+    Tools::MetaToolWriteService.stub :new, mock_service do
+      McpService.delete_tool(tool_name)
+    end
+
+    mock_service.verify
+  end
+
+  test "update_from_creative parses lexical code blocks" do
+    user = users(:one)
+    creative = Creative.create!(user: user, description: <<~HTML)
+      <p>Here is a tool:</p>
+      <pre class="lexical-code-block">
+        class Tools::LexicalTool
+          extend ToolMeta
+          tool_name "lexical_tool"
+          tool_description "Lexical Tool"
+        end
+      </pre>
+    HTML
+
+    # Mock the registration call to avoid actual engine interaction
+    McpService.stub :register_tool_from_source, nil do
+      McpService.new.update_from_creative(creative)
+    end
+
+    tool = McpTool.find_by(name: "lexical_tool")
+    assert tool, "Tool should be created"
+    assert_equal "Lexical Tool", tool.description
+    assert_includes tool.source_code, "class Tools::LexicalTool"
+  end
+
+  test "update_from_creative handles br tags in code blocks" do
+    user = users(:one)
+    creative = Creative.create!(user: user, description: <<~HTML)
+      <pre class="lexical-code-block">
+        class Tools::BrTool<br>
+          extend ToolMeta<br>
+          tool_name "br_tool"<br>
+        end
+      </pre>
+    HTML
+
+    McpService.stub :register_tool_from_source, nil do
+      McpService.new.update_from_creative(creative)
+    end
+
+    tool = McpTool.find_by(name: "br_tool")
+    assert tool
+    assert_includes tool.source_code, "class Tools::BrTool\n"
+  end
+end

--- a/test/services/mcp_service_test.rb
+++ b/test/services/mcp_service_test.rb
@@ -143,7 +143,7 @@ class McpServiceTest < ActiveSupport::TestCase
     McpService.stub :register_tool_from_source, nil do
       # We need to call update_from_creative manually or via update!
       # Since update! triggers the callback, let's use that.
-      linked.update!(description: <<~HTML)
+      origin.update!(description: <<~HTML)
         <pre class="lexical-code-block">
           class Tools::LinkedTool
             extend ToolMeta

--- a/test/services/mcp_service_test.rb
+++ b/test/services/mcp_service_test.rb
@@ -93,7 +93,7 @@ class McpServiceTest < ActiveSupport::TestCase
     McpService.stub :register_tool_from_source, nil do
       McpService.new.update_from_creative(creative)
     end
-    
+
     tool = McpTool.find_by(name: "stale_tool")
     tool.update!(approved_at: Time.current) # Simulate approval
 
@@ -114,8 +114,23 @@ class McpServiceTest < ActiveSupport::TestCase
     end
 
     mock_service.verify
-    
+
     tool.reload
     assert_nil tool.approved_at
+  end
+
+  test "register_tool_from_source raises error on failure" do
+    source_code = "invalid source"
+
+    mock_service = Minitest::Mock.new
+    mock_service.expect :register_tool_from_source, { error: "Syntax error" }, [], source: source_code
+
+    Tools::MetaToolWriteService.stub :new, mock_service do
+      assert_raises(RuntimeError) do
+        McpService.register_tool_from_source(source_code)
+      end
+    end
+
+    mock_service.verify
   end
 end


### PR DESCRIPTION
- Add McpTool model and migration
- Create McpService to handle tool registration via rails_mcp_engine
- Integrate tool approval with Comments::ActionExecutor
- Add parsing logic for tool definitions in Creative descriptions
- Implement cascading deletion for tools
- Add comprehensive tests