### PR TITLE
Support Liquid templates for AI prompts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,3 +15,12 @@ This document captures best practices for integrating Anthropic's Claude models 
 - Keep dialogue transcripts or prompt iterations in version control when they inform product behavior.
 - Record evaluation results and regression checks so other agents can reuse them.
 - Cross-reference related guidance in `AGENTS.md` to maintain a cohesive developer experience.
+
+## System Prompt Templates
+- AI user system prompts are rendered as [Liquid templates](https://github.com/Shopify/liquid) so you can inject runtime context.
+- Available variables:
+  - `ai_user`: `id`, `name`, `llm_vendor`, `llm_model`.
+  - `creative`: `id`, `description` (plain text), `progress`, `owner_name`.
+  - `comment`: `id`, `content`, `user_name`.
+  - `payload`: user message text after stripping the mention prefix.
+- Templates fall back to the raw prompt if rendering fails; check Rails logs for `AI system prompt rendering failed` warnings when debugging.

--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,7 @@ gem "omniauth-github"
 gem "httparty"
 gem "octokit"
 gem "ruby_llm"
+gem "liquid"
 
 gem "dotenv", groups: [ :development, :test ]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -245,6 +245,9 @@ GEM
       zeitwerk (>= 2.6.18, < 3.0)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
+    liquid (5.11.0)
+      bigdecimal
+      strscan (>= 3.1.1)
     logger (1.7.0)
     loofah (2.24.1)
       crass (~> 1.0.2)
@@ -518,6 +521,7 @@ GEM
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.1.7)
+    strscan (3.1.5)
     thor (1.4.0)
     thruster (0.1.16)
     thruster (0.1.16-aarch64-linux)
@@ -588,6 +592,7 @@ DEPENDENCIES
   jbuilder
   jsbundling-rails
   kamal
+  liquid
   octokit
   omniauth-github
   omniauth-google-oauth2

--- a/app/services/ai_system_prompt_renderer.rb
+++ b/app/services/ai_system_prompt_renderer.rb
@@ -1,0 +1,36 @@
+class AiSystemPromptRenderer
+  def self.render(template:, context: {})
+    new(template:, context:).render
+  end
+
+  def initialize(template:, context: {})
+    @template = template.presence || AiClient::SYSTEM_INSTRUCTIONS
+    @context = context
+  end
+
+  def render
+    parsed_template.render(stringified_context, render_options)
+  rescue StandardError => e
+    Rails.logger.warn("AI system prompt rendering failed: #{e.message}")
+    template
+  end
+
+  private
+
+  attr_reader :template, :context
+
+  def parsed_template
+    Liquid::Template.parse(template, error_mode: :warn)
+  end
+
+  def stringified_context
+    context.deep_stringify_keys
+  end
+
+  def render_options
+    {
+      strict_variables: false,
+      strict_filters: false
+    }
+  end
+end

--- a/package-lock.json
+++ b/package-lock.json
@@ -127,7 +127,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -690,7 +689,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -734,7 +732,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1278,7 +1275,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.2.tgz",
       "integrity": "sha512-Ecx2ig/JLC9ayIQwZHqm41Tzlf4c1WUuFhFUZB1y+JIJqDRE579x7Uil7tKT8MwDpOPwrK5ZtpxdSsrfy/LF8Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/component": "0.7.0",
         "@firebase/logger": "0.5.0",
@@ -1345,7 +1341,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.2.tgz",
       "integrity": "sha512-cn+U27GDaBS/irsbvrfnPZdcCzeZPRGKieSlyb7vV6LSOL6mdECnB86PgYjYGxSNg8+U48L/NeevTV1odU+mOQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/app": "0.14.2",
         "@firebase/component": "0.7.0",
@@ -1361,8 +1356,7 @@
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
       "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@firebase/auth": {
       "version": "1.11.0",
@@ -1813,7 +1807,6 @@
       "integrity": "sha512-0AZUyYUfpMNcztR5l09izHwXkZpghLgCUaAGjtMwXnCg3bj4ml5VgiwqOMOxJ+Nw4qN/zJAaOQBcJ7KGkWStqQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -3686,7 +3679,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -4618,6 +4610,7 @@
       "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
       "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
@@ -5868,7 +5861,6 @@
       "integrity": "sha512-Pcfm3eZ+eO4JdZCXthW9tCDT3nF4K+9dmeZ+5X39n+Kqz0DDIABRP5CAEOHRFZk8RGuC2efksTJxrjp8EXCunQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.19",
         "@asamuzakjp/dom-selector": "^6.7.3",
@@ -5957,6 +5949,7 @@
       "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.114.tgz",
       "integrity": "sha512-gcxmNFzA4hv8UYi8j43uPlQ7CGcyMJ2KQb5kZASw6SnAKAf10hK12i2fjrS3Cl/ugZa5Ui6WwIu1/6MIXiHttQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "isomorphic.js": "^0.2.4"
       },
@@ -6555,7 +6548,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6565,7 +6557,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },

--- a/test/services/comments/ai_responder_test.rb
+++ b/test/services/comments/ai_responder_test.rb
@@ -64,5 +64,45 @@ module Comments
       reply = creative.comments.where(user: ai_user).order(:id).last
       assert_equal "pong", reply.content
     end
+
+    test "renders liquid variables in system prompt" do
+      creative = creatives(:tshirt)
+      commenter = users(:one)
+      ai_user = User.create!(
+        name: "AIBot",
+        email: "aibot@example.com",
+        password: "password",
+        llm_vendor: "google",
+        llm_model: "gemini-2.5-flash",
+        system_prompt: "Assist {{ai_user.name}} on {{creative.description}} for {{comment.user_name}} about {{payload}}",
+        llm_api_key: "dummy-key",
+        email_verified_at: Time.current,
+        searchable: true
+      )
+
+      comment = creative.comments.create!(content: "@AIBot: ping please", user: commenter)
+
+      captured_prompt = nil
+      fake_client = Class.new do
+        attr_reader :system_prompt
+
+        def initialize(**args)
+          @system_prompt = args[:system_prompt]
+        end
+
+        def chat(_messages, tools: [])
+          yield "pong" if block_given?
+          "pong"
+        end
+      end
+
+      AiClient.stub(:new, ->(**args) { instance = fake_client.new(**args); captured_prompt = instance.system_prompt; instance }) do
+        Comments::AiResponder.new(comment: comment, creative: creative).call
+      end
+
+      assert_equal "Assist AIBot on T-Shirt for One about ping please", captured_prompt
+      reply = creative.comments.where(user: ai_user).order(:id).last
+      assert_equal "pong", reply.content
+    end
   end
 end


### PR DESCRIPTION
## Summary
- add Liquid gem and AiSystemPromptRenderer to allow AI user system prompts to be rendered as templates
- render AI system prompts with creative/comment/payload context when handling mentions and document the available variables
- cover Liquid rendering with a service test and keep existing behavior through AI responder updates

## Testing
- ./bin/rubocop -a
- rails test
- rails test:system *(fails: Selenium could not download ChromeDriver in this environment)*

## Original User's Requirements
- when use ai agent's system prompt, it can be liquid template so that we can inject some context for build final prompt
- the liquid template's github: https://github.com/Shopify/liquid

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692eb3a109a88326b3b3759e85f1e988)