### PR TITLE
Add MCP tool chat commands

### DIFF
--- a/app/services/comments/command_processor.rb
+++ b/app/services/comments/command_processor.rb
@@ -1,15 +1,13 @@
 module Comments
   class CommandProcessor
-    COMMANDS = [ CalendarCommand ].freeze
-
     def initialize(comment:, user:)
       @comment = comment
       @user = user
     end
 
     def call
-      COMMANDS.each do |command_class|
-        result = command_class.new(comment: comment, user: user).call
+      command_handlers.each do |command|
+        result = command.call
         return result if result.present?
       end
       nil
@@ -21,5 +19,17 @@ module Comments
     private
 
     attr_reader :comment, :user
+
+    def command_handlers
+      static_commands + mcp_commands
+    end
+
+    def static_commands
+      [ CalendarCommand.new(comment: comment, user: user) ]
+    end
+
+    def mcp_commands
+      McpCommandBuilder.new(comment: comment, user: user).commands
+    end
   end
 end

--- a/app/services/comments/mcp_command.rb
+++ b/app/services/comments/mcp_command.rb
@@ -1,0 +1,106 @@
+require "json"
+
+module Comments
+  class McpCommand
+    def initialize(comment:, user:, tool:, meta_tool_service: default_meta_tool_service)
+      @comment = comment
+      @user = user
+      @tool = tool
+      @meta_tool_service = meta_tool_service
+    end
+
+    def call
+      return unless command_match?
+
+      arguments = parsed_arguments
+      return usage_message unless arguments
+
+      response = meta_tool_service.call(action: "run", tool_name: tool_name, arguments: arguments)
+      format_response(response)
+    rescue StandardError => e
+      Rails.logger.error("MCP command '#{tool_name}' failed: #{e.message}")
+      e.message
+    end
+
+    private
+
+    attr_reader :comment, :user, :tool, :meta_tool_service
+
+    def command_match?
+      comment.content.to_s.strip.match?(command_pattern)
+    end
+
+    def command_pattern
+      @command_pattern ||= /\A\/#{Regexp.escape(tool_name)}\b/i
+    end
+
+    def command_body
+      comment.content.to_s.strip.sub(command_pattern, "").strip
+    end
+
+    def parsed_arguments
+      body = command_body
+      return {} if body.blank?
+
+      JSON.parse(body)
+    rescue JSON::ParserError
+      key_value_arguments(body)
+    end
+
+    def key_value_arguments(body)
+      args = body.split(/\s+/).each_with_object({}) do |pair, result|
+        key, value = pair.split("=", 2)
+        next if key.blank? || value.nil?
+
+        result[key] = cast_value(value)
+      end
+
+      return args if args.present?
+
+      nil
+    end
+
+    def cast_value(value)
+      case value
+      when /\A\d+\z/ then value.to_i
+      when /\A\d+\.\d+\z/ then value.to_f
+      when /\Atrue\z/i then true
+      when /\Afalse\z/i then false
+      else
+        value
+      end
+    end
+
+    def usage_message
+      params = Array(tool[:params]).map { |param| param[:name] }.join(" ").presence
+      usage = [ tool_name, params ].compact.join(" ")
+      "Usage: /#{usage}"
+    end
+
+    def format_response(response)
+      return "Error running /#{tool_name}: #{response[:error]}" if response[:error].present?
+
+      result = response[:result]
+      result_text = format_result(result)
+      header = "/#{tool_name} executed"
+      result_text.present? ? "#{header}: #{result_text}" : header
+    end
+
+    def format_result(result)
+      case result
+      when Hash, Array
+        JSON.pretty_generate(result)
+      else
+        result.to_s
+      end
+    end
+
+    def tool_name
+      tool[:name]
+    end
+
+    def default_meta_tool_service
+      Tools::MetaToolService.new
+    end
+  end
+end

--- a/app/services/comments/mcp_command_builder.rb
+++ b/app/services/comments/mcp_command_builder.rb
@@ -1,0 +1,30 @@
+module Comments
+  class McpCommandBuilder
+    def initialize(comment:, user:, logger: Rails.logger)
+      @comment = comment
+      @user = user
+      @logger = logger
+    end
+
+    def commands
+      return [] unless defined?(RailsMcpEngine)
+
+      RailsMcpEngine::Engine.build_tools!
+      tools = meta_tool_service.call(action: "list", tool_name: nil, query: nil, arguments: nil)
+      Array(tools[:tools]).map do |tool|
+        McpCommand.new(comment: comment, user: user, tool: tool, meta_tool_service: meta_tool_service)
+      end
+    rescue StandardError => e
+      logger.error("MCP command registration failed: #{e.message}")
+      []
+    end
+
+    private
+
+    attr_reader :comment, :user, :logger
+
+    def meta_tool_service
+      @meta_tool_service ||= Tools::MetaToolService.new
+    end
+  end
+end

--- a/package-lock.json
+++ b/package-lock.json
@@ -127,7 +127,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -690,7 +689,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -734,7 +732,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1278,7 +1275,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.2.tgz",
       "integrity": "sha512-Ecx2ig/JLC9ayIQwZHqm41Tzlf4c1WUuFhFUZB1y+JIJqDRE579x7Uil7tKT8MwDpOPwrK5ZtpxdSsrfy/LF8Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/component": "0.7.0",
         "@firebase/logger": "0.5.0",
@@ -1345,7 +1341,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.2.tgz",
       "integrity": "sha512-cn+U27GDaBS/irsbvrfnPZdcCzeZPRGKieSlyb7vV6LSOL6mdECnB86PgYjYGxSNg8+U48L/NeevTV1odU+mOQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/app": "0.14.2",
         "@firebase/component": "0.7.0",
@@ -1361,8 +1356,7 @@
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
       "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@firebase/auth": {
       "version": "1.11.0",
@@ -1813,7 +1807,6 @@
       "integrity": "sha512-0AZUyYUfpMNcztR5l09izHwXkZpghLgCUaAGjtMwXnCg3bj4ml5VgiwqOMOxJ+Nw4qN/zJAaOQBcJ7KGkWStqQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -3686,7 +3679,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -4618,6 +4610,7 @@
       "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
       "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
@@ -5868,7 +5861,6 @@
       "integrity": "sha512-Pcfm3eZ+eO4JdZCXthW9tCDT3nF4K+9dmeZ+5X39n+Kqz0DDIABRP5CAEOHRFZk8RGuC2efksTJxrjp8EXCunQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.19",
         "@asamuzakjp/dom-selector": "^6.7.3",
@@ -5957,6 +5949,7 @@
       "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.114.tgz",
       "integrity": "sha512-gcxmNFzA4hv8UYi8j43uPlQ7CGcyMJ2KQb5kZASw6SnAKAf10hK12i2fjrS3Cl/ugZa5Ui6WwIu1/6MIXiHttQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "isomorphic.js": "^0.2.4"
       },
@@ -6555,7 +6548,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6565,7 +6557,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },


### PR DESCRIPTION
## Summary
- add dynamic MCP command builder to expose each registered tool as a chat command with tool-matched names
- route comment command processing through shared handler list to execute MCP tool invocations and return formatted responses
- parse MCP command arguments from JSON or key/value pairs and provide usage feedback when inputs are missing

## Testing
- ./bin/rubocop -a
- bundle exec rails test
- bundle exec rails test:system *(fails: selenium/chromedriver unavailable in environment)*

Original User's Requirements
- we have calendar command in chat message input,
we will use mcp tool as a chat command so that a user can call any tool in chat input.
generate chat command and auto register all mcp tools as chat command.
one tool for one command and the command name as tool name.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ef3347ea48326bb7437be5efd690e)