### PR TITLE
Ensure comment links load target page

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -42,11 +42,13 @@ class CommentsController < ApplicationController
       last_read_comment_id = nil
     end
 
+    comments_for_render = page <= 1 ? @comments.reverse : @comments
+
     response.set_header("X-Comments-Page", page)
-    if page <= 1
-      render partial: "comments/list", locals: { comments: @comments.reverse, creative: @creative, last_read_comment_id: last_read_comment_id }
+    if page <= 1 || params[:comment_id].present?
+      render partial: "comments/list", locals: { comments: comments_for_render, creative: @creative, last_read_comment_id: last_read_comment_id }
     else
-      render partial: "comments/comment", collection: @comments, as: :comment
+      render partial: "comments/comment", collection: comments_for_render, as: :comment
     end
   end
 


### PR DESCRIPTION
## Summary
- calculate the comments page containing a requested comment and include the page in responses
- update the comments list loader to request the specific page for highlighted links and track the returned page number for pagination

## Testing
- ./bin/rubocop -a *(fails: missing gems, run `bundle install`)*

## Original User's Requirements
- chat message link 를 열었을때, 해당 채팅의 첫번째 페이지에 오지 않으면 표시가 되지 않으므로, 해당 채팅 메세지가 있는 곳으로 바로 조회해서 표시되도록 해야 한다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69303df2b7508326a5e232300e489424)