### PR TITLE
Add table support to Lexical inline editor

### DIFF
--- a/app/assets/stylesheets/actiontext.css
+++ b/app/assets/stylesheets/actiontext.css
@@ -219,6 +219,28 @@
   white-space: pre;
 }
 
+.lexical-table {
+  border-collapse: collapse;
+  margin: 0 0 0.75rem 0;
+  width: 100%;
+}
+
+.lexical-table-cell,
+.lexical-table th,
+.lexical-table td {
+  border: 1px solid var(--color-border);
+  padding: 0.4rem 0.5rem;
+  text-align: left;
+}
+
+.lexical-table-cell--selected {
+  background: rgba(3, 102, 214, 0.1);
+}
+
+.lexical-table-cell--primary-selected {
+  background: rgba(3, 102, 214, 0.2);
+}
+
 .lexical-code-block span {
   background: transparent;
   border: 0;

--- a/app/javascript/components/InlineLexicalEditor.jsx
+++ b/app/javascript/components/InlineLexicalEditor.jsx
@@ -21,6 +21,8 @@ import {
 } from "@lexical/code"
 import { ListItemNode, ListNode, INSERT_ORDERED_LIST_COMMAND, INSERT_UNORDERED_LIST_COMMAND } from "@lexical/list"
 import { LinkNode, AutoLinkNode, TOGGLE_LINK_COMMAND } from "@lexical/link"
+import { TablePlugin } from "@lexical/react/LexicalTablePlugin"
+import { TableCellNode, TableNode, TableRowNode, INSERT_TABLE_COMMAND } from "@lexical/table"
 import {
   $createParagraphNode,
   $createTextNode,
@@ -107,6 +109,13 @@ const theme = {
     underline: "lexical-text-underline",
     strikethrough: "lexical-text-strike",
     code: "lexical-text-code"
+  },
+  table: {
+    table: "lexical-table",
+    tableCell: "lexical-table-cell",
+    tableCellSelected: "lexical-table-cell--selected",
+    tableCellPrimarySelected: "lexical-table-cell--primary-selected",
+    tableRow: "lexical-table-row"
   }
 }
 
@@ -587,6 +596,13 @@ function Toolbar({ onPromptForLink }) {
         title="Insert link">
         🔗
       </button>
+      <button
+        type="button"
+        className="lexical-toolbar-btn"
+        onClick={() => editor.dispatchCommand(INSERT_TABLE_COMMAND, { columns: 3, rows: 3, includeHeaders: false })}
+        title="Insert table">
+        🗂️
+      </button>
       <span className="lexical-toolbar-separator" aria-hidden="true" />
       <ToolbarColorPicker
         icon="🎨"
@@ -705,6 +721,7 @@ function EditorInner({
         <CodeHighlightingPlugin />
         <ListPlugin />
         <LinkPlugin />
+        <TablePlugin hasCellMerge={false} hasCellBackgroundColor={false} />
         <AutoLinkPlugin matchers={URL_MATCHERS} />
         <OnChangePlugin
           onChange={(editorState, editorInstance) => {
@@ -765,6 +782,9 @@ export default function InlineLexicalEditor({
         QuoteNode,
         CodeNode,
         CodeHighlightNode,
+        TableNode,
+        TableRowNode,
+        TableCellNode,
         ListItemNode,
         ListNode,
         LinkNode,

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@lexical/react": "^0.38.2",
         "@lexical/rich-text": "^0.38.2",
         "@lexical/selection": "^0.38.2",
+        "@lexical/table": "^0.38.2",
         "@lexical/utils": "^0.38.2",
         "@rails/actioncable": "^8.0.201",
         "@rails/actiontext": "^8.0.201",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@lexical/react": "^0.38.2",
     "@lexical/rich-text": "^0.38.2",
     "@lexical/selection": "^0.38.2",
+    "@lexical/table": "^0.38.2",
     "@lexical/utils": "^0.38.2",
     "@rails/actioncable": "^8.0.201",
     "@rails/actiontext": "^8.0.201",


### PR DESCRIPTION
## Summary
- enable table nodes and toolbar insertion in the creative inline Lexical editor
- wire the Lexical table plugin and theme styling for table selections
- add table styling to ActionText output and include the new Lexical table dependency

## Testing
- Not run (npm install repeatedly stalled in this environment)

## Original User's Requirements
- Support table in Lexical editor for creative inline edits

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69314e8776c48326b23b2ebcf904d00e)