### PR TITLE
Persist comments popup position after resize

### DIFF
--- a/app/javascript/controllers/comments/popup_controller.js
+++ b/app/javascript/controllers/comments/popup_controller.js
@@ -158,6 +158,12 @@ export default class extends Controller {
       if (parsed.height) {
         this.element.style.height = parsed.height
       }
+      if (parsed.top) this.element.style.top = parsed.top
+      if (parsed.left) {
+        this.element.style.left = parsed.left
+        this.element.style.right = ''
+      }
+      if (parsed.resized) this.element.dataset.resized = 'true'
     } catch (error) {
       console.warn('Failed to parse comments popup size', error)
     }
@@ -247,7 +253,13 @@ export default class extends Controller {
     if (this.resizing) {
       window.localStorage.setItem(
         SIZE_STORAGE_KEY,
-        JSON.stringify({ width: this.element.style.width, height: this.element.style.height })
+        JSON.stringify({
+          width: this.element.style.width,
+          height: this.element.style.height,
+          top: this.element.style.top,
+          left: this.element.style.left,
+          resized: true,
+        })
       )
     }
     this.resizing = null

--- a/test/system/creative_expansion_actions_test.rb
+++ b/test/system/creative_expansion_actions_test.rb
@@ -92,4 +92,36 @@ class CreativeExpansionActionsTest < ApplicationSystemTestCase
     assert_selector "#comments-popup", visible: :visible
     assert_selector "#comment_#{comment.id}.highlight-flash", wait: 5
   end
+
+  test "reopens comments popup at stored position after resize" do
+    stored_top = "150px"
+    stored_left = "250px"
+
+    page.execute_script(<<~JS)
+      window.localStorage.setItem('commentsPopupSize', JSON.stringify({
+        width: '480px',
+        height: '520px',
+        top: '#{stored_top}',
+        left: '#{stored_left}',
+        resized: true,
+      }))
+    JS
+
+    root_selector = row_selector(@root_creative)
+    find(root_selector).hover
+    within(:css, root_selector) do
+      find("[name='show-comments-btn']").click
+    end
+
+    assert_selector "#comments-popup", visible: :visible
+
+    popup_top, popup_left = page.evaluate_script(<<~JS)
+      const popup = document.getElementById('comments-popup')
+      const styles = window.getComputedStyle(popup)
+      [styles.top, styles.left]
+    JS
+
+    assert_equal stored_top, popup_top
+    assert_equal stored_left, popup_left
+  end
 end


### PR DESCRIPTION
## Summary
- persist stored popup dimensions and position when reopening the comments popup
- save popup top/left offsets after resizing so reopening keeps the same placement
- add a system test to verify the popup reopens at the stored coordinates

## Testing
- ./bin/rubocop -a
- bundle exec rails test
- bundle exec rails test:system *(fails: chromedriver download blocked in the environment, preventing Selenium from running)*

## Original User's Requirements
- fix to correct position of comments-popup after resizing and reopen.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932d432ef3c832686368f6d26fb0079)