### PR TITLE
Fix inline edit rendering issue and add regression test

### DIFF
--- a/app/javascript/creative_row_editor.js
+++ b/app/javascript/creative_row_editor.js
@@ -1099,10 +1099,12 @@ export function initializeCreativeRowEditor() {
         const row = treeRowElement(tree);
         if (row) {
           row.dataset.descriptionHtml = currentContent;
+          row.descriptionHtml = currentContent;
           row.dataset.descriptionRawHtml = currentContent;
           row.dataset.progressValue = String(currentProgress);
           if (currentParentId) {
             tree.dataset.parentId = currentParentId;
+            row.parentId = currentParentId;
           }
           // Trigger Lit component re-render to show updated values
           row.requestUpdate?.();

--- a/test/system/creative_inline_edit_test.rb
+++ b/test/system/creative_inline_edit_test.rb
@@ -227,4 +227,20 @@ class CreativeInlineEditTest < ApplicationSystemTestCase
 
     assert_no_selector "#inline-level-up[disabled]", wait: 5
   end
+
+  test "renders modified content when moving down after edit" do
+    creative1 = Creative.create!(description: "Creative 1", user: @user, parent: @root_creative)
+    Creative.create!(description: "Creative 2", user: @user, parent: @root_creative)
+
+    visit creatives_path
+    expand_creative(@root_creative)
+
+    open_inline_editor(creative1)
+    fill_inline_editor("Creative 1 Modified")
+
+    find("#inline-move-down", wait: 5).click
+
+    # Verify the content of the first creative is updated in the static row
+    assert_selector "#creative-#{creative1.id} .creative-content", text: "Creative 1 Modified", wait: 5
+  end
 end


### PR DESCRIPTION
- Fixes a bug where inline edited content was not rendering correctly when moving down.
- Updates 'creative_row_editor.js' to set the 'descriptionHtml' property on the 'creative-tree-row' component directly, ensuring optimistic UI updates work as expected.
- Adds a regression test in 'test/system/creative_inline_edit_test.rb'.