### PR TITLE
Set new creative link after save

### DIFF
--- a/app/javascript/creative_row_editor.js
+++ b/app/javascript/creative_row_editor.js
@@ -906,6 +906,9 @@ export function initializeCreativeRowEditor() {
                 if (rowEl) {
                   rowEl.setAttribute('creative-id', data.id);
                   rowEl.creativeId = data.id;
+                  const creativeLink = `/creatives/${data.id}`;
+                  rowEl.setAttribute('link-url', creativeLink);
+                  rowEl.linkUrl = creativeLink;
                   const levelValue = tree.dataset.level;
                   if (levelValue) {
                     rowEl.setAttribute('level', levelValue);


### PR DESCRIPTION
## Summary
- set the creative row link when a new creative is saved so the shortcut works immediately

## Testing
- ./bin/rubocop -a *(fails: missing gems locally)*

## Original User's Requirements
- 새로 생성된 크리에이티브는 바로가기 링크가 안되는데 저장시 아이디를 받아서 링크가 작동하도록 ui 렌더링을 업데이트 해야해

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69427bfb1090832693a172b574948908)