### PR TITLE
feat: Implement Real-time Chat Read Receipts

### DIFF
--- a/app/assets/stylesheets/comments_popup.css
+++ b/app/assets/stylesheets/comments_popup.css
@@ -85,6 +85,7 @@
     margin-right: 0.5em;
 }
 
+
 .comment-item {
     border-top: 1px solid var(--color-border);
     padding: 0.5em 1.8em 1.5em 0.5em;
@@ -108,10 +109,6 @@
     cursor: pointer;
 }
 
-.comment-item.last-read {
-    border-bottom: 2px solid var(--color-border);
-}
-
 .comment-content {
     margin-top: 0.2em;
 }
@@ -119,6 +116,51 @@
 .comment-action-block {
     margin-top: 0.6em;
 }
+
+
+
+
+.comment-header {
+    display: flex;
+    align-items: center;
+    gap: 0.5em;
+    min-height: 20px;
+    /* Ensure height is at least the size of the avatar */
+}
+
+.read-receipt-wrapper {
+    display: inline-flex;
+    align-items: center;
+    /* margin-left: 0.5em; -- handled by gap */
+    vertical-align: middle;
+    height: 16px;
+    /* Explicit height to match avatar */
+}
+
+.read-receipt-container {
+
+    /* Reset absolute positioning */
+    position: static;
+    width: auto;
+    display: flex;
+    pointer-events: auto;
+    z-index: auto;
+    padding: 0;
+    margin: 0;
+}
+
+.read-receipt-avatars {
+    display: flex;
+    align-items: center;
+    gap: -4px;
+    /* Slight overlap for compactness? Or keep standard gap */
+    gap: 2px;
+    background-color: transparent;
+    padding: 0;
+    border-radius: 0;
+}
+
+
 
 .comment-action-summary {
     cursor: pointer;
@@ -429,4 +471,23 @@
     font-size: 0.85em;
     width: 100px;
     outline: none;
+}
+
+.read-receipt-container {
+    display: flex;
+    align-items: center;
+    margin-top: 0.5em;
+    /* Spacing from the comment above */
+    margin-bottom: 0.5em;
+    width: 100%;
+    padding: 0 1em;
+    /* Add some padding so line doesn't touch edges */
+}
+
+.read-receipt-avatars {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 0 0.5em;
+    /* Space between line and avatars */
 }

--- a/app/assets/stylesheets/comments_popup.css
+++ b/app/assets/stylesheets/comments_popup.css
@@ -472,22 +472,3 @@
     width: 100px;
     outline: none;
 }
-
-.read-receipt-container {
-    display: flex;
-    align-items: center;
-    margin-top: 0.5em;
-    /* Spacing from the comment above */
-    margin-bottom: 0.5em;
-    width: 100%;
-    padding: 0 1em;
-    /* Add some padding so line doesn't touch edges */
-}
-
-.read-receipt-avatars {
-    display: flex;
-    align-items: center;
-    gap: 4px;
-    padding: 0 0.5em;
-    /* Space between line and avatars */
-}

--- a/app/controllers/comment_read_pointers_controller.rb
+++ b/app/controllers/comment_read_pointers_controller.rb
@@ -1,7 +1,7 @@
 class CommentReadPointersController < ApplicationController
   def update
     creative = Creative.find(params[:creative_id]).effective_origin
-    last_id = creative.comments.maximum(:id)
+    last_id = creative.comments.where("comments.private = ? OR comments.user_id = ?", false, Current.user.id).maximum(:id)
     pointer = CommentReadPointer.find_or_initialize_by(user: Current.user, creative: creative)
 
     previous_last_read_id = pointer.last_read_comment_id

--- a/app/controllers/comment_read_pointers_controller.rb
+++ b/app/controllers/comment_read_pointers_controller.rb
@@ -1,7 +1,7 @@
 class CommentReadPointersController < ApplicationController
   def update
     creative = Creative.find(params[:creative_id]).effective_origin
-    last_id = creative.comments.where("comments.private = ? OR comments.user_id = ?", false, Current.user.id).maximum(:id)
+    last_id = creative.comments.where("comments.private = ? OR comments.user_id = ? OR comments.approver_id = ?", false, Current.user.id, Current.user.id).maximum(:id)
     pointer = CommentReadPointer.find_or_initialize_by(user: Current.user, creative: creative)
 
     previous_last_read_id = pointer.last_read_comment_id

--- a/app/controllers/comment_read_pointers_controller.rb
+++ b/app/controllers/comment_read_pointers_controller.rb
@@ -3,14 +3,39 @@ class CommentReadPointersController < ApplicationController
     creative = Creative.find(params[:creative_id]).effective_origin
     last_id = creative.comments.maximum(:id)
     pointer = CommentReadPointer.find_or_initialize_by(user: Current.user, creative: creative)
+
+    previous_last_read_id = pointer.last_read_comment_id
     pointer.last_read_comment_id = last_id
     pointer.save!
+
     mark_inbox_items_read(creative, last_id)
     Comment.broadcast_badge(creative, Current.user)
+
+    if previous_last_read_id && previous_last_read_id != last_id
+      broadcast_read_receipts(creative, previous_last_read_id)
+    end
+    broadcast_read_receipts(creative, last_id)
+
     render json: { success: true }
   end
 
   private
+
+  def broadcast_read_receipts(creative, comment_id)
+    return unless comment_id
+
+    # Fetch all users who have this comment as their last read comment
+    users = CommentReadPointer.where(creative: creative, last_read_comment_id: comment_id)
+                              .includes(user: { avatar_attachment: :blob })
+                              .map(&:user)
+
+    Turbo::StreamsChannel.broadcast_update_to(
+      [ creative, :comments ],
+      target: "read_receipts_comment_#{comment_id}",
+      partial: "comments/read_receipts",
+      locals: { read_by_users: users }
+    )
+  end
 
   def mark_inbox_items_read(creative, last_comment_id)
     return unless last_comment_id

--- a/app/controllers/comment_read_pointers_controller.rb
+++ b/app/controllers/comment_read_pointers_controller.rb
@@ -23,6 +23,8 @@ class CommentReadPointersController < ApplicationController
 
   def broadcast_read_receipts(creative, comment_id)
     return unless comment_id
+    comment = creative.comments.find_by(id: comment_id)
+    return if comment.nil? || comment.private?
 
     # Fetch all users who have this comment as their last read comment
     users = CommentReadPointer.where(creative: creative, last_read_comment_id: comment_id)

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -100,19 +100,7 @@ class CommentsController < ApplicationController
       all_visible_ids = visible_scope.order(id: :asc).pluck(:id)
 
       pointers.each do |pointer|
-        target_id = pointer.last_read_comment_id
-        next unless target_id
-
-        # Find the nearest visible comment ID <= target_id
-        idx = all_visible_ids.bsearch_index { |x| x > target_id }
-        effective_id = if idx
-          # If idx is 0, target_id is smaller than ALL visible IDs (unlikely unless deleted/invisible start)
-          idx > 0 ? all_visible_ids[idx - 1] : nil
-        else
-          # target_id is >= all visible IDs
-          all_visible_ids.last
-        end
-
+        effective_id = pointer.effective_comment_id(all_visible_ids)
         if effective_id
           read_receipts[effective_id] ||= []
           read_receipts[effective_id] << pointer.user

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -97,10 +97,12 @@ class CommentsController < ApplicationController
                                    .includes(user: { avatar_attachment: :blob })
 
       # Fetch all visible IDs for correct read-receipt placement transparency
-      all_visible_ids = visible_scope.order(id: :asc).pluck(:id)
+      # Only map read receipts to PUBLIC comments.
+      # Users who read private comments will appear on the nearest preceding public comment.
+      public_ids = @creative.comments.where(private: false).order(id: :asc).pluck(:id)
 
       pointers.each do |pointer|
-        effective_id = pointer.effective_comment_id(all_visible_ids)
+        effective_id = pointer.effective_comment_id(public_ids)
         if effective_id
           read_receipts[effective_id] ||= []
           read_receipts[effective_id] << pointer.user

--- a/app/models/comment_read_pointer.rb
+++ b/app/models/comment_read_pointer.rb
@@ -4,4 +4,19 @@ class CommentReadPointer < ApplicationRecord
   belongs_to :last_read_comment, class_name: "Comment", optional: true
 
   validates :user_id, uniqueness: { scope: :creative_id }
+
+  def effective_comment_id(sorted_visible_ids)
+    return nil unless last_read_comment_id
+
+    # Find the nearest visible comment ID <= last_read_comment_id
+    idx = sorted_visible_ids.bsearch_index { |x| x > last_read_comment_id }
+
+    if idx
+      # If idx is 0, target is smaller than all visible IDs
+      idx > 0 ? sorted_visible_ids[idx - 1] : nil
+    else
+      # target is >= all visible IDs
+      sorted_visible_ids.last
+    end
+  end
 end

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,4 +1,4 @@
-<div class="comment-item <%= 'last-read' if defined?(last_read_comment_id) && last_read_comment_id && comment.id == last_read_comment_id %>" id="<%= dom_id(comment) %>" data-controller="comment" data-user-id="<%= comment.user&.id %>" data-comment-id="<%= comment.id %>">
+<div class="comment-item" id="<%= dom_id(comment) %>" data-controller="comment" data-user-id="<%= comment.user&.id %>" data-comment-id="<%= comment.id %>">
   <div class="comment-select">
     <input type="checkbox"
            class="comment-select-checkbox"
@@ -26,6 +26,9 @@
         datetime: timestamp.iso8601
       ) %>
     </span>
+    <span id="read_receipts_comment_<%= comment.id %>" class="read-receipt-wrapper">
+      <%= render "comments/read_receipts", read_by_users: (defined?(read_by_users) ? read_by_users : nil) %>
+    </span>
     <% if comment.private? %>
       <span class="private-label">[<%= t('comments.private') %>]</span>
     <% end %>
@@ -34,6 +37,7 @@
     <% end %>
     <% can_convert_comment = comment.user == Current.user || comment.creative.has_permission?(Current.user, :admin) %>
     <div class="comment-action-container">
+
       <button class="<%= ['convert-comment-btn', ('comment-owner-only' unless can_convert_comment)].compact.join(' ') %>" data-comment-target="ownerButton" data-comment-id="<%= comment.id %>" title="<%= t('comments.convert_to_creative') %>">
         <%= t('comments.convert_button') %>
       </button>
@@ -103,4 +107,6 @@
       </details>
     </div>
   <% end %>
+
+
 </div>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -27,7 +27,8 @@
       ) %>
     </span>
     <span id="read_receipts_comment_<%= comment.id %>" class="read-receipt-wrapper">
-      <%= render "comments/read_receipts", read_by_users: (defined?(read_by_users) ? read_by_users : nil) %>
+      <% users_read = defined?(read_by_users) ? read_by_users : (defined?(read_receipts) ? read_receipts[comment.id] : nil) %>
+      <%= render "comments/read_receipts", read_by_users: users_read %>
     </span>
     <% if comment.private? %>
       <span class="private-label">[<%= t('comments.private') %>]</span>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -28,7 +28,7 @@
     </span>
     <span id="read_receipts_comment_<%= comment.id %>" class="read-receipt-wrapper">
       <% users_read = defined?(read_by_users) ? read_by_users : (defined?(read_receipts) ? read_receipts[comment.id] : nil) %>
-      <%= render "comments/read_receipts", read_by_users: users_read %>
+      <%= render "comments/read_receipts", read_by_users: users_read unless comment.private? %>
     </span>
     <% if comment.private? %>
       <span class="private-label">[<%= t('comments.private') %>]</span>

--- a/app/views/comments/_list.html.erb
+++ b/app/views/comments/_list.html.erb
@@ -1,7 +1,7 @@
 <%= turbo_stream_from [creative, :comments] %>
 <% if comments.any? %>
   <% comments.each do |comment| %>
-    <%= render partial: 'comments/comment', locals: { comment: comment, last_read_comment_id: last_read_comment_id } %>
+    <%= render partial: 'comments/comment', locals: { comment: comment, read_by_users: read_receipts&.[](comment.id) } %>
   <% end %>
 <% else %>
   <div id="no-comments"><%= t('comments.no_comments') %></div>

--- a/app/views/comments/_read_receipts.html.erb
+++ b/app/views/comments/_read_receipts.html.erb
@@ -1,0 +1,11 @@
+<% if defined?(read_by_users) && read_by_users.present? %>
+  <div class="read-receipt-container">
+    <div class="read-receipt-avatars">
+      <% read_by_users.each do |user| %>
+        <div class="read-receipt-avatar" title="<%= t('comments.read_by', name: user.display_name) %>">
+          <%= render AvatarComponent.new(user: user, size: 16, classes: 'avatar') %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/config/locales/comments.en.yml
+++ b/config/locales/comments.en.yml
@@ -57,3 +57,4 @@ en:
     select_label: "Select message"
     calendar_command:
       event_created: "event created: [Google Calendar event](%{url})"
+    read_by: "Read by %{name}"

--- a/config/locales/comments.ko.yml
+++ b/config/locales/comments.ko.yml
@@ -57,3 +57,4 @@ ko:
     select_label: "메시지 선택"
     calendar_command:
       event_created: "이벤트가 생성되었습니다: [구글 캘린더 이벤트](%{url})"
+    read_by: "%{name} 님이 읽음"

--- a/package-lock.json
+++ b/package-lock.json
@@ -127,6 +127,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -689,6 +690,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -732,6 +734,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1275,6 +1278,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.2.tgz",
       "integrity": "sha512-Ecx2ig/JLC9ayIQwZHqm41Tzlf4c1WUuFhFUZB1y+JIJqDRE579x7Uil7tKT8MwDpOPwrK5ZtpxdSsrfy/LF8Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/component": "0.7.0",
         "@firebase/logger": "0.5.0",
@@ -1341,6 +1345,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.2.tgz",
       "integrity": "sha512-cn+U27GDaBS/irsbvrfnPZdcCzeZPRGKieSlyb7vV6LSOL6mdECnB86PgYjYGxSNg8+U48L/NeevTV1odU+mOQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/app": "0.14.2",
         "@firebase/component": "0.7.0",
@@ -1356,7 +1361,8 @@
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
       "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@firebase/auth": {
       "version": "1.11.0",
@@ -1807,6 +1813,7 @@
       "integrity": "sha512-0AZUyYUfpMNcztR5l09izHwXkZpghLgCUaAGjtMwXnCg3bj4ml5VgiwqOMOxJ+Nw4qN/zJAaOQBcJ7KGkWStqQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -3679,6 +3686,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -4610,7 +4618,6 @@
       "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
       "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
@@ -5861,6 +5868,7 @@
       "integrity": "sha512-Pcfm3eZ+eO4JdZCXthW9tCDT3nF4K+9dmeZ+5X39n+Kqz0DDIABRP5CAEOHRFZk8RGuC2efksTJxrjp8EXCunQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.19",
         "@asamuzakjp/dom-selector": "^6.7.3",
@@ -5949,7 +5957,6 @@
       "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.114.tgz",
       "integrity": "sha512-gcxmNFzA4hv8UYi8j43uPlQ7CGcyMJ2KQb5kZASw6SnAKAf10hK12i2fjrS3Cl/ugZa5Ui6WwIu1/6MIXiHttQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "isomorphic.js": "^0.2.4"
       },
@@ -6548,6 +6555,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6557,6 +6565,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },


### PR DESCRIPTION
- **Backend**:
  - Updated  to fetch read pointers for all participants.
  - Updated  to broadcast Turbo Stream updates on read status change.
- **Frontend**:
  - Created  partial for rendering read avatars.
  - Updated  to render read receipts inline in the message header (after timestamp).
  - Refactored  to support inline read receipt visualization without layout shifts.
- **Locales**:
  - Added  translations for English and Korean.