### PR TITLE
Include deleted comment content in inbox notification

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -179,7 +179,8 @@ class CommentsController < ApplicationController
             message_key: "inbox.comment_deleted_by_admin",
             message_params: {
               admin_name: Current.user.name,
-              creative_snippet: @creative.creative_snippet
+              creative_snippet: @creative.creative_snippet,
+              comment_content: @comment.content
             },
             link: creative_path(@creative)
           )

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -74,7 +74,7 @@ en:
     creative_shared: "%{user} shared \"%{short_title}\"."
     user_mentioned: "%{user} mentioned you in \"%{creative}\": \"%{comment}\""
     permission_requested: "%{user} requested access to \"%{short_title}\"."
-    comment_deleted_by_admin: "%{admin_name} deleted your comment in \"%{creative_snippet}\"."
+    comment_deleted_by_admin: "%{admin_name} deleted your comment in \"%{creative_snippet}\": %{comment_content}"
     tool_approval_needed: "Tool '%{tool_name}' has been detected/updated. Please approve it to activate."
 
   inbox_mailer:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -75,6 +75,7 @@ en:
     user_mentioned: "%{user} mentioned you in \"%{creative}\": \"%{comment}\""
     permission_requested: "%{user} requested access to \"%{short_title}\"."
     comment_deleted_by_admin: "%{admin_name} deleted your comment in \"%{creative_snippet}\": %{comment_content}"
+    comment_content_unavailable: "(comment unavailable)"
     tool_approval_needed: "Tool '%{tool_name}' has been detected/updated. Please approve it to activate."
 
   inbox_mailer:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -45,7 +45,7 @@ ko:
     creative_shared: "%{user} 가 \"%{short_title}\" 을 공유했습니다."
     user_mentioned: "%{user} 님이 \"%{creative}\" 에서 당신을 언급했습니다: \"%{comment}\""
     permission_requested: "%{user} 이 크리에이티브 \"%{short_title}\" 에 대한 권한 요청을 했습니다."
-    comment_deleted_by_admin: "%{admin_name} 님이 \"%{creative_snippet}\" 에서 당신의 댓글을 삭제했습니다."
+    comment_deleted_by_admin: "%{admin_name} 님이 \"%{creative_snippet}\" 에서 당신의 댓글을 삭제했습니다: %{comment_content}"
     tool_approval_needed: "도구 '%{tool_name}'가 감지/업데이트되었습니다. 활성화하려면 승인해주세요."
 
   inbox_mailer:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -46,6 +46,7 @@ ko:
     user_mentioned: "%{user} 님이 \"%{creative}\" 에서 당신을 언급했습니다: \"%{comment}\""
     permission_requested: "%{user} 이 크리에이티브 \"%{short_title}\" 에 대한 권한 요청을 했습니다."
     comment_deleted_by_admin: "%{admin_name} 님이 \"%{creative_snippet}\" 에서 당신의 댓글을 삭제했습니다: %{comment_content}"
+    comment_content_unavailable: "(삭제된 댓글 내용을 표시할 수 없습니다)"
     tool_approval_needed: "도구 '%{tool_name}'가 감지/업데이트되었습니다. 활성화하려면 승인해주세요."
 
   inbox_mailer:

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -408,6 +408,7 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
     assert_equal other_user, inbox_item.owner
     assert_equal "inbox.comment_deleted_by_admin", inbox_item.message_key
     assert_equal @user.name, inbox_item.message_params["admin_name"]
+    assert_equal "Other user comment", inbox_item.message_params["comment_content"]
   end
 
   test "admin user can delete any comment" do

--- a/test/models/inbox_item_test.rb
+++ b/test/models/inbox_item_test.rb
@@ -18,4 +18,17 @@ class InboxItemTest < ActiveSupport::TestCase
     item = InboxItem.new(message_key: "inbox.nbsp_test", owner: users(:one), message_params: {})
     assert_equal "hello world !", item.localized_message(locale: :en)
   end
+
+  test "localized message provides fallback for missing interpolation" do
+    item = InboxItem.new(
+      message_key: "inbox.comment_deleted_by_admin",
+      owner: users(:one),
+      message_params: { admin_name: "Admin User", creative_snippet: "Sample creative" }
+    )
+
+    assert_equal(
+      "Admin User deleted your comment in \"Sample creative\": (comment unavailable)",
+      item.localized_message(locale: :en)
+    )
+  end
 end


### PR DESCRIPTION
## Summary
- include the deleted comment content when an admin or creative owner removes someone else’s comment so the inbox notification shows what was removed
- update the English and Korean translations to surface the deleted message text in the inbox alert
- extend the deletion notification test coverage to assert the deleted comment content is captured

## Testing
- ./bin/rubocop -a
- bundle exec rails test
- bundle exec rails test:system *(fails: Selenium could not download Chrome/chromedriver because the Selenium Manager request to googlechromelabs.github.io was blocked, so system tests cannot run in this environment)*

## Original User's Requirements
- "댓글 (채팅) 메세지가 다른 사람에 의해 삭제되었을때 inbox 알람 메세지에 삭제된 메세지 내용도 같이 표시해서 어떤 메세지가 삭제되었는지 알려줘야 해."

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943a7eefc6c8326a414185a189b110e)