### PR TITLE
Stabilize comment markdown rendering between live updates and reloads

### DIFF
--- a/app/javascript/controllers/comment_controller.js
+++ b/app/javascript/controllers/comment_controller.js
@@ -1,5 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
-import { renderMarkdown, renderMarkdownInline } from '../lib/utils/markdown'
+import { renderCommentMarkdown } from '../lib/utils/markdown'
 
 // Connects to data-controller="comment"
 export default class extends Controller {
@@ -9,8 +9,7 @@ export default class extends Controller {
     const contentElement = this.element.querySelector('.comment-content')
     if (contentElement && contentElement.dataset.rendered !== 'true') {
       const text = contentElement.textContent || ''
-      const html = text.includes('\n') ? renderMarkdown(text).trim() : renderMarkdownInline(text).trim()
-      contentElement.innerHTML = html
+      contentElement.innerHTML = renderCommentMarkdown(text)
       contentElement.dataset.rendered = 'true'
     }
 

--- a/app/javascript/lib/utils/markdown.js
+++ b/app/javascript/lib/utils/markdown.js
@@ -8,10 +8,16 @@ export function renderMarkdownInline(html) {
   return marked.parseInline(html)
 }
 
+export function renderCommentMarkdown(text) {
+  const content = text || ''
+  const html = content.includes('\n') ? marked.parse(content) : marked.parseInline(content)
+  return html.trim()
+}
+
 export function renderMarkdownInContainer(container) {
   container.querySelectorAll('.comment-content').forEach((element) => {
     if (element.dataset.rendered === 'true') return
-    element.innerHTML = marked.parse(element.textContent)
+    element.innerHTML = renderCommentMarkdown(element.textContent)
     element.dataset.rendered = 'true'
   })
 }


### PR DESCRIPTION
## Summary
- add a shared `renderCommentMarkdown` helper so single-line and multi-line comment markdown renderings stay consistent
- use the shared helper in both the comment controller and list rendering to keep comment heights stable between live updates and reloads

## Testing
- ./bin/rubocop -a
- bundle exec rails test
- bundle exec rails test:system *(fails: Unable to obtain chromedriver in this environment)*

## Original User's Requirements
- 채팅 메세지 리스트에서 새로운 메세지가 실시간으로 들어와서 추가될때, 추가된 메세지와 다시 재로딩해서 보여지는 메세지에서 높이가 더 늘어나서 사용자가 보기에 안좋아, 재로딩되더라도 일부 버튼 "전환", "수정" 등은 다시 표시되더라도 높이가 변경되지 않도록 수정해줘. (메세지가 동일하기 때문에 높이가 재조정될 이유가 없어)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943a7a7f7788326950e77af7593605f)