### PR TITLE
Allow removing comment attachments during edit

### DIFF
--- a/app/javascript/controllers/comments/list_controller.js
+++ b/app/javascript/controllers/comments/list_controller.js
@@ -534,7 +534,17 @@ export default class extends Controller {
     const commentId = button.getAttribute('data-comment-id')
     const content = button.getAttribute('data-comment-content')
     const isPrivate = button.getAttribute('data-comment-private') === 'true'
-    this.formController?.startEditing({ id: commentId, content, private: isPrivate })
+    let attachments = []
+    const attachmentsJson = button.getAttribute('data-comment-attachments')
+    if (attachmentsJson) {
+      try {
+        attachments = JSON.parse(attachmentsJson)
+      } catch (error) {
+        console.error('Failed to parse comment attachments', error)
+      }
+    }
+
+    this.formController?.startEditing({ id: commentId, content, private: isPrivate, attachments })
   }
 
   updateCommentAction(form) {

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -5,6 +5,7 @@
            value="<%= comment.id %>"
            aria-label="<%= t('comments.select_label') %>" />
   </div>
+  <% attachments_data = comment.images.map { |image| { signed_id: image.blob.signed_id, filename: image.filename.to_s } } %>
   <div>
     <%= render AvatarComponent.new(user: comment.user, size: 20, classes: 'avatar comment-avatar') %>
     <% system_prefix = "#{t('comments.system_user')}:" %>
@@ -47,7 +48,13 @@
           <%= t('comments.approve_button') %>
         </button>
       <% end %>
-      <button class="edit-comment-btn comment-owner-only" data-comment-target="ownerButton" data-comment-id="<%= comment.id %>" data-comment-content="<%= comment.content %>" data-comment-private="<%= comment.private? %>" title="<%= t('comments.update_comment') %>">
+      <button class="edit-comment-btn comment-owner-only"
+              data-comment-target="ownerButton"
+              data-comment-id="<%= comment.id %>"
+              data-comment-content="<%= comment.content %>"
+              data-comment-private="<%= comment.private? %>"
+              data-comment-attachments="<%= attachments_data.to_json %>"
+              title="<%= t('comments.update_comment') %>">
         <%= t('comments.edit_button') %>
       </button>
       <button class="copy-comment-link-btn" data-comment-id="<%= comment.id %>" data-comment-url="<%= creative_comment_url(comment.creative, comment) %>" title="<%= t('comments.copy_link_button') %>">
@@ -72,7 +79,7 @@
              else
                rails_blob_path(preview_image, only_path: true)
              end %>
-        <%= link_to rails_blob_path(image, only_path: true), target: '_blank', rel: 'noopener', class: 'comment-attachment-link' do %>
+        <%= link_to rails_blob_path(image, only_path: true), target: '_blank', rel: 'noopener', class: 'comment-attachment-link', data: { attachment_signed_id: image.blob.signed_id, attachment_filename: image.filename.to_s } do %>
           <%= image_tag preview_image_path, class: 'comment-attachment-image', alt: '', loading: 'lazy' %>
         <% end %>
       <% end %>

--- a/app/views/comments/_comments_popup.html.erb
+++ b/app/views/comments/_comments_popup.html.erb
@@ -10,6 +10,7 @@
      data-approve-error-text="<%= t('comments.approve_error') %>"
      data-action-update-success-text="<%= t('comments.action_update_success') %>"
      data-action-update-error-text="<%= t('comments.action_update_error') %>"
+     data-attachment-delete-error-text="<%= t('comments.attachment_delete_error') %>"
      data-search-empty-text="<%= t('comments.search_empty_prompt') %>"
      data-speech-unavailable-text="<%= t('comments.speech_unavailable') %>"
      data-voice-start-text="<%= t('comments.voice_button') %>"

--- a/config/locales/comments.en.yml
+++ b/config/locales/comments.en.yml
@@ -55,6 +55,7 @@ en:
     move_invalid_target: "Select a valid creative to move messages to."
     move_not_allowed: "You do not have permission to move these messages."
     select_label: "Select message"
+    attachment_delete_error: "Unable to delete attachment."
     calendar_command:
       event_created: "event created: [Google Calendar event](%{url})"
     read_by: "Read by %{name}"

--- a/config/locales/comments.ko.yml
+++ b/config/locales/comments.ko.yml
@@ -55,6 +55,7 @@ ko:
     move_invalid_target: "이동할 크리에이티브를 선택해주세요."
     move_not_allowed: "이 메시지를 이동할 권한이 없습니다."
     select_label: "메시지 선택"
+    attachment_delete_error: "첨부파일을 삭제할 수 없습니다."
     calendar_command:
       event_created: "이벤트가 생성되었습니다: [구글 캘린더 이벤트](%{url})"
     read_by: "%{name} 님이 읽음"


### PR DESCRIPTION
## Summary
- show existing image attachments when editing a comment and keep them in the attachment list
- allow deleting existing comment image attachments directly from the edit form and sync the comment preview
- add translated attachment deletion error messaging for the comments popup

## Testing
- ⚠️ `./bin/rubocop -a` *(fails: ruby executable not available in environment)*
- ⚠️ `rails test` *(fails: rails command unavailable in environment)*
- ⚠️ `rails test:system` *(fails: rails command unavailable in environment)*

## Original User's Requirements
- 채팅메세지에 이미지 보냈을경우 수정시 삭제할수 있게 보낼때 처럼 동일하게 파일명으로 하단에 표시

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943d2ddb23c8326a69410be0637259f)