### PR TITLE
Add presence state to read receipt avatars

### DIFF
--- a/app/controllers/comment_read_pointers_controller.rb
+++ b/app/controllers/comment_read_pointers_controller.rb
@@ -32,11 +32,13 @@ class CommentReadPointersController < ApplicationController
 
     users = fetch_users_on_effective_id(creative, effective_id)
 
+    present_user_ids = CommentPresenceStore.list(creative.id)
+
     Turbo::StreamsChannel.broadcast_update_to(
       [ creative, :comments ],
       target: "read_receipts_comment_#{effective_id}",
       partial: "comments/read_receipts",
-      locals: { read_by_users: users }
+      locals: { read_by_users: users, present_user_ids: present_user_ids }
     )
   end
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -84,6 +84,8 @@ class CommentsController < ApplicationController
       scope.limit(limit).to_a.reverse
     end
 
+    present_user_ids = CommentPresenceStore.list(@creative.id)
+
     read_receipts = {}
     if @comments.any?
       # Fetch all read pointers for this creative that point to comments in the current list
@@ -111,12 +113,16 @@ class CommentsController < ApplicationController
     end
 
     if params[:after_id].present? || params[:before_id].present?
-      render partial: "comments/comment", collection: @comments, as: :comment, locals: { read_receipts: read_receipts }
+      render partial: "comments/comment",
+             collection: @comments,
+             as: :comment,
+             locals: { read_receipts: read_receipts, present_user_ids: present_user_ids }
     else
       render partial: "comments/list", locals: {
         comments: @comments,
         creative: @creative,
-        read_receipts: read_receipts
+        read_receipts: read_receipts,
+        present_user_ids: present_user_ids
       }
     end
   end

--- a/app/javascript/controllers/comments/presence_controller.js
+++ b/app/javascript/controllers/comments/presence_controller.js
@@ -127,6 +127,7 @@ export default class extends Controller {
     if (data.ids) {
       this.currentPresentIds = data.ids.map((id) => parseInt(id, 10))
       this.renderParticipants(this.currentPresentIds)
+      this.updateReadReceiptPresence(this.currentPresentIds)
     }
     if (data.typing) {
       const { id, name } = data.typing
@@ -188,6 +189,8 @@ export default class extends Controller {
 
       this.participantsTarget.appendChild(wrapper)
     })
+
+    this.updateReadReceiptPresence(presentIds)
   }
 
   renderTypingIndicator() {
@@ -289,5 +292,20 @@ export default class extends Controller {
 
   isMobile() {
     return window.innerWidth <= 600
+  }
+
+  updateReadReceiptPresence(presentIds = []) {
+    const avatars = this.element.querySelectorAll('.read-receipt-avatars .comment-presence-avatar')
+    const presentLookup = new Set(presentIds)
+
+    avatars.forEach((avatar) => {
+      const userId = parseInt(avatar.dataset.userId, 10)
+      if (Number.isNaN(userId)) return
+      if (presentLookup.has(userId)) {
+        avatar.classList.remove('inactive')
+      } else {
+        avatar.classList.add('inactive')
+      }
+    })
   }
 }

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -28,7 +28,8 @@
     </span>
     <span id="read_receipts_comment_<%= comment.id %>" class="read-receipt-wrapper">
       <% users_read = defined?(read_by_users) ? read_by_users : (defined?(read_receipts) ? read_receipts[comment.id] : nil) %>
-      <%= render "comments/read_receipts", read_by_users: users_read unless comment.private? %>
+      <% present_user_ids = defined?(present_user_ids) ? present_user_ids : nil %>
+      <%= render "comments/read_receipts", read_by_users: users_read, present_user_ids: present_user_ids unless comment.private? %>
     </span>
     <% if comment.private? %>
       <span class="private-label">[<%= t('comments.private') %>]</span>

--- a/app/views/comments/_list.html.erb
+++ b/app/views/comments/_list.html.erb
@@ -1,7 +1,7 @@
 <%= turbo_stream_from [creative, :comments] %>
 <% if comments.any? %>
   <% comments.each do |comment| %>
-    <%= render partial: 'comments/comment', locals: { comment: comment, read_by_users: read_receipts&.[](comment.id) } %>
+    <%= render partial: 'comments/comment', locals: { comment: comment, read_by_users: read_receipts&.[](comment.id), present_user_ids: present_user_ids } %>
   <% end %>
 <% else %>
   <div id="no-comments"><%= t('comments.no_comments') %></div>

--- a/app/views/comments/_read_receipts.html.erb
+++ b/app/views/comments/_read_receipts.html.erb
@@ -2,8 +2,16 @@
   <div class="read-receipt-container">
     <div class="read-receipt-avatars">
       <% read_by_users.each do |user| %>
+        <% present_ids = defined?(present_user_ids) ? present_user_ids : nil %>
+        <% classes = ['avatar', 'comment-presence-avatar'] %>
+        <% classes << 'inactive' if present_ids && !present_ids.include?(user.id) %>
         <div class="read-receipt-avatar" title="<%= t('comments.read_by', name: user.display_name) %>">
-          <%= render AvatarComponent.new(user: user, size: 16, classes: 'avatar') %>
+          <%= render AvatarComponent.new(
+                user: user,
+                size: 16,
+                classes: classes.join(' '),
+                data: { user_id: user.id }
+              ) %>
         </div>
       <% end %>
     </div>


### PR DESCRIPTION
## Summary
- pass active presence data to comment read receipt avatars so their appearance matches participant presence
- broadcast read receipt updates with presence context and keep read receipts in sync with live presence updates on the client

## Testing
- ./bin/rubocop -a
- bundle exec rails test
- bundle exec rails test:system *(fails: selenium could not download chromedriver because the remote host was unreachable in this environment)*

## Original User's Requirements
- 사용자 채팅 메세지 읽음 표시 아바타도 현재 접속여부에 따른 활성 표시를 채팅 참여자처럼 동일하게 표시해줘

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943ce4dd4b48326bdf08079a82dfb75)