### PR TITLE
Show topic tags across main comment view

### DIFF
--- a/app/assets/stylesheets/comments_popup.css
+++ b/app/assets/stylesheets/comments_popup.css
@@ -113,6 +113,24 @@
     margin-top: 0.2em;
 }
 
+.comment-topic-link-row {
+    margin-top: 0.35em;
+}
+
+.comment-topic-link {
+    background: transparent;
+    border: none;
+    color: var(--color-primary);
+    cursor: pointer;
+    font-weight: 600;
+    padding: 0;
+}
+
+.comment-topic-link:hover,
+.comment-topic-link:focus {
+    text-decoration: underline;
+}
+
 .comment-action-block {
     margin-top: 0.6em;
 }

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -11,7 +11,7 @@ class CommentsController < ApplicationController
       Current.user.id,
       Current.user.id
     )
-    scope = visible_scope.with_attached_images
+    scope = visible_scope.with_attached_images.includes(:topic)
 
     if params[:search].present?
       search_term = ActiveRecord::Base.sanitize_sql_like(params[:search].to_s.strip.downcase)
@@ -39,7 +39,7 @@ class CommentsController < ApplicationController
     end
 
     # Apply the Topic Filter
-    scope = scope.where(topic_id: effective_topic_id)
+    scope = scope.where(topic_id: effective_topic_id) if effective_topic_id.present?
 
     # Default order: Newest first (created_at DESC)
     # This matches the column-reverse layout where the first item in the list is the visual bottom (Newest).
@@ -162,7 +162,7 @@ class CommentsController < ApplicationController
           content: @comment.content
         }
       }) unless @comment.private?
-      @comment = Comment.with_attached_images.find(@comment.id)
+      @comment = Comment.with_attached_images.includes(:topic).find(@comment.id)
       render partial: "comments/comment", locals: { comment: @comment }, status: :created
     else
       render json: { errors: @comment.errors.full_messages }, status: :unprocessable_entity
@@ -177,7 +177,7 @@ class CommentsController < ApplicationController
       end
 
       if @comment.update(safe_params)
-        @comment = Comment.with_attached_images.find(@comment.id)
+        @comment = Comment.with_attached_images.includes(:topic).find(@comment.id)
         render partial: "comments/comment", locals: { comment: @comment }
       else
         render json: { errors: @comment.errors.full_messages }, status: :unprocessable_entity

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -116,13 +116,18 @@ class CommentsController < ApplicationController
       render partial: "comments/comment",
              collection: @comments,
              as: :comment,
-             locals: { read_receipts: read_receipts, present_user_ids: present_user_ids }
+             locals: {
+               read_receipts: read_receipts,
+               present_user_ids: present_user_ids,
+               current_topic_id: effective_topic_id
+             }
     else
       render partial: "comments/list", locals: {
         comments: @comments,
         creative: @creative,
         read_receipts: read_receipts,
-        present_user_ids: present_user_ids
+        present_user_ids: present_user_ids,
+        current_topic_id: effective_topic_id
       }
     end
   end
@@ -163,7 +168,9 @@ class CommentsController < ApplicationController
         }
       }) unless @comment.private?
       @comment = Comment.with_attached_images.includes(:topic).find(@comment.id)
-      render partial: "comments/comment", locals: { comment: @comment }, status: :created
+      render partial: "comments/comment",
+             locals: { comment: @comment, current_topic_id: @comment.topic_id },
+             status: :created
     else
       render json: { errors: @comment.errors.full_messages }, status: :unprocessable_entity
     end
@@ -178,7 +185,8 @@ class CommentsController < ApplicationController
 
       if @comment.update(safe_params)
         @comment = Comment.with_attached_images.includes(:topic).find(@comment.id)
-        render partial: "comments/comment", locals: { comment: @comment }
+        render partial: "comments/comment",
+               locals: { comment: @comment, current_topic_id: @comment.topic_id }
       else
         render json: { errors: @comment.errors.full_messages }, status: :unprocessable_entity
       end

--- a/app/javascript/controllers/comments/list_controller.js
+++ b/app/javascript/controllers/comments/list_controller.js
@@ -331,6 +331,16 @@ export default class extends Controller {
 
     if (target.closest('.comment-select-checkbox')) return
 
+    const topicLink = target.closest('.comment-topic-link')
+    if (topicLink) {
+      event.preventDefault()
+      const topicId = topicLink.dataset.topicId
+      if (topicId && this.popupController?.topicsController) {
+        this.popupController.topicsController.selectTopic(topicId)
+      }
+      return
+    }
+
     const copyBtn = target.closest('.copy-comment-link-btn')
     if (copyBtn) {
       event.preventDefault()

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -79,6 +79,13 @@
       <% end %>
     </div>
   <% end %>
+  <% if comment.topic.present? %>
+    <div class="comment-topic-link-row">
+      <button class="comment-topic-link" type="button" data-topic-id="<%= comment.topic_id %>" data-topic-name="<%= comment.topic.name %>">
+        #<%= comment.topic.name %>
+      </button>
+    </div>
+  <% end %>
   <% if comment.action.present? %>
     <div class="comment-action-block" data-comment-id="<%= comment.id %>">
       <details class="comment-action-details">

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -79,7 +79,7 @@
       <% end %>
     </div>
   <% end %>
-  <% if comment.topic.present? %>
+  <% if comment.topic.present? && local_assigns[:current_topic_id].blank? %>
     <div class="comment-topic-link-row">
       <button class="comment-topic-link" type="button" data-topic-id="<%= comment.topic_id %>" data-topic-name="<%= comment.topic.name %>">
         #<%= comment.topic.name %>

--- a/package-lock.json
+++ b/package-lock.json
@@ -127,7 +127,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -690,7 +689,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -734,7 +732,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1278,7 +1275,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.2.tgz",
       "integrity": "sha512-Ecx2ig/JLC9ayIQwZHqm41Tzlf4c1WUuFhFUZB1y+JIJqDRE579x7Uil7tKT8MwDpOPwrK5ZtpxdSsrfy/LF8Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/component": "0.7.0",
         "@firebase/logger": "0.5.0",
@@ -1345,7 +1341,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.2.tgz",
       "integrity": "sha512-cn+U27GDaBS/irsbvrfnPZdcCzeZPRGKieSlyb7vV6LSOL6mdECnB86PgYjYGxSNg8+U48L/NeevTV1odU+mOQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/app": "0.14.2",
         "@firebase/component": "0.7.0",
@@ -1361,8 +1356,7 @@
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
       "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@firebase/auth": {
       "version": "1.11.0",
@@ -1813,7 +1807,6 @@
       "integrity": "sha512-0AZUyYUfpMNcztR5l09izHwXkZpghLgCUaAGjtMwXnCg3bj4ml5VgiwqOMOxJ+Nw4qN/zJAaOQBcJ7KGkWStqQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -3686,7 +3679,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -4618,6 +4610,7 @@
       "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
       "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
@@ -5868,7 +5861,6 @@
       "integrity": "sha512-Pcfm3eZ+eO4JdZCXthW9tCDT3nF4K+9dmeZ+5X39n+Kqz0DDIABRP5CAEOHRFZk8RGuC2efksTJxrjp8EXCunQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.19",
         "@asamuzakjp/dom-selector": "^6.7.3",
@@ -5957,6 +5949,7 @@
       "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.114.tgz",
       "integrity": "sha512-gcxmNFzA4hv8UYi8j43uPlQ7CGcyMJ2KQb5kZASw6SnAKAf10hK12i2fjrS3Cl/ugZa5Ui6WwIu1/6MIXiHttQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "isomorphic.js": "^0.2.4"
       },
@@ -6555,7 +6548,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6565,7 +6557,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },


### PR DESCRIPTION
## Summary
- allow the #Main view to show all comments regardless of topic while keeping topic-specific filtering when a topic is selected
- add per-comment topic links that activate the associated topic when clicked from the aggregated view
- style the topic tag row so linked topics are clearly visible beneath each message

## Testing
- ./bin/rubocop -a
- bundle exec rails test
- bundle exec rails test:system *(fails: Selenium could not download/locate ChromeDriver in this environment)*

## Original User's Requirements
- 채팅 메세지에서 #main 토픽 (즉, 토픽이 없는 메세지를 표시하는 토픽)에서 모든 채팅 메세지 (모든 토픽의 메세지)를 표시하도록 변경한다.
- 대신 토픽이 있는 메세지는 메세지 마지막 줄에 "#토픽" 을 표시하고 링크를 누르면 해당 토픽의 창이 활성화 되도록 한다.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943fce8cc7c8326ab7d0a88ba9d547b)