### PR TITLE
Dispatch event when GitHub webhook is received

### DIFF
--- a/app/controllers/github/webhooks_controller.rb
+++ b/app/controllers/github/webhooks_controller.rb
@@ -11,6 +11,13 @@ module Github
       return head :unauthorized unless valid_signature?(raw_body, payload)
       payload = payload.presence || {}
 
+      SystemEvents::Dispatcher.dispatch("github_webhook", {
+        event: event,
+        action: payload["action"],
+        repository: payload.dig("repository", "full_name"),
+        payload: payload
+      })
+
       case event
       when "pull_request"
         Github::PullRequestProcessor.new(payload: payload).call


### PR DESCRIPTION
## Summary
- dispatch a `github_webhook` system event with repository, action, and payload details when GitHub sends a webhook
- add controller coverage to verify webhook events are dispatched alongside existing processing

## Testing
- ./bin/rubocop -a
- bundle exec rails test
- bundle exec rails test:system *(fails: selenium could not download chromedriver in the container environment)*

## Original User's Requirements
- github hook이 발생하면 이벤트로 보내기


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69448fa3c5e08326a65987fc5779ec59)