### PR TITLE
Show per-topic “New” badges and block cross-topic live comment inserts

### DIFF
--- a/app/assets/stylesheets/comments_popup.css
+++ b/app/assets/stylesheets/comments_popup.css
@@ -455,6 +455,15 @@
     border-color: var(--color-accent, #007bff);
 }
 
+.topic-new-badge {
+    background: var(--color-badge-bg, red);
+    color: var(--color-badge-text, white);
+    border-radius: 10px;
+    padding: 0 4px;
+    font-size: 0.7em;
+    line-height: 1.2;
+}
+
 .add-topic-btn {
     display: inline-flex;
     align-items: center;

--- a/app/javascript/controllers/comments/list_controller.js
+++ b/app/javascript/controllers/comments/list_controller.js
@@ -404,6 +404,14 @@ export default class extends Controller {
     if (event.target.action === 'append') {
       const templateContent = event.target.templateContent || event.target.querySelector('template')?.content
       const firstChild = templateContent?.firstElementChild
+      const incomingTopicId = (firstChild?.dataset?.topicId || '').toString()
+      const currentTopicId = (this.currentTopicId || '').toString()
+
+      if (incomingTopicId !== currentTopicId) {
+        event.preventDefault()
+        this.popupController?.topicsController?.markTopicNew(incomingTopicId)
+        return
+      }
       if (firstChild && firstChild.id && document.getElementById(firstChild.id)) {
         event.preventDefault()
         return

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,6 +1,6 @@
 <% comment_topic = comment.topic %>
 <% current_topic_id = local_assigns[:current_topic_id] %>
-<div class="comment-item" id="<%= dom_id(comment) %>" data-controller="comment" data-user-id="<%= comment.user&.id %>" data-comment-id="<%= comment.id %>">
+<div class="comment-item" id="<%= dom_id(comment) %>" data-controller="comment" data-user-id="<%= comment.user&.id %>" data-comment-id="<%= comment.id %>" data-topic-id="<%= comment_topic&.id || '' %>">
   <div class="comment-select">
     <input type="checkbox"
            class="comment-select-checkbox"


### PR DESCRIPTION
### Motivation
- Prevent live insertion of new chat comments into the UI when the incoming comment belongs to a different topic than the one the user is viewing.
- Surface an unobtrusive indicator so users know which other topic has unseen messages.
- Keep topic selection state consistent and avoid surprising DOM changes while a user is viewing history or a different topic.

### Description
- Add `data-topic-id` to comment DOM elements so incoming stream templates carry their topic context (`app/views/comments/_comment.html.erb`).
- Intercept Turbo Streams in the comments list controller and block `append` actions when the incoming comment's topic differs from the current topic; instead call `topicsController.markTopicNew(...)` (`app/javascript/controllers/comments/list_controller.js`).
- Extend the topics controller with a `newTopicIds` set and helper methods: `markTopicNew`, `clearTopicBadge`, `findTopicTag`, and normalization logic. These render a small `New` badge next to topic tags and clear it when a topic is selected (`app/javascript/controllers/comments/topics_controller.js`).
- Add styling for the per-topic badge (`.topic-new-badge`) in `app/assets/stylesheets/comments_popup.css`.

### Testing
- Automated tests were not executed in this rollout. The following should be run before merging as required by the repo: `./bin/rubocop -a`, `rails test`, `rails test:system`.
- Manual verification steps to run locally (recommended): open comments popup, switch topics, post comment in other topic and verify the new comment is not appended to the DOM and the corresponding topic shows a `New` badge; selecting that topic clears the badge.

### Original User's Requirements
- 채팅에 새메세지가 왔을때, 현재 사용자가 있는 토픽이 메세지와 같은 토픽이 아니거나, #Main 이 아니면 표시하지 말고, 해당 토픽에 뱃지로 New  표시를 해야 한다

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944ae913e0c832684d150a76191d0a5)