### PR TITLE
feat(chat): refine notification logic and topic isolation

### DIFF
--- a/app/assets/stylesheets/comments_popup.css
+++ b/app/assets/stylesheets/comments_popup.css
@@ -471,7 +471,6 @@
     padding: 0.1em 0.4em;
     border-radius: 8px;
     font-weight: bold;
-    border: 1px solid white;
 }
 
 /* Hide the topic link if the message is displayed within that topic's context */

--- a/app/assets/stylesheets/comments_popup.css
+++ b/app/assets/stylesheets/comments_popup.css
@@ -455,6 +455,72 @@
     border-color: var(--color-accent, #007bff);
 }
 
+.topic-tag.has-new-messages {
+    position: relative;
+    border-color: var(--color-accent, #007bff);
+}
+
+.topic-tag.has-new-messages::after {
+    content: "New";
+    position: absolute;
+    top: -8px;
+    right: -10px;
+    background-color: #ff3b30;
+    color: white;
+    font-size: 0.6em;
+    padding: 0.1em 0.4em;
+    border-radius: 8px;
+    font-weight: bold;
+    border: 1px solid white;
+}
+
+/* Hide the topic link if the message is displayed within that topic's context */
+/* Use Javascript to set data-current-topic-id on the list container */
+.comment-topic-link {
+    margin-top: 0.25em;
+    font-size: 0.9em;
+}
+
+/* 
+   We want: if #comments-list[data-current-topic-id="123"] 
+   Then: .comment-item[data-topic-id="123"] .comment-topic-link { display: none; }
+   
+   Since we can't do dynamic matching in pure CSS (attr(x) == attr(y)), we rely on 
+   Stimulus list_controller to either set a specialized class or we just accept 
+   that we need to hide it using a more generic approach if possible, 
+   OR we use the fact that we can't easily do this in pure CSS without many rules.
+   
+   Wait, the requirement is "Show without #topic" if in that topic.
+   
+   If I am in topic 123, list_controller sets dataset.currentTopicId = 123.
+   The comment has dataset.topicId = 123.
+   
+   I can't write a CSS rule `[data-current-topic-id=data-topic-id]`
+   
+   However, I can do this in Javascript when filtering/rendering? 
+   No, user asked for "If current user is in matching topic".
+   
+   Let's use a simpler approach: 
+   If I am in a topic, I only see messages from that topic (filtered by server or client).
+   So ALL messages visible in Topic 123 are BY DEFINITION belonging to Topic 123.
+   (Except pinned? No pinned mentions).
+   
+   So, IF data-current-topic-id is set (meaning we are NOT in Main), 
+   we can hide ALL topic links inside the list?
+   
+   Wait, "Main" shows ALL messages. So currentTopicId is empty. Topic links shown.
+   "Topic A" shows ONLY A messages. So currentTopicId is A. 
+   
+   YES! If we are in a specific topic, we only see that topic's messages.
+   So we can hide ALL topic links when in a specific topic context.
+   
+   #comments-list:not([data-current-topic-id=""]) .comment-topic-link { display: none; }
+*/
+
+#comments-list:not([data-current-topic-id=""]) .comment-topic-link {
+    display: none;
+}
+
 .add-topic-btn {
     display: inline-flex;
     align-items: center;

--- a/app/javascript/controllers/comments/topics_controller.js
+++ b/app/javascript/controllers/comments/topics_controller.js
@@ -14,6 +14,12 @@ export default class extends Controller {
             this.loadTopics()
             this.subscribe()
         }
+        this.handleNewMessage = this.handleNewMessage.bind(this)
+        window.addEventListener('comments--topics:new-message', this.handleNewMessage)
+    }
+
+    disconnect() {
+        window.removeEventListener('comments--topics:new-message', this.handleNewMessage)
     }
 
     disconnect() {
@@ -181,6 +187,9 @@ export default class extends Controller {
 
     selectTopic(id) {
         this.updateSelectionUI(id)
+        if (id) {
+            this.clearNewMessageBadge(id)
+        }
         // Dispatch event
         this.dispatch("change", { detail: { topicId: id } })
     }
@@ -190,7 +199,30 @@ export default class extends Controller {
         // Update UI
         this.listTarget.querySelectorAll('.topic-tag').forEach(el => {
             el.classList.toggle('active', String(el.dataset.id) === String(id))
+            if (String(el.dataset.id) === String(id)) {
+                el.classList.remove('has-new-messages')
+            }
         })
+    }
+
+    handleNewMessage(event) {
+        const topicId = event.detail.topicId
+        if (!topicId) return
+
+        // Don't show badge if we are currently in this topic (shouldn't happen due to list_controller logic, but safety check)
+        if (String(this.currentTopicId) === String(topicId)) return
+
+        const topicEl = this.listTarget.querySelector(`.topic-tag[data-id="${topicId}"]`)
+        if (topicEl) {
+            topicEl.classList.add('has-new-messages')
+        }
+    }
+
+    clearNewMessageBadge(topicId) {
+        const topicEl = this.listTarget.querySelector(`.topic-tag[data-id="${topicId}"]`)
+        if (topicEl) {
+            topicEl.classList.remove('has-new-messages')
+        }
     }
 
     async createTopic(name) {

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,6 +1,6 @@
 <% comment_topic = comment.topic %>
 <% current_topic_id = local_assigns[:current_topic_id] %>
-<div class="comment-item" id="<%= dom_id(comment) %>" data-controller="comment" data-user-id="<%= comment.user&.id %>" data-comment-id="<%= comment.id %>">
+<div class="comment-item" id="<%= dom_id(comment) %>" data-controller="comment" data-user-id="<%= comment.user&.id %>" data-comment-id="<%= comment.id %>" data-topic-id="<%= comment_topic&.id %>">
   <div class="comment-select">
     <input type="checkbox"
            class="comment-select-checkbox"


### PR DESCRIPTION
- Ensure messages sending to specific topics are strictly hidden when viewing a different topic (including Main).
- Hide messages sent to Main when viewing a specific topic.
- Display 'New' badge on topic tags in the sidebar when unseen messages arrive for that topic.
- Add `data-topic-id` to comment elements to support client-side filtering.
- Update `ListController` to filter incoming Turbo Streams based on current topic context.
- Update `TopicsController` to manage new message badges and clear them on selection.
- Add strict topic isolation logic: users in Topic A will not see messages for Topic B or Main.