### PR TITLE
Add link prompt with label and URL in Lexical editor

### DIFF
--- a/app/javascript/components/InlineLexicalEditor.jsx
+++ b/app/javascript/components/InlineLexicalEditor.jsx
@@ -330,11 +330,24 @@ function ToolbarColorPicker({ icon, title, color, onChange, onClear }) {
 function LinkPopup({ initialLabel, initialUrl, onConfirm, onCancel }) {
   const [label, setLabel] = useState(initialLabel || "")
   const [url, setUrl] = useState(initialUrl || "")
+  const popupRef = useRef(null)
 
   useEffect(() => {
     setLabel(initialLabel || "")
     setUrl(initialUrl || "")
   }, [initialLabel, initialUrl])
+
+  useEffect(() => {
+    const handleClickOutside = (event) => {
+      if (popupRef.current && !popupRef.current.contains(event.target)) {
+        onCancel()
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside)
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside)
+    }
+  }, [onCancel])
 
   const handleKeyDown = (e) => {
     if (e.key === "Enter") {
@@ -349,6 +362,7 @@ function LinkPopup({ initialLabel, initialUrl, onConfirm, onCancel }) {
 
   return (
     <div
+      ref={popupRef}
       className="lexical-link-popup stacked-form"
       style={{
         position: "absolute",
@@ -362,6 +376,24 @@ function LinkPopup({ initialLabel, initialUrl, onConfirm, onCancel }) {
         border: "1px solid var(--color-border)",
         minWidth: "260px"
       }}>
+      <button
+        type="button"
+        onClick={onCancel}
+        style={{
+          position: "absolute",
+          top: "8px",
+          right: "8px",
+          background: "none",
+          border: "none",
+          cursor: "pointer",
+          color: "var(--color-muted, #999)",
+          fontSize: "1.2rem",
+          lineHeight: 1,
+          padding: "0 4px"
+        }}
+        title="Close">
+        ×
+      </button>
       <div>
         <label style={{ display: "block", fontSize: "0.8em", fontWeight: "bold", marginBottom: "0.25rem", color: "var(--color-text)" }}>Label</label>
         <input
@@ -384,20 +416,7 @@ function LinkPopup({ initialLabel, initialUrl, onConfirm, onCancel }) {
           style={{ width: "100%", boxSizing: "border-box" }}
         />
       </div>
-      <div style={{ display: "flex", justifyContent: "flex-end", gap: "0.5rem", marginTop: "0.5rem" }}>
-        <button
-          type="button"
-          onClick={onCancel}
-          style={{
-            background: "none",
-            border: "none",
-            cursor: "pointer",
-            color: "var(--color-text)",
-            padding: "0.45em 0.9em",
-            fontSize: "0.9rem"
-          }}>
-          Cancel
-        </button>
+      <div style={{ display: "flex", justifyContent: "flex-end", marginTop: "0.5rem" }}>
         <button
           type="button"
           className="primary-action-button"

--- a/app/javascript/components/InlineLexicalEditor.jsx
+++ b/app/javascript/components/InlineLexicalEditor.jsx
@@ -349,11 +349,13 @@ function LinkPopup({ initialLabel, initialUrl, onConfirm, onCancel }) {
     }
   }, [onCancel])
 
+  const handleSubmit = (e) => {
+    e.preventDefault()
+    onConfirm(label, url)
+  }
+
   const handleKeyDown = (e) => {
-    if (e.key === "Enter") {
-      e.preventDefault()
-      onConfirm(label, url)
-    } else if (e.key === "Escape") {
+    if (e.key === "Escape") {
       e.preventDefault()
       e.stopPropagation()
       onCancel()
@@ -394,36 +396,44 @@ function LinkPopup({ initialLabel, initialUrl, onConfirm, onCancel }) {
         title="Close">
         ×
       </button>
-      <div>
-        <label style={{ display: "block", fontSize: "0.8em", fontWeight: "bold", marginBottom: "0.25rem", color: "var(--color-text)" }}>Label</label>
-        <input
-          type="text"
-          placeholder="Link text"
-          value={label}
-          onChange={(e) => setLabel(e.target.value)}
-          onKeyDown={handleKeyDown}
-          style={{ width: "100%", boxSizing: "border-box" }}
-        />
-      </div>
-      <div>
-        <label style={{ display: "block", fontSize: "0.8em", fontWeight: "bold", marginBottom: "0.25rem", color: "var(--color-text)" }}>URL</label>
-        <input
-          type="text"
-          placeholder="https://example.com"
-          value={url}
-          onChange={(e) => setUrl(e.target.value)}
-          onKeyDown={handleKeyDown}
-          style={{ width: "100%", boxSizing: "border-box" }}
-        />
-      </div>
-      <div style={{ display: "flex", justifyContent: "flex-end", marginTop: "0.5rem" }}>
-        <button
-          type="button"
-          className="primary-action-button"
-          onClick={() => onConfirm(label, url)}>
-          Confirm
-        </button>
-      </div>
+      <form onSubmit={handleSubmit}>
+        <div>
+          <input
+            type="text"
+            placeholder="Link text"
+            value={label}
+            onChange={(e) => setLabel(e.target.value)}
+            onKeyDown={handleKeyDown}
+            style={{ width: "100%", boxSizing: "border-box", marginBottom: "0.5rem" }}
+          />
+        </div>
+        <div>
+          <input
+            type="text"
+            placeholder="https://example.com"
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            onKeyDown={handleKeyDown}
+            style={{ width: "100%", boxSizing: "border-box" }}
+          />
+        </div>
+        <div style={{ display: "flex", justifyContent: "flex-end", marginTop: "0.5rem" }}>
+          <button
+            type="submit"
+            className="primary-action-button"
+            title="Confirm"
+            style={{ display: "flex", alignItems: "center", justifyContent: "center", padding: "0.45em 0.6em" }}>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="16"
+              height="16"
+              fill="currentColor"
+              viewBox="0 0 16 16">
+              <path d="M13.854 3.646a.5.5 0 0 1 0 .708l-7 7a.5.5 0 0 1-.708 0l-3.5-3.5a.5.5 0 1 1 .708-.708L6.5 10.293l6.646-6.647a.5.5 0 0 1 .708 0z" />
+            </svg>
+          </button>
+        </div>
+      </form>
     </div>
   )
 }

--- a/app/javascript/components/InlineLexicalEditor.jsx
+++ b/app/javascript/components/InlineLexicalEditor.jsx
@@ -338,83 +338,57 @@ function LinkPopup({ initialLabel, initialUrl, onConfirm, onCancel }) {
 
   return (
     <div
-      className="lexical-link-popup"
+      className="lexical-link-popup stacked-form"
       style={{
         position: "absolute",
         top: "40px",
         right: "0",
         zIndex: 100,
-        backgroundColor: "white",
-        padding: "12px",
+        backgroundColor: "var(--color-bg)",
+        padding: "1rem",
         borderRadius: "8px",
         boxShadow: "0 4px 12px rgba(0,0,0,0.15)",
-        border: "1px solid #e5e5e5",
-        display: "flex",
-        flexDirection: "column",
-        gap: "10px",
+        border: "1px solid var(--color-border)",
         minWidth: "260px"
       }}>
-      <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
-        <label style={{ fontSize: "12px", fontWeight: "bold", color: "#333" }}>Label</label>
+      <div>
+        <label style={{ display: "block", fontSize: "0.8em", fontWeight: "bold", marginBottom: "0.25rem", color: "var(--color-text)" }}>Label</label>
         <input
           type="text"
           placeholder="Link text"
           value={label}
           onChange={(e) => setLabel(e.target.value)}
-          style={{
-            padding: "6px 8px",
-            borderRadius: "4px",
-            border: "1px solid #ccc",
-            fontSize: "14px",
-            width: "100%",
-            boxSizing: "border-box"
-          }}
+          style={{ width: "100%", boxSizing: "border-box" }}
         />
       </div>
-      <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
-        <label style={{ fontSize: "12px", fontWeight: "bold", color: "#333" }}>URL</label>
+      <div>
+        <label style={{ display: "block", fontSize: "0.8em", fontWeight: "bold", marginBottom: "0.25rem", color: "var(--color-text)" }}>URL</label>
         <input
           type="text"
           placeholder="https://example.com"
           value={url}
           onChange={(e) => setUrl(e.target.value)}
-          style={{
-            padding: "6px 8px",
-            borderRadius: "4px",
-            border: "1px solid #ccc",
-            fontSize: "14px",
-            width: "100%",
-            boxSizing: "border-box"
-          }}
+          style={{ width: "100%", boxSizing: "border-box" }}
         />
       </div>
-      <div style={{ display: "flex", justifyContent: "flex-end", gap: "8px", marginTop: "4px" }}>
+      <div style={{ display: "flex", justifyContent: "flex-end", gap: "0.5rem", marginTop: "0.5rem" }}>
         <button
           type="button"
           onClick={onCancel}
           style={{
-            padding: "6px 12px",
-            cursor: "pointer",
             background: "none",
-            border: "1px solid #ccc",
-            borderRadius: "4px",
-            fontSize: "13px"
+            border: "none",
+            cursor: "pointer",
+            color: "var(--color-text)",
+            padding: "0.45em 0.9em",
+            fontSize: "0.9rem"
           }}>
           Cancel
         </button>
         <button
           type="button"
-          onClick={() => onConfirm(label, url)}
-          style={{
-            padding: "6px 12px",
-            cursor: "pointer",
-            backgroundColor: "#007bff",
-            color: "white",
-            border: "none",
-            borderRadius: "4px",
-            fontSize: "13px",
-            fontWeight: "500"
-          }}>
+          className="primary-action-button"
+          onClick={() => onConfirm(label, url)}>
           Confirm
         </button>
       </div>

--- a/app/javascript/components/InlineLexicalEditor.jsx
+++ b/app/javascript/components/InlineLexicalEditor.jsx
@@ -327,118 +327,9 @@ function ToolbarColorPicker({ icon, title, color, onChange, onClear }) {
 }
 
 
-function LinkPopup({ initialLabel, initialUrl, onConfirm, onCancel }) {
-  const [label, setLabel] = useState(initialLabel || "")
-  const [url, setUrl] = useState(initialUrl || "")
-  const popupRef = useRef(null)
+import LinkPopup from "./LinkPopup"
 
-  useEffect(() => {
-    setLabel(initialLabel || "")
-    setUrl(initialUrl || "")
-  }, [initialLabel, initialUrl])
-
-  useEffect(() => {
-    const handleClickOutside = (event) => {
-      if (popupRef.current && !popupRef.current.contains(event.target)) {
-        onCancel()
-      }
-    }
-    document.addEventListener("mousedown", handleClickOutside)
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside)
-    }
-  }, [onCancel])
-
-  const handleSubmit = (e) => {
-    e.preventDefault()
-    onConfirm(label, url)
-  }
-
-  const handleKeyDown = (e) => {
-    if (e.key === "Escape") {
-      e.preventDefault()
-      e.stopPropagation()
-      onCancel()
-    }
-  }
-
-  return (
-    <div
-      ref={popupRef}
-      className="lexical-link-popup stacked-form"
-      style={{
-        position: "absolute",
-        top: "40px",
-        right: "0",
-        zIndex: 100,
-        backgroundColor: "var(--color-bg)",
-        padding: "1rem",
-        borderRadius: "8px",
-        boxShadow: "0 4px 12px rgba(0,0,0,0.15)",
-        border: "1px solid var(--color-border)",
-        minWidth: "260px"
-      }}>
-      <button
-        type="button"
-        onClick={onCancel}
-        style={{
-          position: "absolute",
-          top: "8px",
-          right: "8px",
-          background: "none",
-          border: "none",
-          cursor: "pointer",
-          color: "var(--color-muted, #999)",
-          fontSize: "1.2rem",
-          lineHeight: 1,
-          padding: "0 4px"
-        }}
-        title="Close">
-        ×
-      </button>
-      <form onSubmit={handleSubmit}>
-        <div>
-          <input
-            type="text"
-            placeholder="Link text"
-            value={label}
-            onChange={(e) => setLabel(e.target.value)}
-            onKeyDown={handleKeyDown}
-            style={{ width: "100%", boxSizing: "border-box", marginBottom: "0.5rem" }}
-          />
-        </div>
-        <div>
-          <input
-            type="text"
-            placeholder="https://example.com"
-            value={url}
-            onChange={(e) => setUrl(e.target.value)}
-            onKeyDown={handleKeyDown}
-            style={{ width: "100%", boxSizing: "border-box" }}
-          />
-        </div>
-        <div style={{ display: "flex", justifyContent: "flex-end", marginTop: "0.5rem" }}>
-          <button
-            type="submit"
-            className="primary-action-button"
-            title="Confirm"
-            style={{ display: "flex", alignItems: "center", justifyContent: "center", padding: "0.45em 0.6em" }}>
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="16"
-              height="16"
-              fill="currentColor"
-              viewBox="0 0 16 16">
-              <path d="M13.854 3.646a.5.5 0 0 1 0 .708l-7 7a.5.5 0 0 1-.708 0l-3.5-3.5a.5.5 0 1 1 .708-.708L6.5 10.293l6.646-6.647a.5.5 0 0 1 .708 0z" />
-            </svg>
-          </button>
-        </div>
-      </form>
-    </div>
-  )
-}
-
-function Toolbar({ onPromptForLink }) {
+function Toolbar() {
   const [editor] = useLexicalComposerContext()
   const [formats, setFormats] = useState({
     bold: false,
@@ -856,7 +747,6 @@ function EditorInner({
   initialHtml,
   onChange,
   onKeyDown,
-  onPromptForLink,
   onReady,
   onUploadStateChange,
   directUploadUrl,
@@ -868,7 +758,7 @@ function EditorInner({
 
   return (
     <div className="lexical-editor-shell">
-      <Toolbar onPromptForLink={onPromptForLink} />
+      <Toolbar />
       <div className="lexical-editor-inner">
         <RichTextPlugin
           contentEditable={
@@ -930,7 +820,6 @@ export default function InlineLexicalEditor({
   initialHtml,
   onChange,
   onKeyDown,
-  onPromptForLink,
   onReady,
   onUploadStateChange,
   directUploadUrl,
@@ -968,7 +857,6 @@ export default function InlineLexicalEditor({
         initialHtml={initialHtml}
         onChange={onChange}
         onKeyDown={onKeyDown}
-        onPromptForLink={onPromptForLink}
         onReady={onReady}
         onUploadStateChange={onUploadStateChange}
         directUploadUrl={directUploadUrl}

--- a/app/javascript/components/InlineLexicalEditor.jsx
+++ b/app/javascript/components/InlineLexicalEditor.jsx
@@ -336,6 +336,17 @@ function LinkPopup({ initialLabel, initialUrl, onConfirm, onCancel }) {
     setUrl(initialUrl || "")
   }, [initialLabel, initialUrl])
 
+  const handleKeyDown = (e) => {
+    if (e.key === "Enter") {
+      e.preventDefault()
+      onConfirm(label, url)
+    } else if (e.key === "Escape") {
+      e.preventDefault()
+      e.stopPropagation()
+      onCancel()
+    }
+  }
+
   return (
     <div
       className="lexical-link-popup stacked-form"
@@ -358,6 +369,7 @@ function LinkPopup({ initialLabel, initialUrl, onConfirm, onCancel }) {
           placeholder="Link text"
           value={label}
           onChange={(e) => setLabel(e.target.value)}
+          onKeyDown={handleKeyDown}
           style={{ width: "100%", boxSizing: "border-box" }}
         />
       </div>
@@ -368,6 +380,7 @@ function LinkPopup({ initialLabel, initialUrl, onConfirm, onCancel }) {
           placeholder="https://example.com"
           value={url}
           onChange={(e) => setUrl(e.target.value)}
+          onKeyDown={handleKeyDown}
           style={{ width: "100%", boxSizing: "border-box" }}
         />
       </div>

--- a/app/javascript/components/LinkPopup.jsx
+++ b/app/javascript/components/LinkPopup.jsx
@@ -1,0 +1,112 @@
+import React, { useState, useEffect, useRef } from "react"
+
+export default function LinkPopup({ initialLabel, initialUrl, onConfirm, onCancel }) {
+    const [label, setLabel] = useState(initialLabel || "")
+    const [url, setUrl] = useState(initialUrl || "")
+    const popupRef = useRef(null)
+
+    useEffect(() => {
+        setLabel(initialLabel || "")
+        setUrl(initialUrl || "")
+    }, [initialLabel, initialUrl])
+
+    useEffect(() => {
+        const handleClickOutside = (event) => {
+            if (popupRef.current && !popupRef.current.contains(event.target)) {
+                onCancel()
+            }
+        }
+        document.addEventListener("mousedown", handleClickOutside)
+        return () => {
+            document.removeEventListener("mousedown", handleClickOutside)
+        }
+    }, [onCancel])
+
+    const handleSubmit = (e) => {
+        e.preventDefault()
+        onConfirm(label, url)
+    }
+
+    const handleKeyDown = (e) => {
+        if (e.key === "Escape") {
+            e.preventDefault()
+            e.stopPropagation()
+            onCancel()
+        }
+    }
+
+    return (
+        <div
+            ref={popupRef}
+            className="lexical-link-popup stacked-form"
+            style={{
+                position: "absolute",
+                top: "40px",
+                right: "0",
+                zIndex: 100,
+                backgroundColor: "var(--color-bg)",
+                padding: "1rem",
+                borderRadius: "8px",
+                boxShadow: "0 4px 12px rgba(0,0,0,0.15)",
+                border: "1px solid var(--color-border)",
+                minWidth: "260px"
+            }}>
+            <button
+                type="button"
+                onClick={onCancel}
+                style={{
+                    position: "absolute",
+                    top: "8px",
+                    right: "8px",
+                    background: "none",
+                    border: "none",
+                    cursor: "pointer",
+                    color: "var(--color-muted, #999)",
+                    fontSize: "1.2rem",
+                    lineHeight: 1,
+                    padding: "0 4px"
+                }}
+                title="Close">
+                ×
+            </button>
+            <form onSubmit={handleSubmit}>
+                <div>
+                    <input
+                        type="text"
+                        placeholder="Link text"
+                        value={label}
+                        onChange={(e) => setLabel(e.target.value)}
+                        onKeyDown={handleKeyDown}
+                        style={{ width: "100%", boxSizing: "border-box", marginBottom: "0.5rem" }}
+                    />
+                </div>
+                <div>
+                    <input
+                        type="text"
+                        placeholder="https://example.com"
+                        value={url}
+                        onChange={(e) => setUrl(e.target.value)}
+                        onKeyDown={handleKeyDown}
+                        style={{ width: "100%", boxSizing: "border-box" }}
+                    />
+                </div>
+                <div style={{ display: "flex", justifyContent: "flex-end", marginTop: "0.5rem" }}>
+                    <button
+                        type="submit"
+                        className="primary-action-button"
+                        title="Confirm"
+                        style={{ display: "flex", alignItems: "center", justifyContent: "center", padding: "0.45em 0.6em" }}>
+                        <svg
+                            xmlns="http://www.w3.org/2000/svg"
+                            width="16"
+                            height="16"
+                            fill="currentColor"
+                            viewBox="0 0 16 16">
+                            <path d="M13.854 3.646a.5.5 0 0 1 0 .708l-7 7a.5.5 0 0 1-.708 0l-3.5-3.5a.5.5 0 1 1 .708-.708L6.5 10.293l6.646-6.647a.5.5 0 0 1 .708 0z" />
+                        </svg>
+                    </button>
+                </div>
+            </form>
+        </div>
+    )
+}

--- a/app/javascript/lexical_inline_editor.jsx
+++ b/app/javascript/lexical_inline_editor.jsx
@@ -130,13 +130,21 @@ export function createInlineEditor(container, {
   }
 }
 
-function promptForLink() {
-  const value = window.prompt("Enter a URL")
-  if (!value) return null
+function promptForLink({ selectionText } = {}) {
+  const trimmedSelection = (selectionText || "").trim()
+  const selectionIsUrl = /^https?:\/\/[^\s<]+$/i.test(trimmedSelection)
+  const labelInput = window.prompt("Link label", trimmedSelection)
+  if (labelInput === null) return null
+  const urlInput = window.prompt("Link URL", selectionIsUrl ? trimmedSelection : "")
+  if (urlInput === null) return null
+  const trimmedUrl = urlInput.trim()
+  if (!trimmedUrl) return null
+  let normalizedUrl = trimmedUrl
   try {
-    const url = new URL(value, window.location.origin)
-    return url.toString()
+    normalizedUrl = new URL(trimmedUrl, window.location.origin).toString()
   } catch (_error) {
-    return value.trim() || null
+    normalizedUrl = trimmedUrl
   }
+  const finalLabel = labelInput.trim() || normalizedUrl
+  return { label: finalLabel, url: normalizedUrl }
 }

--- a/app/javascript/lexical_inline_editor.jsx
+++ b/app/javascript/lexical_inline_editor.jsx
@@ -7,7 +7,7 @@ const DEFAULT_KEY = "creative-inline-editor"
 export function createInlineEditor(container, {
   onChange,
   onKeyDown,
-  onPromptForLink,
+
   onUploadStateChange
 } = {}) {
   if (!container) {
@@ -42,7 +42,7 @@ export function createInlineEditor(container, {
         initialHtml={currentHtml}
         editorKey={currentKey}
         placeholderText={placeholderText}
-        onPromptForLink={onPromptForLink ?? promptForLink}
+        // onPromptForLink removed
         onKeyDown={(event, editor) => {
           if (onKeyDown) onKeyDown(event, editor)
         }}
@@ -130,21 +130,4 @@ export function createInlineEditor(container, {
   }
 }
 
-function promptForLink({ selectionText } = {}) {
-  const trimmedSelection = (selectionText || "").trim()
-  const selectionIsUrl = /^https?:\/\/[^\s<]+$/i.test(trimmedSelection)
-  const labelInput = window.prompt("Link label", trimmedSelection)
-  if (labelInput === null) return null
-  const urlInput = window.prompt("Link URL", selectionIsUrl ? trimmedSelection : "")
-  if (urlInput === null) return null
-  const trimmedUrl = urlInput.trim()
-  if (!trimmedUrl) return null
-  let normalizedUrl = trimmedUrl
-  try {
-    normalizedUrl = new URL(trimmedUrl, window.location.origin).toString()
-  } catch (_error) {
-    normalizedUrl = trimmedUrl
-  }
-  const finalLabel = labelInput.trim() || normalizedUrl
-  return { label: finalLabel, url: normalizedUrl }
-}
+


### PR DESCRIPTION
### Motivation
- Fix the toolbar link action which did not prompt or insert links when clicked.
- Provide a small, usable flow that asks for both a link `label` and `url` so authors can confirm or edit before insertion.
- Prefill fields from the current selection when appropriate (treat selection-as-URL specially).
- Treat empty label as the URL (per UX requirement).

### Description
- Prompt flow: the toolbar now calls `onPromptForLink({ selectionText })` and expects `{ label, url }` back.
- When the selection is already a URL or label matches selection, we call `TOGGLE_LINK_COMMAND` with the `url` to reuse native link toggling.
- When the label differs from the selection we create a new link node and insert it via `$createLinkNode(url)` and a text node for the label.
- Files changed:
  - `app/javascript/components/InlineLexicalEditor.jsx` — import `$createLinkNode`, wire `toggleLink` to request `{label,url}` and insert link nodes when needed.
  - `app/javascript/lexical_inline_editor.jsx` — replace the simple `promptForLink()` with a two-step prompt that pre-fills label and URL based on the selection, normalizes the URL with `new URL(...)`, and returns `{ label, url }`.

### Testing
- Ran `./bin/rubocop -a` — failed in this environment (`/usr/bin/env: 'ruby': No such file or directory`).
- Ran `rails test` — not available in this environment (`bash: command not found: rails`).
- Ran `rails test:system` — not available in this environment (`bash: command not found: rails`).

### Original User's Requirements
- Lexical Editor 툴 도구에서 html link 연결이 눌러도 아무 반응이 없어, 해당 링크를 누르면 현재 선택된 글자 블록을 링크로 만들고 링크를 위한 타이틀과 url 을 입력받도록 팝업을 표시해야 해.
- Link 는 label, url 로 구성돼
- 글자 블록이 url 이면 label, url 모두 팝업에서 자동으로 채워, 사용자는 수정후에 확인할 수 있어
- 글자 블록이 url 이 아니면, label 만 채우고 url 을 입력 받아.
- label 을 비워두면 url 로 처리돼.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944f9fc80c883268ceced3dac303ab1)