### PR TITLE
Enable edit icons for newly added creatives without refresh

### DIFF
--- a/app/javascript/creative_row_editor.js
+++ b/app/javascript/creative_row_editor.js
@@ -1456,10 +1456,16 @@ export function initializeCreativeRowEditor() {
         const rowComponent = document.createElement('creative-tree-row');
         rowComponent.level = level;
         rowComponent.setAttribute('level', level);
-        const iconSource = document.querySelector('creative-tree-row[data-edit-icon-html]');
+        const iconSource = document.querySelector('creative-tree-row[data-edit-icon-html]') || document.getElementById('creatives');
         if (iconSource) {
-          if (iconSource.dataset.editIconHtml) rowComponent.dataset.editIconHtml = iconSource.dataset.editIconHtml;
-          if (iconSource.dataset.editOffIconHtml) rowComponent.dataset.editOffIconHtml = iconSource.dataset.editOffIconHtml;
+          if (iconSource.dataset.editIconHtml) {
+            rowComponent.dataset.editIconHtml = iconSource.dataset.editIconHtml;
+            rowComponent.editIconHtml = iconSource.dataset.editIconHtml;
+          }
+          if (iconSource.dataset.editOffIconHtml) {
+            rowComponent.dataset.editOffIconHtml = iconSource.dataset.editOffIconHtml;
+            rowComponent.editOffIconHtml = iconSource.dataset.editOffIconHtml;
+          }
         }
         if (parentId) {
           rowComponent.parentId = parentId;

--- a/app/views/creatives/index.html.erb
+++ b/app/views/creatives/index.html.erb
@@ -157,7 +157,9 @@
       data: {
         controller: 'creatives--tree',
         'creatives--tree-url-value': tree_url,
-        'creatives--tree-empty-html-value': empty_html.to_s
+        'creatives--tree-empty-html-value': empty_html.to_s,
+        edit_icon_html: svg_tag("edit.svg", className: "icon-edit"),
+        edit_off_icon_html: svg_tag("edit-off.svg", className: "icon-edit")
       }
     ) %>
 


### PR DESCRIPTION
### Motivation
- New creatives created inline did not show the edit button/icon until a full page refresh.
- The UI creates `creative-tree-row` elements client-side; these must inherit the edit icon markup so users can edit immediately.

### Description
- Add default edit icon markup to the `#creatives` root element so dynamic rows can inherit it (`app/views/creatives/index.html.erb`).
- When creating a new `creative-tree-row` client-side, fall back to the `#creatives` element for cached `editIconHtml` / `editOffIconHtml` and copy those into the new row's dataset and properties (`app/javascript/creative_row_editor.js`).
- This ensures newly inserted rows render the edit button (and its visible/hidden states) without requiring a page reload.
- Files modified: `app/views/creatives/index.html.erb`, `app/javascript/creative_row_editor.js`.

### Testing
- Ran `./bin/rubocop -a` (could not complete: `/usr/bin/env: 'ruby': No such file or directory`).
- Ran `rails test` (could not run: `command not found: rails`).
- Ran `rails test:system` (could not run: `command not found: rails`).

### Original User's Requirements
- 현재 생성된 creative 가 저장되면, 동적으로 추가된 creative element 에 edit button 이 보일 수 있도록 처리해야 한다. 지금은 수정 버튼이 보이지 않아 페이지리 refresh 해야 된다. refresh 없이 작동하게 해줘.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69451665f190832699862a619526c5b8)