### PR TITLE
Add Enter key shortcut to open add-creative inline editor

### DIFF
--- a/app/javascript/creative_row_editor.js
+++ b/app/javascript/creative_row_editor.js
@@ -11,6 +11,7 @@ const BULLET_INDENT_STEP_PX = 30;
 
 let initialized = false;
 let creativeEditClickHandler = null;
+let addCreativeShortcutHandler = null;
 
 function deleteAttachment(signedId) {
   if (!signedId) return;
@@ -697,6 +698,22 @@ export function initializeCreativeRowEditor() {
           handleEditButtonClick(tree);
         };
         document.addEventListener('creative-edit-click', creativeEditClickHandler);
+      }
+
+      if (!addCreativeShortcutHandler) {
+        addCreativeShortcutHandler = function (event) {
+          if (event.defaultPrevented || event.isComposing) return;
+          if (event.key !== 'Enter' || event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) return;
+          const target = event.target;
+          const interactiveSelector = 'input, textarea, select, button, a, [contenteditable="true"], [data-lexical-editor-root]';
+          if (target && target.closest && target.closest(interactiveSelector)) return;
+          if (target && target.isContentEditable) return;
+          const addButton = document.querySelector('.creative-actions-row .add-creative-btn, .creative-actions-row .new-root-creative-btn');
+          if (!addButton) return;
+          event.preventDefault();
+          addButton.click();
+        };
+        document.addEventListener('keydown', addCreativeShortcutHandler);
       }
 
       document.body.addEventListener('click', function (e) {

--- a/app/views/creatives/_add_button.html.erb
+++ b/app/views/creatives/_add_button.html.erb
@@ -4,7 +4,7 @@
         class: 'popup-menu-item add-creative-btn',
         data: { parent_id: @parent_creative.id },
         aria: { label: t('creatives.index.new_creative') },
-        title: t('creatives.index.new_creative')
+        title: t('creatives.index.new_creative_shortcut')
       ) do %>
     <span aria-hidden="true"><%= svg_tag 'add.svg', class: 'icon-add', width: 16, height: 16 %></span>
   <% end %>
@@ -13,7 +13,7 @@
         type: 'button',
         class: 'popup-menu-item new-root-creative-btn',
         aria: { label: t('creatives.index.new_creative') },
-        title: t('creatives.index.new_creative')
+        title: t('creatives.index.new_creative_shortcut')
       ) do %>
     <span aria-hidden="true"><%= svg_tag 'add.svg', class: 'icon-add', width: 16, height: 16 %></span>
   <% end %>

--- a/config/locales/creatives.en.yml
+++ b/config/locales/creatives.en.yml
@@ -3,6 +3,7 @@ en:
     index:
       up: "Up"
       new_creative: "Add"
+      new_creative_shortcut: "Add (Enter)"
       new_sub_creative: "New sub-creative"
       edit: "Edit"
       append_as_parent_creative: "New upper-creative"

--- a/config/locales/creatives.ko.yml
+++ b/config/locales/creatives.ko.yml
@@ -3,6 +3,7 @@ ko:
     index:
       up: "위로"
       new_creative: "추가"
+      new_creative_shortcut: "추가 (Enter)"
       new_sub_creative: "하위에 추가"
       edit: "수정"
       append_as_parent_creative: "상위에 추가"


### PR DESCRIPTION
### Motivation
- Provide a keyboard shortcut so pressing `Enter` on the creatives page opens the same inline editor as clicking the top add button to speed up content entry.
- Make the shortcut discoverable by updating the add button tooltip to include the key hint.
- Keep the shortcut inactive when focus is inside inputs, textareas, contenteditable areas, or the Lexical editor to avoid interfering with normal typing.
- Original User's Requirements: 크리에이티브 페이지에서 Enter key 를 누르면 상단 `add-creative-btn` 을 누른 것처럼 새 크리에이티브 추가 인라인 에디터가 표시되도록 하고, 해당 버튼 hover 시 단축키를 표시한다.

### Description
- Added a global `keydown` handler in `app/javascript/creative_row_editor.js` (registered on `turbo:load`) that triggers the add button when `Enter` is pressed and the focused element is not interactive or editable. 
- Introduced `addCreativeShortcutHandler` to guard against composing input and modifier keys and to ignore inputs, `contenteditable` elements, and the Lexical editor root.
- Updated add button titles in `app/views/creatives/_add_button.html.erb` to use the new locale key `creatives.index.new_creative_shortcut` so the tooltip shows the shortcut.
- Added locale strings `new_creative_shortcut` to `config/locales/creatives.en.yml` and `config/locales/creatives.ko.yml`.

### Testing
- Ran `./bin/rubocop -a` which failed due to missing Ruby in the environment (`/usr/bin/env: 'ruby': No such file or directory`).
- Ran `rails test` which could not be executed because `rails` is not available in the environment (`command not found: rails`).
- Ran `rails test:system` which could not be executed because `rails` is not available in the environment (`command not found: rails`).
- Verified changes committed locally and smoke-tested the JavaScript logic by inspecting the updated files and event handler registration in the browser-ready code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69489e9e8400832695958cb41005b007)