### PR TITLE
Enable drag-and-drop uploads in inline Lexical editor

### DIFF
--- a/app/javascript/components/InlineLexicalEditor.jsx
+++ b/app/javascript/components/InlineLexicalEditor.jsx
@@ -755,6 +755,24 @@ function EditorInner({
   deletedAttachmentsRef
 }) {
   const [editor] = useLexicalComposerContext()
+  const handleDrop = useCallback(
+    (event) => {
+      const files = event.dataTransfer?.files
+      if (!files || files.length === 0) return
+      event.preventDefault()
+      Array.from(files).forEach((file) => {
+        if (!file) return
+        editor.dispatchCommand(INSERT_FILE_COMMAND, { file })
+      })
+    },
+    [editor]
+  )
+
+  const handleDragOver = useCallback((event) => {
+    if (event.dataTransfer?.types?.includes("Files")) {
+      event.preventDefault()
+    }
+  }, [])
 
   return (
     <div className="lexical-editor-shell">
@@ -768,6 +786,8 @@ function EditorInner({
                 if (!onKeyDown) return
                 onKeyDown(event, editor)
               }}
+              onDrop={handleDrop}
+              onDragOver={handleDragOver}
             />
           }
           placeholder={<Placeholder text={placeholderText} />}


### PR DESCRIPTION
### Motivation
- Allow users to attach images and files by dragging them directly into the editor surface instead of using the toolbar.
- Improve editor UX by dispatching existing Lexical upload commands from the content surface so uploads integrate with current upload flow.

### Description
- Added `handleDrop` and `handleDragOver` callbacks inside `EditorInner` in `app/javascript/components/InlineLexicalEditor.jsx`.
- Wired `onDrop` and `onDragOver` props on the `ContentEditable` element to call those handlers and dispatch `INSERT_FILE_COMMAND` with `{ file }` for each dropped file.
- Reused the existing `FileUploadPlugin` upload flow and `INSERT_FILE_COMMAND`, so no changes to the upload implementation were required.

### Testing
- Ran `./bin/rubocop -a` which failed in this environment because `ruby` is not available (environment error).
- Ran `rails test` which failed because `rails` is not available in this environment.
- Ran `rails test:system` which failed because `rails` is not available in this environment.

### Original User's Requirements
- 파일을 drag and drop 하면 바로 첨부되도록 `lexical-inline-editor` 를 수정
- toolbar 없이 editor 영역에서 드래그앤드롭으로 이미지/첨부파일 추가 가능하도록 변경

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948c1d4e9d083269edde15f1662e356)