### PR TITLE
Align creative title and actions row start

### DIFF
--- a/app/assets/stylesheets/creatives.css
+++ b/app/assets/stylesheets/creatives.css
@@ -1,12 +1,11 @@
 /* #creatives {} - removed empty rule */
 
 :root {
-    --creative-row-text-offset: 40px;
-    --creative-actions-leading: 1rem;
+    --creative-row-text-offset: 20px;
 }
 
 .creative-actions-row {
-    margin: 0.0em 1.0em 0.0em calc(var(--creative-actions-leading) + var(--creative-row-text-offset));
+    margin: 0.0em 1.0em 0.0em var(--creative-row-text-offset);
     padding: 0.5em 0.5em 0.5em 0;
     display: flex;
     flex-wrap: wrap;
@@ -424,7 +423,7 @@ creative-tree-row.show-edit .creative-row {
 
 @media (max-width: 768px) {
     :root {
-        --creative-actions-leading: 0.3rem;
+        --creative-row-text-offset: 16px;
     }
 }
 

--- a/app/assets/stylesheets/creatives.css
+++ b/app/assets/stylesheets/creatives.css
@@ -1,7 +1,7 @@
 /* #creatives {} - removed empty rule */
 
 :root {
-    --creative-row-text-offset: 20px;
+    --creative-row-text-offset: 0px;
 }
 
 .creative-actions-row {
@@ -421,11 +421,6 @@ creative-tree-row.show-edit .creative-row {
     font-size: 1.4em;
 }
 
-@media (max-width: 768px) {
-    :root {
-        --creative-row-text-offset: 16px;
-    }
-}
 
 /* Constrain images within creative-row to prevent overflow */
 .creative-row img {

--- a/app/assets/stylesheets/creatives.css
+++ b/app/assets/stylesheets/creatives.css
@@ -4,6 +4,16 @@
     --creative-row-text-offset: 0px;
 }
 
+.creative-actions-row,
+.page-title {
+    visibility: hidden;
+}
+
+html.creative-alignment-ready .creative-actions-row,
+html.creative-alignment-ready .page-title {
+    visibility: visible;
+}
+
 .creative-actions-row {
     margin: 0.0em 1.0em 0.0em var(--creative-row-text-offset);
     padding: 0.5em 0.5em 0.5em 0;

--- a/app/assets/stylesheets/creatives.css
+++ b/app/assets/stylesheets/creatives.css
@@ -1,7 +1,7 @@
 /* #creatives {} - removed empty rule */
 
 :root {
-    --creative-row-text-offset: 0px;
+    --creative-row-text-offset: 1.8em;
 }
 
 .creative-actions-row,

--- a/app/assets/stylesheets/creatives.css
+++ b/app/assets/stylesheets/creatives.css
@@ -1,8 +1,18 @@
 /* #creatives {} - removed empty rule */
 
+:root {
+    --creative-row-text-offset: 40px;
+}
+
+@media (max-width: 768px) {
+    :root {
+        --creative-row-text-offset: 20px;
+    }
+}
+
 .creative-actions-row {
-    margin: 0.0em 1.0em;
-    padding: 0.5em;
+    margin: 0.0em 1.0em 0.0em var(--creative-row-text-offset);
+    padding: 0.5em 0.5em 0.5em 0;
     display: flex;
     flex-wrap: wrap;
     gap: 10px;
@@ -413,7 +423,7 @@ creative-tree-row.show-edit .creative-row {
 }
 
 .page-title {
-    margin-left: 1.5em;
+    margin-left: var(--creative-row-text-offset);
     font-size: 1.4em;
 }
 

--- a/app/assets/stylesheets/creatives.css
+++ b/app/assets/stylesheets/creatives.css
@@ -2,16 +2,11 @@
 
 :root {
     --creative-row-text-offset: 40px;
-}
-
-@media (max-width: 768px) {
-    :root {
-        --creative-row-text-offset: 20px;
-    }
+    --creative-actions-leading: 1rem;
 }
 
 .creative-actions-row {
-    margin: 0.0em 1.0em 0.0em var(--creative-row-text-offset);
+    margin: 0.0em 1.0em 0.0em calc(var(--creative-actions-leading) + var(--creative-row-text-offset));
     padding: 0.5em 0.5em 0.5em 0;
     display: flex;
     flex-wrap: wrap;
@@ -425,6 +420,12 @@ creative-tree-row.show-edit .creative-row {
 .page-title {
     margin-left: var(--creative-row-text-offset);
     font-size: 1.4em;
+}
+
+@media (max-width: 768px) {
+    :root {
+        --creative-actions-leading: 0.3rem;
+    }
 }
 
 /* Constrain images within creative-row to prevent overflow */

--- a/app/assets/stylesheets/print.css
+++ b/app/assets/stylesheets/print.css
@@ -1,7 +1,6 @@
 @media print {
   :root {
-    --creative-row-text-offset: 40px;
-    --creative-actions-leading: 1rem;
+    --creative-row-text-offset: 20px;
   }
 
   nav,

--- a/app/assets/stylesheets/print.css
+++ b/app/assets/stylesheets/print.css
@@ -28,5 +28,10 @@
 
   .page-title {
     margin-left: 0 !important;
+    visibility: visible !important;
+  }
+
+  .creative-actions-row {
+    visibility: visible !important;
   }
 }

--- a/app/assets/stylesheets/print.css
+++ b/app/assets/stylesheets/print.css
@@ -1,4 +1,9 @@
 @media print {
+  :root {
+    --creative-row-text-offset: 40px;
+    --creative-actions-leading: 1rem;
+  }
+
   nav,
   #plans-list-area,
   #inbox-panel,

--- a/app/assets/stylesheets/print.css
+++ b/app/assets/stylesheets/print.css
@@ -1,6 +1,6 @@
 @media print {
   :root {
-    --creative-row-text-offset: 20px;
+    --creative-row-text-offset: 0px;
   }
 
   nav,

--- a/app/assets/stylesheets/print.css
+++ b/app/assets/stylesheets/print.css
@@ -9,6 +9,8 @@
   .creative-actions-row,
   .creative-action-btn,
   .creative-row-actions,
+  .creative-toggle-btn,
+  .select-creative-checkbox,
   #creative-guide-popover,
   #creative-guide-link,
   #inbox-menu-btn,
@@ -22,5 +24,9 @@
 
   main {
     margin: 0;
+  }
+
+  .page-title {
+    margin-left: 0 !important;
   }
 }

--- a/app/javascript/controllers/creatives/tree_controller.js
+++ b/app/javascript/controllers/creatives/tree_controller.js
@@ -12,6 +12,7 @@ export default class extends Controller {
     this.loadingIndicator = null
     this.handleResize = this.updateAlignmentOffset.bind(this)
     this.handleTreeUpdated = () => this.queueAlignmentUpdate()
+    document.documentElement.classList.remove('creative-alignment-ready')
     this.load()
     this.queueAlignmentUpdate()
     window.addEventListener('resize', this.handleResize)
@@ -73,6 +74,7 @@ export default class extends Controller {
   showEmptyState() {
     const html = this.hasEmptyHtmlValue ? this.emptyHtmlValue : ''
     this.element.innerHTML = html
+    document.documentElement.classList.add('creative-alignment-ready')
   }
 
   showLoadingIndicator() {

--- a/app/javascript/controllers/creatives/tree_controller.js
+++ b/app/javascript/controllers/creatives/tree_controller.js
@@ -116,6 +116,7 @@ export default class extends Controller {
     const parentRect = parent.getBoundingClientRect()
     const offset = Math.max(0, Math.round(contentRect.left - parentRect.left))
     document.documentElement.style.setProperty('--creative-row-text-offset', `${offset}px`)
+    document.documentElement.classList.add('creative-alignment-ready')
     return true
   }
 

--- a/app/javascript/controllers/creatives/tree_controller.js
+++ b/app/javascript/controllers/creatives/tree_controller.js
@@ -10,7 +10,12 @@ export default class extends Controller {
   connect() {
     this.abortController = null
     this.loadingIndicator = null
+    this.handleResize = this.updateAlignmentOffset.bind(this)
+    this.handleTreeUpdated = this.updateAlignmentOffset.bind(this)
     this.load()
+    this.updateAlignmentOffset()
+    window.addEventListener('resize', this.handleResize)
+    this.element.addEventListener('creative-tree:updated', this.handleTreeUpdated)
   }
 
   disconnect() {
@@ -18,6 +23,8 @@ export default class extends Controller {
       this.abortController.abort()
       this.abortController = null
     }
+    window.removeEventListener('resize', this.handleResize)
+    this.element.removeEventListener('creative-tree:updated', this.handleTreeUpdated)
   }
 
   load() {
@@ -91,5 +98,22 @@ export default class extends Controller {
     if (this.loadingIndicator && this.loadingIndicator.parentNode === this.element) {
       this.element.removeChild(this.loadingIndicator)
     }
+  }
+
+  updateAlignmentOffset() {
+    const actionsRow = document.querySelector('.creative-actions-row')
+    const title = document.querySelector('.page-title')
+    if (!actionsRow && !title) return
+
+    const content = this.element.querySelector('.creative-tree .creative-content')
+    if (!content) return
+
+    const parent = (actionsRow || title)?.parentElement
+    if (!parent) return
+
+    const contentRect = content.getBoundingClientRect()
+    const parentRect = parent.getBoundingClientRect()
+    const offset = Math.max(0, Math.round(contentRect.left - parentRect.left))
+    document.documentElement.style.setProperty('--creative-row-text-offset', `${offset}px`)
   }
 }


### PR DESCRIPTION
### Motivation
- Ensure the creative title text start and the first button in the `creative-actions-row` are vertically aligned with the first creative's text start for a cleaner, consistent layout. 
- Provide consistent spacing on both desktop and mobile viewports so headings and action buttons visually line up.

### Description
- Added a CSS variable `--creative-row-text-offset` at `:root` with a mobile media query override to centralize the alignment offset. 
- Updated `.creative-actions-row` to use the offset for left margin and adjusted padding to align the first action button with the creative text start. 
- Updated `.page-title` margin to use the same offset so the page title aligns with creative rows. 
- Modified file: `app/assets/stylesheets/creatives.css`.

### Testing
- Ran `./bin/rubocop -a`, which could not run in this environment due to missing Ruby (`/usr/bin/env: 'ruby': No such file or directory`).
- Ran `rails test` and `rails test:system`, both could not run because `rails` is not available in this environment (`command not found: rails`).
- Confirmed changes staged and committed locally via Git; file change recorded as 1 file changed.

### Original User's Requirements
- creative title 영역에서 글자 시작 부분과 creative-actions-row 의 첫번째 버튼 시작을 모두 세로로 첫번째 크리에이티브의 글자 시작과 동일하게 맞춰서 시작적으로 깔끔하게 보이도록 해줘

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948d2ea947483268839d66219a62717)