### PR TITLE
Avoid reloading creative tree on Turbo restore

### DIFF
--- a/app/javascript/controllers/creatives/tree_controller.js
+++ b/app/javascript/controllers/creatives/tree_controller.js
@@ -13,7 +13,9 @@ export default class extends Controller {
     this.handleResize = this.updateAlignmentOffset.bind(this)
     this.handleTreeUpdated = () => this.queueAlignmentUpdate()
     document.documentElement.classList.remove('creative-alignment-ready')
-    this.load()
+    if (!this.hasCachedContent()) {
+      this.load()
+    }
     this.queueAlignmentUpdate()
     window.addEventListener('resize', this.handleResize)
     this.element.addEventListener('creative-tree:updated', this.handleTreeUpdated)
@@ -67,6 +69,7 @@ export default class extends Controller {
     }
 
     renderCreativeTree(this.element, nodes)
+    this.markContentLoaded()
     dispatchCreativeTreeUpdated(this.element)
     this.queueAlignmentUpdate()
   }
@@ -74,6 +77,7 @@ export default class extends Controller {
   showEmptyState() {
     const html = this.hasEmptyHtmlValue ? this.emptyHtmlValue : ''
     this.element.innerHTML = html
+    this.markContentLoaded()
     document.documentElement.classList.add('creative-alignment-ready')
   }
 
@@ -93,6 +97,7 @@ export default class extends Controller {
       `
       this.loadingIndicator = indicator
     }
+    this.clearLoadedState()
     this.element.innerHTML = ''
     this.element.appendChild(this.loadingIndicator)
   }
@@ -101,6 +106,19 @@ export default class extends Controller {
     if (this.loadingIndicator && this.loadingIndicator.parentNode === this.element) {
       this.element.removeChild(this.loadingIndicator)
     }
+  }
+
+  hasCachedContent() {
+    if (this.element.dataset.loaded !== 'true') return false
+    return Boolean(this.element.querySelector('creative-tree-row') || this.element.innerHTML.trim() !== '')
+  }
+
+  markContentLoaded() {
+    this.element.dataset.loaded = 'true'
+  }
+
+  clearLoadedState() {
+    delete this.element.dataset.loaded
   }
 
   updateAlignmentOffset() {


### PR DESCRIPTION
### Motivation
- Prevent the creative list from re-fetching and re-rendering when Turbo restores a cached page so the browser can preserve scroll position. 
- Avoid losing the DOM snapshot and scroll point caused by the Stimulus controller always calling `load()` in `connect()`.
- Minimize unnecessary CSR fetches and rendering when the existing DOM already contains the creative rows.

### Description
- Add `hasCachedContent()`, `markContentLoaded()` and `clearLoadedState()` helpers to `app/javascript/controllers/creatives/tree_controller.js` to track when the tree content is loaded. 
- Skip calling `load()` during `connect()` when `hasCachedContent()` returns true so restored Turbo snapshots are preserved. 
- Call `markContentLoaded()` after `renderData()` and in `showEmptyState()` to mark the element as loaded, and call `clearLoadedState()` when showing the loading indicator. 
- Keep existing fetch/render behavior unchanged for first loads and when content is not cached.

### Testing
- Ran `./bin/rubocop -a` in the environment, which failed because Ruby is not available. (failed)
- Ran `rails test` in the environment, which failed because Rails is not available. (failed)
- Ran `rails test:system` in the environment, which failed because Rails is not available. (failed)

### Original User's Requirements
- Implement the idea to keep scroll position and avoid reloading creatives JSON on back navigation by skipping CSR fetch/render when the page is restored from cache.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949f61e73388326850fb9b00a636d78)