### PR TITLE
Shorten move message button label

### DIFF
--- a/config/locales/comments.en.yml
+++ b/config/locales/comments.en.yml
@@ -49,7 +49,7 @@ en:
     voice_button: "Voice"
     voice_stop: "Stop"
     speech_unavailable: "Speech recognition is not supported in this browser."
-    move_button: "Move message"
+    move_button: "Move"
     move_no_selection: "Select at least one message to move."
     move_error: "Unable to move messages."
     move_invalid_target: "Select a valid creative to move messages to."

--- a/config/locales/comments.ko.yml
+++ b/config/locales/comments.ko.yml
@@ -49,7 +49,7 @@ ko:
     voice_button: "음성"
     voice_stop: "중지"
     speech_unavailable: "이 브라우저는 음성 인식을 지원하지 않습니다."
-    move_button: "메시지 이동"
+    move_button: "이동"
     move_no_selection: "이동할 메시지를 선택해주세요."
     move_error: "메시지를 이동할 수 없습니다."
     move_invalid_target: "이동할 크리에이티브를 선택해주세요."


### PR DESCRIPTION
## Summary
- shorten the Move message button label to a concise term in English
- update the Korean translation to the shorter equivalent

## Testing
- `./bin/rubocop -a`
- `bundle exec rails test`
- `bundle exec rails test:system` *(fails: chromedriver could not be obtained in this environment)*

## Original User's Requirements
- 채팅에서 "Move message" 버튼은 너무 길어 다른 단어로 바꿔줘 한글 타이틀도 마찬가지

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b27cba6e48326ae1f1d9bd87806b1)