### PR TITLE
Default comments popup to Main topic when stored selection missing

### DIFF
--- a/app/javascript/controllers/comments/topics_controller.js
+++ b/app/javascript/controllers/comments/topics_controller.js
@@ -76,7 +76,12 @@ export default class extends Controller {
             const exists = this.listTarget.querySelector(`[data-id="${lastTopicId}"]`)
             if (exists) {
                 this.selectTopic(lastTopicId)
+                return
             }
+        }
+
+        if (lastTopicId) {
+            this.selectTopic("")
         }
     }
 


### PR DESCRIPTION
### Motivation
- Ensure the comments popup selects `#Main` when a previously stored topic selection no longer exists so the popup loads a valid context.
- Prevent the popup from remaining in a stale or deleted topic after topics are updated or removed.
- Improve UX by automatically switching to `#Main` to guarantee the comments list is populated and consistent.

### Description
- Update `restoreSelection` in `app/javascript/controllers/comments/topics_controller.js` to fallback to `selectTopic("")` when the stored `currentTopicId` is not found in the rendered topic list.
- Add an early `return` when the stored topic exists to avoid running the fallback unnecessarily.
- This triggers the normal selection flow and dispatches the change event so the list loads in the Main context when needed.
- Modified file: `app/javascript/controllers/comments/topics_controller.js`.

### Testing
- Ran `./bin/rubocop -a`, which failed due to missing Ruby in the environment (`/usr/bin/env: 'ruby': No such file or directory`).
- Ran `rails test`, which failed because `rails` is not available in the environment (`bash: command not found: rails`).
- Ran `rails test:system`, which failed with the same missing `rails` error.
- No frontend JS tests were executed in this environment.

### Original User's Requirements
- 채팅 팝업에서 토픽이 없으면 #Main 토픽으로 선택되서 로딩되어야 해

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a5d05adec8326a9ea08e4356be203)