### PR TITLE
Add themeable nav background images

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -43,7 +43,11 @@ nav {
     max-width: var(--max-width);
     margin: 0 auto;
     padding: 1rem;
-    background: var(--color-nav-bg);
+    background-color: var(--color-nav-bg);
+    background-image: var(--nav-bg-image, none);
+    background-size: cover;
+    background-position: center;
+    background-repeat: no-repeat;
     color: var(--color-nav-text);
     border-bottom: 1px solid var(--color-border);
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);

--- a/app/assets/stylesheets/dark_mode.css
+++ b/app/assets/stylesheets/dark_mode.css
@@ -27,6 +27,7 @@
   --color-input-bg: #f7f7f8;
   --color-input-text: #202123;
   --color-nav-text: #202123;
+  --nav-bg-image: none;
   --max-width: 960px;
   --paragraph-space-1: 0.75rem;
 }
@@ -56,6 +57,7 @@ body.dark-mode {
   --color-input-bg: #212121;
   --color-input-text: #eaeaea;
   --color-nav-text: #eaeaea;
+  --nav-bg-image: none;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -84,6 +86,7 @@ body.dark-mode {
     --color-input-bg: #212121;
     --color-input-text: #eaeaea;
     --color-nav-text: #eaeaea;
+    --nav-bg-image: none;
   }
 }
 
@@ -94,7 +97,8 @@ body {
 }
 
 nav {
-  background: var(--color-nav-bg);
+  background-color: var(--color-nav-bg);
+  background-image: var(--nav-bg-image, none);
 }
 
 a {

--- a/app/services/auto_theme_generator.rb
+++ b/app/services/auto_theme_generator.rb
@@ -24,6 +24,7 @@ class AutoThemeGenerator
     --color-input-text
     --color-nav-text
     --creative-loading-emojis
+    --nav-bg-image
   ].freeze
 
   def initialize(client: default_client)
@@ -43,9 +44,10 @@ class AutoThemeGenerator
       3. Ensure "--color-chat-btn-text" has High Contrast against "--color-section-bg" (where chat messages reside).
       4. Ensure "--color-nav-text" has High Contrast against "--color-nav-bg".
       5. Names of these text colors should be visually distinct from their background colors to ensure readability.
-      6. For "--creative-loading-emojis", provide a comma-separated string of exactly 6 emojis that match the theme mood (e.g., "🌵,🏜️,☀️,🦎,🌾,🐪").
-      7. Do not include any other keys or newlines.
-      8. Return valid JSON only.
+      6. For "--nav-bg-image", provide a CSS background-image value that matches the prompt. Use either "none" or a full URL in the form url("https://example.com/image.jpg"). Avoid base64 data URIs.
+      7. For "--creative-loading-emojis", provide a comma-separated string of exactly 6 emojis that match the theme mood (e.g., "🌵,🏜️,☀️,🦎,🌾,🐪").
+      8. Do not include any other keys or newlines.
+      9. Return valid JSON only.
 
       The JSON object must strictly follow this structure:
       {


### PR DESCRIPTION
## Summary
- allow the navigation bar to display an optional background image with sensible defaults
- add nav background image variables to the default theme tokens and update the theme generator prompt

## Testing
- ./bin/rubocop -a
- bundle exec rails test
- bundle exec rails test:system *(fails: Selenium could not download Chrome/Chromedriver in this environment)*

## Original User's Requirements
- 상단 nav 영역에 배경이미지를 넣을 수 있게해, 그리고 그것을 테마 생성기에서 생성 할 수 있도록 해. 기본은 배경이미지가 없고 그냥 배경색만 있어.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694bcae227608326a85a80e90730821a)