### PR TITLE
Optimize creative progress calculation and implement ancestor filter

### DIFF
--- a/app/controllers/creatives_controller.rb
+++ b/app/controllers/creatives_controller.rb
@@ -17,6 +17,11 @@ class CreativesController < ApplicationController
     @allowed_creative_ids = index_result.allowed_creative_ids
     @progress_map = index_result.progress_map
 
+    # Set filtered_progress on parent creative if progress_map is available
+    if @parent_creative && @progress_map && @progress_map.key?(@parent_creative.id.to_s)
+      @parent_creative.filtered_progress = @progress_map[@parent_creative.id.to_s]
+    end
+
     respond_to do |format|
       format.html
       format.json do

--- a/app/controllers/creatives_controller.rb
+++ b/app/controllers/creatives_controller.rb
@@ -14,6 +14,8 @@ class CreativesController < ApplicationController
     @shared_creative = index_result.shared_creative
     @shared_list = index_result.shared_list
     @overall_progress = index_result.overall_progress if params[:tags].present?
+    @allowed_creative_ids = index_result.allowed_creative_ids
+    @progress_map = index_result.progress_map
 
     respond_to do |format|
       format.html
@@ -21,7 +23,15 @@ class CreativesController < ApplicationController
         if params[:simple].present?
           render json: serialize_creatives(@creatives)
         else
-          render json: { creatives: build_tree(@creatives, params: params, expanded_state_map: @expanded_state_map, level: 1) }
+          @creatives_tree_json = build_tree(
+            index_result.creatives,
+            params: params,
+            expanded_state_map: @expanded_state_map,
+            level: 1,
+            allowed_creative_ids: @allowed_creative_ids,
+            progress_map: @progress_map
+          )
+          render json: { creatives: @creatives_tree_json }
         end
       end
     end
@@ -263,19 +273,30 @@ class CreativesController < ApplicationController
 
   def children
     parent = Creative.find(params[:id])
-    @expanded_state_map = CreativeExpandedState
+    expanded_state_map = CreativeExpandedState
                               .where(user_id: Current.user.id, creative_id: parent.id)
                               .first&.expanded_status || {}
     children = parent.children_with_permission(Current.user)
+
+    allowed_ids = nil
+    progress_map = nil
+    if params[:tags].present? || params[:min_progress].present? || params[:max_progress].present?
+      result = Creatives::IndexQuery.new(user: Current.user, params: params.merge(id: params[:id])).call
+      allowed_ids = result.allowed_creative_ids
+      progress_map = result.progress_map
+    end
+
     level = params[:level].to_i
     json_level = level.zero? ? 1 : level
     render json: {
       creatives: build_tree(
         children,
         params: params,
-        expanded_state_map: @expanded_state_map,
+        expanded_state_map: expanded_state_map,
         level: json_level,
-        select_mode: params[:select_mode] == "1"
+        select_mode: params[:select_mode] == "1",
+        allowed_creative_ids: allowed_ids,
+        progress_map: progress_map
       )
     }
   end
@@ -333,14 +354,16 @@ class CreativesController < ApplicationController
   end
 
   private
-    def build_tree(collection, params:, expanded_state_map:, level:, select_mode: false)
+    def build_tree(collection, params:, expanded_state_map:, level:, select_mode: false, allowed_creative_ids: nil, progress_map: nil)
       Creatives::TreeBuilder.new(
         user: Current.user,
         params: params,
         view_context: view_context,
         expanded_state_map: expanded_state_map,
         select_mode: select_mode,
-        max_level: Current.user&.display_level || User::DEFAULT_DISPLAY_LEVEL
+        max_level: Current.user&.display_level || User::DEFAULT_DISPLAY_LEVEL,
+        allowed_creative_ids: allowed_creative_ids,
+        progress_map: progress_map
       ).build(collection, level: level)
     end
 

--- a/app/helpers/creatives_helper.rb
+++ b/app/helpers/creatives_helper.rb
@@ -32,8 +32,7 @@ module CreativesHelper
 
   def render_creative_progress(creative, select_mode: false)
     progress_value = if params[:tags].present?
-      tag_ids = Array(params[:tags]).map(&:to_s)
-      creative.progress_for_tags(tag_ids) || 0
+      creative.filtered_progress || 0
     else
       creative.progress
     end
@@ -215,7 +214,7 @@ module CreativesHelper
           token = "__IMG#{index}__"; index += 1
           placeholders[token] = "![#{alt_text}](data:#{blob.content_type};base64,#{data})"
           token
-        rescue => e
+        rescue
           # If blob not found, keep original
           match
         end

--- a/app/helpers/creatives_helper.rb
+++ b/app/helpers/creatives_helper.rb
@@ -32,7 +32,10 @@ module CreativesHelper
 
   def render_creative_progress(creative, select_mode: false)
     progress_value = if params[:tags].present?
-      creative.filtered_progress || 0
+      tag_ids = Array(params[:tags]).map(&:to_s)
+      # Use filtered_progress if available (set by IndexQuery/TreeBuilder pipeline)
+      # Otherwise fall back to progress_for_tags for other endpoints
+      creative.filtered_progress || creative.progress_for_tags(tag_ids) || 0
     else
       creative.progress
     end

--- a/app/models/creative.rb
+++ b/app/models/creative.rb
@@ -41,6 +41,8 @@ class Creative < ApplicationRecord
 
   has_closure_tree order: :sequence, name_column: :description
 
+  attr_accessor :filtered_progress
+
   # belongs_to :parent, class_name: "Creative", optional: true
   # has_many :children, -> { order(:sequence) }, class_name: "Creative", foreign_key: :parent_id, dependent: :destroy
 

--- a/app/services/creatives/index_query.rb
+++ b/app/services/creatives/index_query.rb
@@ -140,21 +140,10 @@ module Creatives
       # 1. Get properties of relevant creatives from already-loaded objects
       relevant_creatives = accessible_creatives.select { |c| relevant_ids.include?(c.id) }
 
-      # Apply tag-aware progress logic (matching progress_for_tags semantics):
-      # For nodes in relevant_ids (leaf-most tagged nodes):
-      # - If node has children but none are in relevant_ids (none are tagged): 1.0
-      # - Otherwise (true leaf or has tagged children): actual progress
-      relevant_ids_set = relevant_ids.to_set
-      leaf_values = relevant_creatives.to_h do |c|
-        progress_value = if c.children.any? && c.children.none? { |child| relevant_ids_set.include?(child.id) }
-                          1.0  # Tagged parent with untagged children is treated as complete
-        else
-                          c.progress.to_f  # Leaf node or has tagged children uses actual progress
-        end
-        [ c.id, progress_value ]
-      end
+      # Use actual progress for all relevant nodes
+      leaf_values = relevant_creatives.to_h { |c| [ c.id, c.progress.to_f ] }
 
-      # Calculate overall average from tag-aware values
+      # Calculate overall average from loaded values
       total_progress = leaf_values.values.sum
       overall_average = leaf_values.any? ? total_progress / leaf_values.size : 0.0
 

--- a/app/services/creatives/index_query.rb
+++ b/app/services/creatives/index_query.rb
@@ -100,7 +100,7 @@ module Creatives
       # "Starting Roots" for the result.
       start_nodes = if params[:id]
         parent = Creative.find(params[:id])
-        return [ [], parent, nil, 0, {} ] unless readable?(parent)
+        return [ [], nil, nil, 0, {} ] unless readable?(parent)
 
         parent.children.where(id: allowed_ids)
       else

--- a/app/services/creatives/index_query.rb
+++ b/app/services/creatives/index_query.rb
@@ -140,11 +140,23 @@ module Creatives
       # 1. Get properties of relevant creatives from already-loaded objects
       relevant_creatives = accessible_creatives.select { |c| relevant_ids.include?(c.id) }
 
-      # Calculate overall average from loaded values
-      total_progress = relevant_creatives.sum { |c| c.progress.to_f }
-      overall_average = relevant_creatives.any? ? total_progress / relevant_creatives.size : 0.0
+      # Apply tag-aware progress logic (matching progress_for_tags semantics):
+      # For nodes in relevant_ids (leaf-most tagged nodes):
+      # - If node has children but none are in relevant_ids (none are tagged): 1.0
+      # - Otherwise (true leaf or has tagged children): actual progress
+      relevant_ids_set = relevant_ids.to_set
+      leaf_values = relevant_creatives.to_h do |c|
+        progress_value = if c.children.any? && c.children.none? { |child| relevant_ids_set.include?(child.id) }
+                          1.0  # Tagged parent with untagged children is treated as complete
+        else
+                          c.progress.to_f  # Leaf node or has tagged children uses actual progress
+        end
+        [ c.id, progress_value ]
+      end
 
-      leaf_values = relevant_creatives.to_h { |c| [ c.id, c.progress.to_f ] }
+      # Calculate overall average from tag-aware values
+      total_progress = leaf_values.values.sum
+      overall_average = leaf_values.any? ? total_progress / leaf_values.size : 0.0
 
       # 2. For each allowed_id, find its relevant descendants using batch query
       relationships = CreativeHierarchy

--- a/app/services/creatives/index_query.rb
+++ b/app/services/creatives/index_query.rb
@@ -118,14 +118,14 @@ module Creatives
       parent = params[:id] ? Creative.find(params[:id]) : nil
 
       # Calculate Progress Map
-      # "Leaf-most" logic: efficiently find matched nodes that are ancestors of OTHER matched nodes.
+      # "Leaf-most" logic: find nodes in allowed_ids that are ancestors of OTHER nodes in allowed_ids
       superfluous_ancestors = CreativeHierarchy
-                                .where(ancestor_id: matched_ids, descendant_id: matched_ids)
+                                .where(ancestor_id: allowed_ids, descendant_id: allowed_ids)
                                 .where("generations > 0")
                                 .pluck(:ancestor_id)
                                 .uniq
 
-      relevant_ids = matched_ids - superfluous_ancestors
+      relevant_ids = allowed_ids - superfluous_ancestors
 
       progress_map, filtered_progress = calculate_progress_map(accessible_creatives, allowed_ids, relevant_ids)
 

--- a/app/services/creatives/index_query.rb
+++ b/app/services/creatives/index_query.rb
@@ -111,17 +111,16 @@ module Creatives
         parent.children.where(id: allowed_ids)
       else
         # Find top-most nodes from allowed_ids efficiently using CreativeHierarchy
-        # These are nodes whose parent is either nil or not in allowed_ids
-        top_node_ids = CreativeHierarchy
-                         .where(descendant_id: allowed_ids, generations: 1)
-                         .where.not(ancestor_id: allowed_ids)
-                         .pluck(:descendant_id)
-                         .uniq
+        # These are nodes in allowed_ids that are NOT descendants of other nodes in allowed_ids
+        nodes_with_parents_in_set = CreativeHierarchy
+                                      .where(ancestor_id: allowed_ids, descendant_id: allowed_ids)
+                                      .where("generations > 0")
+                                      .pluck(:descendant_id)
+                                      .uniq
 
-        # Also include true roots (parent_id is nil) that are in allowed_ids
-        root_ids = Creative.where(id: allowed_ids, parent_id: nil).pluck(:id)
+        top_node_ids = allowed_ids - nodes_with_parents_in_set
 
-        Creative.where(id: (top_node_ids + root_ids).uniq)
+        Creative.where(id: top_node_ids)
       end
 
       # Final permission check on start_nodes

--- a/app/services/creatives/tree_builder.rb
+++ b/app/services/creatives/tree_builder.rb
@@ -32,8 +32,8 @@ module Creatives
     end
 
     def build_nodes_for_creative(creative, level:)
-      if progress_map && (p = progress_map[creative.id.to_s])
-        creative.filtered_progress = p
+      if progress_map && progress_map.key?(creative.id.to_s)
+        creative.filtered_progress = progress_map[creative.id.to_s]
       end
 
       filtered_children = filtered_children_for(creative)

--- a/app/services/creatives/tree_builder.rb
+++ b/app/services/creatives/tree_builder.rb
@@ -2,13 +2,15 @@ module Creatives
   class TreeBuilder
     FILTER_IGNORED_KEYS = %w[id controller action format level select_mode].freeze
 
-    def initialize(user:, params:, view_context:, expanded_state_map:, select_mode:, max_level:)
+    def initialize(user:, params:, view_context:, expanded_state_map:, select_mode:, max_level:, allowed_creative_ids: nil, progress_map: nil)
       @user = user
       @view_context = view_context
       @raw_params = params.respond_to?(:to_unsafe_h) ? params.to_unsafe_h : params.to_h
       @expanded_state_map = expanded_state_map || {}
       @select_mode = select_mode
       @max_level = max_level
+      @allowed_creative_ids = allowed_creative_ids
+      @progress_map = progress_map
     end
 
     def build(collection, level: 1)
@@ -19,7 +21,7 @@ module Creatives
 
     private
 
-    attr_reader :user, :view_context, :raw_params, :expanded_state_map, :select_mode, :max_level
+    attr_reader :user, :view_context, :raw_params, :expanded_state_map, :select_mode, :max_level, :allowed_creative_ids, :progress_map
 
     def build_nodes(creatives, level:)
       return [] if level > max_level
@@ -30,6 +32,10 @@ module Creatives
     end
 
     def build_nodes_for_creative(creative, level:)
+      if progress_map && (p = progress_map[creative.id.to_s])
+        creative.filtered_progress = p
+      end
+
       filtered_children = filtered_children_for(creative)
       expanded = expanded?(creative.id)
       skip = skip_creative?(creative)
@@ -67,6 +73,10 @@ module Creatives
     end
 
     def skip_creative?(creative)
+      if allowed_creative_ids
+        return !allowed_creative_ids.include?(creative.id.to_s)
+      end
+
       tags = Array(raw_params["tags"]).map(&:to_s)
       if tags.present?
         creative_label_ids = creative.tags.pluck(:label_id).map(&:to_s)
@@ -89,7 +99,12 @@ module Creatives
     def filtered_children_for(creative)
       return [] if raw_params["comment"] == "true" || raw_params["search"].present?
 
-      creative.children_with_permission(user)
+      children = creative.children_with_permission(user)
+      if allowed_creative_ids
+        children.select { |c| allowed_creative_ids.include?(c.id.to_s) }
+      else
+        children
+      end
     end
 
     def expanded?(creative_id)
@@ -98,6 +113,8 @@ module Creatives
 
     def filters_applied?
       @filters_applied ||= begin
+        return true if allowed_creative_ids.present?
+
         filtered = raw_params.except(*FILTER_IGNORED_KEYS)
         filtered.present?
       end

--- a/package-lock.json
+++ b/package-lock.json
@@ -128,6 +128,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -690,6 +691,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -733,6 +735,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1276,6 +1279,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.2.tgz",
       "integrity": "sha512-Ecx2ig/JLC9ayIQwZHqm41Tzlf4c1WUuFhFUZB1y+JIJqDRE579x7Uil7tKT8MwDpOPwrK5ZtpxdSsrfy/LF8Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/component": "0.7.0",
         "@firebase/logger": "0.5.0",
@@ -1342,6 +1346,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.2.tgz",
       "integrity": "sha512-cn+U27GDaBS/irsbvrfnPZdcCzeZPRGKieSlyb7vV6LSOL6mdECnB86PgYjYGxSNg8+U48L/NeevTV1odU+mOQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/app": "0.14.2",
         "@firebase/component": "0.7.0",
@@ -1357,7 +1362,8 @@
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
       "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@firebase/auth": {
       "version": "1.11.0",
@@ -1808,6 +1814,7 @@
       "integrity": "sha512-0AZUyYUfpMNcztR5l09izHwXkZpghLgCUaAGjtMwXnCg3bj4ml5VgiwqOMOxJ+Nw4qN/zJAaOQBcJ7KGkWStqQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -3690,6 +3697,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -4621,7 +4629,6 @@
       "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
       "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
@@ -5872,6 +5879,7 @@
       "integrity": "sha512-Pcfm3eZ+eO4JdZCXthW9tCDT3nF4K+9dmeZ+5X39n+Kqz0DDIABRP5CAEOHRFZk8RGuC2efksTJxrjp8EXCunQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.19",
         "@asamuzakjp/dom-selector": "^6.7.3",
@@ -5960,7 +5968,6 @@
       "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.114.tgz",
       "integrity": "sha512-gcxmNFzA4hv8UYi8j43uPlQ7CGcyMJ2KQb5kZASw6SnAKAf10hK12i2fjrS3Cl/ugZa5Ui6WwIu1/6MIXiHttQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "isomorphic.js": "^0.2.4"
       },
@@ -6559,6 +6566,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6568,6 +6576,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },

--- a/test/services/creatives/ancestor_filter_test.rb
+++ b/test/services/creatives/ancestor_filter_test.rb
@@ -1,0 +1,164 @@
+require "test_helper"
+
+module Creatives
+  class AncestorFilterTest < ActiveSupport::TestCase
+    class FakeViewContext
+      include Rails.application.routes.url_helpers
+      def embed_youtube_iframe(_content); ""; end
+      def render_creative_progress(_creative, select_mode: false); ""; end
+      def svg_tag(name, **args); ""; end
+      def link_to(_path, *args); block_given? ? yield : ""; end
+      def creative_path(creative); "/creatives/#{creative.id}"; end
+      def children_creative_path(creative, **args); "/children"; end
+    end
+
+    setup do
+      @user = users(:one)
+      @view_context = FakeViewContext.new
+
+      # Setup Tree
+      # A (Tag1) -> B -> C
+      # A -> B -> D (Tag1)
+      # X -> Y
+
+      @root_a = Creative.create!(user: @user, description: "A", sequence: 1)
+      @node_b = Creative.create!(user: @user, parent: @root_a, description: "B", sequence: 1)
+      @node_c = Creative.create!(user: @user, parent: @node_b, description: "C", sequence: 1)
+      @node_d = Creative.create!(user: @user, parent: @node_b, description: "D", sequence: 2)
+
+      @root_x = Creative.create!(user: @user, description: "X", sequence: 2)
+      @node_y = Creative.create!(user: @user, parent: @root_x, description: "Y", sequence: 1)
+
+      @tag_label = Label.create!(owner: @user, name: "Tag1")
+
+      Tag.create!(creative_id: @root_a.id, label: @tag_label)
+      Tag.create!(creative_id: @node_d.id, label: @tag_label)
+
+      # Ensure hierarchy is built (closure_tree should handle it)
+      @root_a.reload
+      @node_d.reload
+    end
+
+    test "IndexQuery calculates allowed_creative_ids including ancestors" do
+      params = { tags: [ @tag_label.id ] }
+      query = Creatives::IndexQuery.new(user: @user, params: params)
+      result = query.call
+
+      assert_not_nil result.allowed_creative_ids
+
+      allowed = result.allowed_creative_ids.map(&:to_s)
+
+      # A is tagged -> A is in allowed
+      assert_includes allowed, @root_a.id.to_s
+
+      # D is tagged. Ancestors of D are B, A.
+      # So B should be in allowed.
+      assert_includes allowed, @node_b.id.to_s
+      assert_includes allowed, @node_d.id.to_s
+
+      # C, X, Y should NOT be in allowed
+      refute_includes allowed, @node_c.id.to_s
+      refute_includes allowed, @root_x.id.to_s
+      refute_includes allowed, @node_y.id.to_s
+
+      # Result creatives should contain Root A
+      result_ids = result.creatives.pluck(:id).map(&:to_s)
+      assert_includes result_ids, @root_a.id.to_s
+      refute_includes result_ids, @root_x.id.to_s
+    end
+
+    test "TreeBuilder preserves structure for filtered nodes" do
+      # Simulate IndexQuery result
+      allowed_ids = [ @root_a.id, @node_b.id, @node_d.id ].map(&:to_s).to_set
+
+      builder = Creatives::TreeBuilder.new(
+        user: @user,
+        params: { tags: [ @tag_label.id ] },
+        view_context: @view_context,
+        expanded_state_map: {},
+        select_mode: false,
+        max_level: 10,
+        allowed_creative_ids: allowed_ids
+      )
+
+      # Start with roots filtered
+      roots = [ @root_a ] # IndexQuery would return this
+
+      nodes = builder.build(roots)
+
+      # A should be present
+      node_a = nodes.find { |n| n[:id] == @root_a.id }
+      assert_not_nil node_a
+
+      # Structure:
+      # A should have children loaded (because filters applied)
+      # Children of A in 'nodes' list?
+      # TreeBuilder returns flattened list if recursively built?
+      # Wait, TreeBuilder returns `[ {..., children_container: { nodes: [...] } } ]`?
+      # Let's check TreeBuilder implementation.
+      # `children_nodes = load_children_now ? build_nodes(...) : []`
+      # `children_container: ... nodes: children_nodes`
+      # So it nests children in `children_container[:nodes]`.
+
+      assert node_a[:children_container][:loaded], "Should be loaded"
+      children_a = node_a[:children_container][:nodes]
+
+      # B should be present in children of A
+      node_b = children_a.find { |n| n[:id] == @node_b.id }
+      assert_not_nil node_b
+
+      # Children of B
+      assert node_b[:children_container][:loaded], "B should be loaded"
+      children_b = node_b[:children_container][:nodes]
+
+      # D should be present
+      node_d = children_b.find { |n| n[:id] == @node_d.id }
+      assert_not_nil node_d
+
+      # C should NOT be present (skipped)
+      node_c = children_b.find { |n| n[:id] == @node_c.id }
+      assert_nil node_c
+    end
+
+    test "IndexQuery calculates filtered progress using leaf-most logic" do
+      # Setup for progress test
+      # A (Tag1, 50%) -> B (Tag1, 100%)
+      # X (Tag1, 10%)
+
+      @root_a.update!(progress: 0.5)
+      @node_b.update!(progress: 1.0) # Not tagged in setup, let's tag it
+      @root_x.update!(progress: 0.1)
+
+      tag_label2 = Label.create!(owner: @user, name: "Tag2")
+      Tag.create!(creative_id: @root_a.id, label: tag_label2)
+      Tag.create!(creative_id: @node_b.id, label: tag_label2)
+      Tag.create!(creative_id: @root_x.id, label: tag_label2)
+
+      # Tag2 Filter
+      # Matched: A, B, X.
+      # Hierarchy: A -> B.
+      # A is ancestor of B. So A is superfluous.
+      # Relevant: B (1.0), X (0.1).
+      # Average: (1.0 + 0.1) / 2 = 0.55
+
+      params = { tags: [ tag_label2.id ] }
+      query = Creatives::IndexQuery.new(user: @user, params: params)
+      result = query.call
+
+      assert_in_delta 0.55, result.overall_progress
+
+      # Verify Progress Map
+      # A: Average of leaf-descendants in relevant set.
+      # A's descendants in relevant set: B (1.0). (X is not descendant of A).
+      # So A should be 1.0. (Because A is superfluous, B is relevant).
+
+      # B: B is relevant. Progress 1.0.
+      # X: X is relevant. Progress 0.1.
+
+      map = result.progress_map
+      assert_in_delta 1.0, map[@root_a.id.to_s]
+      assert_in_delta 1.0, map[@node_b.id.to_s]
+      assert_in_delta 0.1, map[@root_x.id.to_s]
+    end
+  end
+end

--- a/test/services/creatives/ancestor_filter_test.rb
+++ b/test/services/creatives/ancestor_filter_test.rb
@@ -139,29 +139,29 @@ module Creatives
       # Hierarchy: A -> B.
       # A is ancestor of B. So A is superfluous.
       # Relevant (leaf-most): B, X.
-      # Tag-aware progress:
-      #   B has children (C, D) but none are tagged -> 1.0
-      #   X has children (Y) but none are tagged -> 1.0
-      # Average: (1.0 + 1.0) / 2 = 1.0
+      # Progress values:
+      #   B: 1.0 (stored progress)
+      #   X: 0.1 (stored progress)
+      # Average: (1.0 + 0.1) / 2 = 0.55
 
       params = { tags: [ tag_label2.id ] }
       query = Creatives::IndexQuery.new(user: @user, params: params)
       result = query.call
 
-      assert_in_delta 1.0, result.overall_progress
+      assert_in_delta 0.55, result.overall_progress
 
       # Verify Progress Map
       # A: Average of leaf-descendants in relevant set.
-      # A's descendants in relevant set: B (1.0 tag-aware). (X is not descendant of A)
+      # A's descendants in relevant set: B (1.0). (X is not descendant of A)
       # So A should be 1.0.
 
-      # B: B is relevant. Tag-aware progress 1.0 (has untagged children).
-      # X: X is relevant. Tag-aware progress 1.0 (has untagged children).
+      # B: B is relevant. Progress 1.0.
+      # X: X is relevant. Progress 0.1.
 
       map = result.progress_map
       assert_in_delta 1.0, map[@root_a.id.to_s]
       assert_in_delta 1.0, map[@node_b.id.to_s]
-      assert_in_delta 1.0, map[@root_x.id.to_s]
+      assert_in_delta 0.1, map[@root_x.id.to_s]
     end
   end
 end


### PR DESCRIPTION
- Implemented ancestor-based filtering in Creatives::IndexQuery:
  - Now matches tagged nodes and includes their full ancestor path.
  - Ensures tree structure integrity for filtered results.

- Optimized N+1 queries in progress calculation:
  - Introduced calculate_progress_map in IndexQuery to batch compute progress for all visible nodes.
  - Calculates 'leaf-most' relevant nodes to determine accurate progress for ancestors without recursive DB queries.
  - Propagates progress_map through Controller to TreeBuilder.
  - Added attr_accessor :filtered_progress to Creative model to store transient progress values.
  - Updated CreativesHelper to use filtered_progress when available.

- Added test/services/creatives/ancestor_filter_test.rb to verify filtering logic and progress calculation correctness.