### PR TITLE
Apply custom user themes to slide view layout

### DIFF
--- a/app/views/layouts/slide.html.erb
+++ b/app/views/layouts/slide.html.erb
@@ -9,6 +9,17 @@
     <%= stylesheet_link_tag 'slide_view', media: 'all' %>
     <%= javascript_include_tag 'actioncable', defer: true %>
     <%= javascript_include_tag 'slide_view', defer: true %>
+    <% if Current.user&.theme.present? && !%w[light dark].include?(Current.user.theme) %>
+      <% if (custom_theme = UserTheme.find_by(id: Current.user.theme)) %>
+        <style id="user-theme-styles" data-turbo-track="reload">
+          body {
+            <% custom_theme.variables.each do |key, value| %>
+              <%= key %>: <%= value %> !important;
+            <% end %>
+          }
+        </style>
+      <% end %>
+    <% end %>
   </head>
   <body class="<%= 'dark-mode' if Current.user&.theme == 'dark' %><%= ' light-mode' if Current.user&.theme == 'light' %>">
     <%= yield %>


### PR DESCRIPTION
## Summary
- inject custom user theme variables into the slide layout to mirror the main application styling
- ensure slide view respects light/dark mode classes while loading any saved user theme definitions

## Testing
- ./bin/rubocop -a
- bundle exec rails test
- bundle exec rails test:system (fails: Selenium could not obtain chromedriver in this environment)

## Original User's Requirements
- 슬라이드 뷰에도 사용자 테마가 적용되어야한다

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69539c0b80b4832697222793ddb7d2f5)