### PR TITLE
feat: add edit button to creative page title

### DIFF
--- a/app/javascript/components/creative_tree_row.js
+++ b/app/javascript/components/creative_tree_row.js
@@ -223,16 +223,20 @@ class CreativeTreeRow extends LitElement {
         data-parent-id=${this.parentId ?? nothing}
       >
         <div class="creative-row" style="background-color: transparent;" data-creatives--select-mode-target="row">
-          <h1 class="page-title" style="display:flex;align-items:center;gap:1em;">
-            <div class="creative-title-content">
-              ${unsafeHTML(this.descriptionHtml || "")}
-            </div>
-            ${this.originLinkHtml ? unsafeHTML(this.originLinkHtml) : nothing}
-          </h1>
-          <div>
-            <h1 style="display:flex;align-items:center;gap:1em;">
-              ${unsafeHTML(this.progressHtml || "")}
+          <div class="creative-row-start" style="align-items: center;">
+            ${this._renderActionButton()}
+            <div class="creative-toggle-btn" style="visibility: hidden; margin-top: 0;"></div>
+            <h1 class="page-title" style="margin-left: 0; margin-bottom: 0; display:flex; align-items:center; gap:1em;">
+              <div class="creative-title-content">
+                ${unsafeHTML(this.descriptionHtml || "")}
+              </div>
+              ${this.originLinkHtml ? unsafeHTML(this.originLinkHtml) : nothing}
             </h1>
+          </div>
+          <div class="creative-row-end">
+             <h1 class="page-title" style="margin: 0; display:flex; align-items:center;">
+               ${unsafeHTML(this.progressHtml || "")}
+             </h1>
           </div>
         </div>
       </div>

--- a/app/views/creatives/index.html.erb
+++ b/app/views/creatives/index.html.erb
@@ -103,13 +103,22 @@
       <% end %>
     <% end %>
   <% end %>
+  <%
+    title_row_content = safe_join(title_templates)
+    title_row_content += content_tag(:template, data: { part: "edit-icon" }) { svg_tag("edit.svg", class: "icon-edit") }
+    title_row_content += content_tag(:template, data: { part: "edit-off-icon" }) { svg_tag("edit-off.svg", class: "icon-edit") }
+  %>
   <%= content_tag(
         "creative-tree-row",
-        safe_join(title_templates),
+        title_row_content,
         "dom-id": "creative-markdown-block",
         "creative-id": @parent_creative.id,
         "parent-id": @parent_creative.parent_id,
-        "is-title": ""
+        "can-write": @parent_creative.has_permission?(Current.user, :write) ? "true" : "false",
+        "is-title": "",
+        "data-description-raw-html": @parent_creative.description,
+        "data-progress-value": @parent_creative.progress,
+        "data-origin-id": @parent_creative.origin_id
       ) %>
 <% else %>
   <%= content_tag(


### PR DESCRIPTION
- Integrated action button (edit button) into the title view of creative-tree-row component
- Added invisible toggle button spacer to title row for consistent horizontal text alignment with regular rows
- Updated index.html.erb to pass can-write permissions and creative data attributes for instant inline editor loading
- Reorganized title layout using creative-row-start container for better structure