### PR TITLE
feat(label): Automatically tag creative when label is created

### DIFF
--- a/app/models/label.rb
+++ b/app/models/label.rb
@@ -9,6 +9,8 @@ class Label < ApplicationRecord
   # STI: Plan, Version, etc subclasses use type column
   # creative_id, value, target_date etc attributes included
 
+  after_create :create_auto_tag
+
   # Check if user has permission to read this label
   # If linked to a Creative, delegates to Creative's permission system
   # Otherwise falls back to owner-based or public (nil owner) visibility
@@ -20,5 +22,13 @@ class Label < ApplicationRecord
     else
       owner_id.nil?
     end
+  end
+
+  private
+
+  def create_auto_tag
+    return unless creative_id.present?
+
+    tags.create!(creative_id: creative_id)
   end
 end

--- a/db/migrate/20251231010012_backfill_tags_for_labels.rb
+++ b/db/migrate/20251231010012_backfill_tags_for_labels.rb
@@ -1,0 +1,15 @@
+class BackfillTagsForLabels < ActiveRecord::Migration[8.1]
+  def up
+    Label.where.not(creative_id: nil).find_each do |label|
+      next if Tag.exists?(label_id: label.id, creative_id: label.creative_id)
+
+      Tag.create!(label_id: label.id, creative_id: label.creative_id)
+    end
+  end
+
+  def down
+    # No-op or potentially delete tags created by this migration
+    # Since tags might have been created manually later, it's safer to avoid bulk deletion
+    # unless we track which ones were created here.
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_12_30_113607) do
+ActiveRecord::Schema[8.1].define(version: 2025_12_31_010012) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false

--- a/test/models/label_test.rb
+++ b/test/models/label_test.rb
@@ -29,4 +29,12 @@ class LabelTest < ActiveSupport::TestCase
 
     refute label.readable_by?(user), "User with no_access should not be able to read label"
   end
+
+  test "creating a label with creative_id automatically creates a Tag" do
+    creative = creatives(:tshirt)
+    label = Label.create!(creative: creative, owner: users(:one))
+
+    assert_instance_of Tag, label.tags.first
+    assert_equal creative.id, label.tags.first.creative_id
+  end
 end


### PR DESCRIPTION
- Added after_create callback to Label model to create a Tag record
- Added data migration to backfill tags for existing labels with creative_id
- Added unit test to verify auto-tagging logic