### PR TITLE
feat: Implement Admin Settings page and Help Link configuration

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -1,0 +1,21 @@
+module Admin
+  class SettingsController < ApplicationController
+    before_action :require_system_admin!
+
+    def index
+      @help_link = SystemSetting.find_by(key: "help_menu_link")&.value
+    end
+
+    def update
+      setting = SystemSetting.find_or_initialize_by(key: "help_menu_link")
+      setting.value = params[:help_link].to_s.strip
+
+      if setting.save
+        redirect_to admin_path, notice: t("admin.settings.updated")
+      else
+        @help_link = params[:help_link]
+        render :index, status: :unprocessable_entity
+      end
+    end
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -42,6 +42,6 @@ class ApplicationController < ActionController::Base
   def require_system_admin!
     return if Current.user&.system_admin?
 
-    redirect_to root_path, alert: t("users.admin_required")
+    render file: "public/404.html", status: :not_found, layout: false
   end
 end

--- a/app/models/system_setting.rb
+++ b/app/models/system_setting.rb
@@ -1,0 +1,7 @@
+class SystemSetting < ApplicationRecord
+  validates :key, presence: true, uniqueness: true
+
+  def self.help_menu_link
+    find_by(key: "help_menu_link")&.value
+  end
+end

--- a/app/views/admin/settings/index.html.erb
+++ b/app/views/admin/settings/index.html.erb
@@ -1,0 +1,24 @@
+<h1 class="no-top-margin"><%= t('admin.title') %></h1>
+
+<div data-controller="tabs" data-tabs-active-tab-value="system">
+  <div class="tab-list">
+    <button class="tab-button active" data-action="click->tabs#switch" data-tabs-tab-param="system" data-tabs-target="tabButton">
+      <%= t('admin.tabs.system') %>
+    </button>
+  </div>
+
+  <div class="tab-panels">
+    <section class="tab-panel active" data-tabs-target="panel" data-tab-name="system">
+      <%= form_with url: admin_settings_path, method: :patch, local: true, html: { class: 'profile-form' } do |f| %>
+        <div>
+          <%= f.label :help_link, t('admin.settings.help_link') %>
+          <%= f.text_field :help_link, value: @help_link, placeholder: "https://..." %>
+          <div class="help-text" style="font-size: 0.85em; color: var(--color-text-muted); margin-top: 0.25em;">
+            <%= t('admin.settings.help_link_hint') %>
+          </div>
+        </div>
+        <%= f.submit t('admin.settings.save') %>
+      <% end %>
+    </section>
+  </div>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -98,7 +98,7 @@
           </form>
         <% end %>
         <%= button_to t('app.sign_in'), main_app.new_session_path, method: :get unless authenticated? %>
-        <%= button_tag "?", id: "creative-guide-link", class: "creative-guide-link" %>
+        <%= button_tag "?", id: "creative-guide-link", class: "creative-guide-link", data: { help_url: SystemSetting.help_menu_link } %>
       </div>
 
       <%= render PopupMenuComponent.new(
@@ -138,7 +138,7 @@
           </div>
         <% end %>
         <div><%= button_to t('app.sign_in'), main_app.new_session_path, method: :get unless authenticated? %></div>
-        <div><%= button_tag "?", id: "creative-guide-link", class: "creative-guide-link" %></div>
+        <div><%= button_tag "?", id: "creative-guide-link", class: "creative-guide-link", data: { help_url: SystemSetting.help_menu_link } %></div>
       <% end %>
 
       <% if Current.user %>
@@ -440,6 +440,10 @@
         if (links.length && popover && close) {
           links.forEach(function(link) {
             link.addEventListener('click', function(e) {
+              if (link.dataset.helpUrl) {
+                window.location.href = link.dataset.helpUrl;
+                return;
+              }
               e.preventDefault();
               popover.style.display = 'block';
             });

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -116,6 +116,10 @@
         <%= link_to t('users.change_password'), edit_password_user_path %>
         <br>
         <%= link_to t('users.webauthn.manage'), passkeys_user_path(@user) %>
+        <% if @user.system_admin? %>
+          <br>
+          <%= link_to t('admin.title'), admin_path %>
+        <% end %>
       </div>
 
 

--- a/config/locales/admin.en.yml
+++ b/config/locales/admin.en.yml
@@ -1,0 +1,10 @@
+en:
+  admin:
+    title: "Admin Settings"
+    tabs:
+      system: "System"
+    settings:
+      help_link: "Help Menu Link URL"
+      help_link_hint: "If set, the \"?\" menu in the top navigation will link to this URL."
+      updated: "Settings updated successfully."
+      save: "Save Settings"

--- a/config/locales/admin.ko.yml
+++ b/config/locales/admin.ko.yml
@@ -1,0 +1,10 @@
+ko:
+  admin:
+    title: "관리자 설정"
+    tabs:
+      system: "시스템"
+    settings:
+      help_link: "도움말 메뉴 링크 URL"
+      help_link_hint: "설정 시 상단 내비게이션의 \"?\" 메뉴가 이 URL로 연결됩니다."
+      updated: "설정이 성공적으로 업데이트되었습니다."
+      save: "설정 저장"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,6 +48,11 @@ Rails.application.routes.draw do
     end
   end
 
+  get "/admin", to: "admin/settings#index"
+  namespace :admin do
+    resource :settings, only: [ :update ]
+  end
+
   resources :creatives do
     resource :github_integration, only: [ :show, :update, :destroy ], module: :creatives
     resource :notion_integration, only: [ :show, :update, :destroy ], module: :creatives

--- a/db/migrate/20260106160643_create_system_settings.rb
+++ b/db/migrate/20260106160643_create_system_settings.rb
@@ -1,0 +1,11 @@
+class CreateSystemSettings < ActiveRecord::Migration[8.1]
+  def change
+    create_table :system_settings do |t|
+      t.string :key
+      t.text :value
+
+      t.timestamps
+    end
+    add_index :system_settings, :key, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_01_06_090544) do
+ActiveRecord::Schema[8.1].define(version: 2026_01_06_160643) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false
@@ -60,6 +60,33 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_06_090544) do
     t.index ["created_at"], name: "index_activity_logs_on_created_at"
     t.index ["creative_id"], name: "index_activity_logs_on_creative_id"
     t.index ["user_id"], name: "index_activity_logs_on_user_id"
+  end
+
+  create_table "agent_actions", force: :cascade do |t|
+    t.integer "agent_run_id", null: false
+    t.json "arguments", default: {}
+    t.datetime "created_at", null: false
+    t.text "result"
+    t.string "status", default: "pending"
+    t.string "tool_name"
+    t.datetime "updated_at", null: false
+    t.index ["agent_run_id"], name: "index_agent_actions_on_agent_run_id"
+  end
+
+  create_table "agent_runs", force: :cascade do |t|
+    t.integer "ai_user_id", null: false
+    t.json "context", default: {}
+    t.datetime "created_at", null: false
+    t.integer "creative_id", null: false
+    t.text "goal"
+    t.integer "iteration_count", default: 0
+    t.datetime "next_run_at"
+    t.string "state", default: "planning"
+    t.string "status", default: "pending"
+    t.json "transcript", default: []
+    t.datetime "updated_at", null: false
+    t.index ["ai_user_id"], name: "index_agent_runs_on_ai_user_id"
+    t.index ["creative_id"], name: "index_agent_runs_on_creative_id"
   end
 
   create_table "calendar_events", force: :cascade do |t|
@@ -170,7 +197,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_06_090544) do
     t.float "progress", default: 0.0
     t.integer "sequence", default: 0, null: false
     t.datetime "updated_at", null: false
-    t.integer "user_id"
+    t.integer "user_id", null: false
     t.index ["origin_id"], name: "index_creatives_on_origin_id"
     t.index ["parent_id"], name: "index_creatives_on_parent_id"
     t.index ["user_id"], name: "index_creatives_on_user_id"
@@ -524,6 +551,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_06_090544) do
     t.index ["key"], name: "index_solid_queue_semaphores_on_key", unique: true
   end
 
+  create_table "system_settings", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "key"
+    t.datetime "updated_at", null: false
+    t.text "value"
+    t.index ["key"], name: "index_system_settings_on_key", unique: true
+  end
+
   create_table "tags", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.integer "creative_id", null: false
@@ -643,7 +678,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_06_090544) do
   add_foreign_key "creative_expanded_states", "users"
   add_foreign_key "creative_shares", "creatives"
   add_foreign_key "creative_shares", "users"
-  add_foreign_key "creative_shares", "users", column: "shared_by_id", on_delete: :nullify
+  add_foreign_key "creative_shares", "users", column: "shared_by_id"
   add_foreign_key "creatives", "creatives", column: "origin_id"
   add_foreign_key "creatives", "creatives", column: "parent_id"
   add_foreign_key "creatives", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -62,33 +62,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_06_160643) do
     t.index ["user_id"], name: "index_activity_logs_on_user_id"
   end
 
-  create_table "agent_actions", force: :cascade do |t|
-    t.integer "agent_run_id", null: false
-    t.json "arguments", default: {}
-    t.datetime "created_at", null: false
-    t.text "result"
-    t.string "status", default: "pending"
-    t.string "tool_name"
-    t.datetime "updated_at", null: false
-    t.index ["agent_run_id"], name: "index_agent_actions_on_agent_run_id"
-  end
-
-  create_table "agent_runs", force: :cascade do |t|
-    t.integer "ai_user_id", null: false
-    t.json "context", default: {}
-    t.datetime "created_at", null: false
-    t.integer "creative_id", null: false
-    t.text "goal"
-    t.integer "iteration_count", default: 0
-    t.datetime "next_run_at"
-    t.string "state", default: "planning"
-    t.string "status", default: "pending"
-    t.json "transcript", default: []
-    t.datetime "updated_at", null: false
-    t.index ["ai_user_id"], name: "index_agent_runs_on_ai_user_id"
-    t.index ["creative_id"], name: "index_agent_runs_on_creative_id"
-  end
-
   create_table "calendar_events", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.integer "creative_id"

--- a/test/controllers/admin/settings_controller_test.rb
+++ b/test/controllers/admin/settings_controller_test.rb
@@ -13,10 +13,10 @@ class AdminSettingsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test "should redirect if not admin" do
+  test "should return 404 if not admin" do
     sign_in_as(@user, password: "password")
     get admin_path
-    assert_redirected_to root_path
+    assert_response :not_found
   end
 
   test "should update settings" do

--- a/test/controllers/admin/settings_controller_test.rb
+++ b/test/controllers/admin/settings_controller_test.rb
@@ -1,0 +1,28 @@
+require "test_helper"
+require_relative "../../../app/controllers/admin/settings_controller"
+
+class AdminSettingsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @admin = users(:one)
+    @user = users(:two)
+  end
+
+  test "should get index if admin" do
+    sign_in_as(@admin, password: "password")
+    get admin_path
+    assert_response :success
+  end
+
+  test "should redirect if not admin" do
+    sign_in_as(@user, password: "password")
+    get admin_path
+    assert_redirected_to root_path
+  end
+
+  test "should update settings" do
+    sign_in_as(@admin, password: "password")
+    patch admin_settings_path, params: { help_link: "https://new.example.com" }
+    assert_redirected_to admin_path
+    assert_equal "https://new.example.com", SystemSetting.help_menu_link
+  end
+end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -10,9 +10,8 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     sign_in_as(@regular_user, password: "password")
 
     get users_path
-    assert_redirected_to root_path
-    follow_redirect!
-    assert_equal I18n.t("users.admin_required"), flash[:alert]
+    get users_path
+    assert_response :not_found
   end
 
   test "system admin can access user index" do
@@ -28,7 +27,9 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
 
     patch grant_system_admin_user_path(@regular_user)
 
-    assert_redirected_to root_path
+    patch grant_system_admin_user_path(@regular_user)
+
+    assert_response :not_found
     assert_not @regular_user.reload.system_admin?
   end
 
@@ -37,7 +38,9 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
 
     patch revoke_system_admin_user_path(@admin)
 
-    assert_redirected_to root_path
+    patch revoke_system_admin_user_path(@admin)
+
+    assert_response :not_found
     assert @admin.reload.system_admin?
   end
 

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -441,4 +441,17 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     get passkeys_user_path(@regular_user)
     assert_response :success
   end
+  test "admin link appears in profile for system admin" do
+    sign_in_as(@admin, password: "password")
+    get user_path(@admin)
+    assert_response :success
+    assert_select "a[href=?]", admin_path
+  end
+
+  test "admin link does not appear in profile for regular user" do
+    sign_in_as(@regular_user, password: "password")
+    get user_path(@regular_user)
+    assert_response :success
+    assert_select "a[href=?]", admin_path, count: 0
+  end
 end

--- a/test/fixtures/system_settings.yml
+++ b/test/fixtures/system_settings.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  key: help_menu_link
+  value: https://example.com/one
+
+two:
+  key: another_link
+  value: https://example.com/two

--- a/test/models/creative_security_test.rb
+++ b/test/models/creative_security_test.rb
@@ -1,9 +1,13 @@
 require "test_helper"
 
 class CreativeSecurityTest < ActiveSupport::TestCase
+  setup do
+    @user = users(:one)
+  end
+
   test "sanitizes description by removing script tags on save" do
     malicious_html = "Hello <script>alert('xss')</script> world"
-    creative = Creative.create!(description: malicious_html, sequence: 0)
+    creative = Creative.create!(user: @user, description: malicious_html, sequence: 0)
 
     # Should strip script tags but keep text
     assert_equal "Hello alert('xss') world", creative.description.strip
@@ -11,7 +15,7 @@ class CreativeSecurityTest < ActiveSupport::TestCase
 
   test "sanitizes description by removing event handlers" do
     malicious_html = "<div onclick='alert(1)'>Click me</div>"
-    creative = Creative.create!(description: malicious_html, sequence: 0)
+    creative = Creative.create!(user: @user, description: malicious_html, sequence: 0)
 
     # Should remove onclick attribute
     assert_no_match(/onclick/, creative.description)
@@ -20,7 +24,7 @@ class CreativeSecurityTest < ActiveSupport::TestCase
 
   test "allows safe html tags" do
     safe_html = "<b>Bold</b> and <i>Italic</i>"
-    creative = Creative.create!(description: safe_html, sequence: 0)
+    creative = Creative.create!(user: @user, description: safe_html, sequence: 0)
 
     assert_equal safe_html, creative.description
   end

--- a/test/models/system_setting_test.rb
+++ b/test/models/system_setting_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class SystemSettingTest < ActiveSupport::TestCase
+  test "help_menu_link helper" do
+    assert_equal "https://example.com/one", SystemSetting.help_menu_link
+
+    SystemSetting.destroy_all
+    assert_nil SystemSetting.help_menu_link
+
+    SystemSetting.create!(key: "help_menu_link", value: "https://new.example.com")
+    assert_equal "https://new.example.com", SystemSetting.help_menu_link
+  end
+end


### PR DESCRIPTION
- Create SystemSetting model for global configurations
- Add Admin::SettingsController to manage system settings
- Implement Help Menu Link configuration in Admin Settings
- Update '?' menu to redirect to configured help URL
- Add Admin Settings link to User Profile for system admins
- Add localization for Admin interface (en, ko)
- Add tests for SystemSetting and Admin Controllers