### PR TITLE
Match mobile creative menu permissions

### DIFF
--- a/app/views/creatives/_mobile_actions_menu.html.erb
+++ b/app/views/creatives/_mobile_actions_menu.html.erb
@@ -16,7 +16,9 @@
     <% if @parent_creative.present? %>
       <%= button_to t('creatives.index.slide_view'), slide_view_creative_path(@parent_creative), method: :get, class: 'popup-menu-item' %>
     <% end %>
-    <button type="button" class="popup-menu-item" data-controller="click-target" data-click-target-id-value="import-markdown-btn" data-action="click->click-target#trigger"><%= t('creatives.index.import_markdown') %></button>
+    <% if authenticated? && (!params[:id] || (current_creative && current_creative.has_permission?(Current.user, :write))) %>
+      <button type="button" class="popup-menu-item" data-controller="click-target" data-click-target-id-value="import-markdown-btn" data-action="click->click-target#trigger"><%= t('creatives.index.import_markdown') %></button>
+    <% end %>
     <button type="button" class="popup-menu-item" data-controller="click-target" data-click-target-id-value="export-markdown-btn" data-action="click->click-target#trigger"><%= t('creatives.index.export_markdown') %></button>
   <% end %>
 </div>


### PR DESCRIPTION
### Motivation
- Ensure the mobile creative actions menu enforces the same permission rules as the desktop menu so actions visible only to authorized users remain consistent across devices.
- The `import_markdown` action was visible on mobile even when the user did not have write permission on the current creative, causing a permissions mismatch.

### Description
- Added a permission guard around the mobile `import_markdown` button so it is only rendered when the user is authenticated and has the same `:write` access (or when not viewing a specific creative id) as on desktop.
- Change was made in `app/views/creatives/_mobile_actions_menu.html.erb` to wrap the import button with `if authenticated? && (!params[:id] || (current_creative && current_creative.has_permission?(Current.user, :write)))`.

### Testing
- Ran `./bin/rubocop -a`, which could not run in this environment due to missing Ruby (`/usr/bin/env: 'ruby': No such file or directory`).
- Ran `rails test` and `rails test:system`, both of which could not run here because the `rails` command was not available.
- Verified the view change by inspecting the updated file and committing the change; no automated test results available in this environment.

### Original User's Requirements
- 모바일 화면에서도 크리에이티브 페이지의 메뉴중 권한을 pc 화면과 동일하게 적용해야한다

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f7e807b1c83268daa571fe12914ac)