### PR TITLE
Use shared `--max-width` variable for plans panel

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -264,8 +264,10 @@ button {
 }
 
 #plans-list-area {
-    max-width: 960px;
+    max-width: var(--max-width);
+    width: min(100%, var(--max-width));
     margin: 0.5em auto;
+    box-sizing: border-box;
 }
 
 #plans-list-area hr {
@@ -314,10 +316,12 @@ button {
     overflow-x: auto;
     position: relative;
     padding-bottom: 1em;
+    width: 100%;
 }
 
 .plans-timeline-wrapper {
     position: relative;
+    width: 100%;
 }
 
 .plans-timeline-wrapper #timeline-today-btn {


### PR DESCRIPTION
### Motivation
- Prevent the plans panel from exceeding the device viewport width on mobile by making its sizing follow the app-wide maximum width variable. 
- Address reviewer feedback to avoid hard-coded `960px` in CSS and keep sizing consistent with other components.

### Description
- Replace the hard-coded `960px` with the shared `var(--max-width)` for `#plans-list-area` and set `width: min(100%, var(--max-width))` to cap its width responsively. 
- Ensure `#plans-list-area` uses `box-sizing: border-box` so paddings and borders are included in the width calculation. 
- Keep existing fixes that prevent horizontal overflow by using `width: 100%` on `.horizontal-timeline` and `.plans-timeline-wrapper`.

### Testing
- Ran `./bin/rubocop -a`, which failed because Ruby is not available in this environment. 
- Ran `rails test`, which failed because the `rails` command is not available in this environment. 
- Ran `rails test:system`, which also failed because the `rails` command is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e252a69788326b90eab2954977172)