### PR TITLE
Add fullscreen comments chat view

### DIFF
--- a/app/assets/images/exit-fullscreen.svg
+++ b/app/assets/images/exit-fullscreen.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+  <path d="M5 8h2V6H5V4H3v4h2zm12 0h2V4h-2v2h-2v2h2zm-12 8H3v4h2v-2h2v-2H5zm14 0h-2v2h-2v2h4v-4z"/>
+</svg>

--- a/app/assets/images/fullscreen.svg
+++ b/app/assets/images/fullscreen.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+  <path d="M7 3H3v4h2V5h2V3zm14 0h-4v2h2v2h2V3zM5 17H3v4h4v-2H5v-2zm16 0h-2v2h-2v2h4v-4z"/>
+</svg>

--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -13,21 +13,44 @@
     max-width: calc(100vw - 0.5em) !important;
 }
 
-#comments-popup[data-fullscreen="true"] {
-    position: fixed;
-    inset: 0;
-    width: 100%;
-    height: 100vh;
-    max-width: none !important;
-    max-height: none;
-    border-radius: 0;
-    box-shadow: none;
-}
-
 body.chat-fullscreen {
     margin: 0;
+    padding: 0;
     height: 100vh;
     overflow: hidden;
+}
+
+body.chat-fullscreen main {
+    height: 100vh;
+    width: 100vw;
+    max-width: none;
+    padding: 0;
+    margin: 0;
+    box-sizing: border-box;
+}
+
+.comments-fullscreen-page {
+    height: 100vh;
+    width: 100vw;
+    padding: 0;
+    margin: 0;
+    box-sizing: border-box;
+}
+
+.comments-fullscreen-page #comments-popup,
+#comments-popup[data-fullscreen="true"] {
+    display: flex !important;
+    position: static;
+    width: 100%;
+    height: 100%;
+    max-width: none !important;
+    max-height: none !important;
+    border-radius: 0;
+    box-shadow: none;
+    border: none;
+    z-index: auto;
+    box-sizing: border-box;
+    padding: 1em;
 }
 
 .comments-popup-header {
@@ -561,10 +584,16 @@ body.chat-fullscreen {
         transform: translateY(0);
     }
 
+    .comments-fullscreen-page #comments-popup,
     #comments-popup[data-fullscreen="true"] {
+        display: flex !important;
         transform: none;
         border-radius: 0;
         padding: 1em;
+        position: static;
+        width: 100%;
+        height: 100%;
+        box-sizing: border-box;
     }
 }
 

--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -13,6 +13,55 @@
     max-width: calc(100vw - 0.5em) !important;
 }
 
+#comments-popup[data-fullscreen="true"] {
+    position: fixed;
+    inset: 0;
+    width: 100%;
+    height: 100vh;
+    max-width: none !important;
+    max-height: none;
+    border-radius: 0;
+    box-shadow: none;
+}
+
+body.chat-fullscreen {
+    margin: 0;
+    height: 100vh;
+    overflow: hidden;
+}
+
+.comments-popup-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75em;
+}
+
+.comments-popup-actions {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4em;
+}
+
+.comments-popup-action {
+    background: none;
+    border: none;
+    color: var(--color-text);
+    cursor: pointer;
+    padding: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.2em;
+    line-height: 1;
+}
+
+.comments-popup-action-icon {
+    width: 16px;
+    height: 16px;
+    fill: currentColor;
+}
+
 #comments-popup .resize-handle {
     position: absolute;
     width: 10px;
@@ -510,6 +559,12 @@
 
     #comments-popup.open {
         transform: translateY(0);
+    }
+
+    #comments-popup[data-fullscreen="true"] {
+        transform: none;
+        border-radius: 0;
+        padding: 1em;
     }
 }
 

--- a/engines/collavre/app/controllers/collavre/comments_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comments_controller.rb
@@ -1,7 +1,12 @@
 module Collavre
   class CommentsController < ApplicationController
+    layout "collavre/chat", only: [ :fullscreen ]
     before_action :set_creative
     before_action :set_comment, only: [ :destroy, :show, :update, :convert, :approve, :update_action ]
+
+    def fullscreen
+      @creative_snippet = @creative.creative_snippet
+    end
 
     def index
       limit = 20

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/popup_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/popup_controller.test.js
@@ -14,9 +14,10 @@ describe('CommentsPopupController', () => {
     beforeEach(() => {
         container = document.createElement('div')
         container.innerHTML = `
-      <div id="comments-popup" data-controller="comments--popup" style="width: 300px; height: 400px; position: absolute;">
+      <div id="comments-popup" data-controller="comments--popup" data-fullscreen-url-template="/creatives/__CREATIVE_ID__/comments/fullscreen" style="width: 300px; height: 400px; position: absolute;">
         <h3 data-comments--popup-target="title">Title</h3>
         <div data-comments--popup-target="list">List</div>
+        <a data-comments--popup-target="fullscreenLink" href="#"></a>
         <button data-comments--popup-target="closeButton">Close</button>
         <div data-comments--popup-target="leftHandle"></div>
         <div data-comments--popup-target="rightHandle"></div>

--- a/engines/collavre/app/javascript/controllers/comments/popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_controller.js
@@ -139,24 +139,7 @@ export default class extends Controller {
     this.updatePosition()
     document.body.classList.add('no-scroll')
 
-    // Load topics first to establish context
-    if (this.topicsController) {
-      await this.topicsController.onPopupOpened({ creativeId: resolvedCreativeId })
-    }
-
-    if (this.formController) {
-      this.formController.onPopupOpened({ creativeId: resolvedCreativeId, canComment })
-    }
-    if (this.listController) {
-      const topicId = this.topicsController ? this.topicsController.currentTopicId : undefined
-      this.listController.onPopupOpened({ creativeId: resolvedCreativeId, highlightId, topicId })
-    }
-    if (this.presenceController) {
-      this.presenceController.onPopupOpened({ creativeId: resolvedCreativeId })
-    }
-    if (this.mentionMenuController) {
-      this.mentionMenuController.onPopupOpened({ creativeId: resolvedCreativeId })
-    }
+    await this.notifyChildControllers({ creativeId: resolvedCreativeId, canComment, highlightId })
   }
 
   async openForCreative() {
@@ -173,23 +156,27 @@ export default class extends Controller {
 
     this.showPopup()
 
+    await this.notifyChildControllers({ creativeId: resolvedCreativeId, canComment })
+  }
+
+  async notifyChildControllers({ creativeId, canComment, highlightId }) {
     // Load topics first to establish context
     if (this.topicsController) {
-      await this.topicsController.onPopupOpened({ creativeId: resolvedCreativeId })
+      await this.topicsController.onPopupOpened({ creativeId })
     }
 
     if (this.formController) {
-      this.formController.onPopupOpened({ creativeId: resolvedCreativeId, canComment })
+      this.formController.onPopupOpened({ creativeId, canComment })
     }
     if (this.listController) {
       const topicId = this.topicsController ? this.topicsController.currentTopicId : undefined
-      this.listController.onPopupOpened({ creativeId: resolvedCreativeId, topicId })
+      this.listController.onPopupOpened({ creativeId, highlightId, topicId })
     }
     if (this.presenceController) {
-      this.presenceController.onPopupOpened({ creativeId: resolvedCreativeId })
+      this.presenceController.onPopupOpened({ creativeId })
     }
     if (this.mentionMenuController) {
-      this.mentionMenuController.onPopupOpened({ creativeId: resolvedCreativeId })
+      this.mentionMenuController.onPopupOpened({ creativeId })
     }
   }
 
@@ -239,11 +226,9 @@ export default class extends Controller {
 
 
   showPopup() {
+    this.element.style.display = 'flex'
     if (this.isMobile()) {
-      this.element.style.display = 'flex'
       this.element.classList.add('open')
-    } else {
-      this.element.style.display = 'flex'
     }
   }
 

--- a/engines/collavre/app/javascript/controllers/comments/popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_controller.js
@@ -37,16 +37,24 @@ export default class extends Controller {
     window.addEventListener('focus', this.handleWindowFocus)
     document.addEventListener('visibilitychange', this.handleVisibilityChange)
 
-    this.closeButtonTarget?.addEventListener('click', () => this.close())
-    this.leftHandleTarget?.addEventListener('mousedown', (event) => this.startResize(event, 'left'))
-    this.rightHandleTarget?.addEventListener('mousedown', (event) => this.startResize(event, 'right'))
+    if (this.hasCloseButtonTarget) {
+      this.closeButtonTarget.addEventListener('click', () => this.close())
+    }
+    if (this.hasLeftHandleTarget) {
+      this.leftHandleTarget.addEventListener('mousedown', (event) => this.startResize(event, 'left'))
+    }
+    if (this.hasRightHandleTarget) {
+      this.rightHandleTarget.addEventListener('mousedown', (event) => this.startResize(event, 'right'))
+    }
 
     if (this.isMobile()) {
       // Handle touch events directly on the close button to resolve issues on mobile where layout shifts (e.g., keyboard dismissal) cause click events to be lost or delayed.
       this.element.addEventListener('touchstart', this.handleTouchStart)
       this.element.addEventListener('touchend', this.handleTouchEnd)
-      this.closeButtonTarget?.addEventListener('touchstart', this.handleCloseButtonTouchStart, { passive: false })
-      this.closeButtonTarget?.addEventListener('touchend', this.handleCloseButtonTouchEnd)
+      if (this.hasCloseButtonTarget) {
+        this.closeButtonTarget.addEventListener('touchstart', this.handleCloseButtonTouchStart, { passive: false })
+        this.closeButtonTarget.addEventListener('touchend', this.handleCloseButtonTouchEnd)
+      }
     }
 
     document.querySelectorAll('form[action="/session"]').forEach((form) => {
@@ -54,7 +62,8 @@ export default class extends Controller {
     })
 
     if (this.isFullscreen()) {
-      this.openForCreative()
+      // Defer to ensure all sibling controllers are connected
+      requestAnimationFrame(() => this.openForCreative())
     } else {
       this.openFromUrl()
     }
@@ -71,8 +80,10 @@ export default class extends Controller {
     if (this.isMobile()) {
       this.element.removeEventListener('touchstart', this.handleTouchStart)
       this.element.removeEventListener('touchend', this.handleTouchEnd)
-      this.closeButtonTarget?.removeEventListener('touchstart', this.handleCloseButtonTouchStart)
-      this.closeButtonTarget?.removeEventListener('touchend', this.handleCloseButtonTouchEnd)
+      if (this.hasCloseButtonTarget) {
+        this.closeButtonTarget.removeEventListener('touchstart', this.handleCloseButtonTouchStart)
+        this.closeButtonTarget.removeEventListener('touchend', this.handleCloseButtonTouchEnd)
+      }
     }
   }
 
@@ -375,6 +386,7 @@ export default class extends Controller {
 
   openFromUrl() {
     const params = new URLSearchParams(window.location.search)
+    const openComments = params.get('open_comments') === 'true'
     let commentId = params.get('comment_id')
     if (!commentId) {
       const pathCommentMatch = window.location.pathname.match(/\/creatives\/\d+\/comments\/(\d+)/)
@@ -397,13 +409,14 @@ export default class extends Controller {
       }
     }
 
-    if (!commentId || !creativeId) return
+    // Need either open_comments flag or comment_id, plus creativeId
+    if ((!commentId && !openComments) || !creativeId) return
     const selector = `[name="show-comments-btn"][data-creative-id="${creativeId}"]`
     const tryOpenWithButton = () => {
       const button = document.querySelector(selector)
       if (!button) return false
       this.clearPendingOpenFromUrl()
-      this.open(button, { highlightId: commentId })
+      this.open(button, { highlightId: commentId || undefined })
       return true
     }
 

--- a/engines/collavre/app/javascript/controllers/comments/popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_controller.js
@@ -11,6 +11,7 @@ export default class extends Controller {
     'closeButton',
     'leftHandle',
     'rightHandle',
+    'fullscreenLink',
   ]
 
   connect() {
@@ -52,7 +53,11 @@ export default class extends Controller {
       form.addEventListener('submit', () => window.localStorage.removeItem(SIZE_STORAGE_KEY))
     })
 
-    this.openFromUrl()
+    if (this.isFullscreen()) {
+      this.openForCreative()
+    } else {
+      this.openFromUrl()
+    }
   }
 
   disconnect() {
@@ -115,6 +120,8 @@ export default class extends Controller {
     this.element.dataset.canComment = canComment ? 'true' : 'false'
     this.titleTarget.textContent = snippet
 
+    this.updateFullscreenLink(resolvedCreativeId)
+
     this.prepareSize()
 
     this.showPopup()
@@ -132,6 +139,40 @@ export default class extends Controller {
     if (this.listController) {
       const topicId = this.topicsController ? this.topicsController.currentTopicId : undefined
       this.listController.onPopupOpened({ creativeId: resolvedCreativeId, highlightId, topicId })
+    }
+    if (this.presenceController) {
+      this.presenceController.onPopupOpened({ creativeId: resolvedCreativeId })
+    }
+    if (this.mentionMenuController) {
+      this.mentionMenuController.onPopupOpened({ creativeId: resolvedCreativeId })
+    }
+  }
+
+  async openForCreative() {
+    const resolvedCreativeId = this.element.dataset.creativeId
+    const canComment = this.element.dataset.canComment === 'true'
+    const snippet = this.element.dataset.creativeSnippet || ''
+
+    this.currentButton = null
+    this.element.dataset.creativeId = resolvedCreativeId || ''
+    this.element.dataset.canComment = canComment ? 'true' : 'false'
+    this.titleTarget.textContent = snippet
+
+    this.updateFullscreenLink(resolvedCreativeId)
+
+    this.showPopup()
+
+    // Load topics first to establish context
+    if (this.topicsController) {
+      await this.topicsController.onPopupOpened({ creativeId: resolvedCreativeId })
+    }
+
+    if (this.formController) {
+      this.formController.onPopupOpened({ creativeId: resolvedCreativeId, canComment })
+    }
+    if (this.listController) {
+      const topicId = this.topicsController ? this.topicsController.currentTopicId : undefined
+      this.listController.onPopupOpened({ creativeId: resolvedCreativeId, topicId })
     }
     if (this.presenceController) {
       this.presenceController.onPopupOpened({ creativeId: resolvedCreativeId })
@@ -195,12 +236,16 @@ export default class extends Controller {
     }
   }
 
+  isFullscreen() {
+    return this.element.dataset.fullscreen === 'true'
+  }
+
   isMobile() {
     return window.innerWidth <= 600
   }
 
   updatePosition() {
-    if (!this.currentButton || this.isMobile() || this.element.dataset.resized === 'true') return
+    if (this.isFullscreen() || !this.currentButton || this.isMobile() || this.element.dataset.resized === 'true') return
     const rect = this.currentButton.getBoundingClientRect()
     const scrollY = window.scrollY || window.pageYOffset
     let top = rect.bottom + scrollY + 4
@@ -319,6 +364,13 @@ export default class extends Controller {
     if (!document.hidden && this.element.style.display === 'flex') {
       this.listController?.loadInitialComments()
     }
+  }
+
+  updateFullscreenLink(creativeId) {
+    if (!this.hasFullscreenLinkTarget || !creativeId) return
+    const template = this.element.dataset.fullscreenUrlTemplate
+    if (!template) return
+    this.fullscreenLinkTarget.href = template.replace('__CREATIVE_ID__', creativeId)
   }
 
   openFromUrl() {

--- a/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
@@ -1,5 +1,12 @@
 
+<% fullscreen = local_assigns.fetch(:fullscreen, false) %>
+<% creative = local_assigns[:creative] %>
 <div id="comments-popup" data-controller="comments--popup comments--list comments--form comments--presence comments--mention-menu comments--topics" class="popup-box"
+     data-fullscreen="<%= fullscreen %>"
+     data-fullscreen-url-template="<%= collavre.fullscreen_creative_comments_path(creative_id: "__CREATIVE_ID__") %>"
+     <%= "data-creative-id=\"#{creative.id}\"" if fullscreen && creative.present? %>
+     <%= "data-creative-snippet=\"#{ERB::Util.html_escape(creative.creative_snippet)}\"" if fullscreen && creative.present? %>
+     <%= "data-can-comment=\"#{creative.has_permission?(Current.user, :feedback)}\"" if fullscreen && creative.present? %>
      data-loading-text="<%= t('app.loading') %>"
      data-delete-confirm-text="<%= t("collavre.comments.delete_confirm") %>"
      data-update-comment-text="<%= t('collavre.comments.update_comment') %>"
@@ -16,10 +23,24 @@
      data-voice-stop-text="<%= t('collavre.comments.voice_stop') %>"
      data-move-no-selection-text="<%= t('collavre.comments.move_no_selection') %>"
      data-move-error-text="<%= t('collavre.comments.move_error') %>">
-  <div class="resize-handle resize-handle-left" data-comments--popup-target="leftHandle"></div>
-  <div class="resize-handle resize-handle-right" data-comments--popup-target="rightHandle"></div>
-  <button id="close-comments-btn" data-comments--popup-target="closeButton" class="popup-close-btn">&times;</button>
-  <h3 id="comments-popup-title" data-comments--popup-target="title"><%= t('collavre.comments.comments') %></h3>
+  <% unless fullscreen %>
+    <div class="resize-handle resize-handle-left" data-comments--popup-target="leftHandle"></div>
+    <div class="resize-handle resize-handle-right" data-comments--popup-target="rightHandle"></div>
+  <% end %>
+  <div class="comments-popup-header">
+    <h3 id="comments-popup-title" data-comments--popup-target="title"><%= t('collavre.comments.comments') %></h3>
+    <% unless fullscreen %>
+      <div class="comments-popup-actions">
+        <%= link_to "#",
+                    class: "comments-popup-action comments-popup-fullscreen",
+                    data: { "comments--popup-target": "fullscreenLink" },
+                    aria: { label: t("collavre.comments.fullscreen", default: "Full screen") } do %>
+          <%= svg_tag "fullscreen.svg", class: "comments-popup-action-icon" %>
+        <% end %>
+        <button id="close-comments-btn" data-comments--popup-target="closeButton" class="comments-popup-action comments-popup-close" type="button">&times;</button>
+      </div>
+    <% end %>
+  </div>
   <div id="comment-participants" data-comments--presence-target="participants" data-comments--mention-menu-target="participants"></div>
   <div id="comment-topics" data-comments--topics-target="list" class="comment-topics-list"
        data-confirm-delete-text="<%= t('collavre.topics.delete_confirm') %>"

--- a/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
@@ -4,9 +4,11 @@
 <div id="comments-popup" data-controller="comments--popup comments--list comments--form comments--presence comments--mention-menu comments--topics" class="popup-box"
      data-fullscreen="<%= fullscreen %>"
      data-fullscreen-url-template="<%= collavre.fullscreen_creative_comments_path(creative_id: "__CREATIVE_ID__") %>"
-     <%= "data-creative-id=\"#{creative.id}\"" if fullscreen && creative.present? %>
-     <%= "data-creative-snippet=\"#{ERB::Util.html_escape(creative.creative_snippet)}\"" if fullscreen && creative.present? %>
-     <%= "data-can-comment=\"#{creative.has_permission?(Current.user, :feedback)}\"" if fullscreen && creative.present? %>
+     <% if fullscreen && creative.present? %>
+     data-creative-id="<%= creative.id %>"
+     data-creative-snippet="<%= creative.creative_snippet %>"
+     data-can-comment="<%= creative.has_permission?(Current.user, :feedback) %>"
+     <% end %>
      data-loading-text="<%= t('app.loading') %>"
      data-delete-confirm-text="<%= t("collavre.comments.delete_confirm") %>"
      data-update-comment-text="<%= t('collavre.comments.update_comment') %>"
@@ -28,9 +30,15 @@
     <div class="resize-handle resize-handle-right" data-comments--popup-target="rightHandle"></div>
   <% end %>
   <div class="comments-popup-header">
-    <h3 id="comments-popup-title" data-comments--popup-target="title"><%= t('collavre.comments.comments') %></h3>
-    <% unless fullscreen %>
-      <div class="comments-popup-actions">
+    <h3 id="comments-popup-title" data-comments--popup-target="title"><%= fullscreen && creative.present? ? creative.creative_snippet : t('collavre.comments.comments') %></h3>
+    <div class="comments-popup-actions">
+      <% if fullscreen && creative.present? %>
+        <%= link_to collavre.creative_path(creative, open_comments: true),
+                    class: "comments-popup-action comments-popup-fullscreen",
+                    aria: { label: t("collavre.comments.exit_fullscreen", default: "Exit full screen") } do %>
+          <%= svg_tag "exit-fullscreen.svg", class: "comments-popup-action-icon" %>
+        <% end %>
+      <% else %>
         <%= link_to "#",
                     class: "comments-popup-action comments-popup-fullscreen",
                     data: { "comments--popup-target": "fullscreenLink" },
@@ -38,8 +46,8 @@
           <%= svg_tag "fullscreen.svg", class: "comments-popup-action-icon" %>
         <% end %>
         <button id="close-comments-btn" data-comments--popup-target="closeButton" class="comments-popup-action comments-popup-close" type="button">&times;</button>
-      </div>
-    <% end %>
+      <% end %>
+    </div>
   </div>
   <div id="comment-participants" data-comments--presence-target="participants" data-comments--mention-menu-target="participants"></div>
   <div id="comment-topics" data-comments--topics-target="list" class="comment-topics-list"

--- a/engines/collavre/app/views/collavre/comments/fullscreen.html.erb
+++ b/engines/collavre/app/views/collavre/comments/fullscreen.html.erb
@@ -1,0 +1,5 @@
+<% content_for :title, "#{@creative_snippet} - #{t('collavre.comments.comments')}" %>
+
+<div class="comments-fullscreen-page">
+  <%= render "collavre/comments/comments_popup", fullscreen: true, creative: @creative %>
+</div>

--- a/engines/collavre/app/views/layouts/collavre/chat.html.erb
+++ b/engines/collavre/app/views/layouts/collavre/chat.html.erb
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title><%= content_for(:title) || t('app.name') %></title>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="mobile-web-app-capable" content="yes">
+    <meta name="app-version" content="<%= Rails.application.config.app_version %>">
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+
+    <%= yield :head %>
+
+    <link rel="icon" href="/icon-1e3cf549d2.png" type="image/png">
+    <link rel="icon" href="/icon-1e3cf549d2.svg" type="image/svg+xml">
+    <link rel="apple-touch-icon" href="/icon-1e3cf549d2.png">
+
+    <%= stylesheet_link_tag :app, "data-turbo-track": "reload" %>
+    <%= stylesheet_link_tag "collavre/creatives" %>
+    <%= stylesheet_link_tag "collavre/actiontext" %>
+    <%= stylesheet_link_tag "collavre/dark_mode" %>
+    <%= stylesheet_link_tag "collavre/popup" %>
+    <%= stylesheet_link_tag "collavre/comments_popup" %>
+
+    <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true, type: "module" %>
+
+    <% if Current.user&.theme.present? && !%w[light dark].include?(Current.user.theme) %>
+      <% if (custom_theme = UserTheme.find_by(id: Current.user.theme)) %>
+        <style id="user-theme-styles" data-turbo-track="reload">
+          body {
+            <% custom_theme.variables.each do |key, value| %>
+              <%= key %>: <%= value %> !important;
+            <% end %>
+          }
+        </style>
+      <% end %>
+    <% end %>
+  </head>
+  <body class="chat-fullscreen<%= ' dark-mode' if Current.user&.theme == 'dark' %><%= ' light-mode' if Current.user&.theme == 'light' %>" data-current-user-id="<%= Current.user&.id %>" data-controller="action-text-attachment-link" data-action="click->action-text-attachment-link#download">
+    <main>
+      <%= yield %>
+    </main>
+
+    <%= render "collavre/comments/reaction_picker" %>
+  </body>
+</html>

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -71,6 +71,7 @@ en:
       move_no_selection: Select at least one message to move.
       move_error: Unable to move messages.
       fullscreen: Full screen
+      exit_fullscreen: Exit full screen
       move_invalid_target: Select a valid creative to move messages to.
       move_not_allowed: You do not have permission to move these messages.
       select_label: Select message

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -70,6 +70,7 @@ en:
       move_button: Move
       move_no_selection: Select at least one message to move.
       move_error: Unable to move messages.
+      fullscreen: Full screen
       move_invalid_target: Select a valid creative to move messages to.
       move_not_allowed: You do not have permission to move these messages.
       select_label: Select message

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -68,6 +68,7 @@ ko:
       move_no_selection: 이동할 메시지를 선택해주세요.
       move_error: 메시지를 이동할 수 없습니다.
       fullscreen: 전체 화면
+      exit_fullscreen: 전체 화면 종료
       move_invalid_target: 이동할 크리에이티브를 선택해주세요.
       move_not_allowed: 이 메시지를 이동할 권한이 없습니다.
       select_label: 메시지 선택

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -67,6 +67,7 @@ ko:
       move_button: 이동
       move_no_selection: 이동할 메시지를 선택해주세요.
       move_error: 메시지를 이동할 수 없습니다.
+      fullscreen: 전체 화면
       move_invalid_target: 이동할 크리에이티브를 선택해주세요.
       move_not_allowed: 이 메시지를 이동할 권한이 없습니다.
       select_label: 메시지 선택

--- a/engines/collavre/config/routes.rb
+++ b/engines/collavre/config/routes.rb
@@ -64,6 +64,7 @@ Collavre::Engine.routes.draw do
 
       collection do
         get :participants
+        get :fullscreen
         post :move
       end
     end


### PR DESCRIPTION
### Motivation
- Provide a ChatGPT-style fullscreen chat experience for comments so users can open the comment popup as a standalone page without the top GNB or other navigation.
- Make the comments popup capable of toggling into a fullscreen route so it can be used as a dedicated chat page on mobile/desktop.
- Keep existing popup behavior intact while enabling a full-page layout for focused chat usage.

### Description
- Add a new `fullscreen` action and route (`GET /creatives/:creative_id/comments/fullscreen`) in `engines/collavre/config/routes.rb` and `engines/collavre/app/controllers/collavre/comments_controller.rb`, and render it with a new chat-only layout `engines/collavre/app/views/layouts/collavre/chat.html.erb` and view `engines/collavre/app/views/collavre/comments/fullscreen.html.erb`.
- Update the comments popup partial (`engines/collavre/app/views/collavre/comments/_comments_popup.html.erb`) to include a fullscreen button, new `data-*` attributes (`data-fullscreen`, `data-fullscreen-url-template`, creative metadata) and a compact header layout so the popup can either behave as before or be rendered as fullscreen.
- Enhance the Stimulus controller (`engines/collavre/app/javascript/controllers/comments/popup_controller.js`) to support fullscreen mode, generate the fullscreen URL from a template, and open the popup in a fullscreen context via `openForCreative()` while preserving existing popup behavior and resize handling.
- Add styling for fullscreen mode in `engines/collavre/app/assets/stylesheets/collavre/comments_popup.css`, add a `fullscreen.svg` icon at `app/assets/images/fullscreen.svg`, and include locale labels (`fullscreen`) in `engines/collavre/config/locales/comments.en.yml` and `comments.ko.yml`.
- Update the JS popup controller unit test fixture (`engines/collavre/app/javascript/controllers/comments/__tests__/popup_controller.test.js`) to include the fullscreen link target for test compatibility.

Original User's Requirements
- 채팅 팝업에 전체 화면 아이콘을 오른쪽 상단에 넣고 누르면 팝업이 아니라 새로운 페이지로 상단 gnb도 없고 바로 챗지피티처럼 채팅창으로 나오도록해줘

### Testing
- Attempted `./bin/rubocop -a`; could not run because the environment lacks `ruby` (`/usr/bin/env: 'ruby': No such file or directory`).
- Attempted `rails test` and `rails test:system`; could not run because the environment lacks the `rails` command.
- Updated and adjusted a Stimulus unit test (`engines/collavre/app/javascript/controllers/comments/__tests__/popup_controller.test.js`) to include the fullscreen link target but did not run JS tests in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b3a32e81083268592e04d60718388)