### PR TITLE
Guard calendar command without Google login

### DIFF
--- a/engines/collavre/app/services/collavre/comments/calendar_command.rb
+++ b/engines/collavre/app/services/collavre/comments/calendar_command.rb
@@ -47,9 +47,14 @@ module Collavre
         comment.content.to_s.strip.sub(/\A\S+/, "").strip
       end
 
+      def google_login?
+        user&.google_refresh_token.present?
+      end
+
       def create_event
         data = parsed_args
         return unless data
+        return I18n.t("collavre.comments.calendar_command.google_login_required") unless google_login?
 
         timezone = Time.zone
         start_time, end_time = calculate_times(timezone, data[:date], data[:time])

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -77,6 +77,7 @@ en:
       add_reaction_button: "+"
       calendar_command:
         event_created: 'event created: [Google Calendar event](%{url})'
+        google_login_required: Please sign in with Google to create a calendar event.
       read_by: Read by %{name}
       activity_logs_summary: Activity Logs
     calendar_events:

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -74,6 +74,7 @@ ko:
       add_reaction_button: "+"
       calendar_command:
         event_created: '이벤트가 생성되었습니다: [구글 캘린더 이벤트](%{url})'
+        google_login_required: 구글 로그인 후 캘린더 이벤트를 생성할 수 있습니다.
       read_by: "%{name} 님이 읽음"
       activity_logs_summary: 활동 기록
     calendar_events:


### PR DESCRIPTION
### Motivation
- Prevent attempts to create Google Calendar events when the comment author has not linked a Google account, which currently raises errors when the `/calendar` command is used by non-Google users.

### Description
- Add a `google_login?` guard in `engines/collavre/app/services/collavre/comments/calendar_command.rb` to return a localized message instead of calling the Google API when the user lacks a `google_refresh_token`.
- Add localized messages `calendar_command.google_login_required` to `engines/collavre/config/locales/comments.en.yml` and `engines/collavre/config/locales/comments.ko.yml`.

### Testing
- Attempted `./bin/rubocop -a`, which failed with `/usr/bin/env: 'ruby': No such file or directory` in this environment.
- Attempted `rails test` and `rails test:system`, both failed with `command not found` in this environment.

### Original User's Requirements
- `구글 로그인을 하지 않은 사람은 구글 갤린더 등록을 하지 않아야 한다. 지금은 오류가 나 수정해줘`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bfd1b7850832685d608e3f4c94ac9)