### PR TITLE
Simplify creative progress to completion checkbox with child cascade

### DIFF
--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -236,6 +236,8 @@ module Collavre
         permitted = creative_params.to_h
         base = @creative.effective_origin(Set.new)
         success = true
+        previous_progress = base.progress
+        requested_progress = permitted["progress"] || permitted[:progress]
 
         # Handle parent_id change separately for Linked Creatives
         if @creative.origin_id.present? && permitted.key?("parent_id")
@@ -251,6 +253,12 @@ module Collavre
         permitted.delete(:origin_id)
 
         success &&= base.update(permitted)
+        if success && requested_progress.present? && requested_progress.to_f >= 1 && previous_progress.to_f < 1
+          if base.children.exists?
+            base.self_and_descendants.where(origin_id: nil)
+              .update_all(progress: 1.0, updated_at: Time.current)
+          end
+        end
 
         if success
           format.html { redirect_to @creative }

--- a/engines/collavre/app/javascript/modules/__tests__/creative_progress.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/creative_progress.test.js
@@ -1,12 +1,50 @@
 /**
  * @jest-environment jsdom
  */
-import { progressBaselineValueFrom, progressValueChangedFrom } from '../creative_progress';
+import { isProgressComplete, progressBaselineValueFrom, progressValueChangedFrom } from '../creative_progress';
 
 describe('creative progress helpers', () => {
-  test('progressValueChangedFrom preserves fractional values unless checkbox toggled', () => {
-    expect(progressBaselineValueFrom(0.4)).toBe(0);
-    expect(progressValueChangedFrom(0.4, false)).toBe(false);
-    expect(progressValueChangedFrom(0.4, true)).toBe(true);
+  describe('isProgressComplete', () => {
+    test('returns true for values >= 1', () => {
+      expect(isProgressComplete(1)).toBe(true);
+      expect(isProgressComplete(1.0)).toBe(true);
+      expect(isProgressComplete(1.5)).toBe(true);
+    });
+
+    test('returns false for values < 1', () => {
+      expect(isProgressComplete(0)).toBe(false);
+      expect(isProgressComplete(0.5)).toBe(false);
+      expect(isProgressComplete(0.99)).toBe(false);
+    });
+
+    test('returns false for NaN values', () => {
+      expect(isProgressComplete(NaN)).toBe(false);
+      expect(isProgressComplete('invalid')).toBe(false);
+    });
+  });
+
+  describe('progressBaselineValueFrom', () => {
+    test('returns 1 for complete values', () => {
+      expect(progressBaselineValueFrom(1)).toBe(1);
+      expect(progressBaselineValueFrom(1.5)).toBe(1);
+    });
+
+    test('returns 0 for incomplete values', () => {
+      expect(progressBaselineValueFrom(0)).toBe(0);
+      expect(progressBaselineValueFrom(0.4)).toBe(0);
+      expect(progressBaselineValueFrom(0.99)).toBe(0);
+    });
+  });
+
+  describe('progressValueChangedFrom', () => {
+    test('preserves fractional values unless checkbox toggled', () => {
+      expect(progressValueChangedFrom(0.4, false)).toBe(false);
+      expect(progressValueChangedFrom(0.4, true)).toBe(true);
+    });
+
+    test('detects change from complete to incomplete', () => {
+      expect(progressValueChangedFrom(1, false)).toBe(true);
+      expect(progressValueChangedFrom(1, true)).toBe(false);
+    });
   });
 });

--- a/engines/collavre/app/javascript/modules/__tests__/creative_progress.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/creative_progress.test.js
@@ -1,0 +1,12 @@
+/**
+ * @jest-environment jsdom
+ */
+import { progressBaselineValueFrom, progressValueChangedFrom } from '../creative_progress';
+
+describe('creative progress helpers', () => {
+  test('progressValueChangedFrom preserves fractional values unless checkbox toggled', () => {
+    expect(progressBaselineValueFrom(0.4)).toBe(0);
+    expect(progressValueChangedFrom(0.4, false)).toBe(false);
+    expect(progressValueChangedFrom(0.4, true)).toBe(true);
+  });
+});

--- a/engines/collavre/app/javascript/modules/creative_progress.js
+++ b/engines/collavre/app/javascript/modules/creative_progress.js
@@ -1,7 +1,10 @@
+export function isProgressComplete(value) {
+  const numeric = Number(value);
+  return !Number.isNaN(numeric) && numeric >= 1;
+}
+
 export function progressBaselineValueFrom(originalProgress) {
-  const numeric = Number(originalProgress);
-  if (Number.isNaN(numeric)) return 0;
-  return numeric >= 1 ? 1 : 0;
+  return isProgressComplete(originalProgress) ? 1 : 0;
 }
 
 export function progressValueChangedFrom(originalProgress, checked) {

--- a/engines/collavre/app/javascript/modules/creative_progress.js
+++ b/engines/collavre/app/javascript/modules/creative_progress.js
@@ -1,0 +1,11 @@
+export function progressBaselineValueFrom(originalProgress) {
+  const numeric = Number(originalProgress);
+  if (Number.isNaN(numeric)) return 0;
+  return numeric >= 1 ? 1 : 0;
+}
+
+export function progressValueChangedFrom(originalProgress, checked) {
+  const baseline = progressBaselineValueFrom(originalProgress);
+  const current = checked ? 1 : 0;
+  return current !== baseline;
+}

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -172,10 +172,12 @@ export function initializeCreativeRowEditor() {
       if (!progressInput) return;
       const numeric = Number(value);
       const hasChildren = currentRowHasChildren();
-      const shouldDisable = hasChildren && !Number.isNaN(numeric) && numeric >= 1;
+      const isComplete = !Number.isNaN(numeric) && numeric >= 1;
+      const shouldDisable = hasChildren && isComplete;
       progressInput.disabled = shouldDisable;
       if (progressHiddenInput) {
-        progressHiddenInput.disabled = shouldDisable;
+        progressHiddenInput.disabled = false;
+        progressHiddenInput.value = shouldDisable ? (isComplete ? '1' : '0') : '0';
       }
     }
 

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -75,6 +75,8 @@ export function initializeCreativeRowEditor() {
     const editorContainer = template.querySelector('[data-lexical-editor-root]');
     const progressInput = document.getElementById('inline-creative-progress');
     const progressValue = document.getElementById('inline-progress-value');
+    const progressCompleteLabel = progressInput?.dataset.completeLabel || 'Complete';
+    const progressIncompleteLabel = progressInput?.dataset.incompleteLabel || 'Incomplete';
     const upBtn = document.getElementById('inline-move-up');
     const downBtn = document.getElementById('inline-move-down');
     const addBtn = document.getElementById('inline-add');
@@ -136,16 +138,37 @@ export function initializeCreativeRowEditor() {
     let originalProgress = 0;
     let originalOriginId = '';
     let isDirty = false;
+    let completionCascadePending = false;
 
     function formatProgressDisplay(value) {
       const numeric = Number(value);
-      if (Number.isNaN(numeric)) return '0%';
-      const percentage = Math.round(numeric * 100);
-      return `${percentage}%`;
+      if (Number.isNaN(numeric)) return progressIncompleteLabel;
+      return numeric >= 1 ? progressCompleteLabel : progressIncompleteLabel;
+    }
+
+    function readProgressValue() {
+      if (!progressInput) return 0;
+      return progressInput.checked ? 1 : 0;
+    }
+
+    function setProgressState(value) {
+      if (!progressInput) return;
+      const numeric = Number(value);
+      const isComplete = !Number.isNaN(numeric) && numeric >= 1;
+      progressInput.checked = isComplete;
+      if (progressValue) {
+        progressValue.textContent = formatProgressDisplay(isComplete ? 1 : 0);
+      }
     }
 
     function treeRowElement(node) {
       return node && node.closest ? node.closest('creative-tree-row') : null;
+    }
+
+    function currentRowHasChildren() {
+      const row = currentRowElement || (currentTree ? treeRowElement(currentTree) : null);
+      if (!row) return false;
+      return !!(row.hasChildren || row.getAttribute?.('has-children'));
     }
 
     function hasDatasetValue(element, key) {
@@ -245,8 +268,8 @@ export function initializeCreativeRowEditor() {
       isDirty = false;
       const progressNumber = Number(data.progress ?? 0);
       const normalizedProgress = Number.isNaN(progressNumber) ? 0 : progressNumber;
-      progressInput.value = normalizedProgress;
-      progressValue.textContent = formatProgressDisplay(progressInput.value);
+      setProgressState(normalizedProgress);
+      completionCascadePending = false;
       const fallbackParent = tree?.dataset?.parentId || '';
       parentInput.value = data.parent_id ?? fallbackParent ?? '';
       beforeInput.value = '';
@@ -261,7 +284,7 @@ export function initializeCreativeRowEditor() {
       if (unlinkBtn) unlinkBtn.style.display = originId ? '' : 'none';
       const effectiveParent = parentInput.value;
       if (unconvertBtn) unconvertBtn.style.display = effectiveParent ? '' : 'none';
-      originalProgress = normalizedProgress;
+      originalProgress = normalizedProgress >= 1 ? 1 : 0;
       lexicalEditor.focus();
       updateActionButtonStates();
     }
@@ -892,8 +915,9 @@ export function initializeCreativeRowEditor() {
 
         // Capture values being saved to update dirty state on success
         const savedContent = descriptionInput.value;
-        const savedProgress = progressInput.value;
+        const savedProgress = readProgressValue();
         const savedOriginId = originIdInput ? originIdInput.value : '';
+        const cascadeProgressUpdate = completionCascadePending;
 
         savePromise = creativesApi.save(form.action, method, form).then(function (r) {
           if (!r.ok) return r;
@@ -907,7 +931,7 @@ export function initializeCreativeRowEditor() {
 
             // If current values match what was just saved, clear dirty flag
             if (descriptionInput.value === savedContent &&
-              progressInput.value === savedProgress &&
+              readProgressValue() === savedProgress &&
               originIdInput.value === savedOriginId) {
               isDirty = false;
             }
@@ -954,6 +978,10 @@ export function initializeCreativeRowEditor() {
             } else if (method === 'PATCH') {
               if (tree) refreshRow(tree);
             }
+            if (cascadeProgressUpdate && tree) {
+              refreshChildren(tree);
+              completionCascadePending = false;
+            }
 
             // Delete removed attachments after successful save
             if (lexicalEditor && typeof lexicalEditor.getDeletedAttachments === 'function') {
@@ -964,9 +992,9 @@ export function initializeCreativeRowEditor() {
             }
             updateActionButtonStates();
           });
-        }).finally(function () {
-          saving = false;
-        });
+          }).finally(function () {
+            saving = false;
+          });
         return savePromise;
       });
     }
@@ -1071,7 +1099,7 @@ export function initializeCreativeRowEditor() {
       // CRITICAL: Capture ALL values BEFORE awaiting, because the editor may switch
       // to a different creative while we're waiting for uploads
       let currentContent = descriptionInput.value;
-      let currentProgress = progressInput.value;
+      let currentProgress = readProgressValue();
       const currentParentId = tree.dataset.parentId || '';
       const currentBeforeId = tree.previousElementSibling ? creativeIdFrom(tree.previousElementSibling) : '';
       const currentAfterId = tree.nextElementSibling ? creativeIdFrom(tree.nextElementSibling) : '';
@@ -1092,7 +1120,7 @@ export function initializeCreativeRowEditor() {
       // This ensures we capture the final HTML with signed IDs instead of blob URLs
       if (form.dataset.creativeId === startCreativeId) {
         currentContent = descriptionInput.value;
-        currentProgress = progressInput.value;
+        currentProgress = readProgressValue();
       }
 
       // Build request body
@@ -1540,8 +1568,7 @@ export function initializeCreativeRowEditor() {
           resetOriginTracking();
           descriptionInput.value = '';
           lexicalEditor.reset(`new-${Date.now()}`);
-          progressInput.value = 0;
-          progressValue.textContent = formatProgressDisplay(0);
+          setProgressState(0);
           if (unconvertBtn) unconvertBtn.style.display = 'none';
           pendingSave = false;
           lexicalEditor.focus();
@@ -1666,10 +1693,22 @@ export function initializeCreativeRowEditor() {
       return !!node && $isRootOrShadowRoot(node);
     }
 
-    progressInput.addEventListener('input', function () {
-      progressValue.textContent = formatProgressDisplay(progressInput.value);
-      scheduleSave();
-    });
+    if (progressInput) {
+      progressInput.addEventListener('change', function () {
+        if (progressValue) {
+          progressValue.textContent = formatProgressDisplay(readProgressValue());
+        }
+        completionCascadePending = false;
+        if (progressInput.checked && currentRowHasChildren()) {
+          completionCascadePending = true;
+          const alertMessage = progressInput.dataset.childrenAlertMessage;
+          if (alertMessage) {
+            alert(alertMessage);
+          }
+        }
+        scheduleSave();
+      });
+    }
 
     if (parentSuggestBtn && parentSuggestions) {
       parentSuggestBtn.addEventListener('click', function () {

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -3,7 +3,7 @@ import apiQueue from '../lib/api/queue_manager'
 import { $getCharacterOffsets, $getSelection, $isRangeSelection, $isTextNode, $isRootOrShadowRoot } from 'lexical'
 import { createInlineEditor } from './lexical_inline_editor'
 import { renderCreativeTree, dispatchCreativeTreeUpdated } from '../creatives/tree_renderer'
-import { progressBaselineValueFrom, progressValueChangedFrom } from './creative_progress'
+import { isProgressComplete, progressBaselineValueFrom, progressValueChangedFrom } from './creative_progress'
 // Import Stimulus application from the global window (set by host app)
 const application = window.Stimulus
 
@@ -143,9 +143,7 @@ export function initializeCreativeRowEditor() {
     let completionCascadePending = false;
 
     function formatProgressDisplay(value) {
-      const numeric = Number(value);
-      if (Number.isNaN(numeric)) return progressIncompleteLabel;
-      return numeric >= 1 ? progressCompleteLabel : progressIncompleteLabel;
+      return isProgressComplete(value) ? progressCompleteLabel : progressIncompleteLabel;
     }
 
     function readProgressValue() {
@@ -160,24 +158,22 @@ export function initializeCreativeRowEditor() {
 
     function setProgressState(value) {
       if (!progressInput) return;
-      const numeric = Number(value);
-      const isComplete = !Number.isNaN(numeric) && numeric >= 1;
-      progressInput.checked = isComplete;
+      const complete = isProgressComplete(value);
+      progressInput.checked = complete;
       if (progressValue) {
-        progressValue.textContent = formatProgressDisplay(isComplete ? 1 : 0);
+        progressValue.textContent = formatProgressDisplay(value);
       }
     }
 
     function updateProgressInputAvailability(value) {
       if (!progressInput) return;
-      const numeric = Number(value);
       const hasChildren = currentRowHasChildren();
-      const isComplete = !Number.isNaN(numeric) && numeric >= 1;
-      const shouldDisable = hasChildren && isComplete;
+      const complete = isProgressComplete(value);
+      const shouldDisable = hasChildren && complete;
       progressInput.disabled = shouldDisable;
       if (progressHiddenInput) {
         progressHiddenInput.disabled = false;
-        progressHiddenInput.value = shouldDisable ? (isComplete ? '1' : '0') : '0';
+        progressHiddenInput.value = shouldDisable ? '1' : '0';
       }
     }
 
@@ -1023,13 +1019,13 @@ export function initializeCreativeRowEditor() {
             }
             updateActionButtonStates();
           });
-          }).finally(function () {
-            saving = false;
-            if (!shouldPersistProgress) {
-              if (progressInput) progressInput.disabled = progressInputsDisabled;
-              if (progressHiddenInput) progressHiddenInput.disabled = hiddenProgressDisabled;
-            }
-          });
+        }).finally(function () {
+          saving = false;
+          if (!shouldPersistProgress) {
+            if (progressInput) progressInput.disabled = progressInputsDisabled;
+            if (progressHiddenInput) progressHiddenInput.disabled = hiddenProgressDisabled;
+          }
+        });
         return savePromise;
       });
     }

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -1745,7 +1745,9 @@ export function initializeCreativeRowEditor() {
           progressValue.textContent = formatProgressDisplay(readProgressValue());
         }
         completionCascadePending = false;
-        if (progressInput.checked && currentRowHasChildren()) {
+        const hasChildren = currentRowHasChildren();
+        const shouldCascade = hasChildren && progressValueChanged();
+        if (shouldCascade) {
           completionCascadePending = true;
           const alertMessage = progressInput.dataset.childrenAlertMessage;
           if (alertMessage) {

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -3,6 +3,7 @@ import apiQueue from '../lib/api/queue_manager'
 import { $getCharacterOffsets, $getSelection, $isRangeSelection, $isTextNode, $isRootOrShadowRoot } from 'lexical'
 import { createInlineEditor } from './lexical_inline_editor'
 import { renderCreativeTree, dispatchCreativeTreeUpdated } from '../creatives/tree_renderer'
+import { progressBaselineValueFrom, progressValueChangedFrom } from './creative_progress'
 // Import Stimulus application from the global window (set by host app)
 const application = window.Stimulus
 
@@ -152,15 +153,9 @@ export function initializeCreativeRowEditor() {
       return progressInput.checked ? 1 : 0;
     }
 
-    function progressBaselineValue() {
-      const numeric = Number(originalProgress);
-      if (Number.isNaN(numeric)) return 0;
-      return numeric >= 1 ? 1 : 0;
-    }
-
     function progressValueChanged() {
       if (!progressInput) return false;
-      return readProgressValue() !== progressBaselineValue();
+      return progressValueChangedFrom(originalProgress, progressInput.checked);
     }
 
     function setProgressState(value) {
@@ -928,7 +923,7 @@ export function initializeCreativeRowEditor() {
         // Capture values being saved to update dirty state on success
         const savedContent = descriptionInput.value;
         const shouldPersistProgress = progressValueChanged();
-        const savedProgress = shouldPersistProgress ? readProgressValue() : progressBaselineValue();
+        const savedProgress = shouldPersistProgress ? readProgressValue() : progressBaselineValueFrom(originalProgress);
         const savedOriginId = originIdInput ? originIdInput.value : '';
         const cascadeProgressUpdate = completionCascadePending;
         const progressInputsDisabled = progressInput?.disabled ?? false;

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -168,6 +168,17 @@ export function initializeCreativeRowEditor() {
       }
     }
 
+    function updateProgressInputAvailability(value) {
+      if (!progressInput) return;
+      const numeric = Number(value);
+      const hasChildren = currentRowHasChildren();
+      const shouldDisable = hasChildren && !Number.isNaN(numeric) && numeric >= 1;
+      progressInput.disabled = shouldDisable;
+      if (progressHiddenInput) {
+        progressHiddenInput.disabled = shouldDisable;
+      }
+    }
+
     function treeRowElement(node) {
       return node && node.closest ? node.closest('creative-tree-row') : null;
     }
@@ -276,6 +287,7 @@ export function initializeCreativeRowEditor() {
       const progressNumber = Number(data.progress ?? 0);
       const normalizedProgress = Number.isNaN(progressNumber) ? 0 : progressNumber;
       setProgressState(normalizedProgress);
+      updateProgressInputAvailability(normalizedProgress);
       completionCascadePending = false;
       const fallbackParent = tree?.dataset?.parentId || '';
       parentInput.value = data.parent_id ?? fallbackParent ?? '';
@@ -1738,6 +1750,7 @@ export function initializeCreativeRowEditor() {
             alert(alertMessage);
           }
         }
+        updateProgressInputAvailability(readProgressValue());
         scheduleSave();
       });
     }

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -77,6 +77,7 @@ export function initializeCreativeRowEditor() {
     const progressValue = document.getElementById('inline-progress-value');
     const progressCompleteLabel = progressInput?.dataset.completeLabel || 'Complete';
     const progressIncompleteLabel = progressInput?.dataset.incompleteLabel || 'Incomplete';
+    const progressHiddenInput = document.querySelector('input[type="hidden"][name="creative[progress]"]');
     const upBtn = document.getElementById('inline-move-up');
     const downBtn = document.getElementById('inline-move-down');
     const addBtn = document.getElementById('inline-add');
@@ -149,6 +150,17 @@ export function initializeCreativeRowEditor() {
     function readProgressValue() {
       if (!progressInput) return 0;
       return progressInput.checked ? 1 : 0;
+    }
+
+    function progressBaselineValue() {
+      const numeric = Number(originalProgress);
+      if (Number.isNaN(numeric)) return 0;
+      return numeric >= 1 ? 1 : 0;
+    }
+
+    function progressValueChanged() {
+      if (!progressInput) return false;
+      return readProgressValue() !== progressBaselineValue();
     }
 
     function setProgressState(value) {
@@ -284,7 +296,7 @@ export function initializeCreativeRowEditor() {
       if (unlinkBtn) unlinkBtn.style.display = originId ? '' : 'none';
       const effectiveParent = parentInput.value;
       if (unconvertBtn) unconvertBtn.style.display = effectiveParent ? '' : 'none';
-      originalProgress = normalizedProgress >= 1 ? 1 : 0;
+      originalProgress = normalizedProgress;
       lexicalEditor.focus();
       updateActionButtonStates();
     }
@@ -915,9 +927,17 @@ export function initializeCreativeRowEditor() {
 
         // Capture values being saved to update dirty state on success
         const savedContent = descriptionInput.value;
-        const savedProgress = readProgressValue();
+        const shouldPersistProgress = progressValueChanged();
+        const savedProgress = shouldPersistProgress ? readProgressValue() : progressBaselineValue();
         const savedOriginId = originIdInput ? originIdInput.value : '';
         const cascadeProgressUpdate = completionCascadePending;
+        const progressInputsDisabled = progressInput?.disabled ?? false;
+        const hiddenProgressDisabled = progressHiddenInput?.disabled ?? false;
+
+        if (!shouldPersistProgress) {
+          if (progressInput) progressInput.disabled = true;
+          if (progressHiddenInput) progressHiddenInput.disabled = true;
+        }
 
         savePromise = creativesApi.save(form.action, method, form).then(function (r) {
           if (!r.ok) return r;
@@ -926,7 +946,9 @@ export function initializeCreativeRowEditor() {
           }).then(function (data) {
             // Update dirty state to reflect successful save
             originalContent = savedContent;
-            originalProgress = savedProgress;
+            if (shouldPersistProgress) {
+              originalProgress = savedProgress;
+            }
             originalOriginId = savedOriginId;
 
             // If current values match what was just saved, clear dirty flag
@@ -994,6 +1016,10 @@ export function initializeCreativeRowEditor() {
           });
           }).finally(function () {
             saving = false;
+            if (!shouldPersistProgress) {
+              if (progressInput) progressInput.disabled = progressInputsDisabled;
+              if (progressHiddenInput) progressHiddenInput.disabled = hiddenProgressDisabled;
+            }
           });
         return savePromise;
       });
@@ -1100,6 +1126,7 @@ export function initializeCreativeRowEditor() {
       // to a different creative while we're waiting for uploads
       let currentContent = descriptionInput.value;
       let currentProgress = readProgressValue();
+      let shouldPersistProgress = progressValueChanged();
       const currentParentId = tree.dataset.parentId || '';
       const currentBeforeId = tree.previousElementSibling ? creativeIdFrom(tree.previousElementSibling) : '';
       const currentAfterId = tree.nextElementSibling ? creativeIdFrom(tree.nextElementSibling) : '';
@@ -1121,15 +1148,19 @@ export function initializeCreativeRowEditor() {
       if (form.dataset.creativeId === startCreativeId) {
         currentContent = descriptionInput.value;
         currentProgress = readProgressValue();
+        shouldPersistProgress = progressValueChanged();
       }
 
       // Build request body
       // Note: before_id and after_id must be top-level params, not nested under creative[]
       // because CreativesController reads params[:before_id] and params[:after_id] for positioning
       const body = {
-        'creative[description]': currentContent,
-        'creative[progress]': currentProgress
+        'creative[description]': currentContent
       };
+
+      if (shouldPersistProgress) {
+        body['creative[progress]'] = currentProgress;
+      }
 
       // Always include parent_id, even if empty (for moving to root)
       body['creative[parent_id]'] = currentParentId;
@@ -1150,7 +1181,9 @@ export function initializeCreativeRowEditor() {
           row.dataset.descriptionHtml = currentContent;
           row.descriptionHtml = currentContent;
           row.dataset.descriptionRawHtml = currentContent;
-          row.dataset.progressValue = String(currentProgress);
+          if (shouldPersistProgress) {
+            row.dataset.progressValue = String(currentProgress);
+          }
           if (currentParentId) {
             tree.dataset.parentId = currentParentId;
             row.parentId = currentParentId;
@@ -1184,6 +1217,9 @@ export function initializeCreativeRowEditor() {
 
       // Reset dirty state
       originalContent = currentContent;
+      if (shouldPersistProgress) {
+        originalProgress = currentProgress;
+      }
       isDirty = false;
       pendingSave = false;
       clearTimeout(saveTimer);
@@ -1569,6 +1605,7 @@ export function initializeCreativeRowEditor() {
           descriptionInput.value = '';
           lexicalEditor.reset(`new-${Date.now()}`);
           setProgressState(0);
+          originalProgress = 0;
           if (unconvertBtn) unconvertBtn.style.display = 'none';
           pendingSave = false;
           lexicalEditor.focus();

--- a/engines/collavre/app/views/collavre/creatives/_inline_edit_form.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_inline_edit_form.html.erb
@@ -16,8 +16,17 @@
          data-placeholder="<%= t('collavre.creatives.inline_editor.placeholder') %>"></div>
     <div id="actions-inline-editor" style="padding: 0px 8px;">
       <div style="margin-top:0.5em;display:flex;align-items:center;gap:0.5em;">
-        <input type="range" id="inline-creative-progress" name="creative[progress]" min="0" max="1" step="0.01">
-        <span id="inline-progress-value">0%</span>
+        <input type="hidden" name="creative[progress]" value="0">
+        <label for="inline-creative-progress" style="display:flex;align-items:center;gap:0.4em;">
+          <input type="checkbox"
+                 id="inline-creative-progress"
+                 name="creative[progress]"
+                 value="1"
+                 data-complete-label="<%= t('collavre.creatives.index.progress_complete') %>"
+                 data-incomplete-label="<%= t('collavre.creatives.index.progress_incomplete') %>"
+                 data-children-alert-message="<%= t('collavre.creatives.index.progress_complete_children_alert') %>">
+          <span id="inline-progress-value"><%= t('collavre.creatives.index.progress_incomplete') %></span>
+        </label>
       </div>
       <div style="margin-top:0.5em;">
         <button type="button" id="inline-move-up" class="creative-action-btn" title="<%= t('collavre.creatives.index.inline_move_up_tooltip') %>">
@@ -85,5 +94,4 @@
     </div>
   </form>
 </div>
-
 

--- a/engines/collavre/config/locales/creatives.en.yml
+++ b/engines/collavre/config/locales/creatives.en.yml
@@ -136,6 +136,9 @@ en:
         select_plan: Select Plan
         remove_plan: Remove Plan
         add_plan: Add Plan
+        progress_complete: Complete
+        progress_incomplete: Incomplete
+        progress_complete_children_alert: Marking this creative complete will also mark all child creatives complete.
         set_plan_title: Set Plan for Selected Creative
         are_you_sure_delete_share: Are you sure delete share?
         share_deleted: The share are deleted.

--- a/engines/collavre/config/locales/creatives.ko.yml
+++ b/engines/collavre/config/locales/creatives.ko.yml
@@ -120,6 +120,9 @@ ko:
         select_plan: 계획 선택
         remove_plan: 계획 제거
         add_plan: 계획 추가
+        progress_complete: 완료
+        progress_incomplete: 미완료
+        progress_complete_children_alert: 하위 크리에이티브도 모두 완료로 표시됩니다.
         set_plan_title: 선택된 크리에이티브에 대한 계획 설정
         are_you_sure_delete_share: 공유를 삭제하시겠습니까?
         share_deleted: 공유가 삭제 되었습니다.


### PR DESCRIPTION
### Motivation
- Make marking a creative complete faster by replacing the inline progress slider with a simple checkbox and clear labels. 
- When a creative with children is marked complete, apply completion to descendants and surface a user alert so the user knows children will be affected.

### Description
- Replace the inline range progress input with a completion checkbox and labels in the inline editor partial (`engines/collavre/app/views/collavre/creatives/_inline_edit_form.html.erb`).
- Add localized copy for complete/incomplete labels and the children-cascade alert in English and Korean (`engines/collavre/config/locales/creatives.en.yml`, `engines/collavre/config/locales/creatives.ko.yml`).
- Update the inline editor JS (`engines/collavre/app/javascript/modules/creative_row_editor.js`) to treat progress as a boolean complete flag via `readProgressValue` / `setProgressState`, show localized labels, alert when completing an item that has children, and mark a `completionCascadePending` flag so child rows are refreshed after save.
- Add server-side cascade: when an Origin creative is updated from <100% to >=100%, update its descendants (non-origin rows) to `progress = 1.0` in `CreativesController#update` so completion is applied consistently on the backend.

### Testing
- Ran `./bin/rubocop -a` in the environment, but it failed because Ruby is not available in this container (`/usr/bin/env: 'ruby': No such file or directory`).
- Ran `rails test` which could not be executed because Rails is not available in this environment (`rails: command not found`).
- Ran `rails test:system` which could not be executed for the same reason (`rails: command not found`).

Original User's Requirements
- 크리에이티브 수정시 프로그레스 설정을 단순 체크 박스로 변경해서 완료 여부만 신속 처리 힐수 있도록 한다.
- 만약하위 크리에이티브가 있는 크리에이티브를 완료 처리 하면 하위 모두를 적용한다. 이때는 alert 팝업을 띄운다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bfe25616083268e359191b447911e)