### PR TITLE
Fix creative deletion when calendar events exist

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: engines/collavre
   specs:
-    collavre (0.1.0)
+    collavre (0.1.1)
       bcrypt
       closure_tree
       httparty

--- a/engines/collavre/app/models/collavre/creative.rb
+++ b/engines/collavre/app/models/collavre/creative.rb
@@ -51,7 +51,7 @@ module Collavre
     attr_accessor :filtered_progress
 
     belongs_to :origin, class_name: "Collavre::Creative", optional: true
-    has_many :linked_creatives, class_name: "Collavre::Creative", foreign_key: :origin_id, dependent: :delete_all
+    has_many :linked_creatives, class_name: "Collavre::Creative", foreign_key: :origin_id, dependent: :destroy
     belongs_to :user, class_name: Collavre.configuration.user_class_name, optional: true
 
     has_many :creative_shares, class_name: "Collavre::CreativeShare", dependent: :destroy

--- a/engines/collavre/test/models/creative_calendar_event_destroy_test.rb
+++ b/engines/collavre/test/models/creative_calendar_event_destroy_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  class CreativeCalendarEventDestroyTest < ActiveSupport::TestCase
+    test "destroying a creative removes linked creatives with calendar events" do
+      user = users(:one)
+      origin = Creative.create!(user: user, description: "Origin", progress: 0.0)
+      linked = Creative.create!(origin: origin, user: user)
+      event = CalendarEvent.create!(
+        user: user,
+        creative: linked,
+        google_event_id: SecureRandom.uuid,
+        start_time: Time.current,
+        end_time: 1.hour.from_now
+      )
+
+      assert_difference("Creative.count", -2) do
+        assert_difference("CalendarEvent.count", -1) do
+          origin.destroy
+        end
+      end
+
+      assert_not Creative.exists?(linked.id)
+      assert_not CalendarEvent.exists?(event.id)
+    end
+  end
+end


### PR DESCRIPTION
### Motivation
- Deleting an origin creative could fail to remove associated linked creatives and their calendar events due to using `dependent: :delete_all`, causing a bug when calendar events exist. 
- Ensure origin deletion cleans up linked creatives and their dependent records so deletions succeed reliably.

### Description
- Change `linked_creatives` association to `dependent: :destroy` so ActiveRecord callbacks run and associated `calendar_events` are removed (file: `engines/collavre/app/models/collavre/creative.rb`).
- Add a regression test `engines/collavre/test/models/creative_calendar_event_destroy_test.rb` that verifies destroying an origin removes linked creatives and their calendar events.
- Update `Gemfile.lock` to reflect the local engine version bump (`collavre 0.1.1`).

### Testing
- Ran `mise exec -- ./bin/rubocop -a` with no offenses detected. 
- Ran `mise exec -- rails test` which executed 43 runs and 116 assertions with `0 failures, 0 errors, 0 skips`. 
- Ran `mise exec -- rails test:system` which failed due to `cannot load such file -- /workspace/plan42/test/system` (environment/system tests require additional setup).

### Original User's Requirements
- 캘린더 일정이 있으면 크리에이티브가 삭제되지 않는 버그가 있어 수정해줘

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bfd3d8d108326b0d1ebd676440b47)