### PR TITLE
Reload creative children after comment convert

### DIFF
--- a/engines/collavre/app/javascript/controllers/comments/list_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/list_controller.js
@@ -1,6 +1,8 @@
 import { Controller } from '@hotwired/stimulus'
 import { copyTextToClipboard } from '../../utils/clipboard'
 import { renderMarkdownInContainer } from '../../lib/utils/markdown'
+import creativesApi from '../../lib/api/creatives'
+import { renderCreativeTree, dispatchCreativeTreeUpdated } from '../../creatives/tree_renderer'
 
 export default class extends Controller {
   static targets = ['list']
@@ -562,8 +564,33 @@ export default class extends Controller {
         // Conversion usually converts to creative, so maybe reload or redirect?
         // Original code reloaded initial comments. Safe to do:
         this.loadInitialComments()
+        this.reloadCreativeChildren()
       }
     })
+  }
+
+  reloadCreativeChildren() {
+    if (!this.creativeId) return Promise.resolve()
+    const container = document.getElementById(`creative-children-${this.creativeId}`)
+    const loadUrl = container?.dataset?.loadUrl
+    if (!container || !loadUrl) {
+      this.reloadCreativeTree()
+      return Promise.resolve()
+    }
+
+    return creativesApi.loadChildren(loadUrl).then((data) => {
+      const nodes = Array.isArray(data?.creatives) ? data.creatives : []
+      renderCreativeTree(container, nodes, { replace: false })
+      container.dataset.loaded = 'true'
+      dispatchCreativeTreeUpdated(container)
+    })
+  }
+
+  reloadCreativeTree() {
+    const treeElement = document.getElementById('creatives')
+    if (!treeElement) return
+    const controller = this.application.getControllerForElementAndIdentifier(treeElement, 'creatives--tree')
+    controller?.load?.()
   }
 
   approveComment(button) {


### PR DESCRIPTION
### Motivation
- Ensure that when a comment is converted into a sub-creative the UI immediately shows the newly created child nodes without requiring a manual reload.

### Description
- Add imports for `creativesApi`, `renderCreativeTree`, and `dispatchCreativeTreeUpdated` and call a new `reloadCreativeChildren` after a successful `convert` response in the comments list controller.
- Implement `reloadCreativeChildren` to fetch child nodes from the container `loadUrl` and re-render the `creative-children-<id>` container using `renderCreativeTree`, marking it loaded and dispatching `creative-tree:updated`.
- Add `reloadCreativeTree` fallback which invokes the `creatives--tree` controller `load()` when a child container or `loadUrl` is not present.

### Testing
- Committed the change and verified the modified file at `engines/collavre/app/javascript/controllers/comments/list_controller.js` was staged and committed.
- Attempted `./bin/rubocop -a` which failed because `ruby` is not available in the environment (`/usr/bin/env: 'ruby': No such file or directory`).
- Attempted `rails test` and `rails test:system` which failed because `rails` is not available in the environment (`command not found: rails`).

### Original User's Requirements
- 채팅에서 전환(convert)을 하면, 하위 크리에이티브로 추가되기 때문에, 현재 크리에이티브의 하위 크리에이티브를 재로딩해서 표시해야 한다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c0f80d5f48326b5a114a704407125)