### PR TITLE
Support relative dates and weekdays in /calendar

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_01_31_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_01_100000) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false
@@ -62,11 +62,38 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_31_000000) do
     t.index ["user_id"], name: "index_activity_logs_on_user_id"
   end
 
+  create_table "agent_actions", force: :cascade do |t|
+    t.integer "agent_run_id", null: false
+    t.json "arguments", default: {}
+    t.datetime "created_at", null: false
+    t.text "result"
+    t.string "status", default: "pending"
+    t.string "tool_name"
+    t.datetime "updated_at", null: false
+    t.index ["agent_run_id"], name: "index_agent_actions_on_agent_run_id"
+  end
+
+  create_table "agent_runs", force: :cascade do |t|
+    t.integer "ai_user_id", null: false
+    t.json "context", default: {}
+    t.datetime "created_at", null: false
+    t.integer "creative_id", null: false
+    t.text "goal"
+    t.integer "iteration_count", default: 0
+    t.datetime "next_run_at"
+    t.string "state", default: "planning"
+    t.string "status", default: "pending"
+    t.json "transcript", default: []
+    t.datetime "updated_at", null: false
+    t.index ["ai_user_id"], name: "index_agent_runs_on_ai_user_id"
+    t.index ["creative_id"], name: "index_agent_runs_on_creative_id"
+  end
+
   create_table "calendar_events", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.integer "creative_id"
     t.datetime "end_time", null: false
-    t.string "google_event_id", null: false
+    t.string "google_event_id"
     t.string "html_link"
     t.datetime "start_time", null: false
     t.string "summary"
@@ -175,7 +202,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_31_000000) do
 
   create_table "creatives", force: :cascade do |t|
     t.datetime "created_at", null: false
-    t.text "description"
+    t.text "description", limit: 4294967295
     t.text "github_gemini_prompt"
     t.integer "origin_id"
     t.integer "parent_id"
@@ -736,7 +763,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_31_000000) do
   add_foreign_key "creative_expanded_states", "users"
   add_foreign_key "creative_shares", "creatives"
   add_foreign_key "creative_shares", "users"
-  add_foreign_key "creative_shares", "users", column: "shared_by_id", on_delete: :nullify
+  add_foreign_key "creative_shares", "users", column: "shared_by_id"
   add_foreign_key "creatives", "creatives", column: "origin_id"
   add_foreign_key "creatives", "creatives", column: "parent_id"
   add_foreign_key "creatives", "users"

--- a/engines/collavre/app/models/collavre/calendar_event.rb
+++ b/engines/collavre/app/models/collavre/calendar_event.rb
@@ -5,13 +5,19 @@ module Collavre
     belongs_to :user, class_name: Collavre.configuration.user_class_name
     belongs_to :creative, class_name: "Collavre::Creative", optional: true
 
-    validates :google_event_id, :start_time, :end_time, presence: true
+    validates :start_time, :end_time, presence: true
 
     after_commit :delete_google_event, on: :destroy
+
+    def synced_to_google?
+      google_event_id.present?
+    end
 
     private
 
     def delete_google_event
+      return unless google_event_id.present?
+
       GoogleCalendarService.new(user: user).delete_event(google_event_id)
     rescue StandardError => e
       Rails.logger.error("Failed to delete Google event #{google_event_id}: #{e.message}")

--- a/engines/collavre/app/services/collavre/comments/calendar_command.rb
+++ b/engines/collavre/app/services/collavre/comments/calendar_command.rb
@@ -58,7 +58,8 @@ module Collavre
           return [ nil, match[1], match[2] ]
         end
 
-        match = args.match(/\A(\S+)?(?:@(\d{2}:\d{2}))?(?:\s+(.*))?\z/)
+        # Use [^\s@]+ to stop before @ so "today@14:00" splits correctly
+        match = args.match(/\A([^\s@]+)?(?:@(\d{2}:\d{2}))?(?:\s+(.*))?\z/)
         return unless match
 
         [ match[1], match[2], match[3] ]
@@ -117,25 +118,50 @@ module Collavre
       def create_event
         data = parsed_args
         return unless data
-        return I18n.t("collavre.comments.calendar_command.google_login_required") unless google_login?
 
         timezone = Time.zone
         start_time, end_time = calculate_times(timezone, data[:date], data[:time])
         summary = build_summary(data[:memo])
-        calendar_id = comment.user&.calendar_id.presence || "primary"
 
-        event = GoogleCalendarService.new(user: user).create_event(
-          calendar_id: calendar_id,
-          start_time: start_time,
-          end_time: end_time,
+        # Always create local CalendarEvent first
+        calendar_event = CalendarEvent.create!(
+          user: user,
+          creative: creative,
           summary: summary,
-          description: event_description,
-          timezone: timezone.tzinfo.name,
-          all_day: data[:time].nil?,
-          creative: creative
+          start_time: start_time,
+          end_time: end_time
         )
 
-        I18n.t("collavre.comments.calendar_command.event_created", url: event.html_link)
+        # Sync to Google Calendar if connected
+        if google_login?
+          sync_to_google(calendar_event, timezone, data[:time].nil?)
+        else
+          I18n.t("collavre.comments.calendar_command.event_created_local")
+        end
+      end
+
+      def sync_to_google(calendar_event, timezone, all_day)
+        calendar_id = comment.user&.calendar_id.presence || "primary"
+
+        google_event = GoogleCalendarService.new(user: user).create_google_event(
+          calendar_id: calendar_id,
+          start_time: calendar_event.start_time,
+          end_time: calendar_event.end_time,
+          summary: calendar_event.summary,
+          description: event_description,
+          timezone: timezone.tzinfo.name,
+          all_day: all_day
+        )
+
+        calendar_event.update!(
+          google_event_id: google_event.id,
+          html_link: google_event.html_link
+        )
+
+        I18n.t("collavre.comments.calendar_command.event_created", url: google_event.html_link)
+      rescue StandardError => e
+        Rails.logger.error("Google Calendar sync failed: #{e.message}")
+        I18n.t("collavre.comments.calendar_command.event_created_sync_failed")
       end
 
       def calculate_times(timezone, date_str, time_str)

--- a/engines/collavre/app/services/collavre/comments/calendar_command.rb
+++ b/engines/collavre/app/services/collavre/comments/calendar_command.rb
@@ -30,21 +30,84 @@ module Collavre
       def parsed_args
         @parsed_args ||= begin
           args = command_body
-          args = args.sub(/\A(today)\b/i, Time.zone.today.to_s) if args.match?(/\Atoday\b/i)
-          match = args.match(/\A(?:(\d{4}-\d{2}-\d{2}))?(?:@(\d{2}:\d{2}))?(?:\s+(.*))?\z/)
-          return unless match
-          return unless match[1].present? || match[2].present?
+          return if args.blank?
+
+          date_token, time_token, memo = parse_command_parts(args)
+          return unless date_token || time_token
+
+          parsed_date = parse_date_token(date_token)
+          return if date_token.present? && parsed_date.blank?
 
           {
-            date: match[1],
-            time: match[2],
-            memo: match[3]
+            date: parsed_date&.to_s,
+            time: time_token,
+            memo: memo
           }
         end
       end
 
       def command_body
         comment.content.to_s.strip.sub(/\A\S+/, "").strip
+      end
+
+      def parse_command_parts(args)
+        if args.start_with?("@")
+          match = args.match(/\A@(\d{2}:\d{2})(?:\s+(.*))?\z/)
+          return unless match
+
+          return [ nil, match[1], match[2] ]
+        end
+
+        match = args.match(/\A(\S+)?(?:@(\d{2}:\d{2}))?(?:\s+(.*))?\z/)
+        return unless match
+
+        [ match[1], match[2], match[3] ]
+      end
+
+      def parse_date_token(token)
+        return if token.blank?
+
+        today = Time.zone.today
+        token = token.strip
+
+        return today if token.match?(/\Atoday\z/i)
+        return today + 1.day if token.match?(/\Atomorrow\z/i)
+
+        interval_match = token.match(/\A\+(\d+)(days?|weeks?|months?|years?)\z/i)
+        if interval_match
+          amount = interval_match[1].to_i
+          unit = interval_match[2].downcase
+          return today + amount.days if unit.start_with?("day")
+          return today + amount.weeks if unit.start_with?("week")
+          return today.advance(months: amount) if unit.start_with?("month")
+          return today.advance(years: amount) if unit.start_with?("year")
+        end
+
+        weekday_match = token.match(/\A\+(\d+)?(mon|tue|wed|thu|fri|sat|sun|[월화수목금토일])\z/i)
+        if weekday_match
+          count = weekday_match[1].present? ? weekday_match[1].to_i : 1
+          return next_weekday(today, weekday_index(weekday_match[2]), count)
+        end
+
+        Date.iso8601(token) if token.match?(/\A\d{4}-\d{2}-\d{2}\z/)
+      end
+
+      def weekday_index(token)
+        case token.to_s.downcase
+        when "mon", "월" then 1
+        when "tue", "화" then 2
+        when "wed", "수" then 3
+        when "thu", "목" then 4
+        when "fri", "금" then 5
+        when "sat", "토" then 6
+        when "sun", "일" then 0
+        end
+      end
+
+      def next_weekday(base_date, target_wday, count)
+        days_until = (target_wday - base_date.wday) % 7
+        days_until = 7 if days_until.zero?
+        base_date + days_until + (count - 1) * 7
       end
 
       def google_login?

--- a/engines/collavre/app/services/collavre/comments/calendar_command.rb
+++ b/engines/collavre/app/services/collavre/comments/calendar_command.rb
@@ -176,10 +176,7 @@ module Collavre
       end
 
       def build_summary(memo)
-        return memo if memo.present?
-
-        base_summary = creative.effective_description(false, false)
-        base_summary
+        memo.presence || creative.effective_description(false, false)
       end
 
       def event_description

--- a/engines/collavre/app/services/collavre/google_calendar_service.rb
+++ b/engines/collavre/app/services/collavre/google_calendar_service.rb
@@ -12,7 +12,7 @@ module Collavre
       @service.authorization = user_credentials
     end
 
-    # Creates a Google Calendar event.
+    # Creates a Google Calendar event and associated CalendarEvent record.
     # Optional params supported: location, recurrence (array), attendees (array of emails or attendee hashes),
     # reminders (hash: { use_default: true/false, overrides: [{ method: 'email'|'popup', minutes: Integer }, ...] })
     def create_event(
@@ -28,6 +28,46 @@ module Collavre
       reminders: nil,
       all_day: false,
       creative: nil
+    )
+      result = create_google_event(
+        calendar_id: calendar_id,
+        start_time: start_time,
+        end_time: end_time,
+        summary: summary,
+        description: description,
+        timezone: timezone,
+        location: location,
+        recurrence: recurrence,
+        attendees: attendees,
+        reminders: reminders,
+        all_day: all_day
+      )
+      CalendarEvent.create!(
+        user: @user,
+        creative: creative,
+        google_event_id: result.id,
+        summary: result.summary,
+        start_time: result.start.date_time || result.start.date,
+        end_time: result.end.date_time || result.end.date,
+        html_link: result.html_link
+      )
+      result
+    end
+
+    # Creates a Google Calendar event without creating a CalendarEvent record.
+    # Use this when you want to manage the CalendarEvent record separately.
+    def create_google_event(
+      calendar_id: "primary",
+      start_time:,
+      end_time:,
+      summary:,
+      description: nil,
+      timezone: nil,
+      location: nil,
+      recurrence: nil,
+      attendees: nil,
+      reminders: nil,
+      all_day: false
     )
       timezone ||= @user.timezone || Time.zone.tzinfo.name
       event_args = { summary: summary, description: description }
@@ -76,17 +116,7 @@ module Collavre
         @user.calendar_id ||= create_app_calendar
         calendar_id = @user.calendar_id
       end
-      result = @service.insert_event(calendar_id, event)
-      CalendarEvent.create!(
-        user: @user,
-        creative: creative,
-        google_event_id: result.id,
-        summary: result.summary,
-        start_time: result.start.date_time || result.start.date,
-        end_time: result.end.date_time || result.end.date,
-        html_link: result.html_link
-      )
-      result
+      @service.insert_event(calendar_id, event)
     rescue Google::Apis::ClientError => e
       # Surface helpful error info to aid debugging 400 errors
       Rails.logger.error("Google Calendar insert_event 4xx: #{e.class} #{e.status_code} - #{e.message} body=#{e.body}")

--- a/engines/collavre/app/services/collavre/google_calendar_service.rb
+++ b/engines/collavre/app/services/collavre/google_calendar_service.rb
@@ -12,50 +12,9 @@ module Collavre
       @service.authorization = user_credentials
     end
 
-    # Creates a Google Calendar event and associated CalendarEvent record.
+    # Creates a Google Calendar event.
     # Optional params supported: location, recurrence (array), attendees (array of emails or attendee hashes),
     # reminders (hash: { use_default: true/false, overrides: [{ method: 'email'|'popup', minutes: Integer }, ...] })
-    def create_event(
-      calendar_id: "primary",
-      start_time:,
-      end_time:,
-      summary:,
-      description: nil,
-      timezone: nil,
-      location: nil,
-      recurrence: nil,
-      attendees: nil,
-      reminders: nil,
-      all_day: false,
-      creative: nil
-    )
-      result = create_google_event(
-        calendar_id: calendar_id,
-        start_time: start_time,
-        end_time: end_time,
-        summary: summary,
-        description: description,
-        timezone: timezone,
-        location: location,
-        recurrence: recurrence,
-        attendees: attendees,
-        reminders: reminders,
-        all_day: all_day
-      )
-      CalendarEvent.create!(
-        user: @user,
-        creative: creative,
-        google_event_id: result.id,
-        summary: result.summary,
-        start_time: result.start.date_time || result.start.date,
-        end_time: result.end.date_time || result.end.date,
-        html_link: result.html_link
-      )
-      result
-    end
-
-    # Creates a Google Calendar event without creating a CalendarEvent record.
-    # Use this when you want to manage the CalendarEvent record separately.
     def create_google_event(
       calendar_id: "primary",
       start_time:,

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -82,6 +82,8 @@ en:
         calendar_args: "YYYY-MM-DD@HH:MM memo (today/tomorrow, +3days, +2weeks, +1months, +1years, +mon)"
       calendar_command:
         event_created: 'event created: [Google Calendar event](%{url})'
+        event_created_local: 'event created (local only - connect Google Calendar to sync)'
+        event_created_sync_failed: 'event created (Google Calendar sync failed - please reconnect your Google account)'
         google_login_required: Please sign in with Google to create a calendar event.
       read_by: Read by %{name}
       activity_logs_summary: Activity Logs

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -79,7 +79,7 @@ en:
       add_reaction_button: "+"
       command_menu:
         calendar_description: "Create a Google Calendar event."
-        calendar_args: "YYYY-MM-DD@HH:MM memo (or 'today')"
+        calendar_args: "YYYY-MM-DD@HH:MM memo (today/tomorrow, +3days, +2weeks, +1months, +1years, +mon)"
       calendar_command:
         event_created: 'event created: [Google Calendar event](%{url})'
         google_login_required: Please sign in with Google to create a calendar event.

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -84,7 +84,6 @@ en:
         event_created: 'event created: [Google Calendar event](%{url})'
         event_created_local: 'event created (local only - connect Google Calendar to sync)'
         event_created_sync_failed: 'event created (Google Calendar sync failed - please reconnect your Google account)'
-        google_login_required: Please sign in with Google to create a calendar event.
       read_by: Read by %{name}
       activity_logs_summary: Activity Logs
     calendar_events:

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -81,7 +81,6 @@ ko:
         event_created: '이벤트가 생성되었습니다: [구글 캘린더 이벤트](%{url})'
         event_created_local: '이벤트가 생성되었습니다 (로컬 전용 - 구글 캘린더 연동 시 동기화됩니다)'
         event_created_sync_failed: '이벤트가 생성되었습니다 (구글 캘린더 동기화 실패 - 구글 계정을 다시 연동해주세요)'
-        google_login_required: 구글 로그인 후 캘린더 이벤트를 생성할 수 있습니다.
       read_by: "%{name} 님이 읽음"
       activity_logs_summary: 활동 기록
     calendar_events:

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -76,7 +76,7 @@ ko:
       add_reaction_button: "+"
       command_menu:
         calendar_description: 구글 캘린더 이벤트를 생성합니다.
-        calendar_args: "YYYY-MM-DD@HH:MM 메모 (또는 'today')"
+        calendar_args: "YYYY-MM-DD@HH:MM 메모 (today/tomorrow, +3days, +2weeks, +1months, +1years, +mon/+월)"
       calendar_command:
         event_created: '이벤트가 생성되었습니다: [구글 캘린더 이벤트](%{url})'
         google_login_required: 구글 로그인 후 캘린더 이벤트를 생성할 수 있습니다.

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -79,6 +79,8 @@ ko:
         calendar_args: "YYYY-MM-DD@HH:MM 메모 (today/tomorrow, +3days, +2weeks, +1months, +1years, +mon/+월)"
       calendar_command:
         event_created: '이벤트가 생성되었습니다: [구글 캘린더 이벤트](%{url})'
+        event_created_local: '이벤트가 생성되었습니다 (로컬 전용 - 구글 캘린더 연동 시 동기화됩니다)'
+        event_created_sync_failed: '이벤트가 생성되었습니다 (구글 캘린더 동기화 실패 - 구글 계정을 다시 연동해주세요)'
         google_login_required: 구글 로그인 후 캘린더 이벤트를 생성할 수 있습니다.
       read_by: "%{name} 님이 읽음"
       activity_logs_summary: 활동 기록

--- a/engines/collavre/db/migrate/20260201100000_make_google_event_id_nullable.rb
+++ b/engines/collavre/db/migrate/20260201100000_make_google_event_id_nullable.rb
@@ -1,0 +1,5 @@
+class MakeGoogleEventIdNullable < ActiveRecord::Migration[8.0]
+  def change
+    change_column_null :calendar_events, :google_event_id, true
+  end
+end

--- a/engines/collavre/test/integration/comments_calendar_test.rb
+++ b/engines/collavre/test/integration/comments_calendar_test.rb
@@ -2,6 +2,8 @@ require "test_helper"
 require "ostruct"
 
 class CommentsCalendarTest < ActionDispatch::IntegrationTest
+  include ActiveSupport::Testing::TimeHelpers
+
   setup do
     @user = User.create!(email: "user_cal@example.com", password: TEST_PASSWORD, name: "User Cal", google_refresh_token: "test_refresh_token")
     @creative = Creative.create!(user: @user, description: "Calendar test creative")
@@ -55,5 +57,57 @@ class CommentsCalendarTest < ActionDispatch::IntegrationTest
     expected_content = "#{command}\n\n#{I18n.t("collavre.comments.calendar_command.event_created", url: event.html_link)}"
     assert_equal expected_content, Comment.last.content
     assert_mock service
+  end
+
+  test "creates all-day event for tomorrow shortcut" do
+    travel_to Time.zone.local(2025, 1, 6, 9, 0, 0) do
+      command = "/calendar tomorrow"
+      tomorrow = Time.zone.today + 1.day
+      event = OpenStruct.new(html_link: "https://calendar.google.com/event/tomorrow123")
+      service = Minitest::Mock.new
+      service.expect(:create_event, event) do |params|
+        assert params[:all_day]
+        assert_equal tomorrow, params[:start_time]
+        assert_equal tomorrow, params[:end_time]
+        true
+      end
+
+      GoogleCalendarService.stub(:new, ->(user:) { assert_equal @user.id, user.id; service }) do
+        assert_difference("Comment.count", 1) do
+          post creative_comments_path(@creative), params: { comment: { content: command } }
+        end
+      end
+
+      assert_response :created
+      expected_content = "#{command}\n\n#{I18n.t("collavre.comments.calendar_command.event_created", url: event.html_link)}"
+      assert_equal expected_content, Comment.last.content
+      assert_mock service
+    end
+  end
+
+  test "creates all-day event for weekday offsets" do
+    travel_to Time.zone.local(2025, 1, 6, 9, 0, 0) do
+      command = "/calendar +2mon"
+      expected_date = Date.new(2025, 1, 20)
+      event = OpenStruct.new(html_link: "https://calendar.google.com/event/weekday123")
+      service = Minitest::Mock.new
+      service.expect(:create_event, event) do |params|
+        assert params[:all_day]
+        assert_equal expected_date, params[:start_time]
+        assert_equal expected_date, params[:end_time]
+        true
+      end
+
+      GoogleCalendarService.stub(:new, ->(user:) { assert_equal @user.id, user.id; service }) do
+        assert_difference("Comment.count", 1) do
+          post creative_comments_path(@creative), params: { comment: { content: command } }
+        end
+      end
+
+      assert_response :created
+      expected_content = "#{command}\n\n#{I18n.t("collavre.comments.calendar_command.event_created", url: event.html_link)}"
+      assert_equal expected_content, Comment.last.content
+      assert_mock service
+    end
   end
 end

--- a/engines/collavre/test/integration/comments_calendar_test.rb
+++ b/engines/collavre/test/integration/comments_calendar_test.rb
@@ -13,34 +13,34 @@ class CommentsCalendarTest < ActionDispatch::IntegrationTest
 
   test "creates all-day event when date argument provided" do
     command = "/calendar 2025-08-01"
-    event = OpenStruct.new(html_link: "https://calendar.google.com/event/abc123")
+    google_event = OpenStruct.new(id: "google_abc123", html_link: "https://calendar.google.com/event/abc123")
     service = Minitest::Mock.new
-    service.expect(:create_event, event) do |params|
+    service.expect(:create_google_event, google_event) do |params|
       assert params[:all_day], "expected all_day flag"
-      assert_kind_of Date, params[:start_time]
-      assert_kind_of Date, params[:end_time]
-      assert_equal Date.new(2025, 8, 1), params[:start_time]
+      assert_equal Date.new(2025, 8, 1), params[:start_time].to_date
+      assert_equal Date.new(2025, 8, 1), params[:end_time].to_date
       true
     end
 
     GoogleCalendarService.stub(:new, ->(user:) { assert_equal @user.id, user.id; service }) do
-      assert_difference("Comment.count", 1) do
+      assert_difference([ "Comment.count", "CalendarEvent.count" ], 1) do
         post creative_comments_path(@creative), params: { comment: { content: command } }
       end
     end
 
     assert_response :created
-    expected_content = "#{command}\n\n#{I18n.t("collavre.comments.calendar_command.event_created", url: event.html_link)}"
+    expected_content = "#{command}\n\n#{I18n.t("collavre.comments.calendar_command.event_created", url: google_event.html_link)}"
     assert_equal expected_content, Comment.last.content
+    assert_equal google_event.id, CalendarEvent.last.google_event_id
     assert_mock service
   end
 
   test "creates all-day event for today shortcut" do
     command = "/calendar today"
     today = Time.zone.today
-    event = OpenStruct.new(html_link: "https://calendar.google.com/event/today123")
+    google_event = OpenStruct.new(id: "google_today123", html_link: "https://calendar.google.com/event/today123")
     service = Minitest::Mock.new
-    service.expect(:create_event, event) do |params|
+    service.expect(:create_google_event, google_event) do |params|
       assert params[:all_day]
       assert_equal today, params[:start_time]
       assert_equal today, params[:end_time]
@@ -48,14 +48,15 @@ class CommentsCalendarTest < ActionDispatch::IntegrationTest
     end
 
     GoogleCalendarService.stub(:new, ->(user:) { assert_equal @user.id, user.id; service }) do
-      assert_difference("Comment.count", 1) do
+      assert_difference([ "Comment.count", "CalendarEvent.count" ], 1) do
         post creative_comments_path(@creative), params: { comment: { content: command } }
       end
     end
 
     assert_response :created
-    expected_content = "#{command}\n\n#{I18n.t("collavre.comments.calendar_command.event_created", url: event.html_link)}"
+    expected_content = "#{command}\n\n#{I18n.t("collavre.comments.calendar_command.event_created", url: google_event.html_link)}"
     assert_equal expected_content, Comment.last.content
+    assert_equal google_event.id, CalendarEvent.last.google_event_id
     assert_mock service
   end
 
@@ -63,9 +64,9 @@ class CommentsCalendarTest < ActionDispatch::IntegrationTest
     travel_to Time.zone.local(2025, 1, 6, 9, 0, 0) do
       command = "/calendar tomorrow"
       tomorrow = Time.zone.today + 1.day
-      event = OpenStruct.new(html_link: "https://calendar.google.com/event/tomorrow123")
+      google_event = OpenStruct.new(id: "google_tomorrow123", html_link: "https://calendar.google.com/event/tomorrow123")
       service = Minitest::Mock.new
-      service.expect(:create_event, event) do |params|
+      service.expect(:create_google_event, google_event) do |params|
         assert params[:all_day]
         assert_equal tomorrow, params[:start_time]
         assert_equal tomorrow, params[:end_time]
@@ -73,14 +74,15 @@ class CommentsCalendarTest < ActionDispatch::IntegrationTest
       end
 
       GoogleCalendarService.stub(:new, ->(user:) { assert_equal @user.id, user.id; service }) do
-        assert_difference("Comment.count", 1) do
+        assert_difference([ "Comment.count", "CalendarEvent.count" ], 1) do
           post creative_comments_path(@creative), params: { comment: { content: command } }
         end
       end
 
       assert_response :created
-      expected_content = "#{command}\n\n#{I18n.t("collavre.comments.calendar_command.event_created", url: event.html_link)}"
+      expected_content = "#{command}\n\n#{I18n.t("collavre.comments.calendar_command.event_created", url: google_event.html_link)}"
       assert_equal expected_content, Comment.last.content
+      assert_equal google_event.id, CalendarEvent.last.google_event_id
       assert_mock service
     end
   end
@@ -89,9 +91,9 @@ class CommentsCalendarTest < ActionDispatch::IntegrationTest
     travel_to Time.zone.local(2025, 1, 6, 9, 0, 0) do
       command = "/calendar +2mon"
       expected_date = Date.new(2025, 1, 20)
-      event = OpenStruct.new(html_link: "https://calendar.google.com/event/weekday123")
+      google_event = OpenStruct.new(id: "google_weekday123", html_link: "https://calendar.google.com/event/weekday123")
       service = Minitest::Mock.new
-      service.expect(:create_event, event) do |params|
+      service.expect(:create_google_event, google_event) do |params|
         assert params[:all_day]
         assert_equal expected_date, params[:start_time]
         assert_equal expected_date, params[:end_time]
@@ -99,15 +101,83 @@ class CommentsCalendarTest < ActionDispatch::IntegrationTest
       end
 
       GoogleCalendarService.stub(:new, ->(user:) { assert_equal @user.id, user.id; service }) do
-        assert_difference("Comment.count", 1) do
+        assert_difference([ "Comment.count", "CalendarEvent.count" ], 1) do
           post creative_comments_path(@creative), params: { comment: { content: command } }
         end
       end
 
       assert_response :created
-      expected_content = "#{command}\n\n#{I18n.t("collavre.comments.calendar_command.event_created", url: event.html_link)}"
+      expected_content = "#{command}\n\n#{I18n.t("collavre.comments.calendar_command.event_created", url: google_event.html_link)}"
       assert_equal expected_content, Comment.last.content
+      assert_equal google_event.id, CalendarEvent.last.google_event_id
       assert_mock service
     end
+  end
+
+  test "creates local-only event when google not connected" do
+    user_without_google = User.create!(email: "user_no_google@example.com", password: TEST_PASSWORD, name: "User No Google")
+    creative = Creative.create!(user: user_without_google, description: "No Google calendar test")
+    CreativeShare.create!(creative: creative, user: user_without_google, permission: :feedback)
+    sign_in_as(user_without_google)
+
+    command = "/calendar tomorrow"
+
+    assert_difference([ "Comment.count", "CalendarEvent.count" ], 1) do
+      post creative_comments_path(creative), params: { comment: { content: command } }
+    end
+
+    assert_response :created
+    expected_content = "#{command}\n\n#{I18n.t("collavre.comments.calendar_command.event_created_local")}"
+    assert_equal expected_content, Comment.last.content
+
+    calendar_event = CalendarEvent.last
+    assert_nil calendar_event.google_event_id
+    assert_nil calendar_event.html_link
+    assert_equal user_without_google.id, calendar_event.user_id
+    assert_equal creative.id, calendar_event.creative_id
+  end
+
+  test "creates timed event with date and time combined like today@14:00" do
+    user_without_google = User.create!(email: "user_timed@example.com", password: TEST_PASSWORD, name: "User Timed")
+    creative = Creative.create!(user: user_without_google, description: "Timed event test")
+    CreativeShare.create!(creative: creative, user: user_without_google, permission: :feedback)
+    sign_in_as(user_without_google)
+
+    command = "/cal today@14:00"
+
+    assert_difference([ "Comment.count", "CalendarEvent.count" ], 1) do
+      post creative_comments_path(creative), params: { comment: { content: command } }
+    end
+
+    assert_response :created
+
+    calendar_event = CalendarEvent.last
+    assert_equal user_without_google.id, calendar_event.user_id
+    assert_equal creative.id, calendar_event.creative_id
+    assert_equal Time.zone.today, calendar_event.start_time.to_date
+    assert_equal 14, calendar_event.start_time.hour
+    assert_equal 0, calendar_event.start_time.min
+  end
+
+  test "creates local event and shows sync failed message when google sync fails" do
+    command = "/calendar tomorrow"
+    service = Minitest::Mock.new
+    service.expect(:create_google_event, nil) do |_params|
+      raise StandardError, "OAuth error"
+    end
+
+    GoogleCalendarService.stub(:new, ->(user:) { assert_equal @user.id, user.id; service }) do
+      assert_difference([ "Comment.count", "CalendarEvent.count" ], 1) do
+        post creative_comments_path(@creative), params: { comment: { content: command } }
+      end
+    end
+
+    assert_response :created
+    expected_content = "#{command}\n\n#{I18n.t("collavre.comments.calendar_command.event_created_sync_failed")}"
+    assert_equal expected_content, Comment.last.content
+
+    calendar_event = CalendarEvent.last
+    assert_nil calendar_event.google_event_id
+    assert_equal @user.id, calendar_event.user_id
   end
 end

--- a/engines/collavre/test/models/calendar_event_test.rb
+++ b/engines/collavre/test/models/calendar_event_test.rb
@@ -24,4 +24,52 @@ class CalendarEventTest < ActiveSupport::TestCase
     assert_predicate event, :destroyed?
     assert delete_called, "Expected delete_event to be called"
   end
+
+  test "does not call Google delete when google_event_id is nil" do
+    user = User.create!(email: "calendar-user-local@example.com", password: TEST_PASSWORD, name: "Calendar User Local")
+    event = CalendarEvent.create!(
+      user: user,
+      google_event_id: nil,
+      start_time: Time.current,
+      end_time: 1.hour.from_now
+    )
+
+    delete_called = false
+    fake_service = Object.new
+    fake_service.define_singleton_method(:delete_event) do |_event_id|
+      delete_called = true
+      true
+    end
+
+    Collavre::GoogleCalendarService.stub(:new, ->(**_) { fake_service }) do
+      event.destroy
+    end
+
+    assert_predicate event, :destroyed?
+    assert_not delete_called, "Expected delete_event NOT to be called for local-only event"
+  end
+
+  test "synced_to_google? returns true when google_event_id present" do
+    user = User.create!(email: "calendar-user-sync@example.com", password: TEST_PASSWORD, name: "Calendar Sync User")
+    event = CalendarEvent.create!(
+      user: user,
+      google_event_id: "abc123",
+      start_time: Time.current,
+      end_time: 1.hour.from_now
+    )
+
+    assert event.synced_to_google?
+  end
+
+  test "synced_to_google? returns false when google_event_id nil" do
+    user = User.create!(email: "calendar-user-nosync@example.com", password: TEST_PASSWORD, name: "Calendar NoSync User")
+    event = CalendarEvent.create!(
+      user: user,
+      google_event_id: nil,
+      start_time: Time.current,
+      end_time: 1.hour.from_now
+    )
+
+    assert_not event.synced_to_google?
+  end
 end


### PR DESCRIPTION
### Motivation
- Allow users to specify relative dates and weekday shortcuts in the `/calendar` command for more flexible event creation. 
- Support both Korean and English weekday tokens and common relative formats (tomorrow, +Nd/Nweeks/Nmonths/Nyears) to match product UX expectations.

### Description
- Reworked argument parsing in `Collavre::Comments::CalendarCommand#parsed_args` to split date/time/memo and introduced `parse_command_parts` to handle `@HH:MM`-only and full inputs. 
- Implemented `parse_date_token` to handle `today`, `tomorrow`, `+{N}days|weeks|months|years`, ISO `YYYY-MM-DD`, and weekday shorthand `+{N}{mon|tue|...}` plus Korean weekdays (`월화수목금토일`). 
- Added helper methods `weekday_index` and `next_weekday` to compute the correct upcoming weekday (with `{N}` defaulting to 1 and `+weekday` on the same weekday yielding next week). 
- Updated locale hints in `engines/collavre/config/locales/comments.en.yml` and `comments.ko.yml` to document the new formats. 
- Added integration tests in `engines/collavre/test/integration/comments_calendar_test.rb` covering `tomorrow` and weekday offset parsing, and included `ActiveSupport::Testing::TimeHelpers` for deterministic time-based assertions.

### Testing
- Attempted `./bin/rubocop -a`, which failed due to missing Ruby in the environment (`/usr/bin/env: ‘ruby’: No such file or directory`).
- Attempted `rails test` and `rails test:system`, both failed because `rails` is not available in the execution environment (`command not found: rails`).
- Added integration tests (`CommentsCalendarTest`) for `tomorrow` and `+2mon` behaviors; these tests were added to the repo but were not run successfully in this environment due to the missing Ruby/Rails runtime.

### Original User's Requirements
- Support `tomorrow`, `+{number}days`, `+{number}weeks`, `+{number}months`, and `+{number}years` in the `/calendar` command.
- Allow weekday shortcuts using Korean (`월,화,수,목,금,토,일`) or English (`mon, tue, wed, thu, fri, sat, sun`), case-insensitive.
- Weekday shorthand uses `+{number}{weekday}` with `{number}` defaulting to `1`, where `+월` on Monday resolves to next week's Monday and `+2mon` resolves to the second upcoming Monday.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ca30cce148326be338649302e6f53)