### PR TITLE
Fix Creative Tree print bullets

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/print.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/print.css
@@ -34,4 +34,22 @@
   .creative-actions-row {
     visibility: visible !important;
   }
+
+  .creative-tree-bullet {
+    background: none;
+    width: auto;
+    height: auto;
+    min-width: 0;
+    min-height: 0;
+    margin-top: 0.1em;
+  }
+
+  .creative-tree-bullet::before {
+    content: "•";
+    display: inline-block;
+    color: var(--color-text);
+    font-size: 0.9em;
+    line-height: 1;
+    width: 0.6em;
+  }
 }


### PR DESCRIPTION
### Motivation
- Printed Creative Tree list items were missing the visual bullet markers; bullets should render in the print stylesheet so tree levels show as expected on paper/PDF.

### Description
- Add print-specific rules to `engines/collavre/app/assets/stylesheets/collavre/print.css` that replace the non-printable dot element with a text bullet via `.creative-tree-bullet::before { content: "•"; }` and adjust sizing/spacing for reliable print rendering.

### Testing
- Ran `./bin/rubocop -a` which failed due to missing Ruby in this environment (`/usr/bin/env: ‘ruby’: No such file or directory`), and attempted `rails test` and `rails test:system` which failed due to missing `rails` command in this environment; no application tests were executed successfully here.

### Original User's Requirements
- Creative를 페이지를 웹에서 프린트를 눌러서 프린트 할때 Creative Tree List 뷰 렌더링 체계에서 트리 레벨에 따라 bullet point 로 표시하는 부분에서 bullet 부분이 누락되고 있어 bullet 도 표시되서 프린트 되도록 해줘.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ce250d9888326bf78274d57c56423)