### PR TITLE
Migrate Active Storage attachment record types for Collavre engine

### DIFF
--- a/engines/collavre/db/migrate/20260201090000_migrate_active_storage_attachment_record_types.rb
+++ b/engines/collavre/db/migrate/20260201090000_migrate_active_storage_attachment_record_types.rb
@@ -1,0 +1,21 @@
+class MigrateActiveStorageAttachmentRecordTypes < ActiveRecord::Migration[8.1]
+  def up
+    return unless table_exists?(:active_storage_attachments)
+
+    migrate_record_type("User", "Collavre::User")
+    migrate_record_type("Comment", "Collavre::Comment")
+  end
+
+  def down
+    return unless table_exists?(:active_storage_attachments)
+
+    migrate_record_type("Collavre::User", "User")
+    migrate_record_type("Collavre::Comment", "Comment")
+  end
+
+  private
+
+  def migrate_record_type(from, to)
+    ActiveStorage::Attachment.where(record_type: from).update_all(record_type: to)
+  end
+end


### PR DESCRIPTION
### Motivation
- The Collavre engine moved models under the `Collavre::` namespace which causes preexisting Active Storage attachments with `record_type` values like `User` or `Comment` to no longer resolve to the namespaced models.  
- A data migration is required so `active_storage_attachments.record_type` values are updated to the namespaced model names and attachments display correctly after the engine change.

### Description
- Add a migration `engines/collavre/db/migrate/20260201090000_migrate_active_storage_attachment_record_types.rb` that updates `ActiveStorage::Attachment.record_type` values from `User` to `Collavre::User` and from `Comment` to `Collavre::Comment`.  
- The migration includes an `up` that performs the namespace mapping and a `down` that reverses the mappings.  
- The migration checks `table_exists?(:active_storage_attachments)` before attempting updates and uses a helper `migrate_record_type(from, to)` which runs a single `update_all` for each mapping.

### Testing
- Ran `./bin/rubocop -a` which could not run in this environment due to missing Ruby (`/usr/bin/env: 'ruby': No such file or directory`).  
- Ran `rails test` which could not run in this environment because `rails` is not available (`command not found: rails`).  
- Ran `rails test:system` which also could not run for the same reason (`command not found: rails`).

### Original User's Requirements
- collavre engine 을 만들어서 모델이 다 Collavre:: 모듈에 들어가게 됐어 따라서 첨부되는 파일이 모두 표시가 되지 않아. 해당 변경으로 인해 attachement type 에 대한 마이그레이션을 해야 해

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ce4ae639c83269a39f155ae739d95)