### PR TITLE
fix(markdown-import): skip horizontal rules and group code blocks

### DIFF
--- a/engines/collavre/app/services/collavre/markdown_importer.rb
+++ b/engines/collavre/app/services/collavre/markdown_importer.rb
@@ -1,5 +1,8 @@
 module Collavre
   class MarkdownImporter
+    # Matches horizontal rules: ---, ***, ___ (with optional spaces)
+    HORIZONTAL_RULE_REGEX = /^\s*([-*_])\s*\1\s*\1[\s\1]*$/
+
     def self.import(content, parent:, user:, create_root: false)
       lines = content.to_s.lines
       image_refs = {}
@@ -26,21 +29,51 @@ module Collavre
         end
       end
       stack = [ [ 0, root ] ]
-      current_fence = nil
       while i < lines.size
         line = lines[i]
-        if (fence_match = line.match(/^\s*(`{3,}|~{3,})/))
-          fence_marker = fence_match[1]
-          fence_char = fence_marker[0]
-          fence_length = fence_marker.length
-          if current_fence.nil?
-            current_fence = { char: fence_char, length: fence_length }
-          elsif current_fence[:char] == fence_char && fence_length >= current_fence[:length]
-            current_fence = nil
-          end
+
+        # Skip horizontal rules (---, ***, ___)
+        if line =~ HORIZONTAL_RULE_REGEX
+          i += 1
+          next
         end
 
-        if current_fence.nil? && (table_data = parse_markdown_table(lines, i))
+        # Handle fenced code blocks (``` or ~~~)
+        if (fence_match = line.match(/^(\s*)(`{3,}|~{3,})(.*)$/))
+          fence_indent = fence_match[1]
+          fence_marker = fence_match[2]
+          fence_char = fence_marker[0]
+          fence_length = fence_marker.length
+          fence_info = fence_match[3].strip # language info (e.g., "ruby", "javascript")
+
+          # Collect all lines until closing fence
+          code_lines = []
+          i += 1
+          while i < lines.size
+            close_line = lines[i]
+            # Check for closing fence (same char, at least same length)
+            if (close_match = close_line.match(/^\s*(`{3,}|~{3+})\s*$/))
+              close_marker = close_match[1]
+              if close_marker[0] == fence_char && close_marker.length >= fence_length
+                i += 1
+                break
+              end
+            end
+            code_lines << close_line
+            i += 1
+          end
+
+          # Build code block HTML
+          code_content = code_lines.join
+          code_html = build_code_block_html(code_content, fence_info)
+
+          new_parent = stack.any? ? stack.last[1] : root
+          c = Creative.create(user: user, parent: new_parent, description: code_html)
+          created << c
+          next
+        end
+
+        if (table_data = parse_markdown_table(lines, i))
           table_html = build_table_html(table_data, image_refs)
           new_parent = stack.any? ? stack.last[1] : root
           c = Creative.create(user: user, parent: new_parent, description: table_html)
@@ -76,6 +109,12 @@ module Collavre
         end
       end
       created
+    end
+
+    def self.build_code_block_html(code_content, language = nil)
+      escaped_content = ERB::Util.html_escape(code_content)
+      lang_class = language.present? ? " class=\"language-#{ERB::Util.html_escape(language)}\"" : ""
+      "<pre><code#{lang_class}>#{escaped_content}</code></pre>"
     end
 
     def self.parse_markdown_table(lines, index)

--- a/engines/collavre/test/services/markdown_importer_test.rb
+++ b/engines/collavre/test/services/markdown_importer_test.rb
@@ -1,6 +1,92 @@
 require "test_helper"
 
 class MarkdownImporterTest < ActiveSupport::TestCase
+  test "skips horizontal rules" do
+    user = users(:one)
+    parent = Creative.create!(user: user, description: "Parent")
+    markdown = <<~MD
+      # Header
+      Some content
+      ---
+      More content
+      ***
+      Final content
+      ___
+    MD
+
+    created = MarkdownImporter.import(markdown, parent: parent, user: user)
+    descriptions = created.map { |c| c.reload.description }
+
+    # Should have: Header, Some content, More content, Final content
+    assert_equal 4, created.size, "Horizontal rules should be skipped"
+    assert descriptions.none? { |d| d.strip == "---" }, "--- should not create a Creative"
+    assert descriptions.none? { |d| d.strip == "***" }, "*** should not create a Creative"
+    assert descriptions.none? { |d| d.strip == "___" }, "___ should not create a Creative"
+  end
+
+  test "imports fenced code blocks as single creative with pre/code tags" do
+    user = users(:one)
+    parent = Creative.create!(user: user, description: "Parent")
+    markdown = <<~MD
+      # Header
+      ```ruby
+      def hello
+        puts "world"
+      end
+      ```
+      Some text after
+    MD
+
+    created = MarkdownImporter.import(markdown, parent: parent, user: user)
+
+    # Should have: Header, code block, Some text after
+    assert_equal 3, created.size, "Code block should be a single Creative"
+
+    code_creative = created[1].reload
+    html = code_creative.description
+
+    assert_includes html, "<pre><code", "Code block should have pre/code tags"
+    assert_includes html, 'class="language-ruby"', "Code block should preserve language"
+    assert_includes html, "def hello", "Code block should contain the code"
+    assert_includes html, "puts", "Code block should contain all lines"
+  end
+
+  test "handles code blocks without language specifier" do
+    user = users(:one)
+    parent = Creative.create!(user: user, description: "Parent")
+    markdown = <<~MD
+      ```
+      plain code
+      more lines
+      ```
+    MD
+
+    created = MarkdownImporter.import(markdown, parent: parent, user: user)
+    assert_equal 1, created.size
+
+    html = created.first.reload.description
+    assert_includes html, "<pre><code>"
+    assert_includes html, "plain code"
+    assert_not_includes html, 'class="language-'
+  end
+
+  test "escapes html in code blocks" do
+    user = users(:one)
+    parent = Creative.create!(user: user, description: "Parent")
+    markdown = <<~MD
+      ```html
+      <div class="test">Hello</div>
+      ```
+    MD
+
+    created = MarkdownImporter.import(markdown, parent: parent, user: user)
+    html = created.first.reload.description
+
+    assert_includes html, "&lt;div"
+    assert_includes html, "&gt;"
+    assert_not_includes html, "<div class=\"test\">"
+  end
+
   test "imports markdown tables as html" do
     user = users(:one)
     parent = Creative.create!(user: user, description: "Parent")


### PR DESCRIPTION
## Summary

Fix markdown import to properly handle:
1. **Horizontal rules** (`---`, `***`, `___`) - now skipped instead of creating empty Creatives
2. **Fenced code blocks** (````) - now grouped into a single Creative with proper `<pre><code>` HTML tags

## Changes

### Horizontal Rules
- Added `HORIZONTAL_RULE_REGEX` to detect and skip HR patterns
- Supports all standard markdown HR variants: `---`, `***`, `___`

### Code Blocks  
- Collects all lines within fence markers into a single code block
- Generates proper HTML: `<pre><code class="language-xxx">...</code></pre>`
- Preserves language specifier for syntax highlighting
- HTML-escapes content for security

## Tests
- Added 4 new test cases covering:
  - Horizontal rule skipping
  - Code block grouping with language
  - Code blocks without language
  - HTML escaping in code blocks

## Checklist
- [x] All UI text uses `t()` (N/A - no UI changes)
- [x] en.yml completed (N/A)
- [x] ko.yml completed (N/A)
- [x] Tests passing
- [x] Rubocop passing