### PR TITLE
feat(routing): prioritize mention-based routing over Liquid expressions

### DIFF
--- a/engines/collavre/app/services/collavre/system_events/router.rb
+++ b/engines/collavre/app/services/collavre/system_events/router.rb
@@ -6,6 +6,31 @@ module Collavre
         liquid_context = Collavre::SystemEvents::ContextBuilder.new(context).build
         liquid_context["event_name"] = event_name
 
+        # Priority 1: Mention-based routing (exclusive)
+        # If any AI agent is mentioned, ONLY route to that agent
+        mentioned_agent = find_mentioned_agent(liquid_context, context)
+        return [ mentioned_agent ] if mentioned_agent
+
+        # Priority 2: Liquid expression routing (fallback)
+        route_by_liquid_expression(liquid_context, context)
+      end
+
+      private
+
+      def find_mentioned_agent(liquid_context, context)
+        mentioned_user_data = liquid_context.dig("chat", "mentioned_user")
+        return nil unless mentioned_user_data && mentioned_user_data["id"]
+
+        agent = User.find_by(id: mentioned_user_data["id"])
+        return nil unless agent&.ai_user?
+
+        # Permission check for mentioned agent
+        return nil unless has_creative_permission?(agent, context)
+
+        agent
+      end
+
+      def route_by_liquid_expression(liquid_context, context)
         # Find all AI agents
         agents = User.where.not(llm_vendor: nil)
 
@@ -15,32 +40,7 @@ module Collavre
           next if agent.routing_expression.blank?
 
           # Permission Check
-          # If agent is not searchable, it must have feedback permission on the creative
-          unless agent.searchable?
-            creative_id = context.dig("creative", "id") || context.dig(:creative, :id)
-            if creative_id
-              creative = Creative.find_by(id: creative_id)
-              if creative
-                # Check for feedback permission (which implies read access)
-                # has_permission? checks for the specific permission or higher
-                unless creative.has_permission?(agent, :feedback)
-                  # Rails.logger.info "Agent #{agent.id} skipped: No feedback permission on Creative #{creative.id}"
-                  next
-                end
-              else
-                # If creative ID is present but not found, skip for safety
-                next
-              end
-            else
-              # If no creative context, we might skip or allow depending on policy.
-              # Assuming 'chat.creative' implies creative context is required for this check.
-              # If it's a global event without creative, maybe searchable check isn't needed?
-              # But the user said "must have feedback permission on the chat.creative".
-              # If there is no creative, we can't check permission, so we should probably skip to be safe
-              # unless it's a purely global event. But for now, let's skip.
-              next
-            end
-          end
+          next unless has_creative_permission?(agent, context)
 
           begin
             # Add 'agent' to context so they can refer to themselves
@@ -66,6 +66,20 @@ module Collavre
         end
 
         matched_agents
+      end
+
+      def has_creative_permission?(agent, context)
+        # Searchable agents can receive any routed message
+        return true if agent.searchable?
+
+        # Non-searchable agents must have feedback permission on the creative
+        creative_id = context.dig("creative", "id") || context.dig(:creative, :id)
+        return false unless creative_id
+
+        creative = Creative.find_by(id: creative_id)
+        return false unless creative
+
+        creative.has_permission?(agent, :feedback)
       end
     end
   end

--- a/engines/collavre/test/services/system_events/router_test.rb
+++ b/engines/collavre/test/services/system_events/router_test.rb
@@ -27,33 +27,80 @@ module SystemEvents
       }
     end
 
-    test "routes event to agent when expression evaluates to true" do
+    # ========================================
+    # Mention-based Routing (Priority 1)
+    # ========================================
+
+    test "mention routing: routes exclusively to mentioned AI agent" do
+      # Create another agent that would match via Liquid expression
+      other_agent = User.create!(
+        email: "other_agent@example.com",
+        name: "Other Agent",
+        password: "password",
+        llm_vendor: "google",
+        llm_model: "gemini-1.5-flash",
+        routing_expression: "true", # This would always match
+        searchable: true
+      )
+
+      router = SystemEvents::Router.new
+      agents = router.route("comment_created", @context)
+
+      # Only the mentioned agent should receive the message
+      assert_equal 1, agents.length
+      assert_includes agents, @agent
+      assert_not_includes agents, other_agent
+    end
+
+    test "mention routing: ignores liquid expressions when agent is mentioned" do
+      # Even with routing_expression: "false", mentioned agent should receive
+      @agent.update!(routing_expression: "false")
+
       router = SystemEvents::Router.new
       agents = router.route("comment_created", @context)
 
       assert_includes agents, @agent
     end
 
-    test "does not route event when expression evaluates to false" do
-      @agent.update!(routing_expression: "false")
+    test "mention routing: skips mentioned non-AI user" do
+      # Create a regular user (not an AI agent)
+      regular_user = User.create!(
+        email: "regular@example.com",
+        name: "Regular User",
+        password: "password",
+        searchable: true
+      )
+
+      context = {
+        "creative" => { "id" => @creative.id },
+        "chat" => {
+          "content" => "@Regular User: Hello",
+          "mentioned_user" => { "id" => regular_user.id }
+        }
+      }
+
+      # Create an agent with "true" routing expression as fallback
+      @agent.update!(routing_expression: "true")
+
+      router = SystemEvents::Router.new
+      agents = router.route("comment_created", context)
+
+      # Should fall back to Liquid routing
+      assert_includes agents, @agent
+    end
+
+    test "mention routing: respects permission for non-searchable mentioned agent" do
+      @agent.update!(searchable: false)
 
       router = SystemEvents::Router.new
       agents = router.route("comment_created", @context)
 
+      # Mentioned but no permission - should not route
       assert_not_includes agents, @agent
     end
 
-    test "skips non-searchable agent without permission" do
-      @agent.update!(searchable: false, routing_expression: "true")
-
-      router = SystemEvents::Router.new
-      agents = router.route("comment_created", @context)
-
-      assert_not_includes agents, @agent
-    end
-
-    test "routes non-searchable agent with permission" do
-      @agent.update!(searchable: false, routing_expression: "true")
+    test "mention routing: routes to non-searchable mentioned agent with permission" do
+      @agent.update!(searchable: false)
       perform_enqueued_jobs do
         CreativeShare.create!(creative: @creative, user: @agent, permission: :feedback, shared_by: @owner)
       end
@@ -64,26 +111,116 @@ module SystemEvents
       assert_includes agents, @agent
     end
 
-    test "handles liquid error gracefully" do
+    # ========================================
+    # Liquid Expression Routing (Priority 2)
+    # ========================================
+
+    test "liquid routing: routes event to agent when expression evaluates to true" do
+      # No mention in context
+      context = {
+        "creative" => { "id" => @creative.id },
+        "chat" => { "content" => "Hello world" }
+      }
+      @agent.update!(routing_expression: "true")
+
+      router = SystemEvents::Router.new
+      agents = router.route("comment_created", context)
+
+      assert_includes agents, @agent
+    end
+
+    test "liquid routing: does not route event when expression evaluates to false" do
+      context = {
+        "creative" => { "id" => @creative.id },
+        "chat" => { "content" => "Hello world" }
+      }
+      @agent.update!(routing_expression: "false")
+
+      router = SystemEvents::Router.new
+      agents = router.route("comment_created", context)
+
+      assert_not_includes agents, @agent
+    end
+
+    test "liquid routing: skips non-searchable agent without permission" do
+      context = {
+        "creative" => { "id" => @creative.id },
+        "chat" => { "content" => "Hello world" }
+      }
+      @agent.update!(searchable: false, routing_expression: "true")
+
+      router = SystemEvents::Router.new
+      agents = router.route("comment_created", context)
+
+      assert_not_includes agents, @agent
+    end
+
+    test "liquid routing: routes non-searchable agent with permission" do
+      context = {
+        "creative" => { "id" => @creative.id },
+        "chat" => { "content" => "Hello world" }
+      }
+      @agent.update!(searchable: false, routing_expression: "true")
+      perform_enqueued_jobs do
+        CreativeShare.create!(creative: @creative, user: @agent, permission: :feedback, shared_by: @owner)
+      end
+
+      router = SystemEvents::Router.new
+      agents = router.route("comment_created", context)
+
+      assert_includes agents, @agent
+    end
+
+    test "liquid routing: handles liquid error gracefully" do
       @agent.update!(routing_expression: "{{ invalid syntax }")
 
       assert_nothing_raised do
         router = SystemEvents::Router.new
         agents = router.route("comment_created", @context)
-        assert_not_includes agents, @agent
+        # Still routes via mention even if liquid is broken
+        assert_includes agents, @agent
       end
     end
 
-    test "routes based on event_name" do
+    test "liquid routing: routes based on event_name" do
+      context = {
+        "creative" => { "id" => @creative.id },
+        "chat" => { "content" => "Hello world" }
+      }
       @agent.update!(routing_expression: "event_name == 'comment_created'")
 
       router = SystemEvents::Router.new
-      agents = router.route("comment_created", @context)
+      agents = router.route("comment_created", context)
 
       assert_includes agents, @agent
 
-      agents = router.route("other_event", @context)
+      agents = router.route("other_event", context)
       assert_not_includes agents, @agent
+    end
+
+    test "liquid routing: can route to multiple agents" do
+      context = {
+        "creative" => { "id" => @creative.id },
+        "chat" => { "content" => "Hello world" }
+      }
+      @agent.update!(routing_expression: "true")
+
+      other_agent = User.create!(
+        email: "other_agent@example.com",
+        name: "Other Agent",
+        password: "password",
+        llm_vendor: "google",
+        llm_model: "gemini-1.5-flash",
+        routing_expression: "true",
+        searchable: true
+      )
+
+      router = SystemEvents::Router.new
+      agents = router.route("comment_created", context)
+
+      assert_equal 2, agents.length
+      assert_includes agents, @agent
+      assert_includes agents, other_agent
     end
   end
 end


### PR DESCRIPTION
## Summary

When an AI agent is @mentioned in a comment, route the message **exclusively** to that agent. Other agents are excluded even if their `routing_expression` would match.

## Changes

### Router Priority
1. **Mention Match (Priority 1)**: If `@AgentName:` is detected and it's an AI agent, only that agent receives the message
2. **Liquid Expression (Priority 2)**: Falls back to existing Liquid routing when no AI agent is mentioned

### Code Changes
- Refactored `Router#route` to check mentions first
- Extracted `has_creative_permission?` for reusability
- Added `find_mentioned_agent` for mention detection

### Tests
- 12 tests covering both routing paths
- Mention routing: exclusive behavior, permission checks, non-AI user fallback
- Liquid routing: existing behavior preserved

## Why

Makes agent routing more intuitive:
- Users can direct messages to specific agents with `@AgentName:`
- Background agents (with `routing_expression: "true"`) won't intercept targeted conversations
- Future: AI can help generate Liquid expressions from natural language