### PR TITLE
fix: patch RubyLlmBuilder to map float type to number

### DIFF
--- a/config/initializers/ruby_llm.rb
+++ b/config/initializers/ruby_llm.rb
@@ -11,3 +11,19 @@ RubyLLM.configure do |config|
   config.log_level = Logger::DEBUG
   config.log_stream_debug = true
 end
+
+# Monkey patch to fix RubyLlmBuilder float type mapping
+# RubyLLM DSL uses `number` not `float`
+# See: https://github.com/rails_mcp_engine issue
+Rails.application.config.to_prepare do
+  if defined?(ToolSchema::RubyLlmBuilder)
+    ToolSchema::RubyLlmBuilder.singleton_class.prepend(Module.new do
+      def scalar_method(type)
+        case type
+        when :float then :number  # RubyLLM uses `number` not `float`
+        else super
+        end
+      end
+    end)
+  end
+end

--- a/test/lib/ruby_llm_tool_conversion_test.rb
+++ b/test/lib/ruby_llm_tool_conversion_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class RubyLlmToolConversionTest < ActiveSupport::TestCase
   test "converts creative_create_service to RubyLLM tool without error" do
-    tool_names = ["creative_create_service"]
+    tool_names = [ "creative_create_service" ]
 
     # This should not raise "undefined method 'float'" error
     assert_nothing_raised do
@@ -12,7 +12,7 @@ class RubyLlmToolConversionTest < ActiveSupport::TestCase
   end
 
   test "converts creative_update_service to RubyLLM tool without error" do
-    tool_names = ["creative_update_service"]
+    tool_names = [ "creative_update_service" ]
 
     assert_nothing_raised do
       tool_classes = ::Tools::MetaToolService.ruby_llm_tools(tool_names)
@@ -21,7 +21,7 @@ class RubyLlmToolConversionTest < ActiveSupport::TestCase
   end
 
   test "converts all creative tools to RubyLLM tools" do
-    tool_names = ["creative_create_service", "creative_update_service", "creative_retrieval_service"]
+    tool_names = [ "creative_create_service", "creative_update_service", "creative_retrieval_service" ]
 
     assert_nothing_raised do
       tool_classes = ::Tools::MetaToolService.ruby_llm_tools(tool_names)

--- a/test/lib/ruby_llm_tool_conversion_test.rb
+++ b/test/lib/ruby_llm_tool_conversion_test.rb
@@ -1,0 +1,39 @@
+require "test_helper"
+
+class RubyLlmToolConversionTest < ActiveSupport::TestCase
+  test "converts creative_create_service to RubyLLM tool without error" do
+    tool_names = ["creative_create_service"]
+
+    # This should not raise "undefined method 'float'" error
+    assert_nothing_raised do
+      tool_classes = ::Tools::MetaToolService.ruby_llm_tools(tool_names)
+      assert tool_classes.present?, "Expected tool classes to be returned"
+    end
+  end
+
+  test "converts creative_update_service to RubyLLM tool without error" do
+    tool_names = ["creative_update_service"]
+
+    assert_nothing_raised do
+      tool_classes = ::Tools::MetaToolService.ruby_llm_tools(tool_names)
+      assert tool_classes.present?, "Expected tool classes to be returned"
+    end
+  end
+
+  test "converts all creative tools to RubyLLM tools" do
+    tool_names = ["creative_create_service", "creative_update_service", "creative_retrieval_service"]
+
+    assert_nothing_raised do
+      tool_classes = ::Tools::MetaToolService.ruby_llm_tools(tool_names)
+      assert_equal 3, tool_classes.length, "Expected 3 tool classes"
+    end
+  end
+
+  test "float type is mapped to number in RubyLLM params DSL" do
+    # Verify the monkey patch is working
+    assert_equal :number, ToolSchema::RubyLlmBuilder.scalar_method(:float)
+    assert_equal :integer, ToolSchema::RubyLlmBuilder.scalar_method(:integer)
+    assert_equal :string, ToolSchema::RubyLlmBuilder.scalar_method(:string)
+    assert_equal :boolean, ToolSchema::RubyLlmBuilder.scalar_method(:boolean)
+  end
+end


### PR DESCRIPTION
## Problem
AI agents using tools with Float parameters (like `progress` in `creative_create_service`) fail with:
```
AI Error: undefined method 'float' for class #<Class:0x...>
```

## Root Cause
`rails_mcp_engine`'s `ToolSchema::RubyLlmBuilder` maps `:float` type to `ctx.float(name)`, but RubyLLM's params DSL only has `number` method, not `float`.

## Solution
Add a monkey patch in `config/initializers/ruby_llm.rb` that maps `:float` → `:number` using `prepend`.

## Changes
- `config/initializers/ruby_llm.rb`: Add `to_prepare` block with monkey patch
- `test/lib/ruby_llm_tool_conversion_test.rb`: Add tests for RubyLLM tool conversion

## Testing
- All 4 new tests pass
- Verified `creative_create_service` and `creative_update_service` convert correctly