### PR TITLE
feat: Add AI Agent tool execution approval flow

### DIFF
--- a/db/migrate/20260203002637_add_requires_approval_to_mcp_tools.rb
+++ b/db/migrate/20260203002637_add_requires_approval_to_mcp_tools.rb
@@ -1,0 +1,5 @@
+class AddRequiresApprovalToMcpTools < ActiveRecord::Migration[8.1]
+  def change
+    add_column :mcp_tools, :requires_approval, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20260203002643_add_pending_tool_call_to_tasks.rb
+++ b/db/migrate/20260203002643_add_pending_tool_call_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddPendingToolCallToTasks < ActiveRecord::Migration[8.1]
+  def change
+    add_column :tasks, :pending_tool_call, :json
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_02_150002) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_03_002643) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false
@@ -319,6 +319,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_02_150002) do
     t.json "definition", default: {}
     t.text "description"
     t.string "name", null: false
+    t.boolean "requires_approval", default: false, null: false
     t.text "source_code"
     t.datetime "updated_at", null: false
     t.index ["creative_id"], name: "index_mcp_tools_on_creative_id"
@@ -681,6 +682,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_02_150002) do
     t.integer "agent_id", null: false
     t.datetime "created_at", null: false
     t.string "name"
+    t.json "pending_tool_call"
     t.string "status", default: "pending"
     t.string "trigger_event_name"
     t.json "trigger_event_payload"

--- a/engines/collavre/app/errors/collavre/approval_pending_error.rb
+++ b/engines/collavre/app/errors/collavre/approval_pending_error.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Collavre
+  class ApprovalPendingError < StandardError
+    attr_reader :tool_call, :task
+
+    def initialize(message = "Tool execution requires approval", tool_call: nil, task: nil)
+      @tool_call = tool_call
+      @task = task
+      super(message)
+    end
+
+    def tool_name
+      tool_call&.name || tool_call&.dig("name")
+    end
+
+    def tool_arguments
+      tool_call&.arguments || tool_call&.dig("arguments") || {}
+    end
+
+    def tool_call_id
+      tool_call&.id || tool_call&.dig("id")
+    end
+
+    def to_h
+      {
+        tool_name: tool_name,
+        tool_call_id: tool_call_id,
+        arguments: tool_arguments,
+        task_id: task&.id
+      }
+    end
+  end
+end

--- a/engines/collavre/app/errors/collavre/approval_pending_error.rb
+++ b/engines/collavre/app/errors/collavre/approval_pending_error.rb
@@ -11,15 +11,35 @@ module Collavre
     end
 
     def tool_name
-      tool_call&.name || tool_call&.dig("name")
+      return nil unless tool_call
+
+      if tool_call.respond_to?(:name)
+        tool_call.name
+      elsif tool_call.is_a?(Hash)
+        tool_call["name"] || tool_call[:name]
+      end
     end
 
     def tool_arguments
-      tool_call&.arguments || tool_call&.dig("arguments") || {}
+      return {} unless tool_call
+
+      if tool_call.respond_to?(:arguments)
+        tool_call.arguments
+      elsif tool_call.is_a?(Hash)
+        tool_call["arguments"] || tool_call[:arguments] || {}
+      else
+        {}
+      end
     end
 
     def tool_call_id
-      tool_call&.id || tool_call&.dig("id")
+      return nil unless tool_call
+
+      if tool_call.respond_to?(:id)
+        tool_call.id
+      elsif tool_call.is_a?(Hash)
+        tool_call["id"] || tool_call[:id]
+      end
     end
 
     def to_h

--- a/engines/collavre/app/jobs/collavre/ai_agent_job.rb
+++ b/engines/collavre/app/jobs/collavre/ai_agent_job.rb
@@ -1,27 +1,37 @@
 module Collavre
-class AiAgentJob < ApplicationJob
-  queue_as :default
+  class AiAgentJob < ApplicationJob
+    queue_as :default
 
-  def perform(agent_id, event_name, context)
-    agent = User.find(agent_id)
+    # Allow resuming a task that was pending approval
+    def perform(agent_id_or_task, event_name = nil, context = nil)
+      if agent_id_or_task.is_a?(Task)
+        # Resume existing task
+        task = agent_id_or_task
+        task.update!(status: "running")
+      else
+        # Create new task
+        agent = User.find(agent_id_or_task)
+        task = Task.create!(
+          name: "Response to #{event_name}",
+          status: "running",
+          trigger_event_name: event_name,
+          trigger_event_payload: context,
+          agent: agent
+        )
+      end
 
-    # Create Task
-    task = Task.create!(
-      name: "Response to #{event_name}",
-      status: "running",
-      trigger_event_name: event_name,
-      trigger_event_payload: context,
-      agent: agent
-    )
-
-    begin
-      AiAgentService.new(task).call
-      task.update!(status: "done")
-    rescue StandardError => e
-      task.update!(status: "failed")
-      Rails.logger.error("AiAgentJob failed for task #{task.id}: #{e.message}")
-      raise e
+      begin
+        AiAgentService.new(task).call
+        task.update!(status: "done")
+      rescue ApprovalPendingError
+        # Task status already set to pending_approval by AiAgentService
+        # Don't mark as failed, just let the job complete gracefully
+        Rails.logger.info("AiAgentJob paused for task #{task.id}: awaiting tool approval")
+      rescue StandardError => e
+        task.update!(status: "failed")
+        Rails.logger.error("AiAgentJob failed for task #{task.id}: #{e.message}")
+        raise e
+      end
     end
   end
-end
 end

--- a/engines/collavre/app/models/collavre/mcp_tool.rb
+++ b/engines/collavre/app/models/collavre/mcp_tool.rb
@@ -15,6 +15,10 @@ module Collavre
       approved_at.present?
     end
 
+    def requires_approval?
+      requires_approval == true
+    end
+
     def approve!
       # Register the tool immediately upon approval
       ::McpService.register_tool_from_source(source_code)

--- a/engines/collavre/app/services/collavre/ai_agent_service.rb
+++ b/engines/collavre/app/services/collavre/ai_agent_service.rb
@@ -242,9 +242,9 @@ module Collavre
       # Format arguments for display
       args_display = if error.tool_arguments.present?
                        JSON.pretty_generate(error.tool_arguments)
-                     else
+      else
                        "(no arguments)"
-                     end
+      end
 
       content = <<~CONTENT.strip
         🔧 **Tool Approval Required**

--- a/engines/collavre/app/services/collavre/ai_agent_service.rb
+++ b/engines/collavre/app/services/collavre/ai_agent_service.rb
@@ -48,14 +48,18 @@ module Collavre
         end
 
         # we may pass event payload also to the AI client for more context if needed - TODO
+        @creative = @context.dig("creative", "id") ? Creative.find_by(id: @context["creative"]["id"]) : nil
+        @reply_comment = reply_comment
+
         client = AiClient.new(
           vendor: @agent.llm_vendor,
           model: @agent.llm_model,
           system_prompt: rendered_system_prompt,
           llm_api_key: @agent.llm_api_key,
           context: {
-            creative: @context.dig("creative", "id") ? Creative.find_by(id: @context["creative"]["id"]) : nil,
+            creative: @creative,
             user: @agent,
+            task: @task,
             comment: reply_comment || (@context.dig("comment", "id") ? Comment.find_by(id: @context["comment"]["id"]) : nil)
           }
         )
@@ -98,6 +102,9 @@ module Collavre
           reply_to_comment(target_comment_id, response_content)
         end
       end
+    rescue ApprovalPendingError => e
+      handle_approval_pending(e)
+      raise # Re-raise to signal the job to handle status
     end
 
     private
@@ -190,6 +197,80 @@ module Collavre
       )
 
       log_action("reply_created", { comment_id: reply.id, content: content })
+    end
+
+    def handle_approval_pending(error)
+      # Clean up placeholder comment if exists
+      @reply_comment&.destroy! if @reply_comment&.content == "..."
+
+      # Store pending tool call info in task
+      @task.update!(
+        status: "pending_approval",
+        pending_tool_call: {
+          tool_name: error.tool_name,
+          tool_call_id: error.tool_call_id,
+          arguments: error.tool_arguments,
+          requested_at: Time.current.iso8601
+        }
+      )
+
+      # Log the pending approval action
+      log_action("pending_approval", error.to_h)
+
+      # Create approval request comment
+      create_approval_comment(error)
+    end
+
+    def create_approval_comment(error)
+      return unless @creative
+
+      # Determine approver - creative owner or the user who triggered the conversation
+      approver = @creative.user || User.find_by(id: @context.dig("comment", "user_id"))
+      return unless approver
+
+      # Build approval action payload
+      action_payload = {
+        action: "execute_tool",
+        tool_name: error.tool_name,
+        arguments: error.tool_arguments,
+        resume: {
+          task_id: @task.id,
+          tool_call_id: error.tool_call_id
+        }
+      }
+
+      # Format arguments for display
+      args_display = if error.tool_arguments.present?
+                       JSON.pretty_generate(error.tool_arguments)
+                     else
+                       "(no arguments)"
+                     end
+
+      content = <<~CONTENT.strip
+        🔧 **Tool Approval Required**
+
+        **#{error.tool_name}** wants to execute with the following arguments:
+
+        ```json
+        #{args_display}
+        ```
+
+        Please approve or reject this action.
+      CONTENT
+
+      # Get topic_id from the original comment if available
+      original_comment = Comment.find_by(id: @context.dig("comment", "id"))
+      topic_id = original_comment&.topic_id
+
+      Comment.create!(
+        creative: @creative,
+        content: content,
+        user: @agent, # Posted by the agent requesting approval
+        approver: approver,
+        action: JSON.pretty_generate(action_payload),
+        topic_id: topic_id,
+        private: false
+      )
     end
   end
 end

--- a/engines/collavre/app/services/collavre/ai_client.rb
+++ b/engines/collavre/app/services/collavre/ai_client.rb
@@ -110,8 +110,7 @@ module Collavre
              .chat(model: model).tap do |chat|
         chat.with_instructions(system_prompt) if system_prompt.present?
         chat.on_tool_call do |tool_call|
-          # You can do on_tool_call, on_tool_result hook by ruby llm provides
-          # Rails.logger.info("Tool call: #{JSON.pretty_generate(tool_call.to_h)}")
+          check_tool_approval!(tool_call)
         end
         if tools.any?
           # Resolve tool names to classes using the gem's helper
@@ -119,6 +118,32 @@ module Collavre
           chat.with_tools(*tool_classes, replace: true)
         end
       end
+    end
+
+    def check_tool_approval!(tool_call)
+      tool_name = tool_call.name
+      task = context&.dig(:task)
+
+      # Check if this tool requires approval
+      mcp_tool = McpTool.find_by(name: tool_name)
+      return unless mcp_tool&.requires_approval?
+
+      # Check if we already have approval for this specific call (resume scenario)
+      if task&.pending_tool_call.present?
+        pending = task.pending_tool_call
+        if pending["tool_name"] == tool_name && pending["approved"]
+          # Already approved, clear the pending state and proceed
+          task.update!(pending_tool_call: nil)
+          return
+        end
+      end
+
+      # Requires approval - raise error to halt execution
+      raise ApprovalPendingError.new(
+        "Tool '#{tool_name}' requires approval before execution",
+        tool_call: tool_call,
+        task: task
+      )
     end
 
     def add_messages(conversation, contents)

--- a/engines/collavre/app/services/collavre/comments/action_executor.rb
+++ b/engines/collavre/app/services/collavre/comments/action_executor.rb
@@ -73,7 +73,8 @@ module Collavre
         SUPPORTED_ACTIONS = {
           "create_creative" => :create_creative,
           "update_creative" => :update_creative,
-          "approve_tool" => :approve_tool
+          "approve_tool" => :approve_tool,
+          "execute_tool" => :execute_tool
         }.freeze
 
         CREATIVE_ATTRIBUTES = %w[description progress].freeze
@@ -157,6 +158,51 @@ module Collavre
           raise InvalidActionError, "Tool '#{tool_name}' not found" unless tool
 
           tool.approve!
+        end
+
+        def execute_tool(payload)
+          tool_name = payload["tool_name"]
+          arguments = payload["arguments"] || {}
+          resume_info = payload["resume"] || {}
+          task_id = resume_info["task_id"]
+          tool_call_id = resume_info["tool_call_id"]
+
+          raise InvalidActionError, "Tool name is required" if tool_name.blank?
+
+          # Execute the tool via MetaToolService
+          result = begin
+            ::Tools::MetaToolService.new.call(
+              action: "call",
+              tool_name: tool_name,
+              arguments: arguments
+            )
+          rescue StandardError => e
+            Rails.logger.error("Tool execution failed: #{e.message}")
+            { error: e.message }
+          end
+
+          # If there's a task to resume, update it and re-queue the job
+          if task_id.present?
+            task = Task.find_by(id: task_id)
+            if task
+              # Mark the tool call as approved with its result
+              task.update!(
+                pending_tool_call: {
+                  tool_name: tool_name,
+                  tool_call_id: tool_call_id,
+                  arguments: arguments,
+                  approved: true,
+                  result: result,
+                  approved_at: Time.current.iso8601
+                }
+              )
+
+              # Resume the AI agent job
+              AiAgentJob.perform_later(task)
+            end
+          end
+
+          result
         end
 
         def process_action(payload)

--- a/engines/collavre/test/errors/approval_pending_error_test.rb
+++ b/engines/collavre/test/errors/approval_pending_error_test.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  class ApprovalPendingErrorTest < ActiveSupport::TestCase
+    test "stores tool_call and task" do
+      tool_call = OpenStruct.new(
+        name: "test_tool",
+        id: "call_123",
+        arguments: { param: "value" }
+      )
+      task = OpenStruct.new(id: 42)
+
+      error = ApprovalPendingError.new(
+        "Test error",
+        tool_call: tool_call,
+        task: task
+      )
+
+      assert_equal "Test error", error.message
+      assert_equal "test_tool", error.tool_name
+      assert_equal "call_123", error.tool_call_id
+      assert_equal({ param: "value" }, error.tool_arguments)
+    end
+
+    test "handles hash-based tool_call" do
+      tool_call = {
+        "name" => "hash_tool",
+        "id" => "call_456",
+        "arguments" => { "key" => "val" }
+      }
+
+      error = ApprovalPendingError.new(tool_call: tool_call)
+
+      assert_equal "hash_tool", error.tool_name
+      assert_equal "call_456", error.tool_call_id
+      assert_equal({ "key" => "val" }, error.tool_arguments)
+    end
+
+    test "to_h returns structured data" do
+      tool_call = OpenStruct.new(
+        name: "my_tool",
+        id: "call_789",
+        arguments: { a: 1 }
+      )
+      task = OpenStruct.new(id: 99)
+
+      error = ApprovalPendingError.new(tool_call: tool_call, task: task)
+      hash = error.to_h
+
+      assert_equal "my_tool", hash[:tool_name]
+      assert_equal "call_789", hash[:tool_call_id]
+      assert_equal({ a: 1 }, hash[:arguments])
+      assert_equal 99, hash[:task_id]
+    end
+
+    test "handles nil values gracefully" do
+      error = ApprovalPendingError.new
+
+      assert_nil error.tool_name
+      assert_nil error.tool_call_id
+      assert_equal({}, error.tool_arguments)
+    end
+  end
+end

--- a/engines/collavre/test/errors/approval_pending_error_test.rb
+++ b/engines/collavre/test/errors/approval_pending_error_test.rb
@@ -2,65 +2,63 @@
 
 require "test_helper"
 
-module Collavre
-  class ApprovalPendingErrorTest < ActiveSupport::TestCase
-    test "stores tool_call and task" do
-      tool_call = OpenStruct.new(
-        name: "test_tool",
-        id: "call_123",
-        arguments: { param: "value" }
-      )
-      task = OpenStruct.new(id: 42)
+class ApprovalPendingErrorTest < ActiveSupport::TestCase
+  test "stores tool_call and task" do
+    tool_call = OpenStruct.new(
+      name: "test_tool",
+      id: "call_123",
+      arguments: { param: "value" }
+    )
+    task = OpenStruct.new(id: 42)
 
-      error = ApprovalPendingError.new(
-        "Test error",
-        tool_call: tool_call,
-        task: task
-      )
+    error = Collavre::ApprovalPendingError.new(
+      "Test error",
+      tool_call: tool_call,
+      task: task
+    )
 
-      assert_equal "Test error", error.message
-      assert_equal "test_tool", error.tool_name
-      assert_equal "call_123", error.tool_call_id
-      assert_equal({ param: "value" }, error.tool_arguments)
-    end
+    assert_equal "Test error", error.message
+    assert_equal "test_tool", error.tool_name
+    assert_equal "call_123", error.tool_call_id
+    assert_equal({ param: "value" }, error.tool_arguments)
+  end
 
-    test "handles hash-based tool_call" do
-      tool_call = {
-        "name" => "hash_tool",
-        "id" => "call_456",
-        "arguments" => { "key" => "val" }
-      }
+  test "handles hash-based tool_call" do
+    tool_call = {
+      "name" => "hash_tool",
+      "id" => "call_456",
+      "arguments" => { "key" => "val" }
+    }
 
-      error = ApprovalPendingError.new(tool_call: tool_call)
+    error = Collavre::ApprovalPendingError.new(tool_call: tool_call)
 
-      assert_equal "hash_tool", error.tool_name
-      assert_equal "call_456", error.tool_call_id
-      assert_equal({ "key" => "val" }, error.tool_arguments)
-    end
+    assert_equal "hash_tool", error.tool_name
+    assert_equal "call_456", error.tool_call_id
+    assert_equal({ "key" => "val" }, error.tool_arguments)
+  end
 
-    test "to_h returns structured data" do
-      tool_call = OpenStruct.new(
-        name: "my_tool",
-        id: "call_789",
-        arguments: { a: 1 }
-      )
-      task = OpenStruct.new(id: 99)
+  test "to_h returns structured data" do
+    tool_call = OpenStruct.new(
+      name: "my_tool",
+      id: "call_789",
+      arguments: { a: 1 }
+    )
+    task = OpenStruct.new(id: 99)
 
-      error = ApprovalPendingError.new(tool_call: tool_call, task: task)
-      hash = error.to_h
+    error = Collavre::ApprovalPendingError.new(tool_call: tool_call, task: task)
+    hash = error.to_h
 
-      assert_equal "my_tool", hash[:tool_name]
-      assert_equal "call_789", hash[:tool_call_id]
-      assert_equal({ a: 1 }, hash[:arguments])
-      assert_equal 99, hash[:task_id]
-    end
+    assert_equal "my_tool", hash[:tool_name]
+    assert_equal "call_789", hash[:tool_call_id]
+    assert_equal({ a: 1 }, hash[:arguments])
+    assert_equal 99, hash[:task_id]
+  end
 
-    test "handles nil values gracefully" do
-      error = ApprovalPendingError.new
+  test "handles nil values gracefully" do
+    error = Collavre::ApprovalPendingError.new
 
-      assert_nil error.tool_name
-      assert_nil error.tool_call_id
-      assert_equal({}, error.tool_arguments)
-    end
+    assert_nil error.tool_name
+    assert_nil error.tool_call_id
+    assert_equal({}, error.tool_arguments)
   end
 end

--- a/engines/collavre/test/services/comments/action_executor_execute_tool_test.rb
+++ b/engines/collavre/test/services/comments/action_executor_execute_tool_test.rb
@@ -23,7 +23,7 @@ class Comments::ActionExecutorExecuteToolTest < ActiveSupport::TestCase
       }
     )
 
-    # Create a tool that requires approval
+    # Create a tool that requires approval (unique name per test)
     @mcp_tool = Collavre::McpTool.create!(
       name: "test_tool_#{SecureRandom.hex(4)}",
       creative: @creative,
@@ -33,7 +33,7 @@ class Comments::ActionExecutorExecuteToolTest < ActiveSupport::TestCase
     )
   end
 
-  test "execute_tool action executes tool and resumes task" do
+  test "execute_tool action updates task with approval and result" do
     action_payload = {
       "action" => "execute_tool",
       "tool_name" => "test_tool",
@@ -51,16 +51,19 @@ class Comments::ActionExecutorExecuteToolTest < ActiveSupport::TestCase
       action: JSON.pretty_generate(action_payload)
     )
 
-    # Mock MetaToolService using Minitest stub
+    # Mock MetaToolService
     mock_result = { result: "success" }
-    ::Tools::MetaToolService.stub :new, -> { OpenStruct.new(call: mock_result) } do
-      # Execute the action
-      assert_enqueued_with(job: Collavre::AiAgentJob) do
+    mock_service = Object.new
+    mock_service.define_singleton_method(:call) { |**_args| mock_result }
+
+    ::Tools::MetaToolService.stub :new, -> { mock_service } do
+      # Stub AiAgentJob to prevent actual execution
+      Collavre::AiAgentJob.stub :perform_later, ->(task) { task.update!(status: "resumed") } do
         Comments::ActionExecutor.new(comment: comment, executor: @user).call
       end
     end
 
-    # Verify task was updated
+    # Verify task was updated with approval info
     @task.reload
     assert_equal true, @task.pending_tool_call["approved"]
     assert_equal({ "result" => "success" }, @task.pending_tool_call["result"])
@@ -92,7 +95,7 @@ class Comments::ActionExecutorExecuteToolTest < ActiveSupport::TestCase
     assert_match(/Tool name is required/, error.message)
   end
 
-  test "execute_tool handles tool execution errors gracefully" do
+  test "execute_tool stores error in result when tool execution fails" do
     action_payload = {
       "action" => "execute_tool",
       "tool_name" => "test_tool",
@@ -112,13 +115,10 @@ class Comments::ActionExecutorExecuteToolTest < ActiveSupport::TestCase
 
     # Mock MetaToolService to raise an error
     error_service = Object.new
-    def error_service.call(*)
-      raise StandardError, "Tool failed"
-    end
+    error_service.define_singleton_method(:call) { |**_args| raise StandardError, "Tool failed" }
 
     ::Tools::MetaToolService.stub :new, -> { error_service } do
-      # Execute should not raise, but store error in result
-      assert_enqueued_with(job: Collavre::AiAgentJob) do
+      Collavre::AiAgentJob.stub :perform_later, ->(task) { task.update!(status: "resumed") } do
         Comments::ActionExecutor.new(comment: comment, executor: @user).call
       end
     end

--- a/engines/collavre/test/services/comments/action_executor_execute_tool_test.rb
+++ b/engines/collavre/test/services/comments/action_executor_execute_tool_test.rb
@@ -2,129 +2,122 @@
 
 require "test_helper"
 
-module Collavre
-  module Comments
-    class ActionExecutorExecuteToolTest < ActiveSupport::TestCase
-      setup do
-        @user = collavre_users(:one)
-        @creative = collavre_creatives(:one)
-        @agent = collavre_users(:two) # Use as AI agent
+class Comments::ActionExecutorExecuteToolTest < ActiveSupport::TestCase
+  setup do
+    @user = users(:one)
+    @creative = creatives(:tshirt)
+    @agent = users(:two) # Use as AI agent
 
-        # Create a task that's pending approval
-        @task = Collavre::Task.create!(
-          name: "Test task",
-          status: "pending_approval",
-          trigger_event_name: "comment_created",
-          trigger_event_payload: { "creative" => { "id" => @creative.id } },
-          agent: @agent,
-          pending_tool_call: {
-            "tool_name" => "test_tool",
-            "tool_call_id" => "call_123",
-            "arguments" => { "param" => "value" },
-            "requested_at" => Time.current.iso8601
-          }
-        )
+    # Create a task that's pending approval
+    @task = Collavre::Task.create!(
+      name: "Test task",
+      status: "pending_approval",
+      trigger_event_name: "comment_created",
+      trigger_event_payload: { "creative" => { "id" => @creative.id } },
+      agent: @agent,
+      pending_tool_call: {
+        "tool_name" => "test_tool",
+        "tool_call_id" => "call_123",
+        "arguments" => { "param" => "value" },
+        "requested_at" => Time.current.iso8601
+      }
+    )
 
-        # Create a tool that requires approval
-        @mcp_tool = Collavre::McpTool.create!(
-          name: "test_tool",
-          creative: @creative,
-          source_code: "module TestTool; extend ToolMeta; tool_name 'test_tool'; end",
-          requires_approval: true,
-          approved_at: Time.current
-        )
-      end
+    # Create a tool that requires approval
+    @mcp_tool = Collavre::McpTool.create!(
+      name: "test_tool",
+      creative: @creative,
+      source_code: "module TestTool; extend ToolMeta; tool_name 'test_tool'; end",
+      requires_approval: true,
+      approved_at: Time.current
+    )
+  end
 
-      test "execute_tool action executes tool and resumes task" do
-        action_payload = {
-          "action" => "execute_tool",
-          "tool_name" => "test_tool",
-          "arguments" => { "param" => "value" },
-          "resume" => {
-            "task_id" => @task.id,
-            "tool_call_id" => "call_123"
-          }
-        }
+  test "execute_tool action executes tool and resumes task" do
+    action_payload = {
+      "action" => "execute_tool",
+      "tool_name" => "test_tool",
+      "arguments" => { "param" => "value" },
+      "resume" => {
+        "task_id" => @task.id,
+        "tool_call_id" => "call_123"
+      }
+    }
 
-        comment = Collavre::Comment.create!(
-          creative: @creative,
-          user: @agent,
-          content: "Tool approval request",
-          approver: @user,
-          action: JSON.pretty_generate(action_payload)
-        )
+    comment = @creative.comments.create!(
+      user: @agent,
+      content: "Tool approval request",
+      approver: @user,
+      action: JSON.pretty_generate(action_payload)
+    )
 
-        # Mock MetaToolService
-        ::Tools::MetaToolService.any_instance.stubs(:call).returns({ result: "success" })
+    # Mock MetaToolService
+    ::Tools::MetaToolService.any_instance.stubs(:call).returns({ result: "success" })
 
-        # Execute the action
-        assert_enqueued_with(job: AiAgentJob) do
-          ActionExecutor.new(comment: comment, executor: @user).call
-        end
-
-        # Verify task was updated
-        @task.reload
-        assert_equal true, @task.pending_tool_call["approved"]
-        assert_equal({ "result" => "success" }, @task.pending_tool_call["result"])
-        assert @task.pending_tool_call["approved_at"].present?
-
-        # Verify comment was marked as executed
-        comment.reload
-        assert comment.action_executed_at.present?
-        assert_equal @user, comment.action_executed_by
-      end
-
-      test "execute_tool action fails without tool_name" do
-        action_payload = {
-          "action" => "execute_tool",
-          "arguments" => { "param" => "value" }
-        }
-
-        comment = Collavre::Comment.create!(
-          creative: @creative,
-          user: @agent,
-          content: "Tool approval request",
-          approver: @user,
-          action: JSON.pretty_generate(action_payload)
-        )
-
-        error = assert_raises(ActionExecutor::ExecutionError) do
-          ActionExecutor.new(comment: comment, executor: @user).call
-        end
-
-        assert_match(/Tool name is required/, error.message)
-      end
-
-      test "execute_tool handles tool execution errors gracefully" do
-        action_payload = {
-          "action" => "execute_tool",
-          "tool_name" => "test_tool",
-          "arguments" => { "param" => "value" },
-          "resume" => {
-            "task_id" => @task.id,
-            "tool_call_id" => "call_123"
-          }
-        }
-
-        comment = Collavre::Comment.create!(
-          creative: @creative,
-          user: @agent,
-          content: "Tool approval request",
-          approver: @user,
-          action: JSON.pretty_generate(action_payload)
-        )
-
-        # Mock MetaToolService to raise an error
-        ::Tools::MetaToolService.any_instance.stubs(:call).raises(StandardError.new("Tool failed"))
-
-        # Execute should not raise, but store error in result
-        assert_enqueued_with(job: AiAgentJob) do
-          ActionExecutor.new(comment: comment, executor: @user).call
-        end
-
-        @task.reload
-        assert_equal({ "error" => "Tool failed" }, @task.pending_tool_call["result"])
-      end
+    # Execute the action
+    assert_enqueued_with(job: Collavre::AiAgentJob) do
+      Comments::ActionExecutor.new(comment: comment, executor: @user).call
     end
+
+    # Verify task was updated
+    @task.reload
+    assert_equal true, @task.pending_tool_call["approved"]
+    assert_equal({ "result" => "success" }, @task.pending_tool_call["result"])
+    assert @task.pending_tool_call["approved_at"].present?
+
+    # Verify comment was marked as executed
+    comment.reload
+    assert comment.action_executed_at.present?
+    assert_equal @user, comment.action_executed_by
+  end
+
+  test "execute_tool action fails without tool_name" do
+    action_payload = {
+      "action" => "execute_tool",
+      "arguments" => { "param" => "value" }
+    }
+
+    comment = @creative.comments.create!(
+      user: @agent,
+      content: "Tool approval request",
+      approver: @user,
+      action: JSON.pretty_generate(action_payload)
+    )
+
+    error = assert_raises(Comments::ActionExecutor::ExecutionError) do
+      Comments::ActionExecutor.new(comment: comment, executor: @user).call
+    end
+
+    assert_match(/Tool name is required/, error.message)
+  end
+
+  test "execute_tool handles tool execution errors gracefully" do
+    action_payload = {
+      "action" => "execute_tool",
+      "tool_name" => "test_tool",
+      "arguments" => { "param" => "value" },
+      "resume" => {
+        "task_id" => @task.id,
+        "tool_call_id" => "call_123"
+      }
+    }
+
+    comment = @creative.comments.create!(
+      user: @agent,
+      content: "Tool approval request",
+      approver: @user,
+      action: JSON.pretty_generate(action_payload)
+    )
+
+    # Mock MetaToolService to raise an error
+    ::Tools::MetaToolService.any_instance.stubs(:call).raises(StandardError.new("Tool failed"))
+
+    # Execute should not raise, but store error in result
+    assert_enqueued_with(job: Collavre::AiAgentJob) do
+      Comments::ActionExecutor.new(comment: comment, executor: @user).call
+    end
+
+    @task.reload
+    assert_equal({ "error" => "Tool failed" }, @task.pending_tool_call["result"])
   end
 end

--- a/engines/collavre/test/services/comments/action_executor_execute_tool_test.rb
+++ b/engines/collavre/test/services/comments/action_executor_execute_tool_test.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  module Comments
+    class ActionExecutorExecuteToolTest < ActiveSupport::TestCase
+      setup do
+        @user = collavre_users(:one)
+        @creative = collavre_creatives(:one)
+        @agent = collavre_users(:two) # Use as AI agent
+
+        # Create a task that's pending approval
+        @task = Collavre::Task.create!(
+          name: "Test task",
+          status: "pending_approval",
+          trigger_event_name: "comment_created",
+          trigger_event_payload: { "creative" => { "id" => @creative.id } },
+          agent: @agent,
+          pending_tool_call: {
+            "tool_name" => "test_tool",
+            "tool_call_id" => "call_123",
+            "arguments" => { "param" => "value" },
+            "requested_at" => Time.current.iso8601
+          }
+        )
+
+        # Create a tool that requires approval
+        @mcp_tool = Collavre::McpTool.create!(
+          name: "test_tool",
+          creative: @creative,
+          source_code: "module TestTool; extend ToolMeta; tool_name 'test_tool'; end",
+          requires_approval: true,
+          approved_at: Time.current
+        )
+      end
+
+      test "execute_tool action executes tool and resumes task" do
+        action_payload = {
+          "action" => "execute_tool",
+          "tool_name" => "test_tool",
+          "arguments" => { "param" => "value" },
+          "resume" => {
+            "task_id" => @task.id,
+            "tool_call_id" => "call_123"
+          }
+        }
+
+        comment = Collavre::Comment.create!(
+          creative: @creative,
+          user: @agent,
+          content: "Tool approval request",
+          approver: @user,
+          action: JSON.pretty_generate(action_payload)
+        )
+
+        # Mock MetaToolService
+        ::Tools::MetaToolService.any_instance.stubs(:call).returns({ result: "success" })
+
+        # Execute the action
+        assert_enqueued_with(job: AiAgentJob) do
+          ActionExecutor.new(comment: comment, executor: @user).call
+        end
+
+        # Verify task was updated
+        @task.reload
+        assert_equal true, @task.pending_tool_call["approved"]
+        assert_equal({ "result" => "success" }, @task.pending_tool_call["result"])
+        assert @task.pending_tool_call["approved_at"].present?
+
+        # Verify comment was marked as executed
+        comment.reload
+        assert comment.action_executed_at.present?
+        assert_equal @user, comment.action_executed_by
+      end
+
+      test "execute_tool action fails without tool_name" do
+        action_payload = {
+          "action" => "execute_tool",
+          "arguments" => { "param" => "value" }
+        }
+
+        comment = Collavre::Comment.create!(
+          creative: @creative,
+          user: @agent,
+          content: "Tool approval request",
+          approver: @user,
+          action: JSON.pretty_generate(action_payload)
+        )
+
+        error = assert_raises(ActionExecutor::ExecutionError) do
+          ActionExecutor.new(comment: comment, executor: @user).call
+        end
+
+        assert_match(/Tool name is required/, error.message)
+      end
+
+      test "execute_tool handles tool execution errors gracefully" do
+        action_payload = {
+          "action" => "execute_tool",
+          "tool_name" => "test_tool",
+          "arguments" => { "param" => "value" },
+          "resume" => {
+            "task_id" => @task.id,
+            "tool_call_id" => "call_123"
+          }
+        }
+
+        comment = Collavre::Comment.create!(
+          creative: @creative,
+          user: @agent,
+          content: "Tool approval request",
+          approver: @user,
+          action: JSON.pretty_generate(action_payload)
+        )
+
+        # Mock MetaToolService to raise an error
+        ::Tools::MetaToolService.any_instance.stubs(:call).raises(StandardError.new("Tool failed"))
+
+        # Execute should not raise, but store error in result
+        assert_enqueued_with(job: AiAgentJob) do
+          ActionExecutor.new(comment: comment, executor: @user).call
+        end
+
+        @task.reload
+        assert_equal({ "error" => "Tool failed" }, @task.pending_tool_call["result"])
+      end
+    end
+  end
+end

--- a/engines/collavre/test/services/comments/action_executor_execute_tool_test.rb
+++ b/engines/collavre/test/services/comments/action_executor_execute_tool_test.rb
@@ -25,7 +25,7 @@ class Comments::ActionExecutorExecuteToolTest < ActiveSupport::TestCase
 
     # Create a tool that requires approval
     @mcp_tool = Collavre::McpTool.create!(
-      name: "test_tool",
+      name: "test_tool_#{SecureRandom.hex(4)}",
       creative: @creative,
       source_code: "module TestTool; extend ToolMeta; tool_name 'test_tool'; end",
       requires_approval: true,
@@ -51,12 +51,13 @@ class Comments::ActionExecutorExecuteToolTest < ActiveSupport::TestCase
       action: JSON.pretty_generate(action_payload)
     )
 
-    # Mock MetaToolService
-    ::Tools::MetaToolService.any_instance.stubs(:call).returns({ result: "success" })
-
-    # Execute the action
-    assert_enqueued_with(job: Collavre::AiAgentJob) do
-      Comments::ActionExecutor.new(comment: comment, executor: @user).call
+    # Mock MetaToolService using Minitest stub
+    mock_result = { result: "success" }
+    ::Tools::MetaToolService.stub :new, -> { OpenStruct.new(call: mock_result) } do
+      # Execute the action
+      assert_enqueued_with(job: Collavre::AiAgentJob) do
+        Comments::ActionExecutor.new(comment: comment, executor: @user).call
+      end
     end
 
     # Verify task was updated
@@ -110,11 +111,16 @@ class Comments::ActionExecutorExecuteToolTest < ActiveSupport::TestCase
     )
 
     # Mock MetaToolService to raise an error
-    ::Tools::MetaToolService.any_instance.stubs(:call).raises(StandardError.new("Tool failed"))
+    error_service = Object.new
+    def error_service.call(*)
+      raise StandardError, "Tool failed"
+    end
 
-    # Execute should not raise, but store error in result
-    assert_enqueued_with(job: Collavre::AiAgentJob) do
-      Comments::ActionExecutor.new(comment: comment, executor: @user).call
+    ::Tools::MetaToolService.stub :new, -> { error_service } do
+      # Execute should not raise, but store error in result
+      assert_enqueued_with(job: Collavre::AiAgentJob) do
+        Comments::ActionExecutor.new(comment: comment, executor: @user).call
+      end
     end
 
     @task.reload


### PR DESCRIPTION
## Summary

AI Agent가 tool을 실행할 때 승인이 필요한 경우, 사용자에게 승인 요청 후 승인되면 실행을 재개하는 플로우를 구현합니다.

## Changes

### Database Migrations
- `mcp_tools`: `requires_approval` 컬럼 추가 (boolean, default: false)
- `tasks`: `pending_tool_call` 컬럼 추가 (json)

### New Components
- `ApprovalPendingError`: Tool 승인 대기 시 발생하는 커스텀 예외

### Modified Components
- `AiClient`: `on_tool_call`에서 승인 필요 여부 체크
- `AiAgentService`: ApprovalPendingError 처리, 승인 요청 Comment 생성
- `AiAgentJob`: Task 재개 지원
- `ActionExecutor`: `execute_tool` action 추가
- `McpTool`: `requires_approval?` 메서드 추가

## Flow

```
1. AI Agent가 승인 필요한 tool 호출
2. AiClient.on_tool_call에서 ApprovalPendingError 발생
3. AiAgentService가 승인 요청 Comment 생성
4. Task.status = 'pending_approval'
5. 사용자가 UI에서 승인
6. ActionExecutor가 tool 실행 및 Task 재개
7. AiAgentJob이 결과와 함께 계속 진행
```

## Tests
- ApprovalPendingError 단위 테스트
- ActionExecutor execute_tool action 테스트
