### PR TITLE
feat: Add drag-and-drop to move comments between topics

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -718,6 +718,44 @@ body.chat-fullscreen main {
     font-weight: bold;
 }
 
+/* Drag and drop styles for moving comments to topics */
+.topic-tag.drag-over {
+    background-color: var(--color-accent, #007bff);
+    color: white;
+    border-color: var(--color-accent, #007bff);
+    transform: scale(1.05);
+    transition: all 0.15s ease;
+}
+
+.topic-drop-target {
+    transition: all 0.15s ease;
+}
+
+.comment-item[draggable="true"] {
+    cursor: grab;
+}
+
+.comment-item[draggable="true"]:active {
+    cursor: grabbing;
+}
+
+#comments-list.dragging-comments .comment-item:not(.selected-for-move) {
+    opacity: 0.5;
+}
+
+.comment-drag-image {
+    position: fixed;
+    top: -1000px;
+    left: -1000px;
+    padding: 8px 16px;
+    background-color: var(--color-accent, #007bff);
+    color: white;
+    border-radius: 4px;
+    font-size: 0.9em;
+    font-weight: 500;
+    white-space: nowrap;
+}
+
 /* Hide the topic link if the message is displayed within that topic's context */
 /* Use Javascript to set data-current-topic-id on the list container */
 .comment-topic-link {

--- a/engines/collavre/app/controllers/collavre/comments_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comments_controller.rb
@@ -387,12 +387,32 @@ module Collavre
         render json: { error: I18n.t("collavre.comments.move_no_selection") }, status: :unprocessable_entity and return
       end
 
-      target_creative = Creative.find_by(id: params[:target_creative_id])
-      if target_creative.nil?
+      # Support moving to topic within same creative (target_topic_id only)
+      # or moving to different creative (target_creative_id)
+      target_topic_id = params[:target_topic_id]
+      target_creative_id = params[:target_creative_id]
+
+      # Determine target creative and topic
+      if target_creative_id.present?
+        # Moving to different creative
+        target_creative = Creative.find_by(id: target_creative_id)
+        if target_creative.nil?
+          render json: { error: I18n.t("collavre.comments.move_invalid_target") }, status: :unprocessable_entity and return
+        end
+        target_origin = target_creative.effective_origin
+        new_topic_id = nil # Reset topic when moving to different creative
+      elsif target_topic_id.present? || target_topic_id == ""
+        # Moving to topic within same creative (empty string means Main/no topic)
+        target_origin = @creative
+        new_topic_id = target_topic_id.presence # nil for Main topic
+
+        # Validate topic exists if specified
+        if new_topic_id.present? && !@creative.topics.exists?(id: new_topic_id)
+          render json: { error: I18n.t("collavre.comments.move_invalid_topic", default: "Invalid topic") }, status: :unprocessable_entity and return
+        end
+      else
         render json: { error: I18n.t("collavre.comments.move_invalid_target") }, status: :unprocessable_entity and return
       end
-
-      target_origin = target_creative.effective_origin
 
       unless @creative.has_permission?(Current.user, :feedback) && target_origin.has_permission?(Current.user, :feedback)
         render json: { error: I18n.t("collavre.comments.move_not_allowed") }, status: :forbidden and return
@@ -411,20 +431,34 @@ module Collavre
         render json: { error: I18n.t("collavre.comments.move_not_allowed") }, status: :forbidden and return
       end
 
+      moved_count = 0
       ActiveRecord::Base.transaction do
         comments.each do |comment|
-          next if comment.creative_id == target_origin.id
+          # Skip if already in target location
+          same_creative = comment.creative_id == target_origin.id
+          same_topic = comment.topic_id.to_s == new_topic_id.to_s
+
+          next if same_creative && same_topic
 
           original_creative = comment.creative
-          comment.update!(creative: target_origin, topic_id: nil)
-          broadcast_move_removal(comment, original_creative)
+          original_topic_id = comment.topic_id
+
+          if same_creative
+            # Just update topic within same creative
+            comment.update!(topic_id: new_topic_id)
+          else
+            # Move to different creative
+            comment.update!(creative: target_origin, topic_id: new_topic_id)
+            broadcast_move_removal(comment, original_creative)
+          end
+          moved_count += 1
         end
       end
 
       Comment.broadcast_badges(@creative)
       Comment.broadcast_badges(target_origin) unless target_origin == @creative
 
-      render json: { success: true }
+      render json: { success: true, moved_count: moved_count }
     rescue ActiveRecord::RecordInvalid => e
       render json: { error: e.record.errors.full_messages.to_sentence.presence || I18n.t("collavre.comments.move_error") }, status: :unprocessable_entity
     end

--- a/engines/collavre/app/javascript/controllers/comments/list_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/list_controller.js
@@ -46,6 +46,14 @@ export default class extends Controller {
 
     this.handleTopicChange = this.handleTopicChange.bind(this)
     this.element.addEventListener('comments--topics:change', this.handleTopicChange)
+
+    // Drag and drop handlers for moving comments to topics
+    this.handleDragStart = this.handleDragStart.bind(this)
+    this.handleDragEnd = this.handleDragEnd.bind(this)
+    this.handleMoveToTopic = this.handleMoveToTopic.bind(this)
+    this.listTarget.addEventListener('dragstart', this.handleDragStart)
+    this.listTarget.addEventListener('dragend', this.handleDragEnd)
+    this.element.addEventListener('comments--topics:move-to-topic', this.handleMoveToTopic)
   }
 
   handleTopicChange(event) {
@@ -58,12 +66,15 @@ export default class extends Controller {
     this.listTarget.removeEventListener('change', this.handleChange)
     this.listTarget.removeEventListener('click', this.handleClick)
     this.listTarget.removeEventListener('submit', this.handleSubmit)
+    this.listTarget.removeEventListener('dragstart', this.handleDragStart)
+    this.listTarget.removeEventListener('dragend', this.handleDragEnd)
     document.removeEventListener('turbo:before-stream-render', this.handleStreamRender)
     if (this.listObserver) {
       this.listObserver.disconnect()
       this.listObserver = null
     }
     this.element.removeEventListener('comments--topics:change', this.handleTopicChange)
+    this.element.removeEventListener('comments--topics:move-to-topic', this.handleMoveToTopic)
   }
 
   isColumnReverse() {
@@ -461,12 +472,95 @@ export default class extends Controller {
     const item = checkbox.closest('.comment-item')
     if (checkbox.checked) {
       this.selection.add(commentId)
-      if (item) item.classList.add('selected-for-move')
+      if (item) {
+        item.classList.add('selected-for-move')
+        item.setAttribute('draggable', 'true')
+      }
     } else {
       this.selection.delete(commentId)
-      if (item) item.classList.remove('selected-for-move')
+      if (item) {
+        item.classList.remove('selected-for-move')
+        // Only remove draggable if no other items selected
+        if (this.selection.size === 0) {
+          item.removeAttribute('draggable')
+        }
+      }
     }
+    this.updateDraggableState()
     this.notifySelectionChange()
+  }
+
+  updateDraggableState() {
+    const hasSelection = this.selection.size > 0
+    this.listTarget.querySelectorAll('.comment-item').forEach((item) => {
+      const checkbox = item.querySelector('.comment-select-checkbox')
+      if (checkbox?.checked) {
+        item.setAttribute('draggable', 'true')
+      } else {
+        item.removeAttribute('draggable')
+      }
+    })
+  }
+
+  handleDragStart(event) {
+    const item = event.target.closest('.comment-item')
+    if (!item || this.selection.size === 0) {
+      event.preventDefault()
+      return
+    }
+
+    // Include all selected comment IDs
+    const commentIds = Array.from(this.selection)
+    event.dataTransfer.setData('application/x-comment-ids', JSON.stringify(commentIds))
+    event.dataTransfer.effectAllowed = 'move'
+
+    // Add visual feedback
+    this.listTarget.classList.add('dragging-comments')
+    
+    // Create custom drag image showing count
+    if (commentIds.length > 1) {
+      const dragImage = document.createElement('div')
+      dragImage.className = 'comment-drag-image'
+      dragImage.textContent = `${commentIds.length} messages`
+      document.body.appendChild(dragImage)
+      event.dataTransfer.setDragImage(dragImage, 0, 0)
+      setTimeout(() => dragImage.remove(), 0)
+    }
+  }
+
+  handleDragEnd(event) {
+    this.listTarget.classList.remove('dragging-comments')
+  }
+
+  async handleMoveToTopic(event) {
+    const { commentIds, targetTopicId } = event.detail
+    if (!commentIds || commentIds.length === 0 || !this.creativeId) return
+
+    try {
+      const response = await fetch(`/creatives/${this.creativeId}/comments/move`, {
+        method: 'POST',
+        headers: {
+          'X-CSRF-Token': document.querySelector('meta[name=csrf-token]').content,
+          'Content-Type': 'application/json',
+          Accept: 'application/json'
+        },
+        body: JSON.stringify({ 
+          comment_ids: commentIds, 
+          target_topic_id: targetTopicId 
+        })
+      })
+
+      if (response.ok) {
+        this.clearSelection()
+        this.loadInitialComments()
+      } else {
+        const data = await response.json()
+        alert(data.error || 'Failed to move comments')
+      }
+    } catch (error) {
+      console.error('Error moving comments to topic:', error)
+      alert('Failed to move comments')
+    }
   }
 
   notifySelectionChange() {

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -86,12 +86,16 @@ export default class extends Controller {
     }
 
     renderTopics(topics, canManage = false) {
-        let html = `<span class="topic-tag ${this.currentTopicId ? '' : 'active'}" data-action="click->comments--topics#select" data-id="">#Main</span>`
+        let html = `<span class="topic-tag topic-drop-target ${this.currentTopicId ? '' : 'active'}" 
+                          data-action="click->comments--topics#select dragover->comments--topics#handleDragOver dragleave->comments--topics#handleDragLeave drop->comments--topics#handleDrop" 
+                          data-id="">#Main</span>`
 
         topics.forEach(topic => {
             // Ensure comparison handles string/number difference
             const isActive = String(this.currentTopicId) === String(topic.id) ? 'active' : ''
-            html += `<span class="topic-tag ${isActive}" data-action="click->comments--topics#select" data-id="${topic.id}">
+            html += `<span class="topic-tag topic-drop-target ${isActive}" 
+                          data-action="click->comments--topics#select dragover->comments--topics#handleDragOver dragleave->comments--topics#handleDragLeave drop->comments--topics#handleDrop" 
+                          data-id="${topic.id}">
                         #${topic.name}`
 
             if (canManage) {
@@ -109,6 +113,40 @@ export default class extends Controller {
         }
 
         this.listTarget.innerHTML = html
+    }
+
+    handleDragOver(event) {
+        // Only accept comment drops
+        if (!event.dataTransfer.types.includes('application/x-comment-ids')) return
+
+        event.preventDefault()
+        event.dataTransfer.dropEffect = 'move'
+        event.currentTarget.classList.add('drag-over')
+    }
+
+    handleDragLeave(event) {
+        event.currentTarget.classList.remove('drag-over')
+    }
+
+    async handleDrop(event) {
+        event.preventDefault()
+        event.currentTarget.classList.remove('drag-over')
+
+        const commentIdsJson = event.dataTransfer.getData('application/x-comment-ids')
+        if (!commentIdsJson) return
+
+        const commentIds = JSON.parse(commentIdsJson)
+        if (!commentIds || commentIds.length === 0) return
+
+        const targetTopicId = event.currentTarget.dataset.id // Empty string for Main
+
+        // Dispatch event for list_controller to handle the move
+        this.dispatch('move-to-topic', { 
+            detail: { 
+                commentIds, 
+                targetTopicId 
+            } 
+        })
     }
 
     async deleteTopic(event) {

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -70,6 +70,7 @@ en:
       fullscreen: Full screen
       exit_fullscreen: Exit full screen
       move_invalid_target: Select a valid creative to move messages to.
+      move_invalid_topic: Invalid topic selected.
       move_not_allowed: You do not have permission to move these messages.
       select_label: Select message
       add_reaction: Add reaction

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -67,6 +67,7 @@ ko:
       fullscreen: 전체 화면
       exit_fullscreen: 전체 화면 종료
       move_invalid_target: 이동할 크리에이티브를 선택해주세요.
+      move_invalid_topic: 유효하지 않은 토픽입니다.
       move_not_allowed: 이 메시지를 이동할 권한이 없습니다.
       select_label: 메시지 선택
       add_reaction: 리액션 추가

--- a/engines/collavre/test/controllers/comments_controller_move_to_topic_test.rb
+++ b/engines/collavre/test/controllers/comments_controller_move_to_topic_test.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class CommentsControllerMoveToTopicTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:one)
+    @creative = creatives(:tshirt)
+    @user.update!(email_verified_at: Time.current)
+    
+    # Create topics
+    @topic1 = Topic.create!(name: "Topic 1", creative: @creative, user: @user)
+    @topic2 = Topic.create!(name: "Topic 2", creative: @creative, user: @user)
+    
+    # Create comments in Main (no topic)
+    @comment1 = @creative.comments.create!(content: "Comment 1", user: @user, topic_id: nil)
+    @comment2 = @creative.comments.create!(content: "Comment 2", user: @user, topic_id: nil)
+    
+    post session_path, params: { email: @user.email, password: "password" }
+  end
+
+  test "move comments to topic" do
+    post move_creative_comments_path(@creative), 
+         params: { comment_ids: [@comment1.id, @comment2.id], target_topic_id: @topic1.id },
+         as: :json
+
+    assert_response :success
+    
+    @comment1.reload
+    @comment2.reload
+    
+    assert_equal @topic1.id, @comment1.topic_id
+    assert_equal @topic1.id, @comment2.topic_id
+  end
+
+  test "move comments to Main (empty topic_id)" do
+    # First move to topic
+    @comment1.update!(topic_id: @topic1.id)
+    @comment2.update!(topic_id: @topic1.id)
+
+    # Then move back to Main
+    post move_creative_comments_path(@creative), 
+         params: { comment_ids: [@comment1.id, @comment2.id], target_topic_id: "" },
+         as: :json
+
+    assert_response :success
+    
+    @comment1.reload
+    @comment2.reload
+    
+    assert_nil @comment1.topic_id
+    assert_nil @comment2.topic_id
+  end
+
+  test "move comments to different topic" do
+    @comment1.update!(topic_id: @topic1.id)
+
+    post move_creative_comments_path(@creative), 
+         params: { comment_ids: [@comment1.id], target_topic_id: @topic2.id },
+         as: :json
+
+    assert_response :success
+    
+    @comment1.reload
+    assert_equal @topic2.id, @comment1.topic_id
+  end
+
+  test "returns error for invalid topic" do
+    post move_creative_comments_path(@creative), 
+         params: { comment_ids: [@comment1.id], target_topic_id: 99999 },
+         as: :json
+
+    assert_response :unprocessable_entity
+  end
+
+  test "skips comments already in target topic" do
+    @comment1.update!(topic_id: @topic1.id)
+
+    post move_creative_comments_path(@creative), 
+         params: { comment_ids: [@comment1.id], target_topic_id: @topic1.id },
+         as: :json
+
+    assert_response :success
+    json = JSON.parse(response.body)
+    assert_equal 0, json["moved_count"]
+  end
+end

--- a/engines/collavre/test/controllers/comments_controller_move_to_topic_test.rb
+++ b/engines/collavre/test/controllers/comments_controller_move_to_topic_test.rb
@@ -7,28 +7,28 @@ class CommentsControllerMoveToTopicTest < ActionDispatch::IntegrationTest
     @user = users(:one)
     @creative = creatives(:tshirt)
     @user.update!(email_verified_at: Time.current)
-    
+
     # Create topics
     @topic1 = Topic.create!(name: "Topic 1", creative: @creative, user: @user)
     @topic2 = Topic.create!(name: "Topic 2", creative: @creative, user: @user)
-    
+
     # Create comments in Main (no topic)
     @comment1 = @creative.comments.create!(content: "Comment 1", user: @user, topic_id: nil)
     @comment2 = @creative.comments.create!(content: "Comment 2", user: @user, topic_id: nil)
-    
+
     post session_path, params: { email: @user.email, password: "password" }
   end
 
   test "move comments to topic" do
-    post move_creative_comments_path(@creative), 
-         params: { comment_ids: [@comment1.id, @comment2.id], target_topic_id: @topic1.id },
+    post move_creative_comments_path(@creative),
+         params: { comment_ids: [ @comment1.id, @comment2.id ], target_topic_id: @topic1.id },
          as: :json
 
     assert_response :success
-    
+
     @comment1.reload
     @comment2.reload
-    
+
     assert_equal @topic1.id, @comment1.topic_id
     assert_equal @topic1.id, @comment2.topic_id
   end
@@ -39,15 +39,15 @@ class CommentsControllerMoveToTopicTest < ActionDispatch::IntegrationTest
     @comment2.update!(topic_id: @topic1.id)
 
     # Then move back to Main
-    post move_creative_comments_path(@creative), 
-         params: { comment_ids: [@comment1.id, @comment2.id], target_topic_id: "" },
+    post move_creative_comments_path(@creative),
+         params: { comment_ids: [ @comment1.id, @comment2.id ], target_topic_id: "" },
          as: :json
 
     assert_response :success
-    
+
     @comment1.reload
     @comment2.reload
-    
+
     assert_nil @comment1.topic_id
     assert_nil @comment2.topic_id
   end
@@ -55,19 +55,19 @@ class CommentsControllerMoveToTopicTest < ActionDispatch::IntegrationTest
   test "move comments to different topic" do
     @comment1.update!(topic_id: @topic1.id)
 
-    post move_creative_comments_path(@creative), 
-         params: { comment_ids: [@comment1.id], target_topic_id: @topic2.id },
+    post move_creative_comments_path(@creative),
+         params: { comment_ids: [ @comment1.id ], target_topic_id: @topic2.id },
          as: :json
 
     assert_response :success
-    
+
     @comment1.reload
     assert_equal @topic2.id, @comment1.topic_id
   end
 
   test "returns error for invalid topic" do
-    post move_creative_comments_path(@creative), 
-         params: { comment_ids: [@comment1.id], target_topic_id: 99999 },
+    post move_creative_comments_path(@creative),
+         params: { comment_ids: [ @comment1.id ], target_topic_id: 99999 },
          as: :json
 
     assert_response :unprocessable_entity
@@ -76,8 +76,8 @@ class CommentsControllerMoveToTopicTest < ActionDispatch::IntegrationTest
   test "skips comments already in target topic" do
     @comment1.update!(topic_id: @topic1.id)
 
-    post move_creative_comments_path(@creative), 
-         params: { comment_ids: [@comment1.id], target_topic_id: @topic1.id },
+    post move_creative_comments_path(@creative),
+         params: { comment_ids: [ @comment1.id ], target_topic_id: @topic1.id },
          as: :json
 
     assert_response :success


### PR DESCRIPTION
## Summary

Add drag-and-drop functionality to move selected messages between topics in the chat popup.

## Changes

### Backend
- `comments_controller#move`: Added `target_topic_id` parameter support
  - Move comments to different topic within same creative
  - Returns `moved_count` in response
  - Validates topic existence

### Frontend
- **topics_controller.js**: Added drop target handlers on topic tags
- **list_controller.js**: Made selected comments draggable
- **comments_popup.css**: Drag-and-drop visual styles

### i18n
- Added `move_invalid_topic` translation key (en, ko)

## Usage
1. Select messages using checkboxes
2. Drag any selected message
3. Drop on a topic tag (#Main, #Topic1, etc.)
4. All selected messages move to that topic

## Visual Feedback
- **During drag**: Non-selected messages become semi-transparent
- **Drop target**: Topic tag highlights with accent color