### PR TITLE
feat: Add inline edit for topic rename

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -842,3 +842,15 @@ body.chat-fullscreen main {
     width: 100px;
     outline: none;
 }
+
+.topic-edit-input {
+    display: inline-block;
+    padding: 0.1em 0.4em;
+    border-radius: 8px;
+    background: var(--color-bg);
+    border: 1px solid var(--color-accent, #007bff);
+    color: var(--color-text);
+    font-size: 0.85em;
+    width: 80px;
+    outline: none;
+}

--- a/engines/collavre/app/controllers/collavre/topics_controller.rb
+++ b/engines/collavre/app/controllers/collavre/topics_controller.rb
@@ -29,6 +29,24 @@ module Collavre
       end
     end
 
+    def update
+      unless @creative.has_permission?(Current.user, :admin) || @creative.user == Current.user
+        render json: { error: I18n.t("collavre.topics.no_permission") }, status: :forbidden and return
+      end
+
+      topic = @creative.topics.find(params[:id])
+
+      if topic.update(topic_params)
+        TopicsChannel.broadcast_to(
+          @creative,
+          { action: "updated", topic: topic.slice(:id, :name) }
+        )
+        render json: topic
+      else
+        render json: { errors: topic.errors.full_messages }, status: :unprocessable_entity
+      end
+    end
+
     def destroy
       unless @creative.has_permission?(Current.user, :admin) || @creative.user == Current.user
         render json: { error: I18n.t("collavre.topics.no_permission") }, status: :forbidden and return

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -220,8 +220,17 @@ export default class extends Controller {
     select(event) {
         // Ignore if clicking on delete button (though stopPropagation should handle it)
         if (event.target.closest('.delete-topic-btn')) return
+        // Ignore if clicking on edit input
+        if (event.target.closest('.topic-edit-input')) return
 
         const id = event.currentTarget.dataset.id
+        
+        // If clicking on already active topic (not Main), show edit mode
+        if (id && String(this.currentTopicId) === String(id) && this.canManageTopics) {
+            this.showEditInput(event.currentTarget, id)
+            return
+        }
+        
         this.selectTopic(id)
     }
 
@@ -232,6 +241,89 @@ export default class extends Controller {
         }
         // Dispatch event
         this.dispatch("change", { detail: { topicId: id } })
+    }
+
+    showEditInput(topicEl, topicId) {
+        const topic = this.topics.find(t => String(t.id) === String(topicId))
+        if (!topic) return
+
+        const currentName = topic.name
+        
+        // Store original HTML for restore
+        topicEl.dataset.originalHtml = topicEl.innerHTML
+        
+        // Replace content with input
+        topicEl.innerHTML = `<input type="text" class="topic-edit-input" value="${currentName}"
+                              data-action="keydown->comments--topics#handleEditKey blur->comments--topics#cancelEdit"
+                              data-topic-id="${topicId}">`
+        
+        const input = topicEl.querySelector('input')
+        requestAnimationFrame(() => {
+            input.focus()
+            input.select()
+        })
+    }
+
+    handleEditKey(event) {
+        if (event.key === 'Enter') {
+            event.preventDefault()
+            const name = event.target.value.trim()
+            const topicId = event.target.dataset.topicId
+            if (name) {
+                this.updateTopic(topicId, name)
+            } else {
+                this.cancelEdit(event)
+            }
+        } else if (event.key === 'Escape') {
+            event.preventDefault()
+            this.cancelEdit(event)
+        }
+    }
+
+    cancelEdit(event) {
+        // Prevent blur from firing multiple times
+        if (this.editCancelling) return
+        this.editCancelling = true
+
+        const topicEl = event.target.closest('.topic-tag')
+        if (topicEl && topicEl.dataset.originalHtml) {
+            topicEl.innerHTML = topicEl.dataset.originalHtml
+            delete topicEl.dataset.originalHtml
+        }
+
+        setTimeout(() => { this.editCancelling = false }, 100)
+    }
+
+    async updateTopic(topicId, name) {
+        if (!this.creativeId) return
+
+        try {
+            const response = await fetch(`/creatives/${this.creativeId}/topics/${topicId}`, {
+                method: 'PATCH',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').content
+                },
+                body: JSON.stringify({ topic: { name } })
+            })
+
+            if (response.ok) {
+                const updatedTopic = await response.json()
+                // Update local topics array
+                const index = this.topics.findIndex(t => String(t.id) === String(topicId))
+                if (index !== -1) {
+                    this.topics[index] = updatedTopic
+                }
+                this.renderTopics(this.topics, this.canManageTopics)
+                this.restoreSelection()
+            } else {
+                alert("Failed to update topic")
+                this.loadTopics() // Reload to restore state
+            }
+        } catch (e) {
+            console.error("Error updating topic", e)
+            this.loadTopics()
+        }
     }
 
     updateSelectionUI(id) {
@@ -353,6 +445,11 @@ export default class extends Controller {
             return
         }
 
+        if (action === "updated" && data.topic) {
+            this.updateTopicInList(data.topic)
+            return
+        }
+
         if (!data.topic) return
 
         const topics = this.topics || []
@@ -360,6 +457,16 @@ export default class extends Controller {
         if (exists) return
 
         this.topics = [...topics, data.topic]
+        this.renderTopics(this.topics, this.canManageTopics)
+        this.restoreSelection()
+    }
+
+    updateTopicInList(updatedTopic) {
+        const topics = this.topics || []
+        const index = topics.findIndex(t => String(t.id) === String(updatedTopic.id))
+        if (index === -1) return
+
+        this.topics[index] = updatedTopic
         this.renderTopics(this.topics, this.canManageTopics)
         this.restoreSelection()
     }

--- a/engines/collavre/config/routes.rb
+++ b/engines/collavre/config/routes.rb
@@ -49,7 +49,7 @@ Collavre::Engine.routes.draw do
 
   resources :creatives do
     resources :creative_shares, only: [ :create, :destroy ]
-    resources :topics, only: [ :index, :create, :destroy ]
+    resources :topics, only: [ :index, :create, :update, :destroy ]
     resources :comments, only: [ :index, :create, :destroy, :show, :update ] do
       member do
         post :convert

--- a/engines/collavre/test/controllers/topics_controller_test.rb
+++ b/engines/collavre/test/controllers/topics_controller_test.rb
@@ -23,4 +23,23 @@ class TopicsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :no_content
   end
+
+  test "should update topic name" do
+    patch collavre.creative_topic_url(@creative, @topic), params: { topic: { name: "Updated Name" } }, as: :json
+
+    assert_response :success
+    @topic.reload
+    assert_equal "Updated Name", @topic.name
+  end
+
+  test "should not update topic without permission" do
+    other_user = users(:two)
+    sign_in_as other_user, password: "password"
+
+    patch collavre.creative_topic_url(@creative, @topic), params: { topic: { name: "Hacked Name" } }, as: :json
+
+    assert_response :forbidden
+    @topic.reload
+    assert_equal "Existing Topic", @topic.name
+  end
 end


### PR DESCRIPTION
## Summary
Add the ability to rename topics by clicking on the currently selected topic in the chat popup.

## Changes
### Backend
- `TopicsController#update`: New action to update topic name
- Routes: Added `:update` to topics resources
- Broadcasts update via TopicsChannel

### Frontend
- `topics_controller.js`: Click on active topic shows inline edit input
- Enter to save, Escape to cancel
- WebSocket handler for `updated` action
- `comments_popup.css`: Styles for edit input

### Tests
- Added update success test
- Added permission denied test

## Usage
1. Click on the currently active topic tag (not Main)
2. Edit the name in the inline input
3. Press Enter to save or Escape to cancel