### PR TITLE
feat: Add selection hint popup for drag-and-drop guidance

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -854,3 +854,51 @@ body.chat-fullscreen main {
     width: 80px;
     outline: none;
 }
+
+/* Selection hint popup */
+.selection-hint-popup {
+    position: absolute;
+    left: 100%;
+    top: 50%;
+    transform: translateY(-50%);
+    margin-left: 8px;
+    background: var(--color-bg-secondary, #f8f9fa);
+    border: 1px solid var(--color-border, #dee2e6);
+    border-radius: 8px;
+    padding: 8px 12px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+    white-space: nowrap;
+    z-index: 100;
+    animation: hint-fade-in 0.2s ease-out;
+}
+
+.selection-hint-popup .hint-content {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-size: 0.8em;
+    color: var(--color-text-secondary, #6c757d);
+}
+
+.selection-hint-popup .hint-content span {
+    display: block;
+}
+
+@keyframes hint-fade-in {
+    from {
+        opacity: 0;
+        transform: translateY(-50%) translateX(-10px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(-50%) translateX(0);
+    }
+}
+
+/* Dark mode support */
+@media (prefers-color-scheme: dark) {
+    .selection-hint-popup {
+        background: var(--color-bg-secondary, #2d2d2d);
+        border-color: var(--color-border, #444);
+    }
+}

--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -857,18 +857,14 @@ body.chat-fullscreen main {
 
 /* Selection hint popup */
 .selection-hint-popup {
-    position: absolute;
-    left: 100%;
-    top: 50%;
-    transform: translateY(-50%);
-    margin-left: 8px;
+    position: fixed;
     background: var(--color-bg-secondary, #f8f9fa);
     border: 1px solid var(--color-border, #dee2e6);
     border-radius: 8px;
     padding: 8px 12px;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
     white-space: nowrap;
-    z-index: 100;
+    z-index: 10000;
     animation: hint-fade-in 0.2s ease-out;
 }
 
@@ -887,11 +883,11 @@ body.chat-fullscreen main {
 @keyframes hint-fade-in {
     from {
         opacity: 0;
-        transform: translateY(-50%) translateX(-10px);
+        transform: translateY(-4px);
     }
     to {
         opacity: 1;
-        transform: translateY(-50%) translateX(0);
+        transform: translateY(0);
     }
 }
 

--- a/engines/collavre/app/javascript/controllers/comments/list_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/list_controller.js
@@ -512,8 +512,8 @@ export default class extends Controller {
     hint.className = 'selection-hint-popup'
     hint.innerHTML = `
       <div class="hint-content">
-        <span>🎯 드래그 → 토픽 이동</span>
-        <span>📤 이동 버튼 → 다른 채팅창</span>
+        <span>🎯 Drag → Move to topic</span>
+        <span>📤 Move button → Another chat</span>
       </div>
     `
 

--- a/engines/collavre/app/javascript/controllers/comments/list_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/list_controller.js
@@ -488,6 +488,38 @@ export default class extends Controller {
     }
     this.updateDraggableState()
     this.notifySelectionChange()
+    this.updateSelectionHint()
+  }
+
+  updateSelectionHint() {
+    // Remove existing hint
+    const existingHint = this.listTarget.querySelector('.selection-hint-popup')
+    if (existingHint) {
+      existingHint.remove()
+    }
+
+    if (this.selection.size === 0) return
+
+    // Find the first selected checkbox
+    const firstSelected = this.listTarget.querySelector('.comment-item.selected-for-move')
+    if (!firstSelected) return
+
+    const checkbox = firstSelected.querySelector('.comment-select-checkbox')
+    if (!checkbox) return
+
+    // Create hint popup
+    const hint = document.createElement('div')
+    hint.className = 'selection-hint-popup'
+    hint.innerHTML = `
+      <div class="hint-content">
+        <span>🎯 드래그 → 토픽 이동</span>
+        <span>📤 이동 버튼 → 다른 채팅창</span>
+      </div>
+    `
+
+    // Position relative to checkbox
+    checkbox.parentElement.style.position = 'relative'
+    checkbox.parentElement.appendChild(hint)
   }
 
   updateDraggableState() {
@@ -576,6 +608,9 @@ export default class extends Controller {
       if (item) item.classList.remove('selected-for-move')
     })
     this.notifySelectionChange()
+    // Remove hint popup
+    const hint = this.listTarget.querySelector('.selection-hint-popup')
+    if (hint) hint.remove()
   }
 
   copyCommentLink(button) {

--- a/engines/collavre/app/javascript/controllers/comments/list_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/list_controller.js
@@ -520,20 +520,25 @@ export default class extends Controller {
     // Append to body for proper positioning
     document.body.appendChild(hint)
 
-    // Position like CommonPopup - below and left-aligned, within viewport
+    // Position like CommonPopup - to the right of checkbox, within viewport
     requestAnimationFrame(() => {
       const checkboxRect = checkbox.getBoundingClientRect()
       const hintRect = hint.getBoundingClientRect()
       const boundsPadding = 8
 
-      // Start below the checkbox, aligned to left
-      let left = checkboxRect.left
-      let top = checkboxRect.bottom + 4
+      // Start to the right of the checkbox, vertically centered
+      let left = checkboxRect.right + 8
+      let top = checkboxRect.top + (checkboxRect.height / 2) - (hintRect.height / 2)
 
       // Keep within viewport bounds
       const maxLeft = window.innerWidth - hintRect.width - boundsPadding
       const maxTop = window.innerHeight - hintRect.height - boundsPadding
 
+      // If overflows right, position to the left of checkbox instead
+      if (left > maxLeft) {
+        left = checkboxRect.left - hintRect.width - 8
+      }
+      
       left = Math.max(boundsPadding, Math.min(left, maxLeft))
       top = Math.max(boundsPadding, Math.min(top, maxTop))
 

--- a/engines/collavre/app/javascript/controllers/comments/list_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/list_controller.js
@@ -493,7 +493,7 @@ export default class extends Controller {
 
   updateSelectionHint() {
     // Remove existing hint
-    const existingHint = this.listTarget.querySelector('.selection-hint-popup')
+    const existingHint = document.querySelector('.selection-hint-popup')
     if (existingHint) {
       existingHint.remove()
     }
@@ -517,9 +517,29 @@ export default class extends Controller {
       </div>
     `
 
-    // Position relative to checkbox
-    checkbox.parentElement.style.position = 'relative'
-    checkbox.parentElement.appendChild(hint)
+    // Append to body for proper positioning
+    document.body.appendChild(hint)
+
+    // Position like CommonPopup - below and left-aligned, within viewport
+    requestAnimationFrame(() => {
+      const checkboxRect = checkbox.getBoundingClientRect()
+      const hintRect = hint.getBoundingClientRect()
+      const boundsPadding = 8
+
+      // Start below the checkbox, aligned to left
+      let left = checkboxRect.left
+      let top = checkboxRect.bottom + 4
+
+      // Keep within viewport bounds
+      const maxLeft = window.innerWidth - hintRect.width - boundsPadding
+      const maxTop = window.innerHeight - hintRect.height - boundsPadding
+
+      left = Math.max(boundsPadding, Math.min(left, maxLeft))
+      top = Math.max(boundsPadding, Math.min(top, maxTop))
+
+      hint.style.left = `${left}px`
+      hint.style.top = `${top}px`
+    })
   }
 
   updateDraggableState() {
@@ -608,8 +628,8 @@ export default class extends Controller {
       if (item) item.classList.remove('selected-for-move')
     })
     this.notifySelectionChange()
-    // Remove hint popup
-    const hint = this.listTarget.querySelector('.selection-hint-popup')
+    // Remove hint popup from body
+    const hint = document.querySelector('.selection-hint-popup')
     if (hint) hint.remove()
   }
 


### PR DESCRIPTION
## Summary
Add a helpful hint popup when users select messages via checkboxes, guiding them on available actions.

## Changes
### Frontend
- `list_controller.js`: Added `updateSelectionHint()` method to show/hide popup
- Shows hint next to first selected checkbox
- Automatically removed when selection is cleared

### CSS
- `comments_popup.css`: Added styles for hint popup with fade-in animation
- Dark mode support included

## Popup Content
- 🎯 Drag → Move to topic
- 📤 Move button → Move to another chat

## Behavior
- Appears when first checkbox is selected
- Only one popup shown regardless of selection count
- Positioned to the right of the first selected checkbox
- Removed when all selections are cleared