### PR TITLE
fix: Use i18n for selection hint popup text

### DIFF
--- a/engines/collavre/app/javascript/controllers/comments/list_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/list_controller.js
@@ -510,10 +510,12 @@ export default class extends Controller {
     // Create hint popup
     const hint = document.createElement('div')
     hint.className = 'selection-hint-popup'
+    const dragTopicText = this.element.dataset.hintDragTopicText || '🎯 Drag → Move to topic'
+    const moveButtonText = this.element.dataset.hintMoveButtonText || '📤 Move button → Another chat'
     hint.innerHTML = `
       <div class="hint-content">
-        <span>🎯 Drag → Move to topic</span>
-        <span>📤 Move button → Another chat</span>
+        <span>${dragTopicText}</span>
+        <span>${moveButtonText}</span>
       </div>
     `
 

--- a/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
@@ -24,7 +24,9 @@
      data-voice-start-text="<%= t('collavre.comments.voice_button') %>"
      data-voice-stop-text="<%= t('collavre.comments.voice_stop') %>"
      data-move-no-selection-text="<%= t('collavre.comments.move_no_selection') %>"
-     data-move-error-text="<%= t('collavre.comments.move_error') %>">
+     data-move-error-text="<%= t('collavre.comments.move_error') %>"
+     data-hint-drag-topic-text="<%= t('collavre.comments.hint_drag_topic') %>"
+     data-hint-move-button-text="<%= t('collavre.comments.hint_move_button') %>">
   <% unless fullscreen %>
     <div class="resize-handle resize-handle-left" data-comments--popup-target="leftHandle"></div>
     <div class="resize-handle resize-handle-right" data-comments--popup-target="rightHandle"></div>

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -67,6 +67,8 @@ en:
       move_button: Move
       move_no_selection: Select at least one message to move.
       move_error: Unable to move messages.
+      hint_drag_topic: "🎯 Drag → Move to topic"
+      hint_move_button: "📤 Move button → Another chat"
       fullscreen: Full screen
       exit_fullscreen: Exit full screen
       move_invalid_target: Select a valid creative to move messages to.

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -64,6 +64,8 @@ ko:
       move_button: 이동
       move_no_selection: 이동할 메시지를 선택해주세요.
       move_error: 메시지를 이동할 수 없습니다.
+      hint_drag_topic: "🎯 드래그 → 토픽 이동"
+      hint_move_button: "📤 이동 버튼 → 다른 채팅창"
       fullscreen: 전체 화면
       exit_fullscreen: 전체 화면 종료
       move_invalid_target: 이동할 크리에이티브를 선택해주세요.


### PR DESCRIPTION
## Summary
Use i18n translation keys for the selection hint popup text instead of hardcoded strings.

## Changes
- Added `hint_drag_topic` and `hint_move_button` i18n keys (en, ko)
- Updated `_comments_popup.html.erb` to pass i18n texts via data attributes
- Updated `list_controller.js` to read texts from data attributes

## i18n Keys
| Key | English | Korean |
|-----|---------|--------|
| `hint_drag_topic` | 🎯 Drag → Move to topic | 🎯 드래그 → 토픽 이동 |
| `hint_move_button` | 📤 Move button → Another chat | 📤 이동 버튼 → 다른 채팅창 |