### PR TITLE
fix: Allow unchecking private checkbox when editing comments

### DIFF
--- a/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
@@ -64,7 +64,7 @@
     <textarea class="shared-input-surface" name="comment[content]" data-comments--form-target="textarea" data-comments--presence-target="textarea" data-comments--mention-menu-target="textarea" rows="2" enterkeyhint="send"></textarea>
     <div class="comment-bottom">
     <input type="file" id="comment-images" name="comment[images][]" accept="image/*" multiple data-comments--form-target="imageInput" style="display:none;" />
-    <label style="height: 22px"><input type="checkbox" id="comment-private" data-comments--form-target="privateCheckbox" data-comments--presence-target="privateCheckbox" name="comment[private]" /> <%= t('collavre.comments.private') %></label>
+    <label style="height: 22px"><input type="hidden" name="comment[private]" value="0" /><input type="checkbox" id="comment-private" data-comments--form-target="privateCheckbox" data-comments--presence-target="privateCheckbox" name="comment[private]" value="1" /> <%= t('collavre.comments.private') %></label>
     <div class="comment-actions">
     <button class="creative-action-btn" id="attach-image-btn" data-comments--form-target="imageButton" type="button"><%= t('collavre.comments.image_button') %></button>
     <button class="creative-action-btn" id="voice-comments-btn" data-comments--form-target="voiceButton" type="button" data-voice-state="idle"><%= t('collavre.comments.voice_button') %></button>

--- a/engines/collavre/test/controllers/comments_controller_test.rb
+++ b/engines/collavre/test/controllers/comments_controller_test.rb
@@ -254,6 +254,40 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
     assert_nil comment.approver_id
   end
 
+  test "user can uncheck private checkbox when updating comment" do
+    comment = @creative.comments.create!(content: "Secret", user: @user, private: true)
+    assert comment.private?, "Comment should start as private"
+
+    patch creative_comment_path(@creative, comment), params: {
+      comment: {
+        content: "No longer secret",
+        private: "0"
+      }
+    }
+
+    assert_response :success
+    comment.reload
+    assert_equal "No longer secret", comment.content
+    assert_not comment.private?, "Comment should no longer be private after unchecking"
+  end
+
+  test "user can check private checkbox when updating comment" do
+    comment = @creative.comments.create!(content: "Public", user: @user, private: false)
+    assert_not comment.private?, "Comment should start as public"
+
+    patch creative_comment_path(@creative, comment), params: {
+      comment: {
+        content: "Now secret",
+        private: "1"
+      }
+    }
+
+    assert_response :success
+    comment.reload
+    assert_equal "Now secret", comment.content
+    assert comment.private?, "Comment should be private after checking"
+  end
+
   test "user can move comments to another creative" do
     target = creatives(:childless_creative)
     comment = @creative.comments.create!(content: "Move me", user: @user)


### PR DESCRIPTION
## Problem
When editing a private comment and unchecking the private checkbox, the comment remained private.

## Root Cause
HTML checkboxes don't send any value when unchecked. The form was missing the hidden field fallback that Rails conventionally uses.

## Solution
Added a hidden field with value "0" before the checkbox with value "1":
```html
<input type="hidden" name="comment[private]" value="0" />
<input type="checkbox" name="comment[private]" value="1" />
```

When checkbox is:
- **Checked**: sends `comment[private]=1` (hidden field overridden)
- **Unchecked**: sends `comment[private]=0` (hidden field value)

## Testing
1. Create a private comment (check the 비밀/private box)
2. Edit the comment and uncheck the private box
3. Save - the comment should now be public