### PR TITLE
fix: Apply consistent text color to comment submit button

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -483,6 +483,7 @@ body.chat-fullscreen main {
 #voice-comments-btn,
 #attach-image-btn,
 #cancel-edit-btn,
+#new-comment-form button[type="submit"],
 .convert-comment-btn,
 .delete-comment-btn,
 .edit-comment-btn,


### PR DESCRIPTION
## Problem
When editing a comment, the submit button text ('Update') was invisible because it inherited a color similar to the background.

## Cause
The submit button was missing from the CSS selector list that applies `color: var(--color-chat-btn-text)` to chat action buttons.

## Solution
Added `#new-comment-form button[type="submit"]` to the button style selector list in `comments_popup.css`.

## Before
- Edit mode: 'Update' text barely visible (color blends with background)

## After  
- Edit mode: 'Update' text clearly visible with proper contrast