### PR TITLE
feat: Add drag-and-drop reordering for chat topics

### DIFF
--- a/db/migrate/20260203083302_add_position_to_topics.rb
+++ b/db/migrate/20260203083302_add_position_to_topics.rb
@@ -1,0 +1,23 @@
+class AddPositionToTopics < ActiveRecord::Migration[8.1]
+  def change
+    add_column :topics, :position, :integer, default: 0, null: false
+
+    # Set position based on created_at order for existing topics
+    reversible do |dir|
+      dir.up do
+        # Group topics by creative_id and set position based on created_at order
+        execute <<-SQL
+          UPDATE topics
+          SET position = (
+            SELECT COUNT(*)
+            FROM topics t2
+            WHERE t2.creative_id = topics.creative_id
+            AND t2.created_at < topics.created_at
+          )
+        SQL
+      end
+    end
+
+    add_index :topics, [ :creative_id, :position ]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_03_002643) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_03_083302) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false
@@ -694,9 +694,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_03_002643) do
     t.datetime "created_at", null: false
     t.integer "creative_id", null: false
     t.string "name", null: false
+    t.integer "position", default: 0, null: false
     t.datetime "updated_at", null: false
     t.integer "user_id", null: false
     t.index ["creative_id", "name"], name: "index_topics_on_creative_id_and_name", unique: true
+    t.index ["creative_id", "position"], name: "index_topics_on_creative_id_and_position"
     t.index ["creative_id"], name: "index_topics_on_creative_id"
     t.index ["user_id"], name: "index_topics_on_user_id"
   end

--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -731,6 +731,29 @@ body.chat-fullscreen main {
     transition: all 0.15s ease;
 }
 
+/* Topic reorder drag styles */
+.topic-tag[draggable="true"] {
+    cursor: grab;
+}
+
+.topic-tag[draggable="true"]:active {
+    cursor: grabbing;
+}
+
+.topic-tag.topic-dragging {
+    opacity: 0.5;
+}
+
+.topic-tag.topic-drag-over-left {
+    border-left: 3px solid var(--color-accent, #007bff);
+    margin-left: -1px;
+}
+
+.topic-tag.topic-drag-over-right {
+    border-right: 3px solid var(--color-accent, #007bff);
+    margin-right: -1px;
+}
+
 .comment-item[draggable="true"] {
     cursor: grab;
 }

--- a/engines/collavre/app/controllers/collavre/topics_controller.rb
+++ b/engines/collavre/app/controllers/collavre/topics_controller.rb
@@ -63,6 +63,30 @@ module Collavre
       head :no_content
     end
 
+    def reorder
+      unless @creative.has_permission?(Current.user, :admin) || @creative.user == Current.user
+        render json: { error: I18n.t("collavre.topics.no_permission") }, status: :forbidden and return
+      end
+
+      topic_ids = params[:topic_ids]
+      unless topic_ids.is_a?(Array) && topic_ids.present?
+        render json: { error: "Invalid topic_ids" }, status: :unprocessable_entity and return
+      end
+
+      Topic.transaction do
+        topic_ids.each_with_index do |id, index|
+          @creative.topics.where(id: id).update_all(position: index)
+        end
+      end
+
+      TopicsChannel.broadcast_to(
+        @creative,
+        { action: "reordered", topic_ids: topic_ids }
+      )
+
+      render json: { success: true }
+    end
+
     private
 
     def set_creative

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -87,7 +87,7 @@ export default class extends Controller {
 
     renderTopics(topics, canManage = false) {
         const dragActions = canManage 
-            ? 'draggable->comments--topics#handleTopicDragStart dragend->comments--topics#handleTopicDragEnd'
+            ? 'dragstart->comments--topics#handleTopicDragStart dragend->comments--topics#handleTopicDragEnd'
             : ''
         const dropActions = 'dragover->comments--topics#handleDragOver dragleave->comments--topics#handleDragLeave drop->comments--topics#handleDrop'
         const topicDropActions = canManage

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -86,15 +86,24 @@ export default class extends Controller {
     }
 
     renderTopics(topics, canManage = false) {
+        const dragActions = canManage 
+            ? 'draggable->comments--topics#handleTopicDragStart dragend->comments--topics#handleTopicDragEnd'
+            : ''
+        const dropActions = 'dragover->comments--topics#handleDragOver dragleave->comments--topics#handleDragLeave drop->comments--topics#handleDrop'
+        const topicDropActions = canManage
+            ? 'dragover->comments--topics#handleTopicReorderDragOver dragleave->comments--topics#handleTopicReorderDragLeave drop->comments--topics#handleTopicReorderDrop'
+            : ''
+
         let html = `<span class="topic-tag topic-drop-target ${this.currentTopicId ? '' : 'active'}" 
-                          data-action="click->comments--topics#select dragover->comments--topics#handleDragOver dragleave->comments--topics#handleDragLeave drop->comments--topics#handleDrop" 
+                          data-action="click->comments--topics#select ${dropActions}" 
                           data-id="">#Main</span>`
 
         topics.forEach(topic => {
             // Ensure comparison handles string/number difference
             const isActive = String(this.currentTopicId) === String(topic.id) ? 'active' : ''
-            html += `<span class="topic-tag topic-drop-target ${isActive}" 
-                          data-action="click->comments--topics#select dragover->comments--topics#handleDragOver dragleave->comments--topics#handleDragLeave drop->comments--topics#handleDrop" 
+            const draggable = canManage ? 'draggable="true"' : ''
+            html += `<span class="topic-tag topic-drop-target ${isActive}" ${draggable}
+                          data-action="click->comments--topics#select ${dropActions} ${dragActions} ${topicDropActions}" 
                           data-id="${topic.id}">
                         #${topic.name}`
 
@@ -147,6 +156,129 @@ export default class extends Controller {
                 targetTopicId 
             } 
         })
+    }
+
+    // Topic reorder drag & drop handlers
+    handleTopicDragStart(event) {
+        const topicEl = event.currentTarget
+        const topicId = topicEl.dataset.id
+        if (!topicId) {
+            event.preventDefault()
+            return
+        }
+
+        this.draggingTopicId = topicId
+        event.dataTransfer.setData('application/x-topic-id', topicId)
+        event.dataTransfer.effectAllowed = 'move'
+        
+        requestAnimationFrame(() => {
+            topicEl.classList.add('topic-dragging')
+        })
+    }
+
+    handleTopicDragEnd(event) {
+        this.draggingTopicId = null
+        event.currentTarget.classList.remove('topic-dragging')
+        this.listTarget.querySelectorAll('.topic-tag').forEach(el => {
+            el.classList.remove('topic-drag-over-left', 'topic-drag-over-right')
+        })
+    }
+
+    handleTopicReorderDragOver(event) {
+        // Only accept topic reorder drops
+        if (!event.dataTransfer.types.includes('application/x-topic-id')) return
+        if (!this.draggingTopicId) return
+
+        const targetEl = event.currentTarget
+        const targetId = targetEl.dataset.id
+
+        // Don't allow drop on self or Main
+        if (!targetId || targetId === this.draggingTopicId) return
+
+        event.preventDefault()
+        event.dataTransfer.dropEffect = 'move'
+
+        // Determine drop position (left or right) based on mouse position
+        const rect = targetEl.getBoundingClientRect()
+        const midpoint = rect.left + rect.width / 2
+        const isLeft = event.clientX < midpoint
+
+        targetEl.classList.toggle('topic-drag-over-left', isLeft)
+        targetEl.classList.toggle('topic-drag-over-right', !isLeft)
+    }
+
+    handleTopicReorderDragLeave(event) {
+        event.currentTarget.classList.remove('topic-drag-over-left', 'topic-drag-over-right')
+    }
+
+    async handleTopicReorderDrop(event) {
+        event.preventDefault()
+        
+        const targetEl = event.currentTarget
+        targetEl.classList.remove('topic-drag-over-left', 'topic-drag-over-right')
+
+        const draggedTopicId = event.dataTransfer.getData('application/x-topic-id')
+        const targetTopicId = targetEl.dataset.id
+
+        if (!draggedTopicId || !targetTopicId || draggedTopicId === targetTopicId) return
+
+        // Determine drop position
+        const rect = targetEl.getBoundingClientRect()
+        const midpoint = rect.left + rect.width / 2
+        const insertBefore = event.clientX < midpoint
+
+        // Reorder topics array
+        const topics = [...this.topics]
+        const draggedIndex = topics.findIndex(t => String(t.id) === String(draggedTopicId))
+        const targetIndex = topics.findIndex(t => String(t.id) === String(targetTopicId))
+
+        if (draggedIndex === -1 || targetIndex === -1) return
+
+        // Remove dragged topic
+        const [draggedTopic] = topics.splice(draggedIndex, 1)
+
+        // Calculate new position
+        let newIndex = targetIndex
+        if (draggedIndex < targetIndex) {
+            newIndex = insertBefore ? targetIndex - 1 : targetIndex
+        } else {
+            newIndex = insertBefore ? targetIndex : targetIndex + 1
+        }
+
+        // Insert at new position
+        topics.splice(newIndex, 0, draggedTopic)
+
+        // Update local state and UI immediately
+        this.topics = topics
+        this.renderTopics(topics, this.canManageTopics)
+        this.restoreSelection()
+
+        // Send to server
+        await this.saveTopicOrder(topics.map(t => t.id))
+    }
+
+    async saveTopicOrder(topicIds) {
+        if (!this.creativeId) return
+
+        try {
+            const response = await fetch(`/creatives/${this.creativeId}/topics/reorder`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').content
+                },
+                body: JSON.stringify({ topic_ids: topicIds })
+            })
+
+            if (!response.ok) {
+                console.error('Failed to save topic order')
+                // Reload to restore server state
+                this.loadTopics()
+            }
+        } catch (e) {
+            console.error('Error saving topic order', e)
+            this.loadTopics()
+        }
     }
 
     async deleteTopic(event) {
@@ -450,6 +582,11 @@ export default class extends Controller {
             return
         }
 
+        if (action === "reordered" && data.topic_ids) {
+            this.reorderTopicsFromServer(data.topic_ids)
+            return
+        }
+
         if (!data.topic) return
 
         const topics = this.topics || []
@@ -457,6 +594,27 @@ export default class extends Controller {
         if (exists) return
 
         this.topics = [...topics, data.topic]
+        this.renderTopics(this.topics, this.canManageTopics)
+        this.restoreSelection()
+    }
+
+    reorderTopicsFromServer(topicIds) {
+        if (!topicIds || !Array.isArray(topicIds)) return
+
+        const reorderedTopics = []
+        topicIds.forEach(id => {
+            const topic = this.topics.find(t => String(t.id) === String(id))
+            if (topic) reorderedTopics.push(topic)
+        })
+
+        // Add any topics not in the list (shouldn't happen, but safety)
+        this.topics.forEach(topic => {
+            if (!reorderedTopics.find(t => String(t.id) === String(topic.id))) {
+                reorderedTopics.push(topic)
+            }
+        })
+
+        this.topics = reorderedTopics
         this.renderTopics(this.topics, this.canManageTopics)
         this.restoreSelection()
     }

--- a/engines/collavre/app/models/collavre/topic.rb
+++ b/engines/collavre/app/models/collavre/topic.rb
@@ -16,7 +16,7 @@ module Collavre
     private
 
     def set_default_position
-      self.position ||= (creative.topics.unscoped.where(creative_id: creative_id).maximum(:position) || -1) + 1
+      self.position ||= (Topic.unscoped.where(creative_id: creative_id).maximum(:position) || -1) + 1
     end
   end
 end

--- a/engines/collavre/app/models/collavre/topic.rb
+++ b/engines/collavre/app/models/collavre/topic.rb
@@ -8,5 +8,15 @@ module Collavre
     has_many :comments, class_name: "Collavre::Comment", dependent: :destroy
 
     validates :name, presence: true, uniqueness: { scope: :creative_id }
+
+    before_create :set_default_position
+
+    default_scope { order(:position) }
+
+    private
+
+    def set_default_position
+      self.position ||= (creative.topics.unscoped.where(creative_id: creative_id).maximum(:position) || -1) + 1
+    end
   end
 end

--- a/engines/collavre/app/models/collavre/topic.rb
+++ b/engines/collavre/app/models/collavre/topic.rb
@@ -16,7 +16,9 @@ module Collavre
     private
 
     def set_default_position
-      self.position ||= (Topic.unscoped.where(creative_id: creative_id).maximum(:position) || -1) + 1
+      return if position_changed? && position != 0
+
+      self.position = (Topic.unscoped.where(creative_id: creative_id).maximum(:position) || -1) + 1
     end
   end
 end

--- a/engines/collavre/config/routes.rb
+++ b/engines/collavre/config/routes.rb
@@ -49,7 +49,11 @@ Collavre::Engine.routes.draw do
 
   resources :creatives do
     resources :creative_shares, only: [ :create, :destroy ]
-    resources :topics, only: [ :index, :create, :update, :destroy ]
+    resources :topics, only: [ :index, :create, :update, :destroy ] do
+      collection do
+        post :reorder
+      end
+    end
     resources :comments, only: [ :index, :create, :destroy, :show, :update ] do
       member do
         post :convert

--- a/engines/collavre/test/controllers/topics_controller_test.rb
+++ b/engines/collavre/test/controllers/topics_controller_test.rb
@@ -72,4 +72,27 @@ class TopicsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :unprocessable_entity
   end
+
+  test "new topic should be created at the end after reordering" do
+    # Create initial topics
+    topic2 = @creative.topics.create!(name: "Topic 2", user: @user)
+    topic3 = @creative.topics.create!(name: "Topic 3", user: @user)
+
+    # Verify initial order: @topic(0), topic2(1), topic3(2)
+    assert_equal [ @topic.id, topic2.id, topic3.id ], @creative.topics.reload.pluck(:id)
+
+    # Reorder to: topic3(0), @topic(1), topic2(2)
+    post reorder_creative_topics_url(@creative), params: { topic_ids: [ topic3.id, @topic.id, topic2.id ] }, as: :json
+    assert_response :success
+
+    # Create a new topic - should be at the end (position 3)
+    post collavre.creative_topics_url(@creative), params: { topic: { name: "New Topic" } }, as: :json
+    assert_response :created
+
+    new_topic = @creative.topics.find_by(name: "New Topic")
+
+    # Verify new topic is at the end
+    assert_equal [ topic3.id, @topic.id, topic2.id, new_topic.id ], @creative.topics.reload.pluck(:id)
+    assert_equal 3, new_topic.position
+  end
 end

--- a/engines/collavre/test/controllers/topics_controller_test.rb
+++ b/engines/collavre/test/controllers/topics_controller_test.rb
@@ -42,4 +42,34 @@ class TopicsControllerTest < ActionDispatch::IntegrationTest
     @topic.reload
     assert_equal "Existing Topic", @topic.name
   end
+
+  test "should reorder topics" do
+    topic2 = @creative.topics.create!(name: "Topic 2", user: @user)
+    topic3 = @creative.topics.create!(name: "Topic 3", user: @user)
+
+    # Original order: @topic, topic2, topic3
+    assert_equal [ @topic.id, topic2.id, topic3.id ], @creative.topics.reload.pluck(:id)
+
+    # Reorder to: topic3, @topic, topic2
+    post reorder_creative_topics_url(@creative), params: { topic_ids: [ topic3.id, @topic.id, topic2.id ] }, as: :json
+
+    assert_response :success
+    assert_equal [ topic3.id, @topic.id, topic2.id ], @creative.topics.reload.pluck(:id)
+  end
+
+  test "should not reorder topics without permission" do
+    topic2 = @creative.topics.create!(name: "Topic 2", user: @user)
+    other_user = users(:two)
+    sign_in_as other_user, password: "password"
+
+    post reorder_creative_topics_url(@creative), params: { topic_ids: [ topic2.id, @topic.id ] }, as: :json
+
+    assert_response :forbidden
+  end
+
+  test "should return error for invalid topic_ids" do
+    post reorder_creative_topics_url(@creative), params: { topic_ids: nil }, as: :json
+
+    assert_response :unprocessable_entity
+  end
 end


### PR DESCRIPTION
## Summary
Allow users to reorder topics in the chat popup by dragging and dropping them left/right.

## Changes

### Database
- Add `position` column to `topics` table
- Add composite index on `(creative_id, position)`
- Migrate existing topics to set position based on `created_at` order

### Backend
- Add `reorder` action to TopicsController
- Broadcast reorder events via ActionCable
- Add `default_scope { order(:position) }` to Topic model
- Auto-assign position on topic creation

### Frontend
- Add drag-and-drop handlers for topic reordering
- Visual feedback with left/right border indicators
- Sync reorder across clients via ActionCable

## Usage
1. Open chat popup with topics
2. Drag any topic (except #Main) left or right
3. Drop to reorder

Topics with admin/owner permission can reorder.