### PR TITLE
style: Improve comment status badges visibility

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -435,8 +435,29 @@ body.chat-fullscreen main {
 
 .comment-status-label {
     margin-left: 0.4em;
-    font-size: 0.85em;
+    font-size: 0.75em;
+    padding: 0.15em 0.5em;
+    border-radius: 0.8em;
+    font-weight: 500;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25em;
+    vertical-align: middle;
+}
+
+.comment-status-label.private-label {
+    background-color: var(--color-btn-bg);
     color: var(--color-muted);
+}
+
+.comment-status-label.approved-label {
+    background-color: color-mix(in srgb, var(--color-complete) 20%, transparent);
+    color: var(--color-complete);
+}
+
+.comment-status-label.pending-label {
+    background-color: color-mix(in srgb, orange 20%, transparent);
+    color: orange;
 }
 
 .comment-action-container {

--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -446,8 +446,8 @@ body.chat-fullscreen main {
 }
 
 .comment-status-label.private-label {
-    background-color: var(--color-btn-bg);
-    color: var(--color-muted);
+    background-color: color-mix(in srgb, var(--color-badge-bg) 20%, transparent);
+    color: var(--color-badge-bg);
 }
 
 .comment-status-label.approved-label {

--- a/engines/collavre/app/views/collavre/comments/_comment.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comment.html.erb
@@ -34,10 +34,10 @@
       <%= render "collavre/comments/read_receipts", read_by_users: users_read, present_user_ids: present_user_ids unless comment.private? %>
     </span>
     <% if comment.private? %>
-      <span class="private-label">[<%= t('collavre.comments.private') %>]</span>
+      <span class="comment-status-label private-label">🔒 <%= t('collavre.comments.private') %></span>
     <% end %>
     <% if comment.action_executed_at.present? %>
-      <span class="comment-status-label approved-label">[<%= t('collavre.comments.approved_label') %>]</span>
+      <span class="comment-status-label approved-label">✅ <%= t('collavre.comments.approved_label') %></span>
     <% end %>
     <% can_convert_comment = comment.user == Current.user || comment.creative.has_permission?(Current.user, :admin) %>
   </div>


### PR DESCRIPTION
## Problem
Status badges like [Private] and [Approved] were hard to see due to muted color.

## Solution
Changed to chip-style badges with:
- Rounded corners and background color
- Emoji icons for quick recognition
- Theme-aware colors for proper contrast

## Changes

### Before
```
[비밀] [승인됨]
```
Gray muted text, hard to see

### After
```
🔒 비밀   ✅ 승인됨
```
Chip-style with colored background

## Badge Styles
| Badge | Icon | Background |
|-------|------|------------|
| Private | 🔒 | Gray (`--color-btn-bg`) |
| Approved | ✅ | Green tint (`--color-complete`) |
| Pending | ⏳ | Orange tint (future) |