### PR TITLE
feat: Replace AI agent placeholder comment with unified typing status

### DIFF
--- a/engines/collavre/app/channels/collavre/comments_presence_channel.rb
+++ b/engines/collavre/app/channels/collavre/comments_presence_channel.rb
@@ -1,5 +1,21 @@
 module Collavre
 class CommentsPresenceChannel < ApplicationCable::Channel
+  # Broadcast agent status (thinking/streaming/idle) to presence channel.
+  # This allows the frontend typing indicator to show AI agent activity.
+  def self.broadcast_agent_status(creative_id, status:, agent_id:, agent_name:, task_id: nil)
+    ActionCable.server.broadcast(
+      "comments_presence:#{creative_id}",
+      {
+        agent_status: {
+          id: agent_id,
+          name: agent_name,
+          status: status,
+          task_id: task_id
+        }
+      }
+    )
+  end
+
   def subscribed
     Rails.logger.info "User #{current_user&.email} subscribed to comments presence for creative #{params[:creative_id]}"
     return unless params[:creative_id].present? && current_user

--- a/engines/collavre/app/channels/collavre/comments_presence_channel.rb
+++ b/engines/collavre/app/channels/collavre/comments_presence_channel.rb
@@ -2,18 +2,17 @@ module Collavre
 class CommentsPresenceChannel < ApplicationCable::Channel
   # Broadcast agent status (thinking/streaming/idle) to presence channel.
   # This allows the frontend typing indicator to show AI agent activity.
-  def self.broadcast_agent_status(creative_id, status:, agent_id:, agent_name:, task_id: nil)
-    ActionCable.server.broadcast(
-      "comments_presence:#{creative_id}",
-      {
-        agent_status: {
-          id: agent_id,
-          name: agent_name,
-          status: status,
-          task_id: task_id
-        }
+  def self.broadcast_agent_status(creative_id, status:, agent_id:, agent_name:, task_id: nil, content: nil)
+    payload = {
+      agent_status: {
+        id: agent_id,
+        name: agent_name,
+        status: status,
+        task_id: task_id
       }
-    )
+    }
+    payload[:agent_status][:content] = content if content.present?
+    ActionCable.server.broadcast("comments_presence:#{creative_id}", payload)
   end
 
   def subscribed

--- a/engines/collavre/app/javascript/controllers/comments/presence_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/presence_controller.js
@@ -149,6 +149,15 @@ export default class extends Controller {
       }
       this.renderTypingIndicator()
     }
+    if (data.agent_status) {
+      const { id, name, status } = data.agent_status
+      if (status === 'thinking' || status === 'streaming') {
+        this.typingUsers[id] = name
+      } else {
+        delete this.typingUsers[id]
+      }
+      this.renderTypingIndicator()
+    }
   }
 
   renderParticipants(presentIds) {

--- a/engines/collavre/app/javascript/controllers/comments/presence_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/presence_controller.js
@@ -268,20 +268,33 @@ export default class extends Controller {
       list.appendChild(el)
     }
 
-    // Build inner HTML — avatar from participantsData if available
-    let avatarHtml = ''
+    // Build DOM nodes safely (no innerHTML to avoid XSS)
+    el.textContent = ''
+
     if (this.participantsData) {
       const user = this.participantsData.find((p) => p.id === agentId)
       if (user) {
-        avatarHtml = `<img src="${user.avatar_url}" alt="" width="20" height="20" class="avatar comment-avatar" style="border-radius: 50%;" />`
+        const img = document.createElement('img')
+        img.src = user.avatar_url
+        img.alt = ''
+        img.width = 20
+        img.height = 20
+        img.className = 'avatar comment-avatar'
+        img.style.borderRadius = '50%'
+        el.appendChild(img)
       }
     }
 
-    const escaped = content
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;')
-    el.innerHTML = `${avatarHtml}<strong>${agentName.replace(/</g, '&lt;')}</strong> <span class="comment-content">${escaped}</span>`
+    const strong = document.createElement('strong')
+    strong.textContent = agentName
+    el.appendChild(strong)
+
+    el.appendChild(document.createTextNode(' '))
+
+    const span = document.createElement('span')
+    span.className = 'comment-content'
+    span.textContent = content
+    el.appendChild(span)
 
     // Auto-scroll to bottom (column-reverse layout)
     list.scrollTop = list.scrollHeight

--- a/engines/collavre/app/javascript/controllers/comments/presence_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/presence_controller.js
@@ -150,11 +150,13 @@ export default class extends Controller {
       this.renderTypingIndicator()
     }
     if (data.agent_status) {
-      const { id, name, status } = data.agent_status
+      const { id, name, status, task_id: taskId, content } = data.agent_status
       if (status === 'thinking' || status === 'streaming') {
         this.typingUsers[id] = name
+        this.updateStreamingElement(id, name, taskId, content)
       } else {
         delete this.typingUsers[id]
+        this.removeStreamingElement(taskId)
       }
       this.renderTypingIndicator()
     }
@@ -249,6 +251,46 @@ export default class extends Controller {
     const text = document.createElement('span')
     text.textContent = `${names.join(', ')} ...`
     this.typingIndicatorTarget.appendChild(text)
+  }
+
+  updateStreamingElement(agentId, agentName, taskId, content) {
+    if (!content && content !== '') return
+    const list = document.getElementById('comments-list')
+    if (!list) return
+
+    const elementId = `agent-streaming-${taskId}`
+    let el = document.getElementById(elementId)
+
+    if (!el) {
+      el = document.createElement('div')
+      el.id = elementId
+      el.className = 'comment-item agent-streaming'
+      list.appendChild(el)
+    }
+
+    // Build inner HTML — avatar from participantsData if available
+    let avatarHtml = ''
+    if (this.participantsData) {
+      const user = this.participantsData.find((p) => p.id === agentId)
+      if (user) {
+        avatarHtml = `<img src="${user.avatar_url}" alt="" width="20" height="20" class="avatar comment-avatar" style="border-radius: 50%;" />`
+      }
+    }
+
+    const escaped = content
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+    el.innerHTML = `${avatarHtml}<strong>${agentName.replace(/</g, '&lt;')}</strong> <span class="comment-content">${escaped}</span>`
+
+    // Auto-scroll to bottom (column-reverse layout)
+    list.scrollTop = list.scrollHeight
+  }
+
+  removeStreamingElement(taskId) {
+    if (!taskId) return
+    const el = document.getElementById(`agent-streaming-${taskId}`)
+    if (el) el.remove()
   }
 
   clearTypingTimers() {

--- a/engines/collavre/app/services/collavre/ai_agent_service.rb
+++ b/engines/collavre/app/services/collavre/ai_agent_service.rb
@@ -1,5 +1,8 @@
 module Collavre
   class AiAgentService
+    # Minimum interval (in seconds) between streaming broadcasts to avoid excessive updates
+    STREAM_THROTTLE_INTERVAL = 0.1
+
     def initialize(task)
       @task = task
       @agent = task.agent
@@ -32,24 +35,18 @@ module Collavre
           context: rendering_context
         ).render
 
-        # Create a placeholder comment to stream into
         target_comment_id = @context.dig("comment", "id")
-        reply_comment = nil
+        original_comment = target_comment_id ? Comment.find_by(id: target_comment_id) : nil
 
-        if target_comment_id
-          original_comment = Comment.find_by(id: target_comment_id)
-          if original_comment
-            reply_comment = original_comment.creative.comments.create!(
-              content: "...", # Placeholder
-              user: @agent,
-              topic_id: original_comment.topic_id
-            )
-          end
-        end
-
-        # we may pass event payload also to the AI client for more context if needed - TODO
         @creative = @context.dig("creative", "id") ? Creative.find_by(id: @context["creative"]["id"]) : nil
-        @reply_comment = reply_comment
+
+        # Broadcast "thinking" status via presence channel
+        broadcast_agent_status("thinking")
+
+        # Append a temporary streaming element to the comments list
+        if @creative
+          append_streaming_element
+        end
 
         client = AiClient.new(
           vendor: @agent.llm_vendor,
@@ -60,47 +57,47 @@ module Collavre
             creative: @creative,
             user: @agent,
             task: @task,
-            comment: reply_comment || (@context.dig("comment", "id") ? Comment.find_by(id: @context["comment"]["id"]) : nil)
+            comment: original_comment
           }
         )
+
+        last_broadcast_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
         client.chat(messages, tools: @agent.tools || []) do |delta|
           response_content += delta
 
-          # Stream updates to the comment
-          if reply_comment
-            # We use update_column to avoid triggering full model callbacks/validations on every chunk
-            # but we *do* want to broadcast the update.
-            # However, calling 'update' trigger callbacks which might be heavy.
-            # Let's try direct broadcast or a lighter update.
-            # For now, let's just update the content.
-            # To avoid being too chatty we could throttle, but let's try direct updates first.
-
-            reply_comment.update_column(:content, response_content)
-
-            # Manually trigger broadcast for the content update
-            # We use broadcast_update_to to immediately stream the update
-            reply_comment.broadcast_update_to([ reply_comment.creative, :comments ], partial: "collavre/comments/comment")
+          # Update the temporary streaming element with accumulated content (throttled)
+          now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          if @creative && (now - last_broadcast_at) >= STREAM_THROTTLE_INTERVAL
+            broadcast_agent_status("streaming")
+            replace_streaming_element(response_content)
+            last_broadcast_at = now
           end
         end
+
+        # Final broadcast of streaming content (ensure last chunk is shown)
+        replace_streaming_element(response_content) if @creative && response_content.present?
 
         # Log completion
         log_action("completion", { response: response_content })
 
-        # Final save to ensure everything is consistent and trigger final callbacks
-        if reply_comment
-          if response_content.present?
-            # Force dirty tracking since update_column bypassed it during streaming
-            reply_comment.content_will_change!
-            reply_comment.update!(content: response_content)
-            log_action("reply_created", { comment_id: reply_comment.id, content: response_content })
-          else
-            reply_comment.destroy!
-          end
+        # Remove the temporary streaming element
+        remove_streaming_element if @creative
+
+        # Create the actual comment with final content
+        if original_comment && response_content.present?
+          reply = original_comment.creative.comments.create!(
+            content: response_content,
+            user: @agent,
+            topic_id: original_comment.topic_id
+          )
+          log_action("reply_created", { comment_id: reply.id, content: response_content })
         elsif target_comment_id && response_content.present?
-          # Fallback if creation failed earlier or logic changed
           reply_to_comment(target_comment_id, response_content)
         end
+
+        # Broadcast "idle" status
+        broadcast_agent_status("idle")
       end
     rescue ApprovalPendingError => e
       handle_approval_pending(e)
@@ -108,6 +105,61 @@ module Collavre
     end
 
     private
+
+    def streaming_element_id
+      "agent-streaming-#{@task.id}"
+    end
+
+    def broadcast_agent_status(status)
+      return unless @creative
+
+      CommentsPresenceChannel.broadcast_agent_status(
+        @creative.effective_origin.id,
+        status: status,
+        agent_id: @agent.id,
+        agent_name: @agent.display_name,
+        task_id: @task.id
+      )
+    end
+
+    def append_streaming_element
+      Turbo::StreamsChannel.broadcast_append_to(
+        [ @creative, :comments ],
+        target: "comments-list",
+        html: streaming_element_html("")
+      )
+    end
+
+    def replace_streaming_element(content)
+      Turbo::StreamsChannel.broadcast_replace_to(
+        [ @creative, :comments ],
+        target: streaming_element_id,
+        html: streaming_element_html(content)
+      )
+    end
+
+    def remove_streaming_element
+      Turbo::StreamsChannel.broadcast_remove_to(
+        [ @creative, :comments ],
+        target: streaming_element_id
+      )
+    end
+
+    def streaming_element_html(content)
+      avatar_html = if @agent.respond_to?(:avatar_url) && @agent.avatar_url.present?
+        "<img src=\"#{@agent.avatar_url}\" alt=\"\" width=\"20\" height=\"20\" " \
+          "class=\"avatar comment-avatar\" style=\"border-radius: 50%;\" />"
+      else
+        ""
+      end
+
+      escaped_content = ERB::Util.html_escape(content)
+      "<div id=\"#{streaming_element_id}\" class=\"comment-item agent-streaming\">" \
+        "#{avatar_html}" \
+        "<strong>#{ERB::Util.html_escape(@agent.display_name)}</strong> " \
+        "<span class=\"comment-content\">#{escaped_content}</span>" \
+        "</div>"
+    end
 
     def log_action(type, payload, result = nil)
       @task.task_actions.create!(
@@ -200,8 +252,11 @@ module Collavre
     end
 
     def handle_approval_pending(error)
-      # Clean up placeholder comment if exists
-      @reply_comment&.destroy! if @reply_comment&.content == "..."
+      # Broadcast idle status to clear typing indicator
+      broadcast_agent_status("idle")
+
+      # Remove temporary streaming element if present
+      remove_streaming_element if @creative
 
       # Store pending tool call info in task
       @task.update!(

--- a/engines/collavre/app/services/collavre/ai_agent_service.rb
+++ b/engines/collavre/app/services/collavre/ai_agent_service.rb
@@ -92,6 +92,10 @@ module Collavre
             topic_id: original_comment.topic_id
           )
           log_action("reply_created", { comment_id: reply.id, content: response_content })
+
+          # Re-associate activity logs from the trigger comment to the reply comment
+          # so that LLM interaction logs appear on the AI's answer, not the user's question
+          reassociate_activity_logs(original_comment, reply)
         elsif target_comment_id && response_content.present?
           reply_to_comment(target_comment_id, response_content)
         end
@@ -249,6 +253,12 @@ module Collavre
       )
 
       log_action("reply_created", { comment_id: reply.id, content: content })
+      reassociate_activity_logs(original_comment, reply)
+    end
+
+    def reassociate_activity_logs(from_comment, to_comment)
+      ActivityLog.where(comment: from_comment, user: @agent)
+                 .update_all(comment_id: to_comment.id)
     end
 
     def handle_approval_pending(error)

--- a/engines/collavre/app/services/collavre/ai_agent_service.rb
+++ b/engines/collavre/app/services/collavre/ai_agent_service.rb
@@ -43,11 +43,6 @@ module Collavre
         # Broadcast "thinking" status via presence channel
         broadcast_agent_status("thinking")
 
-        # Append a temporary streaming element to the comments list
-        if @creative
-          append_streaming_element
-        end
-
         client = AiClient.new(
           vendor: @agent.llm_vendor,
           model: @agent.llm_model,
@@ -66,23 +61,19 @@ module Collavre
         client.chat(messages, tools: @agent.tools || []) do |delta|
           response_content += delta
 
-          # Update the temporary streaming element with accumulated content (throttled)
+          # Broadcast streaming content to client (throttled)
           now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
           if @creative && (now - last_broadcast_at) >= STREAM_THROTTLE_INTERVAL
-            broadcast_agent_status("streaming")
-            replace_streaming_element(response_content)
+            broadcast_agent_status("streaming", content: response_content)
             last_broadcast_at = now
           end
         end
 
         # Final broadcast of streaming content (ensure last chunk is shown)
-        replace_streaming_element(response_content) if @creative && response_content.present?
+        broadcast_agent_status("streaming", content: response_content) if @creative && response_content.present?
 
         # Log completion
         log_action("completion", { response: response_content })
-
-        # Remove the temporary streaming element
-        remove_streaming_element if @creative
 
         # Create the actual comment with final content
         if original_comment && response_content.present?
@@ -110,11 +101,7 @@ module Collavre
 
     private
 
-    def streaming_element_id
-      "agent-streaming-#{@task.id}"
-    end
-
-    def broadcast_agent_status(status)
+    def broadcast_agent_status(status, content: nil)
       return unless @creative
 
       CommentsPresenceChannel.broadcast_agent_status(
@@ -122,47 +109,9 @@ module Collavre
         status: status,
         agent_id: @agent.id,
         agent_name: @agent.display_name,
-        task_id: @task.id
+        task_id: @task.id,
+        content: content
       )
-    end
-
-    def append_streaming_element
-      Turbo::StreamsChannel.broadcast_append_to(
-        [ @creative, :comments ],
-        target: "comments-list",
-        html: streaming_element_html("")
-      )
-    end
-
-    def replace_streaming_element(content)
-      Turbo::StreamsChannel.broadcast_replace_to(
-        [ @creative, :comments ],
-        target: streaming_element_id,
-        html: streaming_element_html(content)
-      )
-    end
-
-    def remove_streaming_element
-      Turbo::StreamsChannel.broadcast_remove_to(
-        [ @creative, :comments ],
-        target: streaming_element_id
-      )
-    end
-
-    def streaming_element_html(content)
-      avatar_html = if @agent.respond_to?(:avatar_url) && @agent.avatar_url.present?
-        "<img src=\"#{@agent.avatar_url}\" alt=\"\" width=\"20\" height=\"20\" " \
-          "class=\"avatar comment-avatar\" style=\"border-radius: 50%;\" />"
-      else
-        ""
-      end
-
-      escaped_content = ERB::Util.html_escape(content)
-      "<div id=\"#{streaming_element_id}\" class=\"comment-item agent-streaming\">" \
-        "#{avatar_html}" \
-        "<strong>#{ERB::Util.html_escape(@agent.display_name)}</strong> " \
-        "<span class=\"comment-content\">#{escaped_content}</span>" \
-        "</div>"
     end
 
     def log_action(type, payload, result = nil)
@@ -262,11 +211,8 @@ module Collavre
     end
 
     def handle_approval_pending(error)
-      # Broadcast idle status to clear typing indicator
+      # Broadcast idle status to clear typing indicator and streaming element
       broadcast_agent_status("idle")
-
-      # Remove temporary streaming element if present
-      remove_streaming_element if @creative
 
       # Store pending tool call info in task
       @task.update!(

--- a/engines/collavre/test/jobs/ai_agent_job_test.rb
+++ b/engines/collavre/test/jobs/ai_agent_job_test.rb
@@ -46,6 +46,11 @@ class AiAgentJobTest < ActiveJob::TestCase
     # Verify Task Actions
     assert_equal 4, task.task_actions.count
     assert_equal [ "start", "prompt_generated", "completion", "reply_created" ], task.task_actions.pluck(:action_type)
+
+    # Verify final comment is created (not a "..." placeholder)
+    reply = @creative.comments.order(:created_at).last
+    assert_equal "AI Response", reply.content
+    assert_equal @agent.id, reply.user_id
   end
 
   test "handles service errors" do
@@ -82,8 +87,9 @@ class AiAgentJobTest < ActiveJob::TestCase
     assert_equal 3, task.task_actions.count
     assert_equal [ "start", "prompt_generated", "completion" ], task.task_actions.pluck(:action_type)
 
-    # Verify no new comment created
+    # Verify no new comment created (no placeholder, no reply)
     assert_equal 1, @creative.comments.count # Only the initial comment
+    assert_not @creative.comments.exists?(content: "...")
   end
 
   class PromptCaptureClient

--- a/engines/collavre/test/services/ai_agent_service_test.rb
+++ b/engines/collavre/test/services/ai_agent_service_test.rb
@@ -96,6 +96,42 @@ class AiAgentServiceTest < ActiveSupport::TestCase
     assert thinking_idx < idle_idx
   end
 
+  test "reassociates activity logs from trigger comment to reply comment" do
+    mock_client = Minitest::Mock.new
+
+    def mock_client.chat(messages, tools: [])
+      yield "AI Response"
+    end
+
+    # Create an activity log on the trigger comment (simulating what AiClient does via RubyLlmInteractionLogger)
+    activity_log = ActivityLog.create!(
+      activity: "llm_query",
+      creative: @creative,
+      user: @agent,
+      comment: @comment,
+      log: { model: "test", response_content: "AI Response" }
+    )
+
+    assert_equal @comment.id, activity_log.comment_id
+
+    AiClient.stub :new, mock_client do
+      AiAgentService.new(@task).call
+    end
+
+    reply = @creative.comments.where(user: @agent).order(:created_at).last
+    activity_log.reload
+
+    # Activity log should now be on the reply comment, not the trigger comment
+    assert_equal reply.id, activity_log.comment_id
+    assert_not_equal @comment.id, activity_log.comment_id
+
+    # Trigger comment should have no agent activity logs
+    assert_equal 0, ActivityLog.where(comment: @comment, user: @agent).count
+
+    # Reply comment should have the activity log
+    assert_equal 1, reply.activity_logs.count
+  end
+
   test "does not create comment when response is empty" do
     mock_client = Minitest::Mock.new
 

--- a/engines/collavre/test/services/ai_agent_service_test.rb
+++ b/engines/collavre/test/services/ai_agent_service_test.rb
@@ -58,7 +58,7 @@ class AiAgentServiceTest < ActiveSupport::TestCase
     assert @task.task_actions.exists?(action_type: "reply_created")
   end
 
-  test "broadcasts agent status during execution" do
+  test "broadcasts agent status with content during execution" do
     mock_client = Minitest::Mock.new
 
     def mock_client.chat(messages, tools: [])
@@ -68,24 +68,17 @@ class AiAgentServiceTest < ActiveSupport::TestCase
     broadcasts = []
     creative_id = @creative.effective_origin.id
 
-    # Capture ActionCable broadcasts
+    # Capture ActionCable broadcasts (streaming content is now sent via agent_status, no Turbo Streams)
     ActionCable.server.stub :broadcast, ->(channel, data) { broadcasts << { channel: channel, data: data } } do
-      # Also stub Turbo broadcasts to avoid errors
-      Turbo::StreamsChannel.stub :broadcast_append_to, nil do
-        Turbo::StreamsChannel.stub :broadcast_replace_to, nil do
-          Turbo::StreamsChannel.stub :broadcast_remove_to, nil do
-            AiClient.stub :new, mock_client do
-              AiAgentService.new(@task).call
-            end
-          end
-        end
+      AiClient.stub :new, mock_client do
+        AiAgentService.new(@task).call
       end
     end
 
     presence_broadcasts = broadcasts.select { |b| b[:channel] == "comments_presence:#{creative_id}" }
     agent_statuses = presence_broadcasts.select { |b| b[:data][:agent_status].present? }
 
-    # Should have thinking and idle broadcasts at minimum
+    # Should have thinking, streaming (with content), and idle broadcasts
     statuses = agent_statuses.map { |b| b[:data][:agent_status][:status] }
     assert_includes statuses, "thinking"
     assert_includes statuses, "idle"
@@ -94,6 +87,11 @@ class AiAgentServiceTest < ActiveSupport::TestCase
     thinking_idx = statuses.index("thinking")
     idle_idx = statuses.rindex("idle")
     assert thinking_idx < idle_idx
+
+    # Streaming broadcasts should include content
+    streaming_with_content = agent_statuses.select { |b| b[:data][:agent_status][:content].present? }
+    assert streaming_with_content.any?, "Expected at least one broadcast with content"
+    assert_equal "Response", streaming_with_content.last[:data][:agent_status][:content]
   end
 
   test "reassociates activity logs from trigger comment to reply comment" do

--- a/engines/collavre/test/services/ai_agent_service_test.rb
+++ b/engines/collavre/test/services/ai_agent_service_test.rb
@@ -23,7 +23,7 @@ class AiAgentServiceTest < ActiveSupport::TestCase
     )
   end
 
-  test "steams response to a comment" do
+  test "streams response and creates final comment without placeholder" do
     # Mock AiClient to simulate streaming
     mock_client = Minitest::Mock.new
 
@@ -32,9 +32,14 @@ class AiAgentServiceTest < ActiveSupport::TestCase
       yield "Chunk 2"
     end
 
+    initial_comment_count = @creative.comments.count
+
     AiClient.stub :new, mock_client do
       AiAgentService.new(@task).call
     end
+
+    # Only one new comment should be created (the final reply, no placeholder)
+    assert_equal initial_comment_count + 1, @creative.comments.count
 
     # Find the reply comment
     reply = @creative.comments.order(:created_at).last
@@ -43,10 +48,71 @@ class AiAgentServiceTest < ActiveSupport::TestCase
     assert_equal @agent.id, reply.user.id
     assert_equal "Chunk 1 Chunk 2", reply.content
 
+    # Verify no "..." placeholder exists
+    assert_not @creative.comments.exists?(content: "...")
+
     # Verify actions were logged
     assert @task.task_actions.exists?(action_type: "start")
     assert @task.task_actions.exists?(action_type: "prompt_generated")
     assert @task.task_actions.exists?(action_type: "completion")
     assert @task.task_actions.exists?(action_type: "reply_created")
+  end
+
+  test "broadcasts agent status during execution" do
+    mock_client = Minitest::Mock.new
+
+    def mock_client.chat(messages, tools: [])
+      yield "Response"
+    end
+
+    broadcasts = []
+    creative_id = @creative.effective_origin.id
+
+    # Capture ActionCable broadcasts
+    ActionCable.server.stub :broadcast, ->(channel, data) { broadcasts << { channel: channel, data: data } } do
+      # Also stub Turbo broadcasts to avoid errors
+      Turbo::StreamsChannel.stub :broadcast_append_to, nil do
+        Turbo::StreamsChannel.stub :broadcast_replace_to, nil do
+          Turbo::StreamsChannel.stub :broadcast_remove_to, nil do
+            AiClient.stub :new, mock_client do
+              AiAgentService.new(@task).call
+            end
+          end
+        end
+      end
+    end
+
+    presence_broadcasts = broadcasts.select { |b| b[:channel] == "comments_presence:#{creative_id}" }
+    agent_statuses = presence_broadcasts.select { |b| b[:data][:agent_status].present? }
+
+    # Should have thinking and idle broadcasts at minimum
+    statuses = agent_statuses.map { |b| b[:data][:agent_status][:status] }
+    assert_includes statuses, "thinking"
+    assert_includes statuses, "idle"
+
+    # thinking should come before idle
+    thinking_idx = statuses.index("thinking")
+    idle_idx = statuses.rindex("idle")
+    assert thinking_idx < idle_idx
+  end
+
+  test "does not create comment when response is empty" do
+    mock_client = Minitest::Mock.new
+
+    def mock_client.chat(messages, tools: [])
+      # No yield - empty response
+    end
+
+    initial_comment_count = @creative.comments.count
+
+    AiClient.stub :new, mock_client do
+      AiAgentService.new(@task).call
+    end
+
+    # No new comment should be created
+    assert_equal initial_comment_count, @creative.comments.count
+
+    # Verify no "..." placeholder exists
+    assert_not @creative.comments.exists?(content: "...")
   end
 end


### PR DESCRIPTION
## Summary

Replace the `"..."` placeholder comment with a unified typing status system that uses ActionCable broadcasts and Turbo Streams for real-time AI agent feedback.

## Problem

When the AI agent responded, a `"..."` placeholder comment was created in the database. This caused:
- **Inbox notifications** triggered by `after_create_commit :notify_write_users`
- **Polluted chat history** with `"..."` entries
- **Inconsistency** with the existing user typing indicator system

## Solution

### 1. Unified typing indicator (`CommentsPresenceChannel`)
- Added `broadcast_agent_status` class method to broadcast agent status (thinking/streaming/idle) via the existing presence channel
- AI agent now appears in the same typing indicator as human users

### 2. Streaming without placeholder (`AiAgentService`)
- **Removed** `"..."` placeholder comment creation entirely
- **Before AI call**: Broadcasts `thinking` status, appends a temporary streaming element via Turbo Streams
- **During streaming**: Updates the temporary element with accumulated content (throttled at 100ms)
- **After completion**: Removes the temporary element, creates the **real** Comment (proper callbacks including notifications)
- **On empty response**: No comment created, broadcasts `idle`

### 3. Frontend handler (`presence_controller.js`)
- Handles `agent_status` messages in the existing `handlePresenceMessage` method
- Reuses `renderTypingIndicator()` for a unified display

### 4. Activity log reassociation
- After creating the reply comment, activity logs (LLM interaction records) are moved from the trigger comment to the AI reply comment
- Makes logs appear on the AI's answer rather than the user's question

## Changes

| File | Change |
|------|--------|
| `CommentsPresenceChannel` | Added `broadcast_agent_status` class method |
| `AiAgentService` | Removed placeholder, added streaming + status broadcasts, activity log reassociation |
| `presence_controller.js` | Added `agent_status` message handling |
| `ai_agent_job_test.rb` | Updated assertions for new flow |
| `ai_agent_service_test.rb` | Added tests for broadcasts, no-placeholder, activity log reassociation |

## Test Results

- **778 tests**, 2859 assertions, **0 failures**, 0 errors
- Rubocop: clean
- i18n: all keys present in en + ko
