### PR TITLE
fix: Resolve RubyLLM tool names to McpTool names for approval matching

### DIFF
--- a/engines/collavre/app/errors/collavre/approval_pending_error.rb
+++ b/engines/collavre/app/errors/collavre/approval_pending_error.rb
@@ -2,15 +2,17 @@
 
 module Collavre
   class ApprovalPendingError < StandardError
-    attr_reader :tool_call, :task
+    attr_reader :tool_call, :task, :mcp_tool_name
 
-    def initialize(message = "Tool execution requires approval", tool_call: nil, task: nil)
+    def initialize(message = "Tool execution requires approval", tool_call: nil, task: nil, mcp_tool_name: nil)
       @tool_call = tool_call
       @task = task
+      @mcp_tool_name = mcp_tool_name
       super(message)
     end
 
     def tool_name
+      return mcp_tool_name if mcp_tool_name.present?
       return nil unless tool_call
 
       if tool_call.respond_to?(:name)

--- a/engines/collavre/app/services/collavre/ai_client.rb
+++ b/engines/collavre/app/services/collavre/ai_client.rb
@@ -121,17 +121,17 @@ module Collavre
     end
 
     def check_tool_approval!(tool_call)
-      tool_name = tool_call.name
+      mcp_tool_name = resolve_mcp_tool_name(tool_call.name)
       task = context&.dig(:task)
 
       # Check if this tool requires approval
-      mcp_tool = McpTool.find_by(name: tool_name)
+      mcp_tool = McpTool.find_by(name: mcp_tool_name)
       return unless mcp_tool&.requires_approval?
 
       # Check if we already have approval for this specific call (resume scenario)
       if task&.pending_tool_call.present?
         pending = task.pending_tool_call
-        if pending["tool_name"] == tool_name && pending["approved"]
+        if pending["tool_name"] == mcp_tool_name && pending["approved"]
           # Already approved, clear the pending state and proceed
           task.update!(pending_tool_call: nil)
           return
@@ -140,10 +140,33 @@ module Collavre
 
       # Requires approval - raise error to halt execution
       raise ApprovalPendingError.new(
-        "Tool '#{tool_name}' requires approval before execution",
+        "Tool '#{mcp_tool_name}' requires approval before execution",
         tool_call: tool_call,
-        task: task
+        task: task,
+        mcp_tool_name: mcp_tool_name
       )
+    end
+
+    # RubyLLM generates tool names from class names (e.g. Tools::CreativeUpdate -> "tools--creative_update")
+    # but McpTool stores the original tool_name (e.g. "creative_update_service").
+    # This method resolves RubyLLM's tool name back to the McpTool name via the ToolMeta registry.
+    def resolve_mcp_tool_name(ruby_llm_name)
+      @tool_name_map ||= build_tool_name_map
+      @tool_name_map[ruby_llm_name] || ruby_llm_name
+    end
+
+    def build_tool_name_map
+      map = {}
+      ToolMeta.registry.each do |service_class|
+        schema = ToolSchema::Builder.build(service_class)
+        tool_class_name = ToolSchema::RubyLlmFactory.tool_class_name(service_class)
+        # Instantiate the RubyLLM tool class to get its generated name
+        if Tools.const_defined?(tool_class_name)
+          ruby_llm_tool = Tools.const_get(tool_class_name).new
+          map[ruby_llm_tool.name] = schema[:name]
+        end
+      end
+      map
     end
 
     def add_messages(conversation, contents)

--- a/engines/collavre/test/services/ai_client_test.rb
+++ b/engines/collavre/test/services/ai_client_test.rb
@@ -135,6 +135,55 @@ class AiClientTest < ActiveSupport::TestCase
     assert_equal 20, log_data["output_tokens"]
   end
 
+  test "resolve_mcp_tool_name maps RubyLLM tool name to McpTool name" do
+    client = AiClient.new(
+      vendor: "google",
+      model: "gemini-pro",
+      system_prompt: "system",
+      llm_api_key: "api-key"
+    )
+
+    # Build a fake registry mapping
+    fake_tool = Object.new
+    fake_tool.define_singleton_method(:name) { "tools--creative_update" }
+
+    fake_map = { "tools--creative_update" => "creative_update_service" }
+    client.stub(:build_tool_name_map, fake_map) do
+      assert_equal "creative_update_service", client.send(:resolve_mcp_tool_name, "tools--creative_update")
+    end
+  end
+
+  test "resolve_mcp_tool_name returns original name when no mapping exists" do
+    client = AiClient.new(
+      vendor: "google",
+      model: "gemini-pro",
+      system_prompt: "system",
+      llm_api_key: "api-key"
+    )
+
+    client.stub(:build_tool_name_map, {}) do
+      assert_equal "unknown_tool", client.send(:resolve_mcp_tool_name, "unknown_tool")
+    end
+  end
+
+  test "check_tool_approval uses resolved mcp tool name" do
+    client = AiClient.new(
+      vendor: "google",
+      model: "gemini-pro",
+      system_prompt: "system",
+      llm_api_key: "api-key"
+    )
+
+    # Create a tool call with RubyLLM-style name
+    tool_call = OpenStruct.new(name: "tools--creative_update", arguments: { "id" => 1 }, id: "call_1")
+
+    # Stub resolve to return the mcp name
+    client.stub(:resolve_mcp_tool_name, "creative_update_service") do
+      # No McpTool in DB with requires_approval, so it should return nil (no error)
+      assert_nil client.send(:check_tool_approval!, tool_call)
+    end
+  end
+
   test "logs error details when chat fails" do
     ActivityLog.delete_all
     conversation = FakeConversation.new


### PR DESCRIPTION
## Problem

RubyLLM generates tool names from Ruby class names using its own naming convention:
- `Tools::CreativeUpdate` → `tools--creative_update`

But `McpTool` stores the original `tool_name` from `ToolMeta`:
- `creative_update_service`

This name mismatch meant `check_tool_approval!` could never find the matching `McpTool` record, so approval was never triggered.

## Solution

- Add `resolve_mcp_tool_name()` to `AiClient` that builds a mapping from RubyLLM tool names to McpTool names via the `ToolMeta` registry
- Pass the resolved `mcp_tool_name` through `ApprovalPendingError` so `Task` and approval `Comment` store the correct name
- `ActionExecutor` already uses the stored name, so resume-after-approval works correctly

## Changes

| File | Change |
|------|--------|
| `ai_client.rb` | Add `resolve_mcp_tool_name` + `build_tool_name_map`, use resolved name in `check_tool_approval!` |
| `approval_pending_error.rb` | Accept `mcp_tool_name:` kwarg, prefer it over `tool_call.name` |
| `ai_client_test.rb` | Add 3 tests for name resolution + approval check |

## Tests

778 runs, 0 failures, 0 errors ✅