### PR TITLE
fix: Prevent ApprovalPendingError from being swallowed by generic rescue

### DIFF
--- a/engines/collavre/app/services/collavre/ai_client.rb
+++ b/engines/collavre/app/services/collavre/ai_client.rb
@@ -78,6 +78,8 @@ module Collavre
       end
 
       response_content.presence
+    rescue ApprovalPendingError
+      raise # Re-raise approval errors without catching them
     rescue StandardError => e
       error_message = e.message
       Rails.logger.error "AI Client error: #{e.message}"


### PR DESCRIPTION
## Problem

`AiClient#chat` has a `rescue StandardError` block that catches all errors and returns `nil`. Since `ApprovalPendingError < StandardError`, the approval error raised from `on_tool_call` was silently caught here, preventing the approval flow from ever executing.

```ruby
# Before: ApprovalPendingError gets caught here
rescue StandardError => e
  error_message = e.message
  nil  # ← approval flow never reaches AiAgentService
```

## Fix

Add explicit rescue for `ApprovalPendingError` before the generic handler to re-raise it:

```ruby
rescue ApprovalPendingError
  raise  # propagate to AiAgentService
rescue StandardError => e
  # handle other errors
```

## Tests

778 runs, 2861 assertions, 0 failures, 0 errors ✅