### PR TITLE
fix: Use i18n for tool approval comment content

### DIFF
--- a/engines/collavre/app/services/collavre/ai_agent_service.rb
+++ b/engines/collavre/app/services/collavre/ai_agent_service.rb
@@ -254,20 +254,14 @@ module Collavre
       args_display = if error.tool_arguments.present?
                        JSON.pretty_generate(error.tool_arguments)
       else
-                       "(no arguments)"
+                       I18n.t("collavre.ai_agent.approval.no_arguments")
       end
 
-      content = <<~CONTENT.strip
-        🔧 **Tool Approval Required**
-
-        **#{error.tool_name}** wants to execute with the following arguments:
-
-        ```json
-        #{args_display}
-        ```
-
-        Please approve or reject this action.
-      CONTENT
+      content = I18n.t(
+        "collavre.ai_agent.approval.message",
+        tool_name: error.tool_name,
+        arguments: args_display
+      )
 
       # Get topic_id from the original comment if available
       original_comment = Comment.find_by(id: @context.dig("comment", "id"))

--- a/engines/collavre/config/locales/ai_agent.en.yml
+++ b/engines/collavre/config/locales/ai_agent.en.yml
@@ -1,0 +1,15 @@
+en:
+  collavre:
+    ai_agent:
+      approval:
+        message: |
+          🔧 **Tool Approval Required**
+
+          **%{tool_name}** wants to execute with the following arguments:
+
+          ```json
+          %{arguments}
+          ```
+
+          Please approve or reject this action.
+        no_arguments: "(no arguments)"

--- a/engines/collavre/config/locales/ai_agent.ko.yml
+++ b/engines/collavre/config/locales/ai_agent.ko.yml
@@ -1,0 +1,15 @@
+ko:
+  collavre:
+    ai_agent:
+      approval:
+        message: |
+          🔧 **도구 실행 승인 필요**
+
+          **%{tool_name}** 도구가 다음 인자로 실행을 요청합니다:
+
+          ```json
+          %{arguments}
+          ```
+
+          승인 또는 거부해 주세요.
+        no_arguments: "(인자 없음)"


### PR DESCRIPTION
## Problem

Tool approval comment content was hardcoded in English.

## Fix

- Replace hardcoded strings with `I18n.t()` calls
- Add `ai_agent.en.yml` and `ai_agent.ko.yml` locale files

## Tests

778 runs, 2861 assertions, 0 failures ✅
i18n completeness check passed ✅