### PR TITLE
feat: Send inbox notification to approver for tool approval requests

### DIFF
--- a/engines/collavre/app/models/collavre/comment.rb
+++ b/engines/collavre/app/models/collavre/comment.rb
@@ -26,7 +26,7 @@ module Collavre
     validate :creative_must_be_origin_creative
     validate :images_must_be_images
 
-    after_create_commit :broadcast_create, :notify_write_users, :notify_mentions, :broadcast_badges
+    after_create_commit :broadcast_create, :notify_write_users, :notify_mentions, :notify_approver, :broadcast_badges
     after_update_commit :broadcast_update
     after_destroy_commit :broadcast_destroy, :broadcast_badges
 
@@ -174,6 +174,22 @@ module Collavre
           { user: user.display_name, comment: content, creative: creative_snippet }
         )
       end
+    end
+
+    def notify_approver
+      return unless approver.present? && action.present?
+      return if approver == user
+
+      create_inbox_item(
+        approver,
+        "inbox.approval_requested",
+        { user: user&.display_name, tool_name: parsed_action_tool_name, creative: creative_snippet }
+      )
+    end
+
+    def parsed_action_tool_name
+      parsed = JSON.parse(action) rescue nil
+      parsed&.dig("tool_name") || "unknown"
     end
 
     def assign_default_user

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -106,6 +106,7 @@ en:
       comment_content_unavailable: "(comment unavailable)"
       tool_approval_needed: Tool '%{tool_name}' has been detected/updated. Please approve
         it to activate.
+      approval_requested: '%{user} requested approval to execute tool "%{tool_name}" in "%{creative}".'
     emails:
       index_title: Emails
       list:

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -102,6 +102,7 @@ ko:
         삭제했습니다: %{comment_content}'
       comment_content_unavailable: "(삭제된 댓글 내용을 표시할 수 없습니다)"
       tool_approval_needed: 도구 '%{tool_name}'가 감지/업데이트되었습니다. 활성화하려면 승인해주세요.
+      approval_requested: '%{user}님이 "%{creative}"에서 도구 "%{tool_name}" 실행 승인을 요청했습니다.'
     emails:
       index_title: 이메일
       list:


### PR DESCRIPTION
## Problem

When an AI agent requests tool execution approval, the approval comment was created but the approver had no inbox notification — they would only see it if they opened the chat.

## Solution

Add `notify_approver` callback to Comment model that creates an inbox item for the approver when a comment has an action requiring approval.

## Changes

| File | Change |
|------|--------|
| `comment.rb` | Add `notify_approver` + `parsed_action_tool_name` methods |
| `comments.en.yml` | Add `approval_requested` i18n key |
| `comments.ko.yml` | Add `approval_requested` i18n key |

## How it works

- Comment with `approver` + `action` → inbox notification sent to approver
- Skips if approver is the same as comment author
- Inbox message: "%{user} requested approval to execute tool \"%{tool_name}\" in \"%{creative}\"."

## Tests

778 runs, 2861 assertions, 0 failures ✅
i18n completeness check ✅