### PR TITLE
feat: support MM-DD short date format in calendar command

### DIFF
--- a/engines/collavre/app/services/collavre/comments/calendar_command.rb
+++ b/engines/collavre/app/services/collavre/comments/calendar_command.rb
@@ -90,7 +90,15 @@ module Collavre
           return next_weekday(today, weekday_index(weekday_match[2]), count)
         end
 
-        Date.iso8601(token) if token.match?(/\A\d{4}-\d{2}-\d{2}\z/)
+        # YYYY-MM-DD
+        return Date.iso8601(token) if token.match?(/\A\d{4}-\d{2}-\d{2}\z/)
+
+        # MM-DD (assume current year)
+        if token.match?(/\A\d{2}-\d{2}\z/)
+          return Date.parse("#{today.year}-#{token}")
+        end
+
+        nil
       end
 
       def weekday_index(token)

--- a/engines/collavre/test/integration/comments_calendar_test.rb
+++ b/engines/collavre/test/integration/comments_calendar_test.rb
@@ -159,6 +159,48 @@ class CommentsCalendarTest < ActionDispatch::IntegrationTest
     assert_equal 0, calendar_event.start_time.min
   end
 
+  test "creates all-day event with MM-DD short date format using current year" do
+    travel_to Time.zone.local(2026, 1, 10, 9, 0, 0) do
+      user_without_google = User.create!(email: "user_short_date@example.com", password: TEST_PASSWORD, name: "User Short Date")
+      creative = Creative.create!(user: user_without_google, description: "Short date test")
+      CreativeShare.create!(creative: creative, user: user_without_google, permission: :feedback)
+      sign_in_as(user_without_google)
+
+      command = "/calendar 02-17"
+
+      assert_difference([ "Comment.count", "CalendarEvent.count" ], 1) do
+        post creative_comments_path(creative), params: { comment: { content: command } }
+      end
+
+      assert_response :created
+
+      calendar_event = CalendarEvent.last
+      assert_equal Date.new(2026, 2, 17), calendar_event.start_time.to_date
+    end
+  end
+
+  test "creates timed event with MM-DD@HH:MM short date format" do
+    travel_to Time.zone.local(2026, 3, 1, 9, 0, 0) do
+      user_without_google = User.create!(email: "user_short_time@example.com", password: TEST_PASSWORD, name: "User Short Time")
+      creative = Creative.create!(user: user_without_google, description: "Short date time test")
+      CreativeShare.create!(creative: creative, user: user_without_google, permission: :feedback)
+      sign_in_as(user_without_google)
+
+      command = "/calendar 02-17@14:00"
+
+      assert_difference([ "Comment.count", "CalendarEvent.count" ], 1) do
+        post creative_comments_path(creative), params: { comment: { content: command } }
+      end
+
+      assert_response :created
+
+      calendar_event = CalendarEvent.last
+      assert_equal Date.new(2026, 2, 17), calendar_event.start_time.to_date
+      assert_equal 14, calendar_event.start_time.hour
+      assert_equal 0, calendar_event.start_time.min
+    end
+  end
+
   test "creates local event and shows sync failed message when google sync fails" do
     command = "/calendar tomorrow"
     service = Minitest::Mock.new


### PR DESCRIPTION
## Summary

Allow omitting the year in `/calendar` date arguments. When a date is provided as `MM-DD` (e.g., `02-17`), the current year is automatically used.

## Examples

| Command | Parsed Date |
|---------|-------------|
| `/calendar 02-17` | 2026-02-17 (all-day) |
| `/calendar 02-17@14:00` | 2026-02-17 14:00 |
| `/calendar 2026-02-17` | 2026-02-17 (unchanged) |

## Changes

- `CalendarCommand#parse_date_token`: Added `MM-DD` pattern matching with current year fallback
- 2 new integration tests for short date format (all-day and timed)

## Test Results

- 790 tests, 0 failures, 0 errors
- Rubocop clean
- i18n complete