### PR TITLE
fix: make mention routing exclusive for non-AI user mentions

### DIFF
--- a/engines/collavre/app/services/collavre/system_events/router.rb
+++ b/engines/collavre/app/services/collavre/system_events/router.rb
@@ -7,27 +7,37 @@ module Collavre
         liquid_context["event_name"] = event_name
 
         # Priority 1: Mention-based routing (exclusive)
-        # If any AI agent is mentioned, ONLY route to that agent
-        mentioned_agent = find_mentioned_agent(liquid_context, context)
-        return [ mentioned_agent ] if mentioned_agent
+        # If any user is mentioned, mention routing takes over exclusively.
+        # - Mentioned AI agent → route only to that agent
+        # - Mentioned non-AI user → route to nobody (no AI agents)
+        mentioned_result = find_mentioned_routing(liquid_context, context)
+        return mentioned_result unless mentioned_result.nil?
 
-        # Priority 2: Liquid expression routing (fallback)
+        # Priority 2: Liquid expression routing (fallback, only when no mention)
         route_by_liquid_expression(liquid_context, context)
       end
 
       private
 
-      def find_mentioned_agent(liquid_context, context)
+      # Returns Array of agents to route to, or nil if no mention was found.
+      # When a mention IS found, this is exclusive:
+      #   - AI agent mentioned → [agent] (if permitted)
+      #   - Non-AI user mentioned → [] (no AI agents should receive it)
+      def find_mentioned_routing(liquid_context, context)
         mentioned_user_data = liquid_context.dig("chat", "mentioned_user")
         return nil unless mentioned_user_data && mentioned_user_data["id"]
 
-        agent = User.find_by(id: mentioned_user_data["id"])
-        return nil unless agent&.ai_user?
+        mentioned_user = User.find_by(id: mentioned_user_data["id"])
+        return nil unless mentioned_user
 
-        # Permission check for mentioned agent
-        return nil unless has_creative_permission?(agent, context)
+        # Mention found — this is exclusive routing.
+        # If the mentioned user is not an AI agent, no AI agents should receive the message.
+        return [] unless mentioned_user.ai_user?
 
-        agent
+        # Permission check for mentioned AI agent
+        return [] unless has_creative_permission?(mentioned_user, context)
+
+        [ mentioned_user ]
       end
 
       def route_by_liquid_expression(liquid_context, context)

--- a/engines/collavre/test/services/system_events/router_test.rb
+++ b/engines/collavre/test/services/system_events/router_test.rb
@@ -62,7 +62,7 @@ module SystemEvents
       assert_includes agents, @agent
     end
 
-    test "mention routing: skips mentioned non-AI user" do
+    test "mention routing: non-AI user mentioned excludes all AI agents" do
       # Create a regular user (not an AI agent)
       regular_user = User.create!(
         email: "regular@example.com",
@@ -79,14 +79,51 @@ module SystemEvents
         }
       }
 
-      # Create an agent with "true" routing expression as fallback
+      # Even with "true" routing expression, AI agent should NOT receive the message
       @agent.update!(routing_expression: "true")
 
       router = SystemEvents::Router.new
       agents = router.route("comment_created", context)
 
-      # Should fall back to Liquid routing
-      assert_includes agents, @agent
+      # Mention routing is exclusive — mentioning a non-AI user means no AI agents
+      assert_empty agents
+    end
+
+    test "mention routing: non-AI user mentioned excludes multiple AI agents" do
+      regular_user = User.create!(
+        email: "regular2@example.com",
+        name: "sawyer becky",
+        password: "password",
+        searchable: true
+      )
+
+      other_agent = User.create!(
+        email: "other_agent2@example.com",
+        name: "Other Agent",
+        password: "password",
+        llm_vendor: "google",
+        llm_model: "gemini-1.5-flash",
+        routing_expression: "true",
+        searchable: true
+      )
+
+      @agent.update!(routing_expression: "true")
+
+      context = {
+        "creative" => { "id" => @creative.id },
+        "chat" => {
+          "content" => "@sawyer becky: 아직 계시나 모르겠네요 ㅎㅎ",
+          "mentioned_user" => { "id" => regular_user.id }
+        }
+      }
+
+      router = SystemEvents::Router.new
+      agents = router.route("comment_created", context)
+
+      # Neither AI agent should receive this — it's addressed to a human
+      assert_empty agents
+      assert_not_includes agents, @agent
+      assert_not_includes agents, other_agent
     end
 
     test "mention routing: respects permission for non-searchable mentioned agent" do


### PR DESCRIPTION
## Problem

When a chat message mentions a non-AI user (e.g., `@sawyer becky: 아직 계시나 모르겠네요`), the message was still being routed to AI agents with `routing_expression: "true"`.

**Expected behavior:** Mention routing is exclusive — if any user is mentioned, only the mentioned user should receive the routing. AI agents should not receive the message via Liquid expression fallback.

**Actual behavior:** `find_mentioned_agent` returned `nil` for non-AI user mentions, causing fallthrough to Liquid expression routing where AI agents with `routing_expression: "true"` incorrectly received the message.

## Root Cause

In `Router#find_mentioned_agent`, when the mentioned user was not an AI agent (`ai_user?` returned false), the method returned `nil`. The caller treated `nil` as "no mention found" and fell through to Priority 2 (Liquid expression routing).

## Fix

Renamed `find_mentioned_agent` → `find_mentioned_routing` with clear return semantics:

| Return value | Meaning |
|---|---|
| `nil` | No mention found → fall through to Liquid routing |
| `[]` | Mention found, but target is not an AI agent → no AI agents should receive |
| `[agent]` | Mentioned AI agent → route exclusively to that agent |

When **any** user mention is detected, routing is now exclusive regardless of whether the mentioned user is an AI agent or not.

## Tests

- Updated existing test: `mention routing: non-AI user mentioned excludes all AI agents` (previously expected fallthrough, now expects empty result)
- Added new test: `mention routing: non-AI user mentioned excludes multiple AI agents` — reproduces the exact reported scenario with a human user mention and multiple AI agents with `routing_expression: "true"`

All 13 router tests pass.