### PR TITLE
feat: improve AI agent streaming with markdown, topic filter, and stop button

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -943,3 +943,45 @@ body.chat-fullscreen main {
         border-color: var(--color-border, #444);
     }
 }
+
+/* Agent streaming element */
+.agent-streaming {
+    border-left: 3px solid var(--color-link, #4a90d9);
+    background: var(--color-section-bg, #f8f9fa);
+}
+
+.agent-streaming-header {
+    display: flex;
+    align-items: center;
+    gap: 0.4em;
+    margin-bottom: 0.3em;
+}
+
+.stop-streaming-btn {
+    margin-left: auto;
+    background: none;
+    border: 1px solid var(--color-border, #ccc);
+    border-radius: 4px;
+    cursor: pointer;
+    padding: 0.1em 0.4em;
+    font-size: 0.85em;
+    line-height: 1;
+    opacity: 0.7;
+    transition: opacity 0.15s;
+}
+
+.stop-streaming-btn:hover {
+    opacity: 1;
+    background: var(--color-danger-bg, #fee);
+}
+
+.stop-streaming-btn:disabled {
+    opacity: 0.3;
+    cursor: not-allowed;
+}
+
+@media (prefers-color-scheme: dark) {
+    .agent-streaming {
+        background: var(--color-bg-secondary, #2a2a2a);
+    }
+}

--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -944,21 +944,12 @@ body.chat-fullscreen main {
     }
 }
 
-/* Agent streaming element */
+/* Agent streaming element — inherits .comment-item styles */
 .agent-streaming {
     border-left: 3px solid var(--color-link, #4a90d9);
-    background: var(--color-section-bg, #f8f9fa);
-}
-
-.agent-streaming-header {
-    display: flex;
-    align-items: center;
-    gap: 0.4em;
-    margin-bottom: 0.3em;
 }
 
 .stop-streaming-btn {
-    margin-left: auto;
     background: none;
     border: 1px solid var(--color-border, #ccc);
     border-radius: 4px;
@@ -978,10 +969,4 @@ body.chat-fullscreen main {
 .stop-streaming-btn:disabled {
     opacity: 0.3;
     cursor: not-allowed;
-}
-
-@media (prefers-color-scheme: dark) {
-    .agent-streaming {
-        background: var(--color-bg-secondary, #2a2a2a);
-    }
 }

--- a/engines/collavre/app/channels/collavre/comments_presence_channel.rb
+++ b/engines/collavre/app/channels/collavre/comments_presence_channel.rb
@@ -7,25 +7,31 @@ class CommentsPresenceChannel < ApplicationCable::Channel
       task_creative_id = task.trigger_event_payload&.dig("creative", "id")
       next unless task_creative_id == creative_id
 
+      # Resolve topic_id from the trigger comment
+      comment_id = task.trigger_event_payload&.dig("comment", "id")
+      topic_id = comment_id ? Comment.where(id: comment_id).pick(:topic_id) : nil
+
       broadcast_agent_status(
         creative_id,
         status: "thinking",
         agent_id: task.agent_id,
         agent_name: task.agent.display_name,
-        task_id: task.id
+        task_id: task.id,
+        topic_id: topic_id
       )
     end
   end
 
   # Broadcast agent status (thinking/streaming/idle) to presence channel.
   # This allows the frontend typing indicator to show AI agent activity.
-  def self.broadcast_agent_status(creative_id, status:, agent_id:, agent_name:, task_id: nil, content: nil)
+  def self.broadcast_agent_status(creative_id, status:, agent_id:, agent_name:, task_id: nil, content: nil, topic_id: nil)
     payload = {
       agent_status: {
         id: agent_id,
         name: agent_name,
         status: status,
-        task_id: task_id
+        task_id: task_id,
+        topic_id: topic_id
       }
     }
     payload[:agent_status][:content] = content if content.present?

--- a/engines/collavre/app/controllers/collavre/comments_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comments_controller.rb
@@ -463,6 +463,28 @@ module Collavre
       render json: { error: e.record.errors.full_messages.to_sentence.presence || I18n.t("collavre.comments.move_error") }, status: :unprocessable_entity
     end
 
+    def stop_streaming
+      task = Task.find_by(id: params[:task_id])
+
+      unless task
+        head :not_found and return
+      end
+
+      # Verify the task belongs to this creative
+      task_creative_id = task.trigger_event_payload&.dig("creative", "id")
+      unless task_creative_id == @creative.id
+        head :forbidden and return
+      end
+
+      # Only cancel running tasks
+      unless task.status == "running"
+        head :unprocessable_entity and return
+      end
+
+      task.update!(status: "cancelled")
+      head :ok
+    end
+
     private
 
     def set_creative

--- a/engines/collavre/app/javascript/controllers/comments/presence_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/presence_controller.js
@@ -265,6 +265,8 @@ export default class extends Controller {
     return currentTopicId === '' || currentTopicId === streamTopicId
   }
 
+  // Build a streaming element using the same structure as _comment.html.erb
+  // so it inherits identical styling (theme, layout, typography).
   updateStreamingElement(agentId, agentName, taskId, content) {
     if (!content && content !== '') return
     const list = document.getElementById('comments-list')
@@ -276,54 +278,73 @@ export default class extends Controller {
     if (!el) {
       el = document.createElement('div')
       el.id = elementId
+      // Reuse .comment-item class for identical base styling
       el.className = 'comment-item agent-streaming'
       el.dataset.taskId = taskId
-      list.appendChild(el)
-    }
 
-    // Build header only once, update content efficiently
-    let headerEl = el.querySelector('.agent-streaming-header')
-    if (!headerEl) {
-      el.textContent = ''
+      // --- Same structure as _comment.html.erb ---
 
-      headerEl = document.createElement('div')
-      headerEl.className = 'agent-streaming-header'
+      // Avatar + name row (mirrors the <div> wrapping avatar, name, timestamp)
+      const headerDiv = document.createElement('div')
 
-      if (this.participantsData) {
-        const user = this.participantsData.find((p) => p.id === agentId)
-        if (user) {
-          const img = document.createElement('img')
-          img.src = user.avatar_url
-          img.alt = ''
-          img.width = 20
-          img.height = 20
-          img.className = 'avatar comment-avatar'
-          img.style.borderRadius = '50%'
-          headerEl.appendChild(img)
+      const user = this.participantsData?.find((p) => p.id === agentId)
+      if (user) {
+        const avatarWrapper = document.createElement('span')
+        avatarWrapper.className = 'avatar-wrapper'
+        avatarWrapper.style.width = '20px'
+        avatarWrapper.style.height = '20px'
+        avatarWrapper.style.display = 'inline-block'
+        avatarWrapper.style.verticalAlign = 'middle'
+
+        const img = document.createElement('img')
+        img.src = user.avatar_url
+        img.alt = ''
+        img.width = 20
+        img.height = 20
+        img.className = 'avatar comment-avatar'
+        img.style.borderRadius = '50%'
+        avatarWrapper.appendChild(img)
+
+        if (user.default_avatar) {
+          const initial = document.createElement('span')
+          initial.className = 'avatar-initial'
+          initial.textContent = user.initial
+          initial.style.fontSize = '10px'
+          avatarWrapper.appendChild(initial)
         }
+        headerDiv.appendChild(avatarWrapper)
+        headerDiv.appendChild(document.createTextNode(' '))
       }
 
       const strong = document.createElement('strong')
       strong.textContent = agentName
-      headerEl.appendChild(strong)
+      headerDiv.appendChild(strong)
 
-      // Stop button
+      el.appendChild(headerDiv)
+
+      // Action container with stop button (mirrors .comment-action-container)
+      const actionContainer = document.createElement('div')
+      actionContainer.className = 'comment-action-container'
+
       const stopBtn = document.createElement('button')
       stopBtn.className = 'stop-streaming-btn'
       stopBtn.type = 'button'
-      stopBtn.textContent = '⏹'
-      stopBtn.title = this.element.dataset.stopStreamingText || 'Stop'
+      stopBtn.textContent = '⏹ ' + (this.element.dataset.stopStreamingText || 'Stop')
       stopBtn.addEventListener('click', () => this.stopStreaming(taskId))
-      headerEl.appendChild(stopBtn)
+      actionContainer.appendChild(stopBtn)
 
-      el.appendChild(headerEl)
+      el.appendChild(actionContainer)
 
+      // Content area (mirrors .comment-content)
       const contentEl = document.createElement('div')
       contentEl.className = 'comment-content'
+      contentEl.dataset.rendered = 'true' // Mark as rendered to prevent double-processing
       el.appendChild(contentEl)
+
+      list.appendChild(el)
     }
 
-    // Update content with markdown rendering
+    // Update content with markdown rendering (same function as comment_controller.js)
     const contentEl = el.querySelector('.comment-content')
     if (contentEl) {
       contentEl.innerHTML = renderCommentMarkdown(content)

--- a/engines/collavre/app/javascript/controllers/comments/presence_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/presence_controller.js
@@ -1,5 +1,6 @@
 import { Controller } from '@hotwired/stimulus'
 import { createSubscription } from '../../services/cable'
+import { renderCommentMarkdown } from '../../lib/utils/markdown'
 
 const TYPING_TIMEOUT = 3000
 
@@ -150,10 +151,12 @@ export default class extends Controller {
       this.renderTypingIndicator()
     }
     if (data.agent_status) {
-      const { id, name, status, task_id: taskId, content } = data.agent_status
+      const { id, name, status, task_id: taskId, content, topic_id: topicId } = data.agent_status
       if (status === 'thinking' || status === 'streaming') {
         this.typingUsers[id] = name
-        this.updateStreamingElement(id, name, taskId, content)
+        if (this.isCurrentTopic(topicId)) {
+          this.updateStreamingElement(id, name, taskId, content)
+        }
       } else {
         delete this.typingUsers[id]
         this.removeStreamingElement(taskId)
@@ -253,6 +256,15 @@ export default class extends Controller {
     this.typingIndicatorTarget.appendChild(text)
   }
 
+  isCurrentTopic(topicId) {
+    const list = document.getElementById('comments-list')
+    if (!list) return true
+    const currentTopicId = list.dataset.currentTopicId || ''
+    const streamTopicId = (topicId === null || topicId === undefined) ? '' : String(topicId)
+    // Show if no topic filter is set, or if topics match
+    return currentTopicId === '' || currentTopicId === streamTopicId
+  }
+
   updateStreamingElement(agentId, agentName, taskId, content) {
     if (!content && content !== '') return
     const list = document.getElementById('comments-list')
@@ -265,39 +277,79 @@ export default class extends Controller {
       el = document.createElement('div')
       el.id = elementId
       el.className = 'comment-item agent-streaming'
+      el.dataset.taskId = taskId
       list.appendChild(el)
     }
 
-    // Build DOM nodes safely (no innerHTML to avoid XSS)
-    el.textContent = ''
+    // Build header only once, update content efficiently
+    let headerEl = el.querySelector('.agent-streaming-header')
+    if (!headerEl) {
+      el.textContent = ''
 
-    if (this.participantsData) {
-      const user = this.participantsData.find((p) => p.id === agentId)
-      if (user) {
-        const img = document.createElement('img')
-        img.src = user.avatar_url
-        img.alt = ''
-        img.width = 20
-        img.height = 20
-        img.className = 'avatar comment-avatar'
-        img.style.borderRadius = '50%'
-        el.appendChild(img)
+      headerEl = document.createElement('div')
+      headerEl.className = 'agent-streaming-header'
+
+      if (this.participantsData) {
+        const user = this.participantsData.find((p) => p.id === agentId)
+        if (user) {
+          const img = document.createElement('img')
+          img.src = user.avatar_url
+          img.alt = ''
+          img.width = 20
+          img.height = 20
+          img.className = 'avatar comment-avatar'
+          img.style.borderRadius = '50%'
+          headerEl.appendChild(img)
+        }
       }
+
+      const strong = document.createElement('strong')
+      strong.textContent = agentName
+      headerEl.appendChild(strong)
+
+      // Stop button
+      const stopBtn = document.createElement('button')
+      stopBtn.className = 'stop-streaming-btn'
+      stopBtn.type = 'button'
+      stopBtn.textContent = '⏹'
+      stopBtn.title = this.element.dataset.stopStreamingText || 'Stop'
+      stopBtn.addEventListener('click', () => this.stopStreaming(taskId))
+      headerEl.appendChild(stopBtn)
+
+      el.appendChild(headerEl)
+
+      const contentEl = document.createElement('div')
+      contentEl.className = 'comment-content'
+      el.appendChild(contentEl)
     }
 
-    const strong = document.createElement('strong')
-    strong.textContent = agentName
-    el.appendChild(strong)
+    // Update content with markdown rendering
+    const contentEl = el.querySelector('.comment-content')
+    if (contentEl) {
+      contentEl.innerHTML = renderCommentMarkdown(content)
+    }
 
-    el.appendChild(document.createTextNode(' '))
-
-    const span = document.createElement('span')
-    span.className = 'comment-content'
-    span.textContent = content
-    el.appendChild(span)
-
-    // Auto-scroll to bottom (column-reverse layout)
+    // Auto-scroll to bottom
     list.scrollTop = list.scrollHeight
+  }
+
+  stopStreaming(taskId) {
+    if (!taskId || !this.creativeId) return
+
+    const btn = document.querySelector(`#agent-streaming-${taskId} .stop-streaming-btn`)
+    if (btn) btn.disabled = true
+
+    fetch(`/creatives/${this.creativeId}/comments/stop_streaming`, {
+      method: 'POST',
+      headers: {
+        'X-CSRF-Token': document.querySelector('meta[name=csrf-token]').content,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ task_id: taskId }),
+    }).catch((err) => {
+      console.error('Failed to stop streaming:', err)
+      if (btn) btn.disabled = false
+    })
   }
 
   removeStreamingElement(taskId) {

--- a/engines/collavre/app/services/collavre/ai_agent_service.rb
+++ b/engines/collavre/app/services/collavre/ai_agent_service.rb
@@ -22,8 +22,8 @@ module Collavre
         # Log prompt generation
         log_action("prompt_generated", { messages: messages })
 
-        # Call AI Client
-        response_content = ""
+        # Use instance variable so handle_cancelled can access accumulated content
+        @response_content = ""
 
         # Enrich context for rendering
         rendering_context = @context.dup
@@ -38,9 +38,10 @@ module Collavre
         ).render
 
         target_comment_id = @context.dig("comment", "id")
-        original_comment = target_comment_id ? Comment.find_by(id: target_comment_id) : nil
+        @original_comment = target_comment_id ? Comment.find_by(id: target_comment_id) : nil
 
         @creative = @context.dig("creative", "id") ? Creative.find_by(id: @context["creative"]["id"]) : nil
+        @topic_id = @original_comment&.topic_id
 
         # Broadcast "thinking" status via presence channel
         broadcast_agent_status("thinking")
@@ -54,7 +55,7 @@ module Collavre
             creative: @creative,
             user: @agent,
             task: @task,
-            comment: original_comment
+            comment: @original_comment
           }
         )
 
@@ -63,36 +64,36 @@ module Collavre
 
         client.chat(messages, tools: @agent.tools || []) do |delta|
           check_cancelled!
-          response_content += delta
+          @response_content += delta
 
           # Broadcast streaming content to client (throttled)
           now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
           if @creative && (now - last_broadcast_at) >= STREAM_THROTTLE_INTERVAL
-            broadcast_agent_status("streaming", content: response_content)
+            broadcast_agent_status("streaming", content: @response_content)
             last_broadcast_at = now
           end
         end
 
         # Final broadcast of streaming content (ensure last chunk is shown)
-        broadcast_agent_status("streaming", content: response_content) if @creative && response_content.present?
+        broadcast_agent_status("streaming", content: @response_content) if @creative && @response_content.present?
 
         # Log completion
-        log_action("completion", { response: response_content })
+        log_action("completion", { response: @response_content })
 
         # Create the actual comment with final content
-        if original_comment && response_content.present?
-          reply = original_comment.creative.comments.create!(
-            content: response_content,
+        if @original_comment && @response_content.present?
+          reply = @original_comment.creative.comments.create!(
+            content: @response_content,
             user: @agent,
-            topic_id: original_comment.topic_id
+            topic_id: @topic_id
           )
-          log_action("reply_created", { comment_id: reply.id, content: response_content })
+          log_action("reply_created", { comment_id: reply.id, content: @response_content })
 
           # Re-associate activity logs from the trigger comment to the reply comment
           # so that LLM interaction logs appear on the AI's answer, not the user's question
-          reassociate_activity_logs(original_comment, reply)
-        elsif target_comment_id && response_content.present?
-          reply_to_comment(target_comment_id, response_content)
+          reassociate_activity_logs(@original_comment, reply)
+        elsif target_comment_id && @response_content.present?
+          reply_to_comment(target_comment_id, @response_content)
         end
 
         # Broadcast "idle" status
@@ -117,8 +118,23 @@ module Collavre
     end
 
     def handle_cancelled
+      # Save accumulated content as a comment before clearing
+      save_partial_response
+
       broadcast_agent_status("idle")
       log_action("cancelled", { message: "Task cancelled by user" })
+    end
+
+    def save_partial_response
+      return unless @response_content.present? && @original_comment
+
+      reply = @original_comment.creative.comments.create!(
+        content: @response_content,
+        user: @agent,
+        topic_id: @topic_id
+      )
+      log_action("reply_created", { comment_id: reply.id, content: @response_content, partial: true })
+      reassociate_activity_logs(@original_comment, reply)
     end
 
     def broadcast_agent_status(status, content: nil)
@@ -130,7 +146,8 @@ module Collavre
         agent_id: @agent.id,
         agent_name: @agent.display_name,
         task_id: @task.id,
-        content: content
+        content: content,
+        topic_id: @topic_id
       )
     end
 
@@ -223,19 +240,6 @@ module Collavre
 
       log_action("reply_created", { comment_id: reply.id, content: content })
       reassociate_activity_logs(original_comment, reply)
-    end
-
-    def check_cancelled!
-      now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-      return if (now - @last_cancel_check_at) < CANCEL_CHECK_INTERVAL
-
-      @last_cancel_check_at = now
-      raise CancelledError if @task.reload.status == "cancelled"
-    end
-
-    def handle_cancelled
-      broadcast_agent_status("idle")
-      log_action("cancelled", { message: "Task cancelled by user" })
     end
 
     def reassociate_activity_logs(from_comment, to_comment)

--- a/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
@@ -26,7 +26,8 @@
      data-move-no-selection-text="<%= t('collavre.comments.move_no_selection') %>"
      data-move-error-text="<%= t('collavre.comments.move_error') %>"
      data-hint-drag-topic-text="<%= t('collavre.comments.hint_drag_topic') %>"
-     data-hint-move-button-text="<%= t('collavre.comments.hint_move_button') %>">
+     data-hint-move-button-text="<%= t('collavre.comments.hint_move_button') %>"
+     data-stop-streaming-text="<%= t('collavre.comments.stop_streaming') %>">
   <% unless fullscreen %>
     <div class="resize-handle resize-handle-left" data-comments--popup-target="leftHandle"></div>
     <div class="resize-handle resize-handle-right" data-comments--popup-target="rightHandle"></div>

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -63,6 +63,7 @@ en:
       search_empty_prompt: Please enter a search term in the chat message field.
       voice_button: Voice
       voice_stop: Stop
+      stop_streaming: Stop
       speech_unavailable: Speech recognition is not supported in this browser.
       move_button: Move
       move_no_selection: Select at least one message to move.

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -60,6 +60,7 @@ ko:
       search_empty_prompt: 검색어 를 채팅 메세지 입력폼에 입력하시오
       voice_button: 음성
       voice_stop: 중지
+      stop_streaming: 중지
       speech_unavailable: 이 브라우저는 음성 인식을 지원하지 않습니다.
       move_button: 이동
       move_no_selection: 이동할 메시지를 선택해주세요.

--- a/engines/collavre/config/routes.rb
+++ b/engines/collavre/config/routes.rb
@@ -69,6 +69,7 @@ Collavre::Engine.routes.draw do
         get :participants
         get :fullscreen
         post :move
+        post :stop_streaming
         get :commands
       end
     end

--- a/engines/collavre/test/controllers/comments_controller_test.rb
+++ b/engines/collavre/test/controllers/comments_controller_test.rb
@@ -821,4 +821,82 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :forbidden
   end
+
+  # ========================================
+  # stop_streaming
+  # ========================================
+
+  test "stop_streaming cancels a running task" do
+    agent = User.create!(
+      email: "stream_agent@ai.local",
+      name: "Stream Agent",
+      password: "password",
+      llm_vendor: "google",
+      llm_model: "gemini-1.5-flash",
+      searchable: true
+    )
+    task = Collavre::Task.create!(
+      name: "test_task",
+      status: "running",
+      agent: agent,
+      trigger_event_name: "comment_created",
+      trigger_event_payload: { "creative" => { "id" => @creative.id }, "comment" => { "id" => 1 } }
+    )
+
+    post stop_streaming_creative_comments_path(@creative), params: { task_id: task.id }
+
+    assert_response :ok
+    assert_equal "cancelled", task.reload.status
+  end
+
+  test "stop_streaming returns not_found for missing task" do
+    post stop_streaming_creative_comments_path(@creative), params: { task_id: 999999 }
+
+    assert_response :not_found
+  end
+
+  test "stop_streaming returns forbidden for task from different creative" do
+    other_creative = Creative.create!(user: @user, description: "Other")
+    agent = User.create!(
+      email: "stream_agent2@ai.local",
+      name: "Stream Agent 2",
+      password: "password",
+      llm_vendor: "google",
+      llm_model: "gemini-1.5-flash",
+      searchable: true
+    )
+    task = Collavre::Task.create!(
+      name: "test_task",
+      status: "running",
+      agent: agent,
+      trigger_event_name: "comment_created",
+      trigger_event_payload: { "creative" => { "id" => other_creative.id }, "comment" => { "id" => 1 } }
+    )
+
+    post stop_streaming_creative_comments_path(@creative), params: { task_id: task.id }
+
+    assert_response :forbidden
+  end
+
+  test "stop_streaming returns unprocessable_entity for non-running task" do
+    agent = User.create!(
+      email: "stream_agent3@ai.local",
+      name: "Stream Agent 3",
+      password: "password",
+      llm_vendor: "google",
+      llm_model: "gemini-1.5-flash",
+      searchable: true
+    )
+    task = Collavre::Task.create!(
+      name: "test_task",
+      status: "completed",
+      agent: agent,
+      trigger_event_name: "comment_created",
+      trigger_event_payload: { "creative" => { "id" => @creative.id }, "comment" => { "id" => 1 } }
+    )
+
+    post stop_streaming_creative_comments_path(@creative), params: { task_id: task.id }
+
+    assert_response :unprocessable_entity
+  end
 end

--- a/engines/collavre/test/services/ai_agent_service_test.rb
+++ b/engines/collavre/test/services/ai_agent_service_test.rb
@@ -130,6 +130,109 @@ class AiAgentServiceTest < ActiveSupport::TestCase
     assert_equal 1, reply.activity_logs.count
   end
 
+  test "saves partial response as comment when cancelled" do
+    task_id = @task.id
+    mock_client = Object.new
+    mock_client.define_singleton_method(:chat) do |messages, tools: [], &block|
+      block.call("Partial ")
+      block.call("content")
+      # Simulate cancellation by changing task status mid-stream
+      Task.find(task_id).update!(status: "cancelled")
+      # Advance time past CANCEL_CHECK_INTERVAL so check_cancelled! fires
+      sleep(0) # yield control
+      block.call(" more") # This chunk triggers check_cancelled! which raises
+    end
+
+    initial_comment_count = @creative.comments.count
+
+    # Stub CANCEL_CHECK_INTERVAL to 0 so cancellation is detected immediately
+    original_interval = AiAgentService::CANCEL_CHECK_INTERVAL
+    AiAgentService.send(:remove_const, :CANCEL_CHECK_INTERVAL)
+    AiAgentService.const_set(:CANCEL_CHECK_INTERVAL, 0)
+
+    assert_raises(Collavre::CancelledError) do
+      AiClient.stub :new, mock_client do
+        AiAgentService.new(@task).call
+      end
+    end
+
+    # Restore original interval
+    AiAgentService.send(:remove_const, :CANCEL_CHECK_INTERVAL)
+    AiAgentService.const_set(:CANCEL_CHECK_INTERVAL, original_interval)
+
+    # A partial comment should have been saved
+    assert_equal initial_comment_count + 1, @creative.comments.count
+
+    reply = @creative.comments.where(user: @agent).order(:created_at).last
+    # Content should contain at least the chunks before cancellation
+    assert reply.content.start_with?("Partial content")
+
+    # Verify cancel action was logged
+    assert @task.task_actions.exists?(action_type: "cancelled")
+    assert @task.task_actions.exists?(action_type: "reply_created")
+  end
+
+  test "does not create comment when cancelled with empty response" do
+    task_id = @task.id
+    mock_client = Object.new
+    mock_client.define_singleton_method(:chat) do |messages, tools: [], &block|
+      # Cancel immediately before any content
+      Task.find(task_id).update!(status: "cancelled")
+      block.call("") # Empty content, triggers check_cancelled!
+    end
+
+    initial_comment_count = @creative.comments.count
+
+    original_interval = AiAgentService::CANCEL_CHECK_INTERVAL
+    AiAgentService.send(:remove_const, :CANCEL_CHECK_INTERVAL)
+    AiAgentService.const_set(:CANCEL_CHECK_INTERVAL, 0)
+
+    assert_raises(Collavre::CancelledError) do
+      AiClient.stub :new, mock_client do
+        AiAgentService.new(@task).call
+      end
+    end
+
+    AiAgentService.send(:remove_const, :CANCEL_CHECK_INTERVAL)
+    AiAgentService.const_set(:CANCEL_CHECK_INTERVAL, original_interval)
+
+    # No comment created since response was empty
+    assert_equal initial_comment_count, @creative.comments.count
+  end
+
+  test "broadcasts topic_id in agent status" do
+    topic = Topic.create!(creative: @creative, name: "Test Topic", user: @user)
+    @comment.update!(topic_id: topic.id)
+
+    mock_client = Minitest::Mock.new
+
+    def mock_client.chat(messages, tools: [])
+      yield "Response"
+    end
+
+    broadcasts = []
+    creative_id = @creative.effective_origin.id
+
+    ActionCable.server.stub :broadcast, ->(channel, data) { broadcasts << { channel: channel, data: data } } do
+      AiClient.stub :new, mock_client do
+        AiAgentService.new(@task).call
+      end
+    end
+
+    presence_broadcasts = broadcasts.select { |b| b[:channel] == "comments_presence:#{creative_id}" }
+    agent_statuses = presence_broadcasts.select { |b| b[:data][:agent_status].present? }
+
+    # All broadcasts should include topic_id
+    agent_statuses.each do |b|
+      assert_equal topic.id, b[:data][:agent_status][:topic_id],
+        "Expected topic_id #{topic.id} in agent_status broadcast, got #{b[:data][:agent_status][:topic_id]}"
+    end
+
+    # Reply comment should also be in the correct topic
+    reply = @creative.comments.where(user: @agent).order(:created_at).last
+    assert_equal topic.id, reply.topic_id
+  end
+
   test "does not create comment when response is empty" do
     mock_client = Minitest::Mock.new
 


### PR DESCRIPTION
## Problem

The current AI agent streaming implementation has three issues:

1. **Markdown not rendered** — streaming element uses `textContent` (XSS-safe but raw text)
2. **Cross-topic visibility** — streaming broadcasts at creative-level, visible in all topics
3. **No stop control** — users cannot stop a running stream; previously deletion was used for cancellation

## Solution

### 1. Markdown Rendering
Import and use `renderCommentMarkdown` (marked.js) in the streaming element's content area. The streaming element now renders markdown identically to regular comments.

### 2. Topic Filtering
- `broadcast_agent_status` now includes `topic_id` (from the trigger comment)
- `broadcast_running_agents` resolves `topic_id` from the trigger comment on reconnect
- Client `presence_controller.js` checks `isCurrentTopic()` before showing the streaming element, comparing against `data-current-topic-id` on the comments list

### 3. Stop Button
- Streaming element header now includes a ⏹ stop button
- Clicking it POSTs to new `stop_streaming` endpoint with the `task_id`
- Controller validates: task exists, belongs to this creative, is running → sets status to `cancelled`
- `AiAgentService#check_cancelled!` detects the change → raises `CancelledError`
- `handle_cancelled` now calls `save_partial_response` — saves accumulated content as a comment before clearing

### Refactoring
- `response_content`, `original_comment`, `topic_id` promoted to instance variables for access in `handle_cancelled`
- Removed duplicate `check_cancelled!` and `handle_cancelled` methods from bottom of file

## Files Changed (11)

| File | Change |
|---|---|
| `comments_presence_channel.rb` | Accept/forward `topic_id`, resolve in `broadcast_running_agents` |
| `ai_agent_service.rb` | Instance vars, `save_partial_response`, `topic_id` in broadcasts |
| `comments_controller.rb` | New `stop_streaming` action |
| `presence_controller.js` | Markdown rendering, topic filter, stop button |
| `routes.rb` | `post :stop_streaming` |
| `comments_popup.css` | Streaming element styles |
| `_comments_popup.html.erb` | `data-stop-streaming-text` attribute |
| `comments.en.yml` / `comments.ko.yml` | `stop_streaming` i18n key |
| `comments_controller_test.rb` | 4 stop_streaming tests |
| `ai_agent_service_test.rb` | Cancel saves partial content, topic_id broadcast tests |

## Tests
- All 45 comments controller tests pass ✅
- All 7 AI agent service tests pass ✅
- i18n completeness test pass ✅
- Rubocop clean ✅