### PR TITLE
feat: add user button in chat participant list to open share modal

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -649,7 +649,7 @@ body.chat-fullscreen main {
     display: flex;
     align-items: center;
     flex-wrap: wrap;
-    gap: 0.1em;
+    gap: 0.2em;
 }
 
 .add-participant-btn {
@@ -666,7 +666,7 @@ body.chat-fullscreen main {
     font-size: 1.2em;
     line-height: 1;
     padding: 0;
-    margin-left: 0.2em;
+    flex-shrink: 0;
 }
 
 .add-participant-btn:hover {

--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -652,6 +652,12 @@ body.chat-fullscreen main {
     gap: 0.2em;
 }
 
+#comment-participants .avatar-wrapper {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
 .add-participant-btn {
     display: inline-flex;
     align-items: center;
@@ -689,7 +695,7 @@ body.chat-fullscreen main {
 }
 
 .comment-presence-avatar {
-    margin-right: 0.2em;
+    margin-right: 0;
 }
 
 .comment-presence-avatar.inactive {

--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -646,6 +646,32 @@ body.chat-fullscreen main {
 #comment-participants {
     margin-bottom: 0.3em;
     min-height: 20px;
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.1em;
+}
+
+.add-participant-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    border: 1px solid var(--color-border);
+    background: transparent;
+    cursor: pointer;
+    color: var(--color-muted);
+    font-size: 1.2em;
+    line-height: 1;
+    padding: 0;
+    margin-left: 0.2em;
+}
+
+.add-participant-btn:hover {
+    background: var(--color-section-bg);
+    color: var(--color-text);
 }
 
 #typing-indicator {

--- a/engines/collavre/app/controllers/collavre/comments_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comments_controller.rb
@@ -360,7 +360,7 @@ module Collavre
     def participants
       users = [ @creative.user ].compact + @creative.all_shared_users(:feedback).map(&:user)
       users = users.uniq
-      data = users.map do |u|
+      user_data = users.map do |u|
         {
           id: u.id,
           email: u.email,
@@ -370,7 +370,10 @@ module Collavre
           initial: u.display_name[0].upcase
         }
       end
-      render json: data
+      render json: {
+        users: user_data,
+        can_share: @creative.has_permission?(Current.user, :admin)
+      }
     end
 
     def commands

--- a/engines/collavre/app/javascript/controllers/comments/presence_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/presence_controller.js
@@ -91,7 +91,8 @@ export default class extends Controller {
     fetch(`/creatives/${this.creativeId}/comments/participants`)
       .then((response) => response.json())
       .then((data) => {
-        this.participantsData = data
+        this.participantsData = data.users
+        this.canShare = data.can_share
         this.renderParticipants(this.currentPresentIds)
         this.renderTypingIndicator()
       })
@@ -199,7 +200,26 @@ export default class extends Controller {
       this.participantsTarget.appendChild(wrapper)
     })
 
+    if (this.canShare) {
+      const addBtn = document.createElement('button')
+      addBtn.className = 'add-participant-btn'
+      addBtn.textContent = '+'
+      addBtn.title = this.element.dataset.addParticipantText || 'Add user'
+      addBtn.addEventListener('click', () => this.openShareModal())
+      this.participantsTarget.appendChild(addBtn)
+    }
+
     this.updateReadReceiptPresence(presentIds)
+  }
+
+  openShareModal() {
+    const modal = document.getElementById('share-creative-modal')
+    if (modal) {
+      modal.style.display = 'flex'
+      document.body.classList.add('no-scroll')
+    } else if (this.creativeId) {
+      window.location.href = `/creatives/${this.creativeId}?open_comments=true&open_share=true`
+    }
   }
 
   renderTypingIndicator() {

--- a/engines/collavre/app/javascript/modules/share_modal.js
+++ b/engines/collavre/app/javascript/modules/share_modal.js
@@ -69,5 +69,8 @@ document.addEventListener('turbo:load', function() {
         emailInput.dispatchEvent(new Event('blur'))
       }
     }
+    if (params.get('open_share') === 'true') {
+      shareBtn.click()
+    }
   }
 })

--- a/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
@@ -26,7 +26,8 @@
      data-move-no-selection-text="<%= t('collavre.comments.move_no_selection') %>"
      data-move-error-text="<%= t('collavre.comments.move_error') %>"
      data-hint-drag-topic-text="<%= t('collavre.comments.hint_drag_topic') %>"
-     data-hint-move-button-text="<%= t('collavre.comments.hint_move_button') %>">
+     data-hint-move-button-text="<%= t('collavre.comments.hint_move_button') %>"
+     data-add-participant-text="<%= t('collavre.comments.add_participant') %>">
   <% unless fullscreen %>
     <div class="resize-handle resize-handle-left" data-comments--popup-target="leftHandle"></div>
     <div class="resize-handle resize-handle-right" data-comments--popup-target="rightHandle"></div>

--- a/engines/collavre/app/views/collavre/creatives/_share_button.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_share_button.html.erb
@@ -2,7 +2,7 @@
   <span aria-hidden="true"><%= svg_tag 'share.svg', class: 'icon-up', width: 22, height: 20 %></span>
 </button>
 <!-- Share Creative Modal -->
-<div id="share-creative-modal" style="display:none;position:fixed;top:0;left:0;width:100vw;height:100vh;z-index:1000;align-items:center;justify-content:center;" data-creative-id="<%= (@parent_creative || @creative).id %>">
+<div id="share-creative-modal" style="display:none;position:fixed;top:0;left:0;width:100vw;height:100vh;z-index:1100;align-items:center;justify-content:center;" data-creative-id="<%= (@parent_creative || @creative).id %>">
   <div class="popup-box" style="min-width:320px;max-width:90vw;">
     <button id="close-share-modal" class="popup-close-btn">&times;</button>
     <h2><%= t('collavre.creatives.index.share_creative') %></h2>

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -67,6 +67,7 @@ en:
       move_button: Move
       move_no_selection: Select at least one message to move.
       move_error: Unable to move messages.
+      add_participant: Add user
       hint_drag_topic: "🎯 Drag → Move to topic"
       hint_move_button: "📤 Move button → Another chat"
       fullscreen: Full screen

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -64,6 +64,7 @@ ko:
       move_button: 이동
       move_no_selection: 이동할 메시지를 선택해주세요.
       move_error: 메시지를 이동할 수 없습니다.
+      add_participant: 사용자 추가
       hint_drag_topic: "🎯 드래그 → 토픽 이동"
       hint_move_button: "📤 이동 버튼 → 다른 채팅창"
       fullscreen: 전체 화면

--- a/engines/collavre/test/controllers/comments_controller_test.rb
+++ b/engines/collavre/test/controllers/comments_controller_test.rb
@@ -821,4 +821,28 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :forbidden
   end
+
+  test "participants returns users and can_share for admin" do
+    get participants_creative_comments_path(@creative), headers: { "Accept" => "application/json" }
+    assert_response :success
+    data = JSON.parse(response.body)
+    assert data.key?("users"), "Response should include users array"
+    assert data.key?("can_share"), "Response should include can_share flag"
+    assert_kind_of Array, data["users"]
+    assert data["users"].any? { |u| u["id"] == @user.id }
+  end
+
+  test "participants returns can_share false for non-admin shared user" do
+    other = users(:two)
+    other.update!(email_verified_at: Time.current)
+    Collavre::CreativeShare.create!(creative: @creative, user: other, permission: :feedback)
+
+    # Login as the shared user
+    post session_path, params: { email: other.email, password: "password" }
+
+    get participants_creative_comments_path(@creative), headers: { "Accept" => "application/json" }
+    assert_response :success
+    data = JSON.parse(response.body)
+    assert_equal false, data["can_share"]
+  end
 end


### PR DESCRIPTION
## Summary

Add a `+` button in the chat participant avatar list that opens the share modal directly, allowing users to invite participants without navigating away from the chat.

## Changes

### Participants API (`comments_controller.rb`)
- Response format changed from flat array to `{ users: [...], can_share: bool }`
- `can_share` is true when the current user has admin permission on the creative

### Chat UI (`presence_controller.js`)
- Renders a `+` button after participant avatars when `can_share` is true
- Click opens the existing share modal (`#share-creative-modal`) on the same page
- In fullscreen mode (where share modal isn't in DOM), redirects to creative page with `open_share=true` param

### Share Modal (`share_modal.js`)
- Added support for `open_share=true` URL parameter to auto-open the modal on page load

### Styling (`comments_popup.css`)
- `.add-participant-btn` styled identically to `.add-topic-btn` (circular, themed)
- `#comment-participants` now uses flexbox for proper alignment

### i18n
- Added `collavre.comments.add_participant` key (en: "Add user", ko: "사용자 추가")

## Files Changed (8)
| File | Change |
|---|---|
| `comments_controller.rb` | participants returns `{ users, can_share }` |
| `presence_controller.js` | Add button rendering + openShareModal() |
| `share_modal.js` | Handle `open_share` URL param |
| `_comments_popup.html.erb` | Add `data-add-participant-text` attribute |
| `comments_popup.css` | `.add-participant-btn` styles + flex layout |
| `comments.en.yml` | `add_participant: Add user` |
| `comments.ko.yml` | `add_participant: 사용자 추가` |
| `comments_controller_test.rb` | 2 new tests for participants endpoint |
