### PR TITLE
fix: add Collavre:: namespace to all ViewComponent references in engine views

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,6 +202,24 @@ CollavreOpenclaw::OpenclawAccount
 CollavreNotion::NotionAccount
 ```
 
+### Namespaced ViewComponents
+**All ViewComponent references in engine views must use the full namespace.**
+
+```erb
+<%# Bad: Missing namespace — breaks when used as a gem in other apps %>
+<%= render AvatarComponent.new(user: user, size: 20) %>
+<%= render PopupMenuComponent.new(button_content: '...', menu_id: 'my-menu') %>
+
+<%# Good: Full namespace %>
+<%= render Collavre::AvatarComponent.new(user: user, size: 20) %>
+<%= render Collavre::PopupMenuComponent.new(button_content: '...', menu_id: 'my-menu') %>
+<%= render Collavre::Inbox::BadgeComponent.new(user: Current.user, badge_id: 'badge') %>
+```
+
+> **Why?** When the engine is mounted as a gem in a host app, Rails resolves
+> unqualified constants from the host app's namespace first. Without `Collavre::`,
+> the host app will raise `uninitialized constant` errors.
+
 ### Permission Checks
 ```ruby
 before_action :ensure_read_permission

--- a/engines/collavre/app/views/collavre/comments/_comment.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comment.html.erb
@@ -8,7 +8,7 @@
            aria-label="<%= t('collavre.comments.select_label') %>" />
   </div>
   <div>
-    <%= render AvatarComponent.new(user: comment.user, size: 20, classes: 'avatar comment-avatar') %>
+    <%= render Collavre::AvatarComponent.new(user: comment.user, size: 20, classes: 'avatar comment-avatar') %>
     <% system_prefix = "#{t('collavre.comments.system_user')}:" %>
     <% display_name =
          if comment.user.present?

--- a/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
@@ -57,8 +57,8 @@
   <div id="comment-topics" data-comments--topics-target="list" class="comment-topics-list"
        data-confirm-delete-text="<%= t('collavre.topics.delete_confirm') %>"
        data-new-topic-placeholder="<%= t('collavre.topics.new_placeholder') %>"></div>
-  <%= render UserMentionMenuComponent.new(menu_id: 'mention-menu') %>
-  <%= render CommandMenuComponent.new(menu_id: 'command-menu') %>
+  <%= render Collavre::UserMentionMenuComponent.new(menu_id: 'mention-menu') %>
+  <%= render Collavre::CommandMenuComponent.new(menu_id: 'command-menu') %>
   <div id="comments-list" data-comments--popup-target="list" data-comments--list-target="list"><%= t('app.loading') %></div>
   <div id="typing-indicator" data-comments--presence-target="typingIndicator"></div>
   <form id="new-comment-form" data-comments--popup-target="form" data-comments--form-target="form" style="display:none;">

--- a/engines/collavre/app/views/collavre/comments/_presence_avatars.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_presence_avatars.html.erb
@@ -3,6 +3,6 @@
   <% accessible_users.uniq.each do |u| %>
     <% classes = 'avatar comment-presence-avatar' %>
     <% classes += ' inactive' unless present_ids.include?(u.id) %>
-    <%= render AvatarComponent.new(user: u, size: 20, classes: classes, data: { email: u.email }) %>
+    <%= render Collavre::AvatarComponent.new(user: u, size: 20, classes: classes, data: { email: u.email }) %>
   <% end %>
 </div>

--- a/engines/collavre/app/views/collavre/comments/_read_receipts.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_read_receipts.html.erb
@@ -6,7 +6,7 @@
         <% classes = ['avatar', 'comment-presence-avatar'] %>
         <% classes << 'inactive' if present_ids && !present_ids.include?(user.id) %>
         <div class="read-receipt-avatar" title="<%= t('collavre.comments.read_by', name: user.display_name) %>">
-          <%= render AvatarComponent.new(
+          <%= render Collavre::AvatarComponent.new(
                 user: user,
                 size: 16,
                 classes: classes.join(' '),

--- a/engines/collavre/app/views/collavre/creatives/_delete_button.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_delete_button.html.erb
@@ -1,4 +1,4 @@
-<%= render PopupMenuComponent.new(
+<%= render Collavre::PopupMenuComponent.new(
       button_content: t('collavre.creatives.index.delete'),
       button_classes: ["danger-link", local_assigns[:extra_button_classes]].compact.join(" "),
       menu_id: 'delete-options-popup-' + [local_assigns[:extra_button_classes]].compact.join('-')) do %>

--- a/engines/collavre/app/views/collavre/creatives/_inline_edit_form.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_inline_edit_form.html.erb
@@ -49,7 +49,7 @@
         <% inline_delete_button_content = capture do %>
           &nbsp;<%= svg_tag 'trash-bold-outline.svg', class: 'icon-svg', width: 24, height: 24 %>
         <% end %>
-        <%= render PopupMenuComponent.new(
+        <%= render Collavre::PopupMenuComponent.new(
               button_content: inline_delete_button_content,
               button_classes: 'creative-action-btn danger-link',
               button_attributes: { id: 'inline-delete-popup-toggle' },

--- a/engines/collavre/app/views/collavre/creatives/_mobile_actions_menu.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_mobile_actions_menu.html.erb
@@ -1,5 +1,5 @@
 <div class="mobile-only">
-  <%= render PopupMenuComponent.new(
+  <%= render Collavre::PopupMenuComponent.new(
         button_content: '...',
         menu_id: 'mobile-actions-menu',
         align: :right

--- a/engines/collavre/app/views/collavre/creatives/_share_button.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_share_button.html.erb
@@ -18,7 +18,7 @@
           data-share-user-search-target="input"
           data-action="blur->share-invite#check input->share-user-search#input focus->share-user-search#focus keydown->share-user-search#handleKey"
           autocomplete="off" />
-        <%= render UserMentionMenuComponent.new(menu_id: 'share-user-suggestions') %>
+        <%= render Collavre::UserMentionMenuComponent.new(menu_id: 'share-user-suggestions') %>
       </div>
       <div style="margin-bottom:1em;">
         <select name="permission" id="share-permission" style="width:100%;">
@@ -39,7 +39,7 @@
           <% @shared_list.each do |share| %>
             <li>
               <span>
-                <%= render AvatarComponent.new(user: share.user, size: 20, classes: 'avatar share-avatar') %>
+                <%= render Collavre::AvatarComponent.new(user: share.user, size: 20, classes: 'avatar share-avatar') %>
               </span>
               <span><%= share.user&.display_name || (share.user_id.nil? ? t('collavre.creatives.index.public_share') : t('collavre.creatives.index.unknown_user')) %></span>
               <span><%= t("collavre.creatives.index.permission_#{share.permission}") %></span>

--- a/engines/collavre/app/views/collavre/creatives/index.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/index.html.erb
@@ -27,7 +27,7 @@
   <% end %>
 
   <% if can_manage_integrations %>
-    <%= render PopupMenuComponent.new(
+    <%= render Collavre::PopupMenuComponent.new(
           button_content: t('collavre.creatives.index.integrations', default: '연동'),
           menu_id: 'creative-integrations-menu',
           align: :left,

--- a/engines/collavre/app/views/collavre/shared/_navigation.html.erb
+++ b/engines/collavre/app/views/collavre/shared/_navigation.html.erb
@@ -17,8 +17,8 @@
   </div>
 
   <%# Mobile Popup Menu %>
-  <%= render PopupMenuComponent.new(
-        button_content: safe_join(['...', (render(Inbox::BadgeComponent.new(user: Current.user, badge_id: 'mobile-inbox-badge')) if Current.user)]),
+  <%= render Collavre::PopupMenuComponent.new(
+        button_content: safe_join(['...', (render(Collavre::Inbox::BadgeComponent.new(user: Current.user, badge_id: 'mobile-inbox-badge')) if Current.user)]),
         button_classes: 'mobile-only',
         menu_id: 'mobile-more-menu',
         align: :right

--- a/engines/collavre/app/views/collavre/shared/navigation/_inbox_button.html.erb
+++ b/engines/collavre/app/views/collavre/shared/navigation/_inbox_button.html.erb
@@ -1,5 +1,5 @@
 <% if Current.user %>
   <form id="inbox_button_to">
-    <button id="inbox-menu-btn" class="inbox-menu-btn" type="button"><%= t('app.inbox') %><%= render Inbox::BadgeComponent.new(user: Current.user, badge_id: local_assigns[:badge_id] || 'desktop-inbox-badge') %></button>
+    <button id="inbox-menu-btn" class="inbox-menu-btn" type="button"><%= t('app.inbox') %><%= render Collavre::Inbox::BadgeComponent.new(user: Current.user, badge_id: local_assigns[:badge_id] || 'desktop-inbox-badge') %></button>
   </form>
 <% end %>

--- a/engines/collavre/app/views/collavre/shared/navigation/_mobile_inbox_button.html.erb
+++ b/engines/collavre/app/views/collavre/shared/navigation/_mobile_inbox_button.html.erb
@@ -1,3 +1,3 @@
 <% if Current.user %>
-  <button class="inbox-menu-btn" type="button"><%= t('app.inbox') %><%= render Inbox::BadgeComponent.new(user: Current.user, badge_id: 'mobile-inbox-badge') %></button>
+  <button class="inbox-menu-btn" type="button"><%= t('app.inbox') %><%= render Collavre::Inbox::BadgeComponent.new(user: Current.user, badge_id: 'mobile-inbox-badge') %></button>
 <% end %>

--- a/engines/collavre/app/views/collavre/shared/navigation/_panels.html.erb
+++ b/engines/collavre/app/views/collavre/shared/navigation/_panels.html.erb
@@ -1,5 +1,5 @@
 <div id="plans-list-area" style="display:none;">
-  <%= render PlansTimelineComponent.new(plans: Plan.none) %>
+  <%= render Collavre::PlansTimelineComponent.new(plans: Plan.none) %>
 </div>
 
 <div id="inbox-panel" class="slide-panel">

--- a/engines/collavre/app/views/collavre/users/_contact_management.html.erb
+++ b/engines/collavre/app/views/collavre/users/_contact_management.html.erb
@@ -26,7 +26,7 @@
             <% contact_user = contact.contact_user %>
             <tr>
               <td>
-                <%= render AvatarComponent.new(
+                <%= render Collavre::AvatarComponent.new(
                   user: contact_user,
                   size: 32,
                   classes: "avatar"

--- a/engines/collavre/app/views/collavre/users/edit_ai.html.erb
+++ b/engines/collavre/app/views/collavre/users/edit_ai.html.erb
@@ -40,7 +40,7 @@
                             llm_model_target: "input",
                             action: "input->llm-model#search focus->llm-model#focus blur->llm-model#blur keydown->llm-model#handleKeydown"
                           } %>
-      <%= render UserMentionMenuComponent.new(menu_id: 'llm-model-suggestions') %>
+      <%= render Collavre::UserMentionMenuComponent.new(menu_id: 'llm-model-suggestions') %>
     </div>
   </div>
 

--- a/engines/collavre/app/views/collavre/users/index.html.erb
+++ b/engines/collavre/app/views/collavre/users/index.html.erb
@@ -23,7 +23,7 @@
       <% last_login_at = user.sessions.max_by(&:updated_at)&.updated_at %>
       <tr>
         <td>
-          <%= render AvatarComponent.new(
+          <%= render Collavre::AvatarComponent.new(
                 user: user,
                 size: 20,
                 classes: "avatar comment-presence-avatar#{' inactive' if user.sessions.empty?}" ) %>

--- a/engines/collavre/app/views/collavre/users/new_ai.html.erb
+++ b/engines/collavre/app/views/collavre/users/new_ai.html.erb
@@ -45,7 +45,7 @@
                             llm_model_target: "input",
                             action: "input->llm-model#search focus->llm-model#focus blur->llm-model#blur keydown->llm-model#handleKeydown"
                           } %>
-      <%= render UserMentionMenuComponent.new(menu_id: 'llm-model-suggestions') %>
+      <%= render Collavre::UserMentionMenuComponent.new(menu_id: 'llm-model-suggestions') %>
     </div>
   </div>
 

--- a/engines/collavre/app/views/collavre/users/show.html.erb
+++ b/engines/collavre/app/views/collavre/users/show.html.erb
@@ -42,7 +42,7 @@
         <div class="avatar-preview-row">
           <div class="avatar-preview-pane avatar-preview-current">
             <span class="avatar-preview-label"><%= t('collavre.users.current_avatar') %></span>
-            <%= render AvatarComponent.new(user: @user, size: 80, classes: 'avatar') %>
+            <%= render Collavre::AvatarComponent.new(user: @user, size: 80, classes: 'avatar') %>
           </div>
 
           <div class="avatar-preview-pane avatar-preview-container" data-avatar-preview-target="previewContainer">


### PR DESCRIPTION
## Summary

When the Collavre engine is used as a gem in another Rails application, ViewComponents rendered without the full `Collavre::` namespace cause `uninitialized constant` errors. This PR adds the proper namespace to all 20 component references across 19 view files.

## Changes

| Component | Occurrences |
|-----------|-------------|
| `AvatarComponent` → `Collavre::AvatarComponent` | 6 |
| `PopupMenuComponent` → `Collavre::PopupMenuComponent` | 5 |
| `UserMentionMenuComponent` → `Collavre::UserMentionMenuComponent` | 4 |
| `CommandMenuComponent` → `Collavre::CommandMenuComponent` | 1 |
| `Inbox::BadgeComponent` → `Collavre::Inbox::BadgeComponent` | 3 |
| `PlansTimelineComponent` → `Collavre::PlansTimelineComponent` | 1 |

## Documentation

Added `Namespaced ViewComponents` rule to `AGENTS.md` to prevent regressions.

## Root Cause

Rails engines with `isolate_namespace` define components under their namespace (e.g. `Collavre::AvatarComponent`), but when views reference them without the namespace, Rails looks for them in the host app's root namespace — which fails when the host app doesn't define those components.