### PR TITLE
chore: bump collavre gem version to 0.2.1

### DIFF
--- a/engines/collavre/lib/collavre/version.rb
+++ b/engines/collavre/lib/collavre/version.rb
@@ -1,3 +1,3 @@
 module Collavre
-  VERSION = "0.1.1"
+  VERSION = "0.2.1"
 end


### PR DESCRIPTION
Bump collavre gem version from 0.1.1 to 0.2.1 for new release.

## Changes
- Namespaced all ViewComponent references (PR #724)
- Version bump for gem publish