### PR TITLE
fix: move openclaw_accounts migrations into collavre_openclaw engine

### DIFF
--- a/engines/collavre_openclaw/db/migrate/20260202120143_remove_description_from_openclaw_accounts.rb
+++ b/engines/collavre_openclaw/db/migrate/20260202120143_remove_description_from_openclaw_accounts.rb
@@ -1,0 +1,5 @@
+class RemoveDescriptionFromOpenclawAccounts < ActiveRecord::Migration[8.1]
+  def change
+    remove_column :openclaw_accounts, :description, :text
+  end
+end

--- a/engines/collavre_openclaw/db/migrate/20260202120254_remove_agent_provisioned_at_from_openclaw_accounts.rb
+++ b/engines/collavre_openclaw/db/migrate/20260202120254_remove_agent_provisioned_at_from_openclaw_accounts.rb
@@ -1,0 +1,5 @@
+class RemoveAgentProvisionedAtFromOpenclawAccounts < ActiveRecord::Migration[8.1]
+  def change
+    remove_column :openclaw_accounts, :agent_provisioned_at, :datetime
+  end
+end

--- a/engines/collavre_openclaw/db/migrate/20260202130000_remove_agent_id_from_openclaw_accounts.rb
+++ b/engines/collavre_openclaw/db/migrate/20260202130000_remove_agent_id_from_openclaw_accounts.rb
@@ -1,0 +1,5 @@
+class RemoveAgentIdFromOpenclawAccounts < ActiveRecord::Migration[7.2]
+  def change
+    remove_column :openclaw_accounts, :agent_id, :string
+  end
+end

--- a/engines/collavre_openclaw/db/migrate/20260202140000_rename_api_token_to_api_key_in_openclaw_accounts.rb
+++ b/engines/collavre_openclaw/db/migrate/20260202140000_rename_api_token_to_api_key_in_openclaw_accounts.rb
@@ -1,0 +1,5 @@
+class RenameApiTokenToApiKeyInOpenclawAccounts < ActiveRecord::Migration[7.2]
+  def change
+    rename_column :openclaw_accounts, :api_token, :api_key
+  end
+end

--- a/engines/collavre_openclaw/db/migrate/20260202150001_migrate_pending_callbacks_to_user.rb
+++ b/engines/collavre_openclaw/db/migrate/20260202150001_migrate_pending_callbacks_to_user.rb
@@ -1,0 +1,52 @@
+class MigratePendingCallbacksToUser < ActiveRecord::Migration[7.2]
+  def up
+    # Add user_id column
+    add_column :openclaw_pending_callbacks, :user_id, :integer
+
+    # Migrate existing data
+    execute <<-SQL
+      UPDATE openclaw_pending_callbacks
+      SET user_id = (
+        SELECT user_id FROM openclaw_accounts
+        WHERE openclaw_accounts.id = openclaw_pending_callbacks.openclaw_account_id
+      )
+    SQL
+
+    # Remove old foreign key and column
+    remove_foreign_key :openclaw_pending_callbacks, :openclaw_accounts
+    remove_index :openclaw_pending_callbacks, :openclaw_account_id
+    remove_column :openclaw_pending_callbacks, :openclaw_account_id
+
+    # Add new foreign key
+    add_foreign_key :openclaw_pending_callbacks, :users
+    add_index :openclaw_pending_callbacks, :user_id
+
+    # Make user_id not null (after data migration)
+    change_column_null :openclaw_pending_callbacks, :user_id, false
+  end
+
+  def down
+    # Add back openclaw_account_id
+    add_column :openclaw_pending_callbacks, :openclaw_account_id, :integer
+
+    # Migrate data back (if openclaw_accounts still exists)
+    execute <<-SQL
+      UPDATE openclaw_pending_callbacks
+      SET openclaw_account_id = (
+        SELECT id FROM openclaw_accounts
+        WHERE openclaw_accounts.user_id = openclaw_pending_callbacks.user_id
+        LIMIT 1
+      )
+    SQL
+
+    # Remove user foreign key
+    remove_foreign_key :openclaw_pending_callbacks, :users
+    remove_index :openclaw_pending_callbacks, :user_id
+    remove_column :openclaw_pending_callbacks, :user_id
+
+    # Add back original foreign key
+    add_foreign_key :openclaw_pending_callbacks, :openclaw_accounts
+    add_index :openclaw_pending_callbacks, :openclaw_account_id
+    change_column_null :openclaw_pending_callbacks, :openclaw_account_id, false
+  end
+end

--- a/engines/collavre_openclaw/db/migrate/20260202150002_drop_openclaw_accounts.rb
+++ b/engines/collavre_openclaw/db/migrate/20260202150002_drop_openclaw_accounts.rb
@@ -1,0 +1,18 @@
+class DropOpenclawAccounts < ActiveRecord::Migration[7.2]
+  def up
+    drop_table :openclaw_accounts
+  end
+
+  def down
+    create_table :openclaw_accounts do |t|
+      t.integer :user_id, null: false
+      t.string :gateway_url, null: false
+      t.string :api_key
+      t.string :channel_id
+
+      t.timestamps
+    end
+
+    add_index :openclaw_accounts, :user_id, unique: true
+  end
+end


### PR DESCRIPTION
## Problem

When using `collavre_openclaw` gem in a different host app, AI chat fails with:

```
OpenClaw Error: can't write unknown attribute user_id
```

The `PendingCallback` model uses `belongs_to :user` (expecting `user_id` column), but the engine's migration creates the table with `openclaw_account_id` instead. Six migrations that handle the transition were only in the plan42 host app's `db/migrate/` directory.

## Fix

Moved 6 migrations into `engines/collavre_openclaw/db/migrate/`:

1. `remove_description_from_openclaw_accounts`
2. `remove_agent_provisioned_at_from_openclaw_accounts`
3. `remove_agent_id_from_openclaw_accounts`
4. `rename_api_token_to_api_key_in_openclaw_accounts`
5. `migrate_pending_callbacks_to_user` — converts `openclaw_account_id` → `user_id`
6. `drop_openclaw_accounts` — removes the now-unused table

## For other host apps

After updating the gem:
```bash
rails collavre_openclaw:install:migrations
rails db:migrate
```