### PR TITLE
fix: move missing migrations into collavre engine

### DIFF
--- a/engines/collavre/db/migrate/20260203002637_add_requires_approval_to_mcp_tools.rb
+++ b/engines/collavre/db/migrate/20260203002637_add_requires_approval_to_mcp_tools.rb
@@ -1,0 +1,5 @@
+class AddRequiresApprovalToMcpTools < ActiveRecord::Migration[8.1]
+  def change
+    add_column :mcp_tools, :requires_approval, :boolean, default: false, null: false
+  end
+end

--- a/engines/collavre/db/migrate/20260203002643_add_pending_tool_call_to_tasks.rb
+++ b/engines/collavre/db/migrate/20260203002643_add_pending_tool_call_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddPendingToolCallToTasks < ActiveRecord::Migration[8.1]
+  def change
+    add_column :tasks, :pending_tool_call, :json
+  end
+end

--- a/engines/collavre/db/migrate/20260203083302_add_position_to_topics.rb
+++ b/engines/collavre/db/migrate/20260203083302_add_position_to_topics.rb
@@ -1,0 +1,23 @@
+class AddPositionToTopics < ActiveRecord::Migration[8.1]
+  def change
+    add_column :topics, :position, :integer, default: 0, null: false
+
+    # Set position based on created_at order for existing topics
+    reversible do |dir|
+      dir.up do
+        # Group topics by creative_id and set position based on created_at order
+        execute <<-SQL
+          UPDATE topics
+          SET position = (
+            SELECT COUNT(*)
+            FROM topics t2
+            WHERE t2.creative_id = topics.creative_id
+            AND t2.created_at < topics.created_at
+          )
+        SQL
+      end
+    end
+
+    add_index :topics, [ :creative_id, :position ]
+  end
+end


### PR DESCRIPTION
## Problem

When using the collavre gem in a different host app, several columns are missing because their migrations were only in the plan42 host app.

Immediate error:
```
SQLite3::SQLException: no such column: "position"
```

## Fix

Moved 3 migrations into `engines/collavre/db/migrate/`:

| Migration | Table | Column | Used by |
|---|---|---|---|
| `add_position_to_topics` | topics | position | Topic model (`default_scope { order(:position) }`) |
| `add_requires_approval_to_mcp_tools` | mcp_tools | requires_approval | McpTool#requires_approval? |
| `add_pending_tool_call_to_tasks` | tasks | pending_tool_call | AiClient, ActionExecutor |

## For other host apps

```bash
rails collavre:install:migrations
rails db:migrate
```