### PR TITLE
fix: sanitize markdown output with DOMPurify to prevent DOM corruption

### DIFF
--- a/engines/collavre/app/javascript/lib/utils/markdown.js
+++ b/engines/collavre/app/javascript/lib/utils/markdown.js
@@ -1,17 +1,18 @@
 import { marked } from 'marked'
+import DOMPurify from 'dompurify'
 
 export function renderMarkdown(html) {
-  return marked.parse(html)
+  return DOMPurify.sanitize(marked.parse(html))
 }
 
 export function renderMarkdownInline(html) {
-  return marked.parseInline(html)
+  return DOMPurify.sanitize(marked.parseInline(html))
 }
 
 export function renderCommentMarkdown(text) {
   const content = text || ''
   const html = content.includes('\n') ? marked.parse(content) : marked.parseInline(content)
-  return html.trim()
+  return DOMPurify.sanitize(html.trim())
 }
 
 export function renderMarkdownInContainer(container) {


### PR DESCRIPTION
## Problem

Chat send button stops working when comments contain special characters (HTML-like text).

### Root Cause

Comment rendering pipeline:
1. Server renders: `<div class="comment-content">&lt;/div&gt;</div>` (escaped)
2. JS reads: `element.textContent` → `</div>` (decoded)
3. `marked.parseInline('</div>')` → `</div>` (HTML passed through as-is)
4. `element.innerHTML = '</div>'` → **Closes parent div, breaks DOM structure**

When the DOM breaks, Stimulus controllers lose their bindings, the form element gets corrupted, and the send button stops responding.

Also a **XSS vulnerability**: `<script>alert(1)</script>` in a comment would execute via the same pipeline.

### Verified

```
marked.parseInline('</div><img src=x onerror=alert(1)>') 
// → '</div><img src=x onerror=alert(1)>'  ← passed through as-is!
```

## Fix

Pipe all `marked` output through `DOMPurify.sanitize()` before setting `innerHTML`. DOMPurify strips dangerous HTML tags and fixes broken markup.

DOMPurify is already a project dependency (used in `creative_tree_row.js`).