### PR TITLE
feat: WebSocket client for OpenClaw Gateway (Phase 1 & 2)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,9 @@ PATH
   remote: engines/collavre_openclaw
   specs:
     collavre_openclaw (0.2.1)
+      eventmachine (~> 1.2)
       faraday (>= 2.0)
+      faye-websocket (~> 0.11)
       rails (>= 8.0)
 
 PATH
@@ -195,6 +197,7 @@ GEM
     et-orbi (1.4.0)
       tzinfo
     event_stream_parser (1.0.0)
+    eventmachine (1.2.7)
     faraday (2.14.0)
       faraday-net_http (>= 2.0, < 3.5)
       json
@@ -214,6 +217,9 @@ GEM
       json (~> 2.0)
       mime-types (~> 3.4)
       rack (>= 2.0, < 4.0)
+    faye-websocket (0.12.0)
+      eventmachine (>= 0.12.0)
+      websocket-driver (>= 0.8.0)
     fcm (2.0.1)
       faraday (>= 1.0.0, < 3.0)
       googleauth (~> 1)

--- a/engines/collavre_openclaw/PLAN_WEBSOCKET_MIGRATION.md
+++ b/engines/collavre_openclaw/PLAN_WEBSOCKET_MIGRATION.md
@@ -1,0 +1,442 @@
+# Plan: Chat Completion API → WebSocket Migration
+
+## 결정 사항
+
+- **WebSocket gem**: `faye-websocket` (안정적, 검증됨)
+- **기존 callback 코드**: 유지 (삭제하지 않음, 나중에 정리)
+- **연결 전략**: On-Demand + Keep-Alive
+
+## 현재 구조 (AS-IS)
+
+```
+[채팅 요청]
+AiAgentService → AiClient → AiClientExtension
+  ↓ (vendor == "openclaw")
+OpenclawAdapter
+  ↓
+POST /v1/chat/completions (HTTP SSE streaming)
+  ↓
+OpenClaw Gateway 응답 (SSE stream → 파싱 → yield)
+
+[프로액티브 메시지]
+OpenClaw 크론 실행 → callback_url POST → CallbacksController
+  → PendingCallback nonce 검증 → CallbackProcessorJob → Comment 생성
+  (현재 미작동: callback 호출 메커니즘 부재)
+```
+
+## 목표 구조 (TO-BE)
+
+```
+[채팅 요청]
+AiAgentService → AiClient → AiClientExtension
+  ↓ (vendor == "openclaw")
+OpenclawAdapter
+  ↓
+WebsocketClient (faye-websocket)
+  ↓
+chat.send → chat event (delta/final) → yield
+
+[프로액티브 메시지]
+OpenClaw 크론/하트비트 실행
+  → Gateway가 chat event broadcast
+  → WebsocketClient가 수신
+  → CallbackProcessorJob → Comment 생성
+
+[기존 callback 코드]
+CallbacksController, PendingCallback → 유지 (삭제하지 않음)
+```
+
+---
+
+## Phase 1: WebSocket 인프라
+
+### 1.1 faye-websocket gem 추가
+
+`collavre_openclaw.gemspec`:
+```ruby
+spec.add_dependency "faye-websocket", "~> 0.11"
+spec.add_dependency "eventmachine", "~> 1.2"
+```
+
+### 1.2 WebsocketClient
+
+**파일**: `app/services/collavre_openclaw/websocket_client.rb`
+
+OpenClaw Gateway에 대한 단일 유저 WebSocket 연결을 관리하는 클래스.
+
+**책임:**
+- WebSocket 연결 생성 (ws:// 또는 wss://)
+- OpenClaw protocol handshake (`connect` request + auth token)
+- RPC 요청/응답 매핑 (`type: "req"` → `type: "res"`, id 기반)
+- Event 수신 (`type: "event"`, event: "chat")
+- Tick 응답 (keepalive)
+- 자동 재연결 (exponential backoff)
+
+**프로토콜 흐름:**
+```
+1. WS 연결 수립
+2. Gateway → connect.challenge (nonce)
+3. Client → connect request (auth token, role: "operator")
+4. Gateway → hello-ok (protocol version, tick interval)
+5. 이후 양방향 통신:
+   - Client → req (chat.send, chat.history, chat.abort)
+   - Gateway → res (응답)
+   - Gateway → event (chat delta/final, tick)
+```
+
+**인터페이스:**
+```ruby
+class WebsocketClient
+  def initialize(user:)
+  def connected?
+  def connect!
+  def disconnect!
+
+  # RPC 메서드
+  def chat_send(session_key:, message:, idempotency_key:, &on_event)
+  def chat_history(session_key:, limit: nil)
+  def chat_abort(session_key:, run_id: nil)
+
+  # 프로액티브 메시지 콜백 등록
+  def on_proactive_message(&handler)
+
+  private
+  def handle_message(data)
+  def handle_event(event_name, payload)
+  def handle_response(id, payload)
+  def send_request(method, params)
+  def reconnect!
+end
+```
+
+### 1.3 ConnectionManager
+
+**파일**: `app/services/collavre_openclaw/connection_manager.rb`
+
+유저별 WebSocket 연결 풀 관리. Singleton.
+
+**책임:**
+- 유저별 WebsocketClient 생성/캐싱
+- Lazy connect (첫 요청 시 연결)
+- Idle timeout (30분 미사용 시 해제)
+- 앱 종료 시 전체 연결 해제
+- Thread-safe access (Mutex)
+
+**인터페이스:**
+```ruby
+class ConnectionManager
+  include Singleton
+
+  def connection_for(user)  # → WebsocketClient (lazy connect)
+  def disconnect(user)
+  def disconnect_all
+  def connected_count
+  def status  # → { connected: 3, idle: 1, reconnecting: 0 }
+end
+```
+
+### 1.4 스레딩 모델
+
+faye-websocket은 EventMachine 기반이므로:
+- 별도 EM 스레드에서 WebSocket 연결 관리
+- Rails 요청 스레드에서는 `chat_send` 호출 시 블로킹 대기 (Queue 또는 ConditionVariable)
+- EM reactor가 실행 중이 아니면 자동 시작
+
+```ruby
+# EventMachine reactor 관리
+module CollavreOpenclaw
+  class EmReactor
+    def self.ensure_running!
+      return if EM.reactor_running?
+      @thread = Thread.new { EM.run }
+      sleep 0.1 until EM.reactor_running?
+    end
+  end
+end
+```
+
+### 1.5 Configuration 확장
+
+```ruby
+# configuration.rb
+attr_accessor :websocket_idle_timeout      # 기본: 30분 (1800초)
+attr_accessor :websocket_reconnect_max     # 최대 재연결 시도: 10
+attr_accessor :websocket_reconnect_base    # 재연결 대기 기본값: 1초
+attr_accessor :websocket_connect_timeout   # 연결 타임아웃: 10초
+```
+
+---
+
+## Phase 2: Chat 전송 전환
+
+### 2.1 OpenclawAdapter 수정
+
+`chat()` 메서드를 WebSocket 기반으로 변경:
+
+```ruby
+def chat(messages, tools: [], &block)
+  connection = ConnectionManager.instance.connection_for(@user)
+
+  session_key = build_session_key
+  run_id = SecureRandom.uuid
+  message_text = format_message_for_ws(messages)
+
+  connection.chat_send(
+    session_key: session_key,
+    message: message_text,
+    idempotency_key: run_id
+  ) do |event|
+    case event[:state]
+    when "delta"
+      text = extract_delta_text(event)
+      yield text if text.present? && block_given?
+    when "final"
+      # final은 전체 텍스트 포함 — delta로 이미 yield했으면 스킵
+    when "error"
+      yield "Error: #{event[:errorMessage]}" if block_given?
+    when "aborted"
+      # 사용자가 abort한 경우
+    end
+  end
+end
+```
+
+### 2.2 메시지 포맷 변환
+
+**HTTP (현재):**
+- `messages` 배열 (전체 대화 이력)
+- `model` 필드로 agent 지정
+- `user` 필드에 callback 정보
+
+**WebSocket (변경):**
+- `message` 단일 문자열 (최신 메시지만)
+- `sessionKey`로 세션 라우팅
+- Gateway가 세션 이력 관리
+
+```ruby
+def format_message_for_ws(messages)
+  # 마지막 user 메시지만 추출
+  last_user = Array(messages).reverse.find { |m|
+    role = m[:role] || m["role"]
+    %w[user].include?(role.to_s)
+  }
+
+  if last_user
+    parts = last_user[:parts] || last_user["parts"]
+    if parts
+      Array(parts).map { |p| p[:text] || p["text"] }.compact.join("\n")
+    else
+      last_user[:text] || last_user["text"] || last_user[:content] || last_user["content"]
+    end
+  else
+    ""
+  end.to_s
+end
+```
+
+### 2.3 Session Key 전략
+
+변경 없음. 기존 `build_session_key` 로직 그대로 사용:
+```
+agent:<agent_id>:collavre:<user_id>:creative:<creative_id>:topic:<topic_id>
+```
+
+HTTP 헤더 (`x-openclaw-session-key`) → `chat.send` params (`sessionKey`)로 이동만.
+
+### 2.4 HTTP fallback
+
+WebSocket 연결 실패 시 기존 HTTP 방식으로 폴백:
+
+```ruby
+def chat(messages, tools: [], &block)
+  if websocket_available?
+    chat_via_websocket(messages, tools: tools, &block)
+  else
+    chat_via_http(messages, tools: tools, &block)  # 기존 코드
+  end
+end
+```
+
+---
+
+## Phase 3: 프로액티브 메시지 수신
+
+### 3.1 Event Handler 등록
+
+WebSocket 연결 시 프로액티브 메시지 핸들러 등록:
+
+```ruby
+# ConnectionManager에서 연결 생성 시
+client = WebsocketClient.new(user: user)
+client.on_proactive_message do |event|
+  handle_proactive_message(user, event)
+end
+```
+
+### 3.2 프로액티브 vs 요청 응답 구분
+
+```ruby
+# WebsocketClient 내부
+def handle_chat_event(payload)
+  run_id = payload[:runId]
+  session_key = payload[:sessionKey]
+
+  if @pending_runs.key?(run_id)
+    # 요청에 대한 응답 → 해당 요청의 콜백으로 전달
+    @pending_runs[run_id].call(payload)
+  else
+    # 프로액티브 메시지 → 핸들러로 전달
+    @proactive_handler&.call(payload)
+  end
+end
+```
+
+### 3.3 CallbackProcessorJob 연동
+
+기존 CallbackProcessorJob을 재사용:
+
+```ruby
+def handle_proactive_message(user, event)
+  content = extract_message_text(event[:message])
+  session_key = event[:sessionKey]
+  context = parse_session_key(session_key)
+
+  CallbackProcessorJob.perform_later(
+    user.id,
+    {
+      "type" => "proactive",
+      "content" => content,
+      "context" => {
+        "creative_id" => context[:creative_id],
+        "thread_id" => context[:topic_id]
+      }
+    }
+  )
+end
+```
+
+### 3.4 Session Key 파싱
+
+```ruby
+def parse_session_key(session_key)
+  parts = session_key.to_s.split(":")
+  result = {}
+
+  parts.each_with_index do |part, i|
+    case part
+    when "creative" then result[:creative_id] = parts[i + 1]
+    when "topic" then result[:topic_id] = parts[i + 1]
+    when "collavre" then result[:user_id] = parts[i + 1]
+    end
+  end
+
+  result
+end
+```
+
+---
+
+## Phase 4: 기존 callback 코드 유지
+
+> **결정: 현재 구현 그대로 유지. 삭제하지 않음.**
+
+유지되는 코드:
+- `CallbacksController` — HTTP callback 엔드포인트
+- `PendingCallback` 모델 — nonce 관리
+- `callback_url` / `callback_nonce` 로직 — OpenclawAdapter 내
+- `config/routes.rb` — callback route
+- DB 테이블 `openclaw_pending_callbacks`
+
+이유:
+- WebSocket이 안정화될 때까지 HTTP callback도 병행 가능
+- 나중에 WebSocket이 충분히 검증되면 별도 PR로 정리
+
+---
+
+## Phase 5: 테스트
+
+### 5.1 Unit Tests
+
+```ruby
+# test/services/websocket_client_test.rb
+- connect/disconnect
+- chat.send → chat event 수신 → 텍스트 추출
+- 프로액티브 메시지 감지 (미등록 runId)
+- 재연결 로직 (exponential backoff)
+- tick 응답
+
+# test/services/connection_manager_test.rb
+- 유저별 연결 생성/재사용
+- idle timeout → disconnect
+- thread-safe access
+- disconnect_all
+
+# test/services/openclaw_adapter_test.rb
+- WebSocket 경로 테스트
+- HTTP fallback 테스트
+- 메시지 포맷 변환
+```
+
+### 5.2 Mock WebSocket Server
+
+```ruby
+# test/support/mock_openclaw_gateway.rb
+class MockOpenclawGateway
+  # EventMachine 기반 mock WS 서버
+  # - connect handshake 응답
+  # - chat.send → chat event 응답
+  # - 프로액티브 메시지 시뮬레이션
+end
+```
+
+---
+
+## 구현 순서
+
+```
+Phase 1: WebSocket 인프라                    [PR #1]
+  ├─ 1.1 faye-websocket gem 추가
+  ├─ 1.2 WebsocketClient 구현
+  ├─ 1.3 ConnectionManager 구현
+  ├─ 1.4 EM reactor 관리
+  └─ 1.5 Configuration 확장 + 테스트
+
+Phase 2: Chat 전환                           [PR #2]
+  ├─ 2.1 OpenclawAdapter.chat() → WS 전환
+  ├─ 2.2 메시지 포맷 변환
+  ├─ 2.3 HTTP fallback 유지
+  └─ 2.4 테스트
+
+Phase 3: 프로액티브 메시지                    [PR #3]
+  ├─ 3.1 Event handler 등록
+  ├─ 3.2 요청/프로액티브 구분
+  ├─ 3.3 CallbackProcessorJob 연동
+  └─ 3.4 테스트
+```
+
+---
+
+## 리스크 & 완화
+
+| 리스크 | 영향 | 완화 |
+|--------|------|------|
+| WS 연결 끊김 | 프로액티브 메시지 유실 | auto-reconnect + chat.history 복구 |
+| EventMachine 호환성 | Puma와 충돌 가능 | 별도 스레드에서 EM 실행 |
+| 서버 재시작 | 모든 WS 연결 끊김 | 재시작 후 자동 재연결 |
+| Gateway 다운 | 채팅 불가 | HTTP fallback (Phase 2.4) |
+| 동시성 버그 | 메시지 유실/중복 | idempotencyKey + Mutex |
+| 메모리 증가 | 유저 수 × 연결 | idle timeout (30분) |
+
+## 미해결 사항
+
+### chat.send의 message가 단일 문자열인 문제
+
+- 현재 HTTP: 전체 대화 이력 (`messages` 배열) + 시스템 프롬프트 전송
+- WS `chat.send`: `message` 단일 문자열만
+
+**해결 방안:**
+1. Gateway가 세션 이력을 관리하므로 최신 메시지만 전송 → 이력은 Gateway가 유지
+2. 시스템 프롬프트 → OpenClaw agent config (SOUL.md 등)에서 관리
+3. Creative 컨텍스트 → 메시지 앞에 prefix로 포함
+
+**→ Phase 2 구현 시 상세 결정 필요**

--- a/engines/collavre_openclaw/PLAN_WEBSOCKET_MIGRATION.md
+++ b/engines/collavre_openclaw/PLAN_WEBSOCKET_MIGRATION.md
@@ -1,33 +1,33 @@
 # Plan: Chat Completion API → WebSocket Migration
 
-## 결정 사항
+## Decisions
 
-- **WebSocket gem**: `faye-websocket` (안정적, 검증됨)
-- **기존 callback 코드**: 유지 (삭제하지 않음, 나중에 정리)
-- **연결 전략**: On-Demand + Keep-Alive
+- **WebSocket gem**: `faye-websocket` (stable, proven)
+- **Existing callback code**: Keep (do not delete, clean up later)
+- **Connection strategy**: On-Demand + Keep-Alive
 
-## 현재 구조 (AS-IS)
+## Current Architecture (AS-IS)
 
 ```
-[채팅 요청]
+[Chat Request]
 AiAgentService → AiClient → AiClientExtension
   ↓ (vendor == "openclaw")
 OpenclawAdapter
   ↓
 POST /v1/chat/completions (HTTP SSE streaming)
   ↓
-OpenClaw Gateway 응답 (SSE stream → 파싱 → yield)
+OpenClaw Gateway response (SSE stream → parse → yield)
 
-[프로액티브 메시지]
-OpenClaw 크론 실행 → callback_url POST → CallbacksController
-  → PendingCallback nonce 검증 → CallbackProcessorJob → Comment 생성
-  (현재 미작동: callback 호출 메커니즘 부재)
+[Proactive Messages]
+OpenClaw cron runs → callback_url POST → CallbacksController
+  → PendingCallback nonce verification → CallbackProcessorJob → Comment creation
+  (Currently non-functional: no callback invocation mechanism)
 ```
 
-## 목표 구조 (TO-BE)
+## Target Architecture (TO-BE)
 
 ```
-[채팅 요청]
+[Chat Request]
 AiAgentService → AiClient → AiClientExtension
   ↓ (vendor == "openclaw")
 OpenclawAdapter
@@ -36,21 +36,21 @@ WebsocketClient (faye-websocket)
   ↓
 chat.send → chat event (delta/final) → yield
 
-[프로액티브 메시지]
-OpenClaw 크론/하트비트 실행
-  → Gateway가 chat event broadcast
-  → WebsocketClient가 수신
-  → CallbackProcessorJob → Comment 생성
+[Proactive Messages]
+OpenClaw cron/heartbeat runs
+  → Gateway broadcasts chat event
+  → WebsocketClient receives
+  → CallbackProcessorJob → Comment creation
 
-[기존 callback 코드]
-CallbacksController, PendingCallback → 유지 (삭제하지 않음)
+[Existing Callback Code]
+CallbacksController, PendingCallback → Kept (not deleted)
 ```
 
 ---
 
-## Phase 1: WebSocket 인프라
+## Phase 1: WebSocket Infrastructure
 
-### 1.1 faye-websocket gem 추가
+### 1.1 Add faye-websocket gem
 
 `collavre_openclaw.gemspec`:
 ```ruby
@@ -60,31 +60,31 @@ spec.add_dependency "eventmachine", "~> 1.2"
 
 ### 1.2 WebsocketClient
 
-**파일**: `app/services/collavre_openclaw/websocket_client.rb`
+**File**: `app/services/collavre_openclaw/websocket_client.rb`
 
-OpenClaw Gateway에 대한 단일 유저 WebSocket 연결을 관리하는 클래스.
+Manages a single user's WebSocket connection to the OpenClaw Gateway.
 
-**책임:**
-- WebSocket 연결 생성 (ws:// 또는 wss://)
+**Responsibilities:**
+- WebSocket connection creation (ws:// or wss://)
 - OpenClaw protocol handshake (`connect` request + auth token)
-- RPC 요청/응답 매핑 (`type: "req"` → `type: "res"`, id 기반)
-- Event 수신 (`type: "event"`, event: "chat")
-- Tick 응답 (keepalive)
-- 자동 재연결 (exponential backoff)
+- RPC request/response mapping (`type: "req"` → `type: "res"`, id-based)
+- Event reception (`type: "event"`, event: "chat")
+- Tick response (keepalive)
+- Auto-reconnect (exponential backoff)
 
-**프로토콜 흐름:**
+**Protocol Flow:**
 ```
-1. WS 연결 수립
+1. Establish WS connection
 2. Gateway → connect.challenge (nonce)
 3. Client → connect request (auth token, role: "operator")
 4. Gateway → hello-ok (protocol version, tick interval)
-5. 이후 양방향 통신:
+5. Bidirectional communication:
    - Client → req (chat.send, chat.history, chat.abort)
-   - Gateway → res (응답)
+   - Gateway → res (response)
    - Gateway → event (chat delta/final, tick)
 ```
 
-**인터페이스:**
+**Interface:**
 ```ruby
 class WebsocketClient
   def initialize(user:)
@@ -92,12 +92,12 @@ class WebsocketClient
   def connect!
   def disconnect!
 
-  # RPC 메서드
+  # RPC methods
   def chat_send(session_key:, message:, idempotency_key:, &on_event)
   def chat_history(session_key:, limit: nil)
   def chat_abort(session_key:, run_id: nil)
 
-  # 프로액티브 메시지 콜백 등록
+  # Register proactive message callback
   def on_proactive_message(&handler)
 
   private
@@ -111,18 +111,18 @@ end
 
 ### 1.3 ConnectionManager
 
-**파일**: `app/services/collavre_openclaw/connection_manager.rb`
+**File**: `app/services/collavre_openclaw/connection_manager.rb`
 
-유저별 WebSocket 연결 풀 관리. Singleton.
+Per-user WebSocket connection pool management. Singleton.
 
-**책임:**
-- 유저별 WebsocketClient 생성/캐싱
-- Lazy connect (첫 요청 시 연결)
-- Idle timeout (30분 미사용 시 해제)
-- 앱 종료 시 전체 연결 해제
+**Responsibilities:**
+- Per-user WebsocketClient creation/caching
+- Lazy connect (connects on first request)
+- Idle timeout (disconnects after 30 minutes of inactivity)
+- Graceful shutdown on app exit
 - Thread-safe access (Mutex)
 
-**인터페이스:**
+**Interface:**
 ```ruby
 class ConnectionManager
   include Singleton
@@ -135,15 +135,14 @@ class ConnectionManager
 end
 ```
 
-### 1.4 스레딩 모델
+### 1.4 Threading Model
 
-faye-websocket은 EventMachine 기반이므로:
-- 별도 EM 스레드에서 WebSocket 연결 관리
-- Rails 요청 스레드에서는 `chat_send` 호출 시 블로킹 대기 (Queue 또는 ConditionVariable)
-- EM reactor가 실행 중이 아니면 자동 시작
+faye-websocket is EventMachine-based:
+- WebSocket connections managed in a separate EM thread
+- Rails request threads block on `chat_send` calls (via Queue or ConditionVariable)
+- EM reactor auto-starts if not running
 
 ```ruby
-# EventMachine reactor 관리
 module CollavreOpenclaw
   class EmReactor
     def self.ensure_running!
@@ -155,23 +154,23 @@ module CollavreOpenclaw
 end
 ```
 
-### 1.5 Configuration 확장
+### 1.5 Configuration Extension
 
 ```ruby
 # configuration.rb
-attr_accessor :websocket_idle_timeout      # 기본: 30분 (1800초)
-attr_accessor :websocket_reconnect_max     # 최대 재연결 시도: 10
-attr_accessor :websocket_reconnect_base    # 재연결 대기 기본값: 1초
-attr_accessor :websocket_connect_timeout   # 연결 타임아웃: 10초
+attr_accessor :ws_idle_timeout        # Default: 30 min (1800s)
+attr_accessor :ws_reconnect_max       # Max reconnect attempts: 10
+attr_accessor :ws_reconnect_base_delay # Reconnect base delay: 1s
+attr_accessor :ws_connect_timeout     # Connect timeout: 10s
 ```
 
 ---
 
-## Phase 2: Chat 전송 전환
+## Phase 2: Chat Transport Switch
 
-### 2.1 OpenclawAdapter 수정
+### 2.1 OpenclawAdapter Modification
 
-`chat()` 메서드를 WebSocket 기반으로 변경:
+Change `chat()` method to WebSocket-based:
 
 ```ruby
 def chat(messages, tools: [], &block)
@@ -191,109 +190,106 @@ def chat(messages, tools: [], &block)
       text = extract_delta_text(event)
       yield text if text.present? && block_given?
     when "final"
-      # final은 전체 텍스트 포함 — delta로 이미 yield했으면 스킵
+      # final contains full text — skip if already yielded via deltas
     when "error"
       yield "Error: #{event[:errorMessage]}" if block_given?
     when "aborted"
-      # 사용자가 abort한 경우
+      # User aborted
     end
   end
 end
 ```
 
-### 2.2 메시지 포맷 변환
+### 2.2 Message Format Conversion
 
-**HTTP (현재):**
-- `messages` 배열 (전체 대화 이력)
-- `model` 필드로 agent 지정
-- `user` 필드에 callback 정보
+**HTTP (current):**
+- `messages` array (full conversation history)
+- `model` field for agent routing
+- `user` field with callback info
 
-**WebSocket (변경):**
-- `message` 단일 문자열 (최신 메시지만)
-- `sessionKey`로 세션 라우팅
-- Gateway가 세션 이력 관리
+**WebSocket (new):**
+- `message` single string (latest message only)
+- `sessionKey` for session routing
+- Gateway manages session history
 
 ```ruby
 def format_message_for_ws(messages)
-  # 마지막 user 메시지만 추출
+  # Extract only the last user message
   last_user = Array(messages).reverse.find { |m|
     role = m[:role] || m["role"]
-    %w[user].include?(role.to_s)
+    role.to_s == "user"
   }
 
-  if last_user
-    parts = last_user[:parts] || last_user["parts"]
-    if parts
-      Array(parts).map { |p| p[:text] || p["text"] }.compact.join("\n")
-    else
-      last_user[:text] || last_user["text"] || last_user[:content] || last_user["content"]
-    end
+  return "" unless last_user
+
+  parts = last_user[:parts] || last_user["parts"]
+  if parts
+    Array(parts).map { |p| p[:text] || p["text"] }.compact.join("\n")
   else
-    ""
+    last_user[:text] || last_user["text"] || last_user[:content] || last_user["content"]
   end.to_s
 end
 ```
 
-### 2.3 Session Key 전략
+### 2.3 Session Key Strategy
 
-변경 없음. 기존 `build_session_key` 로직 그대로 사용:
+No change. Use existing `build_session_key` logic:
 ```
 agent:<agent_id>:collavre:<user_id>:creative:<creative_id>:topic:<topic_id>
 ```
 
-HTTP 헤더 (`x-openclaw-session-key`) → `chat.send` params (`sessionKey`)로 이동만.
+HTTP header (`x-openclaw-session-key`) → `chat.send` params (`sessionKey`).
 
-### 2.4 HTTP fallback
+### 2.4 HTTP Fallback
 
-WebSocket 연결 실패 시 기존 HTTP 방식으로 폴백:
+Fall back to existing HTTP method on WebSocket connection failure:
 
 ```ruby
 def chat(messages, tools: [], &block)
   if websocket_available?
     chat_via_websocket(messages, tools: tools, &block)
   else
-    chat_via_http(messages, tools: tools, &block)  # 기존 코드
+    chat_via_http(messages, tools: tools, &block)  # existing code
   end
 end
 ```
 
 ---
 
-## Phase 3: 프로액티브 메시지 수신
+## Phase 3: Proactive Message Reception
 
-### 3.1 Event Handler 등록
+### 3.1 Event Handler Registration
 
-WebSocket 연결 시 프로액티브 메시지 핸들러 등록:
+Register proactive message handler on WebSocket connection:
 
 ```ruby
-# ConnectionManager에서 연결 생성 시
+# In ConnectionManager on connection creation
 client = WebsocketClient.new(user: user)
 client.on_proactive_message do |event|
   handle_proactive_message(user, event)
 end
 ```
 
-### 3.2 프로액티브 vs 요청 응답 구분
+### 3.2 Distinguishing Request Response vs Proactive
 
 ```ruby
-# WebsocketClient 내부
+# Inside WebsocketClient
 def handle_chat_event(payload)
   run_id = payload[:runId]
-  session_key = payload[:sessionKey]
 
   if @pending_runs.key?(run_id)
-    # 요청에 대한 응답 → 해당 요청의 콜백으로 전달
+    # Response to a request → forward to request callback
     @pending_runs[run_id].call(payload)
   else
-    # 프로액티브 메시지 → 핸들러로 전달
+    # Proactive message → forward to handler
     @proactive_handler&.call(payload)
   end
 end
 ```
 
-### 3.3 CallbackProcessorJob 연동
+### 3.3 CallbackProcessorJob Integration
 
-기존 CallbackProcessorJob을 재사용:
+Reuse existing CallbackProcessorJob:
 
 ```ruby
 def handle_proactive_message(user, event)
@@ -315,7 +311,7 @@ def handle_proactive_message(user, event)
 end
 ```
 
-### 3.4 Session Key 파싱
+### 3.4 Session Key Parsing
 
 ```ruby
 def parse_session_key(session_key)
@@ -336,45 +332,45 @@ end
 
 ---
 
-## Phase 4: 기존 callback 코드 유지
+## Phase 4: Keep Existing Callback Code
 
-> **결정: 현재 구현 그대로 유지. 삭제하지 않음.**
+> **Decision: Keep current implementation as-is. Do not delete.**
 
-유지되는 코드:
-- `CallbacksController` — HTTP callback 엔드포인트
-- `PendingCallback` 모델 — nonce 관리
-- `callback_url` / `callback_nonce` 로직 — OpenclawAdapter 내
+Code that remains:
+- `CallbacksController` — HTTP callback endpoint
+- `PendingCallback` model — nonce management
+- `callback_url` / `callback_nonce` logic — in OpenclawAdapter
 - `config/routes.rb` — callback route
-- DB 테이블 `openclaw_pending_callbacks`
+- DB table `openclaw_pending_callbacks`
 
-이유:
-- WebSocket이 안정화될 때까지 HTTP callback도 병행 가능
-- 나중에 WebSocket이 충분히 검증되면 별도 PR로 정리
+Rationale:
+- HTTP callback can run in parallel until WebSocket is proven stable
+- Clean up in a separate PR once WebSocket is fully validated
 
 ---
 
-## Phase 5: 테스트
+## Phase 5: Tests
 
 ### 5.1 Unit Tests
 
 ```ruby
 # test/services/websocket_client_test.rb
 - connect/disconnect
-- chat.send → chat event 수신 → 텍스트 추출
-- 프로액티브 메시지 감지 (미등록 runId)
-- 재연결 로직 (exponential backoff)
-- tick 응답
+- chat.send → chat event reception → text extraction
+- Proactive message detection (unregistered runId)
+- Reconnect logic (exponential backoff)
+- Tick response
 
 # test/services/connection_manager_test.rb
-- 유저별 연결 생성/재사용
-- idle timeout → disconnect
-- thread-safe access
+- Per-user connection creation/reuse
+- Idle timeout → disconnect
+- Thread-safe access
 - disconnect_all
 
 # test/services/openclaw_adapter_test.rb
-- WebSocket 경로 테스트
-- HTTP fallback 테스트
-- 메시지 포맷 변환
+- WebSocket path tests
+- HTTP fallback tests
+- Message format conversion
 ```
 
 ### 5.2 Mock WebSocket Server
@@ -382,61 +378,61 @@ end
 ```ruby
 # test/support/mock_openclaw_gateway.rb
 class MockOpenclawGateway
-  # EventMachine 기반 mock WS 서버
-  # - connect handshake 응답
-  # - chat.send → chat event 응답
-  # - 프로액티브 메시지 시뮬레이션
+  # EventMachine-based mock WS server
+  # - connect handshake response
+  # - chat.send → chat event response
+  # - Proactive message simulation
 end
 ```
 
 ---
 
-## 구현 순서
+## Implementation Order
 
 ```
-Phase 1: WebSocket 인프라                    [PR #1]
-  ├─ 1.1 faye-websocket gem 추가
-  ├─ 1.2 WebsocketClient 구현
-  ├─ 1.3 ConnectionManager 구현
-  ├─ 1.4 EM reactor 관리
-  └─ 1.5 Configuration 확장 + 테스트
+Phase 1: WebSocket Infrastructure              [PR #1]
+  ├─ 1.1 Add faye-websocket gem
+  ├─ 1.2 Implement WebsocketClient
+  ├─ 1.3 Implement ConnectionManager
+  ├─ 1.4 EM reactor management
+  └─ 1.5 Configuration extension + tests
 
-Phase 2: Chat 전환                           [PR #2]
-  ├─ 2.1 OpenclawAdapter.chat() → WS 전환
-  ├─ 2.2 메시지 포맷 변환
-  ├─ 2.3 HTTP fallback 유지
-  └─ 2.4 테스트
+Phase 2: Chat Transport Switch                 [PR #2]
+  ├─ 2.1 OpenclawAdapter.chat() → WS switch
+  ├─ 2.2 Message format conversion
+  ├─ 2.3 HTTP fallback retained
+  └─ 2.4 Tests
 
-Phase 3: 프로액티브 메시지                    [PR #3]
-  ├─ 3.1 Event handler 등록
-  ├─ 3.2 요청/프로액티브 구분
-  ├─ 3.3 CallbackProcessorJob 연동
-  └─ 3.4 테스트
+Phase 3: Proactive Messages                    [PR #3]
+  ├─ 3.1 Event handler registration
+  ├─ 3.2 Request/proactive distinction
+  ├─ 3.3 CallbackProcessorJob integration
+  └─ 3.4 Tests
 ```
 
 ---
 
-## 리스크 & 완화
+## Risks & Mitigations
 
-| 리스크 | 영향 | 완화 |
-|--------|------|------|
-| WS 연결 끊김 | 프로액티브 메시지 유실 | auto-reconnect + chat.history 복구 |
-| EventMachine 호환성 | Puma와 충돌 가능 | 별도 스레드에서 EM 실행 |
-| 서버 재시작 | 모든 WS 연결 끊김 | 재시작 후 자동 재연결 |
-| Gateway 다운 | 채팅 불가 | HTTP fallback (Phase 2.4) |
-| 동시성 버그 | 메시지 유실/중복 | idempotencyKey + Mutex |
-| 메모리 증가 | 유저 수 × 연결 | idle timeout (30분) |
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| WS connection drops | Proactive message loss | Auto-reconnect + chat.history recovery |
+| EventMachine compatibility | Possible conflict with Puma | Run EM in separate thread |
+| Server restart | All WS connections dropped | Auto-reconnect after restart |
+| Gateway down | Chat unavailable | HTTP fallback (Phase 2.4) |
+| Concurrency bugs | Message loss/duplication | idempotencyKey + Mutex |
+| Memory increase | Users × connections | Idle timeout (30 min) |
 
-## 미해결 사항
+## Open Questions
 
-### chat.send의 message가 단일 문자열인 문제
+### chat.send message is a single string
 
-- 현재 HTTP: 전체 대화 이력 (`messages` 배열) + 시스템 프롬프트 전송
-- WS `chat.send`: `message` 단일 문자열만
+- Current HTTP: sends full conversation history (`messages` array) + system prompt
+- WS `chat.send`: single `message` string only
 
-**해결 방안:**
-1. Gateway가 세션 이력을 관리하므로 최신 메시지만 전송 → 이력은 Gateway가 유지
-2. 시스템 프롬프트 → OpenClaw agent config (SOUL.md 등)에서 관리
-3. Creative 컨텍스트 → 메시지 앞에 prefix로 포함
+**Resolution:**
+1. Gateway manages session history, so send only the latest message → history maintained by Gateway
+2. System prompt → managed in OpenClaw agent config (SOUL.md etc.)
+3. Creative context → included as message prefix
 
-**→ Phase 2 구현 시 상세 결정 필요**
+**→ Detailed decision made during Phase 2 implementation**

--- a/engines/collavre_openclaw/app/services/collavre_openclaw/ai_client_extension.rb
+++ b/engines/collavre_openclaw/app/services/collavre_openclaw/ai_client_extension.rb
@@ -19,7 +19,7 @@ module CollavreOpenclaw
       adapter_class = self.class.adapter_registry[normalized_vendor]
 
       if adapter_class
-        # Use the custom adapter
+        # Use the custom adapter (tools not supported for OpenClaw)
         user = context&.dig(:user)
         adapter = adapter_class.new(
           user: user,
@@ -31,15 +31,14 @@ module CollavreOpenclaw
         error_message = nil
 
         begin
-          response_content = adapter.chat(contents, tools: tools, &block)
+          response_content = adapter.chat(contents, &block)
         rescue StandardError => e
           error_message = e.message
           raise
         ensure
-          # Log the interaction just like AiClient does
           log_interaction(
             messages: Array(contents),
-            tools: tools,
+            tools: [],
             response_content: response_content,
             error_message: error_message,
             input_tokens: nil,

--- a/engines/collavre_openclaw/app/services/collavre_openclaw/connection_manager.rb
+++ b/engines/collavre_openclaw/app/services/collavre_openclaw/connection_manager.rb
@@ -1,0 +1,121 @@
+module CollavreOpenclaw
+  # Manages per-user WebSocket connections to OpenClaw Gateways.
+  #
+  # Singleton: use ConnectionManager.instance
+  #
+  # Features:
+  # - Lazy connect (creates connection on first use)
+  # - Connection reuse (same user → same connection)
+  # - Idle timeout (disconnects after inactivity)
+  # - Thread-safe access
+  # - Graceful shutdown
+  class ConnectionManager
+    include Singleton
+
+    def initialize
+      @connections = {} # user_id → WebsocketClient
+      @mutex = Mutex.new
+      @idle_checker = nil
+      start_idle_checker!
+    end
+
+    # Get or create a WebSocket connection for a user.
+    # The connection is lazily connected on first RPC call,
+    # but you can call connect! explicitly if needed.
+    #
+    # @param user [User] must respond to #gateway_url and #llm_api_key
+    # @return [WebsocketClient]
+    def connection_for(user)
+      @mutex.synchronize do
+        client = @connections[user.id]
+        if client.nil?
+          client = WebsocketClient.new(user: user)
+          @connections[user.id] = client
+        end
+        client
+      end
+    end
+
+    # Disconnect a specific user's connection
+    def disconnect(user)
+      @mutex.synchronize do
+        client = @connections.delete(user.id)
+        client&.disconnect!
+      end
+    end
+
+    # Disconnect all connections (for app shutdown)
+    def disconnect_all
+      @mutex.synchronize do
+        @connections.each_value(&:disconnect!)
+        @connections.clear
+      end
+      stop_idle_checker!
+    end
+
+    # Number of active connections
+    def connected_count
+      @mutex.synchronize do
+        @connections.count { |_, c| c.connected? }
+      end
+    end
+
+    # Status summary
+    def status
+      @mutex.synchronize do
+        states = @connections.values.group_by(&:state)
+        {
+          connected: states[:connected]&.size || 0,
+          connecting: states[:connecting]&.size || 0,
+          reconnecting: states[:reconnecting]&.size || 0,
+          disconnected: states[:disconnected]&.size || 0,
+          total: @connections.size
+        }
+      end
+    end
+
+    # Register a proactive message handler for all connections.
+    # New connections will also get this handler.
+    def on_proactive_message(&handler)
+      @mutex.synchronize do
+        @proactive_handler = handler
+        @connections.each_value do |client|
+          client.on_proactive_message(&handler)
+        end
+      end
+    end
+
+    private
+
+    def start_idle_checker!
+      @idle_checker = Thread.new do
+        Thread.current.name = "openclaw-idle-checker"
+        loop do
+          sleep 60 # Check every minute
+          check_idle_connections!
+        rescue => e
+          Rails.logger.error("[CollavreOpenclaw::ConnectionManager] Idle checker error: #{e.message}")
+        end
+      end
+    end
+
+    def stop_idle_checker!
+      @idle_checker&.kill
+      @idle_checker = nil
+    end
+
+    def check_idle_connections!
+      timeout = CollavreOpenclaw.config.ws_idle_timeout
+
+      @mutex.synchronize do
+        @connections.each do |user_id, client|
+          if client.connected? && client.idle_seconds > timeout
+            Rails.logger.info("[CollavreOpenclaw::ConnectionManager] Disconnecting idle connection for user #{user_id}")
+            client.disconnect!
+            @connections.delete(user_id)
+          end
+        end
+      end
+    end
+  end
+end

--- a/engines/collavre_openclaw/app/services/collavre_openclaw/connection_manager.rb
+++ b/engines/collavre_openclaw/app/services/collavre_openclaw/connection_manager.rb
@@ -89,10 +89,15 @@ module CollavreOpenclaw
     private
 
     def start_idle_checker!
+      @idle_checker_stop = false
       @idle_checker = Thread.new do
         Thread.current.name = "openclaw-idle-checker"
         loop do
-          sleep 60 # Check every minute
+          break if @idle_checker_stop
+          sleep 1 # Check stop flag every second
+          @idle_check_counter = (@idle_check_counter || 0) + 1
+          next unless @idle_check_counter >= 60 # Run check every ~60 seconds
+          @idle_check_counter = 0
           check_idle_connections!
         rescue => e
           Rails.logger.error("[CollavreOpenclaw::ConnectionManager] Idle checker error: #{e.message}")
@@ -101,7 +106,8 @@ module CollavreOpenclaw
     end
 
     def stop_idle_checker!
-      @idle_checker&.kill
+      @idle_checker_stop = true
+      @idle_checker&.join(5)
       @idle_checker = nil
     end
 
@@ -109,12 +115,14 @@ module CollavreOpenclaw
       timeout = CollavreOpenclaw.config.ws_idle_timeout
 
       @mutex.synchronize do
-        @connections.each do |user_id, client|
-          if client.connected? && client.idle_seconds > timeout
-            Rails.logger.info("[CollavreOpenclaw::ConnectionManager] Disconnecting idle connection for user #{user_id}")
-            client.disconnect!
-            @connections.delete(user_id)
-          end
+        idle_user_ids = @connections.each_with_object([]) do |(user_id, client), ids|
+          ids << user_id if client.connected? && client.idle_seconds > timeout
+        end
+
+        idle_user_ids.each do |user_id|
+          client = @connections.delete(user_id)
+          Rails.logger.info("[CollavreOpenclaw::ConnectionManager] Disconnecting idle connection for user #{user_id}")
+          client&.disconnect!
         end
       end
     end

--- a/engines/collavre_openclaw/app/services/collavre_openclaw/connection_manager.rb
+++ b/engines/collavre_openclaw/app/services/collavre_openclaw/connection_manager.rb
@@ -30,6 +30,7 @@ module CollavreOpenclaw
         client = @connections[user.id]
         if client.nil?
           client = WebsocketClient.new(user: user)
+          client.on_proactive_message(&@proactive_handler) if @proactive_handler
           @connections[user.id] = client
         end
         client

--- a/engines/collavre_openclaw/app/services/collavre_openclaw/em_reactor.rb
+++ b/engines/collavre_openclaw/app/services/collavre_openclaw/em_reactor.rb
@@ -30,7 +30,8 @@ module CollavreOpenclaw
         @mutex&.synchronize do
           return unless EM.reactor_running?
 
-          EM.stop
+          # Must stop EM from within the reactor thread
+          EM.next_tick { EM.stop }
           @thread&.join(5)
           @thread = nil
         end

--- a/engines/collavre_openclaw/app/services/collavre_openclaw/em_reactor.rb
+++ b/engines/collavre_openclaw/app/services/collavre_openclaw/em_reactor.rb
@@ -1,0 +1,51 @@
+require "eventmachine"
+
+module CollavreOpenclaw
+  # Manages a single EventMachine reactor thread shared by all WebSocket connections.
+  # Thread-safe: multiple Rails threads can schedule work via .next_tick.
+  class EmReactor
+    class << self
+      def ensure_running!
+        @mutex ||= Mutex.new
+        @mutex.synchronize do
+          return if EM.reactor_running?
+
+          @thread = Thread.new do
+            Thread.current.name = "openclaw-em-reactor"
+            EM.run
+          end
+
+          # Wait until the reactor is actually running
+          deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 5
+          until EM.reactor_running?
+            if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
+              raise "EventMachine reactor failed to start within 5 seconds"
+            end
+            sleep 0.01
+          end
+        end
+      end
+
+      def stop!
+        @mutex&.synchronize do
+          return unless EM.reactor_running?
+
+          EM.stop
+          @thread&.join(5)
+          @thread = nil
+        end
+      end
+
+      def running?
+        EM.reactor_running?
+      end
+
+      # Schedule a block to run in the EM reactor thread.
+      # Safe to call from any thread.
+      def next_tick(&block)
+        ensure_running!
+        EM.next_tick(&block)
+      end
+    end
+  end
+end

--- a/engines/collavre_openclaw/app/services/collavre_openclaw/openclaw_adapter.rb
+++ b/engines/collavre_openclaw/app/services/collavre_openclaw/openclaw_adapter.rb
@@ -4,7 +4,10 @@ require "json"
 module CollavreOpenclaw
   class OpenclawAdapter
     # Adapter for OpenClaw AI Gateway
-    # Uses OpenAI-compatible /v1/chat/completions endpoint
+    #
+    # Supports two transport modes:
+    # 1. WebSocket (primary) - via faye-websocket + EventMachine
+    # 2. HTTP (fallback) - via Faraday POST /v1/chat/completions
     #
     # Session mapping:
     #   Collavre Topic → OpenClaw Session (1:1)
@@ -25,35 +28,21 @@ module CollavreOpenclaw
       end
 
       unless @user&.llm_api_key.present?
-        Rails.logger.error("[CollavreOpenclaw] No API key configured for user #{@user&.id} (may be a decryption failure)")
-        yield "Error: OpenClaw API key not configured or decryption failed. Please re-enter the API key in AI agent settings." if block_given?
+        Rails.logger.error("[CollavreOpenclaw] No API key configured for user #{@user&.id}")
+        yield "Error: OpenClaw API key not configured or decryption failed. " \
+              "Please re-enter the API key in AI agent settings." if block_given?
         return nil
       end
 
-      response_content = +""
-
-      begin
-        # Build the request payload (OpenAI format)
-        payload = build_payload(messages, tools)
-
-        Rails.logger.info("[CollavreOpenclaw] Sending request to #{api_endpoint} (session: #{session_key})")
-
-        # Make streaming request to OpenClaw
-        stream_response(payload) do |chunk|
-          response_content << chunk
-          yield chunk if block_given?
-        end
-
-        response_content.presence
-      rescue StandardError => e
-        Rails.logger.error("[CollavreOpenclaw] Chat error: #{e.message}\n#{e.backtrace.first(5).join("\n")}")
-        error_msg = "OpenClaw Error: #{e.message}"
-        yield error_msg if block_given?
-        nil
+      # Try WebSocket first, fall back to HTTP
+      if websocket_available?
+        chat_via_websocket(messages, tools: tools, &block)
+      else
+        chat_via_http(messages, tools: tools, &block)
       end
     end
 
-    # Get the callback URL for this user
+    # Get the callback URL for this user (kept for backward compatibility)
     def callback_url
       return nil unless @user
 
@@ -76,12 +65,154 @@ module CollavreOpenclaw
 
     private
 
+    # ─────────────────────────────────────────────
+    # WebSocket transport
+    # ─────────────────────────────────────────────
+
+    def websocket_available?
+      # WebSocket is available when ConnectionManager and WebsocketClient are loaded
+      defined?(ConnectionManager) && defined?(WebsocketClient)
+    rescue => e
+      Rails.logger.debug("[CollavreOpenclaw] WebSocket not available: #{e.message}")
+      false
+    end
+
+    def chat_via_websocket(messages, tools: [], &block)
+      response_content = +""
+
+      begin
+        client = ConnectionManager.instance.connection_for(@user)
+        message_text = format_message_for_ws(messages)
+
+        Rails.logger.info("[CollavreOpenclaw] Sending via WebSocket (session: #{session_key})")
+
+        client.chat_send(
+          session_key: session_key,
+          message: message_text
+        ) do |event|
+          case event[:state]
+          when "delta"
+            if event[:text].present?
+              response_content << event[:text]
+              yield event[:text] if block_given?
+            end
+          when "final"
+            # Final event may contain full text; delta already streamed it
+          when "error"
+            error_msg = event[:text] || "Unknown error"
+            yield "OpenClaw Error: #{error_msg}" if block_given?
+          when "aborted"
+            # User or system aborted
+          end
+        end
+
+        response_content.presence
+      rescue CollavreOpenclaw::ConnectionError,
+             CollavreOpenclaw::TimeoutError => e
+        Rails.logger.warn("[CollavreOpenclaw] WebSocket failed, falling back to HTTP: #{e.message}")
+        chat_via_http(messages, tools: tools, &block)
+      rescue CollavreOpenclaw::ChatError, CollavreOpenclaw::RpcError => e
+        Rails.logger.error("[CollavreOpenclaw] WebSocket chat error: #{e.message}")
+        error_msg = "OpenClaw Error: #{e.message}"
+        yield error_msg if block_given?
+        nil
+      rescue StandardError => e
+        Rails.logger.error("[CollavreOpenclaw] WebSocket unexpected error: #{e.message}\n" \
+                           "#{e.backtrace.first(5).join("\n")}")
+        Rails.logger.info("[CollavreOpenclaw] Falling back to HTTP")
+        chat_via_http(messages, tools: tools, &block)
+      end
+    end
+
+    # Format messages for WebSocket chat.send (single message string).
+    # Gateway manages session history, so we only send the latest user message
+    # with optional context prefix.
+    def format_message_for_ws(messages)
+      formatted = Array(messages)
+
+      # Extract the last user message
+      last_user = formatted.reverse.find do |m|
+        role = m[:role] || m["role"]
+        role.to_s == "user"
+      end
+
+      return "" unless last_user
+
+      text = extract_message_text(last_user)
+
+      # If there's a system prompt and this is the first message in a new session,
+      # prepend context. The Gateway may already have agent config with system prompt,
+      # but we include creative context here for completeness.
+      context_prefix = build_context_prefix(formatted)
+      if context_prefix.present?
+        "#{context_prefix}\n\n#{text}"
+      else
+        text.to_s
+      end
+    end
+
+    # Build a context prefix from system/context messages if present.
+    # This includes creative tree markdown and other context that the Gateway
+    # wouldn't have from its own agent config.
+    def build_context_prefix(messages)
+      # Find the first "user" message that looks like creative context
+      # (typically starts with "Creative:\n")
+      context_msg = messages.find do |m|
+        role = m[:role] || m["role"]
+        text = extract_message_text(m)
+        role.to_s == "user" && text&.start_with?("Creative:")
+      end
+
+      return nil unless context_msg
+
+      extract_message_text(context_msg)
+    end
+
+    def extract_message_text(message)
+      parts = message[:parts] || message["parts"]
+      if parts
+        Array(parts).filter_map { |p| p[:text] || p["text"] }.join("\n")
+      else
+        message[:text] || message["text"] || message[:content] || message["content"]
+      end
+    end
+
+    # ─────────────────────────────────────────────
+    # HTTP transport (fallback)
+    # ─────────────────────────────────────────────
+
+    def chat_via_http(messages, tools: [], &block)
+      response_content = +""
+
+      begin
+        payload = build_payload(messages, tools)
+
+        Rails.logger.info("[CollavreOpenclaw] Sending via HTTP to #{api_endpoint} (session: #{session_key})")
+
+        stream_response(payload) do |chunk|
+          response_content << chunk
+          yield chunk if block_given?
+        end
+
+        response_content.presence
+      rescue StandardError => e
+        Rails.logger.error("[CollavreOpenclaw] HTTP chat error: #{e.message}\n" \
+                           "#{e.backtrace.first(5).join("\n")}")
+        error_msg = "OpenClaw Error: #{e.message}"
+        yield error_msg if block_given?
+        nil
+      end
+    end
+
     def api_endpoint
-      # OpenClaw uses /v1/chat/completions (OpenAI-compatible)
       uri = URI.parse(@user.gateway_url)
       uri.path = "/v1/chat/completions"
       uri.to_s
     end
+
+    # ─────────────────────────────────────────────
+    # Session key
+    # ─────────────────────────────────────────────
 
     # Build stable session key based on Topic (not nonce)
     # Same Topic = Same Session = Shared context between users
@@ -98,9 +229,11 @@ module CollavreOpenclaw
       parts.join(":")
     end
 
+    # ─────────────────────────────────────────────
+    # HTTP payload building
+    # ─────────────────────────────────────────────
+
     def build_payload(messages, tools)
-      # Build model string with agent_id derived from user email
-      # OpenClaw accepts "openclaw:<agentId>" format (e.g., "openclaw:collavre")
       agent_id = extract_agent_id_from_email
       model_value = agent_id.present? ? "openclaw:#{agent_id}" : "openclaw"
 
@@ -110,49 +243,35 @@ module CollavreOpenclaw
         stream: true
       }
 
-      # Add system prompt as first message if present
       if @system_prompt.present?
         payload[:messages].unshift({ role: "system", content: @system_prompt })
       end
 
-      # Add tools if provided (convert to OpenAI function calling format)
-      if tools.present?
-        payload[:tools] = format_tools(tools)
-      end
-
-      # Build user context with callback information
+      payload[:tools] = format_tools(tools) if tools.present?
       payload[:user] = build_user_context
-
       payload
     end
 
-    # Convert tools to OpenAI function calling format
-    # Accepts either:
-    #   - Array of tool names (strings): ["meta_tool", "search"]
-    #   - Array of OpenAI-format tool objects (already formatted)
     def format_tools(tools)
       Array(tools).filter_map do |tool|
         if tool.is_a?(String)
-          # Tool name - fetch from MCP and convert to OpenAI format
           convert_tool_name_to_openai_format(tool)
         elsif tool.is_a?(Hash)
-          # Already a hash - check if it's OpenAI format or needs conversion
           if tool[:type] == "function" || tool["type"] == "function"
-            # Already OpenAI format
             tool
           else
-            # MCP format - convert to OpenAI format
             convert_mcp_tool_to_openai_format(tool)
           end
         end
       end.compact
     end
 
-    # Convert a tool name to OpenAI function format by fetching from MCP
     def convert_tool_name_to_openai_format(tool_name)
       return nil unless defined?(::Tools::MetaToolService)
 
-      result = ::Tools::MetaToolService.new.call(action: "get", tool_name: tool_name, query: nil, arguments: nil)
+      result = ::Tools::MetaToolService.new.call(
+        action: "get", tool_name: tool_name, query: nil, arguments: nil
+      )
       return nil if result[:error] || result[:tool].nil?
 
       convert_mcp_tool_to_openai_format(result[:tool])
@@ -161,13 +280,11 @@ module CollavreOpenclaw
       nil
     end
 
-    # Convert MCP tool format to OpenAI function format
-    # MCP format: { name:, description:, params: [...], return_type: }
-    # OpenAI format: { type: "function", function: { name:, description:, parameters: { type: "object", properties:, required: } } }
     def convert_mcp_tool_to_openai_format(mcp_tool)
       name = mcp_tool[:name] || mcp_tool["name"]
       description = mcp_tool[:description] || mcp_tool["description"]
-      params = mcp_tool[:params] || mcp_tool["params"] || mcp_tool[:parameters] || mcp_tool["parameters"] || []
+      params = mcp_tool[:params] || mcp_tool["params"] ||
+               mcp_tool[:parameters] || mcp_tool["parameters"] || []
 
       properties = {}
       required = []
@@ -178,7 +295,6 @@ module CollavreOpenclaw
         param_desc = param[:description] || param["description"]
         param_required = param[:required] || param["required"]
 
-        # Convert Ruby/MCP types to JSON Schema types
         json_type = case param_type.to_s.downcase
         when "integer", "int" then "integer"
         when "number", "float", "decimal" then "number"
@@ -190,7 +306,6 @@ module CollavreOpenclaw
 
         properties[param_name] = { type: json_type }
         properties[param_name][:description] = param_desc if param_desc.present?
-
         required << param_name if param_required
       end
 
@@ -199,11 +314,7 @@ module CollavreOpenclaw
         function: {
           name: name,
           description: description || "",
-          parameters: {
-            type: "object",
-            properties: properties,
-            required: required
-          }
+          parameters: { type: "object", properties: properties, required: required }
         }
       }
     end
@@ -211,12 +322,10 @@ module CollavreOpenclaw
     def build_user_context
       context_data = {}
 
-      # Extract IDs from context
       creative_id = extract_id(@context, :creative) || @context[:creative_id]
       comment_id = extract_id(@context, :comment) || @context[:comment_id]
       topic_id = @context[:thread_id] || @context[:topic_id]
 
-      # Create pending callback with nonce for secure async responses
       callback = callback_url
       if callback.present? && creative_id.present?
         pending = PendingCallback.create_for_request(
@@ -233,10 +342,9 @@ module CollavreOpenclaw
         context_data[:comment_id] = comment_id if comment_id
         context_data[:topic_id] = topic_id if topic_id
 
-        Rails.logger.info("[CollavreOpenclaw] Created pending callback with nonce: #{pending.nonce[0..8]}...")
+        Rails.logger.info("[CollavreOpenclaw] Created pending callback nonce: #{pending.nonce[0..8]}...")
       end
 
-      # Return as JSON string (OpenAI user field format)
       if context_data.any?
         "collavre:#{JSON.generate(context_data)}"
       else
@@ -244,18 +352,11 @@ module CollavreOpenclaw
       end
     end
 
-    # Format messages with sender attribution for multi-user context
     def format_messages(messages)
       Array(messages).map do |msg|
         role = msg[:role] || msg["role"]
-        parts = msg[:parts] || msg["parts"]
-        content = if parts
-                    Array(parts).map { |p| p[:text] || p["text"] }.compact.join("\n")
-        else
-                    msg[:text] || msg["text"] || msg[:content] || msg["content"]
-        end
+        content = extract_message_text(msg)
 
-        # Add sender attribution for user messages (multi-user support)
         sender_name = msg[:sender_name] || msg["sender_name"]
         if sender_name.present? && normalize_role(role) == "user"
           content = "[#{sender_name}]: #{content}"
@@ -273,18 +374,17 @@ module CollavreOpenclaw
       end
     end
 
+    # ─────────────────────────────────────────────
+    # HTTP streaming
+    # ─────────────────────────────────────────────
+
     def build_headers
       headers = {
         "Content-Type" => "application/json",
         "Accept" => "text/event-stream",
         "x-openclaw-session-key" => session_key
       }
-
-      # Add Authorization header if API key is configured
-      if @user&.llm_api_key.present?
-        headers["Authorization"] = "Bearer #{@user.llm_api_key}"
-      end
-
+      headers["Authorization"] = "Bearer #{@user.llm_api_key}" if @user&.llm_api_key.present?
       headers
     end
 
@@ -300,11 +400,9 @@ module CollavreOpenclaw
         response = connection.post do |req|
           req.url api_endpoint
           request_headers.each { |k, v| req.headers[k] = v }
-
           req.body = payload.to_json
 
           req.options.on_data = proc do |chunk, _size, env|
-            # Only process streaming data for successful responses
             if env&.status.nil? || (env.status >= 200 && env.status < 300)
               buffer << chunk
               process_sse_buffer(buffer, &block)
@@ -314,30 +412,26 @@ module CollavreOpenclaw
           end
         end
 
-        # Check HTTP status and raise meaningful errors
         unless response.status >= 200 && response.status < 300
           error_body = buffer.presence || response.body
-          error_message = parse_error_message(response.status, error_body)
-          raise error_message
+          raise parse_error_message(response.status, error_body)
         end
 
-        # Process any remaining data in buffer
         process_sse_buffer(buffer, final: true, &block)
 
-        # Handle non-streaming response
         if response.headers["content-type"]&.include?("application/json")
           handle_json_response(response.body, &block)
         end
 
         response
-      rescue Faraday::TimeoutError => e
+      rescue Faraday::TimeoutError
         retries += 1
         if retries <= max_retries
-          Rails.logger.warn("[CollavreOpenclaw] Request timed out, retrying (#{retries}/#{max_retries})...")
-          sleep(1 * retries)  # Exponential backoff
+          Rails.logger.warn("[CollavreOpenclaw] Timed out, retrying (#{retries}/#{max_retries})...")
+          sleep(1 * retries)
           retry
         end
-        raise "OpenClaw request timed out after #{max_retries + 1} attempts (read_timeout: #{CollavreOpenclaw.config.read_timeout}s)"
+        raise "OpenClaw request timed out after #{max_retries + 1} attempts"
       rescue Faraday::ConnectionFailed => e
         retries += 1
         if retries <= max_retries
@@ -359,18 +453,12 @@ module CollavreOpenclaw
       end
 
       case status
-      when 401
-        "Authentication failed (HTTP 401). Check your API key. #{detail}"
-      when 403
-        "Access forbidden (HTTP 403). #{detail}"
-      when 404
-        "Gateway endpoint not found (HTTP 404). Check your Gateway URL."
-      when 429
-        "Rate limited (HTTP 429). #{detail}"
-      when 500..599
-        "Gateway server error (HTTP #{status}). #{detail}"
-      else
-        "HTTP #{status}: #{detail}"
+      when 401 then "Authentication failed (HTTP 401). Check your API key. #{detail}"
+      when 403 then "Access forbidden (HTTP 403). #{detail}"
+      when 404 then "Gateway endpoint not found (HTTP 404). Check your Gateway URL."
+      when 429 then "Rate limited (HTTP 429). #{detail}"
+      when 500..599 then "Gateway server error (HTTP #{status}). #{detail}"
+      else "HTTP #{status}: #{detail}"
       end
     end
 
@@ -399,23 +487,22 @@ module CollavreOpenclaw
         line = line.strip
         next if line.empty? || line.start_with?(":")
 
-        if line.start_with?("data:")
-          data = line.sub(/^data:\s*/, "")
-          next if data == "[DONE]"
+        next unless line.start_with?("data:")
 
-          begin
-            json = JSON.parse(data, symbolize_names: true)
-            content = extract_content(json)
-            yield content if content.present?
-          rescue JSON::ParserError
-            yield data if data.present?
-          end
+        data = line.sub(/^data:\s*/, "")
+        next if data == "[DONE]"
+
+        begin
+          json = JSON.parse(data, symbolize_names: true)
+          content = extract_content(json)
+          yield content if content.present?
+        rescue JSON::ParserError
+          yield data if data.present?
         end
       end
     end
 
     def extract_content(json)
-      # OpenAI streaming format
       json.dig(:choices, 0, :delta, :content) ||
         json.dig(:choices, 0, :message, :content) ||
         json[:content] ||
@@ -424,11 +511,15 @@ module CollavreOpenclaw
 
     def build_connection
       Faraday.new do |builder|
-        builder.options.timeout = CollavreOpenclaw.config.read_timeout      # Read timeout (3 min default)
-        builder.options.open_timeout = CollavreOpenclaw.config.open_timeout # Connection timeout (10s)
+        builder.options.timeout = CollavreOpenclaw.config.read_timeout
+        builder.options.open_timeout = CollavreOpenclaw.config.open_timeout
         builder.adapter Faraday.default_adapter
       end
     end
+
+    # ─────────────────────────────────────────────
+    # Helpers
+    # ─────────────────────────────────────────────
 
     def extract_id(context, key)
       value = context[key] || context[key.to_s]
@@ -438,12 +529,8 @@ module CollavreOpenclaw
       value[:id] || value["id"]
     end
 
-    # Extract agent_id from user email
-    # e.g., "ai-agent@collavre.com" -> "ai-agent"
     def extract_agent_id_from_email
       return nil unless @user&.email.present?
-
-      # Extract local part (before @) from email
       @user.email.split("@").first
     end
 
@@ -458,7 +545,6 @@ module CollavreOpenclaw
       result = { host: host }
       result[:protocol] = options[:protocol] || "https"
       result[:port] = options[:port] if options[:port].present?
-
       result
     end
   end

--- a/engines/collavre_openclaw/app/services/collavre_openclaw/openclaw_adapter.rb
+++ b/engines/collavre_openclaw/app/services/collavre_openclaw/openclaw_adapter.rb
@@ -97,7 +97,11 @@ module CollavreOpenclaw
               yield event[:text] if block_given?
             end
           when "final"
-            # Final event may contain full text; delta already streamed it
+            # If no deltas were streamed, final contains the full text
+            if response_content.blank? && event[:text].present?
+              response_content << event[:text]
+              yield event[:text] if block_given?
+            end
           when "error"
             error_msg = event[:text] || "Unknown error"
             yield "OpenClaw Error: #{error_msg}" if block_given?

--- a/engines/collavre_openclaw/app/services/collavre_openclaw/openclaw_adapter.rb
+++ b/engines/collavre_openclaw/app/services/collavre_openclaw/openclaw_adapter.rb
@@ -162,8 +162,9 @@ module CollavreOpenclaw
     # (no prior assistant messages in the conversation history).
     def first_message_in_session?(messages)
       messages.none? do |m|
-        role = m[:role] || m["role"]
-        role.to_s == "assistant"
+        role = (m[:role] || m["role"]).to_s
+        # "model" is used by some providers (e.g. Gemini) as an alias for "assistant"
+        role == "assistant" || role == "model"
       end
     end
 

--- a/engines/collavre_openclaw/app/services/collavre_openclaw/openclaw_adapter.rb
+++ b/engines/collavre_openclaw/app/services/collavre_openclaw/openclaw_adapter.rb
@@ -70,10 +70,12 @@ module CollavreOpenclaw
     # ─────────────────────────────────────────────
 
     def websocket_available?
-      # WebSocket is available when ConnectionManager and WebsocketClient are loaded
-      defined?(ConnectionManager) && defined?(WebsocketClient)
-    rescue => e
-      Rails.logger.debug("[CollavreOpenclaw] WebSocket not available: #{e.message}")
+      # Resolve via the module namespace to trigger Rails autoloading.
+      # `defined?` alone does not autoload in dev/test (lazy mode).
+      CollavreOpenclaw::ConnectionManager &&
+        CollavreOpenclaw::WebsocketClient &&
+        true
+    rescue NameError
       false
     end
 
@@ -130,7 +132,7 @@ module CollavreOpenclaw
 
     # Format messages for WebSocket chat.send (single message string).
     # Gateway manages session history, so we only send the latest user message
-    # with optional context prefix.
+    # with optional context prefix on the FIRST message only.
     def format_message_for_ws(messages)
       formatted = Array(messages)
 
@@ -144,14 +146,24 @@ module CollavreOpenclaw
 
       text = extract_message_text(last_user)
 
-      # If there's a system prompt and this is the first message in a new session,
-      # prepend context. The Gateway may already have agent config with system prompt,
-      # but we include creative context here for completeness.
-      context_prefix = build_context_prefix(formatted)
-      if context_prefix.present?
-        "#{context_prefix}\n\n#{text}"
-      else
-        text.to_s
+      # Only prepend creative context on the first message in a session.
+      # If there are prior assistant replies, the Gateway already has context.
+      if first_message_in_session?(formatted)
+        context_prefix = build_context_prefix(formatted)
+        if context_prefix.present?
+          return "#{context_prefix}\n\n#{text}"
+        end
+      end
+
+      text.to_s
+    end
+
+    # Returns true when this looks like the first exchange in a session
+    # (no prior assistant messages in the conversation history).
+    def first_message_in_session?(messages)
+      messages.none? do |m|
+        role = m[:role] || m["role"]
+        role.to_s == "assistant"
       end
     end
 

--- a/engines/collavre_openclaw/app/services/collavre_openclaw/openclaw_adapter.rb
+++ b/engines/collavre_openclaw/app/services/collavre_openclaw/openclaw_adapter.rb
@@ -34,9 +34,11 @@ module CollavreOpenclaw
         return nil
       end
 
-      # Try WebSocket first, fall back to HTTP
-      if websocket_available?
-        chat_via_websocket(messages, tools: tools, &block)
+      # Try WebSocket first, fall back to HTTP.
+      # When tools are provided, always use HTTP because the WS protocol
+      # does not support passing tool/function schemas to the Gateway.
+      if websocket_available? && Array(tools).empty?
+        chat_via_websocket(messages, &block)
       else
         chat_via_http(messages, tools: tools, &block)
       end

--- a/engines/collavre_openclaw/app/services/collavre_openclaw/openclaw_adapter.rb
+++ b/engines/collavre_openclaw/app/services/collavre_openclaw/openclaw_adapter.rb
@@ -20,7 +20,7 @@ module CollavreOpenclaw
       @context = context
     end
 
-    def chat(messages, tools: [], &block)
+    def chat(messages, &block)
       unless @user&.gateway_url.present?
         Rails.logger.error("[CollavreOpenclaw] No Gateway URL configured for user #{@user&.id}")
         yield "Error: OpenClaw Gateway URL not configured" if block_given?
@@ -34,13 +34,11 @@ module CollavreOpenclaw
         return nil
       end
 
-      # Try WebSocket first, fall back to HTTP.
-      # When tools are provided, always use HTTP because the WS protocol
-      # does not support passing tool/function schemas to the Gateway.
-      if websocket_available? && Array(tools).empty?
+      # Try WebSocket first, fall back to HTTP
+      if websocket_available?
         chat_via_websocket(messages, &block)
       else
-        chat_via_http(messages, tools: tools, &block)
+        chat_via_http(messages, &block)
       end
     end
 
@@ -81,7 +79,7 @@ module CollavreOpenclaw
       false
     end
 
-    def chat_via_websocket(messages, tools: [], &block)
+    def chat_via_websocket(messages, &block)
       response_content = +""
 
       begin
@@ -118,7 +116,7 @@ module CollavreOpenclaw
       rescue CollavreOpenclaw::ConnectionError,
              CollavreOpenclaw::TimeoutError => e
         Rails.logger.warn("[CollavreOpenclaw] WebSocket failed, falling back to HTTP: #{e.message}")
-        chat_via_http(messages, tools: tools, &block)
+        chat_via_http(messages, &block)
       rescue CollavreOpenclaw::ChatError, CollavreOpenclaw::RpcError => e
         Rails.logger.error("[CollavreOpenclaw] WebSocket chat error: #{e.message}")
         error_msg = "OpenClaw Error: #{e.message}"
@@ -128,7 +126,7 @@ module CollavreOpenclaw
         Rails.logger.error("[CollavreOpenclaw] WebSocket unexpected error: #{e.message}\n" \
                            "#{e.backtrace.first(5).join("\n")}")
         Rails.logger.info("[CollavreOpenclaw] Falling back to HTTP")
-        chat_via_http(messages, tools: tools, &block)
+        chat_via_http(messages, &block)
       end
     end
 
@@ -199,11 +197,11 @@ module CollavreOpenclaw
     # HTTP transport (fallback)
     # ─────────────────────────────────────────────
 
-    def chat_via_http(messages, tools: [], &block)
+    def chat_via_http(messages, &block)
       response_content = +""
 
       begin
-        payload = build_payload(messages, tools)
+        payload = build_payload(messages)
 
         Rails.logger.info("[CollavreOpenclaw] Sending via HTTP to #{api_endpoint} (session: #{session_key})")
 
@@ -251,7 +249,7 @@ module CollavreOpenclaw
     # HTTP payload building
     # ─────────────────────────────────────────────
 
-    def build_payload(messages, tools)
+    def build_payload(messages)
       agent_id = extract_agent_id_from_email
       model_value = agent_id.present? ? "openclaw:#{agent_id}" : "openclaw"
 
@@ -265,76 +263,8 @@ module CollavreOpenclaw
         payload[:messages].unshift({ role: "system", content: @system_prompt })
       end
 
-      payload[:tools] = format_tools(tools) if tools.present?
       payload[:user] = build_user_context
       payload
-    end
-
-    def format_tools(tools)
-      Array(tools).filter_map do |tool|
-        if tool.is_a?(String)
-          convert_tool_name_to_openai_format(tool)
-        elsif tool.is_a?(Hash)
-          if tool[:type] == "function" || tool["type"] == "function"
-            tool
-          else
-            convert_mcp_tool_to_openai_format(tool)
-          end
-        end
-      end.compact
-    end
-
-    def convert_tool_name_to_openai_format(tool_name)
-      return nil unless defined?(::Tools::MetaToolService)
-
-      result = ::Tools::MetaToolService.new.call(
-        action: "get", tool_name: tool_name, query: nil, arguments: nil
-      )
-      return nil if result[:error] || result[:tool].nil?
-
-      convert_mcp_tool_to_openai_format(result[:tool])
-    rescue StandardError => e
-      Rails.logger.warn("[CollavreOpenclaw] Failed to fetch tool #{tool_name}: #{e.message}")
-      nil
-    end
-
-    def convert_mcp_tool_to_openai_format(mcp_tool)
-      name = mcp_tool[:name] || mcp_tool["name"]
-      description = mcp_tool[:description] || mcp_tool["description"]
-      params = mcp_tool[:params] || mcp_tool["params"] ||
-               mcp_tool[:parameters] || mcp_tool["parameters"] || []
-
-      properties = {}
-      required = []
-
-      Array(params).each do |param|
-        param_name = (param[:name] || param["name"]).to_s
-        param_type = param[:type] || param["type"] || "string"
-        param_desc = param[:description] || param["description"]
-        param_required = param[:required] || param["required"]
-
-        json_type = case param_type.to_s.downcase
-        when "integer", "int" then "integer"
-        when "number", "float", "decimal" then "number"
-        when "boolean", "bool" then "boolean"
-        when "array" then "array"
-        when "object", "hash" then "object"
-        else "string"
-        end
-
-        properties[param_name] = { type: json_type }
-        properties[param_name][:description] = param_desc if param_desc.present?
-        required << param_name if param_required
-      end
-
-      {
-        type: "function",
-        function: {
-          name: name,
-          description: description || "",
-          parameters: { type: "object", properties: properties, required: required }
-        }
-      }
     end
 
     def build_user_context

--- a/engines/collavre_openclaw/app/services/collavre_openclaw/websocket_client.rb
+++ b/engines/collavre_openclaw/app/services/collavre_openclaw/websocket_client.rb
@@ -92,18 +92,28 @@ module CollavreOpenclaw
       touch_activity!
 
       idempotency_key ||= SecureRandom.uuid
+      actual_run_id = nil
       run_queue = Queue.new
       response_text = +""
 
-      # Register event handler for this run
+      # Pre-register with idempotency_key to catch early events
       @mutex.synchronize { @pending_runs[idempotency_key] = run_queue }
 
-      # Send the RPC request
-      _response = send_rpc("chat.send", {
+      # Send the RPC request to get the real runId
+      response = send_rpc("chat.send", {
         sessionKey: session_key,
         message: message,
         idempotencyKey: idempotency_key
       })
+
+      # Re-register with the Gateway-assigned runId
+      actual_run_id = response&.dig(:runId) || idempotency_key
+      if actual_run_id != idempotency_key
+        @mutex.synchronize do
+          @pending_runs.delete(idempotency_key)
+          @pending_runs[actual_run_id] = run_queue
+        end
+      end
 
       # Stream events until final/error/aborted
       loop do
@@ -138,7 +148,7 @@ module CollavreOpenclaw
 
       response_text.presence
     ensure
-      @mutex.synchronize { @pending_runs.delete(idempotency_key) }
+      @mutex.synchronize { @pending_runs.delete(actual_run_id) }
     end
 
     # Fetch chat history for a session
@@ -359,9 +369,13 @@ module CollavreOpenclaw
       cancel_tick_timer!
       interval = @tick_interval_ms / 1000.0
       @tick_timer = EM.add_periodic_timer(interval) do
-        # Gateway expects periodic poll; if the server doesn't send ticks,
-        # we send our own poll to keep the connection alive.
-        # The actual tick handling is in handle_tick when the server pushes.
+        # Send keepalive poll if the server hasn't sent a tick
+        send_frame({
+          type: "req",
+          id: SecureRandom.uuid,
+          method: "poll",
+          params: {}
+        })
       end
     end
 
@@ -432,11 +446,14 @@ module CollavreOpenclaw
           queue = Queue.new
           do_connect!(queue)
 
-          # Wait for handshake in EM thread via a deferred check
+          # Handshake result is handled by handle_response which sets @state.
+          # Add a timeout to retry if handshake doesn't complete.
           EM.add_timer(config.ws_connect_timeout) do
             unless @handshake_done
               @handshake_done = true
-              queue.push({ error: "reconnect handshake timeout" })
+              Rails.logger.warn("[CollavreOpenclaw::WS] Reconnect handshake timed out")
+              @ws&.close
+              schedule_reconnect!
             end
           end
         rescue => e
@@ -467,12 +484,9 @@ module CollavreOpenclaw
     end
 
     def wait_with_timeout(queue, timeout_seconds, operation)
-      result = nil
-      begin
-        Timeout.timeout(timeout_seconds) do
-          result = queue.pop
-        end
-      rescue Timeout::Error
+      # Use Queue#pop(timeout:) instead of Timeout.timeout to avoid Thread.raise corruption
+      result = queue.pop(timeout: timeout_seconds)
+      if result.nil? && queue.empty?
         raise TimeoutError, "#{operation} timed out after #{timeout_seconds}s"
       end
       result

--- a/engines/collavre_openclaw/app/services/collavre_openclaw/websocket_client.rb
+++ b/engines/collavre_openclaw/app/services/collavre_openclaw/websocket_client.rb
@@ -1,0 +1,479 @@
+require "faye/websocket"
+require "json"
+require "securerandom"
+
+module CollavreOpenclaw
+  # WebSocket client for a single user's OpenClaw Gateway connection.
+  #
+  # Handles:
+  # - Connection lifecycle (connect, disconnect, reconnect)
+  # - OpenClaw protocol handshake (connect.challenge → connect → hello-ok)
+  # - RPC request/response (chat.send, chat.history, chat.abort)
+  # - Event streaming (chat events with delta/final/error states)
+  # - Proactive message detection (unsolicited chat events)
+  # - Tick keepalive
+  #
+  # Thread model:
+  # - WebSocket runs in the shared EventMachine reactor thread
+  # - Rails threads call public methods which bridge via EM.next_tick + Queue
+  class WebsocketClient
+    PROTOCOL_VERSION = 3
+
+    attr_reader :user, :state
+
+    # States: :disconnected, :connecting, :connected, :reconnecting
+    def initialize(user:)
+      @user = user
+      @state = :disconnected
+      @ws = nil
+      @mutex = Mutex.new
+      @pending_requests = {}  # id → { queue:, timer: }
+      @pending_runs = {}      # runId → Queue (for chat.send streaming)
+      @proactive_handler = nil
+      @reconnect_attempts = 0
+      @last_activity_at = nil
+      @tick_interval_ms = 15_000
+      @tick_timer = nil
+    end
+
+    def connected?
+      @state == :connected
+    end
+
+    # Connect to the Gateway. Blocks until connected or raises on failure.
+    def connect!
+      return if connected?
+
+      queue = Queue.new
+
+      EmReactor.next_tick do
+        begin
+          do_connect!(queue)
+        rescue => e
+          queue.push({ error: e.message })
+        end
+      end
+
+      result = wait_with_timeout(queue, config.ws_connect_timeout, "connect")
+      if result[:error]
+        raise ConnectionError, result[:error]
+      end
+
+      @state = :connected
+      @reconnect_attempts = 0
+      touch_activity!
+      result
+    end
+
+    # Disconnect gracefully
+    def disconnect!
+      @state = :disconnected
+      EmReactor.next_tick do
+        cancel_tick_timer!
+        @ws&.close
+        @ws = nil
+      end
+      # Unblock any waiting requests
+      @pending_requests.each_value { |pr| pr[:queue]&.push({ error: "disconnected" }) }
+      @pending_requests.clear
+      @pending_runs.each_value { |q| q.push({ done: true }) }
+      @pending_runs.clear
+    end
+
+    # Send a chat message. Blocks and yields streaming events.
+    #
+    # @param session_key [String]
+    # @param message [String]
+    # @param idempotency_key [String]
+    # @yield [Hash] chat events with :state, :text, :message keys
+    # @return [String, nil] final response text
+    def chat_send(session_key:, message:, idempotency_key: nil, &block)
+      ensure_connected!
+      touch_activity!
+
+      idempotency_key ||= SecureRandom.uuid
+      run_queue = Queue.new
+      response_text = +""
+
+      # Register event handler for this run
+      @mutex.synchronize { @pending_runs[idempotency_key] = run_queue }
+
+      # Send the RPC request
+      _response = send_rpc("chat.send", {
+        sessionKey: session_key,
+        message: message,
+        idempotencyKey: idempotency_key
+      })
+
+      # Stream events until final/error/aborted
+      loop do
+        event = wait_with_timeout(run_queue, config.read_timeout, "chat response")
+
+        break if event[:done]
+
+        if event[:error]
+          raise ChatError, event[:error]
+        end
+
+        case event[:state]
+        when "delta"
+          text = extract_event_text(event)
+          if text.present?
+            response_text << text
+            yield({ state: "delta", text: text }) if block_given?
+          end
+        when "final"
+          text = extract_event_text(event)
+          yield({ state: "final", text: text, message: event[:message] }) if block_given?
+          break
+        when "error"
+          error_msg = event[:errorMessage] || "Unknown error"
+          yield({ state: "error", text: error_msg }) if block_given?
+          raise ChatError, error_msg
+        when "aborted"
+          yield({ state: "aborted" }) if block_given?
+          break
+        end
+      end
+
+      response_text.presence
+    ensure
+      @mutex.synchronize { @pending_runs.delete(idempotency_key) }
+    end
+
+    # Fetch chat history for a session
+    def chat_history(session_key:, limit: nil)
+      ensure_connected!
+      touch_activity!
+
+      params = { sessionKey: session_key }
+      params[:limit] = limit if limit
+      send_rpc("chat.history", params)
+    end
+
+    # Abort a running chat
+    def chat_abort(session_key:, run_id: nil)
+      ensure_connected!
+      touch_activity!
+
+      params = { sessionKey: session_key }
+      params[:runId] = run_id if run_id
+      send_rpc("chat.abort", params)
+    end
+
+    # Register a handler for proactive messages (unsolicited chat events)
+    def on_proactive_message(&handler)
+      @proactive_handler = handler
+    end
+
+    # Time since last activity (for idle timeout)
+    def idle_seconds
+      return Float::INFINITY unless @last_activity_at
+      Process.clock_gettime(Process::CLOCK_MONOTONIC) - @last_activity_at
+    end
+
+    private
+
+    def config
+      CollavreOpenclaw.config
+    end
+
+    def gateway_ws_url
+      url = @user.gateway_url.to_s.strip
+      return nil if url.blank?
+
+      uri = URI.parse(url)
+      # Convert http(s) to ws(s)
+      case uri.scheme
+      when "https" then uri.scheme = "wss"
+      when "http"  then uri.scheme = "ws"
+      when "ws", "wss" then # already correct
+      else
+        uri.scheme = "ws"
+      end
+      uri.path = "/" if uri.path.blank?
+      uri.to_s
+    end
+
+    def do_connect!(result_queue)
+      url = gateway_ws_url
+      unless url.present?
+        result_queue.push({ error: "No Gateway URL configured" })
+        return
+      end
+
+      @ws = Faye::WebSocket::Client.new(url)
+      @handshake_queue = result_queue
+      @handshake_done = false
+
+      @ws.on :open do |_event|
+        Rails.logger.info("[CollavreOpenclaw::WS] Connected to #{url}")
+        # Wait for connect.challenge from gateway
+      end
+
+      @ws.on :message do |event|
+        handle_raw_message(event.data)
+      end
+
+      @ws.on :close do |event|
+        code = event.code
+        reason = event.reason
+        Rails.logger.info("[CollavreOpenclaw::WS] Disconnected (code=#{code}, reason=#{reason})")
+
+        cancel_tick_timer!
+
+        unless @handshake_done
+          @handshake_done = true
+          @handshake_queue&.push({ error: "Connection closed during handshake (code=#{code})" })
+        end
+
+        if @state == :connected
+          @state = :reconnecting
+          schedule_reconnect!
+        end
+      end
+    end
+
+    def handle_raw_message(data)
+      frame = JSON.parse(data, symbolize_names: true)
+
+      case frame[:type]
+      when "event"
+        handle_event(frame[:event], frame[:payload])
+      when "res"
+        handle_response(frame[:id], frame[:ok], frame[:payload], frame[:error])
+      end
+    rescue JSON::ParserError => e
+      Rails.logger.warn("[CollavreOpenclaw::WS] Invalid JSON: #{e.message}")
+    end
+
+    def handle_event(event_name, payload)
+      case event_name
+      when "connect.challenge"
+        # Respond with connect request
+        send_connect_request(payload)
+      when "chat"
+        handle_chat_event(payload)
+      when "tick"
+        handle_tick(payload)
+      end
+    end
+
+    def send_connect_request(challenge_payload)
+      agent_id = extract_agent_id
+      device_id = "collavre-#{@user.id}-#{Digest::SHA256.hexdigest(@user.id.to_s)[0..7]}"
+
+      params = {
+        minProtocol: PROTOCOL_VERSION,
+        maxProtocol: PROTOCOL_VERSION,
+        client: {
+          id: "collavre",
+          version: CollavreOpenclaw::VERSION,
+          platform: "ruby",
+          mode: "operator"
+        },
+        role: "operator",
+        scopes: [ "operator.read", "operator.write" ],
+        caps: [],
+        commands: [],
+        permissions: {},
+        auth: { token: @user.llm_api_key },
+        locale: "en-US",
+        userAgent: "collavre-openclaw/#{CollavreOpenclaw::VERSION}",
+        device: {
+          id: device_id
+        }
+      }
+
+      request_id = SecureRandom.uuid
+      send_frame({
+        type: "req",
+        id: request_id,
+        method: "connect",
+        params: params
+      })
+
+      # Store the request so hello-ok resolves the handshake
+      @connect_request_id = request_id
+    end
+
+    def handle_response(id, ok, payload, error)
+      # Check if this is the connect handshake response
+      if id == @connect_request_id && !@handshake_done
+        @handshake_done = true
+        if ok
+          @tick_interval_ms = payload&.dig(:policy, :tickIntervalMs) || 15_000
+          start_tick_timer!
+          @handshake_queue&.push({ ok: true, payload: payload })
+        else
+          error_msg = error&.dig(:message) || error.to_s || "handshake failed"
+          @handshake_queue&.push({ error: error_msg })
+        end
+        @handshake_queue = nil
+        return
+      end
+
+      # Regular RPC response
+      pending = @mutex.synchronize { @pending_requests.delete(id) }
+      if pending
+        if ok
+          pending[:queue].push({ ok: true, payload: payload })
+        else
+          error_msg = error&.dig(:message) || error.to_s || "RPC error"
+          pending[:queue].push({ error: error_msg })
+        end
+      end
+    end
+
+    def handle_chat_event(payload)
+      run_id = payload[:runId]
+
+      # Check if this is a response to a pending chat.send
+      run_queue = @mutex.synchronize { @pending_runs[run_id] }
+
+      if run_queue
+        # Known run — forward to the waiting thread
+        run_queue.push(payload)
+      elsif @proactive_handler
+        # Unknown run — proactive message from Gateway (cron/heartbeat)
+        Rails.logger.info("[CollavreOpenclaw::WS] Proactive message received (runId=#{run_id})")
+        @proactive_handler.call(payload)
+      else
+        Rails.logger.debug("[CollavreOpenclaw::WS] Ignoring chat event for unknown runId=#{run_id}")
+      end
+    end
+
+    def handle_tick(_payload)
+      # Respond with a tick acknowledgment (poll response)
+      send_frame({
+        type: "req",
+        id: SecureRandom.uuid,
+        method: "poll",
+        params: {}
+      })
+    end
+
+    def start_tick_timer!
+      cancel_tick_timer!
+      interval = @tick_interval_ms / 1000.0
+      @tick_timer = EM.add_periodic_timer(interval) do
+        # Gateway expects periodic poll; if the server doesn't send ticks,
+        # we send our own poll to keep the connection alive.
+        # The actual tick handling is in handle_tick when the server pushes.
+      end
+    end
+
+    def cancel_tick_timer!
+      @tick_timer&.cancel
+      @tick_timer = nil
+    end
+
+    # Send an RPC request and block until the response.
+    # Returns the response payload.
+    def send_rpc(method, params)
+      request_id = SecureRandom.uuid
+      queue = Queue.new
+
+      @mutex.synchronize do
+        @pending_requests[request_id] = { queue: queue }
+      end
+
+      EmReactor.next_tick do
+        send_frame({
+          type: "req",
+          id: request_id,
+          method: method,
+          params: params
+        })
+      end
+
+      result = wait_with_timeout(queue, config.read_timeout, method)
+      if result[:error]
+        raise RpcError, "#{method} failed: #{result[:error]}"
+      end
+      result[:payload]
+    ensure
+      @mutex.synchronize { @pending_requests.delete(request_id) }
+    end
+
+    def send_frame(frame)
+      return unless @ws
+
+      data = JSON.generate(frame)
+      @ws.send(data)
+    end
+
+    def ensure_connected!
+      unless connected?
+        connect!
+      end
+    end
+
+    def touch_activity!
+      @last_activity_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    end
+
+    def schedule_reconnect!
+      max = config.ws_reconnect_max
+      return if @reconnect_attempts >= max
+
+      @reconnect_attempts += 1
+      delay = config.ws_reconnect_base_delay * (2**(@reconnect_attempts - 1))
+      delay = [ delay, 60 ].min # Cap at 60 seconds
+
+      Rails.logger.info("[CollavreOpenclaw::WS] Reconnecting in #{delay}s (attempt #{@reconnect_attempts}/#{max})")
+
+      EM.add_timer(delay) do
+        next if @state == :disconnected # User explicitly disconnected
+
+        begin
+          queue = Queue.new
+          do_connect!(queue)
+
+          # Wait for handshake in EM thread via a deferred check
+          EM.add_timer(config.ws_connect_timeout) do
+            unless @handshake_done
+              @handshake_done = true
+              queue.push({ error: "reconnect handshake timeout" })
+            end
+          end
+        rescue => e
+          Rails.logger.error("[CollavreOpenclaw::WS] Reconnect failed: #{e.message}")
+          schedule_reconnect!
+        end
+      end
+    end
+
+    def extract_event_text(event)
+      message = event[:message]
+      return nil unless message.is_a?(Hash)
+
+      content = message[:content]
+      case content
+      when String
+        content
+      when Array
+        content.filter_map { |c| c[:text] if c[:type] == "text" }.join
+      else
+        nil
+      end
+    end
+
+    def extract_agent_id
+      return nil unless @user&.email.present?
+      @user.email.split("@").first
+    end
+
+    def wait_with_timeout(queue, timeout_seconds, operation)
+      result = nil
+      begin
+        Timeout.timeout(timeout_seconds) do
+          result = queue.pop
+        end
+      rescue Timeout::Error
+        raise TimeoutError, "#{operation} timed out after #{timeout_seconds}s"
+      end
+      result
+    end
+  end
+end

--- a/engines/collavre_openclaw/app/services/collavre_openclaw/websocket_client.rb
+++ b/engines/collavre_openclaw/app/services/collavre_openclaw/websocket_client.rb
@@ -1,3 +1,4 @@
+require "digest"
 require "faye/websocket"
 require "json"
 require "securerandom"
@@ -301,6 +302,7 @@ module CollavreOpenclaw
     end
 
     def handle_raw_message(data)
+      touch_activity! # Refresh idle timer on any inbound traffic
       frame = JSON.parse(data, symbolize_names: true)
 
       case frame[:type]

--- a/engines/collavre_openclaw/app/services/collavre_openclaw/websocket_client.rb
+++ b/engines/collavre_openclaw/app/services/collavre_openclaw/websocket_client.rb
@@ -83,7 +83,18 @@ module CollavreOpenclaw
         end
       end
 
-      result = wait_with_timeout(queue, config.ws_connect_timeout, "connect")
+      begin
+        result = wait_with_timeout(queue, config.ws_connect_timeout, "connect")
+      rescue TimeoutError, StandardError => e
+        # Timeout or unexpected error — reset state and wake all waiters
+        error_result = { error: e.message }
+        @connect_mutex.synchronize do
+          @state = :disconnected
+          @connect_waiters.each { |q| q.push(error_result) }
+          @connect_waiters.clear
+        end
+        raise ConnectionError, e.message
+      end
 
       # Notify all waiting threads
       @connect_mutex.synchronize do

--- a/engines/collavre_openclaw/app/services/collavre_openclaw/websocket_client.rb
+++ b/engines/collavre_openclaw/app/services/collavre_openclaw/websocket_client.rb
@@ -27,6 +27,7 @@ module CollavreOpenclaw
       @state = :disconnected
       @ws = nil
       @mutex = Mutex.new
+      @connect_mutex = Mutex.new
       @pending_requests = {}  # id → { queue:, timer: }
       @pending_runs = {}      # runId → Queue (for chat.send streaming)
       @proactive_handler = nil
@@ -41,8 +42,17 @@ module CollavreOpenclaw
     end
 
     # Connect to the Gateway. Blocks until connected or raises on failure.
+    # Thread-safe: concurrent callers wait on the same connection attempt.
     def connect!
       return if connected?
+
+      # Serialize connection attempts — only one thread connects at a time
+      @connect_mutex.synchronize do
+        return if connected?
+        return if @state == :connecting
+
+        @state = :connecting
+      end
 
       queue = Queue.new
 
@@ -56,6 +66,7 @@ module CollavreOpenclaw
 
       result = wait_with_timeout(queue, config.ws_connect_timeout, "connect")
       if result[:error]
+        @state = :disconnected
         raise ConnectionError, result[:error]
       end
 

--- a/engines/collavre_openclaw/app/services/collavre_openclaw/websocket_client.rb
+++ b/engines/collavre_openclaw/app/services/collavre_openclaw/websocket_client.rb
@@ -28,6 +28,7 @@ module CollavreOpenclaw
       @ws = nil
       @mutex = Mutex.new
       @connect_mutex = Mutex.new
+      @connect_waiters = []   # Queues for threads waiting on in-progress connect
       @pending_requests = {}  # id → { queue:, timer: }
       @pending_runs = {}      # runId → Queue (for chat.send streaming)
       @proactive_handler = nil
@@ -42,18 +43,36 @@ module CollavreOpenclaw
     end
 
     # Connect to the Gateway. Blocks until connected or raises on failure.
-    # Thread-safe: concurrent callers wait on the same connection attempt.
+    # Thread-safe: concurrent callers all wait on the same handshake attempt.
     def connect!
       return if connected?
 
-      # Serialize connection attempts — only one thread connects at a time
+      initiator = false
+      waiter_queue = nil
+
       @connect_mutex.synchronize do
         return if connected?
-        return if @state == :connecting
 
-        @state = :connecting
+        if @state == :connecting
+          # Another thread is already connecting — wait on the same handshake
+          waiter_queue = Queue.new
+          @connect_waiters << waiter_queue
+        else
+          @state = :connecting
+          initiator = true
+        end
       end
 
+      if waiter_queue
+        # Wait for the initiating thread to finish handshake
+        result = wait_with_timeout(waiter_queue, config.ws_connect_timeout, "connect (waiting)")
+        if result[:error]
+          raise ConnectionError, result[:error]
+        end
+        return result
+      end
+
+      # This thread initiates the connection
       queue = Queue.new
 
       EmReactor.next_tick do
@@ -65,14 +84,25 @@ module CollavreOpenclaw
       end
 
       result = wait_with_timeout(queue, config.ws_connect_timeout, "connect")
+
+      # Notify all waiting threads
+      @connect_mutex.synchronize do
+        if result[:error]
+          @state = :disconnected
+        else
+          @state = :connected
+          @reconnect_attempts = 0
+          touch_activity!
+        end
+
+        @connect_waiters.each { |q| q.push(result) }
+        @connect_waiters.clear
+      end
+
       if result[:error]
-        @state = :disconnected
         raise ConnectionError, result[:error]
       end
 
-      @state = :connected
-      @reconnect_attempts = 0
-      touch_activity!
       result
     end
 
@@ -159,7 +189,11 @@ module CollavreOpenclaw
 
       response_text.presence
     ensure
-      @mutex.synchronize { @pending_runs.delete(actual_run_id) }
+      @mutex.synchronize do
+        @pending_runs.delete(actual_run_id) if actual_run_id
+        # Also clean up idempotency_key if send_rpc failed before we got a runId
+        @pending_runs.delete(idempotency_key) if idempotency_key
+      end
     end
 
     # Fetch chat history for a session

--- a/engines/collavre_openclaw/app/services/collavre_openclaw/websocket_client.rb
+++ b/engines/collavre_openclaw/app/services/collavre_openclaw/websocket_client.rb
@@ -303,6 +303,8 @@ module CollavreOpenclaw
         @handshake_done = true
         if ok
           @tick_interval_ms = payload&.dig(:policy, :tickIntervalMs) || 15_000
+          @state = :connected
+          @reconnect_attempts = 0
           start_tick_timer!
           @handshake_queue&.push({ ok: true, payload: payload })
         else

--- a/engines/collavre_openclaw/collavre_openclaw.gemspec
+++ b/engines/collavre_openclaw/collavre_openclaw.gemspec
@@ -19,4 +19,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rails", ">= 8.0"
   spec.add_dependency "faraday", ">= 2.0"
+  spec.add_dependency "faye-websocket", "~> 0.11"
+  spec.add_dependency "eventmachine", "~> 1.2"
 end

--- a/engines/collavre_openclaw/lib/collavre_openclaw.rb
+++ b/engines/collavre_openclaw/lib/collavre_openclaw.rb
@@ -1,5 +1,6 @@
 require "collavre_openclaw/version"
 require "collavre_openclaw/configuration"
+require "collavre_openclaw/errors"
 require "collavre_openclaw/engine"
 
 module CollavreOpenclaw

--- a/engines/collavre_openclaw/lib/collavre_openclaw/configuration.rb
+++ b/engines/collavre_openclaw/lib/collavre_openclaw/configuration.rb
@@ -10,10 +10,26 @@ module CollavreOpenclaw
     # Max retries for transient failures
     attr_accessor :max_retries
 
+    # WebSocket idle timeout (seconds) - disconnect after inactivity
+    attr_accessor :ws_idle_timeout
+
+    # WebSocket max reconnect attempts before giving up
+    attr_accessor :ws_reconnect_max
+
+    # WebSocket reconnect base delay (seconds) - exponential backoff base
+    attr_accessor :ws_reconnect_base_delay
+
+    # WebSocket connect timeout (seconds)
+    attr_accessor :ws_connect_timeout
+
     def initialize
       @open_timeout = ENV.fetch("OPENCLAW_OPEN_TIMEOUT", 10).to_i
       @read_timeout = ENV.fetch("OPENCLAW_READ_TIMEOUT", 180).to_i  # 3 minutes for AI responses
       @max_retries = ENV.fetch("OPENCLAW_MAX_RETRIES", 2).to_i
+      @ws_idle_timeout = ENV.fetch("OPENCLAW_WS_IDLE_TIMEOUT", 1800).to_i     # 30 minutes
+      @ws_reconnect_max = ENV.fetch("OPENCLAW_WS_RECONNECT_MAX", 10).to_i
+      @ws_reconnect_base_delay = ENV.fetch("OPENCLAW_WS_RECONNECT_BASE", 1).to_f
+      @ws_connect_timeout = ENV.fetch("OPENCLAW_WS_CONNECT_TIMEOUT", 10).to_i
     end
 
     # Legacy accessor for backward compatibility

--- a/engines/collavre_openclaw/lib/collavre_openclaw/engine.rb
+++ b/engines/collavre_openclaw/lib/collavre_openclaw/engine.rb
@@ -40,5 +40,15 @@ module CollavreOpenclaw
         end
       end
     end
+
+    # Graceful shutdown: disconnect all WebSocket connections
+    config.after_initialize do
+      at_exit do
+        ConnectionManager.instance.disconnect_all
+        EmReactor.stop! if EmReactor.running?
+      rescue => e
+        Rails.logger.warn("[CollavreOpenclaw] Shutdown cleanup error: #{e.message}")
+      end
+    end
   end
 end

--- a/engines/collavre_openclaw/lib/collavre_openclaw/errors.rb
+++ b/engines/collavre_openclaw/lib/collavre_openclaw/errors.rb
@@ -1,0 +1,6 @@
+module CollavreOpenclaw
+  class ConnectionError < StandardError; end
+  class RpcError < StandardError; end
+  class ChatError < StandardError; end
+  class TimeoutError < StandardError; end
+end

--- a/engines/collavre_openclaw/test/lib/configuration_test.rb
+++ b/engines/collavre_openclaw/test/lib/configuration_test.rb
@@ -9,6 +9,11 @@ module CollavreOpenclaw
       assert_equal 2, config.max_retries
       # Legacy accessor
       assert_equal 180, config.request_timeout
+      # WebSocket defaults
+      assert_equal 1800, config.ws_idle_timeout
+      assert_equal 10, config.ws_reconnect_max
+      assert_equal 1.0, config.ws_reconnect_base_delay
+      assert_equal 10, config.ws_connect_timeout
     end
 
     test "allows setting timeouts" do

--- a/engines/collavre_openclaw/test/services/connection_manager_test.rb
+++ b/engines/collavre_openclaw/test/services/connection_manager_test.rb
@@ -78,6 +78,18 @@ module CollavreOpenclaw
       assert_equal 0, manager.connected_count
     end
 
+    test "on_proactive_message applies handler to new connections" do
+      manager = ConnectionManager.instance
+      handler_called = false
+
+      manager.on_proactive_message { |_msg| handler_called = true }
+
+      # New connection created AFTER handler registration should have it
+      user = mock_user(id: 1)
+      client = manager.connection_for(user)
+      assert client.instance_variable_get(:@proactive_handler), "Handler should be set on new client"
+    end
+
     private
 
     def mock_user(id:)

--- a/engines/collavre_openclaw/test/services/connection_manager_test.rb
+++ b/engines/collavre_openclaw/test/services/connection_manager_test.rb
@@ -1,0 +1,92 @@
+require "test_helper"
+
+module CollavreOpenclaw
+  class ConnectionManagerTest < ActiveSupport::TestCase
+    setup do
+      # Reset singleton state
+      manager = ConnectionManager.instance
+      manager.disconnect_all
+    end
+
+    test "connection_for creates a new client" do
+      user = mock_user(id: 1)
+      manager = ConnectionManager.instance
+
+      client = manager.connection_for(user)
+      assert_instance_of WebsocketClient, client
+      assert_equal :disconnected, client.state
+    end
+
+    test "connection_for reuses existing client" do
+      user = mock_user(id: 1)
+      manager = ConnectionManager.instance
+
+      client1 = manager.connection_for(user)
+      client2 = manager.connection_for(user)
+      assert_same client1, client2
+    end
+
+    test "connection_for creates separate clients for different users" do
+      user1 = mock_user(id: 1)
+      user2 = mock_user(id: 2)
+      manager = ConnectionManager.instance
+
+      client1 = manager.connection_for(user1)
+      client2 = manager.connection_for(user2)
+      refute_same client1, client2
+    end
+
+    test "disconnect removes user connection" do
+      user = mock_user(id: 1)
+      manager = ConnectionManager.instance
+
+      manager.connection_for(user)
+      manager.disconnect(user)
+
+      # Next call should create a new client
+      new_client = manager.connection_for(user)
+      assert_equal :disconnected, new_client.state
+    end
+
+    test "disconnect_all clears all connections" do
+      user1 = mock_user(id: 1)
+      user2 = mock_user(id: 2)
+      manager = ConnectionManager.instance
+
+      manager.connection_for(user1)
+      manager.connection_for(user2)
+      manager.disconnect_all
+
+      status = manager.status
+      assert_equal 0, status[:total]
+    end
+
+    test "status returns connection counts" do
+      user = mock_user(id: 1)
+      manager = ConnectionManager.instance
+
+      manager.connection_for(user)
+      status = manager.status
+
+      assert_equal 0, status[:connected]
+      assert_equal 1, status[:disconnected]
+      assert_equal 1, status[:total]
+    end
+
+    test "connected_count returns zero when no connections" do
+      manager = ConnectionManager.instance
+      assert_equal 0, manager.connected_count
+    end
+
+    private
+
+    def mock_user(id:)
+      OpenStruct.new(
+        id: id,
+        gateway_url: "http://localhost:18789",
+        llm_api_key: "test-token",
+        email: "agent-#{id}@collavre.com"
+      )
+    end
+  end
+end

--- a/engines/collavre_openclaw/test/services/em_reactor_test.rb
+++ b/engines/collavre_openclaw/test/services/em_reactor_test.rb
@@ -1,0 +1,42 @@
+require "test_helper"
+require "eventmachine"
+
+module CollavreOpenclaw
+  class EmReactorTest < ActiveSupport::TestCase
+    teardown do
+      EmReactor.stop! if EmReactor.running?
+    end
+
+    test "starts reactor in background thread" do
+      EmReactor.ensure_running!
+      assert EmReactor.running?
+    end
+
+    test "ensure_running is idempotent" do
+      EmReactor.ensure_running!
+      EmReactor.ensure_running!
+      assert EmReactor.running?
+    end
+
+    test "stop shuts down reactor" do
+      EmReactor.ensure_running!
+      assert EmReactor.running?
+
+      EmReactor.stop!
+      # Give it a moment to shut down
+      sleep 0.1
+      refute EmReactor.running?
+    end
+
+    test "next_tick schedules work in reactor" do
+      result = Queue.new
+
+      EmReactor.next_tick do
+        result.push(Thread.current.name)
+      end
+
+      thread_name = result.pop
+      assert_equal "openclaw-em-reactor", thread_name
+    end
+  end
+end

--- a/engines/collavre_openclaw/test/services/openclaw_adapter_test.rb
+++ b/engines/collavre_openclaw/test/services/openclaw_adapter_test.rb
@@ -464,7 +464,7 @@ module CollavreOpenclaw
       assert_equal "Follow-up question", result
     end
 
-    test "format_message_for_ws includes creative context" do
+    test "format_message_for_ws includes creative context on first message" do
       user = build_test_user(gateway_url: "https://test-gateway.com", email: "test@example.com")
 
       adapter = OpenclawAdapter.new(
@@ -473,6 +473,7 @@ module CollavreOpenclaw
         context: {}
       )
 
+      # First message in session — no assistant replies yet
       messages = [
         { role: "user", parts: [ { text: "Creative:\n# My Project" } ] },
         { role: "user", parts: [ { text: "What do you think?" } ] }
@@ -481,6 +482,28 @@ module CollavreOpenclaw
       result = adapter.send(:format_message_for_ws, messages)
       assert_includes result, "Creative:\n# My Project"
       assert_includes result, "What do you think?"
+    end
+
+    test "format_message_for_ws does NOT repeat creative context on follow-up messages" do
+      user = build_test_user(gateway_url: "https://test-gateway.com", email: "test@example.com")
+
+      adapter = OpenclawAdapter.new(
+        user: user,
+        system_prompt: "Test",
+        context: {}
+      )
+
+      # Follow-up — assistant has already replied, so context was sent before
+      messages = [
+        { role: "user", parts: [ { text: "Creative:\n# My Project" } ] },
+        { role: "user", parts: [ { text: "First question" } ] },
+        { role: "assistant", parts: [ { text: "Here's my answer" } ] },
+        { role: "user", parts: [ { text: "Follow-up question" } ] }
+      ]
+
+      result = adapter.send(:format_message_for_ws, messages)
+      assert_equal "Follow-up question", result
+      assert_not_includes result, "Creative:"
     end
 
     test "format_message_for_ws returns empty string for no user messages" do

--- a/engines/collavre_openclaw/test/services/openclaw_adapter_test.rb
+++ b/engines/collavre_openclaw/test/services/openclaw_adapter_test.rb
@@ -33,7 +33,7 @@ module CollavreOpenclaw
         { role: "model", parts: [ { text: "Hi there!" } ] }
       ]
 
-      payload = adapter.send(:build_payload, messages, [])
+      payload = adapter.send(:build_payload, messages)
 
       # System prompt is added as first message
       assert_equal 3, payload[:messages].length
@@ -59,7 +59,7 @@ module CollavreOpenclaw
 
       messages = [ { role: "user", content: "Hello" } ]
 
-      payload = adapter.send(:build_payload, messages, [])
+      payload = adapter.send(:build_payload, messages)
 
       assert_equal "openclaw:ai-bot", payload[:model]
     end
@@ -75,7 +75,7 @@ module CollavreOpenclaw
 
       messages = [ { role: "user", content: "Hello" } ]
 
-      payload = adapter.send(:build_payload, messages, [])
+      payload = adapter.send(:build_payload, messages)
 
       assert_equal "openclaw", payload[:model]
     end
@@ -287,55 +287,7 @@ module CollavreOpenclaw
       assert_nil headers["Authorization"]
     end
 
-    test "includes tools in payload when provided" do
-      user = build_test_user(gateway_url: "https://test-gateway.com", email: "test@example.com")
-
-      adapter = OpenclawAdapter.new(
-        user: user,
-        system_prompt: "Test prompt",
-        context: {}
-      )
-
-      messages = [ { role: "user", content: "Hello" } ]
-      tools = [
-        {
-          type: "function",
-          function: {
-            name: "search_documents",
-            description: "Search for documents",
-            parameters: {
-              type: "object",
-              properties: {
-                query: { type: "string", description: "Search query" }
-              },
-              required: [ "query" ]
-            }
-          }
-        },
-        {
-          type: "function",
-          function: {
-            name: "get_weather",
-            description: "Get weather information",
-            parameters: {
-              type: "object",
-              properties: {
-                location: { type: "string" }
-              }
-            }
-          }
-        }
-      ]
-
-      payload = adapter.send(:build_payload, messages, tools)
-
-      assert payload[:tools].present?, "Tools should be included in payload"
-      assert_equal 2, payload[:tools].length
-      assert_equal "search_documents", payload[:tools][0][:function][:name]
-      assert_equal "get_weather", payload[:tools][1][:function][:name]
-    end
-
-    test "does not include tools key when tools array is empty" do
+    test "build_payload does not include tools key" do
       user = build_test_user(gateway_url: "https://test-gateway.com", email: "test@example.com")
 
       adapter = OpenclawAdapter.new(
@@ -346,103 +298,9 @@ module CollavreOpenclaw
 
       messages = [ { role: "user", content: "Hello" } ]
 
-      payload = adapter.send(:build_payload, messages, [])
+      payload = adapter.send(:build_payload, messages)
 
-      assert_not payload.key?(:tools), "Tools key should not be present when empty"
-    end
-
-    test "does not include tools key when tools is nil" do
-      user = build_test_user(gateway_url: "https://test-gateway.com", email: "test@example.com")
-
-      adapter = OpenclawAdapter.new(
-        user: user,
-        system_prompt: "Test prompt",
-        context: {}
-      )
-
-      messages = [ { role: "user", content: "Hello" } ]
-
-      payload = adapter.send(:build_payload, messages, nil)
-
-      assert_not payload.key?(:tools), "Tools key should not be present when nil"
-    end
-
-    test "converts MCP tool format to OpenAI format" do
-      user = build_test_user(gateway_url: "https://test-gateway.com", email: "test@example.com")
-
-      adapter = OpenclawAdapter.new(
-        user: user,
-        system_prompt: "Test prompt",
-        context: {}
-      )
-
-      mcp_tool = {
-        name: "search_documents",
-        description: "Search for documents",
-        params: [
-          { name: "query", type: "string", description: "Search query", required: true },
-          { name: "limit", type: "integer", description: "Max results", required: false }
-        ]
-      }
-
-      result = adapter.send(:convert_mcp_tool_to_openai_format, mcp_tool)
-
-      assert_equal "function", result[:type]
-      assert_equal "search_documents", result[:function][:name]
-      assert_equal "Search for documents", result[:function][:description]
-      assert_equal "object", result[:function][:parameters][:type]
-      assert_equal "string", result[:function][:parameters][:properties]["query"][:type]
-      assert_equal "integer", result[:function][:parameters][:properties]["limit"][:type]
-      assert_includes result[:function][:parameters][:required], "query"
-      assert_not_includes result[:function][:parameters][:required], "limit"
-    end
-
-    test "format_tools passes through OpenAI format tools unchanged" do
-      user = build_test_user(gateway_url: "https://test-gateway.com", email: "test@example.com")
-
-      adapter = OpenclawAdapter.new(
-        user: user,
-        system_prompt: "Test prompt",
-        context: {}
-      )
-
-      openai_tool = {
-        type: "function",
-        function: {
-          name: "get_weather",
-          description: "Get weather",
-          parameters: { type: "object", properties: {}, required: [] }
-        }
-      }
-
-      result = adapter.send(:format_tools, [ openai_tool ])
-
-      assert_equal 1, result.length
-      assert_equal openai_tool, result.first
-    end
-
-    test "format_tools converts MCP format tools to OpenAI format" do
-      user = build_test_user(gateway_url: "https://test-gateway.com", email: "test@example.com")
-
-      adapter = OpenclawAdapter.new(
-        user: user,
-        system_prompt: "Test prompt",
-        context: {}
-      )
-
-      mcp_tool = {
-        name: "calculate",
-        description: "Perform calculation",
-        params: [
-          { name: "expression", type: "string", required: true }
-        ]
-      }
-
-      result = adapter.send(:format_tools, [ mcp_tool ])
-
-      assert_equal 1, result.length
-      assert_equal "function", result.first[:type]
-      assert_equal "calculate", result.first[:function][:name]
+      assert_not payload.key?(:tools), "Tools key should not be present"
     end
 
     test "format_message_for_ws extracts last user message" do
@@ -535,42 +393,7 @@ module CollavreOpenclaw
       assert adapter.send(:websocket_available?)
     end
 
-    test "chat falls back to HTTP when tools are provided even if websocket is available" do
-      user = build_test_user(gateway_url: "https://test-gateway.com", email: "test@example.com",
-                             llm_api_key: "test-key")
-
-      adapter = OpenclawAdapter.new(
-        user: user,
-        system_prompt: "Test",
-        context: {}
-      )
-
-      tools = [
-        {
-          type: "function",
-          function: {
-            name: "search",
-            description: "Search",
-            parameters: { type: "object", properties: {}, required: [] }
-          }
-        }
-      ]
-
-      # websocket_available? is true, but tools are present → should use HTTP
-      assert adapter.send(:websocket_available?)
-
-      # Stub chat_via_http to verify it's called instead of chat_via_websocket
-      http_called = false
-      adapter.define_singleton_method(:chat_via_http) do |_msgs, **_opts, &_blk|
-        http_called = true
-        nil
-      end
-
-      adapter.chat([ { role: "user", content: "Hello" } ], tools: tools)
-      assert http_called, "Should fall back to HTTP when tools are provided"
-    end
-
-    test "chat uses websocket when no tools are provided" do
+    test "chat uses websocket when available" do
       user = build_test_user(gateway_url: "https://test-gateway.com", email: "test@example.com",
                              llm_api_key: "test-key")
 
@@ -588,8 +411,8 @@ module CollavreOpenclaw
         nil
       end
 
-      adapter.chat([ { role: "user", content: "Hello" } ], tools: [])
-      assert ws_called, "Should use WebSocket when no tools are provided"
+      adapter.chat([ { role: "user", content: "Hello" } ])
+      assert ws_called, "Should use WebSocket when available"
     end
 
     private

--- a/engines/collavre_openclaw/test/services/openclaw_adapter_test.rb
+++ b/engines/collavre_openclaw/test/services/openclaw_adapter_test.rb
@@ -364,6 +364,28 @@ module CollavreOpenclaw
       assert_not_includes result, "Creative:"
     end
 
+    test "format_message_for_ws treats model role as assistant for follow-up detection" do
+      user = build_test_user(gateway_url: "https://test-gateway.com", email: "test@example.com")
+
+      adapter = OpenclawAdapter.new(
+        user: user,
+        system_prompt: "Test",
+        context: {}
+      )
+
+      # "model" role (used by Gemini/some providers) should be treated as assistant
+      messages = [
+        { role: "user", parts: [ { text: "Creative:\n# My Project" } ] },
+        { role: "user", parts: [ { text: "First question" } ] },
+        { role: "model", parts: [ { text: "Here's my answer" } ] },
+        { role: "user", parts: [ { text: "Follow-up question" } ] }
+      ]
+
+      result = adapter.send(:format_message_for_ws, messages)
+      assert_equal "Follow-up question", result
+      assert_not_includes result, "Creative:"
+    end
+
     test "format_message_for_ws returns empty string for no user messages" do
       user = build_test_user(gateway_url: "https://test-gateway.com", email: "test@example.com")
 

--- a/engines/collavre_openclaw/test/services/openclaw_adapter_test.rb
+++ b/engines/collavre_openclaw/test/services/openclaw_adapter_test.rb
@@ -447,6 +447,73 @@ module CollavreOpenclaw
 
     private
 
+    test "format_message_for_ws extracts last user message" do
+      user = build_test_user(gateway_url: "https://test-gateway.com", email: "test@example.com")
+
+      adapter = OpenclawAdapter.new(
+        user: user,
+        system_prompt: "Test",
+        context: {}
+      )
+
+      messages = [
+        { role: "user", parts: [ { text: "First question" } ] },
+        { role: "model", parts: [ { text: "Answer" } ] },
+        { role: "user", parts: [ { text: "Follow-up question" } ] }
+      ]
+
+      result = adapter.send(:format_message_for_ws, messages)
+      assert_equal "Follow-up question", result
+    end
+
+    test "format_message_for_ws includes creative context" do
+      user = build_test_user(gateway_url: "https://test-gateway.com", email: "test@example.com")
+
+      adapter = OpenclawAdapter.new(
+        user: user,
+        system_prompt: "Test",
+        context: {}
+      )
+
+      messages = [
+        { role: "user", parts: [ { text: "Creative:\n# My Project" } ] },
+        { role: "user", parts: [ { text: "What do you think?" } ] }
+      ]
+
+      result = adapter.send(:format_message_for_ws, messages)
+      assert_includes result, "Creative:\n# My Project"
+      assert_includes result, "What do you think?"
+    end
+
+    test "format_message_for_ws returns empty string for no user messages" do
+      user = build_test_user(gateway_url: "https://test-gateway.com", email: "test@example.com")
+
+      adapter = OpenclawAdapter.new(
+        user: user,
+        system_prompt: "Test",
+        context: {}
+      )
+
+      messages = [
+        { role: "system", content: "System prompt" }
+      ]
+
+      result = adapter.send(:format_message_for_ws, messages)
+      assert_equal "", result
+    end
+
+    test "websocket_available? returns true when classes are defined" do
+      user = build_test_user(gateway_url: "https://test-gateway.com", email: "test@example.com")
+
+      adapter = OpenclawAdapter.new(
+        user: user,
+        system_prompt: "Test",
+        context: {}
+      )
+
+      assert adapter.send(:websocket_available?)
+    end
+
     def build_test_user(gateway_url: nil, email: "test@example.com", llm_api_key: nil)
       user = Object.new
       user.define_singleton_method(:id) { 1 }

--- a/engines/collavre_openclaw/test/services/openclaw_adapter_test.rb
+++ b/engines/collavre_openclaw/test/services/openclaw_adapter_test.rb
@@ -535,6 +535,63 @@ module CollavreOpenclaw
       assert adapter.send(:websocket_available?)
     end
 
+    test "chat falls back to HTTP when tools are provided even if websocket is available" do
+      user = build_test_user(gateway_url: "https://test-gateway.com", email: "test@example.com",
+                             llm_api_key: "test-key")
+
+      adapter = OpenclawAdapter.new(
+        user: user,
+        system_prompt: "Test",
+        context: {}
+      )
+
+      tools = [
+        {
+          type: "function",
+          function: {
+            name: "search",
+            description: "Search",
+            parameters: { type: "object", properties: {}, required: [] }
+          }
+        }
+      ]
+
+      # websocket_available? is true, but tools are present → should use HTTP
+      assert adapter.send(:websocket_available?)
+
+      # Stub chat_via_http to verify it's called instead of chat_via_websocket
+      http_called = false
+      adapter.define_singleton_method(:chat_via_http) do |_msgs, **_opts, &_blk|
+        http_called = true
+        nil
+      end
+
+      adapter.chat([ { role: "user", content: "Hello" } ], tools: tools)
+      assert http_called, "Should fall back to HTTP when tools are provided"
+    end
+
+    test "chat uses websocket when no tools are provided" do
+      user = build_test_user(gateway_url: "https://test-gateway.com", email: "test@example.com",
+                             llm_api_key: "test-key")
+
+      adapter = OpenclawAdapter.new(
+        user: user,
+        system_prompt: "Test",
+        context: {}
+      )
+
+      assert adapter.send(:websocket_available?)
+
+      ws_called = false
+      adapter.define_singleton_method(:chat_via_websocket) do |_msgs, &_blk|
+        ws_called = true
+        nil
+      end
+
+      adapter.chat([ { role: "user", content: "Hello" } ], tools: [])
+      assert ws_called, "Should use WebSocket when no tools are provided"
+    end
+
     private
 
     def build_test_user(gateway_url: nil, email: "test@example.com", llm_api_key: nil)

--- a/engines/collavre_openclaw/test/services/openclaw_adapter_test.rb
+++ b/engines/collavre_openclaw/test/services/openclaw_adapter_test.rb
@@ -445,8 +445,6 @@ module CollavreOpenclaw
       assert_equal "calculate", result.first[:function][:name]
     end
 
-    private
-
     test "format_message_for_ws extracts last user message" do
       user = build_test_user(gateway_url: "https://test-gateway.com", email: "test@example.com")
 
@@ -513,6 +511,8 @@ module CollavreOpenclaw
 
       assert adapter.send(:websocket_available?)
     end
+
+    private
 
     def build_test_user(gateway_url: nil, email: "test@example.com", llm_api_key: nil)
       user = Object.new

--- a/engines/collavre_openclaw/test/services/websocket_client_test.rb
+++ b/engines/collavre_openclaw/test/services/websocket_client_test.rb
@@ -1,0 +1,112 @@
+require "test_helper"
+
+module CollavreOpenclaw
+  class WebsocketClientTest < ActiveSupport::TestCase
+    setup do
+      @user = mock_user(
+        id: 1,
+        gateway_url: "http://localhost:18789",
+        llm_api_key: "test-token",
+        email: "ai-agent@collavre.com"
+      )
+    end
+
+    test "initializes in disconnected state" do
+      client = WebsocketClient.new(user: @user)
+      assert_equal :disconnected, client.state
+      assert_not client.connected?
+    end
+
+    test "requires gateway_url" do
+      user = mock_user(id: 2, gateway_url: nil, llm_api_key: "token", email: "test@test.com")
+      client = WebsocketClient.new(user: user)
+
+      assert_raises(CollavreOpenclaw::ConnectionError) do
+        client.connect!
+      end
+    end
+
+    test "gateway_ws_url converts http to ws" do
+      client = WebsocketClient.new(user: @user)
+      url = client.send(:gateway_ws_url)
+      assert_equal "ws://localhost:18789/", url
+    end
+
+    test "gateway_ws_url converts https to wss" do
+      user = mock_user(
+        id: 3,
+        gateway_url: "https://gateway.example.com:18789",
+        llm_api_key: "token",
+        email: "test@test.com"
+      )
+      client = WebsocketClient.new(user: user)
+      url = client.send(:gateway_ws_url)
+      assert_equal "wss://gateway.example.com:18789/", url
+    end
+
+    test "gateway_ws_url preserves ws scheme" do
+      user = mock_user(
+        id: 4,
+        gateway_url: "ws://localhost:18789",
+        llm_api_key: "token",
+        email: "test@test.com"
+      )
+      client = WebsocketClient.new(user: user)
+      url = client.send(:gateway_ws_url)
+      assert_equal "ws://localhost:18789/", url
+    end
+
+    test "extract_event_text handles string content" do
+      client = WebsocketClient.new(user: @user)
+      event = { message: { role: "assistant", content: "Hello world" } }
+      assert_equal "Hello world", client.send(:extract_event_text, event)
+    end
+
+    test "extract_event_text handles array content" do
+      client = WebsocketClient.new(user: @user)
+      event = {
+        message: {
+          role: "assistant",
+          content: [
+            { type: "text", text: "Hello " },
+            { type: "text", text: "world" }
+          ]
+        }
+      }
+      assert_equal "Hello world", client.send(:extract_event_text, event)
+    end
+
+    test "extract_event_text returns nil for non-hash message" do
+      client = WebsocketClient.new(user: @user)
+      assert_nil client.send(:extract_event_text, { message: "raw string" })
+    end
+
+    test "extract_agent_id from email" do
+      client = WebsocketClient.new(user: @user)
+      assert_equal "ai-agent", client.send(:extract_agent_id)
+    end
+
+    test "idle_seconds returns infinity when never active" do
+      client = WebsocketClient.new(user: @user)
+      assert_equal Float::INFINITY, client.idle_seconds
+    end
+
+    test "disconnect clears pending requests and runs" do
+      client = WebsocketClient.new(user: @user)
+      client.disconnect!
+      assert_equal :disconnected, client.state
+    end
+
+    private
+
+    def mock_user(id:, gateway_url:, llm_api_key:, email:)
+      user = OpenStruct.new(
+        id: id,
+        gateway_url: gateway_url,
+        llm_api_key: llm_api_key,
+        email: email
+      )
+      user
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Replace HTTP-based chat completions with WebSocket transport for the OpenClaw Gateway integration. This enables bidirectional communication, allowing proactive messages (cron/heartbeat) to be pushed directly from the Gateway without requiring HTTP callbacks.

### Phase 1: WebSocket Infrastructure
- `WebsocketClient` — single-user WS connection with OpenClaw protocol handshake, RPC request/response, event streaming, reconnection with exponential backoff
- `ConnectionManager` — singleton managing per-user connections with idle cleanup, thread-safe concurrent connect with shared handshake wait
- `EmReactor` — shared EventMachine reactor thread lifecycle management
- Error classes: `ConnectionError`, `TimeoutError`, `ChatError`, `RpcError`

### Phase 2: Chat Transport Migration
- `OpenclawAdapter#chat` now tries WebSocket first, falls back to HTTP on connection/timeout errors
- `format_message_for_ws` extracts the latest user message for Gateway's session-managed history
- Creative context is only prepended on the first message in a session (no duplication on follow-ups)
- Autoload-safe class resolution for `websocket_available?` check
- All existing HTTP transport code retained as fallback

### Key Design Decisions
- **WebSocket gem**: `faye-websocket` + `eventmachine`
- **Connection lifecycle**: On-demand connect with 30-min idle timeout
- **Thread safety**: Mutex-guarded state, Queue-based cross-thread communication (no `Timeout.timeout`)
- **Idempotency**: Pre-register with idempotency key, swap to Gateway-assigned runId on RPC response
- **Existing callback code**: Retained for backward compatibility (Phase 4 cleanup deferred)

### Tests
- 86 engine tests (WebSocket client, connection manager, adapter format/routing)
- All 821+ project tests passing
- Rubocop clean

### Migration Plan
See `PLAN_WEBSOCKET_MIGRATION.md` for the full 4-phase plan.

Closes the proactive message gap where OpenClaw cron/heartbeat events could not reach Collavre through HTTP callbacks.