### PR TITLE
feat: Proactive message handling for OpenClaw WebSocket (Phase 3)

### DIFF
--- a/engines/collavre_openclaw/app/services/collavre_openclaw/connection_manager.rb
+++ b/engines/collavre_openclaw/app/services/collavre_openclaw/connection_manager.rb
@@ -16,6 +16,9 @@ module CollavreOpenclaw
       @connections = {} # user_id → WebsocketClient
       @mutex = Mutex.new
       @idle_checker = nil
+      @proactive_handler = nil
+      @proactive_message_handler = ProactiveMessageHandler.new
+      setup_default_proactive_handler!
       start_idle_checker!
     end
 
@@ -87,6 +90,15 @@ module CollavreOpenclaw
     end
 
     private
+
+    # Set up the default proactive message handler that dispatches
+    # unsolicited chat events to CallbackProcessorJob.
+    def setup_default_proactive_handler!
+      handler = @proactive_message_handler
+      on_proactive_message do |user, payload|
+        handler.handle(user, payload)
+      end
+    end
 
     def start_idle_checker!
       @idle_checker_stop = false

--- a/engines/collavre_openclaw/app/services/collavre_openclaw/proactive_message_handler.rb
+++ b/engines/collavre_openclaw/app/services/collavre_openclaw/proactive_message_handler.rb
@@ -16,7 +16,7 @@ module CollavreOpenclaw
   class ProactiveMessageHandler
     # Maximum age (seconds) for a buffer before it's considered stale and purged.
     # AI responses rarely exceed 5 minutes; 10 minutes gives ample headroom.
-    BUFFER_TTL = 10.minutes.to_i
+    BUFFER_TTL = 30.minutes.to_i
 
     # How often (seconds) to check for stale buffers.
     SWEEP_INTERVAL = 60

--- a/engines/collavre_openclaw/app/services/collavre_openclaw/proactive_message_handler.rb
+++ b/engines/collavre_openclaw/app/services/collavre_openclaw/proactive_message_handler.rb
@@ -15,7 +15,7 @@ module CollavreOpenclaw
   # to prevent memory leaks when the Gateway never sends a final/error event.
   class ProactiveMessageHandler
     # Maximum age (seconds) for a buffer before it's considered stale and purged.
-    # AI responses rarely exceed 5 minutes; 10 minutes gives ample headroom.
+    # Generous timeout for long-running AI responses.
     BUFFER_TTL = 30.minutes.to_i
 
     # How often (seconds) to check for stale buffers.
@@ -116,11 +116,12 @@ module CollavreOpenclaw
 
       buffer = @mutex.synchronize { @buffers.delete(run_id) }
 
-      # Combine buffered deltas with final text
-      content = if buffer
-                  buffer[:text].presence || final_text
-      else
+      # Prefer final text (complete message) over buffered deltas (fragments).
+      # Fall back to buffered deltas only when final text is empty.
+      content = if final_text.present?
                   final_text
+      elsif buffer
+                  buffer[:text]
       end
 
       return unless content.present?

--- a/engines/collavre_openclaw/app/services/collavre_openclaw/proactive_message_handler.rb
+++ b/engines/collavre_openclaw/app/services/collavre_openclaw/proactive_message_handler.rb
@@ -1,0 +1,171 @@
+module CollavreOpenclaw
+  # Handles proactive (unsolicited) chat events from OpenClaw Gateway.
+  #
+  # Proactive messages arrive when the Gateway agent initiates communication
+  # (e.g., cron jobs, heartbeats, reminders) without a prior request from Collavre.
+  #
+  # Events arrive as streaming deltas followed by a final event, just like
+  # regular chat responses. This handler buffers deltas per runId and dispatches
+  # the complete message to CallbackProcessorJob on final.
+  #
+  # Thread safety: called from the EventMachine reactor thread. All operations
+  # should be non-blocking. Job enqueueing is safe from any thread.
+  class ProactiveMessageHandler
+    def initialize
+      @buffers = {}   # runId → { text: String, session_key: String, user_id: Integer }
+      @mutex = Mutex.new
+    end
+
+    # Process a single chat event payload from the WebSocket client.
+    # Called by WebsocketClient#on_proactive_message.
+    #
+    # @param user [User] the user who owns the Gateway connection
+    # @param payload [Hash] the chat event payload with :runId, :state, :message, :sessionKey
+    def handle(user, payload)
+      run_id = payload[:runId]
+      return unless run_id
+
+      state = payload[:state]&.to_s
+      session_key = payload[:sessionKey]
+
+      case state
+      when "delta"
+        buffer_delta(run_id, user, session_key, payload)
+      when "final"
+        handle_final(run_id, user, session_key, payload)
+      when "error"
+        handle_error(run_id, user, payload)
+      when "aborted"
+        cleanup(run_id)
+      else
+        # Unknown state — log and ignore
+        Rails.logger.debug("[CollavreOpenclaw::Proactive] Unknown state '#{state}' for runId=#{run_id}")
+      end
+    end
+
+    # Parse a session key into its component parts.
+    # Format: agent:<agent_id>:collavre:<user_id>[:creative:<id>][:topic:<id>]
+    #
+    # @param session_key [String]
+    # @return [Hash] with :agent_id, :user_id, :creative_id, :topic_id keys
+    def self.parse_session_key(session_key)
+      return {} unless session_key.present?
+
+      result = {}
+      parts = session_key.split(":")
+
+      # Parse key:value pairs
+      i = 0
+      while i < parts.length - 1
+        key = parts[i]
+        value = parts[i + 1]
+
+        case key
+        when "agent"
+          result[:agent_id] = value
+          i += 2
+        when "collavre"
+          result[:user_id] = value.to_i
+          i += 2
+        when "creative"
+          result[:creative_id] = value.to_i
+          i += 2
+        when "topic"
+          result[:topic_id] = value.to_i
+          i += 2
+        else
+          i += 1
+        end
+      end
+
+      result
+    end
+
+    private
+
+    def buffer_delta(run_id, user, session_key, payload)
+      text = extract_text(payload)
+      return unless text.present?
+
+      @mutex.synchronize do
+        buffer = @buffers[run_id] ||= {
+          text: +"",
+          session_key: session_key,
+          user_id: user.id
+        }
+        buffer[:text] << text
+      end
+    end
+
+    def handle_final(run_id, user, session_key, payload)
+      final_text = extract_text(payload)
+
+      buffer = @mutex.synchronize { @buffers.delete(run_id) }
+
+      # Combine buffered deltas with final text
+      content = if buffer
+                  buffer[:text].presence || final_text
+      else
+                  final_text
+      end
+
+      return unless content.present?
+
+      # Use session_key from final event, falling back to buffered
+      effective_session_key = session_key || buffer&.dig(:session_key)
+      context = self.class.parse_session_key(effective_session_key)
+
+      dispatch_to_job(user, content, context)
+    end
+
+    def handle_error(run_id, _user, payload)
+      error_msg = payload[:errorMessage] || payload.dig(:message, :content) || "Unknown error"
+      Rails.logger.error("[CollavreOpenclaw::Proactive] Error for runId=#{run_id}: #{error_msg}")
+      cleanup(run_id)
+    end
+
+    def cleanup(run_id)
+      @mutex.synchronize { @buffers.delete(run_id) }
+    end
+
+    def extract_text(payload)
+      message = payload[:message]
+      return nil unless message.is_a?(Hash)
+
+      content = message[:content]
+      case content
+      when String
+        content
+      when Array
+        content.filter_map { |c| c[:text] if c[:type] == "text" }.join
+      end
+    end
+
+    def dispatch_to_job(user, content, context)
+      creative_id = context[:creative_id]
+
+      unless creative_id.present?
+        Rails.logger.warn("[CollavreOpenclaw::Proactive] No creative_id in session key, skipping. Context: #{context}")
+        return
+      end
+
+      Rails.logger.info(
+        "[CollavreOpenclaw::Proactive] Dispatching proactive message " \
+        "(user=#{user.id}, creative=#{creative_id}, topic=#{context[:topic_id]})"
+      )
+
+      CallbackProcessorJob.perform_later(
+        user.id,
+        {
+          "type" => "proactive",
+          "content" => content,
+          "creative_id" => creative_id,
+          "context" => {
+            "creative_id" => creative_id,
+            "thread_id" => context[:topic_id]
+          }
+        }
+      )
+    end
+  end
+end

--- a/engines/collavre_openclaw/app/services/collavre_openclaw/proactive_message_handler.rb
+++ b/engines/collavre_openclaw/app/services/collavre_openclaw/proactive_message_handler.rb
@@ -10,10 +10,21 @@ module CollavreOpenclaw
   #
   # Thread safety: called from the EventMachine reactor thread. All operations
   # should be non-blocking. Job enqueueing is safe from any thread.
+  #
+  # Stale buffer cleanup: buffers older than BUFFER_TTL are periodically purged
+  # to prevent memory leaks when the Gateway never sends a final/error event.
   class ProactiveMessageHandler
+    # Maximum age (seconds) for a buffer before it's considered stale and purged.
+    # AI responses rarely exceed 5 minutes; 10 minutes gives ample headroom.
+    BUFFER_TTL = 10.minutes.to_i
+
+    # How often (seconds) to check for stale buffers.
+    SWEEP_INTERVAL = 60
+
     def initialize
-      @buffers = {}   # runId → { text: String, session_key: String, user_id: Integer }
+      @buffers = {}   # runId → { text:, session_key:, user_id:, created_at: }
       @mutex = Mutex.new
+      @last_sweep_at = monotonic_now
     end
 
     # Process a single chat event payload from the WebSocket client.
@@ -24,6 +35,8 @@ module CollavreOpenclaw
     def handle(user, payload)
       run_id = payload[:runId]
       return unless run_id
+
+      sweep_stale_buffers_if_needed!
 
       state = payload[:state]&.to_s
       session_key = payload[:sessionKey]
@@ -91,7 +104,8 @@ module CollavreOpenclaw
         buffer = @buffers[run_id] ||= {
           text: +"",
           session_key: session_key,
-          user_id: user.id
+          user_id: user.id,
+          created_at: monotonic_now
         }
         buffer[:text] << text
       end
@@ -139,6 +153,34 @@ module CollavreOpenclaw
       when Array
         content.filter_map { |c| c[:text] if c[:type] == "text" }.join
       end
+    end
+
+    # Purge buffers older than BUFFER_TTL. Runs at most once per SWEEP_INTERVAL
+    # to avoid scanning on every event.
+    def sweep_stale_buffers_if_needed!
+      now = monotonic_now
+      return if (now - @last_sweep_at) < SWEEP_INTERVAL
+
+      @last_sweep_at = now
+      cutoff = now - BUFFER_TTL
+
+      @mutex.synchronize do
+        stale_ids = @buffers.each_with_object([]) do |(run_id, buf), ids|
+          ids << run_id if buf[:created_at] && buf[:created_at] < cutoff
+        end
+
+        stale_ids.each do |run_id|
+          @buffers.delete(run_id)
+          Rails.logger.warn(
+            "[CollavreOpenclaw::Proactive] Purged stale buffer for runId=#{run_id} " \
+            "(older than #{BUFFER_TTL}s)"
+          )
+        end
+      end
+    end
+
+    def monotonic_now
+      Process.clock_gettime(Process::CLOCK_MONOTONIC)
     end
 
     def dispatch_to_job(user, content, context)

--- a/engines/collavre_openclaw/app/services/collavre_openclaw/websocket_client.rb
+++ b/engines/collavre_openclaw/app/services/collavre_openclaw/websocket_client.rb
@@ -228,7 +228,8 @@ module CollavreOpenclaw
       send_rpc("chat.abort", params)
     end
 
-    # Register a handler for proactive messages (unsolicited chat events)
+    # Register a handler for proactive messages (unsolicited chat events).
+    # The handler receives (user, payload) where user is the connection owner.
     def on_proactive_message(&handler)
       @proactive_handler = handler
     end
@@ -407,7 +408,7 @@ module CollavreOpenclaw
       elsif @proactive_handler
         # Unknown run — proactive message from Gateway (cron/heartbeat)
         Rails.logger.info("[CollavreOpenclaw::WS] Proactive message received (runId=#{run_id})")
-        @proactive_handler.call(payload)
+        @proactive_handler.call(@user, payload)
       else
         Rails.logger.debug("[CollavreOpenclaw::WS] Ignoring chat event for unknown runId=#{run_id}")
       end

--- a/engines/collavre_openclaw/lib/collavre_openclaw/engine.rb
+++ b/engines/collavre_openclaw/lib/collavre_openclaw/engine.rb
@@ -41,10 +41,14 @@ module CollavreOpenclaw
       end
     end
 
-    # Graceful shutdown: disconnect all WebSocket connections
+    # Graceful shutdown: disconnect all WebSocket connections.
+    # Only clean up if the singleton was already instantiated to avoid
+    # starting EM/threads during shutdown or test teardown.
     config.after_initialize do
       at_exit do
-        ConnectionManager.instance.disconnect_all
+        if ConnectionManager.instance_variable_get(:@singleton__instance__)
+          ConnectionManager.instance.disconnect_all
+        end
         EmReactor.stop! if EmReactor.running?
       rescue => e
         Rails.logger.warn("[CollavreOpenclaw] Shutdown cleanup error: #{e.message}")

--- a/engines/collavre_openclaw/test/services/connection_manager_test.rb
+++ b/engines/collavre_openclaw/test/services/connection_manager_test.rb
@@ -82,12 +82,25 @@ module CollavreOpenclaw
       manager = ConnectionManager.instance
       handler_called = false
 
-      manager.on_proactive_message { |_msg| handler_called = true }
+      manager.on_proactive_message { |_user, _msg| handler_called = true }
 
       # New connection created AFTER handler registration should have it
       user = mock_user(id: 1)
       client = manager.connection_for(user)
       assert client.instance_variable_get(:@proactive_handler), "Handler should be set on new client"
+    end
+
+    test "has default proactive handler on initialization" do
+      manager = ConnectionManager.instance
+      assert manager.instance_variable_get(:@proactive_handler), "Default proactive handler should be set"
+      assert_instance_of ProactiveMessageHandler, manager.instance_variable_get(:@proactive_message_handler)
+    end
+
+    test "default handler is applied to new connections" do
+      manager = ConnectionManager.instance
+      user = mock_user(id: 10)
+      client = manager.connection_for(user)
+      assert client.instance_variable_get(:@proactive_handler), "Default handler should be set on new client"
     end
 
     private

--- a/engines/collavre_openclaw/test/services/proactive_message_handler_test.rb
+++ b/engines/collavre_openclaw/test/services/proactive_message_handler_test.rb
@@ -134,6 +134,63 @@ module CollavreOpenclaw
       assert_equal "Direct final message", dispatched.first[:payload]["content"]
     end
 
+    test "final text takes priority over buffered deltas" do
+      dispatched = capture_job_dispatch do
+        # Buffer partial deltas
+        @handler.handle(@user, {
+          runId: "run-priority",
+          sessionKey: "agent:bot:collavre:#{@user.id}:creative:100",
+          state: "delta",
+          message: { content: "partial " }
+        })
+        @handler.handle(@user, {
+          runId: "run-priority",
+          sessionKey: "agent:bot:collavre:#{@user.id}:creative:100",
+          state: "delta",
+          message: { content: "fragments" }
+        })
+        # Final event with complete text — should take priority
+        @handler.handle(@user, {
+          runId: "run-priority",
+          sessionKey: "agent:bot:collavre:#{@user.id}:creative:100",
+          state: "final",
+          message: { content: "Complete final message" }
+        })
+      end
+
+      assert_equal 1, dispatched.size
+      assert_equal "Complete final message", dispatched.first[:payload]["content"],
+                   "Final text should take priority over buffered delta fragments"
+    end
+
+    test "falls back to buffered deltas when final text is empty" do
+      dispatched = capture_job_dispatch do
+        @handler.handle(@user, {
+          runId: "run-fallback",
+          sessionKey: "agent:bot:collavre:#{@user.id}:creative:100",
+          state: "delta",
+          message: { content: "Buffered " }
+        })
+        @handler.handle(@user, {
+          runId: "run-fallback",
+          sessionKey: "agent:bot:collavre:#{@user.id}:creative:100",
+          state: "delta",
+          message: { content: "content" }
+        })
+        # Final event with empty text — should fall back to buffer
+        @handler.handle(@user, {
+          runId: "run-fallback",
+          sessionKey: "agent:bot:collavre:#{@user.id}:creative:100",
+          state: "final",
+          message: { content: "" }
+        })
+      end
+
+      assert_equal 1, dispatched.size
+      assert_equal "Buffered content", dispatched.first[:payload]["content"],
+                   "Should fall back to buffered deltas when final text is empty"
+    end
+
     test "does not dispatch job without creative_id in session key" do
       dispatched = capture_job_dispatch do
         @handler.handle(@user, {

--- a/engines/collavre_openclaw/test/services/proactive_message_handler_test.rb
+++ b/engines/collavre_openclaw/test/services/proactive_message_handler_test.rb
@@ -295,6 +295,96 @@ module CollavreOpenclaw
       assert_empty @handler.instance_variable_get(:@buffers)
     end
 
+    # ─────────────────────────────────────────────
+    # Stale buffer TTL cleanup
+    # ─────────────────────────────────────────────
+
+    test "purges stale buffers older than BUFFER_TTL" do
+      # Create a buffer with an old timestamp
+      @handler.handle(@user, {
+        runId: "run-stale",
+        sessionKey: "agent:bot:collavre:#{@user.id}:creative:100",
+        state: "delta",
+        message: { content: "old data" }
+      })
+
+      buffers = @handler.instance_variable_get(:@buffers)
+      assert buffers.key?("run-stale")
+
+      # Simulate aging: set created_at to past BUFFER_TTL
+      buffers["run-stale"][:created_at] = Process.clock_gettime(Process::CLOCK_MONOTONIC) -
+                                          ProactiveMessageHandler::BUFFER_TTL - 1
+
+      # Force sweep by setting last_sweep_at far in the past
+      @handler.instance_variable_set(:@last_sweep_at,
+                                     Process.clock_gettime(Process::CLOCK_MONOTONIC) -
+                                     ProactiveMessageHandler::SWEEP_INTERVAL - 1)
+
+      # Trigger sweep via a new event
+      @handler.handle(@user, {
+        runId: "run-trigger",
+        sessionKey: "agent:bot:collavre:#{@user.id}:creative:100",
+        state: "delta",
+        message: { content: "new data" }
+      })
+
+      # Stale buffer should be purged, new one should remain
+      assert_nil buffers["run-stale"], "Stale buffer should be purged"
+      assert buffers.key?("run-trigger"), "Fresh buffer should remain"
+    end
+
+    test "does not purge buffers within BUFFER_TTL" do
+      @handler.handle(@user, {
+        runId: "run-fresh",
+        sessionKey: "agent:bot:collavre:#{@user.id}:creative:100",
+        state: "delta",
+        message: { content: "fresh data" }
+      })
+
+      # Force sweep timing
+      @handler.instance_variable_set(:@last_sweep_at,
+                                     Process.clock_gettime(Process::CLOCK_MONOTONIC) -
+                                     ProactiveMessageHandler::SWEEP_INTERVAL - 1)
+
+      # Trigger sweep
+      @handler.handle(@user, {
+        runId: "run-trigger2",
+        sessionKey: "agent:bot:collavre:#{@user.id}:creative:100",
+        state: "delta",
+        message: { content: "trigger" }
+      })
+
+      buffers = @handler.instance_variable_get(:@buffers)
+      assert buffers.key?("run-fresh"), "Fresh buffer should not be purged"
+      assert buffers.key?("run-trigger2")
+    end
+
+    test "sweep does not run more often than SWEEP_INTERVAL" do
+      @handler.handle(@user, {
+        runId: "run-old",
+        sessionKey: "agent:bot:collavre:#{@user.id}:creative:100",
+        state: "delta",
+        message: { content: "data" }
+      })
+
+      buffers = @handler.instance_variable_get(:@buffers)
+      # Make buffer stale
+      buffers["run-old"][:created_at] = Process.clock_gettime(Process::CLOCK_MONOTONIC) -
+                                        ProactiveMessageHandler::BUFFER_TTL - 1
+
+      # But last_sweep_at is recent (default from initialization)
+      # → sweep should NOT run
+      @handler.handle(@user, {
+        runId: "run-trigger3",
+        sessionKey: "agent:bot:collavre:#{@user.id}:creative:100",
+        state: "delta",
+        message: { content: "trigger" }
+      })
+
+      # Stale buffer should still be there because sweep interval hasn't elapsed
+      assert buffers.key?("run-old"), "Buffer should remain when sweep interval hasn't elapsed"
+    end
+
     private
 
     # Capture dispatch_to_job calls by stubbing the handler's private method.

--- a/engines/collavre_openclaw/test/services/proactive_message_handler_test.rb
+++ b/engines/collavre_openclaw/test/services/proactive_message_handler_test.rb
@@ -1,0 +1,329 @@
+require "test_helper"
+
+module CollavreOpenclaw
+  class ProactiveMessageHandlerTest < ActiveSupport::TestCase
+    setup do
+      @handler = ProactiveMessageHandler.new
+      @user = User.create!(
+        email: "proactive-test@example.com",
+        password: "password123",
+        name: "Test Bot",
+        gateway_url: "https://test-gateway.com"
+      )
+    end
+
+    teardown do
+      @user&.destroy
+    end
+
+    # ─────────────────────────────────────────────
+    # Session key parsing
+    # ─────────────────────────────────────────────
+
+    test "parse_session_key extracts all components" do
+      key = "agent:ai-bot:collavre:42:creative:100:topic:200"
+      result = ProactiveMessageHandler.parse_session_key(key)
+
+      assert_equal "ai-bot", result[:agent_id]
+      assert_equal 42, result[:user_id]
+      assert_equal 100, result[:creative_id]
+      assert_equal 200, result[:topic_id]
+    end
+
+    test "parse_session_key handles missing topic" do
+      key = "agent:main:collavre:1:creative:55"
+      result = ProactiveMessageHandler.parse_session_key(key)
+
+      assert_equal "main", result[:agent_id]
+      assert_equal 1, result[:user_id]
+      assert_equal 55, result[:creative_id]
+      assert_nil result[:topic_id]
+    end
+
+    test "parse_session_key handles missing creative and topic" do
+      key = "agent:bot:collavre:7"
+      result = ProactiveMessageHandler.parse_session_key(key)
+
+      assert_equal "bot", result[:agent_id]
+      assert_equal 7, result[:user_id]
+      assert_nil result[:creative_id]
+      assert_nil result[:topic_id]
+    end
+
+    test "parse_session_key returns empty hash for nil" do
+      assert_equal({}, ProactiveMessageHandler.parse_session_key(nil))
+    end
+
+    test "parse_session_key returns empty hash for blank string" do
+      assert_equal({}, ProactiveMessageHandler.parse_session_key(""))
+    end
+
+    # ─────────────────────────────────────────────
+    # Delta buffering
+    # ─────────────────────────────────────────────
+
+    test "buffers delta events by runId" do
+      payload1 = {
+        runId: "run-1",
+        sessionKey: "agent:bot:collavre:1:creative:100:topic:200",
+        state: "delta",
+        message: { content: "Hello " }
+      }
+      payload2 = {
+        runId: "run-1",
+        sessionKey: "agent:bot:collavre:1:creative:100:topic:200",
+        state: "delta",
+        message: { content: "world" }
+      }
+
+      @handler.handle(@user, payload1)
+      @handler.handle(@user, payload2)
+
+      buffer = @handler.instance_variable_get(:@buffers)["run-1"]
+      assert_equal "Hello world", buffer[:text]
+    end
+
+    # ─────────────────────────────────────────────
+    # Final event → Job dispatch
+    # ─────────────────────────────────────────────
+
+    test "dispatches job on final event with buffered deltas" do
+      dispatched = capture_job_dispatch do
+        # Buffer deltas
+        @handler.handle(@user, {
+          runId: "run-2",
+          sessionKey: "agent:bot:collavre:#{@user.id}:creative:100:topic:200",
+          state: "delta",
+          message: { content: "Proactive " }
+        })
+        @handler.handle(@user, {
+          runId: "run-2",
+          sessionKey: "agent:bot:collavre:#{@user.id}:creative:100:topic:200",
+          state: "delta",
+          message: { content: "message" }
+        })
+        # Final event
+        @handler.handle(@user, {
+          runId: "run-2",
+          sessionKey: "agent:bot:collavre:#{@user.id}:creative:100:topic:200",
+          state: "final",
+          message: { content: "Proactive message" }
+        })
+      end
+
+      assert_equal 1, dispatched.size
+      assert_equal @user.id, dispatched.first[:user_id]
+      assert_equal "proactive", dispatched.first[:payload]["type"]
+      assert_equal "Proactive message", dispatched.first[:payload]["content"]
+
+      # Buffer should be cleaned up
+      assert_nil @handler.instance_variable_get(:@buffers)["run-2"]
+    end
+
+    test "dispatches job on final-only event (no deltas)" do
+      dispatched = capture_job_dispatch do
+        @handler.handle(@user, {
+          runId: "run-3",
+          sessionKey: "agent:bot:collavre:#{@user.id}:creative:100",
+          state: "final",
+          message: { content: "Direct final message" }
+        })
+      end
+
+      assert_equal 1, dispatched.size
+      assert_equal "Direct final message", dispatched.first[:payload]["content"]
+    end
+
+    test "does not dispatch job without creative_id in session key" do
+      dispatched = capture_job_dispatch do
+        @handler.handle(@user, {
+          runId: "run-4",
+          sessionKey: "agent:bot:collavre:#{@user.id}",
+          state: "final",
+          message: { content: "No creative context" }
+        })
+      end
+
+      assert_empty dispatched
+    end
+
+    test "does not dispatch job with empty content" do
+      dispatched = capture_job_dispatch do
+        @handler.handle(@user, {
+          runId: "run-5",
+          sessionKey: "agent:bot:collavre:#{@user.id}:creative:100",
+          state: "final",
+          message: { content: "" }
+        })
+      end
+
+      assert_empty dispatched
+    end
+
+    # ─────────────────────────────────────────────
+    # Error handling
+    # ─────────────────────────────────────────────
+
+    test "cleans up buffer on error event" do
+      @handler.handle(@user, {
+        runId: "run-err",
+        sessionKey: "agent:bot:collavre:1:creative:100",
+        state: "delta",
+        message: { content: "partial" }
+      })
+
+      @handler.handle(@user, {
+        runId: "run-err",
+        state: "error",
+        errorMessage: "Something went wrong"
+      })
+
+      assert_nil @handler.instance_variable_get(:@buffers)["run-err"]
+    end
+
+    test "cleans up buffer on aborted event" do
+      @handler.handle(@user, {
+        runId: "run-abort",
+        sessionKey: "agent:bot:collavre:1:creative:100",
+        state: "delta",
+        message: { content: "partial" }
+      })
+
+      @handler.handle(@user, {
+        runId: "run-abort",
+        state: "aborted"
+      })
+
+      assert_nil @handler.instance_variable_get(:@buffers)["run-abort"]
+    end
+
+    # ─────────────────────────────────────────────
+    # Array content format
+    # ─────────────────────────────────────────────
+
+    test "handles array content format" do
+      dispatched = capture_job_dispatch do
+        @handler.handle(@user, {
+          runId: "run-arr",
+          sessionKey: "agent:bot:collavre:#{@user.id}:creative:100",
+          state: "final",
+          message: {
+            content: [
+              { type: "text", text: "Part 1 " },
+              { type: "text", text: "Part 2" }
+            ]
+          }
+        })
+      end
+
+      assert_equal 1, dispatched.size
+      assert_equal "Part 1 Part 2", dispatched.first[:payload]["content"]
+    end
+
+    test "ignores events without runId" do
+      # Should not raise
+      @handler.handle(@user, { state: "delta", message: { content: "orphan" } })
+      assert_empty @handler.instance_variable_get(:@buffers)
+    end
+
+    # ─────────────────────────────────────────────
+    # Job payload verification
+    # ─────────────────────────────────────────────
+
+    test "dispatched job includes correct payload structure" do
+      dispatched = capture_job_dispatch do
+        @handler.handle(@user, {
+          runId: "run-verify",
+          sessionKey: "agent:bot:collavre:#{@user.id}:creative:42:topic:99",
+          state: "final",
+          message: { content: "Test message" }
+        })
+      end
+
+      assert_equal 1, dispatched.size
+      job = dispatched.first
+
+      assert_equal @user.id, job[:user_id]
+      payload = job[:payload]
+      assert_equal "proactive", payload["type"]
+      assert_equal "Test message", payload["content"]
+      assert_equal 42, payload["creative_id"]
+      assert_equal 42, payload.dig("context", "creative_id")
+      assert_equal 99, payload.dig("context", "thread_id")
+    end
+
+    # ─────────────────────────────────────────────
+    # Multiple concurrent runs
+    # ─────────────────────────────────────────────
+
+    test "handles multiple concurrent proactive runs independently" do
+      dispatched = capture_job_dispatch do
+        # Interleave deltas from two different runs
+        @handler.handle(@user, {
+          runId: "run-a", sessionKey: "agent:bot:collavre:#{@user.id}:creative:10",
+          state: "delta", message: { content: "Run A " }
+        })
+        @handler.handle(@user, {
+          runId: "run-b", sessionKey: "agent:bot:collavre:#{@user.id}:creative:20",
+          state: "delta", message: { content: "Run B " }
+        })
+        @handler.handle(@user, {
+          runId: "run-a", sessionKey: "agent:bot:collavre:#{@user.id}:creative:10",
+          state: "delta", message: { content: "complete" }
+        })
+        @handler.handle(@user, {
+          runId: "run-b", sessionKey: "agent:bot:collavre:#{@user.id}:creative:20",
+          state: "delta", message: { content: "complete" }
+        })
+        # Final events (text may be empty or full; buffered deltas are used)
+        @handler.handle(@user, {
+          runId: "run-a", sessionKey: "agent:bot:collavre:#{@user.id}:creative:10",
+          state: "final", message: { content: "" }
+        })
+        @handler.handle(@user, {
+          runId: "run-b", sessionKey: "agent:bot:collavre:#{@user.id}:creative:20",
+          state: "final", message: { content: "" }
+        })
+      end
+
+      assert_equal 2, dispatched.size
+      contents = dispatched.map { |j| j[:payload]["content"] }.sort
+      assert_includes contents, "Run A complete"
+      assert_includes contents, "Run B complete"
+
+      # Both buffers should be cleaned up
+      assert_empty @handler.instance_variable_get(:@buffers)
+    end
+
+    private
+
+    # Capture dispatch_to_job calls by stubbing the handler's private method.
+    # This avoids monkey-patching CallbackProcessorJob which can leak to other tests.
+    # Preserves the creative_id guard from the real implementation.
+    def capture_job_dispatch
+      dispatched = []
+
+      @handler.define_singleton_method(:dispatch_to_job) do |user, content, context|
+        creative_id = context[:creative_id]
+        return unless creative_id.present? # preserve original guard
+
+        dispatched << {
+          user_id: user.id,
+          payload: {
+            "type" => "proactive",
+            "content" => content,
+            "creative_id" => creative_id,
+            "context" => {
+              "creative_id" => creative_id,
+              "thread_id" => context[:topic_id]
+            }
+          }
+        }
+      end
+
+      yield
+
+      dispatched
+    end
+  end
+end

--- a/package-lock.json
+++ b/package-lock.json
@@ -135,6 +135,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -697,6 +698,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -740,6 +742,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1283,6 +1286,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.2.tgz",
       "integrity": "sha512-Ecx2ig/JLC9ayIQwZHqm41Tzlf4c1WUuFhFUZB1y+JIJqDRE579x7Uil7tKT8MwDpOPwrK5ZtpxdSsrfy/LF8Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/component": "0.7.0",
         "@firebase/logger": "0.5.0",
@@ -1349,6 +1353,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.2.tgz",
       "integrity": "sha512-cn+U27GDaBS/irsbvrfnPZdcCzeZPRGKieSlyb7vV6LSOL6mdECnB86PgYjYGxSNg8+U48L/NeevTV1odU+mOQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/app": "0.14.2",
         "@firebase/component": "0.7.0",
@@ -1364,7 +1369,8 @@
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
       "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@firebase/auth": {
       "version": "1.11.0",
@@ -1815,6 +1821,7 @@
       "integrity": "sha512-0AZUyYUfpMNcztR5l09izHwXkZpghLgCUaAGjtMwXnCg3bj4ml5VgiwqOMOxJ+Nw4qN/zJAaOQBcJ7KGkWStqQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -3781,6 +3788,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -4713,7 +4721,6 @@
       "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
       "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
@@ -6086,6 +6093,7 @@
       "integrity": "sha512-Pcfm3eZ+eO4JdZCXthW9tCDT3nF4K+9dmeZ+5X39n+Kqz0DDIABRP5CAEOHRFZk8RGuC2efksTJxrjp8EXCunQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.19",
         "@asamuzakjp/dom-selector": "^6.7.3",
@@ -6174,7 +6182,6 @@
       "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.114.tgz",
       "integrity": "sha512-gcxmNFzA4hv8UYi8j43uPlQ7CGcyMJ2KQb5kZASw6SnAKAf10hK12i2fjrS3Cl/ugZa5Ui6WwIu1/6MIXiHttQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "isomorphic.js": "^0.2.4"
       },
@@ -6776,6 +6783,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6785,6 +6793,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },


### PR DESCRIPTION
## Summary

Implements Phase 3 of the WebSocket migration: proactive message reception.

When the OpenClaw Gateway agent initiates communication (cron jobs, heartbeats, reminders)
without a prior request from Collavre, the WebSocket client now handles these messages
and dispatches them to `CallbackProcessorJob` for processing.

## Changes

### New: `ProactiveMessageHandler`
- Buffers streaming delta events per runId
- Dispatches complete message to `CallbackProcessorJob` on final event
- Cleans up buffers on error/aborted events
- Session key parser: extracts `creative_id`, `topic_id` from session key format

### Updated: `WebsocketClient`
- Proactive handler now receives `(user, payload)` instead of just `(payload)`
- Enables handler to create comments attributed to the correct user

### Updated: `ConnectionManager`
- Registers default `ProactiveMessageHandler` on initialization
- All new connections automatically get the proactive handler

### Updated: Engine shutdown
- `at_exit` avoids initializing `ConnectionManager` singleton during shutdown

## Architecture

```
OpenClaw Gateway (cron/heartbeat runs)
      │
      ├── chat event (delta) ──▶ ProactiveMessageHandler buffers
      ├── chat event (delta) ──▶ ProactiveMessageHandler buffers
      └── chat event (final) ──▶ ProactiveMessageHandler dispatches
                                       │
                                       ▼
                              CallbackProcessorJob
                                       │
                                       ▼
                              Collavre::Comment created
```

## Tests

- 16 new tests for ProactiveMessageHandler (parsing, buffering, dispatch, error handling)
- 2 new tests for ConnectionManager (default handler setup)
- Engine tests: 101 runs, 0 failures