### PR TITLE
feat: Include creative context in GitHub webhook events

### DIFF
--- a/app/controllers/github/webhooks_controller.rb
+++ b/app/controllers/github/webhooks_controller.rb
@@ -8,15 +8,11 @@ module Github
       end
       raw_body = request.raw_post.presence || request.body.read
       payload = parse_payload(raw_body)
-      return head :unauthorized unless valid_signature?(raw_body, payload)
+      @repository_link = find_repository_link(payload)
+      return head :unauthorized unless valid_signature?(raw_body)
       payload = payload.presence || {}
 
-      SystemEvents::Dispatcher.dispatch("github_webhook", {
-        event: event,
-        action: payload["action"],
-        repository: payload.dig("repository", "full_name"),
-        payload: payload
-      })
+      dispatch_github_event(event, payload)
 
       case event
       when "pull_request"
@@ -32,8 +28,38 @@ module Github
 
     private
 
-    def valid_signature?(raw_body, payload)
-      secret = webhook_secret(payload)
+    def dispatch_github_event(event, payload)
+      context = {
+        event: event,
+        action: payload["action"],
+        repository: payload.dig("repository", "full_name"),
+        payload: payload
+      }
+
+      # Include creative context for AI Agent routing permission check
+      if @repository_link&.creative
+        context[:creative] = {
+          id: @repository_link.creative.id
+        }
+      end
+
+      SystemEvents::Dispatcher.dispatch("github_webhook", context)
+    end
+
+    def find_repository_link(payload)
+      return if payload.blank?
+
+      repo = payload["repository"] || payload[:repository]
+      return if repo.blank?
+
+      full_name = repo["full_name"] || repo[:full_name]
+      return if full_name.blank?
+
+      GithubRepositoryLink.find_by(repository_full_name: full_name)
+    end
+
+    def valid_signature?(raw_body)
+      secret = webhook_secret
       signature_header = request.headers["X-Hub-Signature-256"] || request.headers["X-Hub-Signature"]
 
       if secret.blank?
@@ -58,26 +84,8 @@ module Github
       ActiveSupport::SecurityUtils.secure_compare(expected_signature, signature_header)
     end
 
-    def webhook_secret(payload)
-      repository_secret(payload) || fallback_webhook_secret
-    end
-
-    def repository_secret(payload)
-      return if payload.blank?
-
-      repo = payload["repository"] || payload[:repository]
-      if repo.blank?
-        Rails.logger.warn("GitHub webhook repository missing; rejecting request. payload=#{payload}")
-        return
-      end
-
-      full_name = repo["full_name"] || repo[:full_name]
-      if full_name.blank?
-        Rails.logger.warn("GitHub webhook repository full name missing; rejecting request. payload=#{payload}")
-        return
-      end
-
-      GithubRepositoryLink.find_by(repository_full_name: full_name)&.webhook_secret
+    def webhook_secret
+      @repository_link&.webhook_secret || fallback_webhook_secret
     end
 
     def fallback_webhook_secret

--- a/app/controllers/github/webhooks_controller.rb
+++ b/app/controllers/github/webhooks_controller.rb
@@ -47,13 +47,22 @@ module Github
     end
 
     def find_repository_link(payload)
-      return if payload.blank?
+      if payload.blank?
+        Rails.logger.warn("[GitHub Webhook] Payload is blank")
+        return
+      end
 
       repo = payload["repository"] || payload[:repository]
-      return if repo.blank?
+      if repo.blank?
+        Rails.logger.warn("[GitHub Webhook] Repository missing in payload")
+        return
+      end
 
       full_name = repo["full_name"] || repo[:full_name]
-      return if full_name.blank?
+      if full_name.blank?
+        Rails.logger.warn("[GitHub Webhook] Repository full_name missing in payload")
+        return
+      end
 
       GithubRepositoryLink.find_by(repository_full_name: full_name)
     end

--- a/test/controllers/github/webhooks_controller_test.rb
+++ b/test/controllers/github/webhooks_controller_test.rb
@@ -82,6 +82,66 @@ class Github::WebhooksControllerTest < ActionDispatch::IntegrationTest
     dispatcher.verify
   end
 
+  test "dispatches system event with creative context from repository link" do
+    body = @payload.to_json
+    signature = "sha256=#{OpenSSL::HMAC.hexdigest('SHA256', @link.webhook_secret, body)}"
+
+    processor = Minitest::Mock.new
+    processor.expect(:call, true)
+
+    captured_context = nil
+    dispatcher = ->(event_name, context) { captured_context = context }
+
+    Github::PullRequestProcessor.stub :new, ->(*) { processor } do
+      SystemEvents::Dispatcher.stub :dispatch, dispatcher do
+        post github_webhook_path,
+             params: body,
+             headers: {
+               "CONTENT_TYPE" => "application/json",
+               "HTTP_X_GITHUB_EVENT" => "pull_request",
+               "HTTP_X_HUB_SIGNATURE_256" => signature
+             }
+      end
+    end
+
+    assert_response :success
+    processor.verify
+
+    # Verify creative context is included
+    assert_not_nil captured_context[:creative], "Creative context should be present"
+    assert_equal @link.creative.id, captured_context[:creative][:id]
+  end
+
+  test "dispatches system event without creative when repository link not found" do
+    # Use a different repository that doesn't have a link
+    payload = @payload.merge("repository" => { "full_name" => "unknown/repo" })
+    body = payload.to_json
+
+    # Use fallback secret
+    fallback_secret = "fallback-test-secret"
+    signature = "sha256=#{OpenSSL::HMAC.hexdigest('SHA256', fallback_secret, body)}"
+
+    captured_context = nil
+    dispatcher = ->(event_name, context) { captured_context = context }
+
+    Rails.application.stub :credentials, OpenStruct.new(github: { webhook_secret: fallback_secret }) do
+      SystemEvents::Dispatcher.stub :dispatch, dispatcher do
+        post github_webhook_path,
+             params: body,
+             headers: {
+               "CONTENT_TYPE" => "application/json",
+               "HTTP_X_GITHUB_EVENT" => "push",
+               "HTTP_X_HUB_SIGNATURE_256" => signature
+             }
+      end
+    end
+
+    assert_response :success
+
+    # Creative context should not be present when no repository link
+    assert_nil captured_context[:creative], "Creative context should not be present for unknown repo"
+  end
+
   test "rejects webhook when signature does not match secret" do
     body = @payload.to_json
     signature = "sha256=#{OpenSSL::HMAC.hexdigest('SHA256', 'wrong-secret', body)}"


### PR DESCRIPTION
## Summary

When GitHub webhooks arrive, now includes the associated creative's ID in the SystemEvents dispatch context. This enables AI Agents with `routing_expression` to receive GitHub events.

## Problem

Previously, GitHub webhook events were dispatched without creative context:
```ruby
SystemEvents::Dispatcher.dispatch("github_webhook", {
  event: event,
  action: payload["action"],
  repository: payload.dig("repository", "full_name"),
  payload: payload
  # ❌ No creative context!
})
```

The Router's `has_creative_permission?` check would fail for non-searchable agents because there was no `creative.id` in the context.

## Solution

1. Find the `GithubRepositoryLink` for the repository (already needed for webhook secret)
2. Include the associated creative's ID in the dispatch context
3. Refactor to avoid duplicate lookups

```ruby
context[:creative] = { id: @repository_link.creative.id }
```

## Result

| Before | After |
|--------|-------|
| `routing_expression: "true"` only worked if `agent.searchable? == true` | ✅ Works for any agent with creative permission |
| GitHub events couldn't be routed to creative-specific agents | ✅ Agents in the linked creative can now receive GitHub events |

## Refactoring

- Extract `find_repository_link` method (reused for both secret lookup and creative context)
- Extract `dispatch_github_event` method
- Simplify `webhook_secret` to use cached `@repository_link`

## Tests

All 5 existing webhook controller tests pass.