### PR TITLE
fix: Exit fullscreen returns to mobile position on mobile devices

### DIFF
--- a/engines/collavre/app/javascript/controllers/comments/popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_controller.js
@@ -495,10 +495,48 @@ export default class extends Controller {
     } else {
       const savedStyles = this._savedStyles
       this._savedStyles = null
+      const creativeId = el.dataset.creativeId
 
+      // Mobile: skip animation, just clear inline styles and let CSS handle positioning
+      if (this.isMobile()) {
+        el.style.transition = 'none'
+        el.dataset.fullscreen = 'false'
+        document.body.classList.remove('chat-fullscreen')
+        this._syncFullscreenUI(false)
+
+        // Clear all inline styles so CSS media query rules apply
+        el.style.position = ''
+        el.style.top = ''
+        el.style.left = ''
+        el.style.right = ''
+        el.style.bottom = ''
+        el.style.width = ''
+        el.style.height = ''
+        el.style.transform = ''
+
+        // Force layout then restore transitions
+        el.offsetHeight // eslint-disable-line no-unused-expressions
+        el.style.transition = ''
+
+        // Update URL
+        let backUrl = this._previousUrl || (creativeId ? `/creatives/${creativeId}` : null)
+        if (backUrl) {
+          const url = new URL(backUrl, window.location.origin)
+          url.searchParams.set('open_comments', 'true')
+          window.history.pushState({ fullscreen: false }, '', url.pathname + url.search)
+        }
+        this._previousUrl = null
+
+        // Scroll to bottom after layout change
+        requestAnimationFrame(() => {
+          this.listController?.scrollToBottom()
+        })
+        return
+      }
+
+      // Desktop: animated exit to target position
       // Calculate target position using the same logic as updatePosition()
       // so cleanup can apply it directly without calling updatePosition() (which would cause a snap)
-      const creativeId = el.dataset.creativeId
       const scrollY = window.scrollY || window.pageYOffset
 
       // Final absolute-position values (what updatePosition would set)


### PR DESCRIPTION
## Problem

On mobile devices (viewport width ≤ 600px), when exiting fullscreen mode, the comments popup would go outside the device screen boundaries.

**Root cause:** The exit fullscreen logic was calculating desktop-specific pixel positions (`top`, `left`, `width`, `height`) which conflicted with the CSS media query rules.

### Mobile CSS uses:
```css
#comments-popup {
  position: fixed;
  bottom: 0;
  transform: translateY(100%); /* hidden */
}
#comments-popup.open {
  transform: translateY(0);    /* visible */
}
```

### Desktop JS was setting:
```js
el.style.top = '100px';
el.style.left = '500px';
el.style.width = '420px';
// etc. — conflicts with mobile CSS
```

## Solution

Add mobile-specific exit path that:
1. **Skips** the desktop animation
2. **Clears** all inline styles (`position`, `top`, `left`, `right`, `bottom`, `width`, `height`, `transform`)
3. **Lets CSS** media query handle the positioning
4. Updates URL and scrolls to bottom as before

```js
if (this.isMobile()) {
  // Clear all inline styles so CSS takes over
  el.style.position = ''
  el.style.top = ''
  // ... etc
  return
}
```

## Testing

- [x] Jest test passes
- [ ] Manual test on mobile device