### PR TITLE
feat: Restrict sharing non-searchable AI agents to owners only

### DIFF
--- a/engines/collavre/app/controllers/collavre/creative_shares_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creative_shares_controller.rb
@@ -12,6 +12,12 @@ module Collavre
           flash[:notice] = t("collavre.invites.invite_sent")
           redirect_back(fallback_location: creatives_path) and return
         end
+
+        # Restrict sharing non-searchable AI agents to their owners only
+        if user.ai_user? && !user.searchable? && user.created_by_id != Current.user.id
+          flash[:alert] = t("collavre.creatives.share.cannot_share_private_ai_agent")
+          redirect_back(fallback_location: creatives_path) and return
+        end
       end
 
       permission = params[:permission]

--- a/engines/collavre/config/locales/creatives.en.yml
+++ b/engines/collavre/config/locales/creatives.en.yml
@@ -124,6 +124,7 @@ en:
         already_shared_in_parent: Creative already shared in parent creative.
         can_not_share_by_no_access_in_parent: You can not share by no access in parent
           creative.
+        cannot_share_private_ai_agent: Only the owner can share this AI Agent.
       notices:
         progress_recalculated: All parent progress recalculated.
       errors:

--- a/engines/collavre/config/locales/creatives.ko.yml
+++ b/engines/collavre/config/locales/creatives.ko.yml
@@ -111,6 +111,7 @@ ko:
         shared: 크리에이티브가 성공적으로 공유되었습니다.
         already_shared_in_parent: 크리에이티브가 상위 크리에이티브에 이미 공유되었습니다.
         can_not_share_by_no_access_in_parent: 상위 크리에이티브에 접근 금지가 있어서 공유할 수 없습니다.
+        cannot_share_private_ai_agent: AI Agent 소유자만 공유할 수 있습니다.
       notices:
         progress_recalculated: 진행률을 다시 계산 했습니다.
       errors:

--- a/engines/collavre/test/controllers/creative_shares_controller_test.rb
+++ b/engines/collavre/test/controllers/creative_shares_controller_test.rb
@@ -16,4 +16,72 @@ class CreativeSharesControllerTest < ActionDispatch::IntegrationTest
 
     assert Contact.exists?(user: @owner, contact_user: @target_user)
   end
+
+  test "non-owner cannot share non-searchable AI agent" do
+    # Create a non-searchable AI agent owned by @owner
+    ai_agent = User.create!(
+      email: "private-ai@ai.local",
+      password: "password123",
+      name: "Private AI",
+      llm_vendor: "openai",
+      searchable: false,
+      created_by_id: @owner.id
+    )
+
+    # @target_user tries to share the AI agent to their own creative
+    other_user = users(:two)
+    other_creative = Collavre::Creative.create!(user: other_user, description: "Other's creative")
+
+    sign_in_as(other_user, password: "password")
+
+    assert_no_difference("Collavre::CreativeShare.count") do
+      post collavre.creative_creative_shares_path(other_creative), params: { user_email: ai_agent.email, permission: :feedback }
+    end
+
+    assert_match I18n.t("collavre.creatives.share.cannot_share_private_ai_agent"), flash[:alert]
+  end
+
+  test "owner can share non-searchable AI agent" do
+    # Create a non-searchable AI agent owned by @owner
+    ai_agent = User.create!(
+      email: "owner-private-ai@ai.local",
+      password: "password123",
+      name: "Owner's Private AI",
+      llm_vendor: "openai",
+      searchable: false,
+      created_by_id: @owner.id
+    )
+
+    sign_in_as(@owner, password: "password")
+
+    assert_difference("Collavre::CreativeShare.count", 1) do
+      post collavre.creative_creative_shares_path(@creative), params: { user_email: ai_agent.email, permission: :feedback }
+    end
+
+    assert_equal I18n.t("collavre.creatives.share.shared"), flash[:notice]
+  end
+
+  test "anyone can share searchable AI agent" do
+    # Create a searchable AI agent owned by @owner
+    ai_agent = User.create!(
+      email: "public-ai@ai.local",
+      password: "password123",
+      name: "Public AI",
+      llm_vendor: "openai",
+      searchable: true,
+      created_by_id: @owner.id
+    )
+
+    # @target_user (non-owner) shares the searchable AI agent
+    other_user = users(:two)
+    other_creative = Collavre::Creative.create!(user: other_user, description: "Other's creative for public AI")
+
+    sign_in_as(other_user, password: "password")
+
+    assert_difference("Collavre::CreativeShare.count", 1) do
+      post collavre.creative_creative_shares_path(other_creative), params: { user_email: ai_agent.email, permission: :feedback }
+    end
+
+    assert_equal I18n.t("collavre.creatives.share.shared"), flash[:notice]
+  end
 end


### PR DESCRIPTION
## Problem

Users could share any AI Agent (even `searchable: false` ones they don't own) to their own creatives by knowing the AI's email address. This bypassed the `searchable` flag's intended privacy.

### Example scenario:
1. UserA creates AI Agent with `searchable: false`
2. UserA shares AI Agent to Creative A
3. UserB has access to Creative A, sees AI Agent's email
4. UserB could share the AI Agent to their own Creative B ← **Should not be allowed**

## Solution

Add a check in `CreativeSharesController#create`:

```ruby
if user.ai_user? && !user.searchable? && user.created_by_id != Current.user.id
  flash[:alert] = t("collavre.creatives.share.cannot_share_private_ai_agent")
  redirect_back(fallback_location: creatives_path) and return
end
```

## Result

| AI Agent | Who can share to any Creative |
|---|---|
| `searchable: true` | ✅ Anyone |
| `searchable: false` | ✅ Owner only (`created_by_id`) |

## Changes

- `CreativeSharesController#create`: Add AI agent ownership check
- i18n: Add error messages (en, ko)
- Tests: 3 new tests covering all scenarios

## Tests

```
4 runs, 18 assertions, 0 failures, 0 errors
```