### PR TITLE
fix: show AI typing indicator only on the correct creative

### DIFF
--- a/engines/collavre/app/channels/collavre/comments_presence_channel.rb
+++ b/engines/collavre/app/channels/collavre/comments_presence_channel.rb
@@ -12,20 +12,23 @@ class CommentsPresenceChannel < ApplicationCable::Channel
         status: "thinking",
         agent_id: task.agent_id,
         agent_name: task.agent.display_name,
-        task_id: task.id
+        task_id: task.id,
+        source_creative_id: task_creative_id
       )
     end
   end
 
   # Broadcast agent status (thinking/streaming/idle) to presence channel.
   # This allows the frontend typing indicator to show AI agent activity.
-  def self.broadcast_agent_status(creative_id, status:, agent_id:, agent_name:, task_id: nil, content: nil)
+  # source_creative_id: the actual creative where agent is working (for filtering on frontend)
+  def self.broadcast_agent_status(creative_id, status:, agent_id:, agent_name:, task_id: nil, content: nil, source_creative_id: nil)
     payload = {
       agent_status: {
         id: agent_id,
         name: agent_name,
         status: status,
-        task_id: task_id
+        task_id: task_id,
+        creative_id: source_creative_id || creative_id
       }
     }
     payload[:agent_status][:content] = content if content.present?

--- a/engines/collavre/app/javascript/controllers/comments/presence_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/presence_controller.js
@@ -151,7 +151,11 @@ export default class extends Controller {
       this.renderTypingIndicator()
     }
     if (data.agent_status) {
-      const { id, name, status } = data.agent_status
+      const { id, name, status, creative_id: agentCreativeId } = data.agent_status
+      // Only show typing indicator if agent is working on this specific creative
+      if (agentCreativeId && agentCreativeId !== this.creativeId) {
+        return
+      }
       if (status === 'thinking' || status === 'streaming') {
         this.typingUsers[id] = name
       } else {

--- a/engines/collavre/app/services/collavre/ai_agent_service.rb
+++ b/engines/collavre/app/services/collavre/ai_agent_service.rb
@@ -154,7 +154,8 @@ module Collavre
         agent_id: @agent.id,
         agent_name: @agent.display_name,
         task_id: @task.id,
-        content: content
+        content: content,
+        source_creative_id: @creative.id
       )
     end
 


### PR DESCRIPTION
## Bug
AI Agent typing indicator was appearing on all creatives sharing the same `effective_origin`, not just the creative where the agent is actually responding.

**Example:**
- Creative A (chat) and Creative B (creative page) share the same origin
- AI Agent responds in Creative A's chat
- Typing indicator shows on BOTH A and B (wrong!)

## Fix
- Add `source_creative_id` to `agent_status` broadcast payload
- Frontend filters typing indicator by comparing `creative_id`
- Only shows typing indicator when agent is working on *this* specific creative

## Changes
- `comments_presence_channel.rb`: Add `source_creative_id` param to `broadcast_agent_status`
- `ai_agent_service.rb`: Pass actual `@creative.id` as `source_creative_id`
- `presence_controller.js`: Filter `agent_status` by `creative_id`