### PR TITLE
refactor: remove unused Github module aliases

### DIFF
--- a/config/initializers/collavre_model_aliases.rb
+++ b/config/initializers/collavre_model_aliases.rb
@@ -96,15 +96,6 @@ Rails.application.config.to_prepare do
   set_alias(Comments, :McpCommand, Collavre::Comments::McpCommand)
   set_alias(Comments, :CalendarCommand, Collavre::Comments::CalendarCommand)
 
-  # Github module (from CollavreGithub engine)
-  if defined?(CollavreGithub)
-    Object.const_set(:Github, Module.new) unless Object.const_defined?(:Github, false)
-    set_alias(Github, :PullRequestProcessor, CollavreGithub::PullRequestProcessor)
-    set_alias(Github, :WebhookProvisioner, CollavreGithub::WebhookProvisioner)
-    set_alias(Github, :Client, CollavreGithub::Client)
-    set_alias(Github, :PullRequestAnalyzer, CollavreGithub::PullRequestAnalyzer)
-  end
-
   # SystemEvents module
   Object.const_set(:SystemEvents, Module.new) unless Object.const_defined?(:SystemEvents, false)
   set_alias(SystemEvents, :Router, Collavre::SystemEvents::Router)


### PR DESCRIPTION
## Summary

Remove unused non-model aliases for the CollavreGithub engine.

## Changes

Removed the following unused aliases from `config/initializers/collavre_model_aliases.rb`:

```ruby
# Removed (never used - all code uses CollavreGithub:: directly)
Github::PullRequestProcessor
Github::WebhookProvisioner  
Github::Client
Github::PullRequestAnalyzer
```

## Kept

Model aliases are retained for fixture compatibility:
- `GithubAccount` → `CollavreGithub::Account`
- `GithubRepositoryLink` → `CollavreGithub::RepositoryLink`

## Testing

All 833 tests pass.