### PR TITLE
feat: add GitHub PR MCP tools for AI Agent

### DIFF
--- a/engines/collavre_github/app/services/collavre_github/tools/github_pr_commits_service.rb
+++ b/engines/collavre_github/app/services/collavre_github/tools/github_pr_commits_service.rb
@@ -1,0 +1,55 @@
+module CollavreGithub
+  require "sorbet-runtime"
+  require "rails_mcp_engine"
+
+  module Tools
+    class GithubPrCommitsService
+      extend T::Sig
+      extend ToolMeta
+
+      tool_name "github_pr_commits"
+      tool_description <<~DESC.strip
+        Get the commit messages of a GitHub pull request.
+        Returns a list of commit messages in the PR.
+        Requires the creative to have a connected GitHub repository.
+      DESC
+
+      tool_param :creative_id, description: "The ID of the creative with GitHub integration."
+      tool_param :repo, description: "Repository full name (e.g., 'owner/repo')."
+      tool_param :pr_number, description: "Pull request number."
+
+      sig { params(creative_id: Integer, repo: String, pr_number: Integer).returns(T::Hash[Symbol, T.untyped]) }
+      def call(creative_id:, repo:, pr_number:)
+        client = find_github_client(creative_id, repo)
+        return { error: "GitHub account not found for this creative and repository" } unless client
+
+        messages = client.pull_request_commit_messages(repo, pr_number)
+
+        {
+          commits: messages.map.with_index(1) { |msg, i| { index: i, message: msg } },
+          count: messages.size
+        }
+      rescue StandardError => e
+        { error: "Failed to fetch PR commits: #{e.message}" }
+      end
+
+      private
+
+      def find_github_client(creative_id, repo)
+        creative = Collavre::Creative.find_by(id: creative_id)
+        return nil unless creative
+
+        origin = creative.effective_origin
+        link = CollavreGithub::RepositoryLink
+          .joins(:creative)
+          .where(repository_full_name: repo)
+          .where(creative: origin.self_and_descendants)
+          .first
+
+        return nil unless link&.github_account
+
+        CollavreGithub::Client.new(link.github_account)
+      end
+    end
+  end
+end

--- a/engines/collavre_github/app/services/collavre_github/tools/github_pr_details_service.rb
+++ b/engines/collavre_github/app/services/collavre_github/tools/github_pr_details_service.rb
@@ -1,0 +1,69 @@
+module CollavreGithub
+  require "sorbet-runtime"
+  require "rails_mcp_engine"
+
+  module Tools
+    class GithubPrDetailsService
+      extend T::Sig
+      extend ToolMeta
+
+      tool_name "github_pr_details"
+      tool_description <<~DESC.strip
+        Get details of a GitHub pull request including title, body, author, files changed, etc.
+        Requires the creative to have a connected GitHub repository.
+      DESC
+
+      tool_param :creative_id, description: "The ID of the creative with GitHub integration."
+      tool_param :repo, description: "Repository full name (e.g., 'owner/repo')."
+      tool_param :pr_number, description: "Pull request number."
+
+      sig { params(creative_id: Integer, repo: String, pr_number: Integer).returns(T::Hash[Symbol, T.untyped]) }
+      def call(creative_id:, repo:, pr_number:)
+        client = find_github_client(creative_id, repo)
+        return { error: "GitHub account not found for this creative and repository" } unless client
+
+        pr = client.pull_request_details(repo, pr_number)
+        return { error: "Pull request not found" } unless pr
+
+        {
+          number: pr.number,
+          title: pr.title,
+          body: pr.body.to_s.truncate(2000),
+          state: pr.state,
+          merged: pr.merged,
+          author: pr.user&.login,
+          created_at: pr.created_at&.iso8601,
+          updated_at: pr.updated_at&.iso8601,
+          merged_at: pr.merged_at&.iso8601,
+          additions: pr.additions,
+          deletions: pr.deletions,
+          changed_files: pr.changed_files,
+          html_url: pr.html_url,
+          base_branch: pr.base&.ref,
+          head_branch: pr.head&.ref
+        }
+      rescue StandardError => e
+        { error: "Failed to fetch PR details: #{e.message}" }
+      end
+
+      private
+
+      def find_github_client(creative_id, repo)
+        creative = Collavre::Creative.find_by(id: creative_id)
+        return nil unless creative
+
+        # Find repository link for this creative (or its origin)
+        origin = creative.effective_origin
+        link = CollavreGithub::RepositoryLink
+          .joins(:creative)
+          .where(repository_full_name: repo)
+          .where(creative: origin.self_and_descendants)
+          .first
+
+        return nil unless link&.github_account
+
+        CollavreGithub::Client.new(link.github_account)
+      end
+    end
+  end
+end

--- a/engines/collavre_github/app/services/collavre_github/tools/github_pr_diff_service.rb
+++ b/engines/collavre_github/app/services/collavre_github/tools/github_pr_diff_service.rb
@@ -1,0 +1,72 @@
+module CollavreGithub
+  require "sorbet-runtime"
+  require "rails_mcp_engine"
+
+  module Tools
+    class GithubPrDiffService
+      extend T::Sig
+      extend ToolMeta
+
+      DIFF_MAX_LENGTH = 10_000
+
+      tool_name "github_pr_diff"
+      tool_description <<~DESC.strip
+        Get the diff of a GitHub pull request.
+        Returns the patch/diff for all changed files.
+        Requires the creative to have a connected GitHub repository.
+      DESC
+
+      tool_param :creative_id, description: "The ID of the creative with GitHub integration."
+      tool_param :repo, description: "Repository full name (e.g., 'owner/repo')."
+      tool_param :pr_number, description: "Pull request number."
+      tool_param :max_length, description: "Maximum diff length (default: 10000 chars).", required: false
+
+      sig do
+        params(
+          creative_id: Integer,
+          repo: String,
+          pr_number: Integer,
+          max_length: T.nilable(Integer)
+        ).returns(T::Hash[Symbol, T.untyped])
+      end
+      def call(creative_id:, repo:, pr_number:, max_length: nil)
+        max_length ||= DIFF_MAX_LENGTH
+
+        client = find_github_client(creative_id, repo)
+        return { error: "GitHub account not found for this creative and repository" } unless client
+
+        diff = client.pull_request_diff(repo, pr_number)
+        return { error: "Could not fetch diff", diff: nil } unless diff
+
+        truncated = diff.length > max_length
+        diff_text = truncated ? "#{diff[0, max_length]}\n...\n[Diff truncated to #{max_length} characters]" : diff
+
+        {
+          diff: diff_text,
+          truncated: truncated,
+          original_length: diff.length
+        }
+      rescue StandardError => e
+        { error: "Failed to fetch PR diff: #{e.message}" }
+      end
+
+      private
+
+      def find_github_client(creative_id, repo)
+        creative = Collavre::Creative.find_by(id: creative_id)
+        return nil unless creative
+
+        origin = creative.effective_origin
+        link = CollavreGithub::RepositoryLink
+          .joins(:creative)
+          .where(repository_full_name: repo)
+          .where(creative: origin.self_and_descendants)
+          .first
+
+        return nil unless link&.github_account
+
+        CollavreGithub::Client.new(link.github_account)
+      end
+    end
+  end
+end

--- a/engines/collavre_github/test/services/collavre_github/tools/github_pr_details_service_test.rb
+++ b/engines/collavre_github/test/services/collavre_github/tools/github_pr_details_service_test.rb
@@ -1,0 +1,62 @@
+require "test_helper"
+
+module CollavreGithub
+  module Tools
+    class GithubPrDetailsServiceTest < ActiveSupport::TestCase
+      setup do
+        @user = users(:one)
+        @account = CollavreGithub::Account.create!(
+          user: @user,
+          github_uid: "12345",
+          login: "testuser",
+          name: "Test User",
+          token: "test-token"
+        )
+        @creative = creatives(:tshirt)
+        @link = CollavreGithub::RepositoryLink.create!(
+          creative: @creative,
+          github_account: @account,
+          repository_full_name: "owner/repo"
+        )
+      end
+
+      test "returns error when creative not found" do
+        service = GithubPrDetailsService.new
+        result = service.call(creative_id: 999999, repo: "owner/repo", pr_number: 1)
+
+        assert_equal "GitHub account not found for this creative and repository", result[:error]
+      end
+
+      test "returns error when repository link not found for different repo" do
+        service = GithubPrDetailsService.new
+        result = service.call(creative_id: @creative.id, repo: "other/repo", pr_number: 1)
+
+        assert_equal "GitHub account not found for this creative and repository", result[:error]
+      end
+
+      test "finds github client for valid creative and repo" do
+        service = GithubPrDetailsService.new
+
+        # Access private method to test client lookup
+        client = service.send(:find_github_client, @creative.id, "owner/repo")
+
+        assert_not_nil client
+        assert_instance_of CollavreGithub::Client, client
+      end
+
+      test "returns nil client when repository not in creative tree" do
+        # Create unrelated creative without link
+        other_creative = Collavre::Creative.create!(
+          user: @user,
+          description: "Unrelated creative"
+        )
+
+        service = GithubPrDetailsService.new
+        client = service.send(:find_github_client, other_creative.id, "owner/repo")
+
+        # Should return nil because other_creative has no link to owner/repo
+        assert_nil client
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Add MCP tools to `collavre_github` engine for AI Agents to analyze GitHub pull requests.

## New Tools

| Tool | Description |
|------|-------------|
| `github_pr_details` | Get PR title, body, author, files, additions/deletions, etc. |
| `github_pr_diff` | Get PR diff with truncation support (default 10K chars) |
| `github_pr_commits` | Get list of commit messages |

## Architecture

```
AI Agent receives PR event (via System Comment)
    │
    ├── github_pr_details(creative_id, repo, pr_number)
    ├── github_pr_diff(creative_id, repo, pr_number)
    └── github_pr_commits(creative_id, repo, pr_number)
    │
    ▼
GitHub account lookup:
Creative → RepositoryLink → GithubAccount → GitHub API
```

## Testing

- 837 runs, 0 failures ✅
- Rubocop passed ✅

## Next Steps

- Add Seed AI Agent with system prompt for PR analysis
- AI Agent response parsing → Action Comment generation