### PR TITLE
feat: add /topic command to create topic with primary agent

### DIFF
--- a/engines/collavre/app/services/collavre/comments/command_processor.rb
+++ b/engines/collavre/app/services/collavre/comments/command_processor.rb
@@ -26,7 +26,10 @@ module Collavre
       end
 
       def static_commands
-        [ Collavre::Comments::CalendarCommand.new(comment: comment, user: user) ]
+        [
+          Collavre::Comments::CalendarCommand.new(comment: comment, user: user),
+          Collavre::Comments::TopicCommand.new(comment: comment, user: user)
+        ]
       end
 
       def mcp_commands

--- a/engines/collavre/app/services/collavre/comments/topic_command.rb
+++ b/engines/collavre/app/services/collavre/comments/topic_command.rb
@@ -1,0 +1,106 @@
+module Collavre
+  module Comments
+    class TopicCommand
+      def initialize(comment:, user:, url_helpers: Collavre::Engine.routes.url_helpers)
+        @comment = comment
+        @user = user
+        @creative = comment.creative.effective_origin
+        @url_helpers = url_helpers
+      end
+
+      def call
+        return unless topic_command?
+
+        create_topic
+      rescue StandardError => e
+        Rails.logger.error("Topic command failed: #{e.message}")
+        e.message
+      end
+
+      private
+
+      attr_reader :comment, :user, :creative, :url_helpers
+
+      # /topic "topic name" @agent_name
+      # /topic "topic name"
+      COMMAND_PATTERN = /\A\/topic\b/i.freeze
+
+      def topic_command?
+        comment.content.to_s.strip.match?(COMMAND_PATTERN)
+      end
+
+      def parsed_args
+        @parsed_args ||= begin
+          content = comment.content.to_s.strip
+
+          # Extract topic name in quotes
+          name_match = content.match(/[""]([^""]+)[""]|"([^"]+)"/)
+          topic_name = name_match ? (name_match[1] || name_match[2]) : nil
+
+          return if topic_name.blank?
+
+          # Extract @mentions for primary agent
+          agent_match = content.match(/@(\w+)/)
+          agent_name = agent_match ? agent_match[1] : nil
+
+          {
+            name: topic_name,
+            agent_name: agent_name
+          }
+        end
+      end
+
+      def create_topic
+        data = parsed_args
+        return I18n.t("collavre.comments.topic_command.missing_name") if data.blank?
+
+        # Create new topic
+        topic = Topic.create!(
+          creative: creative,
+          user: user,
+          name: data[:name]
+        )
+
+        # Set primary agent if specified
+        primary_agent = find_agent(data[:agent_name]) if data[:agent_name].present?
+
+        if primary_agent
+          set_primary_agent(topic, primary_agent)
+          I18n.t("collavre.comments.topic_command.created_with_agent",
+                 name: topic.name,
+                 agent: primary_agent.name)
+        else
+          if data[:agent_name].present?
+            I18n.t("collavre.comments.topic_command.created_agent_not_found",
+                   name: topic.name,
+                   agent_name: data[:agent_name])
+          else
+            I18n.t("collavre.comments.topic_command.created", name: topic.name)
+          end
+        end
+      end
+
+      def find_agent(name)
+        # Find AI agent by name (case-insensitive)
+        user_class = Collavre.configuration.user_class_name.constantize
+        user_class.where.not(llm_vendor: [ nil, "" ])
+                  .where("LOWER(name) = ?", name.downcase)
+                  .first
+      end
+
+      def set_primary_agent(topic, agent)
+        OrchestratorPolicy.create!(
+          policy_type: "arbitration",
+          scope_type: "Topic",
+          scope_id: topic.id,
+          config: {
+            "strategy" => "primary_first",
+            "primary_agent_id" => agent.id
+          },
+          priority: 10,
+          enabled: true
+        )
+      end
+    end
+  end
+end

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -81,10 +81,17 @@ en:
       command_menu:
         calendar_description: "Create a Google Calendar event."
         calendar_args: "YYYY-MM-DD@HH:MM memo (today/tomorrow, +3days, +2weeks, +1months, +1years, +mon)"
+        topic_description: "Create a new topic with optional primary agent."
+        topic_args: '"topic name" @agent_name'
       calendar_command:
         event_created: 'event created: [Google Calendar event](%{url})'
         event_created_local: 'event created (local only - connect Google Calendar to sync)'
         event_created_sync_failed: 'event created (Google Calendar sync failed - please reconnect your Google account)'
+      topic_command:
+        missing_name: 'Please specify a topic name in quotes: /topic "topic name"'
+        created: 'Topic "%{name}" created.'
+        created_with_agent: 'Topic "%{name}" created with @%{agent} as primary agent.'
+        created_agent_not_found: 'Topic "%{name}" created. Note: Agent @%{agent_name} not found.'
       read_by: Read by %{name}
       activity_logs_summary: Activity Logs
     calendar_events:

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -78,10 +78,17 @@ ko:
       command_menu:
         calendar_description: 구글 캘린더 이벤트를 생성합니다.
         calendar_args: "YYYY-MM-DD@HH:MM 메모 (today/tomorrow, +3days, +2weeks, +1months, +1years, +mon/+월)"
+        topic_description: "새 토픽을 생성합니다. Primary Agent를 지정할 수 있습니다."
+        topic_args: '"토픽 이름" @에이전트이름'
       calendar_command:
         event_created: '이벤트가 생성되었습니다: [구글 캘린더 이벤트](%{url})'
         event_created_local: '이벤트가 생성되었습니다 (로컬 전용 - 구글 캘린더 연동 시 동기화됩니다)'
         event_created_sync_failed: '이벤트가 생성되었습니다 (구글 캘린더 동기화 실패 - 구글 계정을 다시 연동해주세요)'
+      topic_command:
+        missing_name: '토픽 이름을 따옴표로 지정하세요: /topic "토픽 이름"'
+        created: '토픽 "%{name}"이(가) 생성되었습니다.'
+        created_with_agent: '토픽 "%{name}"이(가) 생성되었습니다. @%{agent}이(가) Primary Agent로 설정되었습니다.'
+        created_agent_not_found: '토픽 "%{name}"이(가) 생성되었습니다. 참고: @%{agent_name} 에이전트를 찾을 수 없습니다.'
       read_by: "%{name} 님이 읽음"
       activity_logs_summary: 활동 기록
     calendar_events:

--- a/engines/collavre/test/services/comments/topic_command_test.rb
+++ b/engines/collavre/test/services/comments/topic_command_test.rb
@@ -1,0 +1,106 @@
+require "test_helper"
+
+module Collavre
+  module Comments
+    class TopicCommandTest < ActiveSupport::TestCase
+      setup do
+        @creative = creatives(:tshirt)
+        @user = users(:one)
+        # Create AI agent with name without spaces for easier @mention matching
+        @ai_agent = User.create!(
+          email: "testagent@test.local",
+          password: "password123",
+          name: "TestAgent",
+          llm_vendor: "openai",
+          llm_model: "gpt-4"
+        )
+        @topic = Topic.create!(creative: @creative, user: @user, name: "Test Topic")
+      end
+
+      test "creates topic with quoted name" do
+        comment = create_comment('/topic "My New Topic"')
+
+        result = TopicCommand.new(comment: comment, user: @user).call
+
+        assert_match(/My New Topic/, result)
+        assert Topic.exists?(creative: @creative, name: "My New Topic")
+      end
+
+      test "creates topic with smart quotes" do
+        comment = create_comment('/topic "Smart Quotes Topic"')
+
+        result = TopicCommand.new(comment: comment, user: @user).call
+
+        assert_match(/Smart Quotes Topic/, result)
+        assert Topic.exists?(creative: @creative, name: "Smart Quotes Topic")
+      end
+
+      test "creates topic with primary agent" do
+        comment = create_comment('/topic "Agent Topic" @TestAgent')
+
+        result = TopicCommand.new(comment: comment, user: @user).call
+
+        assert_match(/Agent Topic/, result)
+        assert_match(/TestAgent/, result)
+
+        topic = Topic.find_by(creative: @creative, name: "Agent Topic")
+        assert topic.present?
+
+        policy = OrchestratorPolicy.find_by(scope_type: "Topic", scope_id: topic.id)
+        assert policy.present?
+        assert_equal "arbitration", policy.policy_type
+        assert_equal "primary_first", policy.config["strategy"]
+        assert_equal @ai_agent.id, policy.config["primary_agent_id"]
+      end
+
+      test "returns error when agent not found" do
+        comment = create_comment('/topic "Agent Not Found Topic" @nonexistent_agent')
+
+        result = TopicCommand.new(comment: comment, user: @user).call
+
+        assert_match(/Agent Not Found Topic/, result)
+        assert_match(/nonexistent_agent/, result)
+        assert_match(/not found/i, result)
+
+        # Topic should still be created
+        assert Topic.exists?(creative: @creative, name: "Agent Not Found Topic")
+      end
+
+      test "returns error when topic name is missing" do
+        comment = create_comment("/topic")
+
+        result = TopicCommand.new(comment: comment, user: @user).call
+
+        assert_match(/specify.*name/i, result)
+      end
+
+      test "returns nil for non-topic commands" do
+        comment = create_comment("Hello world")
+
+        result = TopicCommand.new(comment: comment, user: @user).call
+
+        assert_nil result
+      end
+
+      test "is case insensitive" do
+        comment = create_comment('/TOPIC "Uppercase Command"')
+
+        result = TopicCommand.new(comment: comment, user: @user).call
+
+        assert_match(/Uppercase Command/, result)
+        assert Topic.exists?(creative: @creative, name: "Uppercase Command")
+      end
+
+      private
+
+      def create_comment(content)
+        Collavre::Comment.create!(
+          creative: @creative,
+          topic: @topic,
+          user: @user,
+          content: content
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Add a new chat command `/topic` to create topics with optional primary agent assignment.

## Usage

```
/topic "topic name"           # Creates a new topic
/topic "topic name" @agent    # Creates topic with @agent as primary agent
```

## Features

- **Topic Creation**: Creates a new topic in the current creative
- **Primary Agent**: Optionally assign a primary agent using `@agent_name`
- **Smart Quotes**: Supports both regular (") and smart quotes ()
- **Case Insensitive**: Command and agent name matching are case-insensitive
- **OrchestratorPolicy**: Automatically creates `arbitration` policy with `primary_first` strategy

## i18n

- English and Korean translations included
- Command menu descriptions added

## Testing

- 938 runs, 3122 assertions, 0 failures ✅
- 7 new tests for TopicCommand