### PR TITLE
feat: add agent context builder for A2A collaboration

### DIFF
--- a/engines/collavre/app/services/collavre/ai_agent_service.rb
+++ b/engines/collavre/app/services/collavre/ai_agent_service.rb
@@ -32,10 +32,18 @@ module Collavre
           rendering_context["creative"] = creative.as_json if creative
         end
 
+        # Add agent collaboration context
+        agent_context = build_agent_context(creative)
+        rendering_context.merge!(agent_context)
+
         rendered_system_prompt = AiSystemPromptRenderer.new(
           template: @agent.system_prompt,
           context: rendering_context
         ).render
+
+        # Append collaboration guide to system prompt
+        collaboration_prompt = build_collaboration_prompt(creative)
+        rendered_system_prompt = "#{rendered_system_prompt}\n\n#{collaboration_prompt}" if collaboration_prompt.present?
 
         # Create a placeholder comment to stream into
         target_comment_id = @context.dig("comment", "id")
@@ -235,6 +243,18 @@ module Collavre
     def reassociate_activity_logs(from_comment, to_comment)
       ActivityLog.where(comment: from_comment, user: @agent)
                  .update_all(comment_id: to_comment.id)
+    end
+
+    def build_agent_context(creative)
+      return {} unless creative
+
+      Orchestration::AgentContextBuilder.new(agent: @agent, creative: creative).build
+    end
+
+    def build_collaboration_prompt(creative)
+      return nil unless creative
+
+      Orchestration::AgentContextBuilder.new(agent: @agent, creative: creative).to_collaboration_prompt
     end
 
     def handle_approval_pending(error)

--- a/engines/collavre/app/services/collavre/orchestration/agent_context_builder.rb
+++ b/engines/collavre/app/services/collavre/orchestration/agent_context_builder.rb
@@ -1,0 +1,179 @@
+module Collavre
+  module Orchestration
+    # Builds context for AI agents including:
+    # - Agent identity
+    # - Available collaborators from Creative permissions
+    # - Organization hierarchy derived from permission levels
+    #
+    # Permission → Role mapping:
+    # - admin:    escalation targets (supervisors)
+    # - write:    peers (collaborators)
+    # - feedback: reviewers
+    # - read:     information sources only
+    class AgentContextBuilder
+      PERMISSION_ROLES = {
+        "admin" => "escalation",    # Can escalate issues to
+        "write" => "collaborator",  # Can collaborate with
+        "feedback" => "reviewer",   # Can request reviews from
+        "read" => "reference"       # Can request information from
+      }.freeze
+
+      def initialize(agent:, creative:)
+        @agent = agent
+        @creative = creative
+      end
+
+      # Returns hash suitable for Liquid template rendering
+      def build
+        {
+          "agent" => build_agent_identity,
+          "collaborators" => build_collaborators,
+          "collaboration_guide" => build_collaboration_guide
+        }
+      end
+
+      # Generates markdown-formatted collaboration section for system prompt
+      def to_collaboration_prompt
+        collaborators = build_collaborators
+        return "" if collaborators.empty?
+
+        sections = []
+
+        sections << "## 협업 가능한 Agent"
+        sections << ""
+
+        # Group by role
+        by_role = collaborators.group_by { |c| c["role"] }
+
+        if by_role["escalation"]&.any?
+          sections << "### 에스컬레이션 대상 (문제 해결 불가 시)"
+          by_role["escalation"].each do |c|
+            sections << "- @#{c['name']}: #{c['description']}"
+          end
+          sections << ""
+        end
+
+        if by_role["collaborator"]&.any?
+          sections << "### 협업 가능 (함께 작업)"
+          by_role["collaborator"].each do |c|
+            sections << "- @#{c['name']}: #{c['description']}"
+          end
+          sections << ""
+        end
+
+        if by_role["reviewer"]&.any?
+          sections << "### 리뷰어 (검토 요청)"
+          by_role["reviewer"].each do |c|
+            sections << "- @#{c['name']}: #{c['description']}"
+          end
+          sections << ""
+        end
+
+        if by_role["reference"]&.any?
+          sections << "### 참조 (정보 요청만)"
+          by_role["reference"].each do |c|
+            sections << "- @#{c['name']}: #{c['description']}"
+          end
+          sections << ""
+        end
+
+        sections << "## 협업 규칙"
+        sections << "- 다른 Agent 호출: @이름 요청내용"
+        sections << "- 확신이 낮으면 재검토 후 발화"
+        sections << "- 막히면 에스컬레이션 대상에게 도움 요청"
+        sections << "- 코드 리뷰가 필요하면 리뷰어에게 요청"
+        sections << ""
+
+        sections.join("\n")
+      end
+
+      private
+
+      def build_agent_identity
+        {
+          "id" => @agent.id,
+          "name" => @agent.name,
+          "display_name" => @agent.display_name,
+          "type" => extract_agent_type
+        }
+      end
+
+      def extract_agent_type
+        # Extract agent type from system_prompt or default
+        prompt = @agent.system_prompt.to_s.downcase
+        case prompt
+        when /developer|개발/ then "developer"
+        when /pm|project.?manager|프로젝트/ then "pm"
+        when /qa|test|quality|테스트|품질/ then "qa"
+        when /research|조사|연구/ then "researcher"
+        when /market|마케팅/ then "marketer"
+        when /plan|기획/ then "planner"
+        else "agent"
+        end
+      end
+
+      def build_collaborators
+        return [] unless @creative
+
+        # Get all AI agents with access to this creative tree
+        ai_agents_with_access.map do |user, permission|
+          next if user.id == @agent.id # Skip self
+
+          {
+            "id" => user.id,
+            "name" => user.name,
+            "display_name" => user.display_name,
+            "role" => PERMISSION_ROLES[permission] || "reference",
+            "permission" => permission,
+            "description" => extract_agent_description(user)
+          }
+        end.compact
+      end
+
+      def ai_agents_with_access
+        # Collect AI agents from creative and its ancestors
+        creatives_to_check = [ @creative ] + @creative.ancestors.to_a
+
+        agent_permissions = {}
+
+        creatives_to_check.each do |creative|
+          creative.creative_shares.includes(:user).each do |share|
+            user = share.user
+            next unless user&.ai_user?
+            next if share.permission == "no_access"
+
+            # Keep highest permission level
+            current = agent_permissions[user]
+            if current.nil? || permission_rank(share.permission) > permission_rank(current)
+              agent_permissions[user] = share.permission
+            end
+          end
+        end
+
+        agent_permissions.to_a
+      end
+
+      def permission_rank(permission)
+        CreativeShare.permissions[permission.to_s] || 0
+      end
+
+      def extract_agent_description(user)
+        prompt = user.system_prompt.to_s
+        # Extract first meaningful line or sentence
+        first_line = prompt.lines.find { |l| l.strip.present? && !l.start_with?("#") }
+        return "AI Agent" unless first_line
+
+        # Truncate to reasonable length
+        first_line.strip.truncate(100)
+      end
+
+      def build_collaboration_guide
+        {
+          "mention_format" => "@이름 요청내용",
+          "escalation_hint" => "확신이 낮거나 막히면 에스컬레이션 대상에게 도움 요청",
+          "review_hint" => "코드 리뷰나 검토가 필요하면 리뷰어에게 요청"
+        }
+      end
+    end
+  end
+end

--- a/engines/collavre/test/services/collavre/orchestration/agent_context_builder_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/agent_context_builder_test.rb
@@ -1,0 +1,278 @@
+require "test_helper"
+
+module Collavre
+  module Orchestration
+    class AgentContextBuilderTest < ActiveSupport::TestCase
+      setup do
+        @human_user = Collavre::User.create!(
+          name: "John",
+          email: "john-#{SecureRandom.hex(4)}@test.test",
+          password: "password123"
+        )
+
+        # Create AI agent
+        @ai_agent = Collavre::User.create!(
+          name: "dev-agent",
+          email: "dev-#{SecureRandom.hex(4)}@agent.test",
+          password: "password123",
+          llm_vendor: "openai",
+          llm_model: "gpt-4",
+          system_prompt: "You are a developer agent specialized in Ruby on Rails."
+        )
+
+        # Create another AI agent for collaboration
+        @qa_agent = Collavre::User.create!(
+          name: "qa-agent",
+          email: "qa-#{SecureRandom.hex(4)}@agent.test",
+          password: "password123",
+          llm_vendor: "openai",
+          llm_model: "gpt-4",
+          system_prompt: "You are a QA engineer focused on testing and quality assurance."
+        )
+
+        # Create PM agent
+        @pm_agent = Collavre::User.create!(
+          name: "pm-agent",
+          email: "pm-#{SecureRandom.hex(4)}@agent.test",
+          password: "password123",
+          llm_vendor: "openai",
+          llm_model: "gpt-4",
+          system_prompt: "You are a project manager coordinating development tasks."
+        )
+
+        # Create creative
+        @creative = Collavre::Creative.create!(
+          description: "Test project",
+          user: @human_user
+        )
+      end
+
+      test "builds agent identity" do
+        builder = AgentContextBuilder.new(agent: @ai_agent, creative: @creative)
+        result = builder.build
+
+        assert_equal @ai_agent.id, result["agent"]["id"]
+        assert_equal "dev-agent", result["agent"]["name"]
+        assert_equal "developer", result["agent"]["type"]
+      end
+
+      test "extracts agent type from system prompt" do
+        builder = AgentContextBuilder.new(agent: @qa_agent, creative: @creative)
+        result = builder.build
+
+        assert_equal "qa", result["agent"]["type"]
+      end
+
+      test "builds empty collaborators when no other agents have access" do
+        builder = AgentContextBuilder.new(agent: @ai_agent, creative: @creative)
+        result = builder.build
+
+        assert_empty result["collaborators"]
+      end
+
+      test "builds collaborators from creative shares" do
+        # Share creative with QA agent (write permission)
+        Collavre::CreativeShare.create!(
+          creative: @creative,
+          user: @qa_agent,
+          permission: :write
+        )
+
+        builder = AgentContextBuilder.new(agent: @ai_agent, creative: @creative)
+        result = builder.build
+
+        assert_equal 1, result["collaborators"].length
+        collaborator = result["collaborators"].first
+        assert_equal @qa_agent.id, collaborator["id"]
+        assert_equal "qa-agent", collaborator["name"]
+        assert_equal "collaborator", collaborator["role"]
+        assert_equal "write", collaborator["permission"]
+      end
+
+      test "maps admin permission to escalation role" do
+        Collavre::CreativeShare.create!(
+          creative: @creative,
+          user: @pm_agent,
+          permission: :admin
+        )
+
+        builder = AgentContextBuilder.new(agent: @ai_agent, creative: @creative)
+        result = builder.build
+
+        collaborator = result["collaborators"].find { |c| c["id"] == @pm_agent.id }
+        assert_equal "escalation", collaborator["role"]
+      end
+
+      test "maps feedback permission to reviewer role" do
+        Collavre::CreativeShare.create!(
+          creative: @creative,
+          user: @qa_agent,
+          permission: :feedback
+        )
+
+        builder = AgentContextBuilder.new(agent: @ai_agent, creative: @creative)
+        result = builder.build
+
+        collaborator = result["collaborators"].first
+        assert_equal "reviewer", collaborator["role"]
+      end
+
+      test "maps read permission to reference role" do
+        Collavre::CreativeShare.create!(
+          creative: @creative,
+          user: @qa_agent,
+          permission: :read
+        )
+
+        builder = AgentContextBuilder.new(agent: @ai_agent, creative: @creative)
+        result = builder.build
+
+        collaborator = result["collaborators"].first
+        assert_equal "reference", collaborator["role"]
+      end
+
+      test "excludes self from collaborators" do
+        # Share creative with self
+        Collavre::CreativeShare.create!(
+          creative: @creative,
+          user: @ai_agent,
+          permission: :write
+        )
+
+        builder = AgentContextBuilder.new(agent: @ai_agent, creative: @creative)
+        result = builder.build
+
+        assert_empty result["collaborators"]
+      end
+
+      test "excludes no_access permission" do
+        Collavre::CreativeShare.create!(
+          creative: @creative,
+          user: @qa_agent,
+          permission: :no_access
+        )
+
+        builder = AgentContextBuilder.new(agent: @ai_agent, creative: @creative)
+        result = builder.build
+
+        assert_empty result["collaborators"]
+      end
+
+      test "excludes human users from collaborators" do
+        Collavre::CreativeShare.create!(
+          creative: @creative,
+          user: @human_user,
+          permission: :admin
+        )
+
+        builder = AgentContextBuilder.new(agent: @ai_agent, creative: @creative)
+        result = builder.build
+
+        # Human user should not be in collaborators
+        human_collaborator = result["collaborators"].find { |c| c["id"] == @human_user.id }
+        assert_nil human_collaborator
+      end
+
+      test "inherits permissions from parent creatives" do
+        # Create parent creative with QA agent access
+        parent = Collavre::Creative.create!(
+          description: "Parent project",
+          user: @human_user
+        )
+
+        Collavre::CreativeShare.create!(
+          creative: parent,
+          user: @qa_agent,
+          permission: :write
+        )
+
+        # Create child creative
+        child = Collavre::Creative.create!(
+          description: "Child task",
+          user: @human_user,
+          parent: parent
+        )
+
+        builder = AgentContextBuilder.new(agent: @ai_agent, creative: child)
+        result = builder.build
+
+        # QA agent should be available from parent permission
+        assert_equal 1, result["collaborators"].length
+        assert_equal @qa_agent.id, result["collaborators"].first["id"]
+      end
+
+      test "keeps highest permission level when multiple exist" do
+        # Create parent with read permission
+        parent = Collavre::Creative.create!(
+          description: "Parent project",
+          user: @human_user
+        )
+
+        Collavre::CreativeShare.create!(
+          creative: parent,
+          user: @qa_agent,
+          permission: :read
+        )
+
+        # Create child with write permission
+        child = Collavre::Creative.create!(
+          description: "Child task",
+          user: @human_user,
+          parent: parent
+        )
+
+        Collavre::CreativeShare.create!(
+          creative: child,
+          user: @qa_agent,
+          permission: :write
+        )
+
+        builder = AgentContextBuilder.new(agent: @ai_agent, creative: child)
+        result = builder.build
+
+        collaborator = result["collaborators"].first
+        assert_equal "write", collaborator["permission"]
+        assert_equal "collaborator", collaborator["role"]
+      end
+
+      test "generates collaboration prompt" do
+        Collavre::CreativeShare.create!(
+          creative: @creative,
+          user: @pm_agent,
+          permission: :admin
+        )
+
+        Collavre::CreativeShare.create!(
+          creative: @creative,
+          user: @qa_agent,
+          permission: :feedback
+        )
+
+        builder = AgentContextBuilder.new(agent: @ai_agent, creative: @creative)
+        prompt = builder.to_collaboration_prompt
+
+        assert_includes prompt, "## 협업 가능한 Agent"
+        assert_includes prompt, "### 에스컬레이션 대상"
+        assert_includes prompt, "@pm-agent"
+        assert_includes prompt, "### 리뷰어"
+        assert_includes prompt, "@qa-agent"
+        assert_includes prompt, "## 협업 규칙"
+      end
+
+      test "returns empty string when no collaborators" do
+        builder = AgentContextBuilder.new(agent: @ai_agent, creative: @creative)
+        prompt = builder.to_collaboration_prompt
+
+        assert_equal "", prompt
+      end
+
+      test "handles nil creative gracefully" do
+        builder = AgentContextBuilder.new(agent: @ai_agent, creative: nil)
+        result = builder.build
+
+        assert_equal @ai_agent.id, result["agent"]["id"]
+        assert_empty result["collaborators"]
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Add AgentContextBuilder service for Agent-to-Agent (A2A) communication support.

## Changes

### New Service: AgentContextBuilder
- Builds collaboration context for AI agents based on Creative permissions
- Extracts available collaborator agents from Creative tree
- Maps permission levels to collaboration roles:
  | Permission | Role | Usage |
  |------------|------|-------|
  | admin | escalation | Report to when stuck |
  | write | collaborator | Work together |
  | feedback | reviewer | Request code reviews |
  | read | reference | Request information |

### AiAgentService Updates
- Injects collaboration context into system prompt
- Adds collaboration guide with @mention format
- Supports permission inheritance from parent creatives

## How It Works

1. When an AI agent starts processing, AgentContextBuilder analyzes:
   - Current Creative's permissions
   - Parent Creative's permissions (inherited)
   - Available AI agents with access

2. System prompt now includes:
   - Agent identity (name, role, type)
   - List of collaborating agents with their roles
   - @mention format for calling other agents
   - Collaboration rules

## Example Generated Context
```
## 협업 가능한 Agent

### 에스컬레이션 대상 (문제 해결 불가 시)
- @pm-agent: You are a project manager...

### 협업 가능 (함께 작업)
- @dev-agent-2: You are a developer...

### 리뷰어 (검토 요청)
- @qa-agent: You are a QA engineer...

## 협업 규칙
- 다른 Agent 호출: @이름 요청내용
- 확신이 낮으면 재검토 후 발화
- 막히면 에스컬레이션 대상에게 도움 요청
```

## Tests
- 15 new tests for AgentContextBuilder
- All 953 tests pass (86 orchestration tests)