### PR TITLE
feat: add A2A sender context for agent-to-agent communication

### DIFF
--- a/engines/collavre/app/services/collavre/ai_agent_service.rb
+++ b/engines/collavre/app/services/collavre/ai_agent_service.rb
@@ -248,13 +248,21 @@ module Collavre
     def build_agent_context(creative)
       return {} unless creative
 
-      Orchestration::AgentContextBuilder.new(agent: @agent, creative: creative).build
+      Orchestration::AgentContextBuilder.new(
+        agent: @agent,
+        creative: creative,
+        sender: @context["sender"]
+      ).build
     end
 
     def build_collaboration_prompt(creative)
       return nil unless creative
 
-      Orchestration::AgentContextBuilder.new(agent: @agent, creative: creative).to_collaboration_prompt
+      Orchestration::AgentContextBuilder.new(
+        agent: @agent,
+        creative: creative,
+        sender: @context["sender"]
+      ).to_collaboration_prompt
     end
 
     def handle_approval_pending(error)

--- a/engines/collavre/app/services/collavre/orchestration/agent_context_builder.rb
+++ b/engines/collavre/app/services/collavre/orchestration/agent_context_builder.rb
@@ -4,6 +4,7 @@ module Collavre
     # - Agent identity
     # - Available collaborators from Creative permissions
     # - Organization hierarchy derived from permission levels
+    # - Sender context for A2A communication
     #
     # Permission → Role mapping:
     # - admin:    escalation targets (supervisors)
@@ -18,26 +19,46 @@ module Collavre
         "read" => "reference"       # Can request information from
       }.freeze
 
-      def initialize(agent:, creative:)
+      def initialize(agent:, creative:, sender: nil)
         @agent = agent
         @creative = creative
+        @sender = sender
+      end
+
+      def a2a_request?
+        @sender && @sender["is_ai"] == true
       end
 
       # Returns hash suitable for Liquid template rendering
       def build
-        {
+        result = {
           "agent" => build_agent_identity,
           "collaborators" => build_collaborators,
-          "collaboration_guide" => build_collaboration_guide
+          "collaboration_guide" => build_collaboration_guide,
+          "is_a2a" => a2a_request?
         }
+
+        result["sender"] = @sender if @sender
+        result
       end
 
       # Generates markdown-formatted collaboration section for system prompt
       def to_collaboration_prompt
-        collaborators = build_collaborators
-        return "" if collaborators.empty?
-
         sections = []
+
+        # Add A2A request context if this is an agent-to-agent call
+        if a2a_request?
+          sections << "## ⚡ Agent 요청"
+          sections << ""
+          sections << "이 메시지는 다른 AI Agent(@#{@sender['name']}, #{@sender['type']})가 보낸 요청입니다."
+          sections << "- 요청에 집중해서 답변하세요"
+          sections << "- 완료되면 결과를 명확히 전달하세요"
+          sections << "- 추가 정보가 필요하면 요청자에게 @멘션으로 물어보세요"
+          sections << ""
+        end
+
+        collaborators = build_collaborators
+        return sections.join("\n") if collaborators.empty?
 
         sections << "## 협업 가능한 Agent"
         sections << ""

--- a/engines/collavre/app/services/collavre/system_events/context_builder.rb
+++ b/engines/collavre/app/services/collavre/system_events/context_builder.rb
@@ -14,10 +14,42 @@ module Collavre
           ctx["chat"]["mentioned_user"] ||= mentioned_user(ctx["chat"])
         end
 
+        # Add sender context for A2A communication
+        ctx["sender"] ||= build_sender_context(ctx)
+
         ctx
       end
 
       private
+
+      def build_sender_context(ctx)
+        user_id = ctx.dig("comment", "user_id")
+        return nil unless user_id
+
+        user = User.find_by(id: user_id)
+        return nil unless user
+
+        {
+          "id" => user.id,
+          "name" => user.name,
+          "display_name" => user.respond_to?(:display_name) ? user.display_name : user.name,
+          "is_ai" => user.ai_user?,
+          "type" => user.ai_user? ? extract_agent_type(user) : "human"
+        }
+      end
+
+      def extract_agent_type(user)
+        prompt = user.system_prompt.to_s.downcase
+        case prompt
+        when /developer|개발/ then "developer"
+        when /pm|project.?manager|프로젝트/ then "pm"
+        when /qa|test|quality|테스트|품질/ then "qa"
+        when /research|조사|연구/ then "researcher"
+        when /market|마케팅/ then "marketer"
+        when /plan|기획/ then "planner"
+        else "agent"
+        end
+      end
 
       def mentioned_user(chat_context)
         # This mimics the chat.mentioned_user function requested

--- a/engines/collavre/test/services/collavre/orchestration/agent_context_builder_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/agent_context_builder_test.rb
@@ -273,6 +273,117 @@ module Collavre
         assert_equal @ai_agent.id, result["agent"]["id"]
         assert_empty result["collaborators"]
       end
+
+      # A2A (Agent-to-Agent) communication tests
+      test "detects A2A request when sender is AI" do
+        sender = {
+          "id" => @qa_agent.id,
+          "name" => @qa_agent.name,
+          "is_ai" => true,
+          "type" => "qa"
+        }
+
+        builder = AgentContextBuilder.new(agent: @ai_agent, creative: @creative, sender: sender)
+
+        assert builder.a2a_request?
+        assert builder.build["is_a2a"]
+      end
+
+      test "does not detect A2A when sender is human" do
+        sender = {
+          "id" => @human_user.id,
+          "name" => @human_user.name,
+          "is_ai" => false,
+          "type" => "human"
+        }
+
+        builder = AgentContextBuilder.new(agent: @ai_agent, creative: @creative, sender: sender)
+
+        assert_not builder.a2a_request?
+        assert_not builder.build["is_a2a"]
+      end
+
+      test "does not detect A2A when sender is nil" do
+        builder = AgentContextBuilder.new(agent: @ai_agent, creative: @creative, sender: nil)
+
+        assert_not builder.a2a_request?
+        assert_not builder.build["is_a2a"]
+      end
+
+      test "includes sender in build result when provided" do
+        sender = {
+          "id" => @qa_agent.id,
+          "name" => @qa_agent.name,
+          "is_ai" => true,
+          "type" => "qa"
+        }
+
+        builder = AgentContextBuilder.new(agent: @ai_agent, creative: @creative, sender: sender)
+        result = builder.build
+
+        assert_equal sender, result["sender"]
+      end
+
+      test "collaboration prompt includes A2A context when sender is AI" do
+        Collavre::CreativeShare.create!(
+          creative: @creative,
+          user: @pm_agent,
+          permission: :admin
+        )
+
+        sender = {
+          "id" => @qa_agent.id,
+          "name" => "qa-agent",
+          "is_ai" => true,
+          "type" => "qa"
+        }
+
+        builder = AgentContextBuilder.new(agent: @ai_agent, creative: @creative, sender: sender)
+        prompt = builder.to_collaboration_prompt
+
+        assert_includes prompt, "## ⚡ Agent 요청"
+        assert_includes prompt, "@qa-agent"
+        assert_includes prompt, "다른 AI Agent"
+        assert_includes prompt, "## 협업 가능한 Agent"
+      end
+
+      test "collaboration prompt excludes A2A context when sender is human" do
+        Collavre::CreativeShare.create!(
+          creative: @creative,
+          user: @pm_agent,
+          permission: :admin
+        )
+
+        sender = {
+          "id" => @human_user.id,
+          "name" => @human_user.name,
+          "is_ai" => false,
+          "type" => "human"
+        }
+
+        builder = AgentContextBuilder.new(agent: @ai_agent, creative: @creative, sender: sender)
+        prompt = builder.to_collaboration_prompt
+
+        assert_not_includes prompt, "## ⚡ Agent 요청"
+        assert_includes prompt, "## 협업 가능한 Agent"
+      end
+
+      test "A2A context appears even without collaborators" do
+        sender = {
+          "id" => @qa_agent.id,
+          "name" => "qa-agent",
+          "is_ai" => true,
+          "type" => "qa"
+        }
+
+        builder = AgentContextBuilder.new(agent: @ai_agent, creative: @creative, sender: sender)
+        prompt = builder.to_collaboration_prompt
+
+        assert_includes prompt, "## ⚡ Agent 요청"
+        assert_includes prompt, "@qa-agent"
+        # No collaborators section since none shared
+        assert_not_includes prompt, "## 협업 가능한 Agent"
+      end
     end
   end
 end

--- a/engines/collavre/test/services/collavre/system_events/context_builder_test.rb
+++ b/engines/collavre/test/services/collavre/system_events/context_builder_test.rb
@@ -1,0 +1,131 @@
+require "test_helper"
+
+module Collavre
+  module SystemEvents
+    class ContextBuilderTest < ActiveSupport::TestCase
+      setup do
+        @human_user = Collavre::User.create!(
+          name: "John",
+          email: "john-#{SecureRandom.hex(4)}@test.test",
+          password: "password123"
+        )
+
+        @ai_agent = Collavre::User.create!(
+          name: "dev-agent",
+          email: "dev-#{SecureRandom.hex(4)}@agent.test",
+          password: "password123",
+          llm_vendor: "openai",
+          llm_model: "gpt-4",
+          system_prompt: "You are a developer agent."
+        )
+
+        @creative = Collavre::Creative.create!(
+          description: "Test project",
+          user: @human_user
+        )
+      end
+
+      test "builds sender context for human user" do
+        context = {
+          comment: { id: 1, content: "Hello", user_id: @human_user.id },
+          creative: { id: @creative.id }
+        }
+
+        result = ContextBuilder.new(context).build
+
+        assert result["sender"].present?
+        assert_equal @human_user.id, result["sender"]["id"]
+        assert_equal @human_user.name, result["sender"]["name"]
+        assert_equal false, result["sender"]["is_ai"]
+        assert_equal "human", result["sender"]["type"]
+      end
+
+      test "builds sender context for AI agent" do
+        context = {
+          comment: { id: 1, content: "Hello", user_id: @ai_agent.id },
+          creative: { id: @creative.id }
+        }
+
+        result = ContextBuilder.new(context).build
+
+        assert result["sender"].present?
+        assert_equal @ai_agent.id, result["sender"]["id"]
+        assert_equal @ai_agent.name, result["sender"]["name"]
+        assert_equal true, result["sender"]["is_ai"]
+        assert_equal "developer", result["sender"]["type"]
+      end
+
+      test "extracts agent type from system prompt" do
+        qa_agent = Collavre::User.create!(
+          name: "qa-agent",
+          email: "qa-#{SecureRandom.hex(4)}@agent.test",
+          password: "password123",
+          llm_vendor: "openai",
+          system_prompt: "You are a QA tester."
+        )
+
+        context = {
+          comment: { id: 1, content: "Review this", user_id: qa_agent.id }
+        }
+
+        result = ContextBuilder.new(context).build
+
+        assert_equal "qa", result["sender"]["type"]
+      end
+
+      test "returns nil sender when user_id is missing" do
+        context = {
+          comment: { id: 1, content: "Hello" }
+        }
+
+        result = ContextBuilder.new(context).build
+
+        assert_nil result["sender"]
+      end
+
+      test "returns nil sender when user not found" do
+        context = {
+          comment: { id: 1, content: "Hello", user_id: 999999 }
+        }
+
+        result = ContextBuilder.new(context).build
+
+        assert_nil result["sender"]
+      end
+
+      test "builds mentioned_user from chat content" do
+        context = {
+          chat: { content: "@#{@ai_agent.name}: please help" }
+        }
+
+        result = ContextBuilder.new(context).build
+
+        assert result["chat"]["mentioned_user"].present?
+        assert_equal @ai_agent.id, result["chat"]["mentioned_user"]["id"]
+      end
+
+      test "handles missing chat context gracefully" do
+        context = {
+          comment: { id: 1, content: "Hello" }
+        }
+
+        result = ContextBuilder.new(context).build
+
+        assert_nil result["chat"]
+      end
+
+      test "preserves existing context keys" do
+        context = {
+          comment: { id: 1, content: "Hello", user_id: @human_user.id },
+          creative: { id: @creative.id, description: "Test" },
+          custom_key: "custom_value"
+        }
+
+        result = ContextBuilder.new(context).build
+
+        assert_equal "custom_value", result["custom_key"]
+        assert_equal @creative.id, result["creative"]["id"]
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Adds sender context to enable proper Agent-to-Agent (A2A) communication.

## Changes

### SystemEvents::ContextBuilder
- Add `sender` context with user info (id, name, is_ai, type)
- Extract agent type from system_prompt (developer, pm, qa, researcher, etc.)

### AgentContextBuilder
- Accept optional `sender` parameter
- Add `a2a_request?` method to detect AI-to-AI requests
- Include `is_a2a` flag in build result
- Add A2A-specific instructions in collaboration prompt when sender is AI

### AiAgentService
- Pass sender context to AgentContextBuilder

## How It Works

1. When a comment is created, `ContextBuilder` extracts sender info
2. If sender is an AI agent (`is_ai: true`), the receiving agent gets:
   - A2A request indicator in collaboration prompt
   - Sender identity (name, type)
   - Instructions to respond to the agent request

## Example A2A Prompt Addition

When Agent B receives a message from Agent A:
```
## ⚡ Agent 요청

이 메시지는 다른 AI Agent(@qa-agent, qa)가 보낸 요청입니다.
- 요청에 집중해서 답변하세요
- 완료되면 결과를 명확히 전달하세요
- 추가 정보가 필요하면 요청자에게 @멘션으로 물어보세요
```

## Tests
- 17 new tests for A2A functionality
- All 986 tests passing