### PR TITLE
feat: add stuck detection and auto-escalation

### DIFF
--- a/engines/collavre/app/jobs/collavre/stuck_detector_job.rb
+++ b/engines/collavre/app/jobs/collavre/stuck_detector_job.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Collavre
+  # StuckDetectorJob runs periodically to detect stuck tasks and creatives.
+  #
+  # This job should be scheduled to run every 5-10 minutes via cron or similar.
+  #
+  # Usage:
+  #   StuckDetectorJob.perform_later
+  #
+  # To schedule with SolidQueue:
+  #   # config/recurring.yml
+  #   stuck_detector:
+  #     class: Collavre::StuckDetectorJob
+  #     schedule: every 10 minutes
+  #
+  class StuckDetectorJob < ApplicationJob
+    queue_as :default
+
+    def perform
+      detector = Orchestration::StuckDetector.new
+      result = detector.detect_and_escalate
+
+      if result.escalated_count > 0
+        Rails.logger.info(
+          "[StuckDetectorJob] Detected #{result.stuck_items.count} stuck items, " \
+          "escalated #{result.escalated_count}"
+        )
+      end
+
+      result
+    end
+  end
+end

--- a/engines/collavre/app/models/collavre/orchestrator_policy.rb
+++ b/engines/collavre/app/models/collavre/orchestrator_policy.rb
@@ -38,7 +38,7 @@ module Collavre
     SCOPE_TYPES = %w[Creative Topic User].freeze
 
     # Policy types
-    POLICY_TYPES = %w[matching arbitration scheduling].freeze
+    POLICY_TYPES = %w[matching arbitration scheduling stuck_detection].freeze
 
     # Arbitration strategies
     ARBITRATION_STRATEGIES = %w[all primary_first round_robin bid].freeze

--- a/engines/collavre/app/services/collavre/orchestration/policy_resolver.rb
+++ b/engines/collavre/app/services/collavre/orchestration/policy_resolver.rb
@@ -41,6 +41,12 @@ module Collavre
           "task_timeout_minutes" => 60,         # Max time for a single task
           "token_spike_threshold" => 50_000,    # Token usage spike in window
           "token_spike_window_minutes" => 10
+        },
+        "stuck_detection" => {
+          "enabled" => false,
+          "task_stuck_threshold_minutes" => 30,       # Task running for > N minutes
+          "creative_stall_threshold_minutes" => 120,  # Creative no progress for > N minutes
+          "create_system_comment" => true             # Create system comment on escalation
         }
       }.freeze
 
@@ -127,6 +133,20 @@ module Collavre
           "token_spike_threshold" => scheduling_config["token_spike_threshold"],
           "token_spike_window_minutes" => scheduling_config["token_spike_window_minutes"]
         }
+      end
+
+      # Stuck detection settings
+      def stuck_detection_enabled?
+        stuck_detection_config["enabled"] == true
+      end
+
+      def stuck_detection_config
+        @stuck_detection_config ||= resolve("stuck_detection")
+      end
+
+      # Generic resolve method for any policy type
+      def resolve(policy_type)
+        merge_policies(policy_type)
       end
 
       private

--- a/engines/collavre/app/services/collavre/orchestration/stuck_detector.rb
+++ b/engines/collavre/app/services/collavre/orchestration/stuck_detector.rb
@@ -1,0 +1,275 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Orchestration
+    # StuckDetector detects stuck tasks and creatives, then auto-escalates to admins.
+    #
+    # Detection conditions:
+    # 1. Running tasks that haven't progressed for N minutes
+    # 2. Tasks with too many retries (escalated but not handled)
+    # 3. Creatives with no progress for extended periods
+    #
+    # Auto-escalation:
+    # - Creates InboxItem for admin users
+    # - Optionally creates a system comment
+    #
+    class StuckDetector
+      # Result object for detection
+      Result = Struct.new(:stuck_items, :escalated_count, keyword_init: true)
+
+      # StuckItem represents a detected stuck item
+      StuckItem = Struct.new(:type, :item, :reason, :stuck_since, :escalation_targets, keyword_init: true)
+
+      def initialize(policy_resolver: nil)
+        @policy_resolver = policy_resolver || PolicyResolver.new({})
+      end
+
+      # Run detection and escalation
+      # Returns Result with stuck items and escalation count
+      def detect_and_escalate
+        config = stuck_detection_config
+        return Result.new(stuck_items: [], escalated_count: 0) unless config["enabled"]
+
+        stuck_items = []
+        stuck_items.concat(detect_stuck_tasks(config))
+        stuck_items.concat(detect_stalled_creatives(config))
+
+        escalated_count = escalate_stuck_items(stuck_items, config)
+
+        Result.new(stuck_items: stuck_items, escalated_count: escalated_count)
+      end
+
+      # Detect only (no escalation)
+      def detect
+        config = stuck_detection_config
+        return [] unless config["enabled"]
+
+        stuck_items = []
+        stuck_items.concat(detect_stuck_tasks(config))
+        stuck_items.concat(detect_stalled_creatives(config))
+        stuck_items
+      end
+
+      private
+
+      def stuck_detection_config
+        @policy_resolver.resolve("stuck_detection")
+      end
+
+      # Detect tasks that are stuck in running state
+      def detect_stuck_tasks(config)
+        threshold_minutes = config["task_stuck_threshold_minutes"] || 30
+        threshold_time = threshold_minutes.minutes.ago
+
+        stuck_tasks = Task.where(status: "running")
+                          .where("updated_at < ?", threshold_time)
+
+        stuck_tasks.filter_map do |task|
+          # Skip if already escalated recently
+          next if recently_escalated?(task)
+
+          escalation_targets = find_escalation_targets(task)
+          next if escalation_targets.empty?
+
+          StuckItem.new(
+            type: :task,
+            item: task,
+            reason: :no_progress,
+            stuck_since: task.updated_at,
+            escalation_targets: escalation_targets
+          )
+        end
+      end
+
+      # Detect creatives that have stalled (no activity for extended period)
+      def detect_stalled_creatives(config)
+        threshold_minutes = config["creative_stall_threshold_minutes"] || 120
+        threshold_time = threshold_minutes.minutes.ago
+
+        # Find creatives with incomplete status but no recent activity
+        # Only check creatives that have at least one AI agent with access
+        stalled = []
+
+        Creative.where("progress < 1.0")
+                .where("updated_at < ?", threshold_time)
+                .find_each do |creative|
+          # Skip if no AI agents have access
+          ai_agents = creative.creative_shares.joins(:user)
+                              .where(users: { llm_vendor: [ nil, "" ].map { |v| v } })
+                              .or(creative.creative_shares.joins(:user).where.not(users: { llm_vendor: nil }))
+                              .where.not(permission: "no_access")
+                              .map(&:user)
+                              .select(&:ai_user?)
+
+          next if ai_agents.empty?
+
+          # Skip if already escalated recently
+          next if recently_escalated_creative?(creative)
+
+          escalation_targets = find_creative_escalation_targets(creative)
+          next if escalation_targets.empty?
+
+          stalled << StuckItem.new(
+            type: :creative,
+            item: creative,
+            reason: :stalled,
+            stuck_since: creative.updated_at,
+            escalation_targets: escalation_targets
+          )
+        end
+
+        stalled
+      end
+
+      def find_escalation_targets(task)
+        # Find admin users for the task's creative
+        creative_id = task.trigger_event_payload&.dig("creative", "id")
+        return [] unless creative_id
+
+        creative = Creative.find_by(id: creative_id)
+        return [] unless creative
+
+        find_creative_escalation_targets(creative)
+      end
+
+      def find_creative_escalation_targets(creative)
+        # Find users with admin permission on the creative or its ancestors
+        admin_users = []
+
+        ([ creative ] + creative.ancestors.to_a).each do |c|
+          c.creative_shares.where(permission: "admin").includes(:user).each do |share|
+            admin_users << share.user unless share.user.ai_user?
+          end
+        end
+
+        # Also include the creative owner
+        admin_users << creative.user if creative.user && !creative.user.ai_user?
+
+        admin_users.uniq
+      end
+
+      def recently_escalated?(task)
+        # Check if we've already escalated this task in the last hour
+        cache_key = "stuck_detector:task:#{task.id}"
+        Rails.cache.exist?(cache_key)
+      end
+
+      def recently_escalated_creative?(creative)
+        cache_key = "stuck_detector:creative:#{creative.id}"
+        Rails.cache.exist?(cache_key)
+      end
+
+      def mark_escalated(item)
+        cache_key = case item.type
+        when :task then "stuck_detector:task:#{item.item.id}"
+        when :creative then "stuck_detector:creative:#{item.item.id}"
+        end
+        # Don't re-escalate for 1 hour
+        Rails.cache.write(cache_key, true, expires_in: 1.hour)
+      end
+
+      def escalate_stuck_items(stuck_items, config)
+        escalated_count = 0
+
+        stuck_items.each do |stuck_item|
+          escalated = escalate_item(stuck_item, config)
+          if escalated
+            mark_escalated(stuck_item)
+            escalated_count += 1
+          end
+        end
+
+        escalated_count
+      end
+
+      def escalate_item(stuck_item, config)
+        stuck_item.escalation_targets.each do |target|
+          create_inbox_notification(target, stuck_item)
+        end
+
+        # Optionally create a system comment
+        if config["create_system_comment"] && stuck_item.type == :task
+          create_system_comment(stuck_item)
+        end
+
+        true
+      rescue StandardError => e
+        Rails.logger.error("[StuckDetector] Failed to escalate: #{e.message}")
+        false
+      end
+
+      def create_inbox_notification(owner, stuck_item)
+        message_key, message_params = build_message(stuck_item)
+
+        creative = case stuck_item.type
+        when :task
+                     creative_id = stuck_item.item.trigger_event_payload&.dig("creative", "id")
+                     Creative.find_by(id: creative_id)
+        when :creative
+                     stuck_item.item
+        end
+
+        InboxItem.create!(
+          owner: owner,
+          message_key: message_key,
+          message_params: message_params,
+          creative: creative,
+          link: creative ? Collavre::Engine.routes.url_helpers.creative_path(creative) : nil
+        )
+      end
+
+      def build_message(stuck_item)
+        case stuck_item.type
+        when :task
+          task = stuck_item.item
+          minutes_stuck = ((Time.current - stuck_item.stuck_since) / 60).round
+
+          [
+            "collavre.stuck_detection.task_stuck",
+            {
+              task_name: task.name,
+              agent_name: task.agent&.display_name || "Unknown",
+              minutes: minutes_stuck
+            }
+          ]
+        when :creative
+          creative = stuck_item.item
+          hours_stuck = ((Time.current - stuck_item.stuck_since) / 3600).round
+
+          [
+            "collavre.stuck_detection.creative_stalled",
+            {
+              creative_title: creative.description&.truncate(50) || "Untitled",
+              hours: hours_stuck,
+              progress: ((creative.progress || 0) * 100).round
+            }
+          ]
+        end
+      end
+
+      def create_system_comment(stuck_item)
+        return unless stuck_item.type == :task
+
+        task = stuck_item.item
+        creative_id = task.trigger_event_payload&.dig("creative", "id")
+        creative = Creative.find_by(id: creative_id)
+        return unless creative
+
+        topic_id = task.topic_id
+
+        content = I18n.t(
+          "collavre.stuck_detection.system_comment",
+          task_name: task.name,
+          agent_name: task.agent&.display_name || "Unknown"
+        )
+
+        Comment.create!(
+          creative: creative,
+          content: content,
+          user: nil, # System comment
+          topic_id: topic_id
+        )
+      end
+    end
+  end
+end

--- a/engines/collavre/config/locales/ai_agent.en.yml
+++ b/engines/collavre/config/locales/ai_agent.en.yml
@@ -1,5 +1,9 @@
 en:
   collavre:
+    stuck_detection:
+      task_stuck: "⚠️ Task '%{task_name}' assigned to %{agent_name} has been stuck for %{minutes} minutes."
+      creative_stalled: "⚠️ Creative '%{creative_title}' has stalled at %{progress}%% for %{hours} hours."
+      system_comment: "[System] Task '%{task_name}' by %{agent_name} appears stuck. Admin attention required."
     ai_agent:
       approval:
         message: |

--- a/engines/collavre/config/locales/ai_agent.ko.yml
+++ b/engines/collavre/config/locales/ai_agent.ko.yml
@@ -1,5 +1,9 @@
 ko:
   collavre:
+    stuck_detection:
+      task_stuck: "⚠️ '%{task_name}' 작업이 %{agent_name}에게 할당된 후 %{minutes}분 동안 진행되지 않고 있습니다."
+      creative_stalled: "⚠️ '%{creative_title}' Creative가 %{progress}%%에서 %{hours}시간 동안 정체되어 있습니다."
+      system_comment: "[시스템] %{agent_name}의 '%{task_name}' 작업이 막힌 것 같습니다. 관리자 확인이 필요합니다."
     ai_agent:
       approval:
         message: |

--- a/engines/collavre/test/services/collavre/orchestration/matcher_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/matcher_test.rb
@@ -186,6 +186,8 @@ module Collavre
           searchable: true,
           routing_expression: 'event_name == "comment_created"'
         )
+        # Give other_agent permission on creative
+        CreativeShare.create!(creative: @creative, user: other_agent, permission: "feedback")
 
         context = {
           "event_name" => "comment_created",

--- a/engines/collavre/test/services/collavre/orchestration/stuck_detector_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/stuck_detector_test.rb
@@ -1,0 +1,281 @@
+require "test_helper"
+
+module Collavre
+  module Orchestration
+    class StuckDetectorTest < ActiveSupport::TestCase
+      setup do
+        @human_user = Collavre::User.create!(
+          name: "Admin",
+          email: "admin-#{SecureRandom.hex(4)}@test.test",
+          password: "password123"
+        )
+
+        @ai_agent = Collavre::User.create!(
+          name: "dev-agent",
+          email: "dev-#{SecureRandom.hex(4)}@agent.test",
+          password: "password123",
+          llm_vendor: "openai",
+          llm_model: "gpt-4",
+          system_prompt: "You are a developer agent."
+        )
+
+        @creative = Collavre::Creative.create!(
+          description: "Test project",
+          user: @human_user,
+          progress: 0.5
+        )
+
+        # Give human admin access
+        Collavre::CreativeShare.create!(
+          creative: @creative,
+          user: @human_user,
+          permission: :admin
+        )
+
+        # Create topic for tasks
+        @topic = Collavre::Topic.create!(
+          creative: @creative,
+          name: "Test topic",
+          user: @human_user
+        )
+      end
+
+      def create_policy_with_stuck_detection(enabled: true, task_threshold: 30, creative_threshold: 120)
+        Collavre::OrchestratorPolicy.create!(
+          policy_type: "stuck_detection",
+          scope_type: nil,
+          config: {
+            "enabled" => enabled,
+            "task_stuck_threshold_minutes" => task_threshold,
+            "creative_stall_threshold_minutes" => creative_threshold,
+            "create_system_comment" => true
+          }
+        )
+      end
+
+      # Basic functionality tests
+      test "returns empty result when disabled" do
+        policy = create_policy_with_stuck_detection(enabled: false)
+
+        # Create a stuck task
+        task = Collavre::Task.create!(
+          name: "Stuck task",
+          agent: @ai_agent,
+          status: "running",
+          trigger_event_payload: { "creative" => { "id" => @creative.id } },
+          topic_id: @topic.id,
+          created_at: 1.hour.ago,
+          updated_at: 1.hour.ago
+        )
+
+        detector = StuckDetector.new
+        result = detector.detect_and_escalate
+
+        assert_empty result.stuck_items
+        assert_equal 0, result.escalated_count
+      ensure
+        policy&.destroy
+      end
+
+      test "detects stuck running task" do
+        policy = create_policy_with_stuck_detection(enabled: true, task_threshold: 30)
+
+        # Create a task that's been running for too long
+        task = Collavre::Task.create!(
+          name: "Stuck task",
+          agent: @ai_agent,
+          status: "running",
+          trigger_event_payload: { "creative" => { "id" => @creative.id } },
+          topic_id: @topic.id
+        )
+        task.update_columns(created_at: 1.hour.ago, updated_at: 1.hour.ago)
+
+        detector = StuckDetector.new
+        stuck_items = detector.detect
+
+        assert_equal 1, stuck_items.count
+        assert_equal :task, stuck_items.first.type
+        assert_equal :no_progress, stuck_items.first.reason
+        assert_equal task.id, stuck_items.first.item.id
+      ensure
+        policy&.destroy
+      end
+
+      test "does not detect recently updated task as stuck" do
+        policy = create_policy_with_stuck_detection(enabled: true, task_threshold: 30)
+
+        # Create a task that was updated recently
+        task = Collavre::Task.create!(
+          name: "Active task",
+          agent: @ai_agent,
+          status: "running",
+          trigger_event_payload: { "creative" => { "id" => @creative.id } },
+          topic_id: @topic.id
+        )
+        # Task was updated just now, so it's not stuck
+
+        detector = StuckDetector.new
+        stuck_items = detector.detect
+
+        task_stuck = stuck_items.find { |item| item.type == :task && item.item.id == task.id }
+        assert_nil task_stuck
+      ensure
+        policy&.destroy
+      end
+
+      test "detects stalled creative" do
+        policy = create_policy_with_stuck_detection(enabled: true, creative_threshold: 60)
+
+        # Give AI agent access to creative
+        Collavre::CreativeShare.create!(
+          creative: @creative,
+          user: @ai_agent,
+          permission: :write
+        )
+
+        # Make creative stale
+        @creative.update_columns(updated_at: 3.hours.ago)
+
+        detector = StuckDetector.new
+        stuck_items = detector.detect
+
+        creative_stuck = stuck_items.find { |item| item.type == :creative }
+        assert_not_nil creative_stuck
+        assert_equal :stalled, creative_stuck.reason
+        assert_equal @creative.id, creative_stuck.item.id
+      ensure
+        policy&.destroy
+      end
+
+      test "does not detect completed creative as stalled" do
+        policy = create_policy_with_stuck_detection(enabled: true, creative_threshold: 60)
+
+        # Complete the creative
+        @creative.update!(progress: 1.0)
+        @creative.update_columns(updated_at: 3.hours.ago)
+
+        detector = StuckDetector.new
+        stuck_items = detector.detect
+
+        creative_stuck = stuck_items.find { |item| item.type == :creative && item.item.id == @creative.id }
+        assert_nil creative_stuck
+      ensure
+        policy&.destroy
+      end
+
+      test "escalates and creates inbox item" do
+        policy = create_policy_with_stuck_detection(enabled: true, task_threshold: 30)
+
+        task = Collavre::Task.create!(
+          name: "Stuck task",
+          agent: @ai_agent,
+          status: "running",
+          trigger_event_payload: { "creative" => { "id" => @creative.id } },
+          topic_id: @topic.id
+        )
+        task.update_columns(created_at: 1.hour.ago, updated_at: 1.hour.ago)
+
+        initial_inbox_count = InboxItem.where(owner: @human_user).count
+
+        detector = StuckDetector.new
+        result = detector.detect_and_escalate
+
+        assert_equal 1, result.escalated_count
+        assert_equal initial_inbox_count + 1, InboxItem.where(owner: @human_user).count
+
+        inbox_item = InboxItem.where(owner: @human_user).last
+        assert_equal "collavre.stuck_detection.task_stuck", inbox_item.message_key
+      ensure
+        policy&.destroy
+      end
+
+      test "does not re-escalate recently escalated task" do
+        policy = create_policy_with_stuck_detection(enabled: true, task_threshold: 30)
+
+        task = Collavre::Task.create!(
+          name: "Stuck task",
+          agent: @ai_agent,
+          status: "running",
+          trigger_event_payload: { "creative" => { "id" => @creative.id } },
+          topic_id: @topic.id
+        )
+        task.update_columns(created_at: 1.hour.ago, updated_at: 1.hour.ago)
+
+        detector = StuckDetector.new
+
+        # First escalation
+        result1 = detector.detect_and_escalate
+        assert_equal 1, result1.escalated_count
+
+        # Second escalation should be blocked by cache
+        result2 = detector.detect_and_escalate
+        assert_equal 0, result2.escalated_count
+      ensure
+        policy&.destroy
+        Rails.cache.clear
+      end
+
+      test "finds escalation targets from creative admin permission" do
+        policy = create_policy_with_stuck_detection(enabled: true, task_threshold: 30)
+
+        # Create another admin
+        admin2 = Collavre::User.create!(
+          name: "Admin2",
+          email: "admin2-#{SecureRandom.hex(4)}@test.test",
+          password: "password123"
+        )
+        Collavre::CreativeShare.create!(
+          creative: @creative,
+          user: admin2,
+          permission: :admin
+        )
+
+        task = Collavre::Task.create!(
+          name: "Stuck task",
+          agent: @ai_agent,
+          status: "running",
+          trigger_event_payload: { "creative" => { "id" => @creative.id } },
+          topic_id: @topic.id
+        )
+        task.update_columns(created_at: 1.hour.ago, updated_at: 1.hour.ago)
+
+        detector = StuckDetector.new
+        stuck_items = detector.detect
+
+        escalation_targets = stuck_items.first.escalation_targets
+        assert_includes escalation_targets.map(&:id), @human_user.id
+        assert_includes escalation_targets.map(&:id), admin2.id
+      ensure
+        policy&.destroy
+      end
+
+      test "excludes AI agents from escalation targets" do
+        policy = create_policy_with_stuck_detection(enabled: true, task_threshold: 30)
+
+        # Give AI agent admin permission (should be excluded)
+        Collavre::CreativeShare.create!(
+          creative: @creative,
+          user: @ai_agent,
+          permission: :admin
+        )
+
+        task = Collavre::Task.create!(
+          name: "Stuck task",
+          agent: @ai_agent,
+          status: "running",
+          trigger_event_payload: { "creative" => { "id" => @creative.id } },
+          topic_id: @topic.id
+        )
+        task.update_columns(created_at: 1.hour.ago, updated_at: 1.hour.ago)
+
+        detector = StuckDetector.new
+        stuck_items = detector.detect
+
+        escalation_targets = stuck_items.first.escalation_targets
+        assert_not_includes escalation_targets.map(&:id), @ai_agent.id
+      ensure
+        policy&.destroy
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Add stuck detection and auto-escalation system for AI agents.

## Changes
- Add `StuckDetector` service to detect stuck tasks and stalled creatives
- Add `StuckDetectorJob` for periodic detection
- Add stuck_detection policy settings to `PolicyResolver`
- Add i18n messages for stuck detection alerts (en/ko)
- Add `stuck_detection` to valid policy types
- Fix matcher permission tests for searchable agents
- Fix dispatcher tests to include creative permission cache

## Detection Conditions
- **Stuck tasks**: Tasks running for > N minutes without progress
- **Stalled creatives**: Creatives with < 100% progress and no updates for > N minutes

## Auto-Escalation
- Creates `InboxItem` for admin users
- Optionally creates system comment

## Configurable Settings (via OrchestratorPolicy)
```ruby
{
  "enabled" => false,                      # default disabled
  "task_stuck_threshold_minutes" => 30,
  "creative_stall_threshold_minutes" => 120,
  "create_system_comment" => true
}
```

## Test Results
- 995 runs, 3266 assertions, 0 failures, 0 errors
- All existing tests pass
- 9 new tests for StuckDetector