### PR TITLE
fix: require creative permission for all agents regardless of searchable

### DIFF
--- a/engines/collavre/app/services/collavre/orchestration/matcher.rb
+++ b/engines/collavre/app/services/collavre/orchestration/matcher.rb
@@ -11,8 +11,8 @@ module Collavre
     # 2. Expression-based: Evaluate each agent's routing_expression (Liquid)
     #
     # Permission checks:
-    # - Searchable agents can respond to any message
-    # - Non-searchable agents need feedback permission on the creative
+    # - All agents need feedback permission on the creative to respond
+    # - searchable only affects discoverability, not response permission
     #
     class Matcher
       def initialize(context)
@@ -83,10 +83,8 @@ module Collavre
       end
 
       def has_creative_permission?(agent)
-        # Searchable agents can receive any routed message
-        return true if agent.searchable?
-
-        # Non-searchable agents need feedback permission on the creative
+        # All agents need feedback permission on the creative to respond
+        # searchable only affects discoverability, not response permission
         creative_id = @context.dig("creative", "id") || @context.dig(:creative, :id)
         return false unless creative_id
 

--- a/engines/collavre/test/services/collavre/orchestration/agent_orchestrator_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/agent_orchestrator_test.rb
@@ -13,6 +13,17 @@ module Collavre
         # Ensure AI agent has permission (searchable) for tests
         @ai_agent.update!(searchable: true)
 
+        # Grant feedback permission on the creative for AI agent
+        # (searchable only affects discoverability, not response permission)
+        share = CreativeShare.find_or_create_by!(creative: @creative, user: @ai_agent)
+        share.update!(permission: "feedback")
+        # Manually create cache entry (after_commit doesn't run in test transaction)
+        CreativeSharesCache.find_or_create_by!(
+          creative_id: @creative.id,
+          user_id: @ai_agent.id,
+          permission: :feedback
+        )
+
         # Clear any existing routing expressions
         User.where.not(llm_vendor: nil).update_all(routing_expression: nil)
       end

--- a/engines/collavre/test/services/collavre/orchestration/matcher_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/matcher_test.rb
@@ -13,6 +13,17 @@ module Collavre
         # Default to searchable for most tests (permission tests override this)
         @ai_agent.update!(searchable: true)
 
+        # Grant feedback permission on the creative for AI agent
+        # (searchable only affects discoverability, not response permission)
+        share = CreativeShare.find_or_create_by!(creative: @creative, user: @ai_agent)
+        share.update!(permission: "feedback")
+        # Manually create cache entry (after_commit doesn't run in test transaction)
+        CreativeSharesCache.find_or_create_by!(
+          creative_id: @creative.id,
+          user_id: @ai_agent.id,
+          permission: :feedback
+        )
+
         # Clear any existing routing expressions
         User.where.not(llm_vendor: nil).update_all(routing_expression: nil)
       end
@@ -133,9 +144,10 @@ module Collavre
 
       # --- Permission checks ---
 
-      test "searchable agent matches without creative permission" do
+      test "searchable agent does NOT match without creative permission" do
         @ai_agent.update!(searchable: true, routing_expression: 'event_name == "comment_created"')
         other_creative = Creative.create!(user: @user, description: "Other")
+        # No permission granted on other_creative
 
         context = {
           "event_name" => "comment_created",
@@ -144,7 +156,8 @@ module Collavre
         }
 
         result = Matcher.new(context).match
-        assert_includes result, @ai_agent
+        # searchable only affects discoverability, not response permission
+        assert_not_includes result, @ai_agent
       end
 
       test "non-searchable agent requires creative permission" do

--- a/engines/collavre/test/services/system_events/dispatcher_test.rb
+++ b/engines/collavre/test/services/system_events/dispatcher_test.rb
@@ -9,6 +9,9 @@ module SystemEvents
       @original_adapter = ActiveJob::Base.queue_adapter
       ActiveJob::Base.queue_adapter = :test
 
+      @user = users(:one)
+      @creative = creatives(:tshirt)
+
       @agent = User.create!(
         email: "dispatcher_test_agent@example.com",
         name: "Dispatcher Agent",
@@ -19,7 +22,17 @@ module SystemEvents
         searchable: true
       )
 
-      @context = { "some" => "context" }
+      # Grant feedback permission on the creative for AI agent
+      share = Collavre::CreativeShare.find_or_create_by!(creative: @creative, user: @agent)
+      share.update!(permission: "feedback")
+      # Manually create cache entry (after_commit doesn't run in test transaction)
+      Collavre::CreativeSharesCache.find_or_create_by!(
+        creative_id: @creative.id,
+        user_id: @agent.id,
+        permission: :feedback
+      )
+
+      @context = { "creative" => { "id" => @creative.id }, "some" => "context" }
     end
 
     teardown do
@@ -50,7 +63,10 @@ module SystemEvents
     end
 
     test "preserves mentioned_user in context" do
-      chat_context = { "chat" => { "content" => "@Dispatcher Agent: Hello" } }
+      chat_context = {
+        "creative" => { "id" => @creative.id },
+        "chat" => { "content" => "@Dispatcher Agent: Hello" }
+      }
 
       assert_enqueued_with(job: AiAgentJob) do
         SystemEvents::Dispatcher.dispatch("test_event", chat_context)


### PR DESCRIPTION
## Summary
Fix bug where AI agents with `searchable: true` could respond to messages without having feedback permission on the creative.

## Problem
`Matcher#has_creative_permission?` was returning `true` early for searchable agents, bypassing the creative permission check:
```ruby
def has_creative_permission?(agent)
  return true if agent.searchable?  # ← BUG: bypass permission check
  ...
end
```

## Solution
- Remove `searchable` bypass in `Matcher#has_creative_permission?`
- **searchable** now only affects **discoverability** (can be found in search)
- **All agents** require **feedback permission** on the creative to respond

## Changes
- `matcher.rb`: Remove searchable bypass, update comments
- `matcher_test.rb`: Add permission setup, fix test expectations
- `agent_orchestrator_test.rb`: Add permission setup
- `dispatcher_test.rb`: Add creative context and permission setup

## Test Results
- 986 runs, 3243 assertions, 0 failures, 0 errors