### PR TITLE
fix: share user search showing results briefly then disappearing

### DIFF
--- a/engines/collavre/app/controllers/collavre/users_controller.rb
+++ b/engines/collavre/app/controllers/collavre/users_controller.rb
@@ -137,7 +137,10 @@ module Collavre
       end
 
       scope = if params[:scope] == "contacts" && Current.user
-        Current.user.contact_users
+        # Include both contacts and searchable users (e.g., AI agents with searchable=true)
+        contact_ids = Current.user.contact_users.select(:id)
+        searchable_ids = Collavre::User.where(searchable: true).select(:id)
+        Collavre::User.where(id: contact_ids).or(Collavre::User.where(id: searchable_ids))
       else
         Collavre::User.mentionable_for(creative)
       end

--- a/engines/collavre/app/javascript/collavre.js
+++ b/engines/collavre/app/javascript/collavre.js
@@ -12,7 +12,6 @@ import "./modules/plans_menu"
 import "./modules/inbox_panel"
 import "./modules/creative_guide"
 import "./modules/share_modal"
-import "./modules/share_user_popup"
 import "./modules/creative_row_editor"
 import "./modules/slide_view"
 


### PR DESCRIPTION
## Problem
AI agent (GitHub PR Analyzer) could not be shared via the share popup — search results appeared briefly then disappeared.

## Root Cause
Two competing modules were bound to the same input and popup DOM elements:

1. **Legacy `share_user_popup.js`** (vanilla JS, turbo:load) — searched without scope, had `blur -> setTimeout(hide, 150)` that killed results
2. **`share_user_search_controller.js`** (Stimulus) — searched with `scope=contacts`

This caused race conditions where results appeared from one module and were immediately hidden by the other's blur handler.

Additionally, the `scope=contacts` search only queried the user's contacts, so AI agents with `searchable=true` that weren't in contacts wouldn't appear even without the race condition.

## Changes
- Remove legacy `share_user_popup.js` import (Stimulus controller handles all functionality)
- Include `searchable` users (e.g., AI agents) in contacts scope search results