### PR TITLE
fix: strip HTML from creative title in stuck detector notifications

### DIFF
--- a/engines/collavre/app/services/collavre/orchestration/stuck_detector.rb
+++ b/engines/collavre/app/services/collavre/orchestration/stuck_detector.rb
@@ -267,7 +267,7 @@ module Collavre
           [
             "collavre.stuck_detection.creative_stalled",
             {
-              creative_title: creative.description&.truncate(50) || "Untitled",
+              creative_title: creative.creative_snippet,
               hours: hours_stuck,
               progress: ((creative.progress || 0) * 100).round
             }


### PR DESCRIPTION
## Problem
Stuck detector inbox notifications displayed raw HTML from Lexical editor in the creative title:
```
⚠️ '<div><p class="lexical-paragraph"><span style="...' Creative가 67%에서 130시간 동안 정체되어 있습니다.
```

## Fix
Use `creative_snippet` (which strips HTML tags and truncates) instead of raw `description.truncate(50)`.

## Note
The notifications repeating every hour is by design — the cache TTL for `recently_escalated_creative?` is 1 hour. If this is too frequent, the TTL can be increased separately.