### PR TITLE
feat: add completion emoji reaction on review message update

### DIFF
--- a/engines/collavre/app/controllers/collavre/comments/reactions_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comments/reactions_controller.rb
@@ -45,15 +45,7 @@ module Collavre
       end
 
       def broadcast_reaction_update
-        payload = build_reaction_payload
-        Turbo::StreamsChannel.broadcast_action_to(
-          [ @creative, :comments ],
-          action: "update_reactions",
-          target: view_context.dom_id(@comment),
-          attributes: {
-            data: payload.to_json
-          }
-        )
+        CommentReaction.broadcast_reaction_update(@comment)
       end
 
       def set_creative

--- a/engines/collavre/app/models/collavre/comment_reaction.rb
+++ b/engines/collavre/app/models/collavre/comment_reaction.rb
@@ -7,5 +7,20 @@ module Collavre
 
     validates :emoji, presence: true, length: { maximum: 16 }
     validates :user_id, uniqueness: { scope: [ :comment_id, :emoji ] }
+
+    def self.broadcast_reaction_update(comment)
+      creative = comment.creative
+      reactions = comment.comment_reactions.reload.to_a
+      payload = reactions.group_by(&:emoji).map do |emoji, grouped|
+        { emoji: emoji, count: grouped.size, user_ids: grouped.map(&:user_id) }
+      end
+
+      Turbo::StreamsChannel.broadcast_action_to(
+        [ creative, :comments ],
+        action: "update_reactions",
+        target: "comment_#{comment.id}",
+        attributes: { data: payload.to_json }
+      )
+    end
   end
 end

--- a/engines/collavre/app/services/collavre/ai_agent_service.rb
+++ b/engines/collavre/app/services/collavre/ai_agent_service.rb
@@ -105,6 +105,8 @@ module Collavre
           if @response_content.present?
             # Review message handling: update the quoted comment if agent has edit permission
             if @original_comment&.review_message? && handle_review_message(@response_content)
+              # React to the review message with a completion emoji
+              add_review_completion_reaction(@original_comment)
               # Preserve activity logs by moving them to the quoted comment before destroying placeholder
               reassociate_activity_logs(@reply_comment, @original_comment.quoted_comment)
               @reply_comment.destroy!
@@ -274,6 +276,32 @@ module Collavre
         content: response_content
       })
       true
+    end
+
+    def add_review_completion_reaction(comment)
+      CommentReaction.find_or_create_by!(
+        comment: comment,
+        user: @agent,
+        emoji: "✅"
+      )
+      broadcast_reaction_update(comment)
+    rescue ActiveRecord::RecordNotUnique
+      # Already reacted, ignore
+    end
+
+    def broadcast_reaction_update(comment)
+      creative = comment.creative
+      reactions = comment.comment_reactions.reload.to_a
+      payload = reactions.group_by(&:emoji).map do |emoji, grouped|
+        { emoji: emoji, count: grouped.size, user_ids: grouped.map(&:user_id) }
+      end
+
+      Turbo::StreamsChannel.broadcast_action_to(
+        [ creative, :comments ],
+        action: "update_reactions",
+        target: "comment_#{comment.id}",
+        attributes: { data: payload.to_json }
+      )
     end
 
     def reply_to_comment(comment_id, content)

--- a/engines/collavre/app/services/collavre/ai_agent_service.rb
+++ b/engines/collavre/app/services/collavre/ai_agent_service.rb
@@ -279,29 +279,21 @@ module Collavre
     end
 
     def add_review_completion_reaction(comment)
-      CommentReaction.find_or_create_by!(
-        comment: comment,
-        user: @agent,
-        emoji: "✅"
-      )
-      broadcast_reaction_update(comment)
-    rescue ActiveRecord::RecordNotUnique
-      # Already reacted, ignore
-    end
-
-    def broadcast_reaction_update(comment)
-      creative = comment.creative
-      reactions = comment.comment_reactions.reload.to_a
-      payload = reactions.group_by(&:emoji).map do |emoji, grouped|
-        { emoji: emoji, count: grouped.size, user_ids: grouped.map(&:user_id) }
+      reaction = begin
+        CommentReaction.find_or_create_by!(
+          comment: comment,
+          user: @agent,
+          emoji: "✅"
+        )
+      rescue ActiveRecord::RecordNotUnique
+        # Already reacted via race condition, fetch existing
+        CommentReaction.find_by(comment: comment, user: @agent, emoji: "✅")
       end
 
-      Turbo::StreamsChannel.broadcast_action_to(
-        [ creative, :comments ],
-        action: "update_reactions",
-        target: "comment_#{comment.id}",
-        attributes: { data: payload.to_json }
-      )
+      CommentReaction.broadcast_reaction_update(comment) if reaction
+    rescue StandardError => e
+      # Reaction is supplementary; log but don't fail the review update
+      Rails.logger.warn("[AiAgentService] Failed to add review reaction: #{e.message}")
     end
 
     def reply_to_comment(comment_id, content)


### PR DESCRIPTION
## Summary
When an AI Agent successfully updates the original message via a review message, it now adds a ✅ emoji reaction to the review message.

## Changes
- Added `add_review_completion_reaction` method to `AiAgentService`
- Added `broadcast_reaction_update` to push the reaction via Turbo Streams for real-time UI update
- Reaction is added after successful review message handling, before placeholder comment cleanup

## Behavior
- AI Agent processes a review message → updates the quoted comment → adds ✅ to the review message → destroys placeholder
- Uses `find_or_create_by!` with `RecordNotUnique` rescue for idempotency
- Broadcasts via the same Turbo channel used by the reactions controller