### PR TITLE
fix: correct GitHub PR Analyzer routing expression

### DIFF
--- a/engines/collavre_github/db/seeds.rb
+++ b/engines/collavre_github/db/seeds.rb
@@ -53,9 +53,9 @@ module CollavreGithub
     PROMPT
 
     # Matches GitHub PR merged events
-    # The comment content will contain "### GitHub: Pull Request merged"
+    # The comment content will contain "### GitHub: Pull Request Merged"
     ROUTING_EXPRESSION = <<~EXPR.strip
-      event_name == "comment_created" and chat.comment.user_id == nil and chat.comment.content contains "GitHub: Pull Request merged"
+      event_name == "comment_created" and comment.user_id == nil and comment.content contains "GitHub: Pull Request Merged"
     EXPR
 
     TOOLS = %w[

--- a/engines/collavre_github/test/db/seeds_test.rb
+++ b/engines/collavre_github/test/db/seeds_test.rb
@@ -46,27 +46,25 @@ class CollavreGithub::SeedsTest < ActiveSupport::TestCase
     # Should match PR merged event
     context = {
       "event_name" => "comment_created",
-      "chat" => {
-        "comment" => {
-          "user_id" => nil,
-          "content" => "### GitHub: Pull Request merged\n**Repository:** owner/repo"
-        }
+      "comment" => {
+        "user_id" => nil,
+        "content" => "### GitHub: Pull Request Merged\n**Repository:** owner/repo"
       }
     }
     assert_equal "true", template.render(context)
 
     # Should not match non-merged PR
-    context["chat"]["comment"]["content"] = "### GitHub: Pull Request opened"
+    context["comment"]["content"] = "### GitHub: Pull Request opened"
     assert_equal "", template.render(context)
 
     # Should not match user comments
-    context["chat"]["comment"]["user_id"] = 123
-    context["chat"]["comment"]["content"] = "### GitHub: Pull Request merged"
+    context["comment"]["user_id"] = 123
+    context["comment"]["content"] = "### GitHub: Pull Request Merged"
     assert_equal "", template.render(context)
 
     # Should not match other events
     context["event_name"] = "other_event"
-    context["chat"]["comment"]["user_id"] = nil
+    context["comment"]["user_id"] = nil
     assert_equal "", template.render(context)
   end
 end


### PR DESCRIPTION
## Problem
GitHub PR Analyzer agent was not responding to merged PR webhook events.

## Root Causes
1. **Context path mismatch**: Routing expression used `chat.comment.content` but the dispatch context places `comment` at top level, not nested under `chat`
2. **Case mismatch**: Expression matched `"Pull Request merged"` but the i18n action label produces `"Merged"` (capital M). Liquid `contains` is case-sensitive.

## Fix
- `chat.comment.content` → `comment.content`
- `chat.comment.user_id` → `comment.user_id`
- `"Pull Request merged"` → `"Pull Request Merged"`
- Updated tests to use corrected context structure