### PR TITLE
fix: remove duplicate GitHub integration modal render

### DIFF
--- a/engines/collavre/app/views/collavre/creatives/index.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/index.html.erb
@@ -202,8 +202,6 @@
 
 <%= render 'set_plan_modal' %>
 <% if can_manage_integrations %>
-  <%# Legacy hardcoded integration modals %>
-  <%= render 'collavre_github/integrations/modal', creative: current_creative %>
   <%# Dynamically registered integration modals %>
   <%= render 'integration_modals', creative: current_creative %>
 <% end %>


### PR DESCRIPTION
## Problem
Chrome DevTools warning: multiple form field elements with the same id attribute value.

## Root Cause
GitHub integration modal was rendered twice:
1. Hardcoded `render 'collavre_github/integrations/modal'` (legacy)
2. Dynamic `render 'integration_modals'` via `IntegrationRegistry` (current)

Since `collavre_github` registers itself in `IntegrationRegistry`, the legacy hardcoded render is redundant and creates duplicate DOM ids.

## Fix
Removed the legacy hardcoded render. The modal is now only rendered via `IntegrationRegistry`.