### PR TITLE
feat: add review button to AI agent comments for mobile support

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -560,6 +560,7 @@ body.chat-fullscreen {
 .convert-comment-btn,
 .delete-comment-btn,
 .edit-comment-btn,
+.review-comment-btn,
 .copy-comment-link-btn {
     border: none;
     background: none;

--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -561,6 +561,7 @@ body.chat-fullscreen {
 .delete-comment-btn,
 .edit-comment-btn,
 .review-comment-btn,
+.replace-comment-btn,
 .copy-comment-link-btn {
     border: none;
     background: none;
@@ -574,6 +575,11 @@ body.chat-fullscreen {
 .comment-delete-hidden,
 .comment-approve-hidden {
     display: none;
+}
+
+.replace-comment-btn:disabled {
+    opacity: 0.35;
+    cursor: default;
 }
 
 .comment-copy-notice {

--- a/engines/collavre/app/javascript/controllers/comment_controller.js
+++ b/engines/collavre/app/javascript/controllers/comment_controller.js
@@ -18,9 +18,9 @@ export default class extends Controller {
     this.handleMouseUp = this.handleMouseUp.bind(this)
     this.element.addEventListener('mouseup', this.handleMouseUp)
 
-    // Track selection changes to enable/disable replace button
-    this._handleSelectionChange = this._handleSelectionChange.bind(this)
-    document.addEventListener('selectionchange', this._handleSelectionChange)
+    // Bound handlers for review/replace buttons (stored for cleanup)
+    this._boundReviewClick = this._onReviewClick.bind(this)
+    this._boundReplaceClick = this._onReplaceClick.bind(this)
 
     this.currentUserId = document.body.dataset.currentUserId
     const commentAuthorId = this.element.dataset.userId
@@ -119,7 +119,7 @@ export default class extends Controller {
 
   disconnect() {
     this.element.removeEventListener('mouseup', this.handleMouseUp)
-    document.removeEventListener('selectionchange', this._handleSelectionChange)
+    this._removeSelectionChangeListener()
     this.hideReviewPopup()
     if (this._reviewPopupEl) {
       this._reviewPopupEl.remove()
@@ -216,34 +216,51 @@ export default class extends Controller {
   }
 
   reviewButtonTargetConnected(button) {
-    button.addEventListener('click', (event) => {
-      event.preventDefault()
-      event.stopPropagation()
-      const commentId = this.element.dataset.commentId
-      const contentEl = this.element.querySelector('.comment-content')
-      const fullText = contentEl ? contentEl.textContent.trim() : ''
-      const formController = this.findFormController()
-      if (formController && fullText) {
-        formController.quoteComment(commentId, fullText)
-      }
-    })
+    button.addEventListener('click', this._boundReviewClick)
+  }
+
+  reviewButtonTargetDisconnected(button) {
+    button.removeEventListener('click', this._boundReviewClick)
   }
 
   replaceButtonTargetConnected(button) {
-    button.addEventListener('click', (event) => {
-      event.preventDefault()
-      event.stopPropagation()
-      const selectedText = this._getSelectedTextInContent()
-      if (!selectedText) return
+    button.addEventListener('click', this._boundReplaceClick)
+    // Only listen for selectionchange when a replace button exists
+    this._addSelectionChangeListener()
+  }
 
-      const commentId = this.element.dataset.commentId
-      const formController = this.findFormController()
-      if (formController) {
-        formController.quoteComment(commentId, selectedText)
-      }
-      window.getSelection().removeAllRanges()
-      this._updateReplaceButton()
-    })
+  replaceButtonTargetDisconnected(button) {
+    button.removeEventListener('click', this._boundReplaceClick)
+    if (!this.hasReplaceButtonTarget) {
+      this._removeSelectionChangeListener()
+    }
+  }
+
+  _onReviewClick(event) {
+    event.preventDefault()
+    event.stopPropagation()
+    const commentId = this.element.dataset.commentId
+    const contentEl = this.element.querySelector('.comment-content')
+    const fullText = contentEl ? contentEl.textContent.trim() : ''
+    const formController = this.findFormController()
+    if (formController && fullText) {
+      formController.quoteComment(commentId, fullText)
+    }
+  }
+
+  _onReplaceClick(event) {
+    event.preventDefault()
+    event.stopPropagation()
+    const selectedText = this._getSelectedTextInContent()
+    if (!selectedText) return
+
+    const commentId = this.element.dataset.commentId
+    const formController = this.findFormController()
+    if (formController) {
+      formController.quoteComment(commentId, selectedText)
+    }
+    window.getSelection().removeAllRanges()
+    this._updateReplaceButton()
   }
 
   _getSelectedTextInContent() {
@@ -260,6 +277,19 @@ export default class extends Controller {
     if (!contentEl.contains(range.commonAncestorContainer)) return null
 
     return text
+  }
+
+  _addSelectionChangeListener() {
+    if (this._selectionChangeActive) return
+    this._handleSelectionChange = this._handleSelectionChange.bind(this)
+    document.addEventListener('selectionchange', this._handleSelectionChange)
+    this._selectionChangeActive = true
+  }
+
+  _removeSelectionChangeListener() {
+    if (!this._selectionChangeActive) return
+    document.removeEventListener('selectionchange', this._handleSelectionChange)
+    this._selectionChangeActive = false
   }
 
   _handleSelectionChange() {

--- a/engines/collavre/app/javascript/controllers/comment_controller.js
+++ b/engines/collavre/app/javascript/controllers/comment_controller.js
@@ -4,7 +4,7 @@ import CommonPopup from '../lib/common_popup'
 
 // Connects to data-controller="comment"
 export default class extends Controller {
-  static targets = ["ownerButton", "deleteButton", "approveButton", "actionApproveControls", "reviewButton"]
+  static targets = ["ownerButton", "deleteButton", "approveButton", "actionApproveControls", "reviewButton", "replaceButton"]
 
   connect() {
     const contentElement = this.element.querySelector('.comment-content')
@@ -17,6 +17,10 @@ export default class extends Controller {
     // Text selection quote support
     this.handleMouseUp = this.handleMouseUp.bind(this)
     this.element.addEventListener('mouseup', this.handleMouseUp)
+
+    // Track selection changes to enable/disable replace button
+    this._handleSelectionChange = this._handleSelectionChange.bind(this)
+    document.addEventListener('selectionchange', this._handleSelectionChange)
 
     this.currentUserId = document.body.dataset.currentUserId
     const commentAuthorId = this.element.dataset.userId
@@ -115,6 +119,7 @@ export default class extends Controller {
 
   disconnect() {
     this.element.removeEventListener('mouseup', this.handleMouseUp)
+    document.removeEventListener('selectionchange', this._handleSelectionChange)
     this.hideReviewPopup()
     if (this._reviewPopupEl) {
       this._reviewPopupEl.remove()
@@ -221,6 +226,51 @@ export default class extends Controller {
       if (formController && fullText) {
         formController.quoteComment(commentId, fullText)
       }
+    })
+  }
+
+  replaceButtonTargetConnected(button) {
+    button.addEventListener('click', (event) => {
+      event.preventDefault()
+      event.stopPropagation()
+      const selectedText = this._getSelectedTextInContent()
+      if (!selectedText) return
+
+      const commentId = this.element.dataset.commentId
+      const formController = this.findFormController()
+      if (formController) {
+        formController.quoteComment(commentId, selectedText)
+      }
+      window.getSelection().removeAllRanges()
+      this._updateReplaceButton()
+    })
+  }
+
+  _getSelectedTextInContent() {
+    const selection = window.getSelection()
+    if (!selection || selection.isCollapsed) return null
+
+    const text = selection.toString().trim()
+    if (!text) return null
+
+    const contentEl = this.element.querySelector('.comment-content')
+    if (!contentEl) return null
+
+    const range = selection.getRangeAt(0)
+    if (!contentEl.contains(range.commonAncestorContainer)) return null
+
+    return text
+  }
+
+  _handleSelectionChange() {
+    this._updateReplaceButton()
+  }
+
+  _updateReplaceButton() {
+    if (!this.hasReplaceButtonTarget) return
+    const hasSelection = !!this._getSelectedTextInContent()
+    this.replaceButtonTargets.forEach((btn) => {
+      btn.disabled = !hasSelection
     })
   }
 

--- a/engines/collavre/app/javascript/controllers/comment_controller.js
+++ b/engines/collavre/app/javascript/controllers/comment_controller.js
@@ -4,7 +4,7 @@ import CommonPopup from '../lib/common_popup'
 
 // Connects to data-controller="comment"
 export default class extends Controller {
-  static targets = ["ownerButton", "deleteButton", "approveButton", "actionApproveControls"]
+  static targets = ["ownerButton", "deleteButton", "approveButton", "actionApproveControls", "reviewButton"]
 
   connect() {
     const contentElement = this.element.querySelector('.comment-content')
@@ -208,6 +208,20 @@ export default class extends Controller {
     const popup = this.element.closest('#comments-popup')
     if (!popup) return null
     return this.application.getControllerForElementAndIdentifier(popup, 'comments--form')
+  }
+
+  reviewButtonTargetConnected(button) {
+    button.addEventListener('click', (event) => {
+      event.preventDefault()
+      event.stopPropagation()
+      const commentId = this.element.dataset.commentId
+      const contentEl = this.element.querySelector('.comment-content')
+      const fullText = contentEl ? contentEl.textContent.trim() : ''
+      const formController = this.findFormController()
+      if (formController && fullText) {
+        formController.quoteComment(commentId, fullText)
+      }
+    })
   }
 
   updateReactionsUI(reactionsData) {

--- a/engines/collavre/app/views/collavre/comments/_comment.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comment.html.erb
@@ -2,7 +2,7 @@
 <% current_topic_id = local_assigns[:current_topic_id] %>
 <% has_pending_action = comment.action.present? && comment.action_executed_at.blank? %>
 <% approver_id = comment.approver_id %>
-<div class="comment-item" id="<%= dom_id(comment) %>" data-controller="comment" data-user-id="<%= comment.user&.id %>" data-comment-id="<%= comment.id %>" data-topic-id="<%= comment_topic&.id %>" data-creative-id="<%= comment.creative_id %>" data-creative-owner-id="<%= comment.creative&.user_id %>" data-has-pending-action="<%= has_pending_action %>" data-approver-id="<%= approver_id %>">
+<div class="comment-item" id="<%= dom_id(comment) %>" data-controller="comment" data-user-id="<%= comment.user&.id %>" data-comment-id="<%= comment.id %>" data-topic-id="<%= comment_topic&.id %>" data-creative-id="<%= comment.creative_id %>" data-creative-owner-id="<%= comment.creative&.user_id %>" data-has-pending-action="<%= has_pending_action %>" data-approver-id="<%= approver_id %>" data-ai-user="<%= comment.user&.ai_user? %>">
   <div class="comment-select">
     <input type="checkbox"
            class="comment-select-checkbox"
@@ -59,6 +59,11 @@
       <button class="edit-comment-btn comment-owner-only" data-comment-target="ownerButton" data-comment-id="<%= comment.id %>" data-comment-content="<%= comment.content %>" data-comment-private="<%= comment.private? %>" title="<%= t('collavre.comments.update_comment') %>">
         <%= t('collavre.comments.edit_button') %>
       </button>
+      <% if comment.user&.ai_user? %>
+        <button class="review-comment-btn" data-comment-target="reviewButton" data-comment-id="<%= comment.id %>" title="<%= t('collavre.comments.review_button') %>">
+          <%= t('collavre.comments.review_button') %>
+        </button>
+      <% end %>
       <button class="copy-comment-link-btn" data-comment-id="<%= comment.id %>" data-comment-url="<%= collavre.creative_comment_url(comment.creative, comment, Rails.application.config.action_mailer.default_url_options) %>" title="<%= t('collavre.comments.copy_link_button') %>">
         <%= t('collavre.comments.copy_link_button') %>
       </button>

--- a/engines/collavre/app/views/collavre/comments/_comment.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comment.html.erb
@@ -63,6 +63,9 @@
         <button class="review-comment-btn" data-comment-target="reviewButton" data-comment-id="<%= comment.id %>" title="<%= t('collavre.comments.review_button') %>">
           <%= t('collavre.comments.review_button') %>
         </button>
+        <button class="replace-comment-btn" data-comment-target="replaceButton" data-comment-id="<%= comment.id %>" title="<%= t('collavre.comments.replace_button') %>" disabled>
+          <%= t('collavre.comments.replace_button') %>
+        </button>
       <% end %>
       <button class="copy-comment-link-btn" data-comment-id="<%= comment.id %>" data-comment-url="<%= collavre.creative_comment_url(comment.creative, comment, Rails.application.config.action_mailer.default_url_options) %>" title="<%= t('collavre.comments.copy_link_button') %>">
         <%= t('collavre.comments.copy_link_button') %>

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -66,6 +66,7 @@ en:
       speech_unavailable: Speech recognition is not supported in this browser.
       move_button: Move
       review_button: Review
+      replace_button: Replace
       move_no_selection: Select at least one message to move.
       move_error: Unable to move messages.
       add_participant: Add user

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -63,6 +63,7 @@ ko:
       speech_unavailable: 이 브라우저는 음성 인식을 지원하지 않습니다.
       move_button: 이동
       review_button: 리뷰
+      replace_button: 바꾸기
       move_no_selection: 이동할 메시지를 선택해주세요.
       move_error: 메시지를 이동할 수 없습니다.
       add_participant: 사용자 추가


### PR DESCRIPTION
## Problem

The review (quote + rewrite) feature relied on text selection via `mouseup` events, which is impractical on mobile devices where:
- Text selection triggers the OS context menu (copy/paste)
- Precise text selection is difficult on small screens
- The review popup competes with native selection controls

## Solution

Added a dedicated **Review** button directly in the comment action area for AI agent comments. Users can now tap a single button to quote the full response for review, making the feature accessible on all devices.

## Changes

- `_comment.html.erb` — Added `data-ai-user` attribute and Review button (shown only for AI agent comments)
- `comment_controller.js` — Added `reviewButton` target with click handler that quotes the full comment content
- `comments_popup.css` — Included `.review-comment-btn` in shared button styles

## Notes

- The existing text-selection based review (desktop) still works as before
- The Review button only appears on comments authored by AI agents (`ai_user?`)
- i18n keys (`review_button`) already existed in both en and ko locales