### PR TITLE
fix: save immediately on progress checkbox change instead of debouncing

### DIFF
--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -1751,7 +1751,11 @@ export function initializeCreativeRowEditor() {
           }
         }
         updateProgressInputAvailability(readProgressValue());
-        scheduleSave();
+        // Save immediately on checkbox change to prevent losing the last toggle
+        // when the user navigates away before the debounce timer fires.
+        pendingSave = true;
+        clearTimeout(saveTimer);
+        saveForm();
       });
     }
 


### PR DESCRIPTION
## Problem

When toggling the completion checkbox on a creative, the change was saved via `scheduleSave()` which debounces for **5 seconds**. If the user:

- Clicked another creative to edit
- Navigated to a different page
- Closed the browser tab

...before the 5-second timer fired, the **last checkbox toggle would be silently lost**.

This was especially noticeable when quickly checking off multiple creatives in sequence — the last one checked would often not be saved.

## Root Cause

`scheduleSave()` sets `pendingSave = true` and starts a 5-second `setTimeout`. While `hideCurrent()` does check `pendingSave` and calls `saveForm()` when switching creatives, there are race conditions and edge cases (page navigation, tab close) where the timer is cleared before it fires and no flush mechanism exists.

## Solution

Replace `scheduleSave()` with immediate `saveForm()` for checkbox change events only. Text editing still uses the 5-second debounce (which makes sense for typing), but discrete actions like toggling a checkbox should save immediately.

## Changes

- `creative_row_editor.js` — Progress checkbox `change` handler now calls `saveForm()` directly instead of `scheduleSave()`