### PR TITLE
fix: remove bullet prefix from popup list items

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/mention_menu.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/mention_menu.css
@@ -14,12 +14,12 @@
   list-style: none;
   margin: 0;
   padding: 0;
+  max-height: 260px;
+  overflow-y: auto;
 }
 
 .common-popup-list li {
   list-style: none;
-  max-height: 260px;
-  overflow-y: auto;
 }
 
 .mention-popup ul,

--- a/engines/collavre/app/assets/stylesheets/collavre/mention_menu.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/mention_menu.css
@@ -14,6 +14,10 @@
   list-style: none;
   margin: 0;
   padding: 0;
+}
+
+.common-popup-list li {
+  list-style: none;
   max-height: 260px;
   overflow-y: auto;
 }

--- a/engines/collavre/app/views/collavre/users/edit_ai.html.erb
+++ b/engines/collavre/app/views/collavre/users/edit_ai.html.erb
@@ -1,3 +1,4 @@
+<%= stylesheet_link_tag 'collavre/mention_menu', media: 'all' %>
 <h1 class="text-center" style="margin-top: 0;"><%= t('collavre.users.edit_ai.title') %></h1>
 
 <%= form_with model: @user, url: collavre.update_ai_user_path(@user), method: :patch, class: "stacked-form" do |form| %>

--- a/engines/collavre/app/views/collavre/users/new_ai.html.erb
+++ b/engines/collavre/app/views/collavre/users/new_ai.html.erb
@@ -1,3 +1,4 @@
+<%= stylesheet_link_tag 'collavre/mention_menu', media: 'all' %>
 <h1 class="text-center" style="margin-top: 0;"><%= t('collavre.users.new_ai.title') %></h1>
 
 <%= form_with url: collavre.create_ai_users_path, class: "stacked-form" do |form| %>


### PR DESCRIPTION
## Problem
Model selection popup in new_ai/edit_ai forms shows bullet markers on `<li>` elements.

## Fix
Added explicit `list-style: none` on `.common-popup-list li` to prevent any inherited or browser-default bullet styles from appearing.