### PR TITLE
feat: auto-wrap pasted HTML content in code blocks

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -180,6 +180,17 @@ body.chat-fullscreen {
     margin-top: 0.2em;
 }
 
+.comment-content pre {
+    white-space: pre-wrap;
+    word-break: break-word;
+    overflow-x: auto;
+}
+
+.comment-content pre code {
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
 .comment-quoted-block {
     margin-top: 0.3em;
     margin-bottom: 0.2em;

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -435,22 +435,29 @@ export default class extends Controller {
     const text = clipboardData.getData('text/plain')
     if (!text) return
 
-    // Detect HTML content: must contain at least one HTML tag pair or self-closing tag
-    const htmlTagPattern = /<[a-zA-Z][^>]*>[\s\S]*<\/[a-zA-Z]+>|<[a-zA-Z][^>]*\/>/
-    if (!htmlTagPattern.test(text)) return
+    // Detect HTML tags in pasted text
+    // Match outermost HTML tag blocks (opening tag ... closing tag) or self-closing tags
+    const htmlBlockPattern = /<([a-zA-Z][a-zA-Z0-9]*)\b[^>]*>[\s\S]*?<\/\1>|<[a-zA-Z][^>]*\/>/g
+    if (!htmlBlockPattern.test(text)) return
 
     // Already wrapped in code block — don't double-wrap
     if (text.trimStart().startsWith('```')) return
 
     event.preventDefault()
-    const wrapped = '```html\n' + text + '\n```'
+
+    // Replace only the HTML portions with code blocks, keeping surrounding text intact
+    htmlBlockPattern.lastIndex = 0
+    const result = text.replace(htmlBlockPattern, (match) => {
+      return '\n```html\n' + match + '\n```\n'
+    }).replace(/^\n/, '').replace(/\n$/, '')
+
     const textarea = this.textareaTarget
     const start = textarea.selectionStart
     const end = textarea.selectionEnd
     const before = textarea.value.substring(0, start)
     const after = textarea.value.substring(end)
-    textarea.value = before + wrapped + after
-    const cursorPos = start + wrapped.length
+    textarea.value = before + result + after
+    const cursorPos = start + result.length
     textarea.setSelectionRange(cursorPos, cursorPos)
     textarea.dispatchEvent(new Event('input', { bubbles: true }))
   }

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -433,10 +433,12 @@ export default class extends Controller {
     const clipboardData = event.clipboardData
     if (!clipboardData) return
 
-    const text = clipboardData.getData('text/plain')
+    const text = clipboardData.getData('text/plain') || clipboardData.getData('text')
+    console.log('[paste] text:', JSON.stringify(text), 'types:', [...clipboardData.types])
     if (!text) return
 
     const { changed, result } = wrapHtmlInCodeBlocks(text)
+    console.log('[paste] changed:', changed, 'result:', JSON.stringify(result))
     if (!changed) return
 
     event.preventDefault()

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -434,11 +434,9 @@ export default class extends Controller {
     if (!clipboardData) return
 
     const text = clipboardData.getData('text/plain') || clipboardData.getData('text')
-    console.log('[paste] text:', JSON.stringify(text), 'types:', [...clipboardData.types])
     if (!text) return
 
     const { changed, result } = wrapHtmlInCodeBlocks(text)
-    console.log('[paste] changed:', changed, 'result:', JSON.stringify(result))
     if (!changed) return
 
     event.preventDefault()

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -1,5 +1,6 @@
 import { Controller } from '@hotwired/stimulus'
 import { renderMarkdownInContainer } from '../../lib/utils/markdown'
+import { wrapHtmlInCodeBlocks } from '../../lib/html_code_block_wrapper'
 
 export default class extends Controller {
   static targets = [
@@ -435,21 +436,10 @@ export default class extends Controller {
     const text = clipboardData.getData('text/plain')
     if (!text) return
 
-    // Detect HTML tags in pasted text
-    // Match outermost HTML tag blocks (opening tag ... closing tag) or self-closing tags
-    const htmlBlockPattern = /<([a-zA-Z][a-zA-Z0-9]*)\b[^>]*>[\s\S]*?<\/\1>|<[a-zA-Z][^>]*\/>/g
-    if (!htmlBlockPattern.test(text)) return
-
-    // Already wrapped in code block — don't double-wrap
-    if (text.trimStart().startsWith('```')) return
+    const { changed, result } = wrapHtmlInCodeBlocks(text)
+    if (!changed) return
 
     event.preventDefault()
-
-    // Replace only the HTML portions with code blocks, keeping surrounding text intact
-    htmlBlockPattern.lastIndex = 0
-    const result = text.replace(htmlBlockPattern, (match) => {
-      return '\n```html\n' + match + '\n```\n'
-    }).replace(/^\n/, '').replace(/\n$/, '')
 
     const textarea = this.textareaTarget
     const start = textarea.selectionStart

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -449,7 +449,7 @@ export default class extends Controller {
     const before = textarea.value.substring(0, start)
     const after = textarea.value.substring(end)
     // Ensure blank line before code fence if there's preceding text
-    const separator = before.length > 0 && !before.endsWith('\n\n') ? (before.endsWith('\n') ? '\n' : '\n\n') : ''
+    const separator = before.length > 0 && !before.endsWith('\n') ? '\n' : ''
     textarea.value = before + separator + result + after
     const cursorPos = start + separator.length + result.length
     textarea.setSelectionRange(cursorPos, cursorPos)

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -57,6 +57,8 @@ export default class extends Controller {
     this.imageInputTarget?.addEventListener('change', this.handleImageChange)
     this.textareaTarget.addEventListener('dragover', this.handleDragOver)
     this.textareaTarget.addEventListener('drop', this.handleDrop)
+    this.handlePaste = this.handlePaste.bind(this)
+    this.textareaTarget.addEventListener('paste', this.handlePaste)
 
 
     this.recognition = null
@@ -101,6 +103,7 @@ export default class extends Controller {
     this.imageInputTarget?.removeEventListener('change', this.handleImageChange)
     this.textareaTarget.removeEventListener('dragover', this.handleDragOver)
     this.textareaTarget.removeEventListener('drop', this.handleDrop)
+    this.textareaTarget.removeEventListener('paste', this.handlePaste)
     this.element.removeEventListener('comments--topics:change', this.handleTopicChange)
   }
 
@@ -423,6 +426,33 @@ export default class extends Controller {
     this.setImageFiles([...existingFiles, ...newFiles])
     this.cachedImageFiles = null
     this.updateAttachmentList()
+  }
+
+  handlePaste(event) {
+    const clipboardData = event.clipboardData
+    if (!clipboardData) return
+
+    const text = clipboardData.getData('text/plain')
+    if (!text) return
+
+    // Detect HTML content: must contain at least one HTML tag pair or self-closing tag
+    const htmlTagPattern = /<[a-zA-Z][^>]*>[\s\S]*<\/[a-zA-Z]+>|<[a-zA-Z][^>]*\/>/
+    if (!htmlTagPattern.test(text)) return
+
+    // Already wrapped in code block — don't double-wrap
+    if (text.trimStart().startsWith('```')) return
+
+    event.preventDefault()
+    const wrapped = '```html\n' + text + '\n```'
+    const textarea = this.textareaTarget
+    const start = textarea.selectionStart
+    const end = textarea.selectionEnd
+    const before = textarea.value.substring(0, start)
+    const after = textarea.value.substring(end)
+    textarea.value = before + wrapped + after
+    const cursorPos = start + wrapped.length
+    textarea.setSelectionRange(cursorPos, cursorPos)
+    textarea.dispatchEvent(new Event('input', { bubbles: true }))
   }
 
   handleDragOver(event) {

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -446,8 +446,10 @@ export default class extends Controller {
     const end = textarea.selectionEnd
     const before = textarea.value.substring(0, start)
     const after = textarea.value.substring(end)
-    textarea.value = before + result + after
-    const cursorPos = start + result.length
+    // Ensure blank line before code fence if there's preceding text
+    const separator = before.length > 0 && !before.endsWith('\n\n') ? (before.endsWith('\n') ? '\n' : '\n\n') : ''
+    textarea.value = before + separator + result + after
+    const cursorPos = start + separator.length + result.length
     textarea.setSelectionRange(cursorPos, cursorPos)
     textarea.dispatchEvent(new Event('input', { bubbles: true }))
   }

--- a/engines/collavre/app/javascript/lib/__tests__/html_code_block_wrapper.test.js
+++ b/engines/collavre/app/javascript/lib/__tests__/html_code_block_wrapper.test.js
@@ -69,19 +69,19 @@ describe('wrapHtmlInCodeBlocks', () => {
   test('wraps HTML with text before', () => {
     const { changed, result } = wrapHtmlInCodeBlocks('여기 봐봐 <div>hello</div>')
     expect(changed).toBe(true)
-    expect(result).toBe('여기 봐봐 \n```html\n<div>hello</div>\n```')
+    expect(result).toBe('여기 봐봐 \n\n```html\n<div>hello</div>\n```')
   })
 
   test('wraps HTML with text after', () => {
     const { changed, result } = wrapHtmlInCodeBlocks('<div>hello</div> 이거 뭐야?')
     expect(changed).toBe(true)
-    expect(result).toBe('```html\n<div>hello</div>\n```\n 이거 뭐야?')
+    expect(result).toBe('```html\n<div>hello</div>\n```\n\n 이거 뭐야?')
   })
 
   test('wraps HTML with text before and after', () => {
     const { changed, result } = wrapHtmlInCodeBlocks('여기 봐봐 <div>hello</div> 이거 뭐야?')
     expect(changed).toBe(true)
-    expect(result).toBe('여기 봐봐 \n```html\n<div>hello</div>\n```\n 이거 뭐야?')
+    expect(result).toBe('여기 봐봐 \n\n```html\n<div>hello</div>\n```\n\n 이거 뭐야?')
   })
 
   // --- Multiple HTML blocks ---
@@ -89,7 +89,7 @@ describe('wrapHtmlInCodeBlocks', () => {
   test('wraps multiple separate HTML blocks', () => {
     const { changed, result } = wrapHtmlInCodeBlocks('<div>first</div> text <span>second</span>')
     expect(changed).toBe(true)
-    expect(result).toBe('```html\n<div>first</div>\n```\n text \n```html\n<span>second</span>\n```')
+    expect(result).toBe('```html\n<div>first</div>\n```\n\n text \n\n```html\n<span>second</span>\n```')
   })
 
   // --- Complex real-world HTML ---
@@ -106,7 +106,7 @@ describe('wrapHtmlInCodeBlocks', () => {
     const input = '이 코드를 봐줘 ' + html + ' 이게 맞아?'
     const { changed, result } = wrapHtmlInCodeBlocks(input)
     expect(changed).toBe(true)
-    expect(result).toBe('이 코드를 봐줘 \n```html\n' + html + '\n```\n 이게 맞아?')
+    expect(result).toBe('이 코드를 봐줘 \n\n```html\n' + html + '\n```\n\n 이게 맞아?')
   })
 
   // --- Multiline HTML ---
@@ -131,7 +131,6 @@ describe('wrapHtmlInCodeBlocks', () => {
   })
 
   test('handles HTML-like content in markdown', () => {
-    // Bold tags should match
     const { changed, result } = wrapHtmlInCodeBlocks('<b>bold text</b>')
     expect(changed).toBe(true)
     expect(result).toBe('```html\n<b>bold text</b>\n```')
@@ -158,5 +157,15 @@ describe('wrapHtmlInCodeBlocks', () => {
   test('does not wrap template literals with angle brackets', () => {
     const text = 'array.filter(x => x > 0)'
     expect(wrapHtmlInCodeBlocks(text)).toEqual({ changed: false, result: text })
+  })
+
+  // --- Failure scenario: typing text then pasting HTML ---
+
+  test('text followed by HTML renders as proper markdown code block', () => {
+    const { changed, result } = wrapHtmlInCodeBlocks('test <html><h1>hello</h1></html>')
+    expect(changed).toBe(true)
+    // Must have blank line before code fence for marked to parse correctly
+    expect(result).toBe('test \n\n```html\n<html><h1>hello</h1></html>\n```')
+    expect(result).toContain('\n\n```html')
   })
 })

--- a/engines/collavre/app/javascript/lib/__tests__/html_code_block_wrapper.test.js
+++ b/engines/collavre/app/javascript/lib/__tests__/html_code_block_wrapper.test.js
@@ -1,0 +1,162 @@
+import { wrapHtmlInCodeBlocks } from '../html_code_block_wrapper'
+
+describe('wrapHtmlInCodeBlocks', () => {
+  // --- No change cases ---
+
+  test('returns unchanged for null/undefined/empty', () => {
+    expect(wrapHtmlInCodeBlocks(null)).toEqual({ changed: false, result: null })
+    expect(wrapHtmlInCodeBlocks(undefined)).toEqual({ changed: false, result: undefined })
+    expect(wrapHtmlInCodeBlocks('')).toEqual({ changed: false, result: '' })
+  })
+
+  test('returns unchanged for plain text', () => {
+    const text = 'Hello world, no HTML here'
+    expect(wrapHtmlInCodeBlocks(text)).toEqual({ changed: false, result: text })
+  })
+
+  test('returns unchanged for text with angle brackets but no tags', () => {
+    expect(wrapHtmlInCodeBlocks('5 > 3 and 2 < 4')).toEqual({
+      changed: false,
+      result: '5 > 3 and 2 < 4',
+    })
+  })
+
+  test('returns unchanged for already code-blocked content', () => {
+    const text = '```html\n<div>hello</div>\n```'
+    expect(wrapHtmlInCodeBlocks(text)).toEqual({ changed: false, result: text })
+  })
+
+  test('returns unchanged for code block with leading whitespace', () => {
+    const text = '  ```\n<div>hello</div>\n```'
+    expect(wrapHtmlInCodeBlocks(text)).toEqual({ changed: false, result: text })
+  })
+
+  // --- Single HTML block ---
+
+  test('wraps a single div', () => {
+    const { changed, result } = wrapHtmlInCodeBlocks('<div>hello</div>')
+    expect(changed).toBe(true)
+    expect(result).toBe('```html\n<div>hello</div>\n```')
+  })
+
+  test('wraps a div with attributes', () => {
+    const { changed, result } = wrapHtmlInCodeBlocks('<div class="test" id="foo">content</div>')
+    expect(changed).toBe(true)
+    expect(result).toBe('```html\n<div class="test" id="foo">content</div>\n```')
+  })
+
+  test('wraps nested HTML', () => {
+    const html = '<div><p>hello</p><span>world</span></div>'
+    const { changed, result } = wrapHtmlInCodeBlocks(html)
+    expect(changed).toBe(true)
+    expect(result).toBe('```html\n' + html + '\n```')
+  })
+
+  test('wraps self-closing tag', () => {
+    const { changed, result } = wrapHtmlInCodeBlocks('<br/>')
+    expect(changed).toBe(true)
+    expect(result).toBe('```html\n<br/>\n```')
+  })
+
+  test('wraps self-closing tag with space', () => {
+    const { changed, result } = wrapHtmlInCodeBlocks('<img src="test.png" />')
+    expect(changed).toBe(true)
+    expect(result).toBe('```html\n<img src="test.png" />\n```')
+  })
+
+  // --- HTML with surrounding text ---
+
+  test('wraps HTML with text before', () => {
+    const { changed, result } = wrapHtmlInCodeBlocks('여기 봐봐 <div>hello</div>')
+    expect(changed).toBe(true)
+    expect(result).toBe('여기 봐봐 \n```html\n<div>hello</div>\n```')
+  })
+
+  test('wraps HTML with text after', () => {
+    const { changed, result } = wrapHtmlInCodeBlocks('<div>hello</div> 이거 뭐야?')
+    expect(changed).toBe(true)
+    expect(result).toBe('```html\n<div>hello</div>\n```\n 이거 뭐야?')
+  })
+
+  test('wraps HTML with text before and after', () => {
+    const { changed, result } = wrapHtmlInCodeBlocks('여기 봐봐 <div>hello</div> 이거 뭐야?')
+    expect(changed).toBe(true)
+    expect(result).toBe('여기 봐봐 \n```html\n<div>hello</div>\n```\n 이거 뭐야?')
+  })
+
+  // --- Multiple HTML blocks ---
+
+  test('wraps multiple separate HTML blocks', () => {
+    const { changed, result } = wrapHtmlInCodeBlocks('<div>first</div> text <span>second</span>')
+    expect(changed).toBe(true)
+    expect(result).toBe('```html\n<div>first</div>\n```\n text \n```html\n<span>second</span>\n```')
+  })
+
+  // --- Complex real-world HTML ---
+
+  test('wraps complex HTML with attributes and nesting', () => {
+    const html = '<div id="llm-model-suggestions" class="common-popup mention-popup" style="display: none;"><ul class="common-popup-list"><li class="common-popup-item"><div class="mention-item">gemini-2.5-flash</div></li></ul></div>'
+    const { changed, result } = wrapHtmlInCodeBlocks(html)
+    expect(changed).toBe(true)
+    expect(result).toBe('```html\n' + html + '\n```')
+  })
+
+  test('wraps complex HTML with surrounding text', () => {
+    const html = '<div id="test" class="popup" style="display: none;"><ul><li>item</li></ul></div>'
+    const input = '이 코드를 봐줘 ' + html + ' 이게 맞아?'
+    const { changed, result } = wrapHtmlInCodeBlocks(input)
+    expect(changed).toBe(true)
+    expect(result).toBe('이 코드를 봐줘 \n```html\n' + html + '\n```\n 이게 맞아?')
+  })
+
+  // --- Multiline HTML ---
+
+  test('wraps multiline HTML', () => {
+    const html = '<div>\n  <p>hello</p>\n  <p>world</p>\n</div>'
+    const { changed, result } = wrapHtmlInCodeBlocks(html)
+    expect(changed).toBe(true)
+    expect(result).toBe('```html\n' + html + '\n```')
+  })
+
+  // --- Edge cases ---
+
+  test('handles single unclosed tag (no match)', () => {
+    const text = '<div>hello but no closing tag'
+    expect(wrapHtmlInCodeBlocks(text)).toEqual({ changed: false, result: text })
+  })
+
+  test('handles mismatched tags (no match)', () => {
+    const text = '<div>hello</span>'
+    expect(wrapHtmlInCodeBlocks(text)).toEqual({ changed: false, result: text })
+  })
+
+  test('handles HTML-like content in markdown', () => {
+    // Bold tags should match
+    const { changed, result } = wrapHtmlInCodeBlocks('<b>bold text</b>')
+    expect(changed).toBe(true)
+    expect(result).toBe('```html\n<b>bold text</b>\n```')
+  })
+
+  test('handles table HTML', () => {
+    const html = '<table><tr><td>cell</td></tr></table>'
+    const { changed, result } = wrapHtmlInCodeBlocks(html)
+    expect(changed).toBe(true)
+    expect(result).toBe('```html\n' + html + '\n```')
+  })
+
+  test('handles input self-closing tag', () => {
+    const { changed, result } = wrapHtmlInCodeBlocks('<input type="text" />')
+    expect(changed).toBe(true)
+    expect(result).toBe('```html\n<input type="text" />\n```')
+  })
+
+  test('does not wrap markdown syntax', () => {
+    const text = '# heading\n\n**bold** and *italic*'
+    expect(wrapHtmlInCodeBlocks(text)).toEqual({ changed: false, result: text })
+  })
+
+  test('does not wrap template literals with angle brackets', () => {
+    const text = 'array.filter(x => x > 0)'
+    expect(wrapHtmlInCodeBlocks(text)).toEqual({ changed: false, result: text })
+  })
+})

--- a/engines/collavre/app/javascript/lib/html_code_block_wrapper.js
+++ b/engines/collavre/app/javascript/lib/html_code_block_wrapper.js
@@ -1,0 +1,151 @@
+/**
+ * Wraps HTML tag blocks in a string with markdown code blocks.
+ * Handles nested tags of the same name correctly.
+ *
+ * @param {string} text - The input text potentially containing HTML
+ * @returns {{ changed: boolean, result: string }}
+ */
+export function wrapHtmlInCodeBlocks(text) {
+  if (!text) return { changed: false, result: text }
+
+  // Already wrapped in code block — don't double-wrap
+  if (text.trimStart().startsWith('```')) return { changed: false, result: text }
+
+  const segments = extractHtmlSegments(text)
+  if (!segments) return { changed: false, result: text }
+
+  let result = ''
+  let lastIndex = 0
+
+  for (const seg of segments) {
+    result += text.slice(lastIndex, seg.start)
+    result += '\n```html\n' + seg.html + '\n```\n'
+    lastIndex = seg.end
+  }
+  result += text.slice(lastIndex)
+
+  // Trim leading/trailing newlines added by wrapping
+  result = result.replace(/^\n/, '').replace(/\n$/, '')
+
+  return { changed: true, result }
+}
+
+// Self-closing tag pattern: <tagname ... />
+const SELF_CLOSING_RE = /<([a-zA-Z][a-zA-Z0-9]*)\b[^>]*\/>/g
+
+// Opening tag pattern: <tagname ...>
+const OPEN_TAG_RE = /<([a-zA-Z][a-zA-Z0-9]*)\b[^>]*>/g
+
+/**
+ * Find HTML segments (paired open/close tags or self-closing tags) in text.
+ * Returns array of { start, end, html } or null if no HTML found.
+ */
+function extractHtmlSegments(text) {
+  const segments = []
+
+  // First pass: find self-closing tags
+  const selfClosing = []
+  let m
+  SELF_CLOSING_RE.lastIndex = 0
+  while ((m = SELF_CLOSING_RE.exec(text)) !== null) {
+    selfClosing.push({ start: m.index, end: m.index + m[0].length })
+  }
+
+  // Second pass: find paired open/close tags with nesting support
+  let i = 0
+  while (i < text.length) {
+    // Skip positions inside already-found self-closing tags
+    if (selfClosing.some((sc) => i >= sc.start && i < sc.end)) {
+      const sc = selfClosing.find((sc) => i >= sc.start && i < sc.end)
+      i = sc.end
+      continue
+    }
+
+    // Look for opening tag at position i
+    OPEN_TAG_RE.lastIndex = i
+    const openMatch = OPEN_TAG_RE.exec(text)
+    if (!openMatch || openMatch.index !== i) {
+      i++
+      continue
+    }
+
+    // Check if this is actually a self-closing tag
+    if (openMatch[0].endsWith('/>')) {
+      segments.push({
+        start: openMatch.index,
+        end: openMatch.index + openMatch[0].length,
+        html: openMatch[0],
+      })
+      i = openMatch.index + openMatch[0].length
+      continue
+    }
+
+    const tagName = openMatch[1]
+    const searchStart = openMatch.index + openMatch[0].length
+
+    // Find matching close tag with nesting support
+    const closeIndex = findMatchingCloseTag(text, tagName, searchStart)
+    if (closeIndex === -1) {
+      i++
+      continue
+    }
+
+    const closeTag = `</${tagName}>`
+    const endPos = closeIndex + closeTag.length
+    segments.push({
+      start: openMatch.index,
+      end: endPos,
+      html: text.slice(openMatch.index, endPos),
+    })
+    i = endPos
+    continue
+  }
+
+  // Add self-closing tags that aren't inside paired segments
+  for (const sc of selfClosing) {
+    if (!segments.some((seg) => sc.start >= seg.start && sc.end <= seg.end)) {
+      segments.push({ start: sc.start, end: sc.end, html: text.slice(sc.start, sc.end) })
+    }
+  }
+
+  if (segments.length === 0) return null
+
+  // Sort by position
+  segments.sort((a, b) => a.start - b.start)
+  return segments
+}
+
+/**
+ * Find the matching close tag for tagName, handling nested same-name tags.
+ * Returns the index of the matching </tagName> or -1.
+ */
+function findMatchingCloseTag(text, tagName, startFrom) {
+  const openPattern = new RegExp(`<${tagName}\\b[^>]*>`, 'gi')
+  const closePattern = new RegExp(`</${tagName}>`, 'gi')
+
+  let depth = 1
+  let pos = startFrom
+
+  while (depth > 0 && pos < text.length) {
+    openPattern.lastIndex = pos
+    closePattern.lastIndex = pos
+
+    const nextOpen = openPattern.exec(text)
+    const nextClose = closePattern.exec(text)
+
+    if (!nextClose) return -1 // No closing tag found
+
+    if (nextOpen && nextOpen.index < nextClose.index && !nextOpen[0].endsWith('/>')) {
+      // Nested open tag comes first
+      depth++
+      pos = nextOpen.index + nextOpen[0].length
+    } else {
+      // Close tag comes first (or no more open tags)
+      depth--
+      if (depth === 0) return nextClose.index
+      pos = nextClose.index + nextClose[0].length
+    }
+  }
+
+  return -1
+}

--- a/engines/collavre/app/javascript/lib/html_code_block_wrapper.js
+++ b/engines/collavre/app/javascript/lib/html_code_block_wrapper.js
@@ -19,13 +19,13 @@ export function wrapHtmlInCodeBlocks(text) {
 
   for (const seg of segments) {
     result += text.slice(lastIndex, seg.start)
-    result += '\n```html\n' + seg.html + '\n```\n'
+    result += '\n\n```html\n' + seg.html + '\n```\n\n'
     lastIndex = seg.end
   }
   result += text.slice(lastIndex)
 
   // Trim leading/trailing newlines added by wrapping
-  result = result.replace(/^\n/, '').replace(/\n$/, '')
+  result = result.replace(/^\n+/, '').replace(/\n+$/, '')
 
   return { changed: true, result }
 }

--- a/engines/collavre/app/javascript/lib/utils/markdown.js
+++ b/engines/collavre/app/javascript/lib/utils/markdown.js
@@ -11,7 +11,8 @@ export function renderMarkdownInline(html) {
 
 export function renderCommentMarkdown(text) {
   const content = text || ''
-  const html = content.includes('\n') ? marked.parse(content) : marked.parseInline(content)
+  const useBlock = content.includes('\n') || content.includes('```')
+  const html = useBlock ? marked.parse(content) : marked.parseInline(content)
   return DOMPurify.sanitize(html.trim())
 }
 


### PR DESCRIPTION
## Problem
When users paste HTML content into chat, it appears as raw escaped text, making it hard to read.

## Solution
Added a paste event handler in the comment form that detects HTML content (text containing HTML tag pairs or self-closing tags) and automatically wraps it in a markdown code block (```html ... ```).

**Behavior:**
- Paste HTML → automatically wrapped in ```html code block
- Paste plain text → unchanged (no interference)
- Paste text already in code block → unchanged (no double-wrap)
- Cursor positioned after the code block for seamless typing

## Files Changed
- `engines/collavre/app/javascript/controllers/comments/form_controller.js` — added `handlePaste` method