### PR TITLE
fix: voice button active state not visible due to CSS specificity

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/creatives.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/creatives.css
@@ -278,8 +278,8 @@ creative-tree-row.show-edit .creative-row {
 }
 
 #voice-comments-btn.voice-input-active {
-    background-color: #2ecc71;
-    color: #ffffff;
+    background-color: var(--color-complete);
+    color: var(--color-bg);
     border-radius: 6px;
     padding: 4px 8px;
 }

--- a/engines/collavre/app/assets/stylesheets/collavre/creatives.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/creatives.css
@@ -277,7 +277,7 @@ creative-tree-row.show-edit .creative-row {
     pointer-events: none;
 }
 
-.voice-input-active {
+#voice-comments-btn.voice-input-active {
     background-color: #2ecc71;
     color: #ffffff;
     border-radius: 6px;


### PR DESCRIPTION
## Problem

The voice button's active state (green background) was not visible when speech recognition was active.

## Root Cause

`comments_popup.css` applies `background: none` to `#voice-comments-btn` using an ID selector, which has higher specificity than the `.voice-input-active` class selector in `creatives.css`.

## Fix

Changed `.voice-input-active` to `#voice-comments-btn.voice-input-active` to match the ID specificity and ensure the green active background is visible.

## Before / After

- **Before**: Clicking voice button shows no visual feedback
- **After**: Clicking voice button shows green background (`#2ecc71`)