### PR TITLE
fix: add agent_status heartbeat during streaming and safety timeout

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -62,6 +62,33 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_19_104210) do
     t.index ["user_id"], name: "index_activity_logs_on_user_id"
   end
 
+  create_table "agent_actions", force: :cascade do |t|
+    t.integer "agent_run_id", null: false
+    t.json "arguments", default: {}
+    t.datetime "created_at", null: false
+    t.text "result"
+    t.string "status", default: "pending"
+    t.string "tool_name"
+    t.datetime "updated_at", null: false
+    t.index ["agent_run_id"], name: "index_agent_actions_on_agent_run_id"
+  end
+
+  create_table "agent_runs", force: :cascade do |t|
+    t.integer "ai_user_id", null: false
+    t.json "context", default: {}
+    t.datetime "created_at", null: false
+    t.integer "creative_id", null: false
+    t.text "goal"
+    t.integer "iteration_count", default: 0
+    t.datetime "next_run_at"
+    t.string "state", default: "planning"
+    t.string "status", default: "pending"
+    t.json "transcript", default: []
+    t.datetime "updated_at", null: false
+    t.index ["ai_user_id"], name: "index_agent_runs_on_ai_user_id"
+    t.index ["creative_id"], name: "index_agent_runs_on_creative_id"
+  end
+
   create_table "calendar_events", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.integer "creative_id"
@@ -110,6 +137,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_19_104210) do
     t.boolean "private", default: false, null: false
     t.integer "quoted_comment_id"
     t.text "quoted_text"
+    t.boolean "streaming", default: false, null: false
     t.integer "topic_id"
     t.datetime "updated_at", null: false
     t.integer "user_id"
@@ -186,6 +214,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_19_104210) do
     t.integer "sequence", default: 0, null: false
     t.datetime "updated_at", null: false
     t.integer "user_id", null: false
+    t.index ["data"], name: "index_creatives_on_data"
     t.index ["origin_id"], name: "index_creatives_on_origin_id"
     t.index ["parent_id"], name: "index_creatives_on_parent_id"
     t.index ["user_id"], name: "index_creatives_on_user_id"
@@ -777,7 +806,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_19_104210) do
   add_foreign_key "creative_expanded_states", "users"
   add_foreign_key "creative_shares", "creatives"
   add_foreign_key "creative_shares", "users"
-  add_foreign_key "creative_shares", "users", column: "shared_by_id", on_delete: :nullify
+  add_foreign_key "creative_shares", "users", column: "shared_by_id"
   add_foreign_key "creatives", "creatives", column: "origin_id"
   add_foreign_key "creatives", "creatives", column: "parent_id"
   add_foreign_key "creatives", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -62,33 +62,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_19_104210) do
     t.index ["user_id"], name: "index_activity_logs_on_user_id"
   end
 
-  create_table "agent_actions", force: :cascade do |t|
-    t.integer "agent_run_id", null: false
-    t.json "arguments", default: {}
-    t.datetime "created_at", null: false
-    t.text "result"
-    t.string "status", default: "pending"
-    t.string "tool_name"
-    t.datetime "updated_at", null: false
-    t.index ["agent_run_id"], name: "index_agent_actions_on_agent_run_id"
-  end
-
-  create_table "agent_runs", force: :cascade do |t|
-    t.integer "ai_user_id", null: false
-    t.json "context", default: {}
-    t.datetime "created_at", null: false
-    t.integer "creative_id", null: false
-    t.text "goal"
-    t.integer "iteration_count", default: 0
-    t.datetime "next_run_at"
-    t.string "state", default: "planning"
-    t.string "status", default: "pending"
-    t.json "transcript", default: []
-    t.datetime "updated_at", null: false
-    t.index ["ai_user_id"], name: "index_agent_runs_on_ai_user_id"
-    t.index ["creative_id"], name: "index_agent_runs_on_creative_id"
-  end
-
   create_table "calendar_events", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.integer "creative_id"
@@ -137,7 +110,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_19_104210) do
     t.boolean "private", default: false, null: false
     t.integer "quoted_comment_id"
     t.text "quoted_text"
-    t.boolean "streaming", default: false, null: false
     t.integer "topic_id"
     t.datetime "updated_at", null: false
     t.integer "user_id"
@@ -214,7 +186,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_19_104210) do
     t.integer "sequence", default: 0, null: false
     t.datetime "updated_at", null: false
     t.integer "user_id", null: false
-    t.index ["data"], name: "index_creatives_on_data"
     t.index ["origin_id"], name: "index_creatives_on_origin_id"
     t.index ["parent_id"], name: "index_creatives_on_parent_id"
     t.index ["user_id"], name: "index_creatives_on_user_id"
@@ -806,7 +777,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_19_104210) do
   add_foreign_key "creative_expanded_states", "users"
   add_foreign_key "creative_shares", "creatives"
   add_foreign_key "creative_shares", "users"
-  add_foreign_key "creative_shares", "users", column: "shared_by_id"
+  add_foreign_key "creative_shares", "users", column: "shared_by_id", on_delete: :nullify
   add_foreign_key "creatives", "creatives", column: "origin_id"
   add_foreign_key "creatives", "creatives", column: "parent_id"
   add_foreign_key "creatives", "users"

--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -1110,12 +1110,12 @@ body.chat-fullscreen {
     }
 }
 
-/* Blinking cursor at the end of streaming content (not on placeholder dots) */
-.comment-content.streaming:not(:has(.streaming-dots))::after {
-    content: '▍';
+/* Blinking cursor inline at the end of streaming content */
+.streaming-cursor {
     animation: streaming-blink 1s infinite;
     color: var(--color-text, #333);
     margin-left: 1px;
+    font-weight: normal;
 }
 
 @keyframes streaming-blink {

--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -1070,3 +1070,55 @@ body.chat-fullscreen {
 .comments-popup-actions .popup-close-btn {
   position: static;
 }
+
+/* Streaming indicator for AI comments */
+.comment-content.streaming {
+    min-height: 1.5em;
+}
+
+.streaming-dots {
+    display: inline-flex;
+    gap: 2px;
+    font-size: 1.5em;
+    line-height: 1;
+}
+
+.streaming-dots span {
+    animation: streaming-bounce 1.4s infinite ease-in-out both;
+}
+
+.streaming-dots span:nth-child(1) {
+    animation-delay: 0s;
+}
+
+.streaming-dots span:nth-child(2) {
+    animation-delay: 0.2s;
+}
+
+.streaming-dots span:nth-child(3) {
+    animation-delay: 0.4s;
+}
+
+@keyframes streaming-bounce {
+    0%, 80%, 100% {
+        opacity: 0.3;
+        transform: translateY(0);
+    }
+    40% {
+        opacity: 1;
+        transform: translateY(-4px);
+    }
+}
+
+/* Blinking cursor at the end of streaming content (not on placeholder dots) */
+.comment-content.streaming:not(:has(.streaming-dots))::after {
+    content: '▍';
+    animation: streaming-blink 1s infinite;
+    color: var(--color-text, #333);
+    margin-left: 1px;
+}
+
+@keyframes streaming-blink {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0; }
+}

--- a/engines/collavre/app/javascript/controllers/comment_controller.js
+++ b/engines/collavre/app/javascript/controllers/comment_controller.js
@@ -79,7 +79,6 @@ export default class extends Controller {
     // This prevents read-receipt or other sibling Turbo updates from
     // triggering the observer and accidentally re-rendering markdown.
     if (this.element.dataset.aiUser === 'true') {
-      this._streamingTimeout = null
       this._contentObserver = new MutationObserver(() => {
         const el = this.element.querySelector('.comment-content')
         if (!el) return

--- a/engines/collavre/app/javascript/controllers/comment_controller.js
+++ b/engines/collavre/app/javascript/controllers/comment_controller.js
@@ -10,8 +10,46 @@ export default class extends Controller {
     const contentElement = this.element.querySelector('.comment-content')
     if (contentElement && contentElement.dataset.rendered !== 'true') {
       const text = contentElement.textContent || ''
-      contentElement.innerHTML = renderCommentMarkdown(text)
+      if (this.element.dataset.aiUser === 'true' && text.trim() === '...') {
+        // Streaming placeholder — show animated dots
+        contentElement.innerHTML = '<span class="streaming-dots"><span>.</span><span>.</span><span>.</span></span>'
+        contentElement.classList.add('streaming')
+      } else {
+        contentElement.innerHTML = renderCommentMarkdown(text)
+        contentElement.classList.remove('streaming')
+      }
       contentElement.dataset.rendered = 'true'
+    }
+
+    // Observe Turbo replacements to re-render markdown and maintain streaming state
+    if (this.element.dataset.aiUser === 'true') {
+      this._streamingTimeout = null
+      this._contentObserver = new MutationObserver(() => {
+        const el = this.element.querySelector('.comment-content')
+        if (!el) return
+        if (el.dataset.rendering === 'true') return
+        el.dataset.rendering = 'true'
+        try {
+          const text = el.textContent || ''
+          if (text.trim() === '...') {
+            el.innerHTML = '<span class="streaming-dots"><span>.</span><span>.</span><span>.</span></span>'
+            el.classList.add('streaming')
+          } else if (text.trim()) {
+            el.innerHTML = renderCommentMarkdown(text)
+            // Mark as streaming — will be cleared when updates stop
+            el.classList.add('streaming')
+            // Reset timeout: remove streaming class if no update for 3s
+            if (this._streamingTimeout) clearTimeout(this._streamingTimeout)
+            this._streamingTimeout = setTimeout(() => {
+              el.classList.remove('streaming')
+            }, 3000)
+          }
+          el.dataset.rendered = 'true'
+        } finally {
+          requestAnimationFrame(() => { el.dataset.rendering = 'false' })
+        }
+      })
+      this._contentObserver.observe(this.element, { childList: true, subtree: true, characterData: true })
     }
 
     // Text selection quote support
@@ -118,6 +156,14 @@ export default class extends Controller {
   }
 
   disconnect() {
+    if (this._contentObserver) {
+      this._contentObserver.disconnect()
+      this._contentObserver = null
+    }
+    if (this._streamingTimeout) {
+      clearTimeout(this._streamingTimeout)
+      this._streamingTimeout = null
+    }
     this.element.removeEventListener('mouseup', this.handleMouseUp)
     this._removeSelectionChangeListener()
     this.hideReviewPopup()

--- a/engines/collavre/app/javascript/controllers/comment_controller.js
+++ b/engines/collavre/app/javascript/controllers/comment_controller.js
@@ -2,9 +2,50 @@ import { Controller } from "@hotwired/stimulus"
 import { renderCommentMarkdown } from '../lib/utils/markdown'
 import CommonPopup from '../lib/common_popup'
 
+// Global tracker: persists streaming state across Turbo replacements
+// (each replacement creates a new controller instance, losing instance state)
+if (!window._streamingCommentIds) window._streamingCommentIds = new Set()
+
 // Connects to data-controller="comment"
 export default class extends Controller {
   static targets = ["ownerButton", "deleteButton", "approveButton", "actionApproveControls", "reviewButton", "replaceButton"]
+
+  get _commentId() {
+    return this.element.dataset.commentId
+  }
+
+  get _isStreaming() {
+    return window._streamingCommentIds.has(this._commentId)
+  }
+
+  set _isStreaming(val) {
+    if (val) {
+      window._streamingCommentIds.add(this._commentId)
+    } else {
+      window._streamingCommentIds.delete(this._commentId)
+    }
+  }
+
+  _appendStreamingCursor(el) {
+    const cursor = document.createElement('span')
+    cursor.className = 'streaming-cursor'
+    cursor.textContent = '▍'
+    let target = el
+    while (target.lastElementChild && target.lastElementChild.tagName !== 'BR') {
+      target = target.lastElementChild
+    }
+    target.appendChild(cursor)
+  }
+
+  _resetStreamingTimeout(el) {
+    if (this._streamingTimeout) clearTimeout(this._streamingTimeout)
+    this._streamingTimeout = setTimeout(() => {
+      el.classList.remove('streaming')
+      const c = el.querySelector('.streaming-cursor')
+      if (c) c.remove()
+      this._isStreaming = false
+    }, 3000)
+  }
 
   connect() {
     if (!this._streamingTimeout) this._streamingTimeout = null
@@ -16,30 +57,14 @@ export default class extends Controller {
         if (this.element.dataset.aiUser === 'true' && text.trim() === '...') {
           // Streaming placeholder — show animated dots
           this._isStreaming = true
-          this.element.dataset.streaming = 'true'
           contentElement.innerHTML = '<span class="streaming-dots"><span>.</span><span>.</span><span>.</span></span>'
           contentElement.classList.add('streaming')
         } else if (this.element.dataset.aiUser === 'true' && this._isStreaming && text.trim()) {
           // Streaming content arrived — render markdown with cursor
           contentElement.innerHTML = renderCommentMarkdown(text)
-          const cursor = document.createElement('span')
-          cursor.className = 'streaming-cursor'
-          cursor.textContent = '▍'
-          let target = contentElement
-          while (target.lastElementChild && target.lastElementChild.tagName !== 'BR') {
-            target = target.lastElementChild
-          }
-          target.appendChild(cursor)
+          this._appendStreamingCursor(contentElement)
           contentElement.classList.add('streaming')
-          // Auto-remove cursor if no further updates (streaming ended)
-          if (this._streamingTimeout) clearTimeout(this._streamingTimeout)
-          this._streamingTimeout = setTimeout(() => {
-            contentElement.classList.remove('streaming')
-            const c = contentElement.querySelector('.streaming-cursor')
-            if (c) c.remove()
-            this._isStreaming = false
-            this.element.dataset.streaming = 'false'
-          }, 3000)
+          this._resetStreamingTimeout(contentElement)
         } else {
           contentElement.innerHTML = renderCommentMarkdown(text)
           contentElement.classList.remove('streaming')
@@ -50,10 +75,11 @@ export default class extends Controller {
       }
     }
 
-    // Observe Turbo replacements to re-render markdown and maintain streaming state
+    // Observe only .comment-content for content changes.
+    // This prevents read-receipt or other sibling Turbo updates from
+    // triggering the observer and accidentally re-rendering markdown.
     if (this.element.dataset.aiUser === 'true') {
       this._streamingTimeout = null
-      this._isStreaming = this.element.dataset.streaming === 'true'
       this._contentObserver = new MutationObserver(() => {
         const el = this.element.querySelector('.comment-content')
         if (!el) return
@@ -62,32 +88,15 @@ export default class extends Controller {
         try {
           const text = el.textContent || ''
           if (text.trim() === '...') {
-            // Placeholder detected — this comment is streaming
             this._isStreaming = true
             el.innerHTML = '<span class="streaming-dots"><span>.</span><span>.</span><span>.</span></span>'
             el.classList.add('streaming')
           } else if (text.trim()) {
             el.innerHTML = renderCommentMarkdown(text)
             if (this._isStreaming) {
-              // Append blinking cursor inline at the end of content
-              const cursor = document.createElement('span')
-              cursor.className = 'streaming-cursor'
-              cursor.textContent = '▍'
-              // Find the deepest last element to append cursor inline
-              let target = el
-              while (target.lastElementChild && target.lastElementChild.tagName !== 'BR') {
-                target = target.lastElementChild
-              }
-              target.appendChild(cursor)
+              this._appendStreamingCursor(el)
               el.classList.add('streaming')
-              // Reset timeout: remove streaming class if no update for 3s
-              if (this._streamingTimeout) clearTimeout(this._streamingTimeout)
-              this._streamingTimeout = setTimeout(() => {
-                el.classList.remove('streaming')
-                const c = el.querySelector('.streaming-cursor')
-                if (c) c.remove()
-                this._isStreaming = false
-              }, 3000)
+              this._resetStreamingTimeout(el)
             }
           }
           el.dataset.rendered = 'true'
@@ -95,9 +104,6 @@ export default class extends Controller {
           requestAnimationFrame(() => { el.dataset.rendering = 'false' })
         }
       })
-      // Observe only .comment-content, not the entire comment-item.
-      // This prevents read-receipt or other sibling Turbo updates from
-      // triggering the observer and accidentally re-rendering markdown.
       const observeTarget = this.element.querySelector('.comment-content')
       if (observeTarget) {
         this._contentObserver.observe(observeTarget, { childList: true, subtree: true, characterData: true })

--- a/engines/collavre/app/javascript/controllers/comment_controller.js
+++ b/engines/collavre/app/javascript/controllers/comment_controller.js
@@ -59,8 +59,9 @@ export default class extends Controller {
           this._isStreaming = true
           contentElement.innerHTML = '<span class="streaming-dots"><span>.</span><span>.</span><span>.</span></span>'
           contentElement.classList.add('streaming')
-        } else if (this.element.dataset.aiUser === 'true' && this._isStreaming && text.trim()) {
+        } else if (this.element.dataset.aiUser === 'true' && (this._isStreaming || this.element.dataset.streaming === 'true') && text.trim()) {
           // Streaming content arrived — render markdown with cursor
+          this._isStreaming = true
           contentElement.innerHTML = renderCommentMarkdown(text)
           this._appendStreamingCursor(contentElement)
           contentElement.classList.add('streaming')

--- a/engines/collavre/app/javascript/controllers/comment_controller.js
+++ b/engines/collavre/app/javascript/controllers/comment_controller.js
@@ -71,7 +71,13 @@ export default class extends Controller {
           requestAnimationFrame(() => { el.dataset.rendering = 'false' })
         }
       })
-      this._contentObserver.observe(this.element, { childList: true, subtree: true, characterData: true })
+      // Observe only .comment-content, not the entire comment-item.
+      // This prevents read-receipt or other sibling Turbo updates from
+      // triggering the observer and accidentally re-rendering markdown.
+      const observeTarget = this.element.querySelector('.comment-content')
+      if (observeTarget) {
+        this._contentObserver.observe(observeTarget, { childList: true, subtree: true, characterData: true })
+      }
     }
 
     // Text selection quote support

--- a/engines/collavre/app/javascript/controllers/comment_controller.js
+++ b/engines/collavre/app/javascript/controllers/comment_controller.js
@@ -26,6 +26,32 @@ export default class extends Controller {
     }
   }
 
+  // --- Streaming state helpers ---
+
+  get _isAiComment() {
+    return this.element.dataset.aiUser === 'true'
+  }
+
+  // Server explicitly marked this broadcast as streaming (true) or done (false).
+  // When no streaming local is provided the partial defaults to "false".
+  get _serverStreaming() {
+    return this.element.dataset.streaming === 'true'
+  }
+
+  // The server sent streaming: false explicitly — stream just ended.
+  get _serverStreamingDone() {
+    return this.element.dataset.streaming === 'false'
+  }
+
+  // Should we treat this comment as currently streaming?
+  // True when the server says so OR the global Set remembers it,
+  // but NOT if the server explicitly signalled completion.
+  _shouldStream(text) {
+    if (!this._isAiComment || !text.trim()) return false
+    if (this._serverStreamingDone) return false
+    return this._isStreaming || this._serverStreaming
+  }
+
   _appendStreamingCursor(el) {
     const cursor = document.createElement('span')
     cursor.className = 'streaming-cursor'
@@ -37,7 +63,7 @@ export default class extends Controller {
     target.appendChild(cursor)
   }
 
-  _resetStreamingTimeout(el) {
+  _resetStreamingTimeout() {
     if (this._streamingTimeout) clearTimeout(this._streamingTimeout)
     this._streamingTimeout = setTimeout(() => {
       const currentEl = this.element?.querySelector('.comment-content')
@@ -55,6 +81,14 @@ export default class extends Controller {
     }, 10000)
   }
 
+  _cleanupStreaming() {
+    this._isStreaming = false
+    if (this._streamingTimeout) {
+      clearTimeout(this._streamingTimeout)
+      this._streamingTimeout = null
+    }
+  }
+
   connect() {
     if (!this._streamingTimeout) this._streamingTimeout = null
     const contentElement = this.element.querySelector('.comment-content')
@@ -62,67 +96,26 @@ export default class extends Controller {
       contentElement.dataset.rendering = 'true'
       try {
         const text = contentElement.textContent || ''
-        if (this.element.dataset.aiUser === 'true' && text.trim() === '...') {
+        if (this._isAiComment && text.trim() === '...') {
           // Streaming placeholder — show animated dots
           this._isStreaming = true
           contentElement.innerHTML = '<span class="streaming-dots"><span>.</span><span>.</span><span>.</span></span>'
           contentElement.classList.add('streaming')
-        } else if (this.element.dataset.aiUser === 'true' && this.element.dataset.streaming !== 'false' && (this._isStreaming || this.element.dataset.streaming === 'true') && text.trim()) {
+        } else if (this._shouldStream(text)) {
           // Streaming content arrived — render markdown with cursor
           this._isStreaming = true
           contentElement.innerHTML = renderCommentMarkdown(text)
           this._appendStreamingCursor(contentElement)
           contentElement.classList.add('streaming')
-          this._resetStreamingTimeout(contentElement)
+          this._resetStreamingTimeout()
         } else {
           contentElement.innerHTML = renderCommentMarkdown(text)
           contentElement.classList.remove('streaming')
-          // Streaming just finished — clean up
-          if (this._isStreaming) {
-            this._isStreaming = false
-            if (this._streamingTimeout) {
-              clearTimeout(this._streamingTimeout)
-              this._streamingTimeout = null
-            }
-          }
+          if (this._isStreaming) this._cleanupStreaming()
         }
         contentElement.dataset.rendered = 'true'
       } finally {
         requestAnimationFrame(() => { contentElement.dataset.rendering = 'false' })
-      }
-    }
-
-    // Observe only .comment-content for content changes.
-    // This prevents read-receipt or other sibling Turbo updates from
-    // triggering the observer and accidentally re-rendering markdown.
-    if (this.element.dataset.aiUser === 'true') {
-      this._contentObserver = new MutationObserver(() => {
-        const el = this.element.querySelector('.comment-content')
-        if (!el) return
-        if (el.dataset.rendering === 'true') return
-        el.dataset.rendering = 'true'
-        try {
-          const text = el.textContent || ''
-          if (text.trim() === '...') {
-            this._isStreaming = true
-            el.innerHTML = '<span class="streaming-dots"><span>.</span><span>.</span><span>.</span></span>'
-            el.classList.add('streaming')
-          } else if (text.trim()) {
-            el.innerHTML = renderCommentMarkdown(text)
-            if (this._isStreaming) {
-              this._appendStreamingCursor(el)
-              el.classList.add('streaming')
-              this._resetStreamingTimeout(el)
-            }
-          }
-          el.dataset.rendered = 'true'
-        } finally {
-          requestAnimationFrame(() => { el.dataset.rendering = 'false' })
-        }
-      })
-      const observeTarget = this.element.querySelector('.comment-content')
-      if (observeTarget) {
-        this._contentObserver.observe(observeTarget, { childList: true, subtree: true, characterData: true })
       }
     }
 
@@ -230,10 +223,6 @@ export default class extends Controller {
   }
 
   disconnect() {
-    if (this._contentObserver) {
-      this._contentObserver.disconnect()
-      this._contentObserver = null
-    }
     if (this._streamingTimeout) {
       clearTimeout(this._streamingTimeout)
       this._streamingTimeout = null

--- a/engines/collavre/app/javascript/controllers/comment_controller.js
+++ b/engines/collavre/app/javascript/controllers/comment_controller.js
@@ -67,7 +67,7 @@ export default class extends Controller {
           this._isStreaming = true
           contentElement.innerHTML = '<span class="streaming-dots"><span>.</span><span>.</span><span>.</span></span>'
           contentElement.classList.add('streaming')
-        } else if (this.element.dataset.aiUser === 'true' && (this._isStreaming || this.element.dataset.streaming === 'true') && text.trim()) {
+        } else if (this.element.dataset.aiUser === 'true' && this.element.dataset.streaming !== 'false' && (this._isStreaming || this.element.dataset.streaming === 'true') && text.trim()) {
           // Streaming content arrived — render markdown with cursor
           this._isStreaming = true
           contentElement.innerHTML = renderCommentMarkdown(text)

--- a/engines/collavre/app/javascript/controllers/comment_controller.js
+++ b/engines/collavre/app/javascript/controllers/comment_controller.js
@@ -40,9 +40,17 @@ export default class extends Controller {
   _resetStreamingTimeout(el) {
     if (this._streamingTimeout) clearTimeout(this._streamingTimeout)
     this._streamingTimeout = setTimeout(() => {
-      el.classList.remove('streaming')
-      const c = el.querySelector('.streaming-cursor')
-      if (c) c.remove()
+      const currentEl = this.element?.querySelector('.comment-content')
+      if (currentEl) {
+        currentEl.dataset.rendering = 'true'
+        try {
+          currentEl.classList.remove('streaming')
+          const c = currentEl.querySelector('.streaming-cursor')
+          if (c) c.remove()
+        } finally {
+          requestAnimationFrame(() => { currentEl.dataset.rendering = 'false' })
+        }
+      }
       this._isStreaming = false
     }, 10000)
   }

--- a/engines/collavre/app/javascript/controllers/comment_controller.js
+++ b/engines/collavre/app/javascript/controllers/comment_controller.js
@@ -77,6 +77,14 @@ export default class extends Controller {
         } else {
           contentElement.innerHTML = renderCommentMarkdown(text)
           contentElement.classList.remove('streaming')
+          // Streaming just finished — clean up
+          if (this._isStreaming) {
+            this._isStreaming = false
+            if (this._streamingTimeout) {
+              clearTimeout(this._streamingTimeout)
+              this._streamingTimeout = null
+            }
+          }
         }
         contentElement.dataset.rendered = 'true'
       } finally {

--- a/engines/collavre/app/javascript/controllers/comment_controller.js
+++ b/engines/collavre/app/javascript/controllers/comment_controller.js
@@ -7,6 +7,7 @@ export default class extends Controller {
   static targets = ["ownerButton", "deleteButton", "approveButton", "actionApproveControls", "reviewButton", "replaceButton"]
 
   connect() {
+    if (!this._streamingTimeout) this._streamingTimeout = null
     const contentElement = this.element.querySelector('.comment-content')
     if (contentElement && contentElement.dataset.rendered !== 'true') {
       contentElement.dataset.rendering = 'true'
@@ -14,8 +15,31 @@ export default class extends Controller {
         const text = contentElement.textContent || ''
         if (this.element.dataset.aiUser === 'true' && text.trim() === '...') {
           // Streaming placeholder — show animated dots
+          this._isStreaming = true
+          this.element.dataset.streaming = 'true'
           contentElement.innerHTML = '<span class="streaming-dots"><span>.</span><span>.</span><span>.</span></span>'
           contentElement.classList.add('streaming')
+        } else if (this.element.dataset.aiUser === 'true' && this._isStreaming && text.trim()) {
+          // Streaming content arrived — render markdown with cursor
+          contentElement.innerHTML = renderCommentMarkdown(text)
+          const cursor = document.createElement('span')
+          cursor.className = 'streaming-cursor'
+          cursor.textContent = '▍'
+          let target = contentElement
+          while (target.lastElementChild && target.lastElementChild.tagName !== 'BR') {
+            target = target.lastElementChild
+          }
+          target.appendChild(cursor)
+          contentElement.classList.add('streaming')
+          // Auto-remove cursor if no further updates (streaming ended)
+          if (this._streamingTimeout) clearTimeout(this._streamingTimeout)
+          this._streamingTimeout = setTimeout(() => {
+            contentElement.classList.remove('streaming')
+            const c = contentElement.querySelector('.streaming-cursor')
+            if (c) c.remove()
+            this._isStreaming = false
+            this.element.dataset.streaming = 'false'
+          }, 3000)
         } else {
           contentElement.innerHTML = renderCommentMarkdown(text)
           contentElement.classList.remove('streaming')
@@ -29,7 +53,7 @@ export default class extends Controller {
     // Observe Turbo replacements to re-render markdown and maintain streaming state
     if (this.element.dataset.aiUser === 'true') {
       this._streamingTimeout = null
-      this._isStreaming = false  // Only set true when we see '...' placeholder
+      this._isStreaming = this.element.dataset.streaming === 'true'
       this._contentObserver = new MutationObserver(() => {
         const el = this.element.querySelector('.comment-content')
         if (!el) return

--- a/engines/collavre/app/javascript/controllers/comment_controller.js
+++ b/engines/collavre/app/javascript/controllers/comment_controller.js
@@ -44,7 +44,7 @@ export default class extends Controller {
       const c = el.querySelector('.streaming-cursor')
       if (c) c.remove()
       this._isStreaming = false
-    }, 3000)
+    }, 10000)
   }
 
   connect() {

--- a/engines/collavre/app/javascript/controllers/comment_controller.js
+++ b/engines/collavre/app/javascript/controllers/comment_controller.js
@@ -24,6 +24,7 @@ export default class extends Controller {
     // Observe Turbo replacements to re-render markdown and maintain streaming state
     if (this.element.dataset.aiUser === 'true') {
       this._streamingTimeout = null
+      this._isStreaming = false  // Only set true when we see '...' placeholder
       this._contentObserver = new MutationObserver(() => {
         const el = this.element.querySelector('.comment-content')
         if (!el) return
@@ -32,17 +33,33 @@ export default class extends Controller {
         try {
           const text = el.textContent || ''
           if (text.trim() === '...') {
+            // Placeholder detected — this comment is streaming
+            this._isStreaming = true
             el.innerHTML = '<span class="streaming-dots"><span>.</span><span>.</span><span>.</span></span>'
             el.classList.add('streaming')
           } else if (text.trim()) {
             el.innerHTML = renderCommentMarkdown(text)
-            // Mark as streaming — will be cleared when updates stop
-            el.classList.add('streaming')
-            // Reset timeout: remove streaming class if no update for 3s
-            if (this._streamingTimeout) clearTimeout(this._streamingTimeout)
-            this._streamingTimeout = setTimeout(() => {
-              el.classList.remove('streaming')
-            }, 3000)
+            if (this._isStreaming) {
+              // Append blinking cursor inline at the end of content
+              const cursor = document.createElement('span')
+              cursor.className = 'streaming-cursor'
+              cursor.textContent = '▍'
+              // Find the deepest last element to append cursor inline
+              let target = el
+              while (target.lastElementChild && target.lastElementChild.tagName !== 'BR') {
+                target = target.lastElementChild
+              }
+              target.appendChild(cursor)
+              el.classList.add('streaming')
+              // Reset timeout: remove streaming class if no update for 3s
+              if (this._streamingTimeout) clearTimeout(this._streamingTimeout)
+              this._streamingTimeout = setTimeout(() => {
+                el.classList.remove('streaming')
+                const c = el.querySelector('.streaming-cursor')
+                if (c) c.remove()
+                this._isStreaming = false
+              }, 3000)
+            }
           }
           el.dataset.rendered = 'true'
         } finally {

--- a/engines/collavre/app/javascript/controllers/comment_controller.js
+++ b/engines/collavre/app/javascript/controllers/comment_controller.js
@@ -9,16 +9,21 @@ export default class extends Controller {
   connect() {
     const contentElement = this.element.querySelector('.comment-content')
     if (contentElement && contentElement.dataset.rendered !== 'true') {
-      const text = contentElement.textContent || ''
-      if (this.element.dataset.aiUser === 'true' && text.trim() === '...') {
-        // Streaming placeholder — show animated dots
-        contentElement.innerHTML = '<span class="streaming-dots"><span>.</span><span>.</span><span>.</span></span>'
-        contentElement.classList.add('streaming')
-      } else {
-        contentElement.innerHTML = renderCommentMarkdown(text)
-        contentElement.classList.remove('streaming')
+      contentElement.dataset.rendering = 'true'
+      try {
+        const text = contentElement.textContent || ''
+        if (this.element.dataset.aiUser === 'true' && text.trim() === '...') {
+          // Streaming placeholder — show animated dots
+          contentElement.innerHTML = '<span class="streaming-dots"><span>.</span><span>.</span><span>.</span></span>'
+          contentElement.classList.add('streaming')
+        } else {
+          contentElement.innerHTML = renderCommentMarkdown(text)
+          contentElement.classList.remove('streaming')
+        }
+        contentElement.dataset.rendered = 'true'
+      } finally {
+        requestAnimationFrame(() => { contentElement.dataset.rendering = 'false' })
       }
-      contentElement.dataset.rendered = 'true'
     }
 
     // Observe Turbo replacements to re-render markdown and maintain streaming state

--- a/engines/collavre/app/javascript/controllers/comments/presence_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/presence_controller.js
@@ -2,6 +2,7 @@ import { Controller } from '@hotwired/stimulus'
 import { createSubscription } from '../../services/cable'
 
 const TYPING_TIMEOUT = 3000
+const AGENT_STATUS_TIMEOUT = 10000 // Safety timeout for agent_status (heartbeat expected every 3s)
 
 export default class extends Controller {
   static targets = ['participants', 'typingIndicator', 'textarea', 'privateCheckbox']
@@ -158,8 +159,20 @@ export default class extends Controller {
       }
       if (status === 'thinking' || status === 'streaming') {
         this.typingUsers[id] = name
+        // Safety timeout: auto-remove if no heartbeat within AGENT_STATUS_TIMEOUT
+        if (!this.agentStatusTimers) this.agentStatusTimers = {}
+        if (this.agentStatusTimers[id]) clearTimeout(this.agentStatusTimers[id])
+        this.agentStatusTimers[id] = setTimeout(() => {
+          delete this.typingUsers[id]
+          delete this.agentStatusTimers[id]
+          this.renderTypingIndicator()
+        }, AGENT_STATUS_TIMEOUT)
       } else {
         delete this.typingUsers[id]
+        if (this.agentStatusTimers?.[id]) {
+          clearTimeout(this.agentStatusTimers[id])
+          delete this.agentStatusTimers[id]
+        }
       }
       this.renderTypingIndicator()
     }

--- a/engines/collavre/app/services/collavre/ai_agent_service.rb
+++ b/engines/collavre/app/services/collavre/ai_agent_service.rb
@@ -132,6 +132,11 @@ module Collavre
         if @response_content.present?
           @reply_comment.content_will_change!
           @reply_comment.update!(content: @response_content)
+          @reply_comment.broadcast_update_to(
+            [ @reply_comment.creative, :comments ],
+            partial: "collavre/comments/comment",
+            locals: { comment: @reply_comment, streaming: false }
+          )
           log_action("reply_created", { comment_id: @reply_comment.id, content: @response_content, partial: true })
           reassociate_activity_logs(@original_comment, @reply_comment)
         else
@@ -155,6 +160,11 @@ module Collavre
           else
             @reply_comment.content_will_change!
             @reply_comment.update!(content: @response_content)
+            @reply_comment.broadcast_update_to(
+              [ @reply_comment.creative, :comments ],
+              partial: "collavre/comments/comment",
+              locals: { comment: @reply_comment, streaming: false }
+            )
             log_action("reply_created", { comment_id: @reply_comment.id, content: @response_content })
             reassociate_activity_logs(@original_comment, @reply_comment)
             dispatch_a2a_if_needed

--- a/engines/collavre/app/services/collavre/ai_agent_service.rb
+++ b/engines/collavre/app/services/collavre/ai_agent_service.rb
@@ -85,7 +85,8 @@ module Collavre
             @reply_comment.update_column(:content, @response_content)
             @reply_comment.broadcast_update_to(
               [ @reply_comment.creative, :comments ],
-              partial: "collavre/comments/comment"
+              partial: "collavre/comments/comment",
+              locals: { comment: @reply_comment, streaming: true }
             )
             last_broadcast_at = now
           end

--- a/engines/collavre/app/services/collavre/ai_agent_service.rb
+++ b/engines/collavre/app/services/collavre/ai_agent_service.rb
@@ -4,6 +4,8 @@ module Collavre
     STREAM_THROTTLE_INTERVAL = 0.1
     # Minimum interval (in seconds) between cancellation checks to avoid excessive DB queries
     CANCEL_CHECK_INTERVAL = 1.0
+    # Interval (in seconds) between agent_status heartbeats during streaming
+    AGENT_STATUS_HEARTBEAT_INTERVAL = 3.0
 
     def initialize(task)
       @task = task
@@ -71,6 +73,7 @@ module Collavre
         )
 
         last_broadcast_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        last_heartbeat_at = last_broadcast_at
         @last_cancel_check_at = last_broadcast_at
 
         client.chat(messages, tools: @agent.tools || []) do |delta|
@@ -85,6 +88,12 @@ module Collavre
               partial: "collavre/comments/comment"
             )
             last_broadcast_at = now
+          end
+
+          # Periodic agent_status heartbeat so clients know we're still streaming
+          if (now - last_heartbeat_at) >= AGENT_STATUS_HEARTBEAT_INTERVAL
+            broadcast_agent_status("streaming")
+            last_heartbeat_at = now
           end
         end
 

--- a/engines/collavre/app/views/collavre/comments/_comment.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comment.html.erb
@@ -2,7 +2,7 @@
 <% current_topic_id = local_assigns[:current_topic_id] %>
 <% has_pending_action = comment.action.present? && comment.action_executed_at.blank? %>
 <% approver_id = comment.approver_id %>
-<div class="comment-item" id="<%= dom_id(comment) %>" data-controller="comment" data-user-id="<%= comment.user&.id %>" data-comment-id="<%= comment.id %>" data-topic-id="<%= comment_topic&.id %>" data-creative-id="<%= comment.creative_id %>" data-creative-owner-id="<%= comment.creative&.user_id %>" data-has-pending-action="<%= has_pending_action %>" data-approver-id="<%= approver_id %>" data-ai-user="<%= comment.user&.ai_user? %>">
+<div class="comment-item" id="<%= dom_id(comment) %>" data-controller="comment" data-user-id="<%= comment.user&.id %>" data-comment-id="<%= comment.id %>" data-topic-id="<%= comment_topic&.id %>" data-creative-id="<%= comment.creative_id %>" data-creative-owner-id="<%= comment.creative&.user_id %>" data-has-pending-action="<%= has_pending_action %>" data-approver-id="<%= approver_id %>" data-ai-user="<%= comment.user&.ai_user? %>" data-streaming="<%= local_assigns.fetch(:streaming, false) %>">
   <div class="comment-select">
     <input type="checkbox"
            class="comment-select-checkbox"


### PR DESCRIPTION
## Problem

Typing indicator disappears during AI streaming because `agent_status('thinking')` is only broadcast once at the start. If the client misses it (ActionCable reconnect, popup reopen, etc.), the indicator is gone.

## Solution

### Server (ai_agent_service.rb)
- Add `AGENT_STATUS_HEARTBEAT_INTERVAL = 3.0` constant
- Broadcast `agent_status('streaming')` every 3 seconds during streaming
- No additional DB writes — only lightweight ActionCable broadcasts (~50 bytes)

### Client (presence_controller.js)
- Add `AGENT_STATUS_TIMEOUT = 10000` safety timeout
- Auto-remove typing indicator if no heartbeat received within 10 seconds
- Prevents stuck indicators when `idle` event is missed

## Performance Impact
- ~0.3 additional broadcasts per second (vs existing 10/s for comment updates)
- Negligible: 50 bytes JSON vs full comment HTML already being sent