### PR TITLE
refactor: update theme generator to use semantic design tokens

### DIFF
--- a/engines/collavre/app/services/collavre/auto_theme_generator.rb
+++ b/engines/collavre/app/services/collavre/auto_theme_generator.rb
@@ -1,29 +1,36 @@
 module Collavre
   class AutoThemeGenerator
     REQUIRED_VARIABLES = %w[
-      --color-bg
-      --color-text
+      --surface-bg
+      --surface-nav
+      --surface-section
+      --surface-input
+      --surface-btn
+      --surface-secondary
+      --text-primary
+      --text-muted
+      --text-on-btn
+      --text-nav
+      --text-nav-btn
+      --text-chat-btn
+      --text-on-badge
+      --text-input
       --color-link
-      --color-nav-bg
-      --color-section-bg
-      --color-btn-bg
-      --color-btn-text
-      --color-border
-      --color-muted
-      --color-complete
-      --color-chip-bg
-      --color-drag-over
-      --color-drag-over-edge
-      --hover-brightness
+      --color-brand
+      --color-active
+      --color-danger
+      --color-success
+      --color-warning
+      --color-highlight
       --color-badge-bg
-      --color-badge-text
-      --color-secondary-active
-      --color-secondary-background
-      --color-nav-btn-text
-      --color-chat-btn-text
-      --color-input-bg
-      --color-input-text
-      --color-nav-text
+      --color-accent-border
+      --color-accent-text
+      --color-code-bg
+      --color-code-text
+      --border-color
+      --border-drag-over
+      --border-drag-edge
+      --hover-brightness
       --creative-loading-emojis
     ].freeze
 
@@ -34,34 +41,48 @@ module Collavre
     def generate(prompt)
       system_prompt = <<~PROMPT
         You are an expert UI/UX designer specialized in creating color themes for web applications.
-        Your task is to generate a JSON object containing CSS variables.
         Generate a CSS theme as a JSON object based on the prompt: "#{prompt}".
         The JSON must strictly contain ONLY these keys: #{REQUIRED_VARIABLES.join(', ')}.
 
         CRITICAL DESIGN RULES:
-        1. Use **only 'oklch()' color format** for all colors. Do not use hex, rgb, or hsl.
-        2. Ensure "--color-nav-btn-text" has High Contrast (WCAG AA/AAA) against "--color-bg" (which is used as the button background in the nav).
-        3. Ensure "--color-chat-btn-text" has High Contrast against "--color-section-bg" (where chat messages reside).
-        4. Ensure "--color-nav-text" has High Contrast against "--color-nav-bg".
-        5. Names of these text colors should be visually distinct from their background colors to ensure readability.
-        6. For "--creative-loading-emojis", provide a comma-separated string of exactly 6 emojis that match the theme mood (e.g., "🌵,🏜️,☀️,🦎,🌾,🐪").
-        7. Do not include any other keys or newlines.
-        8. Return valid JSON only.
+        1. Use **only 'oklch()' color format** for all colors except --hover-brightness (use percentage like "90%") and --creative-loading-emojis (use comma-separated emojis).
+        2. Ensure "--text-nav-btn" has High Contrast (WCAG AA/AAA) against "--surface-bg".
+        3. Ensure "--text-chat-btn" has High Contrast against "--surface-section".
+        4. Ensure "--text-nav" has High Contrast against "--surface-nav".
+        5. Ensure "--text-primary" has High Contrast against "--surface-bg".
+        6. Ensure "--text-on-btn" has High Contrast against "--surface-btn".
+        7. Ensure "--text-input" has High Contrast against "--surface-input".
+        8. For "--creative-loading-emojis", provide a comma-separated string of exactly 6 emojis that match the theme mood.
+        9. Return valid JSON only. No markdown formatting, no explanations.
 
-        The JSON object must strictly follow this structure:
+        TOKEN ROLES:
+        - --surface-*: Background colors (page, nav, cards, inputs, buttons)
+        - --text-*: Text colors for various contexts
+        - --color-link: Hyperlink color
+        - --color-brand: Brand / accent color
+        - --color-active: Active / selected state
+        - --color-danger: Error / destructive actions
+        - --color-success: Success state
+        - --color-warning: Warning state
+        - --color-highlight: Text highlight flash
+        - --color-badge-bg: Notification badge background
+        - --color-accent-border: Active element border
+        - --color-accent-text: Active element text
+        - --color-code-bg: Code block background
+        - --color-code-text: Code block text
+        - --border-*: Border and divider colors
+        - --hover-brightness: CSS filter brightness on hover (e.g. "90%")
+
+        Example structure:
         {
-          "--color-bg": "oklch(95% 0.01 200)",
-          "--color-text": "oklch(20% 0.02 200)",
+          "--surface-bg": "oklch(95% 0.01 200)",
+          "--text-primary": "oklch(20% 0.02 200)",
           ...
         }
 
-        REQUIRED VARIABLES:
-        #{REQUIRED_VARIABLES.join("\n")}
-
         GUIDELINES:
-        - Ensure high contrast between text and background.
+        - Ensure high contrast between all text and their respective backgrounds.
         - Maintain a consistent aesthetic suitable for the description.
-        - Return ONLY the JSON object. No markdown formatting, no explanations.
       PROMPT
 
       response = @client.chat([

--- a/engines/collavre/app/views/collavre/user_themes/index.html.erb
+++ b/engines/collavre/app/views/collavre/user_themes/index.html.erb
@@ -1,7 +1,7 @@
 <div style="max-width: 960px; margin: 0 auto; padding: 1rem;">
   <h1><%= t('collavre.themes.manage_themes') %></h1>
 
-  <div class="card" style="margin-bottom: 2rem; padding: 1.5rem; background: var(--color-section-bg); border: 1px solid var(--color-border); border-radius: 8px;">
+  <div class="card" style="margin-bottom: 2rem; padding: 1.5rem; background: var(--surface-section); border: 1px solid var(--border-color); border-radius: 8px;">
     <h3><%= t('collavre.themes.create_new') %></h3>
     <%= form_with url: collavre.user_themes_path, method: :post, local: true do |f| %>
       <div class="stacked-form-control">
@@ -38,10 +38,10 @@
             <td>
               <div style="display: flex; gap: 4px;">
                 <% 
-                   preview_vars = theme.variables.slice("--color-bg", "--color-text", "--color-btn-bg", "--color-link")
+                   preview_vars = theme.variables.slice("--surface-bg", "--text-primary", "--surface-btn", "--color-link")
                 %>
                 <% preview_vars.each do |k, v| %>
-                  <div title="<%= k %>: <%= v %>" style="width: 20px; height: 20px; background-color: <%= v %>; border: 1px solid var(--color-border); border-radius: 4px;"></div>
+                  <div title="<%= k %>: <%= v %>" style="width: 20px; height: 20px; background-color: <%= v %>; border: 1px solid var(--border-color); border-radius: 4px;"></div>
                 <% end %>
               </div>
             </td>
@@ -60,7 +60,7 @@
         <% end %>
         <% if @themes.empty? %>
           <tr>
-            <td colspan="4" style="text-align: center; color: var(--color-muted); padding: 2rem;">
+            <td colspan="4" style="text-align: center; color: var(--text-muted); padding: 2rem;">
               <p><%= t('collavre.themes.no_themes') %></p>
             </td>
           </tr>

--- a/engines/collavre/test/services/auto_theme_generator_conversion_test.rb
+++ b/engines/collavre/test/services/auto_theme_generator_conversion_test.rb
@@ -26,13 +26,13 @@ class AutoThemeGeneratorConversionTest < ActiveSupport::TestCase
 
   test "process_variables converts values in hash" do
     input = {
-      "--color-bg" => "oklch(100% 0 0)",
-      "--color-text" => "#123456"
+      "--surface-bg" => "oklch(100% 0 0)",
+      "--text-primary" => "#123456"
     }
     output = @generator.send(:process_variables, input)
 
-    assert_equal "#ffffff", output["--color-bg"]
-    assert_equal "#123456", output["--color-text"] # Should remain unchanged
+    assert_equal "#ffffff", output["--surface-bg"]
+    assert_equal "#123456", output["--text-primary"] # Should remain unchanged
   end
 
   test "parse_response handles non-hash JSON gracefully" do
@@ -51,15 +51,15 @@ class AutoThemeGeneratorConversionTest < ActiveSupport::TestCase
 
   test "process_variables handles non-string values gracefully" do
     input = {
-      "--color-bg" => "oklch(100% 0 0)",
+      "--surface-bg" => "oklch(100% 0 0)",
       "--hover-brightness" => 0.95,
-      "--color-muted" => nil
+      "--text-muted" => nil
     }
     output = @generator.send(:process_variables, input)
 
-    assert_equal "#ffffff", output["--color-bg"]
+    assert_equal "#ffffff", output["--surface-bg"]
     assert_equal 0.95, output["--hover-brightness"]
-    assert_nil output["--color-muted"]
+    assert_nil output["--text-muted"]
   end
 
   test "converts complex oklch formats (degrees, alpha)" do


### PR DESCRIPTION
## Summary
Update AutoThemeGenerator and theme views to use semantic design tokens instead of legacy variable names (Phase 4 of design system roadmap).

## Changes
- **AutoThemeGenerator**: Replace legacy REQUIRED_VARIABLES (`--color-bg`, `--color-text`, etc.) with semantic tokens (`--surface-bg`, `--text-primary`, `--color-active`, etc.)
- **AI prompt**: Updated with semantic token roles and specific contrast requirements for each text/surface pair
- **Theme preview**: Updated to slice semantic token names for color swatches
- **Views**: Updated inline CSS to use semantic variables (`--surface-section`, `--border-color`, `--text-muted`)
- **Tests**: Updated variable names in conversion tests

## Note
Existing saved themes with legacy variable names will still work via legacy aliases in `dark_mode.css`. New themes will generate semantic tokens directly.

## Design System Roadmap
- [x] Phase 0: Open Props + Stylelint infra (#781)
- [x] Phase 1: Semantic tokens + legacy aliases (#782)
- [x] Phase 2: Hardcoded value removal (#783, #784, #785)
- [x] Phase 3: Stylelint error enforcement (#786)
- [x] **Phase 4: Theme generator integration (this PR)**
- [ ] Phase 5: Documentation