### PR TITLE
feat: add agent_conf YAML field for AI agent context settings

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_12_011655) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_13_044247) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false
@@ -62,6 +62,33 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_12_011655) do
     t.index ["user_id"], name: "index_activity_logs_on_user_id"
   end
 
+  create_table "agent_actions", force: :cascade do |t|
+    t.integer "agent_run_id", null: false
+    t.json "arguments", default: {}
+    t.datetime "created_at", null: false
+    t.text "result"
+    t.string "status", default: "pending"
+    t.string "tool_name"
+    t.datetime "updated_at", null: false
+    t.index ["agent_run_id"], name: "index_agent_actions_on_agent_run_id"
+  end
+
+  create_table "agent_runs", force: :cascade do |t|
+    t.integer "ai_user_id", null: false
+    t.json "context", default: {}
+    t.datetime "created_at", null: false
+    t.integer "creative_id", null: false
+    t.text "goal"
+    t.integer "iteration_count", default: 0
+    t.datetime "next_run_at"
+    t.string "state", default: "planning"
+    t.string "status", default: "pending"
+    t.json "transcript", default: []
+    t.datetime "updated_at", null: false
+    t.index ["ai_user_id"], name: "index_agent_runs_on_ai_user_id"
+    t.index ["creative_id"], name: "index_agent_runs_on_creative_id"
+  end
+
   create_table "calendar_events", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.integer "creative_id"
@@ -110,6 +137,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_12_011655) do
     t.boolean "private", default: false, null: false
     t.integer "quoted_comment_id"
     t.text "quoted_text"
+    t.boolean "streaming", default: false, null: false
     t.integer "topic_id"
     t.datetime "updated_at", null: false
     t.integer "user_id"
@@ -706,6 +734,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_12_011655) do
   end
 
   create_table "users", force: :cascade do |t|
+    t.text "agent_conf"
     t.string "avatar_url"
     t.string "calendar_id"
     t.string "completion_mark", default: "", null: false
@@ -776,7 +805,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_12_011655) do
   add_foreign_key "creative_expanded_states", "users"
   add_foreign_key "creative_shares", "creatives"
   add_foreign_key "creative_shares", "users"
-  add_foreign_key "creative_shares", "users", column: "shared_by_id", on_delete: :nullify
+  add_foreign_key "creative_shares", "users", column: "shared_by_id"
   add_foreign_key "creatives", "creatives", column: "origin_id"
   add_foreign_key "creatives", "creatives", column: "parent_id"
   add_foreign_key "creatives", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_13_044247) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_12_011655) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false
@@ -62,33 +62,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_13_044247) do
     t.index ["user_id"], name: "index_activity_logs_on_user_id"
   end
 
-  create_table "agent_actions", force: :cascade do |t|
-    t.integer "agent_run_id", null: false
-    t.json "arguments", default: {}
-    t.datetime "created_at", null: false
-    t.text "result"
-    t.string "status", default: "pending"
-    t.string "tool_name"
-    t.datetime "updated_at", null: false
-    t.index ["agent_run_id"], name: "index_agent_actions_on_agent_run_id"
-  end
-
-  create_table "agent_runs", force: :cascade do |t|
-    t.integer "ai_user_id", null: false
-    t.json "context", default: {}
-    t.datetime "created_at", null: false
-    t.integer "creative_id", null: false
-    t.text "goal"
-    t.integer "iteration_count", default: 0
-    t.datetime "next_run_at"
-    t.string "state", default: "planning"
-    t.string "status", default: "pending"
-    t.json "transcript", default: []
-    t.datetime "updated_at", null: false
-    t.index ["ai_user_id"], name: "index_agent_runs_on_ai_user_id"
-    t.index ["creative_id"], name: "index_agent_runs_on_creative_id"
-  end
-
   create_table "calendar_events", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.integer "creative_id"
@@ -137,7 +110,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_13_044247) do
     t.boolean "private", default: false, null: false
     t.integer "quoted_comment_id"
     t.text "quoted_text"
-    t.boolean "streaming", default: false, null: false
     t.integer "topic_id"
     t.datetime "updated_at", null: false
     t.integer "user_id"
@@ -734,7 +706,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_13_044247) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.text "agent_conf"
     t.string "avatar_url"
     t.string "calendar_id"
     t.string "completion_mark", default: "", null: false
@@ -805,7 +776,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_13_044247) do
   add_foreign_key "creative_expanded_states", "users"
   add_foreign_key "creative_shares", "creatives"
   add_foreign_key "creative_shares", "users"
-  add_foreign_key "creative_shares", "users", column: "shared_by_id"
+  add_foreign_key "creative_shares", "users", column: "shared_by_id", on_delete: :nullify
   add_foreign_key "creatives", "creatives", column: "origin_id"
   add_foreign_key "creatives", "creatives", column: "parent_id"
   add_foreign_key "creatives", "users"

--- a/engines/collavre/app/controllers/collavre/users_controller.rb
+++ b/engines/collavre/app/controllers/collavre/users_controller.rb
@@ -112,7 +112,7 @@ module Collavre
         return
       end
 
-      ai_params = params.require(:user).permit(:name, :system_prompt, :llm_vendor, :llm_model, :llm_api_key, :gateway_url, :searchable, :routing_expression, tools: [])
+      ai_params = params.require(:user).permit(:name, :system_prompt, :llm_vendor, :llm_model, :llm_api_key, :gateway_url, :searchable, :routing_expression, :agent_conf, tools: [])
 
       if @user.update(ai_params)
         redirect_to edit_ai_user_path(@user), notice: I18n.t("collavre.users.update_ai.success")

--- a/engines/collavre/app/models/collavre/user.rb
+++ b/engines/collavre/app/models/collavre/user.rb
@@ -69,6 +69,36 @@ module Collavre
     attribute :llm_api_key, :string
     attribute :gateway_url, :string
     attribute :tools, :json, default: -> { [] }
+    attribute :agent_conf, :string
+
+    # Default context settings for AI agents
+    AGENT_CONF_DEFAULTS = {
+      "context" => {
+        "chat_history" => 50,
+        "chat_history_size" => 100_000
+      }
+    }.freeze
+
+    # Returns parsed agent_conf merged with defaults
+    def parsed_agent_conf
+      defaults = AGENT_CONF_DEFAULTS.deep_dup
+      return defaults if agent_conf.blank?
+
+      user_conf = YAML.safe_load(agent_conf, permitted_classes: [Symbol]) || {}
+      defaults.deep_merge(user_conf)
+    rescue Psych::SyntaxError => e
+      Rails.logger.warn("[User#parsed_agent_conf] Invalid YAML for user #{id}: #{e.message}")
+      AGENT_CONF_DEFAULTS.deep_dup
+    end
+
+    # Convenience accessors for context settings
+    def chat_history_limit
+      parsed_agent_conf.dig("context", "chat_history") || 50
+    end
+
+    def chat_history_size_limit
+      parsed_agent_conf.dig("context", "chat_history_size") || 100_000
+    end
 
     encrypts :llm_api_key, deterministic: false
     encrypts :google_access_token, deterministic: false

--- a/engines/collavre/app/models/collavre/user.rb
+++ b/engines/collavre/app/models/collavre/user.rb
@@ -84,7 +84,7 @@ module Collavre
       defaults = AGENT_CONF_DEFAULTS.deep_dup
       return defaults if agent_conf.blank?
 
-      user_conf = YAML.safe_load(agent_conf, permitted_classes: [Symbol]) || {}
+      user_conf = YAML.safe_load(agent_conf, permitted_classes: [ Symbol ]) || {}
       defaults.deep_merge(user_conf)
     rescue Psych::SyntaxError => e
       Rails.logger.warn("[User#parsed_agent_conf] Invalid YAML for user #{id}: #{e.message}")

--- a/engines/collavre/app/services/collavre/ai_agent_service.rb
+++ b/engines/collavre/app/services/collavre/ai_agent_service.rb
@@ -211,17 +211,21 @@ module Collavre
         trigger_comment = Comment.find_by(id: trigger_comment_id)
         topic_id = trigger_comment&.topic_id
 
+        history_limit = @agent.chat_history_limit
+        history_size_limit = @agent.chat_history_size_limit
+        history_chars = 0
+
         Comment.where(creative_id: creative_id, private: false)
                .where(topic_id: topic_id)
                .includes(:user)
                .order(created_at: :desc)
-               .limit(50)
+               .limit(history_limit)
                .reverse
                .each do |c|
           next if c.id == @context.dig("comment", "id")
 
           role = (c.user_id == @agent.id) ? "model" : "user"
-          content = c.content
+          content = c.content.to_s
 
           if role == "user"
             content = MentionParser.strip_self_mention(content, @agent.name)
@@ -229,6 +233,10 @@ module Collavre
             speaker = c.user&.name || "unknown"
             content = "[#{speaker}]: #{content}"
           end
+
+          # Enforce chat_history_size limit
+          history_chars += content.length
+          break if history_chars > history_size_limit
 
           messages << { role: role, parts: [ { text: content } ] }
         end

--- a/engines/collavre/app/views/collavre/users/edit_ai.html.erb
+++ b/engines/collavre/app/views/collavre/users/edit_ai.html.erb
@@ -84,6 +84,12 @@
   </div>
 
   <div class="form-group">
+    <%= form.label :agent_conf, t('collavre.users.edit_ai.agent_conf_label', default: 'Agent Configuration (YAML)') %>
+    <%= form.text_area :agent_conf, class: "stacked-form-control", rows: 6, placeholder: "context:\n  chat_history: 50\n  chat_history_size: 100000", style: "font-family: monospace; font-size: 0.85em;" %>
+    <small class="form-text text-muted"><%= t('collavre.users.edit_ai.agent_conf_help', default: 'YAML configuration for agent behavior. chat_history: max previous messages, chat_history_size: max total characters.') %></small>
+  </div>
+
+  <div class="form-group">
     <div class="form-check">
       <%= form.check_box :searchable, { class: "form-check-input" }, true, false %>
       <%= form.label :searchable, t('collavre.users.new_ai.searchable_label'), class: "form-check-label" %>

--- a/engines/collavre/config/locales/users.en.yml
+++ b/engines/collavre/config/locales/users.en.yml
@@ -42,6 +42,8 @@ en:
         tools_title: Available Tools
         tools_description: These tools are available for the agent to use.
         no_tools_found: No tools found.
+        agent_conf_label: "Agent Configuration (YAML)"
+        agent_conf_help: "YAML configuration for agent behavior. chat_history: max previous messages (default 50), chat_history_size: max total characters (default 100000)."
         chat_title: Chat with Agent
         chat_placeholder: Type a message to test the agent...
       update_ai:

--- a/engines/collavre/config/locales/users.ko.yml
+++ b/engines/collavre/config/locales/users.ko.yml
@@ -40,6 +40,8 @@ ko:
         tools_title: 사용 가능한 도구
         tools_description: 에이전트가 사용할 수 있는 도구 목록입니다.
         no_tools_found: 사용 가능한 도구가 없습니다.
+        agent_conf_label: "에이전트 설정 (YAML)"
+        agent_conf_help: "에이전트 동작을 위한 YAML 설정. chat_history: 최대 이전 메시지 수 (기본 50), chat_history_size: 최대 총 문자 수 (기본 100000)."
         chat_title: 에이전트와 대화하기
         chat_placeholder: 에이전트를 테스트하려면 메시지를 입력하세요...
       update_ai:

--- a/engines/collavre/db/migrate/20260213044247_add_agent_conf_to_users.rb
+++ b/engines/collavre/db/migrate/20260213044247_add_agent_conf_to_users.rb
@@ -1,0 +1,5 @@
+class AddAgentConfToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :agent_conf, :text
+  end
+end

--- a/engines/collavre/test/models/user_agent_conf_test.rb
+++ b/engines/collavre/test/models/user_agent_conf_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  class UserAgentConfTest < ActiveSupport::TestCase
+    setup do
+      @user = users(:ai_bot)
+    end
+
+    test "returns defaults when agent_conf is blank" do
+      @user.agent_conf = nil
+      assert_equal 50, @user.chat_history_limit
+      assert_equal 100_000, @user.chat_history_size_limit
+    end
+
+    test "parses valid YAML config" do
+      @user.agent_conf = "context:\n  chat_history: 5\n  chat_history_size: 2000"
+      assert_equal 5, @user.chat_history_limit
+      assert_equal 2000, @user.chat_history_size_limit
+    end
+
+    test "merges partial config with defaults" do
+      @user.agent_conf = "context:\n  chat_history: 10"
+      assert_equal 10, @user.chat_history_limit
+      assert_equal 100_000, @user.chat_history_size_limit
+    end
+
+    test "returns defaults for invalid YAML" do
+      @user.agent_conf = "context: {invalid: [}"
+      assert_equal 50, @user.chat_history_limit
+      assert_equal 100_000, @user.chat_history_size_limit
+    end
+
+    test "returns defaults for empty YAML" do
+      @user.agent_conf = ""
+      assert_equal 50, @user.chat_history_limit
+    end
+  end
+end

--- a/engines/collavre_github/db/seeds.rb
+++ b/engines/collavre_github/db/seeds.rb
@@ -58,6 +58,12 @@ module CollavreGithub
       event_name == "comment_created" and comment.user_id == nil and comment.content contains "GitHub: Pull Request Merged"
     EXPR
 
+    AGENT_CONF = <<~YAML
+      context:
+        chat_history: 1
+        chat_history_size: 1000
+    YAML
+
     TOOLS = %w[
       github_pr_details
       github_pr_diff
@@ -94,6 +100,7 @@ module CollavreGithub
         llm_model: default_llm_model,
         system_prompt: SYSTEM_PROMPT,
         routing_expression: ROUTING_EXPRESSION,
+        agent_conf: AGENT_CONF,
         tools: TOOLS,
         searchable: true # Can analyze PRs for any Creative with GitHub integration
       )


### PR DESCRIPTION
## Summary

Add a `agent_conf` YAML configuration field to AI agents, allowing fine-grained control over context window settings.

## Changes

- **Migration**: Add `agent_conf` text column to users table
- **User model**: `parsed_agent_conf`, `chat_history_limit`, `chat_history_size_limit` methods with defaults (50 messages, 100K chars)
- **AiAgentService**: Apply `chat_history` and `chat_history_size` limits when building message context
- **UI**: YAML editor field in AI agent edit form with i18n (en/ko)
- **Seed**: GitHub PR Analyzer set to `chat_history: 1, chat_history_size: 1000` (minimal context)
- **Tests**: 5 unit tests covering defaults, parsing, partial merge, invalid YAML

## Configuration Format

```yaml
context:
  chat_history: 50        # max previous chat messages (default: 50)
  chat_history_size: 100000  # max total characters (default: 100000)
```