### PR TITLE
feat: add copy action for AI agents on contacts page

### DIFF
--- a/engines/collavre/app/controllers/collavre/users_controller.rb
+++ b/engines/collavre/app/controllers/collavre/users_controller.rb
@@ -83,6 +83,7 @@ module Collavre
         created_by_id: Current.user.id,
         routing_expression: params[:routing_expression]
       )
+      @user.agent_conf = params[:agent_conf] if @user.respond_to?(:agent_conf=) && params[:agent_conf].present?
 
       if @user.save
         Collavre::Contact.ensure(user: Current.user, contact_user: @user)

--- a/engines/collavre/app/controllers/collavre/users_controller.rb
+++ b/engines/collavre/app/controllers/collavre/users_controller.rb
@@ -53,6 +53,14 @@ module Collavre
 
     def new_ai
       @available_tools = load_available_tools
+
+      if params[:copy_from].present?
+        source = Collavre::User.find_by(id: params[:copy_from])
+        if source&.ai_user? && source.created_by_id == Current.user.id
+          @copy_source = source
+          @copy_name = "#{source.name} (copy)"
+        end
+      end
     end
 
     def create_ai

--- a/engines/collavre/app/views/collavre/users/_contact_management.html.erb
+++ b/engines/collavre/app/views/collavre/users/_contact_management.html.erb
@@ -44,6 +44,7 @@
                 <td class="text-right">
                   <% if contact_user.ai_user? && contact_user.created_by_id == Current.user.id %>
                     <%= link_to t('collavre.users.edit_ai.link'), collavre.edit_ai_user_path(contact_user), class: "btn btn-sm btn-secondary mr-1" %>
+                    <%= link_to t('collavre.users.copy_ai.link'), collavre.new_ai_users_path(copy_from: contact_user.id), class: "btn btn-sm btn-secondary mr-1" %>
                     <%= button_to t('collavre.users.destroy.delete_ai_user'),
                                   collavre.user_path(contact_user),
                                   method: :delete,

--- a/engines/collavre/app/views/collavre/users/new_ai.html.erb
+++ b/engines/collavre/app/views/collavre/users/new_ai.html.erb
@@ -89,6 +89,14 @@
     <% end %>
   </div>
 
+  <% if Collavre::User.column_names.include?("agent_conf") %>
+    <div class="form-group">
+      <%= form.label :agent_conf, t('collavre.users.edit_ai.agent_conf_label', default: 'Agent Configuration (YAML)') %>
+      <%= form.text_area :agent_conf, class: "stacked-form-control", rows: 6, placeholder: "context:\n  chat_history: 50\n  chat_history_size: 100000", style: "font-family: monospace; font-size: 0.85em;", value: @copy_source&.agent_conf %>
+      <small class="form-text text-muted"><%= t('collavre.users.edit_ai.agent_conf_help', default: 'YAML configuration for agent behavior.') %></small>
+    </div>
+  <% end %>
+
   <div class="form-group">
     <div class="form-check">
       <%= form.check_box :searchable, { class: "form-check-input", checked: @copy_source&.searchable }, true, false %>

--- a/engines/collavre/app/views/collavre/users/new_ai.html.erb
+++ b/engines/collavre/app/views/collavre/users/new_ai.html.erb
@@ -4,22 +4,22 @@
 <%= form_with url: collavre.create_ai_users_path, class: "stacked-form" do |form| %>
   <div class="form-group">
     <%= form.label :ai_id, t('collavre.users.new_ai.id_label') %>
-    <%= form.text_field :ai_id, required: true, class: "stacked-form-control", placeholder: "e.g. my_bot" %>
+    <%= form.text_field :ai_id, required: true, class: "stacked-form-control", placeholder: "e.g. my_bot", value: @copy_source ? "#{@copy_source.email.split('@').first}_copy" : nil %>
   </div>
 
   <div class="form-group">
     <%= form.label :name, t('collavre.users.new_ai.name_label') %>
-    <%= form.text_field :name, required: true, class: "stacked-form-control", placeholder: "e.g. My Bot" %>
+    <%= form.text_field :name, required: true, class: "stacked-form-control", placeholder: "e.g. My Bot", value: @copy_name %>
   </div>
 
   <div class="form-group">
     <%= form.label :system_prompt, t('collavre.users.new_ai.system_prompt_label') %>
-    <%= form.text_area :system_prompt, required: true, class: "stacked-form-control", rows: 5, value: AiClient::SYSTEM_INSTRUCTIONS %>
+    <%= form.text_area :system_prompt, required: true, class: "stacked-form-control", rows: 5, value: @copy_source&.system_prompt || AiClient::SYSTEM_INSTRUCTIONS %>
   </div>
 
   <div class="form-group">
     <%= form.label :routing_expression, "Routing Expression (Liquid)" %>
-    <%= form.text_area :routing_expression, class: "stacked-form-control", rows: 2, placeholder: "chat.mentioned_user.id == agent.id" %>
+    <%= form.text_area :routing_expression, class: "stacked-form-control", rows: 2, placeholder: "chat.mentioned_user.id == agent.id", value: @copy_source&.routing_expression %>
     <small class="form-text text-muted">Liquid expression to determine if this agent should handle an event. Example: <code>chat.mentioned_user.id == agent.id</code></small>
   </div>
 
@@ -28,7 +28,7 @@
     <%= form.select :llm_vendor, options_for_select([
       ["Google (Gemini)", "google"],
       ["OpenClaw", "openclaw"]
-    ], "google"), {}, class: "stacked-form-control" %>
+    ], @copy_source&.llm_vendor || "google"), {}, class: "stacked-form-control" %>
     <small class="form-text text-muted"><%= t('collavre.users.new_ai.vendor_help', default: 'Select the AI provider for this agent') %></small>
   </div>
 
@@ -42,6 +42,7 @@
                           required: true,
                           class: "stacked-form-control",
                           autocomplete: "off",
+                          value: @copy_source&.llm_model,
                           data: {
                             llm_model_target: "input",
                             action: "input->llm-model#search focus->llm-model#focus blur->llm-model#blur keydown->llm-model#handleKeydown"
@@ -58,7 +59,7 @@
 
   <div class="form-group">
     <%= form.label :gateway_url, t('collavre.users.new_ai.gateway_url_label', default: 'Gateway URL') %>
-    <%= form.text_field :gateway_url, class: "stacked-form-control", placeholder: "http://localhost:18789" %>
+    <%= form.text_field :gateway_url, class: "stacked-form-control", placeholder: "http://localhost:18789", value: @copy_source&.gateway_url %>
     <small class="form-text text-muted"><%= t('collavre.users.new_ai.gateway_url_help', default: 'Required for OpenClaw. The URL of your OpenClaw gateway.') %></small>
   </div>
 
@@ -70,7 +71,7 @@
       <div class="tools-selection">
         <% @available_tools.each do |tool| %>
           <div class="form-check mb-2">
-            <%= check_box_tag "tools[]", tool[:name], false, id: "tool_#{tool[:name]}", class: "form-check-input" %>
+            <%= check_box_tag "tools[]", tool[:name], @copy_source&.tools&.include?(tool[:name]) || false, id: "tool_#{tool[:name]}", class: "form-check-input" %>
             <label class="form-check-label" for="tool_<%= tool[:name] %>">
               <strong><%= tool[:name] %></strong>
               <br>
@@ -90,7 +91,7 @@
 
   <div class="form-group">
     <div class="form-check">
-      <%= form.check_box :searchable, { class: "form-check-input" }, true, false %>
+      <%= form.check_box :searchable, { class: "form-check-input", checked: @copy_source&.searchable }, true, false %>
       <%= form.label :searchable, t('collavre.users.new_ai.searchable_label'), class: "form-check-label" %>
     </div>
     <small class="form-text text-muted"><%= t('collavre.users.new_ai.searchable_help') %></small>

--- a/engines/collavre/config/locales/users.en.yml
+++ b/engines/collavre/config/locales/users.en.yml
@@ -35,6 +35,8 @@ en:
         tools_note: You can check and test available tools after creating the agent.
       create_ai:
         success: AI User created successfully.
+      copy_ai:
+        link: Copy
       edit_ai:
         title: Edit AI Agent
         link: Edit

--- a/engines/collavre/config/locales/users.ko.yml
+++ b/engines/collavre/config/locales/users.ko.yml
@@ -33,6 +33,8 @@ ko:
         tools_note: 에이전트 생성 후 사용 가능한 도구를 확인하고 테스트할 수 있습니다.
       create_ai:
         success: AI 에이전트가 생성되었습니다.
+      copy_ai:
+        link: 복사
       edit_ai:
         title: AI 에이전트 수정
         link: 수정


### PR DESCRIPTION
## Summary

Add a **Copy** button for AI agents on the contacts tab (`/users/{id}?tab=contacts`), allowing users to quickly duplicate an existing AI agent's configuration.

## How it works

1. Click **Copy** next to any AI agent you created
2. Redirects to the new AI agent form with all settings pre-filled:
   - Name (with " (copy)" suffix)
   - AI ID (with "_copy" suffix)
   - System prompt, routing expression
   - LLM vendor, model, gateway URL
   - Tool selections
   - Searchable setting
3. User adjusts as needed and saves

## Security

- Copy button only appears for agents created by the current user (`created_by_id == Current.user.id`)
- Server-side check in controller prevents copying other users' agents

## Changes

- `users_controller.rb`: Handle `copy_from` param in `new_ai` action
- `new_ai.html.erb`: Pre-fill form fields from `@copy_source`
- `_contact_management.html.erb`: Add Copy button
- i18n: en/ko