### PR TITLE
feat: sort simple search results by relevance (description length)

### DIFF
--- a/engines/collavre/app/services/collavre/creatives/index_query.rb
+++ b/engines/collavre/app/services/collavre/creatives/index_query.rb
@@ -82,6 +82,9 @@ module Creatives
         # Sort by comment updated_at for comment filter
         if params[:comment] == "true"
           matched_creatives = matched_creatives.sort_by { |c| c.comments.maximum(:updated_at) || c.updated_at }.reverse
+        elsif params[:search].present? && params[:simple].present?
+          # Sort by description length (shorter = more relevant match)
+          matched_creatives = matched_creatives.sort_by { |c| c.description.to_s.length }
         end
 
         parent = params[:id] ? Creative.find_by(id: params[:id]) : nil


### PR DESCRIPTION
## Summary

Sort creative search results by relevance when using simple search (creative link popup).

## Problem

Searching for "Test" could return "Test xxxd dfff" before "Test" because results were sorted by sequence, not relevance.

## Solution

For simple search (`?simple=true&search=query`), sort results by description length ascending. Shorter descriptions = closer match to query.

## Changes

- `index_query.rb`: Add `sort_by { |c| c.description.to_s.length }` for simple search results

## Impact

Only affects the creative link popup search. No change to main creative index or comment search.