### PR TITLE
fix: remove duplicate GitHub integration button

### DIFF
--- a/engines/collavre/app/views/collavre/creatives/_mobile_actions_menu.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_mobile_actions_menu.html.erb
@@ -10,9 +10,6 @@
       <button type="button" class="popup-menu-item" data-controller="click-target" data-click-target-id-value="share-creative-btn" data-action="click->click-target#trigger"><%= t('collavre.creatives.index.share') %></button>
     <% end %>
     <% if can_manage_integrations %>
-      <%# Legacy hardcoded integrations %>
-      <button type="button" class="popup-menu-item" data-controller="click-target" data-click-target-id-value="github-integration-btn" data-action="click->click-target#trigger"><%= t('collavre.creatives.index.integrations', default: '연동') %> - Github</button>
-      <%# Dynamically registered integrations %>
       <% Collavre::IntegrationRegistry.each do |integration| %>
         <% if integration.enabled_for?(current_creative) %>
           <button type="button"

--- a/engines/collavre/app/views/collavre/creatives/index.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/index.html.erb
@@ -33,9 +33,6 @@
           align: :left,
           button_classes: 'desktop-only'
         ) do %>
-      <%# Legacy hardcoded integrations (to be migrated to IntegrationRegistry) %>
-      <button type="button" class="popup-menu-item" data-controller="click-target" data-click-target-id-value="github-integration-btn" data-action="click->click-target#trigger">Github</button>
-      <%# Dynamically registered integrations %>
       <%= render 'integrations_menu', creative: current_creative %>
     <% end %>
   <% end %>
@@ -66,9 +63,6 @@
   <%= render 'import_upload_zone' %>
 
 <% if can_manage_integrations %>
-  <%# Legacy hardcoded integration triggers %>
-  <button id="github-integration-btn" data-creative-id="<%= current_creative&.id %>" style="display:none;"></button>
-  <%# Dynamically registered integration triggers %>
   <%= render 'integration_triggers', creative: current_creative %>
 <% end %>
 


### PR DESCRIPTION
## Problem

GitHub integration button appeared twice in creative actions row (both PC and mobile).

## Cause

GitHub was registered in `IntegrationRegistry` (dynamic) AND hardcoded as legacy buttons in:
- `index.html.erb` (desktop integrations popup menu)
- `_mobile_actions_menu.html.erb` (mobile menu)
- Hidden trigger button in `index.html.erb`

## Fix

Remove legacy hardcoded GitHub buttons. `IntegrationRegistry` already handles them via:
- `_integrations_menu.html.erb` (menu items)
- `_integration_triggers.html.erb` (hidden trigger buttons)

## Changes

- `index.html.erb`: Remove legacy Github menu item + hidden trigger button (-5 lines)
- `_mobile_actions_menu.html.erb`: Remove legacy Github menu item (-4 lines)