### PR TITLE
feat: add admin unlock user action

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -74,4 +74,7 @@ Rails.application.configure do
   config.hosts << /.*\.ngrok\.app/
   config.hosts << /.*\.ngrok-free\.app/
   config.hosts << /.*\.ngrok\.io/
+
+  # Allow Tailscale hosts for remote development access
+  config.hosts << /.*\.tailadceed\.ts\.net/
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_12_011655) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_13_044247) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false
@@ -62,6 +62,33 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_12_011655) do
     t.index ["user_id"], name: "index_activity_logs_on_user_id"
   end
 
+  create_table "agent_actions", force: :cascade do |t|
+    t.integer "agent_run_id", null: false
+    t.json "arguments", default: {}
+    t.datetime "created_at", null: false
+    t.text "result"
+    t.string "status", default: "pending"
+    t.string "tool_name"
+    t.datetime "updated_at", null: false
+    t.index ["agent_run_id"], name: "index_agent_actions_on_agent_run_id"
+  end
+
+  create_table "agent_runs", force: :cascade do |t|
+    t.integer "ai_user_id", null: false
+    t.json "context", default: {}
+    t.datetime "created_at", null: false
+    t.integer "creative_id", null: false
+    t.text "goal"
+    t.integer "iteration_count", default: 0
+    t.datetime "next_run_at"
+    t.string "state", default: "planning"
+    t.string "status", default: "pending"
+    t.json "transcript", default: []
+    t.datetime "updated_at", null: false
+    t.index ["ai_user_id"], name: "index_agent_runs_on_ai_user_id"
+    t.index ["creative_id"], name: "index_agent_runs_on_creative_id"
+  end
+
   create_table "calendar_events", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.integer "creative_id"
@@ -110,6 +137,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_12_011655) do
     t.boolean "private", default: false, null: false
     t.integer "quoted_comment_id"
     t.text "quoted_text"
+    t.boolean "streaming", default: false, null: false
     t.integer "topic_id"
     t.datetime "updated_at", null: false
     t.integer "user_id"
@@ -706,6 +734,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_12_011655) do
   end
 
   create_table "users", force: :cascade do |t|
+    t.text "agent_conf"
     t.string "avatar_url"
     t.string "calendar_id"
     t.string "completion_mark", default: "", null: false
@@ -776,7 +805,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_12_011655) do
   add_foreign_key "creative_expanded_states", "users"
   add_foreign_key "creative_shares", "creatives"
   add_foreign_key "creative_shares", "users"
-  add_foreign_key "creative_shares", "users", column: "shared_by_id", on_delete: :nullify
+  add_foreign_key "creative_shares", "users", column: "shared_by_id"
   add_foreign_key "creatives", "creatives", column: "origin_id"
   add_foreign_key "creatives", "creatives", column: "parent_id"
   add_foreign_key "creatives", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_13_044247) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_12_011655) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false
@@ -62,33 +62,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_13_044247) do
     t.index ["user_id"], name: "index_activity_logs_on_user_id"
   end
 
-  create_table "agent_actions", force: :cascade do |t|
-    t.integer "agent_run_id", null: false
-    t.json "arguments", default: {}
-    t.datetime "created_at", null: false
-    t.text "result"
-    t.string "status", default: "pending"
-    t.string "tool_name"
-    t.datetime "updated_at", null: false
-    t.index ["agent_run_id"], name: "index_agent_actions_on_agent_run_id"
-  end
-
-  create_table "agent_runs", force: :cascade do |t|
-    t.integer "ai_user_id", null: false
-    t.json "context", default: {}
-    t.datetime "created_at", null: false
-    t.integer "creative_id", null: false
-    t.text "goal"
-    t.integer "iteration_count", default: 0
-    t.datetime "next_run_at"
-    t.string "state", default: "planning"
-    t.string "status", default: "pending"
-    t.json "transcript", default: []
-    t.datetime "updated_at", null: false
-    t.index ["ai_user_id"], name: "index_agent_runs_on_ai_user_id"
-    t.index ["creative_id"], name: "index_agent_runs_on_creative_id"
-  end
-
   create_table "calendar_events", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.integer "creative_id"
@@ -137,7 +110,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_13_044247) do
     t.boolean "private", default: false, null: false
     t.integer "quoted_comment_id"
     t.text "quoted_text"
-    t.boolean "streaming", default: false, null: false
     t.integer "topic_id"
     t.datetime "updated_at", null: false
     t.integer "user_id"
@@ -734,7 +706,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_13_044247) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.text "agent_conf"
     t.string "avatar_url"
     t.string "calendar_id"
     t.string "completion_mark", default: "", null: false
@@ -805,7 +776,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_13_044247) do
   add_foreign_key "creative_expanded_states", "users"
   add_foreign_key "creative_shares", "creatives"
   add_foreign_key "creative_shares", "users"
-  add_foreign_key "creative_shares", "users", column: "shared_by_id"
+  add_foreign_key "creative_shares", "users", column: "shared_by_id", on_delete: :nullify
   add_foreign_key "creatives", "creatives", column: "origin_id"
   add_foreign_key "creatives", "creatives", column: "parent_id"
   add_foreign_key "creatives", "users"

--- a/engines/collavre/app/controllers/collavre/users_controller.rb
+++ b/engines/collavre/app/controllers/collavre/users_controller.rb
@@ -2,7 +2,7 @@ module Collavre
   class UsersController < ApplicationController
     allow_unauthenticated_access only: %i[new create exists]
     before_action -> { enforce_auth_provider!(:email) }, only: [ :new, :create ]
-    before_action :require_system_admin!, only: [ :index, :grant_system_admin, :revoke_system_admin, :unlock ]
+    before_action :require_system_admin!, only: [ :index, :grant_system_admin, :revoke_system_admin, :unlock, :lock ]
 
     def new
       @user = Collavre::User.new
@@ -236,6 +236,16 @@ module Collavre
       @user = Collavre::User.find(params[:id])
       @user.unlock_account!
       redirect_to users_path, notice: I18n.t("collavre.users.unlock.success", name: @user.display_name)
+    end
+
+    def lock
+      @user = Collavre::User.find(params[:id])
+      if @user == Current.user
+        redirect_to users_path, alert: I18n.t("collavre.users.lock.cannot_lock_self")
+        return
+      end
+      @user.lock_account!
+      redirect_to users_path, notice: I18n.t("collavre.users.lock.success", name: @user.display_name)
     end
 
     def update

--- a/engines/collavre/app/controllers/collavre/users_controller.rb
+++ b/engines/collavre/app/controllers/collavre/users_controller.rb
@@ -2,7 +2,7 @@ module Collavre
   class UsersController < ApplicationController
     allow_unauthenticated_access only: %i[new create exists]
     before_action -> { enforce_auth_provider!(:email) }, only: [ :new, :create ]
-    before_action :require_system_admin!, only: [ :index, :grant_system_admin, :revoke_system_admin ]
+    before_action :require_system_admin!, only: [ :index, :grant_system_admin, :revoke_system_admin, :unlock ]
 
     def new
       @user = Collavre::User.new
@@ -230,6 +230,12 @@ module Collavre
       else
         redirect_to users_path, alert: I18n.t("collavre.users.system_admin.failed")
       end
+    end
+
+    def unlock
+      @user = Collavre::User.find(params[:id])
+      @user.unlock_account!
+      redirect_to users_path, notice: I18n.t("collavre.users.unlock.success", name: @user.display_name)
     end
 
     def update

--- a/engines/collavre/app/views/collavre/users/index.html.erb
+++ b/engines/collavre/app/views/collavre/users/index.html.erb
@@ -73,6 +73,12 @@
                             collavre.unlock_user_path(user),
                             method: :patch,
                             class: 'btn btn-xs btn-secondary' %>
+            <% else %>
+              <%= button_to t('collavre.users.lock.button'),
+                            collavre.lock_user_path(user),
+                            method: :patch,
+                            class: 'btn btn-xs btn-danger',
+                            form: { data: { turbo_confirm: t('collavre.users.lock.confirm') } } %>
             <% end %>
             <%= button_to t('collavre.users.delete'),
                           collavre.user_path(user),

--- a/engines/collavre/app/views/collavre/users/index.html.erb
+++ b/engines/collavre/app/views/collavre/users/index.html.erb
@@ -68,6 +68,12 @@
                             class: 'btn btn-xs btn-success',
                             form: { data: { turbo_confirm: t('collavre.users.confirm_grant_system_admin') } } %>
             <% end %>
+            <% if user.locked? %>
+              <%= button_to t('collavre.users.unlock.button'),
+                            collavre.unlock_user_path(user),
+                            method: :patch,
+                            class: 'btn btn-xs btn-secondary' %>
+            <% end %>
             <%= button_to t('collavre.users.delete'),
                           collavre.user_path(user),
                           method: :delete,

--- a/engines/collavre/config/locales/users.en.yml
+++ b/engines/collavre/config/locales/users.en.yml
@@ -130,6 +130,9 @@ en:
         granted: System admin access granted.
         revoked: System admin access removed.
         failed: Could not update the user's system admin status.
+      unlock:
+        button: Unlock
+        success: "%{name} has been unlocked."
       destroy:
         success: The user and all associated data have been deleted.
         failure: Could not delete the user.

--- a/engines/collavre/config/locales/users.en.yml
+++ b/engines/collavre/config/locales/users.en.yml
@@ -133,6 +133,11 @@ en:
       unlock:
         button: Unlock
         success: "%{name} has been unlocked."
+      lock:
+        button: Lock
+        confirm: "Lock this user's account? They will not be able to log in."
+        success: "%{name} has been locked."
+        cannot_lock_self: "You cannot lock your own account."
       destroy:
         success: The user and all associated data have been deleted.
         failure: Could not delete the user.

--- a/engines/collavre/config/locales/users.ko.yml
+++ b/engines/collavre/config/locales/users.ko.yml
@@ -128,6 +128,11 @@ ko:
       unlock:
         button: 잠금 해제
         success: "%{name}의 잠금이 해제되었습니다."
+      lock:
+        button: 잠금
+        confirm: "이 사용자의 계정을 잠글까요? 로그인할 수 없게 됩니다."
+        success: "%{name}의 계정이 잠겼습니다."
+        cannot_lock_self: "자신의 계정은 잠글 수 없습니다."
       destroy:
         success: 사용자와 모든 관련 데이터가 삭제되었습니다.
         failure: 사용자를 삭제하지 못했습니다.

--- a/engines/collavre/config/locales/users.ko.yml
+++ b/engines/collavre/config/locales/users.ko.yml
@@ -125,6 +125,9 @@ ko:
         granted: 시스템 관리자 권한이 부여되었습니다.
         revoked: 시스템 관리자 권한이 해제되었습니다.
         failed: 사용자의 시스템 관리자 상태를 변경하지 못했습니다.
+      unlock:
+        button: 잠금 해제
+        success: "%{name}의 잠금이 해제되었습니다."
       destroy:
         success: 사용자와 모든 관련 데이터가 삭제되었습니다.
         failure: 사용자를 삭제하지 못했습니다.

--- a/engines/collavre/config/routes.rb
+++ b/engines/collavre/config/routes.rb
@@ -16,6 +16,7 @@ Collavre::Engine.routes.draw do
       patch :grant_system_admin
       patch :revoke_system_admin
       patch :unlock
+      patch :lock
       get :edit_password
       patch :update_password
       get :passkeys

--- a/engines/collavre/config/routes.rb
+++ b/engines/collavre/config/routes.rb
@@ -15,6 +15,7 @@ Collavre::Engine.routes.draw do
       patch :update_ai
       patch :grant_system_admin
       patch :revoke_system_admin
+      patch :unlock
       get :edit_password
       patch :update_password
       get :passkeys


### PR DESCRIPTION
## Summary
Add an unlock button to the admin user management page for locked users.

## Changes
- Add `unlock` action to UsersController (admin only)
- Add `PATCH /users/:id/unlock` route
- Show unlock button next to locked users in the admin user list
- i18n: en + ko

## How it works
- When a user is locked (too many failed login attempts), the admin can click **Unlock** to clear the lock
- Calls `User#unlock_account!` which resets `locked_at` and `failed_login_attempts`
- Only system admins can unlock users