### PR TITLE
feat: add context.creative_children_level to agent_conf

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_12_011655) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_13_044247) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false
@@ -62,6 +62,33 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_12_011655) do
     t.index ["user_id"], name: "index_activity_logs_on_user_id"
   end
 
+  create_table "agent_actions", force: :cascade do |t|
+    t.integer "agent_run_id", null: false
+    t.json "arguments", default: {}
+    t.datetime "created_at", null: false
+    t.text "result"
+    t.string "status", default: "pending"
+    t.string "tool_name"
+    t.datetime "updated_at", null: false
+    t.index ["agent_run_id"], name: "index_agent_actions_on_agent_run_id"
+  end
+
+  create_table "agent_runs", force: :cascade do |t|
+    t.integer "ai_user_id", null: false
+    t.json "context", default: {}
+    t.datetime "created_at", null: false
+    t.integer "creative_id", null: false
+    t.text "goal"
+    t.integer "iteration_count", default: 0
+    t.datetime "next_run_at"
+    t.string "state", default: "planning"
+    t.string "status", default: "pending"
+    t.json "transcript", default: []
+    t.datetime "updated_at", null: false
+    t.index ["ai_user_id"], name: "index_agent_runs_on_ai_user_id"
+    t.index ["creative_id"], name: "index_agent_runs_on_creative_id"
+  end
+
   create_table "calendar_events", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.integer "creative_id"
@@ -110,6 +137,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_12_011655) do
     t.boolean "private", default: false, null: false
     t.integer "quoted_comment_id"
     t.text "quoted_text"
+    t.boolean "streaming", default: false, null: false
     t.integer "topic_id"
     t.datetime "updated_at", null: false
     t.integer "user_id"
@@ -706,6 +734,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_12_011655) do
   end
 
   create_table "users", force: :cascade do |t|
+    t.text "agent_conf"
     t.string "avatar_url"
     t.string "calendar_id"
     t.string "completion_mark", default: "", null: false
@@ -776,7 +805,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_12_011655) do
   add_foreign_key "creative_expanded_states", "users"
   add_foreign_key "creative_shares", "creatives"
   add_foreign_key "creative_shares", "users"
-  add_foreign_key "creative_shares", "users", column: "shared_by_id", on_delete: :nullify
+  add_foreign_key "creative_shares", "users", column: "shared_by_id"
   add_foreign_key "creatives", "creatives", column: "origin_id"
   add_foreign_key "creatives", "creatives", column: "parent_id"
   add_foreign_key "creatives", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_13_044247) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_12_011655) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false
@@ -62,33 +62,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_13_044247) do
     t.index ["user_id"], name: "index_activity_logs_on_user_id"
   end
 
-  create_table "agent_actions", force: :cascade do |t|
-    t.integer "agent_run_id", null: false
-    t.json "arguments", default: {}
-    t.datetime "created_at", null: false
-    t.text "result"
-    t.string "status", default: "pending"
-    t.string "tool_name"
-    t.datetime "updated_at", null: false
-    t.index ["agent_run_id"], name: "index_agent_actions_on_agent_run_id"
-  end
-
-  create_table "agent_runs", force: :cascade do |t|
-    t.integer "ai_user_id", null: false
-    t.json "context", default: {}
-    t.datetime "created_at", null: false
-    t.integer "creative_id", null: false
-    t.text "goal"
-    t.integer "iteration_count", default: 0
-    t.datetime "next_run_at"
-    t.string "state", default: "planning"
-    t.string "status", default: "pending"
-    t.json "transcript", default: []
-    t.datetime "updated_at", null: false
-    t.index ["ai_user_id"], name: "index_agent_runs_on_ai_user_id"
-    t.index ["creative_id"], name: "index_agent_runs_on_creative_id"
-  end
-
   create_table "calendar_events", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.integer "creative_id"
@@ -137,7 +110,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_13_044247) do
     t.boolean "private", default: false, null: false
     t.integer "quoted_comment_id"
     t.text "quoted_text"
-    t.boolean "streaming", default: false, null: false
     t.integer "topic_id"
     t.datetime "updated_at", null: false
     t.integer "user_id"
@@ -734,7 +706,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_13_044247) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.text "agent_conf"
     t.string "avatar_url"
     t.string "calendar_id"
     t.string "completion_mark", default: "", null: false
@@ -805,7 +776,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_13_044247) do
   add_foreign_key "creative_expanded_states", "users"
   add_foreign_key "creative_shares", "creatives"
   add_foreign_key "creative_shares", "users"
-  add_foreign_key "creative_shares", "users", column: "shared_by_id"
+  add_foreign_key "creative_shares", "users", column: "shared_by_id", on_delete: :nullify
   add_foreign_key "creatives", "creatives", column: "origin_id"
   add_foreign_key "creatives", "creatives", column: "parent_id"
   add_foreign_key "creatives", "users"

--- a/engines/collavre/app/helpers/collavre/creatives_helper.rb
+++ b/engines/collavre/app/helpers/collavre/creatives_helper.rb
@@ -93,7 +93,7 @@ module Collavre
       !!(expanded_state_map && expanded_state_map[creative_id.to_s])
     end
 
-    def render_creative_tree_markdown(creatives, level = 1, with_progress = false)
+    def render_creative_tree_markdown(creatives, level = 1, with_progress = false, max_depth: nil)
       return "" if creatives.blank?
       md = ""
       creatives.each do |creative|
@@ -134,8 +134,8 @@ module Collavre
           md += "#{indent}* #{inner}\n"
         end
         children = creative.linked_children
-        if children.present?
-          md += render_creative_tree_markdown(children, level + 1, with_progress)
+        if children.present? && (max_depth.nil? || level < max_depth)
+          md += render_creative_tree_markdown(children, level + 1, with_progress, max_depth: max_depth)
         end
         md += "\n" if level <= 4 && !rendered_table_block
       end

--- a/engines/collavre/app/models/collavre/user.rb
+++ b/engines/collavre/app/models/collavre/user.rb
@@ -75,9 +75,13 @@ module Collavre
     AGENT_CONF_DEFAULTS = {
       "context" => {
         "chat_history" => 50,
-        "chat_history_size" => 100_000
+        "chat_history_size" => 100_000,
+        "creative_children_level" => nil
       }
     }.freeze
+
+    # Default creative children level when agent_conf doesn't specify one
+    DEFAULT_CREATIVE_CHILDREN_LEVEL = 6
 
     # Returns parsed agent_conf merged with defaults
     def parsed_agent_conf
@@ -98,6 +102,14 @@ module Collavre
 
     def chat_history_size_limit
       parsed_agent_conf.dig("context", "chat_history_size") || 100_000
+    end
+
+    # Returns the creative children depth level for AI context.
+    # nil in agent_conf means use the default (6).
+    # 0 = no children, 1 = direct children only, 2 = grandchildren, etc.
+    def creative_children_level
+      level = parsed_agent_conf.dig("context", "creative_children_level")
+      level.nil? ? DEFAULT_CREATIVE_CHILDREN_LEVEL : level.to_i
     end
 
     encrypts :llm_api_key, deterministic: false

--- a/engines/collavre/app/services/collavre/ai_agent_service.rb
+++ b/engines/collavre/app/services/collavre/ai_agent_service.rb
@@ -198,7 +198,13 @@ module Collavre
         if creative_id
           creative = Creative.find_by(id: creative_id)
           if creative
-            markdown = ApplicationController.helpers.render_creative_tree_markdown([ creative ], 1, true)
+            # creative_children_level: 0=no children, 1=children, 2=grandchildren, etc.
+            # max_depth = 1 (root) + creative_children_level
+            children_level = @agent.creative_children_level
+            max_depth = 1 + children_level
+            markdown = ApplicationController.helpers.render_creative_tree_markdown(
+              [ creative ], 1, true, max_depth: max_depth
+            )
             messages << { role: "user", parts: [ { text: "Creative:\n#{markdown}" } ] }
           end
         end

--- a/engines/collavre/test/helpers/creatives_helper_test.rb
+++ b/engines/collavre/test/helpers/creatives_helper_test.rb
@@ -220,4 +220,48 @@ class CreativesHelperTest < ActionView::TestCase
       assert_match(/Origin Child/, markdown)
     end
   end
+
+  # max_depth tests for render_creative_tree_markdown
+
+  test "render_creative_tree_markdown with max_depth limits tree depth" do
+    user = users(:one)
+
+    root = Collavre::Creative.create!(description: "Root", user: user)
+    child = Collavre::Creative.create!(description: "Child", parent: root, user: user)
+    Collavre::Creative.create!(description: "Grandchild", parent: child, user: user)
+
+    Current.set(user: user) do
+      # max_depth: 1 → only root (level 1), no children
+      md = render_creative_tree_markdown([ root ], 1, false, max_depth: 1)
+      assert_match(/Root/, md)
+      assert_no_match(/Child/, md)
+
+      # max_depth: 2 → root + children, no grandchildren
+      md = render_creative_tree_markdown([ root ], 1, false, max_depth: 2)
+      assert_match(/Root/, md)
+      assert_match(/Child/, md)
+      assert_no_match(/Grandchild/, md)
+
+      # max_depth: 3 → root + children + grandchildren
+      md = render_creative_tree_markdown([ root ], 1, false, max_depth: 3)
+      assert_match(/Root/, md)
+      assert_match(/Child/, md)
+      assert_match(/Grandchild/, md)
+    end
+  end
+
+  test "render_creative_tree_markdown without max_depth includes all levels" do
+    user = users(:one)
+
+    root = Collavre::Creative.create!(description: "Root", user: user)
+    child = Collavre::Creative.create!(description: "Child", parent: root, user: user)
+    Collavre::Creative.create!(description: "Grandchild", parent: child, user: user)
+
+    Current.set(user: user) do
+      md = render_creative_tree_markdown([ root ], 1, false)
+      assert_match(/Root/, md)
+      assert_match(/Child/, md)
+      assert_match(/Grandchild/, md)
+    end
+  end
 end

--- a/engines/collavre/test/models/user_agent_conf_test.rb
+++ b/engines/collavre/test/models/user_agent_conf_test.rb
@@ -36,5 +36,32 @@ module Collavre
       @user.agent_conf = ""
       assert_equal 50, @user.chat_history_limit
     end
+
+    # creative_children_level tests
+
+    test "creative_children_level returns default 6 when agent_conf is blank" do
+      @user.agent_conf = nil
+      assert_equal 6, @user.creative_children_level
+    end
+
+    test "creative_children_level returns default 6 when set to nil" do
+      @user.agent_conf = "context:\n  creative_children_level:"
+      assert_equal 6, @user.creative_children_level
+    end
+
+    test "creative_children_level returns 0 when set to 0" do
+      @user.agent_conf = "context:\n  creative_children_level: 0"
+      assert_equal 0, @user.creative_children_level
+    end
+
+    test "creative_children_level returns configured value" do
+      @user.agent_conf = "context:\n  creative_children_level: 2"
+      assert_equal 2, @user.creative_children_level
+    end
+
+    test "creative_children_level coerces string to integer" do
+      @user.agent_conf = "context:\n  creative_children_level: '3'"
+      assert_equal 3, @user.creative_children_level
+    end
   end
 end


### PR DESCRIPTION
## Summary

Add `context.creative_children_level` to AI agent configuration, controlling how deep the creative tree is included in the AI context.

## Changes

### Model (`user.rb`)
- Add `creative_children_level` to `AGENT_CONF_DEFAULTS` (default: `nil`)
- Add `DEFAULT_CREATIVE_CHILDREN_LEVEL = 6`
- Add `User#creative_children_level` convenience accessor

### Helper (`creatives_helper.rb`)
- Add `max_depth` keyword parameter to `render_creative_tree_markdown`
- When `max_depth` is nil (default), all levels are included (backward compatible)
- When set, children are only rendered if `level < max_depth`

### Service (`ai_agent_service.rb`)
- Use `@agent.creative_children_level` to compute `max_depth = 1 + children_level`
- Pass `max_depth` to `render_creative_tree_markdown`

### Behavior

| `creative_children_level` | Effect |
|---------------------------|--------|
| `nil` (default) | Uses default of 6 levels |
| `0` | Only the root creative, no children |
| `1` | Root + direct children |
| `2` | Root + children + grandchildren |
| `N` | Root + N levels of descendants |

### Example `agent_conf`
```yaml
context:
  creative_children_level: 2  # include up to grandchildren
```

## Tests Added (7 new)

- 5 tests for `User#creative_children_level` (default, nil, 0, custom value, string coercion)
- 2 tests for `render_creative_tree_markdown` max_depth (depth limiting + unlimited)

## Files Changed (4 + 2 test files)

- `engines/collavre/app/models/collavre/user.rb`
- `engines/collavre/app/helpers/collavre/creatives_helper.rb`
- `engines/collavre/app/services/collavre/ai_agent_service.rb`
- `engines/collavre/test/models/user_agent_conf_test.rb`
- `engines/collavre/test/helpers/creatives_helper_test.rb`

## Tests

1098 runs, 3505 assertions, 0 failures ✅