### PR TITLE
fix: make share popup close and delete buttons transparent

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/popup.css
@@ -75,12 +75,32 @@
   position: absolute;
   top: 0.75em;
   right: 0.75em;
-  background: none;
+  background: transparent;
   border: none;
   font-size: 1.2em;
   line-height: 1;
   cursor: pointer;
   color: var(--text-primary);
+  opacity: 0.6;
+}
+
+.popup-close-btn:hover {
+  opacity: 1;
+}
+
+.delete-share-btn {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--text-primary);
+  font-size: 1.1em;
+  opacity: 0.6;
+  padding: 0 0.5em;
+}
+
+.delete-share-btn:hover {
+  opacity: 1;
+  color: var(--danger);
 }
 
 #github-integration-modal .github-modal-status {

--- a/engines/collavre/app/views/collavre/creatives/_share_button.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_share_button.html.erb
@@ -44,7 +44,7 @@
               <span><%= share.user&.display_name || (share.user_id.nil? ? t('collavre.creatives.index.public_share') : t('collavre.creatives.index.unknown_user')) %></span>
               <span><%= t("collavre.creatives.index.permission_#{share.permission}") %></span>
               <span>
-                <%= button_to '×', collavre.creative_creative_share_path(@parent_creative || @creative, share), method: :delete, form: { data: { turbo_confirm: t('collavre.creatives.index.are_you_sure_delete_share') } }, class: 'delete-share-btn', style: 'padding:0 0.5em;' %>
+                <%= button_to '×', collavre.creative_creative_share_path(@parent_creative || @creative, share), method: :delete, form: { data: { turbo_confirm: t('collavre.creatives.index.are_you_sure_delete_share') } }, class: 'delete-share-btn' %>
               </span>
             </li>
           <% end %>


### PR DESCRIPTION
## Changes

- Make share popup close button (×) transparent with hover opacity effect
- Make permission delete button (×) transparent with hover effect (turns danger color)
- Remove inline style from delete button, use CSS class instead

## Files Changed
- `engines/collavre/app/assets/stylesheets/collavre/popup.css` — added `.delete-share-btn` styles, updated `.popup-close-btn` with opacity hover
- `engines/collavre/app/views/collavre/creatives/_share_button.html.erb` — removed inline style from delete button