### PR TITLE
fix: use inherit/currentColor defaults for creative tree CSS variables

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/creatives.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/creatives.css
@@ -2,16 +2,17 @@
     --creative-row-text-offset: 1.8em;
     --creative-loading-emojis: "🚀,🧠,🧩,🤝,🗂️,⚡";
 
-    /* Creative tree heading styles */
+    /* Creative tree heading styles — defaults match pre-#799 behavior.
+       Themes that don't define these variables render identically to before. */
     --creative-h1-size: 1.3em;
     --creative-h2-size: 1.2em;
     --creative-h3-size: 1.1em;
-    --creative-h1-weight: 700;
-    --creative-h2-weight: 600;
-    --creative-h3-weight: 500;
-    --creative-h1-color: var(--text-primary);
-    --creative-h2-color: var(--text-primary);
-    --creative-h3-color: var(--text-primary);
+    --creative-h1-weight: bold;
+    --creative-h2-weight: bold;
+    --creative-h3-weight: bold;
+    --creative-h1-color: inherit;
+    --creative-h2-color: inherit;
+    --creative-h3-color: inherit;
     --creative-h1-bg: transparent;
     --creative-h2-bg: transparent;
     --creative-h3-bg: transparent;
@@ -22,7 +23,7 @@
 
     /* Bullet style */
     --creative-bullet-size: 5px;
-    --creative-bullet-color: var(--text-primary);
+    --creative-bullet-color: currentColor;
 
     /* Tree line style */
     --creative-tree-line-color: var(--border-color);


### PR DESCRIPTION
## Problem
PR #799 added creative tree CSS variables (`--creative-h1-color`, `--creative-h1-weight`, `--creative-bullet-color`, etc.) with defaults that reference `var(--text-primary)` and specific weight values (700/600/500).

Existing themes created before #799 don't define these new variables, causing headings to render differently:
- **Before #799**: Headings inherited color from parent, used browser-default bold weight
- **After #799**: Headings got explicit `var(--text-primary)` color and specific numeric weights

This also affected light/dark mode switching — `var(--text-primary)` at `:root` level doesn't automatically follow theme-scoped overrides.

## Solution
Change `:root` defaults to match pre-#799 behavior:

| Variable | Before (broken) | After (fixed) |
|----------|-----------------|---------------|
| `--creative-h1/h2/h3-color` | `var(--text-primary)` | `inherit` |
| `--creative-h1/h2/h3-weight` | `700`/`600`/`500` | `bold` |
| `--creative-bullet-color` | `var(--text-primary)` | `currentColor` |

### Why this works
- **`inherit`**: Headings get color from their parent element, exactly like before #799. Works in both light and dark mode automatically.
- **`bold`**: Browser-default heading weight, matching pre-#799 behavior.
- **`currentColor`**: Bullets use the current text color, inheriting from context.
- **Themed creatives**: Themes that explicitly define these variables (generated by `AutoThemeGenerator`) still override correctly.

## Testing
- 1098 runs, 3505 assertions, 0 failures