### PR TITLE
docs: add creative_children_level to agent_conf help text

### DIFF
--- a/engines/collavre/config/locales/users.en.yml
+++ b/engines/collavre/config/locales/users.en.yml
@@ -45,7 +45,7 @@ en:
         tools_description: These tools are available for the agent to use.
         no_tools_found: No tools found.
         agent_conf_label: "Agent Configuration (YAML)"
-        agent_conf_help: "YAML configuration for agent behavior. chat_history: max previous messages (default 50), chat_history_size: max total characters (default 100000)."
+        agent_conf_help: "YAML configuration for agent behavior. chat_history: max previous messages (default 50), chat_history_size: max total characters (default 100000), context.creative_children_level: depth of children to include in creative context (default nil → follows user setting, 0=no children, 1=direct children, 2=grandchildren)."
         chat_title: Chat with Agent
         chat_placeholder: Type a message to test the agent...
       update_ai:

--- a/engines/collavre/config/locales/users.ko.yml
+++ b/engines/collavre/config/locales/users.ko.yml
@@ -43,7 +43,7 @@ ko:
         tools_description: 에이전트가 사용할 수 있는 도구 목록입니다.
         no_tools_found: 사용 가능한 도구가 없습니다.
         agent_conf_label: "에이전트 설정 (YAML)"
-        agent_conf_help: "에이전트 동작을 위한 YAML 설정. chat_history: 최대 이전 메시지 수 (기본 50), chat_history_size: 최대 총 문자 수 (기본 100000)."
+        agent_conf_help: "에이전트 동작을 위한 YAML 설정. chat_history: 최대 이전 메시지 수 (기본 50), chat_history_size: 최대 총 문자 수 (기본 100000), context.creative_children_level: 크리에이티브 컨텍스트에 포함할 자식 깊이 (기본 nil → 사용자 설정 따름, 0=자식 없음, 1=직접 자식, 2=손자까지)."
         chat_title: 에이전트와 대화하기
         chat_placeholder: 에이전트를 테스트하려면 메시지를 입력하세요...
       update_ai:


### PR DESCRIPTION
Add the new `context.creative_children_level` property to the agent_conf help text in both en and ko locales.

Follow-up to PR #800.