### PR TITLE
fix: tree-line and bullet color not following dark mode

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/creatives.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/creatives.css
@@ -23,10 +23,13 @@
 
     /* Bullet style */
     --creative-bullet-size: 5px;
-    --creative-bullet-color: currentColor;
+    /* --creative-bullet-color: NOT set here; inline fallback (currentColor) used.
+       Setting it at :root would freeze the value to :root scope,
+       ignoring dark-mode overrides on body. */
 
-    /* Tree line style */
-    --creative-tree-line-color: var(--border-color);
+    /* Tree line style — only size/opacity have safe defaults.
+       --creative-tree-line-color: NOT set here; inline fallback var(--border-color) used.
+       This ensures dark mode's --border-color override on body is respected. */
     --creative-tree-line-opacity: 0.5;
 }
 


### PR DESCRIPTION
## Problem
Tree lines and bullets show light-mode colors in dark mode.

**Root cause**: `:root` defined `--creative-tree-line-color: var(--border-color)` and `--creative-bullet-color: currentColor`. CSS custom properties resolve references at the scope where they're defined. Since `:root` is above `body.dark-mode`, the `var(--border-color)` resolves to the light-mode value and stays frozen — dark mode's override on `body` is ignored.

## Solution
Remove `--creative-tree-line-color` and `--creative-bullet-color` from `:root` entirely. The inline fallbacks at usage sites handle the defaults:

```css
/* Before (broken in dark mode) */
:root { --creative-tree-line-color: var(--border-color); }
.tree-line::before { background-color: var(--creative-tree-line-color, var(--border-color)); }

/* After (works in both modes) */
/* :root — no --creative-tree-line-color defined */
.tree-line::before { background-color: var(--creative-tree-line-color, var(--border-color)); }
```

When `--creative-tree-line-color` is **not set**, the fallback `var(--border-color)` resolves at the `.tree-line::before` element's scope — which is inside `body.dark-mode`, so it correctly picks up the dark mode value.

When a theme **does set** `--creative-tree-line-color` (e.g., via AutoThemeGenerator), that explicit value is used instead.

## Testing
- 1098 runs, 3505 assertions, 0 failures