### PR TITLE
fix: github integration modal duplicate message and missing links

### DIFF
--- a/app/javascript/github_integration.js
+++ b/app/javascript/github_integration.js
@@ -150,7 +150,7 @@ if (!githubIntegrationInitialized) {
         return;
       }
       clearError();
-      fetch(`/creatives/${creativeId}/github_integration`, { headers: { Accept: 'application/json' } })
+      fetch(`/github/creatives/${creativeId}/integration`, { headers: { Accept: 'application/json' } })
         .then(function (response) { return response.json(); })
         .then(function (data) {
           if (!data.connected) {
@@ -427,7 +427,7 @@ if (!githubIntegrationInitialized) {
       clearError();
       const payload = { repositories: Array.from(selectedRepos) };
       if (promptInput) payload.github_gemini_prompt = promptInput.value;
-      fetch(`/creatives/${creativeId}/github_integration`, {
+      fetch(`/github/creatives/${creativeId}/integration`, {
         method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',
@@ -531,7 +531,7 @@ if (!githubIntegrationInitialized) {
       }
       if (!window.confirm(deleteConfirm)) return;
 
-      fetch(`/creatives/${creativeId}/github_integration`, {
+      fetch(`/github/creatives/${creativeId}/integration`, {
         method: 'DELETE',
         headers: {
           'Content-Type': 'application/json',

--- a/app/javascript/github_integration.js
+++ b/app/javascript/github_integration.js
@@ -154,11 +154,21 @@ if (!githubIntegrationInitialized) {
         .then(function (response) { return response.json(); })
         .then(function (data) {
           if (!data.connected) {
-            statusEl.textContent = modal.dataset.loginRequired;
-            hasExistingIntegration = false;
-            renderExistingConnections([]);
-            if (connectMessage) connectMessage.style.display = '';
-            if (loginBtn) loginBtn.style.display = 'inline-block';
+            var allRepos = data.all_repositories || [];
+            if (allRepos.length > 0) {
+              // Other users have linked repositories to this creative
+              statusEl.textContent = existingMessage;
+              hasExistingIntegration = true;
+              renderExistingConnections(allRepos, true);
+              if (connectMessage) connectMessage.style.display = 'none';
+              if (loginBtn) loginBtn.style.display = 'inline-block';
+            } else {
+              statusEl.textContent = '';
+              hasExistingIntegration = false;
+              renderExistingConnections([]);
+              if (connectMessage) connectMessage.style.display = '';
+              if (loginBtn) loginBtn.style.display = 'inline-block';
+            }
             currentStep = 'connect';
             updateStep();
             return;
@@ -192,7 +202,7 @@ if (!githubIntegrationInitialized) {
         });
     }
 
-    function renderExistingConnections(repos) {
+    function renderExistingConnections(repos, readOnly) {
       if (!existingContainer || !existingList) return;
       existingList.innerHTML = '';
       selectedReposForDeletion = new Set();
@@ -217,27 +227,29 @@ if (!githubIntegrationInitialized) {
         label.style.display = 'flex';
         label.style.alignItems = 'center';
         label.style.gap = '0.5em';
-        label.style.cursor = 'pointer';
+        label.style.cursor = readOnly ? 'default' : 'pointer';
         label.style.flex = '1';
 
-        const checkbox = document.createElement('input');
-        checkbox.type = 'checkbox';
-        checkbox.value = fullName;
-        checkbox.className = 'github-existing-repo-checkbox';
-        checkbox.addEventListener('change', function () {
-          if (checkbox.checked) {
-            selectedReposForDeletion.add(fullName);
-          } else {
-            selectedReposForDeletion.delete(fullName);
-          }
-          updateDeleteButtonState();
-        });
+        if (!readOnly) {
+          const checkbox = document.createElement('input');
+          checkbox.type = 'checkbox';
+          checkbox.value = fullName;
+          checkbox.className = 'github-existing-repo-checkbox';
+          checkbox.addEventListener('change', function () {
+            if (checkbox.checked) {
+              selectedReposForDeletion.add(fullName);
+            } else {
+              selectedReposForDeletion.delete(fullName);
+            }
+            updateDeleteButtonState();
+          });
+          label.appendChild(checkbox);
+        }
 
         const nameSpan = document.createElement('span');
         nameSpan.textContent = fullName;
         nameSpan.style.flex = '1';
 
-        label.appendChild(checkbox);
         label.appendChild(nameSpan);
         li.appendChild(label);
         existingList.appendChild(li);
@@ -245,7 +257,7 @@ if (!githubIntegrationInitialized) {
 
       existingContainer.style.display = 'block';
       if (deleteBtn) {
-        deleteBtn.style.display = 'inline-flex';
+        deleteBtn.style.display = readOnly ? 'none' : 'inline-flex';
         updateDeleteButtonState();
       }
       if (loginBtn) loginBtn.style.display = 'none';

--- a/engines/collavre_github/app/controllers/collavre_github/creatives/integrations_controller.rb
+++ b/engines/collavre_github/app/controllers/collavre_github/creatives/integrations_controller.rb
@@ -9,6 +9,10 @@ module CollavreGithub
         account = Current.user.github_account
         links = linked_repository_links(account)
 
+        # Also include repositories linked by other users for this creative
+        all_links = @creative.github_repository_links.includes(:github_account)
+        all_repositories = all_links.map(&:repository_full_name).uniq
+
         render json: {
           connected: account.present?,
           account: account && {
@@ -17,6 +21,7 @@ module CollavreGithub
             avatar_url: account.avatar_url
           },
           selected_repositories: links.map(&:repository_full_name),
+          all_repositories: all_repositories,
           webhooks: serialize_webhooks(links),
           github_gemini_prompt: @creative.github_gemini_prompt_template
         }


### PR DESCRIPTION
## Problem
1. **Duplicate message**: When GitHub is not connected, both `statusEl` and `connectMessage` show the same "Sign in with GitHub" text
2. **Missing other users' links**: The integration popup only checks the current user's `github_account` — if another user (e.g., AI Agent) linked repositories, the popup shows "not connected"

## Solution
1. Clear `statusEl` text when not connected (keep only `connectMessage`)
2. Add `all_repositories` to the show API response (includes links from all users on this creative)
3. When current user has no GitHub account but the creative has links from other users, show them in read-only mode (no checkboxes, no delete button)

## Testing
- 1098 runs, 3505 assertions, 0 failures