### PR TITLE
fix: store GitHub integration links on origin creative

### DIFF
--- a/engines/collavre_github/app/controllers/collavre_github/creatives/integrations_controller.rb
+++ b/engines/collavre_github/app/controllers/collavre_github/creatives/integrations_controller.rb
@@ -2,6 +2,7 @@ module CollavreGithub
   module Creatives
     class IntegrationsController < ApplicationController
       before_action :set_creative
+      before_action :set_origin
       before_action :ensure_read_permission
       before_action :ensure_admin_permission, only: [ :show, :update ]
 
@@ -18,7 +19,7 @@ module CollavreGithub
           },
           selected_repositories: links.map(&:repository_full_name),
           webhooks: serialize_webhooks(links),
-          github_gemini_prompt: @creative.github_gemini_prompt_template
+          github_gemini_prompt: @origin.github_gemini_prompt_template
         }
       end
 
@@ -41,7 +42,7 @@ module CollavreGithub
             .delete_all
 
           repositories.each do |full_name|
-            @creative.github_repository_links.find_or_create_by!(
+            @origin.github_repository_links.find_or_create_by!(
               github_account: account,
               repository_full_name: full_name
             )
@@ -50,7 +51,7 @@ module CollavreGithub
           links = linked_repository_links(account).to_a
 
           if prompt_param
-            @creative.update!(github_gemini_prompt: prompt_param.presence)
+            @origin.update!(github_gemini_prompt: prompt_param.presence)
           end
         end
 
@@ -64,7 +65,7 @@ module CollavreGithub
           success: true,
           selected_repositories: links.map(&:repository_full_name),
           webhooks: serialize_webhooks(links),
-          github_gemini_prompt: @creative.github_gemini_prompt_template
+          github_gemini_prompt: @origin.github_gemini_prompt_template
         }
       rescue ActiveRecord::RecordInvalid => e
         render json: { error: e.message }, status: :unprocessable_entity
@@ -133,7 +134,7 @@ module CollavreGithub
           success: true,
           selected_repositories: links.pluck(:repository_full_name),
           webhooks: serialize_webhooks(links),
-          github_gemini_prompt: @creative.github_gemini_prompt_template
+          github_gemini_prompt: @origin.github_gemini_prompt_template
         }
       end
 
@@ -141,6 +142,10 @@ module CollavreGithub
 
       def set_creative
         @creative = Collavre::Creative.find(params[:creative_id])
+      end
+
+      def set_origin
+        @origin = @creative.effective_origin
       end
 
       def ensure_read_permission
@@ -158,7 +163,7 @@ module CollavreGithub
       def linked_repository_links(account)
         return CollavreGithub::RepositoryLink.none unless account
 
-        @creative.github_repository_links.where(github_account: account)
+        @origin.github_repository_links.where(github_account: account)
       end
 
       def integration_params


### PR DESCRIPTION
## Summary

GitHub repository links and prompt settings are now stored on the **effective origin** creative instead of the current creative. This ensures all linked creatives share the same GitHub integration settings.

## Changes

- `IntegrationsController`: Added `set_origin` before_action that resolves `@creative.effective_origin`
- All repository link CRUD operations now use `@origin` instead of `@creative`
- `github_gemini_prompt` is read from and saved to the origin
- Permission checks still use the original `@creative` (as the user accesses it from that context)

## Why

When a creative has an `origin_id` (i.e., it's a linked creative in another workspace), the GitHub integration should be stored on the origin creative so it's shared across all workspaces that reference it. Previously, links were stored on the accessed creative, leading to fragmented integration state.

The `GithubClientFinder` concern already traverses to the origin when looking up clients, so this change aligns the write path with the read path.