### PR TITLE
fix: add rescue logging around SystemEvents dispatch

### DIFF
--- a/engines/collavre/app/controllers/collavre/comments_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comments_controller.rb
@@ -163,24 +163,33 @@ module Collavre
       if @comment.save
 
         # Dispatch system event
-        ::SystemEvents::Dispatcher.dispatch("comment_created", {
-          comment: {
-            id: @comment.id,
-            content: @comment.content,
-            user_id: @comment.user_id,
-            quoted_comment_id: @comment.quoted_comment_id
-          }.compact,
-          creative: {
-            id: @creative.id,
-            description: @creative.description
-          },
-          topic: {
-            id: @comment.topic_id
-          },
-          chat: {
-            content: @comment.content
-          }
-        }) unless @comment.private? || response.present?
+        unless @comment.private? || response.present?
+          begin
+            ::SystemEvents::Dispatcher.dispatch("comment_created", {
+              comment: {
+                id: @comment.id,
+                content: @comment.content,
+                user_id: @comment.user_id,
+                quoted_comment_id: @comment.quoted_comment_id
+              }.compact,
+              creative: {
+                id: @creative.id,
+                description: @creative.description
+              },
+              topic: {
+                id: @comment.topic_id
+              },
+              chat: {
+                content: @comment.content
+              }
+            })
+          rescue => e
+            Rails.logger.error(
+              "[SystemEvents] Dispatch failed for comment #{@comment.id}: " \
+              "#{e.class} #{e.message}\n#{e.backtrace&.first(5)&.join("\n")}"
+            )
+          end
+        end
         @comment = Comment.with_attached_images.includes(:comment_reactions).find(@comment.id)
         render partial: "collavre/comments/comment", locals: { comment: @comment, current_topic_id: current_topic_context }, status: :created
       else


### PR DESCRIPTION
## Problem

Comments are saved successfully but AI agents intermittently don't receive messages. The `SystemEvents::Dispatcher.dispatch` call in `comments_controller#create` can fail silently — the comment is already persisted, and the response renders fine, but the dispatch exception is swallowed.

This was observed on creative 6242 where multiple comments were created but no `AiAgentJob` was enqueued.

## Solution

Wrap the dispatch call in a `rescue` block with error logging so we can identify the root cause next time it occurs.

## Changes

- `comments_controller.rb`: Added `begin/rescue` around `SystemEvents::Dispatcher.dispatch` with `Rails.logger.error` including class, message, and backtrace.