### PR TITLE
fix: prevent double-wrapping HTML inside existing markdown code blocks

### DIFF
--- a/engines/collavre/app/javascript/lib/__tests__/html_code_block_wrapper.test.js
+++ b/engines/collavre/app/javascript/lib/__tests__/html_code_block_wrapper.test.js
@@ -168,4 +168,34 @@ describe('wrapHtmlInCodeBlocks', () => {
     expect(result).toBe('test \n\n```html\n<html><h1>hello</h1></html>\n```')
     expect(result).toContain('\n\n```html')
   })
+
+  // --- Double-wrap prevention ---
+
+  test('does not double-wrap HTML inside existing code blocks', () => {
+    const input = '"\n```html\n<button type="button" class="popup-close-btn">×</button>\n```\n"'
+    const { changed } = wrapHtmlInCodeBlocks(input)
+    expect(changed).toBe(false)
+  })
+
+  test('does not wrap HTML inside code blocks but wraps HTML outside', () => {
+    const input = 'before\n```html\n<div>inside</div>\n```\nafter <span>outside</span> end'
+    const { changed, result } = wrapHtmlInCodeBlocks(input)
+    expect(changed).toBe(true)
+    expect(result).toContain('```html\n<div>inside</div>\n```')
+    expect(result).toContain('```html\n<span>outside</span>\n```')
+    // The inside div should NOT be double-wrapped
+    expect(result).not.toContain('```html\n```html')
+  })
+
+  test('mixed text with code block containing HTML is not double-wrapped', () => {
+    const input = 'some text\n```\n<button>click</button>\n```\nmore text'
+    const { changed } = wrapHtmlInCodeBlocks(input)
+    expect(changed).toBe(false)
+  })
+
+  test('text starting with quote then code block is not double-wrapped', () => {
+    const input = '"\n```html\n<button id="close-slack-modal" class="popup-close-btn">×</button>\n```\n"'
+    const { changed } = wrapHtmlInCodeBlocks(input)
+    expect(changed).toBe(false)
+  })
 })

--- a/engines/collavre/app/javascript/lib/html_code_block_wrapper.js
+++ b/engines/collavre/app/javascript/lib/html_code_block_wrapper.js
@@ -8,8 +8,10 @@
 export function wrapHtmlInCodeBlocks(text) {
   if (!text) return { changed: false, result: text }
 
-  // Already wrapped in code block — don't double-wrap
-  if (text.trimStart().startsWith('```')) return { changed: false, result: text }
+  // If entire text is a single code block, skip
+  if (text.trimStart().startsWith('```') && text.trimEnd().endsWith('```')) {
+    return { changed: false, result: text }
+  }
 
   const segments = extractHtmlSegments(text)
   if (!segments) return { changed: false, result: text }
@@ -112,6 +114,21 @@ function extractHtmlSegments(text) {
 
   // Sort by position
   segments.sort((a, b) => a.start - b.start)
+
+  // Filter out segments inside existing markdown code blocks
+  const codeBlockRanges = []
+  const codeBlockRe = /^```[^\n]*\n[\s\S]*?^```/gm
+  let cbMatch
+  while ((cbMatch = codeBlockRe.exec(text)) !== null) {
+    codeBlockRanges.push({ start: cbMatch.index, end: cbMatch.index + cbMatch[0].length })
+  }
+  if (codeBlockRanges.length > 0) {
+    const filtered = segments.filter(
+      (seg) => !codeBlockRanges.some((cb) => seg.start >= cb.start && seg.end <= cb.end)
+    )
+    return filtered.length > 0 ? filtered : null
+  }
+
   return segments
 }
 


### PR DESCRIPTION
## Problem

When a chat message contains HTML inside a markdown code block (e.g. ```html ... ```), the `wrapHtmlInCodeBlocks` function detects the HTML tags and wraps them again, resulting in double-wrapped code blocks.

## Root Cause

`extractHtmlSegments` finds HTML tags without checking whether they're already inside existing markdown code blocks. The early guard only checks if the entire text starts with ``````, missing cases where code blocks appear mid-text.

## Fix

- Identify existing markdown code block ranges in `extractHtmlSegments`
- Filter out any HTML segments found within those ranges
- Improved the early guard to check if the entire text is a single code block
- Added 4 test cases covering the double-wrap scenario

## Tests

29 vitest tests passing (25 existing + 4 new).