### PR TITLE
fix: replace inline styles with CSS class for share modal inputs

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/popup.css
@@ -71,6 +71,12 @@
   font-size: 1.1em;
 }
 
+.popup-box input,
+.popup-box select {
+  width: 100%;
+  box-sizing: border-box;
+}
+
 .popup-close-btn {
   position: absolute;
   top: 0.75em;

--- a/engines/collavre/app/views/collavre/creatives/_share_modal.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_share_modal.html.erb
@@ -10,7 +10,7 @@
            data-share-user-search-creative-id-value="<%= (@parent_creative || @creative).id %>"
            data-share-user-search-scope-value="contacts">
         <label for="share-user-email"><%= t('collavre.creatives.index.user_email') %></label>
-        <input type="email" name="user_email" id="share-user-email" style="width:100%;box-sizing:border-box;" 
+        <input type="email" name="user_email" id="share-user-email" 
           data-share-invite-target="email" 
           data-share-user-search-target="input"
           data-action="blur->share-invite#check input->share-user-search#input focus->share-user-search#focus keydown->share-user-search#handleKey"
@@ -18,7 +18,7 @@
         <%= render Collavre::UserMentionMenuComponent.new(menu_id: 'share-user-suggestions') %>
       </div>
       <div style="margin-bottom:1em;">
-        <select name="permission" id="share-permission" style="width:100%;box-sizing:border-box;">
+        <select name="permission" id="share-permission">
           <option value="no_access"><%= t('collavre.creatives.index.permission_no_access') %></option>
           <option value="read"><%= t('collavre.creatives.index.permission_read') %></option>
           <option value="feedback"><%= t('collavre.creatives.index.permission_feedback') %></option>


### PR DESCRIPTION
## Summary
Replace inline `style="width:100%;box-sizing:border-box;"` on email input and permission select in the share modal with a CSS rule on `.popup-box input, .popup-box select` in `popup.css`.

## Changes
- Added `.popup-box input, .popup-box select { width: 100%; box-sizing: border-box; }` to `popup.css`
- Removed inline styles from `_share_modal.html.erb`

## Result
- Consistent left/right padding on inputs
- No more inline styles for layout properties