### PR TITLE
feat: add creative_batch_service tool with approval requirement

### DIFF
--- a/engines/collavre/app/services/collavre/ai_client.rb
+++ b/engines/collavre/app/services/collavre/ai_client.rb
@@ -129,9 +129,12 @@ module Collavre
       tool_name = tool_call.name
       task = context&.dig(:task)
 
-      # Check if this tool requires approval
+      # Check if this tool requires approval (dynamic McpTool or system tool)
       mcp_tool = McpTool.find_by(name: tool_name)
-      return unless mcp_tool&.requires_approval?
+      system_tool_class = ToolMeta.registry.find { |klass| klass.tool_metadata[:name] == tool_name }
+      requires = mcp_tool&.requires_approval? ||
+                 (system_tool_class.respond_to?(:requires_approval?) && system_tool_class.requires_approval?)
+      return unless requires
 
       # Check if we already have approval for this specific call (resume scenario)
       if task&.pending_tool_call.present?

--- a/engines/collavre/app/services/collavre/comments/action_executor.rb
+++ b/engines/collavre/app/services/collavre/comments/action_executor.rb
@@ -153,6 +153,10 @@ module Collavre
 
         def delete_creative(payload)
           creative = find_target_creative(payload)
+          executor = comment.user || Current.user
+          unless creative.has_permission?(executor, :write)
+            raise InvalidActionError, I18n.t("collavre.comments.approve_no_write_permission")
+          end
           creative.destroy!
         end
 

--- a/engines/collavre/app/services/collavre/comments/action_executor.rb
+++ b/engines/collavre/app/services/collavre/comments/action_executor.rb
@@ -73,6 +73,7 @@ module Collavre
         SUPPORTED_ACTIONS = {
           "create_creative" => :create_creative,
           "update_creative" => :update_creative,
+          "delete_creative" => :delete_creative,
           "approve_tool" => :approve_tool,
           "execute_tool" => :execute_tool
         }.freeze
@@ -148,6 +149,11 @@ module Collavre
           creative.save!
         rescue ActiveRecord::RecordInvalid => e
           raise InvalidActionError, e.record.errors.full_messages.to_sentence
+        end
+
+        def delete_creative(payload)
+          creative = find_target_creative(payload)
+          creative.destroy!
         end
 
         def approve_tool(payload)

--- a/engines/collavre/app/services/collavre/tools/creative_batch_service.rb
+++ b/engines/collavre/app/services/collavre/tools/creative_batch_service.rb
@@ -1,0 +1,102 @@
+module Collavre
+  require "sorbet-runtime"
+  require "rails_mcp_engine"
+
+  module Tools
+    class CreativeBatchService
+      extend T::Sig
+      extend ToolMeta
+
+      tool_name "creative_batch_service"
+      tool_description "Execute multiple Creative operations (create, update, delete) in a single batch call. " \
+                       "All operations run inside a transaction — if any operation fails, the entire batch is rolled back.\n\n" \
+                       "This tool requires approval before execution.\n\n" \
+                       "Each operation is a hash with an 'action' key ('create', 'update', or 'delete') plus action-specific fields."
+
+      def self.requires_approval?
+        true
+      end
+
+      tool_param :operations, description: "Array of operation objects. Each object must have an 'action' key.\n\n" \
+                 "For 'create': { action: 'create', parent_id: <int>, description: <string>, progress: <float>, after_id: <int>, before_id: <int> }\n" \
+                 "For 'update': { action: 'update', id: <int>, description: <string>, progress: <float>, parent_id: <int> }\n" \
+                 "For 'delete': { action: 'delete', id: <int> }\n\n" \
+                 "Fields other than 'action' and 'id'/'parent_id' are optional.", required: true
+
+      sig { params(operations: T::Array[T::Hash[String, T.untyped]]).returns(T::Hash[Symbol, T.untyped]) }
+      def call(operations:)
+        raise "Current.user is required" unless Current.user
+
+        results = []
+
+        ApplicationRecord.transaction do
+          operations.each_with_index do |op, idx|
+            op = op.transform_keys(&:to_s)
+            action = op["action"]
+
+            result = case action
+            when "create" then execute_create(op)
+            when "update" then execute_update(op)
+            when "delete" then execute_delete(op)
+            else
+                       { error: "Unknown action '#{action}'" }
+            end
+
+            result[:index] = idx
+            result[:action] = action
+            results << result
+
+            if result[:error]
+              raise ActiveRecord::Rollback
+            end
+          end
+        end
+
+        failed = results.find { |r| r[:error] }
+        if failed
+          { success: false, error: "Operation #{failed[:index]} (#{failed[:action]}) failed: #{failed[:error]}", results: results }
+        else
+          { success: true, results: results }
+        end
+      end
+
+      private
+
+      def execute_create(op)
+        service = CreativeCreateService.new
+        service.call(
+          description: op["description"] || "",
+          parent_id: op["parent_id"]&.to_i,
+          progress: op["progress"]&.to_f,
+          after_id: op["after_id"]&.to_i,
+          before_id: op["before_id"]&.to_i
+        )
+      end
+
+      def execute_update(op)
+        id = op["id"]&.to_i
+        return { error: "id is required for update" } unless id&.positive?
+
+        service = CreativeUpdateService.new
+        service.call(
+          id: id,
+          description: op["description"],
+          progress: op["progress"]&.to_f,
+          parent_id: op["parent_id"]&.to_i
+        )
+      end
+
+      def execute_delete(op)
+        id = op["id"]&.to_i
+        return { error: "id is required for delete" } unless id&.positive?
+
+        creative = Creative.find_by(id: id)
+        return { error: "Creative not found", id: id } unless creative
+        return { error: "No write permission on this Creative", id: id } unless creative.has_permission?(Current.user, :write)
+
+        creative.destroy!
+        { success: true, id: id, deleted: true }
+      end
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/tools/creative_batch_service.rb
+++ b/engines/collavre/app/services/collavre/tools/creative_batch_service.rb
@@ -23,6 +23,15 @@ module Collavre
                  "For 'delete': { action: 'delete', id: <int> }\n\n" \
                  "Fields other than 'action' and 'id'/'parent_id' are optional.", required: true
 
+      class BatchRollbackError < StandardError
+        attr_reader :results
+
+        def initialize(results)
+          @results = results
+          super("Batch operation failed")
+        end
+      end
+
       sig { params(operations: T::Array[T::Hash[String, T.untyped]]).returns(T::Hash[Symbol, T.untyped]) }
       def call(operations:)
         raise "Current.user is required" unless Current.user
@@ -46,18 +55,14 @@ module Collavre
             result[:action] = action
             results << result
 
-            if result[:error]
-              raise ActiveRecord::Rollback
-            end
+            raise BatchRollbackError, results if result[:error]
           end
         end
 
-        failed = results.find { |r| r[:error] }
-        if failed
-          { success: false, error: "Operation #{failed[:index]} (#{failed[:action]}) failed: #{failed[:error]}", results: results }
-        else
-          { success: true, results: results }
-        end
+        { success: true, results: results }
+      rescue BatchRollbackError => e
+        failed = e.results.find { |r| r[:error] }
+        { success: false, error: "Operation #{failed[:index]} (#{failed[:action]}) failed: #{failed[:error]}", results: e.results }
       end
 
       private
@@ -81,8 +86,8 @@ module Collavre
         service.call(
           id: id,
           description: op["description"],
-          progress: op["progress"]&.to_f,
-          parent_id: op["parent_id"]&.to_i
+          progress: op.key?("progress") ? op["progress"]&.to_f : nil,
+          parent_id: op.key?("parent_id") ? op["parent_id"]&.to_i : nil
         )
       end
 

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -46,6 +46,7 @@ en:
       approve_invalid_attributes: Comment action attributes must be an object.
       approve_no_attributes: Comment action must include at least one allowed attribute.
       approve_invalid_creative: Comment action targets an invalid creative.
+      approve_no_write_permission: No write permission to perform this action on the creative.
       approve_invalid_progress: Comment action progress must be a number.
       approve_invalid_description: Comment action description must be text.
       approved_label: Approved

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -44,6 +44,7 @@ ko:
       approve_invalid_attributes: 댓글 작업 속성은 객체 형식이어야 합니다.
       approve_no_attributes: 댓글 작업에는 최소 한 개의 허용 속성이 포함되어야 합니다.
       approve_invalid_creative: 댓글 작업이 잘못된 크리에이티브를 대상으로 하고 있습니다.
+      approve_no_write_permission: 이 크리에이티브에 대한 쓰기 권한이 없습니다.
       approve_invalid_progress: 댓글 작업 진행률은 숫자여야 합니다.
       approve_invalid_description: 댓글 작업 설명은 텍스트여야 합니다.
       approved_label: 승인됨

--- a/engines/collavre/test/services/tools/creative_batch_service_test.rb
+++ b/engines/collavre/test/services/tools/creative_batch_service_test.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  module Tools
+    class CreativeBatchServiceTest < ActiveSupport::TestCase
+      setup do
+        @user = User.create!(name: "Batch Test", email: "batch_test@example.com", password: "password123")
+        Current.user = @user
+        @root = Creative.create!(description: "<p>Root</p>", user: @user, progress: 0)
+      end
+
+      teardown do
+        Current.user = nil
+      end
+
+      test "requires_approval? returns true" do
+        assert CreativeBatchService.requires_approval?
+      end
+
+      test "creates a creative via batch" do
+        service = CreativeBatchService.new
+        result = service.call(operations: [
+          { "action" => "create", "parent_id" => @root.id, "description" => "Batch created task" }
+        ])
+
+        assert result[:success]
+        assert_equal 1, result[:results].size
+        assert result[:results][0][:id].present?
+      end
+
+      test "updates a creative via batch" do
+        service = CreativeBatchService.new
+        result = service.call(operations: [
+          { "action" => "update", "id" => @root.id, "progress" => 0.5 }
+        ])
+
+        assert result[:success]
+        assert_equal 0.5, result[:results][0][:progress]
+      end
+
+      test "deletes a creative via batch" do
+        child = Creative.create!(description: "<p>To delete</p>", user: @user, parent: @root)
+
+        service = CreativeBatchService.new
+        result = service.call(operations: [
+          { "action" => "delete", "id" => child.id }
+        ])
+
+        assert result[:success]
+        assert result[:results][0][:deleted]
+        assert_nil Creative.find_by(id: child.id)
+      end
+
+      test "mixed operations in a single batch" do
+        service = CreativeBatchService.new
+        result = service.call(operations: [
+          { "action" => "create", "parent_id" => @root.id, "description" => "New task" },
+          { "action" => "update", "id" => @root.id, "progress" => 0.75 }
+        ])
+
+        assert result[:success]
+        assert_equal 2, result[:results].size
+      end
+
+      test "unknown action returns error" do
+        service = CreativeBatchService.new
+        result = service.call(operations: [
+          { "action" => "unknown_action" }
+        ])
+
+        assert_not result[:success]
+        assert_match(/Unknown action/, result[:error])
+      end
+
+      test "rolls back all operations on failure" do
+        initial_count = Creative.count
+
+        service = CreativeBatchService.new
+        result = service.call(operations: [
+          { "action" => "create", "parent_id" => @root.id, "description" => "Should be rolled back" },
+          { "action" => "delete", "id" => 999_999 }
+        ])
+
+        assert_not result[:success]
+        assert_equal initial_count, Creative.count
+      end
+    end
+  end
+end

--- a/engines/collavre_github/db/seeds.rb
+++ b/engines/collavre_github/db/seeds.rb
@@ -23,33 +23,26 @@ module CollavreGithub
       - Consider the PR title, description, and commit messages for context
 
       ## Response Format:
-      After your analysis, if you identify tasks to update or create, respond with an action comment.
+      After your analysis, use the `creative_batch_service` tool to apply all changes at once.
+      This tool accepts an array of operations (create, update, delete) and executes them in a single transaction.
 
-      For completed tasks, suggest updating progress to 1.0:
-      ```json
-      {
-        "actions": [
-          { "action": "update_creative", "creative_id": <id>, "attributes": { "progress": 1.0 } }
-        ]
-      }
+      Example tool call:
       ```
-
-      For new tasks discovered:
-      ```json
-      {
-        "actions": [
-          { "action": "create_creative", "parent_id": <parent_id>, "attributes": { "description": "Task description" } }
+      creative_batch_service({
+        operations: [
+          { action: "update", id: 123, progress: 1.0 },
+          { action: "create", parent_id: 456, description: "New task discovered" },
+          { action: "delete", id: 789 }
         ]
-      }
+      })
       ```
-
-      You can combine multiple actions in a single response.
 
       ## Important:
       - Only suggest updates for tasks that are clearly addressed by the PR
       - Be conservative - don't mark tasks complete unless the PR clearly resolves them
-      - Provide a brief summary of your analysis before the action JSON
-      - If no task updates are needed, just provide your analysis summary without action JSON
+      - Provide a brief summary of your analysis before calling the tool
+      - If no task updates are needed, just provide your analysis summary without calling any tool
+      - The batch tool requires approval — a human will review and approve your changes before they are applied
     PROMPT
 
     # Matches GitHub PR merged events
@@ -69,7 +62,7 @@ module CollavreGithub
       github_pr_diff
       github_pr_commits
       creative_retrieval_service
-      creative_update_service
+      creative_batch_service
     ].freeze
 
     def self.call


### PR DESCRIPTION
## Summary
Add a new `creative_batch_service` system tool that executes multiple Creative operations (create, update, delete) in a single transactional batch call. This tool requires human approval before execution.

## Changes

### New: `creative_batch_service` tool
- Accepts an array of operations: `create`, `update`, `delete`
- All operations run in a single DB transaction (atomic — all succeed or all roll back)
- **Requires approval** via `requires_approval?` class method

### System tool approval support
- Extended `check_tool_approval!` in `AiClient` to check `requires_approval?` on system tool classes (not just `McpTool` records)

### ActionExecutor: `delete_creative` action
- Added `delete_creative` as a supported action in the comment approval flow

### GitHub PR Analyzer updated
- Now uses `creative_batch_service` tool instead of producing raw JSON action comments
- Removed `creative_update_service` from its tools, added `creative_batch_service`

## Tests
- 7 tests, 16 assertions — all passing
- Covers: create, update, delete, mixed ops, unknown action, rollback on failure, requires_approval?