### PR TITLE
fix: pass creative_id to GitHub PR Analyzer tools

### DIFF
--- a/engines/collavre/app/services/collavre/ai_agent_service.rb
+++ b/engines/collavre/app/services/collavre/ai_agent_service.rb
@@ -205,7 +205,7 @@ module Collavre
             markdown = ApplicationController.helpers.render_creative_tree_markdown(
               [ creative ], 1, true, max_depth: max_depth
             )
-            messages << { role: "user", parts: [ { text: "Creative:\n#{markdown}" } ] }
+            messages << { role: "user", parts: [ { text: "Creative (id: #{creative.id}):\n#{markdown}" } ] }
           end
         end
       end

--- a/engines/collavre_github/db/seeds.rb
+++ b/engines/collavre_github/db/seeds.rb
@@ -10,11 +10,17 @@ module CollavreGithub
     SYSTEM_PROMPT = <<~PROMPT
       You are a GitHub Pull Request Analyzer. Your role is to analyze merged PRs and help maintain the project task tree (Creatives).
 
+      ## Context
+      When triggered, you receive the creative context in the first message. The creative ID is provided
+      in the system event. **Always use that creative ID** when calling GitHub tools (`creative_id` parameter).
+      The repository name (e.g., "owner/repo") is included in the webhook event message.
+
       ## When you receive a GitHub PR merged event:
-      1. Use `github_pr_details` to get PR information
-      2. Use `github_pr_diff` to analyze code changes
-      3. Use `github_pr_commits` to understand the work done
-      4. Use `creative_retrieval_service` to see the current task tree
+      1. Extract the `repo` (e.g., "sh1nj1/plan42") and `pr_number` from the event message
+      2. Use `github_pr_details(creative_id: <creative_id from context>, repo: <repo>, pr_number: <number>)` to get PR information
+      3. Use `github_pr_diff` to analyze code changes
+      4. Use `github_pr_commits` to understand the work done
+      5. Use `creative_retrieval_service` to see the current task tree
 
       ## Analysis Guidelines:
       - Match PR changes to existing tasks in the Creative tree

--- a/engines/collavre_github/db/seeds.rb
+++ b/engines/collavre_github/db/seeds.rb
@@ -61,6 +61,7 @@ module CollavreGithub
       context:
         chat_history: 1
         chat_history_size: 1000
+        creative_children_level: 0
     YAML
 
     TOOLS = %w[


### PR DESCRIPTION
## Problem
GitHub PR Analyzer agent fails with 'GitHub account not found for this creative and repository' because it doesn't know which `creative_id` to pass to the GitHub tools.

## Root Cause
1. The system prompt didn't explain how to extract `creative_id` from context
2. The creative ID was not included in the context message sent to the agent
3. The agent had to guess the `creative_id`, leading to lookup failures

## Fix
- **System prompt**: Added explicit 'Context' section explaining that the creative ID comes from the first context message and must be used for all GitHub tool calls
- **Context message**: Changed from `Creative:\n...` to `Creative (id: N):\n...` so the agent can extract the ID

## Testing
After deploying, run `rails db:seed` to update the PR Analyzer agent's system prompt.