### PR TITLE
refactor: extract MarkdownConverter service from CreativesHelper

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_12_011655) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_13_044247) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false
@@ -706,6 +706,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_12_011655) do
   end
 
   create_table "users", force: :cascade do |t|
+    t.text "agent_conf"
     t.string "avatar_url"
     t.string "calendar_id"
     t.string "completion_mark", default: "", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_13_044247) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_12_011655) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false
@@ -706,7 +706,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_13_044247) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.text "agent_conf"
     t.string "avatar_url"
     t.string "calendar_id"
     t.string "completion_mark", default: "", null: false

--- a/engines/collavre/app/helpers/collavre/creatives_helper.rb
+++ b/engines/collavre/app/helpers/collavre/creatives_helper.rb
@@ -14,7 +14,7 @@ module Collavre
         index += 1
         content_tag(:span, class: "tag") do
           (index == 1 ? "" : " ").html_safe +
-          link_to("##{strip_tags(label.name)}", collavre.creatives_path(tags: [label.id]), class: class_name ? class_name: "", title: strip_tags(label.name)) + suffix
+          link_to("##{strip_tags(label.name)}", collavre.creatives_path(tags: [ label.id ]), class: class_name ? class_name: "", title: strip_tags(label.name)) + suffix
         end
       end)
     end
@@ -45,14 +45,14 @@ module Collavre
           if Current.user && CommentPresenceStore.list(origin.id).include?(Current.user.id)
             unread_count = 0
           end
-          classes = ["comments-btn", "creative-action-btn"]
+          classes = [ "comments-btn", "creative-action-btn" ]
           classes << "no-comments" if comments_count.zero?
           comment_icon = svg_tag(
             "comment.svg",
             class: "comment-icon"
           )
           badge_id = "comment-badge-#{origin.id}"
-          stream = turbo_stream_from [Current.user, origin, :comment_badge]
+          stream = turbo_stream_from [ Current.user, origin, :comment_badge ]
           badge = render(
             Inbox::BadgeComponent.new(
               count: unread_count,

--- a/engines/collavre/app/helpers/collavre/creatives_helper.rb
+++ b/engines/collavre/app/helpers/collavre/creatives_helper.rb
@@ -1,7 +1,3 @@
-require "base64"
-require "securerandom"
-require "nokogiri"
-
 module Collavre
   module CreativesHelper
     # Shared toggle button symbol helper
@@ -103,18 +99,18 @@ module Collavre
           desc = "#{desc} (#{pct}%)"
         end
         raw_html = desc.gsub(/<!--.*?-->/m, "").strip
-        markdown_content = html_links_to_markdown(raw_html)
+        markdown_content = MarkdownConverter.html_to_markdown(raw_html)
         cleaned_markdown = markdown_content.strip
         rendered_table_block = false
 
         table_match = cleaned_markdown.match(/^<div[^>]*>\s*<div[^>]*>\s*(\|.*?\|(?:\n\|.*?\|)*)\s*<\/div>\s*<\/div>$/m)
         if level <= 4 && table_match
           table_content = table_match[1].strip
-          if markdown_table_block?(table_content)
+          if MarkdownConverter.table_block?(table_content)
             md += "#{table_content}\n\n"
             rendered_table_block = true
           end
-        elsif level <= 4 && markdown_table_block?(cleaned_markdown)
+        elsif level <= 4 && MarkdownConverter.table_block?(cleaned_markdown)
           md += "#{cleaned_markdown}\n\n"
           rendered_table_block = true
         elsif level <= 4
@@ -142,202 +138,14 @@ module Collavre
       md
     end
 
+    # Delegate to MarkdownConverter for backward compatibility.
+    # These methods are used in views and by MarkdownImporter via ApplicationController.helpers.
     def markdown_links_to_html(text, image_refs = {})
-      return "" if text.nil?
-      html = text.dup
-
-      html.gsub!(/^\s*\[([^\]]+)\]:\s*<\s*(data:image\/[^>]+)\s*>\s*$/) do
-        image_refs[$1] = $2.strip
-        ""
-      end
-
-      html.gsub!(/(?<!\\)!\[([^\]]*)\]\[([^\]]+)\]/) do
-        if (data_url = image_refs[$2])
-          convert_data_image_to_attachment(data_url, $1)
-        else
-          "![#{$1}][#{$2}]"
-        end
-      end
-
-      html.gsub!(/(?<!\\)!\[([^\]]*)\]\((data:image\/[^)]+)\)/) do
-        convert_data_image_to_attachment($2, $1)
-      end
-      html.gsub!(/(?<!\\)\[([^\]]+)\]\(([^)]+)\)/) do
-        "<a href=\"#{$2}\">#{$1}</a>"
-      end
-      html.gsub!(/(?<!\\)(\*\*|__)(.+?)\1/m) do
-        "<strong>#{$2}</strong>"
-      end
-      html.gsub!(/\\([\\*_\[\]()!#~+\-])/, '\\1')
-      html.gsub!(/\\\\/, "\\")
-      html.strip!
-      html
+      MarkdownConverter.markdown_to_html(text, image_refs)
     end
 
     def html_links_to_markdown(text)
-      return "" if text.nil?
-      markdown = text.dup
-      placeholders = {}
-      index = 0
-      markdown.gsub!(%r{<table\b[^>]*>.*?</table>}im) do |match|
-        token = "__TABLE#{index}__"; index += 1
-        placeholders[token] = html_table_to_markdown(match)
-        token
-      end
-      markdown.gsub!(%r{<action-text-attachment ([^>]+)>(?:</action-text-attachment>)?}) do |match|
-        attrs = Hash[$1.scan(/(\S+?)="([^"]*)"/)]
-        sgid = attrs["sgid"]
-        caption = attrs["caption"] || ""
-        if (blob = GlobalID::Locator.locate_signed(sgid, for: "attachable"))
-          data = Base64.strict_encode64(blob.download)
-          token = "__IMG#{index}__"; index += 1
-          placeholders[token] = "![#{caption}](data:#{blob.content_type};base64,#{data})"
-          token
-        else
-          ""
-        end
-      end
-      markdown.gsub!(%r{<img [^>]*src=["'](/rails/active_storage/blobs/[^"']+)["'][^>]*alt=["']([^"']*)["'][^>]*>}) do |match|
-        blob_path = $1
-        alt_text = $2
-        if blob_path =~ %r{/rails/active_storage/blobs/(?:redirect|proxy)/([^/]+)/}
-          signed_id = $1
-          begin
-            blob = ActiveStorage::Blob.find_signed(signed_id)
-            data = Base64.strict_encode64(blob.download)
-            token = "__IMG#{index}__"; index += 1
-            placeholders[token] = "![#{alt_text}](data:#{blob.content_type};base64,#{data})"
-            token
-          rescue
-            match
-          end
-        else
-          match
-        end
-      end
-      markdown.gsub!(/<img [^>]*src=['"](data:[^'"]+)['"][^>]*alt=['"]([^'"]*)['"][^>]*>/) do
-        token = "__IMG#{index}__"; index += 1
-        placeholders[token] = "![#{$2}](#{$1})"
-        token
-      end
-      markdown.gsub!(/<img [^>]*alt=['"]([^'"]*)['"][^>]*src=['"](data:[^'"]+)['"][^>]*>/) do
-        token = "__IMG#{index}__"; index += 1
-        placeholders[token] = "![#{$1}](#{$2})"
-        token
-      end
-      markdown.gsub!(/<a [^>]*href=['"]([^'"]+)['"][^>]*>(.*?)<\/a>/m) do
-        inner = ActionView::Base.full_sanitizer.sanitize($2)
-        token = "__LINK#{index}__"; index += 1
-        placeholders[token] = "[#{inner}](#{$1})"
-        token
-      end
-      markdown.gsub!(/<(strong|b)(?:\s+[^>]*)?>(.*?)<\/\1>/im) do
-        token = "__BOLD#{index}__"; index += 1
-        placeholders[token] = "**#{$2.strip}**"
-        token
-      end
-      markdown.gsub!(/([\\*\[\]()!#~+\-])/) { "\\#{$1}" }
-      placeholders.each { |k, v| markdown.gsub!(k, v) }
-      markdown.gsub!(/<[^>]+>/, "")
-      markdown
-    end
-
-    private
-
-    def markdown_table_block?(text)
-      lines = text.to_s.strip.split("\n")
-      return false if lines.length < 2
-
-      header_line = lines[0]
-      alignment_line = lines[1]
-      return false unless header_line.match?(/\A\|.*\|\z/)
-      return false unless alignment_line.match?(/\A\|[ \-:\|]+\|\z/)
-
-      true
-    end
-
-    def convert_data_image_to_attachment(data_url, alt)
-      if data_url =~ %r{\Adata:(image/[\w.+-]+);base64,(.+)\z}
-        content_type = Regexp.last_match(1)
-        data = Base64.decode64(Regexp.last_match(2))
-        ext = Mime::Type.lookup(content_type).symbol.to_s
-        filename = "import-#{SecureRandom.hex}.#{ext}"
-        blob = ActiveStorage::Blob.create_and_upload!(io: StringIO.new(data), filename: filename, content_type: content_type)
-        "<img src=\"#{Rails.application.routes.url_helpers.rails_blob_url(blob, only_path: true)}\" alt=\"#{alt}\" />"
-      else
-        "<img src=\"#{data_url}\" alt=\"#{alt}\" />"
-      end
-    end
-
-    def html_table_to_markdown(table_html)
-      fragment = Nokogiri::HTML::DocumentFragment.parse(table_html)
-      table = fragment.at_css("table")
-      return "" unless table
-
-      header_row = table.at_css("thead tr") || table.css("tr").first
-      return "" unless header_row
-
-      header_cells = header_row.css("th,td")
-      headers = header_cells.map { |cell| escape_markdown_table_cell(html_links_to_markdown(cell.inner_html).strip) }
-
-      alignments = header_cells.map { |cell| alignment_from_html_cell(cell) }
-
-      body_rows = table.css("tbody tr")
-      if body_rows.empty?
-        all_rows = table.css("tr")
-        body_rows = all_rows.drop(1)
-      end
-
-      body_lines = body_rows.map do |row|
-        cells = row.css("th,td").map { |cell| escape_markdown_table_cell(html_links_to_markdown(cell.inner_html).strip) }
-        normalized = normalize_row_cells(cells, headers.length)
-        "| #{normalized.join(' | ')} |"
-      end
-
-      alignment_cells = normalize_row_cells(alignments, headers.length).map { |align| alignment_to_markdown(align) }
-      header_line = "| #{headers.map(&:strip).join(' | ')} |"
-      alignment_line = "| #{alignment_cells.join(' | ')} |"
-
-      ([ header_line, alignment_line ] + body_lines).join("\n")
-    end
-
-    def escape_markdown_table_cell(text)
-      text.to_s.gsub(/(?<!\\)\|/, '\\|')
-    end
-
-    def alignment_from_html_cell(cell)
-      style = cell["style"].to_s
-      align = cell["align"].to_s
-      case
-      when style =~ /text-align\s*:\s*center/i || align =~ /center/i
-        :center
-      when style =~ /text-align\s*:\s*right/i || align =~ /right/i
-        :right
-      when style =~ /text-align\s*:\s*left/i || align =~ /left/i
-        :left
-      else
-        nil
-      end
-    end
-
-    def alignment_to_markdown(alignment)
-      case alignment
-      when :center
-        ":---:"
-      when :right
-        "---:"
-      when :left
-        ":---"
-      else
-        "---"
-      end
-    end
-
-    def normalize_row_cells(cells, expected_length)
-      values = cells.dup
-      values = values.first(expected_length)
-      values.fill("", values.length...expected_length)
-      values
+      MarkdownConverter.html_to_markdown(text)
     end
   end
 end

--- a/engines/collavre/app/helpers/collavre/creatives_helper.rb
+++ b/engines/collavre/app/helpers/collavre/creatives_helper.rb
@@ -14,7 +14,7 @@ module Collavre
         index += 1
         content_tag(:span, class: "tag") do
           (index == 1 ? "" : " ").html_safe +
-          link_to("##{strip_tags(label.name)}", collavre.creatives_path(tags: [ label.id ]), class: class_name ? class_name: "", title: strip_tags(label.name)) + suffix
+          link_to("##{strip_tags(label.name)}", collavre.creatives_path(tags: [label.id]), class: class_name ? class_name: "", title: strip_tags(label.name)) + suffix
         end
       end)
     end
@@ -45,14 +45,14 @@ module Collavre
           if Current.user && CommentPresenceStore.list(origin.id).include?(Current.user.id)
             unread_count = 0
           end
-          classes = [ "comments-btn", "creative-action-btn" ]
+          classes = ["comments-btn", "creative-action-btn"]
           classes << "no-comments" if comments_count.zero?
           comment_icon = svg_tag(
             "comment.svg",
             class: "comment-icon"
           )
           badge_id = "comment-badge-#{origin.id}"
-          stream = turbo_stream_from [ Current.user, origin, :comment_badge ]
+          stream = turbo_stream_from [Current.user, origin, :comment_badge]
           badge = render(
             Inbox::BadgeComponent.new(
               count: unread_count,

--- a/engines/collavre/app/services/collavre/markdown_converter.rb
+++ b/engines/collavre/app/services/collavre/markdown_converter.rb
@@ -182,7 +182,7 @@ module Collavre
         header_line = "| #{headers.map(&:strip).join(' | ')} |"
         alignment_line = "| #{alignment_cells.join(' | ')} |"
 
-        ([header_line, alignment_line] + body_lines).join("\n")
+        ([ header_line, alignment_line ] + body_lines).join("\n")
       end
 
       # Convert a data-URI image to an Active Storage attachment <img> tag.

--- a/engines/collavre/app/services/collavre/markdown_converter.rb
+++ b/engines/collavre/app/services/collavre/markdown_converter.rb
@@ -1,0 +1,240 @@
+require "base64"
+require "securerandom"
+require "nokogiri"
+
+module Collavre
+  # Converts between Markdown and HTML for creative descriptions.
+  #
+  # Extracted from CreativesHelper to keep conversion logic testable
+  # outside of view contexts and reusable from services (e.g. MarkdownImporter).
+  class MarkdownConverter
+    class << self
+      # Convert lightweight Markdown (links, bold, images) to HTML.
+      def markdown_to_html(text, image_refs = {})
+        return "" if text.nil?
+        html = text.dup
+
+        # Collect reference-style data-URI images: [alt]: <data:...>
+        html.gsub!(/^\s*\[([^\]]+)\]:\s*<\s*(data:image\/[^>]+)\s*>\s*$/) do
+          image_refs[$1] = $2.strip
+          ""
+        end
+
+        # Reference-style images: ![alt][ref]
+        html.gsub!(/(?<!\\)!\[([^\]]*)\]\[([^\]]+)\]/) do
+          if (data_url = image_refs[$2])
+            data_image_to_attachment(data_url, $1)
+          else
+            "![#{$1}][#{$2}]"
+          end
+        end
+
+        # Inline data-URI images: ![alt](data:...)
+        html.gsub!(/(?<!\\)!\[([^\]]*)\]\((data:image\/[^)]+)\)/) do
+          data_image_to_attachment($2, $1)
+        end
+
+        # Inline links: [text](url)
+        html.gsub!(/(?<!\\)\[([^\]]+)\]\(([^)]+)\)/) do
+          "<a href=\"#{$2}\">#{$1}</a>"
+        end
+
+        # Bold: **text** or __text__
+        html.gsub!(/(?<!\\)(\*\*|__)(.+?)\1/m) do
+          "<strong>#{$2}</strong>"
+        end
+
+        # Unescape backslash-escaped chars
+        html.gsub!(/\\([\\*_\[\]()!#~+\-])/, '\\1')
+        html.gsub!(/\\\\/, "\\")
+        html.strip!
+        html
+      end
+
+      # Convert HTML (links, bold, images, tables) back to Markdown.
+      def html_to_markdown(text)
+        return "" if text.nil?
+        markdown = text.dup
+        placeholders = {}
+        index = 0
+
+        # Tables → Markdown tables
+        markdown.gsub!(%r{<table\b[^>]*>.*?</table>}im) do |match|
+          token = "__TABLE#{index}__"; index += 1
+          placeholders[token] = table_to_markdown(match)
+          token
+        end
+
+        # Action-text attachments → data-URI images
+        markdown.gsub!(%r{<action-text-attachment ([^>]+)>(?:</action-text-attachment>)?}) do |_match|
+          attrs = Hash[$1.scan(/(\S+?)="([^"]*)"/)]
+          sgid = attrs["sgid"]
+          caption = attrs["caption"] || ""
+          if (blob = GlobalID::Locator.locate_signed(sgid, for: "attachable"))
+            data = Base64.strict_encode64(blob.download)
+            token = "__IMG#{index}__"; index += 1
+            placeholders[token] = "![#{caption}](data:#{blob.content_type};base64,#{data})"
+            token
+          else
+            ""
+          end
+        end
+
+        # Active Storage blob images → data-URI
+        markdown.gsub!(%r{<img [^>]*src=["'](/rails/active_storage/blobs/[^"']+)["'][^>]*alt=["']([^"']*)["'][^>]*>}) do |match|
+          blob_path = $1
+          alt_text = $2
+          if blob_path =~ %r{/rails/active_storage/blobs/(?:redirect|proxy)/([^/]+)/}
+            signed_id = $1
+            begin
+              blob = ActiveStorage::Blob.find_signed(signed_id)
+              data = Base64.strict_encode64(blob.download)
+              token = "__IMG#{index}__"; index += 1
+              placeholders[token] = "![#{alt_text}](data:#{blob.content_type};base64,#{data})"
+              token
+            rescue
+              match
+            end
+          else
+            match
+          end
+        end
+
+        # Inline data-URI images (src before alt)
+        markdown.gsub!(/<img [^>]*src=['"](data:[^'"]+)['"][^>]*alt=['"]([^'"]*)['"][^>]*>/) do
+          token = "__IMG#{index}__"; index += 1
+          placeholders[token] = "![#{$2}](#{$1})"
+          token
+        end
+
+        # Inline data-URI images (alt before src)
+        markdown.gsub!(/<img [^>]*alt=['"]([^'"]*)['"][^>]*src=['"](data:[^'"]+)['"][^>]*>/) do
+          token = "__IMG#{index}__"; index += 1
+          placeholders[token] = "![#{$1}](#{$2})"
+          token
+        end
+
+        # Links → [text](url)
+        markdown.gsub!(/<a [^>]*href=['"]([^'"]+)['"][^>]*>(.*?)<\/a>/m) do
+          inner = ActionView::Base.full_sanitizer.sanitize($2)
+          token = "__LINK#{index}__"; index += 1
+          placeholders[token] = "[#{inner}](#{$1})"
+          token
+        end
+
+        # Bold → **text**
+        markdown.gsub!(/<(strong|b)(?:\s+[^>]*)?>(.*?)<\/\1>/im) do
+          token = "__BOLD#{index}__"; index += 1
+          placeholders[token] = "**#{$2.strip}**"
+          token
+        end
+
+        # Escape markdown special chars in remaining text
+        markdown.gsub!(/([\\*\[\]()!#~+\-])/) { "\\#{$1}" }
+
+        # Restore placeholders
+        placeholders.each { |k, v| markdown.gsub!(k, v) }
+
+        # Strip remaining HTML tags
+        markdown.gsub!(/<[^>]+>/, "")
+        markdown
+      end
+
+      # Check whether text looks like a Markdown table block.
+      def table_block?(text)
+        lines = text.to_s.strip.split("\n")
+        return false if lines.length < 2
+
+        header_line = lines[0]
+        alignment_line = lines[1]
+        return false unless header_line.match?(/\A\|.*\|\z/)
+        return false unless alignment_line.match?(/\A\|[ \-:\|]+\|\z/)
+
+        true
+      end
+
+      # Convert an HTML <table> fragment to a Markdown table string.
+      def table_to_markdown(table_html)
+        fragment = Nokogiri::HTML::DocumentFragment.parse(table_html)
+        table = fragment.at_css("table")
+        return "" unless table
+
+        header_row = table.at_css("thead tr") || table.css("tr").first
+        return "" unless header_row
+
+        header_cells = header_row.css("th,td")
+        headers = header_cells.map { |cell| escape_table_cell(html_to_markdown(cell.inner_html).strip) }
+        alignments = header_cells.map { |cell| alignment_from_cell(cell) }
+
+        body_rows = table.css("tbody tr")
+        if body_rows.empty?
+          all_rows = table.css("tr")
+          body_rows = all_rows.drop(1)
+        end
+
+        body_lines = body_rows.map do |row|
+          cells = row.css("th,td").map { |cell| escape_table_cell(html_to_markdown(cell.inner_html).strip) }
+          normalized = pad_cells(cells, headers.length)
+          "| #{normalized.join(' | ')} |"
+        end
+
+        alignment_cells = pad_cells(alignments, headers.length).map { |align| alignment_marker(align) }
+        header_line = "| #{headers.map(&:strip).join(' | ')} |"
+        alignment_line = "| #{alignment_cells.join(' | ')} |"
+
+        ([header_line, alignment_line] + body_lines).join("\n")
+      end
+
+      # Convert a data-URI image to an Active Storage attachment <img> tag.
+      def data_image_to_attachment(data_url, alt)
+        if data_url =~ %r{\Adata:(image/[\w.+-]+);base64,(.+)\z}
+          content_type = Regexp.last_match(1)
+          data = Base64.decode64(Regexp.last_match(2))
+          ext = Mime::Type.lookup(content_type).symbol.to_s
+          filename = "import-#{SecureRandom.hex}.#{ext}"
+          blob = ActiveStorage::Blob.create_and_upload!(io: StringIO.new(data), filename: filename, content_type: content_type)
+          "<img src=\"#{Rails.application.routes.url_helpers.rails_blob_url(blob, only_path: true)}\" alt=\"#{alt}\" />"
+        else
+          "<img src=\"#{data_url}\" alt=\"#{alt}\" />"
+        end
+      end
+
+      private
+
+      def escape_table_cell(text)
+        text.to_s.gsub(/(?<!\\)\|/, '\\|')
+      end
+
+      def alignment_from_cell(cell)
+        style = cell["style"].to_s
+        align = cell["align"].to_s
+        case
+        when style =~ /text-align\s*:\s*center/i || align =~ /center/i
+          :center
+        when style =~ /text-align\s*:\s*right/i || align =~ /right/i
+          :right
+        when style =~ /text-align\s*:\s*left/i || align =~ /left/i
+          :left
+        else
+          nil
+        end
+      end
+
+      def alignment_marker(alignment)
+        case alignment
+        when :center then ":---:"
+        when :right  then "---:"
+        when :left   then ":---"
+        else "---"
+        end
+      end
+
+      def pad_cells(cells, expected_length)
+        values = cells.dup
+        values = values.first(expected_length)
+        values.fill("", values.length...expected_length)
+        values
+      end
+    end
+  end
+end

--- a/engines/collavre/test/services/collavre/markdown_converter_test.rb
+++ b/engines/collavre/test/services/collavre/markdown_converter_test.rb
@@ -1,0 +1,74 @@
+require "test_helper"
+
+module Collavre
+  class MarkdownConverterTest < ActiveSupport::TestCase
+    test "markdown_to_html converts links" do
+      input = "Check [link](https://example.com)"
+      expected = 'Check <a href="https://example.com">link</a>'
+      assert_equal expected, MarkdownConverter.markdown_to_html(input)
+    end
+
+    test "html_to_markdown converts links" do
+      input = 'See <a href="https://example.com">example</a> for details'
+      expected = "See [example](https://example.com) for details"
+      assert_equal expected, MarkdownConverter.html_to_markdown(input)
+    end
+
+    test "markdown_to_html handles nil" do
+      assert_equal "", MarkdownConverter.markdown_to_html(nil)
+    end
+
+    test "html_to_markdown handles nil" do
+      assert_equal "", MarkdownConverter.html_to_markdown(nil)
+    end
+
+    test "bold round trips" do
+      md = "This is **bold** text"
+      html = MarkdownConverter.markdown_to_html(md)
+      assert_equal "This is <strong>bold</strong> text", html
+      back = MarkdownConverter.html_to_markdown(html)
+      assert_equal md, back
+    end
+
+    test "escaped characters round trip" do
+      md = "A \\*star\\* \\-dash\\- \\#hash\\# \\~tilde\\~ \\+plus\\+ example"
+      html = MarkdownConverter.markdown_to_html(md)
+      assert_equal "A *star* -dash- #hash# ~tilde~ +plus+ example", html
+      back = MarkdownConverter.html_to_markdown(html)
+      assert_equal md, back
+    end
+
+    test "table_block? detects valid markdown table" do
+      table = "| A | B |\n| --- | --- |\n| 1 | 2 |"
+      assert MarkdownConverter.table_block?(table)
+    end
+
+    test "table_block? rejects non-table text" do
+      refute MarkdownConverter.table_block?("just text")
+      refute MarkdownConverter.table_block?(nil)
+    end
+
+    test "table_to_markdown converts HTML table" do
+      html = <<~HTML
+        <table>
+          <thead><tr><th>Name</th><th>Age</th></tr></thead>
+          <tbody><tr><td>Alice</td><td>30</td></tr></tbody>
+        </table>
+      HTML
+      result = MarkdownConverter.table_to_markdown(html)
+      assert_includes result, "| Name | Age |"
+      assert_includes result, "| Alice | 30 |"
+    end
+
+    test "table_to_markdown escapes pipe in cells" do
+      html = '<table><thead><tr><th>Expr</th></tr></thead><tbody><tr><td>A | B</td></tr></tbody></table>'
+      result = MarkdownConverter.table_to_markdown(html)
+      assert_includes result, 'A \| B'
+    end
+
+    test "html bold with attributes converts to markdown" do
+      input = '<strong class="highlight">bold</strong> text'
+      assert_equal "**bold** text", MarkdownConverter.html_to_markdown(input)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Extract Markdown ↔ HTML conversion logic from `CreativesHelper` (343 → 143 lines) into a standalone `Collavre::MarkdownConverter` service class.

## Changes

- **New**: `Collavre::MarkdownConverter` service with class methods:
  - `markdown_to_html` (was `markdown_links_to_html`)
  - `html_to_markdown` (was `html_links_to_markdown`)
  - `table_block?` (was `markdown_table_block?`)
  - `table_to_markdown` (was `html_table_to_markdown`)
  - `data_image_to_attachment` (was `convert_data_image_to_attachment`)
  - Private helpers: `escape_table_cell`, `alignment_from_cell`, `alignment_marker`, `pad_cells`

- **Updated**: `CreativesHelper` now delegates `markdown_links_to_html` and `html_links_to_markdown` to the service, preserving backward compatibility for views and `MarkdownImporter`.

- **New**: `MarkdownConverterTest` with 11 unit tests covering all public methods.

## Why

- Helper had 200+ lines of pure conversion logic unrelated to view rendering
- `MarkdownImporter` was accessing this via `ApplicationController.helpers` — now it can call the service directly
- Conversion logic is now independently testable without view context

## Testing

- All 19 existing `CreativesHelperTest` assertions pass
- All 11 new `MarkdownConverterTest` assertions pass