### PR TITLE
refactor: extract CommandMenuService and CommentMoveService from CommentsController

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_12_011655) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_13_044247) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false
@@ -706,6 +706,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_12_011655) do
   end
 
   create_table "users", force: :cascade do |t|
+    t.text "agent_conf"
     t.string "avatar_url"
     t.string "calendar_id"
     t.string "completion_mark", default: "", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_13_044247) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_12_011655) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false
@@ -706,7 +706,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_13_044247) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.text "agent_conf"
     t.string "avatar_url"
     t.string "calendar_id"
     t.string "completion_mark", default: "", null: false

--- a/engines/collavre/app/controllers/collavre/comments_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comments_controller.rb
@@ -402,87 +402,19 @@ module Collavre
         head :forbidden and return
       end
 
-      render json: command_menu_items
+      render json: CommandMenuService.new(user: Current.user).items
     end
 
     def move
-      comment_ids = Array(params[:comment_ids]).map(&:presence).compact.map(&:to_i)
-      if comment_ids.empty?
-        render json: { error: I18n.t("collavre.comments.move_no_selection") }, status: :unprocessable_entity and return
-      end
-
-      # Support moving to topic within same creative (target_topic_id only)
-      # or moving to different creative (target_creative_id)
-      target_topic_id = params[:target_topic_id]
-      target_creative_id = params[:target_creative_id]
-
-      # Determine target creative and topic
-      if target_creative_id.present?
-        # Moving to different creative
-        target_creative = Creative.find_by(id: target_creative_id)
-        if target_creative.nil?
-          render json: { error: I18n.t("collavre.comments.move_invalid_target") }, status: :unprocessable_entity and return
-        end
-        target_origin = target_creative.effective_origin
-        new_topic_id = nil # Reset topic when moving to different creative
-      elsif target_topic_id.present? || target_topic_id == ""
-        # Moving to topic within same creative (empty string means Main/no topic)
-        target_origin = @creative
-        new_topic_id = target_topic_id.presence # nil for Main topic
-
-        # Validate topic exists if specified
-        if new_topic_id.present? && !@creative.topics.exists?(id: new_topic_id)
-          render json: { error: I18n.t("collavre.comments.move_invalid_topic", default: "Invalid topic") }, status: :unprocessable_entity and return
-        end
-      else
-        render json: { error: I18n.t("collavre.comments.move_invalid_target") }, status: :unprocessable_entity and return
-      end
-
-      unless @creative.has_permission?(Current.user, :feedback) && target_origin.has_permission?(Current.user, :feedback)
-        render json: { error: I18n.t("collavre.comments.move_not_allowed") }, status: :forbidden and return
-      end
-
-      scope = @creative.comments.where(
-        "comments.private = ? OR comments.user_id = ? OR comments.approver_id = ?",
-        false,
-        Current.user.id,
-        Current.user.id
+      result = CommentMoveService.new(creative: @creative, user: Current.user).call(
+        comment_ids: params[:comment_ids],
+        target_creative_id: params[:target_creative_id],
+        target_topic_id: params[:target_topic_id]
       )
-
-      comments = scope.where(id: comment_ids).to_a
-
-      if comments.length != comment_ids.length
-        render json: { error: I18n.t("collavre.comments.move_not_allowed") }, status: :forbidden and return
-      end
-
-      moved_count = 0
-      ActiveRecord::Base.transaction do
-        comments.each do |comment|
-          # Skip if already in target location
-          same_creative = comment.creative_id == target_origin.id
-          same_topic = comment.topic_id.to_s == new_topic_id.to_s
-
-          next if same_creative && same_topic
-
-          original_creative = comment.creative
-          original_topic_id = comment.topic_id
-
-          if same_creative
-            # Just update topic within same creative
-            comment.update!(topic_id: new_topic_id)
-          else
-            # Move to different creative
-            comment.update!(creative: target_origin, topic_id: new_topic_id)
-            broadcast_move_removal(comment, original_creative)
-          end
-          moved_count += 1
-        end
-      end
-
-      Comment.broadcast_badges(@creative)
-      Comment.broadcast_badges(target_origin) unless target_origin == @creative
-
-      render json: { success: true, moved_count: moved_count }
+      render json: result
+    rescue CommentMoveService::MoveError => e
+      status = e.message == I18n.t("collavre.comments.move_not_allowed") ? :forbidden : :unprocessable_entity
+      render json: { error: e.message }, status: status
     rescue ActiveRecord::RecordInvalid => e
       render json: { error: e.record.errors.full_messages.to_sentence.presence || I18n.t("collavre.comments.move_error") }, status: :unprocessable_entity
     end
@@ -491,63 +423,6 @@ module Collavre
 
     def set_creative
       @creative = Creative.find(params[:creative_id]).effective_origin
-    end
-
-    def command_menu_items
-      [
-        {
-          name: "calendar",
-          label: "/calendar",
-          aliases: [ "/cal" ],
-          description: I18n.t("collavre.comments.command_menu.calendar_description"),
-          args: I18n.t("collavre.comments.command_menu.calendar_args")
-        },
-        {
-          name: "topic",
-          label: "/topic",
-          description: I18n.t("collavre.comments.command_menu.topic_description"),
-          args: I18n.t("collavre.comments.command_menu.topic_args")
-        }
-      ] + mcp_command_items
-    end
-
-    def mcp_command_items
-      Collavre::McpService.available_tools(Current.user).filter_map do |tool|
-        tool_name = tool[:name] || tool["name"]
-        next unless tool_name
-
-        {
-          name: tool_name,
-          label: "/#{tool_name}",
-          description: tool[:description] || tool["description"],
-          args: format_command_args(tool[:params] || tool["params"])
-        }
-      end
-    end
-
-    def format_command_args(params)
-      return if params.blank?
-
-      # Handle array format (from MetaToolService)
-      if params.is_a?(Array)
-        return params.map do |param|
-          name = param[:name] || param["name"]
-          required = param[:required] || param["required"]
-          name.to_s + (required ? "*" : "")
-        end.join(", ")
-      end
-
-      # Handle JSON Schema format (Hash with :properties)
-      properties = params[:properties] || params["properties"]
-      return unless properties.is_a?(Hash)
-
-      required = params[:required] || params["required"] || []
-      required = Array(required).map(&:to_s)
-
-      properties.keys.map do |key|
-        key = key.to_s
-        required.include?(key) ? "#{key}*" : key
-      end.join(", ")
     end
 
     def set_comment
@@ -567,15 +442,6 @@ module Collavre
 
     def can_convert_comment?
       @comment.user == Current.user || @creative.has_permission?(Current.user, :admin)
-    end
-
-    def broadcast_move_removal(comment, original_creative)
-      return if comment.private?
-
-      Turbo::StreamsChannel.broadcast_remove_to(
-        [ original_creative, :comments ],
-        target: view_context.dom_id(comment)
-      )
     end
 
     def build_convert_system_message(creative)

--- a/engines/collavre/app/services/collavre/command_menu_service.rb
+++ b/engines/collavre/app/services/collavre/command_menu_service.rb
@@ -1,0 +1,70 @@
+module Collavre
+  class CommandMenuService
+    def initialize(user:)
+      @user = user
+    end
+
+    def items
+      built_in_items + mcp_items
+    end
+
+    private
+
+    attr_reader :user
+
+    def built_in_items
+      [
+        {
+          name: "calendar",
+          label: "/calendar",
+          aliases: [ "/cal" ],
+          description: I18n.t("collavre.comments.command_menu.calendar_description"),
+          args: I18n.t("collavre.comments.command_menu.calendar_args")
+        },
+        {
+          name: "topic",
+          label: "/topic",
+          description: I18n.t("collavre.comments.command_menu.topic_description"),
+          args: I18n.t("collavre.comments.command_menu.topic_args")
+        }
+      ]
+    end
+
+    def mcp_items
+      Collavre::McpService.available_tools(user).filter_map do |tool|
+        tool_name = tool[:name] || tool["name"]
+        next unless tool_name
+
+        {
+          name: tool_name,
+          label: "/#{tool_name}",
+          description: tool[:description] || tool["description"],
+          args: format_args(tool[:params] || tool["params"])
+        }
+      end
+    end
+
+    def format_args(params)
+      return if params.blank?
+
+      if params.is_a?(Array)
+        return params.map do |param|
+          name = param[:name] || param["name"]
+          required = param[:required] || param["required"]
+          name.to_s + (required ? "*" : "")
+        end.join(", ")
+      end
+
+      properties = params[:properties] || params["properties"]
+      return unless properties.is_a?(Hash)
+
+      required = params[:required] || params["required"] || []
+      required = Array(required).map(&:to_s)
+
+      properties.keys.map do |key|
+        key = key.to_s
+        required.include?(key) ? "#{key}*" : key
+      end.join(", ")
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/comment_move_service.rb
+++ b/engines/collavre/app/services/collavre/comment_move_service.rb
@@ -1,0 +1,94 @@
+module Collavre
+  class CommentMoveService
+    class MoveError < StandardError; end
+
+    def initialize(creative:, user:)
+      @creative = creative
+      @user = user
+    end
+
+    # Returns { success: true, moved_count: N }
+    # Raises MoveError on validation failures
+    def call(comment_ids:, target_creative_id: nil, target_topic_id: nil)
+      comment_ids = Array(comment_ids).map(&:presence).compact.map(&:to_i)
+      raise MoveError, I18n.t("collavre.comments.move_no_selection") if comment_ids.empty?
+
+      target_origin, new_topic_id = resolve_target(target_creative_id, target_topic_id)
+
+      validate_permissions!(target_origin)
+      comments = fetch_visible_comments(comment_ids)
+
+      moved_count = perform_move(comments, target_origin, new_topic_id)
+
+      Comment.broadcast_badges(@creative)
+      Comment.broadcast_badges(target_origin) unless target_origin == @creative
+
+      { success: true, moved_count: moved_count }
+    end
+
+    private
+
+    attr_reader :creative, :user
+
+    def resolve_target(target_creative_id, target_topic_id)
+      if target_creative_id.present?
+        target_creative = Creative.find_by(id: target_creative_id)
+        raise MoveError, I18n.t("collavre.comments.move_invalid_target") unless target_creative
+        [ target_creative.effective_origin, nil ]
+      elsif !target_topic_id.nil?
+        new_topic_id = target_topic_id.presence
+        if new_topic_id.present? && !creative.topics.exists?(id: new_topic_id)
+          raise MoveError, I18n.t("collavre.comments.move_invalid_topic", default: "Invalid topic")
+        end
+        [ creative, new_topic_id ]
+      else
+        raise MoveError, I18n.t("collavre.comments.move_invalid_target")
+      end
+    end
+
+    def validate_permissions!(target_origin)
+      unless creative.has_permission?(user, :feedback) && target_origin.has_permission?(user, :feedback)
+        raise MoveError, I18n.t("collavre.comments.move_not_allowed")
+      end
+    end
+
+    def fetch_visible_comments(comment_ids)
+      scope = creative.comments.where(
+        "comments.private = ? OR comments.user_id = ? OR comments.approver_id = ?",
+        false, user.id, user.id
+      )
+      comments = scope.where(id: comment_ids).to_a
+      raise MoveError, I18n.t("collavre.comments.move_not_allowed") if comments.length != comment_ids.length
+      comments
+    end
+
+    def perform_move(comments, target_origin, new_topic_id)
+      moved_count = 0
+      ActiveRecord::Base.transaction do
+        comments.each do |comment|
+          same_creative = comment.creative_id == target_origin.id
+          same_topic = comment.topic_id.to_s == new_topic_id.to_s
+          next if same_creative && same_topic
+
+          if same_creative
+            comment.update!(topic_id: new_topic_id)
+          else
+            comment.update!(creative: target_origin, topic_id: new_topic_id)
+            broadcast_move_removal(comment, comment.creative)
+          end
+          moved_count += 1
+        end
+      end
+      moved_count
+    end
+
+    def broadcast_move_removal(comment, original_creative)
+      return if comment.private?
+
+      Turbo::StreamsChannel.broadcast_remove_to(
+        [ original_creative, :comments ],
+        target: ActionView::RecordIdentifier.dom_id(comment)
+      )
+    end
+  end
+end

--- a/engines/collavre/test/services/command_menu_service_test.rb
+++ b/engines/collavre/test/services/command_menu_service_test.rb
@@ -1,0 +1,45 @@
+require "test_helper"
+
+module Collavre
+  class CommandMenuServiceTest < ActiveSupport::TestCase
+    test "returns built-in calendar and topic items" do
+      user = users(:one)
+      items = CommandMenuService.new(user: user).items
+
+      calendar_item = items.find { |i| i[:name] == "calendar" }
+      topic_item = items.find { |i| i[:name] == "topic" }
+
+      assert_not_nil calendar_item, "Should include calendar command"
+      assert_equal "/calendar", calendar_item[:label]
+      assert_includes calendar_item[:aliases], "/cal"
+
+      assert_not_nil topic_item, "Should include topic command"
+      assert_equal "/topic", topic_item[:label]
+    end
+
+    test "format_args handles nil params" do
+      service = CommandMenuService.new(user: users(:one))
+      assert_nil service.send(:format_args, nil)
+    end
+
+    test "format_args handles array params" do
+      service = CommandMenuService.new(user: users(:one))
+      params = [
+        { name: "query", required: true },
+        { name: "limit", required: false }
+      ]
+      result = service.send(:format_args, params)
+      assert_equal "query*, limit", result
+    end
+
+    test "format_args handles hash params with properties" do
+      service = CommandMenuService.new(user: users(:one))
+      params = {
+        properties: { "name" => {}, "age" => {} },
+        required: [ "name" ]
+      }
+      result = service.send(:format_args, params)
+      assert_equal "name*, age", result
+    end
+  end
+end

--- a/engines/collavre/test/services/comment_move_service_test.rb
+++ b/engines/collavre/test/services/comment_move_service_test.rb
@@ -1,0 +1,39 @@
+require "test_helper"
+
+module Collavre
+  class CommentMoveServiceTest < ActiveSupport::TestCase
+    setup do
+      @user = users(:one)
+      @creative = creatives(:tshirt)
+      Current.user = @user
+    end
+
+    teardown do
+      Current.user = nil
+    end
+
+    test "raises error when no comment_ids provided" do
+      service = CommentMoveService.new(creative: @creative, user: @user)
+      error = assert_raises(CommentMoveService::MoveError) do
+        service.call(comment_ids: [])
+      end
+      assert_equal I18n.t("collavre.comments.move_no_selection"), error.message
+    end
+
+    test "raises error when target is invalid" do
+      service = CommentMoveService.new(creative: @creative, user: @user)
+      error = assert_raises(CommentMoveService::MoveError) do
+        service.call(comment_ids: [ 1 ])
+      end
+      assert_equal I18n.t("collavre.comments.move_invalid_target"), error.message
+    end
+
+    test "raises error when target creative does not exist" do
+      service = CommentMoveService.new(creative: @creative, user: @user)
+      error = assert_raises(CommentMoveService::MoveError) do
+        service.call(comment_ids: [ 1 ], target_creative_id: -999)
+      end
+      assert_equal I18n.t("collavre.comments.move_invalid_target"), error.message
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Extract two services from CommentsController (592 → 458 lines, -134 lines):

### CommandMenuService
- Encapsulates command menu item generation (built-in + MCP tool items)
- Handles argument formatting for both array and JSON Schema parameter formats

### CommentMoveService
- Encapsulates comment move logic with proper error handling via `MoveError`
- Handles target resolution (creative or topic), permission validation, and broadcast

### Tests
- All 43 existing controller tests pass unchanged
- 4 new CommandMenuService tests (built-in items, format_args edge cases)
- 3 new CommentMoveService tests (validation errors)