### PR TITLE
refactor: extract CreateService and DestroyService from CreativesController

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_12_011655) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_13_044247) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false
@@ -706,6 +706,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_12_011655) do
   end
 
   create_table "users", force: :cascade do |t|
+    t.text "agent_conf"
     t.string "avatar_url"
     t.string "calendar_id"
     t.string "completion_mark", default: "", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_13_044247) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_12_011655) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false
@@ -706,7 +706,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_13_044247) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.text "agent_conf"
     t.string "avatar_url"
     t.string "calendar_id"
     t.string "completion_mark", default: "", null: false

--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -176,47 +176,21 @@ module Collavre
     end
 
     def create
-      @creative = Creative.new(creative_params)
-      if @creative.parent
-        @creative.user = @creative.parent.user
-      else
-        @creative.user = Current.user
-      end
+      result = Creatives::CreateService.new(
+        creative_params: creative_params,
+        user: Current.user,
+        child_id: params[:child_id],
+        before_id: params[:before_id],
+        after_id: params[:after_id],
+        tag_ids: params[:tags]
+      ).call
 
-      # Rebuild @child_creative from params if present
-      if params[:child_id].present?
-        @child_creative = Creative.find_by(id: params[:child_id])
-      end
+      @creative = result.creative
 
-      if @creative.save
-        @child_creative.update(parent: @creative) if @child_creative
-        if params[:before_id].present?
-          before_creative = Creative.find_by(id: params[:before_id])
-          if before_creative && before_creative.parent_id == @creative.parent_id
-            siblings = @creative.parent ? @creative.parent.children.order(:sequence).to_a : Creative.roots.order(:sequence).to_a
-            siblings.reject! { |s| s.id == @creative.id }
-            index = siblings.index { |s| s.id == before_creative.id } || 0
-            siblings.insert(index, @creative)
-            siblings.each_with_index { |c, idx| c.update_column(:sequence, idx) }
-          end
-        elsif params[:after_id].present?
-          after_creative = Creative.find_by(id: params[:after_id])
-          if after_creative && after_creative.parent_id == @creative.parent_id
-            siblings = @creative.parent ? @creative.parent.children.order(:sequence).to_a : Creative.roots.order(:sequence).to_a
-            siblings.reject! { |s| s.id == @creative.id }
-            index = siblings.index { |s| s.id == after_creative.id } || -1
-            siblings.insert(index + 1, @creative)
-            siblings.each_with_index { |c, idx| c.update_column(:sequence, idx) }
-          end
-        end
-        if params[:tags].present?
-          Array(params[:tags]).each do |tag_id|
-            @creative.tags.create(label_id: tag_id)
-          end
-        end
+      if result.success?
         render json: { id: @creative.id }
       else
-        render json: { errors: @creative.errors.full_messages }, status: :unprocessable_entity
+        render json: { errors: result.errors }, status: :unprocessable_entity
       end
     end
 
@@ -275,15 +249,11 @@ module Collavre
       unless @creative.has_permission?(Current.user, :admin)
         redirect_to @creative, alert: t("collavre.creatives.errors.no_permission") and return
       end
-      if params[:delete_with_children]
-        # Recursively destroy deletable descendants before deleting parent
-        destroy_descendants_recursively(@creative, Current.user)
-      else
-        # Re-link children to parent
-        @creative.children.each { |child| child.update(parent: parent) }
-      end
-      CreativeShare.where(creative: @creative).destroy_all
-      @creative.destroy
+      Creatives::DestroyService.new(
+        creative: @creative,
+        user: Current.user,
+        delete_with_children: params[:delete_with_children].present?
+      ).call
     end
 
     def request_permission
@@ -522,16 +492,6 @@ module Collavre
             progress_map: progress_map
           )
         }
-      end
-
-      # Recursively destroy all descendants the user can delete
-      def destroy_descendants_recursively(creative, user)
-        deletable_children = creative.children_with_permission(user, :admin)
-        deletable_children.each do |child|
-          destroy_descendants_recursively(child, user)
-          CreativeShare.where(creative: child).destroy_all
-          child.destroy
-        end
       end
 
       def enforce_creatives_login_policy

--- a/engines/collavre/app/services/collavre/creatives/create_service.rb
+++ b/engines/collavre/app/services/collavre/creatives/create_service.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Creatives
+    # Handles creative creation including sequencing and tagging.
+    class CreateService
+      Result = Struct.new(:creative, :success?, :errors, keyword_init: true)
+
+      def initialize(creative_params:, user:, child_id: nil, before_id: nil, after_id: nil, tag_ids: nil)
+        @creative_params = creative_params
+        @user = user
+        @child_id = child_id
+        @before_id = before_id
+        @after_id = after_id
+        @tag_ids = Array(tag_ids).compact
+      end
+
+      def call
+        creative = Creative.new(@creative_params)
+        creative.user = creative.parent ? creative.parent.user : @user
+
+        unless creative.save
+          return Result.new(creative: creative, success?: false, errors: creative.errors.full_messages)
+        end
+
+        reparent_child(creative)
+        insert_at_position(creative)
+        apply_tags(creative)
+
+        Result.new(creative: creative, success?: true, errors: [])
+      end
+
+      private
+
+      def reparent_child(creative)
+        return unless @child_id.present?
+
+        child = Creative.find_by(id: @child_id)
+        child&.update(parent: creative)
+      end
+
+      def insert_at_position(creative)
+        if @before_id.present?
+          insert_before(creative, @before_id)
+        elsif @after_id.present?
+          insert_after(creative, @after_id)
+        end
+      end
+
+      def insert_before(creative, before_id)
+        before_creative = Creative.find_by(id: before_id)
+        return unless before_creative && before_creative.parent_id == creative.parent_id
+
+        siblings = fetch_siblings(creative)
+        index = siblings.index { |s| s.id == before_creative.id } || 0
+        siblings.insert(index, creative)
+        resequence(siblings)
+      end
+
+      def insert_after(creative, after_id)
+        after_creative = Creative.find_by(id: after_id)
+        return unless after_creative && after_creative.parent_id == creative.parent_id
+
+        siblings = fetch_siblings(creative)
+        index = siblings.index { |s| s.id == after_creative.id } || -1
+        siblings.insert(index + 1, creative)
+        resequence(siblings)
+      end
+
+      def fetch_siblings(creative)
+        collection = creative.parent ? creative.parent.children.order(:sequence) : Creative.roots.order(:sequence)
+        collection.to_a.reject { |s| s.id == creative.id }
+      end
+
+      def resequence(siblings)
+        siblings.each_with_index { |c, idx| c.update_column(:sequence, idx) }
+      end
+
+      def apply_tags(creative)
+        @tag_ids.each do |tag_id|
+          creative.tags.create(label_id: tag_id)
+        end
+      end
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/creatives/destroy_service.rb
+++ b/engines/collavre/app/services/collavre/creatives/destroy_service.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Creatives
+    # Handles creative destruction with optional recursive child deletion.
+    class DestroyService
+      def initialize(creative:, user:, delete_with_children: false)
+        @creative = creative
+        @user = user
+        @delete_with_children = delete_with_children
+      end
+
+      def call
+        if @delete_with_children
+          destroy_descendants_recursively(@creative)
+        else
+          reparent_children
+        end
+
+        CreativeShare.where(creative: @creative).destroy_all
+        @creative.destroy
+      end
+
+      private
+
+      def reparent_children
+        parent = @creative.parent
+        @creative.children.each { |child| child.update(parent: parent) }
+      end
+
+      def destroy_descendants_recursively(creative)
+        deletable_children = creative.children_with_permission(@user, :admin)
+        deletable_children.each do |child|
+          destroy_descendants_recursively(child)
+          CreativeShare.where(creative: child).destroy_all
+          child.destroy
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Extract creation and destruction logic from `CreativesController` (543 → 503 lines).

## New Services

### `Creatives::CreateService`
Handles the full creative creation workflow:
- Create with parent assignment
- Child reparenting (`child_id`)
- Position insertion (`before_id` / `after_id`) with sibling resequencing
- Tag application
- Returns a `Result` struct with `success?`, `creative`, `errors`

### `Creatives::DestroyService`
Handles creative destruction:
- Optional recursive descendant deletion (permission-aware)
- Child reparenting when not deleting children
- Share cleanup

## Testing

- All 17 existing `CreativesControllerTest` pass (1 pre-existing asset error unrelated to changes)
- Rubocop clean