### PR TITLE
fix: apply i18n to mcp_command error message

### DIFF
--- a/engines/collavre/app/services/collavre/comments/mcp_command.rb
+++ b/engines/collavre/app/services/collavre/comments/mcp_command.rb
@@ -79,8 +79,7 @@ module Collavre
       end
 
       def format_response(response)
-        # TODO: i18n text
-        return "Error running /#{tool_name}: #{response[:error]}" if response[:error].present?
+        return I18n.t("collavre.comments.mcp_command.error_running", tool_name: tool_name, error: response[:error]) if response[:error].present?
 
         result = response[:result]
         content = case result

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -90,6 +90,8 @@ en:
         event_created: 'event created: [Google Calendar event](%{url})'
         event_created_local: 'event created (local only - connect Google Calendar to sync)'
         event_created_sync_failed: 'event created (Google Calendar sync failed - please reconnect your Google account)'
+      mcp_command:
+        error_running: "Error running /%{tool_name}: %{error}"
       topic_command:
         missing_name: 'Please specify a topic name in quotes: /topic "topic name"'
         created: 'Topic "%{name}" created.'

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -87,6 +87,8 @@ ko:
         event_created: '이벤트가 생성되었습니다: [구글 캘린더 이벤트](%{url})'
         event_created_local: '이벤트가 생성되었습니다 (로컬 전용 - 구글 캘린더 연동 시 동기화됩니다)'
         event_created_sync_failed: '이벤트가 생성되었습니다 (구글 캘린더 동기화 실패 - 구글 계정을 다시 연동해주세요)'
+      mcp_command:
+        error_running: "/%{tool_name} 실행 오류: %{error}"
       topic_command:
         missing_name: '토픽 이름을 따옴표로 지정하세요: /topic "토픽 이름"'
         created: '토픽 "%{name}"이(가) 생성되었습니다.'


### PR DESCRIPTION
Replace hardcoded error string in MCP command response with I18n.t for en/ko locales.

Resolves TODO in comments/mcp_command.rb:82