### PR TITLE
fix: support mid-text @mentions for A2A agent routing

### DIFF
--- a/engines/collavre/app/services/collavre/ai_agent_service.rb
+++ b/engines/collavre/app/services/collavre/ai_agent_service.rb
@@ -198,16 +198,20 @@ module Collavre
     def dispatch_a2a_if_needed
       return unless @reply_comment&.content.present?
 
-      mentioned_user = MentionParser.resolve_user(@reply_comment.content)
-      return unless mentioned_user&.ai_user?
+      # Find all mentioned AI agents anywhere in the response (not just at the start)
+      mentioned_agents = MentionParser.resolve_all_users(@reply_comment.content).select(&:ai_user?)
+      return if mentioned_agents.empty?
 
       creative = @reply_comment.creative
 
-      if creative
-        context = { "creative" => { "id" => creative.id }, "topic" => { "id" => @reply_comment.topic_id } }
-        Orchestration::LoopBreaker.new(context).record_interaction(@agent.id, mentioned_user.id, creative.id)
+      mentioned_agents.each do |mentioned_user|
+        if creative
+          context = { "creative" => { "id" => creative.id }, "topic" => { "id" => @reply_comment.topic_id } }
+          Orchestration::LoopBreaker.new(context).record_interaction(@agent.id, mentioned_user.id, creative.id)
+        end
       end
 
+      # Dispatch event — downstream Matcher will route to the correct agent(s)
       SystemEvents::Dispatcher.dispatch("comment_created", {
         comment: { id: @reply_comment.id, content: @reply_comment.content, user_id: @reply_comment.user_id },
         creative: { id: creative&.id, description: creative&.description },

--- a/engines/collavre/app/services/collavre/comments/mcp_command.rb
+++ b/engines/collavre/app/services/collavre/comments/mcp_command.rb
@@ -79,8 +79,7 @@ module Collavre
       end
 
       def format_response(response)
-        # TODO: i18n text
-        return "Error running /#{tool_name}: #{response[:error]}" if response[:error].present?
+        return I18n.t("collavre.comments.mcp_command.error_running", tool_name: tool_name, error: response[:error]) if response[:error].present?
 
         result = response[:result]
         content = case result

--- a/engines/collavre/app/services/collavre/mention_parser.rb
+++ b/engines/collavre/app/services/collavre/mention_parser.rb
@@ -12,7 +12,7 @@ module Collavre
     MENTION_LOOSE_PATTERN = /\A@(\S+)\s+/
 
     # Scan pattern: finds all @name: mentions anywhere in text
-    MENTION_SCAN_PATTERN = /(?:^|\s)@([^:]+?):/
+    MENTION_SCAN_PATTERN = /(?:^|(?<=\s))@([^:]+?):/
 
     # Extract the first mentioned name from text (returns nil if no mention found)
     def self.extract_name(text)

--- a/engines/collavre/app/services/collavre/mention_parser.rb
+++ b/engines/collavre/app/services/collavre/mention_parser.rb
@@ -4,17 +4,29 @@ module Collavre
   # to the mention format only need to be made in one place.
   module MentionParser
     # Canonical mention: @name: (with colon separator)
-    MENTION_PATTERN = /\A@([^:]+?):\s*/
+    # Matches at start of text or after whitespace/newline
+    MENTION_PATTERN = /(?:\A|(?<=\s))@([^:]+?):\s*/
 
-    # Mention without colon: @name followed by whitespace
+    # Mention without colon: @name followed by whitespace (start-of-text only
+    # to avoid false positives like email addresses)
     MENTION_LOOSE_PATTERN = /\A@(\S+)\s+/
 
-    # Extract the mentioned name from text (returns nil if no mention found)
+    # Scan pattern: finds all @name: mentions anywhere in text
+    MENTION_SCAN_PATTERN = /(?:^|\s)@([^:]+?):/
+
+    # Extract the first mentioned name from text (returns nil if no mention found)
     def self.extract_name(text)
       return nil if text.blank?
 
       match = text.match(MENTION_PATTERN) || text.match(MENTION_LOOSE_PATTERN)
       match ? match[1].strip : nil
+    end
+
+    # Extract all mentioned names from text
+    def self.extract_all_names(text)
+      return [] if text.blank?
+
+      text.scan(MENTION_SCAN_PATTERN).flatten.map(&:strip).uniq
     end
 
     # Find a User by case-insensitive name match
@@ -28,6 +40,11 @@ module Collavre
     def self.resolve_user(text)
       name = extract_name(text)
       name ? find_user_by_name(name) : nil
+    end
+
+    # Resolve all mentioned users from text (finds mentions anywhere)
+    def self.resolve_all_users(text)
+      extract_all_names(text).filter_map { |name| find_user_by_name(name) }.uniq
     end
 
     # Strip self-mention prefix from text (both @name: and @name formats)

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -90,6 +90,8 @@ en:
         event_created: 'event created: [Google Calendar event](%{url})'
         event_created_local: 'event created (local only - connect Google Calendar to sync)'
         event_created_sync_failed: 'event created (Google Calendar sync failed - please reconnect your Google account)'
+      mcp_command:
+        error_running: "Error running /%{tool_name}: %{error}"
       topic_command:
         missing_name: 'Please specify a topic name in quotes: /topic "topic name"'
         created: 'Topic "%{name}" created.'

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -87,6 +87,8 @@ ko:
         event_created: '이벤트가 생성되었습니다: [구글 캘린더 이벤트](%{url})'
         event_created_local: '이벤트가 생성되었습니다 (로컬 전용 - 구글 캘린더 연동 시 동기화됩니다)'
         event_created_sync_failed: '이벤트가 생성되었습니다 (구글 캘린더 동기화 실패 - 구글 계정을 다시 연동해주세요)'
+      mcp_command:
+        error_running: "/%{tool_name} 실행 오류: %{error}"
       topic_command:
         missing_name: '토픽 이름을 따옴표로 지정하세요: /topic "토픽 이름"'
         created: '토픽 "%{name}"이(가) 생성되었습니다.'


### PR DESCRIPTION
## Problem
`MentionParser` only matched `@AgentName:` at the **start** of text (`\A` anchor). When an AI agent mentioned another agent mid-sentence, the A2A routing was silently skipped.

## Changes

### MentionParser
- `MENTION_PATTERN`: `\A` → `(?:\A|(?<=\s))` — matches at start or after whitespace
- Added `MENTION_SCAN_PATTERN` for scanning all mentions in text
- Added `extract_all_names(text)` — returns all mentioned names
- Added `resolve_all_users(text)` — resolves all mentioned users

### AiAgentService
- `dispatch_a2a_if_needed` now finds **all** mentioned AI agents (not just the first)
- Records loop-breaker interactions for each mentioned agent
- Single `comment_created` event dispatched (downstream Matcher handles routing)