### PR TITLE
fix: align radio/checkbox with text in GitHub integration modal

### DIFF
--- a/app/javascript/github_integration.js
+++ b/app/javascript/github_integration.js
@@ -286,8 +286,11 @@ if (!githubIntegrationInitialized) {
       }
       organizations.forEach(function (org) {
         const label = document.createElement('label');
-        label.style.display = 'block';
+        label.style.display = 'flex';
+        label.style.alignItems = 'center';
+        label.style.gap = '0.5em';
         label.style.marginBottom = '0.5em';
+        label.style.cursor = 'pointer';
 
         const input = document.createElement('input');
         input.type = 'radio';
@@ -303,7 +306,6 @@ if (!githubIntegrationInitialized) {
         span.textContent = org.name || org.login;
 
         label.appendChild(input);
-        label.appendChild(document.createTextNode(' '));
         label.appendChild(span);
         orgList.appendChild(label);
       });
@@ -340,8 +342,11 @@ if (!githubIntegrationInitialized) {
       }
       repositories.forEach(function (repo) {
         const label = document.createElement('label');
-        label.style.display = 'block';
+        label.style.display = 'flex';
+        label.style.alignItems = 'center';
+        label.style.gap = '0.5em';
         label.style.marginBottom = '0.5em';
+        label.style.cursor = 'pointer';
 
         const input = document.createElement('input');
         input.type = 'checkbox';
@@ -359,7 +364,6 @@ if (!githubIntegrationInitialized) {
         span.textContent = repo.full_name;
 
         label.appendChild(input);
-        label.appendChild(document.createTextNode(' '));
         label.appendChild(span);
         repoList.appendChild(label);
       });

--- a/app/javascript/github_integration.js
+++ b/app/javascript/github_integration.js
@@ -297,6 +297,8 @@ if (!githubIntegrationInitialized) {
         input.name = 'github-organization';
         input.value = org.login;
         input.checked = selectedOrg === org.login;
+        input.style.flexShrink = '0';
+        input.style.margin = '0';
         input.addEventListener('change', function () {
           selectedOrg = org.login;
           nextBtn.disabled = false;

--- a/engines/collavre/app/assets/stylesheets/collavre/popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/popup.css
@@ -71,7 +71,7 @@
   font-size: 1.1em;
 }
 
-.popup-box input,
+.popup-box input:not([type="radio"]):not([type="checkbox"]),
 .popup-box select {
   width: 100%;
   box-sizing: border-box;


### PR DESCRIPTION
## Problem
Radio buttons (organization list) and checkboxes (repository list) in the GitHub integration modal were vertically misaligned with their text labels.

## Changes
- Changed label `display: block` → `display: flex; align-items: center; gap: 0.5em` for both organization radio buttons and repository checkboxes
- Added `cursor: pointer` for better UX
- Removed unnecessary text nodes (space characters) since `gap` handles spacing

## Affected views
- Organization selection step (radio buttons)
- Repository selection step (checkboxes)

Consistent with the existing connected-repo list which already uses flex alignment.