### PR TITLE
fix: add confidence format instruction when self-reflection is enabled

### DIFF
--- a/engines/collavre/app/services/collavre/orchestration/agent_context_builder.rb
+++ b/engines/collavre/app/services/collavre/orchestration/agent_context_builder.rb
@@ -104,6 +104,9 @@ module Collavre
         sections << I18n.t("collavre.ai_agent.collaboration.rules_header")
         sections << (collab["mention_rule"] || I18n.t("collavre.ai_agent.collaboration.mention_rule"))
         sections << (collab["confidence_rule"] || I18n.t("collavre.ai_agent.collaboration.confidence_rule"))
+        if @policy_resolver&.self_reflection_enabled?
+          sections << I18n.t("collavre.ai_agent.collaboration.confidence_format_instruction")
+        end
         sections << (collab["escalation_rule"] || I18n.t("collavre.ai_agent.collaboration.escalation_rule"))
         sections << (collab["review_rule"] || I18n.t("collavre.ai_agent.collaboration.review_rule"))
         sections << ""

--- a/engines/collavre/config/locales/ai_agent.en.yml
+++ b/engines/collavre/config/locales/ai_agent.en.yml
@@ -34,5 +34,6 @@ en:
         rules_header: "## Collaboration Rules"
         mention_rule: "- Call other agents: @name: request"
         confidence_rule: "- Re-evaluate before responding if uncertain"
+        confidence_format_instruction: "- End your response with [confidence: 0-100] to indicate your certainty level (e.g. [confidence: 85])"
         escalation_rule: "- Ask escalation targets for help when stuck"
         review_rule: "- Request review from reviewers when code review is needed"

--- a/engines/collavre/config/locales/ai_agent.ko.yml
+++ b/engines/collavre/config/locales/ai_agent.ko.yml
@@ -34,5 +34,6 @@ ko:
         rules_header: "## 협업 규칙"
         mention_rule: "- 다른 Agent 호출: @이름: 요청내용"
         confidence_rule: "- 확신이 낮으면 재검토 후 발화"
+        confidence_format_instruction: "- 응답 끝에 [confidence: 0-100] 형식으로 확신도를 명시하세요 (예: [confidence: 85])"
         escalation_rule: "- 막히면 에스컬레이션 대상에게 도움 요청"
         review_rule: "- 코드 리뷰가 필요하면 리뷰어에게 요청"

--- a/engines/collavre/test/services/collavre/orchestration/agent_context_builder_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/agent_context_builder_test.rb
@@ -470,6 +470,7 @@ module Collavre
       def mock_policy_resolver(overrides = {})
         resolver = Minitest::Mock.new
         resolver.expect(:collaboration_config, overrides)
+        resolver.expect(:self_reflection_enabled?, false)
         resolver
       end
     end


### PR DESCRIPTION
## Problem
Self-reflection feature was not working because agents never included `[confidence: N]` in responses. SelfReflectionEvaluator always returned :done with reason no_signal.

## Root Cause
confidence_rule locale only says 'Re-evaluate before responding if uncertain' — never tells agent to output `[confidence: 0-100]` format.

## Changes
- Added confidence_format_instruction i18n key (en/ko)
- AgentContextBuilder conditionally adds instruction when self_reflection_enabled
- Updated test mock