### PR TITLE
fix: restrict creative progress updates to 100% on leaf nodes only

### DIFF
--- a/engines/collavre/app/services/collavre/tools/creative_batch_service.rb
+++ b/engines/collavre/app/services/collavre/tools/creative_batch_service.rb
@@ -19,7 +19,7 @@ module Collavre
 
       tool_param :operations, description: "Array of operation objects. Each object must have an 'action' key.\n\n" \
                  "For 'create': { action: 'create', parent_id: <int>, description: <string>, progress: <float>, after_id: <int>, before_id: <int> }\n" \
-                 "For 'update': { action: 'update', id: <int>, description: <string>, progress: <float>, parent_id: <int> }\n" \
+                 "For 'update': { action: 'update', id: <int>, description: <string>, progress: 1.0, parent_id: <int> } — progress only accepts 1.0 (complete) and only on leaf Creatives\n" \
                  "For 'delete': { action: 'delete', id: <int> }\n\n" \
                  "Fields other than 'action' and 'id'/'parent_id' are optional.", required: true
 

--- a/engines/collavre/app/services/collavre/tools/creative_update_service.rb
+++ b/engines/collavre/app/services/collavre/tools/creative_update_service.rb
@@ -7,11 +7,11 @@ module Tools
     extend ToolMeta
 
     tool_name "creative_update_service"
-    tool_description "Update an existing Creative's content, progress, or parent. Use this to:\n- Modify the description/title of a Creative\n- Update progress (0.0 to 1.0, where 1.0 = complete)\n- Move a Creative to a different parent\n\nNote: Setting progress to 1.0 on a parent will also complete all descendants."
+    tool_description "Update an existing Creative's content, progress, or parent. Use this to:\n- Modify the description/title of a Creative\n- Mark a leaf Creative as complete (progress = 1.0)\n- Move a Creative to a different parent\n\nProgress constraints:\n- Only 1.0 (100%) is allowed — partial progress updates are not supported\n- Only leaf Creatives (with no children) can have their progress updated\n- Parent Creative progress is automatically calculated from children\n\nUse creative_retrieval_service to find the correct Creative before updating."
 
     tool_param :id, description: "The ID of the Creative to update.", required: true
     tool_param :description, description: "New content/title for the Creative. Accepts HTML format. If omitted, description remains unchanged.", required: false
-    tool_param :progress, description: "New progress value (0.0 to 1.0). Setting to 1.0 marks as complete.", required: false
+    tool_param :progress, description: "Set to 1.0 to mark a leaf Creative as complete. Only 1.0 is allowed; partial progress and updates on parent Creatives are rejected.", required: false
     tool_param :parent_id, description: "New parent Creative ID to move this Creative under. Use null/0 to make it a root Creative.", required: false
 
     sig { params(id: Integer, description: T.nilable(String), progress: T.nilable(Float), parent_id: T.nilable(Integer)).returns(T::Hash[Symbol, T.untyped]) }
@@ -29,7 +29,6 @@ module Tools
 
       # Get the effective origin for updating content
       base = creative.effective_origin
-      previous_progress = base.progress
 
       updates = {}
       parent_updates = {}
@@ -41,7 +40,19 @@ module Tools
 
       # Handle progress update
       if progress.present?
-        updates[:progress] = progress.to_f.clamp(0.0, 1.0)
+        progress_value = progress.to_f.clamp(0.0, 1.0)
+
+        # Only 100% (1.0) progress updates are allowed via tools
+        unless progress_value == 1.0
+          return { error: "Only progress of 1.0 (100%) is allowed. Partial progress updates are not supported.", id: id }
+        end
+
+        # Only leaf creatives (no children) can have progress updated directly
+        if base.children.exists?
+          return { error: "Cannot update progress on a parent Creative. Only leaf Creatives (with no children) can be marked complete.", id: id }
+        end
+
+        updates[:progress] = progress_value
       end
 
       # Handle parent change (on the creative itself, not base)
@@ -77,14 +88,8 @@ module Tools
       if updates.present?
         success &&= base.update(updates)
 
-        # If progress set to 1.0 and has children, complete all descendants
-        requested_progress = updates[:progress]
-        if success && requested_progress.present? && requested_progress >= 1 && previous_progress.to_f < 1
-          if base.children.exists?
-            base.self_and_descendants.where(origin_id: nil)
-              .update_all(progress: 1.0, updated_at: Time.current)
-          end
-        end
+        # Note: progress updates are only allowed on leaf Creatives (validated above).
+        # Parent progress is automatically calculated from children.
       end
 
       if success

--- a/engines/collavre/test/services/tools/creative_update_service_test.rb
+++ b/engines/collavre/test/services/tools/creative_update_service_test.rb
@@ -43,7 +43,20 @@ module Collavre
         assert_equal "<p>Plain text update</p>", @creative.description
       end
 
-      test "updates progress" do
+      test "updates progress to 1.0 on leaf creative" do
+        service = CreativeUpdateService.new
+
+        result = service.call(
+          id: @creative.id,
+          progress: 1.0
+        )
+
+        assert result[:success]
+        @creative.reload
+        assert_in_delta 1.0, @creative.progress, 0.01
+      end
+
+      test "rejects partial progress update" do
         service = CreativeUpdateService.new
 
         result = service.call(
@@ -51,22 +64,28 @@ module Collavre
           progress: 0.75
         )
 
-        assert result[:success]
+        assert result[:error].present?
+        assert_match(/only progress of 1.0/i, result[:error])
         @creative.reload
-        assert_in_delta 0.75, @creative.progress, 0.01
+        assert_in_delta 0.0, @creative.progress, 0.01
       end
 
-      test "clamps progress to valid range" do
+      test "rejects progress update on parent creative" do
+        child = Creative.create!(
+          description: "<p>Child</p>",
+          user: @user,
+          parent: @creative
+        )
+
         service = CreativeUpdateService.new
 
         result = service.call(
           id: @creative.id,
-          progress: 1.5
+          progress: 1.0
         )
 
-        assert result[:success]
-        @creative.reload
-        assert_in_delta 1.0, @creative.progress, 0.01
+        assert result[:error].present?
+        assert_match(/leaf/i, result[:error])
       end
 
       test "updates parent_id" do

--- a/engines/collavre_github/db/seeds.rb
+++ b/engines/collavre_github/db/seeds.rb
@@ -49,6 +49,12 @@ module CollavreGithub
       - Provide a brief summary of your analysis before calling the tool
       - If no task updates are needed, just provide your analysis summary without calling any tool
       - The batch tool requires approval — a human will review and approve your changes before they are applied
+
+      ## Progress Update Rules:
+      - You can ONLY set progress to 1.0 (100% complete) — partial progress values are NOT allowed
+      - You can ONLY update progress on LEAF Creatives (Creatives with no children)
+      - Parent Creative progress is automatically calculated from their children — never try to update it directly
+      - Use `creative_retrieval_service` to navigate the tree and find the correct leaf Creative before updating
     PROMPT
 
     # Matches GitHub PR merged events


### PR DESCRIPTION
## Summary
Restrict progress updates via tool services to enforce two constraints:

1. **Only 100% (1.0) progress is allowed** — partial progress updates are rejected
2. **Only leaf Creatives (no children) can have progress updated** — parent progress is automatically calculated from children

## Changes

### `CreativeUpdateService`
- Added validation: rejects progress values other than 1.0
- Added validation: rejects progress updates on Creatives with children
- Removed dead cascade code (force-completing all descendants) since parent updates are now blocked
- Updated tool description and parameter docs to reflect constraints

### `CreativeBatchService`
- Updated operation description to document the leaf-only, 100%-only constraint

### GitHub PR Analyzer (seeds)
- Added `Progress Update Rules` section to system prompt
- Instructs agent to only mark leaf Creatives as complete
- Emphasizes using `creative_retrieval_service` to find correct leaf nodes

### Tests
- Updated `creative_update_service_test.rb`: replaced partial progress tests with constraint validation tests
- Added test for rejecting progress on parent Creative
- Added test for rejecting partial (non-1.0) progress