### PR TITLE
feat: include sender name in A2A completion instruction for reliable report-back chain

### DIFF
--- a/engines/collavre/app/services/collavre/orchestration/agent_context_builder.rb
+++ b/engines/collavre/app/services/collavre/orchestration/agent_context_builder.rb
@@ -55,8 +55,15 @@ module Collavre
           sections << I18n.t("collavre.ai_agent.a2a.request_description",
                              sender_name: @sender["name"], sender_type: @sender["type"])
           sections << (collab["a2a_focus_instruction"] || I18n.t("collavre.ai_agent.a2a.focus_instruction"))
-          sections << (collab["a2a_completion_instruction"] || I18n.t("collavre.ai_agent.a2a.completion_instruction"))
+          sections << (collab["a2a_completion_instruction"] ||
+                       I18n.t("collavre.ai_agent.a2a.completion_instruction",
+                              sender_name: @sender["name"]))
           sections << (collab["a2a_followup_instruction"] || I18n.t("collavre.ai_agent.a2a.followup_instruction"))
+          sections << ""
+        elsif @sender
+          # Human-triggered request: instruct agent to report back
+          sections << I18n.t("collavre.ai_agent.a2a.human_completion_instruction",
+                             sender_name: @sender["name"])
           sections << ""
         end
 

--- a/engines/collavre/config/locales/ai_agent.en.yml
+++ b/engines/collavre/config/locales/ai_agent.en.yml
@@ -21,9 +21,9 @@ en:
         request_header: "## ⚡ Agent Request"
         request_description: "This message is a request from another AI Agent (@%{sender_name}, %{sender_type})."
         focus_instruction: "- Focus on answering the request"
-        completion_instruction: "- When done, you MUST report results back to @%{sender_name} via mention"
+        completion_instruction: "- When done, you MUST report results back to @%{sender_name}: via mention"
         followup_instruction: "- If you need more information, ask the requester via @mention"
-        human_completion_instruction: "- When done, report your results back to @%{sender_name} via mention"
+        human_completion_instruction: "- When done, report your results back to @%{sender_name}: via mention"
       review:
         context: "The user is reviewing your previous message and requesting changes. Your response will REPLACE the original message entirely. You MUST provide the complete response — never abbreviate, skip, or summarize any part (e.g., do NOT write 'items 2-5 remain the same'). Write the full content from start to finish as if the original never existed."
       collaboration:

--- a/engines/collavre/config/locales/ai_agent.en.yml
+++ b/engines/collavre/config/locales/ai_agent.en.yml
@@ -21,8 +21,9 @@ en:
         request_header: "## ⚡ Agent Request"
         request_description: "This message is a request from another AI Agent (@%{sender_name}, %{sender_type})."
         focus_instruction: "- Focus on answering the request"
-        completion_instruction: "- When done, report results to the requester via @name: mention"
+        completion_instruction: "- When done, you MUST report results back to @%{sender_name} via mention"
         followup_instruction: "- If you need more information, ask the requester via @mention"
+        human_completion_instruction: "- When done, report your results back to @%{sender_name} via mention"
       review:
         context: "The user is reviewing your previous message and requesting changes. Your response will REPLACE the original message entirely. You MUST provide the complete response — never abbreviate, skip, or summarize any part (e.g., do NOT write 'items 2-5 remain the same'). Write the full content from start to finish as if the original never existed."
       collaboration:

--- a/engines/collavre/config/locales/ai_agent.ko.yml
+++ b/engines/collavre/config/locales/ai_agent.ko.yml
@@ -21,8 +21,9 @@ ko:
         request_header: "## ⚡ Agent 요청"
         request_description: "이 메시지는 다른 AI Agent(@%{sender_name}, %{sender_type})가 보낸 요청입니다."
         focus_instruction: "- 요청에 집중해서 답변하세요"
-        completion_instruction: "- 완료되면 요청자에게 @이름: 멘션으로 결과를 보고하세요"
+        completion_instruction: "- 완료되면 반드시 @%{sender_name}에게 멘션으로 결과를 보고하세요"
         followup_instruction: "- 추가 정보가 필요하면 요청자에게 @멘션으로 물어보세요"
+        human_completion_instruction: "- 완료되면 @%{sender_name}에게 멘션으로 결과를 보고하세요"
       review:
         context: "사용자가 당신의 이전 메시지를 리뷰하고 변경을 요청하고 있습니다. 당신의 응답이 원본 메시지를 완전히 대체됩니다. 반드시 전체 응답을 빠짐없이 작성하세요 — 절대로 일부를 생략하거나 요약하지 마세요 (예: '2~5번은 이전과 동일' 같은 표현 금지). 원본이 없다고 생각하고 처음부터 끝까지 완전한 내용을 작성하세요."
       collaboration:

--- a/engines/collavre/config/locales/ai_agent.ko.yml
+++ b/engines/collavre/config/locales/ai_agent.ko.yml
@@ -21,9 +21,9 @@ ko:
         request_header: "## ⚡ Agent 요청"
         request_description: "이 메시지는 다른 AI Agent(@%{sender_name}, %{sender_type})가 보낸 요청입니다."
         focus_instruction: "- 요청에 집중해서 답변하세요"
-        completion_instruction: "- 완료되면 반드시 @%{sender_name}에게 멘션으로 결과를 보고하세요"
+        completion_instruction: "- 완료되면 반드시 @%{sender_name}: 멘션으로 결과를 보고하세요"
         followup_instruction: "- 추가 정보가 필요하면 요청자에게 @멘션으로 물어보세요"
-        human_completion_instruction: "- 완료되면 @%{sender_name}에게 멘션으로 결과를 보고하세요"
+        human_completion_instruction: "- 완료되면 @%{sender_name}: 멘션으로 결과를 보고하세요"
       review:
         context: "사용자가 당신의 이전 메시지를 리뷰하고 변경을 요청하고 있습니다. 당신의 응답이 원본 메시지를 완전히 대체됩니다. 반드시 전체 응답을 빠짐없이 작성하세요 — 절대로 일부를 생략하거나 요약하지 마세요 (예: '2~5번은 이전과 동일' 같은 표현 금지). 원본이 없다고 생각하고 처음부터 끝까지 완전한 내용을 작성하세요."
       collaboration:

--- a/engines/collavre/test/services/collavre/orchestration/agent_context_builder_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/agent_context_builder_test.rb
@@ -348,7 +348,7 @@ module Collavre
         assert_includes prompt, I18n.t("collavre.ai_agent.collaboration.header")
       end
 
-      test "collaboration prompt excludes A2A context when sender is human" do
+      test "collaboration prompt excludes A2A context but includes human completion instruction when sender is human" do
         Collavre::CreativeShare.create!(
           creative: @creative,
           user: @pm_agent,
@@ -366,6 +366,7 @@ module Collavre
         prompt = builder.to_collaboration_prompt
 
         assert_not_includes prompt, I18n.t("collavre.ai_agent.a2a.request_header")
+        assert_includes prompt, "@#{@human_user.name}"
         assert_includes prompt, I18n.t("collavre.ai_agent.collaboration.header")
       end
 
@@ -461,8 +462,47 @@ module Collavre
         )
         prompt = builder.to_collaboration_prompt
 
-        assert_includes prompt, I18n.t("collavre.ai_agent.a2a.completion_instruction")
+        assert_includes prompt, I18n.t("collavre.ai_agent.a2a.completion_instruction",
+                                       sender_name: "qa-agent")
         assert_includes prompt, I18n.t("collavre.ai_agent.collaboration.mention_rule")
+      end
+
+      test "A2A completion instruction includes sender name" do
+        sender = {
+          "id" => @qa_agent.id,
+          "name" => "qa-agent",
+          "is_ai" => true,
+          "type" => "qa"
+        }
+
+        builder = AgentContextBuilder.new(agent: @ai_agent, creative: @creative, sender: sender)
+        prompt = builder.to_collaboration_prompt
+
+        assert_includes prompt, "@qa-agent"
+        assert_includes prompt, I18n.t("collavre.ai_agent.a2a.completion_instruction",
+                                       sender_name: "qa-agent")
+      end
+
+      test "human sender gets completion instruction with their name" do
+        Collavre::CreativeShare.create!(
+          creative: @creative,
+          user: @pm_agent,
+          permission: :admin
+        )
+
+        sender = {
+          "id" => @human_user.id,
+          "name" => "John",
+          "is_ai" => false,
+          "type" => "human"
+        }
+
+        builder = AgentContextBuilder.new(agent: @ai_agent, creative: @creative, sender: sender)
+        prompt = builder.to_collaboration_prompt
+
+        assert_includes prompt, "@John"
+        assert_includes prompt, I18n.t("collavre.ai_agent.a2a.human_completion_instruction",
+                                       sender_name: "John")
       end
 
       private


### PR DESCRIPTION
## Summary

When AI agents are triggered via mention (by another agent or human), the completion instruction now includes the **exact sender name** so agents know precisely who to report back to.

### Problem
- The A2A completion instruction said generic "report to requester via @name: mention"
- Agents didn't know the specific name of who called them, making report-back unreliable
- Human-triggered requests had no completion instruction at all

### Changes
- **A2A completion instruction**: Now interpolates `sender_name` (e.g., "report results back to @qa-agent")
- **Human completion instruction**: New instruction added for human→agent requests (e.g., "report results back to @John")
- **i18n**: Updated both en and ko locale files with `%{sender_name}` interpolation
- **Tests**: Added 3 new tests for sender name interpolation in A2A and human contexts

### How it works
```
User @mentions Agent A → Agent A gets: "report back to @User"
Agent A @mentions Agent B → Agent B gets: "report back to @Agent A"
Agent B finishes → reports to @Agent A → Agent A reports to @User
```

This creates a reliable report-back chain from leaf agents all the way back to the original requester.