### PR TITLE
fix: stabilize flaky CreativeBatchServiceTest

### DIFF
--- a/engines/collavre/test/services/tools/creative_batch_service_test.rb
+++ b/engines/collavre/test/services/tools/creative_batch_service_test.rb
@@ -6,9 +6,13 @@ module Collavre
   module Tools
     class CreativeBatchServiceTest < ActiveSupport::TestCase
       setup do
-        @user = User.create!(name: "Batch Test", email: "batch_test@example.com", password: "password123")
+        @user = User.create!(name: "Batch Test", email: "batch_test_#{SecureRandom.hex(4)}@example.com", password: "password123")
         Current.user = @user
         @root = Creative.create!(description: "<p>Root</p>", user: @user, progress: 0)
+        # Ensure permission cache is populated for the owner
+        CreativeSharesCache.find_or_create_by!(creative: @root, user: @user) do |cache|
+          cache.permission = :admin
+        end
       end
 
       teardown do


### PR DESCRIPTION
## Problem
`CreativeBatchServiceTest` was flaky — `test_updates_a_creative_via_batch` and `test_mixed_operations_in_a_single_batch` intermittently failed with `Expected false to be truthy`.

## Root Cause
The `Creative.create!` triggers `cache_owner_permission` via `after_commit` callback, which enqueues `PermissionCacheJob`. Under parallel test execution, the permission cache (`CreativeSharesCache`) may not be populated before `CreativeUpdateService` checks `has_permission?`, causing the update to return `{error: 'No write permission'}` instead of success.

## Fix
Explicitly create the `CreativeSharesCache` entry in test setup, ensuring the owner always has admin permission regardless of job execution timing.

Ran 5 consecutive executions with 0 failures after the fix.