### PR TITLE
fix: allow mentions after punctuation in MentionParser

### DIFF
--- a/engines/collavre/app/services/collavre/mention_parser.rb
+++ b/engines/collavre/app/services/collavre/mention_parser.rb
@@ -3,16 +3,19 @@ module Collavre
   # All @mention logic should go through this module so changes
   # to the mention format only need to be made in one place.
   module MentionParser
+    # Characters allowed before @ in mentions (besides start-of-text)
+    MENTION_PREFIX_CHARS = /[\s:.,;\n\r]/
+
     # Canonical mention: @name: (with colon separator)
-    # Matches at start of text or after whitespace/newline
-    MENTION_PATTERN = /(?:\A|(?<=\s))@([^:]+?):\s*/
+    # Matches at start of text or after whitespace/punctuation/newline
+    MENTION_PATTERN = /(?:\A|(?<=#{MENTION_PREFIX_CHARS}))@([^:]+?):\s*/
 
     # Mention without colon: @name followed by whitespace (start-of-text only
     # to avoid false positives like email addresses)
     MENTION_LOOSE_PATTERN = /\A@(\S+)\s+/
 
     # Scan pattern: finds all @name: mentions anywhere in text
-    MENTION_SCAN_PATTERN = /(?:^|(?<=\s))@([^:]+?):/
+    MENTION_SCAN_PATTERN = /(?:^|(?<=#{MENTION_PREFIX_CHARS}))@([^:]+?):/
 
     # Extract the first mentioned name from text (returns nil if no mention found)
     def self.extract_name(text)

--- a/engines/collavre/test/services/collavre/mention_parser_test.rb
+++ b/engines/collavre/test/services/collavre/mention_parser_test.rb
@@ -68,5 +68,39 @@ module Collavre
       assert_nil MentionParser.strip_self_mention(nil, "Bot")
       assert_equal "@Bot: hello", MentionParser.strip_self_mention("@Bot: hello", nil)
     end
+
+    # Lenient prefix character tests
+    test "extract_name after colon" do
+      assert_equal "AgentB", MentionParser.extract_name("결과:@AgentB: 완료")
+    end
+
+    test "extract_name after period" do
+      assert_equal "AgentB", MentionParser.extract_name("done.@AgentB: check")
+    end
+
+    test "extract_name after comma" do
+      assert_equal "AgentB", MentionParser.extract_name("ok,@AgentB: check")
+    end
+
+    test "extract_name after semicolon" do
+      assert_equal "AgentB", MentionParser.extract_name("ok;@AgentB: check")
+    end
+
+    test "extract_name after newline" do
+      assert_equal "AgentB", MentionParser.extract_name("line1\n@AgentB: check")
+    end
+
+    test "extract_all_names finds mentions after punctuation" do
+      text = "결과:@Agent1: 완료,@Agent2: 확인.@Agent3: 검토"
+      names = MentionParser.extract_all_names(text)
+      assert_includes names, "Agent1"
+      assert_includes names, "Agent2"
+      assert_includes names, "Agent3"
+    end
+
+    test "extract_name does not match after alphanumeric" do
+      # email-like patterns should not match
+      assert_nil MentionParser.extract_name("user@agent: test")
+    end
   end
 end


### PR DESCRIPTION
## Problem
`MentionParser` only matched `@name:` mentions when preceded by whitespace or start-of-text. Mentions after punctuation like `결과:@Agent:` or `done.@Agent:` were silently ignored, breaking A2A report-back chains.

## Fix
Extended `MENTION_PATTERN` and `MENTION_SCAN_PATTERN` to also accept `@` after: `:`, `.`, `,`, `;`, `\n`, `\r`

Extracted allowed prefix chars into `MENTION_PREFIX_CHARS` constant for single-source-of-truth.

## Tests Added
- Mention after colon (`결과:@Agent:`)
- Mention after period (`done.@Agent:`)
- Mention after comma (`ok,@Agent:`)
- Mention after semicolon (`ok;@Agent:`)
- Mention after newline
- Multiple mentions with mixed punctuation prefixes
- Email-like pattern does NOT match (`user@agent:` — no prefix char before `@`)