### PR TITLE
fix: update tests broken by landing page layout change

### DIFF
--- a/engines/collavre/test/controllers/locale_test.rb
+++ b/engines/collavre/test/controllers/locale_test.rb
@@ -8,7 +8,7 @@ class LocaleTest < ActionDispatch::IntegrationTest
 
   test "should use user locale for authenticated user on public page" do
     sign_in_as @user, password: "password"
-    get root_path, headers: { "HTTP_ACCEPT_LANGUAGE" => "en" }
+    get collavre.creatives_path, headers: { "HTTP_ACCEPT_LANGUAGE" => "en" }
 
     assert_response :success
     assert_match "하나 이상의 크리에이티브를 선택하세요.", response.body

--- a/engines/collavre/test/integration/engine_override_test.rb
+++ b/engines/collavre/test/integration/engine_override_test.rb
@@ -97,7 +97,11 @@ class EngineOverrideTest < ActionDispatch::IntegrationTest
   end
 
   test "overrides footer partial in layout" do
-    get root_path
+    # Use a page with application layout (which renders shared/_footer)
+    # Landing page uses its own layout without shared/_footer
+    user = users(:one)
+    sign_in_as user
+    get collavre.creatives_path
 
     assert_response :success
     assert_select "#custom-footer", text: "Custom Enterprise Footer"


### PR DESCRIPTION
## Problem
2 tests failing after landing page was changed to use its own layout:

1. **`LocaleTest`**: `root_path` now redirects authenticated users (302) instead of rendering
2. **`EngineOverrideTest`**: Landing layout doesn't render `shared/_footer` partial

## Fix
- `locale_test`: Use `collavre.creatives_path` instead of `root_path`
- `engine_override_test`: Sign in and use `collavre.creatives_path` (application layout renders `shared/_footer`)