### PR TITLE
refactor: remove unused github_gemini_prompt column and UI

### DIFF
--- a/app/javascript/github_integration.js
+++ b/app/javascript/github_integration.js
@@ -20,7 +20,7 @@ if (!githubIntegrationInitialized) {
     const summaryList = document.getElementById('github-selected-repos');
     const summaryEmpty = document.getElementById('github-summary-empty');
     const summaryInstructions = document.getElementById('github-webhook-instructions');
-    const promptInput = document.getElementById('github-gemini-prompt');
+    
     const errorEl = document.getElementById('github-wizard-error');
     const webhookUrlLabel = modal.dataset.webhookUrlLabel || 'Webhook URL';
     const webhookSecretLabel = modal.dataset.webhookSecretLabel || 'Webhook secret';
@@ -40,7 +40,7 @@ if (!githubIntegrationInitialized) {
     let selectedOrg = null;
     let selectedRepos = new Set();
     let webhookDetails = {};
-    let geminiPrompt = '';
+    
     let hasExistingIntegration = false;
     let selectedReposForDeletion = new Set();
 
@@ -54,14 +54,14 @@ if (!githubIntegrationInitialized) {
       selectedOrg = null;
       selectedRepos = new Set();
       webhookDetails = {};
-      geminiPrompt = '';
+      
       hasExistingIntegration = false;
       selectedReposForDeletion = new Set();
       statusEl.textContent = '';
       errorEl.style.display = 'none';
       errorEl.textContent = '';
       if (summaryInstructions) summaryInstructions.style.display = 'none';
-      if (promptInput) promptInput.value = '';
+      
       if (existingContainer) {
         existingContainer.style.display = 'none';
       }
@@ -83,7 +83,7 @@ if (!githubIntegrationInitialized) {
     }
 
     function updateStep() {
-      ['connect', 'organization', 'repositories', 'summary', 'prompt']
+      ['connect', 'organization', 'repositories', 'summary']
         .forEach(function (step) {
           const el = document.getElementById(`github-step-${step}`);
           if (!el) return;
@@ -111,15 +111,9 @@ if (!githubIntegrationInitialized) {
         finishBtn.style.display = 'none';
       } else if (currentStep === 'summary') {
         prevBtn.style.display = 'block';
-        nextBtn.style.display = 'block';
-        nextBtn.disabled = false;
-        finishBtn.style.display = 'none';
-        updateSummary();
-      } else if (currentStep === 'prompt') {
-        prevBtn.style.display = 'block';
         nextBtn.style.display = 'none';
         finishBtn.style.display = 'block';
-        if (promptInput) promptInput.focus();
+        updateSummary();
       }
     }
 
@@ -175,9 +169,9 @@ if (!githubIntegrationInitialized) {
           }
           selectedRepos = new Set(data.selected_repositories || []);
           webhookDetails = data.webhooks || {};
-          geminiPrompt = data.github_gemini_prompt || '';
+          
           hasExistingIntegration = selectedRepos.size > 0;
-          if (promptInput) promptInput.value = geminiPrompt;
+          
           if (loginBtn) loginBtn.style.display = 'none';
           renderExistingConnections(Array.from(selectedRepos));
 
@@ -432,7 +426,7 @@ if (!githubIntegrationInitialized) {
     function saveSelection() {
       clearError();
       const payload = { repositories: Array.from(selectedRepos) };
-      if (promptInput) payload.github_gemini_prompt = promptInput.value;
+      
       fetch(`/github/creatives/${creativeId}/integration`, {
         method: 'PATCH',
         headers: {
@@ -449,8 +443,8 @@ if (!githubIntegrationInitialized) {
           }
           selectedRepos = new Set(result.body.selected_repositories || []);
           webhookDetails = result.body.webhooks || {};
-          geminiPrompt = result.body.github_gemini_prompt || '';
-          if (promptInput) promptInput.value = geminiPrompt;
+          
+          
           updateSummary();
           alert(modal.dataset.successMessage);
         })
@@ -483,8 +477,6 @@ if (!githubIntegrationInitialized) {
         currentStep = 'organization';
       } else if (currentStep === 'summary') {
         currentStep = 'repositories';
-      } else if (currentStep === 'prompt') {
-        currentStep = 'summary';
       }
       updateStep();
       if (currentStep === 'organization' && organizations.length === 0) loadOrganizations();
@@ -504,10 +496,6 @@ if (!githubIntegrationInitialized) {
       } else if (currentStep === 'repositories') {
         currentStep = 'summary';
         updateStep();
-      } else if (currentStep === 'summary') {
-        currentStep = 'prompt';
-        updateStep();
-        if (promptInput) promptInput.focus();
       }
     });
 
@@ -554,9 +542,9 @@ if (!githubIntegrationInitialized) {
 
           selectedRepos = new Set(result.body.selected_repositories || []);
           webhookDetails = result.body.webhooks || {};
-          geminiPrompt = result.body.github_gemini_prompt || '';
+          
           hasExistingIntegration = selectedRepos.size > 0;
-          if (promptInput) promptInput.value = geminiPrompt;
+          
           renderExistingConnections(Array.from(selectedRepos));
           updateSummary();
           statusEl.textContent = deleteSuccess;

--- a/db/migrate/20260219095224_remove_github_gemini_prompt_from_creatives.rb
+++ b/db/migrate/20260219095224_remove_github_gemini_prompt_from_creatives.rb
@@ -1,0 +1,5 @@
+class RemoveGithubGeminiPromptFromCreatives < ActiveRecord::Migration[8.1]
+  def change
+    remove_column :creatives, :github_gemini_prompt, :text
+  end
+end

--- a/engines/collavre/app/models/collavre/creative.rb
+++ b/engines/collavre/app/models/collavre/creative.rb
@@ -12,36 +12,6 @@ module Collavre
 
     after_save :touch_subtree_on_move, if: :saved_change_to_parent_id?
 
-    unless const_defined?(:DEFAULT_GITHUB_GEMINI_PROMPT)
-      DEFAULT_GITHUB_GEMINI_PROMPT = <<~PROMPT.freeze
-        You are reviewing a GitHub pull request and mapping it to Creative tasks.
-        Pull request title: \#{pr_title}
-        Pull request body:
-        \#{pr_body}
-
-        Pull request commit messages:
-        \#{commit_messages}
-
-        Pull request diff:
-        \#{diff}
-
-        Creative tree structure. Each line represents a creative node with indentation indicating depth (4 spaces per level).
-        Format: - {"id": <ID>, "progress": <0.0-1.0>, "desc": "<Description>"}
-        \#{creative_tree}
-
-        \#{language_instructions}
-
-        When describing creatives, write from an end-user perspective similar to a user manual. Avoid unnecessary technical detail, and keep sentences concise.
-
-        Return a JSON object with two keys:
-        - "completed": array of objects representing tasks finished by this PR. Each object must include "creative_id" (from the IDs above). Use only creatives marked [LEAF] in the list above. Optionally include "progress" (0.0 to 1.0), "note", or "path" for context.
-        - "additional": array of objects for new creatives that are not already represented in the tree above. Each object must include "parent_id" (from the IDs above) and "description" (the new creative text). Do not use this list for follow-up tasks on existing creatives—only describe brand new creatives. Optionally include "progress" (0.0 to 1.0), "note", or "path".
-
-        Do not add tasks to "completed" if they already show 100% progress in the tree above unless this PR clearly made new changes that justify marking them complete.
-
-        Use only IDs present in the tree. Respond with valid JSON only.
-      PROMPT
-    end
 
     include Linkable
     include Permissible
@@ -122,9 +92,6 @@ module Collavre
       end
     end
 
-    def github_gemini_prompt_template
-      github_gemini_prompt.presence || DEFAULT_GITHUB_GEMINI_PROMPT
-    end
 
     private
 

--- a/engines/collavre_github/app/controllers/collavre_github/creatives/integrations_controller.rb
+++ b/engines/collavre_github/app/controllers/collavre_github/creatives/integrations_controller.rb
@@ -23,8 +23,7 @@ module CollavreGithub
           },
           selected_repositories: links.map(&:repository_full_name),
           all_repositories: all_repositories,
-          webhooks: serialize_webhooks(links),
-          github_gemini_prompt: @origin.github_gemini_prompt_template
+          webhooks: serialize_webhooks(links)
         }
       end
 
@@ -37,7 +36,6 @@ module CollavreGithub
 
         integration_attributes = integration_params
         repositories = Array(integration_attributes[:repositories]).map(&:to_s).uniq
-        prompt_param = integration_attributes[:github_gemini_prompt] if integration_attributes.key?(:github_gemini_prompt)
 
         links = nil
 
@@ -54,10 +52,6 @@ module CollavreGithub
           end
 
           links = linked_repository_links(account).to_a
-
-          if prompt_param
-            @origin.update!(github_gemini_prompt: prompt_param.presence)
-          end
         end
 
         CollavreGithub::WebhookProvisioner.ensure_for_links(
@@ -69,8 +63,7 @@ module CollavreGithub
         render json: {
           success: true,
           selected_repositories: links.map(&:repository_full_name),
-          webhooks: serialize_webhooks(links),
-          github_gemini_prompt: @origin.github_gemini_prompt_template
+          webhooks: serialize_webhooks(links)
         }
       rescue ActiveRecord::RecordInvalid => e
         render json: { error: e.message }, status: :unprocessable_entity
@@ -138,8 +131,7 @@ module CollavreGithub
         render json: {
           success: true,
           selected_repositories: links.pluck(:repository_full_name),
-          webhooks: serialize_webhooks(links),
-          github_gemini_prompt: @origin.github_gemini_prompt_template
+          webhooks: serialize_webhooks(links)
         }
       end
 
@@ -172,7 +164,7 @@ module CollavreGithub
       end
 
       def integration_params
-        params.permit(:github_gemini_prompt, repositories: [])
+        params.permit(repositories: [])
       end
 
       def serialize_webhooks(links)

--- a/engines/collavre_github/app/views/collavre_github/integrations/_modal.html.erb
+++ b/engines/collavre_github/app/views/collavre_github/integrations/_modal.html.erb
@@ -50,20 +50,6 @@
       <p id="github-summary-empty" class="github-modal-empty" style="display:none;"><%= t('collavre_github.integration.summary_empty', default: 'No repositories selected.') %></p>
     </div>
 
-    <div class="github-wizard-step" id="github-step-prompt" style="display:none;">
-      <p class="github-modal-subtext"><%= t('collavre_github.integration.prompt_title', default: 'Review the Gemini analysis prompt and edit it if needed.') %></p>
-      <textarea id="github-gemini-prompt" style="width:100%;min-height:220px;padding:0.75em;border:1px solid var(--color-border);border-radius:4px;font-family:monospace;font-size:0.95em;"></textarea>
-      <p class="github-modal-subtext" style="margin-top:0.75em;font-size:0.9em;">
-        <%= t('collavre_github.integration.prompt_help', default: 'Use the placeholders below to inject runtime details as needed:') %>
-        <code>#{pr_title}</code>,
-        <code>#{pr_body}</code>,
-        <code>#{commit_messages}</code>,
-        <code>#{diff}</code>,
-        <code>#{creative_tree}</code>,
-        <code>#{language_instructions}</code>
-      </p>
-    </div>
-
     <div id="github-wizard-error" style="display:none;margin:0.5em 0;color:#c0392b;font-weight:bold;"></div>
 
     <div class="github-wizard-footer" style="display:flex;justify-content:space-between;gap:0.5em;margin-top:1.5em;">

--- a/engines/collavre_github/config/locales/en.yml
+++ b/engines/collavre_github/config/locales/en.yml
@@ -23,8 +23,6 @@ en:
       summary: "The following repositories will be linked to this Creative:"
       webhook_instructions: "Configure each repository with the webhook details below."
       summary_empty: "No repositories selected."
-      prompt_title: "Review the Gemini analysis prompt and edit it if needed."
-      prompt_help: "Use the placeholders below to inject runtime details as needed:"
     auth:
       login_first: "Please log in first to connect your GitHub account"
       connected: "GitHub account connected successfully"

--- a/engines/collavre_github/config/locales/ko.yml
+++ b/engines/collavre_github/config/locales/ko.yml
@@ -23,8 +23,6 @@ ko:
       summary: "다음 저장소가 이 Creative에 연동됩니다:"
       webhook_instructions: "각 저장소에 아래 웹훅 정보를 설정하세요."
       summary_empty: "선택된 저장소가 없습니다."
-      prompt_title: "Gemini 분석 프롬프트를 검토하고 필요시 수정하세요."
-      prompt_help: "다음 플레이스홀더를 사용하여 런타임 정보를 주입할 수 있습니다:"
     auth:
       login_first: "GitHub 계정을 연결하려면 먼저 로그인하세요"
       connected: "GitHub 계정이 연결되었습니다"


### PR DESCRIPTION
## Summary

Remove the `github_gemini_prompt` column from the `creatives` table and all related UI/code. This field was unused — PR analysis is handled by the GitHub PR Analyzer agent's own system prompt, not per-creative prompts.

## Changes

- **Migration**: Remove `github_gemini_prompt` column from `creatives`
- **Model**: Remove `DEFAULT_GITHUB_GEMINI_PROMPT` constant and `github_gemini_prompt_template` method
- **Controller**: Remove prompt reading/writing from `IntegrationsController`
- **UI**: Remove the prompt wizard step from GitHub integration modal
- **JS**: Remove all `geminiPrompt`/`promptInput` references from `github_integration.js`
- **i18n**: Remove `prompt_title` and `prompt_help` keys (en, ko)

## Why

The per-creative Gemini prompt was never actually consumed by any service or job. The GitHub PR Analyzer agent uses its own system prompt for PR analysis, making this field dead code.