### PR TITLE
feat: add data JSONB column to creatives

### DIFF
--- a/db/migrate/20260219104210_add_data_to_creatives.rb
+++ b/db/migrate/20260219104210_add_data_to_creatives.rb
@@ -1,0 +1,6 @@
+class AddDataToCreatives < ActiveRecord::Migration[8.1]
+  def change
+    add_column :creatives, :data, :jsonb, default: {}, null: false
+    add_index :creatives, :data, using: :gin
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_12_011655) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_19_104210) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false
@@ -62,6 +62,33 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_12_011655) do
     t.index ["user_id"], name: "index_activity_logs_on_user_id"
   end
 
+  create_table "agent_actions", force: :cascade do |t|
+    t.integer "agent_run_id", null: false
+    t.json "arguments", default: {}
+    t.datetime "created_at", null: false
+    t.text "result"
+    t.string "status", default: "pending"
+    t.string "tool_name"
+    t.datetime "updated_at", null: false
+    t.index ["agent_run_id"], name: "index_agent_actions_on_agent_run_id"
+  end
+
+  create_table "agent_runs", force: :cascade do |t|
+    t.integer "ai_user_id", null: false
+    t.json "context", default: {}
+    t.datetime "created_at", null: false
+    t.integer "creative_id", null: false
+    t.text "goal"
+    t.integer "iteration_count", default: 0
+    t.datetime "next_run_at"
+    t.string "state", default: "planning"
+    t.string "status", default: "pending"
+    t.json "transcript", default: []
+    t.datetime "updated_at", null: false
+    t.index ["ai_user_id"], name: "index_agent_runs_on_ai_user_id"
+    t.index ["creative_id"], name: "index_agent_runs_on_creative_id"
+  end
+
   create_table "calendar_events", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.integer "creative_id"
@@ -110,6 +137,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_12_011655) do
     t.boolean "private", default: false, null: false
     t.integer "quoted_comment_id"
     t.text "quoted_text"
+    t.boolean "streaming", default: false, null: false
     t.integer "topic_id"
     t.datetime "updated_at", null: false
     t.integer "user_id"
@@ -178,14 +206,15 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_12_011655) do
 
   create_table "creatives", force: :cascade do |t|
     t.datetime "created_at", null: false
+    t.json "data", default: {}, null: false
     t.text "description", limit: 4294967295
-    t.text "github_gemini_prompt"
     t.integer "origin_id"
     t.integer "parent_id"
     t.float "progress", default: 0.0
     t.integer "sequence", default: 0, null: false
     t.datetime "updated_at", null: false
     t.integer "user_id", null: false
+    t.index ["data"], name: "index_creatives_on_data"
     t.index ["origin_id"], name: "index_creatives_on_origin_id"
     t.index ["parent_id"], name: "index_creatives_on_parent_id"
     t.index ["user_id"], name: "index_creatives_on_user_id"
@@ -706,6 +735,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_12_011655) do
   end
 
   create_table "users", force: :cascade do |t|
+    t.text "agent_conf"
     t.string "avatar_url"
     t.string "calendar_id"
     t.string "completion_mark", default: "", null: false
@@ -776,7 +806,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_12_011655) do
   add_foreign_key "creative_expanded_states", "users"
   add_foreign_key "creative_shares", "creatives"
   add_foreign_key "creative_shares", "users"
-  add_foreign_key "creative_shares", "users", column: "shared_by_id", on_delete: :nullify
+  add_foreign_key "creative_shares", "users", column: "shared_by_id"
   add_foreign_key "creatives", "creatives", column: "origin_id"
   add_foreign_key "creatives", "creatives", column: "parent_id"
   add_foreign_key "creatives", "users"


### PR DESCRIPTION
## Summary

Add a `data` JSONB column to the `creatives` table for storing structured data.

### Changes
- Add `data` column (`jsonb`, default: `{}`, not null)
- Add GIN index on `data` for efficient querying

### Why
This is a precursor to creative types. The `data` field will hold the structured source of truth, while `description` serves as the HTML render cache. This enables:
- Programmatic access to structured data (search, filter, AI agent use)
- Type-specific data schemas without schema migrations
- Efficient PostgreSQL JSONB queries with GIN indexing