### PR TITLE
feat: use topic_name instead of topic_id in cron_create tool

### DIFF
--- a/engines/collavre/app/services/collavre/tools/cron_create_service.rb
+++ b/engines/collavre/app/services/collavre/tools/cron_create_service.rb
@@ -10,7 +10,7 @@ module Tools
     tool_description "Create a new recurring scheduled job. The job will periodically post a message to a creative's topic, triggering agent orchestration. Schedule uses cron syntax (e.g., '*/5 * * * *' for every 5 minutes, '0 9 * * *' for daily at 9am)."
 
     tool_param :creative_id, description: "The creative ID to post recurring messages to.", required: true
-    tool_param :topic_id, description: "The topic ID within the creative to post to.", required: true
+    tool_param :topic_name, description: "The topic name within the creative to post to. Use 'Main' for the main topic (topic_id = nil).", required: true
     tool_param :schedule, description: "Cron schedule expression (e.g., '0 9 * * *' for daily at 9am, '*/30 * * * *' for every 30 minutes).", required: true
     tool_param :message, description: "The message content to post on each execution. This triggers the agent orchestration pipeline.", required: true
     tool_param :description, description: "Human-readable description of what this cron job does.", required: false
@@ -18,13 +18,13 @@ module Tools
     sig do
       params(
         creative_id: Integer,
-        topic_id: Integer,
+        topic_name: String,
         schedule: String,
         message: String,
         description: T.nilable(String)
       ).returns(T::Hash[Symbol, T.untyped])
     end
-    def call(creative_id:, topic_id:, schedule:, message:, description: nil)
+    def call(creative_id:, topic_name:, schedule:, message:, description: nil)
       raise "Current.user is required" unless Current.user
 
       creative = Creative.find_by(id: creative_id)
@@ -33,8 +33,8 @@ module Tools
         return { error: "No write permission on this Creative", id: creative_id }
       end
 
-      topic = Topic.find_by(id: topic_id, creative_id: creative.effective_origin.id)
-      return { error: "Topic not found or does not belong to this creative", topic_id: topic_id } unless topic
+      topic_id = resolve_topic_id(creative, topic_name)
+      return topic_id if topic_id.is_a?(Hash) && topic_id[:error]
 
       parsed = Fugit.parse(schedule)
       unless parsed.is_a?(Fugit::Cron)
@@ -65,8 +65,20 @@ module Tools
         schedule: task.schedule,
         description: task.description,
         creative_id: creative_id,
+        topic_name: topic_name,
         next_run: task.next_time&.iso8601
       }
+    end
+
+    private
+
+    def resolve_topic_id(creative, topic_name)
+      return nil if topic_name.casecmp("main").zero?
+
+      topic = Topic.find_by(name: topic_name, creative_id: creative.effective_origin.id)
+      return { error: "Topic '#{topic_name}' not found for this creative" } unless topic
+
+      topic.id
     end
   end
 end

--- a/engines/collavre/test/services/collavre/tools/cron_create_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/cron_create_service_test.rb
@@ -22,10 +22,10 @@ module Collavre
         Current.user = nil
       end
 
-      test "creates a recurring task with correct attributes" do
+      test "creates a recurring task with topic_name" do
         result = CronCreateService.new.call(
           creative_id: @creative.id,
-          topic_id: @topic.id,
+          topic_name: "Cron Test Topic",
           schedule: "0 9 * * *",
           message: "Daily check-in",
           description: "Morning check"
@@ -33,6 +33,7 @@ module Collavre
 
         assert result[:success]
         assert result[:key].start_with?("cron_#{@creative.id}_")
+        assert_equal "Cron Test Topic", result[:topic_name]
 
         task = SolidQueue::RecurringTask.find_by(key: result[:key])
         assert_not_nil task
@@ -40,12 +41,45 @@ module Collavre
         assert_equal "Collavre::CronActionJob", task.class_name
         assert_equal "0 9 * * *", task.schedule
         assert_equal "Morning check", task.description
+
+        args = task.arguments.first
+        assert_equal @topic.id, args[:topic_id]
+      end
+
+      test "topic_name Main resolves to nil topic_id" do
+        result = CronCreateService.new.call(
+          creative_id: @creative.id,
+          topic_name: "Main",
+          schedule: "0 9 * * *",
+          message: "Main topic message"
+        )
+
+        assert result[:success]
+
+        task = SolidQueue::RecurringTask.find_by(key: result[:key])
+        args = task.arguments.first
+        assert_nil args[:topic_id]
+      end
+
+      test "topic_name main (lowercase) resolves to nil topic_id" do
+        result = CronCreateService.new.call(
+          creative_id: @creative.id,
+          topic_name: "main",
+          schedule: "0 9 * * *",
+          message: "Main topic message"
+        )
+
+        assert result[:success]
+
+        task = SolidQueue::RecurringTask.find_by(key: result[:key])
+        args = task.arguments.first
+        assert_nil args[:topic_id]
       end
 
       test "stores arguments for CronActionJob" do
         result = CronCreateService.new.call(
           creative_id: @creative.id,
-          topic_id: @topic.id,
+          topic_name: "Cron Test Topic",
           schedule: "0 9 * * *",
           message: "Test message"
         )
@@ -61,7 +95,7 @@ module Collavre
       test "rejects invalid cron schedule" do
         result = CronCreateService.new.call(
           creative_id: @creative.id,
-          topic_id: @topic.id,
+          topic_name: "Cron Test Topic",
           schedule: "not a valid schedule",
           message: "test"
         )
@@ -73,7 +107,7 @@ module Collavre
       test "rejects when creative not found" do
         result = CronCreateService.new.call(
           creative_id: 999_999,
-          topic_id: @topic.id,
+          topic_name: "Main",
           schedule: "0 9 * * *",
           message: "test"
         )
@@ -81,37 +115,28 @@ module Collavre
         assert_equal "Creative not found", result[:error]
       end
 
-      test "rejects when topic does not belong to creative" do
-        other_creative = creatives(:root_parent)
-        other_topic = Collavre::Topic.create!(
-          name: "Other Topic",
-          creative: other_creative,
-          user: @user
-        )
-
+      test "rejects when topic_name not found" do
         result = CronCreateService.new.call(
           creative_id: @creative.id,
-          topic_id: other_topic.id,
+          topic_name: "Nonexistent Topic",
           schedule: "0 9 * * *",
           message: "test"
         )
 
         assert result[:error]
-        assert_match(/Topic not found/, result[:error])
-      ensure
-        other_topic&.destroy
+        assert_match(/Topic 'Nonexistent Topic' not found/, result[:error])
       end
 
       test "generates unique keys" do
         result1 = CronCreateService.new.call(
           creative_id: @creative.id,
-          topic_id: @topic.id,
+          topic_name: "Cron Test Topic",
           schedule: "0 9 * * *",
           message: "test 1"
         )
         result2 = CronCreateService.new.call(
           creative_id: @creative.id,
-          topic_id: @topic.id,
+          topic_name: "Cron Test Topic",
           schedule: "0 10 * * *",
           message: "test 2"
         )


### PR DESCRIPTION
## Summary

Replace `topic_id` parameter with `topic_name` in the `cron_create` MCP tool for a more intuitive API.

### Changes
- `topic_id` param → `topic_name` param
- `topic_name: 'Main'` (case-insensitive) resolves to `topic_id: nil` (main topic)
- Other topic names are looked up by name within the creative
- Error returned if topic name not found

### Why
Agents don't always know topic IDs. Using names is more natural and doesn't require a lookup step.

### Tests
- 8 tests, 0 failures
- Covers: topic name resolution, Main → nil, case-insensitive Main, not-found error, unique keys