### PR TITLE
fix: handle nil topic_id (main topic) in CronActionJob

### DIFF
--- a/engines/collavre/app/jobs/collavre/cron_action_job.rb
+++ b/engines/collavre/app/jobs/collavre/cron_action_job.rb
@@ -6,25 +6,35 @@ module Collavre
   # agent orchestration pipeline.
   #
   # Created dynamically via the cron_create MCP tool.
+  # topic_id can be nil for the main topic.
   class CronActionJob < ApplicationJob
     queue_as :default
 
     def perform(creative_id:, topic_id:, agent_id:, message:)
       creative = Creative.find_by(id: creative_id)
-      topic = Topic.find_by(id: topic_id)
       agent = User.find_by(id: agent_id)
 
-      unless creative && topic && agent
+      unless creative && agent
         Rails.logger.warn(
-          "[CronActionJob] Skipping: creative=#{creative_id} topic=#{topic_id} agent=#{agent_id} - record not found"
+          "[CronActionJob] Skipping: creative=#{creative_id} agent=#{agent_id} - record not found"
         )
         return
+      end
+
+      # topic_id nil means main topic; otherwise look up the topic
+      topic = nil
+      if topic_id.present?
+        topic = Topic.find_by(id: topic_id)
+        unless topic
+          Rails.logger.warn("[CronActionJob] Skipping: topic=#{topic_id} not found")
+          return
+        end
       end
 
       comment = creative.comments.create!(
         content: message,
         user: agent,
-        topic_id: topic.id,
+        topic_id: topic&.id,
         private: false
       )
 
@@ -40,14 +50,16 @@ module Collavre
           description: creative.description
         },
         topic: {
-          id: topic.id
+          id: topic&.id
         },
         chat: {
           content: comment.content
         }
       })
 
-      Rails.logger.info("[CronActionJob] Posted cron message to creative #{creative_id}, topic #{topic_id}")
+      Rails.logger.info(
+        "[CronActionJob] Posted cron message to creative #{creative_id}, topic #{topic_id || 'main'}"
+      )
     end
   end
 end


### PR DESCRIPTION
## Summary

Fix CronActionJob to handle `topic_id: nil` (main topic) correctly.

### Problem
PR #840 introduced `topic_name: 'Main'` → `topic_id: nil` in `cron_create`. However, `CronActionJob#perform` required a valid topic record and bailed out when `topic_id` was nil, making Main-topic cron jobs non-functional.

Flagged by Codex review on PR #840.

### Changes
- `CronActionJob`: treat `topic_id: nil` as main topic instead of early return
- Only look up Topic when `topic_id` is present
- Comment created with `topic_id: nil` for main topic

### Tests
Existing cron tests pass. The job itself posts to the main topic correctly now.