### PR TITLE
fix: validate ownership on creative move to prevent orphan state

### DIFF
--- a/engines/collavre/app/services/collavre/creatives/reorderer.rb
+++ b/engines/collavre/app/services/collavre/creatives/reorderer.rb
@@ -13,6 +13,7 @@ module Creatives
       dragged, target = fetch_creatives(dragged_id, target_id)
       validate_direction!(direction)
       raise Error, "Invalid creatives" unless dragged && target
+      validate_ownership!(dragged, target)
 
       if direction == "child"
         reorder_as_child(dragged, target)
@@ -34,6 +35,8 @@ module Creatives
       dragged_lookup = Creative.where(id: ids).index_by { |creative| creative.id.to_s }
       ordered_dragged = ids.map { |id| dragged_lookup[id.to_s] }.compact
       raise Error, "Invalid creatives" unless ordered_dragged.size == ids.size
+
+      ordered_dragged.each { |dragged| validate_ownership!(dragged, target) }
 
       if ordered_dragged.any? { |creative| creative.id == target.id }
         raise Error, "Invalid creatives"
@@ -59,6 +62,9 @@ module Creatives
       dragged, target = fetch_creatives(dragged_id, target_id)
       validate_direction!(direction)
       raise Error, "Invalid creatives" unless dragged && target
+      unless owned_by_user?(target)
+        raise Error, "Cannot link into creatives owned by other users"
+      end
 
       origin = dragged.effective_origin
       new_parent = direction == "child" ? target : target.parent
@@ -106,6 +112,16 @@ module Creatives
     private
 
     attr_reader :user
+
+    def validate_ownership!(dragged, target)
+      unless owned_by_user?(dragged) && owned_by_user?(target)
+        raise Error, "Cannot move creatives owned by different users"
+      end
+    end
+
+    def owned_by_user?(creative)
+      creative.user_id == user.id
+    end
 
     def fetch_creatives(dragged_id, target_id)
       [ Creative.find_by(id: dragged_id), Creative.find_by(id: target_id) ]

--- a/engines/collavre/app/services/collavre/creatives/reorderer.rb
+++ b/engines/collavre/app/services/collavre/creatives/reorderer.rb
@@ -62,12 +62,12 @@ module Creatives
       dragged, target = fetch_creatives(dragged_id, target_id)
       validate_direction!(direction)
       raise Error, "Invalid creatives" unless dragged && target
-      unless owned_by_user?(target)
-        raise Error, "Cannot link into creatives owned by other users"
-      end
-
       origin = dragged.effective_origin
       new_parent = direction == "child" ? target : target.parent
+
+      unless owned_by_user?(new_parent || target)
+        raise Error, "Cannot link into creatives owned by other users"
+      end
 
       if new_parent.present?
         origin_descendant_ids = origin.self_and_descendants.pluck(:id)

--- a/engines/collavre/test/services/creatives/reorderer_test.rb
+++ b/engines/collavre/test/services/creatives/reorderer_test.rb
@@ -68,5 +68,82 @@ module Creatives
         )
       end
     end
+
+    test "reorder raises when dragged creative is owned by another user" do
+      other_user = User.create!(
+        email: "other@example.com",
+        password: "password123",
+        name: "Other",
+        email_verified_at: Time.current,
+        notifications_enabled: false
+      )
+      other_creative = Creative.create!(description: "Other's", user: other_user)
+
+      assert_raises(Reorderer::Error) do
+        @reorderer.reorder(
+          dragged_id: other_creative.id,
+          target_id: @root.id,
+          direction: "child"
+        )
+      end
+    end
+
+    test "reorder raises when target creative is owned by another user" do
+      other_user = User.create!(
+        email: "other2@example.com",
+        password: "password123",
+        name: "Other2",
+        email_verified_at: Time.current,
+        notifications_enabled: false
+      )
+      other_creative = Creative.create!(description: "Other's", user: other_user)
+
+      assert_raises(Reorderer::Error) do
+        @reorderer.reorder(
+          dragged_id: @child_a.id,
+          target_id: other_creative.id,
+          direction: "child"
+        )
+      end
+    end
+
+    test "reorder allows moving linked creative owned by user" do
+      other_user = User.create!(
+        email: "other3@example.com",
+        password: "password123",
+        name: "Other3",
+        email_verified_at: Time.current,
+        notifications_enabled: false
+      )
+      origin_creative = Creative.create!(description: "Origin", user: other_user)
+      linked = Creative.create!(origin_id: origin_creative.id, user: @user)
+
+      @reorderer.reorder(
+        dragged_id: linked.id,
+        target_id: @root.id,
+        direction: "child"
+      )
+
+      assert_equal @root.id, linked.reload.parent_id
+    end
+
+    test "reorder_multiple raises when any dragged creative is owned by another user" do
+      other_user = User.create!(
+        email: "other4@example.com",
+        password: "password123",
+        name: "Other4",
+        email_verified_at: Time.current,
+        notifications_enabled: false
+      )
+      other_creative = Creative.create!(description: "Other's", user: other_user)
+
+      assert_raises(Reorderer::Error) do
+        @reorderer.reorder_multiple(
+          dragged_ids: [ @child_a.id, other_creative.id ],
+          target_id: @child_b.id,
+          direction: "up"
+        )
+      end
+    end
   end
 end

--- a/engines/collavre/test/services/creatives/reorderer_test.rb
+++ b/engines/collavre/test/services/creatives/reorderer_test.rb
@@ -145,5 +145,64 @@ module Creatives
         )
       end
     end
+
+    test "link_drop raises when target creative is owned by another user" do
+      other_user = User.create!(
+        email: "other5@example.com",
+        password: "password123",
+        name: "Other5",
+        email_verified_at: Time.current,
+        notifications_enabled: false
+      )
+      other_creative = Creative.create!(description: "Other's", user: other_user)
+
+      assert_raises(Reorderer::Error) do
+        @reorderer.link_drop(
+          dragged_id: @child_a.id,
+          target_id: other_creative.id,
+          direction: "child"
+        )
+      end
+    end
+
+    test "link_drop raises when target parent is owned by another user (sibling direction)" do
+      other_user = User.create!(
+        email: "other6@example.com",
+        password: "password123",
+        name: "Other6",
+        email_verified_at: Time.current,
+        notifications_enabled: false
+      )
+      other_root = Creative.create!(description: "Other root", user: other_user)
+      other_child = Creative.create!(description: "Other child", user: other_user, parent: other_root)
+
+      assert_raises(Reorderer::Error) do
+        @reorderer.link_drop(
+          dragged_id: @child_a.id,
+          target_id: other_child.id,
+          direction: "up"
+        )
+      end
+    end
+
+    test "link_drop allows linking into own creative" do
+      other_user = User.create!(
+        email: "other7@example.com",
+        password: "password123",
+        name: "Other7",
+        email_verified_at: Time.current,
+        notifications_enabled: false
+      )
+      other_creative = Creative.create!(description: "Other's", user: other_user)
+
+      result = @reorderer.link_drop(
+        dragged_id: other_creative.id,
+        target_id: @root.id,
+        direction: "child"
+      )
+
+      assert_equal @root.id, result.new_creative.parent_id
+      assert_equal other_creative.id, result.new_creative.origin_id
+    end
   end
 end


### PR DESCRIPTION
## Problem

Two bugs in creative move (drag & drop):

1. **No ownership validation on move target**: Users could drag others' creatives into their own tree without permission
2. **Orphan state after cross-owner move**: Moved creatives became inaccessible to both the original owner and the mover

## Solution

Add ownership validation in `Creatives::Reorderer`:
- Both dragged and target creatives must have `user_id == current_user.id`
- Linked creatives are checked by their `user_id` column (the linking user), so they remain movable by their owner
- `link_drop` validates target ownership (dragged can be anyone's since we're creating a new link)

## Tests

Added 4 new test cases:
- Reorder raises when dragged creative owned by another user
- Reorder raises when target creative owned by another user  
- Reorder allows moving linked creative owned by user
- Reorder multiple raises when any dragged creative owned by another user

Fixes Creative (id: 8851)