### PR TITLE
fix: debounce creative search with 300ms delay and min 3 chars

### DIFF
--- a/engines/collavre/app/javascript/controllers/link_creative_controller.js
+++ b/engines/collavre/app/javascript/controllers/link_creative_controller.js
@@ -6,7 +6,8 @@ export default class extends CommonPopupController {
 
     connect() {
         super.connect()
-        this.inputTarget.addEventListener('input', this.search.bind(this))
+        this._debounceTimer = null
+        this.inputTarget.addEventListener('input', this._debouncedSearch.bind(this))
         this.inputTarget.addEventListener('keydown', this.handleInputKeydown.bind(this))
         this.closeTarget.addEventListener('click', () => this.close())
 
@@ -42,9 +43,14 @@ export default class extends CommonPopupController {
         }
     }
 
+    _debouncedSearch() {
+        if (this._debounceTimer) clearTimeout(this._debounceTimer)
+        this._debounceTimer = setTimeout(() => this.search(), 300)
+    }
+
     search() {
         const query = this.inputTarget.value.trim()
-        if (!query) {
+        if (query.length < 3) {
             this.setItems([])
             return
         }


### PR DESCRIPTION
## Summary

Fix creative search link popup to debounce search requests and require minimum input length.

### Problem
Every keystroke triggered an API search, causing:
- Excessive server requests
- Race conditions where older responses could override newer ones
- Incorrect search results displayed

### Changes
- Add 300ms debounce delay before firing search
- Require minimum 3 characters before searching
- Clear results when input is below 3 characters

### Files changed
- `engines/collavre/app/javascript/controllers/link_creative_controller.js`