### PR TITLE
fix: display system comments as 'System' instead of 'Gemini'

### DIFF
--- a/engines/collavre/app/views/collavre/comments/_comment.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comment.html.erb
@@ -11,14 +11,11 @@
   </div>
   <div>
     <%= render Collavre::AvatarComponent.new(user: comment.user, size: 20, classes: 'avatar comment-avatar') %>
-    <% system_prefix = "#{t('collavre.comments.system_user')}:" %>
     <% display_name =
          if comment.user.present?
            comment.user.display_name
-         elsif comment.content.to_s.strip.start_with?(system_prefix)
-           t('collavre.comments.system_user')
          else
-           t('collavre.comments.gemini')
+           t('collavre.comments.system_user')
          end %>
     <% timestamp = comment.created_at.in_time_zone %>
     <strong><%= display_name %></strong>

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -24,7 +24,6 @@ en:
       no_permission: You do not have permission to comment.
       convert_not_allowed: Only the comment owner or a creative admin can convert
         this message.
-      gemini: Gemini
       convert_button: Convert
       convert_to_creative: Convert to Creative
       convert_confirm: This will add the comment content as a child creative of the

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -23,7 +23,6 @@ ko:
       not_owner: 댓글 소유자만 수정할 수 있습니다.
       no_permission: 댓글을 추가할 권한이 없습니다.
       convert_not_allowed: 댓글 소유자 또는 크리에이티브 관리자만 이 메시지를 전환할 수 있습니다.
-      gemini: Gemini
       convert_button: 전환
       convert_to_creative: 하위 크리에이티브로 전환
       convert_confirm: 현재 크리에이티브 하위에 해당 댓글의 내용이 추가됩니다. 진행하시겠습니까?


### PR DESCRIPTION
## Problem
Comments with `user_id: nil` (system messages like waiting notices) were displayed as 'Gemini' due to a fallback in the comment template.

## Solution
- Simplify display name logic: if `comment.user` is nil, always show 'System'
- Remove dead `gemini` i18n key from comments locales
- Remove unnecessary `system_prefix` content matching

## Testing
1144 tests, 0 failures