### PR TITLE
fix: make loop breaker per-topic and skip user-initiated messages

### DIFF
--- a/engines/collavre/app/controllers/collavre/comments_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comments_controller.rb
@@ -170,6 +170,7 @@ module Collavre
                 id: @comment.id,
                 content: @comment.content,
                 user_id: @comment.user_id,
+                from_ai: @comment.user&.searchable? || false,
                 quoted_comment_id: @comment.quoted_comment_id
               }.compact,
               creative: {

--- a/engines/collavre/app/jobs/collavre/ai_agent_job.rb
+++ b/engines/collavre/app/jobs/collavre/ai_agent_job.rb
@@ -23,10 +23,15 @@ module Collavre
           topic_id: context&.dig("topic", "id")
         )
 
-        # Record task for loop breaker tracking
+        # Record task for loop breaker tracking (per-topic, skip user-initiated)
         creative_id = context&.dig("creative", "id")
         if creative_id
-          Orchestration::LoopBreaker.new(context).record_task(creative_id, agent.id)
+          comment_user_id = context&.dig("comment", "user_id")
+          triggered_by_user = comment_user_id.present? && !User.where(id: comment_user_id, searchable: true).exists?
+          topic_id = context&.dig("topic", "id")
+          Orchestration::LoopBreaker.new(context).record_task(
+            creative_id, agent.id, topic_id: topic_id, triggered_by_user: triggered_by_user
+          )
         end
       end
 

--- a/engines/collavre/app/jobs/collavre/ai_agent_job.rb
+++ b/engines/collavre/app/jobs/collavre/ai_agent_job.rb
@@ -26,11 +26,10 @@ module Collavre
         # Record task for loop breaker tracking (per-topic, skip user-initiated)
         creative_id = context&.dig("creative", "id")
         if creative_id
-          comment_user_id = context&.dig("comment", "user_id")
-          triggered_by_user = comment_user_id.present? && !User.where(id: comment_user_id, searchable: true).exists?
+          from_ai = context&.dig("comment", "from_ai") == true
           topic_id = context&.dig("topic", "id")
           Orchestration::LoopBreaker.new(context).record_task(
-            creative_id, agent.id, topic_id: topic_id, triggered_by_user: triggered_by_user
+            creative_id, agent.id, topic_id: topic_id, triggered_by_user: !from_ai
           )
         end
       end

--- a/engines/collavre/app/services/collavre/orchestration/loop_breaker.rb
+++ b/engines/collavre/app/services/collavre/orchestration/loop_breaker.rb
@@ -67,9 +67,12 @@ module Collavre
         Rails.cache.write(key, interactions, expires_in: CACHE_EXPIRY)
       end
 
-      # Record a task creation for creative retry detection
-      def record_task(creative_id, agent_id)
-        key = creative_tasks_key(creative_id)
+      # Record a task creation for creative retry detection (per-topic)
+      # Skips recording for user-initiated messages (only agent-to-agent counts as potential loop)
+      def record_task(creative_id, agent_id, topic_id: nil, triggered_by_user: false)
+        return if triggered_by_user
+
+        key = topic_tasks_key(creative_id, topic_id)
         tasks = Rails.cache.read(key) || []
         tasks << { at: Time.current.to_i, agent_id: agent_id }
 
@@ -136,12 +139,13 @@ module Collavre
         safe_result
       end
 
-      # Detect too many tasks on same creative
+      # Detect too many tasks on same topic (per-topic, not per-creative)
       def check_creative_retry
         creative_id = @context.dig("creative", "id")
+        topic_id = @context.dig("topic", "id")
         return safe_result unless creative_id
 
-        key = creative_tasks_key(creative_id)
+        key = topic_tasks_key(creative_id, topic_id)
         tasks = Rails.cache.read(key) || []
 
         # Filter to window
@@ -154,6 +158,7 @@ module Collavre
             reason: :creative_retry_exceeded,
             details: {
               creative_id: creative_id,
+              topic_id: topic_id,
               task_count: recent_tasks.size,
               threshold: creative_retry_threshold,
               window_minutes: @config["creative_retry_window_minutes"]
@@ -253,8 +258,8 @@ module Collavre
         "#{CACHE_PREFIX}:ping_pong:#{sorted[0]}-#{sorted[1]}:#{creative_id}"
       end
 
-      def creative_tasks_key(creative_id)
-        "#{CACHE_PREFIX}:creative:#{creative_id}:tasks"
+      def topic_tasks_key(creative_id, topic_id)
+        "#{CACHE_PREFIX}:creative:#{creative_id}:topic:#{topic_id || "main"}:tasks"
       end
 
       def token_usage_key(agent_id)

--- a/engines/collavre/test/services/collavre/orchestration/cross_topic_parallelism_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/cross_topic_parallelism_test.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  module Orchestration
+    class CrossTopicParallelismTest < ActiveSupport::TestCase
+      setup do
+        @creative = creatives(:tshirt)
+        @user = users(:one)
+        @agent = users(:ai_bot)
+        @agent.update!(searchable: true)
+
+        @topic_a = Topic.create!(name: "Topic A", creative: @creative, user: @user)
+        @topic_b = Topic.create!(name: "Topic B", creative: @creative, user: @user)
+
+        ResourceTracker.for(@agent).reset!
+      end
+
+      teardown do
+        ResourceTracker.for(@agent).reset!
+      end
+
+      test "same agent can run in parallel across different topics" do
+        # Simulate: agent already running in Topic A
+        Task.create!(
+          name: "Running in Topic A",
+          status: "running",
+          trigger_event_name: "comment_created",
+          agent: @agent,
+          topic_id: @topic_a.id
+        )
+        ResourceTracker.for(@agent).reserve!("job-topic-a")
+
+        # Now schedule same agent in Topic B
+        context_b = {
+          "creative" => { "id" => @creative.id },
+          "topic" => { "id" => @topic_b.id }
+        }
+
+        scheduler = Scheduler.new(context_b)
+        decisions = scheduler.schedule([@agent])
+
+        assert_equal 1, decisions.size
+        assert_equal :immediate, decisions.first[:timing],
+          "Same agent should be allowed to run in a different topic, " \
+          "but got: #{decisions.first[:timing]} (reason: #{decisions.first[:reason]})"
+      end
+
+      test "same agent is deferred in same topic when already running" do
+        Task.create!(
+          name: "Running in Topic A",
+          status: "running",
+          trigger_event_name: "comment_created",
+          agent: @agent,
+          topic_id: @topic_a.id
+        )
+        ResourceTracker.for(@agent).reserve!("job-topic-a")
+
+        # Schedule same agent in SAME Topic A
+        context_a = {
+          "creative" => { "id" => @creative.id },
+          "topic" => { "id" => @topic_a.id }
+        }
+
+        scheduler = Scheduler.new(context_a)
+        decisions = scheduler.schedule([@agent])
+
+        assert_equal :deferred, decisions.first[:timing],
+          "Same agent should be deferred in same topic"
+      end
+
+      test "same agent running in topic A does not block topic B via Main" do
+        # Key question: does a comment in Topic A also create a Main topic event?
+        # If so, does Main's running task block Topic B?
+
+        # Running task in Topic A
+        Task.create!(
+          name: "Running in Topic A",
+          status: "running",
+          trigger_event_name: "comment_created",
+          agent: @agent,
+          topic_id: @topic_a.id
+        )
+
+        # Also a running task in Main (topic_id: nil) — simulating Main topic broadcast
+        Task.create!(
+          name: "Running in Main",
+          status: "running",
+          trigger_event_name: "comment_created",
+          agent: @agent,
+          topic_id: nil
+        )
+
+        ResourceTracker.for(@agent).reserve!("job-topic-a")
+        ResourceTracker.for(@agent).reserve!("job-main")
+
+        # Schedule in Topic B
+        context_b = {
+          "creative" => { "id" => @creative.id },
+          "topic" => { "id" => @topic_b.id }
+        }
+
+        scheduler = Scheduler.new(context_b)
+        decisions = scheduler.schedule([@agent])
+
+        assert_equal :immediate, decisions.first[:timing],
+          "Topic B should not be blocked by Topic A or Main running tasks. " \
+          "Got: #{decisions.first[:timing]} (reason: #{decisions.first[:reason]})"
+      end
+
+      test "three topics can run in parallel for same agent" do
+        topic_c = Topic.create!(name: "Topic C", creative: @creative, user: @user)
+
+        # Running tasks in A and B
+        Task.create!(name: "t-a", status: "running", trigger_event_name: "e", agent: @agent, topic_id: @topic_a.id)
+        Task.create!(name: "t-b", status: "running", trigger_event_name: "e", agent: @agent, topic_id: @topic_b.id)
+        ResourceTracker.for(@agent).reserve!("job-a")
+        ResourceTracker.for(@agent).reserve!("job-b")
+
+        # Schedule in Topic C
+        context_c = {
+          "creative" => { "id" => @creative.id },
+          "topic" => { "id" => topic_c.id }
+        }
+
+        scheduler = Scheduler.new(context_c)
+        decisions = scheduler.schedule([@agent])
+
+        assert_equal :immediate, decisions.first[:timing],
+          "Third topic should also run in parallel. " \
+          "Got: #{decisions.first[:timing]} (reason: #{decisions.first[:reason]})"
+      end
+    end
+  end
+end

--- a/engines/collavre/test/services/collavre/orchestration/cross_topic_parallelism_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/cross_topic_parallelism_test.rb
@@ -39,7 +39,7 @@ module Collavre
         }
 
         scheduler = Scheduler.new(context_b)
-        decisions = scheduler.schedule([@agent])
+        decisions = scheduler.schedule([ @agent ])
 
         assert_equal 1, decisions.size
         assert_equal :immediate, decisions.first[:timing],
@@ -64,7 +64,7 @@ module Collavre
         }
 
         scheduler = Scheduler.new(context_a)
-        decisions = scheduler.schedule([@agent])
+        decisions = scheduler.schedule([ @agent ])
 
         assert_equal :deferred, decisions.first[:timing],
           "Same agent should be deferred in same topic"
@@ -102,7 +102,7 @@ module Collavre
         }
 
         scheduler = Scheduler.new(context_b)
-        decisions = scheduler.schedule([@agent])
+        decisions = scheduler.schedule([ @agent ])
 
         assert_equal :immediate, decisions.first[:timing],
           "Topic B should not be blocked by Topic A or Main running tasks. " \
@@ -125,7 +125,7 @@ module Collavre
         }
 
         scheduler = Scheduler.new(context_c)
-        decisions = scheduler.schedule([@agent])
+        decisions = scheduler.schedule([ @agent ])
 
         assert_equal :immediate, decisions.first[:timing],
           "Third topic should also run in parallel. " \

--- a/engines/collavre/test/services/collavre/orchestration/scheduler_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/scheduler_test.rb
@@ -335,3 +335,5 @@ module Collavre
     end
   end
 end
+
+# Temporarily appended test - cross-topic parallelism

--- a/engines/collavre/test/services/collavre/orchestration/thread_exhaustion_integration_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/thread_exhaustion_integration_test.rb
@@ -36,12 +36,12 @@ module Collavre
         decisions = @topics.map do |topic|
           context = build_context(topic)
           scheduler = Scheduler.new(context)
-          scheduler.schedule([@agent]).first
+          scheduler.schedule([ @agent ]).first
         end
 
         assert decisions.all? { |d| d[:timing] == :immediate },
           "All 5 topics should be :immediate from Scheduler, " \
-          "got: #{decisions.map { |d| [d[:timing], d[:reason]] }}"
+          "got: #{decisions.map { |d| [ d[:timing], d[:reason] ] }}"
 
         # Part 2: Simulate job execution with limited thread pool
         # Each job blocks for the duration of AI response (HTTP streaming)

--- a/engines/collavre/test/services/collavre/orchestration/thread_exhaustion_integration_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/thread_exhaustion_integration_test.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  module Orchestration
+    class ThreadExhaustionIntegrationTest < ActiveSupport::TestCase
+      # Integration test: proves that AiAgentJob's blocking nature
+      # (HTTP streaming / WebSocket wait) causes cross-topic serialization
+      # when Solid Queue thread pool is exhausted.
+      #
+      # Uses real Task + ResourceTracker + Scheduler, mocks only the
+      # AI client call (which is the blocking I/O).
+
+      THREAD_POOL_SIZE = 3 # matches production config/queue.yml
+
+      setup do
+        @creative = creatives(:tshirt)
+        @user = users(:one)
+        @agent = users(:ai_bot)
+        @agent.update!(searchable: true)
+
+        @topics = 5.times.map do |i|
+          Topic.create!(name: "Thread Test Topic #{i}", creative: @creative, user: @user)
+        end
+
+        ResourceTracker.for(@agent).reset!
+      end
+
+      teardown do
+        ResourceTracker.for(@agent).reset!
+      end
+
+      test "orchestrator schedules all topics as immediate but thread pool serializes them" do
+        # Part 1: Prove Scheduler marks all as :immediate
+        decisions = @topics.map do |topic|
+          context = build_context(topic)
+          scheduler = Scheduler.new(context)
+          scheduler.schedule([@agent]).first
+        end
+
+        assert decisions.all? { |d| d[:timing] == :immediate },
+          "All 5 topics should be :immediate from Scheduler, " \
+          "got: #{decisions.map { |d| [d[:timing], d[:reason]] }}"
+
+        # Part 2: Simulate job execution with limited thread pool
+        # Each job blocks for the duration of AI response (HTTP streaming)
+        pool = Concurrent::FixedThreadPool.new(THREAD_POOL_SIZE)
+        started_at = {}
+        finished_at = {}
+        mutex = Mutex.new
+        ai_response_time = 0.3 # simulate 300ms AI response
+
+        @topics.each_with_index do |topic, i|
+          pool.post do
+            mutex.synchronize { started_at[i] = Process.clock_gettime(Process::CLOCK_MONOTONIC) }
+
+            # Simulate AiAgentJob blocking work:
+            # 1. Create task
+            task = nil
+            mutex.synchronize do
+              task = Task.create!(
+                name: "Response for topic #{i}",
+                status: "running",
+                trigger_event_name: "comment_created",
+                agent: @agent,
+                topic_id: topic.id
+              )
+            end
+
+            # 2. Reserve resources
+            ResourceTracker.for(@agent).reserve!("thread-test-#{i}")
+
+            # 3. Blocking AI call (HTTP streaming wait)
+            sleep(ai_response_time)
+
+            # 4. Release resources
+            ResourceTracker.for(@agent).release!("thread-test-#{i}", tokens_used: 0)
+            mutex.synchronize do
+              task.update!(status: "done")
+              finished_at[i] = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+            end
+          end
+        end
+
+        pool.shutdown
+        pool.wait_for_termination(10)
+
+        # Analyze timing
+        sorted_starts = started_at.sort_by { |_, t| t }
+
+        # First 3 should start almost simultaneously
+        first_batch = sorted_starts[0..2].map { |_, t| t }
+        first_batch_spread = first_batch.max - first_batch.min
+
+        # 4th and 5th should start AFTER first batch finishes
+        second_batch = sorted_starts[3..4].map { |_, t| t }
+        gap_to_4th = second_batch.first - first_batch.min
+
+        assert first_batch_spread < 0.15,
+          "First 3 jobs should start near-simultaneously " \
+          "(spread: #{first_batch_spread.round(3)}s)"
+
+        assert gap_to_4th >= ai_response_time * 0.8,
+          "4th job should wait for a thread to free up " \
+          "(gap: #{gap_to_4th.round(3)}s, expected >= #{(ai_response_time * 0.8).round(3)}s). " \
+          "This proves thread pool exhaustion causes cross-topic serialization!"
+
+        # Summary
+        Rails.logger.info(
+          "[ThreadExhaustionTest] With #{THREAD_POOL_SIZE} threads and 5 topics:\n" \
+          "  Jobs 0-2 started within #{first_batch_spread.round(3)}s\n" \
+          "  Job 3 waited #{gap_to_4th.round(3)}s (thread pool exhaustion)\n" \
+          "  Total time: #{(finished_at.values.max - started_at.values.min).round(3)}s\n" \
+          "  Ideal (5 threads): #{ai_response_time}s\n" \
+          "  Actual (3 threads): ~#{(ai_response_time * 2).round(1)}s"
+        )
+      end
+
+      test "with more threads all topics run truly in parallel" do
+        pool = Concurrent::FixedThreadPool.new(5) # enough for all topics
+        started_at = {}
+        mutex = Mutex.new
+        ai_response_time = 0.3
+
+        @topics.each_with_index do |topic, i|
+          pool.post do
+            mutex.synchronize { started_at[i] = Process.clock_gettime(Process::CLOCK_MONOTONIC) }
+            sleep(ai_response_time)
+          end
+        end
+
+        pool.shutdown
+        pool.wait_for_termination(10)
+
+        sorted_starts = started_at.sort_by { |_, t| t }
+        total_spread = sorted_starts.last[1] - sorted_starts.first[1]
+
+        assert total_spread < 0.15,
+          "With 5 threads, all 5 jobs should start near-simultaneously " \
+          "(spread: #{total_spread.round(3)}s). " \
+          "Fix: increase threads in config/queue.yml"
+      end
+
+      private
+
+      def build_context(topic)
+        {
+          "creative" => { "id" => @creative.id },
+          "topic" => { "id" => topic.id },
+          "chat" => { "content" => "@#{@agent.name}: test" },
+          "comment" => { "content" => "@#{@agent.name}: test" }
+        }
+      end
+    end
+  end
+end

--- a/engines/collavre/test/services/collavre/orchestration/thread_exhaustion_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/thread_exhaustion_test.rb
@@ -43,7 +43,7 @@ module Collavre
             "topic" => { "id" => topic.id }
           }
           scheduler = Scheduler.new(context)
-          decisions = scheduler.schedule([@agent])
+          decisions = scheduler.schedule([ @agent ])
           decisions.first[:timing] == :immediate
         end
 

--- a/engines/collavre/test/services/collavre/orchestration/thread_exhaustion_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/thread_exhaustion_test.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  module Orchestration
+    class ThreadExhaustionTest < ActiveSupport::TestCase
+      # Reproduces the production issue:
+      # Same AI agent is mentioned in multiple topics simultaneously.
+      # Scheduler correctly marks all as :immediate,
+      # but Solid Queue only has 3 worker threads (config/queue.yml).
+      # Since AiAgentJob blocks (HTTP streaming waits for full response),
+      # 3 running jobs exhaust the thread pool → 4th+ jobs queue up.
+      #
+      # This test proves the bottleneck is at the job execution layer,
+      # NOT the orchestration/scheduling layer.
+
+      SIMULATED_THREADS = 3 # matches config/queue.yml threads for default queue
+
+      setup do
+        @creative = creatives(:tshirt)
+        @user = users(:one)
+        @agent = users(:ai_bot)
+        @agent.update!(searchable: true)
+
+        @topics = 5.times.map do |i|
+          Topic.create!(name: "Topic #{i}", creative: @creative, user: @user)
+        end
+
+        ResourceTracker.for(@agent).reset!
+      end
+
+      teardown do
+        ResourceTracker.for(@agent).reset!
+      end
+
+      test "scheduler allows all topics to run in parallel (no bottleneck here)" do
+        # Schedule 5 topics sequentially — all should be :immediate
+        # because topic_max_concurrent_jobs checks per-topic, not globally
+        all_immediate = @topics.all? do |topic|
+          context = {
+            "creative" => { "id" => @creative.id },
+            "topic" => { "id" => topic.id }
+          }
+          scheduler = Scheduler.new(context)
+          decisions = scheduler.schedule([@agent])
+          decisions.first[:timing] == :immediate
+        end
+
+        assert all_immediate,
+          "All 5 topics should be scheduled as :immediate by the Scheduler"
+      end
+
+      test "thread pool becomes the bottleneck with blocking jobs" do
+        # Simulate: 3 threads occupied by blocking AI agent jobs
+        started = Queue.new
+        finish = Queue.new
+        completed = Concurrent::AtomicFixnum.new(0)
+
+        # Simulate thread pool with limited threads (like Solid Queue)
+        pool = Concurrent::FixedThreadPool.new(SIMULATED_THREADS)
+
+        # Submit 5 "blocking" jobs (simulating AiAgentJob with HTTP streaming)
+        5.times do |i|
+          pool.post do
+            started.push(i)
+            finish.pop # block until signaled — simulates HTTP streaming wait
+            completed.increment
+          end
+        end
+
+        # Wait for first 3 to start (thread pool is full)
+        3.times { started.pop }
+
+        # Give a moment for any additional threads to start
+        sleep 0.1
+
+        # Only 3 should have started — thread pool is exhausted
+        assert_equal 0, started.size,
+          "No more jobs should start — all #{SIMULATED_THREADS} threads are occupied"
+
+        assert_equal 0, completed.value,
+          "No jobs completed yet (all blocking)"
+
+        # Release one thread
+        finish.push(:done)
+        sleep 0.1
+
+        # Now the 4th job should start
+        assert_equal 1, started.size,
+          "4th job should start after one thread is freed"
+
+        # Release all remaining
+        4.times { finish.push(:done) }
+        pool.shutdown
+        pool.wait_for_termination(5)
+
+        assert_equal 5, completed.value, "All 5 jobs should complete eventually"
+      end
+
+      test "increasing thread count allows more parallel jobs" do
+        more_threads = 5
+        pool = Concurrent::FixedThreadPool.new(more_threads)
+
+        started = Concurrent::AtomicFixnum.new(0)
+        finish = Queue.new
+
+        5.times do
+          pool.post do
+            started.increment
+            finish.pop
+          end
+        end
+
+        sleep 0.2
+
+        assert_equal 5, started.value,
+          "With #{more_threads} threads, all 5 jobs should start immediately"
+
+        5.times { finish.push(:done) }
+        pool.shutdown
+        pool.wait_for_termination(5)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Problem

LoopBreaker's `check_creative_retry` was counting tasks at the **creative level**, causing false loop detection when multiple topics in the same creative run in parallel. Additionally, user-initiated messages were being counted toward the loop threshold, even though they are not loops.

Production log evidence:
```
[Orchestrator] Agent 42 (Vrex) → rejected: loop_detected (event=comment_created, topic=228)
```

## Changes

### 1. Per-topic loop detection
- Changed `check_creative_retry` from per-creative to per-topic scope
- Cache key: `loop_breaker:creative:{id}:topic:{topic_id}:tasks`
- Each topic has its own independent retry counter

### 2. Skip user-initiated messages
- `record_task` now accepts `triggered_by_user:` flag
- Messages from non-AI users (human) are excluded from loop counting
- Determined by checking if `comment.user_id` belongs to an AI agent (`searchable: true`)

### 3. Tests
- Cross-topic parallelism tests (Scheduler level)
- Thread exhaustion simulation tests (proves Solid Queue thread pool is the actual bottleneck)

## Impact
- Multiple topics in the same creative can now run in parallel without false loop detection
- User commands to AI agents no longer count toward loop thresholds
- Per-topic isolation prevents one busy topic from blocking others