### PR TITLE
feat: add topic name to AI agent context

### DIFF
--- a/engines/collavre/app/services/collavre/ai_agent/message_builder.rb
+++ b/engines/collavre/app/services/collavre/ai_agent/message_builder.rb
@@ -37,7 +37,11 @@ module Collavre
         markdown = ApplicationController.helpers.render_creative_tree_markdown(
           [ creative ], 1, true, max_depth: max_depth
         )
-        messages << { role: "user", parts: [ { text: "Creative (id: #{creative.id}):\n#{markdown}" } ] }
+
+        topic = current_topic
+        topic_info = topic ? "\nTopic: #{topic.name} (id: #{topic.id})" : ""
+
+        messages << { role: "user", parts: [ { text: "Creative (id: #{creative.id}):#{topic_info}\n#{markdown}" } ] }
       end
 
       def append_chat_history(messages)
@@ -104,6 +108,14 @@ module Collavre
         end
 
         messages << { role: "user", parts: trigger_parts }
+      end
+
+      def current_topic
+        trigger_comment_id = @context.dig("comment", "id")
+        trigger_comment = Comment.find_by(id: trigger_comment_id)
+        return unless trigger_comment&.topic_id
+
+        Topic.find_by(id: trigger_comment.topic_id)
       end
 
       def review_eligible?

--- a/engines/collavre/app/services/collavre/ai_agent/message_builder.rb
+++ b/engines/collavre/app/services/collavre/ai_agent/message_builder.rb
@@ -48,8 +48,6 @@ module Collavre
         creative_id = @context.dig("creative", "id")
         return unless creative_id
 
-        trigger_comment_id = @context.dig("comment", "id")
-        trigger_comment = Comment.find_by(id: trigger_comment_id)
         topic_id = trigger_comment&.topic_id
 
         history_limit = @agent.chat_history_limit
@@ -64,7 +62,7 @@ module Collavre
                .limit(history_limit)
                .reverse
                .each do |c|
-          next if c.id == @context.dig("comment", "id")
+          next if c.id == trigger_comment&.id
 
           role = (c.user_id == @agent.id) ? "model" : "user"
           content = c.content.to_s
@@ -110,9 +108,14 @@ module Collavre
         messages << { role: "user", parts: trigger_parts }
       end
 
+      def trigger_comment
+        @trigger_comment ||= begin
+          id = @context.dig("comment", "id")
+          Comment.find_by(id: id) if id
+        end
+      end
+
       def current_topic
-        trigger_comment_id = @context.dig("comment", "id")
-        trigger_comment = Comment.find_by(id: trigger_comment_id)
         return unless trigger_comment&.topic_id
 
         Topic.find_by(id: trigger_comment.topic_id)


### PR DESCRIPTION
## Summary
Add current topic name and ID to the creative context prefix sent to AI agents.

## Changes
- Modified `MessageBuilder#append_creative_context` to include topic info
- Added `current_topic` helper that resolves topic from the trigger comment
- Format: `Creative (id: X):\nTopic: name (id: Y)\n...`

## Why
AI agents had no way to know which topic they were responding in. This context is needed for:
- Topic-aware cron job creation
- Better context-aware responses
- Routing messages to the correct topic