### PR TITLE
fix: remove process guard from CronSchedulerJob boot initializer

### DIFF
--- a/engines/collavre/lib/collavre/engine.rb
+++ b/engines/collavre/lib/collavre/engine.rb
@@ -70,17 +70,20 @@ module Collavre
 
     # Boot the self-scheduling CronSchedulerJob for dynamic recurring tasks.
     # Uses DB-based guard (SolidQueue::Job table) to prevent duplicate chains.
+    # Boot the self-scheduling CronSchedulerJob for dynamic recurring tasks.
+    # Uses DB-based guard (SolidQueue::Job table) to prevent duplicate chains.
+    # Runs in any non-test process that has DB access — the DB guard ensures
+    # only one scheduler chain is active regardless of how many processes boot.
     initializer "collavre.cron_scheduler" do
       config.after_initialize do
         next if Rails.env.test?
-
-        # Only boot in server or Solid Queue worker processes
-        next unless defined?(Rails::Server) || defined?(SolidQueue::Supervisor)
 
         # DB-based check: skip if a CronSchedulerJob is already pending
         unless SolidQueue::Job.where(class_name: "Collavre::CronSchedulerJob", finished_at: nil).exists?
           Rails.logger.info("[CronScheduler] Booting self-scheduling cron scheduler")
           Collavre::CronSchedulerJob.perform_later
+        else
+          Rails.logger.info("[CronScheduler] Already running, skipping boot")
         end
       rescue StandardError => e
         Rails.logger.error("[CronScheduler] Failed to boot: #{e.message}")


### PR DESCRIPTION
## Problem
CronSchedulerJob never booted in production because the initializer guard `defined?(Rails::Server) || defined?(SolidQueue::Supervisor)` was false — Puma launched via Kamal doesn't define `Rails::Server`.

## Fix
Remove the process guard entirely. The DB-based guard (`SolidQueue::Job` pending check) already prevents duplicate scheduler chains, making the process guard redundant.

## Notes
- Added 'already running' log for observability
- `rails db:migrate` etc. will attempt to boot but safely rescue on StandardError
- test environment is still skipped