### PR TITLE
fix: exclude failed jobs from CronSchedulerJob duplicate guard

### DIFF
--- a/engines/collavre/app/jobs/collavre/cron_scheduler_job.rb
+++ b/engines/collavre/app/jobs/collavre/cron_scheduler_job.rb
@@ -99,6 +99,10 @@ module Collavre
       # Exclude the currently running job to avoid blocking our own reschedule
       scope = scope.where.not(id: provider_job_id) if provider_job_id.present?
 
+      # Exclude failed jobs — they won't run again without manual retry
+      failed_job_ids = SolidQueue::FailedExecution.pluck(:job_id)
+      scope = scope.where.not(id: failed_job_ids) if failed_job_ids.any?
+
       scope.exists?
     end
   end

--- a/engines/collavre/app/jobs/collavre/cron_scheduler_job.rb
+++ b/engines/collavre/app/jobs/collavre/cron_scheduler_job.rb
@@ -46,7 +46,10 @@ module Collavre
       cron = Fugit.parse(task.schedule)
       return false unless cron.is_a?(Fugit::Cron)
 
-      cron.match?(time)
+      # Truncate to the beginning of the current minute so that
+      # cron.match? works regardless of which second the job runs at.
+      minute_start = time.change(sec: 0)
+      cron.match?(minute_start)
     end
 
     def cache_key(task, time)

--- a/engines/collavre/lib/collavre/engine.rb
+++ b/engines/collavre/lib/collavre/engine.rb
@@ -79,7 +79,10 @@ module Collavre
         next if Rails.env.test?
 
         # DB-based check: skip if a CronSchedulerJob is already pending
-        unless SolidQueue::Job.where(class_name: "Collavre::CronSchedulerJob", finished_at: nil).exists?
+        pending = SolidQueue::Job.where(class_name: "Collavre::CronSchedulerJob", finished_at: nil)
+        failed_ids = SolidQueue::FailedExecution.pluck(:job_id)
+        pending = pending.where.not(id: failed_ids) if failed_ids.any?
+        unless pending.exists?
           Rails.logger.info("[CronScheduler] Booting self-scheduling cron scheduler")
           Collavre::CronSchedulerJob.perform_later
         else


### PR DESCRIPTION
## Problem
CronSchedulerJob's DB guard checks for `finished_at: nil` to detect running jobs.
Failed jobs in SolidQueue also have `finished_at: nil` but will never execute without manual retry.
This caused the scheduler to never boot — it thought a job was already running when it was actually failed.

## Root Cause
A previous deployment enqueued CronSchedulerJob before the class existed in the Docker image, causing `ActiveJob::UnknownJobClassError`. The resulting `SolidQueue::FailedExecution` record blocked all subsequent boot attempts.

## Fix
Both the initializer and the `pending_scheduler_exists?` guard now exclude jobs that have a `SolidQueue::FailedExecution` record.

## Also Applied
Manually retried the stuck failed job (id: 26177) in production so the scheduler can start immediately after deploy.

## Tests
7 tests passing, Rubocop clean.