### PR TITLE
feat: refactor creative_retrieval_service for agent-friendly output

### DIFF
--- a/engines/collavre/app/services/collavre/creatives/tree_formatter.rb
+++ b/engines/collavre/app/services/collavre/creatives/tree_formatter.rb
@@ -8,10 +8,18 @@ module Collavre
     #   - [123] My Task (50%)
     #     - [124] Subtask A (100%)
     #     - [125] Subtask B (0%)
+    #
+    # Options:
+    #   max_depth:        Max tree depth (nil = unlimited)
+    #   include_header:   Include format comment header (default: true)
+    #   include_comments: Include recent comments per node (default: false)
+    #   use_permissions:  Use permission-filtered children (default: true)
     class TreeFormatter
-      def initialize(max_depth: nil, include_header: true)
+      def initialize(max_depth: nil, include_header: true, include_comments: false, use_permissions: true)
         @max_depth = max_depth
         @include_header = include_header
+        @include_comments = include_comments
+        @use_permissions = use_permissions
       end
 
       def format(creatives)
@@ -26,19 +34,41 @@ module Collavre
         lines.join("\n")
       end
 
+      # Extract plain text description from a creative (shared helper)
+      def self.plain_description(creative)
+        raw = creative.effective_description(nil, true)
+        ActionView::Base.full_sanitizer.sanitize(raw).strip
+      end
+
       private
 
       def format_node(node, depth, lines)
         return if @max_depth && depth > @max_depth
 
         indent = "  " * depth
-        desc = ActionController::Base.helpers.strip_tags(node.effective_description(nil, false))
+        desc = self.class.plain_description(node)
         progress = ((node.progress || 0.0) * 100).round
 
         lines << "#{indent}- [#{node.id}] #{desc} (#{progress}%)"
 
-        node.children.each do |child|
+        if @include_comments
+          node.comments.order(created_at: :desc).limit(3).reverse_each do |comment|
+            comment_text = ActionView::Base.full_sanitizer.sanitize(comment.content).strip.truncate(100)
+            lines << "#{indent}    > #{comment_text}"
+          end
+        end
+
+        children_for(node).each do |child|
           format_node(child, depth + 1, lines)
+        end
+      end
+
+      def children_for(node)
+        if @use_permissions
+          node.linked_children
+        else
+          # When children are pre-set on association target (e.g. GeminiParentRecommender)
+          node.children
         end
       end
     end

--- a/engines/collavre/app/services/collavre/creatives/tree_formatter.rb
+++ b/engines/collavre/app/services/collavre/creatives/tree_formatter.rb
@@ -1,9 +1,23 @@
 module Collavre
   module Creatives
+    # Compact markdown tree formatter for AI Agent consumption.
+    # Used by: creative_retrieval_service, GeminiParentRecommender, Agent context injection.
+    #
+    # Output format (header declared once, rows are values only):
+    #   <!-- format: [id] description (progress%) -->
+    #   - [123] My Task (50%)
+    #     - [124] Subtask A (100%)
+    #     - [125] Subtask B (0%)
     class TreeFormatter
+      def initialize(max_depth: nil, include_header: true)
+        @max_depth = max_depth
+        @include_header = include_header
+      end
+
       def format(creatives)
         roots = Array(creatives)
         lines = []
+        lines << "<!-- format: [id] description (progress%) -->" if @include_header
 
         roots.each do |root|
           format_node(root, 0, lines)
@@ -15,18 +29,14 @@ module Collavre
       private
 
       def format_node(node, depth, lines)
-        indent = " " * (depth * 4)
+        return if @max_depth && depth > @max_depth
+
+        indent = "  " * depth
         desc = ActionController::Base.helpers.strip_tags(node.effective_description(nil, false))
-        progress = node.progress || 0.0
+        progress = ((node.progress || 0.0) * 100).round
 
-        node_data = { id: node.id, progress: progress, desc: desc }
-        lines << "#{indent}- #{node_data.to_json}"
+        lines << "#{indent}- [#{node.id}] #{desc} (#{progress}%)"
 
-        # We need to handle children. If the node is a new instance (in tests),
-        # children might depend on how it's set up.
-        # In real app, we use children association.
-        # To match the logic in views/controllers where we might want specific ordering:
-        # We'll validly assume `children` association is available.
         node.children.each do |child|
           format_node(child, depth + 1, lines)
         end

--- a/engines/collavre/app/services/collavre/gemini_parent_recommender.rb
+++ b/engines/collavre/app/services/collavre/gemini_parent_recommender.rb
@@ -35,7 +35,7 @@ module Collavre
 
       tree_text = Creatives::TreeFormatter.new(use_permissions: false).format(top_level_categories)
 
-      prompt = build_prompt(tree_text, ActionController::Base.helpers.strip_tags(creative.description).to_s)
+      prompt = build_prompt(tree_text, Creatives::TreeFormatter.plain_description(creative))
       Rails.logger.info("### prompt=#{prompt}")
 
       response = @client.chat([ { role: :user, parts: [ { text: prompt } ] } ])
@@ -45,7 +45,7 @@ module Collavre
       ids.map do |id|
          c = Creative.find_by(id: id)
          next unless c
-         path = c.ancestors.reverse.map { |a| ActionController::Base.helpers.strip_tags(a.description) } + [ ActionController::Base.helpers.strip_tags(c.description) ]
+         path = c.ancestors.reverse.map { |a| Creatives::TreeFormatter.plain_description(a) } + [ Creatives::TreeFormatter.plain_description(c) ]
          { id: id, path: path.join(" > ") }
       end.compact
     end

--- a/engines/collavre/app/services/collavre/gemini_parent_recommender.rb
+++ b/engines/collavre/app/services/collavre/gemini_parent_recommender.rb
@@ -33,7 +33,7 @@ module Collavre
       category_ids = categories.index_by(&:id)
       top_level_categories = categories.reject { |c| category_ids.key?(c.parent_id) }
 
-      tree_text = Creatives::TreeFormatter.new.format(top_level_categories)
+      tree_text = Creatives::TreeFormatter.new(use_permissions: false).format(top_level_categories)
 
       prompt = build_prompt(tree_text, ActionController::Base.helpers.strip_tags(creative.description).to_s)
       Rails.logger.info("### prompt=#{prompt}")

--- a/engines/collavre/app/services/collavre/tools/creative_retrieval_service.rb
+++ b/engines/collavre/app/services/collavre/tools/creative_retrieval_service.rb
@@ -86,7 +86,6 @@ module Tools
       return [] if combined_ids.empty?
 
       Creative.where(id: combined_ids)
-              .order(:sequence)
               .sort_by { |c| c.description.to_s.length }
     end
 
@@ -107,10 +106,14 @@ module Tools
         tag_names = tags.split(",").map(&:strip)
         label_ids = Label.where(value: tag_names).pluck(:id)
         tagged_ids = Tag.where(label_id: label_ids).pluck(:creative_id).to_set
-        # Include creative if it or any descendant is tagged
-        all_descendant_ids = creatives.flat_map { |c| c.self_and_descendants.pluck(:id) }.to_set
-        matching_tagged = tagged_ids & all_descendant_ids
-        result = result.select { |c| matching_tagged.include?(c.id) || (c.self_and_descendants.pluck(:id).to_set & matching_tagged).any? }
+        # Batch: find which input creatives have tagged descendants (single query)
+        creative_ids = result.map(&:id)
+        ancestors_with_tagged = CreativeHierarchy
+          .where(ancestor_id: creative_ids)
+          .where(descendant_id: tagged_ids.to_a)
+          .pluck(:ancestor_id)
+          .to_set
+        result = result.select { |c| tagged_ids.include?(c.id) || ancestors_with_tagged.include?(c.id) }
       end
 
       if progress_min.present?
@@ -169,7 +172,7 @@ module Tools
         result[:recent_comments] = creative.comments.order(created_at: :desc).limit(3).map do |comment|
           {
             content: ActionView::Base.full_sanitizer.sanitize(comment.content).strip.truncate(200),
-            user: comment.user&.email,
+            user: comment.user&.display_name || comment.user&.name,
             created_at: comment.created_at&.iso8601
           }
         end

--- a/engines/collavre/app/services/collavre/tools/creative_retrieval_service.rb
+++ b/engines/collavre/app/services/collavre/tools/creative_retrieval_service.rb
@@ -45,7 +45,12 @@ module Tools
       if format == "json"
         build_json_tree(creatives, depth: level, include_comments: include_comments)
       else
-        build_markdown_tree(creatives, level: 1, max_depth: level, include_comments: include_comments)
+        formatter = Creatives::TreeFormatter.new(
+          max_depth: level - 1,
+          include_header: true,
+          include_comments: include_comments
+        )
+        formatter.format(creatives) + "\n"
       end
     end
 
@@ -64,17 +69,35 @@ module Tools
     end
 
     def search_creatives(query)
-      # Search in descriptions
-      scope = Creative.where("description LIKE ?", "%#{Creative.sanitize_sql_like(query)}%")
+      sanitized = Creative.sanitize_sql_like(query)
 
-      # Also search in comments
-      comment_creative_ids = Comment.where("content LIKE ?", "%#{Comment.sanitize_sql_like(query)}%")
-                                    .pluck(:creative_id)
+      # Scope search to user's own + shared creatives via permission cache
+      accessible_ids = accessible_creative_ids
 
-      combined_ids = scope.pluck(:id) | comment_creative_ids
+      desc_ids = Creative.where(id: accessible_ids)
+                         .where("description LIKE ?", "%#{sanitized}%")
+                         .pluck(:id)
+
+      comment_ids = Comment.where(creative_id: accessible_ids)
+                           .where("content LIKE ?", "%#{sanitized}%")
+                           .pluck(:creative_id)
+
+      combined_ids = (desc_ids | comment_ids)
+      return [] if combined_ids.empty?
+
       Creative.where(id: combined_ids)
-              .select { |c| c.has_permission?(Current.user, :read) }
+              .order(:sequence)
               .sort_by { |c| c.description.to_s.length }
+    end
+
+    def accessible_creative_ids
+      # User's own creatives + those shared via permission cache
+      own_ids = Creative.where(user: Current.user).pluck(:id)
+      shared_ids = CreativeSharesCache
+                     .where(user_id: Current.user.id)
+                     .where.not(permission: :no_access)
+                     .pluck(:creative_id)
+      own_ids | shared_ids
     end
 
     def apply_filters(creatives, tags:, progress_min:, progress_max:, updated_since:)
@@ -83,8 +106,11 @@ module Tools
       if tags.present?
         tag_names = tags.split(",").map(&:strip)
         label_ids = Label.where(value: tag_names).pluck(:id)
-        tagged_creative_ids = Tag.where(label_id: label_ids).pluck(:creative_id).to_set
-        result = result.select { |c| tagged_creative_ids.include?(c.id) || (c.self_and_descendants.pluck(:id) & tagged_creative_ids.to_a).any? }
+        tagged_ids = Tag.where(label_id: label_ids).pluck(:creative_id).to_set
+        # Include creative if it or any descendant is tagged
+        all_descendant_ids = creatives.flat_map { |c| c.self_and_descendants.pluck(:id) }.to_set
+        matching_tagged = tagged_ids & all_descendant_ids
+        result = result.select { |c| matching_tagged.include?(c.id) || (c.self_and_descendants.pluck(:id).to_set & matching_tagged).any? }
       end
 
       if progress_min.present?
@@ -97,50 +123,19 @@ module Tools
 
       if updated_since.present?
         since = Time.parse(updated_since)
-        result = result.select { |c| c.updated_at >= since || c.descendants.where("updated_at >= ?", since).exists? }
+        # Batch check: get all descendant IDs with updates, then filter
+        creative_ids = result.map(&:id)
+        updated_descendant_ancestors = CreativeHierarchy
+          .where(ancestor_id: creative_ids)
+          .joins("INNER JOIN creatives ON creatives.id = creative_hierarchies.descendant_id")
+          .where("creatives.updated_at >= ?", since)
+          .pluck(:ancestor_id)
+          .to_set
+
+        result = result.select { |c| c.updated_at >= since || updated_descendant_ancestors.include?(c.id) }
       end
 
       result
-    end
-
-    # --- Markdown format ---
-
-    def build_markdown_tree(creatives, level:, max_depth:, include_comments: false, header: true)
-      # Use shared TreeFormatter for base tree, then append comments if needed
-      if include_comments
-        build_markdown_tree_with_comments(creatives, level: level, max_depth: max_depth, header: header)
-      else
-        formatter = Creatives::TreeFormatter.new(max_depth: max_depth - 1, include_header: header)
-        formatter.format(creatives) + "\n"
-      end
-    end
-
-    def build_markdown_tree_with_comments(creatives, level:, max_depth:, header: true)
-      md = ""
-      md += "<!-- format: [id] description (progress%) -->\n" if header
-
-      return md if creatives.blank? || level > max_depth
-
-      creatives.each do |creative|
-        desc = plain_description(creative)
-        progress = (creative.progress.to_f * 100).round
-        indent = "  " * (level - 1)
-
-        md += "#{indent}- [#{creative.id}] #{desc} (#{progress}%)\n"
-
-        recent_comments = creative.comments.order(created_at: :desc).limit(3)
-        recent_comments.reverse_each do |comment|
-          comment_text = ActionView::Base.full_sanitizer.sanitize(comment.content).strip.truncate(100)
-          md += "#{indent}    > #{comment_text}\n"
-        end
-
-        children = creative.linked_children
-        if children.present? && level < max_depth
-          md += build_markdown_tree_with_comments(children, level: level + 1, max_depth: max_depth, header: false)
-        end
-      end
-
-      md
     end
 
     # --- JSON format ---
@@ -154,16 +149,18 @@ module Tools
     end
 
     def serialize_creative(creative, depth:, current_depth:, include_comments: false)
+      children = creative.linked_children
+
       result = {
         id: creative.id,
-        description: plain_description(creative),
+        description: Creatives::TreeFormatter.plain_description(creative),
         progress: creative.progress.to_f.round(2),
         parent_id: creative.parent_id,
         tags: creative.tags.includes(:label).map { |t| t.label&.value }.compact,
         linked: creative.origin_id.present?,
         origin_id: creative.origin_id,
-        has_children: creative.linked_children.any?,
-        children_count: creative.linked_children.size,
+        has_children: children.any?,
+        children_count: children.size,
         created_at: creative.created_at&.iso8601,
         updated_at: creative.updated_at&.iso8601
       }
@@ -179,7 +176,7 @@ module Tools
       end
 
       if current_depth < depth
-        result[:children] = creative.linked_children.map do |child|
+        result[:children] = children.map do |child|
           serialize_creative(child, depth: depth, current_depth: current_depth + 1, include_comments: include_comments)
         end
       else
@@ -187,13 +184,6 @@ module Tools
       end
 
       result
-    end
-
-    # --- Helpers ---
-
-    def plain_description(creative)
-      raw = creative.effective_description(nil, true)
-      ActionView::Base.full_sanitizer.sanitize(raw).strip
     end
   end
 end

--- a/engines/collavre/app/services/collavre/tools/creative_retrieval_service.rb
+++ b/engines/collavre/app/services/collavre/tools/creative_retrieval_service.rb
@@ -106,6 +106,16 @@ module Tools
     # --- Markdown format ---
 
     def build_markdown_tree(creatives, level:, max_depth:, include_comments: false, header: true)
+      # Use shared TreeFormatter for base tree, then append comments if needed
+      if include_comments
+        build_markdown_tree_with_comments(creatives, level: level, max_depth: max_depth, header: header)
+      else
+        formatter = Creatives::TreeFormatter.new(max_depth: max_depth - 1, include_header: header)
+        formatter.format(creatives) + "\n"
+      end
+    end
+
+    def build_markdown_tree_with_comments(creatives, level:, max_depth:, header: true)
       md = ""
       md += "<!-- format: [id] description (progress%) -->\n" if header
 
@@ -118,17 +128,15 @@ module Tools
 
         md += "#{indent}- [#{creative.id}] #{desc} (#{progress}%)\n"
 
-        if include_comments
-          recent_comments = creative.comments.order(created_at: :desc).limit(3)
-          recent_comments.reverse_each do |comment|
-            comment_text = ActionView::Base.full_sanitizer.sanitize(comment.content).strip.truncate(100)
-            md += "#{indent}    > #{comment_text}\n"
-          end
+        recent_comments = creative.comments.order(created_at: :desc).limit(3)
+        recent_comments.reverse_each do |comment|
+          comment_text = ActionView::Base.full_sanitizer.sanitize(comment.content).strip.truncate(100)
+          md += "#{indent}    > #{comment_text}\n"
         end
 
         children = creative.linked_children
         if children.present? && level < max_depth
-          md += build_markdown_tree(children, level: level + 1, max_depth: max_depth, include_comments: include_comments, header: false)
+          md += build_markdown_tree_with_comments(children, level: level + 1, max_depth: max_depth, header: false)
         end
       end
 

--- a/engines/collavre/app/services/collavre/tools/creative_retrieval_service.rb
+++ b/engines/collavre/app/services/collavre/tools/creative_retrieval_service.rb
@@ -7,131 +7,185 @@ module Tools
     extend ToolMeta
 
     tool_name "creative_retrieval_service"
-    tool_description "Retrieve creatives by ID or query text. without query  or ID, it will return root creatives. Returns a list of matching creatives with their details, supporting both hierarchical tree and flat list formats.\n\nA Creative is a content block that functions like a task, organized in a tree structure similar to a to-do list. You can navigate the tree at any level as a structured document, with progress automatically calculated to show what’s been completed.\n\ne.g.\n- When user say creative or Test creative, it means \"Test\" creative and it's children as a writing page.\n- Summary of Test creative? - you need to search \"Test\" creatives with level 3 or more and find the title is \"Test\" or similar and make summary of that."
+    tool_description "Retrieve creatives by ID or query text. Without query or ID, it returns root creatives.\n\nA Creative is a content block that functions like a task, organized in a tree structure similar to a to-do list. You can navigate the tree at any level as a structured document, with progress automatically calculated to show what's been completed.\n\nDefault output is a compact markdown tree:\n<!-- format: [id] description (progress%) -->\n- [123] My Task (50%)\n  - [124] Subtask A (100%)\n  - [125] Subtask B (0%)\n\ne.g.\n- When user say creative or Test creative, it means \"Test\" creative and it's children as a writing page.\n- Summary of Test creative? - you need to search \"Test\" creatives with level 3 or more and find the title is \"Test\" or similar and make summary of that."
 
-    tool_param :id, description: "The ID of the creative to retrieve."
-    tool_param :query, description: "Text to search for in creative descriptions."
+    tool_param :id, description: "The ID of the creative to retrieve with its subtree."
+    tool_param :query, description: "Text to search for in creative descriptions and comments."
     tool_param :level, description: "Creative tree depth to return (default: 3).", required: false
-    tool_param :simple, description: "If true, returns a simplified flat list. If false (default), returns a tree structure with HTML.", required: false
+    tool_param :tags, description: "Filter by tag names (comma-separated).", required: false
+    tool_param :progress_min, description: "Min progress filter (0.0-1.0).", required: false
+    tool_param :progress_max, description: "Max progress filter (0.0-1.0).", required: false
+    tool_param :updated_since, description: "ISO8601 timestamp - only items updated after this.", required: false
+    tool_param :include_comments, description: "Include recent comments per creative (default: false).", required: false
+    tool_param :format, description: "Response format: 'markdown' (default, compact tree) or 'json' (structured data with tags/dates).", required: false
 
-    sig { params(id: T.nilable(Integer), query: T.nilable(String), level: T.nilable(Integer), simple: T.nilable(T::Boolean)).returns(T::Array[T::Hash[Symbol, T.untyped]]) }
-    def call(id: nil, query: nil, level: 3, simple: false)
+    sig do
+      params(
+        id: T.nilable(Integer),
+        query: T.nilable(String),
+        level: T.nilable(Integer),
+        tags: T.nilable(String),
+        progress_min: T.nilable(Float),
+        progress_max: T.nilable(Float),
+        updated_since: T.nilable(String),
+        include_comments: T.nilable(T::Boolean),
+        format: T.nilable(String)
+      ).returns(T.any(String, T::Array[T::Hash[Symbol, T.untyped]]))
+    end
+    def call(id: nil, query: nil, level: 3, tags: nil, progress_min: nil, progress_max: nil, updated_since: nil, include_comments: false, format: "markdown")
       level ||= 3
-      simple ||= false
+      format ||= "markdown"
+      include_comments ||= false
 
-      # Ensure fresh permission cache for this tool execution
-      Current.creative_share_cache = nil if Current.respond_to?(:creative_share_cache=)
+      raise "Current.user is required" unless Current.user
 
-      # Mock session and request setup
-      setup_mock_environment
+      creatives = fetch_creatives(id: id, query: query)
+      creatives = apply_filters(creatives, tags: tags, progress_min: progress_min, progress_max: progress_max, updated_since: updated_since)
 
-      controller = Collavre::CreativesController.new
-      setup_controller(controller)
-
-      if id.present?
-        # Get the creative details (show)
-        show_result = dispatch_request(controller, :show, id: id, format: :json)
-        return show_result if show_result.is_a?(Array) && show_result.first[:error]
-
-        # Get the children (index with id acts as parent filter)
-        index_result = dispatch_request(controller, :index, id: id, search: query, simple: simple, level: level, format: :json)
-        return index_result if index_result.is_a?(Array) && index_result.first[:error]
-
-        # Combine results
-        # show_result is expected to be a hash of the creative
-        # index_result is expected to be a list of children or simple list
-
-        # Parse show result
-        creative_details = JSON.parse(show_result[:body], symbolize_names: true)
-
-        # Parse index result
-        children_data = JSON.parse(index_result[:body], symbolize_names: true)
-        filtered_children = filter_result(children_data)
-
-        # Merge
-        # We construct a tree node for the parent, with the children attached
-        parent_node = filter_tree([ creative_details ]).first
-        parent_node[:children] = filtered_children
-
-        [ parent_node ]
+      if format == "json"
+        build_json_tree(creatives, depth: level, include_comments: include_comments)
       else
-        # Normal index call
-        result = dispatch_request(controller, :index, search: query, simple: simple, level: level, format: :json)
-
-        if result[:status] == 200
-           parsed = JSON.parse(result[:body], symbolize_names: true)
-           filter_result(parsed)
-        else
-           [ { error: "Controller returned status #{result[:status]}", body: result[:body] } ]
-        end
+        build_markdown_tree(creatives, level: 1, max_depth: level, include_comments: include_comments)
       end
     end
 
     private
 
-    def setup_mock_environment
-      raise "Current.user is required" unless Current.user
-      unless Current.session
-        require "ostruct"
-        Current.session = OpenStruct.new(user: Current.user, persisted?: false)
-      end
-    end
-
-    def setup_controller(controller)
-      # Stub cookies
-      controller.define_singleton_method(:cookies) do
-        @mock_cookies ||= begin
-          jar = OpenStruct.new
-          def jar.signed; self; end
-          def jar.encrypted; self; end
-          def jar.[](key); nil; end
-          def jar.delete(key); nil; end
-          jar
-        end
-      end
-    end
-
-    def dispatch_request(controller, action, params)
-      env = Rack::MockRequest.env_for(
-        "/creatives",
-        method: "GET",
-        params: params.compact,
-        "HTTP_X_ORIGIN_SECRET" => ENV["ORIGIN_SHARED_SECRET"] # Internal call
-      )
-      controller.request = ActionDispatch::Request.new(env)
-      controller.response = ActionDispatch::Response.new
-      controller.process(action)
-
-      { status: controller.response.status, body: controller.response.body }
-    end
-
-    def filter_result(result)
-      if result.is_a?(Array)
-        # Simple mode
-        result.map { |item| item.slice(:id, :description, :progress) }
-      elsif result.is_a?(Hash) && result[:creatives].is_a?(Array)
-        # Normal mode (Tree)
-        filter_tree(result[:creatives])
+    def fetch_creatives(id:, query:)
+      if id.present?
+        creative = Creative.find_by(id: id)
+        return [] unless creative && creative.has_permission?(Current.user, :read)
+        [ creative ]
+      elsif query.present?
+        search_creatives(query)
       else
-        []
+        Creative.where(user: Current.user).roots.order(:sequence).to_a
       end
     end
 
-    def filter_tree(nodes)
-      nodes.map do |node|
-        description = if node.dig(:templates, :description_html)
-          Rails::Html::FullSanitizer.new.sanitize(node.dig(:templates, :description_html))
-        else
-          node[:description]
+    def search_creatives(query)
+      # Search in descriptions
+      scope = Creative.where("description LIKE ?", "%#{Creative.sanitize_sql_like(query)}%")
+
+      # Also search in comments
+      comment_creative_ids = Comment.where("content LIKE ?", "%#{Comment.sanitize_sql_like(query)}%")
+                                    .pluck(:creative_id)
+
+      combined_ids = scope.pluck(:id) | comment_creative_ids
+      Creative.where(id: combined_ids)
+              .select { |c| c.has_permission?(Current.user, :read) }
+              .sort_by { |c| c.description.to_s.length }
+    end
+
+    def apply_filters(creatives, tags:, progress_min:, progress_max:, updated_since:)
+      result = creatives
+
+      if tags.present?
+        tag_names = tags.split(",").map(&:strip)
+        label_ids = Label.where(value: tag_names).pluck(:id)
+        tagged_creative_ids = Tag.where(label_id: label_ids).pluck(:creative_id).to_set
+        result = result.select { |c| tagged_creative_ids.include?(c.id) || (c.self_and_descendants.pluck(:id) & tagged_creative_ids.to_a).any? }
+      end
+
+      if progress_min.present?
+        result = result.select { |c| c.progress.to_f >= progress_min.to_f }
+      end
+
+      if progress_max.present?
+        result = result.select { |c| c.progress.to_f <= progress_max.to_f }
+      end
+
+      if updated_since.present?
+        since = Time.parse(updated_since)
+        result = result.select { |c| c.updated_at >= since || c.descendants.where("updated_at >= ?", since).exists? }
+      end
+
+      result
+    end
+
+    # --- Markdown format ---
+
+    def build_markdown_tree(creatives, level:, max_depth:, include_comments: false, header: true)
+      md = ""
+      md += "<!-- format: [id] description (progress%) -->\n" if header
+
+      return md if creatives.blank? || level > max_depth
+
+      creatives.each do |creative|
+        desc = plain_description(creative)
+        progress = (creative.progress.to_f * 100).round
+        indent = "  " * (level - 1)
+
+        md += "#{indent}- [#{creative.id}] #{desc} (#{progress}%)\n"
+
+        if include_comments
+          recent_comments = creative.comments.order(created_at: :desc).limit(3)
+          recent_comments.reverse_each do |comment|
+            comment_text = ActionView::Base.full_sanitizer.sanitize(comment.content).strip.truncate(100)
+            md += "#{indent}    > #{comment_text}\n"
+          end
         end
 
-        {
-          id: node[:id],
-          description: description&.strip,
-          progress: node.dig(:inline_editor_payload, :progress) || node[:progress],
-          children: node.dig(:children_container, :nodes) ? filter_tree(node.dig(:children_container, :nodes)) : []
-        }
+        children = creative.linked_children
+        if children.present? && level < max_depth
+          md += build_markdown_tree(children, level: level + 1, max_depth: max_depth, include_comments: include_comments, header: false)
+        end
       end
+
+      md
+    end
+
+    # --- JSON format ---
+
+    def build_json_tree(creatives, depth:, include_comments: false)
+      return [] if creatives.blank?
+
+      creatives.map do |creative|
+        serialize_creative(creative, depth: depth, current_depth: 1, include_comments: include_comments)
+      end
+    end
+
+    def serialize_creative(creative, depth:, current_depth:, include_comments: false)
+      result = {
+        id: creative.id,
+        description: plain_description(creative),
+        progress: creative.progress.to_f.round(2),
+        parent_id: creative.parent_id,
+        tags: creative.tags.includes(:label).map { |t| t.label&.value }.compact,
+        linked: creative.origin_id.present?,
+        origin_id: creative.origin_id,
+        has_children: creative.linked_children.any?,
+        children_count: creative.linked_children.size,
+        created_at: creative.created_at&.iso8601,
+        updated_at: creative.updated_at&.iso8601
+      }
+
+      if include_comments
+        result[:recent_comments] = creative.comments.order(created_at: :desc).limit(3).map do |comment|
+          {
+            content: ActionView::Base.full_sanitizer.sanitize(comment.content).strip.truncate(200),
+            user: comment.user&.email,
+            created_at: comment.created_at&.iso8601
+          }
+        end
+      end
+
+      if current_depth < depth
+        result[:children] = creative.linked_children.map do |child|
+          serialize_creative(child, depth: depth, current_depth: current_depth + 1, include_comments: include_comments)
+        end
+      else
+        result[:children] = []
+      end
+
+      result
+    end
+
+    # --- Helpers ---
+
+    def plain_description(creative)
+      raw = creative.effective_description(nil, true)
+      ActionView::Base.full_sanitizer.sanitize(raw).strip
     end
   end
 end

--- a/engines/collavre/test/services/creatives/tree_formatter_test.rb
+++ b/engines/collavre/test/services/creatives/tree_formatter_test.rb
@@ -2,17 +2,24 @@ require "test_helper"
 
 module Creatives
   class TreeFormatterTest < ActiveSupport::TestCase
-    test "formats single root correctly" do
+    test "formats single root with header" do
       root = Creative.new(id: 1, description: "Root", progress: 0.5)
 
       formatter = Creatives::TreeFormatter.new
       result = formatter.format(root)
 
-      expected = <<~TEXT.chomp
-        - {"id":1,"progress":0.5,"desc":"Root"}
-      TEXT
+      assert_includes result, "<!-- format: [id] description (progress%) -->"
+      assert_includes result, "- [1] Root (50%)"
+    end
 
-      assert_equal expected, result
+    test "formats without header when include_header is false" do
+      root = Creative.new(id: 1, description: "Root", progress: 0.5)
+
+      formatter = Creatives::TreeFormatter.new(include_header: false)
+      result = formatter.format(root)
+
+      refute_includes result, "<!-- format:"
+      assert_includes result, "- [1] Root (50%)"
     end
 
     test "formats tree with depth correctly" do
@@ -35,10 +42,11 @@ module Creatives
       result = formatter.format(root)
 
       expected = <<~TEXT.chomp
-        - {"id":1,"progress":0.0,"desc":"Root"}
-            - {"id":2,"progress":1.0,"desc":"Child1"}
-            - {"id":3,"progress":0.0,"desc":"Child2"}
-                - {"id":4,"progress":0.0,"desc":"Child2-1"}
+        <!-- format: [id] description (progress%) -->
+        - [1] Root (0%)
+          - [2] Child1 (100%)
+          - [3] Child2 (0%)
+            - [4] Child2-1 (0%)
       TEXT
 
       assert_equal expected, result
@@ -60,30 +68,48 @@ module Creatives
       result = formatter.format([ root1, root2 ])
 
       expected = <<~TEXT.chomp
-        - {"id":1,"progress":0.0,"desc":"Root1"}
-            - {"id":2,"progress":1.0,"desc":"Child1"}
-        - {"id":3,"progress":1.0,"desc":"Root2"}
+        <!-- format: [id] description (progress%) -->
+        - [1] Root1 (0%)
+          - [2] Child1 (100%)
+        - [3] Root2 (100%)
       TEXT
 
       assert_equal expected, result
     end
+
+    test "respects max_depth" do
+      root = Creative.new(id: 1, description: "Root", progress: 0.0)
+      child = Creative.new(id: 2, description: "Child", progress: 0.0, parent: root)
+      grandchild = Creative.new(id: 3, description: "Grandchild", progress: 0.0, parent: child)
+
+      def root.children; [ @child ]; end
+      def child.children; [ @grandchild ]; end
+      def grandchild.children; []; end
+
+      root.instance_variable_set(:@child, child)
+      child.instance_variable_set(:@grandchild, grandchild)
+
+      formatter = Creatives::TreeFormatter.new(max_depth: 1)
+      result = formatter.format(root)
+
+      assert_includes result, "[1] Root"
+      assert_includes result, "[2] Child"
+      refute_includes result, "Grandchild"
+    end
+
     test "formats tree correctly with manually set children association" do
       root = Creative.new(id: 1, description: "Root", progress: 0.0)
       child = Creative.new(id: 2, description: "Child", progress: 0.0, parent: root)
 
       # Manually set the association target as we do in GeminiParentRecommender
       root.association(:children).target = [ child ]
-      child.association(:children).target = [] # Ensure recursion stops without db lookup
+      child.association(:children).target = []
 
       formatter = Creatives::TreeFormatter.new
       result = formatter.format(root)
 
-      expected = <<~TEXT.chomp
-        - {"id":1,"progress":0.0,"desc":"Root"}
-            - {"id":2,"progress":0.0,"desc":"Child"}
-      TEXT
-
-      assert_equal expected, result
+      assert_includes result, "- [1] Root (0%)"
+      assert_includes result, "  - [2] Child (0%)"
     end
   end
 end

--- a/engines/collavre/test/services/creatives/tree_formatter_test.rb
+++ b/engines/collavre/test/services/creatives/tree_formatter_test.rb
@@ -5,7 +5,7 @@ module Creatives
     test "formats single root with header" do
       root = Creative.new(id: 1, description: "Root", progress: 0.5)
 
-      formatter = Creatives::TreeFormatter.new
+      formatter = Creatives::TreeFormatter.new(use_permissions: false)
       result = formatter.format(root)
 
       assert_includes result, "<!-- format: [id] description (progress%) -->"
@@ -15,7 +15,7 @@ module Creatives
     test "formats without header when include_header is false" do
       root = Creative.new(id: 1, description: "Root", progress: 0.5)
 
-      formatter = Creatives::TreeFormatter.new(include_header: false)
+      formatter = Creatives::TreeFormatter.new(include_header: false, use_permissions: false)
       result = formatter.format(root)
 
       refute_includes result, "<!-- format:"
@@ -28,7 +28,6 @@ module Creatives
       child2 = Creative.new(id: 3, description: "Child2", progress: 0.0, parent: root)
       child2_1 = Creative.new(id: 4, description: "Child2-1", progress: 0.0, parent: child2)
 
-      # Mock children association since these are not saved records
       def root.children; [ @child1, @child2 ]; end
       def child2.children; [ @child2_1 ]; end
       def child1.children; []; end
@@ -38,7 +37,7 @@ module Creatives
       root.instance_variable_set(:@child2, child2)
       child2.instance_variable_set(:@child2_1, child2_1)
 
-      formatter = Creatives::TreeFormatter.new
+      formatter = Creatives::TreeFormatter.new(use_permissions: false)
       result = formatter.format(root)
 
       expected = <<~TEXT.chomp
@@ -57,14 +56,13 @@ module Creatives
       child1 = Creative.new(id: 2, description: "Child1", progress: 1.0, parent: root1)
       root2 = Creative.new(id: 3, description: "Root2", progress: 1.0)
 
-      # Mock children
       def root1.children; [ @child1 ]; end
       def child1.children; []; end
       def root2.children; []; end
 
       root1.instance_variable_set(:@child1, child1)
 
-      formatter = Creatives::TreeFormatter.new
+      formatter = Creatives::TreeFormatter.new(use_permissions: false)
       result = formatter.format([ root1, root2 ])
 
       expected = <<~TEXT.chomp
@@ -89,7 +87,7 @@ module Creatives
       root.instance_variable_set(:@child, child)
       child.instance_variable_set(:@grandchild, grandchild)
 
-      formatter = Creatives::TreeFormatter.new(max_depth: 1)
+      formatter = Creatives::TreeFormatter.new(max_depth: 1, use_permissions: false)
       result = formatter.format(root)
 
       assert_includes result, "[1] Root"
@@ -101,15 +99,20 @@ module Creatives
       root = Creative.new(id: 1, description: "Root", progress: 0.0)
       child = Creative.new(id: 2, description: "Child", progress: 0.0, parent: root)
 
-      # Manually set the association target as we do in GeminiParentRecommender
       root.association(:children).target = [ child ]
       child.association(:children).target = []
 
-      formatter = Creatives::TreeFormatter.new
+      formatter = Creatives::TreeFormatter.new(use_permissions: false)
       result = formatter.format(root)
 
       assert_includes result, "- [1] Root (0%)"
       assert_includes result, "  - [2] Child (0%)"
+    end
+
+    test "plain_description strips HTML" do
+      creative = Creative.new(description: "<b>Bold</b> text")
+      result = Creatives::TreeFormatter.plain_description(creative)
+      assert_equal "Bold text", result
     end
   end
 end

--- a/engines/collavre/test/services/tools/creative_retrieval_service_test.rb
+++ b/engines/collavre/test/services/tools/creative_retrieval_service_test.rb
@@ -7,72 +7,183 @@ module Tools
       @other_user = users(:two)
 
       perform_enqueued_jobs do
-        @parent = Creative.create!(user: @user, description: "Parent Creative")
-        @child = Creative.create!(user: @user, parent: @parent, description: "Child Creative")
+        @parent = Creative.create!(user: @user, description: "Parent Creative", progress: 0.5)
+        @child = Creative.create!(user: @user, parent: @parent, description: "Child Creative", progress: 1.0)
+        @child2 = Creative.create!(user: @user, parent: @parent, description: "Another Child", progress: 0.0)
 
         # Setup another user who has permission on the parent
         CreativeShare.create!(user: @other_user, creative: @parent, permission: :read)
       end
     end
 
-    test "retrieves children when user has permission on parent" do
-      # Simulate the other user context
-      Current.set(user: @other_user) do
+    # --- A. Direct model access (no controller mocking) ---
+
+    test "retrieves root creatives when no id or query given" do
+      Current.set(user: @user) do
         service = Tools::CreativeRetrievalService.new
+        result = service.call
 
-        # Call with parent ID
-        results = service.call(id: @parent.id, level: 2)
-
-        assert_not_empty results, "Should return results"
-        parent_result = results.first
-
-        assert_equal @parent.id, parent_result[:id], "Should return parent details"
-        assert_not_empty parent_result[:children], "Should include children"
-
-        child_result = parent_result[:children].first
-        assert_equal @child.id, child_result[:id], "Child ID should match"
+        assert_kind_of String, result
+        assert_includes result, "[#{@parent.id}] Parent Creative"
       end
     end
 
-    test "clears permission cache before execution" do
-      # Pre-populate cache with something that would cause failure if not cleared or reused incorrectly
-      # In this test we just ensure it runs without error even if cache was dirty
-      Current.creative_share_cache = { @parent.id => "dirty" }
-
+    test "retrieves children when user has permission on parent (markdown)" do
       Current.set(user: @other_user) do
         service = Tools::CreativeRetrievalService.new
-        results = service.call(id: @parent.id)
+        result = service.call(id: @parent.id, level: 2)
 
-        assert_not_empty results
-        # After call, the cache might be repopulated with correct data or nil depending on implementation details
-        # The key is that it didn't crash or return wrong data due to "dirty"
-        assert_equal @parent.id, results.first[:id]
+        assert_kind_of String, result
+        assert_includes result, "<!-- format:"
+        assert_includes result, "[#{@parent.id}] Parent Creative"
+        assert_includes result, "[#{@child.id}] Child Creative"
       end
     end
 
-    test "retrieves data when origin secret is enforced" do
-      with_env("ORIGIN_SHARED_SECRET" => "test_secret") do
-        Current.set(user: @other_user) do
-          service = Tools::CreativeRetrievalService.new
+    test "retrieves children in json format" do
+      Current.set(user: @other_user) do
+        service = Tools::CreativeRetrievalService.new
+        result = service.call(id: @parent.id, level: 2, format: "json")
 
-          # This should not raise an error and return results
-          # If the secret header wasn't sent, this would fail authentication in ApplicationController (mocked)
-          results = service.call(id: @parent.id)
+        assert_kind_of Array, result
+        parent_result = result.first
+        assert_equal @parent.id, parent_result[:id]
+        assert_equal "Parent Creative", parent_result[:description]
+        assert_includes parent_result.keys, :tags
+        assert_includes parent_result.keys, :created_at
+        assert_includes parent_result.keys, :updated_at
+        assert_not_empty parent_result[:children]
+      end
+    end
 
-          assert_not_empty results
-          assert_equal @parent.id, results.first[:id]
+    test "search by query text" do
+      Current.set(user: @user) do
+        service = Tools::CreativeRetrievalService.new
+        result = service.call(query: "Child")
+
+        assert_kind_of String, result
+        assert_includes result, "Child Creative"
+        assert_includes result, "Another Child"
+      end
+    end
+
+    test "returns empty for inaccessible creative" do
+      other_parent = nil
+      perform_enqueued_jobs do
+        other_parent = Creative.create!(user: @other_user, description: "Private Creative")
+      end
+
+      Current.set(user: @user) do
+        service = Tools::CreativeRetrievalService.new
+        result = service.call(id: other_parent.id)
+
+        # Should return just the header, no content
+        assert_kind_of String, result
+        refute_includes result, "Private Creative"
+      end
+    end
+
+    # --- B. Markdown format ---
+
+    test "markdown format includes header and compact tree" do
+      Current.set(user: @user) do
+        service = Tools::CreativeRetrievalService.new
+        result = service.call(id: @parent.id, level: 3)
+
+        lines = result.strip.split("\n")
+        assert_match(/<!-- format:/, lines.first)
+        assert_match(/\- \[\d+\].*\(\d+%\)/, lines[1])
+      end
+    end
+
+    test "markdown tree respects level depth" do
+      grandchild = nil
+      perform_enqueued_jobs do
+        grandchild = Creative.create!(user: @user, parent: @child, description: "Grandchild")
+      end
+
+      Current.set(user: @user) do
+        service = Tools::CreativeRetrievalService.new
+
+        # level 2: parent + children only
+        result = service.call(id: @parent.id, level: 2)
+        refute_includes result, "Grandchild"
+
+        # level 3: includes grandchild
+        result = service.call(id: @parent.id, level: 3)
+        assert_includes result, "Grandchild"
+      end
+    end
+
+    # --- C. Filters ---
+
+    test "filter by progress range" do
+      Current.set(user: @user) do
+        service = Tools::CreativeRetrievalService.new
+
+        # Only completed items
+        result = service.call(query: "Child", progress_min: 1.0)
+        assert_includes result, "Child Creative"
+        refute_includes result, "Another Child"
+
+        # Only incomplete items
+        result = service.call(query: "Child", progress_max: 0.5)
+        refute_includes result, "Child Creative"
+        assert_includes result, "Another Child"
+      end
+    end
+
+    test "filter by updated_since" do
+      Current.set(user: @user) do
+        service = Tools::CreativeRetrievalService.new
+
+        # All should be recent
+        result = service.call(query: "Child", updated_since: 1.hour.ago.iso8601)
+        assert_includes result, "Child Creative"
+
+        # None should match far future
+        result = service.call(query: "Child", updated_since: 1.day.from_now.iso8601)
+        refute_includes result, "Child Creative"
+      end
+    end
+
+    test "filter by tags" do
+      perform_enqueued_jobs do
+        label = Label.create!(creative_id: @parent.id, value: "important", owner_id: @user.id)
+        Tag.create!(creative_id: @child.id, label: label)
+      end
+
+      Current.set(user: @user) do
+        service = Tools::CreativeRetrievalService.new
+        result = service.call(query: "Child", tags: "important")
+        assert_includes result, "Child Creative"
+      end
+    end
+
+    test "include_comments adds comment content" do
+      Comment.create!(creative: @child, user: @user, content: "This is a test comment")
+
+      Current.set(user: @user) do
+        service = Tools::CreativeRetrievalService.new
+
+        # Markdown with comments
+        result = service.call(id: @parent.id, level: 2, include_comments: true)
+        assert_includes result, "test comment"
+
+        # JSON with comments
+        result = service.call(id: @parent.id, level: 2, include_comments: true, format: "json")
+        child_node = result.first[:children].find { |c| c[:id] == @child.id }
+        assert_not_empty child_node[:recent_comments]
+      end
+    end
+
+    test "raises error without Current.user" do
+      Current.set(user: nil) do
+        service = Tools::CreativeRetrievalService.new
+        assert_raises(RuntimeError, /Current.user is required/) do
+          service.call
         end
       end
-    end
-
-    private
-
-    def with_env(env)
-      original_env = ENV.to_hash
-      env.each { |k, v| ENV[k] = v }
-      yield
-    ensure
-      ENV.replace(original_env)
     end
   end
 end


### PR DESCRIPTION
## Summary

Refactors `creative_retrieval_service` to be agent-friendly by removing controller mock layer and adding compact output formats.

### Changes

**A. Direct model access (remove controller mock)**
- Eliminates `Rack::MockRequest` / `ActionDispatch` workaround
- Queries Creative model directly with permission checks
- No more JSON serialize → parse round-trip

**B. Compact markdown format (default)**
- Format header declared once: `<!-- format: [id] description (progress%) -->`
- Each row: `- [id] desc (N%)` — no repeated labels, token-efficient
- Tree structure via indentation
- JSON format available via `format='json'` with full metadata (tags, dates, linked status)

**C. Rich filter parameters**
- `tags`: filter by label names (comma-separated)
- `progress_min` / `progress_max`: filter by progress range
- `updated_since`: ISO8601 timestamp filter
- `include_comments`: attach recent comments per creative

### Token savings
- Markdown default eliminates JSON overhead (braces, key names)
- Format header once → no `progress:` repeated per row
- `[id]` inline enables agent follow-up without extra lookups