### PR TITLE
feat: unify review and replace buttons with multi-quote support

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -599,7 +599,6 @@ body.chat-fullscreen {
 .delete-comment-btn,
 .edit-comment-btn,
 .review-comment-btn,
-.replace-comment-btn,
 .copy-comment-link-btn {
     border: none;
     background: none;
@@ -612,11 +611,6 @@ body.chat-fullscreen {
 .comment-delete-hidden,
 .comment-approve-hidden {
     display: none;
-}
-
-.replace-comment-btn:disabled {
-    opacity: 0.35;
-    cursor: default;
 }
 
 .comment-copy-notice {

--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -196,10 +196,11 @@ body.chat-fullscreen {
     margin-bottom: 0.2em;
 }
 
-.comment-quoted-text {
+.comment-quoted-text,
+.comment-content blockquote {
     border-left: 3px solid var(--color-border);
     padding: 0.3em 0.6em;
-    margin: 0;
+    margin: 0 0 0.4em 0;
     color: var(--color-muted);
     font-size: 0.9em;
     background: color-mix(in srgb, var(--color-section-bg) 50%, transparent);

--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -199,14 +199,18 @@ body.chat-fullscreen {
 .comment-quoted-text,
 .comment-content blockquote {
     border-left: 3px solid var(--color-border);
-    padding: 0.3em 0.6em;
-    margin: 0 0 0.4em 0;
+    padding: 0.2em 0.6em;
+    margin: 0 0 0.3em 0;
     color: var(--color-muted);
     font-size: 0.9em;
     background: color-mix(in srgb, var(--color-section-bg) 50%, transparent);
     border-radius: 0 4px 4px 0;
     white-space: pre-wrap;
     word-break: break-word;
+}
+
+.comment-content blockquote p {
+    margin: 0;
 }
 
 /* Quote indicator in form */

--- a/engines/collavre/app/javascript/controllers/comment_controller.js
+++ b/engines/collavre/app/javascript/controllers/comment_controller.js
@@ -8,7 +8,7 @@ if (!window._streamingCommentIds) window._streamingCommentIds = new Set()
 
 // Connects to data-controller="comment"
 export default class extends Controller {
-  static targets = ["ownerButton", "deleteButton", "approveButton", "actionApproveControls", "reviewButton", "replaceButton"]
+  static targets = ["ownerButton", "deleteButton", "approveButton", "actionApproveControls", "reviewButton"]
 
   get _commentId() {
     return this.element.dataset.commentId
@@ -123,9 +123,8 @@ export default class extends Controller {
     this.handleMouseUp = this.handleMouseUp.bind(this)
     this.element.addEventListener('mouseup', this.handleMouseUp)
 
-    // Bound handlers for review/replace buttons (stored for cleanup)
+    // Bound handler for review button (stored for cleanup)
     this._boundReviewClick = this._onReviewClick.bind(this)
-    this._boundReplaceClick = this._onReplaceClick.bind(this)
 
     this.currentUserId = document.body.dataset.currentUserId
     const commentAuthorId = this.element.dataset.userId
@@ -228,7 +227,6 @@ export default class extends Controller {
       this._streamingTimeout = null
     }
     this.element.removeEventListener('mouseup', this.handleMouseUp)
-    this._removeSelectionChangeListener()
     this.hideReviewPopup()
     if (this._reviewPopupEl) {
       this._reviewPopupEl.remove()
@@ -288,10 +286,9 @@ export default class extends Controller {
 
     this._reviewPopup = new CommonPopup(this._reviewPopupEl, {
       onSelect: () => {
-        const commentId = this.element.dataset.commentId
         const formController = this.findFormController()
         if (formController) {
-          formController.quoteComment(commentId, selectedText)
+          formController.appendReviewQuote(selectedText)
         }
         window.getSelection().removeAllRanges()
         this.hideReviewPopup()
@@ -332,44 +329,20 @@ export default class extends Controller {
     button.removeEventListener('click', this._boundReviewClick)
   }
 
-  replaceButtonTargetConnected(button) {
-    button.addEventListener('click', this._boundReplaceClick)
-    // Only listen for selectionchange when a replace button exists
-    this._addSelectionChangeListener()
-  }
-
-  replaceButtonTargetDisconnected(button) {
-    button.removeEventListener('click', this._boundReplaceClick)
-    if (!this.hasReplaceButtonTarget) {
-      this._removeSelectionChangeListener()
-    }
-  }
+  // replaceButton removed — unified into reviewButton
 
   _onReviewClick(event) {
     event.preventDefault()
     event.stopPropagation()
-    const commentId = this.element.dataset.commentId
-    const contentEl = this.element.querySelector('.comment-content')
-    const fullText = contentEl ? contentEl.textContent.trim() : ''
-    const formController = this.findFormController()
-    if (formController && fullText) {
-      formController.quoteComment(commentId, fullText)
-    }
-  }
-
-  _onReplaceClick(event) {
-    event.preventDefault()
-    event.stopPropagation()
+    // Use selected text if available, otherwise full comment text
     const selectedText = this._getSelectedTextInContent()
-    if (!selectedText) return
-
-    const commentId = this.element.dataset.commentId
+    const contentEl = this.element.querySelector('.comment-content')
+    const text = selectedText || (contentEl ? contentEl.textContent.trim() : '')
     const formController = this.findFormController()
-    if (formController) {
-      formController.quoteComment(commentId, selectedText)
+    if (formController && text) {
+      formController.appendReviewQuote(text)
     }
-    window.getSelection().removeAllRanges()
-    this._updateReplaceButton()
+    if (selectedText) window.getSelection().removeAllRanges()
   }
 
   _getSelectedTextInContent() {
@@ -388,30 +361,7 @@ export default class extends Controller {
     return text
   }
 
-  _addSelectionChangeListener() {
-    if (this._selectionChangeActive) return
-    this._handleSelectionChange = this._handleSelectionChange.bind(this)
-    document.addEventListener('selectionchange', this._handleSelectionChange)
-    this._selectionChangeActive = true
-  }
-
-  _removeSelectionChangeListener() {
-    if (!this._selectionChangeActive) return
-    document.removeEventListener('selectionchange', this._handleSelectionChange)
-    this._selectionChangeActive = false
-  }
-
-  _handleSelectionChange() {
-    this._updateReplaceButton()
-  }
-
-  _updateReplaceButton() {
-    if (!this.hasReplaceButtonTarget) return
-    const hasSelection = !!this._getSelectedTextInContent()
-    this.replaceButtonTargets.forEach((btn) => {
-      btn.disabled = !hasSelection
-    })
-  }
+  // Selection change listener and replace button logic removed — unified into review
 
   updateReactionsUI(reactionsData) {
     let reactionsContainer = this.element.querySelector('.comment-reactions')

--- a/engines/collavre/app/javascript/controllers/comment_controller.js
+++ b/engines/collavre/app/javascript/controllers/comment_controller.js
@@ -286,9 +286,10 @@ export default class extends Controller {
 
     this._reviewPopup = new CommonPopup(this._reviewPopupEl, {
       onSelect: () => {
+        const commentId = this.element.dataset.commentId
         const formController = this.findFormController()
         if (formController) {
-          formController.appendReviewQuote(selectedText)
+          formController.appendReviewQuote(commentId, selectedText)
         }
         window.getSelection().removeAllRanges()
         this.hideReviewPopup()
@@ -338,9 +339,10 @@ export default class extends Controller {
     const selectedText = this._getSelectedTextInContent()
     const contentEl = this.element.querySelector('.comment-content')
     const text = selectedText || (contentEl ? contentEl.textContent.trim() : '')
+    const commentId = this.element.dataset.commentId
     const formController = this.findFormController()
     if (formController && text) {
-      formController.appendReviewQuote(text)
+      formController.appendReviewQuote(commentId, text)
     }
     if (selectedText) window.getSelection().removeAllRanges()
   }

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -558,7 +558,8 @@ export default class extends Controller {
     const quoted = selectedText.split('\n').map(line => `> ${line}`).join('\n')
     // Add blank line separator between reviews for proper markdown rendering
     const prefix = current.length > 0 ? (current.endsWith('\n\n') ? '' : current.endsWith('\n') ? '\n' : '\n\n') : ''
-    const newValue = current + prefix + quoted + '\n'
+    // Double newline after blockquote so markdown renders it as a separate block
+    const newValue = current + prefix + quoted + '\n\n'
     textarea.value = newValue
     // Place cursor at the end (user types review feedback here)
     textarea.selectionStart = textarea.selectionEnd = newValue.length

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -544,6 +544,25 @@ export default class extends Controller {
     this.focusTextarea()
   }
 
+  // Append a review quote to the textarea as markdown blockquote.
+  // Multiple reviews accumulate; user types feedback after each quote.
+  appendReviewQuote(selectedText) {
+    if (!selectedText) return
+    const textarea = this.textareaTarget
+    const current = textarea.value
+    // Build markdown blockquote: prefix each line with >
+    const quoted = selectedText.split('\n').map(line => `> ${line}`).join('\n')
+    // If textarea already has content, add a blank line separator
+    const prefix = current.length > 0 ? (current.endsWith('\n') ? '' : '\n') : ''
+    const newValue = current + prefix + quoted + '\n'
+    textarea.value = newValue
+    // Place cursor at the end (user types review feedback here)
+    textarea.selectionStart = textarea.selectionEnd = newValue.length
+    this.focusTextarea()
+    // Trigger input event so any external auto-resize logic can adjust height
+    textarea.dispatchEvent(new Event('input', { bubbles: true }))
+  }
+
   cancelQuote() {
     this.quotedCommentIdTarget.value = ''
     this.quotedTextTarget.value = ''

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -546,14 +546,18 @@ export default class extends Controller {
 
   // Append a review quote to the textarea as markdown blockquote.
   // Multiple reviews accumulate; user types feedback after each quote.
-  appendReviewQuote(selectedText) {
+  appendReviewQuote(commentId, selectedText) {
     if (!selectedText) return
+    // Set quoted_comment_id for the review target
+    if (commentId) {
+      this.quotedCommentIdTarget.value = commentId
+    }
     const textarea = this.textareaTarget
     const current = textarea.value
     // Build markdown blockquote: prefix each line with >
     const quoted = selectedText.split('\n').map(line => `> ${line}`).join('\n')
-    // If textarea already has content, add a blank line separator
-    const prefix = current.length > 0 ? (current.endsWith('\n') ? '' : '\n') : ''
+    // Add blank line separator between reviews for proper markdown rendering
+    const prefix = current.length > 0 ? (current.endsWith('\n\n') ? '' : current.endsWith('\n') ? '\n' : '\n\n') : ''
     const newValue = current + prefix + quoted + '\n'
     textarea.value = newValue
     // Place cursor at the end (user types review feedback here)

--- a/engines/collavre/app/views/collavre/comments/_comment.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comment.html.erb
@@ -60,9 +60,6 @@
         <button class="review-comment-btn" data-comment-target="reviewButton" data-comment-id="<%= comment.id %>" title="<%= t('collavre.comments.review_button') %>">
           <%= t('collavre.comments.review_button') %>
         </button>
-        <button class="replace-comment-btn" data-comment-target="replaceButton" data-comment-id="<%= comment.id %>" title="<%= t('collavre.comments.replace_button') %>" disabled>
-          <%= t('collavre.comments.replace_button') %>
-        </button>
       <% end %>
       <button class="copy-comment-link-btn" data-comment-id="<%= comment.id %>" data-comment-url="<%= collavre.creative_comment_url(comment.creative, comment, Rails.application.config.action_mailer.default_url_options) %>" title="<%= t('collavre.comments.copy_link_button') %>">
         <%= t('collavre.comments.copy_link_button') %>


### PR DESCRIPTION
## Summary

Unify the "Review" (리뷰) and "Replace" (바꾸기) buttons into a single **Review** button that supports accumulating multiple review quotes before sending.

## Changes

### UI
- Remove "Replace" (바꾸기) button from comment actions — only "Review" (리뷰) remains
- PC: text selection popup calls the same unified flow
- Mobile: review button uses selected text if available, otherwise full comment text

### Multi-quote accumulation
- `appendReviewQuote(commentId, selectedText)` in `form_controller.js` appends markdown blockquotes to the textarea
- Users can select multiple passages, click Review for each, and send all reviews in a single message
- Format: `> quoted text` followed by blank line for user feedback, repeated for each quote

### Styling
- Apply `.comment-quoted-text` styling to `.comment-content blockquote` for consistent markdown blockquote appearance
- Reset `<p>` margin inside blockquotes to reduce vertical spacing

### Dead code removal
- Remove `replaceButton` target and all related methods from `comment_controller.js` (~50 lines)
- Remove `.replace-comment-btn` CSS styles
- Remove `selectionchange` listener logic

## Files changed (4)
- `_comment.html.erb` — remove replace button HTML
- `comment_controller.js` — unify review flow, remove replace logic
- `form_controller.js` — add `appendReviewQuote()` method
- `comments_popup.css` — blockquote styling, remove replace button styles

## Testing
- 1172 runs, 3721 assertions, 0 failures, 0 errors
- Rubocop clean
- i18n keys complete (en + ko)