### PR TITLE
feat: add /work command for DFS workflow execution

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_19_104210) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_20_072200) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false
@@ -700,7 +700,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_19_104210) do
   create_table "tasks", force: :cascade do |t|
     t.integer "agent_id", null: false
     t.datetime "created_at", null: false
+    t.integer "creative_id"
     t.string "name"
+    t.integer "parent_task_id"
     t.json "pending_tool_call"
     t.integer "retry_count", default: 0, null: false
     t.string "status", default: "pending"
@@ -708,7 +710,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_19_104210) do
     t.string "trigger_event_name"
     t.json "trigger_event_payload"
     t.datetime "updated_at", null: false
+    t.text "workflow_context"
+    t.json "workflow_state"
     t.index ["agent_id"], name: "index_tasks_on_agent_id"
+    t.index ["creative_id"], name: "index_tasks_on_creative_id"
+    t.index ["parent_task_id"], name: "index_tasks_on_parent_task_id"
     t.index ["topic_id", "status"], name: "index_tasks_on_topic_id_and_status"
   end
 

--- a/engines/collavre/app/jobs/collavre/ai_agent_job.rb
+++ b/engines/collavre/app/jobs/collavre/ai_agent_job.rb
@@ -60,11 +60,11 @@ module Collavre
           Rails.logger.info("[AiAgentJob] Task #{task.id} escalated after max retries")
         else # :done
           task.update!(status: "done")
-          # Advance workflow if this is a sub-task
+          tracker.release!(job_id || task.id, tokens_used: 0)
+          # Advance workflow after releasing resources to avoid deadlock
           if task.parent_task_id.present?
             Collavre::Comments::WorkflowExecutor.new(task.parent_task).complete_subtask!(task)
           end
-          tracker.release!(job_id || task.id, tokens_used: 0)
         end
       rescue ApprovalPendingError
         # Task status already set to pending_approval by AiAgentService
@@ -77,6 +77,10 @@ module Collavre
       rescue StandardError => e
         task.update!(status: "failed")
         tracker.release!(job_id || task.id, tokens_used: 0)
+        # Fail workflow if this is a sub-task
+        if task.parent_task_id.present?
+          Collavre::Comments::WorkflowExecutor.new(task.parent_task).fail_subtask!(task, error_message: e.message)
+        end
         Rails.logger.error("AiAgentJob failed for task #{task.id}: #{e.message}")
         raise e
       ensure

--- a/engines/collavre/app/jobs/collavre/ai_agent_job.rb
+++ b/engines/collavre/app/jobs/collavre/ai_agent_job.rb
@@ -60,6 +60,10 @@ module Collavre
           Rails.logger.info("[AiAgentJob] Task #{task.id} escalated after max retries")
         else # :done
           task.update!(status: "done")
+          # Advance workflow if this is a sub-task
+          if task.parent_task_id.present?
+            Collavre::Comments::WorkflowExecutor.new(task.parent_task).complete_subtask!(task)
+          end
           tracker.release!(job_id || task.id, tokens_used: 0)
         end
       rescue ApprovalPendingError

--- a/engines/collavre/app/models/collavre/task.rb
+++ b/engines/collavre/app/models/collavre/task.rb
@@ -5,7 +5,7 @@ module Collavre
     belongs_to :agent, class_name: "Collavre::User"
     has_many :task_actions, class_name: "Collavre::TaskAction", dependent: :destroy
     belongs_to :parent_task, class_name: "Collavre::Task", optional: true
-    has_many :sub_tasks, class_name: "Collavre::Task", foreign_key: :parent_task_id
+    has_many :sub_tasks, class_name: "Collavre::Task", foreign_key: :parent_task_id, dependent: :destroy
     belongs_to :creative, class_name: "Collavre::Creative", optional: true
 
     validates :name, presence: true

--- a/engines/collavre/app/models/collavre/task.rb
+++ b/engines/collavre/app/models/collavre/task.rb
@@ -4,10 +4,21 @@ module Collavre
 
     belongs_to :agent, class_name: "Collavre::User"
     has_many :task_actions, class_name: "Collavre::TaskAction", dependent: :destroy
+    belongs_to :parent_task, class_name: "Collavre::Task", optional: true
+    has_many :sub_tasks, class_name: "Collavre::Task", foreign_key: :parent_task_id
+    belongs_to :creative, class_name: "Collavre::Creative", optional: true
 
     validates :name, presence: true
 
     scope :running_for_topic, ->(topic_id) { where(topic_id: topic_id, status: "running") }
     scope :queued_for_topic, ->(topic_id) { where(topic_id: topic_id, status: "queued").order(:created_at) }
+
+    def workflow_parent?
+      workflow_state.present? && parent_task_id.nil?
+    end
+
+    def all_sub_tasks_done?
+      sub_tasks.where.not(status: %w[done cancelled]).empty?
+    end
   end
 end

--- a/engines/collavre/app/services/collavre/command_menu_service.rb
+++ b/engines/collavre/app/services/collavre/command_menu_service.rb
@@ -26,6 +26,12 @@ module Collavre
           label: "/topic",
           description: I18n.t("collavre.comments.command_menu.topic_description"),
           args: I18n.t("collavre.comments.command_menu.topic_args")
+        },
+        {
+          name: "work",
+          label: "/work",
+          description: I18n.t("collavre.comments.command_menu.work_description"),
+          args: I18n.t("collavre.comments.command_menu.work_args")
         }
       ]
     end

--- a/engines/collavre/app/services/collavre/comments/command_processor.rb
+++ b/engines/collavre/app/services/collavre/comments/command_processor.rb
@@ -28,7 +28,8 @@ module Collavre
       def static_commands
         [
           Collavre::Comments::CalendarCommand.new(comment: comment, user: user),
-          Collavre::Comments::TopicCommand.new(comment: comment, user: user)
+          Collavre::Comments::TopicCommand.new(comment: comment, user: user),
+          Collavre::Comments::WorkCommand.new(comment: comment, user: user)
         ]
       end
 

--- a/engines/collavre/app/services/collavre/comments/work_command.rb
+++ b/engines/collavre/app/services/collavre/comments/work_command.rb
@@ -47,7 +47,8 @@ module Collavre
       end
 
       def find_agent
-        comment.mentioned_users&.find(&:ai_user?)
+        mentioned = MentionParser.resolve_all_users(comment.content.to_s)
+        mentioned.find(&:ai_user?)
       end
 
       def extract_workflow_context

--- a/engines/collavre/app/services/collavre/comments/work_command.rb
+++ b/engines/collavre/app/services/collavre/comments/work_command.rb
@@ -1,0 +1,106 @@
+module Collavre
+  module Comments
+    class WorkCommand
+      def initialize(comment:, user:)
+        @comment = comment
+        @user = user
+        @creative = comment.creative.effective_origin
+      end
+
+      def call
+        return unless work_command?
+        execute_work
+      rescue StandardError => e
+        Rails.logger.error("Work command failed: #{e.message}")
+        e.message
+      end
+
+      private
+
+      COMMAND_PATTERN = /\A\/work\b/i.freeze
+
+      attr_reader :comment, :user, :creative
+
+      def work_command?
+        comment.content.to_s.strip.match?(COMMAND_PATTERN)
+      end
+
+      def execute_work
+        agent = find_agent
+        return I18n.t("collavre.comments.work_command.agent_not_found") unless agent
+        return I18n.t("collavre.comments.work_command.no_children") if creative.descendants.empty?
+
+        workflow_text = extract_workflow_context
+        child_ids = collect_dfs_creative_ids
+        skipped_ids = filter_already_tasked(child_ids)
+        pending_ids = child_ids - skipped_ids
+
+        return I18n.t("collavre.comments.work_command.all_already_tasked") if pending_ids.empty?
+
+        parent_task = create_parent_task(agent, workflow_text, pending_ids)
+        start_next_subtask(parent_task, agent)
+
+        I18n.t("collavre.comments.work_command.started",
+               agent: agent.display_name,
+               total: pending_ids.size,
+               skipped: skipped_ids.size)
+      end
+
+      def find_agent
+        comment.mentioned_users.find(&:ai_user?)
+      end
+
+      def extract_workflow_context
+        # Remove command and @mention, rest is workflow context
+        content = comment.content.to_s.strip
+        content = content.sub(/\A\/work\s+/, "")
+        content = content.sub(/@[^:]+:\s*/, "")
+        content.strip
+      end
+
+      def collect_dfs_creative_ids
+        # DFS order via closure_tree - children ordered by sequence
+        dfs_ids = []
+        dfs_traverse(creative) { |c| dfs_ids << c.id }
+        dfs_ids.reject { |id| id == creative.id } # exclude root
+      end
+
+      def dfs_traverse(node, &block)
+        yield node
+        node.children.order(:sequence).each { |child| dfs_traverse(child, &block) }
+      end
+
+      def filter_already_tasked(creative_ids)
+        Task.where(creative_id: creative_ids)
+            .where(status: %w[running queued pending pending_approval])
+            .pluck(:creative_id)
+            .uniq
+      end
+
+      def create_parent_task(agent, workflow_text, pending_ids)
+        Task.create!(
+          name: "Workflow: #{creative.description&.truncate(50)}",
+          status: "running",
+          agent: agent,
+          creative: creative,
+          workflow_context: workflow_text,
+          workflow_state: {
+            "pending_creative_ids" => pending_ids,
+            "completed_creative_ids" => [],
+            "current_creative_id" => nil,
+            "total" => pending_ids.size
+          },
+          trigger_event_name: "work_command",
+          trigger_event_payload: {
+            "creative" => { "id" => creative.id },
+            "comment" => { "id" => comment.id }
+          }
+        )
+      end
+
+      def start_next_subtask(parent_task, agent)
+        WorkflowExecutor.advance!(parent_task)
+      end
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/comments/work_command.rb
+++ b/engines/collavre/app/services/collavre/comments/work_command.rb
@@ -38,7 +38,7 @@ module Collavre
         return I18n.t("collavre.comments.work_command.all_already_tasked") if pending_ids.empty?
 
         parent_task = create_parent_task(agent, workflow_text, pending_ids)
-        start_next_subtask(parent_task, agent)
+        WorkflowExecutor.advance!(parent_task)
 
         I18n.t("collavre.comments.work_command.started",
                agent: agent.display_name,
@@ -52,7 +52,6 @@ module Collavre
       end
 
       def extract_workflow_context
-        # Remove command and @mention, rest is workflow context
         content = comment.content.to_s.strip
         content = content.sub(/\A\/work\s+/, "")
         content = content.sub(/@[^:]+:\s*/, "")
@@ -60,10 +59,9 @@ module Collavre
       end
 
       def collect_dfs_creative_ids
-        # DFS order via closure_tree - children ordered by sequence
         dfs_ids = []
         dfs_traverse(creative) { |c| dfs_ids << c.id }
-        dfs_ids.reject { |id| id == creative.id } # exclude root
+        dfs_ids.reject { |id| id == creative.id }
       end
 
       def dfs_traverse(node, &block)
@@ -97,13 +95,6 @@ module Collavre
             "comment" => { "id" => comment.id }
           }
         )
-      end
-
-      def start_next_subtask(parent_task, agent)
-        WorkflowExecutor.advance!(parent_task)
-      rescue StandardError => e
-        Rails.logger.error("WorkflowExecutor failed: #{e.message}")
-        raise e
       end
     end
   end

--- a/engines/collavre/app/services/collavre/comments/work_command.rb
+++ b/engines/collavre/app/services/collavre/comments/work_command.rb
@@ -70,10 +70,17 @@ module Collavre
       end
 
       def filter_already_tasked(creative_ids)
-        Task.where(creative_id: creative_ids)
-            .where(status: %w[running queued pending pending_approval])
-            .pluck(:creative_id)
-            .uniq
+        # Skip creatives with active or completed tasks
+        tasked = Task.where(creative_id: creative_ids)
+                     .where(status: %w[running queued pending pending_approval done])
+                     .pluck(:creative_id)
+
+        # Also skip creatives already at 100% progress
+        completed = Creative.where(id: creative_ids)
+                            .where("progress >= 1.0")
+                            .pluck(:id)
+
+        (tasked + completed).uniq
       end
 
       def create_parent_task(agent, workflow_text, pending_ids)

--- a/engines/collavre/app/services/collavre/comments/work_command.rb
+++ b/engines/collavre/app/services/collavre/comments/work_command.rb
@@ -47,7 +47,7 @@ module Collavre
       end
 
       def find_agent
-        comment.mentioned_users.find(&:ai_user?)
+        comment.mentioned_users&.find(&:ai_user?)
       end
 
       def extract_workflow_context
@@ -100,6 +100,9 @@ module Collavre
 
       def start_next_subtask(parent_task, agent)
         WorkflowExecutor.advance!(parent_task)
+      rescue StandardError => e
+        Rails.logger.error("WorkflowExecutor failed: #{e.message}")
+        raise e
       end
     end
   end

--- a/engines/collavre/app/services/collavre/comments/workflow_executor.rb
+++ b/engines/collavre/app/services/collavre/comments/workflow_executor.rb
@@ -11,46 +11,46 @@ module Collavre
       end
 
       def advance!
-        pending = @state["pending_creative_ids"] || []
+        # Loop instead of recursion to avoid stack overflow on many missing creatives
+        loop do
+          pending = @state["pending_creative_ids"] || []
 
-        if pending.empty?
-          complete_workflow!
+          if pending.empty?
+            complete_workflow!
+            return
+          end
+
+          next_creative_id = pending.first
+          next_creative = Creative.find_by(id: next_creative_id)
+
+          unless next_creative
+            skip_current!
+            next
+          end
+
+          # Update state
+          @state["current_creative_id"] = next_creative_id
+          @parent_task.update!(workflow_state: @state)
+
+          # Create sub-task and dispatch to agent
+          sub_task_context = build_subtask_context(next_creative)
+          topic = next_creative.topics.first
+
+          sub_task = Task.create!(
+            name: "Work on: #{next_creative.description&.truncate(50)}",
+            status: "pending",
+            agent: @parent_task.agent,
+            creative: next_creative,
+            parent_task: @parent_task,
+            workflow_context: @parent_task.workflow_context,
+            trigger_event_name: "workflow_subtask",
+            trigger_event_payload: sub_task_context,
+            topic_id: topic&.id
+          )
+
+          AiAgentJob.perform_later(sub_task)
           return
         end
-
-        next_creative_id = pending.first
-        next_creative = Creative.find_by(id: next_creative_id)
-
-        unless next_creative
-          # Skip missing creative
-          skip_current!
-          return advance!
-        end
-
-        # Update state
-        @state["current_creative_id"] = next_creative_id
-        @parent_task.update!(workflow_state: @state)
-
-        # Create sub-task and dispatch to agent
-        sub_task_context = build_subtask_context(next_creative)
-
-        # Use the topic from the creative if available, otherwise nil
-        topic = next_creative.topics.first
-
-        sub_task = Task.create!(
-          name: "Work on: #{next_creative.description&.truncate(50)}",
-          status: "pending",
-          agent: @parent_task.agent,
-          creative: next_creative,
-          parent_task: @parent_task,
-          workflow_context: @parent_task.workflow_context,
-          trigger_event_name: "workflow_subtask",
-          trigger_event_payload: sub_task_context,
-          topic_id: topic&.id
-        )
-
-        # Only dispatch the job if not in test environment to avoid complex test setup
-        AiAgentJob.perform_later(sub_task) unless Rails.env.test?
       end
 
       def complete_subtask!(sub_task)
@@ -73,6 +73,19 @@ module Collavre
         advance!
       end
 
+      def fail_subtask!(sub_task, error_message: nil)
+        @state["current_creative_id"] = nil
+        @parent_task.update!(
+          status: "failed",
+          workflow_state: @state.merge(
+            "failed_creative_id" => sub_task.creative_id,
+            "failure_reason" => error_message
+          )
+        )
+
+        post_failure_notice(sub_task, error_message)
+      end
+
       private
 
       def skip_current!
@@ -86,25 +99,42 @@ module Collavre
         @parent_task.update!(status: "done")
         @parent_task.creative&.update!(progress: 1.0)
 
-        # Post completion notice
-        if (comment_id = @parent_task.trigger_event_payload&.dig("comment", "id"))
-          original_comment = Comment.find_by(id: comment_id)
-          if original_comment
-            completed_count = (@state["completed_creative_ids"] || []).size
-            original_comment.creative.comments.create!(
-              content: I18n.t("collavre.comments.work_command.workflow_completed",
-                             agent: @parent_task.agent.display_name,
-                             completed: completed_count),
-              user: @parent_task.agent,
-              topic_id: original_comment.topic_id
-            )
-          end
-        end
+        post_notice(
+          I18n.t("collavre.comments.work_command.workflow_completed",
+                 agent: @parent_task.agent.display_name,
+                 completed: (@state["completed_creative_ids"] || []).size)
+        )
+      end
+
+      def post_failure_notice(sub_task, error_message)
+        creative_desc = sub_task.creative&.description&.truncate(50) || "unknown"
+        post_notice(
+          I18n.t("collavre.comments.work_command.workflow_failed",
+                 agent: @parent_task.agent.display_name,
+                 creative: creative_desc,
+                 reason: error_message || "unknown error")
+        )
+      end
+
+      def post_notice(content)
+        comment_id = @parent_task.trigger_event_payload&.dig("comment", "id")
+        return unless comment_id
+
+        original_comment = Comment.find_by(id: comment_id)
+        return unless original_comment
+
+        original_comment.creative.comments.create!(
+          content: content,
+          user: @parent_task.agent,
+          topic_id: original_comment.topic_id
+        )
       end
 
       def build_subtask_context(creative)
+        topic = creative.topics.first
         {
           "creative" => { "id" => creative.id, "description" => creative.description },
+          "topic" => topic ? { "id" => topic.id } : nil,
           "workflow" => {
             "context" => @parent_task.workflow_context,
             "parent_task_id" => @parent_task.id,
@@ -117,7 +147,7 @@ module Collavre
           "chat" => {
             "content" => "#{@parent_task.workflow_context}\n\nCurrent creative: #{creative.description}"
           }
-        }
+        }.compact
       end
     end
   end

--- a/engines/collavre/app/services/collavre/comments/workflow_executor.rb
+++ b/engines/collavre/app/services/collavre/comments/workflow_executor.rb
@@ -49,7 +49,8 @@ module Collavre
           topic_id: topic&.id
         )
 
-        AiAgentJob.perform_later(sub_task)
+        # Only dispatch the job if not in test environment to avoid complex test setup
+        AiAgentJob.perform_later(sub_task) unless Rails.env.test?
       end
 
       def complete_subtask!(sub_task)

--- a/engines/collavre/app/services/collavre/comments/workflow_executor.rb
+++ b/engines/collavre/app/services/collavre/comments/workflow_executor.rb
@@ -1,0 +1,123 @@
+module Collavre
+  module Comments
+    class WorkflowExecutor
+      def self.advance!(parent_task)
+        new(parent_task).advance!
+      end
+
+      def initialize(parent_task)
+        @parent_task = parent_task
+        @state = parent_task.workflow_state || {}
+      end
+
+      def advance!
+        pending = @state["pending_creative_ids"] || []
+
+        if pending.empty?
+          complete_workflow!
+          return
+        end
+
+        next_creative_id = pending.first
+        next_creative = Creative.find_by(id: next_creative_id)
+
+        unless next_creative
+          # Skip missing creative
+          skip_current!
+          return advance!
+        end
+
+        # Update state
+        @state["current_creative_id"] = next_creative_id
+        @parent_task.update!(workflow_state: @state)
+
+        # Create sub-task and dispatch to agent
+        sub_task_context = build_subtask_context(next_creative)
+
+        # Use the topic from the creative if available, otherwise nil
+        topic = next_creative.topics.first
+
+        sub_task = Task.create!(
+          name: "Work on: #{next_creative.description&.truncate(50)}",
+          status: "pending",
+          agent: @parent_task.agent,
+          creative: next_creative,
+          parent_task: @parent_task,
+          workflow_context: @parent_task.workflow_context,
+          trigger_event_name: "workflow_subtask",
+          trigger_event_payload: sub_task_context,
+          topic_id: topic&.id
+        )
+
+        AiAgentJob.perform_later(sub_task)
+      end
+
+      def complete_subtask!(sub_task)
+        completed = @state["completed_creative_ids"] || []
+        pending = @state["pending_creative_ids"] || []
+
+        completed << sub_task.creative_id
+        pending.delete(sub_task.creative_id)
+
+        @state["completed_creative_ids"] = completed
+        @state["pending_creative_ids"] = pending
+        @state["current_creative_id"] = nil
+        @parent_task.update!(workflow_state: @state)
+
+        # Update parent creative progress
+        total = @state["total"] || 1
+        progress = completed.size.to_f / total
+        @parent_task.creative&.update!(progress: progress.clamp(0.0, 1.0))
+
+        advance!
+      end
+
+      private
+
+      def skip_current!
+        pending = @state["pending_creative_ids"] || []
+        pending.shift
+        @state["pending_creative_ids"] = pending
+        @parent_task.update!(workflow_state: @state)
+      end
+
+      def complete_workflow!
+        @parent_task.update!(status: "done")
+        @parent_task.creative&.update!(progress: 1.0)
+
+        # Post completion notice
+        if (comment_id = @parent_task.trigger_event_payload&.dig("comment", "id"))
+          original_comment = Comment.find_by(id: comment_id)
+          if original_comment
+            completed_count = (@state["completed_creative_ids"] || []).size
+            original_comment.creative.comments.create!(
+              content: I18n.t("collavre.comments.work_command.workflow_completed",
+                             agent: @parent_task.agent.display_name,
+                             completed: completed_count),
+              user: @parent_task.agent,
+              topic_id: original_comment.topic_id
+            )
+          end
+        end
+      end
+
+      def build_subtask_context(creative)
+        {
+          "creative" => { "id" => creative.id, "description" => creative.description },
+          "workflow" => {
+            "context" => @parent_task.workflow_context,
+            "parent_task_id" => @parent_task.id,
+            "instruction" => "You are working on this creative as part of a workflow. " \
+                           "The workflow context is: #{@parent_task.workflow_context}. " \
+                           "Focus on this specific creative: #{creative.description}. " \
+                           "When done, your work will be marked complete automatically."
+          },
+          "comment" => @parent_task.trigger_event_payload&.dig("comment"),
+          "chat" => {
+            "content" => "#{@parent_task.workflow_context}\n\nCurrent creative: #{creative.description}"
+          }
+        }
+      end
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/comments/workflow_executor.rb
+++ b/engines/collavre/app/services/collavre/comments/workflow_executor.rb
@@ -48,6 +48,7 @@ module Collavre
             topic_id: topic&.id
           )
 
+          post_progress_notice(next_creative)
           AiAgentJob.perform_later(sub_task)
           return
         end
@@ -103,6 +104,21 @@ module Collavre
           I18n.t("collavre.comments.work_command.workflow_completed",
                  agent: @parent_task.agent.display_name,
                  completed: (@state["completed_creative_ids"] || []).size)
+        )
+      end
+
+      def post_progress_notice(creative)
+        total = @state["total"] || 1
+        completed_count = (@state["completed_creative_ids"] || []).size
+        current_index = completed_count + 1
+        creative_desc = creative.description&.truncate(50) || "untitled"
+
+        post_notice(
+          I18n.t("collavre.comments.work_command.subtask_started",
+                 agent: @parent_task.agent.display_name,
+                 creative: creative_desc,
+                 current: current_index,
+                 total: total)
         )
       end
 

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -105,6 +105,7 @@ en:
         all_already_tasked: "All child creatives already have active tasks."
         started: 'Workflow started with @%{agent}: %{total} tasks queued (%{skipped} skipped).'
         workflow_completed: 'Workflow completed by @%{agent}: %{completed} creatives processed.'
+        workflow_failed: 'Workflow failed by @%{agent} on "%{creative}": %{reason}'
       read_by: Read by %{name}
       activity_logs_summary: Activity Logs
     calendar_events:

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -85,6 +85,8 @@ en:
         calendar_args: "YYYY-MM-DD@HH:MM memo (today/tomorrow, +3days, +2weeks, +1months, +1years, +mon)"
         topic_description: "Create a new topic with optional primary agent."
         topic_args: '"topic name" @agent_name'
+        work_description: "Create a workflow to execute tasks on child creatives via DFS traversal."
+        work_args: "@agent_name workflow_context"
       calendar_command:
         event_created: 'event created: [Google Calendar event](%{url})'
         event_created_local: 'event created (local only - connect Google Calendar to sync)'
@@ -97,6 +99,12 @@ en:
         created_with_agent: 'Topic "%{name}" created with @%{agent} as primary agent.'
         updated_agent: 'Topic "%{name}" primary agent updated to @%{agent}.'
         already_exists: 'Topic "%{name}" already exists.'
+      work_command:
+        agent_not_found: "Please mention an AI agent to execute the workflow."
+        no_children: "This creative has no child creatives to work on."
+        all_already_tasked: "All child creatives already have active tasks."
+        started: 'Workflow started with @%{agent}: %{total} tasks queued (%{skipped} skipped).'
+        workflow_completed: 'Workflow completed by @%{agent}: %{completed} creatives processed.'
       read_by: Read by %{name}
       activity_logs_summary: Activity Logs
     calendar_events:

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -104,7 +104,8 @@ en:
         no_children: "This creative has no child creatives to work on."
         all_already_tasked: "All child creatives already have active tasks."
         started: 'Workflow started with @%{agent}: %{total} tasks queued (%{skipped} skipped).'
-        workflow_completed: 'Workflow completed by @%{agent}: %{completed} creatives processed.'
+        subtask_started: '📋 @%{agent} starting work on "%{creative}" (%{current}/%{total})'
+        workflow_completed: '✅ Workflow completed by @%{agent}: %{completed} creatives processed.'
         workflow_failed: 'Workflow failed by @%{agent} on "%{creative}": %{reason}'
       read_by: Read by %{name}
       activity_logs_summary: Activity Logs

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -82,6 +82,8 @@ ko:
         calendar_args: "YYYY-MM-DD@HH:MM 메모 (today/tomorrow, +3days, +2weeks, +1months, +1years, +mon/+월)"
         topic_description: "새 토픽을 생성합니다. Primary Agent를 지정할 수 있습니다."
         topic_args: '"토픽 이름" @에이전트이름'
+        work_description: "하위 크리에이티브들에 대해 DFS 순회를 통한 워크플로우를 실행합니다."
+        work_args: "@에이전트이름 워크플로우_컨텍스트"
       calendar_command:
         event_created: '이벤트가 생성되었습니다: [구글 캘린더 이벤트](%{url})'
         event_created_local: '이벤트가 생성되었습니다 (로컬 전용 - 구글 캘린더 연동 시 동기화됩니다)'
@@ -94,6 +96,12 @@ ko:
         created_with_agent: '토픽 "%{name}"이(가) 생성되었습니다. @%{agent}이(가) Primary Agent로 설정되었습니다.'
         updated_agent: '토픽 "%{name}"의 Primary Agent가 @%{agent}(으)로 변경되었습니다.'
         already_exists: '토픽 "%{name}"이(가) 이미 존재합니다.'
+      work_command:
+        agent_not_found: "워크플로우를 실행할 AI 에이전트를 멘션해주세요."
+        no_children: "이 크리에이티브에는 작업할 하위 크리에이티브가 없습니다."
+        all_already_tasked: "모든 하위 크리에이티브가 이미 활성 작업을 가지고 있습니다."
+        started: '워크플로우가 @%{agent}와 함께 시작되었습니다: %{total}개 작업 대기중 (%{skipped}개 생략).'
+        workflow_completed: '@%{agent}가 워크플로우를 완료했습니다: %{completed}개 크리에이티브 처리됨.'
       read_by: "%{name} 님이 읽음"
       activity_logs_summary: 활동 기록
     calendar_events:

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -102,6 +102,7 @@ ko:
         all_already_tasked: "모든 하위 크리에이티브가 이미 활성 작업을 가지고 있습니다."
         started: '워크플로우가 @%{agent}와 함께 시작되었습니다: %{total}개 작업 대기중 (%{skipped}개 생략).'
         workflow_completed: '@%{agent}가 워크플로우를 완료했습니다: %{completed}개 크리에이티브 처리됨.'
+        workflow_failed: '@%{agent} 워크플로우 실패 - "%{creative}": %{reason}'
       read_by: "%{name} 님이 읽음"
       activity_logs_summary: 활동 기록
     calendar_events:

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -101,7 +101,8 @@ ko:
         no_children: "이 크리에이티브에는 작업할 하위 크리에이티브가 없습니다."
         all_already_tasked: "모든 하위 크리에이티브가 이미 활성 작업을 가지고 있습니다."
         started: '워크플로우가 @%{agent}와 함께 시작되었습니다: %{total}개 작업 대기중 (%{skipped}개 생략).'
-        workflow_completed: '@%{agent}가 워크플로우를 완료했습니다: %{completed}개 크리에이티브 처리됨.'
+        subtask_started: '📋 @%{agent}가 "%{creative}" 작업을 시작합니다 (%{current}/%{total})'
+        workflow_completed: '✅ @%{agent}가 워크플로우를 완료했습니다: %{completed}개 크리에이티브 처리됨.'
         workflow_failed: '@%{agent} 워크플로우 실패 - "%{creative}": %{reason}'
       read_by: "%{name} 님이 읽음"
       activity_logs_summary: 활동 기록

--- a/engines/collavre/db/migrate/20260220072200_add_workflow_fields_to_tasks.rb
+++ b/engines/collavre/db/migrate/20260220072200_add_workflow_fields_to_tasks.rb
@@ -1,0 +1,10 @@
+class AddWorkflowFieldsToTasks < ActiveRecord::Migration[8.1]
+  def change
+    add_column :tasks, :parent_task_id, :integer
+    add_index :tasks, :parent_task_id
+    add_column :tasks, :workflow_context, :text
+    add_column :tasks, :workflow_state, :json
+    add_column :tasks, :creative_id, :integer
+    add_index :tasks, :creative_id
+  end
+end

--- a/engines/collavre/db/migrate/20260220072200_add_workflow_fields_to_tasks.rb
+++ b/engines/collavre/db/migrate/20260220072200_add_workflow_fields_to_tasks.rb
@@ -2,9 +2,11 @@ class AddWorkflowFieldsToTasks < ActiveRecord::Migration[8.1]
   def change
     add_column :tasks, :parent_task_id, :integer
     add_index :tasks, :parent_task_id
+    add_foreign_key :tasks, :tasks, column: :parent_task_id, on_delete: :nullify
     add_column :tasks, :workflow_context, :text
     add_column :tasks, :workflow_state, :json
     add_column :tasks, :creative_id, :integer
     add_index :tasks, :creative_id
+    add_foreign_key :tasks, :creatives, column: :creative_id, on_delete: :nullify
   end
 end

--- a/engines/collavre/test/services/comments/work_command_test.rb
+++ b/engines/collavre/test/services/comments/work_command_test.rb
@@ -3,7 +3,11 @@ require "test_helper"
 module Collavre
   module Comments
     class WorkCommandTest < ActiveSupport::TestCase
+      include ActiveJob::TestHelper
+
       setup do
+        @previous_adapter = ActiveJob::Base.queue_adapter
+        ActiveJob::Base.queue_adapter = :test
         @creative = creatives(:tshirt)
         @user = users(:one)
         @ai_agent = User.create!(
@@ -37,16 +41,22 @@ module Collavre
         )
       end
 
+      teardown do
+        ActiveJob::Base.queue_adapter = @previous_adapter
+      end
+
       test "creates workflow for child creatives with DFS order" do
         comment = create_comment('/work @TestAgent: Analyze and improve each creative')
 
-        result = WorkCommand.new(comment: comment, user: @user).call
+        result = nil
+        assert_enqueued_with(job: AiAgentJob) do
+          result = WorkCommand.new(comment: comment, user: @user).call
+        end
 
         assert_match(/Workflow started/, result)
         assert_match(/TestAgent/, result)
         assert_match(/3 tasks queued/, result)
 
-        # Check parent task was created
         parent_task = Task.find_by(creative: @creative, workflow_context: "Analyze and improve each creative")
         assert parent_task.present?
         assert_equal "running", parent_task.status
@@ -55,7 +65,6 @@ module Collavre
       end
 
       test "skips creatives that already have tasks" do
-        # Create existing task for child1
         Task.create!(
           name: "Existing task",
           status: "running",
@@ -65,7 +74,10 @@ module Collavre
 
         comment = create_comment('/work @TestAgent: Process remaining creatives')
 
-        result = WorkCommand.new(comment: comment, user: @user).call
+        result = nil
+        assert_enqueued_with(job: AiAgentJob) do
+          result = WorkCommand.new(comment: comment, user: @user).call
+        end
 
         assert_match(/2 tasks queued/, result)
         assert_match(/1 skipped/, result)
@@ -116,7 +128,9 @@ module Collavre
       test "extracts workflow context correctly" do
         comment = create_comment('/work @TestAgent: Complex workflow context with multiple words')
 
-        WorkCommand.new(comment: comment, user: @user).call
+        assert_enqueued_with(job: AiAgentJob) do
+          WorkCommand.new(comment: comment, user: @user).call
+        end
 
         parent_task = Task.find_by(creative: @creative)
         assert_equal "Complex workflow context with multiple words", parent_task.workflow_context
@@ -133,7 +147,10 @@ module Collavre
       test "is case insensitive" do
         comment = create_comment('/WORK @TestAgent: Uppercase command')
 
-        result = WorkCommand.new(comment: comment, user: @user).call
+        result = nil
+        assert_enqueued_with(job: AiAgentJob) do
+          result = WorkCommand.new(comment: comment, user: @user).call
+        end
 
         assert_match(/Workflow started/, result)
       end

--- a/engines/collavre/test/services/comments/work_command_test.rb
+++ b/engines/collavre/test/services/comments/work_command_test.rb
@@ -1,0 +1,153 @@
+require "test_helper"
+
+module Collavre
+  module Comments
+    class WorkCommandTest < ActiveSupport::TestCase
+      setup do
+        @creative = creatives(:tshirt)
+        @user = users(:one)
+        @ai_agent = User.create!(
+          email: "testagent@test.local",
+          password: "password123",
+          name: "TestAgent",
+          llm_vendor: "openai",
+          llm_model: "gpt-4",
+          searchable: true
+        )
+        @topic = Topic.create!(creative: @creative, user: @user, name: "Test Topic")
+
+        # Create child creatives
+        @child1 = Creative.create!(
+          description: "Child Creative 1",
+          user: @user,
+          parent: @creative,
+          sequence: 1
+        )
+        @child2 = Creative.create!(
+          description: "Child Creative 2",
+          user: @user,
+          parent: @creative,
+          sequence: 2
+        )
+        @grandchild = Creative.create!(
+          description: "Grandchild Creative",
+          user: @user,
+          parent: @child1,
+          sequence: 1
+        )
+      end
+
+      test "creates workflow for child creatives with DFS order" do
+        comment = create_comment('/work @TestAgent: Analyze and improve each creative')
+
+        result = WorkCommand.new(comment: comment, user: @user).call
+
+        assert_match(/Workflow started/, result)
+        assert_match(/TestAgent/, result)
+        assert_match(/3 tasks queued/, result)
+
+        # Check parent task was created
+        parent_task = Task.find_by(creative: @creative, workflow_context: "Analyze and improve each creative")
+        assert parent_task.present?
+        assert_equal "running", parent_task.status
+        assert parent_task.workflow_parent?
+        assert_equal [ @child1.id, @grandchild.id, @child2.id ], parent_task.workflow_state["pending_creative_ids"]
+      end
+
+      test "skips creatives that already have tasks" do
+        # Create existing task for child1
+        Task.create!(
+          name: "Existing task",
+          status: "running",
+          agent: @ai_agent,
+          creative: @child1
+        )
+
+        comment = create_comment('/work @TestAgent: Process remaining creatives')
+
+        result = WorkCommand.new(comment: comment, user: @user).call
+
+        assert_match(/2 tasks queued/, result)
+        assert_match(/1 skipped/, result)
+
+        parent_task = Task.find_by(creative: @creative, workflow_context: "Process remaining creatives")
+        assert_equal [ @grandchild.id, @child2.id ], parent_task.workflow_state["pending_creative_ids"]
+      end
+
+      test "returns error when no AI agent is mentioned" do
+        comment = create_comment('/work Analyze and improve each creative')
+
+        result = WorkCommand.new(comment: comment, user: @user).call
+
+        assert_match(/mention an AI agent/, result)
+      end
+
+      test "returns error when creative has no children" do
+        childless_creative = Creative.create!(description: "Childless", user: @user)
+        comment = Comment.create!(
+          creative: childless_creative,
+          topic: @topic,
+          user: @user,
+          content: '/work @TestAgent: Do something'
+        )
+
+        result = WorkCommand.new(comment: comment, user: @user).call
+
+        assert_match(/no child creatives/, result)
+      end
+
+      test "returns error when all children already have tasks" do
+        [ @child1, @child2, @grandchild ].each do |creative|
+          Task.create!(
+            name: "Existing task",
+            status: "running",
+            agent: @ai_agent,
+            creative: creative
+          )
+        end
+
+        comment = create_comment('/work @TestAgent: Process creatives')
+
+        result = WorkCommand.new(comment: comment, user: @user).call
+
+        assert_match(/already have active tasks/, result)
+      end
+
+      test "extracts workflow context correctly" do
+        comment = create_comment('/work @TestAgent: Complex workflow context with multiple words')
+
+        WorkCommand.new(comment: comment, user: @user).call
+
+        parent_task = Task.find_by(creative: @creative)
+        assert_equal "Complex workflow context with multiple words", parent_task.workflow_context
+      end
+
+      test "returns nil for non-work commands" do
+        comment = create_comment("Hello world")
+
+        result = WorkCommand.new(comment: comment, user: @user).call
+
+        assert_nil result
+      end
+
+      test "is case insensitive" do
+        comment = create_comment('/WORK @TestAgent: Uppercase command')
+
+        result = WorkCommand.new(comment: comment, user: @user).call
+
+        assert_match(/Workflow started/, result)
+      end
+
+      private
+
+      def create_comment(content)
+        Collavre::Comment.create!(
+          creative: @creative,
+          topic: @topic,
+          user: @user,
+          content: content
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Implements a new /work command for Collavre that allows AI agents to execute workflows on child creatives via depth-first search traversal.

## Features
-  command syntax
- DFS traversal of child creatives
- Parent task tracks workflow progress and state
- Skips creatives that already have active tasks
- Progress tracking (parent task updates as children complete)
- Automatic workflow completion notifications
- Supports both English and Korean i18n

## Implementation
- Added workflow fields to tasks table (parent_task_id, workflow_context, workflow_state, creative_id)
- Created WorkCommand service following existing command pattern
- Created WorkflowExecutor service for managing DFS state progression
- Integrated with AiAgentJob for task execution
- Added comprehensive tests and i18n translations

## Testing
- All existing tests pass
- New WorkCommand tests cover main scenarios
- Rubocop style checks pass
- Migration successfully applied