### PR TITLE
fix: route subtask agent responses to child creative's chat

### DIFF
--- a/engines/collavre/app/services/collavre/comments/workflow_executor.rb
+++ b/engines/collavre/app/services/collavre/comments/workflow_executor.rb
@@ -33,8 +33,9 @@ module Collavre
           @parent_task.update!(workflow_state: @state)
 
           # Create sub-task and dispatch to agent
+          # Trigger comment is created inside build_subtask_context
+          # in the child creative's main topic (topic_id: nil)
           sub_task_context = build_subtask_context(next_creative)
-          topic = next_creative.topics.first
 
           sub_task = Task.create!(
             name: "Work on: #{next_creative.description&.truncate(50)}",
@@ -45,7 +46,7 @@ module Collavre
             workflow_context: @parent_task.workflow_context,
             trigger_event_name: "workflow_subtask",
             trigger_event_payload: sub_task_context,
-            topic_id: topic&.id
+            topic_id: nil
           )
 
           post_progress_notice(next_creative)
@@ -147,10 +148,17 @@ module Collavre
       end
 
       def build_subtask_context(creative)
-        topic = creative.topics.first
+        # Create a trigger comment in the child creative's main topic
+        # so the agent's response appears in that creative's chat
+        trigger_comment = creative.comments.create!(
+          content: @parent_task.workflow_context,
+          user: @parent_task.agent,
+          topic_id: nil # main topic
+        )
+
         {
           "creative" => { "id" => creative.id, "description" => creative.description },
-          "topic" => topic ? { "id" => topic.id } : nil,
+          "topic" => { "id" => nil },
           "workflow" => {
             "context" => @parent_task.workflow_context,
             "parent_task_id" => @parent_task.id,
@@ -159,11 +167,12 @@ module Collavre
                            "Focus on this specific creative: #{creative.description}. " \
                            "When done, your work will be marked complete automatically."
           },
-          "comment" => @parent_task.trigger_event_payload&.dig("comment"),
+          "comment" => { "id" => trigger_comment.id, "content" => trigger_comment.content,
+                         "user_id" => trigger_comment.user_id },
           "chat" => {
             "content" => "#{@parent_task.workflow_context}\n\nCurrent creative: #{creative.description}"
           }
-        }.compact
+        }
       end
     end
   end

--- a/engines/collavre/app/services/collavre/comments/workflow_executor.rb
+++ b/engines/collavre/app/services/collavre/comments/workflow_executor.rb
@@ -149,16 +149,18 @@ module Collavre
 
       def build_subtask_context(creative)
         # Create a trigger comment in the child creative's main topic
-        # so the agent's response appears in that creative's chat
+        # so the agent's response appears in that creative's chat.
+        # Use the original /work command user (not the agent) to avoid self-response loops.
+        original_user = find_original_user
         trigger_comment = creative.comments.create!(
-          content: @parent_task.workflow_context,
-          user: @parent_task.agent,
+          content: I18n.t("collavre.comments.work_command.trigger_comment",
+                         context: @parent_task.workflow_context),
+          user: original_user,
           topic_id: nil # main topic
         )
 
         {
           "creative" => { "id" => creative.id, "description" => creative.description },
-          "topic" => { "id" => nil },
           "workflow" => {
             "context" => @parent_task.workflow_context,
             "parent_task_id" => @parent_task.id,
@@ -173,6 +175,12 @@ module Collavre
             "content" => "#{@parent_task.workflow_context}\n\nCurrent creative: #{creative.description}"
           }
         }
+      end
+
+      def find_original_user
+        comment_id = @parent_task.trigger_event_payload&.dig("comment", "id")
+        comment = Comment.find_by(id: comment_id) if comment_id
+        comment&.user || @parent_task.agent
       end
     end
   end

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -104,6 +104,7 @@ en:
         no_children: "This creative has no child creatives to work on."
         all_already_tasked: "All child creatives already have active tasks."
         started: 'Workflow started with @%{agent}: %{total} tasks queued (%{skipped} skipped).'
+        trigger_comment: '📋 [Workflow] %{context}'
         subtask_started: '📋 @%{agent} starting work on "%{creative}" (%{current}/%{total})'
         workflow_completed: '✅ Workflow completed by @%{agent}: %{completed} creatives processed.'
         workflow_failed: 'Workflow failed by @%{agent} on "%{creative}": %{reason}'

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -101,6 +101,7 @@ ko:
         no_children: "이 크리에이티브에는 작업할 하위 크리에이티브가 없습니다."
         all_already_tasked: "모든 하위 크리에이티브가 이미 활성 작업을 가지고 있습니다."
         started: '워크플로우가 @%{agent}와 함께 시작되었습니다: %{total}개 작업 대기중 (%{skipped}개 생략).'
+        trigger_comment: '📋 [워크플로우] %{context}'
         subtask_started: '📋 @%{agent}가 "%{creative}" 작업을 시작합니다 (%{current}/%{total})'
         workflow_completed: '✅ @%{agent}가 워크플로우를 완료했습니다: %{completed}개 크리에이티브 처리됨.'
         workflow_failed: '@%{agent} 워크플로우 실패 - "%{creative}": %{reason}'


### PR DESCRIPTION
Each /work subtask now creates a trigger comment in the child creative's main topic, so the AI agent's response appears in that creative's chat — just like a regular user-initiated task.

Previously, all subtask responses were routed to the parent creative where /work was issued.