### PR TITLE
feat: add /work stop and /work resume subcommands

### DIFF
--- a/engines/collavre/app/services/collavre/comments/work_command.rb
+++ b/engines/collavre/app/services/collavre/comments/work_command.rb
@@ -26,6 +26,49 @@ module Collavre
       end
 
       def execute_work
+        subcommand = parse_subcommand
+        case subcommand
+        when :stop then execute_stop
+        when :resume then execute_resume
+        else execute_start
+        end
+      end
+
+      def parse_subcommand
+        content = comment.content.to_s.strip.sub(/\A\/work\s*/i, "")
+        case content
+        when /\Astop\b/i then :stop
+        when /\Aresume\b/i then :resume
+        else :start
+        end
+      end
+
+      # --- /work stop ---
+
+      def execute_stop
+        parent_task = find_active_workflow
+        return I18n.t("collavre.comments.work_command.no_active_workflow") unless parent_task
+
+        WorkflowExecutor.new(parent_task).stop!
+        I18n.t("collavre.comments.work_command.stopped",
+               agent: parent_task.agent.display_name)
+      end
+
+      # --- /work resume ---
+
+      def execute_resume
+        parent_task = find_resumable_workflow
+        return I18n.t("collavre.comments.work_command.no_resumable_workflow") unless parent_task
+
+        WorkflowExecutor.new(parent_task).resume!
+        I18n.t("collavre.comments.work_command.resumed",
+               agent: parent_task.agent.display_name,
+               remaining: (parent_task.workflow_state["pending_creative_ids"] || []).size)
+      end
+
+      # --- /work start (default) ---
+
+      def execute_start
         agent = find_agent
         return I18n.t("collavre.comments.work_command.agent_not_found") unless agent
         return I18n.t("collavre.comments.work_command.no_children") if creative.descendants.empty?
@@ -70,12 +113,10 @@ module Collavre
       end
 
       def filter_already_tasked(creative_ids)
-        # Skip creatives with active or completed tasks
         tasked = Task.where(creative_id: creative_ids)
                      .where(status: %w[running queued pending pending_approval done])
                      .pluck(:creative_id)
 
-        # Also skip creatives already at 100% progress
         completed = Creative.where(id: creative_ids)
                             .where("progress >= 1.0")
                             .pluck(:id)
@@ -102,6 +143,16 @@ module Collavre
             "comment" => { "id" => comment.id }
           }
         )
+      end
+
+      def find_active_workflow
+        Task.where(creative: creative, trigger_event_name: "work_command", status: "running")
+            .order(created_at: :desc).first
+      end
+
+      def find_resumable_workflow
+        Task.where(creative: creative, trigger_event_name: "work_command", status: %w[failed cancelled])
+            .order(created_at: :desc).first
       end
     end
   end

--- a/engines/collavre/app/services/collavre/comments/work_command.rb
+++ b/engines/collavre/app/services/collavre/comments/work_command.rb
@@ -61,6 +61,7 @@ module Collavre
         return I18n.t("collavre.comments.work_command.no_resumable_workflow") unless parent_task
 
         WorkflowExecutor.new(parent_task).resume!
+        parent_task.reload
         I18n.t("collavre.comments.work_command.resumed",
                agent: parent_task.agent.display_name,
                remaining: (parent_task.workflow_state["pending_creative_ids"] || []).size)

--- a/engines/collavre/app/services/collavre/comments/workflow_executor.rb
+++ b/engines/collavre/app/services/collavre/comments/workflow_executor.rb
@@ -11,8 +11,9 @@ module Collavre
       end
 
       def advance!
-        # Loop instead of recursion to avoid stack overflow on many missing creatives
         loop do
+          return if @parent_task.status == "cancelled"
+
           pending = @state["pending_creative_ids"] || []
 
           if pending.empty?
@@ -28,13 +29,9 @@ module Collavre
             next
           end
 
-          # Update state
           @state["current_creative_id"] = next_creative_id
           @parent_task.update!(workflow_state: @state)
 
-          # Create sub-task and dispatch to agent
-          # Trigger comment is created inside build_subtask_context
-          # in the child creative's main topic (topic_id: nil)
           sub_task_context = build_subtask_context(next_creative)
 
           sub_task = Task.create!(
@@ -67,7 +64,6 @@ module Collavre
         @state["current_creative_id"] = nil
         @parent_task.update!(workflow_state: @state)
 
-        # Update parent creative progress
         total = @state["total"] || 1
         progress = completed.size.to_f / total
         @parent_task.creative&.update!(progress: progress.clamp(0.0, 1.0))
@@ -86,6 +82,50 @@ module Collavre
         )
 
         post_failure_notice(sub_task, error_message)
+      end
+
+      def stop!
+        # Cancel running sub-task if any
+        current_sub = @parent_task.sub_tasks.where(status: %w[running queued pending]).first
+        current_sub&.update!(status: "cancelled")
+
+        @state["current_creative_id"] = nil
+        @parent_task.update!(
+          status: "cancelled",
+          workflow_state: @state
+        )
+
+        post_notice(
+          I18n.t("collavre.comments.work_command.workflow_stopped",
+                 agent: @parent_task.agent.display_name,
+                 completed: (@state["completed_creative_ids"] || []).size,
+                 remaining: (@state["pending_creative_ids"] || []).size)
+        )
+      end
+
+      def resume!
+        # Re-check pending creatives — some may have been completed manually
+        pending = @state["pending_creative_ids"] || []
+        pending = refilter_pending(pending)
+        @state["pending_creative_ids"] = pending
+        @state["current_creative_id"] = nil
+
+        # Clear failure state
+        @state.delete("failed_creative_id")
+        @state.delete("failure_reason")
+
+        @parent_task.update!(
+          status: "running",
+          workflow_state: @state
+        )
+
+        post_notice(
+          I18n.t("collavre.comments.work_command.workflow_resumed",
+                 agent: @parent_task.agent.display_name,
+                 remaining: pending.size)
+        )
+
+        advance!
       end
 
       private
@@ -148,15 +188,12 @@ module Collavre
       end
 
       def build_subtask_context(creative)
-        # Create a trigger comment in the child creative's main topic
-        # so the agent's response appears in that creative's chat.
-        # Use the original /work command user (not the agent) to avoid self-response loops.
         original_user = find_original_user
         trigger_comment = creative.comments.create!(
           content: I18n.t("collavre.comments.work_command.trigger_comment",
                          context: @parent_task.workflow_context),
           user: original_user,
-          topic_id: nil # main topic
+          topic_id: nil
         )
 
         {
@@ -181,6 +218,22 @@ module Collavre
         comment_id = @parent_task.trigger_event_payload&.dig("comment", "id")
         comment = Comment.find_by(id: comment_id) if comment_id
         comment&.user || @parent_task.agent
+      end
+
+      def refilter_pending(creative_ids)
+        return [] if creative_ids.empty?
+
+        # Remove creatives that now have completed tasks or full progress
+        tasked = Task.where(creative_id: creative_ids)
+                     .where(status: %w[running queued pending pending_approval done])
+                     .pluck(:creative_id)
+
+        completed = Creative.where(id: creative_ids)
+                            .where("progress >= 1.0")
+                            .pluck(:id)
+
+        skip_ids = (tasked + completed).uniq
+        creative_ids - skip_ids
       end
     end
   end

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -108,6 +108,12 @@ en:
         subtask_started: '📋 @%{agent} starting work on "%{creative}" (%{current}/%{total})'
         workflow_completed: '✅ Workflow completed by @%{agent}: %{completed} creatives processed.'
         workflow_failed: 'Workflow failed by @%{agent} on "%{creative}": %{reason}'
+        workflow_stopped: '⏹️ Workflow stopped by @%{agent}. %{completed} completed, %{remaining} remaining.'
+        workflow_resumed: '▶️ Workflow resumed by @%{agent}. %{remaining} tasks remaining.'
+        stopped: 'Workflow stopped for @%{agent}.'
+        resumed: 'Workflow resumed for @%{agent}: %{remaining} tasks remaining.'
+        no_active_workflow: 'No active workflow found on this creative.'
+        no_resumable_workflow: 'No failed or stopped workflow found to resume.'
       read_by: Read by %{name}
       activity_logs_summary: Activity Logs
     calendar_events:

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -105,6 +105,12 @@ ko:
         subtask_started: '📋 @%{agent}가 "%{creative}" 작업을 시작합니다 (%{current}/%{total})'
         workflow_completed: '✅ @%{agent}가 워크플로우를 완료했습니다: %{completed}개 크리에이티브 처리됨.'
         workflow_failed: '@%{agent} 워크플로우 실패 - "%{creative}": %{reason}'
+        workflow_stopped: '⏹️ @%{agent} 워크플로우가 중지되었습니다. %{completed}개 완료, %{remaining}개 남음.'
+        workflow_resumed: '▶️ @%{agent} 워크플로우가 재개되었습니다. %{remaining}개 작업 남음.'
+        stopped: '@%{agent}의 워크플로우가 중지되었습니다.'
+        resumed: '@%{agent}의 워크플로우가 재개되었습니다: %{remaining}개 작업 남음.'
+        no_active_workflow: '이 크리에이티브에 활성 워크플로우가 없습니다.'
+        no_resumable_workflow: '재개할 수 있는 실패/중지된 워크플로우가 없습니다.'
       read_by: "%{name} 님이 읽음"
       activity_logs_summary: 활동 기록
     calendar_events:

--- a/engines/collavre/test/services/comments/work_command_test.rb
+++ b/engines/collavre/test/services/comments/work_command_test.rb
@@ -155,6 +155,83 @@ module Collavre
         assert_match(/Workflow started/, result)
       end
 
+      test "stop cancels active workflow" do
+        comment = create_comment('/work @TestAgent: Do work')
+        assert_enqueued_with(job: AiAgentJob) do
+          WorkCommand.new(comment: comment, user: @user).call
+        end
+
+        parent_task = Task.find_by(creative: @creative, trigger_event_name: "work_command")
+        assert_equal "running", parent_task.status
+
+        stop_comment = create_comment('/work stop')
+        result = WorkCommand.new(comment: stop_comment, user: @user).call
+
+        assert_match(/stopped/, result)
+        parent_task.reload
+        assert_equal "cancelled", parent_task.status
+      end
+
+      test "stop returns error when no active workflow" do
+        stop_comment = create_comment('/work stop')
+        result = WorkCommand.new(comment: stop_comment, user: @user).call
+
+        assert_match(/No active workflow/, result)
+      end
+
+      test "resume restarts cancelled workflow" do
+        comment = create_comment('/work @TestAgent: Do work')
+        assert_enqueued_with(job: AiAgentJob) do
+          WorkCommand.new(comment: comment, user: @user).call
+        end
+
+        parent_task = Task.find_by(creative: @creative, trigger_event_name: "work_command")
+        # Stop it
+        WorkflowExecutor.new(parent_task).stop!
+        assert_equal "cancelled", parent_task.reload.status
+
+        # Resume
+        resume_comment = create_comment('/work resume')
+        result = nil
+        assert_enqueued_with(job: AiAgentJob) do
+          result = WorkCommand.new(comment: resume_comment, user: @user).call
+        end
+
+        assert_match(/resumed/, result)
+        parent_task.reload
+        assert_equal "running", parent_task.status
+      end
+
+      test "resume restarts failed workflow" do
+        comment = create_comment('/work @TestAgent: Do work')
+        assert_enqueued_with(job: AiAgentJob) do
+          WorkCommand.new(comment: comment, user: @user).call
+        end
+
+        parent_task = Task.find_by(creative: @creative, trigger_event_name: "work_command")
+        # Simulate failure
+        parent_task.update!(status: "failed",
+          workflow_state: parent_task.workflow_state.merge("failed_creative_id" => @child1.id, "failure_reason" => "timeout"))
+
+        resume_comment = create_comment('/work resume')
+        result = nil
+        assert_enqueued_with(job: AiAgentJob) do
+          result = WorkCommand.new(comment: resume_comment, user: @user).call
+        end
+
+        assert_match(/resumed/, result)
+        parent_task.reload
+        assert_equal "running", parent_task.status
+        assert_nil parent_task.workflow_state["failed_creative_id"]
+      end
+
+      test "resume returns error when no resumable workflow" do
+        resume_comment = create_comment('/work resume')
+        result = WorkCommand.new(comment: resume_comment, user: @user).call
+
+        assert_match(/No failed or stopped workflow/, result)
+      end
+
       private
 
       def create_comment(content)


### PR DESCRIPTION
## Changes

### /work stop
- Cancels active workflow and any running sub-task
- Posts stop notice to parent creative chat

### /work resume
- Restarts failed or cancelled workflow from remaining tasks
- Re-filters pending creatives (skips manually completed ones)
- Clears failure state before resuming

### Other
- `advance!` checks cancelled status to prevent running after stop
- i18n keys for stop/resume/errors (en + ko)
- 5 new tests (13 total), all passing, Rubocop clean