### PR TITLE
feat: enrich workflow trigger with creative markdown and sender context

### DIFF
--- a/engines/collavre/app/services/collavre/comments/workflow_executor.rb
+++ b/engines/collavre/app/services/collavre/comments/workflow_executor.rb
@@ -189,29 +189,56 @@ module Collavre
 
       def build_subtask_context(creative)
         original_user = find_original_user
+
+        # Build rich trigger comment with creative content + workflow instruction
+        # This mimics a user manually asking the agent in the creative's chat
+        trigger_content = build_trigger_content(creative)
+
         trigger_comment = creative.comments.create!(
-          content: I18n.t("collavre.comments.work_command.trigger_comment",
-                         context: @parent_task.workflow_context),
+          content: trigger_content,
           user: original_user,
           topic_id: nil
         )
 
+        # Context matches the format MessageBuilder expects:
+        # - creative.id → MessageBuilder renders creative tree markdown + chat history
+        # - comment.id → points to trigger comment in the child creative
+        # - sender → original user who issued /work
         {
           "creative" => { "id" => creative.id, "description" => creative.description },
           "workflow" => {
             "context" => @parent_task.workflow_context,
-            "parent_task_id" => @parent_task.id,
-            "instruction" => "You are working on this creative as part of a workflow. " \
-                           "The workflow context is: #{@parent_task.workflow_context}. " \
-                           "Focus on this specific creative: #{creative.description}. " \
-                           "When done, your work will be marked complete automatically."
+            "parent_task_id" => @parent_task.id
           },
           "comment" => { "id" => trigger_comment.id, "content" => trigger_comment.content,
                          "user_id" => trigger_comment.user_id },
-          "chat" => {
-            "content" => "#{@parent_task.workflow_context}\n\nCurrent creative: #{creative.description}"
-          }
+          "sender" => { "name" => original_user.name, "id" => original_user.id }
         }
+      end
+
+      def build_trigger_content(creative)
+        parts = []
+        parts << "@#{@parent_task.agent.name}: #{@parent_task.workflow_context}"
+        parts << ""
+        parts << I18n.t("collavre.comments.work_command.trigger_creative_context",
+                        creative: creative.description)
+        parts << ""
+
+        # Render creative tree markdown so agent sees full content without needing tools
+        markdown = render_creative_markdown(creative)
+        parts << markdown if markdown.present?
+
+        parts.join("\n")
+      end
+
+      def render_creative_markdown(creative)
+        max_depth = @parent_task.agent.creative_children_level + 1
+        ApplicationController.helpers.render_creative_tree_markdown(
+          [ creative ], 1, true, max_depth: max_depth
+        )
+      rescue StandardError => e
+        Rails.logger.warn("WorkflowExecutor: Failed to render creative markdown: #{e.message}")
+        nil
       end
 
       def find_original_user

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -105,6 +105,7 @@ en:
         all_already_tasked: "All child creatives already have active tasks."
         started: 'Workflow started with @%{agent}: %{total} tasks queued (%{skipped} skipped).'
         trigger_comment: '📋 [Workflow] %{context}'
+        trigger_creative_context: 'Current creative: %{creative}'
         subtask_started: '📋 @%{agent} starting work on "%{creative}" (%{current}/%{total})'
         workflow_completed: '✅ Workflow completed by @%{agent}: %{completed} creatives processed.'
         workflow_failed: 'Workflow failed by @%{agent} on "%{creative}": %{reason}'

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -102,6 +102,7 @@ ko:
         all_already_tasked: "모든 하위 크리에이티브가 이미 활성 작업을 가지고 있습니다."
         started: '워크플로우가 @%{agent}와 함께 시작되었습니다: %{total}개 작업 대기중 (%{skipped}개 생략).'
         trigger_comment: '📋 [워크플로우] %{context}'
+        trigger_creative_context: '현재 크리에이티브: %{creative}'
         subtask_started: '📋 @%{agent}가 "%{creative}" 작업을 시작합니다 (%{current}/%{total})'
         workflow_completed: '✅ @%{agent}가 워크플로우를 완료했습니다: %{completed}개 크리에이티브 처리됨.'
         workflow_failed: '@%{agent} 워크플로우 실패 - "%{creative}": %{reason}'


### PR DESCRIPTION
## Changes

Enrich workflow trigger comments with full creative context, matching the same flow as a user manually mentioning an agent in a creative's chat.

### Before
```
📋 [Workflow] 4708
```
Agent only saw a raw ID and had to call creative_retrieval_service tool to get context.

### After
```
@AgentName: Analyze and improve each creative

Current creative: Child Creative 1

# Child Creative 1
(full creative tree markdown content...)
```

### How it works
1. **Trigger comment**: Includes `@Agent: workflow_context` + creative tree markdown — agent sees full content without needing tool calls
2. **Sender context**: Original `/work` command user info added — MessageBuilder formats as `[username]: ...`
3. **MessageBuilder integration**: `creative.id` in context — automatic creative tree markdown + chat history build
4. **Result**: Identical to a user manually mentioning an agent in a creative chat — works for agents with or without tools

### i18n
- Added `trigger_creative_context` key (en + ko)