### PR TITLE
fix: only skip creatives with active tasks, allow re-work after done/failed/cancelled

### DIFF
--- a/engines/collavre/app/services/collavre/comments/work_command.rb
+++ b/engines/collavre/app/services/collavre/comments/work_command.rb
@@ -114,15 +114,13 @@ module Collavre
       end
 
       def filter_already_tasked(creative_ids)
+        # Only skip creatives with currently active tasks.
+        # Completed (done), failed, and cancelled tasks allow re-work.
         tasked = Task.where(creative_id: creative_ids)
-                     .where(status: %w[running queued pending pending_approval done])
+                     .where(status: %w[running queued pending pending_approval])
                      .pluck(:creative_id)
 
-        completed = Creative.where(id: creative_ids)
-                            .where("progress >= 1.0")
-                            .pluck(:id)
-
-        (tasked + completed).uniq
+        tasked.uniq
       end
 
       def create_parent_task(agent, workflow_text, pending_ids)

--- a/engines/collavre/app/services/collavre/comments/workflow_executor.rb
+++ b/engines/collavre/app/services/collavre/comments/workflow_executor.rb
@@ -250,17 +250,13 @@ module Collavre
       def refilter_pending(creative_ids)
         return [] if creative_ids.empty?
 
-        # Remove creatives that now have completed tasks or full progress
+        # Only skip creatives with currently active tasks.
+        # Done/failed/cancelled tasks allow re-work.
         tasked = Task.where(creative_id: creative_ids)
-                     .where(status: %w[running queued pending pending_approval done])
+                     .where(status: %w[running queued pending pending_approval])
                      .pluck(:creative_id)
 
-        completed = Creative.where(id: creative_ids)
-                            .where("progress >= 1.0")
-                            .pluck(:id)
-
-        skip_ids = (tasked + completed).uniq
-        creative_ids - skip_ids
+        creative_ids - tasked.uniq
       end
     end
   end


### PR DESCRIPTION
## Problem
`/work` command skipped creatives that had `done` status tasks or `progress >= 1.0`, preventing re-work on completed creatives.

## Fix
- `filter_already_tasked`: Only skip creatives with active tasks (`running`, `queued`, `pending`, `pending_approval`)
- `refilter_pending`: Same fix for `/work resume`
- Removed `progress >= 1.0` skip — creatives with completed/failed/cancelled tasks can now be re-worked