### PR TITLE
fix: restore progress >= 1.0 skip for completed creatives

### DIFF
--- a/engines/collavre/app/services/collavre/comments/work_command.rb
+++ b/engines/collavre/app/services/collavre/comments/work_command.rb
@@ -114,13 +114,18 @@ module Collavre
       end
 
       def filter_already_tasked(creative_ids)
-        # Only skip creatives with currently active tasks.
-        # Completed (done), failed, and cancelled tasks allow re-work.
-        tasked = Task.where(creative_id: creative_ids)
+        # Skip creatives with currently active tasks.
+        # Done/failed/cancelled tasks allow re-work.
+        active = Task.where(creative_id: creative_ids)
                      .where(status: %w[running queued pending pending_approval])
                      .pluck(:creative_id)
 
-        tasked.uniq
+        # Skip creatives already marked as completed (progress >= 1.0)
+        completed = Creative.where(id: creative_ids)
+                            .where("progress >= 1.0")
+                            .pluck(:id)
+
+        (active + completed).uniq
       end
 
       def create_parent_task(agent, workflow_text, pending_ids)

--- a/engines/collavre/app/services/collavre/comments/workflow_executor.rb
+++ b/engines/collavre/app/services/collavre/comments/workflow_executor.rb
@@ -250,13 +250,17 @@ module Collavre
       def refilter_pending(creative_ids)
         return [] if creative_ids.empty?
 
-        # Only skip creatives with currently active tasks.
-        # Done/failed/cancelled tasks allow re-work.
-        tasked = Task.where(creative_id: creative_ids)
+        # Skip creatives with active tasks (done/failed/cancelled allow re-work)
+        active = Task.where(creative_id: creative_ids)
                      .where(status: %w[running queued pending pending_approval])
                      .pluck(:creative_id)
 
-        creative_ids - tasked.uniq
+        # Skip creatives already completed (progress >= 1.0)
+        completed = Creative.where(id: creative_ids)
+                            .where("progress >= 1.0")
+                            .pluck(:id)
+
+        creative_ids - (active + completed).uniq
       end
     end
   end


### PR DESCRIPTION
## Problem
PR #863 removed the `progress >= 1.0` check when it should have been kept. Completed creatives were no longer being skipped.

## Fix
Restore `progress >= 1.0` skip in both `filter_already_tasked` and `refilter_pending`.

### Skip logic now:
- **Active tasks** (`running`, `queued`, `pending`, `pending_approval`) → skip
- **Completed creatives** (`progress >= 1.0`) → skip
- **Done/failed/cancelled tasks** (without full progress) → allow re-work