### PR TITLE
fix: resolve workflow_context creative ID to markdown content

### DIFF
--- a/engines/collavre/app/services/collavre/comments/workflow_executor.rb
+++ b/engines/collavre/app/services/collavre/comments/workflow_executor.rb
@@ -216,19 +216,33 @@ module Collavre
         }
       end
 
-      def build_trigger_content(creative)
+      def build_trigger_content(_creative)
         parts = []
-        parts << "@#{@parent_task.agent.name}: #{@parent_task.workflow_context}"
-        parts << ""
-        parts << I18n.t("collavre.comments.work_command.trigger_creative_context",
-                        creative: creative.description)
-        parts << ""
 
-        # Render creative tree markdown so agent sees full content without needing tools
-        markdown = render_creative_markdown(creative)
-        parts << markdown if markdown.present?
+        # Resolve workflow_context: if it's a creative ID, render that creative's markdown
+        # as the instruction (like a user pasting the content). Otherwise use as-is.
+        workflow_instruction = resolve_workflow_context
+        parts << "@#{@parent_task.agent.name}: #{workflow_instruction}"
+
+        # NOTE: Do NOT include current creative's markdown here.
+        # MessageBuilder already renders it from context["creative"]["id"].
 
         parts.join("\n")
+      end
+
+      def resolve_workflow_context
+        context_text = @parent_task.workflow_context.to_s.strip
+        creative_id = context_text[/\A\d+\z/]
+        return context_text unless creative_id
+
+        context_creative = Creative.find_by(id: creative_id)
+        return context_text unless context_creative
+
+        # Render the workflow context creative's full tree as markdown
+        markdown = render_creative_markdown(context_creative)
+        return context_text if markdown.blank?
+
+        markdown
       end
 
       def render_creative_markdown(creative)

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -105,7 +105,6 @@ en:
         all_already_tasked: "All child creatives already have active tasks."
         started: 'Workflow started with @%{agent}: %{total} tasks queued (%{skipped} skipped).'
         trigger_comment: '📋 [Workflow] %{context}'
-        trigger_creative_context: 'Current creative: %{creative}'
         subtask_started: '📋 @%{agent} starting work on "%{creative}" (%{current}/%{total})'
         workflow_completed: '✅ Workflow completed by @%{agent}: %{completed} creatives processed.'
         workflow_failed: 'Workflow failed by @%{agent} on "%{creative}": %{reason}'

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -102,7 +102,6 @@ ko:
         all_already_tasked: "모든 하위 크리에이티브가 이미 활성 작업을 가지고 있습니다."
         started: '워크플로우가 @%{agent}와 함께 시작되었습니다: %{total}개 작업 대기중 (%{skipped}개 생략).'
         trigger_comment: '📋 [워크플로우] %{context}'
-        trigger_creative_context: '현재 크리에이티브: %{creative}'
         subtask_started: '📋 @%{agent}가 "%{creative}" 작업을 시작합니다 (%{current}/%{total})'
         workflow_completed: '✅ @%{agent}가 워크플로우를 완료했습니다: %{completed}개 크리에이티브 처리됨.'
         workflow_failed: '@%{agent} 워크플로우 실패 - "%{creative}": %{reason}'


### PR DESCRIPTION
## Problem
When `/work @Agent: 4708` is used, the trigger comment showed the raw ID `4708` instead of the actual creative content. Also, the current creative's markdown was redundantly included in the trigger comment (MessageBuilder already provides it).

## Fix
- `resolve_workflow_context`: If workflow_context is a numeric ID, find the creative and render its full tree as markdown
- Remove redundant current creative markdown from trigger comment (MessageBuilder handles this via `context["creative"]["id"]`)
- Remove unused `trigger_creative_context` i18n key

## Result
**Before:** `@Gemini2: 4708\n\n현재 크리에이티브: ...\n\n(duplicate content)`
**After:** `@Gemini2: (full markdown of creative 4708 and its children)`

MessageBuilder separately provides the current creative's context + chat history.