### PR TITLE
fix: add sub-task completion notice to parent creative chat

### DIFF
--- a/engines/collavre/app/services/collavre/comments/workflow_executor.rb
+++ b/engines/collavre/app/services/collavre/comments/workflow_executor.rb
@@ -68,6 +68,8 @@ module Collavre
         progress = completed.size.to_f / total
         @parent_task.creative&.update!(progress: progress.clamp(0.0, 1.0))
 
+        post_subtask_completed_notice(sub_task, completed.size, total)
+
         advance!
       end
 
@@ -160,6 +162,20 @@ module Collavre
                  creative: creative_desc,
                  current: current_index,
                  total: total)
+        )
+      end
+
+      def post_subtask_completed_notice(sub_task, completed_count, total)
+        creative_desc = sub_task.creative&.description&.truncate(50) || "untitled"
+        progress_pct = ((completed_count.to_f / total) * 100).round
+
+        post_notice(
+          I18n.t("collavre.comments.work_command.subtask_completed",
+                 agent: @parent_task.agent.display_name,
+                 creative: creative_desc,
+                 completed: completed_count,
+                 total: total,
+                 progress: progress_pct)
         )
       end
 

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -106,6 +106,7 @@ en:
         started: 'Workflow started with @%{agent}: %{total} tasks queued (%{skipped} skipped).'
         trigger_comment: '📋 [Workflow] %{context}'
         subtask_started: '📋 @%{agent} starting work on "%{creative}" (%{current}/%{total})'
+        subtask_completed: '✅ @%{agent} completed "%{creative}" (%{completed}/%{total}, %{progress}%%)'
         workflow_completed: '✅ Workflow completed by @%{agent}: %{completed} creatives processed.'
         workflow_failed: 'Workflow failed by @%{agent} on "%{creative}": %{reason}'
         workflow_stopped: '⏹️ Workflow stopped by @%{agent}. %{completed} completed, %{remaining} remaining.'

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -103,6 +103,7 @@ ko:
         started: '워크플로우가 @%{agent}와 함께 시작되었습니다: %{total}개 작업 대기중 (%{skipped}개 생략).'
         trigger_comment: '📋 [워크플로우] %{context}'
         subtask_started: '📋 @%{agent}가 "%{creative}" 작업을 시작합니다 (%{current}/%{total})'
+        subtask_completed: '✅ @%{agent}가 "%{creative}" 완료 (%{completed}/%{total}, %{progress}%%)'
         workflow_completed: '✅ @%{agent}가 워크플로우를 완료했습니다: %{completed}개 크리에이티브 처리됨.'
         workflow_failed: '@%{agent} 워크플로우 실패 - "%{creative}": %{reason}'
         workflow_stopped: '⏹️ @%{agent} 워크플로우가 중지되었습니다. %{completed}개 완료, %{remaining}개 남음.'


### PR DESCRIPTION
Post progress update comment when each sub-task completes in the parent creative chat.

**Before:** Only start notices were posted; no feedback when sub-tasks finish.

**After:** Each sub-task completion posts: `✅ @Agent completed "Creative Name" (2/5, 40%)`

This gives visibility into workflow progress directly in the parent creative's chat.