### PR TITLE
fix: prevent duplicate agent task execution for same comment

### DIFF
--- a/engines/collavre/app/jobs/collavre/ai_agent_job.rb
+++ b/engines/collavre/app/jobs/collavre/ai_agent_job.rb
@@ -104,9 +104,9 @@ module Collavre
     private
 
     def duplicate_running_task?(agent_id, comment_id)
-      Task.where(agent_id: agent_id, status: "running").find_each do |task|
-        payload_comment_id = task.trigger_event_payload&.dig("comment", "id")
-        return true if payload_comment_id.to_s == comment_id.to_s
+      Task.where(agent_id: agent_id, status: "running", trigger_event_name: "comment_created")
+          .find_each do |task|
+        return true if task.trigger_event_payload&.dig("comment", "id").to_s == comment_id.to_s
       end
       false
     end

--- a/engines/collavre/app/jobs/collavre/ai_agent_job.rb
+++ b/engines/collavre/app/jobs/collavre/ai_agent_job.rb
@@ -17,7 +17,7 @@ module Collavre
 
         # Guard: skip if there's already a running task for the same agent + comment
         comment_id = context&.dig("comment", "id")
-        if comment_id && duplicate_running_task?(agent.id, comment_id)
+        if comment_id && Task.duplicate_running_for_comment?(agent.id, comment_id)
           Rails.logger.warn(
             "[AiAgentJob] Skipping duplicate: agent #{agent.id} already has a running task " \
             "for comment #{comment_id} (event=#{event_name})"
@@ -102,14 +102,6 @@ module Collavre
     end
 
     private
-
-    def duplicate_running_task?(agent_id, comment_id)
-      Task.where(agent_id: agent_id, status: "running", trigger_event_name: "comment_created")
-          .find_each do |task|
-        return true if task.trigger_event_payload&.dig("comment", "id").to_s == comment_id.to_s
-      end
-      false
-    end
 
     def evaluate_self_reflection(task, response_content)
       Orchestration::SelfReflectionEvaluator.new(task, response_content: response_content).evaluate

--- a/engines/collavre/app/jobs/collavre/ai_agent_job.rb
+++ b/engines/collavre/app/jobs/collavre/ai_agent_job.rb
@@ -14,6 +14,17 @@ module Collavre
       else
         # Create new task
         agent = User.find(agent_id_or_task)
+
+        # Guard: skip if there's already a running task for the same agent + comment
+        comment_id = context&.dig("comment", "id")
+        if comment_id && duplicate_running_task?(agent.id, comment_id)
+          Rails.logger.warn(
+            "[AiAgentJob] Skipping duplicate: agent #{agent.id} already has a running task " \
+            "for comment #{comment_id} (event=#{event_name})"
+          )
+          return
+        end
+
         task = Task.create!(
           name: "Response to #{event_name}",
           status: "running",
@@ -91,6 +102,14 @@ module Collavre
     end
 
     private
+
+    def duplicate_running_task?(agent_id, comment_id)
+      Task.where(agent_id: agent_id, status: "running").find_each do |task|
+        payload_comment_id = task.trigger_event_payload&.dig("comment", "id")
+        return true if payload_comment_id.to_s == comment_id.to_s
+      end
+      false
+    end
 
     def evaluate_self_reflection(task, response_content)
       Orchestration::SelfReflectionEvaluator.new(task, response_content: response_content).evaluate

--- a/engines/collavre/app/models/collavre/task.rb
+++ b/engines/collavre/app/models/collavre/task.rb
@@ -13,6 +13,15 @@ module Collavre
     scope :running_for_topic, ->(topic_id) { where(topic_id: topic_id, status: "running") }
     scope :queued_for_topic, ->(topic_id) { where(topic_id: topic_id, status: "queued").order(:created_at) }
 
+    # Check if agent already has a running task triggered by the same comment
+    def self.duplicate_running_for_comment?(agent_id, comment_id)
+      where(agent_id: agent_id, status: "running", trigger_event_name: "comment_created")
+        .find_each do |task|
+        return true if task.trigger_event_payload&.dig("comment", "id").to_s == comment_id.to_s
+      end
+      false
+    end
+
     def workflow_parent?
       workflow_state.present? && parent_task_id.nil?
     end

--- a/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
+++ b/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
@@ -129,7 +129,7 @@ module Collavre
 
           # Guard: skip if agent already has a running task for this comment
           comment_id = @context.dig("comment", "id")
-          if comment_id && duplicate_running_task?(agent.id, comment_id)
+          if comment_id && Task.duplicate_running_for_comment?(agent.id, comment_id)
             Rails.logger.warn(
               "[AgentOrchestrator] Skipping enqueue: agent #{agent.id} already has a running task " \
               "for comment #{comment_id}"
@@ -162,14 +162,6 @@ module Collavre
             nil
           end
         end
-      end
-
-      def duplicate_running_task?(agent_id, comment_id)
-        Task.where(agent_id: agent_id, status: "running", trigger_event_name: "comment_created")
-            .find_each do |task|
-          return true if task.trigger_event_payload&.dig("comment", "id").to_s == comment_id.to_s
-        end
-        false
       end
 
       def log_decision(decision)

--- a/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
+++ b/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
@@ -127,6 +127,16 @@ module Collavre
           agent = decision[:agent]
           log_decision(decision)
 
+          # Guard: skip if agent already has a running task for this comment
+          comment_id = @context.dig("comment", "id")
+          if comment_id && duplicate_running_task?(agent.id, comment_id)
+            Rails.logger.warn(
+              "[AgentOrchestrator] Skipping enqueue: agent #{agent.id} already has a running task " \
+              "for comment #{comment_id}"
+            )
+            next
+          end
+
           case decision[:timing]
           when :immediate
             AiAgentJob.perform_later(agent.id, @event_name, @context)
@@ -152,6 +162,14 @@ module Collavre
             nil
           end
         end
+      end
+
+      def duplicate_running_task?(agent_id, comment_id)
+        Task.where(agent_id: agent_id, status: "running", trigger_event_name: "comment_created")
+            .find_each do |task|
+          return true if task.trigger_event_payload&.dig("comment", "id").to_s == comment_id.to_s
+        end
+        false
       end
 
       def log_decision(decision)

--- a/engines/collavre/app/services/collavre/system_events/dispatcher.rb
+++ b/engines/collavre/app/services/collavre/system_events/dispatcher.rb
@@ -6,6 +6,13 @@ module Collavre
       end
 
       def dispatch(event_name, context)
+        Rails.logger.info(
+          "[SystemEvents::Dispatcher] event=#{event_name} " \
+          "comment_id=#{context.dig('comment', 'id') || context.dig(:comment, :id)} " \
+          "comment_user_id=#{context.dig('comment', 'user_id') || context.dig(:comment, :user_id)} " \
+          "creative_id=#{context.dig('creative', 'id') || context.dig(:creative, :id)} " \
+          "caller=#{caller_locations(1, 3)&.map { |l| "#{File.basename(l.path)}:#{l.lineno}" }&.join(' <- ')}"
+        )
         # Delegate to AgentOrchestrator for unified routing/scheduling
         Orchestration::AgentOrchestrator.dispatch(event_name, context)
       end

--- a/engines/collavre/app/services/collavre/system_events/dispatcher.rb
+++ b/engines/collavre/app/services/collavre/system_events/dispatcher.rb
@@ -6,12 +6,14 @@ module Collavre
       end
 
       def dispatch(event_name, context)
+        comment_id = context.dig("comment", "id")
+        comment_user_id = context.dig("comment", "user_id")
+        creative_id = context.dig("creative", "id")
         Rails.logger.info(
           "[SystemEvents::Dispatcher] event=#{event_name} " \
-          "comment_id=#{context.dig('comment', 'id') || context.dig(:comment, :id)} " \
-          "comment_user_id=#{context.dig('comment', 'user_id') || context.dig(:comment, :user_id)} " \
-          "creative_id=#{context.dig('creative', 'id') || context.dig(:creative, :id)} " \
-          "caller=#{caller_locations(1, 3)&.map { |l| "#{File.basename(l.path)}:#{l.lineno}" }&.join(' <- ')}"
+          "comment_id=#{comment_id} comment_user_id=#{comment_user_id} " \
+          "creative_id=#{creative_id} " \
+          "caller=#{caller_locations(1, 5)&.map { |l| "#{File.basename(l.path)}:#{l.lineno}" }&.join(' <- ')}"
         )
         # Delegate to AgentOrchestrator for unified routing/scheduling
         Orchestration::AgentOrchestrator.dispatch(event_name, context)

--- a/engines/collavre/test/jobs/ai_agent_job_test.rb
+++ b/engines/collavre/test/jobs/ai_agent_job_test.rb
@@ -299,4 +299,52 @@ class AiAgentJobTest < ActiveJob::TestCase
     assert messages.count > 40
     assert messages.count < 60
   end
+
+  test "skips duplicate execution when agent already has running task for same comment" do
+    # Create an existing running task for the same agent + comment
+    Task.create!(
+      name: "Response to comment_created",
+      status: "running",
+      trigger_event_name: "comment_created",
+      trigger_event_payload: @context,
+      agent: @agent,
+      topic_id: nil
+    )
+
+    initial_task_count = Task.where(agent_id: @agent.id).count
+
+    AiClient.stub :new, ->(**kwargs) { FakeAiClient.new } do
+      perform_enqueued_jobs do
+        AiAgentJob.perform_later(@agent.id, "comment_created", @context)
+      end
+    end
+
+    # No new task should have been created
+    assert_equal initial_task_count, Task.where(agent_id: @agent.id).count,
+      "Expected no new task when duplicate running task exists for same comment"
+  end
+
+  test "allows execution when existing task for same comment is done" do
+    # Create a completed task for the same agent + comment
+    Task.create!(
+      name: "Response to comment_created",
+      status: "done",
+      trigger_event_name: "comment_created",
+      trigger_event_payload: @context,
+      agent: @agent,
+      topic_id: nil
+    )
+
+    initial_task_count = Task.where(agent_id: @agent.id).count
+
+    AiClient.stub :new, ->(**kwargs) { FakeAiClient.new } do
+      perform_enqueued_jobs do
+        AiAgentJob.perform_later(@agent.id, "comment_created", @context)
+      end
+    end
+
+    # A new task should have been created (the done one doesn't block)
+    assert_operator Task.where(agent_id: @agent.id).count, :>, initial_task_count,
+      "Expected new task when existing task is done"
+  end
 end


### PR DESCRIPTION
## Problem

AI agent infinite loop bug: when an agent's HTTP streaming response takes a long time (e.g., deployment commands), the same `comment_created` event gets re-dispatched repeatedly, creating 20+ duplicate tasks for the same trigger comment. Each task creates a new reply comment, flooding the chat with partial/duplicate responses.

### Root Cause (Investigation)

Production data from creative 8843 shows:
- **27 PendingCallbacks** created for the same creative in 22 minutes
- **22 Tasks** all with identical payload (`comment: { id: 9950 }`), all `status: running`
- **0 Solid Queue failed executions** — jobs aren't failing, they're being re-enqueued
- All tasks triggered by same `comment_created` event for `@Vrex: 배포하자`

The exact re-dispatch path is still under investigation (dispatch tracing added), but the symptoms are clear: same comment triggers multiple concurrent agent executions.

## Fix

### 1. Duplicate Running Task Guard (`AiAgentJob`)

Before creating a new task, check if the same agent already has a running task for the same trigger comment. If so, skip execution with a warning log.

```ruby
# Guard: skip if agent already has running task for same comment
if comment_id && duplicate_running_task?(agent.id, comment_id)
  Rails.logger.warn("[AiAgentJob] Skipping duplicate...")
  return
end
```

### 2. Dispatch Tracing (`SystemEvents::Dispatcher`)

Added caller-stack logging to `Dispatcher.dispatch` to trace exactly which code path triggers repeated `comment_created` events in production:

```
[SystemEvents::Dispatcher] event=comment_created comment_id=9950 caller=comments_controller.rb:168 <- ...
```

## Tests

- ✅ 1187 runs, 3785 assertions, 0 failures, 0 errors
- ✅ New tests: duplicate guard blocks running, allows done
- ✅ Rubocop clean