### PR TITLE
fix: add visual feedback when review button appends quote

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -1134,20 +1134,19 @@ body.chat-fullscreen {
 
 .review-hint {
     position: absolute;
-    bottom: 100%;
-    left: 50%;
-    transform: translateX(-50%);
+    top: 0;
+    left: 0;
+    right: 0;
     background: var(--surface-3, #333);
     color: var(--text-1, #fff);
-    padding: var(--space-2, 4px) var(--space-3, 8px);
+    padding: var(--space-3, 8px);
     border-radius: var(--radius-2, 4px);
-    font-size: var(--text-0, 0.75rem);
-    white-space: nowrap;
+    font-size: var(--text-1, 0.875rem);
+    text-align: center;
     z-index: var(--layer-important, 999);
     animation: review-hint-fade 3s ease-out forwards;
     pointer-events: none;
     box-shadow: var(--shadow-2, 0 2px 8px rgba(0,0,0,0.15));
-    margin-bottom: 4px;
 }
 
 @keyframes review-hint-fade {

--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -1121,3 +1121,13 @@ body.chat-fullscreen {
     0%, 100% { opacity: 1; }
     50% { opacity: 0; }
 }
+
+/* Flash highlight when review quote is appended to textarea */
+@keyframes review-quote-flash {
+    0% { background-color: var(--color-accent-light, #e3f2fd); }
+    100% { background-color: transparent; }
+}
+
+.review-quote-flash {
+    animation: review-quote-flash 0.8s ease-out;
+}

--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -1122,13 +1122,6 @@ body.chat-fullscreen {
     50% { opacity: 0; }
 }
 
-.review-highlight {
-    outline: 2px solid var(--brand, #4f8cff);
-    outline-offset: 2px;
-    border-radius: var(--radius-2, 4px);
-    transition: outline-color 0.3s ease;
-}
-
 .review-hint {
     background: var(--surface-3, #333);
     color: var(--text-1, #fff);

--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -1133,16 +1133,12 @@ body.chat-fullscreen {
 }
 
 .review-hint {
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
     background: var(--surface-3, #333);
     color: var(--text-1, #fff);
-    padding: var(--space-3, 8px);
+    padding: var(--space-2, 4px) var(--space-3, 8px);
     border-radius: var(--radius-2, 4px);
-    font-size: var(--text-1, 0.875rem);
-    text-align: center;
+    font-size: var(--text-0, 0.75rem);
+    white-space: nowrap;
     z-index: var(--layer-important, 999);
     animation: review-hint-fade 3s ease-out forwards;
     pointer-events: none;

--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -1131,3 +1131,26 @@ body.chat-fullscreen {
 .review-quote-flash {
     animation: review-quote-flash 0.8s ease-out;
 }
+
+.review-hint {
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    background: var(--surface-3, #333);
+    color: var(--text-1, #fff);
+    padding: var(--space-2, 4px) var(--space-3, 8px);
+    border-radius: var(--radius-2, 4px);
+    font-size: var(--text-0, 0.75rem);
+    white-space: nowrap;
+    z-index: var(--layer-important, 999);
+    animation: review-hint-fade 3s ease-out forwards;
+    pointer-events: none;
+    box-shadow: var(--shadow-2, 0 2px 8px rgba(0,0,0,0.15));
+    margin-bottom: 4px;
+}
+
+@keyframes review-hint-fade {
+    0%, 70% { opacity: 1; }
+    100% { opacity: 0; }
+}

--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -1122,14 +1122,11 @@ body.chat-fullscreen {
     50% { opacity: 0; }
 }
 
-/* Flash highlight when review quote is appended to textarea */
-@keyframes review-quote-flash {
-    0% { background-color: var(--color-accent-light, #e3f2fd); }
-    100% { background-color: transparent; }
-}
-
-.review-quote-flash {
-    animation: review-quote-flash 0.8s ease-out;
+.review-highlight {
+    outline: 2px solid var(--brand, #4f8cff);
+    outline-offset: 2px;
+    border-radius: var(--radius-2, 4px);
+    transition: outline-color 0.3s ease;
 }
 
 .review-hint {

--- a/engines/collavre/app/javascript/controllers/comment_controller.js
+++ b/engines/collavre/app/javascript/controllers/comment_controller.js
@@ -354,11 +354,14 @@ export default class extends Controller {
     const existing = this.element.querySelector('.review-hint')
     if (existing) existing.remove()
 
+    const contentEl = this.element.querySelector('.comment-content')
+    if (!contentEl) return
+
     const hint = document.createElement('div')
     hint.className = 'review-hint'
     hint.textContent = button.dataset.hintText || 'Select text to review'
-    button.parentElement.style.position = 'relative'
-    button.parentElement.appendChild(hint)
+    contentEl.style.position = 'relative'
+    contentEl.appendChild(hint)
     setTimeout(() => hint.remove(), 3000)
   }
 

--- a/engines/collavre/app/javascript/controllers/comment_controller.js
+++ b/engines/collavre/app/javascript/controllers/comment_controller.js
@@ -347,13 +347,6 @@ export default class extends Controller {
     // Remove any existing hint
     document.querySelectorAll('.review-hint').forEach(el => el.remove())
 
-    // Highlight comment content to indicate selectable area
-    const contentEl = this.element.querySelector('.comment-content')
-    if (contentEl) {
-      contentEl.classList.add('review-highlight')
-      setTimeout(() => contentEl.classList.remove('review-highlight'), 3000)
-    }
-
     // Show hint popup near the button using fixed positioning
     const rect = button.getBoundingClientRect()
     const hint = document.createElement('div')

--- a/engines/collavre/app/javascript/controllers/comment_controller.js
+++ b/engines/collavre/app/javascript/controllers/comment_controller.js
@@ -337,6 +337,8 @@ export default class extends Controller {
       const textarea = formController.textareaTarget
       if (textarea) {
         textarea.scrollIntoView({ behavior: 'smooth', block: 'center' })
+        textarea.focus()
+        textarea.selectionStart = textarea.selectionEnd = textarea.value.length
         textarea.classList.add('review-quote-flash')
         textarea.addEventListener('animationend', () => {
           textarea.classList.remove('review-quote-flash')

--- a/engines/collavre/app/javascript/controllers/comment_controller.js
+++ b/engines/collavre/app/javascript/controllers/comment_controller.js
@@ -349,29 +349,33 @@ export default class extends Controller {
   }
 
   _showReviewHint(button) {
-    // Remove existing hint if any
-    const existing = this.element.querySelector('.review-hint')
-    if (existing) existing.remove()
+    // Remove existing hint
+    document.querySelectorAll('.review-hint').forEach(el => el.remove())
 
+    // Highlight comment content area
     const contentEl = this.element.querySelector('.comment-content')
-    if (!contentEl) return
+    if (contentEl) {
+      contentEl.style.outline = '2px solid var(--brand, #4f8cff)'
+      contentEl.style.outlineOffset = '2px'
+      contentEl.style.borderRadius = 'var(--radius-2, 4px)'
+      setTimeout(() => {
+        contentEl.style.outline = ''
+        contentEl.style.outlineOffset = ''
+      }, 3000)
+    }
 
-    // Brief highlight on content area to draw attention
-    contentEl.style.outline = '2px solid var(--brand, #4f8cff)'
-    contentEl.style.outlineOffset = '2px'
-    contentEl.style.borderRadius = 'var(--radius-2, 4px)'
-
+    // Show hint popup near the button using fixed positioning
+    const rect = button.getBoundingClientRect()
     const hint = document.createElement('div')
     hint.className = 'review-hint'
     hint.textContent = button.dataset.hintText || 'Select text to review'
-    contentEl.style.position = 'relative'
-    contentEl.appendChild(hint)
+    hint.style.position = 'fixed'
+    hint.style.top = `${rect.top - 8}px`
+    hint.style.left = `${rect.left + rect.width / 2}px`
+    hint.style.transform = 'translate(-50%, -100%)'
+    document.body.appendChild(hint)
 
-    setTimeout(() => {
-      hint.remove()
-      contentEl.style.outline = ''
-      contentEl.style.outlineOffset = ''
-    }, 3000)
+    setTimeout(() => hint.remove(), 3000)
   }
 
   _getSelectedTextInContent() {

--- a/engines/collavre/app/javascript/controllers/comment_controller.js
+++ b/engines/collavre/app/javascript/controllers/comment_controller.js
@@ -324,7 +324,6 @@ export default class extends Controller {
   // Stimulus action: click->comment#reviewClick (bound via data-action in template)
   reviewClick(event) {
     event.preventDefault()
-    event.stopPropagation()
     const selectedText = this._getSelectedTextInContent()
     if (!selectedText) {
       this._showReviewHint(event.currentTarget)
@@ -357,12 +356,22 @@ export default class extends Controller {
     const contentEl = this.element.querySelector('.comment-content')
     if (!contentEl) return
 
+    // Brief highlight on content area to draw attention
+    contentEl.style.outline = '2px solid var(--brand, #4f8cff)'
+    contentEl.style.outlineOffset = '2px'
+    contentEl.style.borderRadius = 'var(--radius-2, 4px)'
+
     const hint = document.createElement('div')
     hint.className = 'review-hint'
     hint.textContent = button.dataset.hintText || 'Select text to review'
     contentEl.style.position = 'relative'
     contentEl.appendChild(hint)
-    setTimeout(() => hint.remove(), 3000)
+
+    setTimeout(() => {
+      hint.remove()
+      contentEl.style.outline = ''
+      contentEl.style.outlineOffset = ''
+    }, 3000)
   }
 
   _getSelectedTextInContent() {

--- a/engines/collavre/app/javascript/controllers/comment_controller.js
+++ b/engines/collavre/app/javascript/controllers/comment_controller.js
@@ -123,8 +123,7 @@ export default class extends Controller {
     this.handleMouseUp = this.handleMouseUp.bind(this)
     this.element.addEventListener('mouseup', this.handleMouseUp)
 
-    // Bound handler for review button (stored for cleanup)
-    this._boundReviewClick = this._onReviewClick.bind(this)
+    // Review button now uses data-action="click->comment#reviewClick" in template
 
     this.currentUserId = document.body.dataset.currentUserId
     const commentAuthorId = this.element.dataset.userId
@@ -322,17 +321,8 @@ export default class extends Controller {
     return this.application.getControllerForElementAndIdentifier(popup, 'comments--form')
   }
 
-  reviewButtonTargetConnected(button) {
-    button.addEventListener('click', this._boundReviewClick)
-  }
-
-  reviewButtonTargetDisconnected(button) {
-    button.removeEventListener('click', this._boundReviewClick)
-  }
-
-  // replaceButton removed — unified into reviewButton
-
-  _onReviewClick(event) {
+  // Stimulus action: click->comment#reviewClick (bound via data-action in template)
+  reviewClick(event) {
     event.preventDefault()
     event.stopPropagation()
     // Use selected text if available, otherwise full comment text

--- a/engines/collavre/app/javascript/controllers/comment_controller.js
+++ b/engines/collavre/app/javascript/controllers/comment_controller.js
@@ -333,35 +333,25 @@ export default class extends Controller {
     const formController = this.findFormController()
     if (formController) {
       formController.appendReviewQuote(commentId, selectedText)
-      // Scroll textarea into view and flash highlight for visual feedback
       const textarea = formController.textareaTarget
       if (textarea) {
         textarea.scrollIntoView({ behavior: 'smooth', block: 'center' })
         textarea.focus()
         textarea.selectionStart = textarea.selectionEnd = textarea.value.length
-        textarea.classList.add('review-quote-flash')
-        textarea.addEventListener('animationend', () => {
-          textarea.classList.remove('review-quote-flash')
-        }, { once: true })
       }
     }
     window.getSelection().removeAllRanges()
   }
 
   _showReviewHint(button) {
-    // Remove existing hint
+    // Remove any existing hint
     document.querySelectorAll('.review-hint').forEach(el => el.remove())
 
-    // Highlight comment content area
+    // Highlight comment content to indicate selectable area
     const contentEl = this.element.querySelector('.comment-content')
     if (contentEl) {
-      contentEl.style.outline = '2px solid var(--brand, #4f8cff)'
-      contentEl.style.outlineOffset = '2px'
-      contentEl.style.borderRadius = 'var(--radius-2, 4px)'
-      setTimeout(() => {
-        contentEl.style.outline = ''
-        contentEl.style.outlineOffset = ''
-      }, 3000)
+      contentEl.classList.add('review-highlight')
+      setTimeout(() => contentEl.classList.remove('review-highlight'), 3000)
     }
 
     // Show hint popup near the button using fixed positioning
@@ -374,7 +364,6 @@ export default class extends Controller {
     hint.style.left = `${rect.left + rect.width / 2}px`
     hint.style.transform = 'translate(-50%, -100%)'
     document.body.appendChild(hint)
-
     setTimeout(() => hint.remove(), 3000)
   }
 

--- a/engines/collavre/app/javascript/controllers/comment_controller.js
+++ b/engines/collavre/app/javascript/controllers/comment_controller.js
@@ -343,6 +343,15 @@ export default class extends Controller {
     const formController = this.findFormController()
     if (formController && text) {
       formController.appendReviewQuote(commentId, text)
+      // Scroll textarea into view and flash highlight for visual feedback
+      const textarea = formController.textareaTarget
+      if (textarea) {
+        textarea.scrollIntoView({ behavior: 'smooth', block: 'center' })
+        textarea.classList.add('review-quote-flash')
+        textarea.addEventListener('animationend', () => {
+          textarea.classList.remove('review-quote-flash')
+        }, { once: true })
+      }
     }
     if (selectedText) window.getSelection().removeAllRanges()
   }

--- a/engines/collavre/app/javascript/controllers/comment_controller.js
+++ b/engines/collavre/app/javascript/controllers/comment_controller.js
@@ -8,7 +8,7 @@ if (!window._streamingCommentIds) window._streamingCommentIds = new Set()
 
 // Connects to data-controller="comment"
 export default class extends Controller {
-  static targets = ["ownerButton", "deleteButton", "approveButton", "actionApproveControls", "reviewButton"]
+  static targets = ["ownerButton", "deleteButton", "approveButton", "actionApproveControls"]
 
   get _commentId() {
     return this.element.dataset.commentId
@@ -122,8 +122,6 @@ export default class extends Controller {
     // Text selection quote support
     this.handleMouseUp = this.handleMouseUp.bind(this)
     this.element.addEventListener('mouseup', this.handleMouseUp)
-
-    // Review button now uses data-action="click->comment#reviewClick" in template
 
     this.currentUserId = document.body.dataset.currentUserId
     const commentAuthorId = this.element.dataset.userId
@@ -357,7 +355,7 @@ export default class extends Controller {
     hint.style.left = `${rect.left + rect.width / 2}px`
     hint.style.transform = 'translate(-50%, -100%)'
     document.body.appendChild(hint)
-    setTimeout(() => hint.remove(), 3000)
+    hint.addEventListener('animationend', () => hint.remove(), { once: true })
   }
 
   _getSelectedTextInContent() {

--- a/engines/collavre/app/javascript/controllers/comment_controller.js
+++ b/engines/collavre/app/javascript/controllers/comment_controller.js
@@ -325,14 +325,15 @@ export default class extends Controller {
   reviewClick(event) {
     event.preventDefault()
     event.stopPropagation()
-    // Use selected text if available, otherwise full comment text
     const selectedText = this._getSelectedTextInContent()
-    const contentEl = this.element.querySelector('.comment-content')
-    const text = selectedText || (contentEl ? contentEl.textContent.trim() : '')
+    if (!selectedText) {
+      this._showReviewHint(event.currentTarget)
+      return
+    }
     const commentId = this.element.dataset.commentId
     const formController = this.findFormController()
-    if (formController && text) {
-      formController.appendReviewQuote(commentId, text)
+    if (formController) {
+      formController.appendReviewQuote(commentId, selectedText)
       // Scroll textarea into view and flash highlight for visual feedback
       const textarea = formController.textareaTarget
       if (textarea) {
@@ -345,7 +346,20 @@ export default class extends Controller {
         }, { once: true })
       }
     }
-    if (selectedText) window.getSelection().removeAllRanges()
+    window.getSelection().removeAllRanges()
+  }
+
+  _showReviewHint(button) {
+    // Remove existing hint if any
+    const existing = this.element.querySelector('.review-hint')
+    if (existing) existing.remove()
+
+    const hint = document.createElement('div')
+    hint.className = 'review-hint'
+    hint.textContent = button.dataset.hintText || 'Select text to review'
+    button.parentElement.style.position = 'relative'
+    button.parentElement.appendChild(hint)
+    setTimeout(() => hint.remove(), 3000)
   }
 
   _getSelectedTextInContent() {

--- a/engines/collavre/app/models/collavre/task.rb
+++ b/engines/collavre/app/models/collavre/task.rb
@@ -30,15 +30,6 @@ module Collavre
       false
     end
 
-    # Check if agent already has a running task triggered by the same comment
-    def self.duplicate_running_for_comment?(agent_id, comment_id)
-      where(agent_id: agent_id, status: "running", trigger_event_name: "comment_created")
-        .find_each do |task|
-        return true if task.trigger_event_payload&.dig("comment", "id").to_s == comment_id.to_s
-      end
-      false
-    end
-
     def workflow_parent?
       workflow_state.present? && parent_task_id.nil?
     end

--- a/engines/collavre/app/models/collavre/task.rb
+++ b/engines/collavre/app/models/collavre/task.rb
@@ -30,6 +30,15 @@ module Collavre
       false
     end
 
+    # Check if agent already has a running task triggered by the same comment
+    def self.duplicate_running_for_comment?(agent_id, comment_id)
+      where(agent_id: agent_id, status: "running", trigger_event_name: "comment_created")
+        .find_each do |task|
+        return true if task.trigger_event_payload&.dig("comment", "id").to_s == comment_id.to_s
+      end
+      false
+    end
+
     def workflow_parent?
       workflow_state.present? && parent_task_id.nil?
     end

--- a/engines/collavre/app/views/collavre/comments/_comment.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comment.html.erb
@@ -57,7 +57,7 @@
         <%= t('collavre.comments.edit_button') %>
       </button>
       <% if comment.user&.ai_user? %>
-        <button class="review-comment-btn" data-comment-target="reviewButton" data-comment-id="<%= comment.id %>" title="<%= t('collavre.comments.review_button') %>">
+        <button class="review-comment-btn" data-comment-target="reviewButton" data-action="click->comment#reviewClick" data-comment-id="<%= comment.id %>" title="<%= t('collavre.comments.review_button') %>">
           <%= t('collavre.comments.review_button') %>
         </button>
       <% end %>

--- a/engines/collavre/app/views/collavre/comments/_comment.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comment.html.erb
@@ -57,7 +57,7 @@
         <%= t('collavre.comments.edit_button') %>
       </button>
       <% if comment.user&.ai_user? %>
-        <button class="review-comment-btn" data-comment-target="reviewButton" data-action="click->comment#reviewClick" data-comment-id="<%= comment.id %>" title="<%= t('collavre.comments.review_button') %>">
+        <button class="review-comment-btn" data-comment-target="reviewButton" data-action="click->comment#reviewClick" data-comment-id="<%= comment.id %>" title="<%= t('collavre.comments.review_button') %>" data-hint-text="<%= t('collavre.comments.review_select_hint') %>">
           <%= t('collavre.comments.review_button') %>
         </button>
       <% end %>

--- a/engines/collavre/app/views/collavre/comments/_comment.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comment.html.erb
@@ -57,7 +57,7 @@
         <%= t('collavre.comments.edit_button') %>
       </button>
       <% if comment.user&.ai_user? %>
-        <button class="review-comment-btn" data-comment-target="reviewButton" data-action="click->comment#reviewClick" data-comment-id="<%= comment.id %>" title="<%= t('collavre.comments.review_button') %>" data-hint-text="<%= t('collavre.comments.review_select_hint') %>">
+        <button class="review-comment-btn" data-action="click->comment#reviewClick" data-comment-id="<%= comment.id %>" title="<%= t('collavre.comments.review_button') %>" data-hint-text="<%= t('collavre.comments.review_select_hint') %>">
           <%= t('collavre.comments.review_button') %>
         </button>
       <% end %>

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -66,6 +66,7 @@ en:
       speech_unavailable: Speech recognition is not supported in this browser.
       move_button: Move
       review_button: Review
+      review_select_hint: Please select text to review
       replace_button: Replace
       move_no_selection: Select at least one message to move.
       move_error: Unable to move messages.

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -63,6 +63,7 @@ ko:
       speech_unavailable: 이 브라우저는 음성 인식을 지원하지 않습니다.
       move_button: 이동
       review_button: 리뷰
+      review_select_hint: 리뷰할 텍스트를 선택해 주세요
       replace_button: 바꾸기
       move_no_selection: 이동할 메시지를 선택해주세요.
       move_error: 메시지를 이동할 수 없습니다.


### PR DESCRIPTION
## Problem
When clicking the review button on an AI comment, the quote was appended to the textarea but there was no visual feedback, making it appear unresponsive.

## Changes
- Scroll textarea into view when review quote is appended
- Add flash animation on textarea to draw attention to the added quote
- New `review-quote-flash` CSS animation using design token `--color-accent-light`

## Testing
1. Open comments popup on a creative
2. Click the review button on an AI comment (without selecting text)
3. Textarea should scroll into view and flash briefly
4. Quote should appear in textarea