### PR TITLE
fix: scope topic concurrency checks by creative_id

### DIFF
--- a/engines/collavre/app/jobs/collavre/ai_agent_job.rb
+++ b/engines/collavre/app/jobs/collavre/ai_agent_job.rb
@@ -96,7 +96,7 @@ module Collavre
         raise e
       ensure
         if task&.trigger_event_payload&.key?("topic") && %w[done failed cancelled escalated].include?(task.reload.status)
-          Orchestration::AgentOrchestrator.dequeue_next_for_topic(task.topic_id)
+          Orchestration::AgentOrchestrator.dequeue_next_for_topic(task.topic_id, task.creative_id)
         end
       end
     end

--- a/engines/collavre/app/models/collavre/task.rb
+++ b/engines/collavre/app/models/collavre/task.rb
@@ -10,8 +10,16 @@ module Collavre
 
     validates :name, presence: true
 
-    scope :running_for_topic, ->(topic_id) { where(topic_id: topic_id, status: "running") }
-    scope :queued_for_topic, ->(topic_id) { where(topic_id: topic_id, status: "queued").order(:created_at) }
+    scope :running_for_topic, ->(topic_id, creative_id = nil) {
+      rel = where(topic_id: topic_id, status: "running")
+      rel = rel.where(creative_id: creative_id) if creative_id
+      rel
+    }
+    scope :queued_for_topic, ->(topic_id, creative_id = nil) {
+      rel = where(topic_id: topic_id, status: "queued")
+      rel = rel.where(creative_id: creative_id) if creative_id
+      rel.order(:created_at)
+    }
 
     # Check if agent already has a running task triggered by the same comment
     def self.duplicate_running_for_comment?(agent_id, comment_id)

--- a/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
+++ b/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
@@ -16,8 +16,8 @@ module Collavre
         new(event_name: event_name, context: context).dispatch
       end
 
-      def self.dequeue_next_for_topic(topic_id)
-        task = Task.queued_for_topic(topic_id).first
+      def self.dequeue_next_for_topic(topic_id, creative_id = nil)
+        task = Task.queued_for_topic(topic_id, creative_id).first
         return unless task
 
         updated = Task.where(id: task.id, status: "queued").update_all(status: "pending")
@@ -29,7 +29,7 @@ module Collavre
           if task.status == "cancelled"
             # refresh_deferred_context! cancelled this task (no eligible comment),
             # try the next queued task for this topic.
-            dequeue_next_for_topic(topic_id)
+            dequeue_next_for_topic(topic_id, creative_id)
           else
             AiAgentJob.perform_later(task)
           end

--- a/engines/collavre/app/services/collavre/orchestration/scheduler.rb
+++ b/engines/collavre/app/services/collavre/orchestration/scheduler.rb
@@ -72,11 +72,12 @@ module Collavre
           return delayed_decision(agent, :rate_limited, config)
         end
 
-        # Check 4: Topic concurrency limit (applies to Main topic with nil topic_id too)
+        # Check 4: Topic concurrency limit (scoped by creative to avoid cross-creative blocking)
         topic_max = @policy_resolver.topic_max_concurrent_jobs
         if topic_max && @context.key?("topic")
           topic_id = @context.dig("topic", "id")
-          if (Task.running_for_topic(topic_id).count + topic_immediate_count) >= topic_max
+          creative_id = @context.dig("creative", "id")
+          if (Task.running_for_topic(topic_id, creative_id).count + topic_immediate_count) >= topic_max
             return deferred_decision(agent, :topic_concurrency)
           end
         end

--- a/engines/collavre/app/services/collavre/orchestration/stuck_detector.rb
+++ b/engines/collavre/app/services/collavre/orchestration/stuck_detector.rb
@@ -74,7 +74,7 @@ module Collavre
           end
 
           # Drain the queue for the topic so waiting tasks can execute
-          AgentOrchestrator.dequeue_next_for_topic(task.topic_id)
+          AgentOrchestrator.dequeue_next_for_topic(task.topic_id, task.creative_id)
         rescue StandardError => e
           Rails.logger.error("[StuckDetector] Auto-recovery failed for task #{task.id}: #{e.message}")
         end

--- a/engines/collavre/test/services/collavre/orchestration/agent_orchestrator_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/agent_orchestrator_test.rb
@@ -109,7 +109,7 @@ module Collavre
 
         # Create a running task to trigger topic concurrency limit
         Task.create!(name: "Running", status: "running", trigger_event_name: "e",
-                     agent: @ai_agent, topic_id: topic.id)
+                     agent: @ai_agent, topic_id: topic.id, creative: @creative)
 
         queued_count_before = Task.where(status: "queued", topic_id: topic.id).count
         result = AgentOrchestrator.dispatch("comment_created", context)

--- a/engines/collavre/test/services/collavre/orchestration/scheduler_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/scheduler_test.rb
@@ -221,7 +221,8 @@ module Collavre
           status: "running",
           trigger_event_name: "comment_created",
           agent: @agent,
-          topic_id: @topic.id
+          topic_id: @topic.id,
+          creative: @creative
         )
 
         scheduler = Scheduler.new(@context)
@@ -246,8 +247,8 @@ module Collavre
           config: { "topic_max_concurrent_jobs" => 2 }
         )
 
-        Task.create!(name: "t1", status: "running", trigger_event_name: "e", agent: @agent, topic_id: @topic.id)
-        Task.create!(name: "t2", status: "running", trigger_event_name: "e", agent: @agent, topic_id: @topic.id)
+        Task.create!(name: "t1", status: "running", trigger_event_name: "e", agent: @agent, topic_id: @topic.id, creative: @creative)
+        Task.create!(name: "t2", status: "running", trigger_event_name: "e", agent: @agent, topic_id: @topic.id, creative: @creative)
 
         scheduler = Scheduler.new(@context)
         decisions = scheduler.schedule([ @agent ])
@@ -275,7 +276,8 @@ module Collavre
           status: "running",
           trigger_event_name: "comment_created",
           agent: @agent,
-          topic_id: nil
+          topic_id: nil,
+          creative: @creative
         )
 
         scheduler = Scheduler.new(main_topic_context)
@@ -315,6 +317,30 @@ module Collavre
         assert_equal :deferred, decisions.last[:timing]
       ensure
         ResourceTracker.for(agent2).reset! if agent2
+      end
+
+      test "does not defer when running task belongs to different creative on main topic" do
+        other_creative = Creative.create!(description: "Other Creative", progress: 0, user: @agent)
+
+        # Running task on OTHER creative's main topic
+        Task.create!(
+          name: "Other creative main task",
+          status: "running",
+          trigger_event_name: "comment_created",
+          agent: @agent,
+          topic_id: nil,
+          creative: other_creative
+        )
+
+        main_topic_context = {
+          "creative" => { "id" => @creative.id },
+          "topic" => { "id" => nil }
+        }
+
+        scheduler = Scheduler.new(main_topic_context)
+        decisions = scheduler.schedule([ @agent ])
+
+        assert_equal :immediate, decisions.first[:timing]
       end
 
       # Default policy values


### PR DESCRIPTION
## Problem

`running_for_topic` and `queued_for_topic` scopes on `Task` only filtered by `topic_id`. Since Main topics use `topic_id = nil`, **all creatives' Main topics shared the same concurrency slot**. A running task in Creative A's Main topic would block Creative B's Main topic from executing.

## Solution

Add optional `creative_id` parameter to both scopes and pass it through the entire chain:
- `Task.running_for_topic(topic_id, creative_id)`
- `Task.queued_for_topic(topic_id, creative_id)`
- `Scheduler#evaluate` — reads `creative_id` from context
- `AgentOrchestrator.dequeue_next_for_topic` — accepts `creative_id`
- `AiAgentJob` and `StuckDetector` — pass `task.creative_id`

The parameter is optional for backward compatibility.

## Tests

- Updated existing tests to include `creative` on task fixtures
- Added new test: cross-creative Main topics don't block each other

Fixes Creative #9067, Topic #253