### PR TITLE
fix: populate creative_id on Task creation for topic concurrency checks

### DIFF
--- a/engines/collavre/app/jobs/collavre/ai_agent_job.rb
+++ b/engines/collavre/app/jobs/collavre/ai_agent_job.rb
@@ -31,7 +31,8 @@ module Collavre
           trigger_event_name: event_name,
           trigger_event_payload: context,
           agent: agent,
-          topic_id: context&.dig("topic", "id")
+          topic_id: context&.dig("topic", "id"),
+          creative_id: context&.dig("creative", "id")
         )
 
         # Record task for loop breaker tracking (per-topic, skip user-initiated)

--- a/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
+++ b/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
@@ -148,7 +148,8 @@ module Collavre
               trigger_event_name: @event_name,
               trigger_event_payload: @context,
               agent: agent,
-              topic_id: @context.dig("topic", "id")
+              topic_id: @context.dig("topic", "id"),
+              creative_id: @context.dig("creative", "id")
             )
             post_waiting_notice(agent, decision)
             agent

--- a/engines/collavre/test/jobs/ai_agent_job_test.rb
+++ b/engines/collavre/test/jobs/ai_agent_job_test.rb
@@ -238,7 +238,8 @@ class AiAgentJobTest < ActiveJob::TestCase
       name: "Queued task", status: "queued",
       trigger_event_name: "comment_created",
       trigger_event_payload: context_with_topic,
-      agent: @agent, topic_id: topic.id
+      agent: @agent, topic_id: topic.id,
+      creative_id: @creative.id
     )
 
     AiClient.stub :new, FakeAiClient.new do
@@ -258,7 +259,8 @@ class AiAgentJobTest < ActiveJob::TestCase
       name: "Queued task", status: "queued",
       trigger_event_name: "comment_created",
       trigger_event_payload: context_with_topic,
-      agent: @agent, topic_id: topic.id
+      agent: @agent, topic_id: topic.id,
+      creative_id: @creative.id
     )
 
     AiClient.stub :new, ->(*args) { raise StandardError, "AI Error" } do

--- a/engines/collavre/test/services/collavre/orchestration/cross_topic_parallelism_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/cross_topic_parallelism_test.rb
@@ -28,7 +28,8 @@ module Collavre
           status: "running",
           trigger_event_name: "comment_created",
           agent: @agent,
-          topic_id: @topic_a.id
+          topic_id: @topic_a.id,
+          creative_id: @creative.id
         )
         ResourceTracker.for(@agent).reserve!("job-topic-a")
 
@@ -53,7 +54,8 @@ module Collavre
           status: "running",
           trigger_event_name: "comment_created",
           agent: @agent,
-          topic_id: @topic_a.id
+          topic_id: @topic_a.id,
+          creative_id: @creative.id
         )
         ResourceTracker.for(@agent).reserve!("job-topic-a")
 
@@ -80,7 +82,8 @@ module Collavre
           status: "running",
           trigger_event_name: "comment_created",
           agent: @agent,
-          topic_id: @topic_a.id
+          topic_id: @topic_a.id,
+          creative_id: @creative.id
         )
 
         # Also a running task in Main (topic_id: nil) — simulating Main topic broadcast
@@ -89,7 +92,8 @@ module Collavre
           status: "running",
           trigger_event_name: "comment_created",
           agent: @agent,
-          topic_id: nil
+          topic_id: nil,
+          creative_id: @creative.id
         )
 
         ResourceTracker.for(@agent).reserve!("job-topic-a")
@@ -113,8 +117,8 @@ module Collavre
         topic_c = Topic.create!(name: "Topic C", creative: @creative, user: @user)
 
         # Running tasks in A and B
-        Task.create!(name: "t-a", status: "running", trigger_event_name: "e", agent: @agent, topic_id: @topic_a.id)
-        Task.create!(name: "t-b", status: "running", trigger_event_name: "e", agent: @agent, topic_id: @topic_b.id)
+        Task.create!(name: "t-a", status: "running", trigger_event_name: "e", agent: @agent, topic_id: @topic_a.id, creative_id: @creative.id)
+        Task.create!(name: "t-b", status: "running", trigger_event_name: "e", agent: @agent, topic_id: @topic_b.id, creative_id: @creative.id)
         ResourceTracker.for(@agent).reserve!("job-a")
         ResourceTracker.for(@agent).reserve!("job-b")
 


### PR DESCRIPTION
## Problem

`CrossTopicParallelismTest#test_same_agent_is_deferred_in_same_topic_when_already_running` was failing because Task records were created without `creative_id`.

The `running_for_topic` scope filters by `creative_id` when provided, but tasks never had it set — making the topic concurrency check (`topic_max_concurrent_jobs`) ineffective.

## Changes

- **`ai_agent_job.rb`**: Add `creative_id: context.dig('creative', 'id')` to running Task creation
- **`agent_orchestrator.rb`**: Add `creative_id` to queued Task creation  
- **`cross_topic_parallelism_test.rb`**: Add `creative_id` to test Task fixtures
- **`ai_agent_job_test.rb`**: Add `creative_id` to queued Task fixtures for dequeue tests

## Impact

This was a **real bug**, not just a test issue. Without `creative_id` on tasks, `running_for_topic(topic_id, creative_id)` would never find matching running tasks, so the topic-level concurrency limit was silently bypassed in production.