### PR TITLE
fix: auto-resize textarea in comment form

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -138,8 +138,12 @@ body.chat-fullscreen {
 
 #new-comment-form textarea {
     width: 96%;
-    resize: vertical;
+    resize: none;
     font-size: var(--text-1);
+    overflow-y: auto;
+    min-height: calc(var(--text-1) * 1.5 * 2); /* 2 lines minimum */
+    max-height: calc(var(--text-1) * 1.5 * 10); /* 10 lines maximum */
+    transition: height 0.1s ease-out;
     /* Prevent iOS zoom on focus */
 }
 

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -66,6 +66,15 @@ export default class extends Controller {
     this.listening = false
     this.recognitionActive = false
 
+    // Auto-resize textarea
+    this._autoResize = () => {
+      const textarea = this.textareaTarget
+      textarea.style.height = 'auto'
+      const maxHeight = parseInt(getComputedStyle(textarea).lineHeight, 10) * 10 || 200
+      textarea.style.height = `${Math.min(textarea.scrollHeight, maxHeight)}px`
+    }
+    this.textareaTarget.addEventListener('input', this._autoResize)
+
     this.textareaTarget.addEventListener('keydown', (event) => {
       if (event.key === 'Enter' && !event.shiftKey) {
         if (this.isMentionMenuVisible()) return
@@ -102,6 +111,7 @@ export default class extends Controller {
     this.teardownSpeechRecognition()
     this.imageButtonTarget?.removeEventListener('click', this.handleImageButtonClick)
     this.imageInputTarget?.removeEventListener('change', this.handleImageChange)
+    this.textareaTarget.removeEventListener('input', this._autoResize)
     this.textareaTarget.removeEventListener('dragover', this.handleDragOver)
     this.textareaTarget.removeEventListener('drop', this.handleDrop)
     this.textareaTarget.removeEventListener('paste', this.handlePaste)
@@ -163,6 +173,8 @@ export default class extends Controller {
     this.presenceController?.clearManualTypingMessage()
     this.clearImageAttachments()
     this.cancelQuote()
+    // Reset textarea height after clearing content
+    this.textareaTarget.style.height = 'auto'
   }
 
   setSendingState(isSending) {


### PR DESCRIPTION
## Problem

The comment form textarea was fixed at `rows=2`, making review quotes and multi-line messages invisible without manual resizing. When using the review feature, blockquoted text (`> ...`) was hidden below the visible area.

## Changes

- **Auto-resize on input**: Textarea grows with content (min 2 lines, max 10 lines)
- **Height reset on send**: Returns to default size after form submission
- **CSS**: Replaced `resize: vertical` with `resize: none` + min/max height constraints + smooth transition

## Files changed (2)

- `comments_popup.css` — textarea min/max height, transition
- `form_controller.js` — input listener for auto-resize, height reset in resetForm