### PR TITLE
feat: review quote chips UI for multi-review workflow

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_20_072200) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_23_173533) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false
@@ -137,6 +137,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_20_072200) do
     t.boolean "private", default: false, null: false
     t.integer "quoted_comment_id"
     t.text "quoted_text"
+    t.integer "review_type", limit: 1
     t.boolean "streaming", default: false, null: false
     t.integer "topic_id"
     t.datetime "updated_at", null: false

--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -270,11 +270,33 @@ body.chat-fullscreen {
     gap: 0.3em;
     padding: 0.25em 0.5em;
     background: color-mix(in srgb, var(--color-section-bg) 50%, transparent);
-    border-left: 3px solid var(--color-active);
+    border-left: 3px solid var(--color-muted);
     border-radius: 0 var(--radius-2) var(--radius-2) 0;
     font-size: var(--text-0);
     color: var(--color-muted);
     line-height: 1.3;
+    transition: border-color 0.15s ease, background 0.15s ease;
+}
+
+.review-quote-chip--active {
+    border-left-color: var(--color-active);
+    background: color-mix(in srgb, var(--color-active) 8%, transparent);
+}
+
+.review-quote-type-toggle {
+    border: none;
+    background: none;
+    cursor: pointer;
+    padding: 0 0.1em;
+    font-size: 0.85em;
+    line-height: 1;
+    flex-shrink: 0;
+    opacity: 0.8;
+    transition: opacity 0.15s ease;
+}
+
+.review-quote-type-toggle:hover {
+    opacity: 1;
 }
 
 .review-quote-chip-text {
@@ -290,6 +312,17 @@ body.chat-fullscreen {
     color: var(--color-text);
 }
 
+.review-quote-chip-feedback {
+    flex-shrink: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: 0.85em;
+    color: var(--color-text);
+    opacity: 0.7;
+}
+
 .review-quote-chip-remove {
     border: none;
     background: none;
@@ -303,6 +336,11 @@ body.chat-fullscreen {
 
 .review-quote-chip-remove:hover {
     color: var(--color-danger, #e53e3e);
+}
+
+.review-submit-btn {
+    font-size: var(--text-0) !important;
+    white-space: nowrap;
 }
 
 .comment-highlight {

--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -254,6 +254,62 @@ body.chat-fullscreen {
     color: var(--color-text);
 }
 
+/* Review quote chips */
+.review-quotes-container {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25em;
+    padding: 0.4em 0.5em;
+    max-height: 8em;
+    overflow-y: auto;
+}
+
+.review-quote-chip {
+    display: flex;
+    align-items: center;
+    gap: 0.3em;
+    padding: 0.25em 0.5em;
+    background: color-mix(in srgb, var(--color-section-bg) 50%, transparent);
+    border-left: 3px solid var(--color-active);
+    border-radius: 0 var(--radius-2) var(--radius-2) 0;
+    font-size: var(--text-0);
+    color: var(--color-muted);
+    line-height: 1.3;
+}
+
+.review-quote-chip-text {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    cursor: pointer;
+}
+
+.review-quote-chip-text:hover {
+    color: var(--color-text);
+}
+
+.review-quote-chip-remove {
+    border: none;
+    background: none;
+    cursor: pointer;
+    color: var(--color-muted);
+    font-size: 1em;
+    padding: 0 0.15em;
+    line-height: 1;
+    flex-shrink: 0;
+}
+
+.review-quote-chip-remove:hover {
+    color: var(--color-danger, #e53e3e);
+}
+
+.comment-highlight {
+    background: color-mix(in srgb, var(--color-active) 15%, transparent) !important;
+    transition: background 0.3s ease;
+}
+
 /* Review popup (uses common-popup) */
 .comment-review-popup {
     min-width: auto;

--- a/engines/collavre/app/controllers/collavre/comments_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comments_controller.rb
@@ -438,7 +438,7 @@ module Collavre
     end
 
     def comment_params
-      params.require(:comment).permit(:content, :private, :topic_id, :quoted_comment_id, :quoted_text, images: [])
+      params.require(:comment).permit(:content, :private, :topic_id, :quoted_comment_id, :quoted_text, :review_type, images: [])
     end
 
     def can_convert_comment?

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_review.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_review.test.js
@@ -1,0 +1,308 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { Application } from '@hotwired/stimulus'
+import FormController from '../form_controller'
+
+describe('FormController - Review Quote Chips', () => {
+  let application
+  let container
+  let controller
+
+  beforeEach(async () => {
+    container = document.createElement('div')
+    container.innerHTML = `
+      <div id="comments-popup"
+           data-controller="comments--form"
+           data-review-feedback-placeholder="Write feedback for this quote..."
+           data-review-summary-placeholder="Overall comment (optional)..."
+           data-review-add-quote="+ Add"
+           data-review-send="Send review"
+           data-review-send-question="Send question"
+           data-review-type-review="💬"
+           data-review-type-question="❓"
+           data-review-type-review-label="Review"
+           data-review-type-question-label="Question">
+        <form data-comments--form-target="form">
+          <input type="hidden" name="comment[quoted_comment_id]" data-comments--form-target="quotedCommentId" value="" />
+          <input type="hidden" name="comment[quoted_text]" data-comments--form-target="quotedText" value="" />
+          <div data-comments--form-target="quoteIndicator" style="display:none;">
+            <span data-comments--form-target="quoteIndicatorText"></span>
+          </div>
+          <div class="review-quotes-container" data-comments--form-target="reviewQuotesContainer" style="display:none;"></div>
+          <textarea data-comments--form-target="textarea" rows="2"></textarea>
+          <input type="checkbox" data-comments--form-target="privateCheckbox" />
+          <button type="submit" data-comments--form-target="submit">Send</button>
+          <button data-comments--form-target="cancel" style="display:none;">Cancel</button>
+          <button data-comments--form-target="moveButton" style="display:none;">Move</button>
+          <button data-comments--form-target="searchButton" style="display:none;">Search</button>
+          <button data-comments--form-target="voiceButton" style="display:none;">Voice</button>
+          <input type="file" data-comments--form-target="imageInput" style="display:none;" />
+          <button data-comments--form-target="imageButton" style="display:none;">Image</button>
+          <div data-comments--form-target="attachmentList"></div>
+        </form>
+      </div>
+    `
+    document.body.appendChild(container)
+
+    application = Application.start()
+    application.register('comments--form', FormController)
+
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    const el = container.querySelector('#comments-popup')
+    controller = application.getControllerForElementAndIdentifier(el, 'comments--form')
+  })
+
+  afterEach(() => {
+    application.stop()
+    document.body.removeChild(container)
+  })
+
+  describe('appendReviewQuote', () => {
+    test('adds a review quote chip', () => {
+      controller.appendReviewQuote(42, 'Hello world')
+
+      expect(controller._reviewQuotes).toHaveLength(1)
+      expect(controller._reviewQuotes[0]).toMatchObject({
+        commentId: 42,
+        text: 'Hello world',
+        type: 'review',
+        feedback: '',
+      })
+      expect(container.querySelectorAll('.review-quote-chip')).toHaveLength(1)
+    })
+
+    test('sets active quote id', () => {
+      controller.appendReviewQuote(1, 'text')
+      expect(controller._activeQuoteId).toBe(controller._reviewQuotes[0].id)
+    })
+
+    test('saves previous active quote feedback', () => {
+      controller.appendReviewQuote(1, 'first')
+      controller.textareaTarget.value = 'feedback for first'
+      controller.appendReviewQuote(2, 'second')
+
+      expect(controller._reviewQuotes[0].feedback).toBe('feedback for first')
+      expect(controller._reviewQuotes[1].feedback).toBe('')
+      expect(controller.textareaTarget.value).toBe('')
+    })
+
+    test('sets placeholder to feedback prompt', () => {
+      controller.appendReviewQuote(1, 'text')
+      expect(controller.textareaTarget.placeholder).toBe('Write feedback for this quote...')
+    })
+
+    test('ignores empty text', () => {
+      controller.appendReviewQuote(1, '')
+      expect(controller._reviewQuotes).toHaveLength(0)
+    })
+
+    test('ignores null text', () => {
+      controller.appendReviewQuote(1, null)
+      expect(controller._reviewQuotes).toHaveLength(0)
+    })
+
+    test('accumulates multiple quotes', () => {
+      controller.appendReviewQuote(1, 'first')
+      controller.appendReviewQuote(2, 'second')
+      controller.appendReviewQuote(3, 'third')
+
+      expect(controller._reviewQuotes).toHaveLength(3)
+      expect(container.querySelectorAll('.review-quote-chip')).toHaveLength(3)
+    })
+  })
+
+  describe('_commitActiveQuote', () => {
+    test('saves feedback and deactivates', () => {
+      controller.appendReviewQuote(1, 'text')
+      controller.textareaTarget.value = 'my feedback'
+      controller._commitActiveQuote()
+
+      expect(controller._reviewQuotes[0].feedback).toBe('my feedback')
+      expect(controller._activeQuoteId).toBeNull()
+      expect(controller.textareaTarget.value).toBe('')
+      expect(controller.textareaTarget.placeholder).toBe('Overall comment (optional)...')
+    })
+  })
+
+  describe('_updateSubmitButton', () => {
+    test('default state when no quotes', () => {
+      controller._updateSubmitButton()
+      expect(controller.submitTarget.classList.contains('review-submit-btn')).toBe(false)
+    })
+
+    test('"+ Add" when active review quote', () => {
+      controller.appendReviewQuote(1, 'text')
+      expect(controller.submitTarget.textContent).toBe('+ Add')
+      expect(controller.submitTarget.classList.contains('review-submit-btn')).toBe(true)
+    })
+
+    test('"Send question" when active question quote', () => {
+      controller.appendReviewQuote(1, 'text')
+      controller._reviewQuotes[0].type = 'question'
+      controller._updateSubmitButton()
+      expect(controller.submitTarget.textContent).toBe('Send question')
+    })
+
+    test('"Send review" when all quotes committed', () => {
+      controller.appendReviewQuote(1, 'text')
+      controller._commitActiveQuote()
+      expect(controller.submitTarget.textContent).toBe('Send review')
+    })
+  })
+
+  describe('_buildReviewContent', () => {
+    test('builds markdown from review quotes with feedback', () => {
+      controller._reviewQuotes = [
+        { id: 1, commentId: 1, text: 'line one', type: 'review', feedback: 'good' },
+      ]
+      controller._activeQuoteId = null
+      controller.textareaTarget.value = ''
+
+      const content = controller._buildReviewContent()
+      expect(content).toContain('> line one')
+      expect(content).toContain('good')
+    })
+
+    test('blank line between quotes prevents blockquote merging', () => {
+      controller._reviewQuotes = [
+        { id: 1, commentId: 1, text: 'first', type: 'review', feedback: '' },
+        { id: 2, commentId: 2, text: 'second', type: 'review', feedback: '' },
+      ]
+      controller._activeQuoteId = null
+      controller.textareaTarget.value = ''
+
+      const content = controller._buildReviewContent()
+      const lines = content.split('\n')
+      const firstIdx = lines.indexOf('> first')
+      const secondIdx = lines.indexOf('> second')
+      expect(secondIdx).toBeGreaterThan(firstIdx + 1)
+      expect(lines[firstIdx + 1]).toBe('')
+    })
+
+    test('summary after --- separator', () => {
+      controller._reviewQuotes = [
+        { id: 1, commentId: 1, text: 'quoted', type: 'review', feedback: 'fix' },
+      ]
+      controller._activeQuoteId = null
+      controller.textareaTarget.value = 'overall good'
+
+      const content = controller._buildReviewContent()
+      expect(content).toContain('---')
+      expect(content).toContain('overall good')
+    })
+
+    test('no summary: no --- separator', () => {
+      controller._reviewQuotes = [
+        { id: 1, commentId: 1, text: 'quoted', type: 'review', feedback: 'fix' },
+      ]
+      controller._activeQuoteId = null
+      controller.textareaTarget.value = ''
+
+      const content = controller._buildReviewContent()
+      expect(content).not.toContain('---')
+    })
+
+    test('question type uses ❓ prefix (safety net)', () => {
+      controller._reviewQuotes = [
+        { id: 1, commentId: 1, text: 'why?', type: 'question', feedback: '' },
+      ]
+      controller._activeQuoteId = null
+      controller.textareaTarget.value = ''
+
+      const content = controller._buildReviewContent()
+      expect(content).toContain('> ❓ why?')
+    })
+  })
+
+  describe('type toggle', () => {
+    test('toggles between review and question', () => {
+      controller.appendReviewQuote(1, 'text')
+      expect(controller._reviewQuotes[0].type).toBe('review')
+
+      container.querySelector('.review-quote-type-toggle').click()
+      expect(controller._reviewQuotes[0].type).toBe('question')
+
+      container.querySelector('.review-quote-type-toggle').click()
+      expect(controller._reviewQuotes[0].type).toBe('review')
+    })
+
+    test('updates button text on toggle', () => {
+      controller.appendReviewQuote(1, 'text')
+      expect(controller.submitTarget.textContent).toBe('+ Add')
+
+      container.querySelector('.review-quote-type-toggle').click()
+      expect(controller.submitTarget.textContent).toBe('Send question')
+    })
+  })
+
+  describe('chip removal', () => {
+    test('resets UI when last chip removed', () => {
+      controller.appendReviewQuote(1, 'text')
+      container.querySelector('.review-quote-chip-remove').click()
+
+      expect(controller._reviewQuotes).toHaveLength(0)
+      expect(controller._activeQuoteId).toBeNull()
+      expect(controller.textareaTarget.placeholder).toBe('')
+      expect(container.querySelector('.review-quotes-container').style.display).toBe('none')
+    })
+
+    test('preserves other quotes', () => {
+      controller.appendReviewQuote(1, 'first')
+      controller._commitActiveQuote()
+      controller.appendReviewQuote(2, 'second')
+      controller._commitActiveQuote()
+
+      container.querySelectorAll('.review-quote-chip-remove')[0].click()
+
+      expect(controller._reviewQuotes).toHaveLength(1)
+      expect(controller._reviewQuotes[0].text).toBe('second')
+    })
+  })
+
+  describe('cancelQuote', () => {
+    test('clears all review state', () => {
+      controller.appendReviewQuote(1, 'text')
+      controller.cancelQuote()
+
+      expect(controller._reviewQuotes).toHaveLength(0)
+      expect(controller._activeQuoteId).toBeNull()
+      expect(controller.textareaTarget.placeholder).toBe('')
+    })
+  })
+
+  describe('chip click - feedback editing', () => {
+    test('clicking committed chip loads its feedback', () => {
+      controller.appendReviewQuote(1, 'first')
+      controller.textareaTarget.value = 'feedback1'
+      controller._commitActiveQuote()
+      controller.appendReviewQuote(2, 'second')
+      controller._commitActiveQuote()
+
+      container.querySelectorAll('.review-quote-chip-text')[0].click()
+
+      expect(controller._activeQuoteId).toBe(controller._reviewQuotes[0].id)
+      expect(controller.textareaTarget.value).toBe('feedback1')
+    })
+
+    test('switching chips saves current feedback', () => {
+      controller.appendReviewQuote(1, 'first')
+      controller.textareaTarget.value = 'fb1'
+      controller._commitActiveQuote()
+      controller.appendReviewQuote(2, 'second')
+      controller.textareaTarget.value = 'fb2'
+      controller._commitActiveQuote()
+
+      // Click first chip
+      container.querySelectorAll('.review-quote-chip-text')[0].click()
+      // Type new feedback
+      controller.textareaTarget.value = 'fb1-updated'
+      // Click second chip
+      container.querySelectorAll('.review-quote-chip-text')[1].click()
+
+      expect(controller._reviewQuotes[0].feedback).toBe('fb1-updated')
+      expect(controller.textareaTarget.value).toBe('fb2')
+    })
+  })
+})

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/review_quotes_store.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/review_quotes_store.test.js
@@ -1,0 +1,111 @@
+import ReviewQuotesStore from '../review_quotes_store'
+
+describe('ReviewQuotesStore', () => {
+  let store
+
+  beforeEach(() => {
+    store = new ReviewQuotesStore()
+  })
+
+  describe('add / remove', () => {
+    test('adds a quote and sets it active', () => {
+      const q = store.add(1, 'hello world')
+      expect(store.count).toBe(1)
+      expect(store.activeId).toBe(q.id)
+      expect(q.type).toBe('review')
+      expect(q.feedback).toBe('')
+    })
+
+    test('removes a quote', () => {
+      const q = store.add(1, 'text')
+      store.remove(q.id)
+      expect(store.isEmpty).toBe(true)
+      expect(store.activeId).toBeNull()
+    })
+  })
+
+  describe('feedback', () => {
+    test('saves feedback for active quote', () => {
+      const q = store.add(1, 'text')
+      store.saveActiveFeedback('my feedback')
+      expect(q.feedback).toBe('my feedback')
+    })
+
+    test('commit deactivates', () => {
+      store.add(1, 'text')
+      store.commitActive('feedback')
+      expect(store.hasActive).toBe(false)
+    })
+  })
+
+  describe('toggleType', () => {
+    test('toggles between review and question', () => {
+      const q = store.add(1, 'text')
+      store.toggleType(q.id)
+      expect(q.type).toBe('question')
+      store.toggleType(q.id)
+      expect(q.type).toBe('review')
+    })
+  })
+
+  describe('buttonState', () => {
+    test('normal when empty', () => {
+      expect(store.buttonState).toBe('normal')
+    })
+
+    test('add when active review', () => {
+      store.add(1, 'text')
+      expect(store.buttonState).toBe('add')
+    })
+
+    test('send-question when active question', () => {
+      const q = store.add(1, 'text')
+      store.toggleType(q.id)
+      expect(store.buttonState).toBe('send-question')
+    })
+
+    test('send-review when no active', () => {
+      store.add(1, 'text')
+      store.commitActive('')
+      expect(store.buttonState).toBe('send-review')
+    })
+  })
+
+  describe('buildContent', () => {
+    test('builds markdown with quotes and summary', () => {
+      const q1 = store.add(1, 'quote one')
+      store.setFeedback(q1.id, 'feedback one')
+      store.commitActive('')
+      store.add(2, 'quote two')
+      store.commitActive('feedback two')
+
+      const md = store.buildContent('summary text')
+      expect(md).toContain('> quote one')
+      expect(md).toContain('feedback one')
+      expect(md).toContain('> quote two')
+      expect(md).toContain('feedback two')
+      expect(md).toContain('---')
+      expect(md).toContain('summary text')
+    })
+
+    test('question prefix', () => {
+      const q = store.add(1, 'why?')
+      store.toggleType(q.id)
+      const md = store.buildContent('')
+      expect(md).toContain('> ❓ why?')
+    })
+  })
+
+  describe('backup / restore', () => {
+    test('restores quotes after backup', () => {
+      store.add(1, 'text')
+      store.backup('saved textarea')
+      store.clear()
+      expect(store.isEmpty).toBe(true)
+
+      const restored = store.restore()
+      expect(restored).toBe('saved textarea')
+      expect(store.count).toBe(1)
+    })
+  })
+})

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -227,6 +227,7 @@ export default class extends Controller {
     if (hasQuotes) {
       store.backup(this.textareaTarget.value)
       this.textareaTarget.value = store.buildContent(this.textareaTarget.value)
+      this._pendingReviewType = 'review'
     }
 
     const wasPrivate = this.privateCheckboxTarget?.checked ?? false
@@ -234,6 +235,10 @@ export default class extends Controller {
     const formData = new FormData(this.formTarget)
     if (this.currentTopicId) {
       formData.append('comment[topic_id]', this.currentTopicId)
+    }
+    if (this._pendingReviewType) {
+      formData.append('comment[review_type]', this._pendingReviewType)
+      this._pendingReviewType = null
     }
 
     let url = `/creatives/${this.creativeId}/comments`
@@ -637,10 +642,14 @@ export default class extends Controller {
     this._renderReviewQuoteChips()
     this._updateSubmitButton()
 
-    // Send as a standalone comment (no quoted_comment_id — treated as normal chat)
+    // Send as a question comment with quoted_comment_id preserved + review_type=question
     this.sending = true
     const formData = new FormData()
     formData.append('comment[content]', content)
+    formData.append('comment[review_type]', 'question')
+    if (quote.commentId) {
+      formData.append('comment[quoted_comment_id]', quote.commentId)
+    }
     const isPrivate = this.privateCheckboxTarget?.checked ?? false
     if (isPrivate) formData.append('comment[private]', '1')
     if (this.currentTopicId) {

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -202,8 +202,15 @@ export default class extends Controller {
   handleSend(event) {
     event.preventDefault()
 
-    // If active quote exists, commit its feedback instead of sending
+    // If active quote exists, handle based on type
     if (this._activeQuoteId && this._reviewQuotes.length > 0) {
+      const activeQuote = this._reviewQuotes.find(q => q.id === this._activeQuoteId)
+      if (activeQuote && activeQuote.type === 'question') {
+        // Question type: save feedback then send immediately as standalone comment
+        this._saveActiveQuoteFeedback()
+        this._sendQuestionQuote(activeQuote)
+        return
+      }
       this._commitActiveQuote()
       return
     }
@@ -696,7 +703,14 @@ export default class extends Controller {
       })
       .then((html) => {
         this.renderCommentHtml(html)
-        this.scrollToBottom(true)
+        const listCtrl = this.application.getControllerForElementAndIdentifier(
+          document.querySelector('[data-controller~="comments--list"]'), 'comments--list'
+        )
+        if (listCtrl) {
+          listCtrl.scrollToBottom()
+          listCtrl.updateStickiness()
+          listCtrl.markCommentsRead()
+        }
       })
       .catch((error) => {
         alert(error?.message || 'Failed to send question')
@@ -737,16 +751,9 @@ export default class extends Controller {
         : this._getI18nText('reviewTypeReviewLabel', 'Review')
       typeToggle.addEventListener('click', (e) => {
         e.stopPropagation()
-        if (quote.type === 'review') {
-          quote.type = 'question'
-          // Question type: send immediately with current feedback
-          this._saveActiveQuoteFeedback()
-          this._sendQuestionQuote(quote)
-        } else {
-          quote.type = 'review'
-          this._renderReviewQuoteChips()
-          this._updateSubmitButton()
-        }
+        quote.type = quote.type === 'review' ? 'question' : 'review'
+        this._renderReviewQuoteChips()
+        this._updateSubmitButton()
       })
 
       // Quote text
@@ -835,8 +842,14 @@ export default class extends Controller {
 
     this.submitTarget.classList.add('review-submit-btn')
     if (this._activeQuoteId) {
-      // Active chip awaiting feedback → button = "+ Add quote"
-      this.submitTarget.textContent = this._getI18nText('reviewAddQuote', '+ Add')
+      const activeQuote = this._reviewQuotes.find(q => q.id === this._activeQuoteId)
+      if (activeQuote && activeQuote.type === 'question') {
+        // Question type → button = "Send question"
+        this.submitTarget.textContent = this._getI18nText('reviewSendQuestion', 'Send question')
+      } else {
+        // Review type → button = "+ Add quote"
+        this.submitTarget.textContent = this._getI18nText('reviewAddQuote', '+ Add')
+      }
     } else {
       // All chips done → button = "Send review"
       this.submitTarget.textContent = this._getI18nText('reviewSend', 'Send review')

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -678,13 +678,10 @@ export default class extends Controller {
     this._renderReviewQuoteChips()
     this._updateSubmitButton()
 
-    // Send as a standalone comment
+    // Send as a standalone comment (no quoted_comment_id — question is treated as normal chat)
     this.sending = true
     const formData = new FormData()
     formData.append('comment[content]', content)
-    if (quote.commentId) {
-      formData.append('comment[quoted_comment_id]', quote.commentId)
-    }
     if (this.currentTopicId) {
       formData.append('comment[topic_id]', this.currentTopicId)
     }

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -1,6 +1,7 @@
 import { Controller } from '@hotwired/stimulus'
 import { renderMarkdownInContainer } from '../../lib/utils/markdown'
 import { wrapHtmlInCodeBlocks } from '../../lib/html_code_block_wrapper'
+import ReviewQuotesStore from './review_quotes_store'
 
 export default class extends Controller {
   static targets = [
@@ -26,8 +27,7 @@ export default class extends Controller {
     this.creativeId = null
     this.editingId = null
     this.sending = false
-    this._reviewQuotes = []
-    this._activeQuoteId = null // currently active chip awaiting feedback
+    this._reviewStore = new ReviewQuotesStore()
     this.cachedImageFiles = null
 
     this.handleSubmit = this.handleSubmit.bind(this)
@@ -203,11 +203,11 @@ export default class extends Controller {
     event.preventDefault()
 
     // If active quote exists, handle based on type
-    if (this._activeQuoteId && this._reviewQuotes.length > 0) {
-      const activeQuote = this._reviewQuotes.find(q => q.id === this._activeQuoteId)
+    const store = this._reviewStore
+    if (store.hasActive && !store.isEmpty) {
+      const activeQuote = store.activeQuote
       if (activeQuote && activeQuote.type === 'question') {
-        // Question type: save feedback then send immediately as standalone comment
-        this._saveActiveQuoteFeedback()
+        store.saveActiveFeedback(this.textareaTarget.value)
         this._sendQuestionQuote(activeQuote)
         return
       }
@@ -216,7 +216,7 @@ export default class extends Controller {
     }
 
     const hasText = this.textareaTarget.value.trim().length > 0
-    const hasQuotes = this._reviewQuotes.length > 0
+    const hasQuotes = !store.isEmpty
     const hasImages = this.currentImageFiles().length > 0
     if (this.sending || (!hasText && !hasQuotes && !hasImages) || !this.creativeId) return
     this.sending = true
@@ -225,9 +225,8 @@ export default class extends Controller {
 
     // Build final content from review quotes + user text
     if (hasQuotes) {
-      this._savedReviewQuotes = JSON.parse(JSON.stringify(this._reviewQuotes))
-      this._savedTextareaValue = this.textareaTarget.value
-      this.textareaTarget.value = this._buildReviewContent()
+      store.backup(this.textareaTarget.value)
+      this.textareaTarget.value = store.buildContent(this.textareaTarget.value)
     }
 
     const wasPrivate = this.privateCheckboxTarget?.checked ?? false
@@ -297,11 +296,9 @@ export default class extends Controller {
       })
       .catch((error) => {
         // Restore review quotes state on failure so user doesn't lose work
-        if (this._savedReviewQuotes) {
-          this._reviewQuotes = this._savedReviewQuotes
-          this.textareaTarget.value = this._savedTextareaValue || ''
-          this._savedReviewQuotes = null
-          this._savedTextareaValue = null
+        if (this._reviewStore.hasBackup()) {
+          const restoredText = this._reviewStore.restore()
+          this.textareaTarget.value = restoredText || ''
           this._renderReviewQuoteChips()
           this._updateSubmitButton()
         }
@@ -593,50 +590,28 @@ export default class extends Controller {
   }
 
   // Append a review quote as a visual chip above the textarea.
-  // Multiple reviews accumulate as chips; textarea stays clean for user feedback.
   appendReviewQuote(commentId, selectedText) {
     if (!selectedText) return
 
-    // If there's an active quote awaiting feedback, save current textarea as its feedback first
-    this._saveActiveQuoteFeedback()
+    const store = this._reviewStore
+    store.saveActiveFeedback(this.textareaTarget.value)
 
-    // Set quoted_comment_id for the review target (last one wins for single-quote compat)
     if (commentId) {
       this.quotedCommentIdTarget.value = commentId
     }
 
-    // Add to internal quotes array
-    const quote = {
-      commentId,
-      text: selectedText,
-      id: Date.now(),
-      type: 'review', // 'review' | 'question'
-      feedback: '',
-    }
-    this._reviewQuotes.push(quote)
-    this._activeQuoteId = quote.id
+    store.add(commentId, selectedText)
     this._renderReviewQuoteChips()
     this._updateSubmitButton()
 
-    // Clear textarea for feedback input
     this.textareaTarget.value = ''
     this.textareaTarget.placeholder = this._getI18nText('reviewFeedbackPlaceholder', 'Write feedback for this quote...')
     this.focusTextarea()
   }
 
-  // Save textarea content as feedback for the currently active quote
-  _saveActiveQuoteFeedback() {
-    if (!this._activeQuoteId) return
-    const quote = this._reviewQuotes.find(q => q.id === this._activeQuoteId)
-    if (quote) {
-      quote.feedback = this.textareaTarget.value.trim()
-    }
-  }
-
-  // Commit the active quote's feedback and deactivate it
   _commitActiveQuote() {
-    this._saveActiveQuoteFeedback()
-    this._activeQuoteId = null
+    const store = this._reviewStore
+    store.commitActive(this.textareaTarget.value)
     this.textareaTarget.value = ''
     this.textareaTarget.placeholder = this._getI18nText('reviewSummaryPlaceholder', 'Overall comment (optional)...')
     this._renderReviewQuoteChips()
@@ -645,40 +620,24 @@ export default class extends Controller {
   }
 
   // Send a single question quote immediately as a standalone comment.
-  // Remaining review quotes are preserved.
   _sendQuestionQuote(quote) {
     if (this.sending || !this.creativeId) return
 
-    // Build question content: quoted text + feedback as context
-    const prefix = '> ❓ '
-    const quoted = quote.text.split('\n').map((line, i) => {
-      return i === 0 ? `${prefix}${line}` : `> ${line}`
-    }).join('\n')
-    const parts = [quoted]
-    if (quote.feedback) {
-      parts.push('')
-      parts.push(quote.feedback)
-    }
-    const content = parts.join('\n')
+    const store = this._reviewStore
+    const content = store.buildQuestionContent(quote)
 
-    // Remove this quote from the list
-    const idx = this._reviewQuotes.findIndex(q => q.id === quote.id)
-    if (idx !== -1) this._reviewQuotes.splice(idx, 1)
-    if (this._activeQuoteId === quote.id) {
-      this._activeQuoteId = null
-      this.textareaTarget.value = ''
-    }
+    store.remove(quote.id)
+    this.textareaTarget.value = ''
 
-    // Update UI immediately
-    if (this._reviewQuotes.length === 0) {
+    if (store.isEmpty) {
       this.textareaTarget.placeholder = ''
-    } else if (!this._activeQuoteId) {
+    } else if (!store.hasActive) {
       this.textareaTarget.placeholder = this._getI18nText('reviewSummaryPlaceholder', 'Overall comment (optional)...')
     }
     this._renderReviewQuoteChips()
     this._updateSubmitButton()
 
-    // Send as a standalone comment (no quoted_comment_id — question is treated as normal chat)
+    // Send as a standalone comment (no quoted_comment_id — treated as normal chat)
     this.sending = true
     const formData = new FormData()
     formData.append('comment[content]', content)
@@ -723,18 +682,19 @@ export default class extends Controller {
 
   _renderReviewQuoteChips() {
     const container = this.reviewQuotesContainerTarget
+    const store = this._reviewStore
     container.innerHTML = ''
 
-    if (this._reviewQuotes.length === 0) {
+    if (store.isEmpty) {
       container.style.display = 'none'
       return
     }
 
     container.style.display = ''
-    this._reviewQuotes.forEach((quote) => {
+    store.quotes.forEach((quote) => {
       const chip = document.createElement('div')
       chip.className = 'review-quote-chip'
-      if (quote.id === this._activeQuoteId) {
+      if (quote.id === store.activeId) {
         chip.classList.add('review-quote-chip--active')
       }
 
@@ -750,7 +710,7 @@ export default class extends Controller {
         : this._getI18nText('reviewTypeReviewLabel', 'Review')
       typeToggle.addEventListener('click', (e) => {
         e.stopPropagation()
-        quote.type = quote.type === 'review' ? 'question' : 'review'
+        store.toggleType(quote.id)
         this._renderReviewQuoteChips()
         this._updateSubmitButton()
       })
@@ -766,8 +726,7 @@ export default class extends Controller {
 
       // Click chip to edit its feedback
       textSpan.addEventListener('click', () => {
-        if (quote.id === this._activeQuoteId) {
-          // Already active — scroll to original comment
+        if (quote.id === store.activeId) {
           const commentEl = document.querySelector(`[data-comment-id="${quote.commentId}"]`)
           if (commentEl) {
             commentEl.scrollIntoView({ behavior: 'smooth', block: 'center' })
@@ -776,9 +735,8 @@ export default class extends Controller {
           }
           return
         }
-        // Switch active chip
-        this._saveActiveQuoteFeedback()
-        this._activeQuoteId = quote.id
+        store.saveActiveFeedback(this.textareaTarget.value)
+        store.activate(quote.id)
         this.textareaTarget.value = quote.feedback || ''
         this.textareaTarget.placeholder = this._getI18nText('reviewFeedbackPlaceholder', 'Write feedback for this quote...')
         this._renderReviewQuoteChips()
@@ -789,7 +747,7 @@ export default class extends Controller {
       // Feedback preview (shown when not active and has feedback)
       const feedbackSpan = document.createElement('span')
       feedbackSpan.className = 'review-quote-chip-feedback'
-      if (quote.feedback && quote.id !== this._activeQuoteId) {
+      if (quote.feedback && quote.id !== store.activeId) {
         const fbPreview = quote.feedback.length > 40
           ? quote.feedback.substring(0, 40) + '…'
           : quote.feedback
@@ -804,16 +762,12 @@ export default class extends Controller {
       removeBtn.title = 'Remove'
       removeBtn.addEventListener('click', (e) => {
         e.stopPropagation()
-        const idx = this._reviewQuotes.findIndex(q => q.id === quote.id)
-        if (idx !== -1) this._reviewQuotes.splice(idx, 1)
-        if (this._activeQuoteId === quote.id) {
-          this._activeQuoteId = null
-          this.textareaTarget.value = ''
-        }
-        // Reset placeholder when all chips removed
-        if (this._reviewQuotes.length === 0) {
+        const wasActive = quote.id === store.activeId
+        store.remove(quote.id)
+        if (wasActive) this.textareaTarget.value = ''
+        if (store.isEmpty) {
           this.textareaTarget.placeholder = ''
-        } else if (!this._activeQuoteId) {
+        } else if (!store.hasActive) {
           this.textareaTarget.placeholder = this._getI18nText('reviewSummaryPlaceholder', 'Overall comment (optional)...')
         }
         this._renderReviewQuoteChips()
@@ -822,7 +776,7 @@ export default class extends Controller {
 
       chip.appendChild(typeToggle)
       chip.appendChild(textSpan)
-      if (quote.feedback && quote.id !== this._activeQuoteId) {
+      if (quote.feedback && quote.id !== store.activeId) {
         chip.appendChild(feedbackSpan)
       }
       chip.appendChild(removeBtn)
@@ -830,64 +784,25 @@ export default class extends Controller {
     })
   }
 
-  // Update submit button label based on review state
   _updateSubmitButton() {
-    if (this._reviewQuotes.length === 0) {
-      // Normal mode — restore default send icon
+    const state = this._reviewStore.buttonState
+    if (state === 'normal') {
       this.submitTarget.innerHTML = this.defaultSubmitHTML
       this.submitTarget.classList.remove('review-submit-btn')
       return
     }
 
     this.submitTarget.classList.add('review-submit-btn')
-    if (this._activeQuoteId) {
-      const activeQuote = this._reviewQuotes.find(q => q.id === this._activeQuoteId)
-      if (activeQuote && activeQuote.type === 'question') {
-        // Question type → button = "Send question"
-        this.submitTarget.textContent = this._getI18nText('reviewSendQuestion', 'Send question')
-      } else {
-        // Review type → button = "+ Add quote"
-        this.submitTarget.textContent = this._getI18nText('reviewAddQuote', '+ Add')
-      }
-    } else {
-      // All chips done → button = "Send review"
-      this.submitTarget.textContent = this._getI18nText('reviewSend', 'Send review')
+    const labels = {
+      'add': this._getI18nText('reviewAddQuote', '+ Add'),
+      'send-review': this._getI18nText('reviewSend', 'Send review'),
+      'send-question': this._getI18nText('reviewSendQuestion', 'Send question'),
     }
+    this.submitTarget.textContent = labels[state]
   }
 
   _getI18nText(key, fallback) {
     return this.element.dataset[key] || fallback
-  }
-
-  // Build markdown content from review quotes + user text for submission
-  _buildReviewContent() {
-    if (this._reviewQuotes.length === 0) return this.textareaTarget.value
-
-    const userText = this.textareaTarget.value.trim()
-    const parts = []
-
-    this._reviewQuotes.forEach((q, i) => {
-      if (i > 0) parts.push('') // Blank line between quotes to prevent blockquote merging
-      // Safety net: questions are normally sent immediately via _sendQuestionQuote,
-      // but handle them here in case of future batch-question support
-      const prefix = q.type === 'question' ? '> ❓ ' : '> '
-      const quoted = q.text.split('\n').map((line, j) => {
-        return j === 0 ? `${prefix}${line}` : `> ${line}`
-      }).join('\n')
-      parts.push(quoted)
-      if (q.feedback) {
-        parts.push('')
-        parts.push(q.feedback)
-      }
-    })
-
-    if (userText) {
-      parts.push('')
-      parts.push('---')
-      parts.push(userText)
-    }
-
-    return parts.join('\n')
   }
 
   cancelQuote() {
@@ -895,8 +810,7 @@ export default class extends Controller {
     this.quotedTextTarget.value = ''
     this.quoteIndicatorTarget.style.display = 'none'
     this.quoteIndicatorTextTarget.textContent = ''
-    this._reviewQuotes = []
-    this._activeQuoteId = null
+    this._reviewStore.clear()
     this._renderReviewQuoteChips()
     this._updateSubmitButton()
     this.textareaTarget.placeholder = ''

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -637,6 +637,77 @@ export default class extends Controller {
     this.focusTextarea()
   }
 
+  // Send a single question quote immediately as a standalone comment.
+  // Remaining review quotes are preserved.
+  _sendQuestionQuote(quote) {
+    if (this.sending || !this.creativeId) return
+
+    // Build question content: quoted text + feedback as context
+    const prefix = '> ❓ '
+    const quoted = quote.text.split('\n').map((line, i) => {
+      return i === 0 ? `${prefix}${line}` : `> ${line}`
+    }).join('\n')
+    const parts = [quoted]
+    if (quote.feedback) {
+      parts.push('')
+      parts.push(quote.feedback)
+    }
+    const content = parts.join('\n')
+
+    // Remove this quote from the list
+    const idx = this._reviewQuotes.findIndex(q => q.id === quote.id)
+    if (idx !== -1) this._reviewQuotes.splice(idx, 1)
+    if (this._activeQuoteId === quote.id) {
+      this._activeQuoteId = null
+      this.textareaTarget.value = ''
+    }
+
+    // Update UI immediately
+    if (this._reviewQuotes.length === 0) {
+      this.textareaTarget.placeholder = ''
+    } else if (!this._activeQuoteId) {
+      this.textareaTarget.placeholder = this._getI18nText('reviewSummaryPlaceholder', 'Overall comment (optional)...')
+    }
+    this._renderReviewQuoteChips()
+    this._updateSubmitButton()
+
+    // Send as a standalone comment
+    this.sending = true
+    const formData = new FormData()
+    formData.append('comment[content]', content)
+    if (quote.commentId) {
+      formData.append('comment[quoted_comment_id]', quote.commentId)
+    }
+    if (this.currentTopicId) {
+      formData.append('comment[topic_id]', this.currentTopicId)
+    }
+
+    const url = `/creatives/${this.creativeId}/comments`
+    fetch(url, {
+      method: 'POST',
+      headers: { 'X-CSRF-Token': document.querySelector('meta[name=csrf-token]').content },
+      body: formData,
+    })
+      .then((response) => {
+        if (response.ok) return response.text()
+        return response.json().then((json) => {
+          throw new Error(json.errors?.join(', ') || 'Unable to save comment')
+        })
+      })
+      .then((html) => {
+        this.renderCommentHtml(html)
+        this.scrollToBottom(true)
+      })
+      .catch((error) => {
+        alert(error?.message || 'Failed to send question')
+      })
+      .finally(() => {
+        this.sending = false
+      })
+
+    this.focusTextarea()
+  }
+
   _renderReviewQuoteChips() {
     const container = this.reviewQuotesContainerTarget
     container.innerHTML = ''
@@ -666,8 +737,16 @@ export default class extends Controller {
         : this._getI18nText('reviewTypeReviewLabel', 'Review')
       typeToggle.addEventListener('click', (e) => {
         e.stopPropagation()
-        quote.type = quote.type === 'review' ? 'question' : 'review'
-        this._renderReviewQuoteChips()
+        if (quote.type === 'review') {
+          quote.type = 'question'
+          // Question type: send immediately with current feedback
+          this._saveActiveQuoteFeedback()
+          this._sendQuestionQuote(quote)
+        } else {
+          quote.type = 'review'
+          this._renderReviewQuoteChips()
+          this._updateSubmitButton()
+        }
       })
 
       // Quote text

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -682,6 +682,8 @@ export default class extends Controller {
     this.sending = true
     const formData = new FormData()
     formData.append('comment[content]', content)
+    const isPrivate = this.privateCheckboxTarget?.checked ?? false
+    if (isPrivate) formData.append('comment[private]', '1')
     if (this.currentTopicId) {
       formData.append('comment[topic_id]', this.currentTopicId)
     }
@@ -866,6 +868,8 @@ export default class extends Controller {
 
     this._reviewQuotes.forEach((q, i) => {
       if (i > 0) parts.push('') // Blank line between quotes to prevent blockquote merging
+      // Safety net: questions are normally sent immediately via _sendQuestionQuote,
+      // but handle them here in case of future batch-question support
       const prefix = q.type === 'question' ? '> ❓ ' : '> '
       const quoted = q.text.split('\n').map((line, j) => {
         return j === 0 ? `${prefix}${line}` : `> ${line}`

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -27,6 +27,7 @@ export default class extends Controller {
     this.editingId = null
     this.sending = false
     this._reviewQuotes = []
+    this._activeQuoteId = null // currently active chip awaiting feedback
     this.cachedImageFiles = null
 
     this.handleSubmit = this.handleSubmit.bind(this)
@@ -171,10 +172,12 @@ export default class extends Controller {
     this.editingId = null
     this.submitTarget.innerHTML = this.defaultSubmitHTML
     this.submitTarget.disabled = false
+    this.submitTarget.classList.remove('review-submit-btn')
     if (this.cancelTarget) this.cancelTarget.style.display = 'none'
     this.presenceController?.clearManualTypingMessage()
     this.clearImageAttachments()
     this.cancelQuote()
+    this.textareaTarget.placeholder = ''
     // Reset textarea height after clearing content
     this.textareaTarget.style.height = 'auto'
   }
@@ -198,6 +201,13 @@ export default class extends Controller {
 
   handleSend(event) {
     event.preventDefault()
+
+    // If active quote exists, commit its feedback instead of sending
+    if (this._activeQuoteId && this._reviewQuotes.length > 0) {
+      this._commitActiveQuote()
+      return
+    }
+
     const hasText = this.textareaTarget.value.trim().length > 0
     const hasQuotes = this._reviewQuotes.length > 0
     const hasImages = this.currentImageFiles().length > 0
@@ -568,15 +578,51 @@ export default class extends Controller {
   // Multiple reviews accumulate as chips; textarea stays clean for user feedback.
   appendReviewQuote(commentId, selectedText) {
     if (!selectedText) return
+
+    // If there's an active quote awaiting feedback, save current textarea as its feedback first
+    this._saveActiveQuoteFeedback()
+
     // Set quoted_comment_id for the review target (last one wins for single-quote compat)
     if (commentId) {
       this.quotedCommentIdTarget.value = commentId
     }
 
     // Add to internal quotes array
-    const quote = { commentId, text: selectedText, id: Date.now() }
+    const quote = {
+      commentId,
+      text: selectedText,
+      id: Date.now(),
+      type: 'review', // 'review' | 'question'
+      feedback: '',
+    }
     this._reviewQuotes.push(quote)
+    this._activeQuoteId = quote.id
     this._renderReviewQuoteChips()
+    this._updateSubmitButton()
+
+    // Clear textarea for feedback input
+    this.textareaTarget.value = ''
+    this.textareaTarget.placeholder = this._getI18nText('reviewFeedbackPlaceholder', 'Write feedback for this quote...')
+    this.focusTextarea()
+  }
+
+  // Save textarea content as feedback for the currently active quote
+  _saveActiveQuoteFeedback() {
+    if (!this._activeQuoteId) return
+    const quote = this._reviewQuotes.find(q => q.id === this._activeQuoteId)
+    if (quote) {
+      quote.feedback = this.textareaTarget.value.trim()
+    }
+  }
+
+  // Commit the active quote's feedback and deactivate it
+  _commitActiveQuote() {
+    this._saveActiveQuoteFeedback()
+    this._activeQuoteId = null
+    this.textareaTarget.value = ''
+    this.textareaTarget.placeholder = this._getI18nText('reviewSummaryPlaceholder', 'Overall comment (optional)...')
+    this._renderReviewQuoteChips()
+    this._updateSubmitButton()
     this.focusTextarea()
   }
 
@@ -590,11 +636,30 @@ export default class extends Controller {
     }
 
     container.style.display = ''
-    this._reviewQuotes.forEach((quote, index) => {
+    this._reviewQuotes.forEach((quote) => {
       const chip = document.createElement('div')
       chip.className = 'review-quote-chip'
-      chip.dataset.index = index
+      if (quote.id === this._activeQuoteId) {
+        chip.classList.add('review-quote-chip--active')
+      }
 
+      // Type toggle (review / question)
+      const typeToggle = document.createElement('button')
+      typeToggle.type = 'button'
+      typeToggle.className = `review-quote-type-toggle review-quote-type-toggle--${quote.type}`
+      typeToggle.textContent = quote.type === 'question'
+        ? this._getI18nText('reviewTypeQuestion', '❓')
+        : this._getI18nText('reviewTypeReview', '💬')
+      typeToggle.title = quote.type === 'question'
+        ? this._getI18nText('reviewTypeQuestionLabel', 'Question')
+        : this._getI18nText('reviewTypeReviewLabel', 'Review')
+      typeToggle.addEventListener('click', (e) => {
+        e.stopPropagation()
+        quote.type = quote.type === 'review' ? 'question' : 'review'
+        this._renderReviewQuoteChips()
+      })
+
+      // Quote text
       const textSpan = document.createElement('span')
       textSpan.className = 'review-quote-chip-text'
       const preview = quote.text.length > 60
@@ -603,30 +668,88 @@ export default class extends Controller {
       textSpan.textContent = preview
       textSpan.title = quote.text
 
-      // Click to scroll to original comment
+      // Click chip to edit its feedback
       textSpan.addEventListener('click', () => {
-        const commentEl = document.querySelector(`[data-comment-id="${quote.commentId}"]`)
-        if (commentEl) {
-          commentEl.scrollIntoView({ behavior: 'smooth', block: 'center' })
-          commentEl.classList.add('comment-highlight')
-          setTimeout(() => commentEl.classList.remove('comment-highlight'), 2000)
+        if (quote.id === this._activeQuoteId) {
+          // Already active — scroll to original comment
+          const commentEl = document.querySelector(`[data-comment-id="${quote.commentId}"]`)
+          if (commentEl) {
+            commentEl.scrollIntoView({ behavior: 'smooth', block: 'center' })
+            commentEl.classList.add('comment-highlight')
+            setTimeout(() => commentEl.classList.remove('comment-highlight'), 2000)
+          }
+          return
         }
+        // Switch active chip
+        this._saveActiveQuoteFeedback()
+        this._activeQuoteId = quote.id
+        this.textareaTarget.value = quote.feedback || ''
+        this.textareaTarget.placeholder = this._getI18nText('reviewFeedbackPlaceholder', 'Write feedback for this quote...')
+        this._renderReviewQuoteChips()
+        this._updateSubmitButton()
+        this.focusTextarea()
       })
 
+      // Feedback preview (shown when not active and has feedback)
+      const feedbackSpan = document.createElement('span')
+      feedbackSpan.className = 'review-quote-chip-feedback'
+      if (quote.feedback && quote.id !== this._activeQuoteId) {
+        const fbPreview = quote.feedback.length > 40
+          ? quote.feedback.substring(0, 40) + '…'
+          : quote.feedback
+        feedbackSpan.textContent = `→ ${fbPreview}`
+      }
+
+      // Remove button
       const removeBtn = document.createElement('button')
       removeBtn.type = 'button'
       removeBtn.className = 'review-quote-chip-remove'
       removeBtn.innerHTML = '&times;'
       removeBtn.title = 'Remove'
-      removeBtn.addEventListener('click', () => {
-        this._reviewQuotes.splice(index, 1)
+      removeBtn.addEventListener('click', (e) => {
+        e.stopPropagation()
+        const idx = this._reviewQuotes.findIndex(q => q.id === quote.id)
+        if (idx !== -1) this._reviewQuotes.splice(idx, 1)
+        if (this._activeQuoteId === quote.id) {
+          this._activeQuoteId = null
+          this.textareaTarget.value = ''
+          this.textareaTarget.placeholder = this._getI18nText('reviewSummaryPlaceholder', 'Overall comment (optional)...')
+        }
         this._renderReviewQuoteChips()
+        this._updateSubmitButton()
       })
 
+      chip.appendChild(typeToggle)
       chip.appendChild(textSpan)
+      if (quote.feedback && quote.id !== this._activeQuoteId) {
+        chip.appendChild(feedbackSpan)
+      }
       chip.appendChild(removeBtn)
       container.appendChild(chip)
     })
+  }
+
+  // Update submit button label based on review state
+  _updateSubmitButton() {
+    if (this._reviewQuotes.length === 0) {
+      // Normal mode — restore default send icon
+      this.submitTarget.innerHTML = this.defaultSubmitHTML
+      this.submitTarget.classList.remove('review-submit-btn')
+      return
+    }
+
+    this.submitTarget.classList.add('review-submit-btn')
+    if (this._activeQuoteId) {
+      // Active chip awaiting feedback → button = "+ Add quote"
+      this.submitTarget.textContent = this._getI18nText('reviewAddQuote', '+ Add')
+    } else {
+      // All chips done → button = "Send review"
+      this.submitTarget.textContent = this._getI18nText('reviewSend', 'Send review')
+    }
+  }
+
+  _getI18nText(key, fallback) {
+    return this.element.dataset[key] || fallback
   }
 
   // Build markdown content from review quotes + user text for submission
@@ -634,18 +757,27 @@ export default class extends Controller {
     if (this._reviewQuotes.length === 0) return this.textareaTarget.value
 
     const userText = this.textareaTarget.value.trim()
-    const quoteParts = this._reviewQuotes.map(q => {
-      const quoted = q.text.split('\n').map(line => `> ${line}`).join('\n')
-      return quoted
+    const parts = []
+
+    this._reviewQuotes.forEach(q => {
+      const prefix = q.type === 'question' ? '> ❓ ' : '> '
+      const quoted = q.text.split('\n').map((line, i) => {
+        return i === 0 ? `${prefix}${line}` : `> ${line}`
+      }).join('\n')
+      parts.push(quoted)
+      if (q.feedback) {
+        parts.push('')
+        parts.push(q.feedback)
+      }
     })
 
-    // If single quote + user text: quote then user text
-    // If multiple quotes + user text: all quotes then user text
-    let content = quoteParts.join('\n\n')
     if (userText) {
-      content += '\n\n' + userText
+      parts.push('')
+      parts.push('---')
+      parts.push(userText)
     }
-    return content
+
+    return parts.join('\n')
   }
 
   cancelQuote() {
@@ -654,7 +786,10 @@ export default class extends Controller {
     this.quoteIndicatorTarget.style.display = 'none'
     this.quoteIndicatorTextTarget.textContent = ''
     this._reviewQuotes = []
+    this._activeQuoteId = null
     this._renderReviewQuoteChips()
+    this._updateSubmitButton()
+    this.textareaTarget.placeholder = ''
   }
 
   renderCommentHtml(html, { replaceExisting = false } = {}) {

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -218,6 +218,8 @@ export default class extends Controller {
 
     // Build final content from review quotes + user text
     if (hasQuotes) {
+      this._savedReviewQuotes = JSON.parse(JSON.stringify(this._reviewQuotes))
+      this._savedTextareaValue = this.textareaTarget.value
       this.textareaTarget.value = this._buildReviewContent()
     }
 
@@ -287,6 +289,15 @@ export default class extends Controller {
         }
       })
       .catch((error) => {
+        // Restore review quotes state on failure so user doesn't lose work
+        if (this._savedReviewQuotes) {
+          this._reviewQuotes = this._savedReviewQuotes
+          this.textareaTarget.value = this._savedTextareaValue || ''
+          this._savedReviewQuotes = null
+          this._savedTextareaValue = null
+          this._renderReviewQuoteChips()
+          this._updateSubmitButton()
+        }
         alert(error?.message || 'Failed to submit comment')
       })
       .finally(() => {
@@ -713,6 +724,11 @@ export default class extends Controller {
         if (this._activeQuoteId === quote.id) {
           this._activeQuoteId = null
           this.textareaTarget.value = ''
+        }
+        // Reset placeholder when all chips removed
+        if (this._reviewQuotes.length === 0) {
+          this.textareaTarget.placeholder = ''
+        } else if (!this._activeQuoteId) {
           this.textareaTarget.placeholder = this._getI18nText('reviewSummaryPlaceholder', 'Overall comment (optional)...')
         }
         this._renderReviewQuoteChips()
@@ -759,10 +775,11 @@ export default class extends Controller {
     const userText = this.textareaTarget.value.trim()
     const parts = []
 
-    this._reviewQuotes.forEach(q => {
+    this._reviewQuotes.forEach((q, i) => {
+      if (i > 0) parts.push('') // Blank line between quotes to prevent blockquote merging
       const prefix = q.type === 'question' ? '> ❓ ' : '> '
-      const quoted = q.text.split('\n').map((line, i) => {
-        return i === 0 ? `${prefix}${line}` : `> ${line}`
+      const quoted = q.text.split('\n').map((line, j) => {
+        return j === 0 ? `${prefix}${line}` : `> ${line}`
       }).join('\n')
       parts.push(quoted)
       if (q.feedback) {

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -19,12 +19,14 @@ export default class extends Controller {
     'quotedText',
     'quoteIndicator',
     'quoteIndicatorText',
+    'reviewQuotesContainer',
   ]
 
   connect() {
     this.creativeId = null
     this.editingId = null
     this.sending = false
+    this._reviewQuotes = []
     this.cachedImageFiles = null
 
     this.handleSubmit = this.handleSubmit.bind(this)
@@ -197,11 +199,17 @@ export default class extends Controller {
   handleSend(event) {
     event.preventDefault()
     const hasText = this.textareaTarget.value.trim().length > 0
+    const hasQuotes = this._reviewQuotes.length > 0
     const hasImages = this.currentImageFiles().length > 0
-    if (this.sending || (!hasText && !hasImages) || !this.creativeId) return
+    if (this.sending || (!hasText && !hasQuotes && !hasImages) || !this.creativeId) return
     this.sending = true
     this.setSendingState(true)
     this.presenceController?.stoppedTyping()
+
+    // Build final content from review quotes + user text
+    if (hasQuotes) {
+      this.textareaTarget.value = this._buildReviewContent()
+    }
 
     const wasPrivate = this.privateCheckboxTarget?.checked ?? false
 
@@ -556,28 +564,88 @@ export default class extends Controller {
     this.focusTextarea()
   }
 
-  // Append a review quote to the textarea as markdown blockquote.
-  // Multiple reviews accumulate; user types feedback after each quote.
+  // Append a review quote as a visual chip above the textarea.
+  // Multiple reviews accumulate as chips; textarea stays clean for user feedback.
   appendReviewQuote(commentId, selectedText) {
     if (!selectedText) return
-    // Set quoted_comment_id for the review target
+    // Set quoted_comment_id for the review target (last one wins for single-quote compat)
     if (commentId) {
       this.quotedCommentIdTarget.value = commentId
     }
-    const textarea = this.textareaTarget
-    const current = textarea.value
-    // Build markdown blockquote: prefix each line with >
-    const quoted = selectedText.split('\n').map(line => `> ${line}`).join('\n')
-    // Add blank line separator between reviews for proper markdown rendering
-    const prefix = current.length > 0 ? (current.endsWith('\n\n') ? '' : current.endsWith('\n') ? '\n' : '\n\n') : ''
-    // Double newline after blockquote so markdown renders it as a separate block
-    const newValue = current + prefix + quoted + '\n\n'
-    textarea.value = newValue
-    // Place cursor at the end (user types review feedback here)
-    textarea.selectionStart = textarea.selectionEnd = newValue.length
+
+    // Add to internal quotes array
+    const quote = { commentId, text: selectedText, id: Date.now() }
+    this._reviewQuotes.push(quote)
+    this._renderReviewQuoteChips()
     this.focusTextarea()
-    // Trigger input event so any external auto-resize logic can adjust height
-    textarea.dispatchEvent(new Event('input', { bubbles: true }))
+  }
+
+  _renderReviewQuoteChips() {
+    const container = this.reviewQuotesContainerTarget
+    container.innerHTML = ''
+
+    if (this._reviewQuotes.length === 0) {
+      container.style.display = 'none'
+      return
+    }
+
+    container.style.display = ''
+    this._reviewQuotes.forEach((quote, index) => {
+      const chip = document.createElement('div')
+      chip.className = 'review-quote-chip'
+      chip.dataset.index = index
+
+      const textSpan = document.createElement('span')
+      textSpan.className = 'review-quote-chip-text'
+      const preview = quote.text.length > 60
+        ? quote.text.substring(0, 60) + '…'
+        : quote.text
+      textSpan.textContent = preview
+      textSpan.title = quote.text
+
+      // Click to scroll to original comment
+      textSpan.addEventListener('click', () => {
+        const commentEl = document.querySelector(`[data-comment-id="${quote.commentId}"]`)
+        if (commentEl) {
+          commentEl.scrollIntoView({ behavior: 'smooth', block: 'center' })
+          commentEl.classList.add('comment-highlight')
+          setTimeout(() => commentEl.classList.remove('comment-highlight'), 2000)
+        }
+      })
+
+      const removeBtn = document.createElement('button')
+      removeBtn.type = 'button'
+      removeBtn.className = 'review-quote-chip-remove'
+      removeBtn.innerHTML = '&times;'
+      removeBtn.title = 'Remove'
+      removeBtn.addEventListener('click', () => {
+        this._reviewQuotes.splice(index, 1)
+        this._renderReviewQuoteChips()
+      })
+
+      chip.appendChild(textSpan)
+      chip.appendChild(removeBtn)
+      container.appendChild(chip)
+    })
+  }
+
+  // Build markdown content from review quotes + user text for submission
+  _buildReviewContent() {
+    if (this._reviewQuotes.length === 0) return this.textareaTarget.value
+
+    const userText = this.textareaTarget.value.trim()
+    const quoteParts = this._reviewQuotes.map(q => {
+      const quoted = q.text.split('\n').map(line => `> ${line}`).join('\n')
+      return quoted
+    })
+
+    // If single quote + user text: quote then user text
+    // If multiple quotes + user text: all quotes then user text
+    let content = quoteParts.join('\n\n')
+    if (userText) {
+      content += '\n\n' + userText
+    }
+    return content
   }
 
   cancelQuote() {
@@ -585,6 +653,8 @@ export default class extends Controller {
     this.quotedTextTarget.value = ''
     this.quoteIndicatorTarget.style.display = 'none'
     this.quoteIndicatorTextTarget.textContent = ''
+    this._reviewQuotes = []
+    this._renderReviewQuoteChips()
   }
 
   renderCommentHtml(html, { replaceExisting = false } = {}) {

--- a/engines/collavre/app/javascript/controllers/comments/review_quotes_store.js
+++ b/engines/collavre/app/javascript/controllers/comments/review_quotes_store.js
@@ -1,0 +1,187 @@
+/**
+ * ReviewQuotesStore — Pure state management for review quote chips.
+ *
+ * Responsible for:
+ *   - Adding / removing / updating quotes
+ *   - Tracking the active (editing) quote
+ *   - Building markdown content for submission
+ *   - Backup / restore for send-failure rollback
+ *
+ * Does NOT touch the DOM — the controller handles all rendering.
+ */
+export default class ReviewQuotesStore {
+  constructor() {
+    this._quotes = []
+    this._activeId = null
+    this._backup = null
+  }
+
+  // --- Accessors ---
+
+  get quotes() {
+    return this._quotes
+  }
+
+  get activeId() {
+    return this._activeId
+  }
+
+  set activeId(id) {
+    this._activeId = id
+  }
+
+  get activeQuote() {
+    if (!this._activeId) return null
+    return this._quotes.find(q => q.id === this._activeId) || null
+  }
+
+  get count() {
+    return this._quotes.length
+  }
+
+  get isEmpty() {
+    return this._quotes.length === 0
+  }
+
+  get hasActive() {
+    return this._activeId !== null
+  }
+
+  // --- Mutations ---
+
+  add(commentId, text) {
+    const quote = {
+      id: Date.now(),
+      commentId,
+      text,
+      type: 'review', // 'review' | 'question'
+      feedback: '',
+    }
+    this._quotes.push(quote)
+    this._activeId = quote.id
+    return quote
+  }
+
+  remove(quoteId) {
+    const idx = this._quotes.findIndex(q => q.id === quoteId)
+    if (idx === -1) return null
+    const [removed] = this._quotes.splice(idx, 1)
+    if (this._activeId === quoteId) {
+      this._activeId = null
+    }
+    return removed
+  }
+
+  setFeedback(quoteId, feedback) {
+    const quote = this._quotes.find(q => q.id === quoteId)
+    if (quote) quote.feedback = feedback.trim()
+  }
+
+  saveActiveFeedback(textareaValue) {
+    if (!this._activeId) return
+    const quote = this._quotes.find(q => q.id === this._activeId)
+    if (quote) quote.feedback = textareaValue.trim()
+  }
+
+  commitActive(textareaValue) {
+    this.saveActiveFeedback(textareaValue)
+    this._activeId = null
+  }
+
+  toggleType(quoteId) {
+    const quote = this._quotes.find(q => q.id === quoteId)
+    if (!quote) return null
+    quote.type = quote.type === 'review' ? 'question' : 'review'
+    return quote
+  }
+
+  activate(quoteId) {
+    const quote = this._quotes.find(q => q.id === quoteId)
+    if (!quote) return null
+    this._activeId = quoteId
+    return quote
+  }
+
+  clear() {
+    this._quotes = []
+    this._activeId = null
+    this._backup = null
+  }
+
+  // --- Backup / Restore (for send-failure rollback) ---
+
+  backup(textareaValue) {
+    this._backup = {
+      quotes: JSON.parse(JSON.stringify(this._quotes)),
+      textareaValue,
+    }
+  }
+
+  restore() {
+    if (!this._backup) return null
+    this._quotes = this._backup.quotes
+    const textareaValue = this._backup.textareaValue
+    this._backup = null
+    return textareaValue
+  }
+
+  hasBackup() {
+    return this._backup !== null
+  }
+
+  // --- Markdown Builder ---
+
+  buildContent(summaryText) {
+    if (this._quotes.length === 0) return summaryText
+
+    const parts = []
+
+    this._quotes.forEach((q, i) => {
+      if (i > 0) parts.push('') // Blank line between quotes to prevent blockquote merging
+      const prefix = q.type === 'question' ? '> ❓ ' : '> '
+      const quoted = q.text.split('\n').map((line, j) => {
+        return j === 0 ? `${prefix}${line}` : `> ${line}`
+      }).join('\n')
+      parts.push(quoted)
+      if (q.feedback) {
+        parts.push('')
+        parts.push(q.feedback)
+      }
+    })
+
+    const summary = summaryText.trim()
+    if (summary) {
+      parts.push('')
+      parts.push('---')
+      parts.push(summary)
+    }
+
+    return parts.join('\n')
+  }
+
+  buildQuestionContent(quote) {
+    const prefix = '> ❓ '
+    const quoted = quote.text.split('\n').map((line, i) => {
+      return i === 0 ? `${prefix}${line}` : `> ${line}`
+    }).join('\n')
+    const parts = [quoted]
+    if (quote.feedback) {
+      parts.push('')
+      parts.push(quote.feedback)
+    }
+    return parts.join('\n')
+  }
+
+  // --- Query ---
+
+  /** Button state: 'add' | 'send-review' | 'send-question' | 'normal' */
+  get buttonState() {
+    if (this._quotes.length === 0) return 'normal'
+    if (this._activeId) {
+      const active = this.activeQuote
+      if (active && active.type === 'question') return 'send-question'
+      return 'add'
+    }
+    return 'send-review'
+  }
+}

--- a/engines/collavre/app/models/collavre/comment.rb
+++ b/engines/collavre/app/models/collavre/comment.rb
@@ -40,7 +40,7 @@ module Collavre
     after_destroy_commit :cancel_pending_tasks
 
     def review_message?
-      quoted_comment_id.present? && review_type_review?
+      quoted_comment_id.present? && !review_type_question?
     end
 
     # public for db migration

--- a/engines/collavre/app/models/collavre/comment.rb
+++ b/engines/collavre/app/models/collavre/comment.rb
@@ -15,6 +15,9 @@ module Collavre
     belongs_to :action_executed_by, class_name: Collavre.configuration.user_class_name, optional: true
     belongs_to :topic, class_name: "Collavre::Topic", optional: true
     belongs_to :quoted_comment, class_name: "Collavre::Comment", optional: true
+
+    # review_type: nil = normal chat, 0 = review, 1 = question
+    enum :review_type, { review: 0, question: 1 }, prefix: true
     has_many :activity_logs, class_name: "Collavre::ActivityLog", dependent: :destroy
     has_many :comment_reactions, class_name: "Collavre::CommentReaction", dependent: :destroy
 
@@ -37,7 +40,7 @@ module Collavre
     after_destroy_commit :cancel_pending_tasks
 
     def review_message?
-      quoted_comment_id.present?
+      quoted_comment_id.present? && review_type_review?
     end
 
     # public for db migration

--- a/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
@@ -69,6 +69,7 @@
       <span class="comment-quote-indicator-text" data-comments--form-target="quoteIndicatorText"></span>
       <button type="button" class="comment-quote-cancel" data-action="click->comments--form#cancelQuote" title="<%= t('app.cancel') %>">&times;</button>
     </div>
+    <div class="review-quotes-container" data-comments--form-target="reviewQuotesContainer" style="display:none;"></div>
     <textarea class="shared-input-surface" name="comment[content]" data-comments--form-target="textarea" data-comments--presence-target="textarea" data-comments--mention-menu-target="textarea" rows="2" enterkeyhint="send"></textarea>
     <div class="comment-bottom">
     <input type="file" id="comment-images" name="comment[images][]" accept="image/*" multiple data-comments--form-target="imageInput" style="display:none;" />

--- a/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
@@ -37,6 +37,7 @@
      data-review-summary-placeholder="<%= t('collavre.comments.review_summary_placeholder') %>"
      data-review-add-quote="<%= t('collavre.comments.review_add_quote') %>"
      data-review-send="<%= t('collavre.comments.review_send') %>"
+     data-review-send-question="<%= t('collavre.comments.review_send_question') %>"
      data-review-type-review="💬"
      data-review-type-question="❓"
      data-review-type-review-label="<%= t('collavre.comments.review_type_review') %>"

--- a/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
@@ -32,7 +32,15 @@
      data-hint-drag-topic-text="<%= t('collavre.comments.hint_drag_topic') %>"
      data-hint-move-button-text="<%= t('collavre.comments.hint_move_button') %>"
      data-add-participant-text="<%= t('collavre.comments.add_participant') %>"
-     data-review-button-text="<%= t('collavre.comments.review_button') %>">
+     data-review-button-text="<%= t('collavre.comments.review_button') %>"
+     data-review-feedback-placeholder="<%= t('collavre.comments.review_feedback_placeholder') %>"
+     data-review-summary-placeholder="<%= t('collavre.comments.review_summary_placeholder') %>"
+     data-review-add-quote="<%= t('collavre.comments.review_add_quote') %>"
+     data-review-send="<%= t('collavre.comments.review_send') %>"
+     data-review-type-review="💬"
+     data-review-type-question="❓"
+     data-review-type-review-label="<%= t('collavre.comments.review_type_review') %>"
+     data-review-type-question-label="<%= t('collavre.comments.review_type_question') %>">
   <div class="resize-handle resize-handle-left" data-comments--popup-target="leftHandle"></div>
   <div class="resize-handle resize-handle-right" data-comments--popup-target="rightHandle"></div>
   <div class="comments-popup-header">

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -71,6 +71,7 @@ en:
       review_summary_placeholder: Overall comment (optional)...
       review_add_quote: "+ Add"
       review_send: Send review
+      review_send_question: Send question
       review_type_review: Review
       review_type_question: Question
       replace_button: Replace

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -67,6 +67,12 @@ en:
       move_button: Move
       review_button: Review
       review_select_hint: Please select text to review
+      review_feedback_placeholder: Write feedback for this quote...
+      review_summary_placeholder: Overall comment (optional)...
+      review_add_quote: "+ Add"
+      review_send: Send review
+      review_type_review: Review
+      review_type_question: Question
       replace_button: Replace
       move_no_selection: Select at least one message to move.
       move_error: Unable to move messages.

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -68,6 +68,7 @@ ko:
       review_summary_placeholder: 종합 코멘트 (선택)...
       review_add_quote: "+ 추가"
       review_send: 리뷰 전송
+      review_send_question: 질문 보내기
       review_type_review: 리뷰
       review_type_question: 질문
       replace_button: 바꾸기

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -64,6 +64,12 @@ ko:
       move_button: 이동
       review_button: 리뷰
       review_select_hint: 리뷰할 텍스트를 선택해 주세요
+      review_feedback_placeholder: 이 인용에 대한 피드백을 입력하세요...
+      review_summary_placeholder: 종합 코멘트 (선택)...
+      review_add_quote: "+ 추가"
+      review_send: 리뷰 전송
+      review_type_review: 리뷰
+      review_type_question: 질문
       replace_button: 바꾸기
       move_no_selection: 이동할 메시지를 선택해주세요.
       move_error: 메시지를 이동할 수 없습니다.

--- a/engines/collavre/db/migrate/20260223173533_add_review_type_to_comments.rb
+++ b/engines/collavre/db/migrate/20260223173533_add_review_type_to_comments.rb
@@ -1,0 +1,5 @@
+class AddReviewTypeToComments < ActiveRecord::Migration[8.0]
+  def change
+    add_column :comments, :review_type, :integer, limit: 1
+  end
+end


### PR DESCRIPTION
## Problem

Review quotes were inserted as raw markdown blockquotes (`> ...`) directly into the textarea, making multi-review hard to manage:
- Raw markdown unreadable in a small textarea
- No way to see/remove individual quotes
- No indication which comment was quoted

## Solution: Quote Chips

```
┌─────────────────────────────────┐
│ 📎 "Fix the validation..."  ✕  │  ← chip 1 (click to scroll to original)
│ 📎 "Add test for edge..."  ✕  │  ← chip 2
├─────────────────────────────────┤
│ Here's my review feedback...    │  ← clean textarea
└─────────────────────────────────┘
```

## Changes

- **Quote chips container**: Visual chips above textarea showing quoted text previews
- **Click to navigate**: Click chip text → scroll to and highlight original comment (2s)
- **Individual removal**: × button on each chip removes that specific quote
- **Clean textarea**: User types only their feedback; markdown built on submit
- **Backward compatible**: Still uses `quoted_comment_id` for server-side handling

## Files changed (3)

- `_comments_popup.html.erb` — add `reviewQuotesContainer` div
- `form_controller.js` — chip-based quote management, markdown build on submit
- `comments_popup.css` — chip styling, highlight animation