### PR TITLE
feat: add optional supervisor agent to /work command

### DIFF
--- a/engines/collavre/app/services/collavre/comments/work_command.rb
+++ b/engines/collavre/app/services/collavre/comments/work_command.rb
@@ -70,8 +70,8 @@ module Collavre
       # --- /work start (default) ---
 
       def execute_start
-        agent = find_agent
-        return I18n.t("collavre.comments.work_command.agent_not_found") unless agent
+        worker, supervisor = find_agents
+        return I18n.t("collavre.comments.work_command.agent_not_found") unless worker
         return I18n.t("collavre.comments.work_command.no_children") if creative.descendants.empty?
 
         workflow_text = extract_workflow_context
@@ -81,24 +81,29 @@ module Collavre
 
         return I18n.t("collavre.comments.work_command.all_already_tasked") if pending_ids.empty?
 
-        parent_task = create_parent_task(agent, workflow_text, pending_ids)
+        parent_task = create_parent_task(worker, supervisor, workflow_text, pending_ids)
         WorkflowExecutor.advance!(parent_task)
 
         I18n.t("collavre.comments.work_command.started",
-               agent: agent.display_name,
+               agent: worker.display_name,
                total: pending_ids.size,
                skipped: skipped_ids.size)
       end
 
-      def find_agent
-        mentioned = MentionParser.resolve_all_users(comment.content.to_s)
-        mentioned.find(&:ai_user?)
+      # Parse mentioned AI agents: first = worker, second = supervisor (optional)
+      # Usage: /work @Worker @Supervisor: context
+      def find_agents
+        mentioned = MentionParser.resolve_all_users(comment.content.to_s).select(&:ai_user?)
+        worker = mentioned.first
+        supervisor = mentioned.second # nil if only one agent mentioned
+        [ worker, supervisor ]
       end
 
       def extract_workflow_context
         content = comment.content.to_s.strip
         content = content.sub(/\A\/work\s+/, "")
-        content = content.sub(/@[^:]+:\s*/, "")
+        # Strip all @mentions (worker + optional supervisor)
+        content = content.gsub(/@[^\s:]+:?\s*/, "")
         content.strip
       end
 
@@ -128,19 +133,26 @@ module Collavre
         (active + completed).uniq
       end
 
-      def create_parent_task(agent, workflow_text, pending_ids)
+      def create_parent_task(worker, supervisor, workflow_text, pending_ids)
+        state = {
+          "pending_creative_ids" => pending_ids,
+          "completed_creative_ids" => [],
+          "current_creative_id" => nil,
+          "total" => pending_ids.size
+        }
+
+        # Store supervisor info for WorkflowExecutor to include in trigger comments
+        if supervisor
+          state["supervisor"] = { "id" => supervisor.id, "name" => supervisor.display_name }
+        end
+
         Task.create!(
           name: "Workflow: #{creative.description&.truncate(50)}",
           status: "running",
-          agent: agent,
+          agent: worker,
           creative: creative,
           workflow_context: workflow_text,
-          workflow_state: {
-            "pending_creative_ids" => pending_ids,
-            "completed_creative_ids" => [],
-            "current_creative_id" => nil,
-            "total" => pending_ids.size
-          },
+          workflow_state: state,
           trigger_event_name: "work_command",
           trigger_event_payload: {
             "creative" => { "id" => creative.id },

--- a/engines/collavre/app/services/collavre/comments/work_command.rb
+++ b/engines/collavre/app/services/collavre/comments/work_command.rb
@@ -102,8 +102,8 @@ module Collavre
       def extract_workflow_context
         content = comment.content.to_s.strip
         content = content.sub(/\A\/work\s+/, "")
-        # Strip all @mentions (worker + optional supervisor)
-        content = content.gsub(/@[^\s:]+:?\s*/, "")
+        # Strip @mentions using the same pattern as MentionParser
+        content = content.gsub(MentionParser::MENTION_PATTERN, "")
         content.strip
       end
 

--- a/engines/collavre/app/services/collavre/comments/workflow_executor.rb
+++ b/engines/collavre/app/services/collavre/comments/workflow_executor.rb
@@ -255,7 +255,19 @@ module Collavre
         # original /work user, not the agent. Including @Agent causes the agent to
         # interpret it as a self-referencing instruction.
         # MessageBuilder already renders current creative's markdown from context["creative"]["id"].
-        resolve_workflow_context
+        content = resolve_workflow_context
+
+        # If a supervisor is assigned, append instruction to consult them instead of asking the user
+        supervisor = @state["supervisor"]
+        if supervisor
+          supervisor_instruction = I18n.t(
+            "collavre.comments.work_command.supervisor_instruction",
+            supervisor: supervisor["name"]
+          )
+          content = "#{content}\n\n#{supervisor_instruction}"
+        end
+
+        content
       end
 
       def resolve_workflow_context

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -123,6 +123,7 @@ en:
         resumed: 'Workflow resumed for @%{agent}: %{remaining} tasks remaining.'
         no_active_workflow: 'No active workflow found on this creative.'
         no_resumable_workflow: 'No failed or stopped workflow found to resume.'
+        supervisor_instruction: "If you need clarification, have questions, or are unsure about anything, ask @%{supervisor} instead of the user. They will guide you."
       read_by: Read by %{name}
       activity_logs_summary: Activity Logs
     calendar_events:

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -120,6 +120,7 @@ ko:
         resumed: '@%{agent}의 워크플로우가 재개되었습니다: %{remaining}개 작업 남음.'
         no_active_workflow: '이 크리에이티브에 활성 워크플로우가 없습니다.'
         no_resumable_workflow: '재개할 수 있는 실패/중지된 워크플로우가 없습니다.'
+        supervisor_instruction: "질문이 있거나 확인이 필요하면 사용자 대신 @%{supervisor}에게 물어보세요. 감독자가 안내해줄 것입니다."
       read_by: "%{name} 님이 읽음"
       activity_logs_summary: 활동 기록
     calendar_events:


### PR DESCRIPTION
## Summary

Add optional supervisor agent support to `/work` command. When a supervisor is specified, the worker agent consults the supervisor (via existing A2A orchestration) instead of stopping to ask the user.

## Usage

```
/work @Worker @Supervisor: context
```

- First mentioned agent = **worker** (executes tasks)
- Second mentioned agent = **supervisor** (answers worker's questions)
- Supervisor is optional — `/work @Worker: context` still works

## How it works

1. Supervisor info stored in `workflow_state["supervisor"]`
2. Each trigger comment includes instruction: "If you have questions, ask @Supervisor instead of the user"
3. Worker mentions @Supervisor in response → A2A orchestration handles routing automatically
4. No new infrastructure — leverages existing A2A dispatch

## Changes

- `WorkCommand#find_agents` — parses worker + optional supervisor from mentions
- `WorkflowExecutor#build_trigger_content` — appends supervisor instruction
- i18n: en, ko

## Tests

13 tests passing, Rubocop clean, i18n complete.