### PR TITLE
feat(collavre): add review comment versioning

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_25_065200) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_25_074416) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false
@@ -150,6 +150,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_25_065200) do
     t.integer "quoted_comment_id"
     t.text "quoted_text"
     t.integer "review_type", limit: 1
+    t.integer "selected_version_id"
     t.boolean "streaming", default: false, null: false
     t.integer "topic_id"
     t.datetime "updated_at", null: false
@@ -158,6 +159,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_25_065200) do
     t.index ["approver_id"], name: "index_comments_on_approver_id"
     t.index ["creative_id"], name: "index_comments_on_creative_id"
     t.index ["quoted_comment_id"], name: "index_comments_on_quoted_comment_id"
+    t.index ["selected_version_id"], name: "index_comments_on_selected_version_id"
     t.index ["topic_id"], name: "index_comments_on_topic_id"
     t.index ["user_id"], name: "index_comments_on_user_id"
   end
@@ -816,6 +818,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_25_065200) do
   add_foreign_key "comment_read_pointers", "users"
   add_foreign_key "comment_versions", "comments"
   add_foreign_key "comment_versions", "comments", column: "review_comment_id"
+  add_foreign_key "comments", "comment_versions", column: "selected_version_id"
   add_foreign_key "comments", "creatives"
   add_foreign_key "comments", "topics"
   add_foreign_key "comments", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_23_173533) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_25_065200) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false
@@ -124,6 +124,18 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_23_173533) do
     t.index ["creative_id"], name: "index_comment_read_pointers_on_creative_id"
     t.index ["user_id", "creative_id"], name: "index_comment_read_pointers_on_user_id_and_creative_id", unique: true
     t.index ["user_id"], name: "index_comment_read_pointers_on_user_id"
+  end
+
+  create_table "comment_versions", force: :cascade do |t|
+    t.integer "comment_id", null: false
+    t.text "content", null: false
+    t.datetime "created_at", null: false
+    t.integer "review_comment_id"
+    t.datetime "updated_at", null: false
+    t.integer "version_number", null: false
+    t.index ["comment_id", "version_number"], name: "index_comment_versions_on_comment_id_and_version_number", unique: true
+    t.index ["comment_id"], name: "index_comment_versions_on_comment_id"
+    t.index ["review_comment_id"], name: "index_comment_versions_on_review_comment_id"
   end
 
   create_table "comments", force: :cascade do |t|
@@ -802,6 +814,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_23_173533) do
   add_foreign_key "comment_reactions", "users"
   add_foreign_key "comment_read_pointers", "creatives"
   add_foreign_key "comment_read_pointers", "users"
+  add_foreign_key "comment_versions", "comments"
+  add_foreign_key "comment_versions", "comments", column: "review_comment_id"
   add_foreign_key "comments", "creatives"
   add_foreign_key "comments", "topics"
   add_foreign_key "comments", "users"

--- a/engines/collavre/app/assets/stylesheets/collavre/comment_versions.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comment_versions.css
@@ -1,0 +1,52 @@
+.comment-version-navigator {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2, 0.25rem);
+  margin-top: var(--space-2, 0.25rem);
+  font-size: var(--text-xs, 0.75rem);
+}
+
+.comment-version-btn {
+  background: none;
+  border: 1px solid var(--border-color, #ddd);
+  border-radius: var(--radius-1, 4px);
+  cursor: pointer;
+  padding: 0 var(--space-2, 0.25rem);
+  font-size: var(--text-xs, 0.75rem);
+  line-height: 1.6;
+  color: var(--text-color, #333);
+}
+
+.comment-version-btn:hover:not(:disabled) {
+  background: var(--surface-hover, #f0f0f0);
+}
+
+.comment-version-btn:disabled {
+  opacity: 0.3;
+  cursor: default;
+}
+
+.comment-version-indicator {
+  color: var(--text-muted, #888);
+  font-variant-numeric: tabular-nums;
+  min-width: 3em;
+  text-align: center;
+}
+
+.comment-version-delete-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--text-muted, #888);
+  font-size: var(--text-xs, 0.75rem);
+  padding: 0 var(--space-1, 0.125rem);
+  margin-left: var(--space-1, 0.125rem);
+}
+
+.comment-version-delete-btn:hover {
+  color: var(--danger-color, #e53e3e);
+}
+
+.comment-version-delete-hidden {
+  display: none;
+}

--- a/engines/collavre/app/assets/stylesheets/collavre/comment_versions.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comment_versions.css
@@ -47,6 +47,23 @@
   color: var(--danger-color, #e53e3e);
 }
 
+.comment-version-select-btn {
+  background: none;
+  border: 1px solid var(--primary-color, #4a90d9);
+  border-radius: var(--radius-1, 4px);
+  cursor: pointer;
+  color: var(--primary-color, #4a90d9);
+  font-size: var(--text-xs, 0.75rem);
+  padding: 0 var(--space-2, 0.25rem);
+  margin-left: var(--space-1, 0.125rem);
+  line-height: 1.6;
+}
+
+.comment-version-select-btn:hover {
+  background: var(--primary-color, #4a90d9);
+  color: white;
+}
+
 .comment-version-delete-hidden {
   display: none;
 }

--- a/engines/collavre/app/assets/stylesheets/collavre/comment_versions.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comment_versions.css
@@ -64,11 +64,13 @@
   line-height: 1.6;
 }
 
-.comment-version-select-btn:hover {
+.comment-version-select-btn:hover:not(:disabled) {
   background: var(--primary-color, #4a90d9);
   color: white;
 }
 
-.comment-version-delete-hidden {
-  display: none;
+.comment-version-select-btn:disabled,
+.comment-version-delete-btn:disabled {
+  opacity: 0.3;
+  cursor: default;
 }

--- a/engines/collavre/app/assets/stylesheets/collavre/comment_versions.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comment_versions.css
@@ -47,6 +47,11 @@
   color: var(--danger-color, #e53e3e);
 }
 
+.comment-version-selected {
+  color: var(--primary-color, #4a90d9);
+  font-weight: bold;
+}
+
 .comment-version-select-btn {
   background: none;
   border: 1px solid var(--primary-color, #4a90d9);

--- a/engines/collavre/app/controllers/collavre/comments/versions_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comments/versions_controller.rb
@@ -19,6 +19,7 @@ module Collavre
         render json: {
           versions: versions,
           current_content: @comment.content,
+          selected_version_id: @comment.selected_version_id,
           total: versions.size + 1
         }
       end
@@ -29,16 +30,18 @@ module Collavre
         end
 
         version = @comment.comment_versions.find(params[:id])
+        @comment.update!(selected_version_id: version.id)
 
-        # Save current content as a new version before replacing
-        @comment.comment_versions.create!(
-          content: @comment.content,
-          version_number: @comment.next_version_number
-        )
+        render json: { selected_version_id: version.id }
+      end
 
-        @comment.update!(content: version.content)
+      def deselect
+        unless @comment.user == Current.user || @creative.has_permission?(Current.user, :admin)
+          render json: { error: I18n.t("collavre.comments.not_owner") }, status: :forbidden and return
+        end
 
-        render json: { content: @comment.content, total: @comment.comment_versions.size + 1 }
+        @comment.update!(selected_version_id: nil)
+        render json: { selected_version_id: nil }
       end
 
       def destroy
@@ -47,6 +50,7 @@ module Collavre
         end
 
         version = @comment.comment_versions.find(params[:id])
+        @comment.update!(selected_version_id: nil) if @comment.selected_version_id == version.id
         version.destroy!
         head :no_content
       end

--- a/engines/collavre/app/controllers/collavre/comments/versions_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comments/versions_controller.rb
@@ -62,9 +62,25 @@ module Collavre
         end
 
         version = @comment.comment_versions.find(params[:id])
-        @comment.update!(selected_version_id: nil) if @comment.selected_version_id == version.id
+        was_selected = @comment.selected_version_id == version.id
         version.destroy!
-        head :no_content
+
+        if was_selected
+          # Roll back to the latest remaining version or the newest version's content
+          latest = @comment.comment_versions.order(:version_number).last
+          if latest
+            @comment.update!(selected_version_id: latest.id, content: latest.content)
+          else
+            @comment.update!(selected_version_id: nil)
+          end
+        end
+
+        remaining = @comment.comment_versions.count
+        render json: {
+          selected_version_id: @comment.selected_version_id,
+          content: @comment.content,
+          total: remaining + 1
+        }
       end
 
       private

--- a/engines/collavre/app/controllers/collavre/comments/versions_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comments/versions_controller.rb
@@ -24,6 +24,10 @@ module Collavre
       end
 
       def destroy
+        unless @comment.user == Current.user || @creative.has_permission?(Current.user, :admin)
+          render json: { error: I18n.t("collavre.comments.not_owner") }, status: :forbidden and return
+        end
+
         version = @comment.comment_versions.find(params[:id])
         version.destroy!
         head :no_content
@@ -36,7 +40,14 @@ module Collavre
       end
 
       def set_comment
-        @comment = @creative.comments.find(params[:comment_id])
+        @comment = @creative.comments
+                             .where(
+                               "comments.private = ? OR comments.user_id = ? OR comments.approver_id = ?",
+                               false,
+                               Current.user.id,
+                               Current.user.id
+                             )
+                             .find(params[:comment_id])
       end
     end
   end

--- a/engines/collavre/app/controllers/collavre/comments/versions_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comments/versions_controller.rb
@@ -30,9 +30,19 @@ module Collavre
         end
 
         version = @comment.comment_versions.find(params[:id])
-        @comment.update!(selected_version_id: version.id)
 
-        render json: { selected_version_id: version.id }
+        # Save current content as a version if not already versioned
+        unless @comment.comment_versions.exists?(content: @comment.content)
+          @comment.comment_versions.create!(
+            content: @comment.content,
+            version_number: @comment.next_version_number
+          )
+        end
+
+        # Update pointer AND content
+        @comment.update!(selected_version_id: version.id, content: version.content)
+
+        render json: { selected_version_id: version.id, content: version.content }
       end
 
       def deselect
@@ -40,8 +50,10 @@ module Collavre
           render json: { error: I18n.t("collavre.comments.not_owner") }, status: :forbidden and return
         end
 
-        @comment.update!(selected_version_id: nil)
-        render json: { selected_version_id: nil }
+        latest_version = @comment.comment_versions.order(:version_number).last
+        new_content = latest_version&.content || @comment.content
+        @comment.update!(selected_version_id: nil, content: new_content)
+        render json: { selected_version_id: nil, content: new_content }
       end
 
       def destroy

--- a/engines/collavre/app/controllers/collavre/comments/versions_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comments/versions_controller.rb
@@ -23,6 +23,24 @@ module Collavre
         }
       end
 
+      def select
+        unless @comment.user == Current.user || @creative.has_permission?(Current.user, :admin)
+          render json: { error: I18n.t("collavre.comments.not_owner") }, status: :forbidden and return
+        end
+
+        version = @comment.comment_versions.find(params[:id])
+
+        # Save current content as a new version before replacing
+        @comment.comment_versions.create!(
+          content: @comment.content,
+          version_number: @comment.next_version_number
+        )
+
+        @comment.update!(content: version.content)
+
+        render json: { content: @comment.content, total: @comment.comment_versions.size + 1 }
+      end
+
       def destroy
         unless @comment.user == Current.user || @creative.has_permission?(Current.user, :admin)
           render json: { error: I18n.t("collavre.comments.not_owner") }, status: :forbidden and return

--- a/engines/collavre/app/controllers/collavre/comments/versions_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comments/versions_controller.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Comments
+    class VersionsController < ApplicationController
+      before_action :set_creative
+      before_action :set_comment
+
+      def index
+        versions = @comment.comment_versions.order(:version_number).map do |v|
+          {
+            id: v.id,
+            version_number: v.version_number,
+            content: v.content,
+            created_at: v.created_at.iso8601
+          }
+        end
+
+        render json: {
+          versions: versions,
+          current_content: @comment.content,
+          total: versions.size + 1
+        }
+      end
+
+      def destroy
+        version = @comment.comment_versions.find(params[:id])
+        version.destroy!
+        head :no_content
+      end
+
+      private
+
+      def set_creative
+        @creative = Creative.find(params[:creative_id]).effective_origin
+      end
+
+      def set_comment
+        @comment = @creative.comments.find(params[:comment_id])
+      end
+    end
+  end
+end

--- a/engines/collavre/app/controllers/collavre/comments/versions_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comments/versions_controller.rb
@@ -18,9 +18,8 @@ module Collavre
 
         render json: {
           versions: versions,
-          current_content: @comment.content,
           selected_version_id: @comment.selected_version_id,
-          total: versions.size + 1
+          total: versions.size
         }
       end
 
@@ -30,30 +29,9 @@ module Collavre
         end
 
         version = @comment.comment_versions.find(params[:id])
-
-        # Save current content as a version if not already versioned
-        unless @comment.comment_versions.exists?(content: @comment.content)
-          @comment.comment_versions.create!(
-            content: @comment.content,
-            version_number: @comment.next_version_number
-          )
-        end
-
-        # Update pointer AND content
         @comment.update!(selected_version_id: version.id, content: version.content)
 
         render json: { selected_version_id: version.id, content: version.content }
-      end
-
-      def deselect
-        unless @comment.user == Current.user || @creative.has_permission?(Current.user, :admin)
-          render json: { error: I18n.t("collavre.comments.not_owner") }, status: :forbidden and return
-        end
-
-        latest_version = @comment.comment_versions.order(:version_number).last
-        new_content = latest_version&.content || @comment.content
-        @comment.update!(selected_version_id: nil, content: new_content)
-        render json: { selected_version_id: nil, content: new_content }
       end
 
       def destroy
@@ -66,7 +44,7 @@ module Collavre
         version.destroy!
 
         if was_selected
-          # Roll back to the latest remaining version or the newest version's content
+          # Roll back to the latest remaining version
           latest = @comment.comment_versions.order(:version_number).last
           if latest
             @comment.update!(selected_version_id: latest.id, content: latest.content)
@@ -79,7 +57,7 @@ module Collavre
         render json: {
           selected_version_id: @comment.selected_version_id,
           content: @comment.content,
-          total: remaining + 1
+          total: remaining
         }
       end
 

--- a/engines/collavre/app/controllers/collavre/comments_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comments_controller.rb
@@ -25,7 +25,7 @@ module Collavre
         Current.user.id,
         Current.user.id
       )
-      scope = visible_scope.with_attached_images.includes(:topic, :comment_reactions)
+      scope = visible_scope.with_attached_images.includes(:topic, :comment_reactions, :comment_versions)
 
       if params[:search].present?
         search_term = ActiveRecord::Base.sanitize_sql_like(params[:search].to_s.strip.downcase)
@@ -191,7 +191,7 @@ module Collavre
             )
           end
         end
-        @comment = Comment.with_attached_images.includes(:comment_reactions).find(@comment.id)
+        @comment = Comment.with_attached_images.includes(:comment_reactions, :comment_versions).find(@comment.id)
         render partial: "collavre/comments/comment", locals: { comment: @comment, current_topic_id: current_topic_context }, status: :created
       else
         render json: { errors: @comment.errors.full_messages }, status: :unprocessable_entity
@@ -206,7 +206,7 @@ module Collavre
         end
 
         if @comment.update(safe_params)
-          @comment = Comment.with_attached_images.includes(:comment_reactions).find(@comment.id)
+          @comment = Comment.with_attached_images.includes(:comment_reactions, :comment_versions).find(@comment.id)
           render partial: "collavre/comments/comment", locals: { comment: @comment, current_topic_id: current_topic_context }
         else
           render json: { errors: @comment.errors.full_messages }, status: :unprocessable_entity
@@ -295,7 +295,7 @@ module Collavre
 
       begin
         ::Comments::ActionExecutor.new(comment: @comment, executor: Current.user).call
-        @comment = Comment.with_attached_images.includes(:comment_reactions).find(@comment.id)
+        @comment = Comment.with_attached_images.includes(:comment_reactions, :comment_versions).find(@comment.id)
         render partial: "collavre/comments/comment", locals: { comment: @comment, current_topic_id: current_topic_context }
       rescue ::Comments::ActionExecutor::ExecutionError => e
         render json: { error: e.message }, status: :unprocessable_entity
@@ -365,7 +365,7 @@ module Collavre
       elsif executed_error
         render json: { error: I18n.t("collavre.comments.approve_already_executed") }, status: :unprocessable_entity
       elsif update_success
-        @comment = Comment.with_attached_images.includes(:comment_reactions).find(@comment.id)
+        @comment = Comment.with_attached_images.includes(:comment_reactions, :comment_versions).find(@comment.id)
         render partial: "collavre/comments/comment", locals: { comment: @comment, current_topic_id: current_topic_context }
       else
         error_message = @comment.errors.full_messages.to_sentence.presence || I18n.t("collavre.comments.action_update_error")

--- a/engines/collavre/app/controllers/collavre/comments_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comments_controller.rb
@@ -191,7 +191,7 @@ module Collavre
             )
           end
         end
-        @comment = Comment.with_attached_images.includes(:comment_reactions, :comment_versions).find(@comment.id)
+        @comment = Comment.with_attached_images.includes(:comment_reactions, :comment_versions, :selected_version).find(@comment.id)
         render partial: "collavre/comments/comment", locals: { comment: @comment, current_topic_id: current_topic_context }, status: :created
       else
         render json: { errors: @comment.errors.full_messages }, status: :unprocessable_entity
@@ -206,7 +206,7 @@ module Collavre
         end
 
         if @comment.update(safe_params)
-          @comment = Comment.with_attached_images.includes(:comment_reactions, :comment_versions).find(@comment.id)
+          @comment = Comment.with_attached_images.includes(:comment_reactions, :comment_versions, :selected_version).find(@comment.id)
           render partial: "collavre/comments/comment", locals: { comment: @comment, current_topic_id: current_topic_context }
         else
           render json: { errors: @comment.errors.full_messages }, status: :unprocessable_entity
@@ -295,7 +295,7 @@ module Collavre
 
       begin
         ::Comments::ActionExecutor.new(comment: @comment, executor: Current.user).call
-        @comment = Comment.with_attached_images.includes(:comment_reactions, :comment_versions).find(@comment.id)
+        @comment = Comment.with_attached_images.includes(:comment_reactions, :comment_versions, :selected_version).find(@comment.id)
         render partial: "collavre/comments/comment", locals: { comment: @comment, current_topic_id: current_topic_context }
       rescue ::Comments::ActionExecutor::ExecutionError => e
         render json: { error: e.message }, status: :unprocessable_entity
@@ -365,7 +365,7 @@ module Collavre
       elsif executed_error
         render json: { error: I18n.t("collavre.comments.approve_already_executed") }, status: :unprocessable_entity
       elsif update_success
-        @comment = Comment.with_attached_images.includes(:comment_reactions, :comment_versions).find(@comment.id)
+        @comment = Comment.with_attached_images.includes(:comment_reactions, :comment_versions, :selected_version).find(@comment.id)
         render partial: "collavre/comments/comment", locals: { comment: @comment, current_topic_id: current_topic_context }
       else
         error_message = @comment.errors.full_messages.to_sentence.presence || I18n.t("collavre.comments.action_update_error")

--- a/engines/collavre/app/javascript/controllers/comment_version_controller.js
+++ b/engines/collavre/app/javascript/controllers/comment_version_controller.js
@@ -146,7 +146,12 @@ export default class extends Controller {
   }
 
   isSelectedIndex() {
-    if (!this.versions) return this.currentIndex === this.totalValue
+    if (!this.versions) {
+      // Before versions are fetched, use initialIndex to determine
+      // If no selectedVersionId, the latest (total) is selected
+      if (!this.selectedVersionIdValue) return this.currentIndex === this.totalValue
+      return this.currentIndex === this.initialIndexValue
+    }
     const version = this.versions[this.currentIndex - 1]
     return version && version.id === this.selectedVersionId
   }

--- a/engines/collavre/app/javascript/controllers/comment_version_controller.js
+++ b/engines/collavre/app/javascript/controllers/comment_version_controller.js
@@ -8,12 +8,13 @@ export default class extends Controller {
     total: Number,
     contentTarget: String,
     versionsUrl: String,
-    selectedVersionId: Number
+    selectedVersionId: Number,
+    initialIndex: Number
   }
 
   connect() {
     this.versions = null
-    this.currentIndex = this.totalValue // 1-based, starts at last version
+    this.currentIndex = this.initialIndexValue || this.totalValue
     this.updateButtons()
   }
 

--- a/engines/collavre/app/javascript/controllers/comment_version_controller.js
+++ b/engines/collavre/app/javascript/controllers/comment_version_controller.js
@@ -7,12 +7,13 @@ export default class extends Controller {
     creativeId: Number,
     total: Number,
     contentTarget: String,
-    versionsUrl: String
+    versionsUrl: String,
+    selectedVersionId: Number
   }
 
   connect() {
-    this.currentIndex = this.totalValue // 1-based, starts at latest (current)
     this.versions = null
+    this.currentIndex = this.totalValue // default: latest (current content)
     this.updateButtons()
   }
 
@@ -26,7 +27,17 @@ export default class extends Controller {
     const data = await response.json()
     this.versions = data.versions
     this.currentContent = data.current_content
+    this.selectedVersionId = data.selected_version_id
     this.totalValue = data.total
+
+    // Set currentIndex based on selected version
+    if (this.selectedVersionId) {
+      const idx = this.versions.findIndex(v => v.id === this.selectedVersionId)
+      if (idx !== -1) this.currentIndex = idx + 1
+    } else {
+      this.currentIndex = this.totalValue
+    }
+
     return this.versions
   }
 
@@ -45,9 +56,21 @@ export default class extends Controller {
   }
 
   async selectVersion() {
-    if (this.currentIndex === this.totalValue) return // already current
-
     const versions = await this.fetchVersions()
+
+    if (this.currentIndex === this.totalValue) {
+      // Selecting "current" = deselect (clear pointer)
+      const response = await fetch(
+        `${this.versionsUrlValue}/deselect`,
+        { method: "POST", headers: { "X-CSRF-Token": this.csrfToken } }
+      )
+      if (response.ok) {
+        this.selectedVersionId = null
+        this.updateButtons()
+      }
+      return
+    }
+
     const version = versions[this.currentIndex - 1]
     if (!version) return
 
@@ -57,18 +80,13 @@ export default class extends Controller {
     )
 
     if (response.ok) {
-      const data = await response.json()
-      // Reset: refetch versions on next navigation
-      this.versions = null
-      this.currentContent = data.content
-      this.totalValue = data.total
-      this.currentIndex = this.totalValue
-      this.render()
+      this.selectedVersionId = version.id
+      this.updateButtons()
     }
   }
 
   async deleteVersion() {
-    if (this.currentIndex === this.totalValue) return // can't delete current
+    if (this.currentIndex === this.totalValue) return
 
     const versions = await this.fetchVersions()
     const version = versions[this.currentIndex - 1]
@@ -80,6 +98,11 @@ export default class extends Controller {
     )
 
     if (response.ok) {
+      // If deleting the selected version, clear selection
+      if (this.selectedVersionId === version.id) {
+        this.selectedVersionId = null
+      }
+
       versions.splice(this.currentIndex - 1, 1)
       this.totalValue = versions.length + 1
       if (this.currentIndex > this.totalValue) {
@@ -87,48 +110,60 @@ export default class extends Controller {
       }
       this.render()
 
-      // Remove navigator if no versions left
       if (versions.length === 0) {
+        // Show current content and remove navigator
+        this.setContentText(this.currentContent)
         this.element.remove()
       }
     }
   }
 
   render() {
-    const contentEl = document.getElementById(this.contentTargetValue)
-      ?.querySelector(".comment-content, [data-comment-target='content']")
-      || document.getElementById(this.contentTargetValue)
-        ?.querySelector(".comment-content")
-
-    const target = contentEl || document.querySelector(
-      `#${this.contentTargetValue} [data-comment-target="content"]`
-    )
-
-    if (target) {
-      if (this.currentIndex === this.totalValue) {
-        target.textContent = this.currentContent
-      } else {
-        const version = this.versions[this.currentIndex - 1]
-        if (version) target.textContent = version.content
-      }
+    if (this.currentIndex === this.totalValue) {
+      this.setContentText(this.currentContent)
+    } else {
+      const version = this.versions[this.currentIndex - 1]
+      if (version) this.setContentText(version.content)
     }
 
     this.indicatorTarget.textContent = `v${this.currentIndex}/${this.totalValue}`
     this.updateButtons()
   }
 
+  setContentText(text) {
+    const el = document.getElementById(this.contentTargetValue)
+    const target = el?.querySelector(".comment-content") || el?.querySelector("[data-comment-target='content']")
+    if (target) target.textContent = text
+  }
+
   updateButtons() {
     this.prevBtnTarget.disabled = this.currentIndex <= 1
     this.nextBtnTarget.disabled = this.currentIndex >= this.totalValue
 
-    // Show delete/select buttons only for historical versions (not current)
     const isHistorical = this.currentIndex < this.totalValue
+    const isCurrentlySelected = this.isSelectedIndex()
+
+    // Delete: only for historical versions
     if (this.hasDeleteBtnTarget) {
       this.deleteBtnTarget.classList.toggle("comment-version-delete-hidden", !isHistorical)
     }
+
+    // Select: show for historical versions, disable if already selected
     if (this.hasSelectBtnTarget) {
       this.selectBtnTarget.classList.toggle("comment-version-delete-hidden", !isHistorical)
+      this.selectBtnTarget.disabled = isCurrentlySelected
     }
+
+    // Highlight the indicator if viewing the selected version
+    this.indicatorTarget.classList.toggle("comment-version-selected", isCurrentlySelected && isHistorical)
+  }
+
+  isSelectedIndex() {
+    if (!this.selectedVersionId) return this.currentIndex === this.totalValue
+    if (this.currentIndex === this.totalValue) return !this.selectedVersionId
+    if (!this.versions) return false
+    const version = this.versions[this.currentIndex - 1]
+    return version && version.id === this.selectedVersionId
   }
 
   get csrfToken() {

--- a/engines/collavre/app/javascript/controllers/comment_version_controller.js
+++ b/engines/collavre/app/javascript/controllers/comment_version_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["prevBtn", "nextBtn", "indicator", "deleteBtn"]
+  static targets = ["prevBtn", "nextBtn", "indicator", "deleteBtn", "selectBtn"]
   static values = {
     commentId: Number,
     creativeId: Number,
@@ -42,6 +42,29 @@ export default class extends Controller {
     await this.fetchVersions()
     this.currentIndex++
     this.render()
+  }
+
+  async selectVersion() {
+    if (this.currentIndex === this.totalValue) return // already current
+
+    const versions = await this.fetchVersions()
+    const version = versions[this.currentIndex - 1]
+    if (!version) return
+
+    const response = await fetch(
+      `${this.versionsUrlValue}/${version.id}/select`,
+      { method: "POST", headers: { "X-CSRF-Token": this.csrfToken } }
+    )
+
+    if (response.ok) {
+      const data = await response.json()
+      // Reset: refetch versions on next navigation
+      this.versions = null
+      this.currentContent = data.content
+      this.totalValue = data.total
+      this.currentIndex = this.totalValue
+      this.render()
+    }
   }
 
   async deleteVersion() {
@@ -98,13 +121,13 @@ export default class extends Controller {
     this.prevBtnTarget.disabled = this.currentIndex <= 1
     this.nextBtnTarget.disabled = this.currentIndex >= this.totalValue
 
-    // Show delete button only for historical versions (not current)
+    // Show delete/select buttons only for historical versions (not current)
+    const isHistorical = this.currentIndex < this.totalValue
     if (this.hasDeleteBtnTarget) {
-      if (this.currentIndex < this.totalValue) {
-        this.deleteBtnTarget.classList.remove("comment-version-delete-hidden")
-      } else {
-        this.deleteBtnTarget.classList.add("comment-version-delete-hidden")
-      }
+      this.deleteBtnTarget.classList.toggle("comment-version-delete-hidden", !isHistorical)
+    }
+    if (this.hasSelectBtnTarget) {
+      this.selectBtnTarget.classList.toggle("comment-version-delete-hidden", !isHistorical)
     }
   }
 

--- a/engines/collavre/app/javascript/controllers/comment_version_controller.js
+++ b/engines/collavre/app/javascript/controllers/comment_version_controller.js
@@ -13,7 +13,7 @@ export default class extends Controller {
 
   connect() {
     this.versions = null
-    this.currentIndex = this.totalValue
+    this.currentIndex = this.totalValue // 1-based, starts at last version
     this.updateButtons()
   }
 
@@ -26,10 +26,10 @@ export default class extends Controller {
     )
     const data = await response.json()
     this.versions = data.versions
-    this.currentContent = data.current_content
     this.selectedVersionId = data.selected_version_id
     this.totalValue = data.total
 
+    // Set currentIndex based on selected version
     if (this.selectedVersionId) {
       const idx = this.versions.findIndex(v => v.id === this.selectedVersionId)
       if (idx !== -1) this.currentIndex = idx + 1
@@ -56,24 +56,8 @@ export default class extends Controller {
 
   async selectVersion() {
     const versions = await this.fetchVersions()
-
-    if (this.currentIndex === this.totalValue) {
-      // Selecting latest = deselect (clear pointer)
-      const response = await fetch(
-        `${this.versionsUrlValue}/deselect`,
-        { method: "POST", headers: { "X-CSRF-Token": this.csrfToken } }
-      )
-      if (response.ok) {
-        const data = await response.json()
-        this.selectedVersionId = null
-        this.currentContent = data.content
-        this.render()
-      }
-      return
-    }
-
     const version = versions[this.currentIndex - 1]
-    if (!version) return
+    if (!version || version.id === this.selectedVersionId) return
 
     const response = await fetch(
       `${this.versionsUrlValue}/${version.id}/select`,
@@ -82,22 +66,17 @@ export default class extends Controller {
 
     if (response.ok) {
       this.selectedVersionId = version.id
-      this.currentContent = version.content
       this.render()
     }
   }
 
   async deleteVersion() {
     const versions = await this.fetchVersions()
-
-    if (this.currentIndex === this.totalValue) {
-      // Deleting "latest" (comment.content that's not in versions) — not allowed
-      // This slot represents the latest AI output, only version records can be deleted
-      return
-    }
-
     const version = versions[this.currentIndex - 1]
     if (!version) return
+
+    // Can't delete if it's the only version
+    if (versions.length <= 1) return
 
     const response = await fetch(
       `${this.versionsUrlValue}/${version.id}`,
@@ -109,13 +88,12 @@ export default class extends Controller {
       versions.splice(this.currentIndex - 1, 1)
       this.totalValue = data.total
       this.selectedVersionId = data.selected_version_id
-      this.currentContent = data.content
 
       if (this.currentIndex > this.totalValue) {
         this.currentIndex = this.totalValue
       }
 
-      // If the deleted version was selected, jump to the new selection
+      // Jump to newly selected version if changed
       if (data.selected_version_id) {
         const idx = versions.findIndex(v => v.id === data.selected_version_id)
         if (idx !== -1) this.currentIndex = idx + 1
@@ -123,20 +101,17 @@ export default class extends Controller {
 
       this.render()
 
-      if (versions.length === 0) {
-        this.setContentText(this.currentContent)
+      if (versions.length <= 1) {
+        // Only one version left — no need for navigator
+        this.setContentText(versions[0]?.content || data.content)
         this.element.remove()
       }
     }
   }
 
   render() {
-    if (this.currentIndex === this.totalValue) {
-      this.setContentText(this.currentContent)
-    } else {
-      const version = this.versions[this.currentIndex - 1]
-      if (version) this.setContentText(version.content)
-    }
+    const version = this.versions[this.currentIndex - 1]
+    if (version) this.setContentText(version.content)
 
     this.indicatorTarget.textContent = `v${this.currentIndex}/${this.totalValue}`
     this.updateButtons()
@@ -152,27 +127,25 @@ export default class extends Controller {
     this.prevBtnTarget.disabled = this.currentIndex <= 1
     this.nextBtnTarget.disabled = this.currentIndex >= this.totalValue
 
-    const isLatestSlot = this.currentIndex === this.totalValue
     const isCurrentlySelected = this.isSelectedIndex()
+    const isOnlyVersion = this.totalValue <= 1
 
-    // Delete: always visible, disabled for latest slot (not a version record)
+    // Delete: disabled if it's the selected version or the only version
     if (this.hasDeleteBtnTarget) {
-      this.deleteBtnTarget.disabled = isLatestSlot
+      this.deleteBtnTarget.disabled = isCurrentlySelected || isOnlyVersion
     }
 
-    // Select: always visible, disabled if already selected
+    // Select: disabled if already selected
     if (this.hasSelectBtnTarget) {
       this.selectBtnTarget.disabled = isCurrentlySelected
     }
 
-    // Highlight indicator when viewing the selected/active version
+    // Highlight indicator when viewing the selected version
     this.indicatorTarget.classList.toggle("comment-version-selected", isCurrentlySelected)
   }
 
   isSelectedIndex() {
-    if (!this.selectedVersionId) return this.currentIndex === this.totalValue
-    if (!this.versions) return false
-    if (this.currentIndex === this.totalValue) return !this.selectedVersionId
+    if (!this.versions) return this.currentIndex === this.totalValue
     const version = this.versions[this.currentIndex - 1]
     return version && version.id === this.selectedVersionId
   }

--- a/engines/collavre/app/javascript/controllers/comment_version_controller.js
+++ b/engines/collavre/app/javascript/controllers/comment_version_controller.js
@@ -13,7 +13,7 @@ export default class extends Controller {
 
   connect() {
     this.versions = null
-    this.currentIndex = this.totalValue // default: latest (current content)
+    this.currentIndex = this.totalValue
     this.updateButtons()
   }
 
@@ -30,7 +30,6 @@ export default class extends Controller {
     this.selectedVersionId = data.selected_version_id
     this.totalValue = data.total
 
-    // Set currentIndex based on selected version
     if (this.selectedVersionId) {
       const idx = this.versions.findIndex(v => v.id === this.selectedVersionId)
       if (idx !== -1) this.currentIndex = idx + 1
@@ -59,14 +58,16 @@ export default class extends Controller {
     const versions = await this.fetchVersions()
 
     if (this.currentIndex === this.totalValue) {
-      // Selecting "current" = deselect (clear pointer)
+      // Selecting latest = deselect (clear pointer)
       const response = await fetch(
         `${this.versionsUrlValue}/deselect`,
         { method: "POST", headers: { "X-CSRF-Token": this.csrfToken } }
       )
       if (response.ok) {
+        const data = await response.json()
         this.selectedVersionId = null
-        this.updateButtons()
+        this.currentContent = data.content
+        this.render()
       }
       return
     }
@@ -81,14 +82,20 @@ export default class extends Controller {
 
     if (response.ok) {
       this.selectedVersionId = version.id
-      this.updateButtons()
+      this.currentContent = version.content
+      this.render()
     }
   }
 
   async deleteVersion() {
-    if (this.currentIndex === this.totalValue) return
-
     const versions = await this.fetchVersions()
+
+    if (this.currentIndex === this.totalValue) {
+      // Deleting "latest" (comment.content that's not in versions) — not allowed
+      // This slot represents the latest AI output, only version records can be deleted
+      return
+    }
+
     const version = versions[this.currentIndex - 1]
     if (!version) return
 
@@ -98,20 +105,25 @@ export default class extends Controller {
     )
 
     if (response.ok) {
-      // If deleting the selected version, clear selection
-      if (this.selectedVersionId === version.id) {
-        this.selectedVersionId = null
-      }
-
+      const data = await response.json()
       versions.splice(this.currentIndex - 1, 1)
-      this.totalValue = versions.length + 1
+      this.totalValue = data.total
+      this.selectedVersionId = data.selected_version_id
+      this.currentContent = data.content
+
       if (this.currentIndex > this.totalValue) {
         this.currentIndex = this.totalValue
       }
+
+      // If the deleted version was selected, jump to the new selection
+      if (data.selected_version_id) {
+        const idx = versions.findIndex(v => v.id === data.selected_version_id)
+        if (idx !== -1) this.currentIndex = idx + 1
+      }
+
       this.render()
 
       if (versions.length === 0) {
-        // Show current content and remove navigator
         this.setContentText(this.currentContent)
         this.element.remove()
       }
@@ -140,28 +152,27 @@ export default class extends Controller {
     this.prevBtnTarget.disabled = this.currentIndex <= 1
     this.nextBtnTarget.disabled = this.currentIndex >= this.totalValue
 
-    const isHistorical = this.currentIndex < this.totalValue
+    const isLatestSlot = this.currentIndex === this.totalValue
     const isCurrentlySelected = this.isSelectedIndex()
 
-    // Delete: only for historical versions
+    // Delete: always visible, disabled for latest slot (not a version record)
     if (this.hasDeleteBtnTarget) {
-      this.deleteBtnTarget.classList.toggle("comment-version-delete-hidden", !isHistorical)
+      this.deleteBtnTarget.disabled = isLatestSlot
     }
 
-    // Select: show for historical versions, disable if already selected
+    // Select: always visible, disabled if already selected
     if (this.hasSelectBtnTarget) {
-      this.selectBtnTarget.classList.toggle("comment-version-delete-hidden", !isHistorical)
       this.selectBtnTarget.disabled = isCurrentlySelected
     }
 
-    // Highlight the indicator if viewing the selected version
-    this.indicatorTarget.classList.toggle("comment-version-selected", isCurrentlySelected && isHistorical)
+    // Highlight indicator when viewing the selected/active version
+    this.indicatorTarget.classList.toggle("comment-version-selected", isCurrentlySelected)
   }
 
   isSelectedIndex() {
     if (!this.selectedVersionId) return this.currentIndex === this.totalValue
-    if (this.currentIndex === this.totalValue) return !this.selectedVersionId
     if (!this.versions) return false
+    if (this.currentIndex === this.totalValue) return !this.selectedVersionId
     const version = this.versions[this.currentIndex - 1]
     return version && version.id === this.selectedVersionId
   }

--- a/engines/collavre/app/javascript/controllers/comment_version_controller.js
+++ b/engines/collavre/app/javascript/controllers/comment_version_controller.js
@@ -79,6 +79,8 @@ export default class extends Controller {
     // Can't delete if it's the only version
     if (versions.length <= 1) return
 
+    if (!confirm(this.deleteBtnTarget.dataset.confirmMessage || "Are you sure?")) return
+
     const response = await fetch(
       `${this.versionsUrlValue}/${version.id}`,
       { method: "DELETE", headers: { "X-CSRF-Token": this.csrfToken } }

--- a/engines/collavre/app/javascript/controllers/comment_version_controller.js
+++ b/engines/collavre/app/javascript/controllers/comment_version_controller.js
@@ -6,7 +6,8 @@ export default class extends Controller {
     commentId: Number,
     creativeId: Number,
     total: Number,
-    contentTarget: String
+    contentTarget: String,
+    versionsUrl: String
   }
 
   connect() {
@@ -19,7 +20,7 @@ export default class extends Controller {
     if (this.versions) return this.versions
 
     const response = await fetch(
-      `/collavre/creatives/${this.creativeIdValue}/comments/${this.commentIdValue}/versions`,
+      this.versionsUrlValue,
       { headers: { "Accept": "application/json" } }
     )
     const data = await response.json()
@@ -51,7 +52,7 @@ export default class extends Controller {
     if (!version) return
 
     const response = await fetch(
-      `/collavre/creatives/${this.creativeIdValue}/comments/${this.commentIdValue}/versions/${version.id}`,
+      `${this.versionsUrlValue}/${version.id}`,
       { method: "DELETE", headers: { "X-CSRF-Token": this.csrfToken } }
     )
 

--- a/engines/collavre/app/javascript/controllers/comment_version_controller.js
+++ b/engines/collavre/app/javascript/controllers/comment_version_controller.js
@@ -1,0 +1,113 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["prevBtn", "nextBtn", "indicator", "deleteBtn"]
+  static values = {
+    commentId: Number,
+    creativeId: Number,
+    total: Number,
+    contentTarget: String
+  }
+
+  connect() {
+    this.currentIndex = this.totalValue // 1-based, starts at latest (current)
+    this.versions = null
+    this.updateButtons()
+  }
+
+  async fetchVersions() {
+    if (this.versions) return this.versions
+
+    const response = await fetch(
+      `/collavre/creatives/${this.creativeIdValue}/comments/${this.commentIdValue}/versions`,
+      { headers: { "Accept": "application/json" } }
+    )
+    const data = await response.json()
+    this.versions = data.versions
+    this.currentContent = data.current_content
+    this.totalValue = data.total
+    return this.versions
+  }
+
+  async prev() {
+    if (this.currentIndex <= 1) return
+    await this.fetchVersions()
+    this.currentIndex--
+    this.render()
+  }
+
+  async next() {
+    if (this.currentIndex >= this.totalValue) return
+    await this.fetchVersions()
+    this.currentIndex++
+    this.render()
+  }
+
+  async deleteVersion() {
+    if (this.currentIndex === this.totalValue) return // can't delete current
+
+    const versions = await this.fetchVersions()
+    const version = versions[this.currentIndex - 1]
+    if (!version) return
+
+    const response = await fetch(
+      `/collavre/creatives/${this.creativeIdValue}/comments/${this.commentIdValue}/versions/${version.id}`,
+      { method: "DELETE", headers: { "X-CSRF-Token": this.csrfToken } }
+    )
+
+    if (response.ok) {
+      versions.splice(this.currentIndex - 1, 1)
+      this.totalValue = versions.length + 1
+      if (this.currentIndex > this.totalValue) {
+        this.currentIndex = this.totalValue
+      }
+      this.render()
+
+      // Remove navigator if no versions left
+      if (versions.length === 0) {
+        this.element.remove()
+      }
+    }
+  }
+
+  render() {
+    const contentEl = document.getElementById(this.contentTargetValue)
+      ?.querySelector(".comment-content, [data-comment-target='content']")
+      || document.getElementById(this.contentTargetValue)
+        ?.querySelector(".comment-content")
+
+    const target = contentEl || document.querySelector(
+      `#${this.contentTargetValue} [data-comment-target="content"]`
+    )
+
+    if (target) {
+      if (this.currentIndex === this.totalValue) {
+        target.textContent = this.currentContent
+      } else {
+        const version = this.versions[this.currentIndex - 1]
+        if (version) target.textContent = version.content
+      }
+    }
+
+    this.indicatorTarget.textContent = `v${this.currentIndex}/${this.totalValue}`
+    this.updateButtons()
+  }
+
+  updateButtons() {
+    this.prevBtnTarget.disabled = this.currentIndex <= 1
+    this.nextBtnTarget.disabled = this.currentIndex >= this.totalValue
+
+    // Show delete button only for historical versions (not current)
+    if (this.hasDeleteBtnTarget) {
+      if (this.currentIndex < this.totalValue) {
+        this.deleteBtnTarget.classList.remove("comment-version-delete-hidden")
+      } else {
+        this.deleteBtnTarget.classList.add("comment-version-delete-hidden")
+      }
+    }
+  }
+
+  get csrfToken() {
+    return document.querySelector('meta[name="csrf-token"]')?.content || ""
+  }
+}

--- a/engines/collavre/app/javascript/controllers/index.js
+++ b/engines/collavre/app/javascript/controllers/index.js
@@ -24,6 +24,7 @@ import CommentController from "./comment_controller"
 import ReactionPickerController from "./reaction_picker_controller"
 import ShareInviteController from "./share_invite_controller"
 import ShareUserSearchController from "./share_user_search_controller"
+import CommentVersionController from "./comment_version_controller"
 
 // Export all controllers
 export {
@@ -50,7 +51,8 @@ export {
   CommentController,
   ReactionPickerController,
   ShareInviteController,
-  ShareUserSearchController
+  ShareUserSearchController,
+  CommentVersionController
 }
 
 // Registration function for use with a Stimulus application
@@ -79,4 +81,5 @@ export function registerControllers(application) {
   application.register("reaction-picker", ReactionPickerController)
   application.register("share-invite", ShareInviteController)
   application.register("share-user-search", ShareUserSearchController)
+  application.register("comment-version", CommentVersionController)
 }

--- a/engines/collavre/app/models/collavre/comment.rb
+++ b/engines/collavre/app/models/collavre/comment.rb
@@ -21,6 +21,7 @@ module Collavre
     has_many :activity_logs, class_name: "Collavre::ActivityLog", dependent: :destroy
     has_many :comment_reactions, class_name: "Collavre::CommentReaction", dependent: :destroy
     has_many :comment_versions, class_name: "Collavre::CommentVersion", dependent: :destroy
+    belongs_to :selected_version, class_name: "Collavre::CommentVersion", optional: true
 
     has_many_attached :images, dependent: :purge_later
 
@@ -39,6 +40,10 @@ module Collavre
     validate :images_must_be_images
 
     after_destroy_commit :cancel_pending_tasks
+
+    def display_content
+      selected_version&.content || content
+    end
 
     def next_version_number
       (comment_versions.maximum(:version_number) || 0) + 1

--- a/engines/collavre/app/models/collavre/comment.rb
+++ b/engines/collavre/app/models/collavre/comment.rb
@@ -41,10 +41,6 @@ module Collavre
 
     after_destroy_commit :cancel_pending_tasks
 
-    def display_content
-      selected_version&.content || content
-    end
-
     def next_version_number
       (comment_versions.maximum(:version_number) || 0) + 1
     end

--- a/engines/collavre/app/models/collavre/comment.rb
+++ b/engines/collavre/app/models/collavre/comment.rb
@@ -20,6 +20,7 @@ module Collavre
     enum :review_type, { review: 0, question: 1 }, prefix: true
     has_many :activity_logs, class_name: "Collavre::ActivityLog", dependent: :destroy
     has_many :comment_reactions, class_name: "Collavre::CommentReaction", dependent: :destroy
+    has_many :comment_versions, class_name: "Collavre::CommentVersion", dependent: :destroy
 
     has_many_attached :images, dependent: :purge_later
 
@@ -38,6 +39,10 @@ module Collavre
     validate :images_must_be_images
 
     after_destroy_commit :cancel_pending_tasks
+
+    def next_version_number
+      (comment_versions.maximum(:version_number) || 0) + 1
+    end
 
     def review_message?
       quoted_comment_id.present? && !review_type_question?

--- a/engines/collavre/app/models/collavre/comment_version.rb
+++ b/engines/collavre/app/models/collavre/comment_version.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Collavre
+  class CommentVersion < ApplicationRecord
+    self.table_name = "comment_versions"
+
+    belongs_to :comment, class_name: "Collavre::Comment"
+    belongs_to :review_comment, class_name: "Collavre::Comment", optional: true
+
+    validates :content, presence: true
+    validates :version_number, presence: true,
+                               uniqueness: { scope: :comment_id },
+                               numericality: { only_integer: true, greater_than: 0 }
+  end
+end

--- a/engines/collavre/app/services/collavre/ai_agent/review_handler.rb
+++ b/engines/collavre/app/services/collavre/ai_agent/review_handler.rb
@@ -42,7 +42,7 @@ module Collavre
           review_comment: @original_comment
         )
 
-        quoted_comment.update!(content: response_content)
+        quoted_comment.update!(content: response_content, selected_version_id: nil)
 
         task.task_actions.create!(
           action_type: "review_updated",

--- a/engines/collavre/app/services/collavre/ai_agent/review_handler.rb
+++ b/engines/collavre/app/services/collavre/ai_agent/review_handler.rb
@@ -35,14 +35,23 @@ module Collavre
 
         quoted_comment = @original_comment.quoted_comment
 
-        # Save old content as a version before overwriting
-        quoted_comment.comment_versions.create!(
-          content: quoted_comment.content,
+        # Save old content as a version (only if not already versioned, e.g. first review)
+        unless quoted_comment.comment_versions.exists?(content: quoted_comment.content)
+          quoted_comment.comment_versions.create!(
+            content: quoted_comment.content,
+            version_number: quoted_comment.next_version_number
+          )
+        end
+
+        # Save new content as the latest version
+        new_version = quoted_comment.comment_versions.create!(
+          content: response_content,
           version_number: quoted_comment.next_version_number,
           review_comment: @original_comment
         )
 
-        quoted_comment.update!(content: response_content, selected_version_id: nil)
+        # Update content and point to the new version
+        quoted_comment.update!(content: response_content, selected_version_id: new_version.id)
 
         task.task_actions.create!(
           action_type: "review_updated",

--- a/engines/collavre/app/services/collavre/ai_agent/review_handler.rb
+++ b/engines/collavre/app/services/collavre/ai_agent/review_handler.rb
@@ -34,6 +34,14 @@ module Collavre
         return false unless eligible?
 
         quoted_comment = @original_comment.quoted_comment
+
+        # Save old content as a version before overwriting
+        quoted_comment.comment_versions.create!(
+          content: quoted_comment.content,
+          version_number: quoted_comment.next_version_number,
+          review_comment: @original_comment
+        )
+
         quoted_comment.update!(content: response_content)
 
         task.task_actions.create!(

--- a/engines/collavre/app/services/collavre/ai_agent/review_handler.rb
+++ b/engines/collavre/app/services/collavre/ai_agent/review_handler.rb
@@ -35,8 +35,8 @@ module Collavre
 
         quoted_comment = @original_comment.quoted_comment
 
-        # Save old content as a version (only if not already versioned, e.g. first review)
-        unless quoted_comment.comment_versions.exists?(content: quoted_comment.content)
+        # Save old content as a version if this is the first review (no versions yet)
+        if quoted_comment.comment_versions.empty?
           quoted_comment.comment_versions.create!(
             content: quoted_comment.content,
             version_number: quoted_comment.next_version_number

--- a/engines/collavre/app/views/collavre/comments/_comment.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comment.html.erb
@@ -84,6 +84,7 @@
         v<%= comment.comment_versions.size + 1 %>/<%= comment.comment_versions.size + 1 %>
       </span>
       <button class="comment-version-btn" data-action="click->comment-version#next" data-comment-version-target="nextBtn" title="<%= t('collavre.comments.versions.next') %>">▶</button>
+      <button class="comment-version-select-btn comment-version-delete-hidden" data-action="click->comment-version#selectVersion" data-comment-version-target="selectBtn" title="<%= t('collavre.comments.versions.select') %>">✓ <%= t('collavre.comments.versions.select') %></button>
       <button class="comment-version-delete-btn comment-version-delete-hidden" data-action="click->comment-version#deleteVersion" data-comment-version-target="deleteBtn" title="<%= t('collavre.comments.versions.delete') %>">✕</button>
     </div>
   <% end %>

--- a/engines/collavre/app/views/collavre/comments/_comment.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comment.html.erb
@@ -70,18 +70,22 @@
       <blockquote class="comment-quoted-text"><%= comment.quoted_text %></blockquote>
     </div>
   <% end %>
-  <div class="comment-content" data-comment-target="content"><%= comment.content %></div>
+  <div class="comment-content" data-comment-target="content"><%= comment.display_content %></div>
   <% if comment.comment_versions.any? %>
+    <% version_count = comment.comment_versions.size %>
+    <% selected_id = comment.selected_version_id %>
+    <% selected_index = selected_id ? comment.comment_versions.order(:version_number).pluck(:id).index(selected_id)&.+(1) : version_count + 1 %>
     <div class="comment-version-navigator"
          data-controller="comment-version"
          data-comment-version-comment-id-value="<%= comment.id %>"
          data-comment-version-creative-id-value="<%= comment.creative_id %>"
          data-comment-version-versions-url-value="<%= collavre.creative_comment_versions_path(comment.creative, comment) %>"
-         data-comment-version-total-value="<%= comment.comment_versions.size + 1 %>"
+         data-comment-version-total-value="<%= version_count + 1 %>"
+         data-comment-version-selected-version-id-value="<%= selected_id %>"
          data-comment-version-content-target-value="<%= dom_id(comment) %>">
       <button class="comment-version-btn" data-action="click->comment-version#prev" data-comment-version-target="prevBtn" title="<%= t('collavre.comments.versions.previous') %>">◀</button>
       <span class="comment-version-indicator" data-comment-version-target="indicator">
-        v<%= comment.comment_versions.size + 1 %>/<%= comment.comment_versions.size + 1 %>
+        v<%= selected_index %>/<%= version_count + 1 %>
       </span>
       <button class="comment-version-btn" data-action="click->comment-version#next" data-comment-version-target="nextBtn" title="<%= t('collavre.comments.versions.next') %>">▶</button>
       <button class="comment-version-select-btn comment-version-delete-hidden" data-action="click->comment-version#selectVersion" data-comment-version-target="selectBtn" title="<%= t('collavre.comments.versions.select') %>">✓ <%= t('collavre.comments.versions.select') %></button>

--- a/engines/collavre/app/views/collavre/comments/_comment.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comment.html.erb
@@ -70,7 +70,7 @@
       <blockquote class="comment-quoted-text"><%= comment.quoted_text %></blockquote>
     </div>
   <% end %>
-  <div class="comment-content" data-comment-target="content"><%= comment.display_content %></div>
+  <div class="comment-content" data-comment-target="content"><%= comment.content %></div>
   <% if comment.comment_versions.any? %>
     <% version_count = comment.comment_versions.size %>
     <% selected_id = comment.selected_version_id %>

--- a/engines/collavre/app/views/collavre/comments/_comment.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comment.html.erb
@@ -74,18 +74,19 @@
   <% if comment.comment_versions.any? %>
     <% version_count = comment.comment_versions.size %>
     <% selected_id = comment.selected_version_id %>
-    <% selected_index = selected_id ? comment.comment_versions.order(:version_number).pluck(:id).index(selected_id)&.+(1) : version_count + 1 %>
+    <% version_ids = comment.comment_versions.order(:version_number).pluck(:id) %>
+    <% selected_index = selected_id ? (version_ids.index(selected_id)&.+(1) || version_count) : version_count %>
     <div class="comment-version-navigator"
          data-controller="comment-version"
          data-comment-version-comment-id-value="<%= comment.id %>"
          data-comment-version-creative-id-value="<%= comment.creative_id %>"
          data-comment-version-versions-url-value="<%= collavre.creative_comment_versions_path(comment.creative, comment) %>"
-         data-comment-version-total-value="<%= version_count + 1 %>"
+         data-comment-version-total-value="<%= version_count %>"
          data-comment-version-selected-version-id-value="<%= selected_id %>"
          data-comment-version-content-target-value="<%= dom_id(comment) %>">
       <button class="comment-version-btn" data-action="click->comment-version#prev" data-comment-version-target="prevBtn" title="<%= t('collavre.comments.versions.previous') %>">◀</button>
       <span class="comment-version-indicator" data-comment-version-target="indicator">
-        v<%= selected_index %>/<%= version_count + 1 %>
+        v<%= selected_index %>/<%= version_count %>
       </span>
       <button class="comment-version-btn" data-action="click->comment-version#next" data-comment-version-target="nextBtn" title="<%= t('collavre.comments.versions.next') %>">▶</button>
       <button class="comment-version-select-btn" data-action="click->comment-version#selectVersion" data-comment-version-target="selectBtn" title="<%= t('collavre.comments.versions.select') %>" disabled>✓ <%= t('collavre.comments.versions.select') %></button>

--- a/engines/collavre/app/views/collavre/comments/_comment.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comment.html.erb
@@ -82,6 +82,7 @@
          data-comment-version-creative-id-value="<%= comment.creative_id %>"
          data-comment-version-versions-url-value="<%= collavre.creative_comment_versions_path(comment.creative, comment) %>"
          data-comment-version-total-value="<%= version_count %>"
+         data-comment-version-initial-index-value="<%= selected_index %>"
          data-comment-version-selected-version-id-value="<%= selected_id %>"
          data-comment-version-content-target-value="<%= dom_id(comment) %>">
       <button class="comment-version-btn" data-action="click->comment-version#prev" data-comment-version-target="prevBtn" title="<%= t('collavre.comments.versions.previous') %>">◀</button>

--- a/engines/collavre/app/views/collavre/comments/_comment.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comment.html.erb
@@ -76,6 +76,7 @@
          data-controller="comment-version"
          data-comment-version-comment-id-value="<%= comment.id %>"
          data-comment-version-creative-id-value="<%= comment.creative_id %>"
+         data-comment-version-versions-url-value="<%= collavre.creative_comment_versions_path(comment.creative, comment) %>"
          data-comment-version-total-value="<%= comment.comment_versions.size + 1 %>"
          data-comment-version-content-target-value="<%= dom_id(comment) %>">
       <button class="comment-version-btn" data-action="click->comment-version#prev" data-comment-version-target="prevBtn" title="<%= t('collavre.comments.versions.previous') %>">◀</button>

--- a/engines/collavre/app/views/collavre/comments/_comment.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comment.html.erb
@@ -70,7 +70,22 @@
       <blockquote class="comment-quoted-text"><%= comment.quoted_text %></blockquote>
     </div>
   <% end %>
-  <div class="comment-content"><%= comment.content %></div>
+  <div class="comment-content" data-comment-target="content"><%= comment.content %></div>
+  <% if comment.comment_versions.any? %>
+    <div class="comment-version-navigator"
+         data-controller="comment-version"
+         data-comment-version-comment-id-value="<%= comment.id %>"
+         data-comment-version-creative-id-value="<%= comment.creative_id %>"
+         data-comment-version-total-value="<%= comment.comment_versions.size + 1 %>"
+         data-comment-version-content-target-value="<%= dom_id(comment) %>">
+      <button class="comment-version-btn" data-action="click->comment-version#prev" data-comment-version-target="prevBtn" title="<%= t('collavre.comments.versions.previous') %>">◀</button>
+      <span class="comment-version-indicator" data-comment-version-target="indicator">
+        v<%= comment.comment_versions.size + 1 %>/<%= comment.comment_versions.size + 1 %>
+      </span>
+      <button class="comment-version-btn" data-action="click->comment-version#next" data-comment-version-target="nextBtn" title="<%= t('collavre.comments.versions.next') %>">▶</button>
+      <button class="comment-version-delete-btn comment-version-delete-hidden" data-action="click->comment-version#deleteVersion" data-comment-version-target="deleteBtn" title="<%= t('collavre.comments.versions.delete') %>">✕</button>
+    </div>
+  <% end %>
 
 
   <% if comment.images.attached? %>

--- a/engines/collavre/app/views/collavre/comments/_comment.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comment.html.erb
@@ -91,7 +91,7 @@
       </span>
       <button class="comment-version-btn" data-action="click->comment-version#next" data-comment-version-target="nextBtn" title="<%= t('collavre.comments.versions.next') %>">▶</button>
       <button class="comment-version-select-btn" data-action="click->comment-version#selectVersion" data-comment-version-target="selectBtn" title="<%= t('collavre.comments.versions.select') %>" disabled>✓ <%= t('collavre.comments.versions.select') %></button>
-      <button class="comment-version-delete-btn" data-action="click->comment-version#deleteVersion" data-comment-version-target="deleteBtn" title="<%= t('collavre.comments.versions.delete') %>" disabled>✕</button>
+      <button class="comment-version-delete-btn" data-action="click->comment-version#deleteVersion" data-comment-version-target="deleteBtn" data-confirm-message="<%= t('collavre.comments.versions.delete_confirm') %>" title="<%= t('collavre.comments.versions.delete') %>" disabled>✕</button>
     </div>
   <% end %>
 

--- a/engines/collavre/app/views/collavre/comments/_comment.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comment.html.erb
@@ -88,8 +88,8 @@
         v<%= selected_index %>/<%= version_count + 1 %>
       </span>
       <button class="comment-version-btn" data-action="click->comment-version#next" data-comment-version-target="nextBtn" title="<%= t('collavre.comments.versions.next') %>">▶</button>
-      <button class="comment-version-select-btn comment-version-delete-hidden" data-action="click->comment-version#selectVersion" data-comment-version-target="selectBtn" title="<%= t('collavre.comments.versions.select') %>">✓ <%= t('collavre.comments.versions.select') %></button>
-      <button class="comment-version-delete-btn comment-version-delete-hidden" data-action="click->comment-version#deleteVersion" data-comment-version-target="deleteBtn" title="<%= t('collavre.comments.versions.delete') %>">✕</button>
+      <button class="comment-version-select-btn" data-action="click->comment-version#selectVersion" data-comment-version-target="selectBtn" title="<%= t('collavre.comments.versions.select') %>" disabled>✓ <%= t('collavre.comments.versions.select') %></button>
+      <button class="comment-version-delete-btn" data-action="click->comment-version#deleteVersion" data-comment-version-target="deleteBtn" title="<%= t('collavre.comments.versions.delete') %>" disabled>✕</button>
     </div>
   <% end %>
 

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -133,6 +133,11 @@ en:
         no_active_workflow: 'No active workflow found on this creative.'
         no_resumable_workflow: 'No failed or stopped workflow found to resume.'
         supervisor_instruction: "If you need clarification, have questions, or are unsure about anything, ask @%{supervisor} instead of the user. They will guide you."
+      versions:
+        previous: Previous version
+        next: Next version
+        delete: Delete this version
+        delete_confirm: Are you sure you want to delete this version?
       read_by: Read by %{name}
       activity_logs_summary: Activity Logs
     calendar_events:

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -138,6 +138,7 @@ en:
         next: Next version
         delete: Delete this version
         delete_confirm: Are you sure you want to delete this version?
+        select: Select
       read_by: Read by %{name}
       activity_logs_summary: Activity Logs
     calendar_events:

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -135,6 +135,7 @@ ko:
         next: 다음 버전
         delete: 이 버전 삭제
         delete_confirm: 이 버전을 삭제하시겠습니까?
+        select: 선택
       read_by: "%{name} 님이 읽음"
       activity_logs_summary: 활동 기록
     calendar_events:

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -130,6 +130,11 @@ ko:
         no_active_workflow: '이 크리에이티브에 활성 워크플로우가 없습니다.'
         no_resumable_workflow: '재개할 수 있는 실패/중지된 워크플로우가 없습니다.'
         supervisor_instruction: "질문이 있거나 확인이 필요하면 사용자 대신 @%{supervisor}에게 물어보세요. 감독자가 안내해줄 것입니다."
+      versions:
+        previous: 이전 버전
+        next: 다음 버전
+        delete: 이 버전 삭제
+        delete_confirm: 이 버전을 삭제하시겠습니까?
       read_by: "%{name} 님이 읽음"
       activity_logs_summary: 활동 기록
     calendar_events:

--- a/engines/collavre/config/routes.rb
+++ b/engines/collavre/config/routes.rb
@@ -69,9 +69,6 @@ Collavre::Engine.routes.draw do
         member do
           post :select
         end
-        collection do
-          post :deselect
-        end
       end
 
       collection do

--- a/engines/collavre/config/routes.rb
+++ b/engines/collavre/config/routes.rb
@@ -65,6 +65,7 @@ Collavre::Engine.routes.draw do
 
       resources :reactions, only: [ :create ], module: :comments
       resource :activity_log, only: [ :show ], module: :comments
+      resources :versions, only: [ :index, :destroy ], module: :comments
 
       collection do
         get :participants

--- a/engines/collavre/config/routes.rb
+++ b/engines/collavre/config/routes.rb
@@ -69,6 +69,9 @@ Collavre::Engine.routes.draw do
         member do
           post :select
         end
+        collection do
+          post :deselect
+        end
       end
 
       collection do

--- a/engines/collavre/config/routes.rb
+++ b/engines/collavre/config/routes.rb
@@ -65,7 +65,11 @@ Collavre::Engine.routes.draw do
 
       resources :reactions, only: [ :create ], module: :comments
       resource :activity_log, only: [ :show ], module: :comments
-      resources :versions, only: [ :index, :destroy ], module: :comments
+      resources :versions, only: [ :index, :destroy ], module: :comments do
+        member do
+          post :select
+        end
+      end
 
       collection do
         get :participants

--- a/engines/collavre/db/migrate/20260225065200_create_comment_versions.rb
+++ b/engines/collavre/db/migrate/20260225065200_create_comment_versions.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateCommentVersions < ActiveRecord::Migration[8.0]
+  def change
+    create_table :comment_versions do |t|
+      t.references :comment, null: false, foreign_key: true
+      t.text :content, null: false
+      t.integer :version_number, null: false
+      t.references :review_comment, foreign_key: { to_table: :comments }
+      t.timestamps
+    end
+    add_index :comment_versions, %i[comment_id version_number], unique: true
+  end
+end

--- a/engines/collavre/db/migrate/20260225074416_add_selected_version_id_to_comments.rb
+++ b/engines/collavre/db/migrate/20260225074416_add_selected_version_id_to_comments.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddSelectedVersionIdToComments < ActiveRecord::Migration[8.1]
+  def change
+    add_reference :comments, :selected_version, foreign_key: { to_table: :comment_versions }, null: true
+  end
+end


### PR DESCRIPTION
## Summary

When AI agents update a comment via the review workflow, previous content is now preserved as versions. Users can navigate between versions and delete individual versions.

## Changes

### Database
- New `comment_versions` table (`comment_id`, `content`, `version_number`, `review_comment_id`)
- Unique index on `[comment_id, version_number]`

### Backend
- **CommentVersion model** — belongs_to comment with validation
- **ReviewHandler** — saves old content as version before updating
- **VersionsController** — JSON index + destroy with permission checks (private comment filtering, owner/admin-only delete)
- **Comment model** — `has_many :comment_versions, dependent: :destroy`
- Eager loading added to prevent N+1 queries

### Frontend
- **Version navigator** (◀ v1/3 ▶) shown on comments with versions
- **Delete button** (✕) for individual historical versions
- **Stimulus controller** — lazy-fetches versions, client-side content swap
- i18n support (en + ko)

### Security
- Private comment filtering on version access
- Owner/admin permission check on version delete

## Testing
- All tests pass (39 runs, 0 failures)
- Rubocop: 0 offenses