### PR TITLE
fix: resolve FK constraint error when deleting comments

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -29,6 +29,9 @@ Rails.application.configure do
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false
 
+  # Set default host for URL generation in tests (needed when multiple engines mount at "/")
+  Rails.application.routes.default_url_options[:host] = "example.com"
+
   # Collavre uploaded files on the local file system in a temporary directory.
   config.active_storage.service = :test
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -29,9 +29,6 @@ Rails.application.configure do
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false
 
-  # Set default host for URL generation in tests (needed when multiple engines mount at "/")
-  Rails.application.routes.default_url_options[:host] = "example.com"
-
   # Collavre uploaded files on the local file system in a temporary directory.
   config.active_storage.service = :test
 

--- a/engines/collavre/app/models/collavre/comment.rb
+++ b/engines/collavre/app/models/collavre/comment.rb
@@ -18,9 +18,15 @@ module Collavre
 
     # review_type: nil = normal chat, 0 = review, 1 = question
     enum :review_type, { review: 0, question: 1 }, prefix: true
+
+    # Must run before dependent: :destroy on comment_versions to clear FK
+    before_destroy :nullify_selected_version
+
     has_many :activity_logs, class_name: "Collavre::ActivityLog", dependent: :destroy
     has_many :comment_reactions, class_name: "Collavre::CommentReaction", dependent: :destroy
     has_many :comment_versions, class_name: "Collavre::CommentVersion", dependent: :destroy
+    has_many :inbox_items, class_name: "Collavre::InboxItem", dependent: :nullify
+    has_many :quoting_comments, class_name: "Collavre::Comment", foreign_key: :quoted_comment_id, dependent: :nullify
     belongs_to :selected_version, class_name: "Collavre::CommentVersion", optional: true
 
     has_many_attached :images, dependent: :purge_later
@@ -55,6 +61,10 @@ module Collavre
     end
 
     private
+
+    def nullify_selected_version
+      update_column(:selected_version_id, nil) if selected_version_id.present?
+    end
 
     def cancel_pending_tasks
       # Cancel tasks triggered by this comment

--- a/engines/collavre/test/models/collavre/comment_destroy_fk_test.rb
+++ b/engines/collavre/test/models/collavre/comment_destroy_fk_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative "../../test_helper"
+require "test_helper"
 
 module Collavre
   class CommentDestroyFkTest < ActiveSupport::TestCase

--- a/engines/collavre/test/models/collavre/comment_destroy_fk_test.rb
+++ b/engines/collavre/test/models/collavre/comment_destroy_fk_test.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require_relative "../../test_helper"
+
+module Collavre
+  class CommentDestroyFkTest < ActiveSupport::TestCase
+    setup do
+      @user = users(:one)
+      @creative = Collavre::Creative.create!(description: "test", progress: 0.0, user: @user)
+      Collavre::Current.user = @user
+    end
+
+    test "destroying comment nullifies inbox_items comment_id" do
+      comment = Collavre::Comment.create!(creative: @creative, content: "test", user: @user)
+      inbox_item = Collavre::InboxItem.create!(
+        owner: @user, creative: @creative, comment: comment,
+        message_key: "inbox.test", link: "/test"
+      )
+
+      comment.destroy!
+
+      inbox_item.reload
+      assert_nil inbox_item.comment_id
+    end
+
+    test "destroying comment nullifies quoted_comment_id on quoting comments" do
+      original = Collavre::Comment.create!(creative: @creative, content: "original", user: @user)
+      quoting = Collavre::Comment.create!(creative: @creative, content: "reply", user: @user, quoted_comment_id: original.id)
+
+      original.destroy!
+
+      quoting.reload
+      assert_nil quoting.quoted_comment_id
+    end
+
+    test "destroying comment with selected_version succeeds" do
+      comment = Collavre::Comment.create!(creative: @creative, content: "test", user: @user)
+      version = Collavre::CommentVersion.create!(
+        comment: comment, content: "v1", version_number: 1
+      )
+      comment.update_column(:selected_version_id, version.id)
+
+      assert_nothing_raised { comment.destroy! }
+      assert_not Collavre::CommentVersion.exists?(version.id)
+    end
+  end
+end


### PR DESCRIPTION
## Problem
Deleting a comment in production fails with `ActiveRecord::InvalidForeignKey: SQLite3::ConstraintException: FOREIGN KEY constraint failed`.

## Root Cause
The `inbox_items` table has a `comment_id` FK without `ON DELETE SET NULL` at the DB level (migration specified `on_delete: :nullify` but SQLite didn't apply it). Additionally, `quoted_comment_id` and `selected_version_id` FKs could also block deletion.

## Fix
- Add `has_many :inbox_items, dependent: :nullify` — Rails-level nullification before destroy
- Add `has_many :quoting_comments, dependent: :nullify` — clear quoted_comment_id references
- Add `before_destroy :nullify_selected_version` — clear selected_version_id FK before comment_versions are destroyed (declared before `has_many :comment_versions` to ensure callback order)

## Tests
3 new tests covering all FK scenarios.