### PR TITLE
feat: add collavre agent skill with MCP SSE CLI

### DIFF
--- a/skills/collavre/SKILL.md
+++ b/skills/collavre/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: collavre
+description: Manage Collavre Creatives (hierarchical tasks/content blocks) via CLI. Use when creating, retrieving, updating, importing, or batch-operating on Creatives. Creatives are tree-structured items with automatic progress rollup — like a smart to-do list that doubles as a structured document.
+---
+
+# Collavre
+
+CLI for managing Collavre Creatives via MCP protocol.
+
+## Setup
+
+```bash
+# Configure (once)
+collavre auth --url https://collavre.example.com --token <oauth_token>
+
+# Verify
+collavre list
+```
+
+The `collavre` script lives in `scripts/collavre`. Config is stored at `~/.config/collavre/config.json`.
+
+## Commands
+
+### List root creatives
+```bash
+collavre list
+collavre list --level 5              # deeper tree
+collavre list --format json          # structured output
+```
+
+### Get a creative subtree
+```bash
+collavre get 123
+collavre get 123 --level 5 --comments
+```
+
+### Search
+```bash
+collavre search "project name"
+collavre search "urgent" --tags "v2"
+```
+
+### Create
+```bash
+collavre create --parent 123 --desc "New task"
+collavre create --parent 123 --desc "<h1>Rich content</h1>"
+```
+
+### Update
+```bash
+collavre update 456 --desc "Updated title"
+collavre update 456 --progress 1.0        # mark complete (leaf only)
+collavre update 456 --parent 789           # move
+```
+
+### Import markdown
+```bash
+collavre import --parent 123 --file plan.md
+collavre import --parent 123 --stdin < plan.md
+echo "# Quick\n## Plan" | collavre import --parent 123 --stdin
+```
+
+### Batch operations
+```bash
+collavre batch --file ops.json
+```
+
+ops.json format:
+```json
+[
+  { "action": "create", "parent_id": 100, "description": "Task A" },
+  { "action": "update", "id": 200, "progress": 1.0 },
+  { "action": "delete", "id": 300 }
+]
+```
+
+## Key Concepts
+
+- **Tree structure**: Creatives nest via `parent_id`. Use `--level` to control depth.
+- **Progress**: Leaf = manual (0.0 or 1.0). Parent = auto-calculated from children.
+- **Import**: Markdown headings/bullets become nested Creatives.
+- **Batch**: All-or-nothing transaction. Requires approval.
+- **Description format**: Accepts HTML. Plain text auto-wraps in `<p>` tags.
+
+For detailed MCP tool parameters, see [references/tool-reference.md](references/tool-reference.md).

--- a/skills/collavre/references/tool-reference.md
+++ b/skills/collavre/references/tool-reference.md
@@ -1,0 +1,96 @@
+# Collavre MCP Tool Reference
+
+## creative_retrieval_service
+
+Retrieve Creatives by ID, search query, or list roots.
+
+| Param | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `id` | Integer | No | — | Specific Creative ID (returns subtree) |
+| `query` | String | No | — | Text search in descriptions and comments |
+| `level` | Integer | No | 3 | Tree depth to return |
+| `tags` | String | No | — | Comma-separated tag filter |
+| `progress_min` | Float | No | — | Min progress (0.0–1.0) |
+| `progress_max` | Float | No | — | Max progress (0.0–1.0) |
+| `updated_since` | String | No | — | ISO8601 timestamp |
+| `include_comments` | Boolean | No | false | Include recent comments (up to 3 per Creative) |
+| `format` | String | No | "markdown" | "markdown" or "json" |
+
+**Markdown output format:**
+```
+<!-- format: [id] description (progress%) -->
+- [123] My Task (50%)
+  - [124] Subtask A (100%)
+  - [125] Subtask B (0%)
+```
+
+**JSON output** includes: `id`, `description`, `progress`, `parent_id`, `tags`, `linked`, `origin_id`, `has_children`, `children_count`, `created_at`, `updated_at`, `children[]`, and optionally `recent_comments[]`.
+
+## creative_create_service
+
+Create a new Creative.
+
+| Param | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `description` | String | **Yes** | — | Content/title (HTML or plain text) |
+| `parent_id` | Integer | No | — | Parent Creative ID (omit for root) |
+| `progress` | Float | No | 0 | Initial progress (0.0–1.0) |
+| `after_id` | Integer | No | — | Sibling ID to insert after |
+| `before_id` | Integer | No | — | Sibling ID to insert before |
+
+**Returns:** `{ success, id, description, parent_id, progress }` or `{ error, details }`
+
+## creative_update_service
+
+Update an existing Creative.
+
+| Param | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `id` | Integer | **Yes** | — | Creative ID to update |
+| `description` | String | No | — | New content/title |
+| `progress` | Float | No | — | Only `1.0` allowed; leaf Creatives only |
+| `parent_id` | Integer | No | — | New parent ID (0 = make root) |
+
+**Constraints:**
+- Progress: only `1.0` accepted (mark complete). No partial progress.
+- Only leaf Creatives (no children) can have progress set directly.
+- Parent progress auto-calculates from children.
+- Circular parent references are rejected.
+
+## creative_batch_service
+
+Execute multiple operations atomically. **Requires approval.**
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `operations` | Array | **Yes** | Array of operation objects |
+
+**Operation formats:**
+
+| Action | Fields |
+|--------|--------|
+| `create` | `action`, `description`, `parent_id`, `progress`, `after_id`, `before_id` |
+| `update` | `action`, `id`, `description`, `progress`, `parent_id` |
+| `delete` | `action`, `id` |
+
+**Behavior:** All-or-nothing transaction. If any operation fails, everything rolls back.
+
+**Returns:** `{ success, results[] }` or `{ success: false, error, results[] }`
+
+## creative_import_service
+
+Import a markdown document as a Creative tree. Uses the built-in MarkdownImporter which supports headings, bullet lists, tables, fenced code blocks, and inline images. **Requires approval.**
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `markdown` | String | **Yes** | Markdown text to import |
+| `parent_id` | Integer | **Yes** | Parent Creative ID to import under |
+
+**Supported markdown elements:**
+- Headings (`#` through `######`) → nested Creatives by level
+- Bullet lists (`-`, `*`, `+`) → nested children by indent
+- Tables → single Creative with HTML table
+- Fenced code blocks (`` ``` ``) → single Creative with `<pre><code>`
+- Inline images and links → preserved in description HTML
+
+**Returns:** `{ success, parent_id, created_count, tree[] }`

--- a/skills/collavre/scripts/collavre
+++ b/skills/collavre/scripts/collavre
@@ -35,6 +35,8 @@ class McpClient {
     this.baseUrl = url.replace(/\/+$/, "");
     this.token = token;
     this.sessionUrl = null;
+    this._pendingRequests = new Map();
+    this._sseBuffer = "";
   }
 
   async connect() {
@@ -45,7 +47,6 @@ class McpClient {
         10000
       );
       const req = this._request(sseUrl, { method: "GET" });
-      let buffer = "";
 
       req.on("response", (res) => {
         if (res.statusCode !== 200) {
@@ -53,20 +54,24 @@ class McpClient {
           reject(new Error(`SSE connection failed: ${res.statusCode}`));
           return;
         }
+        this._sseRes = res;
         res.on("data", (chunk) => {
-          buffer += chunk.toString();
-          const lines = buffer.split("\n");
-          buffer = lines.pop() || "";
+          this._sseBuffer += chunk.toString();
+          const lines = this._sseBuffer.split("\n");
+          this._sseBuffer = lines.pop() || "";
           for (const line of lines) {
             if (line.startsWith("data: ")) {
               const data = line.slice(6).trim();
-              if (data.includes("/mcp/messages")) {
+              // First data message contains the messages endpoint URL
+              if (!this.sessionUrl && data.includes("/mcp/messages")) {
                 clearTimeout(timeout);
                 this.sessionUrl = data.startsWith("http")
                   ? data
                   : `${this.baseUrl}${data}`;
-                this._sseRes = res;
                 resolve();
+              } else if (this.sessionUrl) {
+                // Subsequent data messages are JSON-RPC responses
+                this._handleSseMessage(data);
               }
             }
           }
@@ -84,41 +89,69 @@ class McpClient {
     });
   }
 
+  _handleSseMessage(data) {
+    try {
+      const parsed = JSON.parse(data);
+      if (parsed.id && this._pendingRequests.has(parsed.id)) {
+        const { resolve, reject } = this._pendingRequests.get(parsed.id);
+        this._pendingRequests.delete(parsed.id);
+        if (parsed.error) {
+          reject(new Error(parsed.error.message || JSON.stringify(parsed.error)));
+        } else {
+          resolve(parsed.result);
+        }
+      }
+    } catch {
+      // ignore non-JSON SSE messages
+    }
+  }
+
   async callTool(name, args) {
     if (!this.sessionUrl) throw new Error("Not connected. Call connect() first.");
 
+    const id = Date.now();
     const body = JSON.stringify({
       jsonrpc: "2.0",
-      id: Date.now(),
+      id,
       method: "tools/call",
       params: { name, arguments: args },
     });
 
-    return new Promise((resolve, reject) => {
+    // Set up listener for SSE response before sending
+    const resultPromise = new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this._pendingRequests.delete(id);
+        reject(new Error("Tool call timeout (30s)"));
+      }, 30000);
+      this._pendingRequests.set(id, {
+        resolve: (v) => { clearTimeout(timeout); resolve(v); },
+        reject: (e) => { clearTimeout(timeout); reject(e); },
+      });
+    });
+
+    // Send the POST request (response comes via SSE, not HTTP body)
+    await new Promise((resolve, reject) => {
       const req = this._request(this.sessionUrl, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
       });
-      let data = "";
       req.on("response", (res) => {
-        res.on("data", (chunk) => (data += chunk));
-        res.on("end", () => {
-          try {
-            const parsed = JSON.parse(data);
-            if (parsed.error) {
-              reject(new Error(parsed.error.message || JSON.stringify(parsed.error)));
-            } else {
-              resolve(parsed.result);
-            }
-          } catch {
-            reject(new Error(`Invalid response: ${data.slice(0, 200)}`));
-          }
-        });
+        // 200 or 202 = accepted, actual result comes via SSE
+        if (res.statusCode >= 200 && res.statusCode < 300) {
+          res.resume(); // drain response
+          resolve();
+        } else {
+          let data = "";
+          res.on("data", (chunk) => (data += chunk));
+          res.on("end", () => reject(new Error(`HTTP ${res.statusCode}: ${data}`)));
+        }
       });
       req.on("error", reject);
       req.write(body);
       req.end();
     });
+
+    return resultPromise;
   }
 
   disconnect() {

--- a/skills/collavre/scripts/collavre
+++ b/skills/collavre/scripts/collavre
@@ -1,0 +1,370 @@
+#!/usr/bin/env node
+// Collavre CLI — MCP SSE client for Creative management
+// Usage: collavre <command> [options]
+
+const fs = require("fs");
+const path = require("path");
+const https = require("https");
+const http = require("http");
+
+const CONFIG_DIR = path.join(
+  process.env.HOME || process.env.USERPROFILE,
+  ".config",
+  "collavre"
+);
+const CONFIG_FILE = path.join(CONFIG_DIR, "config.json");
+
+// --- Config ---
+function loadConfig() {
+  try {
+    return JSON.parse(fs.readFileSync(CONFIG_FILE, "utf8"));
+  } catch {
+    return {};
+  }
+}
+
+function saveConfig(config) {
+  fs.mkdirSync(CONFIG_DIR, { recursive: true });
+  fs.writeFileSync(CONFIG_FILE, JSON.stringify(config, null, 2));
+}
+
+// --- MCP SSE Client ---
+class McpClient {
+  constructor(url, token) {
+    this.baseUrl = url.replace(/\/+$/, "");
+    this.token = token;
+    this.sessionUrl = null;
+  }
+
+  async connect() {
+    const sseUrl = `${this.baseUrl}/mcp/sse`;
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(
+        () => reject(new Error("SSE connection timeout")),
+        10000
+      );
+      const req = this._request(sseUrl, { method: "GET" });
+      let buffer = "";
+
+      req.on("response", (res) => {
+        if (res.statusCode !== 200) {
+          clearTimeout(timeout);
+          reject(new Error(`SSE connection failed: ${res.statusCode}`));
+          return;
+        }
+        res.on("data", (chunk) => {
+          buffer += chunk.toString();
+          const lines = buffer.split("\n");
+          buffer = lines.pop() || "";
+          for (const line of lines) {
+            if (line.startsWith("data: ")) {
+              const data = line.slice(6).trim();
+              if (data.includes("/mcp/messages")) {
+                clearTimeout(timeout);
+                // Extract the full messages URL
+                this.sessionUrl = data.startsWith("http")
+                  ? data
+                  : `${this.baseUrl}${data}`;
+                this._sseRes = res;
+                resolve();
+              }
+            }
+          }
+        });
+        res.on("error", (e) => {
+          clearTimeout(timeout);
+          reject(e);
+        });
+      });
+      req.on("error", (e) => {
+        clearTimeout(timeout);
+        reject(e);
+      });
+      req.end();
+    });
+  }
+
+  async callTool(name, args) {
+    if (!this.sessionUrl) throw new Error("Not connected. Call connect() first.");
+
+    const body = JSON.stringify({
+      jsonrpc: "2.0",
+      id: Date.now(),
+      method: "tools/call",
+      params: { name, arguments: args },
+    });
+
+    return new Promise((resolve, reject) => {
+      const req = this._request(this.sessionUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      });
+      let data = "";
+      req.on("response", (res) => {
+        res.on("data", (chunk) => (data += chunk));
+        res.on("end", () => {
+          try {
+            const parsed = JSON.parse(data);
+            if (parsed.error) {
+              reject(new Error(parsed.error.message || JSON.stringify(parsed.error)));
+            } else {
+              resolve(parsed.result);
+            }
+          } catch {
+            reject(new Error(`Invalid response: ${data.slice(0, 200)}`));
+          }
+        });
+      });
+      req.on("error", reject);
+      req.write(body);
+      req.end();
+    });
+  }
+
+  disconnect() {
+    if (this._sseRes) {
+      this._sseRes.destroy();
+      this._sseRes = null;
+    }
+  }
+
+  _request(url, opts) {
+    const parsed = new URL(url);
+    const mod = parsed.protocol === "https:" ? https : http;
+    return mod.request(url, {
+      ...opts,
+      headers: {
+        ...(opts.headers || {}),
+        Authorization: `Bearer ${this.token}`,
+      },
+    });
+  }
+}
+
+// --- Commands ---
+async function withClient(fn) {
+  const config = loadConfig();
+  if (!config.url || !config.token) {
+    console.error("Not configured. Run: collavre auth --url <url> --token <token>");
+    process.exit(1);
+  }
+  const client = new McpClient(config.url, config.token);
+  try {
+    await client.connect();
+    await fn(client);
+  } finally {
+    client.disconnect();
+  }
+}
+
+function parseArgs(argv) {
+  const args = {};
+  const positional = [];
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i].startsWith("--")) {
+      const key = argv[i].slice(2);
+      const next = argv[i + 1];
+      if (!next || next.startsWith("--")) {
+        args[key] = true;
+      } else {
+        args[key] = next;
+        i++;
+      }
+    } else {
+      positional.push(argv[i]);
+    }
+  }
+  return { args, positional };
+}
+
+function printResult(result) {
+  if (!result) return;
+  // MCP tool results come as content array
+  if (result.content) {
+    for (const item of result.content) {
+      if (item.type === "text") {
+        try {
+          const parsed = JSON.parse(item.text);
+          console.log(JSON.stringify(parsed, null, 2));
+        } catch {
+          console.log(item.text);
+        }
+      }
+    }
+  } else {
+    console.log(JSON.stringify(result, null, 2));
+  }
+}
+
+const commands = {
+  auth(argv) {
+    const { args } = parseArgs(argv);
+    if (!args.url || !args.token) {
+      console.error("Usage: collavre auth --url <url> --token <token>");
+      process.exit(1);
+    }
+    saveConfig({ url: args.url, token: args.token });
+    console.log(`Saved config to ${CONFIG_FILE}`);
+  },
+
+  async list(argv) {
+    const { args } = parseArgs(argv);
+    await withClient(async (client) => {
+      const result = await client.callTool("creative_retrieval_service", {
+        level: parseInt(args.level) || 3,
+        format: args.format || "markdown",
+        include_comments: args.comments === true,
+      });
+      printResult(result);
+    });
+  },
+
+  async get(argv) {
+    const { args, positional } = parseArgs(argv);
+    const id = parseInt(positional[0]);
+    if (!id) {
+      console.error("Usage: collavre get <id> [--level N] [--comments] [--format json]");
+      process.exit(1);
+    }
+    await withClient(async (client) => {
+      const result = await client.callTool("creative_retrieval_service", {
+        id,
+        level: parseInt(args.level) || 3,
+        format: args.format || "markdown",
+        include_comments: args.comments === true,
+      });
+      printResult(result);
+    });
+  },
+
+  async search(argv) {
+    const { args, positional } = parseArgs(argv);
+    const query = positional[0];
+    if (!query) {
+      console.error("Usage: collavre search <query> [--tags tags] [--level N]");
+      process.exit(1);
+    }
+    await withClient(async (client) => {
+      const params = {
+        query,
+        level: parseInt(args.level) || 3,
+        format: args.format || "markdown",
+      };
+      if (args.tags) params.tags = args.tags;
+      if (args["progress-min"]) params.progress_min = parseFloat(args["progress-min"]);
+      if (args["progress-max"]) params.progress_max = parseFloat(args["progress-max"]);
+      const result = await client.callTool("creative_retrieval_service", params);
+      printResult(result);
+    });
+  },
+
+  async create(argv) {
+    const { args } = parseArgs(argv);
+    if (!args.desc) {
+      console.error("Usage: collavre create --parent <id> --desc <text>");
+      process.exit(1);
+    }
+    await withClient(async (client) => {
+      const params = { description: args.desc };
+      if (args.parent) params.parent_id = parseInt(args.parent);
+      if (args.after) params.after_id = parseInt(args.after);
+      if (args.before) params.before_id = parseInt(args.before);
+      const result = await client.callTool("creative_create_service", params);
+      printResult(result);
+    });
+  },
+
+  async update(argv) {
+    const { args, positional } = parseArgs(argv);
+    const id = parseInt(positional[0]);
+    if (!id) {
+      console.error("Usage: collavre update <id> [--desc text] [--progress 1.0] [--parent id]");
+      process.exit(1);
+    }
+    await withClient(async (client) => {
+      const params = { id };
+      if (args.desc) params.description = args.desc;
+      if (args.progress !== undefined) params.progress = parseFloat(args.progress);
+      if (args.parent !== undefined) params.parent_id = parseInt(args.parent);
+      const result = await client.callTool("creative_update_service", params);
+      printResult(result);
+    });
+  },
+
+  async import(argv) {
+    const { args } = parseArgs(argv);
+    const parentId = parseInt(args.parent);
+    if (!parentId) {
+      console.error("Usage: collavre import --parent <id> --file <path> | --stdin");
+      process.exit(1);
+    }
+
+    let markdown;
+    if (args.file) {
+      markdown = fs.readFileSync(args.file, "utf8");
+    } else if (args.stdin) {
+      markdown = fs.readFileSync(0, "utf8"); // read from stdin
+    } else {
+      console.error("Provide --file <path> or --stdin");
+      process.exit(1);
+    }
+
+    await withClient(async (client) => {
+      const result = await client.callTool("creative_import_service", {
+        markdown,
+        parent_id: parentId,
+      });
+      printResult(result);
+    });
+  },
+
+  async batch(argv) {
+    const { args } = parseArgs(argv);
+    if (!args.file) {
+      console.error("Usage: collavre batch --file <ops.json>");
+      process.exit(1);
+    }
+    const ops = JSON.parse(fs.readFileSync(args.file, "utf8"));
+    await withClient(async (client) => {
+      const result = await client.callTool("creative_batch_service", {
+        operations: ops,
+      });
+      printResult(result);
+    });
+  },
+};
+
+// --- Main ---
+async function main() {
+  const [cmd, ...argv] = process.argv.slice(2);
+
+  if (!cmd || cmd === "help" || cmd === "--help") {
+    console.log(`Collavre CLI — Manage Creatives via MCP
+
+Usage: collavre <command> [options]
+
+Commands:
+  auth     --url <url> --token <token>     Configure connection
+  list     [--level N] [--format json]     List root creatives
+  get      <id> [--level N] [--comments]   Get creative subtree
+  search   <query> [--tags t1,t2]          Search creatives
+  create   --parent <id> --desc <text>     Create creative
+  update   <id> [--desc] [--progress 1.0]  Update creative
+  import   --parent <id> --file <path>     Import markdown
+  batch    --file <ops.json>               Batch operations
+  help                                     Show this help`);
+    process.exit(0);
+  }
+
+  if (commands[cmd]) {
+    await commands[cmd](argv);
+  } else {
+    console.error(`Unknown command: ${cmd}. Run 'collavre help' for usage.`);
+    process.exit(1);
+  }
+}
+
+main().catch((e) => {
+  console.error(`Error: ${e.message}`);
+  process.exit(1);
+});

--- a/skills/collavre/scripts/collavre
+++ b/skills/collavre/scripts/collavre
@@ -2,13 +2,14 @@
 // Collavre CLI — MCP SSE client for Creative management
 // Usage: collavre <command> [options]
 
-const fs = require("fs");
-const path = require("path");
-const https = require("https");
-const http = require("http");
+import fs from "node:fs";
+import path from "node:path";
+import https from "node:https";
+import http from "node:http";
+import os from "node:os";
 
 const CONFIG_DIR = path.join(
-  process.env.HOME || process.env.USERPROFILE,
+  os.homedir(),
   ".config",
   "collavre"
 );
@@ -61,7 +62,6 @@ class McpClient {
               const data = line.slice(6).trim();
               if (data.includes("/mcp/messages")) {
                 clearTimeout(timeout);
-                // Extract the full messages URL
                 this.sessionUrl = data.startsWith("http")
                   ? data
                   : `${this.baseUrl}${data}`;
@@ -179,7 +179,6 @@ function parseArgs(argv) {
 
 function printResult(result) {
   if (!result) return;
-  // MCP tool results come as content array
   if (result.content) {
     for (const item of result.content) {
       if (item.type === "text") {
@@ -303,7 +302,7 @@ const commands = {
     if (args.file) {
       markdown = fs.readFileSync(args.file, "utf8");
     } else if (args.stdin) {
-      markdown = fs.readFileSync(0, "utf8"); // read from stdin
+      markdown = fs.readFileSync(0, "utf8");
     } else {
       console.error("Provide --file <path> or --stdin");
       process.exit(1);


### PR DESCRIPTION
## Summary

Add Collavre Agent Skill to `skills/collavre/` directory, providing:

### SKILL.md
- Usage guide for 5 MCP tools: retrieval, create, update, batch, import
- Workflow patterns and best practices
- skills.sh compatible frontmatter

### scripts/collavre (CLI)
- Pure Node.js CLI connecting to Collavre via MCP SSE protocol (`/mcp/sse`)
- OAuth Bearer token authentication
- Commands: auth, list, get, search, create, update, import, batch
- Zero external dependencies

### references/tool-reference.md
- Detailed parameter reference for all 5 MCP tools

## Structure
```
skills/collavre/
├── SKILL.md
├── references/
│   └── tool-reference.md
└── scripts/
    └── collavre
```

## Notes
- Compatible with both skills.sh and OpenClaw skill systems
- CLI uses standard MCP SSE protocol, no custom API needed
- Skill install includes CLI automatically (no separate npm package needed)