### PR TITLE
feat: add /compress command to summarize and clean topic messages

### DIFF
--- a/engines/collavre/app/jobs/collavre/compress_job.rb
+++ b/engines/collavre/app/jobs/collavre/compress_job.rb
@@ -1,0 +1,90 @@
+module Collavre
+  class CompressJob < ApplicationJob
+    queue_as :default
+
+    def perform(creative_id, topic_id, user_id, extra_prompt = nil)
+      creative = Creative.find(creative_id)
+      topic = Topic.find(topic_id)
+      user = User.find(user_id)
+
+      # Collect all comments in topic (chronological)
+      comments = creative.comments
+        .where(topic_id: topic_id)
+        .order(created_at: :asc)
+        .includes(:user)
+
+      return if comments.size <= 1
+
+      # Build conversation text
+      conversation = comments.map do |c|
+        author = c.user&.name || I18n.t("collavre.comments.anonymous")
+        "#{author}: #{c.content}"
+      end.join("\n\n")
+
+      # Build AI prompt
+      system_prompt = Comments::CompressCommand::SYSTEM_PROMPT.dup
+      if extra_prompt.present?
+        system_prompt += "\n\nAdditional instruction from the user: #{extra_prompt}"
+      end
+
+      # Find an AI agent on this creative, or use default config
+      agent = find_ai_agent(creative)
+
+      client = AiClient.new(
+        vendor: agent&.llm_vendor || default_vendor,
+        model: agent&.llm_model || default_model,
+        system_prompt: system_prompt,
+        llm_api_key: agent&.llm_api_key || agent&.creator&.llm_api_key
+      )
+
+      summary = +""
+      client.chat([ { role: "user", content: conversation } ]) do |delta|
+        summary << delta
+      end
+
+      if summary.blank?
+        Rails.logger.error("[CompressJob] AI returned empty summary for topic #{topic_id}")
+        return
+      end
+
+      # Create summary comment
+      topic_name = topic.name.presence || "Topic"
+      title = I18n.t("collavre.comments.compress_command.summary_title", topic: topic_name)
+      summary_content = "**#{title}**\n\n#{summary}"
+
+      # Store comment IDs to delete before creating the new one
+      comment_ids_to_delete = comments.pluck(:id)
+
+      # Create the summary comment in the same topic
+      summary_comment = creative.comments.create!(
+        user: user,
+        topic_id: topic_id,
+        content: summary_content
+      )
+
+      # Delete original comments (excluding the newly created summary)
+      creative.comments.where(id: comment_ids_to_delete).find_each do |c|
+        c.destroy
+      end
+    rescue StandardError => e
+      Rails.logger.error("[CompressJob] Failed: #{e.message}\n#{e.backtrace&.first(5)&.join("\n")}")
+    end
+
+    private
+
+    def find_ai_agent(creative)
+      # Look for an AI agent with access to this creative
+      creative.effective_origin.all_shared_users(:feedback)
+        .map(&:user)
+        .find(&:ai_user?)
+    end
+
+    def default_vendor
+      "google"
+    end
+
+    def default_model
+      "gemini-2.5-flash"
+    end
+  end
+end

--- a/engines/collavre/app/jobs/collavre/compress_job.rb
+++ b/engines/collavre/app/jobs/collavre/compress_job.rb
@@ -7,16 +7,20 @@ module Collavre
       topic = Topic.find(topic_id)
       user = User.find(user_id)
 
-      # Collect all comments in topic (chronological)
-      comments = creative.comments
+      # Collect all comments in topic (chronological), excluding /compress command
+      all_comments = creative.comments
         .where(topic_id: topic_id)
         .order(created_at: :asc)
         .includes(:user)
 
-      return if comments.size <= 1
+      # Separate: comments to summarize vs the compress command itself
+      compress_pattern = /\A\/compress\b/i
+      target_comments = all_comments.reject { |c| c.content.to_s.strip.match?(compress_pattern) }
+
+      return if target_comments.size <= 1
 
       # Build conversation text
-      conversation = comments.map do |c|
+      conversation = target_comments.map do |c|
         author = c.user&.name || I18n.t("collavre.comments.anonymous")
         "#{author}: #{c.content}"
       end.join("\n\n")
@@ -52,8 +56,8 @@ module Collavre
       title = I18n.t("collavre.comments.compress_command.summary_title", topic: topic_name)
       summary_content = "**#{title}**\n\n#{summary}"
 
-      # Store comment IDs to delete before creating the new one
-      comment_ids_to_delete = comments.pluck(:id)
+      # Store comment IDs to delete before creating the new one (all originals including /compress command)
+      comment_ids_to_delete = all_comments.pluck(:id)
 
       # Create the summary comment in the same topic
       summary_comment = creative.comments.create!(

--- a/engines/collavre/app/jobs/collavre/compress_job.rb
+++ b/engines/collavre/app/jobs/collavre/compress_job.rb
@@ -42,7 +42,7 @@ module Collavre
       )
 
       summary = +""
-      client.chat([ { role: "user", content: conversation } ]) do |delta|
+      client.chat([ { role: "user", text: conversation } ]) do |delta|
         summary << delta
       end
 

--- a/engines/collavre/app/jobs/collavre/compress_job.rb
+++ b/engines/collavre/app/jobs/collavre/compress_job.rb
@@ -17,7 +17,7 @@ module Collavre
       compress_pattern = /\A\/compress\b/i
       target_comments = all_comments.reject { |c| c.content.to_s.strip.match?(compress_pattern) }
 
-      return if target_comments.size <= 1
+      return if target_comments.size < 2
 
       # Build conversation text
       conversation = target_comments.map do |c|
@@ -41,7 +41,7 @@ module Collavre
         llm_api_key: agent&.llm_api_key || agent&.creator&.llm_api_key
       )
 
-      summary = +""
+      summary = String.new
       client.chat([ { role: "user", text: conversation } ]) do |delta|
         summary << delta
       end
@@ -67,11 +67,9 @@ module Collavre
       )
 
       # Delete original comments (excluding the newly created summary)
-      creative.comments.where(id: comment_ids_to_delete).find_each do |c|
-        c.destroy
-      end
-    rescue StandardError => e
-      Rails.logger.error("[CompressJob] Failed: #{e.message}\n#{e.backtrace&.first(5)&.join("\n")}")
+      creative.comments.where(id: comment_ids_to_delete).destroy_all
+    rescue ActiveRecord::RecordNotFound => e
+      Rails.logger.error("[CompressJob] Record not found: #{e.message}")
     end
 
     private

--- a/engines/collavre/app/services/collavre/command_menu_service.rb
+++ b/engines/collavre/app/services/collavre/command_menu_service.rb
@@ -32,6 +32,12 @@ module Collavre
           label: "/work",
           description: I18n.t("collavre.comments.command_menu.work_description"),
           args: I18n.t("collavre.comments.command_menu.work_args")
+        },
+        {
+          name: "compress",
+          label: "/compress",
+          description: I18n.t("collavre.comments.command_menu.compress_description"),
+          args: I18n.t("collavre.comments.command_menu.compress_args")
         }
       ]
     end

--- a/engines/collavre/app/services/collavre/comments/command_processor.rb
+++ b/engines/collavre/app/services/collavre/comments/command_processor.rb
@@ -29,7 +29,8 @@ module Collavre
         [
           Collavre::Comments::CalendarCommand.new(comment: comment, user: user),
           Collavre::Comments::TopicCommand.new(comment: comment, user: user),
-          Collavre::Comments::WorkCommand.new(comment: comment, user: user)
+          Collavre::Comments::WorkCommand.new(comment: comment, user: user),
+          Collavre::Comments::CompressCommand.new(comment: comment, user: user)
         ]
       end
 

--- a/engines/collavre/app/services/collavre/comments/compress_command.rb
+++ b/engines/collavre/app/services/collavre/comments/compress_command.rb
@@ -1,0 +1,65 @@
+module Collavre
+  module Comments
+    class CompressCommand
+      COMMAND_PATTERN = /\A\/compress\b/i.freeze
+
+      SYSTEM_PROMPT = <<~PROMPT.freeze
+        You are summarizing a conversation thread in a project management tool.
+        Preserve key decisions, action items, important context, and any conclusions.
+        Be concise but thorough. Respond in the same language as the conversation.
+        Use markdown formatting for readability.
+      PROMPT
+
+      def initialize(comment:, user:)
+        @comment = comment
+        @user = user
+        @creative = comment.creative
+      end
+
+      def call
+        return unless compress_command?
+
+        validate!
+        enqueue_compress_job
+      rescue StandardError => e
+        Rails.logger.error("Compress command failed: #{e.message}")
+        e.message
+      end
+
+      private
+
+      attr_reader :comment, :user, :creative
+
+      def compress_command?
+        comment.content.to_s.strip.match?(COMMAND_PATTERN)
+      end
+
+      def extra_prompt
+        content = comment.content.to_s.strip
+        rest = content.sub(COMMAND_PATTERN, "").strip
+        rest.presence
+      end
+
+      def validate!
+        unless comment.topic_id.present?
+          raise I18n.t("collavre.comments.compress_command.topic_required")
+        end
+
+        topic_comments = creative.comments.where(topic_id: comment.topic_id)
+        if topic_comments.count <= 1 # only the /compress command itself
+          raise I18n.t("collavre.comments.compress_command.nothing_to_compress")
+        end
+      end
+
+      def enqueue_compress_job
+        CompressJob.perform_later(
+          creative.id,
+          comment.topic_id,
+          user.id,
+          extra_prompt
+        )
+        I18n.t("collavre.comments.compress_command.started")
+      end
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/comments/compress_command.rb
+++ b/engines/collavre/app/services/collavre/comments/compress_command.rb
@@ -20,6 +20,7 @@ module Collavre
         return unless compress_command?
 
         validate!
+        authorize!
         enqueue_compress_job
       rescue StandardError => e
         Rails.logger.error("Compress command failed: #{e.message}")
@@ -45,9 +46,18 @@ module Collavre
           raise I18n.t("collavre.comments.compress_command.topic_required")
         end
 
-        topic_comments = creative.comments.where(topic_id: comment.topic_id)
-        if topic_comments.count <= 1 # only the /compress command itself
+        # The /compress command comment may not be saved yet, so count existing non-compress comments
+        compress_pattern = /\A\/compress\b/i
+        existing_count = creative.comments.where(topic_id: comment.topic_id)
+          .reject { |c| c.content.to_s.strip.match?(compress_pattern) }.size
+        if existing_count < 2
           raise I18n.t("collavre.comments.compress_command.nothing_to_compress")
+        end
+      end
+
+      def authorize!
+        unless creative.has_permission?(user, :write)
+          raise I18n.t("collavre.comments.compress_command.not_authorized")
         end
       end
 

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -113,6 +113,7 @@ en:
       mcp_command:
         error_running: "Error running /%{tool_name}: %{error}"
       compress_command:
+        not_authorized: "You need write permission to compress a topic."
         topic_required: "The /compress command can only be used within a topic."
         nothing_to_compress: "No messages to compress in this topic."
         started: "⏳ Compressing topic messages..."

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -104,12 +104,20 @@ en:
         topic_args: '"topic name" @agent_name'
         work_description: "Create a workflow to execute tasks on child creatives via DFS traversal."
         work_args: "@agent_name workflow_context"
+        compress_description: "Summarize all messages in the current topic and remove originals."
+        compress_args: "[additional instructions]"
       calendar_command:
         event_created: 'event created: [Google Calendar event](%{url})'
         event_created_local: 'event created (local only - connect Google Calendar to sync)'
         event_created_sync_failed: 'event created (Google Calendar sync failed - please reconnect your Google account)'
       mcp_command:
         error_running: "Error running /%{tool_name}: %{error}"
+      compress_command:
+        topic_required: "The /compress command can only be used within a topic."
+        nothing_to_compress: "No messages to compress in this topic."
+        started: "⏳ Compressing topic messages..."
+        summary_title: "Topic Summary — %{topic}"
+        failed: "Compress failed"
       topic_command:
         missing_name: 'Please specify a topic name in quotes: /topic "topic name"'
         created: 'Topic "%{name}" created.'

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -101,12 +101,20 @@ ko:
         topic_args: '"토픽 이름" @에이전트이름'
         work_description: "하위 크리에이티브들에 대해 DFS 순회를 통한 워크플로우를 실행합니다."
         work_args: "@에이전트이름 워크플로우_컨텍스트"
+        compress_description: "현재 토픽의 모든 메세지를 요약하고 원본을 삭제합니다."
+        compress_args: "[추가 지시사항]"
       calendar_command:
         event_created: '이벤트가 생성되었습니다: [구글 캘린더 이벤트](%{url})'
         event_created_local: '이벤트가 생성되었습니다 (로컬 전용 - 구글 캘린더 연동 시 동기화됩니다)'
         event_created_sync_failed: '이벤트가 생성되었습니다 (구글 캘린더 동기화 실패 - 구글 계정을 다시 연동해주세요)'
       mcp_command:
         error_running: "/%{tool_name} 실행 오류: %{error}"
+      compress_command:
+        topic_required: "/compress 명령은 토픽 내에서만 사용할 수 있습니다."
+        nothing_to_compress: "이 토픽에 요약할 메세지가 없습니다."
+        started: "⏳ 토픽 메세지를 요약하는 중..."
+        summary_title: "토픽 요약 — %{topic}"
+        failed: "요약 실패"
       topic_command:
         missing_name: '토픽 이름을 따옴표로 지정하세요: /topic "토픽 이름"'
         created: '토픽 "%{name}"이(가) 생성되었습니다.'

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -110,6 +110,7 @@ ko:
       mcp_command:
         error_running: "/%{tool_name} 실행 오류: %{error}"
       compress_command:
+        not_authorized: "토픽을 요약하려면 쓰기 권한이 필요합니다."
         topic_required: "/compress 명령은 토픽 내에서만 사용할 수 있습니다."
         nothing_to_compress: "이 토픽에 요약할 메세지가 없습니다."
         started: "⏳ 토픽 메세지를 요약하는 중..."

--- a/engines/collavre/test/jobs/compress_job_test.rb
+++ b/engines/collavre/test/jobs/compress_job_test.rb
@@ -1,0 +1,64 @@
+require "test_helper"
+
+class Collavre::CompressJobTest < ActiveSupport::TestCase
+  setup do
+    @user = users(:one)
+    @creative = Collavre::Creative.create!(description: "Compress Job Test", progress: 0.0, user: @user)
+    @topic = Collavre::Topic.create!(creative: @creative, user: @user, name: "compress-job-test")
+
+    @comment1 = @creative.comments.create!(user: @user, content: "First point discussed", topic: @topic)
+    @comment2 = @creative.comments.create!(user: @user, content: "Second important decision", topic: @topic)
+    @comment3 = @creative.comments.create!(user: @user, content: "Action item: do the thing", topic: @topic)
+  end
+
+  test "creates summary and deletes originals" do
+    mock_client = Minitest::Mock.new
+    mock_client.expect(:chat, nil) do |messages, **kwargs, &block|
+      block.call("This is the AI summary of the conversation.")
+      true
+    end
+
+    Collavre::AiClient.stub(:new, mock_client) do
+      Collavre::CompressJob.perform_now(@creative.id, @topic.id, @user.id)
+    end
+
+    # Original comments should be deleted
+    assert_not Collavre::Comment.exists?(@comment1.id)
+    assert_not Collavre::Comment.exists?(@comment2.id)
+    assert_not Collavre::Comment.exists?(@comment3.id)
+
+    # Summary comment should exist
+    summary = @creative.comments.where(topic: @topic).last
+    assert summary.present?
+    assert_includes summary.content, "This is the AI summary"
+    assert_includes summary.content, I18n.t("collavre.comments.compress_command.summary_title", topic: @topic.name)
+  end
+
+  test "does nothing when only one comment" do
+    @comment2.destroy
+    @comment3.destroy
+
+    Collavre::CompressJob.perform_now(@creative.id, @topic.id, @user.id)
+
+    # Original should still exist
+    assert Collavre::Comment.exists?(@comment1.id)
+  end
+
+  test "handles AI failure gracefully" do
+    mock_client = Minitest::Mock.new
+    mock_client.expect(:chat, nil) do |messages, **kwargs, &block|
+      # Return empty (AI failure)
+      true
+    end
+
+    Collavre::AiClient.stub(:new, mock_client) do
+      # Should not raise
+      Collavre::CompressJob.perform_now(@creative.id, @topic.id, @user.id)
+    end
+
+    # Original comments should still exist
+    assert Collavre::Comment.exists?(@comment1.id)
+    assert Collavre::Comment.exists?(@comment2.id)
+    assert Collavre::Comment.exists?(@comment3.id)
+  end
+end

--- a/engines/collavre/test/services/comments/compress_command_test.rb
+++ b/engines/collavre/test/services/comments/compress_command_test.rb
@@ -1,0 +1,70 @@
+require "test_helper"
+
+class Collavre::Comments::CompressCommandTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+  setup do
+    @user = users(:one)
+    @creative = Collavre::Creative.create!(description: "Compress Test", progress: 0.0, user: @user)
+    @topic = Collavre::Topic.create!(creative: @creative, user: @user, name: "test-compress")
+  end
+
+  test "ignores non-compress commands" do
+    comment = build_comment(content: "hello world")
+    result = Collavre::Comments::CompressCommand.new(comment: comment, user: @user).call
+    assert_nil result
+  end
+
+  test "returns error when no topic" do
+    comment = build_comment(content: "/compress", topic_id: nil)
+    result = Collavre::Comments::CompressCommand.new(comment: comment, user: @user).call
+    assert_equal I18n.t("collavre.comments.compress_command.topic_required"), result
+  end
+
+  test "returns error when topic has no other messages" do
+    comment = build_comment(content: "/compress", topic_id: @topic.id)
+    result = Collavre::Comments::CompressCommand.new(comment: comment, user: @user).call
+    assert_equal I18n.t("collavre.comments.compress_command.nothing_to_compress"), result
+  end
+
+  test "enqueues CompressJob when valid" do
+    @creative.comments.create!(user: @user, content: "first message", topic: @topic)
+    @creative.comments.create!(user: @user, content: "second message", topic: @topic)
+
+    comment = build_comment(content: "/compress", topic_id: @topic.id)
+
+    previous_adapter = ActiveJob::Base.queue_adapter
+    ActiveJob::Base.queue_adapter = :test
+    begin
+      assert_enqueued_with(job: Collavre::CompressJob) do
+        result = Collavre::Comments::CompressCommand.new(comment: comment, user: @user).call
+        assert_equal I18n.t("collavre.comments.compress_command.started"), result
+      end
+    ensure
+      ActiveJob::Base.queue_adapter = previous_adapter
+    end
+  end
+
+  test "passes extra prompt to job" do
+    @creative.comments.create!(user: @user, content: "first message", topic: @topic)
+    @creative.comments.create!(user: @user, content: "second message", topic: @topic)
+
+    comment = build_comment(content: "/compress keep action items", topic_id: @topic.id)
+
+    previous_adapter = ActiveJob::Base.queue_adapter
+    ActiveJob::Base.queue_adapter = :test
+    begin
+      assert_enqueued_with(job: Collavre::CompressJob) do
+        result = Collavre::Comments::CompressCommand.new(comment: comment, user: @user).call
+        assert_equal I18n.t("collavre.comments.compress_command.started"), result
+      end
+    ensure
+      ActiveJob::Base.queue_adapter = previous_adapter
+    end
+  end
+
+  private
+
+  def build_comment(content:, topic_id: @topic.id)
+    @creative.comments.build(user: @user, content: content, topic_id: topic_id)
+  end
+end

--- a/engines/collavre/test/services/comments/compress_command_test.rb
+++ b/engines/collavre/test/services/comments/compress_command_test.rb
@@ -26,6 +26,16 @@ class Collavre::Comments::CompressCommandTest < ActiveSupport::TestCase
     assert_equal I18n.t("collavre.comments.compress_command.nothing_to_compress"), result
   end
 
+  test "returns error when user lacks write permission" do
+    @creative.comments.create!(user: @user, content: "first message", topic: @topic)
+    @creative.comments.create!(user: @user, content: "second message", topic: @topic)
+
+    unauthorized_user = users(:two)
+    comment = build_comment(content: "/compress", topic_id: @topic.id)
+    result = Collavre::Comments::CompressCommand.new(comment: comment, user: unauthorized_user).call
+    assert_equal I18n.t("collavre.comments.compress_command.not_authorized"), result
+  end
+
   test "enqueues CompressJob when valid" do
     @creative.comments.create!(user: @user, content: "first message", topic: @topic)
     @creative.comments.create!(user: @user, content: "second message", topic: @topic)


### PR DESCRIPTION
## Summary
Add `/compress` slash command that summarizes all messages in the current topic using AI, creates a summary comment, and deletes the originals.

## Changes
- **CompressCommand** (`compress_command.rb`): Parses `/compress [extra instructions]`, validates topic context (must be in a topic, must have messages), enqueues async job
- **CompressJob** (`compress_job.rb`): Collects all topic comments, sends to AI for summarization via `AiClient`, creates summary comment with title, deletes original comments
- **CommandMenuService**: Adds `/compress` to slash command autocomplete menu
- **i18n**: English and Korean translations for all compress-related messages

## Usage
- `/compress` — summarize all messages in current topic
- `/compress keep action items separate` — summarize with additional instructions

## Flow
1. User types `/compress` in a topic
2. Command validates: must be in a topic, topic must have messages
3. `CompressJob` is enqueued (async)
4. Job collects all comments, sends to AI with system prompt
5. AI summary is created as a new comment with topic summary title
6. Original comments are deleted
7. UI updates via existing Turbo broadcast callbacks

## Tests
- 5 CompressCommand tests (non-command ignore, no-topic error, empty-topic error, job enqueue, extra prompt)
- 3 CompressJob tests (summary + delete, skip single comment, AI failure graceful handling)
