### PR TITLE
feat: add package.json for collavre CLI npm install support

### DIFF
--- a/skills/collavre/package.json
+++ b/skills/collavre/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "collavre-cli",
+  "version": "1.0.0",
+  "type": "module",
+  "bin": {
+    "collavre": "./scripts/collavre"
+  }
+}


### PR DESCRIPTION
Add `package.json` with `bin` field to the collavre skill, enabling CLI installation via `npm install -g .` from the skill directory.

This allows the `collavre` command to be registered on the system PATH when installed as a global npm package.

## Changes
- Added `package.json` with:
  - `name`: collavre-cli
  - `type`: module (ESM support for the existing script)
  - `bin.collavre`: points to `./scripts/collavre`

## Usage
```bash
cd skills/collavre && npm install -g .
```