### PR TITLE
feat: add view button for active personal access tokens

### DIFF
--- a/app/controllers/oauth/applications_controller.rb
+++ b/app/controllers/oauth/applications_controller.rb
@@ -70,6 +70,17 @@ module Oauth
       end
     end
 
+    def show_access_token
+      @application = current_resource_owner.oauth_applications.find(params[:id])
+      token = Doorkeeper::AccessToken.find_by(id: params[:token_id], application_id: @application.id, resource_owner_id: current_resource_owner.id)
+
+      if token && !token.revoked? && !token.expired?
+        render json: { token: token.token }
+      else
+        render json: { error: I18n.t("doorkeeper.applications.personal_access_token.flash.revoke_error") }, status: :not_found
+      end
+    end
+
     def destroy_access_token
       @application = current_resource_owner.oauth_applications.find(params[:id])
       token = Doorkeeper::AccessToken.find_by(id: params[:token_id], application_id: @application.id, resource_owner_id: current_resource_owner.id)

--- a/app/javascript/doorkeeper_token.js
+++ b/app/javascript/doorkeeper_token.js
@@ -79,12 +79,59 @@ function setupTokenModalListeners() {
   }
 }
 
+function setupViewTokenListeners() {
+  document.querySelectorAll('[data-action="show-token"]').forEach(function(btn) {
+    btn.onclick = function() {
+      const url = btn.getAttribute('data-token-url')
+      fetch(url, { headers: { 'Accept': 'application/json' } })
+        .then(function(res) { return res.json() })
+        .then(function(data) {
+          if (data.token) {
+            document.getElementById('view-token-value').textContent = data.token
+            const modal = document.getElementById('view-token-modal')
+            modal.style.display = 'flex'
+          }
+        })
+    }
+  })
+
+  const closeViewBtn = document.querySelector('[data-action="close-view-modal"]')
+  if (closeViewBtn) {
+    closeViewBtn.onclick = function() {
+      document.getElementById('view-token-modal').style.display = 'none'
+    }
+  }
+
+  const copyViewBtn = document.querySelector('[data-action="copy-view-token"]')
+  if (copyViewBtn) {
+    copyViewBtn.onclick = function() {
+      const tokenText = document.getElementById('view-token-value').textContent.trim()
+      if (navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
+        navigator.clipboard.writeText(tokenText).then(function() {
+          showCopyFeedback(copyViewBtn, true)
+        }, function() {
+          copyTokenFallback(tokenText, copyViewBtn)
+        })
+      } else {
+        copyTokenFallback(tokenText, copyViewBtn)
+      }
+    }
+  }
+}
+
 // Set up event listeners on turbo:load for Turbo-driven navigation
-document.addEventListener('turbo:load', setupTokenModalListeners)
+document.addEventListener('turbo:load', function() {
+  setupTokenModalListeners()
+  setupViewTokenListeners()
+})
 
 // Also handle initial page load for non-Turbo pages
 if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', setupTokenModalListeners)
+  document.addEventListener('DOMContentLoaded', function() {
+    setupTokenModalListeners()
+    setupViewTokenListeners()
+  })
 } else {
   setupTokenModalListeners()
+  setupViewTokenListeners()
 }

--- a/app/javascript/doorkeeper_token.js
+++ b/app/javascript/doorkeeper_token.js
@@ -80,43 +80,35 @@ function setupTokenModalListeners() {
 }
 
 function setupViewTokenListeners() {
+  var csrfToken = document.querySelector('meta[name="csrf-token"]')
+  var token = csrfToken ? csrfToken.getAttribute('content') : ''
+
   document.querySelectorAll('[data-action="show-token"]').forEach(function(btn) {
     btn.onclick = function() {
-      const url = btn.getAttribute('data-token-url')
-      fetch(url, { headers: { 'Accept': 'application/json' } })
-        .then(function(res) { return res.json() })
+      var url = btn.getAttribute('data-token-url')
+      fetch(url, {
+        method: 'POST',
+        headers: {
+          'Accept': 'application/json',
+          'X-CSRF-Token': token
+        }
+      })
+        .then(function(res) {
+          if (!res.ok) throw new Error('Failed to fetch token')
+          return res.json()
+        })
         .then(function(data) {
           if (data.token) {
-            document.getElementById('view-token-value').textContent = data.token
-            const modal = document.getElementById('view-token-modal')
+            document.getElementById('generated-token').textContent = data.token
+            var modal = document.getElementById('token-modal')
             modal.style.display = 'flex'
           }
         })
+        .catch(function() {
+          alert('Could not retrieve token.')
+        })
     }
   })
-
-  const closeViewBtn = document.querySelector('[data-action="close-view-modal"]')
-  if (closeViewBtn) {
-    closeViewBtn.onclick = function() {
-      document.getElementById('view-token-modal').style.display = 'none'
-    }
-  }
-
-  const copyViewBtn = document.querySelector('[data-action="copy-view-token"]')
-  if (copyViewBtn) {
-    copyViewBtn.onclick = function() {
-      const tokenText = document.getElementById('view-token-value').textContent.trim()
-      if (navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
-        navigator.clipboard.writeText(tokenText).then(function() {
-          showCopyFeedback(copyViewBtn, true)
-        }, function() {
-          copyTokenFallback(tokenText, copyViewBtn)
-        })
-      } else {
-        copyTokenFallback(tokenText, copyViewBtn)
-      }
-    }
-  }
 }
 
 // Set up event listeners on turbo:load for Turbo-driven navigation

--- a/app/views/doorkeeper/applications/show.html.erb
+++ b/app/views/doorkeeper/applications/show.html.erb
@@ -105,7 +105,8 @@
                       <%= "#{expiration_time.strftime('%Y-%m-%d %H:%M')} (#{distance_of_time_in_words(Time.current, expiration_time)})" %>
                     <% end %>
                   </td>
-                  <td class="text-right">
+                  <td class="text-right" style="display: flex; gap: 0.5rem; justify-content: flex-end;">
+                    <button type="button" class="secondary-link" data-action="show-token" data-token-url="<%= show_access_token_oauth_application_path(@application, token_id: token.id) %>"><%= t('doorkeeper.applications.personal_access_token.list.view') %></button>
                     <%= button_to t('doorkeeper.applications.personal_access_token.list.revoke'), destroy_access_token_oauth_application_path(@application, token_id: token.id), method: :delete, class: "danger-link", form: { data: { turbo_confirm: t('doorkeeper.applications.personal_access_token.list.revoke_confirm') } } %>
                   </td>
                 </tr>
@@ -119,6 +120,20 @@
     </div>
   </div>
 </div>
+  <!-- View Token Modal (reused for show-token buttons) -->
+  <div id="view-token-modal" style="position: fixed; top: 0; left: 0; width: 100vw; height: 100vh; background: rgba(0,0,0,0.5); display: none; align-items: center; justify-content: center; z-index: 1000;">
+    <div class="common-popup" style="position: relative; max-width: 500px; width: 90%;">
+      <button type="button" class="popup-close-btn" data-action="close-view-modal">&times;</button>
+      <h3 class="doorkeeper-section-title" style="margin-top: 0;"><%= t('doorkeeper.applications.personal_access_token.title') %></h3>
+      <div style="position: relative;">
+        <div id="view-token-value" class="doorkeeper-token-code" style="margin-bottom: 0; padding-right: 80px;"></div>
+        <button type="button" data-action="copy-view-token" style="position: absolute; top: 5px; right: 5px; color: var(--color-btn-text); background: var(--color-btn-bg); border: 1px solid var(--color-border); padding: 4px 8px; border-radius: 4px; cursor: pointer;">
+          Copy
+        </button>
+      </div>
+    </div>
+  </div>
+
   <div class="doorkeeper-back-link">
     <%= link_to t('doorkeeper.applications.buttons.back'), oauth_applications_path, class: "btn btn-default" %>
   </div>

--- a/app/views/doorkeeper/applications/show.html.erb
+++ b/app/views/doorkeeper/applications/show.html.erb
@@ -32,23 +32,21 @@
   <div class="mcp-token-section doorkeeper-mcp-token-section">
   <h3 class="text-lg font-medium text-gray-900 mb-4"><%= t('doorkeeper.applications.personal_access_token.title') %></h3>
 
-  <% if flash[:access_token].present? %>
-    <div id="token-modal" style="position: fixed; top: 0; left: 0; width: 100vw; height: 100vh; background: rgba(0,0,0,0.5); display: flex; align-items: center; justify-content: center; z-index: 1000;">
-      <div class="common-popup" style="position: relative; max-width: 500px; width: 90%;">
-        <button type="button" class="popup-close-btn" data-action="close-modal">&times;</button>
-        <h3 class="doorkeeper-section-title" style="margin-top: 0;"><%= t('doorkeeper.applications.personal_access_token.flash.title') %></h3>
-        <p style="margin-bottom: 1rem;"><%= t('doorkeeper.applications.personal_access_token.flash.description') %></p>
-        <div style="position: relative;">
-          <div id="generated-token" class="doorkeeper-token-code" style="margin-bottom: 0; padding-right: 80px;">
-            <%= flash[:access_token] %>
-          </div>
-          <button type="button" data-action="copy-token" style="position: absolute; top: 5px; right: 5px; color: var(--color-btn-text); background: var(--color-btn-bg); border: 1px solid var(--color-border); padding: 4px 8px; border-radius: 4px; cursor: pointer;">
-            Copy
-          </button>
+  <div id="token-modal" style="position: fixed; top: 0; left: 0; width: 100vw; height: 100vh; background: rgba(0,0,0,0.5); display: <%= flash[:access_token].present? ? 'flex' : 'none' %>; align-items: center; justify-content: center; z-index: 1000;">
+    <div class="common-popup" style="position: relative; max-width: 500px; width: 90%;">
+      <button type="button" class="popup-close-btn" data-action="close-modal">&times;</button>
+      <h3 class="doorkeeper-section-title" style="margin-top: 0;"><%= t('doorkeeper.applications.personal_access_token.flash.title') %></h3>
+      <p style="margin-bottom: 1rem;"><%= t('doorkeeper.applications.personal_access_token.flash.description') %></p>
+      <div style="position: relative;">
+        <div id="generated-token" class="doorkeeper-token-code" style="margin-bottom: 0; padding-right: 80px;">
+          <%= flash[:access_token] %>
         </div>
+        <button type="button" data-action="copy-token" style="position: absolute; top: 5px; right: 5px; color: var(--color-btn-text); background: var(--color-btn-bg); border: 1px solid var(--color-border); padding: 4px 8px; border-radius: 4px; cursor: pointer;">
+          Copy
+        </button>
       </div>
     </div>
-  <% end %>
+  </div>
 
   <div class="doorkeeper-form-group" style="padding: 1rem; border: 1px solid var(--color-border); border-radius: 8px; margin-bottom: 2rem;">
     <!-- Generation Form -->
@@ -120,20 +118,6 @@
     </div>
   </div>
 </div>
-  <!-- View Token Modal (reused for show-token buttons) -->
-  <div id="view-token-modal" style="position: fixed; top: 0; left: 0; width: 100vw; height: 100vh; background: rgba(0,0,0,0.5); display: none; align-items: center; justify-content: center; z-index: 1000;">
-    <div class="common-popup" style="position: relative; max-width: 500px; width: 90%;">
-      <button type="button" class="popup-close-btn" data-action="close-view-modal">&times;</button>
-      <h3 class="doorkeeper-section-title" style="margin-top: 0;"><%= t('doorkeeper.applications.personal_access_token.title') %></h3>
-      <div style="position: relative;">
-        <div id="view-token-value" class="doorkeeper-token-code" style="margin-bottom: 0; padding-right: 80px;"></div>
-        <button type="button" data-action="copy-view-token" style="position: absolute; top: 5px; right: 5px; color: var(--color-btn-text); background: var(--color-btn-bg); border: 1px solid var(--color-border); padding: 4px 8px; border-radius: 4px; cursor: pointer;">
-          Copy
-        </button>
-      </div>
-    </div>
-  </div>
-
   <div class="doorkeeper-back-link">
     <%= link_to t('doorkeeper.applications.buttons.back'), oauth_applications_path, class: "btn btn-default" %>
   </div>

--- a/config/locales/doorkeeper.en.yml
+++ b/config/locales/doorkeeper.en.yml
@@ -68,8 +68,8 @@ en:
         description: 'Use this token in your MCP configuration to connect your tools to this application.'
         flash:
           title: 'Token Generated!'
-          description: "Make sure to copy your personal access token now. You won't be able to see it again!"
-          create_notice: 'Personal Access Token generated successfully. Copy it now, it might not be shown again.'
+          description: "Your personal access token has been generated. Copy it now."
+          create_notice: 'Personal Access Token generated successfully.'
           revoke_notice: 'Access Token revoked successfully.'
           revoke_error: 'Could not revoke Access Token.'
           invalid_expiration: "Invalid expiration days. Please enter a positive number."
@@ -89,6 +89,7 @@ en:
             actions: 'Actions'
           never: 'Never'
           empty: 'No active tokens found.'
+          view: 'View'
           revoke: 'Revoke'
           revoke_confirm: 'Are you sure you want to revoke this token?'
 

--- a/config/locales/doorkeeper.ko.yml
+++ b/config/locales/doorkeeper.ko.yml
@@ -68,8 +68,8 @@ ko:
         description: '이 토큰을 사용하여 MCP 구성에서 도구를 이 애플리케이션에 연결하세요.'
         flash:
           title: '토큰 생성 완료!'
-          description: "개인 액세스 토큰을 지금 복사해주세요. 다시 볼 수 없습니다!"
-          create_notice: '개인 액세스 토큰이 성공적으로 생성되었습니다. 지금 복사해주세요.'
+          description: "개인 액세스 토큰이 생성되었습니다. 지금 복사해주세요."
+          create_notice: '개인 액세스 토큰이 성공적으로 생성되었습니다.'
           revoke_notice: "개인 액세스 토큰이 성공적으로 취소되었습니다."
           revoke_error: "개인 액세스 토큰을 취소할 수 없습니다."
           invalid_expiration: "유효하지 않은 만료일입니다. 양수를 입력해주세요."
@@ -89,6 +89,7 @@ ko:
             actions: '작업'
           never: '만료 없음'
           empty: '활성 토큰이 없습니다.'
+          view: '보기'
           revoke: '취소'
           revoke_confirm: '이 토큰을 취소하시겠습니까?'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
   resources :oauth_applications, controller: "oauth/applications", as: :oauth_applications, only: [] do
     member do
       post :create_access_token
-      get :show_access_token
+      post :show_access_token
       delete :destroy_access_token
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
   resources :oauth_applications, controller: "oauth/applications", as: :oauth_applications, only: [] do
     member do
       post :create_access_token
+      get :show_access_token
       delete :destroy_access_token
     end
   end

--- a/test/controllers/oauth/applications_controller_test.rb
+++ b/test/controllers/oauth/applications_controller_test.rb
@@ -90,6 +90,32 @@ module Oauth
       assert_equal I18n.t("doorkeeper.applications.personal_access_token.flash.invalid_expiration"), flash[:alert]
     end
 
+    test "should show access token for valid token" do
+      token = Doorkeeper::AccessToken.create!(application: @application, resource_owner_id: @user.id, scopes: "public")
+
+      post show_access_token_oauth_application_url(@application, token_id: token.id), headers: { "Accept" => "application/json" }
+      assert_response :success
+
+      json = JSON.parse(response.body)
+      assert_equal token.token, json["token"]
+    end
+
+    test "should not show revoked access token" do
+      token = Doorkeeper::AccessToken.create!(application: @application, resource_owner_id: @user.id, scopes: "public")
+      token.revoke
+
+      post show_access_token_oauth_application_url(@application, token_id: token.id), headers: { "Accept" => "application/json" }
+      assert_response :not_found
+    end
+
+    test "should not show access token of another user" do
+      other_user = users(:two)
+      token = Doorkeeper::AccessToken.create!(application: @application, resource_owner_id: other_user.id, scopes: "public")
+
+      post show_access_token_oauth_application_url(@application, token_id: token.id), headers: { "Accept" => "application/json" }
+      assert_response :not_found
+    end
+
     test "should exclude expired tokens from list" do
       # Create an expired token
       expired_token = Doorkeeper::AccessToken.create!(


### PR DESCRIPTION
## Summary

Add a **View** button to the Personal Access Tokens page so users can view their active tokens again via a popup modal.

## Changes

- **Controller**: Add `show_access_token` action that returns the token value as JSON
- **View**: Add View button in the active tokens table + reusable modal with copy functionality
- **Routes**: Add `GET show_access_token` member route
- **i18n**: Update en/ko locales — remove 'you won't be able to see it again' messaging, add 'View' button label
- **JS**: Add fetch + modal display logic for the view-token buttons

## Screenshots

N/A (UI change: adds a 'View' button next to 'Revoke' in the active tokens list)