### PR TITLE
fix: fail workflow subtask on empty AI response and fix supervisor mention format

### DIFF
--- a/engines/collavre/app/jobs/collavre/ai_agent_job.rb
+++ b/engines/collavre/app/jobs/collavre/ai_agent_job.rb
@@ -71,11 +71,33 @@ module Collavre
           tracker.release!(job_id || task.id, tokens_used: 0)
           Rails.logger.info("[AiAgentJob] Task #{task.id} escalated after max retries")
         else # :done
-          task.update!(status: "done")
-          tracker.release!(job_id || task.id, tokens_used: 0)
-          # Advance workflow after releasing resources to avoid deadlock
-          if task.parent_task_id.present?
-            Collavre::Comments::WorkflowExecutor.new(task.parent_task).complete_subtask!(task)
+          # Workflow subtasks with empty responses should retry, then fail
+          if task.parent_task_id.present? && response_content.blank?
+            max_retries = 2
+            current_retry = task.retry_count || 0
+
+            if current_retry < max_retries
+              task.update!(retry_count: current_retry + 1, status: "pending")
+              tracker.release!(job_id || task.id, tokens_used: 0)
+              Rails.logger.warn(
+                "[AiAgentJob] Workflow subtask #{task.id} returned empty response, " \
+                "retrying (#{current_retry + 1}/#{max_retries})"
+              )
+              AiAgentJob.set(wait: 5.seconds).perform_later(task)
+            else
+              task.update!(status: "failed")
+              tracker.release!(job_id || task.id, tokens_used: 0)
+              Collavre::Comments::WorkflowExecutor.new(task.parent_task).fail_subtask!(
+                task, error_message: "Agent returned empty response after #{max_retries} retries"
+              )
+            end
+          else
+            task.update!(status: "done")
+            tracker.release!(job_id || task.id, tokens_used: 0)
+            # Advance workflow after releasing resources to avoid deadlock
+            if task.parent_task_id.present?
+              Collavre::Comments::WorkflowExecutor.new(task.parent_task).complete_subtask!(task)
+            end
           end
         end
       rescue ApprovalPendingError

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -141,7 +141,7 @@ en:
         resumed: 'Workflow resumed for @%{agent}: %{remaining} tasks remaining.'
         no_active_workflow: 'No active workflow found on this creative.'
         no_resumable_workflow: 'No failed or stopped workflow found to resume.'
-        supervisor_instruction: "If you need clarification, have questions, or are unsure about anything, ask @%{supervisor} instead of the user. They will guide you."
+        supervisor_instruction: "If you need clarification, have questions, or are unsure about anything, ask @%{supervisor}: instead of the user. They will guide you."
       versions:
         previous: Previous version
         next: Next version

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -138,7 +138,7 @@ ko:
         resumed: '@%{agent}의 워크플로우가 재개되었습니다: %{remaining}개 작업 남음.'
         no_active_workflow: '이 크리에이티브에 활성 워크플로우가 없습니다.'
         no_resumable_workflow: '재개할 수 있는 실패/중지된 워크플로우가 없습니다.'
-        supervisor_instruction: "질문이 있거나 확인이 필요하면 사용자 대신 @%{supervisor}에게 물어보세요. 감독자가 안내해줄 것입니다."
+        supervisor_instruction: "질문이 있거나 확인이 필요하면 사용자 대신 @%{supervisor}: 에게 물어보세요. 감독자가 안내해줄 것입니다."
       versions:
         previous: 이전 버전
         next: 다음 버전


### PR DESCRIPTION
## Problem

### Issue 1: /work subtasks silently complete without doing work
When an AI agent returns an empty response for a workflow subtask, the task is marked as `done` and the workflow advances to the next subtask. This causes the entire workflow to blow through all children without any actual work being done.

**Production evidence:**
- Task #2184 (work_command): 23 subtasks all `status=done`
- But only 2/23 creatives had progress > 0%
- 18/23 subtasks had NO AI comment at all
- Empty responses were completing in ~3-6 seconds each

### Issue 2: Supervisor mention missing colon
The `supervisor_instruction` i18n text generates `@Yes Man` but MentionParser requires `@Yes Man:` (with colon) to recognize mentions.

## Fix

### Issue 1
Workflow subtasks with empty AI responses are now treated as failures instead of silently completing. `WorkflowExecutor#fail_subtask!` is called, which stops the workflow and posts a failure notice.

### Issue 2
Added colon after `%{supervisor}` in both en/ko i18n files.

## Files Changed
- `engines/collavre/app/jobs/collavre/ai_agent_job.rb` — empty response → fail subtask
- `engines/collavre/config/locales/comments.en.yml` — supervisor mention colon
- `engines/collavre/config/locales/comments.ko.yml` — supervisor mention colon