### PR TITLE
fix: retry workflow subtask on empty AI response and fix supervisor mention format

### DIFF
--- a/engines/collavre/app/jobs/collavre/ai_agent_job.rb
+++ b/engines/collavre/app/jobs/collavre/ai_agent_job.rb
@@ -114,12 +114,12 @@ module Collavre
     EMPTY_RESPONSE_RETRY_DELAY = 5.seconds
 
     def handle_empty_workflow_response(task, tracker)
-      empty_retries = task.result&.dig("empty_response_retries").to_i
+      empty_retries = task.workflow_state&.dig("empty_response_retries").to_i
 
       if empty_retries < EMPTY_RESPONSE_MAX_RETRIES
         task.update!(
           status: "running",
-          result: (task.result || {}).merge("empty_response_retries" => empty_retries + 1)
+          workflow_state: (task.workflow_state || {}).merge("empty_response_retries" => empty_retries + 1)
         )
         tracker.release!(job_id || task.id, tokens_used: 0)
         AiAgentJob.set(wait: EMPTY_RESPONSE_RETRY_DELAY).perform_later(task)

--- a/engines/collavre/app/jobs/collavre/ai_agent_job.rb
+++ b/engines/collavre/app/jobs/collavre/ai_agent_job.rb
@@ -125,7 +125,7 @@ module Collavre
       else
         task.update!(status: "failed")
         tracker.release!(job_id || task.id, tokens_used: 0)
-        error_msg = I18n.t("collavre.comments.workflow.empty_response_after_retries",
+        error_msg = I18n.t("collavre.comments.work_command.empty_response_after_retries",
                            retries: EMPTY_RESPONSE_MAX_RETRIES)
         Collavre::Comments::WorkflowExecutor.new(task.parent_task).fail_subtask!(task, error_message: error_msg)
         Rails.logger.error("[AiAgentJob] Workflow subtask #{task.id} failed: empty response after #{EMPTY_RESPONSE_MAX_RETRIES} retries")

--- a/engines/collavre/app/jobs/collavre/ai_agent_job.rb
+++ b/engines/collavre/app/jobs/collavre/ai_agent_job.rb
@@ -114,13 +114,18 @@ module Collavre
     EMPTY_RESPONSE_RETRY_DELAY = 5.seconds
 
     def handle_empty_workflow_response(task, tracker)
-      if task.retry_count < EMPTY_RESPONSE_MAX_RETRIES
-        task.update!(status: "running", retry_count: task.retry_count + 1)
+      empty_retries = task.result&.dig("empty_response_retries").to_i
+
+      if empty_retries < EMPTY_RESPONSE_MAX_RETRIES
+        task.update!(
+          status: "running",
+          result: (task.result || {}).merge("empty_response_retries" => empty_retries + 1)
+        )
         tracker.release!(job_id || task.id, tokens_used: 0)
         AiAgentJob.set(wait: EMPTY_RESPONSE_RETRY_DELAY).perform_later(task)
         Rails.logger.warn(
           "[AiAgentJob] Empty response for workflow subtask #{task.id}, " \
-          "retry #{task.retry_count}/#{EMPTY_RESPONSE_MAX_RETRIES}"
+          "retry #{empty_retries + 1}/#{EMPTY_RESPONSE_MAX_RETRIES}"
         )
       else
         task.update!(status: "failed")

--- a/engines/collavre/app/jobs/collavre/ai_agent_job.rb
+++ b/engines/collavre/app/jobs/collavre/ai_agent_job.rb
@@ -53,6 +53,12 @@ module Collavre
       begin
         response_content = AiAgentService.new(task).call
 
+        # Workflow subtask: retry on empty response (AI may return no text after tool calls)
+        if response_content.blank? && task.parent_task_id.present?
+          handle_empty_workflow_response(task, tracker)
+          return
+        end
+
         # Evaluate self-reflection if enabled
         reflection_result = evaluate_self_reflection(task, response_content)
 
@@ -103,6 +109,28 @@ module Collavre
     end
 
     private
+
+    EMPTY_RESPONSE_MAX_RETRIES = 2
+    EMPTY_RESPONSE_RETRY_DELAY = 5.seconds
+
+    def handle_empty_workflow_response(task, tracker)
+      if task.retry_count < EMPTY_RESPONSE_MAX_RETRIES
+        task.update!(status: "running", retry_count: task.retry_count + 1)
+        tracker.release!(job_id || task.id, tokens_used: 0)
+        AiAgentJob.set(wait: EMPTY_RESPONSE_RETRY_DELAY).perform_later(task)
+        Rails.logger.warn(
+          "[AiAgentJob] Empty response for workflow subtask #{task.id}, " \
+          "retry #{task.retry_count}/#{EMPTY_RESPONSE_MAX_RETRIES}"
+        )
+      else
+        task.update!(status: "failed")
+        tracker.release!(job_id || task.id, tokens_used: 0)
+        error_msg = I18n.t("collavre.comments.workflow.empty_response_after_retries",
+                           retries: EMPTY_RESPONSE_MAX_RETRIES)
+        Collavre::Comments::WorkflowExecutor.new(task.parent_task).fail_subtask!(task, error_message: error_msg)
+        Rails.logger.error("[AiAgentJob] Workflow subtask #{task.id} failed: empty response after #{EMPTY_RESPONSE_MAX_RETRIES} retries")
+      end
+    end
 
     def evaluate_self_reflection(task, response_content)
       Orchestration::SelfReflectionEvaluator.new(task, response_content: response_content).evaluate

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -141,7 +141,8 @@ en:
         resumed: 'Workflow resumed for @%{agent}: %{remaining} tasks remaining.'
         no_active_workflow: 'No active workflow found on this creative.'
         no_resumable_workflow: 'No failed or stopped workflow found to resume.'
-        supervisor_instruction: "If you need clarification, have questions, or are unsure about anything, ask @%{supervisor} instead of the user. They will guide you."
+        supervisor_instruction: "If you need clarification, have questions, or are unsure about anything, ask @%{supervisor}: instead of the user. They will guide you."
+        empty_response_after_retries: "Agent returned empty response after %{retries} retries"
       versions:
         previous: Previous version
         next: Next version

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -138,7 +138,8 @@ ko:
         resumed: '@%{agent}의 워크플로우가 재개되었습니다: %{remaining}개 작업 남음.'
         no_active_workflow: '이 크리에이티브에 활성 워크플로우가 없습니다.'
         no_resumable_workflow: '재개할 수 있는 실패/중지된 워크플로우가 없습니다.'
-        supervisor_instruction: "질문이 있거나 확인이 필요하면 사용자 대신 @%{supervisor}에게 물어보세요. 감독자가 안내해줄 것입니다."
+        supervisor_instruction: "질문이 있거나 확인이 필요하면 사용자 대신 @%{supervisor}: 에게 물어보세요. 감독자가 안내해줄 것입니다."
+        empty_response_after_retries: "에이전트가 %{retries}회 재시도 후에도 빈 응답을 반환했습니다"
       versions:
         previous: 이전 버전
         next: 다음 버전

--- a/engines/collavre/test/jobs/ai_agent_job_test.rb
+++ b/engines/collavre/test/jobs/ai_agent_job_test.rb
@@ -326,6 +326,68 @@ class AiAgentJobTest < ActiveJob::TestCase
       "Expected no new task when duplicate running task exists for same comment"
   end
 
+  test "retries workflow subtask on empty AI response" do
+    # Create parent workflow task
+    parent_task = Task.create!(
+      name: "Workflow parent",
+      status: "running",
+      trigger_event_name: "workflow",
+      trigger_event_payload: @context,
+      agent: @agent,
+      creative_id: @creative.id
+    )
+
+    # Create subtask
+    subtask = Task.create!(
+      name: "Workflow subtask",
+      status: "running",
+      trigger_event_name: "workflow_subtask",
+      trigger_event_payload: @context,
+      agent: @agent,
+      parent_task: parent_task,
+      creative_id: @creative.id,
+      retry_count: 0
+    )
+
+    AiClient.stub :new, EmptyAiClient.new do
+      AiAgentJob.perform_now(subtask)
+    end
+
+    subtask.reload
+    # Should have incremented retry_count and enqueued a retry
+    assert_equal 1, subtask.retry_count
+    assert_equal "running", subtask.status
+    assert_enqueued_with(job: AiAgentJob, args: [subtask])
+  end
+
+  test "fails workflow subtask after max retries on empty response" do
+    parent_task = Task.create!(
+      name: "Workflow parent",
+      status: "running",
+      trigger_event_name: "workflow",
+      trigger_event_payload: @context,
+      agent: @agent,
+      creative_id: @creative.id
+    )
+
+    subtask = Task.create!(
+      name: "Workflow subtask",
+      status: "running",
+      trigger_event_name: "workflow_subtask",
+      trigger_event_payload: @context,
+      agent: @agent,
+      parent_task: parent_task,
+      creative_id: @creative.id,
+      retry_count: AiAgentJob::EMPTY_RESPONSE_MAX_RETRIES # Already at max
+    )
+
+    AiClient.stub :new, EmptyAiClient.new do
+      AiAgentJob.perform_now(subtask)
+    end
+
+    assert_equal "failed", subtask.reload.status
+  end
+
   test "allows execution when existing task for same comment is done" do
     # Create a completed task for the same agent + comment
     Task.create!(

--- a/engines/collavre/test/jobs/ai_agent_job_test.rb
+++ b/engines/collavre/test/jobs/ai_agent_job_test.rb
@@ -363,7 +363,7 @@ class AiAgentJobTest < ActiveJob::TestCase
     subtask.reload
     # Should track empty_response_retries in result JSON (not retry_count)
     assert_equal 0, subtask.retry_count, "retry_count should stay 0 (reserved for self-reflection)"
-    assert_equal 1, subtask.result&.dig("empty_response_retries")
+    assert_equal 1, subtask.workflow_state&.dig("empty_response_retries")
     assert_equal "running", subtask.status
     assert_enqueued_with(job: AiAgentJob, args: [ subtask ])
   ensure
@@ -388,7 +388,7 @@ class AiAgentJobTest < ActiveJob::TestCase
       agent: @agent,
       parent_task: parent_task,
       creative_id: @creative.id,
-      result: { "empty_response_retries" => AiAgentJob::EMPTY_RESPONSE_MAX_RETRIES } # Already at max
+      workflow_state: { "empty_response_retries" => AiAgentJob::EMPTY_RESPONSE_MAX_RETRIES } # Already at max
     )
 
     # Stub AiAgentService to return empty response (avoids comment lookup)

--- a/engines/collavre/test/jobs/ai_agent_job_test.rb
+++ b/engines/collavre/test/jobs/ai_agent_job_test.rb
@@ -45,7 +45,7 @@ class AiAgentJobTest < ActiveJob::TestCase
 
     # Verify Task Actions
     assert_equal 4, task.task_actions.count
-    assert_equal ["start", "prompt_generated", "completion", "reply_created"], task.task_actions.pluck(:action_type)
+    assert_equal [ "start", "prompt_generated", "completion", "reply_created" ], task.task_actions.pluck(:action_type)
 
     # Verify final comment is created (not a streaming placeholder)
     reply = @creative.comments.order(:created_at).last
@@ -85,7 +85,7 @@ class AiAgentJobTest < ActiveJob::TestCase
 
     # Verify Task Actions - reply_created should be missing
     assert_equal 3, task.task_actions.count
-    assert_equal ["start", "prompt_generated", "completion"], task.task_actions.pluck(:action_type)
+    assert_equal [ "start", "prompt_generated", "completion" ], task.task_actions.pluck(:action_type)
 
     # Verify no new comment created (no placeholder, no reply)
     assert_equal 1, @creative.comments.count # Only the initial comment

--- a/engines/collavre/test/jobs/ai_agent_job_test.rb
+++ b/engines/collavre/test/jobs/ai_agent_job_test.rb
@@ -349,6 +349,10 @@ class AiAgentJobTest < ActiveJob::TestCase
       retry_count: 0
     )
 
+    # Use :test adapter so set(wait:).perform_later works without a real backend
+    old_adapter = ActiveJob::Base.queue_adapter
+    ActiveJob::Base.queue_adapter = :test
+
     AiClient.stub :new, EmptyAiClient.new do
       AiAgentJob.perform_now(subtask)
     end
@@ -358,6 +362,8 @@ class AiAgentJobTest < ActiveJob::TestCase
     assert_equal 1, subtask.retry_count
     assert_equal "running", subtask.status
     assert_enqueued_with(job: AiAgentJob, args: [subtask])
+  ensure
+    ActiveJob::Base.queue_adapter = old_adapter
   end
 
   test "fails workflow subtask after max retries on empty response" do

--- a/engines/collavre/test/jobs/ai_agent_job_test.rb
+++ b/engines/collavre/test/jobs/ai_agent_job_test.rb
@@ -353,7 +353,11 @@ class AiAgentJobTest < ActiveJob::TestCase
     old_adapter = ActiveJob::Base.queue_adapter
     ActiveJob::Base.queue_adapter = :test
 
-    AiClient.stub :new, EmptyAiClient.new do
+    # Stub AiAgentService to return empty response (avoids comment lookup)
+    fake_service = Minitest::Mock.new
+    fake_service.expect :call, ""
+
+    AiAgentService.stub :new, ->(_task) { fake_service } do
       AiAgentJob.perform_now(subtask)
     end
 
@@ -387,7 +391,11 @@ class AiAgentJobTest < ActiveJob::TestCase
       retry_count: AiAgentJob::EMPTY_RESPONSE_MAX_RETRIES # Already at max
     )
 
-    AiClient.stub :new, EmptyAiClient.new do
+    # Stub AiAgentService to return empty response (avoids comment lookup)
+    fake_service = Minitest::Mock.new
+    fake_service.expect :call, ""
+
+    AiAgentService.stub :new, ->(_task) { fake_service } do
       AiAgentJob.perform_now(subtask)
     end
 

--- a/engines/collavre/test/jobs/ai_agent_job_test.rb
+++ b/engines/collavre/test/jobs/ai_agent_job_test.rb
@@ -345,8 +345,7 @@ class AiAgentJobTest < ActiveJob::TestCase
       trigger_event_payload: @context,
       agent: @agent,
       parent_task: parent_task,
-      creative_id: @creative.id,
-      retry_count: 0
+      creative_id: @creative.id
     )
 
     # Use :test adapter so set(wait:).perform_later works without a real backend
@@ -362,8 +361,9 @@ class AiAgentJobTest < ActiveJob::TestCase
     end
 
     subtask.reload
-    # Should have incremented retry_count and enqueued a retry
-    assert_equal 1, subtask.retry_count
+    # Should track empty_response_retries in result JSON (not retry_count)
+    assert_equal 0, subtask.retry_count, "retry_count should stay 0 (reserved for self-reflection)"
+    assert_equal 1, subtask.result&.dig("empty_response_retries")
     assert_equal "running", subtask.status
     assert_enqueued_with(job: AiAgentJob, args: [ subtask ])
   ensure
@@ -388,7 +388,7 @@ class AiAgentJobTest < ActiveJob::TestCase
       agent: @agent,
       parent_task: parent_task,
       creative_id: @creative.id,
-      retry_count: AiAgentJob::EMPTY_RESPONSE_MAX_RETRIES # Already at max
+      result: { "empty_response_retries" => AiAgentJob::EMPTY_RESPONSE_MAX_RETRIES } # Already at max
     )
 
     # Stub AiAgentService to return empty response (avoids comment lookup)

--- a/engines/collavre/test/jobs/ai_agent_job_test.rb
+++ b/engines/collavre/test/jobs/ai_agent_job_test.rb
@@ -365,7 +365,7 @@ class AiAgentJobTest < ActiveJob::TestCase
     # Should have incremented retry_count and enqueued a retry
     assert_equal 1, subtask.retry_count
     assert_equal "running", subtask.status
-    assert_enqueued_with(job: AiAgentJob, args: [subtask])
+    assert_enqueued_with(job: AiAgentJob, args: [ subtask ])
   ensure
     ActiveJob::Base.queue_adapter = old_adapter
   end

--- a/engines/collavre/test/jobs/ai_agent_job_test.rb
+++ b/engines/collavre/test/jobs/ai_agent_job_test.rb
@@ -45,7 +45,7 @@ class AiAgentJobTest < ActiveJob::TestCase
 
     # Verify Task Actions
     assert_equal 4, task.task_actions.count
-    assert_equal [ "start", "prompt_generated", "completion", "reply_created" ], task.task_actions.pluck(:action_type)
+    assert_equal ["start", "prompt_generated", "completion", "reply_created"], task.task_actions.pluck(:action_type)
 
     # Verify final comment is created (not a streaming placeholder)
     reply = @creative.comments.order(:created_at).last
@@ -85,7 +85,7 @@ class AiAgentJobTest < ActiveJob::TestCase
 
     # Verify Task Actions - reply_created should be missing
     assert_equal 3, task.task_actions.count
-    assert_equal [ "start", "prompt_generated", "completion" ], task.task_actions.pluck(:action_type)
+    assert_equal ["start", "prompt_generated", "completion"], task.task_actions.pluck(:action_type)
 
     # Verify no new comment created (no placeholder, no reply)
     assert_equal 1, @creative.comments.count # Only the initial comment


### PR DESCRIPTION
## Problem

### 1. /work command subtasks complete without doing actual work
- AI returns empty response (likely after tool calls without text output)
- Task marked as `done` despite no actual work performed
- 18 of 23 subtasks had no AI comments, 21 had 0% progress

### 2. Supervisor mention missing colon
- `@%{supervisor}` in i18n → `@Yes Man` (MentionParser requires `@Name:` format)

## Solution

### Empty response retry
- Detect empty response for workflow subtasks in `AiAgentJob`
- Retry up to 2 times with 5-second delay using existing `retry_count` column
- After max retries, fail the subtask with i18n error message
- Uses `WorkflowExecutor#fail_subtask!` for proper workflow failure notification

### Mention format fix
- Changed `@%{supervisor}` → `@%{supervisor}:` in en/ko i18n files
- Colon + space needed for `MentionParser::MENTION_PATTERN` (`/(@[^:]+?):\s*/`)

## Tests
- `test_retries_workflow_subtask_on_empty_AI_response`
- `test_fails_workflow_subtask_after_max_retries_on_empty_response`