### PR TITLE
fix: strip whitespace in normalize_description for creative create/update

### DIFF
--- a/engines/collavre/app/services/collavre/tools/creative_create_service.rb
+++ b/engines/collavre/app/services/collavre/tools/creative_create_service.rb
@@ -5,6 +5,7 @@ module Tools
   class CreativeCreateService
     extend T::Sig
     extend ToolMeta
+    include DescriptionNormalizable
 
     tool_name "creative_create_service"
     tool_description "Create a new Creative (task/content block) in the hierarchical structure. Creatives function like tasks in a tree structure, with automatic progress calculation.\n\nUse this to:\n- Create new tasks under a parent Creative\n- Add sub-items to organize work\n- Build hierarchical project structures\n\nNote: The description field accepts HTML format for rich text content."
@@ -61,15 +62,6 @@ module Tools
     end
 
     private
-
-    def normalize_description(desc)
-      return desc if desc.blank?
-      stripped = desc.strip
-      # If it already looks like HTML, return as-is
-      return stripped if stripped.start_with?("<")
-      # Otherwise wrap in <p> tags
-      "<p>#{ERB::Util.html_escape(stripped)}</p>"
-    end
 
     def handle_ordering(creative, before_id:, after_id:)
       return unless before_id.present? || after_id.present?

--- a/engines/collavre/app/services/collavre/tools/creative_create_service.rb
+++ b/engines/collavre/app/services/collavre/tools/creative_create_service.rb
@@ -64,10 +64,11 @@ module Tools
 
     def normalize_description(desc)
       return desc if desc.blank?
+      stripped = desc.strip
       # If it already looks like HTML, return as-is
-      return desc if desc.strip.start_with?("<")
+      return stripped if stripped.start_with?("<")
       # Otherwise wrap in <p> tags
-      "<p>#{ERB::Util.html_escape(desc)}</p>"
+      "<p>#{ERB::Util.html_escape(stripped)}</p>"
     end
 
     def handle_ordering(creative, before_id:, after_id:)

--- a/engines/collavre/app/services/collavre/tools/creative_update_service.rb
+++ b/engines/collavre/app/services/collavre/tools/creative_update_service.rb
@@ -5,6 +5,7 @@ module Tools
   class CreativeUpdateService
     extend T::Sig
     extend ToolMeta
+    include DescriptionNormalizable
 
     tool_name "creative_update_service"
     tool_description "Update an existing Creative's content, progress, or parent. Use this to:\n- Modify the description/title of a Creative\n- Mark a leaf Creative as complete (progress = 1.0)\n- Move a Creative to a different parent\n\nProgress constraints:\n- Only 1.0 (100%) is allowed — partial progress updates are not supported\n- Only leaf Creatives (with no children) can have their progress updated\n- Parent Creative progress is automatically calculated from children\n\nUse creative_retrieval_service to find the correct Creative before updating."
@@ -109,14 +110,7 @@ module Tools
 
     private
 
-    def normalize_description(desc)
-      return desc if desc.blank?
-      stripped = desc.strip
-      # If it already looks like HTML, return as-is
-      return stripped if stripped.start_with?("<")
-      # Otherwise wrap in <p> tags
-      "<p>#{ERB::Util.html_escape(stripped)}</p>"
-    end
+
   end
 end
 end

--- a/engines/collavre/app/services/collavre/tools/creative_update_service.rb
+++ b/engines/collavre/app/services/collavre/tools/creative_update_service.rb
@@ -109,8 +109,6 @@ module Tools
     end
 
     private
-
-
   end
 end
 end

--- a/engines/collavre/app/services/collavre/tools/creative_update_service.rb
+++ b/engines/collavre/app/services/collavre/tools/creative_update_service.rb
@@ -111,10 +111,11 @@ module Tools
 
     def normalize_description(desc)
       return desc if desc.blank?
+      stripped = desc.strip
       # If it already looks like HTML, return as-is
-      return desc if desc.strip.start_with?("<")
+      return stripped if stripped.start_with?("<")
       # Otherwise wrap in <p> tags
-      "<p>#{ERB::Util.html_escape(desc)}</p>"
+      "<p>#{ERB::Util.html_escape(stripped)}</p>"
     end
   end
 end

--- a/engines/collavre/app/services/collavre/tools/description_normalizable.rb
+++ b/engines/collavre/app/services/collavre/tools/description_normalizable.rb
@@ -1,0 +1,16 @@
+module Collavre
+  module Tools
+    module DescriptionNormalizable
+      private
+
+      def normalize_description(desc)
+        return desc if desc.blank?
+        stripped = desc.strip
+        # If it already looks like HTML, return as-is
+        return stripped if stripped.start_with?("<")
+        # Otherwise wrap in <p> tags
+        "<p>#{ERB::Util.html_escape(stripped)}</p>"
+      end
+    end
+  end
+end

--- a/engines/collavre/test/services/tools/creative_create_service_test.rb
+++ b/engines/collavre/test/services/tools/creative_create_service_test.rb
@@ -101,6 +101,45 @@ module Collavre
         assert_match(/permission/i, result[:error])
       end
 
+      test "strips leading and trailing whitespace from plain text description" do
+        service = CreativeCreateService.new
+
+        result = service.call(
+          parent_id: @parent_creative.id,
+          description: "  New task with spaces  "
+        )
+
+        assert result[:success]
+        creative = Creative.find(result[:id])
+        assert_equal "<p>New task with spaces</p>", creative.description
+      end
+
+      test "strips leading and trailing whitespace from HTML description" do
+        service = CreativeCreateService.new
+
+        result = service.call(
+          parent_id: @parent_creative.id,
+          description: "  <p>HTML with spaces</p>  "
+        )
+
+        assert result[:success]
+        creative = Creative.find(result[:id])
+        assert_equal "<p>HTML with spaces</p>", creative.description
+      end
+
+      test "strips newlines from description" do
+        service = CreativeCreateService.new
+
+        result = service.call(
+          parent_id: @parent_creative.id,
+          description: "\nNew task with newlines\n"
+        )
+
+        assert result[:success]
+        creative = Creative.find(result[:id])
+        assert_equal "<p>New task with newlines</p>", creative.description
+      end
+
       test "raises error when no current user" do
         Current.user = nil
         service = CreativeCreateService.new

--- a/engines/collavre/test/services/tools/creative_update_service_test.rb
+++ b/engines/collavre/test/services/tools/creative_update_service_test.rb
@@ -153,6 +153,45 @@ module Collavre
         assert_match(/descendant/i, result[:error])
       end
 
+      test "strips leading and trailing whitespace from plain text description" do
+        service = CreativeUpdateService.new
+
+        result = service.call(
+          id: @creative.id,
+          description: "  Updated with spaces  "
+        )
+
+        assert result[:success]
+        @creative.reload
+        assert_equal "<p>Updated with spaces</p>", @creative.description
+      end
+
+      test "strips leading and trailing whitespace from HTML description" do
+        service = CreativeUpdateService.new
+
+        result = service.call(
+          id: @creative.id,
+          description: "  <p>Updated HTML with spaces</p>  "
+        )
+
+        assert result[:success]
+        @creative.reload
+        assert_equal "<p>Updated HTML with spaces</p>", @creative.description
+      end
+
+      test "strips newlines from description" do
+        service = CreativeUpdateService.new
+
+        result = service.call(
+          id: @creative.id,
+          description: "\nUpdated with newlines\n"
+        )
+
+        assert result[:success]
+        @creative.reload
+        assert_equal "<p>Updated with newlines</p>", @creative.description
+      end
+
       test "raises error when no current user" do
         Current.user = nil
         service = CreativeUpdateService.new


### PR DESCRIPTION
## Problem

Leading and trailing whitespace/newlines in the `description` parameter were preserved in the stored HTML when creating or updating Creatives via MCP tools. This caused unwanted spaces in creative titles.

## Root Cause

The `normalize_description` method called `strip()` only for the HTML detection check (`desc.strip.start_with?("<")`) but returned the **original unstripped value**.

```ruby
# Before
def normalize_description(desc)
  return desc if desc.blank?
  return desc if desc.strip.start_with?("<")  # strip for check only
  "<p>#{ERB::Util.html_escape(desc)}</p>"      # uses original desc
end
```

## Fix

Use the stripped value consistently for both HTML and plain text paths:

```ruby
# After
def normalize_description(desc)
  return desc if desc.blank?
  stripped = desc.strip
  return stripped if stripped.start_with?("<")
  "<p>#{ERB::Util.html_escape(stripped)}</p>"
end
```

## Changes

- `CreativeCreateService#normalize_description` — strip input before processing
- `CreativeUpdateService#normalize_description` — strip input before processing
- Added 6 test cases (3 per service): whitespace, HTML with spaces, newlines

## Tests

- `creative_create_service_test.rb` — 3 new tests
- `creative_update_service_test.rb` — 3 new tests