### PR TITLE
fix: replace html_safe with sanitize in slide_view to prevent XSS

### DIFF
--- a/engines/collavre/app/javascript/modules/slide_view.js
+++ b/engines/collavre/app/javascript/modules/slide_view.js
@@ -1,4 +1,5 @@
 import { createSubscription } from '../services/cable'
+import DOMPurify from 'dompurify'
 
 document.addEventListener('DOMContentLoaded', function() {
   var container = document.getElementById('slide-view');
@@ -59,7 +60,7 @@ document.addEventListener('DOMContentLoaded', function() {
         }
         contentEl.innerHTML = '';
         var el = document.createElement(tag);
-        el.innerHTML = data.description;
+        el.innerHTML = DOMPurify.sanitize(data.description);
         contentEl.appendChild(el);
         if (captionEl) {
           captionEl.textContent = data.prompt || '';

--- a/engines/collavre/app/views/collavre/creatives/slide_view.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/slide_view.html.erb
@@ -8,7 +8,7 @@
 <% initial_index = params[:slide].to_i.clamp(0, @slide_ids.length - 1) %>
 <% initial_prompt = @creative.prompt_for(Current.user) %>
 <div id="slide-view" data-slide-ids="<%= @slide_ids.join(',') %>" data-initial-index="<%= initial_index %>" data-root-id="<%= @creative.id %>">
-  <div id="slide-content"><%= content_tag(tag_name, @creative.effective_description.html_safe) %></div>
+  <div id="slide-content"><%= content_tag(tag_name, sanitize(@creative.effective_description, tags: Rails::HTML5::SafeListSanitizer.allowed_tags.to_a + %w[table thead tbody tfoot tr th td], attributes: Rails::HTML5::SafeListSanitizer.allowed_attributes.to_a + %w[colspan rowspan data-lexical])) %></div>
 </div>
 <div id="slide-controls">
   <div id="slide-counter"><%= initial_index + 1 %> / <%= @slide_ids.length %></div>


### PR DESCRIPTION
## Summary
- Replace `.html_safe` with `sanitize()` in slide_view.html.erb to prevent XSS attacks
- Also sanitize HTML insertion in slide_view.js

## Changes
- `engines/collavre/app/views/collavre/creatives/slide_view.html.erb`: Use `sanitize` instead of `.html_safe`
- `engines/collavre/app/javascript/modules/slide_view.js`: Sanitize HTML before DOM insertion

## Creative
Resolves Creative #9481