### PR TITLE
fix: add reset_session before session creation to prevent session fixation

### DIFF
--- a/app/controllers/webauthn/sessions_controller.rb
+++ b/app/controllers/webauthn/sessions_controller.rb
@@ -28,6 +28,9 @@ module Webauthn
 
           if credential.user.email_verified?
             handle_invitation_for(credential.user) if params[:invite_token].present?
+            return_to = session[:return_to_after_authenticating]
+            reset_session
+            session[:return_to_after_authenticating] = return_to if return_to
             start_new_session_for credential.user
             render json: { status: "ok", redirect_url: after_authentication_url }, status: :ok
           else

--- a/engines/collavre/app/controllers/collavre/google_auth_controller.rb
+++ b/engines/collavre/app/controllers/collavre/google_auth_controller.rb
@@ -40,6 +40,9 @@ module Collavre
       tz = request.env["omniauth.params"] && request.env["omniauth.params"]["timezone"]
       user.update(timezone: tz) if tz.present? && user.timezone != tz
 
+      return_to = session[:return_to_after_authenticating]
+      reset_session
+      session[:return_to_after_authenticating] = return_to if return_to
       start_new_session_for(user)
       redirect_to after_authentication_url
     end

--- a/engines/collavre/app/controllers/collavre/sessions_controller.rb
+++ b/engines/collavre/app/controllers/collavre/sessions_controller.rb
@@ -28,6 +28,9 @@ module Collavre
         if user.email_verified?
           user.reset_failed_login_attempts!
           handle_invitation_for(user) if params[:invite_token].present?
+          return_to = session[:return_to_after_authenticating]
+          reset_session
+          session[:return_to_after_authenticating] = return_to if return_to
           start_new_session_for user
           tz = params[:timezone]
           user.update(timezone: tz) if tz.present? && user.timezone != tz


### PR DESCRIPTION
## Summary
Add `reset_session` before creating new sessions to prevent session fixation attacks.

## Changes
- `collavre/sessions_controller.rb`: Add reset_session before start_new_session_for
- `collavre/google_auth_controller.rb`: Add reset_session before start_new_session_for
- `webauthn/sessions_controller.rb`: Add reset_session before session creation

## Creative
Resolves Creative #9485