### PR TITLE
fix: add authorization checks to prevent IDOR in creative controllers

### DIFF
--- a/engines/collavre/app/controllers/collavre/comments_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comments_controller.rb
@@ -458,6 +458,9 @@ module Collavre
 
     def set_creative
       @creative = Creative.find(params[:creative_id]).effective_origin
+      unless @creative.has_permission?(Current.user, :read)
+        render json: { error: I18n.t("collavre.creatives.errors.no_permission") }, status: :forbidden
+      end
     end
 
     def set_comment

--- a/engines/collavre/app/controllers/collavre/creative_imports_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creative_imports_controller.rb
@@ -8,6 +8,10 @@ module Collavre
       end
 
       parent = params[:parent_id].present? ? Creative.find_by(id: params[:parent_id]) : nil
+      if parent && !parent.has_permission?(Current.user, :write)
+        render json: { error: I18n.t("collavre.creatives.errors.no_permission") }, status: :forbidden and return
+      end
+
       created = ::Creatives::Importer.new(file: params[:markdown], user: Current.user, parent: parent).call
 
       if created.any?

--- a/engines/collavre/app/controllers/collavre/creative_plans_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creative_plans_controller.rb
@@ -51,7 +51,7 @@ module Collavre
     private
 
     def tagger
-      ::Creatives::PlanTagger.new(plan_id: params[:plan_id], creative_ids: parsed_creative_ids)
+      ::Creatives::PlanTagger.new(plan_id: params[:plan_id], creative_ids: parsed_creative_ids, user: Current.user)
     end
 
     def parsed_creative_ids

--- a/engines/collavre/app/controllers/collavre/creative_shares_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creative_shares_controller.rb
@@ -3,6 +3,11 @@ module Collavre
     def create
       @creative = Creative.find(params[:creative_id]).effective_origin
 
+      unless @creative.has_permission?(Current.user, :admin)
+        flash[:alert] = t("collavre.creatives.errors.no_permission")
+        redirect_back(fallback_location: creatives_path) and return
+      end
+
       user = nil
       if params[:user_email].present?
         user = User.find_by(email: params[:user_email])
@@ -66,6 +71,14 @@ module Collavre
 
     def destroy
       @creative_share = CreativeShare.find(params[:id])
+      unless @creative_share.creative.has_permission?(Current.user, :admin)
+        respond_to do |format|
+          format.html { redirect_back fallback_location: main_app.root_path, alert: t("collavre.creatives.errors.no_permission") }
+          format.json { render json: { error: t("collavre.creatives.errors.no_permission") }, status: :forbidden }
+        end
+        return
+      end
+
       @creative_share.destroy
       # remove linked creative if it exists
       linked_creative = Creative.find_by(origin_id: @creative_share.creative_id, user_id: @creative_share.user_id)

--- a/engines/collavre/app/services/collavre/creatives/plan_tagger.rb
+++ b/engines/collavre/app/services/collavre/creatives/plan_tagger.rb
@@ -3,9 +3,10 @@ module Creatives
   class PlanTagger
     Result = Struct.new(:success?, :message, keyword_init: true)
 
-    def initialize(plan_id:, creative_ids: [])
+    def initialize(plan_id:, creative_ids: [], user: nil)
       @plan = Plan.find_by(id: plan_id)
       @creative_ids = Array(creative_ids).map(&:presence).compact
+      @user = user
     end
 
     def apply
@@ -31,10 +32,20 @@ module Creatives
 
     private
 
-    attr_reader :plan, :creative_ids
+    attr_reader :plan, :creative_ids, :user
 
     def creatives
-      Creative.where(id: creative_ids)
+      all_creatives = Creative.where(id: creative_ids)
+      return all_creatives unless user
+
+      # Scope to creatives the user has write permission for via creative_shares
+      permitted_ids = all_creatives.joins(:creative_shares)
+                                   .where(creative_shares: { user_id: user.id })
+                                   .where("creative_shares.permission IN (?)", %w[write admin])
+                                   .pluck(:id)
+      # Also include creatives owned by the user
+      owned_ids = all_creatives.where(user_id: user.id).pluck(:id)
+      Creative.where(id: (permitted_ids + owned_ids).uniq)
     end
 
     def valid?

--- a/engines/collavre/test/controllers/comments_controller_test.rb
+++ b/engines/collavre/test/controllers/comments_controller_test.rb
@@ -9,6 +9,21 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
     post session_path, params: { email: @user.email, password: "password" }
   end
 
+  private
+
+  # Helper to ensure users(:two) has at least read access to the creative
+  def grant_read_access_to_other_user(creative = @creative, user: users(:two), permission: :read)
+    user.update!(email_verified_at: Time.current) unless user.email_verified_at?
+    share = CreativeShare.find_by(creative: creative, user: user)
+    if share
+      share.update!(permission: permission) if share.permission.to_s < permission.to_s
+    else
+      CreativeShare.create!(creative: creative, user: user, shared_by: @user, permission: permission)
+    end
+  end
+
+  public
+
   test "convert markdown comment to sub creatives" do
     comment = @creative.comments.create!(content: "- First\n- Second", user: @user)
     assert_difference("Creative.count", 2) do
@@ -148,6 +163,7 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
   test "approver can execute private comment action" do
     approver = users(:two)
     approver.update!(email_verified_at: Time.current)
+    grant_read_access_to_other_user(user: approver, permission: :write)
 
     action_payload = {
       "action" => "update_creative",
@@ -586,6 +602,7 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
 
     non_admin = users(:two)
     non_admin.update!(email_verified_at: Time.current)
+    grant_read_access_to_other_user(user: non_admin)
 
     # Sign in as non-admin
     delete session_path
@@ -635,6 +652,7 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
   test "non-approver receives 403 (not 422) for blank action payload" do
     non_approver = users(:two)
     non_approver.update!(email_verified_at: Time.current)
+    grant_read_access_to_other_user(user: non_approver)
 
     comment = @creative.comments.create!(
       content: "Needs approval",
@@ -663,6 +681,7 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
   test "approve action performs authz check before content validation" do
     non_approver = users(:two)
     non_approver.update!(email_verified_at: Time.current)
+    grant_read_access_to_other_user(user: non_approver)
 
     # Comment with NO action (invalid state usually, but possible via direct DB creation or bugs)
     comment = @creative.comments.create!(
@@ -690,6 +709,7 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
   test "non-approver receives 403 (not 422) for invalid action payload" do
     non_approver = users(:two)
     non_approver.update!(email_verified_at: Time.current)
+    grant_read_access_to_other_user(user: non_approver)
 
     comment = @creative.comments.create!(
       content: "Needs approval",
@@ -718,6 +738,7 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
   test "non-approver cannot repair invalid action" do
     non_approver = users(:two)
     non_approver.update!(email_verified_at: Time.current)
+    grant_read_access_to_other_user(user: non_approver)
 
     comment = @creative.comments.create!(
       content: "Broken action",
@@ -835,7 +856,7 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
   test "participants returns can_share false for non-admin shared user" do
     other = users(:two)
     other.update!(email_verified_at: Time.current)
-    Collavre::CreativeShare.create!(creative: @creative, user: other, permission: :feedback)
+    grant_read_access_to_other_user(user: other, permission: :feedback)
 
     # Login as the shared user
     post session_path, params: { email: other.email, password: "password" }

--- a/engines/collavre/test/integration/comments_private_test.rb
+++ b/engines/collavre/test/integration/comments_private_test.rb
@@ -5,6 +5,7 @@ class CommentsPrivateTest < ActionDispatch::IntegrationTest
     @user1 = User.create!(email: "user1@example.com", password: TEST_PASSWORD, name: "User1")
     @user2 = User.create!(email: "user2@example.com", password: TEST_PASSWORD, name: "User2")
     @creative = Creative.create!(user: @user1, description: "Some creative")
+    CreativeShare.create!(creative: @creative, user: @user2, shared_by: @user1, permission: :read)
     @creative.comments.create!(user: @user1, content: "public")
     @creative.comments.create!(user: @user1, content: "secret", private: true)
   end


### PR DESCRIPTION
## Summary
Add proper authorization checks to controllers that access creatives by ID without verifying permissions.

## Changes
- comments_controller: Verify user access to the creative before allowing comment actions
- creative_imports_controller: Add parent creative access verification
- creative_plans_controller: Scope plan queries to user-accessible creatives
- creative_shares_controller: Add authorization for share management
- creatives/plan_tagger: Add permission checks

## Creative
Resolves Creative #9489