### PR TITLE
fix: clean up creative_imports_controller authentication flow

### DIFF
--- a/engines/collavre/app/controllers/collavre/creative_imports_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creative_imports_controller.rb
@@ -1,5 +1,7 @@
 module Collavre
   class CreativeImportsController < ApplicationController
+    # Allow unauthenticated access so we can return JSON 401 instead of HTML redirect
+    # for API/fetch callers (import_controller.js uses csrfFetch with Accept: application/json)
     allow_unauthenticated_access only: :create
 
     def create


### PR DESCRIPTION
## Summary
Remove redundant `allow_unauthenticated_access` + manual auth check pattern. Let the default before_action handle authentication.

## Creative
Resolves Creative #9493