### PR TITLE
fix: add rate limiting and documentation to MCP discovery controller

### DIFF
--- a/app/controllers/mcp/discovery_controller.rb
+++ b/app/controllers/mcp/discovery_controller.rb
@@ -1,7 +1,21 @@
 module Mcp
   class DiscoveryController < ApplicationController
+    # CSRF protection is skipped because these are read-only OAuth/MCP discovery endpoints
+    # that must be publicly accessible without session state. MCP clients and OAuth libraries
+    # need to fetch these metadata endpoints before establishing any session.
+    # See RFC 8414 (OAuth 2.0 Authorization Server Metadata) for spec details.
     skip_before_action :verify_authenticity_token
+
+    # These endpoints serve public OAuth/MCP discovery metadata and must be accessible
+    # without authentication per RFC 8414 and MCP specification requirements.
     allow_unauthenticated_access
+
+    # Rate limiting to prevent abuse of public endpoints
+    # Allow 60 requests per minute per IP address
+    rate_limit to: 60, within: 1.minute, with: -> {
+      render json: { error: I18n.t("mcp.discovery.rate_limit_exceeded") },
+             status: :too_many_requests
+    }
 
     def oauth_protected_resource
       render json: {

--- a/config/locales/mcp.en.yml
+++ b/config/locales/mcp.en.yml
@@ -1,0 +1,4 @@
+en:
+  mcp:
+    discovery:
+      rate_limit_exceeded: "Rate limit exceeded. Please try again later."

--- a/config/locales/mcp.ko.yml
+++ b/config/locales/mcp.ko.yml
@@ -1,0 +1,4 @@
+ko:
+  mcp:
+    discovery:
+      rate_limit_exceeded: "요청 횟수 제한을 초과했습니다. 잠시 후 다시 시도해주세요."


### PR DESCRIPTION
## Summary
Add rate limiting to public MCP/OAuth discovery endpoints and document why CSRF skip is appropriate.

## Creative
Resolves Creative #9496