### PR TITLE
fix: replace html_safe with content_tag/sanitize alternatives

### DIFF
--- a/engines/collavre/app/helpers/collavre/application_helper.rb
+++ b/engines/collavre/app/helpers/collavre/application_helper.rb
@@ -36,6 +36,7 @@ module Collavre
         styles << render_theme_media_query(dark_theme, "dark")
       end
 
+      # Safe: CSS generated from admin-configured theme settings (CSS variables only)
       styles.join("\n").html_safe # rubocop:disable Rails/OutputSafety
     end
 

--- a/engines/collavre/app/helpers/collavre/creatives_helper.rb
+++ b/engines/collavre/app/helpers/collavre/creatives_helper.rb
@@ -13,8 +13,11 @@ module Collavre
         suffix = " 🗓#{label.target_date}" if label.type == "Plan" and !name_only
         index += 1
         content_tag(:span, class: "tag") do
-          (index == 1 ? "" : " ").html_safe +
-          link_to("##{strip_tags(label.name)}", collavre.creatives_path(tags: [ label.id ]), class: class_name ? class_name: "", title: strip_tags(label.name)) + suffix
+          safe_join([
+            (index == 1 ? "" : " "),
+            link_to("##{strip_tags(label.name)}", collavre.creatives_path(tags: [ label.id ]), class: class_name ? class_name: "", title: strip_tags(label.name)),
+            suffix
+          ].compact)
         end
       end)
     end
@@ -67,9 +70,14 @@ module Collavre
             class: classes.join(" ")
           )
         else
-          "".html_safe
+          safe_join([])
         end
-        render_progress_value(progress_value) + comment_part + "<br />".html_safe + (creative.tags ? render_creative_tags(creative) : "".html_safe)
+        safe_join([
+          render_progress_value(progress_value),
+          comment_part,
+          tag.br,
+          (creative.tags ? render_creative_tags(creative) : safe_join([]))
+        ])
       end
     end
 

--- a/engines/collavre/app/helpers/collavre/navigation_helper.rb
+++ b/engines/collavre/app/helpers/collavre/navigation_helper.rb
@@ -103,7 +103,7 @@ module Collavre
 
     def render_nav_raw(item)
       content = resolve_nav_value(item[:content])
-      return "".html_safe if content.nil?
+      return safe_join([]) if content.nil?
       content.respond_to?(:html_safe?) && content.html_safe? ? content : ERB::Util.html_escape(content)
     end
 

--- a/engines/collavre/app/views/collavre/creatives/index.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/index.html.erb
@@ -151,7 +151,7 @@
         end +
         content_tag(:template, data: { part: "progress" }) do
           if @overall_progress.nil?
-            "".html_safe
+            safe_join([])
           else
             render_progress_value(@overall_progress)
           end


### PR DESCRIPTION
## Summary
Replace unsafe html_safe calls with content_tag, safe_join, or sanitize helpers.

## Creative
Resolves Creative #9521