### PR TITLE
fix: convert SQL interpolation to parameterized queries

### DIFF
--- a/engines/collavre/app/services/collavre/tools/creative_retrieval_service.rb
+++ b/engines/collavre/app/services/collavre/tools/creative_retrieval_service.rb
@@ -75,16 +75,17 @@ module Tools
 
     def search_creatives(query)
       sanitized = Creative.sanitize_sql_like(query)
+      pattern = "%#{sanitized}%"
 
       # Scope search to user's own + shared creatives via permission cache
       accessible_ids = accessible_creative_ids
 
       desc_ids = Creative.where(id: accessible_ids)
-                         .where("description LIKE ?", "%#{sanitized}%")
+                         .where("description LIKE ?", pattern)
                          .pluck(:id)
 
       comment_ids = Comment.where(creative_id: accessible_ids)
-                           .where("content LIKE ?", "%#{sanitized}%")
+                           .where("content LIKE ?", pattern)
                            .pluck(:creative_id)
 
       combined_ids = (desc_ids | comment_ids)

--- a/engines/collavre/app/services/collavre/tools/cron_list_service.rb
+++ b/engines/collavre/app/services/collavre/tools/cron_list_service.rb
@@ -23,7 +23,7 @@ module Tools
         unless creative.has_permission?(Current.user, :read)
           return { error: "No read permission on this Creative", id: creative_id }
         end
-        tasks = tasks.where("key LIKE ?", "cron_#{creative_id}_%")
+        tasks = tasks.where("key LIKE ?", "cron_#{creative_id.to_i}_%")
       end
 
       results = tasks.filter_map do |task|


### PR DESCRIPTION
## Summary
Convert SQL string interpolation to parameterized queries for safety and consistency.

## Creative
Resolves Creative #9524