### PR TITLE
fix: restore creative-row hover background on level-1/2/3 rows

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/creatives.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/creatives.css
@@ -435,7 +435,10 @@ creative-tree-row:not([expanded]) .creative-toggle-btn {
     background-color: var(--border-drag-over);
 }
 
-.creative-row:hover {
+.creative-row:hover,
+.creative-row.level-1:hover,
+.creative-row.level-2:hover,
+.creative-row.level-3:hover {
     background-color: var(--border-color);
 }
 


### PR DESCRIPTION
## Problem

PR #799 added `background-color` to `.creative-row.level-1/2/3` for theme customization. These selectors have higher CSS specificity than `.creative-row:hover`, so the hover background color was silently overridden — hover no longer shows any visual feedback on heading-level rows.

## Fix

Add level-specific hover selectors so hover background applies regardless of level class:

```css
.creative-row:hover,
.creative-row.level-1:hover,
.creative-row.level-2:hover,
.creative-row.level-3:hover {
    background-color: var(--border-color);
}
```

## Changes

- 1 file changed, 4 insertions, 1 deletion
- `engines/collavre/app/assets/stylesheets/collavre/creatives.css`