### PR TITLE
feat: use email username as model ID in completion API

### DIFF
--- a/engines/collavre_completion_api/app/controllers/collavre_completion_api/api/v1/base_controller.rb
+++ b/engines/collavre_completion_api/app/controllers/collavre_completion_api/api/v1/base_controller.rb
@@ -66,8 +66,9 @@ module CollavreCompletionApi
             # Legacy format: collavre/{id}
             Collavre::User.find_by(id: model_param.sub("collavre/", ""))
           else
-            # Email username format
-            Collavre::User.where("email LIKE ?", "#{model_param}@%").first
+            # Email username format — sanitize to prevent LIKE wildcard injection
+            sanitized = ActiveRecord::Base.sanitize_sql_like(model_param)
+            Collavre::User.where("email LIKE ?", "#{sanitized}@%").first
           end
 
           return nil unless agent&.ai_user?

--- a/engines/collavre_completion_api/app/controllers/collavre_completion_api/api/v1/base_controller.rb
+++ b/engines/collavre_completion_api/app/controllers/collavre_completion_api/api/v1/base_controller.rb
@@ -47,6 +47,35 @@ module CollavreCompletionApi
           Collavre::Current.user
         end
 
+        # Model ID format: email username (before @)
+        # e.g., "devbot" for devbot@collavre.local
+        # Falls back to "collavre/{id}" if email is blank
+        def agent_model_id(agent)
+          if agent.email.present?
+            agent.email.split("@").first
+          else
+            "collavre/#{agent.id}"
+          end
+        end
+
+        # Resolve agent from model parameter (email username or legacy collavre/id format)
+        def resolve_agent_by_model(model_param)
+          return nil if model_param.blank?
+
+          agent = if model_param.start_with?("collavre/")
+            # Legacy format: collavre/{id}
+            Collavre::User.find_by(id: model_param.sub("collavre/", ""))
+          else
+            # Email username format
+            Collavre::User.where("email LIKE ?", "#{model_param}@%").first
+          end
+
+          return nil unless agent&.ai_user?
+          return nil unless agent.created_by_id == current_user.id || agent.searchable?
+
+          agent
+        end
+
         def collavre_creative
           @collavre_creative ||= begin
             creative_id = request.headers["X-Collavre-Creative"]

--- a/engines/collavre_completion_api/app/controllers/collavre_completion_api/api/v1/chat/completions_controller.rb
+++ b/engines/collavre_completion_api/app/controllers/collavre_completion_api/api/v1/chat/completions_controller.rb
@@ -39,7 +39,7 @@ module CollavreCompletionApi
               context: { creative: collavre_creative, user: current_user }
             )
 
-            model_name = params[:model] || "collavre/#{agent.id}"
+            model_name = params[:model] || agent_model_id(agent)
 
             if stream
               stream_response(client, contents, model_name)
@@ -51,20 +51,7 @@ module CollavreCompletionApi
           private
 
           def resolve_agent
-            model_param = params[:model].to_s
-
-            return nil unless model_param.start_with?("collavre/")
-
-            ai_id = model_param.sub("collavre/", "")
-            agent = Collavre::User.find_by(id: ai_id)
-            return nil unless agent&.ai_user?
-            return nil unless agent_accessible?(agent)
-
-            agent
-          end
-
-          def agent_accessible?(agent)
-            agent.created_by_id == current_user.id || agent.searchable?
+            resolve_agent_by_model(params[:model].to_s)
           end
 
           def build_system_prompt(messages, agent)

--- a/engines/collavre_completion_api/app/controllers/collavre_completion_api/api/v1/models_controller.rb
+++ b/engines/collavre_completion_api/app/controllers/collavre_completion_api/api/v1/models_controller.rb
@@ -9,7 +9,7 @@ module CollavreCompletionApi
 
           models = ai_agents.map do |agent|
             {
-              id: "collavre/#{agent.id}",
+              id: agent_model_id(agent),
               object: "model",
               created: agent.created_at.to_i,
               owned_by: "collavre",

--- a/engines/collavre_completion_api/test/controllers/api/v1/completions_controller_test.rb
+++ b/engines/collavre_completion_api/test/controllers/api/v1/completions_controller_test.rb
@@ -39,14 +39,24 @@ module CollavreCompletionApi
           assert_match(/messages is required/, body.dig("error", "message"))
         end
 
-        test "returns 400 with invalid model format" do
+        test "returns 400 with non-existent email username model" do
           post "/api/v1/chat/completions",
-               params: { model: "gpt-4", messages: [ { role: "user", content: "hi" } ] }.to_json,
+               params: { model: "nonexistent", messages: [ { role: "user", content: "hi" } ] }.to_json,
                headers: auth_headers
 
           assert_response :bad_request
           body = JSON.parse(response.body)
           assert_match(/Invalid model/, body.dig("error", "message"))
+        end
+
+        test "resolves agent by email username" do
+          post "/api/v1/chat/completions",
+               params: { model: "bot", messages: [ { role: "user", content: "hi" } ] }.to_json,
+               headers: auth_headers
+
+          # Agent resolved successfully — should not return "Invalid model" error
+          body = JSON.parse(response.body)
+          refute_equal "Invalid model", body.dig("error", "message")
         end
 
         test "returns 400 with non-existent agent" do

--- a/engines/collavre_completion_api/test/controllers/api/v1/completions_controller_test.rb
+++ b/engines/collavre_completion_api/test/controllers/api/v1/completions_controller_test.rb
@@ -49,6 +49,16 @@ module CollavreCompletionApi
           assert_match(/Invalid model/, body.dig("error", "message"))
         end
 
+        test "returns 400 with external model name" do
+          post "/api/v1/chat/completions",
+               params: { model: "gpt-4", messages: [ { role: "user", content: "hi" } ] }.to_json,
+               headers: auth_headers
+
+          assert_response :bad_request
+          body = JSON.parse(response.body)
+          assert_match(/Invalid model/, body.dig("error", "message"))
+        end
+
         test "resolves agent by email username" do
           post "/api/v1/chat/completions",
                params: { model: "bot", messages: [ { role: "user", content: "hi" } ] }.to_json,

--- a/engines/collavre_completion_api/test/controllers/api/v1/models_controller_test.rb
+++ b/engines/collavre_completion_api/test/controllers/api/v1/models_controller_test.rb
@@ -32,7 +32,7 @@ module CollavreCompletionApi
           assert body["data"].is_a?(Array)
 
           model_ids = body["data"].map { |m| m["id"] }
-          assert_includes model_ids, "collavre/#{@ai_bot.id}"
+          assert_includes model_ids, "bot"
         end
 
         test "returns 401 without token" do
@@ -66,7 +66,7 @@ module CollavreCompletionApi
           assert_response :success
           body = JSON.parse(response.body)
           model_ids = body["data"].map { |m| m["id"] }
-          refute_includes model_ids, "collavre/#{@ai_bot.id}"
+          refute_includes model_ids, "bot"
         end
 
         test "includes searchable agents for other users" do
@@ -83,7 +83,7 @@ module CollavreCompletionApi
           assert_response :success
           body = JSON.parse(response.body)
           model_ids = body["data"].map { |m| m["id"] }
-          assert_includes model_ids, "collavre/#{@ai_bot.id}"
+          assert_includes model_ids, "bot"
         end
       end
     end


### PR DESCRIPTION
## Summary

Change the completion API model ID format from `collavre/{id}` (numeric) to email username for better readability and usability.

## Changes

### Before
```json
{ "id": "collavre/5", "object": "model", ... }
// Usage: model: "collavre/5"
```

### After
```json
{ "id": "devbot", "object": "model", ... }
// Usage: model: "devbot"
```

### Backward Compatibility
- Legacy `collavre/{id}` format still supported in `resolve_agent_by_model`
- Falls back to `collavre/{id}` if agent has no email

### Code Changes
- **`BaseController`**: Extract `agent_model_id` and `resolve_agent_by_model` helpers
- **`ModelsController`**: Use `agent_model_id(agent)` instead of `"collavre/#{agent.id}"`
- **`CompletionsController`**: Replace private `resolve_agent`/`agent_accessible?` with shared `resolve_agent_by_model`
- **Tests**: Updated model ID assertions + added email username resolution test

### Files Changed (5 files, +47/-21)
- `base_controller.rb` — new helper methods
- `completions_controller.rb` — simplified agent resolution
- `models_controller.rb` — new model ID format
- 2 test files updated

## Testing
- 1235 runs, 3927 assertions, 0 failures, 0 errors