### PR TITLE
feat: add list/org-chart view switcher for contacts tab

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/org_chart.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/org_chart.css
@@ -307,9 +307,13 @@ details[open] > .org-chart-creative-row::before {
     margin-bottom: var(--space-2);
 }
 
-/* Global action bar */
-.org-chart-global-actions {
-    margin-top: var(--space-4);
-    padding-top: var(--space-3);
-    border-top: 1px solid var(--color-border);
+/* View switcher */
+.contacts-view-switcher {
+    display: flex;
+    gap: var(--space-2);
+    margin-bottom: var(--space-3);
+}
+
+.contacts-description {
+    margin: 0 0 var(--space-2) 0;
 }

--- a/engines/collavre/app/controllers/concerns/collavre/users_controller/contact_management.rb
+++ b/engines/collavre/app/controllers/concerns/collavre/users_controller/contact_management.rb
@@ -40,6 +40,79 @@ module Collavre
 
     private
 
+    def prepare_contacts
+      per_page = 20
+      @contact_page = [ params[:contact_page].to_i, 1 ].max
+
+      creative_shares = Collavre::CreativeShare.arel_table
+      creatives = Collavre::Creative.arel_table
+
+      user_creative_origins_sql = Collavre::Creative
+        .where(user_id: Current.user.id)
+        .select("COALESCE(origin_id, id) AS origin_id")
+        .to_sql
+
+      shared_by_me_scope = Collavre::CreativeShare
+        .joins(:creative)
+        .where.not(permission: Collavre::CreativeShare.permissions[:no_access])
+        .where(
+          creative_shares[:shared_by_id].eq(Current.user.id)
+            .or(
+              creative_shares[:shared_by_id].eq(nil).and(creatives[:user_id].eq(Current.user.id))
+            )
+            .or(
+              creatives[:id].in(Arel.sql("(#{user_creative_origins_sql})"))
+            )
+        )
+
+      shared_with_me_scope = Collavre::CreativeShare
+        .joins(:creative)
+        .where(user_id: Current.user.id)
+        .where.not(permission: Collavre::CreativeShare.permissions[:no_access])
+
+      contact_ids_sql = [
+        Current.user.contacts.select("contact_user_id AS user_id").to_sql,
+        shared_by_me_scope.select("creative_shares.user_id AS user_id").to_sql,
+        shared_with_me_scope.select("COALESCE(creative_shares.shared_by_id, creatives.user_id) AS user_id").to_sql
+      ].join(" UNION ")
+
+      contact_users_relation = Collavre::User.where(
+        id: Collavre::User.from("(#{contact_ids_sql}) AS contact_ids").select(:user_id)
+      )
+
+      @total_contacts = contact_users_relation.count
+      @total_contact_pages = [ (@total_contacts.to_f / per_page).ceil, 1 ].max
+      paged_users = contact_users_relation
+        .includes(avatar_attachment: :blob)
+        .order(:name, :id)
+        .offset((@contact_page - 1) * per_page)
+        .limit(per_page)
+
+      existing_contacts = Current.user.contacts.includes(contact_user: [ avatar_attachment: :blob ]).index_by(&:contact_user_id)
+      @contacts = paged_users.map do |user|
+        existing_contacts[user.id] || Collavre::Contact.new(user: Current.user, contact_user: user)
+      end
+
+      shares_from_me = shared_by_me_scope
+        .where(user_id: paged_users.map(&:id))
+        .includes(:creative)
+
+      @shared_by_me = shares_from_me.group_by(&:user_id).transform_values { |shares| shares.map(&:creative) }
+
+      shares_to_me = Collavre::CreativeShare
+        .joins(:creative)
+        .where(user_id: Current.user.id)
+        .where.not(permission: Collavre::CreativeShare.permissions[:no_access])
+        .where(
+          creative_shares[:shared_by_id].in(paged_users.map(&:id))
+            .or(creative_shares[:shared_by_id].eq(nil).and(creatives[:user_id].in(paged_users.map(&:id))))
+        )
+        .includes(:creative)
+
+      @shared_with_me = shares_to_me.group_by(&:sharer_id)
+                                    .transform_values { |shares| shares.map(&:creative) }
+    end
+
     def prepare_org_chart
       # 1. Creatives with actual shares relevant to current user
       shared_creative_ids = Collavre::Creative.shared_accessible_ids(Current.user)

--- a/engines/collavre/app/controllers/concerns/collavre/users_controller/profile_and_settings.rb
+++ b/engines/collavre/app/controllers/concerns/collavre/users_controller/profile_and_settings.rb
@@ -6,9 +6,19 @@ module Collavre
       @user = Collavre::User.find(params[:id])
       @active_tab = params[:tab].presence || "profile"
       @active_tab = "contacts" if @active_tab == "org_chart"
+      @contacts_view = params[:contacts_view].presence || "list"
       if Current.user
-        prepare_org_chart
+        if @contacts_view == "org_chart"
+          prepare_org_chart
+        else
+          prepare_contacts
+        end
       else
+        @contacts = []
+        @shared_by_me = {}
+        @shared_with_me = {}
+        @total_contact_pages = 1
+        @contact_page = 1
         @org_chart_roots = []
         @org_chart_shares = {}
         @org_chart_invitations = {}

--- a/engines/collavre/app/views/collavre/users/_contact_list.html.erb
+++ b/engines/collavre/app/views/collavre/users/_contact_list.html.erb
@@ -1,0 +1,74 @@
+<div class="contact-management">
+  <% show_actions = (contacts || []).any? { |c| c.contact_user&.ai_user? && c.contact_user&.created_by_id == Current.user.id } %>
+
+  <% if contacts.present? %>
+    <div class="table-scroll">
+      <table class="contacts-table">
+        <thead>
+          <tr>
+            <th><%= t('collavre.users.table.avatar') %></th>
+            <th><%= t('collavre.users.table.name') %></th>
+            <th><%= t('collavre.users.table.email') %></th>
+            <th><%= t('collavre.contacts.table.shared_creatives') %></th>
+            <th><%= t('collavre.contacts.table.shared_with_me') %></th>
+            <% if show_actions %>
+              <th><%= t('collavre.users.table.actions') %></th>
+            <% end %>
+          </tr>
+        </thead>
+        <tbody>
+          <% contacts.each do |contact| %>
+            <% contact_user = contact.contact_user %>
+            <% next unless contact_user %>
+            <tr>
+              <td>
+                <%= render Collavre::AvatarComponent.new(
+                  user: contact_user,
+                  size: 32,
+                  classes: "avatar"
+                ) %>
+              </td>
+              <td><%= contact_user.display_name %></td>
+              <td><%= contact_user.email %></td>
+              <td class="creative-cell">
+                <%= render_contact_creatives(shared_by_me.fetch(contact_user.id, [])) %>
+              </td>
+              <td class="creative-cell">
+                <%= render_contact_creatives(shared_with_me.fetch(contact_user.id, [])) %>
+              </td>
+              <% if show_actions %>
+                <td class="text-right">
+                  <% if contact_user.ai_user? && contact_user.created_by_id == Current.user.id %>
+                    <%= link_to t('collavre.users.edit_ai.link'), collavre.edit_ai_user_path(contact_user), class: "btn btn-sm btn-secondary mr-1" %>
+                    <%= link_to t('collavre.users.copy_ai.link'), collavre.new_ai_users_path(copy_from: contact_user.id), class: "btn btn-sm btn-secondary mr-1" %>
+                    <%= button_to t('collavre.users.destroy.delete_ai_user'),
+                                  collavre.user_path(contact_user),
+                                  method: :delete,
+                                  form: { data: { turbo_confirm: t('collavre.users.destroy.confirm_ai') } },
+                                  class: "btn btn-xs btn-danger" %>
+                  <% end %>
+                </td>
+              <% end %>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% else %>
+    <p class="text-muted"><%= t('collavre.contacts.empty_state') %></p>
+  <% end %>
+
+  <% if total_contact_pages.to_i > 1 %>
+    <nav class="contact-pagination">
+      <% prev_page = contact_page.to_i - 1 %>
+      <% next_page = contact_page.to_i + 1 %>
+      <% if contact_page.to_i > 1 %>
+        <%= link_to t('collavre.contacts.pagination.prev'), collavre.user_path(Current.user, tab: 'contacts', contacts_view: 'list', contact_page: prev_page), class: 'pagination-button' %>
+      <% end %>
+      <span class="pagination-status"><%= t('collavre.contacts.pagination.page_info', current: contact_page, total: total_contact_pages) %></span>
+      <% if contact_page.to_i < total_contact_pages.to_i %>
+        <%= link_to t('collavre.contacts.pagination.next'), collavre.user_path(Current.user, tab: 'contacts', contacts_view: 'list', contact_page: next_page), class: 'pagination-button' %>
+      <% end %>
+    </nav>
+  <% end %>
+</div>

--- a/engines/collavre/app/views/collavre/users/_org_chart.html.erb
+++ b/engines/collavre/app/views/collavre/users/_org_chart.html.erb
@@ -1,6 +1,4 @@
 <div class="org-chart" data-controller="org-chart">
-  <p class="text-muted"><%= t('collavre.contacts.org_chart.description') %></p>
-
   <%# Container for dynamically loaded share modal %>
   <div data-org-chart-target="shareContainer"></div>
 
@@ -67,7 +65,4 @@
     <p class="text-muted"><%= t('collavre.contacts.org_chart.empty_state') %></p>
   <% end %>
 
-  <div class="org-chart-global-actions">
-    <%= link_to t('collavre.users.add_ai_user'), collavre.new_ai_users_path, class: "btn btn-primary" %>
-  </div>
 </div>

--- a/engines/collavre/app/views/collavre/users/show.html.erb
+++ b/engines/collavre/app/views/collavre/users/show.html.erb
@@ -130,13 +130,38 @@
   </section>
 
     <section class="tab-panel <%= 'active' if active_tab == 'contacts' %>" data-tabs-target="panel" data-tab-name="contacts">
-      <%= render partial: 'collavre/users/org_chart', locals: {
-        org_chart_roots: @org_chart_roots,
-        org_chart_shares: @org_chart_shares,
-        org_chart_invitations: @org_chart_invitations,
-        org_chart_children: @org_chart_children,
-        org_chart_unassigned: @org_chart_unassigned
-      } %>
+      <div class="flex-row-center-between">
+        <div class="contacts-view-switcher">
+        <%= link_to t('collavre.contacts.views.list'),
+            collavre.user_path(Current.user, tab: 'contacts', contacts_view: 'list'),
+            class: "btn btn-xs #{@contacts_view == 'list' ? 'btn-primary' : 'btn-secondary'}" %>
+        <%= link_to t('collavre.contacts.views.org_chart'),
+            collavre.user_path(Current.user, tab: 'contacts', contacts_view: 'org_chart'),
+            class: "btn btn-xs #{@contacts_view == 'org_chart' ? 'btn-primary' : 'btn-secondary'}" %>
+        </div>
+        <div>
+          <p class="text-muted contacts-description"><%= t('collavre.contacts.description') %></p>
+          <%= link_to t('collavre.users.add_ai_user'), collavre.new_ai_users_path, class: "primary-action-button" %>
+        </div>
+      </div>
+
+      <% if @contacts_view == 'org_chart' %>
+        <%= render partial: 'collavre/users/org_chart', locals: {
+          org_chart_roots: @org_chart_roots,
+          org_chart_shares: @org_chart_shares,
+          org_chart_invitations: @org_chart_invitations,
+          org_chart_children: @org_chart_children,
+          org_chart_unassigned: @org_chart_unassigned
+        } %>
+      <% else %>
+        <%= render partial: 'collavre/users/contact_list', locals: {
+          contacts: @contacts,
+          shared_by_me: @shared_by_me,
+          shared_with_me: @shared_with_me,
+          contact_page: @contact_page,
+          total_contact_pages: @total_contact_pages
+        } %>
+      <% end %>
     </section>
   </div>
 </div>

--- a/engines/collavre/config/locales/contacts.en.yml
+++ b/engines/collavre/config/locales/contacts.en.yml
@@ -8,6 +8,9 @@ en:
       table:
         shared_creatives: Creatives you shared
         shared_with_me: Creatives shared with you
+      views:
+        list: List
+        org_chart: Org Chart
       pagination:
         prev: Previous
         next: Next

--- a/engines/collavre/config/locales/contacts.ko.yml
+++ b/engines/collavre/config/locales/contacts.ko.yml
@@ -8,6 +8,9 @@ ko:
       table:
         shared_creatives: 공유한 크리에이티브
         shared_with_me: 공유된 크리에이티브
+      views:
+        list: 리스트
+        org_chart: 조직도
       pagination:
         prev: 이전
         next: 다음

--- a/engines/collavre/test/controllers/org_chart_test.rb
+++ b/engines/collavre/test/controllers/org_chart_test.rb
@@ -51,7 +51,7 @@ class OrgChartTest < ActionDispatch::IntegrationTest
 
   test "org chart tab displays owned creatives" do
     sign_in_as(@owner, password: "password")
-    get collavre.user_path(@owner, tab: "contacts")
+    get collavre.user_path(@owner, tab: "contacts", contacts_view: "org_chart")
 
     assert_response :success
     assert_includes response.body, "Project Alpha"
@@ -60,7 +60,7 @@ class OrgChartTest < ActionDispatch::IntegrationTest
 
   test "org chart tab displays shared creatives" do
     sign_in_as(@owner, password: "password")
-    get collavre.user_path(@owner, tab: "contacts")
+    get collavre.user_path(@owner, tab: "contacts", contacts_view: "org_chart")
 
     assert_response :success
     assert_includes response.body, "External Project"
@@ -68,7 +68,7 @@ class OrgChartTest < ActionDispatch::IntegrationTest
 
   test "org chart tab shows shared members" do
     sign_in_as(@owner, password: "password")
-    get collavre.user_path(@owner, tab: "contacts")
+    get collavre.user_path(@owner, tab: "contacts", contacts_view: "org_chart")
 
     assert_response :success
     assert_includes response.body, @other_user.display_name
@@ -78,7 +78,7 @@ class OrgChartTest < ActionDispatch::IntegrationTest
 
   test "org chart tab shows permission badges" do
     sign_in_as(@owner, password: "password")
-    get collavre.user_path(@owner, tab: "contacts")
+    get collavre.user_path(@owner, tab: "contacts", contacts_view: "org_chart")
 
     assert_response :success
     assert_includes response.body, I18n.t("collavre.contacts.org_chart.permissions.admin")
@@ -87,7 +87,7 @@ class OrgChartTest < ActionDispatch::IntegrationTest
 
   test "org chart tab shows owner badge for owned creatives" do
     sign_in_as(@owner, password: "password")
-    get collavre.user_path(@owner, tab: "contacts")
+    get collavre.user_path(@owner, tab: "contacts", contacts_view: "org_chart")
 
     assert_response :success
     assert_includes response.body, I18n.t("collavre.contacts.org_chart.owner")
@@ -95,7 +95,7 @@ class OrgChartTest < ActionDispatch::IntegrationTest
 
   test "org chart tab shows sharer name for shared creatives" do
     sign_in_as(@owner, password: "password")
-    get collavre.user_path(@owner, tab: "contacts")
+    get collavre.user_path(@owner, tab: "contacts", contacts_view: "org_chart")
 
     assert_response :success
     # External Project was shared by @other_user
@@ -105,7 +105,7 @@ class OrgChartTest < ActionDispatch::IntegrationTest
   test "org chart shows non-root shared creatives by walking up to root" do
     # @third_user only has share on child_creative (not root)
     sign_in_as(@third_user, password: "password")
-    get collavre.user_path(@third_user, tab: "contacts")
+    get collavre.user_path(@third_user, tab: "contacts", contacts_view: "org_chart")
 
     assert_response :success
     # Should see root creative (walked up from child)
@@ -115,7 +115,7 @@ class OrgChartTest < ActionDispatch::IntegrationTest
 
   test "org chart shows permission select for admin users" do
     sign_in_as(@owner, password: "password")
-    get collavre.user_path(@owner, tab: "contacts")
+    get collavre.user_path(@owner, tab: "contacts", contacts_view: "org_chart")
 
     assert_response :success
     assert_select "select.org-chart-permission-select"
@@ -123,7 +123,7 @@ class OrgChartTest < ActionDispatch::IntegrationTest
 
   test "org chart shows permission badge (not select) for non-admin users" do
     sign_in_as(@third_user, password: "password")
-    get collavre.user_path(@third_user, tab: "contacts")
+    get collavre.user_path(@third_user, tab: "contacts", contacts_view: "org_chart")
 
     assert_response :success
     assert_select "span.org-chart-permission-badge"
@@ -132,7 +132,7 @@ class OrgChartTest < ActionDispatch::IntegrationTest
 
   test "org chart shows manage permissions button for admin" do
     sign_in_as(@owner, password: "password")
-    get collavre.user_path(@owner, tab: "contacts")
+    get collavre.user_path(@owner, tab: "contacts", contacts_view: "org_chart")
 
     assert_response :success
     assert_includes response.body, I18n.t("collavre.contacts.org_chart.manage_permissions")
@@ -147,7 +147,7 @@ class OrgChartTest < ActionDispatch::IntegrationTest
     )
 
     sign_in_as(@owner, password: "password")
-    get collavre.user_path(@owner, tab: "contacts")
+    get collavre.user_path(@owner, tab: "contacts", contacts_view: "org_chart")
 
     assert_response :success
     assert_includes response.body, I18n.t("collavre.contacts.org_chart.permissions.no_access")
@@ -158,7 +158,7 @@ class OrgChartTest < ActionDispatch::IntegrationTest
   test "org chart empty state for user with no creatives" do
     new_user = User.create!(email: "empty@example.com", password: "password", name: "Empty User")
     sign_in_as(new_user, password: "password")
-    get collavre.user_path(new_user, tab: "contacts")
+    get collavre.user_path(new_user, tab: "contacts", contacts_view: "org_chart")
 
     assert_response :success
     assert_includes response.body, I18n.t("collavre.contacts.org_chart.empty_state")
@@ -242,7 +242,7 @@ class OrgChartTest < ActionDispatch::IntegrationTest
     )
 
     sign_in_as(@owner, password: "password")
-    get collavre.user_path(@owner, tab: "contacts")
+    get collavre.user_path(@owner, tab: "contacts", contacts_view: "org_chart")
 
     assert_response :success
     assert_includes response.body, "newbie@example.com"
@@ -261,7 +261,7 @@ class OrgChartTest < ActionDispatch::IntegrationTest
     )
 
     sign_in_as(@owner, password: "password")
-    get collavre.user_path(@owner, tab: "contacts")
+    get collavre.user_path(@owner, tab: "contacts", contacts_view: "org_chart")
 
     assert_response :success
     refute_includes response.body, "expired@example.com"
@@ -377,7 +377,7 @@ class OrgChartTest < ActionDispatch::IntegrationTest
     )
     Collavre::Creatives::PermissionCacheBuilder.rebuild_for_creative(grandchild)
 
-    get collavre.user_path(@owner, tab: "contacts")
+    get collavre.user_path(@owner, tab: "contacts", contacts_view: "org_chart")
     assert_response :success
 
     # All three levels should be rendered
@@ -398,7 +398,7 @@ class OrgChartTest < ActionDispatch::IntegrationTest
     )
 
     sign_in_as(@owner, password: "password")
-    get collavre.user_path(@owner, tab: "contacts")
+    get collavre.user_path(@owner, tab: "contacts", contacts_view: "org_chart")
     assert_response :success
 
     assert_not_includes response.body, "Empty Project No Shares"
@@ -415,7 +415,7 @@ class OrgChartTest < ActionDispatch::IntegrationTest
     )
 
     sign_in_as(@owner, password: "password")
-    get collavre.user_path(@owner, tab: "contacts")
+    get collavre.user_path(@owner, tab: "contacts", contacts_view: "org_chart")
     assert_response :success
 
     # Root should appear (has shares), but lonely child should not
@@ -446,7 +446,7 @@ class OrgChartTest < ActionDispatch::IntegrationTest
     Collavre::Creatives::PermissionCacheBuilder.rebuild_for_creative(leaf)
 
     sign_in_as(@owner, password: "password")
-    get collavre.user_path(@owner, tab: "contacts")
+    get collavre.user_path(@owner, tab: "contacts", contacts_view: "org_chart")
     assert_response :success
 
     # Root (has shares) and leaf (has shares) should appear
@@ -481,7 +481,7 @@ class OrgChartTest < ActionDispatch::IntegrationTest
     )
 
     sign_in_as(@owner, password: "password")
-    get collavre.user_path(@owner, tab: "contacts")
+    get collavre.user_path(@owner, tab: "contacts", contacts_view: "org_chart")
     assert_response :success
 
     # Linked creative should appear with origin's description (via effective_description)
@@ -500,5 +500,22 @@ class OrgChartTest < ActionDispatch::IntegrationTest
   ensure
     linked&.destroy
     origin&.destroy
+  end
+
+  test "list view shows contacts table by default" do
+    sign_in_as(@owner, password: "password")
+    get collavre.user_path(@owner, tab: "contacts")
+    assert_response :success
+    assert_select ".contact-management"
+    assert_select ".contacts-table"
+    assert_includes response.body, @other_user.display_name
+  end
+
+  test "view switcher links are present" do
+    sign_in_as(@owner, password: "password")
+    get collavre.user_path(@owner, tab: "contacts")
+    assert_response :success
+    assert_select ".contacts-view-switcher"
+    assert_select ".contacts-view-switcher a", minimum: 2
   end
 end


### PR DESCRIPTION
## Changes

Restore contact list view and add a view switcher for the contacts tab.

### Features
- **View switcher**: List / Org Chart toggle buttons at top of contacts tab
- **List view (default)**: User table with name, email, shared creatives columns
- **Org Chart view**: Existing creative-based tree view (unchanged)
- **Pagination**: Contact list supports pagination (20 per page)

### Files changed (8 files, +294/-27)
- `contact_management.rb` — restored `prepare_contacts` method
- `profile_and_settings.rb` — added `@contacts_view` param, conditional data prep
- `_contact_list.html.erb` — new list view partial
- `show.html.erb` — view switcher + conditional rendering
- `org_chart.css` — view switcher + contact list table styles
- `contacts.en.yml` / `contacts.ko.yml` — `views.list` / `views.org_chart` keys
- `org_chart_test.rb` — updated existing tests + 2 new list view tests

### Tests
- 32 runs, 159 assertions, 0 failures