### PR TITLE
feat: drag and drop topics to move between creatives

### DIFF
--- a/engines/collavre/app/controllers/collavre/topics_controller.rb
+++ b/engines/collavre/app/controllers/collavre/topics_controller.rb
@@ -63,6 +63,40 @@ module Collavre
       head :no_content
     end
 
+    def move
+      unless @creative.has_permission?(Current.user, :admin) || @creative.user == Current.user
+        render json: { error: I18n.t("collavre.topics.no_permission") }, status: :forbidden and return
+      end
+
+      topic = @creative.topics.find(params[:id])
+      target_creative = Creative.find(params[:target_creative_id]).effective_origin
+
+      unless target_creative.has_permission?(Current.user, :write) || target_creative.user == Current.user
+        render json: { error: I18n.t("collavre.topics.move.no_target_permission") }, status: :forbidden and return
+      end
+
+      # Check for duplicate topic name in target creative
+      if target_creative.topics.where(name: topic.name).exists?
+        render json: { error: I18n.t("collavre.topics.move.duplicate_name", name: topic.name) }, status: :unprocessable_entity and return
+      end
+
+      Topic.transaction do
+        topic.comments.update_all(creative_id: target_creative.id)
+        topic.update!(creative: target_creative)
+      end
+
+      TopicsChannel.broadcast_to(
+        @creative,
+        { action: "deleted", topic_id: topic.id }
+      )
+      TopicsChannel.broadcast_to(
+        target_creative,
+        { action: "created", topic: topic.slice(:id, :name) }
+      )
+
+      render json: { success: true, topic: topic.slice(:id, :name), target_creative_id: target_creative.id }
+    end
+
     def reorder
       unless @creative.has_permission?(Current.user, :admin) || @creative.user == Current.user
         render json: { error: I18n.t("collavre.topics.no_permission") }, status: :forbidden and return

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -15,11 +15,14 @@ export default class extends Controller {
             this.subscribe()
         }
         this.handleNewMessage = this.handleNewMessage.bind(this)
+        this.handleTopicMoved = this.handleTopicMoved.bind(this)
         window.addEventListener('comments--topics:new-message', this.handleNewMessage)
+        window.addEventListener('collavre:topic-moved', this.handleTopicMoved)
     }
 
     disconnect() {
         window.removeEventListener('comments--topics:new-message', this.handleNewMessage)
+        window.removeEventListener('collavre:topic-moved', this.handleTopicMoved)
         this.unsubscribe()
     }
 
@@ -169,6 +172,11 @@ export default class extends Controller {
 
         this.draggingTopicId = topicId
         event.dataTransfer.setData('application/x-topic-id', topicId)
+        // Include topic move data so creative tree rows can accept this drop
+        event.dataTransfer.setData('application/x-topic-move', JSON.stringify({
+            topicId,
+            sourceCreativeId: this.creativeId
+        }))
         event.dataTransfer.effectAllowed = 'move'
 
         requestAnimationFrame(() => {
@@ -480,6 +488,19 @@ export default class extends Controller {
         const activeEl = this.listTarget.querySelector('.topic-tag.active')
         if (activeEl) {
             activeEl.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'center' })
+        }
+    }
+
+    handleTopicMoved(event) {
+        const { sourceCreativeId, topicId } = event.detail
+        // Reload topics if the moved topic belonged to the currently viewed creative
+        if (String(sourceCreativeId) === String(this.creativeId)) {
+            // If we were viewing the moved topic, switch to Main
+            if (String(this.currentTopicId) === String(topicId)) {
+                this.currentTopicId = ""
+                this.dispatch("change", { detail: { topicId: "" } })
+            }
+            this.loadTopics()
         }
     }
 

--- a/engines/collavre/app/javascript/creatives/drag_drop/event_handlers.js
+++ b/engines/collavre/app/javascript/creatives/drag_drop/event_handlers.js
@@ -24,7 +24,7 @@ import {
   hasDraggedState,
 } from './state';
 import { createMoveContext, applyMove, revertMove } from './operations';
-import { sendNewOrder, sendLinkedCreative } from '../../lib/api/drag_drop';
+import { sendNewOrder, sendLinkedCreative, sendTopicMove } from '../../lib/api/drag_drop';
 import { initIndicator, showLinkHover, hideLinkHover } from './indicator';
 
 const childZoneRatio = 0.3;
@@ -541,6 +541,17 @@ export function handleDragOver(event) {
     clearDragHighlight(lastRow);
   }
   if (!tree || tree.draggable === false) return;
+
+  // Topic move drag: always show as child drop target
+  if (event.dataTransfer.types.includes('application/x-topic-move')) {
+    event.preventDefault();
+    event.dataTransfer.dropEffect = 'move';
+    tree.classList.add('drag-over', 'drag-over-child', 'child-drop-indicator-active');
+    tree.classList.remove('drag-over-top', 'drag-over-bottom');
+    setLastDragOverRow(tree);
+    return;
+  }
+
   event.preventDefault();
   event.dataTransfer.dropEffect = 'move';
 
@@ -599,6 +610,36 @@ function resetDrag() {
 export function handleDrop(event) {
   const targetTree = event.target.closest(DRAGGABLE_SELECTOR);
   const targetId = targetTree ? targetTree.id : '';
+
+  // Handle topic move drop
+  const topicMoveData = event.dataTransfer.getData('application/x-topic-move');
+  if (topicMoveData && targetTree) {
+    event.preventDefault();
+    clearDragHighlight(targetTree);
+    clearDragHighlight(getLastDragOverRow());
+
+    try {
+      const { topicId, sourceCreativeId } = JSON.parse(topicMoveData);
+      const targetCreativeId = targetId.replace('creative-', '');
+
+      if (sourceCreativeId === targetCreativeId) return;
+
+      sendTopicMove({ topicId, sourceCreativeId, targetCreativeId })
+        .then(() => {
+          // Dispatch event so topic list refreshes
+          window.dispatchEvent(new CustomEvent('collavre:topic-moved', {
+            detail: { topicId, sourceCreativeId, targetCreativeId }
+          }));
+        })
+        .catch((error) => {
+          console.error('Failed to move topic', error);
+          alert(error.message || 'Failed to move topic');
+        });
+    } catch (error) {
+      console.error('Failed to parse topic move data', error);
+    }
+    return;
+  }
 
   // Capture visual state before clearing highlights to ensure WYSIWYG
   const isVisualTop = targetTree && targetTree.classList.contains('drag-over-top');

--- a/engines/collavre/app/javascript/lib/api/drag_drop.js
+++ b/engines/collavre/app/javascript/lib/api/drag_drop.js
@@ -17,6 +17,23 @@ export function sendNewOrder({ draggedId, draggedIds, targetId, direction }) {
   });
 }
 
+export function sendTopicMove({ topicId, sourceCreativeId, targetCreativeId }) {
+  return csrfFetch(`/creatives/${sourceCreativeId}/topics/${topicId}/move`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ target_creative_id: targetCreativeId }),
+  }).then((response) => {
+    if (!response.ok) {
+      return response.json().then((data) => {
+        throw new Error(data.error || 'Failed to move topic');
+      });
+    }
+    return response.json();
+  });
+}
+
 export function sendLinkedCreative({ draggedId, targetId, direction }) {
   return csrfFetch('/creatives/link_drop', {
     method: 'POST',

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -5,6 +5,9 @@ en:
       delete_confirm: This will delete all messages in this topic. Are you sure?
       new_placeholder: New Topic
       no_permission: You don't have permission to perform this action.
+      move:
+        no_target_permission: You don't have write permission on the target creative.
+        duplicate_name: A topic named '%{name}' already exists in the target creative.
     github_auth:
       login_first: Please sign in first.
       connected: Github account connected successfully.

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -5,6 +5,9 @@ ko:
       delete_confirm: 이 토픽의 모든 메시지가 삭제됩니다. 확실합니까?
       new_placeholder: 새 토픽
       no_permission: 이 작업을 수행할 권한이 없습니다.
+      move:
+        no_target_permission: 대상 크리에이티브에 대한 쓰기 권한이 없습니다.
+        duplicate_name: "'%{name}' 토픽이 대상 크리에이티브에 이미 존재합니다."
     github_auth:
       login_first: 먼저 로그인해주세요.
       connected: Github 계정이 연동되었습니다.

--- a/engines/collavre/config/routes.rb
+++ b/engines/collavre/config/routes.rb
@@ -55,6 +55,9 @@ Collavre::Engine.routes.draw do
       collection do
         post :reorder
       end
+      member do
+        patch :move
+      end
     end
     resources :comments, only: [ :index, :create, :destroy, :show, :update ] do
       member do

--- a/engines/collavre/test/controllers/topics_controller_test.rb
+++ b/engines/collavre/test/controllers/topics_controller_test.rb
@@ -73,6 +73,50 @@ class TopicsControllerTest < ActionDispatch::IntegrationTest
     assert_response :unprocessable_entity
   end
 
+  test "should move topic with comments to another creative" do
+    target_creative = creatives(:root_parent)
+    comment = Collavre::Comment.create!(creative: @creative, topic: @topic, user: @user, content: "test comment")
+
+    patch move_creative_topic_url(@creative, @topic), params: { target_creative_id: target_creative.id }, as: :json
+
+    assert_response :success
+    @topic.reload
+    comment.reload
+    assert_equal target_creative.id, @topic.creative_id
+    assert_equal target_creative.id, comment.creative_id, "Comment should move with topic"
+  end
+
+  test "should not move topic without permission on source creative" do
+    other_user = users(:two)
+    sign_in_as other_user, password: "password"
+
+    target_creative = creatives(:root_parent)
+
+    patch move_creative_topic_url(@creative, @topic), params: { target_creative_id: target_creative.id }, as: :json
+
+    assert_response :forbidden
+  end
+
+  test "should not move topic without write permission on target creative" do
+    target_creative = creatives(:root_parent)
+    target_creative.update!(user: users(:two))
+
+    patch move_creative_topic_url(@creative, @topic), params: { target_creative_id: target_creative.id }, as: :json
+
+    assert_response :forbidden
+  end
+
+  test "should not move topic if duplicate name exists in target" do
+    target_creative = creatives(:root_parent)
+    target_creative.topics.create!(name: @topic.name, user: @user)
+
+    patch move_creative_topic_url(@creative, @topic), params: { target_creative_id: target_creative.id }, as: :json
+
+    assert_response :unprocessable_entity
+    json = JSON.parse(response.body)
+    assert json["error"].include?(@topic.name)
+  end
+
   test "new topic should be created at the end after reordering" do
     # Create initial topics
     topic2 = @creative.topics.create!(name: "Topic 2", user: @user)


### PR DESCRIPTION
## Summary
Add the ability to drag a topic tag and drop it onto a creative tree row to move the topic (with all its comments) to the target creative.

## Changes

### Backend
- **`TopicsController#move`**: New action that moves a topic to a target creative
  - Requires admin/owner permission on source creative
  - Requires write/owner permission on target creative
  - Validates no duplicate topic names in target creative
  - Broadcasts deletion to source + creation to target via TopicsChannel

### Frontend
- **Topic drag start**: Sets `application/x-topic-move` data with topic ID and source creative ID
- **Creative tree drag over**: Accepts topic move drops, always showing child highlight
- **Creative tree drop**: Calls `sendTopicMove` API, dispatches `collavre:topic-moved` event
- **Topics controller**: Listens for `collavre:topic-moved` to auto-refresh topic list

### Routes
- `PATCH /creatives/:creative_id/topics/:id/move`

### i18n
- Added `topics.move.no_target_permission` (en, ko)
- Added `topics.move.duplicate_name` (en, ko)

### Tests
- 4 new tests: move success, source permission denied, target permission denied, duplicate name error

## Preview
Port 4032 (worktree32)