### PR TITLE
chore: add npm run build to worktree setup script

### DIFF
--- a/bin/setup_worktree
+++ b/bin/setup_worktree
@@ -61,4 +61,11 @@ while IFS= read -r resource || [ -n "$resource" ]; do
 done < "$RESOURCES_FILE"
 
 echo ""
+
+# Build JS/CSS assets so Propshaft can find them
+if [ -f "$CURRENT/package.json" ]; then
+  echo "📦 Building assets (npm run build)..."
+  (cd "$CURRENT" && npm run build 2>&1) || echo "   ⚠️  npm run build failed — run manually if needed"
+fi
+
 echo "🎉 Worktree setup complete!"


### PR DESCRIPTION
Add `npm run build` step to `bin/setup_worktree` so new worktrees have compiled JS/CSS assets available for Propshaft. Prevents `application.js not found` errors when running tests without `bin/dev`.

## Changes
- `bin/setup_worktree`: Run `npm run build` after symlinking shared resources
- Graceful fallback if build fails

1 file, +7 lines