### PR TITLE
feat: creative context injection with inheritance

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -1006,9 +1006,26 @@ body.chat-fullscreen {
     color: var(--color-text);
 }
 
-/* Reduce title margin when contexts are present */
-.comments-popup-header + .comment-contexts-list:not(:empty) {
-    margin-top: -0.25em;
+/* Context toggle button in header */
+.context-toggle-btn {
+    font-size: 0.75em;
+    padding: 0.15em 0.4em;
+    border-radius: 8px;
+    background: none;
+    border: 1px solid transparent;
+    cursor: pointer;
+    transition: all 0.2s;
+    white-space: nowrap;
+}
+
+.context-toggle-btn:hover {
+    background: var(--color-secondary-background);
+}
+
+.context-toggle-btn.context-toggle-active {
+    background: var(--color-secondary-active);
+    color: white;
+    border-color: var(--color-secondary-active);
 }
 
 .comment-topics-list {

--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -939,6 +939,18 @@ body.chat-fullscreen {
     background: var(--color-border);
 }
 
+.context-chip.context-self {
+    background: var(--color-secondary-active);
+    color: white;
+    border-color: var(--color-secondary-active);
+}
+
+.context-chip.context-self.context-disabled {
+    background: var(--color-secondary-background);
+    color: var(--color-text-muted);
+    border-color: var(--color-border);
+}
+
 .context-chip.context-disabled {
     opacity: 0.4;
     text-decoration: line-through;

--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -939,18 +939,6 @@ body.chat-fullscreen {
     background: var(--color-border);
 }
 
-.context-chip.context-self {
-    background: var(--color-secondary-active);
-    color: white;
-    border-color: var(--color-secondary-active);
-}
-
-.context-chip.context-self.context-disabled {
-    background: var(--color-secondary-background);
-    color: var(--color-text-muted);
-    border-color: var(--color-border);
-}
-
 .context-chip.context-disabled {
     opacity: 0.4;
     text-decoration: line-through;

--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -895,6 +895,122 @@ body.chat-fullscreen {
     filter: grayscale(1);
 }
 
+/* --- Context Chips --- */
+.comment-contexts-list {
+    display: flex;
+    flex-wrap: nowrap;
+    align-items: center;
+    gap: 0.4em;
+    padding: 0.25em 0;
+    overflow-x: auto;
+    overflow-y: hidden;
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+    min-height: 0;
+}
+
+.comment-contexts-list:empty {
+    display: none;
+}
+
+.comment-contexts-list::-webkit-scrollbar {
+    display: none;
+}
+
+.context-chip {
+    display: inline-flex;
+    align-items: center;
+    flex-shrink: 0;
+    gap: var(--space-1);
+    padding: 0.15em 0.5em;
+    border-radius: 10px;
+    background: var(--color-secondary-background);
+    border: 1px solid var(--color-border);
+    color: var(--color-text);
+    font-size: 0.75em;
+    cursor: pointer;
+    transition: all 0.2s;
+    white-space: nowrap;
+    height: 22px;
+    box-sizing: border-box;
+}
+
+.context-chip:hover {
+    background: var(--color-border);
+}
+
+.context-chip.context-disabled {
+    opacity: 0.4;
+    text-decoration: line-through;
+}
+
+.context-chip.context-inherited {
+    border-style: dashed;
+}
+
+.context-chip.context-dragging {
+    opacity: 0.5;
+}
+
+.context-chip.context-drag-over-left {
+    border-left: 3px solid var(--color-active);
+    margin-left: -1px;
+}
+
+.context-chip.context-drag-over-right {
+    border-right: 3px solid var(--color-active);
+    margin-right: -1px;
+}
+
+.context-chip[draggable="true"] {
+    cursor: grab;
+}
+
+.context-chip[draggable="true"]:active {
+    cursor: grabbing;
+}
+
+.delete-context-btn {
+    background: none;
+    border: none;
+    color: var(--color-text-muted);
+    cursor: pointer;
+    font-size: 0.9em;
+    padding: 0 0.15em;
+    line-height: 1;
+    margin-left: 0.1em;
+}
+
+.delete-context-btn:hover {
+    color: var(--color-danger);
+}
+
+.add-context-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    width: 22px;
+    height: 22px;
+    border-radius: 50%;
+    background: var(--color-secondary-background);
+    border: 1px dashed var(--color-border);
+    color: var(--color-text-muted);
+    font-size: 0.85em;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.add-context-btn:hover {
+    background: var(--color-border);
+    color: var(--color-text);
+}
+
+/* Reduce title margin when contexts are present */
+.comments-popup-header + .comment-contexts-list:not(:empty) {
+    margin-top: -0.25em;
+}
+
 .comment-topics-list {
     display: flex;
     flex-wrap: nowrap;

--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -235,8 +235,8 @@ module Collavre
 
     def contexts
       creative = @creative.effective_origin(Set.new)
-      own_ids = creative.context_ids
-      inherited_ids = (creative.effective_context_ids - own_ids).uniq
+      own_ids = creative.context_ids - [ creative.id ]
+      inherited_ids = (creative.effective_context_ids - own_ids - [ creative.id ]).uniq
       own_creatives = Creative.where(id: own_ids).index_by(&:id)
       inherited_creatives = Creative.where(id: inherited_ids).index_by(&:id)
 

--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -256,7 +256,11 @@ module Collavre
         { id: c.id, description: c.creative_snippet, inherited: true, disabled: disabled_ids.include?(cid) }
       end
 
-      render json: { contexts: inherited + own, can_manage: creative.has_permission?(Current.user, :admin) }
+      render json: {
+        contexts: inherited + own,
+        can_manage: creative.has_permission?(Current.user, :admin),
+        disabled_self_context: creative.data&.dig("disabled_self_context") == true
+      }
     end
 
     def update_contexts
@@ -270,6 +274,13 @@ module Collavre
       current_data["context_ids"] = Array(params[:context_ids]).map(&:to_i) if params.key?(:context_ids)
       current_data["disabled_context_ids"] = Array(params[:disabled_context_ids]).map(&:to_i) if params.key?(:disabled_context_ids)
       current_data.delete("disabled_context_ids") if current_data["disabled_context_ids"]&.empty?
+      if params.key?(:disabled_self_context)
+        if ActiveModel::Type::Boolean.new.cast(params[:disabled_self_context])
+          current_data["disabled_self_context"] = true
+        else
+          current_data.delete("disabled_self_context")
+        end
+      end
 
       if creative.update(data: current_data)
         head :ok

--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -9,7 +9,7 @@ module Collavre
     # Removed unauthenticated access to index and show actions
     allow_unauthenticated_access only: %i[ index children export_markdown show slide_view ]
     before_action :enforce_creatives_login_policy, only: %i[ index children export_markdown show slide_view ]
-    before_action :set_creative, only: %i[ show edit update destroy parent_suggestions slide_view request_permission unconvert ]
+    before_action :set_creative, only: %i[ show edit update destroy parent_suggestions slide_view request_permission unconvert contexts update_contexts ]
 
     def index
       respond_to do |format|
@@ -230,6 +230,51 @@ module Collavre
           format.html { render :edit, status: :unprocessable_entity }
           format.json { render json: { errors: @creative.errors.full_messages }, status: :unprocessable_entity }
         end
+      end
+    end
+
+    def contexts
+      creative = @creative.effective_origin(Set.new)
+      own_ids = creative.context_ids
+      inherited_ids = (creative.effective_context_ids - own_ids).uniq
+      own_creatives = Creative.where(id: own_ids).index_by(&:id)
+      inherited_creatives = Creative.where(id: inherited_ids).index_by(&:id)
+
+      disabled_ids = Array(creative.data&.dig("disabled_context_ids"))
+
+      own = own_ids.filter_map do |cid|
+        c = own_creatives[cid]
+        next unless c
+
+        { id: c.id, description: c.creative_snippet, inherited: false, disabled: disabled_ids.include?(cid) }
+      end
+
+      inherited = inherited_ids.filter_map do |cid|
+        c = inherited_creatives[cid]
+        next unless c
+
+        { id: c.id, description: c.creative_snippet, inherited: true, disabled: disabled_ids.include?(cid) }
+      end
+
+      render json: { contexts: inherited + own, can_manage: creative.has_permission?(Current.user, :admin) }
+    end
+
+    def update_contexts
+      creative = @creative.effective_origin(Set.new)
+      unless creative.has_permission?(Current.user, :admin)
+        render json: { error: t("collavre.creatives.errors.no_permission") }, status: :forbidden
+        return
+      end
+
+      current_data = (creative.data || {}).dup
+      current_data["context_ids"] = Array(params[:context_ids]).map(&:to_i) if params.key?(:context_ids)
+      current_data["disabled_context_ids"] = Array(params[:disabled_context_ids]).map(&:to_i) if params.key?(:disabled_context_ids)
+      current_data.delete("disabled_context_ids") if current_data["disabled_context_ids"]&.empty?
+
+      if creative.update(data: current_data)
+        head :ok
+      else
+        render json: { errors: creative.errors.full_messages }, status: :unprocessable_entity
       end
     end
 

--- a/engines/collavre/app/javascript/controllers/comments/contexts_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/contexts_controller.js
@@ -10,10 +10,6 @@ export default class extends Controller {
         this.listVisible = false
     }
 
-    disconnect() {
-        // cleanup
-    }
-
     get creativeId() {
         return this.element.closest('#comments-popup')?.dataset?.creativeId
     }
@@ -167,21 +163,7 @@ export default class extends Controller {
     }
 
     async _saveSelfContextState() {
-        const creativeId = this.creativeId
-        if (!creativeId) return
-
-        try {
-            await fetch(`/creatives/${creativeId}/update_contexts`, {
-                method: 'PATCH',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').content
-                },
-                body: JSON.stringify({ disabled_self_context: this._selfContextDisabled })
-            })
-        } catch (e) {
-            console.error('Error saving self context state', e)
-        }
+        await this._patchContexts({ disabled_self_context: this._selfContextDisabled })
     }
 
     toggleContext(event) {
@@ -326,6 +308,15 @@ export default class extends Controller {
 
     // --- API calls ---
     async _updateContextIds(ids) {
+        await this._patchContexts({ context_ids: ids })
+    }
+
+    async _saveDisabledState() {
+        const disabledIds = this.contexts.filter(c => c.disabled).map(c => c.id)
+        await this._patchContexts({ disabled_context_ids: disabledIds })
+    }
+
+    async _patchContexts(params) {
         const creativeId = this.creativeId
         if (!creativeId) return
 
@@ -336,34 +327,14 @@ export default class extends Controller {
                     'Content-Type': 'application/json',
                     'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').content
                 },
-                body: JSON.stringify({ context_ids: ids })
+                body: JSON.stringify(params)
             })
 
             if (!response.ok) {
-                console.error('Failed to update context IDs')
+                console.error('Failed to update contexts', params)
             }
         } catch (e) {
-            console.error('Error updating context IDs', e)
-        }
-    }
-
-    async _saveDisabledState() {
-        const creativeId = this.creativeId
-        if (!creativeId) return
-
-        const disabledIds = this.contexts.filter(c => c.disabled).map(c => c.id)
-
-        try {
-            await fetch(`/creatives/${creativeId}/update_contexts`, {
-                method: 'PATCH',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').content
-                },
-                body: JSON.stringify({ disabled_context_ids: disabledIds })
-            })
-        } catch (e) {
-            console.error('Error saving disabled state', e)
+            console.error('Error updating contexts', e)
         }
     }
 

--- a/engines/collavre/app/javascript/controllers/comments/contexts_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/contexts_controller.js
@@ -43,6 +43,7 @@ export default class extends Controller {
                 const data = await response.json()
                 this.contexts = data.contexts || []
                 this.canManage = data.can_manage || false
+                this._selfContextDisabled = data.disabled_self_context || false
                 this.renderContexts()
             }
         } catch (e) {
@@ -69,23 +70,25 @@ export default class extends Controller {
     _updateToggleButton() {
         if (!this.hasToggleButtonTarget) return
 
-        const hasContexts = this.contexts.length > 0
-        const showButton = hasContexts || this.canManage
-        this.toggleButtonTarget.style.display = showButton ? '' : 'none'
+        const hasLinkedContexts = this.contexts.length > 0
+        // Always show button (self-context toggle is always available)
+        this.toggleButtonTarget.style.display = ''
 
-        // Show badge count when hidden and has contexts
-        if (hasContexts && !this.listVisible) {
-            const activeCount = this.contexts.filter(c => !c.disabled).length
-            this.toggleButtonTarget.textContent = `🔗 ${activeCount}`
+        // Show badge count when hidden
+        if (!this.listVisible) {
+            const activeLinked = this.contexts.filter(c => !c.disabled).length
+            const selfActive = this.selfContextDisabled ? 0 : 1
+            const total = activeLinked + selfActive
+            this.toggleButtonTarget.textContent = `🔗 ${total}`
         } else {
             this.toggleButtonTarget.textContent = '🔗'
         }
 
-        // Auto-show if contexts exist, auto-hide if empty
-        if (hasContexts && !this._hasBeenManuallyToggled) {
+        // Auto-show if linked contexts exist, otherwise keep hidden
+        if (hasLinkedContexts && !this._hasBeenManuallyToggled) {
             this.listVisible = true
             this._updateListVisibility()
-        } else if (!hasContexts && !this.canManage) {
+        } else if (!hasLinkedContexts && !this.canManage && !this._hasBeenManuallyToggled) {
             this.listVisible = false
             this._updateListVisibility()
         }
@@ -96,12 +99,6 @@ export default class extends Controller {
 
         this._updateToggleButton()
 
-        if (this.contexts.length === 0 && !this.canManage) {
-            this.listTarget.innerHTML = ''
-            this.listTarget.style.display = 'none'
-            return
-        }
-
         const dragActions = this.canManage
             ? 'dragstart->comments--contexts#handleDragStart dragend->comments--contexts#handleDragEnd'
             : ''
@@ -110,6 +107,16 @@ export default class extends Controller {
             : ''
 
         let html = ''
+
+        // Current creative self-context toggle (always first)
+        const selfDisabled = this.selfContextDisabled
+        const selfClass = selfDisabled ? 'context-disabled' : ''
+        const selfLabel = this._escapeHtml(this.currentCreativeSnippet || 'Self')
+        html += `<span class="context-chip context-self ${selfClass}"
+                      data-action="click->comments--contexts#toggleSelfContext"
+                      title="${this.selfContextLabel}">
+                    📌 ${selfLabel}
+                 </span>`
 
         this.contexts.forEach(ctx => {
             const disabledClass = ctx.disabled ? 'context-disabled' : ''
@@ -138,6 +145,43 @@ export default class extends Controller {
 
     get inheritedLabel() {
         return this.listTarget.dataset.inheritedLabel || 'Inherited from parent'
+    }
+
+    get selfContextLabel() {
+        return this.listTarget.dataset.selfContextLabel || 'Current creative context'
+    }
+
+    get currentCreativeSnippet() {
+        const popup = this.element.closest('#comments-popup')
+        return popup?.querySelector('#comments-popup-title')?.textContent?.trim()
+    }
+
+    get selfContextDisabled() {
+        return this._selfContextDisabled || false
+    }
+
+    toggleSelfContext(event) {
+        this._selfContextDisabled = !this._selfContextDisabled
+        this.renderContexts()
+        this._saveSelfContextState()
+    }
+
+    async _saveSelfContextState() {
+        const creativeId = this.creativeId
+        if (!creativeId) return
+
+        try {
+            await fetch(`/creatives/${creativeId}/update_contexts`, {
+                method: 'PATCH',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').content
+                },
+                body: JSON.stringify({ disabled_self_context: this._selfContextDisabled })
+            })
+        } catch (e) {
+            console.error('Error saving self context state', e)
+        }
     }
 
     toggleContext(event) {

--- a/engines/collavre/app/javascript/controllers/comments/contexts_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/contexts_controller.js
@@ -213,6 +213,10 @@ export default class extends Controller {
     }
 
     async _addContextId(creativeId) {
+        // Prevent adding self as context
+        const selfId = parseInt(this.creativeId)
+        if (creativeId === selfId) return
+
         const ownContexts = this.contexts.filter(c => !c.inherited)
         const existingIds = ownContexts.map(c => c.id)
 

--- a/engines/collavre/app/javascript/controllers/comments/contexts_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/contexts_controller.js
@@ -1,12 +1,13 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-    static targets = ["list"]
+    static targets = ["list", "toggleButton"]
 
     connect() {
         this.contexts = []
         this.canManage = false
         this.draggingContextId = null
+        this.listVisible = false
     }
 
     disconnect() {
@@ -18,6 +19,8 @@ export default class extends Controller {
     }
 
     async onPopupOpened({ creativeId }) {
+        this._hasBeenManuallyToggled = false
+        this.listVisible = false
         await this.loadContexts()
     }
 
@@ -46,16 +49,57 @@ export default class extends Controller {
         }
     }
 
+    toggleVisibility() {
+        this._hasBeenManuallyToggled = true
+        this.listVisible = !this.listVisible
+        this._updateListVisibility()
+    }
+
+    _updateListVisibility() {
+        if (!this.hasListTarget) return
+        this.listTarget.style.display = this.listVisible ? '' : 'none'
+
+        // Update toggle button active state
+        if (this.hasToggleButtonTarget) {
+            this.toggleButtonTarget.classList.toggle('context-toggle-active', this.listVisible)
+        }
+    }
+
+    _updateToggleButton() {
+        if (!this.hasToggleButtonTarget) return
+
+        const hasContexts = this.contexts.length > 0
+        const showButton = hasContexts || this.canManage
+        this.toggleButtonTarget.style.display = showButton ? '' : 'none'
+
+        // Show badge count when hidden and has contexts
+        if (hasContexts && !this.listVisible) {
+            const activeCount = this.contexts.filter(c => !c.disabled).length
+            this.toggleButtonTarget.textContent = `🔗 ${activeCount}`
+        } else {
+            this.toggleButtonTarget.textContent = '🔗'
+        }
+
+        // Auto-show if contexts exist, auto-hide if empty
+        if (hasContexts && !this._hasBeenManuallyToggled) {
+            this.listVisible = true
+            this._updateListVisibility()
+        } else if (!hasContexts && !this.canManage) {
+            this.listVisible = false
+            this._updateListVisibility()
+        }
+    }
+
     renderContexts() {
         if (!this.hasListTarget) return
+
+        this._updateToggleButton()
 
         if (this.contexts.length === 0 && !this.canManage) {
             this.listTarget.innerHTML = ''
             this.listTarget.style.display = 'none'
             return
         }
-
-        this.listTarget.style.display = ''
 
         const dragActions = this.canManage
             ? 'dragstart->comments--contexts#handleDragStart dragend->comments--contexts#handleDragEnd'

--- a/engines/collavre/app/javascript/controllers/comments/contexts_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/contexts_controller.js
@@ -1,0 +1,286 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+    static targets = ["list"]
+
+    connect() {
+        this.contexts = []
+        this.canManage = false
+        this.draggingContextId = null
+    }
+
+    disconnect() {
+        // cleanup
+    }
+
+    get creativeId() {
+        return this.element.closest('#comments-popup')?.dataset?.creativeId
+    }
+
+    async onPopupOpened({ creativeId }) {
+        await this.loadContexts()
+    }
+
+    onPopupClosed() {
+        this.contexts = []
+        this.canManage = false
+        if (this.hasListTarget) {
+            this.listTarget.innerHTML = ''
+        }
+    }
+
+    async loadContexts() {
+        const creativeId = this.creativeId
+        if (!creativeId) return
+
+        try {
+            const response = await fetch(`/creatives/${creativeId}/contexts`)
+            if (response.ok) {
+                const data = await response.json()
+                this.contexts = data.contexts || []
+                this.canManage = data.can_manage || false
+                this.renderContexts()
+            }
+        } catch (e) {
+            console.error("Failed to load contexts", e)
+        }
+    }
+
+    renderContexts() {
+        if (!this.hasListTarget) return
+
+        if (this.contexts.length === 0 && !this.canManage) {
+            this.listTarget.innerHTML = ''
+            this.listTarget.style.display = 'none'
+            return
+        }
+
+        this.listTarget.style.display = ''
+
+        const dragActions = this.canManage
+            ? 'dragstart->comments--contexts#handleDragStart dragend->comments--contexts#handleDragEnd'
+            : ''
+        const reorderActions = this.canManage
+            ? 'dragover->comments--contexts#handleReorderDragOver dragleave->comments--contexts#handleReorderDragLeave drop->comments--contexts#handleReorderDrop'
+            : ''
+
+        let html = ''
+
+        this.contexts.forEach(ctx => {
+            const disabledClass = ctx.disabled ? 'context-disabled' : ''
+            const inheritedClass = ctx.inherited ? 'context-inherited' : ''
+            const draggable = this.canManage && !ctx.inherited ? 'draggable="true"' : ''
+
+            html += `<span class="context-chip ${disabledClass} ${inheritedClass}" ${draggable}
+                          data-action="click->comments--contexts#toggleContext ${dragActions} ${reorderActions}"
+                          data-context-id="${ctx.id}"
+                          title="${ctx.inherited ? this.inheritedLabel : ''}">
+                        🔗 ${this._escapeHtml(ctx.description)}`
+
+            if (this.canManage && !ctx.inherited) {
+                html += `<button class="delete-context-btn" data-action="click->comments--contexts#removeContext" data-context-id="${ctx.id}">&times;</button>`
+            }
+
+            html += `</span>`
+        })
+
+        if (this.canManage) {
+            html += `<button class="add-context-btn" data-action="click->comments--contexts#addContext">+</button>`
+        }
+
+        this.listTarget.innerHTML = html
+    }
+
+    get inheritedLabel() {
+        return this.listTarget.dataset.inheritedLabel || 'Inherited from parent'
+    }
+
+    toggleContext(event) {
+        if (event.target.closest('.delete-context-btn')) return
+
+        const contextId = parseInt(event.currentTarget.dataset.contextId)
+        if (!contextId) return
+
+        const ctx = this.contexts.find(c => c.id === contextId)
+        if (!ctx) return
+
+        ctx.disabled = !ctx.disabled
+        this.renderContexts()
+        this._saveDisabledState()
+    }
+
+    async removeContext(event) {
+        event.stopPropagation()
+        const contextId = parseInt(event.currentTarget.dataset.contextId)
+        if (!contextId) return
+
+        const ownContexts = this.contexts.filter(c => !c.inherited)
+        const newIds = ownContexts.filter(c => c.id !== contextId).map(c => c.id)
+
+        await this._updateContextIds(newIds)
+        await this.loadContexts()
+    }
+
+    addContext() {
+        // Use the existing link-creative modal
+        const linkController = window.Stimulus?.getControllerForElementAndIdentifier(
+            document.querySelector('[data-controller~="link-creative"]'),
+            'link-creative'
+        )
+
+        if (!linkController) {
+            console.error("link-creative controller not found")
+            return
+        }
+
+        const addBtn = this.listTarget.querySelector('.add-context-btn')
+        const rect = addBtn?.getBoundingClientRect() || { top: 200, left: 200, bottom: 230, right: 230 }
+
+        linkController.open(rect, (selectedCreative) => {
+            this._addContextId(selectedCreative.id)
+        })
+    }
+
+    async _addContextId(creativeId) {
+        const ownContexts = this.contexts.filter(c => !c.inherited)
+        const existingIds = ownContexts.map(c => c.id)
+
+        if (existingIds.includes(creativeId)) return
+        // Also check inherited
+        if (this.contexts.some(c => c.id === creativeId)) return
+
+        const newIds = [...existingIds, creativeId]
+        await this._updateContextIds(newIds)
+        await this.loadContexts()
+    }
+
+    // --- Drag & Drop for reordering ---
+    handleDragStart(event) {
+        const chipEl = event.currentTarget
+        const contextId = chipEl.dataset.contextId
+        if (!contextId) { event.preventDefault(); return }
+
+        this.draggingContextId = contextId
+        event.dataTransfer.setData('application/x-context-id', contextId)
+        event.dataTransfer.effectAllowed = 'move'
+
+        requestAnimationFrame(() => {
+            chipEl.classList.add('context-dragging')
+        })
+    }
+
+    handleDragEnd(event) {
+        this.draggingContextId = null
+        event.currentTarget.classList.remove('context-dragging')
+        this.listTarget.querySelectorAll('.context-chip').forEach(el => {
+            el.classList.remove('context-drag-over-left', 'context-drag-over-right')
+        })
+    }
+
+    handleReorderDragOver(event) {
+        if (!event.dataTransfer.types.includes('application/x-context-id')) return
+        if (!this.draggingContextId) return
+
+        const targetEl = event.currentTarget
+        const targetId = targetEl.dataset.contextId
+        if (!targetId || targetId === this.draggingContextId) return
+        // Don't allow reorder onto inherited chips
+        const ctx = this.contexts.find(c => String(c.id) === targetId)
+        if (ctx?.inherited) return
+
+        event.preventDefault()
+        event.dataTransfer.dropEffect = 'move'
+
+        const rect = targetEl.getBoundingClientRect()
+        const midpoint = rect.left + rect.width / 2
+        const isLeft = event.clientX < midpoint
+
+        targetEl.classList.toggle('context-drag-over-left', isLeft)
+        targetEl.classList.toggle('context-drag-over-right', !isLeft)
+    }
+
+    handleReorderDragLeave(event) {
+        event.currentTarget.classList.remove('context-drag-over-left', 'context-drag-over-right')
+    }
+
+    async handleReorderDrop(event) {
+        event.preventDefault()
+
+        const targetEl = event.currentTarget
+        targetEl.classList.remove('context-drag-over-left', 'context-drag-over-right')
+
+        const draggedId = parseInt(event.dataTransfer.getData('application/x-context-id'))
+        const targetId = parseInt(targetEl.dataset.contextId)
+
+        if (!draggedId || !targetId || draggedId === targetId) return
+
+        const ownContexts = this.contexts.filter(c => !c.inherited)
+        const ids = ownContexts.map(c => c.id)
+
+        const draggedIndex = ids.indexOf(draggedId)
+        const targetIndex = ids.indexOf(targetId)
+        if (draggedIndex === -1 || targetIndex === -1) return
+
+        // Determine drop position
+        const rect = targetEl.getBoundingClientRect()
+        const midpoint = rect.left + rect.width / 2
+        const insertBefore = event.clientX < midpoint
+
+        ids.splice(draggedIndex, 1)
+        let newIndex = ids.indexOf(targetId)
+        if (!insertBefore) newIndex += 1
+        ids.splice(newIndex, 0, draggedId)
+
+        await this._updateContextIds(ids)
+        await this.loadContexts()
+    }
+
+    // --- API calls ---
+    async _updateContextIds(ids) {
+        const creativeId = this.creativeId
+        if (!creativeId) return
+
+        try {
+            const response = await fetch(`/creatives/${creativeId}/update_contexts`, {
+                method: 'PATCH',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').content
+                },
+                body: JSON.stringify({ context_ids: ids })
+            })
+
+            if (!response.ok) {
+                console.error('Failed to update context IDs')
+            }
+        } catch (e) {
+            console.error('Error updating context IDs', e)
+        }
+    }
+
+    async _saveDisabledState() {
+        const creativeId = this.creativeId
+        if (!creativeId) return
+
+        const disabledIds = this.contexts.filter(c => c.disabled).map(c => c.id)
+
+        try {
+            await fetch(`/creatives/${creativeId}/update_contexts`, {
+                method: 'PATCH',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').content
+                },
+                body: JSON.stringify({ disabled_context_ids: disabledIds })
+            })
+        } catch (e) {
+            console.error('Error saving disabled state', e)
+        }
+    }
+
+    _escapeHtml(text) {
+        const div = document.createElement('div')
+        div.textContent = text
+        return div.innerHTML
+    }
+}

--- a/engines/collavre/app/javascript/controllers/comments/contexts_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/contexts_controller.js
@@ -21,6 +21,7 @@ export default class extends Controller {
     async onPopupOpened({ creativeId }) {
         this._hasBeenManuallyToggled = false
         this.listVisible = false
+        this._updateListVisibility()
         await this.loadContexts()
     }
 

--- a/engines/collavre/app/javascript/controllers/comments/popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_controller.js
@@ -126,6 +126,10 @@ export default class extends Controller {
     return this.application.getControllerForElementAndIdentifier(this.element, 'comments--topics')
   }
 
+  get contextsController() {
+    return this.application.getControllerForElementAndIdentifier(this.element, 'comments--contexts')
+  }
+
   handleCreativeClick(event) {
     const button = event.detail?.button
     const creativeId = event.detail?.creativeId
@@ -211,6 +215,9 @@ export default class extends Controller {
     if (this.mentionMenuController) {
       this.mentionMenuController.onPopupOpened({ creativeId })
     }
+    if (this.contextsController) {
+      this.contextsController.onPopupOpened({ creativeId })
+    }
   }
 
   close() {
@@ -228,6 +235,9 @@ export default class extends Controller {
     }
     if (this.topicsController) {
       this.topicsController.onPopupClosed()
+    }
+    if (this.contextsController) {
+      this.contextsController.onPopupClosed()
     }
 
     // Dispatch event for integrations

--- a/engines/collavre/app/javascript/controllers/index.js
+++ b/engines/collavre/app/javascript/controllers/index.js
@@ -14,6 +14,7 @@ import CommentsFormController from "./comments/form_controller"
 import CommentsPresenceController from "./comments/presence_controller"
 import CommentsMentionMenuController from "./comments/mention_menu_controller"
 import CommentsTopicsController from "./comments/topics_controller"
+import CommentsContextsController from "./comments/contexts_controller"
 import CommentsPopupController from "./comments/popup_controller"
 import ClickTargetController from "./click_target_controller"
 import TabsController from "./tabs_controller"
@@ -73,6 +74,7 @@ export function registerControllers(application) {
   application.register("comments--presence", CommentsPresenceController)
   application.register("comments--mention-menu", CommentsMentionMenuController)
   application.register("comments--topics", CommentsTopicsController)
+  application.register("comments--contexts", CommentsContextsController)
   application.register("comments--popup", CommentsPopupController)
   application.register("click-target", ClickTargetController)
   application.register("tabs", TabsController)

--- a/engines/collavre/app/models/collavre/creative.rb
+++ b/engines/collavre/app/models/collavre/creative.rb
@@ -74,6 +74,29 @@ module Collavre
     after_destroy :update_parent_progress
     after_save :update_mcp_tools
 
+    # --- Context IDs ---
+    # Returns the directly-configured context creative IDs for this creative.
+    def context_ids
+      Array(data&.dig("context_ids"))
+    end
+
+    # Returns the effective context IDs: own + inherited from ancestors (deduplicated).
+    def effective_context_ids(visited_ids = Set.new)
+      return [] if visited_ids.include?(id)
+
+      visited_ids.add(id)
+      own = context_ids
+      parent_ctx = parent&.effective_context_ids(visited_ids) || []
+      (own + parent_ctx).uniq
+    end
+
+    # Returns context creatives (excludes self to avoid duplication).
+    def context_creatives
+      ids = effective_context_ids
+      ids -= [ id ]
+      Creative.where(id: ids)
+    end
+
     # Compatibility helper: ancestry gem exposes `subtree_ids`, while
     # closure_tree typically uses `self_and_descendants`.
     def subtree_ids

--- a/engines/collavre/app/services/collavre/ai_agent/message_builder.rb
+++ b/engines/collavre/app/services/collavre/ai_agent/message_builder.rb
@@ -90,7 +90,6 @@ module Collavre
         content = @context.dig("comment", "content")
         return unless content
 
-        current_creative_id = @context.dig("creative", "id")
         children_level = @agent.creative_children_level
         max_depth = 1 + children_level
 

--- a/engines/collavre/app/services/collavre/ai_agent/message_builder.rb
+++ b/engines/collavre/app/services/collavre/ai_agent/message_builder.rb
@@ -60,7 +60,7 @@ module Collavre
         effective_origin = creative.effective_origin(Set.new)
         context_ids = effective_origin.effective_context_ids
         disabled_ids = Array(effective_origin.data&.dig("disabled_context_ids"))
-        active_ids = context_ids - disabled_ids - [ creative_id ]
+        active_ids = context_ids - disabled_ids - [ creative_id, effective_origin.id ]
         return if active_ids.empty?
 
         children_level = @agent.creative_children_level

--- a/engines/collavre/app/services/collavre/ai_agent/message_builder.rb
+++ b/engines/collavre/app/services/collavre/ai_agent/message_builder.rb
@@ -34,6 +34,10 @@ module Collavre
         creative = Creative.find_by(id: creative_id)
         return unless creative
 
+        # Skip self-context if disabled
+        effective = creative.effective_origin(Set.new)
+        return if effective.data&.dig("disabled_self_context") == true
+
         children_level = @agent.creative_children_level
         max_depth = 1 + children_level
         markdown = ApplicationController.helpers.render_creative_tree_markdown(

--- a/engines/collavre/app/services/collavre/ai_agent/message_builder.rb
+++ b/engines/collavre/app/services/collavre/ai_agent/message_builder.rb
@@ -59,7 +59,7 @@ module Collavre
       end
 
       def build_ancestry_chain(creative)
-        creative.self_and_ancestors.reverse.map { |c| c.creative_snippet }.join(" > ")
+        creative.self_and_ancestors.reverse.map(&:creative_snippet).join(" > ")
       end
 
       def append_context_creatives(messages)

--- a/engines/collavre/app/services/collavre/ai_agent/message_builder.rb
+++ b/engines/collavre/app/services/collavre/ai_agent/message_builder.rb
@@ -15,6 +15,7 @@ module Collavre
 
       def build
         messages = []
+        @injected_creative_ids = Set.new
 
         append_creative_context(messages)
         append_context_creatives(messages)
@@ -47,6 +48,7 @@ module Collavre
         topic = current_topic
         topic_info = topic ? "\nTopic: #{topic.name} (id: #{topic.id})" : ""
 
+        @injected_creative_ids << creative.id
         messages << { role: "user", parts: [ { text: "Creative (id: #{creative.id}):#{topic_info}\n#{markdown}" } ] }
       end
 
@@ -67,9 +69,12 @@ module Collavre
         max_depth = 1 + children_level
 
         active_ids.each do |ctx_id|
+          next if @injected_creative_ids.include?(ctx_id)
+
           ctx = Creative.find_by(id: ctx_id)
           next unless ctx
 
+          @injected_creative_ids << ctx_id
           markdown = ApplicationController.helpers.render_creative_tree_markdown(
             [ ctx ], 1, true, max_depth: max_depth
           )
@@ -92,11 +97,12 @@ module Collavre
         # Extract creative IDs from markdown links like [title](/creatives/123)
         content.scan(%r{\[[^\]]*\]\(/creatives/(\d+)\)}).flatten.uniq.each do |id_str|
           creative_id = id_str.to_i
-          next if creative_id == current_creative_id
+          next if @injected_creative_ids.include?(creative_id)
 
           creative = Creative.find_by(id: creative_id)
           next unless creative
 
+          @injected_creative_ids << creative_id
           markdown = ApplicationController.helpers.render_creative_tree_markdown(
             [ creative ], 1, true, max_depth: max_depth
           )

--- a/engines/collavre/app/services/collavre/ai_agent/message_builder.rb
+++ b/engines/collavre/app/services/collavre/ai_agent/message_builder.rb
@@ -35,21 +35,31 @@ module Collavre
         creative = Creative.find_by(id: creative_id)
         return unless creative
 
-        # Skip self-context if disabled
         effective = creative.effective_origin(Set.new)
-        return if effective.data&.dig("disabled_self_context") == true
-
-        children_level = @agent.creative_children_level
-        max_depth = 1 + children_level
-        markdown = ApplicationController.helpers.render_creative_tree_markdown(
-          [ creative ], 1, true, max_depth: max_depth
-        )
-
         topic = current_topic
         topic_info = topic ? "\nTopic: #{topic.name} (id: #{topic.id})" : ""
 
-        @injected_creative_ids << creative.id
-        messages << { role: "user", parts: [ { text: "Creative (id: #{creative.id}):#{topic_info}\n#{markdown}" } ] }
+        if effective.data&.dig("disabled_self_context") == true
+          # Self-context disabled: inject only the ancestry chain so the AI
+          # knows where in the hierarchy the conversation is happening
+          ancestry = build_ancestry_chain(creative)
+          @injected_creative_ids << creative.id
+          messages << { role: "user", parts: [ { text: "Current Creative (id: #{creative.id}):#{topic_info}\nPath: #{ancestry}" } ] }
+        else
+          # Full self-context: inject the creative subtree
+          children_level = @agent.creative_children_level
+          max_depth = 1 + children_level
+          markdown = ApplicationController.helpers.render_creative_tree_markdown(
+            [ creative ], 1, true, max_depth: max_depth
+          )
+
+          @injected_creative_ids << creative.id
+          messages << { role: "user", parts: [ { text: "Creative (id: #{creative.id}):#{topic_info}\n#{markdown}" } ] }
+        end
+      end
+
+      def build_ancestry_chain(creative)
+        creative.self_and_ancestors.reverse.map { |c| c.creative_snippet }.join(" > ")
       end
 
       def append_context_creatives(messages)

--- a/engines/collavre/app/services/collavre/ai_agent/message_builder.rb
+++ b/engines/collavre/app/services/collavre/ai_agent/message_builder.rb
@@ -17,6 +17,7 @@ module Collavre
         messages = []
 
         append_creative_context(messages)
+        append_context_creatives(messages)
         append_referenced_creative_contexts(messages)
         append_chat_history(messages)
         append_trigger_message(messages)
@@ -43,6 +44,37 @@ module Collavre
         topic_info = topic ? "\nTopic: #{topic.name} (id: #{topic.id})" : ""
 
         messages << { role: "user", parts: [ { text: "Creative (id: #{creative.id}):#{topic_info}\n#{markdown}" } ] }
+      end
+
+      def append_context_creatives(messages)
+        creative_id = @context.dig("creative", "id")
+        return unless creative_id
+
+        creative = Creative.find_by(id: creative_id)
+        return unless creative
+
+        effective_origin = creative.effective_origin(Set.new)
+        context_ids = effective_origin.effective_context_ids
+        disabled_ids = Array(effective_origin.data&.dig("disabled_context_ids"))
+        active_ids = context_ids - disabled_ids - [ creative_id ]
+        return if active_ids.empty?
+
+        children_level = @agent.creative_children_level
+        max_depth = 1 + children_level
+
+        active_ids.each do |ctx_id|
+          ctx = Creative.find_by(id: ctx_id)
+          next unless ctx
+
+          markdown = ApplicationController.helpers.render_creative_tree_markdown(
+            [ ctx ], 1, true, max_depth: max_depth
+          )
+
+          messages << {
+            role: "user",
+            parts: [ { text: "Context Creative (id: #{ctx.id}):\n#{markdown}" } ]
+          }
+        end
       end
 
       def append_referenced_creative_contexts(messages)

--- a/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
@@ -77,7 +77,8 @@
     </div>
   </div>
   <div id="comment-contexts" data-comments--contexts-target="list" class="comment-contexts-list" style="display:none;"
-       data-inherited-label="<%= t('collavre.contexts.inherited_label', default: 'Inherited from parent') %>"></div>
+       data-inherited-label="<%= t('collavre.contexts.inherited_label', default: 'Inherited from parent') %>"
+       data-self-context-label="<%= t('collavre.contexts.self_context_label', default: 'Current creative context') %>"></div>
   <div id="comment-participants" data-comments--presence-target="participants" data-comments--mention-menu-target="participants"></div>
   <div id="comment-topics" data-comments--topics-target="list" class="comment-topics-list"
        data-confirm-delete-text="<%= t('collavre.topics.delete_confirm') %>"

--- a/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
@@ -55,6 +55,12 @@
     <h3 id="comments-popup-title" data-comments--popup-target="title"><%= fullscreen && creative.present? ? creative.creative_snippet : t('collavre.comments.comments') %></h3>
     <span data-integration-badges class="integration-badges"></span>
     <div class="comments-popup-actions">
+      <button class="comments-popup-action context-toggle-btn"
+              data-comments--contexts-target="toggleButton"
+              data-action="click->comments--contexts#toggleVisibility"
+              type="button"
+              title="<%= t('collavre.contexts.toggle_label', default: 'Contexts') %>"
+              style="display:none;">🔗</button>
       <button class="comments-popup-action comments-popup-fullscreen"
               data-comments--popup-target="fullscreenButton"
               data-action="click->comments--popup#toggleFullscreen"
@@ -70,7 +76,7 @@
       <button id="close-comments-btn" data-comments--popup-target="closeButton" class="popup-close-btn" type="button">&times;</button>
     </div>
   </div>
-  <div id="comment-contexts" data-comments--contexts-target="list" class="comment-contexts-list"
+  <div id="comment-contexts" data-comments--contexts-target="list" class="comment-contexts-list" style="display:none;"
        data-inherited-label="<%= t('collavre.contexts.inherited_label', default: 'Inherited from parent') %>"></div>
   <div id="comment-participants" data-comments--presence-target="participants" data-comments--mention-menu-target="participants"></div>
   <div id="comment-topics" data-comments--topics-target="list" class="comment-topics-list"

--- a/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
@@ -2,7 +2,7 @@
 <% fullscreen = local_assigns.fetch(:fullscreen, false) %>
 <% auto_fullscreen = local_assigns.fetch(:auto_fullscreen, false) %>
 <% creative = local_assigns[:creative] %>
-<div id="comments-popup" data-controller="comments--popup comments--list comments--form comments--presence comments--mention-menu comments--topics" class="popup-box"
+<div id="comments-popup" data-controller="comments--popup comments--list comments--form comments--presence comments--mention-menu comments--topics comments--contexts" class="popup-box"
      data-fullscreen="<%= fullscreen %>"
      <% if auto_fullscreen %>data-auto-fullscreen="true"<% end %>
      data-fullscreen-label="<%= t('collavre.comments.fullscreen', default: 'Full screen') %>"
@@ -70,6 +70,8 @@
       <button id="close-comments-btn" data-comments--popup-target="closeButton" class="popup-close-btn" type="button">&times;</button>
     </div>
   </div>
+  <div id="comment-contexts" data-comments--contexts-target="list" class="comment-contexts-list"
+       data-inherited-label="<%= t('collavre.contexts.inherited_label', default: 'Inherited from parent') %>"></div>
   <div id="comment-participants" data-comments--presence-target="participants" data-comments--mention-menu-target="participants"></div>
   <div id="comment-topics" data-comments--topics-target="list" class="comment-topics-list"
        data-confirm-delete-text="<%= t('collavre.topics.delete_confirm') %>"

--- a/engines/collavre/config/locales/contexts.en.yml
+++ b/engines/collavre/config/locales/contexts.en.yml
@@ -4,3 +4,4 @@ en:
     contexts:
       inherited_label: "Inherited from parent"
       toggle_label: "Contexts"
+      self_context_label: "Current creative context"

--- a/engines/collavre/config/locales/contexts.en.yml
+++ b/engines/collavre/config/locales/contexts.en.yml
@@ -3,3 +3,4 @@ en:
   collavre:
     contexts:
       inherited_label: "Inherited from parent"
+      toggle_label: "Contexts"

--- a/engines/collavre/config/locales/contexts.en.yml
+++ b/engines/collavre/config/locales/contexts.en.yml
@@ -1,0 +1,5 @@
+---
+en:
+  collavre:
+    contexts:
+      inherited_label: "Inherited from parent"

--- a/engines/collavre/config/locales/contexts.ko.yml
+++ b/engines/collavre/config/locales/contexts.ko.yml
@@ -1,0 +1,5 @@
+---
+ko:
+  collavre:
+    contexts:
+      inherited_label: "상위에서 상속됨"

--- a/engines/collavre/config/locales/contexts.ko.yml
+++ b/engines/collavre/config/locales/contexts.ko.yml
@@ -4,3 +4,4 @@ ko:
     contexts:
       inherited_label: "상위에서 상속됨"
       toggle_label: "컨텍스트"
+      self_context_label: "현재 크리에이티브 컨텍스트"

--- a/engines/collavre/config/locales/contexts.ko.yml
+++ b/engines/collavre/config/locales/contexts.ko.yml
@@ -3,3 +3,4 @@ ko:
   collavre:
     contexts:
       inherited_label: "상위에서 상속됨"
+      toggle_label: "컨텍스트"

--- a/engines/collavre/config/routes.rb
+++ b/engines/collavre/config/routes.rb
@@ -94,6 +94,8 @@ Collavre::Engine.routes.draw do
       post :unconvert
       get :parent_suggestions
       get :slide_view
+      get :contexts
+      patch :update_contexts
     end
   end
 

--- a/engines/collavre/test/controllers/creative_contexts_controller_test.rb
+++ b/engines/collavre/test/controllers/creative_contexts_controller_test.rb
@@ -70,6 +70,37 @@ class CreativeContextsControllerTest < ActionDispatch::IntegrationTest
     refute @features.data.key?("disabled_context_ids")
   end
 
+  test "PATCH update_contexts sets disabled_self_context" do
+    patch update_contexts_creative_path(@features), params: {
+      disabled_self_context: true
+    }, headers: { "ACCEPT" => "application/json" }, as: :json
+
+    assert_response :success
+    @features.reload
+    assert_equal true, @features.data["disabled_self_context"]
+  end
+
+  test "PATCH update_contexts clears disabled_self_context when false" do
+    @features.update!(data: { "disabled_self_context" => true })
+
+    patch update_contexts_creative_path(@features), params: {
+      disabled_self_context: false
+    }, headers: { "ACCEPT" => "application/json" }, as: :json
+
+    assert_response :success
+    @features.reload
+    refute @features.data.key?("disabled_self_context")
+  end
+
+  test "GET contexts returns disabled_self_context flag" do
+    @features.update!(data: { "disabled_self_context" => true })
+
+    get contexts_creative_path(@features), headers: { "ACCEPT" => "application/json" }
+    assert_response :success
+    json = JSON.parse(response.body)
+    assert_equal true, json["disabled_self_context"]
+  end
+
   test "PATCH update_contexts requires admin permission" do
     regular_user = users(:two)
     sign_in_as(regular_user, password: "password")

--- a/engines/collavre/test/controllers/creative_contexts_controller_test.rb
+++ b/engines/collavre/test/controllers/creative_contexts_controller_test.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class CreativeContextsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @admin = users(:one)
+    sign_in_as(@admin, password: "password")
+
+    Collavre::Current.user = @admin
+    @project = Collavre::Creative.create!(description: "Project", user: @admin)
+    @development = Collavre::Creative.create!(description: "Development", user: @admin, parent: @project)
+    @features = Collavre::Creative.create!(description: "Features", user: @admin, parent: @project)
+    @feature_a = Collavre::Creative.create!(description: "Feature A", user: @admin, parent: @features)
+  end
+
+  test "GET contexts returns empty list when no contexts configured" do
+    get contexts_creative_path(@feature_a), headers: { "ACCEPT" => "application/json" }
+    assert_response :success
+    json = JSON.parse(response.body)
+    assert_equal [], json["contexts"]
+    assert json["can_manage"]
+  end
+
+  test "GET contexts returns own and inherited contexts" do
+    @features.update!(data: { "context_ids" => [ @development.id ] })
+
+    get contexts_creative_path(@feature_a), headers: { "ACCEPT" => "application/json" }
+    assert_response :success
+    json = JSON.parse(response.body)
+    contexts = json["contexts"]
+    assert_equal 1, contexts.length
+
+    ctx = contexts.first
+    assert_equal @development.id, ctx["id"]
+    assert ctx["inherited"]
+  end
+
+  test "PATCH update_contexts sets context_ids" do
+    patch update_contexts_creative_path(@features), params: {
+      context_ids: [ @development.id ]
+    }, headers: { "ACCEPT" => "application/json" }, as: :json
+
+    assert_response :success
+    @features.reload
+    assert_equal [ @development.id ], @features.data["context_ids"]
+  end
+
+  test "PATCH update_contexts sets disabled_context_ids" do
+    @features.update!(data: { "context_ids" => [ @development.id ] })
+
+    patch update_contexts_creative_path(@features), params: {
+      disabled_context_ids: [ @development.id ]
+    }, headers: { "ACCEPT" => "application/json" }, as: :json
+
+    assert_response :success
+    @features.reload
+    assert_equal [ @development.id ], @features.data["disabled_context_ids"]
+  end
+
+  test "PATCH update_contexts cleans up empty disabled_context_ids" do
+    @features.update!(data: { "context_ids" => [ @development.id ], "disabled_context_ids" => [ @development.id ] })
+
+    patch update_contexts_creative_path(@features), params: {
+      disabled_context_ids: []
+    }, headers: { "ACCEPT" => "application/json" }, as: :json
+
+    assert_response :success
+    @features.reload
+    refute @features.data.key?("disabled_context_ids")
+  end
+
+  test "PATCH update_contexts requires admin permission" do
+    regular_user = users(:two)
+    sign_in_as(regular_user, password: "password")
+
+    patch update_contexts_creative_path(@features), params: {
+      context_ids: [ @development.id ]
+    }, headers: { "ACCEPT" => "application/json" }, as: :json
+
+    assert_response :forbidden
+  end
+end

--- a/engines/collavre/test/controllers/creative_contexts_controller_test.rb
+++ b/engines/collavre/test/controllers/creative_contexts_controller_test.rb
@@ -101,6 +101,18 @@ class CreativeContextsControllerTest < ActionDispatch::IntegrationTest
     assert_equal true, json["disabled_self_context"]
   end
 
+  test "GET contexts excludes self from context list to prevent duplicates" do
+    # Parent has feature_a as context → feature_a should not see itself in contexts list
+    @features.update!(data: { "context_ids" => [ @feature_a.id, @development.id ] })
+
+    get contexts_creative_path(@feature_a), headers: { "ACCEPT" => "application/json" }
+    assert_response :success
+    json = JSON.parse(response.body)
+    context_ids = json["contexts"].map { |c| c["id"] }
+    refute_includes context_ids, @feature_a.id, "Self creative should be excluded from contexts"
+    assert_includes context_ids, @development.id, "Other contexts should still be present"
+  end
+
   test "PATCH update_contexts requires admin permission" do
     regular_user = users(:two)
     sign_in_as(regular_user, password: "password")

--- a/engines/collavre/test/controllers/users_controller_test.rb
+++ b/engines/collavre/test/controllers/users_controller_test.rb
@@ -230,7 +230,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     )
     Collavre::Contact.ensure(user: @admin, contact_user: regular_user)
 
-    get collavre.user_path(@admin, tab: "contacts")
+    get collavre.user_path(@admin, tab: "contacts", contacts_view: "org_chart")
     assert_response :success
 
     assert_includes response.body, ai_agent.email,

--- a/engines/collavre/test/models/collavre/creative_context_test.rb
+++ b/engines/collavre/test/models/collavre/creative_context_test.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  class CreativeContextTest < ActiveSupport::TestCase
+    setup do
+      @admin = users(:one)
+      Collavre::Current.user = @admin
+
+      @project = Creative.create!(description: "Project", user: @admin)
+      @development = Creative.create!(description: "Development Rules", user: @admin, parent: @project)
+      @goal = Creative.create!(description: "Goal", user: @admin, parent: @project)
+      @features = Creative.create!(description: "Features", user: @admin, parent: @project)
+      @feature_a = Creative.create!(description: "Feature A", user: @admin, parent: @features)
+      @feature_b = Creative.create!(description: "Feature B", user: @admin, parent: @features)
+      @rnd = Creative.create!(description: "R&D", user: @admin, parent: @project)
+      @research_a = Creative.create!(description: "Research A", user: @admin, parent: @rnd)
+    end
+
+    test "context_ids returns empty array when no context configured" do
+      assert_equal [], @feature_a.context_ids
+    end
+
+    test "context_ids returns configured IDs from data" do
+      @features.update!(data: { "context_ids" => [ @development.id ] })
+      assert_equal [ @development.id ], @features.context_ids
+    end
+
+    test "effective_context_ids inherits from parent" do
+      @features.update!(data: { "context_ids" => [ @development.id ] })
+      assert_includes @feature_a.effective_context_ids, @development.id
+      assert_includes @feature_b.effective_context_ids, @development.id
+    end
+
+    test "effective_context_ids combines own and parent contexts" do
+      @features.update!(data: { "context_ids" => [ @development.id ] })
+      @feature_a.update!(data: { "context_ids" => [ @goal.id ] })
+
+      effective = @feature_a.effective_context_ids
+      assert_includes effective, @development.id
+      assert_includes effective, @goal.id
+    end
+
+    test "effective_context_ids deduplicates" do
+      @features.update!(data: { "context_ids" => [ @development.id ] })
+      @feature_a.update!(data: { "context_ids" => [ @development.id, @goal.id ] })
+
+      effective = @feature_a.effective_context_ids
+      assert_equal 1, effective.count(@development.id)
+    end
+
+    test "effective_context_ids returns empty when no context in hierarchy" do
+      assert_equal [], @feature_a.effective_context_ids
+    end
+
+    test "context_creatives returns Creative objects excluding self" do
+      @features.update!(data: { "context_ids" => [ @development.id, @features.id ] })
+      creatives = @features.context_creatives
+      assert_includes creatives, @development
+      refute_includes creatives, @features
+    end
+
+    test "R&D inherits different context than Features" do
+      @features.update!(data: { "context_ids" => [ @development.id ] })
+      @rnd.update!(data: { "context_ids" => [ @goal.id ] })
+
+      assert_includes @feature_a.effective_context_ids, @development.id
+      refute_includes @feature_a.effective_context_ids, @goal.id
+
+      assert_includes @research_a.effective_context_ids, @goal.id
+      refute_includes @research_a.effective_context_ids, @development.id
+    end
+  end
+end

--- a/engines/collavre/test/services/collavre/ai_agent/message_builder_test.rb
+++ b/engines/collavre/test/services/collavre/ai_agent/message_builder_test.rb
@@ -56,6 +56,53 @@ module Collavre
         assert_empty referenced_msgs, "Should not include current creative as referenced"
       end
 
+      test "appends context creatives from effective_context_ids" do
+        dev_rules = Creative.create!(
+          description: "<p>Dev Rules</p>",
+          user: @user,
+          progress: 1.0
+        )
+
+        # Set context_ids on creative's data
+        @creative.update!(data: { "context_ids" => [ dev_rules.id ] })
+
+        context = {
+          "comment" => { "id" => @comment.id, "content" => "Implement feature X" },
+          "creative" => { "id" => @creative.id }
+        }
+
+        builder = MessageBuilder.new(agent: @agent, context: context, original_comment: @comment)
+        messages = builder.build
+
+        context_msg = messages.find { |m| m[:parts]&.first&.dig(:text)&.include?("Context Creative") }
+        assert_not_nil context_msg, "Should include context creative"
+        assert_includes context_msg[:parts].first[:text], "Dev Rules"
+      end
+
+      test "excludes disabled context creatives" do
+        dev_rules = Creative.create!(
+          description: "<p>Dev Rules</p>",
+          user: @user,
+          progress: 1.0
+        )
+
+        @creative.update!(data: {
+          "context_ids" => [ dev_rules.id ],
+          "disabled_context_ids" => [ dev_rules.id ]
+        })
+
+        context = {
+          "comment" => { "id" => @comment.id, "content" => "Implement feature X" },
+          "creative" => { "id" => @creative.id }
+        }
+
+        builder = MessageBuilder.new(agent: @agent, context: context, original_comment: @comment)
+        messages = builder.build
+
+        context_msg = messages.find { |m| m[:parts]&.first&.dig(:text)&.include?("Context Creative") }
+        assert_nil context_msg, "Should not include disabled context creative"
+      end
+
       test "handles message without creative links" do
         context = {
           "comment" => {

--- a/engines/collavre/test/services/collavre/ai_agent/message_builder_test.rb
+++ b/engines/collavre/test/services/collavre/ai_agent/message_builder_test.rb
@@ -103,6 +103,21 @@ module Collavre
         assert_nil context_msg, "Should not include disabled context creative"
       end
 
+      test "skips self context when disabled_self_context is true" do
+        @creative.update!(data: { "disabled_self_context" => true })
+
+        context = {
+          "comment" => { "id" => @comment.id, "content" => "Do something" },
+          "creative" => { "id" => @creative.id }
+        }
+
+        builder = MessageBuilder.new(agent: @agent, context: context, original_comment: @comment)
+        messages = builder.build
+
+        creative_msg = messages.find { |m| m[:parts]&.first&.dig(:text)&.start_with?("Creative (id:") }
+        assert_nil creative_msg, "Should not include self creative context when disabled"
+      end
+
       test "handles message without creative links" do
         context = {
           "comment" => {

--- a/engines/collavre/test/services/collavre/ai_agent/message_builder_test.rb
+++ b/engines/collavre/test/services/collavre/ai_agent/message_builder_test.rb
@@ -103,7 +103,7 @@ module Collavre
         assert_nil context_msg, "Should not include disabled context creative"
       end
 
-      test "skips self context when disabled_self_context is true" do
+      test "injects only ancestry chain when disabled_self_context is true" do
         @creative.update!(data: { "disabled_self_context" => true })
 
         context = {
@@ -114,8 +114,14 @@ module Collavre
         builder = MessageBuilder.new(agent: @agent, context: context, original_comment: @comment)
         messages = builder.build
 
-        creative_msg = messages.find { |m| m[:parts]&.first&.dig(:text)&.start_with?("Creative (id:") }
-        assert_nil creative_msg, "Should not include self creative context when disabled"
+        # Should NOT include full subtree
+        full_msg = messages.find { |m| m[:parts]&.first&.dig(:text)&.start_with?("Creative (id:") }
+        assert_nil full_msg, "Should not include full creative subtree when disabled"
+
+        # Should include ancestry path
+        ancestry_msg = messages.find { |m| m[:parts]&.first&.dig(:text)&.start_with?("Current Creative (id:") }
+        assert_not_nil ancestry_msg, "Should include ancestry chain when self-context disabled"
+        assert_includes ancestry_msg[:parts].first[:text], "Path:"
       end
 
       test "deduplicates context and referenced creatives" do

--- a/engines/collavre/test/services/collavre/ai_agent/message_builder_test.rb
+++ b/engines/collavre/test/services/collavre/ai_agent/message_builder_test.rb
@@ -118,6 +118,34 @@ module Collavre
         assert_nil creative_msg, "Should not include self creative context when disabled"
       end
 
+      test "deduplicates context and referenced creatives" do
+        dev_rules = Creative.create!(
+          description: "<p>Dev Rules</p>",
+          user: @user,
+          progress: 1.0
+        )
+
+        # Same creative as both context AND referenced via markdown link
+        @creative.update!(data: { "context_ids" => [ dev_rules.id ] })
+
+        context = {
+          "comment" => {
+            "id" => @comment.id,
+            "content" => "Check [Dev Rules](/creatives/#{dev_rules.id})"
+          },
+          "creative" => { "id" => @creative.id }
+        }
+
+        builder = MessageBuilder.new(agent: @agent, context: context, original_comment: @comment)
+        messages = builder.build
+
+        # Should appear as Context Creative, NOT also as Referenced Creative
+        context_msgs = messages.select { |m| m[:parts]&.first&.dig(:text)&.include?("Context Creative") }
+        referenced_msgs = messages.select { |m| m[:parts]&.first&.dig(:text)&.include?("Referenced Creative") }
+        assert_equal 1, context_msgs.size, "Should inject context creative once"
+        assert_empty referenced_msgs, "Should not duplicate as referenced creative"
+      end
+
       test "handles message without creative links" do
         context = {
           "comment" => {


### PR DESCRIPTION
## Summary

Add context creative injection system that allows creatives to have linked context creatives (e.g., development rules, goals) automatically injected into AI agent conversations, with inheritance from parent creatives.

## Problem

When working on individual creatives, only child creatives are injected as context. This means:
- AI agents don't know project-level goals, development rules, or git repo locations
- Users must manually inject context for every creative separately

## Solution

Add `context_ids` to the creative `data` JSON column with parent-to-child inheritance:

```
collavre
├── features
│   ├── context_ids: [development]  ← set once at features level
│   ├── feature-a  ← automatically inherits development context
│   └── feature-b  ← automatically inherits development context
├── R&D
│   ├── context_ids: [goal]  ← set once at R&D level
│   └── research-a  ← automatically inherits goal context
└── development
    ├── develop rule
    └── git repo
```

## Features

### Backend
- **Creative model**: `context_ids`, `effective_context_ids(visited_ids)` (with cycle prevention), `context_creatives`
- **API endpoints**: `GET /creatives/:id/contexts`, `PATCH /creatives/:id/update_contexts`
- **MessageBuilder**: `append_context_creatives` injected between self-context and referenced creatives
- **Deduplication**: `@injected_creative_ids` Set tracks all injected IDs across self/context/referenced sources
- **Self-context toggle**: `disabled_self_context` flag in data to skip current creative's subtree injection
- **Disabled contexts**: `disabled_context_ids` in data for temporarily disabling specific contexts

### Frontend
- **Context chips UI**: Horizontal scrolling chip bar below title (similar to topics)
- **🔗 toggle button**: In popup header, left of fullscreen button
  - Hidden when no contexts exist (clean UI for most creatives)
  - Shows active count badge when list is collapsed (e.g., `🔗 3`)
  - Auto-shows list when linked contexts exist
- **📌 Self-context chip**: Always first, toggles self-context injection
- **Click**: Toggle context injection on/off (persisted to server)
- **✕ button**: Remove from `context_ids` (only for directly-set, not inherited)
- **[+] button**: Opens link-creative modal to add new context
- **Drag reorder**: Reorder own context chips (inherited chips not draggable)
- **Inherited contexts**: Dashed border, not deletable, only toggleable
- **Creative switch**: Resets visibility state and reloads contexts

### i18n
- `contexts.en.yml` and `contexts.ko.yml` with labels for inherited, toggle, self-context

## Technical Details

- No migration needed — uses existing `data` JSON column
- `effective_context_ids` uses `visited_ids` Set to prevent infinite loops
- Context list excludes self creative ID to prevent duplicate chips (📌 self-chip handles it)
- `_patchContexts()` common fetch helper eliminates 3x duplicated API code
- Permission: admin required for update_contexts; all users can view contexts

## Tests

- **8 model tests**: context_ids, effective_context_ids, inheritance, dedup, cross-branch isolation
- **10 controller tests**: empty list, inherited, set/clear context_ids, disabled_context_ids, disabled_self_context, self-dedup, permission check
- **7 MessageBuilder tests**: context injection, disabled exclusion, self-context skip, deduplication, referenced creative dedup
- **1 existing test fix**: Added `contacts_view: "org_chart"` param (PR #934 view switcher change)

**Total: 1290 runs, 4158 assertions, 0 failures** ✅

## Files Changed (15 files, +931/-4)

| File | Changes |
|------|---------|
| `creative.rb` | +23 (context_ids, effective_context_ids, context_creatives) |
| `creatives_controller.rb` | +58 (contexts, update_contexts actions) |
| `message_builder.rb` | +43 (append_context_creatives, dedup, self-context toggle) |
| `contexts_controller.js` | +345 (full Stimulus controller) |
| `popup_controller.js` | +10 (contexts lifecycle integration) |
| `index.js` | +2 (controller registration) |
| `comments_popup.css` | +133 (chip styles, toggle button) |
| `_comments_popup.html.erb` | +11 (toggle button, context list div) |
| `routes.rb` | +2 (contexts, update_contexts routes) |
| `contexts.en.yml` | +7 |
| `contexts.ko.yml` | +7 |
| Tests (4 files) | +291 |