### PR TITLE
fix: prevent context chips from being clipped and reduce title padding

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -45,6 +45,11 @@ body.chat-fullscreen {
     gap: 0.75em;
 }
 
+.comments-popup-header h3 {
+    margin: 0;
+    line-height: 1.3;
+}
+
 .comments-popup-actions {
     display: inline-flex;
     align-items: center;
@@ -903,10 +908,10 @@ body.chat-fullscreen {
     gap: 0.4em;
     padding: 0.25em 0;
     overflow-x: auto;
-    overflow-y: hidden;
+    overflow-y: visible;
     scrollbar-width: none;
     -ms-overflow-style: none;
-    min-height: 0;
+    min-height: 26px; /* Ensure chips (22px + padding) are never clipped */
 }
 
 .comment-contexts-list:empty {


### PR DESCRIPTION
## Problem
Context chips in the chat panel were being clipped vertically — text and chip borders cut off. The chat title also had excessive vertical padding.

## Root Cause
- `.comment-contexts-list` had `overflow-y: hidden` with `min-height: 0`, causing chips (22px) to be clipped when the container was smaller than its children
- The h3 title in `.comments-popup-header` used browser default margins

## Changes
- Changed `overflow-y` from `hidden` to `visible` on `.comment-contexts-list`
- Set `min-height: 26px` to ensure the container always fits chips (22px + padding)
- Reset h3 margin to 0 with `line-height: 1.3` for tighter title spacing

(Re-applies #940 which was merged into the feature branch but lost during squash merge to main)