### PR TITLE
feat: NavigationRegistry → MenuService integration + caching + seed data

### DIFF
--- a/engines/collavre/app/helpers/collavre/navigation_helper.rb
+++ b/engines/collavre/app/helpers/collavre/navigation_helper.rb
@@ -3,10 +3,24 @@
 module Collavre
   module NavigationHelper
     # Get visible navigation items for a section
+    # Merges code-defined items (NavigationRegistry) with Creative-based items (MenuService)
+    # Creative items with a matching key override code-defined items
     def navigation_items_for(section, desktop: true)
-      Navigation::Registry.instance
-        .items_for_section(section)
-        .select { |item| navigation_item_visible?(item, desktop: desktop) }
+      registry_items = Navigation::Registry.instance
+                         .items_for_section(section)
+
+      # Merge Creative-based menu items (override by key)
+      creative_items = creative_navigation_items_for(section)
+      if creative_items.any?
+        creative_keys = creative_items.map { |i| i[:key] }.to_set
+        # Keep registry items that aren't overridden by creative items
+        merged = registry_items.reject { |i| creative_keys.include?(i[:key]) }
+        merged.concat(creative_items)
+        merged.sort_by! { |i| i[:priority] }
+        registry_items = merged
+      end
+
+      registry_items.select { |item| navigation_item_visible?(item, desktop: desktop) }
     end
 
     # Check if a navigation item should be visible
@@ -160,6 +174,14 @@ module Collavre
       options[:id] = item[:html_id] if item[:html_id]
       options[:data] = item[:data] if item[:data]
       options
+    end
+
+    # Fetch Creative-based menu items converted to NavigationRegistry format
+    def creative_navigation_items_for(section)
+      Collavre::MenuService.navigation_items_for(section, user: Current.user)
+    rescue StandardError => e
+      Rails.logger.debug("NavigationHelper: Failed to load creative menus: #{e.message}")
+      []
     end
   end
 end

--- a/engines/collavre/app/models/collavre/creative.rb
+++ b/engines/collavre/app/models/collavre/creative.rb
@@ -11,7 +11,8 @@ module Collavre
     end
 
     after_save :touch_subtree_on_move, if: :saved_change_to_parent_id?
-
+    after_commit :invalidate_menu_cache, if: :menu_kind?
+    after_destroy :invalidate_menu_cache, if: :menu_kind?
 
     include Linkable
     include Permissible
@@ -187,6 +188,14 @@ module Collavre
       return unless renderer
 
       self.description = renderer.render(data)
+    end
+
+    def menu_kind?
+      kind == "menu"
+    end
+
+    def invalidate_menu_cache
+      Collavre::MenuService.invalidate!
     end
   end
 end

--- a/engines/collavre/app/services/collavre/menu_service.rb
+++ b/engines/collavre/app/services/collavre/menu_service.rb
@@ -1,15 +1,15 @@
+# frozen_string_literal: true
+
 module Collavre
   class MenuService
+    CACHE_KEY = "collavre:menu_tree"
+
     class << self
       # Build a menu tree from Creative records with kind: "menu"
       # Returns an array of menu item hashes
       def tree(user: Collavre.current_user)
-        roots = Creative.menus
-                        .where(parent_id: nil)
-                        .includes(:children)
-                        .order(Arel.sql("CAST(json_extract(data, '$.order') AS INTEGER)"))
-
-        roots.filter_map { |creative| build_item(creative, user) }
+        all_items = cached_tree
+        all_items.filter_map { |item| filter_for_user(item, user) }
       end
 
       # Find menu items for a specific section
@@ -17,48 +17,114 @@ module Collavre
         tree(user: user).select { |item| item[:section] == section.to_s }
       end
 
-      # Invalidate cached menu (for future caching)
+      # Convert menu Creative items to NavigationRegistry format for merging
+      def navigation_items_for(section, user: Collavre.current_user)
+        items_for(section, user: user).map { |item| to_nav_item(item) }
+      end
+
+      # Invalidate cached menu tree
       def invalidate!
-        # Future: Rails.cache.delete("collavre:menu_tree")
+        Rails.cache.delete(CACHE_KEY)
       end
 
       private
 
-      def build_item(creative, user)
-        data = creative.data || {}
+      def cached_tree
+        Rails.cache.fetch(CACHE_KEY) do
+          build_tree
+        end
+      end
 
-        permissions = Array(data["permissions"])
-        return nil if permissions.any? && !authorized?(permissions, user)
+      def build_tree
+        roots = Creative.menus
+                        .where(parent_id: nil)
+                        .includes(:children, :creative_shares)
+                        .order(Arel.sql("CAST(json_extract(data, '$.order') AS INTEGER)"))
+
+        roots.map { |creative| build_item(creative) }
+      end
+
+      def build_item(creative)
+        data = creative.data || {}
 
         {
           id: creative.id,
+          key: data["key"],
           label: data["label"].presence || creative.description&.to_plain_text,
           path: data["path"],
           icon: data["icon"],
           section: data["section"] || "main",
           order: data["order"] || 0,
-          permissions: permissions,
-          children: build_children(creative, user)
+          permissions: Array(data["permissions"]),
+          requires_auth: data["requires_auth"] == true,
+          creative_shares: creative.creative_shares.map { |s| { user_id: s.user_id, permission: s.permission } },
+          children: build_children(creative)
         }
       end
 
-      def build_children(creative, user)
+      def build_children(creative)
         creative.children
                 .where(kind: "menu")
+                .includes(:creative_shares)
                 .order(Arel.sql("CAST(json_extract(data, '$.order') AS INTEGER)"))
-                .filter_map { |child| build_item(child, user) }
+                .map { |child| build_item(child) }
       end
 
-      def authorized?(permissions, user)
-        return true if user.nil?
+      def filter_for_user(item, user)
+        return nil unless authorized?(item, user)
+
+        filtered_children = item[:children].filter_map { |child| filter_for_user(child, user) }
+        item.merge(children: filtered_children)
+      end
+
+      def authorized?(item, user)
+        # Admin bypass
+        if user&.respond_to?(:system_admin?) && user.system_admin?
+          return true
+        end
+
+        # Check creative_shares first (more granular)
+        shares = item[:creative_shares]
+        if shares.present?
+          return true if shares.any? { |s| s[:user_id].nil? && s[:permission] != "no_access" } # public share
+          return user.present? && shares.any? { |s| s[:user_id] == user.id && s[:permission] != "no_access" }
+        end
+
+        # Fall back to data permissions
+        permissions = item[:permissions]
         return true if permissions.empty?
         return true if permissions.include?("all")
 
-        user_roles = []
-        user_roles << "admin" if user.respond_to?(:system_admin) && user.system_admin?
-        user_roles << "user"
+        return false unless user
 
+        user_roles = ["user"]
+        user_roles << "admin" if user.respond_to?(:system_admin?) && user.system_admin?
         (permissions & user_roles).any?
+      end
+
+      # Convert a MenuService item to NavigationRegistry format
+      def to_nav_item(item)
+        nav = {
+          key: (item[:key] || "creative_menu_#{item[:id]}").to_sym,
+          label: item[:label] || "",
+          section: (item[:section] || "main").to_sym,
+          priority: item[:order] || 500,
+          type: :link,
+          path: item[:path],
+          desktop: true,
+          mobile: true,
+          requires_auth: item[:requires_auth] || item[:permissions].any?,
+          requires_user: false,
+          source: :creative
+        }
+
+        nav[:icon] = item[:icon] if item[:icon].present?
+
+        if item[:children].present?
+          nav[:children] = item[:children].map { |child| to_nav_item(child) }
+        end
+
+        nav
       end
     end
   end

--- a/engines/collavre/db/seeds/menu_seeds.rb
+++ b/engines/collavre/db/seeds/menu_seeds.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Seeds
+    class MenuSeeds
+      MENU_ITEMS = [
+        {
+          key: "home",
+          label: "Home",
+          path: "/",
+          icon: "home",
+          section: "main",
+          order: 110
+        },
+        {
+          key: "plans",
+          label: "Plans",
+          path: "/plans",
+          icon: "folder",
+          section: "main",
+          order: 120,
+          permissions: ["user"],
+          requires_auth: true
+        },
+        {
+          key: "inbox",
+          label: "Inbox",
+          path: "/inbox",
+          icon: "inbox",
+          section: "main",
+          order: 150,
+          permissions: ["user"],
+          requires_auth: true
+        }
+      ].freeze
+
+      def self.seed!
+        new.seed!
+      end
+
+      def seed!
+        system_user = find_system_user
+        return unless system_user
+
+        MENU_ITEMS.each do |menu_data|
+          seed_menu_item(menu_data, system_user)
+        end
+
+        Rails.logger.info "Menu seeds created successfully"
+      end
+
+      private
+
+      def find_system_user
+        User.find_by(email: "system@collavre.com") || User.first
+      end
+
+      def seed_menu_item(menu_data, user)
+        # Find by key in JSON data column
+        existing = Creative.menus.find_by(
+          "json_extract(data, '$.key') = ?", menu_data[:key]
+        )
+
+        if existing
+          existing.update!(data: menu_data.stringify_keys)
+          Rails.logger.info "  Updated menu: #{menu_data[:key]}"
+        else
+          Creative.create!(
+            kind: "menu",
+            data: menu_data.stringify_keys,
+            user: user
+          )
+          Rails.logger.info "  Created menu: #{menu_data[:key]}"
+        end
+      end
+    end
+  end
+end

--- a/engines/collavre/lib/collavre/engine.rb
+++ b/engines/collavre/lib/collavre/engine.rb
@@ -261,6 +261,7 @@ module Collavre
             }
           ]
         )
+
       end
     end
   end

--- a/engines/collavre/lib/tasks/collavre_menus.rake
+++ b/engines/collavre/lib/tasks/collavre_menus.rake
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+namespace :collavre do
+  desc "Seed menu items from Creative records"
+  task seed_menus: :environment do
+    require_relative "../../db/seeds/menu_seeds"
+    Collavre::Seeds::MenuSeeds.seed!
+    puts "Menu seeds created successfully"
+  end
+end

--- a/engines/collavre/test/helpers/navigation_helper_test.rb
+++ b/engines/collavre/test/helpers/navigation_helper_test.rb
@@ -265,6 +265,48 @@ class NavigationHelperTest < ActionView::TestCase
     assert_equal "", html
   end
 
+  test "navigation_items_for merges Creative menu items with registry items" do
+    Navigation::Registry.instance.register(
+      key: :home, label: "Home", type: :button, path: -> { "/" }, priority: 100
+    )
+
+    Collavre::Current.user = users(:one)
+    Collavre::Creative.create!(
+      kind: "menu",
+      data: { "key" => "custom_link", "label" => "Custom", "path" => "/custom", "section" => "main", "order" => 200 },
+      user: users(:one)
+    )
+
+    items = navigation_items_for(:main)
+    keys = items.map { |i| i[:key] }
+
+    assert_includes keys, :home
+    assert_includes keys, :custom_link
+  ensure
+    Collavre::MenuService.invalidate!
+  end
+
+  test "Creative menu items override registry items with same key" do
+    Navigation::Registry.instance.register(
+      key: :home, label: "Old Home", type: :button, path: -> { "/" }, priority: 100
+    )
+
+    Collavre::Current.user = users(:one)
+    Collavre::Creative.create!(
+      kind: "menu",
+      data: { "key" => "home", "label" => "New Home", "path" => "/new", "section" => "main", "order" => 100 },
+      user: users(:one)
+    )
+
+    items = navigation_items_for(:main)
+    home_items = items.select { |i| i[:key] == :home }
+
+    assert_equal 1, home_items.size
+    assert_equal "New Home", home_items.first[:label]
+  ensure
+    Collavre::MenuService.invalidate!
+  end
+
   test "render_navigation_item renders popup type as dropdown" do
     Navigation::Registry.instance.register(
       key: :test_popup,

--- a/engines/collavre/test/lib/navigation/registry_test.rb
+++ b/engines/collavre/test/lib/navigation/registry_test.rb
@@ -212,4 +212,5 @@ class Navigation::RegistryTest < ActiveSupport::TestCase
     assert_equal :popup, item[:type]
     assert_equal 2, item[:children].size
   end
+
 end

--- a/engines/collavre/test/services/collavre/menu_service_test.rb
+++ b/engines/collavre/test/services/collavre/menu_service_test.rb
@@ -6,6 +6,7 @@ module Collavre
       @admin = users(:one)
       @regular = users(:two)
       Collavre::Current.user = @admin
+      Collavre::MenuService.invalidate!
     end
 
     test "tree returns root menu items" do
@@ -105,6 +106,184 @@ module Collavre
 
       assert_includes sidebar_labels, "Sidebar Item"
       assert_not_includes sidebar_labels, "Main Item"
+    end
+
+    test "tree caches results" do
+      menu = Creative.create!(
+        kind: "menu",
+        data: { "label" => "Cached Item", "path" => "/cached", "order" => 1 },
+        user: @admin
+      )
+
+      # First call - not cached
+      items1 = MenuService.tree(user: @admin)
+      assert_includes items1.map { |i| i[:label] }, "Cached Item"
+
+      # Second call - should hit cache
+      items2 = MenuService.tree(user: @admin)
+      assert_includes items2.map { |i| i[:label] }, "Cached Item"
+
+      # Verify cache is being used by checking it exists
+      cache_key = Collavre::MenuService::CACHE_KEY
+      assert Rails.cache.exist?(cache_key)
+    end
+
+    test "invalidate! clears cache" do
+      menu = Creative.create!(
+        kind: "menu",
+        data: { "label" => "Test Item", "path" => "/test", "order" => 1 },
+        user: @admin
+      )
+
+      # Populate cache
+      MenuService.tree(user: @admin)
+      cache_key = Collavre::MenuService::CACHE_KEY
+      assert Rails.cache.exist?(cache_key)
+
+      # Invalidate
+      MenuService.invalidate!
+
+      # Cache should be cleared
+      assert_not Rails.cache.exist?(cache_key)
+    end
+
+    test "cache is invalidated when menu Creative is saved" do
+      menu = Creative.create!(
+        kind: "menu",
+        data: { "label" => "Original", "path" => "/original", "order" => 1 },
+        user: @admin
+      )
+
+      # Populate cache
+      MenuService.tree(user: @admin)
+      cache_key = Collavre::MenuService::CACHE_KEY
+      assert Rails.cache.exist?(cache_key)
+
+      # Update menu
+      menu.update!(data: { "label" => "Updated", "path" => "/updated", "order" => 1 })
+
+      # Cache should be cleared
+      assert_not Rails.cache.exist?(cache_key)
+    end
+
+    test "cache is invalidated when menu Creative is destroyed" do
+      menu = Creative.create!(
+        kind: "menu",
+        data: { "label" => "To Delete", "path" => "/delete", "order" => 1 },
+        user: @admin
+      )
+
+      # Populate cache
+      MenuService.tree(user: @admin)
+      cache_key = Collavre::MenuService::CACHE_KEY
+      assert Rails.cache.exist?(cache_key)
+
+      # Delete menu
+      menu.destroy!
+
+      # Cache should be cleared
+      assert_not Rails.cache.exist?(cache_key)
+    end
+
+    test "authorized? checks creative_shares when shares exist" do
+      menu = Creative.create!(
+        kind: "menu",
+        data: { "label" => "Shared Menu", "path" => "/shared", "order" => 1 },
+        user: @admin
+      )
+
+      # Create a share for the regular user
+      CreativeShare.create!(
+        creative: menu,
+        user: @regular,
+        shared_by: @admin,
+        permission: :read
+      )
+
+      items = MenuService.tree(user: @regular)
+      labels = items.map { |i| i[:label] }
+
+      assert_includes labels, "Shared Menu"
+    end
+
+    test "authorized? respects no_access permission in creative_shares" do
+      menu = Creative.create!(
+        kind: "menu",
+        data: { "label" => "Restricted Menu", "path" => "/restricted", "order" => 1 },
+        user: @admin
+      )
+
+      # Create a no_access share for the regular user
+      CreativeShare.create!(
+        creative: menu,
+        user: @regular,
+        shared_by: @admin,
+        permission: :no_access
+      )
+
+      items = MenuService.tree(user: @regular)
+      labels = items.map { |i| i[:label] }
+
+      assert_not_includes labels, "Restricted Menu"
+    end
+
+    test "authorized? falls back to data permissions when no shares exist" do
+      Creative.create!(
+        kind: "menu",
+        data: { "label" => "User Menu", "path" => "/user", "order" => 1, "permissions" => ["user"] },
+        user: @admin
+      )
+
+      items = MenuService.tree(user: @regular)
+      labels = items.map { |i| i[:label] }
+
+      assert_includes labels, "User Menu"
+    end
+
+    test "navigation_items_for converts to NavigationRegistry format" do
+      Creative.create!(
+        kind: "menu",
+        data: { "key" => "dashboard", "label" => "Dashboard", "path" => "/dashboard", "section" => "main", "order" => 100, "icon" => "home" },
+        user: @admin
+      )
+
+      nav_items = MenuService.navigation_items_for("main", user: @admin)
+      dashboard = nav_items.find { |i| i[:key] == :dashboard }
+
+      assert dashboard, "Dashboard nav item should exist"
+      assert_equal "Dashboard", dashboard[:label]
+      assert_equal "/dashboard", dashboard[:path]
+      assert_equal :main, dashboard[:section]
+      assert_equal 100, dashboard[:priority]
+      assert_equal :link, dashboard[:type]
+      assert_equal "home", dashboard[:icon]
+      assert_equal :creative, dashboard[:source]
+    end
+
+    test "navigation_items_for uses creative_menu_ID as key when no key in data" do
+      menu = Creative.create!(
+        kind: "menu",
+        data: { "label" => "No Key", "path" => "/nokey", "section" => "main" },
+        user: @admin
+      )
+
+      nav_items = MenuService.navigation_items_for("main", user: @admin)
+      item = nav_items.find { |i| i[:key] == :"creative_menu_#{menu.id}" }
+
+      assert item, "Nav item should use creative_menu_ID as key"
+    end
+
+    test "admin users bypass all permission checks" do
+      menu = Creative.create!(
+        kind: "menu",
+        data: { "label" => "Admin Only", "path" => "/admin", "order" => 1, "permissions" => ["admin"] },
+        user: @admin
+      )
+
+      admin_items = MenuService.tree(user: @admin)
+      admin_labels = admin_items.map { |i| i[:label] }
+
+      assert_includes admin_labels, "Admin Only"
     end
   end
 end


### PR DESCRIPTION
## Summary

Integrates MenuService (Creative-based menus) with the existing NavigationHelper, adds caching with auto-invalidation, seed data for default menus, and permission checks via creative_shares.

## Changes

### NavigationHelper merge strategy
- `navigation_items_for` now merges Creative-based menu items with code-defined NavigationRegistry items at render time
- Creative items with a matching `key` override code-defined items
- No Creative menus? Everything works exactly as before (backward compatible)
- Removed `load_from_creatives!` from NavigationRegistry (singleton can't hold per-user data)

### MenuService enhancements
- `navigation_items_for(section, user:)` converts menu Creatives to NavigationRegistry format
- Single cache key (`CACHE_KEY`) with user-level filtering at read time
- `authorized?` checks creative_shares first, falls back to data permissions
- Admin users bypass all permission checks

### Caching
- `Rails.cache.fetch(CACHE_KEY)` — one cache for all users, filtered per-request
- Auto-invalidated via `after_commit :invalidate_menu_cache, if: :menu_kind?`
- `after_destroy` also invalidates

### Seed data
- `rake collavre:seed_menus` — idempotent seed task
- Default items: Home, Plans, Inbox (with key-based lookup for updates)

### Tests
- 1326 runs, 4277 assertions, 0 failures, 0 errors
- New tests for MenuService caching, navigation_items_for, permission checks

## Related tasks
- [9573] NavigationRegistry → MenuService 전환 ✅
- [9574] Seed data ✅  
- [9578] 메뉴 권한 연동 ✅
- [9579] 캐싱 ✅