### PR TITLE
feat: kind-based viewer styling and editor data in creative tree

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/creatives.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/creatives.css
@@ -610,3 +610,38 @@ creative-tree-row:not([expanded]) .creative-toggle-btn {
 .comments-btn .badge[data-count="0"] {
     background: var(--color-brand);
 }
+/* Kind badge for typed creatives */
+.creative-kind-badge {
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.85em;
+  margin-right: 0.3em;
+  opacity: 0.8;
+  vertical-align: middle;
+}
+
+/* Kind-specific row styling */
+creative-tree-row[kind="menu"] .creative-content {
+  border-left: 2px solid var(--color-brand, #3b82f6);
+  padding-left: 0.4em;
+}
+
+creative-tree-row[kind="agent"] .creative-content {
+  border-left: 2px solid #8b5cf6;
+  padding-left: 0.4em;
+}
+
+creative-tree-row[kind="tool"] .creative-content {
+  border-left: 2px solid #f59e0b;
+  padding-left: 0.4em;
+}
+
+creative-tree-row[kind="workflow"] .creative-content {
+  border-left: 2px solid #10b981;
+  padding-left: 0.4em;
+}
+
+creative-tree-row[kind="settings"] .creative-content {
+  border-left: 2px solid #6b7280;
+  padding-left: 0.4em;
+}

--- a/engines/collavre/app/javascript/components/creative_tree_row.js
+++ b/engines/collavre/app/javascript/components/creative_tree_row.js
@@ -10,6 +10,7 @@ class CreativeTreeRow extends LitElement {
     creativeId: { attribute: "creative-id" },
     parentId: { attribute: "parent-id" },
     domId: { attribute: "dom-id" },
+    kind: { attribute: "kind", reflect: true },
     selectMode: { type: Boolean, attribute: "select-mode", reflect: true },
     canWrite: { type: Boolean, attribute: "can-write" },
     level: { type: Number, attribute: "level" },
@@ -32,6 +33,7 @@ class CreativeTreeRow extends LitElement {
     this.creativeId = null;
     this.parentId = null;
     this.domId = null;
+    this.kind = null;
     this.selectMode = false;
     this.canWrite = false;
     this.level = 1;
@@ -292,9 +294,10 @@ class CreativeTreeRow extends LitElement {
   _renderContent() {
     const level = Number(this.level) || 1;
     // Toggle is now rendered outside
+    const kindBadge = this.kind ? this._renderKindBadge() : nothing;
     const content = html`
       <div class="creative-content" @click=${this._handleContentClick}>
-        ${unsafeHTML(this.descriptionHtml || "")}
+        ${kindBadge}${unsafeHTML(this.descriptionHtml || "")}
       </div>
     `;
     const indicator = this.loadingChildren ? this._renderLoadingIndicator() : nothing;
@@ -334,6 +337,20 @@ class CreativeTreeRow extends LitElement {
         ${bullet}${content}${indicator}
       </div>
     `;
+  }
+
+  static KIND_ICONS = {
+    menu: '📋',
+    json: '📄',
+    tool: '🔧',
+    agent: '🤖',
+    workflow: '⚡',
+    settings: '⚙️'
+  };
+
+  _renderKindBadge() {
+    const icon = CreativeTreeRow.KIND_ICONS[this.kind] || '📎';
+    return html`<span class="creative-kind-badge" title="${this.kind}">${icon}</span>`;
   }
 
   _renderLoadingIndicator() {

--- a/engines/collavre/app/javascript/creatives/tree_renderer.js
+++ b/engines/collavre/app/javascript/creatives/tree_renderer.js
@@ -59,6 +59,19 @@ function applyRowProperties(row, node) {
     }
   }
 
+  // Set kind attribute
+  if (node.kind != null) {
+    if (row.kind !== node.kind) {
+      row.kind = node.kind
+      row.setAttribute('kind', node.kind)
+      dirty = true
+    }
+  } else if (row.hasAttribute?.('kind')) {
+    row.kind = null
+    row.removeAttribute('kind')
+    dirty = true
+  }
+
   updateBooleanAttr('selectMode', 'select-mode', node.select_mode)
   updateBooleanAttr('canWrite', 'can-write', node.can_write)
   updateBooleanAttr('hasChildren', 'has-children', node.has_children)

--- a/engines/collavre/app/services/collavre/creatives/tree_builder.rb
+++ b/engines/collavre/app/services/collavre/creatives/tree_builder.rb
@@ -115,6 +115,7 @@ module Creatives
           id: creative.id,
           dom_id: "creative-#{creative.id}",
           parent_id: creative.parent_id,
+          kind: creative.kind,
           level: level,
           select_mode: !!select_mode,
           can_write: cached_can_write?(creative),
@@ -182,11 +183,14 @@ module Creatives
     end
 
     def inline_editor_payload_for(creative)
-      {
+      payload = {
         description_raw_html: creative.effective_description(nil, true),
         progress: creative.progress,
-        origin_id: creative.origin_id
+        origin_id: creative.origin_id,
+        kind: creative.kind
       }
+      payload[:data] = creative.data if creative.kind.present? && creative.data.present?
+      payload
     end
 
     def children_container_payload(creative, filtered_children, child_level:, children_nodes:, expanded:, load_children_now:)


### PR DESCRIPTION
## Summary

Adds kind awareness to the frontend creative tree — typed creatives (menu, agent, tool, etc.) now display visual indicators and carry their data to the inline editor.

## Changes

### TreeBuilder (backend)
- Includes `kind` field in JSON node payload
- `inline_editor_payload` now includes `kind` and `data` when present

### tree_renderer.js
- Passes `kind` attribute from JSON to `<creative-tree-row>` element

### creative_tree_row.js (LitElement)
- New `kind` property with attribute reflection
- Kind badge icons: 📋 menu, 📄 json, 🔧 tool, 🤖 agent, ⚡ workflow, ⚙️ settings
- Badge rendered before description text in `_renderContent()`

### CSS
- Kind-specific left border colors for visual distinction
- `.creative-kind-badge` styling

## Tests
- 1326 runs, 4277 assertions, 0 failures, 0 errors

## Related tasks
- [9575] 프론트엔드 kind별 에디터 분기 (partial — viewer done, editor form TBD)
- [9577] kind별 뷰어 ✅