### PR TITLE
fix: decode HTML entities in creative_snippet

### DIFF
--- a/engines/collavre/app/models/collavre/creative/describable.rb
+++ b/engines/collavre/app/models/collavre/creative/describable.rb
@@ -26,7 +26,7 @@ module Collavre
       end
 
       def creative_snippet
-        ActionController::Base.helpers.strip_tags(effective_origin.description || "").truncate(24, omission: "...")
+        CGI.unescapeHTML(ActionController::Base.helpers.strip_tags(effective_origin.description || "")).truncate(24, omission: "...")
       end
 
       private


### PR DESCRIPTION
## Problem
Chat title displays raw HTML entities like `&amp;` instead of `&`.

## Cause
`creative_snippet` uses `strip_tags` which removes HTML tags but does not decode HTML entities (`&amp;`, `&lt;`, `&gt;`, etc.).

## Fix
Wrap `strip_tags` output with `CGI.unescapeHTML` in `describable.rb` so entities are decoded before display.

```ruby
# Before
strip_tags(description).truncate(24, omission: '...')

# After
CGI.unescapeHTML(strip_tags(description)).truncate(24, omission: '...')
```

## Testing
- All 1295 tests pass
- Verified: `R&amp;D` → `R&D`