### PR TITLE
feat: kind-based editor branching and Lexical JSON storage

### DIFF
--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -320,7 +320,7 @@ module Collavre
       end
 
       def creative_params
-        params.require(:creative).permit(:description, :progress, :parent_id, :sequence, :origin_id)
+        params.require(:creative).permit(:description, :progress, :parent_id, :sequence, :origin_id, :kind, :data)
       end
 
       def any_filter_active?

--- a/engines/collavre/app/javascript/creatives/tree_renderer.js
+++ b/engines/collavre/app/javascript/creatives/tree_renderer.js
@@ -123,6 +123,9 @@ function applyRowProperties(row, node) {
   if (Object.prototype.hasOwnProperty.call(inlinePayload, 'origin_id')) {
     setDatasetValue(row, 'originId', inlinePayload.origin_id ?? '')
   }
+  if (Object.prototype.hasOwnProperty.call(inlinePayload, 'data') && inlinePayload.data) {
+    setDatasetValue(row, 'creativeData', JSON.stringify(inlinePayload.data))
+  }
 
   if (dirty && typeof row.requestUpdate === 'function') {
     row.requestUpdate()

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -99,7 +99,10 @@ export function initializeCreativeRowEditor() {
     const afterInput = document.getElementById('inline-after-id');
     const childInput = document.getElementById('inline-child-id');
     const originIdInput = document.getElementById('inline-origin-id');
+    const kindInput = document.getElementById('inline-creative-kind');
+    const dataInput = document.getElementById('inline-creative-data');
 
+    let currentKind = null; // Track the kind of the currently edited creative
     let lexicalEditor = null;
     if (editorContainer) {
       try {
@@ -250,7 +253,7 @@ export function initializeCreativeRowEditor() {
       const progressValue = hasProgress ? Number(row.dataset.progressValue ?? 0) : 0;
       const parentId = tree.dataset?.parentId || '';
 
-      return {
+      const payload = {
         id: id,
         description,
         description_raw_html: rawHtml,
@@ -258,6 +261,12 @@ export function initializeCreativeRowEditor() {
         parent_id: parentId,
         progress: Number.isNaN(progressValue) ? 0 : progressValue
       };
+      // Include kind and data from the creative-tree-row element
+      if (row.kind) payload.kind = row.kind;
+      if (row.dataset?.creativeData) {
+        try { payload.data = JSON.parse(row.dataset.creativeData); } catch (_) { /* ignore */ }
+      }
+      return payload;
     }
 
     function isHtmlEmpty(html) {
@@ -275,6 +284,10 @@ export function initializeCreativeRowEditor() {
       form.action = `/creatives/${creativeId}`;
       if (methodInput) methodInput.value = 'patch';
       form.dataset.creativeId = creativeId;
+      // Set kind and data
+      currentKind = data.kind || null;
+      if (kindInput) kindInput.value = currentKind || '';
+      if (dataInput) dataInput.value = data.data ? JSON.stringify(data.data) : '';
       const content = data.description_raw_html || data.description || '';
       descriptionInput.value = content;
       lexicalEditor.load(content, `creative-${creativeId}-${Date.now()}`);
@@ -1643,6 +1656,18 @@ export function initializeCreativeRowEditor() {
 
     function onLexicalChange(html) {
       descriptionInput.value = html;
+      // For kind=null or kind=json, store Lexical raw JSON in data
+      if (!currentKind || currentKind === 'json') {
+        const editorStateJSON = lexicalEditor?.getEditorStateJSON?.();
+        if (editorStateJSON && dataInput) {
+          dataInput.value = JSON.stringify({
+            format: 'lexical',
+            content: editorStateJSON
+          });
+          // Auto-set kind to json when data is present
+          if (kindInput && !currentKind) kindInput.value = 'json';
+        }
+      }
       // Mark as dirty if content changed from original
       isDirty = (html !== originalContent);
       scheduleSave();

--- a/engines/collavre/app/javascript/modules/lexical_inline_editor.jsx
+++ b/engines/collavre/app/javascript/modules/lexical_inline_editor.jsx
@@ -126,6 +126,14 @@ export function createInlineEditor(container, {
       const ids = Array.from(deletedAttachmentsRef.current || [])
       deletedAttachmentsRef.current = []
       return ids
+    },
+    getEditorStateJSON() {
+      if (!editorInstance) return null
+      try {
+        return editorInstance.getEditorState().toJSON()
+      } catch (_) {
+        return null
+      }
     }
   }
 }

--- a/engines/collavre/app/models/collavre/creative.rb
+++ b/engines/collavre/app/models/collavre/creative.rb
@@ -25,6 +25,7 @@ module Collavre
     scope :of_kind, ->(kind) { where(kind: kind) }
     scope :menus, -> { of_kind("menu") }
 
+    before_validation :parse_data_if_string
     before_validation :render_description_from_data, if: -> { kind.present? }
 
     has_many :comments, class_name: "Collavre::Comment", dependent: :destroy
@@ -183,11 +184,19 @@ module Collavre
       descendants.update_all(updated_at: Time.current)
     end
 
+    def parse_data_if_string
+      self.data = JSON.parse(data) if data.is_a?(String) && data.present?
+    rescue JSON::ParserError
+      # Keep as-is if invalid JSON
+    end
+
     def render_description_from_data
       renderer = Collavre::CreativeRenderers.for(kind)
       return unless renderer
 
-      self.description = renderer.render(data)
+      rendered = renderer.render(data)
+      # nil means "keep existing description" (e.g., kind: "json" where HTML comes from editor)
+      self.description = rendered unless rendered.nil?
     end
 
     def menu_kind?

--- a/engines/collavre/app/models/collavre/creative_renderers.rb
+++ b/engines/collavre/app/models/collavre/creative_renderers.rb
@@ -1,6 +1,7 @@
 module Collavre
   module CreativeRenderers
     REGISTRY = {
+      "json" => Collavre::CreativeRenderers::Json,
       "menu" => Collavre::CreativeRenderers::Menu
     }.freeze
 

--- a/engines/collavre/app/models/collavre/creative_renderers/json.rb
+++ b/engines/collavre/app/models/collavre/creative_renderers/json.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Collavre
+  module CreativeRenderers
+    class Json
+      # For kind: "json", description is already provided as HTML from the Lexical editor.
+      # The data field stores the Lexical raw JSON as source of truth.
+      # We don't render from data → description because the HTML comes directly from the editor.
+      # This renderer is a no-op: it returns nil to signal "keep the existing description".
+      def self.render(data)
+        nil
+      end
+    end
+  end
+end

--- a/engines/collavre/app/views/collavre/creatives/_inline_edit_form.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_inline_edit_form.html.erb
@@ -3,6 +3,8 @@
     <input type="hidden" id="inline-method" name="_method" value="patch" />
     <input type="hidden" name="authenticity_token" value="<%= form_authenticity_token %>" />
     <input type="hidden" id="inline-creative-description" name="creative[description]" />
+    <input type="hidden" id="inline-creative-kind" name="creative[kind]" />
+    <input type="hidden" id="inline-creative-data" name="creative[data]" />
     <input type="hidden" id="inline-parent-id" name="creative[parent_id]" />
     <input type="hidden" id="inline-before-id" name="before_id" />
     <input type="hidden" id="inline-after-id" name="after_id" />

--- a/engines/collavre/test/models/collavre/creative_kind_test.rb
+++ b/engines/collavre/test/models/collavre/creative_kind_test.rb
@@ -166,5 +166,46 @@ module Collavre
       assert_equal parent_menu.id, child_menu.parent_id
       assert_includes parent_menu.children, child_menu
     end
+
+    # --- kind: "json" tests ---
+
+    test "kind json preserves description when data is present" do
+      creative = Creative.create!(
+        kind: "json",
+        description: "<p>Hello World</p>",
+        data: { "format" => "lexical", "content" => { "root" => {} } },
+        user: @user
+      )
+      assert_equal "<p>Hello World</p>", creative.description.to_s
+      assert_equal "lexical", creative.data["format"]
+    end
+
+    test "kind json parses string data" do
+      creative = Creative.new(
+        kind: "json",
+        description: "<p>Test</p>",
+        data: '{"format":"lexical","content":{"root":{}}}',
+        user: @user
+      )
+      creative.valid?
+      assert creative.data.is_a?(Hash)
+      assert_equal "lexical", creative.data["format"]
+    end
+
+    test "kind json does not overwrite description from data" do
+      creative = Creative.create!(
+        kind: "json",
+        description: "<p>Original</p>",
+        data: { "format" => "lexical", "content" => {} },
+        user: @user
+      )
+      creative.update!(description: "<p>Updated</p>")
+      assert_equal "<p>Updated</p>", creative.description.to_s
+    end
+
+    test "CreativeRenderers::Json render returns nil" do
+      result = Collavre::CreativeRenderers::Json.render({ "format" => "lexical" })
+      assert_nil result
+    end
   end
 end


### PR DESCRIPTION
## Summary

Completes tasks [9575] and [9576] — kind-based editor branching and Lexical raw JSON storage.

## Changes

### Backend
- `creative_params` now permits `kind` and `data`
- `parse_data_if_string` — handles JSON string from form submission
- `render_description_from_data` — nil return = keep existing description
- `CreativeRenderers::Json` — no-op renderer (description comes from Lexical editor, data stores raw JSON)

### Frontend
- Inline edit form: hidden inputs for `kind` and `data`
- `creative_row_editor.js`: tracks `currentKind`, populates kind/data on edit
- `onLexicalChange`: auto-captures Lexical editor state JSON into data input
- `lexical_inline_editor.jsx`: new `getEditorStateJSON()` method
- `tree_renderer.js`: passes `data` to dataset for inline editor

### Data Flow
```
User edits in Lexical → onLexicalChange fires
  → HTML → creative[description]
  → Lexical JSON → creative[data] = {format: 'lexical', content: {...}}
  → kind auto-set to 'json' if null
```

## Tests
- 4 new tests for kind: json behavior
- All pass: 1330 runs, 4283 assertions, 0 failures

## Tasks
- [9575] ✅ 프론트엔드 kind별 에디터 분기
- [9576] ✅ kind: json — Lexical raw JSON 저장