### PR TITLE
feat: add metadata editor to creative inline editor

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/creatives.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/creatives.css
@@ -610,3 +610,26 @@ creative-tree-row:not([expanded]) .creative-toggle-btn {
 .comments-btn .badge[data-count="0"] {
     background: var(--color-brand);
 }
+
+/* Metadata popup styles */
+.metadata-popup {
+    position: absolute;
+    bottom: 100%;
+    left: 0;
+    z-index: 100;
+    background: var(--surface-1, #fff);
+    border: 1px solid var(--surface-3, #ddd);
+    border-radius: var(--radius-2, 8px);
+    padding: var(--space-3, 12px);
+    box-shadow: var(--shadow-3, 0 4px 12px rgba(0,0,0,0.15));
+    min-width: 300px;
+    max-width: 500px;
+}
+
+.metadata-popup-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: var(--space-2, 8px);
+    font-weight: var(--weight-6, 600);
+}

--- a/engines/collavre/app/assets/stylesheets/collavre/creatives.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/creatives.css
@@ -611,25 +611,71 @@ creative-tree-row:not([expanded]) .creative-toggle-btn {
     background: var(--color-brand);
 }
 
-/* Metadata popup styles */
+/* Metadata popup styles — mirrors #comments-popup positioning */
 .metadata-popup {
     position: absolute;
-    bottom: 100%;
-    left: 0;
-    z-index: 100;
-    background: var(--surface-1, #fff);
-    border: 1px solid var(--surface-3, #ddd);
-    border-radius: var(--radius-2, 8px);
-    padding: var(--space-3, 12px);
-    box-shadow: var(--shadow-3, 0 4px 12px rgba(0,0,0,0.15));
-    min-width: 300px;
-    max-width: 500px;
+    right: 2em;
+    z-index: var(--layer-modal);
+    width: 400px;
+    max-width: calc(100vw - 1em);
+    max-height: 60vh;
+    background: var(--surface-bg);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-3);
+    padding: var(--space-3);
+    box-shadow: var(--shadow-3);
+    display: flex;
+    flex-direction: column;
 }
 
 .metadata-popup-header {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    margin-bottom: var(--space-2, 8px);
-    font-weight: var(--weight-6, 600);
+    margin-bottom: var(--space-2);
+    font-weight: var(--weight-6);
+    color: var(--text-primary);
+}
+
+.metadata-popup-header button {
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    font-size: var(--text-3);
+    color: var(--text-muted);
+    padding: 0;
+    line-height: 1;
+}
+
+.metadata-popup-header button:hover {
+    color: var(--text-primary);
+}
+
+#metadata-yaml-editor {
+    flex: 1;
+    width: 100%;
+    min-height: 200px;
+    box-sizing: border-box;
+    font-family: var(--font-mono);
+    font-size: var(--text-0);
+    line-height: var(--leading-2);
+    padding: var(--space-2);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-2);
+    background: var(--surface-input);
+    color: var(--text-primary);
+    resize: vertical;
+}
+
+#metadata-save-btn {
+    margin-top: var(--space-2);
+    align-self: flex-end;
+}
+
+@media (max-width: 768px) {
+    .metadata-popup {
+        right: 0.5em;
+        left: 0.5em;
+        width: auto;
+    }
 }

--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -292,7 +292,7 @@ module Collavre
 
     def update_metadata
       creative = @creative.effective_origin(Set.new)
-      unless creative.has_permission?(Current.user, :admin)
+      unless creative.has_permission?(Current.user, :write)
         render json: { error: t("collavre.creatives.errors.no_permission") }, status: :forbidden
         return
       end

--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -9,7 +9,7 @@ module Collavre
     # Removed unauthenticated access to index and show actions
     allow_unauthenticated_access only: %i[ index children export_markdown show slide_view ]
     before_action :enforce_creatives_login_policy, only: %i[ index children export_markdown show slide_view ]
-    before_action :set_creative, only: %i[ show edit update destroy parent_suggestions slide_view request_permission unconvert contexts update_contexts ]
+    before_action :set_creative, only: %i[ show edit update destroy parent_suggestions slide_view request_permission unconvert contexts update_contexts update_metadata ]
 
     def index
       respond_to do |format|
@@ -143,7 +143,8 @@ module Collavre
               progress_html: view_context.render_creative_progress(@creative),
               depth: depth,
               prompt: @creative.prompt_for(Current.user),
-              has_children: children_count > 0
+              has_children: children_count > 0,
+              data: @creative.effective_origin(Set.new).data
             }
           end
         end
@@ -283,6 +284,26 @@ module Collavre
       end
 
       if creative.update(data: current_data)
+        head :ok
+      else
+        render json: { errors: creative.errors.full_messages }, status: :unprocessable_entity
+      end
+    end
+
+    def update_metadata
+      creative = @creative.effective_origin(Set.new)
+      unless creative.has_permission?(Current.user, :admin)
+        render json: { error: t("collavre.creatives.errors.no_permission") }, status: :forbidden
+        return
+      end
+
+      new_data = begin
+        JSON.parse(params[:data])
+      rescue JSON::ParserError => e
+        render json: { error: "Invalid JSON: #{e.message}" }, status: :unprocessable_entity
+        return
+      end
+      if creative.update(data: new_data)
         head :ok
       else
         render json: { errors: creative.errors.full_messages }, status: :unprocessable_entity

--- a/engines/collavre/app/javascript/lib/api/creatives.js
+++ b/engines/collavre/app/javascript/lib/api/creatives.js
@@ -65,6 +65,17 @@ export function unconvert(id) {
   })
 }
 
+export function updateMetadata(id, data) {
+  const body = new FormData()
+  body.append('data', JSON.stringify(data))
+
+  return csrfFetch(`/creatives/${id}/update_metadata`, {
+    method: 'PATCH',
+    headers: JSON_HEADERS,
+    body,
+  })
+}
+
 const creativesApi = {
   get,
   parentSuggestions,
@@ -74,6 +85,7 @@ const creativesApi = {
   linkExisting,
   destroy,
   unconvert,
+  updateMetadata,
 }
 
 export default creativesApi

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -4,6 +4,7 @@ import { $getCharacterOffsets, $getSelection, $isRangeSelection, $isTextNode, $i
 import { createInlineEditor } from './lexical_inline_editor'
 import { renderCreativeTree, dispatchCreativeTreeUpdated } from '../creatives/tree_renderer'
 import { isProgressComplete, progressBaselineValueFrom, progressValueChangedFrom } from './creative_progress'
+import yaml from 'js-yaml'
 // Import Stimulus application from the global window (set by host app)
 const application = window.Stimulus
 
@@ -99,6 +100,11 @@ export function initializeCreativeRowEditor() {
     const afterInput = document.getElementById('inline-after-id');
     const childInput = document.getElementById('inline-child-id');
     const originIdInput = document.getElementById('inline-origin-id');
+    const metadataBtn = document.getElementById('inline-metadata-btn');
+    const metadataPopup = document.getElementById('metadata-popup');
+    const metadataEditor = document.getElementById('metadata-yaml-editor');
+    const metadataSaveBtn = document.getElementById('metadata-save-btn');
+    const metadataCloseBtn = document.getElementById('metadata-popup-close');
 
     let lexicalEditor = null;
     if (editorContainer) {
@@ -1924,6 +1930,68 @@ export function initializeCreativeRowEditor() {
             unconvertBtn.disabled = false;
           });
       });
+    }
+
+    // Metadata editor handlers
+    if (metadataBtn && metadataPopup && metadataEditor) {
+      metadataBtn.addEventListener('click', function () {
+        const creativeId = form.dataset.creativeId;
+        if (!creativeId) return;
+
+        // Fetch the creative's data via API
+        creativesApi.get(creativeId)
+          .then(function (data) {
+            const metadataObj = data.data || {};
+            // Convert JSON to YAML string
+            const yamlStr = yaml.dump(metadataObj, { lineWidth: -1 });
+            metadataEditor.value = yamlStr;
+            // Show popup
+            metadataPopup.style.display = 'block';
+          })
+          .catch(function (error) {
+            console.error('Failed to load metadata:', error);
+            alert('Failed to load metadata');
+          });
+      });
+
+      if (metadataCloseBtn) {
+        metadataCloseBtn.addEventListener('click', function () {
+          metadataPopup.style.display = 'none';
+        });
+      }
+
+      if (metadataSaveBtn) {
+        metadataSaveBtn.addEventListener('click', function () {
+          const creativeId = form.dataset.creativeId;
+          if (!creativeId) return;
+
+          try {
+            // Parse YAML back to JSON
+            const yamlStr = metadataEditor.value;
+            const parsedData = yaml.load(yamlStr) || {};
+
+            // Send PATCH request
+            creativesApi.updateMetadata(creativeId, parsedData)
+              .then(function (response) {
+                if (response.ok) {
+                  metadataPopup.style.display = 'none';
+                  alert('Metadata saved successfully');
+                } else {
+                  return response.json().then(function (data) {
+                    alert('Failed to save metadata: ' + (data.error || 'Unknown error'));
+                  });
+                }
+              })
+              .catch(function (error) {
+                console.error('Failed to save metadata:', error);
+                alert('Failed to save metadata');
+              });
+          } catch (error) {
+            console.error('YAML parse error:', error);
+            alert('Invalid YAML format: ' + error.message);
+          }
+        });
+      }
     }
   });
 }

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -312,7 +312,13 @@ export function initializeCreativeRowEditor() {
       updateActionButtonStates();
       // Reload metadata if the popup is open
       if (isMetadataPopupVisible()) {
-        loadMetadataForCreative(creativeId);
+        if (data.data !== undefined) {
+          // Use data already fetched from API response — avoids extra request
+          const yamlStr = yaml.dump(data.data || {}, { lineWidth: -1 });
+          metadataEditor.value = yamlStr;
+        } else {
+          loadMetadataForCreative(creativeId);
+        }
       }
     }
 

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -1975,7 +1975,6 @@ export function initializeCreativeRowEditor() {
               .then(function (response) {
                 if (response.ok) {
                   metadataPopup.style.display = 'none';
-                  alert('Metadata saved successfully');
                 } else {
                   return response.json().then(function (data) {
                     alert('Failed to save metadata: ' + (data.error || 'Unknown error'));

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -310,6 +310,10 @@ export function initializeCreativeRowEditor() {
       originalProgress = normalizedProgress;
       lexicalEditor.focus();
       updateActionButtonStates();
+      // Reload metadata if the popup is open
+      if (isMetadataPopupVisible()) {
+        loadMetadataForCreative(creativeId);
+      }
     }
 
     function siblingTreeRow(row, direction) {
@@ -1933,25 +1937,36 @@ export function initializeCreativeRowEditor() {
     }
 
     // Metadata editor handlers
+    function loadMetadataForCreative(creativeId) {
+      if (!creativeId || !metadataPopup || !metadataEditor) return;
+      creativesApi.get(creativeId)
+        .then(function (data) {
+          const metadataObj = data.data || {};
+          const yamlStr = yaml.dump(metadataObj, { lineWidth: -1 });
+          metadataEditor.value = yamlStr;
+        })
+        .catch(function (error) {
+          console.error('Failed to load metadata:', error);
+          alert('Failed to load metadata');
+        });
+    }
+
+    function isMetadataPopupVisible() {
+      return metadataPopup && metadataPopup.style.display !== 'none';
+    }
+
     if (metadataBtn && metadataPopup && metadataEditor) {
       metadataBtn.addEventListener('click', function () {
         const creativeId = form.dataset.creativeId;
         if (!creativeId) return;
 
-        // Fetch the creative's data via API
-        creativesApi.get(creativeId)
-          .then(function (data) {
-            const metadataObj = data.data || {};
-            // Convert JSON to YAML string
-            const yamlStr = yaml.dump(metadataObj, { lineWidth: -1 });
-            metadataEditor.value = yamlStr;
-            // Show popup
-            metadataPopup.style.display = 'block';
-          })
-          .catch(function (error) {
-            console.error('Failed to load metadata:', error);
-            alert('Failed to load metadata');
-          });
+        if (isMetadataPopupVisible()) {
+          metadataPopup.style.display = 'none';
+          return;
+        }
+
+        loadMetadataForCreative(creativeId);
+        metadataPopup.style.display = 'block';
       });
 
       if (metadataCloseBtn) {

--- a/engines/collavre/app/views/collavre/creatives/_inline_edit_form.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_inline_edit_form.html.erb
@@ -97,10 +97,10 @@
       <div id="metadata-popup" style="display:none;" class="metadata-popup">
         <div class="metadata-popup-header">
           <span><%= t('collavre.creatives.index.metadata_title') %></span>
-          <button type="button" id="metadata-popup-close" class="creative-action-btn">&times;</button>
+          <button type="button" id="metadata-popup-close">&times;</button>
         </div>
-        <textarea id="metadata-yaml-editor" rows="12" style="width:100%;font-family:monospace;font-size:0.85em;"></textarea>
-        <button type="button" id="metadata-save-btn" class="creative-action-btn" style="margin-top:0.5em;">
+        <textarea id="metadata-yaml-editor" rows="12"></textarea>
+        <button type="button" id="metadata-save-btn" class="creative-action-btn">
           <%= t('collavre.creatives.index.metadata_save') %>
         </button>
       </div>

--- a/engines/collavre/app/views/collavre/creatives/_inline_edit_form.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_inline_edit_form.html.erb
@@ -27,6 +27,9 @@
                  data-children-alert-message="<%= t('collavre.creatives.index.progress_complete_children_alert') %>">
           <span id="inline-progress-value"><%= t('collavre.creatives.index.progress_incomplete') %></span>
         </label>
+        <button type="button" id="inline-metadata-btn" class="creative-action-btn" title="<%= t('collavre.creatives.index.metadata_tooltip') %>" style="margin-left:0.5em;font-family:monospace;font-size:0.9em;">
+          { }
+        </button>
       </div>
       <div style="margin-top:0.5em;">
         <button type="button" id="inline-move-up" class="creative-action-btn" title="<%= t('collavre.creatives.index.inline_move_up_tooltip') %>">
@@ -91,6 +94,16 @@
       </div>
       <button type="button" id="inline-recommend-parent" class="creative-action-btn" style="margin-top:0.5em;" title="<%= t('collavre.creatives.index.recommend_parent') %>">✨<%= t('collavre.creatives.index.recommend_parent') %></button>
       <select id="parent-suggestions" size="5" style="display:none;margin-top:0.5em;width:100%;"></select>
+      <div id="metadata-popup" style="display:none;" class="metadata-popup">
+        <div class="metadata-popup-header">
+          <span><%= t('collavre.creatives.index.metadata_title') %></span>
+          <button type="button" id="metadata-popup-close" class="creative-action-btn">&times;</button>
+        </div>
+        <textarea id="metadata-yaml-editor" rows="12" style="width:100%;font-family:monospace;font-size:0.85em;"></textarea>
+        <button type="button" id="metadata-save-btn" class="creative-action-btn" style="margin-top:0.5em;">
+          <%= t('collavre.creatives.index.metadata_save') %>
+        </button>
+      </div>
     </div>
   </form>
 </div>

--- a/engines/collavre/config/locales/creatives.en.yml
+++ b/engines/collavre/config/locales/creatives.en.yml
@@ -119,6 +119,9 @@ en:
         inline_level_down_tooltip: Indent / add as child (Ctrl/Cmd+Shift+.)
         inline_level_up_tooltip: Outdent / move up a level (Ctrl/Cmd+Shift+,)
         inline_close_tooltip: Close editor (Esc)
+        metadata_tooltip: Edit metadata
+        metadata_title: Metadata
+        metadata_save: Save
       share:
         shared: Creative shared successfully.
         permission_updated: Permission updated successfully.

--- a/engines/collavre/config/locales/creatives.ko.yml
+++ b/engines/collavre/config/locales/creatives.ko.yml
@@ -107,6 +107,9 @@ ko:
         inline_level_down_tooltip: 들여쓰기 / 자식으로 이동 (Ctrl/Cmd+Shift+.)
         inline_level_up_tooltip: 내어쓰기 / 상위로 이동 (Ctrl/Cmd+Shift+,)
         inline_close_tooltip: 편집기 닫기 (Esc)
+        metadata_tooltip: 메타데이터 편집
+        metadata_title: 메타데이터
+        metadata_save: 저장
       share:
         shared: 크리에이티브가 성공적으로 공유되었습니다.
         permission_updated: 권한이 성공적으로 변경되었습니다.

--- a/engines/collavre/config/routes.rb
+++ b/engines/collavre/config/routes.rb
@@ -99,6 +99,7 @@ Collavre::Engine.routes.draw do
       get :slide_view
       get :contexts
       patch :update_contexts
+      patch :update_metadata
     end
   end
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@rails/actiontext": "^8.0.201",
         "dompurify": "^3.3.0",
         "firebase": "^12.2.1",
+        "js-yaml": "^4.1.0",
         "lexical": "^0.38.2",
         "lit": "^3.1.2",
         "marked": "^16.4.1",
@@ -2137,6 +2138,30 @@
         "node": ">=8"
       }
     },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/@istanbuljs/schema": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
@@ -3732,14 +3757,10 @@
       }
     },
     "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/aria-query": {
       "version": "5.3.0",
@@ -4166,26 +4187,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/cosmiconfig/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "license": "Python-2.0"
-    },
-    "node_modules/cosmiconfig/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/cross-spawn": {
@@ -6652,14 +6653,12 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
-      "dev": true,
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "license": "MIT",
       "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@rails/actiontext": "^8.0.201",
     "dompurify": "^3.3.0",
     "firebase": "^12.2.1",
+    "js-yaml": "^4.1.0",
     "lexical": "^0.38.2",
     "lit": "^3.1.2",
     "marked": "^16.4.1",


### PR DESCRIPTION
## Summary

Add a metadata edit button ("{ }") next to the completion checkbox in the creative inline editor. Clicking it opens a simple popup that displays the creative's `data` JSON column as YAML for editing, with a single Save button.

## Changes

### View
- Added `{ }` metadata button next to progress checkbox in `_inline_edit_form.html.erb`
- Added popup with YAML textarea and save/close buttons

### Controller
- Added `update_metadata` action with admin permission check and JSON parsing
- Added `data` field to show action JSON response

### JavaScript
- Added `js-yaml` dependency for JSON↔YAML conversion
- Added metadata button click handler: fetches creative data, converts to YAML, displays popup
- Added save handler: parses YAML back to JSON, sends PATCH to `update_metadata`
- Added `updateMetadata()` to creatives API module

### Routes
- Added `patch :update_metadata` member route on creatives

### CSS
- Added `.metadata-popup` and `.metadata-popup-header` styles

### i18n
- Added en/ko translations for metadata_tooltip, metadata_title, metadata_save

## Notes
- Uses `js-yaml` library for reliable YAML parsing
- Follows `update_contexts` pattern for the controller action
- Future improvement: replace textarea with a proper YAML editor