### PR TITLE
feat: add scroll navigation to quoted comments

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -203,6 +203,12 @@ body.chat-fullscreen {
 .comment-quoted-block {
     margin-top: 0.3em;
     margin-bottom: 0.2em;
+    cursor: pointer;
+    transition: opacity 0.2s ease;
+}
+
+.comment-quoted-block:hover {
+    opacity: 0.8;
 }
 
 .comment-quoted-text,

--- a/engines/collavre/app/javascript/controllers/comment_controller.js
+++ b/engines/collavre/app/javascript/controllers/comment_controller.js
@@ -376,6 +376,19 @@ export default class extends Controller {
 
   // Selection change listener and replace button logic removed — unified into review
 
+  scrollToQuotedComment(event) {
+    event.preventDefault()
+    const quotedCommentId = event.currentTarget.dataset.quotedCommentId
+    if (!quotedCommentId) return
+
+    const targetComment = document.getElementById(`comment_${quotedCommentId}`)
+    if (!targetComment) return
+
+    targetComment.scrollIntoView({ behavior: 'smooth', block: 'center' })
+    targetComment.classList.add('highlight-flash')
+    setTimeout(() => targetComment.classList.remove('highlight-flash'), 2000)
+  }
+
   updateReactionsUI(reactionsData) {
     let reactionsContainer = this.element.querySelector('.comment-reactions')
 

--- a/engines/collavre/app/views/collavre/comments/_comment.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comment.html.erb
@@ -66,7 +66,9 @@
       </button>
     </div>
   <% if comment.quoted_text.present? %>
-    <div class="comment-quoted-block">
+    <div class="comment-quoted-block"
+         data-quoted-comment-id="<%= comment.quoted_comment_id %>"
+         data-action="click->comment#scrollToQuotedComment">
       <blockquote class="comment-quoted-text"><%= comment.quoted_text %></blockquote>
     </div>
   <% end %>


### PR DESCRIPTION
## Summary

When a user clicks on a quoted text block in the comments, the view now scrolls to the original quoted comment and highlights it with a flash animation.

## Changes

- **View**: Added `data-quoted-comment-id` and `data-action="click->comment#scrollToQuotedComment"` to the `.comment-quoted-block` div
- **JS (comment_controller.js)**: Added `scrollToQuotedComment()` method that finds the target comment DOM element, scrolls it into view with smooth behavior, and applies a 2-second highlight flash animation
- **CSS (comments_popup.css)**: Added `cursor: pointer` and hover opacity effect to `.comment-quoted-block` to indicate clickability

## Notes

- Reuses existing `highlight-flash` CSS animation already defined in the codebase
- If the quoted comment is not in the current DOM (e.g., not loaded due to pagination), the click is silently ignored
- No i18n changes needed (no new user-facing text)