### PR TITLE
fix: load child creatives when entering chat fullscreen directly

### DIFF
--- a/engines/collavre/app/controllers/collavre/comments_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comments_controller.rb
@@ -15,6 +15,9 @@ module Collavre
       @creatives = []
       @shared_list = @creative.all_shared_users
       @auto_fullscreen = true
+      # Set params[:id] so the tree URL in creatives/index loads children of this
+      # creative instead of the root list.
+      params[:id] = @creative.id.to_s
       # Prepend creatives prefix so partials like 'add_button' resolve to collavre/creatives/_add_button
       lookup_context.prefixes.prepend "collavre/creatives"
       render "collavre/creatives/index"


### PR DESCRIPTION
## Problem

When navigating directly to `/creatives/:id/comments/fullscreen`, the background creative list loaded the **root list** instead of the **children** of the current creative.

## Cause

The `fullscreen` action in `CommentsController` renders `creatives/index`, but the route only provides `params[:creative_id]` (from the nested route), not `params[:id]`. The tree URL in `creatives/index.html.erb` is built by slicing `params[:id]`, so without it, the URL becomes `/creatives.json` (root list) instead of `/creatives.json?id=<creative_id>`.

## Fix

Set `params[:id] = @creative.id.to_s` in the `fullscreen` action so the tree URL correctly points to the children of the target creative.

## Testing

- All existing tests pass (1295 runs, 0 failures)
- Rubocop clean
- i18n keys complete

Closes creative #9445