### PR TITLE
fix: refresh CSRF token after OS window switch to prevent 422

### DIFF
--- a/engines/collavre/app/controllers/collavre/application_controller.rb
+++ b/engines/collavre/app/controllers/collavre/application_controller.rb
@@ -2,7 +2,20 @@ module Collavre
   class ApplicationController < ::ApplicationController
     protect_from_forgery with: :exception
 
+    # Include a fresh CSRF token in every response header so that
+    # JavaScript callers can update the stale <meta> tag after the
+    # browser has been in the background (OS window switch, tab
+    # freeze, etc.).  Without this, the meta-tag token drifts out
+    # of sync with the session cookie and POSTs fail with 422.
+    after_action :set_csrf_token_header
+
     private
+
+    def set_csrf_token_header
+      return unless protect_against_forgery?
+
+      response.headers["X-CSRF-Token"] = form_authenticity_token
+    end
 
     # Helper to get the engine's routes
     def collavre_engine

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -1,6 +1,7 @@
 import { Controller } from '@hotwired/stimulus'
 import { renderMarkdownInContainer } from '../../lib/utils/markdown'
 import { wrapHtmlInCodeBlocks } from '../../lib/html_code_block_wrapper'
+import { refreshCsrfToken } from '../../lib/api/csrf_fetch'
 import ReviewQuotesStore from './review_quotes_store'
 
 export default class extends Controller {
@@ -243,13 +244,26 @@ export default class extends Controller {
       method = 'PATCH'
     }
 
-    fetch(url, {
+    const doFetch = () => fetch(url, {
       method,
       headers: { 'X-CSRF-Token': document.querySelector('meta[name=csrf-token]').content },
       body: formData,
     })
+
+    doFetch()
       .then((response) => {
         if (response.ok) return response.text()
+        // On 422, the CSRF token may have gone stale (e.g. after an OS
+        // window switch).  Refresh the token and retry once before giving up.
+        if (response.status === 422 && !this._hasRetried) {
+          this._hasRetried = true
+          return refreshCsrfToken().then(() => doFetch()).then((retryResp) => {
+            if (retryResp.ok) return retryResp.text()
+            return retryResp.json().then((json) => {
+              throw new Error(json.errors?.join(', ') || 'Unable to save comment')
+            })
+          })
+        }
         return response.json().then((json) => {
           throw new Error(json.errors?.join(', ') || 'Unable to save comment')
         })
@@ -305,6 +319,7 @@ export default class extends Controller {
         alert(error?.message || 'Failed to submit comment')
       })
       .finally(() => {
+        this._hasRetried = false
         this.setSendingState(false)
       })
   }
@@ -647,13 +662,24 @@ export default class extends Controller {
     }
 
     const url = `/creatives/${this.creativeId}/comments`
-    fetch(url, {
+    const doFetch = () => fetch(url, {
       method: 'POST',
       headers: { 'X-CSRF-Token': document.querySelector('meta[name=csrf-token]').content },
       body: formData,
     })
+
+    doFetch()
       .then((response) => {
         if (response.ok) return response.text()
+        if (response.status === 422 && !this._hasRetried) {
+          this._hasRetried = true
+          return refreshCsrfToken().then(() => doFetch()).then((retryResp) => {
+            if (retryResp.ok) return retryResp.text()
+            return retryResp.json().then((json) => {
+              throw new Error(json.errors?.join(', ') || 'Unable to save comment')
+            })
+          })
+        }
         return response.json().then((json) => {
           throw new Error(json.errors?.join(', ') || 'Unable to save comment')
         })
@@ -673,6 +699,7 @@ export default class extends Controller {
         alert(error?.message || 'Failed to send question')
       })
       .finally(() => {
+        this._hasRetried = false
         this.sending = false
       })
 

--- a/engines/collavre/app/javascript/controllers/comments/list_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/list_controller.js
@@ -3,6 +3,7 @@ import { copyTextToClipboard } from '../../utils/clipboard'
 import { renderMarkdownInContainer } from '../../lib/utils/markdown'
 import creativesApi from '../../lib/api/creatives'
 import { renderCreativeTree, dispatchCreativeTreeUpdated } from '../../creatives/tree_renderer'
+import { updateCsrfTokenFromResponse } from '../../lib/api/csrf_fetch'
 // CommonPopup is now used via TopicSearchController (Stimulus)
 
 export default class extends Controller {
@@ -242,6 +243,10 @@ export default class extends Controller {
       urlParams.set('topic_id', this.currentTopicId)
     }
     return fetch(`/creatives/${this.creativeId}/comments?${urlParams.toString()}`).then((response) => {
+      // Keep the CSRF meta tag in sync with the session cookie.
+      // This is critical after the browser returns from a background/frozen state.
+      updateCsrfTokenFromResponse(response)
+
       const serverTopicId = response.headers.get("X-Topic-Id")
       if (serverTopicId !== null && serverTopicId !== undefined) {
         // Server says we are in this topic. 

--- a/engines/collavre/app/javascript/lib/api/csrf_fetch.js
+++ b/engines/collavre/app/javascript/lib/api/csrf_fetch.js
@@ -5,6 +5,38 @@ function readCsrfToken() {
   return document.querySelector('meta[name="csrf-token"]')?.content || null
 }
 
+/**
+ * Update the page's CSRF meta tag with a fresh token from the server
+ * response header.  This keeps the client-side token in sync when the
+ * session cookie has been re-encrypted (e.g. after the browser was in
+ * the background and a GET request refreshed the cookie).
+ */
+export function updateCsrfTokenFromResponse(response) {
+  if (typeof document === 'undefined') return
+  const freshToken = response.headers.get('X-CSRF-Token')
+  if (!freshToken) return
+  const meta = document.querySelector('meta[name="csrf-token"]')
+  if (meta) meta.content = freshToken
+}
+
+/**
+ * Fetch a fresh CSRF token from the server.  Uses a lightweight HEAD
+ * request to the current page — the response body is discarded but the
+ * X-CSRF-Token header gives us a valid token.
+ */
+export async function refreshCsrfToken() {
+  try {
+    const response = await fetch(window.location.href, {
+      method: 'HEAD',
+      credentials: 'same-origin',
+    })
+    updateCsrfTokenFromResponse(response)
+    return readCsrfToken()
+  } catch {
+    return null
+  }
+}
+
 export default function csrfFetch(input, options = {}) {
   const { headers: incomingHeaders, credentials, ...rest } = options
   const headers = new Headers(incomingHeaders || undefined)
@@ -18,5 +50,8 @@ export default function csrfFetch(input, options = {}) {
     credentials: credentials ?? DEFAULT_CREDENTIALS,
     headers,
     ...rest,
+  }).then((response) => {
+    updateCsrfTokenFromResponse(response)
+    return response
   })
 }


### PR DESCRIPTION
## Problem

When users switch to another OS window and return to the Collavre chat, all comment submissions fail with **422 Unprocessable Entity**. The CSRF meta tag token goes stale while the session cookie is refreshed by background GET requests triggered by `focus`/`visibilitychange` events.

## Root Cause

`protect_from_forgery with: :exception` raises `InvalidAuthenticityToken` (422) when the CSRF token from the `<meta>` tag no longer matches the one in the session cookie. After a window switch:

1. `handleWindowFocus` / `handleVisibilityChange` fire → GET requests to load comments
2. These GET responses may set a new `_collavre_session` cookie with a rotated/re-encrypted CSRF token
3. The `<meta name='csrf-token'>` tag still has the old token
4. User tries to send a message → POST with stale token → **422**

## Solution — Three-layer defense

### 1. Server: `X-CSRF-Token` response header
`Collavre::ApplicationController` now includes a fresh CSRF token in every response header via `after_action :set_csrf_token_header`. This allows clients to update the meta tag from any server response.

### 2. Client: auto-update meta tag from GET responses
- `list_controller.js` extracts `X-CSRF-Token` from the `fetchComments()` response and updates the meta tag — this runs automatically on window focus/visibility change.
- `csrfFetch()` utility also auto-updates the meta tag from every response.

### 3. Client: retry on 422
`form_controller.js` now retries once on 422: it refreshes the CSRF token (via a GET to the current page) and re-sends the POST. This catches any edge case where the token is still stale.

## Files Changed

| File | Change |
|------|--------|
| `application_controller.rb` | `after_action :set_csrf_token_header` |
| `csrf_fetch.js` | `updateCsrfTokenFromResponse()`, `refreshCsrfToken()`, auto-update in `csrfFetch` |
| `list_controller.js` | Update CSRF meta from `fetchComments()` response |
| `form_controller.js` | Retry on 422 in `handleSend` and `_sendQuestionQuote` |

## Testing

- All 1295 existing tests pass
- Rubocop clean
- i18n complete