### PR TITLE
feat: add navigate button (→) to context chips

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -976,6 +976,21 @@ body.chat-fullscreen {
     cursor: grabbing;
 }
 
+.navigate-context-btn {
+    background: none;
+    border: none;
+    color: var(--color-text-muted);
+    cursor: pointer;
+    font-size: 0.9em;
+    padding: 0 0.15em;
+    line-height: 1;
+    margin-left: 0.1em;
+}
+
+.navigate-context-btn:hover {
+    color: var(--color-active);
+}
+
 .delete-context-btn {
     background: none;
     border: none;

--- a/engines/collavre/app/javascript/controllers/comments/contexts_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/contexts_controller.js
@@ -125,6 +125,8 @@ export default class extends Controller {
                           title="${ctx.inherited ? this.inheritedLabel : ''}">
                         🔗 ${this._escapeHtml(ctx.description)}`
 
+            html += `<button class="navigate-context-btn" data-action="click->comments--contexts#navigateToContext" data-context-id="${ctx.id}" title="Go to creative">→</button>`
+
             if (this.canManage && !ctx.inherited) {
                 html += `<button class="delete-context-btn" data-action="click->comments--contexts#removeContext" data-context-id="${ctx.id}">&times;</button>`
             }
@@ -166,8 +168,15 @@ export default class extends Controller {
         await this._patchContexts({ disabled_self_context: this._selfContextDisabled })
     }
 
+    navigateToContext(event) {
+        event.stopPropagation()
+        const contextId = event.currentTarget.dataset.contextId
+        if (!contextId) return
+        window.location.href = `/creatives/${contextId}`
+    }
+
     toggleContext(event) {
-        if (event.target.closest('.delete-context-btn')) return
+        if (event.target.closest('.delete-context-btn') || event.target.closest('.navigate-context-btn')) return
 
         const contextId = parseInt(event.currentTarget.dataset.contextId)
         if (!contextId) return

--- a/engines/collavre/app/javascript/controllers/comments/contexts_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/contexts_controller.js
@@ -125,7 +125,7 @@ export default class extends Controller {
                           title="${ctx.inherited ? this.inheritedLabel : ''}">
                         🔗 ${this._escapeHtml(ctx.description)}`
 
-            html += `<button class="navigate-context-btn" data-action="click->comments--contexts#navigateToContext" data-context-id="${ctx.id}" title="Go to creative">→</button>`
+            html += `<button class="navigate-context-btn" data-action="click->comments--contexts#navigateToContext" data-context-id="${ctx.id}" title="${this.navigateLabel}">\u2192</button>`
 
             if (this.canManage && !ctx.inherited) {
                 html += `<button class="delete-context-btn" data-action="click->comments--contexts#removeContext" data-context-id="${ctx.id}">&times;</button>`
@@ -147,6 +147,10 @@ export default class extends Controller {
 
     get selfContextLabel() {
         return this.listTarget.dataset.selfContextLabel || 'Current creative context'
+    }
+
+    get navigateLabel() {
+        return this.listTarget.dataset.navigateLabel || 'Go to creative'
     }
 
     get currentCreativeSnippet() {

--- a/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
@@ -78,7 +78,8 @@
   </div>
   <div id="comment-contexts" data-comments--contexts-target="list" class="comment-contexts-list" style="display:none;"
        data-inherited-label="<%= t('collavre.contexts.inherited_label', default: 'Inherited from parent') %>"
-       data-self-context-label="<%= t('collavre.contexts.self_context_label', default: 'Current creative context') %>"></div>
+       data-self-context-label="<%= t('collavre.contexts.self_context_label', default: 'Current creative context') %>"
+       data-navigate-label="<%= t('collavre.contexts.navigate_label', default: 'Go to creative') %>"></div>
   <div id="comment-participants" data-comments--presence-target="participants" data-comments--mention-menu-target="participants"></div>
   <div id="comment-topics" data-comments--topics-target="list" class="comment-topics-list"
        data-confirm-delete-text="<%= t('collavre.topics.delete_confirm') %>"

--- a/engines/collavre/config/locales/contexts.en.yml
+++ b/engines/collavre/config/locales/contexts.en.yml
@@ -5,3 +5,4 @@ en:
       inherited_label: "Inherited from parent"
       toggle_label: "Contexts"
       self_context_label: "Current creative context"
+      navigate_label: "Go to creative"

--- a/engines/collavre/config/locales/contexts.ko.yml
+++ b/engines/collavre/config/locales/contexts.ko.yml
@@ -5,3 +5,4 @@ ko:
       inherited_label: "상위에서 상속됨"
       toggle_label: "컨텍스트"
       self_context_label: "현재 크리에이티브 컨텍스트"
+      navigate_label: "크리에이티브로 이동"


### PR DESCRIPTION
## Summary
Add a navigate button (→) to each context chip in the comments popup. Clicking it navigates to the linked context creative page.

## Changes
- **JS**: Added `→` button to context chip rendering, placed to the left of the delete (✕) button
- **JS**: Added `navigateToContext` handler that navigates to `/creatives/{id}`
- **JS**: Updated `toggleContext` to ignore clicks on the navigate button
- **CSS**: Added `.navigate-context-btn` styles matching the existing delete button style, with active-color hover

## Notes
- The navigate button is shown on all context chips (own + inherited)
- The delete button remains only for own (non-inherited) chips
- Button order: chip label → navigate (→) → delete (✕)