### PR TITLE
fix: prevent background creative list from scrolling through chat popup

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -13,6 +13,8 @@
                 right 0.25s ease, bottom 0.25s ease, border-radius 0.25s ease,
                 box-shadow 0.25s ease, padding 0.25s ease;
     max-width: calc(100vw - 0.5em) !important;
+    overscroll-behavior: contain;
+    overflow: hidden;
 }
 
 body.chat-fullscreen {


### PR DESCRIPTION
## Problem
When the chat popup is open, scrolling inside the chat input area (especially at scroll boundaries) causes the background creative list to scroll — a frustrating UX issue.

## Solution
Add `overscroll-behavior: contain` and `overflow: hidden` to `#comments-popup`.

- `overscroll-behavior: contain` is the modern CSS solution for **scroll chaining prevention**, handling both wheel and touch scroll events at the browser level
- `overflow: hidden` on the popup container ensures no scroll events leak from the popup itself (child elements like `#comments-list` handle their own scrolling with `overflow-y: auto`)
- The existing `handlePopupWheel` JS handler covered wheel events, but touch scroll propagation was not addressed — this CSS fix covers both

## Related
Creative #9761