### PR TITLE
feat: upgrade AI model from gemini-2.5-flash to gemini-3-flash-preview

### DIFF
--- a/engines/collavre/app/jobs/collavre/compress_job.rb
+++ b/engines/collavre/app/jobs/collavre/compress_job.rb
@@ -86,7 +86,7 @@ module Collavre
     end
 
     def default_model
-      "gemini-2.5-flash"
+      "gemini-3-flash-preview"
     end
   end
 end

--- a/engines/collavre/app/models/collavre/user.rb
+++ b/engines/collavre/app/models/collavre/user.rb
@@ -132,7 +132,7 @@ module Collavre
     end
 
     SUPPORTED_LLM_MODELS = [
-      "gemini-2.5-flash",
+      "gemini-3-flash-preview",
       "gemini-1.5-flash",
       "gemini-1.5-pro"
     ].freeze

--- a/engines/collavre/app/services/collavre/auto_theme_generator.rb
+++ b/engines/collavre/app/services/collavre/auto_theme_generator.rb
@@ -195,7 +195,7 @@ module Collavre
     def default_client
       AiClient.new(
         vendor: "google",
-        model: "gemini-2.5-flash",
+        model: "gemini-3-flash-preview",
         system_prompt: nil
       )
     end

--- a/engines/collavre/app/services/collavre/gemini_parent_recommender.rb
+++ b/engines/collavre/app/services/collavre/gemini_parent_recommender.rb
@@ -55,7 +55,7 @@ module Collavre
     def default_client
       AiClient.new(
         vendor: "google",
-        model: "gemini-2.5-flash",
+        model: "gemini-3-flash-preview",
         system_prompt: nil
       )
     end

--- a/engines/collavre/test/controllers/comments_controller_test.rb
+++ b/engines/collavre/test/controllers/comments_controller_test.rb
@@ -519,7 +519,7 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
       email: "aibot@ai.local",
       password: SecureRandom.hex(32),
       llm_vendor: "google",
-      llm_model: "gemini-2.5-flash",
+      llm_model: "gemini-3-flash-preview",
       system_prompt: "I am a bot",
       email_verified_at: Time.current
     )

--- a/engines/collavre/test/controllers/users_controller_test.rb
+++ b/engines/collavre/test/controllers/users_controller_test.rb
@@ -161,7 +161,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
       email: "mybot@ai.local",
       password: "password",
       llm_vendor: "google",
-      llm_model: "gemini-2.5-flash",
+      llm_model: "gemini-3-flash-preview",
       system_prompt: "You are a bot.",
       created_by_id: @regular_user.id,
       email_verified_at: Time.current
@@ -191,7 +191,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
       email: "mybot2@ai.local",
       password: "password",
       llm_vendor: "google",
-      llm_model: "gemini-2.5-flash",
+      llm_model: "gemini-3-flash-preview",
       system_prompt: "You are a bot.",
       created_by_id: creator.id,
       email_verified_at: Time.current
@@ -220,7 +220,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
       email: "agent-delete@ai.local",
       password: "password",
       llm_vendor: "google",
-      llm_model: "gemini-2.5-flash",
+      llm_model: "gemini-3-flash-preview",
       system_prompt: "Bot",
       created_by_id: target_user.id,
       email_verified_at: Time.current
@@ -249,7 +249,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
       email: "unassigned-bot@ai.local",
       password: "password",
       llm_vendor: "google",
-      llm_model: "gemini-2.5-flash",
+      llm_model: "gemini-3-flash-preview",
       system_prompt: "You are a bot.",
       created_by_id: @admin.id,
       email_verified_at: Time.current
@@ -360,7 +360,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
       email: "mybot3@ai.local",
       password: "password",
       llm_vendor: "google",
-      llm_model: "gemini-2.5-flash",
+      llm_model: "gemini-3-flash-preview",
       system_prompt: "You are a bot.",
       created_by_id: @regular_user.id,
       email_verified_at: Time.current
@@ -390,7 +390,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
       email: "otherbot@ai.local",
       password: "password",
       llm_vendor: "google",
-      llm_model: "gemini-2.5-flash",
+      llm_model: "gemini-3-flash-preview",
       system_prompt: "You are a bot.",
       created_by_id: creator.id,
       email_verified_at: Time.current

--- a/engines/collavre/test/models/collavre/comment_cancel_queued_test.rb
+++ b/engines/collavre/test/models/collavre/comment_cancel_queued_test.rb
@@ -13,7 +13,7 @@ module Collavre
         email: "ai-agent-test@example.com",
         password: "password123",
         llm_vendor: "google",
-        llm_model: "gemini-2.5-flash"
+        llm_model: "gemini-3-flash-preview"
       )
     end
 

--- a/engines/collavre/test/services/collavre/orchestration/matcher_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/matcher_test.rb
@@ -182,7 +182,7 @@ module Collavre
           password: "password",
           name: "Other Agent",
           llm_vendor: "gemini",
-          llm_model: "gemini-2.5-flash",
+          llm_model: "gemini-3-flash-preview",
           searchable: true,
           routing_expression: 'event_name == "comment_created"'
         )

--- a/engines/collavre_github/db/seeds.rb
+++ b/engines/collavre_github/db/seeds.rb
@@ -121,7 +121,7 @@ module CollavreGithub
     end
 
     def default_llm_model
-      ENV.fetch("COLLAVRE_DEFAULT_LLM_MODEL", "gemini-2.5-flash")
+      ENV.fetch("COLLAVRE_DEFAULT_LLM_MODEL", "gemini-3-flash-preview")
     end
   end
 end


### PR DESCRIPTION
## Summary

Replace all internal AI client references from `gemini-2.5-flash` to `gemini-3-flash-preview`.

## Changes

### Source files (5)
- `engines/collavre/app/models/collavre/user.rb` — default model list
- `engines/collavre/app/jobs/collavre/compress_job.rb` — compression job model
- `engines/collavre/app/services/collavre/auto_theme_generator.rb` — theme generation
- `engines/collavre/app/services/collavre/gemini_parent_recommender.rb` — parent recommendation
- `engines/collavre_github/db/seeds.rb` — default seed model

### Test files (4)
- `comment_cancel_queued_test.rb`
- `users_controller_test.rb`
- `comments_controller_test.rb`
- `orchestration/matcher_test.rb`

## Testing
- All 1281 tests pass (0 failures, 0 errors)
- Rubocop clean
- i18n keys verified