### PR TITLE
feat: add archive/unarchive for creatives and chat topics

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_25_074416) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_13_011922) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false
@@ -220,6 +220,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_25_074416) do
   end
 
   create_table "creatives", force: :cascade do |t|
+    t.datetime "archived_at"
     t.datetime "created_at", null: false
     t.json "data", default: {}, null: false
     t.text "description", limit: 4294967295
@@ -229,6 +230,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_25_074416) do
     t.integer "sequence", default: 0, null: false
     t.datetime "updated_at", null: false
     t.integer "user_id", null: false
+    t.index ["archived_at"], name: "index_creatives_on_archived_at", where: "archived_at IS NOT NULL"
     t.index ["data"], name: "index_creatives_on_data"
     t.index ["origin_id"], name: "index_creatives_on_origin_id"
     t.index ["parent_id"], name: "index_creatives_on_parent_id"
@@ -734,12 +736,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_25_074416) do
   end
 
   create_table "topics", force: :cascade do |t|
+    t.datetime "archived_at"
     t.datetime "created_at", null: false
     t.integer "creative_id", null: false
     t.string "name", null: false
     t.integer "position", default: 0, null: false
     t.datetime "updated_at", null: false
     t.integer "user_id", null: false
+    t.index ["archived_at"], name: "index_topics_on_archived_at", where: "archived_at IS NOT NULL"
     t.index ["creative_id", "name"], name: "index_topics_on_creative_id_and_name", unique: true
     t.index ["creative_id", "position"], name: "index_topics_on_creative_id_and_position"
     t.index ["creative_id"], name: "index_topics_on_creative_id"

--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -1279,9 +1279,9 @@ body.chat-fullscreen {
 .topic-archived-toggle {
     display: inline-flex;
     align-items: center;
-    padding: 0.15em 0.5em;
-    border-radius: 8px;
-    font-size: 0.85em;
+    padding: 0.15em var(--space-2);
+    border-radius: var(--radius-3);
+    font-size: var(--text-0);
     cursor: pointer;
     opacity: 0.6;
     border: 1px dashed var(--border-color);
@@ -1298,8 +1298,8 @@ body.chat-fullscreen {
     background: none;
     border: none;
     cursor: pointer;
-    font-size: 0.7em;
-    padding: 0 2px;
+    font-size: var(--text-00);
+    padding: 0 var(--space-1);
     opacity: 0.6;
     vertical-align: middle;
 }
@@ -1308,7 +1308,7 @@ body.chat-fullscreen {
     opacity: 1;
 }
 .delete-topic-btn {
-    margin-left: 2px;
+    margin-left: var(--space-1);
 }
 
 /* Selection action bar */

--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -1275,6 +1275,42 @@ body.chat-fullscreen {
     outline: none;
 }
 
+/* Archive topic styles */
+.topic-archived-toggle {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.15em 0.5em;
+    border-radius: 8px;
+    font-size: 0.85em;
+    cursor: pointer;
+    opacity: 0.6;
+    border: 1px dashed var(--border-color);
+}
+.topic-archived-toggle:hover {
+    opacity: 1;
+}
+.topic-tag.topic-archived {
+    opacity: 0.5;
+    font-style: italic;
+}
+.archive-topic-btn,
+.unarchive-topic-btn {
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 0.7em;
+    padding: 0 2px;
+    opacity: 0.6;
+    vertical-align: middle;
+}
+.archive-topic-btn:hover,
+.unarchive-topic-btn:hover {
+    opacity: 1;
+}
+.delete-topic-btn {
+    margin-left: 2px;
+}
+
 /* Selection action bar */
 .selection-action-bar {
     position: sticky;

--- a/engines/collavre/app/assets/stylesheets/collavre/creatives.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/creatives.css
@@ -698,6 +698,12 @@ creative-tree-row:not([expanded]) .creative-toggle-btn {
     border-radius: var(--radius-2);
 }
 
+/* Archive button in popup menu — match height with sibling delete buttons */
+#inline-archive {
+    line-height: 1.4;
+    font-size: inherit;
+}
+
 /* Archived creative row */
 creative-tree-row[archived] .creative-tree {
     opacity: 0.5;

--- a/engines/collavre/app/assets/stylesheets/collavre/creatives.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/creatives.css
@@ -684,17 +684,17 @@ creative-tree-row:not([expanded]) .creative-toggle-btn {
     background: none;
     border: none;
     cursor: pointer;
-    font-size: 1.2em;
-    padding: 2px 6px;
+    font-size: var(--text-2);
+    padding: var(--space-1) var(--space-2);
     opacity: 0.5;
-    transition: opacity 0.2s;
+    transition: opacity var(--ease-2) 0.2s;
 }
 .archive-toggle-btn:hover {
     opacity: 0.8;
 }
 .archive-toggle-btn.active {
     opacity: 1.0;
-    background: var(--surface-hover);
+    background: var(--surface-input);
     border-radius: var(--radius-2);
 }
 
@@ -703,5 +703,5 @@ creative-tree-row[archived] .creative-tree {
     opacity: 0.5;
 }
 creative-tree-row[archived] .creative-row {
-    background-color: var(--surface-archived, rgba(128, 128, 128, 0.05));
+    background-color: var(--surface-input);
 }

--- a/engines/collavre/app/assets/stylesheets/collavre/creatives.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/creatives.css
@@ -687,7 +687,7 @@ creative-tree-row:not([expanded]) .creative-toggle-btn {
     font-size: var(--text-2);
     padding: var(--space-1) var(--space-2);
     opacity: 0.5;
-    transition: opacity var(--ease-2) 0.2s;
+    transition: opacity 0.2s var(--ease-2);
 }
 .archive-toggle-btn:hover {
     opacity: 0.8;

--- a/engines/collavre/app/assets/stylesheets/collavre/creatives.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/creatives.css
@@ -698,12 +698,6 @@ creative-tree-row:not([expanded]) .creative-toggle-btn {
     border-radius: var(--radius-2);
 }
 
-/* Archive button in popup menu — match height with sibling delete buttons */
-#inline-archive {
-    line-height: 1.4;
-    font-size: inherit;
-}
-
 /* Archived creative row */
 creative-tree-row[archived] .creative-tree {
     opacity: 0.5;

--- a/engines/collavre/app/assets/stylesheets/collavre/creatives.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/creatives.css
@@ -679,3 +679,29 @@ creative-tree-row:not([expanded]) .creative-toggle-btn {
         width: auto;
     }
 }
+/* Archive toggle button */
+.archive-toggle-btn {
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 1.2em;
+    padding: 2px 6px;
+    opacity: 0.5;
+    transition: opacity 0.2s;
+}
+.archive-toggle-btn:hover {
+    opacity: 0.8;
+}
+.archive-toggle-btn.active {
+    opacity: 1.0;
+    background: var(--surface-hover);
+    border-radius: var(--radius-2);
+}
+
+/* Archived creative row */
+creative-tree-row[archived] .creative-tree {
+    opacity: 0.5;
+}
+creative-tree-row[archived] .creative-row {
+    background-color: var(--surface-archived, rgba(128, 128, 128, 0.05));
+}

--- a/engines/collavre/app/controllers/collavre/comments_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comments_controller.rb
@@ -156,6 +156,10 @@ module Collavre
     end
 
     def create
+      if @creative.archived?
+        render json: { error: I18n.t("collavre.comments.archived_creative") }, status: :forbidden and return
+      end
+
       unless @creative.has_permission?(Current.user, :feedback)
         render json: { error: I18n.t("collavre.comments.no_permission") }, status: :forbidden and return
       end

--- a/engines/collavre/app/controllers/collavre/comments_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comments_controller.rb
@@ -60,7 +60,13 @@ module Collavre
       end
 
       # Apply the Topic Filter
-      scope = scope.where(topic_id: effective_topic_id) if effective_topic_id.present?
+      if effective_topic_id.present?
+        scope = scope.where(topic_id: effective_topic_id)
+      else
+        # Main view: exclude comments from archived topics
+        archived_topic_ids = @creative.topics.archived.pluck(:id)
+        scope = scope.where.not(topic_id: archived_topic_ids) if archived_topic_ids.any?
+      end
 
       # Default order: Newest first (created_at DESC)
       # This matches the column-reverse layout where the first item in the list is the visual bottom (Newest).

--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -9,7 +9,7 @@ module Collavre
     # Removed unauthenticated access to index and show actions
     allow_unauthenticated_access only: %i[ index children export_markdown show slide_view ]
     before_action :enforce_creatives_login_policy, only: %i[ index children export_markdown show slide_view ]
-    before_action :set_creative, only: %i[ show edit update destroy parent_suggestions slide_view request_permission unconvert contexts update_contexts update_metadata ]
+    before_action :set_creative, only: %i[ show edit update destroy parent_suggestions slide_view request_permission unconvert contexts update_contexts update_metadata archive unarchive ]
 
     def index
       respond_to do |format|
@@ -308,6 +308,24 @@ module Collavre
       else
         render json: { errors: creative.errors.full_messages }, status: :unprocessable_entity
       end
+    end
+
+    def archive
+      unless @creative.has_permission?(Current.user, :admin) || @creative.user == Current.user
+        render json: { error: t("collavre.creatives.errors.no_permission") }, status: :forbidden and return
+      end
+
+      @creative.archive!
+      head :ok
+    end
+
+    def unarchive
+      unless @creative.has_permission?(Current.user, :admin) || @creative.user == Current.user
+        render json: { error: t("collavre.creatives.errors.no_permission") }, status: :forbidden and return
+      end
+
+      @creative.unarchive!
+      head :ok
     end
 
     def destroy

--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -311,7 +311,7 @@ module Collavre
     end
 
     def archive
-      unless @creative.has_permission?(Current.user, :admin) || @creative.user == Current.user
+      unless @creative.has_permission?(Current.user, :write) || @creative.user == Current.user
         render json: { error: t("collavre.creatives.errors.no_permission") }, status: :forbidden and return
       end
 
@@ -320,7 +320,7 @@ module Collavre
     end
 
     def unarchive
-      unless @creative.has_permission?(Current.user, :admin) || @creative.user == Current.user
+      unless @creative.has_permission?(Current.user, :write) || @creative.user == Current.user
         render json: { error: t("collavre.creatives.errors.no_permission") }, status: :forbidden and return
       end
 

--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -373,7 +373,8 @@ module Collavre
           params[:due_after].present? ||
           params[:has_due_date].present? ||
           params[:assignee_id].present? ||
-          params[:unassigned].present?
+          params[:unassigned].present? ||
+          params[:show_archived].present?
       end
 
       def serialize_creatives(collection)

--- a/engines/collavre/app/controllers/collavre/topics_controller.rb
+++ b/engines/collavre/app/controllers/collavre/topics_controller.rb
@@ -9,9 +9,9 @@ module Collavre
 
       topics = if params[:include_archived]
                  @creative.topics.order(:created_at)
-      else
+               else
                  @creative.topics.active.order(:created_at)
-      end
+               end
       archived_count = @creative.topics.archived.count
 
       render json: {

--- a/engines/collavre/app/controllers/collavre/topics_controller.rb
+++ b/engines/collavre/app/controllers/collavre/topics_controller.rb
@@ -7,18 +7,14 @@ module Collavre
       can_manage = @creative.has_permission?(Current.user, :admin) || is_owner
       can_create_topic = can_manage || @creative.has_permission?(Current.user, :write)
 
-      topics = if params[:include_archived]
-                 @creative.topics.order(:created_at)
-               else
-                 @creative.topics.active.order(:created_at)
-               end
-      archived_count = @creative.topics.archived.count
+      active_topics = @creative.topics.active.order(:created_at)
+      archived_topics = @creative.topics.archived.order(:created_at)
 
       render json: {
-        topics: topics,
+        topics: active_topics,
+        archived_topics: archived_topics,
         can_manage: can_manage,
-        can_create_topic: can_create_topic,
-        archived_count: archived_count
+        can_create_topic: can_create_topic
       }
     end
 

--- a/engines/collavre/app/controllers/collavre/topics_controller.rb
+++ b/engines/collavre/app/controllers/collavre/topics_controller.rb
@@ -6,10 +6,19 @@ module Collavre
       is_owner = @creative.user == Current.user
       can_manage = @creative.has_permission?(Current.user, :admin) || is_owner
       can_create_topic = can_manage || @creative.has_permission?(Current.user, :write)
+
+      topics = if params[:include_archived]
+                 @creative.topics.order(:created_at)
+      else
+                 @creative.topics.active.order(:created_at)
+      end
+      archived_count = @creative.topics.archived.count
+
       render json: {
-        topics: @creative.topics.order(:created_at),
+        topics: topics,
         can_manage: can_manage,
-        can_create_topic: can_create_topic
+        can_create_topic: can_create_topic,
+        archived_count: archived_count
       }
     end
 
@@ -98,6 +107,36 @@ module Collavre
       )
 
       render json: { success: true, topic: topic.slice(:id, :name), target_creative_id: target_creative.id }
+    end
+
+    def archive
+      unless @creative.has_permission?(Current.user, :admin) || @creative.user == Current.user
+        render json: { error: I18n.t("collavre.topics.no_permission") }, status: :forbidden and return
+      end
+
+      topic = @creative.topics.find(params[:id])
+      topic.archive!
+
+      TopicsChannel.broadcast_to(
+        @creative,
+        { action: "archived", topic: topic.slice(:id, :name) }
+      )
+      render json: { success: true }
+    end
+
+    def unarchive
+      unless @creative.has_permission?(Current.user, :admin) || @creative.user == Current.user
+        render json: { error: I18n.t("collavre.topics.no_permission") }, status: :forbidden and return
+      end
+
+      topic = @creative.topics.find(params[:id])
+      topic.unarchive!
+
+      TopicsChannel.broadcast_to(
+        @creative,
+        { action: "unarchived", topic: topic.slice(:id, :name, :archived_at) }
+      )
+      render json: { success: true }
     end
 
     def reorder

--- a/engines/collavre/app/controllers/collavre/topics_controller.rb
+++ b/engines/collavre/app/controllers/collavre/topics_controller.rb
@@ -110,7 +110,7 @@ module Collavre
     end
 
     def archive
-      unless @creative.has_permission?(Current.user, :admin) || @creative.user == Current.user
+      unless @creative.has_permission?(Current.user, :write) || @creative.user == Current.user
         render json: { error: I18n.t("collavre.topics.no_permission") }, status: :forbidden and return
       end
 
@@ -125,7 +125,7 @@ module Collavre
     end
 
     def unarchive
-      unless @creative.has_permission?(Current.user, :admin) || @creative.user == Current.user
+      unless @creative.has_permission?(Current.user, :write) || @creative.user == Current.user
         render json: { error: I18n.t("collavre.topics.no_permission") }, status: :forbidden and return
       end
 

--- a/engines/collavre/app/helpers/collavre/creatives_helper.rb
+++ b/engines/collavre/app/helpers/collavre/creatives_helper.rb
@@ -34,7 +34,9 @@ module Collavre
       end
 
       content_tag(:div, class: "creative-row-end") do
-        comment_part = if creative.has_permission?(Current.user, :feedback)
+        comment_part = if creative.archived?
+          safe_join([])
+        elsif creative.has_permission?(Current.user, :feedback)
           origin = creative.effective_origin
           comments_count = origin.comments.size
           pointer = CommentReadPointer.find_by(user: Current.user, creative: origin)

--- a/engines/collavre/app/javascript/components/creative_tree_row.js
+++ b/engines/collavre/app/javascript/components/creative_tree_row.js
@@ -23,6 +23,7 @@ class CreativeTreeRow extends LitElement {
     editOffIconHtml: { state: true },
     originLinkHtml: { state: true },
     isTitle: { type: Boolean, attribute: "is-title", reflect: true },
+    archived: { type: Boolean, attribute: "archived", reflect: true },
     loadingChildren: { type: Boolean, attribute: "loading-children", reflect: true },
     _loadingDotsState: { state: true }
   };

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -58,30 +58,16 @@ export default class extends Controller {
         if (!this.creativeId) return
 
         try {
-            // Load active topics
             const response = await fetch(`/creatives/${this.creativeId}/topics`)
             if (response.ok) {
                 const data = await response.json()
                 const topics = Array.isArray(data) ? data : data.topics
                 const canManage = Array.isArray(data) ? false : data.can_manage
                 const canCreateTopic = Array.isArray(data) ? false : (data.can_create_topic ?? canManage)
-                const archivedCount = data.archived_count || 0
                 this.topics = topics
                 this.canManageTopics = canManage
                 this.canCreateTopic = canCreateTopic
-
-                // Load archived topics if showing or count > 0
-                if (archivedCount > 0) {
-                    const archivedResponse = await fetch(`/creatives/${this.creativeId}/topics?include_archived=true`)
-                    if (archivedResponse.ok) {
-                        const archivedData = await archivedResponse.json()
-                        const allTopics = Array.isArray(archivedData) ? archivedData : archivedData.topics
-                        const activeIds = new Set(topics.map(t => String(t.id)))
-                        this.archivedTopics = allTopics.filter(t => !activeIds.has(String(t.id)))
-                    }
-                } else {
-                    this.archivedTopics = []
-                }
+                this.archivedTopics = data.archived_topics || []
 
                 this.renderTopics(this.topics, this.canManageTopics, this.canCreateTopic)
                 this.restoreSelection()

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -58,15 +58,31 @@ export default class extends Controller {
         if (!this.creativeId) return
 
         try {
+            // Load active topics
             const response = await fetch(`/creatives/${this.creativeId}/topics`)
             if (response.ok) {
                 const data = await response.json()
                 const topics = Array.isArray(data) ? data : data.topics
                 const canManage = Array.isArray(data) ? false : data.can_manage
                 const canCreateTopic = Array.isArray(data) ? false : (data.can_create_topic ?? canManage)
+                const archivedCount = data.archived_count || 0
                 this.topics = topics
                 this.canManageTopics = canManage
                 this.canCreateTopic = canCreateTopic
+
+                // Load archived topics if showing or count > 0
+                if (archivedCount > 0) {
+                    const archivedResponse = await fetch(`/creatives/${this.creativeId}/topics?include_archived=true`)
+                    if (archivedResponse.ok) {
+                        const archivedData = await archivedResponse.json()
+                        const allTopics = Array.isArray(archivedData) ? archivedData : archivedData.topics
+                        const activeIds = new Set(topics.map(t => String(t.id)))
+                        this.archivedTopics = allTopics.filter(t => !activeIds.has(String(t.id)))
+                    }
+                } else {
+                    this.archivedTopics = []
+                }
+
                 this.renderTopics(this.topics, this.canManageTopics, this.canCreateTopic)
                 this.restoreSelection()
             }
@@ -115,11 +131,27 @@ export default class extends Controller {
                         #${topic.name}`
 
             if (canManage) {
+                html += `<button class="archive-topic-btn" data-action="click->comments--topics#archiveTopic" data-id="${topic.id}" title="📦">📦</button>`
                 html += `<button class="delete-topic-btn" data-action="click->comments--topics#deleteTopic" data-id="${topic.id}">&times;</button>`
             }
 
             html += `</span>`
         })
+
+        // Archived topics section
+        if (this.archivedTopics && this.archivedTopics.length > 0) {
+            html += `<span class="topic-archived-toggle" data-action="click->comments--topics#toggleArchivedTopics">
+                      📦 ${this.archivedTopics.length}
+                     </span>`
+            if (this.showingArchived) {
+                this.archivedTopics.forEach(topic => {
+                    html += `<span class="topic-tag topic-archived" data-id="${topic.id}">
+                              #${topic.name}
+                              ${canManage ? `<button class="unarchive-topic-btn" data-action="click->comments--topics#unarchiveTopic" data-id="${topic.id}" title="Restore">↩</button>` : ''}
+                             </span>`
+                })
+            }
+        }
 
         // Add create button container (write permission is sufficient for topic creation)
         if (canCreateTopic) {
@@ -321,6 +353,63 @@ export default class extends Controller {
         } catch (e) {
             console.error("Error deleting topic", e)
         }
+    }
+
+    async archiveTopic(event) {
+        event.stopPropagation()
+        const topicId = event.target.dataset.id
+        if (!topicId) return
+
+        try {
+            const response = await fetch(`/creatives/${this.creativeId}/topics/${topicId}/archive`, {
+                method: 'PATCH',
+                headers: {
+                    'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').content
+                }
+            })
+
+            if (response.ok) {
+                if (String(this.currentTopicId) === String(topicId)) {
+                    this.currentTopicId = ""
+                    this.dispatch("change", { detail: { topicId: "" } })
+                }
+                this.loadTopics()
+            } else {
+                alert("Failed to archive topic")
+            }
+        } catch (e) {
+            console.error("Error archiving topic", e)
+        }
+    }
+
+    async unarchiveTopic(event) {
+        event.stopPropagation()
+        const topicId = event.target.dataset.id
+        if (!topicId) return
+
+        try {
+            const response = await fetch(`/creatives/${this.creativeId}/topics/${topicId}/unarchive`, {
+                method: 'PATCH',
+                headers: {
+                    'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').content
+                }
+            })
+
+            if (response.ok) {
+                this.loadTopics()
+            } else {
+                alert("Failed to restore topic")
+            }
+        } catch (e) {
+            console.error("Error restoring topic", e)
+        }
+    }
+
+    toggleArchivedTopics(event) {
+        event.stopPropagation()
+        this.showingArchived = !this.showingArchived
+        this.renderTopics(this.topics, this.canManageTopics, this.canCreateTopic)
+        this.restoreSelection()
     }
 
     showInput(event) {
@@ -611,6 +700,11 @@ export default class extends Controller {
 
         if (action === "updated" && data.topic) {
             this.updateTopicInList(data.topic)
+            return
+        }
+
+        if (action === "archived" || action === "unarchived") {
+            this.loadTopics()
             return
         }
 

--- a/engines/collavre/app/javascript/controllers/creatives/tree_controller.js
+++ b/engines/collavre/app/javascript/controllers/creatives/tree_controller.js
@@ -32,18 +32,31 @@ export default class extends Controller {
     this.element.removeEventListener('creative-tree:updated', this.handleTreeUpdated)
     if (this._archiveToggleHandler) {
       document.getElementById('toggle-archived-btn')?.removeEventListener('click', this._archiveToggleHandler)
+      document.getElementById('toggle-archived-btn-mobile')?.removeEventListener('click', this._archiveToggleHandler)
     }
   }
 
   _setupArchiveToggle() {
     const btn = document.getElementById('toggle-archived-btn')
-    if (!btn) return
+    const mobileBtn = document.getElementById('toggle-archived-btn-mobile')
+    if (!btn && !mobileBtn) return
 
     this._showingArchived = false
-    this._archiveToggleHandler = () => {
+
+    const toggle = () => {
       this._showingArchived = !this._showingArchived
-      btn.classList.toggle('active', this._showingArchived)
-      btn.title = this._showingArchived ? (btn.dataset.hideText || '') : (btn.dataset.showText || '')
+
+      // Update desktop button
+      if (btn) {
+        btn.classList.toggle('active', this._showingArchived)
+        btn.title = this._showingArchived ? (btn.dataset.hideText || '') : (btn.dataset.showText || '')
+      }
+
+      // Update mobile button text
+      if (mobileBtn) {
+        const label = this._showingArchived ? (mobileBtn.dataset.hideText || '') : (mobileBtn.dataset.showText || '')
+        mobileBtn.textContent = '📦 ' + label
+      }
 
       const url = new URL(this.urlValue, window.location.origin)
       if (this._showingArchived) {
@@ -56,7 +69,10 @@ export default class extends Controller {
       delete this.element.dataset.loaded
       this.load()
     }
-    btn.addEventListener('click', this._archiveToggleHandler)
+
+    this._archiveToggleHandler = toggle
+    if (btn) btn.addEventListener('click', toggle)
+    if (mobileBtn) mobileBtn.addEventListener('click', toggle)
   }
 
   load() {

--- a/engines/collavre/app/javascript/controllers/creatives/tree_controller.js
+++ b/engines/collavre/app/javascript/controllers/creatives/tree_controller.js
@@ -20,6 +20,7 @@ export default class extends Controller {
     this.queueAlignmentUpdate()
     window.addEventListener('resize', this.handleResize)
     this.element.addEventListener('creative-tree:updated', this.handleTreeUpdated)
+    this._setupArchiveToggle()
   }
 
   disconnect() {
@@ -29,6 +30,33 @@ export default class extends Controller {
     }
     window.removeEventListener('resize', this.handleResize)
     this.element.removeEventListener('creative-tree:updated', this.handleTreeUpdated)
+    if (this._archiveToggleHandler) {
+      document.getElementById('toggle-archived-btn')?.removeEventListener('click', this._archiveToggleHandler)
+    }
+  }
+
+  _setupArchiveToggle() {
+    const btn = document.getElementById('toggle-archived-btn')
+    if (!btn) return
+
+    this._showingArchived = false
+    this._archiveToggleHandler = () => {
+      this._showingArchived = !this._showingArchived
+      btn.classList.toggle('active', this._showingArchived)
+      btn.title = this._showingArchived ? (btn.dataset.hideText || '') : (btn.dataset.showText || '')
+
+      const url = new URL(this.urlValue, window.location.origin)
+      if (this._showingArchived) {
+        url.searchParams.set('show_archived', 'true')
+      } else {
+        url.searchParams.delete('show_archived')
+      }
+      this.urlValue = url.pathname + url.search
+      this.element.innerHTML = ''
+      delete this.element.dataset.loaded
+      this.load()
+    }
+    btn.addEventListener('click', this._archiveToggleHandler)
   }
 
   load() {

--- a/engines/collavre/app/javascript/creatives/tree_renderer.js
+++ b/engines/collavre/app/javascript/creatives/tree_renderer.js
@@ -64,6 +64,7 @@ function applyRowProperties(row, node) {
   updateBooleanAttr('hasChildren', 'has-children', node.has_children)
   updateBooleanAttr('expanded', 'expanded', node.expanded)
   updateBooleanAttr('isRoot', 'is-root', node.is_root)
+  updateBooleanAttr('archived', 'archived', node.archived)
 
   if (node.link_url) {
     if (row.linkUrl !== node.link_url) {

--- a/engines/collavre/app/javascript/lib/api/creatives.js
+++ b/engines/collavre/app/javascript/lib/api/creatives.js
@@ -58,6 +58,18 @@ export function destroy(id, withChildren = false) {
   })
 }
 
+export function archive(id) {
+  return csrfFetch(`/creatives/${id}/archive`, {
+    method: 'PATCH',
+  })
+}
+
+export function unarchive(id) {
+  return csrfFetch(`/creatives/${id}/unarchive`, {
+    method: 'PATCH',
+  })
+}
+
 export function unconvert(id) {
   return csrfFetch(`/creatives/${id}/unconvert`, {
     method: 'POST',
@@ -84,6 +96,8 @@ const creativesApi = {
   save,
   linkExisting,
   destroy,
+  archive,
+  unarchive,
   unconvert,
   updateMetadata,
 }

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -678,7 +678,13 @@ export function initializeCreativeRowEditor() {
       if (levelUpBtn) levelUpBtn.disabled = !canLevelUp;
 
       if (deletePopupToggle) deletePopupToggle.disabled = !hasCreativeId;
-      if (archiveBtn) archiveBtn.disabled = !hasCreativeId;
+      if (archiveBtn) {
+        archiveBtn.disabled = !hasCreativeId;
+        // Toggle label between Archive / Restore based on creative state
+        const targetRow = hasCreativeId ? document.querySelector(`creative-tree-row[creative-id="${form.dataset.creativeId}"]`) : null;
+        const isArchived = targetRow?.hasAttribute('archived');
+        archiveBtn.textContent = isArchived ? (archiveBtn.dataset.restoreLabel || 'Restore') : (archiveBtn.dataset.archiveLabel || 'Archive');
+      }
       if (deleteBtn) deleteBtn.disabled = !hasCreativeId;
       if (deleteWithChildrenBtn) deleteWithChildrenBtn.disabled = !hasCreativeId;
       if (linkBtn) linkBtn.disabled = !hasCreativeId || linkBtn.style.display === 'none';
@@ -1854,20 +1860,32 @@ export function initializeCreativeRowEditor() {
       archiveBtn.addEventListener('click', function () {
         const creativeId = form.dataset.creativeId;
         if (!creativeId) return;
-        if (confirm(archiveBtn.dataset.confirm)) {
-          creativesApi.archive(creativeId)
-            .then(res => {
-              if (res.ok) {
-                const row = document.querySelector(`creative-tree-row[creative-id="${creativeId}"]`);
-                if (row) {
-                  // Remove the row and its children container
-                  const childrenContainer = document.getElementById(`creative-children-${creativeId}`);
-                  if (childrenContainer) childrenContainer.remove();
-                  row.remove();
+        const row = document.querySelector(`creative-tree-row[creative-id="${creativeId}"]`);
+        const isArchived = row?.hasAttribute('archived');
+        const confirmMsg = isArchived ? archiveBtn.dataset.restoreConfirm : archiveBtn.dataset.confirm;
+
+        if (confirm(confirmMsg)) {
+          const apiCall = isArchived ? creativesApi.unarchive(creativeId) : creativesApi.archive(creativeId);
+          apiCall.then(res => {
+            if (res.ok) {
+              if (!isArchived) {
+                // Archiving: remove from view
+                const childrenContainer = document.getElementById(`creative-children-${creativeId}`);
+                if (childrenContainer) childrenContainer.remove();
+                if (row) row.remove();
+              } else {
+                // Restoring: reload tree to show updated state
+                const treeEl = document.querySelector('[data-controller="creatives--tree"]');
+                if (treeEl) {
+                  treeEl.innerHTML = '';
+                  delete treeEl.dataset.loaded;
+                  const ctrl = window.Stimulus?.getControllerForElementAndIdentifier(treeEl, 'creatives--tree');
+                  if (ctrl) ctrl.load();
                 }
-                closeEditor();
               }
-            });
+              closeEditor();
+            }
+          });
         }
       });
     }

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -1852,15 +1852,16 @@ export function initializeCreativeRowEditor() {
 
     if (archiveBtn) {
       archiveBtn.addEventListener('click', function () {
-        if (!currentCreativeId) return;
+        const creativeId = form.dataset.creativeId;
+        if (!creativeId) return;
         if (confirm(archiveBtn.dataset.confirm)) {
-          creativesApi.archive(currentCreativeId)
+          creativesApi.archive(creativeId)
             .then(res => {
               if (res.ok) {
-                const row = document.querySelector(`creative-tree-row[creative-id="${currentCreativeId}"]`);
+                const row = document.querySelector(`creative-tree-row[creative-id="${creativeId}"]`);
                 if (row) {
                   // Remove the row and its children container
-                  const childrenContainer = document.getElementById(`creative-children-${currentCreativeId}`);
+                  const childrenContainer = document.getElementById(`creative-children-${creativeId}`);
                   if (childrenContainer) childrenContainer.remove();
                   row.remove();
                 }

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -86,6 +86,7 @@ export function initializeCreativeRowEditor() {
     const levelDownBtn = document.getElementById('inline-level-down');
     const levelUpBtn = document.getElementById('inline-level-up');
     const deletePopupToggle = document.getElementById('inline-delete-popup-toggle');
+    const archiveBtn = document.getElementById('inline-archive');
     const deleteBtn = document.getElementById('inline-delete');
     const deleteWithChildrenBtn = document.getElementById('inline-delete-with-children');
     const linkBtn = document.getElementById('inline-link');
@@ -677,6 +678,7 @@ export function initializeCreativeRowEditor() {
       if (levelUpBtn) levelUpBtn.disabled = !canLevelUp;
 
       if (deletePopupToggle) deletePopupToggle.disabled = !hasCreativeId;
+      if (archiveBtn) archiveBtn.disabled = !hasCreativeId;
       if (deleteBtn) deleteBtn.disabled = !hasCreativeId;
       if (deleteWithChildrenBtn) deleteWithChildrenBtn.disabled = !hasCreativeId;
       if (linkBtn) linkBtn.disabled = !hasCreativeId || linkBtn.style.display === 'none';
@@ -1846,6 +1848,27 @@ export function initializeCreativeRowEditor() {
 
     if (levelUpBtn) {
       levelUpBtn.addEventListener('click', levelUp);
+    }
+
+    if (archiveBtn) {
+      archiveBtn.addEventListener('click', function () {
+        if (!currentCreativeId) return;
+        if (confirm(archiveBtn.dataset.confirm)) {
+          creativesApi.archive(currentCreativeId)
+            .then(res => {
+              if (res.ok) {
+                const row = document.querySelector(`creative-tree-row[creative-id="${currentCreativeId}"]`);
+                if (row) {
+                  // Remove the row and its children container
+                  const childrenContainer = document.getElementById(`creative-children-${currentCreativeId}`);
+                  if (childrenContainer) childrenContainer.remove();
+                  row.remove();
+                }
+                closeEditor();
+              }
+            });
+        }
+      });
     }
 
     if (deleteBtn) {

--- a/engines/collavre/app/models/collavre/creative.rb
+++ b/engines/collavre/app/models/collavre/creative.rb
@@ -155,7 +155,20 @@ module Collavre
     def archive!
       now = Time.current
       self.class.transaction do
+        # Archive self and descendants
         self_and_descendants.update_all(archived_at: now)
+
+        # If this is a linked creative, also archive the origin and its descendants
+        origin = effective_origin(Set.new)
+        if origin != self
+          origin.self_and_descendants.update_all(archived_at: now)
+        end
+
+        # Also archive any linked creatives that point to this one
+        linked_creatives.find_each do |linked|
+          linked.self_and_descendants.update_all(archived_at: now)
+        end
+
         reload
         parent&.reload
         Collavre::Creatives::ProgressService.new(parent).update_progress_from_children! if parent
@@ -164,7 +177,20 @@ module Collavre
 
     def unarchive!
       self.class.transaction do
+        # Unarchive self and descendants
         self_and_descendants.update_all(archived_at: nil)
+
+        # If this is a linked creative, also unarchive the origin and its descendants
+        origin = effective_origin(Set.new)
+        if origin != self
+          origin.self_and_descendants.update_all(archived_at: nil)
+        end
+
+        # Also unarchive any linked creatives that point to this one
+        linked_creatives.find_each do |linked|
+          linked.self_and_descendants.update_all(archived_at: nil)
+        end
+
         reload
         parent&.reload
         Collavre::Creatives::ProgressService.new(parent).update_progress_from_children! if parent

--- a/engines/collavre/app/models/collavre/creative.rb
+++ b/engines/collavre/app/models/collavre/creative.rb
@@ -156,17 +156,21 @@ module Collavre
       now = Time.current
       self.class.transaction do
         # Archive self and descendants
-        self_and_descendants.update_all(archived_at: now)
+        self_and_descendants.where(archived_at: nil).update_all(archived_at: now)
 
         # If this is a linked creative, also archive the origin and its descendants
         origin = effective_origin(Set.new)
         if origin != self
-          origin.self_and_descendants.update_all(archived_at: now)
+          origin.self_and_descendants.where(archived_at: nil).update_all(archived_at: now)
+          # Archive all other linked creatives of the origin
+          origin.linked_creatives.where.not(id: id).find_each do |linked|
+            linked.self_and_descendants.where(archived_at: nil).update_all(archived_at: now)
+          end
         end
 
         # Also archive any linked creatives that point to this one
         linked_creatives.find_each do |linked|
-          linked.self_and_descendants.update_all(archived_at: now)
+          linked.self_and_descendants.where(archived_at: nil).update_all(archived_at: now)
         end
 
         reload
@@ -178,17 +182,21 @@ module Collavre
     def unarchive!
       self.class.transaction do
         # Unarchive self and descendants
-        self_and_descendants.update_all(archived_at: nil)
+        self_and_descendants.where.not(archived_at: nil).update_all(archived_at: nil)
 
         # If this is a linked creative, also unarchive the origin and its descendants
         origin = effective_origin(Set.new)
         if origin != self
-          origin.self_and_descendants.update_all(archived_at: nil)
+          origin.self_and_descendants.where.not(archived_at: nil).update_all(archived_at: nil)
+          # Unarchive all other linked creatives of the origin
+          origin.linked_creatives.where.not(id: id).find_each do |linked|
+            linked.self_and_descendants.where.not(archived_at: nil).update_all(archived_at: nil)
+          end
         end
 
         # Also unarchive any linked creatives that point to this one
         linked_creatives.find_each do |linked|
-          linked.self_and_descendants.update_all(archived_at: nil)
+          linked.self_and_descendants.where.not(archived_at: nil).update_all(archived_at: nil)
         end
 
         reload

--- a/engines/collavre/app/models/collavre/creative.rb
+++ b/engines/collavre/app/models/collavre/creative.rb
@@ -22,6 +22,10 @@ module Collavre
 
     has_closure_tree order: :sequence, name_column: :description, hierarchy_table_name: "creative_hierarchies"
 
+    # --- Archive scopes ---
+    scope :active, -> { where(archived_at: nil) }
+    scope :archived, -> { where.not(archived_at: nil) }
+
     attr_accessor :filtered_progress
 
     belongs_to :user, class_name: Collavre.configuration.user_class_name, optional: true
@@ -140,6 +144,30 @@ module Collavre
         if old_parent_id && (old_parent = Creative.find_by(id: old_parent_id))
           Collavre::Creatives::ProgressService.new(old_parent).update_progress_from_children!
         end
+      end
+    end
+
+    # --- Archive ---
+    def archived?
+      archived_at.present?
+    end
+
+    def archive!
+      now = Time.current
+      self.class.transaction do
+        self_and_descendants.update_all(archived_at: now)
+        reload
+        parent&.reload
+        Collavre::Creatives::ProgressService.new(parent).update_progress_from_children! if parent
+      end
+    end
+
+    def unarchive!
+      self.class.transaction do
+        self_and_descendants.update_all(archived_at: nil)
+        reload
+        parent&.reload
+        Collavre::Creatives::ProgressService.new(parent).update_progress_from_children! if parent
       end
     end
 

--- a/engines/collavre/app/models/collavre/topic.rb
+++ b/engines/collavre/app/models/collavre/topic.rb
@@ -7,11 +7,27 @@ module Collavre
 
     has_many :comments, class_name: "Collavre::Comment", dependent: :destroy
 
+    # --- Archive scopes ---
+    scope :active, -> { where(archived_at: nil) }
+    scope :archived, -> { where.not(archived_at: nil) }
+
     validates :name, presence: true, uniqueness: { scope: :creative_id }
 
     before_create :set_default_position
 
     default_scope { order(:position) }
+
+    def archived?
+      archived_at.present?
+    end
+
+    def archive!
+      update!(archived_at: Time.current)
+    end
+
+    def unarchive!
+      update!(archived_at: nil)
+    end
 
     private
 

--- a/engines/collavre/app/services/collavre/creatives/index_query.rb
+++ b/engines/collavre/app/services/collavre/creatives/index_query.rb
@@ -138,7 +138,7 @@ module Creatives
     end
 
     def determine_scope
-      if params[:id]
+      base_scope = if params[:id]
         base = Creative.find_by(id: params[:id])&.effective_origin
         return Creative.none unless base
 
@@ -169,6 +169,10 @@ module Creatives
       else
         Creative.where(origin_id: nil)  # Only real creatives (not shells)
       end
+
+      # Exclude archived creatives from all filters/search unless explicitly requested
+      base_scope = base_scope.where(archived_at: nil) unless params[:show_archived]
+      base_scope
     end
 
     def determine_start_nodes(allowed_ids)

--- a/engines/collavre/app/services/collavre/creatives/index_query.rb
+++ b/engines/collavre/app/services/collavre/creatives/index_query.rb
@@ -112,8 +112,11 @@ module Creatives
       creative = Creative.find_by(id: params[:id])
       return empty_result unless creative && readable?(creative)
 
+      children = creative.children_with_permission(user, :read)
+      children = children.select { |c| !c.archived? } unless params[:show_archived]
+
       {
-        creatives: creative.children_with_permission(user, :read),
+        creatives: children,
         parent: creative,
         allowed_ids: nil,
         overall_progress: nil,
@@ -122,8 +125,11 @@ module Creatives
     end
 
     def handle_root_query
+      roots = Creative.where(user: user).roots
+      roots = roots.where(archived_at: nil) unless params[:show_archived]
+
       {
-        creatives: Creative.where(user: user).roots,
+        creatives: roots,
         parent: nil,
         allowed_ids: nil,
         overall_progress: nil,

--- a/engines/collavre/app/services/collavre/creatives/progress_service.rb
+++ b/engines/collavre/app/services/collavre/creatives/progress_service.rb
@@ -8,10 +8,11 @@ module Collavre
       end
 
       def update_progress_from_children!
-        if creative.children.any?
+        active_children = creative.children.active
+        if active_children.any?
           # Use Ruby calculation to get effective progress (handling delegation for linked creatives)
           # instead of SQL average which reads potentially stale DB columns.
-          new_progress = creative.children.map(&:progress).sum.to_f / creative.children.size
+          new_progress = active_children.map(&:progress).sum.to_f / active_children.size
           creative.update(progress: new_progress)
         else
           creative.update(progress: 0)
@@ -37,8 +38,9 @@ module Collavre
         rescue ActiveRecord::RecordNotFound
           return
         end
-        new_progress = if parent.children.any?
-                         parent.children.map(&:progress).sum.to_f / parent.children.size
+        active_children = parent.children.active
+        new_progress = if active_children.any?
+                         active_children.map(&:progress).sum.to_f / active_children.size
         else
                          0
         end
@@ -51,9 +53,10 @@ module Collavre
 
       def progress_for_tags(tag_ids, user)
         return creative.progress if tag_ids.blank?
+        return nil if creative.archived?
 
         tag_ids = Array(tag_ids).map(&:to_s)
-        visible_children = creative.children_with_permission(user)
+        visible_children = creative.children_with_permission(user).select { |c| !c.archived? }
         child_values = visible_children.map do |child|
           self.class.new(child).progress_for_tags(tag_ids, user)
         end.compact
@@ -70,7 +73,9 @@ module Collavre
 
       # `tagged_ids` should be a Set of creative IDs tagged with the plan.
       def progress_for_plan(tagged_ids)
-        child_values = creative.children.map do |child|
+        return nil if creative.archived?
+
+        child_values = creative.children.active.map do |child|
           self.class.new(child).progress_for_plan(tagged_ids)
         end.compact
 

--- a/engines/collavre/app/services/collavre/creatives/tree_builder.rb
+++ b/engines/collavre/app/services/collavre/creatives/tree_builder.rb
@@ -121,6 +121,7 @@ module Creatives
           has_children: filtered_children.any?,
           expanded: expanded,
           is_root: creative.parent.nil?,
+          archived: creative.archived?,
           link_url: view_context.collavre.creative_path(creative),
           templates: template_payload_for(creative),
           inline_editor_payload: inline_editor_payload_for(creative),
@@ -148,6 +149,7 @@ module Creatives
       return [] if raw_params["comment"] == "true" || raw_params["search"].present?
 
       children = creative.children_with_permission(user)
+      children = children.select { |c| !c.archived? } unless raw_params["show_archived"]
       if allowed_creative_ids
         children.select { |c| allowed_creative_ids.include?(c.id.to_s) }
       else

--- a/engines/collavre/app/views/collavre/creatives/_inline_edit_form.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_inline_edit_form.html.erb
@@ -63,7 +63,7 @@
                   class="popup-menu-item"
                   title="<%= t('collavre.creatives.index.archive') %>"
                   data-confirm="<%= t('collavre.creatives.index.archive_confirm') %>">
-            📦 <%= t('collavre.creatives.index.archive') %>
+            <%= t('collavre.creatives.index.archive') %>
           </button>
           <button type="button"
                   id="inline-delete"

--- a/engines/collavre/app/views/collavre/creatives/_inline_edit_form.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_inline_edit_form.html.erb
@@ -59,6 +59,13 @@
               menu_id: 'inline-delete-popup-menu'
             ) do %>
           <button type="button"
+                  id="inline-archive"
+                  class="popup-menu-item"
+                  title="<%= t('collavre.creatives.index.archive') %>"
+                  data-confirm="<%= t('collavre.creatives.index.archive_confirm') %>">
+            📦 <%= t('collavre.creatives.index.archive') %>
+          </button>
+          <button type="button"
                   id="inline-delete"
                   class="popup-menu-item danger-link"
                   title="<%= t('collavre.creatives.index.delete_only_this') %>"

--- a/engines/collavre/app/views/collavre/creatives/_inline_edit_form.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_inline_edit_form.html.erb
@@ -62,7 +62,10 @@
                   id="inline-archive"
                   class="popup-menu-item"
                   title="<%= t('collavre.creatives.index.archive') %>"
-                  data-confirm="<%= t('collavre.creatives.index.archive_confirm') %>">
+                  data-confirm="<%= t('collavre.creatives.index.archive_confirm') %>"
+                  data-archive-label="<%= t('collavre.creatives.index.archive') %>"
+                  data-restore-label="<%= t('collavre.creatives.index.unarchive') %>"
+                  data-restore-confirm="<%= t('collavre.creatives.index.unarchive_confirm', default: 'Restore this creative?') %>">
             <%= t('collavre.creatives.index.archive') %>
           </button>
           <button type="button"

--- a/engines/collavre/app/views/collavre/creatives/_mobile_actions_menu.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_mobile_actions_menu.html.erb
@@ -25,6 +25,9 @@
     <% if @parent_creative.present? %>
       <%= button_to t('collavre.creatives.index.slide_view'), slide_view_creative_path(@parent_creative), method: :get, class: 'popup-menu-item' %>
     <% end %>
+    <% if authenticated? %>
+      <button type="button" id="toggle-archived-btn-mobile" class="popup-menu-item" data-show-text="<%= t('collavre.creatives.index.show_archived') %>" data-hide-text="<%= t('collavre.creatives.index.hide_archived') %>">📦 <%= t('collavre.creatives.index.show_archived') %></button>
+    <% end %>
     <% if authenticated? && (!params[:id] || (current_creative && current_creative.has_permission?(Current.user, :write))) %>
       <button type="button" class="popup-menu-item" data-controller="click-target" data-click-target-id-value="import-markdown-btn" data-action="click->click-target#trigger"><%= t('collavre.creatives.index.import_markdown') %></button>
     <% end %>

--- a/engines/collavre/app/views/collavre/creatives/index.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/index.html.erb
@@ -52,11 +52,11 @@
     <button id="delete-selection-btn" class="danger-link" style="display:none;" data-confirm="<%= t('collavre.creatives.index.are_you_sure_delete_selection') %>" data-action="click->creatives--select-mode#deleteSelected" data-creatives--select-mode-target="deleteButton"><%= t('collavre.creatives.index.delete_selection') %></button>
   <% end %>
   <button id="expand-all-btn" class="expand-btn" style="width: 36px;" data-expand-text="<%= t('app.expand_all') %>" data-collapse-text="<%= t('app.collapse_all') %>" data-action="click->creatives--expansion#toggleAll" data-creatives--expansion-target="expand"><span aria-hidden="true">▼</span></button>
-  <% if authenticated? %>
-    <button id="toggle-archived-btn" class="archive-toggle-btn" title="<%= t('collavre.creatives.index.show_archived') %>" data-show-text="<%= t('collavre.creatives.index.show_archived') %>" data-hide-text="<%= t('collavre.creatives.index.hide_archived') %>"><span aria-hidden="true">📦</span></button>
-  <% end %>
   <button id="toggle-edit-btn" class="edit-toggle-btn mobile-only" aria-label="<%= t('.edit') %>" title="<%= t('.edit') %>">
     <span aria-hidden="true"><%= svg_tag 'edit.svg', class: 'icon-edit', width: 16, height: 16 %></span></button>
+  <% if authenticated? %>
+    <button id="toggle-archived-btn" class="archive-toggle-btn desktop-only" title="<%= t('collavre.creatives.index.show_archived') %>" data-show-text="<%= t('collavre.creatives.index.show_archived') %>" data-hide-text="<%= t('collavre.creatives.index.hide_archived') %>"><span aria-hidden="true">📦</span></button>
+  <% end %>
   <% if authenticated? && (!params[:id] || (@parent_creative && @parent_creative.has_permission?(Current.user, :write))) %>
     <button id="import-markdown-btn" class="import-btn desktop-only" data-action="click->creatives--import#toggle" data-creatives--import-target="toggle"><%= t('.import_markdown') %></button>
   <% end %>

--- a/engines/collavre/app/views/collavre/creatives/index.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/index.html.erb
@@ -52,6 +52,9 @@
     <button id="delete-selection-btn" class="danger-link" style="display:none;" data-confirm="<%= t('collavre.creatives.index.are_you_sure_delete_selection') %>" data-action="click->creatives--select-mode#deleteSelected" data-creatives--select-mode-target="deleteButton"><%= t('collavre.creatives.index.delete_selection') %></button>
   <% end %>
   <button id="expand-all-btn" class="expand-btn" style="width: 36px;" data-expand-text="<%= t('app.expand_all') %>" data-collapse-text="<%= t('app.collapse_all') %>" data-action="click->creatives--expansion#toggleAll" data-creatives--expansion-target="expand"><span aria-hidden="true">▼</span></button>
+  <% if authenticated? %>
+    <button id="toggle-archived-btn" class="archive-toggle-btn" title="<%= t('collavre.creatives.index.show_archived') %>" data-show-text="<%= t('collavre.creatives.index.show_archived') %>" data-hide-text="<%= t('collavre.creatives.index.hide_archived') %>"><span aria-hidden="true">📦</span></button>
+  <% end %>
   <button id="toggle-edit-btn" class="edit-toggle-btn mobile-only" aria-label="<%= t('.edit') %>" title="<%= t('.edit') %>">
     <span aria-hidden="true"><%= svg_tag 'edit.svg', class: 'icon-edit', width: 16, height: 16 %></span></button>
   <% if authenticated? && (!params[:id] || (@parent_creative && @parent_creative.has_permission?(Current.user, :write))) %>
@@ -179,7 +182,7 @@
   tree_params = params.to_unsafe_h.slice(
     "id", "tags", "min_progress", "max_progress", "search", "comment",
     "has_comments", "due_before", "due_after", "has_due_date",
-    "assignee_id", "unassigned"
+    "assignee_id", "unassigned", "show_archived"
   ).merge(format: :json)
   tree_url = creatives_path(tree_params)
 %>

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -5,6 +5,9 @@ en:
       delete_confirm: This will delete all messages in this topic. Are you sure?
       new_placeholder: New Topic
       no_permission: You don't have permission to perform this action.
+      archive: Archive
+      unarchive: Restore
+      archived_topics: "Archived topics (%{count})"
       move:
         no_target_permission: You don't have write permission on the target creative.
         duplicate_name: A topic named '%{name}' already exists in the target creative.

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -28,6 +28,7 @@ en:
       delete_button: Delete
       not_owner: Only the comment owner can modify this.
       no_permission: You do not have permission to comment.
+      archived_creative: This creative is archived. Comments are disabled.
       convert_not_allowed: Only the comment owner or a creative admin can convert
         this message.
       convert_button: Convert

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -28,6 +28,7 @@ ko:
       delete_button: 삭제
       not_owner: 댓글 소유자만 수정할 수 있습니다.
       no_permission: 댓글을 추가할 권한이 없습니다.
+      archived_creative: 아카이브된 크리에이티브입니다. 채팅이 비활성화되었습니다.
       convert_not_allowed: 댓글 소유자 또는 크리에이티브 관리자만 이 메시지를 전환할 수 있습니다.
       convert_button: 전환
       convert_to_creative: 하위 크리에이티브로 전환

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -5,6 +5,9 @@ ko:
       delete_confirm: 이 토픽의 모든 메시지가 삭제됩니다. 확실합니까?
       new_placeholder: 새 토픽
       no_permission: 이 작업을 수행할 권한이 없습니다.
+      archive: 아카이브
+      unarchive: 복원
+      archived_topics: "아카이브된 토픽 (%{count}개)"
       move:
         no_target_permission: 대상 크리에이티브에 대한 쓰기 권한이 없습니다.
         duplicate_name: "'%{name}' 토픽이 대상 크리에이티브에 이미 존재합니다."

--- a/engines/collavre/config/locales/creatives.en.yml
+++ b/engines/collavre/config/locales/creatives.en.yml
@@ -13,6 +13,7 @@ en:
         delete: Delete
         archive: Archive
         archive_confirm: Archive this item and all children?
+        unarchive_confirm: Restore this creative from archive?
         unarchive: Restore
         show_archived: Show archived
         hide_archived: Hide archived

--- a/engines/collavre/config/locales/creatives.en.yml
+++ b/engines/collavre/config/locales/creatives.en.yml
@@ -11,6 +11,11 @@ en:
         append_as_parent_creative: New upper-creative
         append_below_creative: Add below
         delete: Delete
+        archive: Archive
+        archive_confirm: Archive this item and all children?
+        unarchive: Restore
+        show_archived: Show archived
+        hide_archived: Hide archived
         delete_only_this: Delete only this Creative
         delete_with_children: Delete this Creative and all its children
         are_you_sure: Are you sure?

--- a/engines/collavre/config/locales/creatives.ko.yml
+++ b/engines/collavre/config/locales/creatives.ko.yml
@@ -11,6 +11,11 @@ ko:
         append_as_parent_creative: 상위에 추가
         append_below_creative: 아래에 추가
         delete: 삭제
+        archive: 아카이브
+        archive_confirm: 이 항목과 모든 하위 항목을 아카이브할까요?
+        unarchive: 복원
+        show_archived: 아카이브 표시
+        hide_archived: 아카이브 숨기기
         delete_only_this: 이 항목만 삭제
         delete_with_children: 이 항목과 모든 하위 항목 삭제
         are_you_sure: 정말 삭제하시겠습니까?

--- a/engines/collavre/config/locales/creatives.ko.yml
+++ b/engines/collavre/config/locales/creatives.ko.yml
@@ -13,6 +13,7 @@ ko:
         delete: 삭제
         archive: 아카이브
         archive_confirm: 이 항목과 모든 하위 항목을 아카이브할까요?
+        unarchive_confirm: 이 크리에이티브를 아카이브에서 복원할까요?
         unarchive: 복원
         show_archived: 아카이브 표시
         hide_archived: 아카이브 숨기기

--- a/engines/collavre/config/routes.rb
+++ b/engines/collavre/config/routes.rb
@@ -57,6 +57,8 @@ Collavre::Engine.routes.draw do
       end
       member do
         patch :move
+        patch :archive
+        patch :unarchive
       end
     end
     resources :comments, only: [ :index, :create, :destroy, :show, :update ] do
@@ -95,6 +97,8 @@ Collavre::Engine.routes.draw do
       post :share, to: "creatives#share", as: :share_creative
       post :request_permission, to: "creatives#request_permission"
       post :unconvert
+      patch :archive
+      patch :unarchive
       get :parent_suggestions
       get :slide_view
       get :contexts

--- a/engines/collavre/db/migrate/20260313011922_add_archived_at_to_creatives_and_topics.rb
+++ b/engines/collavre/db/migrate/20260313011922_add_archived_at_to_creatives_and_topics.rb
@@ -1,0 +1,9 @@
+class AddArchivedAtToCreativesAndTopics < ActiveRecord::Migration[8.0]
+  def change
+    add_column :creatives, :archived_at, :datetime
+    add_column :topics, :archived_at, :datetime
+
+    add_index :creatives, :archived_at, where: "archived_at IS NOT NULL", name: "index_creatives_on_archived_at"
+    add_index :topics, :archived_at, where: "archived_at IS NOT NULL", name: "index_topics_on_archived_at"
+  end
+end

--- a/engines/collavre/test/models/collavre/creative_archive_test.rb
+++ b/engines/collavre/test/models/collavre/creative_archive_test.rb
@@ -60,6 +60,43 @@ module Collavre
       assert_in_delta 0.5, @parent.progress, 0.01
     end
 
+    test "archive! on linked creative also archives origin" do
+      origin = Creative.create!(description: "Origin", user: @user)
+      linked = Creative.create!(description: "Linked", user: @user, parent: @parent, origin_id: origin.id)
+
+      linked.archive!
+
+      origin.reload
+      linked.reload
+      assert origin.archived?, "Origin should be archived when linked creative is archived"
+      assert linked.archived?, "Linked creative should be archived"
+    end
+
+    test "archive! on origin also archives linked creatives" do
+      origin = Creative.create!(description: "Origin", user: @user, parent: @parent)
+      linked = Creative.create!(description: "Linked", user: @user, origin_id: origin.id)
+
+      origin.archive!
+
+      origin.reload
+      linked.reload
+      assert origin.archived?
+      assert linked.archived?, "Linked creative should be archived when origin is archived"
+    end
+
+    test "unarchive! on linked creative also unarchives origin" do
+      origin = Creative.create!(description: "Origin", user: @user)
+      linked = Creative.create!(description: "Linked", user: @user, parent: @parent, origin_id: origin.id)
+
+      linked.archive!
+      linked.unarchive!
+
+      origin.reload
+      linked.reload
+      assert_not origin.archived?
+      assert_not linked.archived?
+    end
+
     test "unarchive! recalculates parent progress including restored child" do
       @child1.archive!
       @parent.reload

--- a/engines/collavre/test/models/collavre/creative_archive_test.rb
+++ b/engines/collavre/test/models/collavre/creative_archive_test.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  class CreativeArchiveTest < ActiveSupport::TestCase
+    setup do
+      @user = users(:one)
+      Collavre::Current.user = @user
+
+      @parent = Creative.create!(description: "Parent", user: @user, progress: 0)
+      @child1 = Creative.create!(description: "Child 1", user: @user, parent: @parent, progress: 1.0)
+      @child2 = Creative.create!(description: "Child 2", user: @user, parent: @parent, progress: 0.5)
+      @grandchild = Creative.create!(description: "Grandchild", user: @user, parent: @child1, progress: 1.0)
+    end
+
+    test "active scope returns non-archived creatives" do
+      @child1.archive!
+      active = Creative.active.where(parent: @parent)
+      assert_includes active, @child2
+      assert_not_includes active, @child1
+    end
+
+    test "archived scope returns archived creatives" do
+      @child1.archive!
+      archived = Creative.archived
+      assert_includes archived, @child1
+      assert_includes archived, @grandchild
+    end
+
+    test "archive! sets archived_at on self and descendants" do
+      @child1.archive!
+
+      @child1.reload
+      @grandchild.reload
+      assert @child1.archived?
+      assert @grandchild.archived?
+      assert_not @child2.archived?
+    end
+
+    test "unarchive! clears archived_at on self and descendants" do
+      @child1.archive!
+      @child1.unarchive!
+
+      @child1.reload
+      @grandchild.reload
+      assert_not @child1.archived?
+      assert_not @grandchild.archived?
+    end
+
+    test "archive! updates parent progress excluding archived child" do
+      # Before archive: parent progress = (1.0 + 0.5) / 2 = 0.75
+      @parent.reload
+      assert_in_delta 0.75, @parent.progress, 0.01
+
+      @child1.archive!
+      @parent.reload
+
+      # After archive: parent progress = 0.5 / 1 = 0.5 (only child2 counts)
+      assert_in_delta 0.5, @parent.progress, 0.01
+    end
+
+    test "unarchive! recalculates parent progress including restored child" do
+      @child1.archive!
+      @parent.reload
+      assert_in_delta 0.5, @parent.progress, 0.01
+
+      @child1.unarchive!
+      @parent.reload
+
+      # After unarchive: parent progress = (1.0 + 0.5) / 2 = 0.75
+      assert_in_delta 0.75, @parent.progress, 0.01
+    end
+  end
+end

--- a/engines/collavre/test/models/collavre/topic_archive_test.rb
+++ b/engines/collavre/test/models/collavre/topic_archive_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  class TopicArchiveTest < ActiveSupport::TestCase
+    setup do
+      @user = users(:one)
+      Collavre::Current.user = @user
+
+      @creative = Creative.create!(description: "Test Creative", user: @user)
+      @topic1 = Topic.create!(name: "Active Topic", creative: @creative, user: @user)
+      @topic2 = Topic.create!(name: "To Archive", creative: @creative, user: @user)
+    end
+
+    test "active scope returns non-archived topics" do
+      @topic2.archive!
+      active = @creative.topics.active
+      assert_includes active, @topic1
+      assert_not_includes active, @topic2
+    end
+
+    test "archived scope returns archived topics" do
+      @topic2.archive!
+      archived = @creative.topics.archived
+      assert_includes archived, @topic2
+      assert_not_includes archived, @topic1
+    end
+
+    test "archive! sets archived_at" do
+      assert_nil @topic2.archived_at
+      @topic2.archive!
+      assert @topic2.archived?
+      assert_not_nil @topic2.archived_at
+    end
+
+    test "unarchive! clears archived_at" do
+      @topic2.archive!
+      assert @topic2.archived?
+      @topic2.unarchive!
+      assert_not @topic2.archived?
+      assert_nil @topic2.archived_at
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Add archive functionality for both Creatives and Chat Topics, allowing users to hide completed or inactive items without deleting them.

## Changes

### Database
- Add `archived_at:datetime` column to `creatives` and `topics` tables
- Partial index on `archived_at IS NOT NULL` for efficient archive queries

### Models
- `Creative#archive!` — archives self and all descendants
- `Creative#unarchive!` — restores self and all descendants
- `Topic#archive!` / `Topic#unarchive!`
- `scope :active` / `scope :archived` on both models

### Progress Calculation
- Archived children are excluded from parent progress calculation
- All ProgressService methods updated (update_progress_from_children!, progress_for_tags, progress_for_plan)

### Controllers & Routes
- `PATCH /creatives/:id/archive` and `/unarchive`
- `PATCH /creatives/:creative_id/topics/:id/archive` and `/unarchive`
- Index queries exclude archived items by default (`?show_archived=true` to include)

### UI
- **Creative archive button**: Added to inline edit form's delete popup menu (📦 Archive option before delete options)
- **Archive toggle button**: 📦 button in creative actions row to show/hide archived items
- **Archived creative styling**: opacity 0.5 for archived rows
- **Topic archive**: Archive/restore buttons per topic, collapsed '📦 N' section for archived topics
- **WebSocket**: Real-time broadcast for topic archive/unarchive events

### i18n
- English and Korean translations for all archive-related strings

### Tests
- Creative archive/unarchive with descendant handling
- Topic archive/unarchive
- Progress recalculation after archive/unarchive
- 10 tests, 31 assertions, all passing