### PR TITLE
fix: reset stale topic_id when switching creatives in chat

### DIFF
--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -128,7 +128,6 @@ export default class extends Controller {
 
   onPopupOpened({ creativeId, canComment }) {
     this.creativeId = creativeId
-    this.currentTopicId = null // Reset stale topic from previous creative
     this.element.dataset.creativeId = creativeId || ''
     this.formTarget.style.display = canComment ? '' : 'none'
     this.resetForm()

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -128,6 +128,7 @@ export default class extends Controller {
 
   onPopupOpened({ creativeId, canComment }) {
     this.creativeId = creativeId
+    this.currentTopicId = null // Reset stale topic from previous creative
     this.element.dataset.creativeId = creativeId || ''
     this.formTarget.style.display = canComment ? '' : 'none'
     this.resetForm()

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -86,9 +86,10 @@ export default class extends Controller {
             }
         }
 
-        if (lastTopicId) {
-            this.selectTopic("")
-        }
+        // Always dispatch change event to ensure form controller gets the correct topic.
+        // Without this, switching to a creative with no stored topic leaves the form
+        // controller with a stale topic_id from the previous creative.
+        this.selectTopic("")
     }
 
     renderTopics(topics, canManage = false, canCreateTopic = canManage) {


### PR DESCRIPTION
## Problem
When switching between creatives in the chat popup, the form controller's `currentTopicId` was not being reset. If the previous creative had a topic selected (e.g. topic X), that topic_id would be sent with the next comment POST to the new creative, causing a **422 Unprocessable Content** because the topic doesn't belong to that creative.

### Root Cause
1. User opens Creative A and selects Topic X → `formController.currentTopicId = X`
2. User switches to Creative B (which doesn't have Topic X)
3. `topicsController.restoreSelection()` finds no stored topic for B, so it does **nothing** — no `change` event dispatched
4. `formController.onPopupOpened()` resets the form but **not** `currentTopicId`
5. User sends a message → `topic_id=X` is sent to Creative B → server returns 422

### Server-side validation that catches this:
```ruby
if @comment.topic_id.present? && !@creative.topics.where(id: @comment.topic_id).exists?
  render json: { error: ... }, status: :unprocessable_entity
end
```

## Fix
Two changes to prevent stale topic IDs:

1. **`form_controller.js`**: Reset `currentTopicId` to `null` in `onPopupOpened()` before any topic events arrive
2. **`topics_controller.js`**: Always dispatch `change` event in `restoreSelection()` — even when no previous topic was stored — to ensure the form controller gets the correct (empty) topic state

## Testing
- Open a creative with topics, select a non-Main topic
- Switch to a different creative (with or without topics)
- Send a message → should succeed (no 422)