### PR TITLE
fix: unify tab-button styles between link and button elements

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -585,8 +585,13 @@ input[type="password"] {
     border-radius: 8px 8px 0 0;
     cursor: pointer;
     font-weight: 600;
+    font-size: inherit;
+    font-family: inherit;
     border-bottom: none;
     box-shadow: inset 0 -1px 0 var(--color-border);
+    text-decoration: none;
+    display: inline-block;
+    line-height: normal;
 }
 
 .tab-button.active {


### PR DESCRIPTION
## Problem

Admin settings tabs use `<a>` tags (`link_to`) while user management tabs use `<button>` tags with Stimulus controller. Browsers apply different defaults to these elements, causing subtle visual inconsistencies (text-decoration, font-size, line-height, display mode).

## Fix

Add CSS resets to `.tab-button` that normalize rendering across both element types:

- `font-size: inherit` — buttons have user-agent font-size override
- `font-family: inherit` — buttons have user-agent font-family override
- `text-decoration: none` — links have underline by default
- `display: inline-block` — links are inline by default
- `line-height: normal` — consistent vertical alignment

## Testing

- All tests pass (1284 runs, 0 failures)
- Rubocop clean
- i18n complete
- Visually verified both pages render identical tabs

Addresses creative #9445