### PR TITLE
fix: prevent stale comments when switching creative chat windows

### DIFF
--- a/engines/collavre/app/javascript/controllers/comments/list_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/list_controller.js
@@ -148,10 +148,13 @@ export default class extends Controller {
     }
 
     const requestTopicId = this.currentTopicId || ""
+    const requestCreativeId = this.creativeId
 
     this.fetchComments(params).then((html) => {
-      // If topic changed while fetching (e.g. deep link detection), discard this stale response.
-      // The topic change event will have triggered a new load.
+      // Discard stale responses if creative or topic changed while fetching.
+      // This prevents a race condition where switching creatives causes
+      // the old creative's comments to overwrite the new creative's list.
+      if (this.creativeId !== requestCreativeId) return
       if (String(this.currentTopicId || "") !== String(requestTopicId)) return
 
       this.listTarget.innerHTML = html

--- a/engines/collavre/app/javascript/controllers/comments/popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_controller.js
@@ -199,6 +199,14 @@ export default class extends Controller {
   }
 
   async notifyChildControllers({ creativeId, canComment, highlightId }) {
+    // Pre-set creativeId on list controller BEFORE loading topics.
+    // Topics loading triggers a change event that list controller handles.
+    // Without this, list controller still holds the previous creative's ID
+    // and would fetch comments for the wrong creative (race condition).
+    if (this.listController) {
+      this.listController.creativeId = creativeId
+    }
+
     // Load topics first to establish context
     if (this.topicsController) {
       await this.topicsController.onPopupOpened({ creativeId })


### PR DESCRIPTION
## Problem

When navigating from **CreativeA#Main** to **CreativeB#Main**, CreativeB's chat window displays CreativeA's comments.

## Root Cause

Race condition in `popup_controller.notifyChildControllers()`:

1. `await topicsController.onPopupOpened(B)` loads topics for Creative B
2. During topic loading, `restoreSelection()` dispatches a `comments--topics:change` event
3. `list_controller.handleTopicChange()` handles this event and calls `resetToLatest()` → `loadInitialComments()`
4. **But at this point, `list_controller.creativeId` still holds Creative A's ID** (because `listController.onPopupOpened(B)` hasn't been called yet)
5. This fetches Creative A's comments
6. Later, `listController.onPopupOpened(B)` fetches Creative B's comments
7. If Creative A's response arrives after Creative B's, it overwrites the correct content

## Fix

Two-layer defense:

1. **Pre-set creativeId** on list controller before awaiting topics load in `popup_controller`, so any topic change event uses the correct creative ID
2. **Stale-response guard** in `loadInitialComments()` — discard fetch responses if `creativeId` changed during the request (similar to the existing `topicId` guard)

## Testing

- All 1284 tests pass
- Rubocop clean
- i18n complete