### PR TITLE
fix: prevent race condition in deep-link comment highlighting

### DIFF
--- a/engines/collavre/app/javascript/controllers/comments/list_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/list_controller.js
@@ -59,6 +59,13 @@ export default class extends Controller {
   }
 
   handleTopicChange(event) {
+    // During notifyChildControllers, topic loading fires change events before
+    // onPopupOpened sets up highlightAfterLoad. Suppress these to avoid a
+    // race where a non-highlight load overwrites the deep-link highlight load.
+    if (this.suppressTopicChangeLoad) {
+      this.currentTopicId = event.detail.topicId
+      return
+    }
     this.currentTopicId = event.detail.topicId
     this.resetToLatest()
   }
@@ -310,6 +317,7 @@ export default class extends Controller {
     if (!comment) return
     comment.scrollIntoView({ behavior: 'auto', block: 'center' })
     comment.classList.add('highlight-flash')
+    comment.dataset.highlighted = 'true'
     window.setTimeout(() => comment.classList.remove('highlight-flash'), 2000)
   }
 

--- a/engines/collavre/app/javascript/controllers/comments/popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_controller.js
@@ -203,13 +203,23 @@ export default class extends Controller {
     // Topics loading triggers a change event that list controller handles.
     // Without this, list controller still holds the previous creative's ID
     // and would fetch comments for the wrong creative (race condition).
+    //
+    // Also suppress topic-change-triggered loads during topic initialization.
+    // Without this, the topic change event fires loadInitialComments() before
+    // onPopupOpened sets highlightAfterLoad, causing a race where the non-highlight
+    // load can overwrite the deep-link highlight load.
     if (this.listController) {
       this.listController.creativeId = creativeId
+      this.listController.suppressTopicChangeLoad = true
     }
 
     // Load topics first to establish context
     if (this.topicsController) {
       await this.topicsController.onPopupOpened({ creativeId })
+    }
+
+    if (this.listController) {
+      this.listController.suppressTopicChangeLoad = false
     }
 
     if (this.formController) {

--- a/engines/collavre/test/system/creative_expansion_actions_test.rb
+++ b/engines/collavre/test/system/creative_expansion_actions_test.rb
@@ -90,6 +90,6 @@ class CreativeExpansionActionsTest < ApplicationSystemTestCase
     visit collavre.creative_comment_path(@child, comment)
 
     assert_selector "#comments-popup", visible: :visible
-    assert_selector "#comment_#{comment.id}.highlight-flash", wait: 5
+    assert_selector "#comment_#{comment.id}[data-highlighted='true']", wait: 5
   end
 end


### PR DESCRIPTION
## Problem

System test `test_visiting_a_comment_share_link_opens_popup_and_highlights_comment` fails intermittently on CI:
```
expected to find css "#comment_1.highlight-flash" but there were no matches
```

## Root Cause

PR #965 introduced a pre-set of `creativeId` on list_controller before loading topics in `notifyChildControllers()`. This creates a race condition during deep-link flows:

1. `notifyChildControllers` pre-sets `listController.creativeId`
2. `topicsController.onPopupOpened()` loads topics → fires topic change event
3. `handleTopicChange()` calls `resetToLatest()` → `loadInitialComments()` **without** `highlightAfterLoad` set (no `around_comment_id` param)
4. Later, `listController.onPopupOpened()` sets `highlightAfterLoad` and calls `loadInitialComments()` again (with `around_comment_id`)
5. Both fetches have the same `creativeId`, so the stale-response guard doesn't catch them
6. If the first (non-highlight) fetch resolves after the second, it overwrites the highlighted content

## Fix

1. **`suppressTopicChangeLoad` flag** — Suppress topic-change-triggered loads during `notifyChildControllers` initialization. The topic ID is still updated, but the redundant fetch is skipped since `onPopupOpened` will trigger the proper load immediately after.

2. **`data-highlighted` attribute** — Add a persistent `data-highlighted` attribute in `highlightComment()` so the system test can assert highlighting occurred without racing against the 2-second CSS animation timeout.

## Testing

- All 1284 unit/integration tests pass
- All 36 system tests pass
- Rubocop clean
- i18n complete