### PR TITLE
fix: 500 error when adding AI Agent with creative_id

### DIFF
--- a/engines/collavre/app/views/collavre/users/new_ai.html.erb
+++ b/engines/collavre/app/views/collavre/users/new_ai.html.erb
@@ -7,7 +7,7 @@
     <% creative = Collavre::Creative.find_by(id: params[:creative_id]) %>
     <% if creative %>
       <div class="form-group">
-        <p class="text-muted"><%= t('collavre.contacts.org_chart.add_ai_agent_to', creative: creative.plain_description) %></p>
+        <p class="text-muted"><%= t('collavre.contacts.org_chart.add_ai_agent_to', creative: Collavre::Creatives::TreeFormatter.plain_description(creative)) %></p>
       </div>
     <% end %>
   <% end %>


### PR DESCRIPTION
## Problem
`/users/new_ai?creative_id=N` raises a 500 error (`NoMethodError`).

The view called `creative.plain_description` but `plain_description` is not an instance method on `Creative`. It's a class method on `Creatives::TreeFormatter`.

## Fix
Replace `creative.plain_description` with `Collavre::Creatives::TreeFormatter.plain_description(creative)` in the `new_ai.html.erb` view.

Closes #(issue for creative 9843)