### PR TITLE
feat(slack): paginate channel list and add channel search

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,6 +86,7 @@ group :test do
   gem "capybara"
   gem "selenium-webdriver"
   gem "minitest-mock"
+  gem "webmock"
 end
 
 gem "doorkeeper", "~> 5.9"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -186,6 +186,9 @@ GEM
     cose (1.3.1)
       cbor (~> 0.5.9)
       openssl-signature_algorithm (~> 1.0)
+    crack (1.0.1)
+      bigdecimal
+      rexml
     crass (1.0.6)
     csv (3.3.5)
     date (3.5.1)
@@ -294,6 +297,7 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
+    hashdiff (1.2.1)
     hashie (5.1.0)
       logger
     httparty (0.24.2)
@@ -658,6 +662,10 @@ GEM
       openssl (>= 2.2)
       safety_net_attestation (~> 0.5.0)
       tpm-key_attestation (~> 0.14.0)
+    webmock (3.26.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket (1.2.11)
     websocket-driver (0.8.0)
       base64
@@ -731,6 +739,7 @@ DEPENDENCIES
   view_component
   web-console
   webauthn
+  webmock
 
 BUNDLED WITH
    2.6.2

--- a/engines/collavre_slack/app/assets/stylesheets/collavre_slack/slack_integration.css
+++ b/engines/collavre_slack/app/assets/stylesheets/collavre_slack/slack_integration.css
@@ -1,3 +1,14 @@
+/* Slack channel search */
+.slack-channel-search {
+  width: 100%;
+  padding: 0.5em 0.75em;
+  margin-bottom: 0.5em;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  font-size: 0.95em;
+  box-sizing: border-box;
+}
+
 /* Slack channel selection */
 .slack-channel-item {
   padding: 0.5em 1em;

--- a/engines/collavre_slack/app/controllers/collavre_slack/creatives/slack_integrations_controller.rb
+++ b/engines/collavre_slack/app/controllers/collavre_slack/creatives/slack_integrations_controller.rb
@@ -86,10 +86,7 @@ module CollavreSlack
 
       def fetch_channels(slack_account)
         client = SlackClient.new(access_token: slack_account.access_token)
-        response = client.list_channels
-        return [] unless response[:ok]
-
-        (response[:channels] || []).map do |channel|
+        client.list_all_channels.map do |channel|
           { id: channel[:id], name: channel[:name] }
         end
       rescue StandardError => e

--- a/engines/collavre_slack/app/javascript/__tests__/slack_channel_list.test.js
+++ b/engines/collavre_slack/app/javascript/__tests__/slack_channel_list.test.js
@@ -1,0 +1,166 @@
+/**
+ * @jest-environment jsdom
+ */
+import { filterChannels, reconcileSelection, buildChannelViewModels } from '../slack_channel_list.js';
+
+const channels = [
+  { id: 'C01', name: 'general' },
+  { id: 'C02', name: 'random' },
+  { id: 'C03', name: 'engineering' },
+  { id: 'C04', name: 'design' },
+  { id: 'C05', name: 'general-kr' },
+];
+
+describe('filterChannels', () => {
+  test('returns all channels when query is empty', () => {
+    expect(filterChannels(channels, '')).toEqual(channels);
+    expect(filterChannels(channels, null)).toEqual(channels);
+    expect(filterChannels(channels, undefined)).toEqual(channels);
+  });
+
+  test('filters by substring match (case-insensitive)', () => {
+    const result = filterChannels(channels, 'gen');
+    expect(result).toEqual([
+      { id: 'C01', name: 'general' },
+      { id: 'C05', name: 'general-kr' },
+    ]);
+  });
+
+  test('is case-insensitive', () => {
+    expect(filterChannels(channels, 'DESIGN')).toEqual([
+      { id: 'C04', name: 'design' },
+    ]);
+  });
+
+  test('returns empty array when nothing matches', () => {
+    expect(filterChannels(channels, 'zzz')).toEqual([]);
+  });
+
+  test('returns empty array when channels list is empty', () => {
+    expect(filterChannels([], 'gen')).toEqual([]);
+  });
+});
+
+describe('reconcileSelection', () => {
+  test('returns null when no channel is selected', () => {
+    expect(reconcileSelection(null, channels)).toBeNull();
+  });
+
+  test('keeps selection when channel is in filtered list', () => {
+    const selected = { id: 'C01', name: 'general' };
+    expect(reconcileSelection(selected, channels)).toBe(selected);
+  });
+
+  test('clears selection when channel is filtered out', () => {
+    const selected = { id: 'C01', name: 'general' };
+    const filtered = [{ id: 'C04', name: 'design' }];
+    expect(reconcileSelection(selected, filtered)).toBeNull();
+  });
+
+  test('clears selection when filtered list is empty', () => {
+    const selected = { id: 'C01', name: 'general' };
+    expect(reconcileSelection(selected, [])).toBeNull();
+  });
+});
+
+describe('buildChannelViewModels', () => {
+  test('marks linked channels', () => {
+    const links = [{ channel_id: 'C02' }];
+    const result = buildChannelViewModels(channels, links, null);
+
+    const linkedItem = result.find(vm => vm.channel.id === 'C02');
+    expect(linkedItem.isLinked).toBe(true);
+
+    const unlinkedItem = result.find(vm => vm.channel.id === 'C01');
+    expect(unlinkedItem.isLinked).toBe(false);
+  });
+
+  test('marks selected channel', () => {
+    const selected = { id: 'C03', name: 'engineering' };
+    const result = buildChannelViewModels(channels, [], selected);
+
+    const selectedItem = result.find(vm => vm.channel.id === 'C03');
+    expect(selectedItem.isSelected).toBe(true);
+
+    const otherItem = result.find(vm => vm.channel.id === 'C01');
+    expect(otherItem.isSelected).toBe(false);
+  });
+
+  test('no channel is selected when selection is null', () => {
+    const result = buildChannelViewModels(channels, [], null);
+    expect(result.every(vm => !vm.isSelected)).toBe(true);
+  });
+
+  test('handles empty inputs', () => {
+    expect(buildChannelViewModels([], [], null)).toEqual([]);
+  });
+
+  test('channel can be both linked and selected', () => {
+    const selected = { id: 'C02', name: 'random' };
+    const links = [{ channel_id: 'C02' }];
+    const result = buildChannelViewModels(channels, links, selected);
+
+    const item = result.find(vm => vm.channel.id === 'C02');
+    expect(item.isLinked).toBe(true);
+    expect(item.isSelected).toBe(true);
+  });
+});
+
+describe('search → selection regression', () => {
+  test('selecting a channel then filtering it out clears selection', () => {
+    // User selects #general
+    const selected = { id: 'C01', name: 'general' };
+
+    // Then types "design" in search
+    const filtered = filterChannels(channels, 'design');
+    expect(filtered).toEqual([{ id: 'C04', name: 'design' }]);
+
+    // Selection should be cleared because #general is not in results
+    const reconciled = reconcileSelection(selected, filtered);
+    expect(reconciled).toBeNull();
+  });
+
+  test('selecting a channel then filtering to include it keeps selection', () => {
+    const selected = { id: 'C01', name: 'general' };
+    const filtered = filterChannels(channels, 'gen');
+
+    // #general is still in the results
+    const reconciled = reconcileSelection(selected, filtered);
+    expect(reconciled).toBe(selected);
+  });
+
+  test('clearing the search restores selection if channel exists', () => {
+    const selected = { id: 'C01', name: 'general' };
+
+    // Filter out, selection cleared
+    const filtered1 = filterChannels(channels, 'design');
+    const reconciled1 = reconcileSelection(selected, filtered1);
+    expect(reconciled1).toBeNull();
+
+    // Clear search — but reconcileSelection won't magically restore,
+    // it returns null because reconciled1 was already null
+    const filtered2 = filterChannels(channels, '');
+    const reconciled2 = reconcileSelection(reconciled1, filtered2);
+    expect(reconciled2).toBeNull();
+  });
+
+  test('full flow: filter → select → widen filter keeps new selection', () => {
+    // User types "des", sees only #design
+    const filtered1 = filterChannels(channels, 'des');
+    expect(filtered1).toEqual([{ id: 'C04', name: 'design' }]);
+
+    // User selects #design
+    const selected = { id: 'C04', name: 'design' };
+
+    // User clears search — #design is still in full list
+    const filtered2 = filterChannels(channels, '');
+    const reconciled = reconcileSelection(selected, filtered2);
+    expect(reconciled).toBe(selected);
+
+    // View models reflect selection correctly
+    const vms = buildChannelViewModels(filtered2, [], reconciled);
+    const designVm = vms.find(vm => vm.channel.id === 'C04');
+    expect(designVm.isSelected).toBe(true);
+    expect(vms.filter(vm => vm.isSelected)).toHaveLength(1);
+  });
+});

--- a/engines/collavre_slack/app/javascript/collavre_slack.js
+++ b/engines/collavre_slack/app/javascript/collavre_slack.js
@@ -1,3 +1,5 @@
+import { filterChannels, reconcileSelection, buildChannelViewModels } from './slack_channel_list.js';
+
 let slackIntegrationInitialized = false;
 
 if (!slackIntegrationInitialized) {
@@ -23,6 +25,7 @@ if (!slackIntegrationInitialized) {
     const addChannelBtn = document.getElementById('slack-add-channel-btn');
     const connectMessage = document.getElementById('slack-connect-message');
     const channelListEl = document.getElementById('slack-channel-list');
+    const channelSearchEl = document.getElementById('slack-channel-search');
     const channelSummaryEl = document.getElementById('slack-channel-summary');
 
     let creativeId = null;
@@ -250,21 +253,32 @@ if (!slackIntegrationInitialized) {
         });
     }
 
-    function renderChannelList() {
+    function renderChannelList(filter) {
       if (!channelListEl) return;
 
       channelListEl.innerHTML = '';
 
       if (availableChannels.length === 0) {
-        channelListEl.innerHTML = '<p style="padding:0.5em;color:var(--color-text-secondary);">No channels available</p>';
+        channelListEl.innerHTML = `<p style="padding:0.5em;color:var(--color-text-secondary);">${modal.dataset.noChannelsAvailable || 'No channels available'}</p>`;
         return;
       }
 
-      availableChannels.forEach(function (channel) {
+      const filtered = filterChannels(availableChannels, filter);
+
+      // Clear selection if the selected channel is not in the filtered results
+      selectedChannel = reconcileSelection(selectedChannel, filtered);
+      nextBtn.disabled = !selectedChannel;
+
+      if (filtered.length === 0) {
+        channelListEl.innerHTML = `<p style="padding:0.5em;color:var(--color-text-secondary);">${modal.dataset.noMatchingChannels || 'No matching channels'}</p>`;
+        return;
+      }
+
+      const viewModels = buildChannelViewModels(filtered, existingLinks, selectedChannel);
+
+      viewModels.forEach(function ({ channel, isLinked, isSelected }) {
         const div = document.createElement('div');
         div.className = 'slack-channel-item';
-
-        const isLinked = existingLinks.some(link => link.channel_id === channel.id);
 
         const linkedLabel = modal.dataset.linkedLabel || '(linked)';
         div.innerHTML = `
@@ -272,9 +286,13 @@ if (!slackIntegrationInitialized) {
           ${isLinked ? `<span style="color:green;margin-left:0.5em;">${linkedLabel}</span>` : ''}
         `;
 
+        if (isSelected) {
+          div.classList.add('active');
+        }
+
         if (!isLinked) {
           div.addEventListener('click', function () {
-            document.querySelectorAll('.slack-channel-item').forEach(el => {
+            channelListEl.querySelectorAll('.slack-channel-item').forEach(el => {
               el.classList.remove('active');
             });
             div.classList.add('active');
@@ -396,6 +414,7 @@ if (!slackIntegrationInitialized) {
       clearError();
       if (currentStep === 'connect') {
         currentStep = 'channels';
+        if (channelSearchEl) channelSearchEl.value = '';
         renderChannelList();
       } else if (currentStep === 'channels') {
         if (!selectedChannel) {
@@ -410,10 +429,17 @@ if (!slackIntegrationInitialized) {
 
     finishBtn.addEventListener('click', performLink);
 
+    if (channelSearchEl) {
+      channelSearchEl.addEventListener('input', function () {
+        renderChannelList(this.value);
+      });
+    }
+
     if (addChannelBtn) {
       addChannelBtn.addEventListener('click', function () {
         currentStep = 'channels';
         selectedChannel = null;
+        if (channelSearchEl) channelSearchEl.value = '';
         renderChannelList();
         updateStep();
       });
@@ -437,7 +463,7 @@ if (!slackIntegrationInitialized) {
             if (data.connected) {
               availableChannels = data.channels || [];
               existingLinks = data.links || [];
-              renderChannelList();
+              renderChannelList(channelSearchEl ? channelSearchEl.value : '');
             }
           })
           .catch(error => {

--- a/engines/collavre_slack/app/javascript/slack_channel_list.js
+++ b/engines/collavre_slack/app/javascript/slack_channel_list.js
@@ -1,0 +1,47 @@
+/**
+ * Pure-logic helpers for the Slack channel list.
+ * Extracted so they can be unit-tested without a full DOM wizard.
+ */
+
+/**
+ * Filter channels by a search query (case-insensitive substring match on name).
+ * @param {Array<{id:string, name:string}>} channels
+ * @param {string} query
+ * @returns {Array<{id:string, name:string}>}
+ */
+export function filterChannels(channels, query) {
+  const q = (query || '').toLowerCase();
+  if (!q) return channels;
+  return channels.filter(ch => ch.name.toLowerCase().includes(q));
+}
+
+/**
+ * Decide whether selectedChannel should be cleared after a filter change.
+ * Returns the selectedChannel as-is if it still exists in `filtered`,
+ * or null if it has been filtered out.
+ *
+ * @param {{id:string, name:string}|null} selectedChannel
+ * @param {Array<{id:string, name:string}>} filtered
+ * @returns {{id:string, name:string}|null}
+ */
+export function reconcileSelection(selectedChannel, filtered) {
+  if (!selectedChannel) return null;
+  return filtered.some(ch => ch.id === selectedChannel.id) ? selectedChannel : null;
+}
+
+/**
+ * Build the view-model array consumed by the DOM renderer.
+ *
+ * @param {Array<{id:string, name:string}>} channels   – filtered channel list
+ * @param {Array<{channel_id:string}>}      links      – already-linked channels
+ * @param {{id:string}|null}                selected   – currently selected channel
+ * @returns {Array<{channel, isLinked:boolean, isSelected:boolean}>}
+ */
+export function buildChannelViewModels(channels, links, selected) {
+  const linkedIds = new Set(links.map(l => l.channel_id));
+  return channels.map(channel => ({
+    channel,
+    isLinked: linkedIds.has(channel.id),
+    isSelected: selected !== null && selected.id === channel.id,
+  }));
+}

--- a/engines/collavre_slack/app/services/collavre_slack/slack_client.rb
+++ b/engines/collavre_slack/app/services/collavre_slack/slack_client.rb
@@ -28,8 +28,26 @@ module CollavreSlack
       parse_response(response)
     end
 
-    def list_channels
-      get("conversations.list", limit: 1000, types: "public_channel,private_channel")
+    def list_channels(cursor: nil)
+      params = { limit: 200, types: "public_channel,private_channel" }
+      params[:cursor] = cursor if cursor.present?
+      get("conversations.list", params)
+    end
+
+    def list_all_channels
+      channels = []
+      cursor = nil
+
+      loop do
+        response = list_channels(cursor: cursor)
+        break unless response[:ok]
+
+        channels.concat(Array(response[:channels]))
+        cursor = response.dig(:response_metadata, :next_cursor)
+        break if cursor.blank?
+      end
+
+      channels
     end
 
     def list_messages(channel:, oldest: nil, cursor: nil)

--- a/engines/collavre_slack/app/views/collavre_slack/integrations/_modal.html.erb
+++ b/engines/collavre_slack/app/views/collavre_slack/integrations/_modal.html.erb
@@ -14,6 +14,8 @@
      data-refresh="<%= t('collavre_slack.modal.refresh') %>"
      data-refresh-error="<%= t('collavre_slack.modal.refresh_error') %>"
      data-linked-label="<%= t('collavre_slack.modal.linked_label') %>"
+     data-no-channels-available="<%= t('collavre_slack.modal.no_channels_available') %>"
+     data-no-matching-channels="<%= t('collavre_slack.modal.no_matching_channels') %>"
      style="display:none;position:fixed;top:0;left:0;width:100vw;height:100vh;z-index:1000;align-items:center;justify-content:center;">
   <div class="popup-box" style="min-width:360px;max-width:90vw;">
     <button type="button" id="close-slack-modal" class="popup-close-btn">&times;</button>
@@ -41,6 +43,7 @@
 
     <div class="slack-wizard-step" id="slack-step-channels" style="display:none;">
       <p class="slack-modal-subtext"><%= t('collavre_slack.modal.choose_channel') %></p>
+      <input type="text" id="slack-channel-search" class="slack-channel-search" placeholder="<%= t('collavre_slack.modal.search_channels') %>" autocomplete="off">
       <div id="slack-channel-list" class="slack-list slack-modal-list-box" style="max-height:240px;overflow:auto;"></div>
     </div>
 

--- a/engines/collavre_slack/config/locales/en.yml
+++ b/engines/collavre_slack/config/locales/en.yml
@@ -55,3 +55,6 @@ en:
       refresh: "Refresh"
       refresh_error: "Failed to refresh channels"
       linked_label: "(Linked)"
+      search_channels: "Search channels..."
+      no_channels_available: "No channels available"
+      no_matching_channels: "No matching channels"

--- a/engines/collavre_slack/config/locales/ko.yml
+++ b/engines/collavre_slack/config/locales/ko.yml
@@ -55,3 +55,6 @@ ko:
       refresh: "새로고침"
       refresh_error: "채널 목록을 새로고침하는데 실패했습니다"
       linked_label: "(연결됨)"
+      search_channels: "채널 검색..."
+      no_channels_available: "사용 가능한 채널이 없습니다"
+      no_matching_channels: "일치하는 채널이 없습니다"

--- a/engines/collavre_slack/test/controllers/slack_integrations_controller_test.rb
+++ b/engines/collavre_slack/test/controllers/slack_integrations_controller_test.rb
@@ -1,0 +1,124 @@
+require_relative "../test_helper"
+
+module CollavreSlack
+  class SlackIntegrationsControllerTest < ActionDispatch::IntegrationTest
+    setup do
+      @routes = CollavreSlack::Engine.routes
+      @user = create_user(email: "integration@example.com", name: "Integration User")
+      @creative = create_creative(@user)
+      @slack_account = SlackAccount.create!(
+        user: @user,
+        team_id: "T123",
+        team_name: "Test Team",
+        access_token: "xoxb-integration-token"
+      )
+    end
+
+    test "index returns all channels across multiple pages" do
+      sign_in_as(@user)
+
+      page1 = [
+        { id: "C01", name: "general" },
+        { id: "C02", name: "random" }
+      ]
+      page2 = [
+        { id: "C03", name: "engineering" },
+        { id: "C04", name: "design" }
+      ]
+
+      # Page 1
+      stub_request(:get, "https://slack.com/api/conversations.list")
+        .with(query: { "limit" => "200", "types" => "public_channel,private_channel" })
+        .to_return(
+          status: 200,
+          body: { ok: true, channels: page1, response_metadata: { next_cursor: "cursor_2" } }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      # Page 2
+      stub_request(:get, "https://slack.com/api/conversations.list")
+        .with(query: hash_including("cursor" => "cursor_2"))
+        .to_return(
+          status: 200,
+          body: { ok: true, channels: page2, response_metadata: { next_cursor: "" } }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      get CollavreSlack::Engine.routes.url_helpers.creative_slack_integrations_path(@creative),
+          headers: { "Accept" => "application/json" }
+
+      assert_response :success
+
+      data = JSON.parse(response.body)
+      assert data["connected"]
+      assert_equal 4, data["channels"].size
+      assert_equal %w[C01 C02 C03 C04], data["channels"].map { |c| c["id"] }
+    end
+
+    test "index returns not connected when user has no Slack account" do
+      # Remove the Slack account so the same user has no Slack connection
+      @slack_account.destroy!
+      sign_in_as(@user)
+
+      get CollavreSlack::Engine.routes.url_helpers.creative_slack_integrations_path(@creative),
+          headers: { "Accept" => "application/json" }
+
+      assert_response :success
+
+      data = JSON.parse(response.body)
+      assert_not data["connected"]
+      assert_equal [], data["channels"]
+    end
+
+    test "index returns channels and existing links" do
+      sign_in_as(@user)
+
+      link = SlackChannelLink.create!(
+        creative: @creative.effective_origin,
+        slack_account: @slack_account,
+        channel_id: "C01",
+        channel_name: "general",
+        created_by: @user
+      )
+
+      stub_request(:get, "https://slack.com/api/conversations.list")
+        .with(query: hash_including("limit" => "200"))
+        .to_return(
+          status: 200,
+          body: { ok: true, channels: [{ id: "C01", name: "general" }, { id: "C02", name: "random" }], response_metadata: { next_cursor: "" } }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      get CollavreSlack::Engine.routes.url_helpers.creative_slack_integrations_path(@creative),
+          headers: { "Accept" => "application/json" }
+
+      assert_response :success
+
+      data = JSON.parse(response.body)
+      assert_equal 2, data["channels"].size
+      assert_equal 1, data["links"].size
+      assert_equal "C01", data["links"].first["channel_id"]
+    end
+
+    test "index handles Slack API error gracefully" do
+      sign_in_as(@user)
+
+      stub_request(:get, "https://slack.com/api/conversations.list")
+        .with(query: hash_including("limit" => "200"))
+        .to_return(
+          status: 200,
+          body: { ok: false, error: "invalid_auth" }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      get CollavreSlack::Engine.routes.url_helpers.creative_slack_integrations_path(@creative),
+          headers: { "Accept" => "application/json" }
+
+      assert_response :success
+
+      data = JSON.parse(response.body)
+      assert data["connected"]
+      assert_equal [], data["channels"]
+    end
+  end
+end

--- a/engines/collavre_slack/test/services/slack_client_test.rb
+++ b/engines/collavre_slack/test/services/slack_client_test.rb
@@ -1,0 +1,168 @@
+require_relative "../test_helper"
+
+module CollavreSlack
+  class SlackClientTest < ActiveSupport::TestCase
+    TOKEN = "xoxb-test-token"
+
+    setup do
+      @client = SlackClient.new(access_token: TOKEN)
+    end
+
+    # -- list_channels (single page) -----------------------------------------
+
+    test "list_channels returns parsed response" do
+      stub_request(:get, "https://slack.com/api/conversations.list")
+        .with(
+          query: { "limit" => "200", "types" => "public_channel,private_channel" },
+          headers: { "Authorization" => "Bearer #{TOKEN}" }
+        )
+        .to_return(
+          status: 200,
+          body: { ok: true, channels: [{ id: "C01", name: "general" }], response_metadata: { next_cursor: "" } }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      response = @client.list_channels
+      assert response[:ok]
+      assert_equal 1, response[:channels].size
+      assert_equal "general", response[:channels].first[:name]
+    end
+
+    test "list_channels passes cursor when provided" do
+      stub_request(:get, "https://slack.com/api/conversations.list")
+        .with(query: hash_including("cursor" => "abc123"))
+        .to_return(
+          status: 200,
+          body: { ok: true, channels: [], response_metadata: { next_cursor: "" } }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      response = @client.list_channels(cursor: "abc123")
+      assert response[:ok]
+    end
+
+    # -- list_all_channels (pagination) ---------------------------------------
+
+    test "list_all_channels fetches single page" do
+      page = [{ id: "C01", name: "general" }, { id: "C02", name: "random" }]
+
+      stub_request(:get, "https://slack.com/api/conversations.list")
+        .with(query: { "limit" => "200", "types" => "public_channel,private_channel" })
+        .to_return(
+          status: 200,
+          body: { ok: true, channels: page, response_metadata: { next_cursor: "" } }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      channels = @client.list_all_channels
+      assert_equal 2, channels.size
+      assert_equal %w[C01 C02], channels.map { |c| c[:id] }
+    end
+
+    test "list_all_channels paginates through multiple pages" do
+      page1 = [{ id: "C01", name: "general" }, { id: "C02", name: "random" }]
+      page2 = [{ id: "C03", name: "engineering" }]
+      page3 = [{ id: "C04", name: "design" }]
+
+      # Page 1: no cursor, returns next_cursor
+      stub_request(:get, "https://slack.com/api/conversations.list")
+        .with(query: { "limit" => "200", "types" => "public_channel,private_channel" })
+        .to_return(
+          status: 200,
+          body: { ok: true, channels: page1, response_metadata: { next_cursor: "cursor_2" } }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      # Page 2: cursor_2, returns cursor_3
+      stub_request(:get, "https://slack.com/api/conversations.list")
+        .with(query: hash_including("cursor" => "cursor_2"))
+        .to_return(
+          status: 200,
+          body: { ok: true, channels: page2, response_metadata: { next_cursor: "cursor_3" } }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      # Page 3: cursor_3, empty next_cursor (last page)
+      stub_request(:get, "https://slack.com/api/conversations.list")
+        .with(query: hash_including("cursor" => "cursor_3"))
+        .to_return(
+          status: 200,
+          body: { ok: true, channels: page3, response_metadata: { next_cursor: "" } }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      channels = @client.list_all_channels
+
+      assert_equal 4, channels.size
+      assert_equal %w[C01 C02 C03 C04], channels.map { |c| c[:id] }
+      assert_equal %w[general random engineering design], channels.map { |c| c[:name] }
+    end
+
+    test "list_all_channels returns empty array on API error" do
+      stub_request(:get, "https://slack.com/api/conversations.list")
+        .with(query: hash_including("limit" => "200"))
+        .to_return(
+          status: 200,
+          body: { ok: false, error: "invalid_auth" }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      channels = @client.list_all_channels
+      assert_equal [], channels
+    end
+
+    test "list_all_channels handles nil next_cursor" do
+      stub_request(:get, "https://slack.com/api/conversations.list")
+        .with(query: hash_including("limit" => "200"))
+        .to_return(
+          status: 200,
+          body: { ok: true, channels: [{ id: "C01", name: "general" }], response_metadata: {} }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      channels = @client.list_all_channels
+      assert_equal 1, channels.size
+    end
+
+    test "list_all_channels handles missing response_metadata" do
+      stub_request(:get, "https://slack.com/api/conversations.list")
+        .with(query: hash_including("limit" => "200"))
+        .to_return(
+          status: 200,
+          body: { ok: true, channels: [{ id: "C01", name: "general" }] }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      channels = @client.list_all_channels
+      assert_equal 1, channels.size
+    end
+
+    # -- Error handling -------------------------------------------------------
+
+    test "list_all_channels stops on mid-pagination error" do
+      # Page 1 succeeds
+      stub_request(:get, "https://slack.com/api/conversations.list")
+        .with(query: { "limit" => "200", "types" => "public_channel,private_channel" })
+        .to_return(
+          status: 200,
+          body: { ok: true, channels: [{ id: "C01", name: "general" }], response_metadata: { next_cursor: "cursor_2" } }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      # Page 2 fails
+      stub_request(:get, "https://slack.com/api/conversations.list")
+        .with(query: hash_including("cursor" => "cursor_2"))
+        .to_return(
+          status: 200,
+          body: { ok: false, error: "ratelimited" }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      channels = @client.list_all_channels
+
+      # Should return whatever was collected before the error
+      assert_equal 1, channels.size
+      assert_equal "C01", channels.first[:id]
+    end
+  end
+end

--- a/engines/collavre_slack/test/services/slack_event_handler_test.rb
+++ b/engines/collavre_slack/test/services/slack_event_handler_test.rb
@@ -35,6 +35,15 @@ module CollavreSlack
         }
       }
 
+      # Stub Slack users.info API call for unknown user mapping
+      stub_request(:get, "https://slack.com/api/users.info")
+        .with(query: hash_including("user" => "U999"))
+        .to_return(
+          status: 200,
+          body: { ok: true, user: { id: "U999", name: "slackuser", profile: { display_name: "Slack User", real_name: "Slack User" } } }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
       result = SlackEventHandler.new(payload: payload).call
 
       assert_equal creative.id, result[:creative_id]

--- a/engines/collavre_slack/test/test_helper.rb
+++ b/engines/collavre_slack/test/test_helper.rb
@@ -1,6 +1,7 @@
 ENV["RAILS_ENV"] ||= "test"
 require_relative "../../../test/test_helper"
 require "collavre_slack"
+require "webmock/minitest"
 
 module CollavreSlackTestHelpers
   def create_user(email: "user@example.com", name: "Test User")
@@ -19,6 +20,29 @@ module CollavreSlackTestHelpers
       progress: 0.0,
       user: user
     )
+  end
+
+  # Stub Slack conversations.list with pagination support
+  def stub_slack_channels(*pages, token: "xoxb-test-token")
+    pages.each_with_index do |page, index|
+      next_cursor = index < pages.size - 1 ? "cursor_page_#{index + 1}" : ""
+      cursor_param = index == 0 ? nil : "cursor_page_#{index}"
+
+      query = { "limit" => "200", "types" => "public_channel,private_channel" }
+      query["cursor"] = cursor_param if cursor_param
+
+      stub_request(:get, "https://slack.com/api/conversations.list")
+        .with(query: hash_including(query), headers: { "Authorization" => "Bearer #{token}" })
+        .to_return(
+          status: 200,
+          body: {
+            ok: true,
+            channels: page,
+            response_metadata: { next_cursor: next_cursor }
+          }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+    end
   end
 end
 


### PR DESCRIPTION
Slack conversations.list API may return fewer channels than the limit per page. The previous code fetched only the first page, causing channels to be silently truncated (e.g. 62 out of hundreds).

Changes:
- Add list_all_channels to SlackClient with cursor-based pagination
- Add client-side search input to channel selection modal
- Extract filtering/selection logic into testable slack_channel_list.js
- Clear selected channel when it is filtered out of search results
- Add all new UI strings to en.yml and ko.yml (no hardcoded defaults)
- Add webmock gem and integration tests for SlackClient and controller
- Add Jest tests for channel filtering and selection regression