### PR TITLE
fix: compact Slack badge with click-to-reveal channel name

### DIFF
--- a/engines/collavre_slack/app/assets/stylesheets/collavre_slack/slack_integration.css
+++ b/engines/collavre_slack/app/assets/stylesheets/collavre_slack/slack_integration.css
@@ -24,3 +24,36 @@
   background: var(--color-drag-over);
   border-left: 3px solid var(--color-secondary-active);
 }
+
+/* Slack badge in comments popup header */
+.slack-channel-badge {
+  display: none;
+  font-size: 0.7em;
+  font-weight: 600;
+  background: #4A154B;
+  color: white;
+  padding: 0.15em 0.45em;
+  border-radius: 4px;
+  margin-left: 0.5em;
+  cursor: pointer;
+  white-space: nowrap;
+  vertical-align: middle;
+  line-height: 1.4;
+}
+
+.slack-channel-badge:hover {
+  background: #611f64;
+}
+
+.slack-channel-tooltip {
+  display: none;
+  font-size: 0.75em;
+  color: var(--color-text-secondary);
+  margin-left: 0.4em;
+  white-space: nowrap;
+  vertical-align: middle;
+}
+
+.slack-channel-tooltip.visible {
+  display: inline;
+}

--- a/engines/collavre_slack/app/controllers/collavre_slack/creatives/slack_integrations_controller.rb
+++ b/engines/collavre_slack/app/controllers/collavre_slack/creatives/slack_integrations_controller.rb
@@ -60,6 +60,17 @@ module CollavreSlack
         end
       end
 
+      # Lightweight endpoint for badge display — returns only existing links, no Slack API calls
+      def badge
+        target_creative = @creative.effective_origin
+        links = SlackChannelLink.where(creative: target_creative)
+        render json: {
+          links: links.map { |link|
+            { channel_name: link.channel_name }
+          }
+        }
+      end
+
       def destroy
         link = SlackChannelLink.find(params[:id])
         # Check against origin creative

--- a/engines/collavre_slack/app/javascript/collavre_slack.js
+++ b/engines/collavre_slack/app/javascript/collavre_slack.js
@@ -497,25 +497,45 @@ if (!slackIntegrationInitialized) {
       badge = document.createElement('span');
       badge.setAttribute('data-slack-badge', '');
       badge.className = 'slack-channel-badge';
-      badge.style.cssText = 'display:none;font-size:0.75em;background:#4A154B;color:white;padding:0.15em 0.5em;border-radius:4px;margin-left:0.5em;';
       badgeContainer.appendChild(badge);
     }
+
+    // Remove any existing tooltip
+    const existingTooltip = badgeContainer.querySelector('[data-slack-tooltip]');
+    if (existingTooltip) existingTooltip.remove();
 
     // Hide badge initially
     badge.style.display = 'none';
     badge.textContent = '';
 
     try {
-      const response = await fetch(`/slack/creatives/${creativeId}/slack_integrations`, {
+      const response = await fetch(`/slack/creatives/${creativeId}/slack_integrations/badge`, {
         headers: { Accept: 'application/json' }
       });
       if (!response.ok) return;
 
       const data = await response.json();
       if (data.links && data.links.length > 0) {
-        const channelNames = data.links.map(link => `#${link.channel_name}`).join(', ');
-        badge.textContent = `Slack: ${channelNames}`;
+        badge.textContent = 'Slack';
         badge.style.display = 'inline-block';
+        badge.title = data.links.map(link => `#${link.channel_name}`).join(', ');
+
+        // Create tooltip element for click display
+        const tooltip = document.createElement('span');
+        tooltip.setAttribute('data-slack-tooltip', '');
+        tooltip.className = 'slack-channel-tooltip';
+        tooltip.textContent = data.links.map(link => `#${link.channel_name}`).join(', ');
+        badgeContainer.appendChild(tooltip);
+
+        badge.addEventListener('click', function (e) {
+          e.stopPropagation();
+          tooltip.classList.toggle('visible');
+        });
+
+        // Close tooltip when clicking elsewhere
+        document.addEventListener('click', function closeTooltip() {
+          tooltip.classList.remove('visible');
+        }, { once: false });
       }
     } catch (error) {
       console.warn('Failed to load Slack badge:', error);
@@ -531,5 +551,7 @@ if (!slackIntegrationInitialized) {
       badge.style.display = 'none';
       badge.textContent = '';
     }
+    const tooltip = badgeContainer.querySelector('[data-slack-tooltip]');
+    if (tooltip) tooltip.remove();
   });
 }

--- a/engines/collavre_slack/app/javascript/collavre_slack.js
+++ b/engines/collavre_slack/app/javascript/collavre_slack.js
@@ -490,10 +490,14 @@ if (!slackIntegrationInitialized) {
   // Store references for cleanup to avoid handler accumulation across popup opens
   let slackBadgeClickHandler = null;
   let slackDocumentClickHandler = null;
+  let slackBadgeRequestId = 0; // Guard against stale async responses
 
   document.addEventListener('comments-popup:opened', async function (event) {
     const { creativeId, badgeContainer } = event.detail;
     if (!badgeContainer || !creativeId) return;
+
+    // Increment request id to invalidate any in-flight fetch
+    const currentRequestId = ++slackBadgeRequestId;
 
     // Create or find slack badge element
     let badge = badgeContainer.querySelector('[data-slack-badge]');
@@ -526,6 +530,10 @@ if (!slackIntegrationInitialized) {
       const response = await fetch(`/slack/creatives/${creativeId}/slack_integrations/badge`, {
         headers: { Accept: 'application/json' }
       });
+
+      // Discard response if a newer popup open has occurred
+      if (currentRequestId !== slackBadgeRequestId) return;
+
       if (!response.ok) return;
 
       const data = await response.json();

--- a/engines/collavre_slack/app/javascript/collavre_slack.js
+++ b/engines/collavre_slack/app/javascript/collavre_slack.js
@@ -570,6 +570,9 @@ if (!slackIntegrationInitialized) {
     const { badgeContainer } = event.detail;
     if (!badgeContainer) return;
 
+    // Invalidate any in-flight badge fetch so late responses are discarded
+    slackBadgeRequestId++;
+
     const badge = badgeContainer.querySelector('[data-slack-badge]');
     if (badge) {
       badge.style.display = 'none';

--- a/engines/collavre_slack/app/javascript/collavre_slack.js
+++ b/engines/collavre_slack/app/javascript/collavre_slack.js
@@ -487,6 +487,10 @@ if (!slackIntegrationInitialized) {
   });
 
   // Slack badge for comments popup
+  // Store references for cleanup to avoid handler accumulation across popup opens
+  let slackBadgeClickHandler = null;
+  let slackDocumentClickHandler = null;
+
   document.addEventListener('comments-popup:opened', async function (event) {
     const { creativeId, badgeContainer } = event.detail;
     if (!badgeContainer || !creativeId) return;
@@ -498,6 +502,16 @@ if (!slackIntegrationInitialized) {
       badge.setAttribute('data-slack-badge', '');
       badge.className = 'slack-channel-badge';
       badgeContainer.appendChild(badge);
+    }
+
+    // Clean up previous handlers before re-registering
+    if (slackBadgeClickHandler) {
+      badge.removeEventListener('click', slackBadgeClickHandler);
+      slackBadgeClickHandler = null;
+    }
+    if (slackDocumentClickHandler) {
+      document.removeEventListener('click', slackDocumentClickHandler);
+      slackDocumentClickHandler = null;
     }
 
     // Remove any existing tooltip
@@ -527,15 +541,17 @@ if (!slackIntegrationInitialized) {
         tooltip.textContent = data.links.map(link => `#${link.channel_name}`).join(', ');
         badgeContainer.appendChild(tooltip);
 
-        badge.addEventListener('click', function (e) {
+        slackBadgeClickHandler = function (e) {
           e.stopPropagation();
           tooltip.classList.toggle('visible');
-        });
+        };
+        badge.addEventListener('click', slackBadgeClickHandler);
 
         // Close tooltip when clicking elsewhere
-        document.addEventListener('click', function closeTooltip() {
+        slackDocumentClickHandler = function () {
           tooltip.classList.remove('visible');
-        }, { once: false });
+        };
+        document.addEventListener('click', slackDocumentClickHandler);
       }
     } catch (error) {
       console.warn('Failed to load Slack badge:', error);
@@ -550,6 +566,14 @@ if (!slackIntegrationInitialized) {
     if (badge) {
       badge.style.display = 'none';
       badge.textContent = '';
+      if (slackBadgeClickHandler) {
+        badge.removeEventListener('click', slackBadgeClickHandler);
+        slackBadgeClickHandler = null;
+      }
+    }
+    if (slackDocumentClickHandler) {
+      document.removeEventListener('click', slackDocumentClickHandler);
+      slackDocumentClickHandler = null;
     }
     const tooltip = badgeContainer.querySelector('[data-slack-tooltip]');
     if (tooltip) tooltip.remove();

--- a/engines/collavre_slack/config/routes.rb
+++ b/engines/collavre_slack/config/routes.rb
@@ -3,7 +3,11 @@ CollavreSlack::Engine.routes.draw do
   get "/auth/slack/callback", to: "slack_auth#callback"
 
   resources :creatives, only: [] do
-    resources :slack_integrations, module: :creatives, only: [ :index, :create, :destroy ]
+    resources :slack_integrations, module: :creatives, only: [ :index, :create, :destroy ] do
+      collection do
+        get :badge
+      end
+    end
     resources :slack_messages, only: [ :create ]
   end
 

--- a/engines/collavre_slack/test/controllers/slack_integrations_controller_test.rb
+++ b/engines/collavre_slack/test/controllers/slack_integrations_controller_test.rb
@@ -100,6 +100,42 @@ module CollavreSlack
       assert_equal "C01", data["links"].first["channel_id"]
     end
 
+    test "badge returns only linked channel names without Slack API call" do
+      sign_in_as(@user)
+
+      SlackChannelLink.create!(
+        creative: @creative.effective_origin,
+        slack_account: @slack_account,
+        channel_id: "C01",
+        channel_name: "general",
+        created_by: @user
+      )
+
+      # No Slack API stubs — badge should NOT call Slack API
+      get CollavreSlack::Engine.routes.url_helpers.badge_creative_slack_integrations_path(@creative),
+          headers: { "Accept" => "application/json" }
+
+      assert_response :success
+
+      data = JSON.parse(response.body)
+      assert_equal 1, data["links"].size
+      assert_equal "general", data["links"].first["channel_name"]
+      assert_nil data["channels"]
+      assert_nil data["connected"]
+    end
+
+    test "badge returns empty links when no channel is linked" do
+      sign_in_as(@user)
+
+      get CollavreSlack::Engine.routes.url_helpers.badge_creative_slack_integrations_path(@creative),
+          headers: { "Accept" => "application/json" }
+
+      assert_response :success
+
+      data = JSON.parse(response.body)
+      assert_equal 0, data["links"].size
+    end
+
     test "index handles Slack API error gracefully" do
       sign_in_as(@user)
 


### PR DESCRIPTION
## Summary

Fixes the Slack label wrapping to two lines in the chat popup header.

### Changes

**UI: Compact Slack badge**
- Show only `Slack` text in the badge instead of `Slack: #channel-name`
- Click the badge to toggle inline channel name display
- Badge uses Slack purple (`#4A154B`) with hover state

**API: New lightweight `/badge` endpoint**
- `GET /slack/creatives/:creative_id/slack_integrations/badge`
- Returns only linked channel names from the database
- **Does NOT call Slack API** (`conversations.list`) — fixes the slow load issue
- The full `index` endpoint (with channel list) is still used only when opening the Slack integration modal

### Files Changed
- `collavre_slack/app/javascript/collavre_slack.js` — Badge display logic
- `collavre_slack/app/assets/stylesheets/slack_integration.css` — Badge & tooltip styles
- `collavre_slack/app/controllers/creatives/slack_integrations_controller.rb` — New `badge` action
- `collavre_slack/config/routes.rb` — Badge route
- `collavre_slack/test/controllers/slack_integrations_controller_test.rb` — 2 new tests

### Related Creative
Closes #9849