### PR TITLE
fix: remove global smooth scroll to fix back navigation scroll restoration

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/dark_mode.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/dark_mode.css
@@ -79,12 +79,7 @@ body.dark-mode {
 /* ============================================================================
  * BASE ELEMENT STYLES
  * ============================================================================ */
-html {
-  scroll-behavior: smooth;
-}
-
 @media (prefers-reduced-motion: reduce) {
-  html { scroll-behavior: auto; }
 
   /* Collapse decorative transitions to instant; state changes still
      apply but without visible motion (hover bg, theme switch, etc.). */


### PR DESCRIPTION
## Problem
When navigating back from a creative detail to the list, the browser restores the previous scroll position with a smooth animation instead of jumping instantly. This makes it feel like the page is auto-scrolling rather than snapping back.

## Cause
`html { scroll-behavior: smooth }` in `dark_mode.css` applied globally, affecting Turbo's scroll position restoration on back navigation.

## Fix
Remove the global `scroll-behavior: smooth` from `html`. JS code that needs smooth scrolling already specifies `{ behavior: 'smooth' }` explicitly in `scrollIntoView()` calls, so this change has no side effects on intended smooth scroll behavior.

Also removes the now-unnecessary `prefers-reduced-motion` override for `scroll-behavior: auto` (the remaining reduced-motion rules for transitions are preserved).

## Changes
- `engines/collavre/app/assets/stylesheets/collavre/dark_mode.css`: Remove `html { scroll-behavior: smooth }` and its reduced-motion counterpart

Closes #9854