### PR TITLE
fix: use Numeric instead of Float in tool service Sorbet sigs

### DIFF
--- a/engines/collavre/app/services/collavre/tools/creative_retrieval_service.rb
+++ b/engines/collavre/app/services/collavre/tools/creative_retrieval_service.rb
@@ -25,8 +25,8 @@ module Tools
         query: T.nilable(String),
         level: T.nilable(Integer),
         tags: T.nilable(String),
-        progress_min: T.nilable(Float),
-        progress_max: T.nilable(Float),
+        progress_min: T.nilable(Numeric),
+        progress_max: T.nilable(Numeric),
         updated_since: T.nilable(String),
         include_comments: T.nilable(T::Boolean),
         format: T.nilable(String)

--- a/engines/collavre/app/services/collavre/tools/creative_update_service.rb
+++ b/engines/collavre/app/services/collavre/tools/creative_update_service.rb
@@ -15,7 +15,7 @@ module Tools
     tool_param :progress, description: "Set to 1.0 to mark a leaf Creative as complete. Only 1.0 is allowed; partial progress and updates on parent Creatives are rejected.", required: false
     tool_param :parent_id, description: "New parent Creative ID to move this Creative under. Use null/0 to make it a root Creative.", required: false
 
-    sig { params(id: Integer, description: T.nilable(String), progress: T.nilable(Float), parent_id: T.nilable(Integer)).returns(T::Hash[Symbol, T.untyped]) }
+    sig { params(id: Integer, description: T.nilable(String), progress: T.nilable(Numeric), parent_id: T.nilable(Integer)).returns(T::Hash[Symbol, T.untyped]) }
     def call(id:, description: nil, progress: nil, parent_id: nil)
       raise "Current.user is required" unless Current.user
 


### PR DESCRIPTION
## Problem

MCP schema type `number` sends both Integer and Float values. Sorbet `T.nilable(Float)` rejects Integer inputs, causing:

```
[TypeError] Parameter 'progress_max': Expected type T.nilable(Float), got type Integer with value 1
```

## Solution

Changed `T.nilable(Float)` → `T.nilable(Numeric)` which accepts both Integer and Float.

`Numeric` is the common parent class of `Integer` and `Float` in Ruby.
Existing logic already calls `.to_f` on these values, so behavior is unchanged.

## Changes

- `CreativeRetrievalService`: `progress_min`, `progress_max` sig updated
- `CreativeUpdateService`: `progress` sig updated

## Testing

All 1309 tests pass. Rubocop clean.