### PR TITLE
feat(github): complete OAuth flow in popup with repository selection

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,4 @@
 web: env RUBY_DEBUG_OPEN=true bin/rails server -p $PORT -b 0.0.0.0
 js: npm run build -- --watch
+# Uncomment to enable GitHub API mock server for UI development:
+# github_mock: bin/rails collavre_github:mock_server

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,4 +1,3 @@
 web: env RUBY_DEBUG_OPEN=true bin/rails server -p $PORT -b 0.0.0.0
 js: npm run build -- --watch
-# Uncomment to enable GitHub API mock server for UI development:
-# github_mock: bin/rails collavre_github:mock_server
+github_mock: bin/rails collavre_github:mock_server

--- a/app/javascript/github_integration.js
+++ b/app/javascript/github_integration.js
@@ -508,8 +508,22 @@ if (!githubIntegrationInitialized) {
       const height = Number(loginBtn.dataset.windowHeight) || 700;
       const left = window.screenX + Math.max(0, (window.outerWidth - width) / 2);
       const top = window.screenY + Math.max(0, (window.outerHeight - height) / 2);
-      window.open('', 'github-auth-window', `width=${width},height=${height},left=${left},top=${top}`);
-      loginForm.submit();
+
+      // Store creative_id in session before opening OAuth popup
+      fetch('/github/auth/store_creative', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRF-Token': csrfToken()
+        },
+        body: JSON.stringify({ creative_id: creativeId })
+      }).then(function () {
+        window.open('', 'github-auth-window', `width=${width},height=${height},left=${left},top=${top}`);
+        loginForm.submit();
+      }).catch(function () {
+        window.open('', 'github-auth-window', `width=${width},height=${height},left=${left},top=${top}`);
+        loginForm.submit();
+      });
     });
 
     deleteBtn?.addEventListener('click', function () {

--- a/app/javascript/github_integration.js
+++ b/app/javascript/github_integration.js
@@ -509,7 +509,10 @@ if (!githubIntegrationInitialized) {
       const left = window.screenX + Math.max(0, (window.outerWidth - width) / 2);
       const top = window.screenY + Math.max(0, (window.outerHeight - height) / 2);
 
-      // Store creative_id in session before opening OAuth popup
+      // Open popup synchronously to avoid browser popup blocking
+      window.open('', 'github-auth-window', `width=${width},height=${height},left=${left},top=${top}`);
+
+      // Store creative_id in session, then submit OAuth form into the already-open popup
       fetch('/github/auth/store_creative', {
         method: 'POST',
         headers: {
@@ -517,11 +520,7 @@ if (!githubIntegrationInitialized) {
           'X-CSRF-Token': csrfToken()
         },
         body: JSON.stringify({ creative_id: creativeId })
-      }).then(function () {
-        window.open('', 'github-auth-window', `width=${width},height=${height},left=${left},top=${top}`);
-        loginForm.submit();
-      }).catch(function () {
-        window.open('', 'github-auth-window', `width=${width},height=${height},left=${left},top=${top}`);
+      }).finally(function () {
         loginForm.submit();
       });
     });

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -38,9 +38,16 @@ end
 
 OmniAuth.config.allowed_request_methods = %i[get post]
 
-# Enable OmniAuth mock mode for development when GITHUB_MOCK=1
-# This allows testing the GitHub integration UI without real credentials.
-if ENV["GITHUB_MOCK"] == "1"
+# Enable OmniAuth mock mode in development when no real GitHub credentials are configured.
+# The mock server (bin/rails collavre_github:mock_server) runs by default via Procfile.dev.
+# Set GITHUB_MOCK=0 to explicitly disable mock mode even without credentials.
+github_mock_enabled = if ENV.key?("GITHUB_MOCK")
+                        ENV["GITHUB_MOCK"] == "1"
+else
+                        Rails.env.development? && github_client_id.blank?
+end
+
+if github_mock_enabled
   OmniAuth.config.test_mode = true
   OmniAuth.config.mock_auth[:github] = OmniAuth::AuthHash.new(
     provider: "github",

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -37,3 +37,21 @@ Rails.application.config.middleware.use OmniAuth::Builder do
 end
 
 OmniAuth.config.allowed_request_methods = %i[get post]
+
+# Enable OmniAuth mock mode for development when GITHUB_MOCK=1
+# This allows testing the GitHub integration UI without real credentials.
+if ENV["GITHUB_MOCK"] == "1"
+  OmniAuth.config.test_mode = true
+  OmniAuth.config.mock_auth[:github] = OmniAuth::AuthHash.new(
+    provider: "github",
+    uid: "12345",
+    info: {
+      nickname: "dev-user",
+      name: "Dev User",
+      image: "https://avatars.githubusercontent.com/u/12345"
+    },
+    credentials: {
+      token: "fake-dev-token"
+    }
+  )
+end

--- a/engines/collavre_github/app/controllers/collavre_github/auth_controller.rb
+++ b/engines/collavre_github/app/controllers/collavre_github/auth_controller.rb
@@ -21,7 +21,33 @@ module CollavreGithub
       account.avatar_url = auth.info.image
       account.save!
 
-      redirect_to collavre.creatives_path, notice: I18n.t("collavre_github.auth.connected")
+      creative_id = session.delete(:github_creative_id)
+      if creative_id.present?
+        redirect_to setup_auth_path(creative_id: creative_id)
+      else
+        redirect_to collavre.creatives_path, notice: I18n.t("collavre_github.auth.connected")
+      end
+    end
+
+    def setup
+      @creative_id = params[:creative_id]
+      unless @creative_id.present?
+        render plain: I18n.t("collavre_github.integration.missing_creative"), status: :bad_request
+        return
+      end
+
+      @creative = Collavre::Creative.find_by(id: @creative_id)
+      unless @creative
+        render plain: I18n.t("collavre_github.integration.missing_creative"), status: :not_found
+        return
+      end
+
+      render layout: false
+    end
+
+    def store_creative
+      session[:github_creative_id] = params[:creative_id]
+      head :ok
     end
   end
 end

--- a/engines/collavre_github/app/controllers/collavre_github/auth_controller.rb
+++ b/engines/collavre_github/app/controllers/collavre_github/auth_controller.rb
@@ -42,6 +42,11 @@ module CollavreGithub
         return
       end
 
+      unless @creative.has_permission?(Current.user, :admin)
+        render plain: I18n.t("collavre_github.errors.forbidden"), status: :forbidden
+        return
+      end
+
       render layout: false
     end
 

--- a/engines/collavre_github/app/services/collavre_github/client.rb
+++ b/engines/collavre_github/app/services/collavre_github/client.rb
@@ -1,7 +1,10 @@
 module CollavreGithub
   class Client
     def initialize(account)
-      @client = Octokit::Client.new(access_token: account.token)
+      options = { access_token: account.token }
+      api_endpoint = ENV["GITHUB_API_ENDPOINT"]
+      options[:api_endpoint] = api_endpoint if api_endpoint.present?
+      @client = Octokit::Client.new(options)
       @client.auto_paginate = true
     end
 

--- a/engines/collavre_github/app/services/collavre_github/client.rb
+++ b/engines/collavre_github/app/services/collavre_github/client.rb
@@ -1,8 +1,10 @@
 module CollavreGithub
   class Client
+    MOCK_SERVER_DEFAULT = "http://localhost:4567"
+
     def initialize(account)
       options = { access_token: account.token }
-      api_endpoint = ENV["GITHUB_API_ENDPOINT"]
+      api_endpoint = resolve_api_endpoint
       options[:api_endpoint] = api_endpoint if api_endpoint.present?
       @client = Octokit::Client.new(options)
       @client.auto_paginate = true
@@ -109,5 +111,15 @@ module CollavreGithub
     private
 
     attr_reader :client
+
+    # Use GITHUB_API_ENDPOINT env var if set, otherwise fall back to mock server
+    # in development when no real GitHub credentials are configured.
+    def resolve_api_endpoint
+      return ENV["GITHUB_API_ENDPOINT"] if ENV["GITHUB_API_ENDPOINT"].present?
+
+      if Rails.env.development? && ENV["GITHUB_CLIENT_ID"].blank?
+        MOCK_SERVER_DEFAULT
+      end
+    end
   end
 end

--- a/engines/collavre_github/app/views/collavre_github/auth/setup.html.erb
+++ b/engines/collavre_github/app/views/collavre_github/auth/setup.html.erb
@@ -1,0 +1,379 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="csrf-token" content="<%= form_authenticity_token %>">
+  <title><%= t('collavre_github.integration.title') %></title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      background: #f5f5f5;
+      color: #333;
+      padding: 2em;
+      line-height: 1.5;
+    }
+    .wizard-container {
+      max-width: 520px;
+      margin: 0 auto;
+      background: #fff;
+      border-radius: 12px;
+      box-shadow: 0 2px 12px rgba(0,0,0,0.1);
+      padding: 2em;
+    }
+    h2 { margin-bottom: 0.5em; font-size: 1.3em; }
+    .step { display: none; }
+    .step.active { display: block; }
+    .step-subtext { color: #666; margin-bottom: 1em; font-size: 0.95em; }
+    .list-box {
+      max-height: 280px;
+      overflow-y: auto;
+      border: 1px solid #ddd;
+      border-radius: 8px;
+      padding: 0.5em;
+      margin-bottom: 1em;
+    }
+    .list-item {
+      display: flex;
+      align-items: center;
+      gap: 0.5em;
+      padding: 0.5em 0.4em;
+      cursor: pointer;
+      border-radius: 4px;
+    }
+    .list-item:hover { background: #f0f0f0; }
+    .list-item input { flex-shrink: 0; }
+    .btn {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0.6em 1.2em;
+      border-radius: 6px;
+      border: 1px solid #ccc;
+      background: #fff;
+      cursor: pointer;
+      font-size: 0.95em;
+      transition: background 0.15s;
+    }
+    .btn:hover { background: #f0f0f0; }
+    .btn-primary { background: #2563eb; color: #fff; border-color: #2563eb; }
+    .btn-primary:hover { background: #1d4ed8; }
+    .btn-primary:disabled { background: #93c5fd; cursor: not-allowed; }
+    .footer { display: flex; justify-content: space-between; margin-top: 1.5em; }
+    .footer-right { display: flex; gap: 0.5em; margin-left: auto; }
+    .error-msg { color: #dc2626; font-weight: 600; margin: 0.5em 0; display: none; }
+    .success-msg { color: #16a34a; font-weight: 600; margin: 0.5em 0; text-align: center; }
+    .loading { text-align: center; padding: 2em; color: #999; }
+    .summary-list { padding-left: 1.2em; }
+    .summary-list li { margin-bottom: 0.3em; }
+    .webhook-detail { margin-top: 0.3em; font-size: 0.85em; }
+    .webhook-detail code { background: #f1f5f9; padding: 0.2em 0.4em; border-radius: 3px; word-break: break-all; }
+    .close-btn { margin-top: 1em; width: 100%; }
+  </style>
+</head>
+<body>
+  <div class="wizard-container" id="wizard"
+       data-creative-id="<%= @creative_id %>"
+       data-success-message="<%= t('collavre_github.integration.saved') %>"
+       data-webhook-url-label="<%= t('collavre_github.integration.webhook_url_label') %>"
+       data-webhook-secret-label="<%= t('collavre_github.integration.webhook_secret_label') %>">
+    <h2><%= t('collavre_github.integration.title') %></h2>
+
+    <!-- Step 1: Organization -->
+    <div class="step active" id="step-organization">
+      <p class="step-subtext"><%= t('collavre_github.integration.choose_org') %></p>
+      <div id="org-list" class="list-box">
+        <div class="loading"><%= t('collavre_github.setup.loading', default: 'Loading...') %></div>
+      </div>
+    </div>
+
+    <!-- Step 2: Repositories -->
+    <div class="step" id="step-repositories">
+      <p class="step-subtext"><%= t('collavre_github.integration.choose_repo') %></p>
+      <div id="repo-list" class="list-box">
+        <div class="loading"><%= t('collavre_github.setup.loading', default: 'Loading...') %></div>
+      </div>
+    </div>
+
+    <!-- Step 3: Summary -->
+    <div class="step" id="step-summary">
+      <p class="step-subtext"><%= t('collavre_github.integration.summary') %></p>
+      <p id="webhook-instructions" class="step-subtext" style="display:none;"><%= t('collavre_github.integration.webhook_instructions') %></p>
+      <ul id="summary-repos" class="summary-list"></ul>
+      <p id="summary-empty" style="display:none;color:#999;"><%= t('collavre_github.integration.summary_empty') %></p>
+    </div>
+
+    <!-- Step 4: Done -->
+    <div class="step" id="step-done">
+      <p class="success-msg"><%= t('collavre_github.integration.saved') %></p>
+      <button type="button" id="close-btn" class="btn btn-primary close-btn"><%= t('collavre_github.setup.close', default: 'Close') %></button>
+    </div>
+
+    <div id="wizard-error" class="error-msg"></div>
+
+    <div class="footer" id="wizard-footer">
+      <button type="button" id="prev-btn" class="btn" style="display:none;"><%= t('app.previous', default: 'Previous') %></button>
+      <div class="footer-right">
+        <button type="button" id="next-btn" class="btn btn-primary" disabled><%= t('app.next', default: 'Next') %></button>
+        <button type="button" id="finish-btn" class="btn btn-primary" style="display:none;"><%= t('app.finish', default: 'Finish') %></button>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    (function() {
+      var wizard = document.getElementById('wizard');
+      var creativeId = wizard.dataset.creativeId;
+      var successMessage = wizard.dataset.successMessage;
+      var webhookUrlLabel = wizard.dataset.webhookUrlLabel;
+      var webhookSecretLabel = wizard.dataset.webhookSecretLabel;
+
+      var steps = ['organization', 'repositories', 'summary', 'done'];
+      var currentStepIndex = 0;
+      var selectedOrg = null;
+      var selectedRepos = new Set();
+      var webhookDetails = {};
+
+      var prevBtn = document.getElementById('prev-btn');
+      var nextBtn = document.getElementById('next-btn');
+      var finishBtn = document.getElementById('finish-btn');
+      var errorEl = document.getElementById('wizard-error');
+      var footer = document.getElementById('wizard-footer');
+
+      function csrfToken() {
+        return document.querySelector('meta[name="csrf-token"]')?.content;
+      }
+
+      function showStep(index) {
+        currentStepIndex = index;
+        steps.forEach(function(s, i) {
+          var el = document.getElementById('step-' + s);
+          if (el) el.className = 'step' + (i === index ? ' active' : '');
+        });
+
+        if (steps[index] === 'done') {
+          footer.style.display = 'none';
+          return;
+        }
+        footer.style.display = 'flex';
+
+        prevBtn.style.display = index > 0 ? 'inline-flex' : 'none';
+
+        if (steps[index] === 'summary') {
+          nextBtn.style.display = 'none';
+          finishBtn.style.display = 'inline-flex';
+          updateSummary();
+        } else {
+          nextBtn.style.display = 'inline-flex';
+          finishBtn.style.display = 'none';
+          nextBtn.disabled = (steps[index] === 'organization' && !selectedOrg);
+        }
+      }
+
+      function showError(msg) {
+        errorEl.textContent = msg;
+        errorEl.style.display = 'block';
+      }
+
+      function clearError() {
+        errorEl.textContent = '';
+        errorEl.style.display = 'none';
+      }
+
+      function loadOrganizations() {
+        var orgList = document.getElementById('org-list');
+        orgList.innerHTML = '<div class="loading">Loading...</div>';
+
+        fetch('/github/account/organizations', { headers: { Accept: 'application/json' } })
+          .then(function(r) { return r.json(); })
+          .then(function(data) {
+            var orgs = data.organizations || [];
+            orgList.innerHTML = '';
+            if (!orgs.length) {
+              orgList.innerHTML = '<p style="padding:0.5em;color:#999;">No organizations found.</p>';
+              return;
+            }
+            orgs.forEach(function(org) {
+              var label = document.createElement('label');
+              label.className = 'list-item';
+
+              var input = document.createElement('input');
+              input.type = 'radio';
+              input.name = 'org';
+              input.value = org.login;
+              input.addEventListener('change', function() {
+                selectedOrg = org.login;
+                nextBtn.disabled = false;
+              });
+
+              var span = document.createElement('span');
+              span.textContent = org.name || org.login;
+
+              label.appendChild(input);
+              label.appendChild(span);
+              orgList.appendChild(label);
+            });
+          })
+          .catch(function() {
+            orgList.innerHTML = '';
+            showError('Failed to load organizations.');
+          });
+      }
+
+      function loadRepositories() {
+        var repoList = document.getElementById('repo-list');
+        repoList.innerHTML = '<div class="loading">Loading...</div>';
+
+        var params = new URLSearchParams({ organization: selectedOrg });
+        if (creativeId) params.append('creative_id', creativeId);
+
+        fetch('/github/account/repositories?' + params.toString(), { headers: { Accept: 'application/json' } })
+          .then(function(r) { return r.json(); })
+          .then(function(data) {
+            var repos = data.repositories || [];
+            repoList.innerHTML = '';
+            if (!repos.length) {
+              repoList.innerHTML = '<p style="padding:0.5em;color:#999;">No repositories found.</p>';
+              return;
+            }
+            repos.forEach(function(repo) {
+              var label = document.createElement('label');
+              label.className = 'list-item';
+
+              var input = document.createElement('input');
+              input.type = 'checkbox';
+              input.value = repo.full_name;
+              input.checked = selectedRepos.has(repo.full_name) || repo.selected;
+              if (input.checked) selectedRepos.add(repo.full_name);
+              input.addEventListener('change', function() {
+                if (input.checked) {
+                  selectedRepos.add(repo.full_name);
+                } else {
+                  selectedRepos.delete(repo.full_name);
+                }
+              });
+
+              var span = document.createElement('span');
+              span.textContent = repo.full_name;
+
+              label.appendChild(input);
+              label.appendChild(span);
+              repoList.appendChild(label);
+            });
+          })
+          .catch(function() {
+            repoList.innerHTML = '';
+            showError('Failed to load repositories.');
+          });
+      }
+
+      function updateSummary() {
+        var summaryList = document.getElementById('summary-repos');
+        var summaryEmpty = document.getElementById('summary-empty');
+        var instructions = document.getElementById('webhook-instructions');
+        summaryList.innerHTML = '';
+
+        var repos = Array.from(selectedRepos);
+        if (!repos.length) {
+          summaryEmpty.style.display = 'block';
+          if (instructions) instructions.style.display = 'none';
+          return;
+        }
+        summaryEmpty.style.display = 'none';
+        if (instructions) instructions.style.display = 'block';
+
+        repos.forEach(function(fullName) {
+          var li = document.createElement('li');
+          var strong = document.createElement('strong');
+          strong.textContent = fullName;
+          li.appendChild(strong);
+
+          var details = webhookDetails[fullName];
+          if (details) {
+            if (details.url) {
+              var urlDiv = document.createElement('div');
+              urlDiv.className = 'webhook-detail';
+              urlDiv.innerHTML = '<span style="font-weight:600;">' + webhookUrlLabel + ': </span><code>' + details.url + '</code>';
+              li.appendChild(urlDiv);
+            }
+            if (details.secret) {
+              var secretDiv = document.createElement('div');
+              secretDiv.className = 'webhook-detail';
+              secretDiv.innerHTML = '<span style="font-weight:600;">' + webhookSecretLabel + ': </span><code>' + details.secret + '</code>';
+              li.appendChild(secretDiv);
+            }
+          }
+          summaryList.appendChild(li);
+        });
+      }
+
+      function saveSelection() {
+        clearError();
+        var payload = { repositories: Array.from(selectedRepos) };
+
+        fetch('/github/creatives/' + creativeId + '/integration', {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-CSRF-Token': csrfToken()
+          },
+          body: JSON.stringify(payload)
+        })
+          .then(function(r) { return r.json().then(function(body) { return { ok: r.ok, body: body }; }); })
+          .then(function(result) {
+            if (!result.ok) {
+              showError(result.body.error || 'Failed to save integration.');
+              return;
+            }
+            webhookDetails = result.body.webhooks || {};
+
+            // Notify parent window and show done step
+            notifyParent();
+            showStep(steps.indexOf('done'));
+          })
+          .catch(function() {
+            showError('Failed to save integration.');
+          });
+      }
+
+      function notifyParent() {
+        try {
+          if (window.opener) {
+            window.opener.postMessage({ type: 'githubConnected' }, window.location.origin);
+          }
+        } catch (e) {
+          // Ignore cross-origin errors
+        }
+      }
+
+      // Navigation
+      prevBtn.addEventListener('click', function() {
+        clearError();
+        if (currentStepIndex > 0) {
+          showStep(currentStepIndex - 1);
+          if (steps[currentStepIndex] === 'repositories') loadRepositories();
+        }
+      });
+
+      nextBtn.addEventListener('click', function() {
+        clearError();
+        var nextIndex = currentStepIndex + 1;
+        showStep(nextIndex);
+        if (steps[nextIndex] === 'repositories') loadRepositories();
+      });
+
+      finishBtn.addEventListener('click', function() {
+        saveSelection();
+      });
+
+      document.getElementById('close-btn').addEventListener('click', function() {
+        window.close();
+      });
+
+      // Initial load
+      loadOrganizations();
+    })();
+  </script>
+</body>
+</html>

--- a/engines/collavre_github/app/views/collavre_github/auth/setup.html.erb
+++ b/engines/collavre_github/app/views/collavre_github/auth/setup.html.erb
@@ -77,7 +77,12 @@
        data-creative-id="<%= @creative_id %>"
        data-success-message="<%= t('collavre_github.integration.saved') %>"
        data-webhook-url-label="<%= t('collavre_github.integration.webhook_url_label') %>"
-       data-webhook-secret-label="<%= t('collavre_github.integration.webhook_secret_label') %>">
+       data-webhook-secret-label="<%= t('collavre_github.integration.webhook_secret_label') %>"
+       data-no-orgs="<%= t('collavre_github.setup.no_orgs') %>"
+       data-no-repos="<%= t('collavre_github.setup.no_repos') %>"
+       data-load-orgs-error="<%= t('collavre_github.setup.load_orgs_error') %>"
+       data-load-repos-error="<%= t('collavre_github.setup.load_repos_error') %>"
+       data-save-error="<%= t('collavre_github.setup.save_error') %>">
     <h2><%= t('collavre_github.integration.title') %></h2>
 
     <!-- Step 1: Organization -->
@@ -128,6 +133,11 @@
       var successMessage = wizard.dataset.successMessage;
       var webhookUrlLabel = wizard.dataset.webhookUrlLabel;
       var webhookSecretLabel = wizard.dataset.webhookSecretLabel;
+      var noOrgsMsg = wizard.dataset.noOrgs;
+      var noReposMsg = wizard.dataset.noRepos;
+      var loadOrgsError = wizard.dataset.loadOrgsError;
+      var loadReposError = wizard.dataset.loadReposError;
+      var saveErrorMsg = wizard.dataset.saveError;
 
       var steps = ['organization', 'repositories', 'summary', 'done'];
       var currentStepIndex = 0;
@@ -191,7 +201,7 @@
             var orgs = data.organizations || [];
             orgList.innerHTML = '';
             if (!orgs.length) {
-              orgList.innerHTML = '<p style="padding:0.5em;color:#999;">No organizations found.</p>';
+              orgList.innerHTML = '<p style="padding:0.5em;color:#999;">' + noOrgsMsg + '</p>';
               return;
             }
             orgs.forEach(function(org) {
@@ -217,7 +227,7 @@
           })
           .catch(function() {
             orgList.innerHTML = '';
-            showError('Failed to load organizations.');
+            showError(loadOrgsError);
           });
       }
 
@@ -234,7 +244,7 @@
             var repos = data.repositories || [];
             repoList.innerHTML = '';
             if (!repos.length) {
-              repoList.innerHTML = '<p style="padding:0.5em;color:#999;">No repositories found.</p>';
+              repoList.innerHTML = '<p style="padding:0.5em;color:#999;">' + noReposMsg + '</p>';
               return;
             }
             repos.forEach(function(repo) {
@@ -264,7 +274,7 @@
           })
           .catch(function() {
             repoList.innerHTML = '';
-            showError('Failed to load repositories.');
+            showError(loadReposError);
           });
       }
 
@@ -323,7 +333,7 @@
           .then(function(r) { return r.json().then(function(body) { return { ok: r.ok, body: body }; }); })
           .then(function(result) {
             if (!result.ok) {
-              showError(result.body.error || 'Failed to save integration.');
+              showError(result.body.error || saveErrorMsg);
               return;
             }
             webhookDetails = result.body.webhooks || {};
@@ -333,7 +343,7 @@
             showStep(steps.indexOf('done'));
           })
           .catch(function() {
-            showError('Failed to save integration.');
+            showError(saveErrorMsg);
           });
       }
 

--- a/engines/collavre_github/config/locales/en.yml
+++ b/engines/collavre_github/config/locales/en.yml
@@ -26,6 +26,11 @@ en:
     setup:
       loading: "Loading..."
       close: "Close"
+      no_orgs: "No organizations found."
+      no_repos: "No repositories found."
+      load_orgs_error: "Failed to load organizations."
+      load_repos_error: "Failed to load repositories."
+      save_error: "Failed to save integration."
     auth:
       login_first: "Please log in first to connect your GitHub account"
       connected: "GitHub account connected successfully"

--- a/engines/collavre_github/config/locales/en.yml
+++ b/engines/collavre_github/config/locales/en.yml
@@ -23,6 +23,9 @@ en:
       summary: "The following repositories will be linked to this Creative:"
       webhook_instructions: "Configure each repository with the webhook details below."
       summary_empty: "No repositories selected."
+    setup:
+      loading: "Loading..."
+      close: "Close"
     auth:
       login_first: "Please log in first to connect your GitHub account"
       connected: "GitHub account connected successfully"

--- a/engines/collavre_github/config/locales/ko.yml
+++ b/engines/collavre_github/config/locales/ko.yml
@@ -26,6 +26,11 @@ ko:
     setup:
       loading: "불러오는 중..."
       close: "닫기"
+      no_orgs: "조직을 찾을 수 없습니다."
+      no_repos: "저장소를 찾을 수 없습니다."
+      load_orgs_error: "조직 목록을 불러오지 못했습니다."
+      load_repos_error: "저장소 목록을 불러오지 못했습니다."
+      save_error: "연동 저장에 실패했습니다."
     auth:
       login_first: "GitHub 계정을 연결하려면 먼저 로그인하세요"
       connected: "GitHub 계정이 연결되었습니다"

--- a/engines/collavre_github/config/locales/ko.yml
+++ b/engines/collavre_github/config/locales/ko.yml
@@ -23,6 +23,9 @@ ko:
       summary: "다음 저장소가 이 Creative에 연동됩니다:"
       webhook_instructions: "각 저장소에 아래 웹훅 정보를 설정하세요."
       summary_empty: "선택된 저장소가 없습니다."
+    setup:
+      loading: "불러오는 중..."
+      close: "닫기"
     auth:
       login_first: "GitHub 계정을 연결하려면 먼저 로그인하세요"
       connected: "GitHub 계정이 연결되었습니다"

--- a/engines/collavre_github/config/routes.rb
+++ b/engines/collavre_github/config/routes.rb
@@ -4,6 +4,10 @@ CollavreGithub::Engine.routes.draw do
   post "webhook", to: "webhooks#create", as: :webhook
   post "webhooks", to: "webhooks#create"
 
+  # OAuth setup flow (popup wizard after callback)
+  get "auth/setup", to: "auth#setup", as: :setup_auth
+  post "auth/store_creative", to: "auth#store_creative", as: :store_creative_auth
+
   # Account endpoints
   resource :account, only: [ :show ] do
     get :organizations

--- a/engines/collavre_github/lib/tasks/mock_server.rake
+++ b/engines/collavre_github/lib/tasks/mock_server.rake
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+namespace :collavre_github do
+  desc "Start GitHub API mock server for development (port: GITHUB_MOCK_PORT, default 4567)"
+  task :mock_server do
+    load CollavreGithub::Engine.root.join("script/mock_server.rb")
+  end
+end

--- a/engines/collavre_github/script/mock_server.rb
+++ b/engines/collavre_github/script/mock_server.rb
@@ -1,0 +1,164 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# GitHub API Mock Server for development
+# Provides fake responses for Octokit API calls so the GitHub integration
+# UI can be previewed without real GitHub credentials.
+#
+# Usage:
+#   ruby engines/collavre_github/script/mock_server.rb
+#   # or via rake:
+#   bin/rails collavre_github:mock_server
+#
+# Set GITHUB_MOCK_PORT to change the port (default: 4567)
+
+require "socket"
+require "json"
+require "uri"
+
+PORT = Integer(ENV.fetch("GITHUB_MOCK_PORT", 4567))
+
+# --- Mock Data ---
+
+MOCK_USER = {
+  id: 12345,
+  login: "dev-user",
+  name: "Dev User",
+  avatar_url: "https://avatars.githubusercontent.com/u/12345",
+  type: "User"
+}.freeze
+
+MOCK_ORGS = [
+  { id: 100, login: "acme-corp", name: "ACME Corporation", type: "Organization" },
+  { id: 101, login: "startup-inc", name: "Startup Inc", type: "Organization" }
+].freeze
+
+MOCK_USER_REPOS = [
+  { id: 1, name: "my-app", full_name: "dev-user/my-app", private: false },
+  { id: 2, name: "dotfiles", full_name: "dev-user/dotfiles", private: true },
+  { id: 3, name: "blog", full_name: "dev-user/blog", private: false }
+].freeze
+
+MOCK_ORG_REPOS = {
+  "acme-corp" => [
+    { id: 10, name: "backend", full_name: "acme-corp/backend", private: true },
+    { id: 11, name: "frontend", full_name: "acme-corp/frontend", private: true },
+    { id: 12, name: "docs", full_name: "acme-corp/docs", private: false },
+    { id: 13, name: "infrastructure", full_name: "acme-corp/infrastructure", private: true }
+  ],
+  "startup-inc" => [
+    { id: 20, name: "product", full_name: "startup-inc/product", private: true },
+    { id: 21, name: "landing-page", full_name: "startup-inc/landing-page", private: false }
+  ]
+}.freeze
+
+# --- Router ---
+
+def route(method, path, query_params)
+  hooks_pattern = %r{\A/repos/[^/]+/[^/]+/hooks\z}
+  org_repos_pattern = %r{\A/orgs/([^/]+)/repos\z}
+
+  if method == "GET" && path == "/user"
+    [ 200, MOCK_USER ]
+  elsif method == "GET" && path == "/user/orgs"
+    [ 200, MOCK_ORGS ]
+  elsif method == "GET" && path == "/user/repos"
+    [ 200, MOCK_USER_REPOS ]
+  elsif method == "GET" && (m = path.match(org_repos_pattern))
+    repos = MOCK_ORG_REPOS[m[1]]
+    repos ? [ 200, repos ] : [ 404, { message: "Not Found" } ]
+  elsif method == "GET" && path.match?(hooks_pattern)
+    [ 200, [] ]
+  elsif method == "POST" && path.match?(hooks_pattern)
+    [ 201, { id: rand(10_000), active: true, config: {} } ]
+  else
+    [ 404, { message: "Mock endpoint not found: #{method} #{path}" } ]
+  end
+end
+
+# --- HTTP Server ---
+
+def parse_request(client)
+  request_line = client.gets
+  return nil unless request_line
+
+  method, full_path, = request_line.split(" ")
+  uri = URI.parse(full_path)
+  path = uri.path
+  query_params = URI.decode_www_form(uri.query || "").to_h
+
+  # Read headers
+  headers = {}
+  while (line = client.gets) && line != "\r\n"
+    key, value = line.split(": ", 2)
+    headers[key.downcase] = value&.strip
+  end
+
+  # Read body if present
+  body = nil
+  if headers["content-length"]
+    body = client.read(headers["content-length"].to_i)
+  end
+
+  { method: method, path: path, query: query_params, headers: headers, body: body }
+end
+
+def send_response(client, status, body)
+  json_body = body.to_json
+  status_text = { 200 => "OK", 201 => "Created", 404 => "Not Found" }[status] || "OK"
+
+  client.print "HTTP/1.1 #{status} #{status_text}\r\n"
+  client.print "Content-Type: application/json\r\n"
+  client.print "Content-Length: #{json_body.bytesize}\r\n"
+  client.print "Access-Control-Allow-Origin: *\r\n"
+  client.print "Access-Control-Allow-Methods: GET, POST, PATCH, DELETE, OPTIONS\r\n"
+  client.print "Access-Control-Allow-Headers: *\r\n"
+  client.print "Connection: close\r\n"
+  client.print "\r\n"
+  client.print json_body
+end
+
+# --- Main ---
+
+server = TCPServer.new("0.0.0.0", PORT)
+puts "🐙 GitHub API Mock Server running on http://localhost:#{PORT}"
+puts "   Set GITHUB_API_ENDPOINT=http://localhost:#{PORT} in .env.development"
+puts "   Press Ctrl+C to stop"
+puts ""
+puts "   Available endpoints:"
+puts "     GET  /user           → mock user profile"
+puts "     GET  /user/orgs      → #{MOCK_ORGS.size} organizations"
+puts "     GET  /user/repos     → #{MOCK_USER_REPOS.size} user repositories"
+MOCK_ORG_REPOS.each do |org, repos|
+  puts "     GET  /orgs/#{org}/repos → #{repos.size} repositories"
+end
+puts "     GET  /repos/:owner/:repo/hooks → empty hooks"
+puts "     POST /repos/:owner/:repo/hooks → created hook"
+puts ""
+
+loop do
+  client = server.accept
+  Thread.new(client) do |c|
+    begin
+      req = parse_request(c)
+      next unless req
+
+      # Handle CORS preflight
+      if req[:method] == "OPTIONS"
+        send_response(c, 200, {})
+      else
+        status, body = route(req[:method], req[:path], req[:query])
+        send_response(c, status, body)
+        puts "  #{req[:method]} #{req[:path]} → #{status}"
+      end
+    rescue StandardError => e
+      puts "  ERROR: #{e.message}"
+    ensure
+      c.close
+    end
+  end
+rescue Interrupt
+  puts "\n🛑 Mock server stopped"
+  server.close
+  break
+end

--- a/engines/collavre_github/test/controllers/collavre_github/accounts_controller_test.rb
+++ b/engines/collavre_github/test/controllers/collavre_github/accounts_controller_test.rb
@@ -1,0 +1,92 @@
+require_relative "../../test_helper"
+
+module CollavreGithub
+  class AccountsControllerTest < ActionDispatch::IntegrationTest
+    setup do
+      @user = create_user(email: "gh-account@example.com", name: "GH Account User")
+      @account = create_github_account(@user)
+    end
+
+    test "show returns account info" do
+      sign_in_as(@user)
+
+      get "/github/account",
+          headers: { "Accept" => "application/json" }
+
+      assert_response :success
+      data = JSON.parse(response.body)
+      assert_equal @account.login, data["login"]
+      assert_equal @account.name, data["name"]
+    end
+
+    test "show returns error when not connected" do
+      @account.destroy!
+      sign_in_as(@user)
+
+      get "/github/account",
+          headers: { "Accept" => "application/json" }
+
+      assert_response :unprocessable_entity
+      data = JSON.parse(response.body)
+      assert_equal "not_connected", data["error"]
+    end
+
+    test "organizations returns user org plus github orgs" do
+      sign_in_as(@user)
+
+      stub_github_organizations([
+        { id: 100, login: "acme", name: "ACME Corp", type: "Organization" }
+      ])
+
+      get "/github/account/organizations",
+          headers: { "Accept" => "application/json" }
+
+      assert_response :success
+      data = JSON.parse(response.body)
+      orgs = data["organizations"]
+      # User org + github orgs
+      assert orgs.size >= 1
+      # First is user's own
+      assert_equal @account.login, orgs[0]["login"]
+      assert_equal "User", orgs[0]["type"]
+      # Check that acme org is present
+      acme = orgs.find { |o| o["login"] == "acme" }
+      assert_not_nil acme, "Expected 'acme' org in response"
+    end
+
+    test "repositories returns repos for user" do
+      sign_in_as(@user)
+
+      stub_github_user_repos([
+        { id: 1, name: "my-app", full_name: "testuser/my-app" }
+      ])
+
+      get "/github/account/repositories",
+          params: { organization: @account.login },
+          headers: { "Accept" => "application/json" }
+
+      assert_response :success
+      data = JSON.parse(response.body)
+      assert_equal 1, data["repositories"].size
+      assert_equal "testuser/my-app", data["repositories"][0]["full_name"]
+    end
+
+    test "repositories returns repos for organization" do
+      sign_in_as(@user)
+
+      stub_github_org_repos("acme", [
+        { id: 10, name: "backend", full_name: "acme/backend" },
+        { id: 11, name: "frontend", full_name: "acme/frontend" }
+      ])
+
+      get "/github/account/repositories",
+          params: { organization: "acme" },
+          headers: { "Accept" => "application/json" }
+
+      assert_response :success
+      data = JSON.parse(response.body)
+      assert_equal 2, data["repositories"].size
+      assert_equal %w[acme/backend acme/frontend], data["repositories"].map { |r| r["full_name"] }
+    end
+  end
+end

--- a/engines/collavre_github/test/controllers/collavre_github/auth_controller_test.rb
+++ b/engines/collavre_github/test/controllers/collavre_github/auth_controller_test.rb
@@ -53,6 +53,15 @@ module CollavreGithub
       assert_response :not_found
     end
 
+    test "setup returns forbidden for user without admin permission" do
+      other_user = create_user(email: "other-github@example.com", name: "Other User")
+      sign_in_as(other_user)
+
+      get "/github/auth/setup", params: { creative_id: @creative.id }
+
+      assert_response :forbidden
+    end
+
     test "callback redirects to setup when creative_id in session" do
       sign_in_as(@user)
 

--- a/engines/collavre_github/test/controllers/collavre_github/auth_controller_test.rb
+++ b/engines/collavre_github/test/controllers/collavre_github/auth_controller_test.rb
@@ -1,0 +1,163 @@
+require_relative "../../test_helper"
+
+module CollavreGithub
+  class AuthControllerTest < ActionDispatch::IntegrationTest
+    setup do
+      @user = create_user(email: "github-auth@example.com", name: "GitHub Auth User")
+      @creative = create_creative(@user)
+    end
+
+    test "store_creative sets creative_id in session" do
+      sign_in_as(@user)
+
+      post "/github/auth/store_creative",
+           params: { creative_id: @creative.id },
+           headers: { "Content-Type" => "application/json" },
+           as: :json
+
+      assert_response :ok
+    end
+
+    test "store_creative requires authentication" do
+      post "/github/auth/store_creative",
+           params: { creative_id: @creative.id },
+           headers: { "Content-Type" => "application/json" },
+           as: :json
+
+      assert_response :redirect
+    end
+
+    test "setup renders wizard with valid creative_id" do
+      sign_in_as(@user)
+
+      get "/github/auth/setup", params: { creative_id: @creative.id }
+
+      assert_response :ok
+      assert_includes response.body, "wizard"
+      assert_includes response.body, @creative.id.to_s
+    end
+
+    test "setup returns bad_request without creative_id" do
+      sign_in_as(@user)
+
+      get "/github/auth/setup"
+
+      assert_response :bad_request
+    end
+
+    test "setup returns not_found for invalid creative_id" do
+      sign_in_as(@user)
+
+      get "/github/auth/setup", params: { creative_id: 999999 }
+
+      assert_response :not_found
+    end
+
+    test "callback redirects to setup when creative_id in session" do
+      sign_in_as(@user)
+
+      # Store creative_id in session
+      post "/github/auth/store_creative",
+           params: { creative_id: @creative.id },
+           headers: { "Content-Type" => "application/json" },
+           as: :json
+      assert_response :ok
+
+      # Simulate OmniAuth callback
+      OmniAuth.config.test_mode = true
+      OmniAuth.config.mock_auth[:github] = OmniAuth::AuthHash.new(
+        provider: "github",
+        uid: "12345",
+        info: {
+          nickname: "testuser",
+          name: "Test User",
+          image: "https://avatars.githubusercontent.com/u/12345"
+        },
+        credentials: {
+          token: "ghp-mock-token-abc"
+        }
+      )
+
+      # Trigger callback
+      get "/auth/github/callback"
+
+      assert_response :redirect
+      assert_match(/setup/, response.location)
+      assert_match(/creative_id=#{@creative.id}/, response.location)
+
+      # Verify account was created
+      account = CollavreGithub::Account.find_by(github_uid: "12345")
+      assert_not_nil account
+      assert_equal "testuser", account.login
+      assert_equal "ghp-mock-token-abc", account.token
+      assert_equal @user.id, account.user_id
+    ensure
+      OmniAuth.config.test_mode = false
+      OmniAuth.config.mock_auth[:github] = nil
+    end
+
+    test "callback redirects to creatives_path when no creative_id in session" do
+      sign_in_as(@user)
+
+      OmniAuth.config.test_mode = true
+      OmniAuth.config.mock_auth[:github] = OmniAuth::AuthHash.new(
+        provider: "github",
+        uid: "12346",
+        info: {
+          nickname: "testuser2",
+          name: "Test User 2",
+          image: "https://avatars.githubusercontent.com/u/12346"
+        },
+        credentials: {
+          token: "ghp-mock-token-def"
+        }
+      )
+
+      get "/auth/github/callback"
+
+      assert_response :redirect
+      assert_match(/creatives/, response.location)
+    ensure
+      OmniAuth.config.test_mode = false
+      OmniAuth.config.mock_auth[:github] = nil
+    end
+
+    test "callback updates existing account token" do
+      sign_in_as(@user)
+
+      existing = CollavreGithub::Account.create!(
+        user: @user,
+        github_uid: "12347",
+        login: "oldlogin",
+        name: "Old Name",
+        token: "ghp-old-token",
+        avatar_url: "https://old.avatar"
+      )
+
+      OmniAuth.config.test_mode = true
+      OmniAuth.config.mock_auth[:github] = OmniAuth::AuthHash.new(
+        provider: "github",
+        uid: "12347",
+        info: {
+          nickname: "newlogin",
+          name: "New Name",
+          image: "https://new.avatar"
+        },
+        credentials: {
+          token: "ghp-new-token"
+        }
+      )
+
+      get "/auth/github/callback"
+
+      existing.reload
+      assert_equal "newlogin", existing.login
+      assert_equal "New Name", existing.name
+      assert_equal "ghp-new-token", existing.token
+      assert_equal "https://new.avatar", existing.avatar_url
+    ensure
+      OmniAuth.config.test_mode = false
+      OmniAuth.config.mock_auth[:github] = nil
+    end
+  end
+end

--- a/engines/collavre_github/test/controllers/collavre_github/integrations_controller_test.rb
+++ b/engines/collavre_github/test/controllers/collavre_github/integrations_controller_test.rb
@@ -1,0 +1,261 @@
+require_relative "../../test_helper"
+
+module CollavreGithub
+  class IntegrationsControllerTest < ActionDispatch::IntegrationTest
+    setup do
+      @user = create_user(email: "gh-integration@example.com", name: "GH Integration User")
+      @creative = create_creative(@user)
+      @account = create_github_account(@user)
+    end
+
+    # --- Show (GET) ---
+
+    test "show returns connected status with no repositories" do
+      sign_in_as(@user)
+
+      get "/github/creatives/#{@creative.id}/integration",
+          headers: { "Accept" => "application/json" }
+
+      assert_response :success
+      data = JSON.parse(response.body)
+      assert data["connected"]
+      assert_equal @account.login, data["account"]["login"]
+      assert_equal [], data["selected_repositories"]
+    end
+
+    test "show returns not connected when user has no github account" do
+      @account.destroy!
+      sign_in_as(@user)
+
+      get "/github/creatives/#{@creative.id}/integration",
+          headers: { "Accept" => "application/json" }
+
+      assert_response :success
+      data = JSON.parse(response.body)
+      assert_not data["connected"]
+    end
+
+    test "show returns selected repositories" do
+      sign_in_as(@user)
+
+      CollavreGithub::RepositoryLink.create!(
+        creative: @creative.effective_origin,
+        github_account: @account,
+        repository_full_name: "testuser/repo1"
+      )
+
+      get "/github/creatives/#{@creative.id}/integration",
+          headers: { "Accept" => "application/json" }
+
+      assert_response :success
+      data = JSON.parse(response.body)
+      assert_includes data["selected_repositories"], "testuser/repo1"
+    end
+
+    # --- Organizations ---
+
+    test "organizations returns mocked github orgs" do
+      sign_in_as(@user)
+
+      stub_github_organizations([
+        { id: 1, login: "myorg", name: "My Org", type: "Organization" },
+        { id: 2, login: "other", name: "Other Org", type: "Organization" }
+      ])
+
+      get "/github/account/organizations",
+          headers: { "Accept" => "application/json" }
+
+      assert_response :success
+      data = JSON.parse(response.body)
+      orgs = data["organizations"]
+
+      # First one is the user's own account
+      assert_equal @account.login, orgs[0]["login"]
+      assert_equal "User", orgs[0]["type"]
+
+      # Then the orgs from GitHub
+      assert_equal "myorg", orgs[1]["login"]
+      assert_equal "other", orgs[2]["login"]
+    end
+
+    test "organizations returns only user org when github api fails" do
+      sign_in_as(@user)
+
+      # Client rescues errors and returns [], so only user org remains
+      stub_request(:get, %r{https://api\.github\.com/user/orgs})
+        .to_return(status: 401, body: { message: "Bad credentials" }.to_json,
+                   headers: { "Content-Type" => "application/json" })
+
+      get "/github/account/organizations",
+          headers: { "Accept" => "application/json" }
+
+      assert_response :success
+      data = JSON.parse(response.body)
+      orgs = data["organizations"]
+      assert_equal 1, orgs.size
+      assert_equal @account.login, orgs[0]["login"]
+    end
+
+    # --- Repositories ---
+
+    test "repositories returns user repos" do
+      sign_in_as(@user)
+
+      stub_github_user_repos([
+        { id: 1, name: "repo1", full_name: "testuser/repo1" },
+        { id: 2, name: "repo2", full_name: "testuser/repo2" }
+      ])
+
+      get "/github/account/repositories",
+          params: { organization: @account.login, creative_id: @creative.id },
+          headers: { "Accept" => "application/json" }
+
+      assert_response :success
+      data = JSON.parse(response.body)
+      repos = data["repositories"]
+      assert_equal 2, repos.size
+      assert_equal "testuser/repo1", repos[0]["full_name"]
+    end
+
+    test "repositories marks selected repos" do
+      sign_in_as(@user)
+
+      CollavreGithub::RepositoryLink.create!(
+        creative: @creative.effective_origin,
+        github_account: @account,
+        repository_full_name: "testuser/repo1"
+      )
+
+      stub_github_user_repos([
+        { id: 1, name: "repo1", full_name: "testuser/repo1" },
+        { id: 2, name: "repo2", full_name: "testuser/repo2" }
+      ])
+
+      get "/github/account/repositories",
+          params: { organization: @account.login, creative_id: @creative.id },
+          headers: { "Accept" => "application/json" }
+
+      assert_response :success
+      data = JSON.parse(response.body)
+      repos = data["repositories"]
+      selected = repos.find { |r| r["full_name"] == "testuser/repo1" }
+      unselected = repos.find { |r| r["full_name"] == "testuser/repo2" }
+      assert selected["selected"]
+      assert_not unselected["selected"]
+    end
+
+    test "repositories returns org repos" do
+      sign_in_as(@user)
+
+      stub_github_org_repos("myorg", [
+        { id: 10, name: "org-repo", full_name: "myorg/org-repo" }
+      ])
+
+      get "/github/account/repositories",
+          params: { organization: "myorg" },
+          headers: { "Accept" => "application/json" }
+
+      assert_response :success
+      data = JSON.parse(response.body)
+      assert_equal 1, data["repositories"].size
+      assert_equal "myorg/org-repo", data["repositories"][0]["full_name"]
+    end
+
+    # --- Update (PATCH) ---
+
+    test "update links repositories" do
+      sign_in_as(@user)
+
+      stub_github_hooks("testuser/repo1")
+      stub_github_create_hook("testuser/repo1")
+
+      patch "/github/creatives/#{@creative.id}/integration",
+            params: { repositories: [ "testuser/repo1" ] },
+            headers: { "Content-Type" => "application/json", "Accept" => "application/json" },
+            as: :json
+
+      assert_response :success
+      data = JSON.parse(response.body)
+      assert data["success"]
+      assert_includes data["selected_repositories"], "testuser/repo1"
+      assert data["webhooks"]["testuser/repo1"].present?
+    end
+
+    test "update replaces existing repositories" do
+      sign_in_as(@user)
+
+      CollavreGithub::RepositoryLink.create!(
+        creative: @creative.effective_origin,
+        github_account: @account,
+        repository_full_name: "testuser/old-repo"
+      )
+
+      stub_github_hooks("testuser/new-repo")
+      stub_github_create_hook("testuser/new-repo")
+
+      patch "/github/creatives/#{@creative.id}/integration",
+            params: { repositories: [ "testuser/new-repo" ] },
+            headers: { "Content-Type" => "application/json", "Accept" => "application/json" },
+            as: :json
+
+      assert_response :success
+      data = JSON.parse(response.body)
+      assert_includes data["selected_repositories"], "testuser/new-repo"
+      assert_not_includes data["selected_repositories"], "testuser/old-repo"
+    end
+
+    test "update returns error when not connected" do
+      @account.destroy!
+      sign_in_as(@user)
+
+      patch "/github/creatives/#{@creative.id}/integration",
+            params: { repositories: [ "testuser/repo1" ] },
+            headers: { "Content-Type" => "application/json", "Accept" => "application/json" },
+            as: :json
+
+      assert_response :unprocessable_entity
+    end
+
+    # --- Destroy (DELETE) ---
+
+    test "destroy removes selected repositories" do
+      sign_in_as(@user)
+
+      CollavreGithub::RepositoryLink.create!(
+        creative: @creative.effective_origin,
+        github_account: @account,
+        repository_full_name: "testuser/repo1"
+      )
+      CollavreGithub::RepositoryLink.create!(
+        creative: @creative.effective_origin,
+        github_account: @account,
+        repository_full_name: "testuser/repo2"
+      )
+
+      # Stub webhook removal
+      stub_github_hooks("testuser/repo1")
+
+      delete "/github/creatives/#{@creative.id}/integration",
+             params: { repositories: [ "testuser/repo1" ] },
+             headers: { "Content-Type" => "application/json", "Accept" => "application/json" },
+             as: :json
+
+      assert_response :success
+      data = JSON.parse(response.body)
+      assert data["success"]
+      assert_not_includes data["selected_repositories"], "testuser/repo1"
+      assert_includes data["selected_repositories"], "testuser/repo2"
+    end
+
+    test "destroy returns not found for non-linked repo" do
+      sign_in_as(@user)
+
+      delete "/github/creatives/#{@creative.id}/integration",
+             params: { repositories: [ "testuser/nonexistent" ] },
+             headers: { "Content-Type" => "application/json", "Accept" => "application/json" },
+             as: :json
+
+      assert_response :not_found
+    end
+  end
+end

--- a/engines/collavre_github/test/test_helper.rb
+++ b/engines/collavre_github/test/test_helper.rb
@@ -2,3 +2,96 @@
 ENV["RAILS_ENV"] = "test"
 
 require_relative "../../../test/test_helper"
+require "collavre_github"
+require "webmock/minitest"
+# Allow net connections by default so other engines' tests are not affected.
+# collavre_github tests rely on explicit stub_request() calls to intercept GitHub API requests.
+WebMock.allow_net_connect!
+
+module CollavreGithubTestHelpers
+  def create_user(email: "user@example.com", name: "Test User")
+    Collavre.user_class.create!(
+      email: email,
+      name: name,
+      password: TEST_PASSWORD,
+      password_confirmation: TEST_PASSWORD,
+      timezone: "UTC"
+    )
+  end
+
+  def create_creative(user)
+    Collavre::Creative.create!(
+      description: "GitHub test creative",
+      progress: 0.0,
+      user: user
+    )
+  end
+
+  def create_github_account(user, login: "testuser", token: "ghp-test-token-123")
+    CollavreGithub::Account.create!(
+      user: user,
+      github_uid: "#{user.id}00001",
+      login: login,
+      name: user.name,
+      token: token,
+      avatar_url: "https://avatars.githubusercontent.com/u/#{user.id}"
+    )
+  end
+
+  # Stub GitHub organizations API (Octokit adds per_page=100 with auto_paginate)
+  def stub_github_organizations(orgs)
+    stub_request(:get, %r{https://api\.github\.com/user/orgs})
+      .to_return(
+        status: 200,
+        body: orgs.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+  end
+
+  # Stub GitHub user repositories API
+  def stub_github_user_repos(repos)
+    stub_request(:get, %r{https://api\.github\.com/user/repos})
+      .to_return(
+        status: 200,
+        body: repos.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+  end
+
+  # Stub GitHub org repositories API
+  def stub_github_org_repos(org, repos)
+    stub_request(:get, %r{https://api\.github\.com/orgs/#{org}/repos})
+      .to_return(
+        status: 200,
+        body: repos.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+  end
+
+  # Stub GitHub hooks API (for webhook provisioning)
+  def stub_github_hooks(repo, hooks: [])
+    stub_request(:get, %r{https://api\.github\.com/repos/#{Regexp.escape(repo)}/hooks})
+      .to_return(
+        status: 200,
+        body: hooks.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+  end
+
+  def stub_github_create_hook(repo)
+    stub_request(:post, "https://api.github.com/repos/#{repo}/hooks")
+      .to_return(
+        status: 201,
+        body: { id: rand(10000), active: true }.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+  end
+end
+
+class ActiveSupport::TestCase
+  include CollavreGithubTestHelpers
+end
+
+class ActionDispatch::SystemTestCase
+  include CollavreGithubTestHelpers
+end

--- a/env.template
+++ b/env.template
@@ -13,8 +13,10 @@ GEMINI_API_KEY=
 GEMINI_API_BASE=
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
-# GitHub mock mode for development (set both to enable mock):
-# GITHUB_MOCK=1
+# GitHub mock: auto-enabled in development when GITHUB_CLIENT_ID is blank.
+# Mock server runs via Procfile.dev (port 4567).
+# Set GITHUB_MOCK=0 to force disable, or GITHUB_API_ENDPOINT to override URL.
+# GITHUB_MOCK=0
 # GITHUB_API_ENDPOINT=http://localhost:4567
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=

--- a/env.template
+++ b/env.template
@@ -13,6 +13,9 @@ GEMINI_API_KEY=
 GEMINI_API_BASE=
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
+# GitHub mock mode for development (set both to enable mock):
+# GITHUB_MOCK=1
+# GITHUB_API_ENDPOINT=http://localhost:4567
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 # optional for fcm by service account credentials


### PR DESCRIPTION
## Summary

After GitHub OAuth callback, the popup window now stays open and continues with the full integration wizard instead of closing and returning to the parent window.

## Flow

```
Parent Window                          Popup Window
─────────────                          ────────────
1. Click 'Sign in with Github'  ──→   Opens popup
   (stores creative_id in session)
                                       2. GitHub OAuth flow
                                       3. Callback → redirect to /github/auth/setup
                                       4. Wizard: Select Organization
                                       5. Wizard: Select Repositories
                                       6. Save (PATCH /github/creatives/:id/integration)
                                       7. postMessage({type:'githubConnected'})
8. Receive message ←──────────────     8. Close popup
9. fetchStatus() to refresh UI
```

## Changes

### Controller
- `AuthController#callback`: redirects to setup page when creative_id is in session
- `AuthController#setup`: renders standalone popup wizard UI
- `AuthController#store_creative`: stores creative_id in session before OAuth popup

### Views
- New `setup.html.erb`: standalone wizard page (org → repos → summary → save → close)

### JavaScript
- `github_integration.js`: stores creative_id in session via API call before opening OAuth popup

### Routes
- `GET /github/auth/setup` - popup wizard page
- `POST /github/auth/store_creative` - session storage endpoint

### i18n
- Added `setup.loading` and `setup.close` keys (en + ko)

## Tests (21 new tests, WebMock-based)

Following the same pattern as `collavre_slack` tests:

- **AuthController** (6 tests): callback with/without creative_id, setup rendering, store_creative, token update
- **IntegrationsController** (10 tests): show, organizations (mock), repositories (mock + selected marking), update (link + replace), destroy
- **AccountsController** (5 tests): show, organizations, user/org repositories
- **Test helper**: WebMock + GitHub API stub helpers (`stub_github_organizations`, `stub_github_user_repos`, `stub_github_org_repos`, `stub_github_hooks`, `stub_github_create_hook`)

## Test Results

```
1335 runs, 4328 assertions, 0 failures, 0 errors, 0 skips
```
