### PR TITLE
feat: show inherited permissions in share modal with inline editing

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/popup.css
@@ -166,17 +166,25 @@
   100% { opacity: 0; }
 }
 
-.share-modal-permission-select {
+/* Override org-chart pill styles inside share modal */
+#share-creative-modal .share-modal-permission-select {
   width: auto;
-  padding: 0.35em 0.5em;
-  font-size: var(--text-1);
+  padding: 0.4em 1.5em 0.4em 0.5em;
+  font-size: 1rem;
+  min-height: 2.2em;
   border-radius: var(--radius-2);
-  min-height: 2em;
+  border: 1px solid var(--border-color);
+  background: var(--surface-input, var(--surface-bg));
+  color: var(--text-primary);
+  appearance: auto;
+  -webkit-appearance: menulist;
+  cursor: pointer;
 }
 
-.share-modal-permission-select[disabled] {
-  opacity: 0.7;
+#share-creative-modal .share-modal-permission-select[disabled] {
+  opacity: 0.6;
   cursor: default;
+  background: var(--surface-3, #333);
 }
 
 .share-inherited-link {

--- a/engines/collavre/app/assets/stylesheets/collavre/popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/popup.css
@@ -166,76 +166,14 @@
   100% { opacity: 0; }
 }
 
-/* Custom permission button + dropdown (avoids native select issues on mobile) */
-.share-perm-wrapper {
-  position: relative;
-  display: inline-block;
+.share-modal-permission-select {
+  width: auto;
 }
 
-.share-perm-btn {
-  padding: 0.3em 0.6em;
-  font-size: 16px;
-  border-radius: var(--radius-2);
-  border: 1px solid var(--border-color);
-  background: var(--surface-input, var(--surface-bg));
-  color: var(--text-primary);
-  cursor: pointer;
-  white-space: nowrap;
-  appearance: none;
-}
-
-.share-perm-btn::after {
-  content: ' ▾';
-  font-size: 0.7em;
-}
-
-.share-perm-dropdown {
-  position: absolute;
-  top: 100%;
-  left: 0;
-  z-index: 10;
-  background: var(--surface-section, var(--surface-bg));
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-2);
-  box-shadow: var(--shadow-3);
-  min-width: 140px;
-  padding: 0.25em 0;
-}
-
-.share-perm-option {
-  display: block;
-  width: 100%;
-  padding: 0.5em 0.75em;
-  font-size: 16px;
-  text-align: left;
-  border: none;
-  background: transparent;
-  color: var(--text-primary);
-  cursor: pointer;
-  white-space: nowrap;
-}
-
-.share-perm-option:hover,
-.share-perm-option:focus {
-  background: var(--surface-3, #f0f0f0);
-}
-
-.share-perm-badge {
-  padding: 0.3em 0.6em;
-  font-size: 16px;
-  border-radius: var(--radius-2);
-  border: 1px solid var(--border-color);
-  background: var(--surface-3, #eee);
-  color: var(--text-primary);
+.share-modal-permission-select[disabled] {
   opacity: 0.7;
-  white-space: nowrap;
+  cursor: default;
 }
-
-.share-perm-admin { color: var(--color-danger); font-weight: var(--weight-6); }
-.share-perm-write { color: var(--color-success); }
-.share-perm-feedback { color: var(--color-warning); }
-.share-perm-read { color: var(--text-muted); }
-.share-perm-no_access { color: var(--text-muted); opacity: 0.7; }
 
 .share-inherited-link {
   font-size: var(--text-0);

--- a/engines/collavre/app/assets/stylesheets/collavre/popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/popup.css
@@ -10,6 +10,10 @@
 }
 
 /* Share popup specific tweaks */
+#share-creative-modal .popup-box {
+  max-height: calc(100vh - 4em);
+  overflow-y: auto;
+}
 
 #share-creative-modal .share-grid {
   max-height: 30vh;

--- a/engines/collavre/app/assets/stylesheets/collavre/popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/popup.css
@@ -166,31 +166,76 @@
   100% { opacity: 0; }
 }
 
-.share-modal-permission-select {
-  width: auto;
-  padding: 0.4em 1.5em 0.4em 0.5em;
-  font-size: 16px; /* prevent iOS zoom on focus */
-  min-height: 2.2em;
+/* Custom permission button + dropdown (avoids native select issues on mobile) */
+.share-perm-wrapper {
+  position: relative;
+  display: inline-block;
+}
+
+.share-perm-btn {
+  padding: 0.3em 0.6em;
+  font-size: 16px;
   border-radius: var(--radius-2);
   border: 1px solid var(--border-color);
   background: var(--surface-input, var(--surface-bg));
   color: var(--text-primary);
-  appearance: auto;
-  -webkit-appearance: menulist;
   cursor: pointer;
+  white-space: nowrap;
+  appearance: none;
 }
 
-.share-modal-permission-select[disabled] {
-  opacity: 0.6;
-  cursor: default;
+.share-perm-btn::after {
+  content: ' ▾';
+  font-size: 0.7em;
+}
+
+.share-perm-dropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  z-index: 10;
+  background: var(--surface-section, var(--surface-bg));
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-2);
+  box-shadow: var(--shadow-3);
+  min-width: 140px;
+  padding: 0.25em 0;
+}
+
+.share-perm-option {
+  display: block;
+  width: 100%;
+  padding: 0.5em 0.75em;
+  font-size: 16px;
+  text-align: left;
+  border: none;
+  background: transparent;
+  color: var(--text-primary);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.share-perm-option:hover,
+.share-perm-option:focus {
+  background: var(--surface-3, #f0f0f0);
+}
+
+.share-perm-badge {
+  padding: 0.3em 0.6em;
+  font-size: 16px;
+  border-radius: var(--radius-2);
+  border: 1px solid var(--border-color);
   background: var(--surface-3, #eee);
+  color: var(--text-primary);
+  opacity: 0.7;
+  white-space: nowrap;
 }
 
-.share-modal-permission-admin { color: var(--color-danger); font-weight: var(--weight-6); }
-.share-modal-permission-write { color: var(--color-success); }
-.share-modal-permission-feedback { color: var(--color-warning); }
-.share-modal-permission-read { color: var(--text-muted); }
-.share-modal-permission-no_access { color: var(--text-muted); opacity: 0.7; }
+.share-perm-admin { color: var(--color-danger); font-weight: var(--weight-6); }
+.share-perm-write { color: var(--color-success); }
+.share-perm-feedback { color: var(--color-warning); }
+.share-perm-read { color: var(--text-muted); }
+.share-perm-no_access { color: var(--text-muted); opacity: 0.7; }
 
 .share-inherited-link {
   font-size: var(--text-0);

--- a/engines/collavre/app/assets/stylesheets/collavre/popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/popup.css
@@ -228,6 +228,7 @@
   margin-left: 0.3em;
   vertical-align: middle;
 }
+
 .share-modal-spinner {
   display: inline-block;
   width: 12px;

--- a/engines/collavre/app/assets/stylesheets/collavre/popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/popup.css
@@ -188,6 +188,19 @@
   color: var(--text-link);
 }
 
+.share-inherited-short {
+  display: none;
+}
+
+@media (max-width: 768px) {
+  .share-inherited-short {
+    display: inline;
+  }
+  .share-inherited-full {
+    display: none;
+  }
+}
+
 .share-modal-pending {
   opacity: 0.6;
 }

--- a/engines/collavre/app/assets/stylesheets/collavre/popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/popup.css
@@ -219,13 +219,10 @@
 .share-pending-badge {
   display: inline-block;
   font-size: var(--text-00);
-  color: var(--text-on-badge);
-  background: var(--text-muted);
-  padding: 0.15em 0.4em;
-  border-radius: var(--radius-2, 4px);
+  color: var(--color-warning);
+  font-weight: var(--weight-5);
   margin-left: 0.3em;
   vertical-align: middle;
-  line-height: 1.4;
 }
 .share-modal-spinner {
   display: inline-block;

--- a/engines/collavre/app/assets/stylesheets/collavre/popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/popup.css
@@ -10,18 +10,6 @@
 }
 
 /* Share popup specific tweaks */
-#share-creative-modal {
-  align-items: flex-start !important;
-  overflow-y: auto;
-  padding: 1em 0;
-}
-
-#share-creative-modal .popup-box {
-  max-height: calc(100vh - 2em);
-  overflow-y: auto;
-  margin: auto;
-  flex-shrink: 0;
-}
 
 #share-creative-modal .share-grid {
   max-height: 30vh;

--- a/engines/collavre/app/assets/stylesheets/collavre/popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/popup.css
@@ -211,6 +211,21 @@
 .share-modal-pending {
   opacity: 0.6;
 }
+
+.share-pending-item {
+  opacity: 0.7;
+}
+
+.share-pending-badge {
+  display: inline-block;
+  font-size: 0.75em;
+  color: var(--text-muted);
+  background: var(--surface-3, #eee);
+  padding: 0.1em 0.4em;
+  border-radius: var(--radius-2, 4px);
+  margin-left: 0.3em;
+  vertical-align: middle;
+}
 .share-modal-spinner {
   display: inline-block;
   width: 12px;

--- a/engines/collavre/app/assets/stylesheets/collavre/popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/popup.css
@@ -168,9 +168,10 @@
 
 .share-modal-permission-select {
   width: auto;
-  padding: 0.15em 0.3em;
-  font-size: var(--text-0);
-  border-radius: var(--radius-1);
+  padding: 0.35em 0.5em;
+  font-size: var(--text-1);
+  border-radius: var(--radius-2);
+  min-height: 2em;
 }
 
 .share-modal-permission-select[disabled] {

--- a/engines/collavre/app/assets/stylesheets/collavre/popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/popup.css
@@ -13,11 +13,24 @@
 #share-creative-modal .popup-box {
   max-height: 80vh;
   overflow-y: auto;
+  margin: auto;
 }
 
 #share-creative-modal .share-grid {
   max-height: 40vh;
   overflow-y: auto;
+}
+
+@media (max-width: 768px) {
+  #share-creative-modal .popup-box {
+    max-height: calc(100vh - 2em);
+    max-width: calc(100vw - 1em) !important;
+    margin: 1em auto;
+  }
+
+  #share-creative-modal .share-grid {
+    max-height: 35vh;
+  }
 }
 
 /* Ensure autocomplete popup inside share modal works without mention_menu.css */

--- a/engines/collavre/app/assets/stylesheets/collavre/popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/popup.css
@@ -10,10 +10,17 @@
 }
 
 /* Share popup specific tweaks */
+#share-creative-modal {
+  align-items: flex-start !important;
+  overflow-y: auto;
+  padding: 1em 0;
+}
+
 #share-creative-modal .popup-box {
   max-height: calc(100vh - 2em);
   overflow-y: auto;
-  margin: 1em auto;
+  margin: auto;
+  flex-shrink: 0;
 }
 
 #share-creative-modal .share-grid {

--- a/engines/collavre/app/assets/stylesheets/collavre/popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/popup.css
@@ -199,6 +199,27 @@
   .share-inherited-full {
     display: none;
   }
+
+  .share-grid li {
+    grid-template-columns: auto 1fr auto;
+    grid-template-rows: auto auto;
+    gap: 0.3em;
+  }
+
+  .share-grid li > span:nth-child(3) {
+    grid-column: 1 / -1;
+  }
+
+  .share-grid li > span:nth-child(4) {
+    grid-column: 1 / -1;
+    justify-self: start;
+  }
+
+  .share-modal-permission-select {
+    width: 100%;
+    padding: 0.4em 0.5em;
+    font-size: var(--text-1);
+  }
 }
 
 .share-modal-pending {

--- a/engines/collavre/app/assets/stylesheets/collavre/popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/popup.css
@@ -199,27 +199,6 @@
   .share-inherited-full {
     display: none;
   }
-
-  .share-grid li {
-    grid-template-columns: auto 1fr auto;
-    grid-template-rows: auto auto;
-    gap: 0.3em;
-  }
-
-  .share-grid li > span:nth-child(3) {
-    grid-column: 1 / -1;
-  }
-
-  .share-grid li > span:nth-child(4) {
-    grid-column: 1 / -1;
-    justify-self: start;
-  }
-
-  .share-modal-permission-select {
-    width: 100%;
-    padding: 0.4em 0.5em;
-    font-size: var(--text-1);
-  }
 }
 
 .share-modal-pending {

--- a/engines/collavre/app/assets/stylesheets/collavre/popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/popup.css
@@ -102,7 +102,7 @@
 }
 
 .popup-box input:not([type="radio"]):not([type="checkbox"]),
-.popup-box select {
+.popup-box select:not(.share-modal-permission-select) {
   width: 100%;
   box-sizing: border-box;
 }
@@ -164,6 +164,28 @@
 @keyframes share-modal-message-fade {
   0%, 80% { opacity: 1; }
   100% { opacity: 0; }
+}
+
+.share-modal-permission-select {
+  width: auto;
+  padding: 0.15em 0.3em;
+  font-size: var(--text-0);
+  border-radius: var(--radius-1);
+}
+
+.share-modal-permission-select[disabled] {
+  opacity: 0.7;
+  cursor: default;
+}
+
+.share-inherited-link {
+  font-size: var(--text-0);
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.share-inherited-link:hover {
+  color: var(--text-link);
 }
 
 .share-modal-pending {

--- a/engines/collavre/app/assets/stylesheets/collavre/popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/popup.css
@@ -11,25 +11,23 @@
 
 /* Share popup specific tweaks */
 #share-creative-modal .popup-box {
-  max-height: 80vh;
+  max-height: calc(100vh - 2em);
   overflow-y: auto;
-  margin: auto;
+  margin: 1em auto;
 }
 
 #share-creative-modal .share-grid {
-  max-height: 40vh;
+  max-height: 30vh;
   overflow-y: auto;
 }
 
 @media (max-width: 768px) {
   #share-creative-modal .popup-box {
-    max-height: calc(100vh - 2em);
     max-width: calc(100vw - 1em) !important;
-    margin: 1em auto;
   }
 
   #share-creative-modal .share-grid {
-    max-height: 35vh;
+    max-height: 25vh;
   }
 }
 

--- a/engines/collavre/app/assets/stylesheets/collavre/popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/popup.css
@@ -212,6 +212,10 @@
   opacity: 0.6;
 }
 
+.share-inherited-item {
+  opacity: 0.8;
+}
+
 .share-pending-item {
   opacity: 0.7;
 }

--- a/engines/collavre/app/assets/stylesheets/collavre/popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/popup.css
@@ -166,11 +166,10 @@
   100% { opacity: 0; }
 }
 
-/* Override org-chart pill styles inside share modal */
-#share-creative-modal .share-modal-permission-select {
+.share-modal-permission-select {
   width: auto;
   padding: 0.4em 1.5em 0.4em 0.5em;
-  font-size: 1rem;
+  font-size: 16px; /* prevent iOS zoom on focus */
   min-height: 2.2em;
   border-radius: var(--radius-2);
   border: 1px solid var(--border-color);
@@ -181,11 +180,17 @@
   cursor: pointer;
 }
 
-#share-creative-modal .share-modal-permission-select[disabled] {
+.share-modal-permission-select[disabled] {
   opacity: 0.6;
   cursor: default;
-  background: var(--surface-3, #333);
+  background: var(--surface-3, #eee);
 }
+
+.share-modal-permission-admin { color: var(--color-danger); font-weight: var(--weight-6); }
+.share-modal-permission-write { color: var(--color-success); }
+.share-modal-permission-feedback { color: var(--color-warning); }
+.share-modal-permission-read { color: var(--text-muted); }
+.share-modal-permission-no_access { color: var(--text-muted); opacity: 0.7; }
 
 .share-inherited-link {
   font-size: var(--text-0);

--- a/engines/collavre/app/assets/stylesheets/collavre/popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/popup.css
@@ -218,13 +218,14 @@
 
 .share-pending-badge {
   display: inline-block;
-  font-size: 0.75em;
-  color: var(--text-muted);
-  background: var(--surface-3, #eee);
-  padding: 0.1em 0.4em;
+  font-size: var(--text-00);
+  color: var(--text-on-badge);
+  background: var(--text-muted);
+  padding: 0.15em 0.4em;
   border-radius: var(--radius-2, 4px);
   margin-left: 0.3em;
   vertical-align: middle;
+  line-height: 1.4;
 }
 .share-modal-spinner {
   display: inline-block;

--- a/engines/collavre/app/controllers/collavre/creative_shares_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creative_shares_controller.rb
@@ -9,6 +9,9 @@ module Collavre
       @shared_list = CreativeShare.where(creative: @creative)
                                   .includes(user: [ avatar_attachment: :blob ])
 
+      # Build inherited shares from ancestor creatives
+      @inherited_shares = build_inherited_shares(@creative)
+
       @pending_invitations = Invitation.where(creative: @creative, accepted_at: nil)
                                        .where("expires_at > ?", Time.current)
                                        .order(created_at: :desc)
@@ -150,6 +153,30 @@ module Collavre
 
       def all_descendants(creative)
         creative.children.flat_map { |child| [ child ] + all_descendants(child) }
+      end
+
+      # Returns inherited shares from ancestor creatives.
+      # Each entry is a hash with :share, :source_creative keys.
+      # Only includes the closest (most specific) share per user.
+      def build_inherited_shares(creative)
+        ancestors = creative.ancestors
+        return [] if ancestors.empty?
+
+        ancestor_ids = ancestors.pluck(:id)
+        direct_user_ids = CreativeShare.where(creative: creative).pluck(:user_id).compact
+
+        ancestor_shares = CreativeShare
+          .where(creative_id: ancestor_ids)
+          .where.not(user_id: direct_user_ids) # Exclude users who already have direct shares
+          .includes(:creative, user: [ avatar_attachment: :blob ])
+
+        # Group by user_id and pick the closest ancestor share
+        ancestor_shares.group_by(&:user_id).filter_map do |_user_id, shares|
+          closest = CreativeShare.closest_parent_share(ancestor_ids, shares)
+          next unless closest && closest.permission != "no_access"
+
+          { share: closest, source_creative: closest.creative }
+        end
       end
   end
 end

--- a/engines/collavre/app/javascript/controllers/comments/popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_controller.js
@@ -387,6 +387,12 @@ export default class extends Controller {
 
   handleTouchStart(event) {
     if (!this.isMobile()) return
+    // Ignore swipe when share modal is open
+    const shareModal = document.getElementById("share-creative-modal")
+    if (shareModal && shareModal.style.display === "flex") {
+      this.touchStartY = null
+      return
+    }
     if (!event.target.closest('#comments-list')) {
       this.touchStartY = event.touches[0].clientY
     } else {

--- a/engines/collavre/app/javascript/controllers/share_modal_controller.js
+++ b/engines/collavre/app/javascript/controllers/share_modal_controller.js
@@ -109,6 +109,7 @@ export default class extends Controller {
     }
 
     this.#initializeForm()
+    this.#initializePermissionSelects()
     this.#initializeDeleteButtons()
     this.#initializeInviteLink()
   }
@@ -209,6 +210,40 @@ export default class extends Controller {
     li.append(avatarSpan, emailSpan, permSpan, spinnerSpan)
     listSection.appendChild(li)
     return li
+  }
+
+  #initializePermissionSelects() {
+    const modal = document.getElementById("share-creative-modal")
+    if (!modal) return
+
+    const selects = modal.querySelectorAll(".share-modal-permission-select:not([disabled])")
+    selects.forEach(select => {
+      select.addEventListener("change", (e) => {
+        const url = select.dataset.updateUrl
+        const permission = select.value
+        const originalClass = select.className
+
+        // Update visual class immediately
+        select.className = select.className.replace(/org-chart-permission-\w+/g, "")
+        select.classList.add("org-chart-permission-select", "share-modal-permission-select", `org-chart-permission-${permission}`)
+
+        fetch(url, {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+            "X-CSRF-Token": document.querySelector("meta[name='csrf-token']")?.content,
+            "Accept": "application/json"
+          },
+          body: JSON.stringify({ permission })
+        }).then(response => {
+          if (!response.ok) throw new Error("Failed")
+          this.#showMessage(null, "success") // silent success
+        }).catch(() => {
+          select.className = originalClass
+          this.#showMessage(this.#errorFallbackMessage, "error")
+        })
+      })
+    })
   }
 
   #initializeDeleteButtons() {

--- a/engines/collavre/app/javascript/controllers/share_modal_controller.js
+++ b/engines/collavre/app/javascript/controllers/share_modal_controller.js
@@ -216,46 +216,58 @@ export default class extends Controller {
     const modal = document.getElementById("share-creative-modal")
     if (!modal) return
 
-    // Fix mobile native picker positioning inside position:fixed modal
-    const allSelects = modal.querySelectorAll(".share-modal-permission-select")
-    allSelects.forEach(select => {
-      select.addEventListener("focus", () => {
-        // Temporarily switch to absolute positioning so mobile browser
-        // can correctly anchor the native picker to the select element
-        modal.style.position = "absolute"
-        modal.style.top = window.scrollY + "px"
-      })
-      select.addEventListener("blur", () => {
-        modal.style.position = "fixed"
-        modal.style.top = "0"
-      })
+    // Close any open dropdown when clicking outside
+    modal.addEventListener("click", (e) => {
+      if (!e.target.closest(".share-perm-wrapper")) {
+        modal.querySelectorAll(".share-perm-dropdown").forEach(d => d.style.display = "none")
+      }
     })
 
-    const selects = modal.querySelectorAll(".share-modal-permission-select:not([disabled])")
-    selects.forEach(select => {
-      select.addEventListener("change", (e) => {
-        const url = select.dataset.updateUrl
-        const permission = select.value
-        const originalClass = select.className
+    const buttons = modal.querySelectorAll(".share-perm-btn")
+    buttons.forEach(btn => {
+      const wrapper = btn.closest(".share-perm-wrapper")
+      const dropdown = wrapper.querySelector(".share-perm-dropdown")
 
-        // Update visual class immediately
-        select.className = select.className.replace(/share-modal-permission-\w+/g, "")
-        select.classList.add("share-modal-permission-select", `share-modal-permission-${permission}`)
+      // Toggle dropdown on button click
+      btn.addEventListener("click", (e) => {
+        e.stopPropagation()
+        // Close other dropdowns
+        modal.querySelectorAll(".share-perm-dropdown").forEach(d => {
+          if (d !== dropdown) d.style.display = "none"
+        })
+        dropdown.style.display = dropdown.style.display === "none" ? "block" : "none"
+      })
 
-        fetch(url, {
-          method: "PATCH",
-          headers: {
-            "Content-Type": "application/json",
-            "X-CSRF-Token": document.querySelector("meta[name='csrf-token']")?.content,
-            "Accept": "application/json"
-          },
-          body: JSON.stringify({ permission })
-        }).then(response => {
-          if (!response.ok) throw new Error("Failed")
-          this.#showMessage(null, "success") // silent success
-        }).catch(() => {
-          select.className = originalClass
-          this.#showMessage(this.#errorFallbackMessage, "error")
+      // Handle option selection
+      dropdown.querySelectorAll(".share-perm-option").forEach(option => {
+        option.addEventListener("click", (e) => {
+          e.stopPropagation()
+          const permission = option.dataset.value
+          const url = btn.dataset.updateUrl
+          const originalText = btn.textContent
+          const originalClass = btn.className
+
+          // Update button immediately
+          btn.textContent = option.textContent.trim()
+          btn.className = `share-perm-btn share-perm-${permission}`
+          btn.dataset.current = permission
+          dropdown.style.display = "none"
+
+          fetch(url, {
+            method: "PATCH",
+            headers: {
+              "Content-Type": "application/json",
+              "X-CSRF-Token": document.querySelector("meta[name='csrf-token']")?.content,
+              "Accept": "application/json"
+            },
+            body: JSON.stringify({ permission })
+          }).then(response => {
+            if (!response.ok) throw new Error("Failed")
+          }).catch(() => {
+            btn.textContent = originalText
+            btn.className = originalClass
+            this.#showMessage(this.#errorFallbackMessage, "error")
+          })
         })
       })
     })

--- a/engines/collavre/app/javascript/controllers/share_modal_controller.js
+++ b/engines/collavre/app/javascript/controllers/share_modal_controller.js
@@ -121,6 +121,12 @@ export default class extends Controller {
     const popupBox = modal.querySelector(".popup-box")
     if (!popupBox) return
 
+    // Ensure the overlay is properly styled for centering
+    modal.style.display = "flex"
+    modal.style.alignItems = "center"
+    modal.style.justifyContent = "center"
+
+    // Constrain popup-box height to viewport
     const maxH = window.innerHeight - 32 // 16px margin top + bottom
     popupBox.style.maxHeight = `${maxH}px`
     popupBox.style.overflowY = "auto"

--- a/engines/collavre/app/javascript/controllers/share_modal_controller.js
+++ b/engines/collavre/app/javascript/controllers/share_modal_controller.js
@@ -99,6 +99,9 @@ export default class extends Controller {
     modal.style.display = "flex"
     document.body.classList.add("no-scroll")
 
+    // Constrain popup-box within viewport
+    this.#constrainModalHeight(modal)
+
     const closeBtn = document.getElementById("close-share-modal")
     if (closeBtn) {
       closeBtn.onclick = () => this.close()
@@ -112,6 +115,15 @@ export default class extends Controller {
     this.#initializePermissionSelects()
     this.#initializeDeleteButtons()
     this.#initializeInviteLink()
+  }
+
+  #constrainModalHeight(modal) {
+    const popupBox = modal.querySelector(".popup-box")
+    if (!popupBox) return
+
+    const maxH = window.innerHeight - 32 // 16px margin top + bottom
+    popupBox.style.maxHeight = `${maxH}px`
+    popupBox.style.overflowY = "auto"
   }
 
   #initializeForm() {

--- a/engines/collavre/app/javascript/controllers/share_modal_controller.js
+++ b/engines/collavre/app/javascript/controllers/share_modal_controller.js
@@ -224,8 +224,8 @@ export default class extends Controller {
         const originalClass = select.className
 
         // Update visual class immediately
-        select.className = select.className.replace(/org-chart-permission-\w+/g, "")
-        select.classList.add("org-chart-permission-select", "share-modal-permission-select", `org-chart-permission-${permission}`)
+        select.className = select.className.replace(/share-modal-permission-\w+/g, "")
+        select.classList.add("share-modal-permission-select", `share-modal-permission-${permission}`)
 
         fetch(url, {
           method: "PATCH",

--- a/engines/collavre/app/javascript/controllers/share_modal_controller.js
+++ b/engines/collavre/app/javascript/controllers/share_modal_controller.js
@@ -216,6 +216,21 @@ export default class extends Controller {
     const modal = document.getElementById("share-creative-modal")
     if (!modal) return
 
+    // Fix mobile native picker positioning inside position:fixed modal
+    const allSelects = modal.querySelectorAll(".share-modal-permission-select")
+    allSelects.forEach(select => {
+      select.addEventListener("focus", () => {
+        // Temporarily switch to absolute positioning so mobile browser
+        // can correctly anchor the native picker to the select element
+        modal.style.position = "absolute"
+        modal.style.top = window.scrollY + "px"
+      })
+      select.addEventListener("blur", () => {
+        modal.style.position = "fixed"
+        modal.style.top = "0"
+      })
+    })
+
     const selects = modal.querySelectorAll(".share-modal-permission-select:not([disabled])")
     selects.forEach(select => {
       select.addEventListener("change", (e) => {

--- a/engines/collavre/app/javascript/controllers/share_modal_controller.js
+++ b/engines/collavre/app/javascript/controllers/share_modal_controller.js
@@ -216,58 +216,30 @@ export default class extends Controller {
     const modal = document.getElementById("share-creative-modal")
     if (!modal) return
 
-    // Close any open dropdown when clicking outside
-    modal.addEventListener("click", (e) => {
-      if (!e.target.closest(".share-perm-wrapper")) {
-        modal.querySelectorAll(".share-perm-dropdown").forEach(d => d.style.display = "none")
-      }
-    })
+    const selects = modal.querySelectorAll(".share-modal-permission-select:not([disabled])")
+    selects.forEach(select => {
+      select.addEventListener("change", () => {
+        const url = select.dataset.updateUrl
+        const permission = select.value
+        const originalClass = select.className
 
-    const buttons = modal.querySelectorAll(".share-perm-btn")
-    buttons.forEach(btn => {
-      const wrapper = btn.closest(".share-perm-wrapper")
-      const dropdown = wrapper.querySelector(".share-perm-dropdown")
+        // Update visual class immediately
+        select.className = select.className.replace(/org-chart-permission-\w+/g, "")
+        select.classList.add("org-chart-permission-select", "share-modal-permission-select", `org-chart-permission-${permission}`)
 
-      // Toggle dropdown on button click
-      btn.addEventListener("click", (e) => {
-        e.stopPropagation()
-        // Close other dropdowns
-        modal.querySelectorAll(".share-perm-dropdown").forEach(d => {
-          if (d !== dropdown) d.style.display = "none"
-        })
-        dropdown.style.display = dropdown.style.display === "none" ? "block" : "none"
-      })
-
-      // Handle option selection
-      dropdown.querySelectorAll(".share-perm-option").forEach(option => {
-        option.addEventListener("click", (e) => {
-          e.stopPropagation()
-          const permission = option.dataset.value
-          const url = btn.dataset.updateUrl
-          const originalText = btn.textContent
-          const originalClass = btn.className
-
-          // Update button immediately
-          btn.textContent = option.textContent.trim()
-          btn.className = `share-perm-btn share-perm-${permission}`
-          btn.dataset.current = permission
-          dropdown.style.display = "none"
-
-          fetch(url, {
-            method: "PATCH",
-            headers: {
-              "Content-Type": "application/json",
-              "X-CSRF-Token": document.querySelector("meta[name='csrf-token']")?.content,
-              "Accept": "application/json"
-            },
-            body: JSON.stringify({ permission })
-          }).then(response => {
-            if (!response.ok) throw new Error("Failed")
-          }).catch(() => {
-            btn.textContent = originalText
-            btn.className = originalClass
-            this.#showMessage(this.#errorFallbackMessage, "error")
-          })
+        fetch(url, {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+            "X-CSRF-Token": document.querySelector("meta[name='csrf-token']")?.content,
+            "Accept": "application/json"
+          },
+          body: JSON.stringify({ permission })
+        }).then(response => {
+          if (!response.ok) throw new Error("Failed")
+        }).catch(() => {
+          select.className = originalClass
+          this.#showMessage(this.#errorFallbackMessage, "error")
         })
       })
     })

--- a/engines/collavre/app/javascript/controllers/share_modal_controller.js
+++ b/engines/collavre/app/javascript/controllers/share_modal_controller.js
@@ -111,6 +111,11 @@ export default class extends Controller {
       if (e.target === modal) this.close()
     }
 
+    // Prevent touch events from propagating to underlying elements (e.g., chat swipe-to-close)
+    modal.addEventListener("touchstart", (e) => e.stopPropagation(), { passive: true })
+    modal.addEventListener("touchmove", (e) => e.stopPropagation(), { passive: true })
+    modal.addEventListener("touchend", (e) => e.stopPropagation(), { passive: true })
+
     this.#initializeForm()
     this.#initializePermissionSelects()
     this.#initializeDeleteButtons()

--- a/engines/collavre/app/views/collavre/creatives/_share_modal.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_share_modal.html.erb
@@ -1,6 +1,6 @@
 <!-- Share Creative Modal -->
-<div id="share-creative-modal" style="display:none;position:fixed;top:0;left:0;width:100vw;height:100vh;z-index:10000;align-items:center;justify-content:center;overflow-y:auto;" data-creative-id="<%= (@parent_creative || @creative).id %>" data-error-message="<%= t('collavre.creatives.share.network_error') %>">
-  <div class="popup-box" style="min-width:320px;max-width:90vw;">
+<div id="share-creative-modal" style="display:none;position:fixed;top:0;left:0;width:100vw;height:100vh;z-index:10000;justify-content:center;overflow-y:auto;padding:1em 0;" data-creative-id="<%= (@parent_creative || @creative).id %>" data-error-message="<%= t('collavre.creatives.share.network_error') %>">
+  <div class="popup-box" style="min-width:320px;max-width:90vw;max-height:calc(100vh - 2em);overflow-y:auto;margin:auto;flex-shrink:0;">
     <button type="button" id="close-share-modal" class="popup-close-btn">&times;</button>
     <h2><%= t('collavre.creatives.index.share_creative') %></h2>
     <form id="share-creative-form" action="<%= collavre.creative_creative_shares_path(@parent_creative || @creative) %>" method="post" data-controller="share-invite">

--- a/engines/collavre/app/views/collavre/creatives/_share_modal.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_share_modal.html.erb
@@ -80,10 +80,11 @@
                 </select>
               </span>
               <span>
-                <% source_name = ActionController::Base.helpers.strip_tags(source.effective_description.to_s).truncate(30) %>
-                <%= link_to t('collavre.creatives.share.inherited_from', name: source_name),
-                    collavre.creative_path(source),
-                    class: 'share-inherited-link' %>
+                <% source_name = source.creative_snippet %>
+                <%= link_to collavre.creative_path(source), class: 'share-inherited-link' do %>
+                  <span class="share-inherited-short"><%= t('collavre.creatives.share.inherited_short') %></span>
+                  <span class="share-inherited-full"><%= t('collavre.creatives.share.inherited_from', name: source_name) %></span>
+                <% end %>
               </span>
             </li>
           <% end %>

--- a/engines/collavre/app/views/collavre/creatives/_share_modal.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_share_modal.html.erb
@@ -21,7 +21,7 @@
         <select name="permission" id="share-permission">
           <option value="no_access"><%= t('collavre.creatives.index.permission_no_access') %></option>
           <option value="read"><%= t('collavre.creatives.index.permission_read') %></option>
-          <option value="feedback"><%= t('collavre.creatives.index.permission_feedback') %></option>
+          <option value="feedback" selected><%= t('collavre.creatives.index.permission_feedback') %></option>
           <option value="write"><%= t('collavre.creatives.index.permission_write') %></option>
           <option value="admin"><%= t('collavre.creatives.index.permission_admin') %></option>
         </select>
@@ -39,9 +39,51 @@
                 <%= render Collavre::AvatarComponent.new(user: share.user, size: 20, classes: 'avatar share-avatar') %>
               </span>
               <span><%= share.user&.display_name || (share.user_id.nil? ? t('collavre.creatives.index.public_share') : t('collavre.creatives.index.unknown_user')) %></span>
-              <span><%= t("collavre.creatives.index.permission_#{share.permission}") %></span>
+              <span>
+                <select class="org-chart-permission-select org-chart-permission-<%= share.permission %> share-modal-permission-select"
+                        data-share-id="<%= share.id %>"
+                        data-update-url="<%= collavre.creative_creative_share_path(@parent_creative || @creative, share) %>">
+                  <% %w[admin write feedback read no_access].each do |perm| %>
+                    <option value="<%= perm %>" <%= 'selected' if share.permission == perm %>>
+                      <%= t("collavre.contacts.org_chart.permissions.#{perm}") %>
+                    </option>
+                  <% end %>
+                </select>
+              </span>
               <span>
                 <%= button_to '×', collavre.creative_creative_share_path(@parent_creative || @creative, share), method: :delete, form: { data: { turbo_confirm: t('collavre.creatives.index.are_you_sure_delete_share') } }, class: 'delete-share-btn' %>
+              </span>
+            </li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+    <% if @inherited_shares.present? && @inherited_shares.any? %>
+      <div style="margin-top:1em;">
+        <strong><%= t('collavre.creatives.share.inherited_permissions') %>:</strong>
+        <ul class="share-grid">
+          <% @inherited_shares.each do |entry| %>
+            <% share = entry[:share] %>
+            <% source = entry[:source_creative] %>
+            <li>
+              <span>
+                <%= render Collavre::AvatarComponent.new(user: share.user, size: 20, classes: 'avatar share-avatar') %>
+              </span>
+              <span><%= share.user&.display_name || t('collavre.creatives.index.unknown_user') %></span>
+              <span>
+                <select class="org-chart-permission-select org-chart-permission-<%= share.permission %> share-modal-permission-select" disabled>
+                  <% %w[admin write feedback read no_access].each do |perm| %>
+                    <option value="<%= perm %>" <%= 'selected' if share.permission == perm %>>
+                      <%= t("collavre.contacts.org_chart.permissions.#{perm}") %>
+                    </option>
+                  <% end %>
+                </select>
+              </span>
+              <span>
+                <% source_name = ActionController::Base.helpers.strip_tags(source.effective_description.to_s).truncate(30) %>
+                <%= link_to t('collavre.creatives.share.inherited_from', name: source_name),
+                    collavre.creative_path(source),
+                    class: 'share-inherited-link' %>
               </span>
             </li>
           <% end %>

--- a/engines/collavre/app/views/collavre/creatives/_share_modal.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_share_modal.html.erb
@@ -1,5 +1,5 @@
 <!-- Share Creative Modal -->
-<div id="share-creative-modal" style="display:none;position:fixed;top:0;left:0;width:100vw;height:100vh;z-index:10000;align-items:center;justify-content:center;" data-creative-id="<%= (@parent_creative || @creative).id %>" data-error-message="<%= t('collavre.creatives.share.network_error') %>">
+<div id="share-creative-modal" style="display:none;position:fixed;top:0;left:0;right:0;bottom:0;z-index:10000;align-items:center;justify-content:center;background:rgba(0,0,0,0.3);" data-creative-id="<%= (@parent_creative || @creative).id %>" data-error-message="<%= t('collavre.creatives.share.network_error') %>">
   <div class="popup-box" style="min-width:320px;max-width:90vw;">
     <button type="button" id="close-share-modal" class="popup-close-btn">&times;</button>
     <h2><%= t('collavre.creatives.index.share_creative') %></h2>

--- a/engines/collavre/app/views/collavre/creatives/_share_modal.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_share_modal.html.erb
@@ -29,11 +29,12 @@
       <button type="submit" class="btn btn-primary" data-share-invite-target="submit" data-share="<%= t('collavre.creatives.index.share') %>" data-invite="<%= t('collavre.creatives.index.invite') %>"><%= t('collavre.creatives.index.share') %></button>
       <button type="button" id="creative-invite-link" class="btn btn-secondary" data-creative-id="<%= (@parent_creative || @creative).id %>" data-no-access-message="<%= t('collavre.creatives.index.invite_link_no_access') %>" data-copied-template="<%= t('collavre.creatives.index.invite_link_copied_permission', permission: '__PERMISSION__') %>"><%= t('collavre.creatives.index.invite_link') %></button>
     </form>
-    <% has_shares = @shared_list.any? || (defined?(@pending_invitations) && @pending_invitations.any?) %>
-    <% if has_shares %>
+    <% has_any_shares = @shared_list.any? || (defined?(@pending_invitations) && @pending_invitations.any?) || @inherited_shares.any? %>
+    <% if has_any_shares %>
       <div style="margin-top:1em;">
         <strong><%= t('collavre.creatives.index.shared_with') %>:</strong>
         <ul class="share-grid">
+          <%# Direct shares %>
           <% @shared_list.each do |share| %>
             <li>
               <span>
@@ -56,6 +57,39 @@
               </span>
             </li>
           <% end %>
+          <%# Inherited shares %>
+          <% @inherited_shares.each do |entry| %>
+            <% share = entry[:share] %>
+            <% source = entry[:source_creative] %>
+            <li class="share-inherited-item">
+              <span>
+                <% if share.user %>
+                  <%= render Collavre::AvatarComponent.new(user: share.user, size: 20, classes: 'avatar share-avatar') %>
+                <% else %>
+                  <span class="avatar share-avatar" style="display:inline-block;width:20px;height:20px;border-radius:50%;background:var(--surface-3,#ddd);text-align:center;line-height:20px;font-size:10px;">🌐</span>
+                <% end %>
+              </span>
+              <span>
+                <%= share.user&.display_name || t('collavre.creatives.index.public_share') %>
+                <% source_name = source.creative_snippet %>
+                <%= link_to collavre.creative_path(source), class: 'share-inherited-link' do %>
+                  <span class="share-inherited-short"><%= t('collavre.creatives.share.inherited_short') %></span>
+                  <span class="share-inherited-full"><%= t('collavre.creatives.share.inherited_from', name: source_name) %></span>
+                <% end %>
+              </span>
+              <span>
+                <select class="org-chart-permission-select org-chart-permission-<%= share.permission %> share-modal-permission-select" disabled>
+                  <% %w[admin write feedback read no_access].each do |perm| %>
+                    <option value="<%= perm %>" <%= 'selected' if share.permission == perm %>>
+                      <%= t("collavre.contacts.org_chart.permissions.#{perm}") %>
+                    </option>
+                  <% end %>
+                </select>
+              </span>
+              <span></span>
+            </li>
+          <% end %>
+          <%# Pending invitations %>
           <% if defined?(@pending_invitations) && @pending_invitations.any? %>
             <% @pending_invitations.each do |invitation| %>
               <li class="share-pending-item">
@@ -83,43 +117,6 @@
                 </span>
               </li>
             <% end %>
-          <% end %>
-        </ul>
-      </div>
-    <% end %>
-    <% if @inherited_shares.any? %>
-      <div style="margin-top:1em;">
-        <strong><%= t('collavre.creatives.share.inherited_permissions') %>:</strong>
-        <ul class="share-grid">
-          <% @inherited_shares.each do |entry| %>
-            <% share = entry[:share] %>
-            <% source = entry[:source_creative] %>
-            <li>
-              <span>
-                <% if share.user %>
-                  <%= render Collavre::AvatarComponent.new(user: share.user, size: 20, classes: 'avatar share-avatar') %>
-                <% else %>
-                  <span class="avatar share-avatar" style="display:inline-block;width:20px;height:20px;border-radius:50%;background:var(--surface-3,#ddd);text-align:center;line-height:20px;font-size:10px;">🌐</span>
-                <% end %>
-              </span>
-              <span><%= share.user&.display_name || t('collavre.creatives.index.public_share') %></span>
-              <span>
-                <select class="org-chart-permission-select org-chart-permission-<%= share.permission %> share-modal-permission-select" disabled>
-                  <% %w[admin write feedback read no_access].each do |perm| %>
-                    <option value="<%= perm %>" <%= 'selected' if share.permission == perm %>>
-                      <%= t("collavre.contacts.org_chart.permissions.#{perm}") %>
-                    </option>
-                  <% end %>
-                </select>
-              </span>
-              <span>
-                <% source_name = source.creative_snippet %>
-                <%= link_to collavre.creative_path(source), class: 'share-inherited-link' do %>
-                  <span class="share-inherited-short"><%= t('collavre.creatives.share.inherited_short') %></span>
-                  <span class="share-inherited-full"><%= t('collavre.creatives.share.inherited_from', name: source_name) %></span>
-                <% end %>
-              </span>
-            </li>
           <% end %>
         </ul>
       </div>

--- a/engines/collavre/app/views/collavre/creatives/_share_modal.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_share_modal.html.erb
@@ -29,7 +29,8 @@
       <button type="submit" class="btn btn-primary" data-share-invite-target="submit" data-share="<%= t('collavre.creatives.index.share') %>" data-invite="<%= t('collavre.creatives.index.invite') %>"><%= t('collavre.creatives.index.share') %></button>
       <button type="button" id="creative-invite-link" class="btn btn-secondary" data-creative-id="<%= (@parent_creative || @creative).id %>" data-no-access-message="<%= t('collavre.creatives.index.invite_link_no_access') %>" data-copied-template="<%= t('collavre.creatives.index.invite_link_copied_permission', permission: '__PERMISSION__') %>"><%= t('collavre.creatives.index.invite_link') %></button>
     </form>
-    <% if @shared_list.any? %>
+    <% has_shares = @shared_list.any? || (defined?(@pending_invitations) && @pending_invitations.any?) %>
+    <% if has_shares %>
       <div style="margin-top:1em;">
         <strong><%= t('collavre.creatives.index.shared_with') %>:</strong>
         <ul class="share-grid">
@@ -54,6 +55,34 @@
                 <%= button_to '×', collavre.creative_creative_share_path(@parent_creative || @creative, share), method: :delete, form: { data: { turbo_confirm: t('collavre.creatives.index.are_you_sure_delete_share') } }, class: 'delete-share-btn' %>
               </span>
             </li>
+          <% end %>
+          <% if defined?(@pending_invitations) && @pending_invitations.any? %>
+            <% @pending_invitations.each do |invitation| %>
+              <li class="share-pending-item">
+                <span>
+                  <div class="avatar-wrapper" style="width: 20px; height: 20px; display: inline-block;">
+                    <% if invitation.email.present? %>
+                      <%= image_tag asset_path("default_avatar.svg"),
+                          alt: '', width: 20, height: 20,
+                          class: 'avatar share-avatar',
+                          title: invitation.email,
+                          style: 'border-radius:50%;vertical-align:middle;' %>
+                      <span class="avatar-initial" style="font-size: 10px;"><%= invitation.email[0]&.upcase %></span>
+                    <% else %>
+                      <span class="avatar share-avatar" style="display:inline-block;width:20px;height:20px;border-radius:50%;background:var(--surface-3,#ddd);text-align:center;line-height:20px;font-size:10px;">🔗</span>
+                    <% end %>
+                  </div>
+                </span>
+                <span>
+                  <%= invitation.email.presence || t('collavre.creatives.share.public_invite') %>
+                  <span class="share-pending-badge"><%= t('collavre.contacts.org_chart.pending_status') %></span>
+                </span>
+                <span><%= t("collavre.creatives.index.permission_#{invitation.permission}") %></span>
+                <span>
+                  <%= button_to '×', collavre.creative_invitation_path(@parent_creative || @creative, invitation), method: :delete, form: { data: { turbo_confirm: t('collavre.contacts.org_chart.cancel_invite_confirm', email: invitation.email.presence || t('collavre.creatives.share.public_invite')) } }, class: 'delete-share-btn' %>
+                </span>
+              </li>
+            <% end %>
           <% end %>
         </ul>
       </div>
@@ -89,36 +118,6 @@
                   <span class="share-inherited-short"><%= t('collavre.creatives.share.inherited_short') %></span>
                   <span class="share-inherited-full"><%= t('collavre.creatives.share.inherited_from', name: source_name) %></span>
                 <% end %>
-              </span>
-            </li>
-          <% end %>
-        </ul>
-      </div>
-    <% end %>
-    <% if defined?(@pending_invitations) && @pending_invitations.any? %>
-      <div style="margin-top:1em;">
-        <strong><%= t('collavre.contacts.org_chart.pending_invitations') %>:</strong>
-        <ul class="share-grid">
-          <% @pending_invitations.each do |invitation| %>
-            <li>
-              <span>
-                <div class="avatar-wrapper" style="width: 20px; height: 20px; display: inline-block;">
-                  <% if invitation.email.present? %>
-                    <%= image_tag asset_path("default_avatar.svg"),
-                        alt: '', width: 20, height: 20,
-                        class: 'avatar share-avatar',
-                        title: invitation.email,
-                        style: 'border-radius:50%;vertical-align:middle;' %>
-                    <span class="avatar-initial" style="font-size: 10px;"><%= invitation.email[0]&.upcase %></span>
-                  <% else %>
-                    <span class="avatar share-avatar" style="display:inline-block;width:20px;height:20px;border-radius:50%;background:var(--surface-3,#ddd);text-align:center;line-height:20px;font-size:10px;">🔗</span>
-                  <% end %>
-                </div>
-              </span>
-              <span><%= invitation.email.presence || t('collavre.creatives.share.public_invite') %></span>
-              <span><%= t("collavre.creatives.index.permission_#{invitation.permission}") %></span>
-              <span>
-                <%= button_to '×', collavre.creative_invitation_path(@parent_creative || @creative, invitation), method: :delete, form: { data: { turbo_confirm: t('collavre.contacts.org_chart.cancel_invite_confirm', email: invitation.email.presence || t('collavre.creatives.share.public_invite')) } }, class: 'delete-share-btn' %>
               </span>
             </li>
           <% end %>

--- a/engines/collavre/app/views/collavre/creatives/_share_modal.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_share_modal.html.erb
@@ -58,7 +58,7 @@
         </ul>
       </div>
     <% end %>
-    <% if @inherited_shares.present? && @inherited_shares.any? %>
+    <% if @inherited_shares.any? %>
       <div style="margin-top:1em;">
         <strong><%= t('collavre.creatives.share.inherited_permissions') %>:</strong>
         <ul class="share-grid">
@@ -67,9 +67,13 @@
             <% source = entry[:source_creative] %>
             <li>
               <span>
-                <%= render Collavre::AvatarComponent.new(user: share.user, size: 20, classes: 'avatar share-avatar') %>
+                <% if share.user %>
+                  <%= render Collavre::AvatarComponent.new(user: share.user, size: 20, classes: 'avatar share-avatar') %>
+                <% else %>
+                  <span class="avatar share-avatar" style="display:inline-block;width:20px;height:20px;border-radius:50%;background:var(--surface-3,#ddd);text-align:center;line-height:20px;font-size:10px;">🌐</span>
+                <% end %>
               </span>
-              <span><%= share.user&.display_name || t('collavre.creatives.index.unknown_user') %></span>
+              <span><%= share.user&.display_name || t('collavre.creatives.index.public_share') %></span>
               <span>
                 <select class="org-chart-permission-select org-chart-permission-<%= share.permission %> share-modal-permission-select" disabled>
                   <% %w[admin write feedback read no_access].each do |perm| %>

--- a/engines/collavre/app/views/collavre/creatives/_share_modal.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_share_modal.html.erb
@@ -1,6 +1,6 @@
 <!-- Share Creative Modal -->
-<div id="share-creative-modal" style="display:none;position:fixed;top:0;left:0;width:100vw;height:100vh;z-index:10000;justify-content:center;overflow-y:auto;padding:1em 0;" data-creative-id="<%= (@parent_creative || @creative).id %>" data-error-message="<%= t('collavre.creatives.share.network_error') %>">
-  <div class="popup-box" style="min-width:320px;max-width:90vw;max-height:calc(100vh - 2em);overflow-y:auto;margin:auto;flex-shrink:0;">
+<div id="share-creative-modal" style="display:none;position:fixed;top:0;left:0;width:100vw;height:100vh;z-index:10000;align-items:center;justify-content:center;" data-creative-id="<%= (@parent_creative || @creative).id %>" data-error-message="<%= t('collavre.creatives.share.network_error') %>">
+  <div class="popup-box" style="min-width:320px;max-width:90vw;">
     <button type="button" id="close-share-modal" class="popup-close-btn">&times;</button>
     <h2><%= t('collavre.creatives.index.share_creative') %></h2>
     <form id="share-creative-form" action="<%= collavre.creative_creative_shares_path(@parent_creative || @creative) %>" method="post" data-controller="share-invite">

--- a/engines/collavre/app/views/collavre/creatives/_share_modal.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_share_modal.html.erb
@@ -40,7 +40,7 @@
               </span>
               <span><%= share.user&.display_name || (share.user_id.nil? ? t('collavre.creatives.index.public_share') : t('collavre.creatives.index.unknown_user')) %></span>
               <span>
-                <select class="org-chart-permission-select org-chart-permission-<%= share.permission %> share-modal-permission-select"
+                <select class="share-modal-permission-select share-modal-permission-<%= share.permission %>"
                         data-share-id="<%= share.id %>"
                         data-update-url="<%= collavre.creative_creative_share_path(@parent_creative || @creative, share) %>">
                   <% %w[admin write feedback read no_access].each do |perm| %>
@@ -71,7 +71,7 @@
               </span>
               <span><%= share.user&.display_name || t('collavre.creatives.index.unknown_user') %></span>
               <span>
-                <select class="org-chart-permission-select org-chart-permission-<%= share.permission %> share-modal-permission-select" disabled>
+                <select class="share-modal-permission-select share-modal-permission-<%= share.permission %>" disabled>
                   <% %w[admin write feedback read no_access].each do |perm| %>
                     <option value="<%= perm %>" <%= 'selected' if share.permission == perm %>>
                       <%= t("collavre.contacts.org_chart.permissions.#{perm}") %>

--- a/engines/collavre/app/views/collavre/creatives/_share_modal.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_share_modal.html.erb
@@ -39,16 +39,21 @@
                 <%= render Collavre::AvatarComponent.new(user: share.user, size: 20, classes: 'avatar share-avatar') %>
               </span>
               <span><%= share.user&.display_name || (share.user_id.nil? ? t('collavre.creatives.index.public_share') : t('collavre.creatives.index.unknown_user')) %></span>
-              <span>
-                <select class="share-modal-permission-select share-modal-permission-<%= share.permission %>"
+              <span class="share-perm-wrapper">
+                <button type="button"
+                        class="share-perm-btn share-perm-<%= share.permission %>"
                         data-share-id="<%= share.id %>"
-                        data-update-url="<%= collavre.creative_creative_share_path(@parent_creative || @creative, share) %>">
+                        data-update-url="<%= collavre.creative_creative_share_path(@parent_creative || @creative, share) %>"
+                        data-current="<%= share.permission %>">
+                  <%= t("collavre.contacts.org_chart.permissions.#{share.permission}") %>
+                </button>
+                <div class="share-perm-dropdown" style="display:none;">
                   <% %w[admin write feedback read no_access].each do |perm| %>
-                    <option value="<%= perm %>" <%= 'selected' if share.permission == perm %>>
+                    <button type="button" class="share-perm-option share-perm-<%= perm %>" data-value="<%= perm %>">
                       <%= t("collavre.contacts.org_chart.permissions.#{perm}") %>
-                    </option>
+                    </button>
                   <% end %>
-                </select>
+                </div>
               </span>
               <span>
                 <%= button_to '×', collavre.creative_creative_share_path(@parent_creative || @creative, share), method: :delete, form: { data: { turbo_confirm: t('collavre.creatives.index.are_you_sure_delete_share') } }, class: 'delete-share-btn' %>
@@ -71,13 +76,9 @@
               </span>
               <span><%= share.user&.display_name || t('collavre.creatives.index.unknown_user') %></span>
               <span>
-                <select class="share-modal-permission-select share-modal-permission-<%= share.permission %>" disabled>
-                  <% %w[admin write feedback read no_access].each do |perm| %>
-                    <option value="<%= perm %>" <%= 'selected' if share.permission == perm %>>
-                      <%= t("collavre.contacts.org_chart.permissions.#{perm}") %>
-                    </option>
-                  <% end %>
-                </select>
+                <span class="share-perm-badge share-perm-<%= share.permission %>">
+                  <%= t("collavre.contacts.org_chart.permissions.#{share.permission}") %>
+                </span>
               </span>
               <span>
                 <% source_name = source.creative_snippet %>

--- a/engines/collavre/app/views/collavre/creatives/_share_modal.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_share_modal.html.erb
@@ -1,5 +1,5 @@
 <!-- Share Creative Modal -->
-<div id="share-creative-modal" style="display:none;position:fixed;top:0;left:0;width:100vw;height:100vh;z-index:10000;align-items:center;justify-content:center;" data-creative-id="<%= (@parent_creative || @creative).id %>" data-error-message="<%= t('collavre.creatives.share.network_error') %>">
+<div id="share-creative-modal" style="display:none;position:fixed;top:0;left:0;width:100vw;height:100vh;z-index:10000;align-items:center;justify-content:center;overflow-y:auto;" data-creative-id="<%= (@parent_creative || @creative).id %>" data-error-message="<%= t('collavre.creatives.share.network_error') %>">
   <div class="popup-box" style="min-width:320px;max-width:90vw;">
     <button type="button" id="close-share-modal" class="popup-close-btn">&times;</button>
     <h2><%= t('collavre.creatives.index.share_creative') %></h2>

--- a/engines/collavre/app/views/collavre/creatives/_share_modal.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_share_modal.html.erb
@@ -39,21 +39,16 @@
                 <%= render Collavre::AvatarComponent.new(user: share.user, size: 20, classes: 'avatar share-avatar') %>
               </span>
               <span><%= share.user&.display_name || (share.user_id.nil? ? t('collavre.creatives.index.public_share') : t('collavre.creatives.index.unknown_user')) %></span>
-              <span class="share-perm-wrapper">
-                <button type="button"
-                        class="share-perm-btn share-perm-<%= share.permission %>"
+              <span>
+                <select class="org-chart-permission-select org-chart-permission-<%= share.permission %> share-modal-permission-select"
                         data-share-id="<%= share.id %>"
-                        data-update-url="<%= collavre.creative_creative_share_path(@parent_creative || @creative, share) %>"
-                        data-current="<%= share.permission %>">
-                  <%= t("collavre.contacts.org_chart.permissions.#{share.permission}") %>
-                </button>
-                <div class="share-perm-dropdown" style="display:none;">
+                        data-update-url="<%= collavre.creative_creative_share_path(@parent_creative || @creative, share) %>">
                   <% %w[admin write feedback read no_access].each do |perm| %>
-                    <button type="button" class="share-perm-option share-perm-<%= perm %>" data-value="<%= perm %>">
+                    <option value="<%= perm %>" <%= 'selected' if share.permission == perm %>>
                       <%= t("collavre.contacts.org_chart.permissions.#{perm}") %>
-                    </button>
+                    </option>
                   <% end %>
-                </div>
+                </select>
               </span>
               <span>
                 <%= button_to '×', collavre.creative_creative_share_path(@parent_creative || @creative, share), method: :delete, form: { data: { turbo_confirm: t('collavre.creatives.index.are_you_sure_delete_share') } }, class: 'delete-share-btn' %>
@@ -76,9 +71,13 @@
               </span>
               <span><%= share.user&.display_name || t('collavre.creatives.index.unknown_user') %></span>
               <span>
-                <span class="share-perm-badge share-perm-<%= share.permission %>">
-                  <%= t("collavre.contacts.org_chart.permissions.#{share.permission}") %>
-                </span>
+                <select class="org-chart-permission-select org-chart-permission-<%= share.permission %> share-modal-permission-select" disabled>
+                  <% %w[admin write feedback read no_access].each do |perm| %>
+                    <option value="<%= perm %>" <%= 'selected' if share.permission == perm %>>
+                      <%= t("collavre.contacts.org_chart.permissions.#{perm}") %>
+                    </option>
+                  <% end %>
+                </select>
               </span>
               <span>
                 <% source_name = source.creative_snippet %>

--- a/engines/collavre/config/locales/creatives.en.yml
+++ b/engines/collavre/config/locales/creatives.en.yml
@@ -133,7 +133,6 @@ en:
         permission_updated: Permission updated successfully.
         network_error: A network error occurred. Please try again.
         public_invite: Public
-        inherited_permissions: Inherited Permissions
         inherited_from: "Inherited from %{name}"
         inherited_short: Inherited
         already_shared_in_parent: Creative already shared in parent creative.

--- a/engines/collavre/config/locales/creatives.en.yml
+++ b/engines/collavre/config/locales/creatives.en.yml
@@ -135,6 +135,7 @@ en:
         public_invite: Public Invite
         inherited_permissions: Inherited Permissions
         inherited_from: "Inherited from %{name}"
+        inherited_short: Inherited
         already_shared_in_parent: Creative already shared in parent creative.
         can_not_share_by_no_access_in_parent: You can not share by no access in parent
           creative.

--- a/engines/collavre/config/locales/creatives.en.yml
+++ b/engines/collavre/config/locales/creatives.en.yml
@@ -132,7 +132,7 @@ en:
         shared: Creative shared successfully.
         permission_updated: Permission updated successfully.
         network_error: A network error occurred. Please try again.
-        public_invite: Public Invite
+        public_invite: Public
         inherited_permissions: Inherited Permissions
         inherited_from: "Inherited from %{name}"
         inherited_short: Inherited

--- a/engines/collavre/config/locales/creatives.en.yml
+++ b/engines/collavre/config/locales/creatives.en.yml
@@ -133,6 +133,8 @@ en:
         permission_updated: Permission updated successfully.
         network_error: A network error occurred. Please try again.
         public_invite: Public Invite
+        inherited_permissions: Inherited Permissions
+        inherited_from: "Inherited from %{name}"
         already_shared_in_parent: Creative already shared in parent creative.
         can_not_share_by_no_access_in_parent: You can not share by no access in parent
           creative.

--- a/engines/collavre/config/locales/creatives.ko.yml
+++ b/engines/collavre/config/locales/creatives.ko.yml
@@ -120,7 +120,7 @@ ko:
         shared: 크리에이티브가 성공적으로 공유되었습니다.
         permission_updated: 권한이 성공적으로 변경되었습니다.
         network_error: 네트워크 오류가 발생했습니다. 다시 시도해주세요.
-        public_invite: 공개 초대
+        public_invite: 공개
         inherited_permissions: 상속된 권한
         inherited_from: "%{name}에서 상속"
         inherited_short: 상속

--- a/engines/collavre/config/locales/creatives.ko.yml
+++ b/engines/collavre/config/locales/creatives.ko.yml
@@ -121,6 +121,8 @@ ko:
         permission_updated: 권한이 성공적으로 변경되었습니다.
         network_error: 네트워크 오류가 발생했습니다. 다시 시도해주세요.
         public_invite: 공개 초대
+        inherited_permissions: 상속된 권한
+        inherited_from: "%{name}에서 상속"
         already_shared_in_parent: 크리에이티브가 상위 크리에이티브에 이미 공유되었습니다.
         can_not_share_by_no_access_in_parent: 상위 크리에이티브에 접근 금지가 있어서 공유할 수 없습니다.
         cannot_share_private_ai_agent: AI Agent 소유자만 공유할 수 있습니다.

--- a/engines/collavre/config/locales/creatives.ko.yml
+++ b/engines/collavre/config/locales/creatives.ko.yml
@@ -123,6 +123,7 @@ ko:
         public_invite: 공개 초대
         inherited_permissions: 상속된 권한
         inherited_from: "%{name}에서 상속"
+        inherited_short: 상속
         already_shared_in_parent: 크리에이티브가 상위 크리에이티브에 이미 공유되었습니다.
         can_not_share_by_no_access_in_parent: 상위 크리에이티브에 접근 금지가 있어서 공유할 수 없습니다.
         cannot_share_private_ai_agent: AI Agent 소유자만 공유할 수 있습니다.

--- a/engines/collavre/config/locales/creatives.ko.yml
+++ b/engines/collavre/config/locales/creatives.ko.yml
@@ -121,7 +121,6 @@ ko:
         permission_updated: 권한이 성공적으로 변경되었습니다.
         network_error: 네트워크 오류가 발생했습니다. 다시 시도해주세요.
         public_invite: 공개
-        inherited_permissions: 상속된 권한
         inherited_from: "%{name}에서 상속"
         inherited_short: 상속
         already_shared_in_parent: 크리에이티브가 상위 크리에이티브에 이미 공유되었습니다.


### PR DESCRIPTION
## Summary

Show inherited permissions from parent creatives in the share popup, replacing the previous behavior that only showed direct shares.

## Changes

### Controller (`creative_shares_controller.rb`)
- Added `build_inherited_shares` private method that walks ancestor creatives to find inherited permissions
- Uses `closest_parent_share` to pick the most specific ancestor share per user
- Excludes users who already have direct shares on the current creative

### View (`_share_modal.html.erb`)
- **Inline permission editing**: Replaced static permission text with `<select>` dropdown for direct shares (same pattern as org chart)
- **Inherited permissions section**: New section showing permissions inherited from parent creatives
  - Each entry displays avatar, user name, permission level (disabled select), and a clickable "Inherited from [name]" link
  - Clicking the link navigates to the source creative
- **Default permission**: Changed from `no_access` to `feedback`

### JavaScript (`share_modal_controller.js`)
- Added `#initializePermissionSelects()` method for inline permission changes
- Sends PATCH request on select change, with optimistic UI class update
- Error handling reverts visual state on failure

### CSS (`popup.css`)
- Added `.share-modal-permission-select` styles for inline select dropdowns
- Added `.share-inherited-link` styles for the inherited source link
- Excluded permission selects from the full-width popup select rule

### i18n
- Added `inherited_permissions` and `inherited_from` keys in both English and Korean

## Testing
- All existing controller and model tests pass
- Rubocop clean