### PR TITLE
fix: unify chat header section spacing

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -51,6 +51,7 @@ body.chat-fullscreen {
     align-items: center;
     justify-content: space-between;
     gap: 0.75em;
+    padding-bottom: 0.5em;
 }
 
 .comments-popup-header h3 {
@@ -126,7 +127,6 @@ body.chat-fullscreen {
     align-items: center;
     gap: 0.5em;
     padding: 0.5em 0;
-    margin-bottom: 0.5em;
     overflow-x: auto;
     overflow-y: hidden;
     scrollbar-width: none; /* Firefox */
@@ -845,7 +845,7 @@ body.chat-fullscreen {
 }
 
 #comment-participants {
-    margin-bottom: 0.3em;
+    padding: 0.5em 0;
     min-height: 20px;
     display: flex;
     align-items: center;
@@ -915,7 +915,7 @@ body.chat-fullscreen {
     flex-wrap: nowrap;
     align-items: center;
     gap: 0.4em;
-    padding: 0.25em 0;
+    padding: 0.5em 0;
     overflow-x: auto;
     overflow-y: visible;
     scrollbar-width: none;
@@ -1069,7 +1069,6 @@ body.chat-fullscreen {
     align-items: center;
     gap: 0.5em;
     padding: 0.5em 0;
-    margin-bottom: 0.5em;
     overflow-x: auto;
     overflow-y: hidden;
     scrollbar-width: none; /* Firefox */

--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -51,7 +51,7 @@ body.chat-fullscreen {
     align-items: center;
     justify-content: space-between;
     gap: 0.75em;
-    padding-bottom: 0.5em;
+    padding-bottom: var(--space-1);
 }
 
 .comments-popup-header h3 {
@@ -126,7 +126,7 @@ body.chat-fullscreen {
     flex-wrap: nowrap;
     align-items: center;
     gap: 0.5em;
-    padding: 0.5em 0;
+    padding: var(--space-1) 0;
     overflow-x: auto;
     overflow-y: hidden;
     scrollbar-width: none; /* Firefox */
@@ -845,7 +845,7 @@ body.chat-fullscreen {
 }
 
 #comment-participants {
-    padding: 0.5em 0;
+    padding: var(--space-1) 0;
     min-height: 20px;
     display: flex;
     align-items: center;
@@ -915,7 +915,7 @@ body.chat-fullscreen {
     flex-wrap: nowrap;
     align-items: center;
     gap: 0.4em;
-    padding: 0.5em 0;
+    padding: var(--space-1) 0;
     overflow-x: auto;
     overflow-y: visible;
     scrollbar-width: none;
@@ -1068,7 +1068,7 @@ body.chat-fullscreen {
     flex-wrap: nowrap;
     align-items: center;
     gap: 0.5em;
-    padding: 0.5em 0;
+    padding: var(--space-1) 0;
     overflow-x: auto;
     overflow-y: hidden;
     scrollbar-width: none; /* Firefox */


### PR DESCRIPTION
## Summary
Standardize vertical spacing between all chat popup header sections to a consistent `0.5em`.

## Changes
- **Header** (`.comments-popup-header`): added `padding-bottom: 0.5em`
- **Contexts** (`.comment-contexts-list`): `padding: 0.25em 0` → `0.5em 0`
- **Participants** (`#comment-participants`): `margin-bottom: 0.3em` → `padding: 0.5em 0`
- **Topics** (`.comment-topics-list`): removed redundant `margin-bottom: 0.5em` (already has `padding: 0.5em 0`)

## Before
Inconsistent spacing: header (0), contexts (0.25em), participants (0.3em margin), topics (0.5em padding + 0.5em margin).

## After
All sections use uniform `0.5em` vertical padding for consistent visual rhythm.

Closes #9916