### PR TITLE
fix: remove global scroll-behavior smooth to prevent scroll animation on back navigation

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/dark_mode.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/dark_mode.css
@@ -79,12 +79,7 @@ body.dark-mode {
 /* ============================================================================
  * BASE ELEMENT STYLES
  * ============================================================================ */
-html {
-  scroll-behavior: smooth;
-}
-
 @media (prefers-reduced-motion: reduce) {
-  html { scroll-behavior: auto; }
 
   /* Collapse decorative transitions to instant; state changes still
      apply but without visible motion (hover bg, theme switch, etc.). */


### PR DESCRIPTION
## Problem
When navigating back from a creative detail to the creative list, the browser restores the scroll position to 0 with a visible smooth scroll animation. This looks jarring and unintended.

## Cause
`html { scroll-behavior: smooth; }` was set globally in `dark_mode.css`. This affects **all** scroll position changes including browser-initiated scroll restoration on back/forward navigation.

## Fix
Remove the global `scroll-behavior: smooth` from `html`. Individual smooth scroll behavior is already handled via JS `scrollIntoView({ behavior: 'smooth' })` where explicitly needed (comments, topics, etc.), so this global setting is unnecessary.

Also removes the now-unnecessary `scroll-behavior: auto` override in the `prefers-reduced-motion` media query.

## Changes
- `engines/collavre/app/assets/stylesheets/collavre/dark_mode.css`: Remove `html { scroll-behavior: smooth; }` and its reduced-motion override

## Testing
- Navigate to a creative with a long list of children
- Scroll down
- Click into a child creative
- Press browser back button
- ✅ Page should restore scroll position instantly without visible animation