### PR TITLE
fix: hide chevron toggle for leaf nodes without children container

### DIFF
--- a/engines/collavre/app/javascript/controllers/creatives/expansion_controller.js
+++ b/engines/collavre/app/javascript/controllers/creatives/expansion_controller.js
@@ -100,6 +100,7 @@ export default class extends Controller {
     const childrenDiv = this.childrenContainerFor(row)
     this.ensureLoaded(row, childrenDiv).then((hasChildren) => {
       if (!hasChildren || !childrenDiv) {
+        row.hasChildren = false
         this.collapseRow(row, { persist: false })
         return
       }
@@ -177,6 +178,13 @@ export default class extends Controller {
 
   syncInitialState(row) {
     const childrenDiv = this.childrenContainerFor(row)
+
+    // If the row claims it has children but no children container exists,
+    // correct the hasChildren flag so the chevron is hidden.
+    if (row.hasChildren && !childrenDiv) {
+      row.hasChildren = false
+    }
+
     const shouldExpand =
       this.allExpanded ||
       row.expanded ||


### PR DESCRIPTION
## Problem

When expanding a creative's children, the chevron toggle icon was shown on all child rows regardless of whether they actually had grandchildren (regression bug). Users had to click the chevron a second time to discover the node was a leaf, at which point the chevron would disappear.

## Solution

Two fixes in `expansion_controller.js`:

1. **`syncInitialState`**: When a row has `hasChildren=true` but no children container div exists, immediately set `hasChildren=false` so the chevron is never rendered for leaf nodes.

2. **`expandRow`**: When `ensureLoaded` resolves with no children or no container, explicitly set `row.hasChildren=false` before collapsing so the chevron is removed on first attempt rather than requiring a second click.

## Files Changed

- `engines/collavre/app/javascript/controllers/creatives/expansion_controller.js`

## Testing

- Rubocop: ✅ passed
- Manual: expand a creative tree → leaf nodes no longer show chevron toggle