### PR TITLE
fix: prevent wheel event handler from blocking share modal scroll

### DIFF
--- a/engines/collavre/app/javascript/controllers/comments/popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_controller.js
@@ -446,6 +446,9 @@ export default class extends Controller {
   handlePopupWheel(event) {
     if (this.isFullscreen()) return // fullscreen already blocks body scroll via CSS
 
+    // Don't interfere with scroll inside overlays (e.g., share modal)
+    if (event.target.closest('#share-creative-modal')) return
+
     if (!this.hasListTarget) {
       event.preventDefault()
       return


### PR DESCRIPTION
## Problem
The share modal's user permission list (`.share-grid`) was not scrollable with mouse wheel.

## Root Cause
`handlePopupWheel` in `comments/popup_controller.js` listens on the `#comments-popup` element and calls `event.preventDefault()` based on the **comments list** scroll state. When the share modal opens as an overlay, wheel events from `.share-grid` bubble up to `#comments-popup`, where they get blocked by this handler.

## Fix
Add an early return in `handlePopupWheel` when the event originates from inside `#share-creative-modal`, allowing the overlay to scroll independently.

Fixes Creative #9981