### PR TITLE
fix: render markdown when navigating comment versions

### DIFF
--- a/engines/collavre/app/javascript/controllers/comment_version_controller.js
+++ b/engines/collavre/app/javascript/controllers/comment_version_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
+import { renderCommentMarkdown } from "../lib/utils/markdown"
 
 export default class extends Controller {
   static targets = ["prevBtn", "nextBtn", "indicator", "deleteBtn", "selectBtn"]
@@ -123,7 +124,10 @@ export default class extends Controller {
   setContentText(text) {
     const el = document.getElementById(this.contentTargetValue)
     const target = el?.querySelector(".comment-content") || el?.querySelector("[data-comment-target='content']")
-    if (target) target.textContent = text
+    if (target) {
+      target.innerHTML = renderCommentMarkdown(text)
+      target.dataset.rendered = "true"
+    }
   }
 
   updateButtons() {


### PR DESCRIPTION
## Problem
When navigating between reviewed comment versions, the markdown rendering breaks and content displays as plain text.

## Cause
`setContentText` in `comment_version_controller.js` used `target.textContent = text` which:
1. Replaces rendered HTML with raw text
2. Leaves `data-rendered="true"` so `renderMarkdownInContainer` won't re-process it

## Fix
- Import `renderCommentMarkdown` from the existing markdown utility
- Use `target.innerHTML = renderCommentMarkdown(text)` instead of `textContent`
- Content is sanitized via DOMPurify (same pipeline as initial comment rendering)

## Testing
- All 1319 tests pass
- Rubocop clean
- i18n complete