### PR TITLE
fix: allow scrolling inside action details and edit textarea in chat popup

### DIFF
--- a/engines/collavre/app/javascript/controllers/comments/popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_controller.js
@@ -462,6 +462,21 @@ export default class extends Controller {
     // Don't interfere with scroll inside overlays (e.g., share modal)
     if (event.target.closest('#share-creative-modal')) return
 
+    // Allow scroll inside independently scrollable elements (action JSON, edit textarea, etc.)
+    const scrollableChild = event.target.closest('.comment-action-json, .comment-action-edit-textarea, .comment-action-body')
+    if (scrollableChild && scrollableChild.scrollHeight > scrollableChild.clientHeight) {
+      const { scrollTop, scrollHeight, clientHeight } = scrollableChild
+      const isScrollingDown = event.deltaY > 0
+      const atTop = scrollTop <= 0
+      const atBottom = scrollTop + clientHeight >= scrollHeight - 1
+
+      // Only prevent if at boundary (to block propagation to background)
+      if ((isScrollingDown && atBottom) || (!isScrollingDown && atTop)) {
+        event.preventDefault()
+      }
+      return
+    }
+
     if (!this.hasListTarget) {
       event.preventDefault()
       return


### PR DESCRIPTION
## Problem
In the chat popup, scrolling is blocked inside:
- `.comment-action-json` (tool execution details when `<details>` is expanded)
- `.comment-action-edit-textarea` (action edit textarea)

## Cause
`handlePopupWheel` in `popup_controller.js` only recognizes `#comments-list` as the scrollable area. All other wheel events inside the popup are blocked with `preventDefault()` to prevent background creative list from scrolling. This inadvertently blocks scrolling in nested scrollable elements.

## Fix
Before checking `#comments-list` scroll boundaries, detect if the wheel event originates from an independently scrollable child element (`.comment-action-json`, `.comment-action-edit-textarea`, `.comment-action-body`). If so, let it handle its own scroll and only block at boundaries to prevent background scroll leak.

## Testing
- All 1319 tests pass
- Rubocop clean, i18n complete