### PR TITLE
fix: apply primary-color active style to selection action bar buttons

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/activity_logs.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/activity_logs.css
@@ -9,7 +9,7 @@
 }
 
 .comment-activity-log-block details>summary::marker {
-    color: var(--border-color);
+    color: var(--text-muted);
 }
 
 /* List container */

--- a/engines/collavre/app/assets/stylesheets/collavre/comment_versions.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comment_versions.css
@@ -14,7 +14,8 @@
   padding: 0 var(--space-2, 0.25rem);
   font-size: var(--text-xs, 0.75rem);
   line-height: 1.6;
-  color: var(--text-color, #333);
+  color: var(--text-primary, #202123);
+  font-weight: bold;
 }
 
 .comment-version-btn:hover:not(:disabled) {
@@ -35,16 +36,18 @@
 
 .comment-version-delete-btn {
   background: none;
-  border: none;
+  border: 1px solid var(--border-color, #ddd);
+  border-radius: var(--radius-1, 4px);
   cursor: pointer;
-  color: var(--text-muted, #888);
+  color: var(--text-primary, #202123);
   font-size: var(--text-xs, 0.75rem);
-  padding: 0 var(--space-1, 0.125rem);
+  padding: 0 var(--space-2, 0.25rem);
   margin-left: var(--space-1, 0.125rem);
+  line-height: 1.6;
 }
 
-.comment-version-delete-btn:hover {
-  color: var(--danger-color, #e53e3e);
+.comment-version-delete-btn:hover:not(:disabled) {
+  background: var(--surface-hover, #f0f0f0);
 }
 
 .comment-version-selected {
@@ -59,6 +62,7 @@
   cursor: pointer;
   color: var(--primary-color, #4a90d9);
   font-size: var(--text-xs, 0.75rem);
+  font-weight: bold;
   padding: 0 var(--space-2, 0.25rem);
   margin-left: var(--space-1, 0.125rem);
   line-height: 1.6;


### PR DESCRIPTION
## Summary

Selection action bar buttons (Move, Delete, Move to topic) were using the muted `--color-chat-btn-text` color, making their active state dim and hard to recognize.

## Changes

- Applied `--primary-color` border and text color to `.selection-action-bar-btn`, matching the style of `.comment-version-select-btn`
- Hover state now fills with `--primary-color` background + white text
- Delete button uses `--color-danger` for clear visual distinction (both default and hover states)
- Works correctly in both light and dark mode via existing design token definitions

## Before/After

**Before:** Buttons blend into the bar with muted gray text, hard to identify as actionable
**After:** Buttons have clear primary-color borders and text, matching the select button's active style

Fixes reviewed message move/delete button style (Creative #10200)