### PR TITLE
fix: allow creative admins to edit action payload in update_action

### DIFF
--- a/engines/collavre/app/controllers/concerns/collavre/comments/approval_actions.rb
+++ b/engines/collavre/app/controllers/concerns/collavre/comments/approval_actions.rb
@@ -53,6 +53,11 @@ module Collavre
             end
           end
 
+          # Creative admins can also edit actions even if not the designated approver
+          if status_in_lock != :ok && @creative.has_permission?(Current.user, :admin)
+            status_in_lock = :ok
+          end
+
           if status_in_lock != :ok
             approver_mismatch_error = true
             status_error_key = case status_in_lock

--- a/engines/collavre/test/controllers/comments_controller_test.rb
+++ b/engines/collavre/test/controllers/comments_controller_test.rb
@@ -388,7 +388,7 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
     assert_equal action_payload, JSON.parse(comment.reload.action)
   end
 
-  test "non approver cannot update comment action" do
+  test "creative admin can update action even if not the approver" do
     approver = users(:two)
     approver.update!(email_verified_at: Time.current)
 
@@ -403,6 +403,40 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
       action: JSON.generate(action_payload),
       approver: approver
     )
+
+    updated_payload = action_payload.merge("attributes" => { "progress" => 0.7 })
+
+    patch update_action_creative_comment_path(@creative, comment), params: {
+      comment: { action: JSON.generate(updated_payload) }
+    }
+
+    assert_response :success
+    comment.reload
+    assert_equal updated_payload, JSON.parse(comment.action)
+  end
+
+  test "non admin non approver cannot update comment action" do
+    approver = users(:two)
+    approver.update!(email_verified_at: Time.current)
+    # Create a third user who has only read access (not admin)
+    reader = users(:three)
+    reader.update!(email_verified_at: Time.current)
+    grant_read_access_to_other_user(@creative, user: reader, permission: :feedback)
+
+    action_payload = {
+      "action" => "update_creative",
+      "attributes" => { "progress" => 0.5 }
+    }
+
+    comment = @creative.comments.create!(
+      content: "Needs approval",
+      user: approver,
+      action: JSON.generate(action_payload),
+      approver: approver
+    )
+
+    # Log in as reader (non-admin, non-approver)
+    post session_path, params: { email: reader.email, password: "password" }
 
     patch update_action_creative_comment_path(@creative, comment), params: {
       comment: { action: JSON.generate(action_payload.merge("attributes" => { "progress" => 0.7 })) }


### PR DESCRIPTION
## Problem

Users with creative admin permission were receiving a 403 Forbidden error when trying to edit an action payload via `update_action`. The `approval_status` check only validated `approver_id` match, ignoring creative-level admin permissions.

**Root cause:** Comment #13688 had `approver_id=1` (admin@example.com), but user #2 (soonoh.jung@gmail.com) — who is a creative admin — tried to edit the action and was rejected because they weren't the designated approver.

## Fix

In `update_action`, after checking `approval_status`, fall back to checking creative admin permission. If the user has admin permission on the creative, they can edit the action payload even if they're not the designated approver.

## Changes

- `engines/collavre/app/controllers/concerns/collavre/comments/approval_actions.rb`: Added creative admin fallback check in `update_action`
- `engines/collavre/test/controllers/comments_controller_test.rb`: Updated tests — split the old "non approver" test into two:
  - "creative admin can update action even if not the approver" (now passes)
  - "non admin non approver cannot update comment action" (still returns 403)