### PR TITLE
fix: close chat popup when creative is deleted

### DIFF
--- a/engines/collavre/app/javascript/controllers/comments/popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_controller.js
@@ -2,6 +2,7 @@ import { Controller } from '@hotwired/stimulus'
 
 const SIZE_STORAGE_KEY = 'commentsPopupSize'
 const CREATIVE_CLICK_EVENT = 'creative-comments-click'
+const CREATIVE_DESTROYED_EVENT = 'creative-destroyed'
 
 export default class extends Controller {
   static targets = [
@@ -24,6 +25,7 @@ export default class extends Controller {
     this.openFromUrlObserver = null
     this.openFromUrlTimeout = null
     this.handleCreativeClick = this.handleCreativeClick.bind(this)
+    this.handleCreativeDestroyed = this.handleCreativeDestroyed.bind(this)
     this.handleTouchStart = this.handleTouchStart.bind(this)
     this.handleTouchEnd = this.handleTouchEnd.bind(this)
     this.handleResizeMove = this.handleResizeMove.bind(this)
@@ -37,6 +39,7 @@ export default class extends Controller {
     this.handlePopupWheel = this.handlePopupWheel.bind(this)
 
     document.addEventListener(CREATIVE_CLICK_EVENT, this.handleCreativeClick)
+    document.addEventListener(CREATIVE_DESTROYED_EVENT, this.handleCreativeDestroyed)
     this.element.addEventListener('wheel', this.handlePopupWheel, { passive: false })
     window.addEventListener('online', this.handleOnline)
     window.addEventListener('focus', this.handleWindowFocus)
@@ -92,6 +95,7 @@ export default class extends Controller {
   disconnect() {
     this.clearPendingOpenFromUrl()
     document.removeEventListener(CREATIVE_CLICK_EVENT, this.handleCreativeClick)
+    document.removeEventListener(CREATIVE_DESTROYED_EVENT, this.handleCreativeDestroyed)
     this.element.removeEventListener('wheel', this.handlePopupWheel)
     window.removeEventListener('online', this.handleOnline)
     window.removeEventListener('focus', this.handleWindowFocus)
@@ -145,6 +149,14 @@ export default class extends Controller {
       return
     }
     this.open(button, { creativeId })
+  }
+
+  handleCreativeDestroyed(event) {
+    const destroyedIds = event.detail?.creativeIds || []
+    if (this.element.style.display !== 'flex') return
+    if (destroyedIds.includes(this.element.dataset.creativeId)) {
+      this.close()
+    }
   }
 
   async open(button, { creativeId, highlightId } = {}) {

--- a/engines/collavre/app/javascript/controllers/creatives/select_mode_controller.js
+++ b/engines/collavre/app/javascript/controllers/creatives/select_mode_controller.js
@@ -97,6 +97,10 @@ export default class extends Controller {
       )
     )
 
+    document.dispatchEvent(new CustomEvent('creative-destroyed', {
+      detail: { creativeIds: ids.map(String) }
+    }))
+
     ids.forEach((id) => {
       const tree = document.getElementById(`creative-${id}`)
       if (tree) tree.remove()

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -1510,8 +1510,18 @@ export function initializeCreativeRowEditor() {
       }
 
       creativesApi.destroy(id, withChildren).then(() => {
+        const destroyedIds = [String(id)];
+        if (withChildren) {
+          const childrenContainer = document.getElementById("creative-children-" + id);
+          if (childrenContainer) {
+            childrenContainer.querySelectorAll('creative-tree-row').forEach(row => {
+              const cid = row.getAttribute('creative-id');
+              if (cid) destroyedIds.push(cid);
+            });
+          }
+        }
         document.dispatchEvent(new CustomEvent('creative-destroyed', {
-          detail: { creativeIds: [String(id)] }
+          detail: { creativeIds: destroyedIds }
         }));
         const parentTree = parentId ? document.getElementById(`creative-${parentId}`) : null;
         const childrenTree = document.getElementById("creative-children-" + id)

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -1510,6 +1510,9 @@ export function initializeCreativeRowEditor() {
       }
 
       creativesApi.destroy(id, withChildren).then(() => {
+        document.dispatchEvent(new CustomEvent('creative-destroyed', {
+          detail: { creativeIds: [String(id)] }
+        }));
         const parentTree = parentId ? document.getElementById(`creative-${parentId}`) : null;
         const childrenTree = document.getElementById("creative-children-" + id)
         if (!withChildren && childrenTree && parentTree) {


### PR DESCRIPTION
## Problem
When a creative is deleted while its chat (comments) popup is open, the popup stays open and the comment list tries to reload, resulting in a **404 error** displayed inside the popup.

## Solution
Dispatch a `creative-destroyed` custom event after successful deletion and listen for it in the comments popup controller.

### Changes
- **`popup_controller.js`**: Listen for `creative-destroyed` event; if the popup is showing the deleted creative, close it automatically.
- **`creative_row_editor.js`**: Dispatch `creative-destroyed` event after single creative deletion.
- **`select_mode_controller.js`**: Dispatch `creative-destroyed` event after batch deletion (select mode).

### Event shape
```js
new CustomEvent('creative-destroyed', {
  detail: { creativeIds: ['123'] }  // array of string IDs
})
```

Closes #10195