### PR TITLE
fix: allow scroll inside chat popup textarea and review quotes

### DIFF
--- a/engines/collavre/app/javascript/controllers/comments/popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_controller.js
@@ -474,8 +474,8 @@ export default class extends Controller {
     // Don't interfere with scroll inside overlays (e.g., share modal)
     if (event.target.closest('#share-creative-modal')) return
 
-    // Allow scroll inside independently scrollable elements (action JSON, edit textarea, etc.)
-    const scrollableChild = event.target.closest('.comment-action-json, .comment-action-edit-textarea, .comment-action-body')
+    // Allow scroll inside independently scrollable elements (action JSON, edit textarea, form textarea, review quotes, etc.)
+    const scrollableChild = event.target.closest('.comment-action-json, .comment-action-edit-textarea, .comment-action-body, #new-comment-form textarea, .review-quotes-container')
     if (scrollableChild && scrollableChild.scrollHeight > scrollableChild.clientHeight) {
       const { scrollTop, scrollHeight, clientHeight } = scrollableChild
       const isScrollingDown = event.deltaY > 0


### PR DESCRIPTION
## Problem
When the message input textarea in the chat popup contains multiple lines exceeding its max-height, the user cannot scroll through the text. This is because the `handlePopupWheel` handler prevents all wheel events on the popup to stop background scrolling, but it didn't allowlist the textarea.

## Fix
Add `#new-comment-form textarea` and `.review-quotes-container` to the scrollable child selector in `handlePopupWheel`, so wheel events inside these elements are handled normally (scroll within the element) instead of being blocked.

## Changes
- `popup_controller.js`: Extended the scrollable child CSS selector in `handlePopupWheel` to include the form textarea and review quotes container.