### PR TITLE
feat: use orchestration rules for agent selection in CompressJob

### DIFF
--- a/engines/collavre/app/jobs/collavre/compress_job.rb
+++ b/engines/collavre/app/jobs/collavre/compress_job.rb
@@ -32,7 +32,7 @@ module Collavre
       end
 
       # Find an AI agent on this creative, or use default config
-      agent = find_ai_agent(creative)
+      agent = resolve_ai_agent(creative, topic_id)
 
       client = AiClient.new(
         vendor: agent&.llm_vendor || default_vendor,
@@ -74,11 +74,33 @@ module Collavre
 
     private
 
-    def find_ai_agent(creative)
-      # Look for an AI agent with access to this creative
+    # Resolve AI agent using orchestration rules:
+    # 1. Topic's primary agent (from OrchestratorPolicy)
+    # 2. Fallback: any AI agent with feedback permission on the creative
+    def resolve_ai_agent(creative, topic_id)
+      # Step 1: Check topic's primary agent via OrchestratorPolicy
+      if topic_id.present?
+        context = build_policy_context(creative, topic_id)
+        resolver = Orchestration::PolicyResolver.new(context)
+        primary_id = resolver.primary_agent_id
+
+        if primary_id.present?
+          agent = User.find_by(id: primary_id)
+          return agent if agent&.ai_user?
+        end
+      end
+
+      # Step 2: Fallback - find any AI agent with access
       creative.effective_origin.all_shared_users(:feedback)
         .map(&:user)
         .find(&:ai_user?)
+    end
+
+    def build_policy_context(creative, topic_id)
+      context = {}
+      context["creative"] = { "id" => creative.id }
+      context["topic"] = { "id" => topic_id } if topic_id.present?
+      context
     end
 
     def default_vendor

--- a/engines/collavre/test/jobs/compress_job_test.rb
+++ b/engines/collavre/test/jobs/compress_job_test.rb
@@ -44,6 +44,56 @@ class Collavre::CompressJobTest < ActiveSupport::TestCase
     assert Collavre::Comment.exists?(@comment1.id)
   end
 
+  test "uses topic primary agent when OrchestratorPolicy defines one" do
+    # Create an AI agent
+    ai_agent = Collavre::User.create!(
+      name: "Test AI Agent",
+      email: "ai-compress-test@example.com",
+      password: "password123",
+      llm_vendor: "google",
+      llm_model: "gemini-3-flash-preview",
+      routing_expression: "true"
+    )
+
+    # Share the creative with the AI agent
+    Collavre::CreativeShare.create!(
+      creative: @creative.effective_origin,
+      user: ai_agent,
+      permission: :feedback
+    )
+
+    # Create a topic-level OrchestratorPolicy with primary_agent_id
+    Collavre::OrchestratorPolicy.create!(
+      policy_type: "arbitration",
+      scope_type: "Topic",
+      scope_id: @topic.id,
+      priority: 10,
+      config: { "strategy" => "primary_first", "primary_agent_id" => ai_agent.id },
+      enabled: true
+    )
+
+    captured_vendor = nil
+    captured_model = nil
+
+    mock_client = Minitest::Mock.new
+    mock_client.expect(:chat, nil) do |messages, **kwargs, &block|
+      block.call("Summary from primary agent.")
+      true
+    end
+
+    Collavre::AiClient.stub(:new, lambda { |**kwargs|
+      captured_vendor = kwargs[:vendor]
+      captured_model = kwargs[:model]
+      mock_client
+    }) do
+      Collavre::CompressJob.perform_now(@creative.id, @topic.id, @user.id)
+    end
+
+    # Verify the primary agent's LLM config was used
+    assert_equal "google", captured_vendor
+    assert_equal "gemini-3-flash-preview", captured_model
+  end
+
   test "handles AI failure gracefully" do
     mock_client = Minitest::Mock.new
     mock_client.expect(:chat, nil) do |messages, **kwargs, &block|


### PR DESCRIPTION
## Summary

`CompressJob` now resolves the AI agent using `OrchestratorPolicy` rules instead of picking an arbitrary AI agent with creative access.

## Changes

### Agent Selection Priority
1. **Topic's primary agent** — Looks up `primary_agent_id` from `OrchestratorPolicy` (arbitration config) for the topic
2. **Fallback** — Any AI agent with feedback permission on the creative (previous behavior)

### Why
The `/compress` command was the only AI-powered feature that bypassed the orchestration rules. All other agent interactions go through the `Matcher → Arbiter → Scheduler` pipeline which respects topic-level primary agent configuration. This change aligns `/compress` with those rules.

### Files Changed
- `engines/collavre/app/jobs/collavre/compress_job.rb` — Replaced `find_ai_agent` with `resolve_ai_agent` that checks `OrchestratorPolicy` first
- `engines/collavre/test/jobs/compress_job_test.rb` — Added test for primary agent selection via policy

### Test Results
- All 1321 tests pass (0 failures, 0 errors)
- Rubocop: 732 files, no offenses
- i18n: All keys present in en and ko

Closes Creative #10221