### PR TITLE
feat: drag & drop AI agent to topic tabs to set primary agent

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -1114,6 +1114,22 @@ body.chat-fullscreen {
     flex-shrink: 0;
 }
 
+.ai-agent-draggable {
+    cursor: grab;
+}
+
+.ai-agent-draggable:active,
+.ai-agent-draggable.dragging {
+    cursor: grabbing;
+    opacity: 0.5;
+}
+
+.topic-creation-container.drag-over {
+    background: var(--color-active);
+    border-radius: 12px;
+    opacity: 0.8;
+}
+
 .topic-tag:hover {
     background: var(--surface-hover);
 }

--- a/engines/collavre/app/controllers/collavre/comments_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comments_controller.rb
@@ -281,7 +281,8 @@ module Collavre
           name: u.display_name,
           avatar_url: view_context.user_avatar_url(u, size: 20),
           default_avatar: !u.avatar.attached? && u.avatar_url.blank?,
-          initial: u.display_name[0].upcase
+          initial: u.display_name[0].upcase,
+          ai_user: u.ai_user?
         }
       end
       render json: {

--- a/engines/collavre/app/controllers/collavre/topics_controller.rb
+++ b/engines/collavre/app/controllers/collavre/topics_controller.rb
@@ -160,6 +160,43 @@ module Collavre
       render json: { success: true }
     end
 
+    def set_primary_agent
+      unless @creative.has_permission?(Current.user, :write) || @creative.user == Current.user
+        render json: { error: I18n.t("collavre.topics.no_permission") }, status: :forbidden and return
+      end
+
+      topic = @creative.topics.find(params[:id])
+      agent = User.find(params[:agent_id])
+
+      unless agent.ai_user?
+        render json: { error: I18n.t("collavre.topics.not_ai_agent") }, status: :unprocessable_entity and return
+      end
+
+      policy = OrchestratorPolicy.find_or_initialize_by(
+        policy_type: "arbitration",
+        scope_type: "Topic",
+        scope_id: topic.id
+      )
+      policy.update!(
+        config: {
+          "strategy" => "primary_first",
+          "primary_agent_id" => agent.id
+        },
+        priority: 10,
+        enabled: true
+      )
+
+      TopicsChannel.broadcast_to(
+        @creative,
+        {
+          action: "updated",
+          topic: topic_json_with_agent(topic, agent)
+        }
+      )
+
+      render json: { success: true, topic: topic_json_with_agent(topic, agent) }
+    end
+
     private
 
     def set_creative
@@ -195,13 +232,23 @@ module Collavre
       data = topic.slice(:id, :name)
       agent = topic.instance_variable_get(:@_primary_agent) || topic.primary_agent
       if agent
-        data[:primary_agent] = {
-          id: agent.id,
-          name: agent.display_name,
-          avatar_url: view_context.user_avatar_url(agent, size: 20)
-        }
+        data[:primary_agent] = agent_json(agent)
       end
       data
+    end
+
+    def topic_json_with_agent(topic, agent)
+      data = topic.slice(:id, :name)
+      data[:primary_agent] = agent_json(agent)
+      data
+    end
+
+    def agent_json(agent)
+      {
+        id: agent.id,
+        name: agent.display_name,
+        avatar_url: view_context.user_avatar_url(agent, size: 20)
+      }
     end
   end
 end

--- a/engines/collavre/app/controllers/collavre/topics_controller.rb
+++ b/engines/collavre/app/controllers/collavre/topics_controller.rb
@@ -28,9 +28,16 @@ module Collavre
       topic.user = Current.user
 
       if topic.save
+        agent = nil
+        if params[:agent_id].present?
+          agent = User.find_by(id: params[:agent_id])
+          topic.set_primary_agent!(agent) if agent&.ai_user?
+        end
+
+        broadcast_data = agent ? topic_json_with_agent(topic, agent) : topic.slice(:id, :name)
         TopicsChannel.broadcast_to(
           @creative,
-          { action: "created", topic: topic.slice(:id, :name) }
+          { action: "created", topic: broadcast_data, user_id: Current.user.id }
         )
         render json: topic, status: :created
       else
@@ -166,25 +173,13 @@ module Collavre
       end
 
       topic = @creative.topics.find(params[:id])
-      agent = User.find(params[:agent_id])
+      agent = User.find_by(id: params[:agent_id])
 
-      unless agent.ai_user?
+      unless agent&.ai_user?
         render json: { error: I18n.t("collavre.topics.not_ai_agent") }, status: :unprocessable_entity and return
       end
 
-      policy = OrchestratorPolicy.find_or_initialize_by(
-        policy_type: "arbitration",
-        scope_type: "Topic",
-        scope_id: topic.id
-      )
-      policy.update!(
-        config: {
-          "strategy" => "primary_first",
-          "primary_agent_id" => agent.id
-        },
-        priority: 10,
-        enabled: true
-      )
+      topic.set_primary_agent!(agent)
 
       TopicsChannel.broadcast_to(
         @creative,

--- a/engines/collavre/app/javascript/controllers/comments/presence_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/presence_controller.js
@@ -204,6 +204,28 @@ export default class extends Controller {
       if (user.email) img.dataset.email = user.email
       img.dataset.userId = user.id
       img.dataset.userName = user.name
+
+      // AI agents are draggable to topic tabs
+      if (user.ai_user) {
+        wrapper.draggable = true
+        wrapper.classList.add('ai-agent-draggable')
+        wrapper.dataset.agentId = user.id
+        wrapper.dataset.agentName = user.name
+        wrapper.dataset.agentAvatarUrl = user.avatar_url
+        wrapper.addEventListener('dragstart', (e) => {
+          e.dataTransfer.setData('application/x-agent-drop', JSON.stringify({
+            id: user.id,
+            name: user.name,
+            avatar_url: user.avatar_url
+          }))
+          e.dataTransfer.effectAllowed = 'copy'
+          wrapper.classList.add('dragging')
+        })
+        wrapper.addEventListener('dragend', () => {
+          wrapper.classList.remove('dragging')
+        })
+      }
+
       wrapper.appendChild(img)
 
       if (user.default_avatar) {

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -839,13 +839,11 @@ export default class extends Controller {
                     'Content-Type': 'application/json',
                     'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').content
                 },
-                body: JSON.stringify({ topic: { name: topicName } })
+                body: JSON.stringify({ topic: { name: topicName }, agent_id: agent.id })
             })
 
             if (response.ok) {
                 const topic = await response.json()
-                // Set the agent as primary agent on the new topic
-                await this.setTopicPrimaryAgent(topic.id, agent)
                 this.currentTopicId = topic.id
                 await this.loadTopics()
                 this.dispatch("change", { detail: { topicId: topic.id } })

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -147,7 +147,8 @@ export default class extends Controller {
 
         // Add create button container (write permission is sufficient for topic creation)
         if (canCreateTopic) {
-            html += `<span class="topic-creation-container" data-comments--topics-target="creationContainer">
+            html += `<span class="topic-creation-container" data-comments--topics-target="creationContainer"
+                          data-action="dragover->comments--topics#handleAddButtonDragOver dragleave->comments--topics#handleDragLeave drop->comments--topics#handleAddButtonDrop">
                   <button class="add-topic-btn" data-action="click->comments--topics#showInput">+</button>
                  </span>`
         }
@@ -156,11 +157,13 @@ export default class extends Controller {
     }
 
     handleDragOver(event) {
-        // Only accept comment drops
-        if (!event.dataTransfer.types.includes('application/x-comment-ids')) return
+        // Accept comment drops or agent drops
+        const isComment = event.dataTransfer.types.includes('application/x-comment-ids')
+        const isAgent = event.dataTransfer.types.includes('application/x-agent-drop')
+        if (!isComment && !isAgent) return
 
         event.preventDefault()
-        event.dataTransfer.dropEffect = 'move'
+        event.dataTransfer.dropEffect = isAgent ? 'copy' : 'move'
         event.currentTarget.classList.add('drag-over')
     }
 
@@ -172,6 +175,18 @@ export default class extends Controller {
         event.preventDefault()
         event.currentTarget.classList.remove('drag-over')
 
+        // Handle agent drop
+        const agentJson = event.dataTransfer.getData('application/x-agent-drop')
+        if (agentJson) {
+            const agent = JSON.parse(agentJson)
+            const targetTopicId = event.currentTarget.dataset.id
+            if (targetTopicId) {
+                await this.setTopicPrimaryAgent(targetTopicId, agent)
+            }
+            return
+        }
+
+        // Handle comment drop
         const commentIdsJson = event.dataTransfer.getData('application/x-comment-ids')
         if (!commentIdsJson) return
 
@@ -769,6 +784,77 @@ export default class extends Controller {
 
         this.renderTopics(this.topics, this.canManageTopics, this.canCreateTopic)
         this.restoreSelection()
+    }
+
+    handleAddButtonDragOver(event) {
+        if (!event.dataTransfer.types.includes('application/x-agent-drop')) return
+        event.preventDefault()
+        event.dataTransfer.dropEffect = 'copy'
+        event.currentTarget.classList.add('drag-over')
+    }
+
+    async handleAddButtonDrop(event) {
+        event.preventDefault()
+        event.currentTarget.classList.remove('drag-over')
+
+        const agentJson = event.dataTransfer.getData('application/x-agent-drop')
+        if (!agentJson) return
+
+        const agent = JSON.parse(agentJson)
+        await this.createTopicWithAgent(agent)
+    }
+
+    async setTopicPrimaryAgent(topicId, agent) {
+        if (!this.creativeId) return
+
+        try {
+            const response = await fetch(`/creatives/${this.creativeId}/topics/${topicId}/set_primary_agent`, {
+                method: 'PATCH',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').content
+                },
+                body: JSON.stringify({ agent_id: agent.id })
+            })
+
+            if (!response.ok) {
+                const data = await response.json()
+                console.error('Failed to set primary agent:', data.error)
+            }
+            // Topic update comes via WebSocket broadcast
+        } catch (e) {
+            console.error('Error setting primary agent', e)
+        }
+    }
+
+    async createTopicWithAgent(agent) {
+        if (!this.creativeId) return
+
+        const topicName = `Talk to ${agent.name}`
+
+        try {
+            const response = await fetch(`/creatives/${this.creativeId}/topics`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').content
+                },
+                body: JSON.stringify({ topic: { name: topicName } })
+            })
+
+            if (response.ok) {
+                const topic = await response.json()
+                // Set the agent as primary agent on the new topic
+                await this.setTopicPrimaryAgent(topic.id, agent)
+                this.currentTopicId = topic.id
+                await this.loadTopics()
+                this.dispatch("change", { detail: { topicId: topic.id } })
+            } else {
+                console.error('Failed to create topic with agent')
+            }
+        } catch (e) {
+            console.error('Error creating topic with agent', e)
+        }
     }
 
     escapeAttr(str) {

--- a/engines/collavre/app/models/collavre/topic.rb
+++ b/engines/collavre/app/models/collavre/topic.rb
@@ -29,6 +29,23 @@ module Collavre
       User.find_by(id: policy.config["primary_agent_id"])
     end
 
+    # Sets or replaces the primary agent for this topic
+    def set_primary_agent!(agent)
+      policy = OrchestratorPolicy.find_or_initialize_by(
+        policy_type: "arbitration",
+        scope_type: "Topic",
+        scope_id: id
+      )
+      policy.update!(
+        config: {
+          "strategy" => "primary_first",
+          "primary_agent_id" => agent.id
+        },
+        priority: 10,
+        enabled: true
+      )
+    end
+
     def archived?
       archived_at.present?
     end

--- a/engines/collavre/app/services/collavre/comments/topic_command.rb
+++ b/engines/collavre/app/services/collavre/comments/topic_command.rb
@@ -108,19 +108,7 @@ module Collavre
       end
 
       def set_primary_agent(topic, agent)
-        policy = OrchestratorPolicy.find_or_initialize_by(
-          policy_type: "arbitration",
-          scope_type: "Topic",
-          scope_id: topic.id
-        )
-        policy.update!(
-          config: {
-            "strategy" => "primary_first",
-            "primary_agent_id" => agent.id
-          },
-          priority: 10,
-          enabled: true
-        )
+        topic.set_primary_agent!(agent)
       end
     end
   end

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -8,6 +8,7 @@ en:
       archive: Archive
       unarchive: Restore
       archived_topics: "Archived topics (%{count})"
+      not_ai_agent: Only AI agents can be set as primary agent.
       move:
         no_target_permission: You don't have write permission on the target creative.
         duplicate_name: A topic named '%{name}' already exists in the target creative.

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -8,6 +8,7 @@ ko:
       archive: 아카이브
       unarchive: 복원
       archived_topics: "아카이브된 토픽 (%{count}개)"
+      not_ai_agent: AI 에이전트만 Primary Agent로 설정할 수 있습니다.
       move:
         no_target_permission: 대상 크리에이티브에 대한 쓰기 권한이 없습니다.
         duplicate_name: "'%{name}' 토픽이 대상 크리에이티브에 이미 존재합니다."

--- a/engines/collavre/config/routes.rb
+++ b/engines/collavre/config/routes.rb
@@ -59,6 +59,7 @@ Collavre::Engine.routes.draw do
         patch :move
         patch :archive
         patch :unarchive
+        patch :set_primary_agent
       end
     end
     resources :comments, only: [ :index, :create, :destroy, :show, :update ] do

--- a/engines/collavre/test/controllers/topics_controller_test.rb
+++ b/engines/collavre/test/controllers/topics_controller_test.rb
@@ -117,6 +117,71 @@ class TopicsControllerTest < ActionDispatch::IntegrationTest
     assert json["error"].include?(@topic.name)
   end
 
+  test "should set primary agent on topic" do
+    ai_agent = User.create!(
+      email: "agent@test.local", password: "password123", name: "TestAgent",
+      llm_vendor: "openai", llm_model: "gpt-4", searchable: true
+    )
+
+    patch set_primary_agent_creative_topic_url(@creative, @topic),
+      params: { agent_id: ai_agent.id }, as: :json
+
+    assert_response :success
+    policy = Collavre::OrchestratorPolicy.find_by(scope_type: "Topic", scope_id: @topic.id)
+    assert_equal ai_agent.id, policy.config["primary_agent_id"]
+  end
+
+  test "should replace existing primary agent" do
+    old_agent = User.create!(
+      email: "old@test.local", password: "password123", name: "OldAgent",
+      llm_vendor: "openai", llm_model: "gpt-4", searchable: true
+    )
+    new_agent = User.create!(
+      email: "new@test.local", password: "password123", name: "NewAgent",
+      llm_vendor: "openai", llm_model: "gpt-4", searchable: true
+    )
+    @topic.set_primary_agent!(old_agent)
+
+    patch set_primary_agent_creative_topic_url(@creative, @topic),
+      params: { agent_id: new_agent.id }, as: :json
+
+    assert_response :success
+    policy = Collavre::OrchestratorPolicy.find_by(scope_type: "Topic", scope_id: @topic.id)
+    assert_equal new_agent.id, policy.config["primary_agent_id"]
+  end
+
+  test "should reject non-AI user as primary agent" do
+    patch set_primary_agent_creative_topic_url(@creative, @topic),
+      params: { agent_id: @user.id }, as: :json
+
+    assert_response :unprocessable_entity
+  end
+
+  test "should reject invalid agent_id" do
+    patch set_primary_agent_creative_topic_url(@creative, @topic),
+      params: { agent_id: 999999 }, as: :json
+
+    assert_response :unprocessable_entity
+  end
+
+  test "should create topic with agent_id" do
+    ai_agent = User.create!(
+      email: "agent2@test.local", password: "password123", name: "Agent2",
+      llm_vendor: "openai", llm_model: "gpt-4", searchable: true
+    )
+
+    assert_difference("Topic.count") do
+      post collavre.creative_topics_url(@creative),
+        params: { topic: { name: "Talk to Agent2" }, agent_id: ai_agent.id }, as: :json
+    end
+
+    assert_response :created
+    topic = @creative.topics.find_by(name: "Talk to Agent2")
+    assert topic.present?
+    policy = Collavre::OrchestratorPolicy.find_by(scope_type: "Topic", scope_id: topic.id)
+    assert_equal ai_agent.id, policy.config["primary_agent_id"]
+  end
+
   test "new topic should be created at the end after reordering" do
     # Create initial topics
     topic2 = @creative.topics.create!(name: "Topic 2", user: @user)


### PR DESCRIPTION
## Summary

Enables drag & drop of AI agents from the chat participant list to topic tabs for managing primary agents.

## Features

### 1. Drag AI Agent → Existing Topic Tab
- Sets the dropped agent as the topic's primary agent
- If a primary agent already exists, it is replaced
- Uses new `PATCH /topics/:id/set_primary_agent` API
- Topic avatar updates instantly via WebSocket broadcast

### 2. Drag AI Agent → '+' (Add Topic) Button
- Creates a new topic named `Talk to {agent name}`
- Automatically sets the agent as primary agent
- Auto-selects the new topic

## Changes

### Backend
- `TopicsController#set_primary_agent`: New endpoint to set/replace primary agent
- `CommentsController#participants`: Added `ai_user` flag to response
- Routes: Added `patch :set_primary_agent` to topics member routes
- i18n: Added `not_ai_agent` error message (en/ko)

### Frontend
- `presence_controller.js`: AI agent avatars are draggable with `application/x-agent-drop` data
- `topics_controller.js`: Topic tabs and '+' button accept agent drops
- CSS: Drag cursor, opacity, and drop highlight styles