### PR TITLE
fix: run db:prepare and db:seed on worktree creation

### DIFF
--- a/bin/setup_worktree
+++ b/bin/setup_worktree
@@ -62,10 +62,19 @@ done < "$RESOURCES_FILE"
 
 echo ""
 
+# Install gems
+echo "📦 Installing dependencies (bundle install)..."
+(cd "$CURRENT" && bundle install 2>&1) || echo "   ⚠️  bundle install failed — run manually if needed"
+
 # Build JS/CSS assets so Propshaft can find them
 if [ -f "$CURRENT/package.json" ]; then
   echo "📦 Building assets (npm run build)..."
   (cd "$CURRENT" && npm run build 2>&1) || echo "   ⚠️  npm run build failed — run manually if needed"
 fi
+
+# Prepare database (create + migrate) and seed
+echo "🗄️  Preparing database (db:prepare + db:seed)..."
+(cd "$CURRENT" && bin/rails db:prepare 2>&1) || echo "   ⚠️  db:prepare failed — run manually if needed"
+(cd "$CURRENT" && bin/rails db:seed 2>&1) || echo "   ⚠️  db:seed failed — run manually if needed"
 
 echo "🎉 Worktree setup complete!"


### PR DESCRIPTION
## Summary

Add automatic database setup when creating a new git worktree.

## Changes

- **`bin/setup_worktree`**: Added `bundle install`, `db:prepare`, and `db:seed` steps after symlink setup and asset build.

## How it works

The existing `.githooks/post-checkout` hook detects new worktree creation (null previous ref) and calls `bin/setup_worktree`. This change extends that script to:

1. **`bundle install`** — Install gem dependencies
2. **`db:prepare`** — Create and migrate the SQLite database
3. **`db:seed`** — Seed the database with default data

Each step gracefully handles failures with a warning message, allowing the user to retry manually if needed.

## Notes

- SQLite databases are per-worktree (`storage/development.sqlite3`), so each worktree needs its own db setup.
- `db:prepare` is idempotent — safe to run if the database already exists.