### PR TITLE
feat: add select-all toggle checkbox to comment selection action bar

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -1374,6 +1374,23 @@ body.chat-fullscreen {
     flex-wrap: wrap;
 }
 
+.selection-action-bar-select-all {
+    display: flex;
+    align-items: center;
+    gap: var(--space-1);
+    font-size: 0.85em;
+    font-weight: bold;
+    color: var(--color-text);
+    cursor: pointer;
+    user-select: none;
+    white-space: nowrap;
+}
+
+.selection-action-bar-select-all-checkbox {
+    cursor: pointer;
+    margin: 0;
+}
+
 .selection-action-bar-count {
     font-size: 0.85em;
     font-weight: bold;

--- a/engines/collavre/app/javascript/controllers/comments/list_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/list_controller.js
@@ -513,13 +513,17 @@ export default class extends Controller {
     if (this.selection.size === 0) return
 
     const count = this.selection.size
+    const total = this.listTarget.querySelectorAll('.comment-select-checkbox').length
+    const allSelected = count === total
     const i18n = (key, fallback) => this.element.dataset[key] || fallback
+    const selectAllLabel = i18n('selectionSelectAllText', 'All')
 
     const bar = document.createElement('div')
     bar.className = 'selection-action-bar'
     bar.innerHTML = `
       <div class="selection-action-bar-main">
-        <span class="selection-action-bar-count">${i18n('selectionCountText', '{count}개 선택').replace('{count}', count)}</span>
+        <label class="selection-action-bar-select-all"><input type="checkbox" class="selection-action-bar-select-all-checkbox"${allSelected ? ' checked' : ''}> ${selectAllLabel}</label>
+        <span class="selection-action-bar-count">${i18n('selectionCountText', '{count}/{total}개 선택').replace('{count}', count).replace('{total}', total)}</span>
         <button type="button" class="selection-action-bar-btn selection-action-delete" title="${i18n('selectionDeleteText', 'Delete')}">🗑 ${i18n('selectionDeleteText', 'Delete')}</button>
         <button type="button" class="selection-action-bar-btn selection-action-merge" title="${i18n('selectionMergeText', 'Merge')}"${count < 2 ? ' disabled' : ''}>🔗 ${i18n('selectionMergeText', 'Merge')}</button>
         <button type="button" class="selection-action-bar-btn selection-action-move" title="${i18n('selectionMoveText', 'Move')}">📤 ${i18n('selectionMoveText', 'Move')}</button>
@@ -530,6 +534,38 @@ export default class extends Controller {
         💡 ${i18n('selectionDragHintText', 'Drag & drop to move to topic')}
       </div>
     `
+
+    // Set indeterminate state if partially selected
+    const selectAllCheckbox = bar.querySelector('.selection-action-bar-select-all-checkbox')
+    if (count > 0 && !allSelected) {
+      selectAllCheckbox.indeterminate = true
+    }
+
+    // Select All toggle handler
+    selectAllCheckbox.addEventListener('change', () => {
+      const shouldSelect = selectAllCheckbox.checked
+      this.listTarget.querySelectorAll('.comment-select-checkbox').forEach((checkbox) => {
+        const commentId = checkbox.value
+        const item = checkbox.closest('.comment-item')
+        if (shouldSelect && !checkbox.checked) {
+          checkbox.checked = true
+          this.selection.add(commentId)
+          if (item) {
+            item.classList.add('selected-for-move')
+            item.setAttribute('draggable', 'true')
+          }
+        } else if (!shouldSelect && checkbox.checked) {
+          checkbox.checked = false
+          this.selection.delete(commentId)
+          if (item) {
+            item.classList.remove('selected-for-move')
+            item.removeAttribute('draggable')
+          }
+        }
+      })
+      this.notifySelectionChange()
+      this.updateSelectionActionBar()
+    })
 
     bar.querySelector('.selection-action-delete').addEventListener('click', (e) => { e.stopPropagation(); this.deleteSelectedComments() })
     bar.querySelector('.selection-action-merge').addEventListener('click', (e) => { e.stopPropagation(); this.mergeSelectedComments() })

--- a/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
@@ -29,6 +29,7 @@
      data-voice-stop-text="<%= t('collavre.comments.voice_stop') %>"
      data-move-no-selection-text="<%= t('collavre.comments.move_no_selection') %>"
      data-move-error-text="<%= t('collavre.comments.move_error') %>"
+     data-selection-select-all-text="<%= t('collavre.comments.select_all') %>"
      data-selection-count-text="<%= t('collavre.comments.selection_count') %>"
      data-selection-delete-text="<%= t('collavre.comments.selection_delete') %>"
      data-selection-move-text="<%= t('collavre.comments.selection_move') %>"

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -86,7 +86,8 @@ en:
       move_no_selection: Select at least one message to move.
       move_error: Unable to move messages.
       add_participant: Add user
-      selection_count: "{count} selected"
+      select_all: All
+      selection_count: "{count}/{total} selected"
       selection_delete: Delete
       selection_move: Move
       selection_topic_move: Move to topic

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -83,7 +83,8 @@ ko:
       move_no_selection: 이동할 메시지를 선택해주세요.
       move_error: 메시지를 이동할 수 없습니다.
       add_participant: 사용자 추가
-      selection_count: "{count}개 선택"
+      select_all: 전체
+      selection_count: "{count}/{total}개 선택"
       selection_delete: 삭제
       selection_move: 이동
       selection_topic_move: 토픽 이동


### PR DESCRIPTION
## Summary

Add a "Select All" toggle checkbox to the comment selection action bar for bulk operations.

## Changes

- **JavaScript** (`list_controller.js`): Added select-all checkbox to `updateSelectionActionBar()` with:
  - Toggle all comment checkboxes on check/uncheck
  - Indeterminate state when partially selected
  - Count display in `selected/total` format (e.g. `3/12 selected`)
  
- **i18n** (en + ko): Added `select_all` key, updated `selection_count` to include `{total}` placeholder

- **CSS** (`comments_popup.css`): Styled `.selection-action-bar-select-all` using design tokens

- **ERB** (`_comments_popup.html.erb`): Added `data-selection-select-all-text` attribute

## UI

```
[☑ All] 3/12개 선택 | 🗑 삭제 | 🔗 머지 | 📤 이동 | 🏷 토픽 | ✕
```

When partially selected, the checkbox shows indeterminate state (dash).