### PR TITLE
feat: create new topic from selected messages via drag-drop and search popup

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -1539,3 +1539,8 @@ body.chat-fullscreen {
     0%, 70% { opacity: 1; }
     100% { opacity: 0; }
 }
+
+.topic-create-option {
+    color: var(--link);
+    font-style: italic;
+}

--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -1544,3 +1544,7 @@ body.chat-fullscreen {
     color: var(--link);
     font-style: italic;
 }
+
+li:hover .topic-create-option {
+    text-decoration: underline;
+}

--- a/engines/collavre/app/controllers/collavre/topics_controller.rb
+++ b/engines/collavre/app/controllers/collavre/topics_controller.rb
@@ -27,22 +27,47 @@ module Collavre
       topic = @creative.topics.build(topic_params)
       topic.user = Current.user
 
-      if topic.save
-        agent = nil
-        if params[:agent_id].present?
-          agent = User.find_by(id: params[:agent_id])
-          topic.set_primary_agent!(agent) if agent&.ai_user?
-        end
+      Topic.transaction do
+        if topic.save
+          agent = nil
+          if params[:agent_id].present?
+            agent = User.find_by(id: params[:agent_id])
+            topic.set_primary_agent!(agent) if agent&.ai_user?
+          end
 
-        broadcast_data = agent ? topic_json_with_agent(topic, agent) : topic.slice(:id, :name)
-        TopicsChannel.broadcast_to(
-          @creative,
-          { action: "created", topic: broadcast_data, user_id: Current.user.id }
-        )
-        render json: topic, status: :created
-      else
-        render json: { errors: topic.errors.full_messages }, status: :unprocessable_entity
+          # Move comments to the new topic if comment_ids provided
+          comment_ids = Array(params[:comment_ids]).map(&:presence).compact
+          if comment_ids.any?
+            CommentMoveService.new(creative: @creative, user: Current.user).call(
+              comment_ids: comment_ids,
+              target_topic_id: topic.id
+            )
+          end
+
+          broadcast_data = agent ? topic_json_with_agent(topic, agent) : topic.slice(:id, :name)
+          TopicsChannel.broadcast_to(
+            @creative,
+            { action: "created", topic: broadcast_data, user_id: Current.user.id }
+          )
+          render json: topic, status: :created
+        else
+          render json: { errors: topic.errors.full_messages }, status: :unprocessable_entity
+        end
       end
+    end
+
+    def next_name
+      prefix = I18n.t("collavre.topics.default_name_prefix")
+      existing_numbers = @creative.topics
+        .where("name LIKE ?", "#{Topic.sanitize_sql_like(prefix)}%")
+        .pluck(:name)
+        .filter_map { |n|
+          suffix = n.delete_prefix(prefix)
+          suffix.match?(/\A\d+\z/) ? suffix.to_i : nil
+        }
+
+      next_number = (existing_numbers.max || 0) + 1
+      render json: { name: "#{prefix}#{next_number}" }
     end
 
     def update

--- a/engines/collavre/app/controllers/collavre/topics_controller.rb
+++ b/engines/collavre/app/controllers/collavre/topics_controller.rb
@@ -54,20 +54,16 @@ module Collavre
           render json: { errors: topic.errors.full_messages }, status: :unprocessable_entity
         end
       end
+    rescue CommentMoveService::MoveError => e
+      render json: { errors: [ e.message ] }, status: :unprocessable_entity
     end
 
     def next_name
-      prefix = I18n.t("collavre.topics.default_name_prefix")
-      existing_numbers = @creative.topics
-        .where("name LIKE ?", "#{Topic.sanitize_sql_like(prefix)}%")
-        .pluck(:name)
-        .filter_map { |n|
-          suffix = n.delete_prefix(prefix)
-          suffix.match?(/\A\d+\z/) ? suffix.to_i : nil
-        }
+      unless @creative.has_permission?(Current.user, :read) || @creative.user == Current.user
+        render json: { error: I18n.t("collavre.topics.no_permission") }, status: :forbidden and return
+      end
 
-      next_number = (existing_numbers.max || 0) + 1
-      render json: { name: "#{prefix}#{next_number}" }
+      render json: { name: generate_next_topic_name }
     end
 
     def update
@@ -225,6 +221,20 @@ module Collavre
 
     def topic_params
       params.require(:topic).permit(:name)
+    end
+
+    def generate_next_topic_name
+      prefix = I18n.t("collavre.topics.default_name_prefix")
+      existing_numbers = @creative.topics.active
+        .where("name LIKE ?", "#{Topic.sanitize_sql_like(prefix)}%")
+        .pluck(:name)
+        .filter_map { |n|
+          suffix = n.delete_prefix(prefix)
+          suffix.match?(/\A\d+\z/) ? suffix.to_i : nil
+        }
+
+      next_number = (existing_numbers.max || 0) + 1
+      "#{prefix}#{next_number}"
     end
 
     # Batch-load primary agents for all topics to avoid N+1 queries

--- a/engines/collavre/app/javascript/controllers/comments/list_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/list_controller.js
@@ -644,15 +644,23 @@ export default class extends Controller {
   openTopicSearchPopup(event) {
     if (this.selection.size === 0) return
 
+    const commentIds = Array.from(this.selection)
+
     const openWithController = (controller, btnRect) => {
       controller.openForCreative(
         this.creativeId,
         btnRect,
         (topic) => {
-          const commentIds = Array.from(this.selection)
-          this.handleMoveToTopic({ detail: { commentIds, targetTopicId: topic.id } })
+          if (topic.created) {
+            // Topic was just created with comments moved — refresh
+            this.clearSelection()
+            this.loadInitialComments()
+          } else {
+            this.handleMoveToTopic({ detail: { commentIds, targetTopicId: topic.id } })
+          }
         },
-        this.element.dataset.topicMainText || 'Main'
+        this.element.dataset.topicMainText || 'Main',
+        commentIds
       )
     }
 
@@ -674,6 +682,7 @@ export default class extends Controller {
     modal.className = 'common-popup'
     modal.style.display = 'none'
     modal.dataset.controller = 'topic-search'
+    modal.dataset.createAndMoveText = this.element.dataset.topicCreateAndMoveText || 'Create "%{name}" and move'
     modal.innerHTML = `
       <button type="button" class="popup-close-btn" data-topic-search-target="close">&times;</button>
       <input type="text" class="shared-input-surface" style="width:100%;margin-bottom:0.5em;"

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -1,5 +1,6 @@
 import { Controller } from "@hotwired/stimulus"
 import { createSubscription } from "../../services/cable"
+import { fetchNextTopicName, createTopicWithComments } from "../../lib/api/topics"
 
 const ICON_ARCHIVE = `<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="5" rx="1"/><path d="M4 8v11a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8"/><path d="M10 12h4"/></svg>`
 const ICON_RESTORE = `<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7v6h6"/><path d="M21 17a9 9 0 0 0-9-9 9 9 0 0 0-6.69 3L3 13"/></svg>`
@@ -820,51 +821,23 @@ export default class extends Controller {
     async createTopicAndMoveComments(commentIds, topicName = null) {
         if (!this.creativeId) return
 
-        try {
-            // Fetch auto-generated name if not provided
-            const name = topicName || await this.fetchNextTopicName()
-            if (!name) return
+        const name = topicName || await fetchNextTopicName(this.creativeId)
+        if (!name) return
 
-            const response = await fetch(`/creatives/${this.creativeId}/topics`, {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').content
-                },
-                body: JSON.stringify({ topic: { name }, comment_ids: commentIds })
-            })
+        const result = await createTopicWithComments(this.creativeId, name, commentIds)
+        if (result.ok) {
+            this.currentTopicId = result.topic.id
+            await this.loadTopics()
+            this.dispatch("change", { detail: { topicId: result.topic.id } })
 
-            if (response.ok) {
-                const topic = await response.json()
-                this.currentTopicId = topic.id
-                await this.loadTopics()
-                this.dispatch("change", { detail: { topicId: topic.id } })
-
-                // Clear selection in list controller
-                const listController = this.application.getControllerForElementAndIdentifier(
-                    this.element, 'comments--list'
-                )
-                if (listController) listController.clearSelection()
-            } else {
-                const data = await response.json().catch(() => ({}))
-                console.error('Failed to create topic and move comments:', data.errors || data.error)
-            }
-        } catch (e) {
-            console.error('Error creating topic with comments', e)
+            // Clear selection in list controller
+            const listController = this.application.getControllerForElementAndIdentifier(
+                this.element, 'comments--list'
+            )
+            if (listController) listController.clearSelection()
+        } else {
+            alert(result.error)
         }
-    }
-
-    async fetchNextTopicName() {
-        try {
-            const response = await fetch(`/creatives/${this.creativeId}/topics/next_name`)
-            if (response.ok) {
-                const data = await response.json()
-                return data.name
-            }
-        } catch (e) {
-            console.error('Error fetching next topic name', e)
-        }
-        return null
     }
 
     async setTopicPrimaryAgent(topicId, agent) {

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -787,9 +787,11 @@ export default class extends Controller {
     }
 
     handleAddButtonDragOver(event) {
-        if (!event.dataTransfer.types.includes('application/x-agent-drop')) return
+        const isAgent = event.dataTransfer.types.includes('application/x-agent-drop')
+        const isComment = event.dataTransfer.types.includes('application/x-comment-ids')
+        if (!isAgent && !isComment) return
         event.preventDefault()
-        event.dataTransfer.dropEffect = 'copy'
+        event.dataTransfer.dropEffect = isAgent ? 'copy' : 'move'
         event.currentTarget.classList.add('drag-over')
     }
 
@@ -797,11 +799,72 @@ export default class extends Controller {
         event.preventDefault()
         event.currentTarget.classList.remove('drag-over')
 
+        // Handle comment drop → create new topic + move
+        const commentIdsJson = event.dataTransfer.getData('application/x-comment-ids')
+        if (commentIdsJson) {
+            const commentIds = JSON.parse(commentIdsJson)
+            if (commentIds && commentIds.length > 0) {
+                await this.createTopicAndMoveComments(commentIds)
+            }
+            return
+        }
+
+        // Handle agent drop (existing logic)
         const agentJson = event.dataTransfer.getData('application/x-agent-drop')
         if (!agentJson) return
 
         const agent = JSON.parse(agentJson)
         await this.createTopicWithAgent(agent)
+    }
+
+    async createTopicAndMoveComments(commentIds, topicName = null) {
+        if (!this.creativeId) return
+
+        try {
+            // Fetch auto-generated name if not provided
+            const name = topicName || await this.fetchNextTopicName()
+            if (!name) return
+
+            const response = await fetch(`/creatives/${this.creativeId}/topics`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').content
+                },
+                body: JSON.stringify({ topic: { name }, comment_ids: commentIds })
+            })
+
+            if (response.ok) {
+                const topic = await response.json()
+                this.currentTopicId = topic.id
+                await this.loadTopics()
+                this.dispatch("change", { detail: { topicId: topic.id } })
+
+                // Clear selection in list controller
+                const listController = this.application.getControllerForElementAndIdentifier(
+                    this.element, 'comments--list'
+                )
+                if (listController) listController.clearSelection()
+            } else {
+                const data = await response.json().catch(() => ({}))
+                console.error('Failed to create topic and move comments:', data.errors || data.error)
+            }
+        } catch (e) {
+            console.error('Error creating topic with comments', e)
+        }
+    }
+
+    async fetchNextTopicName() {
+        try {
+            const response = await fetch(`/creatives/${this.creativeId}/topics/next_name`)
+            if (response.ok) {
+                const data = await response.json()
+                return data.name
+            }
+        } catch (e) {
+            console.error('Error fetching next topic name', e)
+        }
+        return null
     }
 
     async setTopicPrimaryAgent(topicId, agent) {

--- a/engines/collavre/app/javascript/controllers/topic_search_controller.js
+++ b/engines/collavre/app/javascript/controllers/topic_search_controller.js
@@ -7,6 +7,9 @@ export default class extends CommonPopupController {
         super.connect()
         this._debounceTimer = null
         this._allTopics = []
+        this._defaultCreateItem = null
+        this._creativeId = null
+        this._commentIds = null
         this.inputTarget.addEventListener('input', this._onInput.bind(this))
         this.inputTarget.addEventListener('keydown', this.handleInputKeydown.bind(this))
         this.closeTarget.addEventListener('click', () => this.close())
@@ -20,9 +23,12 @@ export default class extends CommonPopupController {
         super.disconnect()
     }
 
-    openForCreative(creativeId, anchorRect, onSelectCallback, mainLabel = 'Main') {
+    openForCreative(creativeId, anchorRect, onSelectCallback, mainLabel = 'Main', commentIds = null) {
         this.onSelectCallback = onSelectCallback
         this._allTopics = []
+        this._defaultCreateItem = null
+        this._creativeId = creativeId
+        this._commentIds = commentIds
         this.setItems([])
         this.inputTarget.value = ''
         super.open(anchorRect)
@@ -50,54 +56,129 @@ export default class extends CommonPopupController {
     }
 
     _onInput() {
-        const q = this.inputTarget.value.toLowerCase()
+        const q = this.inputTarget.value.toLowerCase().trim()
         if (!q) {
-            this.setItems(this._allTopics)
+            // No query: show all topics + default create option
+            const items = [...this._allTopics]
+            if (this._defaultCreateItem) {
+                items.push(this._defaultCreateItem)
+            }
+            this.setItems(items)
             return
         }
         const filtered = this._allTopics.filter(t =>
             (t.label || '').toLowerCase().includes(q)
         )
+        // If no match found, show "create and move" option with the query as name
+        if (filtered.length === 0) {
+            const createLabel = this.element.dataset.createAndMoveText || 'Create "%{name}" and move'
+            filtered.push({
+                id: '__create__',
+                label: `+ ${createLabel.replace('%{name}', this.inputTarget.value.trim())}`,
+                createName: this.inputTarget.value.trim(),
+                isCreate: true
+            })
+        }
         this.setItems(filtered)
     }
 
     async _loadTopics(creativeId, mainLabel) {
         if (!creativeId) return
         try {
-            const response = await fetch(`/creatives/${creativeId}/topics`, {
-                headers: { Accept: 'application/json' }
-            })
-            const data = await response.json()
+            const [topicsResponse, nextNameResponse] = await Promise.all([
+                fetch(`/creatives/${creativeId}/topics`, { headers: { Accept: 'application/json' } }),
+                fetch(`/creatives/${creativeId}/topics/next_name`, { headers: { Accept: 'application/json' } })
+            ])
+
+            const data = await topicsResponse.json()
             const topics = data.topics || []
 
             this._allTopics = [
                 { id: '', label: `📋 ${mainLabel}` },
                 ...topics.map(t => ({ id: t.id, label: `#${t.name}` }))
             ]
-            this.setItems(this._allTopics)
+
+            // Build default create item from next_name
+            if (nextNameResponse.ok) {
+                const nextNameData = await nextNameResponse.json()
+                const createLabel = this.element.dataset.createAndMoveText || 'Create "%{name}" and move'
+                this._defaultCreateItem = {
+                    id: '__create_default__',
+                    label: `+ ${createLabel.replace('%{name}', nextNameData.name)}`,
+                    createName: nextNameData.name,
+                    isCreate: true
+                }
+            }
+
+            const items = [...this._allTopics]
+            if (this._defaultCreateItem) {
+                items.push(this._defaultCreateItem)
+            }
+            this.setItems(items)
         } catch (error) {
             console.error('Error loading topics:', error)
             this.setItems([])
         }
     }
 
-    select(item) {
+    async select(item) {
+        if (item.isCreate && this._commentIds && this._commentIds.length > 0) {
+            // Create new topic + move comments
+            await this._createTopicAndMove(item.createName, this._commentIds)
+            this.close()
+            return
+        }
+
         if (this.onSelectCallback) {
             this.onSelectCallback(item)
         }
         this.close()
     }
 
+    async _createTopicAndMove(name, commentIds) {
+        if (!this._creativeId) return
+
+        try {
+            const response = await fetch(`/creatives/${this._creativeId}/topics`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').content
+                },
+                body: JSON.stringify({ topic: { name }, comment_ids: commentIds })
+            })
+
+            if (response.ok) {
+                const topic = await response.json()
+                // Notify via callback so list_controller refreshes
+                if (this.onSelectCallback) {
+                    this.onSelectCallback({ id: topic.id, label: `#${topic.name}`, created: true })
+                }
+            } else {
+                const data = await response.json().catch(() => ({}))
+                console.error('Failed to create topic:', data.errors || data.error)
+            }
+        } catch (e) {
+            console.error('Error creating topic and moving comments', e)
+        }
+    }
+
     renderItem(item) {
         const text = item.label || ''
-        return text
+        const escaped = text
             .replace(/&/g, "&amp;")
             .replace(/</g, "&lt;")
             .replace(/>/g, "&gt;")
+        if (item.isCreate) {
+            return `<span class="topic-create-option">${escaped}</span>`
+        }
+        return escaped
     }
 
     dispatchClose(reason) {
         this.onSelectCallback = null
+        this._commentIds = null
+        this._creativeId = null
         super.dispatchClose(reason)
     }
 }

--- a/engines/collavre/app/javascript/controllers/topic_search_controller.js
+++ b/engines/collavre/app/javascript/controllers/topic_search_controller.js
@@ -1,4 +1,5 @@
 import CommonPopupController from './common_popup_controller'
+import { fetchNextTopicName, createTopicWithComments } from '../lib/api/topics'
 
 export default class extends CommonPopupController {
     static targets = ['input', 'list', 'close']
@@ -69,8 +70,12 @@ export default class extends CommonPopupController {
         const filtered = this._allTopics.filter(t =>
             (t.label || '').toLowerCase().includes(q)
         )
-        // If no match found, show "create and move" option with the query as name
-        if (filtered.length === 0) {
+        // Always show "create and move" option with the query as name
+        // (even when there are partial matches, user may want to create a new one)
+        const exactMatch = this._allTopics.some(t =>
+            (t.label || '').toLowerCase() === `#${q}`
+        )
+        if (!exactMatch) {
             const createLabel = this.element.dataset.createAndMoveText || 'Create "%{name}" and move'
             filtered.push({
                 id: '__create__',
@@ -85,9 +90,9 @@ export default class extends CommonPopupController {
     async _loadTopics(creativeId, mainLabel) {
         if (!creativeId) return
         try {
-            const [topicsResponse, nextNameResponse] = await Promise.all([
+            const [topicsResponse, nextName] = await Promise.all([
                 fetch(`/creatives/${creativeId}/topics`, { headers: { Accept: 'application/json' } }),
-                fetch(`/creatives/${creativeId}/topics/next_name`, { headers: { Accept: 'application/json' } })
+                fetchNextTopicName(creativeId)
             ])
 
             const data = await topicsResponse.json()
@@ -99,13 +104,12 @@ export default class extends CommonPopupController {
             ]
 
             // Build default create item from next_name
-            if (nextNameResponse.ok) {
-                const nextNameData = await nextNameResponse.json()
+            if (nextName) {
                 const createLabel = this.element.dataset.createAndMoveText || 'Create "%{name}" and move'
                 this._defaultCreateItem = {
                     id: '__create_default__',
-                    label: `+ ${createLabel.replace('%{name}', nextNameData.name)}`,
-                    createName: nextNameData.name,
+                    label: `+ ${createLabel.replace('%{name}', nextName)}`,
+                    createName: nextName,
                     isCreate: true
                 }
             }
@@ -138,28 +142,13 @@ export default class extends CommonPopupController {
     async _createTopicAndMove(name, commentIds) {
         if (!this._creativeId) return
 
-        try {
-            const response = await fetch(`/creatives/${this._creativeId}/topics`, {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').content
-                },
-                body: JSON.stringify({ topic: { name }, comment_ids: commentIds })
-            })
-
-            if (response.ok) {
-                const topic = await response.json()
-                // Notify via callback so list_controller refreshes
-                if (this.onSelectCallback) {
-                    this.onSelectCallback({ id: topic.id, label: `#${topic.name}`, created: true })
-                }
-            } else {
-                const data = await response.json().catch(() => ({}))
-                console.error('Failed to create topic:', data.errors || data.error)
+        const result = await createTopicWithComments(this._creativeId, name, commentIds)
+        if (result.ok) {
+            if (this.onSelectCallback) {
+                this.onSelectCallback({ id: result.topic.id, label: `#${result.topic.name}`, created: true })
             }
-        } catch (e) {
-            console.error('Error creating topic and moving comments', e)
+        } else {
+            alert(result.error)
         }
     }
 

--- a/engines/collavre/app/javascript/lib/api/topics.js
+++ b/engines/collavre/app/javascript/lib/api/topics.js
@@ -1,0 +1,64 @@
+/**
+ * Topics API helper — shared between topics_controller and topic_search_controller
+ */
+
+function csrfToken() {
+    return document.querySelector('meta[name="csrf-token"]')?.content
+}
+
+/**
+ * Fetch the next auto-generated topic name for a creative.
+ * @param {string|number} creativeId
+ * @returns {Promise<string|null>}
+ */
+export async function fetchNextTopicName(creativeId) {
+    try {
+        const response = await fetch(`/creatives/${creativeId}/topics/next_name`, {
+            headers: { Accept: 'application/json' }
+        })
+        if (response.ok) {
+            const data = await response.json()
+            return data.name
+        }
+    } catch (e) {
+        console.error('Error fetching next topic name', e)
+    }
+    return null
+}
+
+/**
+ * Create a new topic and optionally move comments into it.
+ * @param {string|number} creativeId
+ * @param {string} name - topic name
+ * @param {string[]|number[]} commentIds - comments to move (optional)
+ * @returns {Promise<{ok: boolean, topic?: object, error?: string}>}
+ */
+export async function createTopicWithComments(creativeId, name, commentIds = []) {
+    try {
+        const body = { topic: { name } }
+        if (commentIds.length > 0) {
+            body.comment_ids = commentIds
+        }
+
+        const response = await fetch(`/creatives/${creativeId}/topics`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-CSRF-Token': csrfToken()
+            },
+            body: JSON.stringify(body)
+        })
+
+        if (response.ok) {
+            const topic = await response.json()
+            return { ok: true, topic }
+        } else {
+            const data = await response.json().catch(() => ({}))
+            const error = (data.errors || [data.error]).filter(Boolean).join(', ') || 'Failed to create topic'
+            return { ok: false, error }
+        }
+    } catch (e) {
+        console.error('Error creating topic with comments', e)
+        return { ok: false, error: e.message }
+    }
+}

--- a/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
@@ -41,6 +41,7 @@
      data-batch-delete-confirm-text="<%= t('collavre.comments.batch_delete_confirm') %>"
      data-topic-search-placeholder-text="<%= t('collavre.comments.topic_search_placeholder') %>"
      data-topic-main-text="<%= t('collavre.comments.topic_main') %>"
+     data-topic-create-and-move-text="<%= t('collavre.topics.create_and_move', name: '%{name}') %>"
      data-add-participant-text="<%= t('collavre.comments.add_participant') %>"
      data-review-button-text="<%= t('collavre.comments.review_button') %>"
      data-review-feedback-placeholder="<%= t('collavre.comments.review_feedback_placeholder') %>"

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -9,6 +9,8 @@ en:
       unarchive: Restore
       archived_topics: "Archived topics (%{count})"
       not_ai_agent: Only AI agents can be set as primary agent.
+      default_name_prefix: "Topic"
+      create_and_move: 'Create "%{name}" and move'
       move:
         no_target_permission: You don't have write permission on the target creative.
         duplicate_name: A topic named '%{name}' already exists in the target creative.

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -9,6 +9,8 @@ ko:
       unarchive: 복원
       archived_topics: "아카이브된 토픽 (%{count}개)"
       not_ai_agent: AI 에이전트만 Primary Agent로 설정할 수 있습니다.
+      default_name_prefix: "토픽"
+      create_and_move: '"%{name}" 생성후 이동'
       move:
         no_target_permission: 대상 크리에이티브에 대한 쓰기 권한이 없습니다.
         duplicate_name: "'%{name}' 토픽이 대상 크리에이티브에 이미 존재합니다."

--- a/engines/collavre/config/routes.rb
+++ b/engines/collavre/config/routes.rb
@@ -54,6 +54,7 @@ Collavre::Engine.routes.draw do
     resources :topics, only: [ :index, :create, :update, :destroy ] do
       collection do
         post :reorder
+        get :next_name
       end
       member do
         patch :move

--- a/engines/collavre/test/controllers/topics_controller_test.rb
+++ b/engines/collavre/test/controllers/topics_controller_test.rb
@@ -182,6 +182,47 @@ class TopicsControllerTest < ActionDispatch::IntegrationTest
     assert_equal ai_agent.id, policy.config["primary_agent_id"]
   end
 
+  test "should create topic with comment_ids and move comments" do
+    comment1 = Collavre::Comment.create!(creative: @creative, user: @user, content: "Message 1")
+    comment2 = Collavre::Comment.create!(creative: @creative, user: @user, content: "Message 2")
+
+    assert_difference("Topic.count") do
+      post collavre.creative_topics_url(@creative),
+        params: { topic: { name: "New Thread" }, comment_ids: [ comment1.id, comment2.id ] }, as: :json
+    end
+
+    assert_response :created
+    topic = @creative.topics.find_by(name: "New Thread")
+    assert topic.present?
+
+    comment1.reload
+    comment2.reload
+    assert_equal topic.id, comment1.topic_id
+    assert_equal topic.id, comment2.topic_id
+  end
+
+  test "should return next_name for auto-generated topic name" do
+    get next_name_creative_topics_url(@creative), as: :json
+
+    assert_response :success
+    json = JSON.parse(response.body)
+    assert json["name"].present?
+    # First auto-name should be "Topic1" (en locale)
+    assert_match(/\A.+1\z/, json["name"])
+  end
+
+  test "next_name should increment based on existing topics" do
+    @creative.topics.create!(name: "Topic1", user: @user)
+    @creative.topics.create!(name: "Topic3", user: @user)
+
+    get next_name_creative_topics_url(@creative), as: :json
+
+    assert_response :success
+    json = JSON.parse(response.body)
+    # Should return Topic4 (max existing is 3, so 3+1=4)
+    assert_match(/4\z/, json["name"])
+  end
+
   test "new topic should be created at the end after reordering" do
     # Create initial topics
     topic2 = @creative.topics.create!(name: "Topic 2", user: @user)


### PR DESCRIPTION
## Summary

Adds the ability to create a new topic directly from selected chat messages, via two interaction paths:

### 1. Drag & Drop → '+' Button
- Select messages → drag to the '+' (add topic) button
- Auto-generates topic name (Topic1, 토픽1, etc.)
- Creates topic and moves selected messages in one transaction

### 2. 'Move to Topic' Search Popup  
- Click '🏷 Move to topic' button with messages selected
- Search popup now shows a **create option** at the bottom: `+ "토픽1" 생성후 이동`
- When searching with no results, shows: `+ "검색어" 생성후 이동`
- Clicking the create option creates the topic and moves messages

### Backend Changes
- `TopicsController#create`: accepts optional `comment_ids` param to move comments to the new topic (transactional)
- `TopicsController#next_name`: new endpoint `GET /topics/next_name` returns auto-incrementing name based on existing pattern
- i18n: `default_name_prefix` (en: Topic, ko: 토픽), `create_and_move`

### Frontend Changes
- `topics_controller.js`: '+' button drag-over/drop now handles comment drops
- `topic_search_controller.js`: fetches next_name, renders create options, handles create+move flow
- `list_controller.js`: passes `commentIds` to topic search popup

### Tests
- Create topic with comment_ids (moves comments)
- next_name returns auto-incrementing name
- next_name increments based on existing numbered topics
- All 20 topic controller tests pass (74 assertions)