### PR TITLE
fix: prevent Rails callback deduplication from silencing badge broadcasts

### DIFF
--- a/engines/collavre/app/models/collavre/comment/broadcastable.rb
+++ b/engines/collavre/app/models/collavre/comment/broadcastable.rb
@@ -4,9 +4,14 @@ module Collavre
       extend ActiveSupport::Concern
 
       included do
-        after_create_commit :broadcast_create, :broadcast_badges
+        after_create_commit :broadcast_create
         after_update_commit :broadcast_update
-        after_destroy_commit :broadcast_destroy, :broadcast_badges
+        after_destroy_commit :broadcast_destroy
+        # Use after_commit with on: to avoid Rails callback deduplication.
+        # Registering the same method via both after_create_commit and
+        # after_destroy_commit causes the later registration to silently
+        # overwrite the earlier one.
+        after_commit :broadcast_badges, on: [ :create, :destroy ]
       end
 
       module ClassMethods


### PR DESCRIPTION
## Problem

When a new comment was created, the unread badge broadcast (`broadcast_badges`) never fired. The badge count on the creative list never updated in real-time.

## Root Cause

Rails internally converts `after_create_commit` and `after_destroy_commit` into `after_commit` with an `:on` filter. When the **same method name** is registered via both, the later registration silently **overwrites** the earlier one due to callback deduplication.

```ruby
# Before (bug): broadcast_badges only fires on :destroy
after_create_commit :broadcast_create, :broadcast_badges   # ← overwritten
after_destroy_commit :broadcast_destroy, :broadcast_badges  # ← wins
```

This is [documented Rails behavior](https://guides.rubyonrails.org/active_record_callbacks.html#using-a-combination-of-callbacks).

## Fix

Use `after_commit` with explicit `on:` to register a single callback entry:

```ruby
after_create_commit :broadcast_create
after_destroy_commit :broadcast_destroy
after_commit :broadcast_badges, on: [:create, :destroy]
```

## Verification

- ✅ Existing test passes (`comment_read_pointers_controller_test`)
- ✅ WebSocket E2E test: comment creation → badge broadcast received via ActionCable
- ✅ Server logs confirm `[ActionCable] Broadcasting to ...comment_badge` on comment create