### PR TITLE
feat: drag & drop creative into chat form to insert markdown link

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -163,7 +163,7 @@ body.chat-fullscreen {
     /* Prevent iOS zoom on focus */
 }
 
-#new-comment-form textarea.creative-drop-hover {
+#new-comment-form.creative-drop-hover textarea {
     border-color: var(--link);
     box-shadow: 0 0 0 2px color-mix(in srgb, var(--link) 25%, transparent);
 }

--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -159,8 +159,13 @@ body.chat-fullscreen {
     overflow-y: auto;
     min-height: calc(var(--text-1) * 1.5 * 2); /* 2 lines minimum */
     max-height: calc(var(--text-1) * 1.5 * 10); /* 10 lines maximum */
-    transition: height 0.1s ease-out;
+    transition: height 0.1s ease-out, border-color 0.15s ease-out, box-shadow 0.15s ease-out;
     /* Prevent iOS zoom on focus */
+}
+
+#new-comment-form textarea.creative-drop-hover {
+    border-color: var(--link);
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--link) 25%, transparent);
 }
 
 #new-comment-form button[type="submit"] {

--- a/engines/collavre/app/javascript/controllers/comments/contexts_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/contexts_controller.js
@@ -377,7 +377,11 @@ export default class extends Controller {
         this._popupEl = popup
         this._boundPopupDragOver = this._handlePopupDragOver.bind(this)
         this._boundPopupDragLeave = this._handlePopupDragLeave.bind(this)
-        this._boundPopupDrop = this.handleExternalDrop.bind(this)
+        this._boundPopupDrop = (event) => {
+            // Skip if dropping on the comment form — let form_controller handle it
+            if (event.target.closest('#new-comment-form')) return
+            this.handleExternalDrop(event)
+        }
         popup.addEventListener('dragover', this._boundPopupDragOver)
         popup.addEventListener('dragleave', this._boundPopupDragLeave)
         popup.addEventListener('drop', this._boundPopupDrop)
@@ -395,6 +399,8 @@ export default class extends Controller {
         if (this._isInternalReorder(event)) return
         if (!this._isCreativeDrag(event)) return
         if (!this.canManage) return
+        // Skip if dragging over the comment form — let form_controller handle it
+        if (event.target.closest('#new-comment-form')) return
 
         // Must preventDefault to allow drop on the popup
         event.preventDefault()

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -58,9 +58,9 @@ export default class extends Controller {
 
     this.imageButtonTarget?.addEventListener('click', this.handleImageButtonClick)
     this.imageInputTarget?.addEventListener('change', this.handleImageChange)
-    this.textareaTarget.addEventListener('dragover', this.handleDragOver)
-    this.textareaTarget.addEventListener('dragleave', this.handleDragLeave)
-    this.textareaTarget.addEventListener('drop', this.handleDrop)
+    this.formTarget.addEventListener('dragover', this.handleDragOver)
+    this.formTarget.addEventListener('dragleave', this.handleDragLeave)
+    this.formTarget.addEventListener('drop', this.handleDrop)
     this.handlePaste = this.handlePaste.bind(this)
     this.textareaTarget.addEventListener('paste', this.handlePaste)
 
@@ -114,9 +114,9 @@ export default class extends Controller {
     this.imageButtonTarget?.removeEventListener('click', this.handleImageButtonClick)
     this.imageInputTarget?.removeEventListener('change', this.handleImageChange)
     this.textareaTarget.removeEventListener('input', this._autoResize)
-    this.textareaTarget.removeEventListener('dragover', this.handleDragOver)
-    this.textareaTarget.removeEventListener('dragleave', this.handleDragLeave)
-    this.textareaTarget.removeEventListener('drop', this.handleDrop)
+    this.formTarget.removeEventListener('dragover', this.handleDragOver)
+    this.formTarget.removeEventListener('dragleave', this.handleDragLeave)
+    this.formTarget.removeEventListener('drop', this.handleDrop)
     this.textareaTarget.removeEventListener('paste', this.handlePaste)
     this.element.removeEventListener('comments--topics:change', this.handleTopicChange)
   }
@@ -517,17 +517,20 @@ export default class extends Controller {
       event.preventDefault()
       if (this.hasCreativeFromDataTransfer(event.dataTransfer)) {
         event.stopPropagation()
-        this.textareaTarget.classList.add('creative-drop-hover')
+        this.formTarget.classList.add('creative-drop-hover')
       }
     }
   }
 
   handleDragLeave(event) {
-    this.textareaTarget.classList.remove('creative-drop-hover')
+    // Only remove highlight if truly leaving the form
+    if (!this.formTarget.contains(event.relatedTarget)) {
+      this.formTarget.classList.remove('creative-drop-hover')
+    }
   }
 
   handleDrop(event) {
-    this.textareaTarget.classList.remove('creative-drop-hover')
+    this.formTarget.classList.remove('creative-drop-hover')
 
     // Handle creative drop — stop propagation so contexts_controller doesn't intercept
     if (this.hasCreativeFromDataTransfer(event.dataTransfer)) {

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -516,6 +516,7 @@ export default class extends Controller {
     if (this.hasImageFromDataTransfer(event.dataTransfer) || this.hasCreativeFromDataTransfer(event.dataTransfer)) {
       event.preventDefault()
       if (this.hasCreativeFromDataTransfer(event.dataTransfer)) {
+        event.stopPropagation()
         this.textareaTarget.classList.add('creative-drop-hover')
       }
     }
@@ -528,9 +529,10 @@ export default class extends Controller {
   handleDrop(event) {
     this.textareaTarget.classList.remove('creative-drop-hover')
 
-    // Handle creative drop
+    // Handle creative drop — stop propagation so contexts_controller doesn't intercept
     if (this.hasCreativeFromDataTransfer(event.dataTransfer)) {
       event.preventDefault()
+      event.stopPropagation()
       const creativeData = this.extractCreativeData(event.dataTransfer)
       if (creativeData) {
         this.insertCreativeLink(creativeData)

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -513,10 +513,12 @@ export default class extends Controller {
   }
 
   handleDragOver(event) {
-    if (this.hasImageFromDataTransfer(event.dataTransfer) || this.hasCreativeFromDataTransfer(event.dataTransfer)) {
+    const isCreative = this.hasCreativeFromDataTransfer(event.dataTransfer)
+    const isImage = this.hasImageFromDataTransfer(event.dataTransfer)
+    if (isImage || isCreative) {
       event.preventDefault()
-      if (this.hasCreativeFromDataTransfer(event.dataTransfer)) {
-        event.stopPropagation()
+      event.stopPropagation()
+      if (isCreative) {
         this.formTarget.classList.add('creative-drop-hover')
       }
     }

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -45,6 +45,7 @@ export default class extends Controller {
     this.handleImageButtonClick = this.handleImageButtonClick.bind(this)
     this.handleImageChange = this.handleImageChange.bind(this)
     this.handleDragOver = this.handleDragOver.bind(this)
+    this.handleDragLeave = this.handleDragLeave.bind(this)
     this.handleDrop = this.handleDrop.bind(this)
 
     this.formTarget.addEventListener('submit', this.handleSubmit)
@@ -58,6 +59,7 @@ export default class extends Controller {
     this.imageButtonTarget?.addEventListener('click', this.handleImageButtonClick)
     this.imageInputTarget?.addEventListener('change', this.handleImageChange)
     this.textareaTarget.addEventListener('dragover', this.handleDragOver)
+    this.textareaTarget.addEventListener('dragleave', this.handleDragLeave)
     this.textareaTarget.addEventListener('drop', this.handleDrop)
     this.handlePaste = this.handlePaste.bind(this)
     this.textareaTarget.addEventListener('paste', this.handlePaste)
@@ -113,6 +115,7 @@ export default class extends Controller {
     this.imageInputTarget?.removeEventListener('change', this.handleImageChange)
     this.textareaTarget.removeEventListener('input', this._autoResize)
     this.textareaTarget.removeEventListener('dragover', this.handleDragOver)
+    this.textareaTarget.removeEventListener('dragleave', this.handleDragLeave)
     this.textareaTarget.removeEventListener('drop', this.handleDrop)
     this.textareaTarget.removeEventListener('paste', this.handlePaste)
     this.element.removeEventListener('comments--topics:change', this.handleTopicChange)
@@ -510,17 +513,80 @@ export default class extends Controller {
   }
 
   handleDragOver(event) {
-    if (this.hasImageFromDataTransfer(event.dataTransfer)) {
+    if (this.hasImageFromDataTransfer(event.dataTransfer) || this.hasCreativeFromDataTransfer(event.dataTransfer)) {
       event.preventDefault()
+      if (this.hasCreativeFromDataTransfer(event.dataTransfer)) {
+        this.textareaTarget.classList.add('creative-drop-hover')
+      }
     }
   }
 
+  handleDragLeave(event) {
+    this.textareaTarget.classList.remove('creative-drop-hover')
+  }
+
   handleDrop(event) {
+    this.textareaTarget.classList.remove('creative-drop-hover')
+
+    // Handle creative drop
+    if (this.hasCreativeFromDataTransfer(event.dataTransfer)) {
+      event.preventDefault()
+      const creativeData = this.extractCreativeData(event.dataTransfer)
+      if (creativeData) {
+        this.insertCreativeLink(creativeData)
+      }
+      return
+    }
+
+    // Handle image drop
     const imageFiles = this.extractImageFiles(event.dataTransfer)
     if (!imageFiles.length) return
     event.preventDefault()
     this.setImageFiles([...this.currentImageFiles(), ...imageFiles])
     this.updateAttachmentList()
+  }
+
+  hasCreativeFromDataTransfer(dataTransfer) {
+    if (!dataTransfer || !dataTransfer.types) return false
+    return Array.from(dataTransfer.types).includes('application/x-collavre-creative')
+  }
+
+  extractCreativeData(dataTransfer) {
+    if (!dataTransfer) return null
+    const raw = dataTransfer.getData('application/x-collavre-creative') || dataTransfer.getData('text/plain')
+    if (!raw) return null
+    try {
+      const parsed = JSON.parse(raw)
+      if (!parsed || !parsed.creativeId) return null
+      const label = this.getCreativeLabelFromDom(parsed.creativeId)
+      return { id: parsed.creativeId, label: label || `Creative #${parsed.creativeId}` }
+    } catch {
+      return null
+    }
+  }
+
+  getCreativeLabelFromDom(creativeId) {
+    const row = document.querySelector(`creative-tree-row[creative-id="${creativeId}"]`)
+    if (!row) return null
+    const descriptionHtml = row.descriptionHtml || row.dataset?.descriptionHtml || ''
+    if (!descriptionHtml) return null
+    const tmp = document.createElement('div')
+    tmp.innerHTML = descriptionHtml
+    return (tmp.textContent || tmp.innerText || '').trim()
+  }
+
+  insertCreativeLink({ id, label }) {
+    const link = `[${label}](/creatives/${id})`
+    const textarea = this.textareaTarget
+    const pos = textarea.selectionStart
+    const before = textarea.value.substring(0, pos)
+    const after = textarea.value.substring(pos)
+    const needsSpace = before.length > 0 && !before.endsWith(' ') && !before.endsWith('\n')
+    textarea.value = `${before}${needsSpace ? ' ' : ''}${link}${after ? '' : ' '}${after}`
+    const newPos = pos + (needsSpace ? 1 : 0) + link.length + (after ? 0 : 1)
+    textarea.setSelectionRange(newPos, newPos)
+    textarea.dispatchEvent(new Event('input', { bubbles: true }))
+    textarea.focus()
   }
 
   extractImageFiles(dataTransfer) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -139,7 +139,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -726,7 +725,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -767,7 +765,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1357,7 +1354,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.2.tgz",
       "integrity": "sha512-Ecx2ig/JLC9ayIQwZHqm41Tzlf4c1WUuFhFUZB1y+JIJqDRE579x7Uil7tKT8MwDpOPwrK5ZtpxdSsrfy/LF8Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/component": "0.7.0",
         "@firebase/logger": "0.5.0",
@@ -1424,7 +1420,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.2.tgz",
       "integrity": "sha512-cn+U27GDaBS/irsbvrfnPZdcCzeZPRGKieSlyb7vV6LSOL6mdECnB86PgYjYGxSNg8+U48L/NeevTV1odU+mOQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/app": "0.14.2",
         "@firebase/component": "0.7.0",
@@ -1440,8 +1435,7 @@
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
       "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@firebase/auth": {
       "version": "1.11.0",
@@ -1892,7 +1886,6 @@
       "integrity": "sha512-0AZUyYUfpMNcztR5l09izHwXkZpghLgCUaAGjtMwXnCg3bj4ml5VgiwqOMOxJ+Nw4qN/zJAaOQBcJ7KGkWStqQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -3958,7 +3951,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -5307,6 +5299,7 @@
       "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
       "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
@@ -6677,7 +6670,6 @@
       "integrity": "sha512-Pcfm3eZ+eO4JdZCXthW9tCDT3nF4K+9dmeZ+5X39n+Kqz0DDIABRP5CAEOHRFZk8RGuC2efksTJxrjp8EXCunQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.19",
         "@asamuzakjp/dom-selector": "^6.7.3",
@@ -6758,7 +6750,6 @@
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -6801,6 +6792,7 @@
       "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.114.tgz",
       "integrity": "sha512-gcxmNFzA4hv8UYi8j43uPlQ7CGcyMJ2KQb5kZASw6SnAKAf10hK12i2fjrS3Cl/ugZa5Ui6WwIu1/6MIXiHttQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "isomorphic.js": "^0.2.4"
       },
@@ -7431,7 +7423,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -7474,7 +7465,6 @@
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -7617,7 +7607,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7627,7 +7616,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -8171,7 +8159,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -8195,7 +8182,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }


### PR DESCRIPTION
## Summary

When a creative is dragged from the tree and dropped onto the chat textarea, a markdown link `[label](/creatives/{id})` is inserted at the cursor position. This provides the same result as using the `/creative` command but with a more intuitive drag & drop interaction.

## Changes

### `form_controller.js`
- Detect `application/x-collavre-creative` MIME type in `dragover`/`drop` events
- Extract creative ID from drag transfer data and resolve label from DOM (`creative-tree-row` element)
- Insert markdown link at cursor position (text insertion only, no auto-submit)
- Add `dragleave` handler to clean up visual feedback

### `comments_popup.css`
- Add `.creative-drop-hover` class with border highlight + subtle box-shadow using `--link` design token
- Smooth transition on border-color and box-shadow

## Behavior
- **Desktop**: Drag creative from tree → drop on chat textarea → markdown link inserted
- **Mobile**: Use existing `/creative` command (drag & drop not practical on touch)
- **Drop only inserts** text — user can add more text before sending