### PR TITLE
feat: multi-word AND search for creatives and comments

### DIFF
--- a/engines/collavre/app/controllers/collavre/comments_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comments_controller.rb
@@ -35,8 +35,12 @@ module Collavre
       scope = visible_scope.with_attached_images.includes(:topic, :comment_reactions, :comment_versions)
 
       if params[:search].present?
-        search_term = ActiveRecord::Base.sanitize_sql_like(params[:search].to_s.strip.downcase)
-        scope = scope.where("LOWER(comments.content) LIKE ?", "%#{search_term}%")
+        words = params[:search].to_s.strip.downcase.split(/\s+/)
+                  .first(Creatives::Filters::SearchFilter::MAX_SEARCH_WORDS)
+        words.each do |word|
+          sanitized = "%#{ActiveRecord::Base.sanitize_sql_like(word)}%"
+          scope = scope.where("LOWER(comments.content) LIKE ?", sanitized)
+        end
       end
 
       # Filter by topic

--- a/engines/collavre/app/services/collavre/creatives/filters/search_filter.rb
+++ b/engines/collavre/app/services/collavre/creatives/filters/search_filter.rb
@@ -2,17 +2,30 @@ module Collavre
 module Creatives
   module Filters
     class SearchFilter < BaseFilter
+      MAX_SEARCH_WORDS = 5
+
       def active?
         params[:search].present?
       end
 
       def match
-        query = "%#{sanitize_like(params[:search])}%"
+        words = params[:search].to_s.strip.split(/\s+/).first(MAX_SEARCH_WORDS)
+        return [] if words.empty?
 
-        # Search in description OR comments.content
+        # Build AND conditions: each word must appear in description OR comments
+        conditions = []
+        binds = {}
+
+        words.each_with_index do |word, i|
+          key = :"q#{i}"
+          binds[key] = "%#{sanitize_like(word)}%"
+          conditions << "(creatives.description LIKE :#{key} ESCAPE '\\' " \
+                        "OR comments.content LIKE :#{key} ESCAPE '\\')"
+        end
+
         scope
           .left_joins(:comments)
-          .where("creatives.description LIKE :q OR comments.content LIKE :q", q: query)
+          .where(conditions.join(" AND "), **binds)
           .distinct
           .pluck(:id)
       end

--- a/engines/collavre/app/services/collavre/creatives/filters/search_filter.rb
+++ b/engines/collavre/app/services/collavre/creatives/filters/search_filter.rb
@@ -18,9 +18,9 @@ module Creatives
 
         words.each_with_index do |word, i|
           key = :"q#{i}"
-          binds[key] = "%#{sanitize_like(word)}%"
-          conditions << "(creatives.description LIKE :#{key} ESCAPE '\\' " \
-                        "OR comments.content LIKE :#{key} ESCAPE '\\')"
+          binds[key] = "%#{sanitize_like(word.downcase)}%"
+          conditions << "(LOWER(creatives.description) LIKE :#{key} ESCAPE '\\' " \
+                        "OR LOWER(comments.content) LIKE :#{key} ESCAPE '\\')"
         end
 
         scope
@@ -33,7 +33,7 @@ module Creatives
       private
 
       def sanitize_like(str)
-        str.to_s.gsub(/[%_]/) { |m| "\\#{m}" }
+        ActiveRecord::Base.sanitize_sql_like(str.to_s)
       end
     end
   end

--- a/engines/collavre/test/services/creatives/filters/search_filter_test.rb
+++ b/engines/collavre/test/services/creatives/filters/search_filter_test.rb
@@ -57,6 +57,84 @@ module Creatives
 
         assert_equal [ @creative2.id ], result
       end
+
+      # Multi-word AND search tests
+
+      test "multi-word search matches only creatives containing all words" do
+        filter = SearchFilter.new(params: { search: "Apple pie" }, scope: @scope)
+        result = filter.match
+
+        assert_includes result, @creative1.id       # "Apple pie recipe" contains both
+        refute_includes result, @creative3.id        # "Apple sauce" missing "pie"
+        refute_includes result, @creative2.id        # "Banana bread" missing both
+      end
+
+      test "multi-word search returns empty when words span different creatives" do
+        filter = SearchFilter.new(params: { search: "Apple bread" }, scope: @scope)
+        result = filter.match
+
+        # "Apple" is in creative1/3, "bread" is in creative2 — no single creative has both
+        assert_empty result
+      end
+
+      test "multi-word search with more than MAX_SEARCH_WORDS uses only first words" do
+        # 6 words, only first 5 should be used
+        filter = SearchFilter.new(
+          params: { search: "Apple pie recipe extra words ignored" },
+          scope: @scope
+        )
+        result = filter.match
+
+        # "Apple pie recipe" matches first 5 words: Apple, pie, recipe, extra, words
+        # creative1 = "Apple pie recipe" — has Apple, pie, recipe but NOT "extra" or "words"
+        assert_empty result
+      end
+
+      test "single word search still works (backward compatibility)" do
+        filter = SearchFilter.new(params: { search: "Banana" }, scope: @scope)
+        result = filter.match
+
+        assert_equal [ @creative2.id ], result
+      end
+
+      test "whitespace-only search returns empty" do
+        filter = SearchFilter.new(params: { search: "   " }, scope: @scope)
+        result = filter.match
+
+        assert_empty result
+      end
+
+      test "multi-word search works across description and comments" do
+        # Word1 in description, word2 in comment of same creative
+        comment_creative = Creative.create!(user: @owner, description: "Project plan", progress: 0.0)
+        Comment.create!(
+          creative: comment_creative,
+          user: @owner,
+          content: "Need to review timeline"
+        )
+        scope_with_comment = Creative.where(id: [ comment_creative.id, @creative1.id ])
+
+        filter = SearchFilter.new(params: { search: "plan timeline" }, scope: scope_with_comment)
+        result = filter.match
+
+        # "plan" in description, "timeline" in comment — same creative matches
+        assert_includes result, comment_creative.id
+        refute_includes result, @creative1.id
+      end
+
+      test "multi-word search with special characters is sanitized" do
+        special_creative = Creative.create!(user: @owner, description: "100% complete_task", progress: 0.0)
+        scope_special = Creative.where(id: [ special_creative.id ])
+
+        filter = SearchFilter.new(params: { search: "100% complete_task" }, scope: scope_special)
+        result = filter.match
+
+        assert_includes result, special_creative.id
+      end
+
+      test "MAX_SEARCH_WORDS constant is 5" do
+        assert_equal 5, SearchFilter::MAX_SEARCH_WORDS
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

Implement multi-word AND search. When users enter multiple words separated by spaces, each word is matched independently with AND logic — all words must appear in the creative's description or comments for it to match.

## Changes

### `SearchFilter` (Creative search)
- Split search query into individual words (max 5, extras silently ignored)
- Each word must match in `description` OR `comments.content` (AND logic between words)
- Add `ESCAPE` clause for proper special character handling (`%`, `_`)
- Add `MAX_SEARCH_WORDS = 5` constant

### `CommentsController` (Comment search)
- Apply same multi-word AND logic via `.where` chaining
- Reference `SearchFilter::MAX_SEARCH_WORDS` for consistency

### Tests
- Multi-word AND matching (both words required)
- Cross-creative non-match (words in different creatives)
- MAX_SEARCH_WORDS limit enforcement
- Cross-field matching (word in description + word in comment)
- Special character sanitization
- Backward compatibility with single-word search

## Behavior

| Input | Matches | Doesn't Match |
|-------|---------|---------------|
| `Apple pie` | "Apple pie recipe" | "Apple sauce" |
| `Apple bread` | (nothing) | "Apple sauce", "Banana bread" |
| `plan timeline` | Creative with "plan" in desc + "timeline" in comment | — |
