### PR TITLE
fix: constrain mobile chat popup max-height when keyboard opens

### DIFF
--- a/engines/collavre/app/javascript/controllers/comments/presence_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/presence_controller.js
@@ -328,6 +328,7 @@ export default class extends Controller {
       this.typingTimeoutHandle = null
     }
     this.element.style.bottom = ''
+    this.element.style.maxHeight = ''
     if (window.visualViewport && this.visualViewportHandler) {
       window.visualViewport.removeEventListener('resize', this.visualViewportHandler)
       this.visualViewportHandler = null
@@ -348,6 +349,9 @@ export default class extends Controller {
       if (inset < 0) inset = 0
     }
     this.element.style.bottom = `${inset}px`
+    this.element.style.maxHeight = inset > 0
+      ? `${window.innerHeight - inset}px`
+      : ''
   }
 
   isMobile() {


### PR DESCRIPTION
## Problem

On mobile, opening the chat popup triggers the virtual keyboard. The `adjustForKeyboard()` method in `presence_controller.js` correctly pushed the popup up by setting `bottom` to the keyboard height, but did **not** constrain `max-height`. This caused the popup to overflow above the visible screen.

**Example (iPhone, 844px screen):**
- Keyboard height: ~300px
- Popup height: 640px (base) 
- Popup top: 844 - 300 - 640 = **-96px** (above screen!)

## Fix

- Set `max-height` to `window.innerHeight - inset` when the keyboard is open, so the popup fits within the available viewport space above the keyboard
- Clear `max-height` override on blur (keyboard dismiss)

## Changes

- `engines/collavre/app/javascript/controllers/comments/presence_controller.js`
  - `adjustForKeyboard()`: added `max-height` constraint
  - `handleBlur()`: added `maxHeight` reset