### PR TITLE
fix: markdown import drop not working due to missing dragover class

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/creatives.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/creatives.css
@@ -717,3 +717,9 @@ creative-tree-row[archived] .creative-tree {
 creative-tree-row[archived] .creative-row {
     background-color: var(--surface-input);
 }
+
+/* Import dropzone drag-over feedback */
+#import-markdown-dropzone.dragover {
+    border-color: var(--color-accent-border);
+    background-color: var(--surface-input);
+}

--- a/engines/collavre/app/javascript/controllers/creatives/import_controller.js
+++ b/engines/collavre/app/javascript/controllers/creatives/import_controller.js
@@ -25,17 +25,23 @@ export default class extends Controller {
 
   dragOver(event) {
     event.preventDefault()
-    this.dropzoneTarget.classList.add(this.dragoverClass)
+    if (this.hasDragoverClass) {
+      this.dropzoneTarget.classList.add(this.dragoverClass)
+    }
   }
 
   dragLeave(event) {
     event.preventDefault()
-    this.dropzoneTarget.classList.remove(this.dragoverClass)
+    if (this.hasDragoverClass) {
+      this.dropzoneTarget.classList.remove(this.dragoverClass)
+    }
   }
 
   drop(event) {
     event.preventDefault()
-    this.dropzoneTarget.classList.remove(this.dragoverClass)
+    if (this.hasDragoverClass) {
+      this.dropzoneTarget.classList.remove(this.dragoverClass)
+    }
     const file = event.dataTransfer.files[0]
     if (file) {
       this.handleFile(file)

--- a/engines/collavre/app/views/collavre/creatives/index.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/index.html.erb
@@ -6,6 +6,7 @@
      data-creatives--import-success-value="<%= t('collavre.creatives.index.import_success') %>"
      data-creatives--import-failed-value="<%= t('collavre.creatives.index.import_failed') %>"
      data-creatives--import-only-markdown-value="<%= t('collavre.creatives.index.only_markdown') %>"
+     data-creatives--import-dragover-class="dragover"
      data-creatives--set-plan-modal-select-one-value="<%= t('collavre.creatives.index.select_one_creative') %>"
      data-creatives--set-plan-modal-select-plan-value="<%= t('collavre.creatives.index.select_plan_to_remove') %>">
   <div class="creative-actions-row">


### PR DESCRIPTION
## Problem
Markdown file import via drag-and-drop was completely broken:
- Drop zone visual activation (highlight on dragover) did not work
- Dropping a file onto the import area did nothing

## Root Cause
`import_controller.js` declares `static classes = ['dragover']` but the HTML template never sets `data-creatives--import-dragover-class`. In Stimulus, accessing `this.dragoverClass` without the corresponding data attribute throws:
```
Missing CSS class name "dragover" for "creatives--import" controller
```

This error in `drop()` prevents `handleFile()` from executing, so dropped files are silently ignored. The `dragOver()` handler also fails, preventing visual feedback.

## Fix
- Add `data-creatives--import-dragover-class="dragover"` to the controller element in `index.html.erb`
- Guard all `dragoverClass` access with `hasDragoverClass` for resilience (defensive coding)