### PR TITLE
fix: update system test for Enter key shortcut change

### DIFF
--- a/engines/collavre/test/system/creative_inline_edit_test.rb
+++ b/engines/collavre/test/system/creative_inline_edit_test.rb
@@ -113,7 +113,7 @@ class CreativeInlineEditTest < ApplicationSystemTestCase
     sleep 0.5
 
     fill_inline_editor("First child")
-    inline_editor_field.send_keys([ :shift, :enter ])
+    inline_editor_field.send_keys(:enter)
     sleep 0.5
 
     fill_inline_editor("Second child")


### PR DESCRIPTION
## Summary

Update the `creative_inline_edit_test.rb` system test to use bare `:enter` instead of `[:shift, :enter]` for the addNew() keyboard shortcut.

## Context

PR #1019 swapped Enter/Shift+Enter behavior in the creative inline editor:
- Before: Shift+Enter → addNew()
- After: Enter → addNew()

The system test was still using the old Shift+Enter shortcut, causing a failure.

## Changes

```diff
- inline_editor_field.send_keys([ :shift, :enter ])
+ inline_editor_field.send_keys(:enter)
```

## Testing

System test passes locally:
```
1 runs, 5 assertions, 0 failures, 0 errors, 0 skips
```
