### PR TITLE
fix: ensure only one GNB popup is visible at a time on mobile

### DIFF
--- a/engines/collavre/app/javascript/controllers/popup_menu_controller.js
+++ b/engines/collavre/app/javascript/controllers/popup_menu_controller.js
@@ -6,7 +6,7 @@ export default class extends Controller {
 
   connect() {
     this.handleOutsideClick = this.handleOutsideClick.bind(this)
-    this._popupId = 'popup-menu-' + (this.menuTarget.id || Math.random().toString(36).slice(2))
+    this._popupId = 'popup-menu-' + (this.menuTarget.id || this.element.id || this.element.dataset.popupId || Math.random().toString(36).slice(2))
     this._cleanupPopupListener = onOtherPopupOpen(this._popupId, () => {
       if (this.isOpen()) this.hide()
     })

--- a/engines/collavre/app/javascript/controllers/popup_menu_controller.js
+++ b/engines/collavre/app/javascript/controllers/popup_menu_controller.js
@@ -1,14 +1,23 @@
 import { Controller } from '@hotwired/stimulus'
+import { notifyPopupOpen, onOtherPopupOpen } from '../lib/gnb_popup_manager'
 
 export default class extends Controller {
   static targets = ['menu', 'button']
 
   connect() {
     this.handleOutsideClick = this.handleOutsideClick.bind(this)
+    this._popupId = 'popup-menu-' + (this.menuTarget.id || Math.random().toString(36).slice(2))
+    this._cleanupPopupListener = onOtherPopupOpen(this._popupId, () => {
+      if (this.isOpen()) this.hide()
+    })
   }
 
   disconnect() {
     this.removeOutsideClickListener()
+    if (this._cleanupPopupListener) {
+      this._cleanupPopupListener()
+      this._cleanupPopupListener = null
+    }
   }
 
   toggle(event) {
@@ -27,6 +36,7 @@ export default class extends Controller {
   }
 
   show() {
+    notifyPopupOpen(this._popupId)
     const menu = this.menuTarget
     menu.style.display = 'block'
     menu.style.transform = ''

--- a/engines/collavre/app/javascript/lib/gnb_popup_manager.js
+++ b/engines/collavre/app/javascript/lib/gnb_popup_manager.js
@@ -1,0 +1,30 @@
+// GNB Popup Manager
+// Ensures only one GNB popup/panel is visible at a time.
+// Each popup registers itself and dispatches 'gnb:popup-open' when opening.
+// Other popups listen for this event and close themselves.
+
+const EVENT_NAME = 'gnb:popup-open'
+
+/**
+ * Notify all other GNB popups that a popup is opening.
+ * @param {string} id - Unique identifier for the popup being opened
+ */
+export function notifyPopupOpen(id) {
+  document.dispatchEvent(new CustomEvent(EVENT_NAME, { detail: { id } }))
+}
+
+/**
+ * Register a close handler that fires when another popup opens.
+ * @param {string} id - Unique identifier for this popup
+ * @param {Function} closeFn - Function to call to close this popup
+ * @returns {Function} Cleanup function to remove the listener
+ */
+export function onOtherPopupOpen(id, closeFn) {
+  const handler = (event) => {
+    if (event.detail.id !== id) {
+      closeFn()
+    }
+  }
+  document.addEventListener(EVENT_NAME, handler)
+  return () => document.removeEventListener(EVENT_NAME, handler)
+}

--- a/engines/collavre/app/javascript/modules/creative_guide.js
+++ b/engines/collavre/app/javascript/modules/creative_guide.js
@@ -1,6 +1,10 @@
 // Creative guide popover functionality
 // Handles the help button click and popover display
 
+import { notifyPopupOpen, onOtherPopupOpen } from '../lib/gnb_popup_manager'
+
+const POPUP_ID = 'creative-guide'
+
 // Single document-level click handler for dismissing popover (delegated)
 let documentClickHandlerAttached = false
 
@@ -28,6 +32,10 @@ function setupCreativeGuide() {
   const close = document.getElementById('close-creative-guide')
 
   if (links.length && popover && close) {
+    onOtherPopupOpen(POPUP_ID, function() {
+      popover.style.display = 'none'
+    })
+
     links.forEach(function(link) {
       // Use onclick assignment to avoid duplicate listeners
       link.onclick = function(e) {
@@ -36,6 +44,7 @@ function setupCreativeGuide() {
           return
         }
         e.preventDefault()
+        notifyPopupOpen(POPUP_ID)
         popover.style.display = 'block'
       }
     })

--- a/engines/collavre/app/javascript/modules/creative_guide.js
+++ b/engines/collavre/app/javascript/modules/creative_guide.js
@@ -7,6 +7,7 @@ const POPUP_ID = 'creative-guide'
 
 // Single document-level click handler for dismissing popover (delegated)
 let documentClickHandlerAttached = false
+let popupListenerRegistered = false
 
 function setupDocumentClickHandler() {
   if (documentClickHandlerAttached) return
@@ -32,9 +33,13 @@ function setupCreativeGuide() {
   const close = document.getElementById('close-creative-guide')
 
   if (links.length && popover && close) {
-    onOtherPopupOpen(POPUP_ID, function() {
-      popover.style.display = 'none'
-    })
+    if (!popupListenerRegistered) {
+      popupListenerRegistered = true
+      onOtherPopupOpen(POPUP_ID, function() {
+        const p = document.getElementById('creative-guide-popover')
+        if (p) p.style.display = 'none'
+      })
+    }
 
     links.forEach(function(link) {
       // Use onclick assignment to avoid duplicate listeners

--- a/engines/collavre/app/javascript/modules/inbox_panel.js
+++ b/engines/collavre/app/javascript/modules/inbox_panel.js
@@ -1,6 +1,9 @@
 // Inbox panel functionality
 // Manages the inbox slide panel UI with pagination and touch gestures
 
+import { notifyPopupOpen, onOtherPopupOpen } from '../lib/gnb_popup_manager'
+
+const POPUP_ID = 'inbox-panel'
 let initialized = false
 
 function initInboxPanel() {
@@ -163,6 +166,7 @@ function initInboxPanel() {
 
     function openPanel() {
       if (!panel) return
+      notifyPopupOpen(POPUP_ID)
       panel.classList.add('open')
       localStorage.setItem('inboxOpen', '1')
       loadInbox()
@@ -175,6 +179,8 @@ function initInboxPanel() {
       localStorage.removeItem('inboxOpen')
       document.body.classList.remove('no-scroll')
     }
+
+    onOtherPopupOpen(POPUP_ID, closePanel)
 
     let startX = null
     if (panel) {

--- a/engines/collavre/app/javascript/modules/plans_menu.js
+++ b/engines/collavre/app/javascript/modules/plans_menu.js
@@ -1,6 +1,9 @@
 // Plans menu functionality
 // Handles the plans menu button click and lazy-loads plans data
 
+import { notifyPopupOpen, onOtherPopupOpen } from '../lib/gnb_popup_manager'
+
+const POPUP_ID = 'plans-menu'
 let initialized = false
 
 function initPlansMenu() {
@@ -13,9 +16,16 @@ function initPlansMenu() {
     let loaded = false
     const timeline = document.getElementById('plans-timeline')
 
+    function closePlans() {
+      if (area) area.style.display = 'none'
+    }
+
+    onOtherPopupOpen(POPUP_ID, closePlans)
+
     btns.forEach(function(btn) {
       btn.addEventListener('click', function() {
         if (area.style.display === 'none') {
+          notifyPopupOpen(POPUP_ID)
           area.style.display = 'block'
           if (!loaded) {
             fetch('/plans.json')


### PR DESCRIPTION
## Problem
On mobile, multiple GNB popups/panels could be open simultaneously because each popup operates independently without knowledge of others.

Affected popups:
- Plans menu (`#plans-list-area`)
- Inbox panel (`#inbox-panel`)
- Creative Guide (`#creative-guide-popover`)
- Mobile More menu (`#mobile-more-menu`) — Stimulus popup-menu controller
- User menu — Stimulus popup-menu controller

## Solution
Added a centralized `gnb_popup_manager.js` module that uses custom events (`gnb:popup-open`) to coordinate popup visibility:

- When any popup opens, it dispatches a `gnb:popup-open` event with its unique ID
- All other popups listen for this event and close themselves when a different popup opens
- Each module (`plans_menu.js`, `inbox_panel.js`, `creative_guide.js`, `popup_menu_controller.js`) integrates with the manager

## Changes
- **New**: `lib/gnb_popup_manager.js` — lightweight event-based popup coordination (30 lines)
- **Modified**: `modules/plans_menu.js` — notify on open, close on other popup
- **Modified**: `modules/inbox_panel.js` — notify on open, close on other popup
- **Modified**: `modules/creative_guide.js` — notify on open, close on other popup
- **Modified**: `controllers/popup_menu_controller.js` — notify on show, close on other popup, cleanup on disconnect

## Testing
- Rubocop: ✅ passed
- All 1349 tests: ✅ passed (0 failures, 0 errors)
- i18n: ✅ all keys present in en and ko

Closes #10370