### PR TITLE
fix: close fullscreen chat properly on swipe down

### DIFF
--- a/engines/collavre/app/javascript/controllers/comments/__tests__/popup_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/popup_controller.test.js
@@ -43,6 +43,26 @@ describe('CommentsPopupController', () => {
         application.stop()
     })
 
+    test('close in fullscreen exits fullscreen state and cleans up body class', () => {
+        const popup = document.getElementById('comments-popup')
+        const triggerBtn = document.getElementById('trigger-btn')
+
+        // Open popup
+        controller.open(triggerBtn)
+
+        // Simulate entering fullscreen
+        popup.dataset.fullscreen = 'true'
+        popup.dataset.creativeId = '123'
+        document.body.classList.add('chat-fullscreen')
+
+        // Close popup
+        controller.close()
+
+        expect(popup.style.display).toBe('none')
+        expect(popup.dataset.fullscreen).toBe('false')
+        expect(document.body.classList.contains('chat-fullscreen')).toBe(false)
+    })
+
     test('clears resized dataset attribute on close', () => {
         const triggerBtn = document.getElementById('trigger-btn')
         const popup = document.getElementById('comments-popup')

--- a/engines/collavre/app/javascript/controllers/comments/popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_controller.js
@@ -291,12 +291,20 @@ export default class extends Controller {
       this._syncFullscreenUI(false)
       this._savedStyles = null
 
-      // Navigate back from fullscreen URL
+      // Navigate back from fullscreen URL — use replaceState to consume the
+      // fullscreen history entry instead of pushing a new one, preventing a
+      // stale fullscreen entry from being reached via the Back button.
       const creativeId = this.element.dataset.creativeId
       const backUrl = this._previousUrl || (creativeId ? `/creatives/${creativeId}` : null)
       if (backUrl) {
         const url = new URL(backUrl, window.location.origin)
-        window.history.pushState({ fullscreen: false }, '', url.pathname + url.search)
+        // Strip comment auto-open markers so a refresh after close doesn't
+        // re-open the popup (handles ?open_comments, ?comment_id, #comment_*).
+        url.searchParams.delete('open_comments')
+        url.searchParams.delete('comment_id')
+        const cleanPath = url.pathname.replace(/\/comments\/\d+$/, '')
+        url.hash = url.hash.replace(/^#comment_\d+$/, '')
+        window.history.replaceState({ fullscreen: false }, '', cleanPath + url.search + url.hash)
       }
       this._previousUrl = null
     }

--- a/engines/collavre/app/javascript/controllers/comments/popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_controller.js
@@ -284,6 +284,23 @@ export default class extends Controller {
       }
     }))
 
+    // Exit fullscreen state if active
+    if (this.isFullscreen()) {
+      this.element.dataset.fullscreen = 'false'
+      document.body.classList.remove('chat-fullscreen')
+      this._syncFullscreenUI(false)
+      this._savedStyles = null
+
+      // Navigate back from fullscreen URL
+      const creativeId = this.element.dataset.creativeId
+      const backUrl = this._previousUrl || (creativeId ? `/creatives/${creativeId}` : null)
+      if (backUrl) {
+        const url = new URL(backUrl, window.location.origin)
+        window.history.pushState({ fullscreen: false }, '', url.pathname + url.search)
+      }
+      this._previousUrl = null
+    }
+
     this._clearChatActiveRow()
 
     this.element.style.display = 'none'
@@ -294,6 +311,7 @@ export default class extends Controller {
     this.element.style.right = ''
     this.element.style.top = ''
     this.element.style.bottom = ''
+    this.element.style.position = ''
     delete this.element.dataset.resized
   }
 


### PR DESCRIPTION
## Problem
When swiping down in fullscreen chat mode on mobile, the chat content disappeared but the fullscreen overlay remained, blocking the creative list view.

## Root Cause
The `close()` method in `popup_controller.js` did not handle fullscreen state cleanup:
- `dataset.fullscreen` was not reset to `'false'`
- `chat-fullscreen` class was not removed from `document.body`
- Fullscreen UI elements (close button, resize handles) were not restored
- URL was not navigated back from the fullscreen path
- Inline `position` style was not cleared

## Fix
Added fullscreen exit logic to `close()`:
- Resets `dataset.fullscreen` to `'false'`
- Removes `chat-fullscreen` body class
- Calls `_syncFullscreenUI(false)` to restore UI elements
- Navigates back from fullscreen URL via `pushState`
- Clears saved styles and inline position

## Tests
- Added test: `close in fullscreen exits fullscreen state and cleans up body class`
- Existing test still passes

Closes #10376