### PR TITLE
chore: update brakeman.ignore for SQL injection false positive

### DIFF
--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,38 +1,26 @@
 {
   "ignored_warnings": [
     {
-      "warning_type": "Dynamic Render Path",
-      "warning_code": 15,
-      "fingerprint": "5077aaf00de7fd4c6b501f650b231831254c2ed87fb02557789a6aacd5f96454",
-      "check_name": "Render",
-      "message": "Render path contains parameter value",
-      "file": "engines/collavre/app/views/collavre/comments/_comment.html.erb",
-      "line": 11,
-      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "6340b05d4723d411c6e204231b4c3a898ced1b590676297d73cc0f4af2adb6cd",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "engines/collavre/app/services/collavre/creatives/filters/search_filter.rb",
+      "line": 28,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
       "code": null,
       "render_path": null,
-      "location": null,
+      "location": {
+        "type": "method",
+        "class": "Collavre::Creatives::Filters::SearchFilter",
+        "method": "match"
+      },
       "user_input": null,
       "confidence": "Weak",
-      "note": "False positive: AvatarComponent is a fixed ViewComponent class, not a dynamic render path. The user parameter is component data, not a template path."
-    },
-    {
-      "warning_type": "Dynamic Render Path",
-      "warning_code": 15,
-      "fingerprint": "0458ec46d848b877e1babc9a59967a147d750cf709c10f46c837b59132153fcc",
-      "check_name": "Render",
-      "message": "Render path contains parameter value",
-      "file": "engines/collavre/app/views/collavre/users/show.html.erb",
-      "line": 45,
-      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
-      "code": null,
-      "render_path": null,
-      "location": null,
-      "user_input": null,
-      "confidence": "Weak",
-      "note": "False positive: AvatarComponent is a fixed ViewComponent class, not a dynamic render path. The user parameter is component data, not a template path."
+      "note": "False positive: string interpolation is only for named bind parameter keys (:q0, :q1, ...), not user input. User data is safely bound via sanitize_like + named parameters."
     }
   ],
-  "updated": "2026-01-26 15:15:00 +0900",
+  "updated": "2026-07-15 22:00:00 +0900",
   "brakeman_version": "7.1.2"
 }


### PR DESCRIPTION
## Summary

- Add ignore entry for SQL Injection false positive in `SearchFilter#match` (Weak confidence)
  - String interpolation is only for named bind parameter keys (`:q0`, `:q1`, ...), not user input
  - User data is safely bound via `sanitize_like` + named parameters
- Remove 2 obsolete Dynamic Render Path entries (no longer triggered by current codebase)

## Changes

- `config/brakeman.ignore`: Replace obsolete entries with current false positive

## Verification

```
bundle exec brakeman
# Security Warnings: 0, Ignored Warnings: 1, Obsolete Ignore Entries: 0
```