### PR TITLE
feat: redesign creative-actions-row with breadcrumb and overflow menu

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/creatives.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/creatives.css
@@ -52,17 +52,158 @@ html.creative-alignment-ready .page-title {
 }
 
 .creative-actions-row {
-    margin: 0.0em 1.0em 0.0em var(--creative-row-text-offset);
-    padding: 0.5em 0.5em 0.5em 0;
+    margin: 0 0 0 var(--creative-row-text-offset);
+    padding: var(--space-1) 0;
     display: flex;
-    flex-wrap: wrap;
-    gap: 10px;
-    height: 48px;
+    justify-content: space-between;
     align-items: center;
+    min-height: 36px;
+    border: none;
 }
 
-.creative-actions-row button {
-    height: 32px;
+/* === Breadcrumb (left-aligned) === */
+.creative-breadcrumb {
+    display: flex;
+    align-items: center;
+    gap: 0;
+    font-size: var(--text-0);
+    color: var(--text-muted);
+    overflow-x: auto;
+    white-space: nowrap;
+    scrollbar-width: none;
+    min-width: 0;
+}
+
+.creative-breadcrumb::-webkit-scrollbar {
+    display: none;
+}
+
+/* Override application.css .creative-actions-row a global styles for breadcrumb links.
+   Uses .creative-breadcrumb-link (not generic a) + !important to beat global selectors. */
+.creative-actions-row a.creative-breadcrumb-link,
+.creative-actions-row a.creative-breadcrumb-link:hover,
+.creative-actions-row a.creative-breadcrumb-link:visited {
+    color: var(--text-muted) !important;
+    text-decoration: underline !important;
+    text-underline-offset: 2px;
+    text-decoration-color: color-mix(in srgb, var(--text-muted) 40%, transparent);
+    background: none !important;
+    border: none !important;
+    padding: 0 !important;
+    font-size: var(--text-0) !important;
+    filter: none !important;
+    line-height: normal;
+    display: inline;
+}
+
+.creative-actions-row a.creative-breadcrumb-link:hover {
+    color: var(--text-primary) !important;
+    text-decoration-color: var(--text-primary) !important;
+}
+
+.creative-actions-row a.creative-breadcrumb-current {
+    color: var(--text-secondary) !important;
+    font-weight: var(--weight-5);
+}
+
+.creative-breadcrumb-sep {
+    color: var(--text-muted);
+    opacity: 0.4;
+    margin: 0 var(--space-1);
+    font-size: var(--text-00);
+    user-select: none;
+}
+
+/* === Header actions (right-aligned) === */
+.creative-header-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--space-1);
+    flex-shrink: 0;
+}
+
+/* Outline button — GNB-like with border.
+   Higher specificity to override application.css .creative-actions-row button */
+.creative-actions-row .creative-header-actions .creative-header-outline-btn {
+    background: transparent;
+    border: 1px solid var(--border-color);
+    color: var(--text-secondary);
+    cursor: pointer;
+    height: 30px;
+    padding: 0 var(--space-2);
+    border-radius: var(--radius-2);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: var(--text-0);
+    transition: background 0.15s var(--ease-out-2), color 0.15s var(--ease-out-2), border-color 0.15s var(--ease-out-2);
+}
+
+.creative-actions-row .creative-header-actions .creative-header-outline-btn:hover {
+    background: var(--surface-hover);
+    color: var(--text-primary);
+    border-color: var(--text-muted);
+}
+
+/* Add button in header — outline style */
+.creative-actions-row .creative-header-actions .add-creative-btn,
+.creative-actions-row .creative-header-actions .new-root-creative-btn {
+    background: transparent;
+    border: 1px solid var(--border-color);
+    color: var(--text-secondary);
+    cursor: pointer;
+    height: 30px;
+    padding: 0 var(--space-2);
+    border-radius: var(--radius-2);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: var(--text-1);
+    transition: background 0.15s var(--ease-out-2), color 0.15s var(--ease-out-2), border-color 0.15s var(--ease-out-2);
+}
+
+.creative-actions-row .creative-header-actions .add-creative-btn:hover,
+.creative-actions-row .creative-header-actions .new-root-creative-btn:hover {
+    background: var(--surface-hover);
+    color: var(--text-primary);
+    border-color: var(--text-muted);
+}
+
+/* === Overflow popup menu — GNB style === */
+#creative-overflow-menu {
+    min-width: 200px;
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-3);
+    box-shadow: var(--shadow-2);
+    padding: var(--space-1);
+    background: var(--surface-section);
+}
+
+#creative-overflow-menu .popup-menu-item {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    width: 100%;
+    text-align: left;
+    padding: var(--space-1) var(--space-2);
+    border-radius: var(--radius-2);
+    border: none;
+    background: none;
+    color: var(--text-primary);
+    font-size: var(--text-1);
+    cursor: pointer;
+    transition: background 0.15s var(--ease-out-2);
+    white-space: nowrap;
+}
+
+#creative-overflow-menu .popup-menu-item:hover {
+    background: var(--surface-hover);
+}
+
+.creative-overflow-divider {
+    height: 1px;
+    background: var(--border-color);
+    margin: var(--space-1) 0;
 }
 
 .delete-options {

--- a/engines/collavre/app/assets/stylesheets/collavre/creatives.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/creatives.css
@@ -65,7 +65,6 @@ html.creative-alignment-ready .page-title {
 .creative-breadcrumb {
     display: flex;
     align-items: center;
-    gap: 0;
     font-size: var(--text-0);
     color: var(--text-muted);
     overflow-x: auto;
@@ -78,11 +77,8 @@ html.creative-alignment-ready .page-title {
     display: none;
 }
 
-/* Override application.css .creative-actions-row a global styles for breadcrumb links.
-   Uses .creative-breadcrumb-link (not generic a) + !important to beat global selectors. */
-.creative-actions-row a.creative-breadcrumb-link,
-.creative-actions-row a.creative-breadcrumb-link:hover,
-.creative-actions-row a.creative-breadcrumb-link:visited {
+/* Override application.css .creative-actions-row a for breadcrumb links */
+.creative-actions-row a.creative-breadcrumb-link {
     color: var(--text-muted) !important;
     text-decoration: underline !important;
     text-underline-offset: 2px;
@@ -93,7 +89,6 @@ html.creative-alignment-ready .page-title {
     font-size: var(--text-0) !important;
     filter: none !important;
     line-height: normal;
-    display: inline;
 }
 
 .creative-actions-row a.creative-breadcrumb-link:hover {
@@ -140,30 +135,6 @@ html.creative-alignment-ready .page-title {
 }
 
 .creative-actions-row .creative-header-actions .creative-header-outline-btn:hover {
-    background: var(--surface-hover);
-    color: var(--text-primary);
-    border-color: var(--text-muted);
-}
-
-/* Add button in header — outline style */
-.creative-actions-row .creative-header-actions .add-creative-btn,
-.creative-actions-row .creative-header-actions .new-root-creative-btn {
-    background: transparent;
-    border: 1px solid var(--border-color);
-    color: var(--text-secondary);
-    cursor: pointer;
-    height: 30px;
-    padding: 0 var(--space-2);
-    border-radius: var(--radius-2);
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    font-size: var(--text-1);
-    transition: background 0.15s var(--ease-out-2), color 0.15s var(--ease-out-2), border-color 0.15s var(--ease-out-2);
-}
-
-.creative-actions-row .creative-header-actions .add-creative-btn:hover,
-.creative-actions-row .creative-header-actions .new-root-creative-btn:hover {
     background: var(--surface-hover);
     color: var(--text-primary);
     border-color: var(--text-muted);

--- a/engines/collavre/app/assets/stylesheets/collavre/creatives.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/creatives.css
@@ -171,6 +171,11 @@ html.creative-alignment-ready .page-title {
     background: var(--surface-hover);
 }
 
+#creative-overflow-menu .popup-menu-item.active {
+    background: color-mix(in srgb, var(--color-active) 15%, transparent);
+    color: var(--color-active);
+}
+
 .creative-overflow-divider {
     height: 1px;
     background: var(--border-color);

--- a/engines/collavre/app/javascript/controllers/creatives/tree_controller.js
+++ b/engines/collavre/app/javascript/controllers/creatives/tree_controller.js
@@ -46,13 +46,18 @@ export default class extends Controller {
     const toggle = () => {
       this._showingArchived = !this._showingArchived
 
-      // Update desktop button
+      // Update button (now a labeled overflow-menu item)
       if (btn) {
         btn.classList.toggle('active', this._showingArchived)
-        btn.title = this._showingArchived ? (btn.dataset.hideText || '') : (btn.dataset.showText || '')
+        const label = this._showingArchived ? (btn.dataset.hideText || '') : (btn.dataset.showText || '')
+        btn.title = label
+        // Update visible text while preserving the icon span
+        const iconSpan = btn.querySelector('span')
+        const iconHtml = iconSpan ? iconSpan.outerHTML + ' ' : ''
+        btn.innerHTML = iconHtml + label
       }
 
-      // Update mobile button text
+      // Update mobile button text (legacy, kept for backward compat)
       if (mobileBtn) {
         const label = this._showingArchived ? (mobileBtn.dataset.hideText || '') : (mobileBtn.dataset.showText || '')
         const iconSpan = mobileBtn.querySelector('span')

--- a/engines/collavre/app/views/collavre/creatives/_add_button.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_add_button.html.erb
@@ -1,7 +1,7 @@
 <% if @parent_creative %>
   <%= button_tag(
         type: 'button',
-        class: 'popup-menu-item add-creative-btn',
+        class: 'creative-header-outline-btn add-creative-btn',
         data: { parent_id: @parent_creative.id },
         aria: { label: t('collavre.creatives.index.new_creative') },
         title: t('collavre.creatives.index.new_creative_shortcut')
@@ -11,7 +11,7 @@
 <% else %>
   <%= button_tag(
         type: 'button',
-        class: 'popup-menu-item new-root-creative-btn',
+        class: 'creative-header-outline-btn new-root-creative-btn',
         aria: { label: t('collavre.creatives.index.new_creative') },
         title: t('collavre.creatives.index.new_creative_shortcut')
       ) do %>

--- a/engines/collavre/app/views/collavre/creatives/index.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/index.html.erb
@@ -17,7 +17,7 @@
     <div class="creative-breadcrumb" role="navigation" aria-label="<%= t('collavre.creatives.index.breadcrumb', default: 'Breadcrumb') %>">
       <a href="<%= creatives_path %>" class="creative-breadcrumb-link"><%= t('collavre.creatives.index.root_breadcrumb', default: '최상위') %></a>
       <% if @parent_creative %>
-        <% @parent_creative.ancestors.each do |ancestor| %>
+        <% @parent_creative.ancestors.reverse.each do |ancestor| %>
           <span class="creative-breadcrumb-sep" aria-hidden="true">/</span>
           <a href="<%= creative_path(ancestor) %>" class="creative-breadcrumb-link" title="<%= strip_tags(ancestor.effective_description) %>"><%= truncate(strip_tags(ancestor.effective_description), length: 20) %></a>
         <% end %>

--- a/engines/collavre/app/views/collavre/creatives/index.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/index.html.erb
@@ -9,61 +9,88 @@
      data-creatives--import-dragover-class="dragover"
      data-creatives--set-plan-modal-select-one-value="<%= t('collavre.creatives.index.select_one_creative') %>"
      data-creatives--set-plan-modal-select-plan-value="<%= t('collavre.creatives.index.select_plan_to_remove') %>">
-  <div class="creative-actions-row">
-  <%= render 'add_button' if authenticated? && (!params[:id] || (@parent_creative && @parent_creative.has_permission?(Current.user, :write))) %>
-  <% if @parent_creative&.parent_id.present? %>
-    <%= button_to creative_path(@parent_creative.owning_parent), method: :get, aria: { label: t('.up') } do %>
-      <span aria-hidden="true"><%= svg_tag 'arrow-up.svg', class: 'icon-up', width: 16, height: 16 %></span>
-    <% end %>
-  <% elsif @parent_creative.present? %>
-    <%= button_to creatives_path, class: "up-link", method: :get, aria: { label: t('.up') } do %>
-      <span aria-hidden="true"><%= svg_tag 'arrow-up.svg', class: 'icon-up', width: 16, height: 16 %></span>
-    <% end %>
-  <% end %>
-
   <% current_creative = @parent_creative || @creative %>
   <% can_manage_integrations = current_creative&.has_permission?(Current.user, :admin) %>
-  <% if (@parent_creative || @creative) && (@parent_creative || @creative).has_permission?(Current.user, :write) %>
-    <%= render 'share_button' %>
-  <% end %>
 
-  <% if can_manage_integrations %>
-    <%= render Collavre::PopupMenuComponent.new(
-          button_content: t('collavre.creatives.index.integrations', default: '연동'),
-          menu_id: 'creative-integrations-menu',
-          align: :left,
-          button_classes: 'desktop-only'
-        ) do %>
-      <%= render 'integrations_menu', creative: current_creative %>
-    <% end %>
-  <% end %>
+  <div class="creative-actions-row">
+    <%# Left: breadcrumb ancestry %>
+    <div class="creative-breadcrumb" role="navigation" aria-label="<%= t('collavre.creatives.index.breadcrumb', default: 'Breadcrumb') %>">
+      <a href="<%= creatives_path %>" class="creative-breadcrumb-link"><%= t('collavre.creatives.index.root_breadcrumb', default: '최상위') %></a>
+      <% if @parent_creative %>
+        <% @parent_creative.ancestors.each do |ancestor| %>
+          <span class="creative-breadcrumb-sep" aria-hidden="true">/</span>
+          <a href="<%= creative_path(ancestor) %>" class="creative-breadcrumb-link" title="<%= strip_tags(ancestor.effective_description) %>"><%= truncate(strip_tags(ancestor.effective_description), length: 20) %></a>
+        <% end %>
+        <span class="creative-breadcrumb-sep" aria-hidden="true">/</span>
+        <a href="<%= creative_path(@parent_creative) %>" class="creative-breadcrumb-link creative-breadcrumb-current" data-turbo-action="replace"><%= truncate(strip_tags(@parent_creative.effective_description), length: 30) %></a>
+      <% end %>
+    </div>
 
-  <% if @parent_creative.present? %>
-    <%= button_to slide_view_creative_path(@parent_creative), method: :get, class: 'slide-view-btn desktop-only', aria: { label: t('collavre.creatives.index.slide_view') } do %>
-      <span aria-hidden="true"><%= svg_tag 'slide.svg', class: 'icon-slide', width: 22, height: 20 %></span>
-    <% end %>
-  <% end %>
+    <%# Right: primary actions + overflow %>
+    <div class="creative-header-actions">
+      <%# Add button (always visible) %>
+      <%= render 'add_button' if authenticated? && (!params[:id] || (@parent_creative && @parent_creative.has_permission?(Current.user, :write))) %>
 
-  <button id="set-plan-btn" class="set-plan-btn" style="display:none;" data-creatives--select-mode-target="setPlan" data-action="click->creatives--set-plan-modal#open"><%= t('app.set_plan') %></button>
-  <input type="checkbox" id="select-all-creatives" style="display:none;vertical-align:middle;" data-action="change->creatives--select-mode#toggleSelectAll" data-creatives--select-mode-target="selectAll" />
-  <% if authenticated? %>
-    <button id="select-creative-btn" class="select-btn" data-select-text="<%= t('app.select') %>" data-cancel-text="<%= t('app.cancel_select') %>" data-action="click->creatives--select-mode#toggle" data-creatives--select-mode-target="toggle"><%= t('app.select') %></button>
-  <% end %>
-  <% if (@parent_creative || @creative)&.has_permission?(Current.user, :admin) %>
-    <button id="delete-selection-btn" class="danger-link" style="display:none;" data-confirm="<%= t('collavre.creatives.index.are_you_sure_delete_selection') %>" data-action="click->creatives--select-mode#deleteSelected" data-creatives--select-mode-target="deleteButton"><%= t('collavre.creatives.index.delete_selection') %></button>
-  <% end %>
-  <button id="expand-all-btn" class="expand-btn" style="width: 36px;" data-expand-text="<%= t('app.expand_all') %>" data-collapse-text="<%= t('app.collapse_all') %>" data-action="click->creatives--expansion#toggleAll" data-creatives--expansion-target="expand"><span class="icon-expand" aria-hidden="true"><%= svg_tag 'chevron-down.svg', width: 16, height: 16 %></span><span class="icon-collapse" aria-hidden="true" style="display:none"><%= svg_tag 'chevron-right.svg', width: 16, height: 16 %></span></button>
-  <button id="toggle-edit-btn" class="edit-toggle-btn mobile-only" aria-label="<%= t('.edit') %>" title="<%= t('.edit') %>">
-    <span aria-hidden="true"><%= svg_tag 'edit.svg', class: 'icon-edit', width: 16, height: 16 %></span></button>
-  <% if authenticated? %>
-    <button id="toggle-archived-btn" class="archive-toggle-btn desktop-only" title="<%= t('collavre.creatives.index.show_archived') %>" data-show-text="<%= t('collavre.creatives.index.show_archived') %>" data-hide-text="<%= t('collavre.creatives.index.hide_archived') %>"><span aria-hidden="true"><%= svg_tag 'archive.svg', width: 16, height: 16 %></span></button>
-  <% end %>
-  <% if authenticated? && (!params[:id] || (@parent_creative && @parent_creative.has_permission?(Current.user, :write))) %>
-    <button id="import-markdown-btn" class="import-btn desktop-only" data-action="click->creatives--import#toggle" data-creatives--import-target="toggle"><%= t('.import_markdown') %></button>
-  <% end %>
-  <button id="export-markdown-btn" class="export-btn desktop-only" data-parent-creative-id="<%= @parent_creative&.id %>" data-error="<%= t('collavre.creatives.index.export_failed') %>"><%= t('.export_markdown') %></button>
-  <%= render 'mobile_actions_menu', current_creative: current_creative, can_manage_integrations: can_manage_integrations %>
-</div>
+      <%# Expand/collapse toggle (always visible) %>
+      <button id="expand-all-btn" class="creative-header-outline-btn" title="<%= t('app.expand_all') %>" data-expand-text="<%= t('app.expand_all') %>" data-collapse-text="<%= t('app.collapse_all') %>" data-action="click->creatives--expansion#toggleAll" data-creatives--expansion-target="expand">
+        <span class="icon-expand" aria-hidden="true"><%= svg_tag 'chevron-down.svg', width: 14, height: 14 %></span>
+        <span class="icon-collapse" aria-hidden="true" style="display:none"><%= svg_tag 'chevron-right.svg', width: 14, height: 14 %></span>
+      </button>
+
+      <%# Contextual (select mode — hidden until activated) %>
+      <button id="set-plan-btn" class="set-plan-btn" style="display:none;" data-creatives--select-mode-target="setPlan" data-action="click->creatives--set-plan-modal#open"><%= t('app.set_plan') %></button>
+      <input type="checkbox" id="select-all-creatives" style="display:none;vertical-align:middle;" data-action="change->creatives--select-mode#toggleSelectAll" data-creatives--select-mode-target="selectAll" />
+      <% if (@parent_creative || @creative)&.has_permission?(Current.user, :admin) %>
+        <button id="delete-selection-btn" class="danger-link" style="display:none;" data-confirm="<%= t('collavre.creatives.index.are_you_sure_delete_selection') %>" data-action="click->creatives--select-mode#deleteSelected" data-creatives--select-mode-target="deleteButton"><%= t('collavre.creatives.index.delete_selection') %></button>
+      <% end %>
+
+      <%# Overflow menu ⋯ (GNB style) %>
+      <%= render Collavre::PopupMenuComponent.new(
+            button_content: '⋯',
+            menu_id: 'creative-overflow-menu',
+            align: :right,
+            button_classes: 'creative-header-outline-btn'
+          ) do %>
+        <% if (@parent_creative || @creative) && (@parent_creative || @creative).has_permission?(Current.user, :write) %>
+          <button type="button" id="share-creative-btn" class="popup-menu-item" data-action="click->share-modal#open" data-share-modal-url-param="<%= collavre.creative_creative_shares_path(current_creative) %>">
+            <span aria-hidden="true"><%= svg_tag 'share.svg', width: 16, height: 16 %></span> <%= t('collavre.creatives.index.share') %>
+          </button>
+        <% end %>
+        <% if authenticated? %>
+          <button type="button" id="select-creative-btn" class="popup-menu-item" data-select-text="<%= t('app.select') %>" data-cancel-text="<%= t('app.cancel_select') %>" data-action="click->creatives--select-mode#toggle" data-creatives--select-mode-target="toggle">
+            <span aria-hidden="true"><%= svg_tag 'selection.svg', width: 16, height: 16 %></span> <%= t('app.select') %>
+          </button>
+        <% end %>
+        <% if @parent_creative.present? %>
+          <%= button_to slide_view_creative_path(@parent_creative), method: :get, class: 'popup-menu-item' do %>
+            <span aria-hidden="true"><%= svg_tag 'slide.svg', width: 16, height: 16 %></span> <%= t('collavre.creatives.index.slide_view') %>
+          <% end %>
+        <% end %>
+        <div class="creative-overflow-divider"></div>
+        <% if authenticated? && (!params[:id] || (@parent_creative && @parent_creative.has_permission?(Current.user, :write))) %>
+          <button type="button" id="import-markdown-btn" class="popup-menu-item" data-action="click->creatives--import#toggle" data-creatives--import-target="toggle">
+            <span aria-hidden="true"><%= svg_tag 'arrow-down.svg', width: 16, height: 16 %></span> <%= t('.import_markdown') %>
+          </button>
+        <% end %>
+        <button type="button" id="export-markdown-btn" class="popup-menu-item" data-parent-creative-id="<%= @parent_creative&.id %>" data-error="<%= t('collavre.creatives.index.export_failed') %>">
+          <span aria-hidden="true"><%= svg_tag 'arrow-up.svg', width: 16, height: 16 %></span> <%= t('.export_markdown') %>
+        </button>
+        <% if authenticated? %>
+          <button type="button" id="toggle-archived-btn" class="popup-menu-item" title="<%= t('collavre.creatives.index.show_archived') %>" data-show-text="<%= t('collavre.creatives.index.show_archived') %>" data-hide-text="<%= t('collavre.creatives.index.hide_archived') %>">
+            <span aria-hidden="true"><%= svg_tag 'archive.svg', width: 16, height: 16 %></span> <%= t('collavre.creatives.index.show_archived') %>
+          </button>
+        <% end %>
+        <% if can_manage_integrations %>
+          <div class="creative-overflow-divider"></div>
+          <%= render 'integrations_menu', creative: current_creative %>
+        <% end %>
+        <div class="creative-overflow-divider mobile-only"></div>
+        <button type="button" id="toggle-edit-btn" class="popup-menu-item mobile-only" aria-label="<%= t('.edit') %>">
+          <span aria-hidden="true"><%= svg_tag 'edit.svg', width: 16, height: 16 %></span> <%= t('.edit') %>
+        </button>
+      <% end %>
+    </div>
+  </div>
 
   <% if (@parent_creative || @creative) && (@parent_creative || @creative).has_permission?(Current.user, :write) %>
     <div data-share-modal-target="container"></div>

--- a/engines/collavre/config/locales/creatives.en.yml
+++ b/engines/collavre/config/locales/creatives.en.yml
@@ -36,6 +36,7 @@ en:
         are_you_sure_delete_selection: Are you sure you want to delete selected Creatives?
           This cannot be undone.
         creatives: Creatives
+        breadcrumb: Breadcrumb
         root_breadcrumb: Top
         slide_view: Slide View
         recalculate_progress: Recalculate Progress

--- a/engines/collavre/config/locales/creatives.en.yml
+++ b/engines/collavre/config/locales/creatives.en.yml
@@ -36,6 +36,7 @@ en:
         are_you_sure_delete_selection: Are you sure you want to delete selected Creatives?
           This cannot be undone.
         creatives: Creatives
+        root_breadcrumb: Top
         slide_view: Slide View
         recalculate_progress: Recalculate Progress
         recalculate_all_parent_progress: Recalculate all parent progress?

--- a/engines/collavre/config/locales/creatives.ko.yml
+++ b/engines/collavre/config/locales/creatives.ko.yml
@@ -32,6 +32,7 @@ ko:
         delete_selection: 선택 항목 삭제
         are_you_sure_delete_selection: 선택된 크리에이티브를 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.
         creatives: 크리에이티브 목록
+        breadcrumb: 계보
         root_breadcrumb: 최상위
         slide_view: 슬라이드 뷰
         recalculate_progress: 진행률 다시 계산

--- a/engines/collavre/config/locales/creatives.ko.yml
+++ b/engines/collavre/config/locales/creatives.ko.yml
@@ -32,6 +32,7 @@ ko:
         delete_selection: 선택 항목 삭제
         are_you_sure_delete_selection: 선택된 크리에이티브를 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.
         creatives: 크리에이티브 목록
+        root_breadcrumb: 최상위
         slide_view: 슬라이드 뷰
         recalculate_progress: 진행률 다시 계산
         recalculate_all_parent_progress: 모든 상위 진행률을 다시 계산하시겠습니까?

--- a/engines/collavre/test/system/creative_share_test.rb
+++ b/engines/collavre/test/system/creative_share_test.rb
@@ -24,7 +24,8 @@ class CreativeShareSystemTest < ApplicationSystemTestCase
 
     visit collavre.creative_path(@creative)
 
-    # Share modal is loaded via AJAX when share button is clicked
+    # Open overflow menu first, then click share button (share is inside ⋯ menu)
+    find("#creative-overflow-menu", visible: :all).ancestor(".popup-menu-wrapper").find("button", match: :first).click
     find("#share-creative-btn").click
     assert_selector "#share-creative-modal", visible: :visible
 

--- a/engines/collavre/test/system/inline_scripts_test.rb
+++ b/engines/collavre/test/system/inline_scripts_test.rb
@@ -191,7 +191,8 @@ class InlineScriptsTest < ApplicationSystemTestCase
     # Modal is loaded via AJAX, so it should not be in the DOM initially
     assert_no_selector "#share-creative-modal"
 
-    # Click share button to load and open the modal
+    # Open overflow menu, then click share button (share is inside ⋯ menu)
+    find("#creative-overflow-menu", visible: :all).ancestor(".popup-menu-wrapper").find("button", match: :first).click
     find("#share-creative-btn").click
 
     # Modal should become visible after AJAX load
@@ -209,6 +210,7 @@ class InlineScriptsTest < ApplicationSystemTestCase
 
     visit collavre.creative_path(creative)
 
+    find("#creative-overflow-menu", visible: :all).ancestor(".popup-menu-wrapper").find("button", match: :first).click
     find("#share-creative-btn").click
     assert_selector "#share-creative-modal", visible: :visible
 


### PR DESCRIPTION
## Summary

Redesign the `creative-actions-row` to be cleaner and more modern.

### Changes

**Structure**
- **Left side**: Breadcrumb ancestry navigation (`Top / Parent1 / Parent2 / Current`)
  - Each ancestor is a clickable underline link
  - Current title click triggers page refresh (`data-turbo-action: replace`)
  - Root shows "Top" (en) / "최상위" (ko) text
- **Right side**: Only 3 action buttons, aligned with creative-row comments-btn
  - `+` Add button (existing partial)
  - Expand/collapse toggle
  - `⋯` Overflow menu (GNB popup style)

**Overflow menu contains**
- Share | Select | Slide View
- Import | Export | Archive
- Integrations (admin only)
- Edit (mobile only)

**Removed**
- ↑ Parent navigation button (replaced by breadcrumb)
- Individual share, select, archive, import/export buttons from action row
- Separate mobile actions menu partial render

### CSS
- Breadcrumb links override `application.css` global `.creative-actions-row a` styles with higher specificity + `!important`
- Outline button style for action buttons (GNB-like)
- Overflow menu uses GNB popup style with dividers
- `margin-right: 0` on actions-row to align with creative-row comments-btn
- No border below actions-row

### i18n
- Added `breadcrumb`, `root_breadcrumb` keys (en + ko)

### Notes
- Title area is NOT changed
- Existing Stimulus controllers (select-mode, expansion, import, share-modal) are preserved
- FOUC prevention (`visibility:hidden` until `creative-alignment-ready`) is preserved