### PR TITLE
style: add right padding to breadcrumb for action button spacing

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/creatives.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/creatives.css
@@ -71,6 +71,7 @@ html.creative-alignment-ready .page-title {
     white-space: nowrap;
     scrollbar-width: none;
     min-width: 0;
+    padding-right: var(--space-3);
 }
 
 .creative-breadcrumb::-webkit-scrollbar {

--- a/engines/collavre/app/assets/stylesheets/collavre/creatives.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/creatives.css
@@ -71,7 +71,7 @@ html.creative-alignment-ready .page-title {
     white-space: nowrap;
     scrollbar-width: none;
     min-width: 0;
-    padding-right: var(--space-3);
+    margin-right: var(--space-3);
 }
 
 .creative-breadcrumb::-webkit-scrollbar {


### PR DESCRIPTION
## Summary

Add `padding-right: var(--space-3)` to `.creative-breadcrumb` so the breadcrumb trail doesn't butt up against the action buttons when it's long enough to scroll.

## Changes

- `engines/collavre/app/assets/stylesheets/collavre/creatives.css`: Added right padding to breadcrumb container using design token `--space-3`