### PR TITLE
fix: update inbox panel CSS test to reference engine gnb.css

### DIFF
--- a/engines/collavre/test/assets/inbox_panel_css_test.rb
+++ b/engines/collavre/test/assets/inbox_panel_css_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class InboxPanelCssTest < ActiveSupport::TestCase
   test "defines open state for small screens" do
-    css = File.read(Rails.root.join("app/assets/stylesheets/application.css"))
+    css = File.read(Collavre::Engine.root.join("app/assets/stylesheets/collavre/gnb.css"))
     assert_includes css, "@media (max-width: 360px)"
 
     pattern = /#inbox-panel\.slide-panel\.open\s*\{[^\}]*right:\s*0;[^\}]*\}/


### PR DESCRIPTION
## Problem
`InboxPanelCssTest` fails after #1033 which moved GNB styles from `app/assets/stylesheets/application.css` to `engines/collavre/app/assets/stylesheets/collavre/gnb.css`.

The test still reads the host app's `application.css` which no longer contains the inbox panel styles.

## Fix
Update the test to read from `Collavre::Engine.root.join('app/assets/stylesheets/collavre/gnb.css')` instead.

## Testing
- All 1354 tests pass (0 failures, 0 errors)