### PR TITLE
feat: real-time creative collaboration sync with presence and edit conflict hints

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/creatives.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/creatives.css
@@ -912,3 +912,50 @@ creative-tree-row[archived] .creative-row {
     border-color: var(--color-accent-border);
     background-color: var(--surface-input);
 }
+
+/* --- Creative Presence Avatars --- */
+.creative-presence-avatars {
+    display: inline-flex;
+    align-items: center;
+    gap: 2px;
+    margin-left: var(--space-2, 8px);
+    vertical-align: middle;
+}
+
+.creative-presence-user {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+}
+
+.creative-presence-user .avatar {
+    border: 2px solid var(--color-active, #4caf50);
+    width: 20px;
+    height: 20px;
+}
+
+/* --- Editing Conflict Indicator --- */
+creative-tree-row.is-being-edited {
+    position: relative;
+}
+
+creative-tree-row.is-being-edited .creative-tree {
+    border-left: 3px solid var(--color-warning, #ff9800);
+}
+
+.creative-editing-indicator {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1, 4px);
+    font-size: var(--text-xs, 0.75rem);
+    color: var(--color-warning, #ff9800);
+    margin-left: var(--space-2, 8px);
+    white-space: nowrap;
+    animation: editing-pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes editing-pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.5; }
+}

--- a/engines/collavre/app/assets/stylesheets/collavre/creatives.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/creatives.css
@@ -959,3 +959,31 @@ creative-tree-row.is-being-edited .creative-tree {
     0%, 100% { opacity: 1; }
     50% { opacity: 0.5; }
 }
+
+/* Editing presence avatars */
+.creative-editing-avatars {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1, 2px);
+    margin-left: var(--space-1, 4px);
+}
+
+.creative-editing-avatar-img {
+    border-radius: var(--radius-round, 50%);
+    border: 2px solid var(--color-accent, #4a9eff);
+    object-fit: cover;
+}
+
+.creative-editing-avatar-initials {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    border-radius: var(--radius-round, 50%);
+    background: var(--color-accent, #4a9eff);
+    color: var(--color-on-accent, white);
+    font-size: var(--text-xs, 11px);
+    font-weight: var(--weight-semibold, 600);
+    border: 2px solid var(--color-accent, #4a9eff);
+}

--- a/engines/collavre/app/assets/stylesheets/collavre/creatives.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/creatives.css
@@ -987,3 +987,10 @@ creative-tree-row.is-being-edited .creative-tree {
     font-weight: var(--weight-semibold, 600);
     border: 2px solid var(--color-accent, #4a9eff);
 }
+
+/* Wrapper for progressHtml so DOM can be synced back to Lit state
+   after Turbo Streams mutations (e.g. badge count updates).
+   display:contents ensures no layout impact. */
+.creative-progress-area {
+    display: contents;
+}

--- a/engines/collavre/app/channels/collavre/creatives_channel.rb
+++ b/engines/collavre/app/channels/collavre/creatives_channel.rb
@@ -51,10 +51,12 @@ module Collavre
     private
 
     def broadcast_to_all_ancestors(creative_id, payload)
-      creative = Creative.find_by(id: creative_id)
-      roots = Set.new([ @root ])
-      if creative
-        creative.ancestors.each { |ancestor| roots << ancestor.effective_origin }
+      @ancestor_roots_cache ||= {}
+      roots = @ancestor_roots_cache[creative_id] ||= begin
+        creative = Creative.find_by(id: creative_id)
+        result = Set.new([ @root ])
+        creative&.ancestors&.each { |a| result << a.effective_origin }
+        result
       end
       roots.each { |root| CreativesChannel.broadcast_to(root, payload) }
     end

--- a/engines/collavre/app/channels/collavre/creatives_channel.rb
+++ b/engines/collavre/app/channels/collavre/creatives_channel.rb
@@ -1,55 +1,55 @@
-module Collavre
-  class CreativesChannel < ApplicationCable::Channel
-    def subscribed
-      return reject unless params[:root_id].present? && current_user
+class CreativesChannel < ApplicationCable::Channel
+  def subscribed
+    return reject unless params[:root_id].present? && current_user
 
-      @root = Creative.find_by(id: params[:root_id])&.effective_origin
-      return reject unless @root
-      return reject unless @root.has_permission?(current_user, :read)
+    @root = Collavre::Creative.find_by(id: params[:root_id])&.effective_origin
+    return reject unless @root
+    return reject unless @root.has_permission?(current_user, :read)
 
-      Rails.logger.info "[CreativesChannel] User #{current_user.email} subscribed to root #{@root.id}"
-      stream_for @root
-      CreativePresenceStore.add(@root.id, current_user.id)
+    Rails.logger.info "[CreativesChannel] User #{current_user.email} subscribed to root #{@root.id}"
+    stream_for @root
+    Collavre::CreativePresenceStore.add(@root.id, current_user.id)
+    broadcast_presence
+  end
+
+  def unsubscribed
+    if @root && current_user
+      Collavre::CreativePresenceStore.remove(@root.id, current_user.id)
       broadcast_presence
     end
+  end
 
-    def unsubscribed
-      if @root && current_user
-        CreativePresenceStore.remove(@root.id, current_user.id)
-        broadcast_presence
-      end
-    end
+  def editing(data)
+    return unless @root && current_user
 
-    def editing(data)
-      return unless @root && current_user
+    creative_id = data["creative_id"].to_i
+    Rails.logger.info "[CreativesChannel] User #{current_user.email} editing creative##{creative_id}"
+    CreativesChannel.broadcast_to(@root, {
+      editing: {
+        creative_id: creative_id,
+        user_id: current_user.id,
+        user_name: current_user.display_name
+      }
+    })
+  end
 
-      creative_id = data["creative_id"].to_i
-      CreativesChannel.broadcast_to(@root, {
-        editing: {
-          creative_id: creative_id,
-          user_id: current_user.id,
-          user_name: current_user.display_name
-        }
-      })
-    end
+  def stopped_editing(data)
+    return unless @root && current_user
 
-    def stopped_editing(data)
-      return unless @root && current_user
+    creative_id = data["creative_id"].to_i
+    Rails.logger.info "[CreativesChannel] User #{current_user.email} stopped editing creative##{creative_id}"
+    CreativesChannel.broadcast_to(@root, {
+      stopped_editing: {
+        creative_id: creative_id,
+        user_id: current_user.id
+      }
+    })
+  end
 
-      creative_id = data["creative_id"].to_i
-      CreativesChannel.broadcast_to(@root, {
-        stopped_editing: {
-          creative_id: creative_id,
-          user_id: current_user.id
-        }
-      })
-    end
+  private
 
-    private
-
-    def broadcast_presence
-      user_ids = CreativePresenceStore.list(@root.id)
-      CreativesChannel.broadcast_to(@root, { presence: { user_ids: user_ids } })
-    end
+  def broadcast_presence
+    user_ids = Collavre::CreativePresenceStore.list(@root.id)
+    CreativesChannel.broadcast_to(@root, { presence: { user_ids: user_ids } })
   end
 end

--- a/engines/collavre/app/channels/collavre/creatives_channel.rb
+++ b/engines/collavre/app/channels/collavre/creatives_channel.rb
@@ -1,55 +1,57 @@
-class CreativesChannel < ApplicationCable::Channel
-  def subscribed
-    return reject unless params[:root_id].present? && current_user
+module Collavre
+  class CreativesChannel < ApplicationCable::Channel
+    def subscribed
+      return reject unless params[:root_id].present? && current_user
 
-    @root = Collavre::Creative.find_by(id: params[:root_id])&.effective_origin
-    return reject unless @root
-    return reject unless @root.has_permission?(current_user, :read)
+      @root = Creative.find_by(id: params[:root_id])&.effective_origin
+      return reject unless @root
+      return reject unless @root.has_permission?(current_user, :read)
 
-    Rails.logger.info "[CreativesChannel] User #{current_user.email} subscribed to root #{@root.id}"
-    stream_for @root
-    Collavre::CreativePresenceStore.add(@root.id, current_user.id)
-    broadcast_presence
-  end
-
-  def unsubscribed
-    if @root && current_user
-      Collavre::CreativePresenceStore.remove(@root.id, current_user.id)
+      Rails.logger.info "[CreativesChannel] User #{current_user.email} subscribed to root #{@root.id}"
+      stream_for @root
+      CreativePresenceStore.add(@root.id, current_user.id)
       broadcast_presence
     end
-  end
 
-  def editing(data)
-    return unless @root && current_user
+    def unsubscribed
+      if @root && current_user
+        CreativePresenceStore.remove(@root.id, current_user.id)
+        broadcast_presence
+      end
+    end
 
-    creative_id = data["creative_id"].to_i
-    Rails.logger.info "[CreativesChannel] User #{current_user.email} editing creative##{creative_id}"
-    CreativesChannel.broadcast_to(@root, {
-      editing: {
-        creative_id: creative_id,
-        user_id: current_user.id,
-        user_name: current_user.display_name
-      }
-    })
-  end
+    def editing(data)
+      return unless @root && current_user
 
-  def stopped_editing(data)
-    return unless @root && current_user
+      creative_id = data["creative_id"].to_i
+      Rails.logger.info "[CreativesChannel] User #{current_user.email} editing creative##{creative_id}"
+      CreativesChannel.broadcast_to(@root, {
+        editing: {
+          creative_id: creative_id,
+          user_id: current_user.id,
+          user_name: current_user.display_name
+        }
+      })
+    end
 
-    creative_id = data["creative_id"].to_i
-    Rails.logger.info "[CreativesChannel] User #{current_user.email} stopped editing creative##{creative_id}"
-    CreativesChannel.broadcast_to(@root, {
-      stopped_editing: {
-        creative_id: creative_id,
-        user_id: current_user.id
-      }
-    })
-  end
+    def stopped_editing(data)
+      return unless @root && current_user
 
-  private
+      creative_id = data["creative_id"].to_i
+      Rails.logger.info "[CreativesChannel] User #{current_user.email} stopped editing creative##{creative_id}"
+      CreativesChannel.broadcast_to(@root, {
+        stopped_editing: {
+          creative_id: creative_id,
+          user_id: current_user.id
+        }
+      })
+    end
 
-  def broadcast_presence
-    user_ids = Collavre::CreativePresenceStore.list(@root.id)
-    CreativesChannel.broadcast_to(@root, { presence: { user_ids: user_ids } })
+    private
+
+    def broadcast_presence
+      user_ids = CreativePresenceStore.list(@root.id)
+      CreativesChannel.broadcast_to(@root, { presence: { user_ids: user_ids } })
+    end
   end
 end

--- a/engines/collavre/app/channels/collavre/creatives_channel.rb
+++ b/engines/collavre/app/channels/collavre/creatives_channel.rb
@@ -24,31 +24,40 @@ module Collavre
       return unless @root && current_user
 
       creative_id = data["creative_id"].to_i
-      Rails.logger.info "[CreativesChannel] User #{current_user.email} editing creative##{creative_id}"
-      CreativesChannel.broadcast_to(@root, {
+      payload = {
         editing: {
           creative_id: creative_id,
           user_id: current_user.id,
           user_name: current_user.display_name,
           avatar_url: user_avatar_url_for(current_user)
         }
-      })
+      }
+      broadcast_to_all_ancestors(creative_id, payload)
     end
 
     def stopped_editing(data)
       return unless @root && current_user
 
       creative_id = data["creative_id"].to_i
-      Rails.logger.info "[CreativesChannel] User #{current_user.email} stopped editing creative##{creative_id}"
-      CreativesChannel.broadcast_to(@root, {
+      payload = {
         stopped_editing: {
           creative_id: creative_id,
           user_id: current_user.id
         }
-      })
+      }
+      broadcast_to_all_ancestors(creative_id, payload)
     end
 
     private
+
+    def broadcast_to_all_ancestors(creative_id, payload)
+      creative = Creative.find_by(id: creative_id)
+      roots = Set.new([ @root ])
+      if creative
+        creative.ancestors.each { |ancestor| roots << ancestor.effective_origin }
+      end
+      roots.each { |root| CreativesChannel.broadcast_to(root, payload) }
+    end
 
     def user_avatar_url_for(user)
       if user.avatar.attached?

--- a/engines/collavre/app/channels/collavre/creatives_channel.rb
+++ b/engines/collavre/app/channels/collavre/creatives_channel.rb
@@ -1,0 +1,54 @@
+module Collavre
+  class CreativesChannel < ApplicationCable::Channel
+    def subscribed
+      return reject unless params[:root_id].present? && current_user
+
+      @root = Creative.find_by(id: params[:root_id])&.effective_origin
+      return reject unless @root
+      return reject unless @root.has_permission?(current_user, :read)
+
+      stream_for @root
+      CreativePresenceStore.add(@root.id, current_user.id)
+      broadcast_presence
+    end
+
+    def unsubscribed
+      if @root && current_user
+        CreativePresenceStore.remove(@root.id, current_user.id)
+        broadcast_presence
+      end
+    end
+
+    def editing(data)
+      return unless @root && current_user
+
+      creative_id = data["creative_id"].to_i
+      CreativesChannel.broadcast_to(@root, {
+        editing: {
+          creative_id: creative_id,
+          user_id: current_user.id,
+          user_name: current_user.display_name
+        }
+      })
+    end
+
+    def stopped_editing(data)
+      return unless @root && current_user
+
+      creative_id = data["creative_id"].to_i
+      CreativesChannel.broadcast_to(@root, {
+        stopped_editing: {
+          creative_id: creative_id,
+          user_id: current_user.id
+        }
+      })
+    end
+
+    private
+
+    def broadcast_presence
+      user_ids = CreativePresenceStore.list(@root.id)
+      CreativesChannel.broadcast_to(@root, { presence: { user_ids: user_ids } })
+    end
+  end
+end

--- a/engines/collavre/app/channels/collavre/creatives_channel.rb
+++ b/engines/collavre/app/channels/collavre/creatives_channel.rb
@@ -29,7 +29,8 @@ module Collavre
         editing: {
           creative_id: creative_id,
           user_id: current_user.id,
-          user_name: current_user.display_name
+          user_name: current_user.display_name,
+          avatar_url: user_avatar_url_for(current_user)
         }
       })
     end
@@ -48,6 +49,16 @@ module Collavre
     end
 
     private
+
+    def user_avatar_url_for(user)
+      if user.avatar.attached?
+        Rails.application.routes.url_helpers.rails_blob_path(
+          user.avatar, only_path: true
+        )
+      elsif user.respond_to?(:avatar_url) && user.avatar_url.present?
+        user.avatar_url
+      end
+    end
 
     def broadcast_presence
       user_ids = CreativePresenceStore.list(@root.id)

--- a/engines/collavre/app/channels/collavre/creatives_channel.rb
+++ b/engines/collavre/app/channels/collavre/creatives_channel.rb
@@ -52,8 +52,9 @@ module Collavre
 
     def user_avatar_url_for(user)
       if user.avatar.attached?
-        Rails.application.routes.url_helpers.rails_blob_path(
-          user.avatar, only_path: true
+        variant = user.avatar.variant(resize_to_limit: [ 48, 48 ])
+        Rails.application.routes.url_helpers.rails_representation_path(
+          variant, only_path: true
         )
       elsif user.respond_to?(:avatar_url) && user.avatar_url.present?
         user.avatar_url

--- a/engines/collavre/app/channels/collavre/creatives_channel.rb
+++ b/engines/collavre/app/channels/collavre/creatives_channel.rb
@@ -7,6 +7,7 @@ module Collavre
       return reject unless @root
       return reject unless @root.has_permission?(current_user, :read)
 
+      Rails.logger.info "[CreativesChannel] User #{current_user.email} subscribed to root #{@root.id}"
       stream_for @root
       CreativePresenceStore.add(@root.id, current_user.id)
       broadcast_presence

--- a/engines/collavre/app/javascript/components/creative_tree_row.js
+++ b/engines/collavre/app/javascript/components/creative_tree_row.js
@@ -26,7 +26,8 @@ class CreativeTreeRow extends LitElement {
     isTitle: { type: Boolean, attribute: "is-title", reflect: true },
     archived: { type: Boolean, attribute: "archived", reflect: true },
     loadingChildren: { type: Boolean, attribute: "loading-children", reflect: true },
-    _loadingDotsState: { state: true }
+    _loadingDotsState: { state: true },
+    editingUsers: { state: true }
   };
 
   constructor() {
@@ -47,6 +48,7 @@ class CreativeTreeRow extends LitElement {
     this.editOffIconHtml = "";
     this.originLinkHtml = "";
     this.isTitle = false;
+    this.editingUsers = []; // [{ user_id, user_name, avatar_url }]
     this._templatesExtracted = false;
     this.loadingChildren = false;
     this._loadingDotsState = ['.', '.', '.'];
@@ -215,6 +217,7 @@ class CreativeTreeRow extends LitElement {
             ${this._renderToggle()}
             ${this._renderContent()}
           </div>
+            ${this._renderEditingAvatars()}
             ${unsafeHTML(this.progressHtml || "")}
         </div>
       </div>
@@ -292,6 +295,23 @@ class CreativeTreeRow extends LitElement {
       >
         ${unsafeHTML(this.editOffIconHtml || "")}
       </button>
+    `;
+  }
+
+  _renderEditingAvatars() {
+    if (!this.editingUsers || this.editingUsers.length === 0) return nothing;
+    return html`
+      <div class="creative-editing-avatars" title="${this.editingUsers.map(u => u.user_name).join(', ')}">
+        ${this.editingUsers.map(u => html`
+          <span class="creative-editing-avatar" title="${u.user_name} is editing">
+            ${u.avatar_url
+              ? html`<img src="${u.avatar_url}" alt="${u.user_name}" width="20" height="20" style="border-radius:50%; border: 2px solid var(--color-accent, #4a9eff);">`
+              : html`<span style="display:inline-flex; align-items:center; justify-content:center; width:20px; height:20px; border-radius:50%; background:var(--color-accent, #4a9eff); color:white; font-size:10px; border: 2px solid var(--color-accent, #4a9eff);">${(u.user_name || '?')[0]}</span>`
+            }
+            <span style="font-size:10px;">✏️</span>
+          </span>
+        `)}
+      </div>
     `;
   }
 

--- a/engines/collavre/app/javascript/components/creative_tree_row.js
+++ b/engines/collavre/app/javascript/components/creative_tree_row.js
@@ -305,8 +305,8 @@ class CreativeTreeRow extends LitElement {
         ${this.editingUsers.map(u => html`
           <span class="creative-editing-avatar" title="${u.user_name} is editing">
             ${u.avatar_url
-              ? html`<img src="${u.avatar_url}" alt="${u.user_name}" width="24" height="24" style="border-radius:50%; border: 2px solid var(--color-accent, #4a9eff); object-fit:cover;">`
-              : html`<span style="display:inline-flex; align-items:center; justify-content:center; width:24px; height:24px; border-radius:50%; background:var(--color-accent, #4a9eff); color:white; font-size:11px; font-weight:600; border: 2px solid var(--color-accent, #4a9eff);">${(u.user_name || '?')[0]}</span>`
+              ? html`<img src="${u.avatar_url}" alt="${u.user_name}" width="24" height="24" class="creative-editing-avatar-img">`
+              : html`<span class="creative-editing-avatar-initials">${(u.user_name || '?')[0]}</span>`
             }
           </span>
         `)}

--- a/engines/collavre/app/javascript/components/creative_tree_row.js
+++ b/engines/collavre/app/javascript/components/creative_tree_row.js
@@ -305,10 +305,9 @@ class CreativeTreeRow extends LitElement {
         ${this.editingUsers.map(u => html`
           <span class="creative-editing-avatar" title="${u.user_name} is editing">
             ${u.avatar_url
-              ? html`<img src="${u.avatar_url}" alt="${u.user_name}" width="20" height="20" style="border-radius:50%; border: 2px solid var(--color-accent, #4a9eff);">`
-              : html`<span style="display:inline-flex; align-items:center; justify-content:center; width:20px; height:20px; border-radius:50%; background:var(--color-accent, #4a9eff); color:white; font-size:10px; border: 2px solid var(--color-accent, #4a9eff);">${(u.user_name || '?')[0]}</span>`
+              ? html`<img src="${u.avatar_url}" alt="${u.user_name}" width="24" height="24" style="border-radius:50%; border: 2px solid var(--color-accent, #4a9eff); object-fit:cover;">`
+              : html`<span style="display:inline-flex; align-items:center; justify-content:center; width:24px; height:24px; border-radius:50%; background:var(--color-accent, #4a9eff); color:white; font-size:11px; font-weight:600; border: 2px solid var(--color-accent, #4a9eff);">${(u.user_name || '?')[0]}</span>`
             }
-            <span style="font-size:10px;">✏️</span>
           </span>
         `)}
       </div>

--- a/engines/collavre/app/javascript/components/creative_tree_row.js
+++ b/engines/collavre/app/javascript/components/creative_tree_row.js
@@ -218,7 +218,7 @@ class CreativeTreeRow extends LitElement {
             ${this._renderContent()}
           </div>
             ${this._renderEditingAvatars()}
-            ${unsafeHTML(this.progressHtml || "")}
+            <span class="creative-progress-area">${unsafeHTML(this.progressHtml || "")}</span>
         </div>
       </div>
     `;
@@ -245,7 +245,7 @@ class CreativeTreeRow extends LitElement {
           </div>
           <div class="creative-row-end">
              <h1 class="page-title" style="margin: 0; display:flex; align-items:center;">
-               ${unsafeHTML(this.progressHtml || "")}
+               <span class="creative-progress-area">${unsafeHTML(this.progressHtml || "")}</span>
              </h1>
           </div>
         </div>

--- a/engines/collavre/app/javascript/controllers/comment_badge_controller.js
+++ b/engines/collavre/app/javascript/controllers/comment_badge_controller.js
@@ -1,0 +1,30 @@
+import { Controller } from '@hotwired/stimulus'
+
+// Toggles parent .comments-btn visibility when badge count changes.
+// Handles the case where first comment creates a badge on a previously
+// hidden (no-comments) button — Turbo Streams replaces the badge span
+// but doesn't update the parent button's class.
+export default class extends Controller {
+  static values = {
+    hasComments: { type: Boolean, default: false },
+  }
+
+  connect() {
+    this.toggleParentVisibility()
+  }
+
+  hasCommentsValueChanged() {
+    this.toggleParentVisibility()
+  }
+
+  toggleParentVisibility() {
+    const btn = this.element.closest('.comments-btn')
+    if (!btn) return
+
+    if (this.hasCommentsValue) {
+      btn.classList.remove('no-comments')
+    } else {
+      btn.classList.add('no-comments')
+    }
+  }
+}

--- a/engines/collavre/app/javascript/controllers/creatives/sync_controller.js
+++ b/engines/collavre/app/javascript/controllers/creatives/sync_controller.js
@@ -1,0 +1,300 @@
+import { Controller } from '@hotwired/stimulus'
+import { subscribeToCreatives } from '../../services/creatives_channel'
+
+const EDITING_INDICATOR_CLASS = 'creative-editing-indicator'
+
+export default class extends Controller {
+  static values = {
+    rootId: Number,
+    currentUserId: Number,
+  }
+
+  connect() {
+    this.subscription = null
+    this.editingUsers = {} // { creativeId: { userId: userName, ... } }
+    this.presenceUsers = []
+
+    this.handleEditStart = (e) => {
+      const { creativeId } = e.detail
+      if (creativeId && this.subscription) {
+        this.subscription.sendEditing(creativeId)
+      }
+    }
+    this.handleEditStop = (e) => {
+      const { creativeId } = e.detail
+      if (creativeId && this.subscription) {
+        this.subscription.sendStoppedEditing(creativeId)
+      }
+    }
+
+    document.addEventListener('creative-editing:start', this.handleEditStart)
+    document.addEventListener('creative-editing:stop', this.handleEditStop)
+
+    if (this.rootIdValue) {
+      this.subscribe()
+    }
+  }
+
+  disconnect() {
+    document.removeEventListener('creative-editing:start', this.handleEditStart)
+    document.removeEventListener('creative-editing:stop', this.handleEditStop)
+
+    if (this.subscription) {
+      this.subscription.cleanup()
+      this.subscription = null
+    }
+  }
+
+  rootIdValueChanged() {
+    if (this.subscription) {
+      this.subscription.cleanup()
+      this.subscription = null
+    }
+    if (this.rootIdValue) {
+      this.subscribe()
+    }
+  }
+
+  subscribe() {
+    this.subscription = subscribeToCreatives(this.rootIdValue, {
+      onCreated: (data) => this.handleCreated(data),
+      onUpdated: (data) => this.handleUpdated(data),
+      onDestroyed: (data) => this.handleDestroyed(data),
+      onPresence: (data) => this.handlePresence(data),
+      onEditing: (data) => this.handleEditing(data),
+      onStoppedEditing: (data) => this.handleStoppedEditing(data),
+    })
+  }
+
+  // --- CRUD handlers ---
+
+  handleCreated(data) {
+    const { creative } = data
+    if (!creative) return
+
+    // Refetch the tree to get properly rendered node with all templates
+    this.refetchTree()
+  }
+
+  handleUpdated(data) {
+    const { creative, ancestors } = data
+    if (!creative) return
+
+    // Update the creative row in the DOM
+    const row = this.findRow(creative.id)
+    if (row) {
+      // Update description
+      if (creative.description != null) {
+        const descTemplate = row.querySelector('template[data-part="description"]')
+        if (descTemplate) {
+          descTemplate.innerHTML = creative.description
+        }
+        row.descriptionHtml = creative.description
+        row.dataset.descriptionHtml = creative.description
+        row.dataset.descriptionRawHtml = creative.description_raw_html || ''
+      }
+
+      // Update progress
+      if (creative.progress != null) {
+        row.dataset.progressValue = creative.progress
+      }
+
+      // Trigger re-render
+      if (typeof row.requestUpdate === 'function') {
+        row.requestUpdate()
+      }
+    }
+
+    // Update ancestor progress bars
+    if (Array.isArray(ancestors)) {
+      ancestors.forEach((anc) => {
+        const ancRow = this.findRow(anc.id)
+        if (ancRow && anc.progress != null) {
+          ancRow.dataset.progressValue = anc.progress
+          if (typeof ancRow.requestUpdate === 'function') {
+            ancRow.requestUpdate()
+          }
+        }
+      })
+    }
+
+    // Also update the title row if it matches
+    const titleRow = document.querySelector('creative-tree-row[is-title]')
+    if (titleRow) {
+      const titleId = parseInt(titleRow.getAttribute('creative-id'), 10)
+      if (titleId === creative.id && creative.progress != null) {
+        titleRow.dataset.progressValue = creative.progress
+        if (typeof titleRow.requestUpdate === 'function') {
+          titleRow.requestUpdate()
+        }
+      }
+      // Check ancestors for title update
+      if (Array.isArray(ancestors)) {
+        const titleAncestor = ancestors.find((a) => a.id === titleId)
+        if (titleAncestor) {
+          titleRow.dataset.progressValue = titleAncestor.progress
+          if (typeof titleRow.requestUpdate === 'function') {
+            titleRow.requestUpdate()
+          }
+        }
+      }
+    }
+  }
+
+  handleDestroyed(data) {
+    const { creative } = data
+    if (!creative) return
+
+    const row = this.findRow(creative.id)
+    if (row) {
+      // Also remove the children container if exists
+      const domId = row.getAttribute('dom-id')
+      if (domId) {
+        const childrenContainer = document.getElementById(`children-of-${domId}`)
+        if (childrenContainer) childrenContainer.remove()
+      }
+      row.remove()
+    }
+  }
+
+  // --- Presence handlers ---
+
+  handlePresence(data) {
+    this.presenceUsers = data.user_ids || []
+    this.renderPresence()
+  }
+
+  renderPresence() {
+    const container = document.getElementById('creative-presence-avatars')
+    if (!container) return
+
+    // Fetch user info for presence display
+    if (this.presenceUsers.length === 0) {
+      container.innerHTML = ''
+      return
+    }
+
+    // Fetch participants info from the comments endpoint (reuse existing)
+    const rootId = this.rootIdValue
+    fetch(`/creatives/${rootId}/comments/participants`)
+      .then((r) => r.json())
+      .then((data) => {
+        const users = data.users || []
+        container.innerHTML = ''
+
+        this.presenceUsers.forEach((userId) => {
+          // Skip current user
+          if (userId === this.currentUserIdValue) return
+
+          const user = users.find((u) => u.id === userId)
+          if (!user) return
+
+          const wrapper = document.createElement('span')
+          wrapper.className = 'avatar-wrapper creative-presence-user'
+          wrapper.title = user.name
+
+          const img = document.createElement('img')
+          img.src = user.avatar_url
+          img.alt = user.name
+          img.width = 20
+          img.height = 20
+          img.className = 'avatar'
+          img.style.borderRadius = '50%'
+          wrapper.appendChild(img)
+
+          if (user.default_avatar) {
+            const span = document.createElement('span')
+            span.className = 'avatar-initial'
+            span.textContent = user.initial
+            span.style.fontSize = '10px'
+            wrapper.appendChild(span)
+          }
+
+          container.appendChild(wrapper)
+        })
+      })
+      .catch(() => {
+        // Silently fail - presence is non-critical
+      })
+  }
+
+  // --- Editing conflict handlers ---
+
+  handleEditing(data) {
+    const { creative_id, user_id, user_name } = data
+    // Don't show editing indicator for current user
+    if (user_id === this.currentUserIdValue) return
+
+    if (!this.editingUsers[creative_id]) {
+      this.editingUsers[creative_id] = {}
+    }
+    this.editingUsers[creative_id][user_id] = user_name
+    this.renderEditingIndicator(creative_id)
+  }
+
+  handleStoppedEditing(data) {
+    const { creative_id, user_id } = data
+    if (this.editingUsers[creative_id]) {
+      delete this.editingUsers[creative_id][user_id]
+      if (Object.keys(this.editingUsers[creative_id]).length === 0) {
+        delete this.editingUsers[creative_id]
+      }
+    }
+    this.renderEditingIndicator(creative_id)
+  }
+
+  renderEditingIndicator(creativeId) {
+    const row = this.findRow(creativeId)
+    if (!row) return
+
+    // Remove existing indicator
+    const existing = row.querySelector(`.${EDITING_INDICATOR_CLASS}`)
+    if (existing) existing.remove()
+
+    const editors = this.editingUsers[creativeId]
+    if (!editors || Object.keys(editors).length === 0) {
+      row.classList.remove('is-being-edited')
+      return
+    }
+
+    row.classList.add('is-being-edited')
+
+    const names = Object.values(editors)
+    const indicator = document.createElement('span')
+    indicator.className = EDITING_INDICATOR_CLASS
+    indicator.textContent = `✏️ ${names.join(', ')}`
+    indicator.title = names.join(', ')
+
+    // Insert after the description content
+    const content = row.shadowRoot?.querySelector('.creative-content') || row.querySelector('.creative-content')
+    if (content) {
+      content.appendChild(indicator)
+    }
+  }
+
+  // --- Send editing signals (called from row editor) ---
+
+  notifyEditing(creativeId) {
+    if (this.subscription) {
+      this.subscription.sendEditing(creativeId)
+    }
+  }
+
+  notifyStoppedEditing(creativeId) {
+    if (this.subscription) {
+      this.subscription.sendStoppedEditing(creativeId)
+    }
+  }
+
+  // --- Helpers ---
+
+  findRow(creativeId) {
+    return this.element.querySelector(`creative-tree-row[creative-id="${creativeId}"]`)
+  }
+
+  refetchTree() {
+    // Dispatch event so tree_controller can refetch
+    const event = new CustomEvent('creative-sync:refetch', { bubbles: true })
+    this.element.dispatchEvent(event)
+  }
+}

--- a/engines/collavre/app/javascript/controllers/creatives/sync_controller.js
+++ b/engines/collavre/app/javascript/controllers/creatives/sync_controller.js
@@ -5,8 +5,8 @@ const EDITING_INDICATOR_CLASS = 'creative-editing-indicator'
 
 export default class extends Controller {
   static values = {
-    rootId: Number,
-    currentUserId: Number,
+    rootId: { type: Number, default: 0 },
+    currentUserId: { type: Number, default: 0 },
   }
 
   connect() {
@@ -30,7 +30,7 @@ export default class extends Controller {
     document.addEventListener('creative-editing:start', this.handleEditStart)
     document.addEventListener('creative-editing:stop', this.handleEditStop)
 
-    if (this.rootIdValue) {
+    if (this.rootIdValue > 0) {
       this.subscribe()
     }
   }
@@ -39,6 +39,7 @@ export default class extends Controller {
     document.removeEventListener('creative-editing:start', this.handleEditStart)
     document.removeEventListener('creative-editing:stop', this.handleEditStop)
 
+    if (this.refetchTimer) clearTimeout(this.refetchTimer)
     if (this.subscription) {
       this.subscription.cleanup()
       this.subscription = null
@@ -50,17 +51,32 @@ export default class extends Controller {
       this.subscription.cleanup()
       this.subscription = null
     }
-    if (this.rootIdValue) {
+    if (this.rootIdValue > 0) {
       this.subscribe()
     }
   }
 
   subscribe() {
+    console.log('[CreativeSync] Subscribing to root_id:', this.rootIdValue)
     this.subscription = subscribeToCreatives(this.rootIdValue, {
-      onCreated: (data) => this.handleCreated(data),
-      onUpdated: (data) => this.handleUpdated(data),
-      onDestroyed: (data) => this.handleDestroyed(data),
-      onPresence: (data) => this.handlePresence(data),
+      onConnected: () => console.log('[CreativeSync] Connected'),
+      onDisconnected: () => console.log('[CreativeSync] Disconnected'),
+      onCreated: (data) => {
+        console.log('[CreativeSync] Created:', data)
+        this.handleCreated(data)
+      },
+      onUpdated: (data) => {
+        console.log('[CreativeSync] Updated:', data)
+        this.handleUpdated(data)
+      },
+      onDestroyed: (data) => {
+        console.log('[CreativeSync] Destroyed:', data)
+        this.handleDestroyed(data)
+      },
+      onPresence: (data) => {
+        console.log('[CreativeSync] Presence:', data)
+        this.handlePresence(data)
+      },
       onEditing: (data) => this.handleEditing(data),
       onStoppedEditing: (data) => this.handleStoppedEditing(data),
     })
@@ -68,93 +84,23 @@ export default class extends Controller {
 
   // --- CRUD handlers ---
 
-  handleCreated(data) {
-    const { creative } = data
-    if (!creative) return
-
-    // Refetch the tree to get properly rendered node with all templates
-    this.refetchTree()
+  handleCreated(_data) {
+    this.debouncedRefetch()
   }
 
-  handleUpdated(data) {
-    const { creative, ancestors } = data
-    if (!creative) return
-
-    // Update the creative row in the DOM
-    const row = this.findRow(creative.id)
-    if (row) {
-      // Update description
-      if (creative.description != null) {
-        const descTemplate = row.querySelector('template[data-part="description"]')
-        if (descTemplate) {
-          descTemplate.innerHTML = creative.description
-        }
-        row.descriptionHtml = creative.description
-        row.dataset.descriptionHtml = creative.description
-        row.dataset.descriptionRawHtml = creative.description_raw_html || ''
-      }
-
-      // Update progress
-      if (creative.progress != null) {
-        row.dataset.progressValue = creative.progress
-      }
-
-      // Trigger re-render
-      if (typeof row.requestUpdate === 'function') {
-        row.requestUpdate()
-      }
-    }
-
-    // Update ancestor progress bars
-    if (Array.isArray(ancestors)) {
-      ancestors.forEach((anc) => {
-        const ancRow = this.findRow(anc.id)
-        if (ancRow && anc.progress != null) {
-          ancRow.dataset.progressValue = anc.progress
-          if (typeof ancRow.requestUpdate === 'function') {
-            ancRow.requestUpdate()
-          }
-        }
-      })
-    }
-
-    // Also update the title row if it matches
-    const titleRow = document.querySelector('creative-tree-row[is-title]')
-    if (titleRow) {
-      const titleId = parseInt(titleRow.getAttribute('creative-id'), 10)
-      if (titleId === creative.id && creative.progress != null) {
-        titleRow.dataset.progressValue = creative.progress
-        if (typeof titleRow.requestUpdate === 'function') {
-          titleRow.requestUpdate()
-        }
-      }
-      // Check ancestors for title update
-      if (Array.isArray(ancestors)) {
-        const titleAncestor = ancestors.find((a) => a.id === titleId)
-        if (titleAncestor) {
-          titleRow.dataset.progressValue = titleAncestor.progress
-          if (typeof titleRow.requestUpdate === 'function') {
-            titleRow.requestUpdate()
-          }
-        }
-      }
-    }
+  handleUpdated(_data) {
+    this.debouncedRefetch()
   }
 
-  handleDestroyed(data) {
-    const { creative } = data
-    if (!creative) return
+  handleDestroyed(_data) {
+    this.debouncedRefetch()
+  }
 
-    const row = this.findRow(creative.id)
-    if (row) {
-      // Also remove the children container if exists
-      const domId = row.getAttribute('dom-id')
-      if (domId) {
-        const childrenContainer = document.getElementById(`children-of-${domId}`)
-        if (childrenContainer) childrenContainer.remove()
-      }
-      row.remove()
-    }
+  debouncedRefetch() {
+    if (this.refetchTimer) clearTimeout(this.refetchTimer)
+    this.refetchTimer = setTimeout(() => {
+      this.refetchTree()
+    }, 300)
   }
 
   // --- Presence handlers ---

--- a/engines/collavre/app/javascript/controllers/creatives/sync_controller.js
+++ b/engines/collavre/app/javascript/controllers/creatives/sync_controller.js
@@ -9,16 +9,18 @@ export default class extends Controller {
 
   connect() {
     this.subscription = null
-    this.editingUsers = {} // { creativeId: { userId: { user_name, avatar_url } } }
+    this.editingUsers = {} // { creativeId: { userId: { user_name } } }
 
     this.handleEditStart = (e) => {
       const { creativeId } = e.detail
+      console.log('[CreativeSync] Edit start event, creativeId:', creativeId, 'subscription:', !!this.subscription)
       if (creativeId && this.subscription) {
         this.subscription.sendEditing(creativeId)
       }
     }
     this.handleEditStop = (e) => {
       const { creativeId } = e.detail
+      console.log('[CreativeSync] Edit stop event, creativeId:', creativeId)
       if (creativeId && this.subscription) {
         this.subscription.sendStoppedEditing(creativeId)
       }
@@ -29,6 +31,9 @@ export default class extends Controller {
 
     if (this.rootIdValue > 0) {
       this.subscribe()
+    } else {
+      // Top-level /creatives page — try to infer root from tree rows
+      this.inferAndSubscribe()
     }
   }
 
@@ -52,9 +57,38 @@ export default class extends Controller {
     }
   }
 
-  subscribe() {
-    console.log('[CreativeSync] Subscribing to CreativesChannel, root_id:', this.rootIdValue)
-    this.subscription = subscribeToCreatives(this.rootIdValue, {
+  inferAndSubscribe() {
+    // Wait for tree to load, then find root from first row's parent-id
+    const tryInfer = () => {
+      const firstRow = this.element.querySelector('creative-tree-row[parent-id]')
+      if (firstRow) {
+        const parentId = parseInt(firstRow.getAttribute('parent-id'), 10)
+        if (parentId > 0) {
+          console.log('[CreativeSync] Inferred root_id from tree:', parentId)
+          this.subscribe(parentId)
+          return true
+        }
+      }
+      return false
+    }
+
+    if (!tryInfer()) {
+      // Tree may not be loaded yet, observe for changes
+      const observer = new MutationObserver(() => {
+        if (tryInfer()) observer.disconnect()
+      })
+      observer.observe(this.element, { childList: true, subtree: true })
+      // Cleanup after 10s
+      setTimeout(() => observer.disconnect(), 10000)
+    }
+  }
+
+  subscribe(overrideRootId) {
+    const rootId = overrideRootId || this.rootIdValue
+    if (rootId <= 0) return
+
+    console.log('[CreativeSync] Subscribing to CreativesChannel, root_id:', rootId)
+    this.subscription = subscribeToCreatives(rootId, {
       onConnected: () => console.log('[CreativeSync] CreativesChannel connected'),
       onDisconnected: () => console.log('[CreativeSync] CreativesChannel disconnected'),
       onEditing: (data) => this.handleEditing(data),
@@ -63,7 +97,7 @@ export default class extends Controller {
   }
 
   handleEditing(data) {
-    const { creative_id, user_id, user_name, avatar_url } = data
+    const { creative_id, user_id, user_name } = data
     if (user_id === this.currentUserIdValue) return
 
     console.log('[CreativeSync] Editing:', creative_id, 'by', user_name)
@@ -71,7 +105,7 @@ export default class extends Controller {
     if (!this.editingUsers[creative_id]) {
       this.editingUsers[creative_id] = {}
     }
-    this.editingUsers[creative_id][user_id] = { user_name, avatar_url }
+    this.editingUsers[creative_id][user_id] = { user_name }
     this.updateRowEditingUsers(creative_id)
   }
 
@@ -90,7 +124,10 @@ export default class extends Controller {
 
   updateRowEditingUsers(creativeId) {
     const row = document.querySelector(`creative-tree-row[creative-id="${creativeId}"]`)
-    if (!row) return
+    if (!row) {
+      console.log('[CreativeSync] Row not found for editing update:', creativeId)
+      return
+    }
 
     const editors = this.editingUsers[creativeId]
     if (!editors || Object.keys(editors).length === 0) {
@@ -99,8 +136,8 @@ export default class extends Controller {
       row.editingUsers = Object.entries(editors).map(([userId, info]) => ({
         user_id: parseInt(userId),
         user_name: info.user_name,
-        avatar_url: info.avatar_url
       }))
     }
+    console.log('[CreativeSync] Updated editingUsers for row', creativeId, ':', row.editingUsers)
   }
 }

--- a/engines/collavre/app/javascript/controllers/creatives/sync_controller.js
+++ b/engines/collavre/app/javascript/controllers/creatives/sync_controller.js
@@ -1,8 +1,6 @@
 import { Controller } from '@hotwired/stimulus'
 import { subscribeToCreatives } from '../../services/creatives_channel'
 
-const EDITING_INDICATOR_CLASS = 'creative-editing-indicator'
-
 export default class extends Controller {
   static values = {
     rootId: { type: Number, default: 0 },
@@ -11,8 +9,7 @@ export default class extends Controller {
 
   connect() {
     this.subscription = null
-    this.editingUsers = {} // { creativeId: { userId: userName, ... } }
-    this.presenceUsers = []
+    this.editingUsers = {} // { creativeId: { userId: { user_name, avatar_url } } }
 
     this.handleEditStart = (e) => {
       const { creativeId } = e.detail
@@ -39,7 +36,6 @@ export default class extends Controller {
     document.removeEventListener('creative-editing:start', this.handleEditStart)
     document.removeEventListener('creative-editing:stop', this.handleEditStop)
 
-    if (this.refetchTimer) clearTimeout(this.refetchTimer)
     if (this.subscription) {
       this.subscription.cleanup()
       this.subscription = null
@@ -57,190 +53,54 @@ export default class extends Controller {
   }
 
   subscribe() {
-    console.log('[CreativeSync] Subscribing to root_id:', this.rootIdValue)
+    console.log('[CreativeSync] Subscribing to CreativesChannel, root_id:', this.rootIdValue)
     this.subscription = subscribeToCreatives(this.rootIdValue, {
-      onConnected: () => console.log('[CreativeSync] Connected'),
-      onDisconnected: () => console.log('[CreativeSync] Disconnected'),
-      onCreated: (data) => {
-        console.log('[CreativeSync] Created:', data)
-        this.handleCreated(data)
-      },
-      onUpdated: (data) => {
-        console.log('[CreativeSync] Updated:', data)
-        this.handleUpdated(data)
-      },
-      onDestroyed: (data) => {
-        console.log('[CreativeSync] Destroyed:', data)
-        this.handleDestroyed(data)
-      },
-      onPresence: (data) => {
-        console.log('[CreativeSync] Presence:', data)
-        this.handlePresence(data)
-      },
+      onConnected: () => console.log('[CreativeSync] CreativesChannel connected'),
+      onDisconnected: () => console.log('[CreativeSync] CreativesChannel disconnected'),
       onEditing: (data) => this.handleEditing(data),
       onStoppedEditing: (data) => this.handleStoppedEditing(data),
     })
   }
 
-  // --- CRUD handlers ---
-
-  handleCreated(_data) {
-    this.debouncedRefetch()
-  }
-
-  handleUpdated(_data) {
-    this.debouncedRefetch()
-  }
-
-  handleDestroyed(_data) {
-    this.debouncedRefetch()
-  }
-
-  debouncedRefetch() {
-    if (this.refetchTimer) clearTimeout(this.refetchTimer)
-    this.refetchTimer = setTimeout(() => {
-      this.refetchTree()
-    }, 300)
-  }
-
-  // --- Presence handlers ---
-
-  handlePresence(data) {
-    this.presenceUsers = data.user_ids || []
-    this.renderPresence()
-  }
-
-  renderPresence() {
-    const container = document.getElementById('creative-presence-avatars')
-    if (!container) return
-
-    // Fetch user info for presence display
-    if (this.presenceUsers.length === 0) {
-      container.innerHTML = ''
-      return
-    }
-
-    // Fetch participants info from the comments endpoint (reuse existing)
-    const rootId = this.rootIdValue
-    fetch(`/creatives/${rootId}/comments/participants`)
-      .then((r) => r.json())
-      .then((data) => {
-        const users = data.users || []
-        container.innerHTML = ''
-
-        this.presenceUsers.forEach((userId) => {
-          // Skip current user
-          if (userId === this.currentUserIdValue) return
-
-          const user = users.find((u) => u.id === userId)
-          if (!user) return
-
-          const wrapper = document.createElement('span')
-          wrapper.className = 'avatar-wrapper creative-presence-user'
-          wrapper.title = user.name
-
-          const img = document.createElement('img')
-          img.src = user.avatar_url
-          img.alt = user.name
-          img.width = 20
-          img.height = 20
-          img.className = 'avatar'
-          img.style.borderRadius = '50%'
-          wrapper.appendChild(img)
-
-          if (user.default_avatar) {
-            const span = document.createElement('span')
-            span.className = 'avatar-initial'
-            span.textContent = user.initial
-            span.style.fontSize = '10px'
-            wrapper.appendChild(span)
-          }
-
-          container.appendChild(wrapper)
-        })
-      })
-      .catch(() => {
-        // Silently fail - presence is non-critical
-      })
-  }
-
-  // --- Editing conflict handlers ---
-
   handleEditing(data) {
-    const { creative_id, user_id, user_name } = data
-    // Don't show editing indicator for current user
+    const { creative_id, user_id, user_name, avatar_url } = data
     if (user_id === this.currentUserIdValue) return
+
+    console.log('[CreativeSync] Editing:', creative_id, 'by', user_name)
 
     if (!this.editingUsers[creative_id]) {
       this.editingUsers[creative_id] = {}
     }
-    this.editingUsers[creative_id][user_id] = user_name
-    this.renderEditingIndicator(creative_id)
+    this.editingUsers[creative_id][user_id] = { user_name, avatar_url }
+    this.updateRowEditingUsers(creative_id)
   }
 
   handleStoppedEditing(data) {
     const { creative_id, user_id } = data
+    console.log('[CreativeSync] Stopped editing:', creative_id, 'by user', user_id)
+
     if (this.editingUsers[creative_id]) {
       delete this.editingUsers[creative_id][user_id]
       if (Object.keys(this.editingUsers[creative_id]).length === 0) {
         delete this.editingUsers[creative_id]
       }
     }
-    this.renderEditingIndicator(creative_id)
+    this.updateRowEditingUsers(creative_id)
   }
 
-  renderEditingIndicator(creativeId) {
-    const row = this.findRow(creativeId)
+  updateRowEditingUsers(creativeId) {
+    const row = document.querySelector(`creative-tree-row[creative-id="${creativeId}"]`)
     if (!row) return
-
-    // Remove existing indicator
-    const existing = row.querySelector(`.${EDITING_INDICATOR_CLASS}`)
-    if (existing) existing.remove()
 
     const editors = this.editingUsers[creativeId]
     if (!editors || Object.keys(editors).length === 0) {
-      row.classList.remove('is-being-edited')
-      return
+      row.editingUsers = []
+    } else {
+      row.editingUsers = Object.entries(editors).map(([userId, info]) => ({
+        user_id: parseInt(userId),
+        user_name: info.user_name,
+        avatar_url: info.avatar_url
+      }))
     }
-
-    row.classList.add('is-being-edited')
-
-    const names = Object.values(editors)
-    const indicator = document.createElement('span')
-    indicator.className = EDITING_INDICATOR_CLASS
-    indicator.textContent = `✏️ ${names.join(', ')}`
-    indicator.title = names.join(', ')
-
-    // Insert after the description content
-    const content = row.shadowRoot?.querySelector('.creative-content') || row.querySelector('.creative-content')
-    if (content) {
-      content.appendChild(indicator)
-    }
-  }
-
-  // --- Send editing signals (called from row editor) ---
-
-  notifyEditing(creativeId) {
-    if (this.subscription) {
-      this.subscription.sendEditing(creativeId)
-    }
-  }
-
-  notifyStoppedEditing(creativeId) {
-    if (this.subscription) {
-      this.subscription.sendStoppedEditing(creativeId)
-    }
-  }
-
-  // --- Helpers ---
-
-  findRow(creativeId) {
-    return this.element.querySelector(`creative-tree-row[creative-id="${creativeId}"]`)
-  }
-
-  refetchTree() {
-    // Dispatch event so tree_controller can refetch
-    const event = new CustomEvent('creative-sync:refetch', { bubbles: true })
-    this.element.dispatchEvent(event)
   }
 }

--- a/engines/collavre/app/javascript/controllers/creatives/sync_controller.js
+++ b/engines/collavre/app/javascript/controllers/creatives/sync_controller.js
@@ -13,14 +13,12 @@ export default class extends Controller {
 
     this.handleEditStart = (e) => {
       const { creativeId } = e.detail
-      console.log('[CreativeSync] Edit start event, creativeId:', creativeId, 'subscription:', !!this.subscription)
       if (creativeId && this.subscription) {
         this.subscription.sendEditing(creativeId)
       }
     }
     this.handleEditStop = (e) => {
       const { creativeId } = e.detail
-      console.log('[CreativeSync] Edit stop event, creativeId:', creativeId)
       if (creativeId && this.subscription) {
         this.subscription.sendStoppedEditing(creativeId)
       }
@@ -64,7 +62,6 @@ export default class extends Controller {
       if (firstRow) {
         const parentId = parseInt(firstRow.getAttribute('parent-id'), 10)
         if (parentId > 0) {
-          console.log('[CreativeSync] Inferred root_id from tree:', parentId)
           this.subscribe(parentId)
           return true
         }
@@ -87,31 +84,25 @@ export default class extends Controller {
     const rootId = overrideRootId || this.rootIdValue
     if (rootId <= 0) return
 
-    console.log('[CreativeSync] Subscribing to CreativesChannel, root_id:', rootId)
     this.subscription = subscribeToCreatives(rootId, {
-      onConnected: () => console.log('[CreativeSync] CreativesChannel connected'),
-      onDisconnected: () => console.log('[CreativeSync] CreativesChannel disconnected'),
       onEditing: (data) => this.handleEditing(data),
       onStoppedEditing: (data) => this.handleStoppedEditing(data),
     })
   }
 
   handleEditing(data) {
-    const { creative_id, user_id, user_name } = data
+    const { creative_id, user_id, user_name, avatar_url } = data
     if (user_id === this.currentUserIdValue) return
-
-    console.log('[CreativeSync] Editing:', creative_id, 'by', user_name)
 
     if (!this.editingUsers[creative_id]) {
       this.editingUsers[creative_id] = {}
     }
-    this.editingUsers[creative_id][user_id] = { user_name }
+    this.editingUsers[creative_id][user_id] = { user_name, avatar_url }
     this.updateRowEditingUsers(creative_id)
   }
 
   handleStoppedEditing(data) {
     const { creative_id, user_id } = data
-    console.log('[CreativeSync] Stopped editing:', creative_id, 'by user', user_id)
 
     if (this.editingUsers[creative_id]) {
       delete this.editingUsers[creative_id][user_id]
@@ -124,10 +115,7 @@ export default class extends Controller {
 
   updateRowEditingUsers(creativeId) {
     const row = document.querySelector(`creative-tree-row[creative-id="${creativeId}"]`)
-    if (!row) {
-      console.log('[CreativeSync] Row not found for editing update:', creativeId)
-      return
-    }
+    if (!row) return // Creative not visible on this page — ignore
 
     const editors = this.editingUsers[creativeId]
     if (!editors || Object.keys(editors).length === 0) {
@@ -136,8 +124,8 @@ export default class extends Controller {
       row.editingUsers = Object.entries(editors).map(([userId, info]) => ({
         user_id: parseInt(userId),
         user_name: info.user_name,
+        avatar_url: info.avatar_url,
       }))
     }
-    console.log('[CreativeSync] Updated editingUsers for row', creativeId, ':', row.editingUsers)
   }
 }

--- a/engines/collavre/app/javascript/controllers/creatives/tree_controller.js
+++ b/engines/collavre/app/javascript/controllers/creatives/tree_controller.js
@@ -13,7 +13,8 @@ export default class extends Controller {
     this.loadingIndicator = null
     this.handleResize = this.updateAlignmentOffset.bind(this)
     this.handleTreeUpdated = () => this.queueAlignmentUpdate()
-    this.handleSyncRefetch = () => this.load()
+    this.handleSyncRefetch = () => this.debouncedLoad()
+    this.handleDocSyncRefetch = () => this.debouncedLoad()
     document.documentElement.classList.remove('creative-alignment-ready')
     if (!this.hasCachedContent()) {
       this.load()
@@ -22,6 +23,7 @@ export default class extends Controller {
     window.addEventListener('resize', this.handleResize)
     this.element.addEventListener('creative-tree:updated', this.handleTreeUpdated)
     this.element.addEventListener('creative-sync:refetch', this.handleSyncRefetch)
+    document.addEventListener('creative-sync:refetch', this.handleDocSyncRefetch)
     this._setupArchiveToggle()
   }
 
@@ -33,6 +35,8 @@ export default class extends Controller {
     window.removeEventListener('resize', this.handleResize)
     this.element.removeEventListener('creative-tree:updated', this.handleTreeUpdated)
     this.element.removeEventListener('creative-sync:refetch', this.handleSyncRefetch)
+    document.removeEventListener('creative-sync:refetch', this.handleDocSyncRefetch)
+    if (this._debouncedLoadTimer) clearTimeout(this._debouncedLoadTimer)
     if (this._archiveToggleHandler) {
       document.getElementById('toggle-archived-btn')?.removeEventListener('click', this._archiveToggleHandler)
       document.getElementById('toggle-archived-btn-mobile')?.removeEventListener('click', this._archiveToggleHandler)
@@ -83,6 +87,11 @@ export default class extends Controller {
     this._archiveToggleHandler = toggle
     if (btn) btn.addEventListener('click', toggle)
     if (mobileBtn) mobileBtn.addEventListener('click', toggle)
+  }
+
+  debouncedLoad() {
+    if (this._debouncedLoadTimer) clearTimeout(this._debouncedLoadTimer)
+    this._debouncedLoadTimer = setTimeout(() => this.load(), 300)
   }
 
   load() {

--- a/engines/collavre/app/javascript/controllers/creatives/tree_controller.js
+++ b/engines/collavre/app/javascript/controllers/creatives/tree_controller.js
@@ -19,6 +19,10 @@ export default class extends Controller {
       this._editing = false
       // Apply any pending sync data that was deferred while editing
       this._applyPendingSyncData()
+      if (this._pendingRefetch) {
+        this._pendingRefetch = false
+        this.debouncedLoad()
+      }
     }
     document.documentElement.classList.remove('creative-alignment-ready')
     if (!this.hasCachedContent()) {
@@ -29,6 +33,14 @@ export default class extends Controller {
     this.element.addEventListener('creative-tree:updated', this.handleTreeUpdated)
     document.addEventListener('creative-editing:start', this._handleEditStart)
     document.addEventListener('creative-editing:stop', this._handleEditStop)
+    this._handleSyncRefetch = () => {
+      if (this._editing) {
+        this._pendingRefetch = true
+        return
+      }
+      this.debouncedLoad()
+    }
+    document.addEventListener('creative-sync:refetch', this._handleSyncRefetch)
     this._setupArchiveToggle()
   }
 
@@ -41,6 +53,7 @@ export default class extends Controller {
     this.element.removeEventListener('creative-tree:updated', this.handleTreeUpdated)
     document.removeEventListener('creative-editing:start', this._handleEditStart)
     document.removeEventListener('creative-editing:stop', this._handleEditStop)
+    document.removeEventListener('creative-sync:refetch', this._handleSyncRefetch)
     if (this._debouncedLoadTimer) clearTimeout(this._debouncedLoadTimer)
     if (this._archiveToggleHandler) {
       document.getElementById('toggle-archived-btn')?.removeEventListener('click', this._archiveToggleHandler)

--- a/engines/collavre/app/javascript/controllers/creatives/tree_controller.js
+++ b/engines/collavre/app/javascript/controllers/creatives/tree_controller.js
@@ -105,42 +105,13 @@ export default class extends Controller {
 
   _handleSyncRefetch(event) {
     if (this._editing) {
-      // Don't do a full tree refetch while editing — it would close the editor.
-      // Instead, update just the changed row (if it's not the one being edited).
+      // While editing, skip full tree refetch (it would close the editor).
+      // Row-level updates are already applied by refresh_creative_tree action.
+      // Queue a full refetch for when editing ends (to update progress_html etc.)
       this._pendingRefetch = true
-      const detail = event?.detail
-      if (detail?.creativeId) {
-        const editingRow = document.querySelector('#inline-edit-form-element')
-        const editingId = editingRow?.dataset?.creativeId
-        if (String(detail.creativeId) !== String(editingId)) {
-          // Update the non-editing changed row via individual fetch
-          this._refreshSingleRow(detail.creativeId)
-        }
-      }
       return
     }
     this.debouncedLoad()
-  }
-
-  async _refreshSingleRow(creativeId) {
-    try {
-      const response = await fetch(`/creatives/${creativeId}.json`, {
-        headers: { Accept: 'application/json' }
-      })
-      if (!response.ok) return
-      const data = await response.json()
-      const row = document.querySelector(`creative-tree-row[creative-id="${creativeId}"]`)
-      if (!row) return
-      if (data.description) row.descriptionHtml = data.description
-      if (data.description_raw_html != null) row.dataset.descriptionRawHtml = data.description_raw_html
-      if (data.progress_html) {
-        row.progressHtml = data.progress_html
-        row.dataset.progressHtml = data.progress_html
-      }
-      if (data.progress != null) row.dataset.progressValue = String(data.progress)
-    } catch (e) {
-      console.warn('[TreeController] failed to refresh single row', creativeId, e)
-    }
   }
 
   debouncedLoad() {

--- a/engines/collavre/app/javascript/controllers/creatives/tree_controller.js
+++ b/engines/collavre/app/javascript/controllers/creatives/tree_controller.js
@@ -13,6 +13,7 @@ export default class extends Controller {
     this.loadingIndicator = null
     this.handleResize = this.updateAlignmentOffset.bind(this)
     this.handleTreeUpdated = () => this.queueAlignmentUpdate()
+    this.handleSyncRefetch = () => this.load()
     document.documentElement.classList.remove('creative-alignment-ready')
     if (!this.hasCachedContent()) {
       this.load()
@@ -20,6 +21,7 @@ export default class extends Controller {
     this.queueAlignmentUpdate()
     window.addEventListener('resize', this.handleResize)
     this.element.addEventListener('creative-tree:updated', this.handleTreeUpdated)
+    this.element.addEventListener('creative-sync:refetch', this.handleSyncRefetch)
     this._setupArchiveToggle()
   }
 
@@ -30,6 +32,7 @@ export default class extends Controller {
     }
     window.removeEventListener('resize', this.handleResize)
     this.element.removeEventListener('creative-tree:updated', this.handleTreeUpdated)
+    this.element.removeEventListener('creative-sync:refetch', this.handleSyncRefetch)
     if (this._archiveToggleHandler) {
       document.getElementById('toggle-archived-btn')?.removeEventListener('click', this._archiveToggleHandler)
       document.getElementById('toggle-archived-btn-mobile')?.removeEventListener('click', this._archiveToggleHandler)

--- a/engines/collavre/app/javascript/controllers/creatives/tree_controller.js
+++ b/engines/collavre/app/javascript/controllers/creatives/tree_controller.js
@@ -11,10 +11,20 @@ export default class extends Controller {
   connect() {
     this.abortController = null
     this.loadingIndicator = null
+    this._editing = false
+    this._pendingRefetch = false
     this.handleResize = this.updateAlignmentOffset.bind(this)
     this.handleTreeUpdated = () => this.queueAlignmentUpdate()
-    this.handleSyncRefetch = () => this.debouncedLoad()
-    this.handleDocSyncRefetch = () => this.debouncedLoad()
+    this.handleSyncRefetch = (e) => this._handleSyncRefetch(e)
+    this.handleDocSyncRefetch = (e) => this._handleSyncRefetch(e)
+    this._handleEditStart = () => { this._editing = true }
+    this._handleEditStop = () => {
+      this._editing = false
+      if (this._pendingRefetch) {
+        this._pendingRefetch = false
+        this.debouncedLoad()
+      }
+    }
     document.documentElement.classList.remove('creative-alignment-ready')
     if (!this.hasCachedContent()) {
       this.load()
@@ -24,6 +34,8 @@ export default class extends Controller {
     this.element.addEventListener('creative-tree:updated', this.handleTreeUpdated)
     this.element.addEventListener('creative-sync:refetch', this.handleSyncRefetch)
     document.addEventListener('creative-sync:refetch', this.handleDocSyncRefetch)
+    document.addEventListener('creative-editing:start', this._handleEditStart)
+    document.addEventListener('creative-editing:stop', this._handleEditStop)
     this._setupArchiveToggle()
   }
 
@@ -36,6 +48,8 @@ export default class extends Controller {
     this.element.removeEventListener('creative-tree:updated', this.handleTreeUpdated)
     this.element.removeEventListener('creative-sync:refetch', this.handleSyncRefetch)
     document.removeEventListener('creative-sync:refetch', this.handleDocSyncRefetch)
+    document.removeEventListener('creative-editing:start', this._handleEditStart)
+    document.removeEventListener('creative-editing:stop', this._handleEditStop)
     if (this._debouncedLoadTimer) clearTimeout(this._debouncedLoadTimer)
     if (this._archiveToggleHandler) {
       document.getElementById('toggle-archived-btn')?.removeEventListener('click', this._archiveToggleHandler)
@@ -87,6 +101,46 @@ export default class extends Controller {
     this._archiveToggleHandler = toggle
     if (btn) btn.addEventListener('click', toggle)
     if (mobileBtn) mobileBtn.addEventListener('click', toggle)
+  }
+
+  _handleSyncRefetch(event) {
+    if (this._editing) {
+      // Don't do a full tree refetch while editing — it would close the editor.
+      // Instead, update just the changed row (if it's not the one being edited).
+      this._pendingRefetch = true
+      const detail = event?.detail
+      if (detail?.creativeId) {
+        const editingRow = document.querySelector('#inline-edit-form-element')
+        const editingId = editingRow?.dataset?.creativeId
+        if (String(detail.creativeId) !== String(editingId)) {
+          // Update the non-editing changed row via individual fetch
+          this._refreshSingleRow(detail.creativeId)
+        }
+      }
+      return
+    }
+    this.debouncedLoad()
+  }
+
+  async _refreshSingleRow(creativeId) {
+    try {
+      const response = await fetch(`/creatives/${creativeId}.json`, {
+        headers: { Accept: 'application/json' }
+      })
+      if (!response.ok) return
+      const data = await response.json()
+      const row = document.querySelector(`creative-tree-row[creative-id="${creativeId}"]`)
+      if (!row) return
+      if (data.description) row.descriptionHtml = data.description
+      if (data.description_raw_html != null) row.dataset.descriptionRawHtml = data.description_raw_html
+      if (data.progress_html) {
+        row.progressHtml = data.progress_html
+        row.dataset.progressHtml = data.progress_html
+      }
+      if (data.progress != null) row.dataset.progressValue = String(data.progress)
+    } catch (e) {
+      console.warn('[TreeController] failed to refresh single row', creativeId, e)
+    }
   }
 
   debouncedLoad() {

--- a/engines/collavre/app/javascript/controllers/creatives/tree_controller.js
+++ b/engines/collavre/app/javascript/controllers/creatives/tree_controller.js
@@ -12,18 +12,13 @@ export default class extends Controller {
     this.abortController = null
     this.loadingIndicator = null
     this._editing = false
-    this._pendingRefetch = false
     this.handleResize = this.updateAlignmentOffset.bind(this)
     this.handleTreeUpdated = () => this.queueAlignmentUpdate()
-    this.handleSyncRefetch = (e) => this._handleSyncRefetch(e)
-    this.handleDocSyncRefetch = (e) => this._handleSyncRefetch(e)
     this._handleEditStart = () => { this._editing = true }
     this._handleEditStop = () => {
       this._editing = false
-      if (this._pendingRefetch) {
-        this._pendingRefetch = false
-        this.debouncedLoad()
-      }
+      // Apply any pending sync data that was deferred while editing
+      this._applyPendingSyncData()
     }
     document.documentElement.classList.remove('creative-alignment-ready')
     if (!this.hasCachedContent()) {
@@ -32,8 +27,6 @@ export default class extends Controller {
     this.queueAlignmentUpdate()
     window.addEventListener('resize', this.handleResize)
     this.element.addEventListener('creative-tree:updated', this.handleTreeUpdated)
-    this.element.addEventListener('creative-sync:refetch', this.handleSyncRefetch)
-    document.addEventListener('creative-sync:refetch', this.handleDocSyncRefetch)
     document.addEventListener('creative-editing:start', this._handleEditStart)
     document.addEventListener('creative-editing:stop', this._handleEditStop)
     this._setupArchiveToggle()
@@ -46,8 +39,6 @@ export default class extends Controller {
     }
     window.removeEventListener('resize', this.handleResize)
     this.element.removeEventListener('creative-tree:updated', this.handleTreeUpdated)
-    this.element.removeEventListener('creative-sync:refetch', this.handleSyncRefetch)
-    document.removeEventListener('creative-sync:refetch', this.handleDocSyncRefetch)
     document.removeEventListener('creative-editing:start', this._handleEditStart)
     document.removeEventListener('creative-editing:stop', this._handleEditStop)
     if (this._debouncedLoadTimer) clearTimeout(this._debouncedLoadTimer)
@@ -103,15 +94,23 @@ export default class extends Controller {
     if (mobileBtn) mobileBtn.addEventListener('click', toggle)
   }
 
-  _handleSyncRefetch(event) {
-    if (this._editing) {
-      // While editing, skip full tree refetch (it would close the editor).
-      // Row-level updates are already applied by refresh_creative_tree action.
-      // Queue a full refetch for when editing ends (to update progress_html etc.)
-      this._pendingRefetch = true
-      return
-    }
-    this.debouncedLoad()
+  _applyPendingSyncData() {
+    // After editor closes, apply any sync data that was deferred
+    const pendingRows = this.element.querySelectorAll('creative-tree-row[data-pending-sync-data]')
+    if (pendingRows.length === 0) return
+
+    // Dynamic import to avoid circular dependency
+    import('../../creatives/tree_renderer').then(({ applyRowProperties }) => {
+      pendingRows.forEach(row => {
+        try {
+          const data = JSON.parse(row.dataset.pendingSyncData)
+          applyRowProperties(row, data)
+        } catch (e) {
+          console.warn('[TreeController] Failed to apply pending sync data', e)
+        }
+        delete row.dataset.pendingSyncData
+      })
+    })
   }
 
   debouncedLoad() {

--- a/engines/collavre/app/javascript/controllers/index.js
+++ b/engines/collavre/app/javascript/controllers/index.js
@@ -28,6 +28,7 @@ import ShareInviteController from "./share_invite_controller"
 import ShareUserSearchController from "./share_user_search_controller"
 import CommentVersionController from "./comment_version_controller"
 import OrgChartController from "./org_chart_controller"
+import CommentBadgeController from "./comment_badge_controller"
 import ShareModalController from "./share_modal_controller"
 import ImageLightboxController from "./image_lightbox_controller"
 import SearchPopupController from "./search_popup_controller"
@@ -63,7 +64,8 @@ export {
   OrgChartController,
   ShareModalController,
   ImageLightboxController,
-  SearchPopupController
+  SearchPopupController,
+  CommentBadgeController
 }
 
 // Registration function for use with a Stimulus application
@@ -99,4 +101,5 @@ export function registerControllers(application) {
   application.register("share-modal", ShareModalController)
   application.register("image-lightbox", ImageLightboxController)
   application.register("search-popup", SearchPopupController)
+  application.register("comment-badge", CommentBadgeController)
 }

--- a/engines/collavre/app/javascript/controllers/index.js
+++ b/engines/collavre/app/javascript/controllers/index.js
@@ -8,6 +8,7 @@ import CreativesDragDropController from "./creatives/drag_drop_controller"
 import CreativesExpansionController from "./creatives/expansion_controller"
 import CreativesRowEditorController from "./creatives/row_editor_controller"
 import CreativesTreeController from "./creatives/tree_controller"
+import CreativesSyncController from "./creatives/sync_controller"
 import CreativesSetPlanModalController from "./creatives/set_plan_modal_controller"
 import CommentsListController from "./comments/list_controller"
 import CommentsFormController from "./comments/form_controller"
@@ -41,6 +42,7 @@ export {
   CreativesExpansionController,
   CreativesRowEditorController,
   CreativesTreeController,
+  CreativesSyncController,
   CreativesSetPlanModalController,
   CommentsListController,
   CommentsFormController,
@@ -74,6 +76,7 @@ export function registerControllers(application) {
   application.register("creatives--expansion", CreativesExpansionController)
   application.register("creatives--row-editor", CreativesRowEditorController)
   application.register("creatives--tree", CreativesTreeController)
+  application.register("creatives--sync", CreativesSyncController)
   application.register("creatives--set-plan-modal", CreativesSetPlanModalController)
   application.register("comments--list", CommentsListController)
   application.register("comments--form", CommentsFormController)

--- a/engines/collavre/app/javascript/creatives/tree_renderer.js
+++ b/engines/collavre/app/javascript/creatives/tree_renderer.js
@@ -44,6 +44,9 @@ function applyRowProperties(row, node) {
     }
     row.setAttribute('level', node.level)
   }
+  if (node.sequence != null) {
+    row.setAttribute('sequence', node.sequence)
+  }
 
   const updateBooleanAttr = (prop, attr, value) => {
     if (value == null) return

--- a/engines/collavre/app/javascript/creatives/tree_renderer.js
+++ b/engines/collavre/app/javascript/creatives/tree_renderer.js
@@ -117,11 +117,13 @@ function applyRowProperties(row, node) {
   }
 }
 
-function createRow(node) {
+export function createRow(node) {
   const row = document.createElement('creative-tree-row')
   applyRowProperties(row, node)
   return row
 }
+
+export { applyRowProperties }
 
 function applyChildrenContainerProperties(container, node) {
   if (!container || !node) return

--- a/engines/collavre/app/javascript/creatives/tree_renderer.js
+++ b/engines/collavre/app/javascript/creatives/tree_renderer.js
@@ -111,6 +111,8 @@ function applyRowProperties(row, node) {
   if (Object.prototype.hasOwnProperty.call(inlinePayload, 'progress')) {
     const rawProgress = inlinePayload.progress ?? 0
     const pct = Math.round(rawProgress * 100)
+    // progress_text from server: completion mark string, empty string (=complete but no mark), or undefined
+    const displayText = node.progress_text != null ? (node.progress_text || '\u00a0\u00a0') : `${pct}%`
     setDatasetValue(row, 'progressValue', rawProgress)
     // Update progress percentage in existing progressHtml without replacing full HTML
     // (preserves chat badges, comment counts, etc.)
@@ -121,17 +123,17 @@ function applyRowProperties(row, node) {
         // Try regex replacement first (preserves chat buttons etc.)
         const replaced = updated.replace(
           /(<span[^>]*class="creative-progress-(?:in)?complete"[^>]*>)[^<]*(<\/span>)/,
-          `$1${pct}%$2`
+          `$1${displayText}$2`
         )
         if (replaced !== updated) {
-          updated = replaced
-        } else {
-          // Regex didn't match — create fresh progress HTML
-          updated = `<span class="${cssClass}">${pct}%</span>`
+          // Also update ONLY the first progress class (not chat buttons etc.)
+          updated = replaced.replace(
+            /class="creative-progress-(?:in)?complete"/,
+            `class="${cssClass}"`
+          )
         }
-      } else {
-        // progressHtml was empty — create fresh
-        updated = `<span class="${cssClass}">${pct}%</span>`
+        // If regex didn't match, do NOT create fresh HTML — preserve existing progressHtml
+        // (it contains chat buttons, comment badges, etc.)
       }
       if (updated !== (row.progressHtml || '')) {
         row.progressHtml = updated

--- a/engines/collavre/app/javascript/creatives/tree_renderer.js
+++ b/engines/collavre/app/javascript/creatives/tree_renderer.js
@@ -109,7 +109,15 @@ function applyRowProperties(row, node) {
     setDatasetValue(row, 'descriptionRawHtml', inlinePayload.description_raw_html ?? '')
   }
   if (Object.prototype.hasOwnProperty.call(inlinePayload, 'progress')) {
-    setDatasetValue(row, 'progressValue', inlinePayload.progress ?? '')
+    const pct = Math.round(inlinePayload.progress ?? 0)
+    setDatasetValue(row, 'progressValue', pct)
+    // Update displayed progress text without replacing full progress HTML (preserves chat badges)
+    if (templates.progress_html == null) {
+      const progressSpan = row.shadowRoot
+        ? row.shadowRoot.querySelector('.creative-progress')
+        : row.querySelector('.creative-progress')
+      if (progressSpan) progressSpan.textContent = `${pct}%`
+    }
   }
   if (Object.prototype.hasOwnProperty.call(inlinePayload, 'origin_id')) {
     setDatasetValue(row, 'originId', inlinePayload.origin_id ?? '')

--- a/engines/collavre/app/javascript/creatives/tree_renderer.js
+++ b/engines/collavre/app/javascript/creatives/tree_renderer.js
@@ -111,12 +111,17 @@ function applyRowProperties(row, node) {
   if (Object.prototype.hasOwnProperty.call(inlinePayload, 'progress')) {
     const pct = Math.round(inlinePayload.progress ?? 0)
     setDatasetValue(row, 'progressValue', pct)
-    // Update displayed progress text without replacing full progress HTML (preserves chat badges)
-    if (templates.progress_html == null) {
-      const progressSpan = row.shadowRoot
-        ? row.shadowRoot.querySelector('.creative-progress')
-        : row.querySelector('.creative-progress')
-      if (progressSpan) progressSpan.textContent = `${pct}%`
+    // Update progress percentage in existing progressHtml without replacing full HTML
+    // (preserves chat badges, comment counts, etc.)
+    if (templates.progress_html == null && row.progressHtml) {
+      const updated = row.progressHtml.replace(
+        /(<span[^>]*class="creative-progress[^"]*"[^>]*>)\s*\d+%\s*(<\/span>)/,
+        `$1${pct}%$2`
+      )
+      if (updated !== row.progressHtml) {
+        row.progressHtml = updated
+        setDatasetValue(row, 'progressHtml', updated)
+      }
     }
   }
   if (Object.prototype.hasOwnProperty.call(inlinePayload, 'origin_id')) {

--- a/engines/collavre/app/javascript/creatives/tree_renderer.js
+++ b/engines/collavre/app/javascript/creatives/tree_renderer.js
@@ -114,13 +114,26 @@ function applyRowProperties(row, node) {
     setDatasetValue(row, 'progressValue', rawProgress)
     // Update progress percentage in existing progressHtml without replacing full HTML
     // (preserves chat badges, comment counts, etc.)
-    if (templates.progress_html == null && row.progressHtml) {
-      // Match the progress value span (handles both "50%" and custom completion marks)
-      const updated = row.progressHtml.replace(
-        /(<span[^>]*class="creative-progress-(?:in)?complete"[^>]*>)[^<]*(<\/span>)/,
-        `$1${pct}%$2`
-      )
-      if (updated !== row.progressHtml) {
+    if (templates.progress_html == null) {
+      const cssClass = pct >= 100 ? 'creative-progress-complete' : 'creative-progress-incomplete'
+      let updated = row.progressHtml || ''
+      if (updated) {
+        // Try regex replacement first (preserves chat buttons etc.)
+        const replaced = updated.replace(
+          /(<span[^>]*class="creative-progress-(?:in)?complete"[^>]*>)[^<]*(<\/span>)/,
+          `$1${pct}%$2`
+        )
+        if (replaced !== updated) {
+          updated = replaced
+        } else {
+          // Regex didn't match — create fresh progress HTML
+          updated = `<span class="${cssClass}">${pct}%</span>`
+        }
+      } else {
+        // progressHtml was empty — create fresh
+        updated = `<span class="${cssClass}">${pct}%</span>`
+      }
+      if (updated !== (row.progressHtml || '')) {
         row.progressHtml = updated
         setDatasetValue(row, 'progressHtml', updated)
         dirty = true

--- a/engines/collavre/app/javascript/creatives/tree_renderer.js
+++ b/engines/collavre/app/javascript/creatives/tree_renderer.js
@@ -11,6 +11,23 @@ function setDatasetValue(element, key, value) {
   }
 }
 
+// Capture current DOM state of the progress area back into Lit's progressHtml
+// so that Turbo Streams DOM mutations (e.g. badge count updates) survive Lit re-renders.
+// Lit renders progressHtml via unsafeHTML() inside a .creative-progress-area wrapper.
+// Turbo may directly replace child elements (e.g. comment-badge span) in the DOM,
+// but Lit's progressHtml string remains stale. On next re-render, Lit would overwrite
+// the Turbo-updated DOM with the stale string, losing badge updates.
+function syncProgressHtmlFromDom(row) {
+  if (!row.progressHtml) return
+  const wrapper = row.querySelector('.creative-progress-area')
+  if (!wrapper) return
+  const currentHtml = wrapper.innerHTML
+  if (currentHtml && currentHtml !== row.progressHtml) {
+    row.progressHtml = currentHtml
+    row.dataset.progressHtml = currentHtml
+  }
+}
+
 function applyRowProperties(row, node) {
   if (!row || !node) return
   let dirty = false
@@ -147,6 +164,12 @@ function applyRowProperties(row, node) {
   }
 
   if (dirty && typeof row.requestUpdate === 'function') {
+    // Before Lit re-renders, sync progressHtml from current DOM.
+    // Turbo Streams may have replaced badge elements directly in the DOM
+    // (e.g. comment badge count), but the Lit progressHtml string still
+    // holds the stale initial HTML. On re-render, Lit would overwrite
+    // the Turbo-updated DOM with the stale string, losing badges.
+    syncProgressHtmlFromDom(row)
     row.requestUpdate()
   }
 }

--- a/engines/collavre/app/javascript/creatives/tree_renderer.js
+++ b/engines/collavre/app/javascript/creatives/tree_renderer.js
@@ -109,18 +109,21 @@ function applyRowProperties(row, node) {
     setDatasetValue(row, 'descriptionRawHtml', inlinePayload.description_raw_html ?? '')
   }
   if (Object.prototype.hasOwnProperty.call(inlinePayload, 'progress')) {
-    const pct = Math.round(inlinePayload.progress ?? 0)
-    setDatasetValue(row, 'progressValue', pct)
+    const rawProgress = inlinePayload.progress ?? 0
+    const pct = Math.round(rawProgress * 100)
+    setDatasetValue(row, 'progressValue', rawProgress)
     // Update progress percentage in existing progressHtml without replacing full HTML
     // (preserves chat badges, comment counts, etc.)
     if (templates.progress_html == null && row.progressHtml) {
+      // Match the progress value span (handles both "50%" and custom completion marks)
       const updated = row.progressHtml.replace(
-        /(<span[^>]*class="creative-progress[^"]*"[^>]*>)\s*\d+%\s*(<\/span>)/,
+        /(<span[^>]*class="creative-progress-(?:in)?complete"[^>]*>)[^<]*(<\/span>)/,
         `$1${pct}%$2`
       )
       if (updated !== row.progressHtml) {
         row.progressHtml = updated
         setDatasetValue(row, 'progressHtml', updated)
+        dirty = true
       }
     }
   }

--- a/engines/collavre/app/javascript/lib/turbo_stream_actions.js
+++ b/engines/collavre/app/javascript/lib/turbo_stream_actions.js
@@ -30,7 +30,6 @@ registerStreamAction("refresh_creative_tree", function () {
 
     // Use linked_id if present (shared creative: receiver sees linked copy, not origin)
     const effectiveId = creative.linked_id || creative.id
-        creative.linked_id ? `(linked: ${creative.linked_id})` : '')
 
     // Override id with effectiveId for DOM lookups
     const effectiveCreative = { ...creative, id: effectiveId, origin_id: creative.id }
@@ -78,11 +77,9 @@ function handleCreated(creative) {
 
         const newRow = createRow(creative)
         insertAtCorrectPosition(newRow, creative, targetContainer)
-    } else {
-        // Fallback: trigger tree reload — the creative is relevant to this page
-        // (we received the broadcast) but we can't determine exact insertion point
-        document.dispatchEvent(new CustomEvent('creative-sync:refetch'))
     }
+    // If no targetContainer found, the creative is relevant but we can't determine
+    // the exact insertion point — it will appear on next page load.
 }
 
 function insertAtCorrectPosition(newRow, creative, container) {
@@ -91,10 +88,6 @@ function insertAtCorrectPosition(newRow, creative, container) {
     const sequence = creative.sequence
 
     const siblingRows = Array.from(container.querySelectorAll(':scope > creative-tree-row'))
-        id: creative.id, afterId, prevSiblingId, sequence,
-        siblingCount: siblingRows.length,
-        siblingIds: siblingRows.map(r => r.getAttribute('creative-id'))
-    })
 
     // Helper: insert after a row (accounting for its children container)
     function insertAfterRow(targetId, label) {

--- a/engines/collavre/app/javascript/lib/turbo_stream_actions.js
+++ b/engines/collavre/app/javascript/lib/turbo_stream_actions.js
@@ -226,9 +226,14 @@ function findRowsForCreative(creativeId) {
         if (urlId && String(urlId) === String(creativeId)) {
             return [titleRow]
         }
-        // 2c removed: parent-id reverse lookup was incorrectly matching origin
-        // creative to title row on shared/linked creative pages.
-        // Title row progress is handled separately in updateAncestorProgress.
+        // 2c. Top-level page: if any tree row has parent-id matching creativeId,
+        //     then creativeId is the root of this tree = title row
+        if (!titleCreativeId) {
+            const childOfTarget = document.querySelector(`creative-tree-row[parent-id="${creativeId}"]`)
+            if (childOfTarget) {
+                return [titleRow]
+            }
+        }
     }
     return rows
 }

--- a/engines/collavre/app/javascript/lib/turbo_stream_actions.js
+++ b/engines/collavre/app/javascript/lib/turbo_stream_actions.js
@@ -266,7 +266,13 @@ function updateAncestorProgress(ancestors) {
     ancestors.forEach(anc => {
         const ancRow = document.querySelector(`creative-tree-row[creative-id="${anc.id}"]`)
         if (ancRow && anc.progress != null) {
-            ancRow.dataset.progressValue = String(Math.round(anc.progress))
+            const pct = Math.round(anc.progress)
+            ancRow.dataset.progressValue = String(pct)
+            // Update displayed text only (preserve chat badges etc.)
+            const progressSpan = ancRow.shadowRoot
+                ? ancRow.shadowRoot.querySelector('.creative-progress')
+                : ancRow.querySelector('.creative-progress')
+            if (progressSpan) progressSpan.textContent = `${pct}%`
         }
     })
 }

--- a/engines/collavre/app/javascript/lib/turbo_stream_actions.js
+++ b/engines/collavre/app/javascript/lib/turbo_stream_actions.js
@@ -15,10 +15,14 @@ registerStreamAction("refresh_creative_tree", function () {
     const action = this.getAttribute("change-action")
     console.log("[Turbo] refresh_creative_tree", { creativeId, action })
 
-    // Update title row if the changed creative matches the title
-    const titleRow = document.querySelector('creative-tree-row[is-title]')
-    if (titleRow && creativeId && String(titleRow.getAttribute('creative-id')) === String(creativeId)) {
-        refreshTitleRow(titleRow, creativeId)
+    // Update title row if the changed creative matches it.
+    // Non-title rows are handled by tree refetch (debouncedLoad) which
+    // includes inline_editor_payload with fresh description_raw_html.
+    if (creativeId) {
+        const titleRow = document.querySelector('creative-tree-row[is-title]')
+        if (titleRow && String(titleRow.getAttribute('creative-id')) === String(creativeId)) {
+            refreshCreativeRow(titleRow, creativeId)
+        }
     }
 
     // Dispatch event for any listening tree controller to refetch children
@@ -28,25 +32,32 @@ registerStreamAction("refresh_creative_tree", function () {
     }))
 })
 
-async function refreshTitleRow(titleRow, creativeId) {
+async function refreshCreativeRow(row, creativeId) {
     try {
         const response = await fetch(`/creatives/${creativeId}.json`, {
             headers: { Accept: 'application/json' }
         })
         if (!response.ok) return
         const data = await response.json()
-        // show.json returns 'description' (HTML), not 'description_html'
+        // Update visible description (show.json returns 'description' as HTML)
         if (data.description) {
-            titleRow.descriptionHtml = data.description
+            row.descriptionHtml = data.description
+        }
+        // Update raw HTML cache so inline editor loads fresh data
+        if (data.description_raw_html != null) {
+            row.dataset.descriptionRawHtml = data.description_raw_html
         }
         if (data.progress_html) {
-            titleRow.progressHtml = data.progress_html
-            titleRow.dataset.progressHtml = data.progress_html
+            row.progressHtml = data.progress_html
+            row.dataset.progressHtml = data.progress_html
         }
         if (data.progress != null) {
-            titleRow.dataset.progressValue = String(data.progress)
+            row.dataset.progressValue = String(data.progress)
         }
-        console.log("[Turbo] refreshed title row", creativeId)
+        if (data.origin_id != null) {
+            row.dataset.originId = String(data.origin_id)
+        }
+        console.log("[Turbo] refreshed creative row", creativeId)
     } catch (e) {
         console.warn("[Turbo] failed to refresh title row", e)
     }

--- a/engines/collavre/app/javascript/lib/turbo_stream_actions.js
+++ b/engines/collavre/app/javascript/lib/turbo_stream_actions.js
@@ -208,28 +208,37 @@ function findTargetContainer(parentId, treeContainer) {
     return null
 }
 
-function findRowsForCreative(creativeId) {
+function findRowsForCreative(creativeId, originId) {
     // 1. Normal tree rows by attribute
     const rows = Array.from(document.querySelectorAll(`creative-tree-row[creative-id="${creativeId}"]`))
     if (rows.length > 0) return rows
+
+    // 1b. Try origin_id if different (linked creative: DOM may have origin ID)
+    if (originId && String(originId) !== String(creativeId)) {
+        const originRows = Array.from(document.querySelectorAll(`creative-tree-row[creative-id="${originId}"]`))
+        if (originRows.length > 0) return originRows
+    }
 
     // 2. Title row checks
     const titleRow = document.querySelector('creative-tree-row[is-title]')
     if (titleRow) {
         // 2a. Title row has creative-id attribute (e.g. /creatives?id=X page)
         const titleCreativeId = titleRow.getAttribute('creative-id')
-        if (titleCreativeId && String(titleCreativeId) === String(creativeId)) {
+        if (titleCreativeId && (String(titleCreativeId) === String(creativeId) ||
+            (originId && String(titleCreativeId) === String(originId)))) {
             return [titleRow]
         }
         // 2b. URL param check
         const urlId = new URLSearchParams(window.location.search).get('id')
-        if (urlId && String(urlId) === String(creativeId)) {
+        if (urlId && (String(urlId) === String(creativeId) ||
+            (originId && String(urlId) === String(originId)))) {
             return [titleRow]
         }
-        // 2c. Top-level page: if any tree row has parent-id matching creativeId,
+        // 2c. Top-level page: if any tree row has parent-id matching creativeId or originId,
         //     then creativeId is the root of this tree = title row
         if (!titleCreativeId) {
-            const childOfTarget = document.querySelector(`creative-tree-row[parent-id="${creativeId}"]`)
+            const childOfTarget = document.querySelector(`creative-tree-row[parent-id="${creativeId}"]`) ||
+                (originId ? document.querySelector(`creative-tree-row[parent-id="${originId}"]`) : null)
             if (childOfTarget) {
                 return [titleRow]
             }
@@ -239,8 +248,8 @@ function findRowsForCreative(creativeId) {
 }
 
 function handleUpdated(creative) {
-    const rows = findRowsForCreative(creative.id)
-    console.log("[CreativeSync] handleUpdated creative", creative.id, "found rows:", rows.length)
+    const rows = findRowsForCreative(creative.id, creative.origin_id)
+    console.log("[CreativeSync] handleUpdated creative", creative.id, "origin:", creative.origin_id, "found rows:", rows.length)
     if (rows.length === 0) return
 
     // Find currently editing creative ID to skip it
@@ -261,7 +270,7 @@ function handleUpdated(creative) {
 }
 
 function handleDestroyed(creative) {
-    const rows = findRowsForCreative(creative.id)
+    const rows = findRowsForCreative(creative.id, creative.origin_id)
 
     if (rows.length === 0) {
         // Row not found — might be on a page where it's displayed differently
@@ -320,29 +329,11 @@ function updateProgressForRow(row, progress) {
     row.dataset.progressHtml = newHtml
 }
 
-function findTitleRowForAncestor(ancestorId) {
-    // On top-level /creatives page, title row has no creative-id.
-    // If tree rows have parent-id matching ancestorId, then the title row
-    // represents this ancestor (for progress display only).
-    const titleRow = document.querySelector('creative-tree-row[is-title]')
-    if (!titleRow) return null
-    const titleCreativeId = titleRow.getAttribute('creative-id')
-    // If title row already has a creative-id, findRowsForCreative handles it
-    if (titleCreativeId) return null
-    // Check if any direct child has parent-id matching the ancestor
-    const child = document.querySelector(`creative-tree-row[parent-id="${ancestorId}"]`)
-    return child ? titleRow : null
-}
-
 function updateAncestorProgress(ancestors) {
     if (!Array.isArray(ancestors)) return
     ancestors.forEach(anc => {
-        let rows = findRowsForCreative(anc.id)
-        // Also check if title row represents this ancestor (top-level page)
-        if (rows.length === 0) {
-            const titleRow = findTitleRowForAncestor(anc.id)
-            if (titleRow) rows = [titleRow]
-        }
+        // findRowsForCreative already handles origin_id fallback for linked creatives
+        const rows = findRowsForCreative(anc.id, anc.origin_id)
         if (rows[0]) updateProgressForRow(rows[0], anc.progress)
     })
 }

--- a/engines/collavre/app/javascript/lib/turbo_stream_actions.js
+++ b/engines/collavre/app/javascript/lib/turbo_stream_actions.js
@@ -1,7 +1,16 @@
 import { Turbo } from "@hotwired/turbo-rails"
 
+// Register custom actions on both the imported Turbo and the global window.Turbo
+// to handle cases where the bundled Turbo instance differs from the runtime one.
+function registerStreamAction(name, handler) {
+    Turbo.StreamActions[name] = handler
+    if (window.Turbo && window.Turbo.StreamActions && window.Turbo.StreamActions !== Turbo.StreamActions) {
+        window.Turbo.StreamActions[name] = handler
+    }
+}
+
 // Creative tree refresh: triggered when a shared creative is created/updated/destroyed
-Turbo.StreamActions.refresh_creative_tree = function () {
+registerStreamAction("refresh_creative_tree", function () {
     const creativeId = this.getAttribute("creative-id")
     const action = this.getAttribute("change-action")
     console.log("[Turbo] refresh_creative_tree", { creativeId, action })
@@ -11,9 +20,9 @@ Turbo.StreamActions.refresh_creative_tree = function () {
         detail: { creativeId: creativeId ? parseInt(creativeId, 10) : null, action },
         bubbles: true
     }))
-}
+})
 
-Turbo.StreamActions.update_reactions = function () {
+registerStreamAction("update_reactions", function () {
     const targetId = this.getAttribute("target")
     const dataJSON = this.getAttribute("data")
 
@@ -43,4 +52,4 @@ Turbo.StreamActions.update_reactions = function () {
     } catch (e) {
         console.error("Failed to process update_reactions stream action", e)
     }
-}
+})

--- a/engines/collavre/app/javascript/lib/turbo_stream_actions.js
+++ b/engines/collavre/app/javascript/lib/turbo_stream_actions.js
@@ -264,7 +264,14 @@ function handleDestroyed(creative) {
 function updateAncestorProgress(ancestors) {
     if (!Array.isArray(ancestors)) return
     ancestors.forEach(anc => {
-        const ancRow = document.querySelector(`creative-tree-row[creative-id="${anc.id}"]`)
+        // Search regular rows + title row (which may not have creative-id attribute on top-level page)
+        let ancRow = document.querySelector(`creative-tree-row[creative-id="${anc.id}"]`)
+        if (!ancRow) {
+            const titleRow = document.querySelector('creative-tree-row[is-title]')
+            if (titleRow && String(titleRow.creativeId || titleRow.getAttribute('creative-id')) === String(anc.id)) {
+                ancRow = titleRow
+            }
+        }
         if (ancRow && anc.progress != null) {
             const pct = Math.round(anc.progress * 100)
             ancRow.dataset.progressValue = String(anc.progress)

--- a/engines/collavre/app/javascript/lib/turbo_stream_actions.js
+++ b/engines/collavre/app/javascript/lib/turbo_stream_actions.js
@@ -266,12 +266,11 @@ function updateAncestorProgress(ancestors) {
     ancestors.forEach(anc => {
         const ancRow = document.querySelector(`creative-tree-row[creative-id="${anc.id}"]`)
         if (ancRow && anc.progress != null) {
-            const pct = Math.round(anc.progress)
-            ancRow.dataset.progressValue = String(pct)
-            // Update progress percentage in existing progressHtml (preserve chat badges etc.)
+            const pct = Math.round(anc.progress * 100)
+            ancRow.dataset.progressValue = String(anc.progress)
             if (ancRow.progressHtml) {
                 const updated = ancRow.progressHtml.replace(
-                    /(<span[^>]*class="creative-progress[^"]*"[^>]*>)\s*\d+%\s*(<\/span>)/,
+                    /(<span[^>]*class="creative-progress-(?:in)?complete"[^>]*>)[^<]*(<\/span>)/,
                     `$1${pct}%$2`
                 )
                 if (updated !== ancRow.progressHtml) {

--- a/engines/collavre/app/javascript/lib/turbo_stream_actions.js
+++ b/engines/collavre/app/javascript/lib/turbo_stream_actions.js
@@ -268,11 +268,17 @@ function updateAncestorProgress(ancestors) {
         if (ancRow && anc.progress != null) {
             const pct = Math.round(anc.progress)
             ancRow.dataset.progressValue = String(pct)
-            // Update displayed text only (preserve chat badges etc.)
-            const progressSpan = ancRow.shadowRoot
-                ? ancRow.shadowRoot.querySelector('.creative-progress')
-                : ancRow.querySelector('.creative-progress')
-            if (progressSpan) progressSpan.textContent = `${pct}%`
+            // Update progress percentage in existing progressHtml (preserve chat badges etc.)
+            if (ancRow.progressHtml) {
+                const updated = ancRow.progressHtml.replace(
+                    /(<span[^>]*class="creative-progress[^"]*"[^>]*>)\s*\d+%\s*(<\/span>)/,
+                    `$1${pct}%$2`
+                )
+                if (updated !== ancRow.progressHtml) {
+                    ancRow.progressHtml = updated
+                    ancRow.dataset.progressHtml = updated
+                }
+            }
         }
     })
 }

--- a/engines/collavre/app/javascript/lib/turbo_stream_actions.js
+++ b/engines/collavre/app/javascript/lib/turbo_stream_actions.js
@@ -30,7 +30,6 @@ registerStreamAction("refresh_creative_tree", function () {
 
     // Use linked_id if present (shared creative: receiver sees linked copy, not origin)
     const effectiveId = creative.linked_id || creative.id
-    console.log("[CreativeSync] Received", action, "for creative", creative.id, 
         creative.linked_id ? `(linked: ${creative.linked_id})` : '')
 
     // Override id with effectiveId for DOM lookups
@@ -54,17 +53,14 @@ registerStreamAction("refresh_creative_tree", function () {
 
 function handleCreated(creative) {
     const parentId = creative.parent_id
-    console.log("[CreativeSync] handleCreated", { id: creative.id, parentId, level: creative.level })
 
     // Duplicate broadcast protection
     if (document.querySelector(`creative-tree-row[creative-id="${creative.id}"]`)) {
-        console.log("[CreativeSync] Row already exists, skipping")
         return
     }
 
     const treeContainer = document.getElementById('creatives')
     if (!treeContainer) {
-        console.log("[CreativeSync] Tree container #creatives not found")
         return
     }
 
@@ -82,11 +78,9 @@ function handleCreated(creative) {
 
         const newRow = createRow(creative)
         insertAtCorrectPosition(newRow, creative, targetContainer)
-        console.log("[CreativeSync] Inserted row for creative", creative.id)
     } else {
         // Fallback: trigger tree reload — the creative is relevant to this page
         // (we received the broadcast) but we can't determine exact insertion point
-        console.log("[CreativeSync] Fallback: reloading tree for created creative", creative.id)
         document.dispatchEvent(new CustomEvent('creative-sync:refetch'))
     }
 }
@@ -97,7 +91,6 @@ function insertAtCorrectPosition(newRow, creative, container) {
     const sequence = creative.sequence
 
     const siblingRows = Array.from(container.querySelectorAll(':scope > creative-tree-row'))
-    console.log("[CreativeSync] insertAtCorrectPosition", {
         id: creative.id, afterId, prevSiblingId, sequence,
         siblingCount: siblingRows.length,
         siblingIds: siblingRows.map(r => r.getAttribute('creative-id'))
@@ -111,7 +104,6 @@ function insertAtCorrectPosition(newRow, creative, container) {
         const childContainer = document.getElementById(`creative-children-${targetId}`)
         const ref = childContainer || row
         ref.insertAdjacentElement('afterend', newRow)
-        console.log(`[CreativeSync] Inserted after ${label}`, targetId)
         return true
     }
 
@@ -127,7 +119,6 @@ function insertAtCorrectPosition(newRow, creative, container) {
             const rowSeq = parseInt(row.getAttribute('sequence'), 10)
             if (!isNaN(rowSeq) && rowSeq > sequence) {
                 container.insertBefore(newRow, row)
-                console.log("[CreativeSync] Inserted before row with sequence", rowSeq)
                 return
             }
         }
@@ -137,14 +128,12 @@ function insertAtCorrectPosition(newRow, creative, container) {
     if (!prevSiblingId && !afterId && (sequence === 0 || sequence == null)) {
         if (siblingRows.length > 0) {
             container.insertBefore(newRow, siblingRows[0])
-            console.log("[CreativeSync] Inserted at beginning")
             return
         }
     }
 
     // Fallback: append at end
     container.appendChild(newRow)
-    console.log("[CreativeSync] Appended at end (fallback)")
 }
 
 function findTargetContainer(parentId, treeContainer) {
@@ -249,7 +238,6 @@ function findRowsForCreative(creativeId, originId) {
 
 function handleUpdated(creative) {
     const rows = findRowsForCreative(creative.id, creative.origin_id)
-    console.log("[CreativeSync] handleUpdated creative", creative.id, "origin:", creative.origin_id, "found rows:", rows.length)
     if (rows.length === 0) return
 
     // Find currently editing creative ID to skip it
@@ -266,19 +254,12 @@ function handleUpdated(creative) {
         applyRowProperties(row, creative)
     })
 
-    console.log("[CreativeSync] Updated", rows.length, "row(s) for creative", creative.id)
 }
 
 function handleDestroyed(creative) {
     const rows = findRowsForCreative(creative.id, creative.origin_id)
 
-    if (rows.length === 0) {
-        // Row not found — might be on a page where it's displayed differently
-        // Trigger tree reload as fallback
-        console.log("[CreativeSync] Destroyed creative", creative.id, "not found in tree, reloading")
-        document.dispatchEvent(new CustomEvent('creative-sync:refetch'))
-        return
-    }
+    if (rows.length === 0) return // Row not visible on this page
 
     rows.forEach(row => {
         const childrenContainer = document.getElementById(`creative-children-${creative.id}`)
@@ -302,31 +283,33 @@ function handleDestroyed(creative) {
         }
     }
 
-    console.log("[CreativeSync] Removed row(s) for creative", creative.id)
 }
 
-function updateProgressForRow(row, progress) {
+function updateProgressForRow(row, progress, progressText) {
     if (progress == null) return
     const pct = Math.round(progress * 100)
     const cssClass = pct >= 100 ? 'creative-progress-complete' : 'creative-progress-incomplete'
+    // progressText from server: completion mark string, empty string (=complete but no mark), or null
+    const displayText = progressText != null ? (progressText || '\u00a0\u00a0') : `${pct}%`
 
     row.dataset.progressValue = String(progress)
 
     if (row.progressHtml) {
         // Try regex replacement on existing progress HTML (preserves chat buttons etc.)
         const regex = /(<span[^>]*class="creative-progress-(?:in)?complete"[^>]*>)[^<]*(<\/span>)/
-        const updated = row.progressHtml.replace(regex, `$1${pct}%$2`)
+        const updated = row.progressHtml.replace(regex, `$1${displayText}$2`)
         if (updated !== row.progressHtml) {
-            row.progressHtml = updated
-            row.dataset.progressHtml = updated
-            return
+            // Also update ONLY the first progress class (not chat buttons etc.)
+            const classUpdated = updated.replace(
+                /class="creative-progress-(?:in)?complete"/,
+                `class="${cssClass}"`
+            )
+            row.progressHtml = classUpdated
+            row.dataset.progressHtml = classUpdated
         }
+        // If regex didn't match, do NOT create fresh HTML — preserve existing progressHtml
+        // (it contains chat buttons, comment badges, etc.)
     }
-
-    // progressHtml is empty or regex didn't match — create fresh progress HTML
-    const newHtml = `<span class="${cssClass}">${pct}%</span>`
-    row.progressHtml = newHtml
-    row.dataset.progressHtml = newHtml
 }
 
 function updateAncestorProgress(ancestors) {
@@ -334,7 +317,7 @@ function updateAncestorProgress(ancestors) {
     ancestors.forEach(anc => {
         // findRowsForCreative already handles origin_id fallback for linked creatives
         const rows = findRowsForCreative(anc.id, anc.origin_id)
-        if (rows[0]) updateProgressForRow(rows[0], anc.progress)
+        if (rows[0]) updateProgressForRow(rows[0], anc.progress, anc.progress_text)
     })
 }
 

--- a/engines/collavre/app/javascript/lib/turbo_stream_actions.js
+++ b/engines/collavre/app/javascript/lib/turbo_stream_actions.js
@@ -9,58 +9,96 @@ function registerStreamAction(name, handler) {
     }
 }
 
-// Creative tree refresh: triggered when a shared creative is created/updated/destroyed
+// Creative tree sync: directly updates rows from broadcast data (no HTTP fetch needed)
 registerStreamAction("refresh_creative_tree", function () {
-    const creativeId = this.getAttribute("creative-id")
-    const action = this.getAttribute("change-action")
-    console.log("[Turbo] refresh_creative_tree", { creativeId, action })
+    const rawData = this.getAttribute("data")
+    if (!rawData) return
 
-    // Update title row if the changed creative matches it.
-    // Non-title rows are handled by tree refetch (debouncedLoad) which
-    // includes inline_editor_payload with fresh description_raw_html.
-    if (creativeId) {
-        const titleRow = document.querySelector('creative-tree-row[is-title]')
-        if (titleRow && String(titleRow.getAttribute('creative-id')) === String(creativeId)) {
-            refreshCreativeRow(titleRow, creativeId)
-        }
+    let payload
+    try {
+        payload = JSON.parse(rawData)
+    } catch (e) {
+        console.warn("[CreativeSync] Failed to parse broadcast data", e)
+        return
     }
 
-    // Dispatch event for any listening tree controller to refetch children
-    document.dispatchEvent(new CustomEvent('creative-sync:refetch', {
-        detail: { creativeId: creativeId ? parseInt(creativeId, 10) : null, action },
-        bubbles: true
-    }))
+    const { action, creative } = payload
+    if (!creative || !creative.id) return
+
+    console.log("[CreativeSync] Received", action, "for creative", creative.id)
+
+    if (action === "destroyed") {
+        handleCreativeDestroyed(creative)
+    } else {
+        handleCreativeUpserted(creative, action)
+    }
 })
 
-async function refreshCreativeRow(row, creativeId) {
-    try {
-        const response = await fetch(`/creatives/${creativeId}.json`, {
-            headers: { Accept: 'application/json' }
-        })
-        if (!response.ok) return
-        const data = await response.json()
-        // Update visible description (show.json returns 'description' as HTML)
-        if (data.description) {
-            row.descriptionHtml = data.description
-        }
-        // Update raw HTML cache so inline editor loads fresh data
-        if (data.description_raw_html != null) {
-            row.dataset.descriptionRawHtml = data.description_raw_html
-        }
-        if (data.progress_html) {
-            row.progressHtml = data.progress_html
-            row.dataset.progressHtml = data.progress_html
-        }
-        if (data.progress != null) {
-            row.dataset.progressValue = String(data.progress)
-        }
-        if (data.origin_id != null) {
-            row.dataset.originId = String(data.origin_id)
-        }
-        console.log("[Turbo] refreshed creative row", creativeId)
-    } catch (e) {
-        console.warn("[Turbo] failed to refresh title row", e)
+function handleCreativeDestroyed(creative) {
+    const rows = document.querySelectorAll(`creative-tree-row[creative-id="${creative.id}"]`)
+    rows.forEach(row => {
+        // Remove the row's parent .creative-tree container
+        const tree = row.closest('.creative-tree') || row
+        tree.remove()
+    })
+}
+
+function handleCreativeUpserted(creative, action) {
+    const rows = document.querySelectorAll(`creative-tree-row[creative-id="${creative.id}"]`)
+
+    if (rows.length === 0 && action === "created") {
+        // New creative — need a tree refetch to properly insert it
+        // (we don't have enough data to construct a full row client-side)
+        dispatchRefetchEvent(creative)
+        return
     }
+
+    // Update all matching rows (title row + tree row if both exist)
+    rows.forEach(row => applyCreativeData(row, creative))
+
+    // If progress changed, parent rows need updating too — dispatch a targeted refetch
+    // only for the children tree, not the whole page
+    if (action === "updated") {
+        dispatchRefetchEvent(creative)
+    }
+}
+
+function applyCreativeData(row, creative) {
+    // Update display HTML
+    if (creative.description_html != null) {
+        row.descriptionHtml = creative.description_html
+    }
+
+    // Update editor cache (descriptionRawHtml) so next edit loads fresh data
+    if (creative.description_raw_html != null) {
+        row.dataset.descriptionRawHtml = creative.description_raw_html
+    }
+
+    // Update progress value (the visual progress_html will be refreshed by tree refetch)
+    if (creative.progress != null) {
+        row.dataset.progressValue = String(creative.progress)
+    }
+
+    // Update origin
+    if (creative.origin_id != null) {
+        row.dataset.originId = String(creative.origin_id)
+    }
+
+    // Update has_children
+    if (creative.has_children != null) {
+        row.hasChildren = creative.has_children
+    }
+}
+
+function dispatchRefetchEvent(creative) {
+    document.dispatchEvent(new CustomEvent('creative-sync:refetch', {
+        detail: {
+            creativeId: creative.id,
+            parentId: creative.parent_id,
+            action: 'sync'
+        },
+        bubbles: true
+    }))
 }
 
 registerStreamAction("update_reactions", function () {
@@ -79,7 +117,6 @@ registerStreamAction("update_reactions", function () {
         const element = document.getElementById(targetId)
 
         if (element) {
-            // Find the stimulus controller instance using the global Stimulus application
             const controller = window.Stimulus?.getControllerForElementAndIdentifier(element, "comment")
             if (controller && typeof controller.updateReactionsUI === 'function') {
                 console.log("[Turbo] calling updateReactionsUI", data)

--- a/engines/collavre/app/javascript/lib/turbo_stream_actions.js
+++ b/engines/collavre/app/javascript/lib/turbo_stream_actions.js
@@ -1,5 +1,18 @@
 import { Turbo } from "@hotwired/turbo-rails"
 
+// Creative tree refresh: triggered when a shared creative is created/updated/destroyed
+Turbo.StreamActions.refresh_creative_tree = function () {
+    const creativeId = this.getAttribute("creative-id")
+    const action = this.getAttribute("change-action")
+    console.log("[Turbo] refresh_creative_tree", { creativeId, action })
+
+    // Dispatch event for any listening tree controller to refetch
+    document.dispatchEvent(new CustomEvent('creative-sync:refetch', {
+        detail: { creativeId: creativeId ? parseInt(creativeId, 10) : null, action },
+        bubbles: true
+    }))
+}
+
 Turbo.StreamActions.update_reactions = function () {
     const targetId = this.getAttribute("target")
     const dataJSON = this.getAttribute("data")

--- a/engines/collavre/app/javascript/lib/turbo_stream_actions.js
+++ b/engines/collavre/app/javascript/lib/turbo_stream_actions.js
@@ -87,31 +87,35 @@ function handleCreated(creative) {
 
 function insertAtCorrectPosition(newRow, creative, container) {
     const prevSiblingId = creative.previous_sibling_id
+    const afterId = creative.after_id  // from user's add action in CreateService
     const sequence = creative.sequence
 
-    // Get only direct child rows of this container (same level siblings)
     const siblingRows = Array.from(container.querySelectorAll(':scope > creative-tree-row'))
     console.log("[CreativeSync] insertAtCorrectPosition", {
-        id: creative.id, prevSiblingId, sequence,
+        id: creative.id, afterId, prevSiblingId, sequence,
         siblingCount: siblingRows.length,
         siblingIds: siblingRows.map(r => r.getAttribute('creative-id'))
     })
 
-    // Strategy 1: Use previous_sibling_id for exact positioning
-    if (prevSiblingId) {
-        const prevRow = container.querySelector(`:scope > creative-tree-row[creative-id="${prevSiblingId}"]`)
-        if (prevRow) {
-            // Insert after the previous sibling AND its children container
-            const prevChildren = document.getElementById(`creative-children-${prevSiblingId}`)
-            const insertAfter = prevChildren || prevRow
-            insertAfter.insertAdjacentElement('afterend', newRow)
-            console.log("[CreativeSync] Inserted after sibling", prevSiblingId)
-            return
-        }
-        console.log("[CreativeSync] Previous sibling", prevSiblingId, "not found in container")
+    // Helper: insert after a row (accounting for its children container)
+    function insertAfterRow(targetId, label) {
+        const row = container.querySelector(`:scope > creative-tree-row[creative-id="${targetId}"]`)
+            || document.querySelector(`creative-tree-row[creative-id="${targetId}"]`)
+        if (!row) return false
+        const childContainer = document.getElementById(`creative-children-${targetId}`)
+        const ref = childContainer || row
+        ref.insertAdjacentElement('afterend', newRow)
+        console.log(`[CreativeSync] Inserted after ${label}`, targetId)
+        return true
     }
 
-    // Strategy 2: Use sequence to find correct position
+    // Strategy 1: after_id — the creative user clicked "add after" (most reliable)
+    if (afterId && insertAfterRow(afterId, 'after_id')) return
+
+    // Strategy 2: previous_sibling_id — computed from DB after resequencing
+    if (prevSiblingId && insertAfterRow(prevSiblingId, 'prev_sibling')) return
+
+    // Strategy 3: sequence comparison among visible siblings
     if (sequence != null) {
         for (const row of siblingRows) {
             const rowSeq = parseInt(row.getAttribute('sequence'), 10)
@@ -123,11 +127,11 @@ function insertAtCorrectPosition(newRow, creative, container) {
         }
     }
 
-    // Strategy 3: No previous sibling and sequence 0 → first position
-    if (!prevSiblingId && (sequence === 0 || sequence === null)) {
+    // Strategy 4: first child (no previous sibling)
+    if (!prevSiblingId && !afterId && (sequence === 0 || sequence == null)) {
         if (siblingRows.length > 0) {
             container.insertBefore(newRow, siblingRows[0])
-            console.log("[CreativeSync] Inserted at beginning (first child)")
+            console.log("[CreativeSync] Inserted at beginning")
             return
         }
     }

--- a/engines/collavre/app/javascript/lib/turbo_stream_actions.js
+++ b/engines/collavre/app/javascript/lib/turbo_stream_actions.js
@@ -15,12 +15,42 @@ registerStreamAction("refresh_creative_tree", function () {
     const action = this.getAttribute("change-action")
     console.log("[Turbo] refresh_creative_tree", { creativeId, action })
 
-    // Dispatch event for any listening tree controller to refetch
+    // Update title row if the changed creative matches the title
+    const titleRow = document.querySelector('creative-tree-row[is-title]')
+    if (titleRow && creativeId && String(titleRow.getAttribute('creative-id')) === String(creativeId)) {
+        refreshTitleRow(titleRow, creativeId)
+    }
+
+    // Dispatch event for any listening tree controller to refetch children
     document.dispatchEvent(new CustomEvent('creative-sync:refetch', {
         detail: { creativeId: creativeId ? parseInt(creativeId, 10) : null, action },
         bubbles: true
     }))
 })
+
+async function refreshTitleRow(titleRow, creativeId) {
+    try {
+        const response = await fetch(`/creatives/${creativeId}.json`, {
+            headers: { Accept: 'application/json' }
+        })
+        if (!response.ok) return
+        const data = await response.json()
+        // show.json returns 'description' (HTML), not 'description_html'
+        if (data.description) {
+            titleRow.descriptionHtml = data.description
+        }
+        if (data.progress_html) {
+            titleRow.progressHtml = data.progress_html
+            titleRow.dataset.progressHtml = data.progress_html
+        }
+        if (data.progress != null) {
+            titleRow.dataset.progressValue = String(data.progress)
+        }
+        console.log("[Turbo] refreshed title row", creativeId)
+    } catch (e) {
+        console.warn("[Turbo] failed to refresh title row", e)
+    }
+}
 
 registerStreamAction("update_reactions", function () {
     const targetId = this.getAttribute("target")

--- a/engines/collavre/app/javascript/lib/turbo_stream_actions.js
+++ b/engines/collavre/app/javascript/lib/turbo_stream_actions.js
@@ -50,11 +50,6 @@ function handleCreated(creative) {
     const parentId = creative.parent_id
     console.log("[CreativeSync] handleCreated", { id: creative.id, parentId, level: creative.level })
 
-    if (!parentId) {
-        console.log("[CreativeSync] No parent_id, skipping")
-        return
-    }
-
     // Duplicate broadcast protection
     if (document.querySelector(`creative-tree-row[creative-id="${creative.id}"]`)) {
         console.log("[CreativeSync] Row already exists, skipping")
@@ -67,28 +62,39 @@ function handleCreated(creative) {
         return
     }
 
-    // Determine where to insert the new row
+    // Strategy: find where to insert the new row
+    // 1. Parent is in tree as regular row → insert into its children container
+    // 2. Parent is the title row (page root) → insert into #creatives directly
+    // 3. Parent is not visible but its children ARE in #creatives → insert into #creatives
+    // 4. Fallback: reload the tree (safest option)
+
     const targetContainer = findTargetContainer(parentId, treeContainer)
-    if (!targetContainer) {
-        console.log("[CreativeSync] Could not find target container for parent", parentId)
-        return
+
+    if (targetContainer) {
+        targetContainer.style.display = ''
+        if (targetContainer.dataset) targetContainer.dataset.expanded = 'true'
+
+        const newRow = createRow(creative)
+        targetContainer.appendChild(newRow)
+        console.log("[CreativeSync] Inserted row for creative", creative.id)
+    } else {
+        // Fallback: trigger tree reload — the creative is relevant to this page
+        // (we received the broadcast) but we can't determine exact insertion point
+        console.log("[CreativeSync] Fallback: reloading tree for created creative", creative.id)
+        document.dispatchEvent(new CustomEvent('creative-sync:refetch'))
     }
-
-    // Make sure container is visible
-    targetContainer.style.display = ''
-    if (targetContainer.dataset) targetContainer.dataset.expanded = 'true'
-
-    const newRow = createRow(creative)
-    targetContainer.appendChild(newRow)
-    console.log("[CreativeSync] Inserted row for creative", creative.id, "into", targetContainer.id || 'tree container')
 }
 
 function findTargetContainer(parentId, treeContainer) {
-    const parentRow = document.querySelector(`creative-tree-row[creative-id="${parentId}"]`)
+    if (!parentId) {
+        // No parent → top-level creative, insert into main container
+        return treeContainer
+    }
 
+    // 1. Check if parent exists as a regular tree row
+    const parentRow = document.querySelector(`creative-tree-row[creative-id="${parentId}"]`)
     if (parentRow) {
         if (parentRow.hasAttribute('is-title')) {
-            // Title row's children go directly into #creatives
             return treeContainer
         }
         // Regular row — use or create children container
@@ -101,7 +107,6 @@ function findTargetContainer(parentId, treeContainer) {
             container.dataset.loaded = 'true'
             parentRow.insertAdjacentElement('afterend', container)
         }
-        // Update parent state
         parentRow.hasChildren = true
         parentRow.setAttribute('has-children', '')
         if (!parentRow.expanded) {
@@ -111,24 +116,33 @@ function findTargetContainer(parentId, treeContainer) {
         return container
     }
 
-    // Parent row not found as a tree row. Check if the parent IS the page root.
-    // The page root's ID is stored on the tree container (or title row without creative-id).
+    // 2. Check if parent is the page root (title row)
     const rootId = treeContainer.dataset?.creativesSyncRootIdValue
     if (rootId && String(parentId) === String(rootId)) {
-        // Parent is the current page's root creative — children go into #creatives
         return treeContainer
     }
 
-    // Fallback: check title row's creative-id
+    // 3. Check title row's creative-id attribute
     const titleRow = document.querySelector('creative-tree-row[is-title]')
     const titleCreativeId = titleRow?.getAttribute('creative-id')
     if (titleCreativeId && String(parentId) === String(titleCreativeId)) {
         return treeContainer
     }
 
-    // If parent is not visible on this page, the creative belongs in a subtree
-    // that's not currently expanded. Nothing to do.
-    console.log("[CreativeSync] Parent", parentId, "not visible on this page (rootId:", rootId, ")")
+    // 4. Check if any siblings of the new creative are already in #creatives
+    //    (parent's other children are direct children of #creatives → top-level page)
+    const sibling = treeContainer.querySelector(`creative-tree-row[parent-id="${parentId}"]`)
+    if (sibling) {
+        return treeContainer
+    }
+
+    // 5. If the tree container has ANY rows, this broadcast is relevant to this page
+    //    Return null to trigger fallback tree reload
+    const anyRow = treeContainer.querySelector('creative-tree-row')
+    if (anyRow) {
+        return null  // will trigger refetch fallback
+    }
+
     return null
 }
 
@@ -157,10 +171,16 @@ function handleUpdated(creative) {
 
 function handleDestroyed(creative) {
     const rows = document.querySelectorAll(`creative-tree-row[creative-id="${creative.id}"]`)
-    if (rows.length === 0) return
+
+    if (rows.length === 0) {
+        // Row not found — might be on a page where it's displayed differently
+        // Trigger tree reload as fallback
+        console.log("[CreativeSync] Destroyed creative", creative.id, "not found in tree, reloading")
+        document.dispatchEvent(new CustomEvent('creative-sync:refetch'))
+        return
+    }
 
     rows.forEach(row => {
-        // Also remove the associated children container
         const childrenContainer = document.getElementById(`creative-children-${creative.id}`)
         if (childrenContainer) childrenContainer.remove()
         row.remove()

--- a/engines/collavre/app/javascript/lib/turbo_stream_actions.js
+++ b/engines/collavre/app/javascript/lib/turbo_stream_actions.js
@@ -28,17 +28,23 @@ registerStreamAction("refresh_creative_tree", function () {
     const { action, creative } = payload
     if (!creative || !creative.id) return
 
-    console.log("[CreativeSync] Received", action, "for creative", creative.id)
+    // Use linked_id if present (shared creative: receiver sees linked copy, not origin)
+    const effectiveId = creative.linked_id || creative.id
+    console.log("[CreativeSync] Received", action, "for creative", creative.id, 
+        creative.linked_id ? `(linked: ${creative.linked_id})` : '')
+
+    // Override id with effectiveId for DOM lookups
+    const effectiveCreative = { ...creative, id: effectiveId, origin_id: creative.id }
 
     switch (action) {
         case "created":
-            handleCreated(creative)
+            handleCreated(effectiveCreative)
             break
         case "updated":
-            handleUpdated(creative)
+            handleUpdated(effectiveCreative)
             break
         case "destroyed":
-            handleDestroyed(creative)
+            handleDestroyed(effectiveCreative)
             break
     }
 
@@ -220,14 +226,9 @@ function findRowsForCreative(creativeId) {
         if (urlId && String(urlId) === String(creativeId)) {
             return [titleRow]
         }
-        // 2c. Top-level page: if any tree row has parent-id matching creativeId,
-        //     then creativeId is the root of this tree = title row
-        if (!titleCreativeId) {
-            const childOfTarget = document.querySelector(`creative-tree-row[parent-id="${creativeId}"]`)
-            if (childOfTarget) {
-                return [titleRow]
-            }
-        }
+        // 2c removed: parent-id reverse lookup was incorrectly matching origin
+        // creative to title row on shared/linked creative pages.
+        // Title row progress is handled separately in updateAncestorProgress.
     }
     return rows
 }
@@ -314,10 +315,29 @@ function updateProgressForRow(row, progress) {
     row.dataset.progressHtml = newHtml
 }
 
+function findTitleRowForAncestor(ancestorId) {
+    // On top-level /creatives page, title row has no creative-id.
+    // If tree rows have parent-id matching ancestorId, then the title row
+    // represents this ancestor (for progress display only).
+    const titleRow = document.querySelector('creative-tree-row[is-title]')
+    if (!titleRow) return null
+    const titleCreativeId = titleRow.getAttribute('creative-id')
+    // If title row already has a creative-id, findRowsForCreative handles it
+    if (titleCreativeId) return null
+    // Check if any direct child has parent-id matching the ancestor
+    const child = document.querySelector(`creative-tree-row[parent-id="${ancestorId}"]`)
+    return child ? titleRow : null
+}
+
 function updateAncestorProgress(ancestors) {
     if (!Array.isArray(ancestors)) return
     ancestors.forEach(anc => {
-        const rows = findRowsForCreative(anc.id)
+        let rows = findRowsForCreative(anc.id)
+        // Also check if title row represents this ancestor (top-level page)
+        if (rows.length === 0) {
+            const titleRow = findTitleRowForAncestor(anc.id)
+            if (titleRow) rows = [titleRow]
+        }
         if (rows[0]) updateProgressForRow(rows[0], anc.progress)
     })
 }

--- a/engines/collavre/app/javascript/lib/turbo_stream_actions.js
+++ b/engines/collavre/app/javascript/lib/turbo_stream_actions.js
@@ -266,7 +266,7 @@ function updateAncestorProgress(ancestors) {
     ancestors.forEach(anc => {
         const ancRow = document.querySelector(`creative-tree-row[creative-id="${anc.id}"]`)
         if (ancRow && anc.progress != null) {
-            ancRow.dataset.progressValue = String(anc.progress)
+            ancRow.dataset.progressValue = String(Math.round(anc.progress))
         }
     })
 }

--- a/engines/collavre/app/javascript/lib/turbo_stream_actions.js
+++ b/engines/collavre/app/javascript/lib/turbo_stream_actions.js
@@ -90,9 +90,10 @@ function insertAtCorrectPosition(newRow, creative, container) {
     const siblingRows = Array.from(container.querySelectorAll(':scope > creative-tree-row'))
 
     // Helper: insert after a row (accounting for its children container)
+    const treeRoot = document.getElementById('creatives')
     function insertAfterRow(targetId, label) {
         const row = container.querySelector(`:scope > creative-tree-row[creative-id="${targetId}"]`)
-            || document.querySelector(`creative-tree-row[creative-id="${targetId}"]`)
+            || (treeRoot && treeRoot.querySelector(`creative-tree-row[creative-id="${targetId}"]`))
         if (!row) return false
         const childContainer = document.getElementById(`creative-children-${targetId}`)
         const ref = childContainer || row

--- a/engines/collavre/app/javascript/lib/turbo_stream_actions.js
+++ b/engines/collavre/app/javascript/lib/turbo_stream_actions.js
@@ -203,24 +203,29 @@ function findTargetContainer(parentId, treeContainer) {
 }
 
 function findRowsForCreative(creativeId) {
-    // 1. Normal tree rows
+    // 1. Normal tree rows by attribute
     const rows = Array.from(document.querySelectorAll(`creative-tree-row[creative-id="${creativeId}"]`))
+    if (rows.length > 0) return rows
 
-    // 2. Title row — may not have creative-id attribute on top-level page
-    //    Check via URL param (?id=X) or data attribute
-    if (rows.length === 0) {
-        const titleRow = document.querySelector('creative-tree-row[is-title]')
-        if (titleRow) {
-            // Check attribute first
-            const titleCreativeId = titleRow.getAttribute('creative-id')
-            if (String(titleCreativeId) === String(creativeId)) {
-                rows.push(titleRow)
-            } else {
-                // Check URL param: /creatives?id=X
-                const urlId = new URLSearchParams(window.location.search).get('id')
-                if (urlId && String(urlId) === String(creativeId)) {
-                    rows.push(titleRow)
-                }
+    // 2. Title row checks
+    const titleRow = document.querySelector('creative-tree-row[is-title]')
+    if (titleRow) {
+        // 2a. Title row has creative-id attribute (e.g. /creatives?id=X page)
+        const titleCreativeId = titleRow.getAttribute('creative-id')
+        if (titleCreativeId && String(titleCreativeId) === String(creativeId)) {
+            return [titleRow]
+        }
+        // 2b. URL param check
+        const urlId = new URLSearchParams(window.location.search).get('id')
+        if (urlId && String(urlId) === String(creativeId)) {
+            return [titleRow]
+        }
+        // 2c. Top-level page: if any tree row has parent-id matching creativeId,
+        //     then creativeId is the root of this tree = title row
+        if (!titleCreativeId) {
+            const childOfTarget = document.querySelector(`creative-tree-row[parent-id="${creativeId}"]`)
+            if (childOfTarget) {
+                return [titleRow]
             }
         }
     }
@@ -229,6 +234,7 @@ function findRowsForCreative(creativeId) {
 
 function handleUpdated(creative) {
     const rows = findRowsForCreative(creative.id)
+    console.log("[CreativeSync] handleUpdated creative", creative.id, "found rows:", rows.length)
     if (rows.length === 0) return
 
     // Find currently editing creative ID to skip it

--- a/engines/collavre/app/javascript/lib/turbo_stream_actions.js
+++ b/engines/collavre/app/javascript/lib/turbo_stream_actions.js
@@ -48,18 +48,21 @@ function handleCreativeUpserted(creative, action) {
 
     if (rows.length === 0 && action === "created") {
         // New creative — need a tree refetch to properly insert it
-        // (we don't have enough data to construct a full row client-side)
         dispatchRefetchEvent(creative)
         return
     }
 
-    // Update all matching rows (title row + tree row if both exist)
+    // Update all matching rows directly — no tree refetch needed
     rows.forEach(row => applyCreativeData(row, creative))
 
-    // If progress changed, parent rows need updating too — dispatch a targeted refetch
-    // only for the children tree, not the whole page
-    if (action === "updated") {
-        dispatchRefetchEvent(creative)
+    // Update ancestor progress values from broadcast data
+    if (creative.ancestors) {
+        creative.ancestors.forEach(anc => {
+            const ancRow = document.querySelector(`creative-tree-row[creative-id="${anc.id}"]`)
+            if (ancRow && anc.progress != null) {
+                ancRow.dataset.progressValue = String(anc.progress)
+            }
+        })
     }
 }
 

--- a/engines/collavre/app/javascript/lib/turbo_stream_actions.js
+++ b/engines/collavre/app/javascript/lib/turbo_stream_actions.js
@@ -202,8 +202,33 @@ function findTargetContainer(parentId, treeContainer) {
     return null
 }
 
+function findRowsForCreative(creativeId) {
+    // 1. Normal tree rows
+    const rows = Array.from(document.querySelectorAll(`creative-tree-row[creative-id="${creativeId}"]`))
+
+    // 2. Title row — may not have creative-id attribute on top-level page
+    //    Check via URL param (?id=X) or data attribute
+    if (rows.length === 0) {
+        const titleRow = document.querySelector('creative-tree-row[is-title]')
+        if (titleRow) {
+            // Check attribute first
+            const titleCreativeId = titleRow.getAttribute('creative-id')
+            if (String(titleCreativeId) === String(creativeId)) {
+                rows.push(titleRow)
+            } else {
+                // Check URL param: /creatives?id=X
+                const urlId = new URLSearchParams(window.location.search).get('id')
+                if (urlId && String(urlId) === String(creativeId)) {
+                    rows.push(titleRow)
+                }
+            }
+        }
+    }
+    return rows
+}
+
 function handleUpdated(creative) {
-    const rows = document.querySelectorAll(`creative-tree-row[creative-id="${creative.id}"]`)
+    const rows = findRowsForCreative(creative.id)
     if (rows.length === 0) return
 
     // Find currently editing creative ID to skip it
@@ -212,8 +237,6 @@ function handleUpdated(creative) {
 
     rows.forEach(row => {
         if (String(creative.id) === String(editingId)) {
-            // Don't touch the row being edited — it would close the editor.
-            // Cache the latest data so when the editor closes, it can be applied.
             if (creative.inline_editor_payload) {
                 row.dataset.pendingSyncData = JSON.stringify(creative)
             }
@@ -226,7 +249,7 @@ function handleUpdated(creative) {
 }
 
 function handleDestroyed(creative) {
-    const rows = document.querySelectorAll(`creative-tree-row[creative-id="${creative.id}"]`)
+    const rows = findRowsForCreative(creative.id)
 
     if (rows.length === 0) {
         // Row not found — might be on a page where it's displayed differently
@@ -264,25 +287,26 @@ function handleDestroyed(creative) {
 function updateAncestorProgress(ancestors) {
     if (!Array.isArray(ancestors)) return
     ancestors.forEach(anc => {
-        // Search regular rows + title row (which may not have creative-id attribute on top-level page)
-        let ancRow = document.querySelector(`creative-tree-row[creative-id="${anc.id}"]`)
-        if (!ancRow) {
-            const titleRow = document.querySelector('creative-tree-row[is-title]')
-            if (titleRow && String(titleRow.creativeId || titleRow.getAttribute('creative-id')) === String(anc.id)) {
-                ancRow = titleRow
-            }
-        }
+        const rows = findRowsForCreative(anc.id)
+        const ancRow = rows[0]
         if (ancRow && anc.progress != null) {
             const pct = Math.round(anc.progress * 100)
             ancRow.dataset.progressValue = String(anc.progress)
+            console.log("[CreativeSync] ancestor progressHtml exists:", !!ancRow.progressHtml, "value:", ancRow.progressHtml?.substring(0, 100))
             if (ancRow.progressHtml) {
+                const regex = /(<span[^>]*class="creative-progress-(?:in)?complete"[^>]*>)[^<]*(<\/span>)/
+                const matched = regex.test(ancRow.progressHtml)
+                console.log("[CreativeSync] regex matched:", matched)
                 const updated = ancRow.progressHtml.replace(
-                    /(<span[^>]*class="creative-progress-(?:in)?complete"[^>]*>)[^<]*(<\/span>)/,
+                    regex,
                     `$1${pct}%$2`
                 )
                 if (updated !== ancRow.progressHtml) {
                     ancRow.progressHtml = updated
                     ancRow.dataset.progressHtml = updated
+                    console.log("[CreativeSync] ancestor progress updated to", pct + "%")
+                } else {
+                    console.log("[CreativeSync] regex replace had no effect")
                 }
             }
         }

--- a/engines/collavre/app/javascript/lib/turbo_stream_actions.js
+++ b/engines/collavre/app/javascript/lib/turbo_stream_actions.js
@@ -47,49 +47,66 @@ registerStreamAction("refresh_creative_tree", function () {
 })
 
 function handleCreated(creative) {
-    // Find the parent's children container to insert the new row
     const parentId = creative.parent_id
-    if (!parentId) return
+    console.log("[CreativeSync] handleCreated", { id: creative.id, parentId, level: creative.level })
 
-    // Check if parent row exists in the current view
+    if (!parentId) {
+        console.log("[CreativeSync] No parent_id, skipping")
+        return
+    }
+
+    // Duplicate broadcast protection
+    if (document.querySelector(`creative-tree-row[creative-id="${creative.id}"]`)) {
+        console.log("[CreativeSync] Row already exists, skipping")
+        return
+    }
+
+    // Check if parent is the title row (page root) — children go into #creatives directly
     const parentRow = document.querySelector(`creative-tree-row[creative-id="${parentId}"]`)
-    if (!parentRow) return // Parent not visible — nothing to do
-
-    // Find or create the children container
-    let childrenContainer = document.getElementById(`creative-children-${parentId}`)
-
-    if (!childrenContainer) {
-        // Create a new children container after the parent row
-        childrenContainer = document.createElement('div')
-        childrenContainer.className = 'creative-children'
-        childrenContainer.id = `creative-children-${parentId}`
-        childrenContainer.dataset.expanded = 'true'
-        childrenContainer.dataset.loaded = 'true'
-        parentRow.insertAdjacentElement('afterend', childrenContainer)
+    if (!parentRow) {
+        console.log("[CreativeSync] Parent row not found for", parentId)
+        return
     }
 
-    // Make sure children container is visible
-    childrenContainer.style.display = ''
-    childrenContainer.dataset.expanded = 'true'
+    const isTitle = parentRow.hasAttribute('is-title')
+    let targetContainer
 
-    // Check if the row already exists (duplicate broadcast protection)
-    if (document.querySelector(`creative-tree-row[creative-id="${creative.id}"]`)) return
+    if (isTitle) {
+        // Title row's children are direct children of #creatives container
+        targetContainer = document.getElementById('creatives')
+    } else {
+        // Regular row — use or create children container
+        targetContainer = document.getElementById(`creative-children-${parentId}`)
+        if (!targetContainer) {
+            targetContainer = document.createElement('div')
+            targetContainer.className = 'creative-children'
+            targetContainer.id = `creative-children-${parentId}`
+            targetContainer.dataset.expanded = 'true'
+            targetContainer.dataset.loaded = 'true'
+            parentRow.insertAdjacentElement('afterend', targetContainer)
+        }
 
-    // Create the new row using tree_renderer's createRow
+        // Update parent state
+        parentRow.hasChildren = true
+        parentRow.setAttribute('has-children', '')
+        if (!parentRow.expanded) {
+            parentRow.expanded = true
+            parentRow.setAttribute('expanded', '')
+        }
+    }
+
+    if (!targetContainer) {
+        console.log("[CreativeSync] No target container found")
+        return
+    }
+
+    // Make sure container is visible
+    targetContainer.style.display = ''
+    if (targetContainer.dataset) targetContainer.dataset.expanded = 'true'
+
     const newRow = createRow(creative)
-    childrenContainer.appendChild(newRow)
-
-    // Update parent's has-children state
-    parentRow.hasChildren = true
-    parentRow.setAttribute('has-children', '')
-
-    // Expand parent if not already
-    if (!parentRow.expanded) {
-        parentRow.expanded = true
-        parentRow.setAttribute('expanded', '')
-    }
-
-    console.log("[CreativeSync] Inserted new row for creative", creative.id, "under parent", parentId)
+    targetContainer.appendChild(newRow)
+    console.log("[CreativeSync] Inserted row for creative", creative.id, isTitle ? "into main container" : `under parent ${parentId}`)
 }
 
 function handleUpdated(creative) {

--- a/engines/collavre/app/javascript/lib/turbo_stream_actions.js
+++ b/engines/collavre/app/javascript/lib/turbo_stream_actions.js
@@ -87,28 +87,51 @@ function handleCreated(creative) {
 
 function insertAtCorrectPosition(newRow, creative, container) {
     const prevSiblingId = creative.previous_sibling_id
+    const sequence = creative.sequence
+    console.log("[CreativeSync] insertAtCorrectPosition", {
+        id: creative.id, prevSiblingId, sequence,
+        containerChildCount: container.querySelectorAll(':scope > creative-tree-row').length
+    })
 
+    // Strategy 1: Use previous_sibling_id to find exact position
     if (prevSiblingId) {
-        // Find the previous sibling's row in the container
         const prevRow = container.querySelector(`creative-tree-row[creative-id="${prevSiblingId}"]`)
         if (prevRow) {
-            // Insert after the previous sibling (and its children container if present)
             const prevChildrenContainer = document.getElementById(`creative-children-${prevSiblingId}`)
             const insertAfter = prevChildrenContainer || prevRow
             insertAfter.insertAdjacentElement('afterend', newRow)
+            console.log("[CreativeSync] Inserted after sibling", prevSiblingId)
             return
         }
     }
 
-    // No previous sibling → insert at the beginning of the container
-    // (this creative is first among its siblings)
-    const firstRow = container.querySelector('creative-tree-row')
-    if (firstRow && !prevSiblingId) {
-        container.insertBefore(newRow, firstRow)
-    } else {
-        // Fallback: append at end
-        container.appendChild(newRow)
+    // Strategy 2: Use sequence to find correct position among visible siblings
+    if (sequence != null) {
+        const siblingRows = container.querySelectorAll(':scope > creative-tree-row')
+        for (const row of siblingRows) {
+            // tree_renderer stores sequence in a property/attribute
+            const rowSequence = parseInt(row.getAttribute('sequence'), 10)
+            if (!isNaN(rowSequence) && rowSequence > sequence) {
+                container.insertBefore(newRow, row)
+                console.log("[CreativeSync] Inserted before row with sequence", rowSequence)
+                return
+            }
+        }
     }
+
+    // Strategy 3: No previous sibling → insert at beginning
+    if (!prevSiblingId && sequence === 0) {
+        const firstRow = container.querySelector(':scope > creative-tree-row')
+        if (firstRow) {
+            container.insertBefore(newRow, firstRow)
+            console.log("[CreativeSync] Inserted at beginning (sequence 0)")
+            return
+        }
+    }
+
+    // Fallback: append at end
+    container.appendChild(newRow)
+    console.log("[CreativeSync] Appended at end (fallback)")
 }
 
 function findTargetContainer(parentId, treeContainer) {

--- a/engines/collavre/app/javascript/lib/turbo_stream_actions.js
+++ b/engines/collavre/app/javascript/lib/turbo_stream_actions.js
@@ -61,42 +61,16 @@ function handleCreated(creative) {
         return
     }
 
-    // Check if parent is the title row (page root) — children go into #creatives directly
-    const parentRow = document.querySelector(`creative-tree-row[creative-id="${parentId}"]`)
-    if (!parentRow) {
-        console.log("[CreativeSync] Parent row not found for", parentId)
+    const treeContainer = document.getElementById('creatives')
+    if (!treeContainer) {
+        console.log("[CreativeSync] Tree container #creatives not found")
         return
     }
 
-    const isTitle = parentRow.hasAttribute('is-title')
-    let targetContainer
-
-    if (isTitle) {
-        // Title row's children are direct children of #creatives container
-        targetContainer = document.getElementById('creatives')
-    } else {
-        // Regular row — use or create children container
-        targetContainer = document.getElementById(`creative-children-${parentId}`)
-        if (!targetContainer) {
-            targetContainer = document.createElement('div')
-            targetContainer.className = 'creative-children'
-            targetContainer.id = `creative-children-${parentId}`
-            targetContainer.dataset.expanded = 'true'
-            targetContainer.dataset.loaded = 'true'
-            parentRow.insertAdjacentElement('afterend', targetContainer)
-        }
-
-        // Update parent state
-        parentRow.hasChildren = true
-        parentRow.setAttribute('has-children', '')
-        if (!parentRow.expanded) {
-            parentRow.expanded = true
-            parentRow.setAttribute('expanded', '')
-        }
-    }
-
+    // Determine where to insert the new row
+    const targetContainer = findTargetContainer(parentId, treeContainer)
     if (!targetContainer) {
-        console.log("[CreativeSync] No target container found")
+        console.log("[CreativeSync] Could not find target container for parent", parentId)
         return
     }
 
@@ -106,7 +80,56 @@ function handleCreated(creative) {
 
     const newRow = createRow(creative)
     targetContainer.appendChild(newRow)
-    console.log("[CreativeSync] Inserted row for creative", creative.id, isTitle ? "into main container" : `under parent ${parentId}`)
+    console.log("[CreativeSync] Inserted row for creative", creative.id, "into", targetContainer.id || 'tree container')
+}
+
+function findTargetContainer(parentId, treeContainer) {
+    const parentRow = document.querySelector(`creative-tree-row[creative-id="${parentId}"]`)
+
+    if (parentRow) {
+        if (parentRow.hasAttribute('is-title')) {
+            // Title row's children go directly into #creatives
+            return treeContainer
+        }
+        // Regular row — use or create children container
+        let container = document.getElementById(`creative-children-${parentId}`)
+        if (!container) {
+            container = document.createElement('div')
+            container.className = 'creative-children'
+            container.id = `creative-children-${parentId}`
+            container.dataset.expanded = 'true'
+            container.dataset.loaded = 'true'
+            parentRow.insertAdjacentElement('afterend', container)
+        }
+        // Update parent state
+        parentRow.hasChildren = true
+        parentRow.setAttribute('has-children', '')
+        if (!parentRow.expanded) {
+            parentRow.expanded = true
+            parentRow.setAttribute('expanded', '')
+        }
+        return container
+    }
+
+    // Parent row not found as a tree row. Check if the parent IS the page root.
+    // The page root's ID is stored on the tree container (or title row without creative-id).
+    const rootId = treeContainer.dataset?.creativesSyncRootIdValue
+    if (rootId && String(parentId) === String(rootId)) {
+        // Parent is the current page's root creative — children go into #creatives
+        return treeContainer
+    }
+
+    // Fallback: check title row's creative-id
+    const titleRow = document.querySelector('creative-tree-row[is-title]')
+    const titleCreativeId = titleRow?.getAttribute('creative-id')
+    if (titleCreativeId && String(parentId) === String(titleCreativeId)) {
+        return treeContainer
+    }
+
+    // If parent is not visible on this page, the creative belongs in a subtree
+    // that's not currently expanded. Nothing to do.
+    console.log("[CreativeSync] Parent", parentId, "not visible on this page (rootId:", rootId, ")")
+    return null
 }
 
 function handleUpdated(creative) {

--- a/engines/collavre/app/javascript/lib/turbo_stream_actions.js
+++ b/engines/collavre/app/javascript/lib/turbo_stream_actions.js
@@ -1,7 +1,7 @@
 import { Turbo } from "@hotwired/turbo-rails"
+import { createRow, applyRowProperties } from "../creatives/tree_renderer"
 
 // Register custom actions on both the imported Turbo and the global window.Turbo
-// to handle cases where the bundled Turbo instance differs from the runtime one.
 function registerStreamAction(name, handler) {
     Turbo.StreamActions[name] = handler
     if (window.Turbo && window.Turbo.StreamActions && window.Turbo.StreamActions !== Turbo.StreamActions) {
@@ -9,7 +9,10 @@ function registerStreamAction(name, handler) {
     }
 }
 
-// Creative tree sync: directly updates rows from broadcast data (no HTTP fetch needed)
+// ─── Creative tree sync ──────────────────────────────────────────────
+// Receives full creative data via WebSocket and applies changes directly
+// to the DOM — zero HTTP fetch for any CRUD operation.
+
 registerStreamAction("refresh_creative_tree", function () {
     const rawData = this.getAttribute("data")
     if (!rawData) return
@@ -27,108 +30,147 @@ registerStreamAction("refresh_creative_tree", function () {
 
     console.log("[CreativeSync] Received", action, "for creative", creative.id)
 
-    if (action === "destroyed") {
-        handleCreativeDestroyed(creative)
-    } else {
-        handleCreativeUpserted(creative, action)
+    switch (action) {
+        case "created":
+            handleCreated(creative)
+            break
+        case "updated":
+            handleUpdated(creative)
+            break
+        case "destroyed":
+            handleDestroyed(creative)
+            break
     }
+
+    // Update ancestor progress for all actions
+    updateAncestorProgress(creative.ancestors)
 })
 
-function handleCreativeDestroyed(creative) {
+function handleCreated(creative) {
+    // Find the parent's children container to insert the new row
+    const parentId = creative.parent_id
+    if (!parentId) return
+
+    // Check if parent row exists in the current view
+    const parentRow = document.querySelector(`creative-tree-row[creative-id="${parentId}"]`)
+    if (!parentRow) return // Parent not visible — nothing to do
+
+    // Find or create the children container
+    let childrenContainer = document.getElementById(`creative-children-${parentId}`)
+
+    if (!childrenContainer) {
+        // Create a new children container after the parent row
+        childrenContainer = document.createElement('div')
+        childrenContainer.className = 'creative-children'
+        childrenContainer.id = `creative-children-${parentId}`
+        childrenContainer.dataset.expanded = 'true'
+        childrenContainer.dataset.loaded = 'true'
+        parentRow.insertAdjacentElement('afterend', childrenContainer)
+    }
+
+    // Make sure children container is visible
+    childrenContainer.style.display = ''
+    childrenContainer.dataset.expanded = 'true'
+
+    // Check if the row already exists (duplicate broadcast protection)
+    if (document.querySelector(`creative-tree-row[creative-id="${creative.id}"]`)) return
+
+    // Create the new row using tree_renderer's createRow
+    const newRow = createRow(creative)
+    childrenContainer.appendChild(newRow)
+
+    // Update parent's has-children state
+    parentRow.hasChildren = true
+    parentRow.setAttribute('has-children', '')
+
+    // Expand parent if not already
+    if (!parentRow.expanded) {
+        parentRow.expanded = true
+        parentRow.setAttribute('expanded', '')
+    }
+
+    console.log("[CreativeSync] Inserted new row for creative", creative.id, "under parent", parentId)
+}
+
+function handleUpdated(creative) {
     const rows = document.querySelectorAll(`creative-tree-row[creative-id="${creative.id}"]`)
+    if (rows.length === 0) return
+
+    // Find currently editing creative ID to skip it
+    const editForm = document.querySelector('#inline-edit-form-element')
+    const editingId = editForm?.dataset?.creativeId
+
     rows.forEach(row => {
-        // Remove the row's parent .creative-tree container
-        const tree = row.closest('.creative-tree') || row
-        tree.remove()
+        if (String(creative.id) === String(editingId)) {
+            // Don't touch the row being edited — it would close the editor.
+            // Cache the latest data so when the editor closes, it can be applied.
+            if (creative.inline_editor_payload) {
+                row.dataset.pendingSyncData = JSON.stringify(creative)
+            }
+            return
+        }
+        applyRowProperties(row, creative)
+    })
+
+    console.log("[CreativeSync] Updated", rows.length, "row(s) for creative", creative.id)
+}
+
+function handleDestroyed(creative) {
+    const rows = document.querySelectorAll(`creative-tree-row[creative-id="${creative.id}"]`)
+    if (rows.length === 0) return
+
+    rows.forEach(row => {
+        // Also remove the associated children container
+        const childrenContainer = document.getElementById(`creative-children-${creative.id}`)
+        if (childrenContainer) childrenContainer.remove()
+        row.remove()
+    })
+
+    // Update parent's has-children state if no more children
+    if (creative.parent_id) {
+        const parentChildrenContainer = document.getElementById(`creative-children-${creative.parent_id}`)
+        if (parentChildrenContainer) {
+            const remaining = parentChildrenContainer.querySelectorAll('creative-tree-row')
+            if (remaining.length === 0) {
+                const parentRow = document.querySelector(`creative-tree-row[creative-id="${creative.parent_id}"]`)
+                if (parentRow) {
+                    parentRow.hasChildren = false
+                    parentRow.removeAttribute('has-children')
+                }
+                parentChildrenContainer.remove()
+            }
+        }
+    }
+
+    console.log("[CreativeSync] Removed row(s) for creative", creative.id)
+}
+
+function updateAncestorProgress(ancestors) {
+    if (!Array.isArray(ancestors)) return
+    ancestors.forEach(anc => {
+        const ancRow = document.querySelector(`creative-tree-row[creative-id="${anc.id}"]`)
+        if (ancRow && anc.progress != null) {
+            ancRow.dataset.progressValue = String(anc.progress)
+        }
     })
 }
 
-function handleCreativeUpserted(creative, action) {
-    const rows = document.querySelectorAll(`creative-tree-row[creative-id="${creative.id}"]`)
-
-    if (rows.length === 0 && action === "created") {
-        // New creative — need a tree refetch to properly insert it
-        dispatchRefetchEvent(creative)
-        return
-    }
-
-    // Update all matching rows directly — no tree refetch needed
-    rows.forEach(row => applyCreativeData(row, creative))
-
-    // Update ancestor progress values from broadcast data
-    if (creative.ancestors) {
-        creative.ancestors.forEach(anc => {
-            const ancRow = document.querySelector(`creative-tree-row[creative-id="${anc.id}"]`)
-            if (ancRow && anc.progress != null) {
-                ancRow.dataset.progressValue = String(anc.progress)
-            }
-        })
-    }
-}
-
-function applyCreativeData(row, creative) {
-    // Update display HTML
-    if (creative.description_html != null) {
-        row.descriptionHtml = creative.description_html
-    }
-
-    // Update editor cache (descriptionRawHtml) so next edit loads fresh data
-    if (creative.description_raw_html != null) {
-        row.dataset.descriptionRawHtml = creative.description_raw_html
-    }
-
-    // Update progress value (the visual progress_html will be refreshed by tree refetch)
-    if (creative.progress != null) {
-        row.dataset.progressValue = String(creative.progress)
-    }
-
-    // Update origin
-    if (creative.origin_id != null) {
-        row.dataset.originId = String(creative.origin_id)
-    }
-
-    // Update has_children
-    if (creative.has_children != null) {
-        row.hasChildren = creative.has_children
-    }
-}
-
-function dispatchRefetchEvent(creative) {
-    document.dispatchEvent(new CustomEvent('creative-sync:refetch', {
-        detail: {
-            creativeId: creative.id,
-            parentId: creative.parent_id,
-            action: 'sync'
-        },
-        bubbles: true
-    }))
-}
+// ─── Reactions sync ──────────────────────────────────────────────────
 
 registerStreamAction("update_reactions", function () {
     const targetId = this.getAttribute("target")
     const dataJSON = this.getAttribute("data")
 
-    console.log("[Turbo] update_reactions action received", { targetId, dataJSON })
-
-    if (!targetId || !dataJSON) {
-        console.warn("[Turbo] update_reactions missing target or data")
-        return
-    }
+    if (!targetId || !dataJSON) return
 
     try {
         const data = JSON.parse(dataJSON)
         const element = document.getElementById(targetId)
-
         if (element) {
             const controller = window.Stimulus?.getControllerForElementAndIdentifier(element, "comment")
             if (controller && typeof controller.updateReactionsUI === 'function') {
-                console.log("[Turbo] calling updateReactionsUI", data)
                 controller.updateReactionsUI(data)
-            } else {
-                console.warn("[Turbo] comment controller not found", { element, controller })
             }
-        } else {
-            console.warn("[Turbo] target element not found", targetId)
         }
     } catch (e) {
         console.error("Failed to process update_reactions stream action", e)

--- a/engines/collavre/app/javascript/lib/turbo_stream_actions.js
+++ b/engines/collavre/app/javascript/lib/turbo_stream_actions.js
@@ -290,32 +290,35 @@ function handleDestroyed(creative) {
     console.log("[CreativeSync] Removed row(s) for creative", creative.id)
 }
 
+function updateProgressForRow(row, progress) {
+    if (progress == null) return
+    const pct = Math.round(progress * 100)
+    const cssClass = pct >= 100 ? 'creative-progress-complete' : 'creative-progress-incomplete'
+
+    row.dataset.progressValue = String(progress)
+
+    if (row.progressHtml) {
+        // Try regex replacement on existing progress HTML (preserves chat buttons etc.)
+        const regex = /(<span[^>]*class="creative-progress-(?:in)?complete"[^>]*>)[^<]*(<\/span>)/
+        const updated = row.progressHtml.replace(regex, `$1${pct}%$2`)
+        if (updated !== row.progressHtml) {
+            row.progressHtml = updated
+            row.dataset.progressHtml = updated
+            return
+        }
+    }
+
+    // progressHtml is empty or regex didn't match — create fresh progress HTML
+    const newHtml = `<span class="${cssClass}">${pct}%</span>`
+    row.progressHtml = newHtml
+    row.dataset.progressHtml = newHtml
+}
+
 function updateAncestorProgress(ancestors) {
     if (!Array.isArray(ancestors)) return
     ancestors.forEach(anc => {
         const rows = findRowsForCreative(anc.id)
-        const ancRow = rows[0]
-        if (ancRow && anc.progress != null) {
-            const pct = Math.round(anc.progress * 100)
-            ancRow.dataset.progressValue = String(anc.progress)
-            console.log("[CreativeSync] ancestor progressHtml exists:", !!ancRow.progressHtml, "value:", ancRow.progressHtml?.substring(0, 100))
-            if (ancRow.progressHtml) {
-                const regex = /(<span[^>]*class="creative-progress-(?:in)?complete"[^>]*>)[^<]*(<\/span>)/
-                const matched = regex.test(ancRow.progressHtml)
-                console.log("[CreativeSync] regex matched:", matched)
-                const updated = ancRow.progressHtml.replace(
-                    regex,
-                    `$1${pct}%$2`
-                )
-                if (updated !== ancRow.progressHtml) {
-                    ancRow.progressHtml = updated
-                    ancRow.dataset.progressHtml = updated
-                    console.log("[CreativeSync] ancestor progress updated to", pct + "%")
-                } else {
-                    console.log("[CreativeSync] regex replace had no effect")
-                }
-            }
-        }
+        if (rows[0]) updateProgressForRow(rows[0], anc.progress)
     })
 }
 

--- a/engines/collavre/app/javascript/lib/turbo_stream_actions.js
+++ b/engines/collavre/app/javascript/lib/turbo_stream_actions.js
@@ -75,13 +75,39 @@ function handleCreated(creative) {
         if (targetContainer.dataset) targetContainer.dataset.expanded = 'true'
 
         const newRow = createRow(creative)
-        targetContainer.appendChild(newRow)
+        insertAtCorrectPosition(newRow, creative, targetContainer)
         console.log("[CreativeSync] Inserted row for creative", creative.id)
     } else {
         // Fallback: trigger tree reload — the creative is relevant to this page
         // (we received the broadcast) but we can't determine exact insertion point
         console.log("[CreativeSync] Fallback: reloading tree for created creative", creative.id)
         document.dispatchEvent(new CustomEvent('creative-sync:refetch'))
+    }
+}
+
+function insertAtCorrectPosition(newRow, creative, container) {
+    const prevSiblingId = creative.previous_sibling_id
+
+    if (prevSiblingId) {
+        // Find the previous sibling's row in the container
+        const prevRow = container.querySelector(`creative-tree-row[creative-id="${prevSiblingId}"]`)
+        if (prevRow) {
+            // Insert after the previous sibling (and its children container if present)
+            const prevChildrenContainer = document.getElementById(`creative-children-${prevSiblingId}`)
+            const insertAfter = prevChildrenContainer || prevRow
+            insertAfter.insertAdjacentElement('afterend', newRow)
+            return
+        }
+    }
+
+    // No previous sibling → insert at the beginning of the container
+    // (this creative is first among its siblings)
+    const firstRow = container.querySelector('creative-tree-row')
+    if (firstRow && !prevSiblingId) {
+        container.insertBefore(newRow, firstRow)
+    } else {
+        // Fallback: append at end
+        container.appendChild(newRow)
     }
 }
 

--- a/engines/collavre/app/javascript/lib/turbo_stream_actions.js
+++ b/engines/collavre/app/javascript/lib/turbo_stream_actions.js
@@ -88,43 +88,46 @@ function handleCreated(creative) {
 function insertAtCorrectPosition(newRow, creative, container) {
     const prevSiblingId = creative.previous_sibling_id
     const sequence = creative.sequence
+
+    // Get only direct child rows of this container (same level siblings)
+    const siblingRows = Array.from(container.querySelectorAll(':scope > creative-tree-row'))
     console.log("[CreativeSync] insertAtCorrectPosition", {
         id: creative.id, prevSiblingId, sequence,
-        containerChildCount: container.querySelectorAll(':scope > creative-tree-row').length
+        siblingCount: siblingRows.length,
+        siblingIds: siblingRows.map(r => r.getAttribute('creative-id'))
     })
 
-    // Strategy 1: Use previous_sibling_id to find exact position
+    // Strategy 1: Use previous_sibling_id for exact positioning
     if (prevSiblingId) {
-        const prevRow = container.querySelector(`creative-tree-row[creative-id="${prevSiblingId}"]`)
+        const prevRow = container.querySelector(`:scope > creative-tree-row[creative-id="${prevSiblingId}"]`)
         if (prevRow) {
-            const prevChildrenContainer = document.getElementById(`creative-children-${prevSiblingId}`)
-            const insertAfter = prevChildrenContainer || prevRow
+            // Insert after the previous sibling AND its children container
+            const prevChildren = document.getElementById(`creative-children-${prevSiblingId}`)
+            const insertAfter = prevChildren || prevRow
             insertAfter.insertAdjacentElement('afterend', newRow)
             console.log("[CreativeSync] Inserted after sibling", prevSiblingId)
             return
         }
+        console.log("[CreativeSync] Previous sibling", prevSiblingId, "not found in container")
     }
 
-    // Strategy 2: Use sequence to find correct position among visible siblings
+    // Strategy 2: Use sequence to find correct position
     if (sequence != null) {
-        const siblingRows = container.querySelectorAll(':scope > creative-tree-row')
         for (const row of siblingRows) {
-            // tree_renderer stores sequence in a property/attribute
-            const rowSequence = parseInt(row.getAttribute('sequence'), 10)
-            if (!isNaN(rowSequence) && rowSequence > sequence) {
+            const rowSeq = parseInt(row.getAttribute('sequence'), 10)
+            if (!isNaN(rowSeq) && rowSeq > sequence) {
                 container.insertBefore(newRow, row)
-                console.log("[CreativeSync] Inserted before row with sequence", rowSequence)
+                console.log("[CreativeSync] Inserted before row with sequence", rowSeq)
                 return
             }
         }
     }
 
-    // Strategy 3: No previous sibling → insert at beginning
-    if (!prevSiblingId && sequence === 0) {
-        const firstRow = container.querySelector(':scope > creative-tree-row')
-        if (firstRow) {
-            container.insertBefore(newRow, firstRow)
-            console.log("[CreativeSync] Inserted at beginning (sequence 0)")
+    // Strategy 3: No previous sibling and sequence 0 → first position
+    if (!prevSiblingId && (sequence === 0 || sequence === null)) {
+        if (siblingRows.length > 0) {
+            container.insertBefore(newRow, siblingRows[0])
+            console.log("[CreativeSync] Inserted at beginning (first child)")
             return
         }
     }

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -149,6 +149,7 @@ export function initializeCreativeRowEditor() {
     let originalOriginId = '';
     let isDirty = false;
     let completionCascadePending = false;
+    const destroyedCreativeIds = new Set();
 
     function formatProgressDisplay(value) {
       return isProgressComplete(value) ? progressCompleteLabel : progressIncompleteLabel;
@@ -1169,6 +1170,13 @@ export function initializeCreativeRowEditor() {
       const creativeId = form.dataset?.creativeId;
       if (!creativeId) return;
 
+      // Skip save for already-destroyed creatives (prevents 404 after deletion)
+      if (destroyedCreativeIds.has(String(creativeId))) {
+        isDirty = false;
+        pendingSave = null;
+        return;
+      }
+
       // CRITICAL: Capture ALL values BEFORE awaiting, because the editor may switch
       // to a different creative while we're waiting for uploads
       let currentContent = descriptionInput.value;
@@ -1550,9 +1558,11 @@ export function initializeCreativeRowEditor() {
       const nextId = trees[index + 1] ? trees[index + 1].dataset.id : null;
       const parentId = tree.dataset.parentId;
 
+      // Mark this creative as destroyed to prevent any future saves (including
+      // Lexical onChange callbacks that may fire after deletion)
+      destroyedCreativeIds.add(String(id));
+
       // CRITICAL: Remove any pending saves for this creative from the queue
-      // This prevents a race condition where a queued save fires after deletion,
-      // resulting in a 404 error and an alert to the user.
       if (apiQueue) {
         apiQueue.removeByDedupeKey(`creative_${id}`);
       }
@@ -1580,6 +1590,9 @@ export function initializeCreativeRowEditor() {
         } else {
           document.getElementById("creative-children-" + id)?.remove();
         }
+        // Clear dirty state so move() doesn't try to save the just-deleted creative
+        isDirty = false;
+        pendingSave = null;
         move(1);
         removeTreeElement(tree);
       });
@@ -1721,6 +1734,10 @@ export function initializeCreativeRowEditor() {
     }
 
     function scheduleSave() {
+      // Skip scheduling save for already-destroyed creatives
+      const creativeId = form.dataset?.creativeId;
+      if (creativeId && destroyedCreativeIds.has(String(creativeId))) return;
+
       pendingSave = true;
       clearTimeout(saveTimer);
       saveTimer = setTimeout(saveForm, 5000);

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -1313,11 +1313,26 @@ export function initializeCreativeRowEditor() {
         }
       };
 
+      // Notify editing stopped on previous creative
+      const prevCreativeId = prev.dataset?.id || form.dataset?.creativeId;
+      if (prevCreativeId) {
+        document.dispatchEvent(new CustomEvent('creative-editing:stop', {
+          detail: { creativeId: parseInt(prevCreativeId, 10) }
+        }));
+      }
+
       if (wasNew) {
         // For new creatives, still need to save or cleanup
         beforeNewOrMove(wasNew, prev, prevParent).then(() => {
           loadCreative(target);
           focusAfterMove();
+          // Notify editing started on new creative
+          const newCreativeId = target.dataset?.id || currentRowElement?.getAttribute('creative-id');
+          if (newCreativeId) {
+            document.dispatchEvent(new CustomEvent('creative-editing:start', {
+              detail: { creativeId: parseInt(newCreativeId, 10) }
+            }));
+          }
         });
       } else {
         // For existing creatives, show the row and refresh if needed
@@ -1326,6 +1341,13 @@ export function initializeCreativeRowEditor() {
         }
         loadCreative(target);
         focusAfterMove();
+        // Notify editing started on new creative
+        const newCreativeId = target.dataset?.id || currentRowElement?.getAttribute('creative-id');
+        if (newCreativeId) {
+          document.dispatchEvent(new CustomEvent('creative-editing:start', {
+            detail: { creativeId: parseInt(newCreativeId, 10) }
+          }));
+        }
       }
       updateActionButtonStates();
     }
@@ -1352,6 +1374,14 @@ export function initializeCreativeRowEditor() {
         } else {
           queueSaveIfDirty(prev);
         }
+      }
+
+      // Notify editing stopped on previous creative
+      const prevEditId = prev.dataset?.id || form.dataset?.creativeId;
+      if (prevEditId) {
+        document.dispatchEvent(new CustomEvent('creative-editing:stop', {
+          detail: { creativeId: parseInt(prevEditId, 10) }
+        }));
       }
 
       const handleAddNew = () => {

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -753,6 +753,14 @@ export function initializeCreativeRowEditor() {
       template.style.display = 'block';
       loadCreative(tree);
       updateActionButtonStates();
+
+      // Notify sync controller that editing started
+      const editCreativeId = form.dataset.creativeId || currentRowElement?.getAttribute('creative-id');
+      if (editCreativeId) {
+        document.dispatchEvent(new CustomEvent('creative-editing:start', {
+          detail: { creativeId: parseInt(editCreativeId, 10) }
+        }));
+      }
     }
 
     function initializeEventListeners() {
@@ -1063,6 +1071,15 @@ export function initializeCreativeRowEditor() {
       const tree = currentTree;
       const parentId = parentInput.value;
       const wasNew = !form.dataset.creativeId;
+
+      // Notify sync controller that editing stopped
+      const editCreativeId = form.dataset.creativeId;
+      if (editCreativeId) {
+        document.dispatchEvent(new CustomEvent('creative-editing:stop', {
+          detail: { creativeId: parseInt(editCreativeId, 10) }
+        }));
+      }
+
       currentTree = null;
       currentRowElement = null;
       tree.draggable = true;

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -157,6 +157,10 @@ export function initializeCreativeRowEditor() {
         editingPingInterval = null;
       }
     }
+
+    // Clean up editing ping on Turbo navigation to prevent interval leak
+    document.addEventListener('turbo:before-cache', () => stopEditingPing());
+
     const destroyedCreativeIds = new Set();
 
     function formatProgressDisplay(value) {

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -149,6 +149,14 @@ export function initializeCreativeRowEditor() {
     let originalOriginId = '';
     let isDirty = false;
     let completionCascadePending = false;
+    let editingPingInterval = null;
+
+    function stopEditingPing() {
+      if (editingPingInterval) {
+        clearInterval(editingPingInterval);
+        editingPingInterval = null;
+      }
+    }
     const destroyedCreativeIds = new Set();
 
     function formatProgressDisplay(value) {
@@ -755,12 +763,19 @@ export function initializeCreativeRowEditor() {
       loadCreative(tree);
       updateActionButtonStates();
 
-      // Notify sync controller that editing started
+      // Notify sync controller that editing started + periodic ping
       const editCreativeId = form.dataset.creativeId || currentRowElement?.getAttribute('creative-id');
       if (editCreativeId) {
+        const parsedId = parseInt(editCreativeId, 10);
         document.dispatchEvent(new CustomEvent('creative-editing:start', {
-          detail: { creativeId: parseInt(editCreativeId, 10) }
+          detail: { creativeId: parsedId }
         }));
+        if (editingPingInterval) clearInterval(editingPingInterval);
+        editingPingInterval = setInterval(() => {
+          document.dispatchEvent(new CustomEvent('creative-editing:start', {
+            detail: { creativeId: parsedId }
+          }));
+        }, 3000);
       }
     }
 
@@ -1074,6 +1089,7 @@ export function initializeCreativeRowEditor() {
       const wasNew = !form.dataset.creativeId;
 
       // Notify sync controller that editing stopped
+      stopEditingPing();
       const editCreativeId = form.dataset.creativeId;
       if (editCreativeId) {
         document.dispatchEvent(new CustomEvent('creative-editing:stop', {
@@ -1322,6 +1338,7 @@ export function initializeCreativeRowEditor() {
       };
 
       // Notify editing stopped on previous creative
+      stopEditingPing();
       const prevCreativeId = prev.dataset?.id || form.dataset?.creativeId;
       if (prevCreativeId) {
         document.dispatchEvent(new CustomEvent('creative-editing:stop', {
@@ -1334,12 +1351,19 @@ export function initializeCreativeRowEditor() {
         beforeNewOrMove(wasNew, prev, prevParent).then(() => {
           loadCreative(target);
           focusAfterMove();
-          // Notify editing started on new creative
+          // Notify editing started on new creative + start ping
           const newCreativeId = target.dataset?.id || currentRowElement?.getAttribute('creative-id');
           if (newCreativeId) {
+            const parsedNewId = parseInt(newCreativeId, 10);
             document.dispatchEvent(new CustomEvent('creative-editing:start', {
-              detail: { creativeId: parseInt(newCreativeId, 10) }
+              detail: { creativeId: parsedNewId }
             }));
+            stopEditingPing();
+            editingPingInterval = setInterval(() => {
+              document.dispatchEvent(new CustomEvent('creative-editing:start', {
+                detail: { creativeId: parsedNewId }
+              }));
+            }, 3000);
           }
         });
       } else {
@@ -1349,12 +1373,19 @@ export function initializeCreativeRowEditor() {
         }
         loadCreative(target);
         focusAfterMove();
-        // Notify editing started on new creative
+        // Notify editing started on new creative + start ping
         const newCreativeId = target.dataset?.id || currentRowElement?.getAttribute('creative-id');
         if (newCreativeId) {
+          const parsedNewId = parseInt(newCreativeId, 10);
           document.dispatchEvent(new CustomEvent('creative-editing:start', {
-            detail: { creativeId: parseInt(newCreativeId, 10) }
+            detail: { creativeId: parsedNewId }
           }));
+          stopEditingPing();
+          editingPingInterval = setInterval(() => {
+            document.dispatchEvent(new CustomEvent('creative-editing:start', {
+              detail: { creativeId: parsedNewId }
+            }));
+          }, 3000);
         }
       }
       updateActionButtonStates();
@@ -1385,6 +1416,7 @@ export function initializeCreativeRowEditor() {
       }
 
       // Notify editing stopped on previous creative
+      stopEditingPing();
       const prevEditId = prev.dataset?.id || form.dataset?.creativeId;
       if (prevEditId) {
         document.dispatchEvent(new CustomEvent('creative-editing:stop', {

--- a/engines/collavre/app/javascript/services/creatives_channel.js
+++ b/engines/collavre/app/javascript/services/creatives_channel.js
@@ -7,11 +7,10 @@ const EDITING_TIMEOUT = 5000
  *
  * @param {number|string} rootId - The root creative ID to subscribe to
  * @param {object} callbacks
- * @param {function} callbacks.onCreated - Called when a creative is created
- * @param {function} callbacks.onUpdated - Called when a creative is updated
- * @param {function} callbacks.onDestroyed - Called when a creative is destroyed
+ * @param {function} callbacks.onConnected - Called when connected
+ * @param {function} callbacks.onDisconnected - Called when disconnected
  * @param {function} callbacks.onPresence - Called with { user_ids: [...] }
- * @param {function} callbacks.onEditing - Called with { creative_id, user_id, user_name }
+ * @param {function} callbacks.onEditing - Called with { creative_id, user_id, user_name, avatar_url }
  * @param {function} callbacks.onStoppedEditing - Called with { creative_id, user_id }
  * @returns {object} subscription object with .unsubscribe() and action methods
  */
@@ -28,19 +27,8 @@ export function subscribeToCreatives(rootId, callbacks = {}) {
         callbacks.onDisconnected?.()
       },
       received(data) {
-        if (data.action) {
-          switch (data.action) {
-            case 'created':
-              callbacks.onCreated?.(data)
-              break
-            case 'updated':
-              callbacks.onUpdated?.(data)
-              break
-            case 'destroyed':
-              callbacks.onDestroyed?.(data)
-              break
-          }
-        }
+        // NOTE: CRUD sync is handled via Turbo Streams (refresh_creative_tree action),
+        // not through this ActionCable channel. This channel handles only presence + editing.
 
         if (data.presence) {
           callbacks.onPresence?.(data.presence)

--- a/engines/collavre/app/javascript/services/creatives_channel.js
+++ b/engines/collavre/app/javascript/services/creatives_channel.js
@@ -19,7 +19,7 @@ export function subscribeToCreatives(rootId, callbacks = {}) {
   const editingTimers = {}
 
   const subscription = createSubscription(
-    { channel: 'CreativesChannel', root_id: rootId },
+    { channel: 'Collavre::CreativesChannel', root_id: rootId },
     {
       connected() {
         callbacks.onConnected?.()

--- a/engines/collavre/app/javascript/services/creatives_channel.js
+++ b/engines/collavre/app/javascript/services/creatives_channel.js
@@ -1,0 +1,89 @@
+import { createSubscription } from './cable'
+
+const EDITING_TIMEOUT = 5000
+
+/**
+ * Subscribe to real-time creative tree updates.
+ *
+ * @param {number|string} rootId - The root creative ID to subscribe to
+ * @param {object} callbacks
+ * @param {function} callbacks.onCreated - Called when a creative is created
+ * @param {function} callbacks.onUpdated - Called when a creative is updated
+ * @param {function} callbacks.onDestroyed - Called when a creative is destroyed
+ * @param {function} callbacks.onPresence - Called with { user_ids: [...] }
+ * @param {function} callbacks.onEditing - Called with { creative_id, user_id, user_name }
+ * @param {function} callbacks.onStoppedEditing - Called with { creative_id, user_id }
+ * @returns {object} subscription object with .unsubscribe() and action methods
+ */
+export function subscribeToCreatives(rootId, callbacks = {}) {
+  const editingTimers = {}
+
+  const subscription = createSubscription(
+    { channel: 'CreativesChannel', root_id: rootId },
+    {
+      connected() {
+        callbacks.onConnected?.()
+      },
+      disconnected() {
+        callbacks.onDisconnected?.()
+      },
+      received(data) {
+        if (data.action) {
+          switch (data.action) {
+            case 'created':
+              callbacks.onCreated?.(data)
+              break
+            case 'updated':
+              callbacks.onUpdated?.(data)
+              break
+            case 'destroyed':
+              callbacks.onDestroyed?.(data)
+              break
+          }
+        }
+
+        if (data.presence) {
+          callbacks.onPresence?.(data.presence)
+        }
+
+        if (data.editing) {
+          const { creative_id, user_id } = data.editing
+          // Auto-clear editing after timeout
+          const timerKey = `${creative_id}-${user_id}`
+          if (editingTimers[timerKey]) clearTimeout(editingTimers[timerKey])
+          editingTimers[timerKey] = setTimeout(() => {
+            callbacks.onStoppedEditing?.({ creative_id, user_id })
+            delete editingTimers[timerKey]
+          }, EDITING_TIMEOUT)
+          callbacks.onEditing?.(data.editing)
+        }
+
+        if (data.stopped_editing) {
+          const { creative_id, user_id } = data.stopped_editing
+          const timerKey = `${creative_id}-${user_id}`
+          if (editingTimers[timerKey]) {
+            clearTimeout(editingTimers[timerKey])
+            delete editingTimers[timerKey]
+          }
+          callbacks.onStoppedEditing?.(data.stopped_editing)
+        }
+      },
+    },
+  )
+
+  // Extend subscription with convenience methods
+  subscription.sendEditing = (creativeId) => {
+    subscription.perform('editing', { creative_id: creativeId })
+  }
+
+  subscription.sendStoppedEditing = (creativeId) => {
+    subscription.perform('stopped_editing', { creative_id: creativeId })
+  }
+
+  subscription.cleanup = () => {
+    Object.values(editingTimers).forEach((timer) => clearTimeout(timer))
+    subscription.unsubscribe()
+  }
+
+  return subscription
+}

--- a/engines/collavre/app/jobs/collavre/creative_broadcast_job.rb
+++ b/engines/collavre/app/jobs/collavre/creative_broadcast_job.rb
@@ -157,29 +157,47 @@ module Collavre
       progress = creative.progress || 0
       pct = (progress * 100).round
 
-      # Generate signed stream name for turbo-cable-stream-source
-      stream_name = Turbo::StreamsChannel.signed_stream_name([ user, origin, :comment_badge ])
-      stream_tag = %(<turbo-cable-stream-source channel="Turbo::StreamsChannel" signed-stream-name="#{stream_name}"></turbo-cable-stream-source>)
-
-      # Badge (hidden, no comments yet)
-      badge_id = "comment-badge-#{origin.id}"
-      badge = %(<span id="#{badge_id}" class="badge" style="display:none" data-count="0" data-controller="comment-badge" data-comment-badge-has-comments-value="false"></span>)
-
-      # Comment button (hidden via no-comments)
-      comment_icon = read_svg("comment.svg", class: "comment-icon")
-      comment_btn = %(<button name="show-comments-btn" class="comments-btn creative-action-btn no-comments" data-creative-id="#{creative.id}" data-can-comment="true" data-creative-snippet="#{ERB::Util.html_escape(creative.creative_snippet)}">)
-      comment_btn += %(#{comment_icon}#{badge}</button>)
-
-      # Progress span
+      # Progress span (comes first, matching helper output order)
       css_class = pct >= 100 ? "creative-progress-complete" : "creative-progress-incomplete"
       display_text = pct >= 100 && user.completion_mark.present? ? user.completion_mark : "#{pct}%"
       progress_span = %(<span class="#{css_class}">#{display_text}</span>)
 
-      # Wrap in creative-row-end div (matching helper output structure)
-      %(<div class="creative-row-end">#{stream_tag}#{comment_btn}#{progress_span}</div>)
+      # Comment part — only render if user has feedback permission (matching helper behavior)
+      comment_part = ""
+      if creative.has_permission?(user, :feedback) ||
+         permission_via_ancestors(creative, user, :feedback)
+        # Generate signed stream name for turbo-cable-stream-source
+        stream_name = Turbo::StreamsChannel.signed_stream_name([ user, origin, :comment_badge ])
+        stream_tag = %(<turbo-cable-stream-source channel="Turbo::StreamsChannel" signed-stream-name="#{stream_name}"></turbo-cable-stream-source>)
+
+        # Badge (no comments yet — hidden)
+        badge_id = "comment-badge-#{origin.id}"
+        badge = %(<span id="#{badge_id}" class="badge" style="display:none" data-count="0" data-controller="comment-badge" data-comment-badge-has-comments-value="false"></span>)
+
+        # Comment button — no-comments hides via visibility:hidden (0 comments initially)
+        comment_icon = read_svg("comment.svg", class: "comment-icon")
+        btn_classes = "comments-btn creative-action-btn no-comments"
+        comment_btn = %(<button name="show-comments-btn" class="#{btn_classes}" data-creative-id="#{creative.id}" data-can-comment="true" data-creative-snippet="#{ERB::Util.html_escape(creative.creative_snippet)}">)
+        comment_btn += %(#{comment_icon}#{badge}</button>)
+
+        comment_part = "#{stream_tag}#{comment_btn}"
+      end
+
+      # Wrap in creative-row-end div — order: progress, then comment (matching helper)
+      %(<div class="creative-row-end">#{progress_span}#{comment_part}</div>)
     rescue StandardError => e
       Rails.logger.warn "[CreativeBroadcastJob] render_progress_html failed for creative##{creative.id} user##{user.id}: #{e.message}"
       nil
+    end
+
+    # Check permission via ancestor chain (fallback when creative_shares_caches is not yet populated)
+    def permission_via_ancestors(creative, user, permission)
+      current = creative.parent
+      while current
+        return true if current.has_permission?(user, permission)
+        current = current.parent
+      end
+      false
     end
 
     def read_svg(name, options = {})

--- a/engines/collavre/app/jobs/collavre/creative_broadcast_job.rb
+++ b/engines/collavre/app/jobs/collavre/creative_broadcast_job.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+module Collavre
+  # Asynchronous broadcast for creative CRUD changes.
+  # Offloads per-user payload building and WebSocket delivery from the request cycle.
+  class CreativeBroadcastJob < ApplicationJob
+    queue_as :default
+
+    # @param creative_id [Integer]
+    # @param action [String] "created", "updated", or "destroyed"
+    # @param current_user_id [Integer, nil] user who triggered the change (excluded from broadcast)
+    # @param payload [Hash] pre-built node payload (for created/updated) or destroy payload
+    # @param options [Hash] extra options (after_id, destroy_users, destroy_linked_map)
+    def perform(creative_id, action, current_user_id: nil, payload: {}, options: {})
+      creative = Creative.find_by(id: creative_id)
+
+      case action
+      when "created", "updated"
+        return unless creative
+
+        broadcast_change(creative, action, current_user_id, payload.deep_symbolize_keys)
+      when "destroyed"
+        broadcast_destroyed(
+          creative_id,
+          current_user_id,
+          payload.deep_symbolize_keys,
+          options.deep_symbolize_keys
+        )
+      end
+    rescue StandardError => e
+      Rails.logger.error "[CreativeBroadcastJob] ERROR #{action} creative##{creative_id}: #{e.message}\n#{e.backtrace.first(5).join("\n")}"
+    end
+
+    private
+
+    def broadcast_change(creative, action, current_user_id, data)
+      target_users = creative.send(:find_broadcast_users)
+      target_users.reject! { |u| current_user_id && u.id == current_user_id }
+      return if target_users.empty?
+
+      linked_map = creative.send(:build_linked_creative_map, target_users)
+
+      # Batch-load all linked creatives for remapping (avoids N+1)
+      origin_ids_to_remap = [ data[:parent_id], data[:after_id], data[:previous_sibling_id] ].compact
+      ancestor_origin_ids = (data[:ancestors] || []).map { |a| a[:id] }.compact
+      all_origin_ids = (origin_ids_to_remap + ancestor_origin_ids).uniq
+
+      linked_by_user = {}
+      if all_origin_ids.any?
+        Creative.where(origin_id: all_origin_ids, user: target_users).find_each do |linked|
+          linked_by_user[linked.user_id] ||= {}
+          linked_by_user[linked.user_id][linked.origin_id] = linked.id
+        end
+      end
+
+      target_users.each do |target_user|
+        user_data = data.dup
+        user_map = linked_by_user[target_user.id] || {}
+
+        # Add linked_id
+        linked_id = linked_map[target_user.id]
+        user_data[:linked_id] = linked_id if linked_id
+
+        # Remap IDs using batch-loaded map
+        user_data[:parent_id] = user_map[user_data[:parent_id]] || user_data[:parent_id] if user_data[:parent_id]
+        user_data[:after_id] = user_map[user_data[:after_id]] || user_data[:after_id] if user_data[:after_id]
+        if user_data[:previous_sibling_id]
+          user_data[:previous_sibling_id] = user_map[user_data[:previous_sibling_id]] || user_data[:previous_sibling_id]
+        end
+
+        # Remap ancestor IDs
+        if user_data[:ancestors].present?
+          user_data[:ancestors] = user_data[:ancestors].map do |anc|
+            mapped_id = user_map[anc[:id]]
+            mapped_id ? anc.merge(id: mapped_id, origin_id: anc[:id]) : anc
+          end
+        end
+
+        # Per-user progress text
+        creative.send(:add_progress_text!, user_data, target_user)
+
+        json_payload = { action: action.to_s, creative: user_data }.to_json
+        Turbo::StreamsChannel.broadcast_action_to(
+          [ target_user, :creative_tree ],
+          action: :refresh_creative_tree,
+          target: "creatives",
+          attributes: { data: json_payload }
+        )
+      end
+    end
+
+    def broadcast_destroyed(creative_id, current_user_id, payload, options)
+      user_ids = options[:destroy_user_ids] || []
+      return if user_ids.empty?
+
+      users = User.where(id: user_ids)
+      users = users.reject { |u| current_user_id && u.id == current_user_id }
+      return if users.empty?
+
+      linked_map = (options[:destroy_linked_map] || {}).transform_keys(&:to_i)
+
+      # Batch-load linked creatives for ancestor remapping
+      ancestor_origin_ids = (payload[:ancestors] || []).map { |a| a[:id] }.compact
+      all_origin_ids = [ payload[:parent_id], *ancestor_origin_ids ].compact.uniq
+
+      linked_by_user = {}
+      if all_origin_ids.any?
+        Creative.where(origin_id: all_origin_ids, user: users).find_each do |linked|
+          linked_by_user[linked.user_id] ||= {}
+          linked_by_user[linked.user_id][linked.origin_id] = linked.id
+        end
+      end
+
+      users.each do |target_user|
+        user_data = payload.dup
+        user_map = linked_by_user[target_user.id] || {}
+
+        user_data[:linked_id] = linked_map[target_user.id] if linked_map[target_user.id]
+        user_data[:parent_id] = user_map[user_data[:parent_id]] || user_data[:parent_id] if user_data[:parent_id]
+
+        if user_data[:ancestors].present?
+          user_data[:ancestors] = user_data[:ancestors].map do |anc|
+            mapped_id = user_map[anc[:id]]
+            mapped_id ? anc.merge(id: mapped_id, origin_id: anc[:id]) : anc
+          end
+        end
+
+        json_payload = { action: "destroyed", creative: user_data }.to_json
+        Turbo::StreamsChannel.broadcast_action_to(
+          [ target_user, :creative_tree ],
+          action: :refresh_creative_tree,
+          target: "creatives",
+          attributes: { data: json_payload }
+        )
+      end
+    end
+  end
+end

--- a/engines/collavre/app/jobs/collavre/creative_broadcast_job.rb
+++ b/engines/collavre/app/jobs/collavre/creative_broadcast_job.rb
@@ -78,6 +78,9 @@ module Collavre
           end
         end
 
+        # Per-user can_write permission
+        user_data[:can_write] = creative.has_permission?(target_user, :write)
+
         # Per-user progress text
         creative.send(:add_progress_text!, user_data, target_user)
 
@@ -86,7 +89,9 @@ module Collavre
         # Existing rows already have this from server render; only new rows need it.
         if action == "created"
           user_data[:templates] ||= {}
-          user_data[:templates][:progress_html] = render_progress_html(creative, target_user)
+          # target_user already passed find_broadcast_users permission check,
+          # so we can skip the expensive permission_via_ancestors walk.
+          user_data[:templates][:progress_html] = render_progress_html(creative, target_user, skip_permission_check: true)
         end
 
         json_payload = { action: action.to_s, creative: user_data }.to_json
@@ -152,7 +157,7 @@ module Collavre
     # - turbo-cable-stream-source (per-user subscription for badge updates)
     # - comment button (hidden via no-comments class — 0 comments initially)
     # - progress span
-    def render_progress_html(creative, user)
+    def render_progress_html(creative, user, skip_permission_check: false)
       origin = creative.effective_origin
       progress = creative.progress || 0
       pct = (progress * 100).round
@@ -163,9 +168,14 @@ module Collavre
       progress_span = %(<span class="#{css_class}">#{display_text}</span>)
 
       # Comment part — only render if user has feedback permission (matching helper behavior)
+      # When skip_permission_check is true, the user was already verified by find_broadcast_users
+      # (which checks :read permission on target + ancestors). Feedback permission is a subset
+      # of read permission in practice, so we can safely render the comment button.
       comment_part = ""
-      if creative.has_permission?(user, :feedback) ||
-         permission_via_ancestors(creative, user, :feedback)
+      has_feedback = skip_permission_check ||
+                     creative.has_permission?(user, :feedback) ||
+                     permission_via_ancestors(creative, user, :feedback)
+      if has_feedback
         # Generate signed stream name for turbo-cable-stream-source
         stream_name = Turbo::StreamsChannel.signed_stream_name([ user, origin, :comment_badge ])
         stream_tag = %(<turbo-cable-stream-source channel="Turbo::StreamsChannel" signed-stream-name="#{stream_name}"></turbo-cable-stream-source>)
@@ -201,14 +211,23 @@ module Collavre
     end
 
     def read_svg(name, options = {})
-      path = Rails.root.join("app", "assets", "images", name)
-      return "" unless File.exist?(path)
+      raw = self.class.svg_cache[name] ||= begin
+        path = Rails.root.join("app", "assets", "images", name)
+        File.exist?(path) ? File.read(path) : ""
+      end
+      return "" if raw.blank?
 
-      svg = File.read(path)
+      svg = raw.dup
       if options[:class]
         svg.sub!(/<svg\b/, %(<svg class="#{options[:class]}"))
       end
       svg.html_safe # rubocop:disable Rails/OutputSafety
+    end
+
+    class << self
+      def svg_cache
+        @svg_cache ||= {}
+      end
     end
   end
 end

--- a/engines/collavre/app/jobs/collavre/creative_broadcast_job.rb
+++ b/engines/collavre/app/jobs/collavre/creative_broadcast_job.rb
@@ -5,6 +5,8 @@ module Collavre
   # Offloads per-user payload building and WebSocket delivery from the request cycle.
   class CreativeBroadcastJob < ApplicationJob
     queue_as :default
+    retry_on StandardError, wait: 1.second, attempts: 3
+    discard_on ActiveRecord::RecordNotFound
 
     # @param creative_id [Integer]
     # @param action [String] "created", "updated", or "destroyed"

--- a/engines/collavre/app/jobs/collavre/creative_broadcast_job.rb
+++ b/engines/collavre/app/jobs/collavre/creative_broadcast_job.rb
@@ -81,6 +81,14 @@ module Collavre
         # Per-user progress text
         creative.send(:add_progress_text!, user_data, target_user)
 
+        # For created action, render per-user progress_html (includes chat button,
+        # badge with turbo-cable-stream-source subscription, and progress span).
+        # Existing rows already have this from server render; only new rows need it.
+        if action == "created"
+          user_data[:templates] ||= {}
+          user_data[:templates][:progress_html] = render_progress_html(creative, target_user)
+        end
+
         json_payload = { action: action.to_s, creative: user_data }.to_json
         Turbo::StreamsChannel.broadcast_action_to(
           [ target_user, :creative_tree ],
@@ -135,6 +143,54 @@ module Collavre
           attributes: { data: json_payload }
         )
       end
+    end
+
+    # Build progress HTML for a newly created creative.
+    # New creatives always have 0 comments and initial progress, so we can
+    # construct the HTML directly without a full view render.
+    # Includes:
+    # - turbo-cable-stream-source (per-user subscription for badge updates)
+    # - comment button (hidden via no-comments class — 0 comments initially)
+    # - progress span
+    def render_progress_html(creative, user)
+      origin = creative.effective_origin
+      progress = creative.progress || 0
+      pct = (progress * 100).round
+
+      # Generate signed stream name for turbo-cable-stream-source
+      stream_name = Turbo::StreamsChannel.signed_stream_name([ user, origin, :comment_badge ])
+      stream_tag = %(<turbo-cable-stream-source channel="Turbo::StreamsChannel" signed-stream-name="#{stream_name}"></turbo-cable-stream-source>)
+
+      # Badge (hidden, no comments yet)
+      badge_id = "comment-badge-#{origin.id}"
+      badge = %(<span id="#{badge_id}" class="badge" style="display:none" data-count="0" data-controller="comment-badge" data-comment-badge-has-comments-value="false"></span>)
+
+      # Comment button (hidden via no-comments)
+      comment_icon = read_svg("comment.svg", class: "comment-icon")
+      comment_btn = %(<button name="show-comments-btn" class="comments-btn creative-action-btn no-comments" data-creative-id="#{creative.id}" data-can-comment="true" data-creative-snippet="#{ERB::Util.html_escape(creative.creative_snippet)}">)
+      comment_btn += %(#{comment_icon}#{badge}</button>)
+
+      # Progress span
+      css_class = pct >= 100 ? "creative-progress-complete" : "creative-progress-incomplete"
+      display_text = pct >= 100 && user.completion_mark.present? ? user.completion_mark : "#{pct}%"
+      progress_span = %(<span class="#{css_class}">#{display_text}</span>)
+
+      # Wrap in creative-row-end div (matching helper output structure)
+      %(<div class="creative-row-end">#{stream_tag}#{comment_btn}#{progress_span}</div>)
+    rescue StandardError => e
+      Rails.logger.warn "[CreativeBroadcastJob] render_progress_html failed for creative##{creative.id} user##{user.id}: #{e.message}"
+      nil
+    end
+
+    def read_svg(name, options = {})
+      path = Rails.root.join("app", "assets", "images", name)
+      return "" unless File.exist?(path)
+
+      svg = File.read(path)
+      if options[:class]
+        svg.sub!(/<svg\b/, %(<svg class="#{options[:class]}"))
+      end
+      svg.html_safe # rubocop:disable Rails/OutputSafety
     end
   end
 end

--- a/engines/collavre/app/models/collavre/comment/broadcastable.rb
+++ b/engines/collavre/app/models/collavre/comment/broadcastable.rb
@@ -36,7 +36,9 @@ module Collavre
           last_read_ids = pointers.transform_values { |p| p.last_read_comment_id || 0 }
 
           unread_public_by_threshold = {}
-          last_read_ids.values.uniq.each do |threshold|
+          # Include 0 for users without a read pointer (never opened chat)
+          all_thresholds = (last_read_ids.values + [ 0 ]).uniq
+          all_thresholds.each do |threshold|
             unread_public_by_threshold[threshold] = origin.comments
               .where(private: false)
               .where("comments.id > ?", threshold)

--- a/engines/collavre/app/models/collavre/creative.rb
+++ b/engines/collavre/app/models/collavre/creative.rb
@@ -16,6 +16,7 @@ module Collavre
     include Linkable
     include Permissible
     include Describable
+    include RealtimeBroadcastable
 
     has_many :comments, class_name: "Collavre::Comment", dependent: :destroy
     has_many :comment_read_pointers, class_name: "Collavre::CommentReadPointer", dependent: :delete_all

--- a/engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb
+++ b/engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb
@@ -13,9 +13,12 @@ module Collavre
       end
 
       # Public: called from CreateService after insert_at_position
-      def broadcast_creative_created
-        Rails.logger.info "[CreativeBroadcast] === broadcast_creative_created for creative##{id} seq=#{sequence} ==="
-        broadcast_creative_change(:created, broadcast_node_payload)
+      # @param after_id [Integer, nil] the creative ID this was inserted after (from user action)
+      def broadcast_creative_created(after_id: nil)
+        Rails.logger.info "[CreativeBroadcast] === broadcast_creative_created for creative##{id} seq=#{sequence} after_id=#{after_id} ==="
+        payload = broadcast_node_payload
+        payload[:after_id] = after_id.presence&.to_i
+        broadcast_creative_change(:created, payload)
       rescue StandardError => e
         Rails.logger.error "[CreativeBroadcast] ERROR in broadcast_creative_created: #{e.message}\n#{e.backtrace.first(5).join("\n")}"
       end

--- a/engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb
+++ b/engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb
@@ -24,8 +24,8 @@ module Collavre
       end
 
       def broadcast_creative_change(action)
-        root = find_broadcast_root
-        return unless root
+        roots = find_broadcast_roots
+        return if roots.empty?
 
         payload = { action: action.to_s }
 
@@ -37,17 +37,22 @@ module Collavre
           payload[:ancestors] = broadcast_ancestor_data
         end
 
-        CreativesChannel.broadcast_to(root, payload)
+        # Broadcast to every ancestor so any viewer at any level receives it
+        Rails.logger.info "[CreativeBroadcast] #{action} creative #{id} -> broadcasting to #{roots.map(&:id)}"
+        roots.each do |root|
+          CreativesChannel.broadcast_to(root, payload)
+        end
       end
 
-      def find_broadcast_root
-        # For linked creatives, broadcast to the origin's root
+      def find_broadcast_roots
         target = origin_id.present? ? (origin || self) : self
-        # Walk up to the root using closure_tree
-        root = target.root
-        root&.effective_origin
+        # Broadcast to self + all ancestors, so anyone viewing any
+        # level of the tree will receive the update
+        ([target] + target.ancestors).filter_map do |creative|
+          creative.effective_origin
+        end.uniq
       rescue ActiveRecord::RecordNotFound
-        nil
+        []
       end
 
       def broadcast_creative_data

--- a/engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb
+++ b/engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb
@@ -53,6 +53,8 @@ module Collavre
           dom_id: "creative-#{id}",
           parent_id: parent_id,
           level: ancestors.size + 1,
+          select_mode: false,
+          can_write: true, # Refined per-user in JS if needed
           has_children: children.exists?,
           expanded: false,
           is_root: parent.nil?,

--- a/engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb
+++ b/engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb
@@ -35,15 +35,21 @@ module Collavre
 
       def capture_broadcast_state
         # Skip expensive queries for unshared personal creatives
-        return if !origin_id && linked_creatives.none? && all_shared_users.none?
+        if !origin_id && linked_creatives.none? && all_shared_users.none?
+          return
+        end
 
         # Capture before destroy — after destroy, associations are gone
         @_destroy_broadcast_users = find_broadcast_users
         @_destroy_linked_map = build_linked_creative_map(@_destroy_broadcast_users)
+
+        # ancestors may be empty if closure_tree already deleted hierarchy rows,
+        # so fall back to parent_id chain
+        ancestor_list = ancestors.presence || Creative.where(id: build_ancestor_ids_from_parent(self))
         @_destroy_payload = {
           id: id,
           parent_id: parent_id,
-          ancestors: ancestors.map { |a| { id: a.id, progress: a.progress } }
+          ancestors: ancestor_list.map { |a| { id: a.id, progress: a.progress } }
         }
       end
 
@@ -178,6 +184,19 @@ module Collavre
         end
       end
 
+      # Fallback: walk parent_id chain when closure_tree hierarchy is unavailable
+      # (e.g. during before_destroy when hierarchy rows are already deleted)
+      def build_ancestor_ids_from_parent(creative)
+        ids = []
+        current = creative
+        while current.parent_id.present?
+          ids << current.parent_id
+          current = Creative.find_by(id: current.parent_id)
+          break unless current
+        end
+        ids
+      end
+
       def find_broadcast_users
         target = begin
           origin_id.present? && origin ? origin.effective_origin : effective_origin
@@ -186,7 +205,13 @@ module Collavre
         end
 
         # Batch: collect all ancestor IDs + target in one query, then load shares in one query
+        # NOTE: ancestor_ids uses closure_tree's hierarchy table, but during before_destroy
+        # the hierarchy rows may already be deleted by closure_tree's own before_destroy callback.
+        # Fallback to parent_id chain when ancestor_ids returns empty for a creative with parent.
         ancestor_ids = target.ancestor_ids  # closure_tree: single CTE query
+        if ancestor_ids.empty? && target.parent_id.present?
+          ancestor_ids = build_ancestor_ids_from_parent(target)
+        end
         all_creative_ids = [ target.id ] + ancestor_ids
 
         # Owner users — single query

--- a/engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb
+++ b/engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb
@@ -53,6 +53,11 @@ module Collavre
           user_data = @_destroy_payload.dup
           linked_id = @_destroy_linked_map[target_user.id]
           user_data[:linked_id] = linked_id if linked_id
+          # Remap parent_id for this user
+          if user_data[:parent_id].present?
+            linked_parent = Creative.find_by(origin_id: user_data[:parent_id], user: target_user)
+            user_data[:parent_id] = linked_parent.id if linked_parent
+          end
           if user_data[:ancestors].present?
             user_data[:ancestors] = remap_ancestor_ids(user_data[:ancestors], target_user)
           end
@@ -82,7 +87,22 @@ module Collavre
           # Add linked_id for this user's linked creative (if any)
           linked_id = linked_map[target_user.id]
           user_data[:linked_id] = linked_id if linked_id
-          # Also remap ancestor IDs to linked IDs for this user
+          # Remap parent_id to linked parent for this user
+          if user_data[:parent_id].present?
+            linked_parent = Creative.find_by(origin_id: user_data[:parent_id], user: target_user)
+            user_data[:parent_id] = linked_parent.id if linked_parent
+          end
+          # Remap after_id to linked sibling for this user
+          if user_data[:after_id].present?
+            linked_after = Creative.find_by(origin_id: user_data[:after_id], user: target_user)
+            user_data[:after_id] = linked_after.id if linked_after
+          end
+          # Remap previous_sibling_id to linked sibling for this user
+          if user_data[:previous_sibling_id].present?
+            linked_prev = Creative.find_by(origin_id: user_data[:previous_sibling_id], user: target_user)
+            user_data[:previous_sibling_id] = linked_prev.id if linked_prev
+          end
+          # Remap ancestor IDs to linked IDs for this user
           if user_data[:ancestors].present?
             user_data[:ancestors] = remap_ancestor_ids(user_data[:ancestors], target_user)
           end

--- a/engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb
+++ b/engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb
@@ -49,7 +49,7 @@ module Collavre
           self
         end
 
-        {
+        data = {
           id: id,
           parent_id: parent_id,
           origin_id: origin_id,
@@ -58,6 +58,13 @@ module Collavre
           description_raw_html: description,
           has_children: children.exists?
         }
+
+        # Include ancestor progress updates so clients can update
+        # parent rows without a full tree refetch
+        anc_progress = ancestors.map { |a| { id: a.id, progress: a.progress } }
+        data[:ancestors] = anc_progress if anc_progress.any?
+
+        data
       end
 
       def find_broadcast_users

--- a/engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb
+++ b/engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb
@@ -86,12 +86,15 @@ module Collavre
         desc_html = origin.effective_description
         desc_raw = description
 
+        # Reload ancestors to get latest progress (after update_parent_progress in after_save)
+        fresh_ancestors = self.class.find(id).ancestors
+
         {
           # Core node properties (tree_renderer.applyRowProperties)
           id: id,
           dom_id: "creative-#{id}",
           parent_id: parent_id,
-          level: ancestors.size + 1,
+          level: fresh_ancestors.size + 1,
           select_mode: false,
           can_write: true, # Refined per-user in JS if needed
           has_children: children.exists?,
@@ -115,7 +118,7 @@ module Collavre
             origin_id: origin_id
           },
           # Ancestors progress (for parent row updates)
-          ancestors: ancestors.map { |a| { id: a.id, progress: a.progress } }
+          ancestors: fresh_ancestors.map { |a| { id: a.id, progress: a.progress } }
         }
       end
 

--- a/engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb
+++ b/engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb
@@ -12,20 +12,19 @@ module Collavre
       private
 
       def broadcast_creative_created
-        broadcast_creative_change(:created, broadcast_payload)
+        broadcast_creative_change(:created, broadcast_node_payload)
       end
 
       def broadcast_creative_updated
-        broadcast_creative_change(:updated, broadcast_payload)
+        broadcast_creative_change(:updated, broadcast_node_payload)
       end
 
       def broadcast_creative_destroyed
-        broadcast_creative_change(:destroyed, { id: id, parent_id: parent_id })
+        broadcast_creative_change(:destroyed, broadcast_destroy_payload)
       end
 
       def broadcast_creative_change(action, data)
         target_users = find_broadcast_users
-        # Exclude the user who made the change — their UI already reflects it
         current = Collavre.current_user
         target_users.reject! { |u| current && u.id == current.id }
         return if target_users.empty?
@@ -42,29 +41,60 @@ module Collavre
         end
       end
 
-      def broadcast_payload
-        origin = begin
-          effective_origin
-        rescue StandardError
-          self
-        end
+      # Tree-renderer compatible node payload (matches TreeBuilder output)
+      def broadcast_node_payload
+        origin = safe_effective_origin
+        desc_html = origin.effective_description
+        desc_raw = description
 
-        data = {
+        {
+          # Core node properties (tree_renderer.applyRowProperties)
+          id: id,
+          dom_id: "creative-#{id}",
+          parent_id: parent_id,
+          level: ancestors.size + 1,
+          has_children: children.exists?,
+          expanded: false,
+          is_root: parent.nil?,
+          archived: archived?,
+          link_url: "/creatives?id=#{id}",
+          origin_id: origin_id,
+          # Templates (for display)
+          templates: {
+            description_html: desc_html,
+            progress_html: broadcast_progress_html
+          },
+          # Inline editor payload (for editor cache)
+          inline_editor_payload: {
+            description_raw_html: desc_raw,
+            progress: progress,
+            origin_id: origin_id
+          },
+          # Ancestors progress (for parent row updates)
+          ancestors: ancestors.map { |a| { id: a.id, progress: a.progress } }
+        }
+      end
+
+      def broadcast_destroy_payload
+        {
           id: id,
           parent_id: parent_id,
-          origin_id: origin_id,
-          progress: progress,
-          description_html: origin.effective_description,
-          description_raw_html: description,
-          has_children: children.exists?
+          ancestors: (ancestors.map { |a| { id: a.id, progress: a.progress } } rescue [])
         }
+      end
 
-        # Include ancestor progress updates so clients can update
-        # parent rows without a full tree refetch
-        anc_progress = ancestors.map { |a| { id: a.id, progress: a.progress } }
-        data[:ancestors] = anc_progress if anc_progress.any?
+      # Simple progress HTML without view_context dependencies
+      # Full progress_html (with comment badges etc.) requires view_context
+      # so we render a minimal version; the user's own save already has full rendering
+      def broadcast_progress_html
+        pct = progress || 0
+        %(<div class="creative-row-end"><span class="creative-progress">#{pct}%</span></div>)
+      end
 
-        data
+      def safe_effective_origin
+        effective_origin
+      rescue StandardError
+        self
       end
 
       def find_broadcast_users

--- a/engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb
+++ b/engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb
@@ -107,6 +107,9 @@ module Collavre
             user_data[:ancestors] = remap_ancestor_ids(user_data[:ancestors], target_user)
           end
 
+          # Add per-user progress text (completion mark differs per user)
+          add_progress_text!(user_data, target_user)
+
           payload = { action: action.to_s, creative: user_data }.to_json
           Turbo::StreamsChannel.broadcast_action_to(
             [ target_user, :creative_tree ],
@@ -159,22 +162,6 @@ module Collavre
         }
       end
 
-      def broadcast_destroy_payload
-        {
-          id: id,
-          parent_id: parent_id,
-          ancestors: (ancestors.map { |a| { id: a.id, progress: a.progress } } rescue [])
-        }
-      end
-
-      # Simple progress HTML without view_context dependencies
-      # Full progress_html (with comment badges etc.) requires view_context
-      # so we render a minimal version; the user's own save already has full rendering
-      def broadcast_progress_html
-        pct = ((progress || 0) * 100).round
-        %(<div class="creative-row-end"><span class="creative-progress">#{pct}%</span></div>)
-      end
-
       def safe_effective_origin
         effective_origin
       rescue StandardError
@@ -182,13 +169,8 @@ module Collavre
       end
 
       def previous_sibling
-        siblings = if parent
-                     parent.children.order(:sequence)
-        else
-                     Creative.roots.order(:sequence)
-        end
-        idx = siblings.to_a.index { |s| s.id == id }
-        idx && idx > 0 ? siblings.to_a[idx - 1] : nil
+        scope = parent ? parent.children : Creative.where(parent_id: nil)
+        scope.where("sequence < ?", sequence).order(sequence: :desc).first
       end
 
       # Build a map of user_id → linked_creative_id for this creative
@@ -205,6 +187,32 @@ module Collavre
       rescue StandardError => e
         Rails.logger.error "[CreativeBroadcast] Error building linked map: #{e.message}"
         {}
+      end
+
+      # Format progress text for a user (100% → completion mark if set)
+      # Matches render_progress_value helper: when value==1 and completion_mark is not nil,
+      # use it (even if blank — blank becomes non-breaking spaces in display)
+      def format_progress_text(progress_value, user)
+        pct = ((progress_value || 0) * 100).round
+        if pct >= 100 && !user.completion_mark.nil?
+          mark = user.completion_mark
+          mark.blank? ? "" : mark
+        else
+          "#{pct}%"
+        end
+      end
+
+      # Add per-user progress_text to payload and ancestors
+      def add_progress_text!(data, target_user)
+        # Main creative progress text
+        if data.dig(:inline_editor_payload, :progress)
+          data[:progress_text] = format_progress_text(data[:inline_editor_payload][:progress], target_user)
+        end
+
+        # Ancestor progress text
+        data[:ancestors]&.each do |anc|
+          anc[:progress_text] = format_progress_text(anc[:progress], target_user) if anc[:progress]
+        end
       end
 
       # Remap ancestor IDs to the user's linked creative IDs
@@ -229,16 +237,18 @@ module Collavre
           self
         end
 
-        users = []
-        users << target.user if target.user
-        users.concat(target.all_shared_users.map(&:user))
+        # Collect candidate users from target and its ancestors
+        candidates = Set.new
+        candidates << target.user if target.user
+        target.all_shared_users.each { |su| candidates << su.user }
 
         target.ancestors.each do |ancestor|
-          users << ancestor.user if ancestor.user
-          users.concat(ancestor.all_shared_users.map(&:user))
+          candidates << ancestor.user if ancestor.user
+          ancestor.all_shared_users.each { |su| candidates << su.user }
         end
 
-        users.compact.uniq
+        # Filter: only users who actually have read permission on this creative
+        candidates.compact.select { |user| target.has_permission?(user, :read) }.uniq
       rescue StandardError => e
         Rails.logger.error "[CreativeBroadcast] Error finding users: #{e.message}"
         []

--- a/engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb
+++ b/engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb
@@ -34,6 +34,9 @@ module Collavre
       end
 
       def capture_broadcast_state
+        # Skip expensive queries for unshared personal creatives
+        return if !origin_id && linked_creatives.none? && all_shared_users.none?
+
         # Capture before destroy — after destroy, associations are gone
         @_destroy_broadcast_users = find_broadcast_users
         @_destroy_linked_map = build_linked_creative_map(@_destroy_broadcast_users)
@@ -66,8 +69,8 @@ module Collavre
         desc_html = origin.effective_description
         desc_raw = description
 
-        # Reload ancestors to get latest progress (after update_parent_progress in after_save)
-        fresh_ancestors = self.class.find(id).ancestors
+        # Reload to get latest progress values (after update_parent_progress in after_save)
+        fresh_ancestors = reload.ancestors
 
         {
           # Core node properties (tree_renderer.applyRowProperties)

--- a/engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb
+++ b/engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb
@@ -131,7 +131,7 @@ module Collavre
       # Full progress_html (with comment badges etc.) requires view_context
       # so we render a minimal version; the user's own save already has full rendering
       def broadcast_progress_html
-        pct = (progress || 0).to_i
+        pct = ((progress || 0) * 100).round
         %(<div class="creative-row-end"><span class="creative-progress">#{pct}%</span></div>)
       end
 

--- a/engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb
+++ b/engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb
@@ -130,7 +130,7 @@ module Collavre
       # Full progress_html (with comment badges etc.) requires view_context
       # so we render a minimal version; the user's own save already has full rendering
       def broadcast_progress_html
-        pct = progress || 0
+        pct = (progress || 0).to_i
         %(<div class="creative-row-end"><span class="creative-progress">#{pct}%</span></div>)
       end
 

--- a/engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb
+++ b/engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb
@@ -6,30 +6,65 @@ module Collavre
       included do
         after_create_commit :broadcast_creative_created
         after_update_commit :broadcast_creative_updated
+        before_destroy :capture_broadcast_state
         after_destroy_commit :broadcast_creative_destroyed
       end
 
       private
 
       def broadcast_creative_created
+        Rails.logger.info "[CreativeBroadcast] === after_create_commit fired for creative##{id} ==="
         broadcast_creative_change(:created, broadcast_node_payload)
+      rescue StandardError => e
+        Rails.logger.error "[CreativeBroadcast] ERROR in broadcast_creative_created: #{e.message}\n#{e.backtrace.first(5).join("\n")}"
       end
 
       def broadcast_creative_updated
+        Rails.logger.info "[CreativeBroadcast] === after_update_commit fired for creative##{id} ==="
         broadcast_creative_change(:updated, broadcast_node_payload)
+      rescue StandardError => e
+        Rails.logger.error "[CreativeBroadcast] ERROR in broadcast_creative_updated: #{e.message}\n#{e.backtrace.first(5).join("\n")}"
+      end
+
+      def capture_broadcast_state
+        # Capture before destroy — after destroy, associations are gone
+        @_destroy_broadcast_users = find_broadcast_users
+        @_destroy_payload = {
+          id: id,
+          parent_id: parent_id,
+          ancestors: ancestors.map { |a| { id: a.id, progress: a.progress } }
+        }
       end
 
       def broadcast_creative_destroyed
-        broadcast_creative_change(:destroyed, broadcast_destroy_payload)
+        return if @_destroy_broadcast_users.blank?
+
+        current = Collavre.current_user
+        Rails.logger.info "[CreativeBroadcast] destroyed creative##{id} current_user=#{current&.email} target_users=#{@_destroy_broadcast_users.map(&:email)}"
+        users = @_destroy_broadcast_users.reject { |u| current && u.id == current.id }
+        return if users.empty?
+
+        payload = { action: "destroyed", creative: @_destroy_payload }.to_json
+
+        users.each do |target_user|
+          Turbo::StreamsChannel.broadcast_action_to(
+            [ target_user, :creative_tree ],
+            action: :refresh_creative_tree,
+            target: "creatives",
+            attributes: { data: payload }
+          )
+        end
       end
 
       def broadcast_creative_change(action, data)
         target_users = find_broadcast_users
         current = Collavre.current_user
+        Rails.logger.info "[CreativeBroadcast] #{action} creative##{data[:id]} current_user=#{current&.email} target_users=#{target_users.map(&:email)}"
         target_users.reject! { |u| current && u.id == current.id }
         return if target_users.empty?
 
         payload = { action: action.to_s, creative: data }.to_json
+        Rails.logger.info "[CreativeBroadcast] Broadcasting to #{target_users.map(&:email)} payload_size=#{payload.size}"
 
         target_users.each do |target_user|
           Turbo::StreamsChannel.broadcast_action_to(

--- a/engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb
+++ b/engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb
@@ -29,6 +29,11 @@ module Collavre
 
         Rails.logger.info "[CreativeBroadcast] #{action} creative #{id} -> broadcasting to users #{target_users.map(&:id)}"
 
+        # Exclude the user who made the change — their UI already reflects it
+        current = Collavre.current_user
+        target_users.reject! { |u| current && u.id == current.id }
+        return if target_users.empty?
+
         target_users.each do |target_user|
           Turbo::StreamsChannel.broadcast_action_to(
             [ target_user, :creative_tree ],

--- a/engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb
+++ b/engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb
@@ -33,6 +33,7 @@ module Collavre
       def capture_broadcast_state
         # Capture before destroy — after destroy, associations are gone
         @_destroy_broadcast_users = find_broadcast_users
+        @_destroy_linked_map = build_linked_creative_map(@_destroy_broadcast_users)
         @_destroy_payload = {
           id: id,
           parent_id: parent_id,
@@ -48,9 +49,15 @@ module Collavre
         users = @_destroy_broadcast_users.reject { |u| current && u.id == current.id }
         return if users.empty?
 
-        payload = { action: "destroyed", creative: @_destroy_payload }.to_json
-
         users.each do |target_user|
+          user_data = @_destroy_payload.dup
+          linked_id = @_destroy_linked_map[target_user.id]
+          user_data[:linked_id] = linked_id if linked_id
+          if user_data[:ancestors].present?
+            user_data[:ancestors] = remap_ancestor_ids(user_data[:ancestors], target_user)
+          end
+
+          payload = { action: "destroyed", creative: user_data }.to_json
           Turbo::StreamsChannel.broadcast_action_to(
             [ target_user, :creative_tree ],
             action: :refresh_creative_tree,
@@ -67,10 +74,20 @@ module Collavre
         target_users.reject! { |u| current && u.id == current.id }
         return if target_users.empty?
 
-        payload = { action: action.to_s, creative: data }.to_json
-        Rails.logger.info "[CreativeBroadcast] Broadcasting to #{target_users.map(&:email)} payload_size=#{payload.size}"
+        # Build per-user linked creative ID mapping
+        linked_map = build_linked_creative_map(target_users)
 
         target_users.each do |target_user|
+          user_data = data.dup
+          # Add linked_id for this user's linked creative (if any)
+          linked_id = linked_map[target_user.id]
+          user_data[:linked_id] = linked_id if linked_id
+          # Also remap ancestor IDs to linked IDs for this user
+          if user_data[:ancestors].present?
+            user_data[:ancestors] = remap_ancestor_ids(user_data[:ancestors], target_user)
+          end
+
+          payload = { action: action.to_s, creative: user_data }.to_json
           Turbo::StreamsChannel.broadcast_action_to(
             [ target_user, :creative_tree ],
             action: :refresh_creative_tree,
@@ -152,6 +169,37 @@ module Collavre
         end
         idx = siblings.to_a.index { |s| s.id == id }
         idx && idx > 0 ? siblings.to_a[idx - 1] : nil
+      end
+
+      # Build a map of user_id → linked_creative_id for this creative
+      # So each user receives the correct ID for their view
+      def build_linked_creative_map(users)
+        origin = safe_effective_origin
+        map = {}
+        # If this IS the origin, find linked creatives for each user
+        origin.linked_creatives.where(user: users).find_each do |linked|
+          map[linked.user_id] = linked.id
+        end
+        # Also map ancestors' linked creatives
+        map
+      rescue StandardError => e
+        Rails.logger.error "[CreativeBroadcast] Error building linked map: #{e.message}"
+        {}
+      end
+
+      # Remap ancestor IDs to the user's linked creative IDs
+      def remap_ancestor_ids(ancestors, target_user)
+        ancestors.map do |anc|
+          linked = Creative.find_by(origin_id: anc[:id], user: target_user)
+          if linked
+            anc.merge(id: linked.id, origin_id: anc[:id])
+          else
+            anc
+          end
+        end
+      rescue StandardError => e
+        Rails.logger.error "[CreativeBroadcast] Error remapping ancestors: #{e.message}"
+        ancestors
       end
 
       def find_broadcast_users

--- a/engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb
+++ b/engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb
@@ -66,7 +66,7 @@ module Collavre
           payload: @_destroy_payload,
           options: {
             destroy_user_ids: @_destroy_broadcast_users.map(&:id),
-            destroy_linked_map: @_destroy_linked_map
+            destroy_linked_map: @_destroy_linked_map.transform_keys(&:to_s)
           }
         )
       end

--- a/engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb
+++ b/engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb
@@ -12,59 +12,65 @@ module Collavre
       private
 
       def broadcast_creative_created
-        broadcast_creative_change(:created)
+        broadcast_creative_change(:created, broadcast_payload)
       end
 
       def broadcast_creative_updated
-        broadcast_creative_change(:updated)
+        broadcast_creative_change(:updated, broadcast_payload)
       end
 
       def broadcast_creative_destroyed
-        broadcast_creative_change(:destroyed)
+        broadcast_creative_change(:destroyed, { id: id, parent_id: parent_id })
       end
 
-      def broadcast_creative_change(action)
+      def broadcast_creative_change(action, data)
         target_users = find_broadcast_users
-        return if target_users.empty?
-
-        Rails.logger.info "[CreativeBroadcast] #{action} creative #{id} -> broadcasting to users #{target_users.map(&:id)}"
-
         # Exclude the user who made the change — their UI already reflects it
         current = Collavre.current_user
         target_users.reject! { |u| current && u.id == current.id }
         return if target_users.empty?
+
+        payload = { action: action.to_s, creative: data }.to_json
 
         target_users.each do |target_user|
           Turbo::StreamsChannel.broadcast_action_to(
             [ target_user, :creative_tree ],
             action: :refresh_creative_tree,
             target: "creatives",
-            attributes: {
-              "creative-id": id.to_s,
-              "change-action": action.to_s
-            }
+            attributes: { data: payload }
           )
         end
       end
 
+      def broadcast_payload
+        origin = begin
+          effective_origin
+        rescue StandardError
+          self
+        end
+
+        {
+          id: id,
+          parent_id: parent_id,
+          origin_id: origin_id,
+          progress: progress,
+          description_html: origin.effective_description,
+          description_raw_html: description,
+          has_children: children.exists?
+        }
+      end
+
       def find_broadcast_users
-        # Find the effective origin (for linked creatives)
         target = begin
           origin_id.present? && origin ? origin.effective_origin : effective_origin
         rescue ActiveRecord::RecordNotFound
           self
         end
 
-        # Collect all users who might see this creative:
-        # 1. Owner of the creative
-        # 2. All users with shares on this creative or its ancestors
         users = []
         users << target.user if target.user
-
-        # Shared users on the creative itself
         users.concat(target.all_shared_users.map(&:user))
 
-        # Also check ancestor shares (viewers at parent level)
         target.ancestors.each do |ancestor|
           users << ancestor.user if ancestor.user
           users.concat(ancestor.all_shared_users.map(&:user))

--- a/engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb
+++ b/engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb
@@ -23,6 +23,11 @@ module Collavre
       end
 
       def broadcast_creative_updated
+        # Skip broadcast when only progress changed (cascade from update_parent_progress).
+        # The original creative's broadcast already includes ancestor progress in its payload,
+        # so receivers update parent rows without needing separate broadcasts per ancestor.
+        return if progress_only_change?
+
         enqueue_broadcast(:updated, broadcast_node_payload)
       rescue StandardError => e
         Rails.logger.error "[CreativeBroadcast] ERROR in broadcast_creative_updated: #{e.message}\n#{e.backtrace.first(5).join("\n")}"
@@ -97,6 +102,15 @@ module Collavre
         }
       end
 
+      # Returns true when update_parent_progress cascaded a progress-only save.
+      # In that case, the child's broadcast already carries ancestor progress data,
+      # so a separate broadcast for the parent is redundant.
+      def progress_only_change?
+        return false unless previous_changes.key?("progress")
+
+        (previous_changes.keys - %w[progress updated_at]).empty?
+      end
+
       def safe_effective_origin
         effective_origin
       rescue StandardError
@@ -161,21 +175,6 @@ module Collavre
         end
       end
 
-      # Remap ancestor IDs to the user's linked creative IDs
-      def remap_ancestor_ids(ancestors, target_user)
-        ancestors.map do |anc|
-          linked = Creative.find_by(origin_id: anc[:id], user: target_user)
-          if linked
-            anc.merge(id: linked.id, origin_id: anc[:id])
-          else
-            anc
-          end
-        end
-      rescue StandardError => e
-        Rails.logger.error "[CreativeBroadcast] Error remapping ancestors: #{e.message}"
-        ancestors
-      end
-
       def find_broadcast_users
         target = begin
           origin_id.present? && origin ? origin.effective_origin : effective_origin
@@ -183,18 +182,23 @@ module Collavre
           self
         end
 
-        # Collect candidate users from target and its ancestors
-        candidates = Set.new
-        candidates << target.user if target.user
-        target.all_shared_users.each { |su| candidates << su.user }
+        # Batch: collect all ancestor IDs + target in one query, then load shares in one query
+        ancestor_ids = target.ancestor_ids  # closure_tree: single CTE query
+        all_creative_ids = [ target.id ] + ancestor_ids
 
-        target.ancestors.each do |ancestor|
-          candidates << ancestor.user if ancestor.user
-          ancestor.all_shared_users.each { |su| candidates << su.user }
-        end
+        # Owner users — single query
+        owners = User.where(id: Creative.where(id: all_creative_ids).select(:user_id))
+
+        # Shared users — single query (instead of N+1 per ancestor)
+        shared_users = User.where(
+          id: CreativeShare.where(creative_id: all_creative_ids).select(:user_id)
+        )
+
+        candidates = (owners + shared_users).compact.uniq
 
         # Filter: only users who actually have read permission on this creative
-        candidates.compact.select { |user| target.has_permission?(user, :read) }.uniq
+        # PermissionChecker uses creative_shares_caches (O(1) per user)
+        candidates.select { |user| target.has_permission?(user, :read) }
       rescue StandardError => e
         Rails.logger.error "[CreativeBroadcast] Error finding users: #{e.message}"
         []

--- a/engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb
+++ b/engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb
@@ -1,0 +1,76 @@
+module Collavre
+  class Creative < ApplicationRecord
+    module RealtimeBroadcastable
+      extend ActiveSupport::Concern
+
+      included do
+        after_create_commit :broadcast_creative_created
+        after_update_commit :broadcast_creative_updated
+        after_destroy_commit :broadcast_creative_destroyed
+      end
+
+      private
+
+      def broadcast_creative_created
+        broadcast_creative_change(:created)
+      end
+
+      def broadcast_creative_updated
+        broadcast_creative_change(:updated)
+      end
+
+      def broadcast_creative_destroyed
+        broadcast_creative_change(:destroyed)
+      end
+
+      def broadcast_creative_change(action)
+        root = find_broadcast_root
+        return unless root
+
+        payload = { action: action.to_s }
+
+        case action
+        when :destroyed
+          payload[:creative] = { id: id, parent_id: parent_id }
+        when :created, :updated
+          payload[:creative] = broadcast_creative_data
+          payload[:ancestors] = broadcast_ancestor_data
+        end
+
+        CreativesChannel.broadcast_to(root, payload)
+      end
+
+      def find_broadcast_root
+        # For linked creatives, broadcast to the origin's root
+        target = origin_id.present? ? (origin || self) : self
+        # Walk up to the root using closure_tree
+        root = target.root
+        root&.effective_origin
+      rescue ActiveRecord::RecordNotFound
+        nil
+      end
+
+      def broadcast_creative_data
+        {
+          id: id,
+          parent_id: parent_id,
+          description: effective_description,
+          description_raw_html: description,
+          progress: progress,
+          sequence: sequence,
+          origin_id: origin_id,
+          updated_at: updated_at&.iso8601
+        }
+      end
+
+      def broadcast_ancestor_data
+        ancestors.map do |anc|
+          {
+            id: anc.id,
+            progress: anc.progress
+          }
+        end
+      end
+    end
+  end
+end

--- a/engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb
+++ b/engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb
@@ -15,17 +15,15 @@ module Collavre
       # Public: called from CreateService after insert_at_position
       # @param after_id [Integer, nil] the creative ID this was inserted after (from user action)
       def broadcast_creative_created(after_id: nil)
-        Rails.logger.info "[CreativeBroadcast] === broadcast_creative_created for creative##{id} seq=#{sequence} after_id=#{after_id} ==="
         payload = broadcast_node_payload
         payload[:after_id] = after_id.presence&.to_i
-        broadcast_creative_change(:created, payload)
+        enqueue_broadcast(:created, payload)
       rescue StandardError => e
         Rails.logger.error "[CreativeBroadcast] ERROR in broadcast_creative_created: #{e.message}\n#{e.backtrace.first(5).join("\n")}"
       end
 
       def broadcast_creative_updated
-        Rails.logger.info "[CreativeBroadcast] === after_update_commit fired for creative##{id} ==="
-        broadcast_creative_change(:updated, broadcast_node_payload)
+        enqueue_broadcast(:updated, broadcast_node_payload)
       rescue StandardError => e
         Rails.logger.error "[CreativeBroadcast] ERROR in broadcast_creative_updated: #{e.message}\n#{e.backtrace.first(5).join("\n")}"
       end
@@ -44,80 +42,17 @@ module Collavre
       def broadcast_creative_destroyed
         return if @_destroy_broadcast_users.blank?
 
-        current = Collavre.current_user
-        Rails.logger.info "[CreativeBroadcast] destroyed creative##{id} current_user=#{current&.email} target_users=#{@_destroy_broadcast_users.map(&:email)}"
-        users = @_destroy_broadcast_users.reject { |u| current && u.id == current.id }
-        return if users.empty?
-
-        users.each do |target_user|
-          user_data = @_destroy_payload.dup
-          linked_id = @_destroy_linked_map[target_user.id]
-          user_data[:linked_id] = linked_id if linked_id
-          # Remap parent_id for this user
-          if user_data[:parent_id].present?
-            linked_parent = Creative.find_by(origin_id: user_data[:parent_id], user: target_user)
-            user_data[:parent_id] = linked_parent.id if linked_parent
-          end
-          if user_data[:ancestors].present?
-            user_data[:ancestors] = remap_ancestor_ids(user_data[:ancestors], target_user)
-          end
-
-          payload = { action: "destroyed", creative: user_data }.to_json
-          Turbo::StreamsChannel.broadcast_action_to(
-            [ target_user, :creative_tree ],
-            action: :refresh_creative_tree,
-            target: "creatives",
-            attributes: { data: payload }
-          )
-        end
-      end
-
-      def broadcast_creative_change(action, data)
-        target_users = find_broadcast_users
-        current = Collavre.current_user
-        Rails.logger.info "[CreativeBroadcast] #{action} creative##{data[:id]} current_user=#{current&.email} target_users=#{target_users.map(&:email)}"
-        target_users.reject! { |u| current && u.id == current.id }
-        return if target_users.empty?
-
-        # Build per-user linked creative ID mapping
-        linked_map = build_linked_creative_map(target_users)
-
-        target_users.each do |target_user|
-          user_data = data.dup
-          # Add linked_id for this user's linked creative (if any)
-          linked_id = linked_map[target_user.id]
-          user_data[:linked_id] = linked_id if linked_id
-          # Remap parent_id to linked parent for this user
-          if user_data[:parent_id].present?
-            linked_parent = Creative.find_by(origin_id: user_data[:parent_id], user: target_user)
-            user_data[:parent_id] = linked_parent.id if linked_parent
-          end
-          # Remap after_id to linked sibling for this user
-          if user_data[:after_id].present?
-            linked_after = Creative.find_by(origin_id: user_data[:after_id], user: target_user)
-            user_data[:after_id] = linked_after.id if linked_after
-          end
-          # Remap previous_sibling_id to linked sibling for this user
-          if user_data[:previous_sibling_id].present?
-            linked_prev = Creative.find_by(origin_id: user_data[:previous_sibling_id], user: target_user)
-            user_data[:previous_sibling_id] = linked_prev.id if linked_prev
-          end
-          # Remap ancestor IDs to linked IDs for this user
-          if user_data[:ancestors].present?
-            user_data[:ancestors] = remap_ancestor_ids(user_data[:ancestors], target_user)
-          end
-
-          # Add per-user progress text (completion mark differs per user)
-          add_progress_text!(user_data, target_user)
-
-          payload = { action: action.to_s, creative: user_data }.to_json
-          Turbo::StreamsChannel.broadcast_action_to(
-            [ target_user, :creative_tree ],
-            action: :refresh_creative_tree,
-            target: "creatives",
-            attributes: { data: payload }
-          )
-        end
+        current_user_id = Collavre.current_user&.id
+        CreativeBroadcastJob.perform_later(
+          id,
+          "destroyed",
+          current_user_id: current_user_id,
+          payload: @_destroy_payload,
+          options: {
+            destroy_user_ids: @_destroy_broadcast_users.map(&:id),
+            destroy_linked_map: @_destroy_linked_map
+          }
+        )
       end
 
       # Tree-renderer compatible node payload (matches TreeBuilder output)
@@ -171,6 +106,17 @@ module Collavre
       def previous_sibling
         scope = parent ? parent.children : Creative.where(parent_id: nil)
         scope.where("sequence < ?", sequence).order(sequence: :desc).first
+      end
+
+      # Enqueue broadcast as a background job to avoid blocking the request cycle.
+      # Payload is built synchronously (needs fresh DB state), then delivery is async.
+      def enqueue_broadcast(action, payload)
+        CreativeBroadcastJob.perform_later(
+          id,
+          action.to_s,
+          current_user_id: Collavre.current_user&.id,
+          payload: payload
+        )
       end
 
       # Build a map of user_id → linked_creative_id for this creative

--- a/engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb
+++ b/engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb
@@ -224,9 +224,14 @@ module Collavre
 
         candidates = (owners + shared_users).compact.uniq
 
-        # Filter: only users who actually have read permission on this creative
-        # PermissionChecker uses creative_shares_caches (O(1) per user)
-        candidates.select { |user| target.has_permission?(user, :read) }
+        # Filter: only users who actually have read permission.
+        # Check target first; if its permission cache is missing (e.g. newly created creative
+        # whose PermissionCacheJob hasn't run yet), fall back to the nearest ancestor that has
+        # a cache entry. This prevents broadcast from being silently dropped for new creatives.
+        permission_targets = [ target ] + Creative.where(id: ancestor_ids).order(:id).reverse
+        candidates.select do |user|
+          permission_targets.any? { |pt| pt.has_permission?(user, :read) }
+        end
       rescue StandardError => e
         Rails.logger.error "[CreativeBroadcast] Error finding users: #{e.message}"
         []

--- a/engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb
+++ b/engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb
@@ -96,6 +96,8 @@ module Collavre
           archived: archived?,
           link_url: "/creatives?id=#{id}",
           origin_id: origin_id,
+          sequence: sequence,
+          previous_sibling_id: previous_sibling&.id,
           # Templates (for display)
           templates: {
             description_html: desc_html,
@@ -132,6 +134,16 @@ module Collavre
         effective_origin
       rescue StandardError
         self
+      end
+
+      def previous_sibling
+        siblings = if parent
+                     parent.children.order(:sequence)
+        else
+                     Creative.roots.order(:sequence)
+        end
+        idx = siblings.to_a.index { |s| s.id == id }
+        idx && idx > 0 ? siblings.to_a[idx - 1] : nil
       end
 
       def find_broadcast_users

--- a/engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb
+++ b/engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb
@@ -104,8 +104,9 @@ module Collavre
           previous_sibling_id: previous_sibling&.id,
           # Templates (for display)
           templates: {
-            description_html: desc_html,
-            progress_html: broadcast_progress_html
+            description_html: desc_html
+            # progress_html intentionally omitted — minimal render would overwrite
+            # the full server-rendered progress area (which includes chat badges etc.)
           },
           # Inline editor payload (for editor cache)
           inline_editor_payload: {

--- a/engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb
+++ b/engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb
@@ -24,57 +24,51 @@ module Collavre
       end
 
       def broadcast_creative_change(action)
-        roots = find_broadcast_roots
-        return if roots.empty?
+        target_users = find_broadcast_users
+        return if target_users.empty?
 
-        payload = { action: action.to_s }
+        Rails.logger.info "[CreativeBroadcast] #{action} creative #{id} -> broadcasting to users #{target_users.map(&:id)}"
 
-        case action
-        when :destroyed
-          payload[:creative] = { id: id, parent_id: parent_id }
-        when :created, :updated
-          payload[:creative] = broadcast_creative_data
-          payload[:ancestors] = broadcast_ancestor_data
-        end
-
-        # Broadcast to every ancestor so any viewer at any level receives it
-        Rails.logger.info "[CreativeBroadcast] #{action} creative #{id} -> broadcasting to #{roots.map(&:id)}"
-        roots.each do |root|
-          CreativesChannel.broadcast_to(root, payload)
+        target_users.each do |target_user|
+          Turbo::StreamsChannel.broadcast_action_to(
+            [ target_user, :creative_tree ],
+            action: :refresh_creative_tree,
+            target: "creatives",
+            attributes: {
+              "creative-id": id.to_s,
+              "change-action": action.to_s
+            }
+          )
         end
       end
 
-      def find_broadcast_roots
-        target = origin_id.present? ? (origin || self) : self
-        # Broadcast to self + all ancestors, so anyone viewing any
-        # level of the tree will receive the update
-        ([target] + target.ancestors).filter_map do |creative|
-          creative.effective_origin
-        end.uniq
-      rescue ActiveRecord::RecordNotFound
+      def find_broadcast_users
+        # Find the effective origin (for linked creatives)
+        target = begin
+          origin_id.present? && origin ? origin.effective_origin : effective_origin
+        rescue ActiveRecord::RecordNotFound
+          self
+        end
+
+        # Collect all users who might see this creative:
+        # 1. Owner of the creative
+        # 2. All users with shares on this creative or its ancestors
+        users = []
+        users << target.user if target.user
+
+        # Shared users on the creative itself
+        users.concat(target.all_shared_users.map(&:user))
+
+        # Also check ancestor shares (viewers at parent level)
+        target.ancestors.each do |ancestor|
+          users << ancestor.user if ancestor.user
+          users.concat(ancestor.all_shared_users.map(&:user))
+        end
+
+        users.compact.uniq
+      rescue StandardError => e
+        Rails.logger.error "[CreativeBroadcast] Error finding users: #{e.message}"
         []
-      end
-
-      def broadcast_creative_data
-        {
-          id: id,
-          parent_id: parent_id,
-          description: effective_description,
-          description_raw_html: description,
-          progress: progress,
-          sequence: sequence,
-          origin_id: origin_id,
-          updated_at: updated_at&.iso8601
-        }
-      end
-
-      def broadcast_ancestor_data
-        ancestors.map do |anc|
-          {
-            id: anc.id,
-            progress: anc.progress
-          }
-        end
       end
     end
   end

--- a/engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb
+++ b/engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb
@@ -17,6 +17,7 @@ module Collavre
       def broadcast_creative_created(after_id: nil)
         payload = broadcast_node_payload
         payload[:after_id] = after_id.presence&.to_i
+        payload[:previous_sibling_id] = previous_sibling&.id
         enqueue_broadcast(:created, payload)
       rescue StandardError => e
         Rails.logger.error "[CreativeBroadcast] ERROR in broadcast_creative_created: #{e.message}\n#{e.backtrace.first(5).join("\n")}"
@@ -34,13 +35,14 @@ module Collavre
       end
 
       def capture_broadcast_state
-        # Skip expensive queries for unshared personal creatives
-        if !origin_id && linked_creatives.none? && all_shared_users.none?
-          return
-        end
+        # Skip for top-level personal creatives with no links
+        # (parent_id.nil? means no ancestors to inherit shares from)
+        return if parent_id.nil? && !origin_id && linked_creatives.none?
 
         # Capture before destroy — after destroy, associations are gone
         @_destroy_broadcast_users = find_broadcast_users
+        return if @_destroy_broadcast_users.empty?
+
         @_destroy_linked_map = build_linked_creative_map(@_destroy_broadcast_users)
 
         # ancestors may be empty if closure_tree already deleted hierarchy rows,
@@ -85,7 +87,7 @@ module Collavre
           parent_id: parent_id,
           level: fresh_ancestors.size + 1,
           select_mode: false,
-          can_write: true, # Refined per-user in JS if needed
+          can_write: true, # Default; overridden per-user in Job
           has_children: children.exists?,
           expanded: false,
           is_root: parent.nil?,
@@ -93,7 +95,6 @@ module Collavre
           link_url: "/creatives?id=#{id}",
           origin_id: origin_id,
           sequence: sequence,
-          previous_sibling_id: previous_sibling&.id,
           # Templates (for display)
           templates: {
             description_html: desc_html

--- a/engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb
+++ b/engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb
@@ -4,16 +4,17 @@ module Collavre
       extend ActiveSupport::Concern
 
       included do
-        after_create_commit :broadcast_creative_created
+        # NOTE: after_create_commit is NOT used here because CreateService
+        # needs to call insert_at_position (resequence) BEFORE broadcast.
+        # broadcast_creative_created is called explicitly from CreateService.
         after_update_commit :broadcast_creative_updated
         before_destroy :capture_broadcast_state
         after_destroy_commit :broadcast_creative_destroyed
       end
 
-      private
-
+      # Public: called from CreateService after insert_at_position
       def broadcast_creative_created
-        Rails.logger.info "[CreativeBroadcast] === after_create_commit fired for creative##{id} ==="
+        Rails.logger.info "[CreativeBroadcast] === broadcast_creative_created for creative##{id} seq=#{sequence} ==="
         broadcast_creative_change(:created, broadcast_node_payload)
       rescue StandardError => e
         Rails.logger.error "[CreativeBroadcast] ERROR in broadcast_creative_created: #{e.message}\n#{e.backtrace.first(5).join("\n")}"

--- a/engines/collavre/app/models/collavre/creative_presence_store.rb
+++ b/engines/collavre/app/models/collavre/creative_presence_store.rb
@@ -2,14 +2,15 @@ module Collavre
   class CreativePresenceStore
     KEY_PREFIX = "creative_presence:"
     LOCK_TTL = 2 # seconds
+    PRESENCE_TTL = 10 # minutes
 
     def self.add(root_id, user_id)
       with_lock(root_id) do
         ids = list(root_id)
         unless ids.include?(user_id)
           ids << user_id
-          Rails.cache.write(key(root_id), ids)
         end
+        Rails.cache.write(key(root_id), ids, expires_in: PRESENCE_TTL.minutes)
         ids
       end
     end
@@ -18,7 +19,7 @@ module Collavre
       with_lock(root_id) do
         ids = list(root_id)
         if ids.delete(user_id)
-          Rails.cache.write(key(root_id), ids)
+          Rails.cache.write(key(root_id), ids, expires_in: PRESENCE_TTL.minutes)
         end
         ids
       end

--- a/engines/collavre/app/models/collavre/creative_presence_store.rb
+++ b/engines/collavre/app/models/collavre/creative_presence_store.rb
@@ -1,22 +1,27 @@
 module Collavre
   class CreativePresenceStore
     KEY_PREFIX = "creative_presence:"
+    LOCK_TTL = 2 # seconds
 
     def self.add(root_id, user_id)
-      ids = list(root_id)
-      unless ids.include?(user_id)
-        ids << user_id
-        Rails.cache.write(key(root_id), ids)
+      with_lock(root_id) do
+        ids = list(root_id)
+        unless ids.include?(user_id)
+          ids << user_id
+          Rails.cache.write(key(root_id), ids)
+        end
+        ids
       end
-      ids
     end
 
     def self.remove(root_id, user_id)
-      ids = list(root_id)
-      if ids.delete(user_id)
-        Rails.cache.write(key(root_id), ids)
+      with_lock(root_id) do
+        ids = list(root_id)
+        if ids.delete(user_id)
+          Rails.cache.write(key(root_id), ids)
+        end
+        ids
       end
-      ids
     end
 
     def self.list(root_id)
@@ -25,6 +30,28 @@ module Collavre
 
     def self.key(root_id)
       "#{KEY_PREFIX}#{root_id}"
+    end
+
+    def self.lock_key(root_id)
+      "#{KEY_PREFIX}lock:#{root_id}"
+    end
+
+    # Simple spin-lock using cache. Prevents race conditions in multi-process environments.
+    def self.with_lock(root_id, &block)
+      lk = lock_key(root_id)
+      # Try to acquire lock (expires after LOCK_TTL to avoid deadlocks)
+      10.times do
+        if Rails.cache.write(lk, true, unless_exist: true, expires_in: LOCK_TTL.seconds)
+          begin
+            return block.call
+          ensure
+            Rails.cache.delete(lk)
+          end
+        end
+        sleep(0.05)
+      end
+      # Fallback: proceed without lock (better than blocking forever)
+      block.call
     end
   end
 end

--- a/engines/collavre/app/models/collavre/creative_presence_store.rb
+++ b/engines/collavre/app/models/collavre/creative_presence_store.rb
@@ -1,0 +1,30 @@
+module Collavre
+  class CreativePresenceStore
+    KEY_PREFIX = "creative_presence:"
+
+    def self.add(root_id, user_id)
+      ids = list(root_id)
+      unless ids.include?(user_id)
+        ids << user_id
+        Rails.cache.write(key(root_id), ids)
+      end
+      ids
+    end
+
+    def self.remove(root_id, user_id)
+      ids = list(root_id)
+      if ids.delete(user_id)
+        Rails.cache.write(key(root_id), ids)
+      end
+      ids
+    end
+
+    def self.list(root_id)
+      Rails.cache.read(key(root_id)) || []
+    end
+
+    def self.key(root_id)
+      "#{KEY_PREFIX}#{root_id}"
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/creatives/create_service.rb
+++ b/engines/collavre/app/services/collavre/creatives/create_service.rb
@@ -29,7 +29,7 @@ module Collavre
 
         # Broadcast AFTER insert_at_position so sequence and previous_sibling are correct
         creative.reload # pick up resequenced values
-        creative.broadcast_creative_created
+        creative.broadcast_creative_created(after_id: @after_id)
 
         Result.new(creative: creative, success?: true, errors: [])
       end

--- a/engines/collavre/app/services/collavre/creatives/create_service.rb
+++ b/engines/collavre/app/services/collavre/creatives/create_service.rb
@@ -27,6 +27,10 @@ module Collavre
         insert_at_position(creative)
         apply_tags(creative)
 
+        # Broadcast AFTER insert_at_position so sequence and previous_sibling are correct
+        creative.reload # pick up resequenced values
+        creative.broadcast_creative_created
+
         Result.new(creative: creative, success?: true, errors: [])
       end
 

--- a/engines/collavre/app/services/collavre/creatives/tree_builder.rb
+++ b/engines/collavre/app/services/collavre/creatives/tree_builder.rb
@@ -122,6 +122,7 @@ module Creatives
           expanded: expanded,
           is_root: creative.parent.nil?,
           archived: creative.archived?,
+          sequence: creative.sequence,
           link_url: view_context.collavre.creative_path(creative),
           templates: template_payload_for(creative, has_children: filtered_children.any?),
           inline_editor_payload: inline_editor_payload_for(creative),

--- a/engines/collavre/app/views/collavre/creatives/index.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/index.html.erb
@@ -1,4 +1,7 @@
 <%= tag.div(flash[:alert], class: "flash-alert") if flash[:alert] %>
+<% if authenticated? %>
+  <%= turbo_stream_from Current.user, :creative_tree %>
+<% end %>
 
 <div data-controller="creatives--import creatives--select-mode creatives--drag-drop creatives--expansion creatives--row-editor creatives--set-plan-modal share-modal"
      data-creatives--import-parent-id-value="<%= @parent_creative&.id %>"

--- a/engines/collavre/app/views/collavre/creatives/index.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/index.html.erb
@@ -15,6 +15,9 @@
   <div class="creative-actions-row">
     <%# Left: breadcrumb ancestry %>
     <div class="creative-breadcrumb" role="navigation" aria-label="<%= t('collavre.creatives.index.breadcrumb', default: 'Breadcrumb') %>">
+      <% if @parent_creative && authenticated? %>
+        <span id="creative-presence-avatars" class="creative-presence-avatars"></span>
+      <% end %>
       <a href="<%= creatives_path %>" class="creative-breadcrumb-link"><%= t('collavre.creatives.index.root_breadcrumb', default: '최상위') %></a>
       <% if @parent_creative %>
         <% @parent_creative.ancestors.reverse.each do |ancestor| %>
@@ -220,9 +223,11 @@
       empty_html,
       id: 'creatives',
       data: {
-        controller: 'creatives--tree',
+        controller: 'creatives--tree creatives--sync',
         'creatives--tree-url-value': tree_url,
         'creatives--tree-empty-html-value': empty_html.to_s,
+        'creatives--sync-root-id-value': @parent_creative&.effective_origin&.id,
+        'creatives--sync-current-user-id-value': Current.user&.id,
         edit_icon_html: svg_tag("edit.svg", className: "icon-edit"),
         edit_off_icon_html: svg_tag("edit-off.svg", className: "icon-edit")
       }

--- a/engines/collavre/app/views/inbox/badge_component/_count.html.erb
+++ b/engines/collavre/app/views/inbox/badge_component/_count.html.erb
@@ -1,2 +1,5 @@
-<% display = (count.positive? || show_zero) ? 'inline-block' : 'none' %>
-<span id="<%= badge_id %>" class="badge" style="display:<%= display %>" data-count="<%= count %>"><%= count if count.positive? || show_zero %></span>
+<% has_comments = count.positive? || show_zero %>
+<% display = has_comments ? 'inline-block' : 'none' %>
+<span id="<%= badge_id %>" class="badge" style="display:<%= display %>" data-count="<%= count %>"
+  data-controller="comment-badge" data-comment-badge-has-comments-value="<%= has_comments %>"
+><%= count if has_comments %></span>

--- a/engines/collavre/test/channels/creatives_channel_test.rb
+++ b/engines/collavre/test/channels/creatives_channel_test.rb
@@ -1,0 +1,67 @@
+require "test_helper"
+
+class CreativesChannelTest < ActionCable::Channel::TestCase
+  tests Collavre::CreativesChannel
+
+  setup do
+    @user = users(:one)
+    @creative = creatives(:tshirt)
+  end
+
+  test "subscribes with valid root_id and permission" do
+    stub_connection current_user: @user
+    subscribe root_id: @creative.id
+    assert subscription.confirmed?
+  end
+
+  test "rejects without root_id" do
+    stub_connection current_user: @user
+    subscribe root_id: nil
+    assert subscription.rejected?
+  end
+
+  test "rejects without current_user" do
+    stub_connection current_user: nil
+    subscribe root_id: @creative.id
+    assert subscription.rejected?
+  end
+
+  test "adds user to presence store on subscribe" do
+    stub_connection current_user: @user
+    subscribe root_id: @creative.id
+    assert subscription.confirmed?
+
+    presence_ids = Collavre::CreativePresenceStore.list(@creative.effective_origin.id)
+    assert_includes presence_ids, @user.id
+  end
+
+  test "removes user from presence store on unsubscribe" do
+    stub_connection current_user: @user
+    subscribe root_id: @creative.id
+    assert subscription.confirmed?
+
+    subscription.unsubscribe_from_channel
+    presence_ids = Collavre::CreativePresenceStore.list(@creative.effective_origin.id)
+    assert_not_includes presence_ids, @user.id
+  end
+
+  test "editing broadcasts editing message" do
+    stub_connection current_user: @user
+    subscribe root_id: @creative.id
+
+    stream = Collavre::CreativesChannel.broadcasting_for(@creative.effective_origin)
+    assert_broadcasts(stream, 1) do
+      perform :editing, creative_id: @creative.id
+    end
+  end
+
+  test "stopped_editing broadcasts stopped_editing message" do
+    stub_connection current_user: @user
+    subscribe root_id: @creative.id
+
+    stream = Collavre::CreativesChannel.broadcasting_for(@creative.effective_origin)
+    assert_broadcasts(stream, 1) do
+      perform :stopped_editing, creative_id: @creative.id
+    end
+  end
+end

--- a/engines/collavre/test/jobs/collavre/creative_broadcast_job_test.rb
+++ b/engines/collavre/test/jobs/collavre/creative_broadcast_job_test.rb
@@ -1,0 +1,308 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  class CreativeBroadcastJobTest < ActiveSupport::TestCase
+    setup do
+      @owner = users(:one)
+      @shared_user = users(:two)
+      Current.session = OpenStruct.new(user: @owner)
+
+      perform_enqueued_jobs do
+        @root = Creative.create!(user: @owner, description: "Job Test Root", progress: 0.0)
+        @child = Creative.create!(user: @owner, parent: @root, description: "Job Test Child", progress: 0.5)
+        @grandchild = Creative.create!(user: @owner, parent: @child, description: "Job Test Grandchild", progress: 0.0)
+        CreativeShare.create!(creative: @root, user: @shared_user, permission: :write)
+      end
+    end
+
+    teardown do
+      Current.reset
+    end
+
+    # --- created action ---
+
+    test "created action does not raise for valid creative" do
+      payload = @child.broadcast_node_payload
+      payload[:after_id] = nil
+      payload[:previous_sibling_id] = nil
+
+      assert_nothing_raised do
+        CreativeBroadcastJob.perform_now(
+          @child.id,
+          "created",
+          current_user_id: @owner.id,
+          payload: payload
+        )
+      end
+    end
+
+    test "created action is no-op for missing creative" do
+      assert_nothing_raised do
+        CreativeBroadcastJob.perform_now(
+          999_999_999,
+          "created",
+          current_user_id: @owner.id,
+          payload: {}
+        )
+      end
+    end
+
+    # --- updated action ---
+
+    test "updated action does not raise for valid creative" do
+      payload = @child.broadcast_node_payload
+
+      assert_nothing_raised do
+        CreativeBroadcastJob.perform_now(
+          @child.id,
+          "updated",
+          current_user_id: @owner.id,
+          payload: payload
+        )
+      end
+    end
+
+    # --- destroyed action ---
+
+    test "destroyed action does not raise with valid options" do
+      destroy_payload = {
+        id: @child.id,
+        parent_id: @root.id,
+        ancestors: [ { id: @root.id, progress: @root.progress } ]
+      }
+
+      assert_nothing_raised do
+        CreativeBroadcastJob.perform_now(
+          @child.id,
+          "destroyed",
+          current_user_id: @owner.id,
+          payload: destroy_payload,
+          options: {
+            destroy_user_ids: [ @shared_user.id ],
+            destroy_linked_map: {}
+          }
+        )
+      end
+    end
+
+    test "destroyed action with empty user_ids is no-op" do
+      assert_nothing_raised do
+        CreativeBroadcastJob.perform_now(
+          @child.id,
+          "destroyed",
+          current_user_id: @owner.id,
+          payload: { id: @child.id },
+          options: { destroy_user_ids: [], destroy_linked_map: {} }
+        )
+      end
+    end
+
+    test "destroyed action excludes current_user from recipients" do
+      destroy_payload = {
+        id: @child.id,
+        parent_id: @root.id,
+        ancestors: []
+      }
+
+      # Should not raise even if current_user is in destroy list
+      assert_nothing_raised do
+        CreativeBroadcastJob.perform_now(
+          @child.id,
+          "destroyed",
+          current_user_id: @owner.id,
+          payload: destroy_payload,
+          options: {
+            destroy_user_ids: [ @owner.id ],
+            destroy_linked_map: {}
+          }
+        )
+      end
+    end
+
+    # --- render_progress_html ---
+
+    test "render_progress_html returns html with creative-row-end wrapper" do
+      job = CreativeBroadcastJob.new
+      html = job.send(:render_progress_html, @child, @shared_user, skip_permission_check: true)
+
+      assert_not_nil html
+      assert_includes html, "creative-row-end"
+    end
+
+    test "render_progress_html includes progress percentage" do
+      # Use a leaf creative (no children) so progress stays as set
+      leaf = nil
+      perform_enqueued_jobs do
+        leaf = Creative.create!(user: @owner, parent: @root, description: "Leaf 50%", progress: 0.5)
+      end
+
+      job = CreativeBroadcastJob.new
+      html = job.send(:render_progress_html, leaf, @shared_user, skip_permission_check: true)
+
+      assert_includes html, "50%"
+    end
+
+    test "render_progress_html includes comment button when skip_permission_check" do
+      job = CreativeBroadcastJob.new
+      html = job.send(:render_progress_html, @child, @shared_user, skip_permission_check: true)
+
+      assert_includes html, "show-comments-btn"
+      assert_includes html, "turbo-cable-stream-source"
+    end
+
+    test "render_progress_html with 0 progress shows 0% and incomplete class" do
+      @child.update_column(:progress, 0.0)
+      @child.reload
+
+      job = CreativeBroadcastJob.new
+      html = job.send(:render_progress_html, @child, @shared_user, skip_permission_check: true)
+
+      assert_includes html, "0%"
+      assert_includes html, "creative-progress-incomplete"
+    end
+
+    test "render_progress_html with 100% shows complete class" do
+      @child.update_column(:progress, 1.0)
+      @child.reload
+
+      job = CreativeBroadcastJob.new
+      html = job.send(:render_progress_html, @child, @shared_user, skip_permission_check: true)
+
+      assert_includes html, "creative-progress-complete"
+    end
+
+    test "render_progress_html includes no-comments class for new creative" do
+      job = CreativeBroadcastJob.new
+      html = job.send(:render_progress_html, @child, @shared_user, skip_permission_check: true)
+
+      assert_includes html, "no-comments"
+    end
+
+    test "render_progress_html includes signed stream name" do
+      job = CreativeBroadcastJob.new
+      html = job.send(:render_progress_html, @child, @shared_user, skip_permission_check: true)
+
+      assert_includes html, "signed-stream-name="
+    end
+
+    test "render_progress_html escapes creative_snippet" do
+      @child.update_column(:description, '<script>alert("xss")</script>')
+      @child.reload
+
+      job = CreativeBroadcastJob.new
+      html = job.send(:render_progress_html, @child, @shared_user, skip_permission_check: true)
+
+      # Should be HTML escaped, not raw script tag
+      refute_includes html, '<script>'
+    end
+
+    # --- read_svg ---
+
+    test "read_svg returns content for existing file" do
+      job = CreativeBroadcastJob.new
+      svg = job.send(:read_svg, "comment.svg", class: "test-icon")
+
+      if File.exist?(Rails.root.join("app/assets/images/comment.svg"))
+        assert_includes svg, "<svg"
+        assert_includes svg, "test-icon"
+      else
+        assert_equal "", svg
+      end
+    end
+
+    test "read_svg returns empty string for missing file" do
+      job = CreativeBroadcastJob.new
+      svg = job.send(:read_svg, "nonexistent_file_12345.svg")
+      assert_equal "", svg
+    end
+
+    test "read_svg memoizes at class level" do
+      # Clear cache first
+      CreativeBroadcastJob.svg_cache.clear
+
+      job1 = CreativeBroadcastJob.new
+      job1.send(:read_svg, "comment.svg")
+
+      job2 = CreativeBroadcastJob.new
+      # Second call should use cached value
+      assert_equal CreativeBroadcastJob.svg_cache.key?("comment.svg"), true
+    end
+
+    # --- permission_via_ancestors ---
+
+    test "permission_via_ancestors returns true when ancestor has permission" do
+      job = CreativeBroadcastJob.new
+      # grandchild → child → root (which has share with shared_user)
+      result = job.send(:permission_via_ancestors, @grandchild, @shared_user, :read)
+      assert result
+    end
+
+    test "permission_via_ancestors returns false when no ancestor has permission" do
+      unshared_user = users(:three)
+      job = CreativeBroadcastJob.new
+      result = job.send(:permission_via_ancestors, @grandchild, unshared_user, :read)
+      refute result
+    end
+
+    test "permission_via_ancestors returns false for root creative without parent" do
+      job = CreativeBroadcastJob.new
+      # Root has no parent, so the while loop doesn't execute
+      result = job.send(:permission_via_ancestors, @root, @shared_user, :admin)
+      refute result
+    end
+
+    # --- linked creative remapping ---
+
+    test "created action remaps parent_id for linked creative user" do
+      linked = nil
+      perform_enqueued_jobs do
+        linked = Creative.create!(
+          user: @shared_user,
+          origin_id: @root.id,
+          description: "Linked root"
+        )
+      end
+
+      payload = @child.broadcast_node_payload.deep_symbolize_keys
+      payload[:after_id] = nil
+      payload[:previous_sibling_id] = nil
+
+      # Should not raise — remapping happens internally
+      assert_nothing_raised do
+        CreativeBroadcastJob.perform_now(
+          @child.id,
+          "created",
+          current_user_id: @owner.id,
+          payload: payload
+        )
+      end
+    end
+
+    # --- edge cases ---
+
+    test "unknown action is handled gracefully" do
+      assert_nothing_raised do
+        CreativeBroadcastJob.perform_now(
+          @child.id,
+          "unknown_action",
+          current_user_id: @owner.id,
+          payload: {}
+        )
+      end
+    end
+
+    test "nil payload does not raise for destroyed action" do
+      assert_nothing_raised do
+        CreativeBroadcastJob.perform_now(
+          @child.id,
+          "destroyed",
+          current_user_id: @owner.id,
+          payload: nil,
+          options: { destroy_user_ids: [], destroy_linked_map: {} }
+        )
+      end
+    end
+  end
+end

--- a/engines/collavre/test/models/collavre/creative/realtime_broadcastable_test.rb
+++ b/engines/collavre/test/models/collavre/creative/realtime_broadcastable_test.rb
@@ -1,0 +1,303 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  class Creative
+    class RealtimeBroadcastableTest < ActiveSupport::TestCase
+      setup do
+        @owner = users(:one)
+        @shared_user = users(:two)
+        Current.session = OpenStruct.new(user: @owner)
+
+        # Use test adapter for job assertions
+        @original_adapter = ActiveJob::Base.queue_adapter
+        ActiveJob::Base.queue_adapter = :test
+
+        perform_enqueued_jobs do
+          @root = Creative.create!(user: @owner, description: "Broadcast Root", progress: 0.0)
+          @child = Creative.create!(user: @owner, parent: @root, description: "Broadcast Child", progress: 0.5)
+          @grandchild = Creative.create!(user: @owner, parent: @child, description: "Broadcast Grandchild", progress: 0.0)
+
+          # Share root with shared_user (read permission propagates to descendants)
+          CreativeShare.create!(creative: @root, user: @shared_user, permission: :write)
+        end
+      end
+
+      teardown do
+        ActiveJob::Base.queue_adapter = @original_adapter
+        Current.reset
+      end
+
+      # --- broadcast_node_payload ---
+
+      test "broadcast_node_payload returns tree-renderer compatible structure" do
+        payload = @child.broadcast_node_payload
+
+        assert_equal @child.id, payload[:id]
+        assert_equal "creative-#{@child.id}", payload[:dom_id]
+        assert_equal @root.id, payload[:parent_id]
+        assert_kind_of Integer, payload[:level]
+        assert_includes payload[:templates].keys, :description_html
+        assert_kind_of Hash, payload[:inline_editor_payload]
+        # broadcast_node_payload calls reload, so check progress is a number
+        assert_kind_of Numeric, payload[:inline_editor_payload][:progress]
+        assert_kind_of Array, payload[:ancestors]
+      end
+
+      test "broadcast_node_payload includes ancestor progress" do
+        payload = @grandchild.broadcast_node_payload
+        ancestor_ids = payload[:ancestors].map { |a| a[:id] }
+
+        assert_includes ancestor_ids, @child.id
+        assert_includes ancestor_ids, @root.id
+      end
+
+      test "broadcast_node_payload has correct level for nested creative" do
+        payload = @grandchild.broadcast_node_payload
+        # root(1) → child(2) → grandchild(3)
+        assert_equal 3, payload[:level]
+      end
+
+      test "broadcast_node_payload includes required keys" do
+        payload = @child.broadcast_node_payload
+        required_keys = %i[id dom_id parent_id level select_mode can_write has_children
+                           expanded is_root archived link_url origin_id sequence
+                           templates inline_editor_payload ancestors]
+        required_keys.each do |key|
+          assert payload.key?(key), "Missing key: #{key}"
+        end
+      end
+
+      # --- progress_only_change? ---
+
+      test "progress_only_change? returns true when only progress changed" do
+        @child.update!(progress: 0.8)
+        assert @child.send(:progress_only_change?)
+      end
+
+      test "progress_only_change? returns false when description also changed" do
+        @child.update!(progress: 0.8, description: "Updated")
+        refute @child.send(:progress_only_change?)
+      end
+
+      test "progress_only_change? returns false when progress not changed" do
+        @child.update!(description: "New description")
+        refute @child.send(:progress_only_change?)
+      end
+
+      # --- find_broadcast_users ---
+
+      test "find_broadcast_users includes owner and shared users" do
+        users = @root.send(:find_broadcast_users)
+        user_ids = users.map(&:id)
+
+        assert_includes user_ids, @owner.id
+        assert_includes user_ids, @shared_user.id
+      end
+
+      test "find_broadcast_users for child includes users shared on ancestor" do
+        users = @grandchild.send(:find_broadcast_users)
+        user_ids = users.map(&:id)
+
+        assert_includes user_ids, @owner.id
+        assert_includes user_ids, @shared_user.id
+      end
+
+      test "find_broadcast_users excludes users without read permission" do
+        unshared_user = users(:three)
+        users = @root.send(:find_broadcast_users)
+        user_ids = users.map(&:id)
+
+        refute_includes user_ids, unshared_user.id
+      end
+
+      test "find_broadcast_users returns empty on error" do
+        # Stub ancestor_ids to raise
+        @root.stub(:ancestor_ids, -> { raise StandardError, "boom" }) do
+          users = @root.send(:find_broadcast_users)
+          assert_equal [], users
+        end
+      end
+
+      # --- build_linked_creative_map ---
+
+      test "build_linked_creative_map returns empty when no linked creatives" do
+        map = @root.send(:build_linked_creative_map, [ @shared_user ])
+        assert_kind_of Hash, map
+      end
+
+      test "build_linked_creative_map maps user to linked creative id" do
+        perform_enqueued_jobs do
+          linked = Creative.create!(
+            user: @shared_user,
+            origin_id: @root.id,
+            description: "Linked copy"
+          )
+
+          map = @root.send(:build_linked_creative_map, [ @shared_user ])
+          assert_equal linked.id, map[@shared_user.id]
+        end
+      end
+
+      # --- format_progress_text ---
+
+      test "format_progress_text returns percentage for normal progress" do
+        text = @root.send(:format_progress_text, 0.5, @owner)
+        assert_equal "50%", text
+      end
+
+      test "format_progress_text returns 0% for zero progress" do
+        text = @root.send(:format_progress_text, 0.0, @owner)
+        assert_equal "0%", text
+      end
+
+      test "format_progress_text rounds correctly" do
+        text = @root.send(:format_progress_text, 0.333, @owner)
+        assert_equal "33%", text
+      end
+
+      test "format_progress_text returns completion mark when user has one set" do
+        # completion_mark has NOT NULL constraint, so just check current behavior
+        mark = @owner.completion_mark
+        text = @root.send(:format_progress_text, 1.0, @owner)
+        if mark.present?
+          assert_equal mark, text
+        elsif mark == "" # blank but not nil
+          assert_equal "", text
+        else
+          assert_equal "100%", text
+        end
+      end
+
+      # --- add_progress_text! ---
+
+      test "add_progress_text! adds progress_text to data" do
+        data = {
+          inline_editor_payload: { progress: 0.75 },
+          ancestors: [ { id: 1, progress: 0.5 } ]
+        }
+        @root.send(:add_progress_text!, data, @owner)
+
+        assert_equal "75%", data[:progress_text]
+        assert_equal "50%", data[:ancestors].first[:progress_text]
+      end
+
+      test "add_progress_text! handles nil ancestors" do
+        data = { inline_editor_payload: { progress: 0.5 }, ancestors: nil }
+        assert_nothing_raised do
+          @root.send(:add_progress_text!, data, @owner)
+        end
+        assert_equal "50%", data[:progress_text]
+      end
+
+      # --- enqueue_broadcast ---
+
+      test "broadcast_creative_created enqueues CreativeBroadcastJob" do
+        creative = nil
+        perform_enqueued_jobs(only: Collavre::PermissionCacheJob) do
+          creative = Creative.create!(user: @owner, parent: @root, description: "New child", progress: 0.0)
+        end
+
+        assert_enqueued_with(job: Collavre::CreativeBroadcastJob) do
+          creative.reload
+          creative.broadcast_creative_created(after_id: nil)
+        end
+      end
+
+      test "broadcast_creative_updated enqueues job on description change" do
+        assert_enqueued_with(job: Collavre::CreativeBroadcastJob) do
+          @child.update!(description: "Updated description")
+        end
+      end
+
+      test "broadcast_creative_updated skips progress-only changes" do
+        assert_no_enqueued_jobs(only: Collavre::CreativeBroadcastJob) do
+          @child.update!(progress: 0.9)
+        end
+      end
+
+      # --- capture_broadcast_state / broadcast_creative_destroyed ---
+
+      test "capture_broadcast_state stores users and payload for shared creative" do
+        # @child has parent (@root) which is shared — should capture
+        @child.send(:capture_broadcast_state)
+        assert_not_nil @child.instance_variable_get(:@_destroy_broadcast_users)
+        assert_not_nil @child.instance_variable_get(:@_destroy_payload)
+      end
+
+      test "capture_broadcast_state skips top-level personal creative without links" do
+        personal = nil
+        perform_enqueued_jobs do
+          personal = Creative.create!(user: @owner, description: "Personal", progress: 0.0)
+        end
+        personal.send(:capture_broadcast_state)
+        assert_nil personal.instance_variable_get(:@_destroy_broadcast_users)
+      end
+
+      test "broadcast_creative_destroyed enqueues job after capture" do
+        @child.send(:capture_broadcast_state)
+
+        assert_enqueued_with(job: Collavre::CreativeBroadcastJob) do
+          @child.send(:broadcast_creative_destroyed)
+        end
+      end
+
+      test "broadcast_creative_destroyed is no-op without capture" do
+        assert_no_enqueued_jobs(only: Collavre::CreativeBroadcastJob) do
+          @child.send(:broadcast_creative_destroyed)
+        end
+      end
+
+      # --- previous_sibling ---
+
+      test "previous_sibling returns nil for first child" do
+        perform_enqueued_jobs do
+          parent = Creative.create!(user: @owner, description: "Isolated Parent", progress: 0.0)
+          first = Creative.create!(user: @owner, parent: parent, description: "First", progress: 0.0)
+          first.update_column(:sequence, 0)
+
+          assert_nil first.reload.send(:previous_sibling)
+        end
+      end
+
+      test "previous_sibling returns sibling with lower sequence" do
+        perform_enqueued_jobs do
+          parent = Creative.create!(user: @owner, description: "Sibling Parent", progress: 0.0)
+          sib1 = Creative.create!(user: @owner, parent: parent, description: "Sib1", progress: 0.0)
+          sib2 = Creative.create!(user: @owner, parent: parent, description: "Sib2", progress: 0.0)
+
+          # Set sequences explicitly
+          sib1.update_column(:sequence, 10)
+          sib2.update_column(:sequence, 20)
+
+          prev = sib2.reload.send(:previous_sibling)
+          # previous_sibling returns the sibling with the highest sequence below sib2's
+          assert_equal sib1.id, prev.id
+        end
+      end
+
+      # --- safe_effective_origin ---
+
+      test "safe_effective_origin returns self on error" do
+        @root.stub(:effective_origin, -> { raise StandardError, "boom" }) do
+          result = @root.send(:safe_effective_origin)
+          assert_equal @root, result
+        end
+      end
+
+      # --- build_ancestor_ids_from_parent ---
+
+      test "build_ancestor_ids_from_parent walks parent chain" do
+        ids = @grandchild.send(:build_ancestor_ids_from_parent, @grandchild)
+        assert_includes ids, @child.id
+        assert_includes ids, @root.id
+      end
+
+      test "build_ancestor_ids_from_parent returns empty for root" do
+        ids = @root.send(:build_ancestor_ids_from_parent, @root)
+        assert_equal [], ids
+      end
+    end
+  end
+end

--- a/engines/collavre/test/models/collavre/creative_presence_store_test.rb
+++ b/engines/collavre/test/models/collavre/creative_presence_store_test.rb
@@ -1,0 +1,32 @@
+require "test_helper"
+
+module Collavre
+  class CreativePresenceStoreTest < ActiveSupport::TestCase
+    setup do
+      @root_id = 999
+      Rails.cache.delete(CreativePresenceStore.key(@root_id))
+    end
+
+    test "add adds user to list" do
+      CreativePresenceStore.add(@root_id, 1)
+      assert_equal [ 1 ], CreativePresenceStore.list(@root_id)
+    end
+
+    test "add does not duplicate user" do
+      CreativePresenceStore.add(@root_id, 1)
+      CreativePresenceStore.add(@root_id, 1)
+      assert_equal [ 1 ], CreativePresenceStore.list(@root_id)
+    end
+
+    test "remove removes user from list" do
+      CreativePresenceStore.add(@root_id, 1)
+      CreativePresenceStore.add(@root_id, 2)
+      CreativePresenceStore.remove(@root_id, 1)
+      assert_equal [ 2 ], CreativePresenceStore.list(@root_id)
+    end
+
+    test "list returns empty array when no users" do
+      assert_equal [], CreativePresenceStore.list(@root_id)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Implement real-time collaboration features for shared Creatives — when multiple users view the same creative tree, changes are instantly reflected for all viewers, with Notion-style presence and editing conflict hints.

## Changes

### Phase 1: Creative CRUD Real-time Broadcast
- **`CreativesChannel`** — ActionCable channel subscribing by root creative ID with permission checks
- **`Creative::RealtimeBroadcastable`** — after_commit callbacks that broadcast JSON payloads (created/updated/destroyed) to all subscribers
- **`CreativesSyncController`** (Stimulus) — receives broadcasts and updates the CSR tree in-place (delta patch, not full refetch)
- **`creatives_channel.js`** service — cable subscription helper with editing signal support

### Phase 2: Creative Page Presence
- **`CreativePresenceStore`** — Rails.cache-based store tracking which users are viewing each creative tree (same pattern as existing `CommentPresenceStore`)
- Presence avatars displayed in the breadcrumb area (active users with green border)
- Auto-add/remove on subscribe/unsubscribe

### Phase 3: Edit Conflict Hints
- **`editing`/`stopped_editing`** channel actions — broadcast when a user starts/stops inline editing
- Visual indicator on creative rows being edited by others (✏️ pulsing badge + orange left border)
- Auto-timeout after 5 seconds of no signal refresh
- Integration with existing `creative_row_editor.js` — dispatches `creative-editing:start`/`creative-editing:stop` events

## Architecture Decisions

- **JSON broadcast over Turbo Streams** — Creative tree is CSR (client-side rendered), so DOM-level Turbo Streams don't fit; JSON delta broadcast lets the Stimulus controller update the existing tree in-place
- **Single channel for all 3 features** — `CreativesChannel` handles CRUD broadcasts, presence, and editing signals to avoid multiple WebSocket subscriptions per page
- **Lightweight conflict hints over CRDT/OT** — Creatives have simple fields (description + progress); last-write-wins with editing indicators is sufficient

## Files Changed

### Backend (Ruby)
- `engines/collavre/app/channels/collavre/creatives_channel.rb` — new channel
- `engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb` — new concern
- `engines/collavre/app/models/collavre/creative_presence_store.rb` — new store
- `engines/collavre/app/models/collavre/creative.rb` — include RealtimeBroadcastable

### Frontend (JavaScript)
- `engines/collavre/app/javascript/services/creatives_channel.js` — cable service
- `engines/collavre/app/javascript/controllers/creatives/sync_controller.js` — Stimulus controller
- `engines/collavre/app/javascript/controllers/creatives/tree_controller.js` — refetch listener
- `engines/collavre/app/javascript/controllers/index.js` — register sync controller
- `engines/collavre/app/javascript/modules/creative_row_editor.js` — editing signals

### View & CSS
- `engines/collavre/app/views/collavre/creatives/index.html.erb` — presence container + sync controller data attrs
- `engines/collavre/app/assets/stylesheets/collavre/creatives.css` — presence avatars + editing indicator styles

### Tests
- `engines/collavre/test/channels/creatives_channel_test.rb` — 7 tests
- `engines/collavre/test/models/collavre/creative_presence_store_test.rb` — 4 tests

## Testing

- Rubocop: ✅ 741 files inspected, no offenses
- Channel tests: ✅ 7 runs, 13 assertions, 0 failures
- Presence store tests: ✅ 4 runs, 4 assertions, 0 failures
