### PR TITLE
feat: add image lightbox carousel with download and zoom support

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/image_lightbox.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/image_lightbox.css
@@ -105,9 +105,9 @@
   transition: transform 0.1s ease-out;
 }
 
-/* Navigation arrows */
+/* Navigation arrows — positioned relative to container, not stage */
 .image-lightbox-nav {
-  position: absolute;
+  position: fixed;
   top: 50%;
   transform: translateY(-50%);
   width: 3rem;

--- a/engines/collavre/app/assets/stylesheets/collavre/image_lightbox.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/image_lightbox.css
@@ -9,33 +9,21 @@
   margin: 0;
   padding: 0;
   border: none;
-  background: transparent;
+  background: rgba(0, 0, 0, 0.92);
   z-index: var(--layer-important, 999);
   overflow: hidden;
 }
 
 .image-lightbox-dialog::backdrop {
-  background: rgba(0, 0, 0, 0.9);
-}
-
-.image-lightbox-backdrop {
-  position: absolute;
-  inset: 0;
-  z-index: 0;
+  background: rgba(0, 0, 0, 0.92);
 }
 
 .image-lightbox-container {
-  position: relative;
-  z-index: 1;
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-rows: auto 1fr;
   width: 100%;
   height: 100%;
-  pointer-events: none;
-}
-
-.image-lightbox-container > * {
-  pointer-events: auto;
+  position: relative;
 }
 
 /* Toolbar */
@@ -47,6 +35,7 @@
   color: #fff;
   font-size: var(--text-1, 0.875rem);
   background: rgba(0, 0, 0, 0.4);
+  z-index: 3;
 }
 
 .image-lightbox-toolbar-actions {
@@ -83,32 +72,31 @@
   border-color: rgba(255, 255, 255, 0.5);
 }
 
-/* Stage */
+/* Stage — takes all remaining space, centers image */
 .image-lightbox-stage {
-  flex: 1;
   display: flex;
   align-items: center;
   justify-content: center;
-  position: relative;
   overflow: hidden;
   min-height: 0;
+  position: relative;
 }
 
 .image-lightbox-image {
   max-width: 90vw;
-  max-height: calc(100vh - 4rem);
+  max-height: 100%;
   object-fit: contain;
   border-radius: var(--radius-2, 4px);
   user-select: none;
   -webkit-user-drag: none;
   transform-origin: center center;
-  transition: transform 0.1s ease-out;
 }
 
-/* Navigation arrows — positioned relative to container, not stage */
+/* Navigation arrows — absolute within container, vertically centered in stage area */
 .image-lightbox-nav {
-  position: fixed;
-  top: 50%;
+  position: absolute;
+  /* Center in stage area: toolbar height (~46px) + half of remaining */
+  top: calc(50% + 23px);
   transform: translateY(-50%);
   width: 3rem;
   height: 3rem;

--- a/engines/collavre/app/assets/stylesheets/collavre/image_lightbox.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/image_lightbox.css
@@ -101,6 +101,8 @@
   border-radius: var(--radius-2, 4px);
   user-select: none;
   -webkit-user-drag: none;
+  transform-origin: center center;
+  transition: transform 0.1s ease-out;
 }
 
 /* Navigation arrows */

--- a/engines/collavre/app/assets/stylesheets/collavre/image_lightbox.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/image_lightbox.css
@@ -2,21 +2,22 @@
 .image-lightbox-dialog {
   position: fixed;
   inset: 0;
-  width: 100vw;
-  height: 100vh;
-  max-width: 100vw;
-  max-height: 100vh;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  max-height: none;
   margin: 0;
   padding: 0;
   border: none;
   background: rgba(0, 0, 0, 0.92);
   z-index: var(--layer-important, 999);
   overflow: hidden;
-  display: block;
+  display: flex;
+  flex-direction: column;
 }
 
 .image-lightbox-dialog[open] {
-  display: block;
+  display: flex;
 }
 
 .image-lightbox-dialog::backdrop {
@@ -25,17 +26,14 @@
 
 /* Full-size overlay container */
 .image-lightbox-container {
-  width: 100vw;
-  height: 100vh;
-  position: relative;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
 }
 
 /* Toolbar pinned to top */
 .image-lightbox-toolbar {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -44,6 +42,7 @@
   font-size: var(--text-1, 0.875rem);
   background: rgba(0, 0, 0, 0.6);
   z-index: 3;
+  flex-shrink: 0;
 }
 
 .image-lightbox-toolbar-actions {
@@ -80,19 +79,20 @@
   border-color: rgba(255, 255, 255, 0.5);
 }
 
-/* Stage — fills entire container, centers image */
+/* Stage — takes remaining space, centers image */
 .image-lightbox-stage {
-  position: absolute;
-  inset: 0;
+  flex: 1;
   display: flex;
   align-items: center;
   justify-content: center;
   overflow: hidden;
+  min-height: 0;
+  position: relative;
 }
 
 .image-lightbox-image {
-  max-width: 90vw;
-  max-height: 90vh;
+  max-width: 90%;
+  max-height: 90%;
   object-fit: contain;
   border-radius: var(--radius-2, 4px);
   user-select: none;
@@ -101,7 +101,7 @@
   transition: opacity 0.15s ease;
 }
 
-/* Navigation arrows — positioned via JS using fixed pixel values */
+/* Navigation arrows — positioned via JS */
 .image-lightbox-nav {
   position: fixed;
   width: 3rem;
@@ -123,8 +123,6 @@
   background: rgba(0, 0, 0, 0.7);
 }
 
-/* left/right set via JS */
-
 /* Responsive */
 @media (max-width: 768px) {
   .image-lightbox-btn-label {
@@ -138,6 +136,6 @@
   }
 
   .image-lightbox-image {
-    max-width: 96vw;
+    max-width: 96%;
   }
 }

--- a/engines/collavre/app/assets/stylesheets/collavre/image_lightbox.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/image_lightbox.css
@@ -1,0 +1,166 @@
+/* Image Lightbox Carousel */
+.image-lightbox-dialog {
+  position: fixed;
+  inset: 0;
+  width: 100vw;
+  height: 100vh;
+  max-width: 100vw;
+  max-height: 100vh;
+  margin: 0;
+  padding: 0;
+  border: none;
+  background: transparent;
+  z-index: var(--layer-important, 999);
+  overflow: hidden;
+}
+
+.image-lightbox-dialog::backdrop {
+  background: rgba(0, 0, 0, 0.9);
+}
+
+.image-lightbox-backdrop {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+}
+
+.image-lightbox-container {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+
+.image-lightbox-container > * {
+  pointer-events: auto;
+}
+
+/* Toolbar */
+.image-lightbox-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--space-2, 0.5rem) var(--space-3, 0.75rem);
+  color: #fff;
+  font-size: var(--text-1, 0.875rem);
+  background: rgba(0, 0, 0, 0.4);
+}
+
+.image-lightbox-toolbar-actions {
+  display: flex;
+  gap: var(--space-2, 0.5rem);
+  align-items: center;
+}
+
+.image-lightbox-counter {
+  font-weight: var(--weight-6, 600);
+  user-select: none;
+}
+
+.image-lightbox-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border: none;
+  border-radius: var(--radius-2, 4px);
+  background: rgba(255, 255, 255, 0.15);
+  color: #fff;
+  font-size: 1rem;
+  cursor: pointer;
+  text-decoration: none;
+  transition: background 0.15s;
+}
+
+.image-lightbox-btn:hover {
+  background: rgba(255, 255, 255, 0.3);
+}
+
+/* Stage */
+.image-lightbox-stage {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  overflow: hidden;
+  min-height: 0;
+}
+
+.image-lightbox-image {
+  max-width: 90vw;
+  max-height: calc(100vh - 4rem);
+  object-fit: contain;
+  border-radius: var(--radius-2, 4px);
+  user-select: none;
+  -webkit-user-drag: none;
+}
+
+/* Navigation arrows */
+.image-lightbox-nav {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 3rem;
+  height: 3rem;
+  border: none;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.5);
+  color: #fff;
+  font-size: 1.5rem;
+  cursor: pointer;
+  transition: background 0.15s;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.image-lightbox-nav:hover {
+  background: rgba(0, 0, 0, 0.7);
+}
+
+.image-lightbox-prev {
+  left: var(--space-3, 0.75rem);
+}
+
+.image-lightbox-next {
+  right: var(--space-3, 0.75rem);
+}
+
+/* Comment attachments download-all button */
+.comment-download-all-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3em;
+  font-size: 0.8em;
+  color: var(--color-link);
+  text-decoration: none;
+  padding: 0.25em 0.5em;
+  border-radius: var(--radius-2, 4px);
+  border: 1px solid var(--color-border);
+  background: var(--color-section-bg);
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.comment-download-all-btn:hover {
+  filter: brightness(var(--hover-brightness, 0.9));
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .image-lightbox-nav {
+    width: 2.25rem;
+    height: 2.25rem;
+    font-size: 1.25rem;
+  }
+
+  .image-lightbox-image {
+    max-width: 96vw;
+  }
+}

--- a/engines/collavre/app/assets/stylesheets/collavre/image_lightbox.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/image_lightbox.css
@@ -61,23 +61,26 @@
 }
 
 .image-lightbox-btn {
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  color: rgba(255, 255, 255, 0.85);
+  cursor: pointer;
+  height: 30px;
+  padding: 0 var(--space-2, 0.5rem);
+  border-radius: var(--radius-2, 4px);
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 2rem;
-  height: 2rem;
-  border: none;
-  border-radius: var(--radius-2, 4px);
-  background: rgba(255, 255, 255, 0.15);
-  color: #fff;
-  font-size: 1rem;
-  cursor: pointer;
+  font-size: var(--text-0, 0.8rem);
+  transition: background 0.15s var(--ease-out-2, ease-out), color 0.15s var(--ease-out-2, ease-out), border-color 0.15s var(--ease-out-2, ease-out);
   text-decoration: none;
-  transition: background 0.15s;
+  gap: var(--space-1, 0.25rem);
 }
 
 .image-lightbox-btn:hover {
-  background: rgba(255, 255, 255, 0.3);
+  background: rgba(255, 255, 255, 0.15);
+  color: #fff;
+  border-color: rgba(255, 255, 255, 0.5);
 }
 
 /* Stage */

--- a/engines/collavre/app/assets/stylesheets/collavre/image_lightbox.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/image_lightbox.css
@@ -159,6 +159,10 @@
 
 /* Responsive */
 @media (max-width: 768px) {
+  .image-lightbox-btn-label {
+    display: none;
+  }
+
   .image-lightbox-nav {
     width: 2.25rem;
     height: 2.25rem;

--- a/engines/collavre/app/assets/stylesheets/collavre/image_lightbox.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/image_lightbox.css
@@ -101,11 +101,9 @@
   transition: opacity 0.15s ease;
 }
 
-/* Navigation arrows — absolute in container, always vertically centered */
+/* Navigation arrows — positioned via JS using fixed pixel values */
 .image-lightbox-nav {
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
+  position: fixed;
   width: 3rem;
   height: 3rem;
   border: none;
@@ -115,7 +113,7 @@
   font-size: 1.5rem;
   cursor: pointer;
   transition: background 0.15s;
-  z-index: 2;
+  z-index: 99999;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -125,13 +123,7 @@
   background: rgba(0, 0, 0, 0.7);
 }
 
-.image-lightbox-prev {
-  left: var(--space-3, 0.75rem);
-}
-
-.image-lightbox-next {
-  right: var(--space-3, 0.75rem);
-}
+/* left/right set via JS */
 
 /* Responsive */
 @media (max-width: 768px) {

--- a/engines/collavre/app/assets/stylesheets/collavre/image_lightbox.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/image_lightbox.css
@@ -18,23 +18,26 @@
   background: rgba(0, 0, 0, 0.92);
 }
 
+/* Full-size overlay container */
 .image-lightbox-container {
-  display: grid;
-  grid-template-rows: auto 1fr;
-  width: 100%;
-  height: 100%;
+  width: 100vw;
+  height: 100vh;
   position: relative;
 }
 
-/* Toolbar */
+/* Toolbar pinned to top */
 .image-lightbox-toolbar {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
   display: flex;
   justify-content: space-between;
   align-items: center;
   padding: var(--space-2, 0.5rem) var(--space-3, 0.75rem);
   color: #fff;
   font-size: var(--text-1, 0.875rem);
-  background: rgba(0, 0, 0, 0.4);
+  background: rgba(0, 0, 0, 0.6);
   z-index: 3;
 }
 
@@ -72,19 +75,19 @@
   border-color: rgba(255, 255, 255, 0.5);
 }
 
-/* Stage — takes all remaining space, centers image */
+/* Stage — fills entire container, centers image */
 .image-lightbox-stage {
+  position: absolute;
+  inset: 0;
   display: flex;
   align-items: center;
   justify-content: center;
   overflow: hidden;
-  min-height: 0;
-  position: relative;
 }
 
 .image-lightbox-image {
   max-width: 90vw;
-  max-height: 100%;
+  max-height: 90vh;
   object-fit: contain;
   border-radius: var(--radius-2, 4px);
   user-select: none;
@@ -92,11 +95,10 @@
   transform-origin: center center;
 }
 
-/* Navigation arrows — absolute within container, vertically centered in stage area */
+/* Navigation arrows — absolute in container, always vertically centered */
 .image-lightbox-nav {
   position: absolute;
-  /* Center in stage area: toolbar height (~46px) + half of remaining */
-  top: calc(50% + 23px);
+  top: 50%;
   transform: translateY(-50%);
   width: 3rem;
   height: 3rem;
@@ -123,26 +125,6 @@
 
 .image-lightbox-next {
   right: var(--space-3, 0.75rem);
-}
-
-/* Comment attachments download-all button */
-.comment-download-all-btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.3em;
-  font-size: 0.8em;
-  color: var(--color-link);
-  text-decoration: none;
-  padding: 0.25em 0.5em;
-  border-radius: var(--radius-2, 4px);
-  border: 1px solid var(--color-border);
-  background: var(--color-section-bg);
-  cursor: pointer;
-  transition: background 0.15s;
-}
-
-.comment-download-all-btn:hover {
-  filter: brightness(var(--hover-brightness, 0.9));
 }
 
 /* Responsive */

--- a/engines/collavre/app/assets/stylesheets/collavre/image_lightbox.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/image_lightbox.css
@@ -12,6 +12,11 @@
   background: rgba(0, 0, 0, 0.92);
   z-index: var(--layer-important, 999);
   overflow: hidden;
+  display: block;
+}
+
+.image-lightbox-dialog[open] {
+  display: block;
 }
 
 .image-lightbox-dialog::backdrop {

--- a/engines/collavre/app/assets/stylesheets/collavre/image_lightbox.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/image_lightbox.css
@@ -98,6 +98,7 @@
   user-select: none;
   -webkit-user-drag: none;
   transform-origin: center center;
+  transition: opacity 0.15s ease;
 }
 
 /* Navigation arrows — absolute in container, always vertically centered */

--- a/engines/collavre/app/controllers/collavre/comments_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comments_controller.rb
@@ -323,26 +323,19 @@ module Collavre
         return
       end
 
-      # All images as zip (using Tempfile to avoid large memory buffers)
+      # All images as zip
       require "zip"
       zip_filename = "images-comment-#{@comment.id}.zip"
 
-      tempfile = Tempfile.new([ "images", ".zip" ])
-      begin
-        Zip::OutputStream.open(tempfile.path) do |zip|
-          images.each do |image|
-            zip.put_next_entry(image.filename.to_s)
-            image.blob.open do |file|
-              zip.write(file.read)
-            end
-          end
+      buffer = Zip::OutputStream.write_buffer do |zip|
+        images.each do |image|
+          zip.put_next_entry(image.filename.to_s)
+          image.blob.open { |file| zip.write(file.read) }
         end
-
-        send_file tempfile.path, filename: zip_filename, type: "application/zip", disposition: "attachment"
-      ensure
-        tempfile.close
-        tempfile.unlink
       end
+      buffer.rewind
+
+      send_data buffer.read, filename: zip_filename, type: "application/zip", disposition: "attachment"
     end
 
     def remove_image

--- a/engines/collavre/app/controllers/collavre/comments_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comments_controller.rb
@@ -5,7 +5,7 @@ module Collavre
     include Collavre::Comments::BatchOperations
 
     before_action :set_creative
-    before_action :set_comment, only: [ :destroy, :show, :update, :convert, :approve, :update_action, :download_images ]
+    before_action :set_comment, only: [ :destroy, :show, :update, :convert, :approve, :update_action, :download_images, :remove_image ]
 
     def fullscreen
       # Render the creative index page with comments popup auto-opened in fullscreen.
@@ -334,6 +334,25 @@ module Collavre
       buffer.rewind
 
       send_data buffer.read, filename: zip_filename, type: "application/zip", disposition: "attachment"
+    end
+
+    def remove_image
+      images = @comment.images
+      index = params[:index].to_i
+      image = images.to_a[index]
+
+      unless image
+        head :not_found
+        return
+      end
+
+      unless @comment.user_id == Current.user.id || Current.user.system_admin?
+        head :forbidden
+        return
+      end
+
+      image.purge
+      head :ok
     end
 
     private

--- a/engines/collavre/app/controllers/collavre/comments_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comments_controller.rb
@@ -5,7 +5,7 @@ module Collavre
     include Collavre::Comments::BatchOperations
 
     before_action :set_creative
-    before_action :set_comment, only: [ :destroy, :show, :update, :convert, :approve, :update_action ]
+    before_action :set_comment, only: [ :destroy, :show, :update, :convert, :approve, :update_action, :download_images ]
 
     def fullscreen
       # Render the creative index page with comments popup auto-opened in fullscreen.
@@ -305,6 +305,37 @@ module Collavre
 
 
     private
+
+    def download_images
+      images = @comment.images
+      unless images.attached?
+        head :not_found
+        return
+      end
+
+      if images.count == 1
+        redirect_to main_app.rails_blob_path(images.first, disposition: "attachment")
+        return
+      end
+
+      require "zip"
+      zip_filename = "images-comment-#{@comment.id}.zip"
+
+      response.headers["Content-Type"] = "application/zip"
+      response.headers["Content-Disposition"] = "attachment; filename=\"#{zip_filename}\""
+      response.headers["Cache-Control"] = "no-cache"
+
+      # Stream zip
+      self.response_body = Enumerator.new do |yielder|
+        buffer = Zip::OutputStream.write_buffer do |zip|
+          images.each do |image|
+            zip.put_next_entry(image.filename.to_s)
+            image.download { |chunk| zip.write(chunk) }
+          end
+        end
+        yielder << buffer.string
+      end
+    end
 
     def set_creative
       @creative = Creative.find(params[:creative_id]).effective_origin

--- a/engines/collavre/app/controllers/collavre/comments_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comments_controller.rb
@@ -318,20 +318,15 @@ module Collavre
       require "zip"
       zip_filename = "images-comment-#{@comment.id}.zip"
 
-      response.headers["Content-Type"] = "application/zip"
-      response.headers["Content-Disposition"] = "attachment; filename=\"#{zip_filename}\""
-      response.headers["Cache-Control"] = "no-cache"
-
-      # Stream zip
-      self.response_body = Enumerator.new do |yielder|
-        buffer = Zip::OutputStream.write_buffer do |zip|
-          images.each do |image|
-            zip.put_next_entry(image.filename.to_s)
-            image.download { |chunk| zip.write(chunk) }
-          end
+      buffer = Zip::OutputStream.write_buffer do |zip|
+        images.each do |image|
+          zip.put_next_entry(image.filename.to_s)
+          zip.write(image.download)
         end
-        yielder << buffer.string
       end
+      buffer.rewind
+
+      send_data buffer.read, filename: zip_filename, type: "application/zip"
     end
 
     private

--- a/engines/collavre/app/controllers/collavre/comments_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comments_controller.rb
@@ -310,11 +310,18 @@ module Collavre
         return
       end
 
-      if images.count == 1
-        redirect_to main_app.rails_blob_path(images.first, disposition: "attachment")
+      # Single image download by index
+      if params[:index].present?
+        image = images.to_a[params[:index].to_i]
+        unless image
+          head :not_found
+          return
+        end
+        send_data image.download, filename: image.filename.to_s, type: image.content_type, disposition: "attachment"
         return
       end
 
+      # All images as zip
       require "zip"
       zip_filename = "images-comment-#{@comment.id}.zip"
 

--- a/engines/collavre/app/controllers/collavre/comments_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comments_controller.rb
@@ -326,7 +326,7 @@ module Collavre
       end
       buffer.rewind
 
-      send_data buffer.read, filename: zip_filename, type: "application/zip"
+      send_data buffer.read, filename: zip_filename, type: "application/zip", disposition: "attachment"
     end
 
     private

--- a/engines/collavre/app/controllers/collavre/comments_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comments_controller.rb
@@ -317,23 +317,32 @@ module Collavre
           head :not_found
           return
         end
-        send_data image.download, filename: image.filename.to_s, type: image.content_type, disposition: "attachment"
+        image.blob.open do |file|
+          send_data file.read, filename: image.filename.to_s, type: image.content_type, disposition: "attachment"
+        end
         return
       end
 
-      # All images as zip
+      # All images as zip (using Tempfile to avoid large memory buffers)
       require "zip"
       zip_filename = "images-comment-#{@comment.id}.zip"
 
-      buffer = Zip::OutputStream.write_buffer do |zip|
-        images.each do |image|
-          zip.put_next_entry(image.filename.to_s)
-          zip.write(image.download)
+      tempfile = Tempfile.new([ "images", ".zip" ])
+      begin
+        Zip::OutputStream.open(tempfile.path) do |zip|
+          images.each do |image|
+            zip.put_next_entry(image.filename.to_s)
+            image.blob.open do |file|
+              zip.write(file.read)
+            end
+          end
         end
-      end
-      buffer.rewind
 
-      send_data buffer.read, filename: zip_filename, type: "application/zip", disposition: "attachment"
+        send_file tempfile.path, filename: zip_filename, type: "application/zip", disposition: "attachment"
+      ensure
+        tempfile.close
+        tempfile.unlink
+      end
     end
 
     def remove_image

--- a/engines/collavre/app/controllers/collavre/comments_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comments_controller.rb
@@ -303,9 +303,6 @@ module Collavre
       render json: CommandMenuService.new(user: Current.user).items
     end
 
-
-    private
-
     def download_images
       images = @comment.images
       unless images.attached?
@@ -336,6 +333,8 @@ module Collavre
         yielder << buffer.string
       end
     end
+
+    private
 
     def set_creative
       @creative = Creative.find(params[:creative_id]).effective_origin

--- a/engines/collavre/app/helpers/collavre/application_helper.rb
+++ b/engines/collavre/app/helpers/collavre/application_helper.rb
@@ -17,6 +17,7 @@ module Collavre
       collavre/comment_versions
       collavre/mention_menu
       collavre/slide_view
+      collavre/image_lightbox
     ].freeze
 
     COLLAVRE_PRINT_STYLESHEETS = %w[

--- a/engines/collavre/app/javascript/controllers/image_lightbox_controller.js
+++ b/engines/collavre/app/javascript/controllers/image_lightbox_controller.js
@@ -76,14 +76,23 @@ export default class extends Controller {
       this._close()
     })
 
-    // Handle download links - use fetch+blob to bypass Turbo and dialog issues
+    // Handle download links - use hidden iframe to trigger download
+    // This bypasses both Turbo interception and dialog close issues
     dialog.querySelectorAll(".image-lightbox-download-one, .image-lightbox-download-all").forEach((el) => {
       el.addEventListener("click", (e) => {
         e.preventDefault()
         e.stopPropagation()
         const url = el.href
         if (!url) return
-        this._downloadViaFetch(url, el.dataset.filename || "")
+        // Use a hidden iframe to trigger download without leaving the page
+        let iframe = document.getElementById("image-lightbox-download-frame")
+        if (!iframe) {
+          iframe = document.createElement("iframe")
+          iframe.id = "image-lightbox-download-frame"
+          iframe.style.display = "none"
+          document.body.appendChild(iframe)
+        }
+        iframe.src = url
       })
     })
 
@@ -146,28 +155,6 @@ export default class extends Controller {
       this._dialog.remove()
       this._dialog = null
     }
-  }
-
-  _downloadViaFetch(url, fallbackFilename) {
-    fetch(url, { credentials: "same-origin" })
-      .then((resp) => {
-        // Extract filename from Content-Disposition header if available
-        const disposition = resp.headers.get("Content-Disposition") || ""
-        const match = disposition.match(/filename="?([^";\n]+)"?/)
-        const filename = match ? match[1] : (fallbackFilename || url.split("/").pop())
-        return resp.blob().then((blob) => ({ blob, filename }))
-      })
-      .then(({ blob, filename }) => {
-        const blobUrl = URL.createObjectURL(blob)
-        const a = document.createElement("a")
-        a.href = blobUrl
-        a.download = filename
-        a.style.display = "none"
-        document.body.appendChild(a)
-        a.click()
-        document.body.removeChild(a)
-        URL.revokeObjectURL(blobUrl)
-      })
   }
 
   _handleKeydown(e) {

--- a/engines/collavre/app/javascript/controllers/image_lightbox_controller.js
+++ b/engines/collavre/app/javascript/controllers/image_lightbox_controller.js
@@ -4,7 +4,14 @@ import { Controller } from "@hotwired/stimulus"
 // Provides a fullscreen image carousel with navigation, download, and zoom
 export default class extends Controller {
   static values = {
-    downloadAllUrl: String
+    downloadAllUrl: String,
+    i18nClose: { type: String, default: "Close" },
+    i18nPrevious: { type: String, default: "Previous" },
+    i18nNext: { type: String, default: "Next" },
+    i18nDownload: { type: String, default: "Download" },
+    i18nDownloadAll: { type: String, default: "Download all" },
+    i18nDelete: { type: String, default: "Delete" },
+    i18nDeleteConfirm: { type: String, default: "Delete this image?" }
   }
 
   connect() {
@@ -192,20 +199,20 @@ export default class extends Controller {
         <div class="image-lightbox-toolbar">
           <span class="image-lightbox-counter"></span>
           <div class="image-lightbox-toolbar-actions">
-            <button class="image-lightbox-btn image-lightbox-zoom-in" type="button" title="Zoom in">🔍+ <span class="image-lightbox-btn-label">Zoom in</span></button>
-            <button class="image-lightbox-btn image-lightbox-zoom-out" type="button" title="Zoom out">🔍− <span class="image-lightbox-btn-label">Zoom out</span></button>
+            <button class="image-lightbox-btn image-lightbox-zoom-in" type="button" title="Zoom in">🔍+</button>
+            <button class="image-lightbox-btn image-lightbox-zoom-out" type="button" title="Zoom out">🔍−</button>
             <button class="image-lightbox-btn image-lightbox-zoom-reset" type="button" title="Reset zoom">1:1</button>
-            <button class="image-lightbox-btn image-lightbox-download-one" type="button" title="Download">⬇ <span class="image-lightbox-btn-label">Download</span></button>
-            ${this.hasDownloadAllUrlValue ? `<button class="image-lightbox-btn image-lightbox-download-all" type="button" title="Download all">📥 <span class="image-lightbox-btn-label">All</span></button>` : ""}
-            <button class="image-lightbox-btn image-lightbox-delete" type="button" title="Delete">🗑 <span class="image-lightbox-btn-label">Delete</span></button>
-            <button class="image-lightbox-btn image-lightbox-close" type="button" title="Close">✕ <span class="image-lightbox-btn-label">Close</span></button>
+            <button class="image-lightbox-btn image-lightbox-download-one" type="button" title="${this.i18nDownloadValue}">⬇ <span class="image-lightbox-btn-label">${this.i18nDownloadValue}</span></button>
+            ${this.hasDownloadAllUrlValue ? `<button class="image-lightbox-btn image-lightbox-download-all" type="button" title="${this.i18nDownloadAllValue}">📥 <span class="image-lightbox-btn-label">${this.i18nDownloadAllValue}</span></button>` : ""}
+            <button class="image-lightbox-btn image-lightbox-delete" type="button" title="${this.i18nDeleteValue}">🗑 <span class="image-lightbox-btn-label">${this.i18nDeleteValue}</span></button>
+            <button class="image-lightbox-btn image-lightbox-close" type="button" title="${this.i18nCloseValue}">✕ <span class="image-lightbox-btn-label">${this.i18nCloseValue}</span></button>
           </div>
         </div>
         <div class="image-lightbox-stage">
           <img class="image-lightbox-image" src="" alt="" draggable="false" />
         </div>
-        <button class="image-lightbox-nav image-lightbox-prev" type="button" title="Previous">‹</button>
-        <button class="image-lightbox-nav image-lightbox-next" type="button" title="Next">›</button>
+        <button class="image-lightbox-nav image-lightbox-prev" type="button" title="${this.i18nPreviousValue}">‹</button>
+        <button class="image-lightbox-nav image-lightbox-next" type="button" title="${this.i18nNextValue}">›</button>
       </div>
     `
 
@@ -331,7 +338,7 @@ export default class extends Controller {
 
   async _deleteCurrentImage() {
     if (!this.hasDownloadAllUrlValue) return
-    if (!confirm("Delete this image?")) return
+    if (!confirm(this.i18nDeleteConfirmValue)) return
 
     const url = `${this.downloadAllUrlValue.replace("download_images", "remove_image")}?index=${this._currentIndex}`
     const csrfToken = document.querySelector("meta[name='csrf-token']")?.content

--- a/engines/collavre/app/javascript/controllers/image_lightbox_controller.js
+++ b/engines/collavre/app/javascript/controllers/image_lightbox_controller.js
@@ -26,6 +26,7 @@ export default class extends Controller {
     this._createDialog()
     this._showImage()
     this._dialog.showModal()
+    this._positionNavButtons()
     document.addEventListener("keydown", this._boundKeydown)
   }
 
@@ -357,6 +358,20 @@ export default class extends Controller {
     if (this._images.length <= 1) return
     this._currentIndex = (this._currentIndex + 1) % this._images.length
     this._showImage()
+  }
+
+  _positionNavButtons() {
+    if (!this._dialog) return
+    const prevBtn = this._dialog.querySelector(".image-lightbox-prev")
+    const nextBtn = this._dialog.querySelector(".image-lightbox-next")
+    if (!prevBtn || !nextBtn) return
+
+    const centerY = Math.round(window.innerHeight / 2 - 24) // 24 = half of 3rem button
+    prevBtn.style.top = `${centerY}px`
+    prevBtn.style.left = "12px"
+    nextBtn.style.top = `${centerY}px`
+    nextBtn.style.right = "12px"
+    nextBtn.style.left = "auto"
   }
 
   _close() {

--- a/engines/collavre/app/javascript/controllers/image_lightbox_controller.js
+++ b/engines/collavre/app/javascript/controllers/image_lightbox_controller.js
@@ -191,13 +191,13 @@ export default class extends Controller {
         <div class="image-lightbox-toolbar">
           <span class="image-lightbox-counter"></span>
           <div class="image-lightbox-toolbar-actions">
-            <button class="image-lightbox-btn image-lightbox-zoom-in" type="button" title="Zoom in">🔍+</button>
-            <button class="image-lightbox-btn image-lightbox-zoom-out" type="button" title="Zoom out">🔍−</button>
+            <button class="image-lightbox-btn image-lightbox-zoom-in" type="button" title="Zoom in">🔍+ <span class="image-lightbox-btn-label">Zoom in</span></button>
+            <button class="image-lightbox-btn image-lightbox-zoom-out" type="button" title="Zoom out">🔍− <span class="image-lightbox-btn-label">Zoom out</span></button>
             <button class="image-lightbox-btn image-lightbox-zoom-reset" type="button" title="Reset zoom">1:1</button>
-            <button class="image-lightbox-btn image-lightbox-download-one" type="button" title="Download">⬇ Download</button>
-            ${this.hasDownloadAllUrlValue ? `<button class="image-lightbox-btn image-lightbox-download-all" type="button" title="Download all">📥 All</button>` : ""}
-            <button class="image-lightbox-btn image-lightbox-delete" type="button" title="Delete">🗑 Delete</button>
-            <button class="image-lightbox-btn image-lightbox-close" type="button" title="Close">✕ Close</button>
+            <button class="image-lightbox-btn image-lightbox-download-one" type="button" title="Download">⬇ <span class="image-lightbox-btn-label">Download</span></button>
+            ${this.hasDownloadAllUrlValue ? `<button class="image-lightbox-btn image-lightbox-download-all" type="button" title="Download all">📥 <span class="image-lightbox-btn-label">All</span></button>` : ""}
+            <button class="image-lightbox-btn image-lightbox-delete" type="button" title="Delete">🗑 <span class="image-lightbox-btn-label">Delete</span></button>
+            <button class="image-lightbox-btn image-lightbox-close" type="button" title="Close">✕ <span class="image-lightbox-btn-label">Close</span></button>
           </div>
         </div>
         <div class="image-lightbox-stage">

--- a/engines/collavre/app/javascript/controllers/image_lightbox_controller.js
+++ b/engines/collavre/app/javascript/controllers/image_lightbox_controller.js
@@ -201,10 +201,10 @@ export default class extends Controller {
           </div>
         </div>
         <div class="image-lightbox-stage">
-          <button class="image-lightbox-nav image-lightbox-prev" type="button" title="Previous">‹</button>
           <img class="image-lightbox-image" src="" alt="" draggable="false" />
-          <button class="image-lightbox-nav image-lightbox-next" type="button" title="Next">›</button>
         </div>
+        <button class="image-lightbox-nav image-lightbox-prev" type="button" title="Previous">‹</button>
+        <button class="image-lightbox-nav image-lightbox-next" type="button" title="Next">›</button>
       </div>
     `
 

--- a/engines/collavre/app/javascript/controllers/image_lightbox_controller.js
+++ b/engines/collavre/app/javascript/controllers/image_lightbox_controller.js
@@ -364,9 +364,12 @@ export default class extends Controller {
     if (!this._dialog) return
     const prevBtn = this._dialog.querySelector(".image-lightbox-prev")
     const nextBtn = this._dialog.querySelector(".image-lightbox-next")
-    if (!prevBtn || !nextBtn) return
+    const stage = this._dialog.querySelector(".image-lightbox-stage")
+    if (!prevBtn || !nextBtn || !stage) return
 
-    const centerY = Math.round(window.innerHeight / 2 - 24) // 24 = half of 3rem button
+    const stageRect = stage.getBoundingClientRect()
+    const btnHeight = prevBtn.offsetHeight || 48
+    const centerY = Math.round(stageRect.top + stageRect.height / 2 - btnHeight / 2)
     prevBtn.style.top = `${centerY}px`
     prevBtn.style.left = "12px"
     nextBtn.style.top = `${centerY}px`

--- a/engines/collavre/app/javascript/controllers/image_lightbox_controller.js
+++ b/engines/collavre/app/javascript/controllers/image_lightbox_controller.js
@@ -209,106 +209,9 @@ export default class extends Controller {
       </div>
     `
 
-    // Close on backdrop click
-    dialog.addEventListener("click", (e) => {
-      if (e.target === dialog) this._close()
-    })
-    dialog.querySelector(".image-lightbox-close").addEventListener("click", () => this._close())
-    dialog.querySelector(".image-lightbox-prev").addEventListener("click", () => this._prev())
-    dialog.querySelector(".image-lightbox-next").addEventListener("click", () => this._next())
-    dialog.addEventListener("cancel", (e) => {
-      e.preventDefault()
-      this._close()
-    })
-
-    // Zoom buttons
-    dialog.querySelector(".image-lightbox-zoom-in").addEventListener("click", (e) => {
-      e.stopPropagation()
-      this._setZoom(this._zoom + 0.25)
-    })
-    dialog.querySelector(".image-lightbox-zoom-out").addEventListener("click", (e) => {
-      e.stopPropagation()
-      this._setZoom(this._zoom - 0.25)
-    })
-    dialog.querySelector(".image-lightbox-zoom-reset").addEventListener("click", (e) => {
-      e.stopPropagation()
-      this._resetZoom()
-    })
-
-    // Delete button
-    dialog.querySelector(".image-lightbox-delete").addEventListener("click", async (e) => {
-      e.stopPropagation()
-      if (!this.hasDownloadAllUrlValue) return
-      if (!confirm("Delete this image?")) return
-
-      const url = `${this.downloadAllUrlValue.replace("download_images", "remove_image")}?index=${this._currentIndex}`
-      const csrfToken = document.querySelector("meta[name='csrf-token']")?.content
-
-      try {
-        const resp = await fetch(url, {
-          method: "DELETE",
-          credentials: "same-origin",
-          headers: { "X-CSRF-Token": csrfToken }
-        })
-        if (resp.ok) {
-          // Remove from gallery
-          this._images.splice(this._currentIndex, 1)
-          if (this._images.length === 0) {
-            this._close()
-            // Reload comments to reflect removal
-            this.element.closest("[data-controller]")?.dispatchEvent(new CustomEvent("lightbox:image-deleted", { bubbles: true }))
-            location.reload()
-            return
-          }
-          if (this._currentIndex >= this._images.length) {
-            this._currentIndex = this._images.length - 1
-          }
-          this._showImage()
-
-          // Update download-all visibility
-          const downloadAllBtn = this._dialog.querySelector(".image-lightbox-download-all")
-          if (downloadAllBtn && this._images.length <= 1) {
-            downloadAllBtn.style.display = "none"
-          }
-        }
-      } catch (err) {
-        console.error("Delete failed:", err)
-      }
-    })
-
-    // Download buttons
-    dialog.querySelector(".image-lightbox-download-one").addEventListener("click", (e) => {
-      e.stopPropagation()
-      if (!this.hasDownloadAllUrlValue) return
-      const url = `${this.downloadAllUrlValue}?index=${this._currentIndex}`
-      this._triggerDownload(url)
-    })
-
-    const downloadAllBtn = dialog.querySelector(".image-lightbox-download-all")
-    if (downloadAllBtn) {
-      downloadAllBtn.addEventListener("click", (e) => {
-        e.stopPropagation()
-        this._triggerDownload(this.downloadAllUrlValue)
-      })
-    }
-
-    // Touch swipe (only when not zoomed)
-    let touchStartX = 0
-    const stage = dialog.querySelector(".image-lightbox-stage")
-    stage.addEventListener("touchstart", (e) => {
-      if (e.touches.length === 1) touchStartX = e.changedTouches[0].screenX
-    }, { passive: true })
-    stage.addEventListener("touchend", (e) => {
-      if (this._zoom > 1) return // Don't swipe when zoomed
-      if (e.changedTouches.length === 1) {
-        const diff = e.changedTouches[0].screenX - touchStartX
-        if (Math.abs(diff) > 50) {
-          diff > 0 ? this._prev() : this._next()
-        }
-      }
-    }, { passive: true })
-
-    // Setup zoom interactions (wheel, pinch, drag)
+    this._bindNavigationEvents(dialog)
+    this._bindToolbarEvents(dialog)
+    this._bindTouchEvents(dialog)
     this._setupZoom(dialog)
 
     document.body.appendChild(dialog)
@@ -358,6 +261,110 @@ export default class extends Controller {
     if (this._images.length <= 1) return
     this._currentIndex = (this._currentIndex + 1) % this._images.length
     this._showImage()
+  }
+
+  _bindNavigationEvents(dialog) {
+    dialog.addEventListener("click", (e) => {
+      if (e.target === dialog) this._close()
+    })
+    dialog.querySelector(".image-lightbox-close").addEventListener("click", () => this._close())
+    dialog.querySelector(".image-lightbox-prev").addEventListener("click", () => this._prev())
+    dialog.querySelector(".image-lightbox-next").addEventListener("click", () => this._next())
+    dialog.addEventListener("cancel", (e) => {
+      e.preventDefault()
+      this._close()
+    })
+  }
+
+  _bindToolbarEvents(dialog) {
+    // Zoom
+    dialog.querySelector(".image-lightbox-zoom-in").addEventListener("click", (e) => {
+      e.stopPropagation()
+      this._setZoom(this._zoom + 0.25)
+    })
+    dialog.querySelector(".image-lightbox-zoom-out").addEventListener("click", (e) => {
+      e.stopPropagation()
+      this._setZoom(this._zoom - 0.25)
+    })
+    dialog.querySelector(".image-lightbox-zoom-reset").addEventListener("click", (e) => {
+      e.stopPropagation()
+      this._resetZoom()
+    })
+
+    // Download
+    dialog.querySelector(".image-lightbox-download-one").addEventListener("click", (e) => {
+      e.stopPropagation()
+      if (!this.hasDownloadAllUrlValue) return
+      this._triggerDownload(`${this.downloadAllUrlValue}?index=${this._currentIndex}`)
+    })
+    const downloadAllBtn = dialog.querySelector(".image-lightbox-download-all")
+    if (downloadAllBtn) {
+      downloadAllBtn.addEventListener("click", (e) => {
+        e.stopPropagation()
+        this._triggerDownload(this.downloadAllUrlValue)
+      })
+    }
+
+    // Delete
+    dialog.querySelector(".image-lightbox-delete").addEventListener("click", (e) => {
+      e.stopPropagation()
+      this._deleteCurrentImage()
+    })
+  }
+
+  _bindTouchEvents(dialog) {
+    let touchStartX = 0
+    const stage = dialog.querySelector(".image-lightbox-stage")
+    stage.addEventListener("touchstart", (e) => {
+      if (e.touches.length === 1) touchStartX = e.changedTouches[0].screenX
+    }, { passive: true })
+    stage.addEventListener("touchend", (e) => {
+      if (this._zoom > 1) return
+      if (e.changedTouches.length === 1) {
+        const diff = e.changedTouches[0].screenX - touchStartX
+        if (Math.abs(diff) > 50) {
+          diff > 0 ? this._prev() : this._next()
+        }
+      }
+    }, { passive: true })
+  }
+
+  async _deleteCurrentImage() {
+    if (!this.hasDownloadAllUrlValue) return
+    if (!confirm("Delete this image?")) return
+
+    const url = `${this.downloadAllUrlValue.replace("download_images", "remove_image")}?index=${this._currentIndex}`
+    const csrfToken = document.querySelector("meta[name='csrf-token']")?.content
+
+    try {
+      const resp = await fetch(url, {
+        method: "DELETE",
+        credentials: "same-origin",
+        headers: { "X-CSRF-Token": csrfToken }
+      })
+      if (!resp.ok) return
+
+      this._images.splice(this._currentIndex, 1)
+      if (this._images.length === 0) {
+        this._close()
+        this.element.closest("[data-controller]")?.dispatchEvent(
+          new CustomEvent("lightbox:image-deleted", { bubbles: true })
+        )
+        location.reload()
+        return
+      }
+      if (this._currentIndex >= this._images.length) {
+        this._currentIndex = this._images.length - 1
+      }
+      this._showImage()
+
+      const downloadAllBtn = this._dialog.querySelector(".image-lightbox-download-all")
+      if (downloadAllBtn && this._images.length <= 1) {
+        downloadAllBtn.style.display = "none"
+      }
+    } catch (err) {
+      console.error("Delete failed:", err)
+    }
   }
 
   _positionNavButtons() {

--- a/engines/collavre/app/javascript/controllers/image_lightbox_controller.js
+++ b/engines/collavre/app/javascript/controllers/image_lightbox_controller.js
@@ -40,6 +40,19 @@ export default class extends Controller {
     }))
   }
 
+  _triggerDownload(url) {
+    if (!url) return
+    // Use a hidden iframe appended to document.body (outside dialog)
+    // This triggers a normal browser request with cookies, and
+    // Content-Disposition: attachment causes a file download
+    const iframe = document.createElement("iframe")
+    iframe.style.cssText = "position:absolute;width:0;height:0;border:0;visibility:hidden"
+    document.body.appendChild(iframe)
+    iframe.src = url
+    // Clean up after download starts
+    setTimeout(() => iframe.remove(), 30000)
+  }
+
   _createDialog() {
     if (this._dialog) {
       this._dialog.remove()
@@ -48,26 +61,27 @@ export default class extends Controller {
     const dialog = document.createElement("dialog")
     dialog.className = "image-lightbox-dialog"
     dialog.innerHTML = `
-      <div class="image-lightbox-backdrop" data-action="click"></div>
       <div class="image-lightbox-container">
         <div class="image-lightbox-toolbar">
           <span class="image-lightbox-counter"></span>
           <div class="image-lightbox-toolbar-actions">
-            <a class="image-lightbox-btn image-lightbox-download-one" title="" download data-turbo="false">⬇</a>
-            ${this.hasDownloadAllUrlValue ? `<a class="image-lightbox-btn image-lightbox-download-all" href="${this.downloadAllUrlValue}" title="" data-turbo="false">📥</a>` : ""}
-            <button class="image-lightbox-btn image-lightbox-close" type="button" title="">✕</button>
+            <button class="image-lightbox-btn image-lightbox-download-one" type="button" title="Download">⬇</button>
+            ${this.hasDownloadAllUrlValue ? `<button class="image-lightbox-btn image-lightbox-download-all" type="button" title="Download all">📥</button>` : ""}
+            <button class="image-lightbox-btn image-lightbox-close" type="button" title="Close">✕</button>
           </div>
         </div>
         <div class="image-lightbox-stage">
-          <button class="image-lightbox-nav image-lightbox-prev" type="button" title="">‹</button>
+          <button class="image-lightbox-nav image-lightbox-prev" type="button" title="Previous">‹</button>
           <img class="image-lightbox-image" src="" alt="" />
-          <button class="image-lightbox-nav image-lightbox-next" type="button" title="">›</button>
+          <button class="image-lightbox-nav image-lightbox-next" type="button" title="Next">›</button>
         </div>
       </div>
     `
 
-    // Event listeners
-    dialog.querySelector(".image-lightbox-backdrop").addEventListener("click", () => this._close())
+    // Close on backdrop click (clicking the dialog element itself, not children)
+    dialog.addEventListener("click", (e) => {
+      if (e.target === dialog) this._close()
+    })
     dialog.querySelector(".image-lightbox-close").addEventListener("click", () => this._close())
     dialog.querySelector(".image-lightbox-prev").addEventListener("click", () => this._prev())
     dialog.querySelector(".image-lightbox-next").addEventListener("click", () => this._next())
@@ -76,25 +90,20 @@ export default class extends Controller {
       this._close()
     })
 
-    // Handle download links - use hidden iframe to trigger download
-    // This bypasses both Turbo interception and dialog close issues
-    dialog.querySelectorAll(".image-lightbox-download-one, .image-lightbox-download-all").forEach((el) => {
-      el.addEventListener("click", (e) => {
-        e.preventDefault()
-        e.stopPropagation()
-        const url = el.href
-        if (!url) return
-        // Use a hidden iframe to trigger download without leaving the page
-        let iframe = document.getElementById("image-lightbox-download-frame")
-        if (!iframe) {
-          iframe = document.createElement("iframe")
-          iframe.id = "image-lightbox-download-frame"
-          iframe.style.display = "none"
-          document.body.appendChild(iframe)
-        }
-        iframe.src = url
-      })
+    // Download buttons - use <button> not <a> to avoid all link/Turbo issues
+    dialog.querySelector(".image-lightbox-download-one").addEventListener("click", (e) => {
+      e.stopPropagation()
+      const img = this._images[this._currentIndex]
+      if (img) this._triggerDownload(img.downloadSrc)
     })
+
+    const downloadAllBtn = dialog.querySelector(".image-lightbox-download-all")
+    if (downloadAllBtn) {
+      downloadAllBtn.addEventListener("click", (e) => {
+        e.stopPropagation()
+        this._triggerDownload(this.downloadAllUrlValue)
+      })
+    }
 
     // Touch swipe
     let touchStartX = 0
@@ -123,11 +132,6 @@ export default class extends Controller {
     // Counter
     const counter = this._dialog.querySelector(".image-lightbox-counter")
     counter.textContent = `${this._currentIndex + 1} / ${this._images.length}`
-
-    // Download link
-    const downloadBtn = this._dialog.querySelector(".image-lightbox-download-one")
-    downloadBtn.href = img.downloadSrc
-    downloadBtn.dataset.filename = img.filename
 
     // Nav visibility
     const prevBtn = this._dialog.querySelector(".image-lightbox-prev")

--- a/engines/collavre/app/javascript/controllers/image_lightbox_controller.js
+++ b/engines/collavre/app/javascript/controllers/image_lightbox_controller.js
@@ -76,10 +76,22 @@ export default class extends Controller {
       this._close()
     })
 
-    // Prevent download links from closing lightbox or propagating
+    // Handle download links - use programmatic download to avoid dialog interference
     dialog.querySelectorAll(".image-lightbox-download-one, .image-lightbox-download-all").forEach((el) => {
       el.addEventListener("click", (e) => {
+        e.preventDefault()
         e.stopPropagation()
+        const url = el.href
+        if (!url) return
+        // Create a temporary link outside the dialog to trigger download
+        const tmpLink = document.createElement("a")
+        tmpLink.href = url
+        tmpLink.download = el.download || ""
+        tmpLink.setAttribute("data-turbo", "false")
+        tmpLink.style.display = "none"
+        document.body.appendChild(tmpLink)
+        tmpLink.click()
+        document.body.removeChild(tmpLink)
       })
     })
 

--- a/engines/collavre/app/javascript/controllers/image_lightbox_controller.js
+++ b/engines/collavre/app/javascript/controllers/image_lightbox_controller.js
@@ -319,10 +319,22 @@ export default class extends Controller {
 
     const img = this._images[this._currentIndex]
     const imgEl = this._dialog.querySelector(".image-lightbox-image")
+
+    // Hide image during transition to prevent layout jump
+    imgEl.style.opacity = "0"
+
+    // Reset zoom before changing src
+    this._resetZoom()
+
     imgEl.src = img.fullSrc
 
-    // Reset zoom on image change
-    this._resetZoom()
+    // Show image once loaded (or immediately if cached)
+    const showImg = () => { imgEl.style.opacity = "1" }
+    if (imgEl.complete) {
+      showImg()
+    } else {
+      imgEl.onload = showImg
+    }
 
     // Counter
     const counter = this._dialog.querySelector(".image-lightbox-counter")

--- a/engines/collavre/app/javascript/controllers/image_lightbox_controller.js
+++ b/engines/collavre/app/javascript/controllers/image_lightbox_controller.js
@@ -93,8 +93,10 @@ export default class extends Controller {
     // Download buttons - use <button> not <a> to avoid all link/Turbo issues
     dialog.querySelector(".image-lightbox-download-one").addEventListener("click", (e) => {
       e.stopPropagation()
-      const img = this._images[this._currentIndex]
-      if (img && img.downloadSrc) this._fetchDownload(img.downloadSrc, img.filename)
+      if (!this.hasDownloadAllUrlValue) return
+      // Use same-origin endpoint with index param to avoid CORS/CSP issues
+      const url = `${this.downloadAllUrlValue}?index=${this._currentIndex}`
+      this._triggerDownload(url)
     })
 
     const downloadAllBtn = dialog.querySelector(".image-lightbox-download-all")
@@ -159,22 +161,6 @@ export default class extends Controller {
       this._dialog.remove()
       this._dialog = null
     }
-  }
-
-  _fetchDownload(url, filename) {
-    fetch(url, { credentials: "same-origin" })
-      .then((resp) => resp.blob())
-      .then((blob) => {
-        const blobUrl = URL.createObjectURL(blob)
-        const a = document.createElement("a")
-        a.href = blobUrl
-        a.download = filename || "download"
-        a.style.display = "none"
-        document.body.appendChild(a)
-        a.click()
-        a.remove()
-        URL.revokeObjectURL(blobUrl)
-      })
   }
 
   _handleKeydown(e) {

--- a/engines/collavre/app/javascript/controllers/image_lightbox_controller.js
+++ b/engines/collavre/app/javascript/controllers/image_lightbox_controller.js
@@ -1,0 +1,155 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="image-lightbox"
+// Provides a fullscreen image carousel with navigation and download
+export default class extends Controller {
+  static values = {
+    downloadAllUrl: String
+  }
+
+  connect() {
+    this._boundKeydown = this._handleKeydown.bind(this)
+  }
+
+  disconnect() {
+    this._close()
+  }
+
+  open(event) {
+    event.preventDefault()
+    event.stopPropagation()
+
+    const link = event.currentTarget
+    this._images = this._collectImages()
+    this._currentIndex = parseInt(link.dataset.imageLightboxIndexParam, 10) || 0
+
+    this._createDialog()
+    this._showImage()
+    this._dialog.showModal()
+    document.addEventListener("keydown", this._boundKeydown)
+  }
+
+  // --- Private ---
+
+  _collectImages() {
+    const links = this.element.querySelectorAll("[data-full-src]")
+    return Array.from(links).map((link) => ({
+      fullSrc: link.dataset.fullSrc,
+      downloadSrc: link.dataset.downloadSrc,
+      filename: link.dataset.filename || ""
+    }))
+  }
+
+  _createDialog() {
+    if (this._dialog) {
+      this._dialog.remove()
+    }
+
+    const dialog = document.createElement("dialog")
+    dialog.className = "image-lightbox-dialog"
+    dialog.innerHTML = `
+      <div class="image-lightbox-backdrop" data-action="click"></div>
+      <div class="image-lightbox-container">
+        <div class="image-lightbox-toolbar">
+          <span class="image-lightbox-counter"></span>
+          <div class="image-lightbox-toolbar-actions">
+            <a class="image-lightbox-btn image-lightbox-download-one" title="" download>⬇</a>
+            ${this.hasDownloadAllUrlValue ? `<a class="image-lightbox-btn image-lightbox-download-all" href="${this.downloadAllUrlValue}" title="">📥</a>` : ""}
+            <button class="image-lightbox-btn image-lightbox-close" type="button" title="">✕</button>
+          </div>
+        </div>
+        <div class="image-lightbox-stage">
+          <button class="image-lightbox-nav image-lightbox-prev" type="button" title="">‹</button>
+          <img class="image-lightbox-image" src="" alt="" />
+          <button class="image-lightbox-nav image-lightbox-next" type="button" title="">›</button>
+        </div>
+      </div>
+    `
+
+    // Event listeners
+    dialog.querySelector(".image-lightbox-backdrop").addEventListener("click", () => this._close())
+    dialog.querySelector(".image-lightbox-close").addEventListener("click", () => this._close())
+    dialog.querySelector(".image-lightbox-prev").addEventListener("click", () => this._prev())
+    dialog.querySelector(".image-lightbox-next").addEventListener("click", () => this._next())
+    dialog.addEventListener("cancel", (e) => {
+      e.preventDefault()
+      this._close()
+    })
+
+    // Touch swipe
+    let touchStartX = 0
+    const stage = dialog.querySelector(".image-lightbox-stage")
+    stage.addEventListener("touchstart", (e) => {
+      touchStartX = e.changedTouches[0].screenX
+    }, { passive: true })
+    stage.addEventListener("touchend", (e) => {
+      const diff = e.changedTouches[0].screenX - touchStartX
+      if (Math.abs(diff) > 50) {
+        diff > 0 ? this._prev() : this._next()
+      }
+    }, { passive: true })
+
+    document.body.appendChild(dialog)
+    this._dialog = dialog
+  }
+
+  _showImage() {
+    if (!this._dialog || !this._images.length) return
+
+    const img = this._images[this._currentIndex]
+    const imgEl = this._dialog.querySelector(".image-lightbox-image")
+    imgEl.src = img.fullSrc
+
+    // Counter
+    const counter = this._dialog.querySelector(".image-lightbox-counter")
+    counter.textContent = `${this._currentIndex + 1} / ${this._images.length}`
+
+    // Download link
+    const downloadBtn = this._dialog.querySelector(".image-lightbox-download-one")
+    downloadBtn.href = img.downloadSrc
+
+    // Nav visibility
+    const prevBtn = this._dialog.querySelector(".image-lightbox-prev")
+    const nextBtn = this._dialog.querySelector(".image-lightbox-next")
+    prevBtn.style.visibility = this._images.length > 1 ? "visible" : "hidden"
+    nextBtn.style.visibility = this._images.length > 1 ? "visible" : "hidden"
+  }
+
+  _prev() {
+    if (this._images.length <= 1) return
+    this._currentIndex = (this._currentIndex - 1 + this._images.length) % this._images.length
+    this._showImage()
+  }
+
+  _next() {
+    if (this._images.length <= 1) return
+    this._currentIndex = (this._currentIndex + 1) % this._images.length
+    this._showImage()
+  }
+
+  _close() {
+    document.removeEventListener("keydown", this._boundKeydown)
+    if (this._dialog) {
+      this._dialog.close()
+      this._dialog.remove()
+      this._dialog = null
+    }
+  }
+
+  _handleKeydown(e) {
+    switch (e.key) {
+      case "ArrowLeft":
+        e.preventDefault()
+        this._prev()
+        break
+      case "ArrowRight":
+        e.preventDefault()
+        this._next()
+        break
+      case "Escape":
+        e.preventDefault()
+        this._close()
+        break
+    }
+  }
+}

--- a/engines/collavre/app/javascript/controllers/image_lightbox_controller.js
+++ b/engines/collavre/app/javascript/controllers/image_lightbox_controller.js
@@ -76,22 +76,14 @@ export default class extends Controller {
       this._close()
     })
 
-    // Handle download links - use programmatic download to avoid dialog interference
+    // Handle download links - use fetch+blob to bypass Turbo and dialog issues
     dialog.querySelectorAll(".image-lightbox-download-one, .image-lightbox-download-all").forEach((el) => {
       el.addEventListener("click", (e) => {
         e.preventDefault()
         e.stopPropagation()
         const url = el.href
         if (!url) return
-        // Create a temporary link outside the dialog to trigger download
-        const tmpLink = document.createElement("a")
-        tmpLink.href = url
-        tmpLink.download = el.download || ""
-        tmpLink.setAttribute("data-turbo", "false")
-        tmpLink.style.display = "none"
-        document.body.appendChild(tmpLink)
-        tmpLink.click()
-        document.body.removeChild(tmpLink)
+        this._downloadViaFetch(url, el.dataset.filename || "")
       })
     })
 
@@ -126,6 +118,7 @@ export default class extends Controller {
     // Download link
     const downloadBtn = this._dialog.querySelector(".image-lightbox-download-one")
     downloadBtn.href = img.downloadSrc
+    downloadBtn.dataset.filename = img.filename
 
     // Nav visibility
     const prevBtn = this._dialog.querySelector(".image-lightbox-prev")
@@ -153,6 +146,28 @@ export default class extends Controller {
       this._dialog.remove()
       this._dialog = null
     }
+  }
+
+  _downloadViaFetch(url, fallbackFilename) {
+    fetch(url, { credentials: "same-origin" })
+      .then((resp) => {
+        // Extract filename from Content-Disposition header if available
+        const disposition = resp.headers.get("Content-Disposition") || ""
+        const match = disposition.match(/filename="?([^";\n]+)"?/)
+        const filename = match ? match[1] : (fallbackFilename || url.split("/").pop())
+        return resp.blob().then((blob) => ({ blob, filename }))
+      })
+      .then(({ blob, filename }) => {
+        const blobUrl = URL.createObjectURL(blob)
+        const a = document.createElement("a")
+        a.href = blobUrl
+        a.download = filename
+        a.style.display = "none"
+        document.body.appendChild(a)
+        a.click()
+        document.body.removeChild(a)
+        URL.revokeObjectURL(blobUrl)
+      })
   }
 
   _handleKeydown(e) {

--- a/engines/collavre/app/javascript/controllers/image_lightbox_controller.js
+++ b/engines/collavre/app/javascript/controllers/image_lightbox_controller.js
@@ -53,8 +53,8 @@ export default class extends Controller {
         <div class="image-lightbox-toolbar">
           <span class="image-lightbox-counter"></span>
           <div class="image-lightbox-toolbar-actions">
-            <a class="image-lightbox-btn image-lightbox-download-one" title="" download>⬇</a>
-            ${this.hasDownloadAllUrlValue ? `<a class="image-lightbox-btn image-lightbox-download-all" href="${this.downloadAllUrlValue}" title="">📥</a>` : ""}
+            <a class="image-lightbox-btn image-lightbox-download-one" title="" download data-turbo="false">⬇</a>
+            ${this.hasDownloadAllUrlValue ? `<a class="image-lightbox-btn image-lightbox-download-all" href="${this.downloadAllUrlValue}" title="" data-turbo="false">📥</a>` : ""}
             <button class="image-lightbox-btn image-lightbox-close" type="button" title="">✕</button>
           </div>
         </div>
@@ -74,6 +74,13 @@ export default class extends Controller {
     dialog.addEventListener("cancel", (e) => {
       e.preventDefault()
       this._close()
+    })
+
+    // Prevent download links from closing lightbox or propagating
+    dialog.querySelectorAll(".image-lightbox-download-one, .image-lightbox-download-all").forEach((el) => {
+      el.addEventListener("click", (e) => {
+        e.stopPropagation()
+      })
     })
 
     // Touch swipe

--- a/engines/collavre/app/javascript/controllers/image_lightbox_controller.js
+++ b/engines/collavre/app/javascript/controllers/image_lightbox_controller.js
@@ -65,9 +65,9 @@ export default class extends Controller {
         <div class="image-lightbox-toolbar">
           <span class="image-lightbox-counter"></span>
           <div class="image-lightbox-toolbar-actions">
-            <button class="image-lightbox-btn image-lightbox-download-one" type="button" title="Download">⬇</button>
-            ${this.hasDownloadAllUrlValue ? `<button class="image-lightbox-btn image-lightbox-download-all" type="button" title="Download all">📥</button>` : ""}
-            <button class="image-lightbox-btn image-lightbox-close" type="button" title="Close">✕</button>
+            <button class="image-lightbox-btn image-lightbox-download-one" type="button" title="Download">⬇ Download</button>
+            ${this.hasDownloadAllUrlValue ? `<button class="image-lightbox-btn image-lightbox-download-all" type="button" title="Download all">📥 All</button>` : ""}
+            <button class="image-lightbox-btn image-lightbox-close" type="button" title="Close">✕ Close</button>
           </div>
         </div>
         <div class="image-lightbox-stage">

--- a/engines/collavre/app/javascript/controllers/image_lightbox_controller.js
+++ b/engines/collavre/app/javascript/controllers/image_lightbox_controller.js
@@ -94,7 +94,7 @@ export default class extends Controller {
     dialog.querySelector(".image-lightbox-download-one").addEventListener("click", (e) => {
       e.stopPropagation()
       const img = this._images[this._currentIndex]
-      if (img) this._triggerDownload(img.downloadSrc)
+      if (img && img.downloadSrc) window.open(img.downloadSrc, "_blank")
     })
 
     const downloadAllBtn = dialog.querySelector(".image-lightbox-download-all")

--- a/engines/collavre/app/javascript/controllers/image_lightbox_controller.js
+++ b/engines/collavre/app/javascript/controllers/image_lightbox_controller.js
@@ -196,6 +196,7 @@ export default class extends Controller {
             <button class="image-lightbox-btn image-lightbox-zoom-reset" type="button" title="Reset zoom">1:1</button>
             <button class="image-lightbox-btn image-lightbox-download-one" type="button" title="Download">⬇ Download</button>
             ${this.hasDownloadAllUrlValue ? `<button class="image-lightbox-btn image-lightbox-download-all" type="button" title="Download all">📥 All</button>` : ""}
+            <button class="image-lightbox-btn image-lightbox-delete" type="button" title="Delete">🗑 Delete</button>
             <button class="image-lightbox-btn image-lightbox-close" type="button" title="Close">✕ Close</button>
           </div>
         </div>
@@ -231,6 +232,47 @@ export default class extends Controller {
     dialog.querySelector(".image-lightbox-zoom-reset").addEventListener("click", (e) => {
       e.stopPropagation()
       this._resetZoom()
+    })
+
+    // Delete button
+    dialog.querySelector(".image-lightbox-delete").addEventListener("click", async (e) => {
+      e.stopPropagation()
+      if (!this.hasDownloadAllUrlValue) return
+      if (!confirm("Delete this image?")) return
+
+      const url = `${this.downloadAllUrlValue.replace("download_images", "remove_image")}?index=${this._currentIndex}`
+      const csrfToken = document.querySelector("meta[name='csrf-token']")?.content
+
+      try {
+        const resp = await fetch(url, {
+          method: "DELETE",
+          credentials: "same-origin",
+          headers: { "X-CSRF-Token": csrfToken }
+        })
+        if (resp.ok) {
+          // Remove from gallery
+          this._images.splice(this._currentIndex, 1)
+          if (this._images.length === 0) {
+            this._close()
+            // Reload comments to reflect removal
+            this.element.closest("[data-controller]")?.dispatchEvent(new CustomEvent("lightbox:image-deleted", { bubbles: true }))
+            location.reload()
+            return
+          }
+          if (this._currentIndex >= this._images.length) {
+            this._currentIndex = this._images.length - 1
+          }
+          this._showImage()
+
+          // Update download-all visibility
+          const downloadAllBtn = this._dialog.querySelector(".image-lightbox-download-all")
+          if (downloadAllBtn && this._images.length <= 1) {
+            downloadAllBtn.style.display = "none"
+          }
+        }
+      } catch (err) {
+        console.error("Delete failed:", err)
+      }
     })
 
     // Download buttons

--- a/engines/collavre/app/javascript/controllers/image_lightbox_controller.js
+++ b/engines/collavre/app/javascript/controllers/image_lightbox_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 
 // Connects to data-controller="image-lightbox"
-// Provides a fullscreen image carousel with navigation and download
+// Provides a fullscreen image carousel with navigation, download, and zoom
 export default class extends Controller {
   static values = {
     downloadAllUrl: String
@@ -42,19 +42,145 @@ export default class extends Controller {
 
   _triggerDownload(url) {
     if (!url) return
-    // Use a hidden iframe appended to document.body (outside dialog)
-    // This triggers a normal browser request with cookies, and
-    // Content-Disposition: attachment causes a file download
     const iframe = document.createElement("iframe")
     iframe.style.cssText = "position:absolute;width:0;height:0;border:0;visibility:hidden"
     document.body.appendChild(iframe)
     iframe.src = url
-    // Clean up after download starts
     setTimeout(() => iframe.remove(), 30000)
+  }
+
+  // --- Zoom ---
+
+  _resetZoom() {
+    this._zoom = 1
+    this._panX = 0
+    this._panY = 0
+    this._applyTransform()
+  }
+
+  _setZoom(newZoom, centerX, centerY) {
+    const MIN = 0.5, MAX = 5
+    const clamped = Math.min(MAX, Math.max(MIN, newZoom))
+    if (clamped === this._zoom) return
+
+    // Adjust pan so zoom centers on the pointer position
+    if (centerX !== undefined && centerY !== undefined) {
+      const imgEl = this._dialog.querySelector(".image-lightbox-image")
+      const rect = imgEl.getBoundingClientRect()
+      const ox = centerX - rect.left - rect.width / 2
+      const oy = centerY - rect.top - rect.height / 2
+      const ratio = 1 - clamped / this._zoom
+      this._panX += ox * ratio
+      this._panY += oy * ratio
+    }
+
+    this._zoom = clamped
+
+    // Reset pan if back to fit
+    if (this._zoom <= 1) {
+      this._panX = 0
+      this._panY = 0
+    }
+
+    this._applyTransform()
+  }
+
+  _applyTransform() {
+    const imgEl = this._dialog?.querySelector(".image-lightbox-image")
+    if (!imgEl) return
+    imgEl.style.transform = `translate(${this._panX}px, ${this._panY}px) scale(${this._zoom})`
+    imgEl.style.cursor = this._zoom > 1 ? "grab" : "default"
+  }
+
+  _setupZoom(dialog) {
+    this._zoom = 1
+    this._panX = 0
+    this._panY = 0
+
+    const stage = dialog.querySelector(".image-lightbox-stage")
+    const imgEl = dialog.querySelector(".image-lightbox-image")
+
+    // Mouse wheel zoom
+    stage.addEventListener("wheel", (e) => {
+      e.preventDefault()
+      const delta = e.deltaY > 0 ? -0.15 : 0.15
+      this._setZoom(this._zoom + delta, e.clientX, e.clientY)
+    }, { passive: false })
+
+    // Double-click to toggle zoom
+    imgEl.addEventListener("dblclick", (e) => {
+      e.stopPropagation()
+      if (this._zoom > 1) {
+        this._resetZoom()
+      } else {
+        this._setZoom(2.5, e.clientX, e.clientY)
+      }
+    })
+
+    // Mouse drag to pan when zoomed
+    let dragging = false, dragStartX = 0, dragStartY = 0, panStartX = 0, panStartY = 0
+
+    imgEl.addEventListener("mousedown", (e) => {
+      if (this._zoom <= 1) return
+      e.preventDefault()
+      dragging = true
+      dragStartX = e.clientX
+      dragStartY = e.clientY
+      panStartX = this._panX
+      panStartY = this._panY
+      imgEl.style.cursor = "grabbing"
+    })
+
+    window.addEventListener("mousemove", this._onMouseMove = (e) => {
+      if (!dragging) return
+      this._panX = panStartX + (e.clientX - dragStartX)
+      this._panY = panStartY + (e.clientY - dragStartY)
+      this._applyTransform()
+    })
+
+    window.addEventListener("mouseup", this._onMouseUp = () => {
+      if (!dragging) return
+      dragging = false
+      const imgEl2 = this._dialog?.querySelector(".image-lightbox-image")
+      if (imgEl2) imgEl2.style.cursor = this._zoom > 1 ? "grab" : "default"
+    })
+
+    // Pinch zoom (touch)
+    let lastPinchDist = 0
+
+    stage.addEventListener("touchstart", (e) => {
+      if (e.touches.length === 2) {
+        lastPinchDist = Math.hypot(
+          e.touches[0].clientX - e.touches[1].clientX,
+          e.touches[0].clientY - e.touches[1].clientY
+        )
+      }
+    }, { passive: true })
+
+    stage.addEventListener("touchmove", (e) => {
+      if (e.touches.length === 2) {
+        e.preventDefault()
+        const dist = Math.hypot(
+          e.touches[0].clientX - e.touches[1].clientX,
+          e.touches[0].clientY - e.touches[1].clientY
+        )
+        const centerX = (e.touches[0].clientX + e.touches[1].clientX) / 2
+        const centerY = (e.touches[0].clientY + e.touches[1].clientY) / 2
+        const scale = dist / lastPinchDist
+        this._setZoom(this._zoom * scale, centerX, centerY)
+        lastPinchDist = dist
+      }
+    }, { passive: false })
+  }
+
+  _cleanupZoom() {
+    if (this._onMouseMove) window.removeEventListener("mousemove", this._onMouseMove)
+    if (this._onMouseUp) window.removeEventListener("mouseup", this._onMouseUp)
   }
 
   _createDialog() {
     if (this._dialog) {
+      this._cleanupZoom()
       this._dialog.remove()
     }
 
@@ -65,6 +191,9 @@ export default class extends Controller {
         <div class="image-lightbox-toolbar">
           <span class="image-lightbox-counter"></span>
           <div class="image-lightbox-toolbar-actions">
+            <button class="image-lightbox-btn image-lightbox-zoom-in" type="button" title="Zoom in">🔍+</button>
+            <button class="image-lightbox-btn image-lightbox-zoom-out" type="button" title="Zoom out">🔍−</button>
+            <button class="image-lightbox-btn image-lightbox-zoom-reset" type="button" title="Reset zoom">1:1</button>
             <button class="image-lightbox-btn image-lightbox-download-one" type="button" title="Download">⬇ Download</button>
             ${this.hasDownloadAllUrlValue ? `<button class="image-lightbox-btn image-lightbox-download-all" type="button" title="Download all">📥 All</button>` : ""}
             <button class="image-lightbox-btn image-lightbox-close" type="button" title="Close">✕ Close</button>
@@ -72,13 +201,13 @@ export default class extends Controller {
         </div>
         <div class="image-lightbox-stage">
           <button class="image-lightbox-nav image-lightbox-prev" type="button" title="Previous">‹</button>
-          <img class="image-lightbox-image" src="" alt="" />
+          <img class="image-lightbox-image" src="" alt="" draggable="false" />
           <button class="image-lightbox-nav image-lightbox-next" type="button" title="Next">›</button>
         </div>
       </div>
     `
 
-    // Close on backdrop click (clicking the dialog element itself, not children)
+    // Close on backdrop click
     dialog.addEventListener("click", (e) => {
       if (e.target === dialog) this._close()
     })
@@ -90,11 +219,24 @@ export default class extends Controller {
       this._close()
     })
 
-    // Download buttons - use <button> not <a> to avoid all link/Turbo issues
+    // Zoom buttons
+    dialog.querySelector(".image-lightbox-zoom-in").addEventListener("click", (e) => {
+      e.stopPropagation()
+      this._setZoom(this._zoom + 0.25)
+    })
+    dialog.querySelector(".image-lightbox-zoom-out").addEventListener("click", (e) => {
+      e.stopPropagation()
+      this._setZoom(this._zoom - 0.25)
+    })
+    dialog.querySelector(".image-lightbox-zoom-reset").addEventListener("click", (e) => {
+      e.stopPropagation()
+      this._resetZoom()
+    })
+
+    // Download buttons
     dialog.querySelector(".image-lightbox-download-one").addEventListener("click", (e) => {
       e.stopPropagation()
       if (!this.hasDownloadAllUrlValue) return
-      // Use same-origin endpoint with index param to avoid CORS/CSP issues
       const url = `${this.downloadAllUrlValue}?index=${this._currentIndex}`
       this._triggerDownload(url)
     })
@@ -107,18 +249,24 @@ export default class extends Controller {
       })
     }
 
-    // Touch swipe
+    // Touch swipe (only when not zoomed)
     let touchStartX = 0
     const stage = dialog.querySelector(".image-lightbox-stage")
     stage.addEventListener("touchstart", (e) => {
-      touchStartX = e.changedTouches[0].screenX
+      if (e.touches.length === 1) touchStartX = e.changedTouches[0].screenX
     }, { passive: true })
     stage.addEventListener("touchend", (e) => {
-      const diff = e.changedTouches[0].screenX - touchStartX
-      if (Math.abs(diff) > 50) {
-        diff > 0 ? this._prev() : this._next()
+      if (this._zoom > 1) return // Don't swipe when zoomed
+      if (e.changedTouches.length === 1) {
+        const diff = e.changedTouches[0].screenX - touchStartX
+        if (Math.abs(diff) > 50) {
+          diff > 0 ? this._prev() : this._next()
+        }
       }
     }, { passive: true })
+
+    // Setup zoom interactions (wheel, pinch, drag)
+    this._setupZoom(dialog)
 
     document.body.appendChild(dialog)
     this._dialog = dialog
@@ -130,6 +278,9 @@ export default class extends Controller {
     const img = this._images[this._currentIndex]
     const imgEl = this._dialog.querySelector(".image-lightbox-image")
     imgEl.src = img.fullSrc
+
+    // Reset zoom on image change
+    this._resetZoom()
 
     // Counter
     const counter = this._dialog.querySelector(".image-lightbox-counter")
@@ -156,6 +307,7 @@ export default class extends Controller {
 
   _close() {
     document.removeEventListener("keydown", this._boundKeydown)
+    this._cleanupZoom()
     if (this._dialog) {
       this._dialog.close()
       this._dialog.remove()
@@ -176,6 +328,19 @@ export default class extends Controller {
       case "Escape":
         e.preventDefault()
         this._close()
+        break
+      case "+":
+      case "=":
+        e.preventDefault()
+        this._setZoom(this._zoom + 0.25)
+        break
+      case "-":
+        e.preventDefault()
+        this._setZoom(this._zoom - 0.25)
+        break
+      case "0":
+        e.preventDefault()
+        this._resetZoom()
         break
     }
   }

--- a/engines/collavre/app/javascript/controllers/image_lightbox_controller.js
+++ b/engines/collavre/app/javascript/controllers/image_lightbox_controller.js
@@ -94,7 +94,7 @@ export default class extends Controller {
     dialog.querySelector(".image-lightbox-download-one").addEventListener("click", (e) => {
       e.stopPropagation()
       const img = this._images[this._currentIndex]
-      if (img && img.downloadSrc) window.open(img.downloadSrc, "_blank")
+      if (img && img.downloadSrc) this._fetchDownload(img.downloadSrc, img.filename)
     })
 
     const downloadAllBtn = dialog.querySelector(".image-lightbox-download-all")
@@ -159,6 +159,22 @@ export default class extends Controller {
       this._dialog.remove()
       this._dialog = null
     }
+  }
+
+  _fetchDownload(url, filename) {
+    fetch(url, { credentials: "same-origin" })
+      .then((resp) => resp.blob())
+      .then((blob) => {
+        const blobUrl = URL.createObjectURL(blob)
+        const a = document.createElement("a")
+        a.href = blobUrl
+        a.download = filename || "download"
+        a.style.display = "none"
+        document.body.appendChild(a)
+        a.click()
+        a.remove()
+        URL.revokeObjectURL(blobUrl)
+      })
   }
 
   _handleKeydown(e) {

--- a/engines/collavre/app/javascript/controllers/index.js
+++ b/engines/collavre/app/javascript/controllers/index.js
@@ -28,6 +28,7 @@ import ShareUserSearchController from "./share_user_search_controller"
 import CommentVersionController from "./comment_version_controller"
 import OrgChartController from "./org_chart_controller"
 import ShareModalController from "./share_modal_controller"
+import ImageLightboxController from "./image_lightbox_controller"
 
 // Export all controllers
 export {
@@ -57,7 +58,8 @@ export {
   ShareUserSearchController,
   CommentVersionController,
   OrgChartController,
-  ShareModalController
+  ShareModalController,
+  ImageLightboxController
 }
 
 // Registration function for use with a Stimulus application
@@ -90,4 +92,5 @@ export function registerControllers(application) {
   application.register("comment-version", CommentVersionController)
   application.register("org-chart", OrgChartController)
   application.register("share-modal", ShareModalController)
+  application.register("image-lightbox", ImageLightboxController)
 }

--- a/engines/collavre/app/views/collavre/comments/_comment.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comment.html.erb
@@ -119,7 +119,7 @@
         </a>
       <% end %>
       <% if images_list.size > 1 %>
-        <a href="<%= collavre.download_images_creative_comment_path(comment.creative, comment) %>" class="comment-download-all-btn" data-turbo="false">
+        <a href="<%= collavre.download_images_creative_comment_path(comment.creative, comment) %>" class="comment-download-all-btn" data-turbo="false" onclick="event.stopPropagation()">
           📥 <%= t('collavre.comments.lightbox.download_all') %>
         </a>
       <% end %>

--- a/engines/collavre/app/views/collavre/comments/_comment.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comment.html.erb
@@ -100,7 +100,7 @@
     <% images_list = comment.images.to_a %>
     <div class="comment-attachments"
          data-controller="image-lightbox"
-         <% if images_list.size > 1 %>data-image-lightbox-download-all-url-value="<%= collavre.download_images_creative_comment_path(comment.creative, comment) %>"<% end %>>
+         data-image-lightbox-download-all-url-value="<%= collavre.download_images_creative_comment_path(comment.creative, comment) %>">
       <% images_list.each_with_index do |image, idx| %>
         <% preview_image = image.variable? ? image.variant(resize_to_limit: [ 800, 800 ]) : image %>
         <% preview_image_path =

--- a/engines/collavre/app/views/collavre/comments/_comment.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comment.html.erb
@@ -119,7 +119,7 @@
         </a>
       <% end %>
       <% if images_list.size > 1 %>
-        <a href="<%= collavre.download_images_creative_comment_path(comment.creative, comment) %>" class="comment-download-all-btn">
+        <a href="<%= collavre.download_images_creative_comment_path(comment.creative, comment) %>" class="comment-download-all-btn" data-turbo="false">
           📥 <%= t('collavre.comments.lightbox.download_all') %>
         </a>
       <% end %>

--- a/engines/collavre/app/views/collavre/comments/_comment.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comment.html.erb
@@ -100,7 +100,7 @@
     <% images_list = comment.images.to_a %>
     <div class="comment-attachments"
          data-controller="image-lightbox"
-         <%= images_list.size > 1 ? "data-image-lightbox-download-all-url-value=\"#{collavre.download_images_creative_comment_path(comment.creative, comment)}\"" : "" %>>
+         <% if images_list.size > 1 %>data-image-lightbox-download-all-url-value="<%= collavre.download_images_creative_comment_path(comment.creative, comment) %>"<% end %>>
       <% images_list.each_with_index do |image, idx| %>
         <% preview_image = image.variable? ? image.variant(resize_to_limit: [ 800, 800 ]) : image %>
         <% preview_image_path =

--- a/engines/collavre/app/views/collavre/comments/_comment.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comment.html.erb
@@ -118,11 +118,7 @@
           <%= image_tag preview_image_path, class: 'comment-attachment-image', alt: '', loading: 'lazy' %>
         </a>
       <% end %>
-      <% if images_list.size > 1 %>
-        <a href="<%= collavre.download_images_creative_comment_path(comment.creative, comment) %>" class="comment-download-all-btn" data-turbo="false" onclick="event.stopPropagation()">
-          📥 <%= t('collavre.comments.lightbox.download_all') %>
-        </a>
-      <% end %>
+
     </div>
   <% end %>
   <% reaction_emojis = [ "👍", "🎉", "❤️", "😂", "😮", "😢", "😡" ] %>

--- a/engines/collavre/app/views/collavre/comments/_comment.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comment.html.erb
@@ -97,8 +97,11 @@
 
 
   <% if comment.images.attached? %>
-    <div class="comment-attachments">
-      <% comment.images.each do |image| %>
+    <% images_list = comment.images.to_a %>
+    <div class="comment-attachments"
+         data-controller="image-lightbox"
+         <%= images_list.size > 1 ? "data-image-lightbox-download-all-url-value=\"#{collavre.download_images_creative_comment_path(comment.creative, comment)}\"" : "" %>>
+      <% images_list.each_with_index do |image, idx| %>
         <% preview_image = image.variable? ? image.variant(resize_to_limit: [ 800, 800 ]) : image %>
         <% preview_image_path =
              if preview_image.respond_to?(:processed)
@@ -106,9 +109,19 @@
              else
                main_app.rails_blob_path(preview_image, only_path: true)
              end %>
-        <%= link_to main_app.rails_blob_path(image, only_path: true), target: '_blank', rel: 'noopener', class: 'comment-attachment-link' do %>
+        <a href="#" class="comment-attachment-link"
+           data-action="click->image-lightbox#open"
+           data-image-lightbox-index-param="<%= idx %>"
+           data-full-src="<%= main_app.rails_blob_path(image, only_path: true) %>"
+           data-download-src="<%= main_app.rails_blob_path(image, disposition: 'attachment', only_path: true) %>"
+           data-filename="<%= image.filename %>">
           <%= image_tag preview_image_path, class: 'comment-attachment-image', alt: '', loading: 'lazy' %>
-        <% end %>
+        </a>
+      <% end %>
+      <% if images_list.size > 1 %>
+        <a href="<%= collavre.download_images_creative_comment_path(comment.creative, comment) %>" class="comment-download-all-btn">
+          📥 <%= t('collavre.comments.lightbox.download_all') %>
+        </a>
       <% end %>
     </div>
   <% end %>

--- a/engines/collavre/app/views/collavre/comments/_comment.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comment.html.erb
@@ -100,7 +100,14 @@
     <% images_list = comment.images.to_a %>
     <div class="comment-attachments"
          data-controller="image-lightbox"
-         data-image-lightbox-download-all-url-value="<%= collavre.download_images_creative_comment_path(comment.creative, comment) %>">
+         data-image-lightbox-download-all-url-value="<%= collavre.download_images_creative_comment_path(comment.creative, comment) %>"
+         data-image-lightbox-i18n-close-value="<%= t('collavre.comments.lightbox.close') %>"
+         data-image-lightbox-i18n-previous-value="<%= t('collavre.comments.lightbox.previous') %>"
+         data-image-lightbox-i18n-next-value="<%= t('collavre.comments.lightbox.next') %>"
+         data-image-lightbox-i18n-download-value="<%= t('collavre.comments.lightbox.download') %>"
+         data-image-lightbox-i18n-download-all-value="<%= t('collavre.comments.lightbox.download_all') %>"
+         data-image-lightbox-i18n-delete-value="<%= t('collavre.comments.lightbox.delete') %>"
+         data-image-lightbox-i18n-delete-confirm-value="<%= t('collavre.comments.lightbox.delete_confirm') %>">
       <% images_list.each_with_index do |image, idx| %>
         <% preview_image = image.variable? ? image.variant(resize_to_limit: [ 800, 800 ]) : image %>
         <% preview_image_path =

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -170,6 +170,13 @@ en:
         select: Select
       read_by: Read by %{name}
       activity_logs_summary: Activity Logs
+      lightbox:
+        close: Close
+        previous: Previous
+        next: Next
+        download: Download
+        download_all: Download all
+        counter: "%{current} / %{total}"
     calendar_events:
       deleted: Calendar event deleted.
     google_calendar:

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -176,6 +176,8 @@ en:
         next: Next
         download: Download
         download_all: Download all
+        delete: Delete
+        delete_confirm: Delete this image?
         counter: "%{current} / %{total}"
     calendar_events:
       deleted: Calendar event deleted.

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -173,6 +173,8 @@ ko:
         next: 다음
         download: 다운로드
         download_all: 전체 다운로드
+        delete: 삭제
+        delete_confirm: 이 이미지를 삭제하시겠습니까?
         counter: "%{current} / %{total}"
     calendar_events:
       deleted: 캘린더 이벤트가 삭제되었습니다.

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -167,6 +167,13 @@ ko:
         select: 선택
       read_by: "%{name} 님이 읽음"
       activity_logs_summary: 활동 기록
+      lightbox:
+        close: 닫기
+        previous: 이전
+        next: 다음
+        download: 다운로드
+        download_all: 전체 다운로드
+        counter: "%{current} / %{total}"
     calendar_events:
       deleted: 캘린더 이벤트가 삭제되었습니다.
     google_calendar:

--- a/engines/collavre/config/routes.rb
+++ b/engines/collavre/config/routes.rb
@@ -70,6 +70,7 @@ Collavre::Engine.routes.draw do
         patch :update_action
         delete :reactions, to: "comments/reactions#destroy"
         get :download_images
+        delete :remove_image
       end
 
       resources :reactions, only: [ :create ], module: :comments

--- a/engines/collavre/config/routes.rb
+++ b/engines/collavre/config/routes.rb
@@ -69,6 +69,7 @@ Collavre::Engine.routes.draw do
         post :approve
         patch :update_action
         delete :reactions, to: "comments/reactions#destroy"
+        get :download_images
       end
 
       resources :reactions, only: [ :create ], module: :comments


### PR DESCRIPTION
## Summary

Add a native image lightbox/carousel for chat comments with multiple image attachments. Built with Stimulus + `<dialog>` (zero npm dependencies).

## Features

- **Image Lightbox**: Click any attached image to open fullscreen lightbox
- **Carousel Navigation**: Left/right arrows, keyboard (← →), touch swipe
- **Zoom**: Mouse wheel, pinch gesture, double-click toggle, +/- keys, toolbar buttons
- **Individual Download**: Download current image via server proxy (no CORS/CSP issues)
- **Bulk Download**: Download all images as zip file
- **Delete Image**: Remove individual images from lightbox (author/admin only)
- **Responsive**: Icon-only buttons on mobile (≤768px), full labels on desktop
- **i18n**: English and Korean translations

## Technical Details

- **Stimulus controller** (`image_lightbox_controller.js`, ~420 lines)
- **CSS** (`image_lightbox.css`, ~140 lines) — flexbox layout, dialog fullscreen
- **Server endpoints**: `GET download_images` (single/zip), `DELETE remove_image`
- **Downloads routed through server** to avoid S3 CORS and CSP frame-src issues
- **Nav buttons positioned via JS** using `getBoundingClientRect()` for stability inside `<dialog>` top layer
- **Zero npm dependencies** — fits Hotwire/Stimulus philosophy

## Files Changed (11)

- `image_lightbox_controller.js` — new Stimulus controller
- `image_lightbox.css` — new stylesheet
- `_comment.html.erb` — data attributes for lightbox
- `comments_controller.rb` — download_images + remove_image actions
- `routes.rb` — new member routes
- `index.js` — controller registration
- `application_helper.rb` — stylesheet inclusion
- `comments.en.yml` / `comments.ko.yml` — i18n keys
- `Gemfile.lock` / `package-lock.json` — dependency updates