### PR TITLE
feat: add mobile touch drag-and-drop for comment-to-topic moves

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -187,6 +187,12 @@ body.chat-fullscreen {
 .comment-item.selected-for-move {
     background-color: var(--color-section-bg);
     border-color: var(--color-border);
+    /* Prevent native long-press behaviors (text selection, context menu,
+       native drag preview) from stealing touch events on mobile */
+    touch-action: none;
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    user-select: none;
 }
 
 .comment-select {

--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -1452,10 +1452,50 @@ body.chat-fullscreen {
     margin-top: var(--space-1);
 }
 
+/* Hide touch hint on non-touch devices */
+.selection-action-bar-hint.touch-drag-hint {
+    display: none;
+}
+
 @media (pointer: coarse) {
     .selection-action-bar-hint.no-touch {
         display: none;
     }
+    .selection-action-bar-hint.touch-drag-hint {
+        display: block;
+    }
+}
+
+/* Touch drag proxy (mobile drag-and-drop) */
+.touch-drag-proxy {
+    position: fixed;
+    z-index: var(--layer-popover, 9999);
+    pointer-events: none;
+    animation: touch-drag-pop-in 0.15s ease-out;
+}
+
+.touch-drag-proxy-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+    padding: var(--space-1) var(--space-3);
+    background-color: var(--color-active);
+    color: var(--color-badge-text);
+    border-radius: var(--radius-round, 999px);
+    font-size: var(--text-0, 0.85em);
+    font-weight: 600;
+    white-space: nowrap;
+    box-shadow: var(--shadow-3, 0 4px 12px rgba(0,0,0,0.25));
+}
+
+@keyframes touch-drag-pop-in {
+    from { opacity: 0; transform: scale(0.7); }
+    to   { opacity: 1; transform: scale(1); }
+}
+
+/* During touch drag, dim non-selected items (reuses existing class) */
+#comments-list.touch-dragging .comment-item:not(.selected-for-move) {
+    opacity: 0.5;
 }
 
 @keyframes action-bar-slide-up {

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/list_controller_selection.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/list_controller_selection.test.js
@@ -32,6 +32,9 @@ describe('Selection Action Bar - DOM behavior', () => {
       <div class="selection-action-bar-hint no-touch">
         💡 ${i18n('selectionDragHintText', 'Drag & drop to move to topic')}
       </div>
+      <div class="selection-action-bar-hint touch-drag-hint">
+        💡 ${i18n('selectionTouchDragHintText', 'Long press to drag to topic')}
+      </div>
     `
     document.body.appendChild(bar)
     return bar
@@ -76,6 +79,15 @@ describe('Selection Action Bar - DOM behavior', () => {
     expect(hint).toBeTruthy()
     expect(hint.classList.contains('no-touch')).toBe(true)
     expect(hint.textContent).toContain('Drag & drop')
+  })
+
+  test('shows touch drag hint with touch-drag-hint class', () => {
+    const bar = createActionBar(1)
+    const hints = bar.querySelectorAll('.selection-action-bar-hint')
+    expect(hints.length).toBe(2)
+    const touchHint = bar.querySelector('.selection-action-bar-hint.touch-drag-hint')
+    expect(touchHint).toBeTruthy()
+    expect(touchHint.textContent).toContain('Long press')
   })
 
   test('uses i18n dataset values when provided', () => {

--- a/engines/collavre/app/javascript/controllers/comments/list_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/list_controller.js
@@ -778,6 +778,7 @@ export default class extends Controller {
       },
 
       onDrop: (targetEl) => {
+        this.listTarget.classList.remove('dragging-comments')
         const commentIds = Array.from(this.selection)
         if (commentIds.length === 0) return
 

--- a/engines/collavre/app/javascript/controllers/comments/list_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/list_controller.js
@@ -773,7 +773,9 @@ export default class extends Controller {
 
       proxyContent: (items) => {
         const count = this.selection.size || items.length
-        const label = count === 1 ? '1 message' : `${count} messages`
+        const oneText = this.element.dataset.touchDragProxyOneText || '1 message'
+        const otherText = this.element.dataset.touchDragProxyOtherText || '%{count} messages'
+        const label = count === 1 ? oneText : otherText.replace('%{count}', count)
         return `<span class="touch-drag-proxy-badge">${label}</span>`
       },
 

--- a/engines/collavre/app/javascript/controllers/comments/list_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/list_controller.js
@@ -4,6 +4,7 @@ import { renderMarkdownInContainer } from '../../lib/utils/markdown'
 import creativesApi from '../../lib/api/creatives'
 import { renderCreativeTree, dispatchCreativeTreeUpdated } from '../../creatives/tree_renderer'
 import { updateCsrfTokenFromResponse } from '../../lib/api/csrf_fetch'
+import TouchDragHandler from '../../lib/touch_drag'
 // CommonPopup is now used via TopicSearchController (Stimulus)
 
 export default class extends Controller {
@@ -56,6 +57,9 @@ export default class extends Controller {
     this.listTarget.addEventListener('dragstart', this.handleDragStart)
     this.listTarget.addEventListener('dragend', this.handleDragEnd)
     this.element.addEventListener('comments--topics:move-to-topic', this.handleMoveToTopic)
+
+    // Touch drag-and-drop for mobile
+    this._initTouchDrag()
   }
 
   handleTopicChange(event) {
@@ -84,6 +88,7 @@ export default class extends Controller {
     }
     this.element.removeEventListener('comments--topics:change', this.handleTopicChange)
     this.element.removeEventListener('comments--topics:move-to-topic', this.handleMoveToTopic)
+    this._destroyTouchDrag()
   }
 
   isColumnReverse() {
@@ -533,6 +538,9 @@ export default class extends Controller {
       <div class="selection-action-bar-hint no-touch">
         💡 ${i18n('selectionDragHintText', 'Drag & drop to move to topic')}
       </div>
+      <div class="selection-action-bar-hint touch-drag-hint">
+        💡 ${i18n('selectionTouchDragHintText', 'Long press to drag to topic')}
+      </div>
     `
 
     // Set indeterminate state if partially selected
@@ -743,6 +751,66 @@ export default class extends Controller {
 
   handleDragEnd(event) {
     this.listTarget.classList.remove('dragging-comments')
+  }
+
+  // ── Touch drag-and-drop (mobile) ────────────────────────
+
+  _initTouchDrag() {
+    // Only init on touch-capable devices
+    if (!('ontouchstart' in window)) return
+
+    this._touchDrag = new TouchDragHandler({
+      container: this.listTarget,
+      itemSelector: '.comment-item.selected-for-move',
+      dropTargetSelector: '.topic-tag.topic-drop-target, .topic-creation-container',
+      longPressMs: 400,
+      moveTolerance: 10,
+
+      onDragStart: () => {
+        if (this.selection.size === 0) return false
+        this.listTarget.classList.add('dragging-comments')
+      },
+
+      proxyContent: (items) => {
+        const count = this.selection.size || items.length
+        const label = count === 1 ? '1 message' : `${count} messages`
+        return `<span class="touch-drag-proxy-badge">${label}</span>`
+      },
+
+      onDrop: (targetEl) => {
+        const commentIds = Array.from(this.selection)
+        if (commentIds.length === 0) return
+
+        // Dropping on "+" / creation container → create topic & move
+        if (targetEl.closest('.topic-creation-container')) {
+          const topicsCtrl = this.application.getControllerForElementAndIdentifier(
+            this.element, 'comments--topics'
+          )
+          if (topicsCtrl) {
+            topicsCtrl.createTopicAndMoveComments(commentIds)
+          }
+          return
+        }
+
+        // Dropping on a topic tag
+        const topicTag = targetEl.closest('.topic-tag.topic-drop-target')
+        if (topicTag) {
+          const targetTopicId = topicTag.dataset.id
+          this.handleMoveToTopic({ detail: { commentIds, targetTopicId } })
+        }
+      },
+
+      onCancel: () => {
+        this.listTarget.classList.remove('dragging-comments')
+      }
+    })
+  }
+
+  _destroyTouchDrag() {
+    if (this._touchDrag) {
+      this._touchDrag.destroy()
+      this._touchDrag = null
+    }
   }
 
   async handleMoveToTopic(event) {

--- a/engines/collavre/app/javascript/controllers/comments/presence_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/presence_controller.js
@@ -401,8 +401,11 @@ export default class extends Controller {
 
     const moveProxy = (x, y) => {
       if (!proxy) return
-      proxy.style.left = `${x + 12}px`
-      proxy.style.top = `${y - 30}px`
+      const rect = proxy.getBoundingClientRect()
+      const hw = (rect.width || 80) / 2
+      const hh = (rect.height || 30) / 2
+      proxy.style.left = `${x - hw}px`
+      proxy.style.top = `${y - hh}px`
     }
 
     const updateDropTarget = (x, y) => {

--- a/engines/collavre/app/javascript/controllers/comments/presence_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/presence_controller.js
@@ -405,11 +405,21 @@ export default class extends Controller {
       proxy.style.top = `${y - 30}px`
     }
 
-    const updateDropTarget = (x, y) => {
-      if (proxy) proxy.style.pointerEvents = 'none'
+    const findDropTarget = (x, y) => {
       const el = document.elementFromPoint(x, y)
-      if (proxy) proxy.style.pointerEvents = ''
-      const target = el?.closest?.(DROP_TARGET_SEL) ?? null
+      return el?.closest?.(DROP_TARGET_SEL) ?? null
+    }
+
+    const updateDropTarget = (x, y) => {
+      if (proxy) proxy.style.display = 'none'
+      // Check exact point and nearby points (finger imprecision on mobile)
+      let target = findDropTarget(x, y)
+      if (!target) target = findDropTarget(x, y - 15)
+      if (!target) target = findDropTarget(x, y + 15)
+      if (!target) target = findDropTarget(x - 10, y)
+      if (!target) target = findDropTarget(x + 10, y)
+      if (proxy) proxy.style.display = ''
+
       if (target !== currentTarget) {
         currentTarget?.classList.remove(DRAG_OVER_CLASS)
         currentTarget = target
@@ -464,7 +474,11 @@ export default class extends Controller {
       if (timer) {
         const dx = Math.abs(touch.clientX - startX)
         const dy = Math.abs(touch.clientY - startY)
-        if (dx > MOVE_TOLERANCE || dy > MOVE_TOLERANCE) cancelLongPress()
+        if (dx > MOVE_TOLERANCE || dy > MOVE_TOLERANCE) {
+          cancelLongPress()
+        } else {
+          e.preventDefault() // Prevent scroll within tolerance during long-press wait
+        }
       }
     }, { passive: false })
 

--- a/engines/collavre/app/javascript/controllers/comments/presence_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/presence_controller.js
@@ -212,6 +212,8 @@ export default class extends Controller {
         wrapper.dataset.agentId = user.id
         wrapper.dataset.agentName = user.name
         wrapper.dataset.agentAvatarUrl = user.avatar_url
+
+        // HTML5 DnD (desktop)
         wrapper.addEventListener('dragstart', (e) => {
           e.dataTransfer.setData('application/x-agent-drop', JSON.stringify({
             id: user.id,
@@ -224,6 +226,9 @@ export default class extends Controller {
         wrapper.addEventListener('dragend', () => {
           wrapper.classList.remove('dragging')
         })
+
+        // Touch drag (mobile)
+        this._addAgentTouchDrag(wrapper, user)
       }
 
       wrapper.appendChild(img)
@@ -371,5 +376,126 @@ export default class extends Controller {
         avatar.classList.add('inactive')
       }
     })
+  }
+
+  // ── Agent touch drag-and-drop (mobile) ─────────────────
+
+  _addAgentTouchDrag(wrapper, user) {
+    if (!('ontouchstart' in window)) return
+
+    const LONG_PRESS_MS = 400
+    const MOVE_TOLERANCE = 10
+    const DROP_TARGET_SEL = '.topic-tag.topic-drop-target, .topic-creation-container'
+    const DRAG_OVER_CLASS = 'drag-over'
+
+    let timer = null
+    let dragging = false
+    let proxy = null
+    let currentTarget = null
+    let startX = 0
+    let startY = 0
+
+    const cancelLongPress = () => {
+      if (timer) { clearTimeout(timer); timer = null }
+    }
+
+    const moveProxy = (x, y) => {
+      if (!proxy) return
+      proxy.style.left = `${x + 12}px`
+      proxy.style.top = `${y - 30}px`
+    }
+
+    const updateDropTarget = (x, y) => {
+      if (proxy) proxy.style.pointerEvents = 'none'
+      const el = document.elementFromPoint(x, y)
+      if (proxy) proxy.style.pointerEvents = ''
+      const target = el?.closest?.(DROP_TARGET_SEL) ?? null
+      if (target !== currentTarget) {
+        currentTarget?.classList.remove(DRAG_OVER_CLASS)
+        currentTarget = target
+        currentTarget?.classList.add(DRAG_OVER_CLASS)
+      }
+    }
+
+    const endDrag = () => {
+      dragging = false
+      cancelLongPress()
+      document.removeEventListener('contextmenu', preventContext, true)
+      wrapper.classList.remove('dragging')
+      if (currentTarget) { currentTarget.classList.remove(DRAG_OVER_CLASS); currentTarget = null }
+      if (proxy) { proxy.remove(); proxy = null }
+    }
+
+    const preventContext = (e) => { if (dragging || timer) e.preventDefault() }
+
+    const startDrag = (touch) => {
+      timer = null
+      dragging = true
+      if (navigator.vibrate) navigator.vibrate(30)
+      document.addEventListener('contextmenu', preventContext, { capture: true })
+      wrapper.classList.add('dragging')
+
+      proxy = document.createElement('div')
+      proxy.className = 'touch-drag-proxy'
+      proxy.innerHTML = `<span class="touch-drag-proxy-badge">${user.name}</span>`
+      document.body.appendChild(proxy)
+      moveProxy(touch.clientX, touch.clientY)
+    }
+
+    wrapper.addEventListener('touchstart', (e) => {
+      if (dragging) return
+      const touch = e.touches[0]
+      if (!touch) return
+      startX = touch.clientX
+      startY = touch.clientY
+      cancelLongPress()
+      timer = setTimeout(() => startDrag(touch), LONG_PRESS_MS)
+    }, { passive: false })
+
+    wrapper.addEventListener('touchmove', (e) => {
+      const touch = e.touches[0]
+      if (!touch) return
+      if (dragging) {
+        e.preventDefault()
+        moveProxy(touch.clientX, touch.clientY)
+        updateDropTarget(touch.clientX, touch.clientY)
+        return
+      }
+      if (timer) {
+        const dx = Math.abs(touch.clientX - startX)
+        const dy = Math.abs(touch.clientY - startY)
+        if (dx > MOVE_TOLERANCE || dy > MOVE_TOLERANCE) cancelLongPress()
+      }
+    }, { passive: false })
+
+    const onTouchEnd = (e) => {
+      if (timer) { cancelLongPress(); return }
+      if (!dragging) return
+      e.preventDefault()
+
+      if (currentTarget) {
+        const agentData = { id: user.id, name: user.name, avatar_url: user.avatar_url }
+        const topicsCtrl = this.application.getControllerForElementAndIdentifier(
+          this.element, 'comments--topics'
+        )
+        if (topicsCtrl) {
+          // Drop on "+" button → create topic with agent
+          if (currentTarget.closest('.topic-creation-container')) {
+            topicsCtrl.createTopicWithAgent(agentData)
+          } else {
+            // Drop on topic tag → set primary agent
+            const topicTag = currentTarget.closest('.topic-tag.topic-drop-target')
+            if (topicTag && topicTag.dataset.id) {
+              topicsCtrl.setTopicPrimaryAgent(topicTag.dataset.id, agentData)
+            }
+          }
+        }
+      }
+
+      endDrag()
+    }
+
+    wrapper.addEventListener('touchend', onTouchEnd, { passive: false })
+    wrapper.addEventListener('touchcancel', onTouchEnd, { passive: false })
   }
 }

--- a/engines/collavre/app/javascript/controllers/comments/presence_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/presence_controller.js
@@ -405,24 +405,21 @@ export default class extends Controller {
       proxy.style.top = `${y - 30}px`
     }
 
-    const findDropTarget = (x, y) => {
-      const el = document.elementFromPoint(x, y)
-      return el?.closest?.(DROP_TARGET_SEL) ?? null
-    }
-
     const updateDropTarget = (x, y) => {
-      if (proxy) proxy.style.display = 'none'
-      // Check exact point and nearby points (finger imprecision on mobile)
-      let target = findDropTarget(x, y)
-      if (!target) target = findDropTarget(x, y - 15)
-      if (!target) target = findDropTarget(x, y + 15)
-      if (!target) target = findDropTarget(x - 10, y)
-      if (!target) target = findDropTarget(x + 10, y)
-      if (proxy) proxy.style.display = ''
-
-      if (target !== currentTarget) {
+      const PAD = 12
+      const targets = document.querySelectorAll(DROP_TARGET_SEL)
+      let found = null
+      for (const t of targets) {
+        const rect = t.getBoundingClientRect()
+        if (x >= rect.left - PAD && x <= rect.right + PAD &&
+            y >= rect.top - PAD && y <= rect.bottom + PAD) {
+          found = t
+          break
+        }
+      }
+      if (found !== currentTarget) {
         currentTarget?.classList.remove(DRAG_OVER_CLASS)
-        currentTarget = target
+        currentTarget = found
         currentTarget?.classList.add(DRAG_OVER_CLASS)
       }
     }

--- a/engines/collavre/app/javascript/controllers/comments/presence_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/presence_controller.js
@@ -1,5 +1,6 @@
 import { Controller } from '@hotwired/stimulus'
 import { createSubscription } from '../../services/cable'
+import TouchDragHandler from '../../lib/touch_drag'
 
 const TYPING_TIMEOUT = 3000
 const AGENT_STATUS_TIMEOUT = 10000 // Safety timeout for agent_status (heartbeat expected every 3s)
@@ -383,133 +384,35 @@ export default class extends Controller {
   _addAgentTouchDrag(wrapper, user) {
     if (!('ontouchstart' in window)) return
 
-    const LONG_PRESS_MS = 400
-    const MOVE_TOLERANCE = 10
-    const DROP_TARGET_SEL = '.topic-tag.topic-drop-target, .topic-creation-container'
-    const DRAG_OVER_CLASS = 'drag-over'
+    const handler = new TouchDragHandler({
+      container: wrapper,
+      singleElement: true,
+      dropTargetSelector: '.topic-tag.topic-drop-target, .topic-creation-container',
+      draggingClass: 'dragging',
 
-    let timer = null
-    let dragging = false
-    let proxy = null
-    let currentTarget = null
-    let startX = 0
-    let startY = 0
+      proxyContent: () =>
+        `<span class="touch-drag-proxy-badge">${user.name}</span>`,
 
-    const cancelLongPress = () => {
-      if (timer) { clearTimeout(timer); timer = null }
-    }
-
-    const moveProxy = (x, y) => {
-      if (!proxy) return
-      const rect = proxy.getBoundingClientRect()
-      const hw = (rect.width || 80) / 2
-      const hh = (rect.height || 30) / 2
-      proxy.style.left = `${x - hw}px`
-      proxy.style.top = `${y - hh}px`
-    }
-
-    const updateDropTarget = (x, y) => {
-      const PAD = 12
-      const targets = document.querySelectorAll(DROP_TARGET_SEL)
-      let found = null
-      for (const t of targets) {
-        const rect = t.getBoundingClientRect()
-        if (x >= rect.left - PAD && x <= rect.right + PAD &&
-            y >= rect.top - PAD && y <= rect.bottom + PAD) {
-          found = t
-          break
-        }
-      }
-      if (found !== currentTarget) {
-        currentTarget?.classList.remove(DRAG_OVER_CLASS)
-        currentTarget = found
-        currentTarget?.classList.add(DRAG_OVER_CLASS)
-      }
-    }
-
-    const endDrag = () => {
-      dragging = false
-      cancelLongPress()
-      document.removeEventListener('contextmenu', preventContext, true)
-      wrapper.classList.remove('dragging')
-      if (currentTarget) { currentTarget.classList.remove(DRAG_OVER_CLASS); currentTarget = null }
-      if (proxy) { proxy.remove(); proxy = null }
-    }
-
-    const preventContext = (e) => { if (dragging || timer) e.preventDefault() }
-
-    const startDrag = (touch) => {
-      timer = null
-      dragging = true
-      if (navigator.vibrate) navigator.vibrate(30)
-      document.addEventListener('contextmenu', preventContext, { capture: true })
-      wrapper.classList.add('dragging')
-
-      proxy = document.createElement('div')
-      proxy.className = 'touch-drag-proxy'
-      proxy.innerHTML = `<span class="touch-drag-proxy-badge">${user.name}</span>`
-      document.body.appendChild(proxy)
-      moveProxy(touch.clientX, touch.clientY)
-    }
-
-    wrapper.addEventListener('touchstart', (e) => {
-      if (dragging) return
-      const touch = e.touches[0]
-      if (!touch) return
-      startX = touch.clientX
-      startY = touch.clientY
-      cancelLongPress()
-      timer = setTimeout(() => startDrag(touch), LONG_PRESS_MS)
-    }, { passive: false })
-
-    wrapper.addEventListener('touchmove', (e) => {
-      const touch = e.touches[0]
-      if (!touch) return
-      if (dragging) {
-        e.preventDefault()
-        moveProxy(touch.clientX, touch.clientY)
-        updateDropTarget(touch.clientX, touch.clientY)
-        return
-      }
-      if (timer) {
-        const dx = Math.abs(touch.clientX - startX)
-        const dy = Math.abs(touch.clientY - startY)
-        if (dx > MOVE_TOLERANCE || dy > MOVE_TOLERANCE) {
-          cancelLongPress()
-        } else {
-          e.preventDefault() // Prevent scroll within tolerance during long-press wait
-        }
-      }
-    }, { passive: false })
-
-    const onTouchEnd = (e) => {
-      if (timer) { cancelLongPress(); return }
-      if (!dragging) return
-      e.preventDefault()
-
-      if (currentTarget) {
+      onDrop: (targetEl) => {
         const agentData = { id: user.id, name: user.name, avatar_url: user.avatar_url }
         const topicsCtrl = this.application.getControllerForElementAndIdentifier(
           this.element, 'comments--topics'
         )
-        if (topicsCtrl) {
-          // Drop on "+" button → create topic with agent
-          if (currentTarget.closest('.topic-creation-container')) {
-            topicsCtrl.createTopicWithAgent(agentData)
-          } else {
-            // Drop on topic tag → set primary agent
-            const topicTag = currentTarget.closest('.topic-tag.topic-drop-target')
-            if (topicTag && topicTag.dataset.id) {
-              topicsCtrl.setTopicPrimaryAgent(topicTag.dataset.id, agentData)
-            }
+        if (!topicsCtrl) return
+
+        if (targetEl.closest('.topic-creation-container')) {
+          topicsCtrl.createTopicWithAgent(agentData)
+        } else {
+          const topicTag = targetEl.closest('.topic-tag.topic-drop-target')
+          if (topicTag?.dataset.id) {
+            topicsCtrl.setTopicPrimaryAgent(topicTag.dataset.id, agentData)
           }
         }
       }
+    })
 
-      endDrag()
-    }
-
-    wrapper.addEventListener('touchend', onTouchEnd, { passive: false })
-    wrapper.addEventListener('touchcancel', onTouchEnd, { passive: false })
+    // Store for cleanup if needed
+    if (!this._agentTouchDragHandlers) this._agentTouchDragHandlers = []
+    this._agentTouchDragHandlers.push(handler)
   }
 }

--- a/engines/collavre/app/javascript/lib/touch_drag.js
+++ b/engines/collavre/app/javascript/lib/touch_drag.js
@@ -1,0 +1,222 @@
+/**
+ * Touch-based drag-and-drop for mobile devices.
+ *
+ * Usage:
+ *   const td = new TouchDragHandler({
+ *     container: listElement,           // scroll container that holds draggable items
+ *     itemSelector: '.comment-item.selected-for-move',
+ *     dropTargetSelector: '.topic-drop-target, .topic-creation-container',
+ *     longPressMs: 400,
+ *     moveTolerance: 10,                // px before long-press is cancelled
+ *     proxyClass: 'touch-drag-proxy',
+ *     dragOverClass: 'drag-over',
+ *     draggingClass: 'touch-dragging',
+ *     onDragStart(items) {},            // return false to cancel
+ *     onDrop(targetEl) {},              // called when dropped on a valid target
+ *     onCancel() {},
+ *     proxyContent(items) { return '...' }  // HTML for the drag proxy badge
+ *   })
+ *
+ *   td.destroy()  // cleanup
+ */
+
+const DEFAULT_LONG_PRESS_MS = 400
+const DEFAULT_MOVE_TOLERANCE = 10
+
+export default class TouchDragHandler {
+  constructor(opts) {
+    this.container = opts.container
+    this.itemSelector = opts.itemSelector
+    this.dropTargetSelector = opts.dropTargetSelector
+    this.longPressMs = opts.longPressMs ?? DEFAULT_LONG_PRESS_MS
+    this.moveTolerance = opts.moveTolerance ?? DEFAULT_MOVE_TOLERANCE
+    this.proxyClass = opts.proxyClass ?? 'touch-drag-proxy'
+    this.dragOverClass = opts.dragOverClass ?? 'drag-over'
+    this.draggingClass = opts.draggingClass ?? 'touch-dragging'
+    this.onDragStart = opts.onDragStart
+    this.onDrop = opts.onDrop
+    this.onCancel = opts.onCancel
+    this.proxyContent = opts.proxyContent
+
+    // State
+    this._timer = null
+    this._dragging = false
+    this._proxy = null
+    this._startX = 0
+    this._startY = 0
+    this._currentTarget = null
+
+    // Bind handlers
+    this._onTouchStart = this._handleTouchStart.bind(this)
+    this._onTouchMove = this._handleTouchMove.bind(this)
+    this._onTouchEnd = this._handleTouchEnd.bind(this)
+    this._onContextMenu = this._handleContextMenu.bind(this)
+
+    this.container.addEventListener('touchstart', this._onTouchStart, { passive: false })
+    this.container.addEventListener('touchmove', this._onTouchMove, { passive: false })
+    this.container.addEventListener('touchend', this._onTouchEnd, { passive: false })
+    this.container.addEventListener('touchcancel', this._onTouchEnd, { passive: false })
+  }
+
+  destroy() {
+    this._cancelLongPress()
+    this._endDrag()
+    this.container.removeEventListener('touchstart', this._onTouchStart)
+    this.container.removeEventListener('touchmove', this._onTouchMove)
+    this.container.removeEventListener('touchend', this._onTouchEnd)
+    this.container.removeEventListener('touchcancel', this._onTouchEnd)
+  }
+
+  // ── Private ───────────────────────────────────────────────
+
+  _handleTouchStart(e) {
+    if (this._dragging) return
+
+    const touch = e.touches[0]
+    if (!touch) return
+
+    // Must start on a selected item
+    const item = touch.target.closest?.(this.itemSelector)
+    if (!item) return
+
+    // Ignore if started on interactive elements
+    if (touch.target.closest('input, button, a, textarea, .comment-select')) return
+
+    this._startX = touch.clientX
+    this._startY = touch.clientY
+    this._startItem = item
+
+    this._cancelLongPress()
+    this._timer = setTimeout(() => {
+      this._startDrag(touch)
+    }, this.longPressMs)
+  }
+
+  _handleTouchMove(e) {
+    const touch = e.touches[0]
+    if (!touch) return
+
+    if (this._dragging) {
+      e.preventDefault()
+      this._moveDrag(touch)
+      return
+    }
+
+    // If not dragging yet, check if we moved too far (cancel long-press)
+    if (this._timer) {
+      const dx = Math.abs(touch.clientX - this._startX)
+      const dy = Math.abs(touch.clientY - this._startY)
+      if (dx > this.moveTolerance || dy > this.moveTolerance) {
+        this._cancelLongPress()
+      }
+    }
+  }
+
+  _handleTouchEnd(e) {
+    if (this._timer) {
+      this._cancelLongPress()
+      return
+    }
+
+    if (!this._dragging) return
+
+    e.preventDefault()
+
+    if (this._currentTarget) {
+      this.onDrop?.(this._currentTarget)
+    } else {
+      this.onCancel?.()
+    }
+
+    this._endDrag()
+  }
+
+  _handleContextMenu(e) {
+    // Suppress native context menu during drag
+    if (this._dragging || this._timer) {
+      e.preventDefault()
+    }
+  }
+
+  _startDrag(touch) {
+    this._timer = null
+
+    // Collect matched items
+    const items = this.container.querySelectorAll(this.itemSelector)
+    if (!items || items.length === 0) return
+
+    // Let caller cancel
+    if (this.onDragStart && this.onDragStart(items) === false) return
+
+    this._dragging = true
+
+    // Suppress context menu while dragging
+    document.addEventListener('contextmenu', this._onContextMenu, { capture: true })
+
+    // Vibrate for haptic feedback (if supported)
+    if (navigator.vibrate) navigator.vibrate(30)
+
+    // Add class to container
+    this.container.classList.add(this.draggingClass)
+
+    // Create floating proxy
+    this._proxy = document.createElement('div')
+    this._proxy.className = this.proxyClass
+    this._proxy.innerHTML = this.proxyContent?.(items) ?? `${items.length}`
+    document.body.appendChild(this._proxy)
+    this._moveProxy(touch.clientX, touch.clientY)
+  }
+
+  _moveDrag(touch) {
+    this._moveProxy(touch.clientX, touch.clientY)
+    this._updateDropTarget(touch.clientX, touch.clientY)
+  }
+
+  _moveProxy(x, y) {
+    if (!this._proxy) return
+    this._proxy.style.left = `${x + 12}px`
+    this._proxy.style.top = `${y - 30}px`
+  }
+
+  _updateDropTarget(x, y) {
+    // Hide proxy momentarily to hit-test what's underneath
+    if (this._proxy) this._proxy.style.pointerEvents = 'none'
+    const el = document.elementFromPoint(x, y)
+    if (this._proxy) this._proxy.style.pointerEvents = ''
+
+    const target = el?.closest?.(this.dropTargetSelector) ?? null
+
+    if (target !== this._currentTarget) {
+      this._currentTarget?.classList.remove(this.dragOverClass)
+      this._currentTarget = target
+      this._currentTarget?.classList.add(this.dragOverClass)
+    }
+  }
+
+  _endDrag() {
+    this._dragging = false
+    this._cancelLongPress()
+
+    document.removeEventListener('contextmenu', this._onContextMenu, { capture: true })
+
+    this.container.classList.remove(this.draggingClass)
+
+    if (this._currentTarget) {
+      this._currentTarget.classList.remove(this.dragOverClass)
+      this._currentTarget = null
+    }
+
+    if (this._proxy) {
+      this._proxy.remove()
+      this._proxy = null
+    }
+  }
+
+  _cancelLongPress() {
+    if (this._timer) {
+      clearTimeout(this._timer)
+      this._timer = null
+    }
+    this._startItem = null
+  }
+}

--- a/engines/collavre/app/javascript/lib/touch_drag.js
+++ b/engines/collavre/app/javascript/lib/touch_drag.js
@@ -187,8 +187,12 @@ export default class TouchDragHandler {
 
   _moveProxy(x, y) {
     if (!this._proxy) return
-    this._proxy.style.left = `${x + 12}px`
-    this._proxy.style.top = `${y - 30}px`
+    // Center the proxy on the touch point
+    const rect = this._proxy.getBoundingClientRect()
+    const hw = (rect.width || 80) / 2
+    const hh = (rect.height || 30) / 2
+    this._proxy.style.left = `${x - hw}px`
+    this._proxy.style.top = `${y - hh}px`
   }
 
   _updateDropTarget(x, y) {

--- a/engines/collavre/app/javascript/lib/touch_drag.js
+++ b/engines/collavre/app/javascript/lib/touch_drag.js
@@ -86,6 +86,13 @@ export default class TouchDragHandler {
     this._startY = touch.clientY
     this._startItem = item
 
+    // Prevent native long-press behavior (text selection, context menu,
+    // native drag preview) from stealing touch events after ~500ms.
+    // Scrolling is handled via touchmove: within tolerance we preventDefault,
+    // beyond tolerance we cancel the timer and the user can scroll normally
+    // on the next touch.
+    e.preventDefault()
+
     this._cancelLongPress()
     this._timer = setTimeout(() => {
       this._startDrag(touch)

--- a/engines/collavre/app/javascript/lib/touch_drag.js
+++ b/engines/collavre/app/javascript/lib/touch_drag.js
@@ -26,7 +26,8 @@ const DEFAULT_MOVE_TOLERANCE = 10
 export default class TouchDragHandler {
   constructor(opts) {
     this.container = opts.container
-    this.itemSelector = opts.itemSelector
+    this.itemSelector = opts.itemSelector       // optional when singleElement is true
+    this.singleElement = opts.singleElement ?? false  // treat container itself as the draggable
     this.dropTargetSelector = opts.dropTargetSelector
     this.longPressMs = opts.longPressMs ?? DEFAULT_LONG_PRESS_MS
     this.moveTolerance = opts.moveTolerance ?? DEFAULT_MOVE_TOLERANCE
@@ -75,16 +76,19 @@ export default class TouchDragHandler {
     const touch = e.touches[0]
     if (!touch) return
 
-    // Must start on a selected item
-    const item = touch.target.closest?.(this.itemSelector)
-    if (!item) return
+    if (this.singleElement) {
+      // In single-element mode, the container itself is the draggable
+    } else {
+      // Must start on a selected item
+      const item = touch.target.closest?.(this.itemSelector)
+      if (!item) return
 
-    // Ignore if started on interactive elements
-    if (touch.target.closest('input, button, a, textarea, .comment-select')) return
+      // Ignore if started on interactive elements
+      if (touch.target.closest('input, button, a, textarea, .comment-select')) return
+    }
 
     this._startX = touch.clientX
     this._startY = touch.clientY
-    this._startItem = item
 
     // Prevent native long-press behavior (text selection, context menu,
     // native drag preview) from stealing touch events after ~500ms.
@@ -154,8 +158,10 @@ export default class TouchDragHandler {
   _startDrag(touch) {
     this._timer = null
 
-    // Collect matched items
-    const items = this.container.querySelectorAll(this.itemSelector)
+    // Collect matched items (or the container itself in single-element mode)
+    const items = this.singleElement
+      ? [this.container]
+      : this.container.querySelectorAll(this.itemSelector)
     if (!items || items.length === 0) return
 
     // Let caller cancel
@@ -187,12 +193,14 @@ export default class TouchDragHandler {
 
   _moveProxy(x, y) {
     if (!this._proxy) return
-    // Center the proxy on the touch point
-    const rect = this._proxy.getBoundingClientRect()
-    const hw = (rect.width || 80) / 2
-    const hh = (rect.height || 30) / 2
-    this._proxy.style.left = `${x - hw}px`
-    this._proxy.style.top = `${y - hh}px`
+    // Cache proxy dimensions on first call (size doesn't change during drag)
+    if (this._proxyHW === undefined) {
+      const rect = this._proxy.getBoundingClientRect()
+      this._proxyHW = (rect.width || 80) / 2
+      this._proxyHH = (rect.height || 30) / 2
+    }
+    this._proxy.style.left = `${x - this._proxyHW}px`
+    this._proxy.style.top = `${y - this._proxyHH}px`
   }
 
   _updateDropTarget(x, y) {
@@ -200,7 +208,11 @@ export default class TouchDragHandler {
     // elementFromPoint is unreliable on mobile when z-index, overlays,
     // or reflow timing interfere with the result.
     const PAD = 12 // extra padding for finger imprecision
-    const targets = document.querySelectorAll(this.dropTargetSelector)
+    // Cache drop targets on first call (topic list doesn't change during drag)
+    if (!this._cachedDropTargets) {
+      this._cachedDropTargets = document.querySelectorAll(this.dropTargetSelector)
+    }
+    const targets = this._cachedDropTargets
     let found = null
 
     for (const target of targets) {
@@ -235,7 +247,10 @@ export default class TouchDragHandler {
     if (this._proxy) {
       this._proxy.remove()
       this._proxy = null
+      this._proxyHW = undefined
+      this._proxyHH = undefined
     }
+    this._cachedDropTargets = null
   }
 
   _cancelLongPress() {
@@ -243,6 +258,5 @@ export default class TouchDragHandler {
       clearTimeout(this._timer)
       this._timer = null
     }
-    this._startItem = null
   }
 }

--- a/engines/collavre/app/javascript/lib/touch_drag.js
+++ b/engines/collavre/app/javascript/lib/touch_drag.js
@@ -102,12 +102,18 @@ export default class TouchDragHandler {
       return
     }
 
-    // If not dragging yet, check if we moved too far (cancel long-press)
+    // During long-press wait: prevent scroll within tolerance so the
+    // timer isn't accidentally cancelled by natural finger tremor causing
+    // a scroll offset shift.
     if (this._timer) {
       const dx = Math.abs(touch.clientX - this._startX)
       const dy = Math.abs(touch.clientY - this._startY)
       if (dx > this.moveTolerance || dy > this.moveTolerance) {
+        // User intentionally scrolling — cancel long-press, let scroll happen
         this._cancelLongPress()
+      } else {
+        // Within tolerance — prevent scroll to keep the long-press alive
+        e.preventDefault()
       }
     }
   }
@@ -179,18 +185,28 @@ export default class TouchDragHandler {
   }
 
   _updateDropTarget(x, y) {
-    // Hide proxy momentarily to hit-test what's underneath
-    if (this._proxy) this._proxy.style.pointerEvents = 'none'
-    const el = document.elementFromPoint(x, y)
-    if (this._proxy) this._proxy.style.pointerEvents = ''
+    // Temporarily hide the proxy so elementFromPoint can see through it
+    if (this._proxy) this._proxy.style.display = 'none'
 
-    const target = el?.closest?.(this.dropTargetSelector) ?? null
+    // Check both the exact point and nearby points (finger is imprecise on mobile)
+    let target = this._findDropTarget(x, y)
+    if (!target) target = this._findDropTarget(x, y - 15)
+    if (!target) target = this._findDropTarget(x, y + 15)
+    if (!target) target = this._findDropTarget(x - 10, y)
+    if (!target) target = this._findDropTarget(x + 10, y)
+
+    if (this._proxy) this._proxy.style.display = ''
 
     if (target !== this._currentTarget) {
       this._currentTarget?.classList.remove(this.dragOverClass)
       this._currentTarget = target
       this._currentTarget?.classList.add(this.dragOverClass)
     }
+  }
+
+  _findDropTarget(x, y) {
+    const el = document.elementFromPoint(x, y)
+    return el?.closest?.(this.dropTargetSelector) ?? null
   }
 
   _endDrag() {

--- a/engines/collavre/app/javascript/lib/touch_drag.js
+++ b/engines/collavre/app/javascript/lib/touch_drag.js
@@ -185,28 +185,27 @@ export default class TouchDragHandler {
   }
 
   _updateDropTarget(x, y) {
-    // Temporarily hide the proxy so elementFromPoint can see through it
-    if (this._proxy) this._proxy.style.display = 'none'
+    // Use bounding-rect hit testing instead of elementFromPoint.
+    // elementFromPoint is unreliable on mobile when z-index, overlays,
+    // or reflow timing interfere with the result.
+    const PAD = 12 // extra padding for finger imprecision
+    const targets = document.querySelectorAll(this.dropTargetSelector)
+    let found = null
 
-    // Check both the exact point and nearby points (finger is imprecise on mobile)
-    let target = this._findDropTarget(x, y)
-    if (!target) target = this._findDropTarget(x, y - 15)
-    if (!target) target = this._findDropTarget(x, y + 15)
-    if (!target) target = this._findDropTarget(x - 10, y)
-    if (!target) target = this._findDropTarget(x + 10, y)
+    for (const target of targets) {
+      const rect = target.getBoundingClientRect()
+      if (x >= rect.left - PAD && x <= rect.right + PAD &&
+          y >= rect.top - PAD && y <= rect.bottom + PAD) {
+        found = target
+        break
+      }
+    }
 
-    if (this._proxy) this._proxy.style.display = ''
-
-    if (target !== this._currentTarget) {
+    if (found !== this._currentTarget) {
       this._currentTarget?.classList.remove(this.dragOverClass)
-      this._currentTarget = target
+      this._currentTarget = found
       this._currentTarget?.classList.add(this.dragOverClass)
     }
-  }
-
-  _findDropTarget(x, y) {
-    const el = document.elementFromPoint(x, y)
-    return el?.closest?.(this.dropTargetSelector) ?? null
   }
 
   _endDrag() {

--- a/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
@@ -36,6 +36,7 @@
      data-selection-topic-move-text="<%= t('collavre.comments.selection_topic_move') %>"
      data-selection-close-text="<%= t('collavre.comments.selection_close') %>"
      data-selection-drag-hint-text="<%= t('collavre.comments.selection_drag_hint') %>"
+     data-selection-touch-drag-hint-text="<%= t('collavre.comments.selection_touch_drag_hint') %>"
      data-selection-merge-text="<%= t('collavre.comments.selection_merge') %>"
      data-merge-confirm-text="<%= t('collavre.comments.merge_confirm') %>"
      data-batch-delete-confirm-text="<%= t('collavre.comments.batch_delete_confirm') %>"

--- a/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
@@ -37,6 +37,8 @@
      data-selection-close-text="<%= t('collavre.comments.selection_close') %>"
      data-selection-drag-hint-text="<%= t('collavre.comments.selection_drag_hint') %>"
      data-selection-touch-drag-hint-text="<%= t('collavre.comments.selection_touch_drag_hint') %>"
+     data-touch-drag-proxy-one-text="<%= t('collavre.comments.touch_drag_proxy_label.one') %>"
+     data-touch-drag-proxy-other-text="<%= t('collavre.comments.touch_drag_proxy_label.other') %>"
      data-selection-merge-text="<%= t('collavre.comments.selection_merge') %>"
      data-merge-confirm-text="<%= t('collavre.comments.merge_confirm') %>"
      data-batch-delete-confirm-text="<%= t('collavre.comments.batch_delete_confirm') %>"

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -95,6 +95,7 @@ en:
       selection_topic_move: Move to topic
       selection_close: Cancel
       selection_drag_hint: "You can also drag & drop to move to a topic"
+      selection_touch_drag_hint: "Long press a selected message to drag to a topic"
       selection_merge: Merge
       merge_confirm: "Merge the selected messages into one? The first message will be updated and the rest will be deleted."
       merge:

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -96,6 +96,9 @@ en:
       selection_close: Cancel
       selection_drag_hint: "You can also drag & drop to move to a topic"
       selection_touch_drag_hint: "Long press a selected message to drag to a topic"
+      touch_drag_proxy_label:
+        one: "1 message"
+        other: "%{count} messages"
       selection_merge: Merge
       merge_confirm: "Merge the selected messages into one? The first message will be updated and the rest will be deleted."
       merge:

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -93,6 +93,9 @@ ko:
       selection_close: 취소
       selection_drag_hint: "드래그&드롭으로도 토픽 이동 가능"
       selection_touch_drag_hint: "선택한 메시지를 길게 눌러 토픽으로 드래그하세요"
+      touch_drag_proxy_label:
+        one: "메시지 1개"
+        other: "메시지 %{count}개"
       selection_merge: 병합
       merge_confirm: "선택한 메시지를 하나로 병합하시겠습니까? 첫 번째 메시지가 업데이트되고 나머지는 삭제됩니다."
       merge:

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -92,6 +92,7 @@ ko:
       selection_topic_move: 토픽 이동
       selection_close: 취소
       selection_drag_hint: "드래그&드롭으로도 토픽 이동 가능"
+      selection_touch_drag_hint: "선택한 메시지를 길게 눌러 토픽으로 드래그하세요"
       selection_merge: 병합
       merge_confirm: "선택한 메시지를 하나로 병합하시겠습니까? 첫 번째 메시지가 업데이트되고 나머지는 삭제됩니다."
       merge:


### PR DESCRIPTION
## Summary

Add touch-based drag-and-drop support for mobile browsers, enabling users to long-press selected chat messages and drag them to topic tags or the "+" button to move/create topics — the same workflow that works via HTML5 DnD on desktop.

## Changes

### New: `lib/touch_drag.js` — Reusable Touch Drag Handler
- Long-press (400ms) on selected items initiates drag mode
- Floating proxy badge follows the finger showing message count
- Hit-tests elements under touch point to highlight valid drop targets
- Cancels on scroll or excess movement before long-press triggers
- Haptic feedback via `navigator.vibrate()` on drag start
- Suppresses native context menu during drag

### Modified: `list_controller.js`
- Initializes `TouchDragHandler` on touch-capable devices (`ontouchstart in window`)
- Wires drop targets:
  - `.topic-tag.topic-drop-target` → move comments to that topic
  - `.topic-creation-container` → create new topic and move
- Adds touch-specific hint in selection action bar ("Long press to drag")
- Clean destroy on controller disconnect

### CSS: `comments_popup.css`
- `.touch-drag-proxy` + `.touch-drag-proxy-badge` styles using design tokens
- Pop-in animation for drag proxy
- `.touch-dragging` class dims non-selected items
- Show touch hint on `pointer: coarse`, hide on non-touch

### i18n (en + ko)
- `selection_touch_drag_hint`: en/ko strings for the long-press hint

### Tests
- Updated `list_controller_selection.test.js` with touch hint assertion

## How to Test
1. Open the app on an Android/iOS device (or Chrome DevTools mobile emulation)
2. Open a creative's chat popup
3. Select one or more messages via checkboxes
4. Long-press on a selected message (~400ms)
5. A floating badge should appear; drag to a topic tag or "+" button
6. Release to move/create topic

Desktop drag-and-drop continues to work unchanged.