### PR TITLE
feat: add snapshot recovery for compress and merge operations

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -126,6 +126,24 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_20_061144) do
     t.index ["user_id"], name: "index_comment_read_pointers_on_user_id"
   end
 
+  create_table "comment_snapshots", force: :cascade do |t|
+    t.json "comments_data", default: [], null: false
+    t.datetime "created_at", null: false
+    t.integer "creative_id", null: false
+    t.string "operation", null: false
+    t.datetime "restored_at"
+    t.integer "result_comment_id"
+    t.integer "topic_id"
+    t.datetime "updated_at", null: false
+    t.integer "user_id", null: false
+    t.index ["creative_id", "operation"], name: "index_comment_snapshots_on_creative_id_and_operation"
+    t.index ["creative_id"], name: "index_comment_snapshots_on_creative_id"
+    t.index ["restored_at"], name: "index_comment_snapshots_on_restored_at"
+    t.index ["result_comment_id"], name: "index_comment_snapshots_on_result_comment_id"
+    t.index ["topic_id"], name: "index_comment_snapshots_on_topic_id"
+    t.index ["user_id"], name: "index_comment_snapshots_on_user_id"
+  end
+
   create_table "comment_versions", force: :cascade do |t|
     t.integer "comment_id", null: false
     t.text "content", null: false
@@ -822,6 +840,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_20_061144) do
   add_foreign_key "comment_reactions", "users"
   add_foreign_key "comment_read_pointers", "creatives"
   add_foreign_key "comment_read_pointers", "users"
+  add_foreign_key "comment_snapshots", "comments", column: "result_comment_id", on_delete: :nullify
+  add_foreign_key "comment_snapshots", "creatives"
+  add_foreign_key "comment_snapshots", "topics"
+  add_foreign_key "comment_snapshots", "users"
   add_foreign_key "comment_versions", "comments"
   add_foreign_key "comment_versions", "comments", column: "review_comment_id"
   add_foreign_key "comments", "comment_versions", column: "selected_version_id"
@@ -883,7 +905,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_20_061144) do
   add_foreign_key "topics", "creatives"
   add_foreign_key "topics", "users"
   add_foreign_key "user_creative_preferences", "creatives"
-  add_foreign_key "user_creative_preferences", "topics", column: "last_topic_id"
+  add_foreign_key "user_creative_preferences", "topics", column: "last_topic_id", on_delete: :nullify
   add_foreign_key "user_creative_preferences", "users"
   add_foreign_key "user_themes", "users"
   add_foreign_key "webauthn_credentials", "users"

--- a/engines/collavre/app/assets/stylesheets/collavre/comment_snapshots.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comment_snapshots.css
@@ -1,0 +1,26 @@
+.comment-snapshot-restore {
+  margin-top: var(--space-2);
+}
+
+.restore-snapshot-btn {
+  background: none;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-1);
+  cursor: pointer;
+  padding: var(--space-1) var(--space-3);
+  font-size: var(--text-xs);
+  line-height: 1.6;
+  color: var(--text-muted);
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+
+.restore-snapshot-btn:hover:not(:disabled) {
+  background: var(--surface-hover);
+  color: var(--text-primary);
+  border-color: var(--color-accent-border);
+}
+
+.restore-snapshot-btn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}

--- a/engines/collavre/app/controllers/collavre/comments/snapshots_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comments/snapshots_controller.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Comments
+    class SnapshotsController < ApplicationController
+      before_action :set_creative
+      before_action :set_snapshot, only: [ :restore ]
+
+      # GET /creatives/:creative_id/comments/snapshots
+      def index
+        snapshots = @creative.comment_snapshots
+          .restorable
+          .order(created_at: :desc)
+
+        render json: snapshots.map { |s| snapshot_json(s) }
+      end
+
+      # POST /creatives/:creative_id/comments/snapshots/:id/restore
+      def restore
+        service = CommentSnapshotRestoreService.new(snapshot: @snapshot, user: Current.user)
+        recreated = service.call
+        render json: {
+          message: I18n.t("collavre.comment_snapshots.restored"),
+          count: recreated.size
+        }
+      rescue CommentSnapshotRestoreService::RestoreError => e
+        render json: { error: e.message }, status: :unprocessable_entity
+      end
+
+      private
+
+      def set_creative
+        @creative = Creative.find(params[:creative_id]).effective_origin
+        unless @creative.has_permission?(Current.user, :read)
+          render json: { error: I18n.t("collavre.creatives.errors.no_permission") }, status: :forbidden
+        end
+      end
+
+      def set_snapshot
+        @snapshot = @creative.comment_snapshots.find(params[:id])
+      end
+
+      def snapshot_json(snapshot)
+        {
+          id: snapshot.id,
+          operation: snapshot.operation,
+          comment_count: snapshot.comment_count,
+          created_at: snapshot.created_at,
+          result_comment_id: snapshot.result_comment_id,
+          restorable: snapshot.restorable?
+        }
+      end
+    end
+  end
+end

--- a/engines/collavre/app/controllers/collavre/comments_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comments_controller.rb
@@ -32,7 +32,7 @@ module Collavre
         Current.user.id,
         Current.user.id
       )
-      scope = visible_scope.with_attached_images.includes(:topic, :comment_reactions, :comment_versions)
+      scope = visible_scope.with_attached_images.includes(:topic, :comment_reactions, :comment_versions, :snapshot_as_result)
 
       if params[:search].present?
         words = params[:search].to_s.strip.downcase.split(/\s+/)

--- a/engines/collavre/app/javascript/controllers/comment_controller.js
+++ b/engines/collavre/app/javascript/controllers/comment_controller.js
@@ -454,4 +454,36 @@ export default class extends Controller {
       reactionsList.appendChild(button)
     })
   }
+
+  async restoreSnapshot(event) {
+    const button = event.currentTarget
+    const snapshotId = button.dataset.snapshotId
+    const creativeId = button.dataset.creativeId
+    const confirmText = button.dataset.confirmText || 'Restore original messages?'
+
+    if (!confirm(confirmText)) return
+
+    button.disabled = true
+    try {
+      const response = await fetch(`/creatives/${creativeId}/comments/snapshots/${snapshotId}/restore`, {
+        method: 'POST',
+        headers: {
+          'X-CSRF-Token': document.querySelector('meta[name=csrf-token]')?.content,
+          'Content-Type': 'application/json',
+        },
+      })
+      if (response.ok) {
+        // Restored comments will appear via ActionCable broadcast;
+        // the summary comment (this one) will be destroyed via broadcast too
+      } else {
+        const data = await response.json().catch(() => ({}))
+        alert(data.error || 'Failed to restore')
+        button.disabled = false
+      }
+    } catch (error) {
+      console.error('Error restoring snapshot:', error)
+      alert('Failed to restore')
+      button.disabled = false
+    }
+  }
 }

--- a/engines/collavre/app/jobs/collavre/compress_job.rb
+++ b/engines/collavre/app/jobs/collavre/compress_job.rb
@@ -1,6 +1,7 @@
 module Collavre
   class CompressJob < ApplicationJob
     include AiAgentResolvable
+    include CommentSerializable
 
     queue_as :default
 
@@ -13,7 +14,7 @@ module Collavre
       all_comments = creative.comments
         .where(topic_id: topic_id)
         .order(created_at: :asc)
-        .includes(:user)
+        .includes(:user, images_attachments: :blob)
 
       # Separate: comments to summarize vs the compress command itself
       compress_pattern = /\A\/compress\b/i
@@ -80,6 +81,20 @@ module Collavre
         user: user,
         topic_id: topic_id,
         content: summary_content
+      )
+
+      # Save snapshot for recovery before deleting originals
+      # Exclude the last comment only if it's the /compress command trigger
+      last_comment = all_comments.last
+      last_is_command = last_comment&.content.to_s.strip.match?(compress_pattern)
+      restorable_comments = last_is_command ? all_comments[0..-2] : all_comments.to_a
+      CommentSnapshot.create!(
+        creative: creative,
+        topic_id: topic_id,
+        user: user,
+        operation: "compress",
+        comments_data: serialize_comments(restorable_comments),
+        result_comment: summary_comment
       )
 
       # Delete original comments (excluding the newly created summary)

--- a/engines/collavre/app/jobs/collavre/merge_comments_job.rb
+++ b/engines/collavre/app/jobs/collavre/merge_comments_job.rb
@@ -1,6 +1,7 @@
 module Collavre
   class MergeCommentsJob < ApplicationJob
     include AiAgentResolvable
+    include CommentSerializable
 
     queue_as :default
 
@@ -20,7 +21,7 @@ module Collavre
       comments = creative.comments
         .where(id: comment_ids)
         .order(created_at: :asc)
-        .includes(:user)
+        .includes(:user, images_attachments: :blob)
         .to_a
 
       return if comments.size < 2
@@ -69,6 +70,16 @@ module Collavre
       # Update the first comment and delete the rest atomically
       remaining_ids = comments[1..].map(&:id)
       ActiveRecord::Base.transaction do
+        # Save snapshot for recovery before modifying/deleting originals
+        CommentSnapshot.create!(
+          creative: creative,
+          topic_id: topic_id,
+          user_id: user_id,
+          operation: "merge",
+          comments_data: serialize_comments(comments),
+          result_comment: target_comment
+        )
+
         target_comment.update!(content: merged_content)
         creative.comments.where(id: remaining_ids).destroy_all
       end

--- a/engines/collavre/app/jobs/concerns/collavre/comment_serializable.rb
+++ b/engines/collavre/app/jobs/concerns/collavre/comment_serializable.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Collavre
+  module CommentSerializable
+    extend ActiveSupport::Concern
+
+    private
+
+    def serialize_comments(comments)
+      comments.map do |c|
+        data = {
+          "id" => c.id,
+          "user_id" => c.user_id,
+          "content" => c.content,
+          "topic_id" => c.topic_id,
+          "private" => c.private,
+          "created_at" => c.created_at.iso8601,
+          "quoted_comment_id" => c.quoted_comment_id,
+          "quoted_text" => c.quoted_text,
+          "review_type" => c.review_type
+        }
+        # Preserve attachment blob IDs for restore
+        if c.images.attached?
+          data["image_blob_ids"] = c.images.map { |img| img.blob_id }
+        end
+        data
+      end
+    end
+  end
+end

--- a/engines/collavre/app/models/collavre/comment.rb
+++ b/engines/collavre/app/models/collavre/comment.rb
@@ -28,6 +28,7 @@ module Collavre
     has_many :review_versions, class_name: "Collavre::CommentVersion", foreign_key: :review_comment_id, dependent: :nullify
     has_many :inbox_items, class_name: "Collavre::InboxItem", dependent: :nullify
     has_many :quoting_comments, class_name: "Collavre::Comment", foreign_key: :quoted_comment_id, dependent: :destroy
+    has_one :snapshot_as_result, class_name: "Collavre::CommentSnapshot", foreign_key: :result_comment_id, dependent: :nullify
     belongs_to :selected_version, class_name: "Collavre::CommentVersion", optional: true
 
     has_many_attached :images, dependent: :purge_later

--- a/engines/collavre/app/models/collavre/comment_snapshot.rb
+++ b/engines/collavre/app/models/collavre/comment_snapshot.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Collavre
+  class CommentSnapshot < ApplicationRecord
+    self.table_name = "comment_snapshots"
+
+    belongs_to :creative, class_name: "Collavre::Creative"
+    belongs_to :topic, class_name: "Collavre::Topic", optional: true
+    belongs_to :user, class_name: Collavre.configuration.user_class_name
+    belongs_to :result_comment, class_name: "Collavre::Comment", optional: true
+
+    validates :operation, presence: true, inclusion: { in: %w[compress merge] }
+    validates :comments_data, presence: true
+
+    scope :restorable, -> { where(restored_at: nil) }
+    scope :restored, -> { where.not(restored_at: nil) }
+
+    def restorable?
+      restored_at.nil?
+    end
+
+    def comment_count
+      comments_data.size
+    end
+  end
+end

--- a/engines/collavre/app/models/collavre/creative.rb
+++ b/engines/collavre/app/models/collavre/creative.rb
@@ -19,6 +19,7 @@ module Collavre
 
     has_many :comments, class_name: "Collavre::Comment", dependent: :destroy
     has_many :comment_read_pointers, class_name: "Collavre::CommentReadPointer", dependent: :delete_all
+    has_many :comment_snapshots, class_name: "Collavre::CommentSnapshot", dependent: :destroy
 
     has_closure_tree order: :sequence, name_column: :description, hierarchy_table_name: "creative_hierarchies"
 

--- a/engines/collavre/app/services/collavre/comment_snapshot_restore_service.rb
+++ b/engines/collavre/app/services/collavre/comment_snapshot_restore_service.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+module Collavre
+  class CommentSnapshotRestoreService
+    class RestoreError < StandardError; end
+
+    def initialize(snapshot:, user:)
+      @snapshot = snapshot
+      @user = user
+    end
+
+    def call
+      ActiveRecord::Base.transaction do
+        # Lock the snapshot row to prevent concurrent restore (P2 fix)
+        locked_snapshot = CommentSnapshot.lock.find(@snapshot.id)
+
+        if locked_snapshot.restored_at.present?
+          raise RestoreError, I18n.t("collavre.comment_snapshots.already_restored")
+        end
+
+        validate_permission!
+
+        # Build a mapping from old comment IDs to new comments for quoted_comment_id restoration
+        old_id_to_new = {}
+
+        # First pass: recreate all comments without quoted_comment_id
+        recreated = locked_snapshot.comments_data.map do |data|
+          comment = Comment.create!(
+            creative_id: locked_snapshot.creative_id,
+            user_id: data["user_id"],
+            topic_id: data["topic_id"],
+            content: data["content"],
+            private: data["private"] || false,
+            quoted_text: data["quoted_text"],
+            review_type: data["review_type"],
+            skip_default_user: true
+          )
+          # Re-attach images if blob IDs were preserved in the snapshot
+          if data["image_blob_ids"].present?
+            blobs = ActiveStorage::Blob.where(id: data["image_blob_ids"])
+            blobs.each { |blob| comment.images.attach(blob) }
+          end
+          old_id_to_new[data["id"]] = comment
+          comment
+        end
+
+        # Second pass: restore quoted_comment_id for comments that reference other restored comments
+        locked_snapshot.comments_data.each do |data|
+          next unless data["quoted_comment_id"].present?
+
+          new_comment = old_id_to_new[data["id"]]
+          quoted_new = old_id_to_new[data["quoted_comment_id"]]
+          new_comment.update_column(:quoted_comment_id, quoted_new.id) if quoted_new
+        end
+
+        # Delete the result comment (the AI summary/merged comment)
+        # Use nullify + delete to avoid cascading destruction of quoting_comments (P1 fix)
+        if locked_snapshot.result_comment
+          result = locked_snapshot.result_comment
+          # Detach any comments that quote this result so they aren't cascade-deleted
+          result.quoting_comments.update_all(quoted_comment_id: nil) # rubocop:disable Rails/SkipsModelValidations
+          result.destroy
+        end
+
+        # Mark snapshot as restored
+        locked_snapshot.update!(restored_at: Time.current)
+
+        recreated
+      end
+    end
+
+    private
+
+    def validate_permission!
+      creative = @snapshot.creative
+      unless creative.has_permission?(@user, :write)
+        raise RestoreError, I18n.t("collavre.comment_snapshots.not_authorized")
+      end
+    end
+  end
+end

--- a/engines/collavre/app/views/collavre/comments/_comment.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comment.html.erb
@@ -159,6 +159,20 @@
       </details>
     </div>
   <% end %>
+  <% snapshot = comment.snapshot_as_result %>
+  <% if snapshot&.restorable? %>
+    <div class="comment-snapshot-restore">
+      <button class="restore-snapshot-btn"
+              type="button"
+              data-snapshot-id="<%= snapshot.id %>"
+              data-creative-id="<%= comment.creative_id %>"
+              data-action="click->comment#restoreSnapshot"
+              data-confirm-text="<%= t('collavre.comment_snapshots.restore_confirm') %>"
+              title="<%= t('collavre.comment_snapshots.restore_button') %> (<%= snapshot.comment_count %>)">
+        ↩️ <%= t('collavre.comment_snapshots.restore_button') %> (<%= snapshot.comment_count %>)
+      </button>
+    </div>
+  <% end %>
   <% if comment.activity_logs.exists? %>
     <div class="comment-activity-log-block">
       <details>

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -202,6 +202,12 @@ en:
       event:
         invitation: Invitation
         inbox_summary: Inbox summary
+    comment_snapshots:
+      restored: "Original messages have been restored."
+      already_restored: "This snapshot has already been restored."
+      not_authorized: "You don't have permission to restore this snapshot."
+      restore_confirm: "Restore original messages? The summary will be removed."
+      restore_button: "Restore originals"
     inbox_mailer:
       daily_summary:
         subject: Your inbox summary

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -198,6 +198,12 @@ ko:
       event:
         invitation: 초대
         inbox_summary: 인박스 요약
+    comment_snapshots:
+      restored: "원본 메시지가 복구되었습니다."
+      already_restored: "이미 복구된 스냅샷입니다."
+      not_authorized: "이 스냅샷을 복구할 권한이 없습니다."
+      restore_confirm: "원본 메시지를 복구하시겠습니까? 요약이 삭제됩니다."
+      restore_button: "원본 복구"
     inbox_mailer:
       daily_summary:
         subject: 인박스 요약

--- a/engines/collavre/config/routes.rb
+++ b/engines/collavre/config/routes.rb
@@ -86,6 +86,12 @@ Collavre::Engine.routes.draw do
         delete :batch_destroy
         post :merge
         get :commands
+
+        resources :snapshots, only: [ :index ], module: :comments do
+          member do
+            post :restore
+          end
+        end
       end
     end
     collection do

--- a/engines/collavre/db/migrate/20260319132153_create_comment_snapshots.rb
+++ b/engines/collavre/db/migrate/20260319132153_create_comment_snapshots.rb
@@ -1,0 +1,18 @@
+class CreateCommentSnapshots < ActiveRecord::Migration[8.0]
+  def change
+    create_table :comment_snapshots do |t|
+      t.references :creative, null: false, foreign_key: true
+      t.references :topic, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+      t.string :operation, null: false
+      t.json :comments_data, null: false, default: []
+      t.references :result_comment, foreign_key: { to_table: :comments, on_delete: :nullify }
+      t.datetime :restored_at
+
+      t.timestamps
+    end
+
+    add_index :comment_snapshots, [ :creative_id, :operation ]
+    add_index :comment_snapshots, :restored_at
+  end
+end


### PR DESCRIPTION
## Summary

Add ability to restore original messages after compress or merge operations.

### Problem
When users run `/compress` or merge selected messages, the original comments are permanently deleted. If the AI summary/merge result is unsatisfactory, there's no way to recover the original messages.

### Solution
Before deleting original comments, save a snapshot of all comment data to a new `comment_snapshots` table. The result comment (summary/merged) displays a restore button that allows users to recreate the original comments and remove the AI-generated result.

### Changes

**New files:**
- `CommentSnapshot` model + migration — stores original comment data as JSON
- `CommentSnapshotRestoreService` — validates permissions, recreates comments in a transaction
- `Comments::SnapshotsController` — index (list) + restore (undo) API endpoints
- `CommentSerializable` concern — shared serialization logic for jobs
- `comment_snapshots.css` — restore button styles using design tokens

**Modified files:**
- `CompressJob` — creates snapshot before deleting originals (excludes /compress command from snapshot)
- `MergeCommentsJob` — creates snapshot within transaction before modifying/deleting
- `_comment.html.erb` — shows restore button on comments with restorable snapshots
- `comment_controller.js` — `restoreSnapshot` Stimulus action
- `comments_controller.rb` — eager loads `snapshot_as_result` to prevent N+1
- i18n — English and Korean translations

### How it works
1. Compress/merge runs → original comment data saved to `comment_snapshots`
2. Result comment shows "↩️ Restore originals (N)" button
3. Click → confirm → original comments recreated, summary removed (via ActionCable broadcast)
4. Double-restore prevented via `restored_at` timestamp
5. `quoted_comment_id` relationships restored via 2-pass mapping within same snapshot

### Technical notes
- `result_comment_id` FK uses `on_delete: :nullify` for safety
- Controller uses `effective_origin` + permission check (same pattern as CommentsController)
- CSS uses only defined design tokens (no hardcoded fallbacks)