### PR TITLE
fix: align breadcrumb to bottom of creative-actions-row

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/creatives.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/creatives.css
@@ -56,7 +56,7 @@ html.creative-alignment-ready .page-title {
     padding: var(--space-1) 0;
     display: flex;
     justify-content: space-between;
-    align-items: center;
+    align-items: flex-end;
     min-height: 36px;
     border: none;
 }


### PR DESCRIPTION
## Summary

Align the breadcrumb navigation to the bottom edge of the right-side action buttons in `creative-actions-row`.

## Changes

- Changed `align-items` from `center` to `flex-end` on `.creative-actions-row` so the breadcrumb text baseline aligns with the bottom of the taller action buttons on the right.

## Before / After

**Before**: Breadcrumb text centered vertically relative to action buttons  
**After**: Breadcrumb text aligned to the bottom of action buttons for a cleaner visual baseline