### PR TITLE
feat: add remove button to chat navigation history dropdown

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -71,7 +71,7 @@ body.chat-fullscreen {
 .chat-nav-buttons {
     display: inline-flex;
     align-items: center;
-    gap: 2px;
+    gap: var(--space-1);
     flex-shrink: 0;
     position: relative;
 }
@@ -81,16 +81,16 @@ body.chat-fullscreen {
     border: none;
     color: var(--color-text);
     cursor: pointer;
-    padding: 2px;
+    padding: var(--space-1);
     display: inline-flex;
     align-items: center;
     justify-content: center;
     border-radius: var(--radius-1);
-    transition: opacity 0.15s ease, background-color 0.15s ease;
+    transition: opacity 0.15s var(--ease-out-2), background-color 0.15s var(--ease-out-2);
 }
 
 .chat-nav-btn:hover:not(:disabled) {
-    background-color: var(--color-surface-hover, rgba(0, 0, 0, 0.06));
+    background-color: var(--color-surface-hover);
 }
 
 .chat-nav-btn:disabled {
@@ -100,8 +100,8 @@ body.chat-fullscreen {
 }
 
 .chat-nav-icon {
-    width: 16px;
-    height: 16px;
+    width: var(--space-px-4);
+    height: var(--space-px-4);
     stroke: currentColor;
     fill: none;
 }
@@ -115,11 +115,11 @@ body.chat-fullscreen {
     max-width: 300px;
     max-height: 320px;
     overflow-y: auto;
-    background: var(--color-surface, #fff);
-    border: 1px solid var(--color-border, #ddd);
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
     border-radius: var(--radius-2);
     box-shadow: var(--shadow-3);
-    z-index: var(--layer-popover, 1000);
+    z-index: var(--layer-popover);
     padding: var(--space-1) 0;
 }
 
@@ -136,11 +136,11 @@ body.chat-fullscreen {
 }
 
 .chat-nav-dropdown-item:hover {
-    background-color: var(--color-surface-hover, rgba(0, 0, 0, 0.06));
+    background-color: var(--color-surface-hover);
 }
 
 .chat-nav-dropdown-item.current {
-    font-weight: var(--weight-bold, 700);
+    font-weight: var(--weight-7);
 }
 
 .chat-nav-dropdown-label {
@@ -162,13 +162,13 @@ body.chat-fullscreen {
     flex-shrink: 0;
     background: none;
     border: none;
-    color: var(--color-muted, #999);
+    color: var(--color-muted);
     cursor: pointer;
-    font-size: var(--text-2, 1.1em);
+    font-size: var(--text-2);
     padding: var(--space-1) var(--space-2);
     line-height: 1;
     opacity: 0;
-    transition: opacity 0.15s ease, color 0.15s ease;
+    transition: opacity 0.15s var(--ease-out-2), color 0.15s var(--ease-out-2);
 }
 
 .chat-nav-dropdown-item:hover .chat-nav-dropdown-remove {
@@ -176,7 +176,7 @@ body.chat-fullscreen {
 }
 
 .chat-nav-dropdown-remove:hover {
-    color: var(--color-danger, #e53e3e);
+    color: var(--color-danger);
 }
 
 .comments-popup-actions {

--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -171,7 +171,7 @@ body.chat-fullscreen {
 }
 
 .chat-nav-dropdown-remove:hover {
-    color: var(--color-danger);
+    color: var(--color-text);
 }
 
 .comments-popup-actions {

--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -52,7 +52,7 @@ body.chat-fullscreen {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    gap: 0.75em;
+    gap: var(--space-1);
     padding-bottom: var(--space-1);
 }
 

--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -124,18 +124,14 @@ body.chat-fullscreen {
 }
 
 .chat-nav-dropdown-item {
-    display: block;
+    display: flex;
+    align-items: center;
     width: 100%;
-    padding: var(--space-1) var(--space-3);
+    padding: 0;
     background: none;
     border: none;
-    text-align: left;
-    cursor: pointer;
     font-size: var(--text-1);
     color: var(--color-text);
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
     line-height: 1.4;
 }
 
@@ -145,6 +141,42 @@ body.chat-fullscreen {
 
 .chat-nav-dropdown-item.current {
     font-weight: var(--weight-bold, 700);
+}
+
+.chat-nav-dropdown-label {
+    flex: 1;
+    min-width: 0;
+    padding: var(--space-1) var(--space-3);
+    background: none;
+    border: none;
+    text-align: left;
+    cursor: pointer;
+    font: inherit;
+    color: inherit;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.chat-nav-dropdown-remove {
+    flex-shrink: 0;
+    background: none;
+    border: none;
+    color: var(--color-muted, #999);
+    cursor: pointer;
+    font-size: var(--text-2, 1.1em);
+    padding: var(--space-1) var(--space-2);
+    line-height: 1;
+    opacity: 0;
+    transition: opacity 0.15s ease, color 0.15s ease;
+}
+
+.chat-nav-dropdown-item:hover .chat-nav-dropdown-remove {
+    opacity: 1;
+}
+
+.chat-nav-dropdown-remove:hover {
+    color: var(--color-danger, #e53e3e);
 }
 
 .comments-popup-actions {

--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -90,7 +90,7 @@ body.chat-fullscreen {
 }
 
 .chat-nav-btn:hover:not(:disabled) {
-    background-color: var(--color-surface-hover);
+    background-color: var(--surface-hover);
 }
 
 .chat-nav-btn:disabled {
@@ -115,8 +115,8 @@ body.chat-fullscreen {
     max-width: 300px;
     max-height: 320px;
     overflow-y: auto;
-    background: var(--color-surface);
-    border: 1px solid var(--color-border);
+    background: var(--surface-section);
+    border: 1px solid var(--border-color);
     border-radius: var(--radius-2);
     box-shadow: var(--shadow-3);
     z-index: var(--layer-popover);
@@ -136,7 +136,7 @@ body.chat-fullscreen {
 }
 
 .chat-nav-dropdown-item:hover {
-    background-color: var(--color-surface-hover);
+    background-color: var(--surface-hover);
 }
 
 .chat-nav-dropdown-item.current {

--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -119,7 +119,7 @@ body.chat-fullscreen {
     border: 1px solid var(--border-color);
     border-radius: var(--radius-2);
     box-shadow: var(--shadow-3);
-    z-index: var(--layer-popover);
+    z-index: var(--layer-modal);
     padding: var(--space-1) 0;
 }
 

--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -167,12 +167,7 @@ body.chat-fullscreen {
     font-size: var(--text-2);
     padding: var(--space-1) var(--space-2);
     line-height: 1;
-    opacity: 0;
-    transition: opacity 0.15s var(--ease-out-2), color 0.15s var(--ease-out-2);
-}
-
-.chat-nav-dropdown-item:hover .chat-nav-dropdown-remove {
-    opacity: 1;
+    transition: color 0.15s var(--ease-out-2);
 }
 
 .chat-nav-dropdown-remove:hover {

--- a/engines/collavre/app/javascript/controllers/comments/list_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/list_controller.js
@@ -336,7 +336,7 @@ export default class extends Controller {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({ creative_id: this.creativeId }),
-      })
+      }).catch(() => { /* ignore — creative may have been deleted */ })
     }, 2000);
   }
 

--- a/engines/collavre/app/javascript/controllers/comments/popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_controller.js
@@ -1082,8 +1082,8 @@ export default class extends Controller {
 
   showRecentChats(event) {
     event.preventDefault()
-    const list = chatHistory.recentList()
-    if (list.length <= 1) return
+    const list = chatHistory.recentList().filter(entry => !entry.isCurrent)
+    if (list.length === 0) return
 
     if (!this.hasNavDropdownTarget) return
     const dropdown = this.navDropdownTarget
@@ -1092,7 +1092,6 @@ export default class extends Controller {
     list.forEach((entry, index) => {
       const item = document.createElement('div')
       item.className = 'chat-nav-dropdown-item'
-      if (entry.isCurrent) item.classList.add('current')
 
       const label = document.createElement('button')
       label.type = 'button'
@@ -1100,31 +1099,29 @@ export default class extends Controller {
       label.textContent = entry.snippet || `Creative #${entry.creativeId}`
       label.addEventListener('click', () => {
         this._hideNavDropdown()
-        const target = chatHistory.goTo(index)
+        const target = chatHistory.goTo(entry.index)
         if (target) this._navigateToEntry(target)
       })
       item.appendChild(label)
 
-      // Remove button (not for current chat)
-      if (!entry.isCurrent) {
-        const removeBtn = document.createElement('button')
-        removeBtn.type = 'button'
-        removeBtn.className = 'chat-nav-dropdown-remove'
-        removeBtn.innerHTML = '&times;'
-        removeBtn.title = this._i18n('remove_from_history')
-        removeBtn.addEventListener('click', (e) => {
-          e.stopPropagation()
-          chatHistory.remove(entry.creativeId)
-          this._updateNavButtons()
-          // Re-render dropdown if still enough items
-          if (chatHistory.recentList().length > 1) {
-            this.showRecentChats(new Event('contextmenu', { bubbles: true }))
-          } else {
-            this._hideNavDropdown()
-          }
-        })
-        item.appendChild(removeBtn)
-      }
+      const removeBtn = document.createElement('button')
+      removeBtn.type = 'button'
+      removeBtn.className = 'chat-nav-dropdown-remove'
+      removeBtn.innerHTML = '&times;'
+      removeBtn.title = this._i18n('remove_from_history')
+      removeBtn.addEventListener('click', (e) => {
+        e.stopPropagation()
+        chatHistory.remove(entry.creativeId)
+        this._updateNavButtons()
+        // Re-render dropdown if still enough items
+        const remaining = chatHistory.recentList().filter(e => !e.isCurrent)
+        if (remaining.length > 0) {
+          this.showRecentChats(new Event('contextmenu', { bubbles: true }))
+        } else {
+          this._hideNavDropdown()
+        }
+      })
+      item.appendChild(removeBtn)
 
       dropdown.appendChild(item)
     })

--- a/engines/collavre/app/javascript/controllers/comments/popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_controller.js
@@ -1085,16 +1085,42 @@ export default class extends Controller {
     dropdown.innerHTML = ''
 
     list.forEach((entry, index) => {
-      const item = document.createElement('button')
-      item.type = 'button'
+      const item = document.createElement('div')
       item.className = 'chat-nav-dropdown-item'
       if (entry.isCurrent) item.classList.add('current')
-      item.textContent = entry.snippet || `Creative #${entry.creativeId}`
-      item.addEventListener('click', () => {
+
+      const label = document.createElement('button')
+      label.type = 'button'
+      label.className = 'chat-nav-dropdown-label'
+      label.textContent = entry.snippet || `Creative #${entry.creativeId}`
+      label.addEventListener('click', () => {
         this._hideNavDropdown()
         const target = chatHistory.goTo(index)
         if (target) this._navigateToEntry(target)
       })
+      item.appendChild(label)
+
+      // Remove button (not for current chat)
+      if (!entry.isCurrent) {
+        const removeBtn = document.createElement('button')
+        removeBtn.type = 'button'
+        removeBtn.className = 'chat-nav-dropdown-remove'
+        removeBtn.innerHTML = '&times;'
+        removeBtn.title = this._i18n('remove_from_history')
+        removeBtn.addEventListener('click', (e) => {
+          e.stopPropagation()
+          chatHistory.remove(entry.creativeId)
+          this._updateNavButtons()
+          // Re-render dropdown if still enough items
+          if (chatHistory.recentList().length > 1) {
+            this.showRecentChats(new Event('contextmenu', { bubbles: true }))
+          } else {
+            this._hideNavDropdown()
+          }
+        })
+        item.appendChild(removeBtn)
+      }
+
       dropdown.appendChild(item)
     })
 
@@ -1231,6 +1257,13 @@ export default class extends Controller {
       // Swipe right → previous chat
       this.navigateBack()
     }
+  }
+
+  _i18n(key) {
+    const translations = {
+      remove_from_history: this.element.dataset.removeFromHistoryLabel || 'Remove from history'
+    }
+    return translations[key] || key
   }
 
   _hideNavDropdown() {

--- a/engines/collavre/app/javascript/controllers/comments/popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_controller.js
@@ -18,7 +18,7 @@ export default class extends Controller {
     'fullscreenIcon',
     'exitFullscreenIcon',
     'navBack',
-    'navForward',
+
     'navContainer',
     'navDropdown',
     'header',
@@ -1150,9 +1150,6 @@ export default class extends Controller {
     if (event.altKey && event.key === 'ArrowLeft') {
       event.preventDefault()
       this.navigateBack()
-    } else if (event.altKey && event.key === 'ArrowRight') {
-      event.preventDefault()
-      this.navigateForward()
     }
   }
 
@@ -1192,9 +1189,7 @@ export default class extends Controller {
     if (this.hasNavBackTarget) {
       this.navBackTarget.disabled = !chatHistory.canNavigate()
     }
-    if (this.hasNavForwardTarget) {
-      this.navForwardTarget.disabled = !chatHistory.canNavigate()
-    }
+
   }
 
   _setupNavLongPress() {
@@ -1219,7 +1214,6 @@ export default class extends Controller {
       btn.addEventListener('touchcancel', () => this._clearLongPressTimer())
     }
     if (this.hasNavBackTarget) setupBtn(this.navBackTarget)
-    if (this.hasNavForwardTarget) setupBtn(this.navForwardTarget)
   }
 
   _clearLongPressTimer() {

--- a/engines/collavre/app/javascript/controllers/comments/popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_controller.js
@@ -186,6 +186,11 @@ export default class extends Controller {
 
   handleCreativeDestroyed(event) {
     const destroyedIds = event.detail?.creativeIds || []
+
+    // Remove destroyed creatives from navigation history
+    destroyedIds.forEach(id => chatHistory.remove(id))
+    this._updateNavButtons()
+
     if (this.element.style.display !== 'flex') return
     if (destroyedIds.includes(this.element.dataset.creativeId)) {
       this.close()

--- a/engines/collavre/app/javascript/controllers/comments/popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_controller.js
@@ -1071,13 +1071,13 @@ export default class extends Controller {
   navigateBack() {
     const entry = chatHistory.prev()
     if (!entry) return
-    this._navigateToEntry(entry)
+    this._navigateToEntry(entry, 'back')
   }
 
   navigateForward() {
     const entry = chatHistory.next()
     if (!entry) return
-    this._navigateToEntry(entry)
+    this._navigateToEntry(entry, 'forward')
   }
 
   showRecentChats(event) {
@@ -1159,7 +1159,7 @@ export default class extends Controller {
     }
   }
 
-  async _navigateToEntry(entry) {
+  async _navigateToEntry(entry, direction = 'forward') {
     this._isNavigating = true
     try {
       // Try to find the button for this creative in the tree
@@ -1174,6 +1174,17 @@ export default class extends Controller {
         this.element.dataset.canComment = entry.canComment ? 'true' : 'false'
         this.element.dataset.creativeSnippet = entry.snippet || ''
         await this.openForCreative()
+      }
+    } catch (error) {
+      // Creative likely deleted (404) — remove from history and skip to next
+      console.warn(`[chat-nav] Failed to open creative ${entry.creativeId}, removing from history:`, error)
+      chatHistory.remove(entry.creativeId)
+      this._updateNavButtons()
+
+      if (chatHistory.canNavigate()) {
+        this._isNavigating = false
+        const next = direction === 'back' ? chatHistory.prev() : chatHistory.next()
+        if (next) return this._navigateToEntry(next, direction)
       }
     } finally {
       this._isNavigating = false

--- a/engines/collavre/app/javascript/controllers/comments/popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_controller.js
@@ -18,7 +18,6 @@ export default class extends Controller {
     'fullscreenIcon',
     'exitFullscreenIcon',
     'navBack',
-
     'navContainer',
     'navDropdown',
     'header',
@@ -1189,7 +1188,6 @@ export default class extends Controller {
     if (this.hasNavBackTarget) {
       this.navBackTarget.disabled = !chatHistory.canNavigate()
     }
-
   }
 
   _setupNavLongPress() {

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -63,6 +63,9 @@ export default class extends Controller {
 
         try {
             const response = await fetch(`/creatives/${this.creativeId}/topics`)
+            if (response.status === 404) {
+                throw new Error(`Creative ${this.creativeId} not found`)
+            }
             if (response.ok) {
                 const data = await response.json()
                 const topics = Array.isArray(data) ? data : data.topics

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -85,6 +85,7 @@ export default class extends Controller {
             }
         } catch (e) {
             console.error("Failed to load topics", e)
+            throw e
         }
     }
 

--- a/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
@@ -67,7 +67,6 @@
               aria-label="<%= t('collavre.comments.navigate_back', default: 'Previous chat') %>">
         <%= svg_tag "chevron-left.svg", class: "chat-nav-icon" %>
       </button>
-
       <div class="chat-nav-dropdown" data-comments--popup-target="navDropdown" style="display:none;"></div>
     </div>
     <h3 id="comments-popup-title" data-comments--popup-target="title"><%= fullscreen && creative.present? ? creative.creative_snippet : t('collavre.comments.comments') %></h3>

--- a/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
@@ -55,7 +55,8 @@
      data-review-type-review="💬"
      data-review-type-question="❓"
      data-review-type-review-label="<%= t('collavre.comments.review_type_review') %>"
-     data-review-type-question-label="<%= t('collavre.comments.review_type_question') %>">
+     data-review-type-question-label="<%= t('collavre.comments.review_type_question') %>"
+     data-remove-from-history-label="<%= t('collavre.comments.remove_from_history') %>">
   <div class="resize-handle resize-handle-left" data-comments--popup-target="leftHandle"></div>
   <div class="resize-handle resize-handle-right" data-comments--popup-target="rightHandle"></div>
   <div class="comments-popup-header" data-comments--popup-target="header">

--- a/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
@@ -67,12 +67,7 @@
               aria-label="<%= t('collavre.comments.navigate_back', default: 'Previous chat') %>">
         <%= svg_tag "chevron-left.svg", class: "chat-nav-icon" %>
       </button>
-      <button class="chat-nav-btn" type="button" disabled
-              data-comments--popup-target="navForward"
-              data-action="click->comments--popup#navigateForward contextmenu->comments--popup#showRecentChats"
-              aria-label="<%= t('collavre.comments.navigate_forward', default: 'Next chat') %>">
-        <%= svg_tag "chevron-right.svg", class: "chat-nav-icon" %>
-      </button>
+
       <div class="chat-nav-dropdown" data-comments--popup-target="navDropdown" style="display:none;"></div>
     </div>
     <h3 id="comments-popup-title" data-comments--popup-target="title"><%= fullscreen && creative.present? ? creative.creative_snippet : t('collavre.comments.comments') %></h3>

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -87,6 +87,7 @@ en:
       navigate_back: Previous chat
       navigate_forward: Next chat
       recent_chats: Recent chats
+      remove_from_history: Remove from history
       replace_button: Replace
       move_no_selection: Select at least one message to move.
       move_error: Unable to move messages.

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -84,6 +84,7 @@ ko:
       navigate_back: 이전 채팅
       navigate_forward: 다음 채팅
       recent_chats: 최근 채팅
+      remove_from_history: 히스토리에서 제거
       replace_button: 바꾸기
       move_no_selection: 이동할 메시지를 선택해주세요.
       move_error: 메시지를 이동할 수 없습니다.


### PR DESCRIPTION
## Summary
Add ability for users to remove individual chats from the navigation history dropdown.

## Changes
- Each non-current item in the recent chats dropdown shows an × remove button on hover
- Clicking × removes that chat from the circular navigation history
- Dropdown re-renders after removal; auto-hides if fewer than 2 items remain
- CSS: remove button appears only on hover, turns red on hover for clear affordance

## i18n
- `remove_from_history`: en (Remove from history) / ko (히스토리에서 제거)

## Related
- Follows up on PR #1047 (chat navigation feature)