### PR TITLE
fix: allow Alt+← chat navigation shortcut when textarea is focused

### DIFF
--- a/engines/collavre/app/javascript/controllers/comments/popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_controller.js
@@ -1142,10 +1142,6 @@ export default class extends Controller {
   handleChatNavKeydown(event) {
     // Only when popup is visible
     if (this.element.style.display !== 'flex') return
-    // Skip when typing in textarea/input
-    const tag = event.target.tagName
-    if (tag === 'TEXTAREA' || tag === 'INPUT' || event.target.isContentEditable) return
-
     if (event.altKey && event.key === 'ArrowLeft') {
       event.preventDefault()
       this.navigateBack()


### PR DESCRIPTION
## Changes

Remove the textarea/input focus guard from `handleChatNavKeydown` so that `Alt+←` works even when the chat input form is focused.

`Alt+←` does not conflict with textarea cursor movement (plain `←` handles that), so the guard was unnecessarily blocking navigation.

### Before
- `Alt+←` only worked when focus was outside textarea/input

### After  
- `Alt+←` works from any focus state within the chat popup