### PR TITLE
fix: require write permission for creative update

### DIFF
--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -144,7 +144,8 @@ module Collavre
               depth: depth,
               prompt: @creative.prompt_for(Current.user),
               has_children: children_count > 0,
-              data: @creative.effective_origin(Set.new).data
+              data: @creative.effective_origin(Set.new).data,
+              can_edit: @creative.has_permission?(Current.user, :write)
             }
           end
         end
@@ -190,6 +191,9 @@ module Collavre
     end
 
     def edit
+      unless @creative.has_permission?(Current.user, :write)
+        redirect_to @creative, alert: t("collavre.creatives.errors.no_permission") and return
+      end
       if params[:inline]
         render partial: "inline_edit_form"
       end
@@ -207,6 +211,14 @@ module Collavre
         if @creative.origin_id.present? && permitted.key?("parent_id")
           parent_id = permitted.delete("parent_id")
           success &&= @creative.update(parent_id: parent_id)
+        end
+
+        # Require write permission for origin content changes (description, progress, sequence)
+        origin_changes = permitted.except("parent_id")
+        if origin_changes.any? && !@creative.has_permission?(Current.user, :write)
+          format.html { redirect_to @creative, alert: t("collavre.creatives.errors.no_permission") }
+          format.json { render json: { error: t("collavre.creatives.errors.no_permission") }, status: :forbidden }
+          next
         end
 
         # When updating the base (Origin), we must NOT pass origin_id.

--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -207,18 +207,18 @@ module Collavre
         previous_progress = base.progress
         requested_progress = permitted["progress"] || permitted[:progress]
 
-        # Handle parent_id change separately for Linked Creatives
-        if @creative.origin_id.present? && permitted.key?("parent_id")
-          parent_id = permitted.delete("parent_id")
-          success &&= @creative.update(parent_id: parent_id)
-        end
-
         # Require write permission for origin content changes (description, progress, sequence)
         origin_changes = permitted.except("parent_id")
         if origin_changes.any? && !@creative.has_permission?(Current.user, :write)
           format.html { redirect_to @creative, alert: t("collavre.creatives.errors.no_permission") }
           format.json { render json: { error: t("collavre.creatives.errors.no_permission") }, status: :forbidden }
           next
+        end
+
+        # Handle parent_id change separately for Linked Creatives
+        if @creative.origin_id.present? && permitted.key?("parent_id")
+          parent_id = permitted.delete("parent_id")
+          success &&= @creative.update(parent_id: parent_id)
         end
 
         # When updating the base (Origin), we must NOT pass origin_id.

--- a/engines/collavre/test/integration/creative_update_permission_test.rb
+++ b/engines/collavre/test/integration/creative_update_permission_test.rb
@@ -1,0 +1,56 @@
+require "test_helper"
+
+class CreativeUpdatePermissionTest < ActionDispatch::IntegrationTest
+  setup do
+    @owner = User.create!(email: "owner-update@example.com", password: TEST_PASSWORD, name: "Owner")
+    @feedback_user = User.create!(email: "feedback-update@example.com", password: TEST_PASSWORD, name: "Feedback User")
+    @write_user = User.create!(email: "write-update@example.com", password: TEST_PASSWORD, name: "Write User")
+    @read_user = User.create!(email: "read-update@example.com", password: TEST_PASSWORD, name: "Read User")
+
+    @creative = Creative.create!(user: @owner, description: "Original Description", sequence: 0)
+
+    CreativeShare.create!(creative: @creative, user: @feedback_user, permission: :feedback)
+    CreativeShare.create!(creative: @creative, user: @write_user, permission: :write)
+    CreativeShare.create!(creative: @creative, user: @read_user, permission: :read)
+  end
+
+  test "owner can update creative" do
+    sign_in_as(@owner)
+    patch creative_path(@creative), params: { creative: { description: "Updated by owner" } }, as: :json
+
+    assert_response :success
+    assert_equal "Updated by owner", @creative.reload.description
+  end
+
+  test "write permission user can update creative" do
+    sign_in_as(@write_user)
+    patch creative_path(@creative), params: { creative: { description: "Updated by writer" } }, as: :json
+
+    assert_response :success
+    assert_equal "Updated by writer", @creative.reload.description
+  end
+
+  test "feedback permission user cannot update creative" do
+    sign_in_as(@feedback_user)
+    patch creative_path(@creative), params: { creative: { description: "Updated by feedback" } }, as: :json
+
+    assert_response :forbidden
+    assert_equal "Original Description", @creative.reload.description
+  end
+
+  test "read permission user cannot update creative" do
+    sign_in_as(@read_user)
+    patch creative_path(@creative), params: { creative: { description: "Updated by reader" } }, as: :json
+
+    assert_response :forbidden
+    assert_equal "Original Description", @creative.reload.description
+  end
+
+  test "feedback permission user cannot update progress" do
+    sign_in_as(@feedback_user)
+    patch creative_path(@creative), params: { creative: { progress: 0.5 } }, as: :json
+
+    assert_response :forbidden
+    assert_equal 0.0, @creative.reload.progress.to_f
+  end
+end


### PR DESCRIPTION
## Problem

`CreativesController#update` had no permission check, allowing users with feedback or read permission to modify creative content (description, progress, sequence). This was a security bug.

## Changes

- **`CreativesController#update`**: Add write permission check for origin content changes (description, progress, sequence). Returns 403 Forbidden for JSON requests and redirects with alert for HTML requests.
- **`CreativesController#edit`**: Add write permission check (redirects with alert if insufficient permission).
- **Show JSON response**: Add `can_edit` flag so the frontend can conditionally render edit UI.
- **Linked Creative parent_id change**: Remains allowed without write permission on origin, since it only affects the linked creative's tree structure.

## Tests

Added `creative_update_permission_test.rb` with 5 integration tests:
- Owner can update ✅
- Write permission user can update ✅
- Feedback permission user cannot update (403) ✅
- Read permission user cannot update (403) ✅
- Feedback permission user cannot update progress (403) ✅

All 66 integration tests pass. Existing `LinkedCreativeParentTest` continues to pass.