### PR TITLE
feat: add Alt+→ keyboard shortcut for forward chat navigation

### DIFF
--- a/engines/collavre/app/javascript/controllers/comments/popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_controller.js
@@ -1145,6 +1145,9 @@ export default class extends Controller {
     if (event.altKey && event.key === 'ArrowLeft') {
       event.preventDefault()
       this.navigateBack()
+    } else if (event.altKey && event.key === 'ArrowRight') {
+      event.preventDefault()
+      this.navigateForward()
     }
   }
 


### PR DESCRIPTION
## Changes

Add `Alt+→` keyboard shortcut for forward navigation in chat popup.

### Navigation methods summary
| Method | Back (prev) | Forward (next) |
|--------|------------|----------------|
| Button | ← button | — (removed) |
| Keyboard | `Alt+←` | `Alt+→` ✨ |
| Swipe | Right swipe | Left swipe |
| Dropdown | Long press ← | Long press ← |

Both shortcuts work regardless of textarea/input focus state.