### PR TITLE
fix: auto-resize textarea height when editing a chat message

### DIFF
--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -163,7 +163,7 @@ export default class extends Controller {
     this.clearImageAttachments()
     this.submitTarget.textContent = this.element.dataset.updateCommentText
     if (this.cancelTarget) this.cancelTarget.style.display = ''
-    this._autoResize()
+    requestAnimationFrame(() => this._autoResize())
     this.focusTextarea()
   }
 

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -163,6 +163,7 @@ export default class extends Controller {
     this.clearImageAttachments()
     this.submitTarget.textContent = this.element.dataset.updateCommentText
     if (this.cancelTarget) this.cancelTarget.style.display = ''
+    this._autoResize()
     this.focusTextarea()
   }
 


### PR DESCRIPTION
## Problem
When clicking "Edit" on a chat message, the textarea was stuck at its default single-line height regardless of content length.

## Root Cause
`startEditing()` sets `textarea.value` programmatically, but the `_autoResize()` handler only triggers on the `input` event — which is not fired by programmatic value assignment.

## Fix
Call `_autoResize()` explicitly in `startEditing()` after setting the textarea value, so the height adjusts to fit the existing content.

## Changes
- `engines/collavre/app/javascript/controllers/comments/form_controller.js`: Added `this._autoResize()` call in `startEditing()`