### PR TITLE
fix: prevent click navigation when long-press dropdown is triggered

### DIFF
--- a/engines/collavre/app/javascript/controllers/comments/popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_controller.js
@@ -1069,6 +1069,10 @@ export default class extends Controller {
   // ── Chat Navigation ───────────────────────────────────────────────
 
   navigateBack() {
+    if (this._longPressTriggered) {
+      this._longPressTriggered = false
+      return
+    }
     const entry = chatHistory.prev()
     if (!entry) return
     this._navigateToEntry(entry, 'back')
@@ -1203,13 +1207,6 @@ export default class extends Controller {
       })
       btn.addEventListener('mouseup', () => this._clearLongPressTimer())
       btn.addEventListener('mouseleave', () => this._clearLongPressTimer())
-      btn.addEventListener('click', (e) => {
-        if (this._longPressTriggered) {
-          e.preventDefault()
-          e.stopImmediatePropagation()
-          this._longPressTriggered = false
-        }
-      })
       // Touch long press
       btn.addEventListener('touchstart', () => {
         this._longPressTriggered = false

--- a/engines/collavre/app/javascript/controllers/comments/popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_controller.js
@@ -47,6 +47,7 @@ export default class extends Controller {
     this.handleChatNavKeydown = this.handleChatNavKeydown.bind(this)
     this.handleDropdownOutsideClick = this.handleDropdownOutsideClick.bind(this)
     this._longPressTimer = null
+    this._longPressTriggered = false
     this._isNavigating = false
     this._headerSwipeStartX = null
     this._headerSwipeStartY = null
@@ -1193,17 +1194,28 @@ export default class extends Controller {
     const setupBtn = (btn) => {
       if (!btn) return
       btn.addEventListener('mousedown', () => {
+        this._longPressTriggered = false
         this._clearLongPressTimer()
         this._longPressTimer = setTimeout(() => {
+          this._longPressTriggered = true
           this.showRecentChats(new MouseEvent('contextmenu', { bubbles: true }))
         }, LONG_PRESS_MS)
       })
       btn.addEventListener('mouseup', () => this._clearLongPressTimer())
       btn.addEventListener('mouseleave', () => this._clearLongPressTimer())
+      btn.addEventListener('click', (e) => {
+        if (this._longPressTriggered) {
+          e.preventDefault()
+          e.stopImmediatePropagation()
+          this._longPressTriggered = false
+        }
+      })
       // Touch long press
       btn.addEventListener('touchstart', () => {
+        this._longPressTriggered = false
         this._clearLongPressTimer()
         this._longPressTimer = setTimeout(() => {
+          this._longPressTriggered = true
           this.showRecentChats(new Event('contextmenu', { bubbles: true }))
         }, LONG_PRESS_MS)
       }, { passive: true })

--- a/engines/collavre/app/javascript/lib/chat_history.js
+++ b/engines/collavre/app/javascript/lib/chat_history.js
@@ -24,8 +24,12 @@ class ChatNavigationHistory {
   push(entry) {
     if (!entry?.creativeId) return
 
+    // Normalize creativeId to string (dataset values are always strings,
+    // but callers may pass numbers — avoid duplicates from type mismatch)
+    const creativeId = String(entry.creativeId)
+
     const existingIdx = this.entries.findIndex(
-      (e) => e.creativeId === entry.creativeId
+      (e) => String(e.creativeId) === creativeId
     )
 
     if (existingIdx !== -1) {
@@ -39,7 +43,7 @@ class ChatNavigationHistory {
 
     // New entry — insert after currentIndex and point to it
     const newEntry = {
-      creativeId: entry.creativeId,
+      creativeId: creativeId,
       snippet: entry.snippet || '',
       canComment: !!entry.canComment,
     }
@@ -118,7 +122,7 @@ class ChatNavigationHistory {
 
   /** Remove an entry by creativeId (e.g., when creative is deleted). */
   remove(creativeId) {
-    const idx = this.entries.findIndex((e) => e.creativeId === creativeId)
+    const idx = this.entries.findIndex((e) => String(e.creativeId) === String(creativeId))
     if (idx === -1) return
 
     this.entries.splice(idx, 1)


### PR DESCRIPTION
## Problem

On PC, long-pressing the ← navigation button would:
1. Show the recent chats dropdown (correct) ✅
2. **Also navigate to the previous chat** (incorrect) ❌

The `click` event fires after `mouseup`, so both the long-press dropdown and the click action were triggered.

## Solution

Add a `_longPressTriggered` flag:
- Set to `true` when the long-press timer fires and dropdown opens
- Check on `click` event — if flagged, suppress the click with `preventDefault()` + `stopImmediatePropagation()`
- Reset on each `mousedown`/`touchstart`