### PR TITLE
feat: show default avatar with initial for topic agents

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -1226,12 +1226,23 @@ body.chat-fullscreen {
     box-sizing: border-box;
 }
 
+.topic-agent-avatar-wrapper {
+    position: relative;
+    display: inline-flex;
+    flex-shrink: 0;
+    vertical-align: middle;
+}
+
 .topic-agent-avatar {
     width: 16px;
     height: 16px;
     border-radius: 50%;
     object-fit: cover;
     flex-shrink: 0;
+}
+
+.topic-agent-avatar-wrapper .avatar-initial {
+    font-size: 8px;
 }
 
 .ai-agent-draggable {

--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -1242,7 +1242,7 @@ body.chat-fullscreen {
 }
 
 .topic-agent-avatar-wrapper .avatar-initial {
-    font-size: 8px;
+    font-size: var(--text-00);
 }
 
 .ai-agent-draggable {

--- a/engines/collavre/app/controllers/collavre/topics_controller.rb
+++ b/engines/collavre/app/controllers/collavre/topics_controller.rb
@@ -286,7 +286,9 @@ module Collavre
       {
         id: agent.id,
         name: agent.display_name,
-        avatar_url: view_context.user_avatar_url(agent, size: 20)
+        avatar_url: view_context.user_avatar_url(agent, size: 20),
+        default_avatar: !agent.avatar.attached? && agent.avatar_url.blank?,
+        initial: agent.display_name[0].upcase
       }
     end
   end

--- a/engines/collavre/app/controllers/collavre/topics_controller.rb
+++ b/engines/collavre/app/controllers/collavre/topics_controller.rb
@@ -288,7 +288,7 @@ module Collavre
         name: agent.display_name,
         avatar_url: view_context.user_avatar_url(agent, size: 20),
         default_avatar: !agent.avatar.attached? && agent.avatar_url.blank?,
-        initial: agent.display_name[0].upcase
+        initial: agent.display_name&.at(0)&.upcase || "?"
       }
     end
   end

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -943,7 +943,7 @@ export default class extends Controller {
         let html = `<span class="avatar-wrapper topic-agent-avatar-wrapper" style="width:${size}px;height:${size}px;" title="${this.escapeAttr(agent.name)}">`
         html += `<img src="${this.escapeAttr(agent.avatar_url)}" alt="" width="${size}" height="${size}" class="topic-agent-avatar" style="border-radius:50%;vertical-align:middle;">`
         if (agent.default_avatar) {
-            html += `<span class="avatar-initial" style="font-size:${Math.round(size / 2)}px;">${this.escapeAttr(agent.initial)}</span>`
+            html += `<span class="avatar-initial">${this.escapeAttr(agent.initial)}</span>`
         }
         html += `</span>`
         return html

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -123,8 +123,8 @@ export default class extends Controller {
             // Ensure comparison handles string/number difference
             const isActive = String(this.currentTopicId) === String(topic.id) ? 'active' : ''
             const draggable = canManage ? 'draggable="true"' : ''
-            const agentAvatar = topic.primary_agent?.avatar_url
-                ? `<img src="${this.escapeAttr(topic.primary_agent.avatar_url)}" class="topic-agent-avatar" alt="${this.escapeAttr(topic.primary_agent.name)}" title="${this.escapeAttr(topic.primary_agent.name)}">`
+            const agentAvatar = topic.primary_agent
+                ? this.renderAgentAvatar(topic.primary_agent)
                 : ''
             html += `<span class="topic-tag topic-drop-target ${isActive}" ${draggable}
                           data-action="click->comments--topics#select ${dropActions} ${dragActions} ${topicDropActions}" 
@@ -936,6 +936,17 @@ export default class extends Controller {
         } catch (e) {
             console.error('Error creating topic with agent', e)
         }
+    }
+
+    renderAgentAvatar(agent) {
+        const size = 16
+        let html = `<span class="avatar-wrapper topic-agent-avatar-wrapper" style="width:${size}px;height:${size}px;" title="${this.escapeAttr(agent.name)}">`
+        html += `<img src="${this.escapeAttr(agent.avatar_url)}" alt="" width="${size}" height="${size}" class="topic-agent-avatar" style="border-radius:50%;vertical-align:middle;">`
+        if (agent.default_avatar) {
+            html += `<span class="avatar-initial" style="font-size:${Math.round(size / 2)}px;">${this.escapeAttr(agent.initial)}</span>`
+        }
+        html += `</span>`
+        return html
     }
 
     escapeAttr(str) {


### PR DESCRIPTION
## Summary

When a topic has a primary agent assigned but the agent has no custom avatar, show the default avatar with initial letter — matching the avatar-wrapper pattern used in participant list and profile.

## Changes

### Backend (`topics_controller.rb`)
- `agent_json` now includes `default_avatar` and `initial` fields (same pattern as `comments_controller#participants`)

### Frontend (`topics_controller.js`)
- New `renderAgentAvatar()` method creates `avatar-wrapper` with:
  - Agent avatar image (always rendered)
  - Initial letter overlay when `default_avatar` is true
- Consistent with `presence_controller` participant rendering

### CSS (`comments_popup.css`)
- `.topic-agent-avatar-wrapper` for inline-flex layout in topic tags
- Initial font-size override for 16px topic avatars

## Result
- Agent with custom avatar → shows avatar (no change)
- Agent without avatar → shows default avatar with initial letter (was previously blank)
- Matches profile/participant avatar rendering exactly