### PR TITLE
feat: add syntax highlighting to chat code blocks

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/code_highlight.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/code_highlight.css
@@ -1,0 +1,333 @@
+/*
+ * Code Syntax Highlighting Theme
+ *
+ * Uses Collavre design tokens (--color-code-bg, --color-code-text, --font-mono).
+ * Light/dark mode is handled automatically via design_tokens.css overrides.
+ *
+ * Based on GitHub-style highlighting with token-based theming.
+ */
+
+/* ============================================================================
+ * CODE BLOCK CONTAINER
+ * ============================================================================ */
+.comment-content pre {
+  background: var(--color-code-bg);
+  color: var(--color-code-text);
+  border: var(--border-1) solid var(--border-color);
+  border-radius: var(--radius-2);
+  padding: var(--space-2) var(--space-3);
+  margin: var(--space-2) 0;
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: var(--text-0);
+  line-height: var(--leading-3);
+}
+
+.comment-content pre code {
+  background: none;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  font-size: inherit;
+  color: inherit;
+}
+
+/* Inline code */
+.comment-content code {
+  background: var(--color-code-bg);
+  color: var(--color-code-text);
+  border-radius: var(--radius-1);
+  padding: 0.15em 0.35em;
+  font-family: var(--font-mono);
+  font-size: 0.9em;
+}
+
+/* Don't double-style code inside pre */
+.comment-content pre code {
+  background: none;
+  padding: 0;
+  border-radius: 0;
+}
+
+/* ============================================================================
+ * LIGHT MODE SYNTAX COLORS
+ * ============================================================================ */
+.comment-content .hljs-comment,
+.comment-content .hljs-quote {
+  color: #6a737d;
+  font-style: italic;
+}
+
+.comment-content .hljs-keyword,
+.comment-content .hljs-selector-tag,
+.comment-content .hljs-type {
+  color: #d73a49;
+}
+
+.comment-content .hljs-string,
+.comment-content .hljs-addition {
+  color: #032f62;
+}
+
+.comment-content .hljs-number,
+.comment-content .hljs-literal {
+  color: #005cc5;
+}
+
+.comment-content .hljs-built_in,
+.comment-content .hljs-builtin-name {
+  color: #6f42c1;
+}
+
+.comment-content .hljs-function .hljs-keyword {
+  color: #d73a49;
+}
+
+.comment-content .hljs-title,
+.comment-content .hljs-title.function_ {
+  color: #6f42c1;
+}
+
+.comment-content .hljs-attr,
+.comment-content .hljs-attribute {
+  color: #005cc5;
+}
+
+.comment-content .hljs-variable,
+.comment-content .hljs-template-variable {
+  color: #e36209;
+}
+
+.comment-content .hljs-params {
+  color: var(--color-code-text);
+}
+
+.comment-content .hljs-regexp {
+  color: #032f62;
+}
+
+.comment-content .hljs-tag {
+  color: #22863a;
+}
+
+.comment-content .hljs-name {
+  color: #22863a;
+}
+
+.comment-content .hljs-selector-class,
+.comment-content .hljs-selector-id {
+  color: #6f42c1;
+}
+
+.comment-content .hljs-selector-attr,
+.comment-content .hljs-selector-pseudo {
+  color: #005cc5;
+}
+
+.comment-content .hljs-symbol,
+.comment-content .hljs-bullet {
+  color: #005cc5;
+}
+
+.comment-content .hljs-meta {
+  color: #6a737d;
+}
+
+.comment-content .hljs-deletion {
+  color: #b31d28;
+  background: #ffeef0;
+}
+
+.comment-content .hljs-addition {
+  color: #22863a;
+  background: #f0fff4;
+}
+
+.comment-content .hljs-emphasis {
+  font-style: italic;
+}
+
+.comment-content .hljs-strong {
+  font-weight: var(--weight-7);
+}
+
+/* ============================================================================
+ * DARK MODE SYNTAX COLORS
+ * ============================================================================ */
+body.dark-mode .comment-content .hljs-comment,
+body.dark-mode .comment-content .hljs-quote {
+  color: #8b949e;
+}
+
+body.dark-mode .comment-content .hljs-keyword,
+body.dark-mode .comment-content .hljs-selector-tag,
+body.dark-mode .comment-content .hljs-type {
+  color: #ff7b72;
+}
+
+body.dark-mode .comment-content .hljs-string,
+body.dark-mode .comment-content .hljs-addition {
+  color: #a5d6ff;
+}
+
+body.dark-mode .comment-content .hljs-number,
+body.dark-mode .comment-content .hljs-literal {
+  color: #79c0ff;
+}
+
+body.dark-mode .comment-content .hljs-built_in,
+body.dark-mode .comment-content .hljs-builtin-name {
+  color: #d2a8ff;
+}
+
+body.dark-mode .comment-content .hljs-title,
+body.dark-mode .comment-content .hljs-title.function_ {
+  color: #d2a8ff;
+}
+
+body.dark-mode .comment-content .hljs-attr,
+body.dark-mode .comment-content .hljs-attribute {
+  color: #79c0ff;
+}
+
+body.dark-mode .comment-content .hljs-variable,
+body.dark-mode .comment-content .hljs-template-variable {
+  color: #ffa657;
+}
+
+body.dark-mode .comment-content .hljs-params {
+  color: var(--color-code-text);
+}
+
+body.dark-mode .comment-content .hljs-regexp {
+  color: #a5d6ff;
+}
+
+body.dark-mode .comment-content .hljs-tag {
+  color: #7ee787;
+}
+
+body.dark-mode .comment-content .hljs-name {
+  color: #7ee787;
+}
+
+body.dark-mode .comment-content .hljs-selector-class,
+body.dark-mode .comment-content .hljs-selector-id {
+  color: #d2a8ff;
+}
+
+body.dark-mode .comment-content .hljs-selector-attr,
+body.dark-mode .comment-content .hljs-selector-pseudo {
+  color: #79c0ff;
+}
+
+body.dark-mode .comment-content .hljs-symbol,
+body.dark-mode .comment-content .hljs-bullet {
+  color: #79c0ff;
+}
+
+body.dark-mode .comment-content .hljs-meta {
+  color: #8b949e;
+}
+
+body.dark-mode .comment-content .hljs-deletion {
+  color: #ffa198;
+  background: rgba(248, 81, 73, 0.15);
+}
+
+body.dark-mode .comment-content .hljs-addition {
+  color: #7ee787;
+  background: rgba(63, 185, 80, 0.15);
+}
+
+/* ============================================================================
+ * SYSTEM DARK MODE (prefers-color-scheme)
+ * Mirror dark mode colors for users without explicit toggle
+ * ============================================================================ */
+@media (prefers-color-scheme: dark) {
+  body:not(.light-mode):not(.dark-mode) .comment-content .hljs-comment,
+  body:not(.light-mode):not(.dark-mode) .comment-content .hljs-quote {
+    color: #8b949e;
+  }
+
+  body:not(.light-mode):not(.dark-mode) .comment-content .hljs-keyword,
+  body:not(.light-mode):not(.dark-mode) .comment-content .hljs-selector-tag,
+  body:not(.light-mode):not(.dark-mode) .comment-content .hljs-type {
+    color: #ff7b72;
+  }
+
+  body:not(.light-mode):not(.dark-mode) .comment-content .hljs-string,
+  body:not(.light-mode):not(.dark-mode) .comment-content .hljs-addition {
+    color: #a5d6ff;
+  }
+
+  body:not(.light-mode):not(.dark-mode) .comment-content .hljs-number,
+  body:not(.light-mode):not(.dark-mode) .comment-content .hljs-literal {
+    color: #79c0ff;
+  }
+
+  body:not(.light-mode):not(.dark-mode) .comment-content .hljs-built_in,
+  body:not(.light-mode):not(.dark-mode) .comment-content .hljs-builtin-name {
+    color: #d2a8ff;
+  }
+
+  body:not(.light-mode):not(.dark-mode) .comment-content .hljs-title,
+  body:not(.light-mode):not(.dark-mode) .comment-content .hljs-title.function_ {
+    color: #d2a8ff;
+  }
+
+  body:not(.light-mode):not(.dark-mode) .comment-content .hljs-attr,
+  body:not(.light-mode):not(.dark-mode) .comment-content .hljs-attribute {
+    color: #79c0ff;
+  }
+
+  body:not(.light-mode):not(.dark-mode) .comment-content .hljs-variable,
+  body:not(.light-mode):not(.dark-mode) .comment-content .hljs-template-variable {
+    color: #ffa657;
+  }
+
+  body:not(.light-mode):not(.dark-mode) .comment-content .hljs-params {
+    color: var(--color-code-text);
+  }
+
+  body:not(.light-mode):not(.dark-mode) .comment-content .hljs-regexp {
+    color: #a5d6ff;
+  }
+
+  body:not(.light-mode):not(.dark-mode) .comment-content .hljs-tag {
+    color: #7ee787;
+  }
+
+  body:not(.light-mode):not(.dark-mode) .comment-content .hljs-name {
+    color: #7ee787;
+  }
+
+  body:not(.light-mode):not(.dark-mode) .comment-content .hljs-selector-class,
+  body:not(.light-mode):not(.dark-mode) .comment-content .hljs-selector-id {
+    color: #d2a8ff;
+  }
+
+  body:not(.light-mode):not(.dark-mode) .comment-content .hljs-selector-attr,
+  body:not(.light-mode):not(.dark-mode) .comment-content .hljs-selector-pseudo {
+    color: #79c0ff;
+  }
+
+  body:not(.light-mode):not(.dark-mode) .comment-content .hljs-symbol,
+  body:not(.light-mode):not(.dark-mode) .comment-content .hljs-bullet {
+    color: #79c0ff;
+  }
+
+  body:not(.light-mode):not(.dark-mode) .comment-content .hljs-meta {
+    color: #8b949e;
+  }
+
+  body:not(.light-mode):not(.dark-mode) .comment-content .hljs-deletion {
+    color: #ffa198;
+    background: rgba(248, 81, 73, 0.15);
+  }
+
+  body:not(.light-mode):not(.dark-mode) .comment-content .hljs-addition {
+    color: #7ee787;
+    background: rgba(63, 185, 80, 0.15);
+  }
+}

--- a/engines/collavre/app/assets/stylesheets/collavre/code_highlight.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/code_highlight.css
@@ -2,10 +2,77 @@
  * Code Syntax Highlighting Theme
  *
  * Uses Collavre design tokens (--color-code-bg, --color-code-text, --font-mono).
- * Light/dark mode is handled automatically via design_tokens.css overrides.
- *
- * Based on GitHub-style highlighting with token-based theming.
+ * Syntax color tokens defined as CSS variables — overridden per theme context.
+ * Based on GitHub-style highlighting.
  */
+
+/* ============================================================================
+ * SYNTAX COLOR TOKENS (light mode defaults)
+ * ============================================================================ */
+:root {
+  --syntax-comment: #6a737d;
+  --syntax-keyword: #d73a49;
+  --syntax-string: #032f62;
+  --syntax-number: #005cc5;
+  --syntax-builtin: #6f42c1;
+  --syntax-title: #6f42c1;
+  --syntax-attr: #005cc5;
+  --syntax-variable: #e36209;
+  --syntax-regexp: #032f62;
+  --syntax-tag: #22863a;
+  --syntax-name: #22863a;
+  --syntax-selector: #6f42c1;
+  --syntax-meta: #6a737d;
+  --syntax-deletion-text: #b31d28;
+  --syntax-deletion-bg: #ffeef0;
+  --syntax-addition-text: #22863a;
+  --syntax-addition-bg: #f0fff4;
+}
+
+/* ============================================================================
+ * DARK MODE SYNTAX TOKENS
+ * ============================================================================ */
+body.dark-mode {
+  --syntax-comment: #8b949e;
+  --syntax-keyword: #ff7b72;
+  --syntax-string: #a5d6ff;
+  --syntax-number: #79c0ff;
+  --syntax-builtin: #d2a8ff;
+  --syntax-title: #d2a8ff;
+  --syntax-attr: #79c0ff;
+  --syntax-variable: #ffa657;
+  --syntax-regexp: #a5d6ff;
+  --syntax-tag: #7ee787;
+  --syntax-name: #7ee787;
+  --syntax-selector: #d2a8ff;
+  --syntax-meta: #8b949e;
+  --syntax-deletion-text: #ffa198;
+  --syntax-deletion-bg: rgba(248, 81, 73, 0.15);
+  --syntax-addition-text: #7ee787;
+  --syntax-addition-bg: rgba(63, 185, 80, 0.15);
+}
+
+@media (prefers-color-scheme: dark) {
+  body:not(.light-mode):not(.dark-mode) {
+    --syntax-comment: #8b949e;
+    --syntax-keyword: #ff7b72;
+    --syntax-string: #a5d6ff;
+    --syntax-number: #79c0ff;
+    --syntax-builtin: #d2a8ff;
+    --syntax-title: #d2a8ff;
+    --syntax-attr: #79c0ff;
+    --syntax-variable: #ffa657;
+    --syntax-regexp: #a5d6ff;
+    --syntax-tag: #7ee787;
+    --syntax-name: #7ee787;
+    --syntax-selector: #d2a8ff;
+    --syntax-meta: #8b949e;
+    --syntax-deletion-text: #ffa198;
+    --syntax-deletion-bg: rgba(248, 81, 73, 0.15);
+    --syntax-addition-text: #7ee787;
+    --syntax-addition-bg: rgba(63, 185, 80, 0.15);
+  }
+}
 
 /* ============================================================================
  * CODE BLOCK CONTAINER
@@ -27,6 +94,7 @@
   background: none;
   border: none;
   padding: 0;
+  border-radius: 0;
   font-family: inherit;
   font-size: inherit;
   color: inherit;
@@ -42,60 +110,48 @@
   font-size: 0.9em;
 }
 
-/* Don't double-style code inside pre */
-.comment-content pre code {
-  background: none;
-  padding: 0;
-  border-radius: 0;
-}
-
 /* ============================================================================
- * LIGHT MODE SYNTAX COLORS
+ * SYNTAX HIGHLIGHTING RULES (token-based, theme-agnostic)
  * ============================================================================ */
 .comment-content .hljs-comment,
 .comment-content .hljs-quote {
-  color: #6a737d;
+  color: var(--syntax-comment);
   font-style: italic;
 }
 
 .comment-content .hljs-keyword,
 .comment-content .hljs-selector-tag,
 .comment-content .hljs-type {
-  color: #d73a49;
+  color: var(--syntax-keyword);
 }
 
-.comment-content .hljs-string,
-.comment-content .hljs-addition {
-  color: #032f62;
+.comment-content .hljs-string {
+  color: var(--syntax-string);
 }
 
 .comment-content .hljs-number,
 .comment-content .hljs-literal {
-  color: #005cc5;
+  color: var(--syntax-number);
 }
 
 .comment-content .hljs-built_in,
 .comment-content .hljs-builtin-name {
-  color: #6f42c1;
-}
-
-.comment-content .hljs-function .hljs-keyword {
-  color: #d73a49;
+  color: var(--syntax-builtin);
 }
 
 .comment-content .hljs-title,
 .comment-content .hljs-title.function_ {
-  color: #6f42c1;
+  color: var(--syntax-title);
 }
 
 .comment-content .hljs-attr,
 .comment-content .hljs-attribute {
-  color: #005cc5;
+  color: var(--syntax-attr);
 }
 
 .comment-content .hljs-variable,
 .comment-content .hljs-template-variable {
-  color: #e36209;
+  color: var(--syntax-variable);
 }
 
 .comment-content .hljs-params {
@@ -103,44 +159,44 @@
 }
 
 .comment-content .hljs-regexp {
-  color: #032f62;
+  color: var(--syntax-regexp);
 }
 
 .comment-content .hljs-tag {
-  color: #22863a;
+  color: var(--syntax-tag);
 }
 
 .comment-content .hljs-name {
-  color: #22863a;
+  color: var(--syntax-name);
 }
 
 .comment-content .hljs-selector-class,
 .comment-content .hljs-selector-id {
-  color: #6f42c1;
+  color: var(--syntax-selector);
 }
 
 .comment-content .hljs-selector-attr,
 .comment-content .hljs-selector-pseudo {
-  color: #005cc5;
+  color: var(--syntax-attr);
 }
 
 .comment-content .hljs-symbol,
 .comment-content .hljs-bullet {
-  color: #005cc5;
+  color: var(--syntax-number);
 }
 
 .comment-content .hljs-meta {
-  color: #6a737d;
+  color: var(--syntax-meta);
 }
 
 .comment-content .hljs-deletion {
-  color: #b31d28;
-  background: #ffeef0;
+  color: var(--syntax-deletion-text);
+  background: var(--syntax-deletion-bg);
 }
 
 .comment-content .hljs-addition {
-  color: #22863a;
-  background: #f0fff4;
+  color: var(--syntax-addition-text);
+  background: var(--syntax-addition-bg);
 }
 
 .comment-content .hljs-emphasis {
@@ -149,185 +205,4 @@
 
 .comment-content .hljs-strong {
   font-weight: var(--weight-7);
-}
-
-/* ============================================================================
- * DARK MODE SYNTAX COLORS
- * ============================================================================ */
-body.dark-mode .comment-content .hljs-comment,
-body.dark-mode .comment-content .hljs-quote {
-  color: #8b949e;
-}
-
-body.dark-mode .comment-content .hljs-keyword,
-body.dark-mode .comment-content .hljs-selector-tag,
-body.dark-mode .comment-content .hljs-type {
-  color: #ff7b72;
-}
-
-body.dark-mode .comment-content .hljs-string,
-body.dark-mode .comment-content .hljs-addition {
-  color: #a5d6ff;
-}
-
-body.dark-mode .comment-content .hljs-number,
-body.dark-mode .comment-content .hljs-literal {
-  color: #79c0ff;
-}
-
-body.dark-mode .comment-content .hljs-built_in,
-body.dark-mode .comment-content .hljs-builtin-name {
-  color: #d2a8ff;
-}
-
-body.dark-mode .comment-content .hljs-title,
-body.dark-mode .comment-content .hljs-title.function_ {
-  color: #d2a8ff;
-}
-
-body.dark-mode .comment-content .hljs-attr,
-body.dark-mode .comment-content .hljs-attribute {
-  color: #79c0ff;
-}
-
-body.dark-mode .comment-content .hljs-variable,
-body.dark-mode .comment-content .hljs-template-variable {
-  color: #ffa657;
-}
-
-body.dark-mode .comment-content .hljs-params {
-  color: var(--color-code-text);
-}
-
-body.dark-mode .comment-content .hljs-regexp {
-  color: #a5d6ff;
-}
-
-body.dark-mode .comment-content .hljs-tag {
-  color: #7ee787;
-}
-
-body.dark-mode .comment-content .hljs-name {
-  color: #7ee787;
-}
-
-body.dark-mode .comment-content .hljs-selector-class,
-body.dark-mode .comment-content .hljs-selector-id {
-  color: #d2a8ff;
-}
-
-body.dark-mode .comment-content .hljs-selector-attr,
-body.dark-mode .comment-content .hljs-selector-pseudo {
-  color: #79c0ff;
-}
-
-body.dark-mode .comment-content .hljs-symbol,
-body.dark-mode .comment-content .hljs-bullet {
-  color: #79c0ff;
-}
-
-body.dark-mode .comment-content .hljs-meta {
-  color: #8b949e;
-}
-
-body.dark-mode .comment-content .hljs-deletion {
-  color: #ffa198;
-  background: rgba(248, 81, 73, 0.15);
-}
-
-body.dark-mode .comment-content .hljs-addition {
-  color: #7ee787;
-  background: rgba(63, 185, 80, 0.15);
-}
-
-/* ============================================================================
- * SYSTEM DARK MODE (prefers-color-scheme)
- * Mirror dark mode colors for users without explicit toggle
- * ============================================================================ */
-@media (prefers-color-scheme: dark) {
-  body:not(.light-mode):not(.dark-mode) .comment-content .hljs-comment,
-  body:not(.light-mode):not(.dark-mode) .comment-content .hljs-quote {
-    color: #8b949e;
-  }
-
-  body:not(.light-mode):not(.dark-mode) .comment-content .hljs-keyword,
-  body:not(.light-mode):not(.dark-mode) .comment-content .hljs-selector-tag,
-  body:not(.light-mode):not(.dark-mode) .comment-content .hljs-type {
-    color: #ff7b72;
-  }
-
-  body:not(.light-mode):not(.dark-mode) .comment-content .hljs-string,
-  body:not(.light-mode):not(.dark-mode) .comment-content .hljs-addition {
-    color: #a5d6ff;
-  }
-
-  body:not(.light-mode):not(.dark-mode) .comment-content .hljs-number,
-  body:not(.light-mode):not(.dark-mode) .comment-content .hljs-literal {
-    color: #79c0ff;
-  }
-
-  body:not(.light-mode):not(.dark-mode) .comment-content .hljs-built_in,
-  body:not(.light-mode):not(.dark-mode) .comment-content .hljs-builtin-name {
-    color: #d2a8ff;
-  }
-
-  body:not(.light-mode):not(.dark-mode) .comment-content .hljs-title,
-  body:not(.light-mode):not(.dark-mode) .comment-content .hljs-title.function_ {
-    color: #d2a8ff;
-  }
-
-  body:not(.light-mode):not(.dark-mode) .comment-content .hljs-attr,
-  body:not(.light-mode):not(.dark-mode) .comment-content .hljs-attribute {
-    color: #79c0ff;
-  }
-
-  body:not(.light-mode):not(.dark-mode) .comment-content .hljs-variable,
-  body:not(.light-mode):not(.dark-mode) .comment-content .hljs-template-variable {
-    color: #ffa657;
-  }
-
-  body:not(.light-mode):not(.dark-mode) .comment-content .hljs-params {
-    color: var(--color-code-text);
-  }
-
-  body:not(.light-mode):not(.dark-mode) .comment-content .hljs-regexp {
-    color: #a5d6ff;
-  }
-
-  body:not(.light-mode):not(.dark-mode) .comment-content .hljs-tag {
-    color: #7ee787;
-  }
-
-  body:not(.light-mode):not(.dark-mode) .comment-content .hljs-name {
-    color: #7ee787;
-  }
-
-  body:not(.light-mode):not(.dark-mode) .comment-content .hljs-selector-class,
-  body:not(.light-mode):not(.dark-mode) .comment-content .hljs-selector-id {
-    color: #d2a8ff;
-  }
-
-  body:not(.light-mode):not(.dark-mode) .comment-content .hljs-selector-attr,
-  body:not(.light-mode):not(.dark-mode) .comment-content .hljs-selector-pseudo {
-    color: #79c0ff;
-  }
-
-  body:not(.light-mode):not(.dark-mode) .comment-content .hljs-symbol,
-  body:not(.light-mode):not(.dark-mode) .comment-content .hljs-bullet {
-    color: #79c0ff;
-  }
-
-  body:not(.light-mode):not(.dark-mode) .comment-content .hljs-meta {
-    color: #8b949e;
-  }
-
-  body:not(.light-mode):not(.dark-mode) .comment-content .hljs-deletion {
-    color: #ffa198;
-    background: rgba(248, 81, 73, 0.15);
-  }
-
-  body:not(.light-mode):not(.dark-mode) .comment-content .hljs-addition {
-    color: #7ee787;
-    background: rgba(63, 185, 80, 0.15);
-  }
 }

--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -323,7 +323,6 @@ body.chat-fullscreen {
 .comment-content pre {
     white-space: pre-wrap;
     word-break: break-word;
-    overflow-x: auto;
 }
 
 .comment-content pre code {

--- a/engines/collavre/app/helpers/collavre/application_helper.rb
+++ b/engines/collavre/app/helpers/collavre/application_helper.rb
@@ -14,6 +14,7 @@ module Collavre
       collavre/org_chart
       collavre/popup
       collavre/comments_popup
+      collavre/code_highlight
       collavre/comment_versions
       collavre/mention_menu
       collavre/slide_view

--- a/engines/collavre/app/javascript/lib/utils/markdown.js
+++ b/engines/collavre/app/javascript/lib/utils/markdown.js
@@ -1,19 +1,120 @@
 import { marked } from 'marked'
 import DOMPurify from 'dompurify'
+import hljs from 'highlight.js/lib/core'
+
+// Register only commonly used languages to keep the bundle small
+import javascript from 'highlight.js/lib/languages/javascript'
+import typescript from 'highlight.js/lib/languages/typescript'
+import ruby from 'highlight.js/lib/languages/ruby'
+import python from 'highlight.js/lib/languages/python'
+import css from 'highlight.js/lib/languages/css'
+import xml from 'highlight.js/lib/languages/xml'
+import json from 'highlight.js/lib/languages/json'
+import yaml from 'highlight.js/lib/languages/yaml'
+import bash from 'highlight.js/lib/languages/bash'
+import sql from 'highlight.js/lib/languages/sql'
+import markdownLang from 'highlight.js/lib/languages/markdown'
+import diff from 'highlight.js/lib/languages/diff'
+import erb from 'highlight.js/lib/languages/erb'
+import go from 'highlight.js/lib/languages/go'
+import java from 'highlight.js/lib/languages/java'
+import plaintext from 'highlight.js/lib/languages/plaintext'
+
+hljs.registerLanguage('javascript', javascript)
+hljs.registerLanguage('js', javascript)
+hljs.registerLanguage('typescript', typescript)
+hljs.registerLanguage('ts', typescript)
+hljs.registerLanguage('ruby', ruby)
+hljs.registerLanguage('rb', ruby)
+hljs.registerLanguage('python', python)
+hljs.registerLanguage('py', python)
+hljs.registerLanguage('css', css)
+hljs.registerLanguage('html', xml)
+hljs.registerLanguage('xml', xml)
+hljs.registerLanguage('json', json)
+hljs.registerLanguage('yaml', yaml)
+hljs.registerLanguage('yml', yaml)
+hljs.registerLanguage('bash', bash)
+hljs.registerLanguage('sh', bash)
+hljs.registerLanguage('shell', bash)
+hljs.registerLanguage('sql', sql)
+hljs.registerLanguage('markdown', markdownLang)
+hljs.registerLanguage('md', markdownLang)
+hljs.registerLanguage('diff', diff)
+hljs.registerLanguage('erb', erb)
+hljs.registerLanguage('go', go)
+hljs.registerLanguage('java', java)
+hljs.registerLanguage('plaintext', plaintext)
+hljs.registerLanguage('text', plaintext)
+
+function highlightCode(code, lang) {
+  if (lang && hljs.getLanguage(lang)) {
+    try {
+      return hljs.highlight(code, { language: lang }).value
+    } catch (_) { /* fall through */ }
+  }
+  // Auto-detect for unlabeled code blocks
+  try {
+    return hljs.highlightAuto(code).value
+  } catch (_) {
+    return code
+  }
+}
+
+// Custom renderer for code blocks with syntax highlighting
+marked.use({
+  renderer: {
+    code({ text, lang }) {
+      const highlighted = highlightCode(text, lang)
+      const langClass = lang ? ` language-${lang}` : ''
+      return `<pre><code class="hljs${langClass}">${highlighted}</code></pre>`
+    }
+  }
+})
+
+// Allow hljs span classes through DOMPurify
+DOMPurify.addHook('uponSanitizeAttribute', (node, data) => {
+  if (node.tagName === 'SPAN' && data.attrName === 'class') {
+    const classes = data.attrValue.split(/\s+/)
+    const safe = classes.filter(c => c.startsWith('hljs-'))
+    if (safe.length > 0) {
+      data.attrValue = safe.join(' ')
+      data.forceKeepAttr = true
+    }
+  }
+  // Allow hljs and language-* classes on code elements
+  if (node.tagName === 'CODE' && data.attrName === 'class') {
+    const classes = data.attrValue.split(/\s+/)
+    const safe = classes.filter(c => c === 'hljs' || c.startsWith('language-'))
+    if (safe.length > 0) {
+      data.attrValue = safe.join(' ')
+      data.forceKeepAttr = true
+    }
+  }
+})
+
+const PURIFY_CONFIG = {
+  ADD_ATTR: ['class'],
+  ADD_TAGS: ['span']
+}
+
+function sanitize(html) {
+  return DOMPurify.sanitize(html, PURIFY_CONFIG)
+}
 
 export function renderMarkdown(html) {
-  return DOMPurify.sanitize(marked.parse(html))
+  return sanitize(marked.parse(html))
 }
 
 export function renderMarkdownInline(html) {
-  return DOMPurify.sanitize(marked.parseInline(html))
+  return sanitize(marked.parseInline(html))
 }
 
 export function renderCommentMarkdown(text) {
   const content = text || ''
   const useBlock = content.includes('\n') || content.includes('```')
   const html = useBlock ? marked.parse(content) : marked.parseInline(content)
-  return DOMPurify.sanitize(html.trim())
+  return sanitize(html.trim())
 }
 
 export function renderMarkdownInContainer(container) {

--- a/engines/collavre/app/javascript/lib/utils/markdown.js
+++ b/engines/collavre/app/javascript/lib/utils/markdown.js
@@ -61,12 +61,19 @@ function highlightCode(code, lang) {
   }
 }
 
+// Sanitize language identifier to prevent class attribute injection
+function sanitizeLang(lang) {
+  if (!lang) return ''
+  return lang.replace(/[^a-zA-Z0-9_-]/g, '')
+}
+
 // Custom renderer for code blocks with syntax highlighting
 marked.use({
   renderer: {
     code({ text, lang }) {
-      const highlighted = highlightCode(text, lang)
-      const langClass = lang ? ` language-${lang}` : ''
+      const safeLang = sanitizeLang(lang)
+      const highlighted = highlightCode(text, safeLang)
+      const langClass = safeLang ? ` language-${safeLang}` : ''
       return `<pre><code class="hljs${langClass}">${highlighted}</code></pre>`
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@rails/actiontext": "^8.0.201",
         "dompurify": "^3.3.0",
         "firebase": "^12.2.1",
+        "highlight.js": "^11.11.1",
         "js-yaml": "^4.1.0",
         "lexical": "^0.38.2",
         "lit": "^3.1.2",
@@ -4976,6 +4977,15 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/hookified": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@rails/actiontext": "^8.0.201",
     "dompurify": "^3.3.0",
     "firebase": "^12.2.1",
+    "highlight.js": "^11.11.1",
     "js-yaml": "^4.1.0",
     "lexical": "^0.38.2",
     "lit": "^3.1.2",


### PR DESCRIPTION
## Summary

Add syntax highlighting to code blocks in chat messages using **highlight.js** integrated with the existing `marked` markdown renderer.

## Changes

### JavaScript (`markdown.js`)
- Integrate highlight.js with selective language imports (js, ts, ruby, python, css, html/xml, json, yaml, bash/shell, sql, markdown, diff, erb, go, java, plaintext)
- Custom `marked` renderer for code blocks with syntax highlighting
- Language auto-detection for unlabeled code blocks
- DOMPurify hooks to allow `hljs-*` span classes and `language-*` code classes through sanitization

### CSS (`code_highlight.css`)
- GitHub-style syntax highlighting theme using design tokens (`--color-code-bg`, `--color-code-text`, `--font-mono`, `--border-color`, etc.)
- Full light mode + dark mode (`body.dark-mode`) + system preference (`prefers-color-scheme`) support
- Styled inline code (`\`code\``) and fenced code blocks (`\`\`\`lang`)

### Infrastructure
- Added `highlight.js` npm dependency
- Registered `collavre/code_highlight` in `COLLAVRE_STYLESHEETS` load order

## Supported Languages
javascript/js, typescript/ts, ruby/rb, python/py, css, html, xml, json, yaml/yml, bash/sh/shell, sql, markdown/md, diff, erb, go, java, plaintext/text

## How It Works
1. User writes a fenced code block in chat (e.g. `\`\`\`ruby ... \`\`\``)
2. `marked` parses the markdown and calls the custom renderer
3. highlight.js applies syntax coloring (explicit language or auto-detect)
4. DOMPurify sanitizes HTML while preserving hljs class attributes
5. CSS theme colors tokens based on light/dark mode

## Testing
- All 1451 tests pass (0 failures, 0 errors)
- Rubocop: 755 files, no offenses
- npm build: success
