### PR TITLE
fix: prevent swipe-to-close when scrolling chat nav dropdown

### DIFF
--- a/engines/collavre/app/javascript/controllers/comments/popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_controller.js
@@ -501,10 +501,10 @@ export default class extends Controller {
       this.touchStartY = null
       return
     }
-    if (!event.target.closest('#comments-list')) {
-      this.touchStartY = event.touches[0].clientY
-    } else {
+    if (event.target.closest('#comments-list') || event.target.closest('.chat-nav-dropdown')) {
       this.touchStartY = null
+    } else {
+      this.touchStartY = event.touches[0].clientY
     }
   }
 


### PR DESCRIPTION
## Problem

On mobile, scrolling down inside the chat navigation history dropdown (recent chats list) triggered the popup's swipe-to-close gesture, closing the chat popup.

## Cause

`handleTouchStart` excluded `#comments-list` from swipe detection but not `.chat-nav-dropdown`. The dropdown is inside the popup but outside the comments list, so vertical touch movement was interpreted as a close swipe.

## Fix

Add `.chat-nav-dropdown` to the exclusion check alongside `#comments-list`.