### PR TITLE
feat: move inbox next to profile and help into user menu on mobile

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,6 +39,7 @@ en:
     home: "Home"
     sign_in: "Sign in"
     sign_out: "Sign out"
+    help: "Help"
     cancel: "Cancel"
     previous: "Previous"
     next: "Next"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,7 +39,7 @@ en:
     home: "Home"
     sign_in: "Sign in"
     sign_out: "Sign out"
-    help: "Help"
+    help: "?"
     cancel: "Cancel"
     previous: "Previous"
     next: "Next"

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -27,7 +27,7 @@ ko:
     home: "홈"
     sign_in: "로그인"
     sign_out: "로그아웃"
-    help: "도움말"
+    help: "?"
     cancel: "취소"
     previous: "이전"
     next: "다음"

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -27,6 +27,7 @@ ko:
     home: "홈"
     sign_in: "로그인"
     sign_out: "로그아웃"
+    help: "도움말"
     cancel: "취소"
     previous: "이전"
     next: "다음"

--- a/engines/collavre/app/views/collavre/shared/_navigation.html.erb
+++ b/engines/collavre/app/views/collavre/shared/_navigation.html.erb
@@ -26,18 +26,6 @@
     <% end %>
   </div>
 
-  <%# Mobile Popup Menu %>
-  <%= render Collavre::PopupMenuComponent.new(
-        button_content: '...',
-        button_classes: 'mobile-only',
-        menu_id: 'mobile-more-menu',
-        align: :right
-      ) do %>
-    <% navigation_items_for(:main, desktop: false).reject { |i| i[:key].in?([:mobile_plans, :search, :home, :comment_filter, :mobile_inbox]) }.each do |item| %>
-      <%= render_mobile_navigation_item(item) %>
-    <% end %>
-  <% end %>
-
   <%# Mobile Inbox (next to profile avatar) %>
   <% if (mobile_inbox_item = Navigation::Registry.instance.find(:mobile_inbox)) && navigation_item_visible?(mobile_inbox_item, desktop: false) %>
     <span class="mobile-only"><%= render_navigation_item(mobile_inbox_item, mobile: true) %></span>

--- a/engines/collavre/app/views/collavre/shared/_navigation.html.erb
+++ b/engines/collavre/app/views/collavre/shared/_navigation.html.erb
@@ -28,14 +28,19 @@
 
   <%# Mobile Popup Menu %>
   <%= render Collavre::PopupMenuComponent.new(
-        button_content: safe_join(['...', (render(Collavre::Inbox::BadgeComponent.new(user: Current.user, badge_id: 'mobile-inbox-badge')) if Current.user)]),
+        button_content: '...',
         button_classes: 'mobile-only',
         menu_id: 'mobile-more-menu',
         align: :right
       ) do %>
-    <% navigation_items_for(:main, desktop: false).reject { |i| i[:key].in?([:mobile_plans, :search, :home, :comment_filter]) }.each do |item| %>
+    <% navigation_items_for(:main, desktop: false).reject { |i| i[:key].in?([:mobile_plans, :search, :home, :comment_filter, :mobile_inbox]) }.each do |item| %>
       <%= render_mobile_navigation_item(item) %>
     <% end %>
+  <% end %>
+
+  <%# Mobile Inbox (next to profile avatar) %>
+  <% if (mobile_inbox_item = Navigation::Registry.instance.find(:mobile_inbox)) && navigation_item_visible?(mobile_inbox_item, desktop: false) %>
+    <span class="mobile-only"><%= render_navigation_item(mobile_inbox_item, mobile: true) %></span>
   <% end %>
 
   <%# User Menu %>

--- a/engines/collavre/app/views/collavre/shared/navigation/_help_button.html.erb
+++ b/engines/collavre/app/views/collavre/shared/navigation/_help_button.html.erb
@@ -1,1 +1,1 @@
-<%= button_tag "?", id: "creative-guide-link", class: "creative-guide-link", data: { help_url: SystemSetting.help_menu_link } %>
+<%= button_tag t('app.help'), id: "creative-guide-link", class: "creative-guide-link", data: { help_url: SystemSetting.help_menu_link } %>

--- a/engines/collavre/lib/collavre/engine.rb
+++ b/engines/collavre/lib/collavre/engine.rb
@@ -203,7 +203,8 @@ module Collavre
           label: "?",
           type: :partial,
           partial: "collavre/shared/navigation/help_button",
-          priority: 170
+          priority: 170,
+          mobile: false
         )
 
         # ============================================
@@ -235,6 +236,15 @@ module Collavre
               path: -> { Collavre::Engine.routes.url_helpers.session_path },
               method: :delete,
               priority: 900
+            },
+            {
+              key: :help_mobile,
+              label: "app.help",
+              type: :partial,
+              partial: "collavre/shared/navigation/help_button",
+              priority: 950,
+              desktop: false,
+              mobile: true
             }
           ]
         )

--- a/engines/collavre/lib/collavre/engine.rb
+++ b/engines/collavre/lib/collavre/engine.rb
@@ -200,12 +200,11 @@ module Collavre
 
         Navigation::Registry.instance.register(
           key: :help,
-          label: "?",
+          label: "app.help",
           type: :partial,
           partial: "collavre/shared/navigation/help_button",
           priority: 170,
-          mobile: false,
-          desktop: true
+          mobile: false
         )
 
         # ============================================

--- a/engines/collavre/lib/collavre/engine.rb
+++ b/engines/collavre/lib/collavre/engine.rb
@@ -240,7 +240,7 @@ module Collavre
             },
             {
               key: :help_menu,
-              label: "?",
+              label: "app.help",
               type: :partial,
               partial: "collavre/shared/navigation/help_button",
               priority: 950

--- a/engines/collavre/lib/collavre/engine.rb
+++ b/engines/collavre/lib/collavre/engine.rb
@@ -204,7 +204,8 @@ module Collavre
           type: :partial,
           partial: "collavre/shared/navigation/help_button",
           priority: 170,
-          mobile: false
+          mobile: false,
+          desktop: true
         )
 
         # ============================================
@@ -238,13 +239,11 @@ module Collavre
               priority: 900
             },
             {
-              key: :help_mobile,
-              label: "app.help",
+              key: :help_menu,
+              label: "?",
               type: :partial,
               partial: "collavre/shared/navigation/help_button",
-              priority: 950,
-              desktop: false,
-              mobile: true
+              priority: 950
             }
           ]
         )


### PR DESCRIPTION
## Summary

Move mobile navigation items for a cleaner mobile layout:

### Changes
1. **Inbox button** → moved from `...` popup menu to directly next to the profile avatar (left side)
2. **Help button** → moved from `...` popup menu into the user/profile dropdown menu (below Sign out)
3. **`...` popup badge** → removed inbox badge overlay from the `...` button since inbox is no longer inside it

### Desktop
No changes — inbox and help remain in the navigation bar as before.

### i18n
- Added `app.help` key: en=`Help`, ko=`도움말`

### Files changed
- `engines/collavre/lib/collavre/engine.rb` — navigation item registration
- `engines/collavre/app/views/collavre/shared/_navigation.html.erb` — template layout
- `config/locales/en.yml`, `config/locales/ko.yml` — i18n