### PR TITLE
fix: ensure resource release in AiAgentJob via ensure block

### DIFF
--- a/engines/collavre/app/jobs/collavre/ai_agent_job.rb
+++ b/engines/collavre/app/jobs/collavre/ai_agent_job.rb
@@ -48,7 +48,9 @@ module Collavre
 
       # Reserve resources before starting work
       tracker = Orchestration::ResourceTracker.for(agent)
-      tracker.reserve!(job_id || task.id)
+      resource_id = job_id || task.id
+      tracker.reserve!(resource_id)
+      should_release = true
 
       begin
         response_content = AiAgentService.new(task).call
@@ -60,7 +62,6 @@ module Collavre
 
           if current_retry < max_retries
             task.update!(retry_count: current_retry + 1, status: "pending")
-            tracker.release!(job_id || task.id, tokens_used: 0)
             Rails.logger.warn(
               "[AiAgentJob] Workflow subtask #{task.id} returned empty response, " \
               "retrying (#{current_retry + 1}/#{max_retries})"
@@ -68,14 +69,12 @@ module Collavre
             AiAgentJob.set(wait: 5.seconds).perform_later(task)
           else
             task.update!(status: "failed")
-            tracker.release!(job_id || task.id, tokens_used: 0)
             Collavre::Comments::WorkflowExecutor.new(task.parent_task).fail_subtask!(
               task, error_message: "Agent returned empty response after #{max_retries} retries"
             )
           end
         else
           task.update!(status: "done")
-          tracker.release!(job_id || task.id, tokens_used: 0)
           # Advance workflow after releasing resources to avoid deadlock
           if task.parent_task_id.present?
             Collavre::Comments::WorkflowExecutor.new(task.parent_task).complete_subtask!(task)
@@ -84,14 +83,13 @@ module Collavre
       rescue ApprovalPendingError
         # Task status already set to pending_approval by AiAgentService
         # Don't release resources yet - task will resume
+        should_release = false
         Rails.logger.info("AiAgentJob paused for task #{task.id}: awaiting tool approval")
       rescue CancelledError
         # Task status already set to "cancelled" by Comment callback
-        tracker.release!(job_id || task.id, tokens_used: 0)
         Rails.logger.info("AiAgentJob cancelled for task #{task.id}: trigger message deleted")
       rescue StandardError => e
         task.update!(status: "failed")
-        tracker.release!(job_id || task.id, tokens_used: 0)
         # Fail workflow if this is a sub-task
         if task.parent_task_id.present?
           Collavre::Comments::WorkflowExecutor.new(task.parent_task).fail_subtask!(task, error_message: e.message)
@@ -99,6 +97,8 @@ module Collavre
         Rails.logger.error("AiAgentJob failed for task #{task.id}: #{e.message}")
         raise e
       ensure
+        # Guarantee resource release for all paths except pending_approval
+        tracker&.release!(resource_id, tokens_used: 0) if should_release && tracker && resource_id
         if task&.trigger_event_payload&.key?("topic") && %w[done failed cancelled escalated].include?(task.reload.status)
           Orchestration::AgentOrchestrator.dequeue_next_for_topic(task.topic_id, task.creative_id)
         end

--- a/engines/collavre/app/jobs/collavre/ai_agent_job.rb
+++ b/engines/collavre/app/jobs/collavre/ai_agent_job.rb
@@ -75,7 +75,7 @@ module Collavre
           end
         else
           task.update!(status: "done")
-          # Advance workflow after releasing resources to avoid deadlock
+          # Advance workflow (release happens in ensure block)
           if task.parent_task_id.present?
             Collavre::Comments::WorkflowExecutor.new(task.parent_task).complete_subtask!(task)
           end
@@ -98,7 +98,7 @@ module Collavre
         raise e
       ensure
         # Guarantee resource release for all paths except pending_approval
-        tracker&.release!(resource_id, tokens_used: 0) if should_release && tracker && resource_id
+        tracker.release!(resource_id, tokens_used: 0) if should_release && tracker && resource_id
         if task&.trigger_event_payload&.key?("topic") && %w[done failed cancelled escalated].include?(task.reload.status)
           Orchestration::AgentOrchestrator.dequeue_next_for_topic(task.topic_id, task.creative_id)
         end

--- a/engines/collavre/test/jobs/ai_agent_job_test.rb
+++ b/engines/collavre/test/jobs/ai_agent_job_test.rb
@@ -328,6 +328,42 @@ class AiAgentJobTest < ActiveJob::TestCase
       "Expected no new task when duplicate running task exists for same comment"
   end
 
+  test "releases resources in ensure block on success" do
+    AiClient.stub :new, FakeAiClient.new do
+      AiAgentJob.perform_now(@agent.id, "test_event", @context)
+    end
+
+    tracker = Collavre::Orchestration::ResourceTracker.for(@agent)
+    assert_equal 0, tracker.active_jobs,
+      "Expected active_jobs to be 0 after successful completion"
+  end
+
+  test "releases resources in ensure block on error" do
+    AiClient.stub :new, ->(*args) { raise StandardError, "AI Error" } do
+      assert_raises(StandardError) do
+        AiAgentJob.perform_now(@agent.id, "test_event", @context)
+      end
+    end
+
+    tracker = Collavre::Orchestration::ResourceTracker.for(@agent)
+    assert_equal 0, tracker.active_jobs,
+      "Expected active_jobs to be 0 after error"
+  end
+
+  test "does not release resources on approval pending" do
+    # Stub AiAgentService to raise ApprovalPendingError directly
+    fake_service = Minitest::Mock.new
+    fake_service.expect(:call, nil) { raise Collavre::ApprovalPendingError }
+
+    Collavre::AiAgentService.stub :new, ->(_task) { fake_service } do
+      AiAgentJob.perform_now(@agent.id, "test_event", @context)
+    end
+
+    tracker = Collavre::Orchestration::ResourceTracker.for(@agent)
+    assert_operator tracker.active_jobs, :>, 0,
+      "Expected active_jobs > 0 when approval is pending"
+  end
+
   test "allows execution when existing task for same comment is done" do
     # Create a completed task for the same agent + comment
     Task.create!(


### PR DESCRIPTION
## Problem

`ResourceTracker` cache entries were leaking when `AiAgentJob` terminated unexpectedly. The `release!()` call was scattered across individual success/rescue branches, so any unhandled exception path or edge case would leave stale entries in the `active_job_set` cache.

This caused false "에이전트 동시 실행 한도 도달" (agent concurrent limit reached) errors in production, blocking all new agent executions even when no jobs were actually running.

### Production Impact
- **Vrex**: 8 stale cache entries (limit: 5) — all new requests blocked
- **GitHub PR Analyzer**: 126 stuck `pending_approval` tasks

## Solution

Move `tracker.release!()` into the `ensure` block so resources are always freed regardless of how the job exits. Use a `should_release` flag that defaults to `true` and is only set to `false` for `ApprovalPendingError` (which legitimately needs to hold the reservation).

### Changes
- **`ai_agent_job.rb`**: Consolidate 5 separate `release!()` calls into 1 in the `ensure` block
- **`ai_agent_job_test.rb`**: Add 3 tests verifying release behavior (success, error, approval pending)

### Before
```ruby
begin
  # ... success path ...
  tracker.release!(...)  # ← 1
rescue ApprovalPendingError
  # no release (correct)
rescue CancelledError
  tracker.release!(...)  # ← 2
rescue StandardError
  tracker.release!(...)  # ← 3
  raise e
ensure
  # dequeue only, no release
end
```

### After
```ruby
should_release = true
begin
  # ... success path (no release calls) ...
rescue ApprovalPendingError
  should_release = false
rescue CancelledError
  # ...
rescue StandardError
  # ...
  raise e
ensure
  tracker&.release!(resource_id, tokens_used: 0) if should_release
  # dequeue logic
end
```

## Tests
- ✅ 15 tests, 47 assertions, 0 failures
- ✅ Rubocop clean (756 files)