### PR TITLE
feat: add Drop Trigger for creative workflow automation

### DIFF
--- a/app/assets/images/zap.svg
+++ b/app/assets/images/zap.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"></polygon></svg>

--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -1071,7 +1071,8 @@ body.chat-fullscreen {
 }
 
 .context-chip svg,
-.context-toggle-btn svg {
+.context-toggle-btn svg,
+.drop-trigger-toggle-btn svg {
     vertical-align: middle;
     flex-shrink: 0;
 }
@@ -1188,6 +1189,34 @@ body.chat-fullscreen {
     background: var(--color-secondary-active);
     color: var(--color-badge-text);
     border-color: var(--color-secondary-active);
+}
+
+/* Drop trigger toggle button */
+.drop-trigger-toggle-btn {
+    font-size: 0.75em;
+    padding: 0.15em 0.4em;
+    border-radius: 8px;
+    background: none;
+    border: 1px solid transparent;
+    cursor: pointer;
+    transition: all 0.2s;
+    white-space: nowrap;
+}
+
+.drop-trigger-toggle-btn:hover {
+    background: var(--color-secondary-background);
+}
+
+.drop-trigger-toggle-btn.drop-trigger-active {
+    background: var(--color-warning-background, #fff3cd);
+    color: var(--color-warning-text, #856404);
+    border-color: var(--color-warning-border, #ffc107);
+}
+
+.drop-trigger-toggle-btn.drop-trigger-active svg {
+    stroke: var(--color-warning-text, #856404);
+    fill: var(--color-warning-text, #856404);
+    fill-opacity: 0.2;
 }
 
 .comment-topics-list {

--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -1208,14 +1208,14 @@ body.chat-fullscreen {
 }
 
 .drop-trigger-toggle-btn.drop-trigger-active {
-    background: var(--color-warning-background, #fff3cd);
-    color: var(--color-warning-text, #856404);
-    border-color: var(--color-warning-border, #ffc107);
+    background: color-mix(in srgb, var(--color-warning) 20%, transparent);
+    color: var(--color-warning);
+    border-color: var(--color-warning);
 }
 
 .drop-trigger-toggle-btn.drop-trigger-active svg {
-    stroke: var(--color-warning-text, #856404);
-    fill: var(--color-warning-text, #856404);
+    stroke: var(--color-warning);
+    fill: var(--color-warning);
     fill-opacity: 0.2;
 }
 

--- a/engines/collavre/app/javascript/controllers/comments/drop_trigger_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/drop_trigger_controller.js
@@ -6,6 +6,7 @@ export default class extends Controller {
     connect() {
         this.enabled = false
         this.canWrite = false
+        this._cachedData = null
     }
 
     get creativeId() {
@@ -15,6 +16,7 @@ export default class extends Controller {
     async onPopupOpened({ creativeId }) {
         this.enabled = false
         this.canWrite = false
+        this._cachedData = null
         this._updateButtonState()
         await this._loadTriggerState()
     }
@@ -22,6 +24,7 @@ export default class extends Controller {
     onPopupClosed() {
         this.enabled = false
         this.canWrite = false
+        this._cachedData = null
         this._updateButtonState()
     }
 
@@ -34,8 +37,7 @@ export default class extends Controller {
         this._updateButtonState()
 
         try {
-            // Fetch current data first to preserve other fields
-            const currentData = await this._fetchCreativeData()
+            const currentData = this._cachedData || {}
             const newData = {
                 ...currentData,
                 trigger: { ...(currentData.trigger || {}), on_child_enter: newState }
@@ -51,7 +53,10 @@ export default class extends Controller {
                 body: new URLSearchParams({ data: JSON.stringify(newData) })
             })
 
-            if (!response.ok) {
+            if (response.ok) {
+                // Update cache with new data
+                this._cachedData = newData
+            } else {
                 // Revert on failure
                 this.enabled = !newState
                 this._updateButtonState()
@@ -71,27 +76,14 @@ export default class extends Controller {
             const response = await fetch(`/creatives/${creativeId}.json`)
             if (response.ok) {
                 const json = await response.json()
-                this.enabled = json.data?.trigger?.on_child_enter === true
+                this._cachedData = json.data || {}
+                this.enabled = this._cachedData?.trigger?.on_child_enter === true
                 this.canWrite = json.can_edit || false
                 this._updateButtonState()
             }
         } catch (e) {
             console.error("Failed to load drop trigger state", e)
         }
-    }
-
-    async _fetchCreativeData() {
-        const creativeId = this.creativeId
-        if (!creativeId) return {}
-
-        try {
-            const response = await fetch(`/creatives/${creativeId}.json`)
-            if (response.ok) {
-                const json = await response.json()
-                return json.data || {}
-            }
-        } catch (e) { /* ignore */ }
-        return {}
     }
 
     _updateButtonState() {

--- a/engines/collavre/app/javascript/controllers/comments/drop_trigger_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/drop_trigger_controller.js
@@ -1,0 +1,108 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+    static targets = ["toggleButton"]
+
+    connect() {
+        this.enabled = false
+        this.canWrite = false
+    }
+
+    get creativeId() {
+        return this.element.closest('#comments-popup')?.dataset?.creativeId
+    }
+
+    async onPopupOpened({ creativeId }) {
+        this.enabled = false
+        this.canWrite = false
+        this._updateButtonState()
+        await this._loadTriggerState()
+    }
+
+    onPopupClosed() {
+        this.enabled = false
+        this.canWrite = false
+        this._updateButtonState()
+    }
+
+    async toggle() {
+        const creativeId = this.creativeId
+        if (!creativeId || !this.canWrite) return
+
+        const newState = !this.enabled
+        this.enabled = newState
+        this._updateButtonState()
+
+        try {
+            // Fetch current data first to preserve other fields
+            const currentData = await this._fetchCreativeData()
+            const newData = {
+                ...currentData,
+                trigger: { ...(currentData.trigger || {}), on_child_enter: newState }
+            }
+
+            const csrfToken = document.querySelector('meta[name="csrf-token"]')?.content
+            const response = await fetch(`/creatives/${creativeId}/update_metadata`, {
+                method: 'PATCH',
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                    'X-CSRF-Token': csrfToken
+                },
+                body: new URLSearchParams({ data: JSON.stringify(newData) })
+            })
+
+            if (!response.ok) {
+                // Revert on failure
+                this.enabled = !newState
+                this._updateButtonState()
+            }
+        } catch (e) {
+            console.error("Failed to toggle drop trigger", e)
+            this.enabled = !newState
+            this._updateButtonState()
+        }
+    }
+
+    async _loadTriggerState() {
+        const creativeId = this.creativeId
+        if (!creativeId) return
+
+        try {
+            const response = await fetch(`/creatives/${creativeId}.json`)
+            if (response.ok) {
+                const json = await response.json()
+                this.enabled = json.data?.trigger?.on_child_enter === true
+                this.canWrite = json.can_edit || false
+                this._updateButtonState()
+            }
+        } catch (e) {
+            console.error("Failed to load drop trigger state", e)
+        }
+    }
+
+    async _fetchCreativeData() {
+        const creativeId = this.creativeId
+        if (!creativeId) return {}
+
+        try {
+            const response = await fetch(`/creatives/${creativeId}.json`)
+            if (response.ok) {
+                const json = await response.json()
+                return json.data || {}
+            }
+        } catch (e) { /* ignore */ }
+        return {}
+    }
+
+    _updateButtonState() {
+        if (!this.hasToggleButtonTarget) return
+
+        const btn = this.toggleButtonTarget
+        // Only show for users with write permission
+        btn.style.display = this.canWrite ? '' : 'none'
+        btn.classList.toggle('drop-trigger-active', this.enabled)
+        btn.title = this.enabled
+            ? (btn.dataset.titleOn || 'Drop Trigger enabled')
+            : (btn.dataset.titleOff || 'Drop Trigger disabled')
+    }
+}

--- a/engines/collavre/app/javascript/controllers/comments/popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_controller.js
@@ -170,6 +170,10 @@ export default class extends Controller {
     return this.application.getControllerForElementAndIdentifier(this.element, 'comments--contexts')
   }
 
+  get dropTriggerController() {
+    return this.application.getControllerForElementAndIdentifier(this.element, 'comments--drop-trigger')
+  }
+
   handleCreativeClick(event) {
     const button = event.detail?.button
     const creativeId = event.detail?.creativeId
@@ -304,6 +308,9 @@ export default class extends Controller {
     if (this.contextsController) {
       this.contextsController.onPopupOpened({ creativeId })
     }
+    if (this.dropTriggerController) {
+      this.dropTriggerController.onPopupOpened({ creativeId })
+    }
   }
 
   close() {
@@ -324,6 +331,9 @@ export default class extends Controller {
     }
     if (this.contextsController) {
       this.contextsController.onPopupClosed()
+    }
+    if (this.dropTriggerController) {
+      this.dropTriggerController.onPopupClosed()
     }
 
     // Dispatch event for integrations

--- a/engines/collavre/app/javascript/controllers/index.js
+++ b/engines/collavre/app/javascript/controllers/index.js
@@ -16,6 +16,7 @@ import CommentsPresenceController from "./comments/presence_controller"
 import CommentsMentionMenuController from "./comments/mention_menu_controller"
 import CommentsTopicsController from "./comments/topics_controller"
 import CommentsContextsController from "./comments/contexts_controller"
+import CommentsDropTriggerController from "./comments/drop_trigger_controller"
 import CommentsPopupController from "./comments/popup_controller"
 import ClickTargetController from "./click_target_controller"
 import TabsController from "./tabs_controller"
@@ -50,6 +51,7 @@ export {
   CommentsPresenceController,
   CommentsMentionMenuController,
   CommentsTopicsController,
+  CommentsDropTriggerController,
   CommentsPopupController,
   ClickTargetController,
   TabsController,
@@ -86,6 +88,7 @@ export function registerControllers(application) {
   application.register("comments--mention-menu", CommentsMentionMenuController)
   application.register("comments--topics", CommentsTopicsController)
   application.register("comments--contexts", CommentsContextsController)
+  application.register("comments--drop-trigger", CommentsDropTriggerController)
   application.register("comments--popup", CommentsPopupController)
   application.register("click-target", ClickTargetController)
   application.register("tabs", TabsController)

--- a/engines/collavre/app/jobs/collavre/drop_trigger_job.rb
+++ b/engines/collavre/app/jobs/collavre/drop_trigger_job.rb
@@ -71,9 +71,9 @@ module Collavre
     def create_trigger_comment(child, parent, agent, topic)
       trigger_text = I18n.t(
         "collavre.drop_trigger.child_entered",
-        child_description: child.description,
+        child_description: child.creative_snippet,
         child_id: child.id,
-        parent_description: parent.description
+        parent_description: parent.creative_snippet
       )
       # Mention the agent to ensure exclusive routing via Matcher
       content = "@#{agent.name}: #{trigger_text}"

--- a/engines/collavre/app/jobs/collavre/drop_trigger_job.rb
+++ b/engines/collavre/app/jobs/collavre/drop_trigger_job.rb
@@ -17,7 +17,7 @@ module Collavre
 
       # Create trigger topic and comment on the CHILD creative
       topic = find_or_create_trigger_topic(child, agent)
-      comment = create_trigger_comment(child, parent, topic)
+      comment = create_trigger_comment(child, parent, agent, topic)
 
       # Dispatch event targeting the child creative
       SystemEvents::Dispatcher.dispatch("comment_created", {
@@ -35,7 +35,11 @@ module Collavre
           "id" => topic.id
         },
         "chat" => {
-          "content" => comment.content
+          "content" => comment.content,
+          "mentioned_user" => {
+            "id" => agent.id,
+            "name" => agent.name
+          }
         },
         "drop_trigger" => {
           "parent_id" => parent.id,
@@ -64,13 +68,15 @@ module Collavre
       topic
     end
 
-    def create_trigger_comment(child, parent, topic)
-      content = I18n.t(
+    def create_trigger_comment(child, parent, agent, topic)
+      trigger_text = I18n.t(
         "collavre.drop_trigger.child_entered",
         child_description: child.description,
         child_id: child.id,
         parent_description: parent.description
       )
+      # Mention the agent to ensure exclusive routing via Matcher
+      content = "@#{agent.name}: #{trigger_text}"
       child.comments.create!(
         content: content,
         topic_id: topic.id,

--- a/engines/collavre/app/jobs/collavre/drop_trigger_job.rb
+++ b/engines/collavre/app/jobs/collavre/drop_trigger_job.rb
@@ -10,12 +10,16 @@ module Collavre
       return unless parent && child
       return unless parent.drop_trigger_enabled?
 
+      # Agent is resolved from the parent (where the trigger is configured),
+      # but the work happens on the child creative's chat
       agent = find_trigger_agent(parent)
       return unless agent
 
-      topic = find_or_create_trigger_topic(parent, agent)
-      comment = create_trigger_comment(parent, child, topic)
+      # Create trigger topic and comment on the CHILD creative
+      topic = find_or_create_trigger_topic(child, agent)
+      comment = create_trigger_comment(child, parent, topic)
 
+      # Dispatch event targeting the child creative
       SystemEvents::Dispatcher.dispatch("comment_created", {
         "comment" => {
           "id" => comment.id,
@@ -24,8 +28,8 @@ module Collavre
           "from_ai" => false
         },
         "creative" => {
-          "id" => parent.id,
-          "description" => parent.description
+          "id" => child.id,
+          "description" => child.description
         },
         "topic" => {
           "id" => topic.id
@@ -34,8 +38,8 @@ module Collavre
           "content" => comment.content
         },
         "drop_trigger" => {
-          "child_id" => child.id,
-          "child_description" => child.description
+          "parent_id" => parent.id,
+          "parent_description" => parent.description
         }
       })
     end
@@ -60,18 +64,18 @@ module Collavre
       topic
     end
 
-    def create_trigger_comment(parent, child, topic)
+    def create_trigger_comment(child, parent, topic)
       content = I18n.t(
         "collavre.drop_trigger.child_entered",
         child_description: child.description,
         child_id: child.id,
         parent_description: parent.description
       )
-      parent.comments.create!(
+      child.comments.create!(
         content: content,
         topic_id: topic.id,
         private: false,
-        user: parent.user
+        user: child.user
       )
     end
   end

--- a/engines/collavre/app/jobs/collavre/drop_trigger_job.rb
+++ b/engines/collavre/app/jobs/collavre/drop_trigger_job.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+module Collavre
+  class DropTriggerJob < ApplicationJob
+    queue_as :default
+
+    def perform(parent_creative_id, child_creative_id)
+      parent = Creative.find_by(id: parent_creative_id)
+      child = Creative.find_by(id: child_creative_id)
+      return unless parent && child
+      return unless parent.drop_trigger_enabled?
+
+      agent = find_trigger_agent(parent)
+      return unless agent
+
+      topic = find_or_create_trigger_topic(parent, agent)
+      comment = create_trigger_comment(parent, child, topic)
+
+      SystemEvents::Dispatcher.dispatch("comment_created", {
+        "comment" => {
+          "id" => comment.id,
+          "content" => comment.content,
+          "user_id" => comment.user_id,
+          "from_ai" => false
+        },
+        "creative" => {
+          "id" => parent.id,
+          "description" => parent.description
+        },
+        "topic" => {
+          "id" => topic.id
+        },
+        "chat" => {
+          "content" => comment.content
+        },
+        "drop_trigger" => {
+          "child_id" => child.id,
+          "child_description" => child.description
+        }
+      })
+    end
+
+    private
+
+    def find_trigger_agent(creative)
+      creative.all_shared_users(:feedback)
+              .map(&:user)
+              .find(&:ai_user?)
+    end
+
+    def find_or_create_trigger_topic(creative, agent)
+      topic = creative.topics.find_by(name: "Drop Trigger")
+      return topic if topic
+
+      topic = creative.topics.create!(
+        name: "Drop Trigger",
+        user: creative.user
+      )
+      topic.set_primary_agent!(agent)
+      topic
+    end
+
+    def create_trigger_comment(parent, child, topic)
+      content = I18n.t(
+        "collavre.drop_trigger.child_entered",
+        child_description: child.description,
+        child_id: child.id,
+        parent_description: parent.description
+      )
+      parent.comments.create!(
+        content: content,
+        topic_id: topic.id,
+        private: false,
+        user: parent.user
+      )
+    end
+  end
+end

--- a/engines/collavre/app/models/collavre/creative.rb
+++ b/engines/collavre/app/models/collavre/creative.rb
@@ -245,6 +245,9 @@ module Collavre
     end
 
     def fire_drop_trigger_on_move
+      # Skip on create — after_create_commit handles that case
+      return if previously_new_record?
+
       new_parent_id = parent_id
       return unless new_parent_id
 

--- a/engines/collavre/app/models/collavre/creative.rb
+++ b/engines/collavre/app/models/collavre/creative.rb
@@ -11,6 +11,8 @@ module Collavre
     end
 
     after_save :touch_subtree_on_move, if: :saved_change_to_parent_id?
+    after_save :fire_drop_trigger_on_move, if: :saved_change_to_parent_id?
+    after_create_commit :fire_drop_trigger_on_create, if: :parent_id?
 
 
     include Linkable
@@ -79,6 +81,11 @@ module Collavre
     after_save :update_parent_progress
     after_destroy :update_parent_progress
     after_save :update_mcp_tools
+
+    # --- Drop Trigger ---
+    def drop_trigger_enabled?
+      data&.dig("trigger", "on_child_enter") == true
+    end
 
     # --- Context IDs ---
     # Returns the directly-configured context creative IDs for this creative.
@@ -235,6 +242,22 @@ module Collavre
 
     def touch_subtree_on_move
       descendants.update_all(updated_at: Time.current)
+    end
+
+    def fire_drop_trigger_on_move
+      new_parent_id = parent_id
+      return unless new_parent_id
+
+      new_parent = Creative.find_by(id: new_parent_id)
+      return unless new_parent&.drop_trigger_enabled?
+
+      DropTriggerJob.perform_later(new_parent.id, id)
+    end
+
+    def fire_drop_trigger_on_create
+      return unless parent&.drop_trigger_enabled?
+
+      DropTriggerJob.perform_later(parent_id, id)
     end
   end
 end

--- a/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
@@ -2,7 +2,7 @@
 <% fullscreen = local_assigns.fetch(:fullscreen, false) %>
 <% auto_fullscreen = local_assigns.fetch(:auto_fullscreen, false) %>
 <% creative = local_assigns[:creative] %>
-<div id="comments-popup" data-controller="comments--popup comments--list comments--form comments--presence comments--mention-menu comments--topics comments--contexts share-modal" class="popup-box"
+<div id="comments-popup" data-controller="comments--popup comments--list comments--form comments--presence comments--mention-menu comments--topics comments--contexts comments--drop-trigger share-modal" class="popup-box"
      data-fullscreen="<%= fullscreen %>"
      <% if auto_fullscreen %>data-auto-fullscreen="true"<% end %>
      data-fullscreen-label="<%= t('collavre.comments.fullscreen', default: 'Full screen') %>"
@@ -72,6 +72,14 @@
     <h3 id="comments-popup-title" data-comments--popup-target="title"><%= fullscreen && creative.present? ? creative.creative_snippet : t('collavre.comments.comments') %></h3>
     <span data-integration-badges class="integration-badges"></span>
     <div class="comments-popup-actions">
+      <button class="comments-popup-action drop-trigger-toggle-btn"
+              data-comments--drop-trigger-target="toggleButton"
+              data-action="click->comments--drop-trigger#toggle"
+              type="button"
+              data-title-on="<%= t('collavre.drop_trigger.toggle_on') %>"
+              data-title-off="<%= t('collavre.drop_trigger.toggle_off') %>"
+              title="<%= t('collavre.drop_trigger.toggle_off') %>"
+              style="display:none;"><%= svg_tag "zap.svg", class: "comments-popup-action-icon", width: 16, height: 16 %></button>
       <button class="comments-popup-action context-toggle-btn"
               data-comments--contexts-target="toggleButton"
               data-action="click->comments--contexts#toggleVisibility"

--- a/engines/collavre/config/locales/drop_trigger.en.yml
+++ b/engines/collavre/config/locales/drop_trigger.en.yml
@@ -1,0 +1,6 @@
+en:
+  collavre:
+    drop_trigger:
+      child_entered: "🔔 Drop Trigger: Creative '%{child_description}' (ID: %{child_id}) was added to '%{parent_description}'. Please process this creative according to this stage's purpose."
+      toggle_on: "Drop Trigger enabled"
+      toggle_off: "Drop Trigger disabled"

--- a/engines/collavre/config/locales/drop_trigger.ko.yml
+++ b/engines/collavre/config/locales/drop_trigger.ko.yml
@@ -1,0 +1,6 @@
+ko:
+  collavre:
+    drop_trigger:
+      child_entered: "🔔 드롭 트리거: 크리에이티브 '%{child_description}' (ID: %{child_id})가 '%{parent_description}'에 추가되었습니다. 이 단계의 목적에 맞게 처리해주세요."
+      toggle_on: "드롭 트리거 활성화됨"
+      toggle_off: "드롭 트리거 비활성화됨"

--- a/engines/collavre/test/jobs/collavre/drop_trigger_job_test.rb
+++ b/engines/collavre/test/jobs/collavre/drop_trigger_job_test.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  class DropTriggerJobTest < ActiveSupport::TestCase
+    include ActiveJob::TestHelper
+
+    setup do
+      @owner = users(:one)
+      @ai_bot = users(:ai_bot)
+      Current.session = OpenStruct.new(user: @owner)
+
+      perform_enqueued_jobs do
+        @parent = Creative.create!(user: @owner, description: "Trigger Parent", data: { "trigger" => { "on_child_enter" => true } })
+        @child = Creative.create!(user: @owner, description: "Dropped Child")
+        CreativeShare.create!(creative: @parent, user: @ai_bot, permission: :feedback)
+      end
+    end
+
+    teardown do
+      Current.reset
+    end
+
+    test "creates trigger topic and comment on child creative" do
+      assert_difference -> { @child.comments.count }, 1 do
+        assert_difference -> { @child.topics.count }, 1 do
+          DropTriggerJob.perform_now(@parent.id, @child.id)
+        end
+      end
+
+      topic = @child.topics.find_by(name: "Drop Trigger")
+      assert topic, "Drop Trigger topic should be created on child"
+
+      comment = @child.comments.last
+      assert_includes comment.content, "@#{@ai_bot.name}:"
+      assert_includes comment.content, @child.creative_snippet
+    end
+
+    test "reuses existing Drop Trigger topic" do
+      DropTriggerJob.perform_now(@parent.id, @child.id)
+      topic = @child.topics.find_by(name: "Drop Trigger")
+
+      assert_no_difference -> { @child.topics.count } do
+        DropTriggerJob.perform_now(@parent.id, @child.id)
+      end
+
+      assert_equal topic.id, @child.topics.find_by(name: "Drop Trigger").id
+    end
+
+    test "skips when parent trigger is disabled" do
+      @parent.update!(data: {})
+
+      assert_no_difference -> { Comment.count } do
+        DropTriggerJob.perform_now(@parent.id, @child.id)
+      end
+    end
+
+    test "skips when no AI agent found" do
+      CreativeShare.where(creative: @parent, user: @ai_bot).destroy_all
+
+      assert_no_difference -> { Comment.count } do
+        DropTriggerJob.perform_now(@parent.id, @child.id)
+      end
+    end
+
+    test "skips when parent creative not found" do
+      assert_no_difference -> { Comment.count } do
+        DropTriggerJob.perform_now(0, @child.id)
+      end
+    end
+
+    test "skips when child creative not found" do
+      assert_no_difference -> { Comment.count } do
+        DropTriggerJob.perform_now(@parent.id, 0)
+      end
+    end
+
+    test "comment mentions the AI agent for routing" do
+      DropTriggerJob.perform_now(@parent.id, @child.id)
+
+      comment = @child.comments.last
+      assert comment.content.start_with?("@#{@ai_bot.name}:"),
+        "Comment should start with @AgentName: mention"
+    end
+
+    test "uses creative_snippet for plain text names" do
+      @child.update!(description: "<p>HTML <strong>description</strong> that is very long and should be truncated</p>")
+
+      DropTriggerJob.perform_now(@parent.id, @child.id)
+
+      comment = @child.comments.last
+      refute_includes comment.content, "<p>"
+      refute_includes comment.content, "<strong>"
+    end
+  end
+end

--- a/engines/collavre/test/models/collavre/creative_drop_trigger_test.rb
+++ b/engines/collavre/test/models/collavre/creative_drop_trigger_test.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  class CreativeDropTriggerTest < ActiveSupport::TestCase
+    include ActiveJob::TestHelper
+
+    setup do
+      @owner = users(:one)
+      @ai_bot = users(:ai_bot)
+      Current.session = OpenStruct.new(user: @owner)
+      @original_adapter = ActiveJob::Base.queue_adapter
+      ActiveJob::Base.queue_adapter = :test
+
+      @trigger_parent = Creative.create!(
+        user: @owner,
+        description: "Trigger Parent",
+        data: { "trigger" => { "on_child_enter" => true } }
+      )
+      @normal_parent = Creative.create!(user: @owner, description: "Normal Parent")
+      CreativeShare.create!(creative: @trigger_parent, user: @ai_bot, permission: :feedback)
+    end
+
+    teardown do
+      ActiveJob::Base.queue_adapter = @original_adapter
+      Current.reset
+    end
+
+    test "drop_trigger_enabled? returns true when configured" do
+      assert @trigger_parent.drop_trigger_enabled?
+    end
+
+    test "drop_trigger_enabled? returns false when not configured" do
+      refute @normal_parent.drop_trigger_enabled?
+    end
+
+    test "drop_trigger_enabled? returns false for nil data" do
+      creative = Creative.new(data: nil)
+      refute creative.drop_trigger_enabled?
+    end
+
+    test "creating child under trigger parent enqueues DropTriggerJob" do
+      assert_enqueued_with(job: DropTriggerJob) do
+        Creative.create!(user: @owner, parent: @trigger_parent, description: "New Child")
+      end
+    end
+
+    test "creating child under normal parent does not enqueue DropTriggerJob" do
+      assert_no_enqueued_jobs(only: DropTriggerJob) do
+        Creative.create!(user: @owner, parent: @normal_parent, description: "New Child")
+      end
+    end
+
+    test "moving creative into trigger parent enqueues DropTriggerJob" do
+      child = Creative.create!(user: @owner, description: "Orphan")
+      clear_enqueued_jobs
+
+      assert_enqueued_with(job: DropTriggerJob) do
+        child.update!(parent: @trigger_parent)
+      end
+    end
+
+    test "moving creative into normal parent does not enqueue DropTriggerJob" do
+      child = Creative.create!(user: @owner, description: "Orphan")
+      clear_enqueued_jobs
+
+      assert_no_enqueued_jobs(only: DropTriggerJob) do
+        child.update!(parent: @normal_parent)
+      end
+    end
+
+    test "creating child enqueues exactly one DropTriggerJob not two" do
+      assert_enqueued_jobs(1, only: DropTriggerJob) do
+        Creative.create!(user: @owner, parent: @trigger_parent, description: "Single Trigger Child")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Add **Drop Trigger** feature that enables cascading workflow automation through Collavre's creative tree structure.

When a child creative is added/moved into a parent creative with drop trigger enabled (`data.trigger.on_child_enter = true`), the system automatically:
1. Finds an AI Agent with feedback permission on the parent
2. Creates/reuses a 'Drop Trigger' topic on the parent creative
3. Posts a trigger comment with child creative info
4. Dispatches via existing SystemEvents pipeline to AgentOrchestrator

This enables workflows like: **Research → Define → Plan → Implement → Document** where each stage's AI Agent processes incoming creatives and moves them to the next stage automatically.

## Changes

### Backend
- `Creative` model: `drop_trigger_enabled?` method + `after_save`/`after_create_commit` callbacks
- `DropTriggerJob`: async trigger execution via existing SystemEvents → AgentOrchestrator pipeline
- i18n: en/ko locale files for trigger messages and UI labels

### Frontend
- ⚡ zap icon toggle button in chat header (left of context toggle)
- Stimulus `comments--drop-trigger` controller for toggle state via `update_metadata` API
- CSS styling with active state highlight
- Registered in `popup_controller.js` lifecycle (open/close)

## Architecture

- **No DB migration needed** — uses existing `data` jsonb column on creatives
- **Reuses existing event pipeline** — `SystemEvents::Dispatcher` → `AgentOrchestrator` → `Matcher` → `Arbiter` → `Scheduler` → `AiAgentJob`
- **Parallel execution supported** — multiple children entering the same parent each trigger independent jobs; existing orchestration handles concurrency
- **Minimal new code** — only `DropTriggerJob` is truly new; everything else leverages existing infrastructure

## How to Test

1. Enable drop trigger on a parent creative via the ⚡ toggle in chat header
2. Move or create a child creative under that parent
3. Verify: 'Drop Trigger' topic created, trigger comment posted, AI Agent responds
