### PR TITLE
fix: require write permission for drop trigger AI agent selection

### DIFF
--- a/engines/collavre/app/jobs/collavre/drop_trigger_job.rb
+++ b/engines/collavre/app/jobs/collavre/drop_trigger_job.rb
@@ -51,7 +51,7 @@ module Collavre
     private
 
     def find_trigger_agent(creative)
-      creative.all_shared_users(:feedback)
+      creative.all_shared_users(:write)
               .map(&:user)
               .find(&:ai_user?)
     end

--- a/engines/collavre/test/jobs/collavre/drop_trigger_job_test.rb
+++ b/engines/collavre/test/jobs/collavre/drop_trigger_job_test.rb
@@ -14,7 +14,7 @@ module Collavre
       perform_enqueued_jobs do
         @parent = Creative.create!(user: @owner, description: "Trigger Parent", data: { "trigger" => { "on_child_enter" => true } })
         @child = Creative.create!(user: @owner, description: "Dropped Child")
-        CreativeShare.create!(creative: @parent, user: @ai_bot, permission: :feedback)
+        CreativeShare.create!(creative: @parent, user: @ai_bot, permission: :write)
       end
     end
 

--- a/engines/collavre/test/models/collavre/creative_drop_trigger_test.rb
+++ b/engines/collavre/test/models/collavre/creative_drop_trigger_test.rb
@@ -19,7 +19,7 @@ module Collavre
         data: { "trigger" => { "on_child_enter" => true } }
       )
       @normal_parent = Creative.create!(user: @owner, description: "Normal Parent")
-      CreativeShare.create!(creative: @trigger_parent, user: @ai_bot, permission: :feedback)
+      CreativeShare.create!(creative: @trigger_parent, user: @ai_bot, permission: :write)
     end
 
     teardown do


### PR DESCRIPTION
Change `find_trigger_agent` to use `all_shared_users(:write)` instead of `:feedback`, ensuring only AI agents with write+ permission (write or admin) are selected to handle drop trigger events.

## Changes
- `drop_trigger_job.rb`: `:feedback` → `:write` in `find_trigger_agent`
- Tests updated to use `:write` permission for AI bot shares