### PR TITLE
fix: replace colon with em dash in drop trigger message

### DIFF
--- a/engines/collavre/config/locales/drop_trigger.en.yml
+++ b/engines/collavre/config/locales/drop_trigger.en.yml
@@ -1,6 +1,6 @@
 en:
   collavre:
     drop_trigger:
-      child_entered: "🔔 Drop Trigger: Creative '%{child_description}' (ID: %{child_id}) was added to '%{parent_description}'. Please process this creative according to this stage's purpose."
+      child_entered: "🔔 Drop Trigger — Creative '%{child_description}' (ID: %{child_id}) was added to '%{parent_description}'. Please process this creative according to this stage's purpose."
       toggle_on: "Drop Trigger enabled"
       toggle_off: "Drop Trigger disabled"

--- a/engines/collavre/config/locales/drop_trigger.ko.yml
+++ b/engines/collavre/config/locales/drop_trigger.ko.yml
@@ -1,6 +1,6 @@
 ko:
   collavre:
     drop_trigger:
-      child_entered: "🔔 드롭 트리거: 크리에이티브 '%{child_description}' (ID: %{child_id})가 '%{parent_description}'에 추가되었습니다. 이 단계의 목적에 맞게 처리해주세요."
+      child_entered: "🔔 드롭 트리거 — 크리에이티브 '%{child_description}' (ID: %{child_id})가 '%{parent_description}'에 추가되었습니다. 이 단계의 목적에 맞게 처리해주세요."
       toggle_on: "드롭 트리거 활성화됨"
       toggle_off: "드롭 트리거 비활성화됨"


### PR DESCRIPTION
Replace colon separator with em dash (—) in drop trigger i18n messages to avoid potential confusion with @mention: parsing pattern.

Before: `@Vrex: 🔔 드롭 트리거: 크리에이티브...`
After: `@Vrex: 🔔 드롭 트리거 — 크리에이티브...`