### PR TITLE
fix: show failure notice when drop trigger has no eligible AI agent

### DIFF
--- a/engines/collavre/app/jobs/collavre/drop_trigger_job.rb
+++ b/engines/collavre/app/jobs/collavre/drop_trigger_job.rb
@@ -13,7 +13,10 @@ module Collavre
       # Agent is resolved from the parent (where the trigger is configured),
       # but the work happens on the child creative's chat
       agent = find_trigger_agent(parent)
-      return unless agent
+      unless agent
+        post_trigger_failure_notice(child, parent)
+        return
+      end
 
       # Create trigger topic and comment on the CHILD creative
       topic = find_or_create_trigger_topic(child, agent)
@@ -49,6 +52,23 @@ module Collavre
     end
 
     private
+
+    def post_trigger_failure_notice(child, parent)
+      topic = child.topics.find_or_create_by!(name: "Drop Trigger") do |t|
+        t.user = child.user
+      end
+      # System message (user: nil, skip_default_user: true) — not dispatched
+      # to SystemEvents, so no AI agent will be triggered by this comment.
+      child.comments.create!(
+        content: I18n.t(
+          "collavre.drop_trigger.no_agent",
+          parent_description: parent.creative_snippet
+        ),
+        topic_id: topic.id,
+        private: false,
+        skip_default_user: true
+      )
+    end
 
     def find_trigger_agent(creative)
       creative.all_shared_users(:write)

--- a/engines/collavre/config/locales/drop_trigger.en.yml
+++ b/engines/collavre/config/locales/drop_trigger.en.yml
@@ -2,5 +2,6 @@ en:
   collavre:
     drop_trigger:
       child_entered: "🔔 Drop Trigger — Creative '%{child_description}' (ID: %{child_id}) was added to '%{parent_description}'. Please process this creative according to this stage's purpose."
+      no_agent: "⚠️ Drop Trigger failed — No AI agent with write permission found on '%{parent_description}'. Please share an AI agent with write permission to enable automatic processing."
       toggle_on: "Drop Trigger enabled"
       toggle_off: "Drop Trigger disabled"

--- a/engines/collavre/config/locales/drop_trigger.ko.yml
+++ b/engines/collavre/config/locales/drop_trigger.ko.yml
@@ -2,5 +2,6 @@ ko:
   collavre:
     drop_trigger:
       child_entered: "🔔 드롭 트리거 — 크리에이티브 '%{child_description}' (ID: %{child_id})가 '%{parent_description}'에 추가되었습니다. 이 단계의 목적에 맞게 처리해주세요."
+      no_agent: "⚠️ 드롭 트리거 실패 — '%{parent_description}'에 쓰기 권한을 가진 AI 에이전트가 없습니다. 자동 처리를 위해 AI 에이전트에 쓰기 권한을 부여해주세요."
       toggle_on: "드롭 트리거 활성화됨"
       toggle_off: "드롭 트리거 비활성화됨"

--- a/engines/collavre/test/jobs/collavre/drop_trigger_job_test.rb
+++ b/engines/collavre/test/jobs/collavre/drop_trigger_job_test.rb
@@ -56,12 +56,17 @@ module Collavre
       end
     end
 
-    test "skips when no AI agent found" do
+    test "posts failure notice when no AI agent found" do
       CreativeShare.where(creative: @parent, user: @ai_bot).destroy_all
 
-      assert_no_difference -> { Comment.count } do
+      assert_difference -> { @child.comments.count }, 1 do
         DropTriggerJob.perform_now(@parent.id, @child.id)
       end
+
+      comment = @child.comments.last
+      assert_nil comment.user_id, "Failure notice should be a system message (user_id: nil)"
+      assert_includes comment.content, "⚠️"
+      assert_includes comment.content, @parent.creative_snippet
     end
 
     test "skips when parent creative not found" do


### PR DESCRIPTION
When no AI agent with write permission is found on the parent creative, the drop trigger now posts a warning system message on the child creative's chat instead of silently failing.

## Problem
Drop trigger was silently returning when no eligible AI agent was found, leaving users unaware of why automation didn't work.

## Solution
- Post a system message (`user_id: nil`, `skip_default_user: true`) with ⚠️ warning explaining no write-permission AI agent was found
- System message is NOT dispatched to `SystemEvents::Dispatcher`, so it won't trigger any AI agent
- i18n messages added (en/ko)

## Why it won't trigger AI
1. No `SystemEvents::Dispatcher.dispatch()` call for failure notices
2. Comment has `user_id: nil` — even if dispatched, `refresh_deferred_context!` excludes nil user_id comments