### PR TITLE
fix: keep inline editor delete popup on-screen on mobile

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/popup.css
@@ -294,9 +294,11 @@
   box-shadow: var(--shadow-3);
   border-radius: var(--radius-2);
   min-width: 220px;
+  max-width: min(320px, calc(100vw - 8px));
   top: calc(100% + 4px);
   left: 0;
   transform: translateX(0);
+  box-sizing: border-box;
 }
 
 .popup-menu-right {
@@ -318,6 +320,15 @@
 }
 
 @media (max-width: 768px) {
+  .popup-menu {
+    min-width: min(220px, calc(100vw - 8px));
+    max-width: calc(100vw - 8px);
+  }
+
+  #inline-delete-popup-menu {
+    right: 0;
+    left: auto;
+  }
 
   #mobile-more-menu button,
   #mobile-more-menu a {

--- a/engines/collavre/app/assets/stylesheets/collavre/popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/popup.css
@@ -325,7 +325,7 @@
     max-width: calc(100vw - 8px);
   }
 
-  #inline-delete-popup-menu {
+  .inline-delete-popup-menu {
     right: 0;
     left: auto;
   }

--- a/engines/collavre/app/components/collavre/popup_menu_component.html.erb
+++ b/engines/collavre/app/components/collavre/popup_menu_component.html.erb
@@ -1,6 +1,6 @@
 <div class="popup-menu-wrapper" data-controller="popup-menu">
   <%= button_tag raw(button_content), button_options %>
-  <div id="<%= menu_id %>" class="popup-menu <%= 'popup-menu-right' if align.to_sym == :right %>" data-popup-menu-target="menu" data-action="click->popup-menu#menuClick">
+  <div id="<%= menu_id %>" class="<%= ['popup-menu', ('popup-menu-right' if align.to_sym == :right), menu_classes.presence].compact.join(' ') %>" data-popup-menu-target="menu" data-action="click->popup-menu#menuClick">
     <%= content %>
   </div>
 </div>

--- a/engines/collavre/app/components/collavre/popup_menu_component.rb
+++ b/engines/collavre/app/components/collavre/popup_menu_component.rb
@@ -1,14 +1,15 @@
 module Collavre
 class PopupMenuComponent < ViewComponent::Base
-  def initialize(button_content:, button_classes: "", menu_id: nil, align: :left, button_attributes: {})
+  def initialize(button_content:, button_classes: "", menu_classes: "", menu_id: nil, align: :left, button_attributes: {})
     @button_content = button_content
     @button_classes = button_classes
+    @menu_classes = menu_classes
     @menu_id = menu_id || "popup-menu-#{SecureRandom.hex(4)}"
     @align = align
     @button_attributes = button_attributes
   end
 
-  attr_reader :button_content, :button_classes, :menu_id, :align, :button_attributes
+  attr_reader :button_content, :button_classes, :menu_classes, :menu_id, :align, :button_attributes
 
   def button_options
     defaults = {

--- a/engines/collavre/app/javascript/controllers/__tests__/popup_menu_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/popup_menu_controller.test.js
@@ -1,0 +1,88 @@
+/**
+ * @jest-environment jsdom
+ */
+import { jest } from '@jest/globals'
+import { Application } from '@hotwired/stimulus'
+
+const notifyPopupOpen = jest.fn()
+const onOtherPopupOpen = jest.fn(() => () => {})
+
+jest.unstable_mockModule('../../lib/gnb_popup_manager', () => ({
+  __esModule: true,
+  notifyPopupOpen,
+  onOtherPopupOpen
+}))
+
+const { default: PopupMenuController } = await import('../popup_menu_controller')
+
+describe('PopupMenuController', () => {
+  let application
+  let container
+  let controller
+  let menu
+
+  beforeEach(async () => {
+    document.body.innerHTML = ''
+    notifyPopupOpen.mockClear()
+    onOtherPopupOpen.mockClear()
+
+    container = document.createElement('div')
+    container.innerHTML = `
+      <div data-controller="popup-menu">
+        <button type="button" data-popup-menu-target="button">Open</button>
+        <div id="test-menu" data-popup-menu-target="menu" style="display:none"></div>
+      </div>
+    `
+    document.body.appendChild(container)
+
+    application = Application.start()
+    application.register('popup-menu', PopupMenuController)
+
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    const element = container.querySelector('[data-controller="popup-menu"]')
+    controller = application.getControllerForElementAndIdentifier(element, 'popup-menu')
+    menu = container.querySelector('#test-menu')
+
+    Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 360 })
+    Object.defineProperty(window, 'innerHeight', { writable: true, configurable: true, value: 640 })
+  })
+
+  afterEach(() => {
+    application?.stop()
+    document.body.innerHTML = ''
+    jest.restoreAllMocks()
+  })
+
+  test('flips upward when there is more space above than below', async () => {
+    const rects = [
+      { top: 520, bottom: 700, left: 20, right: 220, width: 200, height: 180 },
+      { top: 336, bottom: 516, left: 20, right: 220, width: 200, height: 180 }
+    ]
+    let callCount = 0
+    jest.spyOn(menu, 'getBoundingClientRect').mockImplementation(() => rects[Math.min(callCount++, rects.length - 1)])
+
+    controller.show()
+    await new Promise(resolve => requestAnimationFrame(resolve))
+
+    expect(menu.style.bottom).toBe('calc(100% + 4px)')
+    expect(menu.style.top).toBe('auto')
+  })
+
+  test('stays below when there is more space below than above', async () => {
+    jest.spyOn(menu, 'getBoundingClientRect').mockReturnValue({
+      top: 40,
+      bottom: 220,
+      left: 20,
+      right: 220,
+      width: 200,
+      height: 180
+    })
+
+    controller.show()
+    await new Promise(resolve => requestAnimationFrame(resolve))
+
+    expect(menu.style.top).toBe('calc(100% + 4px)')
+    expect(menu.style.bottom).toBe('auto')
+  })
+})

--- a/engines/collavre/app/javascript/controllers/popup_menu_controller.js
+++ b/engines/collavre/app/javascript/controllers/popup_menu_controller.js
@@ -38,26 +38,39 @@ export default class extends Controller {
   show() {
     notifyPopupOpen(this._popupId)
     const menu = this.menuTarget
+    const viewportPadding = 4
+
     menu.style.display = 'block'
     menu.style.transform = ''
-
-    const transforms = []
-    const viewportPadding = 4
+    menu.style.maxWidth = `calc(100vw - ${viewportPadding * 2}px)`
 
     this.buttonTarget?.setAttribute('aria-expanded', 'true')
 
     requestAnimationFrame(() => {
-      const rect = menu.getBoundingClientRect()
-      if (rect.right > window.innerWidth) {
-        transforms.push(`translateX(-${rect.right - window.innerWidth + viewportPadding}px)`)
-      } else if (rect.left < 0) {
-        transforms.push(`translateX(${Math.abs(rect.left) + viewportPadding}px)`)
+      const transforms = []
+      let rect = menu.getBoundingClientRect()
+      const spaceBelow = window.innerHeight - rect.top
+      const spaceAbove = rect.bottom
+
+      if (rect.bottom > window.innerHeight && spaceAbove > spaceBelow) {
+        menu.style.top = 'auto'
+        menu.style.bottom = 'calc(100% + 4px)'
+        rect = menu.getBoundingClientRect()
+      } else {
+        menu.style.top = 'calc(100% + 4px)'
+        menu.style.bottom = 'auto'
       }
 
-      if (rect.bottom > window.innerHeight) {
+      if (rect.right > window.innerWidth - viewportPadding) {
+        transforms.push(`translateX(-${rect.right - window.innerWidth + viewportPadding}px)`)
+      } else if (rect.left < viewportPadding) {
+        transforms.push(`translateX(${viewportPadding - rect.left}px)`)
+      }
+
+      if (rect.bottom > window.innerHeight - viewportPadding) {
         transforms.push(`translateY(-${rect.bottom - window.innerHeight + viewportPadding}px)`)
-      } else if (rect.top < 0) {
-        transforms.push(`translateY(${Math.abs(rect.top) + viewportPadding}px)`)
+      } else if (rect.top < viewportPadding) {
+        transforms.push(`translateY(${viewportPadding - rect.top}px)`)
       }
 
       menu.style.transform = transforms.join(' ')

--- a/engines/collavre/app/javascript/controllers/popup_menu_controller.js
+++ b/engines/collavre/app/javascript/controllers/popup_menu_controller.js
@@ -49,8 +49,8 @@ export default class extends Controller {
     requestAnimationFrame(() => {
       const transforms = []
       let rect = menu.getBoundingClientRect()
-      const spaceBelow = window.innerHeight - rect.top
-      const spaceAbove = rect.bottom
+      const spaceBelow = window.innerHeight - rect.bottom
+      const spaceAbove = rect.top
 
       if (rect.bottom > window.innerHeight && spaceAbove > spaceBelow) {
         menu.style.top = 'auto'

--- a/engines/collavre/app/views/collavre/creatives/_inline_edit_form.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_inline_edit_form.html.erb
@@ -56,7 +56,8 @@
               button_content: inline_delete_button_content,
               button_classes: 'creative-action-btn danger-link',
               button_attributes: { id: 'inline-delete-popup-toggle' },
-              menu_id: 'inline-delete-popup-menu'
+              menu_id: 'inline-delete-popup-menu',
+              align: :right
             ) do %>
           <button type="button"
                   id="inline-archive"

--- a/engines/collavre/app/views/collavre/creatives/_inline_edit_form.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_inline_edit_form.html.erb
@@ -55,6 +55,7 @@
         <%= render Collavre::PopupMenuComponent.new(
               button_content: inline_delete_button_content,
               button_classes: 'creative-action-btn danger-link',
+              menu_classes: 'inline-delete-popup-menu',
               button_attributes: { id: 'inline-delete-popup-toggle' },
               menu_id: 'inline-delete-popup-menu',
               align: :right


### PR DESCRIPTION
## Summary
- keep the inline editor delete popup anchored within the mobile viewport
- right-align the inline delete menu and cap popup width on small screens
- flip and re-clamp popup menus when there is not enough space below or at the sides
- replace the inline delete popup's ID-specific mobile styling with a reusable menu class

## Testing
- bundle exec ruby -c engines/collavre/app/components/collavre/popup_menu_component.rb
- bundle exec ruby -c config/routes.rb
- npm test -- --runInBand engines/collavre/app/javascript/controllers/__tests__/popup_menu_controller.test.js

## Notes
- full pre-push validation in this worktree is still blocked by existing unrelated issues observed before this change:
  - some test runs fail because `application.js` is missing from the asset load path
  - existing `NotifiableTest` failures are present outside this change set