### PR TITLE
fix: warn when enabling drop trigger without eligible AI agent

### DIFF
--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -335,7 +335,10 @@ module Collavre
         render json: { error: "Invalid JSON: #{e.message}" }, status: :unprocessable_entity
         return
       end
+      previous_enabled = creative.drop_trigger_enabled?
+
       if creative.update(data: new_data)
+        notify_drop_trigger_missing_agent!(creative) if !previous_enabled && creative.drop_trigger_enabled?
         head :ok
       else
         render json: { errors: creative.errors.full_messages }, status: :unprocessable_entity
@@ -419,6 +422,21 @@ module Collavre
 
       def reorderer
         @reorderer ||= ::Creatives::Reorderer.new(user: Current.user)
+      end
+
+      def notify_drop_trigger_missing_agent!(creative)
+        return if creative.all_shared_users(:write).map(&:user).any?(&:ai_user?)
+
+        topic = creative.topics.find_or_create_by!(name: "Drop Trigger") do |t|
+          t.user = creative.user
+        end
+
+        creative.comments.create!(
+          content: t("collavre.drop_trigger.no_agent", parent_description: creative.creative_snippet),
+          topic_id: topic.id,
+          private: false,
+          skip_default_user: true
+        )
       end
 
       def enforce_creatives_login_policy

--- a/engines/collavre/test/controllers/creatives_controller_update_test.rb
+++ b/engines/collavre/test/controllers/creatives_controller_update_test.rb
@@ -37,4 +37,41 @@ class CreativesControllerUpdateTest < ActionDispatch::IntegrationTest
     # Verify the update propagated to the origin
     assert_equal 0.5, @b1_origin.reload.progress
   end
+
+  test "update_metadata posts drop trigger warning when enabling without write-permission AI agent" do
+    creative = Creative.create!(description: "Documentation", user: @user, data: {})
+    feedback_ai = users(:ai_bot)
+    CreativeShare.create!(creative: creative, user: feedback_ai, permission: :feedback)
+
+    assert_difference -> { creative.comments.count }, 1 do
+      patch update_metadata_creative_url(creative), params: {
+        data: {
+          trigger: { on_child_enter: true }
+        }.to_json
+      }
+    end
+
+    assert_response :success
+    comment = creative.comments.order(:id).last
+    assert_nil comment.user_id
+    assert_includes comment.content, "⚠️"
+    assert_includes comment.content, creative.creative_snippet
+    assert_equal "Drop Trigger", comment.topic.name
+  end
+
+  test "update_metadata does not post duplicate warning when already enabled" do
+    creative = Creative.create!(description: "Documentation", user: @user, data: { "trigger" => { "on_child_enter" => true } })
+    feedback_ai = users(:ai_bot)
+    CreativeShare.create!(creative: creative, user: feedback_ai, permission: :feedback)
+
+    assert_no_difference -> { creative.comments.count } do
+      patch update_metadata_creative_url(creative), params: {
+        data: {
+          trigger: { on_child_enter: true }
+        }.to_json
+      }
+    end
+
+    assert_response :success
+  end
 end


### PR DESCRIPTION
## Summary
- post the same system warning when Drop Trigger is enabled without any write-permission AI agent
- only post the warning on the false -> true transition
- add controller tests for warning creation and duplicate prevention

## Why
Users should get immediate feedback at enable time, not only after a child creative is dropped.