### PR TITLE
fix: harden drop trigger orchestration dispatch

### DIFF
--- a/engines/collavre/app/jobs/collavre/drop_trigger_job.rb
+++ b/engines/collavre/app/jobs/collavre/drop_trigger_job.rb
@@ -22,33 +22,16 @@ module Collavre
       topic = find_or_create_trigger_topic(child, agent)
       comment = create_trigger_comment(child, parent, agent, topic)
 
-      # Dispatch event targeting the child creative
-      SystemEvents::Dispatcher.dispatch("comment_created", {
-        "comment" => {
-          "id" => comment.id,
-          "content" => comment.content,
-          "user_id" => comment.user_id,
-          "from_ai" => false
-        },
-        "creative" => {
-          "id" => child.id,
-          "description" => child.description
-        },
-        "topic" => {
-          "id" => topic.id
-        },
-        "chat" => {
-          "content" => comment.content,
-          "mentioned_user" => {
-            "id" => agent.id,
-            "name" => agent.name
-          }
-        },
-        "drop_trigger" => {
-          "parent_id" => parent.id,
-          "parent_description" => parent.description
-        }
-      })
+      scheduled_agents = dispatch_trigger_comment(comment, child, parent)
+      return if scheduled_agents.present?
+
+      post_dispatch_failure_notice(child, parent, topic)
+    rescue StandardError => e
+      Rails.logger.error(
+        "[DropTriggerJob] Failed for parent=#{parent_creative_id} child=#{child_creative_id}: " \
+        "#{e.class} #{e.message}\n#{e.backtrace&.first(5)&.join("\n")}"
+      )
+      raise
     end
 
     private
@@ -57,17 +40,54 @@ module Collavre
       topic = child.topics.find_or_create_by!(name: "Drop Trigger") do |t|
         t.user = child.user
       end
+      post_system_notice(child, topic, I18n.t(
+        "collavre.drop_trigger.no_agent",
+        parent_description: parent.creative_snippet
+      ))
+    end
+
+    def post_dispatch_failure_notice(child, parent, topic)
+      post_system_notice(child, topic, I18n.t(
+        "collavre.drop_trigger.no_dispatch",
+        parent_description: parent.creative_snippet
+      ))
+    end
+
+    def post_system_notice(child, topic, content)
       # System message (user: nil, skip_default_user: true) — not dispatched
       # to SystemEvents, so no AI agent will be triggered by this comment.
       child.comments.create!(
-        content: I18n.t(
-          "collavre.drop_trigger.no_agent",
-          parent_description: parent.creative_snippet
-        ),
+        content: content,
         topic_id: topic.id,
         private: false,
         skip_default_user: true
       )
+    end
+
+    def dispatch_trigger_comment(comment, child, parent)
+      SystemEvents::Dispatcher.dispatch("comment_created", {
+        comment: {
+          id: comment.id,
+          content: comment.content,
+          user_id: comment.user_id,
+          from_ai: comment.user&.searchable? || false,
+          quoted_comment_id: comment.quoted_comment_id
+        }.compact,
+        creative: {
+          id: child.id,
+          description: child.description
+        },
+        topic: {
+          id: comment.topic_id
+        },
+        chat: {
+          content: comment.content
+        },
+        drop_trigger: {
+          parent_id: parent.id,
+          parent_description: parent.description
+        }
+      })
     end
 
     def find_trigger_agent(creative)

--- a/engines/collavre/config/locales/drop_trigger.en.yml
+++ b/engines/collavre/config/locales/drop_trigger.en.yml
@@ -3,5 +3,6 @@ en:
     drop_trigger:
       child_entered: "🔔 Drop Trigger — Creative '%{child_description}' (ID: %{child_id}) was added to '%{parent_description}'. Please process this creative according to this stage's purpose."
       no_agent: "⚠️ Drop Trigger failed — No AI agent with write permission found on '%{parent_description}'. Please share an AI agent with write permission to enable automatic processing."
+      no_dispatch: "⚠️ Drop Trigger failed — A trigger message was created for '%{parent_description}', but no AI agent task was scheduled. Please check orchestration settings or retry."
       toggle_on: "Drop Trigger enabled"
       toggle_off: "Drop Trigger disabled"

--- a/engines/collavre/config/locales/drop_trigger.ko.yml
+++ b/engines/collavre/config/locales/drop_trigger.ko.yml
@@ -3,5 +3,6 @@ ko:
     drop_trigger:
       child_entered: "🔔 드롭 트리거 — 크리에이티브 '%{child_description}' (ID: %{child_id})가 '%{parent_description}'에 추가되었습니다. 이 단계의 목적에 맞게 처리해주세요."
       no_agent: "⚠️ 드롭 트리거 실패 — '%{parent_description}'에 쓰기 권한을 가진 AI 에이전트가 없습니다. 자동 처리를 위해 AI 에이전트에 쓰기 권한을 부여해주세요."
+      no_dispatch: "⚠️ 드롭 트리거 실패 — '%{parent_description}'용 트리거 메시지는 생성되었지만 AI 에이전트 작업이 예약되지 않았습니다. 오케스트레이션 설정을 확인하거나 다시 시도해주세요."
       toggle_on: "드롭 트리거 활성화됨"
       toggle_off: "드롭 트리거 비활성화됨"

--- a/engines/collavre/test/jobs/collavre/drop_trigger_job_test.rb
+++ b/engines/collavre/test/jobs/collavre/drop_trigger_job_test.rb
@@ -23,9 +23,11 @@ module Collavre
     end
 
     test "creates trigger topic and comment on child creative" do
-      assert_difference -> { @child.comments.count }, 1 do
-        assert_difference -> { @child.topics.count }, 1 do
-          DropTriggerJob.perform_now(@parent.id, @child.id)
+      SystemEvents::Dispatcher.stub(:dispatch, [ @ai_bot ]) do
+        assert_difference -> { @child.comments.count }, 1 do
+          assert_difference -> { @child.topics.count }, 1 do
+            DropTriggerJob.perform_now(@parent.id, @child.id)
+          end
         end
       end
 
@@ -38,11 +40,15 @@ module Collavre
     end
 
     test "reuses existing Drop Trigger topic" do
-      DropTriggerJob.perform_now(@parent.id, @child.id)
+      SystemEvents::Dispatcher.stub(:dispatch, [ @ai_bot ]) do
+        DropTriggerJob.perform_now(@parent.id, @child.id)
+      end
       topic = @child.topics.find_by(name: "Drop Trigger")
 
-      assert_no_difference -> { @child.topics.count } do
-        DropTriggerJob.perform_now(@parent.id, @child.id)
+      SystemEvents::Dispatcher.stub(:dispatch, [ @ai_bot ]) do
+        assert_no_difference -> { @child.topics.count } do
+          DropTriggerJob.perform_now(@parent.id, @child.id)
+        end
       end
 
       assert_equal topic.id, @child.topics.find_by(name: "Drop Trigger").id
@@ -82,7 +88,9 @@ module Collavre
     end
 
     test "comment mentions the AI agent for routing" do
-      DropTriggerJob.perform_now(@parent.id, @child.id)
+      SystemEvents::Dispatcher.stub(:dispatch, [ @ai_bot ]) do
+        DropTriggerJob.perform_now(@parent.id, @child.id)
+      end
 
       comment = @child.comments.last
       assert comment.content.start_with?("@#{@ai_bot.name}:"),
@@ -92,11 +100,26 @@ module Collavre
     test "uses creative_snippet for plain text names" do
       @child.update!(description: "<p>HTML <strong>description</strong> that is very long and should be truncated</p>")
 
-      DropTriggerJob.perform_now(@parent.id, @child.id)
+      SystemEvents::Dispatcher.stub(:dispatch, [ @ai_bot ]) do
+        DropTriggerJob.perform_now(@parent.id, @child.id)
+      end
 
       comment = @child.comments.last
       refute_includes comment.content, "<p>"
       refute_includes comment.content, "<strong>"
+    end
+
+    test "posts failure notice when dispatch schedules no agent" do
+      SystemEvents::Dispatcher.stub(:dispatch, []) do
+        assert_difference -> { @child.comments.count }, 2 do
+          DropTriggerJob.perform_now(@parent.id, @child.id)
+        end
+      end
+
+      comments = @child.comments.order(:id).last(2)
+      assert_includes comments.first.content, "@#{@ai_bot.name}:"
+      assert_nil comments.last.user_id
+      assert_includes comments.last.content, "⚠️"
     end
   end
 end


### PR DESCRIPTION
## Summary\n- align drop trigger dispatch payload with the standard comment-created path\n- treat zero scheduled agents as a drop-trigger failure and post a visible system warning\n- add tests for successful dispatch and silent-orchestration failure\n\n## Why\nProduction showed cases where the drop trigger comment was created but no AI task was scheduled. This change makes the trigger path closer to the normal comment flow and prevents silent failures.