### PR TITLE
test: fix main broken ai completion notification specs

### DIFF
--- a/engines/collavre/test/models/collavre/comment/notifiable_test.rb
+++ b/engines/collavre/test/models/collavre/comment/notifiable_test.rb
@@ -15,7 +15,7 @@ module Collavre
         @topic = Topic.create!(creative: @creative, name: "test", user: @owner)
       end
 
-      test "notify_ai_completion creates inbox item for absent users" do
+      test "notify_ai_completion creates inbox comment for absent users" do
         comment = @creative.comments.create!(
           content: Comment::STREAMING_PLACEHOLDER_CONTENT,
           user: @agent,
@@ -23,13 +23,17 @@ module Collavre
         )
         comment.update!(content: "AI response complete")
 
-        assert_difference "InboxItem.count", 1 do
+        inbox = Creative.inbox_for(@owner)
+
+        assert_difference "inbox.comments.count", 1 do
           comment.notify_ai_completion
         end
 
-        inbox_item = InboxItem.last
-        assert_equal @owner, inbox_item.owner
-        assert_equal "inbox.comment_added", inbox_item.message_key
+        inbox_comment = inbox.comments.where(quoted_comment: comment).last
+        assert inbox_comment, "Expected inbox comment for owner"
+        assert_nil inbox_comment.user
+        assert_equal comment.id, inbox_comment.quoted_comment_id
+        assert_includes inbox_comment.content, "AI response complete"
       end
 
       test "notify_ai_completion sends mention notification for mentioned users" do
@@ -40,14 +44,17 @@ module Collavre
         )
         comment.update!(content: "Hello @#{@owner.name}: check this out")
 
-        # Owner is mentioned → gets mention notification (not comment_added)
-        inbox_items_before = InboxItem.count
-        comment.notify_ai_completion
-        new_items = InboxItem.where("id > ?", inbox_items_before).order(:id)
+        inbox = Creative.inbox_for(@owner)
 
-        mention_item = new_items.find { |i| i.message_key == "inbox.user_mentioned" }
-        assert mention_item, "Expected a mention notification for the owner"
-        assert_equal @owner, mention_item.owner
+        assert_difference "inbox.comments.count", 1 do
+          comment.notify_ai_completion
+        end
+
+        mention_comment = inbox.comments.where(quoted_comment: comment).last
+        assert mention_comment, "Expected a mention notification for the owner"
+        assert_nil mention_comment.user
+        assert_equal comment.id, mention_comment.quoted_comment_id
+        assert_includes mention_comment.content, @owner.name
       end
 
       test "notify_ai_completion skips present users" do
@@ -57,9 +64,10 @@ module Collavre
           topic: @topic
         )
 
+        inbox = Creative.inbox_for(@owner)
         CommentPresenceStore.add(@creative.id, @owner.id)
 
-        assert_no_difference "InboxItem.count" do
+        assert_no_difference "inbox.comments.count" do
           comment.notify_ai_completion
         end
       ensure
@@ -73,12 +81,14 @@ module Collavre
           topic: @topic
         )
 
-        assert_no_difference "InboxItem.count" do
+        inbox = Creative.inbox_for(@owner)
+
+        assert_no_difference "inbox.comments.count" do
           comment.notify_ai_completion
         end
       end
 
-      test "notify_ai_completion truncates long message content in inbox item" do
+      test "notify_ai_completion includes long message content in inbox comment" do
         long_content = "A" * 200
         comment = @creative.comments.create!(
           content: long_content,
@@ -86,11 +96,15 @@ module Collavre
           topic: @topic
         )
 
-        comment.notify_ai_completion
-        inbox_item = InboxItem.last
-        snippet = inbox_item.message_params["comment"]
-        assert snippet.length <= 100, "Expected comment to be truncated to 100 chars, got #{snippet.length}"
-        assert snippet.end_with?("..."), "Expected truncated comment to end with '...'"
+        inbox = Creative.inbox_for(@owner)
+
+        assert_difference "inbox.comments.count", 1 do
+          comment.notify_ai_completion
+        end
+
+        inbox_comment = inbox.comments.where(quoted_comment: comment).last
+        assert inbox_comment
+        assert_includes inbox_comment.content, long_content
       end
 
       test "notify_ai_completion rescues errors without raising" do


### PR DESCRIPTION
## Summary
- update AI completion notification specs to match inbox comment notifications
- assert inbox creative system comments instead of legacy InboxItem records
- cover mention, presence, non-AI, and long-content cases with current behavior

## Testing
- bin/rails test engines/collavre/test/models/collavre/comment/notifiable_test.rb
- bundle exec rake test
