### PR TITLE
fix: update inbox badge immediately for inbox notifications

### DIFF
--- a/engines/collavre/app/models/collavre/comment/notifiable.rb
+++ b/engines/collavre/app/models/collavre/comment/notifiable.rb
@@ -53,6 +53,7 @@ module Collavre
           quoted_comment: self
         )
 
+        broadcast_inbox_badge(inbox_creative, owner)
         PushNotificationJob.perform_later(owner.id, message: msg, link: inbox_comment_link)
         comment
       rescue StandardError => e
@@ -170,6 +171,21 @@ module Collavre
           "inbox.approval_requested",
           { user: user&.display_name, tool_name: parsed_action_tool_name, creative: creative_markdown_link }
         )
+      end
+
+      def broadcast_inbox_badge(inbox_creative, owner)
+        %w[desktop-inbox-badge mobile-inbox-badge].each do |target_id|
+          Turbo::StreamsChannel.broadcast_replace_to(
+            [ "inbox", owner ],
+            target: target_id,
+            partial: "inbox/badge_component/count",
+            locals: {
+              count: Collavre::Inbox::BadgeComponent.new(user: owner, creative: inbox_creative).count,
+              badge_id: target_id,
+              show_zero: false
+            }
+          )
+        end
       end
     end
   end

--- a/engines/collavre/test/models/collavre/comment/notifiable_test.rb
+++ b/engines/collavre/test/models/collavre/comment/notifiable_test.rb
@@ -25,17 +25,19 @@ module Collavre
 
         inbox = Creative.inbox_for(@owner)
 
-        assert_difference("inbox.comments.count", 1) do
+        assert_difference -> { inbox.comments.count }, 1 do
           comment.notify_ai_completion
         end
 
         inbox_comment = inbox.comments.order(:id).last
-        assert_nil inbox_comment.user
         assert_equal comment.id, inbox_comment.quoted_comment_id
+        assert_nil inbox_comment.user
         assert_includes inbox_comment.content, "AI response complete"
       end
 
       test "notify_ai_completion sends mention notification as inbox comment for mentioned users" do
+        @owner.update!(searchable: true)
+
         comment = @creative.comments.create!(
           content: Comment::STREAMING_PLACEHOLDER_CONTENT,
           user: @agent,
@@ -45,7 +47,7 @@ module Collavre
 
         inbox = Creative.inbox_for(@owner)
 
-        assert_difference("inbox.comments.count", 1) do
+        assert_difference -> { inbox.comments.count }, 1 do
           comment.notify_ai_completion
         end
 
@@ -66,7 +68,7 @@ module Collavre
         inbox = Creative.inbox_for(@owner)
         CommentPresenceStore.add(@creative.id, @owner.id)
 
-        assert_no_difference("inbox.comments.count") do
+        assert_no_difference -> { inbox.comments.count } do
           comment.notify_ai_completion
         end
       ensure
@@ -82,7 +84,7 @@ module Collavre
 
         inbox = Creative.inbox_for(@owner)
 
-        assert_no_difference("inbox.comments.count") do
+        assert_no_difference -> { inbox.comments.count } do
           comment.notify_ai_completion
         end
       end
@@ -97,7 +99,7 @@ module Collavre
 
         inbox = Creative.inbox_for(@owner)
 
-        assert_difference("inbox.comments.count", 1) do
+        assert_difference -> { inbox.comments.count }, 1 do
           comment.notify_ai_completion
         end
 
@@ -115,8 +117,7 @@ module Collavre
           topic: @topic
         )
 
-        # Stub create_inbox_item to raise an error
-        comment.stub(:create_inbox_item, ->(*_args) { raise StandardError, "test error" }) do
+        comment.stub(:create_inbox_comment, ->(*_args) { raise StandardError, "test error" }) do
           assert_nothing_raised do
             comment.notify_ai_completion
           end

--- a/engines/collavre/test/models/comment_test.rb
+++ b/engines/collavre/test/models/comment_test.rb
@@ -143,7 +143,7 @@ class CommentTest < ActiveSupport::TestCase
       end
     end
 
-    inbox_broadcasts = broadcasts.select { |payload| payload[:stream] == ["inbox", owner] }
+    inbox_broadcasts = broadcasts.select { |payload| payload[:stream] == [ "inbox", owner ] }
 
     assert inbox_broadcasts.any?, "expected inbox badge broadcast"
     assert inbox_broadcasts.any? { |payload| payload[:target] == "desktop-inbox-badge" && payload.dig(:locals, :count) == 1 }

--- a/engines/collavre/test/models/comment_test.rb
+++ b/engines/collavre/test/models/comment_test.rb
@@ -126,4 +126,28 @@ class CommentTest < ActiveSupport::TestCase
     # No inbox comments should be created for "..." placeholder from AI agent
     assert_equal initial_inbox_comment_count, inbox.comments.count
   end
+
+  test "creating an inbox notification broadcasts inbox badge immediately" do
+    creative = creatives(:tshirt)
+    commenter = users(:two)
+    owner = creative.user
+    inbox_creative = Creative.inbox_for(owner)
+
+    broadcasts = []
+
+    Turbo::StreamsChannel.stub(:broadcast_replace_to, ->(*args, **kwargs) {
+      broadcasts << { stream: args.first, target: kwargs[:target], locals: kwargs[:locals] }
+    }) do
+      perform_enqueued_jobs do
+        Comment.create!(creative: creative, user: commenter, content: "immediate inbox badge")
+      end
+    end
+
+    inbox_broadcasts = broadcasts.select { |payload| payload[:stream] == ["inbox", owner] }
+
+    assert inbox_broadcasts.any?, "expected inbox badge broadcast"
+    assert inbox_broadcasts.any? { |payload| payload[:target] == "desktop-inbox-badge" && payload.dig(:locals, :count) == 1 }
+    assert inbox_broadcasts.any? { |payload| payload[:target] == "mobile-inbox-badge" && payload.dig(:locals, :count) == 1 }
+    assert_equal 1, Collavre::Inbox::BadgeComponent.new(user: owner, creative: inbox_creative).count
+  end
 end


### PR DESCRIPTION
## Summary
- broadcast inbox badge updates immediately when inbox notification comments are created
- keep desktop and mobile inbox badges in sync
- align notification tests with the inbox comment model
- add regression coverage for immediate badge updates

## Testing
- bundle exec ruby -Itest engines/collavre/test/models/comment_test.rb
- bundle exec ruby -Itest engines/collavre/test/controllers/comment_read_pointers_controller_test.rb
- bundle exec ruby -Itest engines/collavre/test/models/collavre/comment/notifiable_test.rb
- pre-push hook (rubocop + full test suite)