### PR TITLE
fix: send image attachments in openclaw websocket mode

### DIFF
--- a/engines/collavre_openclaw/PLAN_WEBSOCKET_MIGRATION.md
+++ b/engines/collavre_openclaw/PLAN_WEBSOCKET_MIGRATION.md
@@ -93,7 +93,7 @@ class WebsocketClient
   def disconnect!
 
   # RPC methods
-  def chat_send(session_key:, message:, idempotency_key:, &on_event)
+  def chat_send(session_key:, message:, attachments: nil, idempotency_key:, &on_event)
   def chat_history(session_key:, limit: nil)
   def chat_abort(session_key:, run_id: nil)
 

--- a/engines/collavre_openclaw/app/services/collavre_openclaw/openclaw_adapter.rb
+++ b/engines/collavre_openclaw/app/services/collavre_openclaw/openclaw_adapter.rb
@@ -88,13 +88,14 @@ module CollavreOpenclaw
 
       begin
         client = ConnectionManager.instance.connection_for(@user)
-        message_text = format_message_for_ws(messages)
+        payload = build_ws_chat_payload(messages)
 
         Rails.logger.info("[CollavreOpenclaw] Sending via WebSocket (session: #{session_key})")
 
         client.chat_send(
           session_key: session_key,
-          message: message_text
+          message: payload[:message],
+          attachments: payload[:attachments]
         ) do |event|
           case event[:state]
           when "delta"
@@ -134,7 +135,18 @@ module CollavreOpenclaw
       end
     end
 
-    # Format messages for WebSocket chat.send (single message string).
+    # Build WebSocket chat.send payload.
+    #
+    # Includes the same full text context as HTTP mode plus optional base64
+    # image attachments supported by the Gateway's chat.send.attachments field.
+    def build_ws_chat_payload(messages)
+      {
+        message: format_message_for_ws(messages),
+        attachments: extract_ws_attachments(messages).presence
+      }
+    end
+
+    # Format messages for WebSocket chat.send text payload.
     #
     # Includes full context on EVERY request, matching HTTP mode behavior.
     # The Gateway's WS session may be new (no prior history), so we cannot
@@ -204,6 +216,12 @@ module CollavreOpenclaw
       Array(parts).filter_map { |part| part[:image] || part["image"] }
     end
 
+    def extract_ws_attachments(messages)
+      Array(messages).flat_map do |message|
+        extract_image_sources(message).filter_map { |source| encode_image_source_for_ws(source) }
+      end
+    end
+
     def encode_image_source(source)
       if defined?(ActiveStorage) && source.is_a?(ActiveStorage::Blob)
         data = Base64.strict_encode64(source.download)
@@ -235,6 +253,43 @@ module CollavreOpenclaw
       end
     rescue StandardError => e
       Rails.logger.warn("[CollavreOpenclaw] Failed to encode image: #{e.message}")
+      nil
+    end
+
+    def encode_image_source_for_ws(source)
+      if defined?(ActiveStorage) && source.is_a?(ActiveStorage::Blob)
+        {
+          type: "image",
+          mimeType: source.content_type,
+          fileName: source.filename.to_s,
+          content: Base64.strict_encode64(source.download)
+        }
+      elsif source.respond_to?(:download)
+        blob = source.respond_to?(:blob) ? source.blob : source
+        return nil unless blob
+
+        {
+          type: "image",
+          mimeType: blob.content_type,
+          fileName: blob.filename.to_s,
+          content: Base64.strict_encode64(blob.download)
+        }
+      elsif source.is_a?(String) && source.match?(%r{^https?://})
+        nil
+      elsif source.is_a?(String)
+        return nil unless File.exist?(source)
+
+        {
+          type: "image",
+          mimeType: Marcel::MimeType.for(Pathname.new(source)),
+          fileName: File.basename(source),
+          content: Base64.strict_encode64(File.binread(source))
+        }
+      else
+        nil
+      end
+    rescue StandardError => e
+      Rails.logger.warn("[CollavreOpenclaw] Failed to encode WS image attachment: #{e.message}")
       nil
     end
 

--- a/engines/collavre_openclaw/app/services/collavre_openclaw/websocket_client.rb
+++ b/engines/collavre_openclaw/app/services/collavre_openclaw/websocket_client.rb
@@ -152,10 +152,11 @@ module CollavreOpenclaw
     #
     # @param session_key [String]
     # @param message [String]
+    # @param attachments [Array<Hash>, nil]
     # @param idempotency_key [String]
     # @yield [Hash] chat events with :state, :text, :message keys
     # @return [String, nil] final response text
-    def chat_send(session_key:, message:, idempotency_key: nil, &block)
+    def chat_send(session_key:, message:, attachments: nil, idempotency_key: nil, &block)
       ensure_connected!
       touch_activity!
 
@@ -176,11 +177,14 @@ module CollavreOpenclaw
       rpc_request_id = SecureRandom.uuid
       @mutex.synchronize { @rpc_run_registrations[rpc_request_id] = run_queue }
 
-      response = send_rpc("chat.send", {
+      rpc_params = {
         sessionKey: session_key,
         message: message,
         idempotencyKey: idempotency_key
-      }, request_id: rpc_request_id)
+      }
+      rpc_params[:attachments] = attachments if attachments.present?
+
+      response = send_rpc("chat.send", rpc_params, request_id: rpc_request_id)
 
       # The EM thread already registered @pending_runs[actual_run_id] in
       # handle_response. Clean up the idempotency_key entry if a different

--- a/engines/collavre_openclaw/test/services/openclaw_adapter_test.rb
+++ b/engines/collavre_openclaw/test/services/openclaw_adapter_test.rb
@@ -413,6 +413,41 @@ module CollavreOpenclaw
       assert_includes result, "[Bob]: Hello"
     end
 
+    test "build_ws_chat_payload includes base64 image attachments" do
+      user = build_test_user(gateway_url: "https://test-gateway.com", email: "test@example.com")
+
+      adapter = OpenclawAdapter.new(
+        user: user,
+        system_prompt: "You are a helpful agent",
+        context: {}
+      )
+
+      blob = ActiveStorage::Blob.create_and_upload!(
+        io: StringIO.new("\x89PNG\r\n\x1a\n" + "\x00" * 100),
+        filename: "test.png",
+        content_type: "image/png"
+      )
+
+      messages = [
+        { role: "user", parts: [ { text: "Creative (id: 42):\n# My Project" } ] },
+        { role: "user", parts: [ { text: "What is this?" }, { image: blob } ] }
+      ]
+
+      result = adapter.send(:build_ws_chat_payload, messages)
+
+      assert_includes result[:message], "You are a helpful agent"
+      assert_includes result[:message], "Creative (id: 42):"
+      assert_includes result[:message], "What is this?"
+      assert_equal 1, result[:attachments].size
+      attachment = result[:attachments].first
+      assert_equal "image", attachment[:type]
+      assert_equal "image/png", attachment[:mimeType]
+      assert_equal "test.png", attachment[:fileName]
+      assert_match(/\A[A-Za-z0-9+\/=]+\z/, attachment[:content])
+    ensure
+      blob&.purge
+    end
+
     test "format_message_for_ws returns empty string for empty messages" do
       user = build_test_user(gateway_url: "https://test-gateway.com", email: "test@example.com")
 

--- a/engines/collavre_openclaw/test/services/websocket_client_test.rb
+++ b/engines/collavre_openclaw/test/services/websocket_client_test.rb
@@ -361,6 +361,37 @@ module CollavreOpenclaw
 
     # Exercises chat_send by stubbing send_rpc / ensure_connected! and
     # feeding events directly into the pending_runs queue.
+    test "chat_send includes attachments in RPC params" do
+      client = WebsocketClient.new(
+        user: mock_user(id: 1, gateway_url: "wss://gw.example", llm_api_key: "tok", email: "a@b.c")
+      )
+
+      client.define_singleton_method(:ensure_connected!) { nil }
+      client.define_singleton_method(:touch_activity!) { nil }
+
+      captured = nil
+      client.define_singleton_method(:send_rpc) do |_method, params, **_kwargs|
+        captured = params
+        run_queue = instance_variable_get(:@mutex).synchronize do
+          instance_variable_get(:@pending_runs)[params[:idempotencyKey]]
+        end
+        run_queue.push({ state: "final", text: "done", seq: 0 })
+        run_queue.push({ done: true })
+        { runId: params[:idempotencyKey] }
+      end
+
+      client.chat_send(
+        session_key: "test-session",
+        message: "Hello",
+        attachments: [ { type: "image", mimeType: "image/png", fileName: "x.png", content: "abcd" } ],
+        idempotency_key: "test-key"
+      )
+
+      assert_equal 1, captured[:attachments].size
+      assert_equal "image/png", captured[:attachments].first[:mimeType]
+      assert_equal "x.png", captured[:attachments].first[:fileName]
+    end
+
     def run_chat_send_with_events(client, events, &block)
       session_key = "test-session"
       idempotency_key = "test-key"


### PR DESCRIPTION
## Summary
- send image attachments through the OpenClaw WebSocket adapter using `chat.send.attachments`
- keep the existing full-text WS context payload and add WS attachment encoding alongside HTTP encoding
- add adapter/client tests covering WS payload building and RPC attachment forwarding

## Testing
- bundle exec ruby -Itest engines/collavre_openclaw/test/services/openclaw_adapter_test.rb
- bundle exec ruby -Itest engines/collavre_openclaw/test/services/websocket_client_test.rb
- bundle exec ruby -Itest engines/collavre_openclaw/test/services/websocket_integration_test.rb

## Notes
- full pre-push suite is currently blocked by pre-existing failures in `engines/collavre/test/models/collavre/comment/notifiable_test.rb`
- confirmed the same failures reproduce on the base worktree before this change