### PR TITLE
fix: preserve openclaw callback topic context

### DIFF
--- a/engines/collavre_openclaw/app/controllers/collavre_openclaw/callbacks_controller.rb
+++ b/engines/collavre_openclaw/app/controllers/collavre_openclaw/callbacks_controller.rb
@@ -66,6 +66,7 @@ module CollavreOpenclaw
       payload[:context][:creative_id] ||= pending.creative_id
       payload[:context][:comment_id] ||= pending.comment_id
       payload[:context][:thread_id] ||= pending.thread_id
+      payload[:context][:topic_id] ||= pending.thread_id
 
       # Merge any extra context stored in pending callback
       if pending.context.present?

--- a/engines/collavre_openclaw/app/jobs/collavre_openclaw/callback_processor_job.rb
+++ b/engines/collavre_openclaw/app/jobs/collavre_openclaw/callback_processor_job.rb
@@ -39,6 +39,8 @@ module CollavreOpenclaw
       comment_id = context[:comment_id]
       content = payload[:content] || payload[:message]
 
+      normalize_topic_context!(context)
+
       if comment_id.present?
         # Update existing comment (streaming completion)
         comment = Collavre::Comment.find_by(id: comment_id)
@@ -56,7 +58,7 @@ module CollavreOpenclaw
     def handle_proactive(payload)
       creative_id = payload[:creative_id] || payload.dig(:context, :creative_id)
       content = payload[:content] || payload[:message]
-      thread_id = payload[:thread_id] || payload.dig(:context, :thread_id)
+      thread_id = payload[:thread_id] || payload[:topic_id] || payload.dig(:context, :thread_id) || payload.dig(:context, :topic_id)
       parent_comment_id = payload[:parent_comment_id] || payload.dig(:context, :parent_comment_id)
 
       unless creative_id.present?
@@ -94,6 +96,8 @@ module CollavreOpenclaw
     end
 
     def create_ai_comment(creative_id, content, context = {})
+      normalize_topic_context!(context)
+
       creative = Collavre::Creative.find_by(id: creative_id)
       unless creative
         Rails.logger.error("[CollavreOpenclaw] Creative not found: #{creative_id}")
@@ -134,6 +138,14 @@ module CollavreOpenclaw
     rescue ActiveRecord::RecordInvalid => e
       Rails.logger.error("[CollavreOpenclaw] Failed to create comment: #{e.message}")
       nil
+    end
+
+    def normalize_topic_context!(context)
+      return unless context.is_a?(Hash)
+      return if context[:thread_id].present?
+
+      topic_id = context[:topic_id]
+      context[:thread_id] = topic_id if topic_id.present?
     end
   end
 end

--- a/engines/collavre_openclaw/test/controllers/callbacks_controller_test.rb
+++ b/engines/collavre_openclaw/test/controllers/callbacks_controller_test.rb
@@ -179,5 +179,46 @@ module CollavreOpenclaw
       creative&.destroy
       owner&.destroy
     end
+
+    test "nonce callback preserves topic when payload uses topic_id semantics downstream" do
+      owner = User.create!(
+        email: "owner-topic-test@example.com",
+        password: "password123",
+        name: "Owner Topic"
+      )
+      creative = Collavre::Creative.create!(
+        description: "Test Creative Topic",
+        user: owner
+      )
+      topic = Collavre::Topic.create!(creative: creative, user: owner, name: "Talk to Vrex")
+
+      pending = PendingCallback.create_for_request(
+        user: @user,
+        creative_id: creative.id,
+        thread_id: topic.id
+      )
+
+      body = {
+        type: "proactive",
+        nonce: pending.nonce,
+        content: "Proactive message in topic"
+      }.to_json
+
+      perform_enqueued_jobs do
+        post callback_path(user_id: @user.id),
+             params: body,
+             headers: { "Content-Type" => "application/json" }
+      end
+
+      assert_response :ok
+
+      comment = creative.comments.order(:id).last
+      assert_equal topic, comment.topic
+      assert_equal "Proactive message in topic", comment.content
+    ensure
+      Collavre::Comment.where(creative: creative).destroy_all
+      creative&.destroy
+      owner&.destroy
+    end
   end
 end

--- a/engines/collavre_openclaw/test/jobs/callback_processor_job_test.rb
+++ b/engines/collavre_openclaw/test/jobs/callback_processor_job_test.rb
@@ -100,6 +100,39 @@ module CollavreOpenclaw
       assert_equal "Proactive message via context", comment.content
     end
 
+    test "creates comment in topic when proactive payload uses topic_id" do
+      topic = Collavre::Topic.create!(creative: @creative, user: @owner, name: "Talk to Vrex")
+
+      before_count = @creative.comments.count
+      CallbackProcessorJob.perform_now(@user.id, {
+        "type" => "proactive",
+        "creative_id" => @creative.id,
+        "topic_id" => topic.id,
+        "content" => "Topic scoped proactive message"
+      })
+
+      assert_equal before_count + 1, @creative.comments.reload.count
+      comment = @creative.comments.order(:id).last
+      assert_equal topic, comment.topic
+      assert_equal "Topic scoped proactive message", comment.content
+    end
+
+    test "creates response comment in topic when context uses topic_id" do
+      topic = Collavre::Topic.create!(creative: @creative, user: @owner, name: "Talk to Vrex")
+
+      before_count = @creative.comments.count
+      CallbackProcessorJob.perform_now(@user.id, {
+        "type" => "response",
+        "content" => "Async response in topic",
+        "context" => { "creative_id" => @creative.id, "topic_id" => topic.id }
+      })
+
+      assert_equal before_count + 1, @creative.comments.reload.count
+      comment = @creative.comments.order(:id).last
+      assert_equal topic, comment.topic
+      assert_equal "Async response in topic", comment.content
+    end
+
     test "proactive message without creative_id logs error" do
       before_count = Collavre::Comment.count
       CallbackProcessorJob.perform_now(@user.id, {


### PR DESCRIPTION
## Summary
- preserve callback topic context when pending callback state is merged
- normalize `topic_id` callback payloads onto the existing thread/topic context flow
- add regression coverage for callback and proactive message topic retention

## Testing
- bundle exec rails test engines/collavre_openclaw/test/jobs/callback_processor_job_test.rb engines/collavre_openclaw/test/controllers/callbacks_controller_test.rb