### PR TITLE
fix: prevent inbox open autofocus

### DIFF
--- a/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_review.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_review.test.js
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 
+import { jest } from '@jest/globals'
 import { Application } from '@hotwired/stimulus'
 import FormController from '../form_controller'
 
@@ -11,6 +12,17 @@ describe('FormController - Review Quote Chips', () => {
   let controller
 
   beforeEach(async () => {
+    if (!global.DataTransfer) {
+      global.DataTransfer = class {
+        constructor() {
+          this.files = []
+          this.items = {
+            add: (file) => this.files.push(file),
+          }
+        }
+      }
+    }
+
     container = document.createElement('div')
     container.innerHTML = `
       <div id="comments-popup"
@@ -62,6 +74,20 @@ describe('FormController - Review Quote Chips', () => {
   // Helper accessors for the refactored store-based API
   const getQuotes = (ctrl) => ctrl._reviewStore.quotes
   const getActiveId = (ctrl) => ctrl._reviewStore.activeId
+
+  describe('auto focus on open', () => {
+    test('skips initial focus when popup opts out', () => {
+      container.querySelector('#comments-popup').dataset.autoFocusOnOpen = 'false'
+      const resetFormSpy = jest.spyOn(controller, 'resetForm').mockImplementation(() => {})
+      const focusSpy = jest.spyOn(controller.textareaTarget, 'focus').mockImplementation(() => {})
+
+      controller.onPopupOpened({ creativeId: '123', canComment: true })
+
+      expect(focusSpy).not.toHaveBeenCalled()
+      focusSpy.mockRestore()
+      resetFormSpy.mockRestore()
+    })
+  })
 
   describe('appendReviewQuote', () => {
     test('adds a review quote chip', () => {

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/popup_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/popup_controller.test.js
@@ -86,4 +86,15 @@ describe('CommentsPopupController', () => {
         expect(popup.style.display).toBe('none')
         expect(popup.dataset.resized).toBeUndefined()
     })
+
+    test('inherits auto-focus preference from trigger button', async () => {
+        const triggerBtn = document.getElementById('trigger-btn')
+        const popup = document.getElementById('comments-popup')
+
+        triggerBtn.dataset.autoFocusOnOpen = 'false'
+
+        await controller.open(triggerBtn)
+
+        expect(popup.dataset.autoFocusOnOpen).toBe('false')
+    })
 })

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/popup_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/popup_controller.test.js
@@ -97,4 +97,17 @@ describe('CommentsPopupController', () => {
 
         expect(popup.dataset.autoFocusOnOpen).toBe('false')
     })
+
+    test('openForCreative resets auto-focus preference to default', async () => {
+        const triggerBtn = document.getElementById('trigger-btn')
+        const popup = document.getElementById('comments-popup')
+
+        triggerBtn.dataset.autoFocusOnOpen = 'false'
+        await controller.open(triggerBtn)
+        expect(popup.dataset.autoFocusOnOpen).toBe('false')
+
+        await controller.openForCreative()
+
+        expect(popup.dataset.autoFocusOnOpen).toBe('true')
+    })
 })

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -134,7 +134,7 @@ export default class extends Controller {
     this.element.dataset.creativeId = creativeId || ''
     this.formTarget.style.display = canComment ? '' : 'none'
     this.resetForm()
-    if (canComment) {
+    if (canComment && this.shouldAutoFocusOnOpen()) {
       requestAnimationFrame(() => this.textareaTarget.focus())
     }
   }
@@ -146,6 +146,10 @@ export default class extends Controller {
 
   onSelectionChanged({ size, moving }) {
     // Selection state now managed by list_controller action bar
+  }
+
+  shouldAutoFocusOnOpen() {
+    return this.element.dataset.autoFocusOnOpen !== 'false'
   }
 
   focusTextarea() {

--- a/engines/collavre/app/javascript/controllers/comments/list_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/list_controller.js
@@ -182,7 +182,9 @@ export default class extends Controller {
       }
 
       this.initialLoadComplete = true
-      this.formController?.focusTextarea()
+      if (this.formController?.shouldAutoFocusOnOpen()) {
+        this.formController.focusTextarea()
+      }
       this.markCommentsRead()
 
     })

--- a/engines/collavre/app/javascript/controllers/comments/popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_controller.js
@@ -209,6 +209,7 @@ export default class extends Controller {
 
     this.element.dataset.creativeId = resolvedCreativeId || ''
     this.element.dataset.canComment = canComment ? 'true' : 'false'
+    this.element.dataset.autoFocusOnOpen = button?.dataset.autoFocusOnOpen || 'true'
     this.titleTarget.textContent = snippet
 
     this._markChatActiveRow(resolvedCreativeId)
@@ -244,6 +245,7 @@ export default class extends Controller {
     this.currentButton = null
     this.element.dataset.creativeId = resolvedCreativeId || ''
     this.element.dataset.canComment = canComment ? 'true' : 'false'
+    this.element.dataset.autoFocusOnOpen ||= 'true'
     this.titleTarget.textContent = snippet
 
     this._markChatActiveRow(resolvedCreativeId)

--- a/engines/collavre/app/javascript/controllers/comments/popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_controller.js
@@ -245,7 +245,7 @@ export default class extends Controller {
     this.currentButton = null
     this.element.dataset.creativeId = resolvedCreativeId || ''
     this.element.dataset.canComment = canComment ? 'true' : 'false'
-    this.element.dataset.autoFocusOnOpen ||= 'true'
+    this.element.dataset.autoFocusOnOpen = 'true'
     this.titleTarget.textContent = snippet
 
     this._markChatActiveRow(resolvedCreativeId)

--- a/engines/collavre/app/views/collavre/shared/navigation/_inbox_button.html.erb
+++ b/engines/collavre/app/views/collavre/shared/navigation/_inbox_button.html.erb
@@ -5,6 +5,7 @@
           type="button"
           data-creative-id="<%= inbox.id %>"
           data-can-comment="true"
+          data-auto-focus-on-open="false"
           data-creative-snippet="<%= inbox.creative_snippet %>"
           name="show-comments-btn"><%= t('app.inbox') %><%= render Collavre::Inbox::BadgeComponent.new(
             creative: inbox,

--- a/engines/collavre/app/views/collavre/shared/navigation/_mobile_inbox_button.html.erb
+++ b/engines/collavre/app/views/collavre/shared/navigation/_mobile_inbox_button.html.erb
@@ -4,6 +4,7 @@
           type="button"
           data-creative-id="<%= inbox.id %>"
           data-can-comment="true"
+          data-auto-focus-on-open="false"
           data-creative-snippet="<%= inbox.creative_snippet %>"
           name="show-comments-btn"><%= t('app.inbox') %><%= render Collavre::Inbox::BadgeComponent.new(
             creative: inbox,


### PR DESCRIPTION
## Summary
- prevent the inbox comment form from auto-focusing when opening inbox
- keep existing auto-focus behavior for other comment entry flows
- add controller test coverage for the inbox-specific open behavior

## Testing
- npm test -- --runInBand engines/collavre/app/javascript/controllers/comments/__tests__/popup_controller.test.js engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_review.test.js