### PR TITLE
fix: restore mobile sign in navigation entry

### DIFF
--- a/engines/collavre/app/views/collavre/shared/_navigation.html.erb
+++ b/engines/collavre/app/views/collavre/shared/_navigation.html.erb
@@ -26,6 +26,11 @@
     <% end %>
   </div>
 
+  <%# Mobile Help (guest entry point after removing the mobile ... menu) %>
+  <% if Current.user.nil? && (help_item = Navigation::Registry.instance.find(:help)) %>
+    <span class="mobile-only"><%= render_navigation_item(help_item, mobile: true) %></span>
+  <% end %>
+
   <%# Mobile Sign In (guest entry point after removing the mobile ... menu) %>
   <% if (sign_in_item = Navigation::Registry.instance.find(:sign_in)) && navigation_item_visible?(sign_in_item, desktop: false) %>
     <span class="mobile-only"><%= render_navigation_item(sign_in_item, mobile: true) %></span>

--- a/engines/collavre/app/views/collavre/shared/_navigation.html.erb
+++ b/engines/collavre/app/views/collavre/shared/_navigation.html.erb
@@ -26,6 +26,11 @@
     <% end %>
   </div>
 
+  <%# Mobile Sign In (guest entry point after removing the mobile ... menu) %>
+  <% if (sign_in_item = Navigation::Registry.instance.find(:sign_in)) && navigation_item_visible?(sign_in_item, desktop: false) %>
+    <span class="mobile-only"><%= render_navigation_item(sign_in_item, mobile: true) %></span>
+  <% end %>
+
   <%# Mobile Inbox (next to profile avatar) %>
   <% if (mobile_inbox_item = Navigation::Registry.instance.find(:mobile_inbox)) && navigation_item_visible?(mobile_inbox_item, desktop: false) %>
     <span class="mobile-only"><%= render_navigation_item(mobile_inbox_item, mobile: true) %></span>

--- a/engines/collavre/app/views/collavre/shared/_navigation.html.erb
+++ b/engines/collavre/app/views/collavre/shared/_navigation.html.erb
@@ -26,11 +26,6 @@
     <% end %>
   </div>
 
-  <%# Mobile Help (guest entry point after removing the mobile ... menu) %>
-  <% if Current.user.nil? && (help_item = Navigation::Registry.instance.find(:help)) %>
-    <span class="mobile-only"><%= render_navigation_item(help_item, mobile: true) %></span>
-  <% end %>
-
   <%# Mobile Sign In (guest entry point after removing the mobile ... menu) %>
   <% if (sign_in_item = Navigation::Registry.instance.find(:sign_in)) && navigation_item_visible?(sign_in_item, desktop: false) %>
     <span class="mobile-only"><%= render_navigation_item(sign_in_item, mobile: true) %></span>
@@ -44,6 +39,11 @@
   <%# User Menu %>
   <% navigation_items_for(:user).each do |item| %>
     <%= render_navigation_item_with_children(item) %>
+  <% end %>
+
+  <%# Mobile Help (guest entry point after removing the mobile ... menu) - keep at far right %>
+  <% if Current.user.nil? && (help_item = Navigation::Registry.instance.find(:help)) %>
+    <span class="mobile-only"><%= render_navigation_item(help_item, mobile: true) %></span>
   <% end %>
 </nav>
 

--- a/engines/collavre/lib/collavre/engine.rb
+++ b/engines/collavre/lib/collavre/engine.rb
@@ -204,7 +204,7 @@ module Collavre
           type: :partial,
           partial: "collavre/shared/navigation/help_button",
           priority: 170,
-          mobile: false
+          mobile: true
         )
 
         # ============================================

--- a/engines/collavre/test/helpers/navigation_helper_test.rb
+++ b/engines/collavre/test/helpers/navigation_helper_test.rb
@@ -145,7 +145,16 @@ class NavigationHelperTest < ActionView::TestCase
     assert_match(/Test Button/, html)
   end
 
-  test "navigation partial renders mobile sign in button for guests" do
+  test "navigation partial renders mobile guest help and sign in buttons" do
+    Navigation::Registry.instance.register(
+      key: :help,
+      label: "app.help",
+      type: :partial,
+      partial: "collavre/shared/navigation/help_button",
+      priority: 170,
+      mobile: true
+    )
+
     Navigation::Registry.instance.register(
       key: :sign_in,
       label: "app.sign_in",
@@ -158,6 +167,7 @@ class NavigationHelperTest < ActionView::TestCase
     render partial: "collavre/shared/navigation"
 
     assert_includes rendered, 'class="mobile-only"'
+    assert_includes rendered, 'creative-guide-link'
     assert_includes rendered, I18n.t("app.sign_in")
     assert_includes rendered, collavre.new_session_path
   end

--- a/engines/collavre/test/helpers/navigation_helper_test.rb
+++ b/engines/collavre/test/helpers/navigation_helper_test.rb
@@ -145,6 +145,23 @@ class NavigationHelperTest < ActionView::TestCase
     assert_match(/Test Button/, html)
   end
 
+  test "navigation partial renders mobile sign in button for guests" do
+    Navigation::Registry.instance.register(
+      key: :sign_in,
+      label: "app.sign_in",
+      type: :button,
+      path: -> { collavre.new_session_path },
+      priority: 160,
+      visible: -> { true }
+    )
+
+    render partial: "collavre/shared/navigation"
+
+    assert_includes rendered, 'class="mobile-only"'
+    assert_includes rendered, I18n.t("app.sign_in")
+    assert_includes rendered, collavre.new_session_path
+  end
+
   test "render_navigation_item respects html_class option" do
     Navigation::Registry.instance.register(
       key: :test,


### PR DESCRIPTION
## Summary
- restore the guest mobile sign-in entry on the home navigation
- render the mobile sign-in button directly after the mobile ... menu removal
- add a helper/view regression test to prevent the guest entry point from disappearing again

## Testing
- bundle exec ruby -Itest engines/collavre/test/helpers/navigation_helper_test.rb
