### PR TITLE
fix: preserve deep-linked topic selection in chat popup

### DIFF
--- a/engines/collavre/app/javascript/controllers/comments/__tests__/popup_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/popup_controller.test.js
@@ -3,7 +3,7 @@
  * @jest-environment jsdom
  */
 
-import { Application, Controller } from '@hotwired/stimulus'
+import { Application } from '@hotwired/stimulus'
 import CommentsPopupController from '../popup_controller'
 
 describe('CommentsPopupController', () => {
@@ -110,4 +110,5 @@ describe('CommentsPopupController', () => {
 
         expect(popup.dataset.autoFocusOnOpen).toBe('true')
     })
+
 })

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_override.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_override.test.js
@@ -2,16 +2,37 @@
  * @jest-environment jsdom
  */
 
+import { Application } from '@hotwired/stimulus'
 import TopicsController from '../topics_controller'
 
 describe('TopicsController override topic selection', () => {
+  let application
+  let container
   let controller
 
   beforeEach(() => {
-    controller = Object.create(TopicsController.prototype)
-    controller.serverLastTopicId = '533'
-    delete controller.overrideTopicId
-    window.history.replaceState({}, '', '/creatives/10544')
+    container = document.createElement('div')
+    container.innerHTML = `
+      <div id="topics" data-controller="comments--topics">
+        <div data-comments--topics-target="list"></div>
+      </div>
+    `
+    document.body.appendChild(container)
+
+    application = Application.start()
+    application.register('comments--topics', TopicsController)
+
+    return new Promise(resolve => setTimeout(resolve, 0)).then(() => {
+      const element = document.getElementById('topics')
+      controller = application.getControllerForElementAndIdentifier(element, 'comments--topics')
+      controller.serverLastTopicId = '533'
+    })
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+    application.stop()
+    window.history.replaceState({}, '', '/')
   })
 
   test('returns override topic id before saved topic id', () => {

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_override.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_override.test.js
@@ -1,0 +1,39 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import TopicsController from '../topics_controller'
+
+describe('TopicsController override topic selection', () => {
+  let controller
+
+  beforeEach(() => {
+    controller = Object.create(TopicsController.prototype)
+    controller.serverLastTopicId = '533'
+    delete controller.overrideTopicId
+    window.history.replaceState({}, '', '/creatives/10544')
+  })
+
+  test('returns override topic id before saved topic id', () => {
+    controller.setOverrideTopicId('777')
+
+    expect(controller.currentTopicId).toBe('777')
+  })
+
+  test('returns url topic id when override is absent', () => {
+    window.history.replaceState({}, '', '/creatives/10544?topic_id=888')
+
+    expect(controller.currentTopicId).toBe('888')
+  })
+
+  test('returns saved topic id when override and url topic id are absent', () => {
+    expect(controller.currentTopicId).toBe('533')
+  })
+
+  test('clearOverrideTopicId removes one-shot override', () => {
+    controller.setOverrideTopicId('777')
+    controller.clearOverrideTopicId()
+
+    expect(controller.currentTopicId).toBe('533')
+  })
+})

--- a/engines/collavre/app/javascript/controllers/comments/list_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/list_controller.js
@@ -277,6 +277,9 @@ export default class extends Controller {
           // Ideally direct controller access, but event bus is safer if decoupled.
           // Or access via popupController?
           if (this.popupController && this.popupController.topicsController) {
+            // Deep link / around_comment_id resolution from server must win over
+            // saved topic state for the current popup session.
+            this.popupController.topicsController.setOverrideTopicId(serverTopicId)
             // Update UI and local state without dispatching change event (to avoid loop)
             this.popupController.topicsController.updateSelectionUI(serverTopicId)
 

--- a/engines/collavre/app/javascript/controllers/comments/popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_controller.js
@@ -271,9 +271,7 @@ export default class extends Controller {
   }
 
   async notifyChildControllers({ creativeId, canComment, highlightId }) {
-    if (this.topicsController?.clearOverrideTopicId) {
-      this.topicsController.clearOverrideTopicId()
-    }
+    this.topicsController?.clearOverrideTopicId()
     // Pre-set creativeId on list controller BEFORE loading topics.
     // Topics loading triggers a change event that list controller handles.
     // Without this, list controller still holds the previous creative's ID

--- a/engines/collavre/app/javascript/controllers/comments/popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_controller.js
@@ -271,6 +271,9 @@ export default class extends Controller {
   }
 
   async notifyChildControllers({ creativeId, canComment, highlightId }) {
+    if (this.topicsController?.clearOverrideTopicId) {
+      this.topicsController.clearOverrideTopicId()
+    }
     // Pre-set creativeId on list controller BEFORE loading topics.
     // Topics loading triggers a change event that list controller handles.
     // Without this, list controller still holds the previous creative's ID

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -667,11 +667,23 @@ export default class extends Controller {
     }
 
     get currentTopicId() {
+        if (this.overrideTopicId !== undefined && this.overrideTopicId !== null) {
+            return this.overrideTopicId ? String(this.overrideTopicId) : ""
+        }
+
         const urlParams = new URLSearchParams(window.location.search)
         const urlTopicId = urlParams.get('topic_id')
         if (urlTopicId) return urlTopicId
 
         return this.serverLastTopicId || ""
+    }
+
+    setOverrideTopicId(id) {
+        this.overrideTopicId = id ? String(id) : ""
+    }
+
+    clearOverrideTopicId() {
+        this.overrideTopicId = undefined
     }
 
     set currentTopicId(id) {

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -666,9 +666,12 @@ export default class extends Controller {
         }
     }
 
+    // Priority: overrideTopicId (one-shot, set by deep-link) → URL topic_id → serverLastTopicId.
+    // overrideTopicId is a plain JS property (not a Stimulus value) because it is
+    // transient per popup session and should not survive connect/disconnect cycles.
     get currentTopicId() {
         if (this.overrideTopicId !== undefined && this.overrideTopicId !== null) {
-            return this.overrideTopicId ? String(this.overrideTopicId) : ""
+            return this.overrideTopicId
         }
 
         const urlParams = new URLSearchParams(window.location.search)


### PR DESCRIPTION
## Summary
- preserve the server-selected topic when opening the chat popup from a deep-linked message
- clear the temporary override when the popup is reopened so normal last-topic behavior remains intact
- add regression coverage for topic override handling in the popup/topic controllers

## Testing
- node --experimental-vm-modules ./node_modules/.bin/jest engines/collavre/app/javascript/controllers/comments/__tests__/popup_controller.test.js engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_override.test.js --runInBand