### PR TITLE
feat: refresh open chat on creative share changes

### DIFF
--- a/engines/collavre/app/channels/collavre/comments_presence_channel.rb
+++ b/engines/collavre/app/channels/collavre/comments_presence_channel.rb
@@ -1,5 +1,18 @@
 module Collavre
 class CommentsPresenceChannel < ApplicationCable::Channel
+  def self.broadcast_shares_changed(creative_id, shared_user_id:, permission: nil, action: "updated")
+    ActionCable.server.broadcast(
+      "comments_presence:#{creative_id}",
+      {
+        shares_changed: {
+          user_id: shared_user_id,
+          permission: permission,
+          action: action
+        }
+      }
+    )
+  end
+
   # Broadcast status for any currently running AI agent tasks for a creative.
   # Called when a user subscribes to ensure they see ongoing agent activity.
   def self.broadcast_running_agents(creative_id)

--- a/engines/collavre/app/channels/collavre/comments_presence_channel.rb
+++ b/engines/collavre/app/channels/collavre/comments_presence_channel.rb
@@ -1,13 +1,17 @@
 module Collavre
 class CommentsPresenceChannel < ApplicationCable::Channel
-  def self.broadcast_shares_changed(creative_id, shared_user_id:, permission: nil, action: "updated")
+  def self.broadcast_shares_changed(creative_id, shared_user_id:, permission: nil, action: "updated", has_access: nil, can_comment: nil, has_access_changed: nil, can_comment_changed: nil)
     ActionCable.server.broadcast(
       "comments_presence:#{creative_id}",
       {
         shares_changed: {
           user_id: shared_user_id,
           permission: permission,
-          action: action
+          action: action,
+          has_access: has_access,
+          can_comment: can_comment,
+          has_access_changed: has_access_changed,
+          can_comment_changed: can_comment_changed
         }
       }
     )

--- a/engines/collavre/app/controllers/collavre/comments_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comments_controller.rb
@@ -291,7 +291,9 @@ module Collavre
       end
       render json: {
         users: user_data,
-        can_share: @creative.has_permission?(Current.user, :admin)
+        can_share: @creative.has_permission?(Current.user, :admin),
+        can_comment: @creative.has_permission?(Current.user, :feedback),
+        has_access: @creative.has_permission?(Current.user, :read)
       }
     end
 

--- a/engines/collavre/app/controllers/collavre/comments_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comments_controller.rb
@@ -276,7 +276,7 @@ module Collavre
     end
 
     def participants
-      users = [ @creative.user ].compact + @creative.all_shared_users(:read).map(&:user)
+      users = [ @creative.user ].compact + @creative.all_shared_users(:feedback).map(&:user)
       users = users.uniq
       user_data = users.map do |u|
         {

--- a/engines/collavre/app/controllers/collavre/comments_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comments_controller.rb
@@ -276,7 +276,7 @@ module Collavre
     end
 
     def participants
-      users = [ @creative.user ].compact + @creative.all_shared_users(:feedback).map(&:user)
+      users = [ @creative.user ].compact + @creative.all_shared_users(:read).map(&:user)
       users = users.uniq
       user_data = users.map do |u|
         {

--- a/engines/collavre/app/controllers/collavre/comments_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comments_controller.rb
@@ -289,6 +289,10 @@ module Collavre
           ai_user: u.ai_user?
         }
       end
+      response.headers["Cache-Control"] = "no-store"
+      response.headers["Pragma"] = "no-cache"
+      response.headers["Expires"] = "0"
+
       render json: {
         users: user_data,
         can_share: @creative.has_permission?(Current.user, :admin),

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/presence_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/presence_controller.test.js
@@ -1,0 +1,123 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { jest } from '@jest/globals'
+import { Application } from '@hotwired/stimulus'
+import PresenceController from '../presence_controller'
+
+describe('CommentsPresenceController', () => {
+  let application
+  let container
+  let controller
+
+  beforeEach(async () => {
+    document.body.dataset.currentUserId = '7'
+    global.fetch = jest.fn()
+    global.alert = jest.fn()
+
+    container = document.createElement('div')
+    container.innerHTML = `
+      <div id="comments-popup"
+           data-controller="comments--presence"
+           data-no-permission-text="No permission">
+        <div data-comments--presence-target="participants"></div>
+        <div data-comments--presence-target="typingIndicator"></div>
+        <textarea data-comments--presence-target="textarea"></textarea>
+        <input type="checkbox" data-comments--presence-target="privateCheckbox" />
+      </div>
+    `
+    document.body.appendChild(container)
+
+    application = Application.start()
+    application.register('comments--presence', PresenceController)
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    const el = document.getElementById('comments-popup')
+    controller = application.getControllerForElementAndIdentifier(el, 'comments--presence')
+    controller.creativeId = '123'
+  })
+
+  afterEach(() => {
+    application.stop()
+    document.body.innerHTML = ''
+    delete document.body.dataset.currentUserId
+    jest.restoreAllMocks()
+  })
+
+  test('hides comment input immediately when affected user loses comment permission', () => {
+    const loadParticipantsSpy = jest.spyOn(controller, 'loadParticipants').mockImplementation(() => {})
+    const setCommentPermission = jest.fn()
+    const close = jest.fn()
+
+    jest.spyOn(controller, 'formController', 'get').mockReturnValue({ setCommentPermission })
+    jest.spyOn(controller, 'popupController', 'get').mockReturnValue({ close })
+    jest.spyOn(controller, 'listController', 'get').mockReturnValue({ loadInitialComments: jest.fn() })
+
+    controller.handlePresenceMessage({
+      shares_changed: {
+        user_id: 7,
+        has_access: true,
+        can_comment: false,
+        has_access_changed: false,
+        can_comment_changed: true,
+      },
+    })
+
+    expect(setCommentPermission).toHaveBeenCalledWith(false)
+    expect(loadParticipantsSpy).toHaveBeenCalledWith({ closeOnForbidden: false })
+    expect(close).not.toHaveBeenCalled()
+  })
+
+  test('closes popup when affected user loses access', async () => {
+    const close = jest.fn()
+    jest.spyOn(controller, 'popupController', 'get').mockReturnValue({ close })
+    jest.spyOn(controller, 'formController', 'get').mockReturnValue({ setCommentPermission: jest.fn() })
+
+    global.fetch.mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: 'No permission' }),
+    })
+
+    controller.handlePresenceMessage({
+      shares_changed: {
+        user_id: 7,
+        has_access: false,
+        can_comment: false,
+        has_access_changed: true,
+        can_comment_changed: true,
+      },
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(global.alert).toHaveBeenCalledWith('No permission')
+    expect(close).toHaveBeenCalled()
+  })
+
+  test('keeps popup open for unaffected users and only refreshes participants', () => {
+    const loadParticipantsSpy = jest.spyOn(controller, 'loadParticipants').mockImplementation(() => {})
+    const close = jest.fn()
+    const setCommentPermission = jest.fn()
+    const loadInitialComments = jest.fn()
+
+    jest.spyOn(controller, 'popupController', 'get').mockReturnValue({ close })
+    jest.spyOn(controller, 'formController', 'get').mockReturnValue({ setCommentPermission })
+    jest.spyOn(controller, 'listController', 'get').mockReturnValue({ loadInitialComments })
+
+    controller.handlePresenceMessage({
+      shares_changed: {
+        user_id: 99,
+        has_access: true,
+        can_comment: true,
+        has_access_changed: false,
+        can_comment_changed: false,
+      },
+    })
+
+    expect(loadParticipantsSpy).toHaveBeenCalledWith()
+    expect(setCommentPermission).not.toHaveBeenCalled()
+    expect(loadInitialComments).not.toHaveBeenCalled()
+    expect(close).not.toHaveBeenCalled()
+  })
+})

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -144,6 +144,18 @@ export default class extends Controller {
     this.resetForm()
   }
 
+  setCommentPermission(canComment) {
+    this.formTarget.style.display = canComment ? '' : 'none'
+
+    if (!canComment) {
+      this.stopSpeechRecognition()
+      this.resetForm()
+      return
+    }
+
+    requestAnimationFrame(() => this.textareaTarget.focus())
+  }
+
   onSelectionChanged({ size, moving }) {
     // Selection state now managed by list_controller action bar
   }

--- a/engines/collavre/app/javascript/controllers/comments/list_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/list_controller.js
@@ -185,6 +185,8 @@ export default class extends Controller {
       this.formController?.focusTextarea()
       this.markCommentsRead()
 
+    }).catch((error) => {
+      this.listTarget.innerHTML = `<div class="comments-list-error">${error.message}</div>`
     })
   }
 
@@ -253,10 +255,21 @@ export default class extends Controller {
     if (this.currentTopicId) {
       urlParams.set('topic_id', this.currentTopicId)
     }
-    return fetch(`/creatives/${this.creativeId}/comments?${urlParams.toString()}`).then((response) => {
+    return fetch(`/creatives/${this.creativeId}/comments?${urlParams.toString()}`).then(async (response) => {
       // Keep the CSRF meta tag in sync with the session cookie.
       // This is critical after the browser returns from a background/frozen state.
       updateCsrfTokenFromResponse(response)
+
+      if (!response.ok) {
+        let errorMessage = this.element.dataset.noPermissionText || 'No permission'
+        try {
+          const payload = await response.json()
+          errorMessage = payload.error || errorMessage
+        } catch (_error) {
+          // Ignore non-JSON error bodies and keep fallback text.
+        }
+        throw new Error(errorMessage)
+      }
 
       const serverTopicId = response.headers.get("X-Topic-Id")
       if (serverTopicId !== null && serverTopicId !== undefined) {

--- a/engines/collavre/app/javascript/controllers/comments/presence_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/presence_controller.js
@@ -182,7 +182,10 @@ export default class extends Controller {
     if (data.shares_changed) {
       const affectedCurrentUser = this.currentUserId && String(data.shares_changed.user_id) === String(this.currentUserId)
       this.loadParticipants({ closeOnForbidden: affectedCurrentUser })
-      this.listController?.loadInitialComments()
+
+      if (affectedCurrentUser) {
+        this.listController?.loadInitialComments()
+      }
     }
     if (data.agent_status) {
       const { id, name, status, creative_id: agentCreativeId } = data.agent_status

--- a/engines/collavre/app/javascript/controllers/comments/presence_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/presence_controller.js
@@ -99,7 +99,10 @@ export default class extends Controller {
 
   loadParticipants({ closeOnForbidden = false } = {}) {
     if (!this.creativeId) return
-    fetch(`/creatives/${this.creativeId}/comments/participants`)
+    fetch(`/creatives/${this.creativeId}/comments/participants`, {
+      cache: 'no-store',
+      headers: { Accept: 'application/json' },
+    })
       .then(async (response) => {
         if (!response.ok) {
           const payload = await response.json().catch(() => ({}))

--- a/engines/collavre/app/javascript/controllers/comments/presence_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/presence_controller.js
@@ -180,12 +180,20 @@ export default class extends Controller {
       this.renderTypingIndicator()
     }
     if (data.shares_changed) {
-      const affectedCurrentUser = this.currentUserId && String(data.shares_changed.user_id) === String(this.currentUserId)
-      this.loadParticipants({ closeOnForbidden: affectedCurrentUser })
+      const shareChange = data.shares_changed
+      const affectedCurrentUser = this.currentUserId && String(shareChange.user_id) === String(this.currentUserId)
 
-      if (affectedCurrentUser) {
-        this.listController?.loadInitialComments()
+      if (!affectedCurrentUser) {
+        this.loadParticipants()
+        return
       }
+
+      if (shareChange.can_comment_changed && typeof shareChange.can_comment === 'boolean') {
+        this.formController?.setCommentPermission(shareChange.can_comment)
+      }
+
+      this.loadParticipants({ closeOnForbidden: shareChange.has_access === false })
+      return
     }
     if (data.agent_status) {
       const { id, name, status, creative_id: agentCreativeId } = data.agent_status

--- a/engines/collavre/app/javascript/controllers/comments/presence_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/presence_controller.js
@@ -18,6 +18,7 @@ export default class extends Controller {
     this.presenceSubscription = null
     this.typingTimeoutHandle = null
     this.hasPresenceConnected = false
+    this.currentUserId = document.body.dataset.currentUserId
 
     this.handleInput = this.handleInput.bind(this)
     this.handleFocus = this.handleFocus.bind(this)
@@ -38,6 +39,14 @@ export default class extends Controller {
 
   get listController() {
     return this.application.getControllerForElementAndIdentifier(this.element, 'comments--list')
+  }
+
+  get formController() {
+    return this.application.getControllerForElementAndIdentifier(this.element, 'comments--form')
+  }
+
+  get popupController() {
+    return this.application.getControllerForElementAndIdentifier(this.element, 'comments--popup')
   }
 
   onPopupOpened({ creativeId }) {
@@ -88,15 +97,33 @@ export default class extends Controller {
     }
   }
 
-  loadParticipants() {
+  loadParticipants({ closeOnForbidden = false } = {}) {
     if (!this.creativeId) return
     fetch(`/creatives/${this.creativeId}/comments/participants`)
-      .then((response) => response.json())
+      .then(async (response) => {
+        if (!response.ok) {
+          const payload = await response.json().catch(() => ({}))
+          throw new Error(payload.error || this.element.dataset.noPermissionText || 'No permission')
+        }
+        return response.json()
+      })
       .then((data) => {
         this.participantsData = data.users
         this.canShare = data.can_share
+        this.formController?.setCommentPermission(data.can_comment)
         this.renderParticipants(this.currentPresentIds)
         this.renderTypingIndicator()
+      })
+      .catch((error) => {
+        this.participantsData = []
+        this.canShare = false
+        this.renderParticipants([])
+        this.renderTypingIndicator()
+
+        if (closeOnForbidden) {
+          alert(error.message)
+          this.popupController?.close()
+        }
       })
   }
 
@@ -151,6 +178,11 @@ export default class extends Controller {
         delete this.typingTimers[id]
       }
       this.renderTypingIndicator()
+    }
+    if (data.shares_changed) {
+      const affectedCurrentUser = this.currentUserId && String(data.shares_changed.user_id) === String(this.currentUserId)
+      this.loadParticipants({ closeOnForbidden: affectedCurrentUser })
+      this.listController?.loadInitialComments()
     }
     if (data.agent_status) {
       const { id, name, status, creative_id: agentCreativeId } = data.agent_status

--- a/engines/collavre/app/models/collavre/creative_share.rb
+++ b/engines/collavre/app/models/collavre/creative_share.rb
@@ -25,7 +25,9 @@ module Collavre
     after_destroy :touch_creative_subtree
 
     after_commit :propagate_cache, on: [ :create, :update ]
+    after_commit :broadcast_share_change, on: [ :create, :update ]
     after_destroy_commit :remove_cache
+    after_destroy_commit :broadcast_share_destroy
 
     # Given ancestor_ids and ancestor_shares, returns the closest CreativeShare
     # in the ancestors. If there is no ancestor share, returns nil.
@@ -116,6 +118,24 @@ module Collavre
         creative_share_id: id,
         creative_id: creative_id,
         user_id: user_id
+      )
+    end
+
+    def broadcast_share_change
+      CommentsPresenceChannel.broadcast_shares_changed(
+        creative.effective_origin.id,
+        shared_user_id: user_id,
+        permission: permission,
+        action: previously_new_record? ? "created" : "updated"
+      )
+    end
+
+    def broadcast_share_destroy
+      CommentsPresenceChannel.broadcast_shares_changed(
+        creative.effective_origin.id,
+        shared_user_id: user_id,
+        permission: nil,
+        action: "destroyed"
       )
     end
   end

--- a/engines/collavre/app/models/collavre/creative_share.rb
+++ b/engines/collavre/app/models/collavre/creative_share.rb
@@ -122,21 +122,41 @@ module Collavre
     end
 
     def broadcast_share_change
+      previous_permission = saved_change_to_permission? ? permission_before_last_save : nil
+
       CommentsPresenceChannel.broadcast_shares_changed(
         creative.effective_origin.id,
         shared_user_id: user_id,
         permission: permission,
-        action: previously_new_record? ? "created" : "updated"
+        action: previously_new_record? ? "created" : "updated",
+        has_access: permission_allows_access?(permission),
+        can_comment: permission_allows_comment?(permission),
+        has_access_changed: permission_allows_access?(previous_permission) != permission_allows_access?(permission),
+        can_comment_changed: permission_allows_comment?(previous_permission) != permission_allows_comment?(permission)
       )
     end
 
     def broadcast_share_destroy
+      previous_permission = permission
+
       CommentsPresenceChannel.broadcast_shares_changed(
         creative.effective_origin.id,
         shared_user_id: user_id,
         permission: nil,
-        action: "destroyed"
+        action: "destroyed",
+        has_access: false,
+        can_comment: false,
+        has_access_changed: permission_allows_access?(previous_permission),
+        can_comment_changed: permission_allows_comment?(previous_permission)
       )
+    end
+
+    def permission_allows_access?(value)
+      value.present? && value != "no_access"
+    end
+
+    def permission_allows_comment?(value)
+      value.present? && CreativeShare.permissions[value] >= CreativeShare.permissions["feedback"]
     end
   end
 end

--- a/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
@@ -46,6 +46,7 @@
      data-topic-main-text="<%= t('collavre.comments.topic_main') %>"
      data-topic-create-and-move-text="<%= t('collavre.topics.create_and_move', name: '%{name}') %>"
      data-add-participant-text="<%= t('collavre.comments.add_participant') %>"
+     data-no-permission-text="<%= t('collavre.creatives.errors.no_permission') %>"
      data-review-button-text="<%= t('collavre.comments.review_button') %>"
      data-review-feedback-placeholder="<%= t('collavre.comments.review_feedback_placeholder') %>"
      data-review-summary-placeholder="<%= t('collavre.comments.review_summary_placeholder') %>"

--- a/engines/collavre/test/controllers/comments_controller_test.rb
+++ b/engines/collavre/test/controllers/comments_controller_test.rb
@@ -908,7 +908,7 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
     assert_equal true, data["has_access"]
   end
 
-  test "participants includes read-only shared users" do
+  test "participants excludes read-only shared users" do
     other = users(:two)
     other.update!(email_verified_at: Time.current)
     grant_read_access_to_other_user(user: other, permission: :read)
@@ -917,7 +917,7 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     data = JSON.parse(response.body)
-    assert data["users"].any? { |u| u["id"] == other.id }
+    refute data["users"].any? { |u| u["id"] == other.id }
   end
 
   test "participants disables caching" do

--- a/engines/collavre/test/controllers/comments_controller_test.rb
+++ b/engines/collavre/test/controllers/comments_controller_test.rb
@@ -907,4 +907,16 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
     assert_equal true, data["can_comment"]
     assert_equal true, data["has_access"]
   end
+
+  test "participants includes read-only shared users" do
+    other = users(:two)
+    other.update!(email_verified_at: Time.current)
+    grant_read_access_to_other_user(user: other, permission: :read)
+
+    get participants_creative_comments_path(@creative), headers: { "Accept" => "application/json" }
+
+    assert_response :success
+    data = JSON.parse(response.body)
+    assert data["users"].any? { |u| u["id"] == other.id }
+  end
 end

--- a/engines/collavre/test/controllers/comments_controller_test.rb
+++ b/engines/collavre/test/controllers/comments_controller_test.rb
@@ -919,4 +919,13 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
     data = JSON.parse(response.body)
     assert data["users"].any? { |u| u["id"] == other.id }
   end
+
+  test "participants disables caching" do
+    get participants_creative_comments_path(@creative), headers: { "Accept" => "application/json" }
+
+    assert_response :success
+    assert_equal "no-store", response.headers["Cache-Control"]
+    assert_equal "no-cache", response.headers["Pragma"]
+    assert_equal "0", response.headers["Expires"]
+  end
 end

--- a/engines/collavre/test/controllers/comments_controller_test.rb
+++ b/engines/collavre/test/controllers/comments_controller_test.rb
@@ -877,17 +877,22 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
     assert_response :forbidden
   end
 
-  test "participants returns users and can_share for admin" do
+  test "participants returns permission flags for admin" do
     get participants_creative_comments_path(@creative), headers: { "Accept" => "application/json" }
     assert_response :success
     data = JSON.parse(response.body)
     assert data.key?("users"), "Response should include users array"
     assert data.key?("can_share"), "Response should include can_share flag"
+    assert data.key?("can_comment"), "Response should include can_comment flag"
+    assert data.key?("has_access"), "Response should include has_access flag"
+    assert_equal true, data["can_share"]
+    assert_equal true, data["can_comment"]
+    assert_equal true, data["has_access"]
     assert_kind_of Array, data["users"]
     assert data["users"].any? { |u| u["id"] == @user.id }
   end
 
-  test "participants returns can_share false for non-admin shared user" do
+  test "participants returns correct permission flags for non-admin shared user" do
     other = users(:two)
     other.update!(email_verified_at: Time.current)
     grant_read_access_to_other_user(user: other, permission: :feedback)
@@ -899,5 +904,7 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     data = JSON.parse(response.body)
     assert_equal false, data["can_share"]
+    assert_equal true, data["can_comment"]
+    assert_equal true, data["has_access"]
   end
 end

--- a/engines/collavre/test/models/creative_share_test.rb
+++ b/engines/collavre/test/models/creative_share_test.rb
@@ -57,4 +57,51 @@ class CreativeShareTest < ActiveSupport::TestCase
   ensure
     Current.reset
   end
+
+  test "create broadcasts share change to comments presence channel" do
+    creative = creatives(:tshirt)
+    recipient = users(:two)
+
+    broadcast_args = nil
+    CommentsPresenceChannel.stub :broadcast_shares_changed, ->(*args, **kwargs) { broadcast_args = [ args, kwargs ] } do
+      CreativeShare.create!(creative: creative, user: recipient, permission: :read)
+    end
+
+    assert_equal [ creative.effective_origin.id ], broadcast_args[0]
+    assert_equal recipient.id, broadcast_args[1][:shared_user_id]
+    assert_equal "read", broadcast_args[1][:permission]
+    assert_equal "created", broadcast_args[1][:action]
+  end
+
+  test "update broadcasts share change to comments presence channel" do
+    creative = creatives(:tshirt)
+    recipient = users(:two)
+    share = CreativeShare.create!(creative: creative, user: recipient, permission: :read)
+
+    broadcasts = []
+    CommentsPresenceChannel.stub :broadcast_shares_changed, ->(*args, **kwargs) { broadcasts << [ args, kwargs ] } do
+      share.update!(permission: :feedback)
+    end
+
+    assert_equal [ creative.effective_origin.id ], broadcasts.last[0]
+    assert_equal recipient.id, broadcasts.last[1][:shared_user_id]
+    assert_equal "feedback", broadcasts.last[1][:permission]
+    assert_equal "updated", broadcasts.last[1][:action]
+  end
+
+  test "destroy broadcasts share removal to comments presence channel" do
+    creative = creatives(:tshirt)
+    recipient = users(:two)
+    share = CreativeShare.create!(creative: creative, user: recipient, permission: :read)
+
+    broadcasts = []
+    CommentsPresenceChannel.stub :broadcast_shares_changed, ->(*args, **kwargs) { broadcasts << [ args, kwargs ] } do
+      share.destroy!
+    end
+
+    assert_equal [ creative.effective_origin.id ], broadcasts.last[0]
+    assert_equal recipient.id, broadcasts.last[1][:shared_user_id]
+    assert_nil broadcasts.last[1][:permission]
+    assert_equal "destroyed", broadcasts.last[1][:action]
+  end
 end

--- a/engines/collavre/test/models/creative_share_test.rb
+++ b/engines/collavre/test/models/creative_share_test.rb
@@ -71,6 +71,10 @@ class CreativeShareTest < ActiveSupport::TestCase
     assert_equal recipient.id, broadcast_args[1][:shared_user_id]
     assert_equal "read", broadcast_args[1][:permission]
     assert_equal "created", broadcast_args[1][:action]
+    assert_equal true, broadcast_args[1][:has_access]
+    assert_equal false, broadcast_args[1][:can_comment]
+    assert_equal true, broadcast_args[1][:has_access_changed]
+    assert_equal false, broadcast_args[1][:can_comment_changed]
   end
 
   test "update broadcasts share change to comments presence channel" do
@@ -87,6 +91,10 @@ class CreativeShareTest < ActiveSupport::TestCase
     assert_equal recipient.id, broadcasts.last[1][:shared_user_id]
     assert_equal "feedback", broadcasts.last[1][:permission]
     assert_equal "updated", broadcasts.last[1][:action]
+    assert_equal true, broadcasts.last[1][:has_access]
+    assert_equal true, broadcasts.last[1][:can_comment]
+    assert_equal false, broadcasts.last[1][:has_access_changed]
+    assert_equal true, broadcasts.last[1][:can_comment_changed]
   end
 
   test "destroy broadcasts share removal to comments presence channel" do
@@ -103,5 +111,9 @@ class CreativeShareTest < ActiveSupport::TestCase
     assert_equal recipient.id, broadcasts.last[1][:shared_user_id]
     assert_nil broadcasts.last[1][:permission]
     assert_equal "destroyed", broadcasts.last[1][:action]
+    assert_equal false, broadcasts.last[1][:has_access]
+    assert_equal false, broadcasts.last[1][:can_comment]
+    assert_equal true, broadcasts.last[1][:has_access_changed]
+    assert_equal false, broadcasts.last[1][:can_comment_changed]
   end
 end


### PR DESCRIPTION
## Summary
- broadcast creative share changes to the comments presence channel
- refresh participants and comment permissions in open chat popups in real time
- close the chat popup if the current user loses access while it is open

## Testing
- bundle exec ruby -Itest engines/collavre/test/models/creative_share_test.rb
- bundle exec ruby -Itest engines/collavre/test/channels/comments_presence_channel_test.rb
- bundle exec ruby -Itest engines/collavre/test/controllers/comments_controller_test.rb