### PR TITLE
fix: dismiss inbox badge immediately when messages are read

### DIFF
--- a/engines/collavre/app/models/collavre/comment/broadcastable.rb
+++ b/engines/collavre/app/models/collavre/comment/broadcastable.rb
@@ -75,6 +75,9 @@ module Collavre
                 show_zero: total_count.positive?
               }
             )
+
+            # Also update the global inbox badge when the creative is an inbox
+            broadcast_inbox_badge(origin, u, count: unread_count) if origin.inbox?
           end
         end
 
@@ -99,14 +102,17 @@ module Collavre
           )
 
           # Also update the global inbox badge when the creative is an inbox
-          broadcast_inbox_badge(origin, user) if origin.inbox?
+          broadcast_inbox_badge(origin, user, count: unread_count) if origin.inbox?
         end
 
         # Broadcast updated inbox badge count to the user's global inbox badge.
         # Called when inbox comments are created (via Notifiable) and when the
         # user reads their inbox (via read pointer update / presence unsubscribe).
-        def broadcast_inbox_badge(inbox_creative, owner)
-          count = Collavre::Inbox::BadgeComponent.new(user: owner, creative: inbox_creative).count
+        # Accepts an optional pre-computed count to avoid duplicate queries.
+        def broadcast_inbox_badge(inbox_creative, owner, count: nil)
+          return unless inbox_creative && owner
+
+          count ||= Collavre::Inbox::BadgeComponent.new(user: owner, creative: inbox_creative).count
 
           %w[desktop-inbox-badge mobile-inbox-badge].each do |target_id|
             Turbo::StreamsChannel.broadcast_replace_to(

--- a/engines/collavre/app/models/collavre/comment/broadcastable.rb
+++ b/engines/collavre/app/models/collavre/comment/broadcastable.rb
@@ -97,6 +97,29 @@ module Collavre
               show_zero: comments_count.positive?
             }
           )
+
+          # Also update the global inbox badge when the creative is an inbox
+          broadcast_inbox_badge(origin, user) if origin.inbox?
+        end
+
+        # Broadcast updated inbox badge count to the user's global inbox badge.
+        # Called when inbox comments are created (via Notifiable) and when the
+        # user reads their inbox (via read pointer update / presence unsubscribe).
+        def broadcast_inbox_badge(inbox_creative, owner)
+          count = Collavre::Inbox::BadgeComponent.new(user: owner, creative: inbox_creative).count
+
+          %w[desktop-inbox-badge mobile-inbox-badge].each do |target_id|
+            Turbo::StreamsChannel.broadcast_replace_to(
+              [ "inbox", owner ],
+              target: target_id,
+              partial: "inbox/badge_component/count",
+              locals: {
+                count: count,
+                badge_id: target_id,
+                show_zero: false
+              }
+            )
+          end
         end
       end
 

--- a/engines/collavre/app/models/collavre/comment/notifiable.rb
+++ b/engines/collavre/app/models/collavre/comment/notifiable.rb
@@ -53,7 +53,7 @@ module Collavre
           quoted_comment: self
         )
 
-        broadcast_inbox_badge(inbox_creative, owner)
+        Comment.broadcast_inbox_badge(inbox_creative, owner)
         PushNotificationJob.perform_later(owner.id, message: msg, link: inbox_comment_link)
         comment
       rescue StandardError => e
@@ -173,20 +173,6 @@ module Collavre
         )
       end
 
-      def broadcast_inbox_badge(inbox_creative, owner)
-        %w[desktop-inbox-badge mobile-inbox-badge].each do |target_id|
-          Turbo::StreamsChannel.broadcast_replace_to(
-            [ "inbox", owner ],
-            target: target_id,
-            partial: "inbox/badge_component/count",
-            locals: {
-              count: Collavre::Inbox::BadgeComponent.new(user: owner, creative: inbox_creative).count,
-              badge_id: target_id,
-              show_zero: false
-            }
-          )
-        end
-      end
     end
   end
 end

--- a/engines/collavre/app/models/collavre/comment/notifiable.rb
+++ b/engines/collavre/app/models/collavre/comment/notifiable.rb
@@ -172,7 +172,6 @@ module Collavre
           { user: user&.display_name, tool_name: parsed_action_tool_name, creative: creative_markdown_link }
         )
       end
-
     end
   end
 end


### PR DESCRIPTION
## Problem

The inbox badge count updates immediately when new notifications arrive (PR #1074), but does **not** disappear in real-time when the user reads their inbox messages — a page refresh is required.

## Root Cause

`broadcast_inbox_badge` was only called from `Notifiable#create_inbox_comment` when new inbox comments are created. When the user reads messages (via `CommentReadPointersController#update` or `CommentsPresenceChannel#unsubscribed`), `Comment.broadcast_badge` updates the creative's comment badge but never broadcasts to the global inbox badge targets (`desktop-inbox-badge` / `mobile-inbox-badge`).

## Solution

1. **Extracted** `broadcast_inbox_badge` from `Notifiable` (private instance method) into `Comment.broadcast_inbox_badge` (public class method in `Broadcastable`)
2. **Added inbox badge broadcast** to `broadcast_badge`: when the creative is an inbox (`origin.inbox?`), it also broadcasts the updated count to the global inbox badge via `broadcast_inbox_badge`
3. **Updated** `Notifiable#create_inbox_comment` to call the new class method

This ensures the inbox badge updates in real-time for both directions:
- ✅ Badge appears immediately when notifications arrive
- ✅ Badge disappears immediately when user reads inbox messages

## Changes

- `comment/broadcastable.rb`: Added `Comment.broadcast_inbox_badge` class method; `broadcast_badge` now calls it for inbox creatives
- `comment/notifiable.rb`: Removed duplicate private method; calls `Comment.broadcast_inbox_badge` instead