### PR TITLE
refactor: move comment dispatch from controller to model callback

### DIFF
--- a/engines/collavre/app/controllers/collavre/comments_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comments_controller.rb
@@ -180,38 +180,12 @@ module Collavre
       @comment.user = Current.user
       @comment.images.attach(image_attachments) if image_attachments.present?
       response = ::Comments::CommandProcessor.new(comment: @comment, user: Current.user).call
-      @comment.content = "#{@comment.content}\n\n#{response}" if response.present?
+      if response.present?
+        @comment.content = "#{@comment.content}\n\n#{response}"
+        @comment.skip_dispatch = true
+      end
       if @comment.save
-
-        # Dispatch system event
-        unless @comment.private? || response.present?
-          begin
-            ::SystemEvents::Dispatcher.dispatch("comment_created", {
-              comment: {
-                id: @comment.id,
-                content: @comment.content,
-                user_id: @comment.user_id,
-                from_ai: @comment.user&.searchable? || false,
-                quoted_comment_id: @comment.quoted_comment_id
-              }.compact,
-              creative: {
-                id: @creative.id,
-                description: @creative.description
-              },
-              topic: {
-                id: @comment.topic_id
-              },
-              chat: {
-                content: @comment.content
-              }
-            })
-          rescue => e
-            Rails.logger.error(
-              "[SystemEvents] Dispatch failed for comment #{@comment.id}: " \
-              "#{e.class} #{e.message}\n#{e.backtrace&.first(5)&.join("\n")}"
-            )
-          end
-        end
+        # Dispatch is handled by Comment#after_create_commit callback
         @comment = Comment.with_attached_images.includes(:comment_reactions, :comment_versions, :selected_version).find(@comment.id)
         render partial: "collavre/comments/comment", locals: { comment: @comment, current_topic_id: current_topic_context }, status: :created
       else

--- a/engines/collavre/app/jobs/collavre/compress_job.rb
+++ b/engines/collavre/app/jobs/collavre/compress_job.rb
@@ -39,7 +39,7 @@ module Collavre
 
       unless agent
         error_msg = I18n.t("collavre.comments.compress_command.no_agent")
-        creative.comments.create!(user: user, topic_id: topic_id, content: "⚠️ #{error_msg}")
+        creative.comments.create!(user: user, topic_id: topic_id, content: "⚠️ #{error_msg}", skip_dispatch: true)
         Rails.logger.error("[CompressJob] No AI agent found for creative #{creative_id}, topic #{topic_id}")
         return
       end
@@ -80,7 +80,8 @@ module Collavre
       summary_comment = creative.comments.create!(
         user: user,
         topic_id: topic_id,
-        content: summary_content
+        content: summary_content,
+        skip_dispatch: true  # system-generated summary, not user input
       )
 
       # Save snapshot for recovery before deleting originals

--- a/engines/collavre/app/jobs/collavre/cron_action_job.rb
+++ b/engines/collavre/app/jobs/collavre/cron_action_job.rb
@@ -35,10 +35,12 @@ module Collavre
         content: message,
         user: agent,
         topic_id: topic&.id,
-        private: false
+        private: false,
+        skip_dispatch: true  # manual dispatch below (AI user would skip model callback)
       )
 
       # Dispatch system event to trigger agent orchestration pipeline
+      # (manual because cron-initiated AI messages intentionally need dispatch)
       SystemEvents::Dispatcher.dispatch("comment_created", {
         comment: {
           id: comment.id,

--- a/engines/collavre/app/jobs/collavre/drop_trigger_job.rb
+++ b/engines/collavre/app/jobs/collavre/drop_trigger_job.rb
@@ -18,14 +18,17 @@ module Collavre
         return
       end
 
-      # Create trigger topic and comment on the CHILD creative
+      # Create trigger topic and comment on the CHILD creative.
+      # The comment's after_create_commit callback dispatches to orchestration
+      # automatically — same path as a normal user comment.
       topic = find_or_create_trigger_topic(child, agent)
-      comment = create_trigger_comment(child, parent, agent, topic)
 
-      scheduled_agents = dispatch_trigger_comment(comment, child, parent)
-      return if scheduled_agents.present?
+      # Idempotency: skip if a trigger comment already exists for this parent/child pair.
+      # This prevents duplicate comments when SolidQueue retries a job after
+      # after_create_commit succeeds but dispatch raises.
+      return if already_triggered?(child, parent, topic)
 
-      post_dispatch_failure_notice(child, parent, topic)
+      create_trigger_comment(child, parent, agent, topic)
     rescue StandardError => e
       Rails.logger.error(
         "[DropTriggerJob] Failed for parent=#{parent_creative_id} child=#{child_creative_id}: " \
@@ -46,13 +49,6 @@ module Collavre
       ))
     end
 
-    def post_dispatch_failure_notice(child, parent, topic)
-      post_system_notice(child, topic, I18n.t(
-        "collavre.drop_trigger.no_dispatch",
-        parent_description: parent.creative_snippet
-      ))
-    end
-
     def post_system_notice(child, topic, content)
       # System message (user: nil, skip_default_user: true) — not dispatched
       # to SystemEvents, so no AI agent will be triggered by this comment.
@@ -62,32 +58,6 @@ module Collavre
         private: false,
         skip_default_user: true
       )
-    end
-
-    def dispatch_trigger_comment(comment, child, parent)
-      SystemEvents::Dispatcher.dispatch("comment_created", {
-        comment: {
-          id: comment.id,
-          content: comment.content,
-          user_id: comment.user_id,
-          from_ai: comment.user&.searchable? || false,
-          quoted_comment_id: comment.quoted_comment_id
-        }.compact,
-        creative: {
-          id: child.id,
-          description: child.description
-        },
-        topic: {
-          id: comment.topic_id
-        },
-        chat: {
-          content: comment.content
-        },
-        drop_trigger: {
-          parent_id: parent.id,
-          parent_description: parent.description
-        }
-      })
     end
 
     def find_trigger_agent(creative)
@@ -106,6 +76,18 @@ module Collavre
       )
       topic.set_primary_agent!(agent)
       topic
+    end
+
+    def already_triggered?(child, parent, topic)
+      trigger_key = I18n.t(
+        "collavre.drop_trigger.child_entered",
+        child_description: child.creative_snippet,
+        child_id: child.id,
+        parent_description: parent.creative_snippet
+      )
+      child.comments.where(topic_id: topic.id)
+           .where("content LIKE ?", "%#{trigger_key.first(80)}%")
+           .exists?
     end
 
     def create_trigger_comment(child, parent, agent, topic)

--- a/engines/collavre/app/models/collavre/comment.rb
+++ b/engines/collavre/app/models/collavre/comment.rb
@@ -38,10 +38,12 @@ module Collavre
     include Approvable
 
     attribute :skip_default_user, :boolean, default: false
+    attribute :skip_dispatch, :boolean, default: false
 
     before_validation :use_origin_creative
     before_validation :assign_default_user, on: :create
     before_save :apply_link_previews, if: :should_apply_link_previews?
+    after_create_commit :dispatch_to_orchestration
 
     validates :content, presence: true, unless: -> { images.attached? }
     validate :creative_must_be_origin_creative
@@ -89,6 +91,41 @@ module Collavre
       scope = topic_id ? scope.where(topic_id: topic_id) : scope.where(topic_id: nil)
       task = scope.order(created_at: :desc).first
       task&.update!(status: "cancelled")
+    end
+
+    def dispatch_to_orchestration
+      return if private?
+      return if skip_default_user  # system notices should not trigger AI
+      return if skip_dispatch      # explicit opt-out (e.g., command processor responses)
+      return unless user_id        # nil user = system message
+      return if user&.ai_user?     # AI replies use A2aDispatcher, not this callback
+      return unless creative
+
+      SystemEvents::Dispatcher.dispatch("comment_created", {
+        comment: {
+          id: id,
+          content: content,
+          user_id: user_id,
+          from_ai: user&.searchable? || false,
+          quoted_comment_id: quoted_comment_id
+        }.compact,
+        creative: {
+          id: creative_id,
+          description: creative&.description
+        },
+        topic: {
+          id: topic_id
+        },
+        chat: {
+          content: content
+        }
+      })
+    rescue StandardError => e
+      Rails.logger.error(
+        "[Comment#dispatch_to_orchestration] Failed for comment #{id}: " \
+        "#{e.class} #{e.message}\n#{e.backtrace&.first(5)&.join("\n")}"
+      )
+      raise  # re-raise so calling jobs (e.g. DropTriggerJob) can retry
     end
 
     def assign_default_user

--- a/engines/collavre/app/services/collavre/ai_agent_service.rb
+++ b/engines/collavre/app/services/collavre/ai_agent_service.rb
@@ -124,7 +124,8 @@ module Collavre
       @original_comment.creative.comments.create!(
         content: Comment::STREAMING_PLACEHOLDER_CONTENT,
         user: @agent,
-        topic_id: @original_comment.topic_id
+        topic_id: @original_comment.topic_id,
+        skip_dispatch: true  # A2A routing handled by A2aDispatcher after finalization
       )
     end
 

--- a/engines/collavre/config/locales/drop_trigger.en.yml
+++ b/engines/collavre/config/locales/drop_trigger.en.yml
@@ -3,6 +3,6 @@ en:
     drop_trigger:
       child_entered: "🔔 Drop Trigger — Creative '%{child_description}' (ID: %{child_id}) was added to '%{parent_description}'. Please process this creative according to this stage's purpose."
       no_agent: "⚠️ Drop Trigger failed — No AI agent with write permission found on '%{parent_description}'. Please share an AI agent with write permission to enable automatic processing."
-      no_dispatch: "⚠️ Drop Trigger failed — A trigger message was created for '%{parent_description}', but no AI agent task was scheduled. Please check orchestration settings or retry."
+
       toggle_on: "Drop Trigger enabled"
       toggle_off: "Drop Trigger disabled"

--- a/engines/collavre/config/locales/drop_trigger.ko.yml
+++ b/engines/collavre/config/locales/drop_trigger.ko.yml
@@ -3,6 +3,6 @@ ko:
     drop_trigger:
       child_entered: "🔔 드롭 트리거 — 크리에이티브 '%{child_description}' (ID: %{child_id})가 '%{parent_description}'에 추가되었습니다. 이 단계의 목적에 맞게 처리해주세요."
       no_agent: "⚠️ 드롭 트리거 실패 — '%{parent_description}'에 쓰기 권한을 가진 AI 에이전트가 없습니다. 자동 처리를 위해 AI 에이전트에 쓰기 권한을 부여해주세요."
-      no_dispatch: "⚠️ 드롭 트리거 실패 — '%{parent_description}'용 트리거 메시지는 생성되었지만 AI 에이전트 작업이 예약되지 않았습니다. 오케스트레이션 설정을 확인하거나 다시 시도해주세요."
+
       toggle_on: "드롭 트리거 활성화됨"
       toggle_off: "드롭 트리거 비활성화됨"

--- a/engines/collavre/test/jobs/collavre/drop_trigger_job_test.rb
+++ b/engines/collavre/test/jobs/collavre/drop_trigger_job_test.rb
@@ -23,11 +23,9 @@ module Collavre
     end
 
     test "creates trigger topic and comment on child creative" do
-      SystemEvents::Dispatcher.stub(:dispatch, [ @ai_bot ]) do
-        assert_difference -> { @child.comments.count }, 1 do
-          assert_difference -> { @child.topics.count }, 1 do
-            DropTriggerJob.perform_now(@parent.id, @child.id)
-          end
+      assert_difference -> { @child.comments.count }, 1 do
+        assert_difference -> { @child.topics.count }, 1 do
+          DropTriggerJob.perform_now(@parent.id, @child.id)
         end
       end
 
@@ -39,19 +37,35 @@ module Collavre
       assert_includes comment.content, @child.creative_snippet
     end
 
-    test "reuses existing Drop Trigger topic" do
-      SystemEvents::Dispatcher.stub(:dispatch, [ @ai_bot ]) do
+    test "trigger comment dispatches via model callback" do
+      dispatched = false
+      SystemEvents::Dispatcher.stub(:dispatch, ->(*_args) { dispatched = true; [ @ai_bot ] }) do
         DropTriggerJob.perform_now(@parent.id, @child.id)
       end
+
+      assert dispatched, "Comment creation should trigger dispatch via after_create_commit"
+    end
+
+    test "reuses existing Drop Trigger topic" do
+      DropTriggerJob.perform_now(@parent.id, @child.id)
       topic = @child.topics.find_by(name: "Drop Trigger")
 
-      SystemEvents::Dispatcher.stub(:dispatch, [ @ai_bot ]) do
-        assert_no_difference -> { @child.topics.count } do
-          DropTriggerJob.perform_now(@parent.id, @child.id)
-        end
+      assert_no_difference -> { @child.topics.count } do
+        DropTriggerJob.perform_now(@parent.id, @child.id)
       end
 
       assert_equal topic.id, @child.topics.find_by(name: "Drop Trigger").id
+    end
+
+    test "skips duplicate trigger comment on retry (idempotency)" do
+      # First run creates the trigger comment
+      DropTriggerJob.perform_now(@parent.id, @child.id)
+      comment_count = @child.comments.count
+
+      # Second run (simulating SolidQueue retry) should NOT create another comment
+      assert_no_difference -> { @child.comments.count } do
+        DropTriggerJob.perform_now(@parent.id, @child.id)
+      end
     end
 
     test "skips when parent trigger is disabled" do
@@ -75,6 +89,16 @@ module Collavre
       assert_includes comment.content, @parent.creative_snippet
     end
 
+    test "failure notice does not dispatch to orchestration" do
+      CreativeShare.where(creative: @parent, user: @ai_bot).destroy_all
+      dispatched = false
+      SystemEvents::Dispatcher.stub(:dispatch, ->(*_args) { dispatched = true; [] }) do
+        DropTriggerJob.perform_now(@parent.id, @child.id)
+      end
+
+      refute dispatched, "System notice should not trigger orchestration dispatch"
+    end
+
     test "skips when parent creative not found" do
       assert_no_difference -> { Comment.count } do
         DropTriggerJob.perform_now(0, @child.id)
@@ -88,9 +112,7 @@ module Collavre
     end
 
     test "comment mentions the AI agent for routing" do
-      SystemEvents::Dispatcher.stub(:dispatch, [ @ai_bot ]) do
-        DropTriggerJob.perform_now(@parent.id, @child.id)
-      end
+      DropTriggerJob.perform_now(@parent.id, @child.id)
 
       comment = @child.comments.last
       assert comment.content.start_with?("@#{@ai_bot.name}:"),
@@ -100,26 +122,11 @@ module Collavre
     test "uses creative_snippet for plain text names" do
       @child.update!(description: "<p>HTML <strong>description</strong> that is very long and should be truncated</p>")
 
-      SystemEvents::Dispatcher.stub(:dispatch, [ @ai_bot ]) do
-        DropTriggerJob.perform_now(@parent.id, @child.id)
-      end
+      DropTriggerJob.perform_now(@parent.id, @child.id)
 
       comment = @child.comments.last
       refute_includes comment.content, "<p>"
       refute_includes comment.content, "<strong>"
-    end
-
-    test "posts failure notice when dispatch schedules no agent" do
-      SystemEvents::Dispatcher.stub(:dispatch, []) do
-        assert_difference -> { @child.comments.count }, 2 do
-          DropTriggerJob.perform_now(@parent.id, @child.id)
-        end
-      end
-
-      comments = @child.comments.order(:id).last(2)
-      assert_includes comments.first.content, "@#{@ai_bot.name}:"
-      assert_nil comments.last.user_id
-      assert_includes comments.last.content, "⚠️"
     end
   end
 end

--- a/engines/collavre/test/models/collavre/comment_dispatch_test.rb
+++ b/engines/collavre/test/models/collavre/comment_dispatch_test.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  class CommentDispatchTest < ActiveSupport::TestCase
+    setup do
+      @user = users(:one)
+      @creative = creatives(:tshirt)
+      Current.session = OpenStruct.new(user: @user)
+    end
+
+    teardown do
+      Current.reset
+    end
+
+    test "dispatches to orchestration after create" do
+      dispatched_event = nil
+      dispatched_context = nil
+
+      SystemEvents::Dispatcher.stub(:dispatch, ->(event, context) {
+        dispatched_event = event
+        dispatched_context = context
+        []
+      }) do
+        @creative.comments.create!(content: "test dispatch", user: @user)
+      end
+
+      assert_equal "comment_created", dispatched_event
+      assert_equal "test dispatch", dispatched_context.dig(:comment, :content)
+      assert_equal @creative.id, dispatched_context.dig(:creative, :id)
+    end
+
+    test "does not dispatch for private comments" do
+      dispatched = false
+      SystemEvents::Dispatcher.stub(:dispatch, ->(*_args) { dispatched = true; [] }) do
+        @creative.comments.create!(content: "private msg", user: @user, private: true)
+      end
+
+      refute dispatched, "Private comments should not dispatch"
+    end
+
+    test "does not dispatch for system notices (skip_default_user)" do
+      dispatched = false
+      SystemEvents::Dispatcher.stub(:dispatch, ->(*_args) { dispatched = true; [] }) do
+        @creative.comments.create!(content: "system notice", skip_default_user: true)
+      end
+
+      refute dispatched, "System notices should not dispatch"
+    end
+
+    test "does not dispatch when skip_dispatch is set" do
+      dispatched = false
+      SystemEvents::Dispatcher.stub(:dispatch, ->(*_args) { dispatched = true; [] }) do
+        @creative.comments.create!(content: "command response", user: @user, skip_dispatch: true)
+      end
+
+      refute dispatched, "Comments with skip_dispatch should not dispatch"
+    end
+
+    test "does not dispatch for AI user comments" do
+      ai_bot = users(:ai_bot)
+      dispatched = false
+      SystemEvents::Dispatcher.stub(:dispatch, ->(*_args) { dispatched = true; [] }) do
+        @creative.comments.create!(content: "AI reply", user: ai_bot)
+      end
+
+      refute dispatched, "AI user comments should not dispatch (A2A has its own path)"
+    end
+
+    test "does not dispatch for nil user comments" do
+      dispatched = false
+      SystemEvents::Dispatcher.stub(:dispatch, ->(*_args) { dispatched = true; [] }) do
+        @creative.comments.create!(content: "system msg", skip_default_user: true)
+      end
+
+      refute dispatched, "Nil user comments should not dispatch"
+    end
+
+    test "dispatch failure is re-raised for job retry" do
+      assert_raises(RuntimeError, "dispatch error") do
+        SystemEvents::Dispatcher.stub(:dispatch, ->(*_args) { raise "dispatch error" }) do
+          @creative.comments.create!(content: "triggers error", user: @user)
+        end
+      end
+    end
+  end
+end

--- a/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
+++ b/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
@@ -28,30 +28,12 @@ module CollavreGithub
 
       content = format_github_event(event, payload)
 
-      comment = creative.comments.create!(
+      creative.comments.create!(
         user: nil,
         content: content,
         private: false
       )
-
-      # Dispatch event for AI Agent routing
-      Collavre::SystemEvents::Dispatcher.dispatch("comment_created", {
-        comment: {
-          id: comment.id,
-          content: comment.content,
-          user_id: nil
-        },
-        creative: {
-          id: creative.id,
-          description: creative.description
-        },
-        topic: {
-          id: comment.topic_id
-        },
-        chat: {
-          content: comment.content
-        }
-      })
+      # Dispatch handled by Comment#after_create_commit (skipped for system messages with user: nil)
     end
 
     def format_github_event(event, payload)

--- a/engines/collavre_slack/app/jobs/collavre_slack/slack_inbound_message_job.rb
+++ b/engines/collavre_slack/app/jobs/collavre_slack/slack_inbound_message_job.rb
@@ -46,30 +46,11 @@ module CollavreSlack
       comment.instance_variable_set(:@from_slack, true)
 
       response = Collavre::Comments::CommandProcessor.new(comment: comment, user: user).call
-      comment.content = "#{comment.content}\n\n#{response}" if response.present?
-      comment.save!
-
-      # Dispatch system event to trigger AI agents (same as CommentsController#create)
-      # Skip dispatch for slash command messages (e.g. /topic, /calendar)
-      unless comment.private? || response.present?
-        Collavre::SystemEvents::Dispatcher.dispatch("comment_created", {
-          comment: {
-            id: comment.id,
-            content: comment.content,
-            user_id: comment.user_id
-          },
-          creative: {
-            id: creative.id,
-            description: creative.description
-          },
-          topic: {
-            id: comment.topic_id
-          },
-          chat: {
-            content: comment.content
-          }
-        })
+      if response.present?
+        comment.content = "#{comment.content}\n\n#{response}"
+        comment.skip_dispatch = true  # slash command responses should not trigger AI
       end
+      comment.save!
 
       # Create link between Slack message and comment for reaction sync
       if data[:slack_channel_link_id].present? && data[:slack_message_ts].present?

--- a/test/controllers/github/webhooks_controller_test.rb
+++ b/test/controllers/github/webhooks_controller_test.rb
@@ -55,19 +55,13 @@ class CollavreGithub::WebhooksControllerTest < ActionDispatch::IntegrationTest
     assert_includes comment.content, "webhook-user/example"
   end
 
-  test "dispatches comment_created event for AI agent routing" do
+  test "does not dispatch for system comments (user nil)" do
     body = @payload.to_json
     signature = "sha256=#{OpenSSL::HMAC.hexdigest('SHA256', @link.webhook_secret, body)}"
 
-    captured_event = nil
-    captured_context = nil
+    dispatched = false
 
-    dispatcher = ->(event_name, context) {
-      captured_event = event_name
-      captured_context = context
-    }
-
-    Collavre::SystemEvents::Dispatcher.stub :dispatch, dispatcher do
+    Collavre::SystemEvents::Dispatcher.stub :dispatch, ->(*_args) { dispatched = true } do
       post "/github/webhook",
            params: body,
            headers: {
@@ -78,10 +72,7 @@ class CollavreGithub::WebhooksControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :success
-    assert_equal "comment_created", captured_event
-    assert_not_nil captured_context[:comment]
-    assert_not_nil captured_context[:creative]
-    assert_equal @creative.effective_origin.id, captured_context[:creative][:id]
+    refute dispatched, "System comments (user: nil) should not dispatch to orchestration"
   end
 
   test "does not create comment when repository link not found" do


### PR DESCRIPTION
## Summary

Move `SystemEvents::Dispatcher.dispatch('comment_created', ...)` from `CommentsController#create` into `Comment#after_create_commit` callback.

## Problem

`DropTriggerJob` manually assembled its own dispatch payload, which could drift from the controller's payload over time. This caused intermittent dispatch failures where the trigger comment was created but no AI agent task was scheduled.

## Solution

- Add `after_create_commit :dispatch_to_orchestration` to Comment model
- Add `skip_dispatch` attribute for explicit opt-out (used by CommandProcessor, CompressJob)
- Remove manual dispatch from CommentsController (now handled by model)
- Remove `dispatch_trigger_comment` and `post_dispatch_failure_notice` from DropTriggerJob — comment creation alone triggers dispatch via the shared callback
- Add `user&.ai_user?` guard — AI agent replies skip model dispatch (A2A uses its own dispatcher)

## Dispatch skip conditions

The callback skips dispatch when:
- Comment is private
- `skip_default_user: true` (system notices)
- `skip_dispatch: true` (CommandProcessor responses, CompressJob summaries)
- `user_id` is nil (system messages)
- User is an AI agent (`user.ai_user?`) — A2A routing handled separately by `A2aDispatcher`

## Tests

- New `CommentDispatchTest` with 7 tests covering all skip conditions
- Updated `DropTriggerJobTest` to verify dispatch happens via model callback
- All 1519 tests pass (0 failures, 0 errors)