### PR TITLE
feat: prevent screen dimming while chat popup is open

### DIFF
--- a/engines/collavre/app/javascript/controllers/comments/popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_controller.js
@@ -117,6 +117,7 @@ export default class extends Controller {
   }
 
   disconnect() {
+    this._releaseWakeLock()
     this.clearPendingOpenFromUrl()
     document.removeEventListener(CREATIVE_CLICK_EVENT, this.handleCreativeClick)
     document.removeEventListener(CREATIVE_DESTROYED_EVENT, this.handleCreativeDestroyed)
@@ -374,6 +375,7 @@ export default class extends Controller {
 
     this._clearChatActiveRow()
     this._hideNavDropdown()
+    this._releaseWakeLock()
 
     this.element.style.display = 'none'
     this.element.classList.remove('open')
@@ -408,6 +410,7 @@ export default class extends Controller {
     if (this.isMobile()) {
       this.element.classList.add('open')
     }
+    this._requestWakeLock()
   }
 
   isFullscreen() {
@@ -554,6 +557,8 @@ export default class extends Controller {
   handleVisibilityChange() {
     if (!document.hidden && this.element.style.display === 'flex') {
       this.listController?.loadInitialComments()
+      // Re-acquire wake lock — released automatically when tab loses visibility
+      this._requestWakeLock()
     }
   }
 
@@ -1297,6 +1302,33 @@ export default class extends Controller {
     if (this.hasNavDropdownTarget) {
       this.navDropdownTarget.style.display = 'none'
       this.navDropdownTarget.innerHTML = ''
+    }
+  }
+
+  // ── Screen Wake Lock ──────────────────────────────────────────────
+  // Prevent the device screen from dimming/locking while the chat popup
+  // is open.  The browser automatically releases the lock when the tab
+  // loses visibility, so we re-acquire it in handleVisibilityChange().
+
+  async _requestWakeLock() {
+    if (!('wakeLock' in navigator)) return
+
+    try {
+      this._wakeLock = await navigator.wakeLock.request('screen')
+      this._wakeLock.addEventListener('release', () => {
+        this._wakeLock = null
+      })
+    } catch (err) {
+      // Wake lock request can fail (e.g. low battery, browser policy).
+      // This is non-critical — just log and continue.
+      console.debug('[chat] Wake lock request failed:', err.message)
+    }
+  }
+
+  _releaseWakeLock() {
+    if (this._wakeLock) {
+      this._wakeLock.release()
+      this._wakeLock = null
     }
   }
 }


### PR DESCRIPTION
## Summary

Use the **Screen Wake Lock API** to prevent the device screen from dimming or locking while the comments chat popup is open.

## Changes

- **`popup_controller.js`**: Added `_requestWakeLock()` / `_releaseWakeLock()` methods
  - Wake lock acquired when popup opens (`showPopup()`)
  - Wake lock released when popup closes (`close()`) or controller disconnects
  - Wake lock re-acquired on tab visibility change (browsers auto-release on tab switch)
  - Graceful degradation: if the API is unavailable or the request fails (e.g. low battery), the popup works normally

## Browser Support

- Chrome 84+, Edge 84+, Safari 16.4+, Firefox 126+
- Requires HTTPS (localhost works)

## Testing

- Rubocop: ✅ clean
- JS build: ✅ passes
- Manual: open chat popup → screen stays awake; close popup → normal dimming resumes

Closes Creative #10524