### PR TITLE
fix: make DropTriggerJob end-to-end idempotent

### DIFF
--- a/engines/collavre/app/jobs/collavre/drop_trigger_job.rb
+++ b/engines/collavre/app/jobs/collavre/drop_trigger_job.rb
@@ -4,31 +4,39 @@ module Collavre
   class DropTriggerJob < ApplicationJob
     queue_as :default
 
+    # End-to-end idempotent: safe to retry at any point.
+    #
+    # 1. Find or create trigger comment (no duplicates)
+    # 2. Check if dispatch already succeeded (Task exists)
+    # 3. Dispatch explicitly if needed (not via after_create_commit)
+    #
+    # This avoids the failure mode where:
+    #   - Comment is created (committed)
+    #   - after_create_commit dispatch fails
+    #   - Retry skips everything because comment already exists
     def perform(parent_creative_id, child_creative_id)
       parent = Creative.find_by(id: parent_creative_id)
       child = Creative.find_by(id: child_creative_id)
       return unless parent && child
       return unless parent.drop_trigger_enabled?
 
-      # Agent is resolved from the parent (where the trigger is configured),
-      # but the work happens on the child creative's chat
       agent = find_trigger_agent(parent)
       unless agent
         post_trigger_failure_notice(child, parent)
         return
       end
 
-      # Create trigger topic and comment on the CHILD creative.
-      # The comment's after_create_commit callback dispatches to orchestration
-      # automatically — same path as a normal user comment.
       topic = find_or_create_trigger_topic(child, agent)
 
-      # Idempotency: skip if a trigger comment already exists for this parent/child pair.
-      # This prevents duplicate comments when SolidQueue retries a job after
-      # after_create_commit succeeds but dispatch raises.
-      return if already_triggered?(child, parent, topic)
+      # Step 1: Find existing or create new trigger comment (idempotent)
+      comment = find_trigger_comment(child, parent, topic) ||
+                create_trigger_comment(child, parent, agent, topic)
 
-      create_trigger_comment(child, parent, agent, topic)
+      # Step 2: Skip if dispatch already produced a Task for this comment
+      return if task_exists_for?(comment)
+
+      # Step 3: Dispatch explicitly
+      dispatch_trigger(comment)
     rescue StandardError => e
       Rails.logger.error(
         "[DropTriggerJob] Failed for parent=#{parent_creative_id} child=#{child_creative_id}: " \
@@ -50,8 +58,6 @@ module Collavre
     end
 
     def post_system_notice(child, topic, content)
-      # System message (user: nil, skip_default_user: true) — not dispatched
-      # to SystemEvents, so no AI agent will be triggered by this comment.
       child.comments.create!(
         content: content,
         topic_id: topic.id,
@@ -78,33 +84,69 @@ module Collavre
       topic
     end
 
-    def already_triggered?(child, parent, topic)
-      trigger_key = I18n.t(
+    def trigger_content_key(child, parent)
+      I18n.t(
         "collavre.drop_trigger.child_entered",
         child_description: child.creative_snippet,
         child_id: child.id,
         parent_description: parent.creative_snippet
       )
+    end
+
+    def find_trigger_comment(child, parent, topic)
+      key = trigger_content_key(child, parent)
       child.comments.where(topic_id: topic.id)
-           .where("content LIKE ?", "%#{trigger_key.first(80)}%")
-           .exists?
+           .where("content LIKE ?", "%#{key.first(80)}%")
+           .first
     end
 
     def create_trigger_comment(child, parent, agent, topic)
-      trigger_text = I18n.t(
-        "collavre.drop_trigger.child_entered",
-        child_description: child.creative_snippet,
-        child_id: child.id,
-        parent_description: parent.creative_snippet
-      )
-      # Mention the agent to ensure exclusive routing via Matcher
-      content = "@#{agent.name}: #{trigger_text}"
+      content = "@#{agent.name}: #{trigger_content_key(child, parent)}"
+      # skip_dispatch: true — we dispatch explicitly in Step 3,
+      # not via after_create_commit, so retries can re-attempt dispatch
+      # even when the comment already exists.
       child.comments.create!(
         content: content,
         topic_id: topic.id,
         private: false,
-        user: child.user
+        user: child.user,
+        skip_dispatch: true
       )
+    end
+
+    def task_exists_for?(comment)
+      Task.where(creative_id: comment.creative_id, topic_id: comment.topic_id)
+          .where.not(status: "cancelled")
+          .any? { |t| t.trigger_event_payload&.dig("comment", "id").to_s == comment.id.to_s }
+    end
+
+    def dispatch_trigger(comment)
+      scheduled_agents = SystemEvents::Dispatcher.dispatch("comment_created", {
+        comment: {
+          id: comment.id,
+          content: comment.content,
+          user_id: comment.user_id,
+          from_ai: false,
+          quoted_comment_id: comment.quoted_comment_id
+        }.compact,
+        creative: {
+          id: comment.creative_id,
+          description: comment.creative&.description
+        },
+        topic: {
+          id: comment.topic_id
+        },
+        chat: {
+          content: comment.content
+        }
+      })
+
+      if scheduled_agents.blank?
+        Rails.logger.warn(
+          "[DropTriggerJob] Dispatch returned no agents for comment #{comment.id} " \
+          "(creative=#{comment.creative_id}, topic=#{comment.topic_id})"
+        )
+      end
     end
   end
 end

--- a/engines/collavre/app/jobs/collavre/drop_trigger_job.rb
+++ b/engines/collavre/app/jobs/collavre/drop_trigger_job.rb
@@ -115,31 +115,21 @@ module Collavre
     end
 
     def task_exists_for?(comment)
+      comment_id_str = comment.id.to_s
       Task.where(creative_id: comment.creative_id, topic_id: comment.topic_id)
           .where.not(status: "cancelled")
-          .any? { |t| t.trigger_event_payload&.dig("comment", "id").to_s == comment.id.to_s }
+          .find_each do |t|
+        return true if t.trigger_event_payload&.dig("comment", "id").to_s == comment_id_str
+      end
+      false
     end
 
     def dispatch_trigger(comment)
-      scheduled_agents = SystemEvents::Dispatcher.dispatch("comment_created", {
-        comment: {
-          id: comment.id,
-          content: comment.content,
-          user_id: comment.user_id,
-          from_ai: false,
-          quoted_comment_id: comment.quoted_comment_id
-        }.compact,
-        creative: {
-          id: comment.creative_id,
-          description: comment.creative&.description
-        },
-        topic: {
-          id: comment.topic_id
-        },
-        chat: {
-          content: comment.content
-        }
-      })
+      # Use Comment#dispatch_payload — single source of truth shared with
+      # the after_create_commit callback, preventing payload drift.
+      scheduled_agents = SystemEvents::Dispatcher.dispatch(
+        "comment_created", comment.dispatch_payload
+      )
 
       if scheduled_agents.blank?
         Rails.logger.warn(

--- a/engines/collavre/app/models/collavre/comment.rb
+++ b/engines/collavre/app/models/collavre/comment.rb
@@ -64,6 +64,31 @@ module Collavre
       creative.creative_snippet
     end
 
+    # Build the dispatch payload for comment_created events.
+    # Used by both after_create_commit callback and DropTriggerJob
+    # to ensure a single source of truth (no payload drift).
+    def dispatch_payload
+      {
+        comment: {
+          id: id,
+          content: content,
+          user_id: user_id,
+          from_ai: user&.searchable? || false,
+          quoted_comment_id: quoted_comment_id
+        }.compact,
+        creative: {
+          id: creative_id,
+          description: creative&.description
+        },
+        topic: {
+          id: topic_id
+        },
+        chat: {
+          content: content
+        }
+      }
+    end
+
     private
 
     def nullify_selected_version
@@ -101,25 +126,7 @@ module Collavre
       return if user&.ai_user?     # AI replies use A2aDispatcher, not this callback
       return unless creative
 
-      SystemEvents::Dispatcher.dispatch("comment_created", {
-        comment: {
-          id: id,
-          content: content,
-          user_id: user_id,
-          from_ai: user&.searchable? || false,
-          quoted_comment_id: quoted_comment_id
-        }.compact,
-        creative: {
-          id: creative_id,
-          description: creative&.description
-        },
-        topic: {
-          id: topic_id
-        },
-        chat: {
-          content: content
-        }
-      })
+      SystemEvents::Dispatcher.dispatch("comment_created", dispatch_payload)
     rescue StandardError => e
       Rails.logger.error(
         "[Comment#dispatch_to_orchestration] Failed for comment #{id}: " \

--- a/engines/collavre/test/jobs/collavre/drop_trigger_job_test.rb
+++ b/engines/collavre/test/jobs/collavre/drop_trigger_job_test.rb
@@ -23,7 +23,7 @@ module Collavre
     end
 
     test "creates trigger topic and comment on child creative" do
-      SystemEvents::Dispatcher.stub(:dispatch, ->(*_args) { [@ai_bot] }) do
+      SystemEvents::Dispatcher.stub(:dispatch, ->(*_args) { [ @ai_bot ] }) do
         assert_difference -> { @child.comments.count }, 1 do
           assert_difference -> { @child.topics.count }, 1 do
             DropTriggerJob.perform_now(@parent.id, @child.id)
@@ -41,7 +41,7 @@ module Collavre
 
     test "dispatches exactly once via explicit call, not callback" do
       dispatch_calls = []
-      dispatcher = ->(*args) { dispatch_calls << args; [@ai_bot] }
+      dispatcher = ->(*args) { dispatch_calls << args; [ @ai_bot ] }
 
       SystemEvents::Dispatcher.stub(:dispatch, dispatcher) do
         DropTriggerJob.perform_now(@parent.id, @child.id)
@@ -54,12 +54,12 @@ module Collavre
     end
 
     test "reuses existing Drop Trigger topic" do
-      SystemEvents::Dispatcher.stub(:dispatch, ->(*_args) { [@ai_bot] }) do
+      SystemEvents::Dispatcher.stub(:dispatch, ->(*_args) { [ @ai_bot ] }) do
         DropTriggerJob.perform_now(@parent.id, @child.id)
       end
 
       assert_no_difference -> { @child.topics.count } do
-        SystemEvents::Dispatcher.stub(:dispatch, ->(*_args) { [@ai_bot] }) do
+        SystemEvents::Dispatcher.stub(:dispatch, ->(*_args) { [ @ai_bot ] }) do
           DropTriggerJob.perform_now(@parent.id, @child.id)
         end
       end
@@ -78,7 +78,7 @@ module Collavre
 
       # Second run (retry): finds existing comment, retries dispatch successfully
       dispatch_calls = []
-      dispatcher = ->(*args) { dispatch_calls << args; [@ai_bot] }
+      dispatcher = ->(*args) { dispatch_calls << args; [ @ai_bot ] }
 
       SystemEvents::Dispatcher.stub(:dispatch, dispatcher) do
         assert_no_difference -> { @child.comments.count } do
@@ -91,7 +91,7 @@ module Collavre
 
     test "skips dispatch when task already exists for comment" do
       dispatched = false
-      SystemEvents::Dispatcher.stub(:dispatch, ->(*_args) { dispatched = true; [@ai_bot] }) do
+      SystemEvents::Dispatcher.stub(:dispatch, ->(*_args) { dispatched = true; [ @ai_bot ] }) do
         DropTriggerJob.perform_now(@parent.id, @child.id)
       end
       assert dispatched, "First run should dispatch"
@@ -110,14 +110,14 @@ module Collavre
       )
 
       dispatched = false
-      SystemEvents::Dispatcher.stub(:dispatch, ->(*_args) { dispatched = true; [@ai_bot] }) do
+      SystemEvents::Dispatcher.stub(:dispatch, ->(*_args) { dispatched = true; [ @ai_bot ] }) do
         DropTriggerJob.perform_now(@parent.id, @child.id)
       end
       refute dispatched, "Should skip dispatch when Task already exists"
     end
 
     test "retries dispatch when existing task is cancelled" do
-      SystemEvents::Dispatcher.stub(:dispatch, ->(*_args) { [@ai_bot] }) do
+      SystemEvents::Dispatcher.stub(:dispatch, ->(*_args) { [ @ai_bot ] }) do
         DropTriggerJob.perform_now(@parent.id, @child.id)
       end
 
@@ -134,7 +134,7 @@ module Collavre
       )
 
       dispatched = false
-      SystemEvents::Dispatcher.stub(:dispatch, ->(*_args) { dispatched = true; [@ai_bot] }) do
+      SystemEvents::Dispatcher.stub(:dispatch, ->(*_args) { dispatched = true; [ @ai_bot ] }) do
         DropTriggerJob.perform_now(@parent.id, @child.id)
       end
       assert dispatched, "Should retry dispatch when only a cancelled Task exists"
@@ -184,7 +184,7 @@ module Collavre
     end
 
     test "comment mentions the AI agent for routing" do
-      SystemEvents::Dispatcher.stub(:dispatch, ->(*_args) { [@ai_bot] }) do
+      SystemEvents::Dispatcher.stub(:dispatch, ->(*_args) { [ @ai_bot ] }) do
         DropTriggerJob.perform_now(@parent.id, @child.id)
       end
 
@@ -196,7 +196,7 @@ module Collavre
     test "uses creative_snippet for plain text names" do
       @child.update!(description: "<p>HTML <strong>description</strong> that is very long and should be truncated</p>")
 
-      SystemEvents::Dispatcher.stub(:dispatch, ->(*_args) { [@ai_bot] }) do
+      SystemEvents::Dispatcher.stub(:dispatch, ->(*_args) { [ @ai_bot ] }) do
         DropTriggerJob.perform_now(@parent.id, @child.id)
       end
 

--- a/engines/collavre/test/jobs/collavre/drop_trigger_job_test.rb
+++ b/engines/collavre/test/jobs/collavre/drop_trigger_job_test.rb
@@ -23,9 +23,11 @@ module Collavre
     end
 
     test "creates trigger topic and comment on child creative" do
-      assert_difference -> { @child.comments.count }, 1 do
-        assert_difference -> { @child.topics.count }, 1 do
-          DropTriggerJob.perform_now(@parent.id, @child.id)
+      SystemEvents::Dispatcher.stub(:dispatch, ->(*_args) { [@ai_bot] }) do
+        assert_difference -> { @child.comments.count }, 1 do
+          assert_difference -> { @child.topics.count }, 1 do
+            DropTriggerJob.perform_now(@parent.id, @child.id)
+          end
         end
       end
 
@@ -37,35 +39,105 @@ module Collavre
       assert_includes comment.content, @child.creative_snippet
     end
 
-    test "trigger comment dispatches via model callback" do
-      dispatched = false
-      SystemEvents::Dispatcher.stub(:dispatch, ->(*_args) { dispatched = true; [ @ai_bot ] }) do
+    test "dispatches exactly once via explicit call, not callback" do
+      dispatch_calls = []
+      dispatcher = ->(*args) { dispatch_calls << args; [@ai_bot] }
+
+      SystemEvents::Dispatcher.stub(:dispatch, dispatcher) do
         DropTriggerJob.perform_now(@parent.id, @child.id)
       end
 
-      assert dispatched, "Comment creation should trigger dispatch via after_create_commit"
+      # Dispatch should be called exactly once:
+      # - after_create_commit callback is suppressed (skip_dispatch: true)
+      # - Job dispatches explicitly in Step 3
+      assert_equal 1, dispatch_calls.size, "Should dispatch exactly once (job only, not callback)"
     end
 
     test "reuses existing Drop Trigger topic" do
-      DropTriggerJob.perform_now(@parent.id, @child.id)
-      topic = @child.topics.find_by(name: "Drop Trigger")
+      SystemEvents::Dispatcher.stub(:dispatch, ->(*_args) { [@ai_bot] }) do
+        DropTriggerJob.perform_now(@parent.id, @child.id)
+      end
 
       assert_no_difference -> { @child.topics.count } do
-        DropTriggerJob.perform_now(@parent.id, @child.id)
+        SystemEvents::Dispatcher.stub(:dispatch, ->(*_args) { [@ai_bot] }) do
+          DropTriggerJob.perform_now(@parent.id, @child.id)
+        end
       end
-
-      assert_equal topic.id, @child.topics.find_by(name: "Drop Trigger").id
     end
 
-    test "skips duplicate trigger comment on retry (idempotency)" do
-      # First run creates the trigger comment
-      DropTriggerJob.perform_now(@parent.id, @child.id)
-      comment_count = @child.comments.count
+    test "finds existing comment and retries dispatch on retry" do
+      # First run: create comment, dispatch fails
+      SystemEvents::Dispatcher.stub(:dispatch, ->(*_args) { raise "dispatch error" }) do
+        assert_raises(RuntimeError) do
+          DropTriggerJob.perform_now(@parent.id, @child.id)
+        end
+      end
 
-      # Second run (simulating SolidQueue retry) should NOT create another comment
-      assert_no_difference -> { @child.comments.count } do
+      comment_count = @child.comments.count
+      assert_operator comment_count, :>, 0, "Comment should be created even if dispatch fails"
+
+      # Second run (retry): finds existing comment, retries dispatch successfully
+      dispatch_calls = []
+      dispatcher = ->(*args) { dispatch_calls << args; [@ai_bot] }
+
+      SystemEvents::Dispatcher.stub(:dispatch, dispatcher) do
+        assert_no_difference -> { @child.comments.count } do
+          DropTriggerJob.perform_now(@parent.id, @child.id)
+        end
+      end
+
+      assert_equal 1, dispatch_calls.size, "Should retry dispatch for existing comment"
+    end
+
+    test "skips dispatch when task already exists for comment" do
+      dispatched = false
+      SystemEvents::Dispatcher.stub(:dispatch, ->(*_args) { dispatched = true; [@ai_bot] }) do
         DropTriggerJob.perform_now(@parent.id, @child.id)
       end
+      assert dispatched, "First run should dispatch"
+
+      # Create a Task matching this comment
+      comment = @child.comments.last
+      topic = @child.topics.find_by(name: "Drop Trigger")
+      Task.create!(
+        name: "Response to comment_created",
+        status: "running",
+        trigger_event_name: "comment_created",
+        trigger_event_payload: { "comment" => { "id" => comment.id } },
+        agent_id: @ai_bot.id,
+        creative_id: @child.id,
+        topic_id: topic.id
+      )
+
+      dispatched = false
+      SystemEvents::Dispatcher.stub(:dispatch, ->(*_args) { dispatched = true; [@ai_bot] }) do
+        DropTriggerJob.perform_now(@parent.id, @child.id)
+      end
+      refute dispatched, "Should skip dispatch when Task already exists"
+    end
+
+    test "retries dispatch when existing task is cancelled" do
+      SystemEvents::Dispatcher.stub(:dispatch, ->(*_args) { [@ai_bot] }) do
+        DropTriggerJob.perform_now(@parent.id, @child.id)
+      end
+
+      comment = @child.comments.last
+      topic = @child.topics.find_by(name: "Drop Trigger")
+      Task.create!(
+        name: "Response to comment_created",
+        status: "cancelled",
+        trigger_event_name: "comment_created",
+        trigger_event_payload: { "comment" => { "id" => comment.id } },
+        agent_id: @ai_bot.id,
+        creative_id: @child.id,
+        topic_id: topic.id
+      )
+
+      dispatched = false
+      SystemEvents::Dispatcher.stub(:dispatch, ->(*_args) { dispatched = true; [@ai_bot] }) do
+        DropTriggerJob.perform_now(@parent.id, @child.id)
+      end
+      assert dispatched, "Should retry dispatch when only a cancelled Task exists"
     end
 
     test "skips when parent trigger is disabled" do
@@ -112,7 +184,9 @@ module Collavre
     end
 
     test "comment mentions the AI agent for routing" do
-      DropTriggerJob.perform_now(@parent.id, @child.id)
+      SystemEvents::Dispatcher.stub(:dispatch, ->(*_args) { [@ai_bot] }) do
+        DropTriggerJob.perform_now(@parent.id, @child.id)
+      end
 
       comment = @child.comments.last
       assert comment.content.start_with?("@#{@ai_bot.name}:"),
@@ -122,7 +196,9 @@ module Collavre
     test "uses creative_snippet for plain text names" do
       @child.update!(description: "<p>HTML <strong>description</strong> that is very long and should be truncated</p>")
 
-      DropTriggerJob.perform_now(@parent.id, @child.id)
+      SystemEvents::Dispatcher.stub(:dispatch, ->(*_args) { [@ai_bot] }) do
+        DropTriggerJob.perform_now(@parent.id, @child.id)
+      end
 
       comment = @child.comments.last
       refute_includes comment.content, "<p>"


### PR DESCRIPTION
## Problem

DropTriggerJob relied on Comment's `after_create_commit` callback for dispatch, which caused a **permanent failure mode**:

1. Job creates trigger comment (committed to DB)
2. Callback dispatch fails → raises
3. SolidQueue retries job
4. `already_triggered?` guard finds existing comment → **skips entirely**
5. Result: comment exists but dispatch **never happens**

This was the root cause of intermittent trigger failures in production.

## Solution

Make DropTriggerJob fully idempotent with explicit 3-step flow:

1. **Find or create** trigger comment (`skip_dispatch: true` — no callback dispatch)
2. **Check** if Task already exists for this comment → skip if found
3. **Dispatch explicitly** via `SystemEvents::Dispatcher`

Safe to retry at any point:
- No duplicate comments (find-or-create)
- Dispatch retried until Task is created
- Cancelled Tasks are ignored (re-trigger works)

## Key Changes

- `DropTriggerJob`: 3-step idempotent flow, explicit dispatch, `task_exists_for?` check
- Comments created with `skip_dispatch: true` to prevent callback double-dispatch
- `find_trigger_comment` + `create_trigger_comment` split from old `already_triggered?` + `create_trigger_comment`

## Tests

- 13 job tests (4 new: retry dispatch, task exists check, cancelled task re-dispatch, explicit dispatch verification)
- 1522 total runs, 0 failures, 0 errors