### PR TITLE
fix: retry drop trigger dispatch when no agents scheduled

### DIFF
--- a/engines/collavre/app/jobs/collavre/drop_trigger_job.rb
+++ b/engines/collavre/app/jobs/collavre/drop_trigger_job.rb
@@ -4,6 +4,12 @@ module Collavre
   class DropTriggerJob < ApplicationJob
     queue_as :default
 
+    # Custom error raised when dispatch returns no scheduled agents.
+    # This triggers retry_on instead of silently succeeding.
+    class DispatchFailedError < StandardError; end
+
+    retry_on DispatchFailedError, wait: 5.seconds, attempts: 3
+
     # End-to-end idempotent: safe to retry at any point.
     #
     # 1. Find or create trigger comment (no duplicates)
@@ -132,10 +138,9 @@ module Collavre
       )
 
       if scheduled_agents.blank?
-        Rails.logger.warn(
-          "[DropTriggerJob] Dispatch returned no agents for comment #{comment.id} " \
+        raise DispatchFailedError,
+          "Dispatch returned no agents for comment #{comment.id} " \
           "(creative=#{comment.creative_id}, topic=#{comment.topic_id})"
-        )
       end
     end
   end

--- a/engines/collavre/test/jobs/collavre/drop_trigger_job_test.rb
+++ b/engines/collavre/test/jobs/collavre/drop_trigger_job_test.rb
@@ -140,6 +140,44 @@ module Collavre
       assert dispatched, "Should retry dispatch when only a cancelled Task exists"
     end
 
+    test "raises DispatchFailedError when dispatch returns no agents" do
+      # retry_on reschedules the job; verify the error is raised on perform_now
+      # by temporarily removing retry_on behavior
+      SystemEvents::Dispatcher.stub(:dispatch, ->(*_args) { [] }) do
+        error = assert_raises(Collavre::DropTriggerJob::DispatchFailedError) do
+          # perform_now bypasses retry_on wait scheduling
+          job = DropTriggerJob.new(@parent.id, @child.id)
+          job.perform(@parent.id, @child.id)
+        end
+        assert_includes error.message, "no agents"
+      end
+    end
+
+    test "comment survives dispatch failure for retry" do
+      # Simulate first attempt: dispatch fails
+      SystemEvents::Dispatcher.stub(:dispatch, ->(*_args) { [] }) do
+        begin
+          job = DropTriggerJob.new(@parent.id, @child.id)
+          job.perform(@parent.id, @child.id)
+        rescue Collavre::DropTriggerJob::DispatchFailedError
+          # Expected
+        end
+      end
+
+      # Comment should exist for next retry attempt
+      topic = @child.topics.find_by(name: "Drop Trigger")
+      assert topic, "Topic should exist"
+      trigger_comment = @child.comments.where(topic_id: topic.id).where.not(user_id: nil).first
+      assert trigger_comment, "Trigger comment should exist for retry"
+
+      # Simulate retry: dispatch succeeds
+      SystemEvents::Dispatcher.stub(:dispatch, ->(*_args) { [@ai_bot] }) do
+        assert_no_difference -> { @child.comments.count } do
+          DropTriggerJob.perform_now(@parent.id, @child.id)
+        end
+      end
+    end
+
     test "skips when parent trigger is disabled" do
       @parent.update!(data: {})
 


### PR DESCRIPTION
## Problem

When `DropTriggerJob` dispatch returned no agents, the job **silently succeeded** — no error, no retry, no `FailedExecution` record. The trigger comment existed but the AI agent never started.

This was the root cause of repeated production failures: dispatch returned empty but the job logged a warning and completed normally.

## Solution

- **`DispatchFailedError`** raised when `scheduled_agents.blank?`
- **`retry_on DispatchFailedError, wait: 5.seconds, attempts: 3`** for automatic recovery
- After 3 failed attempts, error propagates to `FailedExecution` for operator visibility
- Idempotent design ensures retries are safe (find-or-create comment, skip if Task exists)

## Test Coverage

- `raises DispatchFailedError when dispatch returns no agents` — verifies error + message
- `comment survives dispatch failure for retry` — verifies comment persists across retry, then succeeds on 2nd attempt
- 1524 total runs, 0 failures