### PR TITLE
fix: keep inline delete popup on-screen on mobile

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/creatives.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/creatives.css
@@ -142,35 +142,12 @@ html.creative-alignment-ready .page-title {
 }
 
 /* === Overflow popup menu — GNB style === */
+/* #creative-overflow-menu inherits base styles from .popup-menu in popup.css */
 #creative-overflow-menu {
     min-width: 200px;
-    border: 1px solid var(--border-color);
-    border-radius: var(--radius-3);
-    box-shadow: var(--shadow-2);
-    padding: var(--space-1);
-    background: var(--surface-section);
 }
 
-#creative-overflow-menu .popup-menu-item {
-    display: flex;
-    align-items: center;
-    gap: var(--space-2);
-    width: 100%;
-    text-align: left;
-    padding: var(--space-1) var(--space-2);
-    border-radius: var(--radius-2);
-    border: none;
-    background: none;
-    color: var(--text-primary);
-    font-size: var(--text-1);
-    cursor: pointer;
-    transition: background 0.15s var(--ease-out-2);
-    white-space: nowrap;
-}
-
-#creative-overflow-menu .popup-menu-item:hover {
-    background: var(--surface-hover);
-}
+/* popup-menu-item base styles are now in popup.css */
 
 #creative-overflow-menu .popup-menu-item.active {
     background: color-mix(in srgb, var(--color-active) 15%, transparent);

--- a/engines/collavre/app/assets/stylesheets/collavre/popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/popup.css
@@ -325,11 +325,6 @@
     max-width: calc(100vw - 8px);
   }
 
-  .inline-delete-popup-menu {
-    right: 0;
-    left: auto;
-  }
-
   #mobile-more-menu button,
   #mobile-more-menu a {
     display: block;

--- a/engines/collavre/app/assets/stylesheets/collavre/popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/popup.css
@@ -331,7 +331,7 @@
 }
 
 .popup-menu .popup-menu-item.danger-link:hover {
-  background: color-mix(in srgb, var(--danger) 12%, transparent);
+  background: color-mix(in srgb, var(--color-danger) 12%, transparent);
 }
 
 #user-menu button {

--- a/engines/collavre/app/assets/stylesheets/collavre/popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/popup.css
@@ -294,7 +294,6 @@
   box-shadow: var(--shadow-3);
   border-radius: var(--radius-2);
   min-width: 220px;
-  max-width: min(320px, calc(100vw - 8px));
   top: calc(100% + 4px);
   left: 0;
   transform: translateX(0);
@@ -322,7 +321,7 @@
 @media (max-width: 768px) {
   .popup-menu {
     min-width: min(220px, calc(100vw - 8px));
-    max-width: calc(100vw - 8px);
+    max-width: min(320px, calc(100vw - 8px));
   }
 
   #mobile-more-menu button,

--- a/engines/collavre/app/assets/stylesheets/collavre/popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/popup.css
@@ -330,12 +330,13 @@
   background: var(--surface-hover);
 }
 
+/* Inside popup menus, danger-link items use the same style as other items */
 .popup-menu .popup-menu-item.danger-link {
-  color: var(--color-danger);
+  color: inherit;
 }
 
 .popup-menu .popup-menu-item.danger-link:hover {
-  background: color-mix(in srgb, var(--color-danger) 15%, transparent);
+  background: var(--surface-hover);
 }
 
 #user-menu button {

--- a/engines/collavre/app/assets/stylesheets/collavre/popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/popup.css
@@ -290,9 +290,9 @@
   z-index: var(--layer-modal);
   background: var(--surface-section);
   border: 1px solid var(--border-color);
-  padding: 0.5em;
-  box-shadow: var(--shadow-3);
-  border-radius: var(--radius-2);
+  padding: var(--space-1);
+  box-shadow: var(--shadow-2);
+  border-radius: var(--radius-3);
   min-width: 220px;
   top: calc(100% + 4px);
   left: 0;
@@ -305,11 +305,33 @@
   right: 0;
 }
 
+.popup-menu .popup-menu-item,
 .popup-menu-item button,
 .popup-menu-item a {
-  display: block;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
   width: 100%;
   text-align: left;
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-2);
+  border: none;
+  background: none;
+  color: var(--text-primary);
+  font-size: var(--text-1);
+  cursor: pointer;
+  transition: background 0.15s var(--ease-out-2);
+  white-space: nowrap;
+}
+
+.popup-menu .popup-menu-item:hover,
+.popup-menu-item button:hover,
+.popup-menu-item a:hover {
+  background: var(--surface-hover);
+}
+
+.popup-menu .popup-menu-item.danger-link:hover {
+  background: color-mix(in srgb, var(--danger) 12%, transparent);
 }
 
 #user-menu button {

--- a/engines/collavre/app/assets/stylesheets/collavre/popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/popup.css
@@ -294,9 +294,11 @@
   box-shadow: var(--shadow-3);
   border-radius: var(--radius-2);
   min-width: 220px;
+  max-width: min(320px, calc(100vw - 8px));
   top: calc(100% + 4px);
   left: 0;
   transform: translateX(0);
+  box-sizing: border-box;
 }
 
 .popup-menu-right {
@@ -318,6 +320,15 @@
 }
 
 @media (max-width: 768px) {
+  .popup-menu {
+    min-width: min(220px, calc(100vw - 8px));
+    max-width: calc(100vw - 8px);
+  }
+
+  #inline-delete-popup-menu {
+    right: 0;
+    left: auto;
+  }
 
   #mobile-more-menu button,
   #mobile-more-menu a {

--- a/engines/collavre/app/assets/stylesheets/collavre/popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/popup.css
@@ -330,8 +330,12 @@
   background: var(--surface-hover);
 }
 
+.popup-menu .popup-menu-item.danger-link {
+  color: var(--color-danger);
+}
+
 .popup-menu .popup-menu-item.danger-link:hover {
-  background: color-mix(in srgb, var(--color-danger) 12%, transparent);
+  background: color-mix(in srgb, var(--color-danger) 15%, transparent);
 }
 
 #user-menu button {

--- a/engines/collavre/app/assets/stylesheets/collavre/popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/popup.css
@@ -325,7 +325,7 @@
     max-width: calc(100vw - 8px);
   }
 
-  #inline-delete-popup-menu {
+  .inline-delete-popup-menu {
     right: 0;
     left: auto;
   }

--- a/engines/collavre/app/assets/stylesheets/collavre/popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/popup.css
@@ -330,13 +330,9 @@
   background: var(--surface-hover);
 }
 
-/* Inside popup menus, danger-link items use the same style as other items */
+/* Inside popup menus, danger-link items inherit normal item styles */
 .popup-menu .popup-menu-item.danger-link {
   color: inherit;
-}
-
-.popup-menu .popup-menu-item.danger-link:hover {
-  background: var(--surface-hover);
 }
 
 #user-menu button {

--- a/engines/collavre/app/components/collavre/popup_menu_component.html.erb
+++ b/engines/collavre/app/components/collavre/popup_menu_component.html.erb
@@ -1,6 +1,6 @@
 <div class="popup-menu-wrapper" data-controller="popup-menu">
   <%= button_tag raw(button_content), button_options %>
-  <div id="<%= menu_id %>" class="popup-menu <%= 'popup-menu-right' if align.to_sym == :right %>" data-popup-menu-target="menu" data-action="click->popup-menu#menuClick">
+  <div id="<%= menu_id %>" class="<%= ['popup-menu', ('popup-menu-right' if align.to_sym == :right), menu_classes.presence].compact.join(' ') %>" data-popup-menu-target="menu" data-action="click->popup-menu#menuClick">
     <%= content %>
   </div>
 </div>

--- a/engines/collavre/app/components/collavre/popup_menu_component.rb
+++ b/engines/collavre/app/components/collavre/popup_menu_component.rb
@@ -1,14 +1,15 @@
 module Collavre
 class PopupMenuComponent < ViewComponent::Base
-  def initialize(button_content:, button_classes: "", menu_id: nil, align: :left, button_attributes: {})
+  def initialize(button_content:, button_classes: "", menu_classes: "", menu_id: nil, align: :left, button_attributes: {})
     @button_content = button_content
     @button_classes = button_classes
+    @menu_classes = menu_classes
     @menu_id = menu_id || "popup-menu-#{SecureRandom.hex(4)}"
     @align = align
     @button_attributes = button_attributes
   end
 
-  attr_reader :button_content, :button_classes, :menu_id, :align, :button_attributes
+  attr_reader :button_content, :button_classes, :menu_classes, :menu_id, :align, :button_attributes
 
   def button_options
     defaults = {

--- a/engines/collavre/app/javascript/controllers/__tests__/popup_menu_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/popup_menu_controller.test.js
@@ -1,0 +1,88 @@
+/**
+ * @jest-environment jsdom
+ */
+import { jest } from '@jest/globals'
+import { Application } from '@hotwired/stimulus'
+
+const notifyPopupOpen = jest.fn()
+const onOtherPopupOpen = jest.fn(() => () => {})
+
+jest.unstable_mockModule('../../lib/gnb_popup_manager', () => ({
+  __esModule: true,
+  notifyPopupOpen,
+  onOtherPopupOpen
+}))
+
+const { default: PopupMenuController } = await import('../popup_menu_controller')
+
+describe('PopupMenuController', () => {
+  let application
+  let container
+  let controller
+  let menu
+
+  beforeEach(async () => {
+    document.body.innerHTML = ''
+    notifyPopupOpen.mockClear()
+    onOtherPopupOpen.mockClear()
+
+    container = document.createElement('div')
+    container.innerHTML = `
+      <div data-controller="popup-menu">
+        <button type="button" data-popup-menu-target="button">Open</button>
+        <div id="test-menu" data-popup-menu-target="menu" style="display:none"></div>
+      </div>
+    `
+    document.body.appendChild(container)
+
+    application = Application.start()
+    application.register('popup-menu', PopupMenuController)
+
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    const element = container.querySelector('[data-controller="popup-menu"]')
+    controller = application.getControllerForElementAndIdentifier(element, 'popup-menu')
+    menu = container.querySelector('#test-menu')
+
+    Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 360 })
+    Object.defineProperty(window, 'innerHeight', { writable: true, configurable: true, value: 640 })
+  })
+
+  afterEach(() => {
+    application?.stop()
+    document.body.innerHTML = ''
+    jest.restoreAllMocks()
+  })
+
+  test('flips upward when there is more space above than below', async () => {
+    const rects = [
+      { top: 520, bottom: 700, left: 20, right: 220, width: 200, height: 180 },
+      { top: 336, bottom: 516, left: 20, right: 220, width: 200, height: 180 }
+    ]
+    let callCount = 0
+    jest.spyOn(menu, 'getBoundingClientRect').mockImplementation(() => rects[Math.min(callCount++, rects.length - 1)])
+
+    controller.show()
+    await new Promise(resolve => requestAnimationFrame(resolve))
+
+    expect(menu.style.bottom).toBe('calc(100% + 4px)')
+    expect(menu.style.top).toBe('auto')
+  })
+
+  test('stays below when there is more space below than above', async () => {
+    jest.spyOn(menu, 'getBoundingClientRect').mockReturnValue({
+      top: 40,
+      bottom: 220,
+      left: 20,
+      right: 220,
+      width: 200,
+      height: 180
+    })
+
+    controller.show()
+    await new Promise(resolve => requestAnimationFrame(resolve))
+
+    expect(menu.style.top).toBe('calc(100% + 4px)')
+    expect(menu.style.bottom).toBe('auto')
+  })
+})

--- a/engines/collavre/app/javascript/controllers/__tests__/popup_menu_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/popup_menu_controller.test.js
@@ -85,4 +85,18 @@ describe('PopupMenuController', () => {
     expect(menu.style.top).toBe('calc(100% + 4px)')
     expect(menu.style.bottom).toBe('auto')
   })
+
+  test('switches to right alignment when left alignment would overflow the viewport', async () => {
+    const rects = [
+      { top: 80, bottom: 260, left: 260, right: 460, width: 200, height: 180 },
+      { top: 80, bottom: 260, left: 140, right: 340, width: 200, height: 180 }
+    ]
+    let callCount = 0
+    jest.spyOn(menu, 'getBoundingClientRect').mockImplementation(() => rects[Math.min(callCount++, rects.length - 1)])
+
+    controller.show()
+    await new Promise(resolve => requestAnimationFrame(resolve))
+
+    expect(menu.classList.contains('popup-menu-right')).toBe(true)
+  })
 })

--- a/engines/collavre/app/javascript/controllers/__tests__/popup_menu_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/popup_menu_controller.test.js
@@ -99,4 +99,50 @@ describe('PopupMenuController', () => {
 
     expect(menu.classList.contains('popup-menu-right')).toBe(true)
   })
+
+  test('preserves initial right alignment through show/hide cycle', async () => {
+    // Simulate a menu rendered with align: :right (server adds popup-menu-right)
+    menu.classList.add('popup-menu-right')
+
+    // Re-connect so controller picks up the initial state
+    const element = container.querySelector('[data-controller="popup-menu"]')
+    application.stop()
+    application = Application.start()
+    application.register('popup-menu', PopupMenuController)
+    await new Promise(resolve => setTimeout(resolve, 0))
+    controller = application.getControllerForElementAndIdentifier(element, 'popup-menu')
+
+    jest.spyOn(menu, 'getBoundingClientRect').mockReturnValue({
+      top: 80, bottom: 260, left: 20, right: 220, width: 200, height: 180
+    })
+
+    // show() should preserve popup-menu-right
+    controller.show()
+    await new Promise(resolve => requestAnimationFrame(resolve))
+    expect(menu.classList.contains('popup-menu-right')).toBe(true)
+
+    // hide() should also preserve it
+    controller.hide()
+    expect(menu.classList.contains('popup-menu-right')).toBe(true)
+  })
+
+  test('hide() cleans up inline styles set by show()', async () => {
+    jest.spyOn(menu, 'getBoundingClientRect').mockReturnValue({
+      top: 40, bottom: 220, left: 20, right: 220, width: 200, height: 180
+    })
+
+    controller.show()
+    await new Promise(resolve => requestAnimationFrame(resolve))
+
+    // Verify show() set some styles
+    expect(menu.style.display).toBe('block')
+
+    controller.hide()
+
+    expect(menu.style.display).toBe('none')
+    expect(menu.style.top).toBe('')
+    expect(menu.style.bottom).toBe('')
+    expect(menu.style.maxWidth).toBe('')
+    expect(menu.style.transform).toBe('')
+  })
 })

--- a/engines/collavre/app/javascript/controllers/__tests__/popup_menu_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/popup_menu_controller.test.js
@@ -20,6 +20,7 @@ describe('PopupMenuController', () => {
   let container
   let controller
   let menu
+  let button
 
   beforeEach(async () => {
     document.body.innerHTML = ''
@@ -30,7 +31,9 @@ describe('PopupMenuController', () => {
     container.innerHTML = `
       <div data-controller="popup-menu">
         <button type="button" data-popup-menu-target="button">Open</button>
-        <div id="test-menu" data-popup-menu-target="menu" style="display:none"></div>
+        <div id="test-menu" data-popup-menu-target="menu" style="display:none">
+          <button class="popup-menu-item">Action</button>
+        </div>
       </div>
     `
     document.body.appendChild(container)
@@ -43,6 +46,7 @@ describe('PopupMenuController', () => {
     const element = container.querySelector('[data-controller="popup-menu"]')
     controller = application.getControllerForElementAndIdentifier(element, 'popup-menu')
     menu = container.querySelector('#test-menu')
+    button = container.querySelector('[data-popup-menu-target="button"]')
 
     Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 360 })
     Object.defineProperty(window, 'innerHeight', { writable: true, configurable: true, value: 640 })
@@ -54,54 +58,54 @@ describe('PopupMenuController', () => {
     jest.restoreAllMocks()
   })
 
-  test('flips upward when there is more space above than below', async () => {
-    const rects = [
-      { top: 520, bottom: 700, left: 20, right: 220, width: 200, height: 180 },
-      { top: 336, bottom: 516, left: 20, right: 220, width: 200, height: 180 }
-    ]
-    let callCount = 0
-    jest.spyOn(menu, 'getBoundingClientRect').mockImplementation(() => rects[Math.min(callCount++, rects.length - 1)])
-
-    controller.show()
-    await new Promise(resolve => requestAnimationFrame(resolve))
-
-    expect(menu.style.bottom).toBe('calc(100% + 4px)')
-    expect(menu.style.top).toBe('auto')
-  })
-
-  test('stays below when there is more space below than above', async () => {
+  test('uses fixed positioning to avoid creating scrollbars', async () => {
+    jest.spyOn(button, 'getBoundingClientRect').mockReturnValue({
+      top: 40, bottom: 60, left: 20, right: 80, width: 60, height: 20
+    })
     jest.spyOn(menu, 'getBoundingClientRect').mockReturnValue({
-      top: 40,
-      bottom: 220,
-      left: 20,
-      right: 220,
-      width: 200,
-      height: 180
+      top: 0, bottom: 180, left: 0, right: 200, width: 200, height: 180
     })
 
     controller.show()
     await new Promise(resolve => requestAnimationFrame(resolve))
 
-    expect(menu.style.top).toBe('calc(100% + 4px)')
-    expect(menu.style.bottom).toBe('auto')
+    expect(menu.style.position).toBe('fixed')
+    expect(menu.style.visibility).toBe('')
+    expect(menu.style.display).toBe('block')
   })
 
-  test('switches to right alignment when left alignment would overflow the viewport', async () => {
-    const rects = [
-      { top: 80, bottom: 260, left: 260, right: 460, width: 200, height: 180 },
-      { top: 80, bottom: 260, left: 140, right: 340, width: 200, height: 180 }
-    ]
-    let callCount = 0
-    jest.spyOn(menu, 'getBoundingClientRect').mockImplementation(() => rects[Math.min(callCount++, rects.length - 1)])
+  test('positions below the button when there is enough space', async () => {
+    jest.spyOn(button, 'getBoundingClientRect').mockReturnValue({
+      top: 40, bottom: 60, left: 20, right: 80, width: 60, height: 20
+    })
+    jest.spyOn(menu, 'getBoundingClientRect').mockReturnValue({
+      top: 0, bottom: 180, left: 0, right: 200, width: 200, height: 180
+    })
 
     controller.show()
     await new Promise(resolve => requestAnimationFrame(resolve))
 
-    expect(menu.classList.contains('popup-menu-right')).toBe(true)
+    // Menu should be placed below button: btnRect.bottom + gap = 60 + 4 = 64
+    expect(menu.style.top).toBe('64px')
+    expect(menu.style.left).toBe('20px')
   })
 
-  test('preserves initial right alignment through show/hide cycle', async () => {
-    // Simulate a menu rendered with align: :right (server adds popup-menu-right)
+  test('positions above the button when more space above', async () => {
+    jest.spyOn(button, 'getBoundingClientRect').mockReturnValue({
+      top: 580, bottom: 600, left: 20, right: 80, width: 60, height: 20
+    })
+    jest.spyOn(menu, 'getBoundingClientRect').mockReturnValue({
+      top: 0, bottom: 180, left: 0, right: 200, width: 200, height: 180
+    })
+
+    controller.show()
+    await new Promise(resolve => requestAnimationFrame(resolve))
+
+    // Menu should be above button: btnRect.top - gap - menuH = 580 - 4 - 180 = 396
+    expect(menu.style.top).toBe('396px')
+  })
+
+  test('right-aligns when _initialAlignRight is true', async () => {
     menu.classList.add('popup-menu-right')
 
     // Re-connect so controller picks up the initial state
@@ -112,37 +116,81 @@ describe('PopupMenuController', () => {
     await new Promise(resolve => setTimeout(resolve, 0))
     controller = application.getControllerForElementAndIdentifier(element, 'popup-menu')
 
+    jest.spyOn(button, 'getBoundingClientRect').mockReturnValue({
+      top: 40, bottom: 60, left: 200, right: 260, width: 60, height: 20
+    })
     jest.spyOn(menu, 'getBoundingClientRect').mockReturnValue({
-      top: 80, bottom: 260, left: 20, right: 220, width: 200, height: 180
+      top: 0, bottom: 180, left: 0, right: 200, width: 200, height: 180
     })
 
-    // show() should preserve popup-menu-right
     controller.show()
     await new Promise(resolve => requestAnimationFrame(resolve))
-    expect(menu.classList.contains('popup-menu-right')).toBe(true)
 
-    // hide() should also preserve it
-    controller.hide()
-    expect(menu.classList.contains('popup-menu-right')).toBe(true)
+    // Right-align: left = btnRect.right - menuW = 260 - 200 = 60
+    expect(menu.style.left).toBe('60px')
   })
 
-  test('hide() cleans up inline styles set by show()', async () => {
+  test('clamps menu to stay within viewport on narrow screens', async () => {
+    jest.spyOn(button, 'getBoundingClientRect').mockReturnValue({
+      top: 40, bottom: 60, left: 300, right: 350, width: 50, height: 20
+    })
     jest.spyOn(menu, 'getBoundingClientRect').mockReturnValue({
-      top: 40, bottom: 220, left: 20, right: 220, width: 200, height: 180
+      top: 0, bottom: 180, left: 0, right: 220, width: 220, height: 180
     })
 
     controller.show()
     await new Promise(resolve => requestAnimationFrame(resolve))
 
-    // Verify show() set some styles
-    expect(menu.style.display).toBe('block')
+    // Left would be 300, but 300 + 220 = 520 > 360 - 4 = 356
+    // So left = 356 - 220 = 136
+    expect(menu.style.left).toBe('136px')
+  })
+
+  test('hide() resets all inline styles', async () => {
+    jest.spyOn(button, 'getBoundingClientRect').mockReturnValue({
+      top: 40, bottom: 60, left: 20, right: 80, width: 60, height: 20
+    })
+    jest.spyOn(menu, 'getBoundingClientRect').mockReturnValue({
+      top: 0, bottom: 180, left: 0, right: 200, width: 200, height: 180
+    })
+
+    controller.show()
+    await new Promise(resolve => requestAnimationFrame(resolve))
 
     controller.hide()
 
     expect(menu.style.display).toBe('none')
+    expect(menu.style.position).toBe('')
+    expect(menu.style.visibility).toBe('')
     expect(menu.style.top).toBe('')
     expect(menu.style.bottom).toBe('')
+    expect(menu.style.left).toBe('')
+    expect(menu.style.right).toBe('')
     expect(menu.style.maxWidth).toBe('')
     expect(menu.style.transform).toBe('')
+  })
+
+  test('hide() preserves initial popup-menu-right class', async () => {
+    menu.classList.add('popup-menu-right')
+
+    const element = container.querySelector('[data-controller="popup-menu"]')
+    application.stop()
+    application = Application.start()
+    application.register('popup-menu', PopupMenuController)
+    await new Promise(resolve => setTimeout(resolve, 0))
+    controller = application.getControllerForElementAndIdentifier(element, 'popup-menu')
+
+    jest.spyOn(button, 'getBoundingClientRect').mockReturnValue({
+      top: 40, bottom: 60, left: 20, right: 80, width: 60, height: 20
+    })
+    jest.spyOn(menu, 'getBoundingClientRect').mockReturnValue({
+      top: 0, bottom: 180, left: 0, right: 200, width: 200, height: 180
+    })
+
+    controller.show()
+    await new Promise(resolve => requestAnimationFrame(resolve))
+    controller.hide()
+
+    expect(menu.classList.contains('popup-menu-right')).toBe(true)
   })
 })

--- a/engines/collavre/app/javascript/controllers/popup_menu_controller.js
+++ b/engines/collavre/app/javascript/controllers/popup_menu_controller.js
@@ -7,6 +7,7 @@ export default class extends Controller {
   connect() {
     this.handleOutsideClick = this.handleOutsideClick.bind(this)
     this._popupId = 'popup-menu-' + (this.menuTarget.id || this.element.id || this.element.dataset.popupId || Math.random().toString(36).slice(2))
+    this._initialAlignRight = this.menuTarget.classList.contains('popup-menu-right')
     this._cleanupPopupListener = onOtherPopupOpen(this._popupId, () => {
       if (this.isOpen()) this.hide()
     })
@@ -43,7 +44,11 @@ export default class extends Controller {
     menu.style.display = 'block'
     menu.style.transform = ''
     menu.style.maxWidth = `calc(100vw - ${viewportPadding * 2}px)`
-    menu.classList.remove('popup-menu-right')
+    if (this._initialAlignRight) {
+      menu.classList.add('popup-menu-right')
+    } else {
+      menu.classList.remove('popup-menu-right')
+    }
     menu.style.top = 'calc(100% + 4px)'
     menu.style.bottom = 'auto'
 
@@ -90,7 +95,17 @@ export default class extends Controller {
   }
 
   hide() {
-    this.menuTarget.style.display = 'none'
+    const menu = this.menuTarget
+    menu.style.display = 'none'
+    menu.style.top = ''
+    menu.style.bottom = ''
+    menu.style.maxWidth = ''
+    menu.style.transform = ''
+    if (this._initialAlignRight) {
+      menu.classList.add('popup-menu-right')
+    } else {
+      menu.classList.remove('popup-menu-right')
+    }
     this.buttonTarget?.setAttribute('aria-expanded', 'false')
     this.removeOutsideClickListener()
   }

--- a/engines/collavre/app/javascript/controllers/popup_menu_controller.js
+++ b/engines/collavre/app/javascript/controllers/popup_menu_controller.js
@@ -43,6 +43,9 @@ export default class extends Controller {
     menu.style.display = 'block'
     menu.style.transform = ''
     menu.style.maxWidth = `calc(100vw - ${viewportPadding * 2}px)`
+    menu.classList.remove('popup-menu-right')
+    menu.style.top = 'calc(100% + 4px)'
+    menu.style.bottom = 'auto'
 
     this.buttonTarget?.setAttribute('aria-expanded', 'true')
 
@@ -56,9 +59,16 @@ export default class extends Controller {
         menu.style.top = 'auto'
         menu.style.bottom = 'calc(100% + 4px)'
         rect = menu.getBoundingClientRect()
-      } else {
-        menu.style.top = 'calc(100% + 4px)'
-        menu.style.bottom = 'auto'
+      }
+
+      if (rect.right > window.innerWidth - viewportPadding) {
+        menu.classList.add('popup-menu-right')
+        rect = menu.getBoundingClientRect()
+      }
+
+      if (rect.left < viewportPadding && menu.classList.contains('popup-menu-right')) {
+        menu.classList.remove('popup-menu-right')
+        rect = menu.getBoundingClientRect()
       }
 
       if (rect.right > window.innerWidth - viewportPadding) {

--- a/engines/collavre/app/javascript/controllers/popup_menu_controller.js
+++ b/engines/collavre/app/javascript/controllers/popup_menu_controller.js
@@ -40,55 +40,67 @@ export default class extends Controller {
     notifyPopupOpen(this._popupId)
     const menu = this.menuTarget
     const viewportPadding = 4
+    const gap = 4
 
-    menu.style.display = 'block'
+    // Use fixed positioning to avoid creating scrollbars on any parent
+    menu.style.position = 'fixed'
+    menu.style.left = '0'
+    menu.style.right = 'auto'
+    menu.style.top = '0'
+    menu.style.bottom = 'auto'
     menu.style.transform = ''
     menu.style.maxWidth = `calc(100vw - ${viewportPadding * 2}px)`
-    if (this._initialAlignRight) {
-      menu.classList.add('popup-menu-right')
-    } else {
-      menu.classList.remove('popup-menu-right')
-    }
-    menu.style.top = 'calc(100% + 4px)'
-    menu.style.bottom = 'auto'
+    menu.classList.remove('popup-menu-right')
+    // Render invisible while we compute position
+    menu.style.visibility = 'hidden'
+    menu.style.display = 'block'
 
     this.buttonTarget?.setAttribute('aria-expanded', 'true')
 
     requestAnimationFrame(() => {
-      const transforms = []
-      let rect = menu.getBoundingClientRect()
-      const spaceBelow = window.innerHeight - rect.bottom
-      const spaceAbove = rect.top
+      const btnRect = this.buttonTarget.getBoundingClientRect()
+      const menuRect = menu.getBoundingClientRect()
+      const menuW = menuRect.width
+      const menuH = menuRect.height
+      const vw = window.innerWidth
+      const vh = window.innerHeight
 
-      if (rect.bottom > window.innerHeight && spaceAbove > spaceBelow) {
-        menu.style.top = 'auto'
-        menu.style.bottom = 'calc(100% + 4px)'
-        rect = menu.getBoundingClientRect()
+      // Vertical: prefer below the button, flip above if not enough space
+      const spaceBelow = vh - btnRect.bottom - gap
+      const spaceAbove = btnRect.top - gap
+      let top
+      if (menuH <= spaceBelow || spaceBelow >= spaceAbove) {
+        top = btnRect.bottom + gap
+      } else {
+        top = btnRect.top - gap - menuH
       }
 
-      if (rect.right > window.innerWidth - viewportPadding) {
-        menu.classList.add('popup-menu-right')
-        rect = menu.getBoundingClientRect()
+      // Horizontal: align left edge to button, shift if overflowing
+      let left
+      if (this._initialAlignRight) {
+        // Right-align: menu right edge to button right edge
+        left = btnRect.right - menuW
+      } else {
+        left = btnRect.left
       }
 
-      if (rect.left < viewportPadding && menu.classList.contains('popup-menu-right')) {
-        menu.classList.remove('popup-menu-right')
-        rect = menu.getBoundingClientRect()
+      // Clamp within viewport
+      if (left + menuW > vw - viewportPadding) {
+        left = vw - viewportPadding - menuW
+      }
+      if (left < viewportPadding) {
+        left = viewportPadding
+      }
+      if (top + menuH > vh - viewportPadding) {
+        top = vh - viewportPadding - menuH
+      }
+      if (top < viewportPadding) {
+        top = viewportPadding
       }
 
-      if (rect.right > window.innerWidth - viewportPadding) {
-        transforms.push(`translateX(-${rect.right - window.innerWidth + viewportPadding}px)`)
-      } else if (rect.left < viewportPadding) {
-        transforms.push(`translateX(${viewportPadding - rect.left}px)`)
-      }
-
-      if (rect.bottom > window.innerHeight - viewportPadding) {
-        transforms.push(`translateY(-${rect.bottom - window.innerHeight + viewportPadding}px)`)
-      } else if (rect.top < viewportPadding) {
-        transforms.push(`translateY(${viewportPadding - rect.top}px)`)
-      }
-
-      menu.style.transform = transforms.join(' ')
+      menu.style.left = `${left}px`
+      menu.style.top = `${top}px`
+      menu.style.visibility = ''
     })
 
     this.addOutsideClickListener()
@@ -97,6 +109,10 @@ export default class extends Controller {
   hide() {
     const menu = this.menuTarget
     menu.style.display = 'none'
+    menu.style.position = ''
+    menu.style.visibility = ''
+    menu.style.left = ''
+    menu.style.right = ''
     menu.style.top = ''
     menu.style.bottom = ''
     menu.style.maxWidth = ''

--- a/engines/collavre/app/javascript/controllers/popup_menu_controller.js
+++ b/engines/collavre/app/javascript/controllers/popup_menu_controller.js
@@ -38,26 +38,39 @@ export default class extends Controller {
   show() {
     notifyPopupOpen(this._popupId)
     const menu = this.menuTarget
+    const viewportPadding = 4
+
     menu.style.display = 'block'
     menu.style.transform = ''
-
-    const transforms = []
-    const viewportPadding = 4
+    menu.style.maxWidth = `calc(100vw - ${viewportPadding * 2}px)`
 
     this.buttonTarget?.setAttribute('aria-expanded', 'true')
 
     requestAnimationFrame(() => {
-      const rect = menu.getBoundingClientRect()
-      if (rect.right > window.innerWidth) {
-        transforms.push(`translateX(-${rect.right - window.innerWidth + viewportPadding}px)`)
-      } else if (rect.left < 0) {
-        transforms.push(`translateX(${Math.abs(rect.left) + viewportPadding}px)`)
+      const transforms = []
+      let rect = menu.getBoundingClientRect()
+      const spaceBelow = window.innerHeight - rect.top
+      const spaceAbove = rect.bottom
+
+      if (rect.bottom > window.innerHeight && spaceAbove > spaceBelow) {
+        menu.style.top = 'auto'
+        menu.style.bottom = 'calc(100% + 4px)'
+        rect = menu.getBoundingClientRect()
+      } else {
+        menu.style.top = 'calc(100% + 4px)'
+        menu.style.bottom = 'auto'
       }
 
-      if (rect.bottom > window.innerHeight) {
+      if (rect.right > window.innerWidth - viewportPadding) {
+        transforms.push(`translateX(-${rect.right - window.innerWidth + viewportPadding}px)`)
+      } else if (rect.left < viewportPadding) {
+        transforms.push(`translateX(${viewportPadding - rect.left}px)`)
+      }
+
+      if (rect.bottom > window.innerHeight - viewportPadding) {
         transforms.push(`translateY(-${rect.bottom - window.innerHeight + viewportPadding}px)`)
-      } else if (rect.top < 0) {
-        transforms.push(`translateY(${Math.abs(rect.top) + viewportPadding}px)`)
+      } else if (rect.top < viewportPadding) {
+        transforms.push(`translateY(${viewportPadding - rect.top}px)`)
       }
 
       menu.style.transform = transforms.join(' ')

--- a/engines/collavre/app/javascript/controllers/popup_menu_controller.js
+++ b/engines/collavre/app/javascript/controllers/popup_menu_controller.js
@@ -49,8 +49,8 @@ export default class extends Controller {
     requestAnimationFrame(() => {
       const transforms = []
       let rect = menu.getBoundingClientRect()
-      const spaceBelow = window.innerHeight - rect.top
-      const spaceAbove = rect.bottom
+      const spaceBelow = window.innerHeight - rect.bottom
+      const spaceAbove = rect.top
 
       if (rect.bottom > window.innerHeight && spaceAbove > spaceBelow) {
         menu.style.top = 'auto'

--- a/engines/collavre/app/views/collavre/creatives/_inline_edit_form.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_inline_edit_form.html.erb
@@ -56,7 +56,8 @@
               button_content: inline_delete_button_content,
               button_classes: 'creative-action-btn danger-link',
               button_attributes: { id: 'inline-delete-popup-toggle' },
-              menu_id: 'inline-delete-popup-menu'
+              menu_id: 'inline-delete-popup-menu',
+              align: :right
             ) do %>
           <button type="button"
                   id="inline-archive"

--- a/engines/collavre/app/views/collavre/creatives/_inline_edit_form.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_inline_edit_form.html.erb
@@ -54,7 +54,6 @@
         <% end %>
         <%= render Collavre::PopupMenuComponent.new(
               button_content: inline_delete_button_content,
-              menu_classes: 'inline-delete-popup-menu',
               button_classes: 'creative-action-btn danger-link',
               button_attributes: { id: 'inline-delete-popup-toggle' },
               menu_id: 'inline-delete-popup-menu'

--- a/engines/collavre/app/views/collavre/creatives/_inline_edit_form.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_inline_edit_form.html.erb
@@ -54,11 +54,10 @@
         <% end %>
         <%= render Collavre::PopupMenuComponent.new(
               button_content: inline_delete_button_content,
-              button_classes: 'creative-action-btn danger-link',
               menu_classes: 'inline-delete-popup-menu',
+              button_classes: 'creative-action-btn danger-link',
               button_attributes: { id: 'inline-delete-popup-toggle' },
-              menu_id: 'inline-delete-popup-menu',
-              align: :right
+              menu_id: 'inline-delete-popup-menu'
             ) do %>
           <button type="button"
                   id="inline-archive"

--- a/engines/collavre/app/views/collavre/creatives/_inline_edit_form.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_inline_edit_form.html.erb
@@ -55,6 +55,7 @@
         <%= render Collavre::PopupMenuComponent.new(
               button_content: inline_delete_button_content,
               button_classes: 'creative-action-btn danger-link',
+              menu_classes: 'inline-delete-popup-menu',
               button_attributes: { id: 'inline-delete-popup-toggle' },
               menu_id: 'inline-delete-popup-menu',
               align: :right


### PR DESCRIPTION
## Summary

Fix the inline editor delete popup overflowing the viewport on mobile devices.

## Problem

On narrow mobile screens, the delete confirmation popup (archive/destroy) in the Creative inline editor was positioned off-screen, making it impossible to interact with.

## Changes

### CSS (`popup.css`)
- Added `max-width: min(320px, calc(100vw - 8px))` to `.popup-menu` for viewport containment
- Added mobile-specific `min-width` and `max-width` constraints at `@media (max-width: 768px)`

### JS (`popup_menu_controller.js`)
- Enhanced `show()` to dynamically flip popup upward when more space is available above the trigger
- Added dynamic `popup-menu-right` class toggling when left-aligned popup would overflow right edge
- Improved viewport boundary detection with consistent padding

### Component (`popup_menu_component.rb`)
- Added `menu_classes` parameter to `PopupMenuComponent` for custom CSS classes on the menu element

### Template (`_inline_edit_form.html.erb`)
- Applied `inline-delete-popup-menu` class to the delete popup for targeted styling

### Tests
- Added `popup_menu_controller.test.js` with 3 test cases:
  - Flips upward when more space above
  - Stays below when more space below
  - Switches to right alignment on viewport overflow
- System tests pass (8/8)

## Testing

- [x] Jest tests pass (3/3)
- [x] System tests pass (8/8)
- [x] Manual: delete popup stays within viewport on 360px-wide screen