### PR TITLE
fix: strengthen DONE instructions to prevent premature completion claims

### DIFF
--- a/engines/collavre/config/locales/drop_trigger.en.yml
+++ b/engines/collavre/config/locales/drop_trigger.en.yml
@@ -11,8 +11,8 @@ en:
         ---
         [LOOP INSTRUCTIONS]
         This is a looped trigger. Report your status at the end of each response:
-        - [STATUS: DONE] — task completed successfully
-        - [STATUS: CONTINUE] — making progress, need another iteration
+        - [STATUS: DONE] — ALL actions fully executed and verified. Do NOT report DONE if any action remains unexecuted (e.g. moving creatives, creating PRs, updating records). If you describe remaining work in your response, you are NOT done — use CONTINUE instead.
+        - [STATUS: CONTINUE] — making progress, but some actions still need to be executed
         - [STATUS: BLOCKED reason] — cannot proceed without help
       continue: "🔄 Trigger Loop — iteration %{iteration}/%{max}. Previous work is incomplete. Please continue where you left off and report [STATUS: DONE/CONTINUE/BLOCKED]."
       retry: "🔄 Trigger Loop — iteration %{iteration}/%{max}. The previous attempt failed due to an infrastructure error (timeout/connection). Please try again from the beginning and report [STATUS: DONE/CONTINUE/BLOCKED]."

--- a/engines/collavre/config/locales/drop_trigger.ko.yml
+++ b/engines/collavre/config/locales/drop_trigger.ko.yml
@@ -11,8 +11,8 @@ ko:
         ---
         [LOOP INSTRUCTIONS]
         이것은 루프 트리거입니다. 각 응답의 마지막에 상태를 보고해주세요:
-        - [STATUS: DONE] — 작업 완료
-        - [STATUS: CONTINUE] — 진행 중, 추가 반복 필요
+        - [STATUS: DONE] — 모든 작업을 실제로 실행하고 검증 완료. 실행하지 않은 작업이 남아있으면 (예: 크리에이티브 이동, PR 생성, 레코드 업데이트 등) 절대 DONE을 보고하지 마세요. 응답에 남은 작업을 설명했다면 완료가 아닙니다 — CONTINUE를 사용하세요.
+        - [STATUS: CONTINUE] — 진행 중이지만 아직 실행해야 할 작업이 남아있음
         - [STATUS: BLOCKED 사유] — 도움 없이 진행 불가
       continue: "🔄 트리거 루프 — 반복 %{iteration}/%{max}. 이전 작업이 미완료입니다. 이어서 진행하고 [STATUS: DONE/CONTINUE/BLOCKED]으로 보고해주세요."
       retry: "🔄 트리거 루프 — 반복 %{iteration}/%{max}. 이전 시도가 인프라 에러(타임아웃/연결 실패)로 실패했습니다. 처음부터 다시 시도하고 [STATUS: DONE/CONTINUE/BLOCKED]으로 보고해주세요."


### PR DESCRIPTION
## Problem

AI agents report `[STATUS: DONE]` while describing remaining unexecuted actions in the same response. Example:

> "트리거 지침에 따라 리뷰 (id: 10535) 아래로 이동이 필요합니다. [STATUS: DONE]"

The agent says DONE but hasn't actually performed the move action.

## Solution

Strengthen the `[LOOP INSTRUCTIONS]` prompt in both en/ko:

- **DONE definition**: "ALL actions fully executed and verified" (was: "task completed successfully")
- **Explicit prohibition**: Do NOT report DONE if any action remains unexecuted
- **Self-check rule**: If you describe remaining work in your response, you are NOT done — use CONTINUE

This is the prompt-level defense. LLM-based verification will be added in Phase 2.

## Changes

- `drop_trigger.en.yml`: Updated `trigger_loop.instructions` DONE/CONTINUE descriptions
- `drop_trigger.ko.yml`: Updated `trigger_loop.instructions` DONE/CONTINUE descriptions

## Tests

31 runs, 0 failures (trigger loop + drop trigger jobs)