### PR TITLE
feat: add LLM verification for trigger loop DONE claims (Phase 2)

### DIFF
--- a/engines/collavre/app/jobs/collavre/trigger_loop_check_job.rb
+++ b/engines/collavre/app/jobs/collavre/trigger_loop_check_job.rb
@@ -2,6 +2,8 @@
 
 module Collavre
   class TriggerLoopCheckJob < ApplicationJob
+    include TriggerLoopHelpers
+
     queue_as :default
 
     # Evaluates whether a trigger loop should continue after an AI agent
@@ -74,16 +76,6 @@ module Collavre
 
     private
 
-    def find_last_agent_comment(creative, topic, task)
-      # Bind to this task's agent to avoid reading unrelated AI comments
-      # that may appear during cooldown delay
-      creative.comments
-              .where(topic_id: topic.id, user_id: task.agent_id)
-              .where("comments.created_at >= ?", task.created_at)
-              .order(created_at: :desc)
-              .first
-    end
-
     # Detect infrastructure errors (timeout, connection failure, etc.)
     # These are NOT valid task results — the agent never actually worked.
     MAX_INFRA_RETRIES = 3
@@ -151,18 +143,6 @@ module Collavre
       :continue
     end
 
-    # Single method to update loop state — avoids multiple DB writes per Job execution.
-    # Only the keys passed in `changes` are updated; others are preserved.
-    def update_loop_data(child_creative, **changes)
-      data = child_creative.data || {}
-      trigger = data["trigger"] || {}
-      loop_data = trigger["loop"] || {}
-      changes.each { |key, value| loop_data[key.to_s] = value }
-      trigger["loop"] = loop_data
-      data["trigger"] = trigger
-      child_creative.update!(data: data)
-    end
-
     def post_continue_instruction(child_creative, topic, parent_creative, iteration, max)
       agent = find_trigger_agent(parent_creative)
       return unless agent
@@ -198,15 +178,6 @@ module Collavre
         private: false,
         user: child_creative.user,
         skip_dispatch: false
-      )
-    end
-
-    def post_system_notice(creative, topic, content)
-      creative.comments.create!(
-        content: content,
-        topic_id: topic.id,
-        private: false,
-        skip_default_user: true
       )
     end
 

--- a/engines/collavre/app/jobs/collavre/trigger_loop_check_job.rb
+++ b/engines/collavre/app/jobs/collavre/trigger_loop_check_job.rb
@@ -44,7 +44,9 @@ module Collavre
 
       case status
       when :done
-        update_loop_data(child_creative, state: "completed", infra_retry_count: 0)
+        # Transition to pending_verification and enqueue LLM verification
+        update_loop_data(child_creative, state: "pending_verification", infra_retry_count: 0)
+        TriggerLoopVerifyJob.perform_later(task.id)
       when :stuck
         update_loop_data(child_creative, state: "stuck", infra_retry_count: 0)
         post_system_notice(child_creative, topic, I18n.t(

--- a/engines/collavre/app/jobs/collavre/trigger_loop_verify_job.rb
+++ b/engines/collavre/app/jobs/collavre/trigger_loop_verify_job.rb
@@ -26,6 +26,10 @@ module Collavre
       topic = Topic.find_by(id: task.topic_id)
       return unless topic
 
+      # Only verify tasks from the loop's trigger topic (cross-topic guard)
+      trigger_topic_id = loop_config["trigger_topic_id"]
+      return if trigger_topic_id.present? && trigger_topic_id != task.topic_id
+
       last_agent_comment = find_last_agent_comment(child_creative, topic, task)
       return unless last_agent_comment
 
@@ -56,7 +60,7 @@ module Collavre
           update_loop_data(child_creative,
             state: "running", current_iteration: iteration,
             last_task_id: task.id)
-          post_verification_failed(child_creative, topic, parent_creative, iteration, max, result)
+          post_verification_failed(child_creative, topic, task.agent, iteration, max, result)
         end
       end
     end
@@ -71,17 +75,28 @@ module Collavre
               .first
     end
 
-    # Collect instructions from context creatives + parent description
+    # Collect instructions from context creatives of both parent and child
     def collect_instructions(child_creative, parent_creative)
       parts = []
+      seen_ids = Set.new
 
-      # Parent's trigger instructions (context creative descriptions)
+      # Parent's context creatives (trigger instructions, dev rules, etc.)
       parent_creative.context_creatives.each do |ctx|
+        next if seen_ids.include?(ctx.id)
+        seen_ids.add(ctx.id)
         desc = ctx.description.to_s.strip
         parts << desc if desc.present?
       end
 
-      # Child's own description
+      # Child's own context creatives (may have additional instructions)
+      child_creative.context_creatives.each do |ctx|
+        next if seen_ids.include?(ctx.id)
+        seen_ids.add(ctx.id)
+        desc = ctx.description.to_s.strip
+        parts << desc if desc.present?
+      end
+
+      # Child's own description (the task itself)
       child_desc = child_creative.description.to_s.strip
       parts << "Task: #{child_desc}" if child_desc.present?
 
@@ -137,15 +152,16 @@ module Collavre
       )
 
       response_text = +""
-      client.chat([{ role: "user", text: prompt }]) do |delta|
+      client.chat([ { role: "user", text: prompt } ]) do |delta|
         response_text << delta
       end
 
-      if response_text.strip.start_with?("VERIFIED")
+      cleaned = response_text.strip
+      if cleaned.blank? || cleaned.start_with?("VERIFIED")
         :verified
       else
         # Extract the incomplete reason for the feedback message
-        response_text.strip
+        cleaned
       end
     rescue StandardError => e
       Rails.logger.error("[TriggerLoopVerifyJob] LLM verification failed: #{e.class} #{e.message}")
@@ -163,11 +179,10 @@ module Collavre
       child_creative.update!(data: data)
     end
 
-    def post_verification_failed(child_creative, topic, parent_creative, iteration, max, reason)
-      agent = find_trigger_agent(parent_creative)
-      return unless agent
+    def post_verification_failed(child_creative, topic, task_agent, iteration, max, reason)
+      return unless task_agent
 
-      content = "@#{agent.name}: #{I18n.t(
+      content = "@#{task_agent.name}: #{I18n.t(
         'collavre.trigger_loop.verification_failed',
         iteration: iteration,
         max: max,
@@ -190,12 +205,6 @@ module Collavre
         private: false,
         skip_default_user: true
       )
-    end
-
-    def find_trigger_agent(creative)
-      creative.all_shared_users(:write)
-              .map(&:user)
-              .find(&:ai_user?)
     end
   end
 end

--- a/engines/collavre/app/jobs/collavre/trigger_loop_verify_job.rb
+++ b/engines/collavre/app/jobs/collavre/trigger_loop_verify_job.rb
@@ -2,6 +2,8 @@
 
 module Collavre
   class TriggerLoopVerifyJob < ApplicationJob
+    include TriggerLoopHelpers
+
     queue_as :default
 
     # Verifies whether an agent's [STATUS: DONE] claim is genuine by asking
@@ -66,14 +68,6 @@ module Collavre
     end
 
     private
-
-    def find_last_agent_comment(creative, topic, task)
-      creative.comments
-              .where(topic_id: topic.id, user_id: task.agent_id)
-              .where("comments.created_at >= ?", task.created_at)
-              .order(created_at: :desc)
-              .first
-    end
 
     # Collect instructions from context creatives of both parent and child
     def collect_instructions(child_creative, parent_creative)
@@ -169,16 +163,6 @@ module Collavre
       :verified
     end
 
-    def update_loop_data(child_creative, **changes)
-      data = child_creative.data || {}
-      trigger = data["trigger"] || {}
-      loop_data = trigger["loop"] || {}
-      changes.each { |key, value| loop_data[key.to_s] = value }
-      trigger["loop"] = loop_data
-      data["trigger"] = trigger
-      child_creative.update!(data: data)
-    end
-
     def post_verification_failed(child_creative, topic, task_agent, iteration, max, reason)
       return unless task_agent
 
@@ -195,15 +179,6 @@ module Collavre
         private: false,
         user: child_creative.user,
         skip_dispatch: false
-      )
-    end
-
-    def post_system_notice(creative, topic, content)
-      creative.comments.create!(
-        content: content,
-        topic_id: topic.id,
-        private: false,
-        skip_default_user: true
       )
     end
   end

--- a/engines/collavre/app/jobs/collavre/trigger_loop_verify_job.rb
+++ b/engines/collavre/app/jobs/collavre/trigger_loop_verify_job.rb
@@ -1,0 +1,201 @@
+# frozen_string_literal: true
+
+module Collavre
+  class TriggerLoopVerifyJob < ApplicationJob
+    queue_as :default
+
+    # Verifies whether an agent's [STATUS: DONE] claim is genuine by asking
+    # a separate LLM to compare the agent's response against the original
+    # instructions. If the verification fails, the loop continues instead
+    # of completing.
+    #
+    # The verifier agent is chosen from feedback+ permission AI agents on
+    # the creative, preferring one that is NOT the original task agent.
+    # Falls back to the task agent if no alternative exists.
+    def perform(task_id)
+      task = Task.find_by(id: task_id)
+      return unless task&.creative
+
+      child_creative = task.creative
+      parent_creative = child_creative.parent
+      return unless parent_creative&.drop_trigger_enabled?
+
+      loop_config = child_creative.data&.dig("trigger", "loop")
+      return unless loop_config && loop_config["state"] == "pending_verification"
+
+      topic = Topic.find_by(id: task.topic_id)
+      return unless topic
+
+      last_agent_comment = find_last_agent_comment(child_creative, topic, task)
+      return unless last_agent_comment
+
+      instructions = collect_instructions(child_creative, parent_creative)
+      verifier = pick_verifier_agent(parent_creative, task.agent_id)
+
+      unless verifier
+        # No verifier available — accept DONE as-is
+        update_loop_data(child_creative, state: "completed")
+        return
+      end
+
+      result = verify_completion(verifier, instructions, last_agent_comment.content.to_s)
+
+      if result == :verified
+        update_loop_data(child_creative, state: "completed")
+      else
+        # Verification failed — continue the loop
+        iteration = (loop_config["current_iteration"] || 0) + 1
+        max = loop_config["max_iterations"] || 10
+
+        if iteration >= max
+          update_loop_data(child_creative, state: "max_reached")
+          post_system_notice(child_creative, topic, I18n.t(
+            "collavre.trigger_loop.max_reached", max: max
+          ))
+        else
+          update_loop_data(child_creative,
+            state: "running", current_iteration: iteration,
+            last_task_id: task.id)
+          post_verification_failed(child_creative, topic, parent_creative, iteration, max, result)
+        end
+      end
+    end
+
+    private
+
+    def find_last_agent_comment(creative, topic, task)
+      creative.comments
+              .where(topic_id: topic.id, user_id: task.agent_id)
+              .where("comments.created_at >= ?", task.created_at)
+              .order(created_at: :desc)
+              .first
+    end
+
+    # Collect instructions from context creatives + parent description
+    def collect_instructions(child_creative, parent_creative)
+      parts = []
+
+      # Parent's trigger instructions (context creative descriptions)
+      parent_creative.context_creatives.each do |ctx|
+        desc = ctx.description.to_s.strip
+        parts << desc if desc.present?
+      end
+
+      # Child's own description
+      child_desc = child_creative.description.to_s.strip
+      parts << "Task: #{child_desc}" if child_desc.present?
+
+      parts.join("\n\n---\n\n")
+    end
+
+    # Pick a verifier AI agent: prefer one with feedback+ permission that
+    # is NOT the original task agent. Fall back to the task agent only if
+    # no other AI agent exists.
+    def pick_verifier_agent(creative, task_agent_id)
+      ai_agents = creative.all_shared_users(:feedback)
+                          .map(&:user)
+                          .select(&:ai_user?)
+
+      return nil if ai_agents.empty?
+
+      # Prefer a different agent
+      other = ai_agents.find { |a| a.id != task_agent_id }
+      other || ai_agents.first
+    end
+
+    VERIFY_SYSTEM_PROMPT = <<~PROMPT.freeze
+      You are a strict task completion verifier. Your job is to determine whether an AI agent has ACTUALLY completed all required actions described in the instructions.
+
+      Rules:
+      - Compare the agent's response against every action item in the instructions.
+      - "Completed" means the agent EXECUTED the action (e.g. created a PR, moved a creative, updated a record), not merely described or planned it.
+      - If the agent says something "needs to be done" or "should be done" but didn't do it, that is NOT completed.
+      - Be strict: if ANY required action was not executed, respond INCOMPLETE.
+    PROMPT
+
+    def verify_completion(verifier, instructions, agent_response)
+      prompt = <<~PROMPT
+        ## Instructions given to the agent:
+        #{instructions}
+
+        ## Agent's response:
+        #{agent_response}
+
+        ## Question:
+        Did the agent actually execute ALL required actions in the instructions?
+        Respond with exactly one of:
+        - VERIFIED — all actions were executed
+        - INCOMPLETE: [list the unexecuted actions]
+      PROMPT
+
+      client = AiClient.new(
+        vendor: verifier.llm_vendor,
+        model: verifier.llm_model,
+        system_prompt: VERIFY_SYSTEM_PROMPT,
+        llm_api_key: verifier.llm_api_key || verifier.creator&.llm_api_key,
+        context: {}
+      )
+
+      response_text = +""
+      client.chat([{ role: "user", text: prompt }]) do |delta|
+        response_text << delta
+      end
+
+      if response_text.strip.start_with?("VERIFIED")
+        :verified
+      else
+        # Extract the incomplete reason for the feedback message
+        response_text.strip
+      end
+    rescue StandardError => e
+      Rails.logger.error("[TriggerLoopVerifyJob] LLM verification failed: #{e.class} #{e.message}")
+      # On LLM failure, accept DONE to avoid blocking
+      :verified
+    end
+
+    def update_loop_data(child_creative, **changes)
+      data = child_creative.data || {}
+      trigger = data["trigger"] || {}
+      loop_data = trigger["loop"] || {}
+      changes.each { |key, value| loop_data[key.to_s] = value }
+      trigger["loop"] = loop_data
+      data["trigger"] = trigger
+      child_creative.update!(data: data)
+    end
+
+    def post_verification_failed(child_creative, topic, parent_creative, iteration, max, reason)
+      agent = find_trigger_agent(parent_creative)
+      return unless agent
+
+      content = "@#{agent.name}: #{I18n.t(
+        'collavre.trigger_loop.verification_failed',
+        iteration: iteration,
+        max: max,
+        reason: reason.to_s.truncate(500)
+      )}"
+
+      child_creative.comments.create!(
+        content: content,
+        topic_id: topic.id,
+        private: false,
+        user: child_creative.user,
+        skip_dispatch: false
+      )
+    end
+
+    def post_system_notice(creative, topic, content)
+      creative.comments.create!(
+        content: content,
+        topic_id: topic.id,
+        private: false,
+        skip_default_user: true
+      )
+    end
+
+    def find_trigger_agent(creative)
+      creative.all_shared_users(:write)
+              .map(&:user)
+              .find(&:ai_user?)
+    end
+  end
+end

--- a/engines/collavre/app/jobs/concerns/collavre/trigger_loop_helpers.rb
+++ b/engines/collavre/app/jobs/concerns/collavre/trigger_loop_helpers.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Collavre
+  module TriggerLoopHelpers
+    extend ActiveSupport::Concern
+
+    private
+
+    # Find the last comment by the task's agent in the trigger topic,
+    # scoped to comments created after the task was dispatched.
+    def find_last_agent_comment(creative, topic, task)
+      creative.comments
+              .where(topic_id: topic.id, user_id: task.agent_id)
+              .where("comments.created_at >= ?", task.created_at)
+              .order(created_at: :desc)
+              .first
+    end
+
+    # Single method to update loop state — avoids multiple DB writes per Job execution.
+    # Only the keys passed in `changes` are updated; others are preserved.
+    def update_loop_data(child_creative, **changes)
+      data = child_creative.data || {}
+      trigger = data["trigger"] || {}
+      loop_data = trigger["loop"] || {}
+      changes.each { |key, value| loop_data[key.to_s] = value }
+      trigger["loop"] = loop_data
+      data["trigger"] = trigger
+      child_creative.update!(data: data)
+    end
+
+    # Post a system notice (no specific user author) in the trigger topic.
+    def post_system_notice(creative, topic, content)
+      creative.comments.create!(
+        content: content,
+        topic_id: topic.id,
+        private: false,
+        skip_default_user: true
+      )
+    end
+  end
+end

--- a/engines/collavre/config/locales/drop_trigger.en.yml
+++ b/engines/collavre/config/locales/drop_trigger.en.yml
@@ -19,3 +19,4 @@ en:
       stuck: "⚠️ Trigger Loop paused — Agent reported BLOCKED at iteration %{iteration}. User intervention may be needed."
       max_reached: "⚠️ Trigger Loop stopped — Reached maximum iterations (%{max}). Review progress and restart if needed."
       infra_stuck: "⚠️ Trigger Loop paused — %{count} consecutive infrastructure errors (timeout/connection). The service may be unavailable. User intervention needed."
+      verification_failed: "🔍 Trigger Loop — iteration %{iteration}/%{max}. Your [STATUS: DONE] was not verified. The following actions were not completed:\n%{reason}\n\nPlease complete all remaining actions and report [STATUS: DONE/CONTINUE/BLOCKED]."

--- a/engines/collavre/config/locales/drop_trigger.ko.yml
+++ b/engines/collavre/config/locales/drop_trigger.ko.yml
@@ -19,3 +19,4 @@ ko:
       stuck: "⚠️ 트리거 루프 일시정지 — 에이전트가 반복 %{iteration}에서 BLOCKED를 보고했습니다. 사용자 개입이 필요할 수 있습니다."
       max_reached: "⚠️ 트리거 루프 중단 — 최대 반복 횟수(%{max})에 도달했습니다. 진행 상황을 확인하고 필요시 재시작해주세요."
       infra_stuck: "⚠️ 트리거 루프 일시정지 — 연속 %{count}회 인프라 에러(타임아웃/연결 실패) 발생. 서비스가 불안정할 수 있습니다. 사용자 개입이 필요합니다."
+      verification_failed: "🔍 트리거 루프 — 반복 %{iteration}/%{max}. [STATUS: DONE] 검증에 실패했습니다. 다음 작업이 완료되지 않았습니다:\n%{reason}\n\n남은 작업을 모두 완료한 후 [STATUS: DONE/CONTINUE/BLOCKED]으로 보고해주세요."

--- a/engines/collavre/test/jobs/collavre/trigger_loop_check_job_test.rb
+++ b/engines/collavre/test/jobs/collavre/trigger_loop_check_job_test.rb
@@ -62,7 +62,7 @@ module Collavre
       Task.where(id: @task.id).update_all(status: "done")
     end
 
-    test "completes loop when agent reports STATUS: DONE" do
+    test "transitions to pending_verification when agent reports STATUS: DONE" do
       @child.comments.create!(
         content: "All done! [STATUS: DONE]",
         topic_id: @topic.id,
@@ -70,10 +70,13 @@ module Collavre
         created_at: @task.created_at + 1.second
       )
 
-      TriggerLoopCheckJob.perform_now(@task.id)
+      # Stub VerifyJob to prevent inline execution from changing state
+      TriggerLoopVerifyJob.stub(:perform_later, ->(task_id) { }) do
+        TriggerLoopCheckJob.perform_now(@task.id)
+      end
 
       @child.reload
-      assert_equal "completed", @child.data.dig("trigger", "loop", "state")
+      assert_equal "pending_verification", @child.data.dig("trigger", "loop", "state")
     end
 
     test "completes loop when agent reports STATUS: BLOCKED" do

--- a/engines/collavre/test/jobs/collavre/trigger_loop_verify_job_test.rb
+++ b/engines/collavre/test/jobs/collavre/trigger_loop_verify_job_test.rb
@@ -1,0 +1,186 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  class TriggerLoopVerifyJobTest < ActiveSupport::TestCase
+    include ActiveJob::TestHelper
+
+    setup do
+      @human = users(:one)
+      @ai_bot = users(:ai_bot)
+
+      @parent = Creative.create!(
+        description: "Parent with trigger",
+        user: @human,
+        data: {
+          "trigger" => { "on_child_enter" => true }
+        }
+      )
+      CreativeShare.create!(creative: @parent, user: @ai_bot, permission: :write)
+
+      # Create child without parent, then move it to avoid DropTriggerJob
+      @child = Creative.create!(
+        description: "Child task",
+        user: @human
+      )
+      Creative.where(id: @child.id).update_all(parent_id: @parent.id)
+      @child.reload
+
+      @topic = @child.topics.create!(name: "Drop Trigger", user: @human)
+
+      @child.update!(data: {
+        "trigger" => {
+          "loop" => {
+            "state" => "pending_verification",
+            "current_iteration" => 1,
+            "max_iterations" => 10,
+            "trigger_topic_id" => @topic.id,
+            "last_task_id" => nil,
+            "cooldown_seconds" => 0,
+            "infra_retry_count" => 0
+          }
+        }
+      })
+
+      @task = Task.create!(
+        name: "Response to comment_created",
+        status: "running",
+        trigger_event_name: "comment_created",
+        trigger_event_payload: { "comment" => { "id" => 999 } },
+        agent_id: @ai_bot.id,
+        creative_id: @child.id,
+        topic_id: @topic.id
+      )
+      Task.where(id: @task.id).update_all(status: "done")
+
+      @agent_comment = @child.comments.create!(
+        content: "I have completed all tasks. PR created and creative moved. [STATUS: DONE]",
+        topic_id: @topic.id,
+        user: @ai_bot,
+        skip_dispatch: true,
+        created_at: @task.created_at + 1.second
+      )
+    end
+
+    test "completes loop when verification returns VERIFIED" do
+      mock_client = mock_ai_client("VERIFIED")
+
+      AiClient.stub(:new, mock_client) do
+        TriggerLoopVerifyJob.perform_now(@task.id)
+      end
+
+      @child.reload
+      assert_equal "completed", @child.data.dig("trigger", "loop", "state")
+    end
+
+    test "continues loop when verification returns INCOMPLETE" do
+      mock_client = mock_ai_client("INCOMPLETE: creative not moved to review")
+
+      AiClient.stub(:new, mock_client) do
+        # Stub SystemEvents::Dispatcher to prevent dispatch errors
+        SystemEvents::Dispatcher.stub(:dispatch, []) do
+          TriggerLoopVerifyJob.perform_now(@task.id)
+        end
+      end
+
+      @child.reload
+      assert_equal "running", @child.data.dig("trigger", "loop", "state")
+      assert_equal 2, @child.data.dig("trigger", "loop", "current_iteration")
+    end
+
+    test "accepts DONE when LLM call fails (graceful degradation)" do
+      error_client = ->(**opts) {
+        obj = Object.new
+        obj.define_singleton_method(:chat) { |messages, &block| raise StandardError, "LLM API error" }
+        obj
+      }
+
+      AiClient.stub(:new, error_client) do
+        TriggerLoopVerifyJob.perform_now(@task.id)
+      end
+
+      @child.reload
+      assert_equal "completed", @child.data.dig("trigger", "loop", "state")
+    end
+
+    test "skips when loop state is not pending_verification" do
+      @child.data["trigger"]["loop"]["state"] = "running"
+      @child.save!
+
+      TriggerLoopVerifyJob.perform_now(@task.id)
+
+      @child.reload
+      assert_equal "running", @child.data.dig("trigger", "loop", "state")
+    end
+
+    test "accepts DONE when no verifier agent available" do
+      CreativeShare.where(creative: @parent, user: @ai_bot).destroy_all
+
+      TriggerLoopVerifyJob.perform_now(@task.id)
+
+      @child.reload
+      assert_equal "completed", @child.data.dig("trigger", "loop", "state")
+    end
+
+    test "prefers a different AI agent for verification" do
+      ai_bot2 = users(:two)
+      ai_bot2.update_columns(llm_vendor: "google", llm_model: "gemini-2.0-flash")
+      CreativeShare.create!(creative: @parent, user: ai_bot2, permission: :feedback)
+
+      selected_vendor = nil
+      factory = ->(**opts) {
+        selected_vendor = opts[:vendor]
+        mock_ai_client("VERIFIED")
+      }
+
+      AiClient.stub(:new, factory) do
+        TriggerLoopVerifyJob.perform_now(@task.id)
+      end
+
+      # Should have used ai_bot2 (different from task agent ai_bot)
+      assert_equal "google", selected_vendor
+    end
+
+    test "falls back to task agent when no other AI agent exists" do
+      selected_vendor = nil
+      factory = ->(**opts) {
+        selected_vendor = opts[:vendor]
+        mock_ai_client("VERIFIED")
+      }
+
+      AiClient.stub(:new, factory) do
+        TriggerLoopVerifyJob.perform_now(@task.id)
+      end
+
+      # Only ai_bot exists, so it should be used
+      assert_equal @ai_bot.llm_vendor, selected_vendor
+    end
+
+    test "transitions to max_reached when verification fails at last iteration" do
+      @child.data["trigger"]["loop"]["current_iteration"] = 9
+      @child.data["trigger"]["loop"]["max_iterations"] = 10
+      @child.save!
+
+      mock_client = mock_ai_client("INCOMPLETE: PR not created")
+
+      AiClient.stub(:new, mock_client) do
+        TriggerLoopVerifyJob.perform_now(@task.id)
+      end
+
+      @child.reload
+      assert_equal "max_reached", @child.data.dig("trigger", "loop", "state")
+    end
+
+    private
+
+    def mock_ai_client(response_text)
+      obj = Object.new
+      obj.define_singleton_method(:chat) do |messages, &block|
+        block&.call(response_text)
+        response_text
+      end
+      obj
+    end
+  end
+end


### PR DESCRIPTION
## Problem

AI agents report `[STATUS: DONE]` without actually completing all required actions. Example: agent says "creative needs to be moved to review" but reports DONE without executing the move.

Prompt strengthening (PR #1095) helps but isn't sufficient — agents can still violate instructions.

## Solution

**LLM-based DONE verification**: When an agent claims `[STATUS: DONE]`, a separate LLM verifies whether all actions described in the instructions were actually executed.

### Flow

```
Agent reports [STATUS: DONE]
  → TriggerLoopCheckJob: state → pending_verification
  → TriggerLoopVerifyJob:
      1. Collect instructions from context creatives
      2. Pick verifier agent (different AI agent with feedback+ permission)
      3. Ask LLM: "Did the agent execute ALL required actions?"
      4a. VERIFIED → state: completed
      4b. INCOMPLETE → state: running, continue loop with feedback
      4c. LLM error → gracefully accept DONE (no blocking)
```

### Verifier Agent Selection

- Prefers a **different** AI agent from the one that performed the task
- Requires **feedback or higher** permission on the parent creative
- Falls back to the same agent only if no other AI agent exists
- This prevents self-grading bias

### Key Design Decisions

- **Graceful degradation**: If LLM verification fails (API error, timeout), DONE is accepted rather than blocking the loop
- **Detailed feedback**: On verification failure, the agent receives specific info about what wasn't completed
- **Cost-efficient**: LLM is only called once per DONE claim, not every iteration

## Changes

- **New**: `TriggerLoopVerifyJob` — LLM-based completion verification
- **Modified**: `TriggerLoopCheckJob` — DONE now transitions to `pending_verification` state
- **i18n**: `verification_failed` key (en/ko)

## Tests

39 runs, 118 assertions, 0 failures (verify job: 8, check job: 16, drop trigger: 15)