### PR TITLE
fix: add real-time broadcast for creative creation via MCP tools

### DIFF
--- a/engines/collavre/app/jobs/collavre/creative_broadcast_job.rb
+++ b/engines/collavre/app/jobs/collavre/creative_broadcast_job.rb
@@ -8,16 +8,29 @@ module Collavre
     retry_on StandardError, wait: 1.second, attempts: 3
     discard_on ActiveRecord::RecordNotFound
 
-    # @param creative_id [Integer]
-    # @param action [String] "created", "updated", or "destroyed"
+    # @param creative_id [Integer, Array<Integer>] single ID or array of IDs (for batch_created)
+    # @param action [String] "created", "updated", "destroyed", or "batch_created"
     # @param current_user_id [Integer, nil] user who triggered the change (excluded from broadcast)
     # @param payload [Hash] pre-built node payload (for created/updated) or destroy payload
     # @param options [Hash] extra options (after_id, destroy_users, destroy_linked_map)
     def perform(creative_id, action, current_user_id: nil, payload: {}, options: {})
-      creative = Creative.find_by(id: creative_id)
-
       case action
+      when "batch_created"
+        # creative_id is an array of IDs in tree order (parent before child).
+        # Process sequentially within a single job to guarantee ordering.
+        creative_ids = Array(creative_id)
+        creative_ids.each do |cid|
+          creative = Creative.find_by(id: cid)
+          next unless creative
+
+          creative.reload
+          node_payload = creative.broadcast_node_payload
+          node_payload[:previous_sibling_id] = creative.previous_sibling&.id
+          broadcast_change(creative, "created", current_user_id, node_payload)
+        end
+        return
       when "created", "updated"
+        creative = Creative.find_by(id: creative_id)
         return unless creative
 
         broadcast_change(creative, action, current_user_id, payload.deep_symbolize_keys)

--- a/engines/collavre/app/jobs/collavre/creative_broadcast_job.rb
+++ b/engines/collavre/app/jobs/collavre/creative_broadcast_job.rb
@@ -28,7 +28,7 @@ module Collavre
           node_payload[:previous_sibling_id] = creative.previous_sibling&.id
           broadcast_change(creative, "created", current_user_id, node_payload)
         end
-        return
+        nil
       when "created", "updated"
         creative = Creative.find_by(id: creative_id)
         return unless creative

--- a/engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb
+++ b/engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb
@@ -143,6 +143,20 @@ module Collavre
         )
       end
 
+      # Enqueue a single batch job for multiple created creatives (e.g. MarkdownImporter).
+      # Processes all broadcasts sequentially within one job to guarantee parent-before-child
+      # ordering, preventing silent drops when child broadcasts arrive before parent DOM exists.
+      def self.broadcast_batch_created(creatives)
+        return if creatives.blank?
+
+        creative_ids = creatives.map(&:id)
+        CreativeBroadcastJob.perform_later(
+          creative_ids,
+          "batch_created",
+          current_user_id: Collavre.current_user&.id
+        )
+      end
+
       # Build a map of user_id → linked_creative_id for this creative
       # So each user receives the correct ID for their view
       def build_linked_creative_map(users)

--- a/engines/collavre/app/services/collavre/markdown_importer.rb
+++ b/engines/collavre/app/services/collavre/markdown_importer.rb
@@ -108,6 +108,10 @@ module Collavre
           i += 1
         end
       end
+
+      # Broadcast all created creatives for real-time UI sync
+      created.each { |c| c.reload.broadcast_creative_created }
+
       created
     end
 

--- a/engines/collavre/app/services/collavre/markdown_importer.rb
+++ b/engines/collavre/app/services/collavre/markdown_importer.rb
@@ -109,8 +109,9 @@ module Collavre
         end
       end
 
-      # Broadcast all created creatives for real-time UI sync
-      created.each { |c| c.reload.broadcast_creative_created }
+      # Broadcast all created creatives in a single batch job to guarantee
+      # parent-before-child ordering (prevents silent drops in frontend)
+      Creative::RealtimeBroadcastable.broadcast_batch_created(created)
 
       created
     end

--- a/engines/collavre/app/services/collavre/tools/creative_create_service.rb
+++ b/engines/collavre/app/services/collavre/tools/creative_create_service.rb
@@ -52,6 +52,10 @@ module Tools
       # Handle ordering
       handle_ordering(creative, before_id: before_id, after_id: after_id)
 
+      # Broadcast after ordering so sequence and previous_sibling are correct
+      creative.reload
+      creative.broadcast_creative_created(after_id: after_id)
+
       {
         success: true,
         id: creative.id,

--- a/engines/collavre/test/jobs/collavre/creative_broadcast_job_test.rb
+++ b/engines/collavre/test/jobs/collavre/creative_broadcast_job_test.rb
@@ -304,5 +304,60 @@ module Collavre
         )
       end
     end
+
+    # --- batch_created action ---
+
+    test "batch_created processes multiple creatives in order without raising" do
+      child2 = nil
+      perform_enqueued_jobs do
+        child2 = Creative.create!(user: @owner, parent: @root, description: "Batch child 2")
+      end
+
+      assert_nothing_raised do
+        CreativeBroadcastJob.perform_now(
+          [ @child.id, child2.id, @grandchild.id ],
+          "batch_created",
+          current_user_id: @owner.id
+        )
+      end
+    end
+
+    test "batch_created skips missing creative IDs gracefully" do
+      assert_nothing_raised do
+        CreativeBroadcastJob.perform_now(
+          [ @child.id, 999_999_999, @grandchild.id ],
+          "batch_created",
+          current_user_id: @owner.id
+        )
+      end
+    end
+
+    test "batch_created with empty array is no-op" do
+      assert_nothing_raised do
+        CreativeBroadcastJob.perform_now(
+          [],
+          "batch_created",
+          current_user_id: @owner.id
+        )
+      end
+    end
+
+    test "broadcast_batch_created enqueues single job with all creative IDs" do
+      saved_adapter = ActiveJob::Base.queue_adapter
+      ActiveJob::Base.queue_adapter = :test
+
+      begin
+        child2 = nil
+        perform_enqueued_jobs do
+          child2 = Creative.create!(user: @owner, parent: @root, description: "Batch test")
+        end
+
+        assert_enqueued_with(job: CreativeBroadcastJob) do
+          Creative::RealtimeBroadcastable.broadcast_batch_created([ @child, child2 ])
+        end
+      ensure
+        ActiveJob::Base.queue_adapter = saved_adapter
+      end
+    end
   end
 end

--- a/engines/collavre/test/services/tools/creative_create_service_test.rb
+++ b/engines/collavre/test/services/tools/creative_create_service_test.rb
@@ -3,9 +3,13 @@ require "test_helper"
 module Collavre
   module Tools
     class CreativeCreateServiceTest < ActiveSupport::TestCase
+      include ActiveJob::TestHelper
+
       setup do
         @user = User.create!(name: "Test User", email: "test_create@example.com", password: "password123")
         Current.user = @user
+        @original_adapter = ActiveJob::Base.queue_adapter
+        ActiveJob::Base.queue_adapter = :test
         @parent_creative = Creative.create!(
           description: "<p>Parent Creative</p>",
           user: @user
@@ -14,6 +18,7 @@ module Collavre
 
       teardown do
         Current.user = nil
+        ActiveJob::Base.queue_adapter = @original_adapter
       end
 
       test "creates a creative with plain text description" do
@@ -138,6 +143,18 @@ module Collavre
         assert result[:success]
         creative = Creative.find(result[:id])
         assert_equal "<p>New task with newlines</p>", creative.description
+      end
+
+      test "enqueues broadcast job after create" do
+        service = CreativeCreateService.new
+
+        assert_enqueued_with(job: CreativeBroadcastJob) do
+          result = service.call(
+            parent_id: @parent_creative.id,
+            description: "Broadcast test"
+          )
+          assert result[:success]
+        end
       end
 
       test "raises error when no current user" do


### PR DESCRIPTION
## Problem

Creative CRUD operations performed by AI agents (via MCP tools) were not triggering real-time UI updates via WebSocket. This affected all creatives created through drop triggers and other AI agent workflows.

### Root Cause

`RealtimeBroadcastable` intentionally does **not** use `after_create_commit` because `Creatives::CreateService` needs to call `insert_at_position` (resequence) **before** broadcasting. Instead, `broadcast_creative_created` is called explicitly from `CreateService`.

However, the MCP tool code paths (`Tools::CreativeCreateService` and `MarkdownImporter`) were never updated to include this explicit broadcast call.

| Service | Create Broadcast | Update Broadcast | Destroy Broadcast |
|---|---|---|---|
| `Tools::CreativeCreateService` | ❌ **Missing** → ✅ Fixed | N/A | N/A |
| `Tools::CreativeBatchService` | ❌ (delegates to above) → ✅ Fixed | ✅ callback | ✅ callback |
| `Tools::CreativeImportService` | ❌ (`MarkdownImporter`) → ✅ Fixed | N/A | N/A |
| `Tools::CreativeUpdateService` | N/A | ✅ `after_update_commit` | N/A |

Note: Update and Destroy already worked because they use model callbacks (`after_update_commit`, `after_destroy_commit`).

## Changes

- **`Tools::CreativeCreateService`**: Call `broadcast_creative_created` after `handle_ordering`, matching the pattern in `Creatives::CreateService`
- **`MarkdownImporter`**: Broadcast all created creatives after import completes
- **Test**: Added test verifying `CreativeBroadcastJob` is enqueued when creating via MCP tool

## Same-user session behavior

The broadcast correctly excludes the AI agent user (`Collavre.current_user`) and delivers to human users who have read permission on the creative tree.