### PR TITLE
fix: infer topic_id from comment in OpenClaw session key

### DIFF
--- a/engines/collavre_openclaw/app/services/collavre_openclaw/openclaw_adapter.rb
+++ b/engines/collavre_openclaw/app/services/collavre_openclaw/openclaw_adapter.rb
@@ -335,7 +335,7 @@ module CollavreOpenclaw
     # Format: agent:<agent_id>:collavre:<user_id>:creative:<id>:topic:<id>
     def build_session_key
       creative_id = extract_id(@context, :creative) || @context[:creative_id]
-      topic_id = @context[:thread_id] || @context[:topic_id]
+      topic_id = @context[:thread_id] || @context[:topic_id] || infer_topic_id
       agent_id = extract_agent_id_from_email || "main"
 
       parts = [ "agent", agent_id, "collavre", @user.id ]
@@ -372,7 +372,7 @@ module CollavreOpenclaw
 
       creative_id = extract_id(@context, :creative) || @context[:creative_id]
       comment_id = extract_id(@context, :comment) || @context[:comment_id]
-      topic_id = @context[:thread_id] || @context[:topic_id]
+      topic_id = @context[:thread_id] || @context[:topic_id] || infer_topic_id
 
       callback = callback_url
       if callback.present? && creative_id.present?
@@ -591,6 +591,15 @@ module CollavreOpenclaw
     def extract_agent_id_from_email
       return nil unless @user&.email.present?
       @user.email.split("@").first
+    end
+
+    # Infer topic_id from the comment object in context when not explicitly provided.
+    # AiAgentService passes :comment (the reply or original comment) which carries topic_id.
+    def infer_topic_id
+      comment = @context[:comment]
+      return comment.topic_id if comment.respond_to?(:topic_id) && comment.topic_id.present?
+
+      nil
     end
 
     def default_url_options

--- a/engines/collavre_openclaw/test/services/openclaw_adapter_test.rb
+++ b/engines/collavre_openclaw/test/services/openclaw_adapter_test.rb
@@ -291,6 +291,73 @@ module CollavreOpenclaw
       assert_not_equal adapter1.session_key, adapter2.session_key
     end
 
+    test "session key infers topic_id from comment object in context" do
+      user = build_test_user(gateway_url: "https://test-gateway.com", email: "bot@example.com")
+
+      # Simulate a comment object with topic_id (as passed by AiAgentService)
+      comment = Object.new
+      comment.define_singleton_method(:id) { 42 }
+      comment.define_singleton_method(:topic_id) { 789 }
+
+      creative = Object.new
+      creative.define_singleton_method(:id) { 100 }
+
+      adapter = OpenclawAdapter.new(
+        user: user,
+        system_prompt: "",
+        context: { creative: creative, comment: comment }
+      )
+
+      session_key = adapter.session_key
+
+      assert_includes session_key, "creative:100"
+      assert_includes session_key, "topic:789"
+    end
+
+    test "session key does not include topic when comment has no topic_id" do
+      user = build_test_user(gateway_url: "https://test-gateway.com", email: "bot@example.com")
+
+      comment = Object.new
+      comment.define_singleton_method(:id) { 42 }
+      comment.define_singleton_method(:topic_id) { nil }
+
+      creative = Object.new
+      creative.define_singleton_method(:id) { 100 }
+
+      adapter = OpenclawAdapter.new(
+        user: user,
+        system_prompt: "",
+        context: { creative: creative, comment: comment }
+      )
+
+      session_key = adapter.session_key
+
+      assert_includes session_key, "creative:100"
+      assert_not_includes session_key, "topic:"
+    end
+
+    test "explicit topic_id takes precedence over inferred from comment" do
+      user = build_test_user(gateway_url: "https://test-gateway.com", email: "bot@example.com")
+
+      comment = Object.new
+      comment.define_singleton_method(:id) { 42 }
+      comment.define_singleton_method(:topic_id) { 789 }
+
+      creative = Object.new
+      creative.define_singleton_method(:id) { 100 }
+
+      adapter = OpenclawAdapter.new(
+        user: user,
+        system_prompt: "",
+        context: { creative: creative, comment: comment, topic_id: 555 }
+      )
+
+      session_key = adapter.session_key
+
+      assert_includes session_key, "topic:555"
+      assert_not_includes session_key, "topic:789"
+    end
+
     test "session key differs for different agents" do
       user1 = build_test_user(gateway_url: "https://test-gateway.com", email: "agent-a@example.com")
       user2 = build_test_user(gateway_url: "https://test-gateway.com", email: "agent-b@example.com")


### PR DESCRIPTION
## Problem

When `AiAgentService` sends a message to the OpenClaw Gateway via WebSocket, it passes a context with `:creative`, `:user`, `:task`, and `:comment` objects — but no explicit `:topic_id` or `:thread_id`.

`OpenclawAdapter#build_session_key` only looked for `@context[:thread_id] || @context[:topic_id]`, resulting in session keys **without** the `topic:<id>` segment. The same issue affected `build_user_context` (HTTP callback flow).

**Impact:** When the Gateway sent proactive messages (heartbeats, cron, late events), `ProactiveMessageHandler` parsed the session key but found no topic. `CallbackProcessorJob` then created the comment **without** a topic association, causing it to appear in **#Main** instead of the correct topic.

## Solution

Add `infer_topic_id` helper to `OpenclawAdapter` that extracts `topic_id` from the comment object in context when not explicitly provided. This is used as a fallback in both:
- `build_session_key` (WebSocket transport)
- `build_user_context` (HTTP callback transport)

The explicit `:thread_id` / `:topic_id` context keys still take precedence.

## Changes

- **`openclaw_adapter.rb`**: Add `infer_topic_id` helper, use as fallback in `build_session_key` and `build_user_context`
- **`openclaw_adapter_test.rb`**: 3 new tests covering inference from comment, nil topic_id, and explicit precedence

## Testing

All 1553 tests pass. Rubocop clean.