### PR TITLE
fix: show empty completion mark when not configured (regression)

### DIFF
--- a/engines/collavre/app/helpers/collavre/creatives_helper.rb
+++ b/engines/collavre/app/helpers/collavre/creatives_helper.rb
@@ -115,7 +115,7 @@ module Collavre
     def render_progress_value(value)
       text = number_to_percentage(value * 100, precision: 0)
       completion_mark = Collavre::SystemSetting.completion_mark
-      if value == 1 && completion_mark.present?
+      if value == 1 && !completion_mark.nil?
         text = completion_mark
       end
       display_text = text.blank? ? "&nbsp;&nbsp;".html_safe : text

--- a/engines/collavre/app/jobs/collavre/creative_broadcast_job.rb
+++ b/engines/collavre/app/jobs/collavre/creative_broadcast_job.rb
@@ -165,7 +165,7 @@ module Collavre
       # Progress span (comes first, matching helper output order)
       css_class = pct >= 100 ? "creative-progress-complete" : "creative-progress-incomplete"
       completion_mark = Collavre::SystemSetting.completion_mark
-      display_text = pct >= 100 && completion_mark.present? ? completion_mark : "#{pct}%"
+      display_text = pct >= 100 && !completion_mark.nil? ? completion_mark : "#{pct}%"
       progress_span = %(<span class="#{css_class}">#{display_text}</span>)
 
       # Comment part — only render if user has feedback permission (matching helper behavior)

--- a/engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb
+++ b/engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb
@@ -165,7 +165,7 @@ module Collavre
       def format_progress_text(progress_value, _user = nil)
         pct = ((progress_value || 0) * 100).round
         completion_mark = Collavre::SystemSetting.completion_mark
-        if pct >= 100 && completion_mark.present?
+        if pct >= 100 && !completion_mark.nil?
           completion_mark
         else
           "#{pct}%"

--- a/engines/collavre/test/models/collavre/creative/realtime_broadcastable_test.rb
+++ b/engines/collavre/test/models/collavre/creative/realtime_broadcastable_test.rb
@@ -168,12 +168,23 @@ module Collavre
         Rails.cache.delete("system_setting:completion_mark")
       end
 
-      test "format_progress_text returns 100% when no completion mark set" do
+      test "format_progress_text returns empty string when completion mark is blank" do
+        Collavre::SystemSetting.find_or_initialize_by(key: "completion_mark").tap { |s| s.value = ""; s.save! }
+        Rails.cache.delete("system_setting:completion_mark")
+
+        text = @root.send(:format_progress_text, 1.0)
+        assert_equal "", text
+      ensure
+        Collavre::SystemSetting.find_by(key: "completion_mark")&.destroy
+        Rails.cache.delete("system_setting:completion_mark")
+      end
+
+      test "format_progress_text returns empty string when no completion mark record exists" do
         Collavre::SystemSetting.find_by(key: "completion_mark")&.destroy
         Rails.cache.delete("system_setting:completion_mark")
 
         text = @root.send(:format_progress_text, 1.0)
-        assert_equal "100%", text
+        assert_equal "", text
       end
 
       # --- add_progress_text! ---


### PR DESCRIPTION
## Problem

When `completion_mark` is not set (empty string, which is the default), completed creatives displayed **"100%"** instead of being **blank**. This is a regression introduced in #1094 when `completion_mark` was moved from user profile to admin settings.

## Root Cause

All three rendering paths used `.present?` to check the completion mark value. Since `"".present?` returns `false` in Ruby, an empty/unset completion mark fell through to the percentage display (`100%`).

## Fix

Changed `.present?` → `!.nil?` in all 3 locations so that empty strings are correctly treated as a valid (blank) completion mark:

1. **`creatives_helper.rb`** — `render_progress_value` (server-side HTML render)
2. **`realtime_broadcastable.rb`** — `format_progress_text` (WebSocket broadcast payload)
3. **`creative_broadcast_job.rb`** — `render_progress_html` (new creative broadcast HTML)

The existing `display_text = text.blank? ? "&nbsp;&nbsp;".html_safe : text` in the helper already handles rendering blank text as non-breaking spaces, so no additional UI changes needed.

## Tests

- Updated `realtime_broadcastable_test.rb`: changed "returns 100%" assertion to "returns empty string" and added test for both blank value and missing record scenarios.
- All 1554 tests pass, Rubocop clean.