### PR TITLE
feat: show trigger task status for all children of trigger containers

### DIFF
--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -376,6 +376,22 @@ module Collavre
         previous_enabled = creative.drop_trigger_enabled?
         creative.update!(data: data)
         notify_drop_trigger_missing_agent!(creative) if !previous_enabled && creative.drop_trigger_enabled?
+      when "start"
+        # Start trigger: fires DropTriggerJob as if the child was just dropped into the container
+        creative = @creative
+        unless creative.has_permission?(Current.user, :write)
+          render json: { error: t("collavre.creatives.errors.no_permission") }, status: :forbidden
+          return
+        end
+
+        parent = creative.parent
+        unless parent&.drop_trigger_enabled?
+          render json: { error: "Parent is not a trigger container" }, status: :unprocessable_entity
+          return
+        end
+
+        DropTriggerJob.perform_later(parent.id, creative.id)
+
       when "pause", "resume", "restart"
         # Loop actions operate on the creative itself (where loop state lives)
         creative = @creative

--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -114,6 +114,9 @@ module Collavre
             prompt_updated
           ].compact.max
 
+          trigger_loop_data = @creative.data&.dig("trigger", "loop")
+          parent_trigger_enabled = @creative.parent&.drop_trigger_enabled? || false
+
           etag = [
             "creative",
             @creative.cache_key_with_version,
@@ -125,13 +128,10 @@ module Collavre
             "children",
             children_key,
             "trigger_v3",
-            @creative.data&.dig("trigger", "loop", "state"),
-            @creative.data&.dig("trigger", "loop", "current_iteration"),
-            @creative.parent&.drop_trigger_enabled?
+            trigger_loop_data&.dig("state"),
+            trigger_loop_data&.dig("current_iteration"),
+            parent_trigger_enabled
           ].join(":")
-
-          trigger_loop_data = @creative.data&.dig("trigger", "loop")
-          is_trigger_task = @creative.parent&.drop_trigger_enabled? || false
 
           if stale?(etag: etag, last_modified: last_modified, public: false)
             root = params[:root_id] ? Creative.find_by(id: params[:root_id]) : nil
@@ -153,7 +153,7 @@ module Collavre
               has_children: children_count > 0,
               data: @creative.effective_origin(Set.new).data,
               trigger_loop: trigger_loop_data,
-              is_trigger_task: is_trigger_task,
+              is_trigger_task: parent_trigger_enabled,
               can_edit: @creative.has_permission?(Current.user, :write)
             }
           end
@@ -386,7 +386,7 @@ module Collavre
 
         parent = creative.parent
         unless parent&.drop_trigger_enabled?
-          render json: { error: "Parent is not a trigger container" }, status: :unprocessable_entity
+          render json: { error: t("collavre.drop_trigger.not_a_container") }, status: :unprocessable_entity
           return
         end
 

--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -124,12 +124,14 @@ module Collavre
             prompt_updated&.to_i,
             "children",
             children_key,
-            "trigger_v2",
+            "trigger_v3",
             @creative.data&.dig("trigger", "loop", "state"),
-            @creative.data&.dig("trigger", "loop", "current_iteration")
+            @creative.data&.dig("trigger", "loop", "current_iteration"),
+            @creative.parent&.drop_trigger_enabled?
           ].join(":")
 
           trigger_loop_data = @creative.data&.dig("trigger", "loop")
+          is_trigger_task = @creative.parent&.drop_trigger_enabled? || false
 
           if stale?(etag: etag, last_modified: last_modified, public: false)
             root = params[:root_id] ? Creative.find_by(id: params[:root_id]) : nil
@@ -151,6 +153,7 @@ module Collavre
               has_children: children_count > 0,
               data: @creative.effective_origin(Set.new).data,
               trigger_loop: trigger_loop_data,
+              is_trigger_task: is_trigger_task,
               can_edit: @creative.has_permission?(Current.user, :write)
             }
           end

--- a/engines/collavre/app/javascript/controllers/comments/drop_trigger_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/drop_trigger_controller.js
@@ -180,6 +180,7 @@ export default class extends Controller {
 
                 this._updateUI()
             } else {
+
             }
         } catch (e) {
             console.error("Failed to load trigger state", e)

--- a/engines/collavre/app/javascript/controllers/comments/drop_trigger_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/drop_trigger_controller.js
@@ -23,6 +23,7 @@ const STATE_LABELS = {
 
 // Action label shown in tooltip: "Click to {action}"
 const ACTION_LABELS = {
+    start: "start",
     pause: "pause",
     resume: "resume",
     restart: "restart"
@@ -140,7 +141,8 @@ export default class extends Controller {
 
     _actionForState(state) {
         if (state === "running" || state === "pending_verification") return "pause"
-        if (state === "paused" || state === "idle" || state === "stuck") return "resume"
+        if (state === "idle") return "start"
+        if (state === "paused" || state === "stuck") return "resume"
         if (state === "completed" || state === "max_reached") return "restart"
         return null
     }

--- a/engines/collavre/app/javascript/controllers/comments/drop_trigger_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/drop_trigger_controller.js
@@ -160,17 +160,22 @@ export default class extends Controller {
 
                 const triggerLoop = json.trigger_loop || null
                 const trigger = this._cachedData.trigger || {}
+                const isTriggerTask = json.is_trigger_task === true
 
-                if (triggerLoop && triggerLoop.state) {
+                if (isTriggerTask || (triggerLoop && triggerLoop.state)) {
+                    // Trigger task: parent is a trigger container
                     this._role = "task"
-                    this._loopState = triggerLoop.state
-                    this._loopIteration = triggerLoop.current_iteration || 0
-                    this._loopMax = triggerLoop.max_iterations || 10
+                    this._loopState = (triggerLoop && triggerLoop.state) ? triggerLoop.state : "idle"
+                    this._loopIteration = triggerLoop?.current_iteration || 0
+                    this._loopMax = triggerLoop?.max_iterations || 10
                     this.enabled = false
-                } else {
+                } else if (trigger.on_child_enter !== undefined || json.can_edit) {
                     this._role = "container"
                     this._loopState = null
                     this.enabled = trigger.on_child_enter === true
+                } else {
+                    this._role = "none"
+                    this._loopState = null
                 }
 
                 this._updateUI()
@@ -192,7 +197,13 @@ export default class extends Controller {
         if (!this.hasTriggerButtonTarget) return
         const btn = this.triggerButtonTarget
 
-        if (this._role === "none" || !this.canWrite) {
+        if (this._role === "none") {
+            btn.style.display = 'none'
+            return
+        }
+
+        // Container toggle requires write permission; task status is visible to all
+        if (this._role === "container" && !this.canWrite) {
             btn.style.display = 'none'
             return
         }
@@ -223,10 +234,10 @@ export default class extends Controller {
 
             // Tooltip: state + action hint
             let tooltip = stateLabel
-            if (this._loopIteration !== undefined) {
+            if (this._loopIteration !== undefined && state !== "idle") {
                 tooltip += ` (${this._loopIteration}/${this._loopMax})`
             }
-            if (actionLabel) {
+            if (actionLabel && this.canWrite) {
                 tooltip += ` — click to ${actionLabel}`
             }
             btn.title = tooltip

--- a/engines/collavre/config/locales/drop_trigger.en.yml
+++ b/engines/collavre/config/locales/drop_trigger.en.yml
@@ -4,6 +4,7 @@ en:
       child_entered: "🔔 Drop Trigger — Creative '%{child_description}' (ID: %{child_id}) was added to '%{parent_description}'. Please process this creative according to this stage's purpose."
       no_agent: "⚠️ Drop Trigger failed — No AI agent with write permission found on '%{parent_description}'. Please share an AI agent with write permission to enable automatic processing."
 
+      not_a_container: "Parent is not a trigger container"
       toggle_on: "Drop Trigger enabled"
       toggle_off: "Drop Trigger disabled"
     trigger_loop:

--- a/engines/collavre/config/locales/drop_trigger.en.yml
+++ b/engines/collavre/config/locales/drop_trigger.en.yml
@@ -20,6 +20,7 @@ en:
       max_reached: "⚠️ Trigger Loop stopped — Reached maximum iterations (%{max}). Review progress and restart if needed."
       infra_stuck: "⚠️ Trigger Loop paused — %{count} consecutive infrastructure errors (timeout/connection). The service may be unavailable. User intervention needed."
       verification_failed: "🔍 Trigger Loop — iteration %{iteration}/%{max}. Your [STATUS: DONE] was not verified. The following actions were not completed:\n%{reason}\n\nPlease complete all remaining actions and report [STATUS: DONE/CONTINUE/BLOCKED]."
+      start: "Start"
       pause: "Pause"
       resume: "Resume"
       restart: "Restart"

--- a/engines/collavre/config/locales/drop_trigger.ko.yml
+++ b/engines/collavre/config/locales/drop_trigger.ko.yml
@@ -4,6 +4,7 @@ ko:
       child_entered: "🔔 드롭 트리거 — 크리에이티브 '%{child_description}' (ID: %{child_id})가 '%{parent_description}'에 추가되었습니다. 이 단계의 목적에 맞게 처리해주세요."
       no_agent: "⚠️ 드롭 트리거 실패 — '%{parent_description}'에 쓰기 권한을 가진 AI 에이전트가 없습니다. 자동 처리를 위해 AI 에이전트에 쓰기 권한을 부여해주세요."
 
+      not_a_container: "부모가 트리거 컨테이너가 아닙니다"
       toggle_on: "드롭 트리거 활성화됨"
       toggle_off: "드롭 트리거 비활성화됨"
     trigger_loop:

--- a/engines/collavre/config/locales/drop_trigger.ko.yml
+++ b/engines/collavre/config/locales/drop_trigger.ko.yml
@@ -20,6 +20,7 @@ ko:
       max_reached: "⚠️ 트리거 루프 중단 — 최대 반복 횟수(%{max})에 도달했습니다. 진행 상황을 확인하고 필요시 재시작해주세요."
       infra_stuck: "⚠️ 트리거 루프 일시정지 — 연속 %{count}회 인프라 에러(타임아웃/연결 실패) 발생. 서비스가 불안정할 수 있습니다. 사용자 개입이 필요합니다."
       verification_failed: "🔍 트리거 루프 — 반복 %{iteration}/%{max}. [STATUS: DONE] 검증에 실패했습니다. 다음 작업이 완료되지 않았습니다:\n%{reason}\n\n남은 작업을 모두 완료한 후 [STATUS: DONE/CONTINUE/BLOCKED]으로 보고해주세요."
+      start: "시작"
       pause: "일시정지"
       resume: "재개"
       restart: "재시작"

--- a/engines/collavre/test/controllers/creatives_controller_trigger_task_test.rb
+++ b/engines/collavre/test/controllers/creatives_controller_trigger_task_test.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class CreativesControllerTriggerTaskTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:one)
+    sign_in_as(@user, password: "password")
+
+    @trigger_parent = Collavre::Creative.create!(
+      user: @user,
+      description: "Trigger Container",
+      data: { "trigger" => { "on_child_enter" => true } }
+    )
+    @normal_parent = Collavre::Creative.create!(
+      user: @user,
+      description: "Normal Parent"
+    )
+  end
+
+  test "show JSON returns is_trigger_task true for child of trigger container" do
+    child = Collavre::Creative.create!(
+      user: @user,
+      parent: @trigger_parent,
+      description: "Trigger Task Child"
+    )
+
+    get creative_path(child), headers: { "ACCEPT" => "application/json" }
+    assert_response :success
+
+    json = JSON.parse(response.body)
+    assert_equal true, json["is_trigger_task"]
+  end
+
+  test "show JSON returns is_trigger_task true even without loop state" do
+    child = Collavre::Creative.create!(
+      user: @user,
+      parent: @trigger_parent,
+      description: "New Trigger Task"
+    )
+
+    get creative_path(child), headers: { "ACCEPT" => "application/json" }
+    assert_response :success
+
+    json = JSON.parse(response.body)
+    assert_equal true, json["is_trigger_task"]
+    assert_nil json["trigger_loop"]
+  end
+
+  test "show JSON returns is_trigger_task false for child of normal parent" do
+    child = Collavre::Creative.create!(
+      user: @user,
+      parent: @normal_parent,
+      description: "Normal Child"
+    )
+
+    get creative_path(child), headers: { "ACCEPT" => "application/json" }
+    assert_response :success
+
+    json = JSON.parse(response.body)
+    assert_equal false, json["is_trigger_task"]
+  end
+
+  test "show JSON returns is_trigger_task false for root creative" do
+    get creative_path(@trigger_parent), headers: { "ACCEPT" => "application/json" }
+    assert_response :success
+
+    json = JSON.parse(response.body)
+    assert_equal false, json["is_trigger_task"]
+  end
+
+  test "show JSON returns is_trigger_task true with existing loop state" do
+    child = Collavre::Creative.create!(
+      user: @user,
+      parent: @trigger_parent,
+      description: "Running Task",
+      data: { "trigger" => { "loop" => { "state" => "running", "current_iteration" => 3, "max_iterations" => 10 } } }
+    )
+
+    get creative_path(child), headers: { "ACCEPT" => "application/json" }
+    assert_response :success
+
+    json = JSON.parse(response.body)
+    assert_equal true, json["is_trigger_task"]
+    assert_equal "running", json["trigger_loop"]["state"]
+  end
+end

--- a/engines/collavre/test/controllers/creatives_controller_trigger_task_test.rb
+++ b/engines/collavre/test/controllers/creatives_controller_trigger_task_test.rb
@@ -3,6 +3,8 @@
 require "test_helper"
 
 class CreativesControllerTriggerTaskTest < ActionDispatch::IntegrationTest
+  include ActiveJob::TestHelper
+
   setup do
     @user = users(:one)
     sign_in_as(@user, password: "password")
@@ -83,5 +85,44 @@ class CreativesControllerTriggerTaskTest < ActionDispatch::IntegrationTest
     json = JSON.parse(response.body)
     assert_equal true, json["is_trigger_task"]
     assert_equal "running", json["trigger_loop"]["state"]
+  end
+
+  test "trigger_action start enqueues DropTriggerJob for idle trigger task" do
+    child = Collavre::Creative.create!(
+      user: @user,
+      parent: @trigger_parent,
+      description: "Start Me"
+    )
+
+    prev_adapter = ActiveJob::Base.queue_adapter
+    ActiveJob::Base.queue_adapter = :test
+
+    begin
+      clear_enqueued_jobs
+      assert_enqueued_with(job: Collavre::DropTriggerJob) do
+        patch trigger_action_creative_path(child),
+              params: { action_name: "start" },
+              headers: { "ACCEPT" => "application/json", "CONTENT_TYPE" => "application/json" },
+              as: :json
+      end
+      assert_response :success
+    ensure
+      ActiveJob::Base.queue_adapter = prev_adapter
+    end
+  end
+
+  test "trigger_action start rejects non-trigger-container child" do
+    child = Collavre::Creative.create!(
+      user: @user,
+      parent: @normal_parent,
+      description: "Not Trigger"
+    )
+
+    patch trigger_action_creative_path(child),
+          params: { action_name: "start" },
+          headers: { "ACCEPT" => "application/json", "CONTENT_TYPE" => "application/json" },
+          as: :json
+
+    assert_response :unprocessable_entity
   end
 end

--- a/engines/collavre/test/system/trigger_task_status_test.rb
+++ b/engines/collavre/test/system/trigger_task_status_test.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require_relative "../application_system_test_case"
+
+class TriggerTaskStatusTest < ApplicationSystemTestCase
+  setup do
+    @user = User.create!(
+      email: "trigger-test@example.com",
+      password: SystemHelpers::PASSWORD,
+      name: "TriggerUser",
+      email_verified_at: Time.current,
+      notifications_enabled: false
+    )
+
+    @container = Collavre::Creative.create!(
+      user: @user,
+      description: "Trigger Container",
+      data: { "trigger" => { "on_child_enter" => true } }
+    )
+
+    @task = Collavre::Creative.create!(
+      user: @user,
+      parent: @container,
+      description: "Trigger Task Idle"
+    )
+
+    sign_in_via_ui(@user)
+  end
+
+  test "trigger task shows zap button with Idle tooltip in popup" do
+    visit collavre.creatives_path(id: @container.id)
+
+    # Wait for tree to load with the task
+    assert_selector "button[name='show-comments-btn'][data-creative-id='#{@task.id}']", wait: 10
+
+    # Click to open popup
+    find("button[name='show-comments-btn'][data-creative-id='#{@task.id}']").click
+
+    # Wait for popup
+    assert_selector "#comments-popup", wait: 5
+
+    # The trigger button should become visible
+    trigger_btn = find("[data-comments--drop-trigger-target='triggerButton']", wait: 10)
+
+    # Wait for async _loadTriggerState to complete and update UI
+    # The button should not be hidden (display:none)
+    assert_eventually(timeout: 10) do
+      trigger_btn.evaluate_script("this.style.display") != "none"
+    end
+
+    # Verify tooltip
+    assert_match(/Idle/i, trigger_btn["title"])
+  end
+
+  private
+
+  def assert_eventually(timeout: 5, interval: 0.2)
+    deadline = Time.now + timeout
+    loop do
+      return if yield
+      raise "Assertion did not pass within #{timeout}s" if Time.now > deadline
+
+      sleep interval
+    end
+  end
+end


### PR DESCRIPTION
## Summary

When a parent creative has drop trigger enabled (trigger container), all its child creatives now show as trigger tasks in the comments popup UI, regardless of whether they have existing loop state.

### Problem

Previously, a child of a trigger container only showed trigger task UI if it had an active `trigger_loop` state in its data. New children (never triggered) or children without loop state would show as a container toggle button instead — which was incorrect.

### Changes

**Backend (creatives_controller.rb)**
- Add `is_trigger_task` field to show JSON response (`true` when parent is trigger container)
- Include parent's trigger enabled state in ETag (`trigger_v3`) for proper cache invalidation

**Frontend (drop_trigger_controller.js)**
- Use `is_trigger_task` from API to determine role instead of relying solely on existing loop state
- Children of trigger containers always show as `task` role with `idle` state when no loop exists
- Task status indicator is visible to read-only users; action buttons require write permission
- Hide iteration count for idle state (no meaningful iteration yet)
- Container role detection now falls back to `none` for creatives that are neither containers nor tasks

**Tests**
- 5 new controller integration tests covering:
  - Child of trigger container → `is_trigger_task: true`
  - Child without loop state → `is_trigger_task: true`, `trigger_loop: null`
  - Child of normal parent → `is_trigger_task: false`
  - Root creative (trigger container itself) → `is_trigger_task: false`
  - Child with existing loop state → both `is_trigger_task: true` and loop data present