### PR TITLE
fix: hide search GNB menu for unauthenticated users

### DIFF
--- a/engines/collavre/lib/collavre/engine.rb
+++ b/engines/collavre/lib/collavre/engine.rb
@@ -113,7 +113,8 @@ module Collavre
           section: :main,
           type: :partial,
           partial: "collavre/shared/navigation/search_form",
-          priority: 105
+          priority: 105,
+          requires_auth: true
         )
 
         # ============================================


### PR DESCRIPTION
## Summary

Hide the search button in the GNB (Global Navigation Bar) when the user is not logged in.

## Changes

- Added `requires_auth: true` to the `:search` navigation item registration in `collavre/engine.rb`

## How it works

The navigation system already has `requires_auth` support — when set to `true`, `navigation_item_visible?` checks `authenticated?` and hides the item for guests. The search item was missing this flag.

## Testing

- Existing navigation helper tests pass (22 tests, 66 assertions)
- Rubocop clean

Closes Creative #10621