### PR TITLE
fix: respect autoFocusOnOpen in setCommentPermission

### DIFF
--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -153,7 +153,9 @@ export default class extends Controller {
       return
     }
 
-    requestAnimationFrame(() => this.textareaTarget.focus())
+    if (this.shouldAutoFocusOnOpen()) {
+      requestAnimationFrame(() => this.textareaTarget.focus())
+    }
   }
 
   onSelectionChanged({ size, moving }) {


### PR DESCRIPTION
## Problem

Inbox autofocus prevention (#1079) stopped working after #1084 was merged.

When opening the Inbox, the comment input form gets focused and the mobile keyboard pops up — the exact issue #1079 was supposed to fix.

## Root Cause

PR #1084 (`feat: refresh open chat on creative share changes`) added `setCommentPermission()` to `form_controller.js`. This method unconditionally calls `this.textareaTarget.focus()` when `canComment` is true, bypassing the `autoFocusOnOpen` guard from #1079.

The `presence_controller` calls `setCommentPermission(true)` during popup open (when the presence channel confirms comment permission), which triggers the focus after the initial `onPopupOpened` correctly suppressed it.

## Fix

Add `shouldAutoFocusOnOpen()` check to `setCommentPermission()`, consistent with the existing guard in `onPopupOpened()`.

## Changes

- `form_controller.js`: Gate focus in `setCommentPermission()` behind `shouldAutoFocusOnOpen()`

Fixes regression from #1084 on #1079.