### PR TITLE
fix: remove emoji prefix from inbox creative

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,11 @@
 PATH
+  remote: engines/collavre_plan
+  specs:
+    collavre_plan (0.1.0)
+      collavre
+      rails (>= 8.0)
+
+PATH
   remote: engines/collavre_completion_api
   specs:
     collavre_completion_api (0.2.0)
@@ -29,13 +36,6 @@ PATH
       eventmachine (~> 1.2)
       faraday (>= 2.0)
       faye-websocket (~> 0.11)
-      rails (>= 8.0)
-
-PATH
-  remote: engines/collavre_plan
-  specs:
-    collavre_plan (0.1.0)
-      collavre
       rails (>= 8.0)
 
 PATH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,4 @@
 PATH
-  remote: engines/collavre_plan
-  specs:
-    collavre_plan (0.1.0)
-      collavre
-      rails (>= 8.0)
-
-PATH
   remote: engines/collavre_completion_api
   specs:
     collavre_completion_api (0.2.0)
@@ -36,6 +29,13 @@ PATH
       eventmachine (~> 1.2)
       faraday (>= 2.0)
       faye-websocket (~> 0.11)
+      rails (>= 8.0)
+
+PATH
+  remote: engines/collavre_plan
+  specs:
+    collavre_plan (0.1.0)
+      collavre
       rails (>= 8.0)
 
 PATH

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_31_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_01_120000) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false

--- a/engines/collavre/app/models/collavre/creative.rb
+++ b/engines/collavre/app/models/collavre/creative.rb
@@ -54,7 +54,7 @@ module Collavre
       return existing if existing
 
       create!(
-        description: "Inbox",
+        description: I18n.t("collavre.inbox.default_name"),
         data: { "kind" => "inbox" },
         user: user,
         progress: 0.0

--- a/engines/collavre/app/models/collavre/creative.rb
+++ b/engines/collavre/app/models/collavre/creative.rb
@@ -54,7 +54,7 @@ module Collavre
       return existing if existing
 
       create!(
-        description: "📥 Inbox",
+        description: "Inbox",
         data: { "kind" => "inbox" },
         user: user,
         progress: 0.0

--- a/engines/collavre/config/locales/creatives.en.yml
+++ b/engines/collavre/config/locales/creatives.en.yml
@@ -167,6 +167,8 @@ en:
         submit: Submit
       slide_view:
         go_to_creative: Go to Creative
+    inbox:
+      default_name: Inbox
     creative_mailer:
       in_stock:
         subject: Good news!

--- a/engines/collavre/config/locales/creatives.ko.yml
+++ b/engines/collavre/config/locales/creatives.ko.yml
@@ -152,6 +152,8 @@ ko:
         submit: 제출
       slide_view:
         go_to_creative: 현재 크리에이티브로 이동
+    inbox:
+      default_name: 인박스
     creative_mailer:
       in_stock:
         subject: 좋은 소식!

--- a/engines/collavre/db/migrate/20260401120000_remove_emoji_prefix_from_inbox_creatives.rb
+++ b/engines/collavre/db/migrate/20260401120000_remove_emoji_prefix_from_inbox_creatives.rb
@@ -1,0 +1,19 @@
+class RemoveEmojiPrefixFromInboxCreatives < ActiveRecord::Migration[8.0]
+  def up
+    execute <<~SQL
+      UPDATE creatives
+      SET description = 'Inbox'
+      WHERE data->>'kind' = 'inbox'
+        AND description LIKE '📥%'
+    SQL
+  end
+
+  def down
+    execute <<~SQL
+      UPDATE creatives
+      SET description = '📥 Inbox'
+      WHERE data->>'kind' = 'inbox'
+        AND description = 'Inbox'
+    SQL
+  end
+end


### PR DESCRIPTION
## Summary

Remove the childish emoji prefix (📥) from inbox creative description.

## Changes

- **`creative.rb`**: Changed inbox creative description from `📥 Inbox` to `Inbox`
- **Migration**: Update existing inbox creatives in database to remove the emoji prefix

## Motivation

The emoji prefix on inbox creatives was deemed unnecessary and childish (유치함).

Creative ID: 10642