### PR TITLE
feat: add stop button for AI agent streaming responses

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -1682,6 +1682,52 @@ body.chat-fullscreen {
     50% { opacity: 0; }
 }
 
+/* Stop generating button on streaming comments */
+.comment-stop-btn {
+    background: var(--surface-btn);
+    color: var(--text-on-btn);
+    border: none;
+    border-radius: var(--radius-round);
+    width: 22px;
+    height: 22px;
+    font-size: 10px;
+    line-height: 1;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0.8;
+    transition: opacity 0.15s;
+}
+
+.comment-stop-btn:hover {
+    opacity: 1;
+}
+
+/* Stop button in typing indicator */
+.stop-generating-btn {
+    background: var(--surface-btn);
+    color: var(--text-on-btn);
+    border: none;
+    border-radius: var(--radius-round);
+    width: 20px;
+    height: 20px;
+    font-size: 9px;
+    line-height: 1;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    margin-left: 0.4em;
+    opacity: 0.8;
+    transition: opacity 0.15s;
+    flex-shrink: 0;
+}
+
+.stop-generating-btn:hover {
+    opacity: 1;
+}
+
 .review-hint {
     background: var(--surface-btn);
     color: var(--text-on-btn);

--- a/engines/collavre/app/controllers/collavre/comments_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comments_controller.rb
@@ -290,6 +290,39 @@ module Collavre
       render json: CommandMenuService.new(user: Current.user).items
     end
 
+    def cancel_task
+      unless @creative.has_permission?(Current.user, :feedback)
+        render json: { error: I18n.t("collavre.comments.no_permission") }, status: :forbidden and return
+      end
+
+      task = Task.find_by(id: params[:task_id])
+      unless task
+        render json: { error: "Task not found" }, status: :not_found and return
+      end
+
+      task_creative_id = task.trigger_event_payload&.dig("creative", "id")
+      unless task_creative_id == @creative.id
+        render json: { error: "Task does not belong to this creative" }, status: :forbidden and return
+      end
+
+      unless %w[running pending queued].include?(task.status)
+        render json: { error: "Task is not cancellable" }, status: :unprocessable_entity and return
+      end
+
+      task.update!(status: "cancelled")
+
+      CommentsPresenceChannel.broadcast_agent_status(
+        @creative.id,
+        status: "idle",
+        agent_id: task.agent_id,
+        agent_name: task.agent.display_name,
+        task_id: task.id,
+        source_creative_id: task_creative_id
+      )
+
+      render json: { success: true }
+    end
+
     def download_images
       images = @comment.images
       unless images.attached?

--- a/engines/collavre/app/javascript/controllers/comment_controller.js
+++ b/engines/collavre/app/javascript/controllers/comment_controller.js
@@ -52,6 +52,55 @@ export default class extends Controller {
     return this._isStreaming || this._serverStreaming
   }
 
+  _showStopButton() {
+    // Only show if not already present
+    if (this.element.querySelector('.comment-stop-btn')) return
+
+    const actionContainer = this.element.querySelector('.comment-action-container')
+    if (!actionContainer) return
+
+    const btn = document.createElement('button')
+    btn.type = 'button'
+    btn.className = 'comment-stop-btn'
+    btn.textContent = '■'
+    btn.title = this.element.dataset.stopGeneratingText || 'Stop'
+    btn.addEventListener('click', (e) => {
+      e.preventDefault()
+      this._cancelTask()
+    })
+    actionContainer.prepend(btn)
+  }
+
+  _hideStopButton() {
+    const btn = this.element.querySelector('.comment-stop-btn')
+    if (btn) btn.remove()
+  }
+
+  _cancelTask() {
+    const userId = this.element.dataset.userId
+    const creativeId = this.element.dataset.creativeId
+    if (!userId || !creativeId) return
+
+    // Find task ID from global active agent tasks (set by presence_controller)
+    const agentInfo = window._activeAgentTasks?.[userId]
+    if (!agentInfo?.taskId) return
+
+    const url = `/creatives/${creativeId}/comments/cancel_task`
+    fetch(url, {
+      method: 'POST',
+      headers: {
+        'X-CSRF-Token': document.querySelector('meta[name=csrf-token]')?.content || '',
+        'Content-Type': 'application/json',
+        'Accept': 'application/json',
+      },
+      body: JSON.stringify({ task_id: agentInfo.taskId }),
+    })
+      .then((response) => {
+        if (response.ok) this._hideStopButton()
+      })
+      .catch((error) => console.error('Cancel task error:', error))
+  }
+
   _appendStreamingCursor(el) {
     const cursor = document.createElement('span')
     cursor.className = 'streaming-cursor'
@@ -87,6 +136,7 @@ export default class extends Controller {
       clearTimeout(this._streamingTimeout)
       this._streamingTimeout = null
     }
+    this._hideStopButton()
   }
 
   connect() {
@@ -101,6 +151,7 @@ export default class extends Controller {
           this._isStreaming = true
           contentElement.innerHTML = '<span class="streaming-dots"><span>.</span><span>.</span><span>.</span></span>'
           contentElement.classList.add('streaming')
+          this._showStopButton()
         } else if (this._shouldStream(text)) {
           // Streaming content arrived — render markdown with cursor
           this._isStreaming = true
@@ -108,10 +159,12 @@ export default class extends Controller {
           this._appendStreamingCursor(contentElement)
           contentElement.classList.add('streaming')
           this._resetStreamingTimeout()
+          this._showStopButton()
         } else {
           contentElement.innerHTML = renderCommentMarkdown(text)
           contentElement.classList.remove('streaming')
           if (this._isStreaming) this._cleanupStreaming()
+          this._hideStopButton()
         }
         contentElement.dataset.rendered = 'true'
       } finally {

--- a/engines/collavre/app/javascript/controllers/comments/presence_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/presence_controller.js
@@ -14,6 +14,7 @@ export default class extends Controller {
     this.currentPresentIds = []
     this.typingUsers = {}
     this.typingTimers = {}
+    this.activeAgentTasks = {} // agent_id -> { name, taskId }
     this.manualTypingMessage = null
     this.presenceSubscription = null
     this.typingTimeoutHandle = null
@@ -199,23 +200,33 @@ export default class extends Controller {
       return
     }
     if (data.agent_status) {
-      const { id, name, status, creative_id: agentCreativeId } = data.agent_status
+      const { id, name, status, task_id: taskId, creative_id: agentCreativeId } = data.agent_status
       // Only show typing indicator if agent is working on this specific creative
       if (agentCreativeId && agentCreativeId !== this.creativeId) {
         return
       }
       if (status === 'thinking' || status === 'streaming') {
         this.typingUsers[id] = name
+        if (taskId) {
+          this.activeAgentTasks[id] = { name, taskId }
+          // Expose for comment_controller to read
+          if (!window._activeAgentTasks) window._activeAgentTasks = {}
+          window._activeAgentTasks[id] = { name, taskId, creativeId: this.creativeId }
+        }
         // Safety timeout: auto-remove if no heartbeat within AGENT_STATUS_TIMEOUT
         if (!this.agentStatusTimers) this.agentStatusTimers = {}
         if (this.agentStatusTimers[id]) clearTimeout(this.agentStatusTimers[id])
         this.agentStatusTimers[id] = setTimeout(() => {
           delete this.typingUsers[id]
+          delete this.activeAgentTasks[id]
           delete this.agentStatusTimers[id]
+          if (window._activeAgentTasks) delete window._activeAgentTasks[id]
           this.renderTypingIndicator()
         }, AGENT_STATUS_TIMEOUT)
       } else {
         delete this.typingUsers[id]
+        delete this.activeAgentTasks[id]
+        if (window._activeAgentTasks) delete window._activeAgentTasks[id]
         if (this.agentStatusTimers?.[id]) {
           clearTimeout(this.agentStatusTimers[id])
           delete this.agentStatusTimers[id]
@@ -353,6 +364,51 @@ export default class extends Controller {
     const text = document.createElement('span')
     text.textContent = `${names.join(', ')} ...`
     this.typingIndicatorTarget.appendChild(text)
+
+    // Add stop button if any agent has an active task
+    const agentIds = ids.filter((id) => this.activeAgentTasks[id])
+    if (agentIds.length > 0) {
+      const stopBtn = document.createElement('button')
+      stopBtn.type = 'button'
+      stopBtn.className = 'stop-generating-btn'
+      stopBtn.textContent = this.element.dataset.stopGeneratingText || '■'
+      stopBtn.title = this.element.dataset.stopGeneratingText || 'Stop'
+      stopBtn.addEventListener('click', (e) => {
+        e.preventDefault()
+        agentIds.forEach((agentId) => this._cancelAgentTask(agentId))
+      })
+      this.typingIndicatorTarget.appendChild(stopBtn)
+    }
+  }
+
+  _cancelAgentTask(agentId) {
+    const agentInfo = this.activeAgentTasks[agentId]
+    if (!agentInfo || !this.creativeId) return
+
+    const { taskId } = agentInfo
+    const url = `/creatives/${this.creativeId}/comments/cancel_task`
+    fetch(url, {
+      method: 'POST',
+      headers: {
+        'X-CSRF-Token': document.querySelector('meta[name=csrf-token]')?.content || '',
+        'Content-Type': 'application/json',
+        'Accept': 'application/json',
+      },
+      body: JSON.stringify({ task_id: taskId }),
+    })
+      .then((response) => {
+        if (!response.ok) {
+          return response.json().then((data) => {
+            console.error('Cancel task failed:', data.error)
+          })
+        }
+        // Clean up immediately on success (broadcast will also arrive)
+        delete this.typingUsers[agentId]
+        delete this.activeAgentTasks[agentId]
+        if (window._activeAgentTasks) delete window._activeAgentTasks[agentId]
+        this.renderTypingIndicator()
+      })
+      .catch((error) => console.error('Cancel task error:', error))
   }
 
   clearTypingTimers() {

--- a/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
@@ -57,7 +57,8 @@
      data-review-type-question="❓"
      data-review-type-review-label="<%= t('collavre.comments.review_type_review') %>"
      data-review-type-question-label="<%= t('collavre.comments.review_type_question') %>"
-     data-remove-from-history-label="<%= t('collavre.comments.remove_from_history') %>">
+     data-remove-from-history-label="<%= t('collavre.comments.remove_from_history') %>"
+     data-stop-generating-text="<%= t('collavre.comments.stop_generating') %>">
   <div class="resize-handle resize-handle-left" data-comments--popup-target="leftHandle"></div>
   <div class="resize-handle resize-handle-right" data-comments--popup-target="rightHandle"></div>
   <div class="comments-popup-header" data-comments--popup-target="header">

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -75,6 +75,8 @@ en:
       voice_stop: Stop
       speech_unavailable: Speech recognition is not supported in this browser.
       move_button: Move
+      stop_generating: Stop
+      cancel_task_error: Unable to stop the task.
       review_button: Review
       review_select_hint: Please select text to review
       review_feedback_placeholder: Write feedback for this quote...

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -72,6 +72,8 @@ ko:
       voice_stop: 중지
       speech_unavailable: 이 브라우저는 음성 인식을 지원하지 않습니다.
       move_button: 이동
+      stop_generating: 중지
+      cancel_task_error: 작업을 중지할 수 없습니다.
       review_button: 리뷰
       review_select_hint: 리뷰할 텍스트를 선택해 주세요
       review_feedback_placeholder: 이 인용에 대한 피드백을 입력하세요...

--- a/engines/collavre/config/routes.rb
+++ b/engines/collavre/config/routes.rb
@@ -84,6 +84,7 @@ Collavre::Engine.routes.draw do
         delete :batch_destroy
         post :merge
         get :commands
+        post :cancel_task
 
         resources :snapshots, only: [ :index ], module: :comments do
           member do


### PR DESCRIPTION
## Summary

Add a stop/cancel button that appears when AI agents are generating responses, allowing users to interrupt ongoing AI tasks.

## Changes

### Backend
- **`cancel_task` API endpoint** (`POST /creatives/:id/comments/cancel_task`): Accepts `task_id`, validates ownership and permission, sets task status to `cancelled`, and broadcasts `agent_status: idle` via ActionCable.

### Frontend
- **Typing indicator stop button** (`presence_controller.js`): When an AI agent is thinking/streaming, a ■ stop button appears inline next to the agent name in the typing indicator. Tracks active agent tasks (`activeAgentTasks`) and exposes them via `window._activeAgentTasks` for cross-controller access.
- **Streaming comment stop button** (`comment_controller.js`): A ■ stop button appears in the action container of comments that are currently streaming (placeholder `...` or streaming cursor). Reads task info from `window._activeAgentTasks`.
- **CSS**: Styled stop buttons using design tokens (`--surface-btn`, `--text-on-btn`, `--radius-round`) — dark mode compatible automatically.

### i18n
- Added `stop_generating` and `cancel_task_error` keys for both `en` and `ko`.

## How it works
1. AI agent starts → `AgentLifecycleManager` broadcasts `agent_status: thinking/streaming` with `task_id`
2. Frontend receives via ActionCable → shows typing indicator + stop button
3. User clicks stop → `POST cancel_task` → task status → `cancelled`
4. `AgentLifecycleManager#check_cancelled!` detects cancellation within 1s → stops streaming
5. `agent_status: idle` broadcast → UI cleans up

## Testing
- Rubocop: ✅ No offenses
- All tests pass (1574 runs, 0 failures; 1 pre-existing error in CreativesHelperTest unrelated to this change)