### PR TITLE
fix: resolve NoMethodError in render_tags helper test

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,4 @@
 PATH
-  remote: engines/collavre_plan
-  specs:
-    collavre_plan (0.1.0)
-      collavre
-      rails (>= 8.0)
-
-PATH
   remote: engines/collavre_completion_api
   specs:
     collavre_completion_api (0.2.0)
@@ -36,6 +29,13 @@ PATH
       eventmachine (~> 1.2)
       faraday (>= 2.0)
       faye-websocket (~> 0.11)
+      rails (>= 8.0)
+
+PATH
+  remote: engines/collavre_plan
+  specs:
+    collavre_plan (0.1.0)
+      collavre
       rails (>= 8.0)
 
 PATH

--- a/engines/collavre/test/helpers/creatives_helper_test.rb
+++ b/engines/collavre/test/helpers/creatives_helper_test.rb
@@ -192,7 +192,7 @@ class CreativesHelperTest < ActionView::TestCase
   end
   test "render_tags strips html from label names" do
     label = Label.new(id: 1, creative: Creative.new(description: "<b>HTML</b> Tag"))
-    html = render_tags([ label ])
+    html = render_tags([ label ], nil, true)
     assert_includes html, ">#HTML Tag</a>", "Link text should be stripped"
     assert_includes html, "title=\"HTML Tag\"", "Title attribute should be stripped"
   end


### PR DESCRIPTION
## Problem

`CreativesHelperTest#test_render_tags_strips_html_from_label_names` fails with:

```
NoMethodError: undefined method 'render_label_suffix' for an instance of CreativesHelperTest
```

`render_tags` calls `render_label_suffix` (defined in `ApplicationHelper`) when `name_only` is `false` (default). In the helper test context, `ApplicationHelper` is not included, causing the error.

## Fix

Pass `name_only = true` in the test since it only verifies HTML stripping from label names — the suffix rendering is irrelevant to that assertion.