### PR TITLE
feat: render leaf creatives as plain text in markdown export

### DIFF
--- a/engines/collavre/app/helpers/collavre/creatives_helper.rb
+++ b/engines/collavre/app/helpers/collavre/creatives_helper.rb
@@ -144,6 +144,9 @@ module Collavre
         cleaned_markdown = markdown_content.strip
         rendered_table_block = false
 
+        children = creative.linked_children
+        has_children = children.present? && (max_depth.nil? || level < max_depth)
+
         table_match = cleaned_markdown.match(/^<div[^>]*>\s*<div[^>]*>\s*(\|.*?\|(?:\n\|.*?\|)*)\s*<\/div>\s*<\/div>$/m)
         if level <= 4 && table_match
           table_content = table_match[1].strip
@@ -154,24 +157,28 @@ module Collavre
         elsif level <= 4 && MarkdownConverter.table_block?(cleaned_markdown)
           md += "#{cleaned_markdown}\n\n"
           rendered_table_block = true
-        elsif level <= 4
+        elsif level <= 4 && has_children
           md += "#{'#' * level} #{ActionView::Base.full_sanitizer.sanitize(markdown_content).strip}\n\n"
         else
-          inner_html = begin
-            fragment = Nokogiri::HTML.fragment(raw_html)
-            wrapper = fragment.at_css("div.trix-content")
-            if wrapper
-              wrapper.inner_html.strip
-            else
-              ActionView::Base.full_sanitizer.sanitize(markdown_content).strip
+          plain_text = ActionView::Base.full_sanitizer.sanitize(markdown_content).strip
+          if level <= 4
+            md += "#{plain_text}\n\n"
+          else
+            inner_html = begin
+              fragment = Nokogiri::HTML.fragment(raw_html)
+              wrapper = fragment.at_css("div.trix-content")
+              if wrapper
+                wrapper.inner_html.strip
+              else
+                plain_text
+              end
             end
+            inner = ActionView::Base.full_sanitizer.sanitize(inner_html)
+            indent = "  " * (level - 5)
+            md += "#{indent}* #{inner}\n"
           end
-          inner = ActionView::Base.full_sanitizer.sanitize(inner_html)
-          indent = "  " * (level - 5)
-          md += "#{indent}* #{inner}\n"
         end
-        children = creative.linked_children
-        if children.present? && (max_depth.nil? || level < max_depth)
+        if has_children
           md += render_creative_tree_markdown(children, level + 1, with_progress, max_depth: max_depth)
         end
         md += "\n" if level <= 4 && !rendered_table_block

--- a/engines/collavre/test/helpers/creatives_helper_test.rb
+++ b/engines/collavre/test/helpers/creatives_helper_test.rb
@@ -250,6 +250,46 @@ class CreativesHelperTest < ActionView::TestCase
     end
   end
 
+  test "render_creative_tree_markdown renders leaf creatives as plain text not headings" do
+    user = users(:one)
+
+    # A > B > B1, B2 and A > C
+    root_a = Collavre::Creative.create!(description: "A", user: user)
+    child_b = Collavre::Creative.create!(description: "B", parent: root_a, user: user)
+    Collavre::Creative.create!(description: "B1", parent: child_b, user: user)
+    Collavre::Creative.create!(description: "B2", parent: child_b, user: user)
+    Collavre::Creative.create!(description: "C", parent: root_a, user: user)
+
+    Current.set(user: user) do
+      md = render_creative_tree_markdown([ root_a ])
+
+      # A has children → heading
+      assert_match(/^# A$/, md)
+      # B has children → heading
+      assert_match(/^## B$/, md)
+      # B1, B2, C have no children → plain text (no heading prefix)
+      assert_match(/^B1$/, md)
+      assert_match(/^B2$/, md)
+      assert_match(/^C$/, md)
+      # Must NOT have ### for leaf nodes
+      assert_no_match(/^### /, md)
+    end
+  end
+
+  test "render_creative_tree_markdown renders single root without children as plain text" do
+    user = users(:one)
+
+    root = Collavre::Creative.create!(description: "Solo", user: user)
+
+    Current.set(user: user) do
+      md = render_creative_tree_markdown([ root ])
+
+      # Solo has no children → plain text
+      assert_match(/^Solo$/, md)
+      assert_no_match(/^# Solo$/, md)
+    end
+  end
+
   test "render_creative_tree_markdown without max_depth includes all levels" do
     user = users(:one)
 


### PR DESCRIPTION
## Summary

When exporting creatives as markdown, heading markers (`#`, `##`, etc.) are now only applied to creatives that **have children**. Leaf creatives (no children) are rendered as **plain text** regardless of their tree depth.

This matches the visual rendering behavior — headings serve as structural containers, not styling for individual leaf items.

## Example

Given tree: A > B > B1, B2 and A > C

**Before:**
```markdown
# A
## B
### B1
### B2
## C
```

**After:**
```markdown
# A
## B
B1
B2
C
```

## Changes

- **`creatives_helper.rb`**: Modified `render_creative_tree_markdown` to check `has_children` before applying heading prefix. Leaf nodes at level ≤ 4 now render as plain text instead of headings.
- **`creatives_helper_test.rb`**: Added 2 tests:
  - Leaf creatives in a tree render as plain text (not headings)
  - Single root without children renders as plain text

## Test Results

All 1576 tests pass, 0 failures.