### PR TITLE
feat: increase creative tree title font size

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/creatives.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/creatives.css
@@ -621,6 +621,11 @@ creative-tree-row.chat-active .creative-row {
     font-size: 1.4em;
 }
 
+/* ── Title text: larger than default h1 ── */
+.creative-tree-title .page-title {
+    font-size: var(--text-5, 2rem);
+}
+
 
 /* Constrain images within creative-row to prevent overflow */
 .creative-row img {

--- a/engines/collavre/app/javascript/components/creative_tree_row.js
+++ b/engines/collavre/app/javascript/components/creative_tree_row.js
@@ -83,6 +83,7 @@ class CreativeTreeRow extends LitElement {
         this._stopAnimation();
       }
     }
+
   }
 
   disconnectedCallback() {


### PR DESCRIPTION
## Summary

Increase the creative tree title font size from the default `1.4em` to `var(--text-5, 2rem)` (approximately 32px) to make it visually distinct and consistent with other page-level titles (e.g., user profile).

## Changes

- **CSS**: Added `.creative-tree-title .page-title { font-size: var(--text-5, 2rem); }` in `creatives.css`
- **JS**: Minor whitespace cleanup in `creative_tree_row.js` (`updated()` method)

## Design Tokens

Uses Open Props scale `--text-5` with `2rem` fallback for consistent typography.

## Testing

- Rubocop: ✅ passed (783 files, no offenses)
- Visual: ✅ confirmed on preview server (port 4078)
