### PR TITLE
feat: add design token colors to editor toolbar color pickers

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/actiontext.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/actiontext.css
@@ -56,14 +56,48 @@
   top: calc(100% + 0.35rem);
   left: 0;
   z-index: 10;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  padding: 0.4rem 0.5rem;
-  background: var(--surface-bg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-2);
+  background: var(--surface-section);
   border: 1px solid var(--border-color);
   border-radius: var(--radius-2);
   box-shadow: var(--shadow-3);
+  min-width: 180px;
+}
+
+.lexical-toolbar-color__tokens {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: var(--space-1);
+}
+
+.lexical-toolbar-color__token-btn {
+  width: 28px;
+  height: 28px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-2);
+  cursor: pointer;
+  padding: 0;
+  transition: transform 0.1s var(--ease-out-2);
+}
+
+.lexical-toolbar-color__token-btn:hover {
+  transform: scale(1.15);
+  border-color: var(--color-active);
+}
+
+.lexical-toolbar-color__token-btn.active {
+  box-shadow: 0 0 0 2px var(--color-active);
+}
+
+.lexical-toolbar-color__custom-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  border-top: 1px solid var(--border-color);
+  padding-top: var(--space-2);
 }
 
 .lexical-toolbar-color__popover input[type="color"] {
@@ -74,6 +108,7 @@
   height: var(--space-7);
   padding: 0;
   background: transparent;
+  flex-shrink: 0;
 }
 
 .lexical-toolbar-btn--small {

--- a/engines/collavre/app/assets/stylesheets/collavre/design_tokens.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/design_tokens.css
@@ -208,6 +208,33 @@
   /* -- Layout -- */
   --max-width: 960px;                /* content max width */
   --paragraph-space: 0.75rem;        /* gap between paragraphs */
+
+  /* ============================================================================
+   * EDITOR COLOR PALETTE
+   * Token colors for the Lexical rich-text editor color pickers.
+   * Using var(--editor-text-*) / var(--editor-bg-*) in inline styles makes
+   * the colors theme-responsive (light ↔ dark).
+   * ============================================================================ */
+
+  /* -- Editor text colors -- */
+  --editor-text-default: #202123;
+  --editor-text-gray: #787878;
+  --editor-text-red: #c4342d;
+  --editor-text-orange: #c07415;
+  --editor-text-green: #2d8a4e;
+  --editor-text-blue: #2563eb;
+  --editor-text-purple: #7c3aed;
+  --editor-text-pink: #c026d3;
+
+  /* -- Editor background colors -- */
+  --editor-bg-default: transparent;
+  --editor-bg-gray: #ededed;
+  --editor-bg-red: #fde8e8;
+  --editor-bg-orange: #fef3c7;
+  --editor-bg-green: #d1fae5;
+  --editor-bg-blue: #dbeafe;
+  --editor-bg-purple: #ede9fe;
+  --editor-bg-pink: #fce7f3;
 }
 
 /* ============================================================================
@@ -269,6 +296,25 @@ body.dark-mode {
   /* -- Effects -- */
   --hover-brightness: 110%;
 
+  /* -- Editor text colors (dark) -- */
+  --editor-text-default: #eaeaea;
+  --editor-text-gray: #999999;
+  --editor-text-red: #f87171;
+  --editor-text-orange: #fbbf24;
+  --editor-text-green: #34d399;
+  --editor-text-blue: #60a5fa;
+  --editor-text-purple: #a78bfa;
+  --editor-text-pink: #f472b6;
+
+  /* -- Editor background colors (dark) -- */
+  --editor-bg-default: transparent;
+  --editor-bg-gray: #3a3a3a;
+  --editor-bg-red: #4c1d1d;
+  --editor-bg-orange: #4a3520;
+  --editor-bg-green: #1a3a2a;
+  --editor-bg-blue: #1e2d4a;
+  --editor-bg-purple: #2e1f4a;
+  --editor-bg-pink: #4a1d3a;
 }
 
 /* ============================================================================
@@ -315,6 +361,26 @@ body.dark-mode {
     --border-drag-edge: #777777;
 
     --hover-brightness: 110%;
+
+    /* -- Editor text colors (system dark) -- */
+    --editor-text-default: #eaeaea;
+    --editor-text-gray: #999999;
+    --editor-text-red: #f87171;
+    --editor-text-orange: #fbbf24;
+    --editor-text-green: #34d399;
+    --editor-text-blue: #60a5fa;
+    --editor-text-purple: #a78bfa;
+    --editor-text-pink: #f472b6;
+
+    /* -- Editor background colors (system dark) -- */
+    --editor-bg-default: transparent;
+    --editor-bg-gray: #3a3a3a;
+    --editor-bg-red: #4c1d1d;
+    --editor-bg-orange: #4a3520;
+    --editor-bg-green: #1a3a2a;
+    --editor-bg-blue: #1e2d4a;
+    --editor-bg-purple: #2e1f4a;
+    --editor-bg-pink: #4a1d3a;
 
     /* Legacy aliases — must be redefined here so var() resolves against
        the dark semantic tokens above, not :root's light values. */

--- a/engines/collavre/app/javascript/components/InlineLexicalEditor.jsx
+++ b/engines/collavre/app/javascript/components/InlineLexicalEditor.jsx
@@ -273,10 +273,40 @@ function CodeHighlightingPlugin() {
   return null
 }
 
-function ToolbarColorPicker({ icon, title, color, onChange, onClear }) {
+const EDITOR_TEXT_TOKENS = [
+  { token: "var(--editor-text-default)", label: "Default" },
+  { token: "var(--editor-text-gray)", label: "Gray" },
+  { token: "var(--editor-text-red)", label: "Red" },
+  { token: "var(--editor-text-orange)", label: "Orange" },
+  { token: "var(--editor-text-green)", label: "Green" },
+  { token: "var(--editor-text-blue)", label: "Blue" },
+  { token: "var(--editor-text-purple)", label: "Purple" },
+  { token: "var(--editor-text-pink)", label: "Pink" }
+]
+
+const EDITOR_BG_TOKENS = [
+  { token: "var(--editor-bg-default)", label: "Default" },
+  { token: "var(--editor-bg-gray)", label: "Gray" },
+  { token: "var(--editor-bg-red)", label: "Red" },
+  { token: "var(--editor-bg-orange)", label: "Orange" },
+  { token: "var(--editor-bg-green)", label: "Green" },
+  { token: "var(--editor-bg-blue)", label: "Blue" },
+  { token: "var(--editor-bg-purple)", label: "Purple" },
+  { token: "var(--editor-bg-pink)", label: "Pink" }
+]
+
+function resolveColorForInput(color) {
+  if (!color || !color.startsWith("var(")) return color
+  const match = color.match(/^var\(([^)]+)\)$/)
+  if (!match) return color
+  return getComputedStyle(document.documentElement).getPropertyValue(match[1]).trim() || color
+}
+
+function ToolbarColorPicker({ icon, title, color, onChange, onClear, colorType }) {
   const [open, setOpen] = useState(false)
   const triggerRef = useRef(null)
   const popoverRef = useRef(null)
+  const tokens = colorType === "background" ? EDITOR_BG_TOKENS : EDITOR_TEXT_TOKENS
 
   useEffect(() => {
     if (!open) return
@@ -294,6 +324,8 @@ function ToolbarColorPicker({ icon, title, color, onChange, onClear }) {
     return () => document.removeEventListener("mousedown", handleClick)
   }, [open])
 
+  const resolvedColor = resolveColorForInput(color)
+
   return (
     <div className="lexical-toolbar-color" title={title}>
       <button
@@ -306,20 +338,37 @@ function ToolbarColorPicker({ icon, title, color, onChange, onClear }) {
       </button>
       {open ? (
         <div className="lexical-toolbar-color__popover" ref={popoverRef}>
-          <input
-            type="color"
-            value={color}
-            onChange={(event) => onChange(event.target.value)}
-          />
-          <button
-            type="button"
-            className="lexical-toolbar-btn lexical-toolbar-btn--small"
-            onClick={() => {
-              onClear()
-              setOpen(false)
-            }}>
-            ✕
-          </button>
+          <div className="lexical-toolbar-color__tokens">
+            {tokens.map(({ token, label }) => (
+              <button
+                key={token}
+                type="button"
+                className={`lexical-toolbar-color__token-btn${color === token ? " active" : ""}`}
+                style={{ backgroundColor: token }}
+                title={label}
+                onClick={() => {
+                  onChange(token)
+                  setOpen(false)
+                }}
+              />
+            ))}
+          </div>
+          <div className="lexical-toolbar-color__custom-row">
+            <input
+              type="color"
+              value={resolvedColor.startsWith("#") ? resolvedColor : "#000000"}
+              onChange={(event) => onChange(event.target.value)}
+            />
+            <button
+              type="button"
+              className="lexical-toolbar-btn lexical-toolbar-btn--small"
+              onClick={() => {
+                onClear()
+                setOpen(false)
+              }}>
+              ✕
+            </button>
+          </div>
         </div>
       ) : null}
     </div>
@@ -696,6 +745,7 @@ function Toolbar() {
         icon="🎨"
         title="Text color"
         color={fontColor}
+        colorType="text"
         onChange={(value) => {
           setFontColor(value)
           applyTextStyle({ color: value })
@@ -709,6 +759,7 @@ function Toolbar() {
         icon="🖌️"
         title="Background color"
         color={bgColor}
+        colorType="background"
         onChange={(value) => {
           setBgColor(value)
           applyTextStyle({ "background-color": value })


### PR DESCRIPTION
## Summary

Add theme-responsive color swatches to the Lexical editor's text color and background color picker popups. Colors are defined as CSS custom properties (design tokens) so they automatically adapt to light/dark themes.

## Changes

### Design Tokens (`design_tokens.css`)
- Added `--editor-text-*` tokens: default, gray, red, orange, green, blue, purple, pink
- Added `--editor-bg-*` tokens: default, gray, red, orange, green, blue, purple, pink
- Defined for all three modes: light (default), `body.dark-mode`, and `@media (prefers-color-scheme: dark)`

### Editor Component (`InlineLexicalEditor.jsx`)
- Replaced native `<input type="color">` with a token swatch grid showing 8 preset colors
- Text color picker shows `--editor-text-*` tokens; background picker shows `--editor-bg-*` tokens
- Colors are applied as `var(--token-name)` inline styles, making them theme-responsive
- Native color picker retained as fallback for custom colors below the swatch grid
- Added `resolveColorForInput()` helper to resolve CSS variables for the native `<input type="color">`

### Styles (`actiontext.css`)
- Popover layout changed from inline-flex to flex-column for swatch grid + custom color row
- Added `.lexical-toolbar-color__tokens` grid (4 columns)
- Added `.lexical-toolbar-color__token-btn` with hover scale and active ring
- Separated custom color input into `.lexical-toolbar-color__custom-row`

## How it works

When a user selects a token color, the value `var(--editor-text-red)` (for example) is applied as an inline style. This means:
- In light mode, the browser resolves it to the light variant (`#c4342d`)
- In dark mode, the browser resolves it to the dark variant (`#f87171`)
- Theme changes take effect immediately without re-rendering

Closes Creative #10678