### PR TITLE
feat: add markdown shortcuts to Lexical inline editor

### DIFF
--- a/engines/collavre/app/javascript/components/InlineLexicalEditor.jsx
+++ b/engines/collavre/app/javascript/components/InlineLexicalEditor.jsx
@@ -48,6 +48,7 @@ import FileUploadPlugin, {
 import { ImageNode } from "../lib/lexical/image_node"
 import { AttachmentNode } from "../lib/lexical/attachment_node"
 import AttachmentCleanupPlugin from "./plugins/attachment_cleanup_plugin"
+import MarkdownShortcutsPlugin from "./plugins/markdown_shortcuts_plugin"
 import { syncLexicalStyleAttributes } from "../lib/lexical/style_attributes"
 import { updateResponsiveImages } from "../lib/responsive_images"
 
@@ -956,6 +957,7 @@ function EditorInner({
           blobUrlTemplate={blobUrlTemplate}
         />
         <AttachmentCleanupPlugin deletedAttachmentsRef={deletedAttachmentsRef} />
+        <MarkdownShortcutsPlugin />
         {onEnterKey && <EnterKeyPlugin onEnterKey={onEnterKey} />}
       </div>
     </div>

--- a/engines/collavre/app/javascript/components/plugins/markdown_shortcuts_plugin.jsx
+++ b/engines/collavre/app/javascript/components/plugins/markdown_shortcuts_plugin.jsx
@@ -1,0 +1,34 @@
+import { useEffect } from "react"
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext"
+import {
+  registerMarkdownShortcuts,
+  UNORDERED_LIST,
+  ORDERED_LIST,
+  CODE
+} from "@lexical/markdown"
+
+/**
+ * Markdown-style shortcuts for the creative inline editor:
+ *
+ * - "* " / "- " / "+ " at line start → unordered list
+ * - "1. " (any number) at line start → ordered list
+ * - "```" + space at line start → code block
+ *
+ * These fire on text change (not on Enter), so they don't conflict
+ * with the Enter→addNew() shortcut on desktop.
+ */
+const CREATIVE_MARKDOWN_TRANSFORMERS = [
+  UNORDERED_LIST,
+  ORDERED_LIST,
+  CODE
+]
+
+export default function MarkdownShortcutsPlugin() {
+  const [editor] = useLexicalComposerContext()
+
+  useEffect(() => {
+    return registerMarkdownShortcuts(editor, CREATIVE_MARKDOWN_TRANSFORMERS)
+  }, [editor])
+
+  return null
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@lexical/html": "^0.38.2",
         "@lexical/link": "^0.38.2",
         "@lexical/list": "^0.38.2",
+        "@lexical/markdown": "^0.38.2",
         "@lexical/react": "^0.38.2",
         "@lexical/rich-text": "^0.38.2",
         "@lexical/selection": "^0.38.2",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@lexical/html": "^0.38.2",
     "@lexical/link": "^0.38.2",
     "@lexical/list": "^0.38.2",
+    "@lexical/markdown": "^0.38.2",
     "@lexical/react": "^0.38.2",
     "@lexical/rich-text": "^0.38.2",
     "@lexical/selection": "^0.38.2",


### PR DESCRIPTION
## Summary

Add markdown-style shortcuts to the creative inline Lexical editor:

- `* `, `- `, `+ ` at line start → **unordered list**
- `1. ` (any number followed by dot+space) at line start → **ordered list**
- ``````` + space at line start → **code block**

## Implementation

- Added `@lexical/markdown` as an explicit dependency (was already available as a transitive dep)
- Created `MarkdownShortcutsPlugin` component using `registerMarkdownShortcuts` from `@lexical/markdown`
- Registered only the three required transformers: `UNORDERED_LIST`, `ORDERED_LIST`, `CODE`
- Added the plugin to `InlineLexicalEditor.jsx`

## How it works

`registerMarkdownShortcuts` uses an `updateListener` that watches for text changes. When the user types a markdown pattern (e.g., `* ` at line start), it transforms the current paragraph into the appropriate block type. This fires on text change (not on Enter key), so it **does not conflict** with the desktop Enter→addNew() behavior.

## Testing

- Build passes
- Rubocop passes
- Manual verification needed: open a creative inline editor, type `* ` to get a bullet list, `1. ` for numbered list, ``````` + space for code block

Closes Creative #10684