### PR TITLE
fix: render comments popup globally for inbox availability on all pages

### DIFF
--- a/engines/collavre/app/views/collavre/creatives/index.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/index.html.erb
@@ -2,6 +2,9 @@
 <% if authenticated? %>
   <%= turbo_stream_from Current.user, :creative_tree %>
 <% end %>
+<% if @auto_fullscreen %>
+  <% content_for :comments_popup_auto_fullscreen, "true" %>
+<% end %>
 
 <div data-controller="creatives--import creatives--select-mode creatives--drag-drop creatives--expansion creatives--row-editor share-modal"
      data-creatives--import-parent-id-value="<%= @parent_creative&.id %>"
@@ -222,7 +225,6 @@
       }
     ) %>
 
-<%= render 'collavre/comments/comments_popup', auto_fullscreen: @auto_fullscreen %>
 <%= render 'inline_edit_form' %>
 
 <%= render_extension_slot(:creative_modals) %>

--- a/engines/collavre/app/views/collavre/shared/navigation/_panels.html.erb
+++ b/engines/collavre/app/views/collavre/shared/navigation/_panels.html.erb
@@ -1,5 +1,10 @@
 <%= render_extension_slot(:navigation_panels) %>
 
+<% if Current.user %>
+  <%= render 'collavre/comments/comments_popup',
+             auto_fullscreen: content_for?(:comments_popup_auto_fullscreen) %>
+<% end %>
+
 <div id="creative-guide-popover" style="display:none; position:fixed; top:60px; left:50%; transform:translateX(-50%); background:white; border:1px solid var(--color-border); box-shadow:0 2px 8px rgba(0,0,0,0.12); padding:1.2em; max-width:400px; z-index:1000; border-radius:8px;">
   <button type="button" id="close-creative-guide" class="popup-close-btn">&times;</button>
   <div style="margin-top:0.5em; color:#444; font-size:1em; line-height:1.5;">


### PR DESCRIPTION
## Problem
The comments popup (inbox) was only rendered inside `creatives/index.html.erb`, so the inbox button did not work on host app pages without a creative context (e.g., newly created pages).

## Solution
Move the `comments_popup` partial rendering to the navigation panels partial (`_panels.html.erb`), which is included in the global layout. This ensures the inbox popup is always available for authenticated users on every page.

### Changes
- **`_panels.html.erb`**: Render `comments_popup` for logged-in users
- **`creatives/index.html.erb`**: Remove duplicate popup render; pass `auto_fullscreen` via `content_for` so the panels partial can forward it

### Preserved behavior
- `auto_fullscreen` on creative pages still works via `content_for(:comments_popup_auto_fullscreen)`
- `@parent_creative` instance variable is accessible in the layout since Rails renders the view before the layout
- No duplicate `#comments-popup` elements in the DOM