### PR TITLE
fix: GNB avatar popup menu hover background overflow and click area

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/popup.css
@@ -298,6 +298,7 @@
   left: 0;
   transform: translateX(0);
   box-sizing: border-box;
+  overflow: hidden;
 }
 
 .popup-menu-right {
@@ -305,9 +306,22 @@
   right: 0;
 }
 
-.popup-menu .popup-menu-item,
+/* Wrapper div: layout only, no interaction styles */
+div.popup-menu-item {
+  display: flex;
+  width: 100%;
+}
+
+/* Ensure forms from button_to fill the full width */
+.popup-menu .popup-menu-item form {
+  width: 100%;
+}
+
+/* Interactive elements: button/a inside wrapper OR directly classed as popup-menu-item */
 .popup-menu-item button,
-.popup-menu-item a {
+.popup-menu-item a,
+button.popup-menu-item,
+a.popup-menu-item {
   display: flex;
   align-items: center;
   gap: var(--space-2);
@@ -324,9 +338,10 @@
   white-space: nowrap;
 }
 
-.popup-menu .popup-menu-item:hover,
 .popup-menu-item button:hover,
-.popup-menu-item a:hover {
+.popup-menu-item a:hover,
+button.popup-menu-item:hover,
+a.popup-menu-item:hover {
   background: var(--surface-hover);
 }
 

--- a/engines/collavre/lib/collavre/engine.rb
+++ b/engines/collavre/lib/collavre/engine.rb
@@ -207,7 +207,6 @@ module Collavre
               label: "collavre.users.profile",
               type: :button,
               path: -> { Collavre::Engine.routes.url_helpers.user_path(Current.user) },
-              html_class: "popup-menu-item",
               priority: 100
             },
             {


### PR DESCRIPTION
## Problem

The GNB avatar popup menu had two visual bugs:

1. **Hover background bleeds past popup corners** — The popup has `border-radius` but no `overflow: hidden`, so item hover backgrounds extended beyond the rounded corners.

2. **Click area limited to text only** — The `.popup-menu-item` CSS selector was applied to both the wrapper `<div>` (from `render_dropdown_child`) and the inner `<button>`/`<a>`. The wrapper div got padding, hover, and cursor styles, making it look clickable while the actual click target was only the smaller inner element. Additionally, `button_to` generates a `<form>` wrapper that didn't have `width: 100%`, further constraining the button size.

## Changes

### `popup.css`
- Add `overflow: hidden` to `.popup-menu` to clip hover backgrounds at rounded corners
- Split `.popup-menu-item` styles into two concerns:
  - **Wrapper div** (`div.popup-menu-item`): layout only (display, width)
  - **Interactive elements** (`.popup-menu-item button/a`, `button.popup-menu-item`, `a.popup-menu-item`): padding, hover, cursor, transitions
- Add `.popup-menu .popup-menu-item form { width: 100% }` so `button_to` forms fill the full menu width

### `engine.rb`
- Remove redundant `html_class: "popup-menu-item"` from the profile nav item (already wrapped by `render_dropdown_child`)

## Compatibility

Both popup-menu-item usage patterns are handled:
- **Navigation dropdowns**: `<div class="popup-menu-item"><form><button>...</button></form></div>`
- **Creative menus**: `<button class="popup-menu-item">...</button>` (direct usage)

## Testing

- All 1574 tests pass (0 failures, 0 errors)
- Rubocop clean
- Preview server running on worktree79