### PR TITLE
feat: add awaiting_user state for trigger loop BLOCKED handling

### DIFF
--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -413,7 +413,7 @@ module Collavre
             creative.update!(data: data)
           end
         when "resume"
-          if loop_data && %w[paused idle stuck].include?(loop_data["state"])
+          if loop_data && %w[paused idle stuck awaiting_user].include?(loop_data["state"])
             loop_data["state"] = "running"
             trigger["loop"] = loop_data
             data["trigger"] = trigger

--- a/engines/collavre/app/javascript/controllers/comments/drop_trigger_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/drop_trigger_controller.js
@@ -6,6 +6,7 @@ const STATE_COLORS = {
     running:                "var(--color-active)",
     pending_verification:   "var(--color-warning)",
     completed:              "var(--color-success)",
+    awaiting_user:          "var(--color-warning)",
     stuck:                  "var(--color-danger)",
     max_reached:            "var(--color-warning)",
     paused:                 "var(--text-muted)"
@@ -16,6 +17,7 @@ const STATE_LABELS = {
     running: "Running",
     pending_verification: "Verifying",
     completed: "Completed",
+    awaiting_user: "Awaiting user",
     stuck: "Stuck",
     max_reached: "Max reached",
     paused: "Paused"
@@ -142,7 +144,7 @@ export default class extends Controller {
     _actionForState(state) {
         if (state === "running" || state === "pending_verification") return "pause"
         if (state === "idle") return "start"
-        if (state === "paused" || state === "stuck") return "resume"
+        if (state === "paused" || state === "stuck" || state === "awaiting_user") return "resume"
         if (state === "completed" || state === "max_reached") return "restart"
         return null
     }

--- a/engines/collavre/app/jobs/collavre/trigger_loop_check_job.rb
+++ b/engines/collavre/app/jobs/collavre/trigger_loop_check_job.rb
@@ -11,7 +11,7 @@ module Collavre
     # tags to determine next action.
     #
     # Status flow:
-    #   idle → running → completed | stuck | max_reached
+    #   idle → running → completed | awaiting_user | stuck | max_reached
     def perform(task_id)
       task = Task.find_by(id: task_id)
       return unless task&.creative
@@ -55,10 +55,10 @@ module Collavre
         # Transition to pending_verification and enqueue LLM verification
         update_loop_data(child_creative, state: "pending_verification", infra_retry_count: 0)
         TriggerLoopVerifyJob.perform_later(task.id)
-      when :stuck
-        update_loop_data(child_creative, state: "stuck", infra_retry_count: 0)
+      when :awaiting_user
+        update_loop_data(child_creative, state: "awaiting_user", infra_retry_count: 0)
         post_system_notice(child_creative, topic, I18n.t(
-          "collavre.trigger_loop.stuck",
+          "collavre.trigger_loop.awaiting_user",
           iteration: loop_config["current_iteration"]
         ))
       when :continue
@@ -131,17 +131,17 @@ module Collavre
       end
 
       if content.match?(/\[STATUS:\s*BLOCKED\b/i)
-        return :stuck
+        return :awaiting_user
       end
 
       if content.match?(/\[STATUS:\s*CONTINUE\b/i)
         return :continue
       end
 
-      # Keyword fallback — only for stuck detection, NOT for completion.
+      # Keyword fallback — only for blocked detection, NOT for completion.
       stuck = loop_config["stuck_conditions"] || []
       if stuck.any? { |kw| content.downcase.include?(kw.downcase) }
-        return :stuck
+        return :awaiting_user
       end
 
       # No status tag found — signal for LLM fallback evaluation
@@ -246,7 +246,7 @@ module Collavre
       when /\ADONE\b/
         :done
       when /\ABLOCKED\b/
-        :stuck
+        :awaiting_user
       else
         :continue
       end

--- a/engines/collavre/app/jobs/collavre/trigger_loop_verify_job.rb
+++ b/engines/collavre/app/jobs/collavre/trigger_loop_verify_job.rb
@@ -48,6 +48,13 @@ module Collavre
 
       if result == :verified
         update_loop_data(child_creative, state: "completed")
+      elsif result == :awaiting_user
+        # Agent correctly paused to wait for user — do NOT re-loop
+        update_loop_data(child_creative, state: "awaiting_user")
+        post_system_notice(child_creative, topic, I18n.t(
+          "collavre.trigger_loop.awaiting_user",
+          iteration: loop_config["current_iteration"]
+        ))
       else
         # Verification failed — continue the loop
         iteration = (loop_config["current_iteration"] || 0) + 1
@@ -120,6 +127,7 @@ module Collavre
       - "Completed" means the agent EXECUTED the action (e.g. created a PR, moved a creative, updated a record), not merely described or planned it.
       - If the agent says something "needs to be done" or "should be done" but didn't do it, that is NOT completed.
       - Be strict: if ANY required action was not executed, respond INCOMPLETE.
+      - IMPORTANT: If the agent correctly identified that it needs user approval, user input, or user action before it can proceed, and has paused/stopped to wait for the user, respond AWAITING_USER. This is NOT incomplete work — the agent did the right thing by asking.
     PROMPT
 
     def verify_completion(verifier, instructions, agent_response)
@@ -134,6 +142,7 @@ module Collavre
         Did the agent actually execute ALL required actions in the instructions?
         Respond with exactly one of:
         - VERIFIED — all actions were executed
+        - AWAITING_USER — the agent correctly paused to wait for user approval/input/action
         - INCOMPLETE: [list the unexecuted actions]
       PROMPT
 
@@ -153,6 +162,8 @@ module Collavre
       cleaned = response_text.strip
       if cleaned.blank? || cleaned.start_with?("VERIFIED")
         :verified
+      elsif cleaned.start_with?("AWAITING_USER")
+        :awaiting_user
       else
         # Extract the incomplete reason for the feedback message
         cleaned

--- a/engines/collavre/app/models/collavre/comment.rb
+++ b/engines/collavre/app/models/collavre/comment.rb
@@ -44,6 +44,7 @@ module Collavre
     before_validation :assign_default_user, on: :create
     before_save :apply_link_previews, if: :should_apply_link_previews?
     after_create_commit :dispatch_to_orchestration
+    after_create_commit :resume_trigger_loop_if_awaiting
 
     validates :content, presence: true, unless: -> { images.attached? }
     validate :creative_must_be_origin_creative
@@ -138,6 +139,56 @@ module Collavre
     def assign_default_user
       return if skip_default_user
       self.user ||= Collavre.current_user
+    end
+
+    # When a human user comments in a trigger topic that is awaiting user input,
+    # auto-resume the trigger loop so the agent can continue working.
+    def resume_trigger_loop_if_awaiting
+      return unless user_id                # must have a user (not system)
+      return if user&.ai_user?             # must be a human, not an AI agent
+      return unless creative
+
+      loop_data = creative.data&.dig("trigger", "loop")
+      return unless loop_data && loop_data["state"] == "awaiting_user"
+
+      # Only resume if this comment is in the trigger topic
+      trigger_topic_id = loop_data["trigger_topic_id"]
+      return if trigger_topic_id.present? && trigger_topic_id != topic_id
+
+      # Transition to running and post continue instruction
+      data = creative.data || {}
+      trigger = data["trigger"] || {}
+      loop_cfg = trigger["loop"] || {}
+      iteration = loop_cfg["current_iteration"] || 0
+      max = loop_cfg["max_iterations"] || 10
+      loop_cfg["state"] = "running"
+      trigger["loop"] = loop_cfg
+      data["trigger"] = trigger
+      creative.update!(data: data)
+
+      # Find the trigger agent from parent to post continue instruction
+      parent = creative.parent
+      return unless parent&.drop_trigger_enabled?
+
+      agent = parent.all_shared_users(:write).map(&:user).find(&:ai_user?)
+      return unless agent
+
+      creative.comments.create!(
+        content: "@#{agent.name}: #{I18n.t(
+          'collavre.trigger_loop.user_resumed',
+          iteration: iteration,
+          max: max
+        )}",
+        topic_id: topic_id,
+        private: false,
+        user: creative.user,
+        skip_dispatch: false
+      )
+    rescue StandardError => e
+      Rails.logger.error(
+        "[Comment#resume_trigger_loop_if_awaiting] Failed for comment #{id}: " \
+        "#{e.class} #{e.message}"
+      )
     end
 
     def use_origin_creative

--- a/engines/collavre/app/models/collavre/comment.rb
+++ b/engines/collavre/app/models/collavre/comment.rb
@@ -148,25 +148,32 @@ module Collavre
       return if user&.ai_user?             # must be a human, not an AI agent
       return unless creative
 
-      loop_data = creative.data&.dig("trigger", "loop")
-      return unless loop_data && loop_data["state"] == "awaiting_user"
+      # Use pessimistic lock to prevent duplicate resume from concurrent comments
+      iteration = nil
+      max = nil
+      creative.with_lock do
+        loop_data = creative.data&.dig("trigger", "loop")
+        return unless loop_data && loop_data["state"] == "awaiting_user"
 
-      # Only resume if this comment is in the trigger topic
-      trigger_topic_id = loop_data["trigger_topic_id"]
-      return if trigger_topic_id.present? && trigger_topic_id != topic_id
+        # Only resume if this comment is in the trigger topic
+        trigger_topic_id = loop_data["trigger_topic_id"]
+        return if trigger_topic_id.present? && trigger_topic_id != topic_id
 
-      # Transition to running and post continue instruction
-      data = creative.data || {}
-      trigger = data["trigger"] || {}
-      loop_cfg = trigger["loop"] || {}
-      iteration = loop_cfg["current_iteration"] || 0
-      max = loop_cfg["max_iterations"] || 10
-      loop_cfg["state"] = "running"
-      trigger["loop"] = loop_cfg
-      data["trigger"] = trigger
-      creative.update!(data: data)
+        # Transition to running and post continue instruction atomically
+        data = creative.data || {}
+        trigger = data["trigger"] || {}
+        loop_cfg = trigger["loop"] || {}
+        iteration = loop_cfg["current_iteration"] || 0
+        max = loop_cfg["max_iterations"] || 10
+        loop_cfg["state"] = "running"
+        trigger["loop"] = loop_cfg
+        data["trigger"] = trigger
+        creative.update!(data: data)
+      end
 
-      # Find the trigger agent from parent to post continue instruction
+      # Post continue instruction outside lock (state already committed)
+      return unless iteration # guard: lock block returned early
+
       parent = creative.parent
       return unless parent&.drop_trigger_enabled?
 

--- a/engines/collavre/config/locales/drop_trigger.en.yml
+++ b/engines/collavre/config/locales/drop_trigger.en.yml
@@ -17,6 +17,8 @@ en:
         - [STATUS: BLOCKED reason] — cannot proceed without help
       continue: "🔄 Trigger Loop — iteration %{iteration}/%{max}. Previous work is incomplete. Please continue where you left off and report [STATUS: DONE/CONTINUE/BLOCKED]."
       retry: "🔄 Trigger Loop — iteration %{iteration}/%{max}. The previous attempt failed due to an infrastructure error (timeout/connection). Please try again from the beginning and report [STATUS: DONE/CONTINUE/BLOCKED]."
+      awaiting_user: "⏸️ Trigger Loop paused — Awaiting user input at iteration %{iteration}. The agent has requested your approval or action. Reply in this topic to resume automatically."
+      user_resumed: "🔄 Trigger Loop — iteration %{iteration}/%{max}. User has responded. Please continue where you left off, incorporating the user's input, and report [STATUS: DONE/CONTINUE/BLOCKED]."
       stuck: "⚠️ Trigger Loop paused — Agent reported BLOCKED at iteration %{iteration}. User intervention may be needed."
       max_reached: "⚠️ Trigger Loop stopped — Reached maximum iterations (%{max}). Review progress and restart if needed."
       infra_stuck: "⚠️ Trigger Loop paused — %{count} consecutive infrastructure errors (timeout/connection). The service may be unavailable. User intervention needed."
@@ -31,4 +33,5 @@ en:
       state_completed: "Completed"
       state_stuck: "Stuck"
       state_max_reached: "Max iterations reached"
+      state_awaiting_user: "Awaiting user"
       state_paused: "Paused"

--- a/engines/collavre/config/locales/drop_trigger.ko.yml
+++ b/engines/collavre/config/locales/drop_trigger.ko.yml
@@ -17,6 +17,8 @@ ko:
         - [STATUS: BLOCKED 사유] — 도움 없이 진행 불가
       continue: "🔄 트리거 루프 — 반복 %{iteration}/%{max}. 이전 작업이 미완료입니다. 이어서 진행하고 [STATUS: DONE/CONTINUE/BLOCKED]으로 보고해주세요."
       retry: "🔄 트리거 루프 — 반복 %{iteration}/%{max}. 이전 시도가 인프라 에러(타임아웃/연결 실패)로 실패했습니다. 처음부터 다시 시도하고 [STATUS: DONE/CONTINUE/BLOCKED]으로 보고해주세요."
+      awaiting_user: "⏸️ 트리거 루프 일시정지 — 반복 %{iteration}에서 사용자 입력 대기 중입니다. 에이전트가 승인 또는 조치를 요청했습니다. 이 토픽에 답변하면 자동으로 재개됩니다."
+      user_resumed: "🔄 트리거 루프 — 반복 %{iteration}/%{max}. 사용자가 응답했습니다. 사용자의 입력을 반영하여 이어서 진행하고 [STATUS: DONE/CONTINUE/BLOCKED]으로 보고해주세요."
       stuck: "⚠️ 트리거 루프 일시정지 — 에이전트가 반복 %{iteration}에서 BLOCKED를 보고했습니다. 사용자 개입이 필요할 수 있습니다."
       max_reached: "⚠️ 트리거 루프 중단 — 최대 반복 횟수(%{max})에 도달했습니다. 진행 상황을 확인하고 필요시 재시작해주세요."
       infra_stuck: "⚠️ 트리거 루프 일시정지 — 연속 %{count}회 인프라 에러(타임아웃/연결 실패) 발생. 서비스가 불안정할 수 있습니다. 사용자 개입이 필요합니다."
@@ -31,4 +33,5 @@ ko:
       state_completed: "완료"
       state_stuck: "중단됨"
       state_max_reached: "최대 반복 도달"
+      state_awaiting_user: "사용자 대기 중"
       state_paused: "일시정지됨"

--- a/engines/collavre/test/jobs/collavre/trigger_loop_check_job_test.rb
+++ b/engines/collavre/test/jobs/collavre/trigger_loop_check_job_test.rb
@@ -79,7 +79,7 @@ module Collavre
       assert_equal "pending_verification", @child.data.dig("trigger", "loop", "state")
     end
 
-    test "completes loop when agent reports STATUS: BLOCKED" do
+    test "transitions to awaiting_user when agent reports STATUS: BLOCKED" do
       @child.comments.create!(
         content: "Cannot proceed [STATUS: BLOCKED need credentials]",
         topic_id: @topic.id,
@@ -94,8 +94,8 @@ module Collavre
       end
 
       @child.reload
-      assert_equal "stuck", @child.data.dig("trigger", "loop", "state")
-      assert_includes @child.comments.last.content, "⚠️"
+      assert_equal "awaiting_user", @child.data.dig("trigger", "loop", "state")
+      assert_includes @child.comments.last.content, "⏸️"
     end
 
     test "continues loop when agent reports STATUS: CONTINUE" do
@@ -267,7 +267,7 @@ module Collavre
       assert_equal 1, @child.data.dig("trigger", "loop", "current_iteration")
     end
 
-    test "falls back to stuck_conditions keywords" do
+    test "falls back to stuck_conditions keywords as awaiting_user" do
       @child.comments.create!(
         content: "I need help with this",
         topic_id: @topic.id,
@@ -280,7 +280,7 @@ module Collavre
       end
 
       @child.reload
-      assert_equal "stuck", @child.data.dig("trigger", "loop", "state")
+      assert_equal "awaiting_user", @child.data.dig("trigger", "loop", "state")
     end
 
     test "defaults to continue when no status tag or keywords match" do
@@ -415,7 +415,7 @@ module Collavre
       assert_equal 1, @child.data.dig("trigger", "loop", "current_iteration")
     end
 
-    test "LLM fallback: marks stuck when LLM says BLOCKED" do
+    test "LLM fallback: marks awaiting_user when LLM says BLOCKED" do
       @child.comments.create!(
         content: "I can't proceed because I don't have permission to access the repo.",
         topic_id: @topic.id,
@@ -433,7 +433,7 @@ module Collavre
       end
 
       @child.reload
-      assert_equal "stuck", @child.data.dig("trigger", "loop", "state")
+      assert_equal "awaiting_user", @child.data.dig("trigger", "loop", "state")
     end
 
     test "LLM fallback: defaults to continue on LLM error" do

--- a/engines/collavre/test/models/collavre/comment_resume_trigger_test.rb
+++ b/engines/collavre/test/models/collavre/comment_resume_trigger_test.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  class CommentResumeTriggerTest < ActiveSupport::TestCase
+    setup do
+      @human = users(:one)
+      @ai_bot = users(:ai_bot)
+
+      @parent = Creative.create!(
+        description: "Parent with trigger",
+        user: @human,
+        data: {
+          "trigger" => {
+            "on_child_enter" => true
+          }
+        }
+      )
+      CreativeShare.create!(creative: @parent, user: @ai_bot, permission: :write)
+
+      @child = Creative.create!(
+        description: "Child task",
+        user: @human
+      )
+      Creative.where(id: @child.id).update_all(parent_id: @parent.id)
+      @child.reload
+
+      @topic = @child.topics.create!(name: "Drop Trigger", user: @human)
+
+      @child.update!(data: {
+        "trigger" => {
+          "loop" => {
+            "state" => "awaiting_user",
+            "current_iteration" => 2,
+            "max_iterations" => 10,
+            "trigger_topic_id" => @topic.id
+          }
+        }
+      })
+    end
+
+    test "human comment in trigger topic resumes awaiting_user loop" do
+      SystemEvents::Dispatcher.stub(:dispatch, ->(*_args) { [ @ai_bot ] }) do
+        assert_difference -> { @child.comments.count }, 2 do
+          # 1 = the human comment itself, 2 = the auto-posted resume instruction
+          @child.comments.create!(
+            content: "Approved, go ahead",
+            topic_id: @topic.id,
+            user: @human
+          )
+        end
+      end
+
+      @child.reload
+      assert_equal "running", @child.data.dig("trigger", "loop", "state")
+      resume_comment = @child.comments.order(:created_at).last
+      assert_includes resume_comment.content, "@#{@ai_bot.name}:"
+      assert_includes resume_comment.content, "🔄"
+    end
+
+    test "AI comment does not resume awaiting_user loop" do
+      SystemEvents::Dispatcher.stub(:dispatch, ->(*_args) { [] }) do
+        assert_difference -> { @child.comments.count }, 1 do
+          @child.comments.create!(
+            content: "Still waiting for user",
+            topic_id: @topic.id,
+            user: @ai_bot
+          )
+        end
+      end
+
+      @child.reload
+      assert_equal "awaiting_user", @child.data.dig("trigger", "loop", "state")
+    end
+
+    test "human comment in different topic does not resume loop" do
+      other_topic = @child.topics.create!(name: "General", user: @human)
+
+      SystemEvents::Dispatcher.stub(:dispatch, ->(*_args) { [] }) do
+        assert_difference -> { @child.comments.count }, 1 do
+          @child.comments.create!(
+            content: "Some unrelated comment",
+            topic_id: other_topic.id,
+            user: @human
+          )
+        end
+      end
+
+      @child.reload
+      assert_equal "awaiting_user", @child.data.dig("trigger", "loop", "state")
+    end
+
+    test "human comment does not resume when loop is in running state" do
+      @child.data["trigger"]["loop"]["state"] = "running"
+      @child.save!
+
+      SystemEvents::Dispatcher.stub(:dispatch, ->(*_args) { [] }) do
+        assert_difference -> { @child.comments.count }, 1 do
+          @child.comments.create!(
+            content: "Some comment",
+            topic_id: @topic.id,
+            user: @human
+          )
+        end
+      end
+
+      @child.reload
+      assert_equal "running", @child.data.dig("trigger", "loop", "state")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

When an AI agent reports `[STATUS: BLOCKED]` during a trigger loop, the loop now transitions to `awaiting_user` instead of `stuck`. This prevents the verification job from re-looping the agent when it correctly paused to ask for user input.

When a human user comments in the trigger topic while the loop is in `awaiting_user` state, the loop automatically resumes.

## Changes

### Backend
- **TriggerLoopCheckJob**: `BLOCKED` status tag, stuck_conditions keywords, and LLM fallback all now return `:awaiting_user` instead of `:stuck`
- **TriggerLoopVerifyJob**: Added `AWAITING_USER` detection in both the system prompt and response parsing; transitions to `awaiting_user` instead of re-looping
- **Comment model**: New `after_create_commit :resume_trigger_loop_if_awaiting` callback — when a human comments in the trigger topic while state is `awaiting_user`, automatically resumes the loop and posts a continue instruction to the agent
- **CreativesController**: Added `awaiting_user` to the list of states that allow manual resume

### Frontend
- **drop_trigger_controller.js**: Added `awaiting_user` to state colors (warning) and labels; resume click works from `awaiting_user` state

### i18n (en/ko)
- `awaiting_user`: System notice when loop pauses for user input
- `user_resumed`: Continue instruction posted when human responds
- `state_awaiting_user`: UI label

### Tests
- Updated existing BLOCKED tests to expect `awaiting_user` state
- New `comment_resume_trigger_test.rb` with 4 tests covering:
  - Human comment resumes awaiting_user loop
  - AI comment does NOT resume
  - Wrong topic does NOT resume
  - Non-awaiting states are unaffected

## State Flow
```
idle → running → pending_verification → completed
                ↘ awaiting_user (BLOCKED) → human comments → running (auto-resume)
                ↘ stuck (infra errors)
                ↘ max_reached
```