### PR TITLE
fix: block navigation click in select mode, toggle selection only

### DIFF
--- a/engines/collavre/app/javascript/components/creative_tree_row.js
+++ b/engines/collavre/app/javascript/components/creative_tree_row.js
@@ -579,16 +579,11 @@ class CreativeTreeRow extends LitElement {
   }
 
   _handleContentClick(event) {
-    // In select mode, block navigation and toggle selection instead
+    // In select mode, block navigation — selection toggle is handled by
+    // select_mode_controller's mousedown handler to avoid double-toggling.
     if (this.selectMode) {
       event.preventDefault();
       event.stopPropagation();
-      const checkbox = this.querySelector('.select-creative-checkbox');
-      if (checkbox) {
-        checkbox.checked = !checkbox.checked;
-        const row = this.querySelector('.creative-row');
-        if (row) row.classList.toggle('selected', checkbox.checked);
-      }
       return;
     }
 

--- a/engines/collavre/app/javascript/components/creative_tree_row.js
+++ b/engines/collavre/app/javascript/components/creative_tree_row.js
@@ -579,6 +579,19 @@ class CreativeTreeRow extends LitElement {
   }
 
   _handleContentClick(event) {
+    // In select mode, block navigation and toggle selection instead
+    if (this.selectMode) {
+      event.preventDefault();
+      event.stopPropagation();
+      const checkbox = this.querySelector('.select-creative-checkbox');
+      if (checkbox) {
+        checkbox.checked = !checkbox.checked;
+        const row = this.querySelector('.creative-row');
+        if (row) row.classList.toggle('selected', checkbox.checked);
+      }
+      return;
+    }
+
     // Check if the clicked element is an interactive element or inside one
     const target = event.target;
     if (target.tagName === 'A' || target.closest('a') ||


### PR DESCRIPTION
## Problem
When select mode is active, clicking a creative row still triggers `Turbo.visit()` navigation to the creative's detail page. Users expect click to only toggle selection.

## Root Cause
`_handleContentClick()` in `creative_tree_row.js` had no awareness of `selectMode`. The `select_mode_controller`'s `mousedown` handler runs separately and can't prevent the LitElement `@click` handler from firing.

## Fix
Added a `selectMode` guard at the top of `_handleContentClick()`:
- When `selectMode === true`: prevent default, stop propagation, toggle the checkbox and `.selected` class on the row
- When `selectMode === false`: existing navigation behavior unchanged

## Testing
1. Enter select mode (선택 버튼 클릭)
2. Click any creative row content → should toggle checkbox, NOT navigate
3. Exit select mode → click should navigate as before