### PR TITLE
fix: preserve attachment attributes in inline editor and fix upload issues

### DIFF
--- a/engines/collavre/app/javascript/components/InlineLexicalEditor.jsx
+++ b/engines/collavre/app/javascript/components/InlineLexicalEditor.jsx
@@ -891,19 +891,9 @@ function EditorInner({
   deletedAttachmentsRef
 }) {
   const [editor] = useLexicalComposerContext()
-  const handleDrop = useCallback(
-    (event) => {
-      const files = event.dataTransfer?.files
-      if (!files || files.length === 0) return
-      event.preventDefault()
-      Array.from(files).forEach((file) => {
-        if (!file) return
-        editor.dispatchCommand(INSERT_FILE_COMMAND, { file })
-      })
-    },
-    [editor]
-  )
 
+  // File drop is handled by FileUploadPlugin's DROP_COMMAND handler.
+  // We only need dragOver to allow the browser to accept file drops.
   const handleDragOver = useCallback((event) => {
     if (event.dataTransfer?.types?.includes("Files")) {
       event.preventDefault()
@@ -922,7 +912,6 @@ function EditorInner({
                 if (!onKeyDown) return
                 onKeyDown(event, editor)
               }}
-              onDrop={handleDrop}
               onDragOver={handleDragOver}
             />
           }

--- a/engines/collavre/app/javascript/components/plugins/image_upload_plugin.jsx
+++ b/engines/collavre/app/javascript/components/plugins/image_upload_plugin.jsx
@@ -59,10 +59,9 @@ export default function FileUploadPlugin({
             const upload = new UploadConstructor(file, resolvedDirectUploadUrl)
 
             upload.create((error, attributes) => {
-                if (onUploadStateChange) onUploadStateChange(false)
-
                 if (error) {
                     console.error("Upload failed", error)
+                    if (onUploadStateChange) onUploadStateChange(false)
                     return
                 }
 
@@ -102,6 +101,10 @@ export default function FileUploadPlugin({
                         paragraph.selectStart()
                     }
                 })
+
+                // Notify upload complete AFTER editor update so onChange captures
+                // the new content before save can proceed
+                if (onUploadStateChange) onUploadStateChange(false)
             })
         },
         [blobUrlTemplate, directUploadUrl, editor, onUploadStateChange]

--- a/engines/collavre/app/models/collavre/creative/describable.rb
+++ b/engines/collavre/app/models/collavre/creative/describable.rb
@@ -34,10 +34,11 @@ module Collavre
       def sanitize_description_html
         table_tags = %w[table thead tbody tfoot tr th td]
         table_attrs = %w[colspan rowspan]
+        attachment_attrs = %w[download data-filesize]
         self.description = ActionController::Base.helpers.sanitize(
           description,
           tags: Rails::HTML5::SafeListSanitizer.allowed_tags.to_a + table_tags,
-          attributes: Rails::HTML5::SafeListSanitizer.allowed_attributes.to_a + table_attrs + %w[data-lexical]
+          attributes: Rails::HTML5::SafeListSanitizer.allowed_attributes.to_a + table_attrs + attachment_attrs + %w[data-lexical]
         )
       end
 

--- a/engines/collavre/test/models/creative_test.rb
+++ b/engines/collavre/test/models/creative_test.rb
@@ -202,4 +202,27 @@ class CreativeTest < ActiveSupport::TestCase
 
     assert_empty McpTool.where(id: tool.id)
   end
+
+  test "sanitize_description_html preserves download attribute on anchor tags" do
+    user = users(:one)
+    creative = Creative.create!(
+      user: user,
+      description: '<a href="/rails/active_storage/blobs/redirect/abc123/report.pdf" download="report.pdf" data-filesize="1024">report.pdf</a>'
+    )
+    assert_includes creative.description, 'download="report.pdf"',
+      "download attribute should be preserved by sanitizer"
+    assert_includes creative.description, 'data-filesize="1024"',
+      "data-filesize attribute should be preserved by sanitizer"
+  end
+
+  test "sanitize_description_html preserves img tags with src and alt" do
+    user = users(:one)
+    creative = Creative.create!(
+      user: user,
+      description: '<img src="/rails/active_storage/blobs/redirect/abc123/photo.png" alt="photo.png" width="800" height="600">'
+    )
+    assert_includes creative.description, '<img'
+    assert_includes creative.description, 'src="/rails/active_storage/blobs/redirect/abc123/photo.png"'
+    assert_includes creative.description, 'alt="photo.png"'
+  end
 end


### PR DESCRIPTION
## Problem

Images and file attachments uploaded via the creative inline editor were not properly persisting across save/reload cycles. Additionally, file drops caused duplicate uploads.

## Root Causes

### 1. HTML Sanitizer Stripping Attachment Attributes
The `sanitize_description_html` method in `Creative::Describable` did not include `download` or `data-filesize` in the allowed attributes list. When the editor content was saved:
- `<a href="..." download="file.pdf" data-filesize="1024">` became `<a href="...">`
- On reload, `AttachmentNode.importDOM()` checks `node.hasAttribute('download')` to identify attachment links — without it, attachments degraded to plain links

### 2. Duplicate File Drop Handling
Both `EditorInner.handleDrop` (React `onDrop`) and `FileUploadPlugin`'s `DROP_COMMAND` handler processed file drops, causing each dropped file to be uploaded and inserted twice.

### 3. Upload Completion Race Condition
`onUploadStateChange(false)` fired before `editor.update()` inserted the uploaded node. If a save triggered between these two calls, it would capture stale content without the newly uploaded image/attachment.

## Changes

- **describable.rb**: Add `download` and `data-filesize` to sanitizer allowed attributes
- **InlineLexicalEditor.jsx**: Remove duplicate `onDrop` handler (FileUploadPlugin already handles `DROP_COMMAND`)
- **image_upload_plugin.jsx**: Move `onUploadStateChange(false)` after `editor.update()` so onChange captures the inserted node before save can proceed
- **creative_test.rb**: Add tests verifying sanitizer preserves attachment attributes

## Testing

- `bin/rails test engines/collavre/test/models/creative_test.rb` — 15 runs, 0 failures
- `npm test` — 146 tests passed
- Rubocop clean
- JS build clean