### PR TITLE
feat: add OpenAI provider support for AI agents

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,9 +1,13 @@
 require_relative "../../lib/omniauth/strategies/notion"
 
-Rails.application.config.middleware.use OmniAuth::Builder do
-  google_client_id = ENV["GOOGLE_CLIENT_ID"] || Rails.application.credentials.dig(:google, :client_id)
-  google_client_secret = ENV["GOOGLE_CLIENT_SECRET"] || Rails.application.credentials.dig(:google, :client_secret)
+google_client_id = ENV["GOOGLE_CLIENT_ID"] || Rails.application.credentials.dig(:google, :client_id)
+google_client_secret = ENV["GOOGLE_CLIENT_SECRET"] || Rails.application.credentials.dig(:google, :client_secret)
+github_client_id = ENV["GITHUB_CLIENT_ID"] || Rails.application.credentials.dig(:github, :client_id)
+github_client_secret = ENV["GITHUB_CLIENT_SECRET"] || Rails.application.credentials.dig(:github, :client_secret)
+notion_client_id = ENV["NOTION_CLIENT_ID"] || Rails.application.credentials.dig(:notion, :client_id)
+notion_client_secret = ENV["NOTION_CLIENT_SECRET"] || Rails.application.credentials.dig(:notion, :client_secret)
 
+Rails.application.config.middleware.use OmniAuth::Builder do
   if google_client_id.present? && google_client_secret.present?
     provider :google_oauth2,
              google_client_id,
@@ -17,8 +21,6 @@ Rails.application.config.middleware.use OmniAuth::Builder do
              include_granted_scopes: "true"
   end
 
-  github_client_id = ENV["GITHUB_CLIENT_ID"] || Rails.application.credentials.dig(:github, :client_id)
-  github_client_secret = ENV["GITHUB_CLIENT_SECRET"] || Rails.application.credentials.dig(:github, :client_secret)
   if github_client_id.present? && github_client_secret.present?
     provider :github,
              github_client_id,
@@ -27,8 +29,6 @@ Rails.application.config.middleware.use OmniAuth::Builder do
              allow_signup: false
   end
 
-  notion_client_id = ENV["NOTION_CLIENT_ID"] || Rails.application.credentials.dig(:notion, :client_id)
-  notion_client_secret = ENV["NOTION_CLIENT_SECRET"] || Rails.application.credentials.dig(:notion, :client_secret)
   if notion_client_id.present? && notion_client_secret.present?
     provider :notion,
              notion_client_id,

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -62,33 +62,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_01_120000) do
     t.index ["user_id"], name: "index_activity_logs_on_user_id"
   end
 
-  create_table "agent_actions", force: :cascade do |t|
-    t.integer "agent_run_id", null: false
-    t.json "arguments", default: {}
-    t.datetime "created_at", null: false
-    t.text "result"
-    t.string "status", default: "pending"
-    t.string "tool_name"
-    t.datetime "updated_at", null: false
-    t.index ["agent_run_id"], name: "index_agent_actions_on_agent_run_id"
-  end
-
-  create_table "agent_runs", force: :cascade do |t|
-    t.integer "ai_user_id", null: false
-    t.json "context", default: {}
-    t.datetime "created_at", null: false
-    t.integer "creative_id", null: false
-    t.text "goal"
-    t.integer "iteration_count", default: 0
-    t.datetime "next_run_at"
-    t.string "state", default: "planning"
-    t.string "status", default: "pending"
-    t.json "transcript", default: []
-    t.datetime "updated_at", null: false
-    t.index ["ai_user_id"], name: "index_agent_runs_on_ai_user_id"
-    t.index ["creative_id"], name: "index_agent_runs_on_creative_id"
-  end
-
   create_table "calendar_events", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.integer "creative_id"
@@ -169,7 +142,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_01_120000) do
     t.text "quoted_text"
     t.integer "review_type", limit: 1
     t.integer "selected_version_id"
-    t.boolean "streaming", default: false, null: false
     t.integer "topic_id"
     t.datetime "updated_at", null: false
     t.integer "user_id"
@@ -238,7 +210,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_01_120000) do
     t.datetime "updated_at", null: false
     t.integer "user_id", null: false
     t.index ["archived_at"], name: "index_creatives_on_archived_at", where: "archived_at IS NOT NULL"
-    t.index ["data"], name: "index_creatives_on_data"
     t.index ["origin_id"], name: "index_creatives_on_origin_id"
     t.index ["parent_id"], name: "index_creatives_on_parent_id"
     t.index ["user_id"], name: "index_creatives_on_user_id"
@@ -854,7 +825,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_01_120000) do
   add_foreign_key "contacts", "users", column: "contact_user_id"
   add_foreign_key "creative_shares", "creatives"
   add_foreign_key "creative_shares", "users"
-  add_foreign_key "creative_shares", "users", column: "shared_by_id"
+  add_foreign_key "creative_shares", "users", column: "shared_by_id", on_delete: :nullify
   add_foreign_key "creatives", "creatives", column: "origin_id"
   add_foreign_key "creatives", "creatives", column: "parent_id"
   add_foreign_key "creatives", "users"
@@ -899,6 +870,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_01_120000) do
   add_foreign_key "solid_queue_scheduled_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "tags", "labels"
   add_foreign_key "task_actions", "tasks"
+  add_foreign_key "tasks", "creatives", on_delete: :nullify
+  add_foreign_key "tasks", "tasks", column: "parent_task_id", on_delete: :nullify
   add_foreign_key "tasks", "users", column: "agent_id"
   add_foreign_key "topics", "creatives"
   add_foreign_key "topics", "users"

--- a/engines/collavre/app/models/collavre/user.rb
+++ b/engines/collavre/app/models/collavre/user.rb
@@ -131,10 +131,10 @@ module Collavre
     end
 
     LLM_VENDOR_OPTIONS = [
-      ["Google (Gemini)", "google"],
-      ["OpenAI", "openai"],
-      ["Anthropic", "anthropic"],
-      ["OpenClaw", "openclaw"]
+      [ "Google (Gemini)", "google" ],
+      [ "OpenAI", "openai" ],
+      [ "Anthropic", "anthropic" ],
+      [ "OpenClaw", "openclaw" ]
     ].freeze
 
     SUPPORTED_LLM_MODELS = [

--- a/engines/collavre/app/models/collavre/user.rb
+++ b/engines/collavre/app/models/collavre/user.rb
@@ -130,6 +130,13 @@ module Collavre
       end
     end
 
+    LLM_VENDOR_OPTIONS = [
+      ["Google (Gemini)", "google"],
+      ["OpenAI", "openai"],
+      ["Anthropic", "anthropic"],
+      ["OpenClaw", "openclaw"]
+    ].freeze
+
     SUPPORTED_LLM_MODELS = [
       "gemini-3-flash-preview",
       "gemini-1.5-flash",

--- a/engines/collavre/app/services/collavre/ai_agent_service.rb
+++ b/engines/collavre/app/services/collavre/ai_agent_service.rb
@@ -135,6 +135,7 @@ module Collavre
         model: @agent.llm_model,
         system_prompt: system_prompt,
         llm_api_key: @agent.llm_api_key,
+        gateway_url: @agent.gateway_url,
         context: {
           creative: @creative,
           user: @agent,

--- a/engines/collavre/app/services/collavre/ai_client.rb
+++ b/engines/collavre/app/services/collavre/ai_client.rb
@@ -28,7 +28,7 @@ module Collavre
       output_tokens = nil
 
       normalized_vendor = vendor.to_s.downcase
-      unless %w[google gemini openai anthropic].include?(normalized_vendor)
+      unless VENDOR_TO_PROVIDER.key?(normalized_vendor)
         Rails.logger.warn "Unsupported LLM vendor '#{@vendor}'. Attempting to use default (google)."
       end
 

--- a/engines/collavre/app/services/collavre/ai_client.rb
+++ b/engines/collavre/app/services/collavre/ai_client.rb
@@ -27,34 +27,8 @@ module Collavre
       input_tokens = nil
       output_tokens = nil
 
-      # For now, we assume the API key is in the environment variable GEMINI_API_KEY
-      # In a real generic implementation, we might need to fetch keys based on vendor.
-      # Since the user request mentioned "ruby_llm", we try to use it.
-      # However, RubyLLM configuration in this project seems to be static in initializer.
-      # We might need to adjust RubyLLM usage to be dynamic if possible, or just support Gemini for now via RubyLLM
-      # but allowing model configuration.
-
-      # Current RubyLLM initializer:
-      # RubyLLM.configure do |config|
-      #   config.gemini_api_key = ENV["GEMINI_API_KEY"]
-      # end
-
-      # We can use RubyLLM.context to override config per request if needed,
-      # but for now we'll stick to the pattern in GeminiChatClient but make it slightly more generic
-      # if RubyLLM supports other vendors.
-
-      # NOTE: The current requirement implies we should support what RubyLLM supports.
-      # If the user enters vendor='google', we use Gemini.
-
-      # For now, we assume the API key is in the environment variable GEMINI_API_KEY
-      # In a real generic implementation, we might need to fetch keys based on vendor.
-      # Since the user request mentioned "ruby_llm", we try to use it.
-      # Previously the method returned early unless vendor was "google" which caused AI responses
-      # to be omitted for agents with a different or nil vendor. We now proceed for any vendor
-      # and log a warning if the vendor is unsupported.
-
       normalized_vendor = vendor.to_s.downcase
-      unless %w[google gemini openai].include?(normalized_vendor)
+      unless %w[google gemini openai anthropic].include?(normalized_vendor)
         Rails.logger.warn "Unsupported LLM vendor '#{@vendor}'. Attempting to use default (google)."
       end
 
@@ -127,23 +101,39 @@ module Collavre
 
     attr_reader :vendor, :model, :system_prompt, :llm_api_key, :gateway_url, :context
 
+    VENDOR_TO_PROVIDER = {
+      "openai" => :openai,
+      "anthropic" => :anthropic,
+      "google" => :gemini,
+      "gemini" => :gemini
+    }.freeze
+
     def build_conversation(tools = [])
       normalized_vendor = @vendor.to_s.downcase
 
-      context_block = if normalized_vendor == "openai"
+      context_block = case normalized_vendor
+      when "openai"
         api_key = @llm_api_key.presence || ENV["OPENAI_API_KEY"]
         base_url = @gateway_url.presence
         proc do |config|
           config.openai_api_key = api_key
           config.openai_api_base = base_url if base_url
         end
+      when "anthropic"
+        api_key = @llm_api_key.presence || ENV["ANTHROPIC_API_KEY"]
+        proc { |config| config.anthropic_api_key = api_key }
       else
         api_key = @llm_api_key.presence || ENV["GEMINI_API_KEY"]
         proc { |config| config.gemini_api_key = api_key }
       end
 
+      provider = VENDOR_TO_PROVIDER[normalized_vendor]
+      chat_opts = { model: model }
+      chat_opts[:provider] = provider if provider
+      chat_opts[:assume_model_exists] = true if provider
+
       RubyLLM.context(&context_block)
-             .chat(model: model).tap do |chat|
+             .chat(**chat_opts).tap do |chat|
         chat.with_instructions(system_prompt) if system_prompt.present?
         chat.on_tool_call do |tool_call|
           check_tool_approval!(tool_call)

--- a/engines/collavre/app/services/collavre/ai_client.rb
+++ b/engines/collavre/app/services/collavre/ai_client.rb
@@ -10,11 +10,12 @@ module Collavre
 
     attr_reader :last_input_tokens, :last_output_tokens
 
-    def initialize(vendor:, model:, system_prompt:, llm_api_key: nil, context: {})
+    def initialize(vendor:, model:, system_prompt:, llm_api_key: nil, gateway_url: nil, context: {})
       @vendor = vendor
       @model = model
       @system_prompt = system_prompt
       @llm_api_key = llm_api_key
+      @gateway_url = gateway_url
       @context = context
       @last_input_tokens = 0
       @last_output_tokens = 0
@@ -53,7 +54,7 @@ module Collavre
       # and log a warning if the vendor is unsupported.
 
       normalized_vendor = vendor.to_s.downcase
-      unless %w[google gemini].include?(normalized_vendor)
+      unless %w[google gemini openai].include?(normalized_vendor)
         Rails.logger.warn "Unsupported LLM vendor '#{@vendor}'. Attempting to use default (google)."
       end
 
@@ -124,16 +125,24 @@ module Collavre
 
     private
 
-    attr_reader :vendor, :model, :system_prompt, :llm_api_key, :context
+    attr_reader :vendor, :model, :system_prompt, :llm_api_key, :gateway_url, :context
 
     def build_conversation(tools = [])
-      # Using RubyLLM.context to ensure we can potentially switch keys if we had them.
-      # We explicitly set the key from ENV for now, as RubyLLM might not pick it up from global config in context?
-      # Or maybe the global config was not loaded in the runner context properly?
-      # Regardless, setting it here ensures it works like GeminiChatClient.
+      normalized_vendor = @vendor.to_s.downcase
 
-      api_key = @llm_api_key.presence || ENV["GEMINI_API_KEY"]
-      RubyLLM.context { |config| config.gemini_api_key = api_key }
+      context_block = if normalized_vendor == "openai"
+        api_key = @llm_api_key.presence || ENV["OPENAI_API_KEY"]
+        base_url = @gateway_url.presence
+        proc do |config|
+          config.openai_api_key = api_key
+          config.openai_api_base = base_url if base_url
+        end
+      else
+        api_key = @llm_api_key.presence || ENV["GEMINI_API_KEY"]
+        proc { |config| config.gemini_api_key = api_key }
+      end
+
+      RubyLLM.context(&context_block)
              .chat(model: model).tap do |chat|
         chat.with_instructions(system_prompt) if system_prompt.present?
         chat.on_tool_call do |tool_call|

--- a/engines/collavre/app/views/collavre/users/edit_ai.html.erb
+++ b/engines/collavre/app/views/collavre/users/edit_ai.html.erb
@@ -22,6 +22,7 @@
     <%= form.label :llm_vendor, t('collavre.users.new_ai.vendor_label', default: 'LLM Provider') %>
     <%= form.select :llm_vendor, options_for_select([
       ["Google (Gemini)", "google"],
+      ["OpenAI", "openai"],
       ["OpenClaw", "openclaw"]
     ], @user.llm_vendor || "google"), {}, class: "stacked-form-control" %>
     <small class="form-text text-muted"><%= t('collavre.users.new_ai.vendor_help', default: 'Select the AI provider for this agent') %></small>
@@ -54,7 +55,7 @@
   <div class="form-group">
     <%= form.label :gateway_url, t('collavre.users.new_ai.gateway_url_label', default: 'Gateway URL') %>
     <%= form.text_field :gateway_url, class: "stacked-form-control", placeholder: "http://localhost:18789" %>
-    <small class="form-text text-muted"><%= t('collavre.users.new_ai.gateway_url_help', default: 'Required for OpenClaw. The URL of your OpenClaw gateway.') %></small>
+    <small class="form-text text-muted"><%= t('collavre.users.new_ai.gateway_url_help', default: 'Gateway/Base URL. Required for OpenClaw. For OpenAI-compatible providers, enter the base URL (e.g. https://api.openai.com/v1).') %></small>
   </div>
 
   <div class="form-group">

--- a/engines/collavre/app/views/collavre/users/edit_ai.html.erb
+++ b/engines/collavre/app/views/collavre/users/edit_ai.html.erb
@@ -20,11 +20,9 @@
 
   <div class="form-group">
     <%= form.label :llm_vendor, t('collavre.users.new_ai.vendor_label', default: 'LLM Provider') %>
-    <%= form.select :llm_vendor, options_for_select([
-      ["Google (Gemini)", "google"],
-      ["OpenAI", "openai"],
-      ["OpenClaw", "openclaw"]
-    ], @user.llm_vendor || "google"), {}, class: "stacked-form-control" %>
+    <%= form.select :llm_vendor, options_for_select(
+      Collavre::User::LLM_VENDOR_OPTIONS, @user.llm_vendor || "google"
+    ), {}, class: "stacked-form-control" %>
     <small class="form-text text-muted"><%= t('collavre.users.new_ai.vendor_help', default: 'Select the AI provider for this agent') %></small>
   </div>
 

--- a/engines/collavre/app/views/collavre/users/new_ai.html.erb
+++ b/engines/collavre/app/views/collavre/users/new_ai.html.erb
@@ -34,11 +34,9 @@
 
   <div class="form-group">
     <%= form.label :llm_vendor, t('collavre.users.new_ai.vendor_label', default: 'LLM Provider') %>
-    <%= form.select :llm_vendor, options_for_select([
-      ["Google (Gemini)", "google"],
-      ["OpenAI", "openai"],
-      ["OpenClaw", "openclaw"]
-    ], @copy_source&.llm_vendor || "google"), {}, class: "stacked-form-control" %>
+    <%= form.select :llm_vendor, options_for_select(
+      Collavre::User::LLM_VENDOR_OPTIONS, @copy_source&.llm_vendor || "google"
+    ), {}, class: "stacked-form-control" %>
     <small class="form-text text-muted"><%= t('collavre.users.new_ai.vendor_help', default: 'Select the AI provider for this agent') %></small>
   </div>
 

--- a/engines/collavre/app/views/collavre/users/new_ai.html.erb
+++ b/engines/collavre/app/views/collavre/users/new_ai.html.erb
@@ -36,6 +36,7 @@
     <%= form.label :llm_vendor, t('collavre.users.new_ai.vendor_label', default: 'LLM Provider') %>
     <%= form.select :llm_vendor, options_for_select([
       ["Google (Gemini)", "google"],
+      ["OpenAI", "openai"],
       ["OpenClaw", "openclaw"]
     ], @copy_source&.llm_vendor || "google"), {}, class: "stacked-form-control" %>
     <small class="form-text text-muted"><%= t('collavre.users.new_ai.vendor_help', default: 'Select the AI provider for this agent') %></small>
@@ -69,7 +70,7 @@
   <div class="form-group">
     <%= form.label :gateway_url, t('collavre.users.new_ai.gateway_url_label', default: 'Gateway URL') %>
     <%= form.text_field :gateway_url, class: "stacked-form-control", placeholder: "http://localhost:18789", value: @copy_source&.gateway_url %>
-    <small class="form-text text-muted"><%= t('collavre.users.new_ai.gateway_url_help', default: 'Required for OpenClaw. The URL of your OpenClaw gateway.') %></small>
+    <small class="form-text text-muted"><%= t('collavre.users.new_ai.gateway_url_help', default: 'Gateway/Base URL. Required for OpenClaw. For OpenAI-compatible providers, enter the base URL (e.g. https://api.openai.com/v1).') %></small>
   </div>
 
   <div class="form-group">

--- a/engines/collavre/test/jobs/ai_agent_job_test.rb
+++ b/engines/collavre/test/jobs/ai_agent_job_test.rb
@@ -96,7 +96,7 @@ class AiAgentJobTest < ActiveJob::TestCase
     attr_reader :captured_system_prompt
     attr_reader :captured_context
 
-    def initialize(vendor:, model:, system_prompt:, llm_api_key:, context: {})
+    def initialize(vendor:, model:, system_prompt:, llm_api_key:, gateway_url: nil, context: {})
       @captured_system_prompt = system_prompt
       @captured_context = context
     end

--- a/engines/collavre/test/services/ai_client_test.rb
+++ b/engines/collavre/test/services/ai_client_test.rb
@@ -66,7 +66,7 @@ class AiClientTest < ActiveSupport::TestCase
     fake_chat = FakeConversation.new
 
     mock_context = Object.new
-    mock_context.define_singleton_method(:chat) do |model:|
+    mock_context.define_singleton_method(:chat) do |**kwargs|
       fake_chat
     end
 
@@ -97,7 +97,7 @@ class AiClientTest < ActiveSupport::TestCase
     fake_chat = FakeConversation.new
 
     mock_context = Object.new
-    mock_context.define_singleton_method(:chat) do |model:|
+    mock_context.define_singleton_method(:chat) do |**kwargs|
       fake_chat
     end
 

--- a/engines/collavre_completion_api/app/controllers/collavre_completion_api/api/v1/chat/completions_controller.rb
+++ b/engines/collavre_completion_api/app/controllers/collavre_completion_api/api/v1/chat/completions_controller.rb
@@ -36,6 +36,7 @@ module CollavreCompletionApi
               model: agent.llm_model,
               system_prompt: system_prompt,
               llm_api_key: api_key,
+              gateway_url: agent.respond_to?(:gateway_url) ? agent.gateway_url : nil,
               context: { creative: collavre_creative, user: current_user }
             )
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -140,6 +140,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -726,6 +727,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -766,6 +768,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1355,6 +1358,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.2.tgz",
       "integrity": "sha512-Ecx2ig/JLC9ayIQwZHqm41Tzlf4c1WUuFhFUZB1y+JIJqDRE579x7Uil7tKT8MwDpOPwrK5ZtpxdSsrfy/LF8Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/component": "0.7.0",
         "@firebase/logger": "0.5.0",
@@ -1421,6 +1425,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.2.tgz",
       "integrity": "sha512-cn+U27GDaBS/irsbvrfnPZdcCzeZPRGKieSlyb7vV6LSOL6mdECnB86PgYjYGxSNg8+U48L/NeevTV1odU+mOQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/app": "0.14.2",
         "@firebase/component": "0.7.0",
@@ -1436,7 +1441,8 @@
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
       "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@firebase/auth": {
       "version": "1.11.0",
@@ -1887,6 +1893,7 @@
       "integrity": "sha512-0AZUyYUfpMNcztR5l09izHwXkZpghLgCUaAGjtMwXnCg3bj4ml5VgiwqOMOxJ+Nw4qN/zJAaOQBcJ7KGkWStqQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -3952,6 +3959,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -5309,7 +5317,6 @@
       "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
       "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
@@ -6680,6 +6687,7 @@
       "integrity": "sha512-Pcfm3eZ+eO4JdZCXthW9tCDT3nF4K+9dmeZ+5X39n+Kqz0DDIABRP5CAEOHRFZk8RGuC2efksTJxrjp8EXCunQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.19",
         "@asamuzakjp/dom-selector": "^6.7.3",
@@ -6760,6 +6768,7 @@
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -6802,7 +6811,6 @@
       "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.114.tgz",
       "integrity": "sha512-gcxmNFzA4hv8UYi8j43uPlQ7CGcyMJ2KQb5kZASw6SnAKAf10hK12i2fjrS3Cl/ugZa5Ui6WwIu1/6MIXiHttQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "isomorphic.js": "^0.2.4"
       },
@@ -7433,6 +7441,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -7475,6 +7484,7 @@
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -7617,6 +7627,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7626,6 +7637,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -8169,6 +8181,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -8192,6 +8205,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }


### PR DESCRIPTION
Add "OpenAI" as a selectable LLM provider when creating or editing AI agents. When selected, AiClient configures RubyLLM's openai_api_key and openai_api_base (via the existing gateway_url field). Falls back to RubyLLM's default OpenAI base URL when no gateway URL is provided.