### PR TITLE
fix: use relative paths for direct upload URLs in inline editor

### DIFF
--- a/engines/collavre/app/views/collavre/creatives/_inline_edit_form.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_inline_edit_form.html.erb
@@ -11,8 +11,8 @@
     <div id="lexical-inline-editor"
          data-lexical-editor-root
          class="lexical-inline-editor"
-         data-direct-upload-url="<%= main_app.rails_direct_uploads_url %>"
-         data-blob-url-template="<%= main_app.rails_service_blob_url(':signed_id', ':filename') %>"
+         data-direct-upload-url="<%= main_app.rails_direct_uploads_path %>"
+         data-blob-url-template="<%= main_app.rails_service_blob_path(':signed_id', ':filename') %>"
          data-placeholder="<%= t('collavre.creatives.inline_editor.placeholder') %>"></div>
     <div id="actions-inline-editor" style="padding: 0px 8px;">
       <div style="margin-top:0.5em;display:flex;align-items:center;gap:0.5em;">


### PR DESCRIPTION
## Summary
- Switch `rails_direct_uploads_url` → `rails_direct_uploads_path` and `rails_service_blob_url` → `rails_service_blob_path` in `_inline_edit_form.html.erb`
- This was missed in PR #1130 which fixed sanitizer/drop/race-condition issues
- The `_url` helpers generate absolute URLs using `config/application.rb` PORT env, which doesn't match the actual server port (e.g. preview servers on non-standard ports), causing `ERR_CONNECTION_REFUSED` on direct uploads
- Using `_path` helpers generates relative paths that resolve correctly regardless of port

## Test plan
- [x] All tests pass (Rubocop + Rails + JS)
- [ ] Verify image upload works in inline editor on localhost:3000