### PR TITLE
feat: add stop button for AI agent responses

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -1033,19 +1033,23 @@ body.chat-fullscreen {
 .agent-stop-btn {
     background: var(--surface-3);
     border: 1px solid var(--surface-4);
-    border-radius: var(--radius-round);
+    border-radius: var(--radius-2);
     color: var(--text-2);
     cursor: pointer;
-    font-size: var(--text-0);
-    width: 20px;
-    height: 20px;
-    padding: 0;
+    font-size: var(--text-00);
+    padding: 2px 8px;
     display: inline-flex;
     align-items: center;
-    justify-content: center;
-    margin-right: 4px;
+    gap: 3px;
+    margin-right: 6px;
     flex-shrink: 0;
-    transition: background 0.15s;
+    transition: background 0.15s, color 0.15s;
+    white-space: nowrap;
+    line-height: 1;
+}
+
+.agent-stop-btn .agent-stop-icon {
+    font-size: 8px;
 }
 
 .agent-stop-btn:hover {

--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -1030,6 +1030,28 @@ body.chat-fullscreen {
     filter: grayscale(1);
 }
 
+.agent-stop-btn {
+    background: var(--surface-3);
+    border: 1px solid var(--surface-4);
+    border-radius: var(--radius-round);
+    color: var(--text-2);
+    cursor: pointer;
+    font-size: var(--text-0);
+    width: 20px;
+    height: 20px;
+    padding: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    margin-left: 4px;
+    transition: background 0.15s;
+}
+
+.agent-stop-btn:hover {
+    background: var(--red-5);
+    color: white;
+}
+
 /* --- Context Chips --- */
 .comment-contexts-list {
     display: flex;

--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -1031,17 +1031,17 @@ body.chat-fullscreen {
 }
 
 .agent-stop-btn {
-    background: var(--surface-3);
-    border: 1px solid var(--surface-4);
+    background: var(--surface-btn);
+    border: 1px solid var(--border-color);
     border-radius: var(--radius-2);
-    color: var(--text-2);
+    color: var(--text-muted);
     cursor: pointer;
     font-size: var(--text-00);
-    padding: 2px 8px;
+    padding: var(--space-px-1) var(--space-px-2);
     display: inline-flex;
     align-items: center;
-    gap: 3px;
-    margin-right: 6px;
+    gap: var(--space-px-1);
+    margin-right: var(--space-px-1);
     flex-shrink: 0;
     transition: background 0.15s, color 0.15s;
     white-space: nowrap;
@@ -1049,12 +1049,12 @@ body.chat-fullscreen {
 }
 
 .agent-stop-btn .agent-stop-icon {
-    font-size: 8px;
+    font-size: var(--text-00);
 }
 
 .agent-stop-btn:hover {
-    background: var(--red-5);
-    color: white;
+    background: var(--color-danger);
+    color: var(--text-on-btn);
 }
 
 /* --- Context Chips --- */

--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -1043,7 +1043,8 @@ body.chat-fullscreen {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    margin-left: 4px;
+    margin-right: 4px;
+    flex-shrink: 0;
     transition: background 0.15s;
 }
 

--- a/engines/collavre/app/controllers/collavre/tasks_controller.rb
+++ b/engines/collavre/app/controllers/collavre/tasks_controller.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Collavre
+  class TasksController < ApplicationController
+    def cancel
+      task = Task.find(params[:id])
+      creative = task.creative || Creative.find_by(id: task.trigger_event_payload&.dig("creative", "id"))
+
+      unless creative && creative.has_permission?(Current.user, :feedback)
+        return head :forbidden
+      end
+
+      unless %w[running pending queued].include?(task.status)
+        return head :unprocessable_entity
+      end
+
+      task.update!(status: "cancelled")
+
+      abort_openclaw_session(task)
+
+      head :ok
+    end
+
+    private
+
+    def abort_openclaw_session(task)
+      return unless task.agent.llm_vendor&.downcase == "openclaw"
+      return unless defined?(CollavreOpenclaw::ConnectionManager)
+
+      conn = CollavreOpenclaw::ConnectionManager.instance.connection_for(task.agent)
+      session_key = build_session_key(task)
+      conn.chat_abort(session_key: session_key)
+    rescue StandardError => e
+      Rails.logger.warn("[TasksController] OpenClaw abort failed: #{e.message}")
+    end
+
+    def build_session_key(task)
+      context = task.trigger_event_payload || {}
+      CollavreOpenclaw::OpenclawAdapter.new(
+        user: task.agent,
+        system_prompt: "",
+        context: context
+      ).session_key
+    end
+  end
+end

--- a/engines/collavre/app/controllers/collavre/tasks_controller.rb
+++ b/engines/collavre/app/controllers/collavre/tasks_controller.rb
@@ -35,11 +35,19 @@ module Collavre
     end
 
     def build_session_key(task)
-      context = task.trigger_event_payload || {}
+      payload = task.trigger_event_payload || {}
+      creative = task.creative || Creative.find_by(id: payload.dig("creative", "id"))
+      comment = Comment.find_by(id: payload.dig("comment", "id"))
+
       CollavreOpenclaw::OpenclawAdapter.new(
         user: task.agent,
         system_prompt: "",
-        context: context
+        context: {
+          creative: creative,
+          user: task.agent,
+          task: task,
+          comment: comment
+        }
       ).session_key
     end
   end

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -79,6 +79,10 @@ export default class extends Controller {
     this.textareaTarget.addEventListener('input', this._autoResize)
 
     this.textareaTarget.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape') {
+        this.presenceController?.cancelAllAgentTasks()
+        return
+      }
       if (event.key === 'Enter' && !event.shiftKey) {
         if (this.isMentionMenuVisible()) return
         this.handleSend(event)

--- a/engines/collavre/app/javascript/controllers/comments/presence_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/presence_controller.js
@@ -338,8 +338,9 @@ export default class extends Controller {
       const stopBtn = document.createElement('button')
       stopBtn.type = 'button'
       stopBtn.className = 'agent-stop-btn'
-      stopBtn.textContent = '\u25A0'
-      stopBtn.title = this.typingIndicatorTarget.dataset.stopAgentText || 'Stop'
+      const stopLabel = this.typingIndicatorTarget.dataset.stopAgentText || 'Stop'
+      stopBtn.innerHTML = `<span class="agent-stop-icon">\u25A0</span> ${stopLabel}`
+      stopBtn.title = stopLabel
       stopBtn.addEventListener('click', () => {
         ids.forEach((id) => {
           const taskId = this.activeAgentTasks?.[id]

--- a/engines/collavre/app/javascript/controllers/comments/presence_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/presence_controller.js
@@ -330,6 +330,24 @@ export default class extends Controller {
     }
 
     this.typingIndicatorTarget.style.opacity = '1'
+
+    // Add stop button first (before avatars/names) for active agent tasks
+    const hasActiveTask = ids.some((id) => this.activeAgentTasks?.[id])
+    if (hasActiveTask) {
+      const stopBtn = document.createElement('button')
+      stopBtn.type = 'button'
+      stopBtn.className = 'agent-stop-btn'
+      stopBtn.textContent = '\u25A0'
+      stopBtn.title = this.typingIndicatorTarget.dataset.stopAgentText || 'Stop'
+      stopBtn.addEventListener('click', () => {
+        ids.forEach((id) => {
+          const taskId = this.activeAgentTasks?.[id]
+          if (taskId) this.cancelAgentTask(taskId, id)
+        })
+      })
+      this.typingIndicatorTarget.appendChild(stopBtn)
+    }
+
     if (this.participantsData) {
       ids.forEach((id) => {
         const user = this.participantsData.find((participant) => participant.id === parseInt(id, 10))
@@ -358,20 +376,16 @@ export default class extends Controller {
     const text = document.createElement('span')
     text.textContent = `${names.join(', ')} ...`
     this.typingIndicatorTarget.appendChild(text)
+  }
 
-    // Add stop button for active agent tasks
+  cancelAllAgentTasks() {
+    const ids = Object.keys(this.activeAgentTasks || {})
+    if (ids.length === 0) return false
     ids.forEach((id) => {
-      const taskId = this.activeAgentTasks?.[id]
-      if (taskId) {
-        const stopBtn = document.createElement('button')
-        stopBtn.type = 'button'
-        stopBtn.className = 'agent-stop-btn'
-        stopBtn.textContent = '\u25A0'
-        stopBtn.title = this.typingIndicatorTarget.dataset.stopAgentText || 'Stop'
-        stopBtn.addEventListener('click', () => this.cancelAgentTask(taskId, id))
-        this.typingIndicatorTarget.appendChild(stopBtn)
-      }
+      const taskId = this.activeAgentTasks[id]
+      if (taskId) this.cancelAgentTask(taskId, id)
     })
+    return true
   }
 
   cancelAgentTask(taskId, agentId) {

--- a/engines/collavre/app/javascript/controllers/comments/presence_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/presence_controller.js
@@ -62,6 +62,7 @@ export default class extends Controller {
     this.participantsData = null
     this.currentPresentIds = []
     this.typingUsers = {}
+    this.activeAgentTasks = {}
     this.clearTypingTimers()
     this.clearManualTypingMessage()
     this.renderParticipants([])
@@ -199,23 +200,27 @@ export default class extends Controller {
       return
     }
     if (data.agent_status) {
-      const { id, name, status, creative_id: agentCreativeId } = data.agent_status
+      const { id, name, status, task_id, creative_id: agentCreativeId } = data.agent_status
       // Only show typing indicator if agent is working on this specific creative
       if (agentCreativeId && agentCreativeId !== this.creativeId) {
         return
       }
       if (status === 'thinking' || status === 'streaming') {
         this.typingUsers[id] = name
+        if (!this.activeAgentTasks) this.activeAgentTasks = {}
+        if (task_id) this.activeAgentTasks[id] = task_id
         // Safety timeout: auto-remove if no heartbeat within AGENT_STATUS_TIMEOUT
         if (!this.agentStatusTimers) this.agentStatusTimers = {}
         if (this.agentStatusTimers[id]) clearTimeout(this.agentStatusTimers[id])
         this.agentStatusTimers[id] = setTimeout(() => {
           delete this.typingUsers[id]
           delete this.agentStatusTimers[id]
+          delete this.activeAgentTasks?.[id]
           this.renderTypingIndicator()
         }, AGENT_STATUS_TIMEOUT)
       } else {
         delete this.typingUsers[id]
+        delete this.activeAgentTasks?.[id]
         if (this.agentStatusTimers?.[id]) {
           clearTimeout(this.agentStatusTimers[id])
           delete this.agentStatusTimers[id]
@@ -353,6 +358,43 @@ export default class extends Controller {
     const text = document.createElement('span')
     text.textContent = `${names.join(', ')} ...`
     this.typingIndicatorTarget.appendChild(text)
+
+    // Add stop button for active agent tasks
+    ids.forEach((id) => {
+      const taskId = this.activeAgentTasks?.[id]
+      if (taskId) {
+        const stopBtn = document.createElement('button')
+        stopBtn.type = 'button'
+        stopBtn.className = 'agent-stop-btn'
+        stopBtn.textContent = '\u25A0'
+        stopBtn.title = this.typingIndicatorTarget.dataset.stopAgentText || 'Stop'
+        stopBtn.addEventListener('click', () => this.cancelAgentTask(taskId, id))
+        this.typingIndicatorTarget.appendChild(stopBtn)
+      }
+    })
+  }
+
+  cancelAgentTask(taskId, agentId) {
+    const csrfToken = document.querySelector('meta[name=csrf-token]')?.content
+    fetch(`/tasks/${taskId}/cancel`, {
+      method: 'POST',
+      headers: {
+        'X-CSRF-Token': csrfToken,
+        'Content-Type': 'application/json',
+      },
+    })
+      .then((response) => {
+        if (response.ok) {
+          delete this.typingUsers[agentId]
+          delete this.activeAgentTasks?.[agentId]
+          if (this.agentStatusTimers?.[agentId]) {
+            clearTimeout(this.agentStatusTimers[agentId])
+            delete this.agentStatusTimers[agentId]
+          }
+          this.renderTypingIndicator()
+        }
+      })
+      .catch(() => {})
   }
 
   clearTypingTimers() {

--- a/engines/collavre/app/javascript/controllers/comments/presence_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/presence_controller.js
@@ -1,6 +1,7 @@
 import { Controller } from '@hotwired/stimulus'
 import { createSubscription } from '../../services/cable'
 import TouchDragHandler from '../../lib/touch_drag'
+import csrfFetch from '../../lib/api/csrf_fetch'
 
 const TYPING_TIMEOUT = 3000
 const AGENT_STATUS_TIMEOUT = 10000 // Safety timeout for agent_status (heartbeat expected every 3s)
@@ -202,7 +203,7 @@ export default class extends Controller {
     if (data.agent_status) {
       const { id, name, status, task_id, creative_id: agentCreativeId } = data.agent_status
       // Only show typing indicator if agent is working on this specific creative
-      if (agentCreativeId && agentCreativeId !== this.creativeId) {
+      if (agentCreativeId && String(agentCreativeId) !== String(this.creativeId)) {
         return
       }
       if (status === 'thinking' || status === 'streaming') {
@@ -389,13 +390,9 @@ export default class extends Controller {
   }
 
   cancelAgentTask(taskId, agentId) {
-    const csrfToken = document.querySelector('meta[name=csrf-token]')?.content
-    fetch(`/tasks/${taskId}/cancel`, {
+    csrfFetch(`/tasks/${taskId}/cancel`, {
       method: 'POST',
-      headers: {
-        'X-CSRF-Token': csrfToken,
-        'Content-Type': 'application/json',
-      },
+      headers: { 'Content-Type': 'application/json' },
     })
       .then((response) => {
         if (response.ok) {
@@ -408,7 +405,7 @@ export default class extends Controller {
           this.renderTypingIndicator()
         }
       })
-      .catch(() => {})
+      .catch((err) => console.warn('[presence] cancel agent task failed:', err))
   }
 
   clearTypingTimers() {

--- a/engines/collavre/app/services/collavre/ai_agent_service.rb
+++ b/engines/collavre/app/services/collavre/ai_agent_service.rb
@@ -70,6 +70,7 @@ module Collavre
       raise
     rescue CancelledError
       handle_cancelled
+      abort_openclaw_if_needed
       raise
     end
 
@@ -232,6 +233,26 @@ module Collavre
 
     def build_policy_resolver
       Orchestration::PolicyResolver.new(@context)
+    end
+
+    def abort_openclaw_if_needed
+      return unless @agent.llm_vendor&.downcase == "openclaw"
+      return unless defined?(CollavreOpenclaw::ConnectionManager)
+
+      adapter = CollavreOpenclaw::OpenclawAdapter.new(
+        user: @agent,
+        system_prompt: "",
+        context: {
+          creative: @creative,
+          user: @agent,
+          task: @task,
+          comment: @reply_comment || @original_comment
+        }
+      )
+      conn = CollavreOpenclaw::ConnectionManager.instance.connection_for(@agent)
+      conn.chat_abort(session_key: adapter.session_key)
+    rescue StandardError => e
+      Rails.logger.warn("[AiAgentService] OpenClaw abort fallback failed: #{e.message}")
     end
   end
 end

--- a/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
@@ -114,7 +114,7 @@
   <%= render Collavre::UserMentionMenuComponent.new(menu_id: 'mention-menu') %>
   <%= render Collavre::CommandMenuComponent.new(menu_id: 'command-menu') %>
   <div id="comments-list" data-comments--popup-target="list" data-comments--list-target="list"><%= t('app.loading') %></div>
-  <div id="typing-indicator" data-comments--presence-target="typingIndicator" data-comments--popup-target="typingIndicator"></div>
+  <div id="typing-indicator" data-comments--presence-target="typingIndicator" data-comments--popup-target="typingIndicator" data-stop-agent-text="<%= t('collavre.comments.stop_agent') %>"></div>
   <form id="new-comment-form" data-comments--popup-target="form" data-comments--form-target="form" style="display:none;">
     <input type="hidden" name="comment[quoted_comment_id]" data-comments--form-target="quotedCommentId" value="" />
     <input type="hidden" name="comment[quoted_text]" data-comments--form-target="quotedText" value="" />

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -176,6 +176,7 @@ en:
         delete: Delete this version
         delete_confirm: Are you sure you want to delete this version?
         select: Select
+      stop_agent: Stop
       read_by: Read by %{name}
       activity_logs_summary: Activity Logs
       lightbox:

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -173,6 +173,7 @@ ko:
         delete: 이 버전 삭제
         delete_confirm: 이 버전을 삭제하시겠습니까?
         select: 선택
+      stop_agent: 중지
       read_by: "%{name} 님이 읽음"
       activity_logs_summary: 활동 기록
       lightbox:

--- a/engines/collavre/config/routes.rb
+++ b/engines/collavre/config/routes.rb
@@ -44,6 +44,11 @@ Collavre::Engine.routes.draw do
   end
 
   resources :creative_imports, only: [ :create ]
+  resources :tasks, only: [] do
+    member do
+      post :cancel
+    end
+  end
   resources :creatives do
     resources :creative_shares, only: [ :index, :create, :update, :destroy ]
     resources :invitations, only: [ :update, :destroy ], controller: "creative_invitations"

--- a/engines/collavre/test/controllers/tasks_controller_test.rb
+++ b/engines/collavre/test/controllers/tasks_controller_test.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TasksControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:one)
+    @creative = Collavre::Creative.create!(user: @user, description: "Test Creative")
+    @agent = User.create!(
+      email: "cancel_task_agent@example.com",
+      name: "Cancel Agent",
+      password: "password",
+      llm_vendor: "google",
+      llm_model: "gemini-2.0-flash",
+      routing_expression: "true",
+      searchable: true
+    )
+    @task = Collavre::Task.create!(
+      name: "Response to comment_created",
+      status: "running",
+      trigger_event_name: "comment_created",
+      trigger_event_payload: {
+        "comment" => { "id" => 1, "content" => "Hello" },
+        "creative" => { "id" => @creative.id }
+      },
+      agent: @agent
+    )
+  end
+
+  test "cancel sets task status to cancelled" do
+    sign_in_as(@user, password: "password")
+    post cancel_task_path(@task)
+    assert_response :ok
+    assert_equal "cancelled", @task.reload.status
+  end
+
+  test "cancel returns forbidden for user without permission" do
+    other_user = User.create!(
+      email: "no_perm_cancel@example.com",
+      name: "No Perm",
+      password: "password"
+    )
+    sign_in_as(other_user, password: "password")
+
+    post cancel_task_path(@task)
+    assert_response :forbidden
+    assert_equal "running", @task.reload.status
+  end
+
+  test "cancel returns unprocessable_entity for done task" do
+    sign_in_as(@user, password: "password")
+    @task.update!(status: "done")
+
+    post cancel_task_path(@task)
+    assert_response :unprocessable_entity
+    assert_equal "done", @task.reload.status
+  end
+
+  test "cancel works for pending task" do
+    sign_in_as(@user, password: "password")
+    @task.update!(status: "pending")
+
+    post cancel_task_path(@task)
+    assert_response :ok
+    assert_equal "cancelled", @task.reload.status
+  end
+
+  test "cancel works for queued task" do
+    sign_in_as(@user, password: "password")
+    @task.update!(status: "queued")
+
+    post cancel_task_path(@task)
+    assert_response :ok
+    assert_equal "cancelled", @task.reload.status
+  end
+
+  test "cancel returns unprocessable_entity for already cancelled task" do
+    sign_in_as(@user, password: "password")
+    @task.update!(status: "cancelled")
+
+    post cancel_task_path(@task)
+    assert_response :unprocessable_entity
+  end
+end


### PR DESCRIPTION
## Summary
- Add a stop button (■) in the typing indicator when an AI agent is responding to a chat message
- Clicking stop cancels the running task via `POST /tasks/:id/cancel`
- RubyLLM path: existing `check_cancelled!` polling (≤1s) raises `CancelledError` → TCP close → provider stops generation
- OpenClaw path: explicit `chat.abort` RPC sent to Gateway for immediate upstream cancellation (both in TasksController and as fallback in AiAgentService)
- Permission check ensures only creative participants with feedback permission can cancel

## Changes
- **New:** `TasksController#cancel` — cancels task + sends OpenClaw abort RPC
- **New:** Route `POST /tasks/:id/cancel`
- **Modified:** `presence_controller.js` — tracks `task_id` from agent_status broadcast, renders stop button, sends cancel request
- **Modified:** `ai_agent_service.rb` — `abort_openclaw_if_needed` fallback on CancelledError
- **Modified:** `_comments_popup.html.erb` — data attribute for i18n stop text
- **New:** CSS for `.agent-stop-btn`
- **New:** i18n keys (en/ko)
- **New:** Controller tests (6 tests)

## Test plan
- [x] Rubocop passes (786 files, no offenses)
- [x] All tests pass (pre-push hook)
- [x] TasksController tests: cancel running/pending/queued tasks, forbidden for unauthorized users, unprocessable for done/cancelled tasks
- [ ] Manual: verify stop button appears when agent is typing
- [ ] Manual: verify clicking stop cancels agent response and preserves partial content
- [ ] Manual: verify OpenClaw abort RPC is sent (check Gateway logs)