### PR TITLE
Add dark mode support for syntax highlighting in code blocks

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/actiontext.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/actiontext.css
@@ -279,15 +279,51 @@
 }
 
 /* stylelint-disable color-no-hex -- syntax highlight theme colors are intentionally hardcoded */
+:root {
+  --lexical-token-comment: #6a737d;
+  --lexical-token-punctuation: #393a34;
+  --lexical-token-property: #b31d28;
+  --lexical-token-string: #1a7f37;
+  --lexical-token-operator: #9a6e3a;
+  --lexical-token-keyword: #0550ae;
+  --lexical-token-function: #bc4c00;
+  --lexical-token-regex: #1a7f37;
+}
+
+body.dark-mode {
+  --lexical-token-comment: #8b949e;
+  --lexical-token-punctuation: #c9d1d9;
+  --lexical-token-property: #ff7b72;
+  --lexical-token-string: #7ee787;
+  --lexical-token-operator: #ffa657;
+  --lexical-token-keyword: #79c0ff;
+  --lexical-token-function: #d2a8ff;
+  --lexical-token-regex: #7ee787;
+}
+
+@media (prefers-color-scheme: dark) {
+  body:not(.light-mode):not(.dark-mode) {
+    --lexical-token-comment: #8b949e;
+    --lexical-token-punctuation: #c9d1d9;
+    --lexical-token-property: #ff7b72;
+    --lexical-token-string: #7ee787;
+    --lexical-token-operator: #ffa657;
+    --lexical-token-keyword: #79c0ff;
+    --lexical-token-function: #d2a8ff;
+    --lexical-token-regex: #7ee787;
+  }
+}
+/* stylelint-enable color-no-hex */
+
 .lexical-token-comment,
 .lexical-token-prolog,
 .lexical-token-doctype,
 .lexical-token-cdata {
-  color: #6a737d;
+  color: var(--lexical-token-comment);
 }
 
 .lexical-token-punctuation {
-  color: #393a34;
+  color: var(--lexical-token-punctuation);
 }
 
 .lexical-token-property,
@@ -297,7 +333,7 @@
 .lexical-token-deleted,
 .lexical-token-boolean,
 .lexical-token-number {
-  color: #b31d28;
+  color: var(--lexical-token-property);
 }
 
 .lexical-token-selector,
@@ -306,14 +342,14 @@
 .lexical-token-char,
 .lexical-token-builtin,
 .lexical-token-inserted {
-  color: #1a7f37;
+  color: var(--lexical-token-string);
 }
 
 .lexical-token-operator,
 .lexical-token-entity,
 .lexical-token-url,
 .lexical-token-variable {
-  color: #9a6e3a;
+  color: var(--lexical-token-operator);
 }
 
 .lexical-token-atrule,
@@ -321,16 +357,16 @@
 .lexical-token-class,
 .lexical-token-classname,
 .lexical-token-namespace {
-  color: #0550ae;
+  color: var(--lexical-token-keyword);
 }
 
 .lexical-token-function,
 .lexical-token-important {
-  color: #bc4c00;
+  color: var(--lexical-token-function);
 }
 
 .lexical-token-regex {
-  color: #1a7f37;
+  color: var(--lexical-token-regex);
 }
 
 .lexical-token-tag,
@@ -338,7 +374,6 @@
 .lexical-token-keyword {
   font-weight: var(--weight-6);
 }
-/* stylelint-enable color-no-hex */
 
 .lexical-attachment {
   position: relative;

--- a/engines/collavre/app/assets/stylesheets/collavre/code_highlight.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/code_highlight.css
@@ -189,6 +189,10 @@ body.dark-mode {
   color: var(--syntax-meta);
 }
 
+.comment-content .hljs-punctuation {
+  color: var(--color-code-text);
+}
+
 .comment-content .hljs-deletion {
   color: var(--syntax-deletion-text);
   background: var(--syntax-deletion-bg);


### PR DESCRIPTION
## Summary
This PR adds comprehensive dark mode support for syntax highlighting in code blocks by introducing CSS custom properties (variables) for lexical token colors and implementing theme-aware color schemes.

## Key Changes
- **Lexical token color variables**: Defined 8 CSS custom properties (`--lexical-token-*`) for syntax highlighting colors in the `:root` selector
- **Dark mode theme**: Added explicit dark mode color palette under `body.dark-mode` selector
- **System preference support**: Implemented `prefers-color-scheme: dark` media query to automatically apply dark colors when system dark mode is enabled (for bodies without explicit light/dark mode classes)
- **Variable migration**: Replaced all hardcoded hex color values in `.lexical-token-*` classes with corresponding CSS variables
- **Code highlight refinement**: Added punctuation color styling in `.comment-content .hljs-punctuation` to use the standard code text color variable

## Implementation Details
- Light mode uses GitHub-inspired syntax colors (e.g., `#6a737d` for comments, `#0550ae` for keywords)
- Dark mode uses complementary GitHub dark theme colors (e.g., `#8b949e` for comments, `#79c0ff` for keywords)
- The media query approach ensures dark mode colors are applied by default on dark system preferences while respecting explicit light/dark mode class overrides
- All color definitions are now centralized in CSS variables, making future theme adjustments easier

https://claude.ai/code/session_01Jd124kMwu3rWxkTuWMKtHx