### PR TITLE
fix: skip textarea auto-focus on mobile to prevent keyboard push-up

### DIFF
--- a/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_review.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_review.test.js
@@ -93,7 +93,7 @@ describe('FormController - Review Quote Chips', () => {
       const resetFormSpy = jest.spyOn(controller, 'resetForm').mockImplementation(() => {})
       const focusSpy = jest.spyOn(controller.textareaTarget, 'focus').mockImplementation(() => {})
       const originalInnerWidth = window.innerWidth
-      Object.defineProperty(window, 'innerWidth', { value: 500, configurable: true })
+      Object.defineProperty(window, 'innerWidth', { value: 760, configurable: true })
 
       controller.onPopupOpened({ creativeId: '123', canComment: true })
 

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_review.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_review.test.js
@@ -87,6 +87,21 @@ describe('FormController - Review Quote Chips', () => {
       focusSpy.mockRestore()
       resetFormSpy.mockRestore()
     })
+
+    test('skips initial focus on mobile even when autoFocusOnOpen is true', () => {
+      container.querySelector('#comments-popup').dataset.autoFocusOnOpen = 'true'
+      const resetFormSpy = jest.spyOn(controller, 'resetForm').mockImplementation(() => {})
+      const focusSpy = jest.spyOn(controller.textareaTarget, 'focus').mockImplementation(() => {})
+      const originalInnerWidth = window.innerWidth
+      Object.defineProperty(window, 'innerWidth', { value: 500, configurable: true })
+
+      controller.onPopupOpened({ creativeId: '123', canComment: true })
+
+      expect(focusSpy).not.toHaveBeenCalled()
+      Object.defineProperty(window, 'innerWidth', { value: originalInnerWidth, configurable: true })
+      focusSpy.mockRestore()
+      resetFormSpy.mockRestore()
+    })
   })
 
   describe('appendReviewQuote', () => {

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -163,7 +163,7 @@ export default class extends Controller {
   }
 
   shouldAutoFocusOnOpen() {
-    if (window.innerWidth <= 600) return false
+    if (window.innerWidth <= 768) return false
     return this.element.dataset.autoFocusOnOpen !== 'false'
   }
 

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -163,6 +163,7 @@ export default class extends Controller {
   }
 
   shouldAutoFocusOnOpen() {
+    if (window.innerWidth <= 600) return false
     return this.element.dataset.autoFocusOnOpen !== 'false'
   }
 

--- a/engines/collavre/app/views/collavre/shared/navigation/_inbox_button.html.erb
+++ b/engines/collavre/app/views/collavre/shared/navigation/_inbox_button.html.erb
@@ -5,7 +5,6 @@
           type="button"
           data-creative-id="<%= inbox.id %>"
           data-can-comment="true"
-          data-auto-focus-on-open="false"
           data-creative-snippet="<%= inbox.creative_snippet %>"
           name="show-comments-btn"><%= t('app.inbox') %><%= render Collavre::Inbox::BadgeComponent.new(
             creative: inbox,

--- a/engines/collavre/app/views/collavre/shared/navigation/_mobile_inbox_button.html.erb
+++ b/engines/collavre/app/views/collavre/shared/navigation/_mobile_inbox_button.html.erb
@@ -4,7 +4,6 @@
           type="button"
           data-creative-id="<%= inbox.id %>"
           data-can-comment="true"
-          data-auto-focus-on-open="false"
           data-creative-snippet="<%= inbox.creative_snippet %>"
           name="show-comments-btn"><%= t('app.inbox') %><%= render Collavre::Inbox::BadgeComponent.new(
             creative: inbox,


### PR DESCRIPTION
On mobile, the soft keyboard appearing on focus pushes the chat popup
up, degrading UX when users just want to read messages. Now
shouldAutoFocusOnOpen() checks viewport width and skips focus on
mobile (<=600px). Removed per-button data-auto-focus-on-open="false"
from inbox buttons so PC always auto-focuses including inbox.

https://claude.ai/code/session_01HJj74nVPAjkQrsUgQReFoa