### PR TITLE
fix: guard PlansTimelineComponent alias with CollavrePlan engine check

### DIFF
--- a/config/initializers/collavre_model_aliases.rb
+++ b/config/initializers/collavre_model_aliases.rb
@@ -45,7 +45,9 @@ Rails.application.config.to_prepare do
   set_alias(Object, :AvatarComponent, Collavre::AvatarComponent)
   set_alias(Object, :AutocompletePopupComponent, Collavre::AutocompletePopupComponent)
   set_alias(Object, :CommandMenuComponent, Collavre::CommandMenuComponent)
-  set_alias(Object, :PlansTimelineComponent, Collavre::PlansTimelineComponent)
+  if defined?(CollavrePlan)
+    set_alias(Object, :PlansTimelineComponent, Collavre::PlansTimelineComponent)
+  end
   set_alias(Object, :PopupMenuComponent, Collavre::PopupMenuComponent)
   set_alias(Object, :ProgressFilterComponent, Collavre::ProgressFilterComponent)
   set_alias(Object, :UserMentionMenuComponent, Collavre::UserMentionMenuComponent)


### PR DESCRIPTION
## Summary
- Wraps `PlansTimelineComponent` alias registration in `if defined?(CollavrePlan)` guard
- Fixes `NameError: uninitialized constant Collavre::PlansTimelineComponent` when running `rails db:migrate` without the `collavre_plan` engine loaded
- Follows existing pattern already used for `CollavreGithub` aliases (lines 137-140)

## Test plan
- [x] Rubocop passed (786 files, 0 offenses)
- [x] All 1603 tests passed (0 failures, 0 errors)