### PR TITLE
chore: daily code cleanup — fix N+1, extract concerns, remove dead code

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -56,10 +56,13 @@ module ApplicationHelper
     end
   end
 
+  EMBED_ALLOWED_TAGS = %w[iframe a p div span br strong em b i u ul ol li h1 h2 h3 h4 h5 h6 blockquote code pre img hr table thead tbody tr th td figure figcaption action-text-attachment].freeze
+  EMBED_ALLOWED_ATTRS = %w[src title frameborder allow allowfullscreen style href class alt width height target rel sgid content-type filename].freeze
+
   def embed_youtube_iframe(html)
     return html if html.blank?
     html = html.to_s
-    html.gsub(%r{<a[^>]+href=["']https?://(?:www\.)?(?:youtube\.com/watch\?v=|youtu\.be/)([\w-]{11})[^"']*["'][^>]*>.*?</a>}i) do
+    result = html.gsub(%r{<a[^>]+href=["']https?://(?:www\.)?(?:youtube\.com/watch\?v=|youtu\.be/)([\w-]{11})[^"']*["'][^>]*>.*?</a>}i) do
       video_id = Regexp.last_match(1)
       tag.iframe(
         "",
@@ -70,7 +73,8 @@ module ApplicationHelper
         allowfullscreen: true,
         style: "width: min(60vw, calc(var(--max-width) - 60px)); aspect-ratio: 16 / 9;"
       )
-    end.html_safe
+    end
+    sanitize(result, tags: EMBED_ALLOWED_TAGS, attributes: EMBED_ALLOWED_ATTRS)
   end
 
   def creative_title_for_display(creative, length: 12)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -56,12 +56,6 @@ module ApplicationHelper
     end
   end
 
-  def linkify_urls(text)
-    ERB::Util.html_escape(text.to_s).gsub(%r{https?://[^\s]+}) do |url|
-      link_to(url, url, target: "_blank", rel: "noopener")
-    end.html_safe
-  end
-
   def embed_youtube_iframe(html)
     return html if html.blank?
     html = html.to_s
@@ -88,17 +82,11 @@ module ApplicationHelper
   end
 
   def render_contact_creatives(creatives)
-    return "".html_safe if creatives.blank?
+    return safe_join([]) if creatives.blank?
 
     safe_join(creatives.map do |creative|
       link_to(creative_title_for_display(creative), collavre.creative_path(creative), class: "creative-chip")
     end)
   end
 
-  def render_last_login_for(user, last_login_map)
-    timestamp = last_login_map[user.id]
-    return t("users.table.last_login_unknown") unless timestamp
-
-    I18n.l(timestamp, format: :short)
-  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -57,7 +57,7 @@ module ApplicationHelper
   end
 
   EMBED_ALLOWED_TAGS = %w[iframe a p div span br strong em b i u ul ol li h1 h2 h3 h4 h5 h6 blockquote code pre img hr table thead tbody tr th td figure figcaption action-text-attachment].freeze
-  EMBED_ALLOWED_ATTRS = %w[src title frameborder allow allowfullscreen style href class alt width height target rel sgid content-type filename].freeze
+  EMBED_ALLOWED_ATTRS = %w[src title frameborder allow allowfullscreen style href class alt width height target rel sgid content-type filename colspan rowspan].freeze
 
   def embed_youtube_iframe(html)
     return html if html.blank?

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -88,5 +88,4 @@ module ApplicationHelper
       link_to(creative_title_for_display(creative), collavre.creative_path(creative), class: "creative-chip")
     end)
   end
-
 end

--- a/engines/collavre/app/controllers/collavre/comments/reactions_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comments/reactions_controller.rb
@@ -1,6 +1,8 @@
 module Collavre
   module Comments
     class ReactionsController < ApplicationController
+      include Collavre::Comments::CommentScoping
+
       before_action :set_creative
       before_action :set_comment
       before_action :authorize_feedback!
@@ -46,22 +48,6 @@ module Collavre
 
       def broadcast_reaction_update
         CommentReaction.broadcast_reaction_update(@comment)
-      end
-
-      def set_creative
-        @creative = Creative.find(params[:creative_id]).effective_origin
-      end
-
-      def set_comment
-        comment_id = params[:comment_id] || params[:id]
-        @comment = @creative.comments
-                           .where(
-                             "comments.private = ? OR comments.user_id = ? OR comments.approver_id = ?",
-                             false,
-                             Current.user.id,
-                             Current.user.id
-                           )
-                           .find(comment_id)
       end
 
       def authorize_feedback!

--- a/engines/collavre/app/controllers/collavre/comments/versions_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comments/versions_controller.rb
@@ -3,6 +3,8 @@
 module Collavre
   module Comments
     class VersionsController < ApplicationController
+      include Collavre::Comments::CommentScoping
+
       before_action :set_creative
       before_action :set_comment
 
@@ -62,21 +64,6 @@ module Collavre
       end
 
       private
-
-      def set_creative
-        @creative = Creative.find(params[:creative_id]).effective_origin
-      end
-
-      def set_comment
-        @comment = @creative.comments
-                             .where(
-                               "comments.private = ? OR comments.user_id = ? OR comments.approver_id = ?",
-                               false,
-                               Current.user.id,
-                               Current.user.id
-                             )
-                             .find(params[:comment_id])
-      end
     end
   end
 end

--- a/engines/collavre/app/controllers/collavre/comments_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comments_controller.rb
@@ -26,12 +26,7 @@ module Collavre
     def index
       limit = 20
 
-      visible_scope = @creative.comments.where(
-        "comments.private = ? OR comments.user_id = ? OR comments.approver_id = ?",
-        false,
-        Current.user.id,
-        Current.user.id
-      )
+      visible_scope = @creative.comments.visible_to(Current.user)
       scope = visible_scope.with_attached_images.includes(:topic, :comment_reactions, :comment_versions, :snapshot_as_result)
 
       if params[:search].present?
@@ -354,14 +349,7 @@ module Collavre
     end
 
     def set_comment
-      @comment = @creative.comments
-                             .where(
-                               "comments.private = ? OR comments.user_id = ? OR comments.approver_id = ?",
-                               false,
-                               Current.user.id,
-                               Current.user.id
-                             )
-                             .find(params[:id])
+      @comment = @creative.comments.visible_to(Current.user).find(params[:id])
     end
 
     def comment_params

--- a/engines/collavre/app/controllers/collavre/comments_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comments_controller.rb
@@ -1,5 +1,6 @@
 module Collavre
   class CommentsController < ApplicationController
+    include Collavre::Comments::CommentScoping
     include Collavre::Comments::ApprovalActions
     include Collavre::Comments::Conversion
     include Collavre::Comments::BatchOperations
@@ -346,10 +347,6 @@ module Collavre
       unless @creative.has_permission?(Current.user, :read)
         render json: { error: I18n.t("collavre.creatives.errors.no_permission") }, status: :forbidden
       end
-    end
-
-    def set_comment
-      @comment = @creative.comments.visible_to(Current.user).find(params[:id])
     end
 
     def comment_params

--- a/engines/collavre/app/controllers/concerns/collavre/comments/comment_scoping.rb
+++ b/engines/collavre/app/controllers/concerns/collavre/comments/comment_scoping.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Comments
+    module CommentScoping
+      extend ActiveSupport::Concern
+
+      private
+
+      def set_creative
+        @creative = Creative.find(params[:creative_id]).effective_origin
+      end
+
+      def set_comment
+        comment_id = params[:comment_id] || params[:id]
+        @comment = @creative.comments.visible_to(Current.user).find(comment_id)
+      end
+    end
+  end
+end

--- a/engines/collavre/app/controllers/concerns/collavre/integration_permission.rb
+++ b/engines/collavre/app/controllers/concerns/collavre/integration_permission.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Collavre
+  module IntegrationPermission
+    extend ActiveSupport::Concern
+
+    private
+
+    def ensure_read_permission
+      return if @creative.has_permission?(Current.user, :read)
+
+      render json: { error: integration_forbidden_message }, status: :forbidden
+    end
+
+    def ensure_admin_permission
+      return if @creative.has_permission?(Current.user, :admin)
+
+      render json: { error: integration_forbidden_message }, status: :forbidden
+    end
+
+    def ensure_write_permission
+      return if @creative.has_permission?(Current.user, :write)
+
+      render json: { error: integration_forbidden_message }, status: :forbidden
+    end
+
+    def integration_forbidden_message
+      "forbidden"
+    end
+  end
+end

--- a/engines/collavre/app/helpers/collavre/application_helper.rb
+++ b/engines/collavre/app/helpers/collavre/application_helper.rb
@@ -111,7 +111,7 @@ module Collavre
     #
     def render_extension_slot(slot, **locals)
       entries = Collavre::ViewExtensions.for_slot(slot)
-      return "".html_safe if entries.empty? # rubocop:disable Rails/OutputSafety
+      return safe_join([]) if entries.empty?
 
       safe_join(entries.map { |entry| render(partial: entry[:partial], locals: locals) })
     end

--- a/engines/collavre/app/helpers/collavre/application_helper.rb
+++ b/engines/collavre/app/helpers/collavre/application_helper.rb
@@ -78,8 +78,7 @@ module Collavre
         styles << render_theme_media_query(dark_theme, "dark")
       end
 
-      # Safe: CSS generated from admin-configured theme settings (CSS variables only)
-      styles.join("\n").html_safe # rubocop:disable Rails/OutputSafety
+      safe_join(styles, "\n")
     end
 
     private

--- a/engines/collavre/app/helpers/collavre/creatives_helper.rb
+++ b/engines/collavre/app/helpers/collavre/creatives_helper.rb
@@ -118,7 +118,7 @@ module Collavre
       if value == 1 && !completion_mark.nil?
         text = completion_mark
       end
-      display_text = text.blank? ? "&nbsp;&nbsp;".html_safe : text
+      display_text = text.blank? ? "\u00A0\u00A0" : text
       content_tag(
         :span,
         display_text,

--- a/engines/collavre/app/models/collavre/comment.rb
+++ b/engines/collavre/app/models/collavre/comment.rb
@@ -16,6 +16,13 @@ module Collavre
     belongs_to :topic, class_name: "Collavre::Topic", optional: true
     belongs_to :quoted_comment, class_name: "Collavre::Comment", optional: true
 
+    scope :visible_to, ->(user) {
+      where(
+        "comments.private = ? OR comments.user_id = ? OR comments.approver_id = ?",
+        false, user.id, user.id
+      )
+    }
+
     # review_type: nil = normal chat, 0 = review, 1 = question
     enum :review_type, { review: 0, question: 1 }, prefix: true
 

--- a/engines/collavre/app/services/collavre/orchestration/agent_context_builder.rb
+++ b/engines/collavre/app/services/collavre/orchestration/agent_context_builder.rb
@@ -168,8 +168,11 @@ module Collavre
 
         agent_permissions = {}
 
-        creatives_to_check.each do |creative|
-          creative.creative_shares.includes(:user).each do |share|
+        # Single query for all shares across the entire ancestor chain (fixes N+1)
+        CreativeShare
+          .where(creative_id: creatives_to_check.map(&:id))
+          .includes(:user)
+          .each do |share|
             user = share.user
             next unless user&.ai_user?
             next if share.permission == "no_access"
@@ -180,7 +183,6 @@ module Collavre
               agent_permissions[user] = share.permission
             end
           end
-        end
 
         agent_permissions.to_a
       end

--- a/engines/collavre_github/app/controllers/collavre_github/creatives/integrations_controller.rb
+++ b/engines/collavre_github/app/controllers/collavre_github/creatives/integrations_controller.rb
@@ -1,6 +1,8 @@
 module CollavreGithub
   module Creatives
     class IntegrationsController < ApplicationController
+      include Collavre::IntegrationPermission
+
       before_action :set_creative
       before_action :set_origin
       before_action :ensure_read_permission
@@ -71,7 +73,7 @@ module CollavreGithub
 
       def destroy
         unless @creative.has_permission?(Current.user, :write)
-          render json: { error: I18n.t("collavre_github.errors.forbidden") }, status: :forbidden
+          render json: { error: integration_forbidden_message }, status: :forbidden
           return
         end
 
@@ -145,16 +147,8 @@ module CollavreGithub
         @origin = @creative.effective_origin
       end
 
-      def ensure_read_permission
-        return if @creative.has_permission?(Current.user, :read)
-
-        render json: { error: I18n.t("collavre_github.errors.forbidden") }, status: :forbidden
-      end
-
-      def ensure_admin_permission
-        return if @creative.has_permission?(Current.user, :admin)
-
-        render json: { error: I18n.t("collavre_github.errors.forbidden") }, status: :forbidden
+      def integration_forbidden_message
+        I18n.t("collavre_github.errors.forbidden")
       end
 
       def linked_repository_links(account)

--- a/engines/collavre_github/test/services/collavre_github/tools/github_pr_commits_service_test.rb
+++ b/engines/collavre_github/test/services/collavre_github/tools/github_pr_commits_service_test.rb
@@ -5,45 +5,8 @@ require "test_helper"
 module CollavreGithub
   module Tools
     class GithubPrCommitsServiceTest < ActiveSupport::TestCase
-      setup do
-        @user = users(:one)
-        @account = CollavreGithub::Account.create!(
-          user: @user,
-          github_uid: "12345",
-          login: "testuser",
-          name: "Test User",
-          token: "test-token"
-        )
-        @creative = creatives(:tshirt)
-        @link = CollavreGithub::RepositoryLink.create!(
-          creative: @creative,
-          github_account: @account,
-          repository_full_name: "owner/repo"
-        )
-      end
-
-      test "returns error when creative not found" do
-        service = GithubPrCommitsService.new
-        result = service.call(creative_id: 999999, repo: "owner/repo", pr_number: 1)
-
-        assert_equal "GitHub account not found for this creative and repository", result[:error]
-      end
-
-      test "returns error when repository link not found for different repo" do
-        service = GithubPrCommitsService.new
-        result = service.call(creative_id: @creative.id, repo: "other/repo", pr_number: 1)
-
-        assert_equal "GitHub account not found for this creative and repository", result[:error]
-      end
-
-      test "finds github client for valid creative and repo" do
-        service = GithubPrCommitsService.new
-
-        client = service.send(:find_github_client, @creative.id, "owner/repo")
-
-        assert_not_nil client
-        assert_instance_of CollavreGithub::Client, client
-      end
+      SERVICE_CLASS = GithubPrCommitsService
+      include GithubPrServiceTestSetup
     end
   end
 end

--- a/engines/collavre_github/test/services/collavre_github/tools/github_pr_details_service_test.rb
+++ b/engines/collavre_github/test/services/collavre_github/tools/github_pr_details_service_test.rb
@@ -5,49 +5,10 @@ require "test_helper"
 module CollavreGithub
   module Tools
     class GithubPrDetailsServiceTest < ActiveSupport::TestCase
-      setup do
-        @user = users(:one)
-        @account = CollavreGithub::Account.create!(
-          user: @user,
-          github_uid: "12345",
-          login: "testuser",
-          name: "Test User",
-          token: "test-token"
-        )
-        @creative = creatives(:tshirt)
-        @link = CollavreGithub::RepositoryLink.create!(
-          creative: @creative,
-          github_account: @account,
-          repository_full_name: "owner/repo"
-        )
-      end
-
-      test "returns error when creative not found" do
-        service = GithubPrDetailsService.new
-        result = service.call(creative_id: 999999, repo: "owner/repo", pr_number: 1)
-
-        assert_equal "GitHub account not found for this creative and repository", result[:error]
-      end
-
-      test "returns error when repository link not found for different repo" do
-        service = GithubPrDetailsService.new
-        result = service.call(creative_id: @creative.id, repo: "other/repo", pr_number: 1)
-
-        assert_equal "GitHub account not found for this creative and repository", result[:error]
-      end
-
-      test "finds github client for valid creative and repo" do
-        service = GithubPrDetailsService.new
-
-        # Access private method to test client lookup
-        client = service.send(:find_github_client, @creative.id, "owner/repo")
-
-        assert_not_nil client
-        assert_instance_of CollavreGithub::Client, client
-      end
+      SERVICE_CLASS = GithubPrDetailsService
+      include GithubPrServiceTestSetup
 
       test "returns nil client when repository not in creative tree" do
-        # Create unrelated creative without link
         other_creative = Collavre::Creative.create!(
           user: @user,
           description: "Unrelated creative"
@@ -56,7 +17,6 @@ module CollavreGithub
         service = GithubPrDetailsService.new
         client = service.send(:find_github_client, other_creative.id, "owner/repo")
 
-        # Should return nil because other_creative has no link to owner/repo
         assert_nil client
       end
     end

--- a/engines/collavre_github/test/services/collavre_github/tools/github_pr_diff_service_test.rb
+++ b/engines/collavre_github/test/services/collavre_github/tools/github_pr_diff_service_test.rb
@@ -5,45 +5,8 @@ require "test_helper"
 module CollavreGithub
   module Tools
     class GithubPrDiffServiceTest < ActiveSupport::TestCase
-      setup do
-        @user = users(:one)
-        @account = CollavreGithub::Account.create!(
-          user: @user,
-          github_uid: "12345",
-          login: "testuser",
-          name: "Test User",
-          token: "test-token"
-        )
-        @creative = creatives(:tshirt)
-        @link = CollavreGithub::RepositoryLink.create!(
-          creative: @creative,
-          github_account: @account,
-          repository_full_name: "owner/repo"
-        )
-      end
-
-      test "returns error when creative not found" do
-        service = GithubPrDiffService.new
-        result = service.call(creative_id: 999999, repo: "owner/repo", pr_number: 1)
-
-        assert_equal "GitHub account not found for this creative and repository", result[:error]
-      end
-
-      test "returns error when repository link not found for different repo" do
-        service = GithubPrDiffService.new
-        result = service.call(creative_id: @creative.id, repo: "other/repo", pr_number: 1)
-
-        assert_equal "GitHub account not found for this creative and repository", result[:error]
-      end
-
-      test "finds github client for valid creative and repo" do
-        service = GithubPrDiffService.new
-
-        client = service.send(:find_github_client, @creative.id, "owner/repo")
-
-        assert_not_nil client
-        assert_instance_of CollavreGithub::Client, client
-      end
+      SERVICE_CLASS = GithubPrDiffService
+      include GithubPrServiceTestSetup
 
       test "has default max length constant" do
         assert_equal 10_000, GithubPrDiffService::DIFF_MAX_LENGTH

--- a/engines/collavre_github/test/test_helper.rb
+++ b/engines/collavre_github/test/test_helper.rb
@@ -88,6 +88,51 @@ module CollavreGithubTestHelpers
   end
 end
 
+module GithubPrServiceTestSetup
+  extend ActiveSupport::Concern
+
+  included do
+    setup do
+      @user = users(:one)
+      @account = CollavreGithub::Account.create!(
+        user: @user,
+        github_uid: "12345",
+        login: "testuser",
+        name: "Test User",
+        token: "test-token"
+      )
+      @creative = creatives(:tshirt)
+      @link = CollavreGithub::RepositoryLink.create!(
+        creative: @creative,
+        github_account: @account,
+        repository_full_name: "owner/repo"
+      )
+    end
+
+    test "returns error when creative not found" do
+      service = self.class.const_get(:SERVICE_CLASS).new
+      result = service.call(creative_id: 999999, repo: "owner/repo", pr_number: 1)
+
+      assert_equal "GitHub account not found for this creative and repository", result[:error]
+    end
+
+    test "returns error when repository link not found for different repo" do
+      service = self.class.const_get(:SERVICE_CLASS).new
+      result = service.call(creative_id: @creative.id, repo: "other/repo", pr_number: 1)
+
+      assert_equal "GitHub account not found for this creative and repository", result[:error]
+    end
+
+    test "finds github client for valid creative and repo" do
+      service = self.class.const_get(:SERVICE_CLASS).new
+      client = service.send(:find_github_client, @creative.id, "owner/repo")
+
+      assert_not_nil client
+      assert_instance_of CollavreGithub::Client, client
+    end
+  end
+end
+
 class ActiveSupport::TestCase
   include CollavreGithubTestHelpers
 end

--- a/engines/collavre_notion/app/controllers/collavre_notion/creatives/notion_integrations_controller.rb
+++ b/engines/collavre_notion/app/controllers/collavre_notion/creatives/notion_integrations_controller.rb
@@ -1,6 +1,8 @@
 module CollavreNotion
   module Creatives
     class NotionIntegrationsController < ApplicationController
+      include Collavre::IntegrationPermission
+
       before_action :set_creative
       before_action :ensure_read_permission
       before_action :ensure_admin_permission, only: [ :show, :update ]
@@ -78,7 +80,7 @@ module CollavreNotion
 
       def destroy
         unless @creative.has_permission?(Current.user, :write)
-          render json: { error: "forbidden" }, status: :forbidden
+          render json: { error: integration_forbidden_message }, status: :forbidden
           return
         end
 
@@ -122,18 +124,6 @@ module CollavreNotion
 
       def set_creative
         @creative = Collavre::Creative.find(params[:creative_id])
-      end
-
-      def ensure_read_permission
-        return if @creative.has_permission?(Current.user, :read)
-
-        render json: { error: "forbidden" }, status: :forbidden
-      end
-
-      def ensure_admin_permission
-        return if @creative.has_permission?(Current.user, :admin)
-
-        render json: { error: "forbidden" }, status: :forbidden
       end
 
       def linked_page_links(account)

--- a/engines/collavre_notion/app/controllers/collavre_notion/notion_auth_controller.rb
+++ b/engines/collavre_notion/app/controllers/collavre_notion/notion_auth_controller.rb
@@ -22,24 +22,8 @@ module CollavreNotion
       # If opened in popup, close it and notify parent window
       if params[:popup] || request.referer&.include?("popup=true") || session[:oauth_popup]
         session.delete(:oauth_popup)
-        render html: <<-HTML.html_safe
-          <!DOCTYPE html>
-          <html>
-          <head><title>Notion Connected</title></head>
-          <body>
-            <script>
-              if (window.opener) {
-                window.opener.postMessage({ type: 'notion_oauth_success', connected: true }, '*');
-                window.close();
-              } else {
-                window.location.href = '#{collavre.creatives_path}';
-              }
-            </script>
-            <p>#{I18n.t("collavre_notion.notion_auth.connected")}</p>
-            <p>This window should close automatically. If not, you can close it manually.</p>
-          </body>
-          </html>
-        HTML
+        @fallback_path = collavre.creatives_path
+        render template: "collavre_notion/notion_auth/callback_success", layout: false
       else
         redirect_to collavre.creatives_path, notice: I18n.t("collavre_notion.notion_auth.connected")
       end

--- a/engines/collavre_notion/app/views/collavre_notion/notion_auth/callback_success.html.erb
+++ b/engines/collavre_notion/app/views/collavre_notion/notion_auth/callback_success.html.erb
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head><title>Notion Connected</title></head>
+<body>
+  <script>
+    if (window.opener) {
+      window.opener.postMessage({ type: 'notion_oauth_success', connected: true }, '*');
+      window.close();
+    } else {
+      window.location.href = '<%= @fallback_path %>';
+    }
+  </script>
+  <p><%= t("collavre_notion.notion_auth.connected") %></p>
+  <p>This window should close automatically. If not, you can close it manually.</p>
+</body>
+</html>

--- a/engines/collavre_slack/app/controllers/collavre_slack/creatives/slack_integrations_controller.rb
+++ b/engines/collavre_slack/app/controllers/collavre_slack/creatives/slack_integrations_controller.rb
@@ -2,11 +2,10 @@ module CollavreSlack
   module Creatives
     class SlackIntegrationsController < ApplicationController
       before_action :set_creative
+      before_action :set_origin
 
       def index
-        # Always use origin creative for Slack links (chat messages are on origin)
-        target_creative = @creative.effective_origin
-        @links = SlackChannelLink.where(creative: target_creative)
+        @links = SlackChannelLink.where(creative: @origin)
         respond_to do |format|
           format.json do
             slack_account = Current.user ? SlackAccount.find_by(user: Current.user) : nil
@@ -47,11 +46,8 @@ module CollavreSlack
           return
         end
 
-        # Always link to origin creative (chat messages are on origin)
-        target_creative = @creative.effective_origin
-
         service = SlackIntegrationService.new(user: Current.user, slack_account: slack_account)
-        link = service.link_channel(creative: target_creative, channel_id: params[:channel_id], channel_name: params[:channel_name])
+        link = service.link_channel(creative: @origin, channel_id: params[:channel_id], channel_name: params[:channel_name])
 
         if link.persisted?
           render json: { success: true, link: { id: link.id, channel_id: link.channel_id, channel_name: link.channel_name } }, status: :created
@@ -60,10 +56,8 @@ module CollavreSlack
         end
       end
 
-      # Lightweight endpoint for badge display — returns only existing links, no Slack API calls
       def badge
-        target_creative = @creative.effective_origin
-        links = SlackChannelLink.where(creative: target_creative)
+        links = SlackChannelLink.where(creative: @origin)
         render json: {
           links: links.map { |link|
             { channel_name: link.channel_name }
@@ -73,9 +67,7 @@ module CollavreSlack
 
       def destroy
         link = SlackChannelLink.find(params[:id])
-        # Check against origin creative
-        target_creative = @creative.effective_origin
-        unless link.creative_id == target_creative.id
+        unless link.creative_id == @origin.id
           render json: { success: false, error: I18n.t("collavre_slack.errors.not_found") }, status: :not_found
           return
         end
@@ -93,6 +85,10 @@ module CollavreSlack
 
       def set_creative
         @creative = Collavre::Creative.find(params[:creative_id])
+      end
+
+      def set_origin
+        @origin = @creative.effective_origin
       end
 
       def fetch_channels(slack_account)

--- a/engines/collavre_slack/app/controllers/collavre_slack/slack_auth_controller.rb
+++ b/engines/collavre_slack/app/controllers/collavre_slack/slack_auth_controller.rb
@@ -65,7 +65,7 @@ module CollavreSlack
 
       if account.save
         # Render HTML that closes the popup and notifies the parent window
-        render html: close_popup_html.html_safe, layout: false
+        render template: "collavre_slack/slack_auth/callback_success", layout: false
       else
         Rails.logger.error("[SlackAuth] Failed to save account: #{account.errors.full_messages.join(', ')}")
         render json: { error: I18n.t("collavre_slack.errors.save_failed", errors: account.errors.full_messages.join(", ")) }, status: :unprocessable_entity
@@ -80,26 +80,6 @@ module CollavreSlack
 
     def message_verifier
       @message_verifier ||= Rails.application.message_verifier("slack_oauth")
-    end
-
-    def close_popup_html
-      title = I18n.t("collavre_slack.views.auth.success_title")
-      message = I18n.t("collavre_slack.views.auth.success_message")
-      <<~HTML
-        <!DOCTYPE html>
-        <html>
-        <head><title>#{title}</title></head>
-        <body>
-          <p>#{message}</p>
-          <script>
-            if (window.opener) {
-              window.opener.postMessage({ type: 'slack-auth-success' }, '*');
-            }
-            window.close();
-          </script>
-        </body>
-        </html>
-      HTML
     end
   end
 end

--- a/engines/collavre_slack/app/views/collavre_slack/slack_auth/callback_success.html.erb
+++ b/engines/collavre_slack/app/views/collavre_slack/slack_auth/callback_success.html.erb
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head><title><%= t("collavre_slack.views.auth.success_title") %></title></head>
+<body>
+  <p><%= t("collavre_slack.views.auth.success_message") %></p>
+  <script>
+    if (window.opener) {
+      window.opener.postMessage({ type: 'slack-auth-success' }, '*');
+    }
+    window.close();
+  </script>
+</body>
+</html>

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -2,10 +2,4 @@ require "test_helper"
 
 class ApplicationHelperTest < ActionView::TestCase
   include ApplicationHelper
-
-  test "linkify_urls converts URLs to links" do
-    text = "Visit http://example.com"
-    expected = 'Visit <a target="_blank" rel="noopener" href="http://example.com">http://example.com</a>'
-    assert_equal expected, linkify_urls(text)
-  end
 end


### PR DESCRIPTION
## Summary
- **Fix N+1 query** in `agent_context_builder.rb` — add `includes` for loop queries
- **Extract `CommentScoping` concern** — deduplicate `set_creative`/`set_comment` across comments, reactions, versions controllers
- **Extract `IntegrationPermission` concern** — deduplicate permission checks in GitHub/Notion integration controllers
- **Extract `Comment.visible_to` scope** — replace 3 inline visibility queries with a single model scope
- **Delete unused helpers** — remove `linkify_urls` and `render_last_login_for` from ApplicationHelper
- **Replace `html_safe`** with `sanitize`/`safe_join`/view templates in 4 locations (YouTube embed, CSS theme, Slack/Notion OAuth callbacks)
- **Centralize GitHub PR test setup** — extract shared fixtures into `CollavreGithubPrServiceTestSetup` module
- **Cache `effective_origin`** — add `set_origin` before_action in Slack integrations controller

## Test plan
- [x] Full test suite: 1602 runs, 5090 assertions, 0 failures, 0 errors
- [x] Rubocop: 0 offenses