### PR TITLE
fix: patch XSS vulnerabilities and update action_text-trix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,7 +65,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    action_text-trix (2.1.17)
+    action_text-trix (2.1.18)
       railties
     actioncable (8.1.2.1)
       actionpack (= 8.1.2.1)
@@ -165,7 +165,7 @@ GEM
     base64 (0.3.0)
     bcrypt (3.1.22)
     bcrypt_pbkdf (1.1.2)
-    bigdecimal (4.0.1)
+    bigdecimal (4.1.1)
     bindata (2.5.1)
     bindex (0.8.1)
     bootsnap (1.23.0)
@@ -331,7 +331,7 @@ GEM
     jmespath (1.6.2)
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
-    json (2.19.2)
+    json (2.19.3)
     jwt (3.1.2)
       base64
     kamal (2.11.0)
@@ -369,7 +369,7 @@ GEM
     mini_magick (5.3.1)
       logger
     mini_mime (1.1.5)
-    minitest (6.0.2)
+    minitest (6.0.3)
       drb (~> 2.0)
       prism (~> 1.5)
     minitest-mock (5.27.0)
@@ -470,12 +470,12 @@ GEM
       nio4r (~> 2.0)
     raabro (1.4.0)
     racc (1.8.1)
-    rack (3.2.5)
+    rack (3.2.6)
     rack-protection (4.2.1)
       base64 (>= 0.1.0)
       logger (>= 1.6.0)
       rack (>= 3.0.0, < 4)
-    rack-session (2.1.1)
+    rack-session (2.1.2)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
     rack-test (2.2.0)

--- a/engines/collavre/app/views/collavre/shared/_custom_theme_style.html.erb
+++ b/engines/collavre/app/views/collavre/shared/_custom_theme_style.html.erb
@@ -3,10 +3,14 @@
     <style id="user-theme-styles" data-turbo-track="reload">
       body {
         <% custom_theme.variables.each do |key, value| %>
-          <%= key %>: <%= value %> !important;
+          <% if key.match?(/\A--[a-zA-Z0-9_-]+\z/) && value.match?(/\A[^;}{<>"']+\z/) %>
+            <%= key %>: <%= value %> !important;
+          <% end %>
         <% end %>
         <% legacy_alias_declarations(custom_theme.variables).each do |key, value| %>
-          <%= key %>: <%= value %> !important;
+          <% if key.match?(/\A--[a-zA-Z0-9_-]+\z/) && value.match?(/\A[^;}{<>"']+\z/) %>
+            <%= key %>: <%= value %> !important;
+          <% end %>
         <% end %>
         <% if custom_theme.dark? %>
           --color-scheme: dark !important;

--- a/engines/collavre_notion/app/views/collavre_notion/notion_auth/callback_success.html.erb
+++ b/engines/collavre_notion/app/views/collavre_notion/notion_auth/callback_success.html.erb
@@ -4,7 +4,7 @@
 <body>
   <script>
     if (window.opener) {
-      window.opener.postMessage({ type: 'notion_oauth_success', connected: true }, '*');
+      window.opener.postMessage({ type: 'notion_oauth_success', connected: true }, window.location.origin);
       window.close();
     } else {
       window.location.href = '<%= @fallback_path %>';

--- a/engines/collavre_slack/app/views/collavre_slack/slack_auth/callback_success.html.erb
+++ b/engines/collavre_slack/app/views/collavre_slack/slack_auth/callback_success.html.erb
@@ -5,7 +5,7 @@
   <p><%= t("collavre_slack.views.auth.success_message") %></p>
   <script>
     if (window.opener) {
-      window.opener.postMessage({ type: 'slack-auth-success' }, '*');
+      window.opener.postMessage({ type: 'slack-auth-success' }, window.location.origin);
     }
     window.close();
   </script>


### PR DESCRIPTION
## Summary

- **Update action_text-trix** from 2.1.17 to 2.1.18 to fix drag-and-drop XSS vulnerability (GHSA-53p3-c7vp-4mcc)
- **Sanitize theme CSS variables** in `_custom_theme_style.html.erb` — validate CSS custom property keys match `--[a-zA-Z0-9_-]+` and values contain no CSS injection characters (`;`, `{`, `}`, `<`, `>`, `"`, `'`), preventing style tag breakout via crafted UserTheme variables
- **Replace postMessage wildcard origin** (`'*'`) with `window.location.origin` in Slack and Notion OAuth callback views to prevent cross-origin message leakage

## Test plan

- [x] `bundle exec rake test` — 1602 tests, 0 failures, 0 errors
- [ ] Verify custom user themes still render correctly with valid CSS variables
- [ ] Verify Slack OAuth callback still sends postMessage to opener
- [ ] Verify Notion OAuth callback still sends postMessage to opener