### PR TITLE
refactor: extract OpenClaw abort logic into shared service

### DIFF
--- a/engines/collavre/app/controllers/collavre/tasks_controller.rb
+++ b/engines/collavre/app/controllers/collavre/tasks_controller.rb
@@ -24,31 +24,7 @@ module Collavre
     private
 
     def abort_openclaw_session(task)
-      return unless task.agent.llm_vendor&.downcase == "openclaw"
-      return unless defined?(CollavreOpenclaw::ConnectionManager)
-
-      conn = CollavreOpenclaw::ConnectionManager.instance.connection_for(task.agent)
-      session_key = build_session_key(task)
-      conn.chat_abort(session_key: session_key)
-    rescue StandardError => e
-      Rails.logger.warn("[TasksController] OpenClaw abort failed: #{e.message}")
-    end
-
-    def build_session_key(task)
-      payload = task.trigger_event_payload || {}
-      creative = task.creative || Creative.find_by(id: payload.dig("creative", "id"))
-      comment = Comment.find_by(id: payload.dig("comment", "id"))
-
-      CollavreOpenclaw::OpenclawAdapter.new(
-        user: task.agent,
-        system_prompt: "",
-        context: {
-          creative: creative,
-          user: task.agent,
-          task: task,
-          comment: comment
-        }
-      ).session_key
+      Collavre::OpenclawAbortService.call(agent: task.agent, task: task)
     end
   end
 end

--- a/engines/collavre/app/services/collavre/ai_agent_service.rb
+++ b/engines/collavre/app/services/collavre/ai_agent_service.rb
@@ -236,23 +236,12 @@ module Collavre
     end
 
     def abort_openclaw_if_needed
-      return unless @agent.llm_vendor&.downcase == "openclaw"
-      return unless defined?(CollavreOpenclaw::ConnectionManager)
-
-      adapter = CollavreOpenclaw::OpenclawAdapter.new(
-        user: @agent,
-        system_prompt: "",
-        context: {
-          creative: @creative,
-          user: @agent,
-          task: @task,
-          comment: @reply_comment || @original_comment
-        }
+      Collavre::OpenclawAbortService.call(
+        agent: @agent,
+        task: @task,
+        creative: @creative,
+        comment: @reply_comment || @original_comment
       )
-      conn = CollavreOpenclaw::ConnectionManager.instance.connection_for(@agent)
-      conn.chat_abort(session_key: adapter.session_key)
-    rescue StandardError => e
-      Rails.logger.warn("[AiAgentService] OpenClaw abort fallback failed: #{e.message}")
     end
   end
 end

--- a/engines/collavre/app/services/collavre/openclaw_abort_service.rb
+++ b/engines/collavre/app/services/collavre/openclaw_abort_service.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Collavre
+  class OpenclawAbortService
+    def self.call(agent:, task:, creative: nil, comment: nil)
+      new(agent: agent, task: task, creative: creative, comment: comment).call
+    end
+
+    def initialize(agent:, task:, creative: nil, comment: nil)
+      @agent = agent
+      @task = task
+      @creative = creative
+      @comment = comment
+    end
+
+    def call
+      return unless @agent.llm_vendor&.downcase == "openclaw"
+      return unless defined?(CollavreOpenclaw::ConnectionManager)
+
+      creative = @creative || @task.creative || Creative.find_by(id: payload.dig("creative", "id"))
+      comment = @comment || Comment.find_by(id: payload.dig("comment", "id"))
+
+      adapter = CollavreOpenclaw::OpenclawAdapter.new(
+        user: @agent,
+        system_prompt: "",
+        context: {
+          creative: creative,
+          user: @agent,
+          task: @task,
+          comment: comment
+        }
+      )
+      conn = CollavreOpenclaw::ConnectionManager.instance.connection_for(@agent)
+      conn.chat_abort(session_key: adapter.session_key)
+    rescue StandardError => e
+      Rails.logger.warn("[OpenclawAbortService] abort failed: #{e.message}")
+    end
+
+    private
+
+    def payload
+      @task.trigger_event_payload || {}
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Created `Collavre::OpenclawAbortService` to encapsulate OpenClaw session abort logic that was duplicated across two locations
- Updated `TasksController#abort_openclaw_session` and `AiAgentService#abort_openclaw_if_needed` to delegate to the new service
- The shared service unifies vendor check, adapter construction, connection lookup, and error handling in one place

## Test plan
- [x] Full test suite passes (1602 tests, 0 failures)
- [x] Rubocop passes (789 files, no offenses)