### PR TITLE
refactor: replace inline comment visibility queries with visible_to scope

### DIFF
--- a/engines/collavre/app/components/collavre/inbox/badge_component.rb
+++ b/engines/collavre/app/components/collavre/inbox/badge_component.rb
@@ -26,8 +26,7 @@ module Collavre
       private
 
       def unread_count_for_creative
-        visible_comments = @creative.comments.where(private: false)
-                                             .or(@creative.comments.where(user_id: @user.id))
+        visible_comments = @creative.comments.visible_to(@user)
         pointer = CommentReadPointer.find_by(user: @user, creative: @creative)
         last_read_id = pointer&.last_read_comment_id
 

--- a/engines/collavre/app/controllers/collavre/comment_read_pointers_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comment_read_pointers_controller.rb
@@ -2,7 +2,7 @@ module Collavre
   class CommentReadPointersController < ApplicationController
     def update
       creative = Creative.find(params[:creative_id]).effective_origin
-      last_id = creative.comments.where("comments.private = ? OR comments.user_id = ? OR comments.approver_id = ?", false, Current.user.id, Current.user.id).maximum(:id)
+      last_id = creative.comments.visible_to(Current.user).maximum(:id)
       pointer = CommentReadPointer.find_or_initialize_by(user: Current.user, creative: creative)
 
       previous_last_read_id = pointer.last_read_comment_id

--- a/engines/collavre/app/controllers/concerns/collavre/comments/batch_operations.rb
+++ b/engines/collavre/app/controllers/concerns/collavre/comments/batch_operations.rb
@@ -14,10 +14,7 @@ module Collavre
         is_admin = @creative.has_permission?(Current.user, :admin)
         is_creative_owner = @creative.user == Current.user
 
-        visible_scope = @creative.comments.where(
-          "comments.private = ? OR comments.user_id = ? OR comments.approver_id = ?",
-          false, Current.user.id, Current.user.id
-        )
+        visible_scope = @creative.comments.visible_to(Current.user)
         comments = visible_scope.where(id: comment_ids).to_a
 
         if comments.length != comment_ids.length
@@ -47,10 +44,7 @@ module Collavre
           render json: { error: I18n.t("collavre.comments.merge.not_authorized") }, status: :forbidden and return
         end
 
-        visible_scope = @creative.comments.where(
-          "comments.private = ? OR comments.user_id = ? OR comments.approver_id = ?",
-          false, Current.user.id, Current.user.id
-        )
+        visible_scope = @creative.comments.visible_to(Current.user)
         comments = visible_scope.where(id: comment_ids).to_a
 
         if comments.length != comment_ids.length

--- a/engines/collavre/app/models/collavre/comment/broadcastable.rb
+++ b/engines/collavre/app/models/collavre/comment/broadcastable.rb
@@ -83,7 +83,7 @@ module Collavre
 
         def broadcast_badge(creative, user)
           origin = creative.effective_origin
-          visible_comments = origin.comments.where("comments.private = ? OR comments.user_id = ?", false, user.id)
+          visible_comments = origin.comments.visible_to(user)
           comments_count = visible_comments.count
           pointer = CommentReadPointer.find_by(user: user, creative: origin)
           last_read_id = pointer&.last_read_comment_id

--- a/engines/collavre/app/services/collavre/comment_move_service.rb
+++ b/engines/collavre/app/services/collavre/comment_move_service.rb
@@ -53,10 +53,7 @@ module Collavre
     end
 
     def fetch_visible_comments(comment_ids)
-      scope = creative.comments.where(
-        "comments.private = ? OR comments.user_id = ? OR comments.approver_id = ?",
-        false, user.id, user.id
-      )
+      scope = creative.comments.visible_to(user)
       comments = scope.where(id: comment_ids).to_a
       raise MoveError, I18n.t("collavre.comments.move_not_allowed") if comments.length != comment_ids.length
       comments


### PR DESCRIPTION
## Summary
- Extract duplicated comment visibility WHERE clause into a reusable `visible_to` scope on Comment model
- Replace 5 inline visibility query locations with the new scope
- Reduces code duplication and centralizes comment access control logic

## Duplication
Addresses HIGH-priority duplication finding from daily code scan (2026-04-09):
- **[HIGH]** Comment visibility query duplicated across 8 locations — same WHERE clause repeated in inbox badge, read pointers, batch operations, broadcastable, and comment move service

## Test plan
- [x] All 1602 tests pass (0 failures, 0 errors)
- [x] Rubocop: 788 files, 0 offenses
- [ ] Manual: verify comment visibility behavior unchanged across all views