### PR TITLE
chore: add CommandMenuComponent test and remove dead search mode block

### DIFF
--- a/engines/collavre/app/views/collavre/shared/navigation/_search_form.html.erb
+++ b/engines/collavre/app/views/collavre/shared/navigation/_search_form.html.erb
@@ -66,23 +66,6 @@
         </div>
       </div>
 
-      <%# TODO: Search results mode (flat/tree) — currently locked by filter state, re-enable when independent %>
-      <% if false # disabled: search results mode %>
-      <div class="search-popup-filter-section">
-        <span class="search-popup-filter-label"><%= t('collavre.search_popup.search_results') %></span>
-        <div class="search-popup-filter-buttons">
-          <button type="button"
-                  class="search-popup-filter-btn<%= ' active' if search_mode == 'flat' %>"
-                  data-mode="flat"
-                  data-action="click->search-popup#applySearchMode"><%= t('collavre.search_popup.flat_view') %></button>
-          <button type="button"
-                  class="search-popup-filter-btn<%= ' active' if search_mode == 'tree' %>"
-                  data-mode="tree"
-                  data-action="click->search-popup#applySearchMode"><%= t('collavre.search_popup.tree_view') %></button>
-        </div>
-      </div>
-      <% end %>
-
       <div class="search-popup-filter-section">
         <span class="search-popup-filter-label"><%= t('collavre.search_popup.other_filters') %></span>
         <div class="search-popup-filter-buttons">

--- a/engines/collavre/test/components/command_menu_component_test.rb
+++ b/engines/collavre/test/components/command_menu_component_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+
+class CommandMenuComponentTest < ViewComponent::TestCase
+  test "renders with default menu_id" do
+    render_inline(Collavre::CommandMenuComponent.new)
+
+    assert_selector "#command-menu.common-popup", visible: :all
+    assert_selector "#command-menu ul.common-popup-list", visible: :all
+  end
+
+  test "renders with custom menu_id" do
+    render_inline(Collavre::CommandMenuComponent.new(menu_id: "custom-menu"))
+
+    assert_selector "#custom-menu.common-popup", visible: :all
+    assert_selector "#custom-menu ul.common-popup-list", visible: :all
+  end
+
+  test "does not include extra CSS classes" do
+    component = Collavre::CommandMenuComponent.new
+    assert_nil component.extra_classes
+    assert_equal "common-popup", component.css_classes
+  end
+
+  test "form_submit_label returns i18n translation" do
+    component = Collavre::CommandMenuComponent.new
+    assert_equal I18n.t("collavre.comments.command_menu.form_submit"), component.form_submit_label
+  end
+
+  test "form_cancel_label returns i18n translation" do
+    component = Collavre::CommandMenuComponent.new
+    assert_equal I18n.t("collavre.comments.command_menu.form_cancel"), component.form_cancel_label
+  end
+end


### PR DESCRIPTION
## Summary
- Add ViewComponent test for `CommandMenuComponent` covering rendering, custom menu_id, CSS classes, and i18n labels
- Remove disabled search results mode filter (`if false` block) from `_search_form.html.erb`

## Test plan
- [x] CommandMenuComponent test passes (5 tests, 8 assertions)
- [x] No regressions — removed block was unreachable dead code