### PR TITLE
feat: add Ctrl+A to select all messages in chat popup

### DIFF
--- a/engines/collavre/app/javascript/controllers/comments/list_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/list_controller.js
@@ -563,28 +563,11 @@ export default class extends Controller {
 
     // Select All toggle handler
     selectAllCheckbox.addEventListener('change', () => {
-      const shouldSelect = selectAllCheckbox.checked
-      this.listTarget.querySelectorAll('.comment-select-checkbox').forEach((checkbox) => {
-        const commentId = checkbox.value
-        const item = checkbox.closest('.comment-item')
-        if (shouldSelect && !checkbox.checked) {
-          checkbox.checked = true
-          this.selection.add(commentId)
-          if (item) {
-            item.classList.add('selected-for-move')
-            item.setAttribute('draggable', 'true')
-          }
-        } else if (!shouldSelect && checkbox.checked) {
-          checkbox.checked = false
-          this.selection.delete(commentId)
-          if (item) {
-            item.classList.remove('selected-for-move')
-            item.removeAttribute('draggable')
-          }
-        }
-      })
-      this.notifySelectionChange()
-      this.updateSelectionActionBar()
+      if (selectAllCheckbox.checked) {
+        this.selectAll()
+      } else {
+        this.clearSelection()
+      }
     })
 
     bar.querySelector('.selection-action-delete').addEventListener('click', (e) => { e.stopPropagation(); this.deleteSelectedComments() })

--- a/engines/collavre/app/javascript/controllers/comments/list_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/list_controller.js
@@ -798,6 +798,23 @@ export default class extends Controller {
     this.formController?.onSelectionChanged({ size, moving: this.movingComments })
   }
 
+  selectAll() {
+    this.listTarget.querySelectorAll('.comment-select-checkbox').forEach((checkbox) => {
+      if (!checkbox.checked) {
+        checkbox.checked = true
+        const commentId = checkbox.value
+        this.selection.add(commentId)
+        const item = checkbox.closest('.comment-item')
+        if (item) {
+          item.classList.add('selected-for-move')
+          item.setAttribute('draggable', 'true')
+        }
+      }
+    })
+    this.notifySelectionChange()
+    this.updateSelectionActionBar()
+  }
+
   clearSelection() {
     this.selection.clear()
     this.listTarget.querySelectorAll('.comment-select-checkbox').forEach((checkbox) => {

--- a/engines/collavre/app/javascript/controllers/comments/popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_controller.js
@@ -1171,6 +1171,13 @@ export default class extends Controller {
     } else if (event.altKey && event.key === 'ArrowRight') {
       event.preventDefault()
       this.navigateForward()
+    } else if ((event.ctrlKey || event.metaKey) && event.key === 'a') {
+      // Ctrl+A / Cmd+A: select all messages — but only when not typing in an input
+      const tag = document.activeElement?.tagName
+      if (tag === 'TEXTAREA' || tag === 'INPUT' || document.activeElement?.isContentEditable) return
+      if (!this.element.contains(document.activeElement) && document.activeElement !== document.body) return
+      event.preventDefault()
+      this.listController?.selectAll()
     }
   }
 


### PR DESCRIPTION
## Summary
- Adds Ctrl+A (Cmd+A on Mac) keyboard shortcut in the chat popup to select all messages
- Enters selection mode with the action bar showing count, delete, merge, move, and topic actions
- Skips the shortcut when focus is in a textarea/input to preserve normal text selection behavior

## Test plan
- [ ] Open chat popup, press Ctrl+A (or Cmd+A on Mac) — all messages should be selected with checkboxes checked
- [ ] Verify selection action bar appears with correct count (all selected)
- [ ] Click in the message input textarea, press Ctrl+A — only text in textarea should be selected, not messages
- [ ] Close selection with the cancel button, verify all checkboxes are unchecked
- [ ] Press Ctrl+A when popup is not visible — no effect (browser default behavior)