### PR TITLE
fix: review popup not shown when mouse released outside comment

### DIFF
--- a/engines/collavre/app/javascript/controllers/comment_controller.js
+++ b/engines/collavre/app/javascript/controllers/comment_controller.js
@@ -121,7 +121,7 @@ export default class extends Controller {
 
     // Text selection quote support
     this.handleMouseUp = this.handleMouseUp.bind(this)
-    this.element.addEventListener('mouseup', this.handleMouseUp)
+    document.addEventListener('mouseup', this.handleMouseUp)
 
     this.currentUserId = document.body.dataset.currentUserId
     const commentAuthorId = this.element.dataset.userId
@@ -223,7 +223,7 @@ export default class extends Controller {
       clearTimeout(this._streamingTimeout)
       this._streamingTimeout = null
     }
-    this.element.removeEventListener('mouseup', this.handleMouseUp)
+    document.removeEventListener('mouseup', this.handleMouseUp)
     this.hideReviewPopup()
     if (this._reviewPopupEl) {
       this._reviewPopupEl.remove()


### PR DESCRIPTION
## Summary
- Fix review popup not appearing when mouse is released outside the comment element during text selection
- Changed `mouseup` event binding from `this.element` to `document` in `comment_controller.js`
- The existing `contentEl.contains(range.commonAncestorContainer)` guard already ensures only valid in-comment selections trigger the popup

## Test plan
- [x] All existing tests pass (1603 runs, 0 failures)
- [ ] Manual: Select text in a chat message by dragging the mouse outside the comment boundary → review popup should appear
- [ ] Manual: Select text within the comment boundary → review popup should still appear as before
- [ ] Manual: Click outside any comment → no popup should appear