### PR TITLE
feat: add chat branching — copy selected messages into new topic

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_01_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_09_000000) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false
@@ -719,12 +719,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_01_120000) do
     t.integer "creative_id", null: false
     t.string "name", null: false
     t.integer "position", default: 0, null: false
+    t.integer "source_topic_id"
     t.datetime "updated_at", null: false
     t.integer "user_id", null: false
     t.index ["archived_at"], name: "index_topics_on_archived_at", where: "archived_at IS NOT NULL"
     t.index ["creative_id", "name"], name: "index_topics_on_creative_id_and_name", unique: true
     t.index ["creative_id", "position"], name: "index_topics_on_creative_id_and_position"
     t.index ["creative_id"], name: "index_topics_on_creative_id"
+    t.index ["source_topic_id"], name: "index_topics_on_source_topic_id"
     t.index ["user_id"], name: "index_topics_on_user_id"
   end
 
@@ -874,6 +876,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_01_120000) do
   add_foreign_key "tasks", "tasks", column: "parent_task_id", on_delete: :nullify
   add_foreign_key "tasks", "users", column: "agent_id"
   add_foreign_key "topics", "creatives"
+  add_foreign_key "topics", "topics", column: "source_topic_id", on_delete: :nullify
   add_foreign_key "topics", "users"
   add_foreign_key "user_creative_preferences", "creatives"
   add_foreign_key "user_creative_preferences", "topics", column: "last_topic_id", on_delete: :nullify

--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -1514,6 +1514,10 @@ body.chat-fullscreen {
     font-size: 0.75em;
     opacity: 0.6;
     margin-right: 1px;
+    cursor: pointer;
+}
+.topic-branch-icon:hover {
+    opacity: 1;
 }
 .archive-topic-btn,
 .unarchive-topic-btn {

--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -1510,6 +1510,11 @@ body.chat-fullscreen {
     opacity: 0.5;
     font-style: italic;
 }
+.topic-branch-icon {
+    font-size: 0.75em;
+    opacity: 0.6;
+    margin-right: 1px;
+}
 .archive-topic-btn,
 .unarchive-topic-btn {
     background: none;

--- a/engines/collavre/app/controllers/collavre/topics_controller.rb
+++ b/engines/collavre/app/controllers/collavre/topics_controller.rb
@@ -268,7 +268,7 @@ module Collavre
     end
 
     def topic_json(topic)
-      data = topic.slice(:id, :name)
+      data = topic.slice(:id, :name, :source_topic_id)
       agent = topic.instance_variable_get(:@_primary_agent) || topic.primary_agent
       if agent
         data[:primary_agent] = agent_json(agent)
@@ -277,7 +277,7 @@ module Collavre
     end
 
     def topic_json_with_agent(topic, agent)
-      data = topic.slice(:id, :name)
+      data = topic.slice(:id, :name, :source_topic_id)
       data[:primary_agent] = agent_json(agent)
       data
     end

--- a/engines/collavre/app/controllers/concerns/collavre/comments/batch_operations.rb
+++ b/engines/collavre/app/controllers/concerns/collavre/comments/batch_operations.rb
@@ -76,6 +76,18 @@ module Collavre
       rescue ActiveRecord::RecordInvalid => e
         render json: { error: e.record.errors.full_messages.to_sentence.presence || I18n.t("collavre.comments.move_error") }, status: :unprocessable_entity
       end
+
+      def branch
+        source_topic = params[:topic_id].present? ? @creative.topics.find(params[:topic_id]) : nil
+        new_topic = TopicBranchService.new(creative: @creative, user: Current.user, source_topic: source_topic).call(
+          comment_ids: params[:comment_ids]
+        )
+        render json: { success: true, topic: new_topic.slice(:id, :name, :source_topic_id) }, status: :created
+      rescue TopicBranchService::BranchError => e
+        render json: { error: e.message }, status: :unprocessable_entity
+      rescue ActiveRecord::RecordInvalid => e
+        render json: { error: e.record.errors.full_messages.to_sentence }, status: :unprocessable_entity
+      end
     end
   end
 end

--- a/engines/collavre/app/javascript/controllers/comments/list_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/list_controller.js
@@ -548,6 +548,7 @@ export default class extends Controller {
         <button type="button" class="selection-action-bar-btn selection-action-merge" title="${i18n('selectionMergeText', 'Merge')}"${count < 2 ? ' disabled' : ''}>🔗 ${i18n('selectionMergeText', 'Merge')}</button>
         <button type="button" class="selection-action-bar-btn selection-action-move" title="${i18n('selectionMoveText', 'Move')}">📤 ${i18n('selectionMoveText', 'Move')}</button>
         <button type="button" class="selection-action-bar-btn selection-action-topic" title="${i18n('selectionTopicMoveText', 'Move to topic')}">🏷 ${i18n('selectionTopicMoveText', 'Move to topic')}</button>
+        <button type="button" class="selection-action-bar-btn selection-action-branch" title="${i18n('selectionBranchText', 'Branch')}">🌿 ${i18n('selectionBranchText', 'Branch')}</button>
         <button type="button" class="selection-action-bar-close" title="${i18n('selectionCloseText', 'Cancel')}">✕</button>
       </div>
       <div class="selection-action-bar-hint no-touch">
@@ -574,6 +575,7 @@ export default class extends Controller {
     bar.querySelector('.selection-action-merge').addEventListener('click', (e) => { e.stopPropagation(); this.mergeSelectedComments() })
     bar.querySelector('.selection-action-move').addEventListener('click', (e) => this.openMoveModal(e))
     bar.querySelector('.selection-action-topic').addEventListener('click', (e) => this.openTopicSearchPopup(e))
+    bar.querySelector('.selection-action-branch').addEventListener('click', (e) => { e.stopPropagation(); this.branchSelectedComments() })
     bar.querySelector('.selection-action-bar-close').addEventListener('click', () => this.clearSelection())
 
     // Insert before typing indicator so it stays inside the popup window
@@ -641,6 +643,39 @@ export default class extends Controller {
     } catch (error) {
       console.error('Error merging comments:', error)
       alert('Failed to merge comments')
+    }
+  }
+
+  async branchSelectedComments() {
+    if (this.selection.size === 0) return
+
+    const commentIds = Array.from(this.selection)
+    try {
+      const body = { comment_ids: commentIds }
+      if (this.currentTopicId) body.topic_id = this.currentTopicId
+
+      const response = await fetch(`/creatives/${this.creativeId}/comments/branch`, {
+        method: 'POST',
+        headers: {
+          'X-CSRF-Token': document.querySelector('meta[name=csrf-token]').content,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(body),
+      })
+      if (response.ok) {
+        const data = await response.json()
+        this.clearSelection()
+        // Switch to the new branched topic
+        if (data.topic?.id) {
+          this.switchToTopic(data.topic.id)
+        }
+      } else {
+        const data = await response.json().catch(() => ({}))
+        alert(data.error || 'Failed to branch comments')
+      }
+    } catch (error) {
+      console.error('Error branching comments:', error)
+      alert('Failed to branch comments')
     }
   }
 

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -473,6 +473,15 @@ export default class extends Controller {
         // Ignore if clicking on edit input
         if (event.target.closest('.topic-edit-input')) return
 
+        // Navigate to source topic when clicking branch icon
+        if (event.target.closest('.topic-branch-icon')) {
+            const sourceTopicId = event.currentTarget.dataset.sourceTopicId
+            if (sourceTopicId) {
+                this.selectTopic(sourceTopicId)
+                return
+            }
+        }
+
         const id = event.currentTarget.dataset.id
 
         // If clicking on already active topic (not Main), show edit mode

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -126,10 +126,11 @@ export default class extends Controller {
             const agentAvatar = topic.primary_agent
                 ? this.renderAgentAvatar(topic.primary_agent)
                 : ''
+            const branchIcon = topic.source_topic_id ? '<span class="topic-branch-icon" title="Branched">↗</span>' : ''
             html += `<span class="topic-tag topic-drop-target ${isActive}" ${draggable}
-                          data-action="click->comments--topics#select ${dropActions} ${dragActions} ${topicDropActions}" 
-                          data-id="${topic.id}">
-                        ${agentAvatar}#${topic.name}`
+                          data-action="click->comments--topics#select ${dropActions} ${dragActions} ${topicDropActions}"
+                          data-id="${topic.id}"${topic.source_topic_id ? ` data-source-topic-id="${topic.source_topic_id}"` : ''}>
+                        ${agentAvatar}${branchIcon}#${topic.name}`
 
             if (canManage) {
                 html += `<button class="archive-topic-btn" data-action="click->comments--topics#archiveTopic" data-id="${topic.id}" title="Archive">${ICON_ARCHIVE}</button>`

--- a/engines/collavre/app/javascript/lib/api/topics.js
+++ b/engines/collavre/app/javascript/lib/api/topics.js
@@ -56,6 +56,40 @@ export async function saveLastTopic(creativeId, topicId) {
  * @param {string[]|number[]} commentIds - comments to move (optional)
  * @returns {Promise<{ok: boolean, topic?: object, error?: string}>}
  */
+/**
+ * Branch (copy) selected comments into a new topic.
+ * @param {string|number} creativeId
+ * @param {string[]|number[]} commentIds
+ * @param {string|number|null} topicId - source topic (null for Main)
+ * @returns {Promise<{ok: boolean, topic?: object, error?: string}>}
+ */
+export async function branchComments(creativeId, commentIds, topicId = null) {
+    try {
+        const body = { comment_ids: commentIds }
+        if (topicId) body.topic_id = topicId
+
+        const response = await fetch(`/creatives/${creativeId}/comments/branch`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-CSRF-Token': csrfToken()
+            },
+            body: JSON.stringify(body)
+        })
+
+        if (response.ok) {
+            const data = await response.json()
+            return { ok: true, topic: data.topic }
+        } else {
+            const data = await response.json().catch(() => ({}))
+            return { ok: false, error: data.error || 'Failed to branch comments' }
+        }
+    } catch (e) {
+        console.error('Error branching comments', e)
+        return { ok: false, error: e.message }
+    }
+}
+
 export async function createTopicWithComments(creativeId, name, commentIds = []) {
     try {
         const body = { topic: { name } }

--- a/engines/collavre/app/javascript/lib/api/topics.js
+++ b/engines/collavre/app/javascript/lib/api/topics.js
@@ -56,40 +56,6 @@ export async function saveLastTopic(creativeId, topicId) {
  * @param {string[]|number[]} commentIds - comments to move (optional)
  * @returns {Promise<{ok: boolean, topic?: object, error?: string}>}
  */
-/**
- * Branch (copy) selected comments into a new topic.
- * @param {string|number} creativeId
- * @param {string[]|number[]} commentIds
- * @param {string|number|null} topicId - source topic (null for Main)
- * @returns {Promise<{ok: boolean, topic?: object, error?: string}>}
- */
-export async function branchComments(creativeId, commentIds, topicId = null) {
-    try {
-        const body = { comment_ids: commentIds }
-        if (topicId) body.topic_id = topicId
-
-        const response = await fetch(`/creatives/${creativeId}/comments/branch`, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                'X-CSRF-Token': csrfToken()
-            },
-            body: JSON.stringify(body)
-        })
-
-        if (response.ok) {
-            const data = await response.json()
-            return { ok: true, topic: data.topic }
-        } else {
-            const data = await response.json().catch(() => ({}))
-            return { ok: false, error: data.error || 'Failed to branch comments' }
-        }
-    } catch (e) {
-        console.error('Error branching comments', e)
-        return { ok: false, error: e.message }
-    }
-}
-
 export async function createTopicWithComments(creativeId, name, commentIds = []) {
     try {
         const body = { topic: { name } }

--- a/engines/collavre/app/models/collavre/topic.rb
+++ b/engines/collavre/app/models/collavre/topic.rb
@@ -4,8 +4,10 @@ module Collavre
 
     belongs_to :creative, class_name: "Collavre::Creative"
     belongs_to :user, class_name: Collavre.configuration.user_class_name
+    belongs_to :source_topic, class_name: "Collavre::Topic", optional: true
 
     has_many :comments, class_name: "Collavre::Comment", dependent: :destroy
+    has_many :branches, class_name: "Collavre::Topic", foreign_key: :source_topic_id, dependent: :nullify
     has_many :user_creative_preferences_as_last_topic, class_name: "Collavre::UserCreativePreference",
              foreign_key: :last_topic_id, dependent: :nullify, inverse_of: :last_topic
 

--- a/engines/collavre/app/services/collavre/topic_branch_service.rb
+++ b/engines/collavre/app/services/collavre/topic_branch_service.rb
@@ -1,0 +1,112 @@
+module Collavre
+  class TopicBranchService
+    class BranchError < StandardError; end
+
+    MAX_BRANCH_COMMENTS = 100
+
+    def initialize(creative:, user:, source_topic:)
+      @creative = creative
+      @user = user
+      @source_topic = source_topic
+    end
+
+    # Creates a new topic with copies of the selected comments.
+    # Returns the new Topic.
+    def call(comment_ids:)
+      comment_ids = Array(comment_ids).map(&:presence).compact.map(&:to_i).first(MAX_BRANCH_COMMENTS)
+      raise BranchError, I18n.t("collavre.comments.branch.no_selection") if comment_ids.empty?
+
+      validate_permissions!
+      originals = fetch_comments(comment_ids)
+
+      Topic.transaction do
+        @new_topic = create_branch_topic
+        copy_comments(originals)
+      end
+
+      broadcast_topic_created
+
+      @new_topic
+    end
+
+    private
+
+    attr_reader :creative, :user, :source_topic
+
+    def validate_permissions!
+      unless creative.has_permission?(user, :feedback)
+        raise BranchError, I18n.t("collavre.comments.branch.not_authorized")
+      end
+    end
+
+    def fetch_comments(comment_ids)
+      scope = source_topic ? source_topic.comments.visible_to(user) : creative.comments.visible_to(user).where(topic_id: nil)
+      comments = scope.where(id: comment_ids).order(:created_at).to_a
+      if comments.length != comment_ids.length
+        raise BranchError, I18n.t("collavre.comments.branch.comments_not_found")
+      end
+      comments
+    end
+
+    def create_branch_topic
+      prefix = I18n.t("collavre.topics.branch_prefix")
+      source_name = source_topic&.name || I18n.t("collavre.topics.main_name", default: "Main")
+      name = "#{prefix}:#{source_name}"
+
+      # Ensure uniqueness
+      existing = creative.topics.where("name LIKE ?", "#{Topic.sanitize_sql_like(name)}%").pluck(:name)
+      if existing.include?(name)
+        counter = 2
+        counter += 1 while existing.include?("#{name} #{counter}")
+        name = "#{name} #{counter}"
+      end
+
+      creative.topics.create!(
+        name: name,
+        user: user,
+        source_topic_id: source_topic&.id
+      )
+    end
+
+    def copy_comments(originals)
+      id_mapping = {}
+
+      originals.each do |original|
+        new_comment = Comment.new(
+          creative: creative,
+          topic: @new_topic,
+          user_id: original.user_id,
+          content: original.content,
+          private: original.private,
+          review_type: original.review_type,
+          skip_default_user: true,
+          skip_dispatch: true
+        )
+
+        # Remap quoted_comment_id if the quoted comment was also copied
+        if original.quoted_comment_id && id_mapping[original.quoted_comment_id]
+          new_comment.quoted_comment_id = id_mapping[original.quoted_comment_id]
+        end
+
+        new_comment.save!
+        id_mapping[original.id] = new_comment.id
+
+        # Share image blobs (no duplication of file data)
+        original.images.each do |image|
+          new_comment.images.attach(image.blob)
+        end
+      end
+    end
+
+    def broadcast_topic_created
+      TopicsChannel.broadcast_to(
+        creative,
+        {
+          action: "created",
+          topic: { id: @new_topic.id, name: @new_topic.name, source_topic_id: @new_topic.source_topic_id },
+          user_id: user.id
+        }
+      )
+    end
+  end
+end

--- a/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
@@ -40,6 +40,7 @@
      data-touch-drag-proxy-one-text="<%= t('collavre.comments.touch_drag_proxy_label.one') %>"
      data-touch-drag-proxy-other-text="<%= t('collavre.comments.touch_drag_proxy_label.other') %>"
      data-selection-merge-text="<%= t('collavre.comments.selection_merge') %>"
+     data-selection-branch-text="<%= t('collavre.comments.selection_branch') %>"
      data-merge-confirm-text="<%= t('collavre.comments.merge_confirm') %>"
      data-batch-delete-confirm-text="<%= t('collavre.comments.batch_delete_confirm') %>"
      data-topic-search-placeholder-text="<%= t('collavre.comments.topic_search_placeholder') %>"

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -10,6 +10,8 @@ en:
       archived_topics: "Archived topics (%{count})"
       not_ai_agent: Only AI agents can be set as primary agent.
       default_name_prefix: "Topic"
+      branch_prefix: "Branch"
+      main_name: "Main"
       create_and_move: 'Create "%{name}" and move'
       move:
         no_target_permission: You don't have write permission on the target creative.
@@ -104,12 +106,17 @@ en:
         one: "1 message"
         other: "%{count} messages"
       selection_merge: Merge
+      selection_branch: Branch
       merge_confirm: "Merge the selected messages into one? The first message will be updated and the rest will be deleted."
       merge:
         started: "⏳ Merging messages..."
         minimum_required: "Select at least 2 messages to merge."
         not_authorized: "You don't have permission to merge messages."
         own_messages_only: "You can only merge your own messages or messages from your AI agents."
+      branch:
+        no_selection: "Select at least one message to branch."
+        not_authorized: "You don't have permission to branch messages."
+        comments_not_found: "Some selected messages could not be found."
       batch_delete_confirm: Are you sure you want to delete the selected messages?
       batch_delete_no_selection: Select at least one message to delete.
       batch_delete_not_found: Some selected messages could not be found.

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -10,6 +10,8 @@ ko:
       archived_topics: "아카이브된 토픽 (%{count}개)"
       not_ai_agent: AI 에이전트만 Primary Agent로 설정할 수 있습니다.
       default_name_prefix: "토픽"
+      branch_prefix: "분기"
+      main_name: "메인"
       create_and_move: '"%{name}" 생성후 이동'
       move:
         no_target_permission: 대상 크리에이티브에 대한 쓰기 권한이 없습니다.
@@ -101,12 +103,17 @@ ko:
         one: "메시지 1개"
         other: "메시지 %{count}개"
       selection_merge: 병합
+      selection_branch: 분기
       merge_confirm: "선택한 메시지를 하나로 병합하시겠습니까? 첫 번째 메시지가 업데이트되고 나머지는 삭제됩니다."
       merge:
         started: "⏳ 메시지 병합 중..."
         minimum_required: "병합하려면 2개 이상의 메시지를 선택하세요."
         not_authorized: "메시지를 병합할 권한이 없습니다."
         own_messages_only: "자신의 메시지 또는 자신의 AI 에이전트 메시지만 병합할 수 있습니다."
+      branch:
+        no_selection: "분기할 메시지를 선택하세요."
+        not_authorized: "메시지를 분기할 권한이 없습니다."
+        comments_not_found: "일부 선택한 메시지를 찾을 수 없습니다."
       batch_delete_confirm: 선택한 메시지를 삭제하시겠습니까?
       batch_delete_no_selection: 삭제할 메시지를 선택해주세요.
       batch_delete_not_found: 일부 선택한 메시지를 찾을 수 없습니다.

--- a/engines/collavre/config/routes.rb
+++ b/engines/collavre/config/routes.rb
@@ -88,6 +88,7 @@ Collavre::Engine.routes.draw do
         post :move
         delete :batch_destroy
         post :merge
+        post :branch
         get :commands
 
         resources :snapshots, only: [ :index ], module: :comments do

--- a/engines/collavre/db/migrate/20260409000000_add_source_topic_id_to_topics.rb
+++ b/engines/collavre/db/migrate/20260409000000_add_source_topic_id_to_topics.rb
@@ -1,0 +1,5 @@
+class AddSourceTopicIdToTopics < ActiveRecord::Migration[8.0]
+  def change
+    add_reference :topics, :source_topic, foreign_key: { to_table: :topics, on_delete: :nullify }, null: true
+  end
+end

--- a/engines/collavre/test/controllers/comments_controller_branch_test.rb
+++ b/engines/collavre/test/controllers/comments_controller_branch_test.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class CommentsControllerBranchTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:one)
+    @creative = creatives(:tshirt)
+    @user.update!(email_verified_at: Time.current)
+
+    @topic = Topic.create!(name: "Original", creative: @creative, user: @user)
+    @comment1 = @creative.comments.create!(content: "Hello", user: @user, topic: @topic)
+    @comment2 = @creative.comments.create!(content: "World", user: @user, topic: @topic)
+
+    post session_path, params: { email: @user.email, password: "password" }
+  end
+
+  test "branch comments into new topic" do
+    assert_difference "Topic.count", 1 do
+      assert_difference "Comment.count", 2 do
+        post branch_creative_comments_path(@creative),
+             params: { comment_ids: [ @comment1.id, @comment2.id ], topic_id: @topic.id },
+             as: :json
+      end
+    end
+
+    assert_response :created
+    json = JSON.parse(response.body)
+    assert json["success"]
+    assert_equal "Branch:Original", json["topic"]["name"]
+    assert_equal @topic.id, json["topic"]["source_topic_id"]
+
+    # Originals unchanged
+    assert_equal @topic.id, @comment1.reload.topic_id
+    assert_equal @topic.id, @comment2.reload.topic_id
+  end
+
+  test "branch from Main (nil topic_id)" do
+    main_comment = @creative.comments.create!(content: "Main msg", user: @user, topic_id: nil)
+
+    post branch_creative_comments_path(@creative),
+         params: { comment_ids: [ main_comment.id ] },
+         as: :json
+
+    assert_response :created
+    json = JSON.parse(response.body)
+    assert_match(/Branch:Main/, json["topic"]["name"])
+    assert_nil json["topic"]["source_topic_id"]
+  end
+
+  test "branch preserves quoted_comment_id mapping" do
+    @comment2.update!(quoted_comment_id: @comment1.id)
+
+    post branch_creative_comments_path(@creative),
+         params: { comment_ids: [ @comment1.id, @comment2.id ], topic_id: @topic.id },
+         as: :json
+
+    assert_response :created
+    new_topic = Topic.find(JSON.parse(response.body)["topic"]["id"])
+    new_comments = new_topic.comments.order(:created_at)
+    assert_equal 2, new_comments.size
+    # The second copied comment should quote the first copied comment, not the original
+    assert_equal new_comments.first.id, new_comments.second.quoted_comment_id
+  end
+
+  test "returns error for empty selection" do
+    post branch_creative_comments_path(@creative),
+         params: { comment_ids: [] },
+         as: :json
+
+    assert_response :unprocessable_entity
+    json = JSON.parse(response.body)
+    assert json["error"].present?
+  end
+
+  test "returns error for invalid comment ids" do
+    post branch_creative_comments_path(@creative),
+         params: { comment_ids: [ 99999 ], topic_id: @topic.id },
+         as: :json
+
+    assert_response :unprocessable_entity
+  end
+
+  test "branch creates unique topic names" do
+    # First branch
+    post branch_creative_comments_path(@creative),
+         params: { comment_ids: [ @comment1.id ], topic_id: @topic.id },
+         as: :json
+    assert_response :created
+    assert_equal "Branch:Original", JSON.parse(response.body)["topic"]["name"]
+
+    # Second branch — name should be unique
+    post branch_creative_comments_path(@creative),
+         params: { comment_ids: [ @comment2.id ], topic_id: @topic.id },
+         as: :json
+    assert_response :created
+    assert_equal "Branch:Original 2", JSON.parse(response.body)["topic"]["name"]
+  end
+end


### PR DESCRIPTION
## Summary
- Add "Branch" button to selection action bar — copies selected messages into a new topic
- New topic is named "Branch:{source topic name}" with auto-incrementing suffix for uniqueness
- `source_topic_id` column tracks parent-child relationship between topics (↗ icon in topic list)
- Copies preserve quoted_comment_id remapping and share image blobs without duplication

## Changes
- **Migration**: `add_reference :topics, :source_topic` with FK + nullify on delete
- **Model**: `Topic` gets `source_topic` / `branches` associations
- **Service**: `TopicBranchService` — copies comments, remaps quotes, shares images, broadcasts
- **Controller**: `batch_operations#branch` endpoint (`POST /creatives/:id/comments/branch`)
- **Frontend**: Branch button in selection bar, ↗ icon for branched topics, `branchComments` API
- **i18n**: en + ko for all new strings

## Test plan
- [x] Integration tests for branch operation (6 tests, all passing)
- [x] Full test suite passes (1609 runs, 0 failures)
- [x] Rubocop clean
- [x] i18n completeness check passes