### PR TITLE
feat: inline reply from inbox System topic

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -478,6 +478,11 @@ body.chat-fullscreen {
     white-space: nowrap;
 }
 
+.inbox-reply-btn {
+    font-size: var(--text-0) !important;
+    white-space: nowrap;
+}
+
 .comment-highlight {
     background: color-mix(in srgb, var(--color-active) 15%, transparent) !important;
     transition: background 0.3s ease;

--- a/engines/collavre/app/controllers/collavre/comments_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comments_controller.rb
@@ -181,6 +181,9 @@ module Collavre
         @comment.skip_dispatch = true
       end
       if @comment.save
+        # Cross-post inbox inline replies to the original creative/topic
+        InboxReplyService.call(@comment)
+
         # Dispatch is handled by Comment#after_create_commit callback
         @comment = Comment.with_attached_images.includes(:comment_reactions, :comment_versions, :selected_version).find(@comment.id)
         render partial: "collavre/comments/comment", locals: { comment: @comment, current_topic_id: current_topic_context }, status: :created

--- a/engines/collavre/app/controllers/collavre/topics_controller.rb
+++ b/engines/collavre/app/controllers/collavre/topics_controller.rb
@@ -17,12 +17,16 @@ module Collavre
                           .pick(:last_topic_id)
       end
 
+      system_topic_id = @creative.inbox? ? @creative.topics.find_by(name: Creative::SYSTEM_TOPIC_NAME)&.id : nil
+
       render json: {
         topics: active_topics.map { |t| topic_json(t) },
         archived_topics: archived_topics,
         can_manage: can_manage,
         can_create_topic: can_create_topic,
-        last_topic_id: last_topic_id
+        last_topic_id: last_topic_id,
+        is_inbox: @creative.inbox?,
+        system_topic_id: system_topic_id
       }
     end
 

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -93,6 +93,9 @@ export default class extends Controller {
 
     this.handleTopicChange = this.handleTopicChange.bind(this)
     this.element.addEventListener('comments--topics:change', this.handleTopicChange)
+
+    this.handleListLoaded = () => this._updateInboxReplyMode()
+    this.element.addEventListener('comments--list:loaded', this.handleListLoaded)
   }
 
   handleTopicChange(event) {
@@ -126,6 +129,7 @@ export default class extends Controller {
     this.formTarget.removeEventListener('drop', this.handleDrop)
     this.textareaTarget.removeEventListener('paste', this.handlePaste)
     this.element.removeEventListener('comments--topics:change', this.handleTopicChange)
+    this.element.removeEventListener('comments--list:loaded', this.handleListLoaded)
   }
 
   get listController() {

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -21,6 +21,7 @@ export default class extends Controller {
     'quoteIndicator',
     'quoteIndicatorText',
     'reviewQuotesContainer',
+    'quoteCancelButton',
   ]
 
   connect() {
@@ -956,10 +957,18 @@ export default class extends Controller {
         this.quoteIndicatorTextTarget.textContent = ''
         this._inboxReplyIndicator = false
       }
+      if (this.hasQuoteCancelButtonTarget) {
+        this.quoteCancelButtonTarget.style.display = ''
+      }
       return
     }
 
     this._inboxReplyMode = true
+
+    // Hide cancel button — inbox reply mode has no cancel action
+    if (this.hasQuoteCancelButtonTarget) {
+      this.quoteCancelButtonTarget.style.display = 'none'
+    }
 
     // Find the latest alarm (system message) in the comment list
     const latestAlarm = this._findLatestAlarm()

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -97,6 +97,9 @@ export default class extends Controller {
 
   handleTopicChange(event) {
     this.currentTopicId = event.detail.topicId
+    this._isInbox = event.detail.isInbox || false
+    this._systemTopicId = event.detail.systemTopicId || null
+    this._updateInboxReplyMode()
   }
 
 
@@ -196,6 +199,7 @@ export default class extends Controller {
     this.submitTarget.innerHTML = this.defaultSubmitHTML
     this.submitTarget.disabled = false
     this.submitTarget.classList.remove('review-submit-btn')
+    this.submitTarget.classList.remove('inbox-reply-btn')
     if (this.cancelTarget) this.cancelTarget.style.display = 'none'
     this.presenceController?.clearManualTypingMessage()
     this.clearImageAttachments()
@@ -928,6 +932,65 @@ export default class extends Controller {
     return this.element.dataset[key] || fallback
   }
 
+  // --- Inbox inline reply mode ---
+
+  get _isInboxSystemTopic() {
+    return this._isInbox && this._systemTopicId &&
+      String(this.currentTopicId) === String(this._systemTopicId)
+  }
+
+  _updateInboxReplyMode() {
+    if (!this._isInboxSystemTopic) {
+      this._inboxReplyMode = false
+      // Reset submit button if not in review mode
+      if (!this._reviewStore || this._reviewStore.isEmpty) {
+        this.submitTarget.innerHTML = this.defaultSubmitHTML
+        this.submitTarget.classList.remove('inbox-reply-btn')
+      }
+      if (this._inboxReplyIndicator) {
+        this.quoteIndicatorTarget.style.display = 'none'
+        this.quoteIndicatorTextTarget.textContent = ''
+        this._inboxReplyIndicator = false
+      }
+      return
+    }
+
+    this._inboxReplyMode = true
+
+    // Find the latest alarm (system message) in the comment list
+    const latestAlarm = this._findLatestAlarm()
+    if (latestAlarm) {
+      const alarmText = latestAlarm.textContent?.trim() || ''
+      const truncated = alarmText.length > 100 ? alarmText.substring(0, 100) + '…' : alarmText
+      this.quoteIndicatorTarget.style.display = ''
+      this.quoteIndicatorTextTarget.textContent = truncated
+      this._inboxReplyIndicator = true
+    }
+
+    // Change submit button to reply text
+    this.submitTarget.textContent = this._getI18nText('inboxReplyButton', 'Reply')
+    this.submitTarget.classList.add('inbox-reply-btn')
+  }
+
+  _findLatestAlarm() {
+    const list = document.getElementById('comments-list')
+    if (!list) return null
+
+    // System messages have data-user-id="" (no user)
+    const allComments = list.querySelectorAll('.comment-item')
+    let latest = null
+    for (const el of allComments) {
+      if (!el.dataset.userId) {
+        latest = el
+      }
+    }
+    // Get the content element from the latest system message
+    if (latest) {
+      return latest.querySelector('.comment-content')
+    }
+    return null
+  }
+
   cancelQuote() {
     this.quotedCommentIdTarget.value = ''
     this.quotedTextTarget.value = ''
@@ -937,6 +1000,10 @@ export default class extends Controller {
     this._renderReviewQuoteChips()
     this._updateSubmitButton()
     this.textareaTarget.placeholder = ''
+    // Re-apply inbox reply mode indicator if we're in inbox System topic
+    if (this._isInboxSystemTopic) {
+      requestAnimationFrame(() => this._updateInboxReplyMode())
+    }
   }
 
   renderCommentHtml(html, { replaceExisting = false } = {}) {

--- a/engines/collavre/app/javascript/controllers/comments/list_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/list_controller.js
@@ -186,7 +186,7 @@ export default class extends Controller {
       if (this.formController?.shouldAutoFocusOnOpen()) {
         this.formController.focusTextarea()
       }
-      this.formController?._updateInboxReplyMode?.()
+      this.element.dispatchEvent(new CustomEvent('comments--list:loaded', { bubbles: true }))
       this.markCommentsRead()
 
     }).catch((error) => {

--- a/engines/collavre/app/javascript/controllers/comments/list_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/list_controller.js
@@ -186,6 +186,7 @@ export default class extends Controller {
       if (this.formController?.shouldAutoFocusOnOpen()) {
         this.formController.focusTextarea()
       }
+      this.formController?._updateInboxReplyMode?.()
       this.markCommentsRead()
 
     }).catch((error) => {

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -76,6 +76,8 @@ export default class extends Controller {
                 this.canCreateTopic = canCreateTopic
                 this.archivedTopics = data.archived_topics || []
                 this.serverLastTopicId = data.last_topic_id ? String(data.last_topic_id) : ""
+                this.isInbox = !!data.is_inbox
+                this.systemTopicId = data.system_topic_id ? String(data.system_topic_id) : null
 
                 // Migrate localStorage to server if server has no value
                 this.migrateLocalStorage()
@@ -489,7 +491,7 @@ export default class extends Controller {
             this.clearNewMessageBadge(id)
         }
         // Dispatch event
-        this.dispatch("change", { detail: { topicId: id } })
+        this.dispatch("change", { detail: { topicId: id, isInbox: this.isInbox, systemTopicId: this.systemTopicId } })
     }
 
     showEditInput(topicEl, topicId) {

--- a/engines/collavre/app/services/collavre/inbox_reply_service.rb
+++ b/engines/collavre/app/services/collavre/inbox_reply_service.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module Collavre
+  # Handles inline replies from the inbox System topic.
+  # When a user sends a message in their inbox's #System topic,
+  # this service finds the most recent notification (alarm) and
+  # cross-posts the reply to the original creative/topic that
+  # the notification was about.
+  class InboxReplyService
+    def self.call(comment)
+      new(comment).call
+    end
+
+    def initialize(comment)
+      @comment = comment
+      @creative = comment.creative
+    end
+
+    def call
+      return unless eligible?
+
+      original = find_original_comment
+      return unless original
+
+      cross_post(original)
+    end
+
+    private
+
+    def eligible?
+      @creative.inbox? &&
+        @comment.topic&.name == Creative::SYSTEM_TOPIC_NAME &&
+        @comment.user_id.present? &&
+        !@comment.user&.ai_user?
+    end
+
+    # Find the most recent system notification in this topic before the user's comment.
+    # System notifications have user_id: nil and often a quoted_comment pointing
+    # to the original comment that triggered the notification.
+    def find_original_comment
+      latest_alarm = @creative.comments
+        .where(topic: @comment.topic, user_id: nil)
+        .where("comments.id < ?", @comment.id)
+        .order(created_at: :desc)
+        .first
+
+      return nil unless latest_alarm
+
+      latest_alarm.quoted_comment
+    end
+
+    def cross_post(original)
+      Comment.create!(
+        creative: original.creative,
+        topic: original.topic,
+        content: @comment.content,
+        user: @comment.user,
+        quoted_comment: original,
+        private: false
+      )
+    rescue StandardError => e
+      Rails.logger.error(
+        "[InboxReplyService] Failed to cross-post comment #{@comment.id}: " \
+        "#{e.class} #{e.message}"
+      )
+      nil
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/inbox_reply_service.rb
+++ b/engines/collavre/app/services/collavre/inbox_reply_service.rb
@@ -50,7 +50,15 @@ module Collavre
     end
 
     def cross_post(original)
-      Comment.create!(
+      unless original.creative.has_permission?(@comment.user, :feedback)
+        Rails.logger.warn(
+          "[InboxReplyService] User #{@comment.user_id} lacks :feedback permission " \
+          "on creative #{original.creative_id}, skipping cross-post"
+        )
+        return nil
+      end
+
+      cross_posted = Comment.create!(
         creative: original.creative,
         topic: original.topic,
         content: @comment.content,
@@ -58,12 +66,22 @@ module Collavre
         quoted_comment: original,
         private: false
       )
+
+      copy_images(cross_posted) if @comment.images.attached?
+
+      cross_posted
     rescue StandardError => e
       Rails.logger.error(
         "[InboxReplyService] Failed to cross-post comment #{@comment.id}: " \
         "#{e.class} #{e.message}"
       )
       nil
+    end
+
+    def copy_images(target)
+      @comment.images.each do |image|
+        target.images.attach(image.blob)
+      end
     end
   end
 end

--- a/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
@@ -121,7 +121,7 @@
     <input type="hidden" name="comment[quoted_text]" data-comments--form-target="quotedText" value="" />
     <div class="comment-quote-indicator" data-comments--form-target="quoteIndicator" style="display:none;">
       <span class="comment-quote-indicator-text" data-comments--form-target="quoteIndicatorText"></span>
-      <button type="button" class="comment-quote-cancel" data-action="click->comments--form#cancelQuote" title="<%= t('app.cancel') %>">&times;</button>
+      <button type="button" class="comment-quote-cancel" data-comments--form-target="quoteCancelButton" data-action="click->comments--form#cancelQuote" title="<%= t('app.cancel') %>">&times;</button>
     </div>
     <div class="review-quotes-container" data-comments--form-target="reviewQuotesContainer" style="display:none;"></div>
     <textarea class="shared-input-surface" name="comment[content]" data-comments--form-target="textarea" data-comments--presence-target="textarea" data-comments--mention-menu-target="textarea" rows="2" enterkeyhint="send"></textarea>

--- a/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
@@ -57,7 +57,8 @@
      data-review-type-question="❓"
      data-review-type-review-label="<%= t('collavre.comments.review_type_review') %>"
      data-review-type-question-label="<%= t('collavre.comments.review_type_question') %>"
-     data-remove-from-history-label="<%= t('collavre.comments.remove_from_history') %>">
+     data-remove-from-history-label="<%= t('collavre.comments.remove_from_history') %>"
+     data-inbox-reply-button="<%= t('collavre.comments.inbox_reply_button') %>">
   <div class="resize-handle resize-handle-left" data-comments--popup-target="leftHandle"></div>
   <div class="resize-handle resize-handle-right" data-comments--popup-target="rightHandle"></div>
   <div class="comments-popup-header" data-comments--popup-target="header">

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -88,6 +88,7 @@ en:
       navigate_forward: Next chat
       recent_chats: Recent chats
       remove_from_history: Remove from history
+      inbox_reply_button: Reply
       replace_button: Replace
       move_no_selection: Select at least one message to move.
       move_error: Unable to move messages.

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -85,6 +85,7 @@ ko:
       navigate_forward: 다음 채팅
       recent_chats: 최근 채팅
       remove_from_history: 히스토리에서 제거
+      inbox_reply_button: 답글
       replace_button: 바꾸기
       move_no_selection: 이동할 메시지를 선택해주세요.
       move_error: 메시지를 이동할 수 없습니다.

--- a/engines/collavre/test/services/collavre/inbox_reply_service_test.rb
+++ b/engines/collavre/test/services/collavre/inbox_reply_service_test.rb
@@ -1,0 +1,116 @@
+require "test_helper"
+
+module Collavre
+  class InboxReplyServiceTest < ActiveSupport::TestCase
+    setup do
+      @user = users(:one)
+      @other_user = users(:two)
+      @creative = creatives(:tshirt)
+
+      # Ensure presence cache is clear so notifications fire
+      Rails.cache.delete(CommentPresenceStore.key(@creative.id))
+
+      # Create a comment on the creative that triggers an inbox notification
+      @original_comment = Comment.create!(
+        creative: @creative,
+        user: @other_user,
+        content: "Original message",
+        skip_dispatch: true
+      )
+
+      # Set up inbox with system topic
+      @inbox = Creative.inbox_for(@user)
+      @system_topic = @inbox.system_topic(fallback_user: @user)
+
+      # Simulate a notification alarm (system message with quoted_comment)
+      @alarm = Comment.create!(
+        creative: @inbox,
+        topic: @system_topic,
+        content: 'Test User added "Original message" to "T-Shirt".',
+        user: nil,
+        skip_default_user: true,
+        quoted_comment: @original_comment
+      )
+    end
+
+    test "cross-posts reply to original creative and topic" do
+      reply = Comment.create!(
+        creative: @inbox,
+        topic: @system_topic,
+        content: "My reply from inbox",
+        user: @user,
+        skip_dispatch: true
+      )
+
+      assert_difference("Comment.count", 1) do
+        InboxReplyService.call(reply)
+      end
+
+      cross_posted = @creative.comments.where(user: @user, content: "My reply from inbox").last
+      assert cross_posted, "Expected cross-posted comment in original creative"
+      assert_nil cross_posted.topic_id, "Topic should match original (nil)"
+      assert_equal @original_comment.id, cross_posted.quoted_comment_id
+    end
+
+    test "does not cross-post for non-inbox creatives" do
+      reply = Comment.create!(
+        creative: @creative,
+        content: "Normal comment",
+        user: @user,
+        skip_dispatch: true
+      )
+
+      assert_no_difference("Comment.count") do
+        InboxReplyService.call(reply)
+      end
+    end
+
+    test "does not cross-post for non-System topic" do
+      other_topic = @inbox.topics.create!(name: "Other", user: @user)
+      reply = Comment.create!(
+        creative: @inbox,
+        topic: other_topic,
+        content: "Not a system topic reply",
+        user: @user,
+        skip_dispatch: true
+      )
+
+      assert_no_difference("Comment.count") do
+        InboxReplyService.call(reply)
+      end
+    end
+
+    test "does not cross-post when no alarm exists" do
+      # Remove all system messages (including auto-created notifications)
+      @inbox.comments.where(topic: @system_topic, user_id: nil).destroy_all
+
+      reply = Comment.create!(
+        creative: @inbox,
+        topic: @system_topic,
+        content: "Reply with no alarm",
+        user: @user,
+        skip_dispatch: true
+      )
+
+      assert_no_difference("Comment.count") do
+        InboxReplyService.call(reply)
+      end
+    end
+
+    test "does not cross-post when alarm has no quoted_comment" do
+      @alarm.update!(quoted_comment: nil)
+
+      reply = Comment.create!(
+        creative: @inbox,
+        topic: @system_topic,
+        content: "Reply to alarm without quote",
+        user: @user,
+        skip_dispatch: true
+      )
+
+      assert_no_difference("Comment.count") do
+        InboxReplyService.call(reply)
+      end
+    end
+  end
+end

--- a/engines/collavre/test/services/collavre/inbox_reply_service_test.rb
+++ b/engines/collavre/test/services/collavre/inbox_reply_service_test.rb
@@ -97,6 +97,35 @@ module Collavre
       end
     end
 
+    test "does not cross-post when user lacks feedback permission on original creative" do
+      # Use a third user who has no permission on @creative
+      third_user = users(:three)
+      third_inbox = Creative.inbox_for(third_user)
+      third_system_topic = third_inbox.system_topic(fallback_user: third_user)
+
+      # Simulate alarm in third user's inbox
+      alarm = Comment.create!(
+        creative: third_inbox,
+        topic: third_system_topic,
+        content: 'Notification about original',
+        user: nil,
+        skip_default_user: true,
+        quoted_comment: @original_comment
+      )
+
+      reply = Comment.create!(
+        creative: third_inbox,
+        topic: third_system_topic,
+        content: "Reply from unauthorized user",
+        user: third_user,
+        skip_dispatch: true
+      )
+
+      assert_no_difference("Comment.count") do
+        InboxReplyService.call(reply)
+      end
+    end
+
     test "does not cross-post when alarm has no quoted_comment" do
       @alarm.update!(quoted_comment: nil)
 


### PR DESCRIPTION
## Summary
- When a user sends a message in their inbox's #System topic, it is automatically treated as a reply to the most recent notification alarm
- The reply is cross-posted to the original creative/topic that triggered the notification, maintaining context via `quoted_comment`
- Submit button changes to "답글" (Reply) when in inbox System topic, with a quote indicator showing the alarm preview
- No new UI components needed — leverages existing review UI and quote indicator

## Changes
- **InboxReplyService** — new service that finds the latest alarm and cross-posts the reply to the original creative/topic
- **CommentsController#create** — integrates `InboxReplyService.call` after comment save
- **TopicsController#index** — exposes `is_inbox` and `system_topic_id` in JSON response
- **form_controller.js** — inbox reply mode: detects System topic, shows quote indicator, changes submit button text
- **topics_controller.js** — passes `isInbox` and `systemTopicId` in topic change event
- **i18n** — en: "Reply", ko: "답글"
- **CSS** — `inbox-reply-btn` styling

## Test plan
- [x] Unit tests for InboxReplyService (5 tests, all passing)
- [x] Full test suite passes (Rubocop + all tests via pre-push hook)
- [ ] Manual QA: send message in inbox #System topic → verify cross-post appears in original topic
- [ ] Manual QA: verify submit button shows "답글" in System topic and reverts in other topics