### PR TITLE
feat: replace routing expression with trigger type selector

### DIFF
--- a/engines/collavre/app/javascript/controllers/agent_trigger_controller.js
+++ b/engines/collavre/app/javascript/controllers/agent_trigger_controller.js
@@ -1,0 +1,90 @@
+import { Controller } from '@hotwired/stimulus'
+
+// Maps trigger type radio buttons to routing_expression values.
+// Shows/hides keyword input and advanced expression textarea based on selection.
+export default class extends Controller {
+  static targets = ['hiddenField', 'keywordInput', 'keywordGroup', 'advancedGroup', 'advancedInput']
+
+  static values = {
+    currentExpression: String
+  }
+
+  connect() {
+    this.detectTriggerType()
+    this.updateVisibility()
+  }
+
+  // Called when a radio button changes
+  change() {
+    this.updateVisibility()
+    this.updateExpression()
+  }
+
+  // Called when keyword input changes
+  keywordChanged() {
+    this.updateExpression()
+  }
+
+  // Called when advanced expression changes
+  advancedChanged() {
+    this.hiddenFieldTarget.value = this.advancedInputTarget.value
+  }
+
+  get selectedType() {
+    const checked = this.element.querySelector('input[name="trigger_type"]:checked')
+    return checked?.value || 'mention'
+  }
+
+  detectTriggerType() {
+    const expr = (this.currentExpressionValue || '').trim()
+    if (!expr || expr === 'chat.mentioned_user.id == agent.id') {
+      this.selectRadio('mention')
+    } else if (expr === 'event_name == "comment_created"') {
+      this.selectRadio('auto')
+    } else {
+      const keywordMatch = expr.match(/^chat\.content\s+contains\s+"([^"]*)"$/)
+      if (keywordMatch) {
+        this.selectRadio('keyword')
+        this.keywordInputTarget.value = keywordMatch[1]
+      } else {
+        this.selectRadio('advanced')
+        this.advancedInputTarget.value = expr
+      }
+    }
+  }
+
+  selectRadio(value) {
+    const radio = this.element.querySelector(`input[name="trigger_type"][value="${value}"]`)
+    if (radio) radio.checked = true
+  }
+
+  updateVisibility() {
+    const type = this.selectedType
+    this.keywordGroupTarget.style.display = type === 'keyword' ? '' : 'none'
+    this.advancedGroupTarget.style.display = type === 'advanced' ? '' : 'none'
+  }
+
+  updateExpression() {
+    const type = this.selectedType
+    let expression = ''
+
+    switch (type) {
+      case 'auto':
+        expression = 'event_name == "comment_created"'
+        break
+      case 'mention':
+        expression = 'chat.mentioned_user.id == agent.id'
+        break
+      case 'keyword': {
+        const keyword = this.keywordInputTarget.value.trim()
+        expression = keyword ? `chat.content contains "${keyword}"` : ''
+        break
+      }
+      case 'advanced':
+        expression = this.advancedInputTarget.value
+        break
+    }
+
+    this.hiddenFieldTarget.value = expression
+  }
+}

--- a/engines/collavre/app/javascript/controllers/agent_trigger_controller.js
+++ b/engines/collavre/app/javascript/controllers/agent_trigger_controller.js
@@ -22,6 +22,10 @@ export default class extends Controller {
 
   // Called when keyword input changes
   keywordChanged() {
+    // Strip double quotes to prevent Liquid injection
+    const input = this.keywordInputTarget
+    const sanitized = input.value.replace(/"/g, '')
+    if (input.value !== sanitized) input.value = sanitized
     this.updateExpression()
   }
 
@@ -76,7 +80,7 @@ export default class extends Controller {
         expression = 'chat.mentioned_user.id == agent.id'
         break
       case 'keyword': {
-        const keyword = this.keywordInputTarget.value.trim()
+        const keyword = this.keywordInputTarget.value.trim().replace(/"/g, '')
         expression = keyword ? `chat.content contains "${keyword}"` : ''
         break
       }

--- a/engines/collavre/app/javascript/controllers/index.js
+++ b/engines/collavre/app/javascript/controllers/index.js
@@ -1,5 +1,6 @@
 // Collavre Engine Controllers
 // Import all controllers
+import AgentTriggerController from "./agent_trigger_controller"
 import PopupMenuController from "./popup_menu_controller"
 import ProgressFilterController from "./progress_filter_controller"
 import CreativesImportController from "./creatives/import_controller"
@@ -35,6 +36,7 @@ import SearchPopupController from "./search_popup_controller"
 
 // Export all controllers
 export {
+  AgentTriggerController,
   PopupMenuController,
   ProgressFilterController,
   CreativesImportController,
@@ -70,6 +72,7 @@ export {
 
 // Registration function for use with a Stimulus application
 export function registerControllers(application) {
+  application.register("agent-trigger", AgentTriggerController)
   application.register("popup-menu", PopupMenuController)
   application.register("progress-filter", ProgressFilterController)
   application.register("creatives--import", CreativesImportController)

--- a/engines/collavre/app/views/collavre/users/_trigger_field.html.erb
+++ b/engines/collavre/app/views/collavre/users/_trigger_field.html.erb
@@ -1,0 +1,51 @@
+<%# Shared trigger type selector for AI agent forms.
+     Locals:
+       form            – the form builder
+       routing_expression – current expression value (String or nil)
+%>
+<% current_expression = local_assigns.fetch(:routing_expression, nil).to_s %>
+
+<div class="form-group" data-controller="agent-trigger" data-agent-trigger-current-expression-value="<%= current_expression %>">
+  <label class="form-label"><%= t('collavre.users.new_ai.trigger_label') %></label>
+
+  <div class="form-check mb-1">
+    <input type="radio" name="trigger_type" value="auto" id="trigger_auto" class="form-check-input"
+           data-action="change->agent-trigger#change">
+    <label class="form-check-label" for="trigger_auto"><%= t('collavre.users.new_ai.trigger_auto') %></label>
+    <small class="form-text text-muted d-block"><%= t('collavre.users.new_ai.trigger_auto_help') %></small>
+  </div>
+
+  <div class="form-check mb-1">
+    <input type="radio" name="trigger_type" value="mention" id="trigger_mention" class="form-check-input"
+           data-action="change->agent-trigger#change">
+    <label class="form-check-label" for="trigger_mention"><%= t('collavre.users.new_ai.trigger_mention') %></label>
+    <small class="form-text text-muted d-block"><%= t('collavre.users.new_ai.trigger_mention_help') %></small>
+  </div>
+
+  <div class="form-check mb-1">
+    <input type="radio" name="trigger_type" value="keyword" id="trigger_keyword" class="form-check-input"
+           data-action="change->agent-trigger#change">
+    <label class="form-check-label" for="trigger_keyword"><%= t('collavre.users.new_ai.trigger_keyword') %></label>
+    <small class="form-text text-muted d-block"><%= t('collavre.users.new_ai.trigger_keyword_help') %></small>
+  </div>
+
+  <div class="ml-4 mt-1 mb-2" style="display: none;" data-agent-trigger-target="keywordGroup">
+    <input type="text" class="stacked-form-control" data-agent-trigger-target="keywordInput"
+           data-action="input->agent-trigger#keywordChanged"
+           placeholder="<%= t('collavre.users.new_ai.trigger_keyword_placeholder') %>">
+  </div>
+
+  <div class="form-check mb-1">
+    <input type="radio" name="trigger_type" value="advanced" id="trigger_advanced" class="form-check-input"
+           data-action="change->agent-trigger#change">
+    <label class="form-check-label" for="trigger_advanced"><%= t('collavre.users.new_ai.trigger_advanced') %></label>
+    <small class="form-text text-muted d-block"><%= t('collavre.users.new_ai.trigger_advanced_help') %></small>
+  </div>
+
+  <div class="ml-4 mt-1 mb-2" style="display: none;" data-agent-trigger-target="advancedGroup">
+    <textarea class="stacked-form-control" rows="2" data-agent-trigger-target="advancedInput"
+              data-action="input->agent-trigger#advancedChanged"></textarea>
+  </div>
+
+  <%= form.hidden_field :routing_expression, value: current_expression, data: { agent_trigger_target: "hiddenField" } %>
+</div>

--- a/engines/collavre/app/views/collavre/users/edit_ai.html.erb
+++ b/engines/collavre/app/views/collavre/users/edit_ai.html.erb
@@ -12,11 +12,7 @@
     <%= form.text_area :system_prompt, required: true, class: "stacked-form-control", rows: 5 %>
   </div>
 
-  <div class="form-group">
-    <%= form.label :routing_expression, "Routing Expression (Liquid)" %>
-    <%= form.text_area :routing_expression, class: "stacked-form-control", rows: 2, placeholder: "chat.mentioned_user.id == agent.id" %>
-    <small class="form-text text-muted">Liquid expression to determine if this agent should handle an event. Example: <code>chat.mentioned_user.id == agent.id</code></small>
-  </div>
+  <%= render "collavre/users/trigger_field", form: form, routing_expression: @user.routing_expression %>
 
   <div class="form-group">
     <%= form.label :llm_vendor, t('collavre.users.new_ai.vendor_label', default: 'LLM Provider') %>

--- a/engines/collavre/app/views/collavre/users/new_ai.html.erb
+++ b/engines/collavre/app/views/collavre/users/new_ai.html.erb
@@ -26,11 +26,7 @@
     <%= form.text_area :system_prompt, required: true, class: "stacked-form-control", rows: 5, value: @copy_source&.system_prompt || AiClient::SYSTEM_INSTRUCTIONS %>
   </div>
 
-  <div class="form-group">
-    <%= form.label :routing_expression, "Routing Expression (Liquid)" %>
-    <%= form.text_area :routing_expression, class: "stacked-form-control", rows: 2, placeholder: "chat.mentioned_user.id == agent.id", value: @copy_source&.routing_expression %>
-    <small class="form-text text-muted">Liquid expression to determine if this agent should handle an event. Example: <code>chat.mentioned_user.id == agent.id</code></small>
-  </div>
+  <%= render "collavre/users/trigger_field", form: form, routing_expression: @copy_source&.routing_expression %>
 
   <div class="form-group">
     <%= form.label :llm_vendor, t('collavre.users.new_ai.vendor_label', default: 'LLM Provider') %>

--- a/engines/collavre/config/locales/users.en.yml
+++ b/engines/collavre/config/locales/users.en.yml
@@ -33,6 +33,16 @@ en:
         searchable_help: When enabled, others can find and mention this AI by name.
         submit: Add AI Agent
         tools_note: You can check and test available tools after creating the agent.
+        trigger_label: Trigger
+        trigger_auto: Auto-respond
+        trigger_auto_help: Agent responds to all new comments automatically.
+        trigger_mention: Respond on mention
+        trigger_mention_help: Agent responds only when @mentioned by name.
+        trigger_keyword: Respond on keyword
+        trigger_keyword_help: Agent responds when message contains a specific keyword.
+        trigger_keyword_placeholder: Enter keyword
+        trigger_advanced: Advanced (Liquid expression)
+        trigger_advanced_help: "Write a custom Liquid expression. Example: chat.content contains \"help\" and event_name == \"comment_created\""
       create_ai:
         success: AI User created successfully.
       copy_ai:

--- a/engines/collavre/config/locales/users.ko.yml
+++ b/engines/collavre/config/locales/users.ko.yml
@@ -31,6 +31,16 @@ ko:
         searchable_help: 활성화하면 다른 사용자가 이름으로 이 AI를 찾고 멘션할 수 있습니다.
         submit: AI 에이전트 추가
         tools_note: 에이전트 생성 후 사용 가능한 도구를 확인하고 테스트할 수 있습니다.
+        trigger_label: 트리거
+        trigger_auto: 자동 응답
+        trigger_auto_help: 새 댓글에 자동으로 응답합니다.
+        trigger_mention: 멘션으로 호출
+        trigger_mention_help: "@멘션되었을 때만 응답합니다."
+        trigger_keyword: 특정 메시지 포함
+        trigger_keyword_help: 메시지에 특정 키워드가 포함되면 응답합니다.
+        trigger_keyword_placeholder: 키워드 입력
+        trigger_advanced: 고급 (Liquid 표현식)
+        trigger_advanced_help: "직접 Liquid 표현식을 작성합니다. 예: chat.content contains \"help\" and event_name == \"comment_created\""
       create_ai:
         success: AI 에이전트가 생성되었습니다.
       copy_ai:

--- a/engines/collavre/test/controllers/users_controller_ai_test.rb
+++ b/engines/collavre/test/controllers/users_controller_ai_test.rb
@@ -86,6 +86,28 @@ class UsersControllerAiTest < ActionDispatch::IntegrationTest
     assert_not_equal "Hacked Bot Name", @ai_user.name
   end
 
+  test "should save routing_expression with keyword trigger" do
+    patch update_ai_user_url(@ai_user), params: {
+      user: {
+        routing_expression: 'chat.content contains "help"'
+      }
+    }
+    assert_redirected_to edit_ai_user_path(@ai_user)
+    @ai_user.reload
+    assert_equal 'chat.content contains "help"', @ai_user.routing_expression
+  end
+
+  test "should save routing_expression with auto trigger" do
+    patch update_ai_user_url(@ai_user), params: {
+      user: {
+        routing_expression: 'event_name == "comment_created"'
+      }
+    }
+    assert_redirected_to edit_ai_user_path(@ai_user)
+    @ai_user.reload
+    assert_equal 'event_name == "comment_created"', @ai_user.routing_expression
+  end
+
   test "should handle validation errors in update_ai" do
     patch update_ai_user_url(@ai_user), params: {
       user: {


### PR DESCRIPTION
## Summary
- Replace the raw Liquid `routing_expression` textarea with a user-friendly trigger type selector (radio buttons)
- Three main options: **Auto-respond**, **Respond on mention**, **Respond on keyword** — plus an **Advanced** option for power users who need custom Liquid expressions
- Shared `_trigger_field.html.erb` partial used in both `new_ai` and `edit_ai` forms
- Stimulus controller (`agent_trigger_controller.js`) handles visibility toggling, expression generation, and reverse-mapping existing expressions back to the correct radio option
- i18n translations added for both `en` and `ko`

## Test plan
- [ ] Create a new AI agent with each trigger type (auto, mention, keyword, advanced)
- [ ] Verify the correct `routing_expression` is saved for each type
- [ ] Edit an existing agent — verify the saved expression maps back to the correct radio option
- [ ] Enter a keyword and verify the expression updates to `chat.content contains "keyword"`
- [ ] Switch between trigger types and verify the hidden field updates correctly
- [ ] Test with an existing agent that has a custom Liquid expression — should show "Advanced" selected