### PR TITLE
feat: add CSV and Excel download for tables in chat messages

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -352,6 +352,68 @@ body.chat-fullscreen {
     margin: 0;
 }
 
+/* Table styling */
+.comment-content table {
+    border-collapse: collapse;
+    width: 100%;
+    font-size: 0.85em;
+    margin: 0;
+}
+
+.comment-content table th,
+.comment-content table td {
+    border: 1px solid var(--color-border);
+    padding: 0.3em 0.6em;
+    text-align: left;
+    white-space: nowrap;
+}
+
+.comment-content table th {
+    background: var(--color-section-bg);
+    font-weight: 600;
+}
+
+.comment-content table tr:hover td {
+    background: color-mix(in srgb, var(--color-section-bg) 40%, transparent);
+}
+
+/* Table download wrapper */
+.table-download-wrapper {
+    position: relative;
+    overflow-x: auto;
+    margin: 0.4em 0;
+}
+
+.table-download-toolbar {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.3em;
+    padding: 0.15em 0;
+    opacity: 0;
+    transition: opacity 0.15s ease;
+}
+
+.table-download-wrapper:hover .table-download-toolbar {
+    opacity: 1;
+}
+
+.table-download-btn {
+    background: none;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-2);
+    color: var(--color-muted);
+    font-size: 0.75em;
+    padding: 0.15em 0.5em;
+    cursor: pointer;
+    line-height: 1.4;
+    transition: color 0.15s ease, border-color 0.15s ease;
+}
+
+.table-download-btn:hover {
+    color: var(--color-active);
+    border-color: var(--color-active);
+}
+
 /* Quote indicator in form */
 .comment-quote-indicator {
     display: flex;

--- a/engines/collavre/app/javascript/controllers/comment_controller.js
+++ b/engines/collavre/app/javascript/controllers/comment_controller.js
@@ -1,5 +1,6 @@
 import { Controller } from "@hotwired/stimulus"
 import { renderCommentMarkdown } from '../lib/utils/markdown'
+import { addTableDownloadButtons } from '../lib/utils/table_download'
 import CommonPopup from '../lib/common_popup'
 
 // Global tracker: persists streaming state across Turbo replacements
@@ -110,6 +111,7 @@ export default class extends Controller {
           this._resetStreamingTimeout()
         } else {
           contentElement.innerHTML = renderCommentMarkdown(text)
+          addTableDownloadButtons(contentElement)
           contentElement.classList.remove('streaming')
           if (this._isStreaming) this._cleanupStreaming()
         }

--- a/engines/collavre/app/javascript/lib/utils/markdown.js
+++ b/engines/collavre/app/javascript/lib/utils/markdown.js
@@ -1,5 +1,6 @@
 import { marked } from 'marked'
 import DOMPurify from 'dompurify'
+import { addTableDownloadButtons } from './table_download'
 import hljs from 'highlight.js/lib/core'
 
 // Register only commonly used languages to keep the bundle small
@@ -129,5 +130,6 @@ export function renderMarkdownInContainer(container) {
     if (element.dataset.rendered === 'true') return
     element.innerHTML = renderCommentMarkdown(element.textContent)
     element.dataset.rendered = 'true'
+    addTableDownloadButtons(element)
   })
 }

--- a/engines/collavre/app/javascript/lib/utils/table_download.js
+++ b/engines/collavre/app/javascript/lib/utils/table_download.js
@@ -1,0 +1,163 @@
+/**
+ * Table Download Utility
+ *
+ * Detects rendered <table> elements within comment content and adds
+ * download buttons (CSV / Excel) above each table.
+ */
+
+function getI18n(commentEl) {
+  const popup = commentEl.closest('#comments-popup')
+  return {
+    csv: popup?.dataset?.tableDownloadCsvText || 'CSV',
+    excel: popup?.dataset?.tableDownloadExcelText || 'Excel',
+  }
+}
+
+function parseTable(table) {
+  const rows = []
+  table.querySelectorAll('tr').forEach((tr) => {
+    const cells = []
+    tr.querySelectorAll('th, td').forEach((cell) => {
+      cells.push(cell.textContent.trim())
+    })
+    rows.push(cells)
+  })
+  return rows
+}
+
+function escapeCsvCell(value) {
+  if (/[",\n\r]/.test(value)) {
+    return `"${value.replace(/"/g, '""')}"`
+  }
+  return value
+}
+
+function downloadBlob(blob, filename) {
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  document.body.appendChild(a)
+  a.click()
+  document.body.removeChild(a)
+  URL.revokeObjectURL(url)
+}
+
+function downloadCsv(rows, filename) {
+  const csv = rows.map((row) => row.map(escapeCsvCell).join(',')).join('\r\n')
+  // BOM for Excel UTF-8 compatibility
+  const blob = new Blob(['\ufeff' + csv], { type: 'text/csv;charset=utf-8' })
+  downloadBlob(blob, filename)
+}
+
+function downloadExcel(rows, filename) {
+  const escapeXml = (s) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
+
+  const headerRow = rows[0] || []
+  const dataRows = rows.slice(1)
+
+  let xml = '<?xml version="1.0" encoding="UTF-8"?>\n'
+  xml += '<?mso-application progid="Excel.Sheet"?>\n'
+  xml += '<Workbook xmlns="urn:schemas-microsoft-com:office:spreadsheet"\n'
+  xml += '  xmlns:ss="urn:schemas-microsoft-com:office:spreadsheet">\n'
+  xml += '  <Styles>\n'
+  xml += '    <Style ss:ID="header"><Font ss:Bold="1"/></Style>\n'
+  xml += '  </Styles>\n'
+  xml += '  <Worksheet ss:Name="Sheet1">\n'
+  xml += '    <Table>\n'
+
+  // Header row
+  if (headerRow.length) {
+    xml += '      <Row>\n'
+    headerRow.forEach((cell) => {
+      xml += `        <Cell ss:StyleID="header"><Data ss:Type="String">${escapeXml(cell)}</Data></Cell>\n`
+    })
+    xml += '      </Row>\n'
+  }
+
+  // Data rows
+  dataRows.forEach((row) => {
+    xml += '      <Row>\n'
+    row.forEach((cell) => {
+      const type = isNaN(cell) || cell === '' ? 'String' : 'Number'
+      xml += `        <Cell><Data ss:Type="${type}">${escapeXml(cell)}</Data></Cell>\n`
+    })
+    xml += '      </Row>\n'
+  })
+
+  xml += '    </Table>\n'
+  xml += '  </Worksheet>\n'
+  xml += '</Workbook>'
+
+  const blob = new Blob([xml], { type: 'application/vnd.ms-excel;charset=utf-8' })
+  downloadBlob(blob, filename)
+}
+
+function generateFilename(table, index) {
+  // Try to use the first header cell as a hint for the filename
+  const firstHeader = table.querySelector('th')
+  if (firstHeader) {
+    const hint = firstHeader.textContent.trim().slice(0, 30).replace(/[^a-zA-Z0-9가-힣_-]/g, '_')
+    if (hint) return `table_${hint}`
+  }
+  return `table_${index + 1}`
+}
+
+function createToolbar(table, index, i18n) {
+  const toolbar = document.createElement('div')
+  toolbar.className = 'table-download-toolbar'
+
+  const csvBtn = document.createElement('button')
+  csvBtn.type = 'button'
+  csvBtn.className = 'table-download-btn'
+  csvBtn.textContent = `\u2913 ${i18n.csv}`
+  csvBtn.addEventListener('click', (e) => {
+    e.preventDefault()
+    e.stopPropagation()
+    const rows = parseTable(table)
+    const filename = generateFilename(table, index)
+    downloadCsv(rows, `${filename}.csv`)
+  })
+
+  const excelBtn = document.createElement('button')
+  excelBtn.type = 'button'
+  excelBtn.className = 'table-download-btn'
+  excelBtn.textContent = `\u2913 ${i18n.excel}`
+  excelBtn.addEventListener('click', (e) => {
+    e.preventDefault()
+    e.stopPropagation()
+    const rows = parseTable(table)
+    const filename = generateFilename(table, index)
+    downloadExcel(rows, `${filename}.xls`)
+  })
+
+  toolbar.appendChild(csvBtn)
+  toolbar.appendChild(excelBtn)
+  return toolbar
+}
+
+/**
+ * Scans the given content element for <table> tags and adds download
+ * toolbars. Call this after markdown has been rendered into HTML.
+ */
+export function addTableDownloadButtons(contentElement) {
+  if (!contentElement) return
+
+  const tables = contentElement.querySelectorAll('table')
+  if (!tables.length) return
+
+  const i18n = getI18n(contentElement)
+
+  tables.forEach((table, index) => {
+    // Skip if already wrapped
+    if (table.parentElement?.classList.contains('table-download-wrapper')) return
+
+    const wrapper = document.createElement('div')
+    wrapper.className = 'table-download-wrapper'
+
+    const toolbar = createToolbar(table, index, i18n)
+    table.parentNode.insertBefore(wrapper, table)
+    wrapper.appendChild(toolbar)
+    wrapper.appendChild(table)
+  })
+}

--- a/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
@@ -59,7 +59,9 @@
      data-review-type-review-label="<%= t('collavre.comments.review_type_review') %>"
      data-review-type-question-label="<%= t('collavre.comments.review_type_question') %>"
      data-remove-from-history-label="<%= t('collavre.comments.remove_from_history') %>"
-     data-inbox-reply-button="<%= t('collavre.comments.inbox_reply_button') %>">
+     data-inbox-reply-button="<%= t('collavre.comments.inbox_reply_button') %>"
+     data-table-download-csv-text="<%= t('collavre.comments.table_download.csv') %>"
+     data-table-download-excel-text="<%= t('collavre.comments.table_download.excel') %>">
   <div class="resize-handle resize-handle-left" data-comments--popup-target="leftHandle"></div>
   <div class="resize-handle resize-handle-right" data-comments--popup-target="rightHandle"></div>
   <div class="comments-popup-header" data-comments--popup-target="header">

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -196,6 +196,9 @@ en:
       stop_agent: Stop
       read_by: Read by %{name}
       activity_logs_summary: Activity Logs
+      table_download:
+        csv: CSV
+        excel: Excel
       lightbox:
         close: Close
         previous: Previous

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -193,6 +193,9 @@ ko:
       stop_agent: 중지
       read_by: "%{name} 님이 읽음"
       activity_logs_summary: 활동 기록
+      table_download:
+        csv: CSV
+        excel: Excel
       lightbox:
         close: 닫기
         previous: 이전


### PR DESCRIPTION
## Summary
- Detect rendered `<table>` elements in chat message content and add download buttons (CSV / Excel) on hover
- CSV export includes BOM for UTF-8/Korean compatibility when opening in Excel
- Excel export uses XML Spreadsheet format (no external library required)
- Fully client-side — no server roundtrip needed

## Changes
- `table_download.js`: Table detection, CSV/Excel generation, download toolbar
- `comment_controller.js`: Integrate `addTableDownloadButtons` after markdown rendering
- `comments_popup.css`: Table styling + hover-reveal download toolbar
- `_comments_popup.html.erb`: i18n data attributes for button labels
- `comments.en.yml` / `comments.ko.yml`: en/ko translations

## Test plan
- [x] Rubocop passed (794 files, no offenses)
- [x] All tests passed (1617 runs, 5140 assertions, 0 failures)
- [x] i18n keys present in both en and ko
- [ ] Manual: Send a message with a markdown table → verify download buttons appear on hover
- [ ] Manual: Click CSV → opens in Excel with correct Korean encoding
- [ ] Manual: Click Excel → opens in Excel with bold headers and number detection
- [ ] Manual: Multiple tables in one message → each gets independent download buttons