### PR TITLE
feat(collavre): add tool command for meta_tool support

### DIFF
--- a/skills/collavre/SKILL.md
+++ b/skills/collavre/SKILL.md
@@ -74,6 +74,16 @@ ops.json format:
 ]
 ```
 
+### Discover & run tools (meta)
+```bash
+collavre tool list                                # list available tools
+collavre tool list --full                         # list with full details
+collavre tool search "github"                     # search by name/description
+collavre tool info <tool_name>                    # show tool parameters
+collavre tool run <tool_name> --json '{"k":"v"}'  # run with JSON args
+collavre tool run <tool_name> --key value         # run with flag args
+```
+
 ## Key Concepts
 
 - **Tree structure**: Creatives nest via `parent_id`. Use `--level` to control depth.

--- a/skills/collavre/references/tool-reference.md
+++ b/skills/collavre/references/tool-reference.md
@@ -94,3 +94,34 @@ Import a markdown document as a Creative tree. Uses the built-in MarkdownImporte
 - Inline images and links → preserved in description HTML
 
 **Returns:** `{ success, parent_id, created_count, tree[] }`
+
+## meta_tool
+
+Introspect and dynamically run any registered MCP tool. Enables tool discovery without CLI updates.
+
+| Param | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `action` | String | **Yes** | — | `list`, `list_summary`, `search`, `get`, or `run` |
+| `tool_name` | String | No | — | Target tool name (required for `get` and `run`) |
+| `query` | String | No | — | Search term (for `search` action) |
+| `arguments` | Object | No | `{}` | Arguments to pass to the tool (for `run` action) |
+
+**Actions:**
+
+| Action | Description |
+|--------|-------------|
+| `list` | Full list of all tools with names, descriptions, and parameters |
+| `list_summary` | Compact list with names and one-line descriptions only |
+| `search` | Filter tools by name or description matching `query` |
+| `get` | Full schema for a single tool (params, types, usage) |
+| `run` | Execute a tool by name, passing `arguments` through |
+
+**CLI mapping:**
+
+| CLI Command | meta_tool Action |
+|-------------|------------------|
+| `collavre tool list` | `list_summary` |
+| `collavre tool list --full` | `list` |
+| `collavre tool search <q>` | `search` |
+| `collavre tool info <name>` | `get` |
+| `collavre tool run <name>` | `run` |

--- a/skills/collavre/scripts/collavre
+++ b/skills/collavre/scripts/collavre
@@ -489,7 +489,7 @@ Subcommands:
             toolArgs = JSON.parse(args.json);
           } else {
             // Build arguments from remaining --key value flags
-            const { json: _, full: __, ...rest } = args;
+            const { json: _, ...rest } = args;
             for (const [k, v] of Object.entries(rest)) {
               // Auto-parse numbers and booleans
               if (v === "true") toolArgs[k] = true;

--- a/skills/collavre/scripts/collavre
+++ b/skills/collavre/scripts/collavre
@@ -423,6 +423,96 @@ const commands = {
       printResult(result);
     });
   },
+
+  async tool(argv) {
+    const { args, positional } = parseArgs(argv);
+    const sub = positional[0];
+
+    if (!sub || sub === "help") {
+      console.log(`Usage: collavre tool <subcommand> [options]
+
+Subcommands:
+  list                          List available tools (summary)
+  list --full                   List with full details
+  search <query>                Search tools by name/description
+  info <tool_name>              Show tool parameters and usage
+  run <tool_name> --json '{}'   Run tool with JSON arguments
+  run <tool_name> --key value   Run tool with flag arguments`);
+      process.exit(0);
+    }
+
+    await withClient(async (client) => {
+      switch (sub) {
+        case "list": {
+          const action = args.full ? "list" : "list_summary";
+          const result = await client.callTool("meta_tool", { action });
+          printResult(result);
+          break;
+        }
+
+        case "search": {
+          const query = positional[1];
+          if (!query) {
+            console.error("Usage: collavre tool search <query>");
+            process.exit(1);
+          }
+          const result = await client.callTool("meta_tool", {
+            action: "search",
+            query,
+          });
+          printResult(result);
+          break;
+        }
+
+        case "info": {
+          const toolName = positional[1];
+          if (!toolName) {
+            console.error("Usage: collavre tool info <tool_name>");
+            process.exit(1);
+          }
+          const result = await client.callTool("meta_tool", {
+            action: "get",
+            tool_name: toolName,
+          });
+          printResult(result);
+          break;
+        }
+
+        case "run": {
+          const toolName = positional[1];
+          if (!toolName) {
+            console.error("Usage: collavre tool run <tool_name> [--json '{}' | --key value ...]");
+            process.exit(1);
+          }
+          let toolArgs = {};
+          if (args.json) {
+            toolArgs = JSON.parse(args.json);
+          } else {
+            // Build arguments from remaining --key value flags
+            const { json: _, full: __, ...rest } = args;
+            for (const [k, v] of Object.entries(rest)) {
+              // Auto-parse numbers and booleans
+              if (v === "true") toolArgs[k] = true;
+              else if (v === "false") toolArgs[k] = false;
+              else if (v !== true && !isNaN(v) && v !== "") toolArgs[k] = Number(v);
+              else toolArgs[k] = v;
+            }
+          }
+          const result = await client.callTool("meta_tool", {
+            action: "run",
+            tool_name: toolName,
+            arguments: toolArgs,
+          });
+          printResult(result);
+          break;
+        }
+
+        default:
+          console.error(`Unknown subcommand: ${sub}. Run 'collavre tool help' for usage.`);
+          process.exit(1);
+      }
+    });
+  },
 };
 
 // --- Main ---
@@ -443,6 +533,7 @@ Commands:
   update   <id> [--desc] [--progress 1.0]  Update creative
   import   --parent <id> --file <path>     Import markdown
   batch    --file <ops.json>               Batch operations
+  tool     <list|search|info|run>          Discover & run any tool
   help                                     Show this help`);
     process.exit(0);
   }


### PR DESCRIPTION
## Summary
- Add `collavre tool` CLI command that wraps `meta_tool` MCP interface
- Subcommands: `list`, `search`, `info`, `run` — enables discovery and execution of any server-registered tool without CLI updates
- Supports both `--json '{...}'` and `--key value` argument styles for `run`
- Updated SKILL.md and tool-reference.md with documentation

## Test plan
- [ ] `collavre tool list` returns summary of all registered tools
- [ ] `collavre tool list --full` returns detailed tool info
- [ ] `collavre tool search "creative"` filters tools by query
- [ ] `collavre tool info creative_retrieval_service` shows full parameter schema
- [ ] `collavre tool run creative_retrieval_service --json '{"level":1}'` executes tool with JSON args
- [ ] `collavre tool run creative_retrieval_service --level 1` executes tool with flag args
- [ ] `collavre tool help` shows subcommand usage
- [ ] `collavre help` shows `tool` in command list