### PR TITLE
feat: swap Enter/Shift+Enter shortcuts in creative inline editor

### DIFF
--- a/engines/collavre/app/javascript/components/InlineLexicalEditor.jsx
+++ b/engines/collavre/app/javascript/components/InlineLexicalEditor.jsx
@@ -966,14 +966,16 @@ function EnterKeyPlugin({ onEnterKey }) {
   const [editor] = useLexicalComposerContext()
 
   useEffect(() => {
-    // Use capture-phase keydown on the root element to intercept Enter
-    // BEFORE Lexical's own handlers process it and insert a paragraph.
+    // Use capture-phase keydown on the root element to intercept Shift+Enter
+    // BEFORE Lexical's own handlers process it.
+    // Bare Enter is left to Lexical for newline insertion.
     const rootElement = editor.getRootElement()
     if (!rootElement) return
 
     const handler = (event) => {
       if (event.key !== 'Enter') return
-      if (event.shiftKey || event.altKey || event.ctrlKey || event.metaKey) return
+      if (!event.shiftKey) return // only intercept Shift+Enter
+      if (event.altKey || event.ctrlKey || event.metaKey) return
       if (event.isComposing) return
 
       if (onEnterKey(event, editor) === true) {

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -1786,17 +1786,13 @@ export function initializeCreativeRowEditor() {
       scheduleSave();
     }
 
-    // Intercepts bare Enter via capture-phase keydown on Lexical's root element.
-    // Returning true triggers preventDefault + stopImmediatePropagation,
-    // preventing Lexical from inserting a paragraph node.
-    // PC: Enter → addNew (complete & move to next)
-    // Mobile: Enter → newline (let Lexical handle it)
+    // Intercepts Shift+Enter via capture-phase keydown on Lexical's root element.
+    // Returning true triggers preventDefault + stopImmediatePropagation.
+    // Shift+Enter → addNew (save & add next)
+    // Bare Enter → newline (handled by Lexical)
     function handleEditorEnterKey(event, editorInstance) {
-      if (window.innerWidth > 600) {
-        addNew();
-        return true; // handled — suppress Lexical's newline
-      }
-      return false; // mobile: let Lexical insert newline
+      addNew();
+      return true; // handled — suppress default behavior
     }
 
     function handleEditorKeyDown(event, editorInstance) {
@@ -1811,8 +1807,6 @@ export function initializeCreativeRowEditor() {
         addChild();
         return;
       }
-      // Note: bare Enter is handled by handleEditorEnterKey via capture-phase keydown
-      // on Lexical's root element to prevent newline insertion before addNew().
       if ((event.ctrlKey || event.metaKey) && event.shiftKey && (event.key === '.' || event.key === '>')) {
         event.preventDefault();
         levelDown();

--- a/engines/collavre/test/system/creative_inline_edit_test.rb
+++ b/engines/collavre/test/system/creative_inline_edit_test.rb
@@ -113,7 +113,7 @@ class CreativeInlineEditTest < ApplicationSystemTestCase
     sleep 0.5
 
     fill_inline_editor("First child")
-    inline_editor_field.send_keys(:enter)
+    inline_editor_field.send_keys([ :shift, :enter ])
     sleep 0.5
 
     fill_inline_editor("Second child")


### PR DESCRIPTION
## Summary
- **Enter** now inserts a newline (Lexical default behavior)
- **Shift+Enter** now saves the current creative and adds a new sibling
- Previously these were reversed — bare Enter saved/added, Shift+Enter inserted newline

## Changes
- `EnterKeyPlugin` (InlineLexicalEditor.jsx): intercepts `Shift+Enter` instead of bare `Enter`
- `handleEditorEnterKey` (creative_row_editor.js): removed mobile width check since the plugin now only fires on explicit `Shift+Enter`
- System test updated to use `[:shift, :enter]` for the add-sibling shortcut

## Test plan
- [x] All 1617 unit/integration tests pass (0 failures)
- [x] All 39 system tests pass including `creative_inline_edit_test.rb`
- [x] Rubocop clean
- [x] i18n keys verified for en/ko