### PR TITLE
fix: broadcast MCP-triggered creative changes to all users

### DIFF
--- a/engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb
+++ b/engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb
@@ -27,7 +27,9 @@ module Collavre
         # Skip broadcast when only progress changed (cascade from update_parent_progress).
         # The original creative's broadcast already includes ancestor progress in its payload,
         # so receivers update parent rows without needing separate broadcasts per ancestor.
-        return if progress_only_change?
+        # Exception: MCP requests must always broadcast because the browser has no HTTP
+        # response to update from — WebSocket is the only delivery channel.
+        return if progress_only_change? && !Collavre::Current.mcp_request
 
         enqueue_broadcast(:updated, broadcast_node_payload)
       rescue StandardError => e
@@ -58,7 +60,7 @@ module Collavre
       def broadcast_creative_destroyed
         return if @_destroy_broadcast_users.blank?
 
-        current_user_id = Collavre.current_user&.id
+        current_user_id = Collavre::Current.mcp_request ? nil : Collavre.current_user&.id
         CreativeBroadcastJob.perform_later(
           id,
           "destroyed",
@@ -134,11 +136,14 @@ module Collavre
 
       # Enqueue broadcast as a background job to avoid blocking the request cycle.
       # Payload is built synchronously (needs fresh DB state), then delivery is async.
+      # For MCP requests, current_user_id is nil so the job broadcasts to ALL users
+      # including the requester (whose browser relies solely on WebSocket updates).
       def enqueue_broadcast(action, payload)
+        user_id = Collavre::Current.mcp_request ? nil : Collavre.current_user&.id
         CreativeBroadcastJob.perform_later(
           id,
           action.to_s,
-          current_user_id: Collavre.current_user&.id,
+          current_user_id: user_id,
           payload: payload
         )
       end
@@ -150,10 +155,11 @@ module Collavre
         return if creatives.blank?
 
         creative_ids = creatives.map(&:id)
+        user_id = Collavre::Current.mcp_request ? nil : Collavre.current_user&.id
         CreativeBroadcastJob.perform_later(
           creative_ids,
           "batch_created",
-          current_user_id: Collavre.current_user&.id
+          current_user_id: user_id
         )
       end
 

--- a/engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb
+++ b/engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb
@@ -60,11 +60,10 @@ module Collavre
       def broadcast_creative_destroyed
         return if @_destroy_broadcast_users.blank?
 
-        current_user_id = Collavre::Current.mcp_request ? nil : Collavre.current_user&.id
         CreativeBroadcastJob.perform_later(
           id,
           "destroyed",
-          current_user_id: current_user_id,
+          current_user_id: broadcast_excludable_user_id,
           payload: @_destroy_payload,
           options: {
             destroy_user_ids: @_destroy_broadcast_users.map(&:id),
@@ -139,11 +138,10 @@ module Collavre
       # For MCP requests, current_user_id is nil so the job broadcasts to ALL users
       # including the requester (whose browser relies solely on WebSocket updates).
       def enqueue_broadcast(action, payload)
-        user_id = Collavre::Current.mcp_request ? nil : Collavre.current_user&.id
         CreativeBroadcastJob.perform_later(
           id,
           action.to_s,
-          current_user_id: user_id,
+          current_user_id: broadcast_excludable_user_id,
           payload: payload
         )
       end
@@ -155,11 +153,10 @@ module Collavre
         return if creatives.blank?
 
         creative_ids = creatives.map(&:id)
-        user_id = Collavre::Current.mcp_request ? nil : Collavre.current_user&.id
         CreativeBroadcastJob.perform_later(
           creative_ids,
           "batch_created",
-          current_user_id: user_id
+          current_user_id: broadcast_excludable_user_id
         )
       end
 
@@ -256,6 +253,15 @@ module Collavre
       rescue StandardError => e
         Rails.logger.error "[CreativeBroadcast] Error finding users: #{e.message}"
         []
+      end
+      # Returns nil for MCP requests so broadcast includes all users;
+      # returns current_user's ID for web requests so the requester is excluded.
+      def self.broadcast_excludable_user_id
+        Collavre::Current.mcp_request ? nil : Collavre.current_user&.id
+      end
+
+      def broadcast_excludable_user_id
+        RealtimeBroadcastable.broadcast_excludable_user_id
       end
     end
   end

--- a/engines/collavre/app/models/collavre/current.rb
+++ b/engines/collavre/app/models/collavre/current.rb
@@ -5,6 +5,7 @@ module Collavre
     attribute :session
     attribute :creative_share_cache
     attribute :mcp_tool_approval_required
+    attribute :mcp_request
     attribute :user
 
     def user

--- a/engines/collavre/app/services/collavre/tools/creative_batch_service.rb
+++ b/engines/collavre/app/services/collavre/tools/creative_batch_service.rb
@@ -99,7 +99,10 @@ module Collavre
         return { error: "Creative not found", id: id } unless creative
         return { error: "No write permission on this Creative", id: id } unless creative.has_permission?(Current.user, :write)
 
-        creative.destroy!
+        Creatives::DestroyService.new(
+          creative: creative,
+          user: Current.user
+        ).call
         { success: true, id: id, deleted: true }
       end
     end

--- a/engines/collavre/app/services/collavre/tools/creative_batch_service.rb
+++ b/engines/collavre/app/services/collavre/tools/creative_batch_service.rb
@@ -99,10 +99,11 @@ module Collavre
         return { error: "Creative not found", id: id } unless creative
         return { error: "No write permission on this Creative", id: id } unless creative.has_permission?(Current.user, :write)
 
-        Creatives::DestroyService.new(
+        result = Creatives::DestroyService.new(
           creative: creative,
           user: Current.user
         ).call
+        return { error: "Failed to destroy creative", id: id } unless result
         { success: true, id: id, deleted: true }
       end
     end

--- a/engines/collavre/test/models/collavre/creative/realtime_broadcastable_test.rb
+++ b/engines/collavre/test/models/collavre/creative/realtime_broadcastable_test.rb
@@ -234,6 +234,67 @@ module Collavre
         end
       end
 
+      # --- MCP request context ---
+
+      test "enqueue_broadcast passes nil current_user_id during MCP request" do
+        Collavre::Current.mcp_request = true
+
+        assert_enqueued_with(job: Collavre::CreativeBroadcastJob) do
+          @child.update!(description: "MCP update")
+        end
+
+        job = enqueued_jobs.select { |j| j["job_class"] == "Collavre::CreativeBroadcastJob" }.last
+        args = job["arguments"]
+        # Third argument is keyword args hash — current_user_id should be nil
+        kwargs = args.last
+        assert_nil kwargs["current_user_id"], "MCP requests must not exclude current user from broadcast"
+      ensure
+        Collavre::Current.mcp_request = nil
+      end
+
+      test "broadcast_creative_updated broadcasts progress-only changes during MCP request" do
+        Collavre::Current.mcp_request = true
+
+        assert_enqueued_with(job: Collavre::CreativeBroadcastJob) do
+          @child.update!(progress: 0.95)
+        end
+      ensure
+        Collavre::Current.mcp_request = nil
+      end
+
+      test "broadcast_creative_destroyed passes nil current_user_id during MCP request" do
+        Collavre::Current.mcp_request = true
+        @child.send(:capture_broadcast_state)
+
+        assert_enqueued_with(job: Collavre::CreativeBroadcastJob) do
+          @child.send(:broadcast_creative_destroyed)
+        end
+
+        job = enqueued_jobs.select { |j| j["job_class"] == "Collavre::CreativeBroadcastJob" }.last
+        kwargs = job["arguments"].last
+        assert_nil kwargs["current_user_id"], "MCP destroy must not exclude current user"
+      ensure
+        Collavre::Current.mcp_request = nil
+      end
+
+      test "broadcast_batch_created passes nil current_user_id during MCP request" do
+        Collavre::Current.mcp_request = true
+        creatives = []
+        perform_enqueued_jobs do
+          creatives << Creative.create!(user: @owner, parent: @root, description: "Batch 1", progress: 0.0)
+        end
+
+        assert_enqueued_with(job: Collavre::CreativeBroadcastJob) do
+          Creative::RealtimeBroadcastable.broadcast_batch_created(creatives)
+        end
+
+        job = enqueued_jobs.select { |j| j["job_class"] == "Collavre::CreativeBroadcastJob" }.last
+        kwargs = job["arguments"].last
+        assert_nil kwargs["current_user_id"], "MCP batch create must not exclude current user"
+      ensure
+        Collavre::Current.mcp_request = nil
+      end
+
       # --- capture_broadcast_state / broadcast_creative_destroyed ---
 
       test "capture_broadcast_state stores users and payload for shared creative" do

--- a/lib/mcp_oauth_middleware.rb
+++ b/lib/mcp_oauth_middleware.rb
@@ -46,6 +46,7 @@ class McpOauthMiddleware
         if user
           Rails.logger.info "McpOauthMiddleware: Found user #{user.id} for token"
           Current.user = user
+          Collavre::Current.mcp_request = true if defined?(Collavre::Current)
           true
         else
           Rails.logger.warn "McpOauthMiddleware: User missing for token #{token.resource_owner_id}"


### PR DESCRIPTION
## Summary

- MCP tool로 creative를 생성/수정/삭제할 때 WebSocket broadcast에서 요청 사용자가 제외되어 브라우저에서 실시간 동기화가 안 되는 버그 수정
- `Collavre::Current.mcp_request` 플래그를 추가하여 MCP 컨텍스트에서는 broadcast 대상에서 current_user를 제외하지 않도록 변경
- MCP 컨텍스트에서 progress-only 변경도 broadcast 수행하도록 수정
- batch delete에서 `creative.destroy!` 직접 호출 대신 `DestroyService`를 사용하여 자식 reparenting과 CreativeShare 정리가 정상 동작하도록 수정

## Root Cause

`CreativeBroadcastJob`이 변경을 일으킨 사용자를 broadcast 대상에서 제외하는 로직이 있음. 웹 UI에서는 HTTP 응답으로 직접 UI가 갱신되므로 본인 제외가 맞지만, MCP에서는 AI 에이전트가 요청하고 사용자 브라우저는 WebSocket으로만 변경을 수신하므로 본인이 제외되면 실시간 동기화 불가.

## Changes

| File | Change |
|------|--------|
| `engines/collavre/app/models/collavre/current.rb` | `mcp_request` attribute 추가 |
| `lib/mcp_oauth_middleware.rb` | MCP 요청 시 `Collavre::Current.mcp_request = true` 설정 |
| `engines/collavre/app/models/collavre/creative/realtime_broadcastable.rb` | MCP일 때 current_user_id를 nil로 전달 (모든 사용자에게 broadcast), progress-only 스킵 비활성화 |
| `engines/collavre/app/services/collavre/tools/creative_batch_service.rb` | `destroy!` → `DestroyService` 사용 |
| `engines/collavre/test/models/collavre/creative/realtime_broadcastable_test.rb` | MCP 컨텍스트 테스트 4개 추가 |

## Test plan

- [x] `realtime_broadcastable_test.rb` — 37 tests, 0 failures
- [x] `creative_batch_service_test.rb` — 7 tests, 0 failures
- [x] Full test suite — 1621 tests, 0 failures, 0 errors
- [x] Rubocop — no offenses
- [ ] Manual: MCP tool로 creative CRUD 후 브라우저에서 실시간 반영 확인