### PR TITLE
fix: prevent popup jumping to (0,0) when exiting fullscreen quickly

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -2,7 +2,7 @@
     display: none;
     position: fixed;
     right: 2em;
-    /* top: 10em; */
+    top: 10em;
     z-index: var(--layer-modal);
     width: 420px;
     height: 640px;

--- a/engines/collavre/app/javascript/controllers/comments/popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_controller.js
@@ -705,9 +705,10 @@ export default class extends Controller {
       }
 
       // Clean up inline styles after transition ends
-      const cleanup = () => {
-        el.removeEventListener('transitionend', cleanup)
+      this._enterCleanupFn = () => {
+        el.removeEventListener('transitionend', this._enterCleanupFn)
         this._enterCleanupTimer = null
+        this._enterCleanupFn = null
         el.style.top = ''
         el.style.left = ''
         el.style.right = ''
@@ -716,9 +717,9 @@ export default class extends Controller {
         el.style.height = ''
         el.style.position = ''
       }
-      el.addEventListener('transitionend', cleanup, { once: true })
+      el.addEventListener('transitionend', this._enterCleanupFn, { once: true })
       // Fallback if transitionend doesn't fire
-      this._enterCleanupTimer = setTimeout(cleanup, 300)
+      this._enterCleanupTimer = setTimeout(this._enterCleanupFn, 300)
 
     } else {
       // Cancel any pending enter-fullscreen cleanup to prevent it from
@@ -726,6 +727,10 @@ export default class extends Controller {
       if (this._enterCleanupTimer) {
         clearTimeout(this._enterCleanupTimer)
         this._enterCleanupTimer = null
+      }
+      if (this._enterCleanupFn) {
+        el.removeEventListener('transitionend', this._enterCleanupFn)
+        this._enterCleanupFn = null
       }
 
       const savedStyles = this._savedStyles

--- a/engines/collavre/app/javascript/controllers/comments/popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_controller.js
@@ -623,6 +623,16 @@ export default class extends Controller {
   // Enter fullscreen immediately without animation (for auto-fullscreen on page load)
   _enterFullscreenImmediate() {
     const el = this.element
+
+    // Save current inline styles so exit-fullscreen can restore them
+    this._savedStyles = {
+      top: el.style.top,
+      right: el.style.right,
+      left: el.style.left,
+      width: el.style.width,
+      height: el.style.height,
+    }
+
     el.style.transition = 'none'
     el.dataset.fullscreen = 'true'
     document.body.classList.add('chat-fullscreen')
@@ -697,6 +707,7 @@ export default class extends Controller {
       // Clean up inline styles after transition ends
       const cleanup = () => {
         el.removeEventListener('transitionend', cleanup)
+        this._enterCleanupTimer = null
         el.style.top = ''
         el.style.left = ''
         el.style.right = ''
@@ -707,9 +718,16 @@ export default class extends Controller {
       }
       el.addEventListener('transitionend', cleanup, { once: true })
       // Fallback if transitionend doesn't fire
-      setTimeout(cleanup, 300)
+      this._enterCleanupTimer = setTimeout(cleanup, 300)
 
     } else {
+      // Cancel any pending enter-fullscreen cleanup to prevent it from
+      // wiping inline styles mid-exit animation (race condition fix)
+      if (this._enterCleanupTimer) {
+        clearTimeout(this._enterCleanupTimer)
+        this._enterCleanupTimer = null
+      }
+
       const savedStyles = this._savedStyles
       this._savedStyles = null
       const creativeId = el.dataset.creativeId


### PR DESCRIPTION
## Summary
- Fix race condition where enter-fullscreen cleanup `setTimeout` fires during exit animation, wiping inline styles and causing the popup to snap to (0,0)
- Save `_savedStyles` in `_enterFullscreenImmediate()` so exit-fullscreen has a restore target when auto-fullscreen was used on page load
- Uncomment CSS `top: 10em` default on `#comments-popup` as a fallback position

## Root cause
When a user maximizes then quickly minimizes the chat popup (within 300ms), the enter-fullscreen cleanup timer fires mid-exit-animation, clearing all inline position styles. Without a CSS `top` fallback, the popup jumps to the browser's default position (≈ top-left corner).

## Test plan
- [ ] Open chat popup, maximize, wait for animation to complete, then minimize → should return to original position
- [ ] Open chat popup, maximize, immediately minimize (within 300ms) → should return to original position (was broken)
- [ ] Navigate to fullscreen URL directly, then minimize → should restore to default position
- [ ] Mobile: maximize/minimize should continue to work without animation