### PR TITLE
feat(collavre): support MCP tool defaults per creative

### DIFF
--- a/engines/collavre/app/controllers/collavre/comments_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comments_controller.rb
@@ -286,7 +286,7 @@ module Collavre
         head :forbidden and return
       end
 
-      render json: CommandMenuService.new(user: Current.user).items
+      render json: CommandMenuService.new(user: Current.user, creative: @creative).items
     end
 
     def download_images

--- a/engines/collavre/app/javascript/modules/command_args_form.js
+++ b/engines/collavre/app/javascript/modules/command_args_form.js
@@ -241,6 +241,20 @@ export default class CommandArgsForm {
     input.dataset.paramRequired = param.required ? 'true' : 'false'
     if (param.description) input.placeholder = param.description
 
+    // Pre-fill with default value from creative tool defaults
+    if (param.default_value != null) {
+      const dv = String(param.default_value)
+      if (input.tagName === 'SELECT') {
+        input.value = dv
+      } else {
+        input.value = dv
+        if (input.tagName === 'TEXTAREA') {
+          // Trigger auto-resize for pre-filled textarea
+          requestAnimationFrame(() => this._autoResize(input))
+        }
+      }
+    }
+
     // Enter submits; Shift+Enter inserts newline (textarea only)
     input.addEventListener('keydown', (e) => {
       if (e.key === 'Enter' && !e.shiftKey) {

--- a/engines/collavre/app/javascript/modules/command_args_form.js
+++ b/engines/collavre/app/javascript/modules/command_args_form.js
@@ -243,15 +243,9 @@ export default class CommandArgsForm {
 
     // Pre-fill with default value from creative tool defaults
     if (param.default_value != null) {
-      const dv = String(param.default_value)
-      if (input.tagName === 'SELECT') {
-        input.value = dv
-      } else {
-        input.value = dv
-        if (input.tagName === 'TEXTAREA') {
-          // Trigger auto-resize for pre-filled textarea
-          requestAnimationFrame(() => this._autoResize(input))
-        }
+      input.value = String(param.default_value)
+      if (input.tagName === 'TEXTAREA') {
+        requestAnimationFrame(() => this._autoResize(input))
       }
     }
 

--- a/engines/collavre/app/services/collavre/command_menu_service.rb
+++ b/engines/collavre/app/services/collavre/command_menu_service.rb
@@ -1,7 +1,8 @@
 module Collavre
   class CommandMenuService
-    def initialize(user:)
+    def initialize(user:, creative: nil)
       @user = user
+      @creative = creative
     end
 
     def items
@@ -10,7 +11,7 @@ module Collavre
 
     private
 
-    attr_reader :user
+    attr_reader :user, :creative
 
     def built_in_items
       [
@@ -70,12 +71,16 @@ module Collavre
         next unless tool_name
 
         raw_params = tool[:params] || tool["params"]
+        schema = normalize_params(raw_params)
+        defaults = tool_defaults_for(tool_name)
+        apply_defaults_to_schema(schema, defaults) if defaults.present?
+
         {
           name: tool_name,
           label: "/#{tool_name}",
           description: tool[:description] || tool["description"],
           args: format_args(raw_params),
-          input_schema: normalize_params(raw_params)
+          input_schema: schema
         }
       end
     end
@@ -108,6 +113,21 @@ module Collavre
           description: value[:description] || value["description"],
           enum: value[:enum] || value["enum"]
         }.compact
+      end
+    end
+
+    def tool_defaults_for(tool_name)
+      creative&.data&.dig("tools", tool_name)
+    end
+
+    def apply_defaults_to_schema(schema, defaults)
+      return unless schema.is_a?(Array) && defaults.is_a?(Hash)
+
+      schema.each do |param|
+        name = param[:name]
+        if defaults.key?(name)
+          param[:default_value] = defaults[name]
+        end
       end
     end
 

--- a/engines/collavre/app/services/collavre/comments/command_processor.rb
+++ b/engines/collavre/app/services/collavre/comments/command_processor.rb
@@ -35,7 +35,7 @@ module Collavre
       end
 
       def mcp_commands
-        Collavre::Comments::McpCommandBuilder.new(comment: comment, user: user).commands
+        Collavre::Comments::McpCommandBuilder.new(comment: comment, user: user, creative: comment.creative).commands
       end
     end
   end

--- a/engines/collavre/app/services/collavre/comments/mcp_command.rb
+++ b/engines/collavre/app/services/collavre/comments/mcp_command.rb
@@ -3,10 +3,11 @@ module Collavre
 
   module Comments
     class McpCommand
-      def initialize(comment:, user:, tool:, meta_tool_service: default_meta_tool_service)
+      def initialize(comment:, user:, tool:, creative: nil, meta_tool_service: default_meta_tool_service)
         @comment = comment
         @user = user
         @tool = tool
+        @creative = creative
         @meta_tool_service = meta_tool_service
       end
 
@@ -25,7 +26,7 @@ module Collavre
 
       private
 
-      attr_reader :comment, :user, :tool, :meta_tool_service
+      attr_reader :comment, :user, :tool, :creative, :meta_tool_service
 
       def command_match?
         comment.content.to_s.strip.match?(command_pattern)
@@ -41,11 +42,17 @@ module Collavre
 
       def parsed_arguments
         body = command_body
-        return {} if body.blank?
+        explicit_args = if body.blank?
+          {}
+        else
+          begin
+            JSON.parse(body)
+          rescue JSON::ParserError
+            key_value_arguments(body)
+          end
+        end
 
-        JSON.parse(body)
-      rescue JSON::ParserError
-        key_value_arguments(body)
+        merge_with_defaults(explicit_args)
       end
 
       def key_value_arguments(body)
@@ -59,6 +66,15 @@ module Collavre
         return args if args.present?
 
         nil
+      end
+
+      def merge_with_defaults(explicit_args)
+        return explicit_args unless explicit_args.is_a?(Hash)
+
+        defaults = creative&.data&.dig("tools", tool_name)
+        return explicit_args unless defaults.is_a?(Hash)
+
+        defaults.merge(explicit_args)
       end
 
       def cast_value(value)

--- a/engines/collavre/app/services/collavre/comments/mcp_command_builder.rb
+++ b/engines/collavre/app/services/collavre/comments/mcp_command_builder.rb
@@ -1,9 +1,10 @@
 module Collavre
   module Comments
     class McpCommandBuilder
-      def initialize(comment:, user:, logger: Rails.logger)
+      def initialize(comment:, user:, creative: nil, logger: Rails.logger)
         @comment = comment
         @user = user
+        @creative = creative
         @logger = logger
       end
 
@@ -13,7 +14,7 @@ module Collavre
         RailsMcpEngine::Engine.build_tools!
         tools = meta_tool_service.call(action: "list", tool_name: nil, query: nil, arguments: nil)
         Array(tools[:tools]).map do |tool|
-          Collavre::Comments::McpCommand.new(comment: comment, user: user, tool: tool, meta_tool_service: meta_tool_service)
+          Collavre::Comments::McpCommand.new(comment: comment, user: user, tool: tool, creative: creative, meta_tool_service: meta_tool_service)
         end
       rescue StandardError => e
         logger.error("MCP command registration failed: #{e.message}")
@@ -22,7 +23,7 @@ module Collavre
 
       private
 
-      attr_reader :comment, :user, :logger
+      attr_reader :comment, :user, :creative, :logger
 
       def meta_tool_service
         @meta_tool_service ||= ::Tools::MetaToolService.new

--- a/engines/collavre/test/services/command_menu_service_test.rb
+++ b/engines/collavre/test/services/command_menu_service_test.rb
@@ -130,5 +130,46 @@ module Collavre
       creative_item = items.find { |i| i[:name] == "creative" }
       assert_nil creative_item[:input_schema]
     end
+
+    test "tool_defaults_for returns nil when no creative" do
+      service = CommandMenuService.new(user: users(:one))
+      assert_nil service.send(:tool_defaults_for, "run_sql_query")
+    end
+
+    test "tool_defaults_for returns nil when creative has no tool defaults" do
+      creative = creatives(:tshirt)
+      service = CommandMenuService.new(user: users(:one), creative: creative)
+      assert_nil service.send(:tool_defaults_for, "run_sql_query")
+    end
+
+    test "tool_defaults_for returns defaults from creative data" do
+      creative = creatives(:tshirt)
+      creative.update!(data: { "tools" => { "run_sql_query" => { "query" => "select * from patient", "limit" => 100 } } })
+      service = CommandMenuService.new(user: users(:one), creative: creative)
+
+      defaults = service.send(:tool_defaults_for, "run_sql_query")
+      assert_equal({ "query" => "select * from patient", "limit" => 100 }, defaults)
+    end
+
+    test "apply_defaults_to_schema merges default_value into schema params" do
+      service = CommandMenuService.new(user: users(:one))
+      schema = [
+        { name: "query", type: "string", required: true },
+        { name: "limit", type: "integer", required: false },
+        { name: "format", type: "string", required: false }
+      ]
+      defaults = { "query" => "select * from patient", "limit" => 100 }
+
+      service.send(:apply_defaults_to_schema, schema, defaults)
+
+      query_param = schema.find { |p| p[:name] == "query" }
+      assert_equal "select * from patient", query_param[:default_value]
+
+      limit_param = schema.find { |p| p[:name] == "limit" }
+      assert_equal 100, limit_param[:default_value]
+
+      format_param = schema.find { |p| p[:name] == "format" }
+      assert_nil format_param[:default_value], "Params without defaults should not have default_value"
+    end
   end
 end

--- a/engines/collavre/test/services/comments/mcp_command_test.rb
+++ b/engines/collavre/test/services/comments/mcp_command_test.rb
@@ -1,0 +1,102 @@
+require "test_helper"
+
+module Collavre
+  module Comments
+    class McpCommandTest < ActiveSupport::TestCase
+      setup do
+        @creative = creatives(:tshirt)
+        @user = users(:one)
+        @topic = Topic.create!(creative: @creative, user: @user, name: "Test Topic")
+        @tool = {
+          name: "run_sql_query",
+          description: "Run a SQL query",
+          params: [
+            { name: "query", type: "string", required: true },
+            { name: "limit", type: "integer", required: false }
+          ]
+        }
+        @mock_service = Minitest::Mock.new
+      end
+
+      test "merge_with_defaults returns explicit args when no creative" do
+        comment = create_comment("/run_sql_query #{JSON.generate(query: 'select 1')}")
+        cmd = McpCommand.new(comment: comment, user: @user, tool: @tool, meta_tool_service: @mock_service)
+
+        result = cmd.send(:merge_with_defaults, { "query" => "select 1" })
+        assert_equal({ "query" => "select 1" }, result)
+      end
+
+      test "merge_with_defaults returns explicit args when creative has no tool defaults" do
+        comment = create_comment("/run_sql_query #{JSON.generate(query: 'select 1')}")
+        cmd = McpCommand.new(comment: comment, user: @user, tool: @tool, creative: @creative, meta_tool_service: @mock_service)
+
+        result = cmd.send(:merge_with_defaults, { "query" => "select 1" })
+        assert_equal({ "query" => "select 1" }, result)
+      end
+
+      test "merge_with_defaults applies creative defaults for missing args" do
+        @creative.update!(data: { "tools" => { "run_sql_query" => { "query" => "select * from patient", "limit" => 100 } } })
+
+        comment = create_comment("/run_sql_query")
+        cmd = McpCommand.new(comment: comment, user: @user, tool: @tool, creative: @creative, meta_tool_service: @mock_service)
+
+        result = cmd.send(:merge_with_defaults, {})
+        assert_equal({ "query" => "select * from patient", "limit" => 100 }, result)
+      end
+
+      test "merge_with_defaults lets explicit args override defaults" do
+        @creative.update!(data: { "tools" => { "run_sql_query" => { "query" => "select * from patient", "limit" => 100 } } })
+
+        comment = create_comment('/run_sql_query {"query":"select count(*) from patient"}')
+        cmd = McpCommand.new(comment: comment, user: @user, tool: @tool, creative: @creative, meta_tool_service: @mock_service)
+
+        result = cmd.send(:merge_with_defaults, { "query" => "select count(*) from patient" })
+        assert_equal "select count(*) from patient", result["query"]
+        assert_equal 100, result["limit"]
+      end
+
+      test "merge_with_defaults partial override preserves remaining defaults" do
+        @creative.update!(data: {
+          "tools" => {
+            "run_sql_query" => { "query" => "select * from patient", "limit" => 100 }
+          }
+        })
+
+        comment = create_comment('/run_sql_query {"limit":50}')
+        cmd = McpCommand.new(comment: comment, user: @user, tool: @tool, creative: @creative, meta_tool_service: @mock_service)
+
+        result = cmd.send(:merge_with_defaults, { "limit" => 50 })
+        assert_equal "select * from patient", result["query"]
+        assert_equal 50, result["limit"]
+      end
+
+      test "parsed_arguments uses defaults when no args provided" do
+        @creative.update!(data: { "tools" => { "run_sql_query" => { "query" => "select * from patient" } } })
+
+        comment = create_comment("/run_sql_query")
+        cmd = McpCommand.new(comment: comment, user: @user, tool: @tool, creative: @creative, meta_tool_service: @mock_service)
+
+        result = cmd.send(:parsed_arguments)
+        assert_equal({ "query" => "select * from patient" }, result)
+      end
+
+      test "returns nil for non-matching commands" do
+        comment = create_comment("Hello world")
+        cmd = McpCommand.new(comment: comment, user: @user, tool: @tool, creative: @creative, meta_tool_service: @mock_service)
+
+        assert_nil cmd.call
+      end
+
+      private
+
+      def create_comment(content)
+        Collavre::Comment.create!(
+          creative: @creative,
+          topic: @topic,
+          user: @user,
+          content: content
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Allow creatives to define default argument values for MCP tools via `creative.data["tools"]`
- When a user invokes a tool command (e.g., `/run_sql_query`), defaults are merged with explicit args — explicit args always win
- The command args popup pre-fills fields with default values for easy confirmation or override
- If the popup is not used (direct chat invocation), all args must be provided explicitly

## Changes
- **CommandMenuService**: Accepts `creative`, merges `default_value` into `input_schema` for each tool param
- **McpCommand**: Merges creative tool defaults with parsed arguments (`defaults.merge(explicit_args)`)
- **McpCommandBuilder**: Passes `creative` through to `McpCommand`
- **CommandProcessor**: Passes `comment.creative` to `McpCommandBuilder`
- **CommentsController**: Passes `@creative` to `CommandMenuService`
- **command_args_form.js**: Pre-fills input fields with `default_value` from schema, including textarea auto-resize

## Data structure
```json
{
  "data": {
    "tools": {
      "run_sql_query": {
        "query": "select * from patient",
        "limit": 100
      }
    }
  }
}
```

## Test plan
- [x] Unit tests for `CommandMenuService` tool defaults methods (3 tests)
- [x] Unit tests for `McpCommand` merge behavior (7 tests: no creative, no defaults, apply defaults, explicit override, partial override, parsed_arguments integration, non-matching command)
- [x] Full test suite: 1628 runs, 0 failures, 0 errors
- [x] Rubocop: 796 files, no offenses
- [x] i18n: all keys present in en and ko