### PR TITLE
feat: add Markdown content type for creatives

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/actiontext.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/actiontext.css
@@ -56,7 +56,7 @@
 }
 
 .markdown-preview:empty::before {
-  content: "Preview";
+  content: attr(data-placeholder);
   color: var(--text-muted);
   font-style: italic;
 }

--- a/engines/collavre/app/assets/stylesheets/collavre/actiontext.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/actiontext.css
@@ -15,6 +15,97 @@
   padding: 0 0 var(--space-3) 0;
 }
 
+/* Markdown Editor */
+.markdown-editor-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-2);
+}
+
+.markdown-editor-textarea {
+  width: 100%;
+  min-height: 6rem;
+  padding: 0.6rem 0.75rem;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-2);
+  background: var(--surface-section, var(--surface-bg));
+  color: var(--text-primary);
+  font-family: ui-monospace, SFMono-Regular, SFMono, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  resize: vertical;
+  outline: none;
+  box-sizing: border-box;
+}
+
+.markdown-editor-textarea:focus {
+  border-color: var(--color-active);
+  box-shadow: 0 0 0 2px rgba(79, 70, 229, 0.15);
+}
+
+.markdown-preview {
+  padding: 0.6rem 0.75rem;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-2);
+  background: var(--surface-btn, var(--surface-bg));
+  min-height: 2rem;
+  line-height: 1.5;
+  overflow-wrap: break-word;
+  word-break: break-word;
+}
+
+.markdown-preview:empty::before {
+  content: "Preview";
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.markdown-preview h1, .markdown-preview h2, .markdown-preview h3 {
+  margin: 0 0 var(--space-2) 0;
+}
+
+.markdown-preview ul, .markdown-preview ol {
+  margin: 0 0 0.75rem 1.25rem;
+  padding: 0;
+}
+
+.markdown-preview pre {
+  background: var(--color-code-bg, #f6f8fa);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-2);
+  padding: 0.75rem;
+  overflow-x: auto;
+  font-size: 0.9em;
+}
+
+.markdown-preview code {
+  font-family: ui-monospace, SFMono-Regular, SFMono, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-size: 0.9em;
+}
+
+.markdown-preview blockquote {
+  border-left: 3px solid var(--border-color);
+  margin: 0 0 0.75rem 0;
+  padding-left: 0.75rem;
+  color: var(--text-muted);
+}
+
+.markdown-preview table {
+  border-collapse: collapse;
+  margin: 0 0 0.75rem 0;
+}
+
+.markdown-preview th, .markdown-preview td {
+  border: 1px solid var(--border-color);
+  padding: 0.35rem 0.6rem;
+}
+
+.markdown-preview img {
+  max-width: 100%;
+  height: auto;
+}
+
 .lexical-editor-shell {
   display: flex;
   flex-direction: column;

--- a/engines/collavre/app/assets/stylesheets/collavre/actiontext.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/actiontext.css
@@ -41,7 +41,7 @@
 
 .markdown-editor-textarea:focus {
   border-color: var(--color-active);
-  box-shadow: 0 0 0 2px rgba(79, 70, 229, 0.15);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-active) 15%, transparent);
 }
 
 .markdown-preview {
@@ -491,7 +491,7 @@ body.dark-mode {
 
 .lexical-attachment.is-selected {
   border-color: var(--color-active);
-  box-shadow: 0 0 0 2px rgba(79, 70, 229, 0.2);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-active) 20%, transparent);
 }
 
 .lexical-attachment__remove {
@@ -589,7 +589,7 @@ body.dark-mode {
 .lexical-attachment__caption-input:focus {
   outline: none;
   border-color: var(--color-active);
-  box-shadow: 0 0 0 2px rgba(79, 70, 229, 0.15);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-active) 15%, transparent);
 }
 
 .lexical-attachment__caption-size {

--- a/engines/collavre/app/assets/stylesheets/collavre/actiontext.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/actiontext.css
@@ -83,20 +83,6 @@
   padding: 0;
 }
 
-.markdown-preview pre {
-  background: var(--color-code-bg, #f6f8fa);
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-2);
-  padding: 0.75rem;
-  overflow-x: auto;
-  font-size: 0.9em;
-}
-
-.markdown-preview code {
-  font-family: ui-monospace, SFMono-Regular, SFMono, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
-  font-size: 0.9em;
-}
-
 .markdown-preview blockquote {
   border-left: 3px solid var(--border-color);
   margin: 0 0 0.75rem 0;

--- a/engines/collavre/app/assets/stylesheets/collavre/actiontext.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/actiontext.css
@@ -23,6 +23,19 @@
   padding: var(--space-2);
 }
 
+@media (min-width: 768px) {
+  .markdown-editor-wrapper {
+    flex-direction: row;
+    align-items: stretch;
+  }
+
+  .markdown-editor-wrapper > .markdown-editor-textarea,
+  .markdown-editor-wrapper > .markdown-preview {
+    flex: 1 1 0;
+    min-width: 0;
+  }
+}
+
 .markdown-editor-textarea {
   width: 100%;
   min-height: 6rem;

--- a/engines/collavre/app/assets/stylesheets/collavre/code_highlight.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/code_highlight.css
@@ -4,6 +4,12 @@
  * Uses Collavre design tokens (--color-code-bg, --color-code-text, --font-mono).
  * Syntax color tokens defined as CSS variables — overridden per theme context.
  * Based on GitHub-style highlighting.
+ *
+ * Scoped to the three markdown rendering surfaces so they share container,
+ * inline-code, and syntax-token styles:
+ *   .comment-content   — chat / comments
+ *   .markdown-preview  — creative inline editor live preview
+ *   .creative-content  — persisted creative description in the tree view
  */
 
 /* ============================================================================
@@ -77,20 +83,26 @@ body.dark-mode {
 /* ============================================================================
  * MERMAID DIAGRAM CONTAINER
  * ============================================================================ */
-.comment-content .mermaid-chart {
+.comment-content .mermaid-chart,
+.markdown-preview .mermaid-chart,
+.creative-content .mermaid-chart {
   margin: var(--space-2) 0;
   overflow-x: auto;
   text-align: center;
 }
 
-.comment-content .mermaid-chart svg {
+.comment-content .mermaid-chart svg,
+.markdown-preview .mermaid-chart svg,
+.creative-content .mermaid-chart svg {
   max-width: 100%;
 }
 
 /* ============================================================================
  * CODE BLOCK CONTAINER
  * ============================================================================ */
-.comment-content pre {
+.comment-content pre,
+.markdown-preview pre,
+.creative-content pre {
   background: var(--color-code-bg);
   color: var(--color-code-text);
   border: var(--border-1) solid var(--border-color);
@@ -103,7 +115,9 @@ body.dark-mode {
   line-height: var(--leading-3);
 }
 
-.comment-content pre code {
+.comment-content pre code,
+.markdown-preview pre code,
+.creative-content pre code {
   background: none;
   border: none;
   padding: 0;
@@ -114,7 +128,9 @@ body.dark-mode {
 }
 
 /* Inline code */
-.comment-content code {
+.comment-content code,
+.markdown-preview code,
+.creative-content code {
   background: var(--color-code-bg);
   color: var(--color-code-text);
   border-radius: var(--radius-1);
@@ -127,99 +143,163 @@ body.dark-mode {
  * SYNTAX HIGHLIGHTING RULES (token-based, theme-agnostic)
  * ============================================================================ */
 .comment-content .hljs-comment,
-.comment-content .hljs-quote {
+.comment-content .hljs-quote,
+.markdown-preview .hljs-comment,
+.markdown-preview .hljs-quote,
+.creative-content .hljs-comment,
+.creative-content .hljs-quote {
   color: var(--syntax-comment);
   font-style: italic;
 }
 
 .comment-content .hljs-keyword,
 .comment-content .hljs-selector-tag,
-.comment-content .hljs-type {
+.comment-content .hljs-type,
+.markdown-preview .hljs-keyword,
+.markdown-preview .hljs-selector-tag,
+.markdown-preview .hljs-type,
+.creative-content .hljs-keyword,
+.creative-content .hljs-selector-tag,
+.creative-content .hljs-type {
   color: var(--syntax-keyword);
 }
 
-.comment-content .hljs-string {
+.comment-content .hljs-string,
+.markdown-preview .hljs-string,
+.creative-content .hljs-string {
   color: var(--syntax-string);
 }
 
 .comment-content .hljs-number,
-.comment-content .hljs-literal {
+.comment-content .hljs-literal,
+.markdown-preview .hljs-number,
+.markdown-preview .hljs-literal,
+.creative-content .hljs-number,
+.creative-content .hljs-literal {
   color: var(--syntax-number);
 }
 
 .comment-content .hljs-built_in,
-.comment-content .hljs-builtin-name {
+.comment-content .hljs-builtin-name,
+.markdown-preview .hljs-built_in,
+.markdown-preview .hljs-builtin-name,
+.creative-content .hljs-built_in,
+.creative-content .hljs-builtin-name {
   color: var(--syntax-builtin);
 }
 
 .comment-content .hljs-title,
-.comment-content .hljs-title.function_ {
+.comment-content .hljs-title.function_,
+.markdown-preview .hljs-title,
+.markdown-preview .hljs-title.function_,
+.creative-content .hljs-title,
+.creative-content .hljs-title.function_ {
   color: var(--syntax-title);
 }
 
 .comment-content .hljs-attr,
-.comment-content .hljs-attribute {
+.comment-content .hljs-attribute,
+.markdown-preview .hljs-attr,
+.markdown-preview .hljs-attribute,
+.creative-content .hljs-attr,
+.creative-content .hljs-attribute {
   color: var(--syntax-attr);
 }
 
 .comment-content .hljs-variable,
-.comment-content .hljs-template-variable {
+.comment-content .hljs-template-variable,
+.markdown-preview .hljs-variable,
+.markdown-preview .hljs-template-variable,
+.creative-content .hljs-variable,
+.creative-content .hljs-template-variable {
   color: var(--syntax-variable);
 }
 
-.comment-content .hljs-params {
+.comment-content .hljs-params,
+.markdown-preview .hljs-params,
+.creative-content .hljs-params {
   color: var(--color-code-text);
 }
 
-.comment-content .hljs-regexp {
+.comment-content .hljs-regexp,
+.markdown-preview .hljs-regexp,
+.creative-content .hljs-regexp {
   color: var(--syntax-regexp);
 }
 
-.comment-content .hljs-tag {
+.comment-content .hljs-tag,
+.markdown-preview .hljs-tag,
+.creative-content .hljs-tag {
   color: var(--syntax-tag);
 }
 
-.comment-content .hljs-name {
+.comment-content .hljs-name,
+.markdown-preview .hljs-name,
+.creative-content .hljs-name {
   color: var(--syntax-name);
 }
 
 .comment-content .hljs-selector-class,
-.comment-content .hljs-selector-id {
+.comment-content .hljs-selector-id,
+.markdown-preview .hljs-selector-class,
+.markdown-preview .hljs-selector-id,
+.creative-content .hljs-selector-class,
+.creative-content .hljs-selector-id {
   color: var(--syntax-selector);
 }
 
 .comment-content .hljs-selector-attr,
-.comment-content .hljs-selector-pseudo {
+.comment-content .hljs-selector-pseudo,
+.markdown-preview .hljs-selector-attr,
+.markdown-preview .hljs-selector-pseudo,
+.creative-content .hljs-selector-attr,
+.creative-content .hljs-selector-pseudo {
   color: var(--syntax-attr);
 }
 
 .comment-content .hljs-symbol,
-.comment-content .hljs-bullet {
+.comment-content .hljs-bullet,
+.markdown-preview .hljs-symbol,
+.markdown-preview .hljs-bullet,
+.creative-content .hljs-symbol,
+.creative-content .hljs-bullet {
   color: var(--syntax-number);
 }
 
-.comment-content .hljs-meta {
+.comment-content .hljs-meta,
+.markdown-preview .hljs-meta,
+.creative-content .hljs-meta {
   color: var(--syntax-meta);
 }
 
-.comment-content .hljs-punctuation {
+.comment-content .hljs-punctuation,
+.markdown-preview .hljs-punctuation,
+.creative-content .hljs-punctuation {
   color: var(--color-code-text);
 }
 
-.comment-content .hljs-deletion {
+.comment-content .hljs-deletion,
+.markdown-preview .hljs-deletion,
+.creative-content .hljs-deletion {
   color: var(--syntax-deletion-text);
   background: var(--syntax-deletion-bg);
 }
 
-.comment-content .hljs-addition {
+.comment-content .hljs-addition,
+.markdown-preview .hljs-addition,
+.creative-content .hljs-addition {
   color: var(--syntax-addition-text);
   background: var(--syntax-addition-bg);
 }
 
-.comment-content .hljs-emphasis {
+.comment-content .hljs-emphasis,
+.markdown-preview .hljs-emphasis,
+.creative-content .hljs-emphasis {
   font-style: italic;
 }
 
-.comment-content .hljs-strong {
+.comment-content .hljs-strong,
+.markdown-preview .hljs-strong,
+.creative-content .hljs-strong {
   font-weight: var(--weight-7);
 }

--- a/engines/collavre/app/assets/stylesheets/collavre/code_highlight.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/code_highlight.css
@@ -5,11 +5,12 @@
  * Syntax color tokens defined as CSS variables — overridden per theme context.
  * Based on GitHub-style highlighting.
  *
- * Scoped to the three markdown rendering surfaces so they share container,
+ * Scoped to the markdown rendering surfaces so they share container,
  * inline-code, and syntax-token styles:
- *   .comment-content   — chat / comments
- *   .markdown-preview  — creative inline editor live preview
- *   .creative-content  — persisted creative description in the tree view
+ *   .comment-content        — chat / comments
+ *   .markdown-preview       — creative inline editor live preview
+ *   .creative-content       — persisted creative description in the tree view
+ *   .creative-title-content — persisted creative description in the title (h1) area
  */
 
 /* ============================================================================
@@ -85,7 +86,8 @@ body.dark-mode {
  * ============================================================================ */
 .comment-content .mermaid-chart,
 .markdown-preview .mermaid-chart,
-.creative-content .mermaid-chart {
+.creative-content .mermaid-chart,
+.creative-title-content .mermaid-chart {
   margin: var(--space-2) 0;
   overflow-x: auto;
   text-align: center;
@@ -93,7 +95,8 @@ body.dark-mode {
 
 .comment-content .mermaid-chart svg,
 .markdown-preview .mermaid-chart svg,
-.creative-content .mermaid-chart svg {
+.creative-content .mermaid-chart svg,
+.creative-title-content .mermaid-chart svg {
   max-width: 100%;
 }
 
@@ -102,7 +105,8 @@ body.dark-mode {
  * ============================================================================ */
 .comment-content pre,
 .markdown-preview pre,
-.creative-content pre {
+.creative-content pre,
+.creative-title-content pre {
   background: var(--color-code-bg);
   color: var(--color-code-text);
   border: var(--border-1) solid var(--border-color);
@@ -117,7 +121,8 @@ body.dark-mode {
 
 .comment-content pre code,
 .markdown-preview pre code,
-.creative-content pre code {
+.creative-content pre code,
+.creative-title-content pre code {
   background: none;
   border: none;
   padding: 0;
@@ -130,7 +135,8 @@ body.dark-mode {
 /* Inline code */
 .comment-content code,
 .markdown-preview code,
-.creative-content code {
+.creative-content code,
+.creative-title-content code {
   background: var(--color-code-bg);
   color: var(--color-code-text);
   border-radius: var(--radius-1);
@@ -147,7 +153,9 @@ body.dark-mode {
 .markdown-preview .hljs-comment,
 .markdown-preview .hljs-quote,
 .creative-content .hljs-comment,
-.creative-content .hljs-quote {
+.creative-content .hljs-quote,
+.creative-title-content .hljs-comment,
+.creative-title-content .hljs-quote {
   color: var(--syntax-comment);
   font-style: italic;
 }
@@ -160,13 +168,17 @@ body.dark-mode {
 .markdown-preview .hljs-type,
 .creative-content .hljs-keyword,
 .creative-content .hljs-selector-tag,
-.creative-content .hljs-type {
+.creative-content .hljs-type,
+.creative-title-content .hljs-keyword,
+.creative-title-content .hljs-selector-tag,
+.creative-title-content .hljs-type {
   color: var(--syntax-keyword);
 }
 
 .comment-content .hljs-string,
 .markdown-preview .hljs-string,
-.creative-content .hljs-string {
+.creative-content .hljs-string,
+.creative-title-content .hljs-string {
   color: var(--syntax-string);
 }
 
@@ -175,7 +187,9 @@ body.dark-mode {
 .markdown-preview .hljs-number,
 .markdown-preview .hljs-literal,
 .creative-content .hljs-number,
-.creative-content .hljs-literal {
+.creative-content .hljs-literal,
+.creative-title-content .hljs-number,
+.creative-title-content .hljs-literal {
   color: var(--syntax-number);
 }
 
@@ -184,7 +198,9 @@ body.dark-mode {
 .markdown-preview .hljs-built_in,
 .markdown-preview .hljs-builtin-name,
 .creative-content .hljs-built_in,
-.creative-content .hljs-builtin-name {
+.creative-content .hljs-builtin-name,
+.creative-title-content .hljs-built_in,
+.creative-title-content .hljs-builtin-name {
   color: var(--syntax-builtin);
 }
 
@@ -193,7 +209,9 @@ body.dark-mode {
 .markdown-preview .hljs-title,
 .markdown-preview .hljs-title.function_,
 .creative-content .hljs-title,
-.creative-content .hljs-title.function_ {
+.creative-content .hljs-title.function_,
+.creative-title-content .hljs-title,
+.creative-title-content .hljs-title.function_ {
   color: var(--syntax-title);
 }
 
@@ -202,7 +220,9 @@ body.dark-mode {
 .markdown-preview .hljs-attr,
 .markdown-preview .hljs-attribute,
 .creative-content .hljs-attr,
-.creative-content .hljs-attribute {
+.creative-content .hljs-attribute,
+.creative-title-content .hljs-attr,
+.creative-title-content .hljs-attribute {
   color: var(--syntax-attr);
 }
 
@@ -211,31 +231,37 @@ body.dark-mode {
 .markdown-preview .hljs-variable,
 .markdown-preview .hljs-template-variable,
 .creative-content .hljs-variable,
-.creative-content .hljs-template-variable {
+.creative-content .hljs-template-variable,
+.creative-title-content .hljs-variable,
+.creative-title-content .hljs-template-variable {
   color: var(--syntax-variable);
 }
 
 .comment-content .hljs-params,
 .markdown-preview .hljs-params,
-.creative-content .hljs-params {
+.creative-content .hljs-params,
+.creative-title-content .hljs-params {
   color: var(--color-code-text);
 }
 
 .comment-content .hljs-regexp,
 .markdown-preview .hljs-regexp,
-.creative-content .hljs-regexp {
+.creative-content .hljs-regexp,
+.creative-title-content .hljs-regexp {
   color: var(--syntax-regexp);
 }
 
 .comment-content .hljs-tag,
 .markdown-preview .hljs-tag,
-.creative-content .hljs-tag {
+.creative-content .hljs-tag,
+.creative-title-content .hljs-tag {
   color: var(--syntax-tag);
 }
 
 .comment-content .hljs-name,
 .markdown-preview .hljs-name,
-.creative-content .hljs-name {
+.creative-content .hljs-name,
+.creative-title-content .hljs-name {
   color: var(--syntax-name);
 }
 
@@ -244,7 +270,9 @@ body.dark-mode {
 .markdown-preview .hljs-selector-class,
 .markdown-preview .hljs-selector-id,
 .creative-content .hljs-selector-class,
-.creative-content .hljs-selector-id {
+.creative-content .hljs-selector-id,
+.creative-title-content .hljs-selector-class,
+.creative-title-content .hljs-selector-id {
   color: var(--syntax-selector);
 }
 
@@ -253,7 +281,9 @@ body.dark-mode {
 .markdown-preview .hljs-selector-attr,
 .markdown-preview .hljs-selector-pseudo,
 .creative-content .hljs-selector-attr,
-.creative-content .hljs-selector-pseudo {
+.creative-content .hljs-selector-pseudo,
+.creative-title-content .hljs-selector-attr,
+.creative-title-content .hljs-selector-pseudo {
   color: var(--syntax-attr);
 }
 
@@ -262,44 +292,52 @@ body.dark-mode {
 .markdown-preview .hljs-symbol,
 .markdown-preview .hljs-bullet,
 .creative-content .hljs-symbol,
-.creative-content .hljs-bullet {
+.creative-content .hljs-bullet,
+.creative-title-content .hljs-symbol,
+.creative-title-content .hljs-bullet {
   color: var(--syntax-number);
 }
 
 .comment-content .hljs-meta,
 .markdown-preview .hljs-meta,
-.creative-content .hljs-meta {
+.creative-content .hljs-meta,
+.creative-title-content .hljs-meta {
   color: var(--syntax-meta);
 }
 
 .comment-content .hljs-punctuation,
 .markdown-preview .hljs-punctuation,
-.creative-content .hljs-punctuation {
+.creative-content .hljs-punctuation,
+.creative-title-content .hljs-punctuation {
   color: var(--color-code-text);
 }
 
 .comment-content .hljs-deletion,
 .markdown-preview .hljs-deletion,
-.creative-content .hljs-deletion {
+.creative-content .hljs-deletion,
+.creative-title-content .hljs-deletion {
   color: var(--syntax-deletion-text);
   background: var(--syntax-deletion-bg);
 }
 
 .comment-content .hljs-addition,
 .markdown-preview .hljs-addition,
-.creative-content .hljs-addition {
+.creative-content .hljs-addition,
+.creative-title-content .hljs-addition {
   color: var(--syntax-addition-text);
   background: var(--syntax-addition-bg);
 }
 
 .comment-content .hljs-emphasis,
 .markdown-preview .hljs-emphasis,
-.creative-content .hljs-emphasis {
+.creative-content .hljs-emphasis,
+.creative-title-content .hljs-emphasis {
   font-style: italic;
 }
 
 .comment-content .hljs-strong,
 .markdown-preview .hljs-strong,
-.creative-content .hljs-strong {
+.creative-content .hljs-strong,
+.creative-title-content .hljs-strong {
   font-weight: var(--weight-7);
 }

--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -146,7 +146,10 @@ module Collavre
                       @creative.ancestors.count + 1
             end
             sanitized_data = @creative.effective_origin(Set.new).data
-            if !can_edit && sanitized_data.is_a?(Hash) && sanitized_data.key?("markdown_source")
+            # markdown_source is exposed via the top-level `markdown_source:` field for writers;
+            # exclude it from the editable `data` payload so the metadata YAML editor can't
+            # round-trip a stale copy back into data["markdown_source"] on update_metadata.
+            if sanitized_data.is_a?(Hash) && sanitized_data.key?("markdown_source")
               sanitized_data = sanitized_data.except("markdown_source")
             end
             render json: {
@@ -367,6 +370,18 @@ module Collavre
       rescue JSON::ParserError => e
         render json: { error: "Invalid JSON: #{e.message}" }, status: :unprocessable_entity
         return
+      end
+      # Reserved markdown fields are not editable via metadata; preserve current values so a stale
+      # YAML payload from the metadata popup can't overwrite a concurrent markdown edit.
+      if new_data.is_a?(Hash)
+        current_data = creative.data || {}
+        %w[markdown_source content_type].each do |key|
+          if current_data.key?(key)
+            new_data[key] = current_data[key]
+          else
+            new_data.delete(key)
+          end
+        end
       end
       previous_enabled = creative.drop_trigger_enabled?
 

--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -202,7 +202,16 @@ module Collavre
       @creative = result.creative
 
       if result.success?
-        render json: { id: @creative.id }
+        # Expose the post-rewrite markdown source so the client can sync its
+        # textarea after the server replaces inline data: URIs with blob paths,
+        # matching the update endpoint contract. Without this, a freshly created
+        # markdown creative with a pasted data: URI would re-import the blob on
+        # the next keystroke save.
+        render json: {
+          id: @creative.id,
+          content_type: @creative.data&.dig("content_type"),
+          markdown_source: @creative.data&.dig("markdown_source")
+        }
       else
         render json: { errors: result.errors }, status: :unprocessable_entity
       end

--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -271,7 +271,13 @@ module Collavre
               id: base.id,
               progress: base.progress,
               progress_html: view_context.render_creative_progress(base),
-              has_children: base.children.exists?
+              has_children: base.children.exists?,
+              content_type: base.data&.dig("content_type"),
+              # Expose the post-rewrite markdown source so the client can sync its
+              # textarea after the server replaces inline data: URIs with blob paths.
+              # The next keystroke save will then carry the blob path instead of
+              # re-importing the same image as a fresh Active Storage blob.
+              markdown_source: base.data&.dig("markdown_source")
             }
             # Build ancestor chain for progress updates (closure_tree: 1 SELECT via hierarchy table)
             ancestor_records = base.ancestors.order(:id)

--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -389,16 +389,18 @@ module Collavre
         render json: { error: "Invalid JSON: #{e.message}" }, status: :unprocessable_entity
         return
       end
+      unless new_data.is_a?(Hash)
+        render json: { error: "Metadata must be an object" }, status: :unprocessable_entity
+        return
+      end
       # Reserved markdown fields are not editable via metadata; preserve current values so a stale
       # YAML payload from the metadata popup can't overwrite a concurrent markdown edit.
-      if new_data.is_a?(Hash)
-        current_data = creative.data || {}
-        %w[markdown_source content_type].each do |key|
-          if current_data.key?(key)
-            new_data[key] = current_data[key]
-          else
-            new_data.delete(key)
-          end
+      current_data = creative.data || {}
+      %w[markdown_source content_type].each do |key|
+        if current_data.key?(key)
+          new_data[key] = current_data[key]
+        else
+          new_data.delete(key)
         end
       end
       previous_enabled = creative.drop_trigger_enabled?

--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -118,6 +118,7 @@ module Collavre
 
           trigger_loop_data = @creative.data&.dig("trigger", "loop")
           parent_trigger_enabled = @creative.parent&.drop_trigger_enabled? || false
+          can_edit = @creative.has_permission?(Current.user, :write)
 
           etag = [
             "creative",
@@ -132,7 +133,9 @@ module Collavre
             "trigger_v3",
             trigger_loop_data&.dig("state"),
             trigger_loop_data&.dig("current_iteration"),
-            parent_trigger_enabled
+            parent_trigger_enabled,
+            "can_edit",
+            can_edit
           ].join(":")
 
           if stale?(etag: etag, last_modified: last_modified, public: false)
@@ -142,7 +145,6 @@ module Collavre
             else
                       @creative.ancestors.count + 1
             end
-            can_edit = @creative.has_permission?(Current.user, :write)
             sanitized_data = @creative.effective_origin(Set.new).data
             if !can_edit && sanitized_data.is_a?(Hash) && sanitized_data.key?("markdown_source")
               sanitized_data = sanitized_data.except("markdown_source")

--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -281,13 +281,16 @@ module Collavre
               progress: base.progress,
               progress_html: view_context.render_creative_progress(base),
               has_children: base.children.exists?,
-              content_type: base.data&.dig("content_type"),
-              # Expose the post-rewrite markdown source so the client can sync its
-              # textarea after the server replaces inline data: URIs with blob paths.
-              # The next keystroke save will then carry the blob path instead of
-              # re-importing the same image as a fresh Active Storage blob.
-              markdown_source: base.data&.dig("markdown_source")
+              content_type: base.data&.dig("content_type")
             }
+            # Expose the post-rewrite markdown source so the client can sync its
+            # textarea after the server replaces inline data: URIs with blob paths.
+            # Gated on write permission so a read-only share recipient moving a
+            # linked creative (parent_id-only PATCH bypasses the origin_changes
+            # write check) cannot read the origin's raw Markdown source.
+            if @creative.has_permission?(Current.user, :write)
+              response_data[:markdown_source] = base.data&.dig("markdown_source")
+            end
             # Build ancestor chain for progress updates (closure_tree: 1 SELECT via hierarchy table)
             ancestor_records = base.ancestors.order(:id)
             if ancestor_records.any?

--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -390,7 +390,7 @@ module Collavre
         return
       end
       unless new_data.is_a?(Hash)
-        render json: { error: "Metadata must be an object" }, status: :unprocessable_entity
+        render json: { error: t("collavre.creatives.errors.metadata_must_be_object") }, status: :unprocessable_entity
         return
       end
       # Reserved markdown fields are not editable via metadata; preserve current values so a stale

--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -154,6 +154,8 @@ module Collavre
               prompt: @creative.prompt_for(Current.user),
               has_children: children_count > 0,
               data: @creative.effective_origin(Set.new).data,
+              content_type: effective.data&.dig("content_type"),
+              markdown_source: effective.data&.dig("markdown_source"),
               trigger_loop: trigger_loop_data,
               is_trigger_task: parent_trigger_enabled,
               can_edit: @creative.has_permission?(Current.user, :write)
@@ -499,7 +501,7 @@ module Collavre
       end
 
       def creative_params
-        params.require(:creative).permit(:description, :progress, :parent_id, :sequence, :origin_id)
+        params.require(:creative).permit(:description, :progress, :parent_id, :sequence, :origin_id, :markdown_source, :content_type_input)
       end
 
       def any_filter_active?

--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -142,6 +142,11 @@ module Collavre
             else
                       @creative.ancestors.count + 1
             end
+            can_edit = @creative.has_permission?(Current.user, :write)
+            sanitized_data = @creative.effective_origin(Set.new).data
+            if !can_edit && sanitized_data.is_a?(Hash) && sanitized_data.key?("markdown_source")
+              sanitized_data = sanitized_data.except("markdown_source")
+            end
             render json: {
               id: @creative.id,
               description: @creative.effective_description,
@@ -153,12 +158,12 @@ module Collavre
               depth: depth,
               prompt: @creative.prompt_for(Current.user),
               has_children: children_count > 0,
-              data: @creative.effective_origin(Set.new).data,
+              data: sanitized_data,
               content_type: effective.data&.dig("content_type"),
-              markdown_source: effective.data&.dig("markdown_source"),
+              markdown_source: can_edit ? effective.data&.dig("markdown_source") : nil,
               trigger_loop: trigger_loop_data,
               is_trigger_task: parent_trigger_enabled,
-              can_edit: @creative.has_permission?(Current.user, :write)
+              can_edit: can_edit
             }
           end
         end

--- a/engines/collavre/app/javascript/creatives/tree_renderer.js
+++ b/engines/collavre/app/javascript/creatives/tree_renderer.js
@@ -163,6 +163,12 @@ function applyRowProperties(row, node) {
   if (Object.prototype.hasOwnProperty.call(inlinePayload, 'origin_id')) {
     setDatasetValue(row, 'originId', inlinePayload.origin_id ?? '')
   }
+  if (Object.prototype.hasOwnProperty.call(inlinePayload, 'content_type')) {
+    setDatasetValue(row, 'contentType', inlinePayload.content_type ?? '')
+  }
+  if (Object.prototype.hasOwnProperty.call(inlinePayload, 'markdown_source')) {
+    setDatasetValue(row, 'markdownSource', inlinePayload.markdown_source ?? '')
+  }
 
   if (dirty && typeof row.requestUpdate === 'function') {
     // Before Lit re-renders, sync progressHtml from current DOM.

--- a/engines/collavre/app/javascript/lib/api/__tests__/queue_manager.test.js
+++ b/engines/collavre/app/javascript/lib/api/__tests__/queue_manager.test.js
@@ -122,6 +122,33 @@ describe('ApiQueueManager', () => {
         expect(options.body.has('file')).toBe(true);
     });
 
+    test('should pass parsed JSON response data to onSuccess callback', async () => {
+        // Restore processQueue for this test
+        apiQueue.processQueue.mockRestore();
+
+        const callback = jest.fn();
+
+        // Mock successful response with JSON body containing markdown_source rewrite
+        const rewrittenSource = '![img](/rails/active_storage/blobs/abc/image.png)';
+        mockCsrfFetch.mockResolvedValue({
+            ok: true,
+            text: async () => JSON.stringify({ id: 42, markdown_source: rewrittenSource })
+        });
+
+        const item = {
+            path: '/creatives/42',
+            method: 'PATCH',
+            onSuccess: callback,
+            retries: 0
+        };
+
+        apiQueue.queue = [item];
+        await apiQueue.processQueue();
+
+        expect(callback).toHaveBeenCalledTimes(1);
+        expect(callback).toHaveBeenCalledWith({ id: 42, markdown_source: rewrittenSource });
+    });
+
     test('should dispatch event on permanent failure', async () => {
         // Restore processQueue for this test
         apiQueue.processQueue.mockRestore();

--- a/engines/collavre/app/javascript/lib/api/queue_manager.js
+++ b/engines/collavre/app/javascript/lib/api/queue_manager.js
@@ -174,11 +174,11 @@ class ApiQueueManager {
         // Merge new callback with existing callbacks
         let mergedCallback = null
         if (existingCallbacks.length > 0 || request.onSuccess) {
-            mergedCallback = () => {
+            mergedCallback = (responseData) => {
                 // Run all existing callbacks first
                 existingCallbacks.forEach(cb => {
                     try {
-                        cb()
+                        cb(responseData)
                     } catch (error) {
                         console.error('Merged callback failed:', error)
                     }
@@ -186,7 +186,7 @@ class ApiQueueManager {
                 // Then run the new callback
                 if (typeof request.onSuccess === 'function') {
                     try {
-                        request.onSuccess()
+                        request.onSuccess(responseData)
                     } catch (error) {
                         console.error('New callback failed:', error)
                     }
@@ -229,8 +229,20 @@ class ApiQueueManager {
         while (this.queue.length > 0) {
             const item = this.queue[0]
 
+            let responseData = null
             try {
-                await this.executeRequest(item)
+                const response = await this.executeRequest(item)
+                // Parse JSON body so callbacks can react to server-side rewrites
+                // (e.g. markdown_source data: URIs → blob paths). Best-effort: empty
+                // or non-JSON bodies leave responseData null.
+                if (response && typeof response.text === 'function') {
+                    try {
+                        const text = await response.text()
+                        responseData = text ? JSON.parse(text) : null
+                    } catch (_parseError) {
+                        responseData = null
+                    }
+                }
                 // Success - handle cleanup actions
 
                 // Dispatch event for attachment cleanup if needed
@@ -243,7 +255,7 @@ class ApiQueueManager {
                 // Call onSuccess callback if provided (for non-serializable actions)
                 if (typeof item.onSuccess === 'function') {
                     try {
-                        item.onSuccess()
+                        item.onSuccess(responseData)
                     } catch (callbackError) {
                         console.error('onSuccess callback failed:', callbackError)
                     }

--- a/engines/collavre/app/javascript/modules/__tests__/html_content_empty.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/html_content_empty.test.js
@@ -1,0 +1,41 @@
+/**
+ * @jest-environment jsdom
+ */
+import { isHtmlEmpty } from '../html_content_empty';
+
+describe('isHtmlEmpty', () => {
+  test('returns true for null/empty string', () => {
+    expect(isHtmlEmpty('')).toBe(true);
+    expect(isHtmlEmpty(null)).toBe(true);
+    expect(isHtmlEmpty(undefined)).toBe(true);
+  });
+
+  test('returns true for whitespace-only HTML', () => {
+    expect(isHtmlEmpty('<p>   </p>')).toBe(true);
+    expect(isHtmlEmpty('<div><br></div>')).toBe(true);
+  });
+
+  test('returns false when there is text content', () => {
+    expect(isHtmlEmpty('<p>hello</p>')).toBe(false);
+  });
+
+  test('returns false for image-only HTML', () => {
+    expect(isHtmlEmpty('<p><img src="/blob/abc.png"></p>')).toBe(false);
+  });
+
+  test('returns false for action-text-attachment-only HTML', () => {
+    expect(isHtmlEmpty(
+      '<action-text-attachment sgid="abc" url="/blob" filename="file.png"></action-text-attachment>'
+    )).toBe(false);
+  });
+
+  test('returns false for figure.attachment-only HTML (trix-style)', () => {
+    expect(isHtmlEmpty(
+      '<figure class="attachment attachment--file" data-trix-attachment=\'{"sgid":"abc"}\'></figure>'
+    )).toBe(false);
+  });
+
+  test('returns false for [data-trix-attachment]-only HTML', () => {
+    expect(isHtmlEmpty('<div data-trix-attachment=\'{"sgid":"x"}\'></div>')).toBe(false);
+  });
+});

--- a/engines/collavre/app/javascript/modules/__tests__/markdown_source_reconcile.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/markdown_source_reconcile.test.js
@@ -1,0 +1,70 @@
+/**
+ * @jest-environment jsdom
+ */
+import { reconcileMarkdownSource } from '../markdown_source_reconcile';
+
+const DATA_URI = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=';
+const BLOB_PATH = '/rails/active_storage/blobs/redirect/abc123def/image.png';
+const DATA_URI_2 = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+const BLOB_PATH_2 = '/rails/active_storage/blobs/redirect/xyz789/two.gif';
+
+describe('reconcileMarkdownSource', () => {
+  test('returns rewritten value when current still equals saved', () => {
+    const saved = `Hello ![pic](${DATA_URI}) world`;
+    const rewritten = `Hello ![pic](${BLOB_PATH}) world`;
+    expect(reconcileMarkdownSource(saved, rewritten, saved)).toBe(rewritten);
+  });
+
+  test('returns null when no rewrites happened', () => {
+    expect(reconcileMarkdownSource('a', 'a', 'a')).toBe(null);
+  });
+
+  test('returns null when saved has no data URI and current diverged from saved', () => {
+    expect(reconcileMarkdownSource('saved', 'rewritten', 'user typed something else')).toBe(null);
+  });
+
+  test('merges substitutions when user typed AFTER the data URI mid-save', () => {
+    const saved = `![pic](${DATA_URI})`;
+    const rewritten = `![pic](${BLOB_PATH})`;
+    const current = `![pic](${DATA_URI})\n\nNew paragraph user typed during save.`;
+    const expected = `![pic](${BLOB_PATH})\n\nNew paragraph user typed during save.`;
+    expect(reconcileMarkdownSource(saved, rewritten, current)).toBe(expected);
+  });
+
+  test('merges substitutions when user typed BEFORE the data URI mid-save', () => {
+    const saved = `start ![pic](${DATA_URI}) end`;
+    const rewritten = `start ![pic](${BLOB_PATH}) end`;
+    const current = `inserted at top\n\nstart ![pic](${DATA_URI}) end`;
+    const expected = `inserted at top\n\nstart ![pic](${BLOB_PATH}) end`;
+    expect(reconcileMarkdownSource(saved, rewritten, current)).toBe(expected);
+  });
+
+  test('handles multiple data URIs in a single save', () => {
+    const saved = `A ![1](${DATA_URI}) B ![2](${DATA_URI_2}) C`;
+    const rewritten = `A ![1](${BLOB_PATH}) B ![2](${BLOB_PATH_2}) C`;
+    const current = `A ![1](${DATA_URI}) B ![2](${DATA_URI_2}) C\n\nextra text`;
+    const expected = `A ![1](${BLOB_PATH}) B ![2](${BLOB_PATH_2}) C\n\nextra text`;
+    expect(reconcileMarkdownSource(saved, rewritten, current)).toBe(expected);
+  });
+
+  test('handles reference-style data URI definitions', () => {
+    const saved = `![pic][p]\n\n[p]: ${DATA_URI}`;
+    const rewritten = `![pic][p]\n\n[p]: ${BLOB_PATH}`;
+    const current = `![pic][p]\n\nuser typed more\n\n[p]: ${DATA_URI}`;
+    const expected = `![pic][p]\n\nuser typed more\n\n[p]: ${BLOB_PATH}`;
+    expect(reconcileMarkdownSource(saved, rewritten, current)).toBe(expected);
+  });
+
+  test('returns null when user removed the data URI before response', () => {
+    const saved = `![pic](${DATA_URI})`;
+    const rewritten = `![pic](${BLOB_PATH})`;
+    const current = 'user wiped everything';
+    expect(reconcileMarkdownSource(saved, rewritten, current)).toBe(null);
+  });
+
+  test('returns null on non-string inputs', () => {
+    expect(reconcileMarkdownSource(null, 'a', 'a')).toBe(null);
+    expect(reconcileMarkdownSource('a', null, 'a')).toBe(null);
+    expect(reconcileMarkdownSource('a', 'a', null)).toBe(null);
+  });
+});

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -1059,7 +1059,9 @@ export function initializeCreativeRowEditor() {
         saving = true;
 
         // Capture values being saved to update dirty state on success
-        const savedContent = markdownMode ? (markdownTextarea?.value || '') : descriptionInput.value;
+        // NOTE: `let` (not `const`) — when the server rewrites markdown_source
+        // (e.g. data: URI → blob path) we reassign below.
+        let savedContent = markdownMode ? (markdownTextarea?.value || '') : descriptionInput.value;
         const shouldPersistProgress = progressValueChanged();
         const savedProgress = shouldPersistProgress ? readProgressValue() : progressBaselineValueFrom(originalProgress);
         const savedOriginId = originIdInput ? originIdInput.value : '';

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -4,6 +4,7 @@ import { $getCharacterOffsets, $getSelection, $isRangeSelection, $isTextNode, $i
 import { createInlineEditor } from './lexical_inline_editor'
 import { renderCreativeTree, dispatchCreativeTreeUpdated } from '../creatives/tree_renderer'
 import { isProgressComplete, progressBaselineValueFrom, progressValueChangedFrom } from './creative_progress'
+import { renderMarkdown } from '../lib/utils/markdown'
 import yaml from 'js-yaml'
 // Import Stimulus application from the global window (set by host app)
 const application = window.Stimulus
@@ -106,6 +107,16 @@ export function initializeCreativeRowEditor() {
     const metadataEditor = document.getElementById('metadata-yaml-editor');
     const metadataSaveBtn = document.getElementById('metadata-save-btn');
     const metadataCloseBtn = document.getElementById('metadata-popup-close');
+
+    // Markdown editor elements
+    const contentTypeInput = document.getElementById('inline-content-type');
+    const markdownSourceInput = document.getElementById('inline-markdown-source');
+    const markdownWrapper = document.getElementById('markdown-editor-wrapper');
+    const markdownTextarea = document.getElementById('markdown-editor-textarea');
+    const markdownPreview = document.getElementById('markdown-preview');
+    const toggleMarkdownBtn = document.getElementById('inline-toggle-markdown');
+    let markdownMode = false;
+    let markdownPreviewTimer = null;
 
     let lexicalEditor = null;
     if (editorContainer) {
@@ -239,6 +250,12 @@ export function initializeCreativeRowEditor() {
       if (Object.prototype.hasOwnProperty.call(data, 'origin_id')) {
         setRowDatasetValue(row, 'originId', data.origin_id ?? '');
       }
+      if (Object.prototype.hasOwnProperty.call(data, 'content_type')) {
+        setRowDatasetValue(row, 'contentType', data.content_type ?? '');
+      }
+      if (Object.prototype.hasOwnProperty.call(data, 'markdown_source')) {
+        setRowDatasetValue(row, 'markdownSource', data.markdown_source ?? '');
+      }
       if (Object.prototype.hasOwnProperty.call(data, 'has_children')) {
         if (data.has_children) {
           row.setAttribute('has-children', '');
@@ -277,7 +294,9 @@ export function initializeCreativeRowEditor() {
         description_raw_html: rawHtml,
         origin_id: row.dataset?.originId || '',
         parent_id: parentId,
-        progress: Number.isNaN(progressValue) ? 0 : progressValue
+        progress: Number.isNaN(progressValue) ? 0 : progressValue,
+        content_type: row.dataset?.contentType || null,
+        markdown_source: row.dataset?.markdownSource || null
       };
     }
 
@@ -289,6 +308,43 @@ export function initializeCreativeRowEditor() {
       return (temp.textContent || '').trim().length === 0;
     }
 
+    function isMarkdownEmpty(md) {
+      return !md || md.trim().length === 0;
+    }
+
+    function activateMarkdownMode(source) {
+      markdownMode = true;
+      if (contentTypeInput) contentTypeInput.value = 'markdown';
+      if (markdownTextarea) markdownTextarea.value = source || '';
+      if (markdownWrapper) markdownWrapper.style.display = '';
+      if (editorContainer) editorContainer.style.display = 'none';
+      if (markdownPreview) markdownPreview.innerHTML = source ? renderMarkdown(source) : '';
+      if (toggleMarkdownBtn) {
+        toggleMarkdownBtn.textContent = toggleMarkdownBtn.dataset.labelRichtext || 'Rich Text';
+        toggleMarkdownBtn.classList.add('active');
+      }
+      if (markdownTextarea) markdownTextarea.focus();
+    }
+
+    function deactivateMarkdownMode() {
+      markdownMode = false;
+      if (contentTypeInput) contentTypeInput.value = 'html';
+      if (markdownSourceInput) markdownSourceInput.value = '';
+      if (markdownWrapper) markdownWrapper.style.display = 'none';
+      if (editorContainer) editorContainer.style.display = '';
+      if (toggleMarkdownBtn) {
+        toggleMarkdownBtn.textContent = toggleMarkdownBtn.dataset.labelMarkdown || 'MD';
+        toggleMarkdownBtn.classList.remove('active');
+      }
+    }
+
+    function syncMarkdownToForm() {
+      if (!markdownMode) return;
+      const md = markdownTextarea ? markdownTextarea.value : '';
+      if (markdownSourceInput) markdownSourceInput.value = md;
+      if (descriptionInput) descriptionInput.value = renderMarkdown(md);
+    }
+
     function applyCreativeData(data, tree) {
       if (!data) return;
       const creativeId = data.id;
@@ -298,10 +354,21 @@ export function initializeCreativeRowEditor() {
       form.dataset.creativeId = creativeId;
       const content = data.description_raw_html || data.description || '';
       descriptionInput.value = content;
-      lexicalEditor.load(content, `creative-${creativeId}-${Date.now()}`);
+
+      // Handle markdown vs rich text mode
+      const isMarkdown = data.content_type === 'markdown';
+      if (isMarkdown) {
+        activateMarkdownMode(data.markdown_source || '');
+        // Also load Lexical with HTML for fallback/switching
+        lexicalEditor.load(content, `creative-${creativeId}-${Date.now()}`);
+      } else {
+        deactivateMarkdownMode();
+        lexicalEditor.load(content, `creative-${creativeId}-${Date.now()}`);
+      }
+
       pendingSave = false;
       // Track original content for dirty state detection
-      originalContent = content;
+      originalContent = isMarkdown ? (data.markdown_source || '') : content;
       isDirty = false;
       const progressNumber = Number(data.progress ?? 0);
       const normalizedProgress = Number.isNaN(progressNumber) ? 0 : progressNumber;
@@ -323,7 +390,9 @@ export function initializeCreativeRowEditor() {
       const effectiveParent = parentInput.value;
       if (unconvertBtn) unconvertBtn.style.display = effectiveParent ? '' : 'none';
       originalProgress = normalizedProgress;
-      lexicalEditor.focus();
+      if (!isMarkdown) {
+        lexicalEditor.focus();
+      }
       updateActionButtonStates();
       // Reload metadata if the popup is open
       if (isMetadataPopupVisible()) {
@@ -973,7 +1042,13 @@ export function initializeCreativeRowEditor() {
         if (saving) return savePromise;
         clearTimeout(saveTimer);
 
-        if (isHtmlEmpty(descriptionInput.value)) {
+        // Sync markdown form fields before saving
+        if (markdownMode) syncMarkdownToForm();
+
+        const isEmpty = markdownMode
+          ? isMarkdownEmpty(markdownTextarea?.value)
+          : isHtmlEmpty(descriptionInput.value);
+        if (isEmpty) {
           pendingSave = false;
           return Promise.resolve();
         }
@@ -984,7 +1059,7 @@ export function initializeCreativeRowEditor() {
         saving = true;
 
         // Capture values being saved to update dirty state on success
-        const savedContent = descriptionInput.value;
+        const savedContent = markdownMode ? (markdownTextarea?.value || '') : descriptionInput.value;
         const shouldPersistProgress = progressValueChanged();
         const savedProgress = shouldPersistProgress ? readProgressValue() : progressBaselineValueFrom(originalProgress);
         const savedOriginId = originIdInput ? originIdInput.value : '';
@@ -1010,7 +1085,8 @@ export function initializeCreativeRowEditor() {
             originalOriginId = savedOriginId;
 
             // If current values match what was just saved, clear dirty flag
-            if (descriptionInput.value === savedContent &&
+            const currentContent = markdownMode ? (markdownTextarea?.value || '') : descriptionInput.value;
+            if (currentContent === savedContent &&
               readProgressValue() === savedProgress &&
               originIdInput.value === savedOriginId) {
               isDirty = false;
@@ -1197,6 +1273,8 @@ export function initializeCreativeRowEditor() {
 
       // CRITICAL: Capture ALL values BEFORE awaiting, because the editor may switch
       // to a different creative while we're waiting for uploads
+      const isMarkdownSave = markdownMode;
+      if (isMarkdownSave) syncMarkdownToForm();
       let currentContent = descriptionInput.value;
       let currentProgress = readProgressValue();
       let shouldPersistProgress = progressValueChanged();
@@ -1204,10 +1282,15 @@ export function initializeCreativeRowEditor() {
       const currentBeforeId = tree.previousElementSibling ? creativeIdFrom(tree.previousElementSibling) : '';
       const currentAfterId = tree.nextElementSibling ? creativeIdFrom(tree.nextElementSibling) : '';
       const startCreativeId = creativeId;
+      const capturedMarkdownSource = isMarkdownSave ? (markdownTextarea?.value || '') : '';
+      const capturedContentType = isMarkdownSave ? 'markdown' : 'html';
 
       // Prevent saving empty content, matching saveForm behavior
       // This avoids overwriting existing descriptions with empty strings during quick navigation
-      if (isHtmlEmpty(currentContent)) {
+      const isEmpty = isMarkdownSave
+        ? isMarkdownEmpty(capturedMarkdownSource)
+        : isHtmlEmpty(currentContent);
+      if (isEmpty) {
         pendingSave = false;
         return;
       }
@@ -1228,8 +1311,12 @@ export function initializeCreativeRowEditor() {
       // Note: before_id and after_id must be top-level params, not nested under creative[]
       // because CreativesController reads params[:before_id] and params[:after_id] for positioning
       const body = {
-        'creative[description]': currentContent
+        'creative[description]': currentContent,
+        'creative[content_type_input]': capturedContentType
       };
+      if (isMarkdownSave) {
+        body['creative[markdown_source]'] = capturedMarkdownSource;
+      }
 
       if (shouldPersistProgress) {
         body['creative[progress]'] = currentProgress;
@@ -1739,6 +1826,7 @@ export function initializeCreativeRowEditor() {
           afterInput.value = afterId || '';
           if (childInput) childInput.value = childId || '';
           resetOriginTracking();
+          deactivateMarkdownMode();
           descriptionInput.value = '';
           lexicalEditor.reset(`new-${Date.now()}`);
           setProgressState(0);
@@ -1781,10 +1869,23 @@ export function initializeCreativeRowEditor() {
     }
 
     function onLexicalChange(html) {
+      if (markdownMode) return; // Ignore Lexical changes in markdown mode
       descriptionInput.value = html;
       // Mark as dirty if content changed from original
       isDirty = (html !== originalContent);
       scheduleSave();
+    }
+
+    function onMarkdownTextareaInput() {
+      const md = markdownTextarea.value;
+      syncMarkdownToForm();
+      isDirty = (md !== originalContent);
+      scheduleSave();
+      // Debounced live preview
+      clearTimeout(markdownPreviewTimer);
+      markdownPreviewTimer = setTimeout(() => {
+        if (markdownPreview) markdownPreview.innerHTML = renderMarkdown(md);
+      }, 300);
     }
 
     // Intercepts Shift+Enter via capture-phase keydown on Lexical's root element.
@@ -2173,6 +2274,49 @@ export function initializeCreativeRowEditor() {
           }
         });
       }
+    }
+
+    // Markdown toggle button
+    if (toggleMarkdownBtn) {
+      toggleMarkdownBtn.addEventListener('click', function () {
+        if (markdownMode) {
+          // Switching from Markdown → Rich Text
+          const confirmMsg = toggleMarkdownBtn.dataset.confirmToRichtext;
+          if (confirmMsg && !confirm(confirmMsg)) return;
+          const md = markdownTextarea?.value || '';
+          const html = md ? renderMarkdown(md) : '';
+          deactivateMarkdownMode();
+          descriptionInput.value = html;
+          lexicalEditor.load(html, `creative-switch-${Date.now()}`);
+          lexicalEditor.focus();
+          isDirty = true;
+          scheduleSave();
+        } else {
+          // Switching from Rich Text → Markdown
+          activateMarkdownMode('');
+          isDirty = true;
+          scheduleSave();
+        }
+      });
+    }
+
+    // Markdown textarea input handler
+    if (markdownTextarea) {
+      markdownTextarea.addEventListener('input', onMarkdownTextareaInput);
+
+      // Support keyboard shortcuts in markdown textarea
+      markdownTextarea.addEventListener('keydown', function (event) {
+        if (event.key === 'Escape') {
+          event.preventDefault();
+          hideCurrent();
+          return;
+        }
+        // Shift+Enter → add new sibling (same as Lexical)
+        if (event.key === 'Enter' && event.shiftKey) {
+          event.preventDefault();
+          addNew();
+        }
+      });
     }
   });
 }

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -1077,6 +1077,19 @@ export function initializeCreativeRowEditor() {
           return r.text().then(function (text) {
             try { return text ? JSON.parse(text) : {}; } catch (e) { return {}; }
           }).then(function (data) {
+            // Sync rewritten markdown source back into the textarea/hidden input.
+            // Server rewrites inline data: URIs in markdown_source to blob paths so
+            // re-saves don't re-import the same image. If the user hasn't edited
+            // during the request (textarea still equals what we sent), apply the
+            // rewritten source so the next save carries the blob path.
+            if (markdownMode && data && typeof data.markdown_source === 'string'
+                && data.markdown_source !== savedContent
+                && markdownTextarea && markdownTextarea.value === savedContent) {
+              markdownTextarea.value = data.markdown_source;
+              syncMarkdownToForm();
+              savedContent = data.markdown_source;
+            }
+
             // Update dirty state to reflect successful save
             originalContent = savedContent;
             if (shouldPersistProgress) {
@@ -1375,12 +1388,42 @@ export function initializeCreativeRowEditor() {
 
       // Queue the save request
       // Store deletedAttachmentIds as data, not as callback, so it can be serialized
+      // Capture per-enqueue values for the onSuccess closure so concurrent edits
+      // on a different creative don't get clobbered when the response comes back.
+      const onSuccessCreativeId = startCreativeId;
+      const onSuccessSavedMarkdown = isMarkdownSave ? capturedMarkdownSource : null;
+      const onSuccessTree = tree;
       apiQueue.enqueue({
         path: `/creatives/${creativeId}`,
         method: 'PATCH',
         body: body,
         dedupeKey: `creative_${creativeId}`,
-        deletedAttachmentIds: deletedAttachmentIds  // Store as data for serialization
+        deletedAttachmentIds: deletedAttachmentIds,  // Store as data for serialization
+        onSuccess: function (data) {
+          if (!isMarkdownSave || !data || typeof data.markdown_source !== 'string') return;
+          if (data.markdown_source === onSuccessSavedMarkdown) return;
+
+          // Update the row dataset cache regardless of which creative is active now,
+          // so a later loadCreative() for this row picks up the rewritten source.
+          if (onSuccessTree) {
+            const row = treeRowElement(onSuccessTree);
+            if (row && row.dataset.markdownSource === onSuccessSavedMarkdown) {
+              row.dataset.markdownSource = data.markdown_source;
+              row.requestUpdate?.();
+            }
+          }
+
+          // Only touch the live textarea if we are still editing the same creative
+          // AND the user hasn't typed since we queued the save.
+          if (form.dataset.creativeId === onSuccessCreativeId
+              && markdownMode
+              && markdownTextarea
+              && markdownTextarea.value === onSuccessSavedMarkdown) {
+            markdownTextarea.value = data.markdown_source;
+            syncMarkdownToForm();
+            originalContent = data.markdown_source;
+          }
+        }
       });
       // console.warn('apiQueue.enqueue disabled for debugging');
 

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -6,6 +6,7 @@ import { renderCreativeTree, dispatchCreativeTreeUpdated } from '../creatives/tr
 import { isProgressComplete, progressBaselineValueFrom, progressValueChangedFrom } from './creative_progress'
 import { renderMarkdown } from '../lib/utils/markdown'
 import { reconcileMarkdownSource } from './markdown_source_reconcile'
+import { isHtmlEmpty } from './html_content_empty'
 import yaml from 'js-yaml'
 // Import Stimulus application from the global window (set by host app)
 const application = window.Stimulus
@@ -299,14 +300,6 @@ export function initializeCreativeRowEditor() {
         content_type: row.dataset?.contentType || null,
         markdown_source: row.dataset?.markdownSource || null
       };
-    }
-
-    function isHtmlEmpty(html) {
-      if (!html) return true;
-      const temp = document.createElement('div');
-      temp.innerHTML = html;
-      if (temp.querySelector('img')) return false;
-      return (temp.textContent || '').trim().length === 0;
     }
 
     function isMarkdownEmpty(md) {
@@ -2362,8 +2355,7 @@ export function initializeCreativeRowEditor() {
         } else {
           // Switching from Rich Text → Markdown
           const currentHtml = descriptionInput.value || '';
-          const hasRichText = currentHtml.replace(/<[^>]*>/g, '').trim().length > 0;
-          if (hasRichText) {
+          if (!isHtmlEmpty(currentHtml)) {
             const confirmMsg = toggleMarkdownBtn.dataset.confirmToMarkdown;
             if (confirmMsg && !confirm(confirmMsg)) return;
           }

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -2302,6 +2302,12 @@ export function initializeCreativeRowEditor() {
           scheduleSave();
         } else {
           // Switching from Rich Text → Markdown
+          const currentHtml = descriptionInput.value || '';
+          const hasRichText = currentHtml.replace(/<[^>]*>/g, '').trim().length > 0;
+          if (hasRichText) {
+            const confirmMsg = toggleMarkdownBtn.dataset.confirmToMarkdown;
+            if (confirmMsg && !confirm(confirmMsg)) return;
+          }
           activateMarkdownMode('');
           isDirty = true;
           scheduleSave();

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -1344,6 +1344,8 @@ export function initializeCreativeRowEditor() {
           if (shouldPersistProgress) {
             row.dataset.progressValue = String(currentProgress);
           }
+          row.dataset.contentType = capturedContentType;
+          row.dataset.markdownSource = isMarkdownSave ? capturedMarkdownSource : '';
           if (currentParentId) {
             tree.dataset.parentId = currentParentId;
             row.parentId = currentParentId;

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -5,6 +5,7 @@ import { createInlineEditor } from './lexical_inline_editor'
 import { renderCreativeTree, dispatchCreativeTreeUpdated } from '../creatives/tree_renderer'
 import { isProgressComplete, progressBaselineValueFrom, progressValueChangedFrom } from './creative_progress'
 import { renderMarkdown } from '../lib/utils/markdown'
+import { reconcileMarkdownSource } from './markdown_source_reconcile'
 import yaml from 'js-yaml'
 // Import Stimulus application from the global window (set by host app)
 const application = window.Stimulus
@@ -1081,15 +1082,21 @@ export function initializeCreativeRowEditor() {
           }).then(function (data) {
             // Sync rewritten markdown source back into the textarea/hidden input.
             // Server rewrites inline data: URIs in markdown_source to blob paths so
-            // re-saves don't re-import the same image. If the user hasn't edited
-            // during the request (textarea still equals what we sent), apply the
-            // rewritten source so the next save carries the blob path.
+            // re-saves don't re-import the same image. If the user typed during the
+            // request, merge the substitutions into the live textarea so the next
+            // save still carries blob paths instead of re-importing the data URI.
             if (markdownMode && data && typeof data.markdown_source === 'string'
-                && data.markdown_source !== savedContent
-                && markdownTextarea && markdownTextarea.value === savedContent) {
-              markdownTextarea.value = data.markdown_source;
-              syncMarkdownToForm();
-              savedContent = data.markdown_source;
+                && data.markdown_source !== savedContent && markdownTextarea) {
+              const reconciled = reconcileMarkdownSource(
+                savedContent, data.markdown_source, markdownTextarea.value
+              );
+              if (reconciled !== null && reconciled !== markdownTextarea.value) {
+                markdownTextarea.value = reconciled;
+                syncMarkdownToForm();
+              }
+              if (reconciled !== null) {
+                savedContent = data.markdown_source;
+              }
             }
 
             // Update dirty state to reflect successful save
@@ -1415,15 +1422,22 @@ export function initializeCreativeRowEditor() {
             }
           }
 
-          // Only touch the live textarea if we are still editing the same creative
-          // AND the user hasn't typed since we queued the save.
+          // Merge the data: URI -> blob path substitutions into the live textarea,
+          // even if the user typed during the queued save. We still require the
+          // same creative to be open (race-safe across editor switches).
           if (form.dataset.creativeId === onSuccessCreativeId
               && markdownMode
-              && markdownTextarea
-              && markdownTextarea.value === onSuccessSavedMarkdown) {
-            markdownTextarea.value = data.markdown_source;
-            syncMarkdownToForm();
-            originalContent = data.markdown_source;
+              && markdownTextarea) {
+            const reconciled = reconcileMarkdownSource(
+              onSuccessSavedMarkdown, data.markdown_source, markdownTextarea.value
+            );
+            if (reconciled !== null && reconciled !== markdownTextarea.value) {
+              markdownTextarea.value = reconciled;
+              syncMarkdownToForm();
+            }
+            if (reconciled !== null) {
+              originalContent = data.markdown_source;
+            }
           }
         }
       });

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -1282,7 +1282,7 @@ export function initializeCreativeRowEditor() {
       const currentBeforeId = tree.previousElementSibling ? creativeIdFrom(tree.previousElementSibling) : '';
       const currentAfterId = tree.nextElementSibling ? creativeIdFrom(tree.nextElementSibling) : '';
       const startCreativeId = creativeId;
-      const capturedMarkdownSource = isMarkdownSave ? (markdownTextarea?.value || '') : '';
+      let capturedMarkdownSource = isMarkdownSave ? (markdownTextarea?.value || '') : '';
       const capturedContentType = isMarkdownSave ? 'markdown' : 'html';
 
       // Prevent saving empty content, matching saveForm behavior
@@ -1300,8 +1300,15 @@ export function initializeCreativeRowEditor() {
       await waitForUploads();
 
       // If we are still on the same creative (e.g. move awaited us), refresh the content
-      // This ensures we capture the final HTML with signed IDs instead of blob URLs
+      // This ensures we capture the final HTML with signed IDs instead of blob URLs.
+      // Markdown saves regenerate description from creative[markdown_source] server-side,
+      // so we must re-sync and re-capture the latest textarea value too — otherwise edits
+      // made during the upload wait get overwritten by the stale pre-wait source.
       if (form.dataset.creativeId === startCreativeId) {
+        if (isMarkdownSave) {
+          syncMarkdownToForm();
+          capturedMarkdownSource = markdownTextarea?.value || '';
+        }
         currentContent = descriptionInput.value;
         currentProgress = readProgressValue();
         shouldPersistProgress = progressValueChanged();

--- a/engines/collavre/app/javascript/modules/html_content_empty.js
+++ b/engines/collavre/app/javascript/modules/html_content_empty.js
@@ -1,0 +1,12 @@
+// True when an HTML fragment has no user-visible content. Treats inline
+// images and attachments (action-text-attachment / figure.attachment /
+// data-trix-attachment) as content so image-only or attachment-only bodies
+// don't get discarded silently when switching editor modes.
+export function isHtmlEmpty(html, doc = typeof document !== 'undefined' ? document : null) {
+  if (!html) return true;
+  if (!doc) return html.replace(/<[^>]*>/g, '').trim().length === 0;
+  const temp = doc.createElement('div');
+  temp.innerHTML = html;
+  if (temp.querySelector('img, action-text-attachment, figure.attachment, [data-trix-attachment]')) return false;
+  return (temp.textContent || '').trim().length === 0;
+}

--- a/engines/collavre/app/javascript/modules/markdown_source_reconcile.js
+++ b/engines/collavre/app/javascript/modules/markdown_source_reconcile.js
@@ -1,0 +1,53 @@
+// Reconcile a server-rewritten markdown source with the current textarea value
+// when the user typed during the save. The server's rewrite is a pure
+// data: URI -> blob path substitution on what we sent (`savedContent`).
+// If every data: URI we sent is still present in `currentValue`, apply the
+// same substitutions there and return the merged value; otherwise return null.
+export function reconcileMarkdownSource(savedContent, rewritten, currentValue) {
+  if (typeof savedContent !== 'string' || typeof rewritten !== 'string'
+      || typeof currentValue !== 'string') return null;
+  if (rewritten === savedContent) return null;
+  if (currentValue === savedContent) return rewritten;
+
+  const dataUriRegex = /data:image\/[^\s)>"'`\]]+/g;
+  const matches = [];
+  let m;
+  while ((m = dataUriRegex.exec(savedContent)) !== null) {
+    matches.push({ uri: m[0], start: m.index, end: m.index + m[0].length });
+  }
+  if (matches.length === 0) return null;
+
+  const pairs = [];
+  let savedPos = 0;
+  let rewrittenPos = 0;
+  for (let i = 0; i < matches.length; i++) {
+    const match = matches[i];
+    const textLen = match.start - savedPos;
+    if (rewritten.slice(rewrittenPos, rewrittenPos + textLen)
+        !== savedContent.slice(savedPos, match.start)) return null;
+    rewrittenPos += textLen;
+    savedPos = match.end;
+
+    const nextStart = (i + 1 < matches.length) ? matches[i + 1].start : savedContent.length;
+    const tail = savedContent.slice(savedPos, nextStart);
+    let blobEnd;
+    if (tail.length === 0) {
+      blobEnd = rewritten.length;
+    } else {
+      blobEnd = rewritten.indexOf(tail, rewrittenPos);
+      if (blobEnd === -1) return null;
+    }
+    pairs.push({ from: match.uri, to: rewritten.slice(rewrittenPos, blobEnd) });
+    rewrittenPos = blobEnd;
+  }
+  if (rewritten.slice(rewrittenPos) !== savedContent.slice(savedPos)) return null;
+
+  let result = currentValue;
+  for (const pair of pairs) {
+    if (pair.from === pair.to) continue;
+    const idx = result.indexOf(pair.from);
+    if (idx === -1) return null;
+    result = result.slice(0, idx) + pair.to + result.slice(idx + pair.from.length);
+  }
+  return result;
+}

--- a/engines/collavre/app/models/collavre/creative/describable.rb
+++ b/engines/collavre/app/models/collavre/creative/describable.rb
@@ -70,6 +70,15 @@ module Collavre
           self.data ||= {}
           self.data.delete("content_type")
           self.data.delete("markdown_source")
+        elsif !new_record? && description_changed? && data&.dig("content_type") == "markdown"
+          # Description was rewritten through a non-markdown path (tool/MCP
+          # update, direct base.update(description: ...), etc.) on a creative
+          # that was previously in markdown mode. The new HTML no longer
+          # matches data["markdown_source"], so the next inline-markdown open
+          # would load the stale source and silently overwrite this update.
+          # Demote to HTML mode so the persisted source matches description.
+          self.data.delete("content_type")
+          self.data.delete("markdown_source")
         end
       end
 

--- a/engines/collavre/app/models/collavre/creative/describable.rb
+++ b/engines/collavre/app/models/collavre/creative/describable.rb
@@ -10,7 +10,7 @@ module Collavre
         validate :description_cannot_change_if_has_origin, on: :update
         validate :description_cannot_change_if_github_source, on: :update
 
-        before_save :convert_markdown_to_html
+        before_validation :convert_markdown_to_html
         before_save :sanitize_description_html
         after_destroy_commit :purge_description_attachments
       end

--- a/engines/collavre/app/models/collavre/creative/describable.rb
+++ b/engines/collavre/app/models/collavre/creative/describable.rb
@@ -84,10 +84,24 @@ module Collavre
         table_tags = %w[table thead tbody tfoot tr th td]
         table_attrs = %w[colspan rowspan]
         attachment_attrs = %w[download data-filesize]
+        task_list_attrs = %w[type disabled checked]
+
+        # GFM task list checkboxes (`- [ ]` / `- [x]`) render as
+        # <input type="checkbox" disabled> via Commonmarker's tasklist
+        # extension. Strip any other <input> variant before sanitization
+        # so allowing the `input` tag in the safelist can't smuggle in
+        # text/image/submit inputs.
+        scrubbed = Loofah.fragment(description.to_s)
+        scrubbed.css("input").each do |node|
+          unless node["type"] == "checkbox" && node.has_attribute?("disabled")
+            node.remove
+          end
+        end
+
         self.description = ActionController::Base.helpers.sanitize(
-          description,
-          tags: Rails::HTML5::SafeListSanitizer.allowed_tags.to_a + table_tags,
-          attributes: Rails::HTML5::SafeListSanitizer.allowed_attributes.to_a + table_attrs + attachment_attrs + %w[data-lexical]
+          scrubbed.to_html,
+          tags: Rails::HTML5::SafeListSanitizer.allowed_tags.to_a + table_tags + %w[input],
+          attributes: Rails::HTML5::SafeListSanitizer.allowed_attributes.to_a + table_attrs + attachment_attrs + task_list_attrs + %w[data-lexical]
         )
       end
 

--- a/engines/collavre/app/models/collavre/creative/describable.rb
+++ b/engines/collavre/app/models/collavre/creative/describable.rb
@@ -55,10 +55,16 @@ module Collavre
           prev_source = data["markdown_source"].to_s
           prev_type = data["content_type"]
           self.data["content_type"] = "markdown"
-          self.data["markdown_source"] = new_source
           if new_source != prev_source || prev_type != "markdown"
-            self.description = Collavre::MarkdownConverter.markdown_to_html(new_source)
+            # Rewrite inline data-URI images to freshly-uploaded blob paths
+            # FIRST, then persist the rewritten source. Subsequent edits
+            # around the same image carry the blob path instead of the
+            # data URI, so re-renders no longer create duplicate blobs.
+            rewritten_source = Collavre::MarkdownConverter.rewrite_data_uri_images(new_source)
+            self.data["markdown_source"] = rewritten_source
+            self.description = Collavre::MarkdownConverter.markdown_to_html(rewritten_source)
           else
+            self.data["markdown_source"] = new_source
             # Source unchanged: description must stay derived from markdown_source.
             # Restore the persisted value rather than trusting params[:description],
             # which would let a stale/crafted request diverge from markdown_source.

--- a/engines/collavre/app/models/collavre/creative/describable.rb
+++ b/engines/collavre/app/models/collavre/creative/describable.rb
@@ -20,14 +20,6 @@ module Collavre
         after_destroy_commit :purge_description_attachments
       end
 
-      def markdown_type?
-        data&.dig("content_type") == "markdown"
-      end
-
-      def markdown_source_text
-        data&.dig("markdown_source")
-      end
-
       # Linked Creative의 description을 안전하게 반환
       def effective_description(variation_id = nil, html = true)
         if variation_id.present?

--- a/engines/collavre/app/models/collavre/creative/describable.rb
+++ b/engines/collavre/app/models/collavre/creative/describable.rb
@@ -4,12 +4,23 @@ module Collavre
       extend ActiveSupport::Concern
 
       included do
+        attr_accessor :markdown_source, :content_type_input
+
         validates :description, presence: true, unless: -> { origin_id.present? }
         validate :description_cannot_change_if_has_origin, on: :update
         validate :description_cannot_change_if_github_source, on: :update
 
+        before_save :convert_markdown_to_html
         before_save :sanitize_description_html
         after_destroy_commit :purge_description_attachments
+      end
+
+      def markdown_type?
+        data&.dig("content_type") == "markdown"
+      end
+
+      def markdown_source_text
+        data&.dig("markdown_source")
       end
 
       # Linked Creative의 description을 안전하게 반환
@@ -31,6 +42,24 @@ module Collavre
       end
 
       private
+
+      def convert_markdown_to_html
+        if content_type_input == "markdown"
+          self.data ||= {}
+          self.data["content_type"] = "markdown"
+          self.data["markdown_source"] = markdown_source.to_s
+          self.description = render_markdown_to_html(markdown_source.to_s)
+        elsif content_type_input == "html"
+          self.data ||= {}
+          self.data.delete("content_type")
+          self.data.delete("markdown_source")
+        end
+      end
+
+      def render_markdown_to_html(md)
+        return "" if md.blank?
+        Commonmarker.to_html(md, options: { extension: { table: true, autolink: true, strikethrough: true, tasklist: true } })
+      end
 
       def sanitize_description_html
         table_tags = %w[table thead tbody tfoot tr th td]

--- a/engines/collavre/app/models/collavre/creative/describable.rb
+++ b/engines/collavre/app/models/collavre/creative/describable.rb
@@ -4,7 +4,12 @@ module Collavre
       extend ActiveSupport::Concern
 
       included do
-        attr_accessor :markdown_source, :content_type_input
+        attr_accessor :content_type_input
+        attr_reader :markdown_source
+
+        def markdown_source=(value)
+          @markdown_source = value.is_a?(String) ? value.gsub(/\r\n?/, "\n") : value
+        end
 
         validates :description, presence: true, unless: -> { origin_id.present? }
         validate :description_cannot_change_if_has_origin, on: :update

--- a/engines/collavre/app/models/collavre/creative/describable.rb
+++ b/engines/collavre/app/models/collavre/creative/describable.rb
@@ -51,10 +51,15 @@ module Collavre
           prev_type = data["content_type"]
           self.data["content_type"] = "markdown"
           self.data["markdown_source"] = new_source
-          # Skip re-rendering when source is unchanged so repeat saves (autosave,
-          # progress, move) don't re-import data-URI images as fresh blobs.
           if new_source != prev_source || prev_type != "markdown"
             self.description = Collavre::MarkdownConverter.markdown_to_html(new_source)
+          else
+            # Source unchanged: description must stay derived from markdown_source.
+            # Restore the persisted value rather than trusting params[:description],
+            # which would let a stale/crafted request diverge from markdown_source.
+            # Skipping the re-render also avoids re-importing data-URI images as
+            # fresh Active Storage blobs on every autosave/progress/move.
+            self.description = description_was if description_changed?
           end
         elsif content_type_input == "html"
           self.data ||= {}

--- a/engines/collavre/app/models/collavre/creative/describable.rb
+++ b/engines/collavre/app/models/collavre/creative/describable.rb
@@ -48,17 +48,12 @@ module Collavre
           self.data ||= {}
           self.data["content_type"] = "markdown"
           self.data["markdown_source"] = markdown_source.to_s
-          self.description = render_markdown_to_html(markdown_source.to_s)
+          self.description = Collavre::MarkdownConverter.markdown_to_html(markdown_source.to_s)
         elsif content_type_input == "html"
           self.data ||= {}
           self.data.delete("content_type")
           self.data.delete("markdown_source")
         end
-      end
-
-      def render_markdown_to_html(md)
-        return "" if md.blank?
-        Commonmarker.to_html(md, options: { extension: { table: true, autolink: true, strikethrough: true, tasklist: true } })
       end
 
       def sanitize_description_html

--- a/engines/collavre/app/models/collavre/creative/describable.rb
+++ b/engines/collavre/app/models/collavre/creative/describable.rb
@@ -46,9 +46,16 @@ module Collavre
       def convert_markdown_to_html
         if content_type_input == "markdown"
           self.data ||= {}
+          new_source = markdown_source.to_s
+          prev_source = data["markdown_source"].to_s
+          prev_type = data["content_type"]
           self.data["content_type"] = "markdown"
-          self.data["markdown_source"] = markdown_source.to_s
-          self.description = Collavre::MarkdownConverter.markdown_to_html(markdown_source.to_s)
+          self.data["markdown_source"] = new_source
+          # Skip re-rendering when source is unchanged so repeat saves (autosave,
+          # progress, move) don't re-import data-URI images as fresh blobs.
+          if new_source != prev_source || prev_type != "markdown"
+            self.description = Collavre::MarkdownConverter.markdown_to_html(new_source)
+          end
         elsif content_type_input == "html"
           self.data ||= {}
           self.data.delete("content_type")

--- a/engines/collavre/app/services/collavre/creatives/tree_builder.rb
+++ b/engines/collavre/app/services/collavre/creatives/tree_builder.rb
@@ -128,7 +128,7 @@ module Creatives
           sequence: creative.sequence,
           link_url: view_context.collavre.creative_path(creative),
           templates: template_payload_for(creative, has_children: filtered_children.any?),
-          inline_editor_payload: inline_editor_payload_for(creative),
+          inline_editor_payload: inline_editor_payload_for(creative, can_write: cached_can_write?(creative)),
           children_container: children_container_payload(
             creative,
             filtered_children,
@@ -187,14 +187,14 @@ module Creatives
       }
     end
 
-    def inline_editor_payload_for(creative)
+    def inline_editor_payload_for(creative, can_write:)
       effective = creative.effective_origin(Set.new)
       {
         description_raw_html: creative.effective_description(nil, true),
         progress: creative.progress,
         origin_id: creative.origin_id,
         content_type: effective.data&.dig("content_type"),
-        markdown_source: effective.data&.dig("markdown_source")
+        markdown_source: can_write ? effective.data&.dig("markdown_source") : nil
       }
     end
 

--- a/engines/collavre/app/services/collavre/creatives/tree_builder.rb
+++ b/engines/collavre/app/services/collavre/creatives/tree_builder.rb
@@ -189,12 +189,13 @@ module Creatives
 
     def inline_editor_payload_for(creative, can_write:)
       effective = creative.effective_origin(Set.new)
+      origin_writable = effective.id == creative.id ? can_write : creative.has_permission?(user, :write)
       {
         description_raw_html: creative.effective_description(nil, true),
         progress: creative.progress,
         origin_id: creative.origin_id,
         content_type: effective.data&.dig("content_type"),
-        markdown_source: can_write ? effective.data&.dig("markdown_source") : nil
+        markdown_source: origin_writable ? effective.data&.dig("markdown_source") : nil
       }
     end
 

--- a/engines/collavre/app/services/collavre/creatives/tree_builder.rb
+++ b/engines/collavre/app/services/collavre/creatives/tree_builder.rb
@@ -188,10 +188,13 @@ module Creatives
     end
 
     def inline_editor_payload_for(creative)
+      effective = creative.effective_origin(Set.new)
       {
         description_raw_html: creative.effective_description(nil, true),
         progress: creative.progress,
-        origin_id: creative.origin_id
+        origin_id: creative.origin_id,
+        content_type: effective.data&.dig("content_type"),
+        markdown_source: effective.data&.dig("markdown_source")
       }
     end
 

--- a/engines/collavre/app/services/collavre/markdown_converter.rb
+++ b/engines/collavre/app/services/collavre/markdown_converter.rb
@@ -33,7 +33,11 @@ module Collavre
           end
         end
 
-        input.gsub!(/(?<!\\)!\[([^\]]*)\]\((data:image\/[^)]+)\)/) do
+        # Inline data-URI images. base64 contains no whitespace or `)`, so bound
+        # the URL on those and capture an optional CommonMark title separately;
+        # otherwise `data:...;base64,XYZ "caption"` would be slurped as one URL
+        # and fail the strict parser in `data_image_to_attachment`.
+        input.gsub!(/(?<!\\)!\[([^\]]*)\]\(\s*(data:image\/[^\s)]+)(?:\s+(?:"[^"]*"|'[^']*'))?\s*\)/) do
           data_image_to_attachment($2, $1)
         end
 
@@ -221,10 +225,13 @@ module Collavre
           "#{lead}#{label}#{mid}#{blob_path}#{tail}"
         end
 
-        # Inline data-URI images: ![alt](data:...) → ![alt](blob_path)
-        result.gsub!(/(?<!\\)!\[([^\]]*)\]\((data:image\/[^)]+)\)/) do
-          alt, data_url = $1, $2
-          "![#{alt}](#{data_uri_to_blob_path(data_url)})"
+        # Inline data-URI images: ![alt](data:...) or ![alt](data:... "title")
+        # → ![alt](blob_path) / ![alt](blob_path "title"). Parse the title
+        # separately so it doesn't get captured into the data URL and break
+        # strict matching in `data_uri_to_blob_path`.
+        result.gsub!(/(?<!\\)!\[([^\]]*)\]\(\s*(data:image\/[^\s)]+)(\s+(?:"[^"]*"|'[^']*'))?\s*\)/) do
+          alt, data_url, title = $1, $2, $3
+          "![#{alt}](#{data_uri_to_blob_path(data_url)}#{title})"
         end
 
         result

--- a/engines/collavre/app/services/collavre/markdown_converter.rb
+++ b/engines/collavre/app/services/collavre/markdown_converter.rb
@@ -14,32 +14,38 @@ module Collavre
       # Falls back to lightweight regex conversion for short inline fragments.
       def markdown_to_html(text, image_refs = {})
         return "" if text.nil?
-        input = text.dup
 
-        # Collect reference-style data-URI images. CommonMark allows both the
-        # angle-bracket form `[alt]: <data:...>` and the bare form
-        # `[alt]: data:image/...`, optionally followed by a title.
-        input.gsub!(/^\s*\[([^\]]+)\]:\s*(?:<\s*(data:image\/[^>]+?)\s*>|(data:image\/\S+))\s*(?:"[^"]*"|'[^']*'|\([^)]*\))?\s*$/) do
-          image_refs[$1] = ($2 || $3).strip
-          ""
-        end
-
-        # Convert data-URI images to Active Storage before rendering
-        input.gsub!(/(?<!\\)!\[([^\]]*)\]\[([^\]]+)\]/) do
-          if (data_url = image_refs[$2])
-            data_image_to_attachment(data_url, $1)
-          else
-            "![#{$1}][#{$2}]"
+        # Protect fenced code blocks and inline code spans from the regex
+        # rewrites below — a Markdown sample like ```` ```md\n![x](data:...)\n``` ````
+        # must not silently upload its data URI as an Active Storage blob.
+        input = with_code_protected(text.dup) do |source|
+          # Collect reference-style data-URI images. CommonMark allows both the
+          # angle-bracket form `[alt]: <data:...>` and the bare form
+          # `[alt]: data:image/...`, optionally followed by a title.
+          source.gsub!(/^\s*\[([^\]]+)\]:\s*(?:<\s*(data:image\/[^>]+?)\s*>|(data:image\/\S+))\s*(?:"[^"]*"|'[^']*'|\([^)]*\))?\s*$/) do
+            image_refs[$1] = ($2 || $3).strip
+            ""
           end
-        end
 
-        # Inline data-URI images. base64 contains no whitespace or `)`, so bound
-        # the URL on those and capture an optional CommonMark title separately;
-        # otherwise `data:...;base64,XYZ "caption"` would be slurped as one URL
-        # and fail the strict parser in `data_image_to_attachment`. Titles may be
-        # double-quoted, single-quoted, or parenthesized per CommonMark.
-        input.gsub!(/(?<!\\)!\[([^\]]*)\]\(\s*(data:image\/[^\s)]+)(?:\s+(?:"[^"]*"|'[^']*'|\([^)]*\)))?\s*\)/) do
-          data_image_to_attachment($2, $1)
+          # Convert data-URI images to Active Storage before rendering
+          source.gsub!(/(?<!\\)!\[([^\]]*)\]\[([^\]]+)\]/) do
+            if (data_url = image_refs[$2])
+              data_image_to_attachment(data_url, $1)
+            else
+              "![#{$1}][#{$2}]"
+            end
+          end
+
+          # Inline data-URI images. base64 contains no whitespace or `)`, so bound
+          # the URL on those and capture an optional CommonMark title separately;
+          # otherwise `data:...;base64,XYZ "caption"` would be slurped as one URL
+          # and fail the strict parser in `data_image_to_attachment`. Titles may be
+          # double-quoted, single-quoted, or parenthesized per CommonMark.
+          source.gsub!(/(?<!\\)!\[([^\]]*)\]\(\s*(data:image\/[^\s)]+)(?:\s+(?:"[^"]*"|'[^']*'|\([^)]*\)))?\s*\)/) do
+            data_image_to_attachment($2, $1)
+          end
+
+          source
         end
 
         # Render with commonmarker (GFM extensions: table, strikethrough, autolink, tasklist, tagfilter)
@@ -209,34 +215,39 @@ module Collavre
       # re-import the same data URI into a fresh blob on every autosave.
       def rewrite_data_uri_images(text)
         return text if text.nil?
-        result = text.dup
         image_refs = {}
 
-        # Collect reference-style data-URI image definitions. CommonMark accepts
-        # both the angle-bracket form `[alt]: <data:...>` and the bare form
-        # `[alt]: data:image/...`, optionally followed by a title. Rewrite each
-        # definition to point at a freshly-uploaded blob, normalizing to the
-        # bare form (titles are dropped since blob paths cannot collide with
-        # surrounding text).
-        result.gsub!(/^(\s*\[)([^\]]+)(\]:\s*)(?:<\s*(data:image\/[^>]+?)\s*>|(data:image\/\S+))(\s*(?:"[^"]*"|'[^']*'|\([^)]*\))?\s*)$/) do
-          lead, label, mid, angle_url, bare_url, tail = $1, $2, $3, $4, $5, $6
-          data_url = (angle_url || bare_url).strip
-          blob_path = data_uri_to_blob_path(data_url)
-          image_refs[label] = blob_path
-          "#{lead}#{label}#{mid}#{blob_path}#{tail}"
-        end
+        # Protect fenced code blocks and inline code spans before rewriting —
+        # a Markdown code sample like ```` ```md\n![x](data:...)\n``` ```` must
+        # not be silently uploaded as a blob and have its source rewritten,
+        # which would corrupt the user's code snippet on every autosave.
+        with_code_protected(text.dup) do |result|
+          # Collect reference-style data-URI image definitions. CommonMark accepts
+          # both the angle-bracket form `[alt]: <data:...>` and the bare form
+          # `[alt]: data:image/...`, optionally followed by a title. Rewrite each
+          # definition to point at a freshly-uploaded blob, normalizing to the
+          # bare form (titles are dropped since blob paths cannot collide with
+          # surrounding text).
+          result.gsub!(/^(\s*\[)([^\]]+)(\]:\s*)(?:<\s*(data:image\/[^>]+?)\s*>|(data:image\/\S+))(\s*(?:"[^"]*"|'[^']*'|\([^)]*\))?\s*)$/) do
+            lead, label, mid, angle_url, bare_url, tail = $1, $2, $3, $4, $5, $6
+            data_url = (angle_url || bare_url).strip
+            blob_path = data_uri_to_blob_path(data_url)
+            image_refs[label] = blob_path
+            "#{lead}#{label}#{mid}#{blob_path}#{tail}"
+          end
 
-        # Inline data-URI images: ![alt](data:...) or ![alt](data:... "title")
-        # → ![alt](blob_path) / ![alt](blob_path "title"). Parse the title
-        # separately so it doesn't get captured into the data URL and break
-        # strict matching in `data_uri_to_blob_path`. Titles may be
-        # double-quoted, single-quoted, or parenthesized per CommonMark.
-        result.gsub!(/(?<!\\)!\[([^\]]*)\]\(\s*(data:image\/[^\s)]+)(\s+(?:"[^"]*"|'[^']*'|\([^)]*\)))?\s*\)/) do
-          alt, data_url, title = $1, $2, $3
-          "![#{alt}](#{data_uri_to_blob_path(data_url)}#{title})"
-        end
+          # Inline data-URI images: ![alt](data:...) or ![alt](data:... "title")
+          # → ![alt](blob_path) / ![alt](blob_path "title"). Parse the title
+          # separately so it doesn't get captured into the data URL and break
+          # strict matching in `data_uri_to_blob_path`. Titles may be
+          # double-quoted, single-quoted, or parenthesized per CommonMark.
+          result.gsub!(/(?<!\\)!\[([^\]]*)\]\(\s*(data:image\/[^\s)]+)(\s+(?:"[^"]*"|'[^']*'|\([^)]*\)))?\s*\)/) do
+            alt, data_url, title = $1, $2, $3
+            "![#{alt}](#{data_uri_to_blob_path(data_url)}#{title})"
+          end
 
-        result
+          result
+        end
       end
 
       # Convert a data-URI to a freshly-uploaded Active Storage blob path.
@@ -253,6 +264,37 @@ module Collavre
       end
 
       private
+
+      # Run a regex-rewriting block on `text` with fenced code blocks and
+      # inline code spans swapped for unique tokens, then restore the original
+      # segments in the block's return value. Prevents data-URI rewrites from
+      # touching code samples that happen to contain image syntax.
+      def with_code_protected(text)
+        segments = {}
+        index = 0
+        protected_text = text
+
+        # Fenced code blocks (``` or ~~~, indented up to 3 spaces per CommonMark).
+        protected_text.gsub!(/^([ \t]{0,3})(`{3,}|~{3,})[^\n]*\n[\s\S]*?\n\1\2[ \t]*(?=\n|\z)/) do |match|
+          token = "\x00MDPROTECT#{index}\x00"
+          segments[token] = match
+          index += 1
+          token
+        end
+
+        # Inline single-backtick code spans. Multi-backtick spans are rare in
+        # practice; the protection above already covers fenced samples.
+        protected_text.gsub!(/`[^`\n]+?`/) do |match|
+          token = "\x00MDPROTECT#{index}\x00"
+          segments[token] = match
+          index += 1
+          token
+        end
+
+        rewritten = yield(protected_text)
+        segments.each { |token, original| rewritten.sub!(token, original) }
+        rewritten
+      end
 
       def escape_table_cell(text)
         text.to_s.gsub(/(?<!\\)\|/, '\\|')

--- a/engines/collavre/app/services/collavre/markdown_converter.rb
+++ b/engines/collavre/app/services/collavre/markdown_converter.rb
@@ -276,7 +276,9 @@ module Collavre
         protected_text = text
 
         # Fenced code blocks (``` or ~~~, indented up to 3 spaces per CommonMark).
-        protected_text.gsub!(/^([ \t]{0,3})(`{3,}|~{3,})[^\n]*\n[\s\S]*?\n\1\2[ \t]*(?=\n|\z)/) do |match|
+        # The closing fence is optional: per CommonMark, an unclosed fence runs to
+        # end-of-document, so we still need to protect its contents from rewrites.
+        protected_text.gsub!(/^([ \t]{0,3})(`{3,}|~{3,})[^\n]*(?:\n(?:[\s\S]*?\n\1\2[ \t]*(?=\n|\z)|[\s\S]*\z)|\z)/) do |match|
           token = "\x00MDPROTECT#{index}\x00"
           segments[token] = match
           index += 1

--- a/engines/collavre/app/services/collavre/markdown_converter.rb
+++ b/engines/collavre/app/services/collavre/markdown_converter.rb
@@ -16,9 +16,11 @@ module Collavre
         return "" if text.nil?
         input = text.dup
 
-        # Collect reference-style data-URI images: [alt]: <data:...>
-        input.gsub!(/^\s*\[([^\]]+)\]:\s*<\s*(data:image\/[^>]+)\s*>\s*$/) do
-          image_refs[$1] = $2.strip
+        # Collect reference-style data-URI images. CommonMark allows both the
+        # angle-bracket form `[alt]: <data:...>` and the bare form
+        # `[alt]: data:image/...`, optionally followed by a title.
+        input.gsub!(/^\s*\[([^\]]+)\]:\s*(?:<\s*(data:image\/[^>]+?)\s*>|(data:image\/\S+))\s*(?:"[^"]*"|'[^']*'|\([^)]*\))?\s*$/) do
+          image_refs[$1] = ($2 || $3).strip
           ""
         end
 
@@ -205,10 +207,15 @@ module Collavre
         result = text.dup
         image_refs = {}
 
-        # Collect reference-style data-URI image definitions: [alt]: <data:...>
-        # Rewrite each definition to point at a freshly-uploaded blob.
-        result.gsub!(/^(\s*\[)([^\]]+)(\]:\s*<\s*)(data:image\/[^>]+)(\s*>\s*)$/) do
-          lead, label, mid, data_url, tail = $1, $2, $3, $4.strip, $5
+        # Collect reference-style data-URI image definitions. CommonMark accepts
+        # both the angle-bracket form `[alt]: <data:...>` and the bare form
+        # `[alt]: data:image/...`, optionally followed by a title. Rewrite each
+        # definition to point at a freshly-uploaded blob, normalizing to the
+        # bare form (titles are dropped since blob paths cannot collide with
+        # surrounding text).
+        result.gsub!(/^(\s*\[)([^\]]+)(\]:\s*)(?:<\s*(data:image\/[^>]+?)\s*>|(data:image\/\S+))(\s*(?:"[^"]*"|'[^']*'|\([^)]*\))?\s*)$/) do
+          lead, label, mid, angle_url, bare_url, tail = $1, $2, $3, $4, $5, $6
+          data_url = (angle_url || bare_url).strip
           blob_path = data_uri_to_blob_path(data_url)
           image_refs[label] = blob_path
           "#{lead}#{label}#{mid}#{blob_path}#{tail}"

--- a/engines/collavre/app/services/collavre/markdown_converter.rb
+++ b/engines/collavre/app/services/collavre/markdown_converter.rb
@@ -194,6 +194,48 @@ module Collavre
         end
       end
 
+      # Rewrite data-URI image references in Markdown source to point at
+      # newly-created Active Storage blobs. Returns rewritten Markdown.
+      #
+      # Used by the inline Markdown editor to persist blob URLs in the stored
+      # `markdown_source`, so subsequent text edits around the image do not
+      # re-import the same data URI into a fresh blob on every autosave.
+      def rewrite_data_uri_images(text)
+        return text if text.nil?
+        result = text.dup
+        image_refs = {}
+
+        # Collect reference-style data-URI image definitions: [alt]: <data:...>
+        # Rewrite each definition to point at a freshly-uploaded blob.
+        result.gsub!(/^(\s*\[)([^\]]+)(\]:\s*<\s*)(data:image\/[^>]+)(\s*>\s*)$/) do
+          lead, label, mid, data_url, tail = $1, $2, $3, $4.strip, $5
+          blob_path = data_uri_to_blob_path(data_url)
+          image_refs[label] = blob_path
+          "#{lead}#{label}#{mid}#{blob_path}#{tail}"
+        end
+
+        # Inline data-URI images: ![alt](data:...) → ![alt](blob_path)
+        result.gsub!(/(?<!\\)!\[([^\]]*)\]\((data:image\/[^)]+)\)/) do
+          alt, data_url = $1, $2
+          "![#{alt}](#{data_uri_to_blob_path(data_url)})"
+        end
+
+        result
+      end
+
+      # Convert a data-URI to a freshly-uploaded Active Storage blob path.
+      # Returns the original URL unchanged on parse failure.
+      def data_uri_to_blob_path(data_url)
+        return data_url unless data_url =~ %r{\Adata:(image/[\w.+-]+);base64,(.+)\z}
+
+        content_type = Regexp.last_match(1)
+        data = Base64.decode64(Regexp.last_match(2))
+        ext = Mime::Type.lookup(content_type).symbol.to_s
+        filename = "import-#{SecureRandom.hex}.#{ext}"
+        blob = ActiveStorage::Blob.create_and_upload!(io: StringIO.new(data), filename: filename, content_type: content_type)
+        Rails.application.routes.url_helpers.rails_blob_url(blob, only_path: true)
+      end
+
       private
 
       def escape_table_cell(text)

--- a/engines/collavre/app/services/collavre/markdown_converter.rb
+++ b/engines/collavre/app/services/collavre/markdown_converter.rb
@@ -36,8 +36,9 @@ module Collavre
         # Inline data-URI images. base64 contains no whitespace or `)`, so bound
         # the URL on those and capture an optional CommonMark title separately;
         # otherwise `data:...;base64,XYZ "caption"` would be slurped as one URL
-        # and fail the strict parser in `data_image_to_attachment`.
-        input.gsub!(/(?<!\\)!\[([^\]]*)\]\(\s*(data:image\/[^\s)]+)(?:\s+(?:"[^"]*"|'[^']*'))?\s*\)/) do
+        # and fail the strict parser in `data_image_to_attachment`. Titles may be
+        # double-quoted, single-quoted, or parenthesized per CommonMark.
+        input.gsub!(/(?<!\\)!\[([^\]]*)\]\(\s*(data:image\/[^\s)]+)(?:\s+(?:"[^"]*"|'[^']*'|\([^)]*\)))?\s*\)/) do
           data_image_to_attachment($2, $1)
         end
 
@@ -228,8 +229,9 @@ module Collavre
         # Inline data-URI images: ![alt](data:...) or ![alt](data:... "title")
         # → ![alt](blob_path) / ![alt](blob_path "title"). Parse the title
         # separately so it doesn't get captured into the data URL and break
-        # strict matching in `data_uri_to_blob_path`.
-        result.gsub!(/(?<!\\)!\[([^\]]*)\]\(\s*(data:image\/[^\s)]+)(\s+(?:"[^"]*"|'[^']*'))?\s*\)/) do
+        # strict matching in `data_uri_to_blob_path`. Titles may be
+        # double-quoted, single-quoted, or parenthesized per CommonMark.
+        result.gsub!(/(?<!\\)!\[([^\]]*)\]\(\s*(data:image\/[^\s)]+)(\s+(?:"[^"]*"|'[^']*'|\([^)]*\)))?\s*\)/) do
           alt, data_url, title = $1, $2, $3
           "![#{alt}](#{data_uri_to_blob_path(data_url)}#{title})"
         end

--- a/engines/collavre/app/services/collavre/markdown_converter.rb
+++ b/engines/collavre/app/services/collavre/markdown_converter.rb
@@ -265,10 +265,11 @@ module Collavre
 
       private
 
-      # Run a regex-rewriting block on `text` with fenced code blocks and
-      # inline code spans swapped for unique tokens, then restore the original
-      # segments in the block's return value. Prevents data-URI rewrites from
-      # touching code samples that happen to contain image syntax.
+      # Run a regex-rewriting block on `text` with fenced code blocks,
+      # indented code blocks, and inline code spans swapped for unique tokens,
+      # then restore the original segments in the block's return value.
+      # Prevents data-URI rewrites from touching code samples that happen to
+      # contain image syntax.
       def with_code_protected(text)
         segments = {}
         index = 0
@@ -280,6 +281,18 @@ module Collavre
           segments[token] = match
           index += 1
           token
+        end
+
+        # Indented code blocks: contiguous lines each starting with 4+ spaces
+        # or a tab, preceded by start-of-document or a blank line (CommonRule
+        # requirement so we don't mistake list-item continuations for code).
+        protected_text.gsub!(/(\A|\n\n+)((?:(?:[ ]{4,}|\t)[^\n]*(?:\n|\z))+)/) do
+          prefix = Regexp.last_match(1)
+          block = Regexp.last_match(2)
+          token = "\x00MDPROTECT#{index}\x00"
+          segments[token] = block
+          index += 1
+          "#{prefix}#{token}"
         end
 
         # Inline single-backtick code spans. Multi-backtick spans are rare in

--- a/engines/collavre/app/services/collavre/markdown_importer.rb
+++ b/engines/collavre/app/services/collavre/markdown_importer.rb
@@ -6,9 +6,14 @@ module Collavre
     def self.import(content, parent:, user:, create_root: false)
       lines = content.to_s.lines
       image_refs = {}
+      # CommonMark allows both the angle-bracket form `[alt]: <data:...>` and
+      # the bare form `[alt]: data:image/...`, optionally followed by a title
+      # (`"..."`, `'...'`, or `(...)`). Match both so reference-style data-URI
+      # images survive the import path and resolve to attachments downstream
+      # (mirrors MarkdownConverter#markdown_to_html).
       lines.reject! do |ln|
-        if ln =~ /^\s*\[([^\]]+)\]:\s*<\s*(data:image\/[^>]+)\s*>\s*$/
-          image_refs[$1] = $2.strip
+        if ln =~ /^\s*\[([^\]]+)\]:\s*(?:<\s*(data:image\/[^>]+?)\s*>|(data:image\/\S+))\s*(?:"[^"]*"|'[^']*'|\([^)]*\))?\s*$/
+          image_refs[$1] = ($2 || $3).strip
           true
         else
           false

--- a/engines/collavre/app/views/collavre/creatives/_inline_edit_form.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_inline_edit_form.html.erb
@@ -46,7 +46,7 @@
                 data-label-richtext="<%= t('collavre.creatives.index.toggle_richtext') %>"
                 data-confirm-to-richtext="<%= t('collavre.creatives.index.markdown_to_richtext_confirm') %>"
                 data-confirm-to-markdown="<%= t('collavre.creatives.index.richtext_to_markdown_confirm') %>"
-                style="margin-left:0.5em;font-family:monospace;font-size:0.85em;">
+                style="margin-left:0.5em;font-family:monospace;font-size:0.9em;">
           MD
         </button>
       </div>

--- a/engines/collavre/app/views/collavre/creatives/_inline_edit_form.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_inline_edit_form.html.erb
@@ -45,6 +45,7 @@
                 data-label-markdown="<%= t('collavre.creatives.index.toggle_markdown') %>"
                 data-label-richtext="<%= t('collavre.creatives.index.toggle_richtext') %>"
                 data-confirm-to-richtext="<%= t('collavre.creatives.index.markdown_to_richtext_confirm') %>"
+                data-confirm-to-markdown="<%= t('collavre.creatives.index.richtext_to_markdown_confirm') %>"
                 style="margin-left:0.5em;font-family:monospace;font-size:0.85em;">
           MD
         </button>

--- a/engines/collavre/app/views/collavre/creatives/_inline_edit_form.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_inline_edit_form.html.erb
@@ -47,7 +47,7 @@
                 data-confirm-to-richtext="<%= t('collavre.creatives.index.markdown_to_richtext_confirm') %>"
                 data-confirm-to-markdown="<%= t('collavre.creatives.index.richtext_to_markdown_confirm') %>"
                 style="margin-left:0.5em;font-family:monospace;font-size:0.9em;">
-          MD
+          <%= t('collavre.creatives.index.toggle_markdown') %>
         </button>
       </div>
       <div style="margin-top:0.5em;">

--- a/engines/collavre/app/views/collavre/creatives/_inline_edit_form.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_inline_edit_form.html.erb
@@ -21,7 +21,8 @@
                 class="markdown-editor-textarea"
                 rows="10"
                 placeholder="<%= t('collavre.creatives.inline_editor.markdown_placeholder') %>"></textarea>
-      <div id="markdown-preview" class="markdown-preview"></div>
+      <div id="markdown-preview" class="markdown-preview"
+           data-placeholder="<%= t('collavre.creatives.inline_editor.markdown_preview_placeholder') %>"></div>
     </div>
     <div id="actions-inline-editor" style="padding: 0px 8px;">
       <div style="margin-top:0.5em;display:flex;align-items:center;gap:0.5em;">

--- a/engines/collavre/app/views/collavre/creatives/_inline_edit_form.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_inline_edit_form.html.erb
@@ -3,6 +3,8 @@
     <input type="hidden" id="inline-method" name="_method" value="patch" />
     <input type="hidden" name="authenticity_token" value="<%= form_authenticity_token %>" />
     <input type="hidden" id="inline-creative-description" name="creative[description]" />
+    <input type="hidden" id="inline-content-type" name="creative[content_type_input]" value="html" />
+    <input type="hidden" id="inline-markdown-source" name="creative[markdown_source]" />
     <input type="hidden" id="inline-parent-id" name="creative[parent_id]" />
     <input type="hidden" id="inline-before-id" name="before_id" />
     <input type="hidden" id="inline-after-id" name="after_id" />
@@ -14,6 +16,13 @@
          data-direct-upload-url="<%= main_app.rails_direct_uploads_path %>"
          data-blob-url-template="<%= main_app.rails_service_blob_path(':signed_id', ':filename') %>"
          data-placeholder="<%= t('collavre.creatives.inline_editor.placeholder') %>"></div>
+    <div id="markdown-editor-wrapper" class="markdown-editor-wrapper" style="display:none;">
+      <textarea id="markdown-editor-textarea"
+                class="markdown-editor-textarea"
+                rows="10"
+                placeholder="<%= t('collavre.creatives.inline_editor.markdown_placeholder') %>"></textarea>
+      <div id="markdown-preview" class="markdown-preview"></div>
+    </div>
     <div id="actions-inline-editor" style="padding: 0px 8px;">
       <div style="margin-top:0.5em;display:flex;align-items:center;gap:0.5em;">
         <input type="hidden" name="creative[progress]" value="0">
@@ -29,6 +38,14 @@
         </label>
         <button type="button" id="inline-metadata-btn" class="creative-action-btn" title="<%= t('collavre.creatives.index.metadata_tooltip') %>" style="margin-left:0.5em;font-family:monospace;font-size:0.9em;">
           { }
+        </button>
+        <button type="button" id="inline-toggle-markdown" class="creative-action-btn"
+                title="<%= t('collavre.creatives.index.toggle_markdown') %>"
+                data-label-markdown="<%= t('collavre.creatives.index.toggle_markdown') %>"
+                data-label-richtext="<%= t('collavre.creatives.index.toggle_richtext') %>"
+                data-confirm-to-richtext="<%= t('collavre.creatives.index.markdown_to_richtext_confirm') %>"
+                style="margin-left:0.5em;font-family:monospace;font-size:0.85em;">
+          MD
         </button>
       </div>
       <div style="margin-top:0.5em;">

--- a/engines/collavre/app/views/collavre/creatives/index.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/index.html.erb
@@ -154,17 +154,25 @@
     title_row_content += content_tag(:template, data: { part: "edit-icon" }) { svg_tag("edit.svg", class: "icon-edit") }
     title_row_content += content_tag(:template, data: { part: "edit-off-icon" }) { svg_tag("edit-off.svg", class: "icon-edit") }
   %>
+  <%
+    title_can_write = @parent_creative.has_permission?(Current.user, :write)
+    title_effective_origin = @parent_creative.effective_origin(Set.new)
+    title_content_type = title_effective_origin.data&.dig("content_type")
+    title_markdown_source = title_can_write ? title_effective_origin.data&.dig("markdown_source") : nil
+  %>
   <%= content_tag(
         "creative-tree-row",
         title_row_content,
         "dom-id": "creative-markdown-block",
         "creative-id": @parent_creative.id,
         "parent-id": @parent_creative.parent_id,
-        "can-write": @parent_creative.has_permission?(Current.user, :write) ? "true" : "false",
+        "can-write": title_can_write ? "true" : "false",
         "is-title": "",
         "data-description-raw-html": @parent_creative.description,
         "data-progress-value": @parent_creative.progress,
-        "data-origin-id": @parent_creative.origin_id
+        "data-origin-id": @parent_creative.origin_id,
+        "data-content-type": title_content_type,
+        "data-markdown-source": title_markdown_source
       ) %>
 <% else %>
   <%= content_tag(

--- a/engines/collavre/config/locales/creatives.en.yml
+++ b/engines/collavre/config/locales/creatives.en.yml
@@ -136,6 +136,8 @@ en:
         toggle_richtext: Rich Text
         markdown_to_richtext_confirm: Switching to Rich Text will discard the Markdown
           source. Continue?
+        richtext_to_markdown_confirm: Switching to Markdown will discard the current
+          rich text content. Continue?
       share:
         shared: Creative shared successfully.
         permission_updated: Permission updated successfully.

--- a/engines/collavre/config/locales/creatives.en.yml
+++ b/engines/collavre/config/locales/creatives.en.yml
@@ -154,6 +154,7 @@ en:
       inline_editor:
         placeholder: Describe the creative…
         markdown_placeholder: Write in Markdown…
+        markdown_preview_placeholder: Preview
       edit_title: Edit creative
       edit:
         inline_editor_only_html: Editing creatives now happens directly in the inline

--- a/engines/collavre/config/locales/creatives.en.yml
+++ b/engines/collavre/config/locales/creatives.en.yml
@@ -153,6 +153,7 @@ en:
         progress_recalculated: All parent progress recalculated.
       errors:
         no_permission: You do not have permission to perform this action.
+        metadata_must_be_object: Metadata must be an object.
       inline_editor:
         placeholder: Describe the creative…
         markdown_placeholder: Write in Markdown…

--- a/engines/collavre/config/locales/creatives.en.yml
+++ b/engines/collavre/config/locales/creatives.en.yml
@@ -132,6 +132,10 @@ en:
         metadata_tooltip: Edit metadata
         metadata_title: Metadata
         metadata_save: Save
+        toggle_markdown: Markdown
+        toggle_richtext: Rich Text
+        markdown_to_richtext_confirm: Switching to Rich Text will discard the Markdown
+          source. Continue?
       share:
         shared: Creative shared successfully.
         permission_updated: Permission updated successfully.
@@ -149,6 +153,7 @@ en:
         no_permission: You do not have permission to perform this action.
       inline_editor:
         placeholder: Describe the creative…
+        markdown_placeholder: Write in Markdown…
       edit_title: Edit creative
       edit:
         inline_editor_only_html: Editing creatives now happens directly in the inline

--- a/engines/collavre/config/locales/creatives.ko.yml
+++ b/engines/collavre/config/locales/creatives.ko.yml
@@ -124,6 +124,7 @@ ko:
         toggle_richtext: 서식 편집
         markdown_to_richtext_confirm: 서식 편집으로 전환하면 마크다운 원본이 삭제됩니다.
           계속하시겠습니까?
+        richtext_to_markdown_confirm: 마크다운으로 전환하면 현재 서식 편집 내용이 삭제됩니다. 계속하시겠습니까?
       share:
         shared: 크리에이티브가 성공적으로 공유되었습니다.
         permission_updated: 권한이 성공적으로 변경되었습니다.

--- a/engines/collavre/config/locales/creatives.ko.yml
+++ b/engines/collavre/config/locales/creatives.ko.yml
@@ -120,6 +120,10 @@ ko:
         metadata_tooltip: 메타데이터 편집
         metadata_title: 메타데이터
         metadata_save: 저장
+        toggle_markdown: 마크다운
+        toggle_richtext: 서식 편집
+        markdown_to_richtext_confirm: 서식 편집으로 전환하면 마크다운 원본이 삭제됩니다.
+          계속하시겠습니까?
       share:
         shared: 크리에이티브가 성공적으로 공유되었습니다.
         permission_updated: 권한이 성공적으로 변경되었습니다.
@@ -136,6 +140,7 @@ ko:
         no_permission: 이 작업을 수행할 권한이 없습니다.
       inline_editor:
         placeholder: 크리에이티브를 설명해주세요…
+        markdown_placeholder: 마크다운으로 작성…
       edit_title: 크리에이티브 수정
       edit:
         inline_editor_only_html: 크리에이티브 수정은 인라인 편집기에서 바로 진행하세요.

--- a/engines/collavre/config/locales/creatives.ko.yml
+++ b/engines/collavre/config/locales/creatives.ko.yml
@@ -139,6 +139,7 @@ ko:
         progress_recalculated: 진행률을 다시 계산 했습니다.
       errors:
         no_permission: 이 작업을 수행할 권한이 없습니다.
+        metadata_must_be_object: 메타데이터는 객체여야 합니다.
       inline_editor:
         placeholder: 크리에이티브를 설명해주세요…
         markdown_placeholder: 마크다운으로 작성…

--- a/engines/collavre/config/locales/creatives.ko.yml
+++ b/engines/collavre/config/locales/creatives.ko.yml
@@ -141,6 +141,7 @@ ko:
       inline_editor:
         placeholder: 크리에이티브를 설명해주세요…
         markdown_placeholder: 마크다운으로 작성…
+        markdown_preview_placeholder: 미리보기
       edit_title: 크리에이티브 수정
       edit:
         inline_editor_only_html: 크리에이티브 수정은 인라인 편집기에서 바로 진행하세요.

--- a/engines/collavre/test/controllers/creatives_controller_update_test.rb
+++ b/engines/collavre/test/controllers/creatives_controller_update_test.rb
@@ -114,6 +114,28 @@ class CreativesControllerUpdateTest < ActionDispatch::IntegrationTest
     assert_match %r{/rails/active_storage/blobs/}, json["markdown_source"]
   end
 
+  test "create JSON response exposes rewritten markdown_source for client sync" do
+    png_b64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEUAAACnej3aAAAAAXRSTlMAQObYZgAAAApJREFUCNdjAAAAAgABc3UBGAAAAABJRU5ErkJggg=="
+    md_src  = "Hello ![img](data:image/png;base64,#{png_b64}) world"
+
+    post creatives_url, params: {
+      creative: {
+        description: "<p>ignored</p>",
+        markdown_source: md_src,
+        content_type_input: "markdown"
+      }
+    }, headers: { "Accept" => "application/json" }
+
+    assert_response :success
+    json = JSON.parse(response.body)
+    assert json["id"].present?, "create response must include id"
+    assert_equal "markdown", json["content_type"]
+    assert json["markdown_source"].is_a?(String), "create response should expose markdown_source"
+    assert_not_includes json["markdown_source"], "data:image/png;base64,",
+      "Server should return rewritten markdown_source with blob path, not the original data URI"
+    assert_match %r{/rails/active_storage/blobs/}, json["markdown_source"]
+  end
+
   test "update_metadata does not post duplicate warning when already enabled" do
     creative = Creative.create!(description: "Documentation", user: @user, data: { "trigger" => { "on_child_enter" => true } })
     feedback_ai = users(:ai_bot)

--- a/engines/collavre/test/controllers/creatives_controller_update_test.rb
+++ b/engines/collavre/test/controllers/creatives_controller_update_test.rb
@@ -105,6 +105,8 @@ class CreativesControllerUpdateTest < ActionDispatch::IntegrationTest
     patch update_metadata_creative_url(creative), params: { data: "[]" }
 
     assert_response :unprocessable_entity
+    body = JSON.parse(response.body)
+    assert_equal I18n.t("collavre.creatives.errors.metadata_must_be_object"), body["error"]
     creative.reload
     assert_equal "keep me", creative.data["markdown_source"]
     assert_equal "markdown", creative.data["content_type"]
@@ -124,6 +126,20 @@ class CreativesControllerUpdateTest < ActionDispatch::IntegrationTest
     creative.reload
     assert_equal "keep me", creative.data["markdown_source"]
     assert_equal "markdown", creative.data["content_type"]
+  end
+
+  test "update_metadata non-hash payload error is localized in Korean" do
+    creative = Creative.create!(
+      description: "<p>html</p>",
+      user: @user,
+      data: { "markdown_source" => "keep me", "content_type" => "markdown" }
+    )
+
+    patch update_metadata_creative_url(creative), params: { data: "[]" }, headers: { "Accept-Language" => "ko" }
+
+    assert_response :unprocessable_entity
+    body = JSON.parse(response.body)
+    assert_equal "메타데이터는 객체여야 합니다.", body["error"]
   end
 
   test "update JSON response exposes rewritten markdown_source for client sync" do

--- a/engines/collavre/test/controllers/creatives_controller_update_test.rb
+++ b/engines/collavre/test/controllers/creatives_controller_update_test.rb
@@ -59,6 +59,42 @@ class CreativesControllerUpdateTest < ActionDispatch::IntegrationTest
     assert_equal "Drop Trigger", comment.topic.name
   end
 
+  test "update_metadata preserves markdown_source and content_type against stale payload" do
+    creative = Creative.create!(
+      description: "<p>html</p>",
+      user: @user,
+      data: { "markdown_source" => "current source", "content_type" => "markdown", "foo" => "bar" }
+    )
+
+    patch update_metadata_creative_url(creative), params: {
+      data: {
+        markdown_source: "stale source",
+        content_type: "richtext",
+        foo: "baz"
+      }.to_json
+    }
+
+    assert_response :success
+    creative.reload
+    assert_equal "current source", creative.data["markdown_source"]
+    assert_equal "markdown", creative.data["content_type"]
+    assert_equal "baz", creative.data["foo"]
+  end
+
+  test "update_metadata strips markdown reserved keys when current data has none" do
+    creative = Creative.create!(description: "<p>html</p>", user: @user, data: { "foo" => "bar" })
+
+    patch update_metadata_creative_url(creative), params: {
+      data: { markdown_source: "injected", content_type: "markdown", foo: "baz" }.to_json
+    }
+
+    assert_response :success
+    creative.reload
+    assert_not creative.data.key?("markdown_source")
+    assert_not creative.data.key?("content_type")
+    assert_equal "baz", creative.data["foo"]
+  end
+
   test "update_metadata does not post duplicate warning when already enabled" do
     creative = Creative.create!(description: "Documentation", user: @user, data: { "trigger" => { "on_child_enter" => true } })
     feedback_ai = users(:ai_bot)

--- a/engines/collavre/test/controllers/creatives_controller_update_test.rb
+++ b/engines/collavre/test/controllers/creatives_controller_update_test.rb
@@ -95,6 +95,37 @@ class CreativesControllerUpdateTest < ActionDispatch::IntegrationTest
     assert_equal "baz", creative.data["foo"]
   end
 
+  test "update_metadata rejects non-hash JSON arrays without clobbering markdown fields" do
+    creative = Creative.create!(
+      description: "<p>html</p>",
+      user: @user,
+      data: { "markdown_source" => "keep me", "content_type" => "markdown", "foo" => "bar" }
+    )
+
+    patch update_metadata_creative_url(creative), params: { data: "[]" }
+
+    assert_response :unprocessable_entity
+    creative.reload
+    assert_equal "keep me", creative.data["markdown_source"]
+    assert_equal "markdown", creative.data["content_type"]
+    assert_equal "bar", creative.data["foo"]
+  end
+
+  test "update_metadata rejects non-hash JSON scalars without clobbering markdown fields" do
+    creative = Creative.create!(
+      description: "<p>html</p>",
+      user: @user,
+      data: { "markdown_source" => "keep me", "content_type" => "markdown" }
+    )
+
+    patch update_metadata_creative_url(creative), params: { data: "\"just a string\"" }
+
+    assert_response :unprocessable_entity
+    creative.reload
+    assert_equal "keep me", creative.data["markdown_source"]
+    assert_equal "markdown", creative.data["content_type"]
+  end
+
   test "update JSON response exposes rewritten markdown_source for client sync" do
     png_b64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEUAAACnej3aAAAAAXRSTlMAQObYZgAAAApJREFUCNdjAAAAAgABc3UBGAAAAABJRU5ErkJggg=="
     md_src  = "Hello ![img](data:image/png;base64,#{png_b64}) world"

--- a/engines/collavre/test/controllers/creatives_controller_update_test.rb
+++ b/engines/collavre/test/controllers/creatives_controller_update_test.rb
@@ -136,6 +136,33 @@ class CreativesControllerUpdateTest < ActionDispatch::IntegrationTest
     assert_match %r{/rails/active_storage/blobs/}, json["markdown_source"]
   end
 
+  test "update JSON response omits markdown_source for read-only parent_id-only PATCH" do
+    owner = users(:one)
+    reader = users(:two)
+
+    origin = Creative.create!(
+      description: "<p>secret html</p>",
+      user: owner,
+      data: { "content_type" => "markdown", "markdown_source" => "secret source" }
+    )
+    new_parent = Creative.create!(description: "New Parent", user: reader)
+    old_parent = Creative.create!(description: "Old Parent", user: reader)
+    linked = Creative.create!(description: "<p>link</p>", user: owner, origin: origin, parent: old_parent)
+    CreativeShare.create!(creative: linked, user: reader, permission: :read)
+
+    sign_in_as reader, password: "password"
+
+    patch creative_url(linked), params: {
+      creative: { parent_id: new_parent.id }
+    }, headers: { "Accept" => "application/json" }
+
+    assert_response :success
+    json = JSON.parse(response.body)
+    assert_not json.key?("markdown_source"),
+      "read-only recipient must not receive origin markdown_source via parent-only PATCH"
+    assert_equal new_parent.id, linked.reload.parent_id
+  end
+
   test "update_metadata does not post duplicate warning when already enabled" do
     creative = Creative.create!(description: "Documentation", user: @user, data: { "trigger" => { "on_child_enter" => true } })
     feedback_ai = users(:ai_bot)

--- a/engines/collavre/test/controllers/creatives_controller_update_test.rb
+++ b/engines/collavre/test/controllers/creatives_controller_update_test.rb
@@ -95,6 +95,25 @@ class CreativesControllerUpdateTest < ActionDispatch::IntegrationTest
     assert_equal "baz", creative.data["foo"]
   end
 
+  test "update JSON response exposes rewritten markdown_source for client sync" do
+    png_b64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEUAAACnej3aAAAAAXRSTlMAQObYZgAAAApJREFUCNdjAAAAAgABc3UBGAAAAABJRU5ErkJggg=="
+    md_src  = "Hello ![img](data:image/png;base64,#{png_b64}) world"
+
+    creative = Creative.create!(description: "<p>placeholder</p>", user: @user)
+
+    patch creative_url(creative), params: {
+      creative: { description: "<p>ignored</p>", markdown_source: md_src, content_type_input: "markdown" }
+    }, headers: { "Accept" => "application/json" }
+
+    assert_response :success
+    json = JSON.parse(response.body)
+    assert_equal "markdown", json["content_type"]
+    assert json["markdown_source"].is_a?(String), "markdown_source should be in update response"
+    assert_not_includes json["markdown_source"], "data:image/png;base64,",
+      "Server should return rewritten markdown_source with blob path, not the original data URI"
+    assert_match %r{/rails/active_storage/blobs/}, json["markdown_source"]
+  end
+
   test "update_metadata does not post duplicate warning when already enabled" do
     creative = Creative.create!(description: "Documentation", user: @user, data: { "trigger" => { "on_child_enter" => true } })
     feedback_ai = users(:ai_bot)

--- a/engines/collavre/test/models/collavre/creative/describable_test.rb
+++ b/engines/collavre/test/models/collavre/creative/describable_test.rb
@@ -55,6 +55,27 @@ module Collavre
         assert_equal "# keep", creative.data["markdown_source"]
       end
 
+      test "GFM task list checkboxes survive sanitization" do
+        source = "- [ ] todo\n- [x] done\n"
+
+        Creative.create!(user: @user, content_type_input: "markdown", markdown_source: source)
+        creative = Creative.last
+
+        assert_match %r{<input[^>]*type="checkbox"[^>]*disabled}, creative.description
+        assert_match %r{<input[^>]*checked[^>]*}, creative.description
+      end
+
+      test "non-checkbox input tags are stripped from description" do
+        Creative.create!(
+          user: @user,
+          description: %(<p>hi <input type="text" value="x"> <input type="submit"></p>)
+        )
+        creative = Creative.last
+
+        refute_match %r{<input}, creative.description
+        assert_includes creative.description, "hi"
+      end
+
       test "inline data-URI image is rewritten to blob path in stored markdown_source" do
         pixel_b64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
         data_uri = "data:image/png;base64,#{pixel_b64}"

--- a/engines/collavre/test/models/collavre/creative/describable_test.rb
+++ b/engines/collavre/test/models/collavre/creative/describable_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+
+module Collavre
+  class Creative
+    class DescribableTest < ActiveSupport::TestCase
+      setup do
+        @user = users(:one)
+      end
+
+      test "markdown_source setter normalizes CRLF and CR to LF" do
+        creative = Creative.new(user: @user)
+
+        creative.markdown_source = "a\r\nb\rc\nd"
+        assert_equal "a\nb\nc\nd", creative.markdown_source
+      end
+
+      test "markdown_source setter leaves non-string values untouched" do
+        creative = Creative.new(user: @user)
+
+        creative.markdown_source = nil
+        assert_nil creative.markdown_source
+      end
+
+      test "convert_markdown_to_html persists normalized markdown_source" do
+        creative = Creative.new(user: @user, content_type_input: "markdown", markdown_source: "line1\r\nline2\r\n")
+        creative.save!
+
+        assert_equal "line1\nline2\n", creative.data["markdown_source"]
+        assert_equal "markdown", creative.data["content_type"]
+      end
+    end
+  end
+end

--- a/engines/collavre/test/models/collavre/creative/describable_test.rb
+++ b/engines/collavre/test/models/collavre/creative/describable_test.rb
@@ -28,6 +28,32 @@ module Collavre
         assert_equal "line1\nline2\n", creative.data["markdown_source"]
         assert_equal "markdown", creative.data["content_type"]
       end
+
+      test "description-only update on markdown creative demotes to html" do
+        Creative.create!(user: @user, content_type_input: "markdown", markdown_source: "# old")
+        creative = Creative.last
+        assert_equal "markdown", creative.data["content_type"]
+        assert_equal "# old", creative.data["markdown_source"]
+
+        creative.update!(description: "<h1>new from tool</h1>")
+        creative.reload
+
+        assert_nil creative.data["content_type"]
+        assert_nil creative.data["markdown_source"]
+        assert_includes creative.description, "new from tool"
+      end
+
+      test "non-description update on markdown creative preserves markdown metadata" do
+        Creative.create!(user: @user, content_type_input: "markdown", markdown_source: "# keep")
+        creative = Creative.last
+        assert_equal "markdown", creative.data["content_type"]
+
+        creative.update!(progress: 1.0)
+        creative.reload
+
+        assert_equal "markdown", creative.data["content_type"]
+        assert_equal "# keep", creative.data["markdown_source"]
+      end
     end
   end
 end

--- a/engines/collavre/test/models/collavre/creative/describable_test.rb
+++ b/engines/collavre/test/models/collavre/creative/describable_test.rb
@@ -54,6 +54,32 @@ module Collavre
         assert_equal "markdown", creative.data["content_type"]
         assert_equal "# keep", creative.data["markdown_source"]
       end
+
+      test "inline data-URI image is rewritten to blob path in stored markdown_source" do
+        pixel_b64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
+        data_uri = "data:image/png;base64,#{pixel_b64}"
+
+        source = "before ![pixel](#{data_uri}) after"
+
+        Creative.create!(user: @user, content_type_input: "markdown", markdown_source: source)
+        creative = Creative.last
+
+        stored = creative.data["markdown_source"]
+        refute_includes stored, "data:image/png;base64,", "data URI should be rewritten out of stored markdown_source"
+        assert_match %r{!\[pixel\]\(/rails/active_storage/blobs/[^)]+\)}, stored
+
+        blob_count_after_first = ActiveStorage::Blob.count
+
+        # Subsequent text edits around the (now blob-backed) image must not
+        # re-import the data URI as a fresh blob.
+        edited_source = stored.sub("before", "edited before")
+        creative.update!(content_type_input: "markdown", markdown_source: edited_source)
+        creative.reload
+
+        assert_equal blob_count_after_first, ActiveStorage::Blob.count,
+                     "editing surrounding text must not create new blobs"
+        assert_includes creative.data["markdown_source"], "edited before"
+      end
     end
   end
 end

--- a/engines/collavre/test/services/collavre/markdown_converter_test.rb
+++ b/engines/collavre/test/services/collavre/markdown_converter_test.rb
@@ -276,5 +276,42 @@ module Collavre
         refute_includes html, "/rails/active_storage/blobs/"
       end
     end
+
+    test "rewrite_data_uri_images leaves data URIs inside unclosed fenced code blocks untouched" do
+      input = "Sample:\n\n```md\n![pic](#{PNG_DATA_URI})\n"
+      assert_no_difference -> { ActiveStorage::Blob.count } do
+        rewritten = MarkdownConverter.rewrite_data_uri_images(input)
+        assert_equal input, rewritten
+        assert_includes rewritten, "data:image/png"
+      end
+    end
+
+    test "rewrite_data_uri_images leaves data URIs inside unclosed tilde-fenced code blocks untouched" do
+      input = "Sample:\n\n~~~\n![pic](#{PNG_DATA_URI})\n"
+      assert_no_difference -> { ActiveStorage::Blob.count } do
+        rewritten = MarkdownConverter.rewrite_data_uri_images(input)
+        assert_equal input, rewritten
+        assert_includes rewritten, "data:image/png"
+      end
+    end
+
+    test "rewrite_data_uri_images rewrites a real image before an unclosed fence but leaves the fenced sample alone" do
+      input = "Real: ![pic](#{PNG_DATA_URI})\n\nSample:\n\n```md\n![pic](#{PNG_DATA_URI})\n"
+      assert_difference -> { ActiveStorage::Blob.count }, +1 do
+        rewritten = MarkdownConverter.rewrite_data_uri_images(input)
+        assert_includes rewritten, "/rails/active_storage/blobs/"
+        assert_includes rewritten, "```md\n![pic](#{PNG_DATA_URI})\n"
+      end
+    end
+
+    test "markdown_to_html leaves data URIs inside unclosed fenced code blocks as literal code" do
+      input = "Sample:\n\n```md\n![pic](#{PNG_DATA_URI})\n"
+      assert_no_difference -> { ActiveStorage::Blob.count } do
+        html = MarkdownConverter.markdown_to_html(input)
+        assert_includes html, "<pre"
+        assert_includes html, "data:image/png"
+        refute_includes html, "/rails/active_storage/blobs/"
+      end
+    end
   end
 end

--- a/engines/collavre/test/services/collavre/markdown_converter_test.rb
+++ b/engines/collavre/test/services/collavre/markdown_converter_test.rb
@@ -174,5 +174,61 @@ module Collavre
         assert_includes rewritten, "(caption)"
       end
     end
+
+    test "rewrite_data_uri_images leaves data URIs inside fenced code blocks untouched" do
+      input = "Sample:\n\n```md\n![pic](#{PNG_DATA_URI})\n```\n"
+      assert_no_difference -> { ActiveStorage::Blob.count } do
+        rewritten = MarkdownConverter.rewrite_data_uri_images(input)
+        assert_equal input, rewritten
+        assert_includes rewritten, "data:image/png"
+      end
+    end
+
+    test "rewrite_data_uri_images leaves data URIs inside tilde-fenced code blocks untouched" do
+      input = "Sample:\n\n~~~\n![pic](#{PNG_DATA_URI})\n~~~\n"
+      assert_no_difference -> { ActiveStorage::Blob.count } do
+        rewritten = MarkdownConverter.rewrite_data_uri_images(input)
+        assert_equal input, rewritten
+        assert_includes rewritten, "data:image/png"
+      end
+    end
+
+    test "rewrite_data_uri_images leaves reference-style data URI definitions inside fenced code blocks untouched" do
+      input = "Sample:\n\n```md\n![pic][p]\n\n[p]: #{PNG_DATA_URI}\n```\n"
+      assert_no_difference -> { ActiveStorage::Blob.count } do
+        rewritten = MarkdownConverter.rewrite_data_uri_images(input)
+        assert_equal input, rewritten
+        assert_includes rewritten, "data:image/png"
+      end
+    end
+
+    test "rewrite_data_uri_images leaves data URIs inside inline code spans untouched" do
+      input = "Use `![pic](#{PNG_DATA_URI})` in your Markdown."
+      assert_no_difference -> { ActiveStorage::Blob.count } do
+        rewritten = MarkdownConverter.rewrite_data_uri_images(input)
+        assert_equal input, rewritten
+        assert_includes rewritten, "data:image/png"
+      end
+    end
+
+    test "rewrite_data_uri_images rewrites a real image but leaves a code-sampled one alone" do
+      input = "Real: ![pic](#{PNG_DATA_URI})\n\nSample:\n\n```md\n![pic](#{PNG_DATA_URI})\n```\n"
+      assert_difference -> { ActiveStorage::Blob.count }, +1 do
+        rewritten = MarkdownConverter.rewrite_data_uri_images(input)
+        assert_includes rewritten, "/rails/active_storage/blobs/"
+        # The code block content survives intact.
+        assert_includes rewritten, "```md\n![pic](#{PNG_DATA_URI})\n```"
+      end
+    end
+
+    test "markdown_to_html leaves data URIs inside fenced code blocks as literal code" do
+      input = "Sample:\n\n```md\n![pic](#{PNG_DATA_URI})\n```\n"
+      assert_no_difference -> { ActiveStorage::Blob.count } do
+        html = MarkdownConverter.markdown_to_html(input)
+        assert_includes html, "<pre"
+        assert_includes html, "data:image/png"
+        refute_includes html, "/rails/active_storage/blobs/"
+      end
+    end
   end
 end

--- a/engines/collavre/test/services/collavre/markdown_converter_test.rb
+++ b/engines/collavre/test/services/collavre/markdown_converter_test.rb
@@ -155,5 +155,24 @@ module Collavre
         refute_includes rewritten, "data:image/png"
       end
     end
+
+    test "markdown_to_html handles inline data URI with parenthesized title" do
+      input = %Q(![pic](#{PNG_DATA_URI} (caption)))
+      assert_difference -> { ActiveStorage::Blob.count }, +1 do
+        html = MarkdownConverter.markdown_to_html(input)
+        assert_includes html, "/rails/active_storage/blobs/"
+        refute_includes html, "data:image/png"
+      end
+    end
+
+    test "rewrite_data_uri_images rewrites inline data URI with parenthesized title and preserves title" do
+      input = %Q(![pic](#{PNG_DATA_URI} (caption)))
+      assert_difference -> { ActiveStorage::Blob.count }, +1 do
+        rewritten = MarkdownConverter.rewrite_data_uri_images(input)
+        assert_includes rewritten, "/rails/active_storage/blobs/"
+        refute_includes rewritten, "data:image/png"
+        assert_includes rewritten, "(caption)"
+      end
+    end
   end
 end

--- a/engines/collavre/test/services/collavre/markdown_converter_test.rb
+++ b/engines/collavre/test/services/collavre/markdown_converter_test.rb
@@ -230,5 +230,51 @@ module Collavre
         refute_includes html, "/rails/active_storage/blobs/"
       end
     end
+
+    test "rewrite_data_uri_images leaves data URIs inside 4-space indented code blocks untouched" do
+      input = "Sample:\n\n    ![pic](#{PNG_DATA_URI})\n\nAfter.\n"
+      assert_no_difference -> { ActiveStorage::Blob.count } do
+        rewritten = MarkdownConverter.rewrite_data_uri_images(input)
+        assert_equal input, rewritten
+        assert_includes rewritten, "data:image/png"
+      end
+    end
+
+    test "rewrite_data_uri_images leaves data URIs inside tab-indented code blocks untouched" do
+      input = "Sample:\n\n\t![pic](#{PNG_DATA_URI})\n\nAfter.\n"
+      assert_no_difference -> { ActiveStorage::Blob.count } do
+        rewritten = MarkdownConverter.rewrite_data_uri_images(input)
+        assert_equal input, rewritten
+        assert_includes rewritten, "data:image/png"
+      end
+    end
+
+    test "rewrite_data_uri_images leaves reference-style data URI defs inside indented code blocks untouched" do
+      input = "Sample:\n\n    [p]: #{PNG_DATA_URI}\n    ![pic][p]\n\nAfter.\n"
+      assert_no_difference -> { ActiveStorage::Blob.count } do
+        rewritten = MarkdownConverter.rewrite_data_uri_images(input)
+        assert_equal input, rewritten
+        assert_includes rewritten, "data:image/png"
+      end
+    end
+
+    test "rewrite_data_uri_images rewrites a real image but leaves an indented-code-sampled one alone" do
+      input = "Real: ![pic](#{PNG_DATA_URI})\n\nSample:\n\n    ![pic](#{PNG_DATA_URI})\n\nAfter.\n"
+      assert_difference -> { ActiveStorage::Blob.count }, +1 do
+        rewritten = MarkdownConverter.rewrite_data_uri_images(input)
+        assert_includes rewritten, "/rails/active_storage/blobs/"
+        assert_includes rewritten, "    ![pic](#{PNG_DATA_URI})"
+      end
+    end
+
+    test "markdown_to_html leaves data URIs inside 4-space indented code blocks as literal code" do
+      input = "Sample:\n\n    ![pic](#{PNG_DATA_URI})\n\nAfter.\n"
+      assert_no_difference -> { ActiveStorage::Blob.count } do
+        html = MarkdownConverter.markdown_to_html(input)
+        assert_includes html, "<pre"
+        assert_includes html, "data:image/png"
+        refute_includes html, "/rails/active_storage/blobs/"
+      end
+    end
   end
 end

--- a/engines/collavre/test/services/collavre/markdown_converter_test.rb
+++ b/engines/collavre/test/services/collavre/markdown_converter_test.rb
@@ -110,6 +110,43 @@ module Collavre
       end
     end
 
+    test "markdown_to_html handles inline data URI with title" do
+      input = %Q(Hello ![pic](#{PNG_DATA_URI} "caption"))
+      assert_difference -> { ActiveStorage::Blob.count }, +1 do
+        html = MarkdownConverter.markdown_to_html(input)
+        assert_includes html, "/rails/active_storage/blobs/"
+        refute_includes html, "data:image/png"
+      end
+    end
+
+    test "markdown_to_html handles inline data URI with single-quoted title" do
+      input = %Q(![pic](#{PNG_DATA_URI} 'cap'))
+      assert_difference -> { ActiveStorage::Blob.count }, +1 do
+        html = MarkdownConverter.markdown_to_html(input)
+        assert_includes html, "/rails/active_storage/blobs/"
+        refute_includes html, "data:image/png"
+      end
+    end
+
+    test "rewrite_data_uri_images rewrites inline data URI with title and preserves title" do
+      input = %Q(![pic](#{PNG_DATA_URI} "caption"))
+      assert_difference -> { ActiveStorage::Blob.count }, +1 do
+        rewritten = MarkdownConverter.rewrite_data_uri_images(input)
+        assert_includes rewritten, "/rails/active_storage/blobs/"
+        refute_includes rewritten, "data:image/png"
+        assert_includes rewritten, '"caption"'
+      end
+    end
+
+    test "rewrite_data_uri_images rewrites inline data URI without title" do
+      input = "![pic](#{PNG_DATA_URI})"
+      assert_difference -> { ActiveStorage::Blob.count }, +1 do
+        rewritten = MarkdownConverter.rewrite_data_uri_images(input)
+        assert_includes rewritten, "/rails/active_storage/blobs/"
+        refute_includes rewritten, "data:image/png"
+      end
+    end
+
     test "rewrite_data_uri_images still handles angle-bracket reference form" do
       input = "Hello ![pic][p]\n\n[p]: <#{PNG_DATA_URI}>\n"
       assert_difference -> { ActiveStorage::Blob.count }, +1 do

--- a/engines/collavre/test/services/collavre/markdown_converter_test.rb
+++ b/engines/collavre/test/services/collavre/markdown_converter_test.rb
@@ -69,5 +69,54 @@ module Collavre
       input = '<strong class="highlight">bold</strong> text'
       assert_equal "**bold** text", MarkdownConverter.html_to_markdown(input)
     end
+
+    # 1x1 transparent PNG
+    PNG_DATA_URI = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=".freeze
+
+    test "markdown_to_html handles bare reference-style data URI" do
+      input = "Hello ![pic][p]\n\n[p]: #{PNG_DATA_URI}\n"
+      assert_difference -> { ActiveStorage::Blob.count }, +1 do
+        html = MarkdownConverter.markdown_to_html(input)
+        assert_includes html, "/rails/active_storage/blobs/"
+        refute_includes html, "data:image/png"
+      end
+    end
+
+    test "markdown_to_html handles bare reference-style data URI with title" do
+      input = %Q(Hello ![pic][p]\n\n[p]: #{PNG_DATA_URI} "caption"\n)
+      assert_difference -> { ActiveStorage::Blob.count }, +1 do
+        html = MarkdownConverter.markdown_to_html(input)
+        assert_includes html, "/rails/active_storage/blobs/"
+        refute_includes html, "data:image/png"
+      end
+    end
+
+    test "rewrite_data_uri_images rewrites bare reference-style data URI" do
+      input = "Hello ![pic][p]\n\n[p]: #{PNG_DATA_URI}\n"
+      assert_difference -> { ActiveStorage::Blob.count }, +1 do
+        rewritten = MarkdownConverter.rewrite_data_uri_images(input)
+        assert_includes rewritten, "/rails/active_storage/blobs/"
+        refute_includes rewritten, "data:image/png"
+      end
+    end
+
+    test "rewrite_data_uri_images rewrites bare reference-style data URI with title" do
+      input = %Q(Hello ![pic][p]\n\n[p]: #{PNG_DATA_URI} "caption"\n)
+      assert_difference -> { ActiveStorage::Blob.count }, +1 do
+        rewritten = MarkdownConverter.rewrite_data_uri_images(input)
+        assert_includes rewritten, "/rails/active_storage/blobs/"
+        refute_includes rewritten, "data:image/png"
+        assert_includes rewritten, '"caption"'
+      end
+    end
+
+    test "rewrite_data_uri_images still handles angle-bracket reference form" do
+      input = "Hello ![pic][p]\n\n[p]: <#{PNG_DATA_URI}>\n"
+      assert_difference -> { ActiveStorage::Blob.count }, +1 do
+        rewritten = MarkdownConverter.rewrite_data_uri_images(input)
+        assert_includes rewritten, "/rails/active_storage/blobs/"
+        refute_includes rewritten, "data:image/png"
+      end
+    end
   end
 end

--- a/engines/collavre/test/services/markdown_importer_test.rb
+++ b/engines/collavre/test/services/markdown_importer_test.rb
@@ -132,4 +132,55 @@ class MarkdownImporterTest < ActiveSupport::TestCase
     table_htmls = html_fragments.select { |html| html.include?("<table>") }
     assert_equal 1, table_htmls.size, "Only actual tables should be converted to HTML"
   end
+
+  test "imports bare reference-style data-URI image definitions as attachments" do
+    user = users(:one)
+    parent = Creative.create!(user: user, description: "Parent")
+    png_b64 = Base64.strict_encode64("\x89PNG\r\n\x1A\n" + "x" * 64)
+    markdown = <<~MD
+      ![pic][p]
+
+      [p]: data:image/png;base64,#{png_b64}
+    MD
+
+    created = MarkdownImporter.import(markdown, parent: parent, user: user)
+
+    image_creative = created.find { |c| c.reload.description.match?(%r{<img[^>]+/rails/active_storage/}) }
+    assert_not_nil image_creative, "Bare reference-style data URI should resolve to an Active Storage blob image"
+    assert_no_match(/data:image\/png;base64/, image_creative.description, "Raw data URI must not survive import")
+  end
+
+  test "imports angle-bracket reference-style data-URI image definitions as attachments" do
+    user = users(:one)
+    parent = Creative.create!(user: user, description: "Parent")
+    png_b64 = Base64.strict_encode64("\x89PNG\r\n\x1A\n" + "y" * 64)
+    markdown = <<~MD
+      ![pic][p]
+
+      [p]: <data:image/png;base64,#{png_b64}>
+    MD
+
+    created = MarkdownImporter.import(markdown, parent: parent, user: user)
+
+    image_creative = created.find { |c| c.reload.description.match?(%r{<img[^>]+/rails/active_storage/}) }
+    assert_not_nil image_creative, "Angle-bracket reference-style data URI should still resolve to an Active Storage blob image"
+    assert_no_match(/data:image\/png;base64/, image_creative.description, "Raw data URI must not survive import")
+  end
+
+  test "imports bare reference-style data-URI image with optional title" do
+    user = users(:one)
+    parent = Creative.create!(user: user, description: "Parent")
+    png_b64 = Base64.strict_encode64("\x89PNG\r\n\x1A\n" + "z" * 64)
+    markdown = <<~MD
+      ![pic][p]
+
+      [p]: data:image/png;base64,#{png_b64} "caption"
+    MD
+
+    created = MarkdownImporter.import(markdown, parent: parent, user: user)
+
+    image_creative = created.find { |c| c.reload.description.match?(%r{<img[^>]+/rails/active_storage/}) }
+    assert_not_nil image_creative, "Bare reference-style data URI with title should still resolve to an Active Storage blob image"
+    assert_no_match(/data:image\/png;base64/, image_creative.description, "Raw data URI must not survive import")
+  end
 end


### PR DESCRIPTION
## Summary
- Add Markdown editing mode to creative inline editor with live preview, toggled via MD button
- Store markdown source in `data["markdown_source"]` while `description` always contains rendered HTML — zero changes to existing rendering pipelines
- Add `commonmarker` gem for server-side GFM Markdown→HTML conversion (tables, autolink, strikethrough, tasklist)

## Changes
- **Backend**: `Describable` concern with `before_save` markdown conversion, controller strong params, TreeBuilder/show payload extension
- **Frontend**: Markdown textarea + live preview in inline editor, MD/Rich Text toggle button, keyboard shortcuts (Escape, Shift+Enter)
- **i18n**: en/ko translations for toggle labels and confirmation dialog
- **CSS**: Markdown editor and preview styling matching existing editor dimensions

## Design decisions
- `description` column is always HTML → no downstream rendering changes needed
- Original markdown preserved in `data` JSON column → no DB migration required
- Switching MD→Rich Text warns user that markdown source will be lost

## Test plan
- [x] All 1617 tests pass (0 failures, 0 errors)
- [x] Rubocop clean (795 files, 0 offenses)
- [x] i18n completeness check passes (en + ko)
- [ ] Manual: create creative, toggle MD mode, write markdown, verify live preview
- [ ] Manual: save markdown creative, reload page, verify markdown source persists
- [ ] Manual: toggle back to Rich Text, confirm warning dialog appears
- [ ] Manual: verify linked creatives with markdown origin render correctly