### PR TITLE
fix: prevent layout shift on creative row hover progress toggle

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/creatives.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/creatives.css
@@ -364,13 +364,15 @@ creative-tree-row.show-edit .creative-row {
 
     .creative-row:hover .progress-toggle-wrap .creative-progress-complete,
     .creative-row:hover .progress-toggle-wrap .creative-progress-incomplete {
-        display: none;
+        visibility: hidden;
     }
 
     .creative-row:hover .progress-toggle-checkbox {
         visibility: visible;
         opacity: 1;
-        position: relative;
+        position: absolute;
+        inset: 0;
+        margin: auto;
         pointer-events: auto;
         accent-color: var(--color-brand);
     }


### PR DESCRIPTION
## Summary
- Use `visibility: hidden` instead of `display: none` for progress text on hover, preserving the element's layout space
- Keep checkbox `position: absolute` (with `inset: 0; margin: auto`) instead of switching to `position: relative`, preventing the progress area from changing size
- Prevents text reflow/jumping in creative rows with wrapped content when hovering

## Test plan
- [ ] Hover over a creative row with long wrapped text and verify no layout shift occurs
- [ ] Verify the checkbox appears correctly centered in the progress area on hover
- [ ] Verify touch device behavior is unchanged (`@media (hover: none)`)
- [ ] Verify completed/incomplete progress indicators display correctly in non-hover state