### PR TITLE
fix: add authorization checks to InvitesController and InboxItemsController

### DIFF
--- a/engines/collavre/app/controllers/collavre/inbox_items_controller.rb
+++ b/engines/collavre/app/controllers/collavre/inbox_items_controller.rb
@@ -58,7 +58,7 @@ module Collavre
     private
 
     def set_inbox_item
-      @inbox_item = InboxItem.find(params[:id])
+      @inbox_item = InboxItem.where(owner: Current.user).find(params[:id])
     end
   end
 end

--- a/engines/collavre/app/controllers/collavre/invites_controller.rb
+++ b/engines/collavre/app/controllers/collavre/invites_controller.rb
@@ -5,6 +5,9 @@ module Collavre
 
     def create
       creative = Creative.find(params[:creative_id]).effective_origin
+      unless creative.has_permission?(Current.user, :admin)
+        return head :forbidden
+      end
       permission = params[:permission] || :read
       invitation = Invitation.create!(inviter: Current.user,
                                       creative: creative,


### PR DESCRIPTION
## Summary
- Add `has_permission?(:admin)` check in `InvitesController#create` to prevent unauthorized users from creating invitations for any creative (IDOR)
- Scope `InboxItemsController#set_inbox_item` to `Current.user` to prevent access to other users' inbox items (IDOR)

## Test plan
- [ ] Verify non-admin users cannot create invitations for creatives they don't own
- [ ] Verify users cannot access/modify other users' inbox items
- [ ] Verify existing invitation and inbox flows work correctly for authorized users