### PR TITLE
fix: replace SQL interpolation with parameterized query and standardize rescue clauses

### DIFF
--- a/engines/collavre/app/controllers/collavre/attachments_controller.rb
+++ b/engines/collavre/app/controllers/collavre/attachments_controller.rb
@@ -12,7 +12,7 @@ module Collavre
       head :no_content
     rescue ActiveRecord::RecordNotFound
       head :not_found
-    rescue => e
+    rescue StandardError => e
       Rails.logger.error("Failed to delete attachment: #{e.message}")
       head :internal_server_error
     end

--- a/engines/collavre/app/controllers/collavre/google_auth_controller.rb
+++ b/engines/collavre/app/controllers/collavre/google_auth_controller.rb
@@ -33,7 +33,7 @@ module Collavre
       # Ensure app calendar exists if the granted scope allows creating an app calendar
       begin
         ::GoogleCalendarService.new(user: user).ensure_app_calendar!
-      rescue => e
+      rescue StandardError => e
         Rails.logger.error("Post-login calendar setup failed: #{e.message}")
       end
 

--- a/engines/collavre/app/models/collavre/creative/describable.rb
+++ b/engines/collavre/app/models/collavre/creative/describable.rb
@@ -60,7 +60,7 @@ module Collavre
             blob.purge
           rescue ActiveRecord::RecordNotFound, ActiveSupport::MessageVerifier::InvalidSignature
             Rails.logger.warn("Creative##{id}: could not find blob for signed_id=#{signed_id}")
-          rescue => e
+          rescue StandardError => e
             Rails.logger.error("Creative##{id}: failed to purge blob #{signed_id}: #{e.message}")
           end
         end

--- a/engines/collavre/app/services/collavre/google_calendar_service.rb
+++ b/engines/collavre/app/services/collavre/google_calendar_service.rb
@@ -132,7 +132,7 @@ module Collavre
     def raw_google_refresh_token
       ActiveRecord::Base.connection.select_value(
         ActiveRecord::Base.sanitize_sql_array(
-          ["SELECT google_refresh_token FROM users WHERE id = ?", @user.id]
+          [ "SELECT google_refresh_token FROM users WHERE id = ?", @user.id ]
         )
       )
     end

--- a/engines/collavre/app/services/collavre/google_calendar_service.rb
+++ b/engines/collavre/app/services/collavre/google_calendar_service.rb
@@ -130,10 +130,11 @@ module Collavre
     end
 
     def raw_google_refresh_token
-      result = ActiveRecord::Base.connection.select_value(
-        "SELECT google_refresh_token FROM users WHERE id = #{@user.id}"
+      ActiveRecord::Base.connection.select_value(
+        ActiveRecord::Base.sanitize_sql_array(
+          ["SELECT google_refresh_token FROM users WHERE id = ?", @user.id]
+        )
       )
-      result
     end
 
     def encrypted_value?(value)

--- a/engines/collavre/app/services/collavre/markdown_converter.rb
+++ b/engines/collavre/app/services/collavre/markdown_converter.rb
@@ -92,7 +92,7 @@ module Collavre
               token = "__IMG#{index}__"; index += 1
               placeholders[token] = "![#{alt_text}](data:#{blob.content_type};base64,#{data})"
               token
-            rescue
+            rescue StandardError
               match
             end
           else

--- a/engines/collavre/app/services/collavre/mcp_service.rb
+++ b/engines/collavre/app/services/collavre/mcp_service.rb
@@ -39,7 +39,7 @@ module Collavre
             result: result
           }
         )
-      rescue => e
+      rescue StandardError => e
         Rails.logger.error("Failed to log tool activity: #{e.message}")
       end
 
@@ -55,7 +55,7 @@ module Collavre
         Rails.logger.error(error_msg)
         raise error_msg
       end
-    rescue => e
+    rescue StandardError => e
       Rails.logger.error("Failed to register tool from source: #{e.message}")
       raise e
     end
@@ -131,7 +131,7 @@ module Collavre
       if result[:error]
         Rails.logger.error("Failed to delete tool #{tool_name}: #{result[:error]}")
       end
-    rescue => e
+    rescue StandardError => e
       Rails.logger.error("Failed to delete tool #{tool_name}: #{e.message}")
     end
 

--- a/engines/collavre/db/migrate/20251126040752_add_description_to_creatives.rb
+++ b/engines/collavre/db/migrate/20251126040752_add_description_to_creatives.rb
@@ -38,7 +38,7 @@ class AddDescriptionToCreatives < ActiveRecord::Migration[8.1]
       blob = nil
       begin
         blob = ActionText::Attachable.from_attachable_sgid(sgid)
-      rescue => e
+      rescue StandardError => e
         puts "Error locating blob for sgid #{sgid}: #{e.message}"
       end
 

--- a/engines/collavre_openclaw/app/controllers/collavre_openclaw/health_controller.rb
+++ b/engines/collavre_openclaw/app/controllers/collavre_openclaw/health_controller.rb
@@ -23,7 +23,7 @@ module CollavreOpenclaw
 
     def authenticated?
       respond_to?(:current_user, true) && current_user.present?
-    rescue
+    rescue StandardError
       false
     end
   end

--- a/engines/collavre_openclaw/app/services/collavre_openclaw/connection_manager.rb
+++ b/engines/collavre_openclaw/app/services/collavre_openclaw/connection_manager.rb
@@ -205,7 +205,7 @@ module CollavreOpenclaw
           next unless @idle_check_counter >= 60 # Run check every ~60 seconds
           @idle_check_counter = 0
           check_idle_connections!
-        rescue => e
+        rescue StandardError => e
           Rails.logger.error("[CollavreOpenclaw::ConnectionManager] Idle checker error: #{e.message}")
         end
       end

--- a/engines/collavre_openclaw/app/services/collavre_openclaw/websocket_client.rb
+++ b/engines/collavre_openclaw/app/services/collavre_openclaw/websocket_client.rb
@@ -94,7 +94,7 @@ module CollavreOpenclaw
       EmReactor.next_tick do
         begin
           do_connect!(queue)
-        rescue => e
+        rescue StandardError => e
           queue.push({ error: e.message })
         end
       end
@@ -659,7 +659,7 @@ module CollavreOpenclaw
               schedule_reconnect!
             end
           end
-        rescue => e
+        rescue StandardError => e
           Rails.logger.error("[CollavreOpenclaw::WS] RECONNECT gateway=#{url} state=fail reason=#{e.message}")
           schedule_reconnect!
         end

--- a/engines/collavre_openclaw/lib/collavre_openclaw/engine.rb
+++ b/engines/collavre_openclaw/lib/collavre_openclaw/engine.rb
@@ -50,7 +50,7 @@ module CollavreOpenclaw
           ConnectionManager.instance.disconnect_all
         end
         EmReactor.stop! if EmReactor.running?
-      rescue => e
+      rescue StandardError => e
         Rails.logger.warn("[CollavreOpenclaw] Shutdown cleanup error: #{e.message}")
       end
     end


### PR DESCRIPTION
## Summary
- Replace raw SQL string interpolation in `GoogleCalendarService#raw_google_refresh_token` with `sanitize_sql_array` parameterized query
- Standardize bare `rescue` / `rescue => e` to `rescue StandardError => e` across 11 production files (controllers, services, models, migrations)

## Files changed
- `engines/collavre/app/services/collavre/google_calendar_service.rb` — SQL injection fix
- `engines/collavre/app/controllers/collavre/attachments_controller.rb` — bare rescue
- `engines/collavre/app/controllers/collavre/google_auth_controller.rb` — bare rescue
- `engines/collavre/app/models/collavre/creative/describable.rb` — bare rescue
- `engines/collavre/app/services/collavre/markdown_converter.rb` — bare rescue
- `engines/collavre/app/services/collavre/mcp_service.rb` — bare rescue (3 locations)
- `engines/collavre/db/migrate/20251126040752_add_description_to_creatives.rb` — bare rescue
- `engines/collavre_openclaw/app/controllers/collavre_openclaw/health_controller.rb` — bare rescue
- `engines/collavre_openclaw/app/services/collavre_openclaw/connection_manager.rb` — bare rescue
- `engines/collavre_openclaw/app/services/collavre_openclaw/websocket_client.rb` — bare rescue (2 locations)
- `engines/collavre_openclaw/lib/collavre_openclaw/engine.rb` — bare rescue

## Test plan
- [ ] Verify Google Calendar sync still works correctly
- [ ] Run full test suite to ensure no regressions from rescue clause changes
- [ ] Verify error logging still captures expected exceptions