### PR TITLE
refactor: extract IntegrationSetup concern from integration controllers

### DIFF
--- a/engines/collavre/app/controllers/concerns/collavre/integration_setup.rb
+++ b/engines/collavre/app/controllers/concerns/collavre/integration_setup.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Collavre
+  module IntegrationSetup
+    extend ActiveSupport::Concern
+
+    private
+
+    def set_creative
+      @creative = Collavre::Creative.find(params[:creative_id])
+    end
+
+    def set_origin
+      @origin = @creative.effective_origin
+    end
+  end
+end

--- a/engines/collavre_github/app/controllers/collavre_github/creatives/integrations_controller.rb
+++ b/engines/collavre_github/app/controllers/collavre_github/creatives/integrations_controller.rb
@@ -1,6 +1,7 @@
 module CollavreGithub
   module Creatives
     class IntegrationsController < ApplicationController
+      include Collavre::IntegrationSetup
       include Collavre::IntegrationPermission
 
       before_action :set_creative
@@ -138,14 +139,6 @@ module CollavreGithub
       end
 
       private
-
-      def set_creative
-        @creative = Collavre::Creative.find(params[:creative_id])
-      end
-
-      def set_origin
-        @origin = @creative.effective_origin
-      end
 
       def integration_forbidden_message
         I18n.t("collavre_github.errors.forbidden")

--- a/engines/collavre_notion/app/controllers/collavre_notion/creatives/notion_integrations_controller.rb
+++ b/engines/collavre_notion/app/controllers/collavre_notion/creatives/notion_integrations_controller.rb
@@ -1,6 +1,7 @@
 module CollavreNotion
   module Creatives
     class NotionIntegrationsController < ApplicationController
+      include Collavre::IntegrationSetup
       include Collavre::IntegrationPermission
 
       before_action :set_creative
@@ -121,10 +122,6 @@ module CollavreNotion
       end
 
       private
-
-      def set_creative
-        @creative = Collavre::Creative.find(params[:creative_id])
-      end
 
       def linked_page_links(account)
         return CollavreNotion::NotionPageLink.none unless account

--- a/engines/collavre_slack/app/controllers/collavre_slack/creatives/slack_integrations_controller.rb
+++ b/engines/collavre_slack/app/controllers/collavre_slack/creatives/slack_integrations_controller.rb
@@ -1,6 +1,9 @@
 module CollavreSlack
   module Creatives
     class SlackIntegrationsController < ApplicationController
+      include Collavre::IntegrationSetup
+      include Collavre::IntegrationPermission
+
       before_action :set_creative
       before_action :set_origin
 
@@ -30,7 +33,7 @@ module CollavreSlack
 
       def create
         unless @creative.has_permission?(Current.user, :feedback)
-          render json: { success: false, error: I18n.t("collavre_slack.errors.forbidden") }, status: :forbidden
+          render json: { success: false, error: integration_forbidden_message }, status: :forbidden
           return
         end
 
@@ -73,7 +76,7 @@ module CollavreSlack
         end
 
         unless @creative.has_permission?(Current.user, :feedback)
-          render json: { success: false, error: I18n.t("collavre_slack.errors.forbidden") }, status: :forbidden
+          render json: { success: false, error: integration_forbidden_message }, status: :forbidden
           return
         end
 
@@ -83,12 +86,8 @@ module CollavreSlack
 
       private
 
-      def set_creative
-        @creative = Collavre::Creative.find(params[:creative_id])
-      end
-
-      def set_origin
-        @origin = @creative.effective_origin
+      def integration_forbidden_message
+        I18n.t("collavre_slack.errors.forbidden")
       end
 
       def fetch_channels(slack_account)


### PR DESCRIPTION
## Summary
- Extract common `set_creative` and `set_origin` callbacks into new `Collavre::IntegrationSetup` concern
- Apply to Slack, GitHub, and Notion integration controllers, removing duplicated private methods
- Add `IntegrationPermission` include to Slack controller for consistency

## Test plan
- [x] All 1621 tests pass
- [x] Rubocop passes
- [x] No behavior changes — pure extraction refactoring