### PR TITLE
refactor: extract shared IntegrationWizard JS module

### DIFF
--- a/app/javascript/github_integration.js
+++ b/app/javascript/github_integration.js
@@ -1,3 +1,5 @@
+import { csrfToken, showError, clearError, updateStepVisibility, openOAuthPopup, fetchWithCsrf, setupModalClose } from 'collavre/modules/integration_wizard';
+
 let githubIntegrationInitialized = false;
 
 if (!githubIntegrationInitialized) {

--- a/engines/collavre/app/javascript/modules/integration_wizard.js
+++ b/engines/collavre/app/javascript/modules/integration_wizard.js
@@ -1,0 +1,162 @@
+/**
+ * Integration Wizard — shared helpers for integration modal wizards.
+ *
+ * Provides common utilities used across Slack, Notion, and future
+ * integration wizard UIs: CSRF handling, error display, step management,
+ * OAuth popups, fetch wrappers, and modal close behavior.
+ *
+ * Usage:
+ *   import { csrfToken, showError, ... } from 'collavre/modules/integration_wizard'
+ */
+
+/**
+ * Read the Rails CSRF token from the meta tag.
+ * @returns {string|undefined}
+ */
+export function csrfToken() {
+  return document.querySelector('meta[name="csrf-token"]')?.content;
+}
+
+/**
+ * Display an error message inside the given element.
+ * @param {HTMLElement} el - The error container element
+ * @param {string} message - Error text to display
+ */
+export function showError(el, message) {
+  if (!message) return;
+  el.textContent = message;
+  el.style.display = 'block';
+}
+
+/**
+ * Hide and clear the error element.
+ * @param {HTMLElement} el - The error container element
+ */
+export function clearError(el) {
+  el.style.display = 'none';
+  el.textContent = '';
+}
+
+/**
+ * Show/hide step panes by step name.
+ *
+ * @param {string} currentStep - The active step name
+ * @param {string[]} stepNames - All step names in order
+ * @param {string} prefix - DOM id prefix, e.g. 'slack-step' produces ids like 'slack-step-connect'
+ */
+export function updateStepVisibility(currentStep, stepNames, prefix) {
+  stepNames.forEach(function (step) {
+    const el = document.getElementById(`${prefix}-${step}`);
+    if (!el) return;
+    el.style.display = (step === currentStep) ? 'block' : 'none';
+  });
+}
+
+/**
+ * Open a centered OAuth popup window and poll for its closure.
+ *
+ * @param {string} windowName - Name for window.open (e.g. 'slack-auth-window')
+ * @param {Object} options
+ * @param {number} [options.width=600] - Popup width
+ * @param {number} [options.height=700] - Popup height
+ * @param {string} [options.url=''] - URL to open (pass '' if submitting a form to the window)
+ * @param {Function} [options.onClose] - Callback invoked when the popup is closed
+ * @returns {Window|null} The opened window reference
+ */
+export function openOAuthPopup(windowName, options = {}) {
+  const width = options.width || 600;
+  const height = options.height || 700;
+  const left = (screen.width - width) / 2;
+  const top = (screen.height - height) / 2;
+  const url = options.url || '';
+
+  const authWindow = window.open(
+    url,
+    windowName,
+    `width=${width},height=${height},left=${left},top=${top},scrollbars=yes,resizable=yes`
+  );
+
+  if (authWindow && options.onClose) {
+    const checkClosed = setInterval(() => {
+      if (authWindow.closed) {
+        clearInterval(checkClosed);
+        setTimeout(() => options.onClose(), 1000);
+      }
+    }, 1000);
+  }
+
+  return authWindow;
+}
+
+/**
+ * Perform a fetch request with CSRF token and JSON headers.
+ *
+ * @param {string} url - Request URL
+ * @param {Object} [options={}]
+ * @param {string} [options.method='GET'] - HTTP method
+ * @param {Object} [options.body] - Body payload (will be JSON-stringified)
+ * @param {Object} [options.headers] - Additional headers (merged with defaults)
+ * @returns {Promise<Response>}
+ */
+export function fetchWithCsrf(url, options = {}) {
+  const method = options.method || 'GET';
+  const headers = {
+    'X-CSRF-Token': csrfToken(),
+    'Accept': 'application/json',
+    ...options.headers,
+  };
+
+  // Include Content-Type for requests with a body
+  if (options.body) {
+    headers['Content-Type'] = 'application/json';
+  }
+
+  const fetchOptions = { method, headers };
+  if (options.body) {
+    fetchOptions.body = JSON.stringify(options.body);
+  }
+
+  return fetch(url, fetchOptions);
+}
+
+/**
+ * Hide a list of DOM elements (set display to 'none') and optionally clear their content.
+ *
+ * @param {Array<{el: HTMLElement|null, clear?: boolean}>} items
+ *   Each item has an `el` (may be null) and an optional `clear` flag.
+ *   When `clear` is true, textContent or innerHTML is also reset.
+ */
+export function resetElements(items) {
+  items.forEach(function ({ el, clear }) {
+    if (!el) return;
+    el.style.display = 'none';
+    if (clear) {
+      if ('innerHTML' in el && el.tagName !== 'INPUT') {
+        el.textContent = '';
+      }
+    }
+  });
+}
+
+/**
+ * Set up common modal close behavior: close button, backdrop click, and Escape key.
+ *
+ * @param {HTMLElement} modal - The modal overlay element
+ * @param {HTMLElement} closeBtn - The close button element
+ * @param {Function} onClose - Callback to execute on close (e.g. resetWizard)
+ */
+export function setupModalClose(modal, closeBtn, onClose) {
+  if (closeBtn) {
+    closeBtn.addEventListener('click', function () {
+      modal.style.display = 'none';
+      onClose();
+    });
+  }
+
+  modal.addEventListener('click', function (e) {
+    if (e.target === modal) {
+      modal.style.display = 'none';
+      onClose();
+    }
+  });
+}

--- a/engines/collavre_notion/app/javascript/collavre_notion.js
+++ b/engines/collavre_notion/app/javascript/collavre_notion.js
@@ -1,3 +1,5 @@
+import { csrfToken, showError, clearError, updateStepVisibility, openOAuthPopup, fetchWithCsrf, setupModalClose } from 'collavre/modules/integration_wizard';
+
 let notionIntegrationInitialized = false;
 
 if (!notionIntegrationInitialized) {
@@ -43,10 +45,6 @@ if (!notionIntegrationInitialized) {
     let exportType = 'new-page';
     let selectedParentPage = null;
 
-    function csrfToken() {
-      return document.querySelector('meta[name="csrf-token"]')?.content;
-    }
-
     function resetWizard() {
       currentStep = 'connect';
       hasExistingIntegration = false;
@@ -55,8 +53,7 @@ if (!notionIntegrationInitialized) {
       exportType = 'new-page';
       selectedParentPage = null;
       statusEl.textContent = '';
-      errorEl.style.display = 'none';
-      errorEl.textContent = '';
+      clearError(errorEl);
       if (existingContainer) {
         existingContainer.style.display = 'none';
       }
@@ -74,12 +71,7 @@ if (!notionIntegrationInitialized) {
     }
 
     function updateStep() {
-      ['connect', 'workspace', 'summary']
-        .forEach(function (step) {
-          const el = document.getElementById(`notion-step-${step}`);
-          if (!el) return;
-          el.style.display = (step === currentStep) ? 'block' : 'none';
-        });
+      updateStepVisibility(currentStep, ['connect', 'workspace', 'summary'], 'notion-step');
 
       if (currentStep === 'connect') {
         prevBtn.style.display = 'none';
@@ -105,29 +97,13 @@ if (!notionIntegrationInitialized) {
       }
     }
 
-    function showError(message) {
-      errorEl.textContent = message;
-      errorEl.style.display = 'block';
-    }
-
-    function clearError() {
-      errorEl.style.display = 'none';
-      errorEl.textContent = '';
-    }
-
     function loadIntegrationStatus() {
       if (!creativeId) return;
 
       statusEl.textContent = modal.dataset.loading;
-      clearError();
+      clearError(errorEl);
 
-      fetch(`/notion/creatives/${creativeId}/notion_integration`, {
-        method: 'GET',
-        headers: {
-          'X-CSRF-Token': csrfToken(),
-          'Content-Type': 'application/json'
-        }
-      })
+      fetchWithCsrf(`/notion/creatives/${creativeId}/notion_integration`)
         .then(response => response.json())
         .then(data => {
           console.log('Notion integration status:', data);
@@ -168,7 +144,7 @@ if (!notionIntegrationInitialized) {
         .catch(error => {
           console.error('Error loading integration status:', error);
           statusEl.textContent = '';
-          showError(modal.dataset.loadFailed);
+          showError(errorEl, modal.dataset.loadFailed);
         });
     }
 
@@ -285,13 +261,13 @@ if (!notionIntegrationInitialized) {
 
     function performExport() {
       if (!creativeId) {
-        showError(modal.dataset.noCreative);
+        showError(errorEl, modal.dataset.noCreative);
         return;
       }
 
       exportBtn.disabled = true;
       exportBtn.textContent = modal.dataset.exporting;
-      clearError();
+      clearError(errorEl);
 
       const requestData = {
         action: 'export'
@@ -304,13 +280,9 @@ if (!notionIntegrationInitialized) {
       console.log('Sending export request:', requestData);
       console.log('Export type:', exportType, 'Selected parent page:', selectedParentPage);
 
-      fetch(`/notion/creatives/${creativeId}/notion_integration`, {
+      fetchWithCsrf(`/notion/creatives/${creativeId}/notion_integration`, {
         method: 'PATCH',
-        headers: {
-          'X-CSRF-Token': csrfToken(),
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify(requestData)
+        body: requestData
       })
         .then(response => response.json())
         .then(data => {
@@ -322,12 +294,12 @@ if (!notionIntegrationInitialized) {
               resetWizard();
             }, 2000);
           } else {
-            showError(data.message || modal.dataset.exportFailed);
+            showError(errorEl, data.message || modal.dataset.exportFailed);
           }
         })
         .catch(error => {
           console.error('Export error:', error);
-          showError(modal.dataset.exportFailed);
+          showError(errorEl, modal.dataset.exportFailed);
         })
         .finally(() => {
           exportBtn.disabled = false;
@@ -340,15 +312,11 @@ if (!notionIntegrationInitialized) {
 
       syncBtn.disabled = true;
       syncBtn.textContent = modal.dataset.syncing;
-      clearError();
+      clearError(errorEl);
 
-      fetch(`/notion/creatives/${creativeId}/notion_integration`, {
+      fetchWithCsrf(`/notion/creatives/${creativeId}/notion_integration`, {
         method: 'PATCH',
-        headers: {
-          'X-CSRF-Token': csrfToken(),
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({ action: 'sync' })
+        body: { action: 'sync' }
       })
         .then(response => response.json())
         .then(data => {
@@ -356,12 +324,12 @@ if (!notionIntegrationInitialized) {
             statusEl.textContent = modal.dataset.syncSuccess || 'Sync completed successfully';
             statusEl.style.color = 'green';
           } else {
-            showError(data.message || modal.dataset.syncFailed);
+            showError(errorEl, data.message || modal.dataset.syncFailed);
           }
         })
         .catch(error => {
           console.error('Sync error:', error);
-          showError(modal.dataset.syncFailed);
+          showError(errorEl, modal.dataset.syncFailed);
         })
         .finally(() => {
           syncBtn.disabled = false;
@@ -374,15 +342,9 @@ if (!notionIntegrationInitialized) {
 
       deleteBtn.disabled = true;
       deleteBtn.textContent = modal.dataset.removing;
-      clearError();
+      clearError(errorEl);
 
-      fetch(`/notion/creatives/${creativeId}/notion_integration`, {
-        method: 'DELETE',
-        headers: {
-          'X-CSRF-Token': csrfToken(),
-          'Content-Type': 'application/json'
-        }
-      })
+      fetchWithCsrf(`/notion/creatives/${creativeId}/notion_integration`, { method: 'DELETE' })
         .then(response => response.json())
         .then(data => {
           if (data.success) {
@@ -393,12 +355,12 @@ if (!notionIntegrationInitialized) {
               resetWizard();
             }, 2000);
           } else {
-            showError(data.message || modal.dataset.deleteFailed);
+            showError(errorEl, data.message || modal.dataset.deleteFailed);
           }
         })
         .catch(error => {
           console.error('Delete error:', error);
-          showError(modal.dataset.deleteFailed);
+          showError(errorEl, modal.dataset.deleteFailed);
         })
         .finally(() => {
           deleteBtn.disabled = false;
@@ -418,10 +380,7 @@ if (!notionIntegrationInitialized) {
       loadIntegrationStatus();
     });
 
-    closeBtn.addEventListener('click', function () {
-      modal.style.display = 'none';
-      resetWizard();
-    });
+    setupModalClose(modal, closeBtn, resetWizard);
 
     // Listen for OAuth success message from popup window
     window.addEventListener('message', function(event) {
@@ -436,26 +395,19 @@ if (!notionIntegrationInitialized) {
 
     loginBtn.addEventListener('click', function () {
       console.log('Notion login button clicked');
-      const width = parseInt(this.dataset.windowWidth) || 600;
-      const height = parseInt(this.dataset.windowHeight) || 700;
-      const left = (screen.width - width) / 2;
-      const top = (screen.height - height) / 2;
+      const authWindow = openOAuthPopup('notion-auth-window', {
+        width: parseInt(this.dataset.windowWidth) || 600,
+        height: parseInt(this.dataset.windowHeight) || 700,
+        onClose: function () {
+          console.log('Auth window closed, reloading integration status');
+          loadIntegrationStatus();
+        }
+      });
 
-      const authWindow = window.open('', 'notion-auth-window', 
-        `width=${width},height=${height},left=${left},top=${top},scrollbars=yes,resizable=yes`);
-      
       if (authWindow) {
         loginForm.target = 'notion-auth-window';
         loginForm.submit();
         console.log('Auth form submitted to popup window');
-        
-        const checkClosed = setInterval(() => {
-          if (authWindow.closed) {
-            clearInterval(checkClosed);
-            console.log('Auth window closed, reloading integration status');
-            setTimeout(() => loadIntegrationStatus(), 1000);
-          }
-        }, 1000);
       } else {
         loginForm.target = '_blank';
         loginForm.submit();
@@ -472,7 +424,7 @@ if (!notionIntegrationInitialized) {
     });
 
     nextBtn.addEventListener('click', function () {
-      clearError();
+      clearError(errorEl);
       if (currentStep === 'connect') {
         currentStep = 'workspace';
         updateParentPageOptions();
@@ -501,11 +453,5 @@ if (!notionIntegrationInitialized) {
       });
     }
 
-    modal.addEventListener('click', function (e) {
-      if (e.target === modal) {
-        modal.style.display = 'none';
-        resetWizard();
-      }
-    });
   });
 }

--- a/engines/collavre_slack/app/javascript/collavre_slack.js
+++ b/engines/collavre_slack/app/javascript/collavre_slack.js
@@ -1,4 +1,5 @@
 import { filterChannels, reconcileSelection, buildChannelViewModels } from './slack_channel_list.js';
+import { csrfToken, showError, clearError, updateStepVisibility, openOAuthPopup, fetchWithCsrf, setupModalClose } from 'collavre/modules/integration_wizard';
 
 let slackIntegrationInitialized = false;
 
@@ -35,10 +36,6 @@ if (!slackIntegrationInitialized) {
     let selectedChannel = null;
     let existingLinks = [];
 
-    function csrfToken() {
-      return document.querySelector('meta[name="csrf-token"]')?.content;
-    }
-
     function resetWizard() {
       currentStep = 'connect';
       hasExistingIntegration = false;
@@ -46,8 +43,7 @@ if (!slackIntegrationInitialized) {
       selectedChannel = null;
       existingLinks = [];
       statusEl.textContent = '';
-      errorEl.style.display = 'none';
-      errorEl.textContent = '';
+      clearError(errorEl);
       if (connectedStatus) {
         connectedStatus.style.display = 'none';
       }
@@ -69,12 +65,7 @@ if (!slackIntegrationInitialized) {
     }
 
     function updateStep() {
-      ['connect', 'channels', 'summary']
-        .forEach(function (step) {
-          const el = document.getElementById(`slack-step-${step}`);
-          if (!el) return;
-          el.style.display = (step === currentStep) ? 'block' : 'none';
-        });
+      updateStepVisibility(currentStep, ['connect', 'channels', 'summary'], 'slack-step');
 
       if (currentStep === 'connect') {
         prevBtn.style.display = 'none';
@@ -99,29 +90,13 @@ if (!slackIntegrationInitialized) {
       }
     }
 
-    function showError(message) {
-      errorEl.textContent = message;
-      errorEl.style.display = 'block';
-    }
-
-    function clearError() {
-      errorEl.style.display = 'none';
-      errorEl.textContent = '';
-    }
-
     function loadIntegrationStatus() {
       if (!creativeId) return;
 
       statusEl.textContent = modal.dataset.loading || 'Loading...';
-      clearError();
+      clearError(errorEl);
 
-      fetch(`/slack/creatives/${creativeId}/slack_integrations`, {
-        method: 'GET',
-        headers: {
-          'X-CSRF-Token': csrfToken(),
-          'Accept': 'application/json'
-        }
-      })
+      fetchWithCsrf(`/slack/creatives/${creativeId}/slack_integrations`)
         .then(response => response.json())
         .then(data => {
           console.log('Slack integration status:', data);
@@ -147,7 +122,7 @@ if (!slackIntegrationInitialized) {
         .catch(error => {
           console.error('Error loading integration status:', error);
           statusEl.textContent = '';
-          showError('Failed to load integration status');
+          showError(errorEl, 'Failed to load integration status');
         });
     }
 
@@ -218,15 +193,9 @@ if (!slackIntegrationInitialized) {
       const btn = event.target;
       btn.disabled = true;
       btn.textContent = '...';
-      clearError();
+      clearError(errorEl);
 
-      fetch(`/slack/creatives/${creativeId}/slack_integrations/${link.id}`, {
-        method: 'DELETE',
-        headers: {
-          'X-CSRF-Token': csrfToken(),
-          'Accept': 'application/json'
-        }
-      })
+      fetchWithCsrf(`/slack/creatives/${creativeId}/slack_integrations/${link.id}`, { method: 'DELETE' })
         .then(response => response.json())
         .then(data => {
           if (data.success) {
@@ -240,14 +209,14 @@ if (!slackIntegrationInitialized) {
             statusEl.textContent = modal.dataset.deleteSuccess || 'Channel link removed';
             statusEl.style.color = 'green';
           } else {
-            showError(data.message || data.error || 'Deletion failed');
+            showError(errorEl, data.message || data.error || 'Deletion failed');
             btn.disabled = false;
             btn.textContent = modal.dataset.deleteButtonLabel || 'Remove';
           }
         })
         .catch(error => {
           console.error('Delete error:', error);
-          showError('Deletion failed');
+          showError(errorEl, 'Deletion failed');
           btn.disabled = false;
           btn.textContent = modal.dataset.deleteButtonLabel || 'Remove';
         });
@@ -316,25 +285,20 @@ if (!slackIntegrationInitialized) {
 
     function performLink() {
       if (!creativeId || !selectedChannel) {
-        showError(modal.dataset.noCreative);
+        showError(errorEl, modal.dataset.noCreative);
         return;
       }
 
       finishBtn.disabled = true;
       finishBtn.textContent = modal.dataset.linking || 'Linking...';
-      clearError();
+      clearError(errorEl);
 
-      fetch(`/slack/creatives/${creativeId}/slack_integrations`, {
+      fetchWithCsrf(`/slack/creatives/${creativeId}/slack_integrations`, {
         method: 'POST',
-        headers: {
-          'X-CSRF-Token': csrfToken(),
-          'Content-Type': 'application/json',
-          'Accept': 'application/json'
-        },
-        body: JSON.stringify({
+        body: {
           channel_id: selectedChannel.id,
           channel_name: selectedChannel.name
-        })
+        }
       })
         .then(response => response.json())
         .then(data => {
@@ -346,12 +310,12 @@ if (!slackIntegrationInitialized) {
               resetWizard();
             }, 2000);
           } else {
-            showError(data.message || data.error || 'Failed to link channel');
+            showError(errorEl, data.message || data.error || 'Failed to link channel');
           }
         })
         .catch(error => {
           console.error('Link error:', error);
-          showError('Failed to link channel');
+          showError(errorEl, 'Failed to link channel');
         })
         .finally(() => {
           finishBtn.disabled = false;
@@ -371,34 +335,20 @@ if (!slackIntegrationInitialized) {
       loadIntegrationStatus();
     });
 
-    closeBtn.addEventListener('click', function () {
-      modal.style.display = 'none';
-      resetWizard();
-    });
+    setupModalClose(modal, closeBtn, resetWizard);
 
     loginBtn.addEventListener('click', function (e) {
       e.preventDefault();
       console.log('Slack login button clicked');
-      const width = parseInt(this.dataset.windowWidth) || 600;
-      const height = parseInt(this.dataset.windowHeight) || 700;
-      const left = (screen.width - width) / 2;
-      const top = (screen.height - height) / 2;
-
-      const authUrl = this.href;
-      const authWindow = window.open(authUrl, 'slack-auth-window',
-        `width=${width},height=${height},left=${left},top=${top},scrollbars=yes,resizable=yes`);
-
-      if (authWindow) {
-        console.log('Auth window opened');
-
-        const checkClosed = setInterval(() => {
-          if (authWindow.closed) {
-            clearInterval(checkClosed);
-            console.log('Auth window closed, reloading integration status');
-            setTimeout(() => loadIntegrationStatus(), 1000);
-          }
-        }, 1000);
-      }
+      openOAuthPopup('slack-auth-window', {
+        width: parseInt(this.dataset.windowWidth) || 600,
+        height: parseInt(this.dataset.windowHeight) || 700,
+        url: this.href,
+        onClose: function () {
+          console.log('Auth window closed, reloading integration status');
+          loadIntegrationStatus();
+        }
+      });
     });
 
     prevBtn.addEventListener('click', function () {
@@ -411,14 +361,14 @@ if (!slackIntegrationInitialized) {
     });
 
     nextBtn.addEventListener('click', function () {
-      clearError();
+      clearError(errorEl);
       if (currentStep === 'connect') {
         currentStep = 'channels';
         if (channelSearchEl) channelSearchEl.value = '';
         renderChannelList();
       } else if (currentStep === 'channels') {
         if (!selectedChannel) {
-          showError('Please select a channel');
+          showError(errorEl, 'Please select a channel');
           return;
         }
         updateSummary();
@@ -451,13 +401,7 @@ if (!slackIntegrationInitialized) {
         refreshBtn.textContent = modal.dataset.loading || 'Loading...';
         selectedChannel = null;
 
-        fetch(`/slack/creatives/${creativeId}/slack_integrations`, {
-          method: 'GET',
-          headers: {
-            'X-CSRF-Token': csrfToken(),
-            'Accept': 'application/json'
-          }
-        })
+        fetchWithCsrf(`/slack/creatives/${creativeId}/slack_integrations`)
           .then(response => response.json())
           .then(data => {
             if (data.connected) {
@@ -468,7 +412,7 @@ if (!slackIntegrationInitialized) {
           })
           .catch(error => {
             console.error('Error refreshing channels:', error);
-            showError(modal.dataset.refreshError || 'Failed to refresh channels');
+            showError(errorEl, modal.dataset.refreshError || 'Failed to refresh channels');
           })
           .finally(() => {
             refreshBtn.disabled = false;
@@ -478,12 +422,6 @@ if (!slackIntegrationInitialized) {
       });
     }
 
-    modal.addEventListener('click', function (e) {
-      if (e.target === modal) {
-        modal.style.display = 'none';
-        resetWizard();
-      }
-    });
   });
 
   // Slack badge for comments popup


### PR DESCRIPTION
## Summary
- Extract common JS patterns from Slack/Notion/GitHub integration wizards into `collavre/modules/integration_wizard.js`
- Shared utilities: `csrfToken`, `showError`, `clearError`, `updateStepVisibility`, `openOAuthPopup`, `fetchWithCsrf`, `setupModalClose`
- Net reduction: ~114 lines of duplicated code across 3 integration JS files

## Code scan reference
- [HIGH] JavaScript modal wizard duplication (~600+ lines) (code-scan-2026-04-11)

## Test plan
- [ ] Verify Slack integration modal: connect, channel select, link channel flow
- [ ] Verify Notion integration modal: connect, workspace, export flow
- [ ] Verify GitHub integration modal opens correctly
- [ ] Verify OAuth popup opens and closes correctly for all 3 integrations
- [ ] Verify error display and clearing works in all modals