### PR TITLE
fix: escape html_safe input and add Google Calendar error handling

### DIFF
--- a/engines/collavre/app/jobs/collavre/creative_broadcast_job.rb
+++ b/engines/collavre/app/jobs/collavre/creative_broadcast_job.rb
@@ -233,8 +233,11 @@ module Collavre
 
       svg = raw.dup
       if options[:class]
-        svg.sub!(/<svg\b/, %(<svg class="#{options[:class]}"))
+        escaped_class = ERB::Util.html_escape(options[:class])
+        svg.sub!(/<svg\b/, %(<svg class="#{escaped_class}"))
       end
+      # Safe: SVG source is a static asset file bundled with the app;
+      # user-supplied class attribute is escaped above via html_escape.
       svg.html_safe # rubocop:disable Rails/OutputSafety
     end
 

--- a/engines/collavre/app/services/collavre/google_calendar_service.rb
+++ b/engines/collavre/app/services/collavre/google_calendar_service.rb
@@ -95,6 +95,12 @@ module Collavre
 
     def list_calendars
       @service.list_calendar_lists.items.map { |c| [ c.summary, c.id ] }.to_h
+    rescue Google::Apis::AuthorizationError => e
+      Rails.logger.error("Google Calendar list_calendars auth error for user #{@user.id}: #{e.message}")
+      raise GoogleCalendarError, I18n.t("collavre.google_calendar.errors.reconnect")
+    rescue Faraday::ConnectionFailed, Faraday::TimeoutError, Google::Apis::TransmissionError => e
+      Rails.logger.error("Google Calendar list_calendars network error for user #{@user.id}: #{e.class} - #{e.message}")
+      raise GoogleCalendarError, I18n.t("collavre.google_calendar.errors.network")
     end
 
     private
@@ -109,6 +115,12 @@ module Collavre
         scope:         [ Google::Apis::CalendarV3::AUTH_CALENDAR_APP_CREATED ],
         refresh_token: token
       ).tap(&:fetch_access_token!)
+    rescue Signet::AuthorizationError => e
+      Rails.logger.error("Google Calendar fetch_access_token! auth error for user #{@user.id}: #{e.message}")
+      raise GoogleCalendarError, I18n.t("collavre.google_calendar.errors.reconnect")
+    rescue Faraday::ConnectionFailed, Faraday::TimeoutError => e
+      Rails.logger.error("Google Calendar fetch_access_token! network error for user #{@user.id}: #{e.class} - #{e.message}")
+      raise GoogleCalendarError, I18n.t("collavre.google_calendar.errors.network")
     end
 
     def refresh_token
@@ -161,9 +173,22 @@ module Collavre
         if @user.calendar_id.nil?
           @user.calendar_id = create_app_calendar
         else
-          calendar = @service.get_calendar(@user.calendar_id)
-          if calendar.id != @user.calendar_id
-            @user.calendar_id = create_app_calendar
+          begin
+            calendar = @service.get_calendar(@user.calendar_id)
+            if calendar.id != @user.calendar_id
+              @user.calendar_id = create_app_calendar
+            end
+          rescue Google::Apis::ClientError => e
+            if e.status_code == 404
+              Rails.logger.error("Google Calendar not found (deleted?) for user #{@user.id}, calendar_id=#{@user.calendar_id}")
+              @user.calendar_id = create_app_calendar
+            else
+              Rails.logger.error("Google Calendar get_calendar error for user #{@user.id}: #{e.class} #{e.status_code} - #{e.message}")
+              raise
+            end
+          rescue Google::Apis::AuthorizationError => e
+            Rails.logger.error("Google Calendar get_calendar auth error for user #{@user.id}: #{e.message}")
+            raise GoogleCalendarError, I18n.t("collavre.google_calendar.errors.reconnect")
           end
         end
       end

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -213,6 +213,8 @@ en:
     google_calendar:
       errors:
         not_connected: Google Calendar is not connected. Please connect your Google account first.
+        reconnect: Google Calendar authorization has expired. Please reconnect your Google account.
+        network: Unable to reach Google Calendar. Please try again later.
     inbox:
       mark_read: Read
       mark_unread: Unread

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -210,6 +210,8 @@ ko:
     google_calendar:
       errors:
         not_connected: 구글 캘린더가 연동되지 않았습니다. 먼저 구글 계정을 연동해주세요.
+        reconnect: 구글 캘린더 인증이 만료되었습니다. 구글 계정을 다시 연동해주세요.
+        network: 구글 캘린더에 연결할 수 없습니다. 잠시 후 다시 시도해주세요.
     inbox:
       mark_read: 읽음
       mark_unread: 안읽음


### PR DESCRIPTION
## Summary
- Escape user-supplied CSS class in `creative_broadcast_job.rb` SVG helper before calling `html_safe`
- Add proper error handling for Google Calendar API: auth errors, network errors, and 404 (deleted calendar) recovery
- Add i18n keys for Google Calendar error messages (en, ko)

## Test plan
- [ ] Verify SVG inline icons still render correctly in creative broadcasts
- [ ] Test Google Calendar integration with expired/revoked tokens — should show reconnect message
- [ ] Test Google Calendar with deleted calendar — should auto-recreate
- [ ] Verify network timeout handling returns user-friendly error