### PR TITLE
fix: reorder chat history entries on revisit (LRU)

### DIFF
--- a/engines/collavre/app/javascript/lib/__tests__/chat_history.test.js
+++ b/engines/collavre/app/javascript/lib/__tests__/chat_history.test.js
@@ -36,6 +36,37 @@ describe('ChatNavigationHistory', () => {
     expect(history.current().snippet).toBe('A updated')
   })
 
+  test('revisit reorders entry to reflect visit order', () => {
+    history.push({ creativeId: '1', snippet: 'A' })
+    history.push({ creativeId: '2', snippet: 'B' })
+    history.push({ creativeId: '3', snippet: 'C' })
+    history.push({ creativeId: '4', snippet: 'D' })
+    // entries: [A, B, C, D], cursor at D (index 3)
+
+    history.push({ creativeId: '2', snippet: 'B' })
+    // B should move after D: [A, C, D, B], cursor at B (index 3)
+    expect(history.entries.map(e => e.creativeId)).toEqual(['1', '3', '4', '2'])
+    expect(history.current().creativeId).toBe('2')
+
+    // prev should go back to D (where we came from)
+    expect(history.prev().creativeId).toBe('4')
+    expect(history.prev().creativeId).toBe('3')
+    expect(history.prev().creativeId).toBe('1')
+    // wraps around
+    expect(history.prev().creativeId).toBe('2')
+  })
+
+  test('revisit current entry does not reorder', () => {
+    history.push({ creativeId: '1', snippet: 'A' })
+    history.push({ creativeId: '2', snippet: 'B' })
+    history.push({ creativeId: '3', snippet: 'C' })
+
+    history.push({ creativeId: '3', snippet: 'C updated' })
+    expect(history.entries.map(e => e.creativeId)).toEqual(['1', '2', '3'])
+    expect(history.current().creativeId).toBe('3')
+    expect(history.current().snippet).toBe('C updated')
+  })
+
   test('prev cycles backward', () => {
     history.push({ creativeId: '1', snippet: 'A' })
     history.push({ creativeId: '2', snippet: 'B' })

--- a/engines/collavre/app/javascript/lib/chat_history.js
+++ b/engines/collavre/app/javascript/lib/chat_history.js
@@ -33,10 +33,20 @@ class ChatNavigationHistory {
     )
 
     if (existingIdx !== -1) {
-      // Already in list — update metadata and move cursor there
       this.entries[existingIdx].snippet = entry.snippet || this.entries[existingIdx].snippet
       this.entries[existingIdx].canComment = !!entry.canComment
-      this.currentIndex = existingIdx
+
+      if (existingIdx === this.currentIndex) {
+        this._save()
+        return
+      }
+
+      // Move to after current position to reflect visit order (LRU)
+      const [moved] = this.entries.splice(existingIdx, 1)
+      if (existingIdx < this.currentIndex) this.currentIndex--
+      const insertAt = this.currentIndex + 1
+      this.entries.splice(insertAt, 0, moved)
+      this.currentIndex = insertAt
       this._save()
       return
     }


### PR DESCRIPTION
## Summary
- Fix chat navigation history to maintain visit order when revisiting a chat
- On revisit, the existing entry is removed from its old position and inserted after the current position (LRU style), so back navigation always reflects the actual visit order
- Dedup and circular navigation behavior preserved

## Changes
- `chat_history.js`: Modified `push()` to splice-and-reinsert on revisit instead of just moving the cursor
- Added 2 test cases verifying revisit reorder and current-entry revisit no-op

## Test plan
- [x] All 18 unit tests pass
- [ ] Manual test: visit A → B → C → B, verify Back goes D → C → A (circular)