### PR TITLE
fix: inherit disabled_context_ids from ancestor creatives

### DIFF
--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -314,8 +314,12 @@ module Collavre
 
       current_data = (creative.data || {}).dup
       current_data["context_ids"] = Array(params[:context_ids]).map(&:to_i) if params.key?(:context_ids)
-      current_data["disabled_context_ids"] = Array(params[:disabled_context_ids]).map(&:to_i) if params.key?(:disabled_context_ids)
-      current_data.delete("disabled_context_ids") if current_data["disabled_context_ids"]&.empty?
+      if params.key?(:disabled_context_ids)
+        requested_disabled = Array(params[:disabled_context_ids]).map(&:to_i)
+        parent_disabled = creative.parent&.effective_disabled_context_ids || []
+        current_data["disabled_context_ids"] = requested_disabled - parent_disabled
+        current_data.delete("disabled_context_ids") if current_data["disabled_context_ids"].empty?
+      end
       if params.key?(:disabled_self_context)
         if ActiveModel::Type::Boolean.new.cast(params[:disabled_self_context])
           current_data["disabled_self_context"] = true

--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -317,7 +317,8 @@ module Collavre
       if params.key?(:disabled_context_ids)
         requested_disabled = Array(params[:disabled_context_ids]).map(&:to_i)
         parent_disabled = creative.parent&.effective_disabled_context_ids || []
-        current_data["disabled_context_ids"] = requested_disabled - parent_disabled
+        inherited_only = parent_disabled - creative.disabled_context_ids
+        current_data["disabled_context_ids"] = requested_disabled - inherited_only
         current_data.delete("disabled_context_ids") if current_data["disabled_context_ids"].empty?
       end
       if params.key?(:disabled_self_context)

--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -282,7 +282,7 @@ module Collavre
       own_creatives = Creative.where(id: own_ids).index_by(&:id)
       inherited_creatives = Creative.where(id: inherited_ids).index_by(&:id)
 
-      disabled_ids = Array(creative.data&.dig("disabled_context_ids"))
+      disabled_ids = creative.effective_disabled_context_ids
 
       own = own_ids.filter_map do |cid|
         c = own_creatives[cid]

--- a/engines/collavre/app/models/collavre/creative.rb
+++ b/engines/collavre/app/models/collavre/creative.rb
@@ -134,6 +134,16 @@ module Collavre
       (own + parent_ctx).uniq
     end
 
+    # Returns the effective disabled context IDs: own + inherited from ancestors (deduplicated).
+    def effective_disabled_context_ids(visited_ids = Set.new)
+      return [] if visited_ids.include?(id)
+
+      visited_ids.add(id)
+      own = Array(data&.dig("disabled_context_ids"))
+      parent_disabled = parent&.effective_disabled_context_ids(visited_ids) || []
+      (own + parent_disabled).uniq
+    end
+
     # Returns context creatives (excludes self to avoid duplication).
     def context_creatives
       ids = effective_context_ids

--- a/engines/collavre/app/models/collavre/creative.rb
+++ b/engines/collavre/app/models/collavre/creative.rb
@@ -124,6 +124,11 @@ module Collavre
       Array(data&.dig("context_ids"))
     end
 
+    # Returns the directly-configured disabled context IDs for this creative.
+    def disabled_context_ids
+      Array(data&.dig("disabled_context_ids"))
+    end
+
     # Returns the effective context IDs: own + inherited from ancestors (deduplicated).
     def effective_context_ids(visited_ids = Set.new)
       return [] if visited_ids.include?(id)
@@ -139,7 +144,7 @@ module Collavre
       return [] if visited_ids.include?(id)
 
       visited_ids.add(id)
-      own = Array(data&.dig("disabled_context_ids"))
+      own = disabled_context_ids
       parent_disabled = parent&.effective_disabled_context_ids(visited_ids) || []
       (own + parent_disabled).uniq
     end

--- a/engines/collavre/app/services/collavre/ai_agent/message_builder.rb
+++ b/engines/collavre/app/services/collavre/ai_agent/message_builder.rb
@@ -75,7 +75,7 @@ module Collavre
 
         effective_origin = creative.effective_origin(Set.new)
         context_ids = effective_origin.effective_context_ids
-        disabled_ids = Array(effective_origin.data&.dig("disabled_context_ids"))
+        disabled_ids = effective_origin.effective_disabled_context_ids
         active_ids = context_ids - disabled_ids - [ creative_id, effective_origin.id ]
         return if active_ids.empty?
 

--- a/engines/collavre/test/controllers/creative_contexts_controller_test.rb
+++ b/engines/collavre/test/controllers/creative_contexts_controller_test.rb
@@ -139,6 +139,23 @@ class CreativeContextsControllerTest < ActionDispatch::IntegrationTest
       "Inherited disabled IDs should be filtered out, not copied to child"
   end
 
+  test "PATCH update_contexts preserves child-local disables when parent also disables the same context" do
+    # Child disables X first
+    @feature_a.update!(data: { "context_ids" => [ @development.id ], "disabled_context_ids" => [ @development.id ] })
+    # Parent also disables X
+    @features.update!(data: { "context_ids" => [ @development.id ], "disabled_context_ids" => [ @development.id ] })
+
+    # Child saves again (client sends all disabled IDs including X)
+    patch update_contexts_creative_path(@feature_a), params: {
+      disabled_context_ids: [ @development.id ]
+    }, headers: { "ACCEPT" => "application/json" }, as: :json
+
+    assert_response :success
+    @feature_a.reload
+    assert_equal [ @development.id ], @feature_a.data["disabled_context_ids"],
+      "Child's own disable should be preserved even when parent also disables the same context"
+  end
+
   test "PATCH update_contexts requires admin permission" do
     regular_user = users(:two)
     sign_in_as(regular_user, password: "password")

--- a/engines/collavre/test/controllers/creative_contexts_controller_test.rb
+++ b/engines/collavre/test/controllers/creative_contexts_controller_test.rb
@@ -124,6 +124,21 @@ class CreativeContextsControllerTest < ActionDispatch::IntegrationTest
     assert ctx["disabled"], "Disabled state from parent should be inherited by child"
   end
 
+  test "PATCH update_contexts filters out parent-inherited disabled IDs to prevent sticky disablement" do
+    @features.update!(data: { "context_ids" => [ @development.id ], "disabled_context_ids" => [ @development.id ] })
+
+    # Client sends ALL disabled IDs (including inherited ones) from the child
+    patch update_contexts_creative_path(@feature_a), params: {
+      disabled_context_ids: [ @development.id ]
+    }, headers: { "ACCEPT" => "application/json" }, as: :json
+
+    assert_response :success
+    @feature_a.reload
+    # Inherited disabled ID should NOT be stored on the child
+    refute @feature_a.data&.key?("disabled_context_ids"),
+      "Inherited disabled IDs should be filtered out, not copied to child"
+  end
+
   test "PATCH update_contexts requires admin permission" do
     regular_user = users(:two)
     sign_in_as(regular_user, password: "password")

--- a/engines/collavre/test/controllers/creative_contexts_controller_test.rb
+++ b/engines/collavre/test/controllers/creative_contexts_controller_test.rb
@@ -113,6 +113,17 @@ class CreativeContextsControllerTest < ActionDispatch::IntegrationTest
     assert_includes context_ids, @development.id, "Other contexts should still be present"
   end
 
+  test "GET contexts inherits disabled state from parent" do
+    @features.update!(data: { "context_ids" => [ @development.id ], "disabled_context_ids" => [ @development.id ] })
+
+    get contexts_creative_path(@feature_a), headers: { "ACCEPT" => "application/json" }
+    assert_response :success
+    json = JSON.parse(response.body)
+    ctx = json["contexts"].find { |c| c["id"] == @development.id }
+    assert ctx, "Development context should appear in child"
+    assert ctx["disabled"], "Disabled state from parent should be inherited by child"
+  end
+
   test "PATCH update_contexts requires admin permission" do
     regular_user = users(:two)
     sign_in_as(regular_user, password: "password")

--- a/engines/collavre/test/models/collavre/creative_context_test.rb
+++ b/engines/collavre/test/models/collavre/creative_context_test.rb
@@ -61,6 +61,39 @@ module Collavre
       refute_includes creatives, @features
     end
 
+    # --- effective_disabled_context_ids ---
+
+    test "effective_disabled_context_ids returns empty when nothing disabled" do
+      assert_equal [], @feature_a.effective_disabled_context_ids
+    end
+
+    test "effective_disabled_context_ids returns own disabled IDs" do
+      @features.update!(data: { "context_ids" => [ @development.id ], "disabled_context_ids" => [ @development.id ] })
+      assert_equal [ @development.id ], @features.effective_disabled_context_ids
+    end
+
+    test "effective_disabled_context_ids inherits from parent" do
+      @features.update!(data: { "context_ids" => [ @development.id ], "disabled_context_ids" => [ @development.id ] })
+      assert_includes @feature_a.effective_disabled_context_ids, @development.id
+    end
+
+    test "effective_disabled_context_ids combines own and parent disabled" do
+      @features.update!(data: { "context_ids" => [ @development.id ], "disabled_context_ids" => [ @development.id ] })
+      @feature_a.update!(data: { "context_ids" => [ @goal.id ], "disabled_context_ids" => [ @goal.id ] })
+
+      disabled = @feature_a.effective_disabled_context_ids
+      assert_includes disabled, @development.id
+      assert_includes disabled, @goal.id
+    end
+
+    test "effective_disabled_context_ids deduplicates" do
+      @features.update!(data: { "disabled_context_ids" => [ @development.id ] })
+      @feature_a.update!(data: { "disabled_context_ids" => [ @development.id ] })
+
+      disabled = @feature_a.effective_disabled_context_ids
+      assert_equal 1, disabled.count(@development.id)
+    end
+
     test "R&D inherits different context than Features" do
       @features.update!(data: { "context_ids" => [ @development.id ] })
       @rnd.update!(data: { "context_ids" => [ @goal.id ] })


### PR DESCRIPTION
## Summary
- Parent creative에서 context를 제외(disabled) 토글하면, 자식 creative에서도 동일하게 제외 상태로 표시되도록 수정
- `effective_disabled_context_ids` 메서드를 추가하여 `effective_context_ids`와 동일한 조상 상속 패턴 적용
- Controller(contexts 액션)와 MessageBuilder(AI 채팅 컨텍스트)에서 상속된 disabled IDs 사용

## Changes
- **Creative model**: `effective_disabled_context_ids` — 조상의 disabled IDs를 재귀적으로 수집
- **CreativesController#contexts**: `creative.data.dig("disabled_context_ids")` → `creative.effective_disabled_context_ids`
- **MessageBuilder#append_context_creatives**: 동일 수정

## Test plan
- [x] Model test: 빈 상태, 자기 자신, 부모 상속, 부모+자식 결합, 중복 제거
- [x] Controller test: 자식 creative에서 부모의 disabled 상태가 상속되어 반환되는지 검증
- [x] 기존 24개 테스트 모두 통과