### PR TITLE
fix: prevent vertical scroll blocking over table elements in chat

### DIFF
--- a/engines/collavre/app/javascript/controllers/comments/popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_controller.js
@@ -1085,20 +1085,14 @@ export default class extends Controller {
       if (hasOverflowY || hasOverflowX) {
         const style = getComputedStyle(el)
 
-        // Check dominant axis first for better matching
         if (dominantAxis === 'x' && hasOverflowX) {
           const scrollableX = style.overflowX === 'auto' || style.overflowX === 'scroll'
           if (scrollableX) return { element: el, axis: 'x' }
         }
 
-        if (hasOverflowY) {
+        if (dominantAxis === 'y' && hasOverflowY) {
           const scrollableY = style.overflowY === 'auto' || style.overflowY === 'scroll'
           if (scrollableY) return { element: el, axis: 'y' }
-        }
-
-        if (dominantAxis !== 'x' && hasOverflowX) {
-          const scrollableX = style.overflowX === 'auto' || style.overflowX === 'scroll'
-          if (scrollableX) return { element: el, axis: 'x' }
         }
       }
 


### PR DESCRIPTION
## Summary
- Fix vertical scroll being blocked when mouse is over a table in chat messages
- The `_findScrollableAncestor()` fallback incorrectly matched horizontal-only scroll containers (table wrappers) when the user was scrolling vertically, causing `preventDefault()` to block vertical scroll
- Removed the fallback block so each axis only matches when the dominant scroll direction aligns with the element's scrollable axis

## Test plan
- [ ] Open a chat with a message containing a table
- [ ] Verify vertical scroll works when mouse is over the table
- [ ] Verify horizontal scroll still works on wide tables
- [ ] Verify scroll boundary handling still works on code blocks and other scrollable elements