### PR TITLE
fix: unify form input and submit button heights

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -91,10 +91,10 @@ textarea:focus-visible {
 }
 
 /* Form inputs need more padding than compact nav inputs */
-.stacked-form input:not([type="checkbox"]):not([type="radio"]):not([type="hidden"]):not([type="submit"]),
+.stacked-form input:not([type="checkbox"]):not([type="radio"]):not([type="hidden"]):not([type="range"]),
 .stacked-form select,
 .stacked-form textarea,
-.profile-form input:not([type="checkbox"]):not([type="radio"]):not([type="hidden"]):not([type="submit"]),
+.profile-form input:not([type="checkbox"]):not([type="radio"]):not([type="hidden"]):not([type="range"]),
 .profile-form select,
 .profile-form textarea {
     padding: var(--space-2) var(--space-3);


### PR DESCRIPTION
## Summary
- Login/signup form의 입력 필드(email, password)와 submit 버튼의 높이 불일치를 수정
- `.stacked-form` 패딩 셀렉터에서 `:not([type="submit"])`을 `:not([type="range"])`로 교체하여 submit 버튼도 동일한 `var(--space-2) var(--space-3)` 패딩을 받도록 변경
- 이전: 입력필드 42px vs 버튼 34px → 이후: 모두 42px

## Root Cause
The `.stacked-form` padding override selector explicitly excluded `[type="submit"]` inputs, so submit buttons fell through to the base input rule with only `var(--space-1)` (4px) padding instead of `var(--space-2) var(--space-3)` (8px 16px).

## Test plan
- [x] Login page (/session/new): email, password, Sign in button all 42px
- [x] Signup page (/users/new): name, email, password, confirm password, Sign Up button all 42px
- [x] All 1636 tests pass (0 failures)
- [x] Rubocop clean
- [x] i18n keys complete