### PR TITLE
feat(collavre): extract SessionContextResolver for common session management

### DIFF
--- a/engines/collavre/app/models/collavre/user.rb
+++ b/engines/collavre/app/models/collavre/user.rb
@@ -119,7 +119,7 @@ module Collavre
       explicit = parsed_agent_conf.dig("session", "enabled")
       return ActiveModel::Type::Boolean.new.cast(explicit) unless explicit.nil?
 
-      llm_vendor == "openclaw"
+      llm_vendor&.downcase == "openclaw"
     end
 
     encrypts :llm_api_key, deterministic: false

--- a/engines/collavre/app/models/collavre/user.rb
+++ b/engines/collavre/app/models/collavre/user.rb
@@ -117,7 +117,7 @@ module Collavre
     # nil in agent_conf = auto-detect by vendor (openclaw → true).
     def supports_session?
       explicit = parsed_agent_conf.dig("session", "enabled")
-      return explicit unless explicit.nil?
+      return ActiveModel::Type::Boolean.new.cast(explicit) unless explicit.nil?
 
       llm_vendor == "openclaw"
     end

--- a/engines/collavre/app/models/collavre/user.rb
+++ b/engines/collavre/app/models/collavre/user.rb
@@ -77,7 +77,8 @@ module Collavre
         "chat_history" => 50,
         "chat_history_size" => 100_000,
         "creative_children_level" => nil
-      }
+      },
+      "session" => { "enabled" => nil }
     }.freeze
 
     # Default creative children level when agent_conf doesn't specify one
@@ -110,6 +111,15 @@ module Collavre
     def creative_children_level
       level = parsed_agent_conf.dig("context", "creative_children_level")
       level.nil? ? DEFAULT_CREATIVE_CHILDREN_LEVEL : level.to_i
+    end
+
+    # Whether this agent uses stateful sessions (incremental messaging).
+    # nil in agent_conf = auto-detect by vendor (openclaw → true).
+    def supports_session?
+      explicit = parsed_agent_conf.dig("session", "enabled")
+      return explicit unless explicit.nil?
+
+      llm_vendor == "openclaw"
     end
 
     encrypts :llm_api_key, deterministic: false

--- a/engines/collavre/app/services/collavre/ai_agent/session_context_resolver.rb
+++ b/engines/collavre/app/services/collavre/ai_agent/session_context_resolver.rb
@@ -3,8 +3,6 @@
 module Collavre
   module AiAgent
     class SessionContextResolver
-      CONTEXT_KINDS = %i[creative_context context_creative referenced_creative].freeze
-
       def initialize(agent:, messages_data:, system_prompt:)
         @agent = agent
         @messages_data = messages_data

--- a/engines/collavre/app/services/collavre/ai_agent/session_context_resolver.rb
+++ b/engines/collavre/app/services/collavre/ai_agent/session_context_resolver.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Collavre
+  module AiAgent
+    class SessionContextResolver
+      CONTEXT_KINDS = %i[creative_context context_creative referenced_creative].freeze
+
+      def initialize(agent:, messages_data:, system_prompt:)
+        @agent = agent
+        @messages_data = messages_data
+        @system_prompt = system_prompt
+      end
+
+      def resolve
+        if @agent.supports_session? && !needs_full_context?
+          incremental_payload
+        else
+          full_payload
+        end
+      end
+
+      private
+
+      def needs_full_context?
+        @messages_data[:first_message] || @messages_data[:context_changed]
+      end
+
+      def full_payload
+        {
+          messages: @messages_data[:messages],
+          system_prompt: @system_prompt,
+          first_message: @messages_data[:first_message],
+          context_changed: @messages_data[:context_changed]
+        }
+      end
+
+      def incremental_payload
+        trigger_only = @messages_data[:messages].select { |m| m[:kind] == :trigger }
+
+        {
+          messages: trigger_only,
+          system_prompt: nil,
+          first_message: false,
+          context_changed: false
+        }
+      end
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/ai_agent/session_context_resolver.rb
+++ b/engines/collavre/app/services/collavre/ai_agent/session_context_resolver.rb
@@ -24,11 +24,8 @@ module Collavre
       end
 
       def full_payload
-        msgs = if @agent.supports_session?
-                 @messages_data[:messages].reject { |m| m[:kind] == :chat_history }
-               else
-                 @messages_data[:messages]
-               end
+        msgs = @messages_data[:messages]
+        msgs = msgs.reject { |m| m[:kind] == :chat_history } if @agent.supports_session?
 
         {
           messages: msgs,

--- a/engines/collavre/app/services/collavre/ai_agent/session_context_resolver.rb
+++ b/engines/collavre/app/services/collavre/ai_agent/session_context_resolver.rb
@@ -24,8 +24,14 @@ module Collavre
       end
 
       def full_payload
+        msgs = if @agent.supports_session?
+                 @messages_data[:messages].reject { |m| m[:kind] == :chat_history }
+               else
+                 @messages_data[:messages]
+               end
+
         {
-          messages: @messages_data[:messages],
+          messages: msgs,
           system_prompt: @system_prompt,
           first_message: @messages_data[:first_message],
           context_changed: @messages_data[:context_changed]

--- a/engines/collavre/app/services/collavre/ai_agent_service.rb
+++ b/engines/collavre/app/services/collavre/ai_agent_service.rb
@@ -29,6 +29,9 @@ module Collavre
         rendering_context = prepare_rendering_context
         system_prompt = render_system_prompt(rendering_context)
 
+        # Resolve session context (decides what to send)
+        resolved = resolve_session_context(messages_data, system_prompt)
+
         # Create placeholder comment if needed
         @reply_comment = create_reply_comment_if_needed
 
@@ -48,8 +51,8 @@ module Collavre
         @lifecycle_manager.broadcast_status("thinking")
 
         # Execute AI chat with streaming
-        @client = build_ai_client(system_prompt)
-        stream_response(@client, messages_data)
+        @client = build_ai_client(resolved[:system_prompt])
+        stream_response(@client, resolved)
 
         log_action("completion", { response: @streamer.content })
 
@@ -87,6 +90,14 @@ module Collavre
         context: @context,
         original_comment: @original_comment
       ).build
+    end
+
+    def resolve_session_context(messages_data, system_prompt)
+      AiAgent::SessionContextResolver.new(
+        agent: @agent,
+        messages_data: messages_data,
+        system_prompt: system_prompt
+      ).resolve
     end
 
     def find_creative

--- a/engines/collavre/test/models/user_agent_conf_test.rb
+++ b/engines/collavre/test/models/user_agent_conf_test.rb
@@ -63,5 +63,37 @@ module Collavre
       @user.agent_conf = "context:\n  creative_children_level: '3'"
       assert_equal 3, @user.creative_children_level
     end
+
+    # supports_session? tests
+
+    test "supports_session? auto-detects true for openclaw vendor" do
+      @user.llm_vendor = "openclaw"
+      @user.agent_conf = nil
+      assert @user.supports_session?
+    end
+
+    test "supports_session? auto-detects false for non-openclaw vendor" do
+      @user.llm_vendor = "google"
+      @user.agent_conf = nil
+      assert_not @user.supports_session?
+    end
+
+    test "supports_session? explicit true overrides auto-detect" do
+      @user.llm_vendor = "google"
+      @user.agent_conf = "session:\n  enabled: true"
+      assert @user.supports_session?
+    end
+
+    test "supports_session? explicit false overrides auto-detect for openclaw" do
+      @user.llm_vendor = "openclaw"
+      @user.agent_conf = "session:\n  enabled: false"
+      assert_not @user.supports_session?
+    end
+
+    test "supports_session? returns false when llm_vendor is nil" do
+      @user.llm_vendor = nil
+      @user.agent_conf = nil
+      assert_not @user.supports_session?
+    end
   end
 end

--- a/engines/collavre/test/models/user_agent_conf_test.rb
+++ b/engines/collavre/test/models/user_agent_conf_test.rb
@@ -95,5 +95,17 @@ module Collavre
       @user.agent_conf = nil
       assert_not @user.supports_session?
     end
+
+    test "supports_session? handles quoted string 'false' as false" do
+      @user.llm_vendor = "openclaw"
+      @user.agent_conf = "session:\n  enabled: 'false'"
+      assert_not @user.supports_session?
+    end
+
+    test "supports_session? handles quoted string 'true' as true" do
+      @user.llm_vendor = "google"
+      @user.agent_conf = "session:\n  enabled: 'true'"
+      assert @user.supports_session?
+    end
   end
 end

--- a/engines/collavre/test/services/collavre/ai_agent/session_context_resolver_test.rb
+++ b/engines/collavre/test/services/collavre/ai_agent/session_context_resolver_test.rb
@@ -38,7 +38,7 @@ module Collavre
           agent: agent, messages_data: messages_data, system_prompt: @system_prompt
         ).resolve
 
-        assert_equal @full_messages, result[:messages]
+        assert_no_chat_history(result[:messages])
         assert_equal @system_prompt, result[:system_prompt]
         assert_equal true, result[:first_message]
       end
@@ -51,9 +51,36 @@ module Collavre
           agent: agent, messages_data: messages_data, system_prompt: @system_prompt
         ).resolve
 
-        assert_equal @full_messages, result[:messages]
+        assert_no_chat_history(result[:messages])
         assert_equal @system_prompt, result[:system_prompt]
         assert_equal true, result[:context_changed]
+      end
+
+      test "full payload for session agent excludes chat_history but keeps context and trigger" do
+        agent = build_agent(supports_session: true)
+        messages_data = { messages: @full_messages, first_message: true, context_changed: false }
+
+        result = SessionContextResolver.new(
+          agent: agent, messages_data: messages_data, system_prompt: @system_prompt
+        ).resolve
+
+        kinds = result[:messages].map { |m| m[:kind] }
+        assert_includes kinds, :creative_context
+        assert_includes kinds, :context_creative
+        assert_includes kinds, :trigger
+        assert_not_includes kinds, :chat_history
+      end
+
+      test "full payload for non-session agent includes chat_history" do
+        agent = build_agent(supports_session: false)
+        messages_data = { messages: @full_messages, first_message: true, context_changed: false }
+
+        result = SessionContextResolver.new(
+          agent: agent, messages_data: messages_data, system_prompt: @system_prompt
+        ).resolve
+
+        kinds = result[:messages].map { |m| m[:kind] }
+        assert_includes kinds, :chat_history
       end
 
       test "returns incremental payload for warm session" do
@@ -95,7 +122,7 @@ module Collavre
           agent: agent, messages_data: messages_data, system_prompt: @system_prompt
         ).resolve
 
-        assert_equal @full_messages, result[:messages]
+        assert_no_chat_history(result[:messages])
         assert_equal @system_prompt, result[:system_prompt]
       end
 
@@ -106,6 +133,11 @@ module Collavre
         val = supports_session
         agent.define_singleton_method(:supports_session?) { val }
         agent
+      end
+
+      def assert_no_chat_history(messages)
+        chat_history = messages.select { |m| m[:kind] == :chat_history }
+        assert_empty chat_history, "Expected no chat_history messages but found #{chat_history.length}"
       end
     end
   end

--- a/engines/collavre/test/services/collavre/ai_agent/session_context_resolver_test.rb
+++ b/engines/collavre/test/services/collavre/ai_agent/session_context_resolver_test.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  module AiAgent
+    class SessionContextResolverTest < ActiveSupport::TestCase
+      setup do
+        @system_prompt = "You are a helpful assistant"
+        @full_messages = [
+          { role: "user", kind: :creative_context, parts: [{ text: "Creative (id: 1):\n# Hello" }] },
+          { role: "user", kind: :context_creative, parts: [{ text: "Context Creative (id: 2):\n# Config" }] },
+          { role: "user", kind: :chat_history, parts: [{ text: "[Alice]: hi" }] },
+          { role: "model", kind: :chat_history, parts: [{ text: "Hello!" }] },
+          { role: "user", kind: :trigger, parts: [{ text: "[Alice]: Follow-up" }] }
+        ]
+      end
+
+      test "returns full payload when agent does not support sessions" do
+        agent = build_agent(supports_session: false)
+        messages_data = { messages: @full_messages, first_message: false, context_changed: false }
+
+        result = SessionContextResolver.new(
+          agent: agent, messages_data: messages_data, system_prompt: @system_prompt
+        ).resolve
+
+        assert_equal @full_messages, result[:messages]
+        assert_equal @system_prompt, result[:system_prompt]
+        assert_equal false, result[:first_message]
+        assert_equal false, result[:context_changed]
+      end
+
+      test "returns full payload on first message even when session supported" do
+        agent = build_agent(supports_session: true)
+        messages_data = { messages: @full_messages, first_message: true, context_changed: false }
+
+        result = SessionContextResolver.new(
+          agent: agent, messages_data: messages_data, system_prompt: @system_prompt
+        ).resolve
+
+        assert_equal @full_messages, result[:messages]
+        assert_equal @system_prompt, result[:system_prompt]
+        assert_equal true, result[:first_message]
+      end
+
+      test "returns full payload when context changed even when session supported" do
+        agent = build_agent(supports_session: true)
+        messages_data = { messages: @full_messages, first_message: false, context_changed: true }
+
+        result = SessionContextResolver.new(
+          agent: agent, messages_data: messages_data, system_prompt: @system_prompt
+        ).resolve
+
+        assert_equal @full_messages, result[:messages]
+        assert_equal @system_prompt, result[:system_prompt]
+        assert_equal true, result[:context_changed]
+      end
+
+      test "returns incremental payload for warm session" do
+        agent = build_agent(supports_session: true)
+        messages_data = { messages: @full_messages, first_message: false, context_changed: false }
+
+        result = SessionContextResolver.new(
+          agent: agent, messages_data: messages_data, system_prompt: @system_prompt
+        ).resolve
+
+        assert_equal 1, result[:messages].length
+        assert_equal :trigger, result[:messages].first[:kind]
+        assert_equal "[Alice]: Follow-up", result[:messages].first[:parts].first[:text]
+        assert_nil result[:system_prompt]
+        assert_equal false, result[:first_message]
+        assert_equal false, result[:context_changed]
+      end
+
+      test "incremental payload preserves multiple trigger messages" do
+        agent = build_agent(supports_session: true)
+        messages_with_two_triggers = @full_messages + [
+          { role: "user", kind: :trigger, parts: [{ text: "Another trigger" }] }
+        ]
+        messages_data = { messages: messages_with_two_triggers, first_message: false, context_changed: false }
+
+        result = SessionContextResolver.new(
+          agent: agent, messages_data: messages_data, system_prompt: @system_prompt
+        ).resolve
+
+        assert_equal 2, result[:messages].length
+        assert(result[:messages].all? { |m| m[:kind] == :trigger })
+      end
+
+      test "returns full payload when both first_message and context_changed" do
+        agent = build_agent(supports_session: true)
+        messages_data = { messages: @full_messages, first_message: true, context_changed: true }
+
+        result = SessionContextResolver.new(
+          agent: agent, messages_data: messages_data, system_prompt: @system_prompt
+        ).resolve
+
+        assert_equal @full_messages, result[:messages]
+        assert_equal @system_prompt, result[:system_prompt]
+      end
+
+      private
+
+      def build_agent(supports_session:)
+        agent = Object.new
+        val = supports_session
+        agent.define_singleton_method(:supports_session?) { val }
+        agent
+      end
+    end
+  end
+end

--- a/engines/collavre/test/services/collavre/ai_agent/session_context_resolver_test.rb
+++ b/engines/collavre/test/services/collavre/ai_agent/session_context_resolver_test.rb
@@ -8,11 +8,11 @@ module Collavre
       setup do
         @system_prompt = "You are a helpful assistant"
         @full_messages = [
-          { role: "user", kind: :creative_context, parts: [{ text: "Creative (id: 1):\n# Hello" }] },
-          { role: "user", kind: :context_creative, parts: [{ text: "Context Creative (id: 2):\n# Config" }] },
-          { role: "user", kind: :chat_history, parts: [{ text: "[Alice]: hi" }] },
-          { role: "model", kind: :chat_history, parts: [{ text: "Hello!" }] },
-          { role: "user", kind: :trigger, parts: [{ text: "[Alice]: Follow-up" }] }
+          { role: "user", kind: :creative_context, parts: [ { text: "Creative (id: 1):\n# Hello" } ] },
+          { role: "user", kind: :context_creative, parts: [ { text: "Context Creative (id: 2):\n# Config" } ] },
+          { role: "user", kind: :chat_history, parts: [ { text: "[Alice]: hi" } ] },
+          { role: "model", kind: :chat_history, parts: [ { text: "Hello!" } ] },
+          { role: "user", kind: :trigger, parts: [ { text: "[Alice]: Follow-up" } ] }
         ]
       end
 
@@ -75,7 +75,7 @@ module Collavre
       test "incremental payload preserves multiple trigger messages" do
         agent = build_agent(supports_session: true)
         messages_with_two_triggers = @full_messages + [
-          { role: "user", kind: :trigger, parts: [{ text: "Another trigger" }] }
+          { role: "user", kind: :trigger, parts: [ { text: "Another trigger" } ] }
         ]
         messages_data = { messages: messages_with_two_triggers, first_message: false, context_changed: false }
 

--- a/engines/collavre_openclaw/app/services/collavre_openclaw/ai_client_extension.rb
+++ b/engines/collavre_openclaw/app/services/collavre_openclaw/ai_client_extension.rb
@@ -12,8 +12,8 @@ module CollavreOpenclaw
       end
     end
 
-    # @param messages_input [Hash, Array] Hash { messages:, first_message:, context_changed: }
-    #   from MessageBuilder, or a plain Array from standalone callers (e.g., CompressJob).
+    # @param messages_input [Hash, Array] Hash { messages:, first_message:, context_changed:, system_prompt: }
+    #   from SessionContextResolver, or a plain Array from standalone callers (e.g., CompressJob).
     def chat(messages_input, tools: [], &block)
       normalized_vendor = vendor.to_s.downcase
       messages_data = normalize_messages_input(messages_input)
@@ -23,10 +23,13 @@ module CollavreOpenclaw
 
       if adapter_class
         # Use the custom adapter (tools not supported for OpenClaw)
+        # Prefer resolved system_prompt from SessionContextResolver over instance default.
+        # key?(:system_prompt) distinguishes "not provided" (Array input) from "explicitly nil" (incremental session).
+        resolved_system_prompt = messages_data.key?(:system_prompt) ? messages_data[:system_prompt] : system_prompt
         user = context&.dig(:user)
         adapter = adapter_class.new(
           user: user,
-          system_prompt: system_prompt,
+          system_prompt: resolved_system_prompt,
           context: context
         )
 

--- a/engines/collavre_openclaw/app/services/collavre_openclaw/openclaw_adapter.rb
+++ b/engines/collavre_openclaw/app/services/collavre_openclaw/openclaw_adapter.rb
@@ -3,9 +3,11 @@ require "json"
 
 module CollavreOpenclaw
   class OpenclawAdapter
-    # Adapter for OpenClaw AI Gateway
+    # Pure transport adapter for OpenClaw AI Gateway.
+    # Session context filtering (full vs incremental) is handled upstream
+    # by SessionContextResolver — this adapter sends exactly what it receives.
     #
-    # Supports two transport modes:
+    # Transport modes:
     # 1. WebSocket (primary) - via faye-websocket + EventMachine
     # 2. HTTP (fallback) - via Faraday POST /v1/chat/completions
     #

--- a/engines/collavre_openclaw/app/services/collavre_openclaw/openclaw_adapter.rb
+++ b/engines/collavre_openclaw/app/services/collavre_openclaw/openclaw_adapter.rb
@@ -72,25 +72,10 @@ module CollavreOpenclaw
 
     private
 
-    CONTEXT_KINDS = %i[creative_context context_creative referenced_creative].freeze
-
     def parse_messages_data!(data)
       @all_messages    = data[:messages] || []
       @first_message   = data[:first_message]
       @context_changed = data[:context_changed]
-    end
-
-    def context_messages
-      @all_messages.select { |m| CONTEXT_KINDS.include?(m[:kind]) }
-    end
-
-    def trigger_message
-      @all_messages.find { |m| m[:kind] == :trigger }
-    end
-
-    # Send system prompt and context on first message or when they changed.
-    def include_full_context?
-      @first_message || @context_changed
     end
 
     # ─────────────────────────────────────────────
@@ -159,41 +144,23 @@ module CollavreOpenclaw
       end
     end
 
-    # Build WebSocket chat.send payload.
-    #
-    # Token optimization: only includes system prompt and creative context on
-    # the first message or when context has changed. The Gateway maintains its
-    # own session history, so chat history is never sent — only the trigger.
     def build_ws_chat_payload
-      trigger = trigger_message
       {
         message: format_message_for_ws,
-        attachments: trigger ? extract_ws_attachments([ trigger ]).presence : nil
+        attachments: extract_ws_attachments(@all_messages).presence
       }
     end
 
-    # Format messages for WebSocket chat.send text payload.
-    #
-    # On first message (or context change):
-    #   [system prompt] + [creative context] + [trigger]
-    # On subsequent messages:
-    #   [trigger only]
-    #
-    # Chat history is NOT included — the Gateway's SessionManager tracks
-    # conversation turns automatically.
+    # SessionContextResolver already decided what to include.
+    # We just format and send everything we received.
     def format_message_for_ws
       parts = []
+      parts << @system_prompt if @system_prompt.present?
 
-      if include_full_context?
-        parts << @system_prompt if @system_prompt.present?
-        context_messages.each do |m|
-          text = extract_message_text(m)
-          parts << text if text.present?
-        end
+      @all_messages.each do |m|
+        text = extract_message_text(m)
+        parts << text if text.present?
       end
-
-      trigger = trigger_message
-      parts << extract_message_text(trigger) if trigger
 
       parts.join("\n\n")
     end
@@ -347,28 +314,14 @@ module CollavreOpenclaw
     # HTTP payload building
     # ─────────────────────────────────────────────
 
-    # Build HTTP payload with token optimization.
-    #
-    # On first message (or context change):
-    #   system prompt + creative context + trigger
-    # On subsequent messages:
-    #   trigger only
-    #
-    # Chat history is NOT included — the Gateway's SessionManager tracks
-    # conversation turns via the stable session key.
+    # SessionContextResolver already decided what to include.
     def build_payload
       agent_id = extract_agent_id_from_email
       model_value = agent_id.present? ? "openclaw:#{agent_id}" : "openclaw"
 
       formatted = []
-
-      if include_full_context?
-        formatted << { role: "system", content: @system_prompt } if @system_prompt.present?
-        context_messages.each { |m| formatted << format_single_message(m) }
-      end
-
-      trigger = trigger_message
-      formatted << format_single_message(trigger) if trigger
+      formatted << { role: "system", content: @system_prompt } if @system_prompt.present?
+      @all_messages.each { |m| formatted << format_single_message(m) }
 
       {
         model: model_value,

--- a/engines/collavre_openclaw/test/services/openclaw_adapter_test.rb
+++ b/engines/collavre_openclaw/test/services/openclaw_adapter_test.rb
@@ -545,7 +545,7 @@ module CollavreOpenclaw
       assert_includes result, "[Bob]: Hello"
     end
 
-    test "build_ws_chat_payload includes image attachments from trigger only" do
+    test "build_ws_chat_payload includes image attachments from all messages" do
       user = build_test_user(gateway_url: "https://test-gateway.com", email: "test@example.com")
 
       adapter = OpenclawAdapter.new(

--- a/engines/collavre_openclaw/test/services/openclaw_adapter_test.rb
+++ b/engines/collavre_openclaw/test/services/openclaw_adapter_test.rb
@@ -52,7 +52,7 @@ module CollavreOpenclaw
       assert_equal "openclaw:test", payload[:model]
     end
 
-    test "builds payload with trigger only on warm session" do
+    test "builds payload with all received messages (pure transport)" do
       user = build_test_user(gateway_url: "https://test-gateway.com", email: "test@example.com")
 
       adapter = OpenclawAdapter.new(
@@ -61,9 +61,9 @@ module CollavreOpenclaw
         context: {}
       )
 
+      # SessionContextResolver already filtered to trigger-only for warm sessions
       messages_data = {
         messages: [
-          { role: "user", kind: :creative_context, parts: [ { text: "Creative (id: 1):\n# Hello" } ] },
           { role: "user", kind: :trigger, parts: [ { text: "Follow-up" } ] }
         ],
         first_message: false,
@@ -73,36 +73,39 @@ module CollavreOpenclaw
       adapter.send(:parse_messages_data!, messages_data)
       payload = adapter.send(:build_payload)
 
-      # Trigger only — no system prompt, no context
-      assert_equal 1, payload[:messages].length
-      assert_equal "user", payload[:messages][0][:role]
-      assert_equal "Follow-up", payload[:messages][0][:content]
+      # System prompt + trigger (adapter sends everything it receives)
+      assert_equal 2, payload[:messages].length
+      assert_equal "system", payload[:messages][0][:role]
+      assert_equal "Test prompt", payload[:messages][0][:content]
+      assert_equal "user", payload[:messages][1][:role]
+      assert_equal "Follow-up", payload[:messages][1][:content]
     end
 
-    test "builds payload with full context when context changed" do
+    test "builds payload without system prompt when nil" do
       user = build_test_user(gateway_url: "https://test-gateway.com", email: "test@example.com")
 
+      # SessionContextResolver sets system_prompt to nil for incremental sessions
       adapter = OpenclawAdapter.new(
         user: user,
-        system_prompt: "Test prompt",
+        system_prompt: nil,
         context: {}
       )
 
       messages_data = {
         messages: [
-          { role: "user", kind: :creative_context, parts: [ { text: "Creative (id: 1):\n# Updated" } ] },
-          { role: "user", kind: :trigger, parts: [ { text: "Question" } ] }
+          { role: "user", kind: :trigger, parts: [ { text: "Follow-up" } ] }
         ],
         first_message: false,
-        context_changed: true
+        context_changed: false
       }
 
       adapter.send(:parse_messages_data!, messages_data)
       payload = adapter.send(:build_payload)
 
-      # Re-sends system + context + trigger
-      assert_equal 3, payload[:messages].length
-      assert_equal "system", payload[:messages][0][:role]
+      # Trigger only — no system prompt
+      assert_equal 1, payload[:messages].length
+      assert_equal "user", payload[:messages][0][:role]
+      assert_equal "Follow-up", payload[:messages][0][:content]
     end
 
     test "includes agent_id derived from user email in model field" do
@@ -491,21 +494,18 @@ module CollavreOpenclaw
       assert_includes result, "[Alice]: Follow-up question"
     end
 
-    test "format_message_for_ws sends only trigger on warm session" do
+    test "format_message_for_ws sends all received messages (pure transport)" do
       user = build_test_user(gateway_url: "https://test-gateway.com", email: "test@example.com")
 
+      # SessionContextResolver already filtered to trigger-only for warm sessions
       adapter = OpenclawAdapter.new(
         user: user,
-        system_prompt: "You are a helpful agent",
+        system_prompt: nil,
         context: {}
       )
 
       messages_data = {
         messages: [
-          { role: "user", kind: :creative_context, parts: [ { text: "Creative (id: 42):\n# My Project" } ] },
-          { role: "user", kind: :context_creative, parts: [ { text: "Context Creative (id: 41):\n# Dev Environment" } ] },
-          { role: "user", kind: :chat_history, parts: [ { text: "[Alice]: First question" } ] },
-          { role: "model", kind: :chat_history, parts: [ { text: "Here's my answer" } ] },
           { role: "user", kind: :trigger, parts: [ { text: "[Alice]: Follow-up question" } ] }
         ],
         first_message: false,
@@ -515,14 +515,11 @@ module CollavreOpenclaw
       adapter.send(:parse_messages_data!, messages_data)
       result = adapter.send(:format_message_for_ws)
 
-      # Only trigger, no system prompt, no context, no history
       assert_not_includes result, "You are a helpful agent"
-      assert_not_includes result, "Creative (id: 42):"
-      assert_not_includes result, "[Alice]: First question"
       assert_equal "[Alice]: Follow-up question", result
     end
 
-    test "format_message_for_ws includes context when changed" do
+    test "format_message_for_ws includes all messages when provided" do
       user = build_test_user(gateway_url: "https://test-gateway.com", email: "test@example.com")
 
       adapter = OpenclawAdapter.new(


### PR DESCRIPTION
## Summary
- Extract session filtering logic from `OpenclawAdapter` into a dedicated `SessionContextResolver` service, making session management vendor-agnostic and configurable per agent
- Add `supports_session?` method to `User` model with auto-detection by vendor (openclaw → true) and explicit override via `agent_conf` YAML (`session.enabled: true/false`)
- Simplify `OpenclawAdapter` to pure transport layer — receives pre-filtered messages from SessionContextResolver and sends them as-is

## Changes
| File | Change |
|---|---|
| `collavre/ai_agent/session_context_resolver.rb` | **New** — central decision-maker: full context vs incremental (trigger-only) |
| `collavre/user.rb` | `AGENT_CONF_DEFAULTS` + `supports_session?` accessor |
| `collavre/ai_agent_service.rb` | Call resolver before building AI client |
| `collavre_openclaw/ai_client_extension.rb` | Use resolved `system_prompt` from SessionContextResolver |
| `collavre_openclaw/openclaw_adapter.rb` | Remove `include_full_context?`, `context_messages`, `trigger_message` — pure transport |
| Tests (3 files) | 12 new/updated test cases |

## How it works
```
MessageBuilder.build → full messages
    ↓
SessionContextResolver.resolve
    ├─ supports_session? && warm session → {trigger only, system_prompt: nil}
    └─ otherwise → {all messages, system_prompt: "..."}
    ↓
AiClient.chat(resolved) → OpenclawAdapter sends as-is
```

## Test plan
- [x] SessionContextResolver unit tests (7 cases: no session, first message, context changed, warm session, multiple triggers, both flags, payload structure)
- [x] User `supports_session?` tests (5 cases: openclaw auto-detect, non-openclaw, explicit override true/false, nil vendor)
- [x] OpenclawAdapter updated tests (pure transport assumptions)
- [x] Full test suite: 1647 runs, 5199 assertions, 0 failures
- [x] Rubocop clean