### PR TITLE
feat: fade chat popup when inline editor is active

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -19,10 +19,18 @@
     flex-direction: column;
     transition: top 0.25s ease, left 0.25s ease, width 0.25s ease, height 0.25s ease,
                 right 0.25s ease, bottom 0.25s ease, border-radius 0.25s ease,
-                box-shadow 0.25s ease, padding 0.25s ease;
+                box-shadow 0.25s ease, padding 0.25s ease, opacity 0.3s ease;
     max-width: calc(100vw - 0.5em) !important;
     overscroll-behavior: contain;
     overflow: hidden;
+}
+
+#comments-popup.editor-behind {
+    opacity: 0.15;
+}
+
+#comments-popup.editor-behind:hover {
+    opacity: 1;
 }
 
 body.chat-fullscreen {

--- a/engines/collavre/app/javascript/controllers/comments/popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_controller.js
@@ -33,6 +33,8 @@ export default class extends Controller {
     this.openFromUrlTimeout = null
     this.handleCreativeClick = this.handleCreativeClick.bind(this)
     this.handleCreativeDestroyed = this.handleCreativeDestroyed.bind(this)
+    this.handleEditingStart = this.handleEditingStart.bind(this)
+    this.handleEditingStop = this.handleEditingStop.bind(this)
     this.handleTouchStart = this.handleTouchStart.bind(this)
     this.handleTouchEnd = this.handleTouchEnd.bind(this)
     this.handleResizeMove = this.handleResizeMove.bind(this)
@@ -54,6 +56,8 @@ export default class extends Controller {
 
     document.addEventListener(CREATIVE_CLICK_EVENT, this.handleCreativeClick)
     document.addEventListener(CREATIVE_DESTROYED_EVENT, this.handleCreativeDestroyed)
+    document.addEventListener('creative-editing:start', this.handleEditingStart)
+    document.addEventListener('creative-editing:stop', this.handleEditingStop)
     this.element.addEventListener('wheel', this.handlePopupWheel, { passive: false })
     window.addEventListener('online', this.handleOnline)
     window.addEventListener('focus', this.handleWindowFocus)
@@ -121,6 +125,8 @@ export default class extends Controller {
     this.clearPendingOpenFromUrl()
     document.removeEventListener(CREATIVE_CLICK_EVENT, this.handleCreativeClick)
     document.removeEventListener(CREATIVE_DESTROYED_EVENT, this.handleCreativeDestroyed)
+    document.removeEventListener('creative-editing:start', this.handleEditingStart)
+    document.removeEventListener('creative-editing:stop', this.handleEditingStop)
     this.element.removeEventListener('wheel', this.handlePopupWheel)
     window.removeEventListener('online', this.handleOnline)
     window.removeEventListener('focus', this.handleWindowFocus)
@@ -200,6 +206,16 @@ export default class extends Controller {
     if (destroyedIds.includes(this.element.dataset.creativeId)) {
       this.close()
     }
+  }
+
+  handleEditingStart() {
+    if (this.element.style.display === 'flex' && !this.isFullscreen()) {
+      this.element.classList.add('editor-behind')
+    }
+  }
+
+  handleEditingStop() {
+    this.element.classList.remove('editor-behind')
   }
 
   async open(button, { creativeId, highlightId } = {}) {
@@ -378,7 +394,7 @@ export default class extends Controller {
     this._releaseWakeLock()
 
     this.element.style.display = 'none'
-    this.element.classList.remove('open')
+    this.element.classList.remove('open', 'editor-behind')
     this.element.style.width = ''
     this.element.style.height = ''
     this.element.style.left = ''

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -1749,6 +1749,9 @@ export function initializeCreativeRowEditor() {
           pendingSave = false;
           lexicalEditor.focus();
           updateActionButtonStates();
+          document.dispatchEvent(new CustomEvent('creative-editing:start', {
+            detail: { creativeId: null }
+          }));
           if (parentSuggestions) {
             parentSuggestions.style.display = 'none';
             parentSuggestions.innerHTML = '';


### PR DESCRIPTION
## Summary
- When the inline editor opens while the comments popup is visible (non-fullscreen), the popup fades to 15% opacity with a 0.3s CSS transition
- Hovering the popup restores full opacity so users can still interact with chat
- Fullscreen mode is excluded from this behavior
- Class is cleaned up on popup close and editor stop

## Changed files
- `comments_popup.css` — Added `opacity 0.3s ease` transition and `.editor-behind` / `.editor-behind:hover` rules
- `popup_controller.js` — Listen for `creative-editing:start/stop` events to toggle `.editor-behind` class

## Test plan
- [ ] Open a creative's chat popup
- [ ] Click edit on any creative (same or different) to open inline editor
- [ ] Verify chat popup fades to ~15% opacity
- [ ] Hover over the faded popup — verify it restores to full opacity
- [ ] Move mouse away — verify it fades again
- [ ] Close the inline editor — verify popup returns to normal opacity
- [ ] Open chat in fullscreen mode, then edit a creative — verify popup does NOT fade
- [ ] Close the popup while editor is active — verify no stale class