### PR TITLE
fix: dispatch creative-editing:stop for new creatives without ID

### DIFF
--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -1095,11 +1095,9 @@ export function initializeCreativeRowEditor() {
       // Notify sync controller that editing stopped
       stopEditingPing();
       const editCreativeId = form.dataset.creativeId;
-      if (editCreativeId) {
-        document.dispatchEvent(new CustomEvent('creative-editing:stop', {
-          detail: { creativeId: parseInt(editCreativeId, 10) }
-        }));
-      }
+      document.dispatchEvent(new CustomEvent('creative-editing:stop', {
+        detail: { creativeId: editCreativeId ? parseInt(editCreativeId, 10) : null }
+      }));
 
       currentTree = null;
       currentRowElement = null;


### PR DESCRIPTION
## Summary
- Remove `if (editCreativeId)` guard in `hideCurrent()` so `creative-editing:stop` event fires even for new creatives (which have no ID yet)
- Fixes: closing a new creative editor via button toggle left the chat popup stuck in transparent mode

## Context
Follow-up to #1188 (feat: fade chat popup when inline editor is active). The original PR missed the case where new creatives (without a saved ID) were closed — the stop event never fired, so the popup's `.editor-behind` class was never removed.

## Test plan
- [x] Rubocop passed (799 files, no offenses)
- [x] All 1659 tests passed, 0 failures
- [ ] Manual: open chat popup → click new creative button → popup fades → click new creative button again (toggle close) → popup opacity restores