### PR TITLE
fix: IDOR permission checks + XSS escape in MCP/Slack

### DIFF
--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -195,6 +195,10 @@ module Collavre
     end
 
     def parent_suggestions
+      unless @creative.has_permission?(Current.user, :read)
+        render json: { error: t("collavre.creatives.errors.no_permission") }, status: :forbidden and return
+      end
+
       suggestions = ::GeminiParentRecommender.new.recommend(@creative)
       render json: suggestions
     end
@@ -276,6 +280,10 @@ module Collavre
     end
 
     def contexts
+      unless @creative.has_permission?(Current.user, :read)
+        render json: { error: t("collavre.creatives.errors.no_permission") }, status: :forbidden and return
+      end
+
       creative = @creative.effective_origin(Set.new)
       own_ids = creative.context_ids - [ creative.id ]
       inherited_ids = (creative.effective_context_ids - own_ids - [ creative.id ]).uniq

--- a/engines/collavre/app/services/collavre/comments/mcp_command.rb
+++ b/engines/collavre/app/services/collavre/comments/mcp_command.rb
@@ -105,9 +105,12 @@ module Collavre
           result.to_s
         end
 
+        escaped_tool = ERB::Util.html_escape(tool_name)
+        escaped_content = ERB::Util.html_escape(content)
+
         <<~HTML
-        <details><summary>#{tool_name} response</summary>
-        <pre><code>#{content}</code></pre>
+        <details><summary>#{escaped_tool} response</summary>
+        <pre><code>#{escaped_content}</code></pre>
         </details>
         HTML
       end

--- a/engines/collavre_slack/app/javascript/collavre_slack.js
+++ b/engines/collavre_slack/app/javascript/collavre_slack.js
@@ -135,7 +135,9 @@ if (!slackIntegrationInitialized) {
         li.style.cssText = 'display:flex;align-items:center;justify-content:space-between;padding:0.5em 0.75em;margin-bottom:0.5em;background:var(--color-bg-alt);border-radius:4px;';
 
         const channelInfo = document.createElement('div');
-        channelInfo.innerHTML = `<strong>#${link.channel_name || link.channel_id}</strong>`;
+        const channelStrong = document.createElement('strong');
+        channelStrong.textContent = `#${link.channel_name || link.channel_id}`;
+        channelInfo.appendChild(channelStrong);
 
         if (link.last_synced_at) {
           const syncInfo = document.createElement('span');
@@ -250,10 +252,15 @@ if (!slackIntegrationInitialized) {
         div.className = 'slack-channel-item';
 
         const linkedLabel = modal.dataset.linkedLabel || '(linked)';
-        div.innerHTML = `
-          <strong>#${channel.name}</strong>
-          ${isLinked ? `<span style="color:green;margin-left:0.5em;">${linkedLabel}</span>` : ''}
-        `;
+        const nameStrong = document.createElement('strong');
+        nameStrong.textContent = `#${channel.name}`;
+        div.appendChild(nameStrong);
+        if (isLinked) {
+          const linkedSpan = document.createElement('span');
+          linkedSpan.style.cssText = 'color:green;margin-left:0.5em;';
+          linkedSpan.textContent = linkedLabel;
+          div.appendChild(linkedSpan);
+        }
 
         if (isSelected) {
           div.classList.add('active');


### PR DESCRIPTION
## Summary

Security fixes from code scan:

- **IDOR in `CreativesController#contexts`**: The `contexts` action loaded a creative via `Creative.find(params[:id])` without checking permissions. Added a `:read` permission guard that returns 403 Forbidden for unauthorized users.
- **IDOR in `CreativesController#parent_suggestions`**: The `parent_suggestions` action called `GeminiParentRecommender` without verifying the user has read access to the creative. Added the same `:read` permission check.
- **XSS in `McpCommand#format_response`**: `tool_name` and response `content` were interpolated directly into HTML without escaping. Applied `ERB::Util.html_escape()` to both values before interpolation.
- **XSS in Slack channel name rendering (`collavre_slack.js`)**: `link.channel_name` and `channel.name` were injected via `innerHTML` template literals. Replaced with DOM construction using `textContent` to prevent script injection.

## Test plan

- [x] Rubocop passes (0 offenses)
- [x] `creatives_controller_test.rb` — 17 tests, 0 failures
- [x] `mcp_command_test.rb` — 7 tests, 0 failures
- [x] Full test suite passes via pre-push hook