### PR TITLE
fix: code quality — bootsnap, debug output, bare rescue, N+1 query

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,7 +1,11 @@
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
 require "bundler/setup" # Set up gems listed in the Gemfile.
-require "bootsnap/setup" # Speed up boot time by caching expensive operations.
+begin
+  require "bootsnap/setup" # Speed up boot time by caching expensive operations.
+rescue LoadError
+  # bootsnap not available (e.g., engine tests with their own Gemfile)
+end
 
 # Load environment variables from .env files before Rails boots
 # This ensures RAILS_MASTER_KEY is available for credentials decryption

--- a/engines/collavre/app/services/collavre/mcp_service.rb
+++ b/engines/collavre/app/services/collavre/mcp_service.rb
@@ -48,7 +48,7 @@ module Collavre
         before_call: before_call,
         after_call: after_call
       )
-      puts("Registered tool: #{result}")
+      Rails.logger.info("Registered tool: #{result}")
 
       if result[:error]
         error_msg = "Failed to register tool: #{result[:error]}"

--- a/engines/collavre_github/app/services/collavre_github/webhook_provisioner.rb
+++ b/engines/collavre_github/app/services/collavre_github/webhook_provisioner.rb
@@ -23,8 +23,15 @@ module CollavreGithub
     end
 
     def remove_for_repositories(repositories)
+      # Batch-query to avoid N+1: find all repo names that still have links
+      linked_names = CollavreGithub::RepositoryLink
+        .where(repository_full_name: repositories)
+        .distinct
+        .pluck(:repository_full_name)
+        .to_set
+
       repositories.each do |repository_full_name|
-        next if CollavreGithub::RepositoryLink.where(repository_full_name: repository_full_name).exists?
+        next if linked_names.include?(repository_full_name)
 
         remove_webhook(repository_full_name)
       end

--- a/engines/collavre_openclaw/test/support/mock_openclaw_gateway.rb
+++ b/engines/collavre_openclaw/test/support/mock_openclaw_gateway.rb
@@ -51,7 +51,7 @@ module CollavreOpenclaw
           @port = use_port
           @started = true
           ready.push({ ok: true, port: use_port })
-        rescue => e
+        rescue StandardError => e
           ready.push({ error: e.message })
         end
       end
@@ -74,7 +74,7 @@ module CollavreOpenclaw
             EM.stop_server(@server_signature)
             @server_signature = nil
           end
-        rescue => e
+        rescue StandardError => e
           # Ignore cleanup errors
         ensure
           @started = false

--- a/test/i18n_completeness_test.rb
+++ b/test/i18n_completeness_test.rb
@@ -165,7 +165,7 @@ class I18nCompletenessTest < ActiveSupport::TestCase
 
   def translation_exists?(key, locale)
     I18n.exists?(key, locale)
-  rescue
+  rescue StandardError
     false
   end
 


### PR DESCRIPTION
## Summary

- **Bootsnap LoadError in engine tests (HIGH):** Wrapped `require "bootsnap/setup"` in `config/boot.rb` with a `begin/rescue LoadError` so engine tests using their own Gemfile (without bootsnap) no longer crash on load.
- **Debug `puts` in production code (LOW):** Replaced `puts("Registered tool: ...")` with `Rails.logger.info(...)` in `Collavre::McpService` to avoid writing to stdout in production.
- **Bare `rescue` clauses (LOW):** Changed bare `rescue` to `rescue StandardError` in `test/i18n_completeness_test.rb` and `rescue => e` to `rescue StandardError => e` in `engines/collavre_openclaw/test/support/mock_openclaw_gateway.rb` (2 occurrences) to avoid accidentally catching non-standard exceptions.
- **N+1 query in WebhookProvisioner (MEDIUM):** Refactored `remove_for_repositories` to batch-query `RepositoryLink` for all repository names upfront instead of calling `.exists?` inside the `.each` loop.

## Changed files
- `config/boot.rb`
- `engines/collavre/app/services/collavre/mcp_service.rb`
- `test/i18n_completeness_test.rb`
- `engines/collavre_openclaw/test/support/mock_openclaw_gateway.rb`
- `engines/collavre_github/app/services/collavre_github/webhook_provisioner.rb`

## Test plan
- [x] Rubocop passes on all 5 changed files (0 offenses)
- [x] Full test suite passes via pre-push hook (seed 24013)
- [x] Verified bootsnap rescue works when bootsnap gem is absent