### PR TITLE
refactor: extract permission guards + public_only scope + set_creative concern

### DIFF
--- a/engines/collavre/app/controllers/collavre/comment_read_pointers_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comment_read_pointers_controller.rb
@@ -44,11 +44,11 @@ module Collavre
     end
 
     def find_nearest_public_comment_id(creative, comment_id)
-      creative.comments.where(private: false).where("id <= ?", comment_id).maximum(:id)
+      creative.comments.public_only.where("id <= ?", comment_id).maximum(:id)
     end
 
     def fetch_users_on_effective_id(creative, effective_id)
-      next_public_id = creative.comments.where(private: false).where("id > ?", effective_id).minimum(:id)
+      next_public_id = creative.comments.public_only.where("id > ?", effective_id).minimum(:id)
 
       query = CommentReadPointer.where(creative: creative)
                                 .where("last_read_comment_id >= ?", effective_id)

--- a/engines/collavre/app/controllers/collavre/comments/snapshots_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comments/snapshots_controller.rb
@@ -3,6 +3,8 @@
 module Collavre
   module Comments
     class SnapshotsController < ApplicationController
+      include Collavre::Comments::CommentScoping
+
       before_action :set_creative
       before_action :set_snapshot, only: [ :restore ]
 
@@ -28,13 +30,6 @@ module Collavre
       end
 
       private
-
-      def set_creative
-        @creative = Creative.find(params[:creative_id]).effective_origin
-        unless @creative.has_permission?(Current.user, :read)
-          render json: { error: I18n.t("collavre.creatives.errors.no_permission") }, status: :forbidden
-        end
-      end
 
       def set_snapshot
         @snapshot = @creative.comment_snapshots.find(params[:id])

--- a/engines/collavre/app/controllers/collavre/comments_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comments_controller.rb
@@ -128,7 +128,7 @@ module Collavre
         # Fetch all visible IDs for correct read-receipt placement transparency
         # Only map read receipts to PUBLIC comments.
         # Users who read private comments will appear on the nearest preceding public comment.
-        public_ids = @creative.comments.where(private: false).order(id: :asc).pluck(:id)
+        public_ids = @creative.comments.public_only.order(id: :asc).pluck(:id)
 
         pointers.each do |pointer|
           effective_id = pointer.effective_comment_id(public_ids)
@@ -344,13 +344,6 @@ module Collavre
     end
 
     private
-
-    def set_creative
-      @creative = Creative.find(params[:creative_id]).effective_origin
-      unless @creative.has_permission?(Current.user, :read)
-        render json: { error: I18n.t("collavre.creatives.errors.no_permission") }, status: :forbidden
-      end
-    end
 
     def comment_params
       params.require(:comment).permit(:content, :private, :topic_id, :quoted_comment_id, :quoted_text, :review_type, images: [])

--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -4,12 +4,14 @@ module Collavre
     include Collavre::Concerns::Exportable
     include Collavre::Concerns::TreeManageable
     include Collavre::Concerns::Shareable
+    include Collavre::CreativePermissionGuard
 
     # TODO: for not for security reasons for this Collavre app, we don't expose to public, later it should be controlled by roles for each Creatives
     # Removed unauthenticated access to index and show actions
     allow_unauthenticated_access only: %i[ index children export_markdown show slide_view ]
     before_action :enforce_creatives_login_policy, only: %i[ index children export_markdown show slide_view ]
     before_action :set_creative, only: %i[ show edit update destroy parent_suggestions slide_view request_permission unconvert contexts update_contexts update_metadata archive unarchive trigger_action ]
+    before_action :require_creative_write!, only: %i[archive unarchive]
 
     def index
       respond_to do |format|
@@ -445,19 +447,11 @@ module Collavre
     end
 
     def archive
-      unless @creative.has_permission?(Current.user, :write) || @creative.user == Current.user
-        render json: { error: t("collavre.creatives.errors.no_permission") }, status: :forbidden and return
-      end
-
       @creative.archive!
       head :ok
     end
 
     def unarchive
-      unless @creative.has_permission?(Current.user, :write) || @creative.user == Current.user
-        render json: { error: t("collavre.creatives.errors.no_permission") }, status: :forbidden and return
-      end
-
       @creative.unarchive!
       head :ok
     end
@@ -490,6 +484,10 @@ module Collavre
 
       def set_creative
         @creative = Creative.find(params[:id])
+      end
+
+      def creative_permission_denied_message
+        t("collavre.creatives.errors.no_permission")
       end
 
       def creative_params

--- a/engines/collavre/app/controllers/collavre/topics_controller.rb
+++ b/engines/collavre/app/controllers/collavre/topics_controller.rb
@@ -1,6 +1,11 @@
 module Collavre
   class TopicsController < ApplicationController
+    include Collavre::CreativePermissionGuard
+
     before_action :set_creative
+    before_action :require_creative_read!, only: %i[next_name]
+    before_action :require_creative_admin!, only: %i[update destroy move reorder]
+    before_action :require_creative_write!, only: %i[create archive unarchive set_primary_agent]
 
     def index
       is_owner = @creative.user == Current.user
@@ -31,10 +36,6 @@ module Collavre
     end
 
     def create
-      unless @creative.has_permission?(Current.user, :write) || @creative.user == Current.user
-        render json: { error: I18n.t("collavre.topics.no_permission") }, status: :forbidden and return
-      end
-
       topic = @creative.topics.build(topic_params)
       topic.user = Current.user
 
@@ -70,18 +71,10 @@ module Collavre
     end
 
     def next_name
-      unless @creative.has_permission?(Current.user, :read) || @creative.user == Current.user
-        render json: { error: I18n.t("collavre.topics.no_permission") }, status: :forbidden and return
-      end
-
       render json: { name: generate_next_topic_name }
     end
 
     def update
-      unless @creative.has_permission?(Current.user, :admin) || @creative.user == Current.user
-        render json: { error: I18n.t("collavre.topics.no_permission") }, status: :forbidden and return
-      end
-
       topic = @creative.topics.find(params[:id])
 
       if topic.update(topic_params)
@@ -96,10 +89,6 @@ module Collavre
     end
 
     def destroy
-      unless @creative.has_permission?(Current.user, :admin) || @creative.user == Current.user
-        render json: { error: I18n.t("collavre.topics.no_permission") }, status: :forbidden and return
-      end
-
       topic = @creative.topics.find(params[:id])
       topic_id = topic.id
 
@@ -114,10 +103,6 @@ module Collavre
     end
 
     def move
-      unless @creative.has_permission?(Current.user, :admin) || @creative.user == Current.user
-        render json: { error: I18n.t("collavre.topics.no_permission") }, status: :forbidden and return
-      end
-
       topic = @creative.topics.find(params[:id])
       target_creative = Creative.find(params[:target_creative_id]).effective_origin
 
@@ -148,10 +133,6 @@ module Collavre
     end
 
     def archive
-      unless @creative.has_permission?(Current.user, :write) || @creative.user == Current.user
-        render json: { error: I18n.t("collavre.topics.no_permission") }, status: :forbidden and return
-      end
-
       topic = @creative.topics.find(params[:id])
       topic.archive!
 
@@ -163,10 +144,6 @@ module Collavre
     end
 
     def unarchive
-      unless @creative.has_permission?(Current.user, :write) || @creative.user == Current.user
-        render json: { error: I18n.t("collavre.topics.no_permission") }, status: :forbidden and return
-      end
-
       topic = @creative.topics.find(params[:id])
       topic.unarchive!
 
@@ -178,10 +155,6 @@ module Collavre
     end
 
     def reorder
-      unless @creative.has_permission?(Current.user, :admin) || @creative.user == Current.user
-        render json: { error: I18n.t("collavre.topics.no_permission") }, status: :forbidden and return
-      end
-
       topic_ids = params[:topic_ids]
       unless topic_ids.is_a?(Array) && topic_ids.present?
         render json: { error: "Invalid topic_ids" }, status: :unprocessable_entity and return
@@ -202,10 +175,6 @@ module Collavre
     end
 
     def set_primary_agent
-      unless @creative.has_permission?(Current.user, :write) || @creative.user == Current.user
-        render json: { error: I18n.t("collavre.topics.no_permission") }, status: :forbidden and return
-      end
-
       topic = @creative.topics.find(params[:id])
       agent = User.find_by(id: params[:agent_id])
 

--- a/engines/collavre/app/controllers/concerns/collavre/comments/comment_scoping.rb
+++ b/engines/collavre/app/controllers/concerns/collavre/comments/comment_scoping.rb
@@ -9,6 +9,9 @@ module Collavre
 
       def set_creative
         @creative = Creative.find(params[:creative_id]).effective_origin
+        unless @creative.has_permission?(Current.user, :read)
+          render json: { error: I18n.t("collavre.creatives.errors.no_permission") }, status: :forbidden
+        end
       end
 
       def set_comment

--- a/engines/collavre/app/controllers/concerns/collavre/creative_permission_guard.rb
+++ b/engines/collavre/app/controllers/concerns/collavre/creative_permission_guard.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Collavre
+  module CreativePermissionGuard
+    extend ActiveSupport::Concern
+
+    private
+
+    def require_creative_read!
+      return if @creative.has_permission?(Current.user, :read) || @creative.user == Current.user
+
+      render json: { error: creative_permission_denied_message }, status: :forbidden
+    end
+
+    def require_creative_write!
+      return if @creative.has_permission?(Current.user, :write) || @creative.user == Current.user
+
+      render json: { error: creative_permission_denied_message }, status: :forbidden
+    end
+
+    def require_creative_admin!
+      return if @creative.has_permission?(Current.user, :admin) || @creative.user == Current.user
+
+      render json: { error: creative_permission_denied_message }, status: :forbidden
+    end
+
+    # Override in controllers that use a different i18n key.
+    def creative_permission_denied_message
+      I18n.t("collavre.topics.no_permission")
+    end
+  end
+end

--- a/engines/collavre/app/models/collavre/comment.rb
+++ b/engines/collavre/app/models/collavre/comment.rb
@@ -16,6 +16,8 @@ module Collavre
     belongs_to :topic, class_name: "Collavre::Topic", optional: true
     belongs_to :quoted_comment, class_name: "Collavre::Comment", optional: true
 
+    scope :public_only, -> { where(private: false) }
+
     scope :visible_to, ->(user) {
       where(
         "comments.private = ? OR comments.user_id = ? OR comments.approver_id = ?",

--- a/engines/collavre/app/models/collavre/comment/broadcastable.rb
+++ b/engines/collavre/app/models/collavre/comment/broadcastable.rb
@@ -27,7 +27,7 @@ module Collavre
           pointers = CommentReadPointer.where(user_id: user_ids, creative: origin).index_by(&:user_id)
           present_user_ids = CommentPresenceStore.list(origin.id)
 
-          public_count = origin.comments.where(private: false).count
+          public_count = origin.comments.public_only.count
           private_counts = origin.comments
             .where(private: true, user_id: user_ids)
             .group(:user_id)

--- a/engines/collavre/app/services/collavre/ai_agent/message_builder.rb
+++ b/engines/collavre/app/services/collavre/ai_agent/message_builder.rb
@@ -141,7 +141,7 @@ module Collavre
         history_chars = 0
         count = 0
 
-        Comment.where(creative_id: creative_id, private: false)
+        Comment.public_only.where(creative_id: creative_id)
                .where(topic_id: topic_id)
                .where.not(user_id: nil)
                .includes(:user)

--- a/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
+++ b/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
@@ -59,8 +59,8 @@ module Collavre
         return unless creative_id && context&.key?("topic")
 
         topic_id = context.dig("topic", "id")
-        scope = Comment
-          .where(creative_id: creative_id, topic_id: topic_id, private: false)
+        scope = Comment.public_only
+          .where(creative_id: creative_id, topic_id: topic_id)
           .where.not(user_id: [ task.agent_id, nil ])
           .order(created_at: :desc)
         latest_comment = scope.first

--- a/engines/collavre_completion_api/app/controllers/collavre_completion_api/api/v1/chat/completions_controller.rb
+++ b/engines/collavre_completion_api/app/controllers/collavre_completion_api/api/v1/chat/completions_controller.rb
@@ -80,7 +80,7 @@ module CollavreCompletionApi
             end
 
             scope = collavre_creative.comments
-                                     .where(private: false)
+                                     .public_only
                                      .order(created_at: :desc)
             scope = scope.where(topic_id: collavre_topic.id) if collavre_topic
             recent_comments = scope.limit(CREATIVE_CONTEXT_COMMENT_LIMIT)


### PR DESCRIPTION
## Summary

- **Extract `CreativePermissionGuard` concern** with `require_creative_read!`, `require_creative_write!`, and `require_creative_admin!` methods. Replaces 10 inline permission guard blocks across `TopicsController` (8 actions) and `CreativesController` (`archive`/`unarchive`). Controllers can override `creative_permission_denied_message` for custom i18n keys.

- **Add `Comment.public_only` scope** (`where(private: false)`) and replace all 7 inline `where(private: false)` calls across `comment_read_pointers_controller`, `comments_controller`, `broadcastable`, `completions_controller`, `message_builder`, and `agent_orchestrator`.

- **Consolidate `set_creative` with read permission check** in `CommentScoping` concern, removing duplicate overrides in `CommentsController` and `SnapshotsController`.

## Changed files

| File | Change |
|------|--------|
| `concerns/collavre/creative_permission_guard.rb` | New concern with 3 guard methods |
| `collavre/topics_controller.rb` | Use concern, remove 8 inline guards |
| `collavre/creatives_controller.rb` | Use concern, remove 2 inline guards |
| `collavre/comment.rb` | Add `public_only` scope |
| `collavre/comment/broadcastable.rb` | Use `public_only` scope (2 places) |
| `collavre/comment_read_pointers_controller.rb` | Use `public_only` scope (2 places) |
| `collavre/comments_controller.rb` | Use `public_only` scope, remove `set_creative` override |
| `collavre/comments/snapshots_controller.rb` | Include `CommentScoping`, remove `set_creative` override |
| `concerns/collavre/comments/comment_scoping.rb` | Add read permission check to `set_creative` |
| `ai_agent/message_builder.rb` | Use `public_only` scope |
| `orchestration/agent_orchestrator.rb` | Use `public_only` scope |
| `completions_controller.rb` | Use `public_only` scope |

## Test plan

- [x] Rubocop passes on all 12 changed files (0 offenses)
- [x] Full test suite passes (all tests green)