### PR TITLE
fix: pass gateway_url to AiClient in background jobs

### DIFF
--- a/engines/collavre/app/jobs/collavre/compress_job.rb
+++ b/engines/collavre/app/jobs/collavre/compress_job.rb
@@ -49,7 +49,7 @@ module Collavre
         model: agent.llm_model,
         system_prompt: system_prompt,
         llm_api_key: agent.llm_api_key || agent.creator&.llm_api_key,
-        gateway_url: agent.gateway_url || agent.creator&.gateway_url,
+        gateway_url: agent.gateway_url.presence || agent.creator&.gateway_url,
         context: {
           creative: creative,
           user: agent,

--- a/engines/collavre/app/jobs/collavre/compress_job.rb
+++ b/engines/collavre/app/jobs/collavre/compress_job.rb
@@ -49,6 +49,7 @@ module Collavre
         model: agent.llm_model,
         system_prompt: system_prompt,
         llm_api_key: agent.llm_api_key || agent.creator&.llm_api_key,
+        gateway_url: agent.gateway_url || agent.creator&.gateway_url,
         context: {
           creative: creative,
           user: agent,

--- a/engines/collavre/app/jobs/collavre/merge_comments_job.rb
+++ b/engines/collavre/app/jobs/collavre/merge_comments_job.rb
@@ -48,6 +48,7 @@ module Collavre
         model: agent.llm_model,
         system_prompt: SYSTEM_PROMPT,
         llm_api_key: agent.llm_api_key || agent.creator&.llm_api_key,
+        gateway_url: agent.gateway_url || agent.creator&.gateway_url,
         context: {
           creative: creative,
           user: agent,

--- a/engines/collavre/app/jobs/collavre/merge_comments_job.rb
+++ b/engines/collavre/app/jobs/collavre/merge_comments_job.rb
@@ -48,7 +48,7 @@ module Collavre
         model: agent.llm_model,
         system_prompt: SYSTEM_PROMPT,
         llm_api_key: agent.llm_api_key || agent.creator&.llm_api_key,
-        gateway_url: agent.gateway_url || agent.creator&.gateway_url,
+        gateway_url: agent.gateway_url.presence || agent.creator&.gateway_url,
         context: {
           creative: creative,
           user: agent,

--- a/engines/collavre/app/jobs/collavre/trigger_loop_check_job.rb
+++ b/engines/collavre/app/jobs/collavre/trigger_loop_check_job.rb
@@ -233,7 +233,7 @@ module Collavre
         model: verifier.llm_model,
         system_prompt: LLM_FALLBACK_SYSTEM_PROMPT,
         llm_api_key: verifier.llm_api_key || verifier.creator&.llm_api_key,
-        gateway_url: verifier.gateway_url || verifier.creator&.gateway_url,
+        gateway_url: verifier.gateway_url.presence || verifier.creator&.gateway_url,
         context: {}
       )
 

--- a/engines/collavre/app/jobs/collavre/trigger_loop_check_job.rb
+++ b/engines/collavre/app/jobs/collavre/trigger_loop_check_job.rb
@@ -233,6 +233,7 @@ module Collavre
         model: verifier.llm_model,
         system_prompt: LLM_FALLBACK_SYSTEM_PROMPT,
         llm_api_key: verifier.llm_api_key || verifier.creator&.llm_api_key,
+        gateway_url: verifier.gateway_url || verifier.creator&.gateway_url,
         context: {}
       )
 

--- a/engines/collavre/app/jobs/collavre/trigger_loop_verify_job.rb
+++ b/engines/collavre/app/jobs/collavre/trigger_loop_verify_job.rb
@@ -151,7 +151,7 @@ module Collavre
         model: verifier.llm_model,
         system_prompt: VERIFY_SYSTEM_PROMPT,
         llm_api_key: verifier.llm_api_key || verifier.creator&.llm_api_key,
-        gateway_url: verifier.gateway_url || verifier.creator&.gateway_url,
+        gateway_url: verifier.gateway_url.presence || verifier.creator&.gateway_url,
         context: {}
       )
 

--- a/engines/collavre/app/jobs/collavre/trigger_loop_verify_job.rb
+++ b/engines/collavre/app/jobs/collavre/trigger_loop_verify_job.rb
@@ -151,6 +151,7 @@ module Collavre
         model: verifier.llm_model,
         system_prompt: VERIFY_SYSTEM_PROMPT,
         llm_api_key: verifier.llm_api_key || verifier.creator&.llm_api_key,
+        gateway_url: verifier.gateway_url || verifier.creator&.gateway_url,
         context: {}
       )
 


### PR DESCRIPTION
## Summary
- Four background jobs (`trigger_loop_verify_job`, `trigger_loop_check_job`, `compress_job`, `merge_comments_job`) were missing the `gateway_url` parameter when constructing `AiClient`
- Without `gateway_url`, OpenAI-vendor agents send requests directly to `api.openai.com` instead of through the configured gateway proxy, causing `RubyLLM::BadRequestError: Incorrect API key provided`
- Adds `gateway_url` with `creator` fallback, matching the pattern already used in `ai_agent_service.rb`

## Root cause
Commit `e869bb24` (Apr 6) added OpenAI vendor support and passed `gateway_url` to `AiAgentService` and `CompletionsController`, but missed these 4 background jobs.

## Test plan
- [x] Rubocop: no offenses
- [x] Full test suite: 1659 runs, 5233 assertions, 0 failures, 0 errors
- [ ] Verify trigger loop no longer produces `Incorrect API key` errors in production