### PR TITLE
refactor: extract duplicated topic validation, broadcast helper, and user_json

### DIFF
--- a/engines/collavre/app/controllers/collavre/comments_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comments_controller.rb
@@ -169,9 +169,7 @@ module Collavre
 
       @comment = @creative.comments.build(comment_attributes)
 
-      if @comment.topic_id.present? && !@creative.topics.where(id: @comment.topic_id).exists?
-        render json: { error: I18n.t("collavre.comments.invalid_topic") }, status: :unprocessable_entity and return
-      end
+      validate_topic_id!(@comment.topic_id) or return
 
       @comment.user = Current.user
       @comment.images.attach(image_attachments) if image_attachments.present?
@@ -195,9 +193,7 @@ module Collavre
     def update
       if @comment.user == Current.user
         safe_params = comment_params.except(:quoted_comment_id, :quoted_text)
-        if safe_params[:topic_id].present? && !@creative.topics.where(id: safe_params[:topic_id]).exists?
-          render json: { error: I18n.t("collavre.comments.invalid_topic") }, status: :unprocessable_entity and return
-        end
+        validate_topic_id!(safe_params[:topic_id]) or return
 
         if @comment.update(safe_params)
           @comment = Comment.with_attached_images.includes(:comment_reactions, :comment_versions, :selected_version).find(@comment.id)
@@ -258,17 +254,7 @@ module Collavre
     def participants
       users = [ @creative.user ].compact + @creative.all_shared_users(:feedback).map(&:user)
       users = users.uniq
-      user_data = users.map do |u|
-        {
-          id: u.id,
-          email: u.email,
-          name: u.display_name,
-          avatar_url: view_context.user_avatar_url(u, size: 20),
-          default_avatar: !u.avatar.attached? && u.avatar_url.blank?,
-          initial: u.display_name[0].upcase,
-          ai_user: u.ai_user?
-        }
-      end
+      user_data = users.map { |u| view_context.user_json(u, email: true, ai_user: true) }
       response.headers["Cache-Control"] = "no-store"
       response.headers["Pragma"] = "no-cache"
       response.headers["Expires"] = "0"
@@ -351,6 +337,12 @@ module Collavre
 
     def current_topic_context
       params[:topic_id].presence || params.dig(:comment, :topic_id).presence
+    end
+
+    def validate_topic_id!(topic_id)
+      return true if topic_id.blank? || @creative.topics.where(id: topic_id).exists?
+      render json: { error: I18n.t("collavre.comments.invalid_topic") }, status: :unprocessable_entity
+      false
     end
   end
 end

--- a/engines/collavre/app/controllers/collavre/topics_controller.rb
+++ b/engines/collavre/app/controllers/collavre/topics_controller.rb
@@ -57,10 +57,7 @@ module Collavre
           end
 
           broadcast_data = agent ? topic_json_with_agent(topic, agent) : topic.slice(:id, :name)
-          TopicsChannel.broadcast_to(
-            @creative,
-            { action: "created", topic: broadcast_data, user_id: Current.user.id }
-          )
+          broadcast_topic_event("created", topic: broadcast_data, user_id: Current.user.id)
           render json: topic, status: :created
         else
           render json: { errors: topic.errors.full_messages }, status: :unprocessable_entity
@@ -78,10 +75,7 @@ module Collavre
       topic = @creative.topics.find(params[:id])
 
       if topic.update(topic_params)
-        TopicsChannel.broadcast_to(
-          @creative,
-          { action: "updated", topic: topic.slice(:id, :name) }
-        )
+        broadcast_topic_event("updated", topic: topic.slice(:id, :name))
         render json: topic
       else
         render json: { errors: topic.errors.full_messages }, status: :unprocessable_entity
@@ -95,10 +89,7 @@ module Collavre
       # last_topic_id is nullified by DB FK (on_delete: :nullify) and model dependent: :nullify
       topic.destroy
 
-      TopicsChannel.broadcast_to(
-        @creative,
-        { action: "deleted", topic_id: topic_id }
-      )
+      broadcast_topic_event("deleted", topic_id: topic_id)
       head :no_content
     end
 
@@ -120,14 +111,8 @@ module Collavre
         topic.update!(creative: target_creative)
       end
 
-      TopicsChannel.broadcast_to(
-        @creative,
-        { action: "deleted", topic_id: topic.id }
-      )
-      TopicsChannel.broadcast_to(
-        target_creative,
-        { action: "created", topic: topic.slice(:id, :name) }
-      )
+      broadcast_topic_event("deleted", topic_id: topic.id)
+      broadcast_topic_event("created", creative: target_creative, topic: topic.slice(:id, :name))
 
       render json: { success: true, topic: topic.slice(:id, :name), target_creative_id: target_creative.id }
     end
@@ -136,10 +121,7 @@ module Collavre
       topic = @creative.topics.find(params[:id])
       topic.archive!
 
-      TopicsChannel.broadcast_to(
-        @creative,
-        { action: "archived", topic: topic.slice(:id, :name) }
-      )
+      broadcast_topic_event("archived", topic: topic.slice(:id, :name))
       render json: { success: true }
     end
 
@@ -147,10 +129,7 @@ module Collavre
       topic = @creative.topics.find(params[:id])
       topic.unarchive!
 
-      TopicsChannel.broadcast_to(
-        @creative,
-        { action: "unarchived", topic: topic.slice(:id, :name, :archived_at) }
-      )
+      broadcast_topic_event("unarchived", topic: topic.slice(:id, :name, :archived_at))
       render json: { success: true }
     end
 
@@ -166,10 +145,7 @@ module Collavre
         end
       end
 
-      TopicsChannel.broadcast_to(
-        @creative,
-        { action: "reordered", topic_ids: topic_ids }
-      )
+      broadcast_topic_event("reordered", topic_ids: topic_ids)
 
       render json: { success: true }
     end
@@ -184,13 +160,7 @@ module Collavre
 
       topic.set_primary_agent!(agent)
 
-      TopicsChannel.broadcast_to(
-        @creative,
-        {
-          action: "updated",
-          topic: topic_json_with_agent(topic, agent)
-        }
-      )
+      broadcast_topic_event("updated", topic: topic_json_with_agent(topic, agent))
 
       render json: { success: true, topic: topic_json_with_agent(topic, agent) }
     end
@@ -256,13 +226,11 @@ module Collavre
     end
 
     def agent_json(agent)
-      {
-        id: agent.id,
-        name: agent.display_name,
-        avatar_url: view_context.user_avatar_url(agent, size: 20),
-        default_avatar: !agent.avatar.attached? && agent.avatar_url.blank?,
-        initial: agent.display_name&.at(0)&.upcase || "?"
-      }
+      view_context.user_json(agent)
+    end
+
+    def broadcast_topic_event(action, creative: @creative, **payload)
+      TopicsChannel.broadcast_to(creative, { action: action, **payload })
     end
   end
 end

--- a/engines/collavre/app/helpers/collavre/application_helper.rb
+++ b/engines/collavre/app/helpers/collavre/application_helper.rb
@@ -81,6 +81,19 @@ module Collavre
       safe_join(styles, "\n")
     end
 
+    def user_json(user, email: false, ai_user: false)
+      data = {
+        id: user.id,
+        name: user.display_name,
+        avatar_url: user_avatar_url(user, size: 20),
+        default_avatar: !user.avatar.attached? && user.avatar_url.blank?,
+        initial: user.display_name&.at(0)&.upcase || "?"
+      }
+      data[:email] = user.email if email
+      data[:ai_user] = user.ai_user? if ai_user
+      data
+    end
+
     private
 
     CSS_VARIABLE_KEY_PATTERN = /\A--[a-zA-Z0-9_-]+\z/


### PR DESCRIPTION
## Summary
- **CommentsController**: Extract `validate_topic_id!` private method to eliminate copy-pasted topic_id validation in `create`/`update` actions
- **TopicsController**: Extract `broadcast_topic_event` helper to consolidate 8 `TopicsChannel.broadcast_to` calls into a single method with keyword args
- **ApplicationHelper**: Add `user_json(user, email:, ai_user:)` helper shared by CommentsController `participants` and TopicsController `agent_json`, also fixing unsafe `display_name[0]` access (→ `&.at(0)&.upcase || "?"`)

Net: 36 insertions, 63 deletions (−27 lines).

## Context
Daily code scan 2026-04-15 — duplication scan found 3 items (HIGH 1, MEDIUM 2).

## Test plan
- [x] Rubocop: 0 offenses (795 files)
- [x] Full test suite: 0 failures
- [x] Pre-push hooks passed