### PR TITLE
fix: include primary_agent in topic update broadcast and response

### DIFF
--- a/engines/collavre/app/controllers/collavre/topics_controller.rb
+++ b/engines/collavre/app/controllers/collavre/topics_controller.rb
@@ -75,8 +75,8 @@ module Collavre
       topic = @creative.topics.find(params[:id])
 
       if topic.update(topic_params)
-        broadcast_topic_event("updated", topic: topic.slice(:id, :name))
-        render json: topic
+        broadcast_topic_event("updated", topic: topic_json(topic))
+        render json: topic_json(topic)
       else
         render json: { errors: topic.errors.full_messages }, status: :unprocessable_entity
       end

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -570,10 +570,9 @@ export default class extends Controller {
 
             if (response.ok) {
                 const updatedTopic = await response.json()
-                // Update local topics array
                 const index = this.topics.findIndex(t => String(t.id) === String(topicId))
                 if (index !== -1) {
-                    this.topics[index] = updatedTopic
+                    this.topics[index] = { ...this.topics[index], ...updatedTopic }
                 }
                 this.renderTopics(this.topics, this.canManageTopics, this.canCreateTopic)
                 this.restoreSelection()

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -837,7 +837,7 @@ export default class extends Controller {
         const index = topics.findIndex(t => String(t.id) === String(updatedTopic.id))
         if (index === -1) return
 
-        this.topics[index] = updatedTopic
+        this.topics[index] = { ...this.topics[index], ...updatedTopic }
         this.renderTopics(this.topics, this.canManageTopics, this.canCreateTopic)
         this.restoreSelection()
     }

--- a/engines/collavre/test/controllers/topics_controller_test.rb
+++ b/engines/collavre/test/controllers/topics_controller_test.rb
@@ -32,6 +32,22 @@ class TopicsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Updated Name", @topic.name
   end
 
+  test "should include primary_agent in update response" do
+    ai_agent = User.create!(
+      email: "agent-update@test.local", password: "password123", name: "UpdateAgent",
+      llm_vendor: "openai", llm_model: "gpt-4", searchable: true
+    )
+    @topic.set_primary_agent!(ai_agent)
+
+    patch collavre.creative_topic_url(@creative, @topic), params: { topic: { name: "Renamed" } }, as: :json
+
+    assert_response :success
+    json = JSON.parse(response.body)
+    assert_equal "Renamed", json["name"]
+    assert json["primary_agent"].present?, "Response must include primary_agent"
+    assert_equal ai_agent.id, json["primary_agent"]["id"]
+  end
+
   test "should not update topic without permission" do
     other_user = users(:two)
     sign_in_as other_user, password: "password"


### PR DESCRIPTION
## Summary
- Topic update (rename) broadcast only sent `{id, name}`, causing the UI to lose the `primary_agent` data on rename
- Changed both the WebSocket broadcast and HTTP response to use `topic_json(topic)` which includes `primary_agent`
- Made `updateTopicInList` in the frontend merge incoming data with existing topic state instead of replacing, preventing data loss from partial updates

## Test plan
- [x] All existing tests pass (1653 runs, 0 failures)
- [x] Rubocop clean
- [ ] Manual: assign a primary agent to a topic, rename the topic, verify the agent avatar remains visible