### PR TITLE
feat: separate Main topic from All Messages view

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_09_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_15_000000) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false

--- a/engines/collavre/app/controllers/collavre/topics_controller.rb
+++ b/engines/collavre/app/controllers/collavre/topics_controller.rb
@@ -23,6 +23,7 @@ module Collavre
       end
 
       system_topic_id = @creative.inbox? ? @creative.topics.find_by(name: Creative::SYSTEM_TOPIC_NAME)&.id : nil
+      main_topic_id = @creative.topics.find_by(name: Creative::MAIN_TOPIC_NAME)&.id
 
       render json: {
         topics: active_topics.map { |t| topic_json(t) },
@@ -31,7 +32,8 @@ module Collavre
         can_create_topic: can_create_topic,
         last_topic_id: last_topic_id,
         is_inbox: @creative.inbox?,
-        system_topic_id: system_topic_id
+        system_topic_id: system_topic_id,
+        main_topic_id: main_topic_id
       }
     end
 

--- a/engines/collavre/app/controllers/collavre/topics_controller.rb
+++ b/engines/collavre/app/controllers/collavre/topics_controller.rb
@@ -23,7 +23,7 @@ module Collavre
       end
 
       system_topic_id = @creative.inbox? ? @creative.topics.find_by(name: Creative::SYSTEM_TOPIC_NAME)&.id : nil
-      main_topic_id = @creative.topics.find_by(name: Creative::MAIN_TOPIC_NAME)&.id
+      main_topic_id = @creative.main_topic(fallback_user: Current.user).id
 
       render json: {
         topics: active_topics.map { |t| topic_json(t) },
@@ -86,9 +86,12 @@ module Collavre
 
     def destroy
       topic = @creative.topics.find(params[:id])
-      topic_id = topic.id
 
-      # last_topic_id is nullified by DB FK (on_delete: :nullify) and model dependent: :nullify
+      if topic.name == Creative::MAIN_TOPIC_NAME
+        render json: { error: I18n.t("collavre.topics.cannot_delete_main") }, status: :unprocessable_entity and return
+      end
+
+      topic_id = topic.id
       topic.destroy
 
       broadcast_topic_event("deleted", topic_id: topic_id)

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -103,6 +103,7 @@ export default class extends Controller {
     this.currentTopicId = event.detail.topicId
     this._isInbox = event.detail.isInbox || false
     this._systemTopicId = event.detail.systemTopicId || null
+    this._mainTopicId = event.detail.mainTopicId || null
     this._updateInboxReplyMode()
   }
 
@@ -265,8 +266,9 @@ export default class extends Controller {
     const wasPrivate = this.privateCheckboxTarget?.checked ?? false
 
     const formData = new FormData(this.formTarget)
-    if (this.currentTopicId) {
-      formData.append('comment[topic_id]', this.currentTopicId)
+    const effectiveTopicId = this.currentTopicId || this._mainTopicId
+    if (effectiveTopicId) {
+      formData.append('comment[topic_id]', effectiveTopicId)
     }
     if (this._pendingReviewType) {
       formData.append('comment[review_type]', this._pendingReviewType)
@@ -763,8 +765,9 @@ export default class extends Controller {
     }
     const isPrivate = this.privateCheckboxTarget?.checked ?? false
     if (isPrivate) formData.append('comment[private]', '1')
-    if (this.currentTopicId) {
-      formData.append('comment[topic_id]', this.currentTopicId)
+    const effectiveTopicId = this.currentTopicId || this._mainTopicId
+    if (effectiveTopicId) {
+      formData.append('comment[topic_id]', effectiveTopicId)
     }
 
     const url = `/creatives/${this.creativeId}/comments`

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -78,6 +78,7 @@ export default class extends Controller {
                 this.serverLastTopicId = data.last_topic_id ? String(data.last_topic_id) : ""
                 this.isInbox = !!data.is_inbox
                 this.systemTopicId = data.system_topic_id ? String(data.system_topic_id) : null
+                this.mainTopicId = data.main_topic_id ? String(data.main_topic_id) : null
 
                 // Migrate localStorage to server if server has no value
                 this.migrateLocalStorage()
@@ -117,9 +118,10 @@ export default class extends Controller {
             ? 'dragover->comments--topics#handleTopicReorderDragOver dragleave->comments--topics#handleTopicReorderDragLeave drop->comments--topics#handleTopicReorderDrop'
             : ''
 
-        let html = `<span class="topic-tag topic-drop-target ${this.currentTopicId ? '' : 'active'}" 
-                          data-action="click->comments--topics#select ${dropActions}" 
-                          data-id="">#Main</span>`
+        const allMessagesLabel = this.element.dataset.topicMainText || 'All Messages'
+        let html = `<span class="topic-tag topic-drop-target topic-all-messages ${this.currentTopicId ? '' : 'active'}"
+                          data-action="click->comments--topics#select ${dropActions}"
+                          data-id="">📋 ${allMessagesLabel}</span>`
 
         topics.forEach(topic => {
             // Ensure comparison handles string/number difference
@@ -363,7 +365,7 @@ export default class extends Controller {
             if (response.ok) {
                 if (String(this.currentTopicId) === String(topicId)) {
                     this.currentTopicId = "" // Switch to Main
-                    this.dispatch("change", { detail: { topicId: "" } })
+                    this.dispatch("change", { detail: { topicId: "", mainTopicId: this.mainTopicId } })
                 }
                 this.loadTopics()
             } else {
@@ -390,7 +392,7 @@ export default class extends Controller {
             if (response.ok) {
                 if (String(this.currentTopicId) === String(topicId)) {
                     this.currentTopicId = ""
-                    this.dispatch("change", { detail: { topicId: "" } })
+                    this.dispatch("change", { detail: { topicId: "", mainTopicId: this.mainTopicId } })
                 }
                 this.loadTopics()
             } else {
@@ -501,7 +503,7 @@ export default class extends Controller {
             this.clearNewMessageBadge(id)
         }
         // Dispatch event
-        this.dispatch("change", { detail: { topicId: id, isInbox: this.isInbox, systemTopicId: this.systemTopicId } })
+        this.dispatch("change", { detail: { topicId: id, isInbox: this.isInbox, systemTopicId: this.systemTopicId, mainTopicId: this.mainTopicId } })
     }
 
     showEditInput(topicEl, topicId) {
@@ -618,7 +620,7 @@ export default class extends Controller {
             // If we were viewing the moved topic, switch to Main
             if (String(this.currentTopicId) === String(topicId)) {
                 this.currentTopicId = ""
-                this.dispatch("change", { detail: { topicId: "" } })
+                this.dispatch("change", { detail: { topicId: "", mainTopicId: this.mainTopicId } })
             }
             this.loadTopics()
         }
@@ -666,7 +668,7 @@ export default class extends Controller {
                 await this.flushSaveLastTopic(topic.id)
                 await this.loadTopics()
                 // Dispatch change event manually since we skipped the click handler
-                this.dispatch("change", { detail: { topicId: topic.id } })
+                this.dispatch("change", { detail: { topicId: topic.id, mainTopicId: this.mainTopicId } })
             } else {
                 alert("Failed to create topic")
             }
@@ -851,7 +853,7 @@ export default class extends Controller {
         this.topics = nextTopics
         if (String(this.currentTopicId) === String(topicId)) {
             this.currentTopicId = ""
-            this.dispatch("change", { detail: { topicId: "" } })
+            this.dispatch("change", { detail: { topicId: "", mainTopicId: this.mainTopicId } })
         }
 
         this.renderTopics(this.topics, this.canManageTopics, this.canCreateTopic)
@@ -900,7 +902,7 @@ export default class extends Controller {
             this.currentTopicId = result.topic.id
             await this.flushSaveLastTopic(result.topic.id)
             await this.loadTopics()
-            this.dispatch("change", { detail: { topicId: result.topic.id } })
+            this.dispatch("change", { detail: { topicId: result.topic.id, mainTopicId: this.mainTopicId } })
 
             // Clear selection in list controller
             const listController = this.application.getControllerForElementAndIdentifier(
@@ -955,7 +957,7 @@ export default class extends Controller {
                 this.currentTopicId = topic.id
                 await this.flushSaveLastTopic(topic.id)
                 await this.loadTopics()
-                this.dispatch("change", { detail: { topicId: topic.id } })
+                this.dispatch("change", { detail: { topicId: topic.id, mainTopicId: this.mainTopicId } })
             } else {
                 console.error('Failed to create topic with agent')
             }

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -136,7 +136,8 @@ export default class extends Controller {
                           data-id="${topic.id}"${topic.source_topic_id ? ` data-source-topic-id="${topic.source_topic_id}"` : ''}>
                         ${agentAvatar}${branchIcon}#${topic.name}`
 
-            if (canManage) {
+            const isMainTopic = this.mainTopicId && String(topic.id) === String(this.mainTopicId)
+            if (canManage && !isMainTopic) {
                 html += `<button class="archive-topic-btn" data-action="click->comments--topics#archiveTopic" data-id="${topic.id}" title="Archive">${ICON_ARCHIVE}</button>`
                 html += `<button class="delete-topic-btn" data-action="click->comments--topics#deleteTopic" data-id="${topic.id}">&times;</button>`
             }
@@ -193,7 +194,7 @@ export default class extends Controller {
         const agentJson = event.dataTransfer.getData('application/x-agent-drop')
         if (agentJson) {
             const agent = JSON.parse(agentJson)
-            const targetTopicId = event.currentTarget.dataset.id
+            const targetTopicId = event.currentTarget.dataset.id || this.mainTopicId
             if (targetTopicId) {
                 await this.setTopicPrimaryAgent(targetTopicId, agent)
             }
@@ -207,7 +208,7 @@ export default class extends Controller {
         const commentIds = JSON.parse(commentIdsJson)
         if (!commentIds || commentIds.length === 0) return
 
-        const targetTopicId = event.currentTarget.dataset.id // Empty string for Main
+        const targetTopicId = event.currentTarget.dataset.id || this.mainTopicId
 
         // Dispatch event for list_controller to handle the move
         this.dispatch('move-to-topic', {

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -103,10 +103,7 @@ export default class extends Controller {
             }
         }
 
-        // Always dispatch change event to ensure form controller gets the correct topic.
-        // Without this, switching to a creative with no stored topic leaves the form
-        // controller with a stale topic_id from the previous creative.
-        this.selectTopic("")
+        this.selectTopic(this.mainTopicId || "")
     }
 
     renderTopics(topics, canManage = false, canCreateTopic = canManage) {
@@ -150,7 +147,7 @@ export default class extends Controller {
 
         html += `<span class="topic-tag topic-drop-target topic-all-messages ${this.currentTopicId ? '' : 'active'}"
                       data-action="click->comments--topics#select ${dropActions}"
-                      data-id="${this.mainTopicId || ''}">📋 ${allMessagesLabel}</span>`
+                      data-id="">📋 ${allMessagesLabel}</span>`
 
         // Archived topics section
         if (this.archivedTopics && this.archivedTopics.length > 0) {

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -119,31 +119,38 @@ export default class extends Controller {
             : ''
 
         const allMessagesLabel = this.element.dataset.topicMainText || 'All Messages'
-        let html = `<span class="topic-tag topic-drop-target topic-all-messages ${this.currentTopicId ? '' : 'active'}"
-                          data-action="click->comments--topics#select ${dropActions}"
-                          data-id="">📋 ${allMessagesLabel}</span>`
 
-        topics.forEach(topic => {
-            // Ensure comparison handles string/number difference
+        const mainTopic = this.mainTopicId ? topics.find(t => String(t.id) === String(this.mainTopicId)) : null
+        const otherTopics = topics.filter(t => !mainTopic || String(t.id) !== String(this.mainTopicId))
+
+        let html = ''
+
+        const renderTopic = (topic) => {
             const isActive = String(this.currentTopicId) === String(topic.id) ? 'active' : ''
             const draggable = canManage ? 'draggable="true"' : ''
             const agentAvatar = topic.primary_agent
                 ? this.renderAgentAvatar(topic.primary_agent)
                 : ''
             const branchIcon = topic.source_topic_id ? '<span class="topic-branch-icon" title="Branched">↗</span>' : ''
-            html += `<span class="topic-tag topic-drop-target ${isActive}" ${draggable}
+            const isMainTopic = this.mainTopicId && String(topic.id) === String(this.mainTopicId)
+            let s = `<span class="topic-tag topic-drop-target ${isActive}" ${draggable}
                           data-action="click->comments--topics#select ${dropActions} ${dragActions} ${topicDropActions}"
                           data-id="${topic.id}"${topic.source_topic_id ? ` data-source-topic-id="${topic.source_topic_id}"` : ''}>
                         ${agentAvatar}${branchIcon}#${topic.name}`
-
-            const isMainTopic = this.mainTopicId && String(topic.id) === String(this.mainTopicId)
             if (canManage && !isMainTopic) {
-                html += `<button class="archive-topic-btn" data-action="click->comments--topics#archiveTopic" data-id="${topic.id}" title="Archive">${ICON_ARCHIVE}</button>`
-                html += `<button class="delete-topic-btn" data-action="click->comments--topics#deleteTopic" data-id="${topic.id}">&times;</button>`
+                s += `<button class="archive-topic-btn" data-action="click->comments--topics#archiveTopic" data-id="${topic.id}" title="Archive">${ICON_ARCHIVE}</button>`
+                s += `<button class="delete-topic-btn" data-action="click->comments--topics#deleteTopic" data-id="${topic.id}">&times;</button>`
             }
+            s += `</span>`
+            return s
+        }
 
-            html += `</span>`
-        })
+        if (mainTopic) html += renderTopic(mainTopic)
+        otherTopics.forEach(topic => { html += renderTopic(topic) })
+
+        html += `<span class="topic-tag topic-drop-target topic-all-messages ${this.currentTopicId ? '' : 'active'}"
+                      data-action="click->comments--topics#select ${dropActions}"
+                      data-id="${this.mainTopicId || ''}">📋 ${allMessagesLabel}</span>`
 
         // Archived topics section
         if (this.archivedTopics && this.archivedTopics.length > 0) {

--- a/engines/collavre/app/models/collavre/comment.rb
+++ b/engines/collavre/app/models/collavre/comment.rb
@@ -51,6 +51,7 @@ module Collavre
 
     before_validation :use_origin_creative
     before_validation :assign_default_user, on: :create
+    before_validation :assign_main_topic, on: :create
     before_save :apply_link_previews, if: :should_apply_link_previews?
     after_create_commit :dispatch_to_orchestration
     after_create_commit :resume_trigger_loop_if_awaiting
@@ -205,6 +206,14 @@ module Collavre
         "[Comment#resume_trigger_loop_if_awaiting] Failed for comment #{id}: " \
         "#{e.class} #{e.message}"
       )
+    end
+
+    def assign_main_topic
+      return if topic_id.present?
+      return unless creative
+
+      fallback = user || Collavre.current_user || creative.user
+      self.topic = creative.main_topic(fallback_user: fallback)
     end
 
     def use_origin_creative

--- a/engines/collavre/app/models/collavre/creative.rb
+++ b/engines/collavre/app/models/collavre/creative.rb
@@ -13,7 +13,7 @@ module Collavre
     after_save :touch_subtree_on_move, if: :saved_change_to_parent_id?
     after_save :fire_drop_trigger_on_move, if: :saved_change_to_parent_id?
     after_create_commit :fire_drop_trigger_on_create, if: :parent_id?
-
+    after_create :create_main_topic
 
     include Linkable
     include Permissible
@@ -34,6 +34,7 @@ module Collavre
     scope :inboxes, -> { where("data->>'kind' = 'inbox'") }
 
     SYSTEM_TOPIC_NAME = "System"
+    MAIN_TOPIC_NAME = "Main"
 
     def inbox?
       data&.dig("kind") == "inbox"
@@ -43,6 +44,12 @@ module Collavre
     # Re-creates it if the user deletes it.
     def system_topic(fallback_user: user)
       topics.find_or_create_by!(name: SYSTEM_TOPIC_NAME) do |topic|
+        topic.user = fallback_user
+      end
+    end
+
+    def main_topic(fallback_user: user)
+      topics.find_or_create_by!(name: MAIN_TOPIC_NAME) do |topic|
         topic.user = fallback_user
       end
     end
@@ -301,6 +308,13 @@ module Collavre
       return unless parent&.drop_trigger_enabled?
 
       DropTriggerJob.perform_later(parent_id, id)
+    end
+
+    def create_main_topic
+      effective_user = user || Collavre.current_user
+      return unless effective_user
+
+      topics.create!(name: MAIN_TOPIC_NAME, user: effective_user)
     end
   end
 end

--- a/engines/collavre/app/services/collavre/tools/cron_create_service.rb
+++ b/engines/collavre/app/services/collavre/tools/cron_create_service.rb
@@ -10,7 +10,7 @@ module Tools
     tool_description "Create a new recurring scheduled job. The job will periodically post a message to a creative's topic, triggering agent orchestration. Schedule uses cron syntax (e.g., '*/5 * * * *' for every 5 minutes, '0 9 * * *' for daily at 9am)."
 
     tool_param :creative_id, description: "The creative ID to post recurring messages to.", required: true
-    tool_param :topic_name, description: "The topic name within the creative to post to. Use 'Main' for the main topic (topic_id = nil).", required: true
+    tool_param :topic_name, description: "The topic name within the creative to post to. Use 'Main' for the default main topic.", required: true
     tool_param :schedule, description: "Cron schedule expression (e.g., '0 9 * * *' for daily at 9am, '*/30 * * * *' for every 30 minutes).", required: true
     tool_param :message, description: "The message content to post on each execution. This triggers the agent orchestration pipeline.", required: true
     tool_param :description, description: "Human-readable description of what this cron job does.", required: false
@@ -73,8 +73,6 @@ module Tools
     private
 
     def resolve_topic_id(creative, topic_name)
-      return nil if topic_name.casecmp("main").zero?
-
       topic = Topic.find_by(name: topic_name, creative_id: creative.effective_origin.id)
       return { error: "Topic '#{topic_name}' not found for this creative" } unless topic
 

--- a/engines/collavre/app/services/collavre/tools/cron_create_service.rb
+++ b/engines/collavre/app/services/collavre/tools/cron_create_service.rb
@@ -73,10 +73,15 @@ module Tools
     private
 
     def resolve_topic_id(creative, topic_name)
-      topic = Topic.find_by(name: topic_name, creative_id: creative.effective_origin.id)
-      return { error: "Topic '#{topic_name}' not found for this creative" } unless topic
+      origin = creative.effective_origin
+      if topic_name.casecmp(Creative::MAIN_TOPIC_NAME).zero?
+        origin.main_topic(fallback_user: Current.user).id
+      else
+        topic = Topic.find_by(name: topic_name, creative_id: origin.id)
+        return { error: "Topic '#{topic_name}' not found for this creative" } unless topic
 
-      topic.id
+        topic.id
+      end
     end
   end
 end

--- a/engines/collavre/app/services/collavre/topic_branch_service.rb
+++ b/engines/collavre/app/services/collavre/topic_branch_service.rb
@@ -50,7 +50,7 @@ module Collavre
 
     def create_branch_topic
       prefix = I18n.t("collavre.topics.branch_prefix")
-      source_name = source_topic&.name || I18n.t("collavre.topics.main_name", default: "Main")
+      source_name = source_topic&.name || I18n.t("collavre.comments.topic_main", default: "All Messages")
       name = "#{prefix}:#{source_name}"
 
       # Ensure uniqueness

--- a/engines/collavre/app/services/collavre/topic_branch_service.rb
+++ b/engines/collavre/app/services/collavre/topic_branch_service.rb
@@ -40,7 +40,7 @@ module Collavre
     end
 
     def fetch_comments(comment_ids)
-      scope = source_topic ? source_topic.comments.visible_to(user) : creative.comments.visible_to(user).where(topic_id: nil)
+      scope = source_topic ? source_topic.comments.visible_to(user) : creative.comments.visible_to(user)
       comments = scope.where(id: comment_ids).order(:created_at).to_a
       if comments.length != comment_ids.length
         raise BranchError, I18n.t("collavre.comments.branch.comments_not_found")

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -122,7 +122,7 @@ en:
       batch_delete_no_selection: Select at least one message to delete.
       batch_delete_not_found: Some selected messages could not be found.
       topic_search_placeholder: Search topics...
-      topic_main: Main
+      topic_main: All Messages
       fullscreen: Full screen
       exit_fullscreen: Exit full screen
       move_invalid_target: Select a valid creative to move messages to.

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -12,6 +12,7 @@ en:
       default_name_prefix: "Topic"
       branch_prefix: "Branch"
       main_name: "Main"
+      cannot_delete_main: "Cannot delete the Main topic."
       create_and_move: 'Create "%{name}" and move'
       move:
         no_target_permission: You don't have write permission on the target creative.

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -12,6 +12,7 @@ ko:
       default_name_prefix: "토픽"
       branch_prefix: "분기"
       main_name: "메인"
+      cannot_delete_main: "메인 토픽은 삭제할 수 없습니다."
       create_and_move: '"%{name}" 생성후 이동'
       move:
         no_target_permission: 대상 크리에이티브에 대한 쓰기 권한이 없습니다.

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -119,7 +119,7 @@ ko:
       batch_delete_no_selection: 삭제할 메시지를 선택해주세요.
       batch_delete_not_found: 일부 선택한 메시지를 찾을 수 없습니다.
       topic_search_placeholder: 토픽 검색...
-      topic_main: 메인
+      topic_main: 전체 메세지
       fullscreen: 전체 화면
       exit_fullscreen: 전체 화면 종료
       move_invalid_target: 이동할 크리에이티브를 선택해주세요.

--- a/engines/collavre/db/migrate/20260415000000_create_main_topics_for_existing_creatives.rb
+++ b/engines/collavre/db/migrate/20260415000000_create_main_topics_for_existing_creatives.rb
@@ -1,0 +1,69 @@
+class CreateMainTopicsForExistingCreatives < ActiveRecord::Migration[8.0]
+  def up
+    now = Time.current
+
+    # Find creative IDs that don't already have a "Main" topic
+    creative_ids_with_main = select_values("SELECT creative_id FROM topics WHERE name = 'Main'")
+
+    if creative_ids_with_main.any?
+      creatives = select_all(
+        "SELECT id, user_id FROM creatives WHERE id NOT IN (#{creative_ids_with_main.join(',')})"
+      )
+    else
+      creatives = select_all("SELECT id, user_id FROM creatives")
+    end
+
+    # Create Main topics for each creative
+    creatives.each do |row|
+      max_pos = select_value(
+        "SELECT MAX(position) FROM topics WHERE creative_id = #{row['id']}"
+      ).to_i
+
+      execute(sanitize(
+        "INSERT INTO topics (creative_id, user_id, name, position, created_at, updated_at) VALUES (?, ?, 'Main', ?, ?, ?)",
+        row["id"], row["user_id"], max_pos + 1, now, now
+      ))
+    end
+
+    # Migrate topic_id=nil comments to their creative's Main topic
+    execute(<<~SQL)
+      UPDATE comments
+      SET topic_id = (
+        SELECT topics.id FROM topics
+        WHERE topics.creative_id = comments.creative_id
+          AND topics.name = 'Main'
+        LIMIT 1
+      )
+      WHERE comments.topic_id IS NULL
+    SQL
+  end
+
+  def down
+    # Set comments back to nil for Main topics
+    execute(<<~SQL)
+      UPDATE comments
+      SET topic_id = NULL
+      WHERE topic_id IN (SELECT id FROM topics WHERE name = 'Main')
+    SQL
+
+    execute("DELETE FROM topics WHERE name = 'Main'")
+  end
+
+  private
+
+  def select_all(sql)
+    ActiveRecord::Base.connection.select_all(sql)
+  end
+
+  def select_values(sql)
+    ActiveRecord::Base.connection.select_values(sql)
+  end
+
+  def select_value(sql)
+    ActiveRecord::Base.connection.select_value(sql)
+  end
+
+  def sanitize(*args)
+    ActiveRecord::Base.sanitize_sql_array(args)
+  end
+end

--- a/engines/collavre/test/controllers/comments_controller_branch_test.rb
+++ b/engines/collavre/test/controllers/comments_controller_branch_test.rb
@@ -35,8 +35,8 @@ class CommentsControllerBranchTest < ActionDispatch::IntegrationTest
     assert_equal @topic.id, @comment2.reload.topic_id
   end
 
-  test "branch from Main (nil topic_id)" do
-    main_comment = @creative.comments.create!(content: "Main msg", user: @user, topic_id: nil)
+  test "branch from All Messages view (no topic_id param)" do
+    main_comment = @creative.comments.create!(content: "Main msg", user: @user)
 
     post branch_creative_comments_path(@creative),
          params: { comment_ids: [ main_comment.id ] },

--- a/engines/collavre/test/controllers/comments_controller_branch_test.rb
+++ b/engines/collavre/test/controllers/comments_controller_branch_test.rb
@@ -44,7 +44,7 @@ class CommentsControllerBranchTest < ActionDispatch::IntegrationTest
 
     assert_response :created
     json = JSON.parse(response.body)
-    assert_match(/Branch:Main/, json["topic"]["name"])
+    assert_match(/Branch:All Messages/, json["topic"]["name"])
     assert_nil json["topic"]["source_topic_id"]
   end
 

--- a/engines/collavre/test/services/ai_agent_service_test.rb
+++ b/engines/collavre/test/services/ai_agent_service_test.rb
@@ -42,7 +42,7 @@ class AiAgentServiceTest < ActiveSupport::TestCase
 
     reply = @creative.comments.where(user: @agent).order(:created_at).last
     assert_equal "Chunk 1 Chunk 2", reply.content
-    assert_nil reply.topic_id # trigger comment has no topic
+    assert_equal @creative.main_topic.id, reply.topic_id
 
     # Verify actions were logged
     assert @task.task_actions.exists?(action_type: "start")

--- a/engines/collavre/test/services/collavre/inbox_reply_service_test.rb
+++ b/engines/collavre/test/services/collavre/inbox_reply_service_test.rb
@@ -48,7 +48,8 @@ module Collavre
 
       cross_posted = @creative.comments.where(user: @user, content: "My reply from inbox").last
       assert cross_posted, "Expected cross-posted comment in original creative"
-      assert_nil cross_posted.topic_id, "Topic should match original (nil)"
+      main_topic = @creative.main_topic(fallback_user: @user)
+      assert_equal main_topic.id, cross_posted.topic_id, "Topic should be Main topic"
       assert_equal @original_comment.id, cross_posted.quoted_comment_id
     end
 

--- a/engines/collavre/test/services/collavre/tools/cron_create_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/cron_create_service_test.rb
@@ -8,6 +8,7 @@ module Collavre
       setup do
         @user = users(:one)
         @creative = creatives(:tshirt)
+        @main_topic = @creative.main_topic(fallback_user: @user)
         @topic = Collavre::Topic.create!(
           name: "Cron Test Topic",
           creative: @creative,
@@ -46,7 +47,7 @@ module Collavre
         assert_equal @topic.id, args[:topic_id]
       end
 
-      test "topic_name Main resolves to nil topic_id" do
+      test "topic_name Main resolves to Main topic_id" do
         result = CronCreateService.new.call(
           creative_id: @creative.id,
           topic_name: "Main",
@@ -58,10 +59,10 @@ module Collavre
 
         task = SolidQueue::RecurringTask.find_by(key: result[:key])
         args = task.arguments.first
-        assert_nil args[:topic_id]
+        assert_equal @main_topic.id, args[:topic_id]
       end
 
-      test "topic_name main (lowercase) resolves to nil topic_id" do
+      test "topic_name main (lowercase) returns error" do
         result = CronCreateService.new.call(
           creative_id: @creative.id,
           topic_name: "main",
@@ -69,11 +70,8 @@ module Collavre
           message: "Main topic message"
         )
 
-        assert result[:success]
-
-        task = SolidQueue::RecurringTask.find_by(key: result[:key])
-        args = task.arguments.first
-        assert_nil args[:topic_id]
+        assert result[:error]
+        assert_match(/Topic 'main' not found/, result[:error])
       end
 
       test "stores arguments for CronActionJob" do

--- a/engines/collavre/test/services/collavre/tools/cron_create_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/cron_create_service_test.rb
@@ -62,7 +62,7 @@ module Collavre
         assert_equal @main_topic.id, args[:topic_id]
       end
 
-      test "topic_name main (lowercase) returns error" do
+      test "topic_name main (lowercase) resolves to Main topic" do
         result = CronCreateService.new.call(
           creative_id: @creative.id,
           topic_name: "main",
@@ -70,8 +70,10 @@ module Collavre
           message: "Main topic message"
         )
 
-        assert result[:error]
-        assert_match(/Topic 'main' not found/, result[:error])
+        assert result[:success]
+        task = SolidQueue::RecurringTask.find_by(key: result[:key])
+        args = task.arguments.first
+        assert_equal @main_topic.id, args[:topic_id]
       end
 
       test "stores arguments for CronActionJob" do


### PR DESCRIPTION
## Summary
- **All Messages** (전체 메세지): Renamed from "Main" — virtual view showing all messages across topics
- **Main topic**: Real `Topic` record, eager-created via `after_create` callback on `Creative`
- Messages sent from "All Messages" view now default to the Main topic (via `mainTopicId` in frontend)
- Data migration creates Main topics for existing Creatives and migrates `topic_id=nil` comments

## Changes
- `Creative` model: `MAIN_TOPIC_NAME`, `main_topic`, `after_create :create_main_topic`
- `TopicsController#index`: returns `main_topic_id`
- Frontend `topics_controller.js`: All Messages tab with 📋 icon, passes `mainTopicId` in events
- Frontend `form_controller.js`: defaults to Main topic when in All Messages view
- `CronCreateService`: "Main" resolves to real topic (no longer nil)
- `TopicBranchService`: branching from All Messages uses "All Messages" in name
- i18n: `topic_main` → "All Messages" / "전체 메세지"
- Migration: `20260415000000_create_main_topics_for_existing_creatives`

## Test plan
- [x] All 1654 tests pass (0 failures, 0 errors)
- [x] Rubocop passes (0 offenses)
- [ ] Verify "All Messages" tab shows all messages across topics
- [ ] Verify "Main" topic appears in topic list as a regular topic
- [ ] Verify sending a message from "All Messages" view goes to Main topic
- [ ] Verify new Creative creation auto-creates Main topic