### PR TITLE
feat: add scroll-to-previous-message button in chat popup

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -1077,9 +1077,35 @@ body.chat-fullscreen {
     color: var(--color-text);
 }
 
+#typing-indicator-row {
+    display: flex;
+    align-items: center;
+    min-height: 24px;
+    margin: 0.3em 0;
+    gap: 4px;
+}
+
+.scroll-prev-msg-btn {
+    background: none;
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-2);
+    color: var(--text-muted);
+    cursor: pointer;
+    font-size: 16px;
+    line-height: 1;
+    padding: 2px 6px;
+    flex-shrink: 0;
+    transition: background 0.15s, color 0.15s;
+}
+
+.scroll-prev-msg-btn:hover {
+    background: var(--color-section-bg);
+    color: var(--color-text);
+}
+
 #typing-indicator {
     font-style: italic;
-    margin: 0.3em 0;
+    flex: 1;
     min-height: 24px;
     display: flex;
     align-items: center;

--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -1080,9 +1080,9 @@ body.chat-fullscreen {
 #typing-indicator-row {
     display: flex;
     align-items: center;
-    min-height: 24px;
+    min-height: var(--space-px-5);
     margin: 0.3em 0;
-    gap: 4px;
+    gap: var(--space-1);
 }
 
 .scroll-prev-msg-btn {
@@ -1091,9 +1091,9 @@ body.chat-fullscreen {
     border-radius: var(--radius-2);
     color: var(--text-muted);
     cursor: pointer;
-    font-size: 16px;
+    font-size: var(--text-1);
     line-height: 1;
-    padding: 2px 6px;
+    padding: var(--space-px-1) var(--space-2);
     flex-shrink: 0;
     transition: background 0.15s, color 0.15s;
 }
@@ -1106,7 +1106,7 @@ body.chat-fullscreen {
 #typing-indicator {
     font-style: italic;
     flex: 1;
-    min-height: 24px;
+    min-height: var(--space-px-5);
     display: flex;
     align-items: center;
 }

--- a/engines/collavre/app/javascript/controllers/comments/list_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/list_controller.js
@@ -8,7 +8,7 @@ import { updateCsrfTokenFromResponse } from '../../lib/api/csrf_fetch'
 // CommonPopup is now used via TopicSearchController (Stimulus)
 
 export default class extends Controller {
-  static targets = ['list']
+  static targets = ['list', 'scrollPrevBtn']
 
   connect() {
     this.selection = new Set()
@@ -1059,6 +1059,46 @@ export default class extends Controller {
         this.loadInitialComments()
       })
       .finally(() => { this.movingComments = false })
+  }
+
+  scrollToPreviousMessage() {
+    const list = this.listTarget
+    const items = Array.from(list.querySelectorAll('.comment-item'))
+    if (items.length === 0) return
+
+    const listRect = list.getBoundingClientRect()
+    const viewportTop = listRect.top
+
+    let currentIdx = -1
+    for (let i = 0; i < items.length; i++) {
+      const rect = items[i].getBoundingClientRect()
+      if (rect.top >= viewportTop - 2) {
+        currentIdx = i
+        break
+      }
+    }
+
+    if (currentIdx === -1) currentIdx = items.length - 1
+
+    const currentItem = items[currentIdx]
+    const currentRect = currentItem.getBoundingClientRect()
+    const isAtTop = Math.abs(currentRect.top - viewportTop) < 4
+
+    const targetIdx = isAtTop ? currentIdx - 1 : currentIdx
+    if (targetIdx < 0) {
+      if (!this.allOlderLoaded) {
+        this.loadOlderComments()
+      }
+      return
+    }
+
+    const target = items[targetIdx]
+    const targetTop = target.offsetTop - list.offsetTop
+    list.scrollTo({ top: targetTop, behavior: 'smooth' })
+    this.stickToBottom = false
+
+    target.classList.add('highlight-flash')
+    setTimeout(() => target.classList.remove('highlight-flash'), 2000)
   }
 
   // UI Helpers

--- a/engines/collavre/app/javascript/controllers/comments/list_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/list_controller.js
@@ -8,7 +8,7 @@ import { updateCsrfTokenFromResponse } from '../../lib/api/csrf_fetch'
 // CommonPopup is now used via TopicSearchController (Stimulus)
 
 export default class extends Controller {
-  static targets = ['list', 'scrollPrevBtn']
+  static targets = ['list']
 
   connect() {
     this.selection = new Set()
@@ -579,10 +579,9 @@ export default class extends Controller {
     bar.querySelector('.selection-action-branch').addEventListener('click', (e) => { e.stopPropagation(); this.branchSelectedComments() })
     bar.querySelector('.selection-action-bar-close').addEventListener('click', () => this.clearSelection())
 
-    // Insert before typing indicator so it stays inside the popup window
-    const typingIndicator = this.element.querySelector('#typing-indicator')
-    if (typingIndicator) {
-      typingIndicator.parentNode.insertBefore(bar, typingIndicator)
+    const typingRow = this.element.querySelector('#typing-indicator-row') || this.element.querySelector('#typing-indicator')
+    if (typingRow) {
+      typingRow.parentNode.insertBefore(bar, typingRow)
     } else {
       this.element.appendChild(bar)
     }

--- a/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
@@ -119,7 +119,7 @@
   <%= render Collavre::CommandMenuComponent.new(menu_id: 'command-menu') %>
   <div id="comments-list" data-comments--popup-target="list" data-comments--list-target="list"><%= t('app.loading') %></div>
   <div id="typing-indicator-row">
-    <button type="button" id="scroll-prev-msg-btn" class="scroll-prev-msg-btn" data-comments--list-target="scrollPrevBtn" data-action="click->comments--list#scrollToPreviousMessage" title="<%= t('collavre.comments.scroll_to_prev', default: 'Previous message') %>">&#8963;</button>
+    <button type="button" id="scroll-prev-msg-btn" class="scroll-prev-msg-btn" data-action="click->comments--list#scrollToPreviousMessage" title="<%= t('collavre.comments.scroll_to_prev', default: 'Previous message') %>" aria-label="<%= t('collavre.comments.scroll_to_prev', default: 'Previous message') %>">&#8963;</button>
     <div id="typing-indicator" data-comments--presence-target="typingIndicator" data-comments--popup-target="typingIndicator" data-stop-agent-text="<%= t('collavre.comments.stop_agent') %>"></div>
   </div>
   <form id="new-comment-form" data-comments--popup-target="form" data-comments--form-target="form" style="display:none;">

--- a/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
@@ -118,7 +118,10 @@
   <%= render Collavre::UserMentionMenuComponent.new(menu_id: 'mention-menu') %>
   <%= render Collavre::CommandMenuComponent.new(menu_id: 'command-menu') %>
   <div id="comments-list" data-comments--popup-target="list" data-comments--list-target="list"><%= t('app.loading') %></div>
-  <div id="typing-indicator" data-comments--presence-target="typingIndicator" data-comments--popup-target="typingIndicator" data-stop-agent-text="<%= t('collavre.comments.stop_agent') %>"></div>
+  <div id="typing-indicator-row">
+    <button type="button" id="scroll-prev-msg-btn" class="scroll-prev-msg-btn" data-comments--list-target="scrollPrevBtn" data-action="click->comments--list#scrollToPreviousMessage" title="<%= t('collavre.comments.scroll_to_prev', default: 'Previous message') %>">&#8963;</button>
+    <div id="typing-indicator" data-comments--presence-target="typingIndicator" data-comments--popup-target="typingIndicator" data-stop-agent-text="<%= t('collavre.comments.stop_agent') %>"></div>
+  </div>
   <form id="new-comment-form" data-comments--popup-target="form" data-comments--form-target="form" style="display:none;">
     <input type="hidden" name="comment[quoted_comment_id]" data-comments--form-target="quotedCommentId" value="" />
     <input type="hidden" name="comment[quoted_text]" data-comments--form-target="quotedText" value="" />

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -70,6 +70,7 @@ en:
         creative.'
       convert_system_message_default_title: Untitled
       system_user: System
+      scroll_to_prev: Previous message
       search_button: Search
       image_button: Image
       search_empty_prompt: Please enter a search term in the chat message field.

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -67,6 +67,7 @@ ko:
       convert_system_message: 'System: 메세지가 [%{title}](%{url}) 크리에이티브로 변환되었습니다'
       convert_system_message_default_title: 제목 없음
       system_user: System
+      scroll_to_prev: 이전 메시지
       search_button: 검색
       image_button: 이미지
       search_empty_prompt: 검색어 를 채팅 메세지 입력폼에 입력하시오


### PR DESCRIPTION
## Summary
- Add a chevron-up (⌃) button at the left of the typing indicator area in the chat popup
- Each press scrolls to the top of the previous message, allowing users to read long messages from the beginning
- Highlights the target message briefly (2s flash) for visual feedback
- If already at the first message and more exist, triggers loading of older comments

## Changed files
- `_comments_popup.html.erb` — wrap typing indicator in a flex row with the scroll button
- `list_controller.js` — add `scrollToPreviousMessage()` method with viewport-based message detection
- `comments_popup.css` — style the button and the new `#typing-indicator-row` wrapper
- `comments.en.yml` / `comments.ko.yml` — add `scroll_to_prev` i18n key

## Test plan
- [x] All 1654 unit tests pass (0 failures)
- [x] System tests pass (0 failures)
- [x] Rubocop passes
- [x] i18n keys present in both en and ko
- [ ] Manual QA: open chat popup with multiple messages, click chevron button repeatedly to step through messages
- [ ] Verify highlight flash appears on each target message
- [ ] Verify older messages are loaded when reaching the top
- [ ] Verify typing indicator still renders correctly alongside the button