### PR TITLE
fix: skip orchestration dispatch for inbox comments

### DIFF
--- a/engines/collavre/app/models/collavre/comment.rb
+++ b/engines/collavre/app/models/collavre/comment.rb
@@ -135,6 +135,7 @@ module Collavre
       return unless user_id        # nil user = system message
       return if user&.ai_user?     # AI replies use A2aDispatcher, not this callback
       return unless creative
+      return if creative.inbox?
 
       SystemEvents::Dispatcher.dispatch("comment_created", dispatch_payload)
     rescue StandardError => e

--- a/engines/collavre/test/models/comment_test.rb
+++ b/engines/collavre/test/models/comment_test.rb
@@ -127,6 +127,19 @@ class CommentTest < ActiveSupport::TestCase
     assert_equal initial_inbox_comment_count, inbox.comments.count
   end
 
+  test "inbox comments do not dispatch to orchestration" do
+    owner = User.create!(email: "inbox-orch-owner@example.com", password: TEST_PASSWORD, name: "InboxOrchOwner")
+    commenter = User.create!(email: "inbox-orch-commenter@example.com", password: TEST_PASSWORD, name: "InboxOrchCommenter")
+    inbox = Creative.inbox_for(owner)
+
+    dispatched = false
+    SystemEvents::Dispatcher.stub(:dispatch, ->(*_args) { dispatched = true }) do
+      inbox.comments.create!(user: commenter, content: "reply in inbox")
+    end
+
+    refute dispatched, "Expected no orchestration dispatch for inbox comments"
+  end
+
   test "creating an inbox notification broadcasts inbox badge immediately" do
     creative = creatives(:tshirt)
     commenter = users(:two)


### PR DESCRIPTION
## Summary
- Inbox System의 댓글에서 `dispatch_to_orchestration`이 실행되면 AI Agent가 불필요하게 라우팅되는 문제 수정
- `Comment#dispatch_to_orchestration`에 `return if creative.inbox?` guard 추가
- 인박스 답글은 `InboxReplyService`가 원본 creative로 cross-post하며, cross-post된 댓글이 원본에서 정상적으로 AI 라우팅됨

## Test plan
- [x] 새 테스트 추가: inbox comment가 orchestration dispatch를 트리거하지 않는지 검증
- [x] 전체 테스트 스위트 통과 (1655 tests, 0 failures)
- [x] Rubocop 통과