### PR TITLE
feat: add stop button on streaming AI messages

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -922,8 +922,31 @@ body.chat-fullscreen {
 
 .comment-owner-only,
 .comment-delete-hidden,
-.comment-approve-hidden {
+.comment-approve-hidden,
+.comment-stop-hidden {
     display: none;
+}
+
+.comment-stop-btn {
+    background: var(--surface-btn);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-2);
+    cursor: pointer;
+    padding: 0.1em 0.4em;
+    font-size: var(--text-00);
+    color: var(--color-danger);
+    line-height: 1;
+    white-space: nowrap;
+}
+
+.comment-stop-btn:hover {
+    background: var(--color-danger);
+    color: var(--text-on-btn);
+}
+
+.comment-stop-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
 }
 
 .comment-copy-notice {

--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -932,11 +932,15 @@ body.chat-fullscreen {
     border: 1px solid var(--border-color);
     border-radius: var(--radius-2);
     cursor: pointer;
-    padding: 0.1em 0.4em;
+    padding: var(--space-px-1) var(--space-px-2);
     font-size: var(--text-00);
     color: var(--color-danger);
     line-height: 1;
     white-space: nowrap;
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-px-1);
+    transition: background 0.15s, color 0.15s;
 }
 
 .comment-stop-btn:hover {

--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -922,8 +922,11 @@ body.chat-fullscreen {
 
 .comment-owner-only,
 .comment-delete-hidden,
-.comment-approve-hidden,
-.comment-stop-hidden {
+.comment-approve-hidden {
+    display: none;
+}
+
+.comment-stop-btn.comment-stop-hidden {
     display: none;
 }
 

--- a/engines/collavre/app/javascript/controllers/comment_controller.js
+++ b/engines/collavre/app/javascript/controllers/comment_controller.js
@@ -2,6 +2,7 @@ import { Controller } from "@hotwired/stimulus"
 import { renderCommentMarkdown, renderMermaidDiagrams } from '../lib/utils/markdown'
 import { addTableDownloadButtons } from '../lib/utils/table_download'
 import CommonPopup from '../lib/common_popup'
+import csrfFetch from '../lib/api/csrf_fetch'
 
 // Global tracker: persists streaming state across Turbo replacements
 // (each replacement creates a new controller instance, losing instance state)
@@ -9,7 +10,7 @@ if (!window._streamingCommentIds) window._streamingCommentIds = new Set()
 
 // Connects to data-controller="comment"
 export default class extends Controller {
-  static targets = ["ownerButton", "deleteButton", "approveButton", "actionApproveControls"]
+  static targets = ["ownerButton", "deleteButton", "approveButton", "actionApproveControls", "stopTask"]
 
   get _commentId() {
     return this.element.dataset.commentId
@@ -122,6 +123,11 @@ export default class extends Controller {
       }
     }
 
+    // Stop-task button visibility
+    this._handleAgentTasksChanged = this._handleAgentTasksChanged.bind(this)
+    window.addEventListener('agent-tasks-changed', this._handleAgentTasksChanged)
+    this._updateStopButton()
+
     // Text selection quote support
     this.handleMouseUp = this.handleMouseUp.bind(this)
     document.addEventListener('mouseup', this.handleMouseUp)
@@ -161,6 +167,44 @@ export default class extends Controller {
         el.classList.remove('comment-approve-hidden')
       })
     }
+  }
+
+  _handleAgentTasksChanged() {
+    this._updateStopButton()
+  }
+
+  _getActiveTaskId() {
+    if (!this._isAiComment) return null
+    if (!this._isStreaming) return null
+    const userId = this.element.dataset.userId
+    return window._activeAgentTasks?.[userId] || null
+  }
+
+  _updateStopButton() {
+    if (!this.hasStopTaskTarget) return
+    const taskId = this._getActiveTaskId()
+    if (taskId) {
+      this.stopTaskTarget.classList.remove('comment-stop-hidden')
+      this.stopTaskTarget.dataset.taskId = taskId
+    } else {
+      this.stopTaskTarget.classList.add('comment-stop-hidden')
+    }
+  }
+
+  cancelTask(event) {
+    event.preventDefault()
+    event.stopPropagation()
+    const taskId = event.currentTarget.dataset.taskId
+    if (!taskId) return
+    event.currentTarget.disabled = true
+    csrfFetch(`/tasks/${taskId}/cancel`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    })
+      .then((response) => {
+        if (!response.ok) event.currentTarget.disabled = false
+      })
+      .catch(() => { event.currentTarget.disabled = false })
   }
 
   triggerReactionPicker(event) {
@@ -226,6 +270,7 @@ export default class extends Controller {
       clearTimeout(this._streamingTimeout)
       this._streamingTimeout = null
     }
+    window.removeEventListener('agent-tasks-changed', this._handleAgentTasksChanged)
     document.removeEventListener('mouseup', this.handleMouseUp)
     this.hideReviewPopup()
     if (this._reviewPopupEl) {

--- a/engines/collavre/app/javascript/controllers/comment_controller.js
+++ b/engines/collavre/app/javascript/controllers/comment_controller.js
@@ -80,6 +80,7 @@ export default class extends Controller {
         }
       }
       this._isStreaming = false
+      this._updateStopButton()
     }, 10000)
   }
 
@@ -175,7 +176,6 @@ export default class extends Controller {
 
   _getActiveTaskId() {
     if (!this._isAiComment) return null
-    if (!this._isStreaming) return null
     const userId = this.element.dataset.userId
     return window._activeAgentTasks?.[userId] || null
   }

--- a/engines/collavre/app/javascript/controllers/comments/presence_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/presence_controller.js
@@ -217,6 +217,7 @@ export default class extends Controller {
           delete this.typingUsers[id]
           delete this.agentStatusTimers[id]
           delete this.activeAgentTasks?.[id]
+          this.syncGlobalAgentTasks()
           this.renderTypingIndicator()
         }, AGENT_STATUS_TIMEOUT)
       } else {
@@ -227,6 +228,7 @@ export default class extends Controller {
           delete this.agentStatusTimers[id]
         }
       }
+      this.syncGlobalAgentTasks()
       this.renderTypingIndicator()
     }
   }
@@ -380,6 +382,11 @@ export default class extends Controller {
     this.typingIndicatorTarget.appendChild(text)
   }
 
+  syncGlobalAgentTasks() {
+    window._activeAgentTasks = this.activeAgentTasks ? { ...this.activeAgentTasks } : {}
+    window.dispatchEvent(new CustomEvent('agent-tasks-changed', { detail: window._activeAgentTasks }))
+  }
+
   cancelAllAgentTasks() {
     const ids = Object.keys(this.activeAgentTasks || {})
     if (ids.length === 0) return false
@@ -403,6 +410,7 @@ export default class extends Controller {
             clearTimeout(this.agentStatusTimers[agentId])
             delete this.agentStatusTimers[agentId]
           }
+          this.syncGlobalAgentTasks()
           this.renderTypingIndicator()
         }
       })

--- a/engines/collavre/app/javascript/controllers/comments/presence_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/presence_controller.js
@@ -64,6 +64,7 @@ export default class extends Controller {
     this.currentPresentIds = []
     this.typingUsers = {}
     this.activeAgentTasks = {}
+    this.syncGlobalAgentTasks()
     this.clearTypingTimers()
     this.clearManualTypingMessage()
     this.renderParticipants([])

--- a/engines/collavre/app/views/collavre/comments/_comment.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comment.html.erb
@@ -41,6 +41,9 @@
     <% can_convert_comment = comment.user == Current.user || comment.creative.has_permission?(Current.user, :admin) %>
   </div>
     <div class="comment-action-container">
+      <button class="comment-stop-btn comment-stop-hidden" type="button" data-comment-target="stopTask" data-action="click->comment#cancelTask" title="<%= t('collavre.comments.stop_agent') %>">
+        <span class="agent-stop-icon">&#x25A0;</span> <%= t('collavre.comments.stop_agent') %>
+      </button>
       <button class="add-reaction-btn" type="button" data-action="click->comment#triggerReactionPicker" title="<%= t('collavre.comments.add_reaction') %>">
         <span class="grayscale-emoji">☺</span>
       </button>

--- a/engines/collavre/app/views/collavre/comments/_comment.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comment.html.erb
@@ -41,9 +41,11 @@
     <% can_convert_comment = comment.user == Current.user || comment.creative.has_permission?(Current.user, :admin) %>
   </div>
     <div class="comment-action-container">
-      <button class="comment-stop-btn comment-stop-hidden" type="button" data-comment-target="stopTask" data-action="click->comment#cancelTask" title="<%= t('collavre.comments.stop_agent') %>">
-        <span class="agent-stop-icon">&#x25A0;</span> <%= t('collavre.comments.stop_agent') %>
-      </button>
+      <% if comment.user&.ai_user? %>
+        <button class="comment-stop-btn comment-stop-hidden" type="button" data-comment-target="stopTask" data-action="click->comment#cancelTask" title="<%= t('collavre.comments.stop_agent') %>">
+          <span class="agent-stop-icon">&#x25A0;</span> <%= t('collavre.comments.stop_agent') %>
+        </button>
+      <% end %>
       <button class="add-reaction-btn" type="button" data-action="click->comment#triggerReactionPicker" title="<%= t('collavre.comments.add_reaction') %>">
         <span class="grayscale-emoji">☺</span>
       </button>


### PR DESCRIPTION
## Summary
- AI가 응답을 스트리밍 중인 메시지에 [중지] 버튼을 리액션 버튼 왼쪽에 표시
- 버튼 클릭 시 `POST /tasks/:id/cancel` 호출하여 진행 중인 태스크를 취소
- Presence controller에서 `activeAgentTasks`를 window global로 동기화하고 `agent-tasks-changed` 이벤트를 발행하여 개별 comment controller가 실시간으로 반응

## Changes
- **presence_controller.js**: `syncGlobalAgentTasks()` 추가 — `window._activeAgentTasks`에 동기화 + CustomEvent 발행
- **comment_controller.js**: 스트리밍 AI 코멘트에서 active task가 있으면 [중지] 버튼 표시, 클릭 시 cancel API 호출
- **_comment.html.erb**: `comment-action-container`에 [중지] 버튼 마크업 추가 (기본 hidden)
- **comments_popup.css**: `.comment-stop-btn` 스타일 추가 (danger 색상, hover 시 배경 변경)

## Test plan
- [x] Rubocop passed (795 files, no offenses)
- [x] All tests passed (0 failures, 0 errors)
- [x] Build succeeded
- [ ] Manual: AI 에이전트가 스트리밍 중일 때 메시지에 [중지] 버튼이 나타나는지 확인
- [ ] Manual: [중지] 클릭 시 태스크가 취소되고 버튼이 사라지는지 확인
- [ ] Manual: 스트리밍 종료 후 버튼이 자동으로 숨겨지는지 확인