### PR TITLE
refactor: server-side stop button with comment-task 1:1 link

### DIFF
--- a/db/migrate/20260415094811_add_task_id_to_comments.rb
+++ b/db/migrate/20260415094811_add_task_id_to_comments.rb
@@ -1,0 +1,6 @@
+class AddTaskIdToComments < ActiveRecord::Migration[8.1]
+  def change
+    add_column :comments, :task_id, :integer
+    add_index :comments, :task_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_15_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_15_094811) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false
@@ -142,6 +142,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_15_000000) do
     t.text "quoted_text"
     t.integer "review_type", limit: 1
     t.integer "selected_version_id"
+    t.integer "task_id"
     t.integer "topic_id"
     t.datetime "updated_at", null: false
     t.integer "user_id"
@@ -150,6 +151,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_15_000000) do
     t.index ["creative_id"], name: "index_comments_on_creative_id"
     t.index ["quoted_comment_id"], name: "index_comments_on_quoted_comment_id"
     t.index ["selected_version_id"], name: "index_comments_on_selected_version_id"
+    t.index ["task_id"], name: "index_comments_on_task_id"
     t.index ["topic_id"], name: "index_comments_on_topic_id"
     t.index ["user_id"], name: "index_comments_on_user_id"
   end

--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -926,10 +926,6 @@ body.chat-fullscreen {
     display: none;
 }
 
-.comment-stop-btn.comment-stop-hidden {
-    display: none;
-}
-
 .comment-stop-btn {
     background: var(--surface-btn);
     border: 1px solid var(--border-color);

--- a/engines/collavre/app/controllers/collavre/comments_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comments_controller.rb
@@ -28,7 +28,7 @@ module Collavre
       limit = 20
 
       visible_scope = @creative.comments.visible_to(Current.user)
-      scope = visible_scope.with_attached_images.includes(:topic, :comment_reactions, :comment_versions, :snapshot_as_result)
+      scope = visible_scope.with_attached_images.includes(:task, :topic, :comment_reactions, :comment_versions, :snapshot_as_result)
 
       if params[:search].present?
         words = params[:search].to_s.strip.downcase.split(/\s+/)

--- a/engines/collavre/app/controllers/collavre/tasks_controller.rb
+++ b/engines/collavre/app/controllers/collavre/tasks_controller.rb
@@ -10,7 +10,7 @@ module Collavre
         return head :forbidden
       end
 
-      unless %w[running pending queued].include?(task.status)
+      unless %w[running pending queued pending_approval].include?(task.status)
         return head :unprocessable_entity
       end
 

--- a/engines/collavre/app/javascript/controllers/comment_controller.js
+++ b/engines/collavre/app/javascript/controllers/comment_controller.js
@@ -10,7 +10,7 @@ if (!window._streamingCommentIds) window._streamingCommentIds = new Set()
 
 // Connects to data-controller="comment"
 export default class extends Controller {
-  static targets = ["ownerButton", "deleteButton", "approveButton", "actionApproveControls", "stopTask"]
+  static targets = ["ownerButton", "deleteButton", "approveButton", "actionApproveControls"]
 
   get _commentId() {
     return this.element.dataset.commentId
@@ -80,7 +80,6 @@ export default class extends Controller {
         }
       }
       this._isStreaming = false
-      this._updateStopButton()
     }, 10000)
   }
 
@@ -124,11 +123,6 @@ export default class extends Controller {
       }
     }
 
-    // Stop-task button visibility
-    this._handleAgentTasksChanged = this._handleAgentTasksChanged.bind(this)
-    window.addEventListener('agent-tasks-changed', this._handleAgentTasksChanged)
-    this._updateStopButton()
-
     // Text selection quote support
     this.handleMouseUp = this.handleMouseUp.bind(this)
     document.addEventListener('mouseup', this.handleMouseUp)
@@ -167,27 +161,6 @@ export default class extends Controller {
       this.actionApproveControlsTargets.forEach((el) => {
         el.classList.remove('comment-approve-hidden')
       })
-    }
-  }
-
-  _handleAgentTasksChanged() {
-    this._updateStopButton()
-  }
-
-  _getActiveTaskId() {
-    if (!this._isAiComment) return null
-    const userId = this.element.dataset.userId
-    return window._activeAgentTasks?.[userId] || null
-  }
-
-  _updateStopButton() {
-    if (!this.hasStopTaskTarget) return
-    const taskId = this._getActiveTaskId()
-    if (taskId) {
-      this.stopTaskTarget.classList.remove('comment-stop-hidden')
-      this.stopTaskTarget.dataset.taskId = taskId
-    } else {
-      this.stopTaskTarget.classList.add('comment-stop-hidden')
     }
   }
 
@@ -270,7 +243,6 @@ export default class extends Controller {
       clearTimeout(this._streamingTimeout)
       this._streamingTimeout = null
     }
-    window.removeEventListener('agent-tasks-changed', this._handleAgentTasksChanged)
     document.removeEventListener('mouseup', this.handleMouseUp)
     this.hideReviewPopup()
     if (this._reviewPopupEl) {

--- a/engines/collavre/app/javascript/controllers/comments/presence_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/presence_controller.js
@@ -384,8 +384,7 @@ export default class extends Controller {
   }
 
   syncGlobalAgentTasks() {
-    window._activeAgentTasks = this.activeAgentTasks ? { ...this.activeAgentTasks } : {}
-    window.dispatchEvent(new CustomEvent('agent-tasks-changed', { detail: window._activeAgentTasks }))
+    // no-op: stop button is now server-rendered per comment via task_id
   }
 
   cancelAllAgentTasks() {

--- a/engines/collavre/app/models/collavre/comment.rb
+++ b/engines/collavre/app/models/collavre/comment.rb
@@ -13,6 +13,7 @@ module Collavre
     belongs_to :user, class_name: Collavre.configuration.user_class_name, optional: true
     belongs_to :approver, class_name: Collavre.configuration.user_class_name, optional: true
     belongs_to :action_executed_by, class_name: Collavre.configuration.user_class_name, optional: true
+    belongs_to :task, class_name: "Collavre::Task", optional: true
     belongs_to :topic, class_name: "Collavre::Topic", optional: true
     belongs_to :quoted_comment, class_name: "Collavre::Comment", optional: true
 

--- a/engines/collavre/app/models/collavre/task.rb
+++ b/engines/collavre/app/models/collavre/task.rb
@@ -7,10 +7,12 @@ module Collavre
     belongs_to :parent_task, class_name: "Collavre::Task", optional: true
     has_many :sub_tasks, class_name: "Collavre::Task", foreign_key: :parent_task_id, dependent: :destroy
     belongs_to :creative, class_name: "Collavre::Creative", optional: true
+    has_one :reply_comment, class_name: "Collavre::Comment", foreign_key: :task_id, dependent: :nullify
 
     validates :name, presence: true
 
     after_update_commit :check_trigger_loop_completion, if: :trigger_loop_candidate?
+    after_update_commit :broadcast_stop_button_removal, if: :became_terminal?
 
     scope :running_for_topic, ->(topic_id, creative_id = nil) {
       rel = where(topic_id: topic_id, status: "running")
@@ -46,6 +48,21 @@ module Collavre
 
       trigger_topic_id = loop_config["trigger_topic_id"]
       trigger_topic_id.nil? || trigger_topic_id == topic_id
+    end
+
+    def became_terminal?
+      saved_change_to_attribute?("status") && status.in?(%w[done cancelled failed])
+    end
+
+    def broadcast_stop_button_removal
+      comment = reply_comment
+      return unless comment
+
+      comment.broadcast_replace_to(
+        [ comment.creative, :comments ],
+        partial: "collavre/comments/comment",
+        locals: { comment: comment, streaming: false }
+      )
     end
 
     def check_trigger_loop_completion

--- a/engines/collavre/app/services/collavre/ai_agent/response_finalizer.rb
+++ b/engines/collavre/app/services/collavre/ai_agent/response_finalizer.rb
@@ -72,7 +72,8 @@ module Collavre
         reply_comment = @original_comment.creative.comments.create!(
           content: @response_content,
           user: @agent,
-          topic_id: @original_comment.topic_id
+          topic_id: @original_comment.topic_id,
+          task: @task
         )
 
         log_action("reply_created", { comment_id: reply_comment.id, content: @response_content })

--- a/engines/collavre/app/services/collavre/ai_agent_service.rb
+++ b/engines/collavre/app/services/collavre/ai_agent_service.rb
@@ -137,6 +137,7 @@ module Collavre
         content: Comment::STREAMING_PLACEHOLDER_CONTENT,
         user: @agent,
         topic_id: @original_comment.topic_id,
+        task: @task,
         skip_dispatch: true  # A2A routing handled by A2aDispatcher after finalization
       )
     end

--- a/engines/collavre/app/views/collavre/comments/_comment.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comment.html.erb
@@ -41,8 +41,8 @@
     <% can_convert_comment = comment.user == Current.user || comment.creative.has_permission?(Current.user, :admin) %>
   </div>
     <div class="comment-action-container">
-      <% if comment.user&.ai_user? %>
-        <button class="comment-stop-btn comment-stop-hidden" type="button" data-comment-target="stopTask" data-action="click->comment#cancelTask" title="<%= t('collavre.comments.stop_agent') %>">
+      <% if comment.task_id && comment.task&.status&.in?(%w[running pending queued]) %>
+        <button class="comment-stop-btn" type="button" data-action="click->comment#cancelTask" data-task-id="<%= comment.task_id %>" title="<%= t('collavre.comments.stop_agent') %>">
           <span class="agent-stop-icon">&#x25A0;</span> <%= t('collavre.comments.stop_agent') %>
         </button>
       <% end %>

--- a/engines/collavre/app/views/collavre/comments/_comment.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comment.html.erb
@@ -41,7 +41,7 @@
     <% can_convert_comment = comment.user == Current.user || comment.creative.has_permission?(Current.user, :admin) %>
   </div>
     <div class="comment-action-container">
-      <% if comment.task_id && comment.task&.status&.in?(%w[running pending queued]) %>
+      <% if comment.task_id && comment.task&.status&.in?(%w[running pending queued pending_approval]) %>
         <button class="comment-stop-btn" type="button" data-action="click->comment#cancelTask" data-task-id="<%= comment.task_id %>" title="<%= t('collavre.comments.stop_agent') %>">
           <span class="agent-stop-icon">&#x25A0;</span> <%= t('collavre.comments.stop_agent') %>
         </button>


### PR DESCRIPTION
## Summary
- 중지 버튼을 클라이언트사이드 agent-user-ID 매칭에서 **서버사이드 task 상태 확인**으로 전환
- `comments` 테이블에 `task_id` FK 추가 → AI reply 코멘트가 어떤 task에서 생성되었는지 직접 연결
- 코멘트 렌더 시 `comment.task.status`가 active(running/pending/queued)일 때만 중지 버튼 표시
- Task가 terminal 상태(done/cancelled/failed)에 도달하면 해당 코멘트를 Turbo Stream으로 re-render하여 버튼 자동 제거
- `window._activeAgentTasks` 전역 변수, `agent-tasks-changed` 이벤트, 클라이언트 사이드 상태 관리 코드 전면 제거

## 이전 문제
- agent user ID 기준으로 매칭 → 해당 에이전트의 **모든 과거 메시지**에 중지 버튼 표시
- streaming 상태와 task 상태가 다른 채널(Turbo Stream vs ActionCable)에서 비동기 처리되어 타이밍 불일치

## 변경 파일 (11개)
- Migration: `add_task_id_to_comments` (task_id + index)
- Models: `Comment` (belongs_to :task), `Task` (has_one :reply_comment, broadcast callback)
- Services: `AiAgentService`, `ResponseFinalizer` (task_id 설정)
- View: `_comment.html.erb` (서버사이드 조건부 렌더링)
- Controller: `comments_controller.rb` (includes :task)
- JS: `comment_controller.js` (전역 상태 로직 제거), `presence_controller.js` (syncGlobalAgentTasks no-op)
- CSS: `.comment-stop-hidden` 규칙 제거

## Test plan
- [x] Rubocop 통과 (797 files, 0 offenses)
- [x] 전체 테스트 통과 (1655 runs, 0 failures)
- [ ] 실제 AI 에이전트 메시지 생성 시 중지 버튼이 해당 메시지에만 표시되는지 확인
- [ ] 태스크 완료 후 중지 버튼이 자동 제거되는지 확인
- [ ] 중지 버튼 클릭 시 태스크가 정상 취소되는지 확인
- [ ] 다른 에이전트의 과거 메시지에 중지 버튼이 나타나지 않는지 확인