### PR TITLE
refactor: deduplicate GitHub PR service and Slack job error handling

### DIFF
--- a/engines/collavre_github/app/services/collavre_github/tools/concerns/github_client_finder.rb
+++ b/engines/collavre_github/app/services/collavre_github/tools/concerns/github_client_finder.rb
@@ -30,6 +30,23 @@ module CollavreGithub
 
           CollavreGithub::Client.new(link.github_account)
         end
+
+        # Find client or return error hash. Yields the client to the block.
+        # Wraps the block with a StandardError rescue that returns { error: ... }.
+        #
+        # @param creative_id [Integer]
+        # @param repo [String]
+        # @param error_context [String] human-readable label for error messages
+        # @yield [client] the GitHub client
+        # @return [Hash] the block's result or an error hash
+        def with_github_client(creative_id:, repo:, error_context:, &block)
+          client = find_github_client(creative_id, repo)
+          return { error: "GitHub account not found for this creative and repository" } unless client
+
+          yield client
+        rescue StandardError => e
+          { error: "Failed to #{error_context}: #{e.message}" }
+        end
       end
     end
   end

--- a/engines/collavre_github/app/services/collavre_github/tools/github_pr_commits_service.rb
+++ b/engines/collavre_github/app/services/collavre_github/tools/github_pr_commits_service.rb
@@ -23,17 +23,14 @@ module CollavreGithub
 
       sig { params(creative_id: Integer, repo: String, pr_number: Integer).returns(T::Hash[Symbol, T.untyped]) }
       def call(creative_id:, repo:, pr_number:)
-        client = find_github_client(creative_id, repo)
-        return { error: "GitHub account not found for this creative and repository" } unless client
+        with_github_client(creative_id: creative_id, repo: repo, error_context: "fetch PR commits") do |client|
+          messages = client.pull_request_commit_messages(repo, pr_number)
 
-        messages = client.pull_request_commit_messages(repo, pr_number)
-
-        {
-          commits: messages.map.with_index(1) { |msg, i| { index: i, message: msg } },
-          count: messages.size
-        }
-      rescue StandardError => e
-        { error: "Failed to fetch PR commits: #{e.message}" }
+          {
+            commits: messages.map.with_index(1) { |msg, i| { index: i, message: msg } },
+            count: messages.size
+          }
+        end
       end
     end
   end

--- a/engines/collavre_github/app/services/collavre_github/tools/github_pr_details_service.rb
+++ b/engines/collavre_github/app/services/collavre_github/tools/github_pr_details_service.rb
@@ -22,31 +22,28 @@ module CollavreGithub
 
       sig { params(creative_id: Integer, repo: String, pr_number: Integer).returns(T::Hash[Symbol, T.untyped]) }
       def call(creative_id:, repo:, pr_number:)
-        client = find_github_client(creative_id, repo)
-        return { error: "GitHub account not found for this creative and repository" } unless client
+        with_github_client(creative_id: creative_id, repo: repo, error_context: "fetch PR details") do |client|
+          pr = client.pull_request_details(repo, pr_number)
+          return { error: "Pull request not found" } unless pr
 
-        pr = client.pull_request_details(repo, pr_number)
-        return { error: "Pull request not found" } unless pr
-
-        {
-          number: pr.number,
-          title: pr.title,
-          body: pr.body.to_s.truncate(2000),
-          state: pr.state,
-          merged: pr.merged,
-          author: pr.user&.login,
-          created_at: pr.created_at&.iso8601,
-          updated_at: pr.updated_at&.iso8601,
-          merged_at: pr.merged_at&.iso8601,
-          additions: pr.additions,
-          deletions: pr.deletions,
-          changed_files: pr.changed_files,
-          html_url: pr.html_url,
-          base_branch: pr.base&.ref,
-          head_branch: pr.head&.ref
-        }
-      rescue StandardError => e
-        { error: "Failed to fetch PR details: #{e.message}" }
+          {
+            number: pr.number,
+            title: pr.title,
+            body: pr.body.to_s.truncate(2000),
+            state: pr.state,
+            merged: pr.merged,
+            author: pr.user&.login,
+            created_at: pr.created_at&.iso8601,
+            updated_at: pr.updated_at&.iso8601,
+            merged_at: pr.merged_at&.iso8601,
+            additions: pr.additions,
+            deletions: pr.deletions,
+            changed_files: pr.changed_files,
+            html_url: pr.html_url,
+            base_branch: pr.base&.ref,
+            head_branch: pr.head&.ref
+          }
+        end
       end
     end
   end

--- a/engines/collavre_github/app/services/collavre_github/tools/github_pr_diff_service.rb
+++ b/engines/collavre_github/app/services/collavre_github/tools/github_pr_diff_service.rb
@@ -35,22 +35,19 @@ module CollavreGithub
       def call(creative_id:, repo:, pr_number:, max_length: nil)
         max_length ||= DIFF_MAX_LENGTH
 
-        client = find_github_client(creative_id, repo)
-        return { error: "GitHub account not found for this creative and repository" } unless client
+        with_github_client(creative_id: creative_id, repo: repo, error_context: "fetch PR diff") do |client|
+          diff = client.pull_request_diff(repo, pr_number)
+          return { error: "Could not fetch diff", diff: nil } unless diff
 
-        diff = client.pull_request_diff(repo, pr_number)
-        return { error: "Could not fetch diff", diff: nil } unless diff
+          truncated = diff.length > max_length
+          diff_text = truncated ? "#{diff[0, max_length]}\n...\n[Diff truncated to #{max_length} characters]" : diff
 
-        truncated = diff.length > max_length
-        diff_text = truncated ? "#{diff[0, max_length]}\n...\n[Diff truncated to #{max_length} characters]" : diff
-
-        {
-          diff: diff_text,
-          truncated: truncated,
-          original_length: diff.length
-        }
-      rescue StandardError => e
-        { error: "Failed to fetch PR diff: #{e.message}" }
+          {
+            diff: diff_text,
+            truncated: truncated,
+            original_length: diff.length
+          }
+        end
       end
     end
   end

--- a/engines/collavre_slack/app/jobs/collavre_slack/slack_inbound_message_delete_job.rb
+++ b/engines/collavre_slack/app/jobs/collavre_slack/slack_inbound_message_delete_job.rb
@@ -1,24 +1,26 @@
 module CollavreSlack
   class SlackInboundMessageDeleteJob < ApplicationJob
+    include ErrorLoggable
+
     queue_as :default
 
     def perform(payload)
-      data = payload.with_indifferent_access
-      comment = Collavre::Comment.find_by(id: data[:comment_id])
+      with_slack_error_handling("SlackInboundMessageDeleteJob") do
+        data = payload.with_indifferent_access
+        comment = Collavre::Comment.find_by(id: data[:comment_id])
 
-      if comment
-        # Mark as coming from Slack to prevent loop
-        comment.instance_variable_set(:@from_slack, true)
-        comment.destroy!
-        Rails.logger.info("[CollavreSlack] Deleted comment #{data[:comment_id]} from Slack deletion")
-      end
+        if comment
+          # Mark as coming from Slack to prevent loop
+          comment.instance_variable_set(:@from_slack, true)
+          comment.destroy!
+          Rails.logger.info("[CollavreSlack] Deleted comment #{data[:comment_id]} from Slack deletion")
+        end
 
-      # Clean up the comment link record
-      if data[:slack_comment_link_id].present?
-        SlackCommentLink.find_by(id: data[:slack_comment_link_id])&.destroy
+        # Clean up the comment link record
+        if data[:slack_comment_link_id].present?
+          SlackCommentLink.find_by(id: data[:slack_comment_link_id])&.destroy
+        end
       end
-    rescue StandardError => e
-      Rails.logger.error("[CollavreSlack] SlackInboundMessageDeleteJob error: #{e.message}\n#{e.backtrace.first(5).join("\n")}")
     end
   end
 end

--- a/engines/collavre_slack/app/jobs/collavre_slack/slack_inbound_message_update_job.rb
+++ b/engines/collavre_slack/app/jobs/collavre_slack/slack_inbound_message_update_job.rb
@@ -1,22 +1,24 @@
 module CollavreSlack
   class SlackInboundMessageUpdateJob < ApplicationJob
+    include ErrorLoggable
+
     queue_as :default
 
     def perform(payload)
-      data = payload.with_indifferent_access
-      comment = Collavre::Comment.find_by(id: data[:comment_id])
-      return unless comment
+      with_slack_error_handling("SlackInboundMessageUpdateJob") do
+        data = payload.with_indifferent_access
+        comment = Collavre::Comment.find_by(id: data[:comment_id])
+        return unless comment
 
-      new_content = data[:content]
-      return if new_content.blank?
+        new_content = data[:content]
+        return if new_content.blank?
 
-      # Mark as coming from Slack to prevent loop
-      comment.instance_variable_set(:@from_slack, true)
-      comment.update!(content: new_content)
+        # Mark as coming from Slack to prevent loop
+        comment.instance_variable_set(:@from_slack, true)
+        comment.update!(content: new_content)
 
-      Rails.logger.info("[CollavreSlack] Updated comment #{comment.id} from Slack edit")
-    rescue StandardError => e
-      Rails.logger.error("[CollavreSlack] SlackInboundMessageUpdateJob error: #{e.message}\n#{e.backtrace.first(5).join("\n")}")
+        Rails.logger.info("[CollavreSlack] Updated comment #{comment.id} from Slack edit")
+      end
     end
   end
 end

--- a/engines/collavre_slack/app/jobs/collavre_slack/slack_message_delete_job.rb
+++ b/engines/collavre_slack/app/jobs/collavre_slack/slack_message_delete_job.rb
@@ -1,29 +1,31 @@
 module CollavreSlack
   class SlackMessageDeleteJob < ApplicationJob
+    include ErrorLoggable
+
     queue_as :default
 
     def perform(slack_channel_link_id:, message_ts:)
-      Rails.logger.info("[CollavreSlack] SlackMessageDeleteJob performing for channel_link_id=#{slack_channel_link_id}, ts=#{message_ts}")
+      with_slack_error_handling("SlackMessageDeleteJob") do
+        Rails.logger.info("[CollavreSlack] SlackMessageDeleteJob performing for channel_link_id=#{slack_channel_link_id}, ts=#{message_ts}")
 
-      channel_link = SlackChannelLink.find_by(id: slack_channel_link_id)
-      return unless channel_link
+        channel_link = SlackChannelLink.find_by(id: slack_channel_link_id)
+        return unless channel_link
 
-      client = SlackClient.new(access_token: channel_link.slack_account.access_token)
-      response = client.delete_message(
-        channel: channel_link.channel_id,
-        timestamp: message_ts
-      )
+        client = SlackClient.new(access_token: channel_link.slack_account.access_token)
+        response = client.delete_message(
+          channel: channel_link.channel_id,
+          timestamp: message_ts
+        )
 
-      if response[:ok]
-        Rails.logger.info("[CollavreSlack] Message deleted successfully, ts=#{message_ts}")
-      else
-        # message_not_found is not an error - message may have been deleted on Slack already
-        unless response[:error] == "message_not_found"
-          Rails.logger.error("[CollavreSlack] Failed to delete message: #{response[:error]}")
+        if response[:ok]
+          Rails.logger.info("[CollavreSlack] Message deleted successfully, ts=#{message_ts}")
+        else
+          # message_not_found is not an error - message may have been deleted on Slack already
+          unless response[:error] == "message_not_found"
+            Rails.logger.error("[CollavreSlack] Failed to delete message: #{response[:error]}")
+          end
         end
       end
-    rescue StandardError => e
-      Rails.logger.error("[CollavreSlack] SlackMessageDeleteJob error: #{e.message}\n#{e.backtrace.first(5).join("\n")}")
     end
   end
 end

--- a/engines/collavre_slack/app/jobs/collavre_slack/slack_message_update_job.rb
+++ b/engines/collavre_slack/app/jobs/collavre_slack/slack_message_update_job.rb
@@ -1,32 +1,34 @@
 module CollavreSlack
   class SlackMessageUpdateJob < ApplicationJob
+    include ErrorLoggable
+
     queue_as :default
 
     def perform(slack_comment_link_id:, message:)
-      Rails.logger.info("[CollavreSlack] SlackMessageUpdateJob performing for link_id=#{slack_comment_link_id}")
+      with_slack_error_handling("SlackMessageUpdateJob") do
+        Rails.logger.info("[CollavreSlack] SlackMessageUpdateJob performing for link_id=#{slack_comment_link_id}")
 
-      comment_link = SlackCommentLink.find_by(id: slack_comment_link_id)
-      return unless comment_link
+        comment_link = SlackCommentLink.find_by(id: slack_comment_link_id)
+        return unless comment_link
 
-      channel_link = comment_link.slack_channel_link
-      return unless channel_link
+        channel_link = comment_link.slack_channel_link
+        return unless channel_link
 
-      formatted_message = MentionMapping.to_slack(message, channel_link.slack_account)
+        formatted_message = MentionMapping.to_slack(message, channel_link.slack_account)
 
-      client = SlackClient.new(access_token: channel_link.slack_account.access_token)
-      response = client.update_message(
-        channel: channel_link.channel_id,
-        timestamp: comment_link.message_ts,
-        text: formatted_message
-      )
+        client = SlackClient.new(access_token: channel_link.slack_account.access_token)
+        response = client.update_message(
+          channel: channel_link.channel_id,
+          timestamp: comment_link.message_ts,
+          text: formatted_message
+        )
 
-      if response[:ok]
-        Rails.logger.info("[CollavreSlack] Message updated successfully, ts=#{comment_link.message_ts}")
-      else
-        Rails.logger.error("[CollavreSlack] Failed to update message: #{response[:error]}")
+        if response[:ok]
+          Rails.logger.info("[CollavreSlack] Message updated successfully, ts=#{comment_link.message_ts}")
+        else
+          Rails.logger.error("[CollavreSlack] Failed to update message: #{response[:error]}")
+        end
       end
-    rescue StandardError => e
-      Rails.logger.error("[CollavreSlack] SlackMessageUpdateJob error: #{e.message}\n#{e.backtrace.first(5).join("\n")}")
     end
   end
 end

--- a/engines/collavre_slack/app/models/concerns/collavre_slack/error_loggable.rb
+++ b/engines/collavre_slack/app/models/concerns/collavre_slack/error_loggable.rb
@@ -1,0 +1,20 @@
+module CollavreSlack
+  module ErrorLoggable
+    extend ActiveSupport::Concern
+
+    private
+
+    # Wraps a block with standardized Slack error handling.
+    # Logs the error message and first 5 backtrace lines.
+    #
+    # @param context_name [String] identifies the caller in the log (e.g. "SlackMessageJob")
+    # @param reraise [Boolean] whether to re-raise after logging (default: false)
+    # @yield the block to execute with error handling
+    def with_slack_error_handling(context_name, reraise: false)
+      yield
+    rescue StandardError => e
+      Rails.logger.error("[CollavreSlack] #{context_name} error: #{e.message}\n#{e.backtrace.first(5).join("\n")}")
+      raise if reraise
+    end
+  end
+end

--- a/engines/collavre_slack/app/models/concerns/collavre_slack/slack_dispatchable.rb
+++ b/engines/collavre_slack/app/models/concerns/collavre_slack/slack_dispatchable.rb
@@ -3,6 +3,8 @@ module CollavreSlack
     extend ActiveSupport::Concern
 
     included do
+      include ErrorLoggable
+
       after_create_commit :dispatch_to_slack_channels
       after_update_commit :update_slack_messages, if: :saved_change_to_content?
       before_destroy :prepare_slack_message_deletion
@@ -12,61 +14,61 @@ module CollavreSlack
     private
 
     def dispatch_to_slack_channels
-      # Don't dispatch if this comment came from Slack (prevent loop)
-      if instance_variable_get(:@from_slack)
-        Rails.logger.info("[CollavreSlack] Skipping dispatch - comment came from Slack")
-        return
+      with_slack_error_handling("Failed to dispatch to Slack") do
+        # Don't dispatch if this comment came from Slack (prevent loop)
+        if instance_variable_get(:@from_slack)
+          Rails.logger.info("[CollavreSlack] Skipping dispatch - comment came from Slack")
+          return
+        end
+
+        # Use effective_origin since Slack links are on origin creative
+        target_creative_id = creative.effective_origin.id
+
+        return unless CollavreSlack::SlackChannelLink.where(creative_id: target_creative_id).exists?
+
+        Rails.logger.info("[CollavreSlack] dispatch_to_slack_channels called for comment #{id}, creative_id=#{creative_id}, target_creative_id=#{target_creative_id}")
+
+        links = CollavreSlack::SlackChannelLink.where(creative_id: target_creative_id)
+        Rails.logger.info("[CollavreSlack] Found #{links.count} active Slack links")
+
+        links.find_each do |link|
+          Rails.logger.info("[CollavreSlack] Dispatching to channel #{link.channel_name} (#{link.channel_id})")
+          dispatcher = CollavreSlack::SlackMessageDispatcher.new(channel_link: link)
+          dispatcher.enqueue(message: format_slack_message, sender: user, comment: self)
+        end
       end
-
-      # Use effective_origin since Slack links are on origin creative
-      target_creative_id = creative.effective_origin.id
-
-      return unless CollavreSlack::SlackChannelLink.where(creative_id: target_creative_id).exists?
-
-      Rails.logger.info("[CollavreSlack] dispatch_to_slack_channels called for comment #{id}, creative_id=#{creative_id}, target_creative_id=#{target_creative_id}")
-
-      links = CollavreSlack::SlackChannelLink.where(creative_id: target_creative_id)
-      Rails.logger.info("[CollavreSlack] Found #{links.count} active Slack links")
-
-      links.find_each do |link|
-        Rails.logger.info("[CollavreSlack] Dispatching to channel #{link.channel_name} (#{link.channel_id})")
-        dispatcher = CollavreSlack::SlackMessageDispatcher.new(channel_link: link)
-        dispatcher.enqueue(message: format_slack_message, sender: user, comment: self)
-      end
-    rescue StandardError => e
-      Rails.logger.error("[CollavreSlack] Failed to dispatch to Slack: #{e.message}\n#{e.backtrace.first(5).join("\n")}")
     end
 
     def update_slack_messages
-      return if instance_variable_get(:@from_slack)
+      with_slack_error_handling("Failed to update Slack messages") do
+        return if instance_variable_get(:@from_slack)
 
-      comment_links = CollavreSlack::SlackCommentLink.where(comment_id: id)
-      return if comment_links.empty?
+        comment_links = CollavreSlack::SlackCommentLink.where(comment_id: id)
+        return if comment_links.empty?
 
-      comment_links.each do |link|
-        CollavreSlack::SlackMessageUpdateJob.perform_later(
-          slack_comment_link_id: link.id,
-          message: format_slack_message
-        )
+        comment_links.each do |link|
+          CollavreSlack::SlackMessageUpdateJob.perform_later(
+            slack_comment_link_id: link.id,
+            message: format_slack_message
+          )
+        end
       end
-    rescue StandardError => e
-      Rails.logger.error("[CollavreSlack] Failed to update Slack messages: #{e.message}\n#{e.backtrace.first(5).join("\n")}")
     end
 
     def prepare_slack_message_deletion
-      Rails.logger.info("[CollavreSlack] prepare_slack_message_deletion called for comment #{id}")
-      return if instance_variable_get(:@from_slack)
+      with_slack_error_handling("Failed to prepare Slack message deletion") do
+        Rails.logger.info("[CollavreSlack] prepare_slack_message_deletion called for comment #{id}")
+        return if instance_variable_get(:@from_slack)
 
-      # Save link info before the comment is deleted
-      # The database will cascade delete the records, but we need the info for Slack API
-      comment_links = CollavreSlack::SlackCommentLink.where(comment_id: id)
-      Rails.logger.info("[CollavreSlack] Found #{comment_links.count} slack comment links")
-      @slack_links_to_delete = comment_links.map do |link|
-        { slack_channel_link_id: link.slack_channel_link_id, message_ts: link.message_ts }
+        # Save link info before the comment is deleted
+        # The database will cascade delete the records, but we need the info for Slack API
+        comment_links = CollavreSlack::SlackCommentLink.where(comment_id: id)
+        Rails.logger.info("[CollavreSlack] Found #{comment_links.count} slack comment links")
+        @slack_links_to_delete = comment_links.map do |link|
+          { slack_channel_link_id: link.slack_channel_link_id, message_ts: link.message_ts }
+        end
+        Rails.logger.info("[CollavreSlack] Saved #{@slack_links_to_delete.size} links for deletion")
       end
-      Rails.logger.info("[CollavreSlack] Saved #{@slack_links_to_delete.size} links for deletion")
-    rescue StandardError => e
-      Rails.logger.error("[CollavreSlack] Failed to prepare Slack message deletion: #{e.message}\n#{e.backtrace.first(5).join("\n")}")
     end
 
     def format_slack_message
@@ -76,22 +78,22 @@ module CollavreSlack
     end
 
     def delete_slack_messages
-      Rails.logger.info("[CollavreSlack] delete_slack_messages called")
-      return if instance_variable_get(:@from_slack)
+      with_slack_error_handling("Failed to delete Slack messages") do
+        Rails.logger.info("[CollavreSlack] delete_slack_messages called")
+        return if instance_variable_get(:@from_slack)
 
-      links_to_delete = instance_variable_get(:@slack_links_to_delete) || []
-      Rails.logger.info("[CollavreSlack] Links to delete: #{links_to_delete.size}")
-      return if links_to_delete.empty?
+        links_to_delete = instance_variable_get(:@slack_links_to_delete) || []
+        Rails.logger.info("[CollavreSlack] Links to delete: #{links_to_delete.size}")
+        return if links_to_delete.empty?
 
-      links_to_delete.each do |link_info|
-        Rails.logger.info("[CollavreSlack] Enqueuing SlackMessageDeleteJob for ts=#{link_info[:message_ts]}")
-        CollavreSlack::SlackMessageDeleteJob.perform_later(
-          slack_channel_link_id: link_info[:slack_channel_link_id],
-          message_ts: link_info[:message_ts]
-        )
+        links_to_delete.each do |link_info|
+          Rails.logger.info("[CollavreSlack] Enqueuing SlackMessageDeleteJob for ts=#{link_info[:message_ts]}")
+          CollavreSlack::SlackMessageDeleteJob.perform_later(
+            slack_channel_link_id: link_info[:slack_channel_link_id],
+            message_ts: link_info[:message_ts]
+          )
+        end
       end
-    rescue StandardError => e
-      Rails.logger.error("[CollavreSlack] Failed to delete Slack messages: #{e.message}\n#{e.backtrace.first(5).join("\n")}")
     end
   end
 end


### PR DESCRIPTION
## Summary
- Extract `with_github_client` helper into `GithubClientFinder` concern to consolidate duplicated client lookup, nil-check, and rescue boilerplate across `GithubPrDetailsService`, `GithubPrDiffService`, and `GithubPrCommitsService`
- Add `CollavreSlack::ErrorLoggable` concern with `with_slack_error_handling` method to replace identical `rescue StandardError => e` + `Rails.logger.error` blocks across 4 Slack jobs and 4 `SlackDispatchable` callbacks
- No behavior change -- error messages, log format, and re-raise semantics are preserved exactly

## Test plan
- [x] Full test suite passes (1655 runs, 0 failures, 0 errors)
- [x] Rubocop passes on all 10 changed files (0 offenses)
- [x] Pre-push hooks pass (rubocop, tests, dead code check, i18n check)