### PR TITLE
feat: always inject ancestry breadcrumb in AI agent context

### DIFF
--- a/engines/collavre/app/services/collavre/ai_agent/message_builder.rb
+++ b/engines/collavre/app/services/collavre/ai_agent/message_builder.rb
@@ -50,7 +50,8 @@ module Collavre
           @injected_creative_ids << creative.id
           messages << { role: "user", kind: :creative_context, parts: [ { text: "Current Creative (id: #{creative.id}):#{topic_info}\nPath: #{ancestry}" } ] }
         else
-          # Full self-context: inject the creative subtree
+          # Full self-context: inject the creative subtree with ancestry breadcrumb
+          ancestry = build_ancestry_chain(creative)
           children_level = @agent.creative_children_level
           max_depth = 1 + children_level
           markdown = ApplicationController.helpers.render_creative_tree_markdown(
@@ -58,7 +59,7 @@ module Collavre
           )
 
           @injected_creative_ids << creative.id
-          messages << { role: "user", kind: :creative_context, parts: [ { text: "Creative (id: #{creative.id}):#{topic_info}\n#{markdown}" } ] }
+          messages << { role: "user", kind: :creative_context, parts: [ { text: "Creative (id: #{creative.id}):#{topic_info}\nPath: #{ancestry}\n#{markdown}" } ] }
         end
       end
 

--- a/engines/collavre/app/services/collavre/ai_agent/message_builder.rb
+++ b/engines/collavre/app/services/collavre/ai_agent/message_builder.rb
@@ -48,7 +48,7 @@ module Collavre
           # knows where in the hierarchy the conversation is happening
           ancestry = build_ancestry_chain(creative)
           @injected_creative_ids << creative.id
-          messages << { role: "user", kind: :creative_context, parts: [ { text: "Current Creative (id: #{creative.id}):#{topic_info}\nPath: #{ancestry}" } ] }
+          messages << { role: "user", kind: :creative_context, parts: [ { text: "Creative Path: #{ancestry}#{topic_info}" } ] }
         else
           # Full self-context: inject the creative subtree with ancestry breadcrumb
           ancestry = build_ancestry_chain(creative)
@@ -59,12 +59,12 @@ module Collavre
           )
 
           @injected_creative_ids << creative.id
-          messages << { role: "user", kind: :creative_context, parts: [ { text: "Creative (id: #{creative.id}):#{topic_info}\nPath: #{ancestry}\n#{markdown}" } ] }
+          messages << { role: "user", kind: :creative_context, parts: [ { text: "Creative Path: #{ancestry}#{topic_info}\n#{markdown}" } ] }
         end
       end
 
       def build_ancestry_chain(creative)
-        creative.self_and_ancestors.reverse.map(&:creative_snippet).join(" > ")
+        creative.self_and_ancestors.reverse.map { |c| "#{c.creative_snippet} (id: #{c.id})" }.join(" > ")
       end
 
       def append_context_creatives(messages)

--- a/engines/collavre/app/services/collavre/ai_agent/message_builder.rb
+++ b/engines/collavre/app/services/collavre/ai_agent/message_builder.rb
@@ -43,15 +43,15 @@ module Collavre
         topic = current_topic
         topic_info = topic ? "\nTopic: #{topic.name} (id: #{topic.id})" : ""
 
+        ancestry = build_ancestry_chain(creative)
+
         if effective.data&.dig("disabled_self_context") == true
           # Self-context disabled: inject only the ancestry chain so the AI
           # knows where in the hierarchy the conversation is happening
-          ancestry = build_ancestry_chain(creative)
           @injected_creative_ids << creative.id
           messages << { role: "user", kind: :creative_context, parts: [ { text: "Creative Path: #{ancestry}#{topic_info}" } ] }
         else
           # Full self-context: inject the creative subtree with ancestry breadcrumb
-          ancestry = build_ancestry_chain(creative)
           children_level = @agent.creative_children_level
           max_depth = 1 + children_level
           markdown = ApplicationController.helpers.render_creative_tree_markdown(
@@ -248,9 +248,19 @@ module Collavre
       # This is slightly broader than what's actually rendered (which is
       # limited by children_level), but ensures no descendant change is missed.
       def collect_rendered_creative_ids
-        @injected_creative_ids.flat_map do |root_id|
+        ids = @injected_creative_ids.flat_map do |root_id|
           Creative.find_by(id: root_id)&.subtree_ids || [ root_id ]
-        end.uniq
+        end
+
+        # Include ancestor IDs used in the breadcrumb so that changes to
+        # ancestor titles are detected by context_changed?
+        creative_id = @context.dig("creative", "id")
+        if creative_id
+          ancestor_ids = Creative.find_by(id: creative_id)&.ancestor_ids || []
+          ids.concat(ancestor_ids)
+        end
+
+        ids.uniq
       end
     end
   end

--- a/engines/collavre/test/services/collavre/ai_agent/message_builder_test.rb
+++ b/engines/collavre/test/services/collavre/ai_agent/message_builder_test.rb
@@ -107,6 +107,21 @@ module Collavre
         assert_nil context_msg, "Should not include disabled context creative"
       end
 
+      test "includes ancestry breadcrumb in full subtree context" do
+        context = {
+          "comment" => { "id" => @comment.id, "content" => "Hello" },
+          "creative" => { "id" => @creative.id }
+        }
+
+        builder = MessageBuilder.new(agent: @agent, context: context, original_comment: @comment)
+        result = builder.build
+        messages = result[:messages]
+
+        creative_msg = messages.find { |m| m[:kind] == :creative_context }
+        assert_not_nil creative_msg
+        assert_includes creative_msg[:parts].first[:text], "Path:"
+      end
+
       test "injects only ancestry chain when disabled_self_context is true" do
         @creative.update!(data: { "disabled_self_context" => true })
 

--- a/engines/collavre/test/services/collavre/ai_agent/message_builder_test.rb
+++ b/engines/collavre/test/services/collavre/ai_agent/message_builder_test.rb
@@ -119,7 +119,8 @@ module Collavre
 
         creative_msg = messages.find { |m| m[:kind] == :creative_context }
         assert_not_nil creative_msg
-        assert_includes creative_msg[:parts].first[:text], "Path:"
+        assert_includes creative_msg[:parts].first[:text], "Creative Path:"
+        assert_match(/\(id: #{@creative.id}\)/, creative_msg[:parts].first[:text])
       end
 
       test "injects only ancestry chain when disabled_self_context is true" do
@@ -134,14 +135,10 @@ module Collavre
         result = builder.build
         messages = result[:messages]
 
-        # Should NOT include full subtree
-        full_msg = messages.find { |m| m[:parts]&.first&.dig(:text)&.start_with?("Creative (id:") }
-        assert_nil full_msg, "Should not include full creative subtree when disabled"
-
-        # Should include ancestry path
-        ancestry_msg = messages.find { |m| m[:parts]&.first&.dig(:text)&.start_with?("Current Creative (id:") }
+        # Both modes now use "Creative Path:" format
+        ancestry_msg = messages.find { |m| m[:parts]&.first&.dig(:text)&.start_with?("Creative Path:") }
         assert_not_nil ancestry_msg, "Should include ancestry chain when self-context disabled"
-        assert_includes ancestry_msg[:parts].first[:text], "Path:"
+        assert_match(/\(id: #{@creative.id}\)/, ancestry_msg[:parts].first[:text])
       end
 
       test "deduplicates context and referenced creatives" do

--- a/engines/collavre/test/services/collavre/ai_agent/session_context_resolver_test.rb
+++ b/engines/collavre/test/services/collavre/ai_agent/session_context_resolver_test.rb
@@ -8,7 +8,7 @@ module Collavre
       setup do
         @system_prompt = "You are a helpful assistant"
         @full_messages = [
-          { role: "user", kind: :creative_context, parts: [ { text: "Creative (id: 1):\n# Hello" } ] },
+          { role: "user", kind: :creative_context, parts: [ { text: "Creative Path: Test (id: 1)\n# Hello" } ] },
           { role: "user", kind: :context_creative, parts: [ { text: "Context Creative (id: 2):\n# Config" } ] },
           { role: "user", kind: :chat_history, parts: [ { text: "[Alice]: hi" } ] },
           { role: "model", kind: :chat_history, parts: [ { text: "Hello!" } ] },


### PR DESCRIPTION
## Summary
- AI 채팅 컨텍스트에서 `Path:` breadcrumb(상위 계보)를 **항상** 주입하도록 개선
- 기존에는 `disabled_self_context` 모드에서만 `Path:` breadcrumb가 포함되었음
- 이제 full subtree 모드에서도 `Path: 루트 > 중간 > 현재` 형태로 포함되어, AI가 현재 크리에이티브의 계층 위치를 항상 인지 가능

## Test plan
- [x] MessageBuilder 단위 테스트 추가 (full subtree 모드에서 Path: 포함 확인)
- [x] 전체 테스트 스위트 통과 (pre-push hook)
- [x] Rubocop 통과