### PR TITLE
fix: prevent NoMethodError in GitHub markdown initial sync

### DIFF
--- a/engines/collavre_github/app/services/collavre_github/markdown_sync/initial_import_service.rb
+++ b/engines/collavre_github/app/services/collavre_github/markdown_sync/initial_import_service.rb
@@ -21,8 +21,9 @@ module CollavreGithub
         end
 
         # Archive existing root tree before reimport (pause/resume flow)
-        if @link.markdown_root_creative&.archived_at.nil?
-          @link.markdown_root_creative.archive!
+        root = @link.markdown_root_creative
+        if root && root.archived_at.nil?
+          root.archive!
         end
 
         parent_creative = @link.creative


### PR DESCRIPTION
## Summary
- Fix `NoMethodError (undefined method 'archive!' for nil)` in `InitialMarkdownSyncJob`
- The safe navigation operator `&.archived_at` returns `nil` when `markdown_root_creative` is `nil`, and `nil.nil?` evaluates to `true`, causing `nil.archive!` to be called
- Replace with explicit nil check: `root = @link.markdown_root_creative; if root && root.archived_at.nil?`

## Test plan
- [x] Rubocop passed (806 files, no offenses)
- [x] All existing tests passed
- [ ] Manually trigger GitHub markdown sync on a repository link with no prior `markdown_root_creative`