### PR TITLE
fix: unify stop button text style in chat popup

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -1161,7 +1161,7 @@ body.chat-fullscreen {
     background: var(--surface-btn);
     border: 1px solid var(--border-color);
     border-radius: var(--radius-2);
-    color: var(--text-muted);
+    color: var(--color-danger);
     cursor: pointer;
     font-size: var(--text-00);
     padding: var(--space-px-1) var(--space-px-2);


### PR DESCRIPTION
## Summary
- The typing indicator stop button (`.agent-stop-btn`) used `var(--text-muted)` for text color while the comment-level stop button (`.comment-stop-btn`) used `var(--color-danger)`
- Changed `.agent-stop-btn` color to `var(--color-danger)` to match the comment-level stop button style, as specified in the bug report

## Test plan
- [x] Rubocop passes
- [x] All tests pass
- [x] i18n keys verified (en, ko)
- [ ] Visual verification: open a chat popup with an active agent task, confirm both stop buttons now show the same danger-colored text