### PR TITLE
fix: increase wait times for comment share link system test

### DIFF
--- a/engines/collavre/test/system/creative_expansion_actions_test.rb
+++ b/engines/collavre/test/system/creative_expansion_actions_test.rb
@@ -89,7 +89,7 @@ class CreativeExpansionActionsTest < ApplicationSystemTestCase
 
     visit collavre.creative_comment_path(@child, comment)
 
-    assert_selector "#comments-popup", visible: :visible
-    assert_selector "#comment_#{comment.id}[data-highlighted='true']", wait: 5
+    assert_selector "#comments-popup", visible: :visible, wait: 10
+    assert_selector "#comment_#{comment.id}[data-highlighted='true']", wait: 10
   end
 end


### PR DESCRIPTION
## Summary
- Increased Capybara `wait` from 5s to 10s for both popup visibility and comment highlight assertions in `creative_expansion_actions_test.rb`
- The test involves a long async chain (2 server redirects → CSR tree rendering → MutationObserver button discovery → popup open → AJAX comment fetch → highlight), which can exceed 5s in slower CI environments

## Test plan
- [x] All 5 tests in `creative_expansion_actions_test.rb` pass
- [x] Full test suite passes (pre-push hook)
- [x] Rubocop clean