### PR TITLE
fix: prevent duplicate topics and stale loadTopics race in comments popup

### DIFF
--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -63,6 +63,9 @@ export default class extends Controller {
         if (!this.creativeId) return
 
         const version = ++this._loadTopicsVersion
+        // Clear stale topics from previous creative to prevent name-based
+        // dedupe in handleTopicMessage from blocking valid broadcasts
+        this.topics = []
 
         try {
             const response = await fetch(`/creatives/${this.creativeId}/topics`)

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -14,6 +14,7 @@ export default class extends Controller {
         this.canCreateTopic = false
         this.subscribedCreativeId = null
         this.topicsSubscription = null
+        this._loadTopicsVersion = 0
         // Initial load if creativeId is available (e.g. from dataset if set server-side)
         if (this.creativeId) {
             this.loadTopics()
@@ -61,8 +62,13 @@ export default class extends Controller {
     async loadTopics() {
         if (!this.creativeId) return
 
+        const version = ++this._loadTopicsVersion
+
         try {
             const response = await fetch(`/creatives/${this.creativeId}/topics`)
+            // Discard stale response if a newer loadTopics() call was made
+            if (version !== this._loadTopicsVersion) return
+
             if (response.status === 404) {
                 throw new Error(`Creative ${this.creativeId} not found`)
             }
@@ -802,8 +808,12 @@ export default class extends Controller {
         if (!data.topic) return
 
         const topics = this.topics || []
-        const exists = topics.some((topic) => String(topic.id) === String(data.topic.id))
-        if (exists) return
+        const existsById = topics.some((topic) => String(topic.id) === String(data.topic.id))
+        if (existsById) return
+        // Prevent duplicate topic names (e.g. two "Main" topics from race between
+        // HTTP loadTopics and WebSocket broadcast)
+        const existsByName = data.topic.name && topics.some((topic) => topic.name === data.topic.name)
+        if (existsByName) return
 
         this.topics = [...topics, data.topic]
         this.renderTopics(this.topics, this.canManageTopics, this.canCreateTopic)

--- a/engines/collavre/test/system/creative_expansion_actions_test.rb
+++ b/engines/collavre/test/system/creative_expansion_actions_test.rb
@@ -90,6 +90,8 @@ class CreativeExpansionActionsTest < ApplicationSystemTestCase
     visit collavre.creative_comment_path(@child, comment)
 
     assert_selector "#comments-popup", visible: :visible, wait: 10
+    # Verify comment content loaded (not stuck on Loading...)
+    assert_text "Shared comment", wait: 10
     assert_selector "#comment_#{comment.id}[data-highlighted='true']", wait: 10
   end
 end


### PR DESCRIPTION
## Summary
- Add request versioning to `loadTopics()` so stale responses from concurrent calls are discarded
- Check topic **name** (not just ID) in `handleTopicMessage()` to prevent duplicate `#Main` topics when HTTP response and WebSocket broadcast race
- Assert comment content text in share link system test to catch "Loading..." stuck state

## Context
Comment share link test was intermittently failing with two `#Main` topics visible and chat stuck on "Loading...". Root cause: race between `loadTopics()` HTTP response and ActionCable WebSocket `TopicsChannel` broadcast — both could add a Main topic independently since the duplicate check only compared IDs, not names.

## Test plan
- [x] `bin/rails test engines/collavre/test/system/creative_expansion_actions_test.rb` — 5 tests pass, 10/10 stability runs
- [x] `bin/rails test engines/collavre/test/channels/topics_channel_test.rb` — passes
- [x] Full test suite — 1656 tests, 0 failures