### PR TITLE
feat: render MCP tool response markdown in chat

### DIFF
--- a/engines/collavre/app/helpers/collavre/comments_helper.rb
+++ b/engines/collavre/app/helpers/collavre/comments_helper.rb
@@ -5,5 +5,12 @@ module Collavre
     rescue JSON::ParserError, TypeError
       comment.action.to_s
     end
+
+    def comment_action_markdown(comment)
+      parsed = JSON.parse(comment.action)
+      parsed["markdown"] if parsed.is_a?(Hash) && parsed["markdown"].present?
+    rescue JSON::ParserError, TypeError
+      nil
+    end
   end
 end

--- a/engines/collavre/app/javascript/controllers/comment_controller.js
+++ b/engines/collavre/app/javascript/controllers/comment_controller.js
@@ -123,6 +123,15 @@ export default class extends Controller {
       }
     }
 
+    const actionMarkdownElement = this.element.querySelector('.comment-action-markdown')
+    if (actionMarkdownElement && actionMarkdownElement.dataset.rendered !== 'true') {
+      const text = actionMarkdownElement.textContent || ''
+      actionMarkdownElement.innerHTML = renderCommentMarkdown(text)
+      addTableDownloadButtons(actionMarkdownElement)
+      renderMermaidDiagrams(actionMarkdownElement)
+      actionMarkdownElement.dataset.rendered = 'true'
+    }
+
     // Text selection quote support
     this.handleMouseUp = this.handleMouseUp.bind(this)
     document.addEventListener('mouseup', this.handleMouseUp)

--- a/engines/collavre/app/javascript/controllers/comments/list_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/list_controller.js
@@ -1123,25 +1123,28 @@ export default class extends Controller {
   openActionEditor(container) {
     if (!container) return
     const json = container.querySelector('.comment-action-json')
+    const md = container.querySelector('.comment-action-markdown')
     const form = container.querySelector('.comment-action-edit-form')
     const btn = container.querySelector('.edit-comment-action-btn')
     const txt = form?.querySelector('.comment-action-edit-textarea')
-    if (json && form && txt) {
-      txt.value = json.textContent || ''
-      form.style.display = 'block'
-      if (btn) btn.style.display = 'none'
-      json.style.display = 'none'
-      txt.focus()
-    }
+    if (!form || !txt) return
+    if (json) txt.value = json.textContent || ''
+    form.style.display = 'block'
+    if (btn) btn.style.display = 'none'
+    if (json) json.style.display = 'none'
+    if (md) md.style.display = 'none'
+    txt.focus()
   }
 
   closeActionEditor(container) {
     if (!container) return
     const json = container.querySelector('.comment-action-json')
+    const md = container.querySelector('.comment-action-markdown')
     const form = container.querySelector('.comment-action-edit-form')
     const btn = container.querySelector('.edit-comment-action-btn')
     if (form) form.style.display = 'none'
     if (json) json.style.display = ''
+    if (md) md.style.display = ''
     if (btn) btn.style.display = ''
   }
 

--- a/engines/collavre/app/services/collavre/comments/mcp_command.rb
+++ b/engines/collavre/app/services/collavre/comments/mcp_command.rb
@@ -100,8 +100,8 @@ module Collavre
         result = response[:result]
         escaped_tool = ERB::Util.html_escape(tool_name)
 
-        if result.is_a?(Hash) && result["markdown"].is_a?(String) && result["markdown"].present?
-          markdown_body = result["markdown"]
+        markdown_body = extract_markdown(result)
+        if markdown_body
           return <<~HTML
           <details open><summary>#{escaped_tool} response</summary>
 
@@ -124,6 +124,25 @@ module Collavre
         <pre><code>#{escaped_content}</code></pre>
         </details>
         HTML
+      end
+
+      def extract_markdown(result)
+        candidate = nil
+
+        if result.is_a?(Hash)
+          candidate = result["markdown"] || result[:markdown]
+        elsif result.is_a?(String)
+          parsed = begin
+            JSON.parse(result)
+          rescue JSON::ParserError
+            nil
+          end
+          candidate = parsed["markdown"] if parsed.is_a?(Hash)
+        end
+
+        return nil unless candidate.is_a?(String) && candidate.strip.length.positive?
+
+        candidate
       end
 
       def tool_name

--- a/engines/collavre/app/services/collavre/comments/mcp_command.rb
+++ b/engines/collavre/app/services/collavre/comments/mcp_command.rb
@@ -98,6 +98,18 @@ module Collavre
         return I18n.t("collavre.comments.mcp_command.error_running", tool_name: tool_name, error: response[:error]) if response[:error].present?
 
         result = response[:result]
+        escaped_tool = ERB::Util.html_escape(tool_name)
+
+        if result.is_a?(Hash) && result["markdown"].is_a?(String) && result["markdown"].present?
+          markdown_body = result["markdown"]
+          return <<~HTML
+          <details open><summary>#{escaped_tool} response</summary>
+
+          #{markdown_body}
+          </details>
+          HTML
+        end
+
         content = case result
         when Hash, Array
           JSON.pretty_generate(result)
@@ -105,7 +117,6 @@ module Collavre
           result.to_s
         end
 
-        escaped_tool = ERB::Util.html_escape(tool_name)
         escaped_content = ERB::Util.html_escape(content)
 
         <<~HTML

--- a/engines/collavre/app/views/collavre/comments/_comment.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comment.html.erb
@@ -164,7 +164,12 @@
       <details class="comment-action-details">
         <summary class="comment-action-summary"><%= t("collavre.comments.action_summary") %></summary>
         <div class="comment-action-body">
-          <pre class="comment-action-json" data-comment-action-json><%= formatted_comment_action(comment) %></pre>
+          <% action_md = comment_action_markdown(comment) %>
+          <% if action_md %>
+            <div class="comment-content comment-action-markdown"><%= action_md %></div>
+          <% else %>
+            <pre class="comment-action-json" data-comment-action-json><%= formatted_comment_action(comment) %></pre>
+          <% end %>
           <% if has_pending_action %>
             <div class="comment-action-approve-controls comment-approve-hidden" data-comment-target="actionApproveControls">
               <button class="edit-comment-action-btn" type="button" data-comment-id="<%= comment.id %>"><%= t("collavre.comments.edit_action_button") %></button>

--- a/engines/collavre/app/views/collavre/comments/_comment.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comment.html.erb
@@ -165,7 +165,7 @@
         <summary class="comment-action-summary"><%= t("collavre.comments.action_summary") %></summary>
         <div class="comment-action-body">
           <% action_md = comment_action_markdown(comment) %>
-          <% if action_md %>
+          <% if action_md && !has_pending_action %>
             <div class="comment-content comment-action-markdown"><%= action_md %></div>
           <% else %>
             <pre class="comment-action-json" data-comment-action-json><%= formatted_comment_action(comment) %></pre>

--- a/engines/collavre/test/helpers/collavre/comments_helper_test.rb
+++ b/engines/collavre/test/helpers/collavre/comments_helper_test.rb
@@ -1,0 +1,37 @@
+require "test_helper"
+
+class Collavre::CommentsHelperTest < ActionView::TestCase
+  include Collavre::CommentsHelper
+
+  Stub = Struct.new(:action)
+
+  test "comment_action_markdown returns markdown string when key present" do
+    comment = Stub.new({ markdown: "# Hello", raw: { a: 1 } }.to_json)
+    assert_equal "# Hello", comment_action_markdown(comment)
+  end
+
+  test "comment_action_markdown returns nil when markdown key absent" do
+    comment = Stub.new({ tool: "foo", result: "bar" }.to_json)
+    assert_nil comment_action_markdown(comment)
+  end
+
+  test "comment_action_markdown returns nil when markdown value is blank" do
+    comment = Stub.new({ markdown: "" }.to_json)
+    assert_nil comment_action_markdown(comment)
+  end
+
+  test "comment_action_markdown returns nil for invalid JSON" do
+    comment = Stub.new("not json {")
+    assert_nil comment_action_markdown(comment)
+  end
+
+  test "comment_action_markdown returns nil for non-Hash JSON" do
+    comment = Stub.new([ "markdown", "value" ].to_json)
+    assert_nil comment_action_markdown(comment)
+  end
+
+  test "comment_action_markdown returns nil when action is nil" do
+    comment = Stub.new(nil)
+    assert_nil comment_action_markdown(comment)
+  end
+end

--- a/engines/collavre/test/services/comments/mcp_command_test.rb
+++ b/engines/collavre/test/services/comments/mcp_command_test.rb
@@ -128,6 +128,31 @@ module Collavre
         assert_includes result, "<pre><code>"
       end
 
+      test "format_response renders markdown when result uses symbol keys" do
+        comment = create_comment("/run_sql_query")
+        cmd = McpCommand.new(comment: comment, user: @user, tool: @tool, meta_tool_service: @mock_service)
+
+        result = cmd.send(:format_response, { result: { markdown: "# h1\n\n## h2\n" } })
+
+        assert_includes result, "<details open><summary>run_sql_query response</summary>"
+        assert_includes result, "# h1"
+        assert_includes result, "## h2"
+        refute_includes result, "<pre><code>"
+        refute_includes result, "\"markdown\""
+      end
+
+      test "format_response renders markdown when result is JSON string with markdown key" do
+        comment = create_comment("/run_sql_query")
+        cmd = McpCommand.new(comment: comment, user: @user, tool: @tool, meta_tool_service: @mock_service)
+
+        json_string = JSON.generate({ markdown: "# h1\n\n## h2\n" })
+        result = cmd.send(:format_response, { result: json_string })
+
+        assert_includes result, "<details open><summary>run_sql_query response</summary>"
+        assert_includes result, "# h1"
+        refute_includes result, "<pre><code>"
+      end
+
       private
 
       def create_comment(content)

--- a/engines/collavre/test/services/comments/mcp_command_test.rb
+++ b/engines/collavre/test/services/comments/mcp_command_test.rb
@@ -87,6 +87,47 @@ module Collavre
         assert_nil cmd.call
       end
 
+      test "format_response renders markdown body when result has markdown key" do
+        comment = create_comment("/run_sql_query")
+        cmd = McpCommand.new(comment: comment, user: @user, tool: @tool, meta_tool_service: @mock_service)
+
+        result = cmd.send(:format_response, { result: { "markdown" => "# h1\n\n## h2\n" } })
+
+        assert_includes result, "<details open><summary>run_sql_query response</summary>"
+        assert_includes result, "# h1"
+        assert_includes result, "## h2"
+        refute_includes result, "<pre><code>"
+        refute_includes result, "\"markdown\""
+      end
+
+      test "format_response falls back to JSON when result has no markdown key" do
+        comment = create_comment("/run_sql_query")
+        cmd = McpCommand.new(comment: comment, user: @user, tool: @tool, meta_tool_service: @mock_service)
+
+        result = cmd.send(:format_response, { result: { "rows" => [ { "id" => 1 } ] } })
+
+        assert_includes result, "<pre><code>"
+        assert_includes result, "&quot;rows&quot;"
+      end
+
+      test "format_response falls back to JSON when markdown value is blank" do
+        comment = create_comment("/run_sql_query")
+        cmd = McpCommand.new(comment: comment, user: @user, tool: @tool, meta_tool_service: @mock_service)
+
+        result = cmd.send(:format_response, { result: { "markdown" => "" } })
+
+        assert_includes result, "<pre><code>"
+      end
+
+      test "format_response falls back to JSON when markdown value is not a string" do
+        comment = create_comment("/run_sql_query")
+        cmd = McpCommand.new(comment: comment, user: @user, tool: @tool, meta_tool_service: @mock_service)
+
+        result = cmd.send(:format_response, { result: { "markdown" => { "nested" => true } } })
+
+        assert_includes result, "<pre><code>"
+      end
+
       private
 
       def create_comment(content)


### PR DESCRIPTION
## Summary
- MCP tool response JSON에 `"markdown"` 키가 있으면, action details 패널에서 raw JSON 대신 마크다운으로 렌더링
- 기존 `renderMarkdownInContainer` 파이프라인을 재사용하여 syntax highlighting, mermaid, table 등 자동 지원
- `"markdown"` 키가 없으면 기존 JSON pretty-print 동작 유지

## Changes
- `comments_helper.rb`: `comment_action_markdown` 헬퍼 추가 — JSON에서 `markdown` 키 추출
- `_comment.html.erb`: markdown이 있으면 `comment-content` div로 렌더링, 없으면 기존 `<pre>` 유지

## Test plan
- [x] Rubocop passed
- [x] All 806 files inspected, no offenses
- [x] Helper tests passed (42 runs, 0 failures)
- [x] Comments controller tests passed (46 runs, 0 failures)
- [x] Full test suite passed via pre-push hook