### PR TITLE
fix: prevent IDOR in creative_shares, invitations, and plans controllers

### DIFF
--- a/engines/collavre/app/controllers/collavre/creative_invitations_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creative_invitations_controller.rb
@@ -3,7 +3,6 @@
 module Collavre
   class CreativeInvitationsController < ApplicationController
     before_action :set_invitation
-    before_action :authorize_admin!
 
     def update
       if @invitation.update(permission: params[:permission])
@@ -29,18 +28,16 @@ module Collavre
 
     private
 
+    # Scoped lookup: only returns the invitation if Current.user has admin
+    # permission on its creative. Raises ActiveRecord::RecordNotFound otherwise
+    # so that record existence is not leaked to unauthorized users.
     def set_invitation
-      @invitation = Invitation.find(params[:id])
-      @creative = @invitation.creative
-    end
+      invitation = Invitation.find_by(id: params[:id])
+      creative = invitation&.creative
+      raise ActiveRecord::RecordNotFound unless creative&.has_permission?(Current.user, :admin)
 
-    def authorize_admin!
-      return if @creative.has_permission?(Current.user, :admin)
-
-      respond_to do |format|
-        format.html { redirect_back fallback_location: main_app.root_path, alert: t("collavre.creatives.errors.no_permission") }
-        format.json { render json: { error: t("collavre.creatives.errors.no_permission") }, status: :forbidden }
-      end
+      @invitation = invitation
+      @creative = creative
     end
   end
 end

--- a/engines/collavre/app/controllers/collavre/creative_shares_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creative_shares_controller.rb
@@ -107,14 +107,7 @@ module Collavre
     end
 
     def update
-      @creative_share = CreativeShare.find(params[:id])
-      unless @creative_share.creative.has_permission?(Current.user, :admin)
-        respond_to do |format|
-          format.html { redirect_back fallback_location: main_app.root_path, alert: t("collavre.creatives.errors.no_permission") }
-          format.json { render json: { error: t("collavre.creatives.errors.no_permission") }, status: :forbidden }
-        end
-        return
-      end
+      @creative_share = find_admin_creative_share(params[:id])
 
       if @creative_share.update(permission: params[:permission])
         respond_to do |format|
@@ -130,14 +123,7 @@ module Collavre
     end
 
     def destroy
-      @creative_share = CreativeShare.find(params[:id])
-      unless @creative_share.creative.has_permission?(Current.user, :admin)
-        respond_to do |format|
-          format.html { redirect_back fallback_location: main_app.root_path, alert: t("collavre.creatives.errors.no_permission") }
-          format.json { render json: { error: t("collavre.creatives.errors.no_permission") }, status: :forbidden }
-        end
-        return
-      end
+      @creative_share = find_admin_creative_share(params[:id])
 
       @creative_share.destroy
       # remove linked creative if it exists
@@ -150,6 +136,16 @@ module Collavre
     end
 
     private
+
+      # Scoped lookup: only returns the share if Current.user has admin permission
+      # on its creative. Raises ActiveRecord::RecordNotFound otherwise so that
+      # record existence is not leaked via 403 vs 404 distinction.
+      def find_admin_creative_share(id)
+        share = CreativeShare.find_by(id: id)
+        raise ActiveRecord::RecordNotFound unless share&.creative&.has_permission?(Current.user, :admin)
+
+        share
+      end
 
       def all_descendants(creative)
         creative.children.flat_map { |child| [ child ] + all_descendants(child) }

--- a/engines/collavre/test/controllers/creative_invitations_controller_test.rb
+++ b/engines/collavre/test/controllers/creative_invitations_controller_test.rb
@@ -1,0 +1,57 @@
+require "test_helper"
+
+class CreativeInvitationsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @owner = users(:one)
+    @other_user = users(:two)
+    @creative = creatives(:tshirt)
+    @invitation = Collavre::Invitation.create!(
+      email: "invitee@example.com",
+      inviter: @owner,
+      creative: @creative,
+      permission: :read
+    )
+  end
+
+  test "non-admin user gets 404 (not 403) when updating an invitation" do
+    sign_in_as(@other_user, password: "password")
+
+    patch collavre.creative_invitation_path(@creative, @invitation),
+          params: { permission: :write },
+          as: :json
+
+    assert_response :not_found
+    assert_equal "read", @invitation.reload.permission
+  end
+
+  test "non-admin user gets 404 (not 403) when destroying an invitation" do
+    sign_in_as(@other_user, password: "password")
+
+    assert_no_difference("Collavre::Invitation.count") do
+      delete collavre.creative_invitation_path(@creative, @invitation), as: :json
+    end
+
+    assert_response :not_found
+  end
+
+  test "admin can update invitation permission" do
+    sign_in_as(@owner, password: "password")
+
+    patch collavre.creative_invitation_path(@creative, @invitation),
+          params: { permission: :write },
+          as: :json
+
+    assert_response :ok
+    assert_equal "write", @invitation.reload.permission
+  end
+
+  test "admin can destroy invitation" do
+    sign_in_as(@owner, password: "password")
+
+    assert_difference("Collavre::Invitation.count", -1) do
+      delete collavre.creative_invitation_path(@creative, @invitation), as: :json
+    end
+
+    assert_response :no_content
+  end
+end

--- a/engines/collavre/test/controllers/creative_shares_controller_test.rb
+++ b/engines/collavre/test/controllers/creative_shares_controller_test.rb
@@ -61,6 +61,31 @@ class CreativeSharesControllerTest < ActionDispatch::IntegrationTest
     assert_equal I18n.t("collavre.creatives.share.shared"), flash[:notice]
   end
 
+  test "non-admin user gets 404 (not 403) when updating someone else's share" do
+    other_user = users(:two)
+    share = CreativeShare.create!(creative: @creative, user: @target_user, permission: :read, shared_by: @owner)
+
+    sign_in_as(other_user, password: "password")
+
+    patch collavre.creative_creative_share_path(@creative, share), params: { permission: :write }, as: :json
+
+    assert_response :not_found
+    assert_equal "read", share.reload.permission
+  end
+
+  test "non-admin user gets 404 (not 403) when destroying someone else's share" do
+    other_user = users(:two)
+    share = CreativeShare.create!(creative: @creative, user: @target_user, permission: :read, shared_by: @owner)
+
+    sign_in_as(other_user, password: "password")
+
+    assert_no_difference("CreativeShare.count") do
+      delete collavre.creative_creative_share_path(@creative, share), as: :json
+    end
+
+    assert_response :not_found
+  end
+
   test "anyone can share searchable AI agent" do
     # Create a searchable AI agent owned by @owner
     ai_agent = User.create!(

--- a/engines/collavre/test/controllers/org_chart_test.rb
+++ b/engines/collavre/test/controllers/org_chart_test.rb
@@ -188,7 +188,9 @@ class OrgChartTest < ActionDispatch::IntegrationTest
           headers: { "Accept" => "application/json" },
           as: :json
 
-    assert_response :forbidden
+    # Returns 404 rather than 403 to avoid leaking record existence to
+    # unauthorized users (IDOR hardening).
+    assert_response :not_found
     assert_equal "admin", @share_root.reload.permission
   end
 
@@ -303,7 +305,9 @@ class OrgChartTest < ActionDispatch::IntegrationTest
           headers: { "Accept" => "application/json" },
           as: :json
 
-    assert_response :forbidden
+    # Returns 404 rather than 403 to avoid leaking record existence to
+    # unauthorized users (IDOR hardening).
+    assert_response :not_found
     assert_equal "read", invitation.reload.permission
   ensure
     invitation&.destroy

--- a/engines/collavre_plan/app/controllers/collavre_plan/plans_controller.rb
+++ b/engines/collavre_plan/app/controllers/collavre_plan/plans_controller.rb
@@ -58,8 +58,8 @@ module CollavrePlan
     end
 
     def destroy
-      @plan = Collavre::Plan.find(params[:id])
-      return render_forbidden unless plan_editable_by_current_user?
+      @plan = Collavre::Plan.find_by(id: params[:id])
+      raise ActiveRecord::RecordNotFound unless @plan && plan_editable_by_current_user?
 
       @plan.destroy
       respond_to do |format|
@@ -72,8 +72,8 @@ module CollavrePlan
     end
 
     def update
-      @plan = Collavre::Plan.find(params[:id])
-      return render_forbidden unless plan_editable_by_current_user?
+      @plan = Collavre::Plan.find_by(id: params[:id])
+      raise ActiveRecord::RecordNotFound unless @plan && plan_editable_by_current_user?
 
       if @plan.update(plan_update_params)
         respond_to do |format|
@@ -117,18 +117,6 @@ module CollavrePlan
       return false unless @plan.tags.exists?(creative_id: tagged_creative.id)
 
       tagged_creative.has_permission?(Current.user, :write)
-    end
-
-    def render_forbidden
-      respond_to do |format|
-        format.html do
-          redirect_back fallback_location: main_app.root_path,
-                        alert: t("collavre.plans.update_forbidden", default: "You do not have permission to update this plan.")
-        end
-        format.json do
-          render json: { error: "forbidden" }, status: :forbidden
-        end
-      end
     end
 
     def plan_json(plan, creative_id: nil)

--- a/engines/collavre_plan/test/controllers/plans_controller_test.rb
+++ b/engines/collavre_plan/test/controllers/plans_controller_test.rb
@@ -161,6 +161,30 @@ class PlansControllerTest < ActionDispatch::IntegrationTest
     assert_equal new_target_date, plan.target_date
   end
 
+  test "user without edit permission gets 404 (not 403) when updating plan" do
+    creative = creatives(:tshirt)
+    plan = Plan.create!(target_date: Date.today, creative: creative, owner: @owner)
+
+    login_as(@collaborator)
+    patch collavre_plan_engine.plan_path(plan, format: :json),
+          params: { plan: { target_date: Date.tomorrow } }
+
+    assert_response :not_found
+    assert_equal Date.today, plan.reload.target_date
+  end
+
+  test "user without edit permission gets 404 (not 403) when destroying plan" do
+    creative = creatives(:tshirt)
+    plan = Plan.create!(target_date: Date.today, creative: creative, owner: @owner)
+
+    login_as(@collaborator)
+    assert_no_difference("Plan.count") do
+      delete collavre_plan_engine.plan_path(plan, format: :json)
+    end
+
+    assert_response :not_found
+  end
+
   test "should return stripped html in json" do
     creative = creatives(:tshirt)
     creative.update!(description: "<b>T-Shirt</b> <i>Design</i>")


### PR DESCRIPTION
## Summary

Three controllers looked up records by `params[:id]` and then performed a permission check, returning `403 Forbidden` when the user lacked admin/edit rights. This pattern leaks record existence — an unauthorized but authenticated user could probe IDs and distinguish "exists but no access" (403) from "does not exist" (404). The fix scopes lookups so unauthorized users receive `404 RecordNotFound` instead.

- `Collavre::CreativeSharesController#update` / `#destroy` — extracted a `find_admin_creative_share` helper that returns the share only when `Current.user` has `:admin` on its creative; raises `ActiveRecord::RecordNotFound` otherwise.
- `Collavre::CreativeInvitationsController#set_invitation` — inlined the admin check; raises `ActiveRecord::RecordNotFound` when the user lacks admin permission on the invitation's creative. Removed the now-redundant `authorize_admin!` before_action.
- `CollavrePlan::PlansController#update` / `#destroy` — switched to `find_by(id:)`, raising `ActiveRecord::RecordNotFound` when the plan is missing or the user cannot edit it. Removed the unused `render_forbidden` helper.

## Test plan

- [x] New controller tests for `CreativeSharesController`, `CreativeInvitationsController`, and `PlansController` asserting unauthorized users receive `:not_found` (not `:forbidden`) on `update` / `destroy`.
- [x] Updated existing `OrgChartTest` assertions that previously expected `:forbidden` on non-admin share/invitation updates to expect `:not_found`, with comments explaining the IDOR hardening.
- [x] `bin/rails test engines/collavre/test/controllers/creative_shares_controller_test.rb engines/collavre/test/controllers/creative_invitations_controller_test.rb engines/collavre/test/controllers/org_chart_test.rb engines/collavre_plan/test/controllers/plans_controller_test.rb` — 53 runs, 237 assertions, 0 failures, 0 errors.
- [x] `bin/rubocop` on all changed files — 0 offenses.