### PR TITLE
Auto-verify email when password is reset

### DIFF
--- a/engines/collavre/app/controllers/collavre/passwords_controller.rb
+++ b/engines/collavre/app/controllers/collavre/passwords_controller.rb
@@ -20,6 +20,7 @@ module Collavre
 
     def update
       if @user.update(params.permit(:password, :password_confirmation))
+        @user.update_column(:email_verified_at, Time.current) unless @user.email_verified?
         redirect_to new_session_path, notice: "Password has been reset."
       else
         redirect_to edit_password_path(params[:token]), alert: "Passwords did not match."


### PR DESCRIPTION
## Summary
When a user successfully resets their password, their email is now automatically marked as verified if it hasn't been already.

## Key Changes
- Added automatic email verification upon successful password reset in the `PasswordsController#update` action
- Email is only marked as verified if the user hasn't already verified their email address

## Implementation Details
- Uses `update_column` to directly update the `email_verified_at` timestamp to the current time
- The verification only occurs when the password update is successful and the email is not already verified
- This allows users who reset their password via email link to have their email implicitly verified, as they've demonstrated access to that email address

https://claude.ai/code/session_01TxYpdREYKutye8u5APXurz