### PR TITLE
feat(channels): GitHub PR comment listener via Channel abstraction

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_16_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_26_000000) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false
@@ -75,6 +75,20 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_16_000000) do
     t.index ["creative_id"], name: "index_calendar_events_on_creative_id"
     t.index ["google_event_id"], name: "index_calendar_events_on_google_event_id", unique: true
     t.index ["user_id"], name: "index_calendar_events_on_user_id"
+  end
+
+  create_table "channels", force: :cascade do |t|
+    t.json "config", default: {}, null: false
+    t.datetime "created_at", null: false
+    t.datetime "last_event_at"
+    t.string "latest_label"
+    t.string "latest_link"
+    t.integer "state", default: 0, null: false
+    t.integer "topic_id", null: false
+    t.string "type", null: false
+    t.datetime "updated_at", null: false
+    t.index ["topic_id"], name: "index_channels_on_topic_id"
+    t.index ["type"], name: "index_channels_on_type"
   end
 
   create_table "comment_reactions", force: :cascade do |t|
@@ -815,6 +829,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_16_000000) do
   add_foreign_key "activity_logs", "users"
   add_foreign_key "calendar_events", "creatives"
   add_foreign_key "calendar_events", "users"
+  add_foreign_key "channels", "topics"
   add_foreign_key "comment_reactions", "comments"
   add_foreign_key "comment_reactions", "users"
   add_foreign_key "comment_read_pointers", "creatives"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -87,6 +87,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_26_000000) do
     t.integer "topic_id", null: false
     t.string "type", null: false
     t.datetime "updated_at", null: false
+    t.index "type, topic_id, json_extract(config, '$.repo_full_name'), json_extract(config, '$.pr_number')", name: "index_channels_on_type_topic_repo_pr", unique: true
     t.index ["topic_id"], name: "index_channels_on_topic_id"
     t.index ["type"], name: "index_channels_on_type"
   end

--- a/engines/collavre/app/channels/collavre/comments_presence_channel.rb
+++ b/engines/collavre/app/channels/collavre/comments_presence_channel.rb
@@ -1,5 +1,12 @@
 module Collavre
 class CommentsPresenceChannel < ApplicationCable::Channel
+  def self.broadcast_channel_chips_changed(creative_id, topic_id:)
+    ActionCable.server.broadcast(
+      "comments_presence:#{creative_id}",
+      { channel_chips: { topic_id: topic_id } }
+    )
+  end
+
   def self.broadcast_shares_changed(creative_id, shared_user_id:, permission: nil, action: "updated", has_access: nil, can_comment: nil, has_access_changed: nil, can_comment_changed: nil)
     ActionCable.server.broadcast(
       "comments_presence:#{creative_id}",

--- a/engines/collavre/app/controllers/collavre/channels_controller.rb
+++ b/engines/collavre/app/controllers/collavre/channels_controller.rb
@@ -1,6 +1,9 @@
 module Collavre
   class ChannelsController < ApplicationController
+    include Collavre::CreativePermissionGuard
+
     before_action :set_channel
+    before_action :require_creative_write!
 
     def destroy
       @channel.detach!
@@ -11,6 +14,7 @@ module Collavre
 
     def set_channel
       @channel = Channel.active.find(params[:id])
+      @creative = @channel.topic.creative.effective_origin
     end
   end
 end

--- a/engines/collavre/app/controllers/collavre/channels_controller.rb
+++ b/engines/collavre/app/controllers/collavre/channels_controller.rb
@@ -1,0 +1,16 @@
+module Collavre
+  class ChannelsController < ApplicationController
+    before_action :set_channel
+
+    def destroy
+      @channel.detach!
+      head :no_content
+    end
+
+    private
+
+    def set_channel
+      @channel = Channel.active.find(params[:id])
+    end
+  end
+end

--- a/engines/collavre/app/controllers/collavre/topics_controller.rb
+++ b/engines/collavre/app/controllers/collavre/topics_controller.rb
@@ -3,7 +3,7 @@ module Collavre
     include Collavre::CreativePermissionGuard
 
     before_action :set_creative
-    before_action :require_creative_read!, only: %i[next_name]
+    before_action :require_creative_read!, only: %i[next_name channel_chips]
     before_action :require_creative_admin!, only: %i[update destroy move reorder]
     before_action :require_creative_write!, only: %i[create archive unarchive set_primary_agent]
 
@@ -71,6 +71,11 @@ module Collavre
 
     def next_name
       render json: { name: generate_next_topic_name }
+    end
+
+    def channel_chips
+      topic = @creative.topics.find(params[:id])
+      render partial: "collavre/comments/channel_chips", locals: { topic: topic }
     end
 
     def update

--- a/engines/collavre/app/javascript/controllers/comments/presence_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/presence_controller.js
@@ -68,6 +68,23 @@ export default class extends Controller {
     this.subscribe()
     this.renderParticipants([])
     this.renderTypingIndicator()
+    // Bootstrap chips for the topic that is already active when the popup opens.
+    // Without this, chips only appear after a `topics:change` event fires
+    // (i.e. a topic switch) or after a webhook arrives — leaving the user
+    // unable to detach existing channels until something else triggers a paint.
+    this.bootstrapChannelChips()
+  }
+
+  bootstrapChannelChips() {
+    const topicsCtrl = this.application.getControllerForElementAndIdentifier(
+      this.element, 'comments--topics'
+    )
+    const topicId = topicsCtrl?.currentTopicId
+    if (topicId) {
+      this.refreshChannelChips(topicId)
+    } else {
+      this.clearChannelChips()
+    }
   }
 
   onPopupClosed() {

--- a/engines/collavre/app/javascript/controllers/comments/presence_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/presence_controller.js
@@ -7,7 +7,7 @@ const TYPING_TIMEOUT = 3000
 const AGENT_STATUS_TIMEOUT = 10000 // Safety timeout for agent_status (heartbeat expected every 3s)
 
 export default class extends Controller {
-  static targets = ['participants', 'typingIndicator', 'textarea', 'privateCheckbox']
+  static targets = ['participants', 'typingIndicator', 'textarea', 'privateCheckbox', 'channelChips']
 
   connect() {
     this.creativeId = null
@@ -200,6 +200,9 @@ export default class extends Controller {
 
       this.loadParticipants({ closeOnForbidden: shareChange.has_access === false })
       return
+    }
+    if (data.channel_chips) {
+      this.refreshChannelChips(data.channel_chips.topic_id)
     }
     if (data.agent_status) {
       const { id, name, status, task_id, creative_id: agentCreativeId } = data.agent_status
@@ -415,6 +418,33 @@ export default class extends Controller {
         }
       })
       .catch((err) => console.warn('[presence] cancel agent task failed:', err))
+  }
+
+  refreshChannelChips(topicId) {
+    const target = this.hasChannelChipsTarget ? this.channelChipsTarget : null
+    if (!target) return
+    const currentTopic = target.dataset.topicId
+    if (currentTopic && String(currentTopic) !== String(topicId)) return
+    if (!this.creativeId) return
+    fetch(`/creatives/${this.creativeId}/topics/${topicId}/channel_chips`, {
+      headers: { Accept: 'text/html' },
+      credentials: 'same-origin',
+    })
+      .then((r) => (r.ok ? r.text() : null))
+      .then((html) => {
+        if (html) target.outerHTML = html
+      })
+      .catch((err) => console.warn('[presence] refresh channel chips failed:', err))
+  }
+
+  detachChannel(event) {
+    const btn = event.currentTarget
+    const id = btn.dataset.channelId
+    if (!id) return
+    csrfFetch(`/channels/${id}`, {
+      method: 'DELETE',
+      headers: { Accept: 'application/json' },
+    }).catch((err) => console.warn('[presence] detach channel failed:', err))
   }
 
   clearTypingTimers() {

--- a/engines/collavre/app/javascript/controllers/comments/presence_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/presence_controller.js
@@ -423,9 +423,21 @@ export default class extends Controller {
   refreshChannelChips(topicId) {
     const target = this.hasChannelChipsTarget ? this.channelChipsTarget : null
     if (!target) return
-    const currentTopic = target.dataset.topicId
-    if (currentTopic && String(currentTopic) !== String(topicId)) return
     if (!this.creativeId) return
+
+    // Source of truth for "what the user is looking at" is the topics
+    // controller's currentTopicId, NOT the chip container's data-topic-id:
+    // - On initial popup open the container is empty (no data-topic-id),
+    //   so a stray broadcast for any topic in the same creative used to
+    //   paint chips for the wrong topic.
+    // - After the user switches topics the container's data-topic-id is
+    //   stale until something repaints it, blocking legit updates.
+    const topicsCtrl = this.application.getControllerForElementAndIdentifier(
+      this.element, 'comments--topics'
+    )
+    const activeTopicId = topicsCtrl?.currentTopicId || ''
+    if (String(activeTopicId) !== String(topicId)) return
+
     fetch(`/creatives/${this.creativeId}/topics/${topicId}/channel_chips`, {
       headers: { Accept: 'text/html' },
       credentials: 'same-origin',

--- a/engines/collavre/app/javascript/controllers/comments/presence_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/presence_controller.js
@@ -24,11 +24,13 @@ export default class extends Controller {
     this.handleInput = this.handleInput.bind(this)
     this.handleFocus = this.handleFocus.bind(this)
     this.handleBlur = this.handleBlur.bind(this)
+    this.handleTopicChange = this.handleTopicChange.bind(this)
 
     this.textareaTarget.addEventListener('input', this.handleInput)
     this.textareaTarget.addEventListener('focus', this.handleFocus)
     this.textareaTarget.addEventListener('blur', this.handleBlur)
     this.privateCheckboxTarget?.addEventListener('change', () => this.stoppedTyping())
+    this.element.addEventListener('comments--topics:change', this.handleTopicChange)
   }
 
   disconnect() {
@@ -36,6 +38,16 @@ export default class extends Controller {
     this.textareaTarget.removeEventListener('input', this.handleInput)
     this.textareaTarget.removeEventListener('focus', this.handleFocus)
     this.textareaTarget.removeEventListener('blur', this.handleBlur)
+    this.element.removeEventListener('comments--topics:change', this.handleTopicChange)
+  }
+
+  handleTopicChange(event) {
+    const topicId = event.detail?.topicId
+    if (topicId) {
+      this.refreshChannelChips(topicId)
+    } else {
+      this.clearChannelChips()
+    }
   }
 
   get listController() {
@@ -420,10 +432,21 @@ export default class extends Controller {
       .catch((err) => console.warn('[presence] cancel agent task failed:', err))
   }
 
+  clearChannelChips() {
+    const target = this.hasChannelChipsTarget ? this.channelChipsTarget : null
+    if (!target) return
+    target.innerHTML = ''
+    delete target.dataset.topicId
+  }
+
   refreshChannelChips(topicId) {
     const target = this.hasChannelChipsTarget ? this.channelChipsTarget : null
     if (!target) return
     if (!this.creativeId) return
+    if (!topicId) {
+      this.clearChannelChips()
+      return
+    }
 
     // Source of truth for "what the user is looking at" is the topics
     // controller's currentTopicId, NOT the chip container's data-topic-id:

--- a/engines/collavre/app/models/collavre/channel.rb
+++ b/engines/collavre/app/models/collavre/channel.rb
@@ -33,5 +33,14 @@ module Collavre
         comment
       end
     end
+
+    after_create_commit  :broadcast_chips_changed
+    after_update_commit  :broadcast_chips_changed
+
+    private
+
+    def broadcast_chips_changed
+      Collavre::CommentsPresenceChannel.broadcast_channel_chips_changed(topic.creative_id, topic_id: topic_id)
+    end
   end
 end

--- a/engines/collavre/app/models/collavre/channel.rb
+++ b/engines/collavre/app/models/collavre/channel.rb
@@ -1,5 +1,8 @@
 module Collavre
   class Channel < ApplicationRecord
+    BOT_EMAIL = "channel@collavre.local"
+    BOT_NAME = "Channel"
+
     self.table_name = "channels"
 
     belongs_to :topic, class_name: "Collavre::Topic"

--- a/engines/collavre/app/models/collavre/channel.rb
+++ b/engines/collavre/app/models/collavre/channel.rb
@@ -1,0 +1,21 @@
+module Collavre
+  class Channel < ApplicationRecord
+    self.table_name = "channels"
+
+    belongs_to :topic, class_name: "Collavre::Topic"
+
+    enum :state, { active: 0, detached: 1 }, default: :active
+
+    def handle(event:, payload:)
+      raise NotImplementedError, "#{self.class} must implement #handle"
+    end
+
+    def detach!
+      update!(state: :detached)
+    end
+
+    def record_event!(label:, link:)
+      update!(latest_label: label, latest_link: link, last_event_at: Time.current)
+    end
+  end
+end

--- a/engines/collavre/app/models/collavre/channel.rb
+++ b/engines/collavre/app/models/collavre/channel.rb
@@ -17,5 +17,18 @@ module Collavre
     def record_event!(label:, link:)
       update!(latest_label: label, latest_link: link, last_event_at: Time.current)
     end
+
+    def inject_into_topic!(injected_message)
+      transaction do
+        comment = topic.creative.comments.create!(
+          user: injected_message.speaker,
+          topic_id: topic.id,
+          content: injected_message.message,
+          private: false
+        )
+        record_event!(label: injected_message.label, link: injected_message.link)
+        comment
+      end
+    end
   end
 end

--- a/engines/collavre/app/models/collavre/channel/injected_message.rb
+++ b/engines/collavre/app/models/collavre/channel/injected_message.rb
@@ -1,0 +1,5 @@
+module Collavre
+  class Channel
+    InjectedMessage = Data.define(:speaker, :message, :label, :link)
+  end
+end

--- a/engines/collavre/app/models/collavre/topic.rb
+++ b/engines/collavre/app/models/collavre/topic.rb
@@ -7,6 +7,7 @@ module Collavre
     belongs_to :source_topic, class_name: "Collavre::Topic", optional: true
 
     has_many :comments, class_name: "Collavre::Comment", dependent: :destroy
+    has_many :channels, class_name: "Collavre::Channel", dependent: :destroy
     has_many :branches, class_name: "Collavre::Topic", foreign_key: :source_topic_id, dependent: :nullify
     has_many :user_creative_preferences_as_last_topic, class_name: "Collavre::UserCreativePreference",
              foreign_key: :last_topic_id, dependent: :nullify, inverse_of: :last_topic

--- a/engines/collavre/app/views/collavre/comments/_channel_chips.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_channel_chips.html.erb
@@ -1,0 +1,18 @@
+<%# locals: { topic: Collavre::Topic } %>
+<div class="channel-chips" data-comments--presence-target="channelChips" data-topic-id="<%= topic.id %>">
+  <% topic.channels.active.each do |channel| %>
+    <span class="channel-chip" data-channel-id="<%= channel.id %>">
+      <% if channel.latest_link.present? %>
+        <a href="<%= channel.latest_link %>" target="_blank" rel="noopener">
+          <%= channel.latest_label.presence || channel.class.name.demodulize %>
+        </a>
+      <% else %>
+        <%= channel.latest_label.presence || channel.class.name.demodulize %>
+      <% end %>
+      <button type="button"
+              data-action="comments--presence#detachChannel"
+              data-channel-id="<%= channel.id %>"
+              aria-label="<%= t('collavre.channels.detach', default: 'Detach') %>">&times;</button>
+    </span>
+  <% end %>
+</div>

--- a/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
@@ -120,6 +120,7 @@
   <div id="comments-list" data-comments--popup-target="list" data-comments--list-target="list"><%= t('app.loading') %></div>
   <div id="typing-indicator-row">
     <button type="button" id="scroll-prev-msg-btn" class="scroll-prev-msg-btn" data-action="click->comments--list#scrollToPreviousMessage" title="<%= t('collavre.comments.scroll_to_prev', default: 'Previous message') %>" aria-label="<%= t('collavre.comments.scroll_to_prev', default: 'Previous message') %>">&#8963;</button>
+    <div id="channel-chips-container" data-comments--presence-target="channelChips"></div>
     <div id="typing-indicator" data-comments--presence-target="typingIndicator" data-comments--popup-target="typingIndicator" data-stop-agent-text="<%= t('collavre.comments.stop_agent') %>"></div>
   </div>
   <form id="new-comment-form" data-comments--popup-target="form" data-comments--form-target="form" style="display:none;">

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -211,6 +211,8 @@ en:
         delete: Delete
         delete_confirm: Delete this image?
         counter: "%{current} / %{total}"
+    channels:
+      detach: "Detach"
     calendar_events:
       deleted: Calendar event deleted.
     google_calendar:

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -208,6 +208,8 @@ ko:
         delete: 삭제
         delete_confirm: 이 이미지를 삭제하시겠습니까?
         counter: "%{current} / %{total}"
+    channels:
+      detach: "해제"
     calendar_events:
       deleted: 캘린더 이벤트가 삭제되었습니다.
     google_calendar:

--- a/engines/collavre/config/routes.rb
+++ b/engines/collavre/config/routes.rb
@@ -30,6 +30,7 @@ Collavre::Engine.routes.draw do
   delete "/attachments/:signed_id", to: "attachments#destroy", as: :attachment
 
   resources :calendar_events, only: [ :destroy ]
+  resources :channels, only: [ :destroy ]
   resources :contacts, only: [ :destroy ]
   resources :devices, only: [ :create ]
 

--- a/engines/collavre/config/routes.rb
+++ b/engines/collavre/config/routes.rb
@@ -59,6 +59,7 @@ Collavre::Engine.routes.draw do
         get :next_name
       end
       member do
+        get :channel_chips
         patch :move
         patch :archive
         patch :unarchive

--- a/engines/collavre/db/migrate/20260526000000_create_channels.rb
+++ b/engines/collavre/db/migrate/20260526000000_create_channels.rb
@@ -1,5 +1,5 @@
 class CreateChannels < ActiveRecord::Migration[8.1]
-  def change
+  def up
     postgres = connection.adapter_name == "PostgreSQL"
 
     create_table :channels do |t|
@@ -20,8 +20,23 @@ class CreateChannels < ActiveRecord::Migration[8.1]
     if postgres
       add_index :channels, :config, using: :gin
       add_index :channels, :type
+      # Concurrent webhook safety: a single PR may emit pull_request.opened twice
+      # back-to-back (or auto-attach can race with pr_monitor). Without this
+      # constraint, the dispatch loop would inject every event N times.
+      execute <<~SQL
+        CREATE UNIQUE INDEX index_channels_on_type_topic_repo_pr
+        ON channels (type, topic_id, (config->>'repo_full_name'), (config->>'pr_number'))
+      SQL
     else
       add_index :channels, :type
+      execute <<~SQL
+        CREATE UNIQUE INDEX index_channels_on_type_topic_repo_pr
+        ON channels (type, topic_id, json_extract(config, '$.repo_full_name'), json_extract(config, '$.pr_number'))
+      SQL
     end
+  end
+
+  def down
+    drop_table :channels
   end
 end

--- a/engines/collavre/db/migrate/20260526000000_create_channels.rb
+++ b/engines/collavre/db/migrate/20260526000000_create_channels.rb
@@ -1,0 +1,27 @@
+class CreateChannels < ActiveRecord::Migration[8.1]
+  def change
+    postgres = connection.adapter_name == "PostgreSQL"
+
+    create_table :channels do |t|
+      t.string :type, null: false
+      t.references :topic, null: false, foreign_key: { to_table: :topics }, index: true
+      if postgres
+        t.jsonb :config, null: false, default: {}
+      else
+        t.json :config, null: false, default: {}
+      end
+      t.integer :state, null: false, default: 0
+      t.string :latest_label
+      t.string :latest_link
+      t.datetime :last_event_at
+      t.timestamps
+    end
+
+    if postgres
+      add_index :channels, :config, using: :gin
+      add_index :channels, :type
+    else
+      add_index :channels, :type
+    end
+  end
+end

--- a/engines/collavre/db/seeds.rb
+++ b/engines/collavre/db/seeds.rb
@@ -1,0 +1,20 @@
+module Collavre
+  module ChannelBotSeed
+    EMAIL = "channel@collavre.local"
+    NAME = "Channel"
+
+    def self.call
+      user = User.find_or_initialize_by(email: EMAIL)
+      user.name = NAME
+      user.password = SecureRandom.hex(32) if user.new_record?
+      user.email_verified_at ||= Time.current
+      user.searchable = false if user.respond_to?(:searchable=)
+      user.llm_vendor = nil
+      user.save!
+      Rails.logger.info "[Collavre] Channel bot user ensured: #{EMAIL}"
+      user
+    end
+  end
+end
+
+Collavre::ChannelBotSeed.call

--- a/engines/collavre/db/seeds.rb
+++ b/engines/collavre/db/seeds.rb
@@ -1,17 +1,16 @@
 module Collavre
   module ChannelBotSeed
-    EMAIL = "channel@collavre.local"
-    NAME = "Channel"
-
     def self.call
-      user = User.find_or_initialize_by(email: EMAIL)
-      user.name = NAME
+      email = Channel::BOT_EMAIL
+      name  = Channel::BOT_NAME
+      user = User.find_or_initialize_by(email: email)
+      user.name = name
       user.password = SecureRandom.hex(32) if user.new_record?
       user.email_verified_at ||= Time.current
       user.searchable = false if user.respond_to?(:searchable=)
       user.llm_vendor = nil
       user.save!
-      Rails.logger.info "[Collavre] Channel bot user ensured: #{EMAIL}"
+      Rails.logger.info "[Collavre] Channel bot user ensured: #{email}"
       user
     end
   end

--- a/engines/collavre/test/controllers/collavre/channels_controller_test.rb
+++ b/engines/collavre/test/controllers/collavre/channels_controller_test.rb
@@ -30,5 +30,15 @@ module Collavre
       delete collavre.channel_path(id: 999_999)
       assert_response :not_found
     end
+
+    test "destroy returns 403 when user lacks write permission on creative" do
+      other_user = users(:two)
+      sign_out
+      sign_in_as(other_user, password: "password")
+
+      delete collavre.channel_path(@channel)
+      assert_response :forbidden
+      assert_predicate @channel.reload, :active?
+    end
   end
 end

--- a/engines/collavre/test/controllers/collavre/channels_controller_test.rb
+++ b/engines/collavre/test/controllers/collavre/channels_controller_test.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  class ChannelsControllerTest < ActionDispatch::IntegrationTest
+    setup do
+      @user = users(:one)
+      Collavre::Current.user = @user
+      @creative = Creative.create!(description: "Test Creative", user: @user)
+      @topic = Topic.create!(name: "Channel Topic", creative: @creative, user: @user)
+      @channel = Channel.create!(topic: @topic, type: "Collavre::Channel")
+      sign_in_as(@user, password: "password")
+    end
+
+    test "destroy detaches channel and returns 204" do
+      delete collavre.channel_path(@channel)
+      assert_response :no_content
+      assert_predicate @channel.reload, :detached?
+    end
+
+    test "destroy returns 404 when channel already detached" do
+      @channel.detach!
+
+      delete collavre.channel_path(@channel)
+      assert_response :not_found
+    end
+
+    test "destroy returns 404 when channel id does not exist" do
+      delete collavre.channel_path(id: 999_999)
+      assert_response :not_found
+    end
+  end
+end

--- a/engines/collavre/test/fixtures/users.yml
+++ b/engines/collavre/test/fixtures/users.yml
@@ -30,3 +30,10 @@ ai_bot:
   llm_model: gemini-1.5-flash
   system_prompt: "You are a bot."
   searchable: false
+
+channel_bot:
+  email: channel@collavre.local
+  password_digest: <%= password_digest %>
+  name: Channel
+  system_admin: false
+  searchable: false

--- a/engines/collavre/test/models/collavre/channel_bot_seed_test.rb
+++ b/engines/collavre/test/models/collavre/channel_bot_seed_test.rb
@@ -1,0 +1,12 @@
+require "test_helper"
+
+module Collavre
+  class ChannelBotSeedTest < ActiveSupport::TestCase
+    test "channel bot user exists and is not an ai_user" do
+      bot = User.find_by(email: "channel@collavre.local")
+      assert bot, "Channel bot user must exist"
+      refute_predicate bot, :ai_user?
+      assert_equal "Channel", bot.name
+    end
+  end
+end

--- a/engines/collavre/test/models/collavre/channel_injection_test.rb
+++ b/engines/collavre/test/models/collavre/channel_injection_test.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  class ChannelInjectionTest < ActiveSupport::TestCase
+    setup do
+      @user = users(:one)
+      Collavre::Current.user = @user
+
+      @creative = Creative.create!(description: "Test Creative", user: @user)
+      @topic = Topic.create!(name: "Channel Topic", creative: @creative, user: @user)
+      @channel = Channel.create!(topic: @topic, type: "Collavre::Channel")
+      @bot = User.find_by!(email: "channel@collavre.local")
+      @msg = Channel::InjectedMessage.new(
+        speaker: @bot,
+        message: "hello from PR",
+        label: "PR #42",
+        link: "https://github.com/owner/repo/pull/42"
+      )
+    end
+
+    test "inject_into_topic! creates a comment authored by the speaker" do
+      assert_difference -> { Comment.where(creative_id: @creative.id).count }, 1 do
+        @channel.inject_into_topic!(@msg)
+      end
+      comment = Comment.where(creative_id: @creative.id).last
+      assert_equal "hello from PR", comment.content
+      assert_equal "channel@collavre.local", comment.user.email
+      assert_equal @topic.id, comment.topic_id
+      assert_equal @creative.id, comment.creative_id
+    end
+
+    test "inject_into_topic! caches label and link on channel" do
+      @channel.inject_into_topic!(@msg)
+      @channel.reload
+      assert_equal "PR #42", @channel.latest_label
+      assert_equal "https://github.com/owner/repo/pull/42", @channel.latest_link
+      assert_not_nil @channel.last_event_at
+    end
+  end
+end

--- a/engines/collavre/test/models/collavre/channel_test.rb
+++ b/engines/collavre/test/models/collavre/channel_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  class ChannelTest < ActiveSupport::TestCase
+    setup do
+      @user = users(:one)
+      Collavre::Current.user = @user
+      @creative = Creative.create!(description: "Test Creative", user: @user)
+      @topic = Topic.create!(name: "Channel Topic", creative: @creative, user: @user)
+    end
+
+    test "belongs to topic and defaults to active state" do
+      channel = Channel.new(topic: @topic, type: "Collavre::Channel")
+      assert channel.valid?
+      assert_predicate channel, :active?
+    end
+
+    test "detach! flips state" do
+      channel = Channel.create!(topic: @topic, type: "Collavre::Channel")
+      channel.detach!
+      assert_predicate channel, :detached?
+    end
+
+    test "handle raises NotImplementedError on base class" do
+      channel = Channel.new(topic: @topic)
+      assert_raises(NotImplementedError) { channel.handle(event: "x", payload: {}) }
+    end
+
+    test "InjectedMessage holds speaker, message, label, link" do
+      msg = Channel::InjectedMessage.new(speaker: @user, message: "hi", label: "PR #1", link: "http://x")
+      assert_equal @user, msg.speaker
+      assert_equal "PR #1", msg.label
+    end
+  end
+end

--- a/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
+++ b/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
@@ -21,12 +21,44 @@ module CollavreGithub
         trigger_markdown_sync_for(link, event, payload) if link.markdown_sync_enabled?
       end
 
+      dispatch_to_channels(event, payload)
+
       head :ok
     rescue JSON::ParserError
       head :bad_request
     end
 
     private
+
+    def dispatch_to_channels(event, payload)
+      repo = payload.dig("repository", "full_name")
+      pr_number = extract_pr_number(event, payload)
+      return if repo.blank? || pr_number.nil?
+
+      # Ruby-level filter for DB portability (SQLite dev/test, Postgres prod).
+      # Future optimization: switch to a jsonb-portable query once an established
+      # pattern exists in this codebase.
+      GithubPrChannel.active.find_each do |channel|
+        next unless channel.repo_full_name == repo && channel.pr_number == pr_number
+
+        injected = channel.handle(event: event, payload: payload)
+        next if injected.nil?
+
+        channel.inject_into_topic!(injected)
+      end
+    rescue => e
+      Rails.logger.error("[CollavreGithub] channel dispatch failed: #{e.class}: #{e.message}")
+    end
+
+    def extract_pr_number(event, payload)
+      case event
+      when "issue_comment"
+        n = payload.dig("issue", "number")
+        n if payload.dig("issue", "pull_request")
+      when "pull_request_review_comment", "pull_request_review", "pull_request"
+        payload.dig("pull_request", "number")
+      end
+    end
 
     def create_system_comment_for(link, event, payload)
       creative = link.creative&.effective_origin

--- a/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
+++ b/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
@@ -42,8 +42,20 @@ module CollavreGithub
       topic = Collavre::Topic.find_by(id: topic_id)
       return unless topic
 
+      # Security: the PR description is attacker-controlled. Anyone able to open
+      # a PR on this repo could otherwise drop a link to an unrelated tenant's
+      # topic and have subsequent PR comments injected there. Only auto-attach
+      # when the topic's creative is actually linked to this repo.
+      linked_creative_ids = CollavreGithub::RepositoryLink
+        .where(repository_full_name: repo).pluck(:creative_id)
+      return unless linked_creative_ids.include?(topic.creative_id)
+
       existing = GithubPrChannel.where(topic_id: topic.id).find { |c| c.repo_full_name == repo && c.pr_number == pr_number }
-      existing || GithubPrChannel.create!(
+      if existing
+        existing.update!(state: :active) unless existing.active?
+        return existing
+      end
+      GithubPrChannel.create!(
         topic_id: topic.id,
         config: { "repo_full_name" => repo, "pr_number" => pr_number }
       )

--- a/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
+++ b/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
@@ -79,6 +79,14 @@ module CollavreGithub
       pr_number = extract_pr_number(event, payload)
       return if repo.blank? || pr_number.nil?
 
+      # Re-resolve which creatives are linked to this repo on every dispatch.
+      # The auto-attach guard validated the link at creation time, but a
+      # RepositoryLink can be removed or a topic can be moved to a different
+      # creative subtree after attachment. Without re-validating here, an
+      # orphaned channel would keep receiving cross-tenant PR events.
+      linked_creative_ids = CollavreGithub::RepositoryLink
+        .where("LOWER(repository_full_name) = ?", repo).pluck(:creative_id)
+
       # Ruby-level filter for DB portability (SQLite dev/test, Postgres prod).
       # Future optimization: switch to a jsonb-portable query once an established
       # pattern exists in this codebase. Compare repo names case-insensitively
@@ -86,6 +94,7 @@ module CollavreGithub
       # payload value.
       GithubPrChannel.active.find_each do |channel|
         next unless channel.repo_full_name.to_s.downcase == repo && channel.pr_number == pr_number
+        next unless channel_in_repo_scope?(channel, linked_creative_ids)
 
         begin
           injected = channel.handle(event: event, payload: payload)
@@ -103,6 +112,20 @@ module CollavreGithub
           )
         end
       end
+    end
+
+    # A channel is in-scope iff its topic's creative — or any ancestor — is
+    # still listed in a RepositoryLink for the webhook's repo. Mirrors the
+    # auto-attach guard so removing a link severs the dispatch, not just the
+    # ability to create new monitors.
+    def channel_in_repo_scope?(channel, linked_creative_ids)
+      return false if linked_creative_ids.empty?
+
+      creative = channel.topic&.creative
+      return false unless creative
+
+      candidate_ids = [ creative.id ] + creative.ancestors.pluck(:id)
+      (linked_creative_ids & candidate_ids).any?
     end
 
     def extract_pr_number(event, payload)

--- a/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
+++ b/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
@@ -45,10 +45,14 @@ module CollavreGithub
       # Security: the PR description is attacker-controlled. Anyone able to open
       # a PR on this repo could otherwise drop a link to an unrelated tenant's
       # topic and have subsequent PR comments injected there. Only auto-attach
-      # when the topic's creative is actually linked to this repo.
+      # when the topic's creative — or any of its ancestors — is linked to this
+      # repo (RepositoryLink applies to the whole subtree).
       linked_creative_ids = CollavreGithub::RepositoryLink
         .where(repository_full_name: repo).pluck(:creative_id)
-      return unless linked_creative_ids.include?(topic.creative_id)
+      creative = topic.creative
+      return unless creative
+      candidate_ids = [ creative.id ] + creative.ancestors.pluck(:id)
+      return if (linked_creative_ids & candidate_ids).empty?
 
       existing = GithubPrChannel.where(topic_id: topic.id).find { |c| c.repo_full_name == repo && c.pr_number == pr_number }
       if existing

--- a/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
+++ b/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
@@ -33,7 +33,10 @@ module CollavreGithub
 
     def maybe_auto_attach_channel(event, payload)
       return unless event == "pull_request" && payload["action"] == "opened"
-      repo = payload.dig("repository", "full_name")
+      # GitHub repo identifiers are case-insensitive; normalize so stored
+      # channels (also lowercased) match incoming dispatch payloads regardless
+      # of how the repo casing arrives from clients.
+      repo = payload.dig("repository", "full_name")&.downcase
       pr_number = payload.dig("pull_request", "number")
       body = payload.dig("pull_request", "body")
       topic_id = CollavreGithub::PrTopicLinkParser.call(body)
@@ -48,13 +51,15 @@ module CollavreGithub
       # when the topic's creative — or any of its ancestors — is linked to this
       # repo (RepositoryLink applies to the whole subtree).
       linked_creative_ids = CollavreGithub::RepositoryLink
-        .where(repository_full_name: repo).pluck(:creative_id)
+        .where("LOWER(repository_full_name) = ?", repo).pluck(:creative_id)
       creative = topic.creative
       return unless creative
       candidate_ids = [ creative.id ] + creative.ancestors.pluck(:id)
       return if (linked_creative_ids & candidate_ids).empty?
 
-      existing = GithubPrChannel.where(topic_id: topic.id).find { |c| c.repo_full_name == repo && c.pr_number == pr_number }
+      existing = GithubPrChannel.where(topic_id: topic.id).find do |c|
+        c.repo_full_name.to_s.downcase == repo && c.pr_number == pr_number
+      end
       if existing
         existing.update!(state: :active) unless existing.active?
         return existing
@@ -70,15 +75,17 @@ module CollavreGithub
     end
 
     def dispatch_to_channels(event, payload)
-      repo = payload.dig("repository", "full_name")
+      repo = payload.dig("repository", "full_name")&.downcase
       pr_number = extract_pr_number(event, payload)
       return if repo.blank? || pr_number.nil?
 
       # Ruby-level filter for DB portability (SQLite dev/test, Postgres prod).
       # Future optimization: switch to a jsonb-portable query once an established
-      # pattern exists in this codebase.
+      # pattern exists in this codebase. Compare repo names case-insensitively
+      # so legacy mixed-case rows continue to match the canonical lowercase
+      # payload value.
       GithubPrChannel.active.find_each do |channel|
-        next unless channel.repo_full_name == repo && channel.pr_number == pr_number
+        next unless channel.repo_full_name.to_s.downcase == repo && channel.pr_number == pr_number
 
         begin
           injected = channel.handle(event: event, payload: payload)

--- a/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
+++ b/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
@@ -80,16 +80,22 @@ module CollavreGithub
       GithubPrChannel.active.find_each do |channel|
         next unless channel.repo_full_name == repo && channel.pr_number == pr_number
 
-        injected = channel.handle(event: event, payload: payload)
-        next if injected.nil?
+        begin
+          injected = channel.handle(event: event, payload: payload)
+          next if injected.nil?
 
-        channel.inject_into_topic!(injected)
-        # Detach AFTER injecting the closing message so the chip remains
-        # visible until the closing comment lands in the topic.
-        channel.detach! if event == "pull_request" && payload["action"] == "closed"
+          channel.inject_into_topic!(injected)
+          # Detach AFTER injecting the closing message so the chip remains
+          # visible until the closing comment lands in the topic.
+          channel.detach! if event == "pull_request" && payload["action"] == "closed"
+        rescue => e
+          # Isolate per-channel failures so one broken channel does not block
+          # sibling channels monitoring the same PR.
+          Rails.logger.error(
+            "[CollavreGithub] channel #{channel.id} dispatch failed: #{e.class}: #{e.message}"
+          )
+        end
       end
-    rescue => e
-      Rails.logger.error("[CollavreGithub] channel dispatch failed: #{e.class}: #{e.message}")
     end
 
     def extract_pr_number(event, payload)

--- a/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
+++ b/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
@@ -330,7 +330,9 @@ module CollavreGithub
       repo = payload&.dig("repository", "full_name") || payload&.dig(:repository, :full_name)
       return [ @repository_link ].compact if repo.blank?
 
-      CollavreGithub::RepositoryLink.where(repository_full_name: repo).to_a
+      CollavreGithub::RepositoryLink
+        .where("LOWER(repository_full_name) = ?", repo.downcase)
+        .to_a
     end
 
     def find_repository_link(payload)
@@ -351,7 +353,9 @@ module CollavreGithub
         return
       end
 
-      CollavreGithub::RepositoryLink.find_by(repository_full_name: full_name)
+      CollavreGithub::RepositoryLink
+        .where("LOWER(repository_full_name) = ?", full_name.downcase)
+        .first
     end
 
     def valid_signature?(raw_body)

--- a/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
+++ b/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
@@ -68,6 +68,9 @@ module CollavreGithub
         next if injected.nil?
 
         channel.inject_into_topic!(injected)
+        # Detach AFTER injecting the closing message so the chip remains
+        # visible until the closing comment lands in the topic.
+        channel.detach! if event == "pull_request" && payload["action"] == "closed"
       end
     rescue => e
       Rails.logger.error("[CollavreGithub] channel dispatch failed: #{e.class}: #{e.message}")

--- a/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
+++ b/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
@@ -21,6 +21,7 @@ module CollavreGithub
         trigger_markdown_sync_for(link, event, payload) if link.markdown_sync_enabled?
       end
 
+      maybe_auto_attach_channel(event, payload)
       dispatch_to_channels(event, payload)
 
       head :ok
@@ -29,6 +30,28 @@ module CollavreGithub
     end
 
     private
+
+    def maybe_auto_attach_channel(event, payload)
+      return unless event == "pull_request" && payload["action"] == "opened"
+      repo = payload.dig("repository", "full_name")
+      pr_number = payload.dig("pull_request", "number")
+      body = payload.dig("pull_request", "body")
+      topic_id = CollavreGithub::PrTopicLinkParser.call(body)
+      return unless repo && pr_number && topic_id
+
+      topic = Collavre::Topic.find_by(id: topic_id)
+      return unless topic
+
+      existing = GithubPrChannel.where(topic_id: topic.id).find { |c| c.repo_full_name == repo && c.pr_number == pr_number }
+      existing || GithubPrChannel.create!(
+        topic_id: topic.id,
+        config: { "repo_full_name" => repo, "pr_number" => pr_number }
+      )
+    rescue ActiveRecord::RecordNotUnique
+      # concurrent webhook safe
+    rescue => e
+      Rails.logger.error("[CollavreGithub] auto-attach failed: #{e.class}: #{e.message}")
+    end
 
     def dispatch_to_channels(event, payload)
       repo = payload.dig("repository", "full_name")

--- a/engines/collavre_github/app/models/collavre_github/github_pr_channel.rb
+++ b/engines/collavre_github/app/models/collavre_github/github_pr_channel.rb
@@ -1,0 +1,52 @@
+module CollavreGithub
+  class GithubPrChannel < Collavre::Channel
+    self.table_name = "channels"
+
+    CHANNEL_BOT_EMAIL = "channel@collavre.local"
+
+    def repo_full_name
+      config["repo_full_name"]
+    end
+
+    def pr_number
+      config["pr_number"].to_i
+    end
+
+    def pr_url
+      "https://github.com/#{repo_full_name}/pull/#{pr_number}"
+    end
+
+    def label
+      "PR ##{pr_number}"
+    end
+
+    def handle(event:, payload:)
+      case event
+      when "issue_comment"
+        handle_issue_comment(payload)
+      end
+    end
+
+    private
+
+    def handle_issue_comment(payload)
+      return nil unless payload["action"] == "created"
+      return nil unless payload.dig("issue", "pull_request") # PR comments only
+
+      comment = payload["comment"]
+      author = comment.dig("user", "login")
+      body = comment["body"].to_s
+
+      Collavre::Channel::InjectedMessage.new(
+        speaker: channel_bot_user,
+        message: "**@#{author}** commented on #{label}:\n\n#{body}",
+        label: label,
+        link: pr_url
+      )
+    end
+
+    def channel_bot_user
+      @channel_bot_user ||= Collavre::User.find_by!(email: CHANNEL_BOT_EMAIL)
+    end
+  end
+end

--- a/engines/collavre_github/app/models/collavre_github/github_pr_channel.rb
+++ b/engines/collavre_github/app/models/collavre_github/github_pr_channel.rb
@@ -55,6 +55,7 @@ module CollavreGithub
       return nil if body.strip.empty?
 
       author = review.dig("user", "login")
+      return nil if ignored_actor?(author)
       state = review["state"]
       Collavre::Channel::InjectedMessage.new(
         speaker: channel_bot_user,
@@ -68,6 +69,7 @@ module CollavreGithub
       return nil unless payload["action"] == "created"
       comment = payload["comment"]
       author = comment.dig("user", "login")
+      return nil if ignored_actor?(author)
       path = comment["path"]
       line = comment["line"]
       body = comment["body"].to_s
@@ -87,6 +89,7 @@ module CollavreGithub
 
       comment = payload["comment"]
       author = comment.dig("user", "login")
+      return nil if ignored_actor?(author)
       body = comment["body"].to_s
 
       Collavre::Channel::InjectedMessage.new(
@@ -95,6 +98,10 @@ module CollavreGithub
         label: label,
         link: pr_url
       )
+    end
+
+    def ignored_actor?(login)
+      Array(config["ignore_actor_logins"]).include?(login)
     end
 
     def channel_bot_user

--- a/engines/collavre_github/app/models/collavre_github/github_pr_channel.rb
+++ b/engines/collavre_github/app/models/collavre_github/github_pr_channel.rb
@@ -24,10 +24,28 @@ module CollavreGithub
         handle_issue_comment(payload)
       when "pull_request_review_comment"
         handle_review_comment(payload)
+      when "pull_request_review"
+        handle_review_submitted(payload)
       end
     end
 
     private
+
+    def handle_review_submitted(payload)
+      return nil unless payload["action"] == "submitted"
+      review = payload["review"]
+      body = review["body"].to_s
+      return nil if body.strip.empty?
+
+      author = review.dig("user", "login")
+      state = review["state"]
+      Collavre::Channel::InjectedMessage.new(
+        speaker: channel_bot_user,
+        message: "**@#{author}** submitted a review (`#{state}`) on #{label}:\n\n#{body}",
+        label: label,
+        link: pr_url
+      )
+    end
 
     def handle_review_comment(payload)
       return nil unless payload["action"] == "created"

--- a/engines/collavre_github/app/models/collavre_github/github_pr_channel.rb
+++ b/engines/collavre_github/app/models/collavre_github/github_pr_channel.rb
@@ -38,14 +38,14 @@ module CollavreGithub
       pr = payload["pull_request"]
       verb = pr["merged"] ? "merged" : "closed"
 
-      msg = Collavre::Channel::InjectedMessage.new(
+      Collavre::Channel::InjectedMessage.new(
         speaker: channel_bot_user,
         message: "#{label} was **#{verb}**. Detaching channel.",
         label: "#{label} (#{verb})",
         link: pr_url
       )
-      detach!
-      msg
+      # Detach is performed by the webhook controller AFTER injecting this
+      # message, so the chip stays visible until the closing comment lands.
     end
 
     def handle_review_submitted(payload)

--- a/engines/collavre_github/app/models/collavre_github/github_pr_channel.rb
+++ b/engines/collavre_github/app/models/collavre_github/github_pr_channel.rb
@@ -26,10 +26,27 @@ module CollavreGithub
         handle_review_comment(payload)
       when "pull_request_review"
         handle_review_submitted(payload)
+      when "pull_request"
+        handle_pull_request(payload)
       end
     end
 
     private
+
+    def handle_pull_request(payload)
+      return nil unless payload["action"] == "closed"
+      pr = payload["pull_request"]
+      verb = pr["merged"] ? "merged" : "closed"
+
+      msg = Collavre::Channel::InjectedMessage.new(
+        speaker: channel_bot_user,
+        message: "#{label} was **#{verb}**. Detaching channel.",
+        label: "#{label} (#{verb})",
+        link: pr_url
+      )
+      detach!
+      msg
+    end
 
     def handle_review_submitted(payload)
       return nil unless payload["action"] == "submitted"

--- a/engines/collavre_github/app/models/collavre_github/github_pr_channel.rb
+++ b/engines/collavre_github/app/models/collavre_github/github_pr_channel.rb
@@ -22,10 +22,29 @@ module CollavreGithub
       case event
       when "issue_comment"
         handle_issue_comment(payload)
+      when "pull_request_review_comment"
+        handle_review_comment(payload)
       end
     end
 
     private
+
+    def handle_review_comment(payload)
+      return nil unless payload["action"] == "created"
+      comment = payload["comment"]
+      author = comment.dig("user", "login")
+      path = comment["path"]
+      line = comment["line"]
+      body = comment["body"].to_s
+
+      location = path ? " on `#{path}`#{line ? ":#{line}" : ''}" : ""
+      Collavre::Channel::InjectedMessage.new(
+        speaker: channel_bot_user,
+        message: "**@#{author}** reviewed #{label}#{location}:\n\n#{body}",
+        label: label,
+        link: pr_url
+      )
+    end
 
     def handle_issue_comment(payload)
       return nil unless payload["action"] == "created"

--- a/engines/collavre_github/app/models/collavre_github/github_pr_channel.rb
+++ b/engines/collavre_github/app/models/collavre_github/github_pr_channel.rb
@@ -2,8 +2,6 @@ module CollavreGithub
   class GithubPrChannel < Collavre::Channel
     self.table_name = "channels"
 
-    CHANNEL_BOT_EMAIL = "channel@collavre.local"
-
     def repo_full_name
       config["repo_full_name"]
     end
@@ -46,7 +44,7 @@ module CollavreGithub
     end
 
     def channel_bot_user
-      @channel_bot_user ||= Collavre::User.find_by!(email: CHANNEL_BOT_EMAIL)
+      @channel_bot_user ||= Collavre::User.find_by!(email: Collavre::Channel::BOT_EMAIL)
     end
   end
 end

--- a/engines/collavre_github/app/models/collavre_github/github_pr_channel.rb
+++ b/engines/collavre_github/app/models/collavre_github/github_pr_channel.rb
@@ -15,7 +15,7 @@ module CollavreGithub
     end
 
     def label
-      "PR ##{pr_number}"
+      t("label", number: pr_number)
     end
 
     def handle(event:, payload:)
@@ -36,12 +36,13 @@ module CollavreGithub
     def handle_pull_request(payload)
       return nil unless payload["action"] == "closed"
       pr = payload["pull_request"]
-      verb = pr["merged"] ? "merged" : "closed"
+      verb_key = pr["merged"] ? "state_merged" : "state_closed"
+      verb = t(verb_key)
 
       Collavre::Channel::InjectedMessage.new(
         speaker: channel_bot_user,
-        message: "#{label} was **#{verb}**. Detaching channel.",
-        label: "#{label} (#{verb})",
+        message: t("closed_message", label: label, verb: verb),
+        label: t("label_with_state", label: label, state: verb),
         link: pr_url
       )
       # Detach is performed by the webhook controller AFTER injecting this
@@ -59,7 +60,7 @@ module CollavreGithub
       state = review["state"]
       Collavre::Channel::InjectedMessage.new(
         speaker: channel_bot_user,
-        message: "**@#{author}** submitted a review (`#{state}`) on #{label}:\n\n#{body}",
+        message: t("review_submitted_message", author: author, state: state, label: label, body: body),
         label: label,
         link: pr_url
       )
@@ -74,10 +75,17 @@ module CollavreGithub
       line = comment["line"]
       body = comment["body"].to_s
 
-      location = path ? " on `#{path}`#{line ? ":#{line}" : ''}" : ""
+      location =
+        if path && line
+          t("review_comment_location_path_line", path: path, line: line)
+        elsif path
+          t("review_comment_location_path", path: path)
+        else
+          ""
+        end
       Collavre::Channel::InjectedMessage.new(
         speaker: channel_bot_user,
-        message: "**@#{author}** reviewed #{label}#{location}:\n\n#{body}",
+        message: t("review_comment_message", author: author, label: label, location: location, body: body),
         label: label,
         link: pr_url
       )
@@ -94,7 +102,7 @@ module CollavreGithub
 
       Collavre::Channel::InjectedMessage.new(
         speaker: channel_bot_user,
-        message: "**@#{author}** commented on #{label}:\n\n#{body}",
+        message: t("comment_message", author: author, label: label, body: body),
         label: label,
         link: pr_url
       )
@@ -104,8 +112,30 @@ module CollavreGithub
       Array(config["ignore_actor_logins"]).include?(login)
     end
 
+    def t(key, **opts)
+      I18n.t("collavre_github.channel.pr.#{key}", **opts)
+    end
+
+    # Find the channel bot user. Falls back to creating the row when missing
+    # (e.g. migrations applied but `db:seed` was skipped). Without this
+    # fallback every PR webhook would raise RecordNotFound and the event
+    # would be silently dropped by the controller's rescue.
     def channel_bot_user
-      @channel_bot_user ||= Collavre::User.find_by!(email: Collavre::Channel::BOT_EMAIL)
+      @channel_bot_user ||=
+        Collavre::User.find_by(email: Collavre::Channel::BOT_EMAIL) ||
+          ensure_channel_bot_user!
+    end
+
+    def ensure_channel_bot_user!
+      email = Collavre::Channel::BOT_EMAIL
+      user = Collavre::User.find_or_initialize_by(email: email)
+      user.name = Collavre::Channel::BOT_NAME
+      user.password = SecureRandom.hex(32) if user.new_record?
+      user.email_verified_at ||= Time.current
+      user.searchable = false if user.respond_to?(:searchable=)
+      user.llm_vendor = nil
+      user.save!
+      user
     end
   end
 end

--- a/engines/collavre_github/app/services/collavre_github/pr_topic_link_parser.rb
+++ b/engines/collavre_github/app/services/collavre_github/pr_topic_link_parser.rb
@@ -1,0 +1,11 @@
+module CollavreGithub
+  class PrTopicLinkParser
+    TOPIC_RE = %r{/creatives/\d+/topics/(\d+)}.freeze
+
+    def self.call(body)
+      return nil if body.blank?
+      m = body.match(TOPIC_RE)
+      m && m[1].to_i
+    end
+  end
+end

--- a/engines/collavre_github/app/services/collavre_github/tools/permission_denied_error.rb
+++ b/engines/collavre_github/app/services/collavre_github/tools/permission_denied_error.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module CollavreGithub
+  module Tools
+    # Raised by tool services when the current user lacks the required
+    # creative-level permission to perform a mutating action.
+    class PermissionDeniedError < StandardError; end
+  end
+end

--- a/engines/collavre_github/app/services/collavre_github/tools/pr_monitor_service.rb
+++ b/engines/collavre_github/app/services/collavre_github/tools/pr_monitor_service.rb
@@ -25,7 +25,10 @@ module CollavreGithub
       def call(topic_id:, pr_url:)
         m = pr_url.match(PR_URL_RE)
         raise ArgumentError, "Invalid PR URL: #{pr_url}" unless m
-        repo = m[1]
+        # GitHub owner/repo identifiers are case-insensitive but webhook payloads
+        # always carry the canonical case. Normalize on store so user input
+        # like "Owner/Repo" still matches incoming events.
+        repo = m[1].downcase
         pr_number = m[2].to_i
 
         topic = Collavre::Topic.find(topic_id)
@@ -57,7 +60,7 @@ module CollavreGithub
       sig { params(topic: Collavre::Topic, repo: String, pr_number: Integer).returns(T.nilable(CollavreGithub::GithubPrChannel)) }
       def lookup_channel(topic, repo, pr_number)
         CollavreGithub::GithubPrChannel.where(topic_id: topic.id).find do |c|
-          c.repo_full_name == repo && c.pr_number == pr_number
+          c.repo_full_name.to_s.downcase == repo.downcase && c.pr_number == pr_number
         end
       end
     end

--- a/engines/collavre_github/app/services/collavre_github/tools/pr_monitor_service.rb
+++ b/engines/collavre_github/app/services/collavre_github/tools/pr_monitor_service.rb
@@ -32,11 +32,28 @@ module CollavreGithub
         pr_number = m[2].to_i
 
         topic = Collavre::Topic.find(topic_id)
+        authorize_topic_write!(topic)
         channel = find_or_attach_channel(topic, repo, pr_number)
         { ok: true, channel_id: channel.id, repo: repo, pr_number: pr_number }
       end
 
       private
+
+      # Attaching a channel injects external messages into the topic, so it is a
+      # write-equivalent mutation. Mirror CreativePermissionGuard#require_creative_write!
+      # against the topic's effective_origin so MCP callers cannot drop monitors
+      # onto topics they would not be allowed to comment on.
+      def authorize_topic_write!(topic)
+        creative = topic.creative&.effective_origin
+        raise ArgumentError, "Topic has no creative" unless creative
+
+        user = Collavre::Current.user
+        return if creative.user == user
+        return if user && creative.has_permission?(user, :write)
+
+        raise CollavreGithub::Tools::PermissionDeniedError,
+          "No write permission on topic #{topic.id}"
+      end
 
       sig { params(topic: Collavre::Topic, repo: String, pr_number: Integer).returns(CollavreGithub::GithubPrChannel) }
       def find_or_attach_channel(topic, repo, pr_number)

--- a/engines/collavre_github/app/services/collavre_github/tools/pr_monitor_service.rb
+++ b/engines/collavre_github/app/services/collavre_github/tools/pr_monitor_service.rb
@@ -29,14 +29,36 @@ module CollavreGithub
         pr_number = m[2].to_i
 
         topic = Collavre::Topic.find(topic_id)
-        existing = CollavreGithub::GithubPrChannel.where(topic_id: topic.id).find do |c|
-          c.repo_full_name == repo && c.pr_number == pr_number
+        channel = find_or_attach_channel(topic, repo, pr_number)
+        { ok: true, channel_id: channel.id, repo: repo, pr_number: pr_number }
+      end
+
+      private
+
+      sig { params(topic: Collavre::Topic, repo: String, pr_number: Integer).returns(CollavreGithub::GithubPrChannel) }
+      def find_or_attach_channel(topic, repo, pr_number)
+        existing = lookup_channel(topic, repo, pr_number)
+        if existing
+          existing.update!(state: :active) unless existing.active?
+          return existing
         end
-        channel = existing || CollavreGithub::GithubPrChannel.create!(
+        CollavreGithub::GithubPrChannel.create!(
           topic_id: topic.id,
           config: { "repo_full_name" => repo, "pr_number" => pr_number }
         )
-        { ok: true, channel_id: channel.id, repo: repo, pr_number: pr_number }
+      rescue ActiveRecord::RecordNotUnique
+        # Concurrent caller won the race; reuse the row they created.
+        existing = lookup_channel(topic, repo, pr_number)
+        raise unless existing
+        existing.update!(state: :active) unless existing.active?
+        existing
+      end
+
+      sig { params(topic: Collavre::Topic, repo: String, pr_number: Integer).returns(T.nilable(CollavreGithub::GithubPrChannel)) }
+      def lookup_channel(topic, repo, pr_number)
+        CollavreGithub::GithubPrChannel.where(topic_id: topic.id).find do |c|
+          c.repo_full_name == repo && c.pr_number == pr_number
+        end
       end
     end
   end

--- a/engines/collavre_github/app/services/collavre_github/tools/pr_monitor_service.rb
+++ b/engines/collavre_github/app/services/collavre_github/tools/pr_monitor_service.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "sorbet-runtime"
+require "rails_mcp_engine"
+
+module CollavreGithub
+  module Tools
+    class PrMonitorService
+      extend T::Sig
+      extend ToolMeta
+
+      PR_URL_RE = %r{\Ahttps?://github\.com/([^/]+/[^/]+)/pull/(\d+)\z}.freeze
+
+      tool_name "pr_monitor"
+      tool_description <<~DESC.strip
+        Attach a GitHub PR monitor to a Collavre topic. After attachment,
+        PR comments, review comments, and review submissions are injected
+        into the topic as chat messages. Idempotent.
+      DESC
+
+      tool_param :topic_id, description: "The Collavre topic id to attach the PR channel to."
+      tool_param :pr_url, description: "Full GitHub PR URL, e.g. https://github.com/owner/repo/pull/123"
+
+      sig { params(topic_id: Integer, pr_url: String).returns(T::Hash[Symbol, T.untyped]) }
+      def call(topic_id:, pr_url:)
+        m = pr_url.match(PR_URL_RE)
+        raise ArgumentError, "Invalid PR URL: #{pr_url}" unless m
+        repo = m[1]
+        pr_number = m[2].to_i
+
+        topic = Collavre::Topic.find(topic_id)
+        existing = CollavreGithub::GithubPrChannel.where(topic_id: topic.id).find do |c|
+          c.repo_full_name == repo && c.pr_number == pr_number
+        end
+        channel = existing || CollavreGithub::GithubPrChannel.create!(
+          topic_id: topic.id,
+          config: { "repo_full_name" => repo, "pr_number" => pr_number }
+        )
+        { ok: true, channel_id: channel.id, repo: repo, pr_number: pr_number }
+      end
+    end
+  end
+end

--- a/engines/collavre_github/config/locales/en.yml
+++ b/engines/collavre_github/config/locales/en.yml
@@ -93,3 +93,15 @@ en:
         updated: "Updated"
         ready_for_review: "Ready for Review"
         event: "Event"
+    channel:
+      pr:
+        label: "PR #%{number}"
+        label_with_state: "%{label} (%{state})"
+        state_merged: "merged"
+        state_closed: "closed"
+        comment_message: "**@%{author}** commented on %{label}:\n\n%{body}"
+        review_comment_message: "**@%{author}** reviewed %{label}%{location}:\n\n%{body}"
+        review_comment_location_path: " on `%{path}`"
+        review_comment_location_path_line: " on `%{path}`:%{line}"
+        review_submitted_message: "**@%{author}** submitted a review (`%{state}`) on %{label}:\n\n%{body}"
+        closed_message: "%{label} was **%{verb}**. Detaching channel."

--- a/engines/collavre_github/config/locales/ko.yml
+++ b/engines/collavre_github/config/locales/ko.yml
@@ -93,3 +93,15 @@ ko:
         updated: "업데이트됨"
         ready_for_review: "리뷰 준비됨"
         event: "이벤트"
+    channel:
+      pr:
+        label: "PR #%{number}"
+        label_with_state: "%{label} (%{state})"
+        state_merged: "머지됨"
+        state_closed: "닫힘"
+        comment_message: "**@%{author}**님이 %{label}에 댓글을 남겼습니다:\n\n%{body}"
+        review_comment_message: "**@%{author}**님이 %{label}%{location}을(를) 리뷰했습니다:\n\n%{body}"
+        review_comment_location_path: " (`%{path}`)"
+        review_comment_location_path_line: " (`%{path}`:%{line})"
+        review_submitted_message: "**@%{author}**님이 %{label}에 리뷰를 제출했습니다 (`%{state}`):\n\n%{body}"
+        closed_message: "%{label}이(가) **%{verb}** 되었습니다. 채널을 해제합니다."

--- a/engines/collavre_github/db/seeds.rb
+++ b/engines/collavre_github/db/seeds.rb
@@ -76,6 +76,7 @@ module CollavreGithub
       github_pr_commits
       creative_retrieval_service
       creative_batch_service
+      pr_monitor
     ].freeze
 
     def self.call

--- a/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_auto_attach_test.rb
+++ b/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_auto_attach_test.rb
@@ -1,0 +1,61 @@
+require_relative "../../test_helper"
+
+module CollavreGithub
+  class WebhooksControllerAutoAttachTest < ActionDispatch::IntegrationTest
+    setup do
+      @user = users(:one)
+      @creative = creatives(:tshirt)
+      @account = CollavreGithub::Account.create!(
+        user: @user, github_uid: "12345", login: "testuser",
+        name: "Test", token: "test-token"
+      )
+      @link = CollavreGithub::RepositoryLink.create!(
+        creative: @creative, github_account: @account,
+        repository_full_name: "owner/repo"
+      )
+      @topic = Collavre::Topic.create!(creative: @creative, user: @user, name: "T")
+    end
+
+    test "pull_request.opened with topic link in body creates a channel" do
+      payload = {
+        action: "opened",
+        pull_request: {
+          number: 555,
+          html_url: "https://github.com/#{@link.repository_full_name}/pull/555",
+          body: "Linked topic: /creatives/#{@creative.id}/topics/#{@topic.id}"
+        },
+        repository: { full_name: @link.repository_full_name }
+      }.to_json
+
+      sig = "sha256=" + OpenSSL::HMAC.hexdigest("SHA256", @link.webhook_secret, payload)
+
+      assert_difference -> { GithubPrChannel.count }, 1 do
+        post "/github/webhook",
+          params: payload,
+          headers: {
+            "Content-Type" => "application/json",
+            "X-GitHub-Event" => "pull_request",
+            "X-Hub-Signature-256" => sig
+          }
+      end
+      channel = GithubPrChannel.last
+      assert_equal @topic.id, channel.topic_id
+      assert_equal 555, channel.pr_number
+      assert_equal @link.repository_full_name, channel.repo_full_name
+    end
+
+    test "pull_request.opened without topic link does not create a channel" do
+      payload = {
+        action: "opened",
+        pull_request: { number: 556, body: "no topic link here" },
+        repository: { full_name: @link.repository_full_name }
+      }.to_json
+      sig = "sha256=" + OpenSSL::HMAC.hexdigest("SHA256", @link.webhook_secret, payload)
+
+      assert_no_difference -> { GithubPrChannel.count } do
+        post "/github/webhook", params: payload,
+          headers: { "Content-Type" => "application/json", "X-GitHub-Event" => "pull_request", "X-Hub-Signature-256" => sig }
+      end
+    end
+  end
+end

--- a/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_auto_attach_test.rb
+++ b/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_auto_attach_test.rb
@@ -57,5 +57,64 @@ module CollavreGithub
           headers: { "Content-Type" => "application/json", "X-GitHub-Event" => "pull_request", "X-Hub-Signature-256" => sig }
       end
     end
+
+    test "pull_request.opened ignores topic link pointing to a creative not linked to this repo" do
+      # An attacker opens a PR on owner/repo, but puts a foreign tenant's
+      # topic link in the description. We must NOT auto-attach.
+      foreign_creative = creatives(:childless_creative)
+      foreign_topic = Collavre::Topic.create!(creative: foreign_creative, user: @user, name: "Foreign")
+
+      payload = {
+        action: "opened",
+        pull_request: {
+          number: 557,
+          body: "Linked topic: /creatives/#{foreign_creative.id}/topics/#{foreign_topic.id}"
+        },
+        repository: { full_name: @link.repository_full_name }
+      }.to_json
+      sig = "sha256=" + OpenSSL::HMAC.hexdigest("SHA256", @link.webhook_secret, payload)
+
+      assert_no_difference -> { GithubPrChannel.count } do
+        post "/github/webhook", params: payload,
+          headers: { "Content-Type" => "application/json", "X-GitHub-Event" => "pull_request", "X-Hub-Signature-256" => sig }
+      end
+    end
+
+    test "pull_request.opened reactivates a detached channel" do
+      detached = GithubPrChannel.create!(
+        topic_id: @topic.id,
+        config: { "repo_full_name" => @link.repository_full_name, "pr_number" => 558 },
+        state: :detached
+      )
+
+      payload = {
+        action: "opened",
+        pull_request: {
+          number: 558,
+          body: "Linked topic: /creatives/#{@creative.id}/topics/#{@topic.id}"
+        },
+        repository: { full_name: @link.repository_full_name }
+      }.to_json
+      sig = "sha256=" + OpenSSL::HMAC.hexdigest("SHA256", @link.webhook_secret, payload)
+
+      assert_no_difference -> { GithubPrChannel.count } do
+        post "/github/webhook", params: payload,
+          headers: { "Content-Type" => "application/json", "X-GitHub-Event" => "pull_request", "X-Hub-Signature-256" => sig }
+      end
+      assert detached.reload.active?
+    end
+
+    test "channels table rejects duplicate (type, topic, repo, pr) at DB level" do
+      GithubPrChannel.create!(
+        topic_id: @topic.id,
+        config: { "repo_full_name" => @link.repository_full_name, "pr_number" => 559 }
+      )
+      assert_raises(ActiveRecord::RecordNotUnique) do
+        GithubPrChannel.create!(
+          topic_id: @topic.id,
+          config: { "repo_full_name" => @link.repository_full_name, "pr_number" => 559 }
+        )
+      end
+    end
   end
 end

--- a/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_auto_attach_test.rb
+++ b/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_auto_attach_test.rb
@@ -80,6 +80,28 @@ module CollavreGithub
       end
     end
 
+    test "pull_request.opened with topic on a child creative auto-attaches (subtree inherits link)" do
+      child = Collavre::Creative.create!(parent: @creative, user: @user, description: "child")
+      child_topic = Collavre::Topic.create!(creative: child, user: @user, name: "Child T")
+
+      payload = {
+        action: "opened",
+        pull_request: {
+          number: 560,
+          body: "Linked topic: /creatives/#{child.id}/topics/#{child_topic.id}"
+        },
+        repository: { full_name: @link.repository_full_name }
+      }.to_json
+      sig = "sha256=" + OpenSSL::HMAC.hexdigest("SHA256", @link.webhook_secret, payload)
+
+      assert_difference -> { GithubPrChannel.count }, 1 do
+        post "/github/webhook", params: payload,
+          headers: { "Content-Type" => "application/json", "X-GitHub-Event" => "pull_request", "X-Hub-Signature-256" => sig }
+      end
+      channel = GithubPrChannel.last
+      assert_equal child_topic.id, channel.topic_id
+    end
+
     test "pull_request.opened reactivates a detached channel" do
       detached = GithubPrChannel.create!(
         topic_id: @topic.id,

--- a/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_channels_test.rb
+++ b/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_channels_test.rb
@@ -1,0 +1,53 @@
+require_relative "../../test_helper"
+
+module CollavreGithub
+  class WebhooksControllerChannelsTest < ActionDispatch::IntegrationTest
+    setup do
+      @user = users(:one)
+      @creative = creatives(:tshirt)
+      @account = CollavreGithub::Account.create!(
+        user: @user,
+        github_uid: "12345",
+        login: "testuser",
+        name: "Test",
+        token: "test-token"
+      )
+      @link = CollavreGithub::RepositoryLink.create!(
+        creative: @creative,
+        github_account: @account,
+        repository_full_name: "owner/repo"
+      )
+      @topic = Collavre::Topic.create!(creative: @creative, user: @user, name: "T")
+      @channel = GithubPrChannel.create!(
+        topic: @topic,
+        config: { "repo_full_name" => @link.repository_full_name, "pr_number" => 99 }
+      )
+    end
+
+    test "issue_comment.created on monitored PR injects a comment into the topic" do
+      payload = {
+        action: "created",
+        comment: {
+          id: 1,
+          body: "fix typo",
+          user: { login: "alice", type: "User", id: 1 }
+        },
+        issue: { number: 99, pull_request: {} },
+        repository: { full_name: @link.repository_full_name }
+      }.to_json
+
+      sig = "sha256=" + OpenSSL::HMAC.hexdigest("SHA256", @link.webhook_secret, payload)
+
+      assert_difference -> { Collavre::Comment.where(topic_id: @topic.id).count }, 1 do
+        post "/github/webhook",
+          params: payload,
+          headers: {
+            "Content-Type" => "application/json",
+            "X-GitHub-Event" => "issue_comment",
+            "X-Hub-Signature-256" => sig
+          }
+      end
+      assert_response :ok
+    end
+  end
+end

--- a/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_channels_test.rb
+++ b/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_channels_test.rb
@@ -50,6 +50,63 @@ module CollavreGithub
       assert_response :ok
     end
 
+    test "per-channel handle failure does not block sibling channels on same PR" do
+      # Two extra channels on the same PR. One raises in #handle, the other is healthy.
+      # The healthy one must still receive the injection — the failing channel must
+      # not poison the dispatch loop.
+      broken_class = Class.new(GithubPrChannel) do
+        def handle(event:, payload:)
+          raise "boom"
+        end
+      end
+      CollavreGithub.const_set(:BrokenTestChannel, broken_class)
+      broken_topic = Collavre::Topic.create!(creative: @creative, user: @user, name: "Broken")
+      sibling_topic = Collavre::Topic.create!(creative: @creative, user: @user, name: "Sibling")
+      CollavreGithub::BrokenTestChannel.create!(
+        topic: broken_topic,
+        config: { "repo_full_name" => @link.repository_full_name, "pr_number" => 99 }
+      )
+      GithubPrChannel.create!(
+        topic: sibling_topic,
+        config: { "repo_full_name" => @link.repository_full_name, "pr_number" => 99 }
+      )
+
+      payload = {
+        action: "created",
+        comment: {
+          id: 7,
+          body: "isolation check",
+          user: { login: "alice", type: "User", id: 1 }
+        },
+        issue: { number: 99, pull_request: {} },
+        repository: { full_name: @link.repository_full_name }
+      }.to_json
+      sig = "sha256=" + OpenSSL::HMAC.hexdigest("SHA256", @link.webhook_secret, payload)
+
+      before_sibling = Collavre::Comment.where(topic_id: sibling_topic.id).count
+      before_original = Collavre::Comment.where(topic_id: @topic.id).count
+
+      post "/github/webhook",
+        params: payload,
+        headers: {
+          "Content-Type" => "application/json",
+          "X-GitHub-Event" => "issue_comment",
+          "X-Hub-Signature-256" => sig
+        }
+
+      assert_response :ok
+      assert_equal before_sibling + 1, Collavre::Comment.where(topic_id: sibling_topic.id).count,
+        "healthy sibling channel should still inject"
+      assert_equal before_original + 1, Collavre::Comment.where(topic_id: @topic.id).count,
+        "original healthy channel should still inject"
+      assert_equal 0, Collavre::Comment.where(topic_id: broken_topic.id).count,
+        "broken channel should not inject"
+    ensure
+      if CollavreGithub.const_defined?(:BrokenTestChannel)
+        CollavreGithub.send(:remove_const, :BrokenTestChannel)
+      end
+    end
+
     test "pull_request.closed injects closing comment AND detaches channel" do
       payload = {
         action: "closed",

--- a/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_channels_test.rb
+++ b/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_channels_test.rb
@@ -107,6 +107,41 @@ module CollavreGithub
       end
     end
 
+    test "dispatch matches channels case-insensitively against repo_full_name" do
+      # Legacy channel rows may have stored mixed-case repo names (created
+      # before normalization landed). Webhook payloads always carry the
+      # canonical lowercase value; comparison must be case-insensitive so
+      # those rows still receive events.
+      legacy_topic = Collavre::Topic.create!(creative: @creative, user: @user, name: "Legacy")
+      GithubPrChannel.create!(
+        topic: legacy_topic,
+        config: { "repo_full_name" => @link.repository_full_name.upcase, "pr_number" => 99 }
+      )
+
+      payload = {
+        action: "created",
+        comment: {
+          id: 42,
+          body: "case insensitive",
+          user: { login: "alice", type: "User", id: 1 }
+        },
+        issue: { number: 99, pull_request: {} },
+        repository: { full_name: @link.repository_full_name }
+      }.to_json
+      sig = "sha256=" + OpenSSL::HMAC.hexdigest("SHA256", @link.webhook_secret, payload)
+
+      assert_difference -> { Collavre::Comment.where(topic_id: legacy_topic.id).count }, 1 do
+        post "/github/webhook",
+          params: payload,
+          headers: {
+            "Content-Type" => "application/json",
+            "X-GitHub-Event" => "issue_comment",
+            "X-Hub-Signature-256" => sig
+          }
+      end
+      assert_response :ok
+    end
+
     test "pull_request.closed injects closing comment AND detaches channel" do
       payload = {
         action: "closed",

--- a/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_channels_test.rb
+++ b/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_channels_test.rb
@@ -187,6 +187,42 @@ module CollavreGithub
       assert outside_channel.reload.active?, "channel state remains untouched (only dispatch is skipped)"
     end
 
+    test "case-mismatched repository.full_name still uses repo-specific webhook secret (fallback bypass guard)" do
+      # Stored RepositoryLink: "owner/repo" (lowercase).
+      # Attacker sends payload with case-mutated repo "Owner/Repo" signed with the fallback ENV secret,
+      # hoping exact-case lookup misses → fallback secret is selected → signature passes →
+      # case-insensitive dispatch still finds the channel.
+      # With case-insensitive find_repository_link, the repo-specific secret is always selected,
+      # so a fallback-signed request must be rejected.
+      ENV["GITHUB_WEBHOOK_SECRET"] = "attacker-known-fallback"
+
+      payload = {
+        action: "created",
+        comment: {
+          id: 999,
+          body: "injected via fallback",
+          user: { login: "mallory", type: "User", id: 9 }
+        },
+        issue: { number: 99, pull_request: {} },
+        repository: { full_name: "Owner/Repo" }
+      }.to_json
+
+      sig = "sha256=" + OpenSSL::HMAC.hexdigest("SHA256", ENV["GITHUB_WEBHOOK_SECRET"], payload)
+
+      assert_no_difference -> { Collavre::Comment.where(topic_id: @topic.id).count } do
+        post "/github/webhook",
+          params: payload,
+          headers: {
+            "Content-Type" => "application/json",
+            "X-GitHub-Event" => "issue_comment",
+            "X-Hub-Signature-256" => sig
+          }
+      end
+      assert_response :unauthorized
+    ensure
+      ENV.delete("GITHUB_WEBHOOK_SECRET")
+    end
+
     test "pull_request.closed injects closing comment AND detaches channel" do
       payload = {
         action: "closed",

--- a/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_channels_test.rb
+++ b/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_channels_test.rb
@@ -49,5 +49,30 @@ module CollavreGithub
       end
       assert_response :ok
     end
+
+    test "pull_request.closed injects closing comment AND detaches channel" do
+      payload = {
+        action: "closed",
+        pull_request: {
+          number: 99,
+          merged: true,
+          html_url: "https://github.com/#{@link.repository_full_name}/pull/99"
+        },
+        repository: { full_name: @link.repository_full_name }
+      }.to_json
+      sig = "sha256=" + OpenSSL::HMAC.hexdigest("SHA256", @link.webhook_secret, payload)
+
+      assert_difference -> { Collavre::Comment.where(topic_id: @topic.id).count }, 1 do
+        post "/github/webhook",
+          params: payload,
+          headers: {
+            "Content-Type" => "application/json",
+            "X-GitHub-Event" => "pull_request",
+            "X-Hub-Signature-256" => sig
+          }
+      end
+      assert_response :ok
+      assert_predicate @channel.reload, :detached?
+    end
   end
 end

--- a/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_channels_test.rb
+++ b/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_channels_test.rb
@@ -142,6 +142,51 @@ module CollavreGithub
       assert_response :ok
     end
 
+    test "skips dispatch when channel's creative is no longer in the repo's link scope" do
+      # Channel was attached when the link existed. After the link is removed
+      # (or the topic moves to an unrelated creative subtree), the channel must
+      # NOT receive further events from the original repo — otherwise external
+      # PR comments would keep leaking into a tenant that no longer owns the
+      # repo. Build the scenario by attaching to an unrelated creative.
+      outside_user = users(:two)
+      outside_creative = Collavre::Creative.create!(user: outside_user, description: "outside")
+      outside_topic = Collavre::Topic.create!(creative: outside_creative, user: outside_user, name: "Outside")
+      outside_channel = GithubPrChannel.create!(
+        topic: outside_topic,
+        config: { "repo_full_name" => @link.repository_full_name, "pr_number" => 99 }
+      )
+
+      payload = {
+        action: "created",
+        comment: {
+          id: 11,
+          body: "should not leak",
+          user: { login: "alice", type: "User", id: 1 }
+        },
+        issue: { number: 99, pull_request: {} },
+        repository: { full_name: @link.repository_full_name }
+      }.to_json
+      sig = "sha256=" + OpenSSL::HMAC.hexdigest("SHA256", @link.webhook_secret, payload)
+
+      before_outside = Collavre::Comment.where(topic_id: outside_topic.id).count
+      before_inside = Collavre::Comment.where(topic_id: @topic.id).count
+
+      post "/github/webhook",
+        params: payload,
+        headers: {
+          "Content-Type" => "application/json",
+          "X-GitHub-Event" => "issue_comment",
+          "X-Hub-Signature-256" => sig
+        }
+
+      assert_response :ok
+      assert_equal before_outside, Collavre::Comment.where(topic_id: outside_topic.id).count,
+        "out-of-scope channel must not receive injected message"
+      assert_equal before_inside + 1, Collavre::Comment.where(topic_id: @topic.id).count,
+        "in-scope channel still receives injected message"
+      assert outside_channel.reload.active?, "channel state remains untouched (only dispatch is skipped)"
+    end
+
     test "pull_request.closed injects closing comment AND detaches channel" do
       payload = {
         action: "closed",

--- a/engines/collavre_github/test/integration/pr_channel_end_to_end_test.rb
+++ b/engines/collavre_github/test/integration/pr_channel_end_to_end_test.rb
@@ -1,0 +1,59 @@
+require_relative "../test_helper"
+
+module CollavreGithub
+  class PrChannelEndToEndTest < ActionDispatch::IntegrationTest
+    setup do
+      @user = users(:one)
+      @creative = creatives(:tshirt)
+      @account = CollavreGithub::Account.create!(
+        user: @user,
+        github_uid: "12345",
+        login: "testuser",
+        name: "Test",
+        token: "test-token"
+      )
+      @link = CollavreGithub::RepositoryLink.create!(
+        creative: @creative,
+        github_account: @account,
+        repository_full_name: "owner/repo"
+      )
+      @topic = Collavre::Topic.create!(creative: @creative, user: @user, name: "T")
+      @channel = GithubPrChannel.create!(
+        topic: @topic,
+        config: { "repo_full_name" => @link.repository_full_name, "pr_number" => 321 }
+      )
+    end
+
+    test "webhook → channel → comment → orchestration dispatch" do
+      payload = {
+        action: "created",
+        comment: {
+          id: 9,
+          body: "please rename",
+          user: { login: "alice", type: "User", id: 1 }
+        },
+        issue: { number: 321, pull_request: {} },
+        repository: { full_name: @link.repository_full_name }
+      }.to_json
+      sig = "sha256=" + OpenSSL::HMAC.hexdigest("SHA256", @link.webhook_secret, payload)
+
+      dispatched_events = []
+      Collavre::SystemEvents::Dispatcher.stub(:dispatch, ->(event, _ctx) { dispatched_events << event; [] }) do
+        assert_difference -> { Collavre::Comment.where(topic_id: @topic.id).count }, 1 do
+          post "/github/webhook",
+            params: payload,
+            headers: {
+              "Content-Type" => "application/json",
+              "X-GitHub-Event" => "issue_comment",
+              "X-Hub-Signature-256" => sig
+            }
+        end
+      end
+
+      assert_response :ok
+      assert_includes dispatched_events, "comment_created",
+        "Channel-injected comment must trigger orchestration"
+      assert_equal "PR #321", @channel.reload.latest_label
+    end
+  end
+end

--- a/engines/collavre_github/test/models/collavre_github/github_pr_channel_test.rb
+++ b/engines/collavre_github/test/models/collavre_github/github_pr_channel_test.rb
@@ -108,5 +108,29 @@ module CollavreGithub
       }
       assert_nil @channel.handle(event: "pull_request_review", payload: payload)
     end
+
+    test "handle detaches channel and posts a final closing message on pull_request.closed (merged)" do
+      payload = {
+        "action" => "closed",
+        "pull_request" => { "number" => 42, "merged" => true, "html_url" => "https://github.com/owner/repo/pull/42" },
+        "repository" => { "full_name" => "owner/repo" }
+      }
+      result = @channel.handle(event: "pull_request", payload: payload)
+      assert_kind_of Collavre::Channel::InjectedMessage, result
+      assert_includes result.message, "merged"
+      @channel.reload
+      assert_predicate @channel, :detached?
+    end
+
+    test "handle detaches channel on pull_request.closed (not merged)" do
+      payload = {
+        "action" => "closed",
+        "pull_request" => { "number" => 42, "merged" => false, "html_url" => "https://github.com/owner/repo/pull/42" },
+        "repository" => { "full_name" => "owner/repo" }
+      }
+      result = @channel.handle(event: "pull_request", payload: payload)
+      assert_includes result.message, "closed"
+      assert_predicate @channel.reload, :detached?
+    end
   end
 end

--- a/engines/collavre_github/test/models/collavre_github/github_pr_channel_test.rb
+++ b/engines/collavre_github/test/models/collavre_github/github_pr_channel_test.rb
@@ -1,0 +1,57 @@
+require "test_helper"
+
+module CollavreGithub
+  class GithubPrChannelTest < ActiveSupport::TestCase
+    setup do
+      # NOTE: collavre_topics(:one) fixture does not exist; create inline.
+      @user = Collavre::User.find_by!(email: "one@example1.com")
+      @creative = Collavre::Creative.create!(description: "Test", user: @user)
+      @topic = Collavre::Topic.create!(name: "T", creative: @creative, user: @user)
+      @channel = GithubPrChannel.create!(
+        topic: @topic,
+        config: { "repo_full_name" => "owner/repo", "pr_number" => 42 }
+      )
+    end
+
+    test "handle returns InjectedMessage for issue_comment.created" do
+      payload = {
+        "action" => "created",
+        "comment" => {
+          "id" => 1001,
+          "body" => "please fix typo",
+          "html_url" => "https://github.com/owner/repo/pull/42#issuecomment-1001",
+          "user" => { "login" => "alice", "type" => "User", "id" => 7 }
+        },
+        "issue" => { "number" => 42, "pull_request" => {} },
+        "repository" => { "full_name" => "owner/repo" }
+      }
+
+      result = @channel.handle(event: "issue_comment", payload: payload)
+      assert_kind_of Collavre::Channel::InjectedMessage, result
+      assert_includes result.message, "alice"
+      assert_includes result.message, "please fix typo"
+      assert_equal "PR #42", result.label
+      assert_equal "https://github.com/owner/repo/pull/42", result.link
+    end
+
+    test "handle returns nil when action is not created" do
+      payload = {
+        "action" => "edited",
+        "comment" => { "body" => "x", "user" => { "login" => "a", "type" => "User" } },
+        "issue" => { "number" => 42, "pull_request" => {} },
+        "repository" => { "full_name" => "owner/repo" }
+      }
+      assert_nil @channel.handle(event: "issue_comment", payload: payload)
+    end
+
+    test "handle returns nil when issue has no pull_request (plain issue)" do
+      payload = {
+        "action" => "created",
+        "comment" => { "body" => "x", "user" => { "login" => "a", "type" => "User" } },
+        "issue" => { "number" => 42 },
+        "repository" => { "full_name" => "owner/repo" }
+      }
+      assert_nil @channel.handle(event: "issue_comment", payload: payload)
+    end
+  end
+end

--- a/engines/collavre_github/test/models/collavre_github/github_pr_channel_test.rb
+++ b/engines/collavre_github/test/models/collavre_github/github_pr_channel_test.rb
@@ -109,7 +109,7 @@ module CollavreGithub
       assert_nil @channel.handle(event: "pull_request_review", payload: payload)
     end
 
-    test "handle detaches channel and posts a final closing message on pull_request.closed (merged)" do
+    test "handle returns closing InjectedMessage on pull_request.closed (merged) without detaching" do
       payload = {
         "action" => "closed",
         "pull_request" => { "number" => 42, "merged" => true, "html_url" => "https://github.com/owner/repo/pull/42" },
@@ -118,8 +118,9 @@ module CollavreGithub
       result = @channel.handle(event: "pull_request", payload: payload)
       assert_kind_of Collavre::Channel::InjectedMessage, result
       assert_includes result.message, "merged"
-      @channel.reload
-      assert_predicate @channel, :detached?
+      # Detach is now performed by the webhook controller after inject_into_topic!,
+      # so handle() alone must NOT detach.
+      assert_predicate @channel.reload, :active?
     end
 
     test "handle returns nil when comment author matches ignore_actor_logins" do
@@ -133,7 +134,7 @@ module CollavreGithub
       assert_nil @channel.handle(event: "issue_comment", payload: payload)
     end
 
-    test "handle detaches channel on pull_request.closed (not merged)" do
+    test "handle returns closing InjectedMessage on pull_request.closed (not merged) without detaching" do
       payload = {
         "action" => "closed",
         "pull_request" => { "number" => 42, "merged" => false, "html_url" => "https://github.com/owner/repo/pull/42" },
@@ -141,7 +142,8 @@ module CollavreGithub
       }
       result = @channel.handle(event: "pull_request", payload: payload)
       assert_includes result.message, "closed"
-      assert_predicate @channel.reload, :detached?
+      # Detach is now performed by the webhook controller after inject_into_topic!.
+      assert_predicate @channel.reload, :active?
     end
   end
 end

--- a/engines/collavre_github/test/models/collavre_github/github_pr_channel_test.rb
+++ b/engines/collavre_github/test/models/collavre_github/github_pr_channel_test.rb
@@ -124,7 +124,7 @@ module CollavreGithub
     end
 
     test "handle returns nil when comment author matches ignore_actor_logins" do
-      @channel.update!(config: @channel.config.merge("ignore_actor_logins" => ["my-bot"]))
+      @channel.update!(config: @channel.config.merge("ignore_actor_logins" => [ "my-bot" ]))
       payload = {
         "action" => "created",
         "comment" => { "body" => "noise", "user" => { "login" => "my-bot", "type" => "Bot" } },

--- a/engines/collavre_github/test/models/collavre_github/github_pr_channel_test.rb
+++ b/engines/collavre_github/test/models/collavre_github/github_pr_channel_test.rb
@@ -134,6 +134,21 @@ module CollavreGithub
       assert_nil @channel.handle(event: "issue_comment", payload: payload)
     end
 
+    test "ensures the channel bot user exists when seeds were not run" do
+      Collavre::User.where(email: Collavre::Channel::BOT_EMAIL).destroy_all
+
+      payload = {
+        "action" => "created",
+        "comment" => { "id" => 999, "body" => "hi", "user" => { "login" => "alice", "type" => "User" } },
+        "issue" => { "number" => 42, "pull_request" => {} },
+        "repository" => { "full_name" => "owner/repo" }
+      }
+
+      result = @channel.handle(event: "issue_comment", payload: payload)
+      assert_kind_of Collavre::Channel::InjectedMessage, result
+      assert_equal Collavre::Channel::BOT_EMAIL, result.speaker.email
+    end
+
     test "handle returns closing InjectedMessage on pull_request.closed (not merged) without detaching" do
       payload = {
         "action" => "closed",

--- a/engines/collavre_github/test/models/collavre_github/github_pr_channel_test.rb
+++ b/engines/collavre_github/test/models/collavre_github/github_pr_channel_test.rb
@@ -122,6 +122,17 @@ module CollavreGithub
       assert_predicate @channel, :detached?
     end
 
+    test "handle returns nil when comment author matches ignore_actor_logins" do
+      @channel.update!(config: @channel.config.merge("ignore_actor_logins" => ["my-bot"]))
+      payload = {
+        "action" => "created",
+        "comment" => { "body" => "noise", "user" => { "login" => "my-bot", "type" => "Bot" } },
+        "issue" => { "number" => 42, "pull_request" => {} },
+        "repository" => { "full_name" => "owner/repo" }
+      }
+      assert_nil @channel.handle(event: "issue_comment", payload: payload)
+    end
+
     test "handle detaches channel on pull_request.closed (not merged)" do
       payload = {
         "action" => "closed",

--- a/engines/collavre_github/test/models/collavre_github/github_pr_channel_test.rb
+++ b/engines/collavre_github/test/models/collavre_github/github_pr_channel_test.rb
@@ -53,5 +53,26 @@ module CollavreGithub
       }
       assert_nil @channel.handle(event: "issue_comment", payload: payload)
     end
+
+    test "handle returns InjectedMessage for pull_request_review_comment.created" do
+      payload = {
+        "action" => "created",
+        "comment" => {
+          "id" => 2002,
+          "body" => "rename this var",
+          "path" => "app/foo.rb",
+          "line" => 42,
+          "html_url" => "https://github.com/owner/repo/pull/42#discussion_r2002",
+          "user" => { "login" => "bob", "type" => "User", "id" => 8 }
+        },
+        "pull_request" => { "number" => 42 },
+        "repository" => { "full_name" => "owner/repo" }
+      }
+      result = @channel.handle(event: "pull_request_review_comment", payload: payload)
+      assert_kind_of Collavre::Channel::InjectedMessage, result
+      assert_includes result.message, "bob"
+      assert_includes result.message, "app/foo.rb"
+      assert_includes result.message, "rename this var"
+    end
   end
 end

--- a/engines/collavre_github/test/models/collavre_github/github_pr_channel_test.rb
+++ b/engines/collavre_github/test/models/collavre_github/github_pr_channel_test.rb
@@ -74,5 +74,39 @@ module CollavreGithub
       assert_includes result.message, "app/foo.rb"
       assert_includes result.message, "rename this var"
     end
+
+    test "handle returns InjectedMessage for pull_request_review.submitted with body" do
+      payload = {
+        "action" => "submitted",
+        "review" => {
+          "id" => 3003,
+          "state" => "changes_requested",
+          "body" => "Overall LGTM but please address comments.",
+          "html_url" => "https://github.com/owner/repo/pull/42#pullrequestreview-3003",
+          "user" => { "login" => "carol", "type" => "User", "id" => 9 }
+        },
+        "pull_request" => { "number" => 42 },
+        "repository" => { "full_name" => "owner/repo" }
+      }
+      result = @channel.handle(event: "pull_request_review", payload: payload)
+      assert_kind_of Collavre::Channel::InjectedMessage, result
+      assert_includes result.message, "carol"
+      assert_includes result.message, "changes_requested"
+      assert_includes result.message, "Overall LGTM"
+    end
+
+    test "handle returns nil for pull_request_review.submitted with empty body" do
+      payload = {
+        "action" => "submitted",
+        "review" => {
+          "state" => "approved",
+          "body" => "",
+          "user" => { "login" => "carol", "type" => "User" }
+        },
+        "pull_request" => { "number" => 42 },
+        "repository" => { "full_name" => "owner/repo" }
+      }
+      assert_nil @channel.handle(event: "pull_request_review", payload: payload)
+    end
   end
 end

--- a/engines/collavre_github/test/services/collavre_github/pr_topic_link_parser_test.rb
+++ b/engines/collavre_github/test/services/collavre_github/pr_topic_link_parser_test.rb
@@ -1,0 +1,29 @@
+require "test_helper"
+
+module CollavreGithub
+  class PrTopicLinkParserTest < ActiveSupport::TestCase
+    test "extracts topic id from absolute URL in PR body" do
+      body = "Closes #1.\n\nTopic: https://collavre.example.com/creatives/123/topics/456"
+      assert_equal 456, PrTopicLinkParser.call(body)
+    end
+
+    test "extracts topic id from path-only reference" do
+      body = "Linked: /creatives/123/topics/789"
+      assert_equal 789, PrTopicLinkParser.call(body)
+    end
+
+    test "returns nil when no topic link present" do
+      assert_nil PrTopicLinkParser.call("just a regular PR body")
+    end
+
+    test "returns nil for blank body" do
+      assert_nil PrTopicLinkParser.call(nil)
+      assert_nil PrTopicLinkParser.call("")
+    end
+
+    test "returns first match when multiple topic links present" do
+      body = "A: /creatives/1/topics/10 B: /creatives/2/topics/20"
+      assert_equal 10, PrTopicLinkParser.call(body)
+    end
+  end
+end

--- a/engines/collavre_github/test/services/collavre_github/tools/pr_monitor_service_test.rb
+++ b/engines/collavre_github/test/services/collavre_github/tools/pr_monitor_service_test.rb
@@ -35,6 +35,23 @@ module CollavreGithub
           PrMonitorService.new.call(topic_id: @topic.id, pr_url: "https://example.com/not-a-pr")
         end
       end
+
+      test "reactivates a detached channel instead of orphaning it" do
+        channel = GithubPrChannel.create!(
+          topic_id: @topic.id,
+          config: { "repo_full_name" => "owner/repo", "pr_number" => 77 },
+          state: :detached
+        )
+
+        result = PrMonitorService.new.call(
+          topic_id: @topic.id,
+          pr_url: "https://github.com/owner/repo/pull/77"
+        )
+
+        assert result[:ok]
+        assert_equal channel.id, result[:channel_id]
+        assert channel.reload.active?
+      end
     end
   end
 end

--- a/engines/collavre_github/test/services/collavre_github/tools/pr_monitor_service_test.rb
+++ b/engines/collavre_github/test/services/collavre_github/tools/pr_monitor_service_test.rb
@@ -36,6 +36,29 @@ module CollavreGithub
         end
       end
 
+      test "normalizes mixed-case repo names to lowercase so webhooks match" do
+        result = PrMonitorService.new.call(
+          topic_id: @topic.id,
+          pr_url: "https://github.com/Owner/Repo/pull/88"
+        )
+        assert result[:ok]
+        channel = GithubPrChannel.find(result[:channel_id])
+        assert_equal "owner/repo", channel.repo_full_name
+      end
+
+      test "reuses channel when input casing differs from stored row" do
+        first = PrMonitorService.new.call(
+          topic_id: @topic.id,
+          pr_url: "https://github.com/owner/repo/pull/99"
+        )
+        second = PrMonitorService.new.call(
+          topic_id: @topic.id,
+          pr_url: "https://github.com/OWNER/REPO/pull/99"
+        )
+        assert_equal first[:channel_id], second[:channel_id]
+        assert_equal 1, GithubPrChannel.where(topic_id: @topic.id).count
+      end
+
       test "reactivates a detached channel instead of orphaning it" do
         channel = GithubPrChannel.create!(
           topic_id: @topic.id,

--- a/engines/collavre_github/test/services/collavre_github/tools/pr_monitor_service_test.rb
+++ b/engines/collavre_github/test/services/collavre_github/tools/pr_monitor_service_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module CollavreGithub
+  module Tools
+    class PrMonitorServiceTest < ActiveSupport::TestCase
+      setup do
+        @user = users(:one)
+        @creative = creatives(:tshirt)
+        @topic = Collavre::Topic.create!(name: "T", creative: @creative, user: @user)
+      end
+
+      test "attaches a GithubPrChannel for given topic and PR URL" do
+        result = PrMonitorService.new.call(
+          topic_id: @topic.id,
+          pr_url: "https://github.com/owner/repo/pull/77"
+        )
+        assert result[:ok]
+        channel = GithubPrChannel.last
+        assert_equal @topic.id, channel.topic_id
+        assert_equal "owner/repo", channel.repo_full_name
+        assert_equal 77, channel.pr_number
+      end
+
+      test "idempotent: calling twice does not create duplicate" do
+        2.times do
+          PrMonitorService.new.call(topic_id: @topic.id, pr_url: "https://github.com/owner/repo/pull/77")
+        end
+        assert_equal 1, GithubPrChannel.where(topic_id: @topic.id).count
+      end
+
+      test "raises on invalid PR URL" do
+        assert_raises(ArgumentError) do
+          PrMonitorService.new.call(topic_id: @topic.id, pr_url: "https://example.com/not-a-pr")
+        end
+      end
+    end
+  end
+end

--- a/engines/collavre_github/test/services/collavre_github/tools/pr_monitor_service_test.rb
+++ b/engines/collavre_github/test/services/collavre_github/tools/pr_monitor_service_test.rb
@@ -9,6 +9,11 @@ module CollavreGithub
         @user = users(:one)
         @creative = creatives(:tshirt)
         @topic = Collavre::Topic.create!(name: "T", creative: @creative, user: @user)
+        Collavre::Current.user = @user
+      end
+
+      teardown do
+        Collavre::Current.user = nil
       end
 
       test "attaches a GithubPrChannel for given topic and PR URL" do
@@ -57,6 +62,19 @@ module CollavreGithub
         )
         assert_equal first[:channel_id], second[:channel_id]
         assert_equal 1, GithubPrChannel.where(topic_id: @topic.id).count
+      end
+
+      test "denies attachment when current user lacks write permission on the topic's creative" do
+        outsider = users(:two)
+        Collavre::Current.user = outsider
+
+        assert_raises(CollavreGithub::Tools::PermissionDeniedError) do
+          PrMonitorService.new.call(
+            topic_id: @topic.id,
+            pr_url: "https://github.com/owner/repo/pull/77"
+          )
+        end
+        assert_equal 0, GithubPrChannel.where(topic_id: @topic.id).count
       end
 
       test "reactivates a detached channel instead of orphaning it" do


### PR DESCRIPTION
## Summary
- Adds a generic `Channel` abstraction (STI, polymorphic on topic) that adapts external events into topic chat messages. First implementation is `CollavreGithub::GithubPrChannel`, which converts PR `issue_comment`, `pull_request_review_comment`, and `pull_request_review` events into messages spoken by a seeded `Channel` bot user so the topic's AI agent processes them like normal chat.
- PR description links to a topic auto-attach the channel on `pull_request.opened`; manual attachment is available via the `pr_monitor` MCP tool (and through collavre CLI). `pull_request.closed` injects a closing message and detaches.
- Channel chips render in the typing indicator with a detach (X) button (`DELETE /channels/:id`, write-permission guarded), and broadcast over ActionCable. Loop prevention via `ignore_actor_logins` drops webhooks from our own bot identity.

## Test plan
- [x] collavre engine suite: 1171 runs, 3943 assertions, 0 failures
- [x] host app suite: 41 runs, 0 failures
- [x] new unit tests for `GithubPrChannel`, `PrTopicLinkParser`, `pr_monitor` service
- [x] end-to-end integration test: webhook → channel dispatch → comment injected → agent dispatch path
- [ ] Manual: open a PR with a topic link in the description, leave a PR comment, confirm chip appears and message is injected
- [ ] Manual: click X on chip, confirm channel detached and chip removed