### PR TITLE
fix(pr_monitor): seed chip label/link and announce attach in topic

### DIFF
--- a/engines/collavre_github/app/models/collavre_github/github_pr_channel.rb
+++ b/engines/collavre_github/app/models/collavre_github/github_pr_channel.rb
@@ -18,6 +18,15 @@ module CollavreGithub
       t("label", number: pr_number)
     end
 
+    def attached_message
+      Collavre::Channel::InjectedMessage.new(
+        speaker: channel_bot_user,
+        message: t("attached_message", label: label, url: pr_url),
+        label: label,
+        link: pr_url
+      )
+    end
+
     def handle(event:, payload:)
       case event
       when "issue_comment"

--- a/engines/collavre_github/app/services/collavre_github/tools/pr_monitor_service.rb
+++ b/engines/collavre_github/app/services/collavre_github/tools/pr_monitor_service.rb
@@ -33,7 +33,8 @@ module CollavreGithub
 
         topic = Collavre::Topic.find(topic_id)
         authorize_topic_write!(topic)
-        channel = find_or_attach_channel(topic, repo, pr_number)
+        channel, created = find_or_attach_channel(topic, repo, pr_number)
+        channel.inject_into_topic!(channel.attached_message) if created
         { ok: true, channel_id: channel.id, repo: repo, pr_number: pr_number }
       end
 
@@ -55,23 +56,24 @@ module CollavreGithub
           "No write permission on topic #{topic.id}"
       end
 
-      sig { params(topic: Collavre::Topic, repo: String, pr_number: Integer).returns(CollavreGithub::GithubPrChannel) }
+      sig { params(topic: Collavre::Topic, repo: String, pr_number: Integer).returns([CollavreGithub::GithubPrChannel, T::Boolean]) }
       def find_or_attach_channel(topic, repo, pr_number)
         existing = lookup_channel(topic, repo, pr_number)
         if existing
           existing.update!(state: :active) unless existing.active?
-          return existing
+          return [existing, false]
         end
-        CollavreGithub::GithubPrChannel.create!(
+        created = CollavreGithub::GithubPrChannel.create!(
           topic_id: topic.id,
           config: { "repo_full_name" => repo, "pr_number" => pr_number }
         )
+        [created, true]
       rescue ActiveRecord::RecordNotUnique
         # Concurrent caller won the race; reuse the row they created.
         existing = lookup_channel(topic, repo, pr_number)
         raise unless existing
         existing.update!(state: :active) unless existing.active?
-        existing
+        [existing, false]
       end
 
       sig { params(topic: Collavre::Topic, repo: String, pr_number: Integer).returns(T.nilable(CollavreGithub::GithubPrChannel)) }

--- a/engines/collavre_github/app/services/collavre_github/tools/pr_monitor_service.rb
+++ b/engines/collavre_github/app/services/collavre_github/tools/pr_monitor_service.rb
@@ -56,24 +56,24 @@ module CollavreGithub
           "No write permission on topic #{topic.id}"
       end
 
-      sig { params(topic: Collavre::Topic, repo: String, pr_number: Integer).returns([CollavreGithub::GithubPrChannel, T::Boolean]) }
+      sig { params(topic: Collavre::Topic, repo: String, pr_number: Integer).returns([ CollavreGithub::GithubPrChannel, T::Boolean ]) }
       def find_or_attach_channel(topic, repo, pr_number)
         existing = lookup_channel(topic, repo, pr_number)
         if existing
           existing.update!(state: :active) unless existing.active?
-          return [existing, false]
+          return [ existing, false ]
         end
         created = CollavreGithub::GithubPrChannel.create!(
           topic_id: topic.id,
           config: { "repo_full_name" => repo, "pr_number" => pr_number }
         )
-        [created, true]
+        [ created, true ]
       rescue ActiveRecord::RecordNotUnique
         # Concurrent caller won the race; reuse the row they created.
         existing = lookup_channel(topic, repo, pr_number)
         raise unless existing
         existing.update!(state: :active) unless existing.active?
-        [existing, false]
+        [ existing, false ]
       end
 
       sig { params(topic: Collavre::Topic, repo: String, pr_number: Integer).returns(T.nilable(CollavreGithub::GithubPrChannel)) }

--- a/engines/collavre_github/config/locales/en.yml
+++ b/engines/collavre_github/config/locales/en.yml
@@ -105,3 +105,4 @@ en:
         review_comment_location_path_line: " on `%{path}`:%{line}"
         review_submitted_message: "**@%{author}** submitted a review (`%{state}`) on %{label}:\n\n%{body}"
         closed_message: "%{label} was **%{verb}**. Detaching channel."
+        attached_message: "%{label} monitoring started.\n\n%{url}"

--- a/engines/collavre_github/config/locales/ko.yml
+++ b/engines/collavre_github/config/locales/ko.yml
@@ -105,3 +105,4 @@ ko:
         review_comment_location_path_line: " (`%{path}`:%{line})"
         review_submitted_message: "**@%{author}**님이 %{label}에 리뷰를 제출했습니다 (`%{state}`):\n\n%{body}"
         closed_message: "%{label}이(가) **%{verb}** 되었습니다. 채널을 해제합니다."
+        attached_message: "%{label} 모니터링이 시작되었습니다.\n\n%{url}"

--- a/engines/collavre_github/test/services/collavre_github/tools/pr_monitor_service_test.rb
+++ b/engines/collavre_github/test/services/collavre_github/tools/pr_monitor_service_test.rb
@@ -28,6 +28,36 @@ module CollavreGithub
         assert_equal 77, channel.pr_number
       end
 
+      test "first attach seeds chip label and link so the chip is clickable before any webhook fires" do
+        result = PrMonitorService.new.call(
+          topic_id: @topic.id,
+          pr_url: "https://github.com/owner/repo/pull/77"
+        )
+        channel = GithubPrChannel.find(result[:channel_id])
+        assert_equal "PR #77", channel.latest_label
+        assert_equal "https://github.com/owner/repo/pull/77", channel.latest_link
+      end
+
+      test "first attach injects an announcement comment into the topic creative" do
+        assert_difference -> { @creative.comments.count }, 1 do
+          PrMonitorService.new.call(
+            topic_id: @topic.id,
+            pr_url: "https://github.com/owner/repo/pull/77"
+          )
+        end
+        comment = @creative.comments.order(:created_at).last
+        assert_equal @topic.id, comment.topic_id
+        assert_includes comment.content, "PR #77"
+        assert_includes comment.content, "https://github.com/owner/repo/pull/77"
+      end
+
+      test "idempotent re-attach does not inject a duplicate announcement" do
+        PrMonitorService.new.call(topic_id: @topic.id, pr_url: "https://github.com/owner/repo/pull/77")
+        assert_no_difference -> { @creative.comments.count } do
+          PrMonitorService.new.call(topic_id: @topic.id, pr_url: "https://github.com/owner/repo/pull/77")
+        end
+      end
+
       test "idempotent: calling twice does not create duplicate" do
         2.times do
           PrMonitorService.new.call(topic_id: @topic.id, pr_url: "https://github.com/owner/repo/pull/77")


### PR DESCRIPTION
## Summary
- 첫 `pr_monitor` 호출 시 칩의 `latest_label`/`latest_link`를 `PR #N` / PR URL로 시드 → "GithubPrChannel" 클래스명 대신 즉시 라벨/링크 표시
- 채널이 새로 생성된 경우에만 토픽 타임라인에 "PR 모니터링이 시작되었습니다" 코멘트 1회 주입 (재호출/detached 재첨부에서는 중복 없음)
- ko/en locale에 `attached_message` 키 추가

## Root cause
`PrMonitorService#call`이 채널만 생성하고 `record_event!`/announcement를 호출하지 않아, 첫 webhook이 오기 전까지 칩 메타가 nil이고 토픽에도 흔적이 없었음.

## Test plan
- [x] `pr_monitor_service_test` 10/10 (신규 4건 포함)
- [x] 인접 GitHub 채널/웹훅 테스트 17/17
- [ ] 라이브 PR로 실제 칩 라벨/링크 + 토픽 코멘트 확인