### PR TITLE
fix(pr_monitor): auto-provision PR-channel webhook events and re-seed on reactivate

### DIFF
--- a/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
+++ b/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
@@ -17,7 +17,7 @@ module CollavreGithub
       # Process all links for this repo (same repo can be linked to multiple creatives)
       all_links = all_repository_links_for(payload)
       all_links.each do |link|
-        create_system_comment_for(link, event, payload) if link.creative
+        create_system_comment_for(link, event, payload) if link.creative && !channel_only_event?(event)
         trigger_markdown_sync_for(link, event, payload) if link.markdown_sync_enabled?
       end
 
@@ -30,6 +30,16 @@ module CollavreGithub
     end
 
     private
+
+    # `WebhookProvisioner` auto-subscribes every repo webhook to the events
+    # GithubPrChannel needs (`issue_comment`, `pull_request_review`,
+    # `pull_request_review_comment`). Those events must only reach attached
+    # PR channels — letting them through the creative feed would spam every
+    # linked creative with system comments from issues/PRs that nobody asked
+    # to monitor. `push` and `pull_request` continue to flow into the feed.
+    def channel_only_event?(event)
+      CollavreGithub::WebhookProvisioner::CHANNEL_EVENTS.include?(event)
+    end
 
     def maybe_auto_attach_channel(event, payload)
       return unless event == "pull_request" && payload["action"] == "opened"

--- a/engines/collavre_github/app/services/collavre_github/tools/pr_monitor_service.rb
+++ b/engines/collavre_github/app/services/collavre_github/tools/pr_monitor_service.rb
@@ -33,9 +33,18 @@ module CollavreGithub
 
         topic = Collavre::Topic.find(topic_id)
         authorize_topic_write!(topic)
-        channel, created = find_or_attach_channel(topic, repo, pr_number)
-        channel.inject_into_topic!(channel.attached_message) if created
-        { ok: true, channel_id: channel.id, repo: repo, pr_number: pr_number }
+        channel, attach_status = find_or_attach_channel(topic, repo, pr_number)
+        # Re-seed announcement on fresh attach AND on detached->active so the
+        # chip label/link cache is repopulated after the channel was previously
+        # auto-detached (PR closed) and the user reattached it.
+        if attach_status == :created || attach_status == :reactivated
+          channel.inject_into_topic!(channel.attached_message)
+        end
+
+        result = { ok: true, channel_id: channel.id, repo: repo, pr_number: pr_number }
+        warning = ensure_webhook_events(topic, repo)
+        result[:webhook_warning] = warning if warning
+        result
       end
 
       private
@@ -56,24 +65,35 @@ module CollavreGithub
           "No write permission on topic #{topic.id}"
       end
 
-      sig { params(topic: Collavre::Topic, repo: String, pr_number: Integer).returns([ CollavreGithub::GithubPrChannel, T::Boolean ]) }
+      # Returns the channel plus a status symbol so callers can distinguish:
+      #   :created     - new row inserted
+      #   :reactivated - existing detached row flipped back to active
+      #   :noop        - row was already active (idempotent re-attach)
+      sig { params(topic: Collavre::Topic, repo: String, pr_number: Integer).returns([ CollavreGithub::GithubPrChannel, Symbol ]) }
       def find_or_attach_channel(topic, repo, pr_number)
         existing = lookup_channel(topic, repo, pr_number)
         if existing
-          existing.update!(state: :active) unless existing.active?
-          return [ existing, false ]
+          if existing.active?
+            return [ existing, :noop ]
+          end
+          existing.update!(state: :active)
+          return [ existing, :reactivated ]
         end
         created = CollavreGithub::GithubPrChannel.create!(
           topic_id: topic.id,
           config: { "repo_full_name" => repo, "pr_number" => pr_number }
         )
-        [ created, true ]
+        [ created, :created ]
       rescue ActiveRecord::RecordNotUnique
         # Concurrent caller won the race; reuse the row they created.
         existing = lookup_channel(topic, repo, pr_number)
         raise unless existing
-        existing.update!(state: :active) unless existing.active?
-        [ existing, false ]
+        if existing.active?
+          [ existing, :noop ]
+        else
+          existing.update!(state: :active)
+          [ existing, :reactivated ]
+        end
       end
 
       sig { params(topic: Collavre::Topic, repo: String, pr_number: Integer).returns(T.nilable(CollavreGithub::GithubPrChannel)) }
@@ -81,6 +101,52 @@ module CollavreGithub
         CollavreGithub::GithubPrChannel.where(topic_id: topic.id).find do |c|
           c.repo_full_name.to_s.downcase == repo.downcase && c.pr_number == pr_number
         end
+      end
+
+      # Make sure the repo's webhook subscribes to the PR-channel events
+      # (issue_comment / pull_request_review / pull_request_review_comment).
+      # Without these, GitHub never delivers comment payloads and the channel
+      # silently misses them — exactly the bug that motivated this method.
+      # Returns a warning string when provisioning cannot run or fails; nil on
+      # success so the MCP response stays clean.
+      def ensure_webhook_events(topic, repo)
+        link = primary_repository_link_for(topic, repo)
+        return "no RepositoryLink found for #{repo} in topic creative scope; webhook events not auto-provisioned" unless link
+
+        account = link.github_account
+        return "RepositoryLink for #{repo} has no GitHub account; webhook events not auto-provisioned" unless account
+
+        CollavreGithub::WebhookProvisioner.ensure_for_links(
+          account: account,
+          links: [ link ],
+          webhook_url: github_webhook_url
+        )
+        nil
+      rescue => e
+        Rails.logger.warn("[pr_monitor] webhook provisioning failed for #{repo}: #{e.class}: #{e.message}")
+        "webhook provisioning failed: #{e.message}"
+      end
+
+      # Pick the canonical RepositoryLink whose subtree contains this topic.
+      # Mirrors WebhookProvisioner's "primary link" definition (lowest id) so
+      # the secret/events stay aligned with whatever the integrations controller
+      # would have provisioned.
+      def primary_repository_link_for(topic, repo)
+        creative = topic.creative
+        return nil unless creative
+
+        candidate_ids = [ creative.id ] + creative.ancestors.pluck(:id)
+        CollavreGithub::RepositoryLink
+          .where("LOWER(repository_full_name) = ?", repo.downcase)
+          .where(creative_id: candidate_ids)
+          .order(:id)
+          .first
+      end
+
+      def github_webhook_url
+        CollavreGithub::Engine.routes.url_helpers.webhooks_url(
+          Rails.application.config.action_mailer.default_url_options
+        )
       end
     end
   end

--- a/engines/collavre_github/app/services/collavre_github/tools/pr_monitor_service.rb
+++ b/engines/collavre_github/app/services/collavre_github/tools/pr_monitor_service.rb
@@ -110,28 +110,42 @@ module CollavreGithub
       # Returns a warning string when provisioning cannot run or fails; nil on
       # success so the MCP response stays clean.
       def ensure_webhook_events(topic, repo)
-        link = primary_repository_link_for(topic, repo)
-        return "no RepositoryLink found for #{repo} in topic creative scope; webhook events not auto-provisioned" unless link
+        scoped_link = scoped_repository_link_for(topic, repo)
+        return "no RepositoryLink found for #{repo} in topic creative scope; webhook events not auto-provisioned" unless scoped_link
 
-        account = link.github_account
+        # Provision through the *global* primary link (lowest id across all
+        # creatives), not the scoped link. WebhookProvisioner only patches hook
+        # events when the link IS the primary; non-primary links short-circuit
+        # to secret alignment and skip the GitHub edit_hook call. So if we
+        # provisioned the scoped link and it was not the global primary, the
+        # existing hook would keep its old event list. The scoped link is only
+        # used as an authorization gate above.
+        provisioning_link = global_primary_repository_link_for(repo) || scoped_link
+
+        account = provisioning_link.github_account
         return "RepositoryLink for #{repo} has no GitHub account; webhook events not auto-provisioned" unless account
 
-        CollavreGithub::WebhookProvisioner.ensure_for_links(
+        results = CollavreGithub::WebhookProvisioner.ensure_for_links(
           account: account,
-          links: [ link ],
+          links: [ provisioning_link ],
           webhook_url: github_webhook_url
         )
+        status = results.first&.last
+        # :failed means Client returned nil (Octokit/Faraday error rescued in
+        # CollavreGithub::Client). Surface that to the MCP caller so they know
+        # webhook events were not actually patched.
+        return "webhook provisioning failed: GitHub API rejected the hook request (see logs)" if status == :failed
         nil
       rescue => e
         Rails.logger.warn("[pr_monitor] webhook provisioning failed for #{repo}: #{e.class}: #{e.message}")
         "webhook provisioning failed: #{e.message}"
       end
 
-      # Pick the canonical RepositoryLink whose subtree contains this topic.
-      # Mirrors WebhookProvisioner's "primary link" definition (lowest id) so
-      # the secret/events stay aligned with whatever the integrations controller
-      # would have provisioned.
-      def primary_repository_link_for(topic, repo)
+      # Authorization gate: a RepositoryLink for `repo` must live in this
+      # topic's creative subtree (the topic creative itself or one of its
+      # ancestors). Without one, the dispatch path in WebhooksController would
+      # silently drop events for this topic anyway.
+      def scoped_repository_link_for(topic, repo)
         creative = topic.creative
         return nil unless creative
 
@@ -139,6 +153,17 @@ module CollavreGithub
         CollavreGithub::RepositoryLink
           .where("LOWER(repository_full_name) = ?", repo.downcase)
           .where(creative_id: candidate_ids)
+          .order(:id)
+          .first
+      end
+
+      # Mirrors WebhookProvisioner#primary_link_for: the lowest-id link for the
+      # repo across ALL creatives. This is the link whose secret + events the
+      # hook is aligned to, so we must provision through it to trigger an
+      # actual edit_hook call.
+      def global_primary_repository_link_for(repo)
+        CollavreGithub::RepositoryLink
+          .where("LOWER(repository_full_name) = ?", repo.downcase)
           .order(:id)
           .first
       end

--- a/engines/collavre_github/app/services/collavre_github/webhook_provisioner.rb
+++ b/engines/collavre_github/app/services/collavre_github/webhook_provisioner.rb
@@ -23,10 +23,15 @@ module CollavreGithub
       @webhook_url = webhook_url
     end
 
+    # Returns [[link, status], ...] so callers can detect silent GitHub
+    # rejections. status is one of:
+    #   :created         - new hook created
+    #   :updated         - existing hook patched (events/url/secret)
+    #   :secret_aligned  - non-primary link with existing hook; only the local
+    #                      RepositoryLink secret was aligned. No GitHub call.
+    #   :failed          - Octokit/Faraday error OR Client returned nil
     def ensure_for_links(links)
-      links.each do |link|
-        ensure_webhook(link)
-      end
+      links.map { |link| [ link, ensure_webhook(link) ] }
     end
 
     def remove_for_repositories(repositories)
@@ -56,8 +61,9 @@ module CollavreGithub
       if hook
         if primary_link && primary_link != link
           align_link_secret(link, primary_link.webhook_secret)
+          :secret_aligned
         else
-          update_webhook(repository_full_name, hook.id, link.webhook_secret)
+          update_webhook(repository_full_name, hook.id, link.webhook_secret) ? :updated : :failed
         end
       else
         secret = link.webhook_secret
@@ -67,12 +73,13 @@ module CollavreGithub
           align_link_secret(link, secret)
         end
 
-        create_webhook(repository_full_name, secret)
+        create_webhook(repository_full_name, secret) ? :created : :failed
       end
     rescue Octokit::Error => e
       Rails.logger.warn(
         "GitHub webhook provisioning failed for #{repository_full_name}: #{e.message}"
       )
+      :failed
     end
 
     def remove_webhook(repository_full_name)

--- a/engines/collavre_github/app/services/collavre_github/webhook_provisioner.rb
+++ b/engines/collavre_github/app/services/collavre_github/webhook_provisioner.rb
@@ -1,7 +1,13 @@
 module CollavreGithub
   class WebhookProvisioner
-    EVENTS = %w[pull_request].freeze
-    EVENTS_WITH_PUSH = %w[pull_request push].freeze
+    # PR channel webhooks need every event GithubPrChannel handles. Without
+    # `issue_comment` / `pull_request_review` / `pull_request_review_comment`
+    # GitHub never delivers the relevant deliveries, so pr_monitor would attach
+    # a channel that silently misses comments. `pull_request` is required by
+    # the auto-attach + close detection paths.
+    CHANNEL_EVENTS = %w[issue_comment pull_request_review pull_request_review_comment].freeze
+    EVENTS = (%w[pull_request] + CHANNEL_EVENTS).freeze
+    EVENTS_WITH_PUSH = (%w[pull_request push] + CHANNEL_EVENTS).freeze
     CONTENT_TYPE = "json".freeze
 
     def self.ensure_for_links(account:, links:, webhook_url:)

--- a/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_channels_test.rb
+++ b/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_channels_test.rb
@@ -223,6 +223,110 @@ module CollavreGithub
       ENV.delete("GITHUB_WEBHOOK_SECRET")
     end
 
+    test "channel-only events (issue_comment) do NOT create creative-level feed comments" do
+      # Regression: WebhookProvisioner started auto-subscribing every repo
+      # webhook to issue_comment / pull_request_review / pull_request_review_comment
+      # so PR channels actually receive deliveries. Those events must only feed
+      # attached PR channels — they must NOT spam every linked creative with a
+      # system comment for unrelated issues/PRs. `push` and `pull_request`
+      # still flow into the feed as before. The feed comment lands on the
+      # creative's main_topic (assigned by Comment#assign_main_topic), so we
+      # count comments on that topic — must not increment.
+      main_topic = @creative.main_topic(fallback_user: @user)
+      assert_not_equal @topic.id, main_topic.id, "test depends on @topic != main_topic"
+
+      payload = {
+        action: "created",
+        comment: {
+          id: 501,
+          body: "no feed entry please",
+          user: { login: "alice", type: "User", id: 1 }
+        },
+        issue: { number: 99, pull_request: {} },
+        repository: { full_name: @link.repository_full_name }
+      }.to_json
+      sig = "sha256=" + OpenSSL::HMAC.hexdigest("SHA256", @link.webhook_secret, payload)
+
+      before_main = Collavre::Comment.where(topic_id: main_topic.id).count
+
+      assert_difference -> { Collavre::Comment.where(topic_id: @topic.id).count }, 1 do
+        post "/github/webhook",
+          params: payload,
+          headers: {
+            "Content-Type" => "application/json",
+            "X-GitHub-Event" => "issue_comment",
+            "X-Hub-Signature-256" => sig
+          }
+      end
+      assert_response :ok
+      assert_equal before_main, Collavre::Comment.where(topic_id: main_topic.id).count,
+        "issue_comment must not create a creative-level (main_topic) feed comment"
+    end
+
+    test "channel-only event on UNmonitored PR creates neither feed nor topic comment" do
+      # Detach the only channel so the PR is unmonitored, then send issue_comment.
+      # Nothing should be written anywhere — the event should be dropped entirely.
+      @channel.detach!
+
+      payload = {
+        action: "created",
+        comment: {
+          id: 502,
+          body: "unmonitored",
+          user: { login: "bob", type: "User", id: 2 }
+        },
+        issue: { number: 99, pull_request: {} },
+        repository: { full_name: @link.repository_full_name }
+      }.to_json
+      sig = "sha256=" + OpenSSL::HMAC.hexdigest("SHA256", @link.webhook_secret, payload)
+
+      before_any = Collavre::Comment.where(creative_id: @creative.id).count
+
+      post "/github/webhook",
+        params: payload,
+        headers: {
+          "Content-Type" => "application/json",
+          "X-GitHub-Event" => "issue_comment",
+          "X-Hub-Signature-256" => sig
+        }
+
+      assert_response :ok
+      assert_equal before_any, Collavre::Comment.where(creative_id: @creative.id).count,
+        "unmonitored channel-only event must not produce any comment"
+    end
+
+    test "pull_request event still creates a creative-level feed comment" do
+      # Opposite-direction guard: pull_request is NOT a channel-only event,
+      # so it should keep flowing into the creative feed. Use action=opened
+      # WITHOUT a topic-link body so auto-attach is a no-op and we only
+      # observe the feed write. The feed comment is routed to main_topic.
+      main_topic = @creative.main_topic(fallback_user: @user)
+
+      payload = {
+        action: "opened",
+        pull_request: {
+          number: 1234,
+          title: "feat: x",
+          html_url: "https://github.com/#{@link.repository_full_name}/pull/1234",
+          user: { login: "alice" },
+          body: ""
+        },
+        repository: { full_name: @link.repository_full_name }
+      }.to_json
+      sig = "sha256=" + OpenSSL::HMAC.hexdigest("SHA256", @link.webhook_secret, payload)
+
+      assert_difference -> { Collavre::Comment.where(topic_id: main_topic.id).count }, 1 do
+        post "/github/webhook",
+          params: payload,
+          headers: {
+            "Content-Type" => "application/json",
+            "X-GitHub-Event" => "pull_request",
+            "X-Hub-Signature-256" => sig
+          }
+      end
+      assert_response :ok
+    end
+
     test "pull_request.closed injects closing comment AND detaches channel" do
       payload = {
         action: "closed",

--- a/engines/collavre_github/test/services/collavre_github/tools/pr_monitor_service_test.rb
+++ b/engines/collavre_github/test/services/collavre_github/tools/pr_monitor_service_test.rb
@@ -225,6 +225,129 @@ module CollavreGithub
         assert_includes patched_events, "pull_request_review_comment"
         assert_includes patched_events, "pull_request"
       end
+
+      test "surfaces webhook_warning when GitHub rejects the hook PATCH" do
+        # CollavreGithub::Client rescues Octokit/Faraday errors silently and
+        # returns nil. Without surfacing that result, pr_monitor would report
+        # success even though the hook events were never updated. Confirm the
+        # warning is included in the MCP response when GitHub returns an error.
+        account = CollavreGithub::Account.create!(
+          user: @user,
+          github_uid: "pr-monitor-prov-fail",
+          login: "owner",
+          name: @user.name,
+          token: "ghp-test-token-fail"
+        )
+        CollavreGithub::RepositoryLink.create!(
+          creative: @creative,
+          github_account: account,
+          repository_full_name: "owner/repo",
+          webhook_secret: "secret-fail-1234"
+        )
+
+        webhook_url = CollavreGithub::Engine.routes.url_helpers.webhooks_url(
+          Rails.application.config.action_mailer.default_url_options
+        )
+        existing_hook_id = 99999999
+        stub_request(:get, %r{https://api\.github\.com/repos/owner/repo/hooks})
+          .to_return(
+            status: 200,
+            body: [ { id: existing_hook_id, config: { url: webhook_url }, events: [ "pull_request" ] } ].to_json,
+            headers: { "Content-Type" => "application/json" }
+          )
+        # GitHub rejects the PATCH (e.g. token lost admin perms). Client
+        # rescues + returns nil, so ensure_webhook must surface :failed.
+        stub_request(:patch, "https://api.github.com/repos/owner/repo/hooks/#{existing_hook_id}")
+          .to_return(status: 403, body: { message: "Resource not accessible" }.to_json,
+                     headers: { "Content-Type" => "application/json" })
+
+        result = PrMonitorService.new.call(
+          topic_id: @topic.id,
+          pr_url: "https://github.com/owner/repo/pull/77"
+        )
+
+        assert result[:ok]
+        assert result[:webhook_warning].present?,
+          "expected webhook_warning when GitHub rejects PATCH, got: #{result.inspect}"
+        assert_includes result[:webhook_warning], "webhook provisioning failed"
+      end
+
+      test "provisions through the global primary link when topic's scoped link is non-primary" do
+        # When the same repo is linked from multiple creatives,
+        # WebhookProvisioner only PATCHes hook events for the lowest-id
+        # (primary) link. Non-primary links short-circuit to secret alignment
+        # and never call edit_hook. So we must hand the GLOBAL primary to the
+        # provisioner, not the topic-scoped link, otherwise the existing hook
+        # keeps its old event list.
+        sibling_creative = Collavre::Creative.create!(
+          description: "Sibling",
+          user: @user
+        )
+        # One account per user (UNIQUE constraint on github_accounts.user_id).
+        # Both RepositoryLinks share this account; only their creative scope
+        # and webhook_secret differ.
+        account = CollavreGithub::Account.create!(
+          user: @user,
+          github_uid: "pr-monitor-prov-shared",
+          login: "owner",
+          name: @user.name,
+          token: "ghp-test-token-primary"
+        )
+        # Lower id (created first) → becomes the global primary. Lives on a
+        # sibling creative outside the topic's subtree.
+        CollavreGithub::RepositoryLink.create!(
+          creative: sibling_creative,
+          github_account: account,
+          repository_full_name: "owner/repo",
+          webhook_secret: "primary-secret-1234"
+        )
+        # Higher id, sits in the topic's creative subtree → satisfies the
+        # authorization gate but is NOT the global primary.
+        CollavreGithub::RepositoryLink.create!(
+          creative: @creative,
+          github_account: account,
+          repository_full_name: "owner/repo",
+          webhook_secret: "scoped-secret-5678"
+        )
+
+        webhook_url = CollavreGithub::Engine.routes.url_helpers.webhooks_url(
+          Rails.application.config.action_mailer.default_url_options
+        )
+        existing_hook_id = 51515151
+        stub_request(:get, %r{https://api\.github\.com/repos/owner/repo/hooks})
+          .to_return(
+            status: 200,
+            body: [ { id: existing_hook_id, config: { url: webhook_url }, events: [ "pull_request" ] } ].to_json,
+            headers: { "Content-Type" => "application/json" }
+          )
+        patched_body = nil
+        edit_stub = stub_request(:patch, "https://api.github.com/repos/owner/repo/hooks/#{existing_hook_id}")
+          .with do |req|
+            patched_body = JSON.parse(req.body)
+            true
+          end
+          .to_return(
+            status: 200,
+            body: { id: existing_hook_id, active: true }.to_json,
+            headers: { "Content-Type" => "application/json" }
+          )
+
+        result = PrMonitorService.new.call(
+          topic_id: @topic.id,
+          pr_url: "https://github.com/owner/repo/pull/77"
+        )
+
+        assert result[:ok]
+        assert_nil result[:webhook_warning]
+        # The PATCH must fire — under the old behavior, pr_monitor handed
+        # WebhookProvisioner the scoped (non-primary) link, which would have
+        # short-circuited to `align_link_secret` and never called edit_hook.
+        assert_requested(edit_stub)
+        # And the secret should track the GLOBAL primary's secret, not the
+        # scoped link's. (WebhookProvisioner aligns the hook secret to the
+        # primary link's webhook_secret.)
+        assert_equal "primary-secret-1234", patched_body["config"]["secret"]
+      end
     end
   end
 end

--- a/engines/collavre_github/test/services/collavre_github/tools/pr_monitor_service_test.rb
+++ b/engines/collavre_github/test/services/collavre_github/tools/pr_monitor_service_test.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-require "test_helper"
+# Load the engine's test_helper (not the app's) so WebMock + GitHub stubs are
+# available for the webhook-provisioning test below.
+require_relative "../../../test_helper"
 
 module CollavreGithub
   module Tools
@@ -122,6 +124,106 @@ module CollavreGithub
         assert result[:ok]
         assert_equal channel.id, result[:channel_id]
         assert channel.reload.active?
+      end
+
+      test "detached->active re-attach re-seeds the chip label/link cache and announces in the topic" do
+        # Simulate a previously-attached channel that was auto-detached when
+        # the PR closed: latest_label / latest_link were populated at one
+        # point but no fresh announcement has run since reactivation.
+        channel = GithubPrChannel.create!(
+          topic_id: @topic.id,
+          config: { "repo_full_name" => "owner/repo", "pr_number" => 77 },
+          state: :detached,
+          latest_label: nil,
+          latest_link: nil
+        )
+
+        assert_difference -> { @creative.comments.count }, 1 do
+          PrMonitorService.new.call(
+            topic_id: @topic.id,
+            pr_url: "https://github.com/owner/repo/pull/77"
+          )
+        end
+
+        channel.reload
+        assert channel.active?
+        assert_equal "PR #77", channel.latest_label
+        assert_equal "https://github.com/owner/repo/pull/77", channel.latest_link
+      end
+
+      test "active->active idempotent re-attach does not re-announce" do
+        PrMonitorService.new.call(topic_id: @topic.id, pr_url: "https://github.com/owner/repo/pull/77")
+        assert_no_difference -> { @creative.comments.count } do
+          PrMonitorService.new.call(topic_id: @topic.id, pr_url: "https://github.com/owner/repo/pull/77")
+        end
+      end
+
+      test "returns webhook_warning when no RepositoryLink covers the topic creative scope" do
+        result = PrMonitorService.new.call(
+          topic_id: @topic.id,
+          pr_url: "https://github.com/owner/repo/pull/77"
+        )
+        # No CollavreGithub::RepositoryLink exists for owner/repo in @creative's
+        # subtree, so pr_monitor cannot provision webhook events. It should
+        # surface this in the response rather than silently succeeding.
+        assert_includes result[:webhook_warning].to_s, "no RepositoryLink found"
+      end
+
+      test "auto-provisions PR-channel webhook events when a RepositoryLink exists" do
+        account = CollavreGithub::Account.create!(
+          user: @user,
+          github_uid: "pr-monitor-prov-1",
+          login: "owner",
+          name: @user.name,
+          token: "ghp-test-token-prov"
+        )
+        link = CollavreGithub::RepositoryLink.create!(
+          creative: @creative,
+          github_account: account,
+          repository_full_name: "owner/repo",
+          webhook_secret: "secret-1234567890"
+        )
+
+        # Existing hook on the repo is subscribed only to `pull_request` —
+        # exactly the production bug. WebhookProvisioner must PATCH it to add
+        # the PR-channel events.
+        webhook_url = CollavreGithub::Engine.routes.url_helpers.webhooks_url(
+          Rails.application.config.action_mailer.default_url_options
+        )
+        existing_hook_id = 42424242
+        # Use regex so Octokit's `?per_page=100` query suffix still matches.
+        stub_request(:get, %r{https://api\.github\.com/repos/owner/repo/hooks})
+          .to_return(
+            status: 200,
+            body: [ { id: existing_hook_id, config: { url: webhook_url }, events: [ "pull_request" ] } ].to_json,
+            headers: { "Content-Type" => "application/json" }
+          )
+
+        patched_events = nil
+        edit_stub = stub_request(:patch, "https://api.github.com/repos/owner/repo/hooks/#{existing_hook_id}")
+          .with do |req|
+            body = JSON.parse(req.body)
+            patched_events = body["events"]
+            true
+          end
+          .to_return(
+            status: 200,
+            body: { id: existing_hook_id, active: true }.to_json,
+            headers: { "Content-Type" => "application/json" }
+          )
+
+        result = PrMonitorService.new.call(
+          topic_id: @topic.id,
+          pr_url: "https://github.com/owner/repo/pull/77"
+        )
+
+        assert result[:ok]
+        assert_nil result[:webhook_warning]
+        assert_requested(edit_stub)
+        assert_includes patched_events, "issue_comment"
+        assert_includes patched_events, "pull_request_review"
+        assert_includes patched_events, "pull_request_review_comment"
+        assert_includes patched_events, "pull_request"
       end
     end
   end


### PR DESCRIPTION
## Summary

운영에서 발견된 두 가지 PR 모니터 결함을 함께 수정합니다. 두 증상이 합쳐져 #1238 머지 직후 운영 PR #827 채널이 칩만 잘못 표시되고 코멘트가 토픽에 전혀 주입되지 않는 사고로 나타났습니다.

1. **GitHub webhook 이벤트 자동 등록.** `RepositoryLink`가 가리키는 repo의 GitHub webhook이 `pull_request`만 구독하고 있으면 GitHub는 `issue_comment` / `pull_request_review` / `pull_request_review_comment` payload 자체를 보내지 않아 채널이 조용히 코멘트를 놓칩니다. `pr_monitor` 호출 시 토픽이 속한 creative 서브트리의 `RepositoryLink`를 찾아 `WebhookProvisioner.ensure_for_links`로 누락된 이벤트를 PATCH 합니다. 링크가 없거나 Octokit 호출이 실패하면 MCP 응답의 `webhook_warning` 필드로 사일런트 실패 대신 명시적 경고를 노출합니다.
2. **detached→active 재첨부 시 attached_message 재시드.** PR이 닫혀 자동 detach 된 채널을 `pr_monitor`로 다시 붙이면 칩의 `latest_label` / `latest_link` 캐시가 비어 있어 칩이 클래스명("GithubPrChannel")으로 폴백되던 문제를 수정. 첫 attach 경로와 동일하게 안내 코멘트를 다시 주입해 캐시를 채웁니다.

또한 `WebhookProvisioner::EVENTS` / `EVENTS_WITH_PUSH` 상수에 PR-채널 이벤트 3개를 추가해, 통합 UI 등 기존 호출 경로에서도 다음 저장 시 자연스럽게 구독이 확장되도록 만들었습니다.

운영 진단 메모: `sh1nj1/plan42` repo의 두 webhook (`/github/webhook`, `/github/webhooks`)이 `pull_request`만 구독하고 있어 PR #827 코멘트가 collavre 서버까지 도달하지 않았습니다. 이 PR이 머지된 뒤 해당 토픽에서 `pr_monitor`를 한 번 더 호출하면 GitHub API 통해 이벤트가 자동으로 보강되고, 동시에 칩 라벨/링크도 재시드됩니다.

## Test plan

- [x] `bin/rails test engines/collavre_github/test/services/collavre_github/tools/pr_monitor_service_test.rb` — 14 runs, 46 assertions, 0 failures, 0 errors
- [x] `bin/rails test engines/collavre_github/test` — 83 runs, 277 assertions, 0 failures, 0 errors
- [x] `RAILS_ENV=test rake test` — 1721 runs, 5411 assertions, 0 failures, 0 errors
- [ ] (수동) 운영에서 `pr_monitor` 호출 후 GitHub Settings → Webhooks 페이지에서 events에 `issue_comment` / `pull_request_review` / `pull_request_review_comment`가 추가됐는지 확인, PR #827에 테스트 코멘트가 토픽 441에 주입되는지 확인.