### PR TITLE
fix(pr_monitor): de-dup closed event, status badge chips, dismiss-on-X

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_27_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_27_000100) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_26_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_27_000000) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false
@@ -80,6 +80,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_26_000000) do
   create_table "channels", force: :cascade do |t|
     t.json "config", default: {}, null: false
     t.datetime "created_at", null: false
+    t.datetime "dismissed_at"
     t.datetime "last_event_at"
     t.string "latest_label"
     t.string "latest_link"
@@ -88,6 +89,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_26_000000) do
     t.string "type", null: false
     t.datetime "updated_at", null: false
     t.index "type, topic_id, json_extract(config, '$.repo_full_name'), json_extract(config, '$.pr_number')", name: "index_channels_on_type_topic_repo_pr", unique: true
+    t.index ["dismissed_at"], name: "index_channels_on_dismissed_at"
     t.index ["topic_id"], name: "index_channels_on_topic_id"
     t.index ["type"], name: "index_channels_on_type"
   end

--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -1184,6 +1184,80 @@ body.chat-fullscreen {
     color: var(--text-on-btn);
 }
 
+/* --- Channel Chips (PR monitor etc) ------------------------------------ */
+#channel-chips-container,
+.channel-chips {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: var(--space-1);
+    align-items: center;
+}
+
+.channel-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-px-1);
+    padding: var(--space-px-1) var(--space-2);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-2);
+    background: var(--color-section-bg);
+    font-size: var(--text-00);
+    line-height: 1;
+    white-space: nowrap;
+}
+
+.channel-chip a {
+    color: var(--color-text);
+    text-decoration: none;
+}
+
+.channel-chip a:hover {
+    text-decoration: underline;
+}
+
+.channel-chip button {
+    background: none;
+    border: 0;
+    padding: 0 var(--space-px-1);
+    color: var(--text-muted);
+    cursor: pointer;
+    font-size: 1.1em;
+    line-height: 1;
+}
+
+.channel-chip button:hover {
+    color: var(--color-danger);
+}
+
+/* Detached chips lose a touch of contrast so users can tell a closed/merged
+   PR apart from one that is still actively monitored. */
+.channel-chip--detached {
+    opacity: 0.7;
+}
+
+.channel-chip-badge {
+    display: inline-block;
+    width: var(--space-2);
+    height: var(--space-2);
+    border-radius: 999px;
+    flex-shrink: 0;
+    background: var(--color-text);
+}
+
+.channel-chip-badge--open {
+    background: var(--color-success);
+}
+
+.channel-chip-badge--merged {
+    /* No purple token yet; --color-active (blue) is the closest neutral that
+       reads as "shipped" without colliding with success/danger semantics. */
+    background: var(--color-active);
+}
+
+.channel-chip-badge--closed_without_merge {
+    background: var(--color-danger);
+}
+
 /* --- Context Chips --- */
 .comment-contexts-list {
     display: flex;

--- a/engines/collavre/app/controllers/collavre/channels_controller.rb
+++ b/engines/collavre/app/controllers/collavre/channels_controller.rb
@@ -6,14 +6,17 @@ module Collavre
     before_action :require_creative_write!
 
     def destroy
-      @channel.detach!
+      @channel.dismiss!
       head :no_content
     end
 
     private
 
     def set_channel
-      @channel = Channel.active.find(params[:id])
+      # Look up among not-yet-dismissed channels (active OR detached). The X
+      # button must work on detached chips too — those linger so the user can
+      # still see the final merge/close badge until they choose to clear it.
+      @channel = Channel.not_dismissed.find(params[:id])
       @creative = @channel.topic.creative.effective_origin
     end
   end

--- a/engines/collavre/app/models/collavre/channel.rb
+++ b/engines/collavre/app/models/collavre/channel.rb
@@ -9,12 +9,29 @@ module Collavre
 
     enum :state, { active: 0, detached: 1 }, default: :active
 
+    scope :not_dismissed, -> { where(dismissed_at: nil) }
+
     def handle(event:, payload:)
       raise NotImplementedError, "#{self.class} must implement #handle"
     end
 
     def detach!
       update!(state: :detached)
+    end
+
+    def dismissed?
+      dismissed_at.present?
+    end
+
+    # Hide the chip from the typing-indicator row. Performs detach! as a
+    # side-effect when the channel is still active so dismissal is a single
+    # user-facing action — clicking the X always removes the chip regardless
+    # of prior state.
+    def dismiss!
+      transaction do
+        detach! if active?
+        update!(dismissed_at: Time.current) if dismissed_at.nil?
+      end
     end
 
     def record_event!(label:, link:)

--- a/engines/collavre/app/views/collavre/comments/_channel_chips.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_channel_chips.html.erb
@@ -6,8 +6,7 @@
         `pr_state` get a status-colored badge; others fall back to no badge. %>
     <% pr_state = channel.respond_to?(:pr_state) ? channel.pr_state : nil %>
     <% chip_classes = [ "channel-chip" ]
-       chip_classes << "channel-chip--detached" if channel.respond_to?(:detached?) && channel.detached?
-       chip_classes << "channel-chip--#{pr_state}" if pr_state %>
+       chip_classes << "channel-chip--detached" if channel.detached? %>
     <span class="<%= chip_classes.join(' ') %>" data-channel-id="<%= channel.id %>">
       <% if pr_state %>
         <span class="channel-chip-badge channel-chip-badge--<%= pr_state %>"

--- a/engines/collavre/app/views/collavre/comments/_channel_chips.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_channel_chips.html.erb
@@ -1,7 +1,19 @@
 <%# locals: { topic: Collavre::Topic } %>
 <div class="channel-chips" data-comments--presence-target="channelChips" data-topic-id="<%= topic.id %>">
-  <% topic.channels.active.each do |channel| %>
-    <span class="channel-chip" data-channel-id="<%= channel.id %>">
+  <% topic.channels.not_dismissed.each do |channel| %>
+    <%# Chip is kept after detach so the final merged/closed badge stays visible
+        until the user dismisses it with the X button. Subclasses that expose
+        `pr_state` get a status-colored badge; others fall back to no badge. %>
+    <% pr_state = channel.respond_to?(:pr_state) ? channel.pr_state : nil %>
+    <% chip_classes = [ "channel-chip" ]
+       chip_classes << "channel-chip--detached" if channel.respond_to?(:detached?) && channel.detached?
+       chip_classes << "channel-chip--#{pr_state}" if pr_state %>
+    <span class="<%= chip_classes.join(' ') %>" data-channel-id="<%= channel.id %>">
+      <% if pr_state %>
+        <span class="channel-chip-badge channel-chip-badge--<%= pr_state %>"
+              title="<%= t("collavre_github.channel.pr.badge.#{pr_state}", default: pr_state.to_s) %>"
+              aria-label="<%= t("collavre_github.channel.pr.badge.#{pr_state}", default: pr_state.to_s) %>"></span>
+      <% end %>
       <% if channel.latest_link.present? %>
         <a href="<%= channel.latest_link %>" target="_blank" rel="noopener">
           <%= channel.latest_label.presence || channel.class.name.demodulize %>

--- a/engines/collavre/db/migrate/20260527000000_add_dismissed_at_to_channels.rb
+++ b/engines/collavre/db/migrate/20260527000000_add_dismissed_at_to_channels.rb
@@ -1,0 +1,6 @@
+class AddDismissedAtToChannels < ActiveRecord::Migration[8.1]
+  def change
+    add_column :channels, :dismissed_at, :datetime
+    add_index :channels, :dismissed_at
+  end
+end

--- a/engines/collavre/db/migrate/20260527000100_backfill_dismissed_at_for_legacy_detached_channels.rb
+++ b/engines/collavre/db/migrate/20260527000100_backfill_dismissed_at_for_legacy_detached_channels.rb
@@ -1,0 +1,23 @@
+class BackfillDismissedAtForLegacyDetachedChannels < ActiveRecord::Migration[8.1]
+  # Chips are now rendered via `not_dismissed` (dismissed_at IS NULL) instead
+  # of `state = active`. Without a backfill, any channel that was already
+  # detached pre-upgrade — user clicked X under the old flow, or the PR auto-
+  # detached on close — would reappear as a chip with the default-open badge
+  # the first time the new view runs. Mark legacy detached rows as dismissed
+  # using their last-touched timestamp as a best-effort dismissed_at.
+  #
+  # Idempotent: the WHERE clause skips rows that already have dismissed_at.
+  def up
+    execute <<~SQL.squish
+      UPDATE channels
+      SET dismissed_at = COALESCE(updated_at, CURRENT_TIMESTAMP)
+      WHERE state = 1 AND dismissed_at IS NULL
+    SQL
+  end
+
+  def down
+    # No-op: we can't distinguish backfilled rows from rows the user actually
+    # dismissed at the exact same timestamp, and leaving dismissed_at populated
+    # on rollback is harmless.
+  end
+end

--- a/engines/collavre/db/migrate/20260527000100_backfill_dismissed_at_for_legacy_detached_channels.rb
+++ b/engines/collavre/db/migrate/20260527000100_backfill_dismissed_at_for_legacy_detached_channels.rb
@@ -7,11 +7,16 @@ class BackfillDismissedAtForLegacyDetachedChannels < ActiveRecord::Migration[8.1
   # using their last-touched timestamp as a best-effort dismissed_at.
   #
   # Idempotent: the WHERE clause skips rows that already have dismissed_at.
+  # Scoped to GithubPrChannel because the dismiss-on-detach UI ships only for
+  # PR chips. Future Channel STI subtypes opt in by adding their own backfill
+  # or by being created post-upgrade.
   def up
     execute <<~SQL.squish
       UPDATE channels
       SET dismissed_at = COALESCE(updated_at, CURRENT_TIMESTAMP)
-      WHERE state = 1 AND dismissed_at IS NULL
+      WHERE state = 1
+        AND dismissed_at IS NULL
+        AND type = 'CollavreGithub::GithubPrChannel'
     SQL
   end
 

--- a/engines/collavre/test/controllers/collavre/channels_controller_test.rb
+++ b/engines/collavre/test/controllers/collavre/channels_controller_test.rb
@@ -13,14 +13,24 @@ module Collavre
       sign_in_as(@user, password: "password")
     end
 
-    test "destroy detaches channel and returns 204" do
+    test "destroy dismisses an active channel (detaches + sets dismissed_at) and returns 204" do
       delete collavre.channel_path(@channel)
       assert_response :no_content
-      assert_predicate @channel.reload, :detached?
+      @channel.reload
+      assert_predicate @channel, :detached?
+      assert_predicate @channel, :dismissed?
     end
 
-    test "destroy returns 404 when channel already detached" do
+    test "destroy on a detached (but not yet dismissed) channel dismisses it" do
       @channel.detach!
+
+      delete collavre.channel_path(@channel)
+      assert_response :no_content
+      assert_predicate @channel.reload, :dismissed?
+    end
+
+    test "destroy returns 404 when channel was already dismissed" do
+      @channel.dismiss!
 
       delete collavre.channel_path(@channel)
       assert_response :not_found

--- a/engines/collavre/test/models/collavre/channel_test.rb
+++ b/engines/collavre/test/models/collavre/channel_test.rb
@@ -33,5 +33,37 @@ module Collavre
       assert_equal @user, msg.speaker
       assert_equal "PR #1", msg.label
     end
+
+    test "dismiss! sets dismissed_at and detaches when active" do
+      channel = Channel.create!(topic: @topic, type: "Collavre::Channel")
+      assert_nil channel.dismissed_at
+      channel.dismiss!
+      assert_predicate channel.reload, :dismissed?
+      assert_predicate channel, :detached?
+    end
+
+    test "dismiss! on a detached channel only sets dismissed_at" do
+      channel = Channel.create!(topic: @topic, type: "Collavre::Channel", state: :detached)
+      channel.dismiss!
+      assert_predicate channel.reload, :dismissed?
+      assert_predicate channel, :detached?
+    end
+
+    test "dismiss! is idempotent on already-dismissed channel" do
+      channel = Channel.create!(topic: @topic, type: "Collavre::Channel")
+      channel.dismiss!
+      original_dismissed_at = channel.reload.dismissed_at
+      channel.dismiss!
+      assert_equal original_dismissed_at, channel.reload.dismissed_at
+    end
+
+    test "not_dismissed scope excludes dismissed channels" do
+      kept = Channel.create!(topic: @topic, type: "Collavre::Channel")
+      gone = Channel.create!(topic: @topic, type: "Collavre::Channel")
+      gone.dismiss!
+      ids = Channel.not_dismissed.pluck(:id)
+      assert_includes ids, kept.id
+      refute_includes ids, gone.id
+    end
   end
 end

--- a/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
+++ b/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
@@ -42,7 +42,7 @@ module CollavreGithub
     end
 
     def maybe_auto_attach_channel(event, payload)
-      return unless event == "pull_request" && payload["action"] == "opened"
+      return unless event == "pull_request" && %w[opened reopened].include?(payload["action"])
       # GitHub repo identifiers are case-insensitive; normalize so stored
       # channels (also lowercased) match incoming dispatch payloads regardless
       # of how the repo casing arrives from clients.

--- a/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
+++ b/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
@@ -48,9 +48,23 @@ module CollavreGithub
       # of how the repo casing arrives from clients.
       repo = payload.dig("repository", "full_name")&.downcase
       pr_number = payload.dig("pull_request", "number")
+      return unless repo && pr_number
+
+      # `reopened` must resurrect ANY existing channel for this (repo, pr) — not
+      # just channels whose PR body still contains a topic link. Manually attached
+      # channels (via `pr_monitor`) and PRs whose body link was later removed both
+      # have a valid channel but no link; without this branch, the body-link path
+      # below would short-circuit and dispatch_to_channels (.active scope) would
+      # skip the dismissed/detached row, leaving the chip hidden and the PR
+      # unmonitored for the rest of its reopened life.
+      reactivate_existing_channels_on_reopen(repo, pr_number) if payload["action"] == "reopened"
+
+      # Body-link path: only used to CREATE a new channel. Existing-channel paths
+      # are intentionally handled above (reopened) or as a strict no-op (opened
+      # redelivery — must not undo a user's X dismissal).
       body = payload.dig("pull_request", "body")
       topic_id = CollavreGithub::PrTopicLinkParser.call(body)
-      return unless repo && pr_number && topic_id
+      return unless topic_id
 
       topic = Collavre::Topic.find_by(id: topic_id)
       return unless topic
@@ -70,41 +84,10 @@ module CollavreGithub
       existing = GithubPrChannel.where(topic_id: topic.id).find do |c|
         c.repo_full_name.to_s.downcase == repo && c.pr_number == pr_number
       end
-      if existing
-        # Only `reopened` resurrects a dismissed/detached chip. A redelivered
-        # `opened` webhook (GitHub retries 5xx, or duplicate fan-out) must NOT
-        # undo a user's X dismissal — the PR was not actually reopened, and
-        # silently bringing the chip back would defeat the dismissal UX. For
-        # `opened` on an existing row we just no-op (idempotent redelivery).
-        return existing unless payload["action"] == "reopened"
+      # Existing channel: strict no-op. `reopened` was already handled by the
+      # repo+pr scan above; `opened` redelivery must leave dismissed_at intact.
+      return existing if existing
 
-        # Row-level lock + re-read guards against duplicate reopened announcements
-        # when two `pull_request.reopened` deliveries for the same dismissed/
-        # detached channel arrive concurrently (GitHub retries on 5xx, or
-        # duplicate fan-out). Without it, both requests can read was_inactive=true
-        # before either clears dismissed_at, then both inject the reopened
-        # message. Mirrors the close-path with_lock below.
-        existing.with_lock do
-          was_inactive = !existing.active? || !existing.dismissed_at.nil?
-          if was_inactive || existing.pr_state != "open"
-            existing.state = :active unless existing.active?
-            existing.dismissed_at = nil unless existing.dismissed_at.nil?
-            existing.pr_state = "open" if existing.pr_state != "open"
-            existing.save!
-          end
-          # When the chip silently reappears after dismiss/detach, inject a
-          # one-line announcement so the user can trace the lifecycle —
-          # mirrors the attach announcement on first create.
-          if was_inactive
-            begin
-              existing.inject_into_topic!(existing.reopened_message)
-            rescue => e
-              Rails.logger.error("[CollavreGithub] reopened announce failed: #{e.class}: #{e.message}")
-            end
-          end
-        end
-        return existing
-      end
       GithubPrChannel.create!(
         topic_id: topic.id,
         config: { "repo_full_name" => repo, "pr_number" => pr_number, "pr_state" => "open" }
@@ -113,6 +96,54 @@ module CollavreGithub
       # concurrent webhook safe
     rescue => e
       Rails.logger.error("[CollavreGithub] auto-attach failed: #{e.class}: #{e.message}")
+    end
+
+    # Resurrect every existing channel for (repo, pr_number) on `pull_request.
+    # reopened`, regardless of whether the PR description currently contains a
+    # topic link. Mirrors dispatch's scope re-validation so a channel whose
+    # creative is no longer linked to this repo is NOT resurrected.
+    def reactivate_existing_channels_on_reopen(repo, pr_number)
+      linked_creative_ids = CollavreGithub::RepositoryLink
+        .where("LOWER(repository_full_name) = ?", repo).pluck(:creative_id)
+      return if linked_creative_ids.empty?
+
+      GithubPrChannel.find_each do |channel|
+        next unless channel.repo_full_name.to_s.downcase == repo && channel.pr_number == pr_number
+        next unless channel_in_repo_scope?(channel, linked_creative_ids)
+
+        begin
+          # Row-level lock + re-read guards against duplicate reopened announcements
+          # when two `pull_request.reopened` deliveries for the same dismissed/
+          # detached channel arrive concurrently (GitHub retries on 5xx, or
+          # duplicate fan-out). Without it, both requests can read was_inactive=true
+          # before either clears dismissed_at, then both inject the reopened
+          # message. Mirrors the close-path with_lock in dispatch_to_channels.
+          channel.with_lock do
+            was_inactive = !channel.active? || !channel.dismissed_at.nil?
+            if was_inactive || channel.pr_state != "open"
+              channel.state = :active unless channel.active?
+              channel.dismissed_at = nil unless channel.dismissed_at.nil?
+              channel.pr_state = "open" if channel.pr_state != "open"
+              channel.save!
+            end
+            # When the chip silently reappears after dismiss/detach, inject a
+            # one-line announcement so the user can trace the lifecycle —
+            # mirrors the attach announcement on first create.
+            if was_inactive
+              begin
+                channel.inject_into_topic!(channel.reopened_message)
+              rescue => e
+                Rails.logger.error("[CollavreGithub] reopened announce failed: #{e.class}: #{e.message}")
+              end
+            end
+          end
+        rescue => e
+          # Per-channel isolation: one bad row must not block sibling channels.
+          Rails.logger.error(
+            "[CollavreGithub] reopen reactivate failed for channel #{channel.id}: #{e.class}: #{e.message}"
+          )
+        end
+      end
     end
 
     def dispatch_to_channels(event, payload)

--- a/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
+++ b/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
@@ -71,12 +71,20 @@ module CollavreGithub
         c.repo_full_name.to_s.downcase == repo && c.pr_number == pr_number
       end
       if existing
-        existing.update!(state: :active) unless existing.active?
+        # Clear dismissed_at + flip state in one update so a reopened PR
+        # surfaces the chip again even if the user had previously dismissed
+        # the (post-merge) chip. Reset pr_state to "open" to match the new
+        # lifecycle — the next close event repopulates it.
+        attrs = {}
+        attrs[:state] = :active unless existing.active?
+        attrs[:dismissed_at] = nil unless existing.dismissed_at.nil?
+        attrs[:config] = existing.config.merge("pr_state" => "open") if existing.pr_state != "open"
+        existing.update!(attrs) if attrs.any?
         return existing
       end
       GithubPrChannel.create!(
         topic_id: topic.id,
-        config: { "repo_full_name" => repo, "pr_number" => pr_number }
+        config: { "repo_full_name" => repo, "pr_number" => pr_number, "pr_state" => "open" }
       )
     rescue ActiveRecord::RecordNotUnique
       # concurrent webhook safe
@@ -107,13 +115,22 @@ module CollavreGithub
         next unless channel_in_repo_scope?(channel, linked_creative_ids)
 
         begin
-          injected = channel.handle(event: event, payload: payload)
-          next if injected.nil?
+          # Row-level lock + re-check guards against duplicate dispatch when the
+          # same webhook is redelivered (GitHub retries on 5xx) or two webhooks
+          # arrive concurrently. Without it, both processes read state=active
+          # and each inject the closing comment. The query-level .active scope
+          # alone does not race-protect the inject+detach window.
+          channel.with_lock do
+            next unless channel.active?
 
-          channel.inject_into_topic!(injected)
-          # Detach AFTER injecting the closing message so the chip remains
-          # visible until the closing comment lands in the topic.
-          channel.detach! if event == "pull_request" && payload["action"] == "closed"
+            injected = channel.handle(event: event, payload: payload)
+            next if injected.nil?
+
+            channel.inject_into_topic!(injected)
+            # Detach AFTER injecting the closing message so the chip remains
+            # visible (now with merged/closed badge) until dismissed by the user.
+            channel.detach! if event == "pull_request" && payload["action"] == "closed"
+          end
         rescue => e
           # Isolate per-channel failures so one broken channel does not block
           # sibling channels monitoring the same PR.

--- a/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
+++ b/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
@@ -78,21 +78,29 @@ module CollavreGithub
         # `opened` on an existing row we just no-op (idempotent redelivery).
         return existing unless payload["action"] == "reopened"
 
-        was_inactive = !existing.active? || !existing.dismissed_at.nil?
-        if was_inactive || existing.pr_state != "open"
-          existing.state = :active unless existing.active?
-          existing.dismissed_at = nil unless existing.dismissed_at.nil?
-          existing.pr_state = "open" if existing.pr_state != "open"
-          existing.save!
-        end
-        # When the chip silently reappears after dismiss/detach, inject a
-        # one-line announcement so the user can trace the lifecycle —
-        # mirrors the attach announcement on first create.
-        if was_inactive
-          begin
-            existing.inject_into_topic!(existing.reopened_message)
-          rescue => e
-            Rails.logger.error("[CollavreGithub] reopened announce failed: #{e.class}: #{e.message}")
+        # Row-level lock + re-read guards against duplicate reopened announcements
+        # when two `pull_request.reopened` deliveries for the same dismissed/
+        # detached channel arrive concurrently (GitHub retries on 5xx, or
+        # duplicate fan-out). Without it, both requests can read was_inactive=true
+        # before either clears dismissed_at, then both inject the reopened
+        # message. Mirrors the close-path with_lock below.
+        existing.with_lock do
+          was_inactive = !existing.active? || !existing.dismissed_at.nil?
+          if was_inactive || existing.pr_state != "open"
+            existing.state = :active unless existing.active?
+            existing.dismissed_at = nil unless existing.dismissed_at.nil?
+            existing.pr_state = "open" if existing.pr_state != "open"
+            existing.save!
+          end
+          # When the chip silently reappears after dismiss/detach, inject a
+          # one-line announcement so the user can trace the lifecycle —
+          # mirrors the attach announcement on first create.
+          if was_inactive
+            begin
+              existing.inject_into_topic!(existing.reopened_message)
+            rescue => e
+              Rails.logger.error("[CollavreGithub] reopened announce failed: #{e.class}: #{e.message}")
+            end
           end
         end
         return existing

--- a/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
+++ b/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
@@ -71,10 +71,13 @@ module CollavreGithub
         c.repo_full_name.to_s.downcase == repo && c.pr_number == pr_number
       end
       if existing
-        # Clear dismissed_at + flip state in one update so a reopened PR
-        # surfaces the chip again even if the user had previously dismissed
-        # the (post-merge) chip. Reset pr_state to "open" to match the new
-        # lifecycle — the next close event repopulates it.
+        # Only `reopened` resurrects a dismissed/detached chip. A redelivered
+        # `opened` webhook (GitHub retries 5xx, or duplicate fan-out) must NOT
+        # undo a user's X dismissal — the PR was not actually reopened, and
+        # silently bringing the chip back would defeat the dismissal UX. For
+        # `opened` on an existing row we just no-op (idempotent redelivery).
+        return existing unless payload["action"] == "reopened"
+
         was_inactive = !existing.active? || !existing.dismissed_at.nil?
         if was_inactive || existing.pr_state != "open"
           existing.state = :active unless existing.active?

--- a/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
+++ b/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
@@ -75,11 +75,23 @@ module CollavreGithub
         # surfaces the chip again even if the user had previously dismissed
         # the (post-merge) chip. Reset pr_state to "open" to match the new
         # lifecycle — the next close event repopulates it.
-        attrs = {}
-        attrs[:state] = :active unless existing.active?
-        attrs[:dismissed_at] = nil unless existing.dismissed_at.nil?
-        attrs[:config] = existing.config.merge("pr_state" => "open") if existing.pr_state != "open"
-        existing.update!(attrs) if attrs.any?
+        was_inactive = !existing.active? || !existing.dismissed_at.nil?
+        if was_inactive || existing.pr_state != "open"
+          existing.state = :active unless existing.active?
+          existing.dismissed_at = nil unless existing.dismissed_at.nil?
+          existing.pr_state = "open" if existing.pr_state != "open"
+          existing.save!
+        end
+        # When the chip silently reappears after dismiss/detach, inject a
+        # one-line announcement so the user can trace the lifecycle —
+        # mirrors the attach announcement on first create.
+        if was_inactive
+          begin
+            existing.inject_into_topic!(existing.reopened_message)
+          rescue => e
+            Rails.logger.error("[CollavreGithub] reopened announce failed: #{e.class}: #{e.message}")
+          end
+        end
         return existing
       end
       GithubPrChannel.create!(

--- a/engines/collavre_github/app/models/collavre_github/github_pr_channel.rb
+++ b/engines/collavre_github/app/models/collavre_github/github_pr_channel.rb
@@ -18,6 +18,17 @@ module CollavreGithub
       t("label", number: pr_number)
     end
 
+    # PR lifecycle state used by the chip badge color. Defaults to "open" so
+    # freshly attached channels render the green badge before any close event
+    # has been received. Persisted in `config` to avoid a schema change for a
+    # channel-subtype-specific concern.
+    PR_STATES = %w[open merged closed_without_merge].freeze
+
+    def pr_state
+      state = config["pr_state"].to_s
+      PR_STATES.include?(state) ? state : "open"
+    end
+
     def attached_message
       Collavre::Channel::InjectedMessage.new(
         speaker: channel_bot_user,
@@ -45,13 +56,18 @@ module CollavreGithub
     def handle_pull_request(payload)
       return nil unless payload["action"] == "closed"
       pr = payload["pull_request"]
-      verb_key = pr["merged"] ? "state_merged" : "state_closed"
-      verb = t(verb_key)
+      new_state = pr["merged"] ? "merged" : "closed_without_merge"
+      verb = pr["merged"] ? t("state_merged") : t("state_closed")
+
+      # Persist pr_state inline so the badge color flips even if the caller
+      # later swallows the InjectedMessage (e.g. injection fails). The chip
+      # status is the source of truth for the badge, not the closing comment.
+      update!(config: config.merge("pr_state" => new_state))
 
       Collavre::Channel::InjectedMessage.new(
         speaker: channel_bot_user,
         message: t("closed_message", label: label, verb: verb),
-        label: t("label_with_state", label: label, state: verb),
+        label: label,
         link: pr_url
       )
       # Detach is performed by the webhook controller AFTER injecting this

--- a/engines/collavre_github/app/models/collavre_github/github_pr_channel.rb
+++ b/engines/collavre_github/app/models/collavre_github/github_pr_channel.rb
@@ -29,10 +29,29 @@ module CollavreGithub
       PR_STATES.include?(state) ? state : "open"
     end
 
+    # Symmetric with the reader: refuse to persist values outside PR_STATES
+    # rather than silently downgrading to "open" at read time. Without this
+    # any caller that mistypes (e.g. "merged_") would corrupt the badge color
+    # with no error surfaced.
+    def pr_state=(value)
+      value = value.to_s
+      raise ArgumentError, "Invalid pr_state: #{value.inspect}" unless PR_STATES.include?(value)
+      self.config = config.merge("pr_state" => value)
+    end
+
     def attached_message
       Collavre::Channel::InjectedMessage.new(
         speaker: channel_bot_user,
         message: t("attached_message", label: label, url: pr_url),
+        label: label,
+        link: pr_url
+      )
+    end
+
+    def reopened_message
+      Collavre::Channel::InjectedMessage.new(
+        speaker: channel_bot_user,
+        message: t("reopened_message", label: label, url: pr_url),
         label: label,
         link: pr_url
       )
@@ -59,10 +78,13 @@ module CollavreGithub
       new_state = pr["merged"] ? "merged" : "closed_without_merge"
       verb = pr["merged"] ? t("state_merged") : t("state_closed")
 
-      # Persist pr_state inline so the badge color flips even if the caller
-      # later swallows the InjectedMessage (e.g. injection fails). The chip
-      # status is the source of truth for the badge, not the closing comment.
-      update!(config: config.merge("pr_state" => new_state))
+      # pr_state is updated atomically with the closing comment: the dispatch
+      # path wraps both `handle` and `inject_into_topic!` in a single with_lock
+      # transaction, so an inject failure rolls this update back too. That is
+      # the intended behavior — we don't want the chip to flash merged/closed
+      # without the matching closing message in the timeline.
+      self.pr_state = new_state
+      save!
 
       Collavre::Channel::InjectedMessage.new(
         speaker: channel_bot_user,

--- a/engines/collavre_github/app/services/collavre_github/tools/pr_monitor_service.rb
+++ b/engines/collavre_github/app/services/collavre_github/tools/pr_monitor_service.rb
@@ -73,27 +73,36 @@ module CollavreGithub
       def find_or_attach_channel(topic, repo, pr_number)
         existing = lookup_channel(topic, repo, pr_number)
         if existing
-          if existing.active?
-            return [ existing, :noop ]
-          end
-          existing.update!(state: :active)
+          return [ existing, :noop ] if existing.active? && existing.dismissed_at.nil?
+          reactivate!(existing)
           return [ existing, :reactivated ]
         end
         created = CollavreGithub::GithubPrChannel.create!(
           topic_id: topic.id,
-          config: { "repo_full_name" => repo, "pr_number" => pr_number }
+          config: { "repo_full_name" => repo, "pr_number" => pr_number, "pr_state" => "open" }
         )
         [ created, :created ]
       rescue ActiveRecord::RecordNotUnique
         # Concurrent caller won the race; reuse the row they created.
         existing = lookup_channel(topic, repo, pr_number)
         raise unless existing
-        if existing.active?
+        if existing.active? && existing.dismissed_at.nil?
           [ existing, :noop ]
         else
-          existing.update!(state: :active)
+          reactivate!(existing)
           [ existing, :reactivated ]
         end
+      end
+
+      # Mirror WebhooksController#maybe_auto_attach_channel reactivation: clear
+      # dismissed_at and reset pr_state so the chip surfaces again under the
+      # not_dismissed render scope. Otherwise pr_monitor would report success
+      # and inject the attached message while the chip stayed hidden.
+      def reactivate!(channel)
+        channel.state = :active unless channel.active?
+        channel.dismissed_at = nil unless channel.dismissed_at.nil?
+        channel.pr_state = "open" if channel.pr_state != "open"
+        channel.save!
       end
 
       sig { params(topic: Collavre::Topic, repo: String, pr_number: Integer).returns(T.nilable(CollavreGithub::GithubPrChannel)) }

--- a/engines/collavre_github/config/locales/en.yml
+++ b/engines/collavre_github/config/locales/en.yml
@@ -106,6 +106,7 @@ en:
         review_submitted_message: "**@%{author}** submitted a review (`%{state}`) on %{label}:\n\n%{body}"
         closed_message: "%{label} was **%{verb}**. Detaching channel."
         attached_message: "%{label} monitoring started.\n\n%{url}"
+        reopened_message: "%{label} was reopened. Monitoring resumed.\n\n%{url}"
         badge:
           open: "Open"
           merged: "Merged"

--- a/engines/collavre_github/config/locales/en.yml
+++ b/engines/collavre_github/config/locales/en.yml
@@ -106,3 +106,7 @@ en:
         review_submitted_message: "**@%{author}** submitted a review (`%{state}`) on %{label}:\n\n%{body}"
         closed_message: "%{label} was **%{verb}**. Detaching channel."
         attached_message: "%{label} monitoring started.\n\n%{url}"
+        badge:
+          open: "Open"
+          merged: "Merged"
+          closed_without_merge: "Closed without merging"

--- a/engines/collavre_github/config/locales/ko.yml
+++ b/engines/collavre_github/config/locales/ko.yml
@@ -106,3 +106,7 @@ ko:
         review_submitted_message: "**@%{author}**님이 %{label}에 리뷰를 제출했습니다 (`%{state}`):\n\n%{body}"
         closed_message: "%{label}이(가) **%{verb}** 되었습니다. 채널을 해제합니다."
         attached_message: "%{label} 모니터링이 시작되었습니다.\n\n%{url}"
+        badge:
+          open: "열림"
+          merged: "머지됨"
+          closed_without_merge: "머지 없이 닫힘"

--- a/engines/collavre_github/config/locales/ko.yml
+++ b/engines/collavre_github/config/locales/ko.yml
@@ -106,6 +106,7 @@ ko:
         review_submitted_message: "**@%{author}**님이 %{label}에 리뷰를 제출했습니다 (`%{state}`):\n\n%{body}"
         closed_message: "%{label}이(가) **%{verb}** 되었습니다. 채널을 해제합니다."
         attached_message: "%{label} 모니터링이 시작되었습니다.\n\n%{url}"
+        reopened_message: "%{label}이(가) 재오픈되어 모니터링이 재개되었습니다.\n\n%{url}"
         badge:
           open: "열림"
           merged: "머지됨"

--- a/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_auto_attach_test.rb
+++ b/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_auto_attach_test.rb
@@ -224,6 +224,54 @@ module CollavreGithub
       assert active.reload.active?
     end
 
+    test "pull_request.reopened reactivation runs inside with_lock so concurrent deliveries cannot double-announce" do
+      # Regression: without a row lock + re-read inside, two concurrent reopened
+      # webhook deliveries for the same dismissed/detached channel both observe
+      # was_inactive=true and both inject the reopened announcement. The fix
+      # wraps the reactivation block in `existing.with_lock`; this test asserts
+      # the lock is acquired before any state mutation / inject so that the
+      # contract is captured by tests, not just by inspection.
+      dismissed = GithubPrChannel.create!(
+        topic_id: @topic.id,
+        config: {
+          "repo_full_name" => @link.repository_full_name,
+          "pr_number" => 563,
+          "pr_state" => "merged"
+        },
+        state: :detached,
+        dismissed_at: 1.day.ago
+      )
+
+      lock_acquired = false
+      original_with_lock = GithubPrChannel.instance_method(:with_lock)
+      GithubPrChannel.define_method(:with_lock) do |*args, &block|
+        lock_acquired = true if id == dismissed.id
+        original_with_lock.bind(self).call(*args, &block)
+      end
+
+      begin
+        payload = {
+          action: "reopened",
+          pull_request: {
+            number: 563,
+            body: "Linked topic: /creatives/#{@creative.id}/topics/#{@topic.id}"
+          },
+          repository: { full_name: @link.repository_full_name }
+        }.to_json
+        sig = "sha256=" + OpenSSL::HMAC.hexdigest("SHA256", @link.webhook_secret, payload)
+
+        post "/github/webhook", params: payload,
+          headers: { "Content-Type" => "application/json", "X-GitHub-Event" => "pull_request", "X-Hub-Signature-256" => sig }
+      ensure
+        GithubPrChannel.define_method(:with_lock, original_with_lock)
+      end
+
+      assert lock_acquired, "expected reactivation path to acquire row lock on the dismissed channel"
+      dismissed.reload
+      assert dismissed.active?
+      assert_nil dismissed.dismissed_at
+    end
+
     test "channels table rejects duplicate (type, topic, repo, pr) at DB level" do
       GithubPrChannel.create!(
         topic_id: @topic.id,

--- a/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_auto_attach_test.rb
+++ b/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_auto_attach_test.rb
@@ -272,6 +272,77 @@ module CollavreGithub
       assert_nil dismissed.dismissed_at
     end
 
+    test "pull_request.reopened without topic link in PR body still reactivates an existing manually-attached channel" do
+      # Channels created via `pr_monitor` MCP tool (manual attach) have a valid
+      # GithubPrChannel row but the PR description never had a topic link. When
+      # the PR is later reopened, GitHub's webhook payload has no topic link in
+      # body. Without this regression path, `maybe_auto_attach_channel` would
+      # short-circuit at the PrTopicLinkParser gate and never reactivate the
+      # existing dismissed/detached row; dispatch_to_channels (.active scope)
+      # would then skip the chip and the PR would go unmonitored after reopen.
+      dismissed = GithubPrChannel.create!(
+        topic_id: @topic.id,
+        config: {
+          "repo_full_name" => @link.repository_full_name,
+          "pr_number" => 570,
+          "pr_state" => "closed_without_merge"
+        },
+        state: :detached,
+        dismissed_at: 2.hours.ago
+      )
+
+      payload = {
+        action: "reopened",
+        pull_request: { number: 570, body: "no topic link in this PR body" },
+        repository: { full_name: @link.repository_full_name }
+      }.to_json
+      sig = "sha256=" + OpenSSL::HMAC.hexdigest("SHA256", @link.webhook_secret, payload)
+
+      assert_difference -> { @topic.comments.count }, 1 do
+        post "/github/webhook", params: payload,
+          headers: { "Content-Type" => "application/json", "X-GitHub-Event" => "pull_request", "X-Hub-Signature-256" => sig }
+      end
+      dismissed.reload
+      assert dismissed.active?
+      assert_nil dismissed.dismissed_at
+      assert_equal "open", dismissed.pr_state
+      last = @topic.comments.order(:created_at).last
+      assert_match(/reopened|재오픈/i, last.content)
+    end
+
+    test "pull_request.reopened does NOT reactivate channel whose creative no longer has the repo link" do
+      # If the RepositoryLink for this repo was removed (or the channel's topic
+      # was moved to a creative subtree outside the link scope), the reopen
+      # webhook must not resurrect a stale monitor for a different tenant.
+      foreign_creative = creatives(:childless_creative)
+      foreign_topic = Collavre::Topic.create!(creative: foreign_creative, user: @user, name: "Foreign")
+      stale = GithubPrChannel.create!(
+        topic_id: foreign_topic.id,
+        config: {
+          "repo_full_name" => @link.repository_full_name,
+          "pr_number" => 571,
+          "pr_state" => "merged"
+        },
+        state: :detached,
+        dismissed_at: 1.hour.ago
+      )
+
+      payload = {
+        action: "reopened",
+        pull_request: { number: 571, body: "no link" },
+        repository: { full_name: @link.repository_full_name }
+      }.to_json
+      sig = "sha256=" + OpenSSL::HMAC.hexdigest("SHA256", @link.webhook_secret, payload)
+
+      assert_no_difference -> { foreign_topic.comments.count } do
+        post "/github/webhook", params: payload,
+          headers: { "Content-Type" => "application/json", "X-GitHub-Event" => "pull_request", "X-Hub-Signature-256" => sig }
+      end
+      stale.reload
+      assert stale.detached?
+      assert_not_nil stale.dismissed_at
+    end
+
     test "channels table rejects duplicate (type, topic, repo, pr) at DB level" do
       GithubPrChannel.create!(
         topic_id: @topic.id,

--- a/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_auto_attach_test.rb
+++ b/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_auto_attach_test.rb
@@ -102,7 +102,10 @@ module CollavreGithub
       assert_equal child_topic.id, channel.topic_id
     end
 
-    test "pull_request.opened reactivates a detached channel" do
+    test "pull_request.opened redelivery does NOT reactivate a detached channel" do
+      # A `pull_request.opened` redelivery (GitHub retries on 5xx or duplicate
+      # fan-out) must not undo a prior detach. Only `reopened` reflects an
+      # actual lifecycle change on the GitHub side.
       detached = GithubPrChannel.create!(
         topic_id: @topic.id,
         config: { "repo_full_name" => @link.repository_full_name, "pr_number" => 558 },
@@ -123,7 +126,35 @@ module CollavreGithub
         post "/github/webhook", params: payload,
           headers: { "Content-Type" => "application/json", "X-GitHub-Event" => "pull_request", "X-Hub-Signature-256" => sig }
       end
-      assert detached.reload.active?
+      assert detached.reload.detached?
+    end
+
+    test "pull_request.opened redelivery does NOT undo a dismissed chip" do
+      # User clicks X on an open PR's chip → dismiss! sets dismissed_at and
+      # flips state to detached. A subsequent `opened` redelivery from GitHub
+      # must leave the dismissal intact (no dismissed_at clear, no reactivate,
+      # no announce). Only `reopened` is allowed to resurrect a dismissed chip.
+      dismissed = GithubPrChannel.create!(
+        topic_id: @topic.id,
+        config: { "repo_full_name" => @link.repository_full_name, "pr_number" => 563, "pr_state" => "open" },
+        state: :detached,
+        dismissed_at: 1.hour.ago
+      )
+      original_dismissed_at = dismissed.dismissed_at
+      payload = {
+        action: "opened",
+        pull_request: { number: 563, body: "Linked topic: /creatives/#{@creative.id}/topics/#{@topic.id}" },
+        repository: { full_name: @link.repository_full_name }
+      }.to_json
+      sig = "sha256=" + OpenSSL::HMAC.hexdigest("SHA256", @link.webhook_secret, payload)
+
+      assert_no_difference -> { @topic.comments.count } do
+        post "/github/webhook", params: payload,
+          headers: { "Content-Type" => "application/json", "X-GitHub-Event" => "pull_request", "X-Hub-Signature-256" => sig }
+      end
+      dismissed.reload
+      assert dismissed.detached?
+      assert_equal original_dismissed_at.to_i, dismissed.dismissed_at.to_i
     end
 
     test "pull_request.reopened reactivates a dismissed+detached channel and resets pr_state" do

--- a/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_auto_attach_test.rb
+++ b/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_auto_attach_test.rb
@@ -126,6 +126,43 @@ module CollavreGithub
       assert detached.reload.active?
     end
 
+    test "pull_request.reopened reactivates a dismissed+detached channel and resets pr_state" do
+      # User dismissed the chip after merge; later the PR is reopened on GitHub.
+      # GitHub fires `pull_request.reopened` (NOT `opened`), so the auto-attach
+      # guard must accept reopened to clear dismissed_at and flip state back to
+      # active — otherwise dispatch_to_channels (.active scope) skips the row
+      # and the chip stays hidden for the lifetime of the reopened PR.
+      dismissed = GithubPrChannel.create!(
+        topic_id: @topic.id,
+        config: {
+          "repo_full_name" => @link.repository_full_name,
+          "pr_number" => 561,
+          "pr_state" => "merged"
+        },
+        state: :detached,
+        dismissed_at: 1.day.ago
+      )
+
+      payload = {
+        action: "reopened",
+        pull_request: {
+          number: 561,
+          body: "Linked topic: /creatives/#{@creative.id}/topics/#{@topic.id}"
+        },
+        repository: { full_name: @link.repository_full_name }
+      }.to_json
+      sig = "sha256=" + OpenSSL::HMAC.hexdigest("SHA256", @link.webhook_secret, payload)
+
+      assert_no_difference -> { GithubPrChannel.count } do
+        post "/github/webhook", params: payload,
+          headers: { "Content-Type" => "application/json", "X-GitHub-Event" => "pull_request", "X-Hub-Signature-256" => sig }
+      end
+      dismissed.reload
+      assert dismissed.active?
+      assert_nil dismissed.dismissed_at
+      assert_equal "open", dismissed.pr_state
+    end
+
     test "channels table rejects duplicate (type, topic, repo, pr) at DB level" do
       GithubPrChannel.create!(
         topic_id: @topic.id,

--- a/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_auto_attach_test.rb
+++ b/engines/collavre_github/test/controllers/collavre_github/webhooks_controller_auto_attach_test.rb
@@ -153,14 +153,44 @@ module CollavreGithub
       }.to_json
       sig = "sha256=" + OpenSSL::HMAC.hexdigest("SHA256", @link.webhook_secret, payload)
 
-      assert_no_difference -> { GithubPrChannel.count } do
-        post "/github/webhook", params: payload,
-          headers: { "Content-Type" => "application/json", "X-GitHub-Event" => "pull_request", "X-Hub-Signature-256" => sig }
+      # PR events also feed the creative system-comment stream, so the reopen
+      # webhook produces 2 new comments: the feed event + the channel-scoped
+      # reopen announcement. The announcement is the one we care about here.
+      assert_difference -> { @topic.comments.count }, 1 do
+        assert_no_difference -> { GithubPrChannel.count } do
+          post "/github/webhook", params: payload,
+            headers: { "Content-Type" => "application/json", "X-GitHub-Event" => "pull_request", "X-Hub-Signature-256" => sig }
+        end
       end
       dismissed.reload
       assert dismissed.active?
       assert_nil dismissed.dismissed_at
       assert_equal "open", dismissed.pr_state
+      # User saw the chip silently reappear before this; verify the lifecycle
+      # is now traceable via a one-line announcement comment in the topic.
+      last = @topic.comments.order(:created_at).last
+      assert_match(/reopened|재오픈/i, last.content)
+    end
+
+    test "pull_request.opened reactivation of an already-active channel does NOT re-announce" do
+      # Idempotent webhook redelivery of `opened` shouldn't spam the topic
+      # with a reopen announcement (the creative feed comment is separate).
+      active = GithubPrChannel.create!(
+        topic_id: @topic.id,
+        config: { "repo_full_name" => @link.repository_full_name, "pr_number" => 562, "pr_state" => "open" }
+      )
+      payload = {
+        action: "opened",
+        pull_request: { number: 562, body: "Linked topic: /creatives/#{@creative.id}/topics/#{@topic.id}" },
+        repository: { full_name: @link.repository_full_name }
+      }.to_json
+      sig = "sha256=" + OpenSSL::HMAC.hexdigest("SHA256", @link.webhook_secret, payload)
+
+      assert_no_difference -> { @topic.comments.count } do
+        post "/github/webhook", params: payload,
+          headers: { "Content-Type" => "application/json", "X-GitHub-Event" => "pull_request", "X-Hub-Signature-256" => sig }
+      end
+      assert active.reload.active?
     end
 
     test "channels table rejects duplicate (type, topic, repo, pr) at DB level" do

--- a/engines/collavre_github/test/integration/pr_channel_end_to_end_test.rb
+++ b/engines/collavre_github/test/integration/pr_channel_end_to_end_test.rb
@@ -55,5 +55,31 @@ module CollavreGithub
         "Channel-injected comment must trigger orchestration"
       assert_equal "PR #321", @channel.reload.latest_label
     end
+
+    test "redelivered pull_request.closed webhook only injects one closing comment" do
+      payload = {
+        action: "closed",
+        pull_request: { number: 321, merged: true, html_url: "https://github.com/owner/repo/pull/321" },
+        repository: { full_name: @link.repository_full_name }
+      }.to_json
+      sig = "sha256=" + OpenSSL::HMAC.hexdigest("SHA256", @link.webhook_secret, payload)
+      headers = {
+        "Content-Type" => "application/json",
+        "X-GitHub-Event" => "pull_request",
+        "X-Hub-Signature-256" => sig
+      }
+
+      Collavre::SystemEvents::Dispatcher.stub(:dispatch, ->(_event, _ctx) { [] }) do
+        # GitHub redelivers a webhook when the receiver 5xx's. The second
+        # delivery must short-circuit (row lock + state re-check) instead of
+        # injecting another "PR #321 was merged" comment into the topic.
+        assert_difference -> { Collavre::Comment.where(topic_id: @topic.id).count }, 1 do
+          2.times { post "/github/webhook", params: payload, headers: headers }
+        end
+      end
+
+      assert_predicate @channel.reload, :detached?
+      assert_equal "merged", @channel.pr_state
+    end
   end
 end

--- a/engines/collavre_github/test/models/collavre_github/github_pr_channel_test.rb
+++ b/engines/collavre_github/test/models/collavre_github/github_pr_channel_test.rb
@@ -169,5 +169,21 @@ module CollavreGithub
     test "pr_state defaults to open when config has no pr_state" do
       assert_equal "open", @channel.pr_state
     end
+
+    test "pr_state= rejects values outside PR_STATES" do
+      assert_raises(ArgumentError) { @channel.pr_state = "merged_" }
+      assert_raises(ArgumentError) { @channel.pr_state = "" }
+      assert_raises(ArgumentError) { @channel.pr_state = nil }
+      # Reader stays at the safe default; no garbage written.
+      assert_equal "open", @channel.pr_state
+    end
+
+    test "pr_state= persists each whitelisted value via the config writer" do
+      CollavreGithub::GithubPrChannel::PR_STATES.each do |s|
+        @channel.pr_state = s
+        @channel.save!
+        assert_equal s, @channel.reload.pr_state
+      end
+    end
   end
 end

--- a/engines/collavre_github/test/models/collavre_github/github_pr_channel_test.rb
+++ b/engines/collavre_github/test/models/collavre_github/github_pr_channel_test.rb
@@ -109,7 +109,7 @@ module CollavreGithub
       assert_nil @channel.handle(event: "pull_request_review", payload: payload)
     end
 
-    test "handle returns closing InjectedMessage on pull_request.closed (merged) without detaching" do
+    test "handle returns closing InjectedMessage on pull_request.closed (merged) without detaching and sets pr_state=merged" do
       payload = {
         "action" => "closed",
         "pull_request" => { "number" => 42, "merged" => true, "html_url" => "https://github.com/owner/repo/pull/42" },
@@ -118,9 +118,12 @@ module CollavreGithub
       result = @channel.handle(event: "pull_request", payload: payload)
       assert_kind_of Collavre::Channel::InjectedMessage, result
       assert_includes result.message, "merged"
+      # Badge carries the state; the chip label itself must stay clean.
+      assert_equal "PR #42", result.label
       # Detach is now performed by the webhook controller after inject_into_topic!,
       # so handle() alone must NOT detach.
       assert_predicate @channel.reload, :active?
+      assert_equal "merged", @channel.pr_state
     end
 
     test "handle returns nil when comment author matches ignore_actor_logins" do
@@ -149,7 +152,7 @@ module CollavreGithub
       assert_equal Collavre::Channel::BOT_EMAIL, result.speaker.email
     end
 
-    test "handle returns closing InjectedMessage on pull_request.closed (not merged) without detaching" do
+    test "handle returns closing InjectedMessage on pull_request.closed (not merged) without detaching and sets pr_state=closed_without_merge" do
       payload = {
         "action" => "closed",
         "pull_request" => { "number" => 42, "merged" => false, "html_url" => "https://github.com/owner/repo/pull/42" },
@@ -157,8 +160,14 @@ module CollavreGithub
       }
       result = @channel.handle(event: "pull_request", payload: payload)
       assert_includes result.message, "closed"
+      assert_equal "PR #42", result.label
       # Detach is now performed by the webhook controller after inject_into_topic!.
       assert_predicate @channel.reload, :active?
+      assert_equal "closed_without_merge", @channel.pr_state
+    end
+
+    test "pr_state defaults to open when config has no pr_state" do
+      assert_equal "open", @channel.pr_state
     end
   end
 end

--- a/engines/collavre_github/test/services/collavre_github/tools/pr_monitor_service_test.rb
+++ b/engines/collavre_github/test/services/collavre_github/tools/pr_monitor_service_test.rb
@@ -151,6 +151,30 @@ module CollavreGithub
         assert_equal "https://github.com/owner/repo/pull/77", channel.latest_link
       end
 
+      test "reactivation clears dismissed_at and resets pr_state so the chip resurfaces under not_dismissed" do
+        # Scenario: user dismissed the post-close chip (X button), which set
+        # state=:detached AND dismissed_at to keep the chip hidden under the
+        # new not_dismissed render scope. Calling pr_monitor again must clear
+        # dismissed_at + reset pr_state to "open", or the tool returns success
+        # while the chip stays invisible.
+        channel = GithubPrChannel.create!(
+          topic_id: @topic.id,
+          config: { "repo_full_name" => "owner/repo", "pr_number" => 77, "pr_state" => "merged" },
+          state: :detached,
+          dismissed_at: 1.hour.ago
+        )
+
+        PrMonitorService.new.call(
+          topic_id: @topic.id,
+          pr_url: "https://github.com/owner/repo/pull/77"
+        )
+
+        channel.reload
+        assert channel.active?
+        assert_nil channel.dismissed_at
+        assert_equal "open", channel.pr_state
+      end
+
       test "active->active idempotent re-attach does not re-announce" do
         PrMonitorService.new.call(topic_id: @topic.id, pr_url: "https://github.com/owner/repo/pull/77")
         assert_no_difference -> { @creative.comments.count } do


### PR DESCRIPTION
## Summary
- `pull_request.closed` no longer injects the closing comment twice when GitHub redelivers the webhook. The dispatch loop now wraps `handle + inject + detach` in a row-level `with_lock` + re-check so a second delivery sees `state=detached` and short-circuits.
- Detached chips remain visible in the typing-indicator row until the user dismisses them with the X. The lifecycle is rendered as a small colored status badge on the chip (open / merged / closed_without_merge → success / active / danger design tokens). `latest_label` stays "PR #N" — the suffix `(merged)` is replaced by the badge.
- `pr_state` is persisted in `Channel#config` at the close-event so the badge color is the source of truth for the chip status, independent of whether the closing message was injected.
- X button now calls `Channel#dismiss!`. It detaches the channel if still active and sets `dismissed_at`. The chip is filtered out via the `not_dismissed` scope — one user action removes the chip whether it was active or already detached. Reopening the PR (auto-attach path) clears `dismissed_at` and resets `pr_state="open"` so the chip surfaces again.

Topic 8383 / sample PR #1241 surfaced the dup-closing-message bug; this PR fixes it and reshapes the chip lifecycle around badge + dismiss.

`/creatives/12443/topics/8383`

## Test plan
- [x] `bin/rails test engines/collavre/test/models/collavre/channel_test.rb engines/collavre/test/controllers/collavre/channels_controller_test.rb engines/collavre_github/test/models/collavre_github/github_pr_channel_test.rb engines/collavre_github/test/integration/pr_channel_end_to_end_test.rb` — 26/26 pass
- [x] `bin/rails test:all` — 41/41 pass
- [x] New tests: `dismiss!` idempotency + active→detached transition, `not_dismissed` scope, webhook closed-event redelivery only injects once, controller `destroy` dismisses both active and detached chips
- [ ] Manual: open PR with topic link → chip with green badge appears; merge PR → chip flips to blue (merged) badge + closing comment injected exactly once; click X → chip disappears; reopen PR → chip re-appears with green badge