### PR TITLE
fix(channel-chip): align PR chip font-size with context chip token

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -1201,7 +1201,7 @@ body.chat-fullscreen {
     border: 1px solid var(--border-color);
     border-radius: var(--radius-2);
     background: var(--color-section-bg);
-    font-size: var(--text-00);
+    font-size: var(--text-0);
     line-height: 1;
     white-space: nowrap;
 }


### PR DESCRIPTION
## Summary
- 채널 chip의 글자 크기가 `--text-00`(8px)로 렌더링되어 너무 작고, 주변 chip(topic-tag 0.85em ≈ 13.6px, context-chip 0.75em ≈ 12px)과 톤이 어긋났음.
- `engines/collavre/app/assets/stylesheets/collavre/comments_popup.css`의 `.channel-chip` 폰트를 `--text-0`(12px)로 변경 — context chip과 동일한 effective size, 디자인 토큰 사용.

## 배경
PR 모니터링 topic의 사용자 매뉴얼 토픽에서 "PR 라벨 뱃지 글자 크기가 너무 작다 / creative context 뱃지 정도의 크기가 좋겠다"는 피드백.

## Test plan
- [ ] PR이 부착된 토픽에서 chip 라벨이 context chip과 비슷한 크기로 표시되는지 시각 확인
- [ ] open / merged / closed_without_merge 모든 상태 chip 일관성 유지