### PR TITLE
fix(pr_monitor): default chip label/link fallback from channel config

### DIFF
--- a/engines/collavre/app/models/collavre/channel.rb
+++ b/engines/collavre/app/models/collavre/channel.rb
@@ -15,6 +15,17 @@ module Collavre
       raise NotImplementedError, "#{self.class} must implement #handle"
     end
 
+    # Chip fallbacks rendered before any webhook event populates latest_label /
+    # latest_link. Base class returns nil; subclasses override when they can
+    # derive a stable label/link from their own config (e.g. PR #N + URL).
+    def default_label
+      nil
+    end
+
+    def default_link
+      nil
+    end
+
     def detach!
       update!(state: :detached)
     end

--- a/engines/collavre/app/views/collavre/comments/_channel_chips.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_channel_chips.html.erb
@@ -7,18 +7,20 @@
     <% pr_state = channel.respond_to?(:pr_state) ? channel.pr_state : nil %>
     <% chip_classes = [ "channel-chip" ]
        chip_classes << "channel-chip--detached" if channel.detached? %>
+    <% chip_label = channel.latest_label.presence || channel.default_label.presence || channel.class.name.demodulize %>
+    <% chip_link  = channel.latest_link.presence  || channel.default_link.presence %>
     <span class="<%= chip_classes.join(' ') %>" data-channel-id="<%= channel.id %>">
       <% if pr_state %>
         <span class="channel-chip-badge channel-chip-badge--<%= pr_state %>"
               title="<%= t("collavre_github.channel.pr.badge.#{pr_state}", default: pr_state.to_s) %>"
               aria-label="<%= t("collavre_github.channel.pr.badge.#{pr_state}", default: pr_state.to_s) %>"></span>
       <% end %>
-      <% if channel.latest_link.present? %>
-        <a href="<%= channel.latest_link %>" target="_blank" rel="noopener">
-          <%= channel.latest_label.presence || channel.class.name.demodulize %>
+      <% if chip_link %>
+        <a href="<%= chip_link %>" target="_blank" rel="noopener">
+          <%= chip_label %>
         </a>
       <% else %>
-        <%= channel.latest_label.presence || channel.class.name.demodulize %>
+        <%= chip_label %>
       <% end %>
       <button type="button"
               data-action="comments--presence#detachChannel"

--- a/engines/collavre_github/app/models/collavre_github/github_pr_channel.rb
+++ b/engines/collavre_github/app/models/collavre_github/github_pr_channel.rb
@@ -18,6 +18,17 @@ module CollavreGithub
       t("label", number: pr_number)
     end
 
+    # Chip fallbacks: derived directly from config so the chip can render the
+    # full "PR #N" + URL immediately on attach, without waiting for the first
+    # webhook event to populate latest_label / latest_link.
+    def default_label
+      label
+    end
+
+    def default_link
+      pr_url
+    end
+
     # PR lifecycle state used by the chip badge color. Defaults to "open" so
     # freshly attached channels render the green badge before any close event
     # has been received. Persisted in `config` to avoid a schema change for a

--- a/engines/collavre_github/test/models/collavre_github/github_pr_channel_test.rb
+++ b/engines/collavre_github/test/models/collavre_github/github_pr_channel_test.rb
@@ -178,6 +178,17 @@ module CollavreGithub
       assert_equal "open", @channel.pr_state
     end
 
+    test "default_label and default_link derive from config without any webhook event" do
+      fresh = GithubPrChannel.create!(
+        topic: @topic,
+        config: { "repo_full_name" => "owner/repo", "pr_number" => 7 }
+      )
+      assert_nil fresh.latest_label
+      assert_nil fresh.latest_link
+      assert_equal "PR #7", fresh.default_label
+      assert_equal "https://github.com/owner/repo/pull/7", fresh.default_link
+    end
+
     test "pr_state= persists each whitelisted value via the config writer" do
       CollavreGithub::GithubPrChannel::PR_STATES.each do |s|
         @channel.pr_state = s


### PR DESCRIPTION
## Summary
- Add `default_label` / `default_link` (nil by default) hooks on the `Collavre::Channel` base so subclasses can expose a stable fallback derived from their own config.
- Override them in `CollavreGithub::GithubPrChannel` so `default_label = label` (i.e. `PR #N`) and `default_link = pr_url`. Both are derivable at attach time from `repo_full_name` / `pr_number` without any webhook.
- Change the chip view fallback chain to `latest_label || default_label || class.name.demodulize` and `latest_link || default_link`, so the chip renders as `[PR #N](url)` immediately after attach, before the first webhook arrives.

## Why
PR #1239 fixed the same UX issue by seeding `latest_label` / `latest_link` at attach time. This is a simpler approach: if a channel can derive its label/link straight from its own config, the chip stays safe even when the seed/cache is missing. The seeding logic from PR #1239 stays in place so the topic still gets its one-time announcement comment, but chip rendering no longer depends on cache state.

## Test plan
- [x] New case in `engines/collavre_github/test/models/collavre_github/github_pr_channel_test.rb`: on a fresh channel with `latest_*` still nil, `default_label` / `default_link` are derived from config.
- [x] Existing 14 tests still pass.
- [ ] Manual: open a new PR with the topic link in the description and confirm the chip shows `[PR #N](url)` before the first webhook arrives.
