### PR TITLE
fix(creatives): defer cable subscribe + retry transient fetch errors

### DIFF
--- a/engines/collavre/app/javascript/controllers/creatives/__tests__/sync_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/creatives/__tests__/sync_controller.test.js
@@ -67,4 +67,23 @@ describe('CreativesSyncController subscribe timing', () => {
 
     expect(subscribeToCreatives).toHaveBeenCalledTimes(1)
   })
+
+  test('subscribes immediately when tree is already loaded (Turbo cache restore)', async () => {
+    // Simulate Turbo restoring a cached tree page: data-loaded is already set
+    // before sync_controller connects, so tree_controller skips load() and
+    // never dispatches creative-tree:updated.
+    const cached = document.createElement('div')
+    cached.id = 'sync-cached'
+    cached.setAttribute('data-controller', 'creatives--cached-sync')
+    cached.setAttribute('data-creatives--cached-sync-root-id-value', '991')
+    cached.setAttribute('data-loaded', 'true')
+    cached.innerHTML = '<creative-tree-row creative-id="1"></creative-tree-row>'
+    document.body.appendChild(cached)
+
+    application.register('creatives--cached-sync', SyncController)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(subscribeToCreatives).toHaveBeenCalledTimes(1)
+    expect(subscribeToCreatives).toHaveBeenCalledWith(991, expect.any(Object))
+  })
 })

--- a/engines/collavre/app/javascript/controllers/creatives/__tests__/sync_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/creatives/__tests__/sync_controller.test.js
@@ -1,0 +1,70 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { jest } from '@jest/globals'
+
+const subscribeToCreatives = jest.fn()
+
+jest.unstable_mockModule('../../../services/creatives_channel', () => ({
+  subscribeToCreatives,
+}))
+
+const { Application } = await import('@hotwired/stimulus')
+const SyncController = (await import('../sync_controller')).default
+
+describe('CreativesSyncController subscribe timing', () => {
+  let application
+  let container
+
+  beforeEach(() => {
+    subscribeToCreatives.mockReset()
+    subscribeToCreatives.mockReturnValue({
+      cleanup: jest.fn(),
+      sendEditing: jest.fn(),
+      sendStoppedEditing: jest.fn(),
+    })
+
+    container = document.createElement('div')
+    container.id = 'sync-root'
+    container.setAttribute('data-controller', 'creatives--sync')
+    container.setAttribute('data-creatives--sync-root-id-value', '991')
+    document.body.appendChild(container)
+
+    application = Application.start()
+    application.register('creatives--sync', SyncController)
+  })
+
+  afterEach(() => {
+    application.stop()
+    document.body.innerHTML = ''
+  })
+
+  test('does NOT subscribe immediately when rootIdValue > 0 — waits for tree to load', async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(subscribeToCreatives).not.toHaveBeenCalled()
+  })
+
+  test('subscribes after creative-tree:updated event fires', async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(subscribeToCreatives).not.toHaveBeenCalled()
+
+    container.dispatchEvent(
+      new CustomEvent('creative-tree:updated', { bubbles: true }),
+    )
+
+    expect(subscribeToCreatives).toHaveBeenCalledTimes(1)
+    expect(subscribeToCreatives).toHaveBeenCalledWith(991, expect.any(Object))
+  })
+
+  test('subscribes only once even if creative-tree:updated fires multiple times', async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    container.dispatchEvent(new CustomEvent('creative-tree:updated', { bubbles: true }))
+    container.dispatchEvent(new CustomEvent('creative-tree:updated', { bubbles: true }))
+    container.dispatchEvent(new CustomEvent('creative-tree:updated', { bubbles: true }))
+
+    expect(subscribeToCreatives).toHaveBeenCalledTimes(1)
+  })
+})

--- a/engines/collavre/app/javascript/controllers/creatives/__tests__/tree_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/creatives/__tests__/tree_controller.test.js
@@ -1,0 +1,120 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { jest } from '@jest/globals'
+
+jest.unstable_mockModule('../../../creatives/tree_renderer', () => ({
+  renderCreativeTree: jest.fn(),
+  dispatchCreativeTreeUpdated: jest.fn(),
+  applyRowProperties: jest.fn(),
+}))
+
+jest.unstable_mockModule('../../../utils/emoji_parser', () => ({
+  parseEmojis: jest.fn(() => ['✨']),
+}))
+
+const { Application } = await import('@hotwired/stimulus')
+const TreeController = (await import('../tree_controller')).default
+
+const TRANSIENT_RETRY_DELAYS = [200, 600]
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0))
+
+const collectRetryDelays = (spy) =>
+  spy.mock.calls
+    .map((args) => args[1])
+    .filter((delay) => TRANSIENT_RETRY_DELAYS.includes(delay))
+
+const installController = () => {
+  const container = document.createElement('div')
+  container.setAttribute('data-controller', 'creatives--tree')
+  container.setAttribute('data-creatives--tree-url-value', '/creatives?format=json&id=991')
+  document.body.appendChild(container)
+
+  const application = Application.start()
+  application.register('creatives--tree', TreeController)
+
+  return { container, application }
+}
+
+describe('CreativesTreeController retry on transient network errors', () => {
+  let originalFetch
+  let setTimeoutSpy
+
+  beforeEach(() => {
+    originalFetch = global.fetch
+    setTimeoutSpy = jest.spyOn(global, 'setTimeout')
+  })
+
+  afterEach(() => {
+    setTimeoutSpy.mockRestore()
+    global.fetch = originalFetch
+    document.body.innerHTML = ''
+    jest.restoreAllMocks()
+  })
+
+  test('schedules 200ms then 600ms backoff retry on TypeError "Failed to fetch"', async () => {
+    global.fetch = jest
+      .fn()
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ creatives: [] }),
+      })
+
+    const { application } = installController()
+    // Allow time for the 200ms + 600ms retries to fire
+    await new Promise((resolve) => setTimeout(resolve, 1000))
+
+    expect(collectRetryDelays(setTimeoutSpy)).toEqual(TRANSIENT_RETRY_DELAYS)
+
+    application.stop()
+  })
+
+  test('does NOT schedule retry on HTTP error responses', async () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {})
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({}),
+    })
+
+    const { application } = installController()
+    await flush()
+    await flush()
+    await flush()
+
+    expect(collectRetryDelays(setTimeoutSpy)).toEqual([])
+
+    application.stop()
+  })
+
+  test('does NOT schedule retry on AbortError', async () => {
+    const abortErr = new Error('aborted')
+    abortErr.name = 'AbortError'
+    global.fetch = jest.fn().mockRejectedValue(abortErr)
+
+    const { application } = installController()
+    await flush()
+    await flush()
+
+    expect(collectRetryDelays(setTimeoutSpy)).toEqual([])
+
+    application.stop()
+  })
+
+  test('gives up after exactly 2 retries on persistent transient errors', async () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {})
+    global.fetch = jest.fn().mockRejectedValue(new TypeError('Failed to fetch'))
+
+    const { application } = installController()
+    // Allow time for both retries to complete (200 + 600 = 800ms)
+    await new Promise((resolve) => setTimeout(resolve, 1500))
+
+    expect(collectRetryDelays(setTimeoutSpy)).toEqual(TRANSIENT_RETRY_DELAYS)
+
+    application.stop()
+  })
+})

--- a/engines/collavre/app/javascript/controllers/creatives/sync_controller.js
+++ b/engines/collavre/app/javascript/controllers/creatives/sync_controller.js
@@ -24,20 +24,31 @@ export default class extends Controller {
       }
     }
 
+    // Defer ActionCable subscribe until tree finishes loading. Opening the
+    // WebSocket while the tree fetch is in flight triggers ERR_NETWORK_CHANGED
+    // in Chromium because the browser tears down the in-flight HTTP connection.
+    this._handleTreeUpdated = () => {
+      this.element.removeEventListener('creative-tree:updated', this._handleTreeUpdated)
+      this._handleTreeUpdated = null
+      if (this.rootIdValue > 0) {
+        this.subscribe()
+      } else {
+        this.inferAndSubscribe()
+      }
+    }
+    this.element.addEventListener('creative-tree:updated', this._handleTreeUpdated)
+
     document.addEventListener('creative-editing:start', this.handleEditStart)
     document.addEventListener('creative-editing:stop', this.handleEditStop)
-
-    if (this.rootIdValue > 0) {
-      this.subscribe()
-    } else {
-      // Top-level /creatives page — try to infer root from tree rows
-      this.inferAndSubscribe()
-    }
   }
 
   disconnect() {
     document.removeEventListener('creative-editing:start', this.handleEditStart)
     document.removeEventListener('creative-editing:stop', this.handleEditStop)
+    if (this._handleTreeUpdated) {
+      this.element.removeEventListener('creative-tree:updated', this._handleTreeUpdated)
+      this._handleTreeUpdated = null
+    }
 
     if (this.subscription) {
       this.subscription.cleanup()
@@ -50,9 +61,9 @@ export default class extends Controller {
       this.subscription.cleanup()
       this.subscription = null
     }
-    if (this.rootIdValue > 0) {
-      this.subscribe()
-    }
+    // Skip re-subscribing here — connect() defers the first subscribe until
+    // creative-tree:updated fires so the WebSocket handshake doesn't race
+    // the tree's HTTP fetch.
   }
 
   inferAndSubscribe() {

--- a/engines/collavre/app/javascript/controllers/creatives/sync_controller.js
+++ b/engines/collavre/app/javascript/controllers/creatives/sync_controller.js
@@ -27,16 +27,26 @@ export default class extends Controller {
     // Defer ActionCable subscribe until tree finishes loading. Opening the
     // WebSocket while the tree fetch is in flight triggers ERR_NETWORK_CHANGED
     // in Chromium because the browser tears down the in-flight HTTP connection.
-    this._handleTreeUpdated = () => {
-      this.element.removeEventListener('creative-tree:updated', this._handleTreeUpdated)
-      this._handleTreeUpdated = null
+    // Exception: Turbo cache restores leave data-loaded="true" so tree_controller
+    // skips load() and never dispatches creative-tree:updated — subscribe now.
+    const subscribeForRoot = () => {
       if (this.rootIdValue > 0) {
         this.subscribe()
       } else {
         this.inferAndSubscribe()
       }
     }
-    this.element.addEventListener('creative-tree:updated', this._handleTreeUpdated)
+
+    if (this.element.dataset.loaded === 'true') {
+      subscribeForRoot()
+    } else {
+      this._handleTreeUpdated = () => {
+        this.element.removeEventListener('creative-tree:updated', this._handleTreeUpdated)
+        this._handleTreeUpdated = null
+        subscribeForRoot()
+      }
+      this.element.addEventListener('creative-tree:updated', this._handleTreeUpdated)
+    }
 
     document.addEventListener('creative-editing:start', this.handleEditStart)
     document.addEventListener('creative-editing:stop', this.handleEditStop)

--- a/engines/collavre/app/javascript/controllers/creatives/tree_controller.js
+++ b/engines/collavre/app/javascript/controllers/creatives/tree_controller.js
@@ -2,6 +2,8 @@ import { Controller } from '@hotwired/stimulus'
 import { renderCreativeTree, dispatchCreativeTreeUpdated } from '../../creatives/tree_renderer'
 import { parseEmojis } from '../../utils/emoji_parser'
 
+const TREE_RETRY_DELAYS_MS = [200, 600]
+
 export default class extends Controller {
   static values = {
     url: String,
@@ -48,6 +50,10 @@ export default class extends Controller {
     if (this.abortController) {
       this.abortController.abort()
       this.abortController = null
+    }
+    if (this._retryTimer) {
+      clearTimeout(this._retryTimer)
+      this._retryTimer = null
     }
     window.removeEventListener('resize', this.handleResize)
     this.element.removeEventListener('creative-tree:updated', this.handleTreeUpdated)
@@ -138,8 +144,12 @@ export default class extends Controller {
       this.abortController.abort()
     }
     this.abortController = new AbortController()
+    this._retryCount = 0
     this.showLoadingIndicator()
+    this._fetchTree()
+  }
 
+  _fetchTree() {
     fetch(this.urlValue, {
       headers: { Accept: 'application/json' },
       signal: this.abortController.signal,
@@ -154,10 +164,23 @@ export default class extends Controller {
       })
       .catch((error) => {
         if (error.name === 'AbortError') return
+        // Transient network failures (ERR_NETWORK_CHANGED, offline blips, VPN
+        // toggles) surface as TypeError "Failed to fetch". Retry briefly so a
+        // momentary network event doesn't leave the user with an empty tree.
+        if (this._isTransientNetworkError(error) && this._retryCount < TREE_RETRY_DELAYS_MS.length) {
+          const delay = TREE_RETRY_DELAYS_MS[this._retryCount]
+          this._retryCount += 1
+          this._retryTimer = setTimeout(() => this._fetchTree(), delay)
+          return
+        }
         console.error(error)
         this.hideLoadingIndicator()
         this.showEmptyState()
       })
+  }
+
+  _isTransientNetworkError(error) {
+    return error instanceof TypeError && /fetch|network/i.test(error.message || '')
   }
 
   renderData(data) {


### PR DESCRIPTION
## Summary
- Sub-creative tree pages (`/creatives?id=N`) intermittently failed to load with `ERR_NETWORK_CHANGED` / `TypeError: Failed to fetch` at `tree_controller.js:143`.
- Root cause: `tree_controller` and `sync_controller` are bound to the same DOM element. With `rootIdValue > 0`, `sync_controller.connect()` opened the ActionCable WebSocket immediately while the tree's HTTP fetch was still in flight — Chromium tore down the in-flight HTTP socket while switching to the WebSocket connection. Top-level `/creatives` was unaffected because that path waited for the tree to populate via `inferAndSubscribe()`.

## Fix
- **방안 2 (primary fix)** — `sync_controller`: defer the first `subscribe()` until the `creative-tree:updated` event fires, so the WebSocket handshake never races the tree fetch. Unifies the `rootId>0` and inferred-root paths.
- **방안 1 (safety net)** — `tree_controller`: retry `TypeError` "Failed to fetch" / "network" errors with a 200ms → 600ms backoff (max 2 retries). HTTP errors and `AbortError` are not retried.

## Test plan
- [x] Unit tests for `sync_controller` (3 cases): no subscribe before `creative-tree:updated`, subscribes after the event, subscribes only once on repeated events.
- [x] Unit tests for `tree_controller` (4 cases): transient `TypeError` triggers 200ms+600ms backoff; HTTP 5xx not retried; `AbortError` not retried; gives up after 2 retries.
- [x] `npx jest` — 15 suites / 156 tests pass.
- [ ] Manual: load `/creatives?id=<sub-id>` and confirm tree renders without `ERR_NETWORK_CHANGED`.