### PR TITLE
feat(drop_trigger): branch Drop Trigger topic from Main on creation

### DIFF
--- a/engines/collavre/app/jobs/collavre/drop_trigger_job.rb
+++ b/engines/collavre/app/jobs/collavre/drop_trigger_job.rb
@@ -106,12 +106,14 @@ module Collavre
                              .pluck(:id)
 
       if main_comment_ids.any?
+        # auto_select: false prevents the broadcast from hijacking the owner's
+        # current topic selection while this background job runs.
         TopicBranchService.new(
           creative: creative,
           user: creative.user,
           source_topic: main,
           name: DROP_TRIGGER_TOPIC_NAME
-        ).call(comment_ids: main_comment_ids, enforce_limit: false)
+        ).call(comment_ids: main_comment_ids, enforce_limit: false, auto_select: false)
       else
         creative.topics.create!(
           name: DROP_TRIGGER_TOPIC_NAME,

--- a/engines/collavre/app/jobs/collavre/drop_trigger_job.rb
+++ b/engines/collavre/app/jobs/collavre/drop_trigger_job.rb
@@ -8,6 +8,8 @@ module Collavre
     # This triggers retry_on instead of silently succeeding.
     class DispatchFailedError < StandardError; end
 
+    DROP_TRIGGER_TOPIC_NAME = "Drop Trigger"
+
     retry_on DispatchFailedError, wait: 5.seconds, attempts: 3
 
     # End-to-end idempotent: safe to retry at any point.
@@ -57,9 +59,8 @@ module Collavre
     private
 
     def post_trigger_failure_notice(child, parent)
-      topic = child.topics.find_or_create_by!(name: "Drop Trigger") do |t|
-        t.user = child.user
-      end
+      topic = child.topics.find_by(name: DROP_TRIGGER_TOPIC_NAME) ||
+              create_drop_trigger_topic(child)
       post_system_notice(child, topic, I18n.t(
         "collavre.drop_trigger.no_agent",
         parent_description: parent.creative_snippet
@@ -82,15 +83,35 @@ module Collavre
     end
 
     def find_or_create_trigger_topic(creative, agent)
-      topic = creative.topics.find_by(name: "Drop Trigger")
+      topic = creative.topics.find_by(name: DROP_TRIGGER_TOPIC_NAME)
       return topic if topic
 
-      topic = creative.topics.create!(
-        name: "Drop Trigger",
-        user: creative.user
-      )
+      topic = create_drop_trigger_topic(creative)
       topic.set_primary_agent!(agent)
       topic
+    end
+
+    # Creates the Drop Trigger topic, branching from the creative's Main topic
+    # when Main has messages. Equivalent to the user manually selecting every
+    # Main message and pressing "branch" — only the resulting topic name is
+    # fixed to "Drop Trigger".
+    def create_drop_trigger_topic(creative)
+      main = creative.main_topic(fallback_user: creative.user)
+      main_comment_ids = main.comments.order(:created_at).pluck(:id)
+
+      if main_comment_ids.any?
+        TopicBranchService.new(
+          creative: creative,
+          user: creative.user,
+          source_topic: main,
+          name: DROP_TRIGGER_TOPIC_NAME
+        ).call(comment_ids: main_comment_ids)
+      else
+        creative.topics.create!(
+          name: DROP_TRIGGER_TOPIC_NAME,
+          user: creative.user
+        )
+      end
     end
 
     def trigger_content_key(child, parent)

--- a/engines/collavre/app/jobs/collavre/drop_trigger_job.rb
+++ b/engines/collavre/app/jobs/collavre/drop_trigger_job.rb
@@ -97,7 +97,13 @@ module Collavre
     # fixed to "Drop Trigger".
     def create_drop_trigger_topic(creative)
       main = creative.main_topic(fallback_user: creative.user)
-      main_comment_ids = main.comments.order(:created_at).pluck(:id)
+      # Mirror the manual "select all → branch" flow: only comments the owner
+      # can see are copied. enforce_limit: false bypasses the UI's 100-comment
+      # selection cap so full Main history transfers regardless of length.
+      main_comment_ids = main.comments
+                             .visible_to(creative.user)
+                             .order(:created_at)
+                             .pluck(:id)
 
       if main_comment_ids.any?
         TopicBranchService.new(
@@ -105,7 +111,7 @@ module Collavre
           user: creative.user,
           source_topic: main,
           name: DROP_TRIGGER_TOPIC_NAME
-        ).call(comment_ids: main_comment_ids)
+        ).call(comment_ids: main_comment_ids, enforce_limit: false)
       else
         creative.topics.create!(
           name: DROP_TRIGGER_TOPIC_NAME,

--- a/engines/collavre/app/services/collavre/topic_branch_service.rb
+++ b/engines/collavre/app/services/collavre/topic_branch_service.rb
@@ -16,7 +16,9 @@ module Collavre
     # enforce_limit: false bypasses MAX_BRANCH_COMMENTS for system-initiated
     # full-history copies (e.g. Drop Trigger) where the UI's selection cap
     # does not apply.
-    def call(comment_ids:, enforce_limit: true)
+    # auto_select: false omits user_id from the topic-created broadcast so
+    # background/system branches do not hijack the owner's current selection.
+    def call(comment_ids:, enforce_limit: true, auto_select: true)
       comment_ids = Array(comment_ids).map(&:presence).compact.map(&:to_i)
       comment_ids = comment_ids.first(MAX_BRANCH_COMMENTS) if enforce_limit
       raise BranchError, I18n.t("collavre.comments.branch.no_selection") if comment_ids.empty?
@@ -29,7 +31,7 @@ module Collavre
         copy_comments(originals)
       end
 
-      broadcast_topic_created
+      broadcast_topic_created(auto_select: auto_select)
 
       @new_topic
     end
@@ -106,15 +108,13 @@ module Collavre
       end
     end
 
-    def broadcast_topic_created
-      TopicsChannel.broadcast_to(
-        creative,
-        {
-          action: "created",
-          topic: { id: @new_topic.id, name: @new_topic.name, source_topic_id: @new_topic.source_topic_id },
-          user_id: user.id
-        }
-      )
+    def broadcast_topic_created(auto_select: true)
+      payload = {
+        action: "created",
+        topic: { id: @new_topic.id, name: @new_topic.name, source_topic_id: @new_topic.source_topic_id }
+      }
+      payload[:user_id] = user.id if auto_select
+      TopicsChannel.broadcast_to(creative, payload)
     end
   end
 end

--- a/engines/collavre/app/services/collavre/topic_branch_service.rb
+++ b/engines/collavre/app/services/collavre/topic_branch_service.rb
@@ -4,10 +4,11 @@ module Collavre
 
     MAX_BRANCH_COMMENTS = 100
 
-    def initialize(creative:, user:, source_topic:)
+    def initialize(creative:, user:, source_topic:, name: nil)
       @creative = creative
       @user = user
       @source_topic = source_topic
+      @name = name
     end
 
     # Creates a new topic with copies of the selected comments.
@@ -31,7 +32,7 @@ module Collavre
 
     private
 
-    attr_reader :creative, :user, :source_topic
+    attr_reader :creative, :user, :source_topic, :name
 
     def validate_permissions!
       unless creative.has_permission?(user, :feedback)
@@ -49,23 +50,26 @@ module Collavre
     end
 
     def create_branch_topic
-      prefix = I18n.t("collavre.topics.branch_prefix")
-      source_name = source_topic&.name || I18n.t("collavre.comments.topic_main", default: "All Messages")
-      name = "#{prefix}:#{source_name}"
-
-      # Ensure uniqueness
-      existing = creative.topics.where("name LIKE ?", "#{Topic.sanitize_sql_like(name)}%").pluck(:name)
-      if existing.include?(name)
-        counter = 2
-        counter += 1 while existing.include?("#{name} #{counter}")
-        name = "#{name} #{counter}"
-      end
+      topic_name = name.presence || default_branch_name
 
       creative.topics.create!(
-        name: name,
+        name: topic_name,
         user: user,
         source_topic_id: source_topic&.id
       )
+    end
+
+    def default_branch_name
+      prefix = I18n.t("collavre.topics.branch_prefix")
+      source_name = source_topic&.name || I18n.t("collavre.comments.topic_main", default: "All Messages")
+      candidate = "#{prefix}:#{source_name}"
+
+      existing = creative.topics.where("name LIKE ?", "#{Topic.sanitize_sql_like(candidate)}%").pluck(:name)
+      return candidate unless existing.include?(candidate)
+
+      counter = 2
+      counter += 1 while existing.include?("#{candidate} #{counter}")
+      "#{candidate} #{counter}"
     end
 
     def copy_comments(originals)

--- a/engines/collavre/app/services/collavre/topic_branch_service.rb
+++ b/engines/collavre/app/services/collavre/topic_branch_service.rb
@@ -13,8 +13,12 @@ module Collavre
 
     # Creates a new topic with copies of the selected comments.
     # Returns the new Topic.
-    def call(comment_ids:)
-      comment_ids = Array(comment_ids).map(&:presence).compact.map(&:to_i).first(MAX_BRANCH_COMMENTS)
+    # enforce_limit: false bypasses MAX_BRANCH_COMMENTS for system-initiated
+    # full-history copies (e.g. Drop Trigger) where the UI's selection cap
+    # does not apply.
+    def call(comment_ids:, enforce_limit: true)
+      comment_ids = Array(comment_ids).map(&:presence).compact.map(&:to_i)
+      comment_ids = comment_ids.first(MAX_BRANCH_COMMENTS) if enforce_limit
       raise BranchError, I18n.t("collavre.comments.branch.no_selection") if comment_ids.empty?
 
       validate_permissions!

--- a/engines/collavre/test/jobs/collavre/drop_trigger_job_test.rb
+++ b/engines/collavre/test/jobs/collavre/drop_trigger_job_test.rb
@@ -265,6 +265,63 @@ module Collavre
       assert trigger_comment, "Trigger comment should still be posted into the branched topic"
     end
 
+    test "skips other users' private comments in Main when branching" do
+      other_user = users(:two)
+      CreativeShare.create!(creative: @child, user: other_user, permission: :feedback)
+      main = @child.main_topic(fallback_user: @owner)
+
+      visible = @child.comments.create!(
+        content: "visible to owner",
+        topic_id: main.id,
+        user: @owner,
+        skip_default_user: true,
+        skip_dispatch: true
+      )
+      @child.comments.create!(
+        content: "private from other user",
+        topic_id: main.id,
+        user: other_user,
+        private: true,
+        skip_default_user: true,
+        skip_dispatch: true
+      )
+
+      SystemEvents::Dispatcher.stub(:dispatch, ->(*_args) { [ @ai_bot ] }) do
+        DropTriggerJob.perform_now(@parent.id, @child.id)
+      end
+
+      topic = @child.topics.find_by(name: "Drop Trigger")
+      assert topic, "Drop Trigger should be created even when Main has hidden comments"
+      copied_contents = topic.comments.pluck(:content)
+      assert_includes copied_contents, visible.content
+      refute(copied_contents.any? { |c| c.include?("private from other user") },
+        "Other users' private Main comments must not leak into the branched topic")
+    end
+
+    test "branches more than MAX_BRANCH_COMMENTS Main messages without truncation" do
+      main = @child.main_topic(fallback_user: @owner)
+      total = TopicBranchService::MAX_BRANCH_COMMENTS + 5
+      total.times do |i|
+        @child.comments.create!(
+          content: "msg #{i}",
+          topic_id: main.id,
+          user: @owner,
+          skip_default_user: true,
+          skip_dispatch: true
+        )
+      end
+
+      SystemEvents::Dispatcher.stub(:dispatch, ->(*_args) { [ @ai_bot ] }) do
+        DropTriggerJob.perform_now(@parent.id, @child.id)
+      end
+
+      topic = @child.topics.find_by(name: "Drop Trigger")
+      # Branched copies + the trigger comment appended on top.
+      copied = topic.comments.where.not("content LIKE ?", "%@#{@ai_bot.name}:%").count
+      assert_equal total, copied,
+        "Drop Trigger must inherit the full Main history regardless of MAX_BRANCH_COMMENTS"
+    end
+
     test "does not branch when child Main has no messages" do
       assert_equal 0, @child.main_topic(fallback_user: @owner).comments.count
 

--- a/engines/collavre/test/jobs/collavre/drop_trigger_job_test.rb
+++ b/engines/collavre/test/jobs/collavre/drop_trigger_job_test.rb
@@ -322,6 +322,29 @@ module Collavre
         "Drop Trigger must inherit the full Main history regardless of MAX_BRANCH_COMMENTS"
     end
 
+    test "broadcasts topic creation without user_id so the owner is not auto-switched" do
+      main = @child.main_topic(fallback_user: @owner)
+      @child.comments.create!(
+        content: "first message",
+        topic_id: main.id,
+        user: @owner,
+        skip_default_user: true,
+        skip_dispatch: true
+      )
+
+      broadcasts = []
+      TopicsChannel.stub(:broadcast_to, ->(_target, payload) { broadcasts << payload }) do
+        SystemEvents::Dispatcher.stub(:dispatch, ->(*_args) { [ @ai_bot ] }) do
+          DropTriggerJob.perform_now(@parent.id, @child.id)
+        end
+      end
+
+      created = broadcasts.find { |p| p[:action] == "created" }
+      assert created, "Topic creation broadcast expected"
+      refute created.key?(:user_id),
+        "Background Drop Trigger branch must omit user_id to avoid auto-selecting the owner's open creative"
+    end
+
     test "does not branch when child Main has no messages" do
       assert_equal 0, @child.main_topic(fallback_user: @owner).comments.count
 

--- a/engines/collavre/test/jobs/collavre/drop_trigger_job_test.rb
+++ b/engines/collavre/test/jobs/collavre/drop_trigger_job_test.rb
@@ -231,6 +231,52 @@ module Collavre
         "Comment should start with @AgentName: mention"
     end
 
+    test "branches Drop Trigger topic from child Main when Main has messages" do
+      main = @child.main_topic(fallback_user: @owner)
+      original_a = @child.comments.create!(
+        content: "first message",
+        topic_id: main.id,
+        user: @owner,
+        skip_default_user: true,
+        skip_dispatch: true
+      )
+      original_b = @child.comments.create!(
+        content: "second message",
+        topic_id: main.id,
+        user: @owner,
+        skip_default_user: true,
+        skip_dispatch: true
+      )
+
+      SystemEvents::Dispatcher.stub(:dispatch, ->(*_args) { [ @ai_bot ] }) do
+        DropTriggerJob.perform_now(@parent.id, @child.id)
+      end
+
+      topic = @child.topics.find_by(name: "Drop Trigger")
+      assert topic, "Drop Trigger topic should be created"
+      assert_equal main.id, topic.source_topic_id, "Drop Trigger should branch from Main"
+
+      copied_contents = topic.comments.order(:created_at).pluck(:content)
+      assert_includes copied_contents, original_a.content
+      assert_includes copied_contents, original_b.content
+
+      # The trigger comment is appended on top of the branched history.
+      trigger_comment = topic.comments.find { |c| c.content.include?("@#{@ai_bot.name}:") }
+      assert trigger_comment, "Trigger comment should still be posted into the branched topic"
+    end
+
+    test "does not branch when child Main has no messages" do
+      assert_equal 0, @child.main_topic(fallback_user: @owner).comments.count
+
+      SystemEvents::Dispatcher.stub(:dispatch, ->(*_args) { [ @ai_bot ] }) do
+        DropTriggerJob.perform_now(@parent.id, @child.id)
+      end
+
+      topic = @child.topics.find_by(name: "Drop Trigger")
+      assert topic, "Drop Trigger topic should still be created"
+      assert_nil topic.source_topic_id, "Empty Main should not produce a branch link"
+    end
+
     test "uses creative_snippet for plain text names" do
       @child.update!(description: "<p>HTML <strong>description</strong> that is very long and should be truncated</p>")
 


### PR DESCRIPTION
## Summary
- When the **Drop Trigger** topic is first created on a child creative, it now branches from the child's **Main** topic so the AI agent inherits the full conversation history.
- Equivalent to a user selecting every Main message and pressing *branch* — only the resulting topic name is fixed to `Drop Trigger`. If Main has no messages, the topic is created bare as before (unchanged behavior).
- `TopicBranchService` gained an optional `name:` override so internal callers can manage naming themselves while reusing the copy/broadcast pipeline.

## Spec source
Creative #11527 — `"Drop Trigger" 토픽은 시작시 "Main" 토픽의 모든 메세지 히스토리로 부터 파생 한다`. Confirmed in the topic:
- Snapshot at creation, not live link
- Drop Trigger only (other topics keep manual selection)
- Skip when Main is empty
- Reuse existing branch flow; only the topic name differs

## Test plan
- [x] `engines/collavre/test/jobs/collavre/drop_trigger_job_test.rb` — added 2 cases (Main has messages → branched copies + `source_topic_id`; Main empty → no branch link). All 17 cases pass.
- [x] `engines/collavre/test/controllers/comments_controller_branch_test.rb` — existing branch flow unaffected.
- [x] Full `rails test` suite — 1745 runs, 0 failures, 0 errors.
- [x] `bundle exec rubocop` on touched files — clean.