### PR TITLE
feat(channels): topic-badge abstraction + preview MCP tools

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_27_000100) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_28_000000) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false
@@ -88,6 +88,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_27_000100) do
     t.integer "topic_id", null: false
     t.string "type", null: false
     t.datetime "updated_at", null: false
+    t.index "topic_id, json_extract(config, '$.worktree_id')", name: "index_channels_on_topic_preview_worktree", unique: true, where: "type = 'Collavre::PreviewChannel'"
     t.index "type, topic_id, json_extract(config, '$.repo_full_name'), json_extract(config, '$.pr_number')", name: "index_channels_on_type_topic_repo_pr", unique: true
     t.index ["dismissed_at"], name: "index_channels_on_dismissed_at"
     t.index ["topic_id"], name: "index_channels_on_topic_id"

--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -1258,6 +1258,15 @@ body.chat-fullscreen {
     background: var(--color-danger);
 }
 
+.channel-chip-badge--running {
+    background: var(--color-success);
+}
+
+.channel-chip-badge--stopped {
+    background: var(--color-text);
+    opacity: 0.5;
+}
+
 /* --- Context Chips --- */
 .comment-contexts-list {
     display: flex;

--- a/engines/collavre/app/models/collavre/channel.rb
+++ b/engines/collavre/app/models/collavre/channel.rb
@@ -26,6 +26,19 @@ module Collavre
       nil
     end
 
+    # Badge interface for the typing-indicator chip. Subclasses override
+    # `badge_state` to drive the chip badge color (the value becomes a CSS
+    # modifier: channel-chip-badge--<state>), and `badge_title` to provide a
+    # localized title / aria-label string. Returning nil from `badge_state`
+    # hides the badge entirely.
+    def badge_state
+      nil
+    end
+
+    def badge_title
+      nil
+    end
+
     def detach!
       update!(state: :detached)
     end

--- a/engines/collavre/app/models/collavre/preview_channel.rb
+++ b/engines/collavre/app/models/collavre/preview_channel.rb
@@ -1,0 +1,93 @@
+module Collavre
+  # Topic chip for a running development preview server. Unlike
+  # GithubPrChannel there is no external webhook source — the chip is
+  # populated by AI Agents (or humans) calling preview_attach/preview_detach
+  # MCP tools, one for each ./bin/dev they spin up alongside a worktree.
+  class PreviewChannel < Collavre::Channel
+    self.table_name = "channels"
+
+    PREVIEW_STATES = %w[running stopped].freeze
+
+    def preview_url
+      config["preview_url"]
+    end
+
+    def worktree_id
+      config["worktree_id"]
+    end
+
+    def custom_label
+      config["label"]
+    end
+
+    # Chip fallbacks rendered immediately on attach, before the user has
+    # interacted with the chip. The label prefers the caller-supplied
+    # "Preview #42" style override and falls back to a localized default;
+    # the link is always the preview URL.
+    def default_label
+      custom_label.presence || I18n.t("collavre.channel.preview.label_default")
+    end
+
+    def default_link
+      preview_url
+    end
+
+    def badge_state
+      preview_state
+    end
+
+    def badge_title
+      I18n.t("collavre.channel.preview.badge.#{preview_state}", default: preview_state.to_s)
+    end
+
+    def preview_state
+      state = config["preview_state"].to_s
+      PREVIEW_STATES.include?(state) ? state : "running"
+    end
+
+    def preview_state=(value)
+      value = value.to_s
+      raise ArgumentError, "Invalid preview_state: #{value.inspect}" unless PREVIEW_STATES.include?(value)
+      self.config = config.merge("preview_state" => value)
+    end
+
+    def attached_message
+      Collavre::Channel::InjectedMessage.new(
+        speaker: channel_bot_user,
+        message: I18n.t("collavre.channel.preview.attached_message",
+                        label: default_label, url: preview_url),
+        label: default_label,
+        link: preview_url
+      )
+    end
+
+    # PreviewChannel has no external event source — preview_attach/detach
+    # mutate the channel directly. The base `handle` would raise
+    # NotImplementedError, so override with an explicit no-op.
+    def handle(event:, payload:)
+      nil
+    end
+
+    private
+
+    # Same bot user as GithubPrChannel so all channel-injected comments come
+    # from a single "Channel" speaker in the topic timeline.
+    def channel_bot_user
+      @channel_bot_user ||=
+        Collavre::User.find_by(email: Collavre::Channel::BOT_EMAIL) ||
+          ensure_channel_bot_user!
+    end
+
+    def ensure_channel_bot_user!
+      email = Collavre::Channel::BOT_EMAIL
+      user = Collavre::User.find_or_initialize_by(email: email)
+      user.name = Collavre::Channel::BOT_NAME
+      user.password = SecureRandom.hex(32) if user.new_record?
+      user.email_verified_at ||= Time.current
+      user.searchable = false if user.respond_to?(:searchable=)
+      user.llm_vendor = nil
+      user.save!
+      user
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/channel_attacher.rb
+++ b/engines/collavre/app/services/collavre/channel_attacher.rb
@@ -14,10 +14,15 @@ module Collavre
     #
     # `lookup` is called twice in the unique-violation race path, so it must
     # be a fresh query each call (not a captured AR record).
-    def self.call(channel_class:, lookup:, create_attrs:, on_reactivate: nil)
+    #
+    # `on_noop` runs when the existing channel is still active+visible and we
+    # would otherwise short-circuit. Preview channels use it to silently refresh
+    # config (e.g. new port after a restart) so the chip link never points at a
+    # dead server while reporting success.
+    def self.call(channel_class:, lookup:, create_attrs:, on_reactivate: nil, on_noop: nil)
       existing = lookup.call
       if existing
-        return [ existing, :noop ] if existing.active? && existing.dismissed_at.nil?
+        return noop(existing, on_noop) if existing.active? && existing.dismissed_at.nil?
         reactivate(existing, on_reactivate)
         return [ existing, :reactivated ]
       end
@@ -26,7 +31,7 @@ module Collavre
       existing = lookup.call
       raise unless existing
       if existing.active? && existing.dismissed_at.nil?
-        [ existing, :noop ]
+        noop(existing, on_noop)
       else
         reactivate(existing, on_reactivate)
         [ existing, :reactivated ]
@@ -40,5 +45,14 @@ module Collavre
       channel.save!
     end
     private_class_method :reactivate
+
+    def self.noop(channel, on_noop)
+      if on_noop
+        on_noop.call(channel)
+        channel.save! if channel.changed?
+      end
+      [ channel, :noop ]
+    end
+    private_class_method :noop
   end
 end

--- a/engines/collavre/app/services/collavre/channel_attacher.rb
+++ b/engines/collavre/app/services/collavre/channel_attacher.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Collavre
+  # Shared idempotent attach/reactivate lifecycle for topic channels.
+  # Every channel subtype reaches the same end-state regardless of which tool
+  # invoked it: a row that is active, not dismissed, and visible under the
+  # `not_dismissed` render scope.
+  #
+  # Subtype-specific resets (e.g. PR `pr_state` back to "open" so a previously
+  # merged-then-reattached channel renders the green badge again) run via the
+  # `on_reactivate` proc.
+  class ChannelAttacher
+    # Returns [channel, status] where status ∈ :created / :reactivated / :noop.
+    #
+    # `lookup` is called twice in the unique-violation race path, so it must
+    # be a fresh query each call (not a captured AR record).
+    def self.call(channel_class:, lookup:, create_attrs:, on_reactivate: nil)
+      existing = lookup.call
+      if existing
+        return [ existing, :noop ] if existing.active? && existing.dismissed_at.nil?
+        reactivate(existing, on_reactivate)
+        return [ existing, :reactivated ]
+      end
+      [ channel_class.create!(create_attrs), :created ]
+    rescue ActiveRecord::RecordNotUnique
+      existing = lookup.call
+      raise unless existing
+      if existing.active? && existing.dismissed_at.nil?
+        [ existing, :noop ]
+      else
+        reactivate(existing, on_reactivate)
+        [ existing, :reactivated ]
+      end
+    end
+
+    def self.reactivate(channel, on_reactivate)
+      channel.state = :active unless channel.active?
+      channel.dismissed_at = nil unless channel.dismissed_at.nil?
+      on_reactivate&.call(channel)
+      channel.save!
+    end
+    private_class_method :reactivate
+  end
+end

--- a/engines/collavre/app/services/collavre/tools/permission_denied_error.rb
+++ b/engines/collavre/app/services/collavre/tools/permission_denied_error.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Tools
+    # Raised by tool services when the current user lacks the required
+    # creative-level permission to perform a mutating action.
+    class PermissionDeniedError < StandardError; end
+  end
+end

--- a/engines/collavre/app/services/collavre/tools/preview_attach_service.rb
+++ b/engines/collavre/app/services/collavre/tools/preview_attach_service.rb
@@ -34,8 +34,24 @@ module Tools
       ).returns(T::Hash[Symbol, T.untyped])
     end
     def call(topic_id:, preview_url:, worktree_id:, label: nil)
+      validate_preview_url!(preview_url)
+
       topic = Collavre::Topic.find(topic_id)
       Collavre::Tools::TopicAuthorizer.authorize_write!(topic)
+
+      refresh_config = ->(c) {
+        # Re-attach against the same worktree may carry a fresh URL/label
+        # (e.g. port reassignment after a restart). Refresh the persisted
+        # config so the chip link goes to the live server, not the dead one
+        # — applies both when reactivating a stopped chip and when the chip
+        # is still active (:noop), which is the common dev-restart case.
+        new_config = c.config.merge(
+          "preview_url" => preview_url,
+          "preview_state" => "running"
+        )
+        new_config["label"] = label if label
+        c.config = new_config
+      }
 
       channel, status = Collavre::ChannelAttacher.call(
         channel_class: Collavre::PreviewChannel,
@@ -49,17 +65,8 @@ module Tools
             "label" => label
           }.compact
         },
-        on_reactivate: ->(c) {
-          # Re-attach against the same worktree may carry a fresh URL/label
-          # (e.g. port reassignment after a restart). Refresh the persisted
-          # config so the chip link goes to the live server, not the dead one.
-          new_config = c.config.merge(
-            "preview_url" => preview_url,
-            "preview_state" => "running"
-          )
-          new_config["label"] = label if label
-          c.config = new_config
-        }
+        on_reactivate: refresh_config,
+        on_noop: refresh_config
       )
 
       # Mirror PR-channel UX: only the first attach (and a true reactivation
@@ -79,6 +86,24 @@ module Tools
     end
 
     private
+
+    ALLOWED_PREVIEW_URL_SCHEMES = %w[http https].freeze
+    private_constant :ALLOWED_PREVIEW_URL_SCHEMES
+
+    # The preview_url is rendered directly as the chip's <a href> via ERB,
+    # which escapes quotes but does NOT reject dangerous URL schemes. Without
+    # this gate a write-capable MCP caller could persist `javascript:...` or
+    # `data:...` and turn the chip into a one-click XSS for any topic viewer.
+    sig { params(preview_url: String).void }
+    def validate_preview_url!(preview_url)
+      uri = URI.parse(preview_url)
+      unless ALLOWED_PREVIEW_URL_SCHEMES.include?(uri.scheme&.downcase)
+        raise ArgumentError, "preview_url must be http(s); got: #{preview_url.inspect}"
+      end
+      raise ArgumentError, "preview_url must include a host" if uri.host.to_s.empty?
+    rescue URI::InvalidURIError
+      raise ArgumentError, "preview_url is not a valid URI: #{preview_url.inspect}"
+    end
 
     # config is JSON, so worktree_id matching is a Ruby-side scan over the
     # topic's preview channels. With only a handful of previews per topic in

--- a/engines/collavre/app/services/collavre/tools/preview_attach_service.rb
+++ b/engines/collavre/app/services/collavre/tools/preview_attach_service.rb
@@ -51,6 +51,14 @@ module Tools
         )
         new_config["label"] = label if label
         c.config = new_config
+        # Also refresh the cached chip fields that record_event! seeded on the
+        # first attach. The chip partial renders latest_link.presence ||
+        # default_link, so without this update a :noop reattach with a new port
+        # leaves the chip pointing at the dead URL even though config is fresh.
+        # (On :reactivate the subsequent inject_into_topic! would overwrite
+        # these via record_event! anyway, so updating here is harmless.)
+        c.latest_link = preview_url
+        c.latest_label = c.default_label
       }
 
       channel, status = Collavre::ChannelAttacher.call(

--- a/engines/collavre/app/services/collavre/tools/preview_attach_service.rb
+++ b/engines/collavre/app/services/collavre/tools/preview_attach_service.rb
@@ -1,0 +1,95 @@
+module Collavre
+require "sorbet-runtime"
+require "rails_mcp_engine"
+module Tools
+  # Attach a development-preview chip to a topic. AI Agents call this after
+  # spinning up `./bin/dev` against a worktree so the preview URL and run
+  # state surface as a chip in the typing-indicator row. Idempotent by
+  # (topic_id, worktree_id).
+  class PreviewAttachService
+    extend T::Sig
+    extend ToolMeta
+
+    tool_name "preview_attach"
+    tool_description <<~DESC.strip
+      Attach a development preview server to a Collavre topic. Renders a
+      chip in the topic's typing-indicator row with a clickable link to the
+      preview URL and a state badge (running/stopped). Call this after
+      starting a preview server (e.g. ./bin/dev on a worktree). Idempotent
+      per (topic_id, worktree_id) — calling twice does not duplicate the
+      chip or re-announce.
+    DESC
+
+    tool_param :topic_id, description: "The Collavre topic id to attach the preview chip to."
+    tool_param :preview_url, description: "Full URL of the preview server, e.g. http://localhost:4001"
+    tool_param :worktree_id, description: "Stable identifier for the worktree (or environment) running this preview. Used as the dedup key — re-calling with the same worktree_id reactivates the existing chip instead of creating a duplicate."
+    tool_param :label, description: "Optional display label shown on the chip. Defaults to a localized 'Preview' string.", required: false
+
+    sig do
+      params(
+        topic_id: Integer,
+        preview_url: String,
+        worktree_id: String,
+        label: T.nilable(String)
+      ).returns(T::Hash[Symbol, T.untyped])
+    end
+    def call(topic_id:, preview_url:, worktree_id:, label: nil)
+      topic = Collavre::Topic.find(topic_id)
+      Collavre::Tools::TopicAuthorizer.authorize_write!(topic)
+
+      channel, status = Collavre::ChannelAttacher.call(
+        channel_class: Collavre::PreviewChannel,
+        lookup: -> { lookup_channel(topic, worktree_id) },
+        create_attrs: {
+          topic_id: topic.id,
+          config: {
+            "worktree_id" => worktree_id,
+            "preview_url" => preview_url,
+            "preview_state" => "running",
+            "label" => label
+          }.compact
+        },
+        on_reactivate: ->(c) {
+          # Re-attach against the same worktree may carry a fresh URL/label
+          # (e.g. port reassignment after a restart). Refresh the persisted
+          # config so the chip link goes to the live server, not the dead one.
+          new_config = c.config.merge(
+            "preview_url" => preview_url,
+            "preview_state" => "running"
+          )
+          new_config["label"] = label if label
+          c.config = new_config
+        }
+      )
+
+      # Mirror PR-channel UX: only the first attach (and a true reactivation
+      # from stopped/dismissed) announces in the topic. Subsequent idempotent
+      # attaches stay silent so frequent restarts do not spam the timeline.
+      if status == :created || status == :reactivated
+        channel.inject_into_topic!(channel.attached_message)
+      end
+
+      {
+        ok: true,
+        channel_id: channel.id,
+        worktree_id: worktree_id,
+        preview_url: preview_url,
+        status: status
+      }
+    end
+
+    private
+
+    # config is JSON, so worktree_id matching is a Ruby-side scan over the
+    # topic's preview channels. With only a handful of previews per topic in
+    # practice this is fine and avoids JSON operator divergence between
+    # Postgres (config->>'worktree_id') and SQLite (json_extract).
+    sig { params(topic: Collavre::Topic, worktree_id: String).returns(T.nilable(Collavre::PreviewChannel)) }
+    def lookup_channel(topic, worktree_id)
+      Collavre::PreviewChannel.where(topic_id: topic.id).find do |c|
+        c.worktree_id.to_s == worktree_id.to_s
+      end
+    end
+  end
+end
+end

--- a/engines/collavre/app/services/collavre/tools/preview_detach_service.rb
+++ b/engines/collavre/app/services/collavre/tools/preview_detach_service.rb
@@ -1,0 +1,61 @@
+module Collavre
+require "sorbet-runtime"
+require "rails_mcp_engine"
+module Tools
+  # Mark a previously-attached preview as stopped. AI Agents call this
+  # immediately before killing the preview server (per the worktree cleanup
+  # workflow) so the chip flips to the "stopped" badge with reduced opacity.
+  # The chip stays visible until the user dismisses it with the X button —
+  # mirrors the PR-channel post-close UX where the closed badge persists for
+  # context.
+  class PreviewDetachService
+    extend T::Sig
+    extend ToolMeta
+
+    tool_name "preview_detach"
+    tool_description <<~DESC.strip
+      Mark a development preview as stopped. The chip stays visible with a
+      stopped badge until the user dismisses it. Idempotent — calling on an
+      already-stopped or missing channel returns ok with status :noop.
+    DESC
+
+    tool_param :topic_id, description: "The Collavre topic id the preview was attached to."
+    tool_param :worktree_id, description: "The worktree_id used when the preview was attached."
+
+    sig do
+      params(
+        topic_id: Integer,
+        worktree_id: String
+      ).returns(T::Hash[Symbol, T.untyped])
+    end
+    def call(topic_id:, worktree_id:)
+      topic = Collavre::Topic.find(topic_id)
+      Collavre::Tools::TopicAuthorizer.authorize_write!(topic)
+
+      channel = lookup_channel(topic, worktree_id)
+      return { ok: true, status: :noop, worktree_id: worktree_id } if channel.nil?
+
+      status =
+        if channel.preview_state == "stopped" && channel.detached?
+          :noop
+        else
+          channel.preview_state = "stopped"
+          channel.state = :detached unless channel.detached?
+          channel.save!
+          :stopped
+        end
+
+      { ok: true, channel_id: channel.id, worktree_id: worktree_id, status: status }
+    end
+
+    private
+
+    sig { params(topic: Collavre::Topic, worktree_id: String).returns(T.nilable(Collavre::PreviewChannel)) }
+    def lookup_channel(topic, worktree_id)
+      Collavre::PreviewChannel.where(topic_id: topic.id).find do |c|
+        c.worktree_id.to_s == worktree_id.to_s
+      end
+    end
+  end
+end
+end

--- a/engines/collavre/app/services/collavre/tools/topic_authorizer.rb
+++ b/engines/collavre/app/services/collavre/tools/topic_authorizer.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Tools
+    # Topic write authorization for MCP tool services. Mirrors
+    # CreativePermissionGuard#require_creative_write! but is callable outside a
+    # controller request. Attaching a channel injects external messages into a
+    # topic, so it is a write-equivalent mutation — restrict to users with
+    # write permission on the topic's effective_origin creative.
+    module TopicAuthorizer
+      module_function
+
+      def authorize_write!(topic, user: Collavre::Current.user)
+        creative = topic.creative&.effective_origin
+        raise ArgumentError, "Topic has no creative" unless creative
+        return if creative.user == user
+        return if user && creative.has_permission?(user, :write)
+
+        raise Collavre::Tools::PermissionDeniedError,
+          "No write permission on topic #{topic.id}"
+      end
+    end
+  end
+end

--- a/engines/collavre/app/views/collavre/comments/_channel_chips.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_channel_chips.html.erb
@@ -1,19 +1,21 @@
 <%# locals: { topic: Collavre::Topic } %>
 <div class="channel-chips" data-comments--presence-target="channelChips" data-topic-id="<%= topic.id %>">
   <% topic.channels.not_dismissed.each do |channel| %>
-    <%# Chip is kept after detach so the final merged/closed badge stays visible
-        until the user dismisses it with the X button. Subclasses that expose
-        `pr_state` get a status-colored badge; others fall back to no badge. %>
-    <% pr_state = channel.respond_to?(:pr_state) ? channel.pr_state : nil %>
+    <%# Chip is kept after detach so the final closed/stopped badge stays
+        visible until the user dismisses it with the X button. Subclasses
+        drive the colored badge via badge_state / badge_title; returning nil
+        from badge_state hides the badge entirely. %>
+    <% badge_state = channel.badge_state %>
+    <% badge_title = channel.badge_title %>
     <% chip_classes = [ "channel-chip" ]
        chip_classes << "channel-chip--detached" if channel.detached? %>
     <% chip_label = channel.latest_label.presence || channel.default_label.presence || channel.class.name.demodulize %>
     <% chip_link  = channel.latest_link.presence  || channel.default_link.presence %>
     <span class="<%= chip_classes.join(' ') %>" data-channel-id="<%= channel.id %>">
-      <% if pr_state %>
-        <span class="channel-chip-badge channel-chip-badge--<%= pr_state %>"
-              title="<%= t("collavre_github.channel.pr.badge.#{pr_state}", default: pr_state.to_s) %>"
-              aria-label="<%= t("collavre_github.channel.pr.badge.#{pr_state}", default: pr_state.to_s) %>"></span>
+      <% if badge_state %>
+        <span class="channel-chip-badge channel-chip-badge--<%= badge_state %>"
+              title="<%= badge_title %>"
+              aria-label="<%= badge_title %>"></span>
       <% end %>
       <% if chip_link %>
         <a href="<%= chip_link %>" target="_blank" rel="noopener">

--- a/engines/collavre/config/locales/channels.en.yml
+++ b/engines/collavre/config/locales/channels.en.yml
@@ -1,0 +1,11 @@
+en:
+  collavre:
+    channels:
+      detach: "Detach"
+    channel:
+      preview:
+        label_default: "Preview"
+        attached_message: "%{label} server started.\n\n%{url}"
+        badge:
+          running: "Running"
+          stopped: "Stopped"

--- a/engines/collavre/config/locales/channels.ko.yml
+++ b/engines/collavre/config/locales/channels.ko.yml
@@ -1,0 +1,11 @@
+ko:
+  collavre:
+    channels:
+      detach: "해제"
+    channel:
+      preview:
+        label_default: "프리뷰"
+        attached_message: "%{label} 서버가 시작되었습니다.\n\n%{url}"
+        badge:
+          running: "실행 중"
+          stopped: "중지됨"

--- a/engines/collavre/db/migrate/20260528000000_add_preview_channel_unique_index.rb
+++ b/engines/collavre/db/migrate/20260528000000_add_preview_channel_unique_index.rb
@@ -1,0 +1,31 @@
+class AddPreviewChannelUniqueIndex < ActiveRecord::Migration[8.1]
+  def up
+    postgres = connection.adapter_name == "PostgreSQL"
+
+    # Mirror the PR-channel uniqueness guarantee for preview channels: a topic
+    # has at most one PreviewChannel per worktree_id. Without this, a racing
+    # preview_attach (e.g. concurrent CI + skill calls) could land two rows
+    # for the same worktree and the chip would render twice. `type` is
+    # included so the partial index does not collide with other channel
+    # subtypes that happen to store a `worktree_id` in their config.
+    if postgres
+      execute <<~SQL
+        CREATE UNIQUE INDEX index_channels_on_topic_preview_worktree
+        ON channels (topic_id, (config->>'worktree_id'))
+        WHERE type = 'Collavre::PreviewChannel'
+      SQL
+    else
+      execute <<~SQL
+        CREATE UNIQUE INDEX index_channels_on_topic_preview_worktree
+        ON channels (topic_id, json_extract(config, '$.worktree_id'))
+        WHERE type = 'Collavre::PreviewChannel'
+      SQL
+    end
+  end
+
+  def down
+    if connection.index_exists?(:channels, nil, name: "index_channels_on_topic_preview_worktree")
+      execute "DROP INDEX index_channels_on_topic_preview_worktree"
+    end
+  end
+end

--- a/engines/collavre/test/models/collavre/preview_channel_test.rb
+++ b/engines/collavre/test/models/collavre/preview_channel_test.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  class PreviewChannelTest < ActiveSupport::TestCase
+    setup do
+      @user = users(:one)
+      Collavre::Current.user = @user
+      @creative = Creative.create!(description: "Preview Creative", user: @user)
+      @topic = Topic.create!(name: "Preview Topic", creative: @creative, user: @user)
+      @channel = PreviewChannel.create!(
+        topic: @topic,
+        config: {
+          "worktree_id" => "wt-123",
+          "preview_url" => "http://localhost:4001",
+          "preview_state" => "running"
+        }
+      )
+    end
+
+    test "default_label falls back to localized 'Preview' when no custom label" do
+      assert_equal I18n.t("collavre.channel.preview.label_default"), @channel.default_label
+    end
+
+    test "default_label prefers custom label from config" do
+      @channel.update!(config: @channel.config.merge("label" => "Preview #42"))
+      assert_equal "Preview #42", @channel.default_label
+    end
+
+    test "default_link returns preview_url" do
+      assert_equal "http://localhost:4001", @channel.default_link
+    end
+
+    test "badge_state defaults to running when config has no preview_state" do
+      fresh = PreviewChannel.create!(
+        topic: @topic,
+        config: { "worktree_id" => "wt-fresh", "preview_url" => "http://localhost:4002" }
+      )
+      assert_equal "running", fresh.badge_state
+    end
+
+    test "preview_state= rejects values outside PREVIEW_STATES" do
+      assert_raises(ArgumentError) { @channel.preview_state = "paused" }
+      assert_raises(ArgumentError) { @channel.preview_state = "" }
+      assert_raises(ArgumentError) { @channel.preview_state = nil }
+      assert_equal "running", @channel.preview_state
+    end
+
+    test "preview_state= persists each whitelisted value" do
+      PreviewChannel::PREVIEW_STATES.each do |s|
+        @channel.preview_state = s
+        @channel.save!
+        assert_equal s, @channel.reload.preview_state
+      end
+    end
+
+    test "badge_title returns localized string for each state" do
+      @channel.preview_state = "running"
+      assert_equal I18n.t("collavre.channel.preview.badge.running"), @channel.badge_title
+      @channel.preview_state = "stopped"
+      assert_equal I18n.t("collavre.channel.preview.badge.stopped"), @channel.badge_title
+    end
+
+    test "handle is a no-op — preview channels have no external event source" do
+      assert_nil @channel.handle(event: "anything", payload: {})
+    end
+
+    test "attached_message embeds label and url, authored by the channel bot" do
+      msg = @channel.attached_message
+      assert_kind_of Collavre::Channel::InjectedMessage, msg
+      assert_equal Collavre::Channel::BOT_EMAIL, msg.speaker.email
+      assert_includes msg.message, "http://localhost:4001"
+      assert_equal "http://localhost:4001", msg.link
+    end
+  end
+end

--- a/engines/collavre/test/services/collavre/tools/preview_attach_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/preview_attach_service_test.rb
@@ -119,6 +119,88 @@ module Collavre
         assert_equal 0, Collavre::PreviewChannel.where(topic_id: @topic.id).count
       end
 
+      test "rejects javascript: URL schemes to prevent chip-link XSS" do
+        assert_raises(ArgumentError) do
+          PreviewAttachService.new.call(
+            topic_id: @topic.id,
+            preview_url: "javascript:alert(1)",
+            worktree_id: "wt-1"
+          )
+        end
+        assert_equal 0, Collavre::PreviewChannel.where(topic_id: @topic.id).count
+      end
+
+      test "rejects data: URL schemes" do
+        assert_raises(ArgumentError) do
+          PreviewAttachService.new.call(
+            topic_id: @topic.id,
+            preview_url: "data:text/html,<script>alert(1)</script>",
+            worktree_id: "wt-1"
+          )
+        end
+      end
+
+      test "rejects malformed URLs" do
+        assert_raises(ArgumentError) do
+          PreviewAttachService.new.call(
+            topic_id: @topic.id,
+            preview_url: "not a url at all",
+            worktree_id: "wt-1"
+          )
+        end
+      end
+
+      test "accepts https preview URLs (e.g. tunneled dev servers)" do
+        result = PreviewAttachService.new.call(
+          topic_id: @topic.id,
+          preview_url: "https://wt1.preview.example.com",
+          worktree_id: "wt-1"
+        )
+        assert result[:ok]
+        assert_equal :created, result[:status]
+      end
+
+      test "refreshes preview_url on noop reattach so port changes don't leave dead chip links" do
+        PreviewAttachService.new.call(
+          topic_id: @topic.id,
+          preview_url: "http://localhost:4001",
+          worktree_id: "wt-1"
+        )
+
+        # Same worktree, fresh URL — server restarted on a new port while the
+        # chip is still active. Must update config silently (no announcement).
+        assert_no_difference -> { @creative.comments.count } do
+          result = PreviewAttachService.new.call(
+            topic_id: @topic.id,
+            preview_url: "http://localhost:4099",
+            worktree_id: "wt-1"
+          )
+          assert_equal :noop, result[:status]
+        end
+
+        channel = Collavre::PreviewChannel.where(topic_id: @topic.id).first
+        assert_equal "http://localhost:4099", channel.preview_url
+      end
+
+      test "updates label on noop reattach when caller supplies a new label" do
+        PreviewAttachService.new.call(
+          topic_id: @topic.id,
+          preview_url: "http://localhost:4001",
+          worktree_id: "wt-1",
+          label: "Preview #1"
+        )
+
+        PreviewAttachService.new.call(
+          topic_id: @topic.id,
+          preview_url: "http://localhost:4001",
+          worktree_id: "wt-1",
+          label: "Preview #1 (renamed)"
+        )
+
+        channel = Collavre::PreviewChannel.where(topic_id: @topic.id).first
+        assert_equal "Preview #1 (renamed)", channel.default_label
+      end
+
       test "custom label is persisted and surfaces in the chip" do
         result = PreviewAttachService.new.call(
           topic_id: @topic.id,

--- a/engines/collavre/test/services/collavre/tools/preview_attach_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/preview_attach_service_test.rb
@@ -180,6 +180,10 @@ module Collavre
 
         channel = Collavre::PreviewChannel.where(topic_id: @topic.id).first
         assert_equal "http://localhost:4099", channel.preview_url
+        # Chip partial renders latest_link.presence || default_link, so refreshing
+        # config alone is not enough — the cached field must also update or the
+        # chip keeps pointing at the dead port.
+        assert_equal "http://localhost:4099", channel.latest_link
       end
 
       test "updates label on noop reattach when caller supplies a new label" do
@@ -199,6 +203,9 @@ module Collavre
 
         channel = Collavre::PreviewChannel.where(topic_id: @topic.id).first
         assert_equal "Preview #1 (renamed)", channel.default_label
+        # Cached chip label must follow the renamed config, not the original
+        # announcement value seeded by record_event!.
+        assert_equal "Preview #1 (renamed)", channel.latest_label
       end
 
       test "custom label is persisted and surfaces in the chip" do

--- a/engines/collavre/test/services/collavre/tools/preview_attach_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/preview_attach_service_test.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  module Tools
+    class PreviewAttachServiceTest < ActiveSupport::TestCase
+      setup do
+        @user = users(:one)
+        @creative = creatives(:tshirt)
+        @topic = Collavre::Topic.create!(name: "Preview T", creative: @creative, user: @user)
+        Collavre::Current.user = @user
+      end
+
+      teardown do
+        Collavre::Current.user = nil
+      end
+
+      test "creates a PreviewChannel for the topic and seeds chip label/link" do
+        result = PreviewAttachService.new.call(
+          topic_id: @topic.id,
+          preview_url: "http://localhost:4001",
+          worktree_id: "wt-1"
+        )
+        assert result[:ok]
+        assert_equal :created, result[:status]
+        channel = Collavre::PreviewChannel.find(result[:channel_id])
+        assert_equal @topic.id, channel.topic_id
+        assert_equal "wt-1", channel.worktree_id
+        assert_equal "http://localhost:4001", channel.preview_url
+        # Announcement caches latest_label/latest_link so chip is clickable
+        # immediately, mirroring the PR-channel first-attach behavior.
+        assert_equal "http://localhost:4001", channel.latest_link
+      end
+
+      test "first attach injects exactly one announcement comment" do
+        assert_difference -> { @creative.comments.count }, 1 do
+          PreviewAttachService.new.call(
+            topic_id: @topic.id,
+            preview_url: "http://localhost:4001",
+            worktree_id: "wt-1"
+          )
+        end
+      end
+
+      test "idempotent: same (topic, worktree_id) does not duplicate channel or re-announce" do
+        2.times do
+          PreviewAttachService.new.call(
+            topic_id: @topic.id,
+            preview_url: "http://localhost:4001",
+            worktree_id: "wt-1"
+          )
+        end
+        assert_equal 1, Collavre::PreviewChannel.where(topic_id: @topic.id).count
+
+        assert_no_difference -> { @creative.comments.count } do
+          PreviewAttachService.new.call(
+            topic_id: @topic.id,
+            preview_url: "http://localhost:4001",
+            worktree_id: "wt-1"
+          )
+        end
+      end
+
+      test "different worktree_id on same topic creates a separate chip" do
+        PreviewAttachService.new.call(
+          topic_id: @topic.id,
+          preview_url: "http://localhost:4001",
+          worktree_id: "wt-1"
+        )
+        PreviewAttachService.new.call(
+          topic_id: @topic.id,
+          preview_url: "http://localhost:4002",
+          worktree_id: "wt-2"
+        )
+        assert_equal 2, Collavre::PreviewChannel.where(topic_id: @topic.id).count
+      end
+
+      test "reactivates a stopped+detached channel, refreshes URL, and re-announces" do
+        existing = Collavre::PreviewChannel.create!(
+          topic_id: @topic.id,
+          config: {
+            "worktree_id" => "wt-1",
+            "preview_url" => "http://localhost:4001",
+            "preview_state" => "stopped"
+          },
+          state: :detached,
+          dismissed_at: 1.hour.ago
+        )
+
+        assert_difference -> { @creative.comments.count }, 1 do
+          PreviewAttachService.new.call(
+            topic_id: @topic.id,
+            # Port changed after restart — reattach must adopt the new URL,
+            # otherwise the chip link points at a dead server.
+            preview_url: "http://localhost:4099",
+            worktree_id: "wt-1"
+          )
+        end
+
+        existing.reload
+        assert_predicate existing, :active?
+        assert_nil existing.dismissed_at
+        assert_equal "running", existing.preview_state
+        assert_equal "http://localhost:4099", existing.preview_url
+      end
+
+      test "denies attach when current user lacks write permission on the topic creative" do
+        outsider = users(:two)
+        Collavre::Current.user = outsider
+
+        assert_raises(Collavre::Tools::PermissionDeniedError) do
+          PreviewAttachService.new.call(
+            topic_id: @topic.id,
+            preview_url: "http://localhost:4001",
+            worktree_id: "wt-1"
+          )
+        end
+        assert_equal 0, Collavre::PreviewChannel.where(topic_id: @topic.id).count
+      end
+
+      test "custom label is persisted and surfaces in the chip" do
+        result = PreviewAttachService.new.call(
+          topic_id: @topic.id,
+          preview_url: "http://localhost:4001",
+          worktree_id: "wt-1",
+          label: "Preview #42"
+        )
+        channel = Collavre::PreviewChannel.find(result[:channel_id])
+        assert_equal "Preview #42", channel.default_label
+      end
+    end
+  end
+end

--- a/engines/collavre/test/services/collavre/tools/preview_detach_service_test.rb
+++ b/engines/collavre/test/services/collavre/tools/preview_detach_service_test.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  module Tools
+    class PreviewDetachServiceTest < ActiveSupport::TestCase
+      setup do
+        @user = users(:one)
+        @creative = creatives(:tshirt)
+        @topic = Collavre::Topic.create!(name: "Preview T", creative: @creative, user: @user)
+        Collavre::Current.user = @user
+        @channel = Collavre::PreviewChannel.create!(
+          topic_id: @topic.id,
+          config: {
+            "worktree_id" => "wt-1",
+            "preview_url" => "http://localhost:4001",
+            "preview_state" => "running"
+          }
+        )
+      end
+
+      teardown do
+        Collavre::Current.user = nil
+      end
+
+      test "flips preview_state to stopped and detaches the channel" do
+        result = PreviewDetachService.new.call(topic_id: @topic.id, worktree_id: "wt-1")
+        assert result[:ok]
+        assert_equal :stopped, result[:status]
+        @channel.reload
+        assert_equal "stopped", @channel.preview_state
+        assert_predicate @channel, :detached?
+      end
+
+      test "keeps the chip visible (not dismissed) so users see the final state" do
+        # The PR-channel pattern: post-close chip stays under not_dismissed
+        # until the user explicitly hits X. Preview must match so a freshly
+        # stopped preview is not silently hidden.
+        PreviewDetachService.new.call(topic_id: @topic.id, worktree_id: "wt-1")
+        assert_nil @channel.reload.dismissed_at
+        assert_includes @topic.channels.not_dismissed.pluck(:id), @channel.id
+      end
+
+      test "idempotent on an already stopped+detached channel" do
+        PreviewDetachService.new.call(topic_id: @topic.id, worktree_id: "wt-1")
+        result = PreviewDetachService.new.call(topic_id: @topic.id, worktree_id: "wt-1")
+        assert_equal :noop, result[:status]
+      end
+
+      test "noop when no channel exists for the worktree" do
+        result = PreviewDetachService.new.call(topic_id: @topic.id, worktree_id: "wt-missing")
+        assert result[:ok]
+        assert_equal :noop, result[:status]
+      end
+
+      test "denies detach when current user lacks write permission" do
+        outsider = users(:two)
+        Collavre::Current.user = outsider
+
+        assert_raises(Collavre::Tools::PermissionDeniedError) do
+          PreviewDetachService.new.call(topic_id: @topic.id, worktree_id: "wt-1")
+        end
+        assert_equal "running", @channel.reload.preview_state
+      end
+    end
+  end
+end

--- a/engines/collavre_github/app/models/collavre_github/github_pr_channel.rb
+++ b/engines/collavre_github/app/models/collavre_github/github_pr_channel.rb
@@ -29,6 +29,14 @@ module CollavreGithub
       pr_url
     end
 
+    def badge_state
+      pr_state
+    end
+
+    def badge_title
+      I18n.t("collavre_github.channel.pr.badge.#{pr_state}", default: pr_state.to_s)
+    end
+
     # PR lifecycle state used by the chip badge color. Defaults to "open" so
     # freshly attached channels render the green badge before any close event
     # has been received. Persisted in `config` to avoid a schema change for a

--- a/engines/collavre_github/app/services/collavre_github/tools/permission_denied_error.rb
+++ b/engines/collavre_github/app/services/collavre_github/tools/permission_denied_error.rb
@@ -2,8 +2,9 @@
 
 module CollavreGithub
   module Tools
-    # Raised by tool services when the current user lacks the required
-    # creative-level permission to perform a mutating action.
-    class PermissionDeniedError < StandardError; end
+    # Kept as an alias of the core engine's shared error so existing rescue
+    # blocks and tests in collavre_github continue to match. New code should
+    # reference `Collavre::Tools::PermissionDeniedError` directly.
+    PermissionDeniedError = ::Collavre::Tools::PermissionDeniedError
   end
 end

--- a/engines/collavre_github/app/services/collavre_github/tools/pr_monitor_service.rb
+++ b/engines/collavre_github/app/services/collavre_github/tools/pr_monitor_service.rb
@@ -32,7 +32,7 @@ module CollavreGithub
         pr_number = m[2].to_i
 
         topic = Collavre::Topic.find(topic_id)
-        authorize_topic_write!(topic)
+        Collavre::Tools::TopicAuthorizer.authorize_write!(topic)
         channel, attach_status = find_or_attach_channel(topic, repo, pr_number)
         # Re-seed announcement on fresh attach AND on detached->active so the
         # chip label/link cache is repopulated after the channel was previously
@@ -49,60 +49,25 @@ module CollavreGithub
 
       private
 
-      # Attaching a channel injects external messages into the topic, so it is a
-      # write-equivalent mutation. Mirror CreativePermissionGuard#require_creative_write!
-      # against the topic's effective_origin so MCP callers cannot drop monitors
-      # onto topics they would not be allowed to comment on.
-      def authorize_topic_write!(topic)
-        creative = topic.creative&.effective_origin
-        raise ArgumentError, "Topic has no creative" unless creative
-
-        user = Collavre::Current.user
-        return if creative.user == user
-        return if user && creative.has_permission?(user, :write)
-
-        raise CollavreGithub::Tools::PermissionDeniedError,
-          "No write permission on topic #{topic.id}"
-      end
-
-      # Returns the channel plus a status symbol so callers can distinguish:
-      #   :created     - new row inserted
-      #   :reactivated - existing detached row flipped back to active
-      #   :noop        - row was already active (idempotent re-attach)
+      # Wraps Collavre::ChannelAttacher with PR-specific create attrs and a
+      # PR-specific reactivation reset (pr_state back to "open"). The shared
+      # attacher handles the create/reactivate/noop lifecycle, including the
+      # concurrent insert race and dismissed_at clearing — Mirror
+      # WebhooksController#maybe_auto_attach_channel reactivation, so the
+      # chip resurfaces under the not_dismissed render scope.
       sig { params(topic: Collavre::Topic, repo: String, pr_number: Integer).returns([ CollavreGithub::GithubPrChannel, Symbol ]) }
       def find_or_attach_channel(topic, repo, pr_number)
-        existing = lookup_channel(topic, repo, pr_number)
-        if existing
-          return [ existing, :noop ] if existing.active? && existing.dismissed_at.nil?
-          reactivate!(existing)
-          return [ existing, :reactivated ]
-        end
-        created = CollavreGithub::GithubPrChannel.create!(
-          topic_id: topic.id,
-          config: { "repo_full_name" => repo, "pr_number" => pr_number, "pr_state" => "open" }
+        Collavre::ChannelAttacher.call(
+          channel_class: CollavreGithub::GithubPrChannel,
+          lookup: -> { lookup_channel(topic, repo, pr_number) },
+          create_attrs: {
+            topic_id: topic.id,
+            config: { "repo_full_name" => repo, "pr_number" => pr_number, "pr_state" => "open" }
+          },
+          on_reactivate: ->(channel) {
+            channel.pr_state = "open" if channel.pr_state != "open"
+          }
         )
-        [ created, :created ]
-      rescue ActiveRecord::RecordNotUnique
-        # Concurrent caller won the race; reuse the row they created.
-        existing = lookup_channel(topic, repo, pr_number)
-        raise unless existing
-        if existing.active? && existing.dismissed_at.nil?
-          [ existing, :noop ]
-        else
-          reactivate!(existing)
-          [ existing, :reactivated ]
-        end
-      end
-
-      # Mirror WebhooksController#maybe_auto_attach_channel reactivation: clear
-      # dismissed_at and reset pr_state so the chip surfaces again under the
-      # not_dismissed render scope. Otherwise pr_monitor would report success
-      # and inject the attached message while the chip stayed hidden.
-      def reactivate!(channel)
-        channel.state = :active unless channel.active?
-        channel.dismissed_at = nil unless channel.dismissed_at.nil?
-        channel.pr_state = "open" if channel.pr_state != "open"
-        channel.save!
       end
 
       sig { params(topic: Collavre::Topic, repo: String, pr_number: Integer).returns(T.nilable(CollavreGithub::GithubPrChannel)) }


### PR DESCRIPTION
## Summary

Generalize the existing PR-channel chip into a reusable **topic-badge** domain on `Collavre::Channel`, and add the first non-PR publisher: a development-preview chip driven by two new MCP tools (`preview_attach` / `preview_detach`).

The chip lives in the topic's typing-indicator row and lets agents surface a clickable link + status badge for any external state they want the user to glance at. PR monitoring was already 80% there — this PR removes the PR-specific leaks from the core engine and proves the abstraction by adding a second concrete subtype.

### Core abstraction (collavre engine)

- **`Channel#badge_state` / `Channel#badge_title`** interface on the base class. The chip partial now drives the colored badge dot + tooltip from these instead of duck-typing `pr_state` and hardcoding `collavre_github.*` i18n keys.
- **`Collavre::ChannelAttacher`** extracts the idempotent locate-or-create lifecycle (including `dismissed_at` clear and the concurrent-insert race) shared by every publisher. Subtype-specific resets (e.g. PR `pr_state` back to `"open"`) are passed in as an `on_reactivate` proc.
- **`Collavre::Tools::TopicAuthorizer.authorize_write!`** + **`Collavre::Tools::PermissionDeniedError`** — shared topic write check usable from any MCP tool service. `CollavreGithub::Tools::PermissionDeniedError` is aliased for back-compat.
- `PrMonitorService` refactored to delegate to all three, dropping 50+ lines of duplicated lifecycle code.

### Preview chip (new)

- **`Collavre::PreviewChannel`** keyed on `worktree_id`, with `running` / `stopped` badge states and a no-op `handle()` (the channel is mutated directly by the tools — there's no external event source like a webhook).
- **`preview_attach(topic_id:, preview_url:, worktree_id:, label?)`** MCP tool — idempotent per `(topic_id, worktree_id)`. Refreshes `preview_url` on reactivation so chips survive port reassignments after a restart. Announces in the topic exactly once on `:created` / `:reactivated` (silent on `:noop` so frequent restarts don't spam the timeline).
- **`preview_detach(topic_id:, worktree_id:)`** MCP tool — flips state to `stopped + detached` but keeps the chip visible until the user dismisses it with X, mirroring the post-close PR-chip UX.
- Partial unique index on `(topic_id, config->>'worktree_id') WHERE type='Collavre::PreviewChannel'` for symmetry with the PR-channel uniqueness guarantee.
- i18n: `collavre.channel.preview.*` (en + ko). CSS: `channel-chip-badge--running` (success), `channel-chip-badge--stopped` (dimmed text).

Tools auto-register via the existing FastMcp loader — no wiring changes needed. They're also available via the Collavre skill as `/preview_attach` and `/preview_detach`.

## Test plan

- [x] `bundle exec rake test` (host app + all engines) — 1788 runs, 0 failures, 0 errors
- [x] Existing `PrMonitorServiceTest` (16 cases) green after refactor — confirms attach/reactivate/noop lifecycle unchanged
- [x] New `PreviewChannelTest` covers badge/state validation, no-op handle, label fallback, attached_message authoring
- [x] New `PreviewAttachServiceTest` covers create / idempotent / multi-worktree / reactivate-with-fresh-url / permission denial / custom label
- [x] New `PreviewDetachServiceTest` covers stopped+detached flip, chip visibility preserved, idempotent on already-stopped, noop on missing channel, permission denial
- [ ] Manual: attach a preview from the Collavre skill against a worktree, verify chip renders in topic typing-indicator row with running badge; kill server + detach, verify badge flips to stopped (dimmed)