### PR TITLE
feat(commands): auto-fill creative_id / topic_id from chat context

### DIFF
--- a/engines/collavre/app/controllers/collavre/topics_controller.rb
+++ b/engines/collavre/app/controllers/collavre/topics_controller.rb
@@ -33,7 +33,8 @@ module Collavre
         last_topic_id: last_topic_id,
         is_inbox: @creative.inbox?,
         system_topic_id: system_topic_id,
-        main_topic_id: main_topic_id
+        main_topic_id: main_topic_id,
+        effective_creative_id: @creative.id
       }
     end
 

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -145,10 +145,10 @@ export default class extends Controller {
   onPopupOpened({ creativeId, canComment }) {
     this.creativeId = creativeId
     this.element.dataset.creativeId = creativeId || ''
-    // Clear stale topic ids from the previous creative — handleTopicChange will
-    // repopulate them when comments--topics dispatches change after loadTopics.
-    this.currentTopicId = ''
-    this._mainTopicId = null
+    // Stale topic ids from the previous creative are cleared by the popup
+    // controller BEFORE topics loadTopics() dispatches comments--topics:change,
+    // so by the time we get here, currentTopicId already reflects the new
+    // creative's restored topic. Do not re-clear it.
     this.formTarget.style.display = canComment ? '' : 'none'
     this.resetForm()
     if (canComment && this.shouldAutoFocusOnOpen()) {

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -145,6 +145,10 @@ export default class extends Controller {
   onPopupOpened({ creativeId, canComment }) {
     this.creativeId = creativeId
     this.element.dataset.creativeId = creativeId || ''
+    // Clear stale topic ids from the previous creative — handleTopicChange will
+    // repopulate them when comments--topics dispatches change after loadTopics.
+    this.currentTopicId = ''
+    this._mainTopicId = null
     this.formTarget.style.display = canComment ? '' : 'none'
     this.resetForm()
     if (canComment && this.shouldAutoFocusOnOpen()) {

--- a/engines/collavre/app/javascript/controllers/comments/popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/popup_controller.js
@@ -289,6 +289,15 @@ export default class extends Controller {
 
   async notifyChildControllers({ creativeId, canComment, highlightId }) {
     this.topicsController?.clearOverrideTopicId()
+    // Drop the previous creative's topic selection from the form controller
+    // synchronously, BEFORE topics loadTopics() dispatches `comments--topics:change`
+    // (which repopulates these via handleTopicChange). Doing it later — e.g. in
+    // formController.onPopupOpened, which runs after the topics await — would
+    // erase the topic that restoreSelection() just restored from the server.
+    if (this.formController) {
+      this.formController.currentTopicId = ''
+      this.formController._mainTopicId = null
+    }
     // Pre-set creativeId on list controller BEFORE loading topics.
     // Topics loading triggers a change event that list controller handles.
     // Without this, list controller still holds the previous creative's ID

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -34,6 +34,10 @@ export default class extends Controller {
 
     onPopupOpened({ creativeId }) {
         this.creativeIdValue = creativeId
+        // Clear stale cached effective id from the previous creative — otherwise
+        // chat-context autofill (command_menu) reads the old value during the
+        // window between popup switch and the new topics fetch completing.
+        delete this.element.dataset.effectiveCreativeId
         this.subscribe()
         return this.loadTopics()
     }

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -88,6 +88,12 @@ export default class extends Controller {
                 this.isInbox = !!data.is_inbox
                 this.systemTopicId = data.system_topic_id ? String(data.system_topic_id) : null
                 this.mainTopicId = data.main_topic_id ? String(data.main_topic_id) : null
+                // Expose effective origin id so chat-context autofill (slash commands)
+                // and any other consumer can target the same creative the server uses
+                // (linked creatives resolve params[:creative_id] through effective_origin).
+                if (data.effective_creative_id) {
+                    this.element.dataset.effectiveCreativeId = String(data.effective_creative_id)
+                }
 
                 // Migrate localStorage to server if server has no value
                 this.migrateLocalStorage()

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -34,10 +34,15 @@ export default class extends Controller {
 
     onPopupOpened({ creativeId }) {
         this.creativeIdValue = creativeId
-        // Clear stale cached effective id from the previous creative — otherwise
-        // chat-context autofill (command_menu) reads the old value during the
+        // Clear stale cached state from the previous creative — otherwise
+        // chat-context autofill (command_menu) reads stale values during the
         // window between popup switch and the new topics fetch completing.
+        // form_controller's currentTopicId is cleared upstream in
+        // popup_controller.notifyChildControllers; here we clear our own
+        // mainTopicId (read directly as the autofill fallback) and the cached
+        // effective_creative_id. loadTopics() repopulates both.
         delete this.element.dataset.effectiveCreativeId
+        this.mainTopicId = null
         this.subscribe()
         return this.loadTopics()
     }

--- a/engines/collavre/app/javascript/modules/__tests__/command_args_form.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/command_args_form.test.js
@@ -1,0 +1,103 @@
+/**
+ * @jest-environment jsdom
+ */
+import CommandArgsForm from '../command_args_form'
+
+const baseCommand = (overrides = {}) => ({
+  name: 'foo_tool',
+  label: '/foo_tool',
+  input_schema: [
+    { name: 'creative_id', type: 'string', required: false },
+    { name: 'topic_id', type: 'string', required: false },
+    { name: 'note', type: 'string', required: false }
+  ],
+  ...overrides
+})
+
+const fieldFor = (paramName) =>
+  document.querySelector(`[data-param-name="${paramName}"]`)
+
+describe('CommandArgsForm context auto-fill', () => {
+  let container
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  test('fills creative_id and topic_id from contextValuesFn', () => {
+    const form = new CommandArgsForm({
+      container,
+      contextValuesFn: () => ({ creative_id: '12508', topic_id: '8455' })
+    })
+
+    form.show(baseCommand())
+
+    expect(fieldFor('creative_id').value).toBe('12508')
+    expect(fieldFor('topic_id').value).toBe('8455')
+    expect(fieldFor('note').value).toBe('')
+  })
+
+  test('explicit default_value beats context auto-fill', () => {
+    const form = new CommandArgsForm({
+      container,
+      contextValuesFn: () => ({ creative_id: '12508', topic_id: '8455' })
+    })
+
+    form.show(baseCommand({
+      input_schema: [
+        { name: 'creative_id', type: 'string', required: false, default_value: '999' },
+        { name: 'topic_id', type: 'string', required: false }
+      ]
+    }))
+
+    expect(fieldFor('creative_id').value).toBe('999')
+    expect(fieldFor('topic_id').value).toBe('8455')
+  })
+
+  test('does not fill unrelated params even if names overlap', () => {
+    const form = new CommandArgsForm({
+      container,
+      contextValuesFn: () => ({ creative_id: '12508', topic_id: '8455', note: 'ctx' })
+    })
+
+    form.show(baseCommand())
+
+    expect(fieldFor('note').value).toBe('')
+  })
+
+  test('missing context values leave fields empty', () => {
+    const form = new CommandArgsForm({
+      container,
+      contextValuesFn: () => ({ creative_id: null, topic_id: '' })
+    })
+
+    form.show(baseCommand())
+
+    expect(fieldFor('creative_id').value).toBe('')
+    expect(fieldFor('topic_id').value).toBe('')
+  })
+
+  test('contextValuesFn throwing does not break form', () => {
+    const form = new CommandArgsForm({
+      container,
+      contextValuesFn: () => { throw new Error('boom') }
+    })
+
+    expect(() => form.show(baseCommand())).not.toThrow()
+    expect(fieldFor('creative_id').value).toBe('')
+  })
+
+  test('no contextValuesFn provided behaves like before', () => {
+    const form = new CommandArgsForm({ container })
+
+    form.show(baseCommand())
+
+    expect(fieldFor('creative_id').value).toBe('')
+    expect(fieldFor('topic_id').value).toBe('')
+  })
+})

--- a/engines/collavre/app/javascript/modules/command_args_form.js
+++ b/engines/collavre/app/javascript/modules/command_args_form.js
@@ -20,13 +20,16 @@ export default class CommandArgsForm {
    * @param {Element}  opts.container - if set, the modal is scoped inside this element
    *                                    (overlay covers only the container, content is blurred)
    * @param {Function} opts.creativeIdFn - returns current creative ID for mention search
+   * @param {Function} opts.contextValuesFn - returns { creative_id, topic_id } used to
+   *                                          pre-fill params whose name matches
    */
-  constructor({ onSubmit, onCancel, labels, container, creativeIdFn } = {}) {
+  constructor({ onSubmit, onCancel, labels, container, creativeIdFn, contextValuesFn } = {}) {
     this.onSubmit = onSubmit || (() => {})
     this.onCancel = onCancel || (() => {})
     this.labels = labels || { submit: 'OK', cancel: 'Cancel' }
     this.container = container || null
     this._creativeIdFn = creativeIdFn || (() => null)
+    this._contextValuesFn = contextValuesFn || (() => ({}))
     this.command = null
     this.overlay = null
     this.dialog = null
@@ -173,6 +176,18 @@ export default class CommandArgsForm {
     host.appendChild(this.dialog)
   }
 
+  _contextDefaultFor(paramName) {
+    if (paramName !== 'creative_id' && paramName !== 'topic_id') return null
+    let ctx
+    try {
+      ctx = this._contextValuesFn() || {}
+    } catch (_e) {
+      return null
+    }
+    const value = ctx[paramName]
+    return value == null || value === '' ? null : value
+  }
+
   _buildField(param, index) {
     const wrapper = document.createElement('div')
     wrapper.className = 'modal-dialog-field'
@@ -241,9 +256,12 @@ export default class CommandArgsForm {
     input.dataset.paramRequired = param.required ? 'true' : 'false'
     if (param.description) input.placeholder = param.description
 
-    // Pre-fill with default value from creative tool defaults
-    if (param.default_value != null) {
-      input.value = String(param.default_value)
+    // Pre-fill priority: explicit default_value (from creative tool config) wins,
+    // otherwise auto-fill creative_id / topic_id from the current chat context.
+    const contextFill = this._contextDefaultFor(param.name)
+    const prefill = param.default_value != null ? param.default_value : contextFill
+    if (prefill != null && prefill !== '') {
+      input.value = String(prefill)
       if (input.tagName === 'TEXTAREA') {
         requestAnimationFrame(() => this._autoResize(input))
       }

--- a/engines/collavre/app/javascript/modules/command_menu.js
+++ b/engines/collavre/app/javascript/modules/command_menu.js
@@ -20,7 +20,11 @@ if (!commandMenuInitialized) {
       container: popup,
       creativeIdFn: () => popup.dataset.creativeId,
       contextValuesFn: () => ({
-        creative_id: popup.dataset.creativeId || null,
+        // Prefer the effective origin id (what comments/topics controllers
+        // operate on). For linked creatives, popup.dataset.creativeId is the
+        // wrapper row id, but the server resolves through effective_origin —
+        // MCP tools expect the same effective id.
+        creative_id: popup.dataset.effectiveCreativeId || popup.dataset.creativeId || null,
         topic_id: currentTopicIdFromController(popup) || null
       }),
       labels: {
@@ -84,20 +88,22 @@ if (!commandMenuInitialized) {
     })
 
     function currentTopicIdFromController(popupEl) {
-      // Prefer the form controller's locally-cached topic id (the same value
-      // used when submitting a comment). It is set from the
-      // `comments--topics:change` event so it reflects the user's actual
-      // selection after restoreSelection, while topics_controller's
-      // currentTopicId getter can still return a stale URL deep-link.
+      // Prefer the form controller's locally-cached topic id — the same value
+      // used when submitting a comment. It is set from the
+      // `comments--topics:change` event, so it reflects the user's actual
+      // selection after restoreSelection rather than a stale URL deep-link.
       const formCtrl = window.Stimulus?.getControllerForElementAndIdentifier(popupEl, 'comments--form')
       if (formCtrl) {
         const id = formCtrl.currentTopicId || formCtrl._mainTopicId
         if (id) return String(id)
       }
+      // Topics may not have loaded yet (form hasn't received any change event).
+      // Fall back to mainTopicId only — never topicsCtrl.currentTopicId, whose
+      // getter prioritizes window.location.search?topic_id= even when that
+      // topic does not belong to the current creative.
       const topicsCtrl = window.Stimulus?.getControllerForElementAndIdentifier(popupEl, 'comments--topics')
       if (!topicsCtrl) return ''
-      const id = topicsCtrl.currentTopicId || topicsCtrl.mainTopicId
-      return id ? String(id) : ''
+      return topicsCtrl.mainTopicId ? String(topicsCtrl.mainTopicId) : ''
     }
 
     function clearCommandText() {

--- a/engines/collavre/app/javascript/modules/command_menu.js
+++ b/engines/collavre/app/javascript/modules/command_menu.js
@@ -84,9 +84,19 @@ if (!commandMenuInitialized) {
     })
 
     function currentTopicIdFromController(popupEl) {
-      const controller = window.Stimulus?.getControllerForElementAndIdentifier(popupEl, 'comments--topics')
-      if (!controller) return ''
-      const id = controller.currentTopicId || controller.mainTopicId
+      // Prefer the form controller's locally-cached topic id (the same value
+      // used when submitting a comment). It is set from the
+      // `comments--topics:change` event so it reflects the user's actual
+      // selection after restoreSelection, while topics_controller's
+      // currentTopicId getter can still return a stale URL deep-link.
+      const formCtrl = window.Stimulus?.getControllerForElementAndIdentifier(popupEl, 'comments--form')
+      if (formCtrl) {
+        const id = formCtrl.currentTopicId || formCtrl._mainTopicId
+        if (id) return String(id)
+      }
+      const topicsCtrl = window.Stimulus?.getControllerForElementAndIdentifier(popupEl, 'comments--topics')
+      if (!topicsCtrl) return ''
+      const id = topicsCtrl.currentTopicId || topicsCtrl.mainTopicId
       return id ? String(id) : ''
     }
 

--- a/engines/collavre/app/javascript/modules/command_menu.js
+++ b/engines/collavre/app/javascript/modules/command_menu.js
@@ -85,7 +85,8 @@ if (!commandMenuInitialized) {
 
     function currentTopicIdFromController(popupEl) {
       const controller = window.Stimulus?.getControllerForElementAndIdentifier(popupEl, 'comments--topics')
-      const id = controller?.currentTopicId
+      if (!controller) return ''
+      const id = controller.currentTopicId || controller.mainTopicId
       return id ? String(id) : ''
     }
 

--- a/engines/collavre/app/javascript/modules/command_menu.js
+++ b/engines/collavre/app/javascript/modules/command_menu.js
@@ -19,6 +19,10 @@ if (!commandMenuInitialized) {
     const argsForm = new CommandArgsForm({
       container: popup,
       creativeIdFn: () => popup.dataset.creativeId,
+      contextValuesFn: () => ({
+        creative_id: popup.dataset.creativeId || null,
+        topic_id: currentTopicIdFromController(popup) || null
+      }),
       labels: {
         submit: menu.dataset.formSubmit || 'OK',
         cancel: menu.dataset.formCancel || 'Cancel'
@@ -78,6 +82,12 @@ if (!commandMenuInitialized) {
         textarea.focus()
       }
     })
+
+    function currentTopicIdFromController(popupEl) {
+      const controller = window.Stimulus?.getControllerForElementAndIdentifier(popupEl, 'comments--topics')
+      const id = controller?.currentTopicId
+      return id ? String(id) : ''
+    }
 
     function clearCommandText() {
       const pos = textarea.selectionStart

--- a/engines/collavre/test/controllers/topics_controller_test.rb
+++ b/engines/collavre/test/controllers/topics_controller_test.rb
@@ -8,6 +8,21 @@ class TopicsControllerTest < ActionDispatch::IntegrationTest
     sign_in_as @user, password: "password"
   end
 
+  test "index returns effective_creative_id for non-linked creative" do
+    get collavre.creative_topics_url(@creative), as: :json
+    assert_response :success
+    json = JSON.parse(response.body)
+    assert_equal @creative.id, json["effective_creative_id"]
+  end
+
+  test "index returns effective_creative_id for linked creative (origin id)" do
+    linked = Collavre::Creative.create!(user: @user, description: "linked wrapper", origin: @creative)
+    get collavre.creative_topics_url(linked), as: :json
+    assert_response :success
+    json = JSON.parse(response.body)
+    assert_equal @creative.id, json["effective_creative_id"]
+  end
+
   test "should create topic and broadcast" do
     assert_difference("Topic.count") do
       post collavre.creative_topics_url(@creative), params: { topic: { name: "New Strategy" } }, as: :json


### PR DESCRIPTION
## Summary
- Slash-command parameter form now pre-fills params literally named `creative_id` or `topic_id` with the active chat's creative and topic ids, so the user does not have to retype values that are already visible on screen.
- Per-creative tool defaults (`default_value` returned by the server) still win — context only fills when no explicit default exists.
- Modeled as if the user opened the existing parameter input with the current context already selected; they can override it freely before submitting.

## Implementation
- `command_args_form.js`: new `contextValuesFn` option; in `_buildField`, a context default is used only when no explicit `default_value` is provided.
- `command_menu.js`: wires `contextValuesFn` to `popup.dataset.creativeId` and the `comments--topics` Stimulus controller's `currentTopicId` getter, so the values are read fresh at the moment the args form opens.

## Test plan
- [x] Jest: 6 new cases in `command_args_form.test.js` cover the fill, the default-wins override, the irrelevant-param case, missing context, throwing context fn, and the no-context-fn fallback.
- [x] `npm test` — all 163 tests pass.
- [x] `rake test` — full Rails suite passes (1794 runs, 0 failures, 0 errors).
- [ ] Manual: open a slash command whose schema includes `creative_id` / `topic_id` (e.g. an MCP tool) and verify the fields are pre-filled and editable.

Drop Trigger creative: #12508