### PR TITLE
fix(test): align sign-in landing assertion with authenticated home redirect

### DIFF
--- a/engines/collavre/test/support/system_helpers.rb
+++ b/engines/collavre/test/support/system_helpers.rb
@@ -14,7 +14,16 @@ module SystemHelpers
     fill_in placeholder: I18n.t("collavre.users.new.enter_your_email"), with: user.email
     fill_in placeholder: I18n.t("collavre.users.new.enter_your_password"), with: password
     find("#sign-in-submit").click
-    assert_current_path root_path, ignore_query: true
+    assert_current_path post_sign_in_path, ignore_query: true
+  end
+
+  # Mirrors Collavre::ApplicationController#redirect_authenticated_root_to_home:
+  # authenticated users hitting "/" are redirected to home_page_path_authenticated
+  # unless it is blank or "/", in which case they stay at root.
+  def post_sign_in_path
+    target = Collavre::SystemSetting.home_page_path_authenticated
+    return root_path if target.blank? || target == "/"
+    target
   end
 
   def resize_window_to(width = 1200, height = 800)

--- a/engines/collavre/test/system/creative_share_test.rb
+++ b/engines/collavre/test/system/creative_share_test.rb
@@ -20,7 +20,7 @@ class CreativeShareSystemTest < ApplicationSystemTestCase
     fill_in placeholder: I18n.t("collavre.users.new.enter_your_email"), with: @user.email
     fill_in placeholder: I18n.t("collavre.users.new.enter_your_password"), with: SystemHelpers::PASSWORD
     find("#sign-in-submit").click
-    assert_current_path root_path
+    assert_current_path post_sign_in_path
 
     visit collavre.creative_path(@creative)
 


### PR DESCRIPTION
## Summary

`rake test:system` was failing after #1261 with:

```
CreativeUploadRaceTest#test_navigation_waits_for_pending_uploads
  [engines/collavre/test/support/system_helpers.rb:17]:
  expected "/creatives" to equal "/"
```

#1261 added `Collavre::ApplicationController#redirect_authenticated_root_to_home`, which redirects authenticated users hitting `/` to `home_page_path_authenticated` (default `/creatives`). The shared `sign_in_via_ui` helper still asserted `root_path` post-sign-in, so every system test that signs in now lands on `/creatives` and fails the assertion. `creative_share_test.rb:23` had the same hard-coded `root_path` assertion inline.

## Implementation

- Add `SystemHelpers#post_sign_in_path` that mirrors the controller logic: returns `home_page_path_authenticated` when set, otherwise `root_path` (also treating the `"/"` sentinel as a fall-back so the helper matches the admin opt-out described in the PR #1261 description).
- Update `sign_in_via_ui` and `creative_share_test.rb` to use it.

No production code changes; this is a test-only fix.

## Test plan

- [x] `bin/rails test engines/collavre/test/system/creative_upload_race_test.rb` — 1 run, 0 failures (was failing on main)
- [x] `bundle exec rake test:system` — 42 runs, 0 failures, 0 errors (1 pre-existing unrelated skip in `collavre_slack`)