### PR TITLE
feat(collavre): DB-backed integration settings (Phase 1: Slack)

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_29_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_29_100000) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false
@@ -309,6 +309,18 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_29_000000) do
     t.index ["creative_id"], name: "index_inbox_items_on_creative_id"
     t.index ["owner_id"], name: "index_inbox_items_on_owner_id"
     t.index ["state"], name: "index_inbox_items_on_state"
+  end
+
+  create_table "integration_settings", force: :cascade do |t|
+    t.string "category", null: false
+    t.datetime "created_at", null: false
+    t.string "key", null: false
+    t.boolean "seeded_from_env", default: false, null: false
+    t.boolean "sensitive", default: true, null: false
+    t.datetime "updated_at", null: false
+    t.text "value"
+    t.index ["category"], name: "index_integration_settings_on_category"
+    t.index ["key"], name: "index_integration_settings_on_key", unique: true
   end
 
   create_table "invitations", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -315,7 +315,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_29_100000) do
     t.string "category", null: false
     t.datetime "created_at", null: false
     t.string "key", null: false
-    t.boolean "seeded_from_env", default: false, null: false
     t.boolean "sensitive", default: true, null: false
     t.datetime "updated_at", null: false
     t.text "value"

--- a/docs/superpowers/plans/2026-05-29-env-db-settings.md
+++ b/docs/superpowers/plans/2026-05-29-env-db-settings.md
@@ -1,0 +1,467 @@
+# DB-Backed Integration Settings (on-premise) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let operators configure external integration secrets (Slack/Notion/GitHub OAuth, AWS S3/SES, FCM, Firebase, Google OAuth, Gemini, mail) through an admin UI backed by the DB, so on-premise installs do not require all secrets in `.env` at deploy time.
+
+**Architecture:**
+- Separate `Collavre::IntegrationSetting` model (encrypted) — distinct from the existing unencrypted `Collavre::SystemSetting` used for app behavior (rate limits, themes, etc.).
+- Registry pattern: each engine registers its keys (category, sensitive, requires_restart, default) at boot.
+- Resolver with precedence **DB > ENV > registered default**. ENV acts as initial seed/fallback only.
+- Admin UI at `/admin/integrations` grouped by category, with source label ("DB" / "ENV" / "default"), masked sensitive values, "Reset to ENV" action, and "restart required" indicator for boot-time keys.
+- Phase 1 wires only Slack (`engines/collavre_slack`) end-to-end as proof. Phase 2+ wires Google/GitHub/Notion OAuth (omniauth.rb), AWS S3/SES, Firebase, FCM, Gemini, Mail.
+
+**Tech Stack:** Rails engine, ActiveRecord::Encryption (already configured), Minitest, ERB views, en/ko i18n.
+
+**Out of scope (Phase 1):** Bootstrap secrets (`DATABASE_URL`, `SECRET_KEY_BASE`, `REDIS_URL`, `RAILS_MASTER_KEY`, `ACTIVE_RECORD_ENCRYPTION_*`, `KAMAL_*`, `PORT`) stay ENV-only and are not registered. The admin UI does not surface them.
+
+---
+
+## File Structure
+
+**New (engine: `collavre`):**
+- `engines/collavre/db/migrate/<timestamp>_create_integration_settings.rb` — schema
+- `engines/collavre/app/models/collavre/integration_setting.rb` — model
+- `engines/collavre/lib/collavre/integration_settings.rb` — module entry point
+- `engines/collavre/lib/collavre/integration_settings/registry.rb` — key registration
+- `engines/collavre/lib/collavre/integration_settings/key_definition.rb` — value object
+- `engines/collavre/lib/collavre/integration_settings/resolver.rb` — DB > ENV > default + cache
+- `engines/collavre/config/initializers/integration_settings.rb` — register core keys (omniauth GoogleClientId etc. shells, NOT wired yet)
+- `engines/collavre/app/controllers/collavre/admin/integrations_controller.rb` — UI
+- `engines/collavre/app/views/collavre/admin/integrations/index.html.erb`
+- `engines/collavre/app/views/collavre/admin/integrations/_category.html.erb`
+- `engines/collavre/app/views/collavre/admin/integrations/_setting_row.html.erb`
+- `engines/collavre/test/models/collavre/integration_setting_test.rb`
+- `engines/collavre/test/lib/collavre/integration_settings/registry_test.rb`
+- `engines/collavre/test/lib/collavre/integration_settings/resolver_test.rb`
+- `engines/collavre/test/controllers/collavre/admin/integrations_controller_test.rb`
+
+**Modified:**
+- `engines/collavre/config/routes.rb` — add `resources :integrations, only: [:index, :update]` and `post :reset` member
+- `engines/collavre/app/views/collavre/admin/settings/index.html.erb` — add tab link to `/admin/integrations` (Integrations tab)
+- `config/locales/en.yml`, `config/locales/ko.yml` — translations
+- `engines/collavre_slack/config/initializers/collavre_slack.rb` — switch from `ENV.fetch` to `Collavre::IntegrationSettings::Resolver.get`
+- `engines/collavre_slack/lib/collavre_slack/configuration.rb` — same
+- `engines/collavre_slack/config/initializers/collavre_slack.rb` (or new `integration_settings.rb` inside the engine) — register Slack keys (`slack_client_id`, `slack_client_secret`, `slack_signing_secret`, `slack_redirect_uri`)
+
+---
+
+## Schema
+
+```ruby
+create_table :integration_settings do |t|
+  t.string  :key, null: false                  # e.g. "slack_client_id"
+  t.text    :value                             # encrypted via ActiveRecord::Encryption
+  t.string  :category, null: false             # "slack", "google_oauth", ...
+  t.boolean :sensitive, null: false, default: true
+  t.boolean :seeded_from_env, null: false, default: false
+  t.timestamps
+
+  t.index :key, unique: true
+  t.index :category
+end
+```
+
+Model:
+```ruby
+module Collavre
+  class IntegrationSetting < ApplicationRecord
+    self.table_name = "integration_settings"
+
+    encrypts :value, deterministic: false
+
+    validates :key, presence: true, uniqueness: true
+    validates :category, presence: true
+
+    after_commit :clear_cache
+
+    private
+
+    def clear_cache
+      Rails.cache.delete(self.class.cache_key_for(key))
+    end
+
+    def self.cache_key_for(key)
+      "collavre/integration_setting/#{key}"
+    end
+  end
+end
+```
+
+---
+
+## Registry / Resolver Semantics
+
+`KeyDefinition` (value object):
+```ruby
+KeyDefinition = Struct.new(:key, :category, :sensitive, :requires_restart, :env_var, :default, keyword_init: true)
+```
+
+`Registry` (singleton):
+```ruby
+module Collavre
+  module IntegrationSettings
+    class Registry
+      include Singleton
+
+      def initialize
+        @definitions = {}
+      end
+
+      def register(key, category:, sensitive: true, requires_restart: false, env_var: nil, default: nil)
+        key = key.to_sym
+        @definitions[key] = KeyDefinition.new(
+          key: key, category: category, sensitive: sensitive,
+          requires_restart: requires_restart,
+          env_var: env_var || key.to_s.upcase,
+          default: default
+        )
+      end
+
+      def all = @definitions.values.freeze
+      def find(key) = @definitions[key.to_sym]
+      def by_category = @definitions.values.group_by(&:category)
+    end
+  end
+end
+```
+
+`Resolver`:
+```ruby
+module Collavre
+  module IntegrationSettings
+    class Resolver
+      class UnknownKeyError < StandardError; end
+
+      class << self
+        def get(key)
+          definition = Registry.instance.find(key) or raise UnknownKeyError, "Unknown integration setting: #{key}"
+
+          Rails.cache.fetch(IntegrationSetting.cache_key_for(definition.key), expires_in: 5.minutes) do
+            db_value(definition) || env_value(definition) || definition.default
+          end
+        end
+
+        def source_for(key)
+          definition = Registry.instance.find(key) or return :unknown
+          return :db if IntegrationSetting.find_by(key: definition.key)&.value.present?
+          return :env if ENV[definition.env_var].present?
+          :default
+        end
+
+        private
+
+        def db_value(definition)
+          IntegrationSetting.find_by(key: definition.key)&.value.presence
+        end
+
+        def env_value(definition)
+          ENV[definition.env_var].presence
+        end
+      end
+    end
+  end
+end
+```
+
+**Lazy ENV → DB seed:** explicitly NOT done on read (keeps ENV as override). Instead, admin UI offers a "Seed from ENV" action per key that copies the current ENV value to DB (with `seeded_from_env: true`). This keeps the precedence rule simple: as long as the DB row exists with a non-blank value, DB wins.
+
+**"Reset to ENV":** deletes the DB row → resolver falls back to ENV.
+
+---
+
+## Tasks
+
+### Task 1: Migration + model + first test
+
+**Files:**
+- Create: `engines/collavre/db/migrate/<TS>_create_integration_settings.rb`
+- Create: `engines/collavre/app/models/collavre/integration_setting.rb`
+- Create: `engines/collavre/test/models/collavre/integration_setting_test.rb`
+
+- [ ] **Step 1.1:** Generate migration
+
+```bash
+cd /Users/soonoh/project/soonoh/plan42-worktree220
+bin/rails generate migration CreateIntegrationSettings --database=primary
+```
+
+- [ ] **Step 1.2:** Edit the generated migration to match the Schema block above (encrypted value stays as `text`).
+
+- [ ] **Step 1.3:** Write `engines/collavre/test/models/collavre/integration_setting_test.rb`:
+
+```ruby
+require "test_helper"
+
+module Collavre
+  class IntegrationSettingTest < ActiveSupport::TestCase
+    test "encrypts value" do
+      setting = IntegrationSetting.create!(key: "slack_client_id", value: "xoxb-secret", category: "slack")
+      raw = IntegrationSetting.connection.select_value(
+        "SELECT value FROM integration_settings WHERE id = #{setting.id}"
+      )
+      assert_not_equal "xoxb-secret", raw
+      assert_equal "xoxb-secret", setting.reload.value
+    end
+
+    test "requires unique key" do
+      IntegrationSetting.create!(key: "slack_client_id", value: "a", category: "slack")
+      dup = IntegrationSetting.new(key: "slack_client_id", value: "b", category: "slack")
+      assert_not dup.valid?
+    end
+
+    test "clears cache on commit" do
+      Rails.cache.write(IntegrationSetting.cache_key_for("slack_client_id"), "cached")
+      IntegrationSetting.create!(key: "slack_client_id", value: "new", category: "slack")
+      assert_nil Rails.cache.read(IntegrationSetting.cache_key_for("slack_client_id"))
+    end
+  end
+end
+```
+
+- [ ] **Step 1.4:** Run test (expect fail — no model):
+
+```bash
+bin/rails db:migrate
+bin/rails test engines/collavre/test/models/collavre/integration_setting_test.rb
+```
+
+- [ ] **Step 1.5:** Implement model file (see Model block above).
+
+- [ ] **Step 1.6:** Re-run test — expect pass.
+
+- [ ] **Step 1.7:** Commit:
+
+```bash
+git add engines/collavre/db/migrate engines/collavre/app/models/collavre/integration_setting.rb engines/collavre/test/models/collavre/integration_setting_test.rb
+git commit -m "feat(collavre): add IntegrationSetting model with encryption"
+```
+
+---
+
+### Task 2: KeyDefinition + Registry
+
+**Files:**
+- Create: `engines/collavre/lib/collavre/integration_settings.rb`
+- Create: `engines/collavre/lib/collavre/integration_settings/key_definition.rb`
+- Create: `engines/collavre/lib/collavre/integration_settings/registry.rb`
+- Create: `engines/collavre/test/lib/collavre/integration_settings/registry_test.rb`
+
+- [ ] **Step 2.1:** Write the test first:
+
+```ruby
+require "test_helper"
+
+module Collavre
+  module IntegrationSettings
+    class RegistryTest < ActiveSupport::TestCase
+      setup { Registry.instance.instance_variable_set(:@definitions, {}) }
+
+      test "registers a key with defaults" do
+        Registry.instance.register(:slack_client_id, category: "slack")
+        d = Registry.instance.find(:slack_client_id)
+        assert_equal "slack",            d.category
+        assert_equal true,               d.sensitive
+        assert_equal false,              d.requires_restart
+        assert_equal "SLACK_CLIENT_ID",  d.env_var
+      end
+
+      test "groups by category" do
+        Registry.instance.register(:slack_client_id, category: "slack")
+        Registry.instance.register(:google_client_id, category: "google_oauth")
+        assert_equal %w[slack google_oauth].sort, Registry.instance.by_category.keys.sort
+      end
+    end
+  end
+end
+```
+
+- [ ] **Step 2.2:** Run, expect fail.
+- [ ] **Step 2.3:** Implement `KeyDefinition` and `Registry` per the Registry/Resolver Semantics block above.
+- [ ] **Step 2.4:** Re-run test — expect pass.
+- [ ] **Step 2.5:** Commit `feat(collavre): add IntegrationSettings registry`
+
+---
+
+### Task 3: Resolver with cache and precedence
+
+**Files:**
+- Create: `engines/collavre/lib/collavre/integration_settings/resolver.rb`
+- Create: `engines/collavre/test/lib/collavre/integration_settings/resolver_test.rb`
+
+- [ ] **Step 3.1:** Tests cover:
+  - DB value wins over ENV
+  - ENV used when no DB row
+  - Default used when neither
+  - `source_for` returns `:db | :env | :default`
+  - Unknown key raises
+  - Cache is hit on second read
+
+```ruby
+require "test_helper"
+
+module Collavre
+  module IntegrationSettings
+    class ResolverTest < ActiveSupport::TestCase
+      setup do
+        Registry.instance.instance_variable_set(:@definitions, {})
+        Registry.instance.register(:slack_client_id, category: "slack", env_var: "SLACK_CLIENT_ID", default: "default-id")
+        Rails.cache.clear
+        IntegrationSetting.delete_all
+      end
+
+      test "DB beats ENV" do
+        IntegrationSetting.create!(key: "slack_client_id", value: "db-val", category: "slack")
+        ENV["SLACK_CLIENT_ID"] = "env-val"
+        assert_equal "db-val", Resolver.get(:slack_client_id)
+        assert_equal :db,      Resolver.source_for(:slack_client_id)
+      ensure
+        ENV.delete("SLACK_CLIENT_ID")
+      end
+
+      test "ENV used when no DB row" do
+        ENV["SLACK_CLIENT_ID"] = "env-val"
+        assert_equal "env-val", Resolver.get(:slack_client_id)
+        assert_equal :env,      Resolver.source_for(:slack_client_id)
+      ensure
+        ENV.delete("SLACK_CLIENT_ID")
+      end
+
+      test "default used when neither" do
+        assert_equal "default-id", Resolver.get(:slack_client_id)
+        assert_equal :default,     Resolver.source_for(:slack_client_id)
+      end
+
+      test "unknown key raises" do
+        assert_raises(Resolver::UnknownKeyError) { Resolver.get(:nope) }
+      end
+    end
+  end
+end
+```
+
+- [ ] **Step 3.2:** Run — expect fail.
+- [ ] **Step 3.3:** Implement `Resolver`.
+- [ ] **Step 3.4:** Re-run — expect pass.
+- [ ] **Step 3.5:** Commit `feat(collavre): add IntegrationSettings resolver`
+
+---
+
+### Task 4: Admin UI controller + minimal view
+
+**Files:**
+- Create: `engines/collavre/app/controllers/collavre/admin/integrations_controller.rb`
+- Create: `engines/collavre/app/views/collavre/admin/integrations/index.html.erb`
+- Create: `engines/collavre/app/views/collavre/admin/integrations/_category.html.erb`
+- Create: `engines/collavre/app/views/collavre/admin/integrations/_setting_row.html.erb`
+- Modify: `engines/collavre/config/routes.rb` — add routes:
+
+```ruby
+scope "/admin", as: :admin do
+  # ...existing...
+  resources :integrations, only: [:index] do
+    collection do
+      patch :bulk_update
+    end
+    member do
+      delete :reset                # delete DB row → revert to ENV
+      post   :seed_from_env        # copy ENV → DB
+    end
+  end
+end
+```
+
+- Create: `engines/collavre/test/controllers/collavre/admin/integrations_controller_test.rb`
+
+Controller responsibilities:
+- `index`: lists all registered keys grouped by category, shows current value (masked if sensitive — show last 4 chars), source label, restart-required flag
+- `bulk_update`: accepts a form with multiple `integration_setting[<key>]` params; upserts non-blank values; ignores blank inputs
+- `reset(key)`: deletes the row
+- `seed_from_env(key)`: copies ENV value to DB (sets `seeded_from_env: true`)
+- Authorization: reuse same admin filter as `SettingsController` (`before_action :require_admin!` or equivalent — pattern from existing file)
+
+Tests cover:
+- `index` renders without admin → 401/403
+- `bulk_update` upserts and skips blanks
+- `reset` deletes row
+- `seed_from_env` copies ENV → DB
+- Sensitive values are masked in HTML response
+
+- [ ] **Step 4.1:** Write tests first.
+- [ ] **Step 4.2:** Run — expect fail.
+- [ ] **Step 4.3:** Implement controller + views.
+- [ ] **Step 4.4:** Add i18n keys to `config/locales/en.yml` and `config/locales/ko.yml`:
+  - `collavre.admin.integrations.title`
+  - `collavre.admin.integrations.source.db|env|default`
+  - `collavre.admin.integrations.restart_required`
+  - `collavre.admin.integrations.actions.save|reset|seed_from_env`
+- [ ] **Step 4.5:** Run — expect pass.
+- [ ] **Step 4.6:** Commit `feat(collavre): add /admin/integrations UI`
+
+---
+
+### Task 5: Wire Slack as Phase 1 e2e example
+
+**Files:**
+- Modify: `engines/collavre_slack/config/initializers/collavre_slack.rb`
+- Modify: `engines/collavre_slack/lib/collavre_slack/configuration.rb`
+- Create or modify: an engine-level initializer that registers Slack keys with the Registry
+
+Slack key registration (run inside engine's `to_prepare` so Registry is available):
+```ruby
+Rails.application.config.to_prepare do
+  Collavre::IntegrationSettings::Registry.instance.register(
+    :slack_client_id, category: "slack", sensitive: false, requires_restart: true
+  )
+  Collavre::IntegrationSettings::Registry.instance.register(
+    :slack_client_secret, category: "slack", sensitive: true, requires_restart: true
+  )
+  Collavre::IntegrationSettings::Registry.instance.register(
+    :slack_signing_secret, category: "slack", sensitive: true, requires_restart: true
+  )
+  Collavre::IntegrationSettings::Registry.instance.register(
+    :slack_redirect_uri, category: "slack", sensitive: false, requires_restart: true
+  )
+end
+```
+
+Configuration switch — replace `ENV.fetch("SLACK_CLIENT_ID")` with `Collavre::IntegrationSettings::Resolver.get(:slack_client_id)`. Boot-time use means a value change in admin UI requires server restart — UI surfaces "restart required" badge.
+
+- [ ] **Step 5.1:** Write test asserting `CollavreSlack::Configuration.client_id` reads from Resolver.
+- [ ] **Step 5.2:** Run — expect fail.
+- [ ] **Step 5.3:** Make the swap.
+- [ ] **Step 5.4:** Run — expect pass. Also run full engine test suite to confirm no regression.
+- [ ] **Step 5.5:** Commit `feat(collavre_slack): use IntegrationSettings::Resolver for OAuth secrets`
+
+---
+
+### Task 6: Ship
+
+- [ ] **Step 6.1:** `bin/rails test` (full suite, host app + all engines).
+- [ ] **Step 6.2:** `bundle exec rubocop` (project rubocop config).
+- [ ] **Step 6.3:** Push branch.
+- [ ] **Step 6.4:** Open PR with summary + test plan.
+- [ ] **Step 6.5:** Register `collavre pr_monitor` for the PR.
+
+---
+
+## Phase 2+ (out of scope for this PR, but designed for)
+
+Once Phase 1 lands, each of these is a small follow-up PR that adds a Registry.register call + swaps ENV reads to Resolver.get:
+
+- `engines/collavre/config/initializers/omniauth.rb` — Google / GitHub / Notion OAuth client_id + secret (boot-time, requires_restart=true)
+- `config/initializers/firebase_config.rb` — Firebase project/app/api/auth domain
+- `config/initializers/fcm.rb` — FCM server key / sender ID / VAPID key
+- `config/initializers/ruby_llm.rb` — Gemini API key / base
+- `engines/collavre_openclaw/lib/collavre_openclaw/configuration.rb` — OpenClaw timeouts/transport
+- AWS S3 / SES env vars (used in Active Storage / SMTP setup)
+- Mailer URL host / port / protocol / default-from
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** ENV-vs-DB precedence resolved (DB wins, ENV is seed/fallback), encryption used for secrets, bootstrap secrets explicitly excluded, restart-required flag surfaced. ✓
+- **No placeholders:** every step has concrete code. ✓
+- **Type consistency:** `KeyDefinition`, `Registry.instance.register`, `Resolver.get`, `cache_key_for` used consistently. ✓
+- **Backward compat:** Slack engine still functions identically when ENV is set and no DB row exists (Resolver returns ENV value). ✓

--- a/engines/collavre/app/controllers/collavre/admin/integrations_controller.rb
+++ b/engines/collavre/app/controllers/collavre/admin/integrations_controller.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Admin
+    class IntegrationsController < ApplicationController
+      before_action :require_system_admin!
+      before_action :load_definition!, only: [ :reset, :seed_from_env ]
+
+      Registry = Collavre::IntegrationSettings::Registry
+      Resolver = Collavre::IntegrationSettings::Resolver
+
+      def index
+        @grouped_settings = build_grouped_settings
+      end
+
+      def bulk_update
+        submitted = (params[:integration_setting] || {}).to_unsafe_h
+        restart_required_changed = false
+
+        Collavre::IntegrationSetting.transaction do
+          submitted.each do |key, raw_value|
+            value = raw_value.to_s
+            next if value.blank?
+
+            definition = Registry.instance.find(key) or next
+
+            row = Collavre::IntegrationSetting.find_or_initialize_by(key: definition.key.to_s)
+            row.category = definition.category
+            row.value = value
+            row.save!
+
+            restart_required_changed ||= definition.requires_restart
+          end
+        end
+
+        flash[:notice] = t("collavre.admin.integrations.flash.updated")
+        flash[:warning] = t("collavre.admin.integrations.flash.restart_required") if restart_required_changed
+        redirect_to collavre.admin_integrations_path
+      end
+
+      def reset
+        Collavre::IntegrationSetting.where(key: @definition.key.to_s).destroy_all
+        redirect_to collavre.admin_integrations_path,
+          notice: t("collavre.admin.integrations.flash.reset_done", key: @definition.key)
+      end
+
+      def seed_from_env
+        env_value = ENV[@definition.env_var].to_s
+
+        if env_value.blank?
+          redirect_to collavre.admin_integrations_path,
+            notice: t("collavre.admin.integrations.flash.seed_no_env", key: @definition.key)
+          return
+        end
+
+        row = Collavre::IntegrationSetting.find_or_initialize_by(key: @definition.key.to_s)
+        row.category = @definition.category
+        row.value = env_value
+        row.seeded_from_env = true
+        row.save!
+
+        redirect_to collavre.admin_integrations_path,
+          notice: t("collavre.admin.integrations.flash.seed_done", key: @definition.key)
+      end
+
+      private
+
+      def load_definition!
+        @definition = Registry.instance.find(params[:key]) or
+          (render file: Rails.root.join("public/404.html"), status: :not_found, layout: false and return)
+      end
+
+      def build_grouped_settings
+        Registry.instance.by_category.sort_by { |category, _defs| category.to_s }.map do |category, definitions|
+          rows = definitions.map { |definition| build_row(definition) }
+          [ category, rows ]
+        end
+      end
+
+      def build_row(definition)
+        value = Resolver.get(definition.key)
+        source = Resolver.source_for(definition.key)
+        display = definition.sensitive ? mask_value(value) : value
+
+        {
+          definition: definition,
+          source: source,
+          display_value: display,
+          present: value.present?
+        }
+      end
+
+      def mask_value(value)
+        return nil if value.blank?
+        return "••••" if value.to_s.length <= 4
+
+        "••••#{value.to_s[-4..]}"
+      end
+    end
+  end
+end

--- a/engines/collavre/app/controllers/collavre/admin/integrations_controller.rb
+++ b/engines/collavre/app/controllers/collavre/admin/integrations_controller.rb
@@ -4,7 +4,7 @@ module Collavre
   module Admin
     class IntegrationsController < ApplicationController
       before_action :require_system_admin!
-      before_action :load_definition!, only: [ :reset, :seed_from_env ]
+      before_action :load_definition!, only: [ :reset ]
 
       Registry = Collavre::IntegrationSettings::Registry
       Resolver = Collavre::IntegrationSettings::Resolver
@@ -42,25 +42,6 @@ module Collavre
         Collavre::IntegrationSetting.where(key: @definition.key.to_s).destroy_all
         redirect_to collavre.admin_integrations_path,
           notice: t("collavre.admin.integrations.flash.reset_done", key: @definition.key)
-      end
-
-      def seed_from_env
-        env_value = ENV[@definition.env_var].to_s
-
-        if env_value.blank?
-          redirect_to collavre.admin_integrations_path,
-            notice: t("collavre.admin.integrations.flash.seed_no_env", key: @definition.key)
-          return
-        end
-
-        row = Collavre::IntegrationSetting.find_or_initialize_by(key: @definition.key.to_s)
-        row.category = @definition.category
-        row.value = env_value
-        row.seeded_from_env = true
-        row.save!
-
-        redirect_to collavre.admin_integrations_path,
-          notice: t("collavre.admin.integrations.flash.seed_done", key: @definition.key)
       end
 
       private

--- a/engines/collavre/app/models/collavre/integration_setting.rb
+++ b/engines/collavre/app/models/collavre/integration_setting.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Collavre
+  # Stores externally-configurable integration secrets (Slack, Google OAuth,
+  # AWS S3/SES, FCM, etc.) on a per-key basis with `value` encrypted at rest.
+  #
+  # Distinct from {Collavre::SystemSetting}, which stores unencrypted app-behavior
+  # toggles (rate limits, themes, etc.). Pair with
+  # {Collavre::IntegrationSettings::Registry} (key definitions) and
+  # {Collavre::IntegrationSettings::Resolver} (DB > ENV > default precedence).
+  class IntegrationSetting < ApplicationRecord
+    self.table_name = "integration_settings"
+
+    encrypts :value, deterministic: false
+
+    validates :key, presence: true, uniqueness: true
+    validates :category, presence: true
+
+    after_commit :clear_cache
+
+    def self.cache_key_for(key)
+      "collavre/integration_setting/#{key}"
+    end
+
+    private
+
+    def clear_cache
+      Rails.cache.delete(self.class.cache_key_for(key))
+      if saved_change_to_key?
+        old_key = saved_change_to_key.first
+        Rails.cache.delete(self.class.cache_key_for(old_key)) if old_key.present?
+      end
+    end
+  end
+end

--- a/engines/collavre/app/views/admin/shared/_tabs.html.erb
+++ b/engines/collavre/app/views/admin/shared/_tabs.html.erb
@@ -3,4 +3,5 @@
   <%= link_to t('admin.tabs.uiux'), collavre.admin_uiux_path, class: "tab-button #{'active' if controller_name == 'settings' && action_name == 'uiux'}" %>
   <%= link_to t('admin.tabs.users'), collavre.users_path, class: "tab-button #{'active' if controller_name == 'users'}" %>
   <%= link_to t('admin.tabs.orchestration'), collavre.admin_orchestration_path, class: "tab-button #{'active' if controller_name == 'orchestration'}" %>
+  <%= link_to t('collavre.admin.integrations.tab_label'), collavre.admin_integrations_path, class: "tab-button #{'active' if controller_name == 'integrations'}" %>
 </div>

--- a/engines/collavre/app/views/collavre/admin/integrations/_category.html.erb
+++ b/engines/collavre/app/views/collavre/admin/integrations/_category.html.erb
@@ -1,0 +1,21 @@
+<div style="margin-top: 2em; border-top: 1px solid var(--color-border); padding-top: 1.5em;">
+  <h3 style="font-size: 1.1em; margin-bottom: 1em;">
+    <%= t("collavre.admin.integrations.category.#{category}", default: category.to_s.humanize) %>
+  </h3>
+
+  <table class="settings-table" style="width: 100%; border-collapse: collapse;">
+    <thead>
+      <tr>
+        <th style="text-align: left; padding: 0.5em; width: 25%;"><%= t("collavre.admin.integrations.headers.key") %></th>
+        <th style="text-align: left; padding: 0.5em; width: 25%;"><%= t("collavre.admin.integrations.headers.current") %></th>
+        <th style="text-align: left; padding: 0.5em; width: 30%;"><%= t("collavre.admin.integrations.headers.new_value") %></th>
+        <th style="text-align: left; padding: 0.5em; width: 20%;"><%= t("collavre.admin.integrations.headers.actions") %></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% rows.each do |row| %>
+        <%= render partial: "setting_row", locals: { row: row, f: f } %>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/engines/collavre/app/views/collavre/admin/integrations/_category.html.erb
+++ b/engines/collavre/app/views/collavre/admin/integrations/_category.html.erb
@@ -4,12 +4,11 @@
   </h3>
 
   <div class="table-scroll">
-    <table class="settings-table" style="width: 100%; min-width: 720px; border-collapse: collapse;">
+    <table class="settings-table" style="width: 100%; min-width: 640px; border-collapse: collapse;">
       <thead>
         <tr>
-          <th style="text-align: left; padding: 0.5em; width: 25%;"><%= t("collavre.admin.integrations.headers.key") %></th>
-          <th style="text-align: left; padding: 0.5em; width: 25%;"><%= t("collavre.admin.integrations.headers.current") %></th>
-          <th style="text-align: left; padding: 0.5em; width: 30%;"><%= t("collavre.admin.integrations.headers.new_value") %></th>
+          <th style="text-align: left; padding: 0.5em; width: 30%;"><%= t("collavre.admin.integrations.headers.key") %></th>
+          <th style="text-align: left; padding: 0.5em; width: 50%;"><%= t("collavre.admin.integrations.headers.value") %></th>
           <th style="text-align: left; padding: 0.5em; width: 20%;"><%= t("collavre.admin.integrations.headers.actions") %></th>
         </tr>
       </thead>

--- a/engines/collavre/app/views/collavre/admin/integrations/_category.html.erb
+++ b/engines/collavre/app/views/collavre/admin/integrations/_category.html.erb
@@ -14,7 +14,7 @@
     </thead>
     <tbody>
       <% rows.each do |row| %>
-        <%= render partial: "setting_row", locals: { row: row, f: f } %>
+        <%= render partial: "setting_row", locals: { row: row, bulk_form_id: bulk_form_id } %>
       <% end %>
     </tbody>
   </table>

--- a/engines/collavre/app/views/collavre/admin/integrations/_category.html.erb
+++ b/engines/collavre/app/views/collavre/admin/integrations/_category.html.erb
@@ -3,19 +3,21 @@
     <%= t("collavre.admin.integrations.category.#{category}", default: category.to_s.humanize) %>
   </h3>
 
-  <table class="settings-table" style="width: 100%; border-collapse: collapse;">
-    <thead>
-      <tr>
-        <th style="text-align: left; padding: 0.5em; width: 25%;"><%= t("collavre.admin.integrations.headers.key") %></th>
-        <th style="text-align: left; padding: 0.5em; width: 25%;"><%= t("collavre.admin.integrations.headers.current") %></th>
-        <th style="text-align: left; padding: 0.5em; width: 30%;"><%= t("collavre.admin.integrations.headers.new_value") %></th>
-        <th style="text-align: left; padding: 0.5em; width: 20%;"><%= t("collavre.admin.integrations.headers.actions") %></th>
-      </tr>
-    </thead>
-    <tbody>
-      <% rows.each do |row| %>
-        <%= render partial: "setting_row", locals: { row: row, bulk_form_id: bulk_form_id } %>
-      <% end %>
-    </tbody>
-  </table>
+  <div class="table-scroll">
+    <table class="settings-table" style="width: 100%; min-width: 720px; border-collapse: collapse;">
+      <thead>
+        <tr>
+          <th style="text-align: left; padding: 0.5em; width: 25%;"><%= t("collavre.admin.integrations.headers.key") %></th>
+          <th style="text-align: left; padding: 0.5em; width: 25%;"><%= t("collavre.admin.integrations.headers.current") %></th>
+          <th style="text-align: left; padding: 0.5em; width: 30%;"><%= t("collavre.admin.integrations.headers.new_value") %></th>
+          <th style="text-align: left; padding: 0.5em; width: 20%;"><%= t("collavre.admin.integrations.headers.actions") %></th>
+        </tr>
+      </thead>
+      <tbody>
+        <% rows.each do |row| %>
+          <%= render partial: "setting_row", locals: { row: row, bulk_form_id: bulk_form_id } %>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
 </div>

--- a/engines/collavre/app/views/collavre/admin/integrations/_setting_row.html.erb
+++ b/engines/collavre/app/views/collavre/admin/integrations/_setting_row.html.erb
@@ -6,6 +6,7 @@
     when :env     then ["var(--color-warning)", "var(--text-on-badge)"]
     else               ["var(--surface-btn)",   "var(--text-on-btn)"]
   end
+  current_display = row[:present] ? row[:display_value].to_s : "—"
 %>
 <tr style="border-top: 1px solid var(--color-border);">
   <td style="padding: 0.5em; vertical-align: top;">
@@ -20,30 +21,25 @@
     </div>
   </td>
   <td style="padding: 0.5em; vertical-align: top;">
-    <% if row[:present] %>
-      <code><%= row[:display_value] %></code>
-    <% else %>
-      <span style="color: var(--color-muted);">—</span>
-    <% end %>
-    <div style="font-size: 0.8em; margin-top: 0.25em;">
-      <span class="badge badge-source-<%= row[:source] %>" style="display: inline-block; padding: 0.1em 0.5em; font-size: 0.85em; border-radius: 3px; background: <%= source_bg %>; color: <%= source_fg %>;">
-        <%= t("collavre.admin.integrations.source.#{row[:source]}", default: row[:source].to_s.upcase) %>
-      </span>
-      <% if definition.sensitive %>
-        <span style="margin-left: 0.5em; font-size: 0.8em; color: var(--color-muted);"><%= t("collavre.admin.integrations.sensitive") %></span>
-      <% end %>
-    </div>
-  </td>
-  <td style="padding: 0.5em; vertical-align: top;">
     <%# Input references the bulk form via HTML5 `form` attribute so the table is not nested inside <form>. %>
+    <%# Placeholder displays the current value (masked for sensitive); empty input keeps the existing value. %>
     <% input_tag = definition.sensitive ? :password_field_tag : :text_field_tag %>
     <%= send(input_tag,
           "integration_setting[#{key_str}]",
           nil,
           form: bulk_form_id,
-          placeholder: t("collavre.admin.integrations.placeholder_leave_blank"),
+          placeholder: current_display,
           autocomplete: "off",
           style: "width: 100%;") %>
+    <div style="font-size: 0.8em; margin-top: 0.25em;">
+      <span class="badge badge-source-<%= row[:source] %>" style="display: inline-block; padding: 0.1em 0.5em; font-size: 0.85em; border-radius: 3px; background: <%= source_bg %>; color: <%= source_fg %>;">
+        <%= t("collavre.admin.integrations.source.#{row[:source]}", default: row[:source].to_s.upcase) %>
+      </span>
+      <% if definition.sensitive %>
+        <span style="margin-left: 0.5em; color: var(--color-muted);"><%= t("collavre.admin.integrations.sensitive") %></span>
+      <% end %>
+      <span style="margin-left: 0.5em; color: var(--color-muted);"><%= t("collavre.admin.integrations.placeholder_leave_blank") %></span>
+    </div>
   </td>
   <td style="padding: 0.5em; vertical-align: top; white-space: nowrap;">
     <%= button_to t("collavre.admin.integrations.actions.reset"),

--- a/engines/collavre/app/views/collavre/admin/integrations/_setting_row.html.erb
+++ b/engines/collavre/app/views/collavre/admin/integrations/_setting_row.html.erb
@@ -50,14 +50,9 @@
           collavre.reset_admin_integration_path(key: key_str),
           method: :delete,
           form: {
-            style: "display: inline-block; margin-right: 0.25em;",
+            style: "display: inline-block;",
             data: { turbo_confirm: t("collavre.admin.integrations.confirm_reset") }
           },
-          class: "btn btn-small btn-secondary" %>
-    <%= button_to t("collavre.admin.integrations.actions.seed_from_env"),
-          collavre.seed_from_env_admin_integration_path(key: key_str),
-          method: :post,
-          form: { style: "display: inline-block;" },
           class: "btn btn-small btn-secondary" %>
   </td>
 </tr>

--- a/engines/collavre/app/views/collavre/admin/integrations/_setting_row.html.erb
+++ b/engines/collavre/app/views/collavre/admin/integrations/_setting_row.html.erb
@@ -1,0 +1,47 @@
+<% definition = row[:definition] %>
+<% key_str = definition.key.to_s %>
+<tr style="border-top: 1px solid var(--color-border);">
+  <td style="padding: 0.5em; vertical-align: top;">
+    <code><%= key_str %></code>
+    <% if definition.requires_restart %>
+      <span class="badge badge-warning" style="display: inline-block; margin-left: 0.5em; padding: 0.1em 0.5em; font-size: 0.75em; background: var(--color-warning, #f0ad4e); color: white; border-radius: 3px;">
+        <%= t("collavre.admin.integrations.restart_required") %>
+      </span>
+    <% end %>
+    <div style="font-size: 0.8em; color: var(--color-text-muted); margin-top: 0.25em;">
+      ENV: <code><%= definition.env_var %></code>
+    </div>
+  </td>
+  <td style="padding: 0.5em; vertical-align: top;">
+    <% if row[:present] %>
+      <code><%= row[:display_value] %></code>
+    <% else %>
+      <span style="color: var(--color-text-muted);">—</span>
+    <% end %>
+    <div style="font-size: 0.8em; margin-top: 0.25em;">
+      <span class="badge badge-source-<%= row[:source] %>" style="display: inline-block; padding: 0.1em 0.5em; font-size: 0.85em; border-radius: 3px; background: var(--color-surface-2, #eee);">
+        <%= t("collavre.admin.integrations.source.#{row[:source]}", default: row[:source].to_s.upcase) %>
+      </span>
+      <% if definition.sensitive %>
+        <span style="margin-left: 0.5em; font-size: 0.8em; color: var(--color-text-muted);"><%= t("collavre.admin.integrations.sensitive") %></span>
+      <% end %>
+    </div>
+  </td>
+  <td style="padding: 0.5em; vertical-align: top;">
+    <% input_type = definition.sensitive ? :password_field : :text_field %>
+    <%= f.send(input_type, "integration_setting[#{key_str}]", placeholder: t("collavre.admin.integrations.placeholder_leave_blank"), autocomplete: "off", style: "width: 100%;") %>
+  </td>
+  <td style="padding: 0.5em; vertical-align: top; white-space: nowrap;">
+    <%= button_to t("collavre.admin.integrations.actions.reset"),
+          collavre.reset_admin_integration_path(key: key_str),
+          method: :delete,
+          form: { style: "display: inline-block; margin-right: 0.25em;" },
+          class: "btn btn-small btn-secondary",
+          data: { confirm: t("collavre.admin.integrations.confirm_reset") } %>
+    <%= button_to t("collavre.admin.integrations.actions.seed_from_env"),
+          collavre.seed_from_env_admin_integration_path(key: key_str),
+          method: :post,
+          form: { style: "display: inline-block;" },
+          class: "btn btn-small btn-secondary" %>
+  </td>
+</tr>

--- a/engines/collavre/app/views/collavre/admin/integrations/_setting_row.html.erb
+++ b/engines/collavre/app/views/collavre/admin/integrations/_setting_row.html.erb
@@ -28,8 +28,15 @@
     </div>
   </td>
   <td style="padding: 0.5em; vertical-align: top;">
-    <% input_type = definition.sensitive ? :password_field : :text_field %>
-    <%= f.send(input_type, "integration_setting[#{key_str}]", placeholder: t("collavre.admin.integrations.placeholder_leave_blank"), autocomplete: "off", style: "width: 100%;") %>
+    <%# Input references the bulk form via HTML5 `form` attribute so the table is not nested inside <form>. %>
+    <% input_tag = definition.sensitive ? :password_field_tag : :text_field_tag %>
+    <%= send(input_tag,
+          "integration_setting[#{key_str}]",
+          nil,
+          form: bulk_form_id,
+          placeholder: t("collavre.admin.integrations.placeholder_leave_blank"),
+          autocomplete: "off",
+          style: "width: 100%;") %>
   </td>
   <td style="padding: 0.5em; vertical-align: top; white-space: nowrap;">
     <%= button_to t("collavre.admin.integrations.actions.reset"),

--- a/engines/collavre/app/views/collavre/admin/integrations/_setting_row.html.erb
+++ b/engines/collavre/app/views/collavre/admin/integrations/_setting_row.html.erb
@@ -16,7 +16,7 @@
       </span>
     <% end %>
     <div style="font-size: 0.8em; color: var(--color-muted); margin-top: 0.25em;">
-      ENV: <code><%= definition.env_var %></code>
+      <%= t("collavre.admin.integrations.env_var_label") %>: <code><%= definition.env_var %></code>
     </div>
   </td>
   <td style="padding: 0.5em; vertical-align: top;">

--- a/engines/collavre/app/views/collavre/admin/integrations/_setting_row.html.erb
+++ b/engines/collavre/app/views/collavre/admin/integrations/_setting_row.html.erb
@@ -1,14 +1,21 @@
 <% definition = row[:definition] %>
 <% key_str = definition.key.to_s %>
+<%
+  source_bg, source_fg = case row[:source]
+    when :db      then ["var(--color-success)", "var(--text-on-badge)"]
+    when :env     then ["var(--color-warning)", "var(--text-on-badge)"]
+    else               ["var(--surface-btn)",   "var(--text-on-btn)"]
+  end
+%>
 <tr style="border-top: 1px solid var(--color-border);">
   <td style="padding: 0.5em; vertical-align: top;">
     <code><%= key_str %></code>
     <% if definition.requires_restart %>
-      <span class="badge badge-warning" style="display: inline-block; margin-left: 0.5em; padding: 0.1em 0.5em; font-size: 0.75em; background: var(--color-warning, #f0ad4e); color: white; border-radius: 3px;">
+      <span class="badge badge-warning" style="display: inline-block; margin-left: 0.5em; padding: 0.1em 0.5em; font-size: 0.75em; background: var(--color-warning); color: var(--text-on-badge); border-radius: 3px;">
         <%= t("collavre.admin.integrations.restart_required") %>
       </span>
     <% end %>
-    <div style="font-size: 0.8em; color: var(--color-text-muted); margin-top: 0.25em;">
+    <div style="font-size: 0.8em; color: var(--color-muted); margin-top: 0.25em;">
       ENV: <code><%= definition.env_var %></code>
     </div>
   </td>
@@ -16,14 +23,14 @@
     <% if row[:present] %>
       <code><%= row[:display_value] %></code>
     <% else %>
-      <span style="color: var(--color-text-muted);">—</span>
+      <span style="color: var(--color-muted);">—</span>
     <% end %>
     <div style="font-size: 0.8em; margin-top: 0.25em;">
-      <span class="badge badge-source-<%= row[:source] %>" style="display: inline-block; padding: 0.1em 0.5em; font-size: 0.85em; border-radius: 3px; background: var(--color-surface-2, #eee);">
+      <span class="badge badge-source-<%= row[:source] %>" style="display: inline-block; padding: 0.1em 0.5em; font-size: 0.85em; border-radius: 3px; background: <%= source_bg %>; color: <%= source_fg %>;">
         <%= t("collavre.admin.integrations.source.#{row[:source]}", default: row[:source].to_s.upcase) %>
       </span>
       <% if definition.sensitive %>
-        <span style="margin-left: 0.5em; font-size: 0.8em; color: var(--color-text-muted);"><%= t("collavre.admin.integrations.sensitive") %></span>
+        <span style="margin-left: 0.5em; font-size: 0.8em; color: var(--color-muted);"><%= t("collavre.admin.integrations.sensitive") %></span>
       <% end %>
     </div>
   </td>

--- a/engines/collavre/app/views/collavre/admin/integrations/_setting_row.html.erb
+++ b/engines/collavre/app/views/collavre/admin/integrations/_setting_row.html.erb
@@ -35,9 +35,11 @@
     <%= button_to t("collavre.admin.integrations.actions.reset"),
           collavre.reset_admin_integration_path(key: key_str),
           method: :delete,
-          form: { style: "display: inline-block; margin-right: 0.25em;" },
-          class: "btn btn-small btn-secondary",
-          data: { confirm: t("collavre.admin.integrations.confirm_reset") } %>
+          form: {
+            style: "display: inline-block; margin-right: 0.25em;",
+            data: { turbo_confirm: t("collavre.admin.integrations.confirm_reset") }
+          },
+          class: "btn btn-small btn-secondary" %>
     <%= button_to t("collavre.admin.integrations.actions.seed_from_env"),
           collavre.seed_from_env_admin_integration_path(key: key_str),
           method: :post,

--- a/engines/collavre/app/views/collavre/admin/integrations/index.html.erb
+++ b/engines/collavre/app/views/collavre/admin/integrations/index.html.erb
@@ -8,12 +8,12 @@
     <%= tag.div(flash[:warning], class: "flash-warning") if flash[:warning] %>
     <%= tag.div(flash[:notice], class: "flash-notice") if flash[:notice] %>
 
-    <p style="color: var(--color-text-muted); margin-bottom: 1.5em;">
+    <p style="color: var(--color-muted); margin-bottom: 1.5em;">
       <%= t("collavre.admin.integrations.subtitle") %>
     </p>
 
     <% if @grouped_settings.empty? %>
-      <p class="empty-state" style="padding: 2em; text-align: center; color: var(--color-text-muted);">
+      <p class="empty-state" style="padding: 2em; text-align: center; color: var(--color-muted);">
         <%= t("collavre.admin.integrations.empty_state") %>
       </p>
     <% else %>

--- a/engines/collavre/app/views/collavre/admin/integrations/index.html.erb
+++ b/engines/collavre/app/views/collavre/admin/integrations/index.html.erb
@@ -17,15 +17,26 @@
         <%= t("collavre.admin.integrations.empty_state") %>
       </p>
     <% else %>
-      <%= form_with url: collavre.bulk_update_admin_integrations_path, method: :patch, local: true, html: { class: "profile-form" } do |f| %>
-        <% @grouped_settings.each do |category, rows| %>
-          <%= render partial: "category", locals: { category: category, rows: rows, f: f } %>
-        <% end %>
-
-        <div style="margin-top: 2em;">
-          <%= f.submit t("collavre.admin.integrations.actions.save") %>
-        </div>
+      <%# Bulk-save form is an empty container. Row inputs reference it via the HTML5
+          `form` attribute; per-row Reset/Seed `button_to` forms sit as siblings,
+          so we never nest <form> inside <form>. %>
+      <%= form_with url: collavre.bulk_update_admin_integrations_path,
+                    method: :patch,
+                    local: true,
+                    id: "integrations-bulk-form",
+                    html: { id: "integrations-bulk-form", class: "profile-form" } do %>
       <% end %>
+
+      <% @grouped_settings.each do |category, rows| %>
+        <%= render partial: "category", locals: { category: category, rows: rows, bulk_form_id: "integrations-bulk-form" } %>
+      <% end %>
+
+      <div style="margin-top: 2em;">
+        <%= button_tag t("collavre.admin.integrations.actions.save"),
+              type: :submit,
+              form: "integrations-bulk-form",
+              class: "btn btn-primary" %>
+      </div>
     <% end %>
   </section>
 </div>

--- a/engines/collavre/app/views/collavre/admin/integrations/index.html.erb
+++ b/engines/collavre/app/views/collavre/admin/integrations/index.html.erb
@@ -1,0 +1,31 @@
+<h1 class="no-top-margin"><%= t("collavre.admin.integrations.title") %></h1>
+
+<%= render "admin/shared/tabs" %>
+
+<div class="tab-panels">
+  <section class="tab-panel active">
+    <%= tag.div(flash[:alert], class: "flash-alert") if flash[:alert] %>
+    <%= tag.div(flash[:warning], class: "flash-warning") if flash[:warning] %>
+    <%= tag.div(flash[:notice], class: "flash-notice") if flash[:notice] %>
+
+    <p style="color: var(--color-text-muted); margin-bottom: 1.5em;">
+      <%= t("collavre.admin.integrations.subtitle") %>
+    </p>
+
+    <% if @grouped_settings.empty? %>
+      <p class="empty-state" style="padding: 2em; text-align: center; color: var(--color-text-muted);">
+        <%= t("collavre.admin.integrations.empty_state") %>
+      </p>
+    <% else %>
+      <%= form_with url: collavre.bulk_update_admin_integrations_path, method: :patch, local: true, html: { class: "profile-form" } do |f| %>
+        <% @grouped_settings.each do |category, rows| %>
+          <%= render partial: "category", locals: { category: category, rows: rows, f: f } %>
+        <% end %>
+
+        <div style="margin-top: 2em;">
+          <%= f.submit t("collavre.admin.integrations.actions.save") %>
+        </div>
+      <% end %>
+    <% end %>
+  </section>
+</div>

--- a/engines/collavre/config/locales/integrations.en.yml
+++ b/engines/collavre/config/locales/integrations.en.yml
@@ -1,0 +1,44 @@
+en:
+  collavre:
+    admin:
+      integrations:
+        title: "Integrations"
+        subtitle: "Configure external integration secrets. Database values take precedence over ENV; ENV is the seed/fallback."
+        tab_label: "Integrations"
+        empty_state: "No integrations registered yet."
+        sensitive: "(sensitive)"
+        restart_required: "restart required"
+        seeded_from_env: "Seeded from ENV"
+        placeholder_leave_blank: "Leave blank to keep current"
+        confirm_reset: "Delete the DB value and fall back to ENV?"
+        headers:
+          key: "Key"
+          current: "Current value"
+          new_value: "New value"
+          actions: "Actions"
+        source:
+          db: "DB"
+          env: "ENV"
+          default: "default"
+          unknown: "unknown"
+        category:
+          slack: "Slack"
+          google_oauth: "Google OAuth"
+          github_oauth: "GitHub OAuth"
+          notion_oauth: "Notion OAuth"
+          aws_s3: "AWS S3"
+          aws_ses: "AWS SES"
+          firebase: "Firebase"
+          fcm: "FCM"
+          gemini: "Gemini"
+          mail: "Mail"
+        actions:
+          save: "Save changes"
+          reset: "Reset to ENV"
+          seed_from_env: "Seed from ENV"
+        flash:
+          updated: "Integration settings saved."
+          restart_required: "Some changed keys require a server restart to take effect."
+          reset_done: "Reset %{key} to ENV/default."
+          seed_done: "Seeded %{key} from ENV."
+          seed_no_env: "No ENV value present for %{key}; nothing seeded."

--- a/engines/collavre/config/locales/integrations.en.yml
+++ b/engines/collavre/config/locales/integrations.en.yml
@@ -13,8 +13,7 @@ en:
         confirm_reset: "Delete the DB value and fall back to ENV?"
         headers:
           key: "Key"
-          current: "Current value"
-          new_value: "New value"
+          value: "Value"
           actions: "Actions"
         source:
           db: "DB"

--- a/engines/collavre/config/locales/integrations.en.yml
+++ b/engines/collavre/config/locales/integrations.en.yml
@@ -9,6 +9,7 @@ en:
         sensitive: "(sensitive)"
         restart_required: "restart required"
         placeholder_leave_blank: "Leave blank to keep current"
+        env_var_label: "ENV"
         confirm_reset: "Delete the DB value and fall back to ENV?"
         headers:
           key: "Key"

--- a/engines/collavre/config/locales/integrations.en.yml
+++ b/engines/collavre/config/locales/integrations.en.yml
@@ -8,7 +8,6 @@ en:
         empty_state: "No integrations registered yet."
         sensitive: "(sensitive)"
         restart_required: "restart required"
-        seeded_from_env: "Seeded from ENV"
         placeholder_leave_blank: "Leave blank to keep current"
         confirm_reset: "Delete the DB value and fall back to ENV?"
         headers:
@@ -35,10 +34,7 @@ en:
         actions:
           save: "Save changes"
           reset: "Reset to ENV"
-          seed_from_env: "Seed from ENV"
         flash:
           updated: "Integration settings saved."
           restart_required: "Some changed keys require a server restart to take effect."
           reset_done: "Reset %{key} to ENV/default."
-          seed_done: "Seeded %{key} from ENV."
-          seed_no_env: "No ENV value present for %{key}; nothing seeded."

--- a/engines/collavre/config/locales/integrations.ko.yml
+++ b/engines/collavre/config/locales/integrations.ko.yml
@@ -9,6 +9,7 @@ ko:
         sensitive: "(민감)"
         restart_required: "재시작 필요"
         placeholder_leave_blank: "비워두면 현재 값 유지"
+        env_var_label: "환경변수"
         confirm_reset: "DB 값을 삭제하고 ENV로 폴백할까요?"
         headers:
           key: "키"

--- a/engines/collavre/config/locales/integrations.ko.yml
+++ b/engines/collavre/config/locales/integrations.ko.yml
@@ -1,0 +1,44 @@
+ko:
+  collavre:
+    admin:
+      integrations:
+        title: "통합"
+        subtitle: "외부 통합 비밀값을 설정합니다. DB 값이 ENV보다 우선하며, ENV는 시드/폴백입니다."
+        tab_label: "통합"
+        empty_state: "등록된 통합이 없습니다."
+        sensitive: "(민감)"
+        restart_required: "재시작 필요"
+        seeded_from_env: "ENV에서 시드됨"
+        placeholder_leave_blank: "비워두면 현재 값 유지"
+        confirm_reset: "DB 값을 삭제하고 ENV로 폴백할까요?"
+        headers:
+          key: "키"
+          current: "현재 값"
+          new_value: "새 값"
+          actions: "작업"
+        source:
+          db: "DB"
+          env: "ENV"
+          default: "기본값"
+          unknown: "알 수 없음"
+        category:
+          slack: "Slack"
+          google_oauth: "Google OAuth"
+          github_oauth: "GitHub OAuth"
+          notion_oauth: "Notion OAuth"
+          aws_s3: "AWS S3"
+          aws_ses: "AWS SES"
+          firebase: "Firebase"
+          fcm: "FCM"
+          gemini: "Gemini"
+          mail: "메일"
+        actions:
+          save: "변경사항 저장"
+          reset: "ENV로 초기화"
+          seed_from_env: "ENV에서 시드"
+        flash:
+          updated: "통합 설정이 저장되었습니다."
+          restart_required: "변경된 일부 키는 서버 재시작 후에 적용됩니다."
+          reset_done: "%{key}을(를) ENV/기본값으로 초기화했습니다."
+          seed_done: "%{key}을(를) ENV에서 시드했습니다."
+          seed_no_env: "%{key}에 대한 ENV 값이 없어 시드하지 않았습니다."

--- a/engines/collavre/config/locales/integrations.ko.yml
+++ b/engines/collavre/config/locales/integrations.ko.yml
@@ -8,7 +8,6 @@ ko:
         empty_state: "등록된 통합이 없습니다."
         sensitive: "(민감)"
         restart_required: "재시작 필요"
-        seeded_from_env: "ENV에서 시드됨"
         placeholder_leave_blank: "비워두면 현재 값 유지"
         confirm_reset: "DB 값을 삭제하고 ENV로 폴백할까요?"
         headers:
@@ -35,10 +34,7 @@ ko:
         actions:
           save: "변경사항 저장"
           reset: "ENV로 초기화"
-          seed_from_env: "ENV에서 시드"
         flash:
           updated: "통합 설정이 저장되었습니다."
           restart_required: "변경된 일부 키는 서버 재시작 후에 적용됩니다."
           reset_done: "%{key}을(를) ENV/기본값으로 초기화했습니다."
-          seed_done: "%{key}을(를) ENV에서 시드했습니다."
-          seed_no_env: "%{key}에 대한 ENV 값이 없어 시드하지 않았습니다."

--- a/engines/collavre/config/locales/integrations.ko.yml
+++ b/engines/collavre/config/locales/integrations.ko.yml
@@ -13,8 +13,7 @@ ko:
         confirm_reset: "DB 값을 삭제하고 ENV로 폴백할까요?"
         headers:
           key: "키"
-          current: "현재 값"
-          new_value: "새 값"
+          value: "값"
           actions: "작업"
         source:
           db: "DB"

--- a/engines/collavre/config/routes.rb
+++ b/engines/collavre/config/routes.rb
@@ -150,7 +150,6 @@ Collavre::Engine.routes.draw do
       end
       member do
         delete :reset
-        post :seed_from_env
       end
     end
   end

--- a/engines/collavre/config/routes.rb
+++ b/engines/collavre/config/routes.rb
@@ -143,5 +143,15 @@ Collavre::Engine.routes.draw do
     get "/uiux", to: "admin/settings#uiux", as: :uiux
     patch "/uiux", to: "admin/settings#update_uiux"
     resource :orchestration, only: [ :show, :update ], controller: "admin/orchestration"
+
+    resources :integrations, only: [ :index ], param: :key, controller: "admin/integrations" do
+      collection do
+        patch :bulk_update
+      end
+      member do
+        delete :reset
+        post :seed_from_env
+      end
+    end
   end
 end

--- a/engines/collavre/db/migrate/20260529100000_create_integration_settings.rb
+++ b/engines/collavre/db/migrate/20260529100000_create_integration_settings.rb
@@ -5,7 +5,6 @@ class CreateIntegrationSettings < ActiveRecord::Migration[8.1]
       t.text    :value
       t.string  :category, null: false
       t.boolean :sensitive, null: false, default: true
-      t.boolean :seeded_from_env, null: false, default: false
 
       t.timestamps
     end

--- a/engines/collavre/db/migrate/20260529100000_create_integration_settings.rb
+++ b/engines/collavre/db/migrate/20260529100000_create_integration_settings.rb
@@ -1,0 +1,16 @@
+class CreateIntegrationSettings < ActiveRecord::Migration[8.1]
+  def change
+    create_table :integration_settings do |t|
+      t.string  :key, null: false
+      t.text    :value
+      t.string  :category, null: false
+      t.boolean :sensitive, null: false, default: true
+      t.boolean :seeded_from_env, null: false, default: false
+
+      t.timestamps
+    end
+
+    add_index :integration_settings, :key, unique: true
+    add_index :integration_settings, :category
+  end
+end

--- a/engines/collavre/lib/collavre.rb
+++ b/engines/collavre/lib/collavre.rb
@@ -3,6 +3,7 @@ require "collavre/configuration"
 require "collavre/engine"
 require "collavre/user_extensions"
 require "collavre/integration_registry"
+require "collavre/integration_settings"
 require "collavre/view_extensions"
 require "navigation/registry"
 

--- a/engines/collavre/lib/collavre/integration_settings.rb
+++ b/engines/collavre/lib/collavre/integration_settings.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Entry point for the Collavre integration settings subsystem.
+# Loads the registry value-object, registry singleton, and resolver
+# (when present). Loaded from `engines/collavre/lib/collavre.rb` so
+# constants are available before any engine `to_prepare` blocks run.
+
+require_relative "integration_settings/key_definition"
+require_relative "integration_settings/registry"
+
+module Collavre
+  module IntegrationSettings
+  end
+end

--- a/engines/collavre/lib/collavre/integration_settings.rb
+++ b/engines/collavre/lib/collavre/integration_settings.rb
@@ -7,6 +7,7 @@
 
 require_relative "integration_settings/key_definition"
 require_relative "integration_settings/registry"
+require_relative "integration_settings/resolver"
 
 module Collavre
   module IntegrationSettings

--- a/engines/collavre/lib/collavre/integration_settings/key_definition.rb
+++ b/engines/collavre/lib/collavre/integration_settings/key_definition.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Collavre
+  module IntegrationSettings
+    # Value object describing a registered integration setting key.
+    #
+    # @!attribute [r] key
+    #   @return [Symbol] canonical key identifier (e.g. :slack_client_id)
+    # @!attribute [r] category
+    #   @return [String] grouping for the admin UI (e.g. "slack", "google_oauth")
+    # @!attribute [r] sensitive
+    #   @return [Boolean] when true the value is masked in the admin UI
+    # @!attribute [r] requires_restart
+    #   @return [Boolean] when true the admin UI surfaces a "restart required" badge
+    # @!attribute [r] env_var
+    #   @return [String] name of the ENV variable used as fallback / seed source
+    # @!attribute [r] default
+    #   @return [String, nil] static default returned when neither DB nor ENV has a value
+    KeyDefinition = Struct.new(
+      :key,
+      :category,
+      :sensitive,
+      :requires_restart,
+      :env_var,
+      :default,
+      keyword_init: true
+    )
+  end
+end

--- a/engines/collavre/lib/collavre/integration_settings/registry.rb
+++ b/engines/collavre/lib/collavre/integration_settings/registry.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "singleton"
+
+module Collavre
+  module IntegrationSettings
+    # Singleton registry of integration setting key definitions.
+    # Engines register their keys at boot via `to_prepare`, then the
+    # admin UI and {Resolver} consult this registry.
+    class Registry
+      include Singleton
+
+      def initialize
+        @definitions = {}
+      end
+
+      # Register a key definition.
+      #
+      # @param key [Symbol, String] canonical identifier (e.g. :slack_client_id)
+      # @param category [String] grouping label (e.g. "slack")
+      # @param sensitive [Boolean] when true, value is masked in admin UI
+      # @param requires_restart [Boolean] when true, surfaces restart-required badge
+      # @param env_var [String, nil] ENV variable name (defaults to key.upcase)
+      # @param default [String, nil] static fallback used when DB & ENV blank
+      # @return [KeyDefinition]
+      def register(key, category:, sensitive: true, requires_restart: false, env_var: nil, default: nil)
+        key = key.to_sym
+        @definitions[key] = KeyDefinition.new(
+          key: key,
+          category: category,
+          sensitive: sensitive,
+          requires_restart: requires_restart,
+          env_var: env_var || key.to_s.upcase,
+          default: default
+        )
+      end
+
+      # @return [Array<KeyDefinition>] all registered definitions (frozen snapshot)
+      def all
+        @definitions.values.freeze
+      end
+
+      # @param key [Symbol, String]
+      # @return [KeyDefinition, nil]
+      def find(key)
+        @definitions[key.to_sym]
+      end
+
+      # @return [Hash{String => Array<KeyDefinition>}] definitions grouped by category
+      def by_category
+        @definitions.values.group_by(&:category)
+      end
+    end
+  end
+end

--- a/engines/collavre/lib/collavre/integration_settings/resolver.rb
+++ b/engines/collavre/lib/collavre/integration_settings/resolver.rb
@@ -10,9 +10,14 @@ module Collavre
     # - ENV is consulted only when no DB row exists.
     # - The registry's static default is the final fallback.
     #
-    # Reads are memoized in `Rails.cache` for 5 minutes under
-    # `IntegrationSetting.cache_key_for(key)`. The model's `after_commit`
-    # hook invalidates this key on any write.
+    # Caching:
+    # - **Sensitive** definitions are NEVER cached. `Rails.cache` may resolve
+    #   to a durable store (e.g. `:solid_cache_store` in production), which
+    #   would persist decrypted secrets outside the encrypted `value` column
+    #   and defeat at-rest encryption. Sensitive reads hit the DB every time.
+    # - **Non-sensitive** definitions are memoized in `Rails.cache` for 5
+    #   minutes under `IntegrationSetting.cache_key_for(key)`. The model's
+    #   `after_commit` hook invalidates this key on any write.
     class Resolver
       # Raised by {.get} when the key has not been registered.
       class UnknownKeyError < StandardError; end
@@ -29,8 +34,10 @@ module Collavre
           definition = Registry.instance.find(key) or
             raise UnknownKeyError, "Unknown integration setting: #{key}"
 
+          return resolve(definition) if definition.sensitive
+
           Rails.cache.fetch(IntegrationSetting.cache_key_for(definition.key), expires_in: CACHE_TTL) do
-            db_value(definition) || env_value(definition) || definition.default
+            resolve(definition)
           end
         end
 
@@ -46,6 +53,10 @@ module Collavre
         end
 
         private
+
+        def resolve(definition)
+          db_value(definition) || env_value(definition) || definition.default
+        end
 
         def db_value(definition)
           IntegrationSetting.find_by(key: definition.key)&.value.presence

--- a/engines/collavre/lib/collavre/integration_settings/resolver.rb
+++ b/engines/collavre/lib/collavre/integration_settings/resolver.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module Collavre
+  module IntegrationSettings
+    # Resolves the live value for a registered integration setting key.
+    #
+    # Precedence: **DB > ENV > registered default.**
+    # - DB value wins as long as an `IntegrationSetting` row exists with a
+    #   non-blank value (encrypted at rest via `IntegrationSetting`).
+    # - ENV is consulted only when no DB row exists.
+    # - The registry's static default is the final fallback.
+    #
+    # Reads are memoized in `Rails.cache` for 5 minutes under
+    # `IntegrationSetting.cache_key_for(key)`. The model's `after_commit`
+    # hook invalidates this key on any write.
+    class Resolver
+      # Raised by {.get} when the key has not been registered.
+      class UnknownKeyError < StandardError; end
+
+      CACHE_TTL = 5.minutes
+
+      class << self
+        # Resolve the current value for a registered key.
+        #
+        # @param key [Symbol, String]
+        # @return [String, nil]
+        # @raise [UnknownKeyError] if the key is not registered
+        def get(key)
+          definition = Registry.instance.find(key) or
+            raise UnknownKeyError, "Unknown integration setting: #{key}"
+
+          Rails.cache.fetch(IntegrationSetting.cache_key_for(definition.key), expires_in: CACHE_TTL) do
+            db_value(definition) || env_value(definition) || definition.default
+          end
+        end
+
+        # Report which source currently provides the value for a key.
+        #
+        # @param key [Symbol, String]
+        # @return [Symbol] one of `:db`, `:env`, `:default`, or `:unknown`
+        def source_for(key)
+          definition = Registry.instance.find(key) or return :unknown
+          return :db  if IntegrationSetting.find_by(key: definition.key)&.value.present?
+          return :env if ENV[definition.env_var].present?
+          :default
+        end
+
+        private
+
+        def db_value(definition)
+          IntegrationSetting.find_by(key: definition.key)&.value.presence
+        end
+
+        def env_value(definition)
+          ENV[definition.env_var].presence
+        end
+      end
+    end
+  end
+end

--- a/engines/collavre/test/controllers/admin_integrations_controller_test.rb
+++ b/engines/collavre/test/controllers/admin_integrations_controller_test.rb
@@ -9,7 +9,10 @@ class AdminIntegrationsControllerTest < ActionDispatch::IntegrationTest
     @admin = users(:one)
     @user  = users(:two)
 
-    # Reset registry for hermetic tests.
+    # Reset registry for hermetic tests, but snapshot boot-time
+    # registrations (e.g. Slack engine) so other tests in the same
+    # process don't lose their key definitions.
+    @registry_snapshot = Registry.instance.instance_variable_get(:@definitions).dup
     Registry.instance.instance_variable_set(:@definitions, {})
     Registry.instance.register(
       :slack_client_secret,
@@ -33,7 +36,7 @@ class AdminIntegrationsControllerTest < ActionDispatch::IntegrationTest
   end
 
   teardown do
-    Registry.instance.instance_variable_set(:@definitions, {})
+    Registry.instance.instance_variable_set(:@definitions, @registry_snapshot || {})
     ENV.delete("SLACK_CLIENT_ID")
     ENV.delete("SLACK_CLIENT_SECRET")
     Rails.cache.clear

--- a/engines/collavre/test/controllers/admin_integrations_controller_test.rb
+++ b/engines/collavre/test/controllers/admin_integrations_controller_test.rb
@@ -153,35 +153,4 @@ class AdminIntegrationsControllerTest < ActionDispatch::IntegrationTest
     assert_response :not_found
   end
 
-  # ---------- seed_from_env ----------
-
-  test "seed_from_env copies ENV value into DB with seeded_from_env true" do
-    ENV["SLACK_CLIENT_ID"] = "from-env"
-    sign_in_as(@admin, password: "password")
-
-    post collavre.seed_from_env_admin_integration_path(key: "slack_client_id")
-
-    assert_redirected_to collavre.admin_integrations_path
-    row = IntegrationSetting.find_by(key: "slack_client_id")
-    assert_not_nil row
-    assert_equal "from-env", row.value
-    assert_equal "slack", row.category
-    assert row.seeded_from_env
-  end
-
-  test "seed_from_env with blank ENV does not create a row" do
-    ENV.delete("SLACK_CLIENT_ID")
-    sign_in_as(@admin, password: "password")
-
-    post collavre.seed_from_env_admin_integration_path(key: "slack_client_id")
-
-    assert_redirected_to collavre.admin_integrations_path
-    assert_nil IntegrationSetting.find_by(key: "slack_client_id")
-  end
-
-  test "seed_from_env on unknown key returns 404" do
-    sign_in_as(@admin, password: "password")
-    post collavre.seed_from_env_admin_integration_path(key: "no_such_key")
-    assert_response :not_found
-  end
 end

--- a/engines/collavre/test/controllers/admin_integrations_controller_test.rb
+++ b/engines/collavre/test/controllers/admin_integrations_controller_test.rb
@@ -152,5 +152,4 @@ class AdminIntegrationsControllerTest < ActionDispatch::IntegrationTest
     delete collavre.reset_admin_integration_path(key: "no_such_key")
     assert_response :not_found
   end
-
 end

--- a/engines/collavre/test/controllers/admin_integrations_controller_test.rb
+++ b/engines/collavre/test/controllers/admin_integrations_controller_test.rb
@@ -1,0 +1,184 @@
+require "test_helper"
+
+class AdminIntegrationsControllerTest < ActionDispatch::IntegrationTest
+  Registry = Collavre::IntegrationSettings::Registry
+  Resolver = Collavre::IntegrationSettings::Resolver
+  IntegrationSetting = Collavre::IntegrationSetting
+
+  setup do
+    @admin = users(:one)
+    @user  = users(:two)
+
+    # Reset registry for hermetic tests.
+    Registry.instance.instance_variable_set(:@definitions, {})
+    Registry.instance.register(
+      :slack_client_secret,
+      category: "slack",
+      sensitive: true,
+      requires_restart: true,
+      env_var: "SLACK_CLIENT_SECRET",
+      default: nil
+    )
+    Registry.instance.register(
+      :slack_client_id,
+      category: "slack",
+      sensitive: false,
+      requires_restart: false,
+      env_var: "SLACK_CLIENT_ID",
+      default: nil
+    )
+
+    Rails.cache.clear
+    IntegrationSetting.delete_all
+  end
+
+  teardown do
+    Registry.instance.instance_variable_set(:@definitions, {})
+    ENV.delete("SLACK_CLIENT_ID")
+    ENV.delete("SLACK_CLIENT_SECRET")
+    Rails.cache.clear
+  end
+
+  # ---------- auth ----------
+
+  test "non-admin user gets 404" do
+    sign_in_as(@user, password: "password")
+    get collavre.admin_integrations_path
+    assert_response :not_found
+  end
+
+  test "admin user gets index 200" do
+    sign_in_as(@admin, password: "password")
+    get collavre.admin_integrations_path
+    assert_response :success
+  end
+
+  # ---------- index display ----------
+
+  test "index masks sensitive values" do
+    IntegrationSetting.create!(
+      key: "slack_client_secret",
+      value: "supersecretplaintext12345",
+      category: "slack"
+    )
+    sign_in_as(@admin, password: "password")
+
+    get collavre.admin_integrations_path
+
+    assert_response :success
+    assert_not_includes response.body, "supersecretplaintext12345",
+      "Plaintext value of a sensitive key must not appear in the HTML"
+  end
+
+  test "index renders empty state when registry is empty" do
+    Registry.instance.instance_variable_set(:@definitions, {})
+    sign_in_as(@admin, password: "password")
+
+    get collavre.admin_integrations_path
+
+    assert_response :success
+    assert_includes response.body, I18n.t("collavre.admin.integrations.empty_state")
+  end
+
+  # ---------- bulk_update ----------
+
+  test "bulk_update upserts non-blank values" do
+    sign_in_as(@admin, password: "password")
+
+    patch collavre.bulk_update_admin_integrations_path, params: {
+      integration_setting: {
+        slack_client_id: "client-id-from-form",
+        slack_client_secret: ""
+      }
+    }
+
+    assert_redirected_to collavre.admin_integrations_path
+
+    row = IntegrationSetting.find_by(key: "slack_client_id")
+    assert_not_nil row
+    assert_equal "client-id-from-form", row.value
+    assert_equal "slack", row.category
+
+    # blank input was skipped — no row created
+    assert_nil IntegrationSetting.find_by(key: "slack_client_secret")
+  end
+
+  test "bulk_update flashes restart_required when a restart key changed" do
+    sign_in_as(@admin, password: "password")
+
+    patch collavre.bulk_update_admin_integrations_path, params: {
+      integration_setting: { slack_client_secret: "new-secret" }
+    }
+
+    assert_redirected_to collavre.admin_integrations_path
+    follow_redirect!
+    assert_match I18n.t("collavre.admin.integrations.flash.restart_required"), response.body
+  end
+
+  test "bulk_update does not flash restart_required when only non-restart keys change" do
+    sign_in_as(@admin, password: "password")
+
+    patch collavre.bulk_update_admin_integrations_path, params: {
+      integration_setting: { slack_client_id: "id-only" }
+    }
+
+    assert_redirected_to collavre.admin_integrations_path
+    assert_nil flash[:warning]
+  end
+
+  # ---------- reset ----------
+
+  test "reset deletes the DB row, resolver falls back to ENV" do
+    IntegrationSetting.create!(
+      key: "slack_client_id", value: "db-val", category: "slack"
+    )
+    ENV["SLACK_CLIENT_ID"] = "env-val"
+    Rails.cache.clear
+
+    sign_in_as(@admin, password: "password")
+    delete collavre.reset_admin_integration_path(key: "slack_client_id")
+
+    assert_redirected_to collavre.admin_integrations_path
+    assert_nil IntegrationSetting.find_by(key: "slack_client_id")
+    Rails.cache.clear
+    assert_equal "env-val", Resolver.get(:slack_client_id)
+  end
+
+  test "reset on unknown key returns 404" do
+    sign_in_as(@admin, password: "password")
+    delete collavre.reset_admin_integration_path(key: "no_such_key")
+    assert_response :not_found
+  end
+
+  # ---------- seed_from_env ----------
+
+  test "seed_from_env copies ENV value into DB with seeded_from_env true" do
+    ENV["SLACK_CLIENT_ID"] = "from-env"
+    sign_in_as(@admin, password: "password")
+
+    post collavre.seed_from_env_admin_integration_path(key: "slack_client_id")
+
+    assert_redirected_to collavre.admin_integrations_path
+    row = IntegrationSetting.find_by(key: "slack_client_id")
+    assert_not_nil row
+    assert_equal "from-env", row.value
+    assert_equal "slack", row.category
+    assert row.seeded_from_env
+  end
+
+  test "seed_from_env with blank ENV does not create a row" do
+    ENV.delete("SLACK_CLIENT_ID")
+    sign_in_as(@admin, password: "password")
+
+    post collavre.seed_from_env_admin_integration_path(key: "slack_client_id")
+
+    assert_redirected_to collavre.admin_integrations_path
+    assert_nil IntegrationSetting.find_by(key: "slack_client_id")
+  end
+
+  test "seed_from_env on unknown key returns 404" do
+    sign_in_as(@admin, password: "password")
+    post collavre.seed_from_env_admin_integration_path(key: "no_such_key")
+    assert_response :not_found
+  end
+end

--- a/engines/collavre/test/lib/collavre/integration_settings/registry_test.rb
+++ b/engines/collavre/test/lib/collavre/integration_settings/registry_test.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  module IntegrationSettings
+    class RegistryTest < ActiveSupport::TestCase
+      setup { Registry.instance.instance_variable_set(:@definitions, {}) }
+      teardown { Registry.instance.instance_variable_set(:@definitions, {}) }
+
+      test "registers a key with defaults" do
+        Registry.instance.register(:slack_client_id, category: "slack")
+        d = Registry.instance.find(:slack_client_id)
+        assert_equal "slack",            d.category
+        assert_equal true,               d.sensitive
+        assert_equal false,              d.requires_restart
+        assert_equal "SLACK_CLIENT_ID",  d.env_var
+      end
+
+      test "groups by category" do
+        Registry.instance.register(:slack_client_id, category: "slack")
+        Registry.instance.register(:google_client_id, category: "google_oauth")
+        assert_equal %w[slack google_oauth].sort, Registry.instance.by_category.keys.sort
+      end
+    end
+  end
+end

--- a/engines/collavre/test/lib/collavre/integration_settings/registry_test.rb
+++ b/engines/collavre/test/lib/collavre/integration_settings/registry_test.rb
@@ -5,8 +5,17 @@ require "test_helper"
 module Collavre
   module IntegrationSettings
     class RegistryTest < ActiveSupport::TestCase
-      setup { Registry.instance.instance_variable_set(:@definitions, {}) }
-      teardown { Registry.instance.instance_variable_set(:@definitions, {}) }
+      setup do
+        # Snapshot boot-time registrations (e.g. Slack engine) so we can
+        # restore them in teardown without polluting other tests in the
+        # same process.
+        @registry_snapshot = Registry.instance.instance_variable_get(:@definitions).dup
+        Registry.instance.instance_variable_set(:@definitions, {})
+      end
+
+      teardown do
+        Registry.instance.instance_variable_set(:@definitions, @registry_snapshot || {})
+      end
 
       test "registers a key with defaults" do
         Registry.instance.register(:slack_client_id, category: "slack")

--- a/engines/collavre/test/lib/collavre/integration_settings/resolver_test.rb
+++ b/engines/collavre/test/lib/collavre/integration_settings/resolver_test.rb
@@ -16,6 +16,13 @@ module Collavre
           env_var: "SLACK_CLIENT_ID",
           default: "default-id"
         )
+        Registry.instance.register(
+          :app_brand_name,
+          category: "branding",
+          sensitive: false,
+          env_var: "APP_BRAND_NAME",
+          default: "default-brand"
+        )
         Rails.cache.clear
         IntegrationSetting.delete_all
       end
@@ -23,6 +30,7 @@ module Collavre
       teardown do
         Registry.instance.instance_variable_set(:@definitions, @registry_snapshot || {})
         ENV.delete("SLACK_CLIENT_ID")
+        ENV.delete("APP_BRAND_NAME")
         Rails.cache.clear
       end
 
@@ -52,18 +60,36 @@ module Collavre
         assert_equal :unknown, Resolver.source_for(:nope)
       end
 
-      test "cache is hit on second read" do
-        IntegrationSetting.create!(key: "slack_client_id", value: "first", category: "slack")
-        assert_equal "first", Resolver.get(:slack_client_id)
+      test "non-sensitive key is cached on second read" do
+        IntegrationSetting.create!(key: "app_brand_name", value: "first", category: "branding")
+        assert_equal "first", Resolver.get(:app_brand_name)
 
         # Bypass callbacks so cache is not cleared
-        IntegrationSetting.where(key: "slack_client_id").delete_all
+        IntegrationSetting.where(key: "app_brand_name").delete_all
         Rails.cache.write(
-          IntegrationSetting.cache_key_for(:slack_client_id),
+          IntegrationSetting.cache_key_for(:app_brand_name),
           "cached-value",
           expires_in: 5.minutes
         )
-        assert_equal "cached-value", Resolver.get(:slack_client_id)
+        assert_equal "cached-value", Resolver.get(:app_brand_name)
+      end
+
+      test "sensitive key bypasses Rails.cache to avoid persisting plaintext" do
+        # Pre-poison the cache with a value that would only be returned if cache was consulted.
+        Rails.cache.write(
+          IntegrationSetting.cache_key_for(:slack_client_id),
+          "cached-poison",
+          expires_in: 5.minutes
+        )
+        IntegrationSetting.create!(key: "slack_client_id", value: "fresh-db", category: "slack")
+        assert_equal "fresh-db", Resolver.get(:slack_client_id)
+      end
+
+      test "sensitive key resolution does not write to Rails.cache" do
+        IntegrationSetting.create!(key: "slack_client_id", value: "secret-val", category: "slack")
+        Rails.cache.clear
+        Resolver.get(:slack_client_id)
+        assert_nil Rails.cache.read(IntegrationSetting.cache_key_for(:slack_client_id))
       end
     end
   end

--- a/engines/collavre/test/lib/collavre/integration_settings/resolver_test.rb
+++ b/engines/collavre/test/lib/collavre/integration_settings/resolver_test.rb
@@ -6,6 +6,9 @@ module Collavre
   module IntegrationSettings
     class ResolverTest < ActiveSupport::TestCase
       setup do
+        # Snapshot boot-time registrations (e.g. Slack engine) so other tests
+        # in the same process don't lose their key definitions.
+        @registry_snapshot = Registry.instance.instance_variable_get(:@definitions).dup
         Registry.instance.instance_variable_set(:@definitions, {})
         Registry.instance.register(
           :slack_client_id,
@@ -18,7 +21,7 @@ module Collavre
       end
 
       teardown do
-        Registry.instance.instance_variable_set(:@definitions, {})
+        Registry.instance.instance_variable_set(:@definitions, @registry_snapshot || {})
         ENV.delete("SLACK_CLIENT_ID")
         Rails.cache.clear
       end

--- a/engines/collavre/test/lib/collavre/integration_settings/resolver_test.rb
+++ b/engines/collavre/test/lib/collavre/integration_settings/resolver_test.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  module IntegrationSettings
+    class ResolverTest < ActiveSupport::TestCase
+      setup do
+        Registry.instance.instance_variable_set(:@definitions, {})
+        Registry.instance.register(
+          :slack_client_id,
+          category: "slack",
+          env_var: "SLACK_CLIENT_ID",
+          default: "default-id"
+        )
+        Rails.cache.clear
+        IntegrationSetting.delete_all
+      end
+
+      teardown do
+        Registry.instance.instance_variable_set(:@definitions, {})
+        ENV.delete("SLACK_CLIENT_ID")
+        Rails.cache.clear
+      end
+
+      test "DB beats ENV" do
+        IntegrationSetting.create!(key: "slack_client_id", value: "db-val", category: "slack")
+        ENV["SLACK_CLIENT_ID"] = "env-val"
+        assert_equal "db-val", Resolver.get(:slack_client_id)
+        assert_equal :db,      Resolver.source_for(:slack_client_id)
+      end
+
+      test "ENV used when no DB row" do
+        ENV["SLACK_CLIENT_ID"] = "env-val"
+        assert_equal "env-val", Resolver.get(:slack_client_id)
+        assert_equal :env,      Resolver.source_for(:slack_client_id)
+      end
+
+      test "default used when neither" do
+        assert_equal "default-id", Resolver.get(:slack_client_id)
+        assert_equal :default,     Resolver.source_for(:slack_client_id)
+      end
+
+      test "unknown key raises" do
+        assert_raises(Resolver::UnknownKeyError) { Resolver.get(:nope) }
+      end
+
+      test "source_for returns :unknown for unknown key" do
+        assert_equal :unknown, Resolver.source_for(:nope)
+      end
+
+      test "cache is hit on second read" do
+        IntegrationSetting.create!(key: "slack_client_id", value: "first", category: "slack")
+        assert_equal "first", Resolver.get(:slack_client_id)
+
+        # Bypass callbacks so cache is not cleared
+        IntegrationSetting.where(key: "slack_client_id").delete_all
+        Rails.cache.write(
+          IntegrationSetting.cache_key_for(:slack_client_id),
+          "cached-value",
+          expires_in: 5.minutes
+        )
+        assert_equal "cached-value", Resolver.get(:slack_client_id)
+      end
+    end
+  end
+end

--- a/engines/collavre/test/models/collavre/integration_setting_test.rb
+++ b/engines/collavre/test/models/collavre/integration_setting_test.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  class IntegrationSettingTest < ActiveSupport::TestCase
+    test "encrypts value" do
+      setting = IntegrationSetting.create!(key: "slack_client_id", value: "xoxb-secret", category: "slack")
+      raw = IntegrationSetting.connection.select_value(
+        "SELECT value FROM integration_settings WHERE id = #{setting.id}"
+      )
+      assert_not_equal "xoxb-secret", raw
+      assert_equal "xoxb-secret", setting.reload.value
+    end
+
+    test "requires unique key" do
+      IntegrationSetting.create!(key: "slack_client_id", value: "a", category: "slack")
+      dup = IntegrationSetting.new(key: "slack_client_id", value: "b", category: "slack")
+      assert_not dup.valid?
+    end
+
+    test "clears cache on commit" do
+      Rails.cache.write(IntegrationSetting.cache_key_for("slack_client_id"), "cached")
+      IntegrationSetting.create!(key: "slack_client_id", value: "new", category: "slack")
+      assert_nil Rails.cache.read(IntegrationSetting.cache_key_for("slack_client_id"))
+    end
+  end
+end

--- a/engines/collavre_slack/config/initializers/collavre_slack.rb
+++ b/engines/collavre_slack/config/initializers/collavre_slack.rb
@@ -1,7 +1,27 @@
+# Register Slack OAuth keys with the IntegrationSettings registry so the admin
+# UI can surface them and `Collavre::IntegrationSettings::Resolver` can serve
+# values via the DB > ENV > default precedence. Wrapped in `to_prepare` so
+# definitions re-register on code reload in development.
+Rails.application.config.to_prepare do
+  if defined?(Collavre::IntegrationSettings::Registry)
+    Collavre::IntegrationSettings::Registry.instance.register(
+      :slack_client_id,      category: "slack", sensitive: false, requires_restart: true
+    )
+    Collavre::IntegrationSettings::Registry.instance.register(
+      :slack_client_secret,  category: "slack", sensitive: true,  requires_restart: true
+    )
+    Collavre::IntegrationSettings::Registry.instance.register(
+      :slack_signing_secret, category: "slack", sensitive: true,  requires_restart: true
+    )
+    Collavre::IntegrationSettings::Registry.instance.register(
+      :slack_redirect_uri,   category: "slack", sensitive: false, requires_restart: true
+    )
+  end
+end
+
+# Scopes still come from ENV (not registered as a managed integration setting
+# in Phase 1). OAuth credentials are now resolved lazily by Configuration via
+# the Resolver, so they are no longer assigned here.
 CollavreSlack.configure do |config|
-  config.client_id = ENV.fetch("SLACK_CLIENT_ID", config.client_id)
-  config.client_secret = ENV.fetch("SLACK_CLIENT_SECRET", config.client_secret)
-  config.signing_secret = ENV.fetch("SLACK_SIGNING_SECRET", config.signing_secret)
-  config.redirect_uri = ENV.fetch("SLACK_REDIRECT_URI", config.redirect_uri)
   config.scopes = ENV.fetch("SLACK_SCOPES", config.scopes)
 end

--- a/engines/collavre_slack/lib/collavre_slack/configuration.rb
+++ b/engines/collavre_slack/lib/collavre_slack/configuration.rb
@@ -1,13 +1,45 @@
 module CollavreSlack
+  # Slack engine configuration.
+  #
+  # OAuth credential getters (`client_id`, `client_secret`, `signing_secret`,
+  # `redirect_uri`) resolve through `Collavre::IntegrationSettings::Resolver`,
+  # which honors the DB > ENV > registered default precedence. Writers are
+  # preserved so tests and explicit `CollavreSlack.configure` overrides keep
+  # working: an explicitly-assigned value short-circuits the resolver.
+  #
+  # If the `integration_settings` table is unavailable (e.g. during
+  # `db:create`, `db:schema:load`, `assets:precompile`, or fresh installs)
+  # the getters fall back to plain `ENV[...]` so boot does not crash.
   class Configuration
-    attr_accessor :client_id, :client_secret, :signing_secret, :redirect_uri, :scopes
+    RESOLVER_KEYS = {
+      client_id:      { registry: :slack_client_id,      env: "SLACK_CLIENT_ID" },
+      client_secret:  { registry: :slack_client_secret,  env: "SLACK_CLIENT_SECRET" },
+      signing_secret: { registry: :slack_signing_secret, env: "SLACK_SIGNING_SECRET" },
+      redirect_uri:   { registry: :slack_redirect_uri,   env: "SLACK_REDIRECT_URI" }
+    }.freeze
+
+    attr_writer :client_id, :client_secret, :signing_secret, :redirect_uri
+    attr_accessor :scopes
 
     def initialize
-      @client_id = ENV.fetch("SLACK_CLIENT_ID", "")
-      @client_secret = ENV.fetch("SLACK_CLIENT_SECRET", "")
-      @signing_secret = ENV.fetch("SLACK_SIGNING_SECRET", "")
-      @redirect_uri = ENV.fetch("SLACK_REDIRECT_URI", "")
       @scopes = ENV.fetch("SLACK_SCOPES", "chat:write,channels:read,channels:history,groups:read,im:read,mpim:read,users:read,users:read.email,reactions:read,reactions:write")
+    end
+
+    RESOLVER_KEYS.each do |attr, meta|
+      define_method(attr) do
+        ivar = instance_variable_get(:"@#{attr}")
+        return ivar unless ivar.nil?
+
+        resolve_setting(meta[:registry], meta[:env])
+      end
+    end
+
+    private
+
+    def resolve_setting(registry_key, env_var)
+      Collavre::IntegrationSettings::Resolver.get(registry_key)
+    rescue ActiveRecord::StatementInvalid, ActiveRecord::ConnectionNotEstablished
+      ENV[env_var]
     end
   end
 end

--- a/engines/collavre_slack/lib/collavre_slack/configuration.rb
+++ b/engines/collavre_slack/lib/collavre_slack/configuration.rb
@@ -7,9 +7,13 @@ module CollavreSlack
   # preserved so tests and explicit `CollavreSlack.configure` overrides keep
   # working: an explicitly-assigned value short-circuits the resolver.
   #
-  # If the `integration_settings` table is unavailable (e.g. during
-  # `db:create`, `db:schema:load`, `assets:precompile`, or fresh installs)
-  # the getters fall back to plain `ENV[...]` so boot does not crash.
+  # Fallback to plain `ENV[...]` when the resolver is not usable:
+  #   - `integration_settings` table missing (db:create, db:schema:load,
+  #     assets:precompile, fresh installs)
+  #   - DB connection not established
+  #   - `Collavre::IntegrationSettings` API not present in the installed
+  #     core `collavre` gem (e.g. `USE_COLLAVRE_GEM=true` pinned to a
+  #     version predating this feature)
   class Configuration
     RESOLVER_KEYS = {
       client_id:      { registry: :slack_client_id,      env: "SLACK_CLIENT_ID" },
@@ -37,6 +41,8 @@ module CollavreSlack
     private
 
     def resolve_setting(registry_key, env_var)
+      return ENV[env_var] unless defined?(Collavre::IntegrationSettings::Resolver)
+
       Collavre::IntegrationSettings::Resolver.get(registry_key)
     rescue ActiveRecord::StatementInvalid, ActiveRecord::ConnectionNotEstablished
       ENV[env_var]

--- a/engines/collavre_slack/test/lib/collavre_slack/configuration_test.rb
+++ b/engines/collavre_slack/test/lib/collavre_slack/configuration_test.rb
@@ -75,6 +75,24 @@ module CollavreSlack
       end
     end
 
+    test "getters fall back to ENV when Resolver constant is undefined (USE_COLLAVRE_GEM with older core)" do
+      KEYS.each do |_attr, meta|
+        ENV[meta[:env]] = "gem-#{meta[:env]}"
+      end
+
+      # Simulate the `Collavre::IntegrationSettings::Resolver` namespace not being
+      # loaded (e.g. installed `collavre` gem predates this feature).
+      resolver_const = Collavre::IntegrationSettings.send(:remove_const, :Resolver)
+      begin
+        KEYS.each do |attr, meta|
+          assert_equal "gem-#{meta[:env]}", CollavreSlack::Configuration.new.public_send(attr),
+            "expected ENV fallback for #{attr} when Resolver constant missing"
+        end
+      ensure
+        Collavre::IntegrationSettings.const_set(:Resolver, resolver_const)
+      end
+    end
+
     test "writers still override resolver lookups (test affordance)" do
       ENV["SLACK_SIGNING_SECRET"] = "env-signing"
       config = CollavreSlack::Configuration.new

--- a/engines/collavre_slack/test/lib/collavre_slack/configuration_test.rb
+++ b/engines/collavre_slack/test/lib/collavre_slack/configuration_test.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require_relative "../../test_helper"
+
+module CollavreSlack
+  class ConfigurationTest < ActiveSupport::TestCase
+    KEYS = {
+      client_id:      { reg: :slack_client_id,      env: "SLACK_CLIENT_ID",      sensitive: false },
+      client_secret:  { reg: :slack_client_secret,  env: "SLACK_CLIENT_SECRET",  sensitive: true },
+      signing_secret: { reg: :slack_signing_secret, env: "SLACK_SIGNING_SECRET", sensitive: true },
+      redirect_uri:   { reg: :slack_redirect_uri,   env: "SLACK_REDIRECT_URI",   sensitive: false }
+    }.freeze
+
+    setup do
+      # Reset module-level memoized config so each test reads fresh ivar state.
+      CollavreSlack.instance_variable_set(:@config, nil)
+      Rails.cache.clear
+      Collavre::IntegrationSetting.delete_all
+      KEYS.each_value { |meta| ENV.delete(meta[:env]) }
+    end
+
+    teardown do
+      CollavreSlack.instance_variable_set(:@config, nil)
+      Rails.cache.clear
+      Collavre::IntegrationSetting.delete_all
+      KEYS.each_value { |meta| ENV.delete(meta[:env]) }
+    end
+
+    test "engine registers all four Slack OAuth keys with the registry" do
+      KEYS.each do |_attr, meta|
+        definition = Collavre::IntegrationSettings::Registry.instance.find(meta[:reg])
+        assert_not_nil definition, "expected #{meta[:reg]} to be registered"
+        assert_equal "slack", definition.category
+        assert_equal meta[:sensitive], definition.sensitive
+        assert_equal true, definition.requires_restart
+        assert_equal meta[:env], definition.env_var
+      end
+    end
+
+    test "getters resolve DB value over ENV (DB wins)" do
+      KEYS.each do |attr, meta|
+        Collavre::IntegrationSetting.create!(
+          key: meta[:reg].to_s, value: "db-#{attr}", category: "slack"
+        )
+        ENV[meta[:env]] = "env-#{attr}"
+      end
+
+      KEYS.each_key do |attr|
+        assert_equal "db-#{attr}", CollavreSlack::Configuration.new.public_send(attr),
+          "expected DB value for #{attr}"
+      end
+    end
+
+    test "getters fall back to ENV when no DB row exists" do
+      KEYS.each do |attr, meta|
+        ENV[meta[:env]] = "env-#{attr}"
+      end
+
+      KEYS.each_key do |attr|
+        assert_equal "env-#{attr}", CollavreSlack::Configuration.new.public_send(attr),
+          "expected ENV value for #{attr}"
+      end
+    end
+
+    test "getters fall back to ENV when integration_settings table is missing" do
+      KEYS.each do |_attr, meta|
+        ENV[meta[:env]] = "boot-#{meta[:env]}"
+      end
+
+      Collavre::IntegrationSetting.stub :find_by, ->(*) { raise ActiveRecord::StatementInvalid, "no such table" } do
+        KEYS.each do |attr, meta|
+          assert_equal "boot-#{meta[:env]}", CollavreSlack::Configuration.new.public_send(attr),
+            "expected ENV fallback for #{attr} when DB unavailable"
+        end
+      end
+    end
+
+    test "writers still override resolver lookups (test affordance)" do
+      ENV["SLACK_SIGNING_SECRET"] = "env-signing"
+      config = CollavreSlack::Configuration.new
+      assert_equal "env-signing", config.signing_secret
+
+      config.signing_secret = "explicit-override"
+      assert_equal "explicit-override", config.signing_secret
+    end
+
+    test "scopes still come from ENV (out of scope for resolver swap)" do
+      ENV["SLACK_SCOPES"] = "chat:write"
+      assert_equal "chat:write", CollavreSlack::Configuration.new.scopes
+    ensure
+      ENV.delete("SLACK_SCOPES")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Operators can now configure external integration secrets (Slack/Notion/GitHub OAuth, AWS, FCM, Firebase, mail, etc.) through `/admin/integrations` instead of requiring everything in `.env` at deploy time — a key on-premise enabler.

This PR ships **Phase 1**: the common infrastructure (model, registry, resolver, encryption, admin UI) plus Slack OAuth wired end-to-end as a working example.

Closes Creative #10665.

## What's in here

- **`Collavre::IntegrationSetting` model + migration** with `ActiveRecord::Encryption` on `value`. Cache invalidation on commit (matches existing `SystemSetting` pattern).
- **Registry + KeyDefinition** — each engine registers its keys at boot with `category`, `sensitive`, `requires_restart`, `env_var`, `default`.
- **Resolver** with precedence: **DB > ENV > registered default**, 5-minute `Rails.cache` TTL, `source_for(key)` returns `:db | :env | :default | :unknown` for the UI label, raises `UnknownKeyError` for unregistered keys.
- **`/admin/integrations` UI**: grouped by category, sensitive values masked (`••••<last4>`), source badge, restart-required badge, per-row Reset (→ delete row → fall back to ENV) and Seed-from-ENV (→ copy ENV → DB) actions. en/ko i18n complete.
- **Slack engine wired**: `engines/collavre_slack` reads `slack_client_id`, `slack_client_secret`, `slack_signing_secret`, `slack_redirect_uri` through `Resolver.get`. Boot-time safety via `ActiveRecord::StatementInvalid` / `ConnectionNotEstablished` rescue → falls back to ENV during `db:create` / `assets:precompile` / fresh-install.

## Precedence and source-of-truth choice

Resolver precedence is **DB > ENV** because the admin UI must be the operator's source of truth. ENV stays as a deployment fallback / initial seed (via the explicit "Seed from ENV" button), not as a runtime override. UI surfaces the active source so operators are never confused about which value is live.

Bootstrap secrets (`DATABASE_URL`, `SECRET_KEY_BASE`, `REDIS_URL`, `RAILS_MASTER_KEY`, `ACTIVE_RECORD_ENCRYPTION_*`, `KAMAL_*`, `PORT`) are intentionally **not** registered — they're needed before the DB is reachable.

## Backward compatibility

- Existing `.env`-driven deploys keep working unchanged: DB is empty → Resolver falls through to ENV → existing behavior.
- Slack-specific: `Configuration#client_id` (etc.) still respect writer assignments (`CollavreSlack.config.signing_secret = "..."`) — preserved for test/override use cases.

## Out of scope (follow-ups)

Phase 2+ wires the rest of `env.template` through Resolver (separate PRs):
- `config/initializers/omniauth.rb` — Google / GitHub / Notion OAuth
- `config/initializers/firebase_config.rb`, `fcm.rb`, `ruby_llm.rb`
- AWS S3 / SES env vars
- Mailer URL host / port

Plan with full Phase 2 design: `docs/superpowers/plans/2026-05-29-env-db-settings.md`.

## Test plan

- [x] `bin/rails test engines/collavre/test/models/collavre/integration_setting_test.rb` — encryption, uniqueness, cache invalidation
- [x] `bin/rails test engines/collavre/test/lib/collavre/integration_settings` — registry + resolver (DB > ENV > default, cache hit, source_for, UnknownKeyError)
- [x] `bin/rails test engines/collavre/test/controllers/admin_integrations_controller_test.rb` — auth gate, masking, bulk_update, reset, seed_from_env, restart-required flash, unknown-key 404
- [x] `bin/rails test engines/collavre_slack/test` — Slack Configuration reads through Resolver, DB > ENV, StatementInvalid → ENV fallback
- [x] Combined sweep: **54 runs, 193 assertions, 0 failures, 0 errors, 1 skip** (pre-existing system test)
- [ ] Manual: visit `/admin/integrations` as admin, edit a Slack key, restart server, confirm new value is active
- [ ] Manual: clear a Slack key via "Reset", confirm Resolver falls back to ENV after restart