### PR TITLE
fix(inbox): create System topic on first visit so badge has matching sidebar entry

### DIFF
--- a/engines/collavre/app/controllers/collavre/topics_controller.rb
+++ b/engines/collavre/app/controllers/collavre/topics_controller.rb
@@ -12,6 +12,14 @@ module Collavre
       can_manage = @creative.has_permission?(Current.user, :admin) || is_owner
       can_create_topic = can_manage || @creative.has_permission?(Current.user, :write)
 
+      # Eagerly ensure Main (and System for inboxes) exist BEFORE loading
+      # active_topics. Otherwise the first inbox visit sees no System topic in
+      # the sidebar, and when a later notification creates it via
+      # find_or_create_by!, the unread badge appears but the user has no way to
+      # open the topic.
+      main_topic = @creative.main_topic(fallback_user: Current.user)
+      system_topic = @creative.inbox? ? @creative.system_topic(fallback_user: Current.user) : nil
+
       active_topics = @creative.topics.active.includes(primary_agent: { avatar_attachment: :blob }).order(:created_at).to_a
       archived_topics = @creative.topics.archived.order(:created_at)
 
@@ -21,8 +29,8 @@ module Collavre
                           .pick(:last_topic_id)
       end
 
-      system_topic_id = @creative.inbox? ? @creative.topics.find_by(name: Creative::SYSTEM_TOPIC_NAME)&.id : nil
-      main_topic_id = @creative.main_topic(fallback_user: Current.user).id
+      system_topic_id = system_topic&.id
+      main_topic_id = main_topic.id
 
       render json: {
         topics: active_topics.map { |t| topic_json(t) },

--- a/engines/collavre/test/controllers/topics_controller_test.rb
+++ b/engines/collavre/test/controllers/topics_controller_test.rb
@@ -23,6 +23,30 @@ class TopicsControllerTest < ActionDispatch::IntegrationTest
     assert_equal @creative.id, json["effective_creative_id"]
   end
 
+  test "index eagerly creates System topic on first inbox visit so badge has matching topic" do
+    inbox = Collavre::Creative.inbox_for(@user)
+    inbox.topics.where(name: Collavre::Creative::SYSTEM_TOPIC_NAME).destroy_all
+
+    assert_nil inbox.topics.find_by(name: Collavre::Creative::SYSTEM_TOPIC_NAME),
+      "precondition: System topic should not exist before first visit"
+
+    get collavre.creative_topics_url(inbox), as: :json
+
+    assert_response :success
+    json = JSON.parse(response.body)
+
+    assert json["is_inbox"], "fixture must be an inbox"
+    assert json["system_topic_id"].present?, "system_topic_id must be returned"
+
+    system_topic = inbox.topics.find_by(name: Collavre::Creative::SYSTEM_TOPIC_NAME)
+    assert system_topic.present?, "System topic must be created by index"
+    assert_equal system_topic.id, json["system_topic_id"]
+
+    topic_ids = json["topics"].map { |t| t["id"] }
+    assert_includes topic_ids, system_topic.id,
+      "active topics list must include the System topic so the sidebar can render it"
+  end
+
   test "should create topic and broadcast" do
     assert_difference("Topic.count") do
       post collavre.creative_topics_url(@creative), params: { topic: { name: "New Strategy" } }, as: :json


### PR DESCRIPTION
## Summary
- On the first visit to an inbox, `topics#index` used `find_by` for the System topic. Since no notification had yet created it, the JSON returned `system_topic_id: null` and the sidebar rendered without a System entry.
- When the first inbound notification later arrived, `Comment::Notifiable` created the System topic via `find_or_create_by!` and persisted the comment. `broadcast_inbox_badge` incremented the unread badge — but the previously loaded sidebar still had no System topic, so the user saw a red badge with no way to open the message.
- Fix: eagerly call `system_topic` (for inboxes) and `main_topic` BEFORE loading `active_topics`. This guarantees the sidebar always contains the topic whose id `index` returns.

## Test plan
- [x] New `topics_controller_test.rb` regression: visiting an inbox with no System topic creates one AND includes it in the returned `topics` array
- [x] Full `topics_controller_test.rb` suite passes (24 runs, 94 assertions, 0 failures)

Refs: Creative #11403