### PR TITLE
feat(collavre): Phase 2 OmniAuth — DB-backed Google/GitHub/Notion OAuth keys

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,11 +1,46 @@
 require_relative "../../lib/omniauth/strategies/notion"
 
-google_client_id = ENV["GOOGLE_CLIENT_ID"] || Rails.application.credentials.dig(:google, :client_id)
-google_client_secret = ENV["GOOGLE_CLIENT_SECRET"] || Rails.application.credentials.dig(:google, :client_secret)
-github_client_id = ENV["GITHUB_CLIENT_ID"] || Rails.application.credentials.dig(:github, :client_id)
-github_client_secret = ENV["GITHUB_CLIENT_SECRET"] || Rails.application.credentials.dig(:github, :client_secret)
-notion_client_id = ENV["NOTION_CLIENT_ID"] || Rails.application.credentials.dig(:notion, :client_id)
-notion_client_secret = ENV["NOTION_CLIENT_SECRET"] || Rails.application.credentials.dig(:notion, :client_secret)
+# Register OAuth keys with the IntegrationSettings registry so the admin UI
+# can surface them and `Collavre::IntegrationSettings::Resolver` can serve
+# values via the DB > ENV > default precedence. Registered eagerly (not in
+# `to_prepare`) because the middleware below resolves values at boot.
+if defined?(Collavre::IntegrationSettings::Registry)
+  registry = Collavre::IntegrationSettings::Registry.instance
+  registry.register(:google_client_id,     category: "google_oauth", sensitive: false, requires_restart: true)
+  registry.register(:google_client_secret, category: "google_oauth", sensitive: true,  requires_restart: true)
+  registry.register(:github_client_id,     category: "github_oauth", sensitive: false, requires_restart: true)
+  registry.register(:github_client_secret, category: "github_oauth", sensitive: true,  requires_restart: true)
+  registry.register(:notion_client_id,     category: "notion_oauth", sensitive: false, requires_restart: true)
+  registry.register(:notion_client_secret, category: "notion_oauth", sensitive: true,  requires_restart: true)
+end
+
+resolve_oauth = lambda do |key, credentials_path|
+  resolver_value =
+    if defined?(Collavre::IntegrationSettings::Resolver)
+      begin
+        Collavre::IntegrationSettings::Resolver.get(key)
+      rescue ActiveRecord::StatementInvalid,
+             ActiveRecord::NoDatabaseError,
+             ActiveRecord::ConnectionNotEstablished,
+             NameError
+        # DB not ready or model not yet autoloaded — fall back to ENV. The
+        # registered `requires_restart` flag is still honoured: after the next
+        # boot, the model is loaded and Resolver picks up DB values.
+        ENV[key.to_s.upcase]
+      end
+    else
+      ENV[key.to_s.upcase]
+    end
+
+  resolver_value.presence || Rails.application.credentials.dig(*credentials_path)
+end
+
+google_client_id     = resolve_oauth.call(:google_client_id,     %i[google client_id])
+google_client_secret = resolve_oauth.call(:google_client_secret, %i[google client_secret])
+github_client_id     = resolve_oauth.call(:github_client_id,     %i[github client_id])
+github_client_secret = resolve_oauth.call(:github_client_secret, %i[github client_secret])
+notion_client_id     = resolve_oauth.call(:notion_client_id,     %i[notion client_id])
+notion_client_secret = resolve_oauth.call(:notion_client_secret, %i[notion client_secret])
 
 github_mock_enabled = if ENV.key?("GITHUB_MOCK")
                         ENV["GITHUB_MOCK"] == "1"

--- a/engines/collavre/app/services/collavre/google_calendar_service.rb
+++ b/engines/collavre/app/services/collavre/google_calendar_service.rb
@@ -110,8 +110,10 @@ module Collavre
       raise GoogleCalendarError, I18n.t("collavre.google_calendar.errors.not_connected") if token.blank?
 
       Google::Auth::UserRefreshCredentials.new(
-        client_id:     ENV["GOOGLE_CLIENT_ID"] || Rails.application.credentials.dig(:google, :client_id),
-        client_secret: ENV["GOOGLE_CLIENT_SECRET"] || Rails.application.credentials.dig(:google, :client_secret),
+        client_id:     Collavre::IntegrationSettings::Resolver.get(:google_client_id).presence ||
+                       Rails.application.credentials.dig(:google, :client_id),
+        client_secret: Collavre::IntegrationSettings::Resolver.get(:google_client_secret).presence ||
+                       Rails.application.credentials.dig(:google, :client_secret),
         scope:         [ Google::Apis::CalendarV3::AUTH_CALENDAR_APP_CREATED ],
         refresh_token: token
       ).tap(&:fetch_access_token!)

--- a/engines/collavre/lib/collavre/integration_settings/resolver.rb
+++ b/engines/collavre/lib/collavre/integration_settings/resolver.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 module Collavre
-  module IntegrationSettings
+  module ::Collavre::IntegrationSettings
     # Resolves the live value for a registered integration setting key.
     #
     # Precedence: **DB > ENV > registered default.**
-    # - DB value wins as long as an `IntegrationSetting` row exists with a
-    #   non-blank value (encrypted at rest via `IntegrationSetting`).
+    # - DB value wins as long as an `::Collavre::IntegrationSetting` row exists with a
+    #   non-blank value (encrypted at rest via `::Collavre::IntegrationSetting`).
     # - ENV is consulted only when no DB row exists.
     # - The registry's static default is the final fallback.
     #
@@ -16,7 +16,7 @@ module Collavre
     #   would persist decrypted secrets outside the encrypted `value` column
     #   and defeat at-rest encryption. Sensitive reads hit the DB every time.
     # - **Non-sensitive** definitions are memoized in `Rails.cache` for 5
-    #   minutes under `IntegrationSetting.cache_key_for(key)`. The model's
+    #   minutes under `::Collavre::IntegrationSetting.cache_key_for(key)`. The model's
     #   `after_commit` hook invalidates this key on any write.
     class Resolver
       # Raised by {.get} when the key has not been registered.
@@ -36,7 +36,7 @@ module Collavre
 
           return resolve(definition) if definition.sensitive
 
-          Rails.cache.fetch(IntegrationSetting.cache_key_for(definition.key), expires_in: CACHE_TTL) do
+          Rails.cache.fetch(::Collavre::IntegrationSetting.cache_key_for(definition.key), expires_in: CACHE_TTL) do
             resolve(definition)
           end
         end
@@ -47,7 +47,7 @@ module Collavre
         # @return [Symbol] one of `:db`, `:env`, `:default`, or `:unknown`
         def source_for(key)
           definition = Registry.instance.find(key) or return :unknown
-          return :db  if IntegrationSetting.find_by(key: definition.key)&.value.present?
+          return :db  if ::Collavre::IntegrationSetting.find_by(key: definition.key)&.value.present?
           return :env if ENV[definition.env_var].present?
           :default
         end
@@ -59,7 +59,7 @@ module Collavre
         end
 
         def db_value(definition)
-          IntegrationSetting.find_by(key: definition.key)&.value.presence
+          ::Collavre::IntegrationSetting.find_by(key: definition.key)&.value.presence
         end
 
         def env_value(definition)

--- a/engines/collavre_github/app/services/collavre_github/client.rb
+++ b/engines/collavre_github/app/services/collavre_github/client.rb
@@ -167,7 +167,14 @@ module CollavreGithub
     def resolve_api_endpoint
       return ENV["GITHUB_API_ENDPOINT"] if ENV["GITHUB_API_ENDPOINT"].present?
 
-      if Rails.env.development? && ENV["GITHUB_CLIENT_ID"].blank?
+      github_client_id =
+        if defined?(Collavre::IntegrationSettings::Resolver)
+          Collavre::IntegrationSettings::Resolver.get(:github_client_id).presence
+        else
+          ENV["GITHUB_CLIENT_ID"].presence
+        end
+
+      if Rails.env.development? && github_client_id.blank?
         MOCK_SERVER_DEFAULT
       end
     end


### PR DESCRIPTION
## Summary
- Phase 2 follow-up to #1263 — wires Google/GitHub/Notion OAuth `client_id`+`client_secret` through `Collavre::IntegrationSettings::Resolver`.
- 6 new keys registered with the `google_oauth` / `github_oauth` / `notion_oauth` categories (already in i18n from Phase 1 prep).
- Consumer updates: `Collavre::GoogleCalendarService#user_credentials` and `CollavreGithub::Client#resolve_api_endpoint` now resolve via the DB > ENV > credentials chain.
- Bug fix: `Resolver` used a bare `IntegrationSetting` reference that could fail to autoload from initializer contexts — re-namespaced to `::Collavre::IntegrationSetting`.

## Why eager registration in `omniauth.rb`
The OmniAuth middleware is built at boot, so values must resolve immediately. The `resolve_oauth` lambda rescues `ActiveRecord::*` and `NameError` to fall back to ENV/credentials if the DB/model isn't ready, then a server restart (already required by all OAuth keys) picks up DB values.

## Test plan
- [x] `bundle exec rails test engines/collavre/test/lib/collavre/integration_settings engines/collavre/test/models/collavre/integration_setting_test.rb engines/collavre/test/controllers/admin_integrations_controller_test.rb engines/collavre/test/integration/google_auth_test.rb` — 23 runs / 0 failures
- [ ] Preview: visit `/admin/integrations` — 3 new category cards (Google OAuth / GitHub OAuth / Notion OAuth) each with `client_id`+`client_secret`
- [ ] Set a DB value → save → restart → confirm Resolver picks it up
- [ ] OAuth login flow still works (Google, GitHub) with existing ENV values

Preview: http://macbook-pro.tailadceed.ts.net:4221