### PR TITLE
feat(collavre): Phase 2 GitHub — DB-backed webhook secret, API endpoint, mock toggle

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -45,9 +45,9 @@ notion_client_secret = resolve_oauth.call(:notion_client_secret, %i[notion clien
 github_mock_setting = resolve_oauth.call(:github_mock, %i[github mock])
 github_mock_enabled = if github_mock_setting.present?
                         github_mock_setting == "1"
-                      else
+else
                         Rails.env.development? && github_client_id.blank?
-                      end
+end
 
 Rails.application.config.middleware.use OmniAuth::Builder do
   if google_client_id.present? && google_client_secret.present?

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -42,11 +42,12 @@ github_client_secret = resolve_oauth.call(:github_client_secret, %i[github clien
 notion_client_id     = resolve_oauth.call(:notion_client_id,     %i[notion client_id])
 notion_client_secret = resolve_oauth.call(:notion_client_secret, %i[notion client_secret])
 
-github_mock_enabled = if ENV.key?("GITHUB_MOCK")
-                        ENV["GITHUB_MOCK"] == "1"
-else
+github_mock_setting = resolve_oauth.call(:github_mock, %i[github mock])
+github_mock_enabled = if github_mock_setting.present?
+                        github_mock_setting == "1"
+                      else
                         Rails.env.development? && github_client_id.blank?
-end
+                      end
 
 Rails.application.config.middleware.use OmniAuth::Builder do
   if google_client_id.present? && google_client_secret.present?

--- a/engines/collavre/config/locales/integrations.en.yml
+++ b/engines/collavre/config/locales/integrations.en.yml
@@ -25,6 +25,7 @@ en:
           google_oauth: "Google OAuth"
           github_oauth: "GitHub OAuth"
           notion_oauth: "Notion OAuth"
+          github: "GitHub Integration"
           aws_s3: "AWS S3"
           aws_ses: "AWS SES"
           firebase: "Firebase"

--- a/engines/collavre/config/locales/integrations.ko.yml
+++ b/engines/collavre/config/locales/integrations.ko.yml
@@ -25,6 +25,7 @@ ko:
           google_oauth: "Google OAuth"
           github_oauth: "GitHub OAuth"
           notion_oauth: "Notion OAuth"
+          github: "GitHub 연동"
           aws_s3: "AWS S3"
           aws_ses: "AWS SES"
           firebase: "Firebase"

--- a/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
+++ b/engines/collavre_github/app/controllers/collavre_github/webhooks_controller.rb
@@ -470,7 +470,11 @@ module CollavreGithub
     end
 
     def fallback_webhook_secret
-      ENV["GITHUB_WEBHOOK_SECRET"] || Rails.application.credentials.dig(:github, :webhook_secret)
+      resolved =
+        if defined?(Collavre::IntegrationSettings::Resolver)
+          Collavre::IntegrationSettings::Resolver.get(:github_webhook_secret).presence
+        end
+      resolved || ENV["GITHUB_WEBHOOK_SECRET"] || Rails.application.credentials.dig(:github, :webhook_secret)
     end
 
     def parse_payload(raw_body)

--- a/engines/collavre_github/app/services/collavre_github/client.rb
+++ b/engines/collavre_github/app/services/collavre_github/client.rb
@@ -162,10 +162,17 @@ module CollavreGithub
 
     attr_reader :client
 
-    # Use GITHUB_API_ENDPOINT env var if set, otherwise fall back to mock server
-    # in development when no real GitHub credentials are configured.
+    # Resolve the API endpoint via Resolver (DB > ENV), otherwise fall back to
+    # the mock server in development when no real GitHub credentials are
+    # configured.
     def resolve_api_endpoint
-      return ENV["GITHUB_API_ENDPOINT"] if ENV["GITHUB_API_ENDPOINT"].present?
+      endpoint =
+        if defined?(Collavre::IntegrationSettings::Resolver)
+          Collavre::IntegrationSettings::Resolver.get(:github_api_endpoint).presence
+        else
+          ENV["GITHUB_API_ENDPOINT"].presence
+        end
+      return endpoint if endpoint.present?
 
       github_client_id =
         if defined?(Collavre::IntegrationSettings::Resolver)

--- a/engines/collavre_github/config/initializers/integration_settings.rb
+++ b/engines/collavre_github/config/initializers/integration_settings.rb
@@ -1,0 +1,11 @@
+# Register collavre_github integration setting keys with the central registry.
+# Registered eagerly (not in `to_prepare`) because `github_mock` is read at
+# boot by `config/initializers/omniauth.rb`. The other keys (`webhook_secret`,
+# `api_endpoint`) are resolved per request and don't strictly need eager
+# registration, but we keep them together for clarity.
+if defined?(Collavre::IntegrationSettings::Registry)
+  registry = Collavre::IntegrationSettings::Registry.instance
+  registry.register(:github_webhook_secret, category: "github", sensitive: true,  requires_restart: false)
+  registry.register(:github_api_endpoint,   category: "github", sensitive: false, requires_restart: false)
+  registry.register(:github_mock,           category: "github", sensitive: false, requires_restart: true)
+end


### PR DESCRIPTION
## Summary

Phase 2 (category: `github`) of DB-backed integration settings. Wires three GitHub keys through the IntegrationSettings registry so they can be managed from `/admin/integrations`.

| Key | Sensitive | Restart | Used by |
|---|---|---|---|
| `github_webhook_secret` | ✓ | — | `WebhooksController#fallback_webhook_secret` |
| `github_api_endpoint` | — | — | `CollavreGithub::Client#resolve_api_endpoint` |
| `github_mock` | — | ✓ | `config/initializers/omniauth.rb` (mock OmniAuth provider) |

Eager registration (not `to_prepare`) because `github_mock` is read at boot by `omniauth.rb`.

ENV fallback preserved at every consumer site — drop-in safe.

## Test plan

- [x] `bin/rails test engines/collavre/test/lib/collavre/integration_settings/ engines/collavre/test/controllers/admin_integrations_controller_test.rb` — 19 runs / 56 assertions / 0 failures
- [x] `bin/rails test engines/collavre_github/test/controllers/collavre_github/webhooks_controller_channels_test.rb` — 9 runs / 32 assertions / 0 failures
- [ ] Preview check `/admin/integrations`: `GitHub Integration` category present with 3 keys, English/Korean labels render, masking + source badges render
- [ ] Reset action removes DB row, source flips back to ENV

## Refs

- Builds on #1263 (Phase 1: Slack)
- Builds on #1265 (Phase 2: OmniAuth)
- Spec: `docs/superpowers/plans/2026-05-29-env-db-settings.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)