### PR TITLE
feat(collavre): Phase 3 batch — DB-backed firebase/fcm/llm/openclaw/mail/misc settings

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -53,14 +53,14 @@ class ApplicationController < ActionController::Base
   def verify_cloudfront_origin!
     return if skip_cloudfront_verification?
 
-    unless request.headers["X-Origin-Secret"] == ENV["ORIGIN_SHARED_SECRET"]
+    unless request.headers["X-Origin-Secret"] == Collavre::IntegrationSettings.fetch(:origin_shared_secret)
       head :forbidden
     end
   end
 
   def skip_cloudfront_verification?
     return false if request.headers["X-Origin-Secret"].present?
-    return true if ENV["ORIGIN_SHARED_SECRET"].blank?
+    return true if Collavre::IntegrationSettings.fetch(:origin_shared_secret).blank?
 
     # health checks, internal callbacks, etc.
     request.path.start_with?("/up") || request.path.start_with?("/health")

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,5 +1,5 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: ENV.fetch("DEFAULT_MAILER_FROM", "no-reply@example.com")
+  default from: -> { Collavre::IntegrationSettings.fetch(:default_mailer_from, default: "no-reply@example.com") }
   layout "mailer"
 
   private

--- a/config/initializers/fcm.rb
+++ b/config/initializers/fcm.rb
@@ -2,12 +2,20 @@
 # surface them and `Collavre::IntegrationSettings::Resolver` can serve values
 # via the DB > ENV > credentials precedence. Registered eagerly because the
 # FCM client is wired into `Rails.application.config.x.*` at boot.
+#
+# Firebase keys are also registered here defensively: this initializer (`fcm.rb`)
+# loads before `firebase_config.rb` alphabetically, so without these guards
+# `IntegrationSettings.fetch(:firebase_*)` would raise `UnknownKeyError` and the
+# helper would swallow it to nil — losing the ENV fallback. `register` is
+# idempotent (last write wins), so `firebase_config.rb` re-registering is safe.
 if defined?(Collavre::IntegrationSettings::Registry)
   registry = Collavre::IntegrationSettings::Registry.instance
   registry.register(:fcm_server_key,                  category: "fcm", sensitive: true,  requires_restart: true)
   registry.register(:fcm_sender_id,                   category: "fcm", sensitive: false, requires_restart: true)
   registry.register(:fcm_vapid_key,                   category: "fcm", sensitive: true,  requires_restart: true)
   registry.register(:google_application_credentials,  category: "fcm", sensitive: true,  requires_restart: true)
+  registry.register(:firebase_project_id,             category: "firebase", sensitive: false, requires_restart: true)
+  registry.register(:firebase_service_account,        category: "firebase", sensitive: true,  requires_restart: true)
 end
 
 resolve = ->(key, credentials_path) {
@@ -18,11 +26,16 @@ resolve = ->(key, credentials_path) {
 server_key      = resolve.call(:fcm_server_key,                 %i[fcm server_key])
 project_id      = resolve.call(:firebase_project_id,            %i[firebase project_id])
 project_number  = resolve.call(:fcm_sender_id,                  %i[fcm sender_id])
-service_account = resolve.call(:firebase_service_account,       %i[firebase service_account])
+service_account = resolve.call(:firebase_service_account,       %i[fcm service_account])
 
 # Use service account JSON for local development
 FCM_CREDENTIALS = resolve.call(:google_application_credentials, %i[fcm google_application_credentials])
 if FCM_CREDENTIALS.present? && File.exist?(FCM_CREDENTIALS)
+
+  # `Google::Auth.get_application_default` reads `ENV["GOOGLE_APPLICATION_CREDENTIALS"]`,
+  # so when the path came from DB-only configuration we must export it before the
+  # ADC lookup — otherwise the file-exists check passes but ADC ignores the path.
+  ENV["GOOGLE_APPLICATION_CREDENTIALS"] ||= FCM_CREDENTIALS
 
   # Use default application credentials (reads from GOOGLE_APPLICATION_CREDENTIALS env var)
   credentials = Google::Auth.get_application_default(

--- a/config/initializers/fcm.rb
+++ b/config/initializers/fcm.rb
@@ -33,9 +33,10 @@ FCM_CREDENTIALS = resolve.call(:google_application_credentials, %i[fcm google_ap
 if FCM_CREDENTIALS.present? && File.exist?(FCM_CREDENTIALS)
 
   # `Google::Auth.get_application_default` reads `ENV["GOOGLE_APPLICATION_CREDENTIALS"]`,
-  # so when the path came from DB-only configuration we must export it before the
-  # ADC lookup — otherwise the file-exists check passes but ADC ignores the path.
-  ENV["GOOGLE_APPLICATION_CREDENTIALS"] ||= FCM_CREDENTIALS
+  # so we must export the resolved path before the ADC lookup. Overwrite
+  # unconditionally — `resolve` already applied DB > ENV precedence, so any
+  # pre-existing ENV value lost that race and must not leak back into ADC.
+  ENV["GOOGLE_APPLICATION_CREDENTIALS"] = FCM_CREDENTIALS
 
   # Use default application credentials (reads from GOOGLE_APPLICATION_CREDENTIALS env var)
   credentials = Google::Auth.get_application_default(

--- a/config/initializers/fcm.rb
+++ b/config/initializers/fcm.rb
@@ -1,10 +1,27 @@
-server_key = ENV["FCM_SERVER_KEY"] || Rails.application.credentials.dig(:fcm, :server_key)
-project_id = ENV["FIREBASE_PROJECT_ID"] || Rails.application.credentials.dig(:firebase, :project_id)
-project_number = ENV["FCM_SENDER_ID"] || Rails.application.credentials.dig(:fcm, :sender_id)
-service_account = ENV["FIREBASE_SERVICE_ACCOUNT"] || Rails.application.credentials.dig(:fcm, :service_account)
+# Register FCM keys with the IntegrationSettings registry so the admin UI can
+# surface them and `Collavre::IntegrationSettings::Resolver` can serve values
+# via the DB > ENV > credentials precedence. Registered eagerly because the
+# FCM client is wired into `Rails.application.config.x.*` at boot.
+if defined?(Collavre::IntegrationSettings::Registry)
+  registry = Collavre::IntegrationSettings::Registry.instance
+  registry.register(:fcm_server_key,                  category: "fcm", sensitive: true,  requires_restart: true)
+  registry.register(:fcm_sender_id,                   category: "fcm", sensitive: false, requires_restart: true)
+  registry.register(:fcm_vapid_key,                   category: "fcm", sensitive: true,  requires_restart: true)
+  registry.register(:google_application_credentials,  category: "fcm", sensitive: true,  requires_restart: true)
+end
+
+resolve = ->(key, credentials_path) {
+  value = Collavre::IntegrationSettings.fetch(key)
+  value.presence || Rails.application.credentials.dig(*credentials_path)
+}
+
+server_key      = resolve.call(:fcm_server_key,                 %i[fcm server_key])
+project_id      = resolve.call(:firebase_project_id,            %i[firebase project_id])
+project_number  = resolve.call(:fcm_sender_id,                  %i[fcm sender_id])
+service_account = resolve.call(:firebase_service_account,       %i[firebase service_account])
 
 # Use service account JSON for local development
-FCM_CREDENTIALS = ENV["GOOGLE_APPLICATION_CREDENTIALS"]
+FCM_CREDENTIALS = resolve.call(:google_application_credentials, %i[fcm google_application_credentials])
 if FCM_CREDENTIALS.present? && File.exist?(FCM_CREDENTIALS)
 
   # Use default application credentials (reads from GOOGLE_APPLICATION_CREDENTIALS env var)

--- a/config/initializers/firebase_config.rb
+++ b/config/initializers/firebase_config.rb
@@ -1,10 +1,28 @@
+# Register Firebase keys with the IntegrationSettings registry so the admin UI
+# can surface them and `Collavre::IntegrationSettings::Resolver` can serve
+# values via the DB > ENV > credentials precedence. Registered eagerly because
+# the JS config is built at boot.
+if defined?(Collavre::IntegrationSettings::Registry)
+  registry = Collavre::IntegrationSettings::Registry.instance
+  registry.register(:firebase_api_key,         category: "firebase", sensitive: true,  requires_restart: true)
+  registry.register(:firebase_auth_domain,     category: "firebase", sensitive: false, requires_restart: true)
+  registry.register(:firebase_project_id,      category: "firebase", sensitive: false, requires_restart: true)
+  registry.register(:firebase_app_id,          category: "firebase", sensitive: false, requires_restart: true)
+  registry.register(:firebase_service_account, category: "firebase", sensitive: true,  requires_restart: true)
+end
+
+resolve = ->(key, credentials_path) {
+  value = Collavre::IntegrationSettings.fetch(key)
+  value.presence || Rails.application.credentials.dig(*credentials_path)
+}
+
 firebase_settings = {
-  apiKey: ENV["FIREBASE_API_KEY"] || Rails.application.credentials.dig(:firebase, :api_key),
-  authDomain: ENV["FIREBASE_AUTH_DOMAIN"] || Rails.application.credentials.dig(:firebase, :auth_domain),
-  projectId: ENV["FIREBASE_PROJECT_ID"] || Rails.application.credentials.dig(:firebase, :project_id),
-  appId: ENV["FIREBASE_APP_ID"] || Rails.application.credentials.dig(:firebase, :app_id),
-  messagingSenderId: ENV["FCM_SENDER_ID"] || Rails.application.credentials.dig(:fcm, :sender_id),
-  vapidKey: ENV["FCM_VAPID_KEY"] || Rails.application.credentials.dig(:fcm, :vapid_key)
+  apiKey: resolve.call(:firebase_api_key,     %i[firebase api_key]),
+  authDomain: resolve.call(:firebase_auth_domain, %i[firebase auth_domain]),
+  projectId: resolve.call(:firebase_project_id,  %i[firebase project_id]),
+  appId: resolve.call(:firebase_app_id,       %i[firebase app_id]),
+  messagingSenderId: resolve.call(:fcm_sender_id, %i[fcm sender_id]),
+  vapidKey: resolve.call(:fcm_vapid_key,      %i[fcm vapid_key])
 }.compact
 
 Rails.application.config.x.firebase_config = firebase_settings if firebase_settings.present?

--- a/config/initializers/integration_settings_app.rb
+++ b/config/initializers/integration_settings_app.rb
@@ -1,0 +1,20 @@
+# Register app-level (mailer, host, misc) integration setting keys with the
+# central registry. Registered eagerly because consumers read these at boot or
+# lazily through `Collavre::IntegrationSettings.fetch`.
+#
+# Keys whose values must be present BEFORE this initializer runs (notably
+# `default_url_host` consumed by `config/application.rb`) carry
+# `requires_restart: true` and continue to read from ENV directly in
+# application.rb — the DB value is picked up on the next boot.
+if defined?(Collavre::IntegrationSettings::Registry)
+  registry = Collavre::IntegrationSettings::Registry.instance
+  # mailer/host
+  registry.register(:default_mailer_from,  category: "mail", sensitive: false, requires_restart: true)
+  registry.register(:default_url_host,     category: "mail", sensitive: false, requires_restart: true)
+  registry.register(:app_host,             category: "mail", sensitive: false, requires_restart: false)
+  registry.register(:rails_host,           category: "mail", sensitive: false, requires_restart: false)
+  registry.register(:public_assets_host,   category: "mail", sensitive: false, requires_restart: false)
+  # misc
+  registry.register(:origin_shared_secret, category: "misc", sensitive: true,  requires_restart: false)
+  registry.register(:mcp_upload_root,      category: "misc", sensitive: false, requires_restart: false)
+end

--- a/config/initializers/integration_settings_app.rb
+++ b/config/initializers/integration_settings_app.rb
@@ -1,20 +1,35 @@
-# Register app-level (mailer, host, misc) integration setting keys with the
-# central registry. Registered eagerly because consumers read these at boot or
-# lazily through `Collavre::IntegrationSettings.fetch`.
+# Register app-level integration setting keys with the central registry and
+# wire the keys whose effective values must be (re)applied on every boot.
 #
-# Keys whose values must be present BEFORE this initializer runs (notably
-# `default_url_host` consumed by `config/application.rb`) carry
-# `requires_restart: true` and continue to read from ENV directly in
-# application.rb — the DB value is picked up on the next boot.
+# Engine-internal keys (`:default_mailer_from`, `:public_assets_host`,
+# `:mcp_upload_root`) are registered inside `Collavre::Engine` itself so they
+# remain owned by the engine when it is mounted as a gem in a host app.
+#
+# `:default_url_host` carries `requires_restart: true` because its primary
+# read site (`config/application.rb`) executes before initializers; the wiring
+# block below applies the DB value to mailer/controller/route URL options on
+# the *next* boot so admins can change the host via `/admin/integrations`
+# without redeploying.
 if defined?(Collavre::IntegrationSettings::Registry)
   registry = Collavre::IntegrationSettings::Registry.instance
-  # mailer/host
-  registry.register(:default_mailer_from,  category: "mail", sensitive: false, requires_restart: true)
-  registry.register(:default_url_host,     category: "mail", sensitive: false, requires_restart: true)
-  registry.register(:app_host,             category: "mail", sensitive: false, requires_restart: false)
-  registry.register(:rails_host,           category: "mail", sensitive: false, requires_restart: false)
-  registry.register(:public_assets_host,   category: "mail", sensitive: false, requires_restart: false)
-  # misc
-  registry.register(:origin_shared_secret, category: "misc", sensitive: true,  requires_restart: false)
-  registry.register(:mcp_upload_root,      category: "misc", sensitive: false, requires_restart: false)
+  registry.register(:default_url_host, category: "mail", sensitive: false, requires_restart: true)
+  registry.register(:app_host,         category: "mail", sensitive: false, requires_restart: false)
+  registry.register(:rails_host,       category: "mail", sensitive: false, requires_restart: false)
+  registry.register(:origin_shared_secret, category: "misc", sensitive: true, requires_restart: false)
+end
+
+# Apply DB-backed `default_url_host` (if set in admin UI) over the defaults
+# established in `config/application.rb`. Skipped in `test` to match the host
+# guard in `application.rb` (avoids OpenRedirect mismatches in request specs).
+unless Rails.env.test? || !defined?(Collavre::IntegrationSettings)
+  db_host = Collavre::IntegrationSettings.fetch(:default_url_host)
+  if db_host.present?
+    Rails.application.config.action_mailer.default_url_options ||= {}
+    Rails.application.config.action_controller.default_url_options ||= {}
+    Rails.application.config.action_mailer.default_url_options[:host] = db_host
+    Rails.application.config.action_controller.default_url_options[:host] = db_host
+    Rails.application.config.after_initialize do
+      Rails.application.routes.default_url_options[:host] = db_host
+    end
+  end
 end

--- a/config/initializers/integration_settings_app.rb
+++ b/config/initializers/integration_settings_app.rb
@@ -1,9 +1,10 @@
 # Register app-level integration setting keys with the central registry and
 # wire the keys whose effective values must be (re)applied on every boot.
 #
-# Engine-internal keys (`:default_mailer_from`, `:public_assets_host`,
-# `:mcp_upload_root`) are registered inside `Collavre::Engine` itself so they
-# remain owned by the engine when it is mounted as a gem in a host app.
+# Engine-owned keys live in each engine's `Engine` class so they remain
+# registered when an engine is mounted as a gem in a host app:
+#   - `Collavre::Engine` → `:default_mailer_from`, `:public_assets_host`, `:mcp_upload_root`
+#   - `CollavreOpenclaw::Engine` → `:app_host`, `:rails_host`
 #
 # `:default_url_host` carries `requires_restart: true` because its primary
 # read site (`config/application.rb`) executes before initializers; the wiring
@@ -13,8 +14,6 @@
 if defined?(Collavre::IntegrationSettings::Registry)
   registry = Collavre::IntegrationSettings::Registry.instance
   registry.register(:default_url_host, category: "mail", sensitive: false, requires_restart: true)
-  registry.register(:app_host,         category: "mail", sensitive: false, requires_restart: false)
-  registry.register(:rails_host,       category: "mail", sensitive: false, requires_restart: false)
   registry.register(:origin_shared_secret, category: "misc", sensitive: true, requires_restart: false)
 end
 

--- a/config/initializers/ruby_llm.rb
+++ b/config/initializers/ruby_llm.rb
@@ -2,17 +2,9 @@
 
 return unless defined?(RubyLLM)
 
-# Register LLM API keys with the IntegrationSettings registry so the admin UI
-# can surface them and `Collavre::IntegrationSettings::Resolver` can serve
-# values via the DB > ENV > default precedence. Registered eagerly because
-# RubyLLM is configured at boot below.
-if defined?(Collavre::IntegrationSettings::Registry)
-  registry = Collavre::IntegrationSettings::Registry.instance
-  registry.register(:gemini_api_key,    category: "llm", sensitive: true,  requires_restart: true)
-  registry.register(:openai_api_key,    category: "llm", sensitive: true,  requires_restart: false)
-  registry.register(:anthropic_api_key, category: "llm", sensitive: true,  requires_restart: false)
-  registry.register(:gemini_api_base,   category: "llm", sensitive: false, requires_restart: true)
-end
+# LLM API keys are registered by `Collavre::Engine` so the registry is
+# populated even when the engine is mounted as a gem without this app-level
+# initializer. Resolver here serves values via DB > ENV > default.
 
 RubyLLM.configure do |config|
   config.gemini_api_key = Collavre::IntegrationSettings.fetch(:gemini_api_key)

--- a/config/initializers/ruby_llm.rb
+++ b/config/initializers/ruby_llm.rb
@@ -2,11 +2,22 @@
 
 return unless defined?(RubyLLM)
 
+# Register LLM API keys with the IntegrationSettings registry so the admin UI
+# can surface them and `Collavre::IntegrationSettings::Resolver` can serve
+# values via the DB > ENV > default precedence. Registered eagerly because
+# RubyLLM is configured at boot below.
+if defined?(Collavre::IntegrationSettings::Registry)
+  registry = Collavre::IntegrationSettings::Registry.instance
+  registry.register(:gemini_api_key,    category: "llm", sensitive: true,  requires_restart: true)
+  registry.register(:openai_api_key,    category: "llm", sensitive: true,  requires_restart: false)
+  registry.register(:anthropic_api_key, category: "llm", sensitive: true,  requires_restart: false)
+  registry.register(:gemini_api_base,   category: "llm", sensitive: false, requires_restart: true)
+end
+
 RubyLLM.configure do |config|
-  config.gemini_api_key = ENV["GEMINI_API_KEY"]
-  if ENV["GEMINI_API_BASE"].present?
-    config.gemini_api_base = ENV["GEMINI_API_BASE"]
-  end
+  config.gemini_api_key = Collavre::IntegrationSettings.fetch(:gemini_api_key)
+  gemini_api_base = Collavre::IntegrationSettings.fetch(:gemini_api_base)
+  config.gemini_api_base = gemini_api_base if gemini_api_base.present?
   config.request_timeout = begin
     Collavre::SystemSetting.llm_request_timeout_seconds
   rescue StandardError

--- a/engines/collavre/app/helpers/collavre/public_assets_helper.rb
+++ b/engines/collavre/app/helpers/collavre/public_assets_helper.rb
@@ -7,7 +7,7 @@ module Collavre
     # absolute; otherwise relative so the browser uses the current host.
     def public_asset_url(blob)
       path = "/public-assets/blobs/#{blob.signed_id}/#{blob.filename.sanitized}"
-      host = ENV["PUBLIC_ASSETS_HOST"].presence
+      host = Collavre::IntegrationSettings.fetch(:public_assets_host)
       host ? "#{host.chomp('/')}#{path}" : path
     end
   end

--- a/engines/collavre/app/mailers/collavre/application_mailer.rb
+++ b/engines/collavre/app/mailers/collavre/application_mailer.rb
@@ -1,6 +1,6 @@
 module Collavre
   class ApplicationMailer < ActionMailer::Base
-    default from: ENV.fetch("DEFAULT_MAILER_FROM", "no-reply@example.com")
+    default from: -> { Collavre::IntegrationSettings.fetch(:default_mailer_from, default: "no-reply@example.com") }
     layout "mailer"
 
     private

--- a/engines/collavre/app/services/collavre/ai_client.rb
+++ b/engines/collavre/app/services/collavre/ai_client.rb
@@ -113,17 +113,17 @@ module Collavre
 
       context_block = case normalized_vendor
       when "openai"
-        api_key = @llm_api_key.presence || ENV["OPENAI_API_KEY"]
+        api_key = @llm_api_key.presence || IntegrationSettings.fetch(:openai_api_key)
         base_url = @gateway_url.presence
         proc do |config|
           config.openai_api_key = api_key
           config.openai_api_base = base_url if base_url
         end
       when "anthropic"
-        api_key = @llm_api_key.presence || ENV["ANTHROPIC_API_KEY"]
+        api_key = @llm_api_key.presence || IntegrationSettings.fetch(:anthropic_api_key)
         proc { |config| config.anthropic_api_key = api_key }
       else
-        api_key = @llm_api_key.presence || ENV["GEMINI_API_KEY"]
+        api_key = @llm_api_key.presence || IntegrationSettings.fetch(:gemini_api_key)
         proc { |config| config.gemini_api_key = api_key }
       end
 

--- a/engines/collavre/app/services/collavre/tools/creative_attach_files_service.rb
+++ b/engines/collavre/app/services/collavre/tools/creative_attach_files_service.rb
@@ -80,7 +80,7 @@ module Tools
     end
 
     def self.upload_root
-      raw = ENV["MCP_UPLOAD_ROOT"].presence || Rails.root.join("tmp/mcp_uploads").to_s
+      raw = Collavre::IntegrationSettings.fetch(:mcp_upload_root, default: Rails.root.join("tmp/mcp_uploads").to_s)
       Pathname.new(File.expand_path(raw)).tap do |p|
         FileUtils.mkdir_p(p) unless p.exist?
       end.realpath

--- a/engines/collavre/config/locales/integrations.en.yml
+++ b/engines/collavre/config/locales/integrations.en.yml
@@ -31,7 +31,10 @@ en:
           firebase: "Firebase"
           fcm: "FCM"
           gemini: "Gemini"
-          mail: "Mail"
+          llm: "LLM API Keys"
+          openclaw: "OpenClaw Gateway"
+          mail: "Mail / Host"
+          misc: "Miscellaneous"
         actions:
           save: "Save changes"
           reset: "Reset to ENV"

--- a/engines/collavre/config/locales/integrations.ko.yml
+++ b/engines/collavre/config/locales/integrations.ko.yml
@@ -31,7 +31,10 @@ ko:
           firebase: "Firebase"
           fcm: "FCM"
           gemini: "Gemini"
-          mail: "메일"
+          llm: "LLM API 키"
+          openclaw: "OpenClaw 게이트웨이"
+          mail: "메일 / 호스트"
+          misc: "기타"
         actions:
           save: "변경사항 저장"
           reset: "ENV로 초기화"

--- a/engines/collavre/lib/collavre/engine.rb
+++ b/engines/collavre/lib/collavre/engine.rb
@@ -16,6 +16,21 @@ module Collavre
       root.join("app/assets/stylesheets")
     end
 
+    # Register engine-internal integration settings keys with the central
+    # registry. These keys are consumed by engine code (mailer `from`, public
+    # assets helper, MCP upload service), so the engine itself must own their
+    # registration — host apps may not include the app-level
+    # `integration_settings_app.rb` initializer when mounting the engine as a gem.
+    # `register` is idempotent, so host app re-registration remains safe.
+    initializer "collavre.integration_settings_registry", before: :load_config_initializers do
+      if defined?(Collavre::IntegrationSettings::Registry)
+        registry = Collavre::IntegrationSettings::Registry.instance
+        registry.register(:default_mailer_from, category: "mail", sensitive: false, requires_restart: true)
+        registry.register(:public_assets_host,  category: "mail", sensitive: false, requires_restart: false)
+        registry.register(:mcp_upload_root,     category: "misc", sensitive: false, requires_restart: false)
+      end
+    end
+
     # Add engine migrations to main app's migration path
     # This allows migrations to live in the engine but be run from the host app
     initializer "collavre.migrations" do |app|

--- a/engines/collavre/lib/collavre/engine.rb
+++ b/engines/collavre/lib/collavre/engine.rb
@@ -28,6 +28,13 @@ module Collavre
         registry.register(:default_mailer_from, category: "mail", sensitive: false, requires_restart: true)
         registry.register(:public_assets_host,  category: "mail", sensitive: false, requires_restart: false)
         registry.register(:mcp_upload_root,     category: "misc", sensitive: false, requires_restart: false)
+        # LLM keys consumed by Collavre::AiClient (engine service). Owned by the
+        # engine so gem-mounted host apps don't depend on the app-level
+        # `ruby_llm.rb` initializer for ENV fallback.
+        registry.register(:gemini_api_key,    category: "llm", sensitive: true,  requires_restart: true)
+        registry.register(:openai_api_key,    category: "llm", sensitive: true,  requires_restart: false)
+        registry.register(:anthropic_api_key, category: "llm", sensitive: true,  requires_restart: false)
+        registry.register(:gemini_api_base,   category: "llm", sensitive: false, requires_restart: true)
       end
     end
 

--- a/engines/collavre/lib/collavre/integration_settings.rb
+++ b/engines/collavre/lib/collavre/integration_settings.rb
@@ -11,5 +11,25 @@ require_relative "integration_settings/resolver"
 
 module Collavre
   module IntegrationSettings
+    # Resolve a registered key with a safety net for boot-time consumers.
+    # Returns `Resolver.get(key)` when the registry+DB are reachable, otherwise
+    # falls back to `ENV[key.upcase]`. After the next boot, the DB value wins —
+    # matching the `requires_restart` semantics callers register.
+    def self.fetch(key, default: nil)
+      return ENV[key.to_s.upcase].presence || default unless defined?(Resolver)
+
+      value =
+        begin
+          Resolver.get(key)
+        rescue Resolver::UnknownKeyError
+          nil
+        rescue ActiveRecord::StatementInvalid,
+               ActiveRecord::NoDatabaseError,
+               ActiveRecord::ConnectionNotEstablished,
+               NameError
+          ENV[key.to_s.upcase]
+        end
+      value.presence || default
+    end
   end
 end

--- a/engines/collavre/test/lib/collavre/integration_settings/fetch_test.rb
+++ b/engines/collavre/test/lib/collavre/integration_settings/fetch_test.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  module IntegrationSettings
+    # Boot-time consumers (initializers, mailers) call
+    # `Collavre::IntegrationSettings.fetch` rather than `Resolver.get` directly
+    # so a missing DB / unloaded model degrades gracefully to ENV without
+    # raising. These tests cover that fallback behavior.
+    class FetchTest < ActiveSupport::TestCase
+      setup do
+        @registry_snapshot = Registry.instance.instance_variable_get(:@definitions).dup
+        Registry.instance.instance_variable_set(:@definitions, {})
+        Registry.instance.register(
+          :default_mailer_from,
+          category: "mail",
+          sensitive: false,
+          env_var: "DEFAULT_MAILER_FROM",
+          default: nil
+        )
+        Rails.cache.clear
+        IntegrationSetting.delete_all
+      end
+
+      teardown do
+        Registry.instance.instance_variable_set(:@definitions, @registry_snapshot || {})
+        ENV.delete("DEFAULT_MAILER_FROM")
+        Rails.cache.clear
+      end
+
+      test "returns Resolver value when registered key has DB row" do
+        IntegrationSetting.create!(key: "default_mailer_from", value: "db@example.com", category: "mail")
+        assert_equal "db@example.com", Collavre::IntegrationSettings.fetch(:default_mailer_from)
+      end
+
+      test "returns ENV when no DB row and key is registered" do
+        ENV["DEFAULT_MAILER_FROM"] = "env@example.com"
+        assert_equal "env@example.com", Collavre::IntegrationSettings.fetch(:default_mailer_from)
+      end
+
+      test "unknown key returns nil instead of raising" do
+        assert_nil Collavre::IntegrationSettings.fetch(:not_registered)
+      end
+
+      test "default kwarg returned when value blank" do
+        assert_equal "fallback", Collavre::IntegrationSettings.fetch(:default_mailer_from, default: "fallback")
+      end
+
+      test "default kwarg used for unknown key" do
+        assert_equal "fallback", Collavre::IntegrationSettings.fetch(:not_registered, default: "fallback")
+      end
+
+      test "Resolver errors caused by missing DB fall back to ENV" do
+        ENV["DEFAULT_MAILER_FROM"] = "env-fallback@example.com"
+        Resolver.stub(:get, ->(_k) { raise ActiveRecord::NoDatabaseError, "db down" }) do
+          assert_equal "env-fallback@example.com",
+                       Collavre::IntegrationSettings.fetch(:default_mailer_from)
+        end
+      end
+    end
+  end
+end

--- a/engines/collavre/test/lib/collavre/integration_settings/fetch_test.rb
+++ b/engines/collavre/test/lib/collavre/integration_settings/fetch_test.rb
@@ -19,6 +19,7 @@ module Collavre
           env_var: "DEFAULT_MAILER_FROM",
           default: nil
         )
+        ENV.delete("DEFAULT_MAILER_FROM")
         Rails.cache.clear
         IntegrationSetting.delete_all
       end

--- a/engines/collavre_openclaw/Gemfile.lock
+++ b/engines/collavre_openclaw/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    collavre_openclaw (0.3.0)
+    collavre_openclaw (0.6.1)
       eventmachine (~> 1.2)
       faraday (>= 2.0)
       faye-websocket (~> 0.11)
@@ -95,6 +95,9 @@ GEM
       irb (~> 1.10)
       reline (>= 0.3.8)
     drb (2.2.3)
+    em-websocket (0.5.3)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0)
     erb (6.0.1)
     erubi (1.13.1)
     eventmachine (1.2.7)
@@ -109,6 +112,7 @@ GEM
       websocket-driver (>= 0.8.0)
     globalid (1.3.0)
       activesupport (>= 6.1)
+    http_parser.rb (0.8.1)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     io-console (0.8.2)
@@ -240,6 +244,7 @@ PLATFORMS
 DEPENDENCIES
   collavre_openclaw!
   debug
+  em-websocket (~> 0.5)
   minitest
   rails (>= 8.0)
 

--- a/engines/collavre_openclaw/app/services/collavre_openclaw/openclaw_adapter.rb
+++ b/engines/collavre_openclaw/app/services/collavre_openclaw/openclaw_adapter.rb
@@ -571,8 +571,8 @@ module CollavreOpenclaw
 
       host = options[:host]
       host ||= Rails.application.config.action_controller.default_url_options&.dig(:host)
-      host ||= ENV["APP_HOST"]
-      host ||= ENV["RAILS_HOST"]
+      host ||= Collavre::IntegrationSettings.fetch(:app_host)
+      host ||= Collavre::IntegrationSettings.fetch(:rails_host)
 
       result = { host: host }
       result[:protocol] = options[:protocol] || "https"

--- a/engines/collavre_openclaw/app/services/collavre_openclaw/openclaw_adapter.rb
+++ b/engines/collavre_openclaw/app/services/collavre_openclaw/openclaw_adapter.rb
@@ -571,8 +571,16 @@ module CollavreOpenclaw
 
       host = options[:host]
       host ||= Rails.application.config.action_controller.default_url_options&.dig(:host)
-      host ||= Collavre::IntegrationSettings.fetch(:app_host)
-      host ||= Collavre::IntegrationSettings.fetch(:rails_host)
+      # When the engine is mounted without core Collavre (gemspec has no `collavre`
+      # dependency), `IntegrationSettings` is undefined — fall back to the ENV
+      # path the previous code used so standalone deployments still resolve a host.
+      if defined?(Collavre::IntegrationSettings)
+        host ||= Collavre::IntegrationSettings.fetch(:app_host)
+        host ||= Collavre::IntegrationSettings.fetch(:rails_host)
+      else
+        host ||= ENV["APP_HOST"]
+        host ||= ENV["RAILS_HOST"]
+      end
 
       result = { host: host }
       result[:protocol] = options[:protocol] || "https"

--- a/engines/collavre_openclaw/config/initializers/integration_settings.rb
+++ b/engines/collavre_openclaw/config/initializers/integration_settings.rb
@@ -1,0 +1,13 @@
+# Register collavre_openclaw integration setting keys with the central registry.
+# Registered eagerly because `CollavreOpenclaw::Configuration#initialize` reads
+# them at boot via `Collavre::IntegrationSettings.fetch`.
+if defined?(Collavre::IntegrationSettings::Registry)
+  registry = Collavre::IntegrationSettings::Registry.instance
+  registry.register(:openclaw_open_timeout,        category: "openclaw", sensitive: false, requires_restart: true)
+  registry.register(:openclaw_max_retries,         category: "openclaw", sensitive: false, requires_restart: true)
+  registry.register(:openclaw_ws_idle_timeout,     category: "openclaw", sensitive: false, requires_restart: true)
+  registry.register(:openclaw_ws_reconnect_max,    category: "openclaw", sensitive: false, requires_restart: true)
+  registry.register(:openclaw_ws_reconnect_base,   category: "openclaw", sensitive: false, requires_restart: true)
+  registry.register(:openclaw_ws_connect_timeout,  category: "openclaw", sensitive: false, requires_restart: true)
+  registry.register(:openclaw_transport,           category: "openclaw", sensitive: false, requires_restart: true)
+end

--- a/engines/collavre_openclaw/lib/collavre_openclaw/configuration.rb
+++ b/engines/collavre_openclaw/lib/collavre_openclaw/configuration.rb
@@ -51,18 +51,26 @@ module CollavreOpenclaw
 
     private
 
+    def fetch_raw(key)
+      if defined?(Collavre::IntegrationSettings)
+        Collavre::IntegrationSettings.fetch(key)
+      else
+        ENV[key.to_s.upcase]
+      end
+    end
+
     def fetch_string(key, default)
-      raw = Collavre::IntegrationSettings.fetch(key)
+      raw = fetch_raw(key)
       raw.presence || default
     end
 
     def fetch_int(key, default)
-      raw = Collavre::IntegrationSettings.fetch(key)
+      raw = fetch_raw(key)
       raw.present? ? raw.to_i : default
     end
 
     def fetch_float(key, default)
-      raw = Collavre::IntegrationSettings.fetch(key)
+      raw = fetch_raw(key)
       raw.present? ? raw.to_f : default
     end
   end

--- a/engines/collavre_openclaw/lib/collavre_openclaw/configuration.rb
+++ b/engines/collavre_openclaw/lib/collavre_openclaw/configuration.rb
@@ -26,18 +26,18 @@ module CollavreOpenclaw
     attr_accessor :transport
 
     def initialize
-      @open_timeout = ENV.fetch("OPENCLAW_OPEN_TIMEOUT", 10).to_i
+      @open_timeout            = fetch_int(:openclaw_open_timeout, 10)
       @read_timeout = begin
         Collavre::SystemSetting.llm_request_timeout_seconds
       rescue StandardError
         1800
       end
-      @max_retries = ENV.fetch("OPENCLAW_MAX_RETRIES", 2).to_i
-      @ws_idle_timeout = ENV.fetch("OPENCLAW_WS_IDLE_TIMEOUT", 1800).to_i     # 30 minutes
-      @ws_reconnect_max = ENV.fetch("OPENCLAW_WS_RECONNECT_MAX", 10).to_i
-      @ws_reconnect_base_delay = ENV.fetch("OPENCLAW_WS_RECONNECT_BASE", 1).to_f
-      @ws_connect_timeout = ENV.fetch("OPENCLAW_WS_CONNECT_TIMEOUT", 10).to_i
-      @transport = ENV.fetch("OPENCLAW_TRANSPORT", "auto")
+      @max_retries             = fetch_int(:openclaw_max_retries, 2)
+      @ws_idle_timeout         = fetch_int(:openclaw_ws_idle_timeout, 1800)  # 30 minutes
+      @ws_reconnect_max        = fetch_int(:openclaw_ws_reconnect_max, 10)
+      @ws_reconnect_base_delay = fetch_float(:openclaw_ws_reconnect_base, 1)
+      @ws_connect_timeout      = fetch_int(:openclaw_ws_connect_timeout, 10)
+      @transport               = fetch_string(:openclaw_transport, "auto")
     end
 
     # Legacy accessor for backward compatibility
@@ -47,6 +47,23 @@ module CollavreOpenclaw
 
     def request_timeout=(value)
       @read_timeout = value
+    end
+
+    private
+
+    def fetch_string(key, default)
+      raw = Collavre::IntegrationSettings.fetch(key)
+      raw.presence || default
+    end
+
+    def fetch_int(key, default)
+      raw = Collavre::IntegrationSettings.fetch(key)
+      raw.present? ? raw.to_i : default
+    end
+
+    def fetch_float(key, default)
+      raw = Collavre::IntegrationSettings.fetch(key)
+      raw.present? ? raw.to_f : default
     end
   end
 end

--- a/engines/collavre_openclaw/lib/collavre_openclaw/engine.rb
+++ b/engines/collavre_openclaw/lib/collavre_openclaw/engine.rb
@@ -33,6 +33,18 @@ module CollavreOpenclaw
       end
     end
 
+    # Register host keys consumed by `OpenclawAdapter#default_url_options` so
+    # the umbrella app's `integration_settings_app.rb` initializer is not
+    # required for ENV fallback to work. `register` is idempotent — the
+    # umbrella app may re-register without conflict.
+    initializer "collavre_openclaw.integration_settings_registry", before: :load_config_initializers do
+      if defined?(Collavre::IntegrationSettings::Registry)
+        registry = Collavre::IntegrationSettings::Registry.instance
+        registry.register(:app_host,   category: "mail", sensitive: false, requires_restart: false)
+        registry.register(:rails_host, category: "mail", sensitive: false, requires_restart: false)
+      end
+    end
+
     initializer "collavre_openclaw.migrations" do |app|
       unless app.root.to_s.match?(root.to_s)
         config.paths["db/migrate"].expanded.each do |expanded_path|


### PR DESCRIPTION
## Summary

Register the remaining **27 non-AWS integration keys** with the central `IntegrationSettings::Registry` so they surface under `/admin/integrations` and follow **DB > ENV > credentials** precedence via `Resolver`. Closes the bulk of Phase 3 in one PR (per user request); AWS / `storage.yml` keys are deferred because they need separate boot-time design.

This continues the Phase 1 (Slack #1263) / Phase 2 (OmniAuth #1265, GitHub #1266) work.

## New categories (27 keys)

| Category | Keys | Notes |
|---|---|---|
| **firebase** (5) | api_key, auth_domain, project_id, app_id, service_account | boot-time, `requires_restart: true` |
| **fcm** (4) | server_key, sender_id, vapid_key, google_application_credentials | boot-time |
| **llm** (4) | gemini_api_key, openai_api_key, anthropic_api_key, gemini_api_base | RubyLLM + AiClient |
| **openclaw** (7) | open_timeout, max_retries, ws_idle_timeout, ws_reconnect_max, ws_reconnect_base, ws_connect_timeout, transport | typed int/float/string |
| **mail / host** (5) | default_mailer_from, default_url_host, app_host, rails_host, public_assets_host | lazy consumers via Resolver |
| **misc** (2) | origin_shared_secret, mcp_upload_root | runtime |

## Shared helper

Added `Collavre::IntegrationSettings.fetch(key, default:)` — wraps `Resolver.get` with graceful fallbacks for missing DB / unloaded model so initializers and mailer `default from:` lambdas can resolve safely before the DB is ready.

## Consumers wired

- `config/initializers/{firebase_config,fcm,ruby_llm}.rb`
- `Collavre::AiClient` (per-vendor API key resolution)
- `CollavreOpenclaw::Configuration` (typed `fetch_int` / `fetch_float` / `fetch_string`)
- `ApplicationMailer` + `Collavre::ApplicationMailer` `default from:` lambdas
- `PublicAssetsHelper`, `OpenclawAdapter#default_url_options`
- `ApplicationController` CloudFront origin verification (`X-Origin-Secret`)
- `creative_attach_files_service` upload root

## i18n

Added `category.{llm,openclaw,misc}` labels and broadened `mail` to "Mail / Host" in both `en` and `ko`.

## Notes / out of scope

- Boot-time consumers that run **before** initializers (e.g. `config/application.rb` `default_url_host`) keep reading ENV directly. Their keys are still registered with `requires_restart: true`, so DB values are honored at next boot.
- `LlmRequestTimeoutSeconds` continues to flow through `Collavre::SystemSetting` (separate subsystem) and is intentionally **not** migrated here.
- AWS keys (S3 + SES + region) are not registered because `config/storage.yml` makes boot-time decisions on `AWS_S3_*` that need separate design.

## Test plan

- [x] `engines/collavre/test/lib/collavre/integration_settings/` — registry + resolver tests pass
- [x] New `fetch_test.rb` — DB>ENV>default precedence, unknown-key safety, `NoDatabaseError` fallback
- [x] `engines/collavre/test/controllers/admin_integrations_controller_test.rb` — admin UI renders new categories
- [x] `engines/collavre/test/controllers/application_controller_security_test.rb` — `origin_shared_secret` consumer still gates `X-Origin-Secret`
- [x] `engines/collavre_openclaw/test/lib/configuration_test.rb` — typed `fetch_*` returns correct defaults
- [x] `rubocop` clean on all changed files
- [x] Smoke: `rails runner` reports 40 total keys across 11 categories