### PR TITLE
feat: horizontal-scroll typing/badge row with stick-to-end auto-scroll

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -1111,6 +1111,34 @@ body.chat-fullscreen {
     gap: var(--space-1);
 }
 
+/* Horizontally-scrollable viewport for channel chips + typing indicator.
+   Keeps PR/Preview badges and live typing on a single line so they never
+   wrap and push the form down. The scroll-prev button stays pinned at the
+   left because it is a flex sibling of (not inside) this viewport.
+   min-width:0 lets this flex child shrink below its content width, which is
+   what actually enables overflow scrolling. */
+#typing-scroll-viewport {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    align-items: center;
+    gap: var(--space-1);
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    overflow-y: hidden;
+    scrollbar-width: thin;
+    scroll-behavior: smooth;
+}
+
+#typing-scroll-viewport::-webkit-scrollbar {
+    height: 4px;
+}
+
+#typing-scroll-viewport::-webkit-scrollbar-thumb {
+    background: var(--border-color);
+    border-radius: var(--radius-2);
+}
+
 .scroll-prev-msg-btn {
     background: none;
     border: 1px solid var(--border-color);
@@ -1131,10 +1159,11 @@ body.chat-fullscreen {
 
 #typing-indicator {
     font-style: italic;
-    flex: 1;
+    flex: 0 0 auto;
     min-height: var(--space-px-5);
     display: flex;
     align-items: center;
+    white-space: nowrap;
 }
 
 #typing-indicator .avatar-wrapper {
@@ -1188,7 +1217,8 @@ body.chat-fullscreen {
 #channel-chips-container,
 .channel-chips {
     display: inline-flex;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
+    flex-shrink: 0;
     gap: var(--space-1);
     align-items: center;
 }

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/presence_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/presence_controller.test.js
@@ -205,4 +205,27 @@ describe('CommentsPresenceController typing-row horizontal scroll', () => {
     controller.handlePresenceMessage({ typing: { id: 5, name: 'Alice' } })
     expect(scrollLeftValue).toBe(0)
   })
+
+  test("always scrolls the local user's own new typing indicator into view, even when scrolled back to badges", () => {
+    // currentUserId is '7'. The user is parked at the left looking at PR/Preview
+    // badges (scrollLeft 0, not at end). When they themselves start typing they
+    // always want to see their own indicator, so stick-to-end must not suppress it.
+    setGeometry({ clientWidth: 100, scrollWidth: 300, scrollLeft: 0 })
+
+    controller.handlePresenceMessage({ typing: { id: 7, name: 'Me' } })
+
+    expect(scrollLeftValue).toBe(300)
+  })
+
+  test('does not re-scroll on repeat self typing pings (only the first appearance forces scroll)', () => {
+    setGeometry({ clientWidth: 100, scrollWidth: 300, scrollLeft: 0 })
+    controller.handlePresenceMessage({ typing: { id: 7, name: 'Me' } })
+    expect(scrollLeftValue).toBe(300)
+
+    // A heartbeat ping for the same (already-shown) self typer while scrolled
+    // back must not yank to the end again — only the first appearance forces it.
+    scrollLeftValue = 0
+    controller.handlePresenceMessage({ typing: { id: 7, name: 'Me' } })
+    expect(scrollLeftValue).toBe(0)
+  })
 })

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/presence_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/presence_controller.test.js
@@ -121,3 +121,88 @@ describe('CommentsPresenceController', () => {
     expect(close).not.toHaveBeenCalled()
   })
 })
+
+describe('CommentsPresenceController typing-row horizontal scroll', () => {
+  let application
+  let container
+  let controller
+  let row
+  let scrollLeftValue
+
+  // jsdom has no layout engine, so scroll geometry must be stubbed. Treat the
+  // row as 100px wide with 300px of content: "at end" means scrollLeft >= 176.
+  function setGeometry({ clientWidth, scrollWidth, scrollLeft }) {
+    scrollLeftValue = scrollLeft
+    Object.defineProperty(row, 'clientWidth', { value: clientWidth, configurable: true })
+    Object.defineProperty(row, 'scrollWidth', { value: scrollWidth, configurable: true })
+    Object.defineProperty(row, 'scrollLeft', {
+      configurable: true,
+      get: () => scrollLeftValue,
+      set: (v) => { scrollLeftValue = v },
+    })
+  }
+
+  beforeEach(async () => {
+    document.body.dataset.currentUserId = '7'
+    global.fetch = jest.fn()
+
+    container = document.createElement('div')
+    container.innerHTML = `
+      <div id="comments-popup" data-controller="comments--presence">
+        <textarea data-comments--presence-target="textarea"></textarea>
+        <input type="checkbox" data-comments--presence-target="privateCheckbox" />
+        <div id="typing-indicator-row">
+          <div id="typing-scroll-viewport" data-comments--presence-target="scrollRow">
+            <div data-comments--presence-target="channelChips"></div>
+            <div data-comments--presence-target="typingIndicator"></div>
+          </div>
+        </div>
+      </div>
+    `
+    document.body.appendChild(container)
+
+    application = Application.start()
+    application.register('comments--presence', PresenceController)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    const el = document.getElementById('comments-popup')
+    controller = application.getControllerForElementAndIdentifier(el, 'comments--presence')
+    controller.creativeId = '123'
+    row = el.querySelector('#typing-scroll-viewport')
+  })
+
+  afterEach(() => {
+    application.stop()
+    document.body.innerHTML = ''
+    delete document.body.dataset.currentUserId
+    jest.restoreAllMocks()
+  })
+
+  test('auto-scrolls a new typer into view when parked at the right edge', () => {
+    setGeometry({ clientWidth: 100, scrollWidth: 300, scrollLeft: 200 }) // at end
+
+    controller.handlePresenceMessage({ typing: { id: 5, name: 'Alice' } })
+
+    expect(scrollLeftValue).toBe(300)
+  })
+
+  test('does NOT scroll when the user has scrolled back to look at earlier items', () => {
+    setGeometry({ clientWidth: 100, scrollWidth: 300, scrollLeft: 0 }) // scrolled back
+
+    controller.handlePresenceMessage({ typing: { id: 5, name: 'Alice' } })
+
+    expect(scrollLeftValue).toBe(0)
+  })
+
+  test('does not re-scroll on repeat typing pings from the same user (not a new item)', () => {
+    setGeometry({ clientWidth: 100, scrollWidth: 300, scrollLeft: 200 })
+    controller.handlePresenceMessage({ typing: { id: 5, name: 'Alice' } })
+    expect(scrollLeftValue).toBe(300)
+
+    // User scrolls back; a heartbeat ping for the same (already-shown) typer
+    // must not yank them to the end again.
+    scrollLeftValue = 0
+    controller.handlePresenceMessage({ typing: { id: 5, name: 'Alice' } })
+    expect(scrollLeftValue).toBe(0)
+  })
+})

--- a/engines/collavre/app/javascript/controllers/comments/presence_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/presence_controller.js
@@ -7,7 +7,7 @@ const TYPING_TIMEOUT = 3000
 const AGENT_STATUS_TIMEOUT = 10000 // Safety timeout for agent_status (heartbeat expected every 3s)
 
 export default class extends Controller {
-  static targets = ['participants', 'typingIndicator', 'textarea', 'privateCheckbox', 'channelChips']
+  static targets = ['participants', 'typingIndicator', 'textarea', 'privateCheckbox', 'channelChips', 'scrollRow']
 
   connect() {
     this.creativeId = null
@@ -196,8 +196,9 @@ export default class extends Controller {
     }
     if (data.typing) {
       const { id, name } = data.typing
+      const isNewTyper = !(id in this.typingUsers)
       this.typingUsers[id] = name
-      this.renderTypingIndicator()
+      this.renderTypingIndicator({ newItem: isNewTyper })
       clearTimeout(this.typingTimers[id])
       this.typingTimers[id] = setTimeout(() => {
         delete this.typingUsers[id]
@@ -239,6 +240,7 @@ export default class extends Controller {
       if (agentCreativeId && String(agentCreativeId) !== String(this.creativeId)) {
         return
       }
+      const isNewAgent = (status === 'thinking' || status === 'streaming') && !(id in this.typingUsers)
       if (status === 'thinking' || status === 'streaming') {
         this.typingUsers[id] = name
         if (!this.activeAgentTasks) this.activeAgentTasks = {}
@@ -262,7 +264,7 @@ export default class extends Controller {
         }
       }
       this.syncGlobalAgentTasks()
-      this.renderTypingIndicator()
+      this.renderTypingIndicator({ newItem: isNewAgent })
     }
   }
 
@@ -346,8 +348,14 @@ export default class extends Controller {
   }
 
 
-  renderTypingIndicator() {
+  renderTypingIndicator({ newItem = false } = {}) {
     if (!this.hasTypingIndicatorTarget) return
+
+    // Capture stick-to-end BEFORE mutating the DOM: only auto-scroll a newly
+    // added item into view when the user was already parked at the right edge,
+    // so we never yank them away from a chip they scrolled back to look at.
+    const stickToEnd = newItem && this.isScrollRowAtEnd()
+
     this.typingIndicatorTarget.innerHTML = ''
 
     if (this.manualTypingMessage) {
@@ -413,6 +421,33 @@ export default class extends Controller {
     const text = document.createElement('span')
     text.textContent = `${names.join(', ')} ...`
     this.typingIndicatorTarget.appendChild(text)
+
+    if (stickToEnd) this.scrollRowToEnd()
+  }
+
+  // Distance (px) from the right edge still counted as "at the end". A small
+  // slack absorbs sub-pixel rounding and momentum scroll so stick-to-end stays
+  // engaged when the user is effectively, but not exactly, at the edge.
+  static STICK_TO_END_THRESHOLD = 24
+
+  get scrollRowElement() {
+    return this.hasScrollRowTarget ? this.scrollRowTarget : null
+  }
+
+  // True when the horizontal scroll row is at (or near) its right edge — i.e.
+  // the user is looking at the newest items rather than scrolled back. Returns
+  // true when there is no scroll row or no overflow (nothing to yank away from).
+  isScrollRowAtEnd() {
+    const el = this.scrollRowElement
+    if (!el) return true
+    const threshold = this.constructor.STICK_TO_END_THRESHOLD
+    return el.scrollLeft + el.clientWidth >= el.scrollWidth - threshold
+  }
+
+  scrollRowToEnd() {
+    const el = this.scrollRowElement
+    if (!el) return
+    el.scrollLeft = el.scrollWidth
   }
 
   syncGlobalAgentTasks() {
@@ -484,7 +519,16 @@ export default class extends Controller {
     })
       .then((r) => (r.ok ? r.text() : null))
       .then((html) => {
-        if (html) target.outerHTML = html
+        if (!html) return
+        // A newly attached channel (e.g. a fresh PR/Preview badge) is a "new
+        // item" in the scroll row. Count chips before/after and scroll the new
+        // one into view, but only when the user was already at the right edge.
+        const row = this.scrollRowElement
+        const prevChipCount = row ? row.querySelectorAll('.channel-chip').length : 0
+        const wasAtEnd = this.isScrollRowAtEnd()
+        target.outerHTML = html
+        const newChipCount = row ? row.querySelectorAll('.channel-chip').length : 0
+        if (wasAtEnd && newChipCount > prevChipCount) this.scrollRowToEnd()
       })
       .catch((err) => console.warn('[presence] refresh channel chips failed:', err))
   }

--- a/engines/collavre/app/javascript/controllers/comments/presence_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/presence_controller.js
@@ -197,8 +197,13 @@ export default class extends Controller {
     if (data.typing) {
       const { id, name } = data.typing
       const isNewTyper = !(id in this.typingUsers)
+      // The user always wants to see their OWN typing indicator the moment it
+      // appears — they just started typing. Stick-to-end (which pauses while the
+      // user is scrolled back looking at badges) must not suppress that, so force
+      // the scroll for the local user's first typing frame.
+      const isSelf = String(id) === String(this.currentUserId)
       this.typingUsers[id] = name
-      this.renderTypingIndicator({ newItem: isNewTyper })
+      this.renderTypingIndicator({ newItem: isNewTyper, force: isNewTyper && isSelf })
       clearTimeout(this.typingTimers[id])
       this.typingTimers[id] = setTimeout(() => {
         delete this.typingUsers[id]
@@ -348,13 +353,15 @@ export default class extends Controller {
   }
 
 
-  renderTypingIndicator({ newItem = false } = {}) {
+  renderTypingIndicator({ newItem = false, force = false } = {}) {
     if (!this.hasTypingIndicatorTarget) return
 
     // Capture stick-to-end BEFORE mutating the DOM: only auto-scroll a newly
     // added item into view when the user was already parked at the right edge,
     // so we never yank them away from a chip they scrolled back to look at.
-    const stickToEnd = newItem && this.isScrollRowAtEnd()
+    // `force` overrides that guard for cases where the scroll is always wanted
+    // (e.g. the local user's own typing indicator first appearing).
+    const stickToEnd = force || (newItem && this.isScrollRowAtEnd())
 
     this.typingIndicatorTarget.innerHTML = ''
 

--- a/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
@@ -120,8 +120,10 @@
   <div id="comments-list" data-comments--popup-target="list" data-comments--list-target="list"><%= t('app.loading') %></div>
   <div id="typing-indicator-row">
     <button type="button" id="scroll-prev-msg-btn" class="scroll-prev-msg-btn" data-action="click->comments--list#scrollToPreviousMessage" title="<%= t('collavre.comments.scroll_to_prev', default: 'Previous message') %>" aria-label="<%= t('collavre.comments.scroll_to_prev', default: 'Previous message') %>">&#8963;</button>
-    <div id="channel-chips-container" data-comments--presence-target="channelChips"></div>
-    <div id="typing-indicator" data-comments--presence-target="typingIndicator" data-comments--popup-target="typingIndicator" data-stop-agent-text="<%= t('collavre.comments.stop_agent') %>"></div>
+    <div id="typing-scroll-viewport" data-comments--presence-target="scrollRow">
+      <div id="channel-chips-container" data-comments--presence-target="channelChips"></div>
+      <div id="typing-indicator" data-comments--presence-target="typingIndicator" data-comments--popup-target="typingIndicator" data-stop-agent-text="<%= t('collavre.comments.stop_agent') %>"></div>
+    </div>
   </div>
   <form id="new-comment-form" data-comments--popup-target="form" data-comments--form-target="form" style="display:none;">
     <input type="hidden" name="comment[quoted_comment_id]" data-comments--form-target="quotedCommentId" value="" />


### PR DESCRIPTION
## What

The typing-indicator row holds PR/Preview channel chips **plus** live typing indicators. When several chips and typers stack up, the row wrapped and pushed the comment form down, and a newly-started typer could render off to the right where the user never saw it.

## How

- Chips + typing indicator now share a single **horizontally-scrollable viewport** (`#typing-scroll-viewport`). The `scroll-prev` button stays pinned at the left as a flex sibling outside the viewport.
- **Stick-to-end auto-scroll**: when a *new* item is added — a new typer, an agent starting work, or a freshly attached channel chip — it is scrolled into view, **but only if the user was already parked at the right edge**. If they scrolled back to look at an earlier badge, their position is left alone (manual-scrollback pause).
- Repeat typing heartbeats from an already-shown user do **not** re-scroll.

This implements option **B** from the design discussion (stick-to-end + manual-scrollback pause), per the decision that auto-scroll triggers only on *new item added while at the edge* — not on every typing tick.

## Files

- `_comments_popup.html.erb` — wrap chips + typing in `#typing-scroll-viewport`
- `comments_popup.css` — viewport `overflow-x:auto` + `min-width:0`, thin scrollbar, chips `nowrap`, typing `flex:0 0 auto`
- `presence_controller.js` — `renderTypingIndicator({newItem})` stick-to-end logic; new chip detection in `refreshChannelChips`
- `presence_controller.test.js` — 3 new tests (at-edge → scroll / scrolled-back → no scroll / repeat ping → no scroll)

## Test

`yarn jest presence_controller` → 6/6 passing.

Out of scope (per design decision): truncation/fade visualization — auto-scroll itself teaches that the row is horizontally scrollable.