### PR TITLE
feat: minimize Lexical inline editor HTML output

### DIFF
--- a/engines/collavre/app/javascript/components/InlineLexicalEditor.jsx
+++ b/engines/collavre/app/javascript/components/InlineLexicalEditor.jsx
@@ -27,6 +27,7 @@ import {
   $getRoot,
   $getSelection,
   $isElementNode,
+  $isLineBreakNode,
   $isRangeSelection,
   $isTextNode,
   CAN_REDO_COMMAND,
@@ -208,7 +209,9 @@ function InitialContentPlugin({ html }) {
       }
       uniqueNodes.forEach((node) => {
         const isInlineLeaf =
-          $isTextNode(node) || ($isElementNode(node) && node.isInline())
+          $isTextNode(node) ||
+          $isLineBreakNode(node) ||
+          ($isElementNode(node) && node.isInline())
         if (isInlineLeaf) {
           if (!pendingParagraph) pendingParagraph = $createParagraphNode()
           pendingParagraph.append(node)

--- a/engines/collavre/app/javascript/components/InlineLexicalEditor.jsx
+++ b/engines/collavre/app/javascript/components/InlineLexicalEditor.jsx
@@ -50,6 +50,7 @@ import { AttachmentNode } from "../lib/lexical/attachment_node"
 import AttachmentCleanupPlugin from "./plugins/attachment_cleanup_plugin"
 import MarkdownShortcutsPlugin from "./plugins/markdown_shortcuts_plugin"
 import { syncLexicalStyleAttributes } from "../lib/lexical/style_attributes"
+import { minimizeContentHtml } from "../lib/lexical/minimize_html"
 import { updateResponsiveImages } from "../lib/responsive_images"
 
 const URL_MATCHERS = [
@@ -192,24 +193,33 @@ function InitialContentPlugin({ html }) {
       })
 
       const appendedNodes = []
+      // Text nodes and inline elements (links, etc.) cannot live directly under
+      // the root. Minimized HTML stores a single line without its <p> wrapper, so
+      // a line like "Hello <strong>World</strong>" re-imports as several
+      // top-level inline nodes — group consecutive ones back into one paragraph
+      // so the line is not split apart.
+      let pendingParagraph = null
+      const flushPending = () => {
+        if (pendingParagraph) {
+          root.append(pendingParagraph)
+          appendedNodes.push(pendingParagraph)
+          pendingParagraph = null
+        }
+      }
       uniqueNodes.forEach((node) => {
-        if ($isTextNode(node)) {
-          const paragraph = $createParagraphNode()
-          paragraph.append(node)
-          root.append(paragraph)
-          appendedNodes.push(paragraph)
+        const isInlineLeaf =
+          $isTextNode(node) || ($isElementNode(node) && node.isInline())
+        if (isInlineLeaf) {
+          if (!pendingParagraph) pendingParagraph = $createParagraphNode()
+          pendingParagraph.append(node)
           return
         }
 
-        if ($isElementNode(node) && node.getType?.() === "paragraph") {
-          root.append(node)
-          appendedNodes.push(node)
-          return
-        }
-
+        flushPending()
         root.append(node)
         appendedNodes.push(node)
       })
+      flushPending()
 
       if (root.getChildrenSize() === 0) {
         const paragraph = $createParagraphNode()
@@ -942,7 +952,9 @@ function EditorInner({
                 anchor.setAttribute("target", "_blank")
                 anchor.setAttribute("rel", "noopener")
               })
-              serialized = doc.body.innerHTML
+              // Strip Lexical's verbose markup (extra <div>, white-space spans,
+              // duplicate format wrappers, single-line <p>) before persisting.
+              serialized = minimizeContentHtml(doc.body.firstElementChild)
             })
             // No Trix wrapper
             onChange(serialized)

--- a/engines/collavre/app/javascript/lib/lexical/__tests__/minimize_html.test.js
+++ b/engines/collavre/app/javascript/lib/lexical/__tests__/minimize_html.test.js
@@ -1,0 +1,190 @@
+/**
+ * @jest-environment jsdom
+ */
+import {
+  createEditor,
+  $getRoot,
+  $createParagraphNode,
+  $isElementNode,
+  $isTextNode
+} from "lexical"
+import { HeadingNode, QuoteNode } from "@lexical/rich-text"
+import { CodeNode, CodeHighlightNode } from "@lexical/code"
+import { ListItemNode, ListNode } from "@lexical/list"
+import { LinkNode, AutoLinkNode } from "@lexical/link"
+import { $generateHtmlFromNodes, $generateNodesFromDOM } from "@lexical/html"
+import { minimizeContentHtml } from "../minimize_html"
+
+const theme = {
+  paragraph: "lexical-paragraph",
+  quote: "lexical-quote",
+  heading: { h1: "lexical-heading-h1", h2: "lexical-heading-h2", h3: "lexical-heading-h3" },
+  list: { ul: "lexical-list-ul", ol: "lexical-list-ol", listitem: "lexical-list-item" },
+  code: "lexical-code-block",
+  link: "lexical-link",
+  text: {
+    bold: "lexical-text-bold",
+    italic: "lexical-text-italic",
+    underline: "lexical-text-underline",
+    strikethrough: "lexical-text-strike",
+    code: "lexical-text-code"
+  }
+}
+
+function newEditor() {
+  return createEditor({
+    namespace: "test",
+    theme,
+    nodes: [HeadingNode, QuoteNode, CodeNode, CodeHighlightNode, ListItemNode, ListNode, LinkNode, AutoLinkNode],
+    onError: (e) => { throw e }
+  })
+}
+
+// Replicate the editor's serialize step: render input -> Lexical HTML.
+function serialize(inputHtml) {
+  const editor = newEditor()
+  editor.update(() => {
+    const root = $getRoot()
+    root.getChildren().forEach((c) => c.remove())
+    const doc = new DOMParser().parseFromString(inputHtml, "text/html")
+    root.append(...$generateNodesFromDOM(editor, doc.body))
+  }, { discrete: true })
+  let out = ""
+  editor.getEditorState().read(() => { out = $generateHtmlFromNodes(editor) })
+  return out
+}
+
+// Wrap raw Lexical HTML the way InlineLexicalEditor does, then minimize.
+function minimize(lexicalHtml) {
+  const doc = new DOMParser().parseFromString(`<div>${lexicalHtml}</div>`, "text/html")
+  return minimizeContentHtml(doc.body.firstElementChild)
+}
+
+// Re-import minimized HTML and re-serialize: the second pass must be identical
+// (stable round-trip) and preserve every text format flag.
+function reimportFormats(minimizedHtml) {
+  const editor = newEditor()
+  editor.update(() => {
+    const root = $getRoot()
+    root.getChildren().forEach((c) => c.remove())
+    const doc = new DOMParser().parseFromString(minimizedHtml, "text/html")
+    const nodes = $generateNodesFromDOM(editor, doc.body)
+    // Mirror InitialContentPlugin: group top-level inline/text runs into a <p>.
+    let pending = null
+    const flush = () => { if (pending) { root.append(pending); pending = null } }
+    nodes.forEach((node) => {
+      const inlineLeaf = $isTextNode(node) || ($isElementNode(node) && node.isInline())
+      if (inlineLeaf) {
+        if (!pending) pending = $createParagraphNode()
+        pending.append(node)
+        return
+      }
+      flush()
+      root.append(node)
+    })
+    flush()
+  }, { discrete: true })
+  let out = ""
+  editor.getEditorState().read(() => { out = $generateHtmlFromNodes(editor) })
+  return out
+}
+
+describe("minimizeContentHtml", () => {
+  test("plain single line -> bare text, no wrapper", () => {
+    expect(minimize(serialize("<p>Hello World</p>"))).toBe("Hello World")
+  })
+
+  test("strips the white-space:pre-wrap noise spans", () => {
+    const out = minimize(serialize("<p>Hello World</p>"))
+    expect(out).not.toContain("white-space")
+    expect(out).not.toContain("<span")
+  })
+
+  test("bold keeps a single semantic tag with its class", () => {
+    expect(minimize(serialize("<p><b>x</b></p>"))).toBe(
+      '<strong class="lexical-text-bold">x</strong>'
+    )
+  })
+
+  test("italic keeps a single em with its class", () => {
+    expect(minimize(serialize("<p><i>x</i></p>"))).toBe(
+      '<em class="lexical-text-italic">x</em>'
+    )
+  })
+
+  test("partially styled line keeps text + minimal styled tag", () => {
+    expect(minimize(serialize("<p>Hello <b>World</b></p>"))).toBe(
+      'Hello <strong class="lexical-text-bold">World</strong>'
+    )
+  })
+
+  test("nested bold+italic collapses outer duplicate but keeps both formats", () => {
+    expect(minimize(serialize("<p><b><i>x</i></b></p>"))).toBe(
+      '<i><strong class="lexical-text-bold lexical-text-italic">x</strong></i>'
+    )
+  })
+
+  test("multiple paragraphs keep one <p> per line", () => {
+    expect(minimize(serialize("<p>line1</p><p>line2</p>"))).toBe(
+      '<p class="lexical-paragraph">line1</p><p class="lexical-paragraph">line2</p>'
+    )
+  })
+
+  test("heading stays structural", () => {
+    expect(minimize(serialize("<h1>Title</h1>"))).toBe(
+      '<h1 class="lexical-heading-h1">Title</h1>'
+    )
+  })
+
+  test("list stays structural", () => {
+    expect(minimize(serialize("<ul><li>a</li><li>b</li></ul>"))).toBe(
+      '<ul class="lexical-list-ul"><li value="1" class="lexical-list-item">a</li>' +
+      '<li value="2" class="lexical-list-item">b</li></ul>'
+    )
+  })
+
+  test("link keeps href + class, drops inner span", () => {
+    const out = minimize(serialize('<p><a href="https://a.com">x</a></p>'))
+    expect(out).toContain('href="https://a.com"')
+    expect(out).toContain('class="lexical-link"')
+    expect(out).not.toContain("<span")
+    expect(out).not.toContain("white-space")
+  })
+
+  test("code block preserves structure and highlight classes", () => {
+    const out = minimize(serialize("<pre><code>const a = 1</code></pre>"))
+    expect(out).toContain("lexical-code-block")
+    expect(out).toContain("const a = 1")
+    expect(out).not.toContain("white-space")
+    expect(out).not.toContain("spellcheck")
+  })
+
+  test("empty paragraph minimizes to empty/near-empty", () => {
+    const out = minimize(serialize("<p></p>"))
+    expect(out.replace(/<br\s*\/?>/g, "").trim()).toBe("")
+  })
+
+  // Round-trip stability: minimized HTML re-imported and re-serialized, then
+  // minimized again, must equal the first minimization (no format loss / drift).
+  const roundTripCases = [
+    "<p>Hello World</p>",
+    "<p>Hello <b>World</b></p>",
+    "<p><b>x</b></p>",
+    "<p><i>x</i></p>",
+    "<p><u>x</u></p>",
+    "<p><s>x</s></p>",
+    "<p><b><i>x</i></b></p>",
+    "<p><code>inline</code></p>",
+    "<h1>Title</h1>",
+    "<p>line1</p><p>line2</p>",
+    "<ul><li>a</li><li>b</li></ul>",
+    "<blockquote>quoted</blockquote>",
+    '<p><a href="https://a.com">link</a></p>'
+  ]
+
+  test.each(roundTripCases)("round-trip stable: %s", (input) => {
+    const first = minimize(serialize(input))
+    const second = minimize(reimportFormats(first))
+    expect(second).toBe(first)
+  })
+})

--- a/engines/collavre/app/javascript/lib/lexical/__tests__/minimize_html.test.js
+++ b/engines/collavre/app/javascript/lib/lexical/__tests__/minimize_html.test.js
@@ -6,6 +6,7 @@ import {
   $getRoot,
   $createParagraphNode,
   $isElementNode,
+  $isLineBreakNode,
   $isTextNode
 } from "lexical"
 import { HeadingNode, QuoteNode } from "@lexical/rich-text"
@@ -73,7 +74,10 @@ function reimportFormats(minimizedHtml) {
     let pending = null
     const flush = () => { if (pending) { root.append(pending); pending = null } }
     nodes.forEach((node) => {
-      const inlineLeaf = $isTextNode(node) || ($isElementNode(node) && node.isInline())
+      const inlineLeaf =
+        $isTextNode(node) ||
+        $isLineBreakNode(node) ||
+        ($isElementNode(node) && node.isInline())
       if (inlineLeaf) {
         if (!pending) pending = $createParagraphNode()
         pending.append(node)
@@ -164,6 +168,41 @@ describe("minimizeContentHtml", () => {
     expect(out.replace(/<br\s*\/?>/g, "").trim()).toBe("")
   })
 
+  test("keeps pre-wrap span when text has 2+ consecutive spaces", () => {
+    // The render container has no `white-space: pre-wrap`, so significant
+    // whitespace must survive in the persisted markup.
+    const lexical =
+      '<p class="lexical-paragraph">' +
+      '<span style="white-space: pre-wrap;">foo  bar</span></p>'
+    const out = minimize(lexical)
+    expect(out).toContain("foo  bar")
+    expect(out).toContain("white-space")
+  })
+
+  test("keeps pre-wrap span for leading indentation", () => {
+    const lexical =
+      '<p class="lexical-paragraph">' +
+      '<span style="white-space: pre-wrap;">    indented</span></p>'
+    const out = minimize(lexical)
+    expect(out).toContain("    indented")
+    expect(out).toContain("white-space")
+  })
+
+  test("a single trailing space stays minimal (not significant)", () => {
+    // The "Hello " run has one trailing space — renders fine bare, so no span.
+    expect(minimize(serialize("<p>Hello <b>World</b></p>"))).toBe(
+      'Hello <strong class="lexical-text-bold">World</strong>'
+    )
+  })
+
+  test("soft line break keeps its <p> wrapper", () => {
+    const out = minimize(serialize("<p>line 1<br>line 2</p>"))
+    expect(out).toContain("<br>")
+    expect(out.startsWith("<p")).toBe(true)
+    expect(out).toContain("line 1")
+    expect(out).toContain("line 2")
+  })
+
   // Round-trip stability: minimized HTML re-imported and re-serialized, then
   // minimized again, must equal the first minimization (no format loss / drift).
   const roundTripCases = [
@@ -179,7 +218,8 @@ describe("minimizeContentHtml", () => {
     "<p>line1</p><p>line2</p>",
     "<ul><li>a</li><li>b</li></ul>",
     "<blockquote>quoted</blockquote>",
-    '<p><a href="https://a.com">link</a></p>'
+    '<p><a href="https://a.com">link</a></p>',
+    "<p>line 1<br>line 2</p>"
   ]
 
   test.each(roundTripCases)("round-trip stable: %s", (input) => {

--- a/engines/collavre/app/javascript/lib/lexical/__tests__/minimize_html.test.js
+++ b/engines/collavre/app/javascript/lib/lexical/__tests__/minimize_html.test.js
@@ -195,6 +195,35 @@ describe("minimizeContentHtml", () => {
     )
   })
 
+  test("keeps pre-wrap on both sides when a space run straddles a format boundary", () => {
+    // The live editor serializes a bolded " bar" (within a 2-space run) as
+    // `foo ` + `<b><strong> bar</strong></b>`: the second space is nested inside
+    // the bold. Each node holds one edge space, so dropping pre-wrap from both
+    // would collapse the pair. Both sides must keep pre-wrap.
+    const lexical =
+      '<p class="lexical-paragraph">' +
+      '<span style="white-space: pre-wrap;">foo </span>' +
+      '<b><strong class="lexical-text-bold" style="white-space: pre-wrap;"> bar</strong></b>' +
+      "</p>"
+    const out = minimize(lexical)
+    expect(out).toBe(
+      '<span style="white-space: pre-wrap;">foo </span>' +
+      '<strong class="lexical-text-bold" style="white-space: pre-wrap;"> bar</strong>'
+    )
+    // pre-wrap survives on both the plain run and the styled run.
+    expect(out.match(/white-space/g)).toHaveLength(2)
+  })
+
+  test("boundary space across a paragraph break does NOT keep pre-wrap", () => {
+    // Different blocks have separate inline contexts — trailing space of one
+    // line and leading space of the next never combine, so neither is significant.
+    const lexical =
+      '<p class="lexical-paragraph"><span style="white-space: pre-wrap;">foo </span></p>' +
+      '<p class="lexical-paragraph"><span style="white-space: pre-wrap;"> bar</span></p>'
+    const out = minimize(lexical)
+    expect(out).not.toContain("white-space")
+  })
+
   test("soft line break keeps its <p> wrapper", () => {
     const out = minimize(serialize("<p>line 1<br>line 2</p>"))
     expect(out).toContain("<br>")

--- a/engines/collavre/app/javascript/lib/lexical/minimize_html.js
+++ b/engines/collavre/app/javascript/lib/lexical/minimize_html.js
@@ -44,9 +44,54 @@ function hasSignificantWhitespace(text) {
   return /\s{2,}|[\t\n\r\f]/.test(text)
 }
 
+// Block-level tags terminate an inline formatting context: whitespace never
+// combines across them, so the document-order scan below must not look past one.
+const BLOCK_TAGS = new Set([
+  "BODY", "DIV", "P", "H1", "H2", "H3", "H4", "H5", "H6", "UL", "OL", "LI",
+  "BLOCKQUOTE", "PRE", "TABLE", "THEAD", "TBODY", "TR", "TD", "TH", "FIGURE", "HR"
+])
+
+function isBlock(node) {
+  return node != null && node.nodeType === 1 && BLOCK_TAGS.has(node.tagName)
+}
+
+// The rendered character immediately adjacent to `el` in document order, within
+// the same inline formatting context. `dir` is "previousSibling"/"nextSibling".
+// Climbs out of inline wrappers (e.g. `<b><strong>`) so a space nested one level
+// deep still sees its neighbour, but stops at a block edge (returns "").
+function adjacentInlineChar(el, dir) {
+  let node = el
+  while (node && !node[dir]) {
+    node = node.parentNode
+    if (isBlock(node)) return ""
+  }
+  const sibling = node && node[dir]
+  if (!sibling) return ""
+  const text = sibling.textContent || ""
+  return dir === "previousSibling" ? text.slice(-1) : text.charAt(0)
+}
+
+// Significant whitespace can straddle an inline formatting boundary: e.g. the
+// live editor serializes a bolded " bar" as `foo ` + `<b><strong> bar</strong></b>`,
+// where each node holds a single edge space. Dropping `pre-wrap` from both sides
+// would collapse the pair to one space. Detect each side independently so the
+// kept `pre-wrap` lands on BOTH elements and the run survives unambiguously.
+function hasBoundarySignificantWhitespace(el) {
+  const text = el.textContent || ""
+  if (/^\s/.test(text) && /\s/.test(adjacentInlineChar(el, "previousSibling"))) {
+    return true
+  }
+  if (/\s$/.test(text) && /\s/.test(adjacentInlineChar(el, "nextSibling"))) {
+    return true
+  }
+  return false
+}
+
 function stripRedundantStyle(el) {
   if (!el.hasAttribute("style")) return
-  const keepWhiteSpace = hasSignificantWhitespace(el.textContent)
+  const keepWhiteSpace =
+    hasSignificantWhitespace(el.textContent) ||
+    hasBoundarySignificantWhitespace(el)
   REDUNDANT_STYLE_PROPS.forEach((prop) => {
     if (prop === "white-space" && keepWhiteSpace) return
     el.style.removeProperty(prop)

--- a/engines/collavre/app/javascript/lib/lexical/minimize_html.js
+++ b/engines/collavre/app/javascript/lib/lexical/minimize_html.js
@@ -1,0 +1,115 @@
+// Minimize the HTML that Lexical's `$generateHtmlFromNodes` produces before it
+// is persisted as a creative description / comment body.
+//
+// Lexical emits verbose markup: every text node is wrapped in
+// `<span style="white-space: pre-wrap;">`, bold/italic double-wrap as
+// `<b><strong class="lexical-text-bold">`, and the whole document is nested in
+// an extra `<div>` wrapper. None of that is needed once the content is rendered
+// inside a `.creative-content` container.
+//
+// The goal (per product spec) is: a single line of text needs no markup at all,
+// and styled regions keep a minimal `<span class="…">` / semantic tag. We only
+// strip genuine redundancy — we never drop a tag or class that the renderer or
+// the editor's re-import (`$generateNodesFromDOM`) relies on.
+
+// Editor-only inline style declarations that carry no meaning once rendered.
+// `white-space: pre-wrap` is redundant: plain text wraps normally and code
+// blocks preserve whitespace via the kept `.lexical-code-block` rule (which
+// children inherit).
+const REDUNDANT_STYLE_PROPS = ["white-space"]
+
+// Editor-only attributes that never affect rendering of persisted content.
+const REDUNDANT_ATTRS = ["spellcheck"]
+
+// Same-format wrapper pairs Lexical emits as outer/inner duplicates. Either tag
+// alone still conveys the format on re-import, so the attribute-less one can go.
+const SAME_FORMAT_PAIRS = [
+  ["b", "strong"],
+  ["i", "em"]
+]
+
+function hasNoAttributes(el) {
+  return el.attributes.length === 0
+}
+
+function stripRedundantStyle(el) {
+  if (!el.hasAttribute("style")) return
+  REDUNDANT_STYLE_PROPS.forEach((prop) => el.style.removeProperty(prop))
+  if (el.style.length === 0 || !el.getAttribute("style")?.trim()) {
+    el.removeAttribute("style")
+  }
+}
+
+function isSameFormatPair(tagA, tagB) {
+  const a = tagA.toLowerCase()
+  const b = tagB.toLowerCase()
+  return SAME_FORMAT_PAIRS.some(
+    ([x, y]) => (a === x && b === y) || (a === y && b === x)
+  )
+}
+
+function unwrap(el) {
+  const parent = el.parentNode
+  if (!parent) return
+  while (el.firstChild) parent.insertBefore(el.firstChild, el)
+  parent.removeChild(el)
+}
+
+// Depth-first cleanup: normalize attributes, then collapse redundant wrappers.
+function cleanElement(el) {
+  // Recurse first so inner redundancy is resolved before we inspect a parent.
+  Array.from(el.children).forEach(cleanElement)
+
+  if (el.tagName === "BODY") return
+
+  REDUNDANT_ATTRS.forEach((attr) => el.removeAttribute(attr))
+  stripRedundantStyle(el)
+
+  const tag = el.tagName.toLowerCase()
+
+  // Attribute-less <span> conveys nothing — unwrap it (plain text, link inner).
+  if (tag === "span" && hasNoAttributes(el)) {
+    unwrap(el)
+    return
+  }
+
+  // Collapse Lexical's outer/inner duplicate format wrappers (e.g. <b><strong>).
+  // Drop whichever element carries no attributes; the other keeps the format.
+  const onlyChild =
+    el.children.length === 1 && el.childNodes.length === 1 ? el.children[0] : null
+  if (onlyChild && isSameFormatPair(tag, onlyChild.tagName)) {
+    if (hasNoAttributes(el)) {
+      unwrap(el)
+    } else if (hasNoAttributes(onlyChild)) {
+      unwrap(onlyChild)
+    }
+  }
+}
+
+const MEDIA_SELECTOR = "img, action-text-attachment, figure, [data-trix-attachment]"
+
+// A single top-level paragraph is just a line of text — emit its inline content
+// without the <p> wrapper. Structural blocks (headings, lists, quotes, code,
+// multiple paragraphs) are left intact.
+function unwrapSingleParagraph(root) {
+  const blocks = Array.from(root.children)
+  if (blocks.length === 1 && blocks[0].tagName === "P") {
+    const paragraph = blocks[0]
+    // An empty line (just a <br> / whitespace, no media) collapses to "" so the
+    // stored value matches isHtmlEmpty and re-imports to a fresh paragraph.
+    if (!paragraph.textContent.trim() && !paragraph.querySelector(MEDIA_SELECTOR)) {
+      return ""
+    }
+    return paragraph.innerHTML
+  }
+  return root.innerHTML
+}
+
+// `root` is the element whose children are the serialized content blocks
+// (i.e. the throwaway <div> wrapper Lexical's output was parsed into). Mutates
+// `root` in place and returns the minimized HTML string.
+export function minimizeContentHtml(root) {
+  if (!root) return ""
+  Array.from(root.children).forEach(cleanElement)
+  return unwrapSingleParagraph(root)
+}

--- a/engines/collavre/app/javascript/lib/lexical/minimize_html.js
+++ b/engines/collavre/app/javascript/lib/lexical/minimize_html.js
@@ -13,9 +13,12 @@
 // the editor's re-import (`$generateNodesFromDOM`) relies on.
 
 // Editor-only inline style declarations that carry no meaning once rendered.
-// `white-space: pre-wrap` is redundant: plain text wraps normally and code
-// blocks preserve whitespace via the kept `.lexical-code-block` rule (which
-// children inherit).
+// `white-space: pre-wrap` is usually redundant: plain text wraps normally and
+// code blocks preserve whitespace via the kept `.lexical-code-block` rule (which
+// children inherit). It is NOT redundant when the text carries significant
+// whitespace (see `hasSignificantWhitespace`): the render container
+// (`.creative-content`) has no `pre-wrap`, so dropping it would collapse runs of
+// spaces / indentation that the user actually typed.
 const REDUNDANT_STYLE_PROPS = ["white-space"]
 
 // Editor-only attributes that never affect rendering of persisted content.
@@ -32,9 +35,22 @@ function hasNoAttributes(el) {
   return el.attributes.length === 0
 }
 
+// Whitespace whose rendering changes once `white-space: pre-wrap` is dropped:
+// a run of 2+ whitespace (collapses to one space) or a tab/newline/form-feed.
+// A single leading/trailing space between inline runs renders fine without
+// `pre-wrap`, so it is not significant and must not block minimization of the
+// common case (e.g. the "Hello " before a bold word).
+function hasSignificantWhitespace(text) {
+  return /\s{2,}|[\t\n\r\f]/.test(text)
+}
+
 function stripRedundantStyle(el) {
   if (!el.hasAttribute("style")) return
-  REDUNDANT_STYLE_PROPS.forEach((prop) => el.style.removeProperty(prop))
+  const keepWhiteSpace = hasSignificantWhitespace(el.textContent)
+  REDUNDANT_STYLE_PROPS.forEach((prop) => {
+    if (prop === "white-space" && keepWhiteSpace) return
+    el.style.removeProperty(prop)
+  })
   if (el.style.length === 0 || !el.getAttribute("style")?.trim()) {
     el.removeAttribute("style")
   }
@@ -99,6 +115,12 @@ function unwrapSingleParagraph(root) {
     // stored value matches isHtmlEmpty and re-imports to a fresh paragraph.
     if (!paragraph.textContent.trim() && !paragraph.querySelector(MEDIA_SELECTOR)) {
       return ""
+    }
+    // A soft line break (<br>) inside the line must keep its <p> wrapper: a bare
+    // top-level <br> cannot be re-grouped into a paragraph on re-import and would
+    // break the document shape / split the line.
+    if (paragraph.querySelector("br")) {
+      return root.innerHTML
     }
     return paragraph.innerHTML
   }


### PR DESCRIPTION
## Summary

Lexical's `$generateHtmlFromNodes` emits verbose markup for every creative description / comment body:

- an extra `<div>` wrapper around the whole document
- a `<span style="white-space: pre-wrap;">` around **every** text node
- duplicate `<b><strong class="lexical-text-bold">` format wrappers
- a `<p class="lexical-paragraph">` wrapper even for a single line of plain text

This PR minimizes the stored HTML to only what's needed, while keeping the class-bearing tags the renderer (`.creative-content`) and the editor's re-import (`$generateNodesFromDOM`) rely on.

### Before → After

| Input | Before | After |
|---|---|---|
| `Hello World` | `<div><p class="lexical-paragraph"><span style="white-space: pre-wrap;">Hello World</span></p></div>` | `Hello World` |
| `Hello **World**` | `<div><p ...><span ...>Hello </span><b><strong class="lexical-text-bold" style="white-space: pre-wrap;">World</strong></b></p></div>` | `Hello <strong class="lexical-text-bold">World</strong>` |
| 2 lines | `<div><p ...><span ...>line1</span></p><p ...><span ...>line2</span></p></div>` | `<p class="lexical-paragraph">line1</p><p class="lexical-paragraph">line2</p>` |

## What it does

`lib/lexical/minimize_html.js` runs in `OnChangePlugin` before persisting:

1. Drops the outer `<div>` wrapper — the renderer already wraps content in `.creative-content`.
2. Removes `white-space: pre-wrap` — redundant for normal text; code blocks still get `white-space: pre` (inherited from the kept `.lexical-code-block` rule on `<pre>`).
3. Unwraps attribute-less `<span>` (plain text spans, link inner spans).
4. Collapses same-format duplicate wrappers: `<b><strong>` → `<strong>`, `<i><em>` → `<em>` (either tag alone still conveys the format on re-import).
5. Unwraps the single top-level `<p>` for one-line content; an empty line collapses to `""`.

Theme classes (`lexical-text-bold`, `lexical-heading-h1`, `lexical-code-block`, `lexical-token-*`, …) are **kept** — they carry the styling and need no CSS change, and existing stored content keeps rendering identically.

## Round-trip safety

`InitialContentPlugin` is hardened to regroup top-level inline/text runs back into a single paragraph, so a minimized one-liner like `Hello <strong>World</strong>` round-trips through edit/save without splitting into two lines.

## Tests

- New `minimize_html.test.js`: exact-output assertions per format + round-trip stability through the **real** Lexical import/export (minimize → re-import → re-serialize → minimize is idempotent and loses no format flags).
- Full JS suite: **224 passing**.

Closes Collavre creative #11352.
