### PR TITLE
fix(collavre): allow deleting a topic that has comment snapshots

### DIFF
--- a/engines/collavre/app/models/collavre/topic.rb
+++ b/engines/collavre/app/models/collavre/topic.rb
@@ -9,6 +9,11 @@ module Collavre
 
     has_many :comments, class_name: "Collavre::Comment", dependent: :destroy
     has_many :channels, class_name: "Collavre::Channel", dependent: :destroy
+    # Compress/merge snapshots capture a topic's comments as a restore point. The
+    # comment_snapshots -> topics FK has no DB-level ON DELETE, so without this the
+    # row blocks topic deletion (ActiveRecord::InvalidForeignKey -> 500). Once the
+    # topic is gone the snapshot can no longer be restored into it, so :destroy.
+    has_many :comment_snapshots, class_name: "Collavre::CommentSnapshot", dependent: :destroy
     has_many :branches, class_name: "Collavre::Topic", foreign_key: :source_topic_id, dependent: :nullify
     has_many :user_creative_preferences_as_last_topic, class_name: "Collavre::UserCreativePreference",
              foreign_key: :last_topic_id, dependent: :nullify, inverse_of: :last_topic

--- a/engines/collavre/test/controllers/topics_controller_test.rb
+++ b/engines/collavre/test/controllers/topics_controller_test.rb
@@ -63,14 +63,18 @@ class TopicsControllerTest < ActionDispatch::IntegrationTest
     assert_response :no_content
   end
 
-  test "should destroy topic that has a PR badge channel + injected comments" do
-    channel = CollavreGithub::GithubPrChannel.create!(
+  # Uses the core PreviewChannel (not the collavre_github GithubPrChannel) so
+  # the core engine test suite stays independent of the optional GitHub engine
+  # per AGENTS.md. The cascade-on-delete behavior under test lives in the base
+  # Collavre::Channel, so any channel subclass exercises the same path.
+  test "should destroy topic that has a badge channel + injected comments" do
+    channel = Collavre::PreviewChannel.create!(
       topic_id: @topic.id,
-      config: { "repo_full_name" => "owner/repo", "pr_number" => 123, "pr_state" => "open" }
+      config: { "preview_url" => "http://localhost:4000", "label" => "Preview #1" }
     )
     channel.inject_into_topic!(channel.attached_message)
 
-    assert @topic.channels.exists?, "precondition: topic has a channel (PR badge)"
+    assert @topic.channels.exists?, "precondition: topic has a channel (badge)"
     assert @topic.comments.exists?, "precondition: topic has injected comments"
 
     assert_difference("Topic.count", -1) do

--- a/engines/collavre/test/controllers/topics_controller_test.rb
+++ b/engines/collavre/test/controllers/topics_controller_test.rb
@@ -63,6 +63,43 @@ class TopicsControllerTest < ActionDispatch::IntegrationTest
     assert_response :no_content
   end
 
+  test "should destroy topic that has a PR badge channel + injected comments" do
+    channel = CollavreGithub::GithubPrChannel.create!(
+      topic_id: @topic.id,
+      config: { "repo_full_name" => "owner/repo", "pr_number" => 123, "pr_state" => "open" }
+    )
+    channel.inject_into_topic!(channel.attached_message)
+
+    assert @topic.channels.exists?, "precondition: topic has a channel (PR badge)"
+    assert @topic.comments.exists?, "precondition: topic has injected comments"
+
+    assert_difference("Topic.count", -1) do
+      delete collavre.creative_topic_url(@creative, @topic)
+    end
+
+    assert_response :no_content
+    assert_nil Collavre::Topic.find_by(id: @topic.id), "topic must actually be gone from DB"
+  end
+
+  test "should destroy topic that has a comment_snapshot (compress/merge)" do
+    Collavre::CommentSnapshot.create!(
+      creative: @creative,
+      topic: @topic,
+      user: @user,
+      operation: "compress",
+      comments_data: [ { "id" => 1, "content" => "x" } ]
+    )
+
+    assert Collavre::CommentSnapshot.where(topic_id: @topic.id).exists?, "precondition: topic has a snapshot"
+
+    assert_difference("Topic.count", -1) do
+      delete collavre.creative_topic_url(@creative, @topic)
+    end
+
+    assert_response :no_content
+    assert_nil Collavre::Topic.find_by(id: @topic.id), "topic must actually be gone from DB"
+  end
+
   test "should update topic name" do
     patch collavre.creative_topic_url(@creative, @topic), params: { topic: { name: "Updated Name" } }, as: :json
 


### PR DESCRIPTION
## Problem

Some topics could not be deleted — `DELETE /creatives/:id/topics/:id` returned a 500. The hypothesis was that a **PR badge** (`pr_monitor`-registered topic) blocked deletion.

## Root cause (hypothesis disproven, real cause confirmed empirically)

The PR badge is **not** the cause. The real cause is **comment snapshots**.

`comment_snapshots → topics` is the only FK referencing `topics` that has **no DB-level `ON DELETE`** *and* **no matching `dependent:`** on the `Topic` model:

| FK → topics | handled? |
|---|---|
| `channels → topics` | ✅ `Topic has_many :channels, dependent: :destroy` |
| `comments → topics` | ✅ `dependent: :destroy` |
| `source_topic_id` / `last_topic_id` | ✅ `on_delete: :nullify` |
| **`comment_snapshots → topics`** | ❌ none → `ActiveRecord::InvalidForeignKey` → 500 |

Comment snapshots are produced by **compress/merge comment operations** (context management), not by PR badges.

### Why it looked like the PR badge

PR-monitored topics continuously accumulate injected PR comments → users run compress/merge on them → snapshots get created → topic can no longer be deleted. The PR badge is correlated but innocent; its `Channel` already cascades cleanly.

Verified both directions in tests:
- PR-badge channel + injected comments → **deletes fine**
- A single `comment_snapshot` → **`InvalidForeignKey`** before this fix

## Fix

Add to `Collavre::Topic`:

```ruby
has_many :comment_snapshots, class_name: "Collavre::CommentSnapshot", dependent: :destroy
```

Once a topic is deleted, its snapshots can no longer be restored into it (the restore service recreates comments from the snapshot's stored `topic_id`), so `:destroy` is the correct semantic.

## Tests

Added two regression tests to `topics_controller_test.rb`:
- destroying a topic with a PR-badge channel + injected comments
- destroying a topic with a comment snapshot

All 26 controller tests pass; rubocop clean.