### PR TITLE
fix: bind lexical text color at import time to stop it drifting on reopen

### DIFF
--- a/engines/collavre/app/javascript/components/InlineLexicalEditor.jsx
+++ b/engines/collavre/app/javascript/components/InlineLexicalEditor.jsx
@@ -50,6 +50,7 @@ import { AttachmentNode } from "../lib/lexical/attachment_node"
 import AttachmentCleanupPlugin from "./plugins/attachment_cleanup_plugin"
 import MarkdownShortcutsPlugin from "./plugins/markdown_shortcuts_plugin"
 import { syncLexicalStyleAttributes } from "../lib/lexical/style_attributes"
+import { lexicalHtmlConfig } from "../lib/lexical/color_import"
 import { updateResponsiveImages } from "../lib/responsive_images"
 
 const URL_MATCHERS = [
@@ -120,43 +121,6 @@ function InitialContentPlugin({ html }) {
   const [editor] = useLexicalComposerContext()
   const lastApplied = useRef(null)
 
-  const collectDomTextStyles = useCallback((container) => {
-    const styles = []
-    if (!container) return styles
-    const ownerDocument = container.ownerDocument || document
-    const walker = ownerDocument.createTreeWalker(container, NodeFilter.SHOW_TEXT)
-    let current = walker.nextNode()
-    while (current) {
-      const parent = current.parentElement
-      let styleText = parent?.getAttribute?.("style") || ""
-      const colorAttr = parent?.dataset?.lexicalColor
-      const bgAttr = parent?.dataset?.lexicalBackgroundColor
-
-      if ((!styleText || !styleText.trim()) && (colorAttr || bgAttr)) {
-        const declarations = []
-        if (colorAttr) declarations.push(`color: ${colorAttr}`)
-        if (bgAttr) declarations.push(`background-color: ${bgAttr}`)
-        styleText = declarations.join("; ")
-      } else {
-        const lower = styleText.toLowerCase()
-        const fragments = []
-        if (colorAttr && !lower.includes("color:")) {
-          fragments.push(`color: ${colorAttr}`)
-        }
-        if (bgAttr && !lower.includes("background-color:")) {
-          fragments.push(`background-color: ${bgAttr}`)
-        }
-        if (fragments.length > 0) {
-          styleText = `${styleText}${styleText.trim().endsWith(";") || !styleText.trim() ? "" : ";"} ${fragments.join("; ")}`.trim()
-        }
-      }
-
-      styles.push(styleText || "")
-      current = walker.nextNode()
-    }
-    return styles
-  }, [])
-
   useEffect(() => {
     if (lastApplied.current === html) return
     lastApplied.current = html
@@ -170,8 +134,11 @@ function InitialContentPlugin({ html }) {
       // No more .trix-content wrapper
       const container = doc.body
 
+      // Color / background-color are bound to text nodes during import by the
+      // colorAwareSpanImport html config (see lib/lexical/color_import). We no
+      // longer re-apply styles positionally after import, which used to drift
+      // onto the wrong text node whenever Lexical split or dropped text nodes.
       syncLexicalStyleAttributes(container)
-      const collectedStyles = collectDomTextStyles(container)
       const nodes = $generateNodesFromDOM(editor, container)
 
       // Filter out duplicate image nodes if any
@@ -217,12 +184,6 @@ function InitialContentPlugin({ html }) {
         appendedNodes.push(paragraph)
       }
 
-      const textNodes = root.getAllTextNodes()
-      textNodes.forEach((textNode, index) => {
-        const style = collectedStyles[index]
-        textNode.setStyle(style || "")
-      })
-
       let lastChild = root.getLastChild()
       while (
         lastChild &&
@@ -237,7 +198,7 @@ function InitialContentPlugin({ html }) {
         root.append($createParagraphNode())
       }
     })
-  }, [collectDomTextStyles, editor, html])
+  }, [editor, html])
 
   return null
 }
@@ -1024,7 +985,8 @@ export default function InlineLexicalEditor({
       onError(error) {
         throw error
       },
-      theme
+      theme,
+      html: lexicalHtmlConfig
     }),
     []
   )

--- a/engines/collavre/app/javascript/components/InlineLexicalEditor.jsx
+++ b/engines/collavre/app/javascript/components/InlineLexicalEditor.jsx
@@ -50,7 +50,7 @@ import { AttachmentNode } from "../lib/lexical/attachment_node"
 import AttachmentCleanupPlugin from "./plugins/attachment_cleanup_plugin"
 import MarkdownShortcutsPlugin from "./plugins/markdown_shortcuts_plugin"
 import { syncLexicalStyleAttributes } from "../lib/lexical/style_attributes"
-import { lexicalHtmlConfig } from "../lib/lexical/color_import"
+import { lexicalHtmlConfig, normalizeColoredContainers } from "../lib/lexical/color_import"
 import { updateResponsiveImages } from "../lib/responsive_images"
 
 const URL_MATCHERS = [
@@ -139,6 +139,10 @@ function InitialContentPlugin({ html }) {
       // longer re-apply styles positionally after import, which used to drift
       // onto the wrong text node whenever Lexical split or dropped text nodes.
       syncLexicalStyleAttributes(container)
+      // Push color/background-color from non-span elements onto spans so the
+      // colorAwareSpanImport config binds it (the span importer can't see it
+      // otherwise). Must run after the sync above materializes data-lexical-*.
+      normalizeColoredContainers(container)
       const nodes = $generateNodesFromDOM(editor, container)
 
       // Filter out duplicate image nodes if any

--- a/engines/collavre/app/javascript/lib/lexical/__tests__/color_import.test.js
+++ b/engines/collavre/app/javascript/lib/lexical/__tests__/color_import.test.js
@@ -149,6 +149,21 @@ describe("colorAwareSpanImport", () => {
     ])
   })
 
+  it("preserves a non-span block element's own text formatting alongside its color", () => {
+    // Pasted content can put color AND text formatting on a block element, e.g.
+    // <p style="color:red; font-weight:700; font-style:italic">. The wrapper span
+    // must carry those format styles too, or normalization drops the bold/italic.
+    const html =
+      '<p style="color: rgb(255, 0, 0); font-weight: 700; font-style: italic; ' +
+      'text-decoration: underline;">styled block</p>'
+
+    const nodes = importColors(html, { withConfig: true })
+    expect(nodes).toHaveLength(1)
+    expect(nodes[0].text).toBe("styled block")
+    expect(nodes[0].style).toBe("color: rgb(255, 0, 0)")
+    expect(nodes[0].formats.sort()).toEqual(["bold", "italic", "underline"].sort())
+  })
+
   it("lets an inner colored span override the color of its non-span block parent", () => {
     const html =
       '<p style="color: rgb(255, 0, 0);">outer ' +

--- a/engines/collavre/app/javascript/lib/lexical/__tests__/color_import.test.js
+++ b/engines/collavre/app/javascript/lib/lexical/__tests__/color_import.test.js
@@ -1,6 +1,6 @@
 import { createEditor, $getRoot, $isTextNode, $createParagraphNode } from "lexical"
 import { $generateNodesFromDOM } from "@lexical/html"
-import { lexicalHtmlConfig } from "../color_import"
+import { lexicalHtmlConfig, normalizeColoredContainers } from "../color_import"
 
 // Parse an inline style string into a plain object so order doesn't matter.
 function parseStyleMap(styleText) {
@@ -31,6 +31,7 @@ function importColors(html, { withConfig }) {
       const root = $getRoot()
       root.getChildren().forEach((child) => child.remove())
       const doc = new DOMParser().parseFromString(html, "text/html")
+      if (withConfig) normalizeColoredContainers(doc.body)
       const nodes = $generateNodesFromDOM(editor, doc.body)
       nodes.forEach((node) => {
         if ($isTextNode(node)) {
@@ -134,6 +135,28 @@ describe("colorAwareSpanImport", () => {
       "background-color": "rgb(255, 255, 0)",
       color: "rgb(255, 0, 0)"
     })
+  })
+
+  it("imports color carried on a non-span block element (e.g. <p style=color>)", () => {
+    // Legacy / Trix-migrated / pasted content can put color on a block element
+    // instead of a span. The span importer can't see it; normalizeColoredContainers
+    // wraps the block's direct text in a span so the color survives reopen.
+    const html = '<p style="color: rgb(255, 0, 0);">red paragraph</p>'
+
+    const nodes = importColors(html, { withConfig: true })
+    expect(nodes).toEqual([
+      { text: "red paragraph", style: "color: rgb(255, 0, 0)", formats: [] }
+    ])
+  })
+
+  it("lets an inner colored span override the color of its non-span block parent", () => {
+    const html =
+      '<p style="color: rgb(255, 0, 0);">outer ' +
+      '<span style="color: rgb(0, 0, 255);">inner</span></p>'
+
+    const nodes = importColors(html, { withConfig: true })
+    expect(nodes.find((n) => n.text === "outer ").style).toBe("color: rgb(255, 0, 0)")
+    expect(nodes.find((n) => n.text === "inner").style).toBe("color: rgb(0, 0, 255)")
   })
 
   it("demonstrates the drift the fix removes (no config = color on wrong/lost node)", () => {

--- a/engines/collavre/app/javascript/lib/lexical/__tests__/color_import.test.js
+++ b/engines/collavre/app/javascript/lib/lexical/__tests__/color_import.test.js
@@ -135,6 +135,42 @@ describe("colorAwareSpanImport", () => {
     expect(nodes[0].formats).toEqual([])
   })
 
+  it("carries an unmapped font-weight/font-style/vertical-align value instead of dropping it", () => {
+    // applyTextFormatFromStyle only maps font-weight 700/bold, font-style italic
+    // and vertical-align sub/super to Lexical formats. A value it does NOT map
+    // (font-weight:800, font-style:oblique, vertical-align:middle) is not a
+    // format, so it must survive as carried inline style — the old positional
+    // collector copied the full style string and kept these.
+    const nodes = importColors(
+      '<p><span style="color: rgb(255, 0, 0); font-weight: 800; font-style: oblique; ' +
+        'vertical-align: middle; white-space: pre-wrap;">heavy</span></p>',
+      { withConfig: true }
+    )
+    expect(nodes).toHaveLength(1)
+    expect(nodes[0].text).toBe("heavy")
+    expect(parseStyleMap(nodes[0].style)).toEqual({
+      color: "rgb(255, 0, 0)",
+      "font-weight": "800",
+      "font-style": "oblique",
+      "vertical-align": "middle"
+    })
+    // None of these unmapped values map to a Lexical format.
+    expect(nodes[0].formats).toEqual([])
+  })
+
+  it("does NOT carry a mapped font-weight/font-style value (it becomes a format)", () => {
+    // Guards the value-aware exclusion: 700/bold/italic still convert to Lexical
+    // formats and must not also appear in the carried node style (double-represent).
+    const nodes = importColors(
+      '<p><span style="color: rgb(255, 0, 0); font-weight: 700; font-style: italic; ' +
+        'white-space: pre-wrap;">styled</span></p>',
+      { withConfig: true }
+    )
+    expect(nodes).toHaveLength(1)
+    expect(parseStyleMap(nodes[0].style)).toEqual({ color: "rgb(255, 0, 0)" })
+    expect(nodes[0].formats.sort()).toEqual(["bold", "italic"].sort())
+  })
+
   it("preserves non-format text styles on a non-span colored block element", () => {
     // Same generality for the block path: a colored <p>/<li> carrying font-size
     // etc. must keep those styles when normalizeColoredContainers wraps its text.

--- a/engines/collavre/app/javascript/lib/lexical/__tests__/color_import.test.js
+++ b/engines/collavre/app/javascript/lib/lexical/__tests__/color_import.test.js
@@ -111,6 +111,44 @@ describe("colorAwareSpanImport", () => {
     )
   })
 
+  it("preserves non-format text styles (font-size/family/transform) on a colored span", () => {
+    // The custom span import must carry the span's FULL style, not just color:
+    // a colored span can also set font-size / font-family / text-transform /
+    // letter-spacing, and Lexical's default conversion ignores them, so cherry-
+    // picking color alone drops the rest on reopen.
+    const html =
+      '<p><span style="color: rgb(255, 0, 0); font-size: 20px; font-family: Georgia; ' +
+      'text-transform: uppercase; letter-spacing: 2px; white-space: pre-wrap;">big</span></p>'
+
+    const nodes = importColors(html, { withConfig: true })
+    expect(nodes).toHaveLength(1)
+    expect(nodes[0].text).toBe("big")
+    // white-space (Lexical's own artifact) is intentionally dropped; everything
+    // else survives.
+    expect(parseStyleMap(nodes[0].style)).toEqual({
+      color: "rgb(255, 0, 0)",
+      "font-size": "20px",
+      "font-family": "Georgia",
+      "text-transform": "uppercase",
+      "letter-spacing": "2px"
+    })
+    expect(nodes[0].formats).toEqual([])
+  })
+
+  it("preserves non-format text styles on a non-span colored block element", () => {
+    // Same generality for the block path: a colored <p>/<li> carrying font-size
+    // etc. must keep those styles when normalizeColoredContainers wraps its text.
+    const html = '<p style="color: rgb(255, 0, 0); font-size: 20px;">big block</p>'
+
+    const nodes = importColors(html, { withConfig: true })
+    expect(nodes).toHaveLength(1)
+    expect(nodes[0].text).toBe("big block")
+    expect(parseStyleMap(nodes[0].style)).toEqual({
+      color: "rgb(255, 0, 0)",
+      "font-size": "20px"
+    })
+  })
+
   it("keeps an inner span's own color instead of inheriting the outer color", () => {
     // Pasted content nests colored spans. The outer span's after-callback runs
     // after the inner span is converted, so it must merge (inner color wins)

--- a/engines/collavre/app/javascript/lib/lexical/__tests__/color_import.test.js
+++ b/engines/collavre/app/javascript/lib/lexical/__tests__/color_import.test.js
@@ -39,7 +39,10 @@ function importColors(html, { withConfig }) {
       })
       result = root.getAllTextNodes().map((node) => ({
         text: node.getTextContent(),
-        style: node.getStyle()
+        style: node.getStyle(),
+        formats: ["bold", "italic", "underline", "strikethrough", "subscript", "superscript"].filter(
+          (f) => node.hasFormat(f)
+        )
       }))
     },
     { discrete: true }
@@ -58,8 +61,8 @@ describe("colorAwareSpanImport", () => {
 
     const nodes = importColors(html, { withConfig: true })
     expect(nodes).toEqual([
-      { text: "hello", style: "" },
-      { text: "RED", style: "color: rgb(255, 0, 0)" }
+      { text: "hello", style: "", formats: [] },
+      { text: "RED", style: "color: rgb(255, 0, 0)", formats: [] }
     ])
   })
 
@@ -81,7 +84,26 @@ describe("colorAwareSpanImport", () => {
       '<p><span style="background-color: rgb(255, 255, 0); white-space: pre-wrap;">hi</span></p>'
 
     const nodes = importColors(html, { withConfig: true })
-    expect(nodes).toEqual([{ text: "hi", style: "background-color: rgb(255, 255, 0)" }])
+    expect(nodes).toEqual([
+      { text: "hi", style: "background-color: rgb(255, 255, 0)", formats: [] }
+    ])
+  })
+
+  it("preserves inline-style text formatting on a span that also carries color", () => {
+    // Pasted content (Google Docs / Word) encodes bold/italic/underline as
+    // inline span styles, not <b>/<i> tags. The custom span import must compose
+    // those formats with the color binding instead of dropping them.
+    const html =
+      '<p><span style="color: rgb(255, 0, 0); font-weight: 700; font-style: italic; ' +
+      'text-decoration: underline line-through; white-space: pre-wrap;">styled</span></p>'
+
+    const nodes = importColors(html, { withConfig: true })
+    expect(nodes).toHaveLength(1)
+    expect(nodes[0].text).toBe("styled")
+    expect(nodes[0].style).toBe("color: rgb(255, 0, 0)")
+    expect(nodes[0].formats.sort()).toEqual(
+      ["bold", "italic", "strikethrough", "underline"].sort()
+    )
   })
 
   it("demonstrates the drift the fix removes (no config = color on wrong/lost node)", () => {

--- a/engines/collavre/app/javascript/lib/lexical/__tests__/color_import.test.js
+++ b/engines/collavre/app/javascript/lib/lexical/__tests__/color_import.test.js
@@ -181,6 +181,41 @@ describe("colorAwareSpanImport", () => {
     expect(inherit.find((n) => n.text === "still").formats).toEqual(["bold"])
   })
 
+  it("clears a tag-applied format when a colored span resets it", () => {
+    // Lexical's default conversion toggles bold on for the <b> tag before the
+    // colored span's after-callback runs. A reset value on the span (an
+    // inherited CSS property) must actively un-bold the text, not just claim the
+    // dimension — otherwise reopened/pasted content reopens as bold.
+    const nodes = importColors(
+      '<p><b><span style="color: rgb(255, 0, 0); font-weight: normal;">normal</span></b></p>',
+      { withConfig: true }
+    )
+    expect(nodes).toEqual([
+      { text: "normal", style: "color: rgb(255, 0, 0)", formats: [] }
+    ])
+
+    // Same for italic via <i> + font-style: normal.
+    const italic = importColors(
+      '<p><i><span style="color: rgb(255, 0, 0); font-style: normal;">upright</span></i></p>',
+      { withConfig: true }
+    )
+    expect(italic.find((n) => n.text === "upright").formats).toEqual([])
+  })
+
+  it("keeps an inherited strikethrough when a colored span only adds underline", () => {
+    // text-decoration propagates to descendants additively in CSS: an inner
+    // `text-decoration: underline` does NOT remove an ancestor's line-through.
+    // So a colored span must keep the tag-applied strikethrough and add underline
+    // (add-only), unlike the inherited font-weight/font-style reset above.
+    const nodes = importColors(
+      '<p><s><span style="color: rgb(255, 0, 0); text-decoration: underline;">both</span></s></p>',
+      { withConfig: true }
+    )
+    expect(nodes.find((n) => n.text === "both").formats.sort()).toEqual(
+      ["strikethrough", "underline"].sort()
+    )
+  })
+
   it("demonstrates the drift the fix removes (no config = color on wrong/lost node)", () => {
     const html =
       '<p><span style="white-space: pre-wrap;">hello</span></p>\n' +

--- a/engines/collavre/app/javascript/lib/lexical/__tests__/color_import.test.js
+++ b/engines/collavre/app/javascript/lib/lexical/__tests__/color_import.test.js
@@ -159,6 +159,28 @@ describe("colorAwareSpanImport", () => {
     expect(nodes.find((n) => n.text === "inner").style).toBe("color: rgb(0, 0, 255)")
   })
 
+  it("lets a nested span reset a text format the outer span turned on", () => {
+    // applyTextFormatFromStyle only turns formats ON, so without dimension
+    // tracking the outer span's after-callback re-bolds the inner text even
+    // though the inner span explicitly reset font-weight. The nearer span must
+    // win: an inner font-weight:normal un-bolds, while an inner span with no
+    // weight declaration still inherits the outer bold.
+    const reset = importColors(
+      '<p><span style="color: rgb(255, 0, 0); font-weight: 700;">bold ' +
+        '<span style="color: rgb(0, 0, 255); font-weight: normal;">normal</span></span></p>',
+      { withConfig: true }
+    )
+    expect(reset.find((n) => n.text === "bold ").formats).toEqual(["bold"])
+    expect(reset.find((n) => n.text === "normal").formats).toEqual([])
+
+    const inherit = importColors(
+      '<p><span style="color: rgb(255, 0, 0); font-weight: 700;">bold ' +
+        '<span style="color: rgb(0, 0, 255);">still</span></span></p>',
+      { withConfig: true }
+    )
+    expect(inherit.find((n) => n.text === "still").formats).toEqual(["bold"])
+  })
+
   it("demonstrates the drift the fix removes (no config = color on wrong/lost node)", () => {
     const html =
       '<p><span style="white-space: pre-wrap;">hello</span></p>\n' +

--- a/engines/collavre/app/javascript/lib/lexical/__tests__/color_import.test.js
+++ b/engines/collavre/app/javascript/lib/lexical/__tests__/color_import.test.js
@@ -1,0 +1,97 @@
+import { createEditor, $getRoot, $isTextNode, $createParagraphNode } from "lexical"
+import { $generateNodesFromDOM } from "@lexical/html"
+import { lexicalHtmlConfig } from "../color_import"
+
+// The jsdom jest environment exposes `window`/`document`/`DOMParser`, but
+// Lexical reaches for a few more browser globals at runtime.
+for (const key of ["getComputedStyle", "MutationObserver", "Text", "HTMLElement"]) {
+  if (typeof globalThis[key] === "undefined" && window[key]) {
+    globalThis[key] = window[key]
+  }
+}
+
+// Reproduces InlineLexicalEditor's InitialContentPlugin import path: parse the
+// stored HTML, generate nodes, and read back each text node's color style.
+function importColors(html, { withConfig }) {
+  const editor = createEditor({
+    namespace: "test",
+    onError(error) {
+      throw error
+    },
+    html: withConfig ? lexicalHtmlConfig : undefined
+  })
+
+  let result = []
+  editor.update(
+    () => {
+      const root = $getRoot()
+      root.getChildren().forEach((child) => child.remove())
+      const doc = new DOMParser().parseFromString(html, "text/html")
+      const nodes = $generateNodesFromDOM(editor, doc.body)
+      nodes.forEach((node) => {
+        if ($isTextNode(node)) {
+          const paragraph = $createParagraphNode()
+          paragraph.append(node)
+          root.append(paragraph)
+        } else {
+          root.append(node)
+        }
+      })
+      result = root.getAllTextNodes().map((node) => ({
+        text: node.getTextContent(),
+        style: node.getStyle()
+      }))
+    },
+    { discrete: true }
+  )
+  return result
+}
+
+describe("colorAwareSpanImport", () => {
+  it("keeps the color on the correct node when stored HTML has inter-block whitespace", () => {
+    // Lexical-exported HTML re-serialized by the server keeps a newline between
+    // block tags. Lexical drops that whitespace-only text node on import, which
+    // shifted positional color re-application onto the wrong node.
+    const html =
+      '<p><span style="white-space: pre-wrap;">hello</span></p>\n' +
+      '<p><span style="color: rgb(255, 0, 0); white-space: pre-wrap;">RED</span></p>'
+
+    const nodes = importColors(html, { withConfig: true })
+    expect(nodes).toEqual([
+      { text: "hello", style: "" },
+      { text: "RED", style: "color: rgb(255, 0, 0)" }
+    ])
+  })
+
+  it("keeps the color on the right node when a neighbouring pre-wrap span splits on a newline", () => {
+    // `white-space: pre-wrap` makes Lexical split this span's text into two
+    // nodes on the "\n", turning one DOM text node into two lexical nodes.
+    const html =
+      '<p><span style="white-space: pre-wrap;">line one\nline two</span></p>' +
+      '<p><span style="color: rgb(0, 128, 0); white-space: pre-wrap;">GREEN</span></p>'
+
+    const nodes = importColors(html, { withConfig: true })
+    expect(nodes.map((n) => n.text)).toEqual(["line one", "line two", "GREEN"])
+    expect(nodes.find((n) => n.text === "GREEN").style).toBe("color: rgb(0, 128, 0)")
+    expect(nodes.find((n) => n.text === "line two").style).toBe("")
+  })
+
+  it("preserves background-color", () => {
+    const html =
+      '<p><span style="background-color: rgb(255, 255, 0); white-space: pre-wrap;">hi</span></p>'
+
+    const nodes = importColors(html, { withConfig: true })
+    expect(nodes).toEqual([{ text: "hi", style: "background-color: rgb(255, 255, 0)" }])
+  })
+
+  it("demonstrates the drift the fix removes (no config = color on wrong/lost node)", () => {
+    const html =
+      '<p><span style="white-space: pre-wrap;">hello</span></p>\n' +
+      '<p><span style="color: rgb(255, 0, 0); white-space: pre-wrap;">RED</span></p>'
+
+    // Without the color-aware import, Lexical's default span conversion ignores
+    // color entirely, so "RED" comes back uncolored.
+    const nodes = importColors(html, { withConfig: false })
+    expect(nodes.find((n) => n.text === "RED").style).not.toContain("color: rgb(255, 0, 0)")
+  })
+})

--- a/engines/collavre/app/javascript/lib/lexical/__tests__/color_import.test.js
+++ b/engines/collavre/app/javascript/lib/lexical/__tests__/color_import.test.js
@@ -2,12 +2,16 @@ import { createEditor, $getRoot, $isTextNode, $createParagraphNode } from "lexic
 import { $generateNodesFromDOM } from "@lexical/html"
 import { lexicalHtmlConfig } from "../color_import"
 
-// The jsdom jest environment exposes `window`/`document`/`DOMParser`, but
-// Lexical reaches for a few more browser globals at runtime.
-for (const key of ["getComputedStyle", "MutationObserver", "Text", "HTMLElement"]) {
-  if (typeof globalThis[key] === "undefined" && window[key]) {
-    globalThis[key] = window[key]
-  }
+// Parse an inline style string into a plain object so order doesn't matter.
+function parseStyleMap(styleText) {
+  const map = {}
+  ;(styleText || "").split(";").forEach((decl) => {
+    const idx = decl.indexOf(":")
+    if (idx === -1) return
+    const key = decl.slice(0, idx).trim()
+    if (key) map[key] = decl.slice(idx + 1).trim()
+  })
+  return map
 }
 
 // Reproduces InlineLexicalEditor's InitialContentPlugin import path: parse the
@@ -104,6 +108,32 @@ describe("colorAwareSpanImport", () => {
     expect(nodes[0].formats.sort()).toEqual(
       ["bold", "italic", "strikethrough", "underline"].sort()
     )
+  })
+
+  it("keeps an inner span's own color instead of inheriting the outer color", () => {
+    // Pasted content nests colored spans. The outer span's after-callback runs
+    // after the inner span is converted, so it must merge (inner color wins)
+    // rather than clobber every descendant with the outer color.
+    const html =
+      '<p><span style="color: rgb(255, 0, 0);">outer ' +
+      '<span style="color: rgb(0, 0, 255);">inner</span></span></p>'
+
+    const nodes = importColors(html, { withConfig: true })
+    expect(nodes.find((n) => n.text === "outer ").style).toBe("color: rgb(255, 0, 0)")
+    expect(nodes.find((n) => n.text === "inner").style).toBe("color: rgb(0, 0, 255)")
+  })
+
+  it("preserves an inner span's background-color while inheriting the outer color", () => {
+    const html =
+      '<p><span style="color: rgb(255, 0, 0);">outer ' +
+      '<span style="background-color: rgb(255, 255, 0);">inner</span></span></p>'
+
+    const nodes = importColors(html, { withConfig: true })
+    const inner = nodes.find((n) => n.text === "inner")
+    expect(parseStyleMap(inner.style)).toEqual({
+      "background-color": "rgb(255, 255, 0)",
+      color: "rgb(255, 0, 0)"
+    })
   })
 
   it("demonstrates the drift the fix removes (no config = color on wrong/lost node)", () => {

--- a/engines/collavre/app/javascript/lib/lexical/color_import.js
+++ b/engines/collavre/app/javascript/lib/lexical/color_import.js
@@ -1,39 +1,22 @@
 import { $isElementNode, $isTextNode } from "lexical"
 
-// Tracks, per lexical text node, which format dimensions a nearer (more deeply
-// nested) span has already decided during this import. Child span `after`
-// callbacks run before their ancestors', so a nested span claims its
-// dimensions first and an ancestor must not override them. Keyed by node, so
-// entries fall away with the nodes; distinct nodes never collide across imports.
+// Per text node, which format dimensions a nearer (more nested) span already
+// decided this import. Child span `after` callbacks run before ancestors', so a
+// nested span claims its dimensions first and ancestors must not override them.
 const decidedFormats = new WeakMap()
 
-// Mirrors Lexical's internal applyTextFormatFromStyle (Lexical's
-// convertSpanElement) for the inline-style text formats it reads off a <span>:
-// font-weight / font-style / text-decoration / vertical-align. Lexical does not
-// export it, so we replicate it here — our custom span import must COMPOSE these
-// formats with the color binding, not bypass them. Pasted content (Google Docs,
-// Word) carries bold/italic/underline as inline span styles rather than <b>/<i>
-// tags, so dropping this would lose that formatting on reopen.
+// Replicates Lexical's (non-exported) inline-style format reading for <span>:
+// font-weight / font-style / text-decoration / vertical-align. Pasted content
+// (Google Docs, Word) carries bold/italic as inline styles, not <b>/<i> tags,
+// so our custom span import must compose these formats with the color binding.
 //
-// `applyTextFormatFromStyle` only turns formats ON (toggleFormat when the value
-// matches), so a nested span that RESETS a format — e.g.
-// <span font-weight:700>bold <span font-weight:normal>normal</span></span> —
-// cannot un-bold itself once an ancestor re-applies bold over every descendant.
-// To honour resets we treat a dimension as "decided" by the FIRST (nearest)
-// span that declares it at all: if the inner span sets font-weight (even to
-// `normal`), it owns the bold dimension for that text and the outer span skips
-// it. A span that omits a declaration leaves the dimension open, so the format
-// still inherits from the ancestor (matching CSS).
-//
-// Declaring a dimension is also not enough when an ANCESTOR TAG (<b>/<strong>,
-// <i>/<em>) already toggled the format on via Lexical's default conversion —
-// e.g. <b><span font-weight:normal>normal</span></b>. Our span `after` callback
-// runs after that tag's forChild, so for genuinely-inherited CSS properties
-// (font-weight, font-style) a reset value must actively CLEAR the format, not
-// just claim the dimension. text-decoration and vertical-align are NOT cleared
-// on a non-matching value: in CSS those propagate to descendants additively
-// (an inner `text-decoration: underline` does not remove an ancestor's
-// line-through), so they stay add-only to avoid stripping inherited decorations.
+// Lexical only turns formats ON, so a nested reset (font-weight:normal) can't
+// un-bold itself once an ancestor re-applies bold. We treat a dimension as
+// decided by the FIRST (nearest) span that declares it at all, so the inner
+// span owns it; an omitted declaration leaves it open to inherit from ancestors.
+// For inherited CSS props (font-weight, font-style) a reset value also actively
+// CLEARS a format an ancestor tag (<b>/<i>) already toggled. text-decoration /
+// vertical-align stay add-only (they propagate additively in CSS).
 function applyTextFormatFromStyle(node, domStyle) {
   const fontWeight = domStyle.fontWeight
   const textDecoration = domStyle.textDecoration
@@ -41,8 +24,7 @@ function applyTextFormatFromStyle(node, domStyle) {
   const verticalAlign = domStyle.verticalAlign
   const decorations = (textDecoration || "").split(" ")
 
-  // [declared by this span?, value matches the format?, format name, resettable?]
-  // resettable = inherited CSS property whose reset value clears the format.
+  // [declared by this span?, value matches format?, format name, resettable?]
   const rules = [
     [Boolean(fontWeight), fontWeight === "700" || fontWeight === "bold", "bold", true],
     [Boolean(textDecoration), decorations.includes("line-through"), "strikethrough", false],
@@ -58,9 +40,7 @@ function applyTextFormatFromStyle(node, domStyle) {
     if (shouldApply && !node.hasFormat(format)) {
       node.toggleFormat(format)
     } else if (resettable && declared && !shouldApply && node.hasFormat(format)) {
-      // Explicit reset (font-weight:normal / font-style:normal) clears a format
-      // an ancestor tag or converter already applied.
-      node.toggleFormat(format)
+      node.toggleFormat(format) // explicit reset clears an ancestor's format
     }
     if (declared) {
       if (!decided) {
@@ -72,37 +52,26 @@ function applyTextFormatFromStyle(node, domStyle) {
   })
 }
 
-// For each property applyTextFormatFromStyle consumes, the exact values it maps
-// to a Lexical format (or a reset that clears one). Only these (property, value)
-// pairs are kept OUT of the carried node style — carrying them too would
-// double-represent bold/italic/etc. Crucially this is value-aware, not
-// property-wide: a value the formatter does NOT map (font-weight:800,
-// font-style:oblique, vertical-align:middle) is not turned into a format, so it
-// must be carried as inline style or it would be silently dropped on reopen —
-// exactly what the removed positional collector preserved by copying the full
-// style string.
+// The exact (property, value) pairs applyTextFormatFromStyle turns into a format
+// or reset. Only these are kept OUT of the carried node style (carrying them too
+// would double-represent the format). Value-aware on purpose: an unmapped value
+// (font-weight:800, font-style:oblique, vertical-align:middle) must be carried
+// as inline style or it's silently dropped on reopen.
 const FORMAT_MAPPED_VALUES = {
   "font-weight": new Set(["700", "bold", "normal"]),
   "font-style": new Set(["italic", "normal"]),
   "vertical-align": new Set(["sub", "super"])
 }
 
-// `text-decoration` is dropped wholesale: its tokens (underline / line-through)
-// become Lexical underline / strikethrough formats, which Lexical re-exports by
-// writing its OWN text-decoration on the span. Carrying a remainder token (e.g.
-// `overline`) here would collide with that exported declaration, so unmapped
-// decoration tokens are not preserved (a deliberate boundary). `white-space` is
-// Lexical's own exportDOM artifact (stamped on every span), not user intent.
+// text-decoration is dropped wholesale: its tokens become formats that Lexical
+// re-exports as its own text-decoration, so a remainder token would collide.
+// white-space is Lexical's exportDOM artifact, not user intent.
 const DROPPED_STYLE_PROPS = new Set(["text-decoration", "white-space"])
 
-// Every inline style declaration on the element that should be carried onto the
-// text nodes it produces: ALL of them except (a) the values that become Lexical
-// formats and (b) Lexical's white-space artifact / text-decoration. This
-// preserves color, background-color, font-size, font-family, text-transform,
-// letter-spacing, unmapped font-weight/font-style/vertical-align — and any
-// future text-level style — instead of cherry-picking individual properties. It
-// mirrors the full-style copy the removed positional collector did, so reopening
-// pasted/legacy content keeps every styled attribute, not just color.
+// Every inline declaration to carry onto the produced text nodes: all of them
+// except format-mapped values and the dropped props above. Preserves color,
+// background, font-size/family, text-transform, etc. without cherry-picking,
+// mirroring the full-style copy the removed positional collector did.
 function carriedStyleDeclarations(domStyle) {
   const map = new Map()
   for (let i = 0; i < domStyle.length; i++) {
@@ -110,7 +79,7 @@ function carriedStyleDeclarations(domStyle) {
     if (DROPPED_STYLE_PROPS.has(prop)) continue
     const value = domStyle.getPropertyValue(prop)
     const mapped = FORMAT_MAPPED_VALUES[prop]
-    if (mapped && mapped.has(value)) continue // becomes a format — don't double-carry
+    if (mapped && mapped.has(value)) continue
     map.set(prop, value)
   }
   return map
@@ -134,13 +103,9 @@ function serializeStyle(map) {
     .join("; ")
 }
 
-// `inherited` is the parent span's carried style declarations as a Map (color,
-// background-color, font-size, font-family, … — see carriedStyleDeclarations).
-// We MERGE rather than overwrite: a descendant text node that already carries
-// its own declaration (from a deeper colored span converted first) keeps it —
-// the inner value wins, matching CSS inheritance. The parent only fills in
-// declarations the node is missing. Clobbering here would turn nested content
-// like <span color:red>outer <span color:blue>inner</span></span> all red.
+// Merge (not overwrite) inherited declarations: a node that already carries its
+// own value (from a deeper colored span converted first) keeps it — inner wins,
+// matching CSS inheritance. The parent only fills in what's missing.
 function applyStyleToTextNodes(nodes, inherited, domStyle) {
   nodes.forEach((node) => {
     if ($isTextNode(node)) {
@@ -156,40 +121,18 @@ function applyStyleToTextNodes(nodes, inherited, domStyle) {
   })
 }
 
-// Custom HTML import for <span> that binds the span's inline style (color,
-// background-color, font-size, … — everything except format props and
-// white-space) to the text nodes it produces, at import time.
+// Custom <span> import: binds the span's inline style (color, background, and
+// every other non-format/non-white-space prop) to its text nodes AT IMPORT TIME.
+// The editor used to re-apply collected styles positionally to
+// root.getAllTextNodes(), which drifts whenever Lexical's importer doesn't map
+// DOM text nodes 1:1 (white-space:pre-wrap splits on \n/\t; whitespace-only
+// nodes are dropped). Binding during conversion keeps style on the right node.
 //
-// Lexical's default span import (applyTextFormatFromStyle) only reads
-// font-weight / font-style / text-decoration — it ignores color, background and
-// every other non-format style. The editor used to compensate by collecting one
-// style per DOM text node and re-applying them positionally to
-// root.getAllTextNodes() after import. That drifts whenever Lexical's importer
-// does not produce a 1:1, same-order mapping of DOM text nodes to lexical text
-// nodes — and it frequently does not:
-//   - TextNode.exportDOM stamps `white-space: pre-wrap` on every span, so on
-//     re-import isNodePre() is true and a span's text is split on "\n"/"\t"
-//     into multiple nodes (one DOM text node -> N lexical nodes).
-//   - whitespace-only text nodes (e.g. newlines between block tags in
-//     server-stored / Trix-migrated HTML) are dropped on import but still
-//     counted by the collector.
-// Any such mismatch shifts every subsequent style onto the wrong text node, so
-// reopening the editor showed the color applied somewhere else (or lost).
-//
-// Binding the style during conversion keeps it attached to the right node
-// regardless of how Lexical splits or drops surrounding text. We carry the
-// span's FULL style set (not just color) so font-size / font-family /
-// text-transform / letter-spacing survive reopen too — the positional collector
-// copied the parent's whole style string, and cherry-picking individual
-// properties here drops the rest.
-//
-// We still only take over when the span actually carries color/background:
-// Lexical's default span conversion already handles a colorless span, so
-// deferring there avoids changing behaviour for content this fix isn't about.
+// We only take over when the span carries color/background — Lexical's default
+// conversion already handles colorless spans, so deferring avoids behavior change.
 export function colorAwareSpanImport(domNode) {
   const { color, backgroundColor } = domNode.style
   if (!color && !backgroundColor) {
-    // Defer to Lexical's default span conversion (format-from-style).
     return null
   }
 
@@ -213,34 +156,14 @@ export const lexicalHtmlConfig = {
   }
 }
 
-// Lexical's html.import is keyed per tag, and colorAwareSpanImport only runs for
-// <span>. Color / background-color that sits on a NON-span element — e.g.
-// `<p style="color: red">text</p>`, a `<li>`/`<h1>` carrying color, or a
-// materialized data-lexical-color on a block element (common in legacy /
-// Trix-migrated or pasted content) — would otherwise be dropped on import,
-// because Lexical's default block conversions ignore color. The removed
-// positional collector read each text node's IMMEDIATE parent element regardless
-// of tag, so it preserved these.
-//
-// Normalize the DOM before import: for each colored non-span element, wrap its
-// DIRECT text-node children in a <span> carrying that element's FULL inline
-// style, so the span importer binds it like any other span. We only push onto
-// direct text children (matching the old immediate-parent semantics) — nested
-// colored elements keep their own style and win via the merge in
-// applyStyleToTextNodes. Run this AFTER syncLexicalStyleAttributes so
-// data-lexical-* attributes are already materialized into inline style.
-//
-// The wrapper copies the element's entire style string rather than selected
-// properties: a block element can carry color plus arbitrary text styles — e.g.
-// pasted <p style="color:red; font-weight:700; font-size:20px">. Lexical's
-// default block conversion ignores those styles, and the old positional
-// collector applied the parent's full style string to the text node, so cherry-
-// picking would drop whatever properties we forgot. colorAwareSpanImport then
-// decides what to keep as node style vs. apply as a format vs. drop (white-space),
-// uniformly for spans and these wrappers — block-level declarations like
-// text-align/margin ride along harmlessly on the (inline) wrapper and are
-// re-exported on the text node's span, exactly as the positional collector left
-// them; the block keeps its own style for paragraph-level alignment.
+// colorAwareSpanImport only runs for <span>. Color on a non-span element (a
+// colored <p>/<li>/<h1>, or a materialized data-lexical-color on a block) would
+// be dropped, since Lexical's default block conversions ignore color. Before
+// import (and AFTER syncLexicalStyleAttributes materializes data-lexical-*), wrap
+// each colored non-span's direct text children in a span carrying its full style,
+// so the span importer binds it. Nested colored elements keep their own style and
+// win via the merge in applyStyleToTextNodes. Block-level props (text-align,
+// margin) ride along harmlessly on the inline wrapper.
 const TEXT_NODE = 3
 
 export function normalizeColoredContainers(root) {

--- a/engines/collavre/app/javascript/lib/lexical/color_import.js
+++ b/engines/collavre/app/javascript/lib/lexical/color_import.js
@@ -1,5 +1,12 @@
 import { $isElementNode, $isTextNode } from "lexical"
 
+// Tracks, per lexical text node, which format dimensions a nearer (more deeply
+// nested) span has already decided during this import. Child span `after`
+// callbacks run before their ancestors', so a nested span claims its
+// dimensions first and an ancestor must not override them. Keyed by node, so
+// entries fall away with the nodes; distinct nodes never collide across imports.
+const decidedFormats = new WeakMap()
+
 // Mirrors Lexical's internal applyTextFormatFromStyle (Lexical's
 // convertSpanElement) for the inline-style text formats it reads off a <span>:
 // font-weight / font-style / text-decoration / vertical-align. Lexical does not
@@ -7,23 +14,45 @@ import { $isElementNode, $isTextNode } from "lexical"
 // formats with the color binding, not bypass them. Pasted content (Google Docs,
 // Word) carries bold/italic/underline as inline span styles rather than <b>/<i>
 // tags, so dropping this would lose that formatting on reopen.
+//
+// `applyTextFormatFromStyle` only turns formats ON (toggleFormat when the value
+// matches), so a nested span that RESETS a format — e.g.
+// <span font-weight:700>bold <span font-weight:normal>normal</span></span> —
+// cannot un-bold itself once an ancestor re-applies bold over every descendant.
+// To honour resets we treat a dimension as "decided" by the FIRST (nearest)
+// span that declares it at all: if the inner span sets font-weight (even to
+// `normal`), it owns the bold dimension for that text and the outer span skips
+// it. A span that omits a declaration leaves the dimension open, so the format
+// still inherits from the ancestor (matching CSS).
 function applyTextFormatFromStyle(node, domStyle) {
   const fontWeight = domStyle.fontWeight
-  const textDecoration = (domStyle.textDecoration || "").split(" ")
+  const textDecoration = domStyle.textDecoration
+  const fontStyle = domStyle.fontStyle
   const verticalAlign = domStyle.verticalAlign
+  const decorations = (textDecoration || "").split(" ")
 
-  const toggles = [
-    [fontWeight === "700" || fontWeight === "bold", "bold"],
-    [textDecoration.includes("line-through"), "strikethrough"],
-    [domStyle.fontStyle === "italic", "italic"],
-    [textDecoration.includes("underline"), "underline"],
-    [verticalAlign === "sub", "subscript"],
-    [verticalAlign === "super", "superscript"]
+  // [dimension declared by this span?, value matches the format?, format name]
+  const rules = [
+    [Boolean(fontWeight), fontWeight === "700" || fontWeight === "bold", "bold"],
+    [Boolean(textDecoration), decorations.includes("line-through"), "strikethrough"],
+    [Boolean(fontStyle), fontStyle === "italic", "italic"],
+    [Boolean(textDecoration), decorations.includes("underline"), "underline"],
+    [Boolean(verticalAlign), verticalAlign === "sub", "subscript"],
+    [Boolean(verticalAlign), verticalAlign === "super", "superscript"]
   ]
 
-  toggles.forEach(([shouldApply, format]) => {
+  let decided = decidedFormats.get(node)
+  rules.forEach(([declared, shouldApply, format]) => {
+    if (decided && decided.has(format)) return
     if (shouldApply && !node.hasFormat(format)) {
       node.toggleFormat(format)
+    }
+    if (declared) {
+      if (!decided) {
+        decided = new Set()
+        decidedFormats.set(node, decided)
+      }
+      decided.add(format)
     }
   })
 }

--- a/engines/collavre/app/javascript/lib/lexical/color_import.js
+++ b/engines/collavre/app/javascript/lib/lexical/color_import.js
@@ -24,6 +24,16 @@ const decidedFormats = new WeakMap()
 // `normal`), it owns the bold dimension for that text and the outer span skips
 // it. A span that omits a declaration leaves the dimension open, so the format
 // still inherits from the ancestor (matching CSS).
+//
+// Declaring a dimension is also not enough when an ANCESTOR TAG (<b>/<strong>,
+// <i>/<em>) already toggled the format on via Lexical's default conversion —
+// e.g. <b><span font-weight:normal>normal</span></b>. Our span `after` callback
+// runs after that tag's forChild, so for genuinely-inherited CSS properties
+// (font-weight, font-style) a reset value must actively CLEAR the format, not
+// just claim the dimension. text-decoration and vertical-align are NOT cleared
+// on a non-matching value: in CSS those propagate to descendants additively
+// (an inner `text-decoration: underline` does not remove an ancestor's
+// line-through), so they stay add-only to avoid stripping inherited decorations.
 function applyTextFormatFromStyle(node, domStyle) {
   const fontWeight = domStyle.fontWeight
   const textDecoration = domStyle.textDecoration
@@ -31,20 +41,25 @@ function applyTextFormatFromStyle(node, domStyle) {
   const verticalAlign = domStyle.verticalAlign
   const decorations = (textDecoration || "").split(" ")
 
-  // [dimension declared by this span?, value matches the format?, format name]
+  // [declared by this span?, value matches the format?, format name, resettable?]
+  // resettable = inherited CSS property whose reset value clears the format.
   const rules = [
-    [Boolean(fontWeight), fontWeight === "700" || fontWeight === "bold", "bold"],
-    [Boolean(textDecoration), decorations.includes("line-through"), "strikethrough"],
-    [Boolean(fontStyle), fontStyle === "italic", "italic"],
-    [Boolean(textDecoration), decorations.includes("underline"), "underline"],
-    [Boolean(verticalAlign), verticalAlign === "sub", "subscript"],
-    [Boolean(verticalAlign), verticalAlign === "super", "superscript"]
+    [Boolean(fontWeight), fontWeight === "700" || fontWeight === "bold", "bold", true],
+    [Boolean(textDecoration), decorations.includes("line-through"), "strikethrough", false],
+    [Boolean(fontStyle), fontStyle === "italic", "italic", true],
+    [Boolean(textDecoration), decorations.includes("underline"), "underline", false],
+    [Boolean(verticalAlign), verticalAlign === "sub", "subscript", false],
+    [Boolean(verticalAlign), verticalAlign === "super", "superscript", false]
   ]
 
   let decided = decidedFormats.get(node)
-  rules.forEach(([declared, shouldApply, format]) => {
+  rules.forEach(([declared, shouldApply, format, resettable]) => {
     if (decided && decided.has(format)) return
     if (shouldApply && !node.hasFormat(format)) {
+      node.toggleFormat(format)
+    } else if (resettable && declared && !shouldApply && node.hasFormat(format)) {
+      // Explicit reset (font-weight:normal / font-style:normal) clears a format
+      // an ancestor tag or converter already applied.
       node.toggleFormat(format)
     }
     if (declared) {

--- a/engines/collavre/app/javascript/lib/lexical/color_import.js
+++ b/engines/collavre/app/javascript/lib/lexical/color_import.js
@@ -72,6 +72,37 @@ function applyTextFormatFromStyle(node, domStyle) {
   })
 }
 
+// Style properties that become Lexical text FORMATS (applied via
+// applyTextFormatFromStyle), so they must NOT also be carried in the node's
+// style string — that would double-represent bold/italic/etc. `white-space` is
+// Lexical's own exportDOM artifact (stamped on every span), not user intent, so
+// it is dropped too.
+const NON_CARRIED_STYLE_PROPS = new Set([
+  "font-weight",
+  "font-style",
+  "text-decoration",
+  "vertical-align",
+  "white-space"
+])
+
+// Every inline style declaration on the element that should be carried onto the
+// text nodes it produces: ALL of them except the format-mapped props (which
+// become Lexical formats) and Lexical's white-space artifact. This preserves
+// color, background-color, font-size, font-family, text-transform,
+// letter-spacing — and any future text-level style — instead of cherry-picking
+// individual properties. It mirrors the full-style copy the removed positional
+// collector did, so reopening pasted/legacy content keeps every styled
+// attribute, not just color.
+function carriedStyleDeclarations(domStyle) {
+  const map = new Map()
+  for (let i = 0; i < domStyle.length; i++) {
+    const prop = domStyle.item(i)
+    if (NON_CARRIED_STYLE_PROPS.has(prop)) continue
+    map.set(prop, domStyle.getPropertyValue(prop))
+  }
+  return map
+}
+
 function parseStyle(styleText) {
   const map = new Map()
   ;(styleText || "").split(";").forEach((decl) => {
@@ -90,10 +121,11 @@ function serializeStyle(map) {
     .join("; ")
 }
 
-// `inherited` is the parent span's color/background-color declarations as a Map.
+// `inherited` is the parent span's carried style declarations as a Map (color,
+// background-color, font-size, font-family, … — see carriedStyleDeclarations).
 // We MERGE rather than overwrite: a descendant text node that already carries
-// its own color/background (from a deeper colored span converted first) keeps
-// it — inner color wins, matching CSS inheritance. The parent only fills in
+// its own declaration (from a deeper colored span converted first) keeps it —
+// the inner value wins, matching CSS inheritance. The parent only fills in
 // declarations the node is missing. Clobbering here would turn nested content
 // like <span color:red>outer <span color:blue>inner</span></span> all red.
 function applyStyleToTextNodes(nodes, inherited, domStyle) {
@@ -111,27 +143,36 @@ function applyStyleToTextNodes(nodes, inherited, domStyle) {
   })
 }
 
-// Custom HTML import for <span> that binds inline color / background-color to
-// the text nodes it produces, at import time.
+// Custom HTML import for <span> that binds the span's inline style (color,
+// background-color, font-size, … — everything except format props and
+// white-space) to the text nodes it produces, at import time.
 //
 // Lexical's default span import (applyTextFormatFromStyle) only reads
-// font-weight / font-style / text-decoration — it ignores color and
-// background-color. The editor used to compensate by collecting one style per
-// DOM text node and re-applying them positionally to root.getAllTextNodes()
-// after import. That drifts whenever Lexical's importer does not produce a
-// 1:1, same-order mapping of DOM text nodes to lexical text nodes — and it
-// frequently does not:
+// font-weight / font-style / text-decoration — it ignores color, background and
+// every other non-format style. The editor used to compensate by collecting one
+// style per DOM text node and re-applying them positionally to
+// root.getAllTextNodes() after import. That drifts whenever Lexical's importer
+// does not produce a 1:1, same-order mapping of DOM text nodes to lexical text
+// nodes — and it frequently does not:
 //   - TextNode.exportDOM stamps `white-space: pre-wrap` on every span, so on
 //     re-import isNodePre() is true and a span's text is split on "\n"/"\t"
 //     into multiple nodes (one DOM text node -> N lexical nodes).
 //   - whitespace-only text nodes (e.g. newlines between block tags in
 //     server-stored / Trix-migrated HTML) are dropped on import but still
 //     counted by the collector.
-// Any such mismatch shifts every subsequent color onto the wrong text node, so
+// Any such mismatch shifts every subsequent style onto the wrong text node, so
 // reopening the editor showed the color applied somewhere else (or lost).
 //
-// Binding the color during conversion keeps it attached to the right node
-// regardless of how Lexical splits or drops surrounding text.
+// Binding the style during conversion keeps it attached to the right node
+// regardless of how Lexical splits or drops surrounding text. We carry the
+// span's FULL style set (not just color) so font-size / font-family /
+// text-transform / letter-spacing survive reopen too — the positional collector
+// copied the parent's whole style string, and cherry-picking individual
+// properties here drops the rest.
+//
+// We still only take over when the span actually carries color/background:
+// Lexical's default span conversion already handles a colorless span, so
+// deferring there avoids changing behaviour for content this fix isn't about.
 export function colorAwareSpanImport(domNode) {
   const { color, backgroundColor } = domNode.style
   if (!color && !backgroundColor) {
@@ -139,9 +180,7 @@ export function colorAwareSpanImport(domNode) {
     return null
   }
 
-  const inherited = new Map()
-  if (color) inherited.set("color", color)
-  if (backgroundColor) inherited.set("background-color", backgroundColor)
+  const inherited = carriedStyleDeclarations(domNode.style)
 
   return {
     conversion: () => ({
@@ -171,24 +210,25 @@ export const lexicalHtmlConfig = {
 // of tag, so it preserved these.
 //
 // Normalize the DOM before import: for each colored non-span element, wrap its
-// DIRECT text-node children in a <span> carrying that element's color /
-// background-color, so the span importer binds it like any other span. We only
-// push onto direct text children (matching the old immediate-parent semantics) —
-// nested colored elements keep their own color and win via the merge in
+// DIRECT text-node children in a <span> carrying that element's FULL inline
+// style, so the span importer binds it like any other span. We only push onto
+// direct text children (matching the old immediate-parent semantics) — nested
+// colored elements keep their own style and win via the merge in
 // applyStyleToTextNodes. Run this AFTER syncLexicalStyleAttributes so
 // data-lexical-* attributes are already materialized into inline style.
 //
-// The wrapper also forwards the element's own inline TEXT-format declarations
-// (font-weight / font-style / text-decoration / vertical-align). A block element
-// can carry both color and formatting — e.g. pasted
-// <p style="color:red; font-weight:700">. Lexical's default block conversion
-// ignores those styles, and the old positional collector applied the parent's
-// full style string to the text node, so without forwarding them the bold/italic
-// would be dropped on reopen. colorAwareSpanImport's applyTextFormatFromStyle
-// then reads them off the wrapper span. Block-level styles (text-align, margin,
-// …) are intentionally NOT forwarded — they belong on the block, not the text.
+// The wrapper copies the element's entire style string rather than selected
+// properties: a block element can carry color plus arbitrary text styles — e.g.
+// pasted <p style="color:red; font-weight:700; font-size:20px">. Lexical's
+// default block conversion ignores those styles, and the old positional
+// collector applied the parent's full style string to the text node, so cherry-
+// picking would drop whatever properties we forgot. colorAwareSpanImport then
+// decides what to keep as node style vs. apply as a format vs. drop (white-space),
+// uniformly for spans and these wrappers — block-level declarations like
+// text-align/margin ride along harmlessly on the (inline) wrapper and are
+// re-exported on the text node's span, exactly as the positional collector left
+// them; the block keeps its own style for paragraph-level alignment.
 const TEXT_NODE = 3
-const FORWARDED_TEXT_STYLES = ["fontWeight", "fontStyle", "textDecoration", "verticalAlign"]
 
 export function normalizeColoredContainers(root) {
   if (!root || typeof root.querySelectorAll !== "function") return
@@ -202,11 +242,7 @@ export function normalizeColoredContainers(root) {
     Array.from(element.childNodes).forEach((child) => {
       if (child.nodeType !== TEXT_NODE || !child.nodeValue) return
       const span = ownerDocument.createElement("span")
-      if (color) span.style.color = color
-      if (backgroundColor) span.style.backgroundColor = backgroundColor
-      FORWARDED_TEXT_STYLES.forEach((prop) => {
-        if (element.style[prop]) span.style[prop] = element.style[prop]
-      })
+      span.setAttribute("style", element.getAttribute("style"))
       element.replaceChild(span, child)
       span.appendChild(child)
     })

--- a/engines/collavre/app/javascript/lib/lexical/color_import.js
+++ b/engines/collavre/app/javascript/lib/lexical/color_import.js
@@ -72,33 +72,46 @@ function applyTextFormatFromStyle(node, domStyle) {
   })
 }
 
-// Style properties that become Lexical text FORMATS (applied via
-// applyTextFormatFromStyle), so they must NOT also be carried in the node's
-// style string — that would double-represent bold/italic/etc. `white-space` is
-// Lexical's own exportDOM artifact (stamped on every span), not user intent, so
-// it is dropped too.
-const NON_CARRIED_STYLE_PROPS = new Set([
-  "font-weight",
-  "font-style",
-  "text-decoration",
-  "vertical-align",
-  "white-space"
-])
+// For each property applyTextFormatFromStyle consumes, the exact values it maps
+// to a Lexical format (or a reset that clears one). Only these (property, value)
+// pairs are kept OUT of the carried node style — carrying them too would
+// double-represent bold/italic/etc. Crucially this is value-aware, not
+// property-wide: a value the formatter does NOT map (font-weight:800,
+// font-style:oblique, vertical-align:middle) is not turned into a format, so it
+// must be carried as inline style or it would be silently dropped on reopen —
+// exactly what the removed positional collector preserved by copying the full
+// style string.
+const FORMAT_MAPPED_VALUES = {
+  "font-weight": new Set(["700", "bold", "normal"]),
+  "font-style": new Set(["italic", "normal"]),
+  "vertical-align": new Set(["sub", "super"])
+}
+
+// `text-decoration` is dropped wholesale: its tokens (underline / line-through)
+// become Lexical underline / strikethrough formats, which Lexical re-exports by
+// writing its OWN text-decoration on the span. Carrying a remainder token (e.g.
+// `overline`) here would collide with that exported declaration, so unmapped
+// decoration tokens are not preserved (a deliberate boundary). `white-space` is
+// Lexical's own exportDOM artifact (stamped on every span), not user intent.
+const DROPPED_STYLE_PROPS = new Set(["text-decoration", "white-space"])
 
 // Every inline style declaration on the element that should be carried onto the
-// text nodes it produces: ALL of them except the format-mapped props (which
-// become Lexical formats) and Lexical's white-space artifact. This preserves
-// color, background-color, font-size, font-family, text-transform,
-// letter-spacing — and any future text-level style — instead of cherry-picking
-// individual properties. It mirrors the full-style copy the removed positional
-// collector did, so reopening pasted/legacy content keeps every styled
-// attribute, not just color.
+// text nodes it produces: ALL of them except (a) the values that become Lexical
+// formats and (b) Lexical's white-space artifact / text-decoration. This
+// preserves color, background-color, font-size, font-family, text-transform,
+// letter-spacing, unmapped font-weight/font-style/vertical-align — and any
+// future text-level style — instead of cherry-picking individual properties. It
+// mirrors the full-style copy the removed positional collector did, so reopening
+// pasted/legacy content keeps every styled attribute, not just color.
 function carriedStyleDeclarations(domStyle) {
   const map = new Map()
   for (let i = 0; i < domStyle.length; i++) {
     const prop = domStyle.item(i)
-    if (NON_CARRIED_STYLE_PROPS.has(prop)) continue
-    map.set(prop, domStyle.getPropertyValue(prop))
+    if (DROPPED_STYLE_PROPS.has(prop)) continue
+    const value = domStyle.getPropertyValue(prop)
+    const mapped = FORMAT_MAPPED_VALUES[prop]
+    if (mapped && mapped.has(value)) continue // becomes a format — don't double-carry
+    map.set(prop, value)
   }
   return map
 }

--- a/engines/collavre/app/javascript/lib/lexical/color_import.js
+++ b/engines/collavre/app/javascript/lib/lexical/color_import.js
@@ -116,3 +116,41 @@ export const lexicalHtmlConfig = {
     span: colorAwareSpanImport
   }
 }
+
+// Lexical's html.import is keyed per tag, and colorAwareSpanImport only runs for
+// <span>. Color / background-color that sits on a NON-span element — e.g.
+// `<p style="color: red">text</p>`, a `<li>`/`<h1>` carrying color, or a
+// materialized data-lexical-color on a block element (common in legacy /
+// Trix-migrated or pasted content) — would otherwise be dropped on import,
+// because Lexical's default block conversions ignore color. The removed
+// positional collector read each text node's IMMEDIATE parent element regardless
+// of tag, so it preserved these.
+//
+// Normalize the DOM before import: for each colored non-span element, wrap its
+// DIRECT text-node children in a <span> carrying that element's color /
+// background-color, so the span importer binds it like any other span. We only
+// push onto direct text children (matching the old immediate-parent semantics) —
+// nested colored elements keep their own color and win via the merge in
+// applyStyleToTextNodes. Run this AFTER syncLexicalStyleAttributes so
+// data-lexical-* attributes are already materialized into inline style.
+const TEXT_NODE = 3
+
+export function normalizeColoredContainers(root) {
+  if (!root || typeof root.querySelectorAll !== "function") return
+  const ownerDocument = root.ownerDocument || document
+
+  root.querySelectorAll("[style]").forEach((element) => {
+    if (element.tagName === "SPAN") return
+    const { color, backgroundColor } = element.style
+    if (!color && !backgroundColor) return
+
+    Array.from(element.childNodes).forEach((child) => {
+      if (child.nodeType !== TEXT_NODE || !child.nodeValue) return
+      const span = ownerDocument.createElement("span")
+      if (color) span.style.color = color
+      if (backgroundColor) span.style.backgroundColor = backgroundColor
+      element.replaceChild(span, child)
+      span.appendChild(child)
+    })
+  })
+}

--- a/engines/collavre/app/javascript/lib/lexical/color_import.js
+++ b/engines/collavre/app/javascript/lib/lexical/color_import.js
@@ -1,11 +1,40 @@
 import { $isElementNode, $isTextNode } from "lexical"
 
-function applyStyleToTextNodes(nodes, styleText) {
+// Mirrors Lexical's internal applyTextFormatFromStyle (Lexical's
+// convertSpanElement) for the inline-style text formats it reads off a <span>:
+// font-weight / font-style / text-decoration / vertical-align. Lexical does not
+// export it, so we replicate it here — our custom span import must COMPOSE these
+// formats with the color binding, not bypass them. Pasted content (Google Docs,
+// Word) carries bold/italic/underline as inline span styles rather than <b>/<i>
+// tags, so dropping this would lose that formatting on reopen.
+function applyTextFormatFromStyle(node, domStyle) {
+  const fontWeight = domStyle.fontWeight
+  const textDecoration = (domStyle.textDecoration || "").split(" ")
+  const verticalAlign = domStyle.verticalAlign
+
+  const toggles = [
+    [fontWeight === "700" || fontWeight === "bold", "bold"],
+    [textDecoration.includes("line-through"), "strikethrough"],
+    [domStyle.fontStyle === "italic", "italic"],
+    [textDecoration.includes("underline"), "underline"],
+    [verticalAlign === "sub", "subscript"],
+    [verticalAlign === "super", "superscript"]
+  ]
+
+  toggles.forEach(([shouldApply, format]) => {
+    if (shouldApply && !node.hasFormat(format)) {
+      node.toggleFormat(format)
+    }
+  })
+}
+
+function applyStyleToTextNodes(nodes, styleText, domStyle) {
   nodes.forEach((node) => {
     if ($isTextNode(node)) {
       node.setStyle(styleText)
+      applyTextFormatFromStyle(node, domStyle)
     } else if ($isElementNode(node)) {
-      applyStyleToTextNodes(node.getChildren(), styleText)
+      applyStyleToTextNodes(node.getChildren(), styleText, domStyle)
     }
   })
 }
@@ -47,7 +76,7 @@ export function colorAwareSpanImport(domNode) {
     conversion: () => ({
       node: null,
       after: (childLexicalNodes) => {
-        applyStyleToTextNodes(childLexicalNodes, styleText)
+        applyStyleToTextNodes(childLexicalNodes, styleText, domNode.style)
         return childLexicalNodes
       }
     }),

--- a/engines/collavre/app/javascript/lib/lexical/color_import.js
+++ b/engines/collavre/app/javascript/lib/lexical/color_import.js
@@ -1,0 +1,62 @@
+import { $isElementNode, $isTextNode } from "lexical"
+
+function applyStyleToTextNodes(nodes, styleText) {
+  nodes.forEach((node) => {
+    if ($isTextNode(node)) {
+      node.setStyle(styleText)
+    } else if ($isElementNode(node)) {
+      applyStyleToTextNodes(node.getChildren(), styleText)
+    }
+  })
+}
+
+// Custom HTML import for <span> that binds inline color / background-color to
+// the text nodes it produces, at import time.
+//
+// Lexical's default span import (applyTextFormatFromStyle) only reads
+// font-weight / font-style / text-decoration — it ignores color and
+// background-color. The editor used to compensate by collecting one style per
+// DOM text node and re-applying them positionally to root.getAllTextNodes()
+// after import. That drifts whenever Lexical's importer does not produce a
+// 1:1, same-order mapping of DOM text nodes to lexical text nodes — and it
+// frequently does not:
+//   - TextNode.exportDOM stamps `white-space: pre-wrap` on every span, so on
+//     re-import isNodePre() is true and a span's text is split on "\n"/"\t"
+//     into multiple nodes (one DOM text node -> N lexical nodes).
+//   - whitespace-only text nodes (e.g. newlines between block tags in
+//     server-stored / Trix-migrated HTML) are dropped on import but still
+//     counted by the collector.
+// Any such mismatch shifts every subsequent color onto the wrong text node, so
+// reopening the editor showed the color applied somewhere else (or lost).
+//
+// Binding the color during conversion keeps it attached to the right node
+// regardless of how Lexical splits or drops surrounding text.
+export function colorAwareSpanImport(domNode) {
+  const { color, backgroundColor } = domNode.style
+  if (!color && !backgroundColor) {
+    // Defer to Lexical's default span conversion (format-from-style).
+    return null
+  }
+
+  const declarations = []
+  if (color) declarations.push(`color: ${color}`)
+  if (backgroundColor) declarations.push(`background-color: ${backgroundColor}`)
+  const styleText = declarations.join("; ")
+
+  return {
+    conversion: () => ({
+      node: null,
+      after: (childLexicalNodes) => {
+        applyStyleToTextNodes(childLexicalNodes, styleText)
+        return childLexicalNodes
+      }
+    }),
+    priority: 1
+  }
+}
+
+export const lexicalHtmlConfig = {
+  import: {
+    span: colorAwareSpanImport
+  }
+}

--- a/engines/collavre/app/javascript/lib/lexical/color_import.js
+++ b/engines/collavre/app/javascript/lib/lexical/color_import.js
@@ -28,13 +28,41 @@ function applyTextFormatFromStyle(node, domStyle) {
   })
 }
 
-function applyStyleToTextNodes(nodes, styleText, domStyle) {
+function parseStyle(styleText) {
+  const map = new Map()
+  ;(styleText || "").split(";").forEach((decl) => {
+    const idx = decl.indexOf(":")
+    if (idx === -1) return
+    const key = decl.slice(0, idx).trim()
+    const value = decl.slice(idx + 1).trim()
+    if (key) map.set(key, value)
+  })
+  return map
+}
+
+function serializeStyle(map) {
+  return Array.from(map.entries())
+    .map(([key, value]) => `${key}: ${value}`)
+    .join("; ")
+}
+
+// `inherited` is the parent span's color/background-color declarations as a Map.
+// We MERGE rather than overwrite: a descendant text node that already carries
+// its own color/background (from a deeper colored span converted first) keeps
+// it — inner color wins, matching CSS inheritance. The parent only fills in
+// declarations the node is missing. Clobbering here would turn nested content
+// like <span color:red>outer <span color:blue>inner</span></span> all red.
+function applyStyleToTextNodes(nodes, inherited, domStyle) {
   nodes.forEach((node) => {
     if ($isTextNode(node)) {
-      node.setStyle(styleText)
+      const merged = parseStyle(node.getStyle())
+      inherited.forEach((value, key) => {
+        if (!merged.has(key)) merged.set(key, value)
+      })
+      node.setStyle(serializeStyle(merged))
       applyTextFormatFromStyle(node, domStyle)
     } else if ($isElementNode(node)) {
-      applyStyleToTextNodes(node.getChildren(), styleText, domStyle)
+      applyStyleToTextNodes(node.getChildren(), inherited, domStyle)
     }
   })
 }
@@ -67,16 +95,15 @@ export function colorAwareSpanImport(domNode) {
     return null
   }
 
-  const declarations = []
-  if (color) declarations.push(`color: ${color}`)
-  if (backgroundColor) declarations.push(`background-color: ${backgroundColor}`)
-  const styleText = declarations.join("; ")
+  const inherited = new Map()
+  if (color) inherited.set("color", color)
+  if (backgroundColor) inherited.set("background-color", backgroundColor)
 
   return {
     conversion: () => ({
       node: null,
       after: (childLexicalNodes) => {
-        applyStyleToTextNodes(childLexicalNodes, styleText, domNode.style)
+        applyStyleToTextNodes(childLexicalNodes, inherited, domNode.style)
         return childLexicalNodes
       }
     }),

--- a/engines/collavre/app/javascript/lib/lexical/color_import.js
+++ b/engines/collavre/app/javascript/lib/lexical/color_import.js
@@ -177,7 +177,18 @@ export const lexicalHtmlConfig = {
 // nested colored elements keep their own color and win via the merge in
 // applyStyleToTextNodes. Run this AFTER syncLexicalStyleAttributes so
 // data-lexical-* attributes are already materialized into inline style.
+//
+// The wrapper also forwards the element's own inline TEXT-format declarations
+// (font-weight / font-style / text-decoration / vertical-align). A block element
+// can carry both color and formatting — e.g. pasted
+// <p style="color:red; font-weight:700">. Lexical's default block conversion
+// ignores those styles, and the old positional collector applied the parent's
+// full style string to the text node, so without forwarding them the bold/italic
+// would be dropped on reopen. colorAwareSpanImport's applyTextFormatFromStyle
+// then reads them off the wrapper span. Block-level styles (text-align, margin,
+// …) are intentionally NOT forwarded — they belong on the block, not the text.
 const TEXT_NODE = 3
+const FORWARDED_TEXT_STYLES = ["fontWeight", "fontStyle", "textDecoration", "verticalAlign"]
 
 export function normalizeColoredContainers(root) {
   if (!root || typeof root.querySelectorAll !== "function") return
@@ -193,6 +204,9 @@ export function normalizeColoredContainers(root) {
       const span = ownerDocument.createElement("span")
       if (color) span.style.color = color
       if (backgroundColor) span.style.backgroundColor = backgroundColor
+      FORWARDED_TEXT_STYLES.forEach((prop) => {
+        if (element.style[prop]) span.style[prop] = element.style[prop]
+      })
       element.replaceChild(span, child)
       span.appendChild(child)
     })

--- a/jest.environment.cjs
+++ b/jest.environment.cjs
@@ -12,6 +12,14 @@ class CustomJsdomEnvironment extends NodeEnvironment {
     this.global.DOMParser = window.DOMParser
     this.global.Node = window.Node
     this.global.Element = window.Element
+    // Lexical reads several browser globals — `navigator` at module-eval time
+    // (navigator.platform for IS_APPLE), the rest at runtime. Node 21+ exposes a
+    // global `navigator`, but older Node (CI) does not, so inject jsdom's.
+    this.global.navigator = window.navigator
+    this.global.getComputedStyle = window.getComputedStyle
+    this.global.MutationObserver = window.MutationObserver
+    this.global.Text = window.Text
+    this.global.HTMLElement = window.HTMLElement
   }
 
   async teardown() {

--- a/jest.environment.cjs
+++ b/jest.environment.cjs
@@ -13,9 +13,14 @@ class CustomJsdomEnvironment extends NodeEnvironment {
     this.global.Node = window.Node
     this.global.Element = window.Element
     // Lexical reads several browser globals — `navigator` at module-eval time
-    // (navigator.platform for IS_APPLE), the rest at runtime. Node 21+ exposes a
-    // global `navigator`, but older Node (CI) does not, so inject jsdom's.
-    this.global.navigator = window.navigator
+    // (navigator.platform for IS_APPLE), the rest at runtime. Node 21+ exposes
+    // `navigator` as a getter-only global, so a plain assignment can throw in
+    // strict mode; defineProperty replaces the read-only accessor with jsdom's.
+    Object.defineProperty(this.global, "navigator", {
+      value: window.navigator,
+      configurable: true,
+      writable: true,
+    })
     this.global.getComputedStyle = window.getComputedStyle
     this.global.MutationObserver = window.MutationObserver
     this.global.Text = window.Text


### PR DESCRIPTION
## Symptom
Applying a text color in the inline Lexical editor, then reopening the editor, showed the color applied to a **different location** (or lost entirely). Reported in Collavre: *"버그: lexical editor 글자 색상을 넣었는데, 다시 편집 열면 다른 곳에 적용되는 문제"*.

## Root cause
`InitialContentPlugin` collected one inline style per **DOM** text node (`collectDomTextStyles`, a `TreeWalker` over the parsed HTML) and re-applied them **positionally** to `root.getAllTextNodes()` after `$generateNodesFromDOM`.

Lexical's HTML importer does not produce a 1:1, same-order mapping:
- `TextNode.exportDOM` stamps `white-space: pre-wrap` on **every** span. On re-import `isNodePre()` is therefore true, so `$convertTextDOMNode` takes the preformatted branch and **splits the span's text on `\n`/`\t` into multiple nodes** (1 DOM text node → N lexical nodes).
- Whitespace-only text nodes (e.g. newlines between block tags in server-stored / Trix-migrated HTML) are **dropped** on import but still counted by the collector.

Any such count/order mismatch shifts every subsequent color onto the wrong text node.

Proven with a headless Lexical + jsdom reproduction: a red word after an inter-block newline came back uncolored, and a red word after a `\n`-containing neighbour span landed its color on the neighbour.

## Fix
Register a `colorAwareSpanImport` `html.import` override (priority 1, beats Lexical's default span conversion which ignores color) that binds `color`/`background-color` to the produced text nodes **during conversion** via the conversion `after` hook — so the color travels with the node regardless of how Lexical splits or drops surrounding text. The fragile positional re-application and `collectDomTextStyles` are removed.

`syncLexicalStyleAttributes` still runs first, so legacy `data-lexical-color` content (converted to inline style before import) is still covered.

## Tests
New Jest suite `lib/lexical/__tests__/color_import.test.js`:
- color stays on the right node with inter-block whitespace
- color stays on the right node when a neighbouring pre-wrap span splits on `\n`
- background-color preserved
- regression guard showing the pre-fix path loses the color

Full JS suite: **203/203 passing**.

Note: build artifacts under `app/assets/builds/` are gitignored (generated at deploy), so only source + tests are in this diff.