### PR TITLE
feat(collavre): notify when a deleted topic orphans a cron job

### DIFF
--- a/engines/collavre/app/controllers/collavre/topics_controller.rb
+++ b/engines/collavre/app/controllers/collavre/topics_controller.rb
@@ -108,10 +108,19 @@ module Collavre
       topic_name = topic.name
       topic.destroy
 
-      Collavre::Topics::OrphanedCronNotifier.new(
-        topic_id: topic_id,
-        topic_name: topic_name
-      ).call
+      # Best-effort orphaned-cron notice. Must never break the core deletion:
+      # if it raises, swallow + log so broadcast/head still run.
+      begin
+        Collavre::Topics::OrphanedCronNotifier.new(
+          topic_id: topic_id,
+          topic_name: topic_name
+        ).call
+      rescue StandardError => e
+        Rails.logger.error(
+          "[TopicsController#destroy] OrphanedCronNotifier failed for topic " \
+          "#{topic_id}: #{e.class} #{e.message}"
+        )
+      end
 
       broadcast_topic_event("deleted", topic_id: topic_id)
       head :no_content

--- a/engines/collavre/app/controllers/collavre/topics_controller.rb
+++ b/engines/collavre/app/controllers/collavre/topics_controller.rb
@@ -105,7 +105,13 @@ module Collavre
       end
 
       topic_id = topic.id
+      topic_name = topic.name
       topic.destroy
+
+      Collavre::Topics::OrphanedCronNotifier.new(
+        topic_id: topic_id,
+        topic_name: topic_name
+      ).call
 
       broadcast_topic_event("deleted", topic_id: topic_id)
       head :no_content

--- a/engines/collavre/app/services/collavre/crons/recurring_task_arguments.rb
+++ b/engines/collavre/app/services/collavre/crons/recurring_task_arguments.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Crons
+    # Shared parsing for SolidQueue::RecurringTask records that back our crons.
+    # The cron's creative_id/topic_id/agent_id/message live inside the task's
+    # `arguments` JSON (an array whose first element is the keyword hash), and
+    # the creative id is also encoded in the key as `cron_<creative_id>_<hex>`.
+    #
+    # Included by CronListService and Topics::OrphanedCronNotifier so the
+    # arguments format is parsed in exactly one place.
+    module RecurringTaskArguments
+      private
+
+      def parse_arguments(task)
+        args = task.arguments
+        return {} unless args.is_a?(Array) && args.first.is_a?(Hash)
+
+        args.first.stringify_keys
+      end
+
+      def parse_creative_id_from_key(key)
+        match = key.match(/\Acron_(\d+)_/)
+        match[1].to_i if match
+      end
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/tools/cron_list_service.rb
+++ b/engines/collavre/app/services/collavre/tools/cron_list_service.rb
@@ -5,6 +5,7 @@ module Tools
   class CronListService
     extend T::Sig
     extend ToolMeta
+    include Collavre::Crons::RecurringTaskArguments
 
     tool_name "cron_list"
     tool_description "List recurring scheduled jobs. Returns all cron jobs for creatives the current user has access to. Filter by creative_id to see jobs for a specific creative."
@@ -45,20 +46,6 @@ module Tools
       end
 
       { success: true, cron_jobs: results, count: results.size }
-    end
-
-    private
-
-    def parse_arguments(task)
-      args = task.arguments
-      return {} unless args.is_a?(Array) && args.first.is_a?(Hash)
-
-      args.first.stringify_keys
-    end
-
-    def parse_creative_id_from_key(key)
-      match = key.match(/\Acron_(\d+)_/)
-      match[1].to_i if match
     end
   end
 end

--- a/engines/collavre/app/services/collavre/topics/orphaned_cron_notifier.rb
+++ b/engines/collavre/app/services/collavre/topics/orphaned_cron_notifier.rb
@@ -43,7 +43,11 @@ module Collavre
         creative = Creative.find_by(id: creative_id)
         return unless creative
 
-        main_topic = creative.main_topic
+        # The recurring task stores the original (possibly linked/child) creative
+        # id, but Comment#use_origin_creative rewrites the comment to the origin.
+        # Post to the origin's Main topic so the notice stays on the origin and
+        # is reachable from normal topic navigation (matches CronCreateService).
+        main_topic = creative.effective_origin.main_topic
         return unless main_topic
 
         Comment.create!(

--- a/engines/collavre/app/services/collavre/topics/orphaned_cron_notifier.rb
+++ b/engines/collavre/app/services/collavre/topics/orphaned_cron_notifier.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Topics
+    # When a Topic is deleted, find every non-static recurring cron task that
+    # targets that topic (topic_id stored inside the task's arguments JSON) and
+    # post a system message into the affected creative's Main topic so the user
+    # knows the cron is now orphaned.
+    #
+    # Decision: notify only. The recurring task is intentionally left in place
+    # so the user can decide whether to re-point or cancel it.
+    class OrphanedCronNotifier
+      def initialize(topic_id:, topic_name:)
+        @topic_id = topic_id
+        @topic_name = topic_name
+      end
+
+      def call
+        return if @topic_id.blank?
+
+        matching_tasks.each do |task, args|
+          notify_for(task, args)
+        end
+      end
+
+      private
+
+      def matching_tasks
+        SolidQueue::RecurringTask.where(static: false).filter_map do |task|
+          args = parse_arguments(task)
+          target = args["topic_id"]
+          next if target.blank?
+          next unless target.to_i == @topic_id.to_i
+
+          [ task, args ]
+        end
+      end
+
+      def notify_for(task, args)
+        creative_id = args["creative_id"] || parse_creative_id_from_key(task.key)
+        creative = Creative.find_by(id: creative_id)
+        return unless creative
+
+        main_topic = creative.main_topic
+        return unless main_topic
+
+        Comment.create!(
+          creative: creative,
+          topic_id: main_topic.id,
+          user: nil, # System message
+          content: I18n.t(
+            "collavre.topics.orphaned_cron_notice",
+            topic_name: @topic_name,
+            cron_key: task.key,
+            message: args["message"]
+          )
+        )
+      end
+
+      def parse_arguments(task)
+        args = task.arguments
+        return {} unless args.is_a?(Array) && args.first.is_a?(Hash)
+
+        args.first.stringify_keys
+      end
+
+      def parse_creative_id_from_key(key)
+        match = key.match(/\Acron_(\d+)_/)
+        match[1].to_i if match
+      end
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/topics/orphaned_cron_notifier.rb
+++ b/engines/collavre/app/services/collavre/topics/orphaned_cron_notifier.rb
@@ -10,6 +10,8 @@ module Collavre
     # Decision: notify only. The recurring task is intentionally left in place
     # so the user can decide whether to re-point or cancel it.
     class OrphanedCronNotifier
+      include Collavre::Crons::RecurringTaskArguments
+
       def initialize(topic_id:, topic_name:)
         @topic_id = topic_id
         @topic_name = topic_name
@@ -48,6 +50,7 @@ module Collavre
           creative: creative,
           topic_id: main_topic.id,
           user: nil, # System message
+          skip_default_user: true, # keep user nil even when a deleter is Current.user; don't trigger AI orchestration
           content: I18n.t(
             "collavre.topics.orphaned_cron_notice",
             topic_name: @topic_name,
@@ -55,18 +58,6 @@ module Collavre
             message: args["message"]
           )
         )
-      end
-
-      def parse_arguments(task)
-        args = task.arguments
-        return {} unless args.is_a?(Array) && args.first.is_a?(Hash)
-
-        args.first.stringify_keys
-      end
-
-      def parse_creative_id_from_key(key)
-        match = key.match(/\Acron_(\d+)_/)
-        match[1].to_i if match
       end
     end
   end

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -13,6 +13,7 @@ en:
       branch_prefix: "Branch"
       main_name: "Main"
       cannot_delete_main: "Cannot delete the Main topic."
+      orphaned_cron_notice: "[System] The topic '%{topic_name}' was deleted, but a recurring cron job (%{cron_key}) still targets it and will silently do nothing on each run. Original message: \"%{message}\". Re-point it to another topic or cancel it with cron_cancel."
       create_and_move: 'Create "%{name}" and move'
       move:
         no_target_permission: You don't have write permission on the target creative.

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -13,6 +13,7 @@ ko:
       branch_prefix: "분기"
       main_name: "메인"
       cannot_delete_main: "메인 토픽은 삭제할 수 없습니다."
+      orphaned_cron_notice: "[시스템] '%{topic_name}' 토픽이 삭제되었지만, 이 토픽을 대상으로 하는 반복 크론 작업(%{cron_key})이 아직 남아 있어 실행될 때마다 아무 동작도 하지 않고 조용히 종료됩니다. 원래 메시지: \"%{message}\". 다른 토픽으로 다시 지정하거나 cron_cancel로 취소하세요."
       create_and_move: '"%{name}" 생성후 이동'
       move:
         no_target_permission: 대상 크리에이티브에 대한 쓰기 권한이 없습니다.

--- a/engines/collavre/test/services/collavre/topics/orphaned_cron_notifier_test.rb
+++ b/engines/collavre/test/services/collavre/topics/orphaned_cron_notifier_test.rb
@@ -92,6 +92,30 @@ module Collavre
         assert_nil notice.user_id, "notice must remain a system message (user nil)"
       end
 
+      test "posts to the origin's main topic when the cron creative is a linked/child creative" do
+        # CronCreateService resolves the target topic on the origin but stores the
+        # original (linked) creative id. The notice must land on the origin's Main
+        # topic, consistent with Comment#use_origin_creative rewriting to origin.
+        other_user = Collavre::User.create!(
+          name: "Sharee",
+          email: "sharee-#{SecureRandom.hex(4)}@test.test",
+          password: "password123"
+        )
+        linked = Collavre::Creative.create!(origin_id: @creative.id, user: other_user)
+
+        create_cron(creative_id: linked.id, topic_id: @topic.id)
+        deleted_id = @topic.id
+        @topic.destroy!
+
+        OrphanedCronNotifier.new(topic_id: deleted_id, topic_name: "Counseling").call
+
+        notice = @creative.reload.comments.where(user_id: nil).order(:created_at).last
+        assert_not_nil notice, "notice must be posted on the origin creative"
+        assert_equal @creative.main_topic.id, notice.topic_id
+        # Topic and (origin-rewritten) creative must be consistent — no orphaned topic.
+        assert_equal notice.creative_id, notice.topic.creative_id
+      end
+
       test "ignores crons whose topic_id is nil (main-topic crons)" do
         create_cron(creative_id: @creative.id, topic_id: nil)
         deleted_id = @topic.id

--- a/engines/collavre/test/services/collavre/topics/orphaned_cron_notifier_test.rb
+++ b/engines/collavre/test/services/collavre/topics/orphaned_cron_notifier_test.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  module Topics
+    class OrphanedCronNotifierTest < ActiveSupport::TestCase
+      setup do
+        @user = Collavre::User.create!(
+          name: "Owner",
+          email: "owner-#{SecureRandom.hex(4)}@test.test",
+          password: "password123"
+        )
+        @creative = Collavre::Creative.create!(
+          description: "Cron Host",
+          user: @user
+        )
+        # A non-Main topic that will be "deleted"
+        @topic = @creative.topics.create!(name: "Counseling", user: @user)
+      end
+
+      def create_cron(creative_id:, topic_id:, message: "@Ming: do the thing")
+        SolidQueue::RecurringTask.create!(
+          key: "cron_#{creative_id}_#{SecureRandom.hex(4)}",
+          class_name: "Collavre::CronActionJob",
+          schedule: "0 10 * * *",
+          queue_name: "default",
+          static: false,
+          description: "Cron job for creative #{creative_id}",
+          arguments: [ {
+            creative_id: creative_id,
+            topic_id: topic_id,
+            agent_id: @user.id,
+            message: message
+          } ]
+        )
+      end
+
+      test "posts a system comment to the creative's main topic when a cron targets the deleted topic" do
+        cron = create_cron(creative_id: @creative.id, topic_id: @topic.id)
+        deleted_name = @topic.name
+        deleted_id = @topic.id
+        @topic.destroy!
+
+        assert_difference -> { @creative.reload.comments.where(user_id: nil).count }, 1 do
+          OrphanedCronNotifier.new(topic_id: deleted_id, topic_name: deleted_name).call
+        end
+
+        notice = @creative.comments.where(user_id: nil).order(:created_at).last
+        assert_equal @creative.main_topic.id, notice.topic_id
+        assert_includes notice.content, cron.key
+        assert_includes notice.content, "Counseling"
+      end
+
+      test "leaves the recurring task in place (notify only)" do
+        cron = create_cron(creative_id: @creative.id, topic_id: @topic.id)
+        deleted_id = @topic.id
+        @topic.destroy!
+
+        OrphanedCronNotifier.new(topic_id: deleted_id, topic_name: "Counseling").call
+
+        assert SolidQueue::RecurringTask.exists?(key: cron.key), "cron must NOT be cancelled"
+      end
+
+      test "does nothing for crons targeting a different topic" do
+        other = @creative.topics.create!(name: "Other", user: @user)
+        create_cron(creative_id: @creative.id, topic_id: other.id)
+        deleted_id = @topic.id
+        @topic.destroy!
+
+        assert_no_difference -> { Collavre::Comment.where(user_id: nil).count } do
+          OrphanedCronNotifier.new(topic_id: deleted_id, topic_name: "Counseling").call
+        end
+      end
+
+      test "ignores crons whose topic_id is nil (main-topic crons)" do
+        create_cron(creative_id: @creative.id, topic_id: nil)
+        deleted_id = @topic.id
+        @topic.destroy!
+
+        assert_no_difference -> { Collavre::Comment.where(user_id: nil).count } do
+          OrphanedCronNotifier.new(topic_id: deleted_id, topic_name: "Counseling").call
+        end
+      end
+    end
+  end
+end

--- a/engines/collavre/test/services/collavre/topics/orphaned_cron_notifier_test.rb
+++ b/engines/collavre/test/services/collavre/topics/orphaned_cron_notifier_test.rb
@@ -73,6 +73,25 @@ module Collavre
         end
       end
 
+      test "keeps the notice as a system message even when a deleter is Current.user" do
+        create_cron(creative_id: @creative.id, topic_id: @topic.id)
+        deleted_id = @topic.id
+        @topic.destroy!
+
+        # Simulate the controller path where the admin deleting the topic is the
+        # current user; the notice must still be a system message (user nil) so
+        # it does not get attributed to them or trigger AI orchestration.
+        Collavre::Current.user = @user
+        begin
+          OrphanedCronNotifier.new(topic_id: deleted_id, topic_name: "Counseling").call
+        ensure
+          Collavre::Current.user = nil
+        end
+
+        notice = @creative.comments.order(:created_at).last
+        assert_nil notice.user_id, "notice must remain a system message (user nil)"
+      end
+
       test "ignores crons whose topic_id is nil (main-topic crons)" do
         create_cron(creative_id: @creative.id, topic_id: nil)
         deleted_id = @topic.id


### PR DESCRIPTION
## Problem

When a Topic is deleted, any recurring cron job (`SolidQueue::RecurringTask`) that targets it via `topic_id` keeps firing but silently does nothing: `CronActionJob#perform` finds `topic_id` present, `Topic.find_by` returns `nil`, logs a warning and `return`s — no comment, no error, the task still appears in `cron_list`. The user gets **zero signal**.

This was confirmed in production: cron `cron_6245_2b2348dc` targeted `topic_id: 391`, which was deleted; the job has been a silent no-op ever since while still showing in the list.

## Fix (Decision: notify only)

Add `Collavre::Topics::OrphanedCronNotifier`, called from `TopicsController#destroy` after `topic.destroy`. It scans non-static recurring tasks, parses each task's `arguments` JSON, and for every task whose `topic_id` matches the just-deleted topic, posts a **system message** (`Comment` with `user: nil`) into that cron's creative's **Main topic**.

The recurring task itself is **left untouched** — the original cron was bound to a purpose-specific topic, so the user decides whether to re-point or cancel it after seeing the notice. System messages don't trigger AI orchestration (guarded in `comment.rb`) and do broadcast to the UI.

## Notes / scope boundary

- **No DB migration** — reuses `SolidQueue::RecurringTask` + `Comment`.
- i18n added for **en + ko** (`collavre.topics.orphaned_cron_notice`).
- Plan deviation: used the public `creative.main_topic` (the plan's `effective_origin.main_topic` is a private linked-creative resolver requiring a `Set` arg; the test asserts against `creative.main_topic`).
- **Fires on future deletions only.** Already-orphaned crons (e.g. the production `cron_6245` → topic 391) are not retro-notified; surfacing those is a separate one-off.

## Tests

- New `OrphanedCronNotifierTest` (4 cases): posts to main topic + includes cron key/topic name; leaves the task in place; no-op for a different topic; no-op for `topic_id: nil` (main-topic crons).
- Full `topics_controller_test` + notifier test: **30 runs, 0 failures**. Rubocop clean.

Edge cases: cron targeting a different topic (no-op), `topic_id: nil` (no-op), creative not found (skip), Main topic can't be deleted so `main_topic` always exists.