### PR TITLE
refactor: drop dead action_text_rich_texts table

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,17 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_29_100000) do
-  create_table "action_text_rich_texts", force: :cascade do |t|
-    t.text "body"
-    t.datetime "created_at", null: false
-    t.string "name", null: false
-    t.bigint "record_id", null: false
-    t.string "record_type", null: false
-    t.datetime "updated_at", null: false
-    t.index ["record_type", "record_id", "name"], name: "index_action_text_rich_texts_uniqueness", unique: true
-  end
-
+ActiveRecord::Schema[8.1].define(version: 2026_06_09_000000) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false

--- a/engines/collavre/db/migrate/20260609000000_drop_action_text_rich_texts.rb
+++ b/engines/collavre/db/migrate/20260609000000_drop_action_text_rich_texts.rb
@@ -1,0 +1,20 @@
+# Drops the dead ActionText table. Creatives moved their rich text to the
+# `creatives.description` column (see 20251126040752_add_description_to_creatives),
+# and no model declares `has_rich_text` anymore, so this table is unused.
+class DropActionTextRichTexts < ActiveRecord::Migration[8.1]
+  def up
+    drop_table :action_text_rich_texts
+  end
+
+  def down
+    create_table :action_text_rich_texts do |t|
+      t.string :name, null: false
+      t.text :body
+      t.references :record, null: false, polymorphic: true, index: false
+
+      t.timestamps
+
+      t.index [ :record_type, :record_id, :name ], name: "index_action_text_rich_texts_uniqueness", unique: true
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Drops the unused `action_text_rich_texts` table — the only genuinely dead table found in a full schema audit (45 tables reviewed).

## Why it's dead
- Creatives migrated their rich text to the `creatives.description` column in `20251126040752_add_description_to_creatives`.
- No model declares `has_rich_text` and no view uses `rich_text_area` (grep across host app + all engines: 0 hits).
- No fixtures reference the table.

## What's retained
- The `action_text` gem stays: `ActionText::Content` is still used for HTML parsing in the Notion exporter, and the historical `add_description_to_creatives` migration references `ActionText::RichText`/`Attachable` when backfilling.
- ActiveStorage tables are untouched (attachments use `active_storage_*` directly).

## Migration
- `engines/collavre/db/migrate/20260609000000_drop_action_text_rich_texts.rb` — reversible (`down` recreates the table with its original columns + unique index).
- Placed in the `collavre` engine, consistent with `add_description_to_creatives` which owns the move off ActionText.

## Verification
- Migration runs cleanly; `db/schema.rb` regenerated (table block removed).
- Notion exporter test (uses `ActionText::Content`) passes locally.
- Note: the pre-push full suite was blocked by `SQLite3::BusyException: database is locked` from concurrent worktree agents (all 902 were lock errors, 0 logic failures). CI runs in isolation.

> ⚠️ Before merge/deploy: confirm `SELECT COUNT(*) FROM action_text_rich_texts` is 0 in production.