### PR TITLE
fix(claude-channel): correct plugin.json manifest so plugin install passes validation

### DIFF
--- a/tools/collavre-claude-plugin/.claude-plugin/plugin.json
+++ b/tools/collavre-claude-plugin/.claude-plugin/plugin.json
@@ -9,10 +9,14 @@
   "license": "MIT",
   "userConfig": {
     "url": {
+      "type": "string",
+      "title": "Collavre server URL",
       "description": "Collavre server URL (e.g., https://collavre.com)",
       "sensitive": false
     },
     "token": {
+      "type": "string",
+      "title": "Collavre API token",
       "description": "Collavre API authentication token",
       "sensitive": true
     }
@@ -22,5 +26,5 @@
       "server": "collavre"
     }
   ],
-  "hooks": "hooks/hooks.json"
+  "hooks": "./hooks/hooks.json"
 }


### PR DESCRIPTION
## Problem

`claude plugin install collavre@collavre` fails with manifest validation errors:

```
Validation errors: hooks: Invalid input,
  userConfig.url.type: Invalid option: expected one of "string"|"number"|"boolean"|"directory"|"file",
  userConfig.url.title: Invalid input: expected string, received undefined,
  userConfig.token.type: ...,
  userConfig.token.title: ...
```

## Root cause

The `plugin.json` manifest did not conform to the Claude Code [plugin schema](https://code.claude.com/docs/en/plugins-reference):

- Each `userConfig` entry **requires** `type` (one of `string|number|boolean|directory|file`) and `title` — both were missing on `url` and `token`.
- All manifest path fields **must start with `./`** — `hooks` was `"hooks/hooks.json"`.

## Fix

- Add `type: "string"` and a `title` to the `url` and `token` userConfig options.
- Prefix the hooks path: `"hooks/hooks.json"` → `"./hooks/hooks.json"`.

## Verification

`claude plugin validate` now passes for both the plugin and the marketplace manifest:

```
✔ Validation passed
```