### PR TITLE
fix(claude-channel): drop manifest.hooks to avoid duplicate hooks load

### DIFF
--- a/tools/collavre-claude-plugin/.claude-plugin/plugin.json
+++ b/tools/collavre-claude-plugin/.claude-plugin/plugin.json
@@ -25,6 +25,5 @@
     {
       "server": "collavre"
     }
-  ],
-  "hooks": "./hooks/hooks.json"
+  ]
 }


### PR DESCRIPTION
## 문제
`claude --channels server:collavre` 구동 시 플러그인 로드 에러:

```
collavre@collavre [collavre]: Hook load failed: Duplicate hooks file detected:
./hooks/hooks.json resolves to already-loaded file .../hooks/hooks.json.
The standard hooks/hooks.json is loaded automatically, so manifest.hooks
should only reference additional hook files.
```

## 원인
PR #1288에서 매니페스트 검증의 `hooks: Invalid input`을 고치려 `"hooks": "./hooks/hooks.json"`를 추가했습니다. 그러나 Claude Code는 **표준 경로 `hooks/hooks.json`을 자동 로드**합니다. 매니페스트가 같은 파일을 또 가리키면서 같은 파일이 **이중 로드**되어 에러가 발생했습니다.

당시 `Invalid input`은 필드 *부재*가 아니라 값 형식(`./` 누락) 문제였고, 이 플러그인은 표준 훅 파일만 사용하므로 올바른 해법은 `hooks` 필드를 **제거**하는 것입니다. `manifest.hooks`는 *추가* 훅 파일이 있을 때만 사용합니다.

## 수정
- `tools/collavre-claude-plugin/.claude-plugin/plugin.json`에서 `hooks` 필드 제거

## 검증
- `claude plugin validate .` → `✔ Validation passed` (필드 없이도 통과)
- 표준 `hooks/hooks.json`(SessionStart 빌드 훅 + PreToolUse reply 자동승인 훅)은 그대로 자동 로드됨

관련: #1288 (매니페스트 수정), #1287 (권한 릴레이 런타임)