### PR TITLE
fix(claude-channel): auto-approve reply for marketplace plugin tool name

### DIFF
--- a/tools/collavre-claude-plugin/hooks/hooks.json
+++ b/tools/collavre-claude-plugin/hooks/hooks.json
@@ -12,7 +12,7 @@
     ],
     "PreToolUse": [
       {
-        "matcher": "mcp__collavre__reply",
+        "matcher": "^mcp__(plugin_collavre_)?collavre__reply$",
         "hooks": [
           {
             "type": "command",

--- a/tools/collavre-claude-plugin/src/hook-decision.test.ts
+++ b/tools/collavre-claude-plugin/src/hook-decision.test.ts
@@ -1,16 +1,35 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { decidePreToolUse, REPLY_TOOL_NAME } from "./hook-decision.ts";
+import { decidePreToolUse, isReplyTool, REPLY_TOOL_NAME } from "./hook-decision.ts";
 
-test("auto-approves the Collavre channel reply tool", () => {
-  const decision = decidePreToolUse({ tool_name: REPLY_TOOL_NAME });
-  assert.ok(decision, "reply tool should produce a decision");
-  assert.equal(decision.hookSpecificOutput.hookEventName, "PreToolUse");
-  assert.equal(decision.hookSpecificOutput.permissionDecision, "allow");
-  assert.ok(
-    decision.hookSpecificOutput.permissionDecisionReason.length > 0,
-    "decision should carry a human-readable reason",
-  );
+// The dev install names the tool mcp__collavre__reply; a marketplace plugin
+// install names it mcp__plugin_collavre_collavre__reply. Auto-approval must
+// cover both so the production install path doesn't prompt on every reply.
+const MARKETPLACE_REPLY_TOOL_NAME = "mcp__plugin_collavre_collavre__reply";
+
+for (const toolName of [REPLY_TOOL_NAME, MARKETPLACE_REPLY_TOOL_NAME]) {
+  test(`auto-approves the Collavre channel reply tool (${toolName})`, () => {
+    const decision = decidePreToolUse({ tool_name: toolName });
+    assert.ok(decision, "reply tool should produce a decision");
+    assert.equal(decision.hookSpecificOutput.hookEventName, "PreToolUse");
+    assert.equal(decision.hookSpecificOutput.permissionDecision, "allow");
+    assert.ok(
+      decision.hookSpecificOutput.permissionDecisionReason.length > 0,
+      "decision should carry a human-readable reason",
+    );
+  });
+}
+
+test("isReplyTool matches both install paths and nothing else", () => {
+  assert.ok(isReplyTool(REPLY_TOOL_NAME));
+  assert.ok(isReplyTool(MARKETPLACE_REPLY_TOOL_NAME));
+  // Must not match other servers/tools or partial/substring lookalikes.
+  assert.equal(isReplyTool("mcp__collavre__other"), false);
+  assert.equal(isReplyTool("mcp__plugin_collavre_collavre__cron_create"), false);
+  assert.equal(isReplyTool("mcp__notcollavre__reply"), false);
+  assert.equal(isReplyTool("mcp__collavre__reply_extra"), false);
+  assert.equal(isReplyTool(undefined), false);
+  assert.equal(isReplyTool(null), false);
 });
 
 test("stays silent (null) for side-effecting tools so they remain gated", () => {

--- a/tools/collavre-claude-plugin/src/hook-decision.ts
+++ b/tools/collavre-claude-plugin/src/hook-decision.ts
@@ -11,7 +11,19 @@
 // deliberately left untouched: they keep flowing through the normal permission
 // path, which on the channel surfaces as the structured approval comment.
 
+// The `reply` tool resolves to different fully-qualified names depending on how
+// the MCP server was registered:
+//   - dev install (`claude mcp add --scope local collavre`): mcp__collavre__reply
+//   - marketplace plugin install:               mcp__plugin_collavre_collavre__reply
+// Claude Code derives the prefix from the registration path, not the server, so
+// the auto-approve gate must accept both — otherwise a marketplace install (the
+// production path) prompts on every channel reply.
 export const REPLY_TOOL_NAME = "mcp__collavre__reply";
+export const REPLY_TOOL_NAME_PATTERN = /^mcp__(?:plugin_collavre_)?collavre__reply$/;
+
+export function isReplyTool(toolName: string | undefined | null): boolean {
+  return typeof toolName === "string" && REPLY_TOOL_NAME_PATTERN.test(toolName);
+}
 
 export interface PreToolUseInput {
   tool_name?: string;
@@ -28,7 +40,7 @@ export interface PreToolUseAllow {
 // Returns an allow decision for the channel reply tool, or null for everything
 // else (null = emit nothing, let the normal permission flow proceed).
 export function decidePreToolUse(input: PreToolUseInput | null | undefined): PreToolUseAllow | null {
-  if (input?.tool_name !== REPLY_TOOL_NAME) {
+  if (!isReplyTool(input?.tool_name)) {
     return null;
   }
   return {


### PR DESCRIPTION
## 문제

마켓플레이스로 플러그인을 설치하면 `reply` 툴이 **`mcp__plugin_collavre_collavre__reply`** 라는 이름으로 등록된다. 하지만 dev 설치(`claude mcp add --scope local collavre`)는 **`mcp__collavre__reply`** 로 등록된다. 이름의 prefix는 MCP 서버가 아니라 **등록 경로**에서 Claude Code가 파생한다.

reply 자동승인 게이트가 dev 이름에 두 군데 박혀 있어서, **마켓 설치(=production 경로)에서 매 응답마다 권한 프롬프트가 떴다**:

```
Claude Code wants to run mcp__plugin_collavre_collavre__reply ...
Approve or deny to continue.
```

- `hooks/hooks.json` matcher(정규식)가 플러그인 이름에 대해 훅 자체를 안 띄움
- `hook-decision.ts`의 `REPLY_TOOL_NAME` exact-equality가 띄워도 거부함

## 수정

- `isReplyTool()` + anchored 정규식 `^mcp__(?:plugin_collavre_)?collavre__reply$` 으로 두 설치 경로 이름을 모두 인식
- `hooks.json` matcher를 `^mcp__(plugin_collavre_)?collavre__reply$` 로 확장
- 테스트: 두 설치 경로 + substring/lookalike(`mcp__collavre__reply_extra`, `mcp__notcollavre__reply`, 다른 collavre 툴) 음성 케이스 추가

## 검증

- `npm run build` ✔, `npm test` 28/28 ✔
- 빌드된 `dist/pretooluse-hook.js` 스모크: 마켓 이름·dev 이름 모두 `allow`, `Bash`는 무반응(silent) 확인
- `claude plugin validate` ✔

side-effecting 툴(Bash/Write/Edit/…)은 그대로 게이트 유지 — reply만 자동승인하는 기존 보안 경계는 변하지 않음.

관련: PR #1287 (reply 툴 자동승인), #1288/#1289 (플러그인 매니페스트)