### PR TITLE
fix: keep native playback controls on displayed attached video nodes

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -57,8 +57,14 @@ module ApplicationHelper
     end
   end
 
-  EMBED_ALLOWED_TAGS = %w[iframe a p div span br strong em b i u ul ol li h1 h2 h3 h4 h5 h6 blockquote code pre img hr table thead tbody tr th td figure figcaption action-text-attachment].freeze
-  EMBED_ALLOWED_ATTRS = %w[src title frameborder allow allowfullscreen style href class alt width height target rel sgid content-type filename colspan rowspan].freeze
+  # Display-time safelist for creative descriptions. Must stay in sync with the
+  # storage-time sanitizer in Creative::Describable#sanitize_description_html:
+  # anything stored there but missing here is silently dropped on render. The
+  # `video`/`source` tags and `controls`/`preload`/`poster` attrs mirror that
+  # sanitizer's media safelist so attached video nodes keep their native
+  # playback controls (play/pause/fullscreen) when displayed.
+  EMBED_ALLOWED_TAGS = %w[iframe a p div span br strong em b i u ul ol li h1 h2 h3 h4 h5 h6 blockquote code pre img hr table thead tbody tr th td figure figcaption action-text-attachment video source].freeze
+  EMBED_ALLOWED_ATTRS = %w[src title frameborder allow allowfullscreen style href class alt width height target rel sgid content-type filename colspan rowspan controls preload poster].freeze
 
   def embed_youtube_iframe(html)
     return html if html.blank?

--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -328,6 +328,13 @@ body.chat-fullscreen {
     margin-top: 0.2em;
 }
 
+.comment-content img,
+.comment-content video {
+    max-width: 100%;
+    height: auto;
+    border-radius: 4px;
+}
+
 .comment-content pre {
     white-space: pre-wrap;
     word-break: break-word;

--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -332,7 +332,7 @@ body.chat-fullscreen {
 .comment-content video {
     max-width: 100%;
     height: auto;
-    border-radius: 4px;
+    border-radius: var(--radius-2);
 }
 
 .comment-content pre {

--- a/engines/collavre/app/assets/stylesheets/collavre/creatives.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/creatives.css
@@ -257,12 +257,21 @@ creative-tree-row.show-edit .creative-row {
     word-break: break-word;
 }
 
-/* Allow attachments and images to be clickable independently of the parent link */
+/* Allow attachments, images, and videos to be interactive independently of the
+   parent link. Without pointer-events on the video, the clickable creative row
+   would swallow clicks on the native playback controls (play/pause/fullscreen). */
 .creative-content a[download],
-.creative-content img {
+.creative-content img,
+.creative-content video {
     pointer-events: auto;
     position: relative;
     z-index: var(--layer-1);
+}
+
+.creative-content video {
+    max-width: 100%;
+    height: auto;
+    border-radius: 4px;
 }
 
 .creative-row:hover .creative-content {

--- a/engines/collavre/app/assets/stylesheets/collavre/creatives.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/creatives.css
@@ -271,7 +271,7 @@ creative-tree-row.show-edit .creative-row {
 .creative-content video {
     max-width: 100%;
     height: auto;
-    border-radius: 4px;
+    border-radius: var(--radius-2);
 }
 
 .creative-row:hover .creative-content {

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -2,4 +2,43 @@ require "test_helper"
 
 class ApplicationHelperTest < ActionView::TestCase
   include ApplicationHelper
+
+  test "embed_youtube_iframe keeps attached video with native controls" do
+    html = %(<p>intro</p><video controls src="/public-assets/blobs/abc/clip.mp4"></video>)
+    result = embed_youtube_iframe(html)
+
+    assert_includes result, "<video"
+    assert_match(/controls/, result)
+    assert_includes result, "/public-assets/blobs/abc/clip.mp4"
+  end
+
+  test "embed_youtube_iframe keeps video with nested source and poster" do
+    html = %(<video controls preload="metadata" poster="/p.jpg"><source src="/v.webm" type="video/webm"></video>)
+    result = embed_youtube_iframe(html)
+
+    assert_includes result, "<video"
+    assert_includes result, "<source"
+    assert_includes result, "/v.webm"
+    assert_includes result, "poster"
+  end
+
+  test "embed_youtube_iframe still converts youtube links to iframes" do
+    html = %(<a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">watch</a>)
+    result = embed_youtube_iframe(html)
+
+    assert_includes result, "<iframe"
+    assert_includes result, "youtube.com/embed/dQw4w9WgXcQ"
+  end
+
+  test "embed_youtube_iframe still strips unsafe markup" do
+    html = %(<p>ok</p><script>alert(1)</script>)
+    result = embed_youtube_iframe(html)
+
+    assert_not_includes result, "<script"
+  end
+
+  test "embed_youtube_iframe returns blank input unchanged" do
+    assert_equal "", embed_youtube_iframe("")
+    assert_nil embed_youtube_iframe(nil)
+  end
 end


### PR DESCRIPTION
## Problem

Attached video nodes render with native `controls` in the Lexical editor and the stored HTML, but the **displayed** creative shows no video player at all — no play/pause/fullscreen UI.

## Root cause: sanitizer allowlist drift

Two sanitizers run on a creative description:

1. **Storage** — `Creative::Describable#sanitize_description_html` — *was* updated to allow `video`/`source` + `controls`/`preload`/`poster`. Stored HTML is correct.
2. **Display** — `ApplicationHelper#embed_youtube_iframe`, which **every** creative description passes through (`Creatives::TreeBuilder`) — runs a second `sanitize` whose `EMBED_ALLOWED_TAGS`/`EMBED_ALLOWED_ATTRS` safelist **omitted** `video`/`source`/`controls`.

So the display pass stripped the `<video>` element entirely. Verified empirically with the production safelist constants:

```
IN : <p>hi</p><video controls src="/public-assets/blobs/abc/v.mp4"></video><p>bye</p>
OUT (before): <p>hi</p><p>bye</p>          # video gone
OUT (after):  <p>hi</p><video controls src="..."></video><p>bye</p>
```

(The comment render path uses JS DOMPurify, which already keeps `<video controls>` — so this only affected creative descriptions.)

## Fix

- Add `video`/`source` tags and `controls`/`preload`/`poster` attrs to the display safelist so it mirrors the storage sanitizer. The native `controls` attribute provides exactly the play/pause/fullscreen UI requested.
- CSS: make displayed videos `pointer-events: auto` (so the native controls work over the clickable creative row, mirroring the existing `img` rule) and constrain them to `max-width: 100%` in both creative descriptions and comments.
- Added a code comment documenting the storage↔display safelist sync requirement to prevent recurrence.

## Tests

- New `ApplicationHelperTest`: video preservation (controls/src), nested `<source>` + `poster`, YouTube iframe conversion still works, `<script>` still stripped, blank passthrough.
- Existing `tree_builder` tests + rubocop green; pre-push suite passed.

## Verification

Confirmed at the sanitizer level (exact before/after above) and via unit tests. Browser E2E with a real uploaded video can be run on request (requires seeding a video blob in dev).