### PR TITLE
feat: paginate the Chats (comment filter) list and kill its N+1s

### DIFF
--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -67,7 +67,9 @@ module Collavre
               allowed_creative_ids: @allowed_creative_ids,
               progress_map: @progress_map
             )
-            render json: { creatives: @creatives_tree_json }
+            payload = { creatives: @creatives_tree_json }
+            payload[:pagination] = index_result.pagination if index_result.pagination
+            render json: payload
           end
         end
       end

--- a/engines/collavre/app/javascript/controllers/creatives/__tests__/tree_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/creatives/__tests__/tree_controller.test.js
@@ -213,4 +213,58 @@ describe('CreativesTreeController Chats pagination (load more)', () => {
 
     application.stop()
   })
+
+  test('drops a stale load-more response that resolves after a fresh load', async () => {
+    let resolvePage2
+    const page2Nodes = [{ id: 2 }, { id: 3 }]
+    global.fetch = jest
+      .fn()
+      // initial page-1 (Chats filter, has more)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ creatives: [{ id: 1 }], pagination: { has_more: true, next_page: 2 } }),
+      })
+      // page-2 stays pending until we resolve it manually
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolvePage2 = () =>
+              resolve({
+                ok: true,
+                json: async () => ({ creatives: page2Nodes, pagination: { has_more: true, next_page: 3 } }),
+              })
+          })
+      )
+      // the fresh load() re-renders a different (non-paginated) view
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ creatives: [{ id: 99 }] }),
+      })
+
+    const { container, application } = installController()
+    await flush()
+    await flush()
+
+    // Sentinel intersects -> page-2 fetch kicks off but stays pending.
+    MockIntersectionObserver.instances[0].triggerIntersect()
+    await flush()
+
+    // A fresh load happens before page 2 resolves (filter change, sync refetch,
+    // archive toggle). load() tears down pagination and aborts the in-flight
+    // load-more.
+    const controller = application.getControllerForElementAndIdentifier(container, 'creatives--tree')
+    controller.load()
+    await flush()
+    await flush()
+
+    // The stale page-2 response finally arrives. It must NOT be appended into
+    // the freshly rendered view.
+    resolvePage2()
+    await flush()
+    await flush()
+
+    expect(appendCreativeNodes).not.toHaveBeenCalled()
+
+    application.stop()
+  })
 })

--- a/engines/collavre/app/javascript/controllers/creatives/__tests__/tree_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/creatives/__tests__/tree_controller.test.js
@@ -6,6 +6,7 @@ import { jest } from '@jest/globals'
 
 jest.unstable_mockModule('../../../creatives/tree_renderer', () => ({
   renderCreativeTree: jest.fn(),
+  appendCreativeNodes: jest.fn(),
   dispatchCreativeTreeUpdated: jest.fn(),
   applyRowProperties: jest.fn(),
 }))
@@ -16,6 +17,7 @@ jest.unstable_mockModule('../../../utils/emoji_parser', () => ({
 
 const { Application } = await import('@hotwired/stimulus')
 const TreeController = (await import('../tree_controller')).default
+const { appendCreativeNodes } = await import('../../../creatives/tree_renderer')
 
 const TRANSIENT_RETRY_DELAYS = [200, 600]
 
@@ -114,6 +116,100 @@ describe('CreativesTreeController retry on transient network errors', () => {
     await new Promise((resolve) => setTimeout(resolve, 1500))
 
     expect(collectRetryDelays(setTimeoutSpy)).toEqual(TRANSIENT_RETRY_DELAYS)
+
+    application.stop()
+  })
+})
+
+describe('CreativesTreeController Chats pagination (load more)', () => {
+  let originalFetch
+  let originalIO
+
+  class MockIntersectionObserver {
+    constructor(callback) {
+      this.callback = callback
+      MockIntersectionObserver.instances.push(this)
+    }
+    observe(el) { this.observed = el }
+    disconnect() { this.disconnected = true }
+    triggerIntersect() { this.callback([{ isIntersecting: true }]) }
+  }
+
+  beforeEach(() => {
+    originalFetch = global.fetch
+    originalIO = global.IntersectionObserver
+    MockIntersectionObserver.instances = []
+    global.IntersectionObserver = MockIntersectionObserver
+    appendCreativeNodes.mockClear()
+  })
+
+  afterEach(() => {
+    global.fetch = originalFetch
+    global.IntersectionObserver = originalIO
+    document.body.innerHTML = ''
+    jest.restoreAllMocks()
+  })
+
+  test('observes a sentinel only when the response carries has_more pagination', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ creatives: [{ id: 1 }], pagination: { has_more: true, next_page: 2 } }),
+    })
+
+    const { container, application } = installController()
+    await flush()
+    await flush()
+
+    expect(MockIntersectionObserver.instances).toHaveLength(1)
+    expect(container.querySelector('.creative-chats-load-sentinel')).not.toBeNull()
+
+    application.stop()
+  })
+
+  test('does NOT set up pagination for a plain tree response (no pagination key)', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ creatives: [{ id: 1 }] }),
+    })
+
+    const { container, application } = installController()
+    await flush()
+    await flush()
+
+    expect(MockIntersectionObserver.instances).toHaveLength(0)
+    expect(container.querySelector('.creative-chats-load-sentinel')).toBeNull()
+
+    application.stop()
+  })
+
+  test('fetches the next page and appends rows when the sentinel intersects', async () => {
+    const page2Nodes = [{ id: 2 }, { id: 3 }]
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ creatives: [{ id: 1 }], pagination: { has_more: true, next_page: 2 } }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ creatives: page2Nodes, pagination: { has_more: false, next_page: null } }),
+      })
+
+    const { application } = installController()
+    await flush()
+    await flush()
+
+    const observer = MockIntersectionObserver.instances[0]
+    observer.triggerIntersect()
+    await flush()
+    await flush()
+
+    const secondCallUrl = global.fetch.mock.calls[1][0]
+    expect(secondCallUrl).toContain('page=2')
+    expect(appendCreativeNodes).toHaveBeenCalledTimes(1)
+    expect(appendCreativeNodes.mock.calls[0][1]).toEqual(page2Nodes)
+    // has_more:false on page 2 tears the observer down.
+    expect(observer.disconnected).toBe(true)
 
     application.stop()
   })

--- a/engines/collavre/app/javascript/controllers/creatives/tree_controller.js
+++ b/engines/collavre/app/javascript/controllers/creatives/tree_controller.js
@@ -18,6 +18,7 @@ export default class extends Controller {
     this._sentinel = null
     this._sentinelObserver = null
     this._loadingMore = false
+    this._loadMoreAbort = null
     this._loadMoreIndicator = null
     this.handleResize = this.updateAlignmentOffset.bind(this)
     this.handleTreeUpdated = () => this.queueAlignmentUpdate()
@@ -243,15 +244,25 @@ export default class extends Controller {
     this._loadingMore = true
     this._showLoadMoreIndicator()
 
+    // Tie this request to an AbortController so a fresh load() / teardown (filter
+    // change, archive toggle, sync refetch, disconnect) cancels an in-flight
+    // page fetch. Without this the stale promise could append rows for a
+    // different urlValue into the freshly rendered list and resurrect the
+    // pagination state via _repositionSentinel().
+    if (this._loadMoreAbort) this._loadMoreAbort.abort()
+    this._loadMoreAbort = new AbortController()
+    const signal = this._loadMoreAbort.signal
+
     const url = new URL(this.urlValue, window.location.origin)
     url.searchParams.set('page', String(nextPage))
 
-    fetch(url.pathname + url.search, { headers: { Accept: 'application/json' } })
+    fetch(url.pathname + url.search, { headers: { Accept: 'application/json' }, signal })
       .then((response) => {
         if (!response.ok) throw new Error(`Failed to load more chats: ${response.status}`)
         return response.json()
       })
       .then((data) => {
+        if (signal.aborted) return
         this._hideLoadMoreIndicator()
         const nodes = Array.isArray(data?.creatives) ? data.creatives : []
         if (nodes.length > 0) {
@@ -268,6 +279,7 @@ export default class extends Controller {
         }
       })
       .catch((error) => {
+        if (error.name === 'AbortError') return
         console.error(error)
         this._hideLoadMoreIndicator()
         this._loadingMore = false
@@ -286,6 +298,10 @@ export default class extends Controller {
   }
 
   _teardownPagination() {
+    if (this._loadMoreAbort) {
+      this._loadMoreAbort.abort()
+      this._loadMoreAbort = null
+    }
     if (this._sentinelObserver) {
       this._sentinelObserver.disconnect()
       this._sentinelObserver = null

--- a/engines/collavre/app/javascript/controllers/creatives/tree_controller.js
+++ b/engines/collavre/app/javascript/controllers/creatives/tree_controller.js
@@ -1,5 +1,5 @@
 import { Controller } from '@hotwired/stimulus'
-import { renderCreativeTree, dispatchCreativeTreeUpdated } from '../../creatives/tree_renderer'
+import { renderCreativeTree, appendCreativeNodes, dispatchCreativeTreeUpdated } from '../../creatives/tree_renderer'
 import { parseEmojis } from '../../utils/emoji_parser'
 
 const TREE_RETRY_DELAYS_MS = [200, 600]
@@ -14,6 +14,11 @@ export default class extends Controller {
     this.abortController = null
     this.loadingIndicator = null
     this._editing = false
+    this._pagination = null
+    this._sentinel = null
+    this._sentinelObserver = null
+    this._loadingMore = false
+    this._loadMoreIndicator = null
     this.handleResize = this.updateAlignmentOffset.bind(this)
     this.handleTreeUpdated = () => this.queueAlignmentUpdate()
     this._handleEditStart = () => { this._editing = true }
@@ -60,6 +65,7 @@ export default class extends Controller {
     document.removeEventListener('creative-editing:start', this._handleEditStart)
     document.removeEventListener('creative-editing:stop', this._handleEditStop)
     document.removeEventListener('creative-sync:refetch', this._handleSyncRefetch)
+    this._teardownPagination()
     if (this._debouncedLoadTimer) clearTimeout(this._debouncedLoadTimer)
     if (this._archiveToggleHandler) {
       document.getElementById('toggle-archived-btn')?.removeEventListener('click', this._archiveToggleHandler)
@@ -140,6 +146,11 @@ export default class extends Controller {
   load() {
     if (!this.hasUrlValue) return
 
+    // A fresh load replaces the whole list (filter change, archive toggle, sync
+    // refetch), so any active load-more session is stale — tear it down before
+    // re-rendering page 1.
+    this._teardownPagination()
+
     if (this.abortController) {
       this.abortController.abort()
     }
@@ -196,6 +207,120 @@ export default class extends Controller {
     this.markContentLoaded()
     dispatchCreativeTreeUpdated(this.element)
     this.queueAlignmentUpdate()
+    this._setupPagination(data?.pagination)
+  }
+
+  // --- Load-more (paginated "Chats" feed) -------------------------------------
+  // Only engaged when the JSON response carries a `pagination` object (the
+  // comment filter). For the tree and search views the payload has no
+  // pagination, so none of this runs and behavior is unchanged.
+
+  _setupPagination(pagination) {
+    this._teardownPagination()
+    this._pagination = pagination || null
+    if (!this._pagination || !this._pagination.has_more) return
+    if (typeof IntersectionObserver === 'undefined') return
+    this._createSentinel()
+  }
+
+  _createSentinel() {
+    const sentinel = document.createElement('div')
+    sentinel.className = 'creative-chats-load-sentinel'
+    sentinel.setAttribute('aria-hidden', 'true')
+    this.element.appendChild(sentinel)
+    this._sentinel = sentinel
+    this._sentinelObserver = new IntersectionObserver((entries) => {
+      if (entries.some((entry) => entry.isIntersecting)) this._loadMore()
+    }, { root: null, rootMargin: '300px' })
+    this._sentinelObserver.observe(sentinel)
+  }
+
+  _loadMore() {
+    if (this._loadingMore) return
+    const nextPage = this._pagination && this._pagination.next_page
+    if (!nextPage) return
+
+    this._loadingMore = true
+    this._showLoadMoreIndicator()
+
+    const url = new URL(this.urlValue, window.location.origin)
+    url.searchParams.set('page', String(nextPage))
+
+    fetch(url.pathname + url.search, { headers: { Accept: 'application/json' } })
+      .then((response) => {
+        if (!response.ok) throw new Error(`Failed to load more chats: ${response.status}`)
+        return response.json()
+      })
+      .then((data) => {
+        this._hideLoadMoreIndicator()
+        const nodes = Array.isArray(data?.creatives) ? data.creatives : []
+        if (nodes.length > 0) {
+          appendCreativeNodes(this.element, nodes)
+          dispatchCreativeTreeUpdated(this.element)
+          this.queueAlignmentUpdate()
+        }
+        this._loadingMore = false
+        this._pagination = data?.pagination || null
+        if (this._pagination && this._pagination.has_more) {
+          this._repositionSentinel()
+        } else {
+          this._teardownPagination()
+        }
+      })
+      .catch((error) => {
+        console.error(error)
+        this._hideLoadMoreIndicator()
+        this._loadingMore = false
+        // Leave the sentinel in place so a later scroll can retry the page.
+      })
+  }
+
+  _repositionSentinel() {
+    // New rows were appended after the sentinel; move it back to the tail so it
+    // keeps trailing the list and can trigger the following page.
+    if (this._sentinel && this._sentinel.parentNode === this.element) {
+      this.element.appendChild(this._sentinel)
+    } else {
+      this._createSentinel()
+    }
+  }
+
+  _teardownPagination() {
+    if (this._sentinelObserver) {
+      this._sentinelObserver.disconnect()
+      this._sentinelObserver = null
+    }
+    if (this._sentinel && this._sentinel.parentNode) {
+      this._sentinel.remove()
+    }
+    this._sentinel = null
+    this._pagination = null
+    this._loadingMore = false
+    this._hideLoadMoreIndicator()
+  }
+
+  _showLoadMoreIndicator() {
+    if (this._loadMoreIndicator) return
+    const indicator = document.createElement('div')
+    indicator.className = 'creative-tree-loading-placeholder creative-chats-load-more'
+    indicator.setAttribute('role', 'status')
+    indicator.setAttribute('aria-live', 'polite')
+    indicator.innerHTML = `
+      <span class="creative-loading-indicator" aria-hidden="true">
+        <span class="creative-loading-dot">.</span>
+        <span class="creative-loading-dot">.</span>
+        <span class="creative-loading-dot">.</span>
+      </span>
+    `
+    this.element.appendChild(indicator)
+    this._loadMoreIndicator = indicator
+  }
+
+  _hideLoadMoreIndicator() {
+    if (this._loadMoreIndicator && this._loadMoreIndicator.parentNode) {
+      this._loadMoreIndicator.remove()
+    }
+    this._loadMoreIndicator = null
   }
 
   showEmptyState() {

--- a/engines/collavre/app/javascript/creatives/tree_renderer.js
+++ b/engines/collavre/app/javascript/creatives/tree_renderer.js
@@ -308,6 +308,14 @@ export function renderCreativeTree(container, nodes, { replace = true } = {}) {
   reconcileNodes(container, nodes)
 }
 
+// Append a page of flat nodes to an already-rendered list without clearing the
+// existing rows. Used by the "Chats" feed's load-more, where each page is added
+// below the previous one rather than replacing it.
+export function appendCreativeNodes(container, nodes) {
+  if (!container) return
+  appendNodes(container, nodes)
+}
+
 export function dispatchCreativeTreeUpdated(container) {
   if (!container) return
   const event = new CustomEvent('creative-tree:updated', { bubbles: true })

--- a/engines/collavre/app/services/collavre/creatives/index_query.rb
+++ b/engines/collavre/app/services/collavre/creatives/index_query.rb
@@ -10,6 +10,11 @@ module Creatives
     # than its entire match set.
     PERMISSION_FILTER_BATCH = 200
 
+    # Page size for the top-nav "Chats" feed (the comment filter). The list is
+    # unbounded by nature (it grows with every commented creative), so it is
+    # paginated instead of materialized whole.
+    COMMENT_CHATS_PER_PAGE = 30
+
     Result = Struct.new(
       :creatives,
       :parent_creative,
@@ -18,6 +23,7 @@ module Creatives
       :overall_progress,
       :allowed_creative_ids,
       :progress_map,
+      :pagination,
       keyword_init: true
     )
 
@@ -38,7 +44,8 @@ module Creatives
         shared_list: shared_list,
         overall_progress: result[:overall_progress] || 0,
         allowed_creative_ids: result[:allowed_ids],
-        progress_map: result[:progress_map]
+        progress_map: result[:progress_map],
+        pagination: result[:pagination]
       )
     end
 
@@ -83,29 +90,46 @@ module Creatives
 
       result = pipeline.call
 
-      return empty_result if result.matched_ids.empty?
+      # The comment ("Chats") path still returns a pagination object on an empty
+      # match so the client gets consistent metadata; other filters short-circuit.
+      return empty_result if result.matched_ids.empty? && params[:comment] != "true"
 
       # For search/comment filters, return matched items directly (flat results sorted by relevance)
       # Unless search_mode=tree is specified, which returns tree structure instead
       # For other filters (tags, progress), return tree start nodes
       if (params[:search].present? || params[:comment] == "true") && params[:search_mode] != "tree"
-        matched_creatives = Creative.where(id: result.matched_ids.to_a)
-          .order(:sequence)
-          .select { |c| readable?(c) }
-
-        # Sort by comment updated_at for comment filter
-        if params[:comment] == "true"
-          matched_creatives = matched_creatives.sort_by { |c| c.comments.maximum(:updated_at) || c.updated_at }.reverse
-        end
-
         parent = params[:id] ? Creative.find_by(id: params[:id]) : nil
-        {
-          creatives: matched_creatives,
-          parent: parent,
-          allowed_ids: result.allowed_ids,
-          overall_progress: result.overall_progress,
-          progress_map: result.progress_map
-        }
+
+        if params[:comment] == "true"
+          # Top-nav "Chats" list: one page of commented creatives, newest chat
+          # first. The matched set is permission-filtered in a single batch and
+          # the recency ordering is computed by the DB (LIMIT/OFFSET over a
+          # grouped MAX(comments.updated_at)), so response cost is a fixed page
+          # regardless of how many chats exist. This replaces an unbounded load
+          # that ran a per-row readable? query and a per-row MAX(updated_at)
+          # aggregate (two N+1s that grew with the chat count).
+          page = comment_chats_page(result.matched_ids)
+          {
+            creatives: page[:creatives],
+            parent: parent,
+            allowed_ids: result.allowed_ids,
+            overall_progress: result.overall_progress,
+            progress_map: result.progress_map,
+            pagination: page[:pagination]
+          }
+        else
+          matched_creatives = Creative.where(id: result.matched_ids.to_a)
+            .order(:sequence)
+            .select { |c| readable?(c) }
+
+          {
+            creatives: matched_creatives,
+            parent: parent,
+            allowed_ids: result.allowed_ids,
+            overall_progress: result.overall_progress,
+            progress_map: result.progress_map
+          }
+        end
       else
         start_nodes = determine_start_nodes(result.allowed_ids)
         parent = params[:id] ? Creative.find_by(id: params[:id]) : nil
@@ -117,6 +141,51 @@ module Creatives
           progress_map: result.progress_map
         }
       end
+    end
+
+    # One page of the "Chats" feed from the comment-matched id set, ordered by
+    # most-recent comment. Permission filtering is batched (PermissionFilter does
+    # a handful of IN queries, not one per row) and the recency sort + windowing
+    # happen in SQL, so neither cost scales with the total number of chats.
+    def comment_chats_page(matched_ids)
+      per_page = comment_chats_per_page
+      page = comment_chats_page_number
+      offset = (page - 1) * per_page
+
+      readable_ids = PermissionFilter.new(user: user).readable_ids(matched_ids.to_a)
+      return { creatives: [], pagination: pagination_meta(page, false) } if readable_ids.empty?
+
+      # Fetch one extra row to detect whether a further page exists. id is the
+      # tiebreaker so the order is total and stable across page boundaries.
+      page_ids = Creative.where(id: readable_ids)
+        .joins(:comments)
+        .group("creatives.id")
+        .order(Arel.sql("MAX(comments.updated_at) DESC, creatives.id DESC"))
+        .offset(offset)
+        .limit(per_page + 1)
+        .pluck("creatives.id")
+
+      has_more = page_ids.size > per_page
+      page_ids = page_ids.first(per_page)
+
+      by_id = Creative.where(id: page_ids).index_by(&:id)
+      creatives = page_ids.filter_map { |id| by_id[id] }
+
+      { creatives: creatives, pagination: pagination_meta(page, has_more) }
+    end
+
+    def comment_chats_per_page
+      per = params[:per_page].presence&.to_i || COMMENT_CHATS_PER_PAGE
+      per <= 0 || per > 100 ? COMMENT_CHATS_PER_PAGE : per
+    end
+
+    def comment_chats_page_number
+      page = params[:page].presence&.to_i || 1
+      page < 1 ? 1 : page
+    end
+
+    def pagination_meta(page, has_more)
+      { page: page, next_page: has_more ? page + 1 : nil, has_more: has_more }
     end
 
     def simple_search?

--- a/engines/collavre/test/services/creatives/index_query_comment_pagination_test.rb
+++ b/engines/collavre/test/services/creatives/index_query_comment_pagination_test.rb
@@ -1,0 +1,74 @@
+require "test_helper"
+
+module Creatives
+  # The top-nav "Chats" list is the comment filter (?comment=true). It must be
+  # paginated (newest chat first) and must never run a per-row permission check
+  # or a per-row MAX(comments.updated_at) aggregate.
+  class IndexQueryCommentPaginationTest < ActiveSupport::TestCase
+    setup do
+      @user = users(:one)
+
+      # Four commented creatives, with comments timestamped oldest -> newest so
+      # the expected recency order is c4, c3, c2, c1.
+      @c1 = create_commented("Chat 1", 4.hours.ago)
+      @c2 = create_commented("Chat 2", 3.hours.ago)
+      @c3 = create_commented("Chat 3", 2.hours.ago)
+      @c4 = create_commented("Chat 4", 1.hour.ago)
+
+      # A creative without comments must never appear in the feed.
+      @no_comment = Creative.create!(user: @user, description: "No chat", progress: 0.0)
+    end
+
+    test "first page returns one page ordered by most-recent comment with has_more" do
+      result = IndexQuery.new(user: @user, params: { comment: "true", per_page: 2 }).call
+
+      assert_equal [ @c4, @c3 ], result.creatives
+      assert result.pagination[:has_more]
+      assert_equal 2, result.pagination[:next_page]
+      assert_equal 1, result.pagination[:page]
+    end
+
+    test "second page returns the next slice and reports no further pages" do
+      result = IndexQuery.new(user: @user, params: { comment: "true", per_page: 2, page: 2 }).call
+
+      assert_equal [ @c2, @c1 ], result.creatives
+      refute result.pagination[:has_more]
+      assert_nil result.pagination[:next_page]
+    end
+
+    test "feed excludes creatives the user cannot read" do
+      other = users(:two)
+      private_chat = Creative.create!(user: other, description: "Private chat", progress: 0.0)
+      Comment.create!(creative: private_chat, user: other, content: "secret")
+        .update_column(:updated_at, Time.current)
+
+      result = IndexQuery.new(user: @user, params: { comment: "true" }).call
+
+      refute_includes result.creatives, private_chat
+      assert_includes result.creatives, @c4
+    end
+
+    test "feed excludes creatives without comments" do
+      result = IndexQuery.new(user: @user, params: { comment: "true" }).call
+
+      refute_includes result.creatives, @no_comment
+    end
+
+    test "empty feed reports no further pages" do
+      Comment.delete_all
+      result = IndexQuery.new(user: @user, params: { comment: "true" }).call
+
+      assert_empty result.creatives
+      refute result.pagination[:has_more]
+    end
+
+    private
+
+    def create_commented(description, commented_at)
+      creative = Creative.create!(user: @user, description: description, progress: 0.0)
+      Comment.create!(creative: creative, user: @user, content: "#{description} comment")
+        .update_column(:updated_at, commented_at)
+      creative
+    end
+  end
+end


### PR DESCRIPTION
## What

The top-nav **Chats** page is the creatives index with `?comment=true` (the comment filter). It listed **every** commented creative in one response and had no paging, so it got linearly slower as chats accumulated.

Two N+1s compounded the problem, both scaling with the total chat count:
- a per-row permission check (`readable?` → `has_permission?`) for every matched creative, and
- a per-row `MAX(comments.updated_at)` aggregate, fired once per creative, just to sort "most-recent chat first".

## Changes

**Server (`IndexQuery`)** — the `comment=true` path now:
- permission-filters the whole matched set in a **single batch** via `PermissionFilter#readable_ids` (a handful of `IN` queries, not one per row),
- computes the recency ordering **in SQL** — a grouped `MAX(comments.updated_at) DESC, creatives.id DESC` with `LIMIT/OFFSET` — so no per-row aggregate,
- returns **one page** (default 30, `per_page` overridable up to 100) plus `pagination: { page, next_page, has_more }`.

Response cost is now a fixed page regardless of how many chats exist. `creatives_controller` surfaces the `pagination` object in the JSON payload.

**Client (`tree_controller.js`)** — the shared creatives-tree controller gains a **scoped** load-more that only engages when the JSON response carries a `pagination` object (i.e. the Chats feed). An `IntersectionObserver` sentinel fetches the next page (`?page=N`) and **appends** rows via a new `appendCreativeNodes` export. The normal tree and search views carry no `pagination` key, so none of this runs for them — behavior there is unchanged.

## Tests
- **Service** (`index_query_comment_pagination_test.rb`): ordering by most-recent comment, first/second page boundaries + `has_more`/`next_page`, permission exclusion, no-comment exclusion, empty feed metadata.
- **Jest** (`tree_controller.test.js`): sentinel set up only on `has_more` responses, next-page fetch + append on intersect, and that plain tree responses set up no pagination.

All engine service tests (114) and the controller jest suite (7) pass; rubocop clean; full pre-push suite + i18n checks green.

## Notes / follow-ups
- The matched-set batch permission filter is still O(matched rows) in a few queries (down from N round-trips); fine for the Chats feed and a large improvement, but could later be pushed fully into SQL if the global commented-creative count grows very large.
- Live-preview verification with a heavily-seeded account is recommended as a sanity pass (functional behavior is covered by the automated tests above).

Creative: "Chats 에 페이징 필요" (id 13504)