### PR TITLE
feat(desktop): read open-mode settings from data-dir config.json

### DIFF
--- a/tools/desktop-app/README.md
+++ b/tools/desktop-app/README.md
@@ -14,7 +14,7 @@ otherwise remote clients get a 403 from HostAuthorization even though Puma is
 listening. Example:
 
 ```
-COLLAVRE_BIND_HOST=0.0.0.0 COLLAVRE_ALLOWED_HOSTS=192.168.1.42,macbook-pro.tailadceed.ts.net bin/desktop-server
+COLLAVRE_BIND_HOST=0.0.0.0 COLLAVRE_ALLOWED_HOSTS=192.168.1.42,xxx.tailadceed.ts.net bin/desktop-server
 ```
 
 A **Finder-launched `.app` inherits an empty environment**, so those env vars
@@ -27,7 +27,7 @@ commas):
 
 ```json
 {
-  "allowed_hosts": ["macbook-pro.tailadceed.ts.net"],
+  "allowed_hosts": ["xxx.tailadceed.ts.net"],
   "bind_host": "0.0.0.0",
   "port": 4000
 }

--- a/tools/desktop-app/README.md
+++ b/tools/desktop-app/README.md
@@ -18,19 +18,24 @@ COLLAVRE_BIND_HOST=0.0.0.0 COLLAVRE_ALLOWED_HOSTS=192.168.1.42,macbook-pro.taila
 ```
 
 A **Finder-launched `.app` inherits an empty environment**, so those env vars
-can't reach it that way. For the installed app, put the same settings in a
-`config.json` in the data dir (below) — the Tauri shell reads it on launch and
-exports the recognized keys into the sidecar's environment **only when they
-aren't already set**, so an explicit env var still wins:
+can't reach it that way. For the installed app, put the same settings in
+`~/Library/Application Support/net.collavre.desktop/Collavre/config.json` — the
+Tauri shell reads it on launch and exports the recognized keys into the
+sidecar's environment **only when they aren't already set**, so an explicit env
+var still wins. The file is parsed as strict JSON (no comments or trailing
+commas):
 
-```jsonc
-// ~/Library/Application Support/net.collavre.desktop/Collavre/config.json
+```json
 {
-  "allowed_hosts": ["macbook-pro.tailadceed.ts.net"],  // array or "a,b" string
-  "bind_host": "0.0.0.0",                               // omit to stay loopback
-  "port": 4000                                          // omit for an ephemeral port
+  "allowed_hosts": ["macbook-pro.tailadceed.ts.net"],
+  "bind_host": "0.0.0.0",
+  "port": 4000
 }
 ```
+
+- `allowed_hosts` — a JSON array, or a `"a,b"` comma-separated string.
+- `bind_host` — omit to stay on loopback (`127.0.0.1`); set `"0.0.0.0"` to open.
+- `port` — omit for an ephemeral port.
 
 A missing or malformed file is the normal closed-loopback case and is ignored
 (the app never fails to launch over a bad config).

--- a/tools/desktop-app/README.md
+++ b/tools/desktop-app/README.md
@@ -17,6 +17,24 @@ listening. Example:
 COLLAVRE_BIND_HOST=0.0.0.0 COLLAVRE_ALLOWED_HOSTS=192.168.1.42,macbook-pro.tailadceed.ts.net bin/desktop-server
 ```
 
+A **Finder-launched `.app` inherits an empty environment**, so those env vars
+can't reach it that way. For the installed app, put the same settings in a
+`config.json` in the data dir (below) — the Tauri shell reads it on launch and
+exports the recognized keys into the sidecar's environment **only when they
+aren't already set**, so an explicit env var still wins:
+
+```jsonc
+// ~/Library/Application Support/net.collavre.desktop/Collavre/config.json
+{
+  "allowed_hosts": ["macbook-pro.tailadceed.ts.net"],  // array or "a,b" string
+  "bind_host": "0.0.0.0",                               // omit to stay loopback
+  "port": 4000                                          // omit for an ephemeral port
+}
+```
+
+A missing or malformed file is the normal closed-loopback case and is ignored
+(the app never fails to launch over a bad config).
+
 ## Layout
 
 ```
@@ -55,6 +73,7 @@ All mutable state lives under the OS app-data dir (the `.app` is read-only):
   desktop-{primary,cache,queue,cable}.sqlite3
   storage/            # Active Storage blobs
   credentials/secret_key_base
+  config.json         # optional: open-mode settings for a Finder-launched .app
   log/desktop.log
 ```
 

--- a/tools/desktop-app/src-tauri/Cargo.toml
+++ b/tools/desktop-app/src-tauri/Cargo.toml
@@ -17,6 +17,9 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri = { version = "2", features = [] }
 tauri-plugin-shell = "2"
+# Parse the optional desktop config.json in the data dir. Already in the tree as
+# a transitive Tauri dependency; named here so the shell can read it directly.
+serde_json = "1"
 
 [features]
 # Default Tauri custom-protocol for production builds.

--- a/tools/desktop-app/src-tauri/src/lib.rs
+++ b/tools/desktop-app/src-tauri/src/lib.rs
@@ -200,6 +200,180 @@ extern "C" {
     fn libc_kill(pid: i32, sig: i32) -> i32;
 }
 
+/// Normalize an `allowed_hosts` JSON value into a comma-joined host string.
+/// Accepts either an array of strings (`["a", "b"]`) or a single comma-separated
+/// string (`"a, b"`); trims each entry and drops blanks. Any other JSON type
+/// (number, bool, object) returns `None` so the key is skipped, not misread.
+fn json_to_host_list(v: &serde_json::Value) -> Option<String> {
+    let parts: Vec<String> = match v {
+        serde_json::Value::Array(items) => items
+            .iter()
+            .filter_map(|i| i.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+            .collect(),
+        serde_json::Value::String(s) => s
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+            .collect(),
+        _ => return None,
+    };
+    Some(parts.join(","))
+}
+
+/// Map recognized keys in the desktop `config.json` to the (env var, value)
+/// pairs the sidecar already understands. Pure (no env/fs) so the mapping is
+/// unit-tested in isolation. The result order is fixed (allowed_hosts, bind_host,
+/// port) regardless of key order in the file.
+///
+/// Recognized keys — all optional, unknown keys and wrong-typed values ignored:
+///   "allowed_hosts": ["host", ...] | "host,host"  -> COLLAVRE_ALLOWED_HOSTS
+///   "bind_host":      "0.0.0.0"                    -> COLLAVRE_BIND_HOST
+///   "port":           4000 | "4000"               -> PORT
+///
+/// Malformed JSON (or a non-object top level) yields no overrides: a bad config
+/// file degrades to the built-in closed-loopback defaults rather than failing
+/// the launch.
+fn config_env_overrides(json: &str) -> Vec<(&'static str, String)> {
+    let mut out = Vec::new();
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(json) else {
+        return out;
+    };
+    let Some(obj) = value.as_object() else {
+        return out;
+    };
+
+    if let Some(hosts) = obj.get("allowed_hosts").and_then(json_to_host_list) {
+        if !hosts.is_empty() {
+            out.push(("COLLAVRE_ALLOWED_HOSTS", hosts));
+        }
+    }
+
+    if let Some(host) = obj.get("bind_host").and_then(|v| v.as_str()) {
+        let host = host.trim();
+        if !host.is_empty() {
+            out.push(("COLLAVRE_BIND_HOST", host.to_string()));
+        }
+    }
+
+    if let Some(port) = obj.get("port").and_then(|v| match v {
+        serde_json::Value::Number(n) => n.as_u64().map(|n| n.to_string()),
+        serde_json::Value::String(s) => {
+            let t = s.trim();
+            (!t.is_empty()).then(|| t.to_string())
+        }
+        _ => None,
+    }) {
+        out.push(("PORT", port));
+    }
+
+    out
+}
+
+/// Read the optional `config.json` from the data dir and export its recognized
+/// settings into the process environment — but only for keys not already set, so
+/// an explicit env var (dev/test override, or a launcher that already exported
+/// the value) always wins.
+///
+/// This is the fix for the tailscale-serve UX gap: a Finder-launched `.app`
+/// inherits an empty environment, so there was no way to hand it
+/// COLLAVRE_ALLOWED_HOSTS / COLLAVRE_BIND_HOST and open-mode 403'd. Writing this
+/// file once (alongside the DBs, secrets, and logs the app already keeps here)
+/// lets every later launch pick the settings up. No file is the normal
+/// closed-loopback case and a no-op.
+fn apply_desktop_config(data: &PathBuf) {
+    let path = data.join("config.json");
+    let Ok(json) = fs::read_to_string(&path) else {
+        return;
+    };
+    for (key, value) in config_env_overrides(&json) {
+        if std::env::var_os(key).is_none() {
+            std::env::set_var(key, value);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::config_env_overrides;
+
+    fn pairs(json: &str) -> Vec<(&'static str, String)> {
+        config_env_overrides(json)
+    }
+
+    #[test]
+    fn allowed_hosts_array_joins_with_commas() {
+        let got = pairs(r#"{"allowed_hosts": ["a.ts.net", "b.ts.net"]}"#);
+        assert_eq!(
+            got,
+            vec![("COLLAVRE_ALLOWED_HOSTS", "a.ts.net,b.ts.net".to_string())]
+        );
+    }
+
+    #[test]
+    fn allowed_hosts_comma_string_is_normalized() {
+        let got = pairs(r#"{"allowed_hosts": " a.ts.net , b.ts.net "}"#);
+        assert_eq!(
+            got,
+            vec![("COLLAVRE_ALLOWED_HOSTS", "a.ts.net,b.ts.net".to_string())]
+        );
+    }
+
+    #[test]
+    fn bind_host_string_maps_to_env() {
+        let got = pairs(r#"{"bind_host": "0.0.0.0"}"#);
+        assert_eq!(got, vec![("COLLAVRE_BIND_HOST", "0.0.0.0".to_string())]);
+    }
+
+    #[test]
+    fn port_number_and_string_both_map() {
+        assert_eq!(
+            pairs(r#"{"port": 4000}"#),
+            vec![("PORT", "4000".to_string())]
+        );
+        assert_eq!(
+            pairs(r#"{"port": "4000"}"#),
+            vec![("PORT", "4000".to_string())]
+        );
+    }
+
+    #[test]
+    fn all_three_keys_preserve_a_stable_order() {
+        let got = pairs(r#"{"port": 4000, "bind_host": "0.0.0.0", "allowed_hosts": ["h"]}"#);
+        assert_eq!(
+            got,
+            vec![
+                ("COLLAVRE_ALLOWED_HOSTS", "h".to_string()),
+                ("COLLAVRE_BIND_HOST", "0.0.0.0".to_string()),
+                ("PORT", "4000".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn empty_and_blank_values_are_dropped() {
+        assert!(pairs(r#"{"allowed_hosts": []}"#).is_empty());
+        assert!(pairs(r#"{"allowed_hosts": "  ,  "}"#).is_empty());
+        assert!(pairs(r#"{"bind_host": "   "}"#).is_empty());
+        assert!(pairs(r#"{"port": ""}"#).is_empty());
+    }
+
+    #[test]
+    fn unknown_keys_and_wrong_types_are_ignored() {
+        assert!(pairs(r#"{"nope": 1, "bind_host": 123, "allowed_hosts": 5}"#).is_empty());
+    }
+
+    #[test]
+    fn malformed_json_yields_no_overrides() {
+        assert!(pairs("not json at all").is_empty());
+        assert!(pairs("").is_empty());
+        assert!(pairs("[1,2,3]").is_empty());
+    }
+}
+
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
@@ -209,6 +383,14 @@ pub fn run() {
             let root = app_root(&handle);
             let data = data_dir(&handle);
             std::fs::create_dir_all(&data).ok();
+
+            // Load persisted open-mode settings from the data dir's config.json
+            // into the env before anything reads it. A Finder-launched .app has
+            // no way to receive COLLAVRE_ALLOWED_HOSTS / COLLAVRE_BIND_HOST / PORT
+            // otherwise; explicit env vars still win (see apply_desktop_config).
+            // Must precede the PORT read and spawn_sidecar's COLLAVRE_BIND_HOST
+            // read below so the values actually take effect this launch.
+            apply_desktop_config(&data);
 
             // Honor a caller-supplied PORT so open mode gets a stable URL/firewall
             // rule; fall back to an ephemeral loopback port for the default


### PR DESCRIPTION
## What

Closes the **tailscale-serve UX gap** left as a follow-up on #1296: a Finder-launched `.app` inherits an empty environment, so there was no way to give it `COLLAVRE_ALLOWED_HOSTS` / `COLLAVRE_BIND_HOST`, and open mode (LAN/Tailscale) 403'd from HostAuthorization.

The Tauri shell now reads an optional `config.json` from the data dir and exports recognized keys into the sidecar env **before** the PORT read and `spawn_sidecar` — but only when a key isn't already set, so an explicit env var still wins.

```jsonc
// ~/Library/Application Support/net.collavre.desktop/Collavre/config.json
{
  "allowed_hosts": ["xxxx.tailadceed.ts.net"],  // array or "a,b" string
  "bind_host": "0.0.0.0",                               // omit to stay loopback (tailscale serve)
  "port": 4000                                          // omit for ephemeral port
}
```

## Why this shape

- **Location** — the data dir (`net.collavre.desktop/Collavre/`) is the single source of truth the app already uses for DBs, `credentials/secret_key_base`, storage, mail, and logs. Reusing it (vs `~/.config`) keeps one Tauri-derived, bundle-id-namespaced home. Mirrors the existing `provision-secrets.rb` pattern (read-or-create a file in the data dir).
- **Read point (Rust shell)** — the shell is the Finder entry point (earliest moment env is empty) and already decides `bind_host`. Handling both `bind_host` and `allowed_hosts` in one place means `config.json` alone can open raw `0.0.0.0` LAN, while omitting `bind_host` keeps loopback for the `tailscale serve` (allowlist-only) case.
- **Precedence** — env var > config file, so dev/test overrides and any launcher-exported value are preserved.

## Safety / failure modes

- Missing or malformed `config.json` → no overrides → built-in closed-loopback defaults. The app never fails to launch over a bad config.
- Unknown keys and wrong-typed values are ignored (not misread).
- Parsing (`config_env_overrides`) is a **pure function** with 8 unit tests (array/comma hosts, bind_host, port number+string, stable order, blank-dropping, type-mismatch, malformed JSON).

## Test

`cargo test` → 8/8 pass. `cargo check` + `cargo clippy` clean (the one `&PathBuf` clippy note matches the file's existing convention, e.g. `pidfile_path`).

## Files

- `src-tauri/src/lib.rs` — `json_to_host_list`, `config_env_overrides` (pure + tested), `apply_desktop_config` (fs+env glue), wired into `setup()`.
- `src-tauri/Cargo.toml` — name `serde_json` (already a transitive Tauri dep).
- `README.md` — document config.json for open mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)