### PR TITLE
fix: dispatch AI in all inbox topics except System

### DIFF
--- a/engines/collavre/app/models/collavre/comment.rb
+++ b/engines/collavre/app/models/collavre/comment.rb
@@ -164,18 +164,21 @@ module Collavre
       return unless user_id        # nil user = system message
       return if user&.ai_user?     # AI replies use A2aDispatcher, not this callback
       return unless creative
-      # Inbox creatives hold the user's notifications/DMs and normally must not
-      # trigger AI orchestration. Exception: a Claude Channel agent session
-      # registers its topic *inside* the inbox (Creative.inbox_for) and depends
-      # on the orchestration pipeline (Matcher → Arbiter → AiAgentService) to
-      # deliver comments to the running session. Scope the exception to actual
-      # Claude Channel session topics (primary_agent is a claude_channel_agent?).
-      # An inbox topic can be given any ai_user as primary_agent via
-      # TopicsController#set_primary_agent; gating on mere primary_agent presence
-      # would leak ordinary inbox DMs to the live Claude session, which holds
-      # inbox-wide :feedback + routing_expression="true" and would be selected by
-      # the Matcher for any dispatched inbox comment.
-      return if creative.inbox? && !claude_channel_session_topic?
+      # Inbox creatives hold the user's notifications AND ordinary conversations.
+      # Only the System topic is special: it carries alarms/notifications (stuck
+      # recovery, share notices, …) and must never trigger AI. Every OTHER inbox
+      # topic — Main, Content, user threads, Claude Channel session topics — is an
+      # ordinary conversation surface and dispatches exactly like a normal
+      # (non-inbox) topic.
+      #
+      # A live Claude Channel session holds inbox-wide :feedback +
+      # routing_expression="true", so it would otherwise be selected by the
+      # Matcher for *every* dispatched inbox comment (leaking ordinary inbox
+      # threads into the live session). That confinement now lives in
+      # Orchestration::Matcher, which scopes a Claude session agent to its own
+      # registered session topic — keeping non-System topics truly identical to a
+      # normal topic whether or not a session is live.
+      return if creative.inbox? && inbox_system_topic?
 
       # A Claude Channel session suspended on a native tool-permission prompt
       # parks its in-flight dispatch as a `delegated` task carrying a
@@ -200,19 +203,12 @@ module Collavre
       raise  # re-raise so calling jobs (e.g. DropTriggerJob) can retry
     end
 
-    # True only when this comment's topic is an actual Claude Channel session
-    # topic — it carries the registration marker (session_id) AND its
-    # primary_agent is a claude_channel_agent? (llm_model "claude-code"). Used to
-    # scope the inbox dispatch exception so ordinary inbox threads stay local.
-    #
-    # session_id is required, not just the Claude primary_agent: a Claude
-    # channel ai_user can be assigned as primary_agent on an ordinary inbox
-    # topic via TopicsController#set_primary_agent without ever registering a
-    # session. Gating on the agent alone would dispatch that ordinary thread and
-    # leak it to the live Claude session. session_id is exactly what
-    # ClaudeChannelAdapter#session_topic? keys on, so the two stay consistent.
-    def claude_channel_session_topic?
-      topic&.session_id.present? && topic&.primary_agent&.claude_channel_agent?
+    # The inbox System topic is the alarm/notification stream and must never
+    # trigger AI orchestration. Matched by name (Creative::SYSTEM_TOPIC_NAME),
+    # the same topic Creative#system_topic finds/creates and that stuck-recovery
+    # and share notices post into.
+    def inbox_system_topic?
+      topic&.name == Creative::SYSTEM_TOPIC_NAME
     end
 
     def assign_default_user

--- a/engines/collavre/app/services/collavre/inbox_reply_service.rb
+++ b/engines/collavre/app/services/collavre/inbox_reply_service.rb
@@ -64,6 +64,11 @@ module Collavre
         content: @comment.content,
         user: @comment.user,
         quoted_comment: original,
+        # quoted_comment is set only for linkage to the message being answered.
+        # Mark it as a "question" so review_message? stays false — otherwise the
+        # agent's response would update the quoted comment in place (the review
+        # flow) instead of posting a new reply. See Comment#review_message?.
+        review_type: :question,
         private: false
       )
 

--- a/engines/collavre/app/services/collavre/orchestration/matcher.rb
+++ b/engines/collavre/app/services/collavre/orchestration/matcher.rb
@@ -57,9 +57,24 @@ module Collavre
 
         agents.select do |agent|
           next false unless has_creative_permission?(agent)
+          next false unless eligible_in_inbox?(agent)
 
           evaluate_routing_expression(agent)
         end
+      end
+
+      # A Claude Channel session agent holds inbox-wide :feedback +
+      # routing_expression="true", so within the user's Inbox it would otherwise
+      # match EVERY topic. Confine it to its own registered session topic (the
+      # topic it is primary_agent on, carrying a session_id) so ordinary inbox
+      # topics — Main, Content, user threads — stay identical to a normal topic
+      # and are never absorbed by a live session. Only the inbox is affected: on
+      # work/project creatives the agent still matches via routing_expression.
+      def eligible_in_inbox?(agent)
+        return true unless matched_creative&.inbox?
+        return true unless agent.claude_channel_agent?
+
+        matched_topic&.session_id.present? && matched_topic.primary_agent_id == agent.id
       end
 
       def evaluate_routing_expression(agent)
@@ -85,13 +100,24 @@ module Collavre
       def has_creative_permission?(agent)
         # All agents need feedback permission on the creative to respond
         # searchable only affects discoverability, not response permission
-        creative_id = @context.dig("creative", "id") || @context.dig(:creative, :id)
-        return false unless creative_id
-
-        creative = Creative.find_by(id: creative_id)
+        creative = matched_creative
         return false unless creative
 
         creative.has_permission?(agent, :feedback)
+      end
+
+      def matched_creative
+        return @matched_creative if defined?(@matched_creative)
+
+        creative_id = @context.dig("creative", "id") || @context.dig(:creative, :id)
+        @matched_creative = creative_id && Creative.find_by(id: creative_id)
+      end
+
+      def matched_topic
+        return @matched_topic if defined?(@matched_topic)
+
+        topic_id = @context.dig("topic", "id") || @context.dig(:topic, :id)
+        @matched_topic = topic_id && Topic.find_by(id: topic_id)
       end
     end
   end

--- a/engines/collavre/app/services/collavre/orchestration/matcher.rb
+++ b/engines/collavre/app/services/collavre/orchestration/matcher.rb
@@ -47,6 +47,11 @@ module Collavre
         # Permission check for mentioned AI agent
         return [] unless has_creative_permission?(mentioned_user)
 
+        # Inbox confinement applies to mentions too: a live Claude Channel
+        # session agent must not be pulled into an ordinary inbox topic, even by
+        # an explicit @mention (see #eligible_in_inbox?).
+        return [] unless eligible_in_inbox?(mentioned_user)
+
         [ mentioned_user ]
       end
 

--- a/engines/collavre/test/models/comment_inbox_dispatch_test.rb
+++ b/engines/collavre/test/models/comment_inbox_dispatch_test.rb
@@ -3,13 +3,16 @@
 require "test_helper"
 
 module Collavre
-  # Claude Channel registers each session's topic *inside* the user's Inbox
-  # creative and relies on the orchestration pipeline (Matcher → Arbiter →
-  # AiAgentService) to deliver comments to the running session. The pre-existing
-  # `return if creative.inbox?` guard in Comment#dispatch_to_orchestration must
-  # therefore NOT short-circuit when the inbox topic has a primary_agent
-  # (an agent session topic) — while still skipping ordinary inbox DMs that
-  # have no agent.
+  # Inbox dispatch policy: only the System topic (alarms/notifications) is
+  # silenced; every other inbox topic dispatches exactly like a normal topic
+  # (Comment#dispatch_to_orchestration gates on inbox_system_topic?).
+  #
+  # The catch: a live Claude Channel session agent holds inbox-wide :feedback +
+  # routing_expression="true", so it would otherwise be matched onto every inbox
+  # topic. Orchestration::Matcher confines it to its own registered session
+  # topic, so ordinary inbox topics are never absorbed by a live session. These
+  # tests pin both halves: session topics still deliver to the running session,
+  # and ordinary inbox threads never leak into it.
   class CommentInboxDispatchTest < ActiveSupport::TestCase
     include ActiveJob::TestHelper
 
@@ -60,10 +63,10 @@ module Collavre
 
     # A Claude Channel ai_user can be set as an inbox topic's primary_agent via
     # TopicsController#set_primary_agent without ever registering a session (no
-    # session_id). That is NOT a real session topic: the adapter stamps
-    # session_topic on session_id presence, so dispatching here would route an
-    # ordinary inbox thread to the live Claude session. The exception must key
-    # on the registration marker (session_id), matching the adapter.
+    # session_id). The comment now dispatches (non-System topic), but the Matcher
+    # confines the live session agent to topics carrying a session_id — so this
+    # unregistered topic still produces no AI turn. session_id is the registration
+    # marker the adapter (ClaudeChannelAdapter#session_topic?) keys on too.
     test "human comment in an inbox topic with a Claude primary_agent but NO session_id does not dispatch" do
       topic = @inbox.topics.create!(name: "Claude agent, unregistered", user: @user)
       topic.set_primary_agent!(@agent)
@@ -81,11 +84,10 @@ module Collavre
       end
     end
 
-    # An inbox topic may be given a primary agent that is NOT a Claude Channel
-    # session (TopicsController#set_primary_agent accepts any ai_user). The inbox
-    # dispatch exception must stay scoped to actual Claude Channel session topics
-    # — otherwise an ordinary inbox thread leaks to the live Claude session,
-    # which holds inbox-wide feedback + routing_expression="true".
+    # Leak guard: the live Claude session agent from setup (inbox-wide feedback +
+    # routing_expression="true") must NOT be matched onto an ordinary inbox topic,
+    # even one given its own, different primary agent. The other agent here holds
+    # no feedback on the inbox, so it isn't matched either — leaving zero AI turns.
     test "human comment in an inbox topic with a NON-Claude primary_agent does not dispatch" do
       other_agent = User.create!(
         email: "inbox_other_agent@agent.collavre.local",
@@ -101,6 +103,59 @@ module Collavre
 
       assert_no_enqueued_jobs(only: Collavre::AiAgentJob) do
         @inbox.comments.create!(content: "ordinary dm", user: @user, topic: topic)
+      end
+    end
+
+    # --- Non-System inbox topics are ordinary conversation surfaces ---
+    #
+    # Only Inbox#System carries alarms/notifications (stuck recovery, share
+    # notices) and must stay silent. Every OTHER inbox topic — Main, Content,
+    # user threads — is treated EXACTLY like a normal (non-inbox) topic: an AI
+    # agent that holds feedback on the creative dispatches there as usual.
+
+    # A normal (non-Claude-session) AI agent that holds feedback on the inbox,
+    # mirroring how an agent added to an ordinary topic is set up.
+    def create_shared_inbox_agent(name:, email:)
+      agent = User.create!(
+        email: email,
+        name: name,
+        password: "password",
+        llm_vendor: "anthropic",
+        llm_model: "claude-3-5-sonnet",
+        routing_expression: "true",
+        created_by_id: @user.id
+      )
+      share = Collavre::CreativeShare.find_or_create_by!(creative: @inbox, user: agent)
+      share.update!(permission: "feedback")
+      Collavre::CreativeSharesCache.find_or_create_by!(
+        creative_id: @inbox.id,
+        user_id: agent.id,
+        permission: :feedback
+      )
+      agent
+    end
+
+    test "human comment in an ordinary inbox topic (Main) dispatches like a normal topic" do
+      agent = create_shared_inbox_agent(
+        name: "Inbox Main Agent", email: "inbox_main_agent@agent.collavre.local"
+      )
+      topic = @inbox.main_topic(fallback_user: @user)
+      topic.set_primary_agent!(agent)
+
+      assert_enqueued_with(job: Collavre::AiAgentJob) do
+        @inbox.comments.create!(content: "hello agent", user: @user, topic: topic)
+      end
+    end
+
+    test "human comment in the inbox System topic does NOT dispatch (alarms stay silent)" do
+      agent = create_shared_inbox_agent(
+        name: "Inbox System Agent", email: "inbox_system_agent@agent.collavre.local"
+      )
+      system_topic = @inbox.system_topic(fallback_user: @user)
+      system_topic.set_primary_agent!(agent)
+
+      assert_no_enqueued_jobs(only: Collavre::AiAgentJob) do
+        @inbox.comments.create!(content: "a notification-ish note", user: @user, topic: system_topic)
       end
     end
   end

--- a/engines/collavre/test/models/comment_test.rb
+++ b/engines/collavre/test/models/comment_test.rb
@@ -127,17 +127,20 @@ class CommentTest < ActiveSupport::TestCase
     assert_equal initial_inbox_comment_count, inbox.comments.count
   end
 
-  test "inbox comments do not dispatch to orchestration" do
+  # Only the inbox System topic (alarms/notifications) is silenced; every other
+  # inbox topic dispatches like a normal topic (see comment_inbox_dispatch_test).
+  test "inbox System-topic comments do not dispatch to orchestration" do
     owner = User.create!(email: "inbox-orch-owner@example.com", password: TEST_PASSWORD, name: "InboxOrchOwner")
     commenter = User.create!(email: "inbox-orch-commenter@example.com", password: TEST_PASSWORD, name: "InboxOrchCommenter")
     inbox = Creative.inbox_for(owner)
+    system_topic = inbox.system_topic(fallback_user: owner)
 
     dispatched = false
     SystemEvents::Dispatcher.stub(:dispatch, ->(*_args) { dispatched = true }) do
-      inbox.comments.create!(user: commenter, content: "reply in inbox")
+      inbox.comments.create!(user: commenter, content: "alarm note", topic: system_topic)
     end
 
-    refute dispatched, "Expected no orchestration dispatch for inbox comments"
+    refute dispatched, "Expected no orchestration dispatch for inbox System-topic comments"
   end
 
   test "creating an inbox notification broadcasts inbox badge immediately" do

--- a/engines/collavre/test/services/collavre/inbox_reply_service_test.rb
+++ b/engines/collavre/test/services/collavre/inbox_reply_service_test.rb
@@ -53,6 +53,30 @@ module Collavre
       assert_equal @original_comment.id, cross_posted.quoted_comment_id
     end
 
+    # An inbox cross-post quotes the original comment purely for linkage. It must
+    # NOT be treated as a review message: review_message? drives the in-place
+    # ReviewHandler flow that OVERWRITES the quoted comment with the agent's
+    # reply. When the quoted comment is the agent's own (e.g. it asked a
+    # question), that flow would update the question in place instead of posting
+    # a new answer. The cross-post must reply normally.
+    test "cross-posted reply is not a review message (does not overwrite the quoted comment)" do
+      reply = Comment.create!(
+        creative: @inbox,
+        topic: @system_topic,
+        content: "My reply from inbox",
+        user: @user,
+        skip_dispatch: true
+      )
+
+      InboxReplyService.call(reply)
+
+      cross_posted = @creative.comments.where(user: @user, content: "My reply from inbox").last
+      assert cross_posted, "Expected cross-posted comment in original creative"
+      assert_equal @original_comment.id, cross_posted.quoted_comment_id, "quote linkage preserved"
+      assert_not cross_posted.review_message?,
+                 "inbox cross-post must reply normally, not trigger the in-place review-update flow"
+    end
+
     test "does not cross-post for non-inbox creatives" do
       reply = Comment.create!(
         creative: @creative,

--- a/engines/collavre/test/services/collavre/orchestration/matcher_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/matcher_test.rb
@@ -204,6 +204,69 @@ module Collavre
       ensure
         other_agent&.destroy
       end
+
+      # --- Inbox mention confinement (live Claude Channel session) ---
+      #
+      # A live Claude Channel session agent holds inbox-wide :feedback +
+      # routing_expression="true". The expression path confines it to its own
+      # registered session topic so ordinary inbox topics stay identical to a
+      # normal topic. The mention path must apply the SAME confinement —
+      # otherwise @mentioning the session agent in an ordinary inbox topic would
+      # absorb that thread into the live session.
+
+      def build_claude_inbox_session_agent(inbox)
+        claude = User.create!(
+          email: "matcher_claude_session@agent.collavre.local",
+          name: "Claude Session",
+          password: "password",
+          llm_vendor: "anthropic",
+          llm_model: "claude-code",
+          routing_expression: "true",
+          created_by_id: @user.id
+        )
+        CreativeShare.find_or_create_by!(creative: inbox, user: claude).update!(permission: "feedback")
+        CreativeSharesCache.find_or_create_by!(
+          creative_id: inbox.id, user_id: claude.id, permission: :feedback
+        )
+        claude
+      end
+
+      test "mentioned Claude session agent is confined out of an ordinary inbox topic" do
+        inbox = Creative.create!(
+          description: "Inbox", data: { "kind" => "inbox" }, user: @user, progress: 0.0
+        )
+        claude = build_claude_inbox_session_agent(inbox)
+        ordinary_topic = inbox.topics.create!(name: "Main thread", user: @user)
+
+        context = {
+          "event_name" => "comment_created",
+          "creative" => { "id" => inbox.id },
+          "topic" => { "id" => ordinary_topic.id },
+          "chat" => { "mentioned_user" => { "id" => claude.id } }
+        }
+
+        # Even on an explicit @mention, an ordinary inbox topic must not route
+        # to the live session agent.
+        assert_empty Matcher.new(context).match
+      end
+
+      test "mentioned Claude session agent matches in its own registered session topic" do
+        inbox = Creative.create!(
+          description: "Inbox", data: { "kind" => "inbox" }, user: @user, progress: 0.0
+        )
+        claude = build_claude_inbox_session_agent(inbox)
+        session_topic = inbox.topics.create!(name: "Claude session-y", user: @user, session_id: "sess-y")
+        session_topic.set_primary_agent!(claude)
+
+        context = {
+          "event_name" => "comment_created",
+          "creative" => { "id" => inbox.id },
+          "topic" => { "id" => session_topic.id },
+          "chat" => { "mentioned_user" => { "id" => claude.id } }
+        }
+
+        assert_equal [ claude ], Matcher.new(context).match
+      end
     end
   end
 end


### PR DESCRIPTION
## Problem

Adding an AI agent to a non-System inbox topic (e.g. **Inbox#Main**) and chatting produced **no response** — the comment never reached AI orchestration.

`Comment#dispatch_to_orchestration` short-circuited on `creative.inbox?` for *every* inbox topic except a live Claude Channel session topic. This blanket block was introduced in #1199 ("skip orchestration dispatch for inbox comments") and narrowed in #1161, but it still swallowed ordinary inbox conversations. Inbox#Main has therefore never dispatched to an agent since 2026-04-15.

Per product intent: **only Inbox#System** carries alarms/notifications (stuck recovery, share notices) and must stay silent. Every other inbox topic should behave **exactly like a normal topic**.

## Change

**1. Gate (`comment.rb`)** — block only the System topic:

```ruby
return if creative.inbox? && inbox_system_topic?
```

Non-System inbox topics now reach the orchestration pipeline like any normal topic.

**2. Matcher (`orchestration/matcher.rb`)** — close the leak the old blanket-block was hiding. A live Claude Channel session agent holds **inbox-wide `:feedback` + `routing_expression="true"`**, so once non-System topics dispatch, it would be matched onto *every* inbox comment. The protection is relocated from the dispatch-block to a per-agent rule: within an inbox, a Claude session agent is confined to its **own registered session topic** (`session_id` + `primary_agent`). Work/project creatives are unaffected (zero behavior change off the inbox).

This keeps non-System topics truly identical to a normal topic **whether or not a session is live**.

## Tests

- New: `Inbox#Main` with a shared agent **dispatches**; `Inbox#System` **does not**.
- Existing leak-guard tests stay green — protection is preserved, just relocated to the Matcher.
- `comment_test` updated: the old "inbox comments do not dispatch" case now asserts the System-topic case.

Verified locally: orchestration suite (141), inbox dispatch + comment models, comments/agents controllers + claude_channel_adapter (133) — all green. Rubocop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)