### PR TITLE
feat(desktop): route Turbo data-turbo-confirm through in-app dialog

### DIFF
--- a/engines/collavre/app/javascript/collavre.js
+++ b/engines/collavre/app/javascript/collavre.js
@@ -19,6 +19,7 @@ import "./components/creative_tree_row"
 // Import and re-export lib utilities
 import "./lib/apply_lexical_styles"
 import "./lib/turbo_stream_actions"
+import "./lib/turbo_confirm"
 
 // Export controller registration
 export { registerControllers } from "./controllers"

--- a/engines/collavre/app/javascript/lib/__tests__/turbo_confirm.test.js
+++ b/engines/collavre/app/javascript/lib/__tests__/turbo_confirm.test.js
@@ -1,0 +1,81 @@
+/**
+ * @jest-environment jsdom
+ */
+import { jest } from '@jest/globals'
+
+// Mock the Turbo import so the module installs its confirm method onto a fake
+// config we control, instead of pulling in (and starting) the real Turbo.
+const fakeTurbo = { config: { forms: {} } }
+jest.unstable_mockModule('@hotwired/turbo-rails', () => ({ Turbo: fakeTurbo }))
+
+// Importing the module installs the override (side effect).
+await import('../turbo_confirm')
+
+const turboConfirm = fakeTurbo.config.forms.confirm
+const modal = () => document.querySelector('.modal-dialog')
+const message = () => document.querySelector('.confirm-dialog-message')
+
+afterEach(() => {
+  document.body.innerHTML = ''
+  document.documentElement.lang = ''
+})
+
+test('installs a confirm method on Turbo.config.forms', () => {
+  expect(typeof turboConfirm).toBe('function')
+})
+
+test('renders the in-app confirm dialog with the Turbo message', () => {
+  const form = document.createElement('form')
+  turboConfirm('Revoke this token?', form, null)
+  expect(modal()).not.toBeNull()
+  expect(message().textContent).toBe('Revoke this token?')
+  // Cancel button present (it is a confirm, not an alert).
+  expect(document.querySelector('.modal-dialog-btn-secondary')).not.toBeNull()
+})
+
+test('resolves true when confirmed, false when cancelled', async () => {
+  const form = document.createElement('form')
+
+  const okP = turboConfirm('ok?', form, null)
+  document.querySelector('.modal-dialog-btn-danger, .modal-dialog-btn-primary').click()
+  await expect(okP).resolves.toBe(true)
+
+  const cancelP = turboConfirm('no?', form, null)
+  document.querySelector('.modal-dialog-btn-secondary').click()
+  await expect(cancelP).resolves.toBe(false)
+})
+
+test('styles the confirm button as danger for delete submits', () => {
+  const form = document.createElement('form')
+  form.setAttribute('data-turbo-method', 'delete')
+  turboConfirm('Delete?', form, null)
+  expect(document.querySelector('.modal-dialog-btn-danger')).not.toBeNull()
+  expect(document.querySelector('.modal-dialog-btn-primary')).toBeNull()
+})
+
+test('detects delete via the submitter and the hidden _method input', () => {
+  // Submitter carries the method (button_to renders a button submitter).
+  const form1 = document.createElement('form')
+  const submitter = document.createElement('button')
+  submitter.setAttribute('data-turbo-method', 'delete')
+  turboConfirm('x', form1, submitter)
+  expect(document.querySelector('.modal-dialog-btn-danger')).not.toBeNull()
+  document.body.innerHTML = ''
+
+  // Rails non-Turbo fallback: hidden _method=delete input.
+  const form2 = document.createElement('form')
+  const hidden = document.createElement('input')
+  hidden.name = '_method'
+  hidden.value = 'delete'
+  form2.appendChild(hidden)
+  turboConfirm('x', form2, null)
+  expect(document.querySelector('.modal-dialog-btn-danger')).not.toBeNull()
+})
+
+test('non-destructive submit uses the primary (non-danger) button', () => {
+  const form = document.createElement('form')
+  form.setAttribute('method', 'post')
+  turboConfirm('Proceed?', form, null)
+  expect(document.querySelector('.modal-dialog-btn-primary')).not.toBeNull()
+  expect(document.querySelector('.modal-dialog-btn-danger')).toBeNull()
+})

--- a/engines/collavre/app/javascript/lib/turbo_confirm.js
+++ b/engines/collavre/app/javascript/lib/turbo_confirm.js
@@ -1,0 +1,46 @@
+// turbo_confirm — route Turbo's declarative `data-turbo-confirm` prompts through
+// the in-app confirm dialog instead of the native window.confirm().
+//
+// Why: Rails/Turbo forms gate destructive submits with `data-turbo-confirm`.
+// Turbo's default confirm method calls window.confirm(), which in the packaged
+// desktop app (Tauri WKWebView) returns false with no UI — so the submit
+// silently no-ops (e.g. token revoke, user delete, share removal) and looks
+// like the button is broken. Converting hand-written confirm() calls does not
+// cover these, because Turbo intercepts them before any of our code runs. The
+// fix is a single global override of Turbo's confirm method.
+//
+// Returns a Promise<boolean>; Turbo awaits it before submitting (Turbo 8
+// `config.forms.confirm`, with a fallback to the deprecated setConfirmMethod).
+
+import { Turbo } from "@hotwired/turbo-rails"
+import { confirmDialog } from "./utils/dialog"
+
+// Turbo invokes this with (message, formElement, submitter). Style the confirm
+// button as destructive when the submit deletes (the common case for
+// data-turbo-confirm), so it matches the danger styling used elsewhere.
+function turboConfirm(message, formElement, submitter) {
+    const method = (
+        submitter?.getAttribute?.("data-turbo-method") ||
+        formElement?.getAttribute?.("data-turbo-method") ||
+        formElement?.querySelector?.("input[name='_method']")?.value ||
+        formElement?.getAttribute?.("method") ||
+        ""
+    ).toLowerCase()
+    const danger = method === "delete" || method === "destroy"
+    return confirmDialog(message, { danger })
+}
+
+// Install on both the bundled Turbo and any pre-existing global window.Turbo,
+// mirroring turbo_stream_actions.js — the two can be distinct instances.
+function installTurboConfirm(turbo) {
+    if (!turbo) return
+    if (turbo.config && turbo.config.forms) {
+        turbo.config.forms.confirm = turboConfirm
+    } else if (typeof turbo.setConfirmMethod === "function") {
+        // Turbo < 8 fallback.
+        turbo.setConfirmMethod(turboConfirm)
+    }
+}
+
+installTurboConfirm(Turbo)
+if (window.Turbo && window.Turbo !== Turbo) installTurboConfirm(window.Turbo)


### PR DESCRIPTION
## Follow-up to #1302 (Codex P2)

Codex flagged that #1302 only converted hand-written `confirm()` calls. Rails/Turbo forms gated by **`data-turbo-confirm`** still use Turbo's default confirm method, which calls native `window.confirm()`. In the packaged desktop app (Tauri WKWebView) that returns `false` with no UI → the destructive submit **silently no-ops**, the exact failure #1302 set out to remove.

Verified in this tree:
- 7 product views use `data-turbo-confirm` (creatives `show`/`_share_modal`, users `index`/`_org_chart`/`_org_chart_node`/`_contact_list`, admin integrations `_setting_row`).
- **Zero** `Turbo.config.forms.confirm` / `setConfirmMethod` overrides existed → native confirm everywhere.

## Fix

A single global override of Turbo's confirm method (`engines/collavre/app/javascript/lib/turbo_confirm.js`), imported from `collavre.js` so it loads app-wide via `application.js`:

- Turbo 8 `config.forms.confirm` (with a `setConfirmMethod` fallback for older Turbo) → routes the prompt through the existing `confirmDialog()`.
- Styles the confirm button as **danger** when the submit is a delete (detected via submitter / form `data-turbo-method` / hidden `_method`).
- Returns a `Promise<boolean>`; Turbo awaits it before submitting.

Because it overrides the global, it also restores consistent in-app dialogs in the regular browser (same top-layer dialog as #1302), matching the "unify on custom dialogs" goal.

## Not covered (separate concern)

The Doorkeeper OAuth pages (`app/views/doorkeeper/applications/{index,show}`) render under the **doorkeeper gem layout**, which loads no app JS — so their native confirm predates #1302 and a JS override can't reach them. Fixing those needs an app-level doorkeeper layout override; out of scope here, noted for follow-up.

## Verification

- `npm test`: **277 passed** (24 suites; 6 new in `turbo_confirm.test.js` — install, render, true/false resolution, danger detection via attr/submitter/`_method`, non-destructive primary button).
- `npm run build`: esbuild clean; override bundled into `application.js` + `collavre.js`.