### PR TITLE
refactor(voice): drop client since cursor — server emits all pending approvals

### DIFF
--- a/engines/collavre/app/controllers/collavre/api/v1/mobile/agent_events_controller.rb
+++ b/engines/collavre/app/controllers/collavre/api/v1/mobile/agent_events_controller.rb
@@ -19,17 +19,18 @@ module Collavre
           DENY    = /(거절|거부|반려|deny|reject|취소|아니|\bno\b)/i
 
           def index
-            since = parse_since(params[:since])
-
             approvals = pending_approvals
             notices = system_inbox_messages
 
-            # Only EMIT what is newer than the client cursor. Approvals are
-            # otherwise unbounded by `since` (they stay pending until decided),
-            # so without this filter every poll re-speaks the same approval.
-            new_approvals = since ? approvals.select { |c| c.created_at > since } : approvals
-
-            events = new_approvals.map do |c|
+            # Every undecided approval is emitted on every poll — the server keeps
+            # no per-client cursor. Re-speaking is prevented on the CLIENT (an
+            # in-memory "already spoken" set), the same at-least-once shape as
+            # notices: a pending approval keeps surfacing until it is decided
+            # (which clears it from pending_approvals) or the app restarts (when a
+            # still-pending approval SHOULD be re-surfaced). The old `since` cursor
+            # filtered here, but a batch high-water-mark could burn past an approval
+            # whose created_at trailed a newer notice, losing it forever.
+            events = approvals.map do |c|
               {
                 id: c.id, type: "approval_requested",
                 title: title_for_topic(c.topic_id),
@@ -88,14 +89,6 @@ module Collavre
           end
 
           private
-
-          def parse_since(value)
-            return nil if value.blank?
-
-            Time.iso8601(value.to_s)
-          rescue ArgumentError
-            nil
-          end
 
           # The user's Inbox → System topic is the per-user alarm stream: mentions,
           # agent replies, share notices, … land here as system-authored

--- a/engines/collavre/test/controllers/api/v1/mobile/agent_events_controller_test.rb
+++ b/engines/collavre/test/controllers/api/v1/mobile/agent_events_controller_test.rb
@@ -56,50 +56,62 @@ module Collavre
               "the app lists messages titled 크리에이티브#토픽 so the user knows the thread"
           end
 
-          test "an event already delivered is not re-surfaced once the since cursor advances" do
+          test "a still-pending approval keeps surfacing on every poll (server holds no cursor)" do
             create_permission_comment(request_id: "req-once", tool_name: "Edit")
 
             get "/api/v1/mobile/agent_events", params: { device_id: DEVICE }, headers: auth_headers, as: :json
-            first = JSON.parse(response.body)
-            assert_equal 1, first.size
-            cursor = first.first["created_at"]
+            assert_equal 1, JSON.parse(response.body).size
 
-            # Same poll the client would make next: since = the max created_at it saw.
-            get "/api/v1/mobile/agent_events", params: { device_id: DEVICE, since: cursor }, headers: auth_headers, as: :json
+            # The server keeps no per-client cursor: an undecided approval is emitted
+            # again next poll. Re-speaking is suppressed on the client (in-memory
+            # "already spoken" set), and a restart correctly re-surfaces it.
+            get "/api/v1/mobile/agent_events", params: { device_id: DEVICE }, headers: auth_headers, as: :json
             assert_response :ok
-            assert_empty JSON.parse(response.body),
-              "a still-pending approval must not be re-emitted every poll (infinite TTS bug)"
+            assert_equal 1, JSON.parse(response.body).size,
+              "a pending approval stays in the stream until it is decided"
           end
 
-          test "a pending approval is still decidable after it stops being re-emitted" do
+          test "a pending approval stops surfacing once it is decided" do
             comment = create_permission_comment(request_id: "req-keepref", tool_name: "Bash")
 
             get "/api/v1/mobile/agent_events", params: { device_id: DEVICE }, headers: auth_headers, as: :json
-            cursor = JSON.parse(response.body).first["created_at"]
+            assert_equal 1, JSON.parse(response.body).size
 
-            # Drops out of the emitted stream (already delivered)...
-            get "/api/v1/mobile/agent_events", params: { device_id: DEVICE, since: cursor }, headers: auth_headers, as: :json
-            assert_empty JSON.parse(response.body)
-
-            # ...but responding to it by event id must still decide the permission.
+            # Deciding it (clearing action_executed_at) drops it from pending_approvals.
             post "/api/v1/mobile/agent_events/#{comment.id}/respond",
               params: { device_id: DEVICE, response: "approve" }, headers: auth_headers, as: :json
             assert_response :ok
             assert_equal "allow", JSON.parse(comment.reload.action)["decision"]
+
+            get "/api/v1/mobile/agent_events", params: { device_id: DEVICE }, headers: auth_headers, as: :json
+            assert_empty JSON.parse(response.body), "a decided approval no longer surfaces"
           end
 
-          test "an event created after the cursor still surfaces" do
+          test "all undecided approvals surface together, newest and oldest alike" do
             create_permission_comment(request_id: "req-old", tool_name: "Edit")
-            get "/api/v1/mobile/agent_events", params: { device_id: DEVICE }, headers: auth_headers, as: :json
-            cursor = JSON.parse(response.body).first["created_at"]
 
             travel_to 5.seconds.from_now do
               create_permission_comment(request_id: "req-new", tool_name: "Bash")
-              get "/api/v1/mobile/agent_events", params: { device_id: DEVICE, since: cursor }, headers: auth_headers, as: :json
+              get "/api/v1/mobile/agent_events", params: { device_id: DEVICE }, headers: auth_headers, as: :json
             end
-            events = JSON.parse(response.body)
-            assert_equal 1, events.size, "the newer approval surfaces; the older one does not"
-            assert_equal "req-new", Collavre::Comment.find(events.first["id"]).claude_channel_permission_request_id
+            request_ids = JSON.parse(response.body).map do |e|
+              Collavre::Comment.find(e["id"]).claude_channel_permission_request_id
+            end
+            assert_equal %w[req-new req-old], request_ids.sort,
+              "no server cursor drops the older approval; both pending prompts surface"
+          end
+
+          test "an unknown since param from an older client is harmlessly ignored" do
+            create_permission_comment(request_id: "req-back-compat", tool_name: "Edit")
+
+            # Old APKs still send a `since` cursor; the server no longer reads it and
+            # must not error or suppress anything.
+            get "/api/v1/mobile/agent_events",
+              params: { device_id: DEVICE, since: 1.hour.from_now.iso8601(6) },
+              headers: auth_headers, as: :json
+            assert_response :ok
+            assert_equal 1, JSON.parse(response.body).size,
+              "a stale since cursor no longer hides a pending approval"
           end
 
           test "respond approve decides the permission and broadcasts to the suspended session" do

--- a/tools/android-app/app/src/main/java/com/collavre/voice/data/SettingsRepository.kt
+++ b/tools/android-app/app/src/main/java/com/collavre/voice/data/SettingsRepository.kt
@@ -22,8 +22,7 @@ data class AppSettings(
     val ttsRate: Float,
     val locale: String,
     val eventVoiceEnabled: Boolean,
-    val deviceId: String,
-    val sinceCursor: String?
+    val deviceId: String
 )
 
 private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "collavre_voice")
@@ -39,7 +38,6 @@ class SettingsRepository @Inject constructor(
         val LOCALE = stringPreferencesKey("locale")
         val EVENT_VOICE = booleanPreferencesKey("event_voice_enabled")
         val DEVICE_ID = stringPreferencesKey("device_id")
-        val SINCE = stringPreferencesKey("since_cursor")
     }
 
     companion object {
@@ -57,8 +55,7 @@ class SettingsRepository @Inject constructor(
         ttsRate = this[Keys.TTS_RATE] ?: 1.0f,
         locale = this[Keys.LOCALE] ?: DEFAULT_LOCALE,
         eventVoiceEnabled = this[Keys.EVENT_VOICE] ?: true,
-        deviceId = this[Keys.DEVICE_ID] ?: "",
-        sinceCursor = this[Keys.SINCE]
+        deviceId = this[Keys.DEVICE_ID] ?: ""
     )
 
     /** Generates and persists a stable device id on first use. */
@@ -84,9 +81,5 @@ class SettingsRepository @Inject constructor(
             locale?.let { prefs[Keys.LOCALE] = it }
             eventVoiceEnabled?.let { prefs[Keys.EVENT_VOICE] = it }
         }
-    }
-
-    suspend fun setSinceCursor(cursor: String) {
-        context.dataStore.edit { it[Keys.SINCE] = cursor }
     }
 }

--- a/tools/android-app/app/src/main/java/com/collavre/voice/events/AgentEventRepository.kt
+++ b/tools/android-app/app/src/main/java/com/collavre/voice/events/AgentEventRepository.kt
@@ -15,22 +15,28 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
- * Owns talking to the api/v1/mobile endpoints: a polling cursor for agent_events
- * plus the voice_command (cold mic → Inbox#Main) and respond (reply to a specific
- * message) calls. The cursor governs which events are NEW.
+ * Owns talking to the api/v1/mobile endpoints: polling agent_events plus the
+ * voice_command (cold mic → Inbox#Main) and respond (reply to a specific
+ * message) calls.
+ *
+ * There is NO client cursor. The server emits the full set of currently-relevant
+ * events each poll — unread Inbox#System notices (gated by the inbox read pointer)
+ * and every still-pending approval. Dedup is the consumer's job: VoiceCommandService
+ * keeps an in-memory "already spoken" set so a re-emitted event is not re-read,
+ * while a crash/restart correctly re-surfaces anything still unread/undecided
+ * (at-least-once). A fetch-time `since` high-water-mark could burn past an event
+ * that was fetched but never spoken, losing it forever — hence its removal.
  */
 @Singleton
 class AgentEventRepository @Inject constructor(
     private val api: CollavreApi,
     private val settings: SettingsRepository
 ) {
-    /** One poll for new events; advances the persisted `since` cursor. */
+    /** One poll for the current set of events to surface. */
     suspend fun pollOnce(): List<AgentEvent> {
         val cfg = settings.snapshot()
         if (cfg.token.isBlank()) return emptyList()
-        val events = api.agentEvents(deviceId = cfg.deviceId, since = cfg.sinceCursor)
-        events.maxByOrNull { it.createdAt }?.let { settings.setSinceCursor(it.createdAt) }
-        return events
+        return api.agentEvents(deviceId = cfg.deviceId)
     }
 
     /** Continuous poll loop; emits each batch of newly-surfaced events. */

--- a/tools/android-app/app/src/main/java/com/collavre/voice/network/CollavreApi.kt
+++ b/tools/android-app/app/src/main/java/com/collavre/voice/network/CollavreApi.kt
@@ -16,8 +16,7 @@ interface CollavreApi {
 
     @GET("api/v1/mobile/agent_events")
     suspend fun agentEvents(
-        @Query("device_id") deviceId: String,
-        @Query("since") since: String? = null
+        @Query("device_id") deviceId: String
     ): List<AgentEvent>
 
     @POST("api/v1/mobile/agent_events/{id}/respond")


### PR DESCRIPTION
## Why

Follow-up cleanup to the Voice Companion (#1297). The Android app kept a private `created_at` **`since` cursor** and advanced it to the **max `created_at` of each poll batch** (notices + approvals). Because the cursor was a batch high-water-mark, a still-pending approval whose `created_at` trailed a newer notice could be filtered out server-side and **never re-surface** — an undecided approval lost forever.

The notice path already moved off the cursor onto the inbox read pointer (at-least-once delivery). Approvals are now given the same shape, and the redundant client cursor is removed entirely.

## What

**Contract change:** the server keeps **no per-client cursor**. Every poll returns:
- unread `Inbox#System` notices (gated by the inbox `CommentReadPointer`), and
- **every** still-pending approval (until it is decided, which clears it from `pending_approvals`).

Dedup is the client's job — `VoiceCommandService` already holds an in-memory "already spoken" `seen` set, so a re-emitted approval is **not re-read**, while a crash/restart correctly **re-surfaces** anything still pending (still actionable).

### Server (`engines/collavre`)
- `agent_events#index`: remove `since` parsing + the approval `since` filter; emit all pending approvals.
- Remove the now-unused `parse_since`.

### Android (`tools/android-app`)
- `CollavreApi`: drop the `since` query param.
- `AgentEventRepository.pollOnce`: no cursor read/advance.
- `SettingsRepository`: remove `sinceCursor` field, `since_cursor` key, and `setSinceCursor`.

### Tests
- Rewrote the three `since`-semantics controller tests to the cursorless contract (pending approval keeps surfacing; stops once decided; all pending surface together).
- Added a back-compat test: a stale `since` param from an older APK is harmlessly ignored.

## Verification
- `bin/rails test` mobile `agent_events_controller_test.rb`: **20 runs, 0 failures, 0 errors**.
- Rubocop clean on changed Ruby.
- `./gradlew :app:compileDebugKotlin`: **BUILD SUCCESSFUL**.

Backward compatible: existing APKs still send `since`; the server now ignores it (Rails drops the unknown param) and dedups via the client `seen` set, so they keep working — and stop losing approvals.