### PR TITLE
feat(creatives): make the Lexical editor Markdown-canonical with color/bg spans

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/actiontext.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/actiontext.css
@@ -273,30 +273,43 @@
   top: 0.6rem;
 }
 
-.lexical-paragraph {
+/* The .lexical-* classes are the editor theme (contenteditable). Markdown is now
+   the canonical persisted/displayed form, so .creative-content renders plain
+   semantic tags without those classes — mirror each rule onto the matching
+   element so the display view matches the editor. .lexical-* kept for the
+   editor and for legacy class-bearing HTML saved before the markdown switch. */
+.lexical-paragraph,
+.creative-content p {
   margin: 0 0 0 0;
 }
 
 .lexical-heading-h1,
 .lexical-heading-h2,
-.lexical-heading-h3 {
+.lexical-heading-h3,
+.creative-content h1,
+.creative-content h2,
+.creative-content h3 {
   font-weight: var(--weight-6);
   margin: 0 0 var(--space-2) 0;
 }
 
-.lexical-heading-h1 {
+.lexical-heading-h1,
+.creative-content h1 {
   font-size: 1.35rem;
 }
 
-.lexical-heading-h2 {
+.lexical-heading-h2,
+.creative-content h2 {
   font-size: 1.2rem;
 }
 
-.lexical-heading-h3 {
+.lexical-heading-h3,
+.creative-content h3 {
   font-size: 1.1rem;
 }
 
-.lexical-quote {
+.lexical-quote,
+.creative-content blockquote {
   border-left: var(--space-1) solid var(--border-color);
   color: var(--text-muted);
   margin: 0 0 0.75rem 0;
@@ -304,12 +317,15 @@
 }
 
 .lexical-list-ul,
-.lexical-list-ol {
+.lexical-list-ol,
+.creative-content ul,
+.creative-content ol {
   margin: 0 0 0.75rem 1.25rem;
   padding: 0;
 }
 
-.lexical-list-item {
+.lexical-list-item,
+.creative-content li {
   margin: 0.35rem 0;
 }
 

--- a/engines/collavre/app/assets/stylesheets/collavre/actiontext.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/actiontext.css
@@ -329,25 +329,36 @@
   margin: 0.35rem 0;
 }
 
-.lexical-link {
+/* Content links only — the clickable creative-row anchor is an ancestor of
+   .creative-content, not a descendant, so this never restyles the row wrapper.
+   a[download] is excluded: attachment chips carry their own .lexical-attachment style. */
+.lexical-link,
+.creative-content a:not([download]) {
   color: var(--color-link);
   text-decoration: underline;
   text-decoration-thickness: 1px;
 }
 
-.lexical-text-bold {
+.lexical-text-bold,
+.creative-content strong,
+.creative-content b {
   font-weight: var(--weight-6);
 }
 
-.lexical-text-italic {
+.lexical-text-italic,
+.creative-content em,
+.creative-content i {
   font-style: italic;
 }
 
-.lexical-text-underline {
+.lexical-text-underline,
+.creative-content u {
   text-decoration: underline;
 }
 
-.lexical-text-strike {
+.lexical-text-strike,
+.creative-content s,
+.creative-content del {
   text-decoration: line-through;
 }
 

--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -167,6 +167,7 @@ module Collavre
               has_children: children_count > 0,
               data: sanitized_data,
               content_type: effective.data&.dig("content_type"),
+              markdown_editor: effective.data&.dig("editor"),
               markdown_source: can_edit ? effective.data&.dig("markdown_source") : nil,
               trigger_loop: trigger_loop_data,
               is_trigger_task: parent_trigger_enabled,
@@ -212,6 +213,7 @@ module Collavre
         render json: {
           id: @creative.id,
           content_type: @creative.data&.dig("content_type"),
+          markdown_editor: @creative.data&.dig("editor"),
           markdown_source: @creative.data&.dig("markdown_source")
         }
       else
@@ -283,7 +285,8 @@ module Collavre
               progress: base.progress,
               progress_html: view_context.render_creative_progress(base),
               has_children: base.children.exists?,
-              content_type: base.data&.dig("content_type")
+              content_type: base.data&.dig("content_type"),
+              markdown_editor: base.data&.dig("editor")
             }
             # Expose the post-rewrite markdown source so the client can sync its
             # textarea after the server replaces inline data: URIs with blob paths.
@@ -545,7 +548,7 @@ module Collavre
       end
 
       def creative_params
-        params.require(:creative).permit(:description, :progress, :parent_id, :sequence, :origin_id, :markdown_source, :content_type_input)
+        params.require(:creative).permit(:description, :progress, :parent_id, :sequence, :origin_id, :markdown_source, :content_type_input, :markdown_editor)
       end
 
       def any_filter_active?

--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -399,9 +399,11 @@ module Collavre
         return
       end
       # Reserved markdown fields are not editable via metadata; preserve current values so a stale
-      # YAML payload from the metadata popup can't overwrite a concurrent markdown edit.
+      # YAML payload from the metadata popup (or an API client that omits them) can't overwrite a
+      # concurrent markdown edit. "editor" must be reserved too: dropping it would erase the "rich"
+      # authoring flag and make a Lexical-authored creative reopen in the advanced textarea.
       current_data = creative.data || {}
-      %w[markdown_source content_type].each do |key|
+      %w[markdown_source content_type editor].each do |key|
         if current_data.key?(key)
           new_data[key] = current_data[key]
         else

--- a/engines/collavre/app/javascript/components/InlineLexicalEditor.jsx
+++ b/engines/collavre/app/javascript/components/InlineLexicalEditor.jsx
@@ -54,6 +54,8 @@ import MarkdownShortcutsPlugin from "./plugins/markdown_shortcuts_plugin"
 import { syncLexicalStyleAttributes } from "../lib/lexical/style_attributes"
 import { lexicalHtmlConfig, normalizeColoredContainers } from "../lib/lexical/color_import"
 import { minimizeContentHtml } from "../lib/lexical/minimize_html"
+import { MARKDOWN_TRANSFORMERS } from "../lib/lexical/markdown_serialize"
+import { $convertToMarkdownString } from "@lexical/markdown"
 import { updateResponsiveImages } from "../lib/responsive_images"
 
 const URL_MATCHERS = [
@@ -907,6 +909,7 @@ function EditorInner({
           onChange={(editorState, editorInstance) => {
             if (!onChange) return
             let serialized = ""
+            let markdown = ""
             editorState.read(() => {
               const innerHtml = $generateHtmlFromNodes(editorInstance)
               const parser = new DOMParser()
@@ -924,9 +927,11 @@ function EditorInner({
               // Strip Lexical's verbose markup (extra <div>, white-space spans,
               // duplicate format wrappers, single-line <p>) before persisting.
               serialized = minimizeContentHtml(doc.body.firstElementChild)
+              // Canonical Markdown projection (color/bg -> normalized <span>).
+              markdown = $convertToMarkdownString(MARKDOWN_TRANSFORMERS)
             })
-            // No Trix wrapper
-            onChange(serialized)
+            // html: client-side preview/fallback; markdown: canonical storage.
+            onChange({ html: serialized, markdown })
           }}
         />
         <InitialContentPlugin html={initialHtml} />

--- a/engines/collavre/app/javascript/components/InlineLexicalEditor.jsx
+++ b/engines/collavre/app/javascript/components/InlineLexicalEditor.jsx
@@ -54,7 +54,7 @@ import MarkdownShortcutsPlugin from "./plugins/markdown_shortcuts_plugin"
 import { syncLexicalStyleAttributes } from "../lib/lexical/style_attributes"
 import { lexicalHtmlConfig, normalizeColoredContainers } from "../lib/lexical/color_import"
 import { minimizeContentHtml } from "../lib/lexical/minimize_html"
-import { MARKDOWN_TRANSFORMERS } from "../lib/lexical/markdown_serialize"
+import { MARKDOWN_TRANSFORMERS, collapseParagraphBreaks } from "../lib/lexical/markdown_serialize"
 import { $convertToMarkdownString } from "@lexical/markdown"
 import { updateResponsiveImages } from "../lib/responsive_images"
 
@@ -928,7 +928,10 @@ function EditorInner({
               // duplicate format wrappers, single-line <p>) before persisting.
               serialized = minimizeContentHtml(doc.body.firstElementChild)
               // Canonical Markdown projection (color/bg -> normalized <span>).
-              markdown = $convertToMarkdownString(MARKDOWN_TRANSFORMERS)
+              // collapseParagraphBreaks joins consecutive plain paragraphs with a
+              // single newline so multi-line rich text doesn't gain a blank line;
+              // the renderers run with hard breaks so the line break is preserved.
+              markdown = collapseParagraphBreaks($convertToMarkdownString(MARKDOWN_TRANSFORMERS))
             })
             // html: client-side preview/fallback; markdown: canonical storage.
             onChange({ html: serialized, markdown })

--- a/engines/collavre/app/javascript/creatives/tree_renderer.js
+++ b/engines/collavre/app/javascript/creatives/tree_renderer.js
@@ -169,6 +169,9 @@ function applyRowProperties(row, node) {
   if (Object.prototype.hasOwnProperty.call(inlinePayload, 'markdown_source')) {
     setDatasetValue(row, 'markdownSource', inlinePayload.markdown_source ?? '')
   }
+  if (Object.prototype.hasOwnProperty.call(inlinePayload, 'markdown_editor')) {
+    setDatasetValue(row, 'markdownEditor', inlinePayload.markdown_editor ?? '')
+  }
 
   if (dirty && typeof row.requestUpdate === 'function') {
     // Before Lit re-renders, sync progressHtml from current DOM.

--- a/engines/collavre/app/javascript/lib/lexical/__tests__/markdown_serialize.test.js
+++ b/engines/collavre/app/javascript/lib/lexical/__tests__/markdown_serialize.test.js
@@ -16,7 +16,8 @@ import {
   imageMarkup,
   videoMarkup,
   attachmentMarkup,
-  lexicalToMarkdown
+  lexicalToMarkdown,
+  collapseParagraphBreaks
 } from "../markdown_serialize"
 
 // Minimal DecoratorNode stand-in: the production image/video/attachment nodes
@@ -239,6 +240,57 @@ describe("lexicalToMarkdown", () => {
       root.append(p)
     })
     expect(lexicalToMarkdown(editor)).toBe('plain <span style="color: blue">blue</span>')
+  })
+
+  it("joins consecutive plain paragraphs with a single newline", () => {
+    const editor = buildEditor((root) => {
+      const a = $createParagraphNode()
+      a.append($createTextNode("abc"))
+      root.append(a)
+      const b = $createParagraphNode()
+      b.append($createTextNode("def"))
+      root.append(b)
+    })
+    // No blank line inserted between rich-editor lines (the user's request).
+    expect(lexicalToMarkdown(editor)).toBe("abc\ndef")
+  })
+
+  it("keeps a blank line between a paragraph and a heading", () => {
+    const editor = buildEditor((root) => {
+      const p = $createParagraphNode()
+      p.append($createTextNode("intro"))
+      root.append(p)
+      const h = $createHeadingNode("h2")
+      h.append($createTextNode("Sec"))
+      root.append(h)
+    })
+    expect(lexicalToMarkdown(editor)).toBe("intro\n\n## Sec")
+  })
+})
+
+describe("collapseParagraphBreaks", () => {
+  it("collapses the blank line between two plain paragraphs", () => {
+    expect(collapseParagraphBreaks("a\n\nb")).toBe("a\nb")
+    expect(collapseParagraphBreaks("a\n\nb\n\nc")).toBe("a\nb\nc")
+  })
+
+  it("keeps blank lines around non-paragraph blocks", () => {
+    expect(collapseParagraphBreaks("p\n\n## h")).toBe("p\n\n## h")
+    expect(collapseParagraphBreaks("note\n\n- a\n- b")).toBe("note\n\n- a\n- b")
+    expect(collapseParagraphBreaks("- a\n- b\n\ntail")).toBe("- a\n- b\n\ntail")
+    expect(collapseParagraphBreaks("p\n\n> quote")).toBe("p\n\n> quote")
+    expect(collapseParagraphBreaks('p\n\n<img src="/x.png" alt="x">')).toBe(
+      'p\n\n<img src="/x.png" alt="x">'
+    )
+  })
+
+  it("never collapses blank lines inside a fenced code block", () => {
+    const md = "```js\nconst a = 1\n\nconst b = 2\n```"
+    expect(collapseParagraphBreaks(md)).toBe(md)
+    // ...and still collapses paragraphs around the protected fence
+    expect(collapseParagraphBreaks("a\n\nb\n\n```\nx\n\ny\n```")).toBe(
+      "a\nb\n\n```\nx\n\ny\n```"
+    )
   })
 })
 

--- a/engines/collavre/app/javascript/lib/lexical/__tests__/markdown_serialize.test.js
+++ b/engines/collavre/app/javascript/lib/lexical/__tests__/markdown_serialize.test.js
@@ -2,7 +2,8 @@ import {
   createEditor,
   $getRoot,
   $createParagraphNode,
-  $createTextNode
+  $createTextNode,
+  DecoratorNode
 } from "lexical"
 import { HeadingNode, QuoteNode, $createHeadingNode } from "@lexical/rich-text"
 import { ListNode, ListItemNode } from "@lexical/list"
@@ -18,13 +19,62 @@ import {
   lexicalToMarkdown
 } from "../markdown_serialize"
 
-function buildEditor(builder) {
+// Minimal DecoratorNode stand-in: the production image/video/attachment nodes
+// are .jsx and can't load under native-ESM Jest, but the serializer only
+// duck-types getType()/getSrc()/etc., so a plain-JS DecoratorNode subclass
+// exercises the same export path — including the top-level (root child) case.
+class TestImageNode extends DecoratorNode {
+  static getType() {
+    return "image"
+  }
+
+  static clone(node) {
+    return new TestImageNode(node.__src, node.__altText, node.__key)
+  }
+
+  constructor(src = "", altText = "", key) {
+    super(key)
+    this.__src = src
+    this.__altText = altText
+  }
+
+  getSrc() {
+    return this.__src
+  }
+
+  getAltText() {
+    return this.__altText
+  }
+
+  createDOM() {
+    return document.createElement("span")
+  }
+
+  updateDOM() {
+    return false
+  }
+
+  decorate() {
+    return null
+  }
+}
+
+function buildEditor(builder, extraNodes = []) {
   const editor = createEditor({
     namespace: "test",
     onError(error) {
       throw error
     },
-    nodes: [HeadingNode, QuoteNode, ListNode, ListItemNode, LinkNode, CodeNode, CodeHighlightNode]
+    nodes: [
+      HeadingNode,
+      QuoteNode,
+      ListNode,
+      ListItemNode,
+      LinkNode,
+      CodeNode,
+      CodeHighlightNode,
+      ...extraNodes
+    ]
   })
   editor.update(
     () => {
@@ -158,6 +208,25 @@ describe("lexicalToMarkdown", () => {
       root.append(p)
     })
     expect(lexicalToMarkdown(editor)).toBe('<span style="color: #ff0000">**hot**</span>')
+  })
+
+  it("serializes a top-level media decorator (root child, not inside a paragraph)", () => {
+    const editor = buildEditor((root) => {
+      root.append(new TestImageNode("/u.png", "up"))
+    }, [TestImageNode])
+    // Without an element-type transformer, a top-level decorator falls back to
+    // getTextContent() ("") and the image is silently dropped from markdown_source.
+    expect(lexicalToMarkdown(editor)).toBe('<img src="/u.png" alt="up">')
+  })
+
+  it("serializes a top-level media decorator alongside text", () => {
+    const editor = buildEditor((root) => {
+      const p = $createParagraphNode()
+      p.append($createTextNode("before"))
+      root.append(p)
+      root.append(new TestImageNode("/u.png", "up"))
+    }, [TestImageNode])
+    expect(lexicalToMarkdown(editor)).toBe('before\n\n<img src="/u.png" alt="up">')
   })
 
   it("leaves uncolored neighbours as plain markdown", () => {

--- a/engines/collavre/app/javascript/lib/lexical/__tests__/markdown_serialize.test.js
+++ b/engines/collavre/app/javascript/lib/lexical/__tests__/markdown_serialize.test.js
@@ -72,6 +72,15 @@ describe("colorSpanMarkup", () => {
     expect(colorSpanMarkup('color: red"><script>', "n")).toBeNull()
     expect(colorSpanMarkup("color: expression(alert(1))", "n")).toBeNull()
   })
+
+  it("HTML-escapes the inner text so it can't become raw markup", () => {
+    expect(colorSpanMarkup("color: #ff0000", "<img src=x onerror=alert(1)>")).toBe(
+      '<span style="color: #ff0000">&lt;img src=x onerror=alert(1)&gt;</span>'
+    )
+    expect(colorSpanMarkup("color: #ff0000", "a & b < c")).toBe(
+      '<span style="color: #ff0000">a &amp; b &lt; c</span>'
+    )
+  })
 })
 
 describe("decorator markup", () => {
@@ -222,6 +231,11 @@ describe("round-trip: rendered HTML -> Lexical -> Markdown", () => {
       "bold + color",
       '<p><span style="color: rgb(255, 0, 0)"><strong>hot</strong></span></p>',
       '<span style="color: rgb(255, 0, 0)">**hot**</span>'
+    ],
+    [
+      "colored text with HTML metacharacters",
+      '<p><span style="color: rgb(255, 0, 0)">&lt;tag&gt; &amp; x</span></p>',
+      '<span style="color: rgb(255, 0, 0)">&lt;tag&gt; &amp; x</span>'
     ]
   ]
 

--- a/engines/collavre/app/javascript/lib/lexical/__tests__/markdown_serialize.test.js
+++ b/engines/collavre/app/javascript/lib/lexical/__tests__/markdown_serialize.test.js
@@ -1,0 +1,231 @@
+import {
+  createEditor,
+  $getRoot,
+  $createParagraphNode,
+  $createTextNode
+} from "lexical"
+import { HeadingNode, QuoteNode, $createHeadingNode } from "@lexical/rich-text"
+import { ListNode, ListItemNode } from "@lexical/list"
+import { LinkNode } from "@lexical/link"
+import { CodeNode, CodeHighlightNode } from "@lexical/code"
+import { $generateNodesFromDOM } from "@lexical/html"
+import { lexicalHtmlConfig, normalizeColoredContainers } from "../color_import"
+import {
+  colorSpanMarkup,
+  imageMarkup,
+  videoMarkup,
+  attachmentMarkup,
+  lexicalToMarkdown
+} from "../markdown_serialize"
+
+function buildEditor(builder) {
+  const editor = createEditor({
+    namespace: "test",
+    onError(error) {
+      throw error
+    },
+    nodes: [HeadingNode, QuoteNode, ListNode, ListItemNode, LinkNode, CodeNode, CodeHighlightNode]
+  })
+  editor.update(
+    () => {
+      const root = $getRoot()
+      root.clear()
+      builder(root)
+    },
+    { discrete: true }
+  )
+  return editor
+}
+
+describe("colorSpanMarkup", () => {
+  it("wraps inner text in a normalized color span", () => {
+    expect(colorSpanMarkup("color: rgb(255, 0, 0)", "hi")).toBe(
+      '<span style="color: rgb(255, 0, 0)">hi</span>'
+    )
+  })
+
+  it("emits color first, then background-color, regardless of input order", () => {
+    expect(
+      colorSpanMarkup("background-color: rgb(0, 255, 0); color: #ff0000", "x")
+    ).toBe('<span style="color: #ff0000; background-color: rgb(0, 255, 0)">x</span>')
+  })
+
+  it("supports background-color only", () => {
+    expect(colorSpanMarkup("background-color: #ffff00", "y")).toBe(
+      '<span style="background-color: #ffff00">y</span>'
+    )
+  })
+
+  it("allows CSS custom properties", () => {
+    expect(colorSpanMarkup("color: var(--color-danger)", "z")).toBe(
+      '<span style="color: var(--color-danger)">z</span>'
+    )
+  })
+
+  it("returns null when no color/background present", () => {
+    expect(colorSpanMarkup("font-size: 12px", "n")).toBeNull()
+    expect(colorSpanMarkup("", "n")).toBeNull()
+  })
+
+  it("drops dangerous CSS values (url, expression, injection)", () => {
+    expect(colorSpanMarkup("color: url(javascript:alert(1))", "n")).toBeNull()
+    expect(colorSpanMarkup('color: red"><script>', "n")).toBeNull()
+    expect(colorSpanMarkup("color: expression(alert(1))", "n")).toBeNull()
+  })
+})
+
+describe("decorator markup", () => {
+  it("emits a clean <img> and drops the inherit sentinel", () => {
+    expect(imageMarkup({ src: "/x.png", altText: "cat", width: "inherit", height: "inherit" })).toBe(
+      '<img src="/x.png" alt="cat">'
+    )
+    expect(imageMarkup({ src: "/x.png", altText: "cat", width: 200, height: 100 })).toBe(
+      '<img src="/x.png" alt="cat" width="200" height="100">'
+    )
+  })
+
+  it("escapes attribute values", () => {
+    expect(imageMarkup({ src: '/a.png"', altText: "<b>" })).toBe(
+      '<img src="/a.png&quot;" alt="&lt;b&gt;">'
+    )
+  })
+
+  it("emits a controls <video>", () => {
+    expect(videoMarkup({ src: "/v.mp4" })).toBe('<video controls src="/v.mp4"></video>')
+  })
+
+  it("emits a download <a> with filesize", () => {
+    expect(attachmentMarkup({ src: "/f.pdf", filename: "doc.pdf", filesize: 1234 })).toBe(
+      '<a href="/f.pdf" download="doc.pdf" data-filesize="1234">doc.pdf</a>'
+    )
+    expect(attachmentMarkup({ src: "/f.pdf", filename: "doc.pdf" })).toBe(
+      '<a href="/f.pdf" download="doc.pdf">doc.pdf</a>'
+    )
+  })
+})
+
+describe("lexicalToMarkdown", () => {
+  it("serializes a plain paragraph", () => {
+    const editor = buildEditor((root) => {
+      const p = $createParagraphNode()
+      p.append($createTextNode("hello world"))
+      root.append(p)
+    })
+    expect(lexicalToMarkdown(editor)).toBe("hello world")
+  })
+
+  it("serializes headings and bold via upstream transformers", () => {
+    const editor = buildEditor((root) => {
+      const h = $createHeadingNode("h1")
+      h.append($createTextNode("Title"))
+      root.append(h)
+      const p = $createParagraphNode()
+      const bold = $createTextNode("strong")
+      bold.toggleFormat("bold")
+      p.append(bold)
+      root.append(p)
+    })
+    expect(lexicalToMarkdown(editor)).toBe("# Title\n\n**strong**")
+  })
+
+  it("wraps colored text in a span fragment", () => {
+    const editor = buildEditor((root) => {
+      const p = $createParagraphNode()
+      const t = $createTextNode("red")
+      t.setStyle("color: rgb(255, 0, 0)")
+      p.append(t)
+      root.append(p)
+    })
+    expect(lexicalToMarkdown(editor)).toBe('<span style="color: rgb(255, 0, 0)">red</span>')
+  })
+
+  it("composes bold with color (format inside the span)", () => {
+    const editor = buildEditor((root) => {
+      const p = $createParagraphNode()
+      const t = $createTextNode("hot")
+      t.setStyle("color: #ff0000")
+      t.toggleFormat("bold")
+      p.append(t)
+      root.append(p)
+    })
+    expect(lexicalToMarkdown(editor)).toBe('<span style="color: #ff0000">**hot**</span>')
+  })
+
+  it("leaves uncolored neighbours as plain markdown", () => {
+    const editor = buildEditor((root) => {
+      const p = $createParagraphNode()
+      p.append($createTextNode("plain "))
+      const t = $createTextNode("blue")
+      t.setStyle("color: blue")
+      p.append(t)
+      root.append(p)
+    })
+    expect(lexicalToMarkdown(editor)).toBe('plain <span style="color: blue">blue</span>')
+  })
+})
+
+// Reproduces the production import path: stored Markdown is rendered to HTML by
+// the server (markdown_to_html, unsafe:true keeps the raw <span>), then imported
+// into Lexical via $generateNodesFromDOM + the colorAwareSpanImport config. Then
+// we re-serialize to Markdown and require byte-identity with the rendered HTML's
+// intended source — guarding the md -> html -> lexical -> md round-trip.
+function importHtmlThenToMarkdown(html) {
+  const editor = createEditor({
+    namespace: "test",
+    onError(error) {
+      throw error
+    },
+    nodes: [HeadingNode, QuoteNode, ListNode, ListItemNode, LinkNode, CodeNode, CodeHighlightNode],
+    html: lexicalHtmlConfig
+  })
+  editor.update(
+    () => {
+      const root = $getRoot()
+      root.clear()
+      const doc = new DOMParser().parseFromString(html, "text/html")
+      normalizeColoredContainers(doc.body)
+      const nodes = $generateNodesFromDOM(editor, doc.body)
+      nodes.forEach((node) => {
+        if (node.getType && node.getType() === "text") {
+          const p = $createParagraphNode()
+          p.append(node)
+          root.append(p)
+        } else {
+          root.append(node)
+        }
+      })
+    },
+    { discrete: true }
+  )
+  return lexicalToMarkdown(editor)
+}
+
+describe("round-trip: rendered HTML -> Lexical -> Markdown", () => {
+  // [name, HTML as markdown_to_html would render it, expected canonical Markdown]
+  const cases = [
+    ["plain paragraph", "<p>hello</p>", "hello"],
+    ["heading", "<h1>Title</h1>", "# Title"],
+    ["bold", "<p><strong>bold</strong></p>", "**bold**"],
+    ["italic", "<p><em>nice</em></p>", "*nice*"],
+    ["unordered list", "<ul><li>a</li><li>b</li></ul>", "- a\n- b"],
+    [
+      "colored text",
+      '<p><span style="color: rgb(255, 0, 0)">red</span></p>',
+      '<span style="color: rgb(255, 0, 0)">red</span>'
+    ],
+    [
+      "background color",
+      '<p><span style="background-color: rgb(255, 255, 0)">hi</span></p>',
+      '<span style="background-color: rgb(255, 255, 0)">hi</span>'
+    ],
+    [
+      "bold + color",
+      '<p><span style="color: rgb(255, 0, 0)"><strong>hot</strong></span></p>',
+      '<span style="color: rgb(255, 0, 0)">**hot**</span>'
+    ]
+  ]
+
+  it.each(cases)("round-trips %s", (_name, html, expected) => {
+    expect(importHtmlThenToMarkdown(html)).toBe(expected)
+  })
+})

--- a/engines/collavre/app/javascript/lib/lexical/markdown_serialize.js
+++ b/engines/collavre/app/javascript/lib/lexical/markdown_serialize.js
@@ -174,11 +174,49 @@ export const MARKDOWN_TRANSFORMERS = [
   ...TRANSFORMERS
 ]
 
+// A block that must keep a blank line before/after it (i.e. is NOT a plain
+// paragraph): heading, blockquote, list item, fenced code, table row, thematic
+// break, or a top-level media tag. Anything else is treated as paragraph text.
+const NON_PARAGRAPH_LEAD =
+  /^(?:#{1,6}\s|>|[-*+]\s|\d+[.)]\s|`{3,}|~{3,}|\||<(?:img|video|a)\b|(?:-{3,}|\*{3,}|_{3,})\s*$)/
+
+// Fenced code blocks may legitimately contain blank lines; guard them so the
+// paragraph collapse below never joins lines inside a code sample.
+const FENCE_BLOCK = /(`{3,}|~{3,})[^\n]*\n[\s\S]*?\n\1[ \t]*(?=\n|$)/g
+
+function isPlainParagraph(block) {
+  if (!block || block.includes("\x00MDFENCE")) return false
+  return !NON_PARAGRAPH_LEAD.test(block.split("\n", 1)[0])
+}
+
+// Collapse the blank line between two consecutive plain paragraphs so multi-line
+// rich text serializes as `a\nb` instead of `a\n\nb`. The renderers run with
+// hard breaks (a single `\n` becomes <br>), so the visual line break is
+// preserved while markdown_source stays free of the inserted blank line the user
+// never typed. Headings, lists, quotes, code fences, tables and media keep their
+// standard blank-line separation.
+export function collapseParagraphBreaks(markdown) {
+  const fences = []
+  const guarded = String(markdown).replace(FENCE_BLOCK, (match) => {
+    fences.push(match)
+    return `\x00MDFENCE${fences.length - 1}\x00`
+  })
+
+  const blocks = guarded.split("\n\n")
+  let out = blocks.length ? blocks[0] : ""
+  for (let i = 1; i < blocks.length; i++) {
+    const join = isPlainParagraph(blocks[i - 1]) && isPlainParagraph(blocks[i]) ? "\n" : "\n\n"
+    out += join + blocks[i]
+  }
+
+  return out.replace(/\x00MDFENCE(\d+)\x00/g, (_, n) => fences[Number(n)])
+}
+
 // Read the editor state and return canonical Markdown.
 export function lexicalToMarkdown(editor) {
   let markdown = ""
   editor.getEditorState().read(() => {
     markdown = $convertToMarkdownString(MARKDOWN_TRANSFORMERS)
   })
-  return markdown
+  return collapseParagraphBreaks(markdown)
 }

--- a/engines/collavre/app/javascript/lib/lexical/markdown_serialize.js
+++ b/engines/collavre/app/javascript/lib/lexical/markdown_serialize.js
@@ -67,7 +67,12 @@ export function colorSpanMarkup(styleText, inner) {
   const decls = []
   if (color) decls.push(`color: ${color}`)
   if (background) decls.push(`background-color: ${background}`)
-  return `<span style="${decls.join("; ")}">${inner}</span>`
+  // `inner` is the Markdown-formatted text of a colored node. Lexical's export
+  // escapes Markdown punctuation but NOT HTML metacharacters, so colored text
+  // like `<foo>` would become raw markup inside the <span> and get reinterpreted
+  // (and stripped) by the Markdown renderer/sanitizer. Escape <, >, & so user
+  // text stays text. Markdown syntax chars (*, _, `, ~) are left untouched.
+  return `<span style="${decls.join("; ")}">${escapeHtmlText(inner)}</span>`
 }
 
 // Canonical inline HTML for the decorator nodes, matching the shapes the import

--- a/engines/collavre/app/javascript/lib/lexical/markdown_serialize.js
+++ b/engines/collavre/app/javascript/lib/lexical/markdown_serialize.js
@@ -1,0 +1,159 @@
+import { $isTextNode } from "lexical"
+import { $convertToMarkdownString, TRANSFORMERS } from "@lexical/markdown"
+
+// Serializes the Lexical editor state to Markdown as the canonical storage
+// format. Standard block/inline features (headings, lists, quotes, code,
+// bold/italic/strikethrough, inline code, links) round-trip through Markdown
+// via the upstream TRANSFORMERS. Features Markdown can't express are emitted as
+// a SMALL, FIXED set of normalized inline HTML fragments:
+//
+//   - text color / background-color  -> <span style="...">
+//   - images / videos / attachments  -> raw <img>/<video>/<a download> tags
+//
+// The HTML shape is normalized (one canonical form per feature) and the CSS
+// values are validated, so the server-side sanitizer can safelist exactly these
+// and the import path (markdown -> HTML -> Lexical) reconstructs them losslessly.
+
+// Only these CSS color values are allowed inside an emitted <span>. Anything
+// else (url(), expression(), javascript:, <, >) is dropped so a crafted inline
+// style can't smuggle script or external requests into stored Markdown.
+const SAFE_COLOR_VALUE =
+  /^(#[0-9a-fA-F]{3,8}|rgba?\([0-9.,%\s]+\)|hsla?\([0-9.,%\s]+\)|var\(--[a-zA-Z0-9-_]+\)|[a-zA-Z]+)$/
+
+function safeColorValue(value) {
+  if (!value) return null
+  const v = value.trim().replace(/;+$/, "").trim()
+  if (!v) return null
+  if (/url\(|expression|javascript:|@import|[<>]/i.test(v)) return null
+  return SAFE_COLOR_VALUE.test(v) ? v : null
+}
+
+function colorBgFromStyle(styleText) {
+  let color = null
+  let background = null
+  ;(styleText || "").split(";").forEach((decl) => {
+    const idx = decl.indexOf(":")
+    if (idx === -1) return
+    const key = decl.slice(0, idx).trim().toLowerCase()
+    const value = decl.slice(idx + 1)
+    if (key === "color") color = safeColorValue(value)
+    else if (key === "background-color") background = safeColorValue(value)
+  })
+  return { color, background }
+}
+
+function escapeHtmlAttr(value) {
+  return String(value == null ? "" : value)
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+}
+
+function escapeHtmlText(value) {
+  return String(value == null ? "" : value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+}
+
+// Wrap already-formatted inner Markdown text in a normalized colored <span>, or
+// return null when the style carries no (safe) color/background. The declaration
+// order is fixed (color first) so the same selection always serializes to the
+// same bytes — line-diff/snapshot stability depends on this.
+export function colorSpanMarkup(styleText, inner) {
+  const { color, background } = colorBgFromStyle(styleText)
+  if (!color && !background) return null
+  const decls = []
+  if (color) decls.push(`color: ${color}`)
+  if (background) decls.push(`background-color: ${background}`)
+  return `<span style="${decls.join("; ")}">${inner}</span>`
+}
+
+// Canonical inline HTML for the decorator nodes, matching the shapes the import
+// path (markdown_to_html -> $generateNodesFromDOM) and the server sanitizer
+// expect. Numeric width/height only — Lexical's "inherit" sentinel is dropped.
+export function imageMarkup({ src, altText, width, height }) {
+  let html = `<img src="${escapeHtmlAttr(src)}" alt="${escapeHtmlAttr(altText)}"`
+  if (Number.isFinite(Number(width)) && Number(width) > 0) {
+    html += ` width="${escapeHtmlAttr(width)}"`
+  }
+  if (Number.isFinite(Number(height)) && Number(height) > 0) {
+    html += ` height="${escapeHtmlAttr(height)}"`
+  }
+  return `${html}>`
+}
+
+export function videoMarkup({ src }) {
+  return `<video controls src="${escapeHtmlAttr(src)}"></video>`
+}
+
+export function attachmentMarkup({ src, filename, filesize }) {
+  let html = `<a href="${escapeHtmlAttr(src)}" download="${escapeHtmlAttr(filename)}"`
+  if (filesize != null && filesize !== "") {
+    html += ` data-filesize="${escapeHtmlAttr(filesize)}"`
+  }
+  return `${html}>${escapeHtmlText(filename)}</a>`
+}
+
+// Boilerplate so a TextMatchTransformer can be export-only: import never fires.
+const NEVER = /(?!)/
+
+function exportOnlyTransformer(exportFn, dependencies = []) {
+  return {
+    dependencies,
+    export: exportFn,
+    importRegExp: NEVER,
+    regExp: NEVER,
+    replace: () => false,
+    trigger: "",
+    type: "text-match"
+  }
+}
+
+// Colored / highlighted text -> normalized <span>. Falls through (returns null)
+// for uncolored text so the default text-format export still applies.
+const COLOR_TRANSFORMER = exportOnlyTransformer((node, _exportChildren, exportFormat) => {
+  if (!$isTextNode(node)) return null
+  const style = node.getStyle ? node.getStyle() : ""
+  if (!style) return null
+  return colorSpanMarkup(style, exportFormat(node, node.getTextContent()))
+})
+
+// Decorator nodes -> raw HTML. Duck-typed via getType() so this module stays
+// free of the .jsx node classes (kept importable under native-ESM Jest).
+const DECORATOR_TRANSFORMER = exportOnlyTransformer((node) => {
+  const type = node.getType ? node.getType() : null
+  if (type === "image") {
+    return imageMarkup({
+      src: node.getSrc?.(),
+      altText: node.getAltText?.(),
+      width: node.__width,
+      height: node.__height
+    })
+  }
+  if (type === "video") {
+    return videoMarkup({ src: node.getSrc?.() })
+  }
+  if (type === "attachment") {
+    return attachmentMarkup({
+      src: node.getSrc?.(),
+      filename: node.getFilename?.(),
+      filesize: node.__filesize
+    })
+  }
+  return null
+})
+
+// Our custom text-match transformers run first so colored text and decorator
+// nodes are claimed before the upstream defaults (which would drop their style).
+export const MARKDOWN_TRANSFORMERS = [DECORATOR_TRANSFORMER, COLOR_TRANSFORMER, ...TRANSFORMERS]
+
+// Read the editor state and return canonical Markdown.
+export function lexicalToMarkdown(editor) {
+  let markdown = ""
+  editor.getEditorState().read(() => {
+    markdown = $convertToMarkdownString(MARKDOWN_TRANSFORMERS)
+  })
+  return markdown
+}

--- a/engines/collavre/app/javascript/lib/lexical/markdown_serialize.js
+++ b/engines/collavre/app/javascript/lib/lexical/markdown_serialize.js
@@ -101,10 +101,10 @@ export function attachmentMarkup({ src, filename, filesize }) {
   return `${html}>${escapeHtmlText(filename)}</a>`
 }
 
-// Boilerplate so a TextMatchTransformer can be export-only: import never fires.
+// Boilerplate so a transformer can be export-only: import never fires.
 const NEVER = /(?!)/
 
-function exportOnlyTransformer(exportFn, dependencies = []) {
+function exportOnlyTransformer(exportFn, { dependencies = [], type = "text-match" } = {}) {
   return {
     dependencies,
     export: exportFn,
@@ -112,22 +112,13 @@ function exportOnlyTransformer(exportFn, dependencies = []) {
     regExp: NEVER,
     replace: () => false,
     trigger: "",
-    type: "text-match"
+    type
   }
 }
 
-// Colored / highlighted text -> normalized <span>. Falls through (returns null)
-// for uncolored text so the default text-format export still applies.
-const COLOR_TRANSFORMER = exportOnlyTransformer((node, _exportChildren, exportFormat) => {
-  if (!$isTextNode(node)) return null
-  const style = node.getStyle ? node.getStyle() : ""
-  if (!style) return null
-  return colorSpanMarkup(style, exportFormat(node, node.getTextContent()))
-})
-
 // Decorator nodes -> raw HTML. Duck-typed via getType() so this module stays
 // free of the .jsx node classes (kept importable under native-ESM Jest).
-const DECORATOR_TRANSFORMER = exportOnlyTransformer((node) => {
+function decoratorMarkup(node) {
   const type = node.getType ? node.getType() : null
   if (type === "image") {
     return imageMarkup({
@@ -148,11 +139,40 @@ const DECORATOR_TRANSFORMER = exportOnlyTransformer((node) => {
     })
   }
   return null
+}
+
+// Colored / highlighted text -> normalized <span>. Falls through (returns null)
+// for uncolored text so the default text-format export still applies.
+const COLOR_TRANSFORMER = exportOnlyTransformer((node, _exportChildren, exportFormat) => {
+  if (!$isTextNode(node)) return null
+  const style = node.getStyle ? node.getStyle() : ""
+  if (!style) return null
+  return colorSpanMarkup(style, exportFormat(node, node.getTextContent()))
 })
 
-// Our custom text-match transformers run first so colored text and decorator
-// nodes are claimed before the upstream defaults (which would drop their style).
-export const MARKDOWN_TRANSFORMERS = [DECORATOR_TRANSFORMER, COLOR_TRANSFORMER, ...TRANSFORMERS]
+// Decorator handler registered as a TEXT-MATCH transformer for media that lives
+// INLINE inside a paragraph (claimed during exportChildren).
+const DECORATOR_TEXT_TRANSFORMER = exportOnlyTransformer((node) => decoratorMarkup(node))
+
+// The SAME handler registered as an ELEMENT transformer for media that is a
+// direct child of the root (the upload plugin's no-selection append path, and
+// imported block-level <img> nodes). $convertToMarkdownString only runs element
+// transformers on top-level nodes — a top-level decorator that matches no element
+// transformer falls back to DecoratorNode#getTextContent() (empty for media),
+// silently dropping it from markdown_source. Without this, the first rich save
+// loses every top-level image/video/file.
+const DECORATOR_ELEMENT_TRANSFORMER = exportOnlyTransformer((node) => decoratorMarkup(node), {
+  type: "element"
+})
+
+// Our custom transformers run first so colored text and decorator nodes are
+// claimed before the upstream defaults (which would drop their style/content).
+export const MARKDOWN_TRANSFORMERS = [
+  DECORATOR_ELEMENT_TRANSFORMER,
+  DECORATOR_TEXT_TRANSFORMER,
+  COLOR_TRANSFORMER,
+  ...TRANSFORMERS
+]
 
 // Read the editor state and return canonical Markdown.
 export function lexicalToMarkdown(editor) {

--- a/engines/collavre/app/javascript/lib/utils/__tests__/markdown.test.js
+++ b/engines/collavre/app/javascript/lib/utils/__tests__/markdown.test.js
@@ -1,0 +1,23 @@
+import { renderMarkdown, renderCommentMarkdown } from "../markdown"
+
+// The renderers run with marked's `breaks: true` so a single newline becomes a
+// <br> (GitHub/Slack style), matching the canonical markdown_source which stores
+// consecutive rich-editor lines one-per-line instead of separated by a blank line.
+describe("renderMarkdown hard breaks", () => {
+  it("renders a single newline as <br> within one paragraph", () => {
+    const html = renderMarkdown("abc\ndef")
+    expect(html).toContain("<br")
+    expect((html.match(/<p>/g) || []).length).toBe(1)
+  })
+
+  it("keeps a blank line as a paragraph break", () => {
+    const html = renderMarkdown("abc\n\ndef")
+    expect((html.match(/<p>/g) || []).length).toBe(2)
+  })
+})
+
+describe("renderCommentMarkdown hard breaks", () => {
+  it("renders a single newline in a comment as <br>", () => {
+    expect(renderCommentMarkdown("line1\nline2")).toContain("<br")
+  })
+})

--- a/engines/collavre/app/javascript/lib/utils/markdown.js
+++ b/engines/collavre/app/javascript/lib/utils/markdown.js
@@ -68,6 +68,12 @@ function sanitizeLang(lang) {
   return lang.replace(/[^a-zA-Z0-9_-]/g, '')
 }
 
+// `breaks: true` so a single newline renders as <br> (GitHub/Slack style),
+// matching the canonical markdown_source where consecutive rich-editor lines are
+// stored one-per-line instead of separated by a blank line. Applies app-wide
+// (creative descriptions and comments) so a line break always means a line break.
+marked.use({ breaks: true })
+
 // Custom renderer for code blocks with syntax highlighting + mermaid
 marked.use({
   renderer: {

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -1399,6 +1399,10 @@ export function initializeCreativeRowEditor() {
           }
           row.dataset.contentType = capturedContentType;
           row.dataset.markdownSource = isMarkdownSave ? capturedMarkdownSource : '';
+          // Persist which surface authored this save so a row re-opened from this
+          // cached payload (before any full GET refresh) reopens in the right
+          // editor — without it, rich-authored Markdown falls back to the textarea.
+          row.dataset.markdownEditor = isMarkdownSave ? capturedMarkdownEditor : '';
           if (currentParentId) {
             tree.dataset.parentId = currentParentId;
             row.parentId = currentParentId;

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -113,6 +113,7 @@ export function initializeCreativeRowEditor() {
 
     // Markdown editor elements
     const contentTypeInput = document.getElementById('inline-content-type');
+    const markdownEditorInput = document.getElementById('inline-markdown-editor');
     const markdownSourceInput = document.getElementById('inline-markdown-source');
     const markdownWrapper = document.getElementById('markdown-editor-wrapper');
     const markdownTextarea = document.getElementById('markdown-editor-textarea');
@@ -259,6 +260,9 @@ export function initializeCreativeRowEditor() {
       if (Object.prototype.hasOwnProperty.call(data, 'markdown_source')) {
         setRowDatasetValue(row, 'markdownSource', data.markdown_source ?? '');
       }
+      if (Object.prototype.hasOwnProperty.call(data, 'markdown_editor')) {
+        setRowDatasetValue(row, 'markdownEditor', data.markdown_editor ?? '');
+      }
       if (Object.prototype.hasOwnProperty.call(data, 'has_children')) {
         if (data.has_children) {
           row.setAttribute('has-children', '');
@@ -299,6 +303,7 @@ export function initializeCreativeRowEditor() {
         parent_id: parentId,
         progress: Number.isNaN(progressValue) ? 0 : progressValue,
         content_type: row.dataset?.contentType || null,
+        markdown_editor: row.dataset?.markdownEditor || null,
         markdown_source: row.dataset?.markdownSource || null
       };
     }
@@ -310,6 +315,7 @@ export function initializeCreativeRowEditor() {
     function activateMarkdownMode(source) {
       markdownMode = true;
       if (contentTypeInput) contentTypeInput.value = 'markdown';
+      if (markdownEditorInput) markdownEditorInput.value = 'source';
       if (markdownTextarea) markdownTextarea.value = source || '';
       if (markdownWrapper) markdownWrapper.style.display = '';
       if (editorContainer) editorContainer.style.display = 'none';
@@ -324,6 +330,7 @@ export function initializeCreativeRowEditor() {
     function deactivateMarkdownMode() {
       markdownMode = false;
       if (contentTypeInput) contentTypeInput.value = 'html';
+      if (markdownEditorInput) markdownEditorInput.value = '';
       if (markdownSourceInput) markdownSourceInput.value = '';
       if (markdownWrapper) markdownWrapper.style.display = 'none';
       if (editorContainer) editorContainer.style.display = '';
@@ -350,20 +357,33 @@ export function initializeCreativeRowEditor() {
       const content = data.description_raw_html || data.description || '';
       descriptionInput.value = content;
 
-      // Handle markdown vs rich text mode
+      // Markdown is the canonical storage format for BOTH editors now. Which
+      // surface opens is decided by the persisted editor preference: only
+      // explicitly rich-authored Markdown reopens in Lexical; "source" and
+      // legacy (no preference) Markdown reopen in the advanced textarea.
       const isMarkdown = data.content_type === 'markdown';
-      if (isMarkdown) {
+      const useTextarea = isMarkdown && data.markdown_editor !== 'rich';
+      if (useTextarea) {
         activateMarkdownMode(data.markdown_source || '');
         // Also load Lexical with HTML for fallback/switching
         lexicalEditor.load(content, `creative-${creativeId}-${Date.now()}`);
       } else {
         deactivateMarkdownMode();
+        if (isMarkdown) {
+          // Rich-authored Markdown: prime the hidden fields so a no-edit save
+          // (move, progress toggle) preserves Markdown canonical instead of
+          // demoting back to HTML before the first Lexical change fires.
+          if (contentTypeInput) contentTypeInput.value = 'markdown';
+          if (markdownSourceInput) markdownSourceInput.value = data.markdown_source || '';
+          if (markdownEditorInput) markdownEditorInput.value = 'rich';
+        }
         lexicalEditor.load(content, `creative-${creativeId}-${Date.now()}`);
       }
 
       pendingSave = false;
-      // Track original content for dirty state detection
-      originalContent = isMarkdown ? (data.markdown_source || '') : content;
+      // Dirty detection is HTML-based for the rich surface (compares the editor's
+      // HTML projection), and Markdown-source-based for the textarea surface.
+      originalContent = useTextarea ? (data.markdown_source || '') : content;
       isDirty = false;
       const progressNumber = Number(data.progress ?? 0);
       const normalizedProgress = Number.isNaN(progressNumber) ? 0 : progressNumber;
@@ -1289,8 +1309,12 @@ export function initializeCreativeRowEditor() {
 
       // CRITICAL: Capture ALL values BEFORE awaiting, because the editor may switch
       // to a different creative while we're waiting for uploads
-      const isMarkdownSave = markdownMode;
-      if (isMarkdownSave) syncMarkdownToForm();
+      // Both editor surfaces persist Markdown now. The textarea surface
+      // (markdownMode) syncs its value to the hidden fields here; the rich
+      // surface already kept them current via onLexicalChange/applyCreativeData.
+      if (markdownMode) syncMarkdownToForm();
+      const capturedContentType = contentTypeInput ? contentTypeInput.value : 'html';
+      const isMarkdownSave = capturedContentType === 'markdown';
       let currentContent = descriptionInput.value;
       let currentProgress = readProgressValue();
       let shouldPersistProgress = progressValueChanged();
@@ -1298,8 +1322,8 @@ export function initializeCreativeRowEditor() {
       const currentBeforeId = tree.previousElementSibling ? creativeIdFrom(tree.previousElementSibling) : '';
       const currentAfterId = tree.nextElementSibling ? creativeIdFrom(tree.nextElementSibling) : '';
       const startCreativeId = creativeId;
-      let capturedMarkdownSource = isMarkdownSave ? (markdownTextarea?.value || '') : '';
-      const capturedContentType = isMarkdownSave ? 'markdown' : 'html';
+      let capturedMarkdownSource = isMarkdownSave ? (markdownSourceInput ? markdownSourceInput.value : '') : '';
+      const capturedMarkdownEditor = markdownEditorInput ? markdownEditorInput.value : '';
 
       // Prevent saving empty content, matching saveForm behavior
       // This avoids overwriting existing descriptions with empty strings during quick navigation
@@ -1321,9 +1345,12 @@ export function initializeCreativeRowEditor() {
       // so we must re-sync and re-capture the latest textarea value too — otherwise edits
       // made during the upload wait get overwritten by the stale pre-wait source.
       if (form.dataset.creativeId === startCreativeId) {
-        if (isMarkdownSave) {
+        if (markdownMode) {
           syncMarkdownToForm();
-          capturedMarkdownSource = markdownTextarea?.value || '';
+          capturedMarkdownSource = markdownSourceInput ? markdownSourceInput.value : '';
+        } else if (isMarkdownSave && markdownSourceInput) {
+          // Rich surface: re-capture any Markdown produced by edits during the wait.
+          capturedMarkdownSource = markdownSourceInput.value;
         }
         currentContent = descriptionInput.value;
         currentProgress = readProgressValue();
@@ -1339,6 +1366,9 @@ export function initializeCreativeRowEditor() {
       };
       if (isMarkdownSave) {
         body['creative[markdown_source]'] = capturedMarkdownSource;
+        if (capturedMarkdownEditor) {
+          body['creative[markdown_editor]'] = capturedMarkdownEditor;
+        }
       }
 
       if (shouldPersistProgress) {
@@ -1930,10 +1960,18 @@ export function initializeCreativeRowEditor() {
       saveTimer = setTimeout(saveForm, 5000);
     }
 
-    function onLexicalChange(html) {
-      if (markdownMode) return; // Ignore Lexical changes in markdown mode
+    function onLexicalChange(payload) {
+      if (markdownMode) return; // Ignore Lexical changes when the textarea is active
+      const html = (payload && payload.html) || '';
+      const markdown = (payload && payload.markdown) || '';
       descriptionInput.value = html;
-      // Mark as dirty if content changed from original
+      // The rich editor is now a Markdown-canonical surface: persist the Markdown
+      // projection (text color/background as normalized <span> fragments) and
+      // record that the rich surface authored it, so it reopens in Lexical.
+      if (contentTypeInput) contentTypeInput.value = 'markdown';
+      if (markdownSourceInput) markdownSourceInput.value = markdown;
+      if (markdownEditorInput) markdownEditorInput.value = 'rich';
+      // Mark as dirty if the HTML projection changed from original
       isDirty = (html !== originalContent);
       scheduleSave();
     }
@@ -2342,25 +2380,35 @@ export function initializeCreativeRowEditor() {
     if (toggleMarkdownBtn) {
       toggleMarkdownBtn.addEventListener('click', async function () {
         if (markdownMode) {
-          // Switching from Markdown → Rich Text
+          // Switching from Markdown (advanced textarea) → Rich Text. The Markdown
+          // stays canonical; we only flip the authoring surface to rich so it
+          // reopens in Lexical, and render it to HTML for the editor view.
           const confirmMsg = toggleMarkdownBtn.dataset.confirmToRichtext;
           if (confirmMsg && !(await confirmDialog(confirmMsg))) return;
           const md = markdownTextarea?.value || '';
           const html = md ? renderMarkdown(md) : '';
           deactivateMarkdownMode();
           descriptionInput.value = html;
+          if (md) {
+            if (contentTypeInput) contentTypeInput.value = 'markdown';
+            if (markdownSourceInput) markdownSourceInput.value = md;
+            if (markdownEditorInput) markdownEditorInput.value = 'rich';
+          }
           lexicalEditor.load(html, `creative-switch-${Date.now()}`);
           lexicalEditor.focus();
           isDirty = true;
           scheduleSave();
         } else {
-          // Switching from Rich Text → Markdown
+          // Switching from Rich Text → Markdown (advanced textarea). Preserve the
+          // content by seeding the textarea with the rich surface's current
+          // Markdown projection instead of discarding it.
           const currentHtml = descriptionInput.value || '';
           if (!isHtmlEmpty(currentHtml)) {
             const confirmMsg = toggleMarkdownBtn.dataset.confirmToMarkdown;
             if (confirmMsg && !(await confirmDialog(confirmMsg))) return;
           }
-          activateMarkdownMode('');
+          const existingMarkdown = markdownSourceInput ? markdownSourceInput.value : '';
+          activateMarkdownMode(existingMarkdown);
           isDirty = true;
           scheduleSave();
         }

--- a/engines/collavre/app/javascript/modules/lexical_inline_editor.jsx
+++ b/engines/collavre/app/javascript/modules/lexical_inline_editor.jsx
@@ -52,7 +52,8 @@ export function createInlineEditor(container, {
             suppressNextChange = false
             return
           }
-          currentHtml = value
+          // value is { html, markdown }; keep currentHtml for the render fallback.
+          currentHtml = value?.html ?? ""
           onChange?.(value)
         }}
         onReady={(api) => {

--- a/engines/collavre/app/models/collavre/creative/describable.rb
+++ b/engines/collavre/app/models/collavre/creative/describable.rb
@@ -240,11 +240,17 @@ module Collavre
       # inserted images/videos/files as raw blob-URL tags inside markdown_source,
       # which markdown_to_html renders into `description`. So reconcile must run
       # for markdown mode too, otherwise rich-editor uploads never reach
-      # creative.files (and the attachment list/remove services miss them). But
-      # markdown reconcile is ATTACH-ONLY: markdown creatives may carry out-of-band
-      # / legacy blobs attached directly (never embedded in the derived
-      # description), and the explicit remove path strips + demotes to HTML before
-      # detaching — so auto-detaching here would purge blobs that are still wanted.
+      # creative.files (and the attachment list/remove services miss them).
+      #
+      # Markdown detach is narrowed (not skipped): markdown creatives may carry
+      # legacy blobs attached directly but never embedded in the derived
+      # description (AttachmentBackfill skips markdown, so reconcile is their only
+      # touch point) — those must survive. But media the user actually removed
+      # in-editor WAS referenced in the prior description and no longer is; that
+      # must detach, or creative.files keeps listing a deleted file (the editor's
+      # purge DELETE can't compensate while the attachment still exists). So for
+      # markdown we detach only blobs that were previously referenced. HTML keeps
+      # full detach (backfill embeds its orphans, so none should linger).
       def reconcile_description_attachments
         # Linked creatives don't own their description (it lives on the origin)
         # and their own column is blank, so reconcile would treat every legacy
@@ -262,9 +268,16 @@ module Collavre
         current = files.includes(:blob).to_a
         current_blob_ids = current.map(&:blob_id).to_set
 
-        attach_only = data&.dig("content_type") == "markdown"
+        markdown = data&.dig("content_type") == "markdown"
         to_attach = referenced.reject { |b| current_blob_ids.include?(b.id) }
-        to_detach = attach_only ? [] : current.reject { |a| referenced_ids.include?(a.blob_id) }
+        unreferenced = current.reject { |a| referenced_ids.include?(a.blob_id) }
+        to_detach =
+          if markdown
+            prev_referenced_ids = blob_ids_referenced_in(description_before_last_save)
+            unreferenced.select { |a| prev_referenced_ids.include?(a.blob_id) }
+          else
+            unreferenced
+          end
         return if to_attach.empty? && to_detach.empty?
 
         to_attach.each { |blob| files.attach(blob) }
@@ -317,15 +330,30 @@ module Collavre
       end
 
       def extract_signed_ids_from_description
-        return [] if description.blank?
+        extract_signed_ids_from(description)
+      end
 
-        html = description.to_s
+      def extract_signed_ids_from(html)
+        return [] if html.blank?
+
+        html = html.to_s
 
         ids = html.scan(%r{/rails/active_storage/blobs/(?:redirect|proxy)/([^/?#]+)}).flatten
         ids += html.scan(%r{/rails/active_storage/blobs/([^/?#]+)}).flatten
         ids += html.scan(%r{/public-assets/blobs/([^/?#]+)}).flatten
 
         ids.uniq
+      end
+
+      # Blob ids that `html` references, resolving each signed id to its blob.
+      # Used to tell user-removed media (was referenced, now gone) apart from
+      # legacy orphans (never referenced) during markdown reconcile.
+      def blob_ids_referenced_in(html)
+        extract_signed_ids_from(html).filter_map do |sid|
+          ActiveStorage::Blob.find_signed(sid)&.id
+        rescue ActiveSupport::MessageVerifier::InvalidSignature, ActiveRecord::RecordNotFound
+          nil
+        end.to_set
       end
 
       def description_cannot_change_if_has_origin

--- a/engines/collavre/app/models/collavre/creative/describable.rb
+++ b/engines/collavre/app/models/collavre/creative/describable.rb
@@ -232,14 +232,20 @@ module Collavre
         end
       end
 
-      # Sync creative.files to exactly the blobs referenced in the description
-      # HTML (attach new, detach removed). Must never raise during save —
-      # malformed HTML yields [] and a no-op.
+      # Sync creative.files to the blobs referenced in the description HTML
+      # (attach new, detach removed). Must never raise during save — malformed
+      # HTML yields [] and a no-op.
       #
-      # Markdown-mode creatives manage their own blobs via MarkdownConverter;
-      # the embed paths demote markdown -> html first, so uploads still reconcile.
+      # The rich (Lexical) editor is now Markdown-canonical and serializes
+      # inserted images/videos/files as raw blob-URL tags inside markdown_source,
+      # which markdown_to_html renders into `description`. So reconcile must run
+      # for markdown mode too, otherwise rich-editor uploads never reach
+      # creative.files (and the attachment list/remove services miss them). But
+      # markdown reconcile is ATTACH-ONLY: markdown creatives may carry out-of-band
+      # / legacy blobs attached directly (never embedded in the derived
+      # description), and the explicit remove path strips + demotes to HTML before
+      # detaching — so auto-detaching here would purge blobs that are still wanted.
       def reconcile_description_attachments
-        return if data&.dig("content_type") == "markdown"
         # Linked creatives don't own their description (it lives on the origin)
         # and their own column is blank, so reconcile would treat every legacy
         # attachment as an orphan and purge it on the next save (e.g. a
@@ -256,8 +262,9 @@ module Collavre
         current = files.includes(:blob).to_a
         current_blob_ids = current.map(&:blob_id).to_set
 
+        attach_only = data&.dig("content_type") == "markdown"
         to_attach = referenced.reject { |b| current_blob_ids.include?(b.id) }
-        to_detach = current.reject { |a| referenced_ids.include?(a.blob_id) }
+        to_detach = attach_only ? [] : current.reject { |a| referenced_ids.include?(a.blob_id) }
         return if to_attach.empty? && to_detach.empty?
 
         to_attach.each { |blob| files.attach(blob) }

--- a/engines/collavre/app/models/collavre/creative/describable.rb
+++ b/engines/collavre/app/models/collavre/creative/describable.rb
@@ -5,6 +5,11 @@ module Collavre
 
       included do
         attr_accessor :content_type_input
+        # Which editing surface authored this Markdown: "rich" (Lexical) reopens
+        # in the rich editor, "source" (or absent/legacy) reopens in the advanced
+        # textarea. Stored in data["editor"]; decoupled from the storage format
+        # (content_type), which is now Markdown for both surfaces.
+        attr_accessor :markdown_editor
         attr_reader :markdown_source
 
         def markdown_source=(value)
@@ -128,6 +133,9 @@ module Collavre
           prev_source = data["markdown_source"].to_s
           prev_type = data["content_type"]
           self.data["content_type"] = "markdown"
+          # Remember which surface authored this. Absent param (MCP/tool writes)
+          # keeps the prior choice, defaulting to the advanced textarea.
+          self.data["editor"] = markdown_editor.presence || data["editor"] || "source"
           if new_source != prev_source || prev_type != "markdown"
             # Rewrite inline data-URI images to freshly-uploaded blob paths
             # FIRST, then persist the rewritten source. Subsequent edits
@@ -149,6 +157,7 @@ module Collavre
           self.data ||= {}
           self.data.delete("content_type")
           self.data.delete("markdown_source")
+          self.data.delete("editor")
         elsif !new_record? && description_changed? && data&.dig("content_type") == "markdown"
           # Description was rewritten through a non-markdown path (tool/MCP
           # update, direct base.update(description: ...), etc.) on a creative
@@ -158,6 +167,7 @@ module Collavre
           # Demote to HTML mode so the persisted source matches description.
           self.data.delete("content_type")
           self.data.delete("markdown_source")
+          self.data.delete("editor")
         end
       end
 
@@ -181,11 +191,45 @@ module Collavre
           end
         end
 
+        # The Lexical editor stores text color / background as inline <span
+        # style="...">. Tighten every style attribute to ONLY validated color /
+        # background-color declarations BEFORE sanitization, so allowing `style`
+        # in the safelist can't smuggle layout/position/url() payloads.
+        scrub_inline_color_styles(scrubbed)
+
         self.description = ActionController::Base.helpers.sanitize(
           scrubbed.to_html,
           tags: Rails::HTML5::SafeListSanitizer.allowed_tags.to_a + table_tags + media_tags + %w[input],
-          attributes: Rails::HTML5::SafeListSanitizer.allowed_attributes.to_a + table_attrs + attachment_attrs + task_list_attrs + media_attrs + %w[data-lexical]
+          attributes: Rails::HTML5::SafeListSanitizer.allowed_attributes.to_a + table_attrs + attachment_attrs + task_list_attrs + media_attrs + %w[data-lexical style]
         )
+      end
+
+      # Only these CSS color values may appear in a stored inline style — mirrors
+      # the JS markdown serializer's allowlist (markdown_serialize.js). Blocks
+      # url(), expression(), javascript:, and angle brackets.
+      SAFE_COLOR_VALUE = /\A(#[0-9a-fA-F]{3,8}|rgba?\([0-9.,%\s]+\)|hsla?\([0-9.,%\s]+\)|var\(--[a-zA-Z0-9\-_]+\)|[a-zA-Z]+)\z/
+
+      def scrub_inline_color_styles(fragment)
+        fragment.css("[style]").each do |node|
+          declarations = node["style"].to_s.split(";").filter_map do |decl|
+            key, value = decl.split(":", 2)
+            next if key.nil? || value.nil?
+
+            key = key.strip.downcase
+            value = value.strip
+            next unless %w[color background-color].include?(key)
+            next if value =~ /url\(|expression|javascript:|@import|[<>]/i
+            next unless value =~ SAFE_COLOR_VALUE
+
+            "#{key}: #{value}"
+          end
+
+          if declarations.any?
+            node["style"] = declarations.join("; ")
+          else
+            node.remove_attribute("style")
+          end
+        end
       end
 
       # Sync creative.files to exactly the blobs referenced in the description

--- a/engines/collavre/app/services/collavre/creatives/tree_builder.rb
+++ b/engines/collavre/app/services/collavre/creatives/tree_builder.rb
@@ -195,7 +195,8 @@ module Creatives
         progress: creative.progress,
         origin_id: creative.origin_id,
         content_type: effective.data&.dig("content_type"),
-        markdown_source: origin_writable ? effective.data&.dig("markdown_source") : nil
+        markdown_source: origin_writable ? effective.data&.dig("markdown_source") : nil,
+        markdown_editor: effective.data&.dig("editor")
       }
     end
 

--- a/engines/collavre/app/services/collavre/markdown_converter.rb
+++ b/engines/collavre/app/services/collavre/markdown_converter.rb
@@ -48,10 +48,13 @@ module Collavre
           source
         end
 
-        # Render with commonmarker (GFM extensions: table, strikethrough, autolink, tasklist, tagfilter)
+        # Render with commonmarker (GFM extensions: table, strikethrough, autolink, tasklist, tagfilter).
+        # hardbreaks: a single newline becomes <br>, mirroring the JS renderer (marked breaks:true)
+        # and the canonical markdown_source, which stores consecutive rich-editor lines one-per-line
+        # rather than separated by a blank line.
         html = Commonmarker.to_html(input, options: {
           parse: { smart: true },
-          render: { unsafe: true },
+          render: { unsafe: true, hardbreaks: true },
           extension: { table: true, strikethrough: true, autolink: true, tasklist: true, tagfilter: true }
         })
 

--- a/engines/collavre/app/views/collavre/creatives/_inline_edit_form.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/_inline_edit_form.html.erb
@@ -4,6 +4,7 @@
     <input type="hidden" name="authenticity_token" value="<%= form_authenticity_token %>" />
     <input type="hidden" id="inline-creative-description" name="creative[description]" />
     <input type="hidden" id="inline-content-type" name="creative[content_type_input]" value="html" />
+    <input type="hidden" id="inline-markdown-editor" name="creative[markdown_editor]" />
     <input type="hidden" id="inline-markdown-source" name="creative[markdown_source]" />
     <input type="hidden" id="inline-parent-id" name="creative[parent_id]" />
     <input type="hidden" id="inline-before-id" name="before_id" />

--- a/engines/collavre/app/views/collavre/creatives/index.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/index.html.erb
@@ -170,6 +170,7 @@
     title_effective_origin = @parent_creative.effective_origin(Set.new)
     title_content_type = title_effective_origin.data&.dig("content_type")
     title_markdown_source = title_can_write ? title_effective_origin.data&.dig("markdown_source") : nil
+    title_markdown_editor = title_effective_origin.data&.dig("editor")
   %>
   <%= content_tag(
         "creative-tree-row",
@@ -183,7 +184,8 @@
         "data-progress-value": @parent_creative.progress,
         "data-origin-id": @parent_creative.origin_id,
         "data-content-type": title_content_type,
-        "data-markdown-source": title_markdown_source
+        "data-markdown-source": title_markdown_source,
+        "data-markdown-editor": title_markdown_editor
       ) %>
 <% else %>
   <%= content_tag(

--- a/engines/collavre/test/controllers/creatives_controller_test.rb
+++ b/engines/collavre/test/controllers/creatives_controller_test.rb
@@ -5,6 +5,17 @@ class CreativesControllerTest < ActionDispatch::IntegrationTest
     sign_in_as(users(:one), password: "password")
   end
 
+  test "title row emits markdown editor flag so cached rich rows reopen in Lexical" do
+    rich = Creative.create!(
+      user: users(:one), content_type_input: "markdown", markdown_editor: "rich", markdown_source: "# hi"
+    )
+
+    get creatives_path(id: rich.id)
+
+    assert_response :success
+    assert_match(/data-markdown-editor="rich"/, response.body)
+  end
+
   test "unconvert moves creative tree into parent comment" do
     creative = creatives(:unconvert_target)
     parent = creative.parent

--- a/engines/collavre/test/controllers/creatives_controller_update_test.rb
+++ b/engines/collavre/test/controllers/creatives_controller_update_test.rb
@@ -63,7 +63,12 @@ class CreativesControllerUpdateTest < ActionDispatch::IntegrationTest
     creative = Creative.create!(
       description: "<p>html</p>",
       user: @user,
-      data: { "markdown_source" => "current source", "content_type" => "markdown", "foo" => "bar" }
+      data: {
+        "markdown_source" => "current source",
+        "content_type" => "markdown",
+        "editor" => "rich",
+        "foo" => "bar"
+      }
     )
 
     patch update_metadata_creative_url(creative), params: {
@@ -78,6 +83,9 @@ class CreativesControllerUpdateTest < ActionDispatch::IntegrationTest
     creative.reload
     assert_equal "current source", creative.data["markdown_source"]
     assert_equal "markdown", creative.data["content_type"]
+    # A metadata save that omits "editor" must not drop the rich authoring flag,
+    # else the Lexical-authored creative would reopen in the advanced textarea.
+    assert_equal "rich", creative.data["editor"]
     assert_equal "baz", creative.data["foo"]
   end
 
@@ -85,13 +93,14 @@ class CreativesControllerUpdateTest < ActionDispatch::IntegrationTest
     creative = Creative.create!(description: "<p>html</p>", user: @user, data: { "foo" => "bar" })
 
     patch update_metadata_creative_url(creative), params: {
-      data: { markdown_source: "injected", content_type: "markdown", foo: "baz" }.to_json
+      data: { markdown_source: "injected", content_type: "markdown", editor: "rich", foo: "baz" }.to_json
     }
 
     assert_response :success
     creative.reload
     assert_not creative.data.key?("markdown_source")
     assert_not creative.data.key?("content_type")
+    assert_not creative.data.key?("editor")
     assert_equal "baz", creative.data["foo"]
   end
 

--- a/engines/collavre/test/models/collavre/creative/describable_test.rb
+++ b/engines/collavre/test/models/collavre/creative/describable_test.rb
@@ -65,6 +65,82 @@ module Collavre
         assert_match %r{<input[^>]*checked[^>]*}, creative.description
       end
 
+      test "markdown_editor persists the authoring surface in data[editor]" do
+        rich = Creative.create!(
+          user: @user, content_type_input: "markdown", markdown_editor: "rich", markdown_source: "# hi"
+        )
+        assert_equal "rich", rich.data["editor"]
+
+        source = Creative.create!(
+          user: @user, content_type_input: "markdown", markdown_editor: "source", markdown_source: "# hi"
+        )
+        assert_equal "source", source.data["editor"]
+      end
+
+      test "markdown_editor defaults to source when absent" do
+        creative = Creative.create!(user: @user, content_type_input: "markdown", markdown_source: "# hi")
+        assert_equal "source", creative.data["editor"]
+      end
+
+      test "demoting markdown to html clears the editor preference" do
+        creative = Creative.create!(
+          user: @user, content_type_input: "markdown", markdown_editor: "rich", markdown_source: "# hi"
+        )
+        assert_equal "rich", creative.data["editor"]
+
+        creative.update!(content_type_input: "html", description: "<p>plain</p>")
+        creative.reload
+        assert_nil creative.data["editor"]
+      end
+
+      test "color span survives sanitization in markdown mode" do
+        source = '<span style="color: rgb(255, 0, 0)">red</span> and ' \
+                 '<span style="background-color: #ffff00">hl</span>'
+        Creative.create!(user: @user, content_type_input: "markdown", markdown_source: source)
+        creative = Creative.last
+
+        # Canonical markdown_source is preserved verbatim (sanitizer only touches
+        # the rendered description).
+        assert_equal source, creative.data["markdown_source"]
+        # Rendered description keeps the colors (spacing is normalized by the CSS scrubber).
+        assert_match(/color:\s*rgb\(255, 0, 0\)/, creative.description)
+        assert_match(/background-color:\s*#ffff00/, creative.description)
+        assert_includes creative.description, "red"
+        assert_includes creative.description, "hl"
+      end
+
+      test "color span survives sanitization in html mode" do
+        Creative.create!(user: @user, description: '<p><span style="color: #ff0000">hi</span></p>')
+        creative = Creative.last
+
+        assert_match(/color:\s*#ff0000/, creative.description)
+        assert_includes creative.description, "hi"
+      end
+
+      test "non-color style declarations are scrubbed from spans" do
+        Creative.create!(
+          user: @user,
+          description: '<p><span style="color: red; position: fixed; font-size: 99px">x</span></p>'
+        )
+        creative = Creative.last
+
+        assert_match(/color:\s*red/, creative.description)
+        refute_includes creative.description, "position"
+        refute_includes creative.description, "font-size"
+      end
+
+      test "dangerous style values are dropped, leaving no style attribute" do
+        Creative.create!(
+          user: @user,
+          description: '<p><span style="background: url(javascript:alert(1))">x</span></p>'
+        )
+        creative = Creative.last
+
+        refute_includes creative.description, "javascript"
+        refute_includes creative.description, "url("
+        assert_includes creative.description, "x"
+      end
+
       test "non-checkbox input tags are stripped from description" do
         Creative.create!(
           user: @user,

--- a/engines/collavre/test/models/collavre/creative/describable_test.rb
+++ b/engines/collavre/test/models/collavre/creative/describable_test.rb
@@ -265,6 +265,37 @@ module Collavre
         assert ActiveStorage::Blob.exists?(blob.id), "linked-row legacy blob must survive a save"
       end
 
+      test "rich-editor markdown upload attaches the referenced blob on save" do
+        blob = make_blob
+        # The rich (Lexical) editor is Markdown-canonical: an inserted image is
+        # serialized as a raw <img> blob URL inside markdown_source.
+        source = %(text\n\n<img src="#{asset_url(blob)}" alt="a.png">)
+        creative = Creative.create!(
+          user: @user, content_type_input: "markdown", markdown_editor: "rich", markdown_source: source
+        )
+
+        assert_includes creative.reload.files.map { |f| f.blob.signed_id }, blob.signed_id
+      end
+
+      test "markdown save does not detach an out-of-band attached blob" do
+        # Markdown reconcile is attach-only: a blob attached directly (legacy /
+        # backfill) but not referenced in the derived description must survive a
+        # normal markdown save, since markdown creatives may carry such blobs.
+        creative = Creative.create!(
+          user: @user, content_type_input: "markdown", markdown_source: "# hi"
+        )
+        blob = make_blob
+        creative.files.attach(blob)
+        assert_includes creative.reload.files.map(&:blob_id), blob.id
+
+        perform_enqueued_jobs do
+          creative.update!(content_type_input: "markdown", markdown_source: "# hi\n\nmore")
+        end
+
+        assert_includes creative.reload.files.map(&:blob_id), blob.id
+        assert ActiveStorage::Blob.exists?(blob.id)
+      end
+
       # --- Sanitizer: media tags ---
 
       test "video tag with controls/src survives sanitization" do

--- a/engines/collavre/test/models/collavre/creative/describable_test.rb
+++ b/engines/collavre/test/models/collavre/creative/describable_test.rb
@@ -278,9 +278,12 @@ module Collavre
       end
 
       test "markdown save does not detach an out-of-band attached blob" do
-        # Markdown reconcile is attach-only: a blob attached directly (legacy /
-        # backfill) but not referenced in the derived description must survive a
-        # normal markdown save, since markdown creatives may carry such blobs.
+        # A blob attached directly (legacy / backfill) but never referenced in
+        # the derived description must survive a normal markdown save:
+        # AttachmentBackfill skips markdown creatives, so reconcile is their only
+        # touch point and would otherwise purge a blob the user never removed.
+        # The guard: only blobs that WERE referenced in the prior description get
+        # detached, so an orphan that was never referenced is left alone.
         creative = Creative.create!(
           user: @user, content_type_input: "markdown", markdown_source: "# hi"
         )
@@ -294,6 +297,27 @@ module Collavre
 
         assert_includes creative.reload.files.map(&:blob_id), blob.id
         assert ActiveStorage::Blob.exists?(blob.id)
+      end
+
+      test "rich-editor removing an embedded media node detaches its blob" do
+        # The rich (Lexical) editor embeds an upload as a raw <img> blob URL in
+        # markdown_source. When the user deletes that node, the blob is gone from
+        # the re-rendered description but still attached — and the editor's purge
+        # DELETE can't compensate while the attachment exists. It was referenced
+        # in the prior description, so reconcile must detach (and purge) it.
+        blob = make_blob
+        with_image = %(text\n\n<img src="#{asset_url(blob)}" alt="a.png">)
+        creative = Creative.create!(
+          user: @user, content_type_input: "markdown", markdown_editor: "rich", markdown_source: with_image
+        )
+        assert_includes creative.reload.files.map(&:blob_id), blob.id
+
+        perform_enqueued_jobs do
+          creative.update!(content_type_input: "markdown", markdown_editor: "rich", markdown_source: "text")
+        end
+
+        refute_includes creative.reload.files.map(&:blob_id), blob.id
+        refute ActiveStorage::Blob.exists?(blob.id)
       end
 
       # --- Sanitizer: media tags ---

--- a/engines/collavre/test/services/collavre/markdown_converter_test.rb
+++ b/engines/collavre/test/services/collavre/markdown_converter_test.rb
@@ -18,6 +18,22 @@ module Collavre
       assert_equal "", MarkdownConverter.markdown_to_html(nil)
     end
 
+    test "markdown_to_html renders a single newline as a hard break" do
+      # Mirrors the JS renderer (marked breaks:true): consecutive rich-editor
+      # lines are stored one-per-line and must render as <br>, not be joined.
+      html = MarkdownConverter.markdown_to_html("abc\ndef")
+      assert_includes html, "<br"
+      assert_includes html, "abc"
+      assert_includes html, "def"
+      # Stays a single paragraph (line break, not a paragraph break).
+      assert_equal 1, html.scan("<p>").length
+    end
+
+    test "markdown_to_html keeps a blank line as a paragraph break" do
+      html = MarkdownConverter.markdown_to_html("abc\n\ndef")
+      assert_equal 2, html.scan("<p>").length
+    end
+
     test "html_to_markdown handles nil" do
       assert_equal "", MarkdownConverter.html_to_markdown(nil)
     end


### PR DESCRIPTION
## Summary

Makes the default inline **Lexical** editor store **Markdown as the canonical format** (`content_type=markdown`) for *both* editing surfaces, so AI agents, line-diff snapshots, compress/merge, and search all operate on one text representation. The advanced Markdown textarea stays as-is.

Per the approved design, the only rich features Markdown can't express natively are escaped as a **small, fixed set of normalized inline HTML fragments**. This first slice ships **text color and background-color**.

## What changed

**JS — canonical Markdown serialization**
- `lib/lexical/markdown_serialize.js` (new): `$convertToMarkdownString` with custom transformers:
  - color / background-color → normalized `<span style="color: X; background-color: Y">` (fixed declaration order; CSS values validated — `url()`, `expression()`, `javascript:`, `<`/`>` rejected).
  - images / videos / attachments → their canonical HTML tags (round-trip via `markdown_to_html` → `$generateNodesFromDOM`).
- `InlineLexicalEditor.jsx`: `onChange` now emits `{ html, markdown }`.
- Round-trip tests cover `md → html → Lexical → md` byte-identity, guarding the PR#1276 color-drift class.

**Server — sanitizer**
- `describable.rb`: allow `style` on the stored description, but pre-scrub every inline style down to **only** validated `color` / `background-color` before sanitization (defense-in-depth, deterministic shape). The canonical `markdown_source` is preserved verbatim; only the rendered `description` is sanitized.

**Decouple storage format from editing surface**
- New `data["editor"]` (`rich` | `source`) decides which editor reopens, independent of `content_type` (now always `markdown`). Rich-authored Markdown reopens in Lexical; `source`/legacy Markdown reopens in the advanced textarea.
- Threaded through the form, strong params, JSON responses, and row dataset.
- Editor switches now **preserve content** (seed the textarea from the rich surface's Markdown, and vice-versa) instead of discarding it.

## Migration behavior
- Legacy `content_type=html` creatives stay HTML until edited; editing in Lexical migrates them to Markdown-canonical (no forced mass migration).
- Legacy Markdown (textarea-authored, no `editor` pref) keeps reopening in the textarea.

## Tests
- JS: `markdown_serialize.test.js` — 23 tests (pure serialization + value validation + full import→serialize round-trips). Full JS suite: 110 passing.
- Ruby: `describable_test.rb` — color-span survival (markdown & html modes), non-color/dangerous style scrubbing, editor-preference persistence + demotion clearing. 26 passing. Controller update tests green.
- `node script/build.cjs` succeeds; rubocop clean.

## Deferred (documented)
Rich features beyond color/bg that Markdown can't express — **underline, font-size, text-align** — are not yet round-tripped and will be lost on edit-migration. To be added as further normalized fragments (or scoped out of the toolbar) in follow-ups.

## Verification note
Core conversion + sanitizer + persistence are unit/integration covered. The autosave/dirty/move wiring in `creative_row_editor.js` warrants a manual smoke pass (type colored text → reopen → confirm color survives and it reopens in Lexical) — recommended before merge.