### PR TITLE
feat: typo correction (Phase 0 backend + Phase 1 chat composer)

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -384,6 +384,20 @@ input[type="password"] {
     margin: 0;
 }
 
+/* Match the borderless settings format: group fields without the default fieldset box */
+.profile-form fieldset {
+    border: 0;
+    padding: 0;
+    margin: 0;
+    min-width: 0;
+}
+
+.profile-form legend {
+    padding: 0;
+    margin-bottom: 0.25em;
+    font-weight: 600;
+}
+
 .profile-form input[type="text"],
 .profile-form input[type="number"],
 .profile-form input[type="url"],

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_09_190659) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_17_090000) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -835,6 +835,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_09_190659) do
     t.string "theme"
     t.string "timezone"
     t.json "tools"
+    t.boolean "typo_correction_enabled", default: true, null: false
+    t.boolean "typo_correction_in_chat", default: true, null: false
+    t.boolean "typo_correction_in_editor", default: false, null: false
+    t.boolean "typo_correction_on_physical_keyboard", default: false, null: false
+    t.boolean "typo_correction_on_soft_keyboard", default: true, null: false
+    t.boolean "typo_correction_on_voice", default: true, null: false
+    t.integer "typo_correction_threshold", default: 80, null: false
     t.datetime "updated_at", null: false
     t.string "webauthn_id"
     t.index ["email"], name: "index_users_on_email", unique: true

--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -1996,3 +1996,108 @@ body.chat-fullscreen {
 li:hover .topic-create-option {
     text-decoration: underline;
 }
+
+/* ── Inline typo correction (volatile overlay; never serialized) ───────────── */
+/* The backdrop mirrors the textarea text exactly and paints <mark> spans behind
+   it. The textarea sits on top with a transparent background so the highlight
+   underlines show through around the real (opaque) glyphs. */
+.typo-input-wrap {
+    position: relative;
+    display: block;
+}
+
+.typo-input-wrap > textarea {
+    position: relative;
+    background: transparent;
+    z-index: 1;
+}
+
+.typo-backdrop {
+    position: absolute;
+    inset: 0;
+    overflow: hidden;
+    pointer-events: none;
+    z-index: 0;
+}
+
+.typo-highlights {
+    margin: 0;
+    color: transparent;
+    white-space: pre-wrap;
+    overflow-wrap: break-word;
+    word-break: break-word;
+}
+
+/* Two states, distinguished by BOTH shape and colour (colour-blind safe). */
+.typo-mark {
+    background: transparent;
+    color: transparent;
+    pointer-events: auto;
+    cursor: pointer;
+    border-radius: 2px;
+}
+
+/* Auto-applied (>= threshold): faint straight underline — resolved, dim. */
+.typo-mark-applied {
+    text-decoration: underline solid var(--color-link, #185ABC);
+    text-decoration-thickness: 1px;
+    text-underline-offset: 2px;
+    opacity: 0.55;
+}
+
+/* Candidate (< threshold): wavy dotted amber underline — needs a decision. */
+.typo-mark-candidate {
+    text-decoration: underline wavy var(--color-warning, #f59e0b);
+    text-decoration-thickness: 1px;
+    text-underline-offset: 2px;
+}
+
+/* Creatable combobox reusing CommonPopup positioning. */
+.typo-popup {
+    position: absolute;
+    z-index: 100000;
+    min-width: 180px;
+    max-width: 320px;
+    background: var(--surface, #fff);
+    border: 1px solid var(--border, #d1d5db);
+    border-radius: 8px;
+    box-shadow: 0 6px 24px rgba(0, 0, 0, 0.18);
+    padding: 6px;
+}
+
+.typo-popup-input {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 6px 8px;
+    border: 1px solid var(--border, #d1d5db);
+    border-radius: 6px;
+    font: inherit;
+    margin-bottom: 6px;
+}
+
+.typo-popup-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    max-height: 200px;
+    overflow-y: auto;
+}
+
+.typo-popup-list .common-popup-item {
+    padding: 6px 8px;
+    border-radius: 6px;
+    cursor: pointer;
+    display: flex;
+    justify-content: space-between;
+    gap: 8px;
+}
+
+.typo-popup-list .common-popup-item.active,
+.typo-popup-list .common-popup-item:hover {
+    background: var(--hover-bg, #f1f5f9);
+}
+
+.typo-popup-role {
+    color: var(--text-secondary, #6b7280);
+    font-size: 0.85em;
+}

--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -1998,9 +1998,13 @@ li:hover .topic-create-option {
 }
 
 /* ── Inline typo correction (volatile overlay; never serialized) ───────────── */
-/* The backdrop mirrors the textarea text exactly and paints <mark> spans behind
-   it. The textarea sits on top with a transparent background so the highlight
-   underlines show through around the real (opaque) glyphs. */
+/* The backdrop mirrors the textarea text exactly and paints <mark> spans over
+   it. The backdrop sits ON TOP of the textarea (higher z-index) but is
+   pointer-events:none, so clicks pass through to the textarea everywhere EXCEPT
+   over a <mark> (pointer-events:auto) — that's what makes the marks clickable.
+   If the textarea were on top, the browser would hit-test it first and the mark
+   click handlers would never fire. The backdrop's text is transparent, so the
+   textarea's real (opaque) glyphs show through and only the underlines paint. */
 .typo-input-wrap {
     position: relative;
     display: block;
@@ -2009,7 +2013,7 @@ li:hover .topic-create-option {
 .typo-input-wrap > textarea {
     position: relative;
     background: transparent;
-    z-index: 1;
+    z-index: 0;
 }
 
 .typo-backdrop {
@@ -2017,7 +2021,7 @@ li:hover .topic-create-option {
     inset: 0;
     overflow: hidden;
     pointer-events: none;
-    z-index: 0;
+    z-index: 1;
 }
 
 .typo-highlights {
@@ -2039,7 +2043,7 @@ li:hover .topic-create-option {
 
 /* Auto-applied (>= threshold): faint straight underline — resolved, dim. */
 .typo-mark-applied {
-    text-decoration: underline solid var(--color-link, #185ABC);
+    text-decoration: underline solid var(--color-link);
     text-decoration-thickness: 1px;
     text-underline-offset: 2px;
     opacity: 0.55;
@@ -2047,7 +2051,7 @@ li:hover .topic-create-option {
 
 /* Candidate (< threshold): wavy dotted amber underline — needs a decision. */
 .typo-mark-candidate {
-    text-decoration: underline wavy var(--color-warning, #f59e0b);
+    text-decoration: underline wavy var(--color-warning);
     text-decoration-thickness: 1px;
     text-underline-offset: 2px;
 }
@@ -2058,8 +2062,8 @@ li:hover .topic-create-option {
     z-index: 100000;
     min-width: 180px;
     max-width: 320px;
-    background: var(--surface, #fff);
-    border: 1px solid var(--border, #d1d5db);
+    background: var(--surface-section);
+    border: 1px solid var(--border-color);
     border-radius: 8px;
     box-shadow: 0 6px 24px rgba(0, 0, 0, 0.18);
     padding: 6px;
@@ -2069,7 +2073,7 @@ li:hover .topic-create-option {
     width: 100%;
     box-sizing: border-box;
     padding: 6px 8px;
-    border: 1px solid var(--border, #d1d5db);
+    border: 1px solid var(--border-color);
     border-radius: 6px;
     font: inherit;
     margin-bottom: 6px;
@@ -2094,10 +2098,10 @@ li:hover .topic-create-option {
 
 .typo-popup-list .common-popup-item.active,
 .typo-popup-list .common-popup-item:hover {
-    background: var(--hover-bg, #f1f5f9);
+    background: var(--surface-hover);
 }
 
 .typo-popup-role {
-    color: var(--text-secondary, #6b7280);
+    color: var(--text-muted);
     font-size: 0.85em;
 }

--- a/engines/collavre/app/controllers/collavre/typo_corrections_controller.rb
+++ b/engines/collavre/app/controllers/collavre/typo_corrections_controller.rb
@@ -4,16 +4,35 @@ module Collavre
   # before spending an LLM call, and echo the user's auto-apply threshold so the
   # client never has to hardcode it.
   class TypoCorrectionsController < ApplicationController
+    # The client debounce is only a hint — a scripted/compromised page can loop
+    # this endpoint with arbitrary text, and every accepted call spends an LLM
+    # request. Bound both the call rate and the per-call size server-side. The
+    # chat composer is short text; anything larger is not a typo-correction case.
+    MAX_TEXT_LENGTH = 4_000
+    RATE_LIMIT = 120          # requests
+    RATE_PERIOD = 1.minute    # ...per user per minute
+
     def create
       user = Current.user
       device = params[:device].to_s
       location = params[:location].presence || "chat"
+      text = params[:text].to_s
 
       unless user.typo_correction_active_for?(device: device, location: location)
         return render json: { edits: [], threshold: user.typo_correction_threshold }
       end
 
-      edits = TypoCorrector.new.correct(params[:text])
+      # Oversized input: skip the LLM entirely (return no edits, not an error —
+      # this is a background affordance, not a user-facing failure).
+      if text.length > MAX_TEXT_LENGTH
+        return render json: { edits: [], threshold: user.typo_correction_threshold }
+      end
+
+      # Raises RateLimitExceeded -> 429 (DynamicRateLimiting), which the client
+      # treats as "no suggestions this round".
+      check_rate_limit!(key: "typo_correction:#{user.id}", limit: RATE_LIMIT, period: RATE_PERIOD)
+
+      edits = TypoCorrector.new.correct(text)
       render json: { edits: edits, threshold: user.typo_correction_threshold }
     end
   end

--- a/engines/collavre/app/controllers/collavre/typo_corrections_controller.rb
+++ b/engines/collavre/app/controllers/collavre/typo_corrections_controller.rb
@@ -1,0 +1,20 @@
+module Collavre
+  # Session-authenticated endpoint backing the inline typo-correction UI. The
+  # frontend also gates by device/location, but we re-check here (fail closed)
+  # before spending an LLM call, and echo the user's auto-apply threshold so the
+  # client never has to hardcode it.
+  class TypoCorrectionsController < ApplicationController
+    def create
+      user = Current.user
+      device = params[:device].to_s
+      location = params[:location].presence || "chat"
+
+      unless user.typo_correction_active_for?(device: device, location: location)
+        return render json: { edits: [], threshold: user.typo_correction_threshold }
+      end
+
+      edits = TypoCorrector.new.correct(params[:text])
+      render json: { edits: edits, threshold: user.typo_correction_threshold }
+    end
+  end
+end

--- a/engines/collavre/app/controllers/concerns/collavre/users_controller/profile_and_settings.rb
+++ b/engines/collavre/app/controllers/concerns/collavre/users_controller/profile_and_settings.rb
@@ -58,6 +58,14 @@ module Collavre
       end
     end
 
+    def typo_correction
+      @user = Collavre::User.find(params[:id])
+
+      unless @user == Current.user || Current.user.system_admin?
+        redirect_to user_path(Current.user), alert: I18n.t("collavre.users.destroy.not_authorized")
+      end
+    end
+
     def update_password
       @user = Collavre::User.find(params[:id])
       if @user.authenticate(params[:user][:current_password])

--- a/engines/collavre/app/controllers/concerns/collavre/users_controller/profile_and_settings.rb
+++ b/engines/collavre/app/controllers/concerns/collavre/users_controller/profile_and_settings.rb
@@ -89,7 +89,14 @@ module Collavre
         :notifications_enabled,
         :calendar_id,
         :timezone,
-        :locale
+        :locale,
+        :typo_correction_enabled,
+        :typo_correction_threshold,
+        :typo_correction_on_soft_keyboard,
+        :typo_correction_on_voice,
+        :typo_correction_on_physical_keyboard,
+        :typo_correction_in_chat,
+        :typo_correction_in_editor
       ).tap do |p|
         p[:locale] = normalize_supported_locale(p[:locale]) if p.key?(:locale)
       end

--- a/engines/collavre/app/javascript/collavre.js
+++ b/engines/collavre/app/javascript/collavre.js
@@ -5,6 +5,7 @@
 import "./modules/creatives"
 import "./modules/creative_row_swipe"
 import "./modules/mention_menu"
+import "./modules/typo_corrector"
 import "./modules/command_menu"
 import "./modules/modal_dialog"
 import "./modules/export_to_markdown"

--- a/engines/collavre/app/javascript/lib/__tests__/typo_correction.test.js
+++ b/engines/collavre/app/javascript/lib/__tests__/typo_correction.test.js
@@ -127,6 +127,22 @@ describe('anchorEdits', () => {
     const edits = anchorEdits('hello world', [{ original: 'xyz', suggestion: 'abc' }])
     expect(edits).toEqual([])
   })
+
+  test('honors the server offset so a duplicate inside a protected span is skipped', () => {
+    // "teh" appears first inside backticks (a region the server excludes) and
+    // again in plain text at offset 15. A plain search would bind the protected
+    // one; the offset pins us to the valid occurrence.
+    const text = 'use `teh` then teh'
+    const edits = anchorEdits(text, [{ original: 'teh', suggestion: 'the', offset: 15 }])
+    expect(edits[0].start).toBe(15)
+    expect(text.slice(edits[0].start, edits[0].end)).toBe('teh')
+  })
+
+  test('falls back to search when the offset no longer matches the text', () => {
+    const text = 'hello teh'
+    const edits = anchorEdits(text, [{ original: 'teh', suggestion: 'the', offset: 99 }])
+    expect(edits[0].start).toBe(6)
+  })
 })
 
 describe('applyEditAt + shiftEditsAfter (re-anchoring)', () => {

--- a/engines/collavre/app/javascript/lib/__tests__/typo_correction.test.js
+++ b/engines/collavre/app/javascript/lib/__tests__/typo_correction.test.js
@@ -1,0 +1,176 @@
+import {
+  detectDevice,
+  shouldRun,
+  buildCandidateList,
+  anchorEdits,
+  applyEditAt,
+  shiftEditsAfter,
+  partitionByThreshold,
+  DEVICE_VOICE,
+  DEVICE_SOFT_KEYBOARD,
+  DEVICE_PHYSICAL_KEYBOARD,
+} from '../typo_correction'
+
+const settings = ({
+  enabled = true,
+  onVoice = true,
+  onSoftKeyboard = true,
+  onPhysicalKeyboard = false,
+  inChat = true,
+  inEditor = false,
+} = {}) => ({ enabled, onVoice, onSoftKeyboard, onPhysicalKeyboard, inChat, inEditor })
+
+describe('detectDevice', () => {
+  test('voice recognition wins regardless of keyboard signals', () => {
+    expect(detectDevice({ voiceActive: true, lastPrintableKeydownAt: 100, inputAt: 110 })).toBe(DEVICE_VOICE)
+  })
+
+  test('printable keydown right before input => physical keyboard', () => {
+    expect(detectDevice({ lastPrintableKeydownAt: 1000, inputAt: 1005 })).toBe(DEVICE_PHYSICAL_KEYBOARD)
+  })
+
+  test('input with no preceding printable keydown => soft keyboard', () => {
+    expect(detectDevice({ lastPrintableKeydownAt: null, inputAt: 1000 })).toBe(DEVICE_SOFT_KEYBOARD)
+  })
+
+  test('stale keydown (too far before input) => soft keyboard', () => {
+    expect(detectDevice({ lastPrintableKeydownAt: 1000, inputAt: 2000 })).toBe(DEVICE_SOFT_KEYBOARD)
+  })
+})
+
+describe('shouldRun (2D gating)', () => {
+  test('runs when master + device + location all on', () => {
+    expect(shouldRun(settings(), { device: DEVICE_SOFT_KEYBOARD, location: 'chat' })).toBe(true)
+  })
+
+  test('blocked when master off', () => {
+    expect(shouldRun(settings({ enabled: false }), { device: DEVICE_SOFT_KEYBOARD, location: 'chat' })).toBe(false)
+  })
+
+  test('physical keyboard off by default blocks even in chat', () => {
+    expect(shouldRun(settings(), { device: DEVICE_PHYSICAL_KEYBOARD, location: 'chat' })).toBe(false)
+  })
+
+  test('editor location off by default blocks even with soft keyboard', () => {
+    expect(shouldRun(settings(), { device: DEVICE_SOFT_KEYBOARD, location: 'editor' })).toBe(false)
+  })
+
+  test('voice in chat runs', () => {
+    expect(shouldRun(settings(), { device: DEVICE_VOICE, location: 'chat' })).toBe(true)
+  })
+
+  test('null settings never runs', () => {
+    expect(shouldRun(null, { device: DEVICE_VOICE, location: 'chat' })).toBe(false)
+  })
+})
+
+describe('buildCandidateList', () => {
+  test('candidate state: original pre-filled, suggestions by confidence', () => {
+    const list = buildCandidateList({
+      currentValue: '안녀하세요',
+      originalWord: '안녀하세요',
+      suggestions: [
+        { suggestion: '안녕하세요', confidence: 0.95 },
+        { suggestion: '안녕하셔요', confidence: 0.4 },
+      ],
+    })
+    expect(list.map((i) => i.value)).toEqual(['안녀하세요', '안녕하세요', '안녕하셔요'])
+    expect(list[0].isCurrent).toBe(true)
+    expect(list[0].role).toBe('original')
+  })
+
+  test('auto-applied state: corrected word current, original offered as undo', () => {
+    const list = buildCandidateList({
+      currentValue: '있습니다',
+      originalWord: '잇습니다',
+      suggestions: [{ suggestion: '있습니다', confidence: 0.99 }],
+    })
+    // current (applied) first, then original (undo); suggestion dupes current and is dropped.
+    expect(list.map((i) => i.value)).toEqual(['있습니다', '잇습니다'])
+    expect(list[0].role).toBe('applied')
+    expect(list[0].isCurrent).toBe(true)
+    expect(list[1].role).toBe('original')
+  })
+
+  test('de-duplicates and skips empties', () => {
+    const list = buildCandidateList({
+      currentValue: 'a',
+      originalWord: 'a',
+      suggestions: [{ suggestion: 'a' }, { suggestion: '' }, { suggestion: 'b', confidence: 0.5 }],
+    })
+    expect(list.map((i) => i.value)).toEqual(['a', 'b'])
+  })
+})
+
+describe('anchorEdits', () => {
+  test('binds offsets to substrings', () => {
+    const text = '안녀하세요 저는 콜라브를 만들고 잇습니다'
+    const edits = anchorEdits(text, [
+      { original: '안녀하세요', suggestion: '안녕하세요' },
+      { original: '잇습니다', suggestion: '있습니다' },
+    ])
+    expect(text.slice(edits[0].start, edits[0].end)).toBe('안녀하세요')
+    expect(text.slice(edits[1].start, edits[1].end)).toBe('잇습니다')
+  })
+
+  test('repeated words anchor to distinct occurrences, not all to the first', () => {
+    const text = 'teh cat and teh dog'
+    const edits = anchorEdits(text, [
+      { original: 'teh', suggestion: 'the' },
+      { original: 'teh', suggestion: 'the' },
+    ])
+    expect(edits[0].start).toBe(0)
+    expect(edits[1].start).toBe(12)
+  })
+
+  test('drops edits whose original is gone', () => {
+    const edits = anchorEdits('hello world', [{ original: 'xyz', suggestion: 'abc' }])
+    expect(edits).toEqual([])
+  })
+})
+
+describe('applyEditAt + shiftEditsAfter (re-anchoring)', () => {
+  test('applying one edit shifts the offsets of later edits', () => {
+    let text = 'teh cat saw teh dog'
+    const edits = anchorEdits(text, [
+      { original: 'teh', suggestion: 'the' },
+      { original: 'teh', suggestion: 'the' },
+    ])
+    const first = edits[0]
+    const { text: t2, delta } = applyEditAt(text, { start: first.start, end: first.end, replacement: 'the' })
+    text = t2
+    expect(text).toBe('the cat saw teh dog')
+    const remaining = shiftEditsAfter(edits.slice(1), first.start, delta)
+    // 'the' and 'teh' are the same length here, delta 0; offset unchanged & still valid.
+    expect(text.slice(remaining[0].start, remaining[0].end)).toBe('teh')
+  })
+
+  test('length-changing replacement re-anchors later edits correctly', () => {
+    let text = 'a wrng word and anothr'
+    const edits = anchorEdits(text, [
+      { original: 'wrng', suggestion: 'wrong' },
+      { original: 'anothr', suggestion: 'another' },
+    ])
+    const first = edits[0]
+    const { text: t2, delta } = applyEditAt(text, { start: first.start, end: first.end, replacement: 'wrong' })
+    text = t2
+    expect(text).toBe('a wrong word and anothr')
+    const remaining = shiftEditsAfter(edits.slice(1), first.start, delta)
+    expect(text.slice(remaining[0].start, remaining[0].end)).toBe('anothr')
+  })
+})
+
+describe('partitionByThreshold', () => {
+  test('splits at/above vs below threshold', () => {
+    const { autoApplied, candidates } = partitionByThreshold(
+      [
+        { original: 'a', confidence: 0.9 },
+        { original: 'b', confidence: 0.8 },
+        { original: 'c', confidence: 0.5 },
+      ],
+      80,
+    )
+    expect(autoApplied.map((e) => e.original)).toEqual(['a', 'b'])
+    expect(candidates.map((e) => e.original)).toEqual(['c'])
+  })
+})

--- a/engines/collavre/app/javascript/lib/common_popup.js
+++ b/engines/collavre/app/javascript/lib/common_popup.js
@@ -67,7 +67,15 @@ export default class CommonPopup {
       const li = document.createElement('li')
       li.className = 'common-popup-item'
       li.dataset.index = String(index)
-      li.innerHTML = this.renderItem(item, index)
+      // renderItem may return a DOM node (preferred when the content includes
+      // user-controlled text — build it with textContent so nothing is ever
+      // reinterpreted as HTML) or a trusted HTML string (legacy callers).
+      const rendered = this.renderItem(item, index)
+      if (rendered instanceof Node) {
+        li.appendChild(rendered)
+      } else {
+        li.innerHTML = rendered
+      }
       li.addEventListener('mouseenter', () => this.setActiveIndex(index))
       li.addEventListener('mousedown', (event) => event.preventDefault())
       li.addEventListener('click', () => this.handleItemSelect(index))

--- a/engines/collavre/app/javascript/lib/common_popup.js
+++ b/engines/collavre/app/javascript/lib/common_popup.js
@@ -15,6 +15,14 @@ export default class CommonPopup {
   showAt(anchorRect) {
     if (!this.element) return
 
+    // Re-opening while already open (e.g. clicking the same typo mark twice):
+    // a listener from the previous open is still live, so the opening mousedown
+    // would bubble to it and hide() the popup right after we set display:block,
+    // leaving it stuck (the rAF below only re-flips visibility, not display).
+    // Drop stale listeners first so the opening event can't self-close it.
+    document.removeEventListener('mousedown', this.handleOutsideClick)
+    document.removeEventListener('touchstart', this.handleOutsideClick)
+
     this.element.style.display = 'block'
     this.element.style.visibility = 'hidden'
 

--- a/engines/collavre/app/javascript/lib/common_popup.js
+++ b/engines/collavre/app/javascript/lib/common_popup.js
@@ -67,15 +67,7 @@ export default class CommonPopup {
       const li = document.createElement('li')
       li.className = 'common-popup-item'
       li.dataset.index = String(index)
-      // renderItem may return a DOM node (preferred when the content includes
-      // user-controlled text — build it with textContent so nothing is ever
-      // reinterpreted as HTML) or a trusted HTML string (legacy callers).
-      const rendered = this.renderItem(item, index)
-      if (rendered instanceof Node) {
-        li.appendChild(rendered)
-      } else {
-        li.innerHTML = rendered
-      }
+      li.innerHTML = this.renderItem(item, index)
       li.addEventListener('mouseenter', () => this.setActiveIndex(index))
       li.addEventListener('mousedown', (event) => event.preventDefault())
       li.addEventListener('click', () => this.handleItemSelect(index))

--- a/engines/collavre/app/javascript/lib/common_popup.js
+++ b/engines/collavre/app/javascript/lib/common_popup.js
@@ -21,12 +21,17 @@ export default class CommonPopup {
     requestAnimationFrame(() => {
       this.updatePosition(anchorRect)
       this.element.style.visibility = 'visible'
+      // Register the outside-click listeners only after the opening event has
+      // finished propagating. When a popup is opened from a mousedown handler
+      // (e.g. clicking a typo highlight), registering synchronously here would
+      // let that same mousedown keep bubbling to document, hit handleOutsideClick
+      // (target is outside the popup), and immediately hide() it — the popup
+      // would open and instantly vanish. Deferring one frame avoids that race.
+      if (this.closeOnOutsideClick) {
+        document.addEventListener('mousedown', this.handleOutsideClick)
+        document.addEventListener('touchstart', this.handleOutsideClick)
+      }
     })
-
-    if (this.closeOnOutsideClick) {
-      document.addEventListener('mousedown', this.handleOutsideClick)
-      document.addEventListener('touchstart', this.handleOutsideClick)
-    }
   }
 
   updatePosition(anchorRect) {

--- a/engines/collavre/app/javascript/lib/typo_correction.js
+++ b/engines/collavre/app/javascript/lib/typo_correction.js
@@ -1,0 +1,134 @@
+// Pure logic for client-side typo correction (Phase 1: chat input).
+//
+// This module holds the framework-free core so it can be unit-tested without a
+// DOM: device classification, the 2D gating decision (mirrors the server's
+// `Collavre::User#typo_correction_active_for?`), candidate-list construction for
+// the selection popup, and edit anchoring/application with re-anchoring of the
+// remaining edits after one is applied.
+//
+// The overlay highlight is a *volatile* presentation layer — the textarea value
+// is the only canonical text. Nothing here ever serializes a highlight.
+
+export const DEVICE_VOICE = 'voice'
+export const DEVICE_SOFT_KEYBOARD = 'soft_keyboard'
+export const DEVICE_PHYSICAL_KEYBOARD = 'physical_keyboard'
+
+// Classify the active typing device from the signals we can observe.
+//
+// - Voice dictation is explicit (the composer exposes its recognition state).
+// - A physical keyboard fires a `keydown` for a printable key immediately
+//   before the resulting `input` event. Soft keyboards and IME composition
+//   insert text without that printable keydown (key is 'Unidentified'/'Process'
+//   or no keydown at all), which is the standard heuristic we rely on.
+export function detectDevice({ voiceActive = false, lastPrintableKeydownAt = null, inputAt = null } = {}) {
+  if (voiceActive) return DEVICE_VOICE
+  if (lastPrintableKeydownAt == null || inputAt == null) return DEVICE_SOFT_KEYBOARD
+  // A printable keydown that landed within the same input tick means a physical
+  // key produced this character.
+  const delta = inputAt - lastPrintableKeydownAt
+  if (delta >= 0 && delta <= 50) return DEVICE_PHYSICAL_KEYBOARD
+  return DEVICE_SOFT_KEYBOARD
+}
+
+// Mirror of the server-side 2D gate so the client avoids a pointless round-trip
+// when the feature is off for this device/location. The server re-checks; this
+// is an optimization, not the source of truth.
+export function shouldRun(settings, { device, location }) {
+  if (!settings || settings.enabled !== true) return false
+
+  const deviceOn =
+    device === DEVICE_VOICE ? settings.onVoice
+      : device === DEVICE_SOFT_KEYBOARD ? settings.onSoftKeyboard
+        : device === DEVICE_PHYSICAL_KEYBOARD ? settings.onPhysicalKeyboard
+          : false
+  if (deviceOn !== true) return false
+
+  const locationOn =
+    location === 'chat' ? settings.inChat
+      : location === 'editor' ? settings.inEditor
+        : false
+  return locationOn === true
+}
+
+// Build the popup's option list for one edit: the word currently sitting in the
+// document first (so Enter = keep), then the suggestions in confidence order,
+// de-duplicated. `currentValue` is whatever text is actually in the textarea at
+// the edit's span right now (original word, or the corrected word if it was
+// auto-applied). `originalWord` is the pre-correction text, surfaced as the undo
+// option when the current value is already the suggestion.
+export function buildCandidateList({ currentValue, originalWord, suggestions = [] }) {
+  const seen = new Set()
+  const list = []
+  const push = (value, role) => {
+    if (value == null || value === '') return
+    if (seen.has(value)) return
+    seen.add(value)
+    list.push({ value, label: value, isCurrent: value === currentValue, role })
+  }
+
+  // Current document value is always the pre-selected, pre-filled option.
+  push(currentValue, currentValue === originalWord ? 'original' : 'applied')
+  // If we're showing a corrected word, the original is the undo option.
+  push(originalWord, 'original')
+  // Suggestions, highest confidence first (assumed already sorted; sort defensively).
+  ;[...suggestions]
+    .sort((a, b) => (b.confidence ?? 0) - (a.confidence ?? 0))
+    .forEach((s) => push(s.suggestion, 'suggestion'))
+
+  return list
+}
+
+// Attach character offsets to each edit by locating its `original` substring in
+// `text`. Scanning left-to-right and advancing the cursor past each match keeps
+// repeated words from all anchoring to the first occurrence. Edits whose
+// original can no longer be found (the user already changed that span) are
+// dropped — the caller re-runs the detector for fresh suggestions.
+export function anchorEdits(text, edits = []) {
+  const anchored = []
+  let cursor = 0
+  for (const edit of edits) {
+    if (!edit || !edit.original) continue
+    const idx = text.indexOf(edit.original, cursor)
+    if (idx === -1) continue
+    anchored.push({ ...edit, start: idx, end: idx + edit.original.length })
+    cursor = idx + edit.original.length
+  }
+  return anchored
+}
+
+// Replace the span [start, end) of `text` with `replacement` and return the new
+// text plus the delta, so remaining edits can be shifted. We re-anchor by delta
+// rather than re-searching to avoid mis-binding when the same word repeats.
+export function applyEditAt(text, { start, end, replacement }) {
+  const before = text.slice(0, start)
+  const after = text.slice(end)
+  const newText = before + replacement + after
+  const delta = replacement.length - (end - start)
+  return { text: newText, delta }
+}
+
+// Shift every edit positioned at/after `fromOffset` by `delta`. Edits before the
+// applied span are untouched; the applied edit itself should be removed by the
+// caller before calling this.
+export function shiftEditsAfter(edits, fromOffset, delta) {
+  return edits.map((edit) => {
+    if (edit.start >= fromOffset) {
+      return { ...edit, start: edit.start + delta, end: edit.end + delta }
+    }
+    return edit
+  })
+}
+
+// Partition edits the server returned into auto-applied (confidence at/above the
+// user's threshold) and candidates (below it). Threshold is 0–100 to match the
+// profile setting; confidence is 0–1 from the model.
+export function partitionByThreshold(edits = [], threshold = 80) {
+  const cut = threshold / 100
+  const autoApplied = []
+  const candidates = []
+  for (const edit of edits) {
+    if ((edit.confidence ?? 0) >= cut) autoApplied.push(edit)
+    else candidates.push(edit)
+  }
+  return { autoApplied, candidates }
+}

--- a/engines/collavre/app/javascript/lib/typo_correction.js
+++ b/engines/collavre/app/javascript/lib/typo_correction.js
@@ -78,20 +78,32 @@ export function buildCandidateList({ currentValue, originalWord, suggestions = [
   return list
 }
 
-// Attach character offsets to each edit by locating its `original` substring in
-// `text`. Scanning left-to-right and advancing the cursor past each match keeps
-// repeated words from all anchoring to the first occurrence. Edits whose
-// original can no longer be found (the user already changed that span) are
-// dropped — the caller re-runs the detector for fresh suggestions.
+// Attach character offsets to each edit. Prefer the server-supplied `offset`
+// (the first occurrence the server verified is *outside* a protected span) so a
+// duplicate word sitting inside code/URL/markup is never anchored — anchoring by
+// our own search would bind the first textual occurrence, which can be the
+// protected one the server already excluded. We only trust `offset` if the
+// substring still matches there (text is identical to what the server saw).
+// Without an offset we fall back to a left-to-right search, advancing the cursor
+// so repeated words bind to distinct occurrences. Edits whose original can no
+// longer be found are dropped — the caller re-runs the detector.
 export function anchorEdits(text, edits = []) {
   const anchored = []
   let cursor = 0
   for (const edit of edits) {
     if (!edit || !edit.original) continue
-    const idx = text.indexOf(edit.original, cursor)
+    let idx
+    if (
+      Number.isInteger(edit.offset)
+      && text.slice(edit.offset, edit.offset + edit.original.length) === edit.original
+    ) {
+      idx = edit.offset
+    } else {
+      idx = text.indexOf(edit.original, cursor)
+    }
     if (idx === -1) continue
     anchored.push({ ...edit, start: idx, end: idx + edit.original.length })
-    cursor = idx + edit.original.length
+    cursor = Math.max(cursor, idx + edit.original.length)
   }
   return anchored
 }

--- a/engines/collavre/app/javascript/modules/__tests__/typo_corrector.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/typo_corrector.test.js
@@ -264,4 +264,38 @@ describe('TypoCorrector DOM orchestration', () => {
     expect(form.querySelector('.typo-input-wrap')).toBeNull()
     expect(form.querySelector('.typo-backdrop')).toBeNull()
   })
+
+  test('earlier corrections stay clickable across detection rounds (not just the last)', () => {
+    // Each detection round used to replace this.edits wholesale, and the server
+    // is stateless — it never re-reports an already-corrected word. So a second
+    // round (triggered by typing more) wiped the first correction's undo mark,
+    // leaving only the most recent correction clickable. Earlier corrections must
+    // keep their mark so the user can still undo them.
+    const { textarea, tc } = mount('잇습니다 hello')
+
+    // Round 1: auto-correct 잇습니다 → 있습니다 (high confidence).
+    tc._applyResult({
+      edits: [{ original: '잇습니다', suggestion: '있습니다', confidence: 0.95 }],
+      threshold: 80,
+    })
+    expect(textarea.value).toBe('있습니다 hello')
+    expect(textarea.parentNode.querySelectorAll('.typo-mark')).toHaveLength(1)
+
+    // User types another typo; a fresh detection round returns only the NEW word.
+    textarea.value = '있습니다 hello teh'
+    textarea.dispatchEvent(new Event('input', { bubbles: true }))
+    tc._applyResult({
+      edits: [{ original: 'teh', suggestion: 'the', confidence: 0.95 }],
+      threshold: 80,
+    })
+    expect(textarea.value).toBe('있습니다 hello the')
+
+    // Both corrections must be present and anchored to their own word.
+    const marks = [...textarea.parentNode.querySelectorAll('.typo-mark')]
+    expect(marks.map((m) => m.textContent).sort()).toEqual(['the', '있습니다'])
+    // And each mark resolves to its own edit (not all pointing at the last one).
+    const byWord = Object.fromEntries(tc.edits.map((e) => [e.currentValue, e]))
+    expect(textarea.value.slice(byWord['있습니다'].start, byWord['있습니다'].end)).toBe('있습니다')
+    expect(textarea.value.slice(byWord['the'].start, byWord['the'].end)).toBe('the')
+  })
 })

--- a/engines/collavre/app/javascript/modules/__tests__/typo_corrector.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/typo_corrector.test.js
@@ -224,4 +224,44 @@ describe('TypoCorrector DOM orchestration', () => {
     tc._ensurePopup()
     expect(tc.popupInput.getAttribute('aria-label')).toBe('교정')
   })
+
+  test('form reset clears stale marks off the now-empty composer', () => {
+    // form.reset() empties the textarea without an `input` event, so without the
+    // reset listener the previous draft's marks would linger and stay clickable.
+    const realRaf = window.requestAnimationFrame
+    window.requestAnimationFrame = (cb) => { cb(); return 0 }
+    try {
+      document.body.innerHTML = '<form><textarea></textarea></form>'
+      const form = document.querySelector('form')
+      const textarea = document.querySelector('textarea')
+      const tc = new TypoCorrector(textarea, { settings })
+      textarea.value = 'teh cat'
+      tc._applyResult({ edits: [{ original: 'teh', suggestion: 'the', confidence: 0.4 }], threshold: 80 })
+      expect(textarea.parentNode.querySelector('.typo-mark')).not.toBeNull()
+
+      form.reset()
+      expect(tc.edits).toHaveLength(0)
+      expect(textarea.parentNode.querySelector('.typo-mark')).toBeNull()
+    } finally {
+      window.requestAnimationFrame = realRaf
+    }
+  })
+
+  test('destroy unwraps the textarea and clears the bind marker (Turbo before-cache)', () => {
+    // Turbo caches the DOM but not JS listeners; the snapshot must not keep the
+    // injected backdrop or typoBound, or the restored page would duplicate the
+    // overlay / skip re-init and leave correction dead until a full reload.
+    document.body.innerHTML = '<form><textarea></textarea></form>'
+    const form = document.querySelector('form')
+    const textarea = document.querySelector('textarea')
+    textarea.dataset.typoBound = 'true'
+    const tc = new TypoCorrector(textarea, { settings })
+    expect(textarea.parentNode.classList.contains('typo-input-wrap')).toBe(true)
+
+    tc.destroy()
+    expect(textarea.dataset.typoBound).toBeUndefined()
+    expect(textarea.parentNode).toBe(form) // unwrapped back to the form
+    expect(form.querySelector('.typo-input-wrap')).toBeNull()
+    expect(form.querySelector('.typo-backdrop')).toBeNull()
+  })
 })

--- a/engines/collavre/app/javascript/modules/__tests__/typo_corrector.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/typo_corrector.test.js
@@ -178,6 +178,24 @@ describe('TypoCorrector DOM orchestration', () => {
     expect(detectCalls).toBe(1)
   })
 
+  test('clicking a mark opens the popup and the opening mousedown does not close it', () => {
+    // Regression: the popup opens on a mousedown. CommonPopup.showAt registered
+    // its document-level outside-click mousedown listener synchronously, so the
+    // very mousedown that opened the popup kept bubbling to document, hit that
+    // listener (target = the mark, outside the popup), and called hide() — the
+    // popup opened and instantly closed, so the user never saw it.
+    const { textarea, tc } = mount('teh cat')
+    tc._applyResult({
+      edits: [{ original: 'teh', suggestion: 'the', confidence: 0.4 }],
+      threshold: 80,
+    })
+    const mark = textarea.parentNode.querySelector('.typo-mark-candidate')
+    expect(mark).not.toBeNull()
+    mark.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))
+    expect(tc.popup.isOpen()).toBe(true)
+    expect(tc.popupEl.style.display).toBe('block')
+  })
+
   test('popup input carries a localized aria-label', () => {
     document.body.innerHTML = '<form><textarea></textarea></form>'
     const textarea = document.querySelector('textarea')

--- a/engines/collavre/app/javascript/modules/__tests__/typo_corrector.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/typo_corrector.test.js
@@ -289,11 +289,19 @@ describe('TypoCorrector DOM orchestration', () => {
     const tc = new TypoCorrector(textarea, { settings })
     expect(textarea.parentNode.classList.contains('typo-input-wrap')).toBe(true)
 
+    // The combobox popup lives on document.body, so destroy() must remove it too;
+    // otherwise the Turbo snapshot serializes an orphan popup and the next
+    // corrector appends a duplicate.
+    tc._ensurePopup()
+    expect(document.body.querySelector('.typo-popup')).not.toBeNull()
+
     tc.destroy()
     expect(textarea.dataset.typoBound).toBeUndefined()
     expect(textarea.parentNode).toBe(form) // unwrapped back to the form
     expect(form.querySelector('.typo-input-wrap')).toBeNull()
     expect(form.querySelector('.typo-backdrop')).toBeNull()
+    expect(document.body.querySelector('.typo-popup')).toBeNull()
+    expect(tc.popupEl).toBeNull()
   })
 
   test('earlier corrections stay clickable across detection rounds (not just the last)', () => {

--- a/engines/collavre/app/javascript/modules/__tests__/typo_corrector.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/typo_corrector.test.js
@@ -196,6 +196,37 @@ describe('TypoCorrector DOM orchestration', () => {
     expect(tc.popupEl.style.display).toBe('block')
   })
 
+  test('a mark re-opens the popup on a second click while it is still open', () => {
+    // Regression: showAt registers the document outside-click listener one frame
+    // after opening. Clicking the (still-open) mark again sends a mousedown that
+    // bubbles to that live listener, which hid the popup — and showAt's fresh rAF
+    // only re-flips visibility, never display, so the popup stayed display:none
+    // and every later click repeated the cycle (permanently dead after click 1).
+    // Use queued rAF so the listener registers AFTER the opening mousedown, as in
+    // a real browser.
+    const rafs = []
+    const realRaf = window.requestAnimationFrame
+    window.requestAnimationFrame = (cb) => { rafs.push(cb); return rafs.length }
+    const flush = () => rafs.splice(0).forEach((cb) => cb())
+    try {
+      const { textarea, tc } = mount('teh cat')
+      tc._applyResult({
+        edits: [{ original: 'teh', suggestion: 'the', confidence: 0.4 }],
+        threshold: 80,
+      })
+      const mark = () => textarea.parentNode.querySelector('.typo-mark-candidate')
+      mark().dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))
+      flush() // showAt's rAF registers the outside-click listener
+      expect(tc.popup.isOpen()).toBe(true)
+
+      mark().dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))
+      flush()
+      expect(tc.popup.isOpen()).toBe(true)
+    } finally {
+      window.requestAnimationFrame = realRaf
+    }
+  })
+
   test('opening the popup focuses and selects the input (desktop) for instant replace', () => {
     // showAt keeps the popup visibility:hidden until its own rAF, and a hidden
     // element is not focusable — so focus/select are deferred into a rAF that

--- a/engines/collavre/app/javascript/modules/__tests__/typo_corrector.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/typo_corrector.test.js
@@ -196,6 +196,27 @@ describe('TypoCorrector DOM orchestration', () => {
     expect(tc.popupEl.style.display).toBe('block')
   })
 
+  test('opening the popup focuses and selects the input (desktop) for instant replace', () => {
+    // showAt keeps the popup visibility:hidden until its own rAF, and a hidden
+    // element is not focusable — so focus/select are deferred into a rAF that
+    // runs after showAt's. Flush rAF synchronously to exercise that path.
+    const realRaf = window.requestAnimationFrame
+    window.requestAnimationFrame = (cb) => { cb(); return 0 }
+    try {
+      const { textarea, tc } = mount('teh cat')
+      tc._applyResult({
+        edits: [{ original: 'teh', suggestion: 'the', confidence: 0.4 }],
+        threshold: 80,
+      })
+      const mark = textarea.parentNode.querySelector('.typo-mark-candidate')
+      mark.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))
+      expect(document.activeElement).toBe(tc.popupInput)
+      expect(tc.popupInput.value).toBe('teh') // current word, pre-filled
+    } finally {
+      window.requestAnimationFrame = realRaf
+    }
+  })
+
   test('popup input carries a localized aria-label', () => {
     document.body.innerHTML = '<form><textarea></textarea></form>'
     const textarea = document.querySelector('textarea')

--- a/engines/collavre/app/javascript/modules/__tests__/typo_corrector.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/typo_corrector.test.js
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { TypoCorrector } from '../typo_corrector'
+import { TypoCorrector, initTypoCorrector } from '../typo_corrector'
 
 // Exercises the DOM orchestration that the pure-logic tests don't reach:
 // auto-applying high-confidence edits into the textarea (caret preserved),
@@ -336,5 +336,30 @@ describe('TypoCorrector DOM orchestration', () => {
     const byWord = Object.fromEntries(tc.edits.map((e) => [e.currentValue, e]))
     expect(textarea.value.slice(byWord['있습니다'].start, byWord['있습니다'].end)).toBe('있습니다')
     expect(textarea.value.slice(byWord['the'].start, byWord['the'].end)).toBe('the')
+  })
+})
+
+describe('initTypoCorrector endpoint wiring', () => {
+  afterEach(() => { document.body.innerHTML = '' })
+
+  function mountPopup(endpoint) {
+    document.body.innerHTML =
+      '<div id="comments-popup" data-typo-enabled="true" data-typo-threshold="80"' +
+      (endpoint == null ? '' : ' data-typo-endpoint="' + endpoint + '"') + '></div>' +
+      '<form id="new-comment-form"><textarea></textarea></form>'
+  }
+
+  // The engine can be mounted at a subpath (e.g. /collavre), so a root-relative
+  // default would 404. The endpoint must come from the engine-rendered dataset.
+  test('uses the mounted engine endpoint from the dataset', () => {
+    mountPopup('/collavre/typo_corrections')
+    const tc = initTypoCorrector()
+    expect(tc.endpoint).toBe('/collavre/typo_corrections')
+  })
+
+  test('falls back to the root-relative path when no endpoint is provided', () => {
+    mountPopup(null)
+    const tc = initTypoCorrector()
+    expect(tc.endpoint).toBe('/typo_corrections')
   })
 })

--- a/engines/collavre/app/javascript/modules/__tests__/typo_corrector.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/typo_corrector.test.js
@@ -99,4 +99,51 @@ describe('TypoCorrector DOM orchestration', () => {
     tc._repaint()
     expect(tc.edits).toHaveLength(0)
   })
+
+  test('device classification uses the input-time stamp, surviving the debounce (P1)', () => {
+    // Before the fix, the device was classified at detect time (after the 600ms
+    // debounce), so the keydown→detect gap read ~600ms and every physical
+    // keypress was misread as a soft keyboard — bypassing the default-off gate.
+    const realNow = performance.now
+    let t = 1000
+    performance.now = () => t
+    try {
+      const { textarea, tc } = mount('')
+      textarea.dispatchEvent(new KeyboardEvent('keydown', { key: 'a' })) // physical keydown @1000
+      t = 1002
+      textarea.value = 'a'
+      textarea.dispatchEvent(new Event('input', { bubbles: true })) // input @1002 → lastInputAt
+      t = 1700 // debounce fires ~700ms later, when _detect calls _currentDevice
+      expect(tc._currentDevice()).toBe('physical_keyboard')
+    } finally {
+      performance.now = realNow
+    }
+  })
+
+  test('auto-applied edit anchors to the corrected span, not an earlier twin (P2)', () => {
+    // "the teh" → correct the 2nd word. The highlight/undo must bind the second
+    // word (offset 4), not the pre-existing "the" at offset 0.
+    const { textarea, tc } = mount('the teh')
+    tc._applyResult({
+      edits: [{ original: 'teh', suggestion: 'the', confidence: 0.95, offset: 4 }],
+      threshold: 80,
+    })
+    expect(textarea.value).toBe('the the')
+    const edit = tc.edits.find((e) => e.state === 'applied')
+    expect(edit.start).toBe(4)
+    expect(edit.end).toBe(7)
+  })
+
+  test('undo of an auto-applied edit rewrites the corrected span, not an earlier twin (P2)', () => {
+    const { textarea, tc } = mount('the teh')
+    tc._applyResult({
+      edits: [{ original: 'teh', suggestion: 'the', confidence: 0.95, offset: 4 }],
+      threshold: 80,
+    })
+    const edit = tc.edits.find((e) => e.state === 'applied')
+    tc._ensurePopup()
+    tc._activeEdit = edit
+    tc._chooseValue('teh') // undo back to the original
+    expect(textarea.value).toBe('the teh')
+  })
 })

--- a/engines/collavre/app/javascript/modules/__tests__/typo_corrector.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/typo_corrector.test.js
@@ -158,4 +158,31 @@ describe('TypoCorrector DOM orchestration', () => {
     tc._chooseValue('teh') // undo back to the original
     expect(textarea.value).toBe('the teh')
   })
+
+  test('auto-apply does not re-trigger detection, so the undo affordance survives (P2)', () => {
+    const { textarea, tc } = mount('잇습니다')
+    let detectCalls = 0
+    tc._scheduleDetect = () => { detectCalls += 1 }
+    tc._applyResult({
+      edits: [{ original: '잇습니다', suggestion: '있습니다', confidence: 0.95 }],
+      threshold: 80,
+    })
+    // The synthetic `input` event from our own auto-apply must be swallowed: a
+    // re-detect would return [] on the now-clean text and wipe the highlight.
+    expect(detectCalls).toBe(0)
+    expect(textarea.parentNode.querySelector('.typo-mark-applied')).not.toBeNull()
+
+    // A *real* keystroke afterwards still schedules detection.
+    textarea.value = '있습니다 어쩌구'
+    textarea.dispatchEvent(new Event('input', { bubbles: true }))
+    expect(detectCalls).toBe(1)
+  })
+
+  test('popup input carries a localized aria-label', () => {
+    document.body.innerHTML = '<form><textarea></textarea></form>'
+    const textarea = document.querySelector('textarea')
+    const tc = new TypoCorrector(textarea, { settings, labels: { inputLabel: '교정' } })
+    tc._ensurePopup()
+    expect(tc.popupInput.getAttribute('aria-label')).toBe('교정')
+  })
 })

--- a/engines/collavre/app/javascript/modules/__tests__/typo_corrector.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/typo_corrector.test.js
@@ -1,0 +1,102 @@
+/**
+ * @jest-environment jsdom
+ */
+import { TypoCorrector } from '../typo_corrector'
+
+// Exercises the DOM orchestration that the pure-logic tests don't reach:
+// auto-applying high-confidence edits into the textarea (caret preserved),
+// painting the two highlight states onto the backdrop, and resolving an edit
+// through _chooseValue. Network is bypassed by calling _applyResult directly.
+
+const settings = {
+  enabled: true,
+  threshold: 80,
+  onVoice: true,
+  onSoftKeyboard: true,
+  onPhysicalKeyboard: false,
+  inChat: true,
+  inEditor: false,
+}
+
+function mount(value) {
+  document.body.innerHTML = '<form><textarea>' + value + '</textarea></form>'
+  const textarea = document.querySelector('textarea')
+  textarea.value = value
+  const tc = new TypoCorrector(textarea, { settings })
+  return { textarea, tc }
+}
+
+describe('TypoCorrector DOM orchestration', () => {
+  afterEach(() => { document.body.innerHTML = '' })
+
+  test('wraps textarea in a backdrop overlay', () => {
+    const { textarea } = mount('hello')
+    expect(textarea.parentNode.classList.contains('typo-input-wrap')).toBe(true)
+    expect(textarea.parentNode.querySelector('.typo-highlights')).not.toBeNull()
+  })
+
+  test('auto-applies a high-confidence edit into the textarea value', () => {
+    const { textarea, tc } = mount('잇습니다 그리고')
+    tc._applyResult({
+      edits: [{ original: '잇습니다', suggestion: '있습니다', confidence: 0.95 }],
+      threshold: 80,
+    })
+    expect(textarea.value).toBe('있습니다 그리고')
+    // The applied edit is highlighted with the "applied" (resolved) state.
+    const mark = textarea.parentNode.querySelector('.typo-mark-applied')
+    expect(mark).not.toBeNull()
+    expect(mark.textContent).toBe('있습니다')
+  })
+
+  test('low-confidence edit becomes a candidate highlight, text untouched', () => {
+    const { textarea, tc } = mount('teh cat')
+    tc._applyResult({
+      edits: [{ original: 'teh', suggestion: 'the', confidence: 0.4 }],
+      threshold: 80,
+    })
+    expect(textarea.value).toBe('teh cat') // not auto-applied
+    const mark = textarea.parentNode.querySelector('.typo-mark-candidate')
+    expect(mark).not.toBeNull()
+    expect(mark.textContent).toBe('teh')
+  })
+
+  test('choosing the suggestion applies it and clears the highlight', () => {
+    const { textarea, tc } = mount('teh cat')
+    tc._applyResult({
+      edits: [{ original: 'teh', suggestion: 'the', confidence: 0.4 }],
+      threshold: 80,
+    })
+    const edit = tc.edits[0]
+    tc._ensurePopup()
+    tc._activeEdit = edit
+    tc._chooseValue('the')
+    expect(textarea.value).toBe('the cat')
+    expect(textarea.parentNode.querySelector('.typo-mark')).toBeNull()
+  })
+
+  test('keeping (current value) just clears the highlight without changing text', () => {
+    const { textarea, tc } = mount('teh cat')
+    tc._applyResult({
+      edits: [{ original: 'teh', suggestion: 'the', confidence: 0.4 }],
+      threshold: 80,
+    })
+    const edit = tc.edits[0]
+    tc._ensurePopup()
+    tc._activeEdit = edit
+    tc._chooseValue('teh') // keep
+    expect(textarea.value).toBe('teh cat')
+    expect(tc.edits).toHaveLength(0)
+  })
+
+  test('typing past a highlighted span drops the stale highlight on repaint', () => {
+    const { textarea, tc } = mount('teh cat')
+    tc._applyResult({
+      edits: [{ original: 'teh', suggestion: 'the', confidence: 0.4 }],
+      threshold: 80,
+    })
+    expect(tc.edits).toHaveLength(1)
+    textarea.value = 'text cat' // user edited the span
+    tc._repaint()
+    expect(tc.edits).toHaveLength(0)
+  })
+})

--- a/engines/collavre/app/javascript/modules/__tests__/typo_corrector.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/typo_corrector.test.js
@@ -134,6 +134,18 @@ describe('TypoCorrector DOM orchestration', () => {
     expect(edit.end).toBe(7)
   })
 
+  test('popup renders option labels as text, never as HTML (DOM-XSS safe)', () => {
+    const { tc } = mount('teh cat')
+    tc._applyResult({ edits: [{ original: 'teh', suggestion: 'the', confidence: 0.4 }], threshold: 80 })
+    tc._ensurePopup()
+    tc._activeEdit = tc.edits[0]
+    const payload = '<img src=x onerror=alert(1)>'
+    tc.popup.setItems([{ value: payload, label: payload, role: 'custom' }])
+    const list = tc.popupEl.querySelector('.typo-popup-list')
+    expect(list.querySelector('img')).toBeNull() // not parsed as markup
+    expect(list.textContent).toContain(payload) // shown verbatim as text
+  })
+
   test('undo of an auto-applied edit rewrites the corrected span, not an earlier twin (P2)', () => {
     const { textarea, tc } = mount('the teh')
     tc._applyResult({

--- a/engines/collavre/app/javascript/modules/typo_corrector.js
+++ b/engines/collavre/app/javascript/modules/typo_corrector.js
@@ -154,6 +154,15 @@ export class TypoCorrector {
     this.textarea.removeEventListener('input', this._onInput)
     this.textarea.removeEventListener('scroll', this._onScroll)
     this.form?.removeEventListener('reset', this._onReset)
+    // Drop the combobox popup: it lives on document.body, so without this a Turbo
+    // page-cache snapshot serializes an orphan popup (stale options, no live
+    // instance) and the next corrector appends a duplicate. hide() also detaches
+    // CommonPopup's document-level outside-click listeners.
+    this.popup?.hide()
+    this.popupEl?.remove()
+    this.popupEl = null
+    this.popupInput = null
+    this.popup = null
     // Unwrap the textarea and drop the injected backdrop so a Turbo page-cache
     // snapshot doesn't serialize stale overlay DOM (it would duplicate on the
     // next build) or the bind marker (a restored snapshot keeps typoBound=true

--- a/engines/collavre/app/javascript/modules/typo_corrector.js
+++ b/engines/collavre/app/javascript/modules/typo_corrector.js
@@ -59,6 +59,7 @@ export class TypoCorrector {
 
     this.edits = [] // anchored edits currently painted: {start,end,original,suggestion,confidence,state}
     this.lastPrintableKeydownAt = null
+    this.lastInputAt = null
     this.debounceTimer = null
     this.requestSeq = 0
 
@@ -102,6 +103,11 @@ export class TypoCorrector {
       }
     }
     this._onInput = () => {
+      // Stamp the input time *now*, while the keydown→input relationship is still
+      // fresh. Classifying at detect time (after the debounce) would read a
+      // ~600ms gap and misread every physical keypress as a soft keyboard,
+      // defeating the default-off physical-keyboard gate.
+      this.lastInputAt = performance.now()
       this._syncScroll()
       this._repaint() // keep existing highlights aligned with edited text
       this._scheduleDetect()
@@ -129,7 +135,7 @@ export class TypoCorrector {
     return detectDevice({
       voiceActive: !!this.getVoiceActive(),
       lastPrintableKeydownAt: this.lastPrintableKeydownAt,
-      inputAt: performance.now(),
+      inputAt: this.lastInputAt,
     })
   }
 
@@ -172,66 +178,60 @@ export class TypoCorrector {
   }
 
   _applyResult({ edits = [], threshold = 80 } = {}) {
-    const anchored = anchorEdits(this.textarea.value, edits)
+    const original = this.textarea.value
+    const anchored = anchorEdits(original, edits)
     const { autoApplied, candidates } = partitionByThreshold(anchored, threshold)
 
-    // Auto-apply high-confidence edits to the textarea value, right-to-left so
-    // earlier offsets stay valid, preserving the caret.
-    const applied = []
-    let text = this.textarea.value
-    let caret = this.textarea.selectionStart
-    ;[...autoApplied].sort((a, b) => b.start - a.start).forEach((edit) => {
-      const { text: next } = applyEditAt(text, { start: edit.start, end: edit.end, replacement: edit.suggestion })
-      const delta = edit.suggestion.length - (edit.end - edit.start)
-      if (edit.start < caret) caret += delta
-      text = next
-      // Record where the corrected word now sits for the undo highlight.
-      applied.push({
-        original: edit.original,
-        suggestion: edit.suggestion,
-        confidence: edit.confidence,
-        state: 'applied',
-        currentValue: edit.suggestion,
-      })
-    })
-    if (text !== this.textarea.value) {
-      this.textarea.value = text
+    // Walk all edits left-to-right in one pass, rebuilding the text while
+    // tracking a running delta. This assigns each tracked edit an *exact* final
+    // span, rather than re-searching the corrected word by value afterwards —
+    // that search would bind to an earlier identical word (e.g. correcting the
+    // second "teh" in "the teh" lands the highlight on the first "the", so undo
+    // would rewrite the wrong word).
+    const events = [
+      ...autoApplied.map((e) => ({ ...e, kind: 'applied' })),
+      ...candidates.map((e) => ({ ...e, kind: 'candidate' })),
+    ].sort((a, b) => a.start - b.start)
+
+    const originalCaret = this.textarea.selectionStart
+    let out = ''
+    let cursor = 0
+    let delta = 0
+    let caret = originalCaret
+    const tracked = []
+    for (const e of events) {
+      if (e.start < cursor) continue // overlapping span; skip defensively
+      out += original.slice(cursor, e.start)
+      const finalStart = e.start + delta
+      if (e.kind === 'applied') {
+        out += e.suggestion
+        const d = e.suggestion.length - (e.end - e.start)
+        if (e.start < originalCaret) caret += d
+        delta += d
+        tracked.push({
+          original: e.original, suggestion: e.suggestion, confidence: e.confidence,
+          state: 'applied', currentValue: e.suggestion,
+          start: finalStart, end: finalStart + e.suggestion.length,
+        })
+      } else {
+        out += original.slice(e.start, e.end)
+        tracked.push({
+          original: e.original, suggestion: e.suggestion, confidence: e.confidence,
+          state: 'candidate', currentValue: e.original,
+          start: finalStart, end: finalStart + e.original.length,
+        })
+      }
+      cursor = e.end
+    }
+    out += original.slice(cursor)
+
+    this.edits = tracked
+    if (out !== original) {
+      this.textarea.value = out
       this.textarea.setSelectionRange(caret, caret)
       this.textarea.dispatchEvent(new Event('input', { bubbles: true }))
     }
-
-    const candidateEntries = candidates.map((edit) => ({
-      original: edit.original,
-      suggestion: edit.suggestion,
-      confidence: edit.confidence,
-      state: 'candidate',
-      currentValue: edit.original,
-    }))
-
-    // Re-anchor everything against the (possibly mutated) final text.
-    this.edits = this._reanchorAll([...applied, ...candidateEntries])
     this._repaint()
-  }
-
-  // Re-find each tracked edit's span in the current text by its current value
-  // (corrected word for applied, original for candidate). Entries that no longer
-  // exist are dropped.
-  _reanchorAll(entries) {
-    const text = this.textarea.value
-    const out = []
-    let cursor = 0
-    // Keep input order but anchor monotonically so duplicate words bind distinctly.
-    const ordered = entries
-      .map((e) => ({ e, idx: text.indexOf(e.currentValue) }))
-      .filter((x) => x.idx !== -1)
-      .sort((a, b) => a.idx - b.idx)
-    for (const { e } of ordered) {
-      const idx = text.indexOf(e.currentValue, cursor)
-      if (idx === -1) continue
-      out.push({ ...e, start: idx, end: idx + e.currentValue.length })
-      cursor = idx + e.currentValue.length
-    }
-    return out
   }
 
   _clear() {

--- a/engines/collavre/app/javascript/modules/typo_corrector.js
+++ b/engines/collavre/app/javascript/modules/typo_corrector.js
@@ -294,10 +294,24 @@ export class TypoCorrector {
 
     this.popup = new CommonPopup(el, {
       listElement: el.querySelector('.typo-popup-list'),
+      // Return a DOM node, not an HTML string: item.label is user-typed /
+      // model-suggested text, so we set it via textContent and never route it
+      // through innerHTML (avoids any DOM-text-as-HTML reinterpretation).
       renderItem: (item) => {
-        const tag = item.role === 'original' ? ` <span class="typo-popup-role">(${escapeHtml(this.labels.keep)})</span>`
-          : item.role === 'custom' ? ` <span class="typo-popup-role">(${escapeHtml(this.labels.custom)})</span>` : ''
-        return `<span class="typo-popup-value">${escapeHtml(item.label)}</span>${tag}`
+        const frag = document.createDocumentFragment()
+        const value = document.createElement('span')
+        value.className = 'typo-popup-value'
+        value.textContent = item.label
+        frag.appendChild(value)
+        const roleLabel = item.role === 'original' ? this.labels.keep
+          : item.role === 'custom' ? this.labels.custom : null
+        if (roleLabel) {
+          const role = document.createElement('span')
+          role.className = 'typo-popup-role'
+          role.textContent = ` (${roleLabel})`
+          frag.appendChild(role)
+        }
+        return frag
       },
       onSelect: (item) => this._chooseValue(item.value),
       onClose: () => { this._activeEdit = null },

--- a/engines/collavre/app/javascript/modules/typo_corrector.js
+++ b/engines/collavre/app/javascript/modules/typo_corrector.js
@@ -58,7 +58,11 @@ export class TypoCorrector {
     this.location = location
     this.endpoint = endpoint
     this.getVoiceActive = getVoiceActive
-    this.labels = { keep: labels.keep || 'keep', custom: labels.custom || 'custom' }
+    this.labels = {
+      keep: labels.keep || 'keep',
+      custom: labels.custom || 'custom',
+      inputLabel: labels.inputLabel || 'correction',
+    }
 
     this.edits = [] // anchored edits currently painted: {start,end,original,suggestion,confidence,state}
     this.lastPrintableKeydownAt = null
@@ -113,6 +117,15 @@ export class TypoCorrector {
       this.lastInputAt = performance.now()
       this._syncScroll()
       this._repaint() // keep existing highlights aligned with edited text
+      // Our own auto-apply dispatches a synthetic `input` so other listeners
+      // (auto-resize, draft save, send-button state) update. We must NOT let it
+      // re-trigger detection: the corrected text has no typos, so the follow-up
+      // would return [] and wipe the just-applied underline/undo affordance
+      // before the user can click it. Real keystrokes still schedule detection.
+      if (this.suppressNextDetect) {
+        this.suppressNextDetect = false
+        return
+      }
       this._scheduleDetect()
     }
     this._onScroll = () => this._syncScroll()
@@ -232,6 +245,9 @@ export class TypoCorrector {
     if (out !== original) {
       this.textarea.value = out
       this.textarea.setSelectionRange(caret, caret)
+      // Our own mutation: notify other listeners but don't re-run detection (it
+      // would return [] on the now-clean text and wipe these fresh highlights).
+      this.suppressNextDetect = true
       this.textarea.dispatchEvent(new Event('input', { bubbles: true }))
     }
     this._repaint()
@@ -289,11 +305,14 @@ export class TypoCorrector {
     el.className = 'typo-popup common-popup'
     el.style.display = 'none'
     el.innerHTML = `
-      <input type="text" class="typo-popup-input" aria-label="correction" />
+      <input type="text" class="typo-popup-input" />
       <ul class="typo-popup-list" data-popup-list></ul>`
     document.body.appendChild(el)
     this.popupEl = el
     this.popupInput = el.querySelector('.typo-popup-input')
+    // Localized assistive label (set via setAttribute, not innerHTML, so the
+    // value is never parsed as markup).
+    this.popupInput.setAttribute('aria-label', this.labels.inputLabel)
 
     this.popup = new CommonPopup(el, {
       listElement: el.querySelector('.typo-popup-list'),
@@ -382,6 +401,9 @@ export class TypoCorrector {
         edit.start,
         delta,
       )
+      // Our own mutation: don't re-detect (it would overwrite the remaining
+      // candidate highlights we just shifted to keep them aligned).
+      this.suppressNextDetect = true
       this.textarea.dispatchEvent(new Event('input', { bubbles: true }))
     } else {
       // "Keep" — user resolved it; remove the highlight.
@@ -424,7 +446,11 @@ export function initTypoCorrector() {
     settings,
     location: 'chat',
     getVoiceActive: () => voiceButton?.dataset.voiceState === 'listening',
-    labels: { keep: root.dataset.typoKeepLabel, custom: root.dataset.typoCustomLabel },
+    labels: {
+      keep: root.dataset.typoKeepLabel,
+      custom: root.dataset.typoCustomLabel,
+      inputLabel: root.dataset.typoInputLabel,
+    },
   })
 }
 

--- a/engines/collavre/app/javascript/modules/typo_corrector.js
+++ b/engines/collavre/app/javascript/modules/typo_corrector.js
@@ -41,11 +41,14 @@ const MIRRORED_STYLES = [
   'lineHeight', 'letterSpacing', 'textTransform', 'wordSpacing', 'textIndent',
 ]
 
+// Escape by round-tripping through textContent: the browser never reinterprets
+// it as markup, and it's the canonical DOM-text sanitizer (recognized as a
+// barrier by static XSS analysis) for the values we splice into the backdrop and
+// popup HTML — both of which carry user-typed / model-suggested text.
 function escapeHtml(value) {
-  return String(value)
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
+  const el = document.createElement('div')
+  el.textContent = String(value)
+  return el.innerHTML
 }
 
 export class TypoCorrector {
@@ -294,24 +297,12 @@ export class TypoCorrector {
 
     this.popup = new CommonPopup(el, {
       listElement: el.querySelector('.typo-popup-list'),
-      // Return a DOM node, not an HTML string: item.label is user-typed /
-      // model-suggested text, so we set it via textContent and never route it
-      // through innerHTML (avoids any DOM-text-as-HTML reinterpretation).
+      // item.label is user-typed / model-suggested text; escapeHtml round-trips
+      // it through textContent so it can never be reinterpreted as markup.
       renderItem: (item) => {
-        const frag = document.createDocumentFragment()
-        const value = document.createElement('span')
-        value.className = 'typo-popup-value'
-        value.textContent = item.label
-        frag.appendChild(value)
-        const roleLabel = item.role === 'original' ? this.labels.keep
-          : item.role === 'custom' ? this.labels.custom : null
-        if (roleLabel) {
-          const role = document.createElement('span')
-          role.className = 'typo-popup-role'
-          role.textContent = ` (${roleLabel})`
-          frag.appendChild(role)
-        }
-        return frag
+        const tag = item.role === 'original' ? ` <span class="typo-popup-role">(${escapeHtml(this.labels.keep)})</span>`
+          : item.role === 'custom' ? ` <span class="typo-popup-role">(${escapeHtml(this.labels.custom)})</span>` : ''
+        return `<span class="typo-popup-value">${escapeHtml(item.label)}</span>${tag}`
       },
       onSelect: (item) => this._chooseValue(item.value),
       onClose: () => { this._activeEdit = null },

--- a/engines/collavre/app/javascript/modules/typo_corrector.js
+++ b/engines/collavre/app/javascript/modules/typo_corrector.js
@@ -370,11 +370,17 @@ export class TypoCorrector {
     this.popupInput.value = edit.currentValue
     this._refreshPopupItems('')
     this.popup.showAt(anchorEl.getBoundingClientRect())
-    // Desktop: select-all so a keystroke replaces. Mobile keyboard is left to an
-    // explicit tap on the input (no auto-focus) — chip taps are the primary path.
+    // Desktop: focus + select-all so a keystroke immediately replaces the word.
+    // Mobile keyboard is left to an explicit tap on the input (no auto-focus) —
+    // chip taps are the primary path.
+    // showAt() keeps the popup visibility:hidden until its own rAF (so it can
+    // position off-screen first); focus()/select() are no-ops while hidden, so
+    // defer them into a rAF that runs after showAt's (FIFO, registered later).
     if (!this._isCoarsePointer()) {
-      this.popupInput.focus()
-      this.popupInput.select()
+      requestAnimationFrame(() => {
+        this.popupInput.focus()
+        this.popupInput.select()
+      })
     }
   }
 

--- a/engines/collavre/app/javascript/modules/typo_corrector.js
+++ b/engines/collavre/app/javascript/modules/typo_corrector.js
@@ -1,0 +1,429 @@
+// Inline typo correction for the chat composer (Phase 1).
+//
+// Wires the chat textarea to the server endpoint and paints a *volatile*
+// highlight overlay: a mirror "backdrop" div sitting exactly behind the textarea
+// with <mark> spans over each edit span. The textarea value stays the single
+// source of truth — the backdrop is aria-hidden and never serialized, so
+// markdown-canonical storage never sees a highlight.
+//
+// Two highlight states (shape + colour, for colour-blind safety):
+//   - auto-applied (confidence >= threshold): faint straight underline
+//   - candidate    (below threshold):         wavy dotted underline (needs decision)
+//
+// Clicking a highlight opens a creatable combobox (reusing CommonPopup for
+// positioning + list + keyboard nav) pre-filled with the word currently in the
+// document, so Enter = keep. Typing adds the typed word as an always-present,
+// auto-selected custom option.
+
+import CommonPopup from '../lib/common_popup'
+import csrfFetch from '../lib/api/csrf_fetch'
+import {
+  detectDevice,
+  shouldRun,
+  buildCandidateList,
+  anchorEdits,
+  applyEditAt,
+  shiftEditsAfter,
+  partitionByThreshold,
+} from '../lib/typo_correction'
+
+const DEBOUNCE_MS = 600
+const PRINTABLE_KEYDOWN_TTL_MS = 50
+
+let initialized = false
+
+// Mirror the textarea's box metrics onto the backdrop so highlight spans land on
+// the exact glyphs. Only the properties that affect text layout are copied.
+const MIRRORED_STYLES = [
+  'boxSizing', 'width', 'height', 'paddingTop', 'paddingRight', 'paddingBottom',
+  'paddingLeft', 'borderTopWidth', 'borderRightWidth', 'borderBottomWidth',
+  'borderLeftWidth', 'fontFamily', 'fontSize', 'fontWeight', 'fontStyle',
+  'lineHeight', 'letterSpacing', 'textTransform', 'wordSpacing', 'textIndent',
+]
+
+function escapeHtml(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+}
+
+export class TypoCorrector {
+  constructor(textarea, { settings, location = 'chat', endpoint = '/typo_corrections', getVoiceActive = () => false, labels = {} } = {}) {
+    this.textarea = textarea
+    this.settings = settings
+    this.location = location
+    this.endpoint = endpoint
+    this.getVoiceActive = getVoiceActive
+    this.labels = { keep: labels.keep || 'keep', custom: labels.custom || 'custom' }
+
+    this.edits = [] // anchored edits currently painted: {start,end,original,suggestion,confidence,state}
+    this.lastPrintableKeydownAt = null
+    this.debounceTimer = null
+    this.requestSeq = 0
+
+    this._buildBackdrop()
+    this._bind()
+  }
+
+  _buildBackdrop() {
+    const ta = this.textarea
+    const wrap = document.createElement('div')
+    wrap.className = 'typo-input-wrap'
+    ta.parentNode.insertBefore(wrap, ta)
+
+    this.backdrop = document.createElement('div')
+    this.backdrop.className = 'typo-backdrop'
+    this.backdrop.setAttribute('aria-hidden', 'true')
+    this.highlightLayer = document.createElement('div')
+    this.highlightLayer.className = 'typo-highlights'
+    this.backdrop.appendChild(this.highlightLayer)
+
+    wrap.appendChild(this.backdrop)
+    wrap.appendChild(ta)
+    this._syncBackdropStyle()
+  }
+
+  _syncBackdropStyle() {
+    const computed = getComputedStyle(this.textarea)
+    MIRRORED_STYLES.forEach((prop) => {
+      this.highlightLayer.style[prop] = computed[prop]
+    })
+    // The textarea's own border is transparent-mirrored via padding offsets.
+    this.highlightLayer.style.borderColor = 'transparent'
+    this.highlightLayer.style.borderStyle = 'solid'
+  }
+
+  _bind() {
+    this._onKeydown = (event) => {
+      // A printable keydown immediately preceding the input marks a physical key.
+      if (event.key && event.key.length === 1 && !event.ctrlKey && !event.metaKey) {
+        this.lastPrintableKeydownAt = performance.now()
+      }
+    }
+    this._onInput = () => {
+      this._syncScroll()
+      this._repaint() // keep existing highlights aligned with edited text
+      this._scheduleDetect()
+    }
+    this._onScroll = () => this._syncScroll()
+
+    this.textarea.addEventListener('keydown', this._onKeydown)
+    this.textarea.addEventListener('input', this._onInput)
+    this.textarea.addEventListener('scroll', this._onScroll)
+  }
+
+  destroy() {
+    clearTimeout(this.debounceTimer)
+    this.textarea.removeEventListener('keydown', this._onKeydown)
+    this.textarea.removeEventListener('input', this._onInput)
+    this.textarea.removeEventListener('scroll', this._onScroll)
+  }
+
+  _syncScroll() {
+    this.backdrop.scrollTop = this.textarea.scrollTop
+    this.backdrop.scrollLeft = this.textarea.scrollLeft
+  }
+
+  _currentDevice() {
+    return detectDevice({
+      voiceActive: !!this.getVoiceActive(),
+      lastPrintableKeydownAt: this.lastPrintableKeydownAt,
+      inputAt: performance.now(),
+    })
+  }
+
+  _scheduleDetect() {
+    clearTimeout(this.debounceTimer)
+    this.debounceTimer = setTimeout(() => this._detect(), DEBOUNCE_MS)
+  }
+
+  async _detect() {
+    const device = this._currentDevice();
+    // Reset the printable-keydown marker so a stale value can't mis-classify the
+    // next standalone input (e.g. soft-keyboard insert after a physical keypress).
+    if (this.lastPrintableKeydownAt != null && performance.now() - this.lastPrintableKeydownAt > PRINTABLE_KEYDOWN_TTL_MS) {
+      this.lastPrintableKeydownAt = null
+    }
+
+    if (!shouldRun(this.settings, { device, location: this.location })) return
+    const text = this.textarea.value
+    if (!text.trim()) { this._clear(); return }
+
+    const seq = ++this.requestSeq
+    let payload
+    try {
+      const res = await csrfFetch(this.endpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+        body: JSON.stringify({ text, device, location: this.location }),
+      })
+      if (!res.ok) return
+      payload = await res.json()
+    } catch {
+      return
+    }
+    if (seq !== this.requestSeq) return // a newer keystroke superseded this one
+    // The text may have changed while the request was in flight; only act if the
+    // edits still anchor to the *current* textarea value.
+    if (this.textarea.value !== text) return
+
+    this._applyResult(payload)
+  }
+
+  _applyResult({ edits = [], threshold = 80 } = {}) {
+    const anchored = anchorEdits(this.textarea.value, edits)
+    const { autoApplied, candidates } = partitionByThreshold(anchored, threshold)
+
+    // Auto-apply high-confidence edits to the textarea value, right-to-left so
+    // earlier offsets stay valid, preserving the caret.
+    const applied = []
+    let text = this.textarea.value
+    let caret = this.textarea.selectionStart
+    ;[...autoApplied].sort((a, b) => b.start - a.start).forEach((edit) => {
+      const { text: next } = applyEditAt(text, { start: edit.start, end: edit.end, replacement: edit.suggestion })
+      const delta = edit.suggestion.length - (edit.end - edit.start)
+      if (edit.start < caret) caret += delta
+      text = next
+      // Record where the corrected word now sits for the undo highlight.
+      applied.push({
+        original: edit.original,
+        suggestion: edit.suggestion,
+        confidence: edit.confidence,
+        state: 'applied',
+        currentValue: edit.suggestion,
+      })
+    })
+    if (text !== this.textarea.value) {
+      this.textarea.value = text
+      this.textarea.setSelectionRange(caret, caret)
+      this.textarea.dispatchEvent(new Event('input', { bubbles: true }))
+    }
+
+    const candidateEntries = candidates.map((edit) => ({
+      original: edit.original,
+      suggestion: edit.suggestion,
+      confidence: edit.confidence,
+      state: 'candidate',
+      currentValue: edit.original,
+    }))
+
+    // Re-anchor everything against the (possibly mutated) final text.
+    this.edits = this._reanchorAll([...applied, ...candidateEntries])
+    this._repaint()
+  }
+
+  // Re-find each tracked edit's span in the current text by its current value
+  // (corrected word for applied, original for candidate). Entries that no longer
+  // exist are dropped.
+  _reanchorAll(entries) {
+    const text = this.textarea.value
+    const out = []
+    let cursor = 0
+    // Keep input order but anchor monotonically so duplicate words bind distinctly.
+    const ordered = entries
+      .map((e) => ({ e, idx: text.indexOf(e.currentValue) }))
+      .filter((x) => x.idx !== -1)
+      .sort((a, b) => a.idx - b.idx)
+    for (const { e } of ordered) {
+      const idx = text.indexOf(e.currentValue, cursor)
+      if (idx === -1) continue
+      out.push({ ...e, start: idx, end: idx + e.currentValue.length })
+      cursor = idx + e.currentValue.length
+    }
+    return out
+  }
+
+  _clear() {
+    this.edits = []
+    this._repaint()
+  }
+
+  // Paint the backdrop: plain text with <mark> spans over each edit. Marks carry
+  // the state class so CSS renders the two underline styles.
+  _repaint() {
+    // Drop edits that no longer match the live text (user kept typing).
+    const text = this.textarea.value
+    this.edits = this.edits.filter((e) => text.slice(e.start, e.end) === e.currentValue)
+
+    if (this.edits.length === 0) {
+      this.highlightLayer.textContent = text
+      return
+    }
+    const sorted = [...this.edits].sort((a, b) => a.start - b.start)
+    let html = ''
+    let cursor = 0
+    sorted.forEach((edit, i) => {
+      if (edit.start < cursor) return // overlapping; skip
+      html += escapeHtml(text.slice(cursor, edit.start))
+      const cls = edit.state === 'applied' ? 'typo-mark typo-mark-applied' : 'typo-mark typo-mark-candidate'
+      html += `<mark class="${cls}" data-typo-index="${i}">${escapeHtml(text.slice(edit.start, edit.end))}</mark>`
+      cursor = edit.end
+    })
+    html += escapeHtml(text.slice(cursor))
+    this.highlightLayer.innerHTML = html
+    this._wireMarks(sorted)
+    this._syncScroll()
+  }
+
+  // <mark> has pointer-events:auto (the rest of the backdrop is none), so clicks
+  // land on a highlighted word and open the combobox there.
+  _wireMarks(sorted) {
+    this.highlightLayer.querySelectorAll('.typo-mark').forEach((mark) => {
+      const idx = Number(mark.dataset.typoIndex)
+      const edit = sorted[idx]
+      if (!edit) return
+      mark.addEventListener('mousedown', (event) => {
+        event.preventDefault()
+        this._openPopup(edit, mark)
+      })
+    })
+  }
+
+  _ensurePopup() {
+    if (this.popupEl) return
+    const el = document.createElement('div')
+    el.className = 'typo-popup common-popup'
+    el.style.display = 'none'
+    el.innerHTML = `
+      <input type="text" class="typo-popup-input" aria-label="correction" />
+      <ul class="typo-popup-list" data-popup-list></ul>`
+    document.body.appendChild(el)
+    this.popupEl = el
+    this.popupInput = el.querySelector('.typo-popup-input')
+
+    this.popup = new CommonPopup(el, {
+      listElement: el.querySelector('.typo-popup-list'),
+      renderItem: (item) => {
+        const tag = item.role === 'original' ? ` <span class="typo-popup-role">(${escapeHtml(this.labels.keep)})</span>`
+          : item.role === 'custom' ? ` <span class="typo-popup-role">(${escapeHtml(this.labels.custom)})</span>` : ''
+        return `<span class="typo-popup-value">${escapeHtml(item.label)}</span>${tag}`
+      },
+      onSelect: (item) => this._chooseValue(item.value),
+      onClose: () => { this._activeEdit = null },
+    })
+
+    // Typing builds a creatable option and keeps input ↔ list bound.
+    this.popupInput.addEventListener('input', () => this._refreshPopupItems(this.popupInput.value))
+    this.popupInput.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter') {
+        event.preventDefault()
+        this._chooseValue(this.popupInput.value)
+        return
+      }
+      if (this.popup.handleKey(event)) {
+        // Sync the input to the active list item (arrow navigation).
+        const active = this.popup.items[this.popup.activeIndex]
+        if (active) this.popupInput.value = active.value
+      }
+    })
+  }
+
+  _refreshPopupItems(typed) {
+    const edit = this._activeEdit
+    if (!edit) return
+    let items = buildCandidateList({
+      currentValue: edit.currentValue,
+      originalWord: edit.original,
+      suggestions: [{ suggestion: edit.suggestion, confidence: edit.confidence }],
+    })
+    const trimmed = (typed || '').trim()
+    if (trimmed && !items.some((i) => i.value === trimmed)) {
+      // Creatable: the typed word is always present and auto-selected.
+      items = [{ value: trimmed, label: trimmed, role: 'custom', isCurrent: false }, ...items]
+    }
+    this.popup.setItems(items)
+    // Auto-select the typed custom entry, else the current document value.
+    const selectIndex = trimmed
+      ? Math.max(0, items.findIndex((i) => i.value === trimmed))
+      : Math.max(0, items.findIndex((i) => i.isCurrent))
+    this.popup.setActiveIndex(selectIndex)
+  }
+
+  _openPopup(edit, anchorEl) {
+    this._ensurePopup()
+    this._activeEdit = edit
+    this.popupInput.value = edit.currentValue
+    this._refreshPopupItems('')
+    this.popup.showAt(anchorEl.getBoundingClientRect())
+    // Desktop: select-all so a keystroke replaces. Mobile keyboard is left to an
+    // explicit tap on the input (no auto-focus) — chip taps are the primary path.
+    if (!this._isCoarsePointer()) {
+      this.popupInput.focus()
+      this.popupInput.select()
+    }
+  }
+
+  _isCoarsePointer() {
+    return typeof window.matchMedia === 'function' && window.matchMedia('(pointer: coarse)').matches
+  }
+
+  _chooseValue(value) {
+    const edit = this._activeEdit
+    if (edit == null || value == null) { this.popup?.hide(); return }
+    const replacement = String(value)
+
+    if (replacement !== edit.currentValue) {
+      const { text, delta } = applyEditAt(this.textarea.value, {
+        start: edit.start, end: edit.end, replacement,
+      })
+      let caret = this.textarea.selectionStart
+      if (edit.start < caret) caret += delta
+      this.textarea.value = text
+      this.textarea.setSelectionRange(caret, caret)
+      // Shift later edits, then drop this one (it's now user-confirmed).
+      this.edits = shiftEditsAfter(
+        this.edits.filter((e) => e !== edit),
+        edit.start,
+        delta,
+      )
+      this.textarea.dispatchEvent(new Event('input', { bubbles: true }))
+    } else {
+      // "Keep" — user resolved it; remove the highlight.
+      this.edits = this.edits.filter((e) => e !== edit)
+    }
+
+    this.popup?.hide()
+    this._repaint()
+    this.textarea.focus()
+  }
+}
+
+// Module-scope init, mirroring mention_menu.js. Reads settings exposed by the
+// server on #comments-popup and only attaches when the master switch is on.
+function readSettings(root) {
+  if (!root) return null
+  const d = root.dataset
+  if (d.typoEnabled == null) return null
+  return {
+    enabled: d.typoEnabled === 'true',
+    threshold: parseInt(d.typoThreshold, 10) || 80,
+    onVoice: d.typoOnVoice === 'true',
+    onSoftKeyboard: d.typoOnSoftKeyboard === 'true',
+    onPhysicalKeyboard: d.typoOnPhysicalKeyboard === 'true',
+    inChat: d.typoInChat === 'true',
+    inEditor: d.typoInEditor === 'true',
+  }
+}
+
+export function initTypoCorrector() {
+  const textarea = document.querySelector('#new-comment-form textarea')
+  const root = document.getElementById('comments-popup')
+  const settings = readSettings(root)
+  if (!textarea || !settings || !settings.enabled) return null
+  if (textarea.dataset.typoBound === 'true') return null
+  textarea.dataset.typoBound = 'true'
+
+  const voiceButton = document.getElementById('voice-comments-btn')
+  return new TypoCorrector(textarea, {
+    settings,
+    location: 'chat',
+    getVoiceActive: () => voiceButton?.dataset.voiceState === 'listening',
+    labels: { keep: root.dataset.typoKeepLabel, custom: root.dataset.typoCustomLabel },
+  })
+}
+
+if (!initialized) {
+  initialized = true
+  document.addEventListener('turbo:load', initTypoCorrector)
+}

--- a/engines/collavre/app/javascript/modules/typo_corrector.js
+++ b/engines/collavre/app/javascript/modules/typo_corrector.js
@@ -129,10 +129,23 @@ export class TypoCorrector {
       this._scheduleDetect()
     }
     this._onScroll = () => this._syncScroll()
+    // form.reset() (after a comment sends, or on cancel) empties the textarea
+    // WITHOUT firing an `input` event, so our repaint never runs and stale marks
+    // would linger over the now-empty composer — still clickable, applying stale
+    // offsets to the empty value. The `reset` event fires before the control is
+    // cleared, so drop the edits now and repaint next frame once it's empty.
+    this._onReset = () => {
+      clearTimeout(this.debounceTimer)
+      this.requestSeq++ // invalidate any in-flight detection response
+      this.edits = []
+      requestAnimationFrame(() => this._repaint())
+    }
 
+    this.form = this.textarea.form
     this.textarea.addEventListener('keydown', this._onKeydown)
     this.textarea.addEventListener('input', this._onInput)
     this.textarea.addEventListener('scroll', this._onScroll)
+    this.form?.addEventListener('reset', this._onReset)
   }
 
   destroy() {
@@ -140,6 +153,18 @@ export class TypoCorrector {
     this.textarea.removeEventListener('keydown', this._onKeydown)
     this.textarea.removeEventListener('input', this._onInput)
     this.textarea.removeEventListener('scroll', this._onScroll)
+    this.form?.removeEventListener('reset', this._onReset)
+    // Unwrap the textarea and drop the injected backdrop so a Turbo page-cache
+    // snapshot doesn't serialize stale overlay DOM (it would duplicate on the
+    // next build) or the bind marker (a restored snapshot keeps typoBound=true
+    // but loses the JS listeners, so re-init is skipped and correction stays
+    // dead until a full reload).
+    const wrap = this.backdrop?.parentNode
+    if (wrap && wrap.parentNode) {
+      wrap.parentNode.insertBefore(this.textarea, wrap)
+      wrap.remove()
+    }
+    delete this.textarea.dataset.typoBound
   }
 
   _syncScroll() {
@@ -439,6 +464,8 @@ function readSettings(root) {
   }
 }
 
+let activeInstance = null
+
 export function initTypoCorrector() {
   const textarea = document.querySelector('#new-comment-form textarea')
   const root = document.getElementById('comments-popup')
@@ -448,7 +475,7 @@ export function initTypoCorrector() {
   textarea.dataset.typoBound = 'true'
 
   const voiceButton = document.getElementById('voice-comments-btn')
-  return new TypoCorrector(textarea, {
+  activeInstance = new TypoCorrector(textarea, {
     settings,
     location: 'chat',
     getVoiceActive: () => voiceButton?.dataset.voiceState === 'listening',
@@ -458,9 +485,20 @@ export function initTypoCorrector() {
       inputLabel: root.dataset.typoInputLabel,
     },
   })
+  return activeInstance
+}
+
+export function teardownTypoCorrector() {
+  if (!activeInstance) return
+  activeInstance.destroy()
+  activeInstance = null
 }
 
 if (!initialized) {
   initialized = true
   document.addEventListener('turbo:load', initTypoCorrector)
+  // Turbo caches a DOM snapshot on navigation but not the JS listeners. Tear the
+  // instance down (clearing the bind marker + injected DOM) before the snapshot
+  // is taken so a restored page re-initializes cleanly instead of skipping init.
+  document.addEventListener('turbo:before-cache', teardownTypoCorrector)
 }

--- a/engines/collavre/app/javascript/modules/typo_corrector.js
+++ b/engines/collavre/app/javascript/modules/typo_corrector.js
@@ -223,16 +223,31 @@ export class TypoCorrector {
     const anchored = anchorEdits(original, edits)
     const { autoApplied, candidates } = partitionByThreshold(anchored, threshold)
 
+    // This round's edits. `apply` rewrites the word; `keep` leaves the text as-is
+    // (a low-confidence candidate awaiting a decision).
+    const incoming = [
+      ...autoApplied.map((e) => ({ ...e, kind: 'apply' })),
+      ...candidates.map((e) => ({ ...e, kind: 'keep', state: 'candidate', currentValue: e.original })),
+    ]
+
+    // Carry forward earlier corrections that are still anchored in the live text
+    // and don't collide with this round. The server is stateless and never
+    // re-reports an already-corrected word, so without this every detection round
+    // would wipe the prior correction's mark and leave only the most recent one
+    // clickable. Already-applied survivors sit in the text unchanged, so they're
+    // re-emitted in place (kind 'keep'), not re-applied.
+    const survivors = this.edits
+      .filter((p) => original.slice(p.start, p.end) === p.currentValue)
+      .filter((p) => !incoming.some((n) => n.start < p.end && p.start < n.end))
+      .map((p) => ({ ...p, kind: 'keep' }))
+
     // Walk all edits left-to-right in one pass, rebuilding the text while
     // tracking a running delta. This assigns each tracked edit an *exact* final
     // span, rather than re-searching the corrected word by value afterwards —
     // that search would bind to an earlier identical word (e.g. correcting the
     // second "teh" in "the teh" lands the highlight on the first "the", so undo
     // would rewrite the wrong word).
-    const events = [
-      ...autoApplied.map((e) => ({ ...e, kind: 'applied' })),
-      ...candidates.map((e) => ({ ...e, kind: 'candidate' })),
-    ].sort((a, b) => a.start - b.start)
+    const events = [...incoming, ...survivors].sort((a, b) => a.start - b.start)
 
     const originalCaret = this.textarea.selectionStart
     let out = ''
@@ -244,7 +259,7 @@ export class TypoCorrector {
       if (e.start < cursor) continue // overlapping span; skip defensively
       out += original.slice(cursor, e.start)
       const finalStart = e.start + delta
-      if (e.kind === 'applied') {
+      if (e.kind === 'apply') {
         out += e.suggestion
         const d = e.suggestion.length - (e.end - e.start)
         if (e.start < originalCaret) caret += d
@@ -255,11 +270,14 @@ export class TypoCorrector {
           start: finalStart, end: finalStart + e.suggestion.length,
         })
       } else {
-        out += original.slice(e.start, e.end)
+        // 'keep': a new candidate or a carried-forward survivor — text unchanged,
+        // so re-emit the current slice and preserve its existing state.
+        const slice = original.slice(e.start, e.end)
+        out += slice
         tracked.push({
           original: e.original, suggestion: e.suggestion, confidence: e.confidence,
-          state: 'candidate', currentValue: e.original,
-          start: finalStart, end: finalStart + e.original.length,
+          state: e.state, currentValue: e.currentValue,
+          start: finalStart, end: finalStart + slice.length,
         })
       }
       cursor = e.end

--- a/engines/collavre/app/javascript/modules/typo_corrector.js
+++ b/engines/collavre/app/javascript/modules/typo_corrector.js
@@ -505,6 +505,9 @@ export function initTypoCorrector() {
   activeInstance = new TypoCorrector(textarea, {
     settings,
     location: 'chat',
+    // Use the mounted engine path (e.g. /collavre/typo_corrections) so requests
+    // don't 404 when Collavre is mounted at a subpath instead of root.
+    endpoint: root.dataset.typoEndpoint || '/typo_corrections',
     getVoiceActive: () => voiceButton?.dataset.voiceState === 'listening',
     labels: {
       keep: root.dataset.typoKeepLabel,

--- a/engines/collavre/app/models/collavre/user.rb
+++ b/engines/collavre/app/models/collavre/user.rb
@@ -228,6 +228,11 @@ module Collavre
     validates :timezone,
               inclusion: { in: ActiveSupport::TimeZone.all.map { |z| z.tzinfo.identifier } },
               allow_nil: true
+    # Column is NOT NULL; clearing the profile field (or a crafted PATCH) casts to
+    # nil and would raise a DB error on save. Validate so the form re-renders.
+    validates :typo_correction_threshold,
+              presence: true,
+              numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 100 }
 
     generates_token_for :email_verification, expires_in: 1.day do
       email

--- a/engines/collavre/app/models/collavre/user.rb
+++ b/engines/collavre/app/models/collavre/user.rb
@@ -182,7 +182,7 @@ module Collavre
     ].freeze
 
     SUPPORTED_LLM_MODELS = [
-      "gemini-3-flash-preview",
+      "gemini-3.1-flash-lite",
       "gemini-1.5-flash",
       "gemini-1.5-pro"
     ].freeze

--- a/engines/collavre/app/models/collavre/user.rb
+++ b/engines/collavre/app/models/collavre/user.rb
@@ -58,6 +58,15 @@ module Collavre
     attribute :system_admin, :boolean, default: false
     attribute :searchable, :boolean, default: false
 
+    # Typo correction (2D gating: typing-device AND input-location must both be on).
+    attribute :typo_correction_enabled, :boolean, default: true
+    attribute :typo_correction_threshold, :integer, default: 80
+    attribute :typo_correction_on_soft_keyboard, :boolean, default: true
+    attribute :typo_correction_on_voice, :boolean, default: true
+    attribute :typo_correction_on_physical_keyboard, :boolean, default: false
+    attribute :typo_correction_in_chat, :boolean, default: true
+    attribute :typo_correction_in_editor, :boolean, default: false
+
     attribute :google_uid, :string
     attribute :google_access_token, :string
     attribute :google_refresh_token, :string
@@ -138,6 +147,31 @@ module Collavre
         Rails.logger.error("Failed to decrypt #{attr} for user #{id}: #{e.class}")
         nil
       end
+    end
+
+    TYPO_CORRECTION_DEVICES = %w[voice soft_keyboard physical_keyboard].freeze
+    TYPO_CORRECTION_LOCATIONS = %w[chat editor].freeze
+
+    # 2D gating: typo correction runs only when the master switch is on AND the
+    # originating typing device AND the input location are both enabled. Unknown
+    # device/location values are treated as disabled (fail closed).
+    def typo_correction_active_for?(device:, location:)
+      return false unless typo_correction_enabled
+
+      device_on = case device.to_s
+      when "voice" then typo_correction_on_voice
+      when "soft_keyboard" then typo_correction_on_soft_keyboard
+      when "physical_keyboard" then typo_correction_on_physical_keyboard
+      else false
+      end
+
+      location_on = case location.to_s
+      when "chat" then typo_correction_in_chat
+      when "editor" then typo_correction_in_editor
+      else false
+      end
+
+      device_on && location_on
     end
 
     LLM_VENDOR_OPTIONS = [

--- a/engines/collavre/app/services/collavre/ai_client.rb
+++ b/engines/collavre/app/services/collavre/ai_client.rb
@@ -10,13 +10,18 @@ module Collavre
 
     attr_reader :last_input_tokens, :last_output_tokens
 
-    def initialize(vendor:, model:, system_prompt:, llm_api_key: nil, gateway_url: nil, context: {})
+    # log_interactions: persist each call to ActivityLog. Default true. Pass false
+    # for ephemeral, high-frequency calls on text the user has not submitted (e.g.
+    # inline typo correction on debounced typing) so private drafts are never
+    # written to server-side activity logs.
+    def initialize(vendor:, model:, system_prompt:, llm_api_key: nil, gateway_url: nil, context: {}, log_interactions: true)
       @vendor = vendor
       @model = model
       @system_prompt = system_prompt
       @llm_api_key = llm_api_key
       @gateway_url = gateway_url
       @context = context
+      @log_interactions = log_interactions
       @last_input_tokens = 0
       @last_output_tokens = 0
     end
@@ -72,14 +77,16 @@ module Collavre
     ensure
       @last_input_tokens = input_tokens || 0
       @last_output_tokens = output_tokens || 0
-      log_interaction(
-        messages: @conversation&.messages&.to_a || Array(contents),
-        tools: @conversation&.tools&.to_a || [],
-        response_content: response_content.presence,
-        error_message: error_message,
-        input_tokens: input_tokens,
-        output_tokens: output_tokens
-      )
+      if @log_interactions
+        log_interaction(
+          messages: @conversation&.messages&.to_a || Array(contents),
+          tools: @conversation&.tools&.to_a || [],
+          response_content: response_content.presence,
+          error_message: error_message,
+          input_tokens: input_tokens,
+          output_tokens: output_tokens
+        )
+      end
     end
 
     # Ask a follow-up question using the existing conversation context.

--- a/engines/collavre/app/services/collavre/ai_client.rb
+++ b/engines/collavre/app/services/collavre/ai_client.rb
@@ -122,6 +122,11 @@ module Collavre
       when "openai"
         api_key = @llm_api_key.presence || IntegrationSettings.fetch(:openai_api_key)
         base_url = @gateway_url.presence
+        # A custom OpenAI-compatible gateway (local Ollama / LM Studio, etc.) needs
+        # no real OpenAI key, but RubyLLM raises ConfigurationError before sending
+        # if openai_api_key is blank. Supply a placeholder so keyless local gateways
+        # work; hosted OpenAI (no gateway) still requires a real key.
+        api_key = "local-gateway" if api_key.blank? && base_url
         proc do |config|
           config.openai_api_key = api_key
           config.openai_api_base = base_url if base_url

--- a/engines/collavre/app/services/collavre/ai_client.rb
+++ b/engines/collavre/app/services/collavre/ai_client.rb
@@ -69,7 +69,13 @@ module Collavre
       raise # Re-raise cancellation errors without catching them
     rescue StandardError => e
       error_message = "[#{e.class.name}] #{e.message}"
-      Rails.logger.error "AI Client error: #{error_message}"
+      # When log_interactions is false (inline typo correction runs on the user's
+      # *unsubmitted* draft), the LLM error message can echo the request text. Log
+      # only the error class to app logs so private drafts never leak — matching the
+      # no-log guarantee already enforced on the parse path (TypoCorrector) and the
+      # ActivityLog gate below. error_message stays intact for the gated ensure log
+      # and the streamed yield (which goes back to the same user).
+      Rails.logger.error "AI Client error: #{@log_interactions ? error_message : "[#{e.class.name}]"}"
       Rails.logger.error "Partial response length: #{response_content.length} chars" if response_content.present?
       Rails.logger.debug e.backtrace.join("\n")
       yield "\n\n⚠️ AI Error: #{error_message}" if block_given?

--- a/engines/collavre/app/services/collavre/auto_theme_generator.rb
+++ b/engines/collavre/app/services/collavre/auto_theme_generator.rb
@@ -195,7 +195,7 @@ module Collavre
     def default_client
       AiClient.new(
         vendor: "google",
-        model: "gemini-3-flash-preview",
+        model: "gemini-3.1-flash-lite",
         system_prompt: nil
       )
     end

--- a/engines/collavre/app/services/collavre/gemini_parent_recommender.rb
+++ b/engines/collavre/app/services/collavre/gemini_parent_recommender.rb
@@ -55,7 +55,7 @@ module Collavre
     def default_client
       AiClient.new(
         vendor: "google",
-        model: "gemini-3-flash-preview",
+        model: "gemini-3.1-flash-lite",
         system_prompt: nil
       )
     end

--- a/engines/collavre/app/services/collavre/typo_corrector.rb
+++ b/engines/collavre/app/services/collavre/typo_corrector.rb
@@ -52,6 +52,11 @@ module Collavre
         system_prompt: agent&.system_prompt.presence || FALLBACK_SYSTEM_PROMPT,
         llm_api_key: agent&.llm_api_key,
         gateway_url: agent&.gateway_url,
+        # Vendor adapters (e.g. OpenClaw) resolve the gateway/key from the context
+        # user, not the llm_api_key/gateway_url kwargs. Pass the agent so an
+        # OpenClaw-backed typo agent isn't built with user: nil (which makes the
+        # adapter bail with "Gateway URL not configured" and silently return no edits).
+        context: { user: agent },
         # Runs on debounced typing of *unsubmitted* text — never persist the draft
         # to ActivityLog (RubyLlmInteractionLogger writes `messages` there).
         log_interactions: false

--- a/engines/collavre/app/services/collavre/typo_corrector.rb
+++ b/engines/collavre/app/services/collavre/typo_corrector.rb
@@ -71,7 +71,9 @@ module Collavre
       edits = parsed.is_a?(Hash) ? parsed["edits"] : parsed
       edits.is_a?(Array) ? edits : []
     rescue JSON::ParserError => e
-      Rails.logger.warn("[TypoCorrector] JSON parse error: #{e.message}. Content: #{content.to_s.truncate(200)}")
+      # Never log the raw response: it can echo the user's unsubmitted draft,
+      # which would leak private text to application logs despite log_interactions: false.
+      Rails.logger.warn("[TypoCorrector] JSON parse error: #{e.message} (#{content.to_s.length} chars)")
       []
     end
 

--- a/engines/collavre/app/services/collavre/typo_corrector.rb
+++ b/engines/collavre/app/services/collavre/typo_corrector.rb
@@ -48,7 +48,7 @@ module Collavre
       agent = Collavre.user_class.find_by(email: AGENT_EMAIL)
       AiClient.new(
         vendor: agent&.llm_vendor.presence || ENV.fetch("COLLAVRE_DEFAULT_LLM_VENDOR", "gemini"),
-        model: agent&.llm_model.presence || ENV.fetch("COLLAVRE_DEFAULT_LLM_MODEL", "gemini-3-flash-preview"),
+        model: agent&.llm_model.presence || ENV.fetch("COLLAVRE_DEFAULT_LLM_MODEL", "gemini-3.1-flash-lite"),
         system_prompt: agent&.system_prompt.presence || FALLBACK_SYSTEM_PROMPT,
         llm_api_key: agent&.llm_api_key,
         gateway_url: agent&.gateway_url,

--- a/engines/collavre/app/services/collavre/typo_corrector.rb
+++ b/engines/collavre/app/services/collavre/typo_corrector.rb
@@ -51,7 +51,10 @@ module Collavre
         model: agent&.llm_model.presence || ENV.fetch("COLLAVRE_DEFAULT_LLM_MODEL", "gemini-3-flash-preview"),
         system_prompt: agent&.system_prompt.presence || FALLBACK_SYSTEM_PROMPT,
         llm_api_key: agent&.llm_api_key,
-        gateway_url: agent&.gateway_url
+        gateway_url: agent&.gateway_url,
+        # Runs on debounced typing of *unsubmitted* text — never persist the draft
+        # to ActivityLog (RubyLlmInteractionLogger writes `messages` there).
+        log_interactions: false
       )
     end
 
@@ -100,7 +103,12 @@ module Collavre
           "suggestion" => suggestion,
           "reason" => edit["reason"].presence || "spelling",
           "confidence" => clamp_confidence(edit["confidence"]),
-          "offset" => offset
+          # Emit the offset in UTF-16 code units, the coordinate space JS string
+          # indexing uses. A Ruby character index would be off by one per astral
+          # character (emoji, etc.) before the typo, so the client's substring
+          # check at `offset` would fail and fall back to indexOf — which can bind
+          # to a protected occurrence the server already excluded.
+          "offset" => utf16_offset(text, offset)
         }
       end
     end
@@ -144,6 +152,14 @@ module Collavre
         pos = idx + 1
       end
       nil
+    end
+
+    # Convert a Ruby character index into a UTF-16 code-unit offset (JS string
+    # coordinates). Characters outside the BMP count as two code units in JS.
+    def utf16_offset(text, char_index)
+      text[0, char_index].to_s.encode("UTF-16LE").bytesize / 2
+    rescue Encoding::UndefinedConversionError, Encoding::InvalidByteSequenceError
+      char_index
     end
 
     # Iterative Levenshtein distance.

--- a/engines/collavre/app/services/collavre/typo_corrector.rb
+++ b/engines/collavre/app/services/collavre/typo_corrector.rb
@@ -1,0 +1,156 @@
+module Collavre
+  # Server-side typo correction. Sends the text the user is typing to an LLM and
+  # returns a validated *structured edit list* — never a rewritten string. Each
+  # edit is {original, suggestion, reason, confidence}. Validation rejects anything
+  # that is not a small, in-place spelling fix (style rewrites, hallucinated spans,
+  # edits inside code/URLs/mentions), so the UI can trust every returned edit.
+  class TypoCorrector
+    AGENT_EMAIL = "typo-corrector@collavre.local"
+
+    # Reject "corrections" that are really rewrites: an edit is kept only when the
+    # original is short and the suggestion is within this edit distance of it.
+    MAX_ORIGINAL_LENGTH = 40
+    MIN_EDIT_DISTANCE_CAP = 2
+    EDIT_DISTANCE_RATIO = 0.4
+
+    FALLBACK_SYSTEM_PROMPT = <<~PROMPT.freeze
+      You are a typo correction engine. Fix only spelling mistakes and obvious typos,
+      never style, grammar or meaning, in any language. `original` must be an exact
+      substring of the input. Return ONLY JSON:
+      {"edits":[{"original":"x","suggestion":"y","reason":"spelling","confidence":0.0}]}
+    PROMPT
+
+    def initialize(client: nil)
+      @client = client
+    end
+
+    # Returns an Array of Hashes with string keys: "original", "suggestion",
+    # "reason", "confidence". Empty array on blank input or LLM/parse failure.
+    def correct(text)
+      text = text.to_s
+      return [] if text.strip.blank?
+
+      response = client.chat([
+        { role: :user, parts: [ { text: "Text:\n#{text}" } ] }
+      ])
+
+      edits = parse_response(response)
+      validate(edits, text)
+    end
+
+    private
+
+    def client
+      @client ||= build_client
+    end
+
+    def build_client
+      agent = Collavre.user_class.find_by(email: AGENT_EMAIL)
+      AiClient.new(
+        vendor: agent&.llm_vendor.presence || ENV.fetch("COLLAVRE_DEFAULT_LLM_VENDOR", "gemini"),
+        model: agent&.llm_model.presence || ENV.fetch("COLLAVRE_DEFAULT_LLM_MODEL", "gemini-3-flash-preview"),
+        system_prompt: agent&.system_prompt.presence || FALLBACK_SYSTEM_PROMPT,
+        llm_api_key: agent&.llm_api_key,
+        gateway_url: agent&.gateway_url
+      )
+    end
+
+    def parse_response(content)
+      return [] if content.blank?
+
+      cleaned = content.gsub(/^```json\s*/, "").gsub(/\s*```$/, "").strip
+      parsed = JSON.parse(cleaned)
+      edits = parsed.is_a?(Hash) ? parsed["edits"] : parsed
+      edits.is_a?(Array) ? edits : []
+    rescue JSON::ParserError => e
+      Rails.logger.warn("[TypoCorrector] JSON parse error: #{e.message}. Content: #{content.to_s.truncate(200)}")
+      []
+    end
+
+    def validate(edits, text)
+      skip_ranges = skip_ranges(text)
+      seen = {}
+
+      edits.filter_map do |edit|
+        next unless edit.is_a?(Hash)
+
+        original = edit["original"].to_s
+        suggestion = edit["suggestion"].to_s
+        next if original.empty? || suggestion.empty? || original == suggestion
+        next if original.length > MAX_ORIGINAL_LENGTH
+
+        # `original` must appear verbatim in the text, at least once outside any
+        # skip region (code/URL/mention/markup).
+        next unless occurs_outside_skip_ranges?(text, original, skip_ranges)
+
+        # Reject big rewrites — keep only minimal in-place fixes.
+        cap = [ MIN_EDIT_DISTANCE_CAP, (original.length * EDIT_DISTANCE_RATIO).ceil ].max
+        next if levenshtein(original, suggestion) > cap
+
+        key = [ original, suggestion ]
+        next if seen[key]
+        seen[key] = true
+
+        {
+          "original" => original,
+          "suggestion" => suggestion,
+          "reason" => edit["reason"].presence || "spelling",
+          "confidence" => clamp_confidence(edit["confidence"])
+        }
+      end
+    end
+
+    def clamp_confidence(value)
+      return 0.5 if value.nil?
+
+      Float(value).clamp(0.0, 1.0)
+    rescue ArgumentError, TypeError
+      0.5
+    end
+
+    # Character ranges that must never be edited: fenced code, inline code, URLs,
+    # @mentions, HTML tags, and markdown-canonical <span style> color fragments.
+    def skip_ranges(text)
+      ranges = []
+      patterns = [
+        /```.*?```/m,             # fenced code blocks
+        /`[^`]*`/,                # inline code
+        %r{https?://\S+},         # URLs
+        /@[^\s@]+/,               # @mentions
+        /<[^>]+>/                 # HTML / span-style markup
+      ]
+      patterns.each do |pattern|
+        text.scan(pattern) { ranges << Regexp.last_match.offset(0) }
+      end
+      ranges
+    end
+
+    def occurs_outside_skip_ranges?(text, needle, skip_ranges)
+      pos = 0
+      while (idx = text.index(needle, pos))
+        finish = idx + needle.length
+        inside = skip_ranges.any? { |(s, e)| idx < e && finish > s }
+        return true unless inside
+
+        pos = idx + 1
+      end
+      false
+    end
+
+    # Iterative Levenshtein distance.
+    def levenshtein(a, b)
+      a = a.chars
+      b = b.chars
+      prev = (0..b.length).to_a
+      a.each_with_index do |ac, i|
+        curr = [ i + 1 ]
+        b.each_with_index do |bc, j|
+          cost = ac == bc ? 0 : 1
+          curr << [ curr[j] + 1, prev[j + 1] + 1, prev[j] + cost ].min
+        end
+        prev = curr
+      end
+      prev.last
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/typo_corrector.rb
+++ b/engines/collavre/app/services/collavre/typo_corrector.rb
@@ -79,9 +79,13 @@ module Collavre
         next if original.empty? || suggestion.empty? || original == suggestion
         next if original.length > MAX_ORIGINAL_LENGTH
 
-        # `original` must appear verbatim in the text, at least once outside any
-        # skip region (code/URL/mention/markup).
-        next unless occurs_outside_skip_ranges?(text, original, skip_ranges)
+        # `original` must appear verbatim in the text, outside any skip region
+        # (code/URL/mention/markup). We return the offset of that first *valid*
+        # occurrence so the client anchors there — otherwise the client's own
+        # left-to-right search would bind to an earlier occurrence sitting inside
+        # a protected span and edit it (a markdown-canonical/code-safety hole).
+        offset = first_offset_outside_skip_ranges(text, original, skip_ranges)
+        next if offset.nil?
 
         # Reject big rewrites — keep only minimal in-place fixes.
         cap = [ MIN_EDIT_DISTANCE_CAP, (original.length * EDIT_DISTANCE_RATIO).ceil ].max
@@ -95,7 +99,8 @@ module Collavre
           "original" => original,
           "suggestion" => suggestion,
           "reason" => edit["reason"].presence || "spelling",
-          "confidence" => clamp_confidence(edit["confidence"])
+          "confidence" => clamp_confidence(edit["confidence"]),
+          "offset" => offset
         }
       end
     end
@@ -127,16 +132,18 @@ module Collavre
       ranges
     end
 
-    def occurs_outside_skip_ranges?(text, needle, skip_ranges)
+    # First character offset where `needle` occurs entirely outside every skip
+    # range, or nil if every occurrence overlaps a protected span.
+    def first_offset_outside_skip_ranges(text, needle, skip_ranges)
       pos = 0
       while (idx = text.index(needle, pos))
         finish = idx + needle.length
         inside = skip_ranges.any? { |(s, e)| idx < e && finish > s }
-        return true unless inside
+        return idx unless inside
 
         pos = idx + 1
       end
-      false
+      nil
     end
 
     # Iterative Levenshtein distance.

--- a/engines/collavre/app/services/collavre/typo_corrector.rb
+++ b/engines/collavre/app/services/collavre/typo_corrector.rb
@@ -117,7 +117,9 @@ module Collavre
         /`[^`]*`/,                # inline code
         %r{https?://\S+},         # URLs
         /@[^\s@]+/,               # @mentions
-        /<[^>]+>/                 # HTML / span-style markup
+        # `[^<>]` (not just `[^>]`) keeps this linear: a stray run of "<<<<" can't
+        # make scan re-walk the tail from every "<" (CodeQL polynomial-ReDoS).
+        /<[^<>]+>/                # HTML / span-style markup
       ]
       patterns.each do |pattern|
         text.scan(pattern) { ranges << Regexp.last_match.offset(0) }

--- a/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
@@ -72,6 +72,7 @@
      data-typo-in-editor="<%= Current.user.typo_correction_in_editor %>"
      data-typo-keep-label="<%= t('collavre.comments.typo_keep_label') %>"
      data-typo-custom-label="<%= t('collavre.comments.typo_custom_label') %>"
+     data-typo-input-label="<%= t('collavre.comments.typo_input_label') %>"
      <% end %>>
   <div class="resize-handle resize-handle-left" data-comments--popup-target="leftHandle"></div>
   <div class="resize-handle resize-handle-right" data-comments--popup-target="rightHandle"></div>

--- a/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
@@ -61,7 +61,18 @@
      data-remove-from-history-label="<%= t('collavre.comments.remove_from_history') %>"
      data-inbox-reply-button="<%= t('collavre.comments.inbox_reply_button') %>"
      data-table-download-csv-text="<%= t('collavre.comments.table_download.csv') %>"
-     data-table-download-excel-text="<%= t('collavre.comments.table_download.excel') %>">
+     data-table-download-excel-text="<%= t('collavre.comments.table_download.excel') %>"
+     <% if Current.user %>
+     data-typo-enabled="<%= Current.user.typo_correction_enabled %>"
+     data-typo-threshold="<%= Current.user.typo_correction_threshold %>"
+     data-typo-on-voice="<%= Current.user.typo_correction_on_voice %>"
+     data-typo-on-soft-keyboard="<%= Current.user.typo_correction_on_soft_keyboard %>"
+     data-typo-on-physical-keyboard="<%= Current.user.typo_correction_on_physical_keyboard %>"
+     data-typo-in-chat="<%= Current.user.typo_correction_in_chat %>"
+     data-typo-in-editor="<%= Current.user.typo_correction_in_editor %>"
+     data-typo-keep-label="<%= t('collavre.comments.typo_keep_label') %>"
+     data-typo-custom-label="<%= t('collavre.comments.typo_custom_label') %>"
+     <% end %>>
   <div class="resize-handle resize-handle-left" data-comments--popup-target="leftHandle"></div>
   <div class="resize-handle resize-handle-right" data-comments--popup-target="rightHandle"></div>
   <div class="comments-popup-header" data-comments--popup-target="header">

--- a/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
@@ -70,7 +70,7 @@
      data-typo-on-physical-keyboard="<%= Current.user.typo_correction_on_physical_keyboard %>"
      data-typo-in-chat="<%= Current.user.typo_correction_in_chat %>"
      data-typo-in-editor="<%= Current.user.typo_correction_in_editor %>"
-     data-typo-endpoint="<%= typo_corrections_path %>"
+     data-typo-endpoint="<%= collavre.typo_corrections_path %>"
      data-typo-keep-label="<%= t('collavre.comments.typo_keep_label') %>"
      data-typo-custom-label="<%= t('collavre.comments.typo_custom_label') %>"
      data-typo-input-label="<%= t('collavre.comments.typo_input_label') %>"

--- a/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
@@ -70,6 +70,7 @@
      data-typo-on-physical-keyboard="<%= Current.user.typo_correction_on_physical_keyboard %>"
      data-typo-in-chat="<%= Current.user.typo_correction_in_chat %>"
      data-typo-in-editor="<%= Current.user.typo_correction_in_editor %>"
+     data-typo-endpoint="<%= typo_corrections_path %>"
      data-typo-keep-label="<%= t('collavre.comments.typo_keep_label') %>"
      data-typo-custom-label="<%= t('collavre.comments.typo_custom_label') %>"
      data-typo-input-label="<%= t('collavre.comments.typo_input_label') %>"

--- a/engines/collavre/app/views/collavre/users/show.html.erb
+++ b/engines/collavre/app/views/collavre/users/show.html.erb
@@ -101,6 +101,51 @@
           <%= f.label :timezone, t('collavre.users.timezone') %>
           <%= f.select :timezone, ActiveSupport::TimeZone.all.map { |tz| [tz.to_s, tz.tzinfo.name] } %>
         </div>
+
+        <fieldset class="typo-correction-settings">
+          <legend><%= t('collavre.users.typo_correction.legend') %></legend>
+          <p class="text-muted"><%= t('collavre.users.typo_correction.description') %></p>
+
+          <div class="checkbox-field">
+            <%= f.check_box :typo_correction_enabled %>
+            <%= f.label :typo_correction_enabled, t('collavre.users.typo_correction.enabled') %>
+          </div>
+
+          <div>
+            <%= f.label :typo_correction_threshold, t('collavre.users.typo_correction.threshold') %>
+            <%= f.number_field :typo_correction_threshold, in: 0..100, step: 1 %>
+            <small class="text-muted"><%= t('collavre.users.typo_correction.threshold_hint') %></small>
+          </div>
+
+          <fieldset>
+            <legend><%= t('collavre.users.typo_correction.device_legend') %></legend>
+            <div class="checkbox-field">
+              <%= f.check_box :typo_correction_on_voice %>
+              <%= f.label :typo_correction_on_voice, t('collavre.users.typo_correction.on_voice') %>
+            </div>
+            <div class="checkbox-field">
+              <%= f.check_box :typo_correction_on_soft_keyboard %>
+              <%= f.label :typo_correction_on_soft_keyboard, t('collavre.users.typo_correction.on_soft_keyboard') %>
+            </div>
+            <div class="checkbox-field">
+              <%= f.check_box :typo_correction_on_physical_keyboard %>
+              <%= f.label :typo_correction_on_physical_keyboard, t('collavre.users.typo_correction.on_physical_keyboard') %>
+            </div>
+          </fieldset>
+
+          <fieldset>
+            <legend><%= t('collavre.users.typo_correction.location_legend') %></legend>
+            <div class="checkbox-field">
+              <%= f.check_box :typo_correction_in_chat %>
+              <%= f.label :typo_correction_in_chat, t('collavre.users.typo_correction.in_chat') %>
+            </div>
+            <div class="checkbox-field">
+              <%= f.check_box :typo_correction_in_editor %>
+              <%= f.label :typo_correction_in_editor, t('collavre.users.typo_correction.in_editor') %>
+            </div>
+          </fieldset>
+        </fieldset>
+
         <%= f.submit t('collavre.users.update_profile') %>
       <% end %>
 

--- a/engines/collavre/app/views/collavre/users/show.html.erb
+++ b/engines/collavre/app/views/collavre/users/show.html.erb
@@ -102,50 +102,6 @@
           <%= f.select :timezone, ActiveSupport::TimeZone.all.map { |tz| [tz.to_s, tz.tzinfo.name] } %>
         </div>
 
-        <fieldset class="typo-correction-settings">
-          <legend><%= t('collavre.users.typo_correction.legend') %></legend>
-          <p class="text-muted"><%= t('collavre.users.typo_correction.description') %></p>
-
-          <div class="checkbox-field">
-            <%= f.check_box :typo_correction_enabled %>
-            <%= f.label :typo_correction_enabled, t('collavre.users.typo_correction.enabled') %>
-          </div>
-
-          <div>
-            <%= f.label :typo_correction_threshold, t('collavre.users.typo_correction.threshold') %>
-            <%= f.number_field :typo_correction_threshold, in: 0..100, step: 1, required: true %>
-            <small class="text-muted"><%= t('collavre.users.typo_correction.threshold_hint') %></small>
-          </div>
-
-          <fieldset>
-            <legend><%= t('collavre.users.typo_correction.device_legend') %></legend>
-            <div class="checkbox-field">
-              <%= f.check_box :typo_correction_on_voice %>
-              <%= f.label :typo_correction_on_voice, t('collavre.users.typo_correction.on_voice') %>
-            </div>
-            <div class="checkbox-field">
-              <%= f.check_box :typo_correction_on_soft_keyboard %>
-              <%= f.label :typo_correction_on_soft_keyboard, t('collavre.users.typo_correction.on_soft_keyboard') %>
-            </div>
-            <div class="checkbox-field">
-              <%= f.check_box :typo_correction_on_physical_keyboard %>
-              <%= f.label :typo_correction_on_physical_keyboard, t('collavre.users.typo_correction.on_physical_keyboard') %>
-            </div>
-          </fieldset>
-
-          <fieldset>
-            <legend><%= t('collavre.users.typo_correction.location_legend') %></legend>
-            <div class="checkbox-field">
-              <%= f.check_box :typo_correction_in_chat %>
-              <%= f.label :typo_correction_in_chat, t('collavre.users.typo_correction.in_chat') %>
-            </div>
-            <div class="checkbox-field">
-              <%= f.check_box :typo_correction_in_editor %>
-              <%= f.label :typo_correction_in_editor, t('collavre.users.typo_correction.in_editor') %>
-            </div>
-          </fieldset>
-        </fieldset>
-
         <%= f.submit t('collavre.users.update_profile') %>
       <% end %>
 
@@ -153,6 +109,8 @@
         <%= link_to t('collavre.users.change_password'), collavre.edit_password_user_path(@user) %>
         <br>
         <%= link_to t('collavre.users.webauthn.manage'), collavre.passkeys_user_path(@user) %>
+        <br>
+        <%= link_to t('collavre.users.typo_correction.manage'), collavre.typo_correction_user_path(@user) %>
         <br>
         <%= link_to t('doorkeeper.my_applications'), main_app.oauth_applications_path %>
         <% if @user.system_admin? %>

--- a/engines/collavre/app/views/collavre/users/show.html.erb
+++ b/engines/collavre/app/views/collavre/users/show.html.erb
@@ -113,7 +113,7 @@
 
           <div>
             <%= f.label :typo_correction_threshold, t('collavre.users.typo_correction.threshold') %>
-            <%= f.number_field :typo_correction_threshold, in: 0..100, step: 1 %>
+            <%= f.number_field :typo_correction_threshold, in: 0..100, step: 1, required: true %>
             <small class="text-muted"><%= t('collavre.users.typo_correction.threshold_hint') %></small>
           </div>
 

--- a/engines/collavre/app/views/collavre/users/typo_correction.html.erb
+++ b/engines/collavre/app/views/collavre/users/typo_correction.html.erb
@@ -1,47 +1,45 @@
 <h1 class="no-top-margin"><%= t('collavre.users.typo_correction.legend') %></h1>
 
 <%= form_with model: @user, url: collavre.user_path(@user), method: :patch, local: true, html: { class: 'profile-form' } do |f| %>
-  <fieldset class="typo-correction-settings">
-    <p class="text-muted"><%= t('collavre.users.typo_correction.description') %></p>
+  <p class="text-muted"><%= t('collavre.users.typo_correction.description') %></p>
 
+  <div class="checkbox-field">
+    <%= f.check_box :typo_correction_enabled %>
+    <%= f.label :typo_correction_enabled, t('collavre.users.typo_correction.enabled') %>
+  </div>
+
+  <div>
+    <%= f.label :typo_correction_threshold, t('collavre.users.typo_correction.threshold') %>
+    <%= f.number_field :typo_correction_threshold, in: 0..100, step: 1, required: true %>
+    <small class="text-muted"><%= t('collavre.users.typo_correction.threshold_hint') %></small>
+  </div>
+
+  <fieldset>
+    <legend><%= t('collavre.users.typo_correction.device_legend') %></legend>
     <div class="checkbox-field">
-      <%= f.check_box :typo_correction_enabled %>
-      <%= f.label :typo_correction_enabled, t('collavre.users.typo_correction.enabled') %>
+      <%= f.check_box :typo_correction_on_voice %>
+      <%= f.label :typo_correction_on_voice, t('collavre.users.typo_correction.on_voice') %>
     </div>
-
-    <div>
-      <%= f.label :typo_correction_threshold, t('collavre.users.typo_correction.threshold') %>
-      <%= f.number_field :typo_correction_threshold, in: 0..100, step: 1, required: true %>
-      <small class="text-muted"><%= t('collavre.users.typo_correction.threshold_hint') %></small>
+    <div class="checkbox-field">
+      <%= f.check_box :typo_correction_on_soft_keyboard %>
+      <%= f.label :typo_correction_on_soft_keyboard, t('collavre.users.typo_correction.on_soft_keyboard') %>
     </div>
+    <div class="checkbox-field">
+      <%= f.check_box :typo_correction_on_physical_keyboard %>
+      <%= f.label :typo_correction_on_physical_keyboard, t('collavre.users.typo_correction.on_physical_keyboard') %>
+    </div>
+  </fieldset>
 
-    <fieldset>
-      <legend><%= t('collavre.users.typo_correction.device_legend') %></legend>
-      <div class="checkbox-field">
-        <%= f.check_box :typo_correction_on_voice %>
-        <%= f.label :typo_correction_on_voice, t('collavre.users.typo_correction.on_voice') %>
-      </div>
-      <div class="checkbox-field">
-        <%= f.check_box :typo_correction_on_soft_keyboard %>
-        <%= f.label :typo_correction_on_soft_keyboard, t('collavre.users.typo_correction.on_soft_keyboard') %>
-      </div>
-      <div class="checkbox-field">
-        <%= f.check_box :typo_correction_on_physical_keyboard %>
-        <%= f.label :typo_correction_on_physical_keyboard, t('collavre.users.typo_correction.on_physical_keyboard') %>
-      </div>
-    </fieldset>
-
-    <fieldset>
-      <legend><%= t('collavre.users.typo_correction.location_legend') %></legend>
-      <div class="checkbox-field">
-        <%= f.check_box :typo_correction_in_chat %>
-        <%= f.label :typo_correction_in_chat, t('collavre.users.typo_correction.in_chat') %>
-      </div>
-      <div class="checkbox-field">
-        <%= f.check_box :typo_correction_in_editor %>
-        <%= f.label :typo_correction_in_editor, t('collavre.users.typo_correction.in_editor') %>
-      </div>
-    </fieldset>
+  <fieldset>
+    <legend><%= t('collavre.users.typo_correction.location_legend') %></legend>
+    <div class="checkbox-field">
+      <%= f.check_box :typo_correction_in_chat %>
+      <%= f.label :typo_correction_in_chat, t('collavre.users.typo_correction.in_chat') %>
+    </div>
+    <div class="checkbox-field">
+      <%= f.check_box :typo_correction_in_editor %>
+      <%= f.label :typo_correction_in_editor, t('collavre.users.typo_correction.in_editor') %>
+    </div>
   </fieldset>
 
   <%= f.submit t('collavre.users.update_profile') %>

--- a/engines/collavre/app/views/collavre/users/typo_correction.html.erb
+++ b/engines/collavre/app/views/collavre/users/typo_correction.html.erb
@@ -1,0 +1,52 @@
+<h1 class="no-top-margin"><%= t('collavre.users.typo_correction.legend') %></h1>
+
+<%= form_with model: @user, url: collavre.user_path(@user), method: :patch, local: true, html: { class: 'profile-form' } do |f| %>
+  <fieldset class="typo-correction-settings">
+    <p class="text-muted"><%= t('collavre.users.typo_correction.description') %></p>
+
+    <div class="checkbox-field">
+      <%= f.check_box :typo_correction_enabled %>
+      <%= f.label :typo_correction_enabled, t('collavre.users.typo_correction.enabled') %>
+    </div>
+
+    <div>
+      <%= f.label :typo_correction_threshold, t('collavre.users.typo_correction.threshold') %>
+      <%= f.number_field :typo_correction_threshold, in: 0..100, step: 1, required: true %>
+      <small class="text-muted"><%= t('collavre.users.typo_correction.threshold_hint') %></small>
+    </div>
+
+    <fieldset>
+      <legend><%= t('collavre.users.typo_correction.device_legend') %></legend>
+      <div class="checkbox-field">
+        <%= f.check_box :typo_correction_on_voice %>
+        <%= f.label :typo_correction_on_voice, t('collavre.users.typo_correction.on_voice') %>
+      </div>
+      <div class="checkbox-field">
+        <%= f.check_box :typo_correction_on_soft_keyboard %>
+        <%= f.label :typo_correction_on_soft_keyboard, t('collavre.users.typo_correction.on_soft_keyboard') %>
+      </div>
+      <div class="checkbox-field">
+        <%= f.check_box :typo_correction_on_physical_keyboard %>
+        <%= f.label :typo_correction_on_physical_keyboard, t('collavre.users.typo_correction.on_physical_keyboard') %>
+      </div>
+    </fieldset>
+
+    <fieldset>
+      <legend><%= t('collavre.users.typo_correction.location_legend') %></legend>
+      <div class="checkbox-field">
+        <%= f.check_box :typo_correction_in_chat %>
+        <%= f.label :typo_correction_in_chat, t('collavre.users.typo_correction.in_chat') %>
+      </div>
+      <div class="checkbox-field">
+        <%= f.check_box :typo_correction_in_editor %>
+        <%= f.label :typo_correction_in_editor, t('collavre.users.typo_correction.in_editor') %>
+      </div>
+    </fieldset>
+  </fieldset>
+
+  <%= f.submit t('collavre.users.update_profile') %>
+<% end %>
+
+<div style="margin-top: 1rem;">
+  <%= link_to t('collavre.users.back'), collavre.user_path(@user) %>
+</div>

--- a/engines/collavre/app/views/collavre/users/typo_correction.html.erb
+++ b/engines/collavre/app/views/collavre/users/typo_correction.html.erb
@@ -42,7 +42,7 @@
     </div>
   </fieldset>
 
-  <%= f.submit t('collavre.users.update_profile') %>
+  <%= f.submit t('collavre.users.update') %>
 <% end %>
 
 <div style="margin-top: 1rem;">

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -142,6 +142,8 @@ en:
       topic_main: All Messages
       fullscreen: Full screen
       exit_fullscreen: Exit full screen
+      typo_keep_label: keep
+      typo_custom_label: custom
       move_invalid_target: Select a valid creative to move messages to.
       move_invalid_topic: Invalid topic selected.
       move_not_allowed: You do not have permission to move these messages.

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -144,6 +144,7 @@ en:
       exit_fullscreen: Exit full screen
       typo_keep_label: keep
       typo_custom_label: custom
+      typo_input_label: correction
       move_invalid_target: Select a valid creative to move messages to.
       move_invalid_topic: Invalid topic selected.
       move_not_allowed: You do not have permission to move these messages.

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -141,6 +141,7 @@ ko:
       exit_fullscreen: 전체 화면 종료
       typo_keep_label: 유지
       typo_custom_label: 직접 입력
+      typo_input_label: 교정
       move_invalid_target: 이동할 크리에이티브를 선택해주세요.
       move_invalid_topic: 유효하지 않은 토픽입니다.
       move_not_allowed: 이 메시지를 이동할 권한이 없습니다.

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -139,6 +139,8 @@ ko:
       topic_main: 전체 메세지
       fullscreen: 전체 화면
       exit_fullscreen: 전체 화면 종료
+      typo_keep_label: 유지
+      typo_custom_label: 직접 입력
       move_invalid_target: 이동할 크리에이티브를 선택해주세요.
       move_invalid_topic: 유효하지 않은 토픽입니다.
       move_not_allowed: 이 메시지를 이동할 권한이 없습니다.

--- a/engines/collavre/config/locales/users.en.yml
+++ b/engines/collavre/config/locales/users.en.yml
@@ -102,6 +102,7 @@ en:
       current_avatar: Current avatar
       new_avatar_preview: New avatar preview
       update_profile: Update Profile
+      update: Update
       delete: Delete
       make_system_admin: Make system admin
       make_normal_user: Make normal user

--- a/engines/collavre/config/locales/users.en.yml
+++ b/engines/collavre/config/locales/users.en.yml
@@ -120,6 +120,19 @@ en:
         en: English
         ko: Korean
       timezone: Timezone
+      typo_correction:
+        legend: Typo correction
+        description: Automatically suggest and fix typos as you type. Suggestions run only when both the typing device and the input location below are enabled.
+        enabled: Enable typo correction
+        threshold: Auto-apply threshold
+        threshold_hint: Edits at or above this confidence (0-100) are applied automatically; lower-confidence edits are only suggested.
+        device_legend: Typing devices
+        on_voice: Voice input
+        on_soft_keyboard: On-screen (soft) keyboard
+        on_physical_keyboard: Physical keyboard (Bluetooth/wired)
+        location_legend: Input locations
+        in_chat: Chat message input
+        in_editor: Inline editor (Lexical / markdown)
       profile_updated: Profile updated successfully.
       avatar_updated: Avatar updated successfully.
       password_updated: Password updated successfully.

--- a/engines/collavre/config/locales/users.en.yml
+++ b/engines/collavre/config/locales/users.en.yml
@@ -132,7 +132,7 @@ en:
         on_physical_keyboard: Physical keyboard (Bluetooth/wired)
         location_legend: Input locations
         in_chat: Chat message input
-        in_editor: Inline editor (Lexical / markdown)
+        in_editor: Creative editor
       profile_updated: Profile updated successfully.
       avatar_updated: Avatar updated successfully.
       password_updated: Password updated successfully.

--- a/engines/collavre/config/locales/users.en.yml
+++ b/engines/collavre/config/locales/users.en.yml
@@ -122,6 +122,7 @@ en:
       timezone: Timezone
       typo_correction:
         legend: Typo correction
+        manage: Typo correction settings
         description: Automatically suggest and fix typos as you type. Suggestions run only when both the typing device and the input location below are enabled.
         enabled: Enable typo correction
         threshold: Auto-apply threshold

--- a/engines/collavre/config/locales/users.ko.yml
+++ b/engines/collavre/config/locales/users.ko.yml
@@ -97,6 +97,7 @@ ko:
       current_avatar: 현재 아바타
       new_avatar_preview: 새 아바타 미리보기
       update_profile: 프로파일 업데이트
+      update: 업데이트
       delete: 삭제
       make_system_admin: 시스템 관리자 지정
       make_normal_user: 일반 사용자로 변경

--- a/engines/collavre/config/locales/users.ko.yml
+++ b/engines/collavre/config/locales/users.ko.yml
@@ -127,7 +127,7 @@ ko:
         on_physical_keyboard: 물리 키보드(블루투스/유선)
         location_legend: 입력 위치
         in_chat: 채팅 메시지 입력
-        in_editor: 인라인 에디터(Lexical / 마크다운)
+        in_editor: 크리에이티브 편집기
       profile_updated: 프로파일이 업데이트되었습니다.
       avatar_updated: 아바타가 변경되었습니다.
       password_updated: 비밀번호가 성공적으로 변경되었습니다.

--- a/engines/collavre/config/locales/users.ko.yml
+++ b/engines/collavre/config/locales/users.ko.yml
@@ -117,6 +117,7 @@ ko:
       timezone: 시간대
       typo_correction:
         legend: 오타 자동 수정
+        manage: 오타 자동 수정 설정
         description: 입력하는 동안 오타를 자동으로 제안하고 수정합니다. 아래의 타이핑 장치와 입력 위치가 모두 켜져 있을 때만 동작합니다.
         enabled: 오타 자동 수정 사용
         threshold: 자동 적용 기준

--- a/engines/collavre/config/locales/users.ko.yml
+++ b/engines/collavre/config/locales/users.ko.yml
@@ -115,6 +115,19 @@ ko:
         en: 영어
         ko: 한국어
       timezone: 시간대
+      typo_correction:
+        legend: 오타 자동 수정
+        description: 입력하는 동안 오타를 자동으로 제안하고 수정합니다. 아래의 타이핑 장치와 입력 위치가 모두 켜져 있을 때만 동작합니다.
+        enabled: 오타 자동 수정 사용
+        threshold: 자동 적용 기준
+        threshold_hint: 이 신뢰도(0-100) 이상이면 자동으로 적용되고, 낮으면 후보로만 표시됩니다.
+        device_legend: 타이핑 장치
+        on_voice: 음성 입력
+        on_soft_keyboard: 화면(소프트) 키보드
+        on_physical_keyboard: 물리 키보드(블루투스/유선)
+        location_legend: 입력 위치
+        in_chat: 채팅 메시지 입력
+        in_editor: 인라인 에디터(Lexical / 마크다운)
       profile_updated: 프로파일이 업데이트되었습니다.
       avatar_updated: 아바타가 변경되었습니다.
       password_updated: 비밀번호가 성공적으로 변경되었습니다.

--- a/engines/collavre/config/routes.rb
+++ b/engines/collavre/config/routes.rb
@@ -23,6 +23,7 @@ Collavre::Engine.routes.draw do
       get :edit_password
       patch :update_password
       get :passkeys
+      get :typo_correction
     end
   end
   get "/email_verification/:token", to: "email_verifications#show", as: :email_verification

--- a/engines/collavre/config/routes.rb
+++ b/engines/collavre/config/routes.rb
@@ -51,6 +51,8 @@ Collavre::Engine.routes.draw do
     end
   end
 
+  resources :typo_corrections, only: [ :create ]
+
   resources :creative_imports, only: [ :create ]
   resources :tasks, only: [] do
     member do

--- a/engines/collavre/db/migrate/20260617090000_add_typo_correction_settings_to_users.rb
+++ b/engines/collavre/db/migrate/20260617090000_add_typo_correction_settings_to_users.rb
@@ -1,0 +1,18 @@
+class AddTypoCorrectionSettingsToUsers < ActiveRecord::Migration[8.0]
+  def change
+    # Master switch + auto-apply confidence threshold (0-100).
+    add_column :users, :typo_correction_enabled, :boolean, default: true, null: false
+    add_column :users, :typo_correction_threshold, :integer, default: 80, null: false
+
+    # Typing-device gating (2D gating, dimension 1). Soft keyboard / voice default
+    # on, physical (BT/wired) keyboard default off — each independently toggleable.
+    add_column :users, :typo_correction_on_soft_keyboard, :boolean, default: true, null: false
+    add_column :users, :typo_correction_on_voice, :boolean, default: true, null: false
+    add_column :users, :typo_correction_on_physical_keyboard, :boolean, default: false, null: false
+
+    # Input-location gating (2D gating, dimension 2). Chat message input default on,
+    # inline Lexical/markdown editor default off — each independently toggleable.
+    add_column :users, :typo_correction_in_chat, :boolean, default: true, null: false
+    add_column :users, :typo_correction_in_editor, :boolean, default: false, null: false
+  end
+end

--- a/engines/collavre/db/seeds.rb
+++ b/engines/collavre/db/seeds.rb
@@ -56,7 +56,7 @@ module Collavre
         email_verified_at: Time.current,
         searchable: false,
         llm_vendor: ENV.fetch("COLLAVRE_DEFAULT_LLM_VENDOR", "gemini"),
-        llm_model: ENV.fetch("COLLAVRE_DEFAULT_LLM_MODEL", "gemini-3-flash-preview"),
+        llm_model: ENV.fetch("COLLAVRE_DEFAULT_LLM_MODEL", "gemini-3.1-flash-lite"),
         system_prompt: SYSTEM_PROMPT,
         tools: []
       )

--- a/engines/collavre/db/seeds.rb
+++ b/engines/collavre/db/seeds.rb
@@ -17,3 +17,54 @@ module Collavre
 end
 
 Collavre::ChannelBotSeed.call
+
+module Collavre
+  # Seeds the "Typo Corrector" agent. Unlike event-routed agents (e.g. the GitHub
+  # PR Analyzer) this agent has no routing_expression — it is never dispatched by
+  # comment events. It exists purely as a user-configurable holder for the LLM
+  # vendor/model/system_prompt that Collavre::TypoCorrector invokes directly.
+  module TypoCorrectorSeed
+    AGENT_EMAIL = "typo-corrector@collavre.local"
+
+    SYSTEM_PROMPT = <<~PROMPT
+      You are a typo correction engine. You receive a short piece of text the user
+      is currently typing and return ONLY spelling/typo fixes as a structured edit list.
+
+      Rules:
+      - Fix only spelling mistakes and obvious typos (transposed/missing/extra letters,
+        wrong jamo, mis-spaced words). Works for any language (ko, en, ja, zh, mixed).
+      - Do NOT rewrite style, grammar, word choice, tone, or punctuation.
+      - Do NOT change meaning. Do NOT translate.
+      - Never touch code spans, URLs, @mentions, emojis, or HTML/markdown markup.
+      - `original` MUST be an exact substring copied verbatim from the input text.
+      - Keep each edit minimal: a single word or short phrase, not a whole sentence.
+
+      Return ONLY valid JSON, no markdown, in exactly this shape:
+      {"edits":[{"original":"<verbatim>","suggestion":"<fixed>","reason":"spelling","confidence":0.0}]}
+
+      `confidence` is a float 0.0-1.0 for how sure you are it is a real typo.
+      If there are no typos, return {"edits":[]}.
+    PROMPT
+
+    def self.call
+      user = User.find_or_initialize_by(email: AGENT_EMAIL)
+      return user unless user.new_record?
+
+      user.assign_attributes(
+        name: "Typo Corrector",
+        password: SecureRandom.hex(32),
+        email_verified_at: Time.current,
+        searchable: false,
+        llm_vendor: ENV.fetch("COLLAVRE_DEFAULT_LLM_VENDOR", "gemini"),
+        llm_model: ENV.fetch("COLLAVRE_DEFAULT_LLM_MODEL", "gemini-3-flash-preview"),
+        system_prompt: SYSTEM_PROMPT,
+        tools: []
+      )
+      user.save!
+      Rails.logger.info "[Collavre] Typo Corrector agent ensured: #{AGENT_EMAIL}"
+      user
+    end
+  end
+end
+
+Collavre::TypoCorrectorSeed.call

--- a/engines/collavre/test/controllers/collavre/typo_corrections_controller_test.rb
+++ b/engines/collavre/test/controllers/collavre/typo_corrections_controller_test.rb
@@ -1,0 +1,66 @@
+require "test_helper"
+
+module Collavre
+  class TypoCorrectionsControllerTest < ActionDispatch::IntegrationTest
+    # Raises if #correct is ever reached, so the gating/size/rate guards can
+    # prove they short-circuit *before* spending an LLM call.
+    class RaisingCorrector
+      def correct(_text)
+        raise "TypoCorrector#correct must not be reached when the request is gated"
+      end
+    end
+
+    class StubCorrector
+      def correct(_text)
+        [ { "original" => "teh", "suggestion" => "the", "confidence" => 0.9, "offset" => 0 } ]
+      end
+    end
+
+    setup do
+      Rails.cache.clear
+      @user = User.create!(email: "typo_user@example.com", password: TEST_PASSWORD,
+                           name: "Typo User", email_verified_at: Time.current)
+      sign_in_as(@user)
+    end
+
+    test "runs the corrector and echoes the threshold on an enabled request" do
+      TypoCorrector.stub(:new, StubCorrector.new) do
+        post collavre.typo_corrections_path,
+             params: { text: "teh", device: "soft_keyboard", location: "chat" }, as: :json
+      end
+      assert_response :success
+      body = JSON.parse(response.body)
+      assert_equal 1, body["edits"].size
+      assert_equal @user.typo_correction_threshold, body["threshold"]
+    end
+
+    test "skips the LLM for a disabled typing device (physical keyboard default-off)" do
+      TypoCorrector.stub(:new, RaisingCorrector.new) do
+        post collavre.typo_corrections_path,
+             params: { text: "teh", device: "physical_keyboard", location: "chat" }, as: :json
+      end
+      assert_response :success
+      assert_empty JSON.parse(response.body)["edits"]
+    end
+
+    test "skips the LLM for oversized input without erroring" do
+      TypoCorrector.stub(:new, RaisingCorrector.new) do
+        post collavre.typo_corrections_path,
+             params: { text: "a" * (TypoCorrectionsController::MAX_TEXT_LENGTH + 1),
+                       device: "soft_keyboard", location: "chat" }, as: :json
+      end
+      assert_response :success
+      assert_empty JSON.parse(response.body)["edits"]
+    end
+
+    test "returns 429 once the per-user rate limit is exceeded" do
+      Rails.cache.write("rate_limit:typo_correction:#{@user.id}",
+                        TypoCorrectionsController::RATE_LIMIT, expires_in: 1.minute)
+      TypoCorrector.stub(:new, StubCorrector.new) do
+        post collavre.typo_corrections_path,
+             params: { text: "teh", device: "soft_keyboard", location: "chat" }, as: :json
+      end
+      assert_response :too_many_requests
+    end
+  end
+end

--- a/engines/collavre/test/controllers/users_controller_test.rb
+++ b/engines/collavre/test/controllers/users_controller_test.rb
@@ -490,6 +490,33 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     get collavre.passkeys_user_path(@regular_user)
     assert_response :success
   end
+  test "non admin user cannot access other user's typo correction page" do
+    sign_in_as(@regular_user, password: "password")
+    other_user = users(:one) # admin user
+
+    get collavre.typo_correction_user_path(other_user)
+
+    assert_redirected_to collavre.user_path(@regular_user)
+    assert_equal I18n.t("collavre.users.destroy.not_authorized"), flash[:alert]
+  end
+
+  test "user can access their own typo correction page" do
+    sign_in_as(@regular_user, password: "password")
+
+    get collavre.typo_correction_user_path(@regular_user)
+    assert_response :success
+    assert_select "input[name=?]", "user[typo_correction_enabled]"
+    assert_select "input[name=?]", "user[typo_correction_threshold]"
+  end
+
+  test "profile page links to the typo correction settings page" do
+    sign_in_as(@regular_user, password: "password")
+
+    get collavre.user_path(@regular_user)
+    assert_response :success
+    assert_select "a[href=?]", collavre.typo_correction_user_path(@regular_user)
+  end
+
   test "admin link appears in profile for system admin" do
     sign_in_as(@admin, password: "password")
     get collavre.user_path(@admin)

--- a/engines/collavre/test/controllers/users_controller_test.rb
+++ b/engines/collavre/test/controllers/users_controller_test.rb
@@ -372,7 +372,10 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
 
     get collavre.user_path(@regular_user, tab: "contacts")
     assert_response :success
-    assert_includes response.body, I18n.t("collavre.users.edit_ai.link")
+    # Assert the actual edit-AI link, not the word "Edit" — that text also appears
+    # in unrelated copy (e.g. the typo-correction settings hint), so a bare
+    # substring match would pass even if the link were gone.
+    assert_includes response.body, collavre.edit_ai_user_path(ai_user)
   end
 
   test "non creator does not see edit button for ai user in org chart" do
@@ -402,7 +405,10 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
 
     get collavre.user_path(@regular_user, tab: "contacts")
     assert_response :success
-    refute_includes response.body, I18n.t("collavre.users.edit_ai.link")
+    # Match the actual edit-AI link, not the word "Edit": that text also appears
+    # in unrelated copy (typo-correction settings hint), so a bare substring
+    # match would spuriously fail even though the link is correctly hidden.
+    refute_includes response.body, collavre.edit_ai_user_path(ai_user)
   end
   test "search with scope contacts returns contact users" do
     sign_in_as(@admin, password: "password")

--- a/engines/collavre/test/models/collavre/user_typo_correction_test.rb
+++ b/engines/collavre/test/models/collavre/user_typo_correction_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  # The typo_correction_threshold column is NOT NULL. Clearing the profile field
+  # (or a crafted PATCH) casts the param to nil; without a validation the save
+  # would raise a DB NOT NULL error instead of re-rendering the form.
+  class UserTypoCorrectionTest < ActiveSupport::TestCase
+    setup { @user = users(:one) }
+
+    test "rejects a nil threshold instead of hitting the NOT NULL column" do
+      @user.typo_correction_threshold = nil
+      assert_not @user.valid?
+      assert_includes @user.errors.attribute_names, :typo_correction_threshold
+    end
+
+    test "rejects an out-of-range threshold" do
+      @user.typo_correction_threshold = 150
+      assert_not @user.valid?
+      @user.typo_correction_threshold = -1
+      assert_not @user.valid?
+    end
+
+    test "rejects a non-integer threshold" do
+      @user.typo_correction_threshold = 50.5
+      assert_not @user.valid?
+    end
+
+    test "accepts the inclusive 0..100 bounds" do
+      @user.typo_correction_threshold = 0
+      assert @user.valid?, @user.errors.full_messages.to_sentence
+      @user.typo_correction_threshold = 100
+      assert @user.valid?, @user.errors.full_messages.to_sentence
+    end
+  end
+end

--- a/engines/collavre/test/services/ai_client_test.rb
+++ b/engines/collavre/test/services/ai_client_test.rb
@@ -123,6 +123,40 @@ class AiClientTest < ActiveSupport::TestCase
     mock_config.verify
   end
 
+  test "build_conversation supplies a placeholder key for a keyless local gateway" do
+    # Local OpenAI-compatible gateways (Ollama / LM Studio) need no real key, but
+    # RubyLLM raises ConfigurationError if openai_api_key is blank. We inject a
+    # placeholder so the request proceeds; otherwise the call silently returns nil.
+    client = AiClient.new(
+      vendor: "openai",
+      model: "gemma3",
+      system_prompt: nil,
+      llm_api_key: nil,
+      gateway_url: "http://localhost:11434/v1"
+    )
+
+    fake_chat = FakeConversation.new
+    mock_context = Object.new
+    mock_context.define_singleton_method(:chat) { |**| fake_chat }
+
+    mock_config = Minitest::Mock.new
+    mock_config.expect(:openai_api_key=, nil, [ "local-gateway" ])
+    mock_config.expect(:openai_api_base=, nil, [ "http://localhost:11434/v1" ])
+
+    context_stub = proc do |&block|
+      block.call(mock_config) if block
+      mock_context
+    end
+
+    Collavre::IntegrationSettings.stub(:fetch, nil) do
+      RubyLLM.stub(:context, context_stub) do
+        client.send(:build_conversation)
+      end
+    end
+
+    assert mock_config.verify
+  end
+
   test "build_conversation sets X-Session-Id header from creative and topic" do
     creative = OpenStruct.new(id: 42)
     comment = OpenStruct.new(topic_id: 7)

--- a/engines/collavre/test/services/ai_client_test.rb
+++ b/engines/collavre/test/services/ai_client_test.rb
@@ -417,4 +417,39 @@ class AiClientTest < ActiveSupport::TestCase
     assert_equal "[StandardError] boom", log_entry.log["error_message"]
     assert_nil log_entry.log["response_content"]
   end
+
+  test "does not log raw error message to app log when log_interactions is false" do
+    # Inline typo correction passes log_interactions: false because it runs on the
+    # user's *unsubmitted* draft. An LLM error whose message echoes that draft must
+    # not leak to Rails.logger — only the error class may be logged.
+    draft = "my-secret-unsubmitted-draft-xyzzy"
+    conversation = FakeConversation.new
+    conversation.define_singleton_method(:complete) do |&_block|
+      raise StandardError, "Gemini 400: bad request for input '#{draft}'"
+    end
+
+    client = AiClient.new(
+      vendor: "google",
+      model: "gemini-pro",
+      system_prompt: "system",
+      llm_api_key: "api-key",
+      log_interactions: false
+    )
+
+    logged = []
+    fake_logger = Object.new
+    fake_logger.define_singleton_method(:error) { |msg| logged << msg.to_s }
+    fake_logger.define_singleton_method(:warn) { |msg| logged << msg.to_s }
+    fake_logger.define_singleton_method(:debug) { |*_| }
+
+    Rails.stub(:logger, fake_logger) do
+      client.stub(:build_conversation, conversation) do
+        client.chat([ { role: "user", parts: [ { text: draft } ] } ])
+      end
+    end
+
+    joined = logged.join("\n")
+    assert_not_includes joined, draft, "draft text leaked to app log on error path"
+    assert(logged.any? { |m| m.include?("StandardError") }, "error class should still be logged")
+  end
 end

--- a/engines/collavre/test/services/typo_corrector_test.rb
+++ b/engines/collavre/test/services/typo_corrector_test.rb
@@ -87,6 +87,26 @@ module Collavre
       assert_equal "teh", text[edits.first["offset"], "teh".length]
     end
 
+    test "emits the offset in UTF-16 code units so JS slicing stays aligned past astral chars" do
+      # An emoji (astral, 2 UTF-16 code units but 1 Ruby char) precedes the typo.
+      # The client slices the string in JS (UTF-16) coordinates, so a raw Ruby
+      # char index would be off by one and fall back to indexOf — which could
+      # bind the skipped occurrence inside the backticks. The valid "teh" is the
+      # plain-text one at Ruby char index 17, i.e. UTF-16 index 18 (emoji = +1).
+      text = "😊 use `teh` then teh"
+      response = { edits: [ { original: "teh", suggestion: "the", confidence: 0.9 } ] }.to_json
+
+      edits = correct(text, response)
+      assert_equal 1, edits.size
+      offset = edits.first["offset"]
+      assert_equal 18, offset, "offset must count the emoji as two UTF-16 code units"
+
+      # Verify against JS string semantics: slice the UTF-16 buffer by code units.
+      utf16 = text.encode(Encoding::UTF_16LE)
+      js_slice = utf16.byteslice(offset * 2, 3 * 2).force_encoding(Encoding::UTF_16LE).encode(Encoding::UTF_8)
+      assert_equal "teh", js_slice
+    end
+
     test "defaults confidence to 0.5 when missing or non-numeric" do
       text = "teh dog"
       response = { edits: [ { original: "teh", suggestion: "the", reason: "spelling" } ] }.to_json

--- a/engines/collavre/test/services/typo_corrector_test.rb
+++ b/engines/collavre/test/services/typo_corrector_test.rb
@@ -76,6 +76,17 @@ module Collavre
       assert_equal 1, edits.size
     end
 
+    test "returns the offset of the first occurrence outside a skip region" do
+      # The first "teh" sits inside inline code; the valid one is in plain text.
+      text = "use `teh` then teh"
+      response = { edits: [ { original: "teh", suggestion: "the", confidence: 0.9 } ] }.to_json
+
+      edits = correct(text, response)
+      assert_equal 1, edits.size
+      assert_equal 15, edits.first["offset"]
+      assert_equal "teh", text[edits.first["offset"], "teh".length]
+    end
+
     test "defaults confidence to 0.5 when missing or non-numeric" do
       text = "teh dog"
       response = { edits: [ { original: "teh", suggestion: "the", reason: "spelling" } ] }.to_json

--- a/engines/collavre/test/services/typo_corrector_test.rb
+++ b/engines/collavre/test/services/typo_corrector_test.rb
@@ -1,0 +1,108 @@
+require "test_helper"
+
+module Collavre
+  class TypoCorrectorTest < ActiveSupport::TestCase
+    # Minimal stand-in for AiClient that returns a canned LLM response.
+    class StubClient
+      attr_reader :received
+
+      def initialize(response)
+        @response = response
+      end
+
+      def chat(contents)
+        @received = contents
+        @response
+      end
+    end
+
+    def correct(text, response)
+      TypoCorrector.new(client: StubClient.new(response)).correct(text)
+    end
+
+    test "keeps valid in-place spelling fixes" do
+      text = "안녀하세요 저는 콜라브를 만들고 잇습니다"
+      response = {
+        edits: [
+          { original: "안녀하세요", suggestion: "안녕하세요", reason: "spelling", confidence: 0.95 },
+          { original: "잇습니다", suggestion: "있습니다", reason: "spelling", confidence: 0.9 }
+        ]
+      }.to_json
+
+      edits = correct(text, response)
+
+      assert_equal 2, edits.size
+      assert_equal "안녕하세요", edits.first["suggestion"]
+      assert_in_delta 0.95, edits.first["confidence"], 0.001
+    end
+
+    test "strips markdown code fences around the JSON" do
+      text = "teh cat"
+      response = "```json\n{\"edits\":[{\"original\":\"teh\",\"suggestion\":\"the\",\"confidence\":0.9}]}\n```"
+
+      edits = correct(text, response)
+
+      assert_equal 1, edits.size
+      assert_equal "the", edits.first["suggestion"]
+    end
+
+    test "rejects edits whose original is absent from the text" do
+      text = "the cat sat"
+      response = { edits: [ { original: "doge", suggestion: "dog", confidence: 0.9 } ] }.to_json
+
+      assert_empty correct(text, response)
+    end
+
+    test "rejects large rewrites that exceed the edit-distance cap" do
+      text = "I beleive this"
+      response = { edits: [ { original: "beleive", suggestion: "completely different", confidence: 0.9 } ] }.to_json
+
+      assert_empty correct(text, response)
+    end
+
+    test "rejects edits that only occur inside skip regions" do
+      text = "see `recieve()` and https://recieve.example.com and @recieve"
+      response = { edits: [ { original: "recieve", suggestion: "receive", confidence: 0.9 } ] }.to_json
+
+      assert_empty correct(text, response)
+    end
+
+    test "accepts an edit that occurs outside a skip region even if also inside one" do
+      text = "recieve this, not `recieve()`"
+      response = { edits: [ { original: "recieve", suggestion: "receive", confidence: 0.9 } ] }.to_json
+
+      edits = correct(text, response)
+      assert_equal 1, edits.size
+    end
+
+    test "defaults confidence to 0.5 when missing or non-numeric" do
+      text = "teh dog"
+      response = { edits: [ { original: "teh", suggestion: "the", reason: "spelling" } ] }.to_json
+
+      edits = correct(text, response)
+      assert_in_delta 0.5, edits.first["confidence"], 0.001
+    end
+
+    test "deduplicates identical edits" do
+      text = "teh teh"
+      response = {
+        edits: [
+          { original: "teh", suggestion: "the", confidence: 0.9 },
+          { original: "teh", suggestion: "the", confidence: 0.8 }
+        ]
+      }.to_json
+
+      assert_equal 1, correct(text, response).size
+    end
+
+    test "returns empty array for blank input without calling the LLM" do
+      client = StubClient.new("should not be used")
+      assert_empty TypoCorrector.new(client: client).correct("   ")
+      assert_nil client.received
+    end
+
+    test "returns empty array on unparseable LLM output" do
+      assert_empty correct("teh dog", "not json at all")
+    end
+  end
+end

--- a/engines/collavre/test/services/typo_corrector_test.rb
+++ b/engines/collavre/test/services/typo_corrector_test.rb
@@ -137,6 +137,22 @@ module Collavre
       assert_empty correct("teh dog", "not json at all")
     end
 
+    test "does not log the raw model response on a parse error (draft text could be echoed)" do
+      # A failing model can echo the user's unsubmitted draft in its reply; logging
+      # it would leak private text to application logs despite log_interactions: false.
+      draft = "my secret unsubmitted draft text"
+      logged = []
+      fake_logger = Object.new
+      fake_logger.define_singleton_method(:warn) { |msg| logged << msg }
+
+      Rails.stub :logger, fake_logger do
+        assert_empty correct(draft, "garbage #{draft} not json")
+      end
+
+      assert_equal 1, logged.size
+      refute logged.any? { |msg| msg.include?(draft) }, "parse-error log must not contain the draft text"
+    end
+
     test "skips edits inside an HTML/span-style markup region" do
       text = %(<span style="color:recieve">x</span>)
       response = { edits: [ { original: "recieve", suggestion: "receive", confidence: 0.9 } ] }.to_json

--- a/engines/collavre/test/services/typo_corrector_test.rb
+++ b/engines/collavre/test/services/typo_corrector_test.rb
@@ -1,4 +1,5 @@
 require "test_helper"
+require "benchmark"
 
 module Collavre
   class TypoCorrectorTest < ActiveSupport::TestCase
@@ -103,6 +104,23 @@ module Collavre
 
     test "returns empty array on unparseable LLM output" do
       assert_empty correct("teh dog", "not json at all")
+    end
+
+    test "skips edits inside an HTML/span-style markup region" do
+      text = %(<span style="color:recieve">x</span>)
+      response = { edits: [ { original: "recieve", suggestion: "receive", confidence: 0.9 } ] }.to_json
+
+      assert_empty correct(text, response)
+    end
+
+    test "stays linear on a long run of unmatched '<' (no polynomial ReDoS)" do
+      text = "#{'<' * 50_000} teh"
+      response = { edits: [ { original: "teh", suggestion: "the", confidence: 0.9 } ] }.to_json
+
+      edits = nil
+      elapsed = Benchmark.realtime { edits = correct(text, response) }
+      assert_equal 1, edits.size
+      assert_operator elapsed, :<, 1.0, "skip_ranges scan should be linear, took #{elapsed}s"
     end
   end
 end

--- a/engines/collavre/test/services/typo_corrector_test.rb
+++ b/engines/collavre/test/services/typo_corrector_test.rb
@@ -144,6 +144,18 @@ module Collavre
       assert_empty correct(text, response)
     end
 
+    test "passes the resolved typo agent as context user so vendor adapters can resolve it" do
+      # OpenClaw (and any context-driven adapter) reads the gateway/key from the
+      # context user, not the llm_api_key/gateway_url kwargs. Without this, the
+      # adapter is built with user: nil and silently returns no edits.
+      agent = Struct.new(:llm_vendor, :llm_model, :system_prompt, :llm_api_key, :gateway_url).new
+
+      Collavre.user_class.stub :find_by, agent do
+        client = TypoCorrector.new.send(:build_client)
+        assert_same agent, client.send(:context)[:user]
+      end
+    end
+
     test "stays linear on a long run of unmatched '<' (no polynomial ReDoS)" do
       text = "#{'<' * 50_000} teh"
       response = { edits: [ { original: "teh", suggestion: "the", confidence: 0.9 } ] }.to_json

--- a/engines/collavre_github/db/seeds.rb
+++ b/engines/collavre_github/db/seeds.rb
@@ -122,7 +122,7 @@ module CollavreGithub
     end
 
     def default_llm_model
-      ENV.fetch("COLLAVRE_DEFAULT_LLM_MODEL", "gemini-3-flash-preview")
+      ENV.fetch("COLLAVRE_DEFAULT_LLM_MODEL", "gemini-3.1-flash-lite")
     end
   end
 end

--- a/engines/collavre_openclaw/app/services/collavre_openclaw/ai_client_extension.rb
+++ b/engines/collavre_openclaw/app/services/collavre_openclaw/ai_client_extension.rb
@@ -42,14 +42,20 @@ module CollavreOpenclaw
           error_message = e.message
           raise
         ensure
-          log_interaction(
-            messages: messages_data[:messages],
-            tools: [],
-            response_content: response_content,
-            error_message: error_message,
-            input_tokens: nil,
-            output_tokens: nil
-          )
+          # Honor no-log mode (e.g. inline typo correction on *unsubmitted* drafts).
+          # Base Collavre::AiClient#chat gates logging behind @log_interactions; this
+          # prepended adapter path bypasses super, so it must gate it too — otherwise
+          # private drafts leak to ActivityLog for OpenClaw-backed agents.
+          if @log_interactions
+            log_interaction(
+              messages: messages_data[:messages],
+              tools: [],
+              response_content: response_content,
+              error_message: error_message,
+              input_tokens: nil,
+              output_tokens: nil
+            )
+          end
         end
 
         return response_content

--- a/engines/collavre_openclaw/test/services/ai_client_extension_test.rb
+++ b/engines/collavre_openclaw/test/services/ai_client_extension_test.rb
@@ -1,0 +1,59 @@
+require "test_helper"
+
+module CollavreOpenclaw
+  # The OpenClaw adapter path in AiClientExtension#chat bypasses the base
+  # Collavre::AiClient#chat (no `super`), so it must independently honor
+  # @log_interactions — otherwise unsubmitted typo-correction drafts leak to
+  # ActivityLog for OpenClaw-backed agents.
+  class AiClientExtensionTest < ActiveSupport::TestCase
+    # Minimal adapter so chat() doesn't touch the network.
+    class FakeAdapter
+      def initialize(**) ; end
+
+      def chat(_messages_data, &_block)
+        "ok"
+      end
+    end
+
+    setup do
+      Collavre::AiClient.register_adapter("faketest", FakeAdapter)
+    end
+
+    teardown do
+      Collavre::AiClient.adapter_registry.delete("faketest")
+    end
+
+    def build_client(log_interactions:)
+      Collavre::AiClient.new(
+        vendor: "faketest",
+        model: "m",
+        system_prompt: "s",
+        log_interactions: log_interactions
+      )
+    end
+
+    def messages
+      [ { role: :user, parts: [ { text: "안녀하세요" } ] } ]
+    end
+
+    test "does not log the interaction when log_interactions is false" do
+      client = build_client(log_interactions: false)
+      logged = false
+      client.define_singleton_method(:log_interaction) { |**| logged = true }
+
+      client.chat(messages)
+
+      assert_not logged, "draft must not be persisted to ActivityLog on the adapter path"
+    end
+
+    test "logs the interaction when log_interactions is true (default behavior)" do
+      client = build_client(log_interactions: true)
+      logged = false
+      client.define_singleton_method(:log_interaction) { |**| logged = true }
+
+      client.chat(messages)
+
+      assert logged, "normal adapter calls must still be logged"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Inline typo correction for Collavre — Phase 0 (server) + Phase 1 (chat composer UI). Design spec lives in the Creative tree under `자동 오타 수정` (id 14062).

The approach is **structured edits, not rewrite+diff**: the LLM returns a validated edit list (`original`/`suggestion`/`reason`/`confidence`), so the UI maps 1:1 to highlights and every edit is verifiable. Multilingual (ko/en/ja/zh/mixed) comes for free from the model — no per-language rules.

## Phase 0 — backend

- **Typo Corrector agent** seeded (user-configurable vendor/model/system_prompt, default gemini; not event-routed — just a settings holder).
- **`Collavre::TypoCorrector`** service: returns a validated structured edit list, rejecting non-substring originals, large rewrites (edit-distance cap), and edits inside code/URL/mention/markdown-canonical markup.
- **`POST /typo_corrections`** (session-auth): 2D device+location gating (fail-closed re-check), echoes the user's auto-apply threshold.
- **Per-user profile settings**: master toggle, threshold, per-device (voice/soft-keyboard on, physical off) and per-location (chat on, editor off) toggles — migration, model attrs, strong params, form, i18n.

## Phase 1 — chat composer UI

- **`lib/typo_correction.js`**: framework-free core — device classification, 2D gating (mirrors the server), candidate-list construction, edit anchoring/apply with re-anchoring of the remaining edits after one is applied.
- **`modules/typo_corrector.js`**: a backdrop mirror behind the textarea paints two highlight states — **auto-applied** = faint straight underline; **candidate** = wavy dotted amber (shape **and** colour, for colour-blind safety). Debounced POST, device gating, high-confidence auto-apply (caret preserved), click-to-open **creatable combobox** pre-filled with the current document word (Enter = keep; typed words become always-present custom options). On coarse pointers the input is not auto-focused (chip taps are primary; no keyboard spring-up).
- Highlights are a **volatile** layer: `aria-hidden`, never serialized — markdown-canonical storage stays clean.

## 2D gating (AND)

Runs only when master ON **and** the active device toggle ON **and** the input-location toggle ON. Defaults: voice/soft-keyboard ON, physical OFF; chat ON, editor OFF. This keeps LLM cost/latency under tight control.

## Tests

- Ruby: `TypoCorrector` service validation (10 tests).
- JS: pure-logic (19) + jsdom DOM orchestration (6) — 342 JS tests green total.

## Not in this PR (later phases)

- Phase 2: Lexical/markdown inline editor (decorator nodes, re-anchor, canonical safety).
- Phase 3: device-detection refinement, user dictionary ("always ignore"), more languages.