### PR TITLE
feat: preserve user blank lines in inline editor markdown

### DIFF
--- a/engines/collavre/app/javascript/lib/lexical/__tests__/markdown_serialize.test.js
+++ b/engines/collavre/app/javascript/lib/lexical/__tests__/markdown_serialize.test.js
@@ -266,6 +266,61 @@ describe("lexicalToMarkdown", () => {
     })
     expect(lexicalToMarkdown(editor)).toBe("intro\n\n## Sec")
   })
+
+  it("preserves a single blank line (empty paragraph) as a non-breaking space line", () => {
+    const editor = buildEditor((root) => {
+      const a = $createParagraphNode()
+      a.append($createTextNode("abc"))
+      root.append(a)
+      root.append($createParagraphNode()) // user pressed Enter on an empty line
+      const b = $createParagraphNode()
+      b.append($createTextNode("def"))
+      root.append(b)
+    })
+    // The empty line must survive: renderers run with hard breaks, so the
+    // line renders as a visible blank line inside one <p> instead of collapsing.
+    expect(lexicalToMarkdown(editor)).toBe("abc\n\u00A0\ndef")
+  })
+
+  it("preserves multiple consecutive blank lines, one nbsp line each", () => {
+    const editor = buildEditor((root) => {
+      const a = $createParagraphNode()
+      a.append($createTextNode("abc"))
+      root.append(a)
+      root.append($createParagraphNode())
+      root.append($createParagraphNode())
+      const b = $createParagraphNode()
+      b.append($createTextNode("def"))
+      root.append(b)
+    })
+    expect(lexicalToMarkdown(editor)).toBe("abc\n\u00A0\n\u00A0\ndef")
+  })
+
+  it("serializes an editor that holds only empty paragraphs as empty Markdown", () => {
+    const editor = buildEditor((root) => {
+      root.append($createParagraphNode())
+      root.append($createParagraphNode())
+    })
+    // A document with no real content stays empty (no stray nbsp), matching the
+    // pre-existing empty-state contract so placeholders/presence checks hold.
+    expect(lexicalToMarkdown(editor)).toBe("")
+  })
+
+  it("keeps tight lines tight and only the empty line spaced", () => {
+    const editor = buildEditor((root) => {
+      const a = $createParagraphNode()
+      a.append($createTextNode("abc"))
+      root.append(a)
+      const b = $createParagraphNode()
+      b.append($createTextNode("def"))
+      root.append(b)
+      root.append($createParagraphNode())
+      const c = $createParagraphNode()
+      c.append($createTextNode("ghi"))
+      root.append(c)
+    })
+    expect(lexicalToMarkdown(editor)).toBe("abc\ndef\n\u00A0\nghi")
+  })
 })
 
 describe("collapseParagraphBreaks", () => {
@@ -357,7 +412,10 @@ describe("round-trip: rendered HTML -> Lexical -> Markdown", () => {
       "colored text with HTML metacharacters",
       '<p><span style="color: rgb(255, 0, 0)">&lt;tag&gt; &amp; x</span></p>',
       '<span style="color: rgb(255, 0, 0)">&lt;tag&gt; &amp; x</span>'
-    ]
+    ],
+    // A preserved blank line round-trips: markdown_to_html renders the nbsp line
+    // as <br> <br> inside one <p>; re-importing keeps the same canonical form.
+    ["blank line", "<p>abc<br>\u00A0<br>def</p>", "abc\n\u00A0\ndef"]
   ]
 
   it.each(cases)("round-trips %s", (_name, html, expected) => {

--- a/engines/collavre/app/javascript/lib/lexical/markdown_serialize.js
+++ b/engines/collavre/app/javascript/lib/lexical/markdown_serialize.js
@@ -1,4 +1,4 @@
-import { $isTextNode } from "lexical"
+import { $isTextNode, $isParagraphNode } from "lexical"
 import { $convertToMarkdownString, TRANSFORMERS } from "@lexical/markdown"
 
 // Serializes the Lexical editor state to Markdown as the canonical storage
@@ -141,6 +141,25 @@ function decoratorMarkup(node) {
   return null
 }
 
+// A paragraph the user left blank (pressed Enter on an empty line). Decorator-
+// or text-bearing paragraphs are NOT blank, so media and whitespace-with-content
+// keep their normal export.
+function isBlankParagraph(node) {
+  if (!$isParagraphNode(node)) return false
+  return node.getChildren().every((child) => $isTextNode(child) && !child.getTextContent().trim())
+}
+
+// Blank paragraphs -> a non-breaking-space line (U+00A0). The default export
+// collapses an empty paragraph to "" (indistinguishable from the blank line the
+// upstream join inserts between two normal paragraphs), so collapseParagraphBreaks
+// would erase a deliberately-typed empty line. A NBSP line is non-blank Markdown,
+// so the hard-break renderer keeps it as a visible empty line inside one <p>
+// instead of collapsing it — and N empty paragraphs render as N blank lines.
+const EMPTY_PARAGRAPH_TRANSFORMER = exportOnlyTransformer(
+  (node) => (isBlankParagraph(node) ? "\u00A0" : null),
+  { type: "element" }
+)
+
 // Colored / highlighted text -> normalized <span>. Falls through (returns null)
 // for uncolored text so the default text-format export still applies.
 const COLOR_TRANSFORMER = exportOnlyTransformer((node, _exportChildren, exportFormat) => {
@@ -169,6 +188,7 @@ const DECORATOR_ELEMENT_TRANSFORMER = exportOnlyTransformer((node) => decoratorM
 // claimed before the upstream defaults (which would drop their style/content).
 export const MARKDOWN_TRANSFORMERS = [
   DECORATOR_ELEMENT_TRANSFORMER,
+  EMPTY_PARAGRAPH_TRANSFORMER,
   DECORATOR_TEXT_TRANSFORMER,
   COLOR_TRANSFORMER,
   ...TRANSFORMERS
@@ -196,6 +216,11 @@ function isPlainParagraph(block) {
 // never typed. Headings, lists, quotes, code fences, tables and media keep their
 // standard blank-line separation.
 export function collapseParagraphBreaks(markdown) {
+  // A document made only of blank paragraphs (each now a U+00A0 line) carries no
+  // real content — keep it empty so the empty-state contract (placeholders,
+  // description presence) is unchanged. trim() drops the nbsp too.
+  if (!String(markdown).trim()) return ""
+
   const fences = []
   const guarded = String(markdown).replace(FENCE_BLOCK, (match) => {
     fences.push(match)

--- a/engines/collavre/test/services/collavre/markdown_converter_test.rb
+++ b/engines/collavre/test/services/collavre/markdown_converter_test.rb
@@ -34,6 +34,20 @@ module Collavre
       assert_equal 2, html.scan("<p>").length
     end
 
+    test "markdown_to_html renders a non-breaking-space line as a visible blank line" do
+      # The Lexical serializer stores a user's empty line as a U+00A0 line so it
+      # survives Markdown rendering instead of collapsing. With hardbreaks the
+      # nbsp line becomes a blank visual row inside one paragraph (a<br>nbsp<br>b),
+      # and N empty lines render as N blank rows.
+      html = MarkdownConverter.markdown_to_html("abc\n\u00A0\ndef")
+      assert_equal 1, html.scan("<p>").length
+      assert_equal 2, html.scan("<br").length
+      assert_includes html, "\u00A0"
+
+      two = MarkdownConverter.markdown_to_html("abc\n\u00A0\n\u00A0\ndef")
+      assert_equal 3, two.scan("<br").length
+    end
+
     test "html_to_markdown handles nil" do
       assert_equal "", MarkdownConverter.html_to_markdown(nil)
     end


### PR DESCRIPTION
## Problem

In the creative inline editor, blank lines the user deliberately inserts (pressing Enter on an empty line) were silently dropped from the rendered output — the lines collapsed together. Adding several blank lines for spacing had no visible effect.

## Root cause

The canonical `markdown_source` is produced by `$convertToMarkdownString` + `collapseParagraphBreaks`:

1. Upstream `$convertToMarkdownString` serializes an **empty paragraph** the exact same way it **separates two normal paragraphs** — as a bare blank line. The two cases are indistinguishable in its output.
2. `collapseParagraphBreaks` joins consecutive plain paragraphs with a single newline (an earlier feature so multi-line rich text renders tight, without inserted blank lines). It therefore also erased the *deliberate* blank line, since it couldn't tell it apart from the upstream separator.
3. Even when a blank line did survive, commonmarker collapses multiple blank lines to a single paragraph break, so N empty lines could never render as N blank rows.

## Fix

Serialize each genuinely-blank paragraph as a non-breaking-space (`U+00A0`) line via a new export-only **element** transformer (`EMPTY_PARAGRAPH_TRANSFORMER`).

A nbsp line is non-blank Markdown, so with `hardbreaks: true` (both the JS `marked` and Ruby commonmarker renderers) it renders as a visible empty row inside a single `<p>` (`a<br> <br>b`). N empty paragraphs render as N blank rows — and consecutive non-empty lines stay tight as before.

A document made of *only* blank paragraphs still serializes to `""`, so the empty-state contract (placeholders, `description` presence validation) is unchanged.

## Tests

- `markdown_serialize.test.js`: single/multiple blank lines, tight-then-blank mix, all-empty doc → `""`, and a markdown → HTML → Lexical → markdown round-trip for the blank line.
- `markdown_converter_test.rb`: asserts a nbsp line renders as a visible blank row (1 `<p>`, 2 `<br>`) and that N nbsp lines render N rows.

All 322 JS tests and 40 `MarkdownConverter` Ruby tests pass; rubocop clean.