### PR TITLE
fix: surface server error payload in API failure alerts

### DIFF
--- a/engines/collavre/app/javascript/lib/api/__tests__/api_error.test.js
+++ b/engines/collavre/app/javascript/lib/api/__tests__/api_error.test.js
@@ -1,0 +1,96 @@
+/**
+ * @jest-environment jsdom
+ */
+import { ApiError, apiErrorFromResponse, serverErrorMessage } from '../api_error'
+
+// Minimal Response-like stub: text() resolves once with the given body.
+function fakeResponse({ status = 422, statusText = 'Unprocessable Entity', body = '' } = {}) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText,
+    text: async () => body,
+  }
+}
+
+describe('apiErrorFromResponse', () => {
+  test('surfaces a Rails {errors: [...]} string array as the message', async () => {
+    const response = fakeResponse({
+      body: JSON.stringify({
+        errors: ['Description cannot be changed directly for GitHub synced content'],
+      }),
+    })
+
+    const error = await apiErrorFromResponse(response)
+
+    expect(error).toBeInstanceOf(ApiError)
+    expect(error.status).toBe(422)
+    expect(error.errors).toEqual([
+      'Description cannot be changed directly for GitHub synced content',
+    ])
+    expect(error.message).toBe(
+      'Description cannot be changed directly for GitHub synced content',
+    )
+  })
+
+  test('joins multiple error messages with newlines', async () => {
+    const response = fakeResponse({
+      body: JSON.stringify({ errors: ['First problem', 'Second problem'] }),
+    })
+
+    const error = await apiErrorFromResponse(response)
+
+    expect(error.errors).toEqual(['First problem', 'Second problem'])
+    expect(error.message).toBe('First problem\nSecond problem')
+  })
+
+  test('flattens a Rails hash-style {errors: {field: [...]}} payload', async () => {
+    const response = fakeResponse({
+      body: JSON.stringify({ errors: { description: ['is invalid', 'is too long'] } }),
+    })
+
+    const error = await apiErrorFromResponse(response)
+
+    expect(error.errors).toEqual(['is invalid', 'is too long'])
+  })
+
+  test('supports a singular {error: "..."} payload', async () => {
+    const response = fakeResponse({ status: 403, body: JSON.stringify({ error: 'Forbidden' }) })
+
+    const error = await apiErrorFromResponse(response)
+
+    expect(error.errors).toEqual(['Forbidden'])
+    expect(error.message).toBe('Forbidden')
+  })
+
+  test('falls back to HTTP status when the body has no usable payload', async () => {
+    const response = fakeResponse({ status: 500, statusText: 'Internal Server Error', body: '' })
+
+    const error = await apiErrorFromResponse(response)
+
+    expect(error.errors).toEqual([])
+    expect(error.message).toBe('HTTP 500: Internal Server Error')
+  })
+
+  test('falls back to HTTP status when the body is not JSON', async () => {
+    const response = fakeResponse({ status: 502, statusText: 'Bad Gateway', body: '<html>oops</html>' })
+
+    const error = await apiErrorFromResponse(response)
+
+    expect(error.errors).toEqual([])
+    expect(error.message).toBe('HTTP 502: Bad Gateway')
+  })
+})
+
+describe('serverErrorMessage', () => {
+  test('returns the joined server messages when present', () => {
+    const error = new ApiError('boom', { errors: ['Bad thing', 'Worse thing'] })
+    expect(serverErrorMessage(error)).toBe('Bad thing\nWorse thing')
+  })
+
+  test('returns null for a plain error with no server payload', () => {
+    expect(serverErrorMessage(new Error('HTTP 422: Unprocessable Entity'))).toBeNull()
+    expect(serverErrorMessage(new ApiError('boom', { errors: [] }))).toBeNull()
+    expect(serverErrorMessage(undefined)).toBeNull()
+  })
+})

--- a/engines/collavre/app/javascript/lib/api/__tests__/queue_manager.test.js
+++ b/engines/collavre/app/javascript/lib/api/__tests__/queue_manager.test.js
@@ -177,4 +177,53 @@ describe('ApiQueueManager', () => {
         expect(failedItems[0].path).toBe('/fail');
         expect(failedItems[0].failedAt).toBeDefined();
     });
+
+    test('executeRequest throws an ApiError carrying the server error payload', async () => {
+        mockCsrfFetch.mockResolvedValue({
+            ok: false,
+            status: 422,
+            statusText: 'Unprocessable Entity',
+            text: async () => JSON.stringify({
+                errors: ['Description cannot be changed directly for GitHub synced content'],
+            }),
+        });
+
+        await expect(apiQueue.executeRequest({ path: '/creatives/42', method: 'PATCH' }))
+            .rejects.toMatchObject({
+                status: 422,
+                errors: ['Description cannot be changed directly for GitHub synced content'],
+                message: 'Description cannot be changed directly for GitHub synced content',
+            });
+    });
+
+    test('does not retry non-retryable client errors (422)', async () => {
+        apiQueue.processQueue.mockRestore();
+
+        const eventSpy = jest.spyOn(window, 'dispatchEvent');
+
+        // A 422 validation error will never succeed on retry — it must fail fast.
+        mockCsrfFetch.mockResolvedValue({
+            ok: false,
+            status: 422,
+            statusText: 'Unprocessable Entity',
+            text: async () => JSON.stringify({ errors: ['Cannot do that'] }),
+        });
+
+        const item = { path: '/creatives/42', method: 'PATCH', retries: 0 };
+        apiQueue.queue = [item];
+
+        await apiQueue.processQueue();
+
+        // Exactly one attempt — no retries.
+        expect(mockCsrfFetch).toHaveBeenCalledTimes(1);
+
+        const failureEvent = eventSpy.mock.calls
+            .map(([event]) => event)
+            .find((event) => event.type === 'api-queue-request-failed');
+        expect(failureEvent).toBeDefined();
+        expect(failureEvent.detail.error.errors).toEqual(['Cannot do that']);
+
+        const failedItems = JSON.parse(localStorage.getItem('api_queue_test_user_failed'));
+        expect(failedItems).toHaveLength(1);
+    });
 });

--- a/engines/collavre/app/javascript/lib/api/__tests__/queue_manager.test.js
+++ b/engines/collavre/app/javascript/lib/api/__tests__/queue_manager.test.js
@@ -5,9 +5,11 @@ import { jest } from '@jest/globals';
 
 // Mock csrfFetch using unstable_mockModule for ESM support
 const mockCsrfFetch = jest.fn();
+const mockRefreshCsrfToken = jest.fn().mockResolvedValue('fresh-token');
 jest.unstable_mockModule('../csrf_fetch', () => ({
     __esModule: true,
-    default: mockCsrfFetch
+    default: mockCsrfFetch,
+    refreshCsrfToken: mockRefreshCsrfToken,
 }));
 
 // Dynamic imports are required when using unstable_mockModule
@@ -19,6 +21,7 @@ describe('ApiQueueManager', () => {
         apiQueue.clear();
         localStorage.clear();
         mockCsrfFetch.mockClear();
+        mockRefreshCsrfToken.mockClear();
         // Reset processing state
         apiQueue.processing = false;
         // Mock processQueue to prevent auto-execution during enqueue tests
@@ -225,5 +228,40 @@ describe('ApiQueueManager', () => {
 
         const failedItems = JSON.parse(localStorage.getItem('api_queue_test_user_failed'));
         expect(failedItems).toHaveLength(1);
+    });
+
+    test('refreshes the CSRF token and retries a payload-less 422 (stale token)', async () => {
+        apiQueue.processQueue.mockRestore();
+
+        // A stale CSRF token (e.g. after the tab was backgrounded) returns 422
+        // with no error payload — unlike a validation 422, it is recoverable by
+        // refreshing the token and retrying.
+        mockCsrfFetch
+            .mockResolvedValueOnce({
+                ok: false,
+                status: 422,
+                statusText: 'Unprocessable Entity',
+                text: async () => '',
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                status: 200,
+                text: async () => JSON.stringify({ id: 42 }),
+            });
+
+        const onSuccess = jest.fn();
+        const item = { path: '/creatives/42', method: 'PATCH', retries: 0, onSuccess };
+        apiQueue.queue = [item];
+
+        await apiQueue.processQueue();
+
+        // Token refreshed once, then the request retried and succeeded.
+        expect(mockRefreshCsrfToken).toHaveBeenCalledTimes(1);
+        expect(mockCsrfFetch).toHaveBeenCalledTimes(2);
+        expect(onSuccess).toHaveBeenCalled();
+        expect(apiQueue.queue).toHaveLength(0);
+
+        const stored = localStorage.getItem('api_queue_test_user_failed');
+        expect(stored ? JSON.parse(stored) : []).toHaveLength(0);
     });
 });

--- a/engines/collavre/app/javascript/lib/api/api_error.js
+++ b/engines/collavre/app/javascript/lib/api/api_error.js
@@ -1,0 +1,108 @@
+/**
+ * Shared API error handling.
+ *
+ * Server endpoints report failures as JSON, most commonly the Rails shape
+ * `{ "errors": ["..."] }` (see CreativesController#update). When a request
+ * fails we want the user to see the *server's* message ("Description cannot be
+ * changed directly for GitHub synced content") rather than an opaque
+ * "HTTP 422". This module centralises that extraction so every API caller can
+ * surface the real reason with a generic fallback.
+ */
+
+/**
+ * Error carrying the parsed server payload alongside the HTTP status.
+ * `errors` is always an array of human-readable strings (possibly empty).
+ */
+export class ApiError extends Error {
+  constructor(message, { status, statusText, errors = [], payload = null } = {}) {
+    super(message)
+    this.name = 'ApiError'
+    this.status = status
+    this.statusText = statusText
+    this.errors = errors
+    this.payload = payload
+  }
+}
+
+function stringifyEntry(entry) {
+  if (typeof entry === 'string') return entry.trim()
+  if (entry && typeof entry === 'object') {
+    return String(entry.message || entry.detail || entry.title || '').trim()
+  }
+  return ''
+}
+
+/**
+ * Normalise the assorted server error payload shapes into a flat list of
+ * human-readable strings.
+ *
+ * Supported shapes:
+ *   { errors: ["a", "b"] }                 -> ["a", "b"]
+ *   { errors: { field: ["a"], x: ["b"] } } -> ["a", "b"]  (Rails errors hash)
+ *   { errors: [{ message: "a" }] }         -> ["a"]
+ *   { error: "a" } / { message: "a" }      -> ["a"]
+ */
+export function extractServerErrors(payload) {
+  if (!payload || typeof payload !== 'object') return []
+
+  const { errors } = payload
+  if (Array.isArray(errors)) {
+    return errors.map(stringifyEntry).filter(Boolean)
+  }
+  if (errors && typeof errors === 'object') {
+    return Object.values(errors).flat().map(stringifyEntry).filter(Boolean)
+  }
+  if (typeof payload.error === 'string' && payload.error.trim()) {
+    return [payload.error.trim()]
+  }
+  if (typeof payload.message === 'string' && payload.message.trim()) {
+    return [payload.message.trim()]
+  }
+  return []
+}
+
+/**
+ * Build an {@link ApiError} from a non-ok Response, reading and parsing its
+ * body. Best-effort: an empty or non-JSON body yields an error that falls back
+ * to the HTTP status line. Consumes the response body, so only call this on the
+ * failure path.
+ *
+ * @param {Response} response
+ * @returns {Promise<ApiError>}
+ */
+export async function apiErrorFromResponse(response) {
+  let payload = null
+  try {
+    const text = typeof response.text === 'function' ? await response.text() : ''
+    payload = text ? JSON.parse(text) : null
+  } catch (_parseError) {
+    payload = null
+  }
+
+  const errors = extractServerErrors(payload)
+  const message = errors.length
+    ? errors.join('\n')
+    : `HTTP ${response.status}: ${response.statusText}`
+
+  return new ApiError(message, {
+    status: response.status,
+    statusText: response.statusText,
+    errors,
+    payload,
+  })
+}
+
+/**
+ * Best user-facing message for a caught error: the server-provided messages
+ * when available, otherwise `null` so the caller can apply its own generic
+ * fallback copy.
+ *
+ * @param {unknown} error
+ * @returns {string|null}
+ */
+export function serverErrorMessage(error) {
+  if (error && Array.isArray(error.errors) && error.errors.length) {
+    return error.errors.join('\n')
+  }
+  return null
+}

--- a/engines/collavre/app/javascript/lib/api/queue_manager.js
+++ b/engines/collavre/app/javascript/lib/api/queue_manager.js
@@ -1,7 +1,18 @@
 import csrfFetch from './csrf_fetch'
+import { apiErrorFromResponse } from './api_error'
 
 const STORAGE_KEY = 'api_queue'
 const MAX_RETRIES = 3
+
+// Client errors that will never succeed on retry (validation, auth, conflict,
+// not-found). Retrying them just delays the real error and wastes round-trips,
+// so they fail fast straight to failedItems. 408 (timeout) and 429 (rate limit)
+// are intentionally excluded — those are worth retrying.
+const NON_RETRYABLE_STATUSES = new Set([400, 401, 403, 404, 409, 422])
+
+function isRetryable(error) {
+    return !(error && NON_RETRYABLE_STATUSES.has(error.status))
+}
 
 /**
  * API Queue Manager
@@ -267,8 +278,10 @@ class ApiQueueManager {
             } catch (error) {
                 console.error('API request failed:', error, item)
 
-                // Retry logic
-                if (item.retries < MAX_RETRIES) {
+                // Retry logic — skip retries for client errors that can't
+                // succeed on a repeat (e.g. 422 validation): fail fast so the
+                // user sees the real error immediately.
+                if (isRetryable(error) && item.retries < MAX_RETRIES) {
                     item.retries++
                     // Move to end of queue for retry
                     this.queue.shift()
@@ -353,7 +366,9 @@ class ApiQueueManager {
         const response = await csrfFetch(url, options)
 
         if (!response.ok) {
-            throw new Error(`HTTP ${response.status}: ${response.statusText}`)
+            // Surface the server's error payload (e.g. Rails { errors: [...] })
+            // instead of an opaque "HTTP 422" so the UI can show the real reason.
+            throw await apiErrorFromResponse(response)
         }
 
         return response

--- a/engines/collavre/app/javascript/lib/api/queue_manager.js
+++ b/engines/collavre/app/javascript/lib/api/queue_manager.js
@@ -1,4 +1,4 @@
-import csrfFetch from './csrf_fetch'
+import csrfFetch, { refreshCsrfToken } from './csrf_fetch'
 import { apiErrorFromResponse } from './api_error'
 
 const STORAGE_KEY = 'api_queue'
@@ -8,10 +8,23 @@ const MAX_RETRIES = 3
 // not-found). Retrying them just delays the real error and wastes round-trips,
 // so they fail fast straight to failedItems. 408 (timeout) and 429 (rate limit)
 // are intentionally excluded — those are worth retrying.
-const NON_RETRYABLE_STATUSES = new Set([400, 401, 403, 404, 409, 422])
+const NON_RETRYABLE_STATUSES = new Set([400, 401, 403, 404, 409])
+
+// A 422 is ambiguous. A validation failure carries a server error payload
+// (e.g. { errors: [...] }) and will never succeed on retry. A stale CSRF token
+// (the meta-tag token drifts out of sync after the tab is backgrounded — see
+// Application#set_csrf_token_header) also returns 422 but with no payload, and
+// IS recoverable by refreshing the token and retrying.
+function isStaleCsrf(error) {
+    return !!error && error.status === 422 && !(error.errors && error.errors.length)
+}
 
 function isRetryable(error) {
-    return !(error && NON_RETRYABLE_STATUSES.has(error.status))
+    if (!error) return true
+    if (NON_RETRYABLE_STATUSES.has(error.status)) return false
+    // Validation 422 (has payload) fails fast; payload-less 422 (stale CSRF) retries.
+    if (error.status === 422) return isStaleCsrf(error)
+    return true
 }
 
 /**
@@ -283,6 +296,12 @@ class ApiQueueManager {
                 // user sees the real error immediately.
                 if (isRetryable(error) && item.retries < MAX_RETRIES) {
                     item.retries++
+                    // A payload-less 422 is a stale CSRF token; refresh it first
+                    // so the retry has a fresh token (the failed response itself
+                    // carries none — the forgery exception skips the after_action).
+                    if (isStaleCsrf(error)) {
+                        await refreshCsrfToken()
+                    }
                     // Move to end of queue for retry
                     this.queue.shift()
                     this.queue.push(item)

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -8,6 +8,7 @@ import { renderMarkdown } from '../lib/utils/markdown'
 import { reconcileMarkdownSource } from './markdown_source_reconcile'
 import { isHtmlEmpty } from './html_content_empty'
 import { confirmDialog, alertDialog } from '../lib/utils/dialog'
+import { serverErrorMessage } from '../lib/api/api_error'
 import yaml from 'js-yaml'
 // Import Stimulus application from the global window (set by host app)
 const application = window.Stimulus
@@ -58,11 +59,15 @@ export function initializeCreativeRowEditor() {
       // In a real app, use a toast notification. For now, alert is safe.
       // Suppress 404 errors for PATCH requests, as this likely means the item was deleted
       // and we don't need to alert the user about it.
-      const is404 = error && error.toString().includes('404');
+      const is404 = (error && error.status === 404) || (error && error.toString().includes('404'));
       const isPatch = item && item.method === 'PATCH';
 
       if (!(is404 && isPatch)) {
-        alertDialog(`Failed to save changes. Please check your connection and try again.\nError: ${error}`);
+        // Prefer the server's own error message (e.g. "Description cannot be
+        // changed directly for GitHub synced content") and fall back to the
+        // generic copy only when the failure carries no usable payload.
+        const serverMessage = serverErrorMessage(error);
+        alertDialog(serverMessage || 'Failed to save changes. Please check your connection and try again.');
       }
 
       // If the failed item matches the current creative, mark it as dirty so it can be retried


### PR DESCRIPTION
## Problem

When a save/update request fails with a server error payload like:

```json
{ "errors": ["Description cannot be changed directly for GitHub synced content"] }
```

(HTTP 422), the UI showed only a generic, unhelpful message:

```
Failed to save changes. Please check your connection and try again.
Error: Error: HTTP 422:
```

Root cause: `queue_manager.js`'s `executeRequest` threw a bare `new Error("HTTP <status>: ...")` **without reading the response body**, so the server's `{ "errors": [...] }` payload was discarded before the UI ever saw it.

## Fix

- **New shared helper** `engines/collavre/app/javascript/lib/api/api_error.js` (the common code requested):
  - `apiErrorFromResponse(response)` reads the body and normalizes every common server shape (`{errors:[...]}`, Rails `{errors:{field:[...]}}`, `{error}`/`{message}`) into a readable message, falling back to `HTTP <status>` only when there's no usable payload. The returned `ApiError` carries `.status`.
  - `serverErrorMessage(error)` returns the server message or `null` so callers can apply their own generic fallback.
- **`queue_manager.js`** — throws the parsed `ApiError` on failure, and skips retries for non-retryable 4xx (400/401/403/404/409/422) so a validation error surfaces immediately instead of after 3 pointless retries.
- **`creative_row_editor.js`** — prefers the server message, generic copy only as fallback; 404-suppression now keys off `error.status`.

Strategy: prefer the server error payload when present, fall back to the generic message otherwise — applied via shared code reusable by the other ~40 fetch call sites (scoped this PR to the reported failure path).

## Tests

- TDD: new unit tests for `api_error.js` + integration tests for the queue manager error path.
- Full JS suite green (327 tests), bundle rebuilt.