### PR TITLE
fix: keep YouTube preview iframe through client-side sanitizer

### DIFF
--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -157,6 +157,10 @@ module Collavre
             render json: {
               id: @creative.id,
               description: @creative.effective_description,
+              # Embedded variant for read-only display (e.g. slide view): turns
+              # bare YouTube links into preview iframes. `description` stays the
+              # raw editable form the inline editor round-trips.
+              description_embedded_html: view_context.embed_youtube_iframe(@creative.effective_description),
               description_raw_html: @creative.description,
               origin_id: @creative.origin_id,
               parent_id: @creative.parent_id,

--- a/engines/collavre/app/javascript/components/creative_tree_row.js
+++ b/engines/collavre/app/javascript/components/creative_tree_row.js
@@ -1,8 +1,8 @@
 import { LitElement, html, svg, nothing } from "lit";
-import DOMPurify from "dompurify";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { parseEmojis } from "../utils/emoji_parser";
 import { highlightCodeBlocks } from "../lib/utils/markdown";
+import { sanitizeDescriptionHtml } from "../lib/utils/sanitize_description";
 import csrfFetch from "../lib/api/csrf_fetch";
 
 const BULLET_STARTING_LEVEL = 3;
@@ -106,8 +106,10 @@ class CreativeTreeRow extends LitElement {
 
   set descriptionHtml(value) {
     const oldValue = this._descriptionHtml;
-    // Always sanitize when setting new HTML
-    const sanitized = DOMPurify.sanitize(value ?? "");
+    // Always sanitize when setting new HTML. Uses the shared sanitizer so the
+    // server-generated YouTube preview iframe survives (default DOMPurify config
+    // strips all iframes, which is what broke the YouTube link preview).
+    const sanitized = sanitizeDescriptionHtml(value);
     this._descriptionHtml = sanitized;
     this.dataset.descriptionHtml = sanitized;
     this.requestUpdate("descriptionHtml", oldValue);

--- a/engines/collavre/app/javascript/lib/utils/__tests__/sanitize_description.test.js
+++ b/engines/collavre/app/javascript/lib/utils/__tests__/sanitize_description.test.js
@@ -1,0 +1,68 @@
+import { sanitizeDescriptionHtml } from '../sanitize_description'
+
+describe('sanitizeDescriptionHtml', () => {
+  test('keeps a YouTube embed iframe the server generated', () => {
+    const html =
+      '<p><iframe src="https://www.youtube.com/embed/dQw4w9WgXcQ" ' +
+      'title="YouTube video player" frameborder="0" ' +
+      'allow="autoplay; encrypted-media" allowfullscreen></iframe></p>'
+    const out = sanitizeDescriptionHtml(html)
+    expect(out).toContain('<iframe')
+    expect(out).toContain('youtube.com/embed/dQw4w9WgXcQ')
+    expect(out).toContain('allowfullscreen')
+  })
+
+  test('keeps a youtube-nocookie embed iframe', () => {
+    const html =
+      '<iframe src="https://www.youtube-nocookie.com/embed/abc123"></iframe>'
+    expect(sanitizeDescriptionHtml(html)).toContain('<iframe')
+  })
+
+  test('strips a non-YouTube iframe (XSS protection)', () => {
+    const html = '<p><iframe src="https://evil.example.com/x"></iframe></p>'
+    const out = sanitizeDescriptionHtml(html)
+    expect(out).not.toContain('<iframe')
+    expect(out).not.toContain('evil.example.com')
+  })
+
+  test('strips an iframe pointing at the YouTube watch page (not /embed/)', () => {
+    const html =
+      '<iframe src="https://www.youtube.com/watch?v=dQw4w9WgXcQ"></iframe>'
+    expect(sanitizeDescriptionHtml(html)).not.toContain('<iframe')
+  })
+
+  test('strips an iframe with a javascript: src', () => {
+    const html = '<iframe src="javascript:alert(1)"></iframe>'
+    expect(sanitizeDescriptionHtml(html)).not.toContain('<iframe')
+  })
+
+  test('strips script tags', () => {
+    const out = sanitizeDescriptionHtml('<p>hi</p><script>alert(1)</script>')
+    expect(out).toContain('hi')
+    expect(out).not.toContain('<script')
+  })
+
+  test('preserves ordinary description markup', () => {
+    const html = '<p>Hello <strong>world</strong></p>'
+    expect(sanitizeDescriptionHtml(html)).toBe(html)
+  })
+
+  test('treats null/undefined as empty string', () => {
+    expect(sanitizeDescriptionHtml(null)).toBe('')
+    expect(sanitizeDescriptionHtml(undefined)).toBe('')
+  })
+})
+
+describe('global iframe hook does not leak into the markdown/comment path', () => {
+  test('renderMarkdown still strips YouTube iframes when the hook is loaded', async () => {
+    // Importing the sanitizer registers a global DOMPurify uponSanitizeElement
+    // hook. The comment/markdown sanitizer does not allow <iframe>, so even a
+    // trusted YouTube iframe must still be stripped there.
+    await import('../sanitize_description')
+    const { renderMarkdown } = await import('../markdown')
+    const out = renderMarkdown(
+      '<p><iframe src="https://www.youtube.com/embed/abc"></iframe></p>'
+    )
+    expect(out).not.toContain('<iframe')
+  })
+})

--- a/engines/collavre/app/javascript/lib/utils/sanitize_description.js
+++ b/engines/collavre/app/javascript/lib/utils/sanitize_description.js
@@ -1,0 +1,31 @@
+import DOMPurify from 'dompurify'
+
+// Trusted YouTube embed origins. The server's `embed_youtube_iframe` helper
+// (app/helpers/application_helper.rb) only ever emits `youtube.com/embed/...`
+// iframes, so we mirror that here and refuse every other iframe source.
+const YOUTUBE_EMBED_SRC =
+  /^https:\/\/(www\.)?(youtube\.com|youtube-nocookie\.com)\/embed\//i
+
+// DOMPurify's default config strips <iframe> entirely, which silently removed
+// the YouTube preview iframe the server had already generated — the description
+// rendered blank. Re-allow iframes, but only from trusted YouTube embed origins
+// so arbitrary iframe injection (clickjacking / XSS) stays blocked.
+DOMPurify.addHook('uponSanitizeElement', (node, data) => {
+  if (data.tagName !== 'iframe') return
+  const src = node.getAttribute && node.getAttribute('src')
+  if (!src || !YOUTUBE_EMBED_SRC.test(src)) {
+    node.parentNode && node.parentNode.removeChild(node)
+  }
+})
+
+// Mirrors the iframe attributes in EMBED_ALLOWED_ATTRS server-side.
+const PURIFY_CONFIG = {
+  ADD_TAGS: ['iframe'],
+  ADD_ATTR: ['allow', 'allowfullscreen', 'frameborder']
+}
+
+// Sanitize creative description HTML for client-side rendering while keeping the
+// server-generated YouTube preview iframe intact.
+export function sanitizeDescriptionHtml(html) {
+  return DOMPurify.sanitize(html ?? '', PURIFY_CONFIG)
+}

--- a/engines/collavre/app/javascript/modules/slide_view.js
+++ b/engines/collavre/app/javascript/modules/slide_view.js
@@ -1,6 +1,6 @@
 import { createSubscription } from '../services/cable'
 import { highlightCodeBlocks } from '../lib/utils/markdown'
-import DOMPurify from 'dompurify'
+import { sanitizeDescriptionHtml } from '../lib/utils/sanitize_description'
 
 document.addEventListener('DOMContentLoaded', function() {
   var container = document.getElementById('slide-view');
@@ -65,7 +65,7 @@ document.addEventListener('DOMContentLoaded', function() {
         contentEl.innerHTML = '';
         var el = document.createElement(tag);
         el.className = 'creative-content';
-        el.innerHTML = DOMPurify.sanitize(data.description);
+        el.innerHTML = sanitizeDescriptionHtml(data.description_embedded_html || data.description);
         contentEl.appendChild(el);
         highlightCodeBlocks(el);
         if (captionEl) {

--- a/engines/collavre/app/views/collavre/creatives/slide_view.html.erb
+++ b/engines/collavre/app/views/collavre/creatives/slide_view.html.erb
@@ -8,7 +8,7 @@
 <% initial_index = params[:slide].to_i.clamp(0, @slide_ids.length - 1) %>
 <% initial_prompt = @creative.prompt_for(Current.user) %>
 <div id="slide-view" data-slide-ids="<%= @slide_ids.join(',') %>" data-initial-index="<%= initial_index %>" data-root-id="<%= @creative.id %>">
-  <div id="slide-content"><%= content_tag(tag_name, sanitize(@creative.effective_description, tags: Rails::HTML5::SafeListSanitizer.allowed_tags.to_a + %w[table thead tbody tfoot tr th td], attributes: Rails::HTML5::SafeListSanitizer.allowed_attributes.to_a + %w[colspan rowspan data-lexical]), class: 'creative-content') %></div>
+  <div id="slide-content"><%= content_tag(tag_name, embed_youtube_iframe(@creative.effective_description), class: 'creative-content') %></div>
 </div>
 <div id="slide-controls">
   <div id="slide-counter"><%= initial_index + 1 %> / <%= @slide_ids.length %></div>


### PR DESCRIPTION
## Problem

Typing a YouTube link into a creative description should render an inline preview, but the preview was broken (blank in the tree/panel view).

## Root cause

The server's `embed_youtube_iframe` helper correctly converts a YouTube `<a>` link into an `<iframe src="youtube.com/embed/...">`. The client then re-sanitizes the description before rendering, but `creative_tree_row.js` (and `slide_view.js`) called `DOMPurify.sanitize(value)` with the **default config**, which strips all `<iframe>` elements. The server-generated preview iframe was silently removed, leaving a blank description. This affected the main tree/panel render since #526.

## Fix

- Add a shared `lib/utils/sanitize_description.js#sanitizeDescriptionHtml` that re-allows `<iframe>` but only from trusted YouTube embed origins (`youtube.com/embed`, `youtube-nocookie.com/embed`) via a DOMPurify `uponSanitizeElement` hook, mirroring the server `EMBED_ALLOWED_TAGS/ATTRS` safelist. Any other iframe (incl. `javascript:` and `youtube.com/watch`) is dropped.
- Use it in `creative_tree_row.js` (the reported bug) and `slide_view.js`.
- Slide view: render the embed on the initial server-rendered slide (`slide_view.html.erb` now uses `embed_youtube_iframe`, consistent with the tree view) and add a `description_embedded_html` field to the creative JSON for the JS navigation path. The editable `description` field stays raw HTML so the inline editor keeps round-tripping the link.

## Safety

The global DOMPurify hook only retains YouTube-origin iframes; the markdown/comment sanitizer does not allow iframes and continues to strip them (covered by a test).

## Tests

`engines/collavre/app/javascript/lib/utils/__tests__/sanitize_description.test.js`:
- keeps `youtube.com/embed` and `youtube-nocookie` iframes
- strips non-YouTube, `javascript:`, and `youtube.com/watch` iframes
- strips `<script>`, preserves ordinary markup, handles null/undefined
- markdown/comment path still strips all iframes when the hook is loaded

## Verification

Verified end-to-end in a real browser (logged-in admin, creative authored via the markdown editor):
- Tree/panel view renders the YouTube preview iframe.
- Slide view renders the iframe on initial load and via JS navigation.
- `description_embedded_html` carries the iframe; `description` stays raw.
