### PR TITLE
fix(creatives): keep ArrowUp inside inline editor when not at document start

### DIFF
--- a/engines/collavre/app/javascript/lib/lexical/__tests__/selection_boundary.test.js
+++ b/engines/collavre/app/javascript/lib/lexical/__tests__/selection_boundary.test.js
@@ -1,0 +1,88 @@
+import {
+  createEditor,
+  $getRoot,
+  $createParagraphNode,
+  $createTextNode,
+  $getSelection
+} from "lexical"
+import { registerRichText } from "@lexical/rich-text"
+import {
+  isSelectionAtDocumentStart,
+  isSelectionAtDocumentEnd
+} from "../selection_boundary"
+
+function buildEditor() {
+  const editor = createEditor({
+    namespace: "test",
+    onError(error) {
+      throw error
+    }
+  })
+  registerRichText(editor)
+  return editor
+}
+
+// Builds a document with the given lines (one paragraph per line) and places a
+// collapsed cursor in the requested paragraph at the requested offset.
+function setup(lines, { paragraphIndex, offset }) {
+  const editor = buildEditor()
+  let result = null
+  editor.update(
+    () => {
+      const root = $getRoot()
+      root.clear()
+      const textNodes = lines.map((line) => {
+        const p = $createParagraphNode()
+        const t = $createTextNode(line)
+        p.append(t)
+        root.append(p)
+        return t
+      })
+      const target = textNodes[paragraphIndex]
+      target.select(offset, offset)
+    },
+    { discrete: true }
+  )
+  editor.getEditorState().read(() => {
+    const selection = $getSelection()
+    result = {
+      atStart: isSelectionAtDocumentStart(selection),
+      atEnd: isSelectionAtDocumentEnd(selection)
+    }
+  })
+  return result
+}
+
+describe("selection boundary helpers", () => {
+  it("treats cursor at the very start of the first line as document start", () => {
+    const r = setup(["line1", "line2"], { paragraphIndex: 0, offset: 0 })
+    expect(r.atStart).toBe(true)
+  })
+
+  it("does NOT treat start of the second paragraph as document start", () => {
+    // This is the bug: after Enter, the cursor sits at offset 0 of a new
+    // paragraph. ArrowUp must move the cursor up, not jump to the row above.
+    const r = setup(["line1", "line2"], { paragraphIndex: 1, offset: 0 })
+    expect(r.atStart).toBe(false)
+  })
+
+  it("does NOT treat mid-text cursor as document start", () => {
+    const r = setup(["line1"], { paragraphIndex: 0, offset: 2 })
+    expect(r.atStart).toBe(false)
+  })
+
+  it("treats cursor at the very end of the last line as document end", () => {
+    const r = setup(["line1", "line2"], { paragraphIndex: 1, offset: 5 })
+    expect(r.atEnd).toBe(true)
+  })
+
+  it("does NOT treat end of the first paragraph as document end", () => {
+    const r = setup(["line1", "line2"], { paragraphIndex: 0, offset: 5 })
+    expect(r.atEnd).toBe(false)
+  })
+
+  it("does NOT treat mid-text cursor as document end", () => {
+    const r = setup(["line1"], { paragraphIndex: 0, offset: 2 })
+    expect(r.atEnd).toBe(false)
+  })
+})

--- a/engines/collavre/app/javascript/lib/lexical/selection_boundary.js
+++ b/engines/collavre/app/javascript/lib/lexical/selection_boundary.js
@@ -1,0 +1,58 @@
+import {
+  $isRangeSelection,
+  $isTextNode,
+  $isRootOrShadowRoot
+} from "lexical"
+
+// True when a collapsed selection sits at the very start of the whole document
+// (offset 0 of the first leaf, with no previous siblings up the tree).
+//
+// NOTE: checking `$getCharacterOffsets() === [0, 0]` is NOT enough — that only
+// reports the offset within the current node, so the start of the *second*
+// paragraph (e.g. right after pressing Enter) also reads as [0, 0]. We must walk
+// up the tree confirming there is no earlier content, mirroring
+// isSelectionAtDocumentEnd.
+export function isSelectionAtDocumentStart(selection) {
+  if (!$isRangeSelection(selection) || !selection.isCollapsed()) return false
+
+  const anchor = selection.anchor
+  let node = anchor.getNode()
+  if (!node) return false
+
+  if (anchor.offset !== 0) return false
+
+  while (node && !$isRootOrShadowRoot(node)) {
+    if (node.getPreviousSibling()) return false
+    node = node.getParent()
+  }
+
+  return !!node && $isRootOrShadowRoot(node)
+}
+
+// True when a collapsed selection sits at the very end of the whole document
+// (end of the last leaf, with no following siblings up the tree).
+export function isSelectionAtDocumentEnd(selection) {
+  if (!$isRangeSelection(selection) || !selection.isCollapsed()) return false
+
+  const focus = selection.focus
+  let node = focus.getNode()
+  if (!node) return false
+
+  const offset = focus.offset
+  if ($isTextNode(node)) {
+    if (offset !== node.getTextContentSize()) return false
+  } else if (typeof node.getChildrenSize === "function") {
+    if (offset !== node.getChildrenSize()) return false
+  } else {
+    // Fallback for nodes without children size (e.g., line breaks)
+    const textSize = node.getTextContentSize?.() ?? 0
+    if (offset !== textSize) return false
+  }
+
+  while (node && !$isRootOrShadowRoot(node)) {
+    if (node.getNextSibling()) return false
+    node = node.getParent()
+  }
+
+  return !!node && $isRootOrShadowRoot(node)
+}

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -1,6 +1,7 @@
 import creativesApi from '../lib/api/creatives'
 import apiQueue from '../lib/api/queue_manager'
-import { $getCharacterOffsets, $getSelection, $isRangeSelection, $isTextNode, $isRootOrShadowRoot } from 'lexical'
+import { $getSelection } from 'lexical'
+import { isSelectionAtDocumentStart, isSelectionAtDocumentEnd } from '../lib/lexical/selection_boundary'
 import { createInlineEditor } from './lexical_inline_editor'
 import { renderCreativeTree, dispatchCreativeTreeUpdated } from '../creatives/tree_renderer'
 import { isProgressComplete, progressBaselineValueFrom, progressValueChangedFrom } from './creative_progress'
@@ -2040,9 +2041,11 @@ export function initializeCreativeRowEditor() {
       let atEnd = false;
       editorInstance.getEditorState().read(() => {
         const selection = $getSelection();
-        if (!$isRangeSelection(selection) || !selection.isCollapsed()) return;
-        const [start, end] = $getCharacterOffsets(selection);
-        atStart = start === 0 && end === 0;
+        // atStart must reflect the start of the whole document, not just offset 0
+        // of the current node — otherwise the start of a second paragraph (e.g.
+        // right after pressing Enter) is mistaken for the top and ArrowUp jumps
+        // to the row above instead of moving the cursor up. See isSelectionAtDocumentStart.
+        atStart = isSelectionAtDocumentStart(selection);
         atEnd = isSelectionAtDocumentEnd(selection);
       });
 
@@ -2060,32 +2063,6 @@ export function initializeCreativeRowEditor() {
         move(1);
         requestAnimationFrame(() => lexicalEditor.focus());
       }
-    }
-
-    function isSelectionAtDocumentEnd(selection) {
-      if (!$isRangeSelection(selection) || !selection.isCollapsed()) return false;
-
-      const focus = selection.focus;
-      let node = focus.getNode();
-      if (!node) return false;
-
-      const offset = focus.offset;
-      if ($isTextNode(node)) {
-        if (offset !== node.getTextContentSize()) return false;
-      } else if (typeof node.getChildrenSize === 'function') {
-        if (offset !== node.getChildrenSize()) return false;
-      } else {
-        // Fallback for nodes without children size (e.g., line breaks)
-        const textSize = node.getTextContentSize?.() ?? 0;
-        if (offset !== textSize) return false;
-      }
-
-      while (node && !$isRootOrShadowRoot(node)) {
-        if (node.getNextSibling()) return false;
-        node = node.getParent();
-      }
-
-      return !!node && $isRootOrShadowRoot(node);
     }
 
     if (progressInput) {


### PR DESCRIPTION
## Problem
In the creative inline editor, pressing **Enter** then **ArrowUp** moves focus to the creative row *above* instead of moving the cursor up to the previous line within the editor.

## Root cause
The ArrowUp/Ctrl-P navigation guard in `creative_row_editor.js` computed `atStart` from `$getCharacterOffsets(selection)` — which returns the offset **within the current node only**. After Enter, the cursor sits at offset 0 of a new (second) paragraph, so this read as `[0, 0]` and `atStart` became `true`, triggering `move(-1)` (jump to the row above).

The symmetric `atEnd` check was already correct: it used `isSelectionAtDocumentEnd`, which walks up the tree confirming there are no following siblings. `atStart` had no such walk.

## Fix
- Add `isSelectionAtDocumentStart` that walks up the tree checking `getPreviousSibling` (mirror of the existing end check).
- Extract both boundary helpers into `lib/lexical/selection_boundary.js` (single source of truth, testable).
- Use the helper for `atStart`.

## Tests
New `selection_boundary.test.js` (6 cases, real headless Lexical editor) covering start/end at first/second paragraph and mid-text. Full JS suite: 425 passed. Bundle builds clean.