### PR TITLE
fix(collavre): Shift+Tab leaves a top-level list; verify Enter-twice escape

### DIFF
--- a/engines/collavre/app/javascript/lib/lexical/__tests__/list_tab_indent.test.js
+++ b/engines/collavre/app/javascript/lib/lexical/__tests__/list_tab_indent.test.js
@@ -3,6 +3,7 @@ import {
   $getRoot,
   $createParagraphNode,
   $createTextNode,
+  $isParagraphNode,
   KEY_TAB_COMMAND
 } from "lexical"
 import { HeadingNode, QuoteNode, registerRichText } from "@lexical/rich-text"
@@ -126,6 +127,76 @@ describe("registerListTabIndentation", () => {
     expect(handled).toBe(true)
     editor.read(() => {
       expect(countNestedLists($getRoot())).toBe(1)
+    })
+  })
+
+  it("Shift+Tab on a top-level item removes it from the list (becomes a paragraph)", () => {
+    const editor = buildListEditor()
+    editor.update(
+      () => {
+        const root = $getRoot()
+        root.clear()
+        const ul = $createListNode("bullet")
+        const a = $createListItemNode()
+        const textA = $createTextNode("a")
+        a.append(textA)
+        ul.append(a)
+        root.append(ul)
+        textA.selectEnd()
+      },
+      { discrete: true }
+    )
+
+    const handled = editor.dispatchCommand(KEY_TAB_COMMAND, {
+      preventDefault: () => {},
+      shiftKey: true
+    })
+    expect(handled).toBe(true)
+
+    editor.read(() => {
+      const root = $getRoot()
+      // The whole list is gone; the item is now a top-level paragraph.
+      expect(root.getChildren().some($isListNode)).toBe(false)
+      const only = root.getFirstChild()
+      expect($isParagraphNode(only)).toBe(true)
+      expect(only.getTextContent()).toBe("a")
+    })
+  })
+
+  it("Shift+Tab on a middle top-level item splits the surrounding list", () => {
+    const editor = buildListEditor()
+    editor.update(
+      () => {
+        const root = $getRoot()
+        root.clear()
+        const ul = $createListNode("bullet")
+        const a = $createListItemNode()
+        a.append($createTextNode("a"))
+        const b = $createListItemNode()
+        const textB = $createTextNode("b")
+        b.append(textB)
+        const c = $createListItemNode()
+        c.append($createTextNode("c"))
+        ul.append(a, b, c)
+        root.append(ul)
+        textB.selectEnd()
+      },
+      { discrete: true }
+    )
+
+    const handled = editor.dispatchCommand(KEY_TAB_COMMAND, {
+      preventDefault: () => {},
+      shiftKey: true
+    })
+    expect(handled).toBe(true)
+
+    editor.read(() => {
+      const root = $getRoot()
+      const kinds = root.getChildren().map((child) =>
+        $isListNode(child) ? `list[${child.getTextContent()}]` : `p[${child.getTextContent()}]`
+      )
+      // a stays in the first list, b becomes a paragraph, c moves to a trailing list.
+      expect(kinds).toEqual(["list[a]", "p[b]", "list[c]"])
     })
   })
 

--- a/engines/collavre/app/javascript/lib/lexical/__tests__/list_tab_indent.test.js
+++ b/engines/collavre/app/javascript/lib/lexical/__tests__/list_tab_indent.test.js
@@ -200,6 +200,57 @@ describe("registerListTabIndentation", () => {
     })
   })
 
+  it("Shift+Tab on a top-level item with a nested child list never puts a list inside a paragraph", () => {
+    const editor = buildListEditor()
+    editor.update(
+      () => {
+        const root = $getRoot()
+        root.clear()
+        const ul = $createListNode("bullet")
+        const a = $createListItemNode()
+        a.append($createTextNode("a"))
+        const child = $createListItemNode()
+        const childText = $createTextNode("a1")
+        child.append(childText)
+        ul.append(a, child)
+        root.append(ul)
+        childText.selectEnd()
+      },
+      { discrete: true }
+    )
+
+    // Tab on "a1" nests it under "a" via the real @lexical/list machinery, so the
+    // tree matches what a user actually builds (not a hand-rolled approximation).
+    editor.dispatchCommand(KEY_TAB_COMMAND, { preventDefault: () => {}, shiftKey: false })
+
+    editor.update(
+      () => {
+        const root = $getRoot()
+        const topList = root.getFirstChild()
+        topList.getFirstChild().getFirstChild().selectEnd() // caret into "a"
+      },
+      { discrete: true }
+    )
+
+    const handled = editor.dispatchCommand(KEY_TAB_COMMAND, {
+      preventDefault: () => {},
+      shiftKey: true
+    })
+    expect(handled).toBe(true)
+
+    editor.read(() => {
+      const root = $getRoot()
+      // "a" leaves the list as a paragraph and that paragraph must hold no list block.
+      const paragraph = root.getChildren().find($isParagraphNode)
+      expect(paragraph).toBeDefined()
+      expect(paragraph.getTextContent()).toBe("a")
+      expect(paragraph.getChildren().some($isListNode)).toBe(false)
+      // The nested "a1" content survives somewhere inside a list, not lost.
+      expect(countNestedLists(root)).toBeGreaterThan(0)
+      expect(root.getTextContent()).toContain("a1")
+    })
+  })
+
   it("ignores Tab outside a list (returns false, no preventDefault)", () => {
     const editor = buildListEditor()
     editor.update(

--- a/engines/collavre/app/javascript/lib/lexical/__tests__/list_tab_indent.test.js
+++ b/engines/collavre/app/javascript/lib/lexical/__tests__/list_tab_indent.test.js
@@ -259,6 +259,12 @@ describe("registerListTabIndentation", () => {
         .getChildren()
         .some((li) => $isListItemNode(li) && $isListNode(li.getFirstChild()))
       expect(hasOrphanWrapper).toBe(false)
+      // The original list must not linger as an empty/orphan list before the
+      // paragraph: only the single trailing list should remain at the root, and no
+      // empty list anywhere (it would serialize as stray blank lines in Markdown).
+      const rootLists = root.getChildren().filter($isListNode)
+      expect(rootLists.length).toBe(1)
+      expect(rootLists[0]).toBe(trailingList)
     })
   })
 

--- a/engines/collavre/app/javascript/lib/lexical/__tests__/list_tab_indent.test.js
+++ b/engines/collavre/app/javascript/lib/lexical/__tests__/list_tab_indent.test.js
@@ -322,6 +322,50 @@ describe("registerListTabIndentation", () => {
     })
   })
 
+  it("Shift+Tab promoting a differently-typed child list keeps the child's own marker", () => {
+    const editor = buildListEditor()
+    editor.update(
+      () => {
+        const root = $getRoot()
+        root.clear()
+        // A numbered parent with a bullet sub-list — "1. a / - a1" (valid mixed
+        // Markdown list). Built directly because Tab-nesting inherits the parent
+        // type, so it can't produce a differently-typed child.
+        const ol = $createListNode("number")
+        const a = $createListItemNode()
+        a.append($createTextNode("a"))
+        const wrapper = $createListItemNode()
+        const childList = $createListNode("bullet")
+        const a1 = $createListItemNode()
+        a1.append($createTextNode("a1"))
+        childList.append(a1)
+        wrapper.append(childList)
+        ol.append(a, wrapper)
+        root.append(ol)
+        a.getFirstChild().selectEnd() // caret into "a"
+      },
+      { discrete: true }
+    )
+
+    const handled = editor.dispatchCommand(KEY_TAB_COMMAND, {
+      preventDefault: () => {},
+      shiftKey: true
+    })
+    expect(handled).toBe(true)
+
+    editor.read(() => {
+      const root = $getRoot()
+      const paragraph = root.getChildren().find($isParagraphNode)
+      expect(paragraph.getTextContent()).toBe("a")
+      // a1 was a's bullet child; promoted up it must stay a bullet list, not be
+      // renumbered into an ordered list inheriting the parent's "number" type.
+      const lists = root.getChildren().filter($isListNode)
+      expect(lists.length).toBe(1)
+      expect(lists[0].getListType()).toBe("bullet")
+      expect(lists[0].getTextContent()).toContain("a1")
+    })
+  })
+
   it("Shift+Tab on a list nested in a blockquote removes the list formatting", () => {
     const editor = buildListEditor()
     editor.update(

--- a/engines/collavre/app/javascript/lib/lexical/__tests__/list_tab_indent.test.js
+++ b/engines/collavre/app/javascript/lib/lexical/__tests__/list_tab_indent.test.js
@@ -499,6 +499,72 @@ describe("registerListTabIndentation", () => {
     })
   })
 
+  it("Shift+Tab never produces a zero/negative start with multiple promoted children", () => {
+    const editor = buildListEditor()
+    editor.update(
+      () => {
+        const root = $getRoot()
+        root.clear()
+        // "1. b" (first item) with two ordered children "b1", "b2" and a sibling "c".
+        const ol = $createListNode("number")
+        const b = $createListItemNode()
+        b.append($createTextNode("b"))
+        const b1 = $createListItemNode()
+        b1.append($createTextNode("b1"))
+        const b2 = $createListItemNode()
+        b2.append($createTextNode("b2"))
+        const c = $createListItemNode()
+        c.append($createTextNode("c"))
+        ol.append(b, b1, b2, c)
+        root.append(ol)
+      },
+      { discrete: true }
+    )
+    // Nest both "b1" and "b2" under "b" via the real machinery.
+    for (const text of ["b1", "b2"]) {
+      editor.update(
+        () => {
+          $getRoot()
+            .getAllTextNodes()
+            .find((n) => n.getTextContent() === text)
+            .selectEnd()
+        },
+        { discrete: true }
+      )
+      editor.dispatchCommand(KEY_TAB_COMMAND, { preventDefault: () => {}, shiftKey: false })
+    }
+    // Caret into top-level "b" and outdent it.
+    editor.update(
+      () => {
+        $getRoot()
+          .getAllTextNodes()
+          .find((n) => n.getTextContent() === "b")
+          .selectEnd()
+      },
+      { discrete: true }
+    )
+    const handled = editor.dispatchCommand(KEY_TAB_COMMAND, {
+      preventDefault: () => {},
+      shiftKey: true
+    })
+    expect(handled).toBe(true)
+
+    editor.read(() => {
+      const root = $getRoot()
+      const lists = root.getChildren().filter($isListNode)
+      const trailing = lists[lists.length - 1]
+      // The naive start (b.value + 1 - 2 promoted children = 0) would render "0.".
+      // Clamped to 1 → b1=1, b2=2, c=3 (sequential, all positive).
+      expect(trailing.getStart()).toBeGreaterThanOrEqual(1)
+      const values = trailing
+        .getChildren()
+        .filter((li) => $isListItemNode(li) && !$isListNode(li.getFirstChild()))
+        .map((li) => li.getValue())
+      expect(values).toEqual([1, 2, 3])
+      expect(values.every((v) => v >= 1)).toBe(true)
+    })
+  })
+
   it("ignores Tab outside a list (returns false, no preventDefault)", () => {
     const editor = buildListEditor()
     editor.update(

--- a/engines/collavre/app/javascript/lib/lexical/__tests__/list_tab_indent.test.js
+++ b/engines/collavre/app/javascript/lib/lexical/__tests__/list_tab_indent.test.js
@@ -440,6 +440,65 @@ describe("registerListTabIndentation", () => {
     })
   })
 
+  it("Shift+Tab keeps the trailing numbering when an ordered child list is promoted", () => {
+    const editor = buildListEditor()
+    editor.update(
+      () => {
+        const root = $getRoot()
+        root.clear()
+        // "1. a / 2. b / 3. c" with an ordered child "b1" nested under "b".
+        const ol = $createListNode("number")
+        const a = $createListItemNode()
+        a.append($createTextNode("a"))
+        const b = $createListItemNode()
+        b.append($createTextNode("b"))
+        const b1 = $createListItemNode()
+        const textB1 = $createTextNode("b1")
+        b1.append(textB1)
+        const c = $createListItemNode()
+        c.append($createTextNode("c"))
+        ol.append(a, b, b1, c)
+        root.append(ol)
+        textB1.selectEnd()
+      },
+      { discrete: true }
+    )
+    // Nest "b1" under "b" via the real machinery (same ordered type as the parent).
+    editor.dispatchCommand(KEY_TAB_COMMAND, { preventDefault: () => {}, shiftKey: false })
+    // Caret into top-level "b" and outdent it.
+    editor.update(
+      () => {
+        const root = $getRoot()
+        const target = root.getAllTextNodes().find((n) => n.getTextContent() === "b")
+        target.selectEnd()
+      },
+      { discrete: true }
+    )
+    const handled = editor.dispatchCommand(KEY_TAB_COMMAND, {
+      preventDefault: () => {},
+      shiftKey: true
+    })
+    expect(handled).toBe(true)
+
+    editor.read(() => {
+      const root = $getRoot()
+      // The promoted child list (b1) and the continuation (c) are forced into ONE
+      // ordered list by Lexical's same-type-sibling merge. The continuation "c" must
+      // keep its original value 3, with the promoted child filling the slot before it.
+      const lists = root.getChildren().filter($isListNode)
+      const trailing = lists[lists.length - 1]
+      expect(trailing.getListType()).toBe("number")
+      const values = trailing
+        .getChildren()
+        .filter((li) => $isListItemNode(li) && !$isListNode(li.getFirstChild()))
+        .map((li) => li.getValue())
+      // start=2 → b1=2, c=3 (c is not renumbered down to 2 by the merge).
+      expect(values).toEqual([2, 3])
+      expect(trailing.getTextContent()).toContain("b1")
+      expect(trailing.getTextContent()).toContain("c")
+    })
+  })
+
   it("ignores Tab outside a list (returns false, no preventDefault)", () => {
     const editor = buildListEditor()
     editor.update(

--- a/engines/collavre/app/javascript/lib/lexical/__tests__/list_tab_indent.test.js
+++ b/engines/collavre/app/javascript/lib/lexical/__tests__/list_tab_indent.test.js
@@ -3,6 +3,8 @@ import {
   $getRoot,
   $createParagraphNode,
   $createTextNode,
+  $createRangeSelection,
+  $setSelection,
   $isParagraphNode,
   KEY_TAB_COMMAND
 } from "lexical"
@@ -198,6 +200,45 @@ describe("registerListTabIndentation", () => {
       )
       // a stays in the first list, b becomes a paragraph, c moves to a trailing list.
       expect(kinds).toEqual(["list[a]", "p[b]", "list[c]"])
+    })
+  })
+
+  it("Shift+Tab un-lists every top-level item the selection spans, not just the anchor", () => {
+    const editor = buildListEditor()
+    editor.update(
+      () => {
+        const root = $getRoot()
+        root.clear()
+        const ul = $createListNode("bullet")
+        const a = $createListItemNode()
+        a.append($createTextNode("a"))
+        const b = $createListItemNode()
+        b.append($createTextNode("b"))
+        const c = $createListItemNode()
+        c.append($createTextNode("c"))
+        ul.append(a, b, c)
+        root.append(ul)
+        // Select from inside "a" through inside "c" (spans all three items).
+        const selection = $createRangeSelection()
+        selection.anchor.set(a.getFirstChild().getKey(), 0, "text")
+        selection.focus.set(c.getFirstChild().getKey(), 1, "text")
+        $setSelection(selection)
+      },
+      { discrete: true }
+    )
+
+    const handled = editor.dispatchCommand(KEY_TAB_COMMAND, {
+      preventDefault: () => {},
+      shiftKey: true
+    })
+    expect(handled).toBe(true)
+
+    editor.read(() => {
+      const root = $getRoot()
+      // All three leave the list: no list node survives, three plain paragraphs in order.
+      expect(root.getChildren().some($isListNode)).toBe(false)
+      const kinds = root.getChildren().map((child) => `p[${child.getTextContent()}]`)
+      expect(kinds).toEqual(["p[a]", "p[b]", "p[c]"])
     })
   })
 

--- a/engines/collavre/app/javascript/lib/lexical/__tests__/list_tab_indent.test.js
+++ b/engines/collavre/app/javascript/lib/lexical/__tests__/list_tab_indent.test.js
@@ -251,6 +251,80 @@ describe("registerListTabIndentation", () => {
     })
   })
 
+  it("Shift+Tab on a list nested in a blockquote removes the list formatting", () => {
+    const editor = buildListEditor()
+    editor.update(
+      () => {
+        const root = $getRoot()
+        root.clear()
+        // A list whose parent is a QuoteNode, not the root — `> - item`.
+        const quote = new QuoteNode()
+        const ul = $createListNode("bullet")
+        const a = $createListItemNode()
+        const textA = $createTextNode("quoted")
+        a.append(textA)
+        ul.append(a)
+        quote.append(ul)
+        root.append(quote)
+        textA.selectEnd()
+      },
+      { discrete: true }
+    )
+
+    const handled = editor.dispatchCommand(KEY_TAB_COMMAND, {
+      preventDefault: () => {},
+      shiftKey: true
+    })
+    expect(handled).toBe(true)
+
+    editor.read(() => {
+      const root = $getRoot()
+      // The list must be gone (no `<ul>` anywhere), the text survives, and no
+      // list block remains — `> item` instead of an unchanged `> - item`.
+      expect(countNestedLists(root)).toBe(0)
+      expect(root.getTextContent()).toContain("quoted")
+    })
+  })
+
+  it("Shift+Tab splitting an ordered list keeps the trailing numbering", () => {
+    const editor = buildListEditor()
+    editor.update(
+      () => {
+        const root = $getRoot()
+        root.clear()
+        const ol = $createListNode("number")
+        const a = $createListItemNode()
+        a.append($createTextNode("a"))
+        const b = $createListItemNode()
+        const textB = $createTextNode("b")
+        b.append(textB)
+        const c = $createListItemNode()
+        c.append($createTextNode("c"))
+        ol.append(a, b, c)
+        root.append(ol)
+        textB.selectEnd()
+      },
+      { discrete: true }
+    )
+
+    const handled = editor.dispatchCommand(KEY_TAB_COMMAND, {
+      preventDefault: () => {},
+      shiftKey: true
+    })
+    expect(handled).toBe(true)
+
+    editor.read(() => {
+      const root = $getRoot()
+      const lists = root.getChildren().filter($isListNode)
+      // a stays in the first ordered list; c moves to a trailing ordered list that
+      // continues numbering from 3 (b was 2), not restarting at 1.
+      const trailing = lists[lists.length - 1]
+      expect(trailing.getListType()).toBe("number")
+      expect(trailing.getStart()).toBe(3)
+      expect(trailing.getTextContent()).toBe("c")
+    })
+  })
+
   it("ignores Tab outside a list (returns false, no preventDefault)", () => {
     const editor = buildListEditor()
     editor.update(

--- a/engines/collavre/app/javascript/lib/lexical/__tests__/list_tab_indent.test.js
+++ b/engines/collavre/app/javascript/lib/lexical/__tests__/list_tab_indent.test.js
@@ -13,6 +13,7 @@ import {
   $createListNode,
   $createListItemNode,
   $isListNode,
+  $isListItemNode,
   registerList
 } from "@lexical/list"
 import { registerListTabIndentation } from "../list_tab_indent"
@@ -245,9 +246,73 @@ describe("registerListTabIndentation", () => {
       expect(paragraph).toBeDefined()
       expect(paragraph.getTextContent()).toBe("a")
       expect(paragraph.getChildren().some($isListNode)).toBe(false)
-      // The nested "a1" content survives somewhere inside a list, not lost.
+      // "a1" was a child of the removed "a", so it must be PROMOTED to a top-level
+      // item of the trailing list — not left as an orphan <li><ul> wrapper.
+      const trailingList = root.getChildren().filter($isListNode).pop()
+      const directItems = trailingList
+        .getChildren()
+        .filter((li) => $isListItemNode(li) && !$isListNode(li.getFirstChild()))
+        .map((li) => li.getTextContent())
+      expect(directItems).toContain("a1")
+      // No orphan nested-list wrapper survives at the trailing list's top level.
+      const hasOrphanWrapper = trailingList
+        .getChildren()
+        .some((li) => $isListItemNode(li) && $isListNode(li.getFirstChild()))
+      expect(hasOrphanWrapper).toBe(false)
+    })
+  })
+
+  it("Shift+Tab promotes only the removed item's children, leaving later items' nesting intact", () => {
+    const editor = buildListEditor()
+    editor.update(
+      () => {
+        const root = $getRoot()
+        root.clear()
+        const ul = $createListNode("bullet")
+        const a = $createListItemNode()
+        a.append($createTextNode("a"))
+        const b = $createListItemNode()
+        b.append($createTextNode("b"))
+        const b1 = $createListItemNode()
+        const textB1 = $createTextNode("b1")
+        b1.append(textB1)
+        ul.append(a, b, b1)
+        root.append(ul)
+        textB1.selectEnd()
+      },
+      { discrete: true }
+    )
+
+    // Nest "b1" under "b" via the real machinery.
+    editor.dispatchCommand(KEY_TAB_COMMAND, { preventDefault: () => {}, shiftKey: false })
+
+    // Caret into top-level "a" and outdent it.
+    editor.update(
+      () => {
+        const root = $getRoot()
+        root.getFirstChild().getFirstChild().getFirstChild().selectEnd()
+      },
+      { discrete: true }
+    )
+    const handled = editor.dispatchCommand(KEY_TAB_COMMAND, {
+      preventDefault: () => {},
+      shiftKey: true
+    })
+    expect(handled).toBe(true)
+
+    editor.read(() => {
+      const root = $getRoot()
+      // "a" has no children, so nothing is promoted; "b1" stays nested under "b".
+      const trailingList = root.getChildren().filter($isListNode).pop()
+      const topTexts = trailingList
+        .getChildren()
+        .filter((li) => $isListItemNode(li) && !$isListNode(li.getFirstChild()))
+        .map((li) => li.getTextContent())
+      expect(topTexts).toContain("b")
+      expect(topTexts).not.toContain("b1")
+      // b1 remains nested (one wrapper holding b1's sublist).
       expect(countNestedLists(root)).toBeGreaterThan(0)
-      expect(root.getTextContent()).toContain("a1")
+      expect(root.getTextContent()).toContain("b1")
     })
   })
 

--- a/engines/collavre/app/javascript/lib/lexical/list_tab_indent.js
+++ b/engines/collavre/app/javascript/lib/lexical/list_tab_indent.js
@@ -148,7 +148,11 @@ function $convertListItemToParagraph(listItem) {
           const promotedItems = anchor
             .getChildren()
             .filter((child) => !$isNestedListItemWrapper(child)).length
-          anchor.setStart(listItem.getValue() + 1 - promotedItems)
+          // Clamp to 1: when more children are promoted than the removed item's
+          // value frees up (e.g. "1. b" with children b1, b2 → 1 + 1 - 2 = 0),
+          // a 0/negative start would render literally as "0."/"-1.". Falling back
+          // to 1 just renumbers the merged list sequentially from the top.
+          anchor.setStart(Math.max(1, listItem.getValue() + 1 - promotedItems))
         }
         trailingItems.forEach((sibling) => anchor.append(sibling))
       } else {

--- a/engines/collavre/app/javascript/lib/lexical/list_tab_indent.js
+++ b/engines/collavre/app/javascript/lib/lexical/list_tab_indent.js
@@ -56,6 +56,12 @@ export function registerListTabIndentation(editor) {
   )
 }
 
+// A list item that exists only to hold a nested list (its first/only child is a
+// ListNode). @lexical/list uses this wrapper to represent indentation.
+function $isNestedListItemWrapper(node) {
+  return $isListItemNode(node) && $isListNode(node.getFirstChild())
+}
+
 function $findListItemAncestor(selection) {
   const anchorNode = selection.anchor.getNode()
   if ($isListItemNode(anchorNode)) return anchorNode
@@ -105,7 +111,21 @@ function $convertListItemToParagraph(listItem) {
     const trailingStart =
       listType === "number" ? listItem.getValue() + 1 : undefined
     const trailingList = $createListNode(listType, trailingStart)
-    trailingList.append(...following)
+    // @lexical/list stores a nested child list as a *wrapper* list item (its only
+    // child is a ListNode) placed right after the parent item. Those wrappers are
+    // the removed item's own children, so promote their contents up one level
+    // rather than re-nesting them under an empty item (which renders as an orphan
+    // <li><ul>…). Only the leading run belongs to the removed item — once a real
+    // item appears, later wrappers belong to it and must stay nested.
+    let promotingChildren = true
+    following.forEach((sibling) => {
+      if (promotingChildren && $isNestedListItemWrapper(sibling)) {
+        trailingList.append(...sibling.getFirstChild().getChildren())
+      } else {
+        promotingChildren = false
+        trailingList.append(sibling)
+      }
+    })
     anchor.insertAfter(trailingList)
   }
 

--- a/engines/collavre/app/javascript/lib/lexical/list_tab_indent.js
+++ b/engines/collavre/app/javascript/lib/lexical/list_tab_indent.js
@@ -44,7 +44,15 @@ export function registerListTabIndentation(editor) {
         // because OUTDENT has nothing shallower to move to. Nested item: un-nest one
         // level via OUTDENT, which @lexical/list collapses back into flat structure.
         if ($isTopLevelListItem(listItem)) {
-          $convertListItemToParagraph(listItem)
+          // A selection can span several top-level items; un-list each so multi-item
+          // Shift+Tab matches the range-aware OUTDENT path instead of only dropping
+          // the anchor's item. Collect the items up front (converting one mutates the
+          // tree) and convert in document order — each conversion splits the list and
+          // leaves the next selected item at the head of the trailing list, so the
+          // result is clean sequential paragraphs.
+          $selectedTopLevelListItems(selection, listItem).forEach(
+            $convertListItemToParagraph
+          )
           return true
         }
         return editor.dispatchCommand(OUTDENT_CONTENT_COMMAND, undefined)
@@ -66,6 +74,27 @@ function $findListItemAncestor(selection) {
   const anchorNode = selection.anchor.getNode()
   if ($isListItemNode(anchorNode)) return anchorNode
   return anchorNode.getParents().find($isListItemNode) || null
+}
+
+// The distinct top-level list items the selection touches, in document order.
+// getNodes() returns the range's nodes in document order; we map each to its
+// owning list item and keep only top-level, non-wrapper ones (nested items go
+// through OUTDENT instead). Falls back to the anchor item when the range yields
+// nothing useful (e.g. a collapsed selection on an empty item).
+function $selectedTopLevelListItems(selection, fallbackItem) {
+  const seen = new Set()
+  const items = []
+  selection.getNodes().forEach((node) => {
+    const listItem = $isListItemNode(node)
+      ? node
+      : node.getParents().find($isListItemNode)
+    if (!listItem || seen.has(listItem.getKey())) return
+    if (!$isTopLevelListItem(listItem) || $isNestedListItemWrapper(listItem)) return
+    seen.add(listItem.getKey())
+    items.push(listItem)
+  })
+  if (items.length === 0 && fallbackItem) items.push(fallbackItem)
+  return items
 }
 
 // A list item is "top level" when its parent list is not nested inside another

--- a/engines/collavre/app/javascript/lib/lexical/list_tab_indent.js
+++ b/engines/collavre/app/javascript/lib/lexical/list_tab_indent.js
@@ -2,7 +2,6 @@ import {
   $createParagraphNode,
   $getSelection,
   $isRangeSelection,
-  $isRootOrShadowRoot,
   COMMAND_PRIORITY_LOW,
   INDENT_CONTENT_COMMAND,
   KEY_TAB_COMMAND,
@@ -63,12 +62,14 @@ function $findListItemAncestor(selection) {
   return anchorNode.getParents().find($isListItemNode) || null
 }
 
-// A list item is "top level" when its parent list hangs directly off the root,
-// i.e. it is not nested inside another list item.
+// A list item is "top level" when its parent list is not nested inside another
+// list item. This holds both at the document root and inside a blockquote (where
+// the list's parent is the QuoteNode, not the root) — in both cases OUTDENT has
+// nothing shallower to drop to, so the item should leave the list instead.
 function $isTopLevelListItem(listItem) {
   const parentList = listItem.getParent()
   if (!$isListNode(parentList)) return false
-  return $isRootOrShadowRoot(parentList.getParent())
+  return !$isListItemNode(parentList.getParent())
 }
 
 // Remove a single top-level list item from its list, turning it into a paragraph
@@ -98,7 +99,12 @@ function $convertListItemToParagraph(listItem) {
   })
 
   if (following.length > 0) {
-    const trailingList = $createListNode(parentList.getListType())
+    const listType = parentList.getListType()
+    // For ordered lists, continue numbering from where the converted item was
+    // instead of restarting at 1 (e.g. "1. a / 2. b / 3. c" → outdent b → c stays 3).
+    const trailingStart =
+      listType === "number" ? listItem.getValue() + 1 : undefined
+    const trailingList = $createListNode(listType, trailingStart)
     trailingList.append(...following)
     anchor.insertAfter(trailingList)
   }

--- a/engines/collavre/app/javascript/lib/lexical/list_tab_indent.js
+++ b/engines/collavre/app/javascript/lib/lexical/list_tab_indent.js
@@ -79,21 +79,34 @@ function $convertListItemToParagraph(listItem) {
   if (!$isListNode(parentList)) return
 
   const following = listItem.getNextSiblings()
+  // An item can hold both inline content (text) and a nested child list. Only the
+  // inline content belongs in the paragraph — a nested ListNode inside a paragraph
+  // is invalid block structure, so it is promoted to a sibling list block instead.
   const children = listItem.getChildren()
+  const nestedLists = children.filter($isListNode)
+  const inlineChildren = children.filter((child) => !$isListNode(child))
   const paragraph = $createParagraphNode()
 
   parentList.insertAfter(paragraph)
 
+  // Keep block order: paragraph, then any promoted nested lists, then the split-off
+  // trailing items, by chaining insertAfter off the previously inserted block.
+  let anchor = paragraph
+  nestedLists.forEach((nestedList) => {
+    anchor.insertAfter(nestedList)
+    anchor = nestedList
+  })
+
   if (following.length > 0) {
     const trailingList = $createListNode(parentList.getListType())
     trailingList.append(...following)
-    paragraph.insertAfter(trailingList)
+    anchor.insertAfter(trailingList)
   }
 
-  if (children.length > 0) {
+  if (inlineChildren.length > 0) {
     // Moving the existing nodes (not cloning) keeps any caret pointing into them
     // valid, so the cursor stays where the user was typing.
-    children.forEach((child) => paragraph.append(child))
+    inlineChildren.forEach((child) => paragraph.append(child))
   } else {
     paragraph.select()
   }

--- a/engines/collavre/app/javascript/lib/lexical/list_tab_indent.js
+++ b/engines/collavre/app/javascript/lib/lexical/list_tab_indent.js
@@ -106,32 +106,37 @@ function $convertListItemToParagraph(listItem) {
 
   if (following.length > 0) {
     const listType = parentList.getListType()
-    // For ordered lists, continue numbering from where the converted item was
-    // instead of restarting at 1 (e.g. "1. a / 2. b / 3. c" → outdent b → c stays 3).
-    const trailingStart =
-      listType === "number" ? listItem.getValue() + 1 : undefined
-    const trailingList = $createListNode(listType, trailingStart)
     // @lexical/list stores a nested child list as a *wrapper* list item (its only
-    // child is a ListNode) placed right after the parent item. Those wrappers are
-    // the removed item's own children, so promote their contents up one level
-    // rather than re-nesting them under an empty item (which renders as an orphan
-    // <li><ul>…). Only the leading run belongs to the removed item — once a real
-    // item appears, later wrappers belong to it and must stay nested.
+    // child is a ListNode) placed right after the parent item. The leading run of
+    // such wrappers are the removed item's own children: promote each wrapper's
+    // inner ListNode up one level as its own block, then drop the emptied wrapper.
+    // Moving the whole ListNode (not just its items) preserves the child list's own
+    // marker type — a bullet child of a numbered parent must stay a bullet list, not
+    // get renumbered. Promoting items rather than the wrapper also empties parentList
+    // so the cleanup below can remove it, avoiding an orphan <li><ul>. Once a real
+    // item appears the run ends; later wrappers belong to it and must stay nested.
     let promotingChildren = true
+    const trailingItems = []
     following.forEach((sibling) => {
       if (promotingChildren && $isNestedListItemWrapper(sibling)) {
-        // Move the wrapper's inner items up one level, then drop the wrapper. It only
-        // existed to nest the removed item's children; appending its contents alone
-        // would leave the emptied wrapper behind in parentList, so parentList never
-        // empties and the cleanup below can't remove it — an orphan <li><ul> list.
-        trailingList.append(...sibling.getFirstChild().getChildren())
+        const childList = sibling.getFirstChild()
+        anchor.insertAfter(childList)
+        anchor = childList
         sibling.remove()
       } else {
         promotingChildren = false
-        trailingList.append(sibling)
+        trailingItems.push(sibling)
       }
     })
-    anchor.insertAfter(trailingList)
+    if (trailingItems.length > 0) {
+      // For ordered lists, continue numbering from where the converted item was
+      // instead of restarting at 1 (e.g. "1. a / 2. b / 3. c" → outdent b → c stays 3).
+      const trailingStart =
+        listType === "number" ? listItem.getValue() + 1 : undefined
+      const trailingList = $createListNode(listType, trailingStart)
+      trailingItems.forEach((sibling) => trailingList.append(sibling))
+      anchor.insertAfter(trailingList)
+    }
   }
 
   if (inlineChildren.length > 0) {

--- a/engines/collavre/app/javascript/lib/lexical/list_tab_indent.js
+++ b/engines/collavre/app/javascript/lib/lexical/list_tab_indent.js
@@ -129,13 +129,35 @@ function $convertListItemToParagraph(listItem) {
       }
     })
     if (trailingItems.length > 0) {
-      // For ordered lists, continue numbering from where the converted item was
-      // instead of restarting at 1 (e.g. "1. a / 2. b / 3. c" → outdent b → c stays 3).
-      const trailingStart =
-        listType === "number" ? listItem.getValue() + 1 : undefined
-      const trailingList = $createListNode(listType, trailingStart)
-      trailingItems.forEach((sibling) => trailingList.append(sibling))
-      anchor.insertAfter(trailingList)
+      // For ordered lists the trailing items must keep their original numbers
+      // (e.g. "1. a / 2. b / 3. c" → outdent b → c stays 3, not restart at 1).
+      //
+      // When a same-type list was promoted directly before these items (the removed
+      // item's own ordered child list), Lexical's ListNode transform merges the two
+      // adjacent same-type lists and keeps the *first* list's start — a separate
+      // trailing list's start would be silently discarded. So append the trailing
+      // items into that promoted list instead and set its start so the first trailing
+      // item lands on its original value, with the promoted children filling the slots
+      // leading up to it ("1. a / 2. b / [1.] b1 / 3. c" → outdent b → "2. b1 / 3. c").
+      const mergesWithPromoted =
+        $isListNode(anchor) && anchor.getListType() === listType
+      if (mergesWithPromoted) {
+        if (listType === "number") {
+          // Count real items already in the promoted list (nested wrappers don't
+          // advance numbering) so the first trailing item keeps its original value.
+          const promotedItems = anchor
+            .getChildren()
+            .filter((child) => !$isNestedListItemWrapper(child)).length
+          anchor.setStart(listItem.getValue() + 1 - promotedItems)
+        }
+        trailingItems.forEach((sibling) => anchor.append(sibling))
+      } else {
+        const trailingStart =
+          listType === "number" ? listItem.getValue() + 1 : undefined
+        const trailingList = $createListNode(listType, trailingStart)
+        trailingItems.forEach((sibling) => trailingList.append(sibling))
+        anchor.insertAfter(trailingList)
+      }
     }
   }
 

--- a/engines/collavre/app/javascript/lib/lexical/list_tab_indent.js
+++ b/engines/collavre/app/javascript/lib/lexical/list_tab_indent.js
@@ -120,7 +120,12 @@ function $convertListItemToParagraph(listItem) {
     let promotingChildren = true
     following.forEach((sibling) => {
       if (promotingChildren && $isNestedListItemWrapper(sibling)) {
+        // Move the wrapper's inner items up one level, then drop the wrapper. It only
+        // existed to nest the removed item's children; appending its contents alone
+        // would leave the emptied wrapper behind in parentList, so parentList never
+        // empties and the cleanup below can't remove it — an orphan <li><ul> list.
         trailingList.append(...sibling.getFirstChild().getChildren())
+        sibling.remove()
       } else {
         promotingChildren = false
         trailingList.append(sibling)

--- a/engines/collavre/app/javascript/lib/lexical/list_tab_indent.js
+++ b/engines/collavre/app/javascript/lib/lexical/list_tab_indent.js
@@ -1,23 +1,31 @@
 import {
+  $createParagraphNode,
   $getSelection,
   $isRangeSelection,
+  $isRootOrShadowRoot,
   COMMAND_PRIORITY_LOW,
   INDENT_CONTENT_COMMAND,
   KEY_TAB_COMMAND,
   OUTDENT_CONTENT_COMMAND
 } from "lexical"
-import { $isListItemNode } from "@lexical/list"
+import { $createListNode, $isListItemNode, $isListNode } from "@lexical/list"
 
 /**
  * Tab / Shift+Tab indentation scoped to list items.
  *
- * Inside a list, Tab nests the current item (INDENT_CONTENT_COMMAND) and
- * Shift+Tab un-nests it (OUTDENT_CONTENT_COMMAND); @lexical/list turns those
- * indent changes into real nested <ul>/<ol> structure.
+ * Inside a list, Tab nests the current item (INDENT_CONTENT_COMMAND).
+ * Shift+Tab un-nests it (OUTDENT_CONTENT_COMMAND) when the item is nested;
+ * @lexical/list turns those indent changes into real nested <ul>/<ol> structure.
  *
- * Outside a list the command is ignored (returns false) so Tab keeps its
- * default behaviour (moving focus out of the editor) and plain paragraphs never
- * gain an indent the Markdown-canonical store can't represent cleanly.
+ * At the OUTERMOST level OUTDENT_CONTENT_COMMAND is a no-op (there is no shallower
+ * indent to drop to), so Shift+Tab on a top-level item would do nothing. Other
+ * editors instead remove the list formatting for that item — the item leaves the
+ * list and becomes a normal paragraph. We replicate that here so Shift+Tab always
+ * has a visible, expected effect.
+ *
+ * Outside a list the command is ignored (returns false) so Tab keeps its default
+ * behaviour (moving focus out of the editor) and plain paragraphs never gain an
+ * indent the Markdown-canonical store can't represent cleanly.
  *
  * Returns the editor.registerCommand teardown so callers can clean up.
  */
@@ -27,20 +35,72 @@ export function registerListTabIndentation(editor) {
     (event) => {
       const selection = $getSelection()
       if (!$isRangeSelection(selection)) return false
-      if (!$isSelectionWithinList(selection)) return false
+      const listItem = $findListItemAncestor(selection)
+      if (!listItem) return false
 
       event.preventDefault()
-      return editor.dispatchCommand(
-        event.shiftKey ? OUTDENT_CONTENT_COMMAND : INDENT_CONTENT_COMMAND,
-        undefined
-      )
+
+      if (event.shiftKey) {
+        // Top-level item: drop out of the list entirely (other editors' behaviour),
+        // because OUTDENT has nothing shallower to move to. Nested item: un-nest one
+        // level via OUTDENT, which @lexical/list collapses back into flat structure.
+        if ($isTopLevelListItem(listItem)) {
+          $convertListItemToParagraph(listItem)
+          return true
+        }
+        return editor.dispatchCommand(OUTDENT_CONTENT_COMMAND, undefined)
+      }
+
+      return editor.dispatchCommand(INDENT_CONTENT_COMMAND, undefined)
     },
     COMMAND_PRIORITY_LOW
   )
 }
 
-function $isSelectionWithinList(selection) {
+function $findListItemAncestor(selection) {
   const anchorNode = selection.anchor.getNode()
-  if ($isListItemNode(anchorNode)) return true
-  return anchorNode.getParents().some($isListItemNode)
+  if ($isListItemNode(anchorNode)) return anchorNode
+  return anchorNode.getParents().find($isListItemNode) || null
+}
+
+// A list item is "top level" when its parent list hangs directly off the root,
+// i.e. it is not nested inside another list item.
+function $isTopLevelListItem(listItem) {
+  const parentList = listItem.getParent()
+  if (!$isListNode(parentList)) return false
+  return $isRootOrShadowRoot(parentList.getParent())
+}
+
+// Remove a single top-level list item from its list, turning it into a paragraph
+// in the same position. Items before it stay in the original list; items after it
+// move into a fresh trailing list so the surrounding list is split, not flattened.
+function $convertListItemToParagraph(listItem) {
+  const parentList = listItem.getParent()
+  if (!$isListNode(parentList)) return
+
+  const following = listItem.getNextSiblings()
+  const children = listItem.getChildren()
+  const paragraph = $createParagraphNode()
+
+  parentList.insertAfter(paragraph)
+
+  if (following.length > 0) {
+    const trailingList = $createListNode(parentList.getListType())
+    trailingList.append(...following)
+    paragraph.insertAfter(trailingList)
+  }
+
+  if (children.length > 0) {
+    // Moving the existing nodes (not cloning) keeps any caret pointing into them
+    // valid, so the cursor stays where the user was typing.
+    children.forEach((child) => paragraph.append(child))
+  } else {
+    paragraph.select()
+  }
+
+  listItem.remove()
+
+  if (parentList.getChildrenSize() === 0) {
+    parentList.remove()
+  }
 }


### PR DESCRIPTION
## Summary

Investigates the two reported rich-text list bugs in the inline Lexical editor.

### Bug 1 — "Enter twice should leave the bullet list" → already works on `main`
Verified live (logged into a preview, built a bullet list, pressed Enter twice):

- Enter #1 → new empty bullet: `<ul><li>abc</li><li><br></li></ul>`
- Enter #2 → escapes the list: `<ul><li>abc</li></ul><p><br></p>`, and a normal paragraph can be typed below.

Core Lexical (`@lexical/list`'s `$handleListInsertParagraph`), the markdown round-trip, and the tight/loose HTML reopen path all escape correctly. No code change was needed for Bug 1 — current `main` already behaves as requested. (If it still misbehaves in production, that environment is on an older build.)

### Bug 2 — "Shift+Tab at level 1 should un-list" → fixed here
`registerListTabIndentation` dispatched `OUTDENT_CONTENT_COMMAND` for Shift+Tab. At the outermost level that command is a no-op (no shallower indent to drop to), so Shift+Tab on a top-level item did nothing. Confirmed live with the pre-fix bundle: the HTML was unchanged.

Now a top-level item is converted to a paragraph in place, splitting the surrounding list (matching Notion/Docs/etc.):

- Single item: `<ul><li>a</li></ul>` → `<p>a</p>`
- Middle item: `<ul><li>alpha</li><li>beta</li><li>gamma</li></ul>` → `<ul><li>alpha</li></ul><p>beta</p><ul><li>gamma</li></ul>`

Nested items keep their existing OUTDENT (un-nest one level) behaviour — verified live that nested Shift+Tab still collapses to a flat list rather than un-listing.

## Changes
- `engines/collavre/app/javascript/lib/lexical/list_tab_indent.js` — top-level Shift+Tab converts the item to a paragraph (splitting the list); nested items still OUTDENT.
- Unit tests for the single-item un-list and the middle-item split.

## Testing
- `npm test` → 421/421 pass.
- Live verification in a preview for all four cases (Enter escape, single un-list, middle split, nested un-nest).
