### PR TITLE
fix(lexical): keep editor editable when content ends with an image

### DIFF
--- a/engines/collavre/app/javascript/components/ImageResizer.jsx
+++ b/engines/collavre/app/javascript/components/ImageResizer.jsx
@@ -51,9 +51,15 @@ export default function ImageResizer({ src, altText, width, height, nodeKey }) {
       editor.registerCommand(
         CLICK_COMMAND,
         (event) => {
-          // If click is outside our image, deselect
+          // If click is outside our image, deselect — but only via clearSelection.
+          // setSelected(false) is destructive here: when the click lands in text
+          // (a RangeSelection / the caret), the hook synthesizes a fresh empty
+          // NodeSelection and replaces the caret with it, so the editor loses its
+          // caret and becomes uneditable the instant you click to edit while an
+          // image is present. clearSelection only acts on an existing
+          // NodeSelection, so a RangeSelection (caret) is preserved.
           if (containerRef.current && !containerRef.current.contains(event.target)) {
-            setSelected(false)
+            clearSelection()
           }
           return false
         },
@@ -90,7 +96,7 @@ export default function ImageResizer({ src, altText, width, height, nodeKey }) {
         COMMAND_PRIORITY_LOW
       )
     )
-  }, [editor, isSelected, nodeKey, setSelected])
+  }, [editor, isSelected, nodeKey, clearSelection])
 
   // Resize logic
   const onPointerDown = useCallback(

--- a/engines/collavre/app/javascript/components/InlineLexicalEditor.jsx
+++ b/engines/collavre/app/javascript/components/InlineLexicalEditor.jsx
@@ -58,6 +58,7 @@ import ListTabIndentPlugin from "./plugins/list_tab_indent_plugin"
 import { syncLexicalStyleAttributes } from "../lib/lexical/style_attributes"
 import { lexicalHtmlConfig, normalizeColoredContainers } from "../lib/lexical/color_import"
 import { minimizeContentHtml } from "../lib/lexical/minimize_html"
+import { ensureTrailingParagraph, registerTrailingParagraph } from "../lib/lexical/trailing_paragraph"
 import { MARKDOWN_TRANSFORMERS, collapseParagraphBreaks } from "../lib/lexical/markdown_serialize"
 import { $convertToMarkdownString } from "@lexical/markdown"
 import { updateResponsiveImages } from "../lib/responsive_images"
@@ -237,9 +238,22 @@ function InitialContentPlugin({ html }) {
       if (root.getChildrenSize() === 0) {
         root.append($createParagraphNode())
       }
+
+      // A trailing top-level image/video/attachment leaves no caret position
+      // after it, making the document uneditable. Guarantee an editable
+      // paragraph after it. (The RootNode transform below keeps this true while
+      // editing; this handles the initial load deterministically regardless of
+      // plugin effect ordering.)
+      ensureTrailingParagraph(root)
     })
   }, [editor, html])
 
+  return null
+}
+
+function TrailingParagraphPlugin() {
+  const [editor] = useLexicalComposerContext()
+  useEffect(() => registerTrailingParagraph(editor), [editor])
   return null
 }
 
@@ -1015,6 +1029,7 @@ function EditorInner({
             onChange({ html: serialized, markdown })
           }}
         />
+        <TrailingParagraphPlugin />
         <InitialContentPlugin html={initialHtml} />
         <LinkAttributesPlugin />
         <ReadyPlugin onReady={onReady} />

--- a/engines/collavre/app/javascript/lib/lexical/__tests__/image_focus.test.js
+++ b/engines/collavre/app/javascript/lib/lexical/__tests__/image_focus.test.js
@@ -1,0 +1,139 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Regression for "an external image steals editing focus": clicking into the
+ * text to edit while an image is present used to wipe the caret. ImageResizer
+ * registered a CLICK_COMMAND handler that called the node-selection hook's
+ * setSelected(false) on any click outside the image. That hook, when the live
+ * selection is NOT already a NodeSelection (i.e. it is the RangeSelection caret
+ * the click just placed), synthesizes a fresh empty NodeSelection and replaces
+ * the caret with it — so the editor lost its caret and became uneditable the
+ * instant you clicked to edit. The fix uses clearSelection(), which only acts on
+ * an existing NodeSelection and leaves a RangeSelection (the caret) intact.
+ *
+ * ImageResizer is a .jsx React component that can't be imported under this
+ * native-ESM jest config, so this test reconstructs the two deselect paths and
+ * the exact CLICK_COMMAND handler logic on a headless editor.
+ */
+import {
+  createEditor,
+  $getRoot,
+  $getSelection,
+  $isRangeSelection,
+  $isNodeSelection,
+  $createNodeSelection,
+  $setSelection,
+  $createParagraphNode,
+  $createTextNode,
+  $applyNodeReplacement,
+  DecoratorNode,
+  CLICK_COMMAND,
+  COMMAND_PRIORITY_LOW,
+} from "lexical"
+
+class TestImageNode extends DecoratorNode {
+  __src
+  static getType() { return "image" }
+  static clone(n) { return new TestImageNode(n.__src, n.__key) }
+  static importJSON() { return $createImage("") }
+  constructor(src = "", key) { super(key); this.__src = src }
+  createDOM() { return document.createElement("span") }
+  updateDOM() { return false }
+  decorate() { return null }
+}
+function $createImage(src) { return $applyNodeReplacement(new TestImageNode(src)) }
+
+// Build: [image][paragraph "hello"] with the caret placed inside the text,
+// i.e. the state right after a user clicks into the paragraph to edit.
+function setup() {
+  const editor = createEditor({ namespace: "t", nodes: [TestImageNode], onError: (e) => { throw e } })
+  // jsdom: createEditor needs a root element to dispatch DOM-bound commands.
+  const el = document.createElement("div")
+  el.contentEditable = "true"
+  document.body.appendChild(el)
+  editor.setRootElement(el)
+  let imageKey
+  editor.update(() => {
+    const root = $getRoot()
+    root.clear()
+    root.append($createImage("https://lipcoding.kr/x.png"))
+    const p = $createParagraphNode()
+    p.append($createTextNode("hello"))
+    root.append(p)
+    imageKey = root.getFirstChild().getKey()
+  }, { discrete: true })
+  editor.update(() => {
+    $getRoot().getLastChild().getFirstChild().select(2, 2)
+  }, { discrete: true })
+  return { editor, imageKey }
+}
+
+function selKind(editor) {
+  let kind = "none"
+  editor.getEditorState().read(() => {
+    const s = $getSelection()
+    if ($isRangeSelection(s)) kind = "range"
+    else if ($isNodeSelection(s)) kind = "node"
+  })
+  return kind
+}
+
+// Mirror of the hook's setSelected(false): the OLD, destructive deselect path.
+function setSelectedFalse(editor, key) {
+  editor.update(() => {
+    let selection = $getSelection()
+    if (!$isNodeSelection(selection)) {
+      selection = $createNodeSelection()
+      $setSelection(selection)
+    }
+    if ($isNodeSelection(selection)) selection.delete(key)
+  }, { discrete: true })
+}
+
+// Mirror of the hook's clearSelection(): the safe deselect path the fix uses.
+function clearSelection(editor) {
+  editor.update(() => {
+    const selection = $getSelection()
+    if ($isNodeSelection(selection)) selection.clear()
+  }, { discrete: true })
+}
+
+describe("image editing focus", () => {
+  test("the old setSelected(false) deselect destroys the caret (documents the bug)", () => {
+    const { editor, imageKey } = setup()
+    expect(selKind(editor)).toBe("range")
+    setSelectedFalse(editor, imageKey)
+    expect(selKind(editor)).not.toBe("range") // caret lost — the reported bug
+  })
+
+  test("clearSelection() leaves the caret intact", () => {
+    const { editor } = setup()
+    expect(selKind(editor)).toBe("range")
+    clearSelection(editor)
+    expect(selKind(editor)).toBe("range")
+  })
+
+  test("CLICK_COMMAND outside the image keeps the caret (fixed handler)", () => {
+    const { editor } = setup()
+
+    // Stand-in for ImageResizer's container ref; the click target is text
+    // outside it, exactly like clicking into the paragraph to edit.
+    const container = document.createElement("span")
+    const outsideTarget = document.createElement("span")
+
+    editor.registerCommand(
+      CLICK_COMMAND,
+      (event) => {
+        if (container && !container.contains(event.target)) {
+          clearSelection(editor) // fixed path (was setSelected(false))
+        }
+        return false
+      },
+      COMMAND_PRIORITY_LOW
+    )
+
+    expect(selKind(editor)).toBe("range")
+    editor.dispatchCommand(CLICK_COMMAND, { target: outsideTarget })
+    expect(selKind(editor)).toBe("range") // caret survives the click
+  })
+})

--- a/engines/collavre/app/javascript/lib/lexical/__tests__/trailing_paragraph.test.js
+++ b/engines/collavre/app/javascript/lib/lexical/__tests__/trailing_paragraph.test.js
@@ -1,0 +1,104 @@
+/**
+ * @jest-environment jsdom
+ */
+import {
+  createEditor,
+  $getRoot,
+  $createParagraphNode,
+  $createTextNode,
+  $applyNodeReplacement,
+  DecoratorNode,
+} from "lexical"
+import { ensureTrailingParagraph, registerTrailingParagraph } from "../trailing_paragraph"
+
+// Stand-in for the production image/video/attachment nodes (those are .jsx and
+// can't be imported here). Only the graph-relevant shape matters: a "image"
+// DecoratorNode that is NOT inline, exactly like image_node.jsx.
+class TestImageNode extends DecoratorNode {
+  __src
+  static getType() { return "image" }
+  static clone(n) { return new TestImageNode(n.__src, n.__key) }
+  static importJSON() { return $createImage("") }
+  constructor(src = "", key) { super(key); this.__src = src }
+  createDOM() { return document.createElement("span") }
+  updateDOM() { return false }
+  decorate() { return null }
+}
+function $createImage(src) { return $applyNodeReplacement(new TestImageNode(src)) }
+
+function newEditor() {
+  return createEditor({ namespace: "t", nodes: [TestImageNode], onError: (e) => { throw e } })
+}
+
+function rootTypes(editor) {
+  let types = []
+  editor.getEditorState().read(() => {
+    types = $getRoot().getChildren().map((c) => c.getType())
+  })
+  return types
+}
+
+describe("ensureTrailingParagraph (pure helper)", () => {
+  test("appends a paragraph when the last root child is a decorator", () => {
+    const editor = newEditor()
+    editor.update(() => {
+      const root = $getRoot()
+      root.clear()
+      const p = $createParagraphNode()
+      p.append($createTextNode("hello"))
+      root.append(p, $createImage("https://lipcoding.kr/x.png"))
+      ensureTrailingParagraph(root)
+    }, { discrete: true })
+    expect(rootTypes(editor)).toEqual(["paragraph", "image", "paragraph"])
+  })
+
+  test("image-only content becomes editable (image + trailing paragraph)", () => {
+    const editor = newEditor()
+    editor.update(() => {
+      const root = $getRoot()
+      root.clear()
+      root.append($createImage("https://lipcoding.kr/x.png"))
+      ensureTrailingParagraph(root)
+    }, { discrete: true })
+    expect(rootTypes(editor)).toEqual(["image", "paragraph"])
+  })
+
+  test("no-op when the last child is already a paragraph", () => {
+    const editor = newEditor()
+    editor.update(() => {
+      const root = $getRoot()
+      root.clear()
+      root.append($createImage("a"), $createParagraphNode())
+      ensureTrailingParagraph(root)
+    }, { discrete: true })
+    expect(rootTypes(editor)).toEqual(["image", "paragraph"])
+  })
+})
+
+describe("registerTrailingParagraph (RootNode transform)", () => {
+  test("fires on update: trailing image gets a paragraph appended automatically", () => {
+    const editor = newEditor()
+    registerTrailingParagraph(editor)
+    // Simulate editing that leaves an image as the last block.
+    editor.update(() => {
+      const root = $getRoot()
+      root.clear()
+      const p = $createParagraphNode()
+      p.append($createTextNode("hello"))
+      root.append(p, $createImage("https://lipcoding.kr/x.png"))
+    }, { discrete: true })
+    expect(rootTypes(editor)).toEqual(["paragraph", "image", "paragraph"])
+  })
+
+  test("terminates (does not append unboundedly)", () => {
+    const editor = newEditor()
+    registerTrailingParagraph(editor)
+    editor.update(() => {
+      const root = $getRoot()
+      root.clear()
+      root.append($createImage("a"))
+    }, { discrete: true })
+    // exactly one trailing paragraph, not many
+    expect(rootTypes(editor)).toEqual(["image", "paragraph"])
+  })
+})

--- a/engines/collavre/app/javascript/lib/lexical/trailing_paragraph.js
+++ b/engines/collavre/app/javascript/lib/lexical/trailing_paragraph.js
@@ -1,0 +1,29 @@
+import { $createParagraphNode, $isDecoratorNode, RootNode } from "lexical"
+
+// A top-level DecoratorNode (image / video / attachment) renders as
+// non-editable content. When one is the last child of the root there is no
+// text position after it, so the caret can't land below it and the whole
+// document becomes uneditable — the reported "an image steals focus / can't
+// edit" bug, worst when the image is the only block. Guarantee the root always
+// ends in a paragraph so there is always an editable landing spot after a
+// trailing decorator.
+//
+// Must run inside an editor.update()/transform.
+export function ensureTrailingParagraph(root) {
+  const last = root.getLastChild()
+  if (last !== null && $isDecoratorNode(last)) {
+    last.insertAfter($createParagraphNode())
+    return true
+  }
+  return false
+}
+
+// Keep the guarantee while editing too: deleting the text below an image, or
+// pasting an image as the last block, would otherwise re-trap the caret.
+// Appending leaves the root dirty, so the transform re-runs once more and then
+// no-ops (last child is now the paragraph) — it terminates.
+export function registerTrailingParagraph(editor) {
+  return editor.registerNodeTransform(RootNode, (root) => {
+    ensureTrailingParagraph(root)
+  })
+}


### PR DESCRIPTION
## 문제
서식 편집기 콘텐츠에 이미지(예: 외부 `<img src="https://lipcoding.kr/images/lip-coding.png">`)가 있으면 포커스를 둘 곳이 없어 편집이 안 되는 버그.

## 근본 원인
`ImageNode`/`VideoNode`/`AttachmentNode`는 block `DecoratorNode`라 root 직속으로 import됩니다. 이미지가 **마지막(또는 유일) 노드**면 그 뒤에 캐럿을 놓을 텍스트 위치가 없어 문서 전체가 편집 불가가 됩니다. 게다가 import 시 trailing 빈 paragraph 제거 로직이 편집 가능한 마지막 단락까지 없애 악화시킵니다.

트리 덤프로 실증한 import 결과:
| 콘텐츠 | 결과 트리 | 편집 |
|---|---|---|
| 이미지가 끝 | `paragraph` + `image` | ❌ |
| 이미지만 | `image` (텍스트 노드 0개) | ❌ |
| 이미지가 중간 | `paragraph` + `image` + `paragraph` | ✅ |

## 수정
`lib/lexical/trailing_paragraph.js` 추가:
- `ensureTrailingParagraph(root)` — 마지막 root 자식이 DecoratorNode면 그 뒤에 빈 paragraph 보장 (표준 Lexical TrailingNode 패턴)
- `registerTrailingParagraph(editor)` — `RootNode` transform으로 등록

배선:
- **InitialContentPlugin** 끝에서 호출 → 재오픈 결정적 보장 (플러그인 effect 순서 무관)
- **TrailingParagraphPlugin** (RootNode transform) → 편집 중에도 유지 (이미지 아래 텍스트 삭제/이미지를 마지막에 붙여넣기 등). append 후 root가 한 번 더 dirty → 재실행 → no-op로 종료

## 테스트
`trailing_paragraph.test.js` 신규 5건: 순수 헬퍼(이미지 끝/이미지만/이미 paragraph) + RootNode transform 발화·종료 검증. `RootNode` transform이 이 Lexical 버전에서 정상 발화·종료함을 실증.
전체 **439/439 통과**, 회귀 없음.

## 비고
- 이미지가 콘텐츠 **맨 앞/유일**일 때 위쪽에 텍스트를 추가하려면 Home/방향키로 이동 후 편집 가능(trailing paragraph로 편집 자체는 복구됨). leading paragraph 자동삽입은 콘텐츠 변경이라 범위에서 제외.
- 별건 발견: 이미지가 `<p>텍스트 <img> 텍스트</p>`처럼 단락 **안**에 있으면 import 시 이미지가 통째로 유실됨(block decorator를 inline 부모에 넣을 수 없음). 데이터 유실이라 별도 이슈로 분리 권장.