### PR TITLE
fix: preserve inline-editor blank lines as <br> markers

### DIFF
--- a/engines/collavre/app/javascript/components/InlineLexicalEditor.jsx
+++ b/engines/collavre/app/javascript/components/InlineLexicalEditor.jsx
@@ -59,7 +59,11 @@ import { syncLexicalStyleAttributes } from "../lib/lexical/style_attributes"
 import { lexicalHtmlConfig, normalizeColoredContainers } from "../lib/lexical/color_import"
 import { minimizeContentHtml } from "../lib/lexical/minimize_html"
 import { ensureTrailingParagraph, registerTrailingParagraph } from "../lib/lexical/trailing_paragraph"
-import { MARKDOWN_TRANSFORMERS, normalizeMarkdownBlankLines } from "../lib/lexical/markdown_serialize"
+import {
+  MARKDOWN_TRANSFORMERS,
+  normalizeMarkdownBlankLines,
+  splitBlankLineParagraphs
+} from "../lib/lexical/markdown_serialize"
 import { $convertToMarkdownString } from "@lexical/markdown"
 import { updateResponsiveImages } from "../lib/responsive_images"
 import { CODE_TOKEN_THEME } from "../lib/editor/code_token_theme"
@@ -238,6 +242,15 @@ function InitialContentPlugin({ html }) {
       if (root.getChildrenSize() === 0) {
         root.append($createParagraphNode())
       }
+
+      // A blank line the user typed is an empty paragraph, but the server renders
+      // it as a standalone <br> that re-imports as a paragraph holding a
+      // LineBreakNode — which Lexical draws as TWO lines, so blank lines grew by
+      // one on every reopen. Split those marker paragraphs back into empty
+      // paragraphs so reopened blank lines match freshly typed ones. Runs AFTER
+      // the trailing-empty cleanup above so an intentional trailing blank line
+      // (a marker paragraph the cleanup leaves alone) is preserved, not stripped.
+      splitBlankLineParagraphs(root)
 
       // A trailing top-level image/video/attachment leaves no caret position
       // after it, making the document uneditable. Guarantee an editable

--- a/engines/collavre/app/javascript/components/InlineLexicalEditor.jsx
+++ b/engines/collavre/app/javascript/components/InlineLexicalEditor.jsx
@@ -59,7 +59,7 @@ import { syncLexicalStyleAttributes } from "../lib/lexical/style_attributes"
 import { lexicalHtmlConfig, normalizeColoredContainers } from "../lib/lexical/color_import"
 import { minimizeContentHtml } from "../lib/lexical/minimize_html"
 import { ensureTrailingParagraph, registerTrailingParagraph } from "../lib/lexical/trailing_paragraph"
-import { MARKDOWN_TRANSFORMERS, collapseParagraphBreaks } from "../lib/lexical/markdown_serialize"
+import { MARKDOWN_TRANSFORMERS, normalizeMarkdownBlankLines } from "../lib/lexical/markdown_serialize"
 import { $convertToMarkdownString } from "@lexical/markdown"
 import { updateResponsiveImages } from "../lib/responsive_images"
 import { CODE_TOKEN_THEME } from "../lib/editor/code_token_theme"
@@ -1020,10 +1020,10 @@ function EditorInner({
               // duplicate format wrappers, single-line <p>) before persisting.
               serialized = minimizeContentHtml(doc.body.firstElementChild)
               // Canonical Markdown projection (color/bg -> normalized <span>).
-              // collapseParagraphBreaks joins consecutive plain paragraphs with a
-              // single newline so multi-line rich text doesn't gain a blank line;
-              // the renderers run with hard breaks so the line break is preserved.
-              markdown = collapseParagraphBreaks($convertToMarkdownString(MARKDOWN_TRANSFORMERS))
+              // normalizeMarkdownBlankLines keeps the standard `\n\n` paragraph
+              // separation (Enter = real paragraph break) and only tidies blank-
+              // line runs / the empty-state — no marker characters in the source.
+              markdown = normalizeMarkdownBlankLines($convertToMarkdownString(MARKDOWN_TRANSFORMERS))
             })
             // html: client-side preview/fallback; markdown: canonical storage.
             onChange({ html: serialized, markdown })

--- a/engines/collavre/app/javascript/lib/editor/__tests__/code_language_roundtrip.test.js
+++ b/engines/collavre/app/javascript/lib/editor/__tests__/code_language_roundtrip.test.js
@@ -10,7 +10,7 @@ import { LinkNode, AutoLinkNode } from "@lexical/link"
 import { CodeNode, CodeHighlightNode, registerCodeHighlighting, $isCodeNode, $createCodeNode } from "@lexical/code"
 import { $generateNodesFromDOM } from "@lexical/html"
 import { $convertToMarkdownString } from "@lexical/markdown"
-import { MARKDOWN_TRANSFORMERS, collapseParagraphBreaks } from "../../lexical/markdown_serialize"
+import { MARKDOWN_TRANSFORMERS, normalizeMarkdownBlankLines } from "../../lexical/markdown_serialize"
 import { renderMarkdown } from "../../utils/markdown"
 import {
   bridgeCodeFenceLanguages, detectCodeLanguage, normalizeFenceLang,
@@ -82,7 +82,7 @@ function codeLang(editor) {
 
 function fence(editor) {
   let md = ""
-  editor.update(() => { md = collapseParagraphBreaks($convertToMarkdownString(MARKDOWN_TRANSFORMERS)) }, { discrete: true })
+  editor.update(() => { md = normalizeMarkdownBlankLines($convertToMarkdownString(MARKDOWN_TRANSFORMERS)) }, { discrete: true })
   return md.split("\n")[0]
 }
 

--- a/engines/collavre/app/javascript/lib/lexical/__tests__/markdown_serialize.test.js
+++ b/engines/collavre/app/javascript/lib/lexical/__tests__/markdown_serialize.test.js
@@ -406,6 +406,24 @@ describe("normalizeMarkdownBlankLines", () => {
     )
   })
 
+  it("only isolates a <br> that is the whole blank-line marker line", () => {
+    // A blank-line marker is always emitted alone on its line (see
+    // BLANK_PARAGRAPH_TRANSFORMER). A <br> embedded inside a line of other
+    // content is an in-paragraph hard break / raw HTML, NOT a marker, so the
+    // normalizer must leave it (and its surroundings) untouched — injecting
+    // blank lines around it would rewrite user-authored HTML on save.
+    expect(normalizeMarkdownBlankLines("<span>foo<br>bar</span>")).toBe(
+      "<span>foo<br>bar</span>"
+    )
+    expect(normalizeMarkdownBlankLines("a<br>b")).toBe("a<br>b")
+    expect(normalizeMarkdownBlankLines("foo <br> bar")).toBe("foo <br> bar")
+    // A standalone marker line embedded next to inline-<br> text: only the
+    // whole-line marker is isolated; the inline one is preserved verbatim.
+    expect(normalizeMarkdownBlankLines("a<br>b\n<br>\nc<br>d")).toBe(
+      "a<br>b\n\n<br>\n\nc<br>d"
+    )
+  })
+
   it("migrates legacy NBSP blank-line markers to <br> on save", () => {
     // Pre-<br> content stored blank lines as a line of only U+00A0. Reopening
     // and saving must clean it to a real <br> marker so CommonMark stops

--- a/engines/collavre/app/javascript/lib/lexical/__tests__/markdown_serialize.test.js
+++ b/engines/collavre/app/javascript/lib/lexical/__tests__/markdown_serialize.test.js
@@ -17,7 +17,7 @@ import {
   videoMarkup,
   attachmentMarkup,
   lexicalToMarkdown,
-  collapseParagraphBreaks
+  normalizeMarkdownBlankLines
 } from "../markdown_serialize"
 
 // Minimal DecoratorNode stand-in: the production image/video/attachment nodes
@@ -242,7 +242,7 @@ describe("lexicalToMarkdown", () => {
     expect(lexicalToMarkdown(editor)).toBe('plain <span style="color: blue">blue</span>')
   })
 
-  it("joins consecutive plain paragraphs with a single newline", () => {
+  it("separates consecutive paragraphs with a standard blank line", () => {
     const editor = buildEditor((root) => {
       const a = $createParagraphNode()
       a.append($createTextNode("abc"))
@@ -251,8 +251,9 @@ describe("lexicalToMarkdown", () => {
       b.append($createTextNode("def"))
       root.append(b)
     })
-    // No blank line inserted between rich-editor lines (the user's request).
-    expect(lexicalToMarkdown(editor)).toBe("abc\ndef")
+    // Enter produces a real paragraph break: standard Markdown `\n\n`, no marker
+    // characters in the canonical source (the user's "stray space" complaint).
+    expect(lexicalToMarkdown(editor)).toBe("abc\n\ndef")
   })
 
   it("keeps a blank line between a paragraph and a heading", () => {
@@ -267,7 +268,7 @@ describe("lexicalToMarkdown", () => {
     expect(lexicalToMarkdown(editor)).toBe("intro\n\n## Sec")
   })
 
-  it("preserves a single blank line (empty paragraph) as a non-breaking space line", () => {
+  it("renders an empty paragraph as the standard single blank line (no marker)", () => {
     const editor = buildEditor((root) => {
       const a = $createParagraphNode()
       a.append($createTextNode("abc"))
@@ -277,12 +278,12 @@ describe("lexicalToMarkdown", () => {
       b.append($createTextNode("def"))
       root.append(b)
     })
-    // The empty line must survive: renderers run with hard breaks, so the
-    // line renders as a visible blank line inside one <p> instead of collapsing.
-    expect(lexicalToMarkdown(editor)).toBe("abc\n\u00A0\ndef")
+    // An empty paragraph between two paragraphs is just the standard Markdown
+    // paragraph separation \u2014 no NBSP, no stray space in the canonical source.
+    expect(lexicalToMarkdown(editor)).toBe("abc\n\ndef")
   })
 
-  it("preserves multiple consecutive blank lines, one nbsp line each", () => {
+  it("collapses multiple consecutive blank lines to one standard blank line", () => {
     const editor = buildEditor((root) => {
       const a = $createParagraphNode()
       a.append($createTextNode("abc"))
@@ -293,7 +294,10 @@ describe("lexicalToMarkdown", () => {
       b.append($createTextNode("def"))
       root.append(b)
     })
-    expect(lexicalToMarkdown(editor)).toBe("abc\n\u00A0\n\u00A0\ndef")
+    // Standard Markdown can't distinguish N consecutive blank lines and renders
+    // them identically, so they normalize to a single blank line (round-trip
+    // stable on the first save).
+    expect(lexicalToMarkdown(editor)).toBe("abc\n\ndef")
   })
 
   it("serializes an editor that holds only empty paragraphs as empty Markdown", () => {
@@ -306,7 +310,7 @@ describe("lexicalToMarkdown", () => {
     expect(lexicalToMarkdown(editor)).toBe("")
   })
 
-  it("keeps tight lines tight and only the empty line spaced", () => {
+  it("separates every paragraph with a standard blank line", () => {
     const editor = buildEditor((root) => {
       const a = $createParagraphNode()
       a.append($createTextNode("abc"))
@@ -319,32 +323,38 @@ describe("lexicalToMarkdown", () => {
       c.append($createTextNode("ghi"))
       root.append(c)
     })
-    expect(lexicalToMarkdown(editor)).toBe("abc\ndef\n\u00A0\nghi")
+    expect(lexicalToMarkdown(editor)).toBe("abc\n\ndef\n\nghi")
   })
 })
 
-describe("collapseParagraphBreaks", () => {
-  it("collapses the blank line between two plain paragraphs", () => {
-    expect(collapseParagraphBreaks("a\n\nb")).toBe("a\nb")
-    expect(collapseParagraphBreaks("a\n\nb\n\nc")).toBe("a\nb\nc")
+describe("normalizeMarkdownBlankLines", () => {
+  it("keeps the standard blank line between two plain paragraphs", () => {
+    expect(normalizeMarkdownBlankLines("a\n\nb")).toBe("a\n\nb")
+    expect(normalizeMarkdownBlankLines("a\n\nb\n\nc")).toBe("a\n\nb\n\nc")
   })
 
-  it("keeps blank lines around non-paragraph blocks", () => {
-    expect(collapseParagraphBreaks("p\n\n## h")).toBe("p\n\n## h")
-    expect(collapseParagraphBreaks("note\n\n- a\n- b")).toBe("note\n\n- a\n- b")
-    expect(collapseParagraphBreaks("- a\n- b\n\ntail")).toBe("- a\n- b\n\ntail")
-    expect(collapseParagraphBreaks("p\n\n> quote")).toBe("p\n\n> quote")
-    expect(collapseParagraphBreaks('p\n\n<img src="/x.png" alt="x">')).toBe(
-      'p\n\n<img src="/x.png" alt="x">'
-    )
+  it("collapses runs of 3+ newlines to one standard blank line", () => {
+    expect(normalizeMarkdownBlankLines("a\n\n\nb")).toBe("a\n\nb")
+    expect(normalizeMarkdownBlankLines("a\n\n\n\n\nb")).toBe("a\n\nb")
+  })
+
+  it("returns empty string for blank-only input (empty-state contract)", () => {
+    expect(normalizeMarkdownBlankLines("")).toBe("")
+    expect(normalizeMarkdownBlankLines("\n")).toBe("")
+    expect(normalizeMarkdownBlankLines("\n\n  \n")).toBe("")
+  })
+
+  it("trims trailing whitespace", () => {
+    expect(normalizeMarkdownBlankLines("abc\n\n\n")).toBe("abc")
+    expect(normalizeMarkdownBlankLines("abc  \n")).toBe("abc")
   })
 
   it("never collapses blank lines inside a fenced code block", () => {
-    const md = "```js\nconst a = 1\n\nconst b = 2\n```"
-    expect(collapseParagraphBreaks(md)).toBe(md)
-    // ...and still collapses paragraphs around the protected fence
-    expect(collapseParagraphBreaks("a\n\nb\n\n```\nx\n\ny\n```")).toBe(
-      "a\nb\n\n```\nx\n\ny\n```"
+    const md = "```js\nconst a = 1\n\n\nconst b = 2\n```"
+    expect(normalizeMarkdownBlankLines(md)).toBe(md)
+    // ...and still normalizes blank-line runs around the protected fence
+    expect(normalizeMarkdownBlankLines("a\n\n\nb\n\n```\nx\n\n\ny\n```")).toBe(
+      "a\n\nb\n\n```\nx\n\n\ny\n```"
     )
   })
 })
@@ -415,9 +425,9 @@ describe("round-trip: rendered HTML -> Lexical -> Markdown", () => {
       '<p><span style="color: rgb(255, 0, 0)">&lt;tag&gt; &amp; x</span></p>',
       '<span style="color: rgb(255, 0, 0)">&lt;tag&gt; &amp; x</span>'
     ],
-    // A preserved blank line round-trips: markdown_to_html renders the nbsp line
-    // as <br> <br> inside one <p>; re-importing keeps the same canonical form.
-    ["blank line", "<p>abc<br>\u00A0<br>def</p>", "abc\n\u00A0\ndef"]
+    // A blank line round-trips as standard paragraph separation: markdown_to_html
+    // renders `abc\n\ndef` as two <p> blocks; re-importing keeps the same form.
+    ["blank line", "<p>abc</p><p>def</p>", "abc\n\ndef"]
   ]
 
   it.each(cases)("round-trips %s", (_name, html, expected) => {

--- a/engines/collavre/app/javascript/lib/lexical/__tests__/markdown_serialize.test.js
+++ b/engines/collavre/app/javascript/lib/lexical/__tests__/markdown_serialize.test.js
@@ -21,7 +21,8 @@ import {
   videoMarkup,
   attachmentMarkup,
   lexicalToMarkdown,
-  normalizeMarkdownBlankLines
+  normalizeMarkdownBlankLines,
+  splitBlankLineParagraphs
 } from "../markdown_serialize"
 
 // Minimal DecoratorNode stand-in: the production image/video/attachment nodes
@@ -396,7 +397,7 @@ describe("normalizeMarkdownBlankLines", () => {
 // into Lexical via $generateNodesFromDOM + the colorAwareSpanImport config. Then
 // we re-serialize to Markdown and require byte-identity with the rendered HTML's
 // intended source — guarding the md -> html -> lexical -> md round-trip.
-function importHtmlThenToMarkdown(html) {
+function importHtml(html) {
   const editor = createEditor({
     namespace: "test",
     onError(error) {
@@ -438,10 +439,39 @@ function importHtmlThenToMarkdown(html) {
         root.append(node)
       })
       flush()
+      // Mirror InlineLexicalEditor: a grouped blank-line marker paragraph (only
+      // LineBreakNodes) is split back into N empty paragraphs so reopened blank
+      // lines match the structure fresh typing produces.
+      splitBlankLineParagraphs(root)
     },
     { discrete: true }
   )
-  return lexicalToMarkdown(editor)
+  return editor
+}
+
+// Structure of the root's children, for asserting that blank-line markers import
+// as EMPTY paragraphs (one visual line each) rather than LineBreakNode-bearing
+// paragraphs (which Lexical renders with an extra trailing line).
+function importHtmlToStructure(html) {
+  const editor = importHtml(html)
+  let summary = []
+  editor.getEditorState().read(() => {
+    summary = $getRoot()
+      .getChildren()
+      .map((child) => ({
+        type: child.getType(),
+        childCount: child.getChildrenSize ? child.getChildrenSize() : 0,
+        lineBreaks: child.getChildren
+          ? child.getChildren().filter($isLineBreakNode).length
+          : 0,
+        text: child.getTextContent()
+      }))
+  })
+  return summary
+}
+
+function importHtmlThenToMarkdown(html) {
+  return lexicalToMarkdown(importHtml(html))
 }
 
 describe("round-trip: rendered HTML -> Lexical -> Markdown", () => {
@@ -499,5 +529,49 @@ describe("round-trip: rendered HTML -> Lexical -> Markdown", () => {
 
   it.each(cases)("round-trips %s", (_name, html, expected) => {
     expect(importHtmlThenToMarkdown(html)).toBe(expected)
+  })
+})
+
+describe("import structure: blank-line markers become empty paragraphs", () => {
+  // The bug: a single typed blank line is an EMPTY paragraph (zero children,
+  // one visual line). On reopen the server renders it as a standalone <br>,
+  // which imports as a paragraph holding a LineBreakNode — and Lexical renders
+  // that as TWO lines (the break starts a new line on top of the paragraph's
+  // own line). So the blank line grew by one on every reopen. After the fix a
+  // blank-line marker imports as an empty paragraph, matching fresh typing.
+  it("imports a single blank line as one empty paragraph (not a LineBreakNode)", () => {
+    const structure = importHtmlToStructure("<p>Test</p>\n<br>\n<p>a</p>")
+    expect(structure).toEqual([
+      { type: "paragraph", childCount: 1, lineBreaks: 0, text: "Test" },
+      { type: "paragraph", childCount: 0, lineBreaks: 0, text: "" },
+      { type: "paragraph", childCount: 1, lineBreaks: 0, text: "a" }
+    ])
+  })
+
+  it("imports N consecutive blank lines as N empty paragraphs", () => {
+    const structure = importHtmlToStructure("<p>abc</p>\n<br>\n<br>\n<p>def</p>")
+    expect(structure).toEqual([
+      { type: "paragraph", childCount: 1, lineBreaks: 0, text: "abc" },
+      { type: "paragraph", childCount: 0, lineBreaks: 0, text: "" },
+      { type: "paragraph", childCount: 0, lineBreaks: 0, text: "" },
+      { type: "paragraph", childCount: 1, lineBreaks: 0, text: "def" }
+    ])
+  })
+
+  it("leaves an in-paragraph line break (text + <br>) untouched", () => {
+    // A paragraph that mixes text and a break is NOT a blank-line marker; it
+    // must keep its LineBreakNode so real soft breaks survive.
+    const structure = importHtmlToStructure("<p>line1<br>line2</p>")
+    expect(structure).toEqual([
+      { type: "paragraph", childCount: 3, lineBreaks: 1, text: "line1\nline2" }
+    ])
+  })
+
+  it("splitBlankLineParagraphs preserves the exported <br> count (round-trip stable)", () => {
+    // After splitting, re-export still emits exactly N markers.
+    expect(importHtmlThenToMarkdown("<p>Test</p>\n<br>\n<p>a</p>")).toBe("Test\n\n<br>\n\na")
+    expect(importHtmlThenToMarkdown("<p>abc</p>\n<br>\n<br>\n<p>def</p>")).toBe(
+      "abc\n\n<br>\n\n<br>\n\ndef"
+    )
   })
 })

--- a/engines/collavre/app/javascript/lib/lexical/__tests__/markdown_serialize.test.js
+++ b/engines/collavre/app/javascript/lib/lexical/__tests__/markdown_serialize.test.js
@@ -3,6 +3,10 @@ import {
   $getRoot,
   $createParagraphNode,
   $createTextNode,
+  $createLineBreakNode,
+  $isTextNode,
+  $isLineBreakNode,
+  $isElementNode,
   DecoratorNode
 } from "lexical"
 import { HeadingNode, QuoteNode, $createHeadingNode } from "@lexical/rich-text"
@@ -268,7 +272,7 @@ describe("lexicalToMarkdown", () => {
     expect(lexicalToMarkdown(editor)).toBe("intro\n\n## Sec")
   })
 
-  it("renders an empty paragraph as the standard single blank line (no marker)", () => {
+  it("renders an empty paragraph as a single <br> marker (preserves the blank line)", () => {
     const editor = buildEditor((root) => {
       const a = $createParagraphNode()
       a.append($createTextNode("abc"))
@@ -278,12 +282,13 @@ describe("lexicalToMarkdown", () => {
       b.append($createTextNode("def"))
       root.append(b)
     })
-    // An empty paragraph between two paragraphs is just the standard Markdown
-    // paragraph separation \u2014 no NBSP, no stray space in the canonical source.
-    expect(lexicalToMarkdown(editor)).toBe("abc\n\ndef")
+    // The blank line the user typed is preserved as a semantic <br> marker (not a
+    // stray space, and not collapsed away): standard paragraph separation around
+    // a single <br>. The <br> renders as a visible blank line and round-trips.
+    expect(lexicalToMarkdown(editor)).toBe("abc\n\n<br>\n\ndef")
   })
 
-  it("collapses multiple consecutive blank lines to one standard blank line", () => {
+  it("preserves multiple consecutive blank lines, one <br> per line", () => {
     const editor = buildEditor((root) => {
       const a = $createParagraphNode()
       a.append($createTextNode("abc"))
@@ -294,10 +299,28 @@ describe("lexicalToMarkdown", () => {
       b.append($createTextNode("def"))
       root.append(b)
     })
-    // Standard Markdown can't distinguish N consecutive blank lines and renders
-    // them identically, so they normalize to a single blank line (round-trip
-    // stable on the first save).
-    expect(lexicalToMarkdown(editor)).toBe("abc\n\ndef")
+    // Two empty paragraphs (two Enters) keep their exact count as two <br>
+    // markers \u2014 the standard-paragraph model collapsed these to one blank line.
+    expect(lexicalToMarkdown(editor)).toBe("abc\n\n<br>\n\n<br>\n\ndef")
+  })
+
+  it("serializes a blank paragraph of N line breaks as N <br> markers", () => {
+    // On reopen the importer groups N consecutive <br> elements into ONE
+    // paragraph holding N LineBreakNodes. Export must emit exactly N markers
+    // (not N+1) or blank lines multiply on every save.
+    const editor = buildEditor((root) => {
+      const a = $createParagraphNode()
+      a.append($createTextNode("abc"))
+      root.append(a)
+      const blanks = $createParagraphNode()
+      blanks.append($createLineBreakNode())
+      blanks.append($createLineBreakNode())
+      root.append(blanks)
+      const b = $createParagraphNode()
+      b.append($createTextNode("def"))
+      root.append(b)
+    })
+    expect(lexicalToMarkdown(editor)).toBe("abc\n\n<br>\n\n<br>\n\ndef")
   })
 
   it("serializes an editor that holds only empty paragraphs as empty Markdown", () => {
@@ -310,7 +333,7 @@ describe("lexicalToMarkdown", () => {
     expect(lexicalToMarkdown(editor)).toBe("")
   })
 
-  it("separates every paragraph with a standard blank line", () => {
+  it("separates plain paragraphs with a blank line and keeps an empty one as <br>", () => {
     const editor = buildEditor((root) => {
       const a = $createParagraphNode()
       a.append($createTextNode("abc"))
@@ -323,7 +346,9 @@ describe("lexicalToMarkdown", () => {
       c.append($createTextNode("ghi"))
       root.append(c)
     })
-    expect(lexicalToMarkdown(editor)).toBe("abc\n\ndef\n\nghi")
+    // abc/def are adjacent paragraphs (standard \n\n separation); the empty
+    // paragraph before ghi is a deliberate blank line, kept as a <br>.
+    expect(lexicalToMarkdown(editor)).toBe("abc\n\ndef\n\n<br>\n\nghi")
   })
 })
 
@@ -342,6 +367,13 @@ describe("normalizeMarkdownBlankLines", () => {
     expect(normalizeMarkdownBlankLines("")).toBe("")
     expect(normalizeMarkdownBlankLines("\n")).toBe("")
     expect(normalizeMarkdownBlankLines("\n\n  \n")).toBe("")
+  })
+
+  it("treats a document of only <br> markers as empty (empty-state contract)", () => {
+    // A creative the user filled with nothing but blank lines carries no real
+    // content, so it stays empty (placeholders/presence checks unchanged).
+    expect(normalizeMarkdownBlankLines("<br>")).toBe("")
+    expect(normalizeMarkdownBlankLines("<br>\n\n<br>")).toBe("")
   })
 
   it("trims trailing whitespace", () => {
@@ -380,15 +412,32 @@ function importHtmlThenToMarkdown(html) {
       const doc = new DOMParser().parseFromString(html, "text/html")
       normalizeColoredContainers(doc.body)
       const nodes = $generateNodesFromDOM(editor, doc.body)
-      nodes.forEach((node) => {
-        if (node.getType && node.getType() === "text") {
-          const p = $createParagraphNode()
-          p.append(node)
-          root.append(p)
-        } else {
-          root.append(node)
+      // Mirror InlineLexicalEditor's import grouping: text nodes, line breaks,
+      // and inline elements can't be root children, so consecutive inline leaves
+      // are grouped back into a single paragraph. This is what merges adjacent
+      // <br> markers into ONE blank paragraph holding N LineBreakNodes — the
+      // exact structure the blank-paragraph export rule must round-trip.
+      let pending = null
+      const flush = () => {
+        if (pending) {
+          root.append(pending)
+          pending = null
         }
+      }
+      nodes.forEach((node) => {
+        const isInlineLeaf =
+          $isTextNode(node) ||
+          $isLineBreakNode(node) ||
+          ($isElementNode(node) && node.isInline())
+        if (isInlineLeaf) {
+          if (!pending) pending = $createParagraphNode()
+          pending.append(node)
+          return
+        }
+        flush()
+        root.append(node)
       })
+      flush()
     },
     { discrete: true }
   )
@@ -425,9 +474,27 @@ describe("round-trip: rendered HTML -> Lexical -> Markdown", () => {
       '<p><span style="color: rgb(255, 0, 0)">&lt;tag&gt; &amp; x</span></p>',
       '<span style="color: rgb(255, 0, 0)">&lt;tag&gt; &amp; x</span>'
     ],
-    // A blank line round-trips as standard paragraph separation: markdown_to_html
-    // renders `abc\n\ndef` as two <p> blocks; re-importing keeps the same form.
-    ["blank line", "<p>abc</p><p>def</p>", "abc\n\ndef"]
+    // Two adjacent paragraphs (no deliberate blank line between them) keep the
+    // standard `\n\n` separation and no <br> marker is introduced.
+    ["two adjacent paragraphs", "<p>abc</p><p>def</p>", "abc\n\ndef"],
+    // A deliberate blank line is a <br>. markdown_to_html renders
+    // `abc\n\n<br>\n\ndef` as <p>abc</p><br><p>def</p>; the importer groups the
+    // <br> into a blank paragraph and re-export emits exactly one <br>.
+    ["single blank line", "<p>abc</p>\n<br>\n<p>def</p>", "abc\n\n<br>\n\ndef"],
+    // Two consecutive <br> markers come back as ONE paragraph of two
+    // LineBreakNodes; the count must be preserved (no multiplication on re-save).
+    [
+      "two blank lines",
+      "<p>abc</p>\n<br>\n<br>\n<p>def</p>",
+      "abc\n\n<br>\n\n<br>\n\ndef"
+    ],
+    // A blank line right after a list no longer bleeds into the last <li>: the
+    // list closes and the <br> + following text serialize as their own blocks.
+    [
+      "blank line after a list",
+      "<ul>\n<li>test</li>\n<li>OK</li>\n</ul>\n<br>\n<p>XXXXXXX</p>",
+      "- test\n- OK\n\n<br>\n\nXXXXXXX"
+    ]
   ]
 
   it.each(cases)("round-trips %s", (_name, html, expected) => {

--- a/engines/collavre/app/javascript/lib/lexical/__tests__/markdown_serialize.test.js
+++ b/engines/collavre/app/javascript/lib/lexical/__tests__/markdown_serialize.test.js
@@ -390,6 +390,38 @@ describe("normalizeMarkdownBlankLines", () => {
       "a\n\nb\n\n```\nx\n\n\ny\n```"
     )
   })
+
+  it("never rewrites a literal <br> inside an inline code span", () => {
+    // The rich editor exports inline code whose text is `<br>` as `` `<br>` ``.
+    // The blank-line normalizer must not treat that as a marker and inject
+    // blank lines, which would break the code span on save.
+    expect(normalizeMarkdownBlankLines("Here is `<br>` literal code")).toBe(
+      "Here is `<br>` literal code"
+    )
+    expect(normalizeMarkdownBlankLines("a `<br>` b")).toBe("a `<br>` b")
+    expect(normalizeMarkdownBlankLines("`<br>`")).toBe("`<br>`")
+    // A real marker on its own line is still isolated even alongside a code span
+    expect(normalizeMarkdownBlankLines("a `<br>` b\n<br>\nc")).toBe(
+      "a `<br>` b\n\n<br>\n\nc"
+    )
+  })
+
+  it("migrates legacy NBSP blank-line markers to <br> on save", () => {
+    // Pre-<br> content stored blank lines as a line of only U+00A0. Reopening
+    // and saving must clean it to a real <br> marker so CommonMark stops
+    // treating the following block as a lazy list continuation.
+    expect(normalizeMarkdownBlankLines("abc\n \ndef")).toBe(
+      "abc\n\n<br>\n\ndef"
+    )
+    // ...and a NBSP marker right after a list is isolated as its own block
+    expect(
+      normalizeMarkdownBlankLines("- a\n- b\n \nXXX")
+    ).toBe("- a\n- b\n\n<br>\n\nXXX")
+    // A NBSP inside inline code is left untouched
+    expect(normalizeMarkdownBlankLines("see ` ` here")).toBe(
+      "see ` ` here"
+    )
+  })
 })
 
 // Reproduces the production import path: stored Markdown is rendered to HTML by

--- a/engines/collavre/app/javascript/lib/lexical/markdown_serialize.js
+++ b/engines/collavre/app/javascript/lib/lexical/markdown_serialize.js
@@ -272,7 +272,12 @@ export function normalizeMarkdownBlankLines(markdown) {
     // paragraph to its neighbours with a single `\n`, while a reopened (grouped)
     // blank paragraph gets `\n\n`; canonicalizing here makes the very first save
     // byte-identical to the reopen fixpoint regardless of which path produced it.
-    .replace(/\n*(<br>)\n*/g, "\n\n$1\n\n")
+    // BLANK_PARAGRAPH_TRANSFORMER always emits a marker alone on its line, so we
+    // only match a `<br>` that is the WHOLE line (anchored ^…$ under /m). A
+    // `<br>` embedded in other content (an in-paragraph hard break or raw inline
+    // HTML such as `<span>foo<br>bar</span>`) is not a marker and is left
+    // untouched — isolating it would rewrite user HTML on save.
+    .replace(/\n*^[ \t]*<br>[ \t]*$\n*/gm, "\n\n<br>\n\n")
     .replace(/\n{3,}/g, "\n\n")
     .replace(/^\n+/, "")
     .replace(/\s+$/, "")

--- a/engines/collavre/app/javascript/lib/lexical/markdown_serialize.js
+++ b/engines/collavre/app/javascript/lib/lexical/markdown_serialize.js
@@ -1,4 +1,4 @@
-import { $isTextNode } from "lexical"
+import { $isTextNode, $isParagraphNode, $isLineBreakNode } from "lexical"
 import { $convertToMarkdownString, TRANSFORMERS } from "@lexical/markdown"
 import { TABLE, setCellTransformers } from "./table_transformer"
 
@@ -142,6 +142,47 @@ function decoratorMarkup(node) {
   return null
 }
 
+// A paragraph the user left blank: it carries no real text, only empty text
+// nodes and/or line breaks. (Decorator- or text-bearing paragraphs are NOT
+// blank, so media and real content keep their normal export.) An empty
+// paragraph from pressing Enter has zero children; a run of blank lines that
+// was reopened comes back as ONE paragraph holding N LineBreakNodes (the
+// importer groups consecutive <br> markers together).
+function isBlankParagraph(node) {
+  if (!$isParagraphNode(node)) return false
+  // A blank paragraph inside a table cell is just an empty cell — it must stay
+  // empty (`|  |`), not become a `<br>`. The cell serializer reuses this
+  // transformer set, so exclude paragraphs nested in a cell (duck-typed by type
+  // to keep this module free of the @lexical/table import).
+  const parent = node.getParent ? node.getParent() : null
+  if (parent && parent.getType && parent.getType() === "tablecell") return false
+  return node
+    .getChildren()
+    .every((child) => $isLineBreakNode(child) || ($isTextNode(child) && !child.getTextContent().trim()))
+}
+
+// How many blank lines a blank paragraph represents: one per LineBreakNode, but
+// at least one (a freshly-typed empty paragraph has no line breaks yet still
+// stands for a single blank line). This exact count is what keeps multiple
+// blank lines from multiplying on every save — the reopened paragraph holds N
+// line breaks and must re-emit N markers, not N+1.
+function blankParagraphBreakCount(node) {
+  const breaks = node.getChildren().filter($isLineBreakNode).length
+  return Math.max(1, breaks)
+}
+
+// Blank paragraphs -> one `<br>` per blank line. A `<br>` is a semantic empty
+// line (not a stray space or NBSP): the hard-break renderers keep it as a
+// visible blank line, and because each marker sits in its own block separated
+// by the standard `\n\n`, a blank line after a list no longer gets pulled into
+// the last <li> via lazy continuation. Round-trips: the importer regroups the
+// rendered <br> elements into a blank paragraph that re-exports identically.
+const BLANK_PARAGRAPH_TRANSFORMER = exportOnlyTransformer(
+  (node) =>
+    isBlankParagraph(node) ? Array(blankParagraphBreakCount(node)).fill("<br>").join("\n\n") : null,
+  { type: "element" }
+)
+
 // Colored / highlighted text -> normalized <span>. Falls through (returns null)
 // for uncolored text so the default text-format export still applies.
 const COLOR_TRANSFORMER = exportOnlyTransformer((node, _exportChildren, exportFormat) => {
@@ -171,6 +212,7 @@ const DECORATOR_ELEMENT_TRANSFORMER = exportOnlyTransformer((node) => decoratorM
 export const MARKDOWN_TRANSFORMERS = [
   TABLE,
   DECORATOR_ELEMENT_TRANSFORMER,
+  BLANK_PARAGRAPH_TRANSFORMER,
   DECORATOR_TEXT_TRANSFORMER,
   COLOR_TRANSFORMER,
   ...TRANSFORMERS
@@ -185,16 +227,18 @@ setCellTransformers(MARKDOWN_TRANSFORMERS)
 const FENCE_BLOCK = /(`{3,}|~{3,})[^\n]*\n[\s\S]*?\n\1[ \t]*(?=\n|$)/g
 
 // Normalize the canonical Markdown projection. Enter produces a real paragraph
-// break, so consecutive paragraphs are separated by the standard `\n\n` — no
-// marker characters in the stored source. This pass only:
-//   - returns "" for a blank-only document (placeholder/presence contract),
-//   - collapses runs of 3+ newlines (N consecutive blank paragraphs, which
-//     standard Markdown can't distinguish and renders identically) to one
-//     blank line, so the very first save is already round-trip stable,
+// break (standard `\n\n` separation); a blank line the user typed is preserved
+// as a `<br>` marker (see BLANK_PARAGRAPH_TRANSFORMER). This pass only:
+//   - returns "" for a document with no real content (only whitespace and/or
+//     `<br>` markers), keeping the empty-state placeholder/presence contract,
+//   - collapses runs of 3+ newlines to one blank line so block separation stays
+//     canonical and the very first save is round-trip stable,
 //   - trims trailing whitespace.
 // Blank lines inside fenced code are preserved verbatim.
 export function normalizeMarkdownBlankLines(markdown) {
-  if (!String(markdown).trim()) return ""
+  // A document of only blank lines (each now a `<br>`) carries no real content,
+  // so strip the markers before the emptiness check.
+  if (!String(markdown).replace(/<br\s*\/?>/gi, "").trim()) return ""
 
   const fences = []
   const guarded = String(markdown).replace(FENCE_BLOCK, (match) => {
@@ -202,7 +246,16 @@ export function normalizeMarkdownBlankLines(markdown) {
     return `\x00MDFENCE${fences.length - 1}\x00`
   })
 
-  const normalized = guarded.replace(/\n{3,}/g, "\n\n").replace(/\s+$/, "")
+  const normalized = guarded
+    // Each blank-line marker is its own block: isolate every `<br>` with a blank
+    // line on both sides. Lexical's exporter joins a freshly-typed empty
+    // paragraph to its neighbours with a single `\n`, while a reopened (grouped)
+    // blank paragraph gets `\n\n`; canonicalizing here makes the very first save
+    // byte-identical to the reopen fixpoint regardless of which path produced it.
+    .replace(/\n*(<br>)\n*/g, "\n\n$1\n\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .replace(/^\n+/, "")
+    .replace(/\s+$/, "")
 
   return normalized.replace(/\x00MDFENCE(\d+)\x00/g, (_, n) => fences[Number(n)])
 }

--- a/engines/collavre/app/javascript/lib/lexical/markdown_serialize.js
+++ b/engines/collavre/app/javascript/lib/lexical/markdown_serialize.js
@@ -289,7 +289,7 @@ export function normalizeMarkdownBlankLines(markdown) {
 // paragraph holding N LineBreakNodes. Lexical renders such a paragraph as N+1
 // visual lines — each break starts a new line on top of the paragraph's own
 // line — so a single typed blank line reopens as TWO, growing by one on every
-// reopen (the "임의 새줄 추가" bug). Freshly typed blank lines are EMPTY
+// reopen (the "blank lines keep multiplying" bug). Freshly typed blank lines are EMPTY
 // paragraphs instead (zero children, one visual line each). Re-create that
 // structure: replace every all-LineBreakNode paragraph with N empty paragraphs
 // so reopened blank lines match typed ones. Export is unaffected — each empty

--- a/engines/collavre/app/javascript/lib/lexical/markdown_serialize.js
+++ b/engines/collavre/app/javascript/lib/lexical/markdown_serialize.js
@@ -1,4 +1,9 @@
-import { $isTextNode, $isParagraphNode, $isLineBreakNode } from "lexical"
+import {
+  $isTextNode,
+  $isParagraphNode,
+  $isLineBreakNode,
+  $createParagraphNode
+} from "lexical"
 import { $convertToMarkdownString, TRANSFORMERS } from "@lexical/markdown"
 import { TABLE, setCellTransformers } from "./table_transformer"
 
@@ -258,6 +263,31 @@ export function normalizeMarkdownBlankLines(markdown) {
     .replace(/\s+$/, "")
 
   return normalized.replace(/\x00MDFENCE(\d+)\x00/g, (_, n) => fences[Number(n)])
+}
+
+// On reopen, a run of blank-line markers (<br>) comes back grouped into ONE
+// paragraph holding N LineBreakNodes. Lexical renders such a paragraph as N+1
+// visual lines — each break starts a new line on top of the paragraph's own
+// line — so a single typed blank line reopens as TWO, growing by one on every
+// reopen (the "임의 새줄 추가" bug). Freshly typed blank lines are EMPTY
+// paragraphs instead (zero children, one visual line each). Re-create that
+// structure: replace every all-LineBreakNode paragraph with N empty paragraphs
+// so reopened blank lines match typed ones. Export is unaffected — each empty
+// paragraph still emits exactly one <br> (blankParagraphBreakCount), so the
+// canonical Markdown round-trips byte-for-byte. Paragraphs that mix text with a
+// break (real soft breaks) are left untouched.
+export function splitBlankLineParagraphs(root) {
+  if (!root || !root.getChildren) return
+  root.getChildren().forEach((node) => {
+    if (!$isParagraphNode(node)) return
+    const children = node.getChildren()
+    if (children.length === 0) return
+    if (!children.every($isLineBreakNode)) return
+    for (let i = 0; i < children.length; i++) {
+      node.insertBefore($createParagraphNode())
+    }
+    node.remove()
+  })
 }
 
 // Read the editor state and return canonical Markdown.

--- a/engines/collavre/app/javascript/lib/lexical/markdown_serialize.js
+++ b/engines/collavre/app/javascript/lib/lexical/markdown_serialize.js
@@ -1,4 +1,4 @@
-import { $isTextNode, $isParagraphNode } from "lexical"
+import { $isTextNode } from "lexical"
 import { $convertToMarkdownString, TRANSFORMERS } from "@lexical/markdown"
 import { TABLE, setCellTransformers } from "./table_transformer"
 
@@ -142,25 +142,6 @@ function decoratorMarkup(node) {
   return null
 }
 
-// A paragraph the user left blank (pressed Enter on an empty line). Decorator-
-// or text-bearing paragraphs are NOT blank, so media and whitespace-with-content
-// keep their normal export.
-function isBlankParagraph(node) {
-  if (!$isParagraphNode(node)) return false
-  return node.getChildren().every((child) => $isTextNode(child) && !child.getTextContent().trim())
-}
-
-// Blank paragraphs -> a non-breaking-space line (U+00A0). The default export
-// collapses an empty paragraph to "" (indistinguishable from the blank line the
-// upstream join inserts between two normal paragraphs), so collapseParagraphBreaks
-// would erase a deliberately-typed empty line. A NBSP line is non-blank Markdown,
-// so the hard-break renderer keeps it as a visible empty line inside one <p>
-// instead of collapsing it — and N empty paragraphs render as N blank lines.
-const EMPTY_PARAGRAPH_TRANSFORMER = exportOnlyTransformer(
-  (node) => (isBlankParagraph(node) ? "\u00A0" : null),
-  { type: "element" }
-)
-
 // Colored / highlighted text -> normalized <span>. Falls through (returns null)
 // for uncolored text so the default text-format export still applies.
 const COLOR_TRANSFORMER = exportOnlyTransformer((node, _exportChildren, exportFormat) => {
@@ -190,7 +171,6 @@ const DECORATOR_ELEMENT_TRANSFORMER = exportOnlyTransformer((node) => decoratorM
 export const MARKDOWN_TRANSFORMERS = [
   TABLE,
   DECORATOR_ELEMENT_TRANSFORMER,
-  EMPTY_PARAGRAPH_TRANSFORMER,
   DECORATOR_TEXT_TRANSFORMER,
   COLOR_TRANSFORMER,
   ...TRANSFORMERS
@@ -200,31 +180,20 @@ export const MARKDOWN_TRANSFORMERS = [
 // here (rather than imported into table_transformer.js) to break the cycle.
 setCellTransformers(MARKDOWN_TRANSFORMERS)
 
-// A block that must keep a blank line before/after it (i.e. is NOT a plain
-// paragraph): heading, blockquote, list item, fenced code, table row, thematic
-// break, or a top-level media tag. Anything else is treated as paragraph text.
-const NON_PARAGRAPH_LEAD =
-  /^(?:#{1,6}\s|>|[-*+]\s|\d+[.)]\s|`{3,}|~{3,}|\||<(?:img|video|a)\b|(?:-{3,}|\*{3,}|_{3,})\s*$)/
-
-// Fenced code blocks may legitimately contain blank lines; guard them so the
-// paragraph collapse below never joins lines inside a code sample.
+// Fenced code blocks may legitimately contain consecutive blank lines; guard
+// them so the blank-line normalization below never touches a code sample.
 const FENCE_BLOCK = /(`{3,}|~{3,})[^\n]*\n[\s\S]*?\n\1[ \t]*(?=\n|$)/g
 
-function isPlainParagraph(block) {
-  if (!block || block.includes("\x00MDFENCE")) return false
-  return !NON_PARAGRAPH_LEAD.test(block.split("\n", 1)[0])
-}
-
-// Collapse the blank line between two consecutive plain paragraphs so multi-line
-// rich text serializes as `a\nb` instead of `a\n\nb`. The renderers run with
-// hard breaks (a single `\n` becomes <br>), so the visual line break is
-// preserved while markdown_source stays free of the inserted blank line the user
-// never typed. Headings, lists, quotes, code fences, tables and media keep their
-// standard blank-line separation.
-export function collapseParagraphBreaks(markdown) {
-  // A document made only of blank paragraphs (each now a U+00A0 line) carries no
-  // real content — keep it empty so the empty-state contract (placeholders,
-  // description presence) is unchanged. trim() drops the nbsp too.
+// Normalize the canonical Markdown projection. Enter produces a real paragraph
+// break, so consecutive paragraphs are separated by the standard `\n\n` — no
+// marker characters in the stored source. This pass only:
+//   - returns "" for a blank-only document (placeholder/presence contract),
+//   - collapses runs of 3+ newlines (N consecutive blank paragraphs, which
+//     standard Markdown can't distinguish and renders identically) to one
+//     blank line, so the very first save is already round-trip stable,
+//   - trims trailing whitespace.
+// Blank lines inside fenced code are preserved verbatim.
+export function normalizeMarkdownBlankLines(markdown) {
   if (!String(markdown).trim()) return ""
 
   const fences = []
@@ -233,14 +202,9 @@ export function collapseParagraphBreaks(markdown) {
     return `\x00MDFENCE${fences.length - 1}\x00`
   })
 
-  const blocks = guarded.split("\n\n")
-  let out = blocks.length ? blocks[0] : ""
-  for (let i = 1; i < blocks.length; i++) {
-    const join = isPlainParagraph(blocks[i - 1]) && isPlainParagraph(blocks[i]) ? "\n" : "\n\n"
-    out += join + blocks[i]
-  }
+  const normalized = guarded.replace(/\n{3,}/g, "\n\n").replace(/\s+$/, "")
 
-  return out.replace(/\x00MDFENCE(\d+)\x00/g, (_, n) => fences[Number(n)])
+  return normalized.replace(/\x00MDFENCE(\d+)\x00/g, (_, n) => fences[Number(n)])
 }
 
 // Read the editor state and return canonical Markdown.
@@ -249,5 +213,5 @@ export function lexicalToMarkdown(editor) {
   editor.getEditorState().read(() => {
     markdown = $convertToMarkdownString(MARKDOWN_TRANSFORMERS)
   })
-  return collapseParagraphBreaks(markdown)
+  return normalizeMarkdownBlankLines(markdown)
 }

--- a/engines/collavre/app/javascript/lib/lexical/markdown_serialize.js
+++ b/engines/collavre/app/javascript/lib/lexical/markdown_serialize.js
@@ -231,27 +231,42 @@ setCellTransformers(MARKDOWN_TRANSFORMERS)
 // them so the blank-line normalization below never touches a code sample.
 const FENCE_BLOCK = /(`{3,}|~{3,})[^\n]*\n[\s\S]*?\n\1[ \t]*(?=\n|$)/g
 
+// Inline code spans (`...`) may legitimately contain the literal text `<br>` or
+// a lone NBSP; guard them too so the blank-line normalization never rewrites the
+// span (which would break it on save). Matched after fences are stashed, so the
+// remaining backtick runs are genuine inline code.
+const INLINE_CODE = /(`+)[^\n]*?\1/g
+
 // Normalize the canonical Markdown projection. Enter produces a real paragraph
 // break (standard `\n\n` separation); a blank line the user typed is preserved
 // as a `<br>` marker (see BLANK_PARAGRAPH_TRANSFORMER). This pass only:
 //   - returns "" for a document with no real content (only whitespace and/or
 //     `<br>` markers), keeping the empty-state placeholder/presence contract,
+//   - migrates legacy NBSP-only blank-line markers (pre-`<br>` content) to a
+//     real `<br>` marker so they stop acting as a CommonMark lazy continuation,
+//   - isolates every `<br>` marker as its own block,
 //   - collapses runs of 3+ newlines to one blank line so block separation stays
 //     canonical and the very first save is round-trip stable,
 //   - trims trailing whitespace.
-// Blank lines inside fenced code are preserved verbatim.
+// Blank lines and literal `<br>`/NBSP inside code (fenced or inline) are
+// preserved verbatim.
 export function normalizeMarkdownBlankLines(markdown) {
   // A document of only blank lines (each now a `<br>`) carries no real content,
   // so strip the markers before the emptiness check.
   if (!String(markdown).replace(/<br\s*\/?>/gi, "").trim()) return ""
 
-  const fences = []
-  const guarded = String(markdown).replace(FENCE_BLOCK, (match) => {
-    fences.push(match)
-    return `\x00MDFENCE${fences.length - 1}\x00`
-  })
+  const guards = []
+  const stash = (match) => `\x00MDGUARD${guards.push(match) - 1}\x00`
+  const guarded = String(markdown)
+    .replace(FENCE_BLOCK, stash)
+    .replace(INLINE_CODE, stash)
 
   const normalized = guarded
+    // Legacy blank-line markers stored a line of only NBSP (U+00A0). CommonMark
+    // treats NBSP as content — a lazy list continuation — re-introducing the
+    // list-indent bug, so migrate such lines to a real `<br>` marker on save.
+    // (A regular whitespace-only line is already a CommonMark blank line.)
+    .replace(/^[ \t]*\u00A0[ \t\u00A0]*$/gm, "<br>")
     // Each blank-line marker is its own block: isolate every `<br>` with a blank
     // line on both sides. Lexical's exporter joins a freshly-typed empty
     // paragraph to its neighbours with a single `\n`, while a reopened (grouped)
@@ -262,7 +277,7 @@ export function normalizeMarkdownBlankLines(markdown) {
     .replace(/^\n+/, "")
     .replace(/\s+$/, "")
 
-  return normalized.replace(/\x00MDFENCE(\d+)\x00/g, (_, n) => fences[Number(n)])
+  return normalized.replace(/\x00MDGUARD(\d+)\x00/g, (_, n) => guards[Number(n)])
 }
 
 // On reopen, a run of blank-line markers (<br>) comes back grouped into ONE


### PR DESCRIPTION
## Problem

Pressing Enter on a blank line in the inline editor inserted a non-breaking space (U+00A0) into the canonical Markdown source. The NBSP showed up as a stray \" \" and, when it landed right after a list, CommonMark pulled the NBSP line and the following text into the last `<li>` via lazy continuation, so the blank line inherited the list's indentation.

Two follow-up approaches were evaluated and rejected on real round-trip evidence:
- **Standard-paragraph model** (collapse blanks to `\n\n`): clean source, but *deliberately-typed blank lines disappeared* — N empty lines collapsed to one paragraph break.
- **Revert to NBSP**: brings back both original symptoms.

## Fix

Represent each blank line as a semantic `<br>` marker.

- A `<br>` is **not a stray space** (unlike NBSP) and renders as a visible blank line.
- Each marker sits in **its own block separated by `\n\n`**, so a blank line after a list no longer bleeds into the last `<li>`.
- The **exact blank-line count is preserved** (unlike the standard-paragraph model).

### Implementation
- `BLANK_PARAGRAPH_TRANSFORMER` emits one `<br>` per blank line. A reopened run of blank lines comes back as **one** paragraph holding N `LineBreakNode`s (the importer groups consecutive `<br>` elements); the count rule is `max(1, lineBreaks)` so **blank lines never multiply on re-save**.
- `normalizeMarkdownBlankLines` isolates every `<br>` with a blank line on both sides, making the first save **byte-identical to the reopen fixpoint** regardless of whether the paragraph was freshly typed or grouped.
- Blank paragraphs inside **table cells stay empty** (cells reuse the same transformer set); the empty-state contract treats a `<br>`-only document as empty.

## Verification
- `npm test` → **459/459 pass** (serialization suite updated to the `<br>` contract; new tests for count-preservation, reopen-grouped line breaks, and `<br>`-only emptiness).
- Round-trip idempotency confirmed: 2 blank lines stay 2 across re-imports.
- The reported example renders end-to-end with the list cleanly closed, `XXXXXXX` as its own `<p>`, trailing blanks preserved, and **no stray space**.