### PR TITLE
fix(collavre): focus inline editor when reopening rich-authored Markdown

### DIFF
--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -411,7 +411,12 @@ export function initializeCreativeRowEditor() {
       const effectiveParent = parentInput.value;
       if (unconvertBtn) unconvertBtn.style.display = effectiveParent ? '' : 'none';
       originalProgress = normalizedProgress;
-      if (!isMarkdown) {
+      // Focus the Lexical editor whenever it is the active surface. Gating on
+      // `!isMarkdown` was correct when `content_type === 'markdown'` always meant
+      // the textarea surface, but rich-authored Markdown now reopens in Lexical
+      // (markdown_editor === 'rich'), so use `!useTextarea` to also focus it.
+      // The textarea surface focuses itself in activateMarkdownMode().
+      if (!useTextarea) {
         lexicalEditor.focus();
       }
       updateActionButtonStates();


### PR DESCRIPTION
## Problem

Clicking the edit (수정) button on a Creative mounts the inline Lexical editor, but for **rich-authored Markdown** creatives the editor was not focused — the caret never landed inside it, so the user could not start typing immediately.

## Root cause

In `creative_row_editor.js`, the focus call was gated on `!isMarkdown`:

```js
if (!isMarkdown) {
  lexicalEditor.focus();
}
```

That guard was added in #1169, when `content_type === 'markdown'` always meant the **textarea** surface (so skipping the hidden Lexical editor was correct — the textarea focuses itself).

After the Markdown-canonical transition (#1313), rich-authored Markdown (`content_type === 'markdown'` **and** `markdown_editor === 'rich'`) now reopens in the **Lexical** editor while still reporting `content_type === 'markdown'`. The `!isMarkdown` guard therefore skipped focus for exactly the default editing path.

| content_type | markdown_editor | active surface | old `!isMarkdown` | result |
|---|---|---|---|---|
| html | – | Lexical | focus ✓ | ok |
| markdown | rich | Lexical | **skip ✗** | **bug** |
| markdown | source | textarea | skip (Lexical hidden) | ok (textarea self-focuses) |

## Fix

Gate on `!useTextarea` instead, so the Lexical editor is focused whenever it is the active surface. The textarea surface continues to focus itself in `activateMarkdownMode()`.

Cursor-at-last-line is already handled: Lexical's `editor.focus()` defaults to `root.selectEnd()` when there is no prior selection (verified in lexical 0.38).

## Verification

Headless browser repro on a running preview (rich-markdown creative + HTML creative):

- **Before** (old guard): editor mounts (`editor_ready: true`) but `document.activeElement` stays on `body`, `ce_focused: false`.
- **After**: `document.activeElement` is the `lexical-content-editable` div, `ce_focused: true`, and the caret sits at the end of the last line (`anchorOffset === lastTextLen`, `atEndOfLast: true`).
- HTML creatives still focus (regression check passes).
- Full JS suite: 466 passed / 40 suites.