### PR TITLE
feat: add `rake clean` to reset local dev artifacts

### DIFF
--- a/lib/tasks/clean.rake
+++ b/lib/tasks/clean.rake
@@ -11,7 +11,10 @@
 # gitignored, regenerable output, so this is always safe in development.
 desc "Reset local dev artifacts: clobber public/assets (Propshaft manifest included), clear tmp and log"
 task clean: :environment do
-  if Rails.env.production?
+  # Whitelist safe envs, not just `unless production?`: the `desktop` env
+  # inherits production.rb and ships real precompiled assets, so clobbering
+  # public/assets there would be destructive too.
+  unless Rails.env.development? || Rails.env.test?
     abort "rake clean is development-only; refusing to run in #{Rails.env}"
   end
 

--- a/lib/tasks/clean.rake
+++ b/lib/tasks/clean.rake
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# `rake clean` (a.k.a. `bin/rails clean`)
+#
+# One command to reset regenerable local development artifacts. Its main job
+# is clobbering public/assets: a stray `assets:precompile` in development
+# leaves a public/assets/.manifest.json, and Propshaft switches to its Static
+# resolver whenever that file exists — even in development — so newly added
+# engine assets (e.g. collavre_plan/timeline.css) raise MissingAssetError
+# until the manifest is gone. tmp/ and log/ are cleared too. Every target is
+# gitignored, regenerable output, so this is always safe in development.
+desc "Reset local dev artifacts: clobber public/assets (Propshaft manifest included), clear tmp and log"
+task clean: :environment do
+  if Rails.env.production?
+    abort "rake clean is development-only; refusing to run in #{Rails.env}"
+  end
+
+  %w[assets:clobber tmp:clear log:clear].each { |name| Rake::Task[name].invoke }
+  puts "✓ cleaned: public/assets (Propshaft manifest included), tmp, log"
+end

--- a/test/lib/clean_task_test.rb
+++ b/test/lib/clean_task_test.rb
@@ -6,8 +6,8 @@ require "rake"
 # `rake clean` is a development convenience that resets regenerable local
 # artifacts (most importantly clobbering public/assets so a stale Propshaft
 # .manifest.json can't force the Static resolver into MissingAssetError).
-# It must refuse to run in production, where public/assets is the real
-# precompiled output.
+# It must refuse to run outside development/test (production AND desktop, which
+# inherits production.rb), where public/assets is the real precompiled output.
 class CleanTaskTest < ActiveSupport::TestCase
   setup do
     Rails.application.load_tasks unless Rake::Task.task_defined?("clean")
@@ -18,9 +18,14 @@ class CleanTaskTest < ActiveSupport::TestCase
     assert Rake::Task.task_defined?("clean")
   end
 
-  test "refuses to run in production" do
-    Rails.stub(:env, ActiveSupport::StringInquirer.new("production")) do
-      assert_raises(SystemExit) { Rake::Task["clean"].invoke }
+  # desktop inherits production.rb and ships real precompiled assets, so the
+  # guard whitelists dev/test rather than only blocking production.
+  test "refuses to run outside development/test (production, desktop)" do
+    %w[production desktop].each do |env|
+      Rake::Task["clean"].reenable
+      Rails.stub(:env, ActiveSupport::StringInquirer.new(env)) do
+        assert_raises(SystemExit, "expected clean to abort in #{env}") { Rake::Task["clean"].invoke }
+      end
     end
   end
 

--- a/test/lib/clean_task_test.rb
+++ b/test/lib/clean_task_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "rake"
+
+# `rake clean` is a development convenience that resets regenerable local
+# artifacts (most importantly clobbering public/assets so a stale Propshaft
+# .manifest.json can't force the Static resolver into MissingAssetError).
+# It must refuse to run in production, where public/assets is the real
+# precompiled output.
+class CleanTaskTest < ActiveSupport::TestCase
+  setup do
+    Rails.application.load_tasks unless Rake::Task.task_defined?("clean")
+    Rake::Task["clean"].reenable
+  end
+
+  test "clean task is defined" do
+    assert Rake::Task.task_defined?("clean")
+  end
+
+  test "refuses to run in production" do
+    Rails.stub(:env, ActiveSupport::StringInquirer.new("production")) do
+      assert_raises(SystemExit) { Rake::Task["clean"].invoke }
+    end
+  end
+
+  test "in development invokes assets:clobber, tmp:clear and log:clear in order" do
+    invoked = []
+    clobber = Rake::Task["assets:clobber"]
+    tmp = Rake::Task["tmp:clear"]
+    log = Rake::Task["log:clear"]
+
+    clobber.stub(:invoke, ->(*) { invoked << "assets:clobber" }) do
+      tmp.stub(:invoke, ->(*) { invoked << "tmp:clear" }) do
+        log.stub(:invoke, ->(*) { invoked << "log:clear" }) do
+          Rails.stub(:env, ActiveSupport::StringInquirer.new("development")) do
+            Rake::Task["clean"].invoke
+          end
+        end
+      end
+    end
+
+    assert_equal %w[assets:clobber tmp:clear log:clear], invoked
+  end
+end


### PR DESCRIPTION
## What

Adds a development-only `rake clean` (`bin/rails clean`) that resets regenerable local artifacts in one command:

- `assets:clobber` — removes `public/assets` (including the Propshaft `.manifest.json`)
- `tmp:clear`
- `log:clear`

Aborts in production, where `public/assets` is the real precompiled output.

## Why

A stray `assets:precompile` run in development leaves a `public/assets/.manifest.json`. Propshaft switches to its **Static resolver** whenever that file exists — even in development — and resolves assets from the stale manifest instead of the live filesystem. Any engine asset added after the manifest was generated (e.g. `collavre_plan/timeline.css`) then raises `Propshaft::MissingAssetError`, but only on machines that happen to have the leftover manifest (`public/assets` is gitignored, so it doesn't propagate). This made the bug appear machine-specific and hard to diagnose.

Existing tasks don't cover this: `assets:clean` only prunes old digest copies and leaves `.manifest.json` in place; there was no top-level `clean`. `rake clean` gives one memorable command to drop back to a clean dev state.

## Test plan

- New `test/lib/clean_task_test.rb`: task is defined, aborts in production, and invokes `assets:clobber` / `tmp:clear` / `log:clear` in order.
- Manual: created a stale `public/assets/.manifest.json`, ran `bin/rails clean`, confirmed the directory (manifest included) is removed.
- Full pre-push suite green; rubocop clean.