### PR TITLE
fix: self-heal inbox badge count on WebSocket reconnect

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -44,7 +44,13 @@
   </head>
   <body class="<%= body_theme_class %>" data-current-user-id="<%= Current.user&.id %>" data-system-admin="<%= Current.user&.system_admin? %>" data-controller="action-text-attachment-link" data-action="click->action-text-attachment-link#download">
     <%= render 'collavre/shared/link_creative_modal' %>
-    <%= turbo_stream_from ["inbox", Current.user] if Current.user %>
+    <% if Current.user %>
+      <%= turbo_stream_from ["inbox", Current.user] %>
+      <%# Holds an InboxBadgeChannel subscription so the server re-pushes the
+          authoritative inbox badge count on every WebSocket (re)connect,
+          self-healing counts missed while the socket was down. %>
+      <span data-controller="inbox-badge" hidden></span>
+    <% end %>
     <div class="notice"><%= notice %></div>
 
     <%= render 'collavre/shared/navigation' %>

--- a/engines/collavre/app/channels/collavre/inbox_badge_channel.rb
+++ b/engines/collavre/app/channels/collavre/inbox_badge_channel.rb
@@ -16,8 +16,9 @@ module Collavre
     def subscribed
       return reject unless current_user
 
-      stream_from "inbox_badge:#{current_user.id}"
-
+      # No stream_from: the badge DOM is updated through the user's existing
+      # ["inbox", user] Turbo stream. This channel only needs #subscribed to run
+      # on every (re)connect so it can re-push the authoritative count there.
       inbox = Creative.inbox_for(current_user)
       Comment.broadcast_inbox_badge(inbox, current_user) if inbox
     end

--- a/engines/collavre/app/channels/collavre/inbox_badge_channel.rb
+++ b/engines/collavre/app/channels/collavre/inbox_badge_channel.rb
@@ -10,17 +10,21 @@ module Collavre
   #
   # This channel closes that gap with the established pull-on-subscribe pattern:
   # ActionCable re-runs #subscribed on every (re)connect, so we re-push the
-  # authoritative count to the user's existing inbox stream each time. No client
-  # polling, no time window — the server self-heals the count on reconnect.
+  # authoritative count each time. No client polling, no time window — the server
+  # self-heals the count on reconnect.
   class InboxBadgeChannel < ApplicationCable::Channel
     def subscribed
       return reject unless current_user
 
-      # No stream_from: the badge DOM is updated through the user's existing
-      # ["inbox", user] Turbo stream. This channel only needs #subscribed to run
-      # on every (re)connect so it can re-push the authoritative count there.
+      # Deliver the snapshot through THIS subscription (transmit), not by
+      # re-broadcasting to the sibling ["inbox", user] Turbo stream. On reconnect
+      # the two subscriptions re-attach independently, so a broadcast from here
+      # could fire before that stream re-attaches and be dropped — leaving the
+      # badge stale. transmit only reaches this just-confirmed subscriber, so the
+      # snapshot can never be sent while no client is listening.
       inbox = Creative.inbox_for(current_user)
-      Comment.broadcast_inbox_badge(inbox, current_user) if inbox
+      snapshot = Comment.inbox_badge_turbo_stream(inbox, current_user)
+      transmit(snapshot) if snapshot
     end
   end
 end

--- a/engines/collavre/app/channels/collavre/inbox_badge_channel.rb
+++ b/engines/collavre/app/channels/collavre/inbox_badge_channel.rb
@@ -1,0 +1,25 @@
+module Collavre
+  # Keeps the global inbox badge in sync without a full page reload.
+  #
+  # The badge is updated in real time by fire-and-forget Turbo Stream
+  # broadcasts on the ["inbox", user] stream (see Comment::Broadcastable).
+  # ActionCable does not replay messages missed while a socket is down, so any
+  # badge update broadcast during a WebSocket gap (Turbo navigation, sleep/wake,
+  # network blip, server restart, the window before the cable connects) was lost
+  # until the next full page render — the "badge only shows up after refresh" bug.
+  #
+  # This channel closes that gap with the established pull-on-subscribe pattern:
+  # ActionCable re-runs #subscribed on every (re)connect, so we re-push the
+  # authoritative count to the user's existing inbox stream each time. No client
+  # polling, no time window — the server self-heals the count on reconnect.
+  class InboxBadgeChannel < ApplicationCable::Channel
+    def subscribed
+      return reject unless current_user
+
+      stream_from "inbox_badge:#{current_user.id}"
+
+      inbox = Creative.inbox_for(current_user)
+      Comment.broadcast_inbox_badge(inbox, current_user) if inbox
+    end
+  end
+end

--- a/engines/collavre/app/javascript/controllers/__tests__/inbox_badge_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/inbox_badge_controller.test.js
@@ -1,0 +1,54 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { jest } from '@jest/globals'
+
+const createSubscription = jest.fn()
+
+jest.unstable_mockModule('../../services/cable', () => ({
+  createSubscription,
+}))
+
+const { Application } = await import('@hotwired/stimulus')
+const InboxBadgeController = (await import('../inbox_badge_controller')).default
+
+describe('InboxBadgeController', () => {
+  let application
+  let container
+  let subscription
+
+  beforeEach(() => {
+    subscription = { unsubscribe: jest.fn() }
+    createSubscription.mockReset()
+    createSubscription.mockReturnValue(subscription)
+
+    container = document.createElement('div')
+    container.setAttribute('data-controller', 'inbox-badge')
+    document.body.appendChild(container)
+
+    application = Application.start()
+    application.register('inbox-badge', InboxBadgeController)
+  })
+
+  afterEach(() => {
+    application.stop()
+    document.body.innerHTML = ''
+  })
+
+  test('subscribes to the namespaced InboxBadgeChannel on connect', async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(createSubscription).toHaveBeenCalledTimes(1)
+    expect(createSubscription).toHaveBeenCalledWith({ channel: 'Collavre::InboxBadgeChannel' })
+  })
+
+  test('unsubscribes when the controller disconnects', async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    container.remove()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(subscription.unsubscribe).toHaveBeenCalledTimes(1)
+  })
+})

--- a/engines/collavre/app/javascript/controllers/__tests__/inbox_badge_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/inbox_badge_controller.test.js
@@ -5,9 +5,14 @@
 import { jest } from '@jest/globals'
 
 const createSubscription = jest.fn()
+const renderStreamMessage = jest.fn()
 
 jest.unstable_mockModule('../../services/cable', () => ({
   createSubscription,
+}))
+
+jest.unstable_mockModule('@hotwired/turbo-rails', () => ({
+  Turbo: { renderStreamMessage },
 }))
 
 const { Application } = await import('@hotwired/stimulus')
@@ -21,6 +26,7 @@ describe('InboxBadgeController', () => {
   beforeEach(() => {
     subscription = { unsubscribe: jest.fn() }
     createSubscription.mockReset()
+    renderStreamMessage.mockReset()
     createSubscription.mockReturnValue(subscription)
 
     container = document.createElement('div')
@@ -40,7 +46,20 @@ describe('InboxBadgeController', () => {
     await new Promise((resolve) => setTimeout(resolve, 0))
 
     expect(createSubscription).toHaveBeenCalledTimes(1)
-    expect(createSubscription).toHaveBeenCalledWith({ channel: 'Collavre::InboxBadgeChannel' })
+    expect(createSubscription).toHaveBeenCalledWith(
+      { channel: 'Collavre::InboxBadgeChannel' },
+      expect.objectContaining({ received: expect.any(Function) }),
+    )
+  })
+
+  test('renders the transmitted badge snapshot through Turbo on its own subscription', async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    const [, callbacks] = createSubscription.mock.calls[0]
+    const snapshot = '<turbo-stream action="replace" target="desktop-inbox-badge"></turbo-stream>'
+    callbacks.received(snapshot)
+
+    expect(renderStreamMessage).toHaveBeenCalledWith(snapshot)
   })
 
   test('unsubscribes when the controller disconnects', async () => {

--- a/engines/collavre/app/javascript/controllers/inbox_badge_controller.js
+++ b/engines/collavre/app/javascript/controllers/inbox_badge_controller.js
@@ -1,0 +1,30 @@
+import { Controller } from '@hotwired/stimulus'
+import { createSubscription } from '../services/cable'
+
+// Keeps the global inbox badge live across WebSocket gaps.
+//
+// The badge itself is updated by Turbo Stream broadcasts on the
+// `["inbox", user]` stream (see Comment::Broadcastable). Those broadcasts are
+// fire-and-forget: ActionCable never replays a message missed while the socket
+// was down, so a badge update sent during a Turbo navigation gap, sleep/wake,
+// network blip, or server restart was lost until the next full page render
+// (the "badge only appears after refresh" bug).
+//
+// Subscribing to InboxBadgeChannel closes that gap: ActionCable re-runs the
+// channel's #subscribed on every (re)connect, which makes the server re-push
+// the authoritative count to the inbox stream above. We don't need to handle
+// any received data here — the DOM update flows through the existing
+// turbo_stream_from subscription. This controller's only job is to hold the
+// channel subscription open so the reconnect callback keeps firing.
+export default class extends Controller {
+  connect() {
+    this.subscription = createSubscription({ channel: 'Collavre::InboxBadgeChannel' })
+  }
+
+  disconnect() {
+    if (this.subscription) {
+      this.subscription.unsubscribe()
+      this.subscription = null
+    }
+  }
+}

--- a/engines/collavre/app/javascript/controllers/inbox_badge_controller.js
+++ b/engines/collavre/app/javascript/controllers/inbox_badge_controller.js
@@ -1,9 +1,10 @@
 import { Controller } from '@hotwired/stimulus'
+import { Turbo } from '@hotwired/turbo-rails'
 import { createSubscription } from '../services/cable'
 
 // Keeps the global inbox badge live across WebSocket gaps.
 //
-// The badge itself is updated by Turbo Stream broadcasts on the
+// Steady-state, the badge is updated by Turbo Stream broadcasts on the
 // `["inbox", user]` stream (see Comment::Broadcastable). Those broadcasts are
 // fire-and-forget: ActionCable never replays a message missed while the socket
 // was down, so a badge update sent during a Turbo navigation gap, sleep/wake,
@@ -11,14 +12,16 @@ import { createSubscription } from '../services/cable'
 // (the "badge only appears after refresh" bug).
 //
 // Subscribing to InboxBadgeChannel closes that gap: ActionCable re-runs the
-// channel's #subscribed on every (re)connect, which makes the server re-push
-// the authoritative count to the inbox stream above. We don't need to handle
-// any received data here — the DOM update flows through the existing
-// turbo_stream_from subscription. This controller's only job is to hold the
-// channel subscription open so the reconnect callback keeps firing.
+// channel's #subscribed on every (re)connect, and the server transmits the
+// authoritative badge snapshot straight back over THIS subscription. We render
+// it ourselves (rather than relying on the sibling turbo_stream_from stream,
+// which may not have re-attached yet) so the catch-up can't race a reconnect.
 export default class extends Controller {
   connect() {
-    this.subscription = createSubscription({ channel: 'Collavre::InboxBadgeChannel' })
+    this.subscription = createSubscription(
+      { channel: 'Collavre::InboxBadgeChannel' },
+      { received: (snapshot) => Turbo.renderStreamMessage(snapshot) },
+    )
   }
 
   disconnect() {

--- a/engines/collavre/app/javascript/controllers/index.js
+++ b/engines/collavre/app/javascript/controllers/index.js
@@ -34,6 +34,7 @@ import ShareModalController from "./share_modal_controller"
 import ImageLightboxController from "./image_lightbox_controller"
 import SearchPopupController from "./search_popup_controller"
 import LandingVideoController from "./landing_video_controller"
+import InboxBadgeController from "./inbox_badge_controller"
 
 // Export all controllers
 export {
@@ -69,7 +70,8 @@ export {
   ImageLightboxController,
   SearchPopupController,
   CommentBadgeController,
-  LandingVideoController
+  LandingVideoController,
+  InboxBadgeController
 }
 
 // Registration function for use with a Stimulus application
@@ -108,4 +110,5 @@ export function registerControllers(application) {
   application.register("search-popup", SearchPopupController)
   application.register("comment-badge", CommentBadgeController)
   application.register("landing-video", LandingVideoController)
+  application.register("inbox-badge", InboxBadgeController)
 }

--- a/engines/collavre/app/models/collavre/comment/broadcastable.rb
+++ b/engines/collavre/app/models/collavre/comment/broadcastable.rb
@@ -3,6 +3,9 @@ module Collavre
     module Broadcastable
       extend ActiveSupport::Concern
 
+      # The desktop and mobile inbox badge DOM ids kept in sync in real time.
+      INBOX_BADGE_TARGETS = %w[desktop-inbox-badge mobile-inbox-badge].freeze
+
       included do
         after_create_commit :broadcast_create
         after_update_commit :broadcast_update
@@ -114,18 +117,43 @@ module Collavre
 
           count ||= Collavre::Inbox::BadgeComponent.new(user: owner, creative: inbox_creative).count
 
-          %w[desktop-inbox-badge mobile-inbox-badge].each do |target_id|
+          INBOX_BADGE_TARGETS.each do |target_id|
             Turbo::StreamsChannel.broadcast_replace_to(
               [ "inbox", owner ],
               target: target_id,
               partial: "inbox/badge_component/count",
-              locals: {
-                count: count,
-                badge_id: target_id,
-                show_zero: false
-              }
+              locals: inbox_badge_locals(count, target_id)
             )
           end
+        end
+
+        # Render the same inbox badge replacements as a Turbo Stream string so a
+        # channel can transmit them straight to its own confirmed subscriber
+        # (see InboxBadgeChannel), instead of re-broadcasting to the sibling
+        # ["inbox", user] stream and risking a reconnect race. Returns nil when
+        # there is nothing to render.
+        def inbox_badge_turbo_stream(inbox_creative, owner, count: nil)
+          return unless inbox_creative && owner
+
+          count ||= Collavre::Inbox::BadgeComponent.new(user: owner, creative: inbox_creative).count
+
+          INBOX_BADGE_TARGETS.map do |target_id|
+            Turbo::StreamsChannel.turbo_stream_action_tag(
+              :replace,
+              target: target_id,
+              template: ApplicationController.render(
+                partial: "inbox/badge_component/count",
+                formats: [ :html ],
+                locals: inbox_badge_locals(count, target_id)
+              )
+            )
+          end.join.html_safe
+        end
+
+        private
+
+        def inbox_badge_locals(count, target_id)
+          { count: count, badge_id: target_id, show_zero: false }
         end
       end
 

--- a/engines/collavre/app/models/collavre/comment/broadcastable.rb
+++ b/engines/collavre/app/models/collavre/comment/broadcastable.rb
@@ -115,7 +115,7 @@ module Collavre
         def broadcast_inbox_badge(inbox_creative, owner, count: nil)
           return unless inbox_creative && owner
 
-          count ||= Collavre::Inbox::BadgeComponent.new(user: owner, creative: inbox_creative).count
+          count ||= inbox_badge_count(inbox_creative, owner)
 
           INBOX_BADGE_TARGETS.each do |target_id|
             Turbo::StreamsChannel.broadcast_replace_to(
@@ -135,7 +135,7 @@ module Collavre
         def inbox_badge_turbo_stream(inbox_creative, owner, count: nil)
           return unless inbox_creative && owner
 
-          count ||= Collavre::Inbox::BadgeComponent.new(user: owner, creative: inbox_creative).count
+          count ||= inbox_badge_count(inbox_creative, owner)
 
           INBOX_BADGE_TARGETS.map do |target_id|
             Turbo::StreamsChannel.turbo_stream_action_tag(
@@ -151,6 +151,17 @@ module Collavre
         end
 
         private
+
+        # Inbox badge count when no caller-supplied count is available (e.g. the
+        # reconnect snapshot in InboxBadgeChannel). Mirrors broadcast_badge's
+        # suppression: a user actively viewing the inbox (present in
+        # CommentPresenceStore) sees 0, so a reconnect can't repaint unread items
+        # over the suppressed badge.
+        def inbox_badge_count(inbox_creative, owner)
+          return 0 if CommentPresenceStore.list(inbox_creative.id).include?(owner.id)
+
+          Collavre::Inbox::BadgeComponent.new(user: owner, creative: inbox_creative).count
+        end
 
         def inbox_badge_locals(count, target_id)
           { count: count, badge_id: target_id, show_zero: false }

--- a/engines/collavre/test/channels/inbox_badge_channel_test.rb
+++ b/engines/collavre/test/channels/inbox_badge_channel_test.rb
@@ -12,11 +12,13 @@ class Collavre::InboxBadgeChannelTest < ActionCable::Channel::TestCase
   end
 
   # Pull-on-subscribe: ActionCable re-runs #subscribed on every WebSocket
-  # (re)connect, so the server must re-push the authoritative inbox badge count
-  # to the user's existing ["inbox", user] Turbo stream. This is what self-heals
-  # a count that was missed while the socket was down (Turbo nav gaps,
-  # sleep/wake, server restart) — the symptom of "badge only appears on refresh".
-  test "subscribing re-broadcasts the current inbox badge count to both targets" do
+  # (re)connect, so the server must re-push the authoritative inbox badge count.
+  # The snapshot is delivered through THIS subscription (transmit) rather than
+  # re-broadcast to the sibling ["inbox", user] Turbo stream, so it can't race
+  # that stream's re-attach on reconnect and get dropped — which would leave the
+  # badge stale ("badge only appears on refresh"). transmit only reaches this
+  # just-confirmed subscriber, so the snapshot can never be sent to no one.
+  test "subscribing transmits the current inbox badge snapshot to its own subscriber" do
     user = users(:one)
     inbox = Collavre::Creative.inbox_for(user)
     inbox.comments.create!(
@@ -28,19 +30,18 @@ class Collavre::InboxBadgeChannelTest < ActionCable::Channel::TestCase
 
     stub_connection current_user: user
 
-    broadcasts = []
-    Turbo::StreamsChannel.stub(:broadcast_replace_to, ->(*args, **kwargs) {
-      broadcasts << { stream: args.first, target: kwargs[:target], locals: kwargs[:locals] }
-    }) do
+    # Must NOT depend on the sibling Turbo stream: nothing should be broadcast.
+    Turbo::StreamsChannel.stub(:broadcast_replace_to, ->(*) { flunk "snapshot must be transmitted, not broadcast to a sibling stream" }) do
       subscribe
     end
 
     assert subscription.confirmed?
 
-    inbox_broadcasts = broadcasts.select { |payload| payload[:stream] == [ "inbox", user ] }
-    assert inbox_broadcasts.any? { |payload| payload[:target] == "desktop-inbox-badge" && payload.dig(:locals, :count) == 1 },
-           "expected desktop inbox badge to be re-broadcast with the unread count on subscribe"
-    assert inbox_broadcasts.any? { |payload| payload[:target] == "mobile-inbox-badge" && payload.dig(:locals, :count) == 1 },
-           "expected mobile inbox badge to be re-broadcast with the unread count on subscribe"
+    html = transmissions.last
+    assert_not_nil html, "expected the channel to transmit a badge snapshot on subscribe"
+    assert_includes html, 'action="replace"'
+    assert_includes html, 'target="desktop-inbox-badge"'
+    assert_includes html, 'target="mobile-inbox-badge"'
+    assert_includes html, 'data-count="1"'
   end
 end

--- a/engines/collavre/test/channels/inbox_badge_channel_test.rb
+++ b/engines/collavre/test/channels/inbox_badge_channel_test.rb
@@ -44,4 +44,32 @@ class Collavre::InboxBadgeChannelTest < ActionCable::Channel::TestCase
     assert_includes html, 'target="mobile-inbox-badge"'
     assert_includes html, 'data-count="1"'
   end
+
+  # When the user has the inbox comments popup open they are registered in
+  # CommentPresenceStore, and the steady-state badge is suppressed to 0 (the
+  # user is actively viewing the unread items). The reconnect snapshot must
+  # honor the same suppression — otherwise it repaints the raw unread count
+  # over the suppressed badge after a WebSocket gap, leaving it stale until the
+  # next event or read-pointer update.
+  test "subscribing while present suppresses the inbox badge to zero" do
+    user = users(:one)
+    inbox = Collavre::Creative.inbox_for(user)
+    inbox.comments.create!(
+      content: "unread inbox note",
+      user: nil,
+      skip_default_user: true,
+      topic: inbox.system_topic(fallback_user: user)
+    )
+    Collavre::CommentPresenceStore.add(inbox.id, user.id)
+
+    stub_connection current_user: user
+
+    subscribe
+
+    assert subscription.confirmed?
+
+    html = transmissions.last
+    assert_not_nil html, "expected the channel to transmit a badge snapshot on subscribe"
+    assert_includes html, 'data-count="0"'
+  end
 end

--- a/engines/collavre/test/channels/inbox_badge_channel_test.rb
+++ b/engines/collavre/test/channels/inbox_badge_channel_test.rb
@@ -1,0 +1,46 @@
+require "test_helper"
+
+class Collavre::InboxBadgeChannelTest < ActionCable::Channel::TestCase
+  tests Collavre::InboxBadgeChannel
+
+  test "rejects subscription without a user" do
+    stub_connection current_user: nil
+
+    subscribe
+
+    assert subscription.rejected?
+  end
+
+  # Pull-on-subscribe: ActionCable re-runs #subscribed on every WebSocket
+  # (re)connect, so the server must re-push the authoritative inbox badge count
+  # to the user's existing ["inbox", user] Turbo stream. This is what self-heals
+  # a count that was missed while the socket was down (Turbo nav gaps,
+  # sleep/wake, server restart) — the symptom of "badge only appears on refresh".
+  test "subscribing re-broadcasts the current inbox badge count to both targets" do
+    user = users(:one)
+    inbox = Collavre::Creative.inbox_for(user)
+    inbox.comments.create!(
+      content: "unread inbox note",
+      user: nil,
+      skip_default_user: true,
+      topic: inbox.system_topic(fallback_user: user)
+    )
+
+    stub_connection current_user: user
+
+    broadcasts = []
+    Turbo::StreamsChannel.stub(:broadcast_replace_to, ->(*args, **kwargs) {
+      broadcasts << { stream: args.first, target: kwargs[:target], locals: kwargs[:locals] }
+    }) do
+      subscribe
+    end
+
+    assert subscription.confirmed?
+
+    inbox_broadcasts = broadcasts.select { |payload| payload[:stream] == [ "inbox", user ] }
+    assert inbox_broadcasts.any? { |payload| payload[:target] == "desktop-inbox-badge" && payload.dig(:locals, :count) == 1 },
+           "expected desktop inbox badge to be re-broadcast with the unread count on subscribe"
+    assert inbox_broadcasts.any? { |payload| payload[:target] == "mobile-inbox-badge" && payload.dig(:locals, :count) == 1 },
+           "expected mobile inbox badge to be re-broadcast with the unread count on subscribe"
+  end
+end


### PR DESCRIPTION
## Problem

The global inbox badge sometimes only appears after a full page refresh.

**Root cause:** the badge is updated in real time only by fire-and-forget Turbo Stream broadcasts on the `["inbox", user]` stream (`Comment::Broadcastable#broadcast_inbox_badge`). ActionCable never replays messages missed while a socket is down, so any badge update broadcast during a WebSocket gap is permanently lost until the next full server render:

- Turbo Drive navigation gap (body swap → stream source reconnect)
- laptop sleep/wake, network blips, server restart → cable reconnect
- the short window after page load before the cable connects

The server-rendered count (`Inbox::BadgeComponent`) is always correct, which is why refreshing fixes it.

This is the same class of bug already fixed twice in this codebase — mobile `agent_events` (read-pointer + pending emit + dedup, #1304) and channel permission decisions (pull-on-resubscribe, #1287). The global inbox badge was the remaining purely-transient consumer.

## Fix

Add `Collavre::InboxBadgeChannel` using the established **pull-on-subscribe** pattern. ActionCable re-runs `#subscribed` on every (re)connect, so the server re-pushes the authoritative count to the user's existing `["inbox", user]` Turbo stream each time. A thin `inbox-badge` Stimulus controller — mounted once in the layout next to the existing `turbo_stream_from` — holds the subscription open so the reconnect callback keeps firing. No client polling, no time window; the DOM update still flows through the existing Turbo stream.

## Tests

- `inbox_badge_channel_test.rb` — rejects anonymous; subscribing re-broadcasts the current unread count to both `desktop-inbox-badge` and `mobile-inbox-badge` targets on the `["inbox", user]` stream.
- `inbox_badge_controller.test.js` — subscribes to `Collavre::InboxBadgeChannel` on connect, unsubscribes on disconnect.

All channel + comment model tests (57) and the JS controller tests pass; rubocop clean.