### PR TITLE
fix: let editable fields keep Ctrl+K instead of opening search popup

### DIFF
--- a/engines/collavre/app/javascript/controllers/__tests__/search_popup_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/search_popup_controller.test.js
@@ -1,0 +1,104 @@
+/**
+ * @jest-environment jsdom
+ */
+import { jest } from '@jest/globals'
+import { Application } from '@hotwired/stimulus'
+
+const { default: SearchPopupController } = await import('../search_popup_controller')
+
+describe('SearchPopupController Ctrl+K shortcut', () => {
+  let application
+  let container
+  let popup
+
+  function pressCtrlK(target) {
+    const event = new KeyboardEvent('keydown', {
+      key: 'k',
+      ctrlKey: true,
+      bubbles: true,
+      cancelable: true
+    })
+    target.dispatchEvent(event)
+    return event
+  }
+
+  beforeEach(async () => {
+    document.body.innerHTML = ''
+
+    container = document.createElement('div')
+    container.innerHTML = `
+      <div data-controller="search-popup">
+        <input type="text" data-search-popup-target="input" />
+        <div data-search-popup-target="popup"></div>
+      </div>
+    `
+    document.body.appendChild(container)
+
+    application = Application.start()
+    application.register('search-popup', SearchPopupController)
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    popup = container.querySelector('[data-search-popup-target="popup"]')
+  })
+
+  afterEach(() => {
+    application?.stop()
+    document.body.innerHTML = ''
+    jest.restoreAllMocks()
+  })
+
+  test('opens the popup on Ctrl+K when focus is not in an editable element', () => {
+    const event = pressCtrlK(document.body)
+
+    expect(popup.classList.contains('open')).toBe(true)
+    expect(event.defaultPrevented).toBe(true)
+  })
+
+  test('does not open the popup when Ctrl+K is pressed inside a text input', () => {
+    const input = document.createElement('input')
+    input.type = 'text'
+    document.body.appendChild(input)
+    input.focus()
+
+    const event = pressCtrlK(input)
+
+    expect(popup.classList.contains('open')).toBe(false)
+    expect(event.defaultPrevented).toBe(false)
+  })
+
+  test('does not open the popup when Ctrl+K is pressed inside a textarea', () => {
+    const textarea = document.createElement('textarea')
+    document.body.appendChild(textarea)
+    textarea.focus()
+
+    const event = pressCtrlK(textarea)
+
+    expect(popup.classList.contains('open')).toBe(false)
+    expect(event.defaultPrevented).toBe(false)
+  })
+
+  test('does not open the popup when Ctrl+K is pressed inside a contenteditable element', () => {
+    const editable = document.createElement('div')
+    editable.setAttribute('contenteditable', 'true')
+    document.body.appendChild(editable)
+    editable.focus()
+
+    const event = pressCtrlK(editable)
+
+    expect(popup.classList.contains('open')).toBe(false)
+    expect(event.defaultPrevented).toBe(false)
+  })
+
+  test('does not open the popup when Ctrl+K is pressed inside the inline Lexical editor', () => {
+    const lexicalRoot = document.createElement('div')
+    lexicalRoot.setAttribute('data-lexical-editor-root', '')
+    const inner = document.createElement('p')
+    lexicalRoot.appendChild(inner)
+    document.body.appendChild(lexicalRoot)
+
+    const event = pressCtrlK(inner)
+
+    expect(popup.classList.contains('open')).toBe(false)
+    expect(event.defaultPrevented).toBe(false)
+  })
+})

--- a/engines/collavre/app/javascript/controllers/search_popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/search_popup_controller.js
@@ -9,14 +9,30 @@ export default class extends Controller {
     }
     document.addEventListener('keydown', this._escHandler)
 
-    // Global keyboard shortcut: Cmd/Ctrl + K to open search
+    // Global keyboard shortcut: Cmd/Ctrl + K to open search.
+    // Skip when focus is inside an editable element (input, textarea,
+    // contenteditable, or the inline Lexical editor) so that element's own
+    // Ctrl+K behavior (e.g. delete-to-end-of-line) takes precedence over the
+    // global search popup.
     this._shortcutHandler = (e) => {
       if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+        if (this._isEditableTarget(e.target)) return
         e.preventDefault()
         this.toggle()
       }
     }
     document.addEventListener('keydown', this._shortcutHandler)
+  }
+
+  _isEditableTarget(target) {
+    const el = target instanceof Element ? target : document.activeElement
+    if (!el || typeof el.closest !== 'function') return false
+    const tag = el.tagName
+    if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true
+    if (el.isContentEditable) return true
+    return Boolean(
+      el.closest('[contenteditable]:not([contenteditable="false"]), [data-lexical-editor-root]')
+    )
   }
 
   disconnect() {


### PR DESCRIPTION
## Problem

Pressing **Ctrl+K** while focused in the creative inline editor, a text input, or a textarea opened the global search popup instead of performing the field's own edit. The global `Cmd/Ctrl+K` shortcut in `search_popup_controller` ran unconditionally and called `preventDefault()`, hijacking the keystroke even when focus was inside an editable element. On those elements `Ctrl+K` is the native *delete-to-end-of-line* edit, so the popup stole a key the field already owns.

## Fix

The global shortcut now yields when focus is inside an editable target — `input`, `textarea`, `select`, any `contenteditable`, or the inline Lexical editor (`[data-lexical-editor-root]`). The field's own `Ctrl+K` (delete line) takes precedence; the search popup still opens normally when focus is elsewhere (e.g. browsing the tree).

This matches the existing convention in `comments/popup_controller.js`, where the `Ctrl+A` handler already bails out for input/textarea/contenteditable.

## Tests

Added `search_popup_controller.test.js` (jsdom) covering:
- opens the popup on Ctrl+K when focus is **not** editable (regression guard)
- does **not** open in a text input
- does **not** open in a textarea
- does **not** open in a contenteditable element
- does **not** open in the inline Lexical editor root

`node --experimental-vm-modules ./node_modules/.bin/jest engines/collavre/app/javascript/controllers` → **14 suites / 107 tests pass**. The 4 editable cases fail without the fix, confirming the test is meaningful.