### PR TITLE
fix(collavre): assign per-parent sequence on markdown import

### DIFF
--- a/engines/collavre/app/services/collavre/markdown_importer.rb
+++ b/engines/collavre/app/services/collavre/markdown_importer.rb
@@ -20,6 +20,12 @@ module Collavre
         end
       end
       created = []
+      # Per-parent sequence counters. closure_tree orders siblings by the
+      # `sequence` column (default 0), but plain Creative.create never assigns
+      # it — so without this every imported sibling would share sequence 0 and
+      # fall back to a DB-defined tie-break (stable on SQLite, arbitrary on
+      # Postgres), corrupting document order. Assign contiguous values here.
+      seq = {}
       root = parent
       i = 0
       if create_root
@@ -28,7 +34,7 @@ module Collavre
         end
         if i < lines.size && lines[i] !~ /^\s*#/ && lines[i] !~ /^\s*[-*+]/
           page_title = lines[i].strip
-          root = Creative.create(user: user, parent: parent, description: page_title)
+          root = create_child(user: user, parent: parent, description: page_title, seq: seq)
           created << root
           i += 1
         end
@@ -73,7 +79,7 @@ module Collavre
           code_html = build_code_block_html(code_content, fence_info)
 
           new_parent = stack.any? ? stack.last[1] : root
-          c = Creative.create(user: user, parent: new_parent, description: code_html)
+          c = create_child(user: user, parent: new_parent, description: code_html, seq: seq)
           created << c
           next
         end
@@ -81,7 +87,7 @@ module Collavre
         if (table_data = parse_markdown_table(lines, i))
           table_html = build_table_html(table_data, image_refs)
           new_parent = stack.any? ? stack.last[1] : root
-          c = Creative.create(user: user, parent: new_parent, description: table_html)
+          c = create_child(user: user, parent: new_parent, description: table_html, seq: seq)
           created << c
           i = table_data[:next_index]
         elsif line =~ /^(#+)\s+(.*)$/
@@ -89,7 +95,7 @@ module Collavre
           desc = ApplicationController.helpers.markdown_links_to_html($2.strip, image_refs)
           stack.pop while stack.any? && stack.last[0] >= level
           new_parent = stack.any? ? stack.last[1] : root
-          c = Creative.create(user: user, parent: new_parent, description: desc)
+          c = create_child(user: user, parent: new_parent, description: desc, seq: seq)
           created << c
           stack << [ level, c ]
           i += 1
@@ -99,14 +105,14 @@ module Collavre
           bullet_level = 10 + indent / 2
           stack.pop while stack.any? && stack.last[0] >= bullet_level
           new_parent = stack.any? ? stack.last[1] : root
-          c = Creative.create(user: user, parent: new_parent, description: desc)
+          c = create_child(user: user, parent: new_parent, description: desc, seq: seq)
           created << c
           stack << [ bullet_level, c ]
           i += 1
         elsif !line.strip.empty?
           desc = ApplicationController.helpers.markdown_links_to_html(line.strip, image_refs)
           new_parent = stack.any? ? stack.last[1] : root
-          c = Creative.create(user: user, parent: new_parent, description: desc)
+          c = create_child(user: user, parent: new_parent, description: desc, seq: seq)
           created << c
           i += 1
         else
@@ -119,6 +125,21 @@ module Collavre
       Creative::RealtimeBroadcastable.broadcast_batch_created(created)
 
       created
+    end
+
+    # Creates a child under `parent` with an explicit `sequence`, tracking the
+    # next value per parent in `seq`. The first time a parent is seen the
+    # counter is seeded past any pre-existing children so an import into an
+    # already-populated parent appends after them instead of colliding at 0.
+    def self.create_child(user:, parent:, description:, seq:)
+      key = parent.id
+      unless seq.key?(key)
+        max = parent.children.maximum(:sequence)
+        seq[key] = max ? max + 1 : 0
+      end
+      creative = Creative.create(user: user, parent: parent, description: description, sequence: seq[key])
+      seq[key] += 1
+      creative
     end
 
     def self.build_code_block_html(code_content, language = nil)

--- a/engines/collavre/app/services/collavre/markdown_importer.rb
+++ b/engines/collavre/app/services/collavre/markdown_importer.rb
@@ -131,10 +131,13 @@ module Collavre
     # next value per parent in `seq`. The first time a parent is seen the
     # counter is seeded past any pre-existing children so an import into an
     # already-populated parent appends after them instead of colliding at 0.
+    # A nil parent means a root-level import (top-level page with no parent_id);
+    # closure_tree orders roots by `sequence` too, so seed from Creative.roots.
     def self.create_child(user:, parent:, description:, seq:)
-      key = parent.id
+      key = parent&.id
       unless seq.key?(key)
-        max = parent.children.maximum(:sequence)
+        siblings = parent ? parent.children : Creative.roots
+        max = siblings.maximum(:sequence)
         seq[key] = max ? max + 1 : 0
       end
       creative = Creative.create(user: user, parent: parent, description: description, sequence: seq[key])

--- a/engines/collavre/test/services/markdown_importer_test.rb
+++ b/engines/collavre/test/services/markdown_importer_test.rb
@@ -183,4 +183,68 @@ class MarkdownImporterTest < ActiveSupport::TestCase
     assert_not_nil image_creative, "Bare reference-style data URI with title should still resolve to an Active Storage blob image"
     assert_no_match(/data:image\/png;base64/, image_creative.description, "Raw data URI must not survive import")
   end
+
+  test "assigns contiguous sequence to persisted siblings in document order" do
+    user = users(:one)
+    parent = Creative.create!(user: user, description: "Parent")
+    markdown = <<~MD
+      First
+      Second
+      Third
+      Fourth
+      Fifth
+    MD
+
+    MarkdownImporter.import(markdown, parent: parent, user: user)
+
+    ordered = parent.children.order(:sequence).map { |c| plain_text(c.description) }
+    assert_equal %w[First Second Third Fourth Fifth], ordered,
+      "Persisted children must sort by sequence in document order (not rely on DB tie-break)"
+    assert_equal [ 0, 1, 2, 3, 4 ], parent.children.order(:sequence).map(&:sequence),
+      "Imported siblings must get contiguous 0-based sequence values"
+  end
+
+  test "assigns per-parent sequence for nested headings" do
+    user = users(:one)
+    parent = Creative.create!(user: user, description: "Parent")
+    markdown = <<~MD
+      # H1
+      Alpha
+      Beta
+      ## H2
+      Gamma
+      Delta
+    MD
+
+    MarkdownImporter.import(markdown, parent: parent, user: user)
+
+    h1 = parent.children.order(:sequence).first
+    assert_equal "H1", plain_text(h1.description)
+    # Under H1: "Alpha", "Beta", then "H2" — each a distinct sibling in order
+    assert_equal %w[Alpha Beta H2], h1.children.order(:sequence).map { |c| plain_text(c.description) }
+    assert_equal [ 0, 1, 2 ], h1.children.order(:sequence).map(&:sequence)
+
+    h2 = h1.children.order(:sequence).find { |c| plain_text(c.description) == "H2" }
+    assert_equal %w[Gamma Delta], h2.children.order(:sequence).map { |c| plain_text(c.description) }
+    assert_equal [ 0, 1 ], h2.children.order(:sequence).map(&:sequence)
+  end
+
+  test "appends imported siblings after existing children of the target parent" do
+    user = users(:one)
+    parent = Creative.create!(user: user, description: "Parent")
+    existing = Creative.create!(user: user, parent: parent, description: "Existing", sequence: 0)
+
+    MarkdownImporter.import("Imported one\nImported two\n", parent: parent, user: user)
+
+    ordered = parent.children.order(:sequence).map { |c| plain_text(c.description) }
+    assert_equal [ "Existing", "Imported one", "Imported two" ], ordered,
+      "Imported nodes must append after pre-existing children, not collide at sequence 0"
+    assert_equal existing, parent.children.order(:sequence).first
+  end
+
+  private
+
+  def plain_text(html)
+    html.to_s.gsub(/<[^>]+>/, "").strip
+  end
 end

--- a/engines/collavre/test/services/markdown_importer_test.rb
+++ b/engines/collavre/test/services/markdown_importer_test.rb
@@ -242,9 +242,32 @@ class MarkdownImporterTest < ActiveSupport::TestCase
     assert_equal existing, parent.children.order(:sequence).first
   end
 
+  test "imports at root level with a nil parent and sequences the root siblings" do
+    user = users(:one)
+    markdown = <<~MD
+      # Root Page
+      First child
+      Second child
+    MD
+
+    # Top-level import (no parent_id) passes parent: nil with create_root: true.
+    # Regression guard: create_child must not dereference a nil parent.
+    created = MarkdownImporter.import(markdown, parent: nil, user: user, create_root: true)
+
+    root = created.first
+    assert_nil root.parent, "create_root import must produce a top-level creative"
+    assert_equal "Root Page", plain_text(root.description)
+
+    ordered = root.children.order(:sequence).map { |c| plain_text(c.description) }
+    assert_equal [ "First child", "Second child" ], ordered
+    assert_equal [ 0, 1 ], root.children.order(:sequence).pluck(:sequence)
+  end
+
   private
 
+  # Extract visible text via a real HTML parser; a single-pass tag-strip regex
+  # is incomplete (nested tags like `<<b>b>` slip through) — CodeQL flags it.
   def plain_text(html)
-    html.to_s.gsub(/<[^>]+>/, "").strip
+    Nokogiri::HTML.fragment(html.to_s).text.strip
   end
 end


### PR DESCRIPTION
## Problem

Creatives created by `MarkdownImporter` appeared in the wrong order relative to the source document (reported as "블록 순서가 문서 순서와 불일치, 0%").

## Root cause

`Creative` orders siblings via closure_tree's `sequence` column (`has_closure_tree order: :sequence`). closure_tree 9.6.1 does **not** auto-assign an order value on plain `Creative.create` — the app must set it (as `Creatives::CreateService#resequence` does for interactive creation).

`MarkdownImporter` called `Creative.create(...)` directly and never set `sequence`, so every imported node kept the column default (`default: 0, null: false`). All siblings shared `sequence = 0`, and the display path (`order(:sequence)`, no secondary key) fell back to a DB-defined tie-break: stable insertion order on SQLite, but **arbitrary on Postgres**. Symptom onset lines up with the recent sqlite→pg migration.

Runtime evidence: importing 6 nodes yielded `sequences: [0,0,0,0,0,0]`.

## Fix

Route all node creation through a `create_child` helper that assigns contiguous per-parent `sequence` values in document order. The counter is seeded past any pre-existing children the first time a parent is seen, so importing into an already-populated parent appends after existing children instead of colliding at 0.

## Why tests didn't catch it

Existing tests asserted only on the returned `created` array (always built in document order), never on persisted `children.order(:sequence)` — false-green. Added tests cover flat order, nested per-parent sequencing, and append-after-existing.

## Testing

- `bin/rails test engines/collavre/test/services/markdown_importer_test.rb` — 12 runs, 0 failures
- Caller tests (`creative_import_service_test`, `creatives_helper_test`) — 22 runs, 0 failures
- rubocop clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)