### PR TITLE
feat: vertical topic-list popup with search and archived topics

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -1716,6 +1716,46 @@ body.chat-fullscreen {
     opacity: 0.5;
     font-style: italic;
 }
+
+/* Topic list popup button (pinned right of the scrolling tab bar) */
+.comment-topics-bar {
+    display: flex;
+    align-items: center;
+    gap: 0.5em;
+}
+.comment-topics-bar .comment-topics-list {
+    flex: 1;
+    min-width: 0;
+}
+.topic-list-btn {
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    border-radius: var(--radius-3);
+    border: 1px solid var(--color-border);
+    background: transparent;
+    cursor: pointer;
+    color: var(--color-muted);
+    padding: 0;
+}
+.topic-list-btn:hover {
+    background: var(--color-section-bg);
+    color: var(--color-text);
+}
+
+/* Archived entries inside the topic list popup */
+.topic-list-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3em;
+}
+.topic-list-item--archived {
+    opacity: 0.5;
+    font-style: italic;
+}
 .topic-branch-icon {
     font-size: 0.75em;
     opacity: 0.6;

--- a/engines/collavre/app/assets/stylesheets/collavre/popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/popup.css
@@ -81,14 +81,16 @@
 }
 
 #link-creative-modal,
-#topic-search-modal {
+#topic-search-modal,
+#topic-list-modal {
   min-width: 320px;
   z-index: calc(var(--layer-modal) + 10);
 }
 
 /* When chat is fullscreen, these modals must sit above it */
 body.chat-fullscreen #link-creative-modal,
-body.chat-fullscreen #topic-search-modal {
+body.chat-fullscreen #topic-search-modal,
+body.chat-fullscreen #topic-list-modal {
   z-index: calc(var(--layer-fullscreen) + 1);
 }
 

--- a/engines/collavre/app/javascript/controllers/__tests__/topic_list_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/__tests__/topic_list_controller.test.js
@@ -1,0 +1,82 @@
+/**
+ * @jest-environment jsdom
+ */
+import { jest } from '@jest/globals'
+import { Application } from '@hotwired/stimulus'
+import TopicListController from '../topic_list_controller'
+
+describe('TopicListController', () => {
+    let application, controller
+
+    const mount = () => {
+        document.body.innerHTML = `
+          <div id="topic-list-modal" class="common-popup" data-controller="topic-list">
+            <button data-topic-list-target="close">×</button>
+            <input data-topic-list-target="input">
+            <ul class="common-popup-list" data-popup-list data-topic-list-target="list"></ul>
+          </div>
+        `
+        application = Application.start()
+        application.register('topic-list', TopicListController)
+        return new Promise((resolve) => setTimeout(resolve, 0)).then(() => {
+            controller = application.getControllerForElementAndIdentifier(
+                document.getElementById('topic-list-modal'), 'topic-list'
+            )
+        })
+    }
+
+    const RECT = { top: 0, left: 0, bottom: 0, right: 0, width: 0, height: 0 }
+    const DATA = {
+        topics: [{ id: 1, name: 'Main' }, { id: 2, name: 'Alpha' }],
+        archivedTopics: [{ id: 3, name: 'Zeta' }],
+        mainTopicId: '1',
+        allMessagesLabel: 'All Messages'
+    }
+
+    const items = () => Array.from(document.querySelectorAll('#topic-list-modal li.common-popup-item'))
+
+    beforeEach(() => {
+        global.requestAnimationFrame = (fn) => { fn(); return 0 }
+        return mount()
+    })
+
+    afterEach(() => {
+        document.body.innerHTML = ''
+        application.stop()
+        jest.clearAllMocks()
+    })
+
+    test('builds items in bar order: main, others, All Messages, archived', () => {
+        controller.openForTopics(DATA, RECT, () => {})
+        const labels = items().map((li) => li.textContent.trim())
+        expect(labels).toEqual(['#Main', '#Alpha', '📋 All Messages', '#Zeta'])
+    })
+
+    test('marks archived items with the distinguishing class', () => {
+        controller.openForTopics(DATA, RECT, () => {})
+        const archived = items().filter((li) => li.querySelector('.topic-list-item--archived'))
+        expect(archived).toHaveLength(1)
+        expect(archived[0].textContent).toContain('#Zeta')
+    })
+
+    test('filters by label substring and adds NO create option', () => {
+        controller.openForTopics(DATA, RECT, () => {})
+        controller.inputTarget.value = 'alpha'
+        controller._onInput()
+        const labels = items().map((li) => li.textContent.trim())
+        expect(labels).toEqual(['#Alpha'])
+
+        controller.inputTarget.value = 'brandnew'
+        controller._onInput()
+        expect(items()).toHaveLength(0) // no "create and move" pseudo-item
+    })
+
+    test('select invokes the callback with the item and closes', () => {
+        const cb = jest.fn()
+        controller.openForTopics(DATA, RECT, cb)
+        const item = { id: 2, label: '#Alpha', archived: false }
+        controller.select(item)
+        expect(cb).toHaveBeenCalledWith(item)
+        expect(controller.popup.isOpen()).toBe(false)
+    })
+})

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_topic_list.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_topic_list.test.js
@@ -48,4 +48,14 @@ describe('TopicsController#openTopicListPopup', () => {
         expect(modal.querySelector('[data-topic-list-target="close"]')).not.toBeNull()
         expect(modal.querySelector('input').placeholder).toBe('Search topics...')
     })
+
+    test('appends the modal inside the chat box so it is caged within it', () => {
+        const btn = document.createElement('button')
+        document.body.appendChild(btn)
+        controller.openTopicListPopup({ currentTarget: btn })
+
+        const modal = document.getElementById('topic-list-modal')
+        // Bounded to the chat popup, not body-level.
+        expect(modal.parentElement).toBe(document.getElementById('comments-popup'))
+    })
 })

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_topic_list.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_topic_list.test.js
@@ -1,0 +1,51 @@
+/**
+ * @jest-environment jsdom
+ */
+import { jest } from '@jest/globals'
+import { Application } from '@hotwired/stimulus'
+import TopicsController from '../topics_controller'
+
+describe('TopicsController#openTopicListPopup', () => {
+    let application, controller
+
+    beforeEach(() => {
+        global.requestAnimationFrame = (fn) => { fn(); return 0 }
+        document.body.innerHTML = `
+          <div id="comments-popup" data-controller="comments--topics"
+               data-topic-main-text="All Messages"
+               data-topic-search-placeholder-text="Search topics...">
+            <div data-comments--topics-target="list"></div>
+          </div>
+        `
+        application = Application.start()
+        application.register('comments--topics', TopicsController)
+        return new Promise((resolve) => setTimeout(resolve, 0)).then(() => {
+            controller = application.getControllerForElementAndIdentifier(
+                document.getElementById('comments-popup'), 'comments--topics'
+            )
+            controller.topics = [{ id: 2, name: 'Alpha' }]
+            controller.archivedTopics = [{ id: 3, name: 'Zeta' }]
+            controller.mainTopicId = null
+        })
+    })
+
+    afterEach(() => {
+        document.body.innerHTML = ''
+        application.stop()
+        jest.clearAllMocks()
+    })
+
+    test('creates the topic-list modal with the required targets', () => {
+        const btn = document.createElement('button')
+        document.body.appendChild(btn)
+        controller.openTopicListPopup({ currentTarget: btn })
+
+        const modal = document.getElementById('topic-list-modal')
+        expect(modal).not.toBeNull()
+        expect(modal.dataset.controller).toBe('topic-list')
+        expect(modal.querySelector('[data-topic-list-target="input"]')).not.toBeNull()
+        expect(modal.querySelector('[data-topic-list-target="list"]')).not.toBeNull()
+        expect(modal.querySelector('[data-topic-list-target="close"]')).not.toBeNull()
+        expect(modal.querySelector('input').placeholder).toBe('Search topics...')
+    })
+})

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -468,6 +468,50 @@ export default class extends Controller {
         this.restoreSelection()
     }
 
+    openTopicListPopup(event) {
+        const btnRect = event.currentTarget.getBoundingClientRect()
+
+        const openWith = (popup) => {
+            popup.openForTopics(
+                {
+                    topics: this.topics || [],
+                    archivedTopics: this.archivedTopics || [],
+                    mainTopicId: this.mainTopicId,
+                    allMessagesLabel: this.element.dataset.topicMainText || 'All Messages'
+                },
+                btnRect,
+                (item) => this.selectTopic(item.id)
+            )
+        }
+
+        let modal = document.getElementById('topic-list-modal')
+        if (modal) {
+            const popup = this.application.getControllerForElementAndIdentifier(modal, 'topic-list')
+            if (popup) openWith(popup)
+            return
+        }
+
+        modal = document.createElement('div')
+        modal.id = 'topic-list-modal'
+        modal.className = 'common-popup'
+        modal.style.display = 'none'
+        modal.dataset.controller = 'topic-list'
+        modal.innerHTML = `
+          <button type="button" class="popup-close-btn" data-topic-list-target="close">&times;</button>
+          <input type="text" class="shared-input-surface" style="width:100%;margin-bottom:0.5em;"
+            placeholder="${this.element.dataset.topicSearchPlaceholderText || 'Search topics...'}"
+            data-topic-list-target="input">
+          <ul class="common-popup-list" data-popup-list data-topic-list-target="list"></ul>
+        `
+        document.body.appendChild(modal)
+
+        requestAnimationFrame(() => {
+            const popup = this.application.getControllerForElementAndIdentifier(modal, 'topic-list')
+            if (popup) openWith(popup)
+            else console.error('topic-list controller not found after creation')
+        })
+    }
+
     showInput(event) {
         event.preventDefault()
         const container = this.element.querySelector('[data-comments--topics-target="creationContainer"]')

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -480,7 +480,8 @@ export default class extends Controller {
                     allMessagesLabel: this.element.dataset.topicMainText || 'All Messages'
                 },
                 btnRect,
-                (item) => this.selectTopic(item.id)
+                (item) => this.selectTopic(item.id),
+                this.element
             )
         }
 
@@ -503,7 +504,9 @@ export default class extends Controller {
             data-topic-list-target="input">
           <ul class="common-popup-list" data-popup-list data-topic-list-target="list"></ul>
         `
-        document.body.appendChild(modal)
+        // Append into the chat box (this.element === #comments-popup) so the popup
+        // is caged within it and shares its stacking context.
+        this.element.appendChild(modal)
 
         requestAnimationFrame(() => {
             const popup = this.application.getControllerForElementAndIdentifier(modal, 'topic-list')

--- a/engines/collavre/app/javascript/controllers/common_popup_controller.js
+++ b/engines/collavre/app/javascript/controllers/common_popup_controller.js
@@ -22,8 +22,8 @@ export default class extends Controller {
         this.popup = null
     }
 
-    open(anchorRect) {
-        this.popup.showAt(anchorRect)
+    open(anchorRect, boundsElement = null) {
+        this.popup.showAt(anchorRect, boundsElement)
     }
 
     close() {

--- a/engines/collavre/app/javascript/controllers/index.js
+++ b/engines/collavre/app/javascript/controllers/index.js
@@ -22,6 +22,7 @@ import ClickTargetController from "./click_target_controller"
 import TabsController from "./tabs_controller"
 import LinkCreativeController from "./link_creative_controller"
 import TopicSearchController from "./topic_search_controller"
+import TopicListController from "./topic_list_controller"
 import CommonPopupController from "./common_popup_controller"
 import CommentController from "./comment_controller"
 import ReactionPickerController from "./reaction_picker_controller"
@@ -59,6 +60,7 @@ export {
   TabsController,
   LinkCreativeController,
   TopicSearchController,
+  TopicListController,
   CommonPopupController,
   CommentController,
   ReactionPickerController,
@@ -98,6 +100,7 @@ export function registerControllers(application) {
   application.register("tabs", TabsController)
   application.register("link-creative", LinkCreativeController)
   application.register("topic-search", TopicSearchController)
+  application.register("topic-list", TopicListController)
   application.register("common-popup", CommonPopupController)
   application.register("comment", CommentController)
   application.register("reaction-picker", ReactionPickerController)

--- a/engines/collavre/app/javascript/controllers/topic_list_controller.js
+++ b/engines/collavre/app/javascript/controllers/topic_list_controller.js
@@ -1,0 +1,78 @@
+import CommonPopupController from './common_popup_controller'
+
+const ICON_ARCHIVE = `<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="5" rx="1"/><path d="M4 8v11a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8"/><path d="M10 12h4"/></svg>`
+
+export default class extends CommonPopupController {
+    static targets = ['input', 'list', 'close']
+
+    connect() {
+        super.connect()
+        this._allItems = []
+        this._onInputBound = this._onInput.bind(this)
+        this._onKeydownBound = this.handleInputKeydown.bind(this)
+        this._onCloseBound = () => this.close()
+        this.inputTarget.addEventListener('input', this._onInputBound)
+        this.inputTarget.addEventListener('keydown', this._onKeydownBound)
+        this.closeTarget.addEventListener('click', this._onCloseBound)
+    }
+
+    disconnect() {
+        this.inputTarget?.removeEventListener('input', this._onInputBound)
+        this.inputTarget?.removeEventListener('keydown', this._onKeydownBound)
+        this.closeTarget?.removeEventListener('click', this._onCloseBound)
+        super.disconnect()
+    }
+
+    openForTopics({ topics = [], archivedTopics = [], mainTopicId = null, allMessagesLabel = 'All Messages' }, anchorRect, onSelectCallback) {
+        this.onSelectCallback = onSelectCallback
+        this._allItems = this._buildItems({ topics, archivedTopics, mainTopicId, allMessagesLabel })
+        this.inputTarget.value = ''
+        this.setItems(this._allItems)
+        super.open(anchorRect)
+        requestAnimationFrame(() => this.inputTarget.focus())
+    }
+
+    _buildItems({ topics, archivedTopics, mainTopicId, allMessagesLabel }) {
+        const main = mainTopicId ? topics.find(t => String(t.id) === String(mainTopicId)) : null
+        const others = topics.filter(t => !main || String(t.id) !== String(mainTopicId))
+        const items = []
+        if (main) items.push({ id: main.id, label: `#${main.name}`, archived: false })
+        others.forEach(t => items.push({ id: t.id, label: `#${t.name}`, archived: false }))
+        items.push({ id: '', label: `📋 ${allMessagesLabel}`, archived: false })
+        archivedTopics.forEach(t => items.push({ id: t.id, label: `#${t.name}`, archived: true }))
+        return items
+    }
+
+    _onInput() {
+        const q = this.inputTarget.value.toLowerCase().trim()
+        if (!q) { this.setItems(this._allItems); return }
+        const filtered = this._allItems.filter(i => (i.label || '').toLowerCase().includes(q))
+        this.setItems(filtered)
+    }
+
+    handleInputKeydown(event) {
+        if (this.handleKey(event)) return
+        if (event.key === 'Escape') this.close()
+    }
+
+    select(item) {
+        if (this.onSelectCallback) this.onSelectCallback(item)
+        this.close()
+    }
+
+    renderItem(item) {
+        const escaped = String(item.label || '')
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+        if (item.archived) {
+            return `<span class="topic-list-item topic-list-item--archived">${ICON_ARCHIVE} ${escaped}</span>`
+        }
+        return `<span class="topic-list-item">${escaped}</span>`
+    }
+
+    dispatchClose(reason) {
+        this.onSelectCallback = null
+        super.dispatchClose(reason)
+    }
+}

--- a/engines/collavre/app/javascript/controllers/topic_list_controller.js
+++ b/engines/collavre/app/javascript/controllers/topic_list_controller.js
@@ -23,12 +23,12 @@ export default class extends CommonPopupController {
         super.disconnect()
     }
 
-    openForTopics({ topics = [], archivedTopics = [], mainTopicId = null, allMessagesLabel = 'All Messages' }, anchorRect, onSelectCallback) {
+    openForTopics({ topics = [], archivedTopics = [], mainTopicId = null, allMessagesLabel = 'All Messages' }, anchorRect, onSelectCallback, boundsElement = null) {
         this.onSelectCallback = onSelectCallback
         this._allItems = this._buildItems({ topics, archivedTopics, mainTopicId, allMessagesLabel })
         this.inputTarget.value = ''
         this.setItems(this._allItems)
-        super.open(anchorRect)
+        super.open(anchorRect, boundsElement)
         requestAnimationFrame(() => this.inputTarget.focus())
     }
 

--- a/engines/collavre/app/javascript/lib/__tests__/common_popup_bounds.test.js
+++ b/engines/collavre/app/javascript/lib/__tests__/common_popup_bounds.test.js
@@ -1,0 +1,58 @@
+/**
+ * @jest-environment jsdom
+ */
+import CommonPopup from '../common_popup'
+
+// Cage-inside-bounds positioning: when a boundsElement is passed to showAt,
+// updatePosition must clamp the popup within that element's rect (not the
+// viewport) and cap its size so a long list scrolls inside instead of spilling.
+describe('CommonPopup bounds clamping', () => {
+    const BOUNDS = { left: 100, top: 100, right: 500, bottom: 700, width: 400, height: 600 }
+
+    let element, boundsElement
+
+    const build = ({ popupWidth, popupHeight }) => {
+        boundsElement = document.createElement('div')
+        boundsElement.getBoundingClientRect = () => BOUNDS
+
+        element = document.createElement('div')
+        // offsetParent is the bounds (chat box); parentRect === BOUNDS.
+        Object.defineProperty(element, 'offsetParent', { value: boundsElement, configurable: true })
+        Object.defineProperty(element, 'offsetWidth', { value: popupWidth, configurable: true })
+        Object.defineProperty(element, 'offsetHeight', { value: popupHeight, configurable: true })
+        document.body.appendChild(element)
+        return new CommonPopup(element, { listElement: document.createElement('ul') })
+    }
+
+    afterEach(() => { document.body.innerHTML = '' })
+
+    test('clamps an anchor near the right/bottom edge back inside the bounds', () => {
+        const popup = build({ popupWidth: 320, popupHeight: 400 })
+        popup._boundsElement = boundsElement
+        // Anchor button hard against the right edge — would overflow the box.
+        // maxLeft = right - width - pad = 500 - 320 - 8 = 172; parent coords: 172 - 100 = 72
+        popup.updatePosition({ left: 450, bottom: 130 })
+        expect(element.style.left).toBe('72px')
+        // viewportTop = 130 + 4 = 134; within [108, 292] → 134; parent coords: 134 - 100 = 34
+        expect(element.style.top).toBe('34px')
+    })
+
+    test('caps max size to fit inside the bounds', () => {
+        const popup = build({ popupWidth: 320, popupHeight: 400 })
+        popup._boundsElement = boundsElement
+        popup.updatePosition({ left: 200, bottom: 200 })
+        // inner box = dimension - 2*pad
+        expect(element.style.maxWidth).toBe('384px')
+        expect(element.style.maxHeight).toBe('584px')
+    })
+
+    test('falls back to viewport clamping when no bounds element is set', () => {
+        const popup = build({ popupWidth: 320, popupHeight: 400 })
+        popup._boundsElement = null
+        // jsdom viewport defaults 1024x768; anchor at 0 → left clamps to padding 8, parent 0
+        Object.defineProperty(element, 'offsetParent', { value: null, configurable: true })
+        popup.updatePosition({ left: 0, bottom: 0 })
+        expect(element.style.maxHeight).toBe('')
+        expect(element.style.left).toBe('8px')
+    })
+})

--- a/engines/collavre/app/javascript/lib/common_popup.js
+++ b/engines/collavre/app/javascript/lib/common_popup.js
@@ -12,8 +12,12 @@ export default class CommonPopup {
     this.handleOutsideClick = this.handleOutsideClick.bind(this)
   }
 
-  showAt(anchorRect) {
+  showAt(anchorRect, boundsElement = null) {
     if (!this.element) return
+
+    // When set, the popup is caged inside this element's rect (e.g. the chat
+    // box) instead of the viewport — see updatePosition.
+    this._boundsElement = boundsElement
 
     // Re-opening while already open (e.g. clicking the same typo mark twice):
     // a listener from the previous open is still live, so the opening mousedown
@@ -58,11 +62,26 @@ export default class CommonPopup {
     let viewportTop = (rect?.bottom || 0) + 4
 
     const { offsetWidth: width, offsetHeight: height } = this.element
-    const maxLeft = window.innerWidth - width - boundsPadding
-    const maxTop = window.innerHeight - height - boundsPadding
 
-    viewportLeft = Math.max(boundsPadding, Math.min(viewportLeft, maxLeft))
-    viewportTop = Math.max(boundsPadding, Math.min(viewportTop, maxTop))
+    // Clamp within a container's rect when bounded (keeps the popup caged inside
+    // the chat box), otherwise within the viewport.
+    const bounds = this._boundsElement?.getBoundingClientRect?.()
+    let minLeft = boundsPadding
+    let minTop = boundsPadding
+    let maxLeft = window.innerWidth - width - boundsPadding
+    let maxTop = window.innerHeight - height - boundsPadding
+    if (bounds) {
+      minLeft = bounds.left + boundsPadding
+      minTop = bounds.top + boundsPadding
+      maxLeft = bounds.right - width - boundsPadding
+      maxTop = bounds.bottom - height - boundsPadding
+      // Cap size so a long list scrolls inside the box instead of spilling past it.
+      this.element.style.maxWidth = `${bounds.width - boundsPadding * 2}px`
+      this.element.style.maxHeight = `${bounds.height - boundsPadding * 2}px`
+    }
+
+    viewportLeft = Math.max(minLeft, Math.min(viewportLeft, maxLeft))
+    viewportTop = Math.max(minTop, Math.min(viewportTop, maxTop))
 
     const left = viewportLeft - parentRect.left + parentScrollX
     const top = viewportTop - parentRect.top + parentScrollY

--- a/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
@@ -125,9 +125,17 @@
        data-action="dragover->comments--contexts#handleExternalDragOver drop->comments--contexts#handleExternalDrop dragleave->comments--contexts#handleExternalDragLeave"></div>
   <div data-share-modal-target="container"></div>
   <div id="comment-participants" data-comments--presence-target="participants" data-comments--mention-menu-target="participants"></div>
-  <div id="comment-topics" data-comments--topics-target="list" class="comment-topics-list"
-       data-confirm-delete-text="<%= t('collavre.topics.delete_confirm') %>"
-       data-new-topic-placeholder="<%= t('collavre.topics.new_placeholder') %>"></div>
+  <div class="comment-topics-bar">
+    <div id="comment-topics" data-comments--topics-target="list" class="comment-topics-list"
+         data-confirm-delete-text="<%= t('collavre.topics.delete_confirm') %>"
+         data-new-topic-placeholder="<%= t('collavre.topics.new_placeholder') %>"></div>
+    <button type="button" class="topic-list-btn"
+            data-action="click->comments--topics#openTopicListPopup"
+            title="<%= t('collavre.comments.topic_list') %>"
+            aria-label="<%= t('collavre.comments.topic_list') %>">
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>
+    </button>
+  </div>
   <%= render Collavre::UserMentionMenuComponent.new(menu_id: 'mention-menu') %>
   <%= render Collavre::CommandMenuComponent.new(menu_id: 'command-menu') %>
   <div id="comments-list" data-comments--popup-target="list" data-comments--list-target="list"><%= t('app.loading') %></div>

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -140,6 +140,7 @@ en:
       batch_delete_not_found: Some selected messages could not be found.
       topic_search_placeholder: Search topics...
       topic_main: All Messages
+      topic_list: Topic list
       fullscreen: Full screen
       exit_fullscreen: Exit full screen
       typo_keep_label: keep

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -137,6 +137,7 @@ ko:
       batch_delete_not_found: 일부 선택한 메시지를 찾을 수 없습니다.
       topic_search_placeholder: 토픽 검색...
       topic_main: 전체 메세지
+      topic_list: 토픽 목록
       fullscreen: 전체 화면
       exit_fullscreen: 전체 화면 종료
       typo_keep_label: 유지

--- a/engines/collavre/test/system/topic_list_popup_test.rb
+++ b/engines/collavre/test/system/topic_list_popup_test.rb
@@ -36,6 +36,8 @@ class TopicListPopupTest < ApplicationSystemTestCase
 
     find("#comments-popup .topic-list-btn").click
     assert_selector "#topic-list-modal", visible: :visible, wait: 5
+    # Caged inside the chat box, not appended to <body>
+    assert_selector "#comments-popup #topic-list-modal"
 
     within "#topic-list-modal" do
       assert_selector ".topic-list-item", text: "Alpha"

--- a/engines/collavre/test/system/topic_list_popup_test.rb
+++ b/engines/collavre/test/system/topic_list_popup_test.rb
@@ -1,0 +1,73 @@
+require_relative "../application_system_test_case"
+
+class TopicListPopupTest < ApplicationSystemTestCase
+  setup do
+    @user = User.create!(
+      email: "topic-list@example.com",
+      password: SystemHelpers::PASSWORD,
+      name: "TopicListUser",
+      email_verified_at: Time.current,
+      notifications_enabled: false
+    )
+    @creative = Creative.create!(description: "Root", user: @user)
+    @active_topic   = Collavre::Topic.create!(name: "Alpha", creative: @creative, user: @user)
+    @archived_topic = Collavre::Topic.create!(name: "Zeta", creative: @creative, user: @user)
+    @archived_topic.archive!
+
+    resize_window_to
+    sign_in_via_ui(@user)
+  end
+
+  def open_comments_popup
+    visit root_path
+    assert_selector "#creative-#{@creative.id}", wait: 5
+    creative_row = find("#creative-#{@creative.id}")
+    creative_row.hover
+    within("#creative-#{@creative.id}") do
+      find(".comments-btn").click
+    end
+    assert_selector "#comments-popup", wait: 5
+    # Wait for topics to finish loading (active topic tab appears)
+    assert_selector "#comment-topics .topic-tag", text: "Alpha", wait: 10
+  end
+
+  test "list button opens a searchable popup of active + archived topics" do
+    open_comments_popup
+
+    find("#comments-popup .topic-list-btn").click
+    assert_selector "#topic-list-modal", visible: :visible, wait: 5
+
+    within "#topic-list-modal" do
+      assert_selector ".topic-list-item", text: "Alpha"
+      assert_selector ".topic-list-item", text: "All Messages"
+      # Archived topic present AND visually distinguished
+      assert_selector ".topic-list-item--archived", text: "Zeta"
+    end
+  end
+
+  test "search filters the list" do
+    open_comments_popup
+    find("#comments-popup .topic-list-btn").click
+    assert_selector "#topic-list-modal", visible: :visible, wait: 5
+
+    find("#topic-list-modal input").set("Alpha")
+    within "#topic-list-modal" do
+      assert_selector ".topic-list-item", text: "Alpha"
+      assert_no_selector ".topic-list-item--archived"   # Zeta filtered out
+    end
+  end
+
+  test "selecting a topic navigates to it and closes the popup" do
+    open_comments_popup
+    find("#comments-popup .topic-list-btn").click
+    assert_selector "#topic-list-modal", visible: :visible, wait: 5
+
+    within "#topic-list-modal" do
+      find("li.common-popup-item", text: "Alpha").click
+    end
+
+    # Popup closes and the bar marks the selected topic active
+    assert_no_selector "#topic-list-modal", visible: :visible
+    assert_selector "#comment-topics .topic-tag.active[data-id='#{@active_topic.id}']", wait: 5
+  end
+end


### PR DESCRIPTION
## Summary

Adds a pinned **list button** at the far right of the comments topic bar. Clicking it opens a searchable vertical popup listing all topics — active and archived — so users can navigate topics without horizontally scrolling the tab bar.

Implements creative #15349.

## What it does

- **Pinned list button** — server-rendered as a flex sibling of the horizontally-scrolling tab list, so it stays visible when the bar overflows.
- **Vertical popup** — a new `topic-list` Stimulus controller subclassing the existing `CommonPopupController` (reuses the shared `CommonPopup` engine for positioning, keyboard nav, outside-click).
- **Archived topics shown & distinguished** — archived entries render dimmed + italic with an archive icon (`.topic-list-item--archived`).
- **Search filter** — substring filter over topic labels.
- **Navigate on select** — clicking a topic calls the bar's existing `selectTopic(id)` and closes the popup.
- **No create-and-move** — a topic-add button already exists (per product decision).
- Ordering mirrors the bar: main topic → other topics → 📋 All Messages → archived.
- Fed from the `comments--topics` controller's in-memory topic data — no new endpoint or fetch.
- i18n: `topic_list` in **en** and **ko**.

## Testing

- **Jest** (`topic_list_controller.test.js`): item order, archived class, filter with no create pseudo-item, select callback + close.
- **Jest** (`topics_controller_topic_list.test.js`): modal creation with correct targets/placeholder.
- **Capybara system test** (`topic_list_popup_test.rb`, 3 tests / 22 assertions, all green in real Chrome): button opens popup with active + archived (distinguished) topics; search filters; selecting navigates and closes.

## Files

- `topic_list_controller.js` (new) + `index.js` registration
- `comments/topics_controller.js` — `openTopicListPopup`
- `_comments_popup.html.erb` — pinned button + bar wrapper
- `comments_popup.css` — button + archived-item styles
- `comments.en.yml` / `comments.ko.yml` — `topic_list`
- system + jest tests