### PR TITLE
fix: gate GitHub wizard Next button on the current user's own connection

### DIFF
--- a/engines/collavre_github/app/javascript/__tests__/github_wizard_state.test.js
+++ b/engines/collavre_github/app/javascript/__tests__/github_wizard_state.test.js
@@ -1,0 +1,57 @@
+import { deriveConnectState, shouldShowConnectNext } from '../github_wizard_state.js';
+
+describe('deriveConnectState', () => {
+  test('connected user with selected repos: connected + existing', () => {
+    expect(deriveConnectState({ connected: true, selected_repositories: ['a/b'] }))
+      .toEqual({ userConnected: true, hasExistingIntegration: true });
+  });
+
+  test('connected user with no selected repos: connected, no existing', () => {
+    expect(deriveConnectState({ connected: true, selected_repositories: [] }))
+      .toEqual({ userConnected: true, hasExistingIntegration: false });
+  });
+
+  test('connected user ignores all_repositories for existing flag', () => {
+    // A connected user's existing state comes from their own selection,
+    // never from other members' all_repositories.
+    expect(deriveConnectState({ connected: true, selected_repositories: [], all_repositories: ['x/y', 'x/z'] }))
+      .toEqual({ userConnected: true, hasExistingIntegration: false });
+  });
+
+  test('unconnected user with repos linked by others: not connected but existing', () => {
+    expect(deriveConnectState({ connected: false, all_repositories: ['x/y', 'x/z', 'x/w'] }))
+      .toEqual({ userConnected: false, hasExistingIntegration: true });
+  });
+
+  test('unconnected user with no repos: not connected, no existing', () => {
+    expect(deriveConnectState({ connected: false, all_repositories: [] }))
+      .toEqual({ userConnected: false, hasExistingIntegration: false });
+  });
+
+  test('tolerates missing/empty payload', () => {
+    expect(deriveConnectState()).toEqual({ userConnected: false, hasExistingIntegration: false });
+    expect(deriveConnectState({})).toEqual({ userConnected: false, hasExistingIntegration: false });
+  });
+});
+
+describe('shouldShowConnectNext', () => {
+  test('shows Next only when the current user is connected AND repos exist', () => {
+    expect(shouldShowConnectNext({ hasExistingIntegration: true, userConnected: true })).toBe(true);
+  });
+
+  test('hides Next for an unconnected user even when repos exist (regression)', () => {
+    // Repos linked by other members must not let an unauthenticated user
+    // advance into an empty organization list — they must log in first.
+    expect(shouldShowConnectNext({ hasExistingIntegration: true, userConnected: false })).toBe(false);
+  });
+
+  test('hides Next when there is no existing integration', () => {
+    expect(shouldShowConnectNext({ hasExistingIntegration: false, userConnected: true })).toBe(false);
+    expect(shouldShowConnectNext({ hasExistingIntegration: false, userConnected: false })).toBe(false);
+  });
+
+  test('tolerates missing state', () => {
+    expect(shouldShowConnectNext()).toBe(false);
+    expect(shouldShowConnectNext({})).toBe(false);
+  });
+});

--- a/engines/collavre_github/app/javascript/collavre_github.js
+++ b/engines/collavre_github/app/javascript/collavre_github.js
@@ -1,5 +1,6 @@
 import { csrfToken, showError, clearError, updateStepVisibility, openOAuthPopup, fetchWithCsrf, setupModalClose } from 'collavre/modules/integration_wizard';
 import { alertDialog, confirmDialog } from 'collavre/lib/utils/dialog';
+import { deriveConnectState, shouldShowConnectNext } from './github_wizard_state.js';
 
 let githubIntegrationInitialized = false;
 
@@ -51,6 +52,10 @@ if (!githubIntegrationInitialized) {
     let webhookDetails = {};
 
     let hasExistingIntegration = false;
+    // Whether the *current* user has their own connected GitHub account.
+    // hasExistingIntegration can be true from other members' linked repos while
+    // this user is still unauthenticated, so the two must be tracked separately.
+    let userConnected = false;
     let selectedReposForDeletion = new Set();
 
     const markdownSyncList = document.getElementById('github-markdown-sync-list');
@@ -64,6 +69,7 @@ if (!githubIntegrationInitialized) {
       webhookDetails = {};
 
       hasExistingIntegration = false;
+      userConnected = false;
       selectedReposForDeletion = new Set();
       statusEl.textContent = '';
       errorEl.style.display = 'none';
@@ -101,7 +107,10 @@ if (!githubIntegrationInitialized) {
 
       if (currentStep === 'connect') {
         prevBtn.style.display = 'none';
-        if (hasExistingIntegration) {
+        // Only surface "Next" when the current user is actually connected. When
+        // existing repos come solely from other members, the user must log in
+        // first — otherwise Next leads to an empty (0 org) dead end.
+        if (shouldShowConnectNext({ hasExistingIntegration, userConnected })) {
           nextBtn.style.display = 'block';
           nextBtn.disabled = false;
         } else {
@@ -198,18 +207,19 @@ if (!githubIntegrationInitialized) {
       fetch(`/github/creatives/${creativeId}/integration`, { headers: { Accept: 'application/json' } })
         .then(function (response) { return response.json(); })
         .then(function (data) {
+          var connectState = deriveConnectState(data);
+          userConnected = connectState.userConnected;
+          hasExistingIntegration = connectState.hasExistingIntegration;
+
           if (!data.connected) {
-            var allRepos = data.all_repositories || [];
-            if (allRepos.length > 0) {
+            if (hasExistingIntegration) {
               // Other users have linked repositories to this creative
               statusEl.textContent = existingMessage;
-              hasExistingIntegration = true;
-              renderExistingConnections(allRepos, true);
+              renderExistingConnections(data.all_repositories || [], true);
               if (connectMessage) connectMessage.style.display = 'none';
               if (loginBtn) loginBtn.style.display = 'inline-block';
             } else {
               statusEl.textContent = '';
-              hasExistingIntegration = false;
               renderExistingConnections([]);
               if (connectMessage) connectMessage.style.display = '';
               if (loginBtn) loginBtn.style.display = 'inline-block';
@@ -230,8 +240,7 @@ if (!githubIntegrationInitialized) {
             }
           });
 
-          hasExistingIntegration = selectedRepos.size > 0;
-          
+          // hasExistingIntegration was derived above from selected_repositories.
           if (loginBtn) loginBtn.style.display = 'none';
           renderExistingConnections(Array.from(selectedRepos));
 

--- a/engines/collavre_github/app/javascript/github_wizard_state.js
+++ b/engines/collavre_github/app/javascript/github_wizard_state.js
@@ -29,8 +29,7 @@ export function deriveConnectState(status) {
  * Existing repositories linked by *other* members must not let an
  * unauthenticated user advance: organization lookup requires the user's own
  * connected GitHub account, so advancing would dead-end on an empty
- * organization list ("조회할 수 있는 Organization이 없습니다."). Such a user
- * must log in first.
+ * organization list. Such a user must log in first.
  *
  * @param {{hasExistingIntegration?:boolean, userConnected?:boolean}} state
  * @returns {boolean}

--- a/engines/collavre_github/app/javascript/github_wizard_state.js
+++ b/engines/collavre_github/app/javascript/github_wizard_state.js
@@ -1,0 +1,41 @@
+/**
+ * Pure-logic helpers for the GitHub integration wizard's connect step.
+ * Extracted so the "can this user advance past the connect step" decision
+ * can be unit-tested without the full DOM wizard.
+ */
+
+/**
+ * Derive connect-step flags from the integration status payload.
+ *
+ * `userConnected` reflects whether the *current* user has their own linked
+ * GitHub account. `hasExistingIntegration` reflects whether the creative
+ * already has repositories linked — by this user when connected, or by *any*
+ * member (all_repositories) when the current user is not yet connected.
+ *
+ * @param {{connected?:boolean, all_repositories?:string[], selected_repositories?:string[]}} status
+ * @returns {{userConnected:boolean, hasExistingIntegration:boolean}}
+ */
+export function deriveConnectState(status) {
+  const s = status || {};
+  const userConnected = !!s.connected;
+  const repos = userConnected ? s.selected_repositories : s.all_repositories;
+  const hasExistingIntegration = (repos || []).length > 0;
+  return { userConnected, hasExistingIntegration };
+}
+
+/**
+ * Whether the connect step's "Next" button should be shown.
+ *
+ * Existing repositories linked by *other* members must not let an
+ * unauthenticated user advance: organization lookup requires the user's own
+ * connected GitHub account, so advancing would dead-end on an empty
+ * organization list ("조회할 수 있는 Organization이 없습니다."). Such a user
+ * must log in first.
+ *
+ * @param {{hasExistingIntegration?:boolean, userConnected?:boolean}} state
+ * @returns {boolean}
+ */
+export function shouldShowConnectNext(state) {
+  const s = state || {};
+  return !!(s.hasExistingIntegration && s.userConnected);
+}


### PR DESCRIPTION
## Problem

When a creative already has repositories linked by **other members**, an
unauthenticated user opening the GitHub integration modal was shown the
**Next** button on the connect step. Clicking it advanced to the
organization step, whose lookup (`/github/account/organizations`) requires
the user's *own* connected GitHub account. Without one, the endpoint returns
`not_connected`, the org list is empty, and the wizard dead-ends on:

> 조회할 수 있는 Organization이 없습니다.

The repo count (3) in the report was coincidental — there is no count limit
anywhere. The real trigger is: *current user has no linked GitHub account* +
*creative has repos linked by someone else*.

## Root cause

`fetchStatus()` set `hasExistingIntegration = true` whenever any member's
repos existed (`all_repositories`), and `updateStep()` used that single flag
to reveal the connect-step **Next** button — conflating "the creative has an
integration" with "this user is connected".

## Fix

Track the current user's own connection (`userConnected`) separately from
whether the creative has any existing integration (`hasExistingIntegration`),
and only surface **Next** when the user is actually connected. Otherwise only
the **login** button shows, matching the intended OAuth-first flow: login →
`githubConnected` → `fetchStatus()` re-runs with `connected: true` → org step.

The connect-step decision is extracted into pure, unit-tested helpers
(`github_wizard_state.js`), following the existing Slack wizard pattern
(`slack_channel_list.js`).

## Testing

- New jest suite `github_wizard_state.test.js` (10 tests, all green) covering
  `deriveConnectState` and `shouldShowConnectNext`, including the regression
  case: unconnected user + others' repos → Next hidden.
- `npm run build` succeeds; helpers bundle into the built asset.

Frontend-only change; no backend/filter changes required.