### PR TITLE
feat: psql script to provision the production Postgres database

### DIFF
--- a/db/setup_postgres_databases.sql
+++ b/db/setup_postgres_databases.sql
@@ -1,0 +1,95 @@
+-- =============================================================================
+-- setup_postgres_databases.sql
+-- =============================================================================
+--
+-- Provision the four PostgreSQL databases this app uses in production, all owned
+-- by the application role. Rails 8 keeps primary / cache / queue / cable in
+-- SEPARATE databases (see config/database.yml). If they collapse onto one
+-- physical database they share a single `schema_migrations` table and the
+-- primary (version 2026...) and the Solid Cache/Queue/Cable schemas (version 1)
+-- clobber each other, which breaks `db:migrate` on deploy.
+--
+--   primary -> collavre_production          (real app data)
+--   cache   -> collavre_production_cache     (Solid Cache, volatile)
+--   queue   -> collavre_production_queue     (Solid Queue, volatile)
+--   cable   -> collavre_production_cable     (Solid Cable, volatile)
+--
+-- The script is IDEMPOTENT: it only creates what is missing and re-asserts
+-- ownership, so it is safe to re-run. It never drops a database or any data.
+--
+-- Usage (run as a superuser, e.g. postgres):
+--   # 1) create the app role's password out of band (env, never shell history):
+--   DB_PASSWORD='...' psql -v ON_ERROR_STOP=1 -f db/setup_postgres_databases.sql
+--
+--   # or against a remote server:
+--   DB_PASSWORD='...' psql -h <host> -U postgres -d postgres \
+--     -v ON_ERROR_STOP=1 -f db/setup_postgres_databases.sql
+--
+-- Overrides (all optional):
+--   -v db_user=collavre_user      application role name (default collavre_user)
+--   -v db_prefix=collavre_production   base DB name; the other three append
+--                                 _cache/_queue/_cable (default collavre_production)
+--   DB_PASSWORD=...               (env) sets/updates the role password. If unset,
+--                                 an existing role's password is left untouched
+--                                 and a missing role is created with LOGIN only.
+--
+-- After this runs, point the four *_DATABASE_URL env vars at these databases and
+-- migrate data into the primary with `bin/rails db:sqlite_to_postgres[...]`
+-- (see lib/tasks/db_convert.rake). The cache/queue/cable databases hold volatile
+-- data only — never copy rows into them; `db:prepare` loads their schemas.
+-- =============================================================================
+
+\set ON_ERROR_STOP on
+
+-- Defaults, only applied when not supplied via -v.
+\if :{?db_user}
+\else
+  \set db_user 'collavre_user'
+\endif
+\if :{?db_prefix}
+\else
+  \set db_prefix 'collavre_production'
+\endif
+
+-- Read the desired role password from the environment (empty when unset).
+-- printf avoids a trailing newline; works on psql 14+ (\getenv is 15+ only).
+\set db_password `printf '%s' "${DB_PASSWORD:-}"`
+
+\echo '--- Ensuring application role' :'db_user'
+
+-- Create the login role if it does not exist yet (password set separately below).
+SELECT format('CREATE ROLE %I LOGIN', :'db_user')
+WHERE NOT EXISTS (SELECT FROM pg_roles WHERE rolname = :'db_user')
+\gexec
+
+-- Set/update the password only when one was provided; otherwise leave it as is.
+SELECT format('ALTER ROLE %I PASSWORD %L', :'db_user', :'db_password')
+WHERE :'db_password' <> ''
+\gexec
+
+\echo '--- Ensuring databases owned by' :'db_user'
+
+-- Create each missing database owned by the app role. CREATE DATABASE cannot run
+-- inside a transaction/DO block, so we generate the statements with \gexec.
+SELECT format('CREATE DATABASE %I OWNER %I', :'db_prefix' || suffix, :'db_user')
+FROM (VALUES (''), ('_cache'), ('_queue'), ('_cable')) AS d(suffix)
+WHERE NOT EXISTS (
+  SELECT FROM pg_database WHERE datname = :'db_prefix' || suffix
+)
+\gexec
+
+-- Re-assert ownership in case a database already existed with a different owner.
+SELECT format('ALTER DATABASE %I OWNER TO %I', :'db_prefix' || suffix, :'db_user')
+FROM (VALUES (''), ('_cache'), ('_queue'), ('_cable')) AS d(suffix)
+\gexec
+
+\echo '--- Done. Databases:'
+SELECT datname, pg_catalog.pg_get_userbyid(datdba) AS owner
+FROM pg_database
+WHERE datname IN (
+  :'db_prefix',
+  :'db_prefix' || '_cache',
+  :'db_prefix' || '_queue',
+  :'db_prefix' || '_cable'
+)
+ORDER BY datname;

--- a/db/setup_postgres_databases.sql
+++ b/db/setup_postgres_databases.sql
@@ -2,17 +2,19 @@
 -- setup_postgres_databases.sql
 -- =============================================================================
 --
--- Provision the four PostgreSQL databases this app uses in production, all owned
--- by the application role. Rails 8 keeps primary / cache / queue / cable in
--- SEPARATE databases (see config/database.yml). If they collapse onto one
--- physical database they share a single `schema_migrations` table and the
--- primary (version 2026...) and the Solid Cache/Queue/Cable schemas (version 1)
--- clobber each other, which breaks `db:migrate` on deploy.
+-- Provision the production PostgreSQL database this app uses, owned by the
+-- application role.
 --
---   primary -> collavre_production          (real app data)
---   cache   -> collavre_production_cache     (Solid Cache, volatile)
---   queue   -> collavre_production_queue     (Solid Queue, volatile)
---   cable   -> collavre_production_cable     (Solid Cable, volatile)
+--   primary -> collavre_production   (real app data)
+--
+-- This app keeps everything in ONE database: the Solid Queue / Cache / Cable
+-- tables (solid_queue_jobs, etc.) are created by a primary `db/migrate`
+-- migration and live in the single `db/schema.rb` — there are no separate
+-- queue/cache/cable schema files. The production topology (config/render.yaml)
+-- sets only DATABASE_URL, so cache/queue/cable connect to this same database.
+-- Do NOT create separate _cache/_queue/_cable databases: they would be empty
+-- with no path to load the Solid tables, and CronScheduler/SolidQueue would
+-- boot-fail with `relation "solid_queue_jobs" does not exist`.
 --
 -- The script is IDEMPOTENT: it only creates what is missing and re-asserts
 -- ownership, so it is safe to re-run. It never drops a database or any data.
@@ -26,17 +28,14 @@
 --     -v ON_ERROR_STOP=1 -f db/setup_postgres_databases.sql
 --
 -- Overrides (all optional):
---   -v db_user=collavre_user      application role name (default collavre_user)
---   -v db_prefix=collavre_production   base DB name; the other three append
---                                 _cache/_queue/_cable (default collavre_production)
+--   -v db_user=collavre_user          application role name (default collavre_user)
+--   -v db_name=collavre_production     database name (default collavre_production)
 --   DB_PASSWORD=...               (env) sets/updates the role password. If unset,
 --                                 an existing role's password is left untouched
 --                                 and a missing role is created with LOGIN only.
 --
--- After this runs, point the four *_DATABASE_URL env vars at these databases and
--- migrate data into the primary with `bin/rails db:sqlite_to_postgres[...]`
--- (see lib/tasks/db_convert.rake). The cache/queue/cable databases hold volatile
--- data only — never copy rows into them; `db:prepare` loads their schemas.
+-- After this runs, point DATABASE_URL at this database and migrate data into it
+-- with `bin/rails db:sqlite_to_postgres[...]` (see lib/tasks/db_convert.rake).
 -- =============================================================================
 
 \set ON_ERROR_STOP on
@@ -46,9 +45,9 @@
 \else
   \set db_user 'collavre_user'
 \endif
-\if :{?db_prefix}
+\if :{?db_name}
 \else
-  \set db_prefix 'collavre_production'
+  \set db_name 'collavre_production'
 \endif
 
 -- Read the desired role password from the environment (empty when unset).
@@ -67,29 +66,19 @@ SELECT format('ALTER ROLE %I PASSWORD %L', :'db_user', :'db_password')
 WHERE :'db_password' <> ''
 \gexec
 
-\echo '--- Ensuring databases owned by' :'db_user'
+\echo '--- Ensuring database' :'db_name' 'owned by' :'db_user'
 
--- Create each missing database owned by the app role. CREATE DATABASE cannot run
--- inside a transaction/DO block, so we generate the statements with \gexec.
-SELECT format('CREATE DATABASE %I OWNER %I', :'db_prefix' || suffix, :'db_user')
-FROM (VALUES (''), ('_cache'), ('_queue'), ('_cable')) AS d(suffix)
-WHERE NOT EXISTS (
-  SELECT FROM pg_database WHERE datname = :'db_prefix' || suffix
-)
+-- Create the database owned by the app role if it does not exist yet. CREATE
+-- DATABASE cannot run inside a transaction/DO block, so we generate it with \gexec.
+SELECT format('CREATE DATABASE %I OWNER %I', :'db_name', :'db_user')
+WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = :'db_name')
 \gexec
 
--- Re-assert ownership in case a database already existed with a different owner.
-SELECT format('ALTER DATABASE %I OWNER TO %I', :'db_prefix' || suffix, :'db_user')
-FROM (VALUES (''), ('_cache'), ('_queue'), ('_cable')) AS d(suffix)
+-- Re-assert ownership in case the database already existed with a different owner.
+SELECT format('ALTER DATABASE %I OWNER TO %I', :'db_name', :'db_user')
 \gexec
 
-\echo '--- Done. Databases:'
+\echo '--- Done. Database:'
 SELECT datname, pg_catalog.pg_get_userbyid(datdba) AS owner
 FROM pg_database
-WHERE datname IN (
-  :'db_prefix',
-  :'db_prefix' || '_cache',
-  :'db_prefix' || '_queue',
-  :'db_prefix' || '_cable'
-)
-ORDER BY datname;
+WHERE datname = :'db_name';

--- a/lib/tasks/db_convert.rake
+++ b/lib/tasks/db_convert.rake
@@ -207,6 +207,7 @@ namespace :db do
       # load_schema may leave the connection pointed elsewhere; re-pin to target.
       ActiveRecord::Base.establish_connection(run_config)
       puts "[schema] Done."
+      stamp_all_migrations(ActiveRecord::Base.connection)
     end
     target_conn = ActiveRecord::Base.connection
 
@@ -529,6 +530,32 @@ namespace :db do
   # into their PostgreSQL equivalents. SQLite dumps JSON expression indexes using
   # json_extract(col, '$.key'); PostgreSQL needs (col ->> 'key'). Without this,
   # db:schema:load fails on Postgres with "function json_extract does not exist".
+  # Fully populate schema_migrations after a schema:load.
+  #
+  # Why: schema:load's assume_migrated_upto_version stamps only versions from the
+  # primary db_config's migrations_paths (nil -> just "db/migrate", 7 files here),
+  # leaving the ~160 engine migrations unstamped. db:migrate, however, reads
+  # DatabaseTasks.migrations_paths (primary + every engine that appends its path),
+  # so on deploy it treats those engine migrations as pending and re-runs them
+  # against already-existing tables -> "relation already exists". Stamping the full
+  # set here makes db:migrate a no-op, which is correct: schema:load already built
+  # the exact state those migrations produce.
+  def stamp_all_migrations(conn)
+    paths = ActiveRecord::Tasks::DatabaseTasks.migrations_paths
+    all = ActiveRecord::MigrationContext.new(paths).migrations.map(&:version)
+    sm = conn.quote_table_name("schema_migrations")
+    existing = conn.select_values("SELECT version FROM #{sm}").map(&:to_i)
+    missing = (all - existing).sort
+    if missing.empty?
+      puts "[schema] schema_migrations already complete (#{existing.size} versions)."
+      return
+    end
+    values = missing.map { |v| "(#{conn.quote(v.to_s)})" }.join(", ")
+    conn.execute("INSERT INTO #{sm} (version) VALUES #{values}")
+    puts "[schema] Stamped #{missing.size} engine/primary migration versions " \
+         "(schema_migrations now #{existing.size + missing.size})."
+  end
+
   def load_portable_schema(target_config)
     require "tempfile"
     schema_file = ActiveRecord::Tasks::DatabaseTasks.schema_dump_path(target_config)


### PR DESCRIPTION
## What

Adds `db/setup_postgres_databases.sql` — an idempotent psql script that provisions the production PostgreSQL database, owned by the application role (`collavre_user`).

```
primary -> collavre_production   (real app data)
```

## Why

This app keeps **everything in one database**. The Solid Queue/Cache/Cable tables (`solid_queue_jobs`, etc.) are created by a primary `db/migrate` migration and live in the single `db/schema.rb` — there are no separate queue/cache/cable schema files. The production topology (`config/render.yaml`) sets only `DATABASE_URL`, so cache/queue/cable connect to this same database.

Creating separate `_cache`/`_queue`/`_cable` databases would be actively harmful: they would be empty with no path to load the Solid tables, and `SolidQueue`/`CronScheduler` would boot-fail with `relation "solid_queue_jobs" does not exist`. So this script provisions the single primary DB only.

Follow-up to #1350 (`db:sqlite_to_postgres`): create the database with this script, then migrate the primary's data with the rake task.

## Behaviour

- **Idempotent** — creates only what is missing, re-asserts ownership, never drops a database or any data. Safe to re-run.
- Ensures the login role exists; sets/updates its password only when `DB_PASSWORD` is provided (an existing role's password is left untouched otherwise).
- Overridable via `-v db_user=...` and `-v db_name=...`.
- Works on psql 14+ (uses a backtick `printf` to read `DB_PASSWORD`; `\getenv` is 15+ only).

## Usage

```bash
DB_PASSWORD='...' psql -v ON_ERROR_STOP=1 -f db/setup_postgres_databases.sql
# remote:
DB_PASSWORD='...' psql -h <host> -U postgres -d postgres \
  -v ON_ERROR_STOP=1 -f db/setup_postgres_databases.sql
```

## Testing

Verified locally against throwaway names (`-v db_name=setuptest_db -v db_user=setuptest_user`), then cleaned up:

| Check | Result |
|---|---|
| First run creates role + single DB, owned by app role | ✅ |
| Re-run is idempotent (only re-asserts ownership, no errors) | ✅ |
| No `_cache`/`_queue`/`_cable` databases created | ✅ |
| No `DB_PASSWORD` → existing password left untouched | ✅ |
| Throwaway DB/role dropped, 0 leftover | ✅ |