### PR TITLE
refactor(collavre): make core engine vendor-neutral

### DIFF
--- a/engines/collavre/app/controllers/collavre/attachments_controller.rb
+++ b/engines/collavre/app/controllers/collavre/attachments_controller.rb
@@ -64,8 +64,28 @@ module Collavre
       signed_id = blob.signed_id
       pattern = "%#{ActiveRecord::Base.sanitize_sql_like(signed_id)}%"
 
-      Creative.where("description LIKE ?", pattern).any? do |creative|
-        creative.has_permission?(Current.user, :write)
+      creatives = Creative.where("description LIKE ?", pattern).includes(:origin)
+      return false if creatives.empty?
+
+      # Permission is evaluated on the origin for linked creatives. Resolve every
+      # referencing creative to its permission base and batch-load the cache
+      # entries once, rather than letting each has_permission? call fire its own
+      # per-row CreativeSharesCache lookups (an N+1). Mirrors
+      # Creatives::PermissionChecker#allowed?(:write): a user-specific entry
+      # (including an explicit no_access deny) takes precedence over the public
+      # share entry.
+      bases = creatives.map { |c| c.origin_id.nil? ? c : c.origin }.compact.uniq
+      return true if bases.any? { |base| base.user_id == Current.user.id }
+
+      write_rank = CreativeSharesCache.permissions[:write]
+      entries = CreativeSharesCache
+        .where(creative_id: bases.map(&:id), user_id: [ Current.user.id, nil ])
+        .to_a
+
+      bases.any? do |base|
+        entry = entries.find { |e| e.creative_id == base.id && e.user_id == Current.user.id } ||
+                entries.find { |e| e.creative_id == base.id && e.user_id.nil? }
+        entry && !entry.no_access? && CreativeSharesCache.permissions[entry.permission] >= write_rank
       end
     end
   end

--- a/engines/collavre/app/jobs/collavre/trigger_loop_check_job.rb
+++ b/engines/collavre/app/jobs/collavre/trigger_loop_check_job.rb
@@ -86,17 +86,34 @@ module Collavre
     # These are NOT valid task results — the agent never actually worked.
     MAX_INFRA_RETRIES = 3
 
-    INFRASTRUCTURE_ERROR_PATTERNS = [
-      /OpenClaw Error/i,
+    # Generic, vendor-neutral infrastructure-error signatures. Vendor engines
+    # register their own provider-specific signatures (e.g. an OpenClaw gateway
+    # error banner) via register_infrastructure_error_pattern, so core names no
+    # vendor here.
+    BUILTIN_INFRASTRUCTURE_ERROR_PATTERNS = [
       /(?:request|connection|server)\s+timed?\s*out/i,
       /connection\s*(refused|reset|closed)/i,
       /internal\s*server\s*error/i,
       /\b50[234]\b.*(?:error|gateway|unavailable)/i
     ].freeze
 
+    class << self
+      def registered_infrastructure_error_patterns
+        @registered_infrastructure_error_patterns ||= []
+      end
+
+      def register_infrastructure_error_pattern(pattern)
+        registered_infrastructure_error_patterns << pattern unless registered_infrastructure_error_patterns.include?(pattern)
+      end
+
+      def infrastructure_error_patterns
+        BUILTIN_INFRASTRUCTURE_ERROR_PATTERNS + registered_infrastructure_error_patterns
+      end
+    end
+
     def infrastructure_error?(comment)
       content = comment.content.to_s
-      INFRASTRUCTURE_ERROR_PATTERNS.any? { |pattern| content.match?(pattern) }
+      self.class.infrastructure_error_patterns.any? { |pattern| content.match?(pattern) }
     end
 
     # Retry without consuming an iteration — the agent never actually worked.

--- a/engines/collavre/app/jobs/collavre/update_mcp_tools_job.rb
+++ b/engines/collavre/app/jobs/collavre/update_mcp_tools_job.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Collavre
+  # Re-derives a creative's MCP tool definitions from its description HTML.
+  # Runs off the request/save path (enqueued from Creative after_commit) so the
+  # Nokogiri parsing and tool upserts never block a synchronous save.
+  class UpdateMcpToolsJob < ApplicationJob
+    queue_as :default
+
+    def perform(creative_id)
+      creative = Creative.find_by(id: creative_id)
+      return unless creative
+
+      McpService.new.update_from_creative(creative)
+    end
+  end
+end

--- a/engines/collavre/app/models/collavre/creative.rb
+++ b/engines/collavre/app/models/collavre/creative.rb
@@ -153,7 +153,14 @@ module Collavre
 
     after_save :update_parent_progress
     after_destroy :update_parent_progress
-    after_save :update_mcp_tools
+    # Re-derive MCP tools only when the description (the tool source of truth)
+    # actually changed, and defer the HTML parsing to a background job so it
+    # never runs inline on progress/move/autosave writes. The dirty flag is
+    # captured in after_save (where saved_change_to_description? is reliable);
+    # a later same-transaction save can clobber saved_changes before the
+    # after_commit hook runs.
+    after_save :mark_mcp_tools_sync_pending, if: :saved_change_to_description?
+    after_commit :enqueue_mcp_tools_sync, if: :mcp_tools_sync_pending?
 
     # --- Drop Trigger ---
     def drop_trigger_enabled?
@@ -312,8 +319,17 @@ module Collavre
       @progress_service ||= Collavre::Creatives::ProgressService.new(self)
     end
 
-    def update_mcp_tools
-      McpService.new.update_from_creative(self)
+    def mark_mcp_tools_sync_pending
+      @mcp_tools_sync_pending = true
+    end
+
+    def mcp_tools_sync_pending?
+      @mcp_tools_sync_pending == true
+    end
+
+    def enqueue_mcp_tools_sync
+      @mcp_tools_sync_pending = false
+      UpdateMcpToolsJob.perform_later(id)
     end
 
     def progress_cannot_change_if_has_origin

--- a/engines/collavre/app/models/collavre/creative.rb
+++ b/engines/collavre/app/models/collavre/creative.rb
@@ -23,6 +23,20 @@ module Collavre
       def reserved_metadata_keys
         (BUILTIN_RESERVED_METADATA_KEYS + registered_reserved_metadata_keys).freeze
       end
+
+      # ------------------------------------------------------------------------
+      # Read-only source registry — vendor engines register the `data.source.type`
+      # values whose content is owned by an external system (e.g. a synced GitHub
+      # repository) and therefore must not be edited in-app. Core enforces the
+      # read-only behavior via `read_only_source?` without naming any vendor.
+      # ------------------------------------------------------------------------
+      def read_only_source_types
+        @read_only_source_types ||= Set.new
+      end
+
+      def register_read_only_source(type)
+        read_only_source_types << type.to_s
+      end
     end
 
     # Use non-namespaced partial path for backward compatibility
@@ -63,10 +77,28 @@ module Collavre
       data&.dig("kind") == "inbox"
     end
 
-    attr_accessor :skip_github_validation
+    # Bypass the read-only-source guard for a single save (used by the vendor
+    # sync services that legitimately write the synced content into core).
+    attr_accessor :skip_read_only_source_validation
 
+    # The registered source identifier for this creative, or nil when the
+    # description is authored in-app.
+    def source_type
+      data.is_a?(Hash) ? data.dig("source", "type") : nil
+    end
+
+    # Whether this creative's description is owned by an external, registered
+    # source and therefore read-only in-app.
+    def read_only_source?
+      type = source_type
+      type.present? && self.class.read_only_source_types.include?(type)
+    end
+
+    # GitHub-sourced content still needs a vendor-specific predicate for the
+    # comment view's inline-image rendering (a GitHub-only concern, distinct
+    # from the neutral read-only behavior above).
     def github_markdown?
-      data.is_a?(Hash) && data.dig("source", "type") == "github_markdown"
+      source_type == "github_markdown"
     end
 
     # Find or create the "System" topic for this inbox creative.

--- a/engines/collavre/app/models/collavre/creative/describable.rb
+++ b/engines/collavre/app/models/collavre/creative/describable.rb
@@ -18,7 +18,7 @@ module Collavre
 
         validates :description, presence: true, unless: -> { origin_id.present? }
         validate :description_cannot_change_if_has_origin, on: :update
-        validate :description_cannot_change_if_github_source, on: :update
+        validate :description_cannot_change_if_read_only_source, on: :update
 
         before_validation :convert_markdown_to_html
         before_save :sanitize_description_html
@@ -44,11 +44,11 @@ module Collavre
         CGI.unescapeHTML(ActionController::Base.helpers.strip_tags(effective_origin.description || "")).truncate(24, omission: "...")
       end
 
-      # GitHub-synced creatives reject any description change
-      # (description_cannot_change_if_github_source), so embedding would raise
+      # Read-only-source creatives reject any description change
+      # (description_cannot_change_if_read_only_source), so embedding would raise
       # and orphan the blob. Callers MUST check this before creating the blob.
       def attachments_embeddable?
-        !effective_origin.github_markdown?
+        !effective_origin.read_only_source?
       end
 
       # Append an attachment node and save; after_save reconcile attaches the
@@ -362,12 +362,12 @@ module Collavre
         end
       end
 
-      def description_cannot_change_if_github_source
+      def description_cannot_change_if_read_only_source
         return unless will_save_change_to_description?
-        return unless github_markdown?
-        return if @skip_github_validation
+        return unless read_only_source?
+        return if skip_read_only_source_validation
 
-        errors.add(:description, "cannot be changed directly for GitHub synced content")
+        errors.add(:description, "cannot be changed directly for read-only source content")
       end
     end
   end

--- a/engines/collavre/app/models/collavre/creative/describable.rb
+++ b/engines/collavre/app/models/collavre/creative/describable.rb
@@ -367,7 +367,7 @@ module Collavre
         return unless read_only_source?
         return if skip_read_only_source_validation
 
-        errors.add(:description, "cannot be changed directly for read-only source content")
+        errors.add(:description, I18n.t("collavre.creatives.errors.description_read_only_source"))
       end
     end
   end

--- a/engines/collavre/app/models/collavre/user.rb
+++ b/engines/collavre/app/models/collavre/user.rb
@@ -314,7 +314,24 @@ module Collavre
     # Destroy creatives deepest-first so closure_tree always finds its parent
     def destroy_creatives_leaf_first
       all_creatives = creatives.flat_map { |c| c.self_and_descendants.to_a }.uniq
-      all_creatives.sort_by { |c| -c.self_and_ancestors.count }.each do |c|
+
+      # Order by depth in memory. The subtree is contiguous within all_creatives
+      # (every node between an owned root and its descendant is itself a
+      # descendant), so following parent_id links yields the same leaf-first
+      # ordering as self_and_ancestors.count without firing a COUNT query per
+      # creative (the previous N+1).
+      by_id = all_creatives.index_by(&:id)
+      depth_of = lambda do |creative|
+        depth = 0
+        node = creative
+        while node&.parent_id && (parent = by_id[node.parent_id])
+          depth += 1
+          node = parent
+        end
+        depth
+      end
+
+      all_creatives.sort_by { |c| -depth_of.call(c) }.each do |c|
         c.reload.destroy! if Creative.exists?(c.id)
       end
     end

--- a/engines/collavre/app/models/collavre/user.rb
+++ b/engines/collavre/app/models/collavre/user.rb
@@ -132,12 +132,14 @@ module Collavre
     end
 
     # Whether this agent uses stateful sessions (incremental messaging).
-    # nil in agent_conf = auto-detect by vendor (openclaw → true).
+    # nil in agent_conf = auto-detect via the AiClient adapter layer, which
+    # vendor engines register into (core never string-matches a vendor name).
     def supports_session?
       explicit = parsed_agent_conf.dig("session", "enabled")
       return ActiveModel::Type::Boolean.new.cast(explicit) unless explicit.nil?
+      return false if llm_vendor.blank?
 
-      llm_vendor&.downcase == "openclaw"
+      Collavre::AiClient.vendor_supports_session?(llm_vendor)
     end
 
     encrypts :llm_api_key, deterministic: false
@@ -183,12 +185,17 @@ module Collavre
       device_on && location_on
     end
 
-    LLM_VENDOR_OPTIONS = [
-      [ "Google (Gemini)", "google" ],
-      [ "OpenAI", "openai" ],
-      [ "Anthropic", "anthropic" ],
-      [ "OpenClaw", "openclaw" ]
-    ].freeze
+    # LLM_VENDOR_OPTIONS is resolved dynamically from the AiClient vendor-option
+    # registry so core lists only its built-in providers while vendor engines
+    # (e.g. OpenClaw) contribute their own. Resolved lazily via const_missing so
+    # the value always reflects registrations made after this class first loads
+    # (they run in a to_prepare hook), and existing views keep referring to the
+    # constant unchanged.
+    def self.const_missing(name)
+      return Collavre::AiClient.vendor_options if name == :LLM_VENDOR_OPTIONS
+
+      super
+    end
 
     SUPPORTED_LLM_MODELS = [
       "gemini-3.1-flash-lite",

--- a/engines/collavre/app/services/collavre/ai_client.rb
+++ b/engines/collavre/app/services/collavre/ai_client.rb
@@ -10,6 +10,49 @@ module Collavre
 
     attr_reader :last_input_tokens, :last_output_tokens
 
+    # Vendor <select> options for AI-agent config. Core ships only its built-in
+    # (stateless) providers; vendor engines append their own through
+    # register_vendor_option, so core never names a vendor engine.
+    BASE_VENDOR_OPTIONS = [
+      [ "Google (Gemini)", "google" ],
+      [ "OpenAI", "openai" ],
+      [ "Anthropic", "anthropic" ]
+    ].freeze
+
+    class << self
+      def registered_vendor_options
+        @registered_vendor_options ||= []
+      end
+
+      # Append a vendor <select> option ([label, value]). Idempotent by value.
+      def register_vendor_option(label, value)
+        value = value.to_s
+        return if BASE_VENDOR_OPTIONS.any? { |_l, v| v == value }
+        return if registered_vendor_options.any? { |_l, v| v == value }
+
+        registered_vendor_options << [ label, value ]
+      end
+
+      def vendor_options
+        BASE_VENDOR_OPTIONS + registered_vendor_options
+      end
+
+      # Vendors that use stateful/incremental sessions. Base providers are
+      # stateless; vendor engines that add session support register here so core
+      # never string-matches a vendor name to decide session behavior.
+      def session_vendors
+        @session_vendors ||= Set.new
+      end
+
+      def register_session_vendor(vendor)
+        session_vendors << vendor.to_s.downcase
+      end
+
+      def vendor_supports_session?(vendor)
+        session_vendors.include?(vendor.to_s.downcase)
+      end
+    end
+
     # log_interactions: persist each call to ActivityLog. Default true. Pass false
     # for ephemeral, high-frequency calls on text the user has not submitted (e.g.
     # inline typo correction on debounced typing) so private drafts are never

--- a/engines/collavre/app/services/collavre/creatives/tree_builder.rb
+++ b/engines/collavre/app/services/collavre/creatives/tree_builder.rb
@@ -75,8 +75,8 @@ module Creatives
 
     def cached_can_write?(creative)
       return false unless user
-      # GitHub-synced creatives are always read-only
-      return false if creative.github_markdown?
+      # Read-only-source creatives are never writable
+      return false if creative.read_only_source?
 
       if @permission_cache.key?(creative.id)
         @permission_cache[creative.id]

--- a/engines/collavre/app/services/collavre/creatives/tree_builder.rb
+++ b/engines/collavre/app/services/collavre/creatives/tree_builder.rb
@@ -124,7 +124,10 @@ module Creatives
           expanded: expanded,
           is_root: creative.parent.nil?,
           archived: creative.archived?,
-          github_source: creative.github_markdown?,
+          # `github_source` is the wire key the tree renderer JS reads; its value
+          # is now the neutral read-only-source flag (GitHub-synced content is one
+          # such source) so core names no vendor here.
+          github_source: creative.read_only_source?,
           sequence: creative.sequence,
           link_url: view_context.collavre.creative_path(creative),
           templates: template_payload_for(creative, has_children: filtered_children.any?),

--- a/engines/collavre/config/locales/creatives.en.yml
+++ b/engines/collavre/config/locales/creatives.en.yml
@@ -160,6 +160,8 @@ en:
       errors:
         no_permission: You do not have permission to perform this action.
         metadata_must_be_object: Metadata must be an object.
+        description_read_only_source: cannot be changed directly for read-only source
+          content
       inline_editor:
         placeholder: Describe the creative…
         markdown_placeholder: Write in Markdown…

--- a/engines/collavre/config/locales/creatives.ko.yml
+++ b/engines/collavre/config/locales/creatives.ko.yml
@@ -146,6 +146,7 @@ ko:
       errors:
         no_permission: 이 작업을 수행할 권한이 없습니다.
         metadata_must_be_object: 메타데이터는 객체여야 합니다.
+        description_read_only_source: 읽기 전용 소스 콘텐츠는 직접 변경할 수 없습니다
       inline_editor:
         placeholder: 크리에이티브를 설명해주세요…
         markdown_placeholder: 마크다운으로 작성…

--- a/engines/collavre/db/migrate/20260120045354_encrypt_oauth_tokens.rb
+++ b/engines/collavre/db/migrate/20260120045354_encrypt_oauth_tokens.rb
@@ -7,12 +7,21 @@ class EncryptOauthTokens < ActiveRecord::Migration[8.1]
       encrypt_column(User, :google_refresh_token)
     end
 
-    say_with_time "Encrypting GithubAccount tokens" do
-      encrypt_column(GithubAccount, :token)
+    # Vendor account tokens live in vendor engines. Guard each block so this
+    # core migration runs cleanly on an install where the engine is absent
+    # (the constant would otherwise raise NameError). When the engine is
+    # present on a fresh DB there are no plaintext rows yet, so the block is a
+    # no-op; encryption of new writes is handled by the model's `encrypts`.
+    if defined?(CollavreGithub::Account)
+      say_with_time "Encrypting CollavreGithub::Account tokens" do
+        encrypt_column(CollavreGithub::Account, :token)
+      end
     end
 
-    say_with_time "Encrypting NotionAccount tokens" do
-      encrypt_column(CollavreNotion::NotionAccount, :token)
+    if defined?(CollavreNotion::NotionAccount)
+      say_with_time "Encrypting CollavreNotion::NotionAccount tokens" do
+        encrypt_column(CollavreNotion::NotionAccount, :token)
+      end
     end
   end
 

--- a/engines/collavre_github/app/services/collavre_github/markdown_sync/incremental_sync_service.rb
+++ b/engines/collavre_github/app/services/collavre_github/markdown_sync/incremental_sync_service.rb
@@ -73,7 +73,7 @@ module CollavreGithub
             "sha" => @tree_cache[path]
           )
           source.delete("rendered_html")
-          creative.skip_github_validation = true
+          creative.skip_read_only_source_validation = true
           creative.update!(data: creative.data.merge("source" => source))
 
           processed, blobs = processor.process(content, path)
@@ -107,7 +107,7 @@ module CollavreGithub
               }
             }
           )
-          creative.skip_github_validation = true
+          creative.skip_read_only_source_validation = true
           creative.save!
           @synced_creatives[path] = creative
 
@@ -216,7 +216,7 @@ module CollavreGithub
                 }
               }
             )
-            dir_creative.skip_github_validation = true
+            dir_creative.skip_read_only_source_validation = true
             dir_creative.save!
             @synced_creatives[dir_path] = dir_creative
             new_dirs << dir_creative

--- a/engines/collavre_github/app/services/collavre_github/markdown_sync/initial_import_service.rb
+++ b/engines/collavre_github/app/services/collavre_github/markdown_sync/initial_import_service.rb
@@ -63,7 +63,7 @@ module CollavreGithub
               }
             }
           )
-          creative.skip_github_validation = true
+          creative.skip_read_only_source_validation = true
           creative.save!
           file_creatives << creative
           created << creative
@@ -114,7 +114,7 @@ module CollavreGithub
             }
           }
         )
-        creative.skip_github_validation = true
+        creative.skip_read_only_source_validation = true
         creative.save!
         creative
       end
@@ -175,7 +175,7 @@ module CollavreGithub
                 }
               }
             )
-            dir_creative.skip_github_validation = true
+            dir_creative.skip_read_only_source_validation = true
             dir_creative.save!
             dir_map[current_path] = dir_creative
             created << dir_creative

--- a/engines/collavre_github/config/initializers/read_only_source.rb
+++ b/engines/collavre_github/config/initializers/read_only_source.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# GitHub-synced Markdown creatives are read-only in Collavre: their description
+# is owned by the upstream repository and must not be edited in-app. Register
+# the source type into the core read-only-source registry so core enforces the
+# read-only behavior (validation, attachment embedding, tree write flags)
+# without naming GitHub. Runs on boot and every reload so the registration
+# survives Zeitwerk clearing Collavre::Creative's class state.
+Rails.application.config.to_prepare do
+  if defined?(Collavre::Creative)
+    Collavre::Creative.register_read_only_source("github_markdown")
+  end
+end

--- a/engines/collavre_openclaw/config/initializers/ai_client_extension.rb
+++ b/engines/collavre_openclaw/config/initializers/ai_client_extension.rb
@@ -11,5 +11,16 @@ Rails.application.config.to_prepare do
       Collavre::AiClient.register_adapter("openclaw", CollavreOpenclaw::OpenclawAdapter)
       Rails.logger.info("[CollavreOpenclaw] Registered OpenClaw adapter")
     end
+
+    # OpenClaw uses stateful, incremental sessions and appears in the AI-agent
+    # vendor dropdown. Register both into core so core needs no OpenClaw name of
+    # its own to decide session support or list the vendor. Both registrations
+    # are idempotent, so re-running on reload is safe.
+    if Collavre::AiClient.respond_to?(:register_session_vendor)
+      Collavre::AiClient.register_session_vendor("openclaw")
+    end
+    if Collavre::AiClient.respond_to?(:register_vendor_option)
+      Collavre::AiClient.register_vendor_option("OpenClaw", "openclaw")
+    end
   end
 end

--- a/engines/collavre_openclaw/config/initializers/trigger_loop_patterns.rb
+++ b/engines/collavre_openclaw/config/initializers/trigger_loop_patterns.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# An OpenClaw gateway error banner marks a task result the agent never actually
+# produced, so the trigger loop must retry it without consuming an iteration.
+# Register the OpenClaw-specific signature into the core trigger-loop infra-error
+# registry so core keeps only vendor-neutral patterns. Runs on boot and every
+# reload; registration is idempotent.
+Rails.application.config.to_prepare do
+  if defined?(Collavre::TriggerLoopCheckJob)
+    Collavre::TriggerLoopCheckJob.register_infrastructure_error_pattern(/OpenClaw Error/i)
+  end
+end


### PR DESCRIPTION
## Summary
Makes the core `collavre` engine vendor-neutral: removes hard-coded GitHub/OpenClaw assumptions from core models and jobs, and guards vendor constants in a core migration.

## Changes
- Gate `creative.rb` after_save on `saved_change_to_description?`, move to after_commit + job.
- Replace the "GitHub read-only" concept with a source registry (`read_only_source?`).
- Delegate vendor session support + LLM vendor options to the AiClient registry (removes OpenClaw string-matching).
- Neutralize `tree_builder` `github_source` key and trigger-loop infra regex.
- Eliminate N+1 in attachment auth and user destroy.
- **Blocker fix:** guard vendor constants in the core `encrypt_oauth_tokens` migration (`if defined?`) so core migrations don't reference vendor engines.

## Test
- Targeted tests green; full pre-push suite gate.

Part of the "기술적 완성도" hardening batch. 🤖 Generated with Claude Code.
