### PR TITLE
refactor(collavre): decompose creatives & agents god controllers into services

### DIFF
--- a/engines/collavre/app/controllers/collavre/api/v1/agents_controller.rb
+++ b/engines/collavre/app/controllers/collavre/api/v1/agents_controller.rb
@@ -29,14 +29,14 @@ module Collavre
             return
           end
 
-          ai_user = find_or_create_session_agent(agent_name)
+          ai_user = session_provisioner.find_or_create_agent(agent_name)
           unless ai_user
             render json: { error: "Session agent email is already in use by a different account" }, status: :conflict
             return
           end
 
           inbox = Creative.inbox_for(current_user)
-          topic = find_or_create_session_topic(inbox, ai_user, session_id, params[:session_label])
+          topic = session_provisioner.find_or_create_topic(inbox, ai_user, session_id, params[:session_label])
           topic.unarchive! if topic.archived?
           topic.set_primary_agent!(ai_user)
 
@@ -202,7 +202,7 @@ module Collavre
           )
 
           if comment.save
-            finalize_claimed_task(agent, claimed_task, comment) if claimed_task
+            task_claim_service.finalize(agent: agent, task: claimed_task, comment: comment) if claimed_task
             dispatch_a2a(agent, comment)
             render json: { comment_id: comment.id }, status: :created
           else
@@ -463,90 +463,6 @@ module Collavre
           nil
         end
 
-        # Atomically claim a delegated task for completion. Two-step:
-        #   1. Find a candidate task in delegated state, scoped to this
-        #      agent + topic. With task_id supplied, exact match (required
-        #      under topic concurrency > 1 where multiple delegated tasks
-        #      coexist; the client echoes the dispatch's task_id). Without
-        #      task_id (legacy clients), oldest-first.
-        #   2. Inside a transaction: SELECT FOR UPDATE the row, re-check
-        #      status == 'delegated' under the lock, then update! to 'done'.
-        #      Concurrent claimers block on the lock; the loser sees the
-        #      already-flipped status post-lock and returns nil so the
-        #      caller can refuse the duplicate.
-        # update_all (NOT update!) is required to skip Task's
-        # after_update_commit callbacks at claim time. The callbacks fire
-        # check_trigger_loop_completion (which enqueues TriggerLoopCheckJob)
-        # and broadcast_stop_button_removal (which reads reply_comment).
-        # Both depend on the reply comment already existing — but reply()
-        # claims BEFORE comment.save to win the race against concurrent
-        # /reply calls. If update! fired the trigger-loop check here, the
-        # job could run (cooldown_seconds: 0) before comment.save commits,
-        # find no agent comment, and leave the loop stuck in "running".
-        # finalize_claimed_task replays both callbacks after the comment is
-        # persisted via Task#fire_completion_callbacks_after_external_claim.
-        def claim_delegated_task(agent, topic, requested_task_id)
-          scope = Task.where(agent_id: agent.id, topic_id: topic.id, status: "delegated")
-          candidate =
-            if requested_task_id.present?
-              scope.find_by(id: requested_task_id)
-            else
-              scope.order(:created_at).first
-            end
-          return nil unless candidate
-
-          claimed = nil
-          Task.transaction do
-            locked = Task.lock.find_by(id: candidate.id)
-            next unless locked && locked.status == "delegated"
-
-            Task.where(id: locked.id).update_all(status: "done", pending_tool_call: nil, updated_at: Time.current)
-            claimed = locked.reload
-          end
-          claimed
-        end
-
-        # Post-claim side effects, run only after the reply comment is saved.
-        # Links the comment to the claimed task, releases the ResourceTracker
-        # slot the AiAgentJob held under task.id, advances the parent
-        # workflow (if any), and drains the topic queue — mirroring
-        # AiAgentJob#perform's success path for non-delegated runs.
-        def finalize_claimed_task(agent, task, comment)
-          comment.update_column(:task_id, task.id)
-
-          Orchestration::ResourceTracker.for(agent).release!(task.id)
-
-          if task.parent_task_id.present?
-            Collavre::Comments::WorkflowExecutor.new(task.parent_task).complete_subtask!(task)
-          end
-
-          Orchestration::AgentOrchestrator.dequeue_next_for_topic(task.topic_id, task.creative_id)
-
-          # Replay the after_update_commit callbacks that were bypassed by
-          # update_all in claim_delegated_task — now that the reply comment
-          # is linked, TriggerLoopCheckJob can read it and decide whether to
-          # advance/await/complete the drop-trigger loop, and the stop-button
-          # broadcast has a comment to render.
-          task.fire_completion_callbacks_after_external_claim
-
-          # Clear the typing indicator immediately on reply. ClaudeChannelPresenceJob
-          # would also stop on its next beat (task no longer "delegated"), but that
-          # is up to HEARTBEAT_SECONDS away — broadcast idle now so the indicator
-          # drops the moment Claude's reply lands.
-          broadcast_claude_idle(agent, task, comment)
-        end
-
-        # Clear the chat typing indicator via the canonical status broadcaster
-        # (the same one AiAgentService uses for every other agent), so the Claude
-        # path emits an identical "idle" agent_status payload.
-        def broadcast_claude_idle(agent, task, comment)
-          creative = comment.creative&.effective_origin
-          return unless creative
-
-          AiAgent::AgentLifecycleManager.new(task: task, agent: agent, creative: creative)
-                                        .broadcast_status("idle")
-        end
-
         # When an MCP session unregisters, any tasks still in delegated state
         # are abandoned — the client that would have called /reply is gone.
         # Mirror the cancel path so the agent's slot and each topic's queue
@@ -665,111 +581,24 @@ module Collavre
           ).dispatch
         end
 
-        # Deterministic, collision-free email key for a (current_user, agent_name)
-        # agent. The readable slug is lossy — "qa/bot", "qa bot" and "qa--bot" all
-        # squeeze to "qa-bot", and any all-symbol name collapses to "session" — so
-        # a short digest of the normalized raw name disambiguates distinct
-        # configured names that would otherwise alias onto ONE shared agent
-        # identity (ActionCable stream, routing state, tasks, creative shares).
-        # The slug stays for human readability; the digest decides identity. Same
-        # normalized name -> same key, so idempotent re-register/reuse is
-        # preserved. Normalization (strip+downcase) keeps case/whitespace-only
-        # differences folded, matching the prior behavior — only the lossy
-        # punctuation/spacing collapse is fixed.
-        def session_agent_email(agent_name)
-          normalized = agent_name.to_s.strip.downcase
-          slug = normalized.gsub(/[^a-z0-9-]+/, "-").squeeze("-").gsub(/\A-|-\z/, "")
-          slug = "session" if slug.blank?
-          digest = Digest::SHA256.hexdigest(normalized)[0, 10]
-          "claude-channel-#{current_user.id}-#{slug}-#{digest}@agent.collavre.local"
+        # Provisions the (agent, topic) identities for a Claude Code
+        # registration. Memoized per request; behavior extracted verbatim.
+        def session_provisioner
+          @session_provisioner ||= AiAgent::SessionProvisioner.new(current_user)
         end
 
-        # One ai_user per (current_user, agent_name) so a human's sessions share
-        # one Agent identity. Same agent_name re-registering reuses the existing
-        # row — idempotent retries (and every additional session) don't
-        # proliferate agents.
-        #
-        # Returns nil when a row with the deterministic email already exists
-        # but is owned by someone else or isn't a Claude Channel ai_user. The
-        # email format is human-derivable (current_user.id + slug + digest), so a
-        # foreign row could be planted by signup/import; silently reusing it
-        # would attach the caller's inbox feedback share to that foreign User
-        # and leave the plugin's AgentChannel subscription rejected on
-        # ownership mismatch. Caller renders 409 in that case.
-        def find_or_create_session_agent(agent_name)
-          email = session_agent_email(agent_name)
-
-          existing = User.find_by(email: email)
-          return verified_session_agent(existing) if existing
-
-          # routing_expression: nil so the new ai_user is not matchable until
-          # the client claims the per-agent stream via AgentChannel. See the
-          # comment on verified_session_agent.
-          User.create!(
-            email: email,
-            name: "Claude Channel (#{agent_name})",
-            password: SecureRandom.hex(32),
-            llm_vendor: "anthropic",
-            llm_model: "claude-code",
-            created_by_id: current_user.id,
-            searchable: false,
-            routing_expression: nil
-          )
-        rescue ActiveRecord::RecordNotUnique
-          # A concurrent registration for the same (user, agent_name) won the
-          # users.email unique race. The desired row now exists — re-find and
-          # re-verify ownership instead of surfacing a 500 that aborts one of the
-          # two simultaneously launching plugin instances.
-          verified_session_agent(User.find_by(email: email))
+        # Claims and finalizes delegated tasks on /reply. Stateless, so a single
+        # instance is reused for the request.
+        def task_claim_service
+          @task_claim_service ||= AiAgent::TaskClaimService.new
         end
 
-        # Returns the agent only when it is the current user's own Claude Channel
-        # agent; nil otherwise (the caller renders :conflict). Routing activation
-        # stays deferred to AgentChannel#subscribe_to_agent_stream so the agent
-        # becomes matchable only once a WebSocket subscriber exists for
-        # agent:user:<id> — otherwise comments matched between this POST returning
-        # and the client's subsequent cable subscribe would broadcast into an
-        # empty stream, stranding delegated tasks until stuck recovery.
-        def verified_session_agent(ai_user)
-          return nil unless ai_user &&
-                            ai_user.created_by_id == current_user.id &&
-                            ai_user.ai_user? &&
-                            ai_user.claude_channel_agent?
-
-          ai_user
-        end
-
-        # One Topic per (agent, session_id). On re-register (including --resume
-        # from the same cwd, which yields the same session_id) the existing
-        # topic is reused — even if archived — so the conversation persists
-        # instead of orphaning. A fresh session gets a new topic under the same
-        # shared agent, which is how one agent fans out to many sessions.
-        def find_or_create_session_topic(inbox, ai_user, session_id, session_label)
-          existing = inbox.topics.find_by(primary_agent_id: ai_user.id, session_id: session_id)
-          return existing if existing
-
-          label = session_label.to_s.strip.presence || session_id
-          inbox.topics.create!(
-            name: unique_topic_name(inbox, "Claude #{label}"),
-            user: current_user,
-            primary_agent_id: ai_user.id,
-            session_id: session_id
-          )
-        end
-
-        # Topics carry a UNIQUE (creative_id, name) index, so two sessions whose
-        # friendly labels collide (e.g. both rooted at a dir named "src") cannot
-        # share a name. Append the smallest numeric suffix that is free.
-        def unique_topic_name(inbox, desired)
-          return desired unless inbox.topics.exists?(name: desired)
-
-          n = 2
-          loop do
-            candidate = "#{desired} (#{n})"
-            return candidate unless inbox.topics.exists?(name: candidate)
-
-            n += 1
-          end
+        # Thin delegator to TaskClaimService#claim. Kept as a controller method
+        # (rather than calling the service inline in #reply) so the concurrency
+        # test that patches AgentsController#claim_delegated_task to inject a race
+        # keeps exercising the same seam.
+        def claim_delegated_task(agent, topic, requested_task_id)
+          task_claim_service.claim(agent: agent, topic: topic, requested_task_id: requested_task_id)
         end
       end
     end

--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -592,102 +592,15 @@ module Collavre
           params[:show_archived].present?
       end
 
+      # Thin delegator to Creatives::CreativeTreeSerializer. Kept as a controller
+      # method (rather than inlining the service call at the index call site) so
+      # the picker test that drives serialization via controller.send(:serialize_creatives, ...)
+      # keeps exercising the same seam.
       def serialize_creatives(collection)
-        if params[:simple].present?
-          # Preload origins so effective_origin (used per linked-shell row in both
-          # children_presence_set and the origin_id mapping below) resolves from
-          # memory instead of firing a query per shell. Only browse can hold shells;
-          # search is scoped to origin_id: nil, so this is a no-op there.
-          ActiveRecord::Associations::Preloader.new(records: collection.to_a, associations: :origin).call
-          children_ids = children_presence_set(collection)
-          searching = params[:search].present?
-          breadcrumbs = searching ? ::Creatives::BreadcrumbResolver.new(collection.map(&:id), user: Current.user, include_archived: params[:show_archived].present?).call : {}
-          # For hits routed through a linked shell, the path to expand in the
-          # user's own tree (local folders -> shell) so a breadcrumb jump can
-          # reach a shell nested under a collapsed folder.
-          reveal_paths = searching ? ::Creatives::RevealPathResolver.new(collection.map(&:id), user: Current.user, include_archived: params[:show_archived].present?).call : {}
-          collection.map do |c|
-            item = {
-              id: c.id,
-              description: c.effective_description(nil, false),
-              progress: c.progress,
-              has_children: children_ids.include?(c.id)
-            }
-            reveal = reveal_paths[c.id]
-            path = breadcrumbs[c.id]
-            if path.present?
-              item[:path] = mask_unreachable_crumbs(path, reveal)
-            end
-            item[:reveal_path] = reveal if reveal.present?
-            # For linked shells, expose the effective origin id so the picker can
-            # map a search breadcrumb (origin ids) back to the rendered shell node.
-            item[:origin_id] = c.effective_origin.id if c.origin_id
-            item
-          end
-        else
-          collection.map { |c| { id: c.id, description: c.effective_description, progress: c.progress } }
-        end
-      end
-
-      # A breadcrumb jump expands the tree from a rendered root (or, for a shared
-      # subtree, a linked shell) down to the clicked crumb. If an ancestor above a
-      # crumb is itself unrenderable (unreadable, or archived while archived rows
-      # aren't shown) and no linked shell re-roots the path at/below it, the
-      # descendant can't be expanded either — so mask it too. BreadcrumbResolver
-      # masks the unrenderable ancestor itself; this masks everything downstream of
-      # it on the plain origin chain, matching exactly what the tree can render.
-      #
-      # `reveal` is RevealPathResolver's per-origin map: a crumb whose origin id is
-      # a key re-roots navigation through its own shell (the client anchors at the
-      # nearest reveal entry at/above the clicked crumb), so it clears the block for
-      # itself and its descendants regardless of an archived/unreadable origin
-      # above it.
-      def mask_unreachable_crumbs(path, reveal)
-        blocked = false
-        path.map do |crumb|
-          if reveal&.key?(crumb[:id])
-            blocked = false
-            crumb
-          elsif crumb[:restricted]
-            blocked = true
-            crumb
-          elsif blocked
-            crumb.merge(restricted: true, description: nil)
-          else
-            crumb
-          end
-        end
-      end
-
-      # Batched "does this node have a child the user can actually browse to?"
-      # lookup so the picker tree renders expand toggles without an N+1.
-      #
-      # Must match exactly what expanding the node shows (IndexQuery#handle_id_query
-      # -> children_with_permission, minus archived unless show_archived), or the
-      # toggle either hides a reachable subtree or opens to an empty branch (and
-      # leaks that hidden children exist). Two alignments are needed:
-      #   1. Linked shells (origin_id set) store children under the effective
-      #      origin (redirect_parent_to_origin + children->origin migration), so
-      #      resolve each row to its effective origin before the lookup.
-      #   2. Apply the same archived + read-permission filters as the browse path.
-      def children_presence_set(collection)
-        return Set.new if collection.empty?
-
-        origin_id_by_id = collection.to_h { |c| [ c.id, c.effective_origin.id ] }
-
-        candidates = Creative.where(parent_id: origin_id_by_id.values.uniq)
-        candidates = candidates.where(archived_at: nil) unless params[:show_archived]
-        child_rows = candidates.pluck(:id, :parent_id) # [child_id, origin_id]
-        return Set.new if child_rows.empty?
-
-        readable = ::Creatives::PermissionFilter
-          .new(user: Current.user).readable_ids(child_rows.map(&:first)).to_set
-        origins_with_visible_children = child_rows
-          .each_with_object(Set.new) { |(child_id, origin_id), set| set << origin_id if readable.include?(child_id) }
-
-        collection.each_with_object(Set.new) do |c, set|
-          set << c.id if origins_with_visible_children.include?(origin_id_by_id[c.id])
-        end
+        # Fully-qualified name: this newly extracted service is not registered in
+        # config/initializers/collavre_model_aliases.rb, so the top-level
+        # ::Creatives::* alias used by the older sibling services is unavailable.
+        Collavre::Creatives::CreativeTreeSerializer.new(user: Current.user, params: params).serialize(collection)
       end
 
       def reorderer

--- a/engines/collavre/app/controllers/collavre/creatives_controller.rb
+++ b/engines/collavre/app/controllers/collavre/creatives_controller.rb
@@ -6,8 +6,15 @@ module Collavre
     include Collavre::Concerns::Shareable
     include Collavre::CreativePermissionGuard
 
-    # TODO: for not for security reasons for this Collavre app, we don't expose to public, later it should be controlled by roles for each Creatives
-    # Removed unauthenticated access to index and show actions
+    # Authorization for these read actions is not open-to-public: each action
+    # enforces per-Creative read access via has_permission?(Current.user, :read)
+    # (index/children go through Creatives::IndexQuery, which permission-filters;
+    # show/slide_view/export_markdown check has_permission? directly). Anonymous
+    # requests only ever see Creatives whose share grants public read. Requiring
+    # a login for all reads is gated by SystemSetting.creatives_login_required?
+    # via enforce_creatives_login_policy below. A broader per-Creative role model
+    # (beyond the read/feedback/write/admin share levels) is a product decision
+    # tracked separately and intentionally deferred.
     allow_unauthenticated_access only: %i[ index children export_markdown show slide_view ]
     before_action :enforce_creatives_login_policy, only: %i[ index children export_markdown show slide_view ]
     before_action :set_creative, only: %i[ show edit update destroy parent_suggestions slide_view request_permission unconvert contexts update_contexts update_metadata archive unarchive trigger_action ]
@@ -39,7 +46,7 @@ module Collavre
           else
             {}
           end
-          index_result = ::Creatives::IndexQuery.new(user: Current.user, params: params.to_unsafe_h).call
+          index_result = ::Creatives::IndexQuery.new(user: Current.user, params: index_query_params).call
           @creatives = index_result.creatives || []
           @parent_creative = index_result.parent_creative
           @shared_creative = index_result.shared_creative
@@ -555,6 +562,19 @@ module Collavre
 
       def creative_params
         params.require(:creative).permit(:description, :progress, :parent_id, :sequence, :origin_id, :markdown_source, :content_type_input, :markdown_editor)
+      end
+
+      # Whitelist of query parameters consumed by Creatives::IndexQuery and its
+      # FilterPipeline. Passing an explicitly permitted hash (rather than
+      # params.to_unsafe_h) keeps arbitrary client-supplied keys out of the
+      # query layer while preserving every filter the index endpoint supports.
+      def index_query_params
+        params.permit(
+          :id, :simple, :search, :search_mode, :comment, :has_comments,
+          :min_progress, :max_progress, :due_before, :due_after, :has_due_date,
+          :assignee_id, :unassigned, :show_archived, :page, :per_page,
+          tags: []
+        ).to_h
       end
 
       def any_filter_active?

--- a/engines/collavre/app/services/collavre/agent_type_classifier.rb
+++ b/engines/collavre/app/services/collavre/agent_type_classifier.rb
@@ -1,0 +1,23 @@
+module Collavre
+  # Classifies an AI user/agent into a coarse role type by scanning its
+  # system prompt. Shared by the orchestration and system-events context
+  # builders so the prompt-to-type mapping lives in exactly one place.
+  module AgentTypeClassifier
+    module_function
+
+    # Returns the agent type string ("developer", "pm", "qa", "researcher",
+    # "marketer", "planner") or "agent" as the default when nothing matches.
+    def classify(user)
+      prompt = user.system_prompt.to_s.downcase
+      case prompt
+      when /developer|개발/ then "developer"
+      when /pm|project.?manager|프로젝트/ then "pm"
+      when /qa|test|quality|테스트|품질/ then "qa"
+      when /research|조사|연구/ then "researcher"
+      when /market|마케팅/ then "marketer"
+      when /plan|기획/ then "planner"
+      else "agent"
+      end
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/ai_agent/session_provisioner.rb
+++ b/engines/collavre/app/services/collavre/ai_agent/session_provisioner.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+module Collavre
+  module AiAgent
+    # Provisions the identities a Claude Code registration needs:
+    #   - one shared ai_user per (human, agent_name) — the Agent identity
+    #   - one Topic per (agent, session_id) — the Session identity
+    #
+    # Extracted from Api::V1::AgentsController#register so the action stays a
+    # thin orchestration of provisioning + inbox share. Behavior is identical to
+    # the inlined controller methods it replaces.
+    class SessionProvisioner
+      def initialize(user)
+        @user = user
+      end
+
+      # One ai_user per (user, agent_name) so a human's sessions share one Agent
+      # identity. Same agent_name re-registering reuses the existing row —
+      # idempotent retries (and every additional session) don't proliferate
+      # agents.
+      #
+      # Returns nil when a row with the deterministic email already exists but is
+      # owned by someone else or isn't a Claude Channel ai_user. The email format
+      # is human-derivable (user.id + slug + digest), so a foreign row could be
+      # planted by signup/import; silently reusing it would attach the caller's
+      # inbox feedback share to that foreign User and leave the plugin's
+      # AgentChannel subscription rejected on ownership mismatch. Caller renders
+      # 409 in that case.
+      def find_or_create_agent(agent_name)
+        email = session_agent_email(agent_name)
+
+        existing = User.find_by(email: email)
+        return verified_agent(existing) if existing
+
+        # routing_expression: nil so the new ai_user is not matchable until the
+        # client claims the per-agent stream via AgentChannel. See the comment on
+        # verified_agent.
+        User.create!(
+          email: email,
+          name: "Claude Channel (#{agent_name})",
+          password: SecureRandom.hex(32),
+          llm_vendor: "anthropic",
+          llm_model: "claude-code",
+          created_by_id: @user.id,
+          searchable: false,
+          routing_expression: nil
+        )
+      rescue ActiveRecord::RecordNotUnique
+        # A concurrent registration for the same (user, agent_name) won the
+        # users.email unique race. The desired row now exists — re-find and
+        # re-verify ownership instead of surfacing a 500 that aborts one of the
+        # two simultaneously launching plugin instances.
+        verified_agent(User.find_by(email: email))
+      end
+
+      # One Topic per (agent, session_id). On re-register (including --resume from
+      # the same cwd, which yields the same session_id) the existing topic is
+      # reused — even if archived — so the conversation persists instead of
+      # orphaning. A fresh session gets a new topic under the same shared agent,
+      # which is how one agent fans out to many sessions.
+      def find_or_create_topic(inbox, ai_user, session_id, session_label)
+        existing = inbox.topics.find_by(primary_agent_id: ai_user.id, session_id: session_id)
+        return existing if existing
+
+        label = session_label.to_s.strip.presence || session_id
+        inbox.topics.create!(
+          name: unique_topic_name(inbox, "Claude #{label}"),
+          user: @user,
+          primary_agent_id: ai_user.id,
+          session_id: session_id
+        )
+      end
+
+      private
+
+      # Deterministic, collision-free email key for a (user, agent_name) agent.
+      # The readable slug is lossy — "qa/bot", "qa bot" and "qa--bot" all squeeze
+      # to "qa-bot", and any all-symbol name collapses to "session" — so a short
+      # digest of the normalized raw name disambiguates distinct configured names
+      # that would otherwise alias onto ONE shared agent identity (ActionCable
+      # stream, routing state, tasks, creative shares). The slug stays for human
+      # readability; the digest decides identity. Same normalized name -> same
+      # key, so idempotent re-register/reuse is preserved. Normalization
+      # (strip+downcase) keeps case/whitespace-only differences folded, matching
+      # the prior behavior — only the lossy punctuation/spacing collapse is fixed.
+      def session_agent_email(agent_name)
+        normalized = agent_name.to_s.strip.downcase
+        slug = normalized.gsub(/[^a-z0-9-]+/, "-").squeeze("-").gsub(/\A-|-\z/, "")
+        slug = "session" if slug.blank?
+        digest = Digest::SHA256.hexdigest(normalized)[0, 10]
+        "claude-channel-#{@user.id}-#{slug}-#{digest}@agent.collavre.local"
+      end
+
+      # Returns the agent only when it is the current user's own Claude Channel
+      # agent; nil otherwise (the caller renders :conflict). Routing activation
+      # stays deferred to AgentChannel#subscribe_to_agent_stream so the agent
+      # becomes matchable only once a WebSocket subscriber exists for
+      # agent:user:<id> — otherwise comments matched between register returning
+      # and the client's subsequent cable subscribe would broadcast into an empty
+      # stream, stranding delegated tasks until stuck recovery.
+      def verified_agent(ai_user)
+        return nil unless ai_user &&
+                          ai_user.created_by_id == @user.id &&
+                          ai_user.ai_user? &&
+                          ai_user.claude_channel_agent?
+
+        ai_user
+      end
+
+      # Topics carry a UNIQUE (creative_id, name) index, so two sessions whose
+      # friendly labels collide (e.g. both rooted at a dir named "src") cannot
+      # share a name. Append the smallest numeric suffix that is free.
+      def unique_topic_name(inbox, desired)
+        return desired unless inbox.topics.exists?(name: desired)
+
+        n = 2
+        loop do
+          candidate = "#{desired} (#{n})"
+          return candidate unless inbox.topics.exists?(name: candidate)
+
+          n += 1
+        end
+      end
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/ai_agent/task_claim_service.rb
+++ b/engines/collavre/app/services/collavre/ai_agent/task_claim_service.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+module Collavre
+  module AiAgent
+    # Atomically claims and finalizes a delegated task on behalf of a Claude
+    # Channel /reply. Extracted from Api::V1::AgentsController#reply so the
+    # controller only sequences: claim -> save comment -> finalize. Behavior is
+    # identical to the inlined controller methods it replaces.
+    class TaskClaimService
+      # Atomically claim a delegated task for completion. Two-step:
+      #   1. Find a candidate task in delegated state, scoped to this agent +
+      #      topic. With task_id supplied, exact match (required under topic
+      #      concurrency > 1 where multiple delegated tasks coexist; the client
+      #      echoes the dispatch's task_id). Without task_id (legacy clients),
+      #      oldest-first.
+      #   2. Inside a transaction: SELECT FOR UPDATE the row, re-check
+      #      status == 'delegated' under the lock, then update! to 'done'.
+      #      Concurrent claimers block on the lock; the loser sees the
+      #      already-flipped status post-lock and returns nil so the caller can
+      #      refuse the duplicate.
+      # update_all (NOT update!) is required to skip Task's after_update_commit
+      # callbacks at claim time. The callbacks fire check_trigger_loop_completion
+      # (which enqueues TriggerLoopCheckJob) and broadcast_stop_button_removal
+      # (which reads reply_comment). Both depend on the reply comment already
+      # existing — but reply() claims BEFORE comment.save to win the race against
+      # concurrent /reply calls. If update! fired the trigger-loop check here, the
+      # job could run (cooldown_seconds: 0) before comment.save commits, find no
+      # agent comment, and leave the loop stuck in "running". #finalize replays
+      # both callbacks after the comment is persisted via
+      # Task#fire_completion_callbacks_after_external_claim.
+      def claim(agent:, topic:, requested_task_id:)
+        scope = Task.where(agent_id: agent.id, topic_id: topic.id, status: "delegated")
+        candidate =
+          if requested_task_id.present?
+            scope.find_by(id: requested_task_id)
+          else
+            scope.order(:created_at).first
+          end
+        return nil unless candidate
+
+        claimed = nil
+        Task.transaction do
+          locked = Task.lock.find_by(id: candidate.id)
+          next unless locked && locked.status == "delegated"
+
+          Task.where(id: locked.id).update_all(status: "done", pending_tool_call: nil, updated_at: Time.current)
+          claimed = locked.reload
+        end
+        claimed
+      end
+
+      # Post-claim side effects, run only after the reply comment is saved. Links
+      # the comment to the claimed task, releases the ResourceTracker slot the
+      # AiAgentJob held under task.id, advances the parent workflow (if any), and
+      # drains the topic queue — mirroring AiAgentJob#perform's success path for
+      # non-delegated runs.
+      def finalize(agent:, task:, comment:)
+        comment.update_column(:task_id, task.id)
+
+        Orchestration::ResourceTracker.for(agent).release!(task.id)
+
+        if task.parent_task_id.present?
+          Collavre::Comments::WorkflowExecutor.new(task.parent_task).complete_subtask!(task)
+        end
+
+        Orchestration::AgentOrchestrator.dequeue_next_for_topic(task.topic_id, task.creative_id)
+
+        # Replay the after_update_commit callbacks that were bypassed by
+        # update_all in #claim — now that the reply comment is linked,
+        # TriggerLoopCheckJob can read it and decide whether to advance/await/
+        # complete the drop-trigger loop, and the stop-button broadcast has a
+        # comment to render.
+        task.fire_completion_callbacks_after_external_claim
+
+        # Clear the typing indicator immediately on reply. ClaudeChannelPresenceJob
+        # would also stop on its next beat (task no longer "delegated"), but that
+        # is up to HEARTBEAT_SECONDS away — broadcast idle now so the indicator
+        # drops the moment Claude's reply lands.
+        broadcast_claude_idle(agent, task, comment)
+      end
+
+      private
+
+      # Clear the chat typing indicator via the canonical status broadcaster (the
+      # same one AiAgentService uses for every other agent), so the Claude path
+      # emits an identical "idle" agent_status payload.
+      def broadcast_claude_idle(agent, task, comment)
+        creative = comment.creative&.effective_origin
+        return unless creative
+
+        AiAgent::AgentLifecycleManager.new(task: task, agent: agent, creative: creative)
+                                      .broadcast_status("idle")
+      end
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/creatives/creative_tree_serializer.rb
+++ b/engines/collavre/app/services/collavre/creatives/creative_tree_serializer.rb
@@ -1,0 +1,122 @@
+module Collavre
+module Creatives
+  # Serializes a flat collection of creatives into the lightweight JSON payload
+  # consumed by the picker popup (simple mode) and the plain browse list.
+  #
+  # Extracted from CreativesController#index so the controller action stays thin.
+  # Depends only on the acting user and the request params (read-only), never on
+  # view_context, so the whole responsibility lives outside the controller.
+  class CreativeTreeSerializer
+    def initialize(user:, params:)
+      @user = user
+      @params = params
+    end
+
+    def serialize(collection)
+      if params[:simple].present?
+        serialize_simple(collection)
+      else
+        collection.map { |c| { id: c.id, description: c.effective_description, progress: c.progress } }
+      end
+    end
+
+    private
+
+    attr_reader :user, :params
+
+    def serialize_simple(collection)
+      # Preload origins so effective_origin (used per linked-shell row in both
+      # children_presence_set and the origin_id mapping below) resolves from
+      # memory instead of firing a query per shell. Only browse can hold shells;
+      # search is scoped to origin_id: nil, so this is a no-op there.
+      ActiveRecord::Associations::Preloader.new(records: collection.to_a, associations: :origin).call
+      children_ids = children_presence_set(collection)
+      searching = params[:search].present?
+      breadcrumbs = searching ? BreadcrumbResolver.new(collection.map(&:id), user: user, include_archived: params[:show_archived].present?).call : {}
+      # For hits routed through a linked shell, the path to expand in the
+      # user's own tree (local folders -> shell) so a breadcrumb jump can
+      # reach a shell nested under a collapsed folder.
+      reveal_paths = searching ? RevealPathResolver.new(collection.map(&:id), user: user, include_archived: params[:show_archived].present?).call : {}
+      collection.map do |c|
+        item = {
+          id: c.id,
+          description: c.effective_description(nil, false),
+          progress: c.progress,
+          has_children: children_ids.include?(c.id)
+        }
+        reveal = reveal_paths[c.id]
+        path = breadcrumbs[c.id]
+        if path.present?
+          item[:path] = mask_unreachable_crumbs(path, reveal)
+        end
+        item[:reveal_path] = reveal if reveal.present?
+        # For linked shells, expose the effective origin id so the picker can
+        # map a search breadcrumb (origin ids) back to the rendered shell node.
+        item[:origin_id] = c.effective_origin.id if c.origin_id
+        item
+      end
+    end
+
+    # A breadcrumb jump expands the tree from a rendered root (or, for a shared
+    # subtree, a linked shell) down to the clicked crumb. If an ancestor above a
+    # crumb is itself unrenderable (unreadable, or archived while archived rows
+    # aren't shown) and no linked shell re-roots the path at/below it, the
+    # descendant can't be expanded either — so mask it too. BreadcrumbResolver
+    # masks the unrenderable ancestor itself; this masks everything downstream of
+    # it on the plain origin chain, matching exactly what the tree can render.
+    #
+    # `reveal` is RevealPathResolver's per-origin map: a crumb whose origin id is
+    # a key re-roots navigation through its own shell (the client anchors at the
+    # nearest reveal entry at/above the clicked crumb), so it clears the block for
+    # itself and its descendants regardless of an archived/unreadable origin
+    # above it.
+    def mask_unreachable_crumbs(path, reveal)
+      blocked = false
+      path.map do |crumb|
+        if reveal&.key?(crumb[:id])
+          blocked = false
+          crumb
+        elsif crumb[:restricted]
+          blocked = true
+          crumb
+        elsif blocked
+          crumb.merge(restricted: true, description: nil)
+        else
+          crumb
+        end
+      end
+    end
+
+    # Batched "does this node have a child the user can actually browse to?"
+    # lookup so the picker tree renders expand toggles without an N+1.
+    #
+    # Must match exactly what expanding the node shows (IndexQuery#handle_id_query
+    # -> children_with_permission, minus archived unless show_archived), or the
+    # toggle either hides a reachable subtree or opens to an empty branch (and
+    # leaks that hidden children exist). Two alignments are needed:
+    #   1. Linked shells (origin_id set) store children under the effective
+    #      origin (redirect_parent_to_origin + children->origin migration), so
+    #      resolve each row to its effective origin before the lookup.
+    #   2. Apply the same archived + read-permission filters as the browse path.
+    def children_presence_set(collection)
+      return Set.new if collection.empty?
+
+      origin_id_by_id = collection.to_h { |c| [ c.id, c.effective_origin.id ] }
+
+      candidates = Creative.where(parent_id: origin_id_by_id.values.uniq)
+      candidates = candidates.where(archived_at: nil) unless params[:show_archived]
+      child_rows = candidates.pluck(:id, :parent_id) # [child_id, origin_id]
+      return Set.new if child_rows.empty?
+
+      readable = PermissionFilter
+        .new(user: user).readable_ids(child_rows.map(&:first)).to_set
+      origins_with_visible_children = child_rows
+        .each_with_object(Set.new) { |(child_id, origin_id), set| set << origin_id if readable.include?(child_id) }
+
+      collection.each_with_object(Set.new) do |c, set|
+        set << c.id if origins_with_visible_children.include?(origin_id_by_id[c.id])
+      end
+    end
+  end
+end
+end

--- a/engines/collavre/app/services/collavre/orchestration/agent_context_builder.rb
+++ b/engines/collavre/app/services/collavre/orchestration/agent_context_builder.rb
@@ -126,22 +126,8 @@ module Collavre
           "id" => @agent.id,
           "name" => @agent.name,
           "display_name" => @agent.display_name,
-          "type" => extract_agent_type
+          "type" => AgentTypeClassifier.classify(@agent)
         }
-      end
-
-      def extract_agent_type
-        # Extract agent type from system_prompt or default
-        prompt = @agent.system_prompt.to_s.downcase
-        case prompt
-        when /developer|개발/ then "developer"
-        when /pm|project.?manager|프로젝트/ then "pm"
-        when /qa|test|quality|테스트|품질/ then "qa"
-        when /research|조사|연구/ then "researcher"
-        when /market|마케팅/ then "marketer"
-        when /plan|기획/ then "planner"
-        else "agent"
-        end
       end
 
       def build_collaborators

--- a/engines/collavre/app/services/collavre/system_events/context_builder.rb
+++ b/engines/collavre/app/services/collavre/system_events/context_builder.rb
@@ -34,21 +34,8 @@ module Collavre
           "name" => user.name,
           "display_name" => user.respond_to?(:display_name) ? user.display_name : user.name,
           "is_ai" => user.ai_user?,
-          "type" => user.ai_user? ? extract_agent_type(user) : "human"
+          "type" => user.ai_user? ? AgentTypeClassifier.classify(user) : "human"
         }
-      end
-
-      def extract_agent_type(user)
-        prompt = user.system_prompt.to_s.downcase
-        case prompt
-        when /developer|개발/ then "developer"
-        when /pm|project.?manager|프로젝트/ then "pm"
-        when /qa|test|quality|테스트|품질/ then "qa"
-        when /research|조사|연구/ then "researcher"
-        when /market|마케팅/ then "marketer"
-        when /plan|기획/ then "planner"
-        else "agent"
-        end
       end
 
       def mentioned_user(chat_context)


### PR DESCRIPTION
## Summary
Decomposes the two "god" controllers (`creatives`, `agents`) into focused services and closes a mass-assignment hole.

## Changes
- Remove `to_unsafe_h` in `creatives#index`; permit an explicit query-param whitelist.
- Extract `CreativeTreeSerializer` from `CreativesController` (772 → 705 lines).
- Extract `SessionProvisioner` + `TaskClaimService` from `AgentsController` (777 → 606 lines).
- Extract shared `AgentTypeClassifier` (dedups two byte-identical `extract_agent_type` case blocks).

## Test
- Targeted tests green (177).

Part of the "기술적 완성도" hardening batch. 🤖 Generated with Claude Code.
