### PR TITLE
fix(security): encrypt repository-link webhook secret at rest and block SSRF DNS rebinding

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_02_000005) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_11_000000) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false

--- a/engines/collavre/app/services/collavre/link_preview_fetcher.rb
+++ b/engines/collavre/app/services/collavre/link_preview_fetcher.rb
@@ -65,17 +65,10 @@ module Collavre
       # as public here can no longer be re-resolved to a private/metadata IP at
       # connect time, because the connection targets the pinned address (with the
       # original hostname preserved for Host/SNI).
-      address = pinned_address(uri)
-      return [ nil, nil ] unless address
+      addresses = safe_addresses(uri)
+      return [ nil, nil ] if addresses.empty?
 
-      response = @http_client.get(
-        uri,
-        ip: address,
-        headers: REQUEST_OPTIONS,
-        open_timeout: OPEN_TIMEOUT,
-        read_timeout: READ_TIMEOUT,
-        max_bytes: MAX_BYTES
-      )
+      response = fetch_via_pinned_addresses(uri, addresses)
       return [ nil, nil ] unless response
 
       if redirect?(response.code)
@@ -133,19 +126,45 @@ module Collavre
       nil
     end
 
-    # Resolve the host, reject if it maps to any unsafe address, and return the
-    # single IP to pin the connection to. Rejecting when ANY resolved address is
-    # unsafe (not just the pinned one) keeps defense-in-depth against split-horizon
-    # DNS returning a mix of public and private records.
-    def pinned_address(uri)
+    # Resolve the host, reject if it maps to ANY unsafe address, and return every
+    # validated public IP to pin against. Rejecting when any resolved address is
+    # unsafe (not just the one we pick) keeps defense-in-depth against
+    # split-horizon DNS returning a mix of public and private records. Returning
+    # all safe addresses lets the caller fall back to the next one when the first
+    # is unreachable (e.g. an AAAA record with no IPv6 egress).
+    def safe_addresses(uri)
       host = uri.hostname
-      return if host.nil? || host.empty?
+      return [] if host.nil? || host.empty?
 
       addresses = resolve_addresses(host)
-      return if addresses.empty?
-      return if addresses.any? { |address| unsafe_ip?(address) }
+      return [] if addresses.empty?
+      return [] if addresses.any? { |address| unsafe_ip?(address) }
 
-      addresses.first
+      addresses
+    end
+
+    # Try each pre-validated address in turn, pinning the connection to it, and
+    # return the first response we can actually open. Connection-level failures
+    # fall through to the next candidate; if none connect, the caller treats it
+    # as an empty preview. Every address here already passed safe_addresses, so
+    # falling back never targets an unsafe IP.
+    def fetch_via_pinned_addresses(uri, addresses)
+      last_error = nil
+      addresses.each do |address|
+        return @http_client.get(
+          uri,
+          ip: address,
+          headers: REQUEST_OPTIONS,
+          open_timeout: OPEN_TIMEOUT,
+          read_timeout: READ_TIMEOUT,
+          max_bytes: MAX_BYTES
+        )
+      rescue SocketError, IOError, SystemCallError, Net::OpenTimeout, Net::ReadTimeout,
+             OpenSSL::SSL::SSLError => e
+        last_error = e
+      end
+      @logger&.info("Link preview fetch skipped for #{@url}: #{last_error.class} #{last_error.message}") if last_error
+      nil
     end
 
     def resolve_addresses(host)
@@ -255,7 +274,11 @@ module Collavre
     # read timeouts and byte cap.
     class PinnedHttpClient
       def get(uri, ip:, headers:, open_timeout:, read_timeout:, max_bytes:)
-        http = Net::HTTP.new(uri.hostname, uri.port)
+        # Pass an explicit nil proxy: Net::HTTP.new defaults p_addr to :ENV, so a
+        # set http_proxy/HTTP_PROXY would route through the proxy, which resolves
+        # the hostname itself and defeats `http.ipaddr = ip` pinning — reopening
+        # the DNS-rebinding/SSRF gap. nil forces a direct, pinned connection.
+        http = Net::HTTP.new(uri.hostname, uri.port, nil)
         http.use_ssl = uri.scheme == "https"
         http.ipaddr = ip
         http.open_timeout = open_timeout

--- a/engines/collavre/app/services/collavre/link_preview_fetcher.rb
+++ b/engines/collavre/app/services/collavre/link_preview_fetcher.rb
@@ -1,5 +1,5 @@
 module Collavre
-  require "open-uri"
+  require "net/http"
   require "nokogiri"
   require "uri"
   require "ipaddr"
@@ -29,18 +29,22 @@ module Collavre
       IPAddr.new("ff00::/8")
     ].freeze
 
+    # Minimal HTTP result the fetcher reasons about. `body` is only populated for
+    # successful (2xx) responses; redirects carry a `location` instead.
+    Response = Struct.new(:code, :content_type, :body, :location, keyword_init: true)
+
     def self.fetch(url)
       new(url).fetch
     end
 
-    def initialize(url, io_opener: URI, logger: Rails.logger)
+    def initialize(url, http_client: nil, logger: Rails.logger)
       @url = url
-      @io_opener = io_opener
+      @http_client = http_client || PinnedHttpClient.new
       @logger = logger
     end
 
     def fetch
-      uri = safe_http_uri
+      uri = parse_http_uri(@url)
       return {} unless uri
 
       html, base_uri = read_html(uri)
@@ -56,47 +60,60 @@ module Collavre
     private
 
     def read_html(uri, redirect_limit = MAX_REDIRECTS)
-      html = nil
-      base_uri = nil
-      options = REQUEST_OPTIONS.merge(read_timeout: READ_TIMEOUT, open_timeout: OPEN_TIMEOUT, redirect: false)
-      @io_opener.open(uri.to_s, options) do |io|
-        content_type = io.respond_to?(:content_type) ? io.content_type : nil
-        if content_type && HTML_CONTENT_TYPES.none? { |type| content_type.include?(type) }
-          return [ nil, nil ]
-        end
-        base_uri = io.respond_to?(:base_uri) ? io.base_uri : uri
-        html = io.read(MAX_BYTES)
+      # Resolve+validate the host ONCE per hop and pin the request to that exact
+      # IP. This closes the DNS-rebinding TOCTOU gap: a hostname that validates
+      # as public here can no longer be re-resolved to a private/metadata IP at
+      # connect time, because the connection targets the pinned address (with the
+      # original hostname preserved for Host/SNI).
+      address = pinned_address(uri)
+      return [ nil, nil ] unless address
+
+      response = @http_client.get(
+        uri,
+        ip: address,
+        headers: REQUEST_OPTIONS,
+        open_timeout: OPEN_TIMEOUT,
+        read_timeout: READ_TIMEOUT,
+        max_bytes: MAX_BYTES
+      )
+      return [ nil, nil ] unless response
+
+      if redirect?(response.code)
+        return [ nil, nil ] if redirect_limit <= 0
+
+        redirected_uri = normalize_redirect_uri(uri, response.location)
+        return [ nil, nil ] unless redirected_uri
+
+        # Recurse so the new host is resolved+validated+pinned from scratch;
+        # never follow a hop to an internal address.
+        return read_html(redirected_uri, redirect_limit - 1)
       end
-      [ html, base_uri ]
-    rescue OpenURI::HTTPRedirect => e
-      return [ nil, nil ] if redirect_limit <= 0
 
-      redirected_uri = safe_redirect_uri(uri, e.uri)
-      return [ nil, nil ] unless redirected_uri
+      return [ nil, nil ] unless success?(response.code)
 
-      read_html(redirected_uri, redirect_limit - 1)
-    rescue OpenURI::HTTPError, SocketError, IOError, SystemCallError, URI::InvalidURIError => e
+      content_type = response.content_type
+      if content_type && HTML_CONTENT_TYPES.none? { |type| content_type.include?(type) }
+        return [ nil, nil ]
+      end
+
+      [ response.body, uri ]
+    rescue SocketError, IOError, SystemCallError, Net::OpenTimeout, Net::ReadTimeout,
+           OpenSSL::SSL::SSLError, URI::InvalidURIError => e
       @logger&.info("Link preview fetch skipped for #{@url}: #{e.class} #{e.message}")
       [ nil, nil ]
     end
 
-    def safe_http_uri
-      uri = parse_http_uri(@url)
-      return unless uri
-      return unless allowed_destination?(uri)
-
-      uri
+    def redirect?(code)
+      code.to_i.between?(300, 399)
     end
 
-    def safe_redirect_uri(current_uri, redirected)
-      new_uri = normalize_redirect_uri(current_uri, redirected)
-      return unless new_uri
-      return unless allowed_destination?(new_uri)
-
-      new_uri
+    def success?(code)
+      code.to_i.between?(200, 299)
     end
 
     def normalize_redirect_uri(current_uri, redirected)
+      return if redirected.blank?
+
       target_uri = redirected.is_a?(URI) ? redirected : URI.parse(redirected.to_s)
       target_uri = current_uri.merge(target_uri) if target_uri.relative?
       return unless %w[http https].include?(target_uri.scheme)
@@ -116,15 +133,19 @@ module Collavre
       nil
     end
 
-    def allowed_destination?(uri)
+    # Resolve the host, reject if it maps to any unsafe address, and return the
+    # single IP to pin the connection to. Rejecting when ANY resolved address is
+    # unsafe (not just the pinned one) keeps defense-in-depth against split-horizon
+    # DNS returning a mix of public and private records.
+    def pinned_address(uri)
       host = uri.hostname
-      return false if host.nil? || host.empty?
+      return if host.nil? || host.empty?
 
       addresses = resolve_addresses(host)
-      return false if addresses.empty?
-      return false if addresses.any? { |address| unsafe_ip?(address) }
+      return if addresses.empty?
+      return if addresses.any? { |address| unsafe_ip?(address) }
 
-      true
+      addresses.first
     end
 
     def resolve_addresses(host)
@@ -225,6 +246,53 @@ module Collavre
       return if text.blank?
 
       text.to_s.gsub(/\s+/, " ").strip
+    end
+
+    # Performs a single (non-redirect-following) GET against a pre-resolved IP
+    # while keeping the original hostname for the Host header and TLS SNI/cert
+    # verification. Net::HTTP#ipaddr= pins the socket to `ip`, so no second DNS
+    # lookup happens between validation and connect. Enforces the caller's open/
+    # read timeouts and byte cap.
+    class PinnedHttpClient
+      def get(uri, ip:, headers:, open_timeout:, read_timeout:, max_bytes:)
+        http = Net::HTTP.new(uri.hostname, uri.port)
+        http.use_ssl = uri.scheme == "https"
+        http.ipaddr = ip
+        http.open_timeout = open_timeout
+        http.read_timeout = read_timeout
+
+        request = Net::HTTP::Get.new(uri, headers)
+        response_struct = nil
+
+        http.start do |conn|
+          conn.request(request) do |response|
+            body = read_capped_body(response, max_bytes)
+            response_struct = Response.new(
+              code: response.code.to_i,
+              content_type: response.content_type,
+              body: body,
+              location: response["location"]
+            )
+          end
+        end
+
+        response_struct
+      ensure
+        http&.finish if http&.started?
+      end
+
+      private
+
+      def read_capped_body(response, max_bytes)
+        return nil unless response.is_a?(Net::HTTPSuccess)
+
+        body = +""
+        response.read_body do |chunk|
+          body << chunk
+          break if body.bytesize >= max_bytes
+        end
+        body.byteslice(0, max_bytes)
+      end
     end
   end
 end

--- a/engines/collavre/test/services/link_preview_fetcher_test.rb
+++ b/engines/collavre/test/services/link_preview_fetcher_test.rb
@@ -1,14 +1,19 @@
 require "test_helper"
-require "stringio"
-require "open-uri"
 
 class LinkPreviewFetcherTest < ActiveSupport::TestCase
+  Response = Collavre::LinkPreviewFetcher::Response
+
   class NullLogger
     def warn(*) end
     def info(*) end
   end
 
-  class FakeOpener
+  # Records every request and its pinned IP, then returns the next queued
+  # response (a Response struct) or raises the next queued error. Mirrors the
+  # PinnedHttpClient#get contract.
+  class FakeClient
+    Call = Struct.new(:uri, :ip, keyword_init: true)
+
     attr_reader :calls
 
     def initialize(*responses)
@@ -16,19 +21,16 @@ class LinkPreviewFetcherTest < ActiveSupport::TestCase
       @calls = []
     end
 
-    def open(url, options)
-      @calls << [ url, options ]
-      action, value = @responses.shift
-      raise "No response configured" unless action
+    def get(uri, ip:, headers:, open_timeout:, read_timeout:, max_bytes:)
+      @calls << Call.new(uri: uri, ip: ip)
+      entry = @responses.shift
+      raise "No response configured" unless entry
 
-      case action
-      when :yield
-        raise "Expected block" unless block_given?
-        yield value
-      when :raise
-        raise value
-      else
-        raise "Unknown action: #{action.inspect}"
+      kind, value = entry
+      case kind
+      when :response then value
+      when :raise then raise value
+      else raise "Unknown kind: #{kind.inspect}"
       end
     end
   end
@@ -45,15 +47,12 @@ class LinkPreviewFetcherTest < ActiveSupport::TestCase
     </html>
   HTML
 
-  def build_io(body, content_type: "text/html", base_url: "https://example.com/article")
-    base_uri = URI.parse(base_url)
-    StringIO.new(body).tap do |io|
-      io.define_singleton_method(:content_type) { content_type }
-      io.define_singleton_method(:base_uri) { base_uri }
-      io.define_singleton_method(:read) do |*args|
-        body.dup
-      end
-    end
+  def ok_response(body, content_type: "text/html")
+    Response.new(code: 200, content_type: content_type, body: body, location: nil)
+  end
+
+  def redirect_response(location)
+    Response.new(code: 301, content_type: nil, body: nil, location: location)
   end
 
   def stub_addresses(fetcher, mapping)
@@ -65,9 +64,8 @@ class LinkPreviewFetcherTest < ActiveSupport::TestCase
 
   test "extracts metadata from html head" do
     url = "https://example.com/article"
-    io = build_io(HTML, base_url: url)
-    opener = FakeOpener.new([ :yield, io ])
-    fetcher = LinkPreviewFetcher.new(url, io_opener: opener, logger: NullLogger.new)
+    client = FakeClient.new([ :response, ok_response(HTML) ])
+    fetcher = Collavre::LinkPreviewFetcher.new(url, http_client: client, logger: NullLogger.new)
 
     metadata = stub_addresses(fetcher, URI.parse(url).hostname => [ "93.184.216.34" ]) do
       fetcher.fetch
@@ -78,17 +76,17 @@ class LinkPreviewFetcherTest < ActiveSupport::TestCase
     assert_equal "https://example.com/image.png", metadata[:image_url]
     assert_equal "Example", metadata[:site_name]
 
-    assert_equal 1, opener.calls.size
-    _called_url, options = opener.calls.first
-    assert_equal false, options[:redirect]
-    assert_equal LinkPreviewFetcher::USER_AGENT, options["User-Agent"]
+    assert_equal 1, client.calls.size
+    # Connection is pinned to the resolved IP, not re-resolved at connect time.
+    assert_equal "93.184.216.34", client.calls.first.ip
+    assert_equal url, client.calls.first.uri.to_s
   end
 
   test "falls back to the title tag when og:title missing" do
     url = "https://example.com/article"
-    io = build_io("<html><head><title>Fallback Title</title></head><body></body></html>", base_url: url)
-    opener = FakeOpener.new([ :yield, io ])
-    fetcher = LinkPreviewFetcher.new(url, io_opener: opener, logger: NullLogger.new)
+    body = "<html><head><title>Fallback Title</title></head><body></body></html>"
+    client = FakeClient.new([ :response, ok_response(body) ])
+    fetcher = Collavre::LinkPreviewFetcher.new(url, http_client: client, logger: NullLogger.new)
 
     metadata = stub_addresses(fetcher, URI.parse(url).hostname => [ "93.184.216.34" ]) do
       fetcher.fetch
@@ -99,9 +97,8 @@ class LinkPreviewFetcherTest < ActiveSupport::TestCase
 
   test "returns empty metadata when content type not html" do
     url = "https://example.com/file"
-    io = build_io("binary", content_type: "image/png", base_url: url)
-    opener = FakeOpener.new([ :yield, io ])
-    fetcher = LinkPreviewFetcher.new(url, io_opener: opener, logger: NullLogger.new)
+    client = FakeClient.new([ :response, ok_response("binary", content_type: "image/png") ])
+    fetcher = Collavre::LinkPreviewFetcher.new(url, http_client: client, logger: NullLogger.new)
 
     metadata = stub_addresses(fetcher, URI.parse(url).hostname => [ "93.184.216.34" ]) do
       fetcher.fetch
@@ -112,8 +109,8 @@ class LinkPreviewFetcherTest < ActiveSupport::TestCase
 
   test "handles network errors gracefully" do
     url = "https://example.com/error"
-    opener = FakeOpener.new([ :raise, OpenURI::HTTPError.new("500", nil) ])
-    fetcher = LinkPreviewFetcher.new(url, io_opener: opener, logger: NullLogger.new)
+    client = FakeClient.new([ :raise, SocketError.new("boom") ])
+    fetcher = Collavre::LinkPreviewFetcher.new(url, http_client: client, logger: NullLogger.new)
 
     metadata = stub_addresses(fetcher, URI.parse(url).hostname => [ "93.184.216.34" ]) do
       fetcher.fetch
@@ -124,41 +121,43 @@ class LinkPreviewFetcherTest < ActiveSupport::TestCase
 
   test "returns empty metadata when host resolves to private address" do
     url = "https://example.com/private"
-    opener = FakeOpener.new
-    fetcher = LinkPreviewFetcher.new(url, io_opener: opener, logger: NullLogger.new)
+    client = FakeClient.new
+    fetcher = Collavre::LinkPreviewFetcher.new(url, http_client: client, logger: NullLogger.new)
 
     metadata = stub_addresses(fetcher, URI.parse(url).hostname => [ "10.0.0.5" ]) do
       fetcher.fetch
     end
 
     assert_equal({}, metadata)
-    assert_empty opener.calls
+    # Rejected before any connection is attempted.
+    assert_empty client.calls
   end
 
   test "returns empty metadata for loopback ip urls" do
     url = "http://127.0.0.1/secret"
-    opener = FakeOpener.new
-    fetcher = LinkPreviewFetcher.new(url, io_opener: opener, logger: NullLogger.new)
+    client = FakeClient.new
+    fetcher = Collavre::LinkPreviewFetcher.new(url, http_client: client, logger: NullLogger.new)
 
     metadata = stub_addresses(fetcher, URI.parse(url).hostname => [ "127.0.0.1" ]) do
       fetcher.fetch
     end
 
     assert_equal({}, metadata)
-    assert_empty opener.calls
+    assert_empty client.calls
   end
 
   test "follows redirects when destination allowed" do
     url = "https://example.com/article"
-    redirect_uri = URI.parse("https://www.example.com/article")
-    io = build_io(HTML, base_url: redirect_uri.to_s)
-    redirect_error = OpenURI::HTTPRedirect.new("301", StringIO.new, redirect_uri)
-    opener = FakeOpener.new([ :raise, redirect_error ], [ :yield, io ])
-    fetcher = LinkPreviewFetcher.new(url, io_opener: opener, logger: NullLogger.new)
+    redirect_uri = "https://www.example.com/article"
+    client = FakeClient.new(
+      [ :response, redirect_response(redirect_uri) ],
+      [ :response, ok_response(HTML) ]
+    )
+    fetcher = Collavre::LinkPreviewFetcher.new(url, http_client: client, logger: NullLogger.new)
 
     mapping = {
       URI.parse(url).hostname => [ "93.184.216.34" ],
-      redirect_uri.hostname => [ "93.184.216.35" ]
+      URI.parse(redirect_uri).hostname => [ "93.184.216.35" ]
     }
 
     metadata = stub_addresses(fetcher, mapping) do
@@ -166,22 +165,25 @@ class LinkPreviewFetcherTest < ActiveSupport::TestCase
     end
 
     assert_equal "Example Title", metadata[:title]
+    # Image resolves against the final (redirected) base URI.
     assert_equal "https://www.example.com/image.png", metadata[:image_url]
-    assert_equal 2, opener.calls.size
-    assert_equal url, opener.calls.first.first
-    assert_equal redirect_uri.to_s, opener.calls.second.first
+    assert_equal 2, client.calls.size
+    assert_equal url, client.calls.first.uri.to_s
+    assert_equal "93.184.216.34", client.calls.first.ip
+    assert_equal redirect_uri, client.calls.second.uri.to_s
+    # The redirect target is pinned to its own freshly-resolved IP.
+    assert_equal "93.184.216.35", client.calls.second.ip
   end
 
   test "stops following redirects that resolve to private addresses" do
     url = "https://example.com/article"
-    redirect_uri = URI.parse("https://internal.example/resource")
-    redirect_error = OpenURI::HTTPRedirect.new("301", StringIO.new, redirect_uri)
-    opener = FakeOpener.new([ :raise, redirect_error ])
-    fetcher = LinkPreviewFetcher.new(url, io_opener: opener, logger: NullLogger.new)
+    redirect_uri = "https://internal.example/resource"
+    client = FakeClient.new([ :response, redirect_response(redirect_uri) ])
+    fetcher = Collavre::LinkPreviewFetcher.new(url, http_client: client, logger: NullLogger.new)
 
     mapping = {
       URI.parse(url).hostname => [ "93.184.216.34" ],
-      redirect_uri.hostname => [ "10.0.0.8" ]
+      URI.parse(redirect_uri).hostname => [ "10.0.0.8" ]
     }
 
     metadata = stub_addresses(fetcher, mapping) do
@@ -189,6 +191,20 @@ class LinkPreviewFetcherTest < ActiveSupport::TestCase
     end
 
     assert_equal({}, metadata)
-    assert_equal 1, opener.calls.size
+    # First hop connects; the private redirect target is rejected before connect.
+    assert_equal 1, client.calls.size
+  end
+
+  test "rejects a host that resolves to a mix of public and private addresses" do
+    url = "https://example.com/split-horizon"
+    client = FakeClient.new
+    fetcher = Collavre::LinkPreviewFetcher.new(url, http_client: client, logger: NullLogger.new)
+
+    metadata = stub_addresses(fetcher, URI.parse(url).hostname => [ "93.184.216.34", "169.254.169.254" ]) do
+      fetcher.fetch
+    end
+
+    assert_equal({}, metadata)
+    assert_empty client.calls
   end
 end

--- a/engines/collavre/test/services/link_preview_fetcher_test.rb
+++ b/engines/collavre/test/services/link_preview_fetcher_test.rb
@@ -195,6 +195,25 @@ class LinkPreviewFetcherTest < ActiveSupport::TestCase
     assert_equal 1, client.calls.size
   end
 
+  test "falls back to the next safe address when the first is unreachable" do
+    url = "https://example.com/dual-stack"
+    # First (e.g. AAAA/no egress) address raises at connect; the second succeeds.
+    client = FakeClient.new(
+      [ :raise, SocketError.new("no route to host") ],
+      [ :response, ok_response(HTML) ]
+    )
+    fetcher = Collavre::LinkPreviewFetcher.new(url, http_client: client, logger: NullLogger.new)
+
+    metadata = stub_addresses(fetcher, URI.parse(url).hostname => [ "2606:2800:220:1:248:1893:25c8:1946", "93.184.216.34" ]) do
+      fetcher.fetch
+    end
+
+    assert_equal "Example Title", metadata[:title]
+    assert_equal 2, client.calls.size
+    assert_equal "2606:2800:220:1:248:1893:25c8:1946", client.calls.first.ip
+    assert_equal "93.184.216.34", client.calls.second.ip
+  end
+
   test "rejects a host that resolves to a mix of public and private addresses" do
     url = "https://example.com/split-horizon"
     client = FakeClient.new

--- a/engines/collavre_github/app/models/collavre_github/repository_link.rb
+++ b/engines/collavre_github/app/models/collavre_github/repository_link.rb
@@ -6,6 +6,14 @@ module CollavreGithub
     belongs_to :github_account, class_name: "CollavreGithub::Account"
     belongs_to :markdown_root_creative, class_name: "Collavre::Creative", optional: true
 
+    # HMAC secret GitHub signs webhook deliveries with. Encrypted at rest so a
+    # DB/backup leak can't forge webhooks (mirrors CollavreGithub::Account#token
+    # and CollavreLinear::ProjectLink#webhook_secret). Non-deterministic: the
+    # value is only ever read back decrypted (WebhooksController, provisioner),
+    # never queried by ciphertext. A backfill migration re-encrypts pre-existing
+    # plaintext rows.
+    encrypts :webhook_secret, deterministic: false
+
     validates :repository_full_name, presence: true
     validates :webhook_secret, presence: true
 

--- a/engines/collavre_github/db/migrate/20260711000000_encrypt_github_repository_link_webhook_secrets.rb
+++ b/engines/collavre_github/db/migrate/20260711000000_encrypt_github_repository_link_webhook_secrets.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+# Re-encrypt pre-existing plaintext webhook_secret values in place now that
+# CollavreGithub::RepositoryLink declares `encrypts :webhook_secret`. Reads the
+# raw column with SQL (bypassing the model so we get plaintext, not a decrypt
+# attempt), skips rows already in Active Record Encryption's JSON envelope, and
+# writes the encrypted payload back with the model's own encryptor so the format
+# matches runtime reads. `support_unencrypted_data = true` keeps unmigrated rows
+# readable, so this is safe to run without downtime.
+class EncryptGithubRepositoryLinkWebhookSecrets < ActiveRecord::Migration[8.1]
+  def up
+    say_with_time "Encrypting GitHub repository link webhook secrets" do
+      encrypt_column(CollavreGithub::RepositoryLink, :webhook_secret)
+    end
+  end
+
+  def down
+    # No-op: `encrypts` decrypts transparently, and support_unencrypted_data
+    # keeps any remaining plaintext readable.
+  end
+
+  private
+
+  def encrypt_column(model, attribute)
+    table_name = model.table_name
+    connection = ActiveRecord::Base.connection
+
+    rows = connection.select_all(
+      "SELECT id, #{attribute} FROM #{table_name} WHERE #{attribute} IS NOT NULL"
+    ).to_a
+
+    encryptor = model.type_for_attribute(attribute)
+
+    rows.each do |row|
+      plaintext = row[attribute.to_s]
+      next if plaintext.nil? || encrypted?(plaintext)
+
+      encrypted = encryptor.serialize(plaintext)
+      connection.execute(
+        "UPDATE #{table_name} SET #{attribute} = #{connection.quote(encrypted)} WHERE id = #{connection.quote(row['id'])}"
+      )
+    end
+  end
+
+  # Active Record Encryption stores a JSON envelope containing a "p" (payload)
+  # key; treat anything already in that shape as encrypted and leave it alone.
+  def encrypted?(value)
+    return false unless value.is_a?(String)
+
+    value.start_with?("{") && value.include?('"p":')
+  rescue StandardError
+    false
+  end
+end


### PR DESCRIPTION
## Summary
Two security fixes: encrypt repository-link webhook secrets at rest, and block SSRF DNS-rebinding in the link-preview fetcher.

## Changes
- **CWE-312:** `repository_link.webhook_secret` now uses `encrypts` with a backfill for existing rows.
- **CWE-918:** link preview fetcher resolves the host to an IP once, validates it, and connects to that pinned IP — re-validating on every redirect hop — closing the DNS-rebinding TOCTOU window.

## Test
- Targeted tests green (49).

Part of the "기술적 완성도" hardening batch. 🤖 Generated with Claude Code.
