### PR TITLE
fix(slack): claim inbound message before side effects for exactly-once delivery

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_11_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_12_000000) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -611,6 +611,15 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_11_000000) do
     t.index ["slack_channel_link_id"], name: "index_slack_comment_links_on_slack_channel_link_id"
   end
 
+  create_table "slack_inbound_reservations", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "message_ts", null: false
+    t.integer "slack_channel_link_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["slack_channel_link_id", "message_ts"], name: "idx_slack_inbound_reservations_on_channel_and_ts", unique: true
+    t.index ["slack_channel_link_id"], name: "index_slack_inbound_reservations_on_slack_channel_link_id"
+  end
+
   create_table "slack_message_logs", force: :cascade do |t|
     t.integer "comment_id"
     t.datetime "created_at", null: false
@@ -997,6 +1006,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_11_000000) do
   add_foreign_key "slack_channel_links", "users", column: "created_by_id"
   add_foreign_key "slack_comment_links", "comments", on_delete: :cascade
   add_foreign_key "slack_comment_links", "slack_channel_links"
+  add_foreign_key "slack_inbound_reservations", "slack_channel_links", on_delete: :cascade
   add_foreign_key "slack_message_logs", "comments", on_delete: :cascade
   add_foreign_key "slack_message_logs", "slack_channel_links"
   add_foreign_key "slack_message_logs", "users", column: "sender_id"

--- a/engines/collavre_slack/app/jobs/collavre_slack/slack_inbound_message_job.rb
+++ b/engines/collavre_slack/app/jobs/collavre_slack/slack_inbound_message_job.rb
@@ -2,27 +2,14 @@ module CollavreSlack
   class SlackInboundMessageJob < ApplicationJob
     queue_as :default
 
-    # SlackEventsController acks Slack with 200 the instant it enqueues this job
-    # (ack-before-apply), so Slack never re-delivers the event once accepted.
-    # Without a retry, a transient DB contention error on the final write would
-    # park the job and the inbound Slack message would be lost permanently.
-    #
-    # We deliberately do NOT use a job-level `retry_on` for transient contention:
-    # re-running the whole `perform` would re-run CommandProcessor, whose commands
-    # (/calendar -> CalendarEvent, /work -> tasks, MCP commands) have
-    # non-idempotent, non-transactional side effects that already committed on the
-    # first attempt. A whole-job retry would duplicate those side effects. Instead
-    # CommandProcessor runs exactly once, and the DB writes on either side of it
-    # are wrapped in an in-place #with_transient_retry: the pre-command permission
-    # grant / invite writes (both idempotent — each checks for an existing record
-    # first) and the final comment+link write. Every point where a transient
-    # Deadlocked/LockWaitTimeout can surface is covered, without ever re-running
-    # the non-idempotent commands.
+    # Slack is acked (200) the instant this job is enqueued, so a lost job means a
+    # lost message. We can't use a job-level `retry_on`: re-running `perform` would
+    # re-run CommandProcessor's non-idempotent commands (/calendar, /work, MCP). So
+    # CommandProcessor runs exactly once and each DB write around it is retried in
+    # place via #with_transient_retry.
 
-    # Permanent/unprocessable failures: retrying cannot help. The referenced
-    # creative/user/link was deleted, the payload can no longer deserialize, or a
-    # record is structurally invalid. Discard so the queue self-heals rather than
-    # looping forever.
+    # Retrying can't help these — the record was deleted, the payload can't
+    # deserialize, or it's structurally invalid — so discard to let the queue self-heal.
     discard_on ActiveJob::DeserializationError
     discard_on ActiveRecord::RecordNotFound
     discard_on ActiveRecord::RecordInvalid
@@ -36,46 +23,29 @@ module CollavreSlack
 
       return unless creative && channel_link
 
-      # Exactly-once guard, claimed BEFORE any side effect but AFTER the reads above.
-      # The controller acks Slack before this job runs (at-least-once delivery), so the
-      # same message can be delivered twice — either sequentially (a redelivery after a
-      # completed run) or concurrently (a near-simultaneous retry of an unacked event,
-      # producing two in-flight jobs). A read-only "already applied?" check cannot cover
-      # the concurrent case: both jobs read "not applied" and both run the non-idempotent
-      # side effects below (the grant/invite writes and, critically, CommandProcessor's
-      # /calendar, /work and MCP commands), duplicating them.
+      # Exactly-once guard claimed before any side effect. Slack is acked before this
+      # job runs, so a message can arrive twice — sequentially or concurrently. A
+      # read-only "already applied?" check can't cover the concurrent case: both jobs
+      # read "not applied" and both run the non-idempotent side effects below. Instead
+      # we atomically claim (channel_link, message_ts) via a unique index; only the
+      # winner proceeds, so every write below runs at most once.
       #
-      # Instead we atomically claim the (channel_link, message_ts) pair via a unique
-      # index. Only the row's winner proceeds past this line; a loser (a concurrent
-      # RecordNotUnique or a sequential-redelivery RecordInvalid) no-ops without running
-      # any side effect. This is reserve-before-side-effects: the claim gates every write
-      # below, so they run at most once across all deliveries of the message.
+      # Claimed AFTER the reads so the only pre-claim failure is a RecordNotFound on a
+      # deleted creative (deterministic, unrecoverable — nothing lost by leaving it
+      # un-gated), and channel_link is guaranteed present so a RecordInvalid can only
+      # mean "already claimed".
       #
-      # Placement is deliberate. Claiming AFTER the reads (not at the top of perform)
-      # keeps the only pre-claim failure a RecordNotFound on a deleted creative — which
-      # is deterministic and undeliverable, so leaving it un-gated loses nothing a retry
-      # could recover. It also guarantees channel_link exists before the claim, so the
-      # reservation's belongs_to/FK can never fail and a RecordInvalid here can only mean
-      # "already claimed".
-      #
-      # Trade-off: a discard (via discard_on) or crash AFTER this claim keeps the
-      # reservation, so that message is not retried. This is intentional — by that point
-      # CommandProcessor may already have run, and a retry would duplicate its
-      # non-idempotent commands, which is exactly the bug this change fixes. We prefer
-      # commands-exactly-once over comment-recovery, and use no time-lease (expiry-based
-      # reclaim is fragile). Transient contention on the writes below is still retried in
-      # place, so the realistic loss window is a hard crash (process death) after the
-      # claim but before the comment is persisted — spanning the grant/invite writes and
-      # CommandProcessor. The grant/invite writes there are themselves idempotent.
+      # Trade-off: a discard/crash after the claim keeps the reservation and skips
+      # retry — intentional, since CommandProcessor may have run and a retry would
+      # duplicate it. No time-lease (expiry reclaim is fragile). The only real loss
+      # window is a hard crash after the claim but before the comment persists.
       return unless claim_inbound_message(data)
 
       comment_user = user.presence || channel_link.created_by
 
-      # Pre-command permission grant / invite writes run before the non-idempotent
-      # CommandProcessor, so they must not be part of a whole-job retry. They are
-      # each idempotent (checking for an existing record first), so we retry them
-      # in place on transient contention — otherwise a Deadlocked here would lose
-      # the already-acked Slack message.
+      # Idempotent permission grant / invite writes, run before the non-idempotent
+      # CommandProcessor so they can't ride a whole-job retry. Retried in place on
+      # transient contention — otherwise a Deadlocked here loses the acked message.
       with_transient_retry do
         # Case 1: User exists in Collavre but lacks permission
         if user && !creative.has_permission?(user, :feedback)
@@ -104,8 +74,7 @@ module CollavreSlack
       # Mark this comment as coming from Slack to prevent loop
       comment.instance_variable_set(:@from_slack, true)
 
-      # Command side effects must happen exactly once — run before the retryable
-      # write and never inside the retry loop.
+      # Non-idempotent side effects: run once, outside the retryable write below.
       response = Collavre::Comments::CommandProcessor.new(comment: comment, user: user).call
       if response.present?
         comment.content = "#{comment.content}\n\n#{response}"
@@ -117,11 +86,9 @@ module CollavreSlack
 
     private
 
-    # Persist the comment and its Slack link atomically, retrying only this write
-    # on transient DB contention. Retrying here (rather than the whole job) keeps
-    # the non-idempotent CommandProcessor side effects from being re-applied.
-    # Because `comment` is a fresh unsaved record, a rolled-back attempt re-saves
-    # the same instance, so retries produce exactly one comment and one link.
+    # Persist comment + Slack link atomically, retrying only this write (not the whole
+    # job) so CommandProcessor isn't re-applied. `comment` is a fresh unsaved record,
+    # so a rolled-back retry re-saves the same instance — exactly one comment and link.
     def persist_comment_with_link!(comment, data)
       with_transient_retry do
         ActiveRecord::Base.transaction do
@@ -139,10 +106,9 @@ module CollavreSlack
       end
     end
 
-    # Retry an idempotent block on transient DB contention with exponential
-    # backoff. Only ever wrap idempotent work — a retry re-runs the block from the
-    # top. This is the deliberate substitute for a job-level `retry_on`, which
-    # would also re-run the non-idempotent CommandProcessor.
+    # Retry an idempotent block on transient DB contention. Only wrap idempotent work
+    # — the deliberate substitute for a job-level `retry_on`, which would also re-run
+    # the non-idempotent CommandProcessor.
     def with_transient_retry(max_attempts: 5)
       attempts = 0
       begin
@@ -158,15 +124,10 @@ module CollavreSlack
       end
     end
 
-    # Whether an error is a retryable transient DB contention, whether raised
-    # directly or wrapped by the queue adapter. A `deliver_later` enqueue INSERT
-    # runs inside the surrounding transaction (enqueue_after_transaction_commit is
-    # false), but Solid Queue re-raises any Active Record error from that INSERT as
-    # its own SolidQueue::Job::EnqueueError (not ActiveJob::EnqueueError, so it
-    # propagates instead of being swallowed), preserving the original as #cause. We
-    # match on the cause chain rather than that vendor class so a wrapped
-    # Deadlocked/LockWaitTimeout is still retried while a permanent wrapped failure
-    # (e.g. a validation error) is re-raised instead of looping.
+    # Whether an error is retryable transient contention, raised directly or wrapped.
+    # Solid Queue re-raises a failed `deliver_later` enqueue INSERT as its own
+    # EnqueueError with the original as #cause, so we match the cause chain — retrying
+    # a wrapped Deadlocked/LockWaitTimeout while re-raising a wrapped permanent failure.
     def transient_contention?(error)
       seen = []
       while error && !seen.include?(error)
@@ -178,19 +139,13 @@ module CollavreSlack
       false
     end
 
-    # Atomically claim this inbound message before any side effect runs. Returns true
-    # if this job won the claim (or the message carries no dedup key, so no dedup is
-    # possible — same as the prior behaviour) and false if another job already owns
-    # it and this run must no-op.
-    #
-    # A transient DB contention error (Deadlocked/LockWaitTimeout) on the INSERT is
-    # retried in place — it is NOT a "someone else claimed it" signal. Only a
-    # uniqueness violation means another delivery holds the claim: the DB unique index
-    # (RecordNotUnique) is the authoritative gate under true concurrency, and the model
-    # validation (RecordInvalid) covers the already-committed sequential case. Because
-    # the caller has already verified channel_link exists and message_ts is present,
-    # uniqueness is the ONLY validation that can fail here, so a RecordInvalid
-    # unambiguously means "already claimed" rather than a malformed reservation.
+    # Atomically claim this message before any side effect. True if we won the claim
+    # (or there's no dedup key — same as prior behaviour), false if another job owns it.
+    # Transient contention on the INSERT is retried in place, not a "claimed" signal.
+    # Only uniqueness means already-claimed: RecordNotUnique is the authoritative gate
+    # under concurrency, RecordInvalid covers the committed sequential case. channel_link
+    # and message_ts are verified present, so uniqueness is the only validation that can
+    # fail — RecordInvalid here unambiguously means "already claimed".
     def claim_inbound_message(data)
       channel_link_id = data[:slack_channel_link_id]
       message_ts = data[:slack_message_ts]
@@ -223,19 +178,15 @@ module CollavreSlack
         )
       end
     rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique
-      # A concurrent inbound message for the same user can create the share between
-      # our find_by above and this write, tripping the (creative_id, user_id)
-      # uniqueness validation (RecordInvalid) or its backing unique index
-      # (RecordNotUnique). The grant is already satisfied by that other job, so
-      # re-check and treat it as success. Without this, the RecordInvalid would
-      # escape to the job's global `discard_on ActiveRecord::RecordInvalid` and
-      # drop this still-unposted Slack message even though the grant succeeded.
+      # A concurrent message for the same user can create the share between the find_by
+      # above and this write, tripping the (creative_id, user_id) uniqueness. The grant
+      # is already satisfied, so re-check and treat as success — otherwise RecordInvalid
+      # would hit the job's `discard_on` and drop this still-unposted message.
       raise unless feedback_or_higher?(Collavre::CreativeShare.find_by(creative: creative, user: user))
     end
 
-    # Whether a CreativeShare already grants feedback access or higher. `permission`
-    # is an enum whose reader returns the string label, so rank it against the enum
-    # mapping the same way Collavre::Creative::Permissible does.
+    # Whether a CreativeShare grants feedback access or higher. `permission` is an enum
+    # returning the string label, so rank it via the enum mapping like Permissible does.
     def feedback_or_higher?(share)
       return false unless share
 
@@ -244,22 +195,16 @@ module CollavreSlack
     end
 
     def invite_user_by_email(creative:, email:, inviter:)
-      # A pre-existing invitation means an earlier attempt already created it AND
-      # enqueued its email in the same transaction (below), so there is nothing
-      # left to do — this guard is only ever hit for a genuinely repeated invite,
-      # never for a partially-applied one.
+      # A pre-existing invitation was created AND had its email enqueued in the same
+      # transaction below, so there's nothing left to do.
       existing_invitation = Collavre::Invitation.find_by(creative: creative, email: email)
       return if existing_invitation
 
-      # Create the invitation and enqueue its email atomically. `deliver_later`
-      # enqueues synchronously (enqueue_after_transaction_commit is false), so the
-      # Solid Queue enqueue INSERT participates in this transaction. If that INSERT
-      # raises a transient contention error — which Solid Queue surfaces as a
-      # SolidQueue::Job::EnqueueError wrapping the Deadlocked/LockWaitTimeout — the
-      # invitation create rolls back with it and the enclosing #with_transient_retry
-      # (which unwraps the cause chain) redoes both together. Without this
-      # transaction, a committed invitation with a failed enqueue would, on retry,
-      # hit the existing-invitation guard above and silently never send the email.
+      # Create invitation + enqueue email atomically. `deliver_later` enqueues
+      # synchronously, so its INSERT joins this transaction; a transient EnqueueError
+      # rolls both back and #with_transient_retry redoes them together. Without the
+      # transaction, a committed invitation with a failed enqueue would, on retry, hit
+      # the guard above and silently never send the email.
       ActiveRecord::Base.transaction do
         invitation = Collavre::Invitation.create!(
           email: email,

--- a/engines/collavre_slack/app/jobs/collavre_slack/slack_inbound_message_job.rb
+++ b/engines/collavre_slack/app/jobs/collavre_slack/slack_inbound_message_job.rb
@@ -30,33 +30,42 @@ module CollavreSlack
     def perform(payload)
       data = payload.with_indifferent_access
 
-      # Exactly-once guard, claimed BEFORE any side effect. The controller acks Slack
-      # before this job runs (at-least-once delivery), so the same message can be
-      # delivered twice — either sequentially (a redelivery after a completed run) or
-      # concurrently (a near-simultaneous retry of an unacked event, producing two
-      # in-flight jobs). A read-only "already applied?" check cannot cover the
-      # concurrent case: both jobs read "not applied" and both run the non-idempotent
-      # CommandProcessor below, duplicating its /calendar, /work and MCP side effects.
-      #
-      # Instead we atomically claim the (channel_link, message_ts) pair up front via a
-      # unique index. Only the row's winner proceeds; a loser (uniqueness violation)
-      # no-ops without ever reaching the commands. This is reserve-before-side-effects:
-      # the claim is deliberately taken before CommandProcessor, not after, so the
-      # commands run at most once across all deliveries of the message.
-      #
-      # Trade-off: a winner that hard-crashes between the claim and the final comment
-      # write loses that message (a later redelivery sees the claim and no-ops). This
-      # matches the existing crash-before-persist behaviour, and because the realistic
-      # duplicate is a near-simultaneous retry the winner almost always completes. We
-      # use no time-lease (expiry-based reclaim is fragile) rather than trading that
-      # narrow loss for a re-introduced duplicate-side-effect window.
-      return unless claim_inbound_message(data)
-
       creative = Collavre::Creative.find(data[:creative_id])
       user = Collavre.user_class.find_by(id: data[:user_id])
       channel_link = SlackChannelLink.find_by(id: data[:slack_channel_link_id])
 
       return unless creative && channel_link
+
+      # Exactly-once guard, claimed BEFORE any side effect but AFTER the reads above.
+      # The controller acks Slack before this job runs (at-least-once delivery), so the
+      # same message can be delivered twice — either sequentially (a redelivery after a
+      # completed run) or concurrently (a near-simultaneous retry of an unacked event,
+      # producing two in-flight jobs). A read-only "already applied?" check cannot cover
+      # the concurrent case: both jobs read "not applied" and both run the non-idempotent
+      # side effects below (the grant/invite writes and, critically, CommandProcessor's
+      # /calendar, /work and MCP commands), duplicating them.
+      #
+      # Instead we atomically claim the (channel_link, message_ts) pair via a unique
+      # index. Only the row's winner proceeds past this line; a loser (a concurrent
+      # RecordNotUnique or a sequential-redelivery RecordInvalid) no-ops without running
+      # any side effect. This is reserve-before-side-effects: the claim gates every write
+      # below, so they run at most once across all deliveries of the message.
+      #
+      # Placement is deliberate. Claiming AFTER the reads (not at the top of perform)
+      # keeps the only pre-claim failure a RecordNotFound on a deleted creative — which
+      # is deterministic and undeliverable, so leaving it un-gated loses nothing a retry
+      # could recover. It also guarantees channel_link exists before the claim, so the
+      # reservation's belongs_to/FK can never fail and a RecordInvalid here can only mean
+      # "already claimed".
+      #
+      # Trade-off: a discard (via discard_on) or crash AFTER this claim keeps the
+      # reservation, so that message is not retried. This is intentional — by that point
+      # CommandProcessor may already have run, and a retry would duplicate its
+      # non-idempotent commands, which is exactly the bug this change fixes. We prefer
+      # commands-exactly-once over comment-recovery, and use no time-lease (expiry-based
+      # reclaim is fragile). Transient contention BEFORE the commands is still retried in
+      # place below, so the realistic loss window is a hard crash mid-CommandProcessor.
+      return unless claim_inbound_message(data)
 
       comment_user = user.presence || channel_link.created_by
 
@@ -175,8 +184,11 @@ module CollavreSlack
     # A transient DB contention error (Deadlocked/LockWaitTimeout) on the INSERT is
     # retried in place — it is NOT a "someone else claimed it" signal. Only a
     # uniqueness violation means another delivery holds the claim: the DB unique index
-    # (RecordNotUnique) is the authoritative gate under true concurrency, and the
-    # model validation (RecordInvalid) covers the already-committed sequential case.
+    # (RecordNotUnique) is the authoritative gate under true concurrency, and the model
+    # validation (RecordInvalid) covers the already-committed sequential case. Because
+    # the caller has already verified channel_link exists and message_ts is present,
+    # uniqueness is the ONLY validation that can fail here, so a RecordInvalid
+    # unambiguously means "already claimed" rather than a malformed reservation.
     def claim_inbound_message(data)
       channel_link_id = data[:slack_channel_link_id]
       message_ts = data[:slack_message_ts]

--- a/engines/collavre_slack/app/jobs/collavre_slack/slack_inbound_message_job.rb
+++ b/engines/collavre_slack/app/jobs/collavre_slack/slack_inbound_message_job.rb
@@ -30,13 +30,27 @@ module CollavreSlack
     def perform(payload)
       data = payload.with_indifferent_access
 
-      # Idempotency guard. The controller acks Slack before this job runs
-      # (at-least-once delivery), and this job has multiple non-atomic writes. If a
-      # completed run is somehow re-delivered, reprocessing the same Slack message
-      # would create a duplicate comment. The (channel_link, message_ts) pair
-      # uniquely identifies the inbound message, so a matching SlackCommentLink
-      # means it was already applied — no-op.
-      return if slack_message_already_applied?(data)
+      # Exactly-once guard, claimed BEFORE any side effect. The controller acks Slack
+      # before this job runs (at-least-once delivery), so the same message can be
+      # delivered twice — either sequentially (a redelivery after a completed run) or
+      # concurrently (a near-simultaneous retry of an unacked event, producing two
+      # in-flight jobs). A read-only "already applied?" check cannot cover the
+      # concurrent case: both jobs read "not applied" and both run the non-idempotent
+      # CommandProcessor below, duplicating its /calendar, /work and MCP side effects.
+      #
+      # Instead we atomically claim the (channel_link, message_ts) pair up front via a
+      # unique index. Only the row's winner proceeds; a loser (uniqueness violation)
+      # no-ops without ever reaching the commands. This is reserve-before-side-effects:
+      # the claim is deliberately taken before CommandProcessor, not after, so the
+      # commands run at most once across all deliveries of the message.
+      #
+      # Trade-off: a winner that hard-crashes between the claim and the final comment
+      # write loses that message (a later redelivery sees the claim and no-ops). This
+      # matches the existing crash-before-persist behaviour, and because the realistic
+      # duplicate is a near-simultaneous retry the winner almost always completes. We
+      # use no time-lease (expiry-based reclaim is fragile) rather than trading that
+      # narrow loss for a re-introduced duplicate-side-effect window.
+      return unless claim_inbound_message(data)
 
       creative = Collavre::Creative.find(data[:creative_id])
       user = Collavre.user_class.find_by(id: data[:user_id])
@@ -153,13 +167,30 @@ module CollavreSlack
       false
     end
 
-    def slack_message_already_applied?(data)
-      return false unless data[:slack_channel_link_id].present? && data[:slack_message_ts].present?
+    # Atomically claim this inbound message before any side effect runs. Returns true
+    # if this job won the claim (or the message carries no dedup key, so no dedup is
+    # possible — same as the prior behaviour) and false if another job already owns
+    # it and this run must no-op.
+    #
+    # A transient DB contention error (Deadlocked/LockWaitTimeout) on the INSERT is
+    # retried in place — it is NOT a "someone else claimed it" signal. Only a
+    # uniqueness violation means another delivery holds the claim: the DB unique index
+    # (RecordNotUnique) is the authoritative gate under true concurrency, and the
+    # model validation (RecordInvalid) covers the already-committed sequential case.
+    def claim_inbound_message(data)
+      channel_link_id = data[:slack_channel_link_id]
+      message_ts = data[:slack_message_ts]
+      return true unless channel_link_id.present? && message_ts.present?
 
-      SlackCommentLink.exists?(
-        slack_channel_link_id: data[:slack_channel_link_id],
-        message_ts: data[:slack_message_ts]
-      )
+      with_transient_retry do
+        SlackInboundReservation.create!(
+          slack_channel_link_id: channel_link_id,
+          message_ts: message_ts
+        )
+      end
+      true
+    rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid
+      false
     end
 
     def grant_feedback_permission(creative:, user:, granter:)

--- a/engines/collavre_slack/app/jobs/collavre_slack/slack_inbound_message_job.rb
+++ b/engines/collavre_slack/app/jobs/collavre_slack/slack_inbound_message_job.rb
@@ -63,8 +63,10 @@ module CollavreSlack
       # CommandProcessor may already have run, and a retry would duplicate its
       # non-idempotent commands, which is exactly the bug this change fixes. We prefer
       # commands-exactly-once over comment-recovery, and use no time-lease (expiry-based
-      # reclaim is fragile). Transient contention BEFORE the commands is still retried in
-      # place below, so the realistic loss window is a hard crash mid-CommandProcessor.
+      # reclaim is fragile). Transient contention on the writes below is still retried in
+      # place, so the realistic loss window is a hard crash (process death) after the
+      # claim but before the comment is persisted — spanning the grant/invite writes and
+      # CommandProcessor. The grant/invite writes there are themselves idempotent.
       return unless claim_inbound_message(data)
 
       comment_user = user.presence || channel_link.created_by

--- a/engines/collavre_slack/app/models/collavre_slack/slack_channel_link.rb
+++ b/engines/collavre_slack/app/models/collavre_slack/slack_channel_link.rb
@@ -8,6 +8,7 @@ module CollavreSlack
 
     has_many :slack_message_logs, class_name: "CollavreSlack::SlackMessageLog", dependent: :destroy
     has_many :slack_comment_links, class_name: "CollavreSlack::SlackCommentLink", dependent: :destroy
+    has_many :slack_inbound_reservations, class_name: "CollavreSlack::SlackInboundReservation", dependent: :destroy
 
     validates :channel_id, :channel_name, presence: true
     # 1:1 relationship: one creative can only be linked to one Slack channel

--- a/engines/collavre_slack/app/models/collavre_slack/slack_inbound_reservation.rb
+++ b/engines/collavre_slack/app/models/collavre_slack/slack_inbound_reservation.rb
@@ -1,0 +1,16 @@
+module CollavreSlack
+  # A pre-flight claim on an inbound Slack message, inserted by
+  # SlackInboundMessageJob before it runs the non-idempotent CommandProcessor. The
+  # unique (slack_channel_link_id, message_ts) index makes the claim atomic: of two
+  # concurrent jobs for the same message, exactly one inserts a row and proceeds to
+  # the side effects; the other trips the index and no-ops. See the job for the
+  # crash-window trade-off.
+  class SlackInboundReservation < ApplicationRecord
+    self.table_name = "slack_inbound_reservations"
+
+    belongs_to :slack_channel_link, class_name: "CollavreSlack::SlackChannelLink"
+
+    validates :message_ts, presence: true
+    validates :message_ts, uniqueness: { scope: :slack_channel_link_id }
+  end
+end

--- a/engines/collavre_slack/app/models/collavre_slack/slack_inbound_reservation.rb
+++ b/engines/collavre_slack/app/models/collavre_slack/slack_inbound_reservation.rb
@@ -1,10 +1,8 @@
 module CollavreSlack
-  # A pre-flight claim on an inbound Slack message, inserted by
-  # SlackInboundMessageJob before it runs the non-idempotent CommandProcessor. The
-  # unique (slack_channel_link_id, message_ts) index makes the claim atomic: of two
-  # concurrent jobs for the same message, exactly one inserts a row and proceeds to
-  # the side effects; the other trips the index and no-ops. See the job for the
-  # crash-window trade-off.
+  # Pre-flight claim on an inbound Slack message so its non-idempotent side effects
+  # run once. The unique (slack_channel_link_id, message_ts) index makes the claim
+  # atomic: of two concurrent jobs, only one inserts and proceeds. See the job for
+  # the crash-window trade-off.
   class SlackInboundReservation < ApplicationRecord
     self.table_name = "slack_inbound_reservations"
 

--- a/engines/collavre_slack/db/migrate/20260712000000_create_slack_inbound_reservations.rb
+++ b/engines/collavre_slack/db/migrate/20260712000000_create_slack_inbound_reservations.rb
@@ -1,11 +1,9 @@
 class CreateSlackInboundReservations < ActiveRecord::Migration[8.0]
   def change
-    # Pre-flight claim for an inbound Slack message. SlackInboundMessageJob inserts
-    # a reservation row before running the non-idempotent CommandProcessor, so under
-    # concurrent/redelivered delivery of the same message only the row's winner runs
-    # the commands. The unique (slack_channel_link_id, message_ts) index is the
-    # atomic gate — the same key the completed comment link uses, but claimed up
-    # front rather than after the side effects.
+    # Pre-flight claim so an inbound Slack message's non-idempotent side effects run
+    # once under concurrent/redelivered delivery. The unique (slack_channel_link_id,
+    # message_ts) index is the atomic gate, claimed up front rather than after the
+    # side effects.
     create_table :slack_inbound_reservations do |t|
       t.references :slack_channel_link, null: false, foreign_key: { on_delete: :cascade }
       t.string :message_ts, null: false

--- a/engines/collavre_slack/db/migrate/20260712000000_create_slack_inbound_reservations.rb
+++ b/engines/collavre_slack/db/migrate/20260712000000_create_slack_inbound_reservations.rb
@@ -1,0 +1,19 @@
+class CreateSlackInboundReservations < ActiveRecord::Migration[8.0]
+  def change
+    # Pre-flight claim for an inbound Slack message. SlackInboundMessageJob inserts
+    # a reservation row before running the non-idempotent CommandProcessor, so under
+    # concurrent/redelivered delivery of the same message only the row's winner runs
+    # the commands. The unique (slack_channel_link_id, message_ts) index is the
+    # atomic gate — the same key the completed comment link uses, but claimed up
+    # front rather than after the side effects.
+    create_table :slack_inbound_reservations do |t|
+      t.references :slack_channel_link, null: false, foreign_key: { on_delete: :cascade }
+      t.string :message_ts, null: false
+
+      t.timestamps
+    end
+
+    add_index :slack_inbound_reservations, [ :slack_channel_link_id, :message_ts ],
+      unique: true, name: "idx_slack_inbound_reservations_on_channel_and_ts"
+  end
+end

--- a/engines/collavre_slack/test/jobs/slack_inbound_message_job_test.rb
+++ b/engines/collavre_slack/test/jobs/slack_inbound_message_job_test.rb
@@ -301,15 +301,13 @@ module CollavreSlack
     end
 
     test "a message already claimed by a concurrent delivery no-ops before running commands" do
-      # The exactly-once guarantee: the reservation is claimed BEFORE CommandProcessor,
-      # so a second, concurrent job for the same message (whose winner already claimed
-      # the (channel_link, message_ts) pair) bails without ever running the
-      # non-idempotent commands — no duplicate /calendar event, /work task or MCP call.
+      # The claim precedes CommandProcessor, so a loser whose winner already claimed
+      # the pair must bail without running the non-idempotent commands.
       slack_user = create_user(email: "concurrent-claim@example.com", name: "Concurrent Claim")
       Collavre::CreativeShare.create!(creative: @creative, user: slack_user, permission: :feedback)
 
       ts = "1700000000.246810"
-      # Stand in for the winning concurrent job: it already claimed this exact message.
+      # Stand in for the winning job: it already claimed this message.
       CollavreSlack::SlackInboundReservation.create!(slack_channel_link: @channel_link, message_ts: ts)
 
       payload = {
@@ -379,10 +377,8 @@ module CollavreSlack
     end
 
     test "a transient deadlock on the reservation claim is retried, not mistaken for a duplicate" do
-      # The claim INSERT can itself hit transient DB contention. That is NOT a
-      # "someone else already claimed it" signal — treating it as one would silently
-      # drop the already-acked Slack message. It must be retried in place, and only a
-      # uniqueness violation is allowed to no-op the job.
+      # Transient contention on the claim INSERT is not a "claimed" signal — treating
+      # it as one would drop the acked message. Only uniqueness may no-op the job.
       slack_user = create_user(email: "claimretry@example.com", name: "Claim Retry")
       Collavre::CreativeShare.create!(creative: @creative, user: slack_user, permission: :feedback)
 
@@ -420,12 +416,10 @@ module CollavreSlack
     end
 
     test "a concurrent claim losing the DB unique index (RecordNotUnique) no-ops before running commands" do
-      # Under TRUE concurrency the model's uniqueness validation SELECT can pass in both
-      # jobs (neither sees the other's uncommitted row), so the losing job is rejected by
-      # the DB unique index — surfacing as ActiveRecord::RecordNotUnique, not
-      # RecordInvalid. That authoritative-gate branch is what the fix relies on; drive it
-      # directly by simulating the index rejecting our INSERT. The loser must no-op
-      # WITHOUT running CommandProcessor (reserve-before-side-effects).
+      # Under true concurrency both jobs' uniqueness SELECT passes (neither sees the
+      # other's uncommitted row), so the loser is rejected by the DB index as
+      # RecordNotUnique — the authoritative gate the fix relies on. Drive it directly;
+      # the loser must no-op without running CommandProcessor.
       slack_user = create_user(email: "dbrace@example.com", name: "DB Race")
       Collavre::CreativeShare.create!(creative: @creative, user: slack_user, permission: :feedback)
 
@@ -462,10 +456,8 @@ module CollavreSlack
     end
 
     test "a message for a deleted channel link claims no reservation and no-ops" do
-      # The claim is taken only after channel_link is verified present, so a payload
-      # whose channel link has been deleted returns at the `creative && channel_link`
-      # guard — it must NOT insert a reservation (which would otherwise wedge a valid
-      # redelivery) and must not raise.
+      # The claim runs only after channel_link is verified, so a deleted link returns
+      # at the guard — no reservation inserted (which would wedge a valid redelivery).
       slack_user = create_user(email: "deadlink@example.com", name: "Dead Link")
       Collavre::CreativeShare.create!(creative: @creative, user: slack_user, permission: :feedback)
       missing_link_id = @channel_link.id

--- a/engines/collavre_slack/test/jobs/slack_inbound_message_job_test.rb
+++ b/engines/collavre_slack/test/jobs/slack_inbound_message_job_test.rb
@@ -300,6 +300,125 @@ module CollavreSlack
       end
     end
 
+    test "a message already claimed by a concurrent delivery no-ops before running commands" do
+      # The exactly-once guarantee: the reservation is claimed BEFORE CommandProcessor,
+      # so a second, concurrent job for the same message (whose winner already claimed
+      # the (channel_link, message_ts) pair) bails without ever running the
+      # non-idempotent commands — no duplicate /calendar event, /work task or MCP call.
+      slack_user = create_user(email: "concurrent-claim@example.com", name: "Concurrent Claim")
+      Collavre::CreativeShare.create!(creative: @creative, user: slack_user, permission: :feedback)
+
+      ts = "1700000000.246810"
+      # Stand in for the winning concurrent job: it already claimed this exact message.
+      CollavreSlack::SlackInboundReservation.create!(slack_channel_link: @channel_link, message_ts: ts)
+
+      payload = {
+        creative_id: @creative.id,
+        user_id: slack_user.id,
+        content: "duplicate delivery",
+        slack_channel_link_id: @channel_link.id,
+        slack_message_ts: ts,
+        slack_display_name: "Concurrent Claim",
+        slack_email: "concurrent-claim@example.com",
+        slack_user_id: "U246"
+      }
+
+      command_called = false
+      fake_processor = Object.new
+      fake_processor.define_singleton_method(:call) do
+        command_called = true
+        nil
+      end
+
+      Collavre::Comments::CommandProcessor.stub(:new, ->(**) { fake_processor }) do
+        assert_no_difference [ "@creative.comments.count", "CollavreSlack::SlackCommentLink.count",
+                              "CollavreSlack::SlackInboundReservation.count" ] do
+          SlackInboundMessageJob.perform_now(payload)
+        end
+      end
+
+      refute command_called,
+             "CommandProcessor must not run when the message is already claimed (reserve-before-side-effects)"
+    end
+
+    test "duplicate deliveries run CommandProcessor exactly once and claim exactly one reservation" do
+      slack_user = create_user(email: "once@example.com", name: "Once User")
+      Collavre::CreativeShare.create!(creative: @creative, user: slack_user, permission: :feedback)
+
+      ts = "1700000000.135791"
+      payload = {
+        creative_id: @creative.id,
+        user_id: slack_user.id,
+        content: "exactly once",
+        slack_channel_link_id: @channel_link.id,
+        slack_message_ts: ts,
+        slack_display_name: "Once User",
+        slack_email: "once@example.com",
+        slack_user_id: "U135"
+      }
+
+      command_calls = 0
+      fake_processor = Object.new
+      fake_processor.define_singleton_method(:call) do
+        command_calls += 1
+        nil
+      end
+
+      creative_comment_count = @creative.comments.count
+      Collavre::Comments::CommandProcessor.stub(:new, ->(**) { fake_processor }) do
+        SlackInboundMessageJob.perform_now(payload)
+        # Redelivery of the identical message (the concurrent-loser / retry path).
+        SlackInboundMessageJob.perform_now(payload)
+      end
+
+      assert_equal 1, command_calls, "CommandProcessor must run exactly once across duplicate deliveries"
+      assert_equal creative_comment_count + 1, @creative.comments.reload.count, "exactly one comment"
+      assert_equal 1, CollavreSlack::SlackInboundReservation.where(
+        slack_channel_link_id: @channel_link.id, message_ts: ts
+      ).count, "exactly one reservation claimed"
+    end
+
+    test "a transient deadlock on the reservation claim is retried, not mistaken for a duplicate" do
+      # The claim INSERT can itself hit transient DB contention. That is NOT a
+      # "someone else already claimed it" signal — treating it as one would silently
+      # drop the already-acked Slack message. It must be retried in place, and only a
+      # uniqueness violation is allowed to no-op the job.
+      slack_user = create_user(email: "claimretry@example.com", name: "Claim Retry")
+      Collavre::CreativeShare.create!(creative: @creative, user: slack_user, permission: :feedback)
+
+      ts = "1700000000.112233"
+      payload = {
+        creative_id: @creative.id,
+        user_id: slack_user.id,
+        content: "claim then comment",
+        slack_channel_link_id: @channel_link.id,
+        slack_message_ts: ts,
+        slack_display_name: "Claim Retry",
+        slack_email: "claimretry@example.com",
+        slack_user_id: "U112"
+      }
+
+      claim_calls = 0
+      original_create = CollavreSlack::SlackInboundReservation.method(:create!)
+      creative_comment_count = @creative.comments.count
+
+      CollavreSlack::SlackInboundReservation.stub(:create!, ->(*args, **kwargs) {
+        claim_calls += 1
+        raise ActiveRecord::Deadlocked, "claim deadlock" if claim_calls == 1
+
+        original_create.call(*args, **kwargs)
+      }) do
+        SlackInboundMessageJob.perform_now(payload)
+      end
+
+      assert_equal 2, claim_calls, "the claim should be retried once after a transient deadlock"
+      # The message was NOT dropped: the comment was created and the claim persisted.
+      assert_equal creative_comment_count + 1, @creative.comments.reload.count
+      assert_equal 1, CollavreSlack::SlackInboundReservation.where(
+        slack_channel_link_id: @channel_link.id, message_ts: ts
+      ).count
+    end
+
     test "retries only the write on transient deadlock and runs commands exactly once" do
       slack_user = create_user(email: "retry@example.com", name: "Retry User")
       Collavre::CreativeShare.create!(creative: @creative, user: slack_user, permission: :feedback)

--- a/engines/collavre_slack/test/jobs/slack_inbound_message_job_test.rb
+++ b/engines/collavre_slack/test/jobs/slack_inbound_message_job_test.rb
@@ -419,6 +419,74 @@ module CollavreSlack
       ).count
     end
 
+    test "a concurrent claim losing the DB unique index (RecordNotUnique) no-ops before running commands" do
+      # Under TRUE concurrency the model's uniqueness validation SELECT can pass in both
+      # jobs (neither sees the other's uncommitted row), so the losing job is rejected by
+      # the DB unique index — surfacing as ActiveRecord::RecordNotUnique, not
+      # RecordInvalid. That authoritative-gate branch is what the fix relies on; drive it
+      # directly by simulating the index rejecting our INSERT. The loser must no-op
+      # WITHOUT running CommandProcessor (reserve-before-side-effects).
+      slack_user = create_user(email: "dbrace@example.com", name: "DB Race")
+      Collavre::CreativeShare.create!(creative: @creative, user: slack_user, permission: :feedback)
+
+      payload = {
+        creative_id: @creative.id,
+        user_id: slack_user.id,
+        content: "lost the index race",
+        slack_channel_link_id: @channel_link.id,
+        slack_message_ts: "1700000000.202020",
+        slack_display_name: "DB Race",
+        slack_email: "dbrace@example.com",
+        slack_user_id: "U202"
+      }
+
+      command_called = false
+      fake_processor = Object.new
+      fake_processor.define_singleton_method(:call) do
+        command_called = true
+        nil
+      end
+
+      Collavre::Comments::CommandProcessor.stub(:new, ->(**) { fake_processor }) do
+        CollavreSlack::SlackInboundReservation.stub(:create!, ->(**_kwargs) {
+          raise ActiveRecord::RecordNotUnique, "duplicate key value violates unique constraint"
+        }) do
+          assert_no_difference [ "@creative.comments.count", "CollavreSlack::SlackCommentLink.count" ] do
+            assert_nothing_raised { SlackInboundMessageJob.perform_now(payload) }
+          end
+        end
+      end
+
+      refute command_called,
+             "CommandProcessor must not run when the DB unique index rejects the claim (concurrent loser)"
+    end
+
+    test "a message for a deleted channel link claims no reservation and no-ops" do
+      # The claim is taken only after channel_link is verified present, so a payload
+      # whose channel link has been deleted returns at the `creative && channel_link`
+      # guard — it must NOT insert a reservation (which would otherwise wedge a valid
+      # redelivery) and must not raise.
+      slack_user = create_user(email: "deadlink@example.com", name: "Dead Link")
+      Collavre::CreativeShare.create!(creative: @creative, user: slack_user, permission: :feedback)
+      missing_link_id = @channel_link.id
+      @channel_link.destroy!
+
+      payload = {
+        creative_id: @creative.id,
+        user_id: slack_user.id,
+        content: "channel link is gone",
+        slack_channel_link_id: missing_link_id,
+        slack_message_ts: "1700000000.303030",
+        slack_display_name: "Dead Link",
+        slack_email: "deadlink@example.com",
+        slack_user_id: "U303"
+      }
+
+      assert_no_difference [ "@creative.comments.count", "CollavreSlack::SlackInboundReservation.count" ] do
+        assert_nothing_raised { SlackInboundMessageJob.perform_now(payload) }
+      end
+    end
+
     test "retries only the write on transient deadlock and runs commands exactly once" do
       slack_user = create_user(email: "retry@example.com", name: "Retry User")
       Collavre::CreativeShare.create!(creative: @creative, user: slack_user, permission: :feedback)


### PR DESCRIPTION
## Problem

`SlackInboundMessageJob`'s idempotency guard (`slack_message_already_applied?`) was a **read-only** check run before the non-idempotent `CommandProcessor`. This is a TOCTOU race under **concurrent** delivery of the same Slack message:

- The controller acks Slack *before* the job runs (ack-before-apply). A near-simultaneous retry of an unacked event produces **two in-flight jobs** for the same `(channel_link, message_ts)`.
- Both jobs read "not applied" at the guard, both proceed, and both run `CommandProcessor` — duplicating its side effects: `/calendar` → `CalendarEvent`, `/work` → tasks, MCP commands.
- The existing unique index `idx_slack_comment_links_on_channel_and_ts` only dedupes the **final** comment-link write (line 90), which happens **after** the commands (line 84) have already doubled. The loser then trips the index and gets discarded — but the duplicate calendar event / task is already committed.

This is the deferred `line 39` follow-up from the webhook-hardening pass (#1368): the read-guard covers sequential redelivery but not concurrent delivery.

## Fix — reserve-before-side-effects

Replace the read-check with an **atomic claim** taken *before* any side effect:

- New table `slack_inbound_reservations` with a unique index on `(slack_channel_link_id, message_ts)`.
- At the top of `perform`, `create!` a reservation for the pair. Only the row's **winner** proceeds to `CommandProcessor`; a **loser** trips the unique index (`RecordNotUnique` / `RecordInvalid`) and **no-ops without ever reaching the commands**.
- Transient contention (`Deadlocked` / `LockWaitTimeout`) on the claim INSERT is retried in place via the existing `with_transient_retry` — it is **not** mistaken for a duplicate, which would silently drop the already-acked message.
- The reservation **subsumes** the old read-guard: sequential redelivery *and* concurrent delivery now both no-op, but the non-idempotent commands run **at most once** across all deliveries.

Cross-DB portable (SQLite dev + Postgres prod) — no `pg_advisory_xact_lock` / cross-DB lock abstraction needed.

### Trade-off (documented in-code)

A winner that **hard-crashes between claim and persist** loses that message (a later redelivery sees the claim and no-ops). This matches the **existing** crash-before-persist behaviour, and because the realistic duplicate is a near-simultaneous retry, the winner almost always completes. No time-lease is used — expiry-based reclaim is fragile and would trade this narrow window for a re-introduced duplicate-side-effect window.

## Tests

New (`slack_inbound_message_job_test.rb`):
- already-claimed message no-ops **before** running commands (asserts `CommandProcessor` is never constructed)
- duplicate deliveries run `CommandProcessor` **exactly once** and claim **exactly one** reservation
- transient deadlock on the claim is **retried**, not mistaken for a duplicate (message not dropped)

All 15 job tests + 3 retry tests green; rubocop clean.