### PR TITLE
fix(slack): claim after idempotent grant/invite so transient failures stay recoverable

### DIFF
--- a/engines/collavre_slack/app/jobs/collavre_slack/slack_inbound_message_job.rb
+++ b/engines/collavre_slack/app/jobs/collavre_slack/slack_inbound_message_job.rb
@@ -23,29 +23,14 @@ module CollavreSlack
 
       return unless creative && channel_link
 
-      # Exactly-once guard claimed before any side effect. Slack is acked before this
-      # job runs, so a message can arrive twice — sequentially or concurrently. A
-      # read-only "already applied?" check can't cover the concurrent case: both jobs
-      # read "not applied" and both run the non-idempotent side effects below. Instead
-      # we atomically claim (channel_link, message_ts) via a unique index; only the
-      # winner proceeds, so every write below runs at most once.
-      #
-      # Claimed AFTER the reads so the only pre-claim failure is a RecordNotFound on a
-      # deleted creative (deterministic, unrecoverable — nothing lost by leaving it
-      # un-gated), and channel_link is guaranteed present so a RecordInvalid can only
-      # mean "already claimed".
-      #
-      # Trade-off: a discard/crash after the claim keeps the reservation and skips
-      # retry — intentional, since CommandProcessor may have run and a retry would
-      # duplicate it. No time-lease (expiry reclaim is fragile). The only real loss
-      # window is a hard crash after the claim but before the comment persists.
-      return unless claim_inbound_message(data)
-
       comment_user = user.presence || channel_link.created_by
 
-      # Idempotent permission grant / invite writes, run before the non-idempotent
-      # CommandProcessor so they can't ride a whole-job retry. Retried in place on
-      # transient contention — otherwise a Deadlocked here loses the acked message.
+      # Idempotent permission grant / invite writes. Run BEFORE the exactly-once claim so
+      # a transient failure here (e.g. a Solid Queue enqueue deadlock that exhausts the
+      # in-place retries) commits no reservation — a failed-job retry can still reprocess
+      # the message. Each re-checks the existing share/invitation, so a sequential re-run
+      # is a no-op. Retried in place on transient contention — otherwise a Deadlocked here
+      # loses the acked message.
       with_transient_retry do
         # Case 1: User exists in Collavre but lacks permission
         if user && !creative.has_permission?(user, :feedback)
@@ -63,6 +48,22 @@ module CollavreSlack
           Rails.logger.info("[CollavreSlack] Sent invitation to #{data[:slack_email]} for creative #{creative.id}")
         end
       end
+
+      # Exactly-once guard, claimed here: after the idempotent writes above, immediately
+      # before the non-idempotent CommandProcessor (/calendar, /work, MCP). Slack is acked
+      # before this job runs, so a message can arrive twice (sequentially or concurrently);
+      # a read-only "already applied?" check can't cover concurrency — both jobs read "not
+      # applied" and both run the commands. We atomically claim (channel_link, message_ts)
+      # via a unique index, so only the winner runs CommandProcessor and persists.
+      #
+      # Placed after the reads and the idempotent writes so no recoverable failure leaves a
+      # reservation behind: every pre-claim error is either a deterministic RecordNotFound
+      # (deleted creative) or a transient grant/invite failure a retry can redo. Only past
+      # the claim do we reach the non-idempotent commands, so the sole loss window is a
+      # discard/crash between the claim and the comment persisting — intentional, since a
+      # retry there would duplicate the commands. No time-lease (expiry reclaim is fragile).
+      # channel_link is verified present, so a RecordInvalid can only mean "already claimed".
+      return unless claim_inbound_message(data)
 
       # Create comment with appropriate user
       comment = Collavre::Comment.new(
@@ -139,7 +140,7 @@ module CollavreSlack
       false
     end
 
-    # Atomically claim this message before any side effect. True if we won the claim
+    # Atomically claim this message before the non-idempotent commands. True if we won the claim
     # (or there's no dedup key — same as prior behaviour), false if another job owns it.
     # Transient contention on the INSERT is retried in place, not a "claimed" signal.
     # Only uniqueness means already-claimed: RecordNotUnique is the authoritative gate

--- a/engines/collavre_slack/app/jobs/collavre_slack/slack_inbound_message_job.rb
+++ b/engines/collavre_slack/app/jobs/collavre_slack/slack_inbound_message_job.rb
@@ -197,7 +197,12 @@ module CollavreSlack
 
     def invite_user_by_email(creative:, email:, inviter:)
       # A pre-existing invitation was created AND had its email enqueued in the same
-      # transaction below, so there's nothing left to do.
+      # transaction below, so there's nothing left to do. This dedups sequential
+      # redelivery; a true concurrent double-delivery can still create two invitations
+      # (no unique index on (creative_id, email)) — accepted, since a duplicate invite
+      # email is far less harmful than a lost message. If such an index is ever added,
+      # rescue RecordNotUnique + re-check here like #grant_feedback_permission does,
+      # otherwise the concurrent loser's create! would escape as a hard job failure.
       existing_invitation = Collavre::Invitation.find_by(creative: creative, email: email)
       return if existing_invitation
 

--- a/engines/collavre_slack/test/jobs/slack_inbound_message_job_test.rb
+++ b/engines/collavre_slack/test/jobs/slack_inbound_message_job_test.rb
@@ -479,6 +479,52 @@ module CollavreSlack
       end
     end
 
+    test "a failed pre-command write leaves no reservation, so a retry still reprocesses" do
+      # Codex P2 regression: the exactly-once claim sits AFTER the idempotent grant/invite
+      # writes. If one of those exhausts its in-place retries and raises, no reservation is
+      # committed — so the failed job (or a redelivery) reprocesses the still-unposted
+      # message instead of being permanently no-op'd by a stale claim.
+      ts = "1700000000.424242"
+      payload = {
+        creative_id: @creative.id,
+        user_id: nil,
+        content: "invite me",
+        slack_channel_link_id: @channel_link.id,
+        slack_message_ts: ts,
+        slack_display_name: "Recover User",
+        slack_email: "recover@slack.com",
+        slack_user_id: "U424"
+      }
+
+      # First delivery: the invite enqueue deadlocks on every attempt, exhausting the
+      # in-place retries so perform raises (the acked message is momentarily lost).
+      always_deadlock = Object.new
+      always_deadlock.define_singleton_method(:deliver_later) do
+        raise ActiveRecord::Deadlocked, "persistent enqueue deadlock"
+      end
+      fake_mailer = Object.new
+      fake_mailer.define_singleton_method(:invite) { always_deadlock }
+
+      Collavre::InvitationMailer.stub(:with, ->(**_kwargs) { fake_mailer }) do
+        assert_raises(ActiveRecord::Deadlocked) { SlackInboundMessageJob.perform_now(payload) }
+      end
+
+      # The crux: the pre-claim failure committed NO reservation (and rolled back its
+      # invitation) — nothing is wedged, so the redelivery below is not a stale-claim no-op.
+      assert_equal 0, CollavreSlack::SlackInboundReservation.where(
+        slack_channel_link_id: @channel_link.id, message_ts: ts
+      ).count, "a pre-claim failure must not leave a reservation behind"
+      assert_equal 0, Collavre::Invitation.where(email: "recover@slack.com", creative: @creative).count
+
+      # Retry with the transient fault cleared: the message reprocesses to completion.
+      assert_difference [ "Collavre::Invitation.count", "Collavre::Comment.count" ], 1 do
+        SlackInboundMessageJob.perform_now(payload)
+      end
+      assert_equal 1, CollavreSlack::SlackInboundReservation.where(
+        slack_channel_link_id: @channel_link.id, message_ts: ts
+      ).count, "the successful retry claims the reservation exactly once"
+    end
+
     test "retries only the write on transient deadlock and runs commands exactly once" do
       slack_user = create_user(email: "retry@example.com", name: "Retry User")
       Collavre::CreativeShare.create!(creative: @creative, user: slack_user, permission: :feedback)


### PR DESCRIPTION
## Problem

Follow-up to a Codex P2 finding on #1370. The exactly-once reservation claim was placed **before** the idempotent permission-grant / invite writes in `SlackInboundMessageJob#perform`.

When one of those writes exhausts its in-place transient-contention retries and raises — e.g. a persistent Solid Queue enqueue deadlock while inviting an unmapped Slack user — the reservation has **already committed**, even though `CommandProcessor` and the comment persistence never ran. Any subsequent failed-job retry or duplicate Slack delivery then trips the claim's unique index and returns a no-op, so the still-unposted message is **permanently skipped**. (Before #1370 there was no reservation, so a retry could still reprocess.)

The trade-off comment introduced in #1370 also understated this: it claimed the only loss window was "a hard crash before the comment persists", but a retry-exhausting failure in the grant/invite block was an additional — and likelier — loss window.

## Fix

Move the claim to **immediately before the non-idempotent `CommandProcessor`**, i.e. past the reads *and* the idempotent grant/invite writes.

- The grant/invite writes each re-check the existing share/invitation, so re-running them on a sequential retry is a no-op — they don't need the claim's protection.
- Every **pre-claim** error is now either a deterministic `RecordNotFound` (deleted creative — unrecoverable anyway) or a transient grant/invite failure a retry can **redo**. No recoverable failure leaves a reservation behind.
- `CommandProcessor` (the genuinely non-idempotent part: `/calendar`→CalendarEvent, `/work`→tasks, MCP) still runs **at most once**. The only remaining loss window is a discard/crash *between* the claim and the comment persisting — inherent, since a retry there would duplicate the commands.
- The round-1 invariant holds: `channel_link` is still verified present before the claim, so a `RecordInvalid` there can only mean "already claimed".

### Concurrency trade-off (explicit)

Under a true concurrent double-delivery, both jobs now run the idempotent grant/invite **before** racing for the claim. The grant path stays uniqueness-safe (rescues `RecordInvalid`/`RecordNotUnique` and re-checks). The invite path, however, has no unique index on invitations `(creative_id, email)`, so two concurrent jobs can each create an invitation → **a duplicate invitation row + email**.

This **re-surrenders the incidental dedup that #1370's early claim happened to provide** — it is *not* "unchanged". It matches the *pre-#1370* baseline. It's an accepted trade: a rare duplicate invite email (self-limiting; later messages find the existing invitation) is far less harmful than a silently lost message. Fully closing it would require a unique index on `(creative_id, email)` **plus** a symmetric `RecordNotUnique` rescue in `invite_user_by_email` — deferred as out-of-scope schema work (a bare index risks failing the migration on any existing duplicate rows). A code comment now flags this so the index isn't added without the rescue.

## Tests

Added a regression test proving a **pre-claim invite failure leaves no reservation** and a redelivery reprocesses to completion (claiming exactly one reservation). The test discriminates against the old order: with the claim first, the post-failure "0 reservations" assertion would fail. Full `SlackInboundMessageJob` suite (18) + retry suite (3) green; rubocop clean.

## Adversarial review

Reviewed by an independent skeptical agent tasked to refute the fix. Verdict: **MERGEABLE**. It confirmed `CommandProcessor` stays at-most-once in every interleaving, the discard paths now favor recovery over permanent skip, and the regression test is valid and discriminating. Its two MINOR points — the concurrency trade-off above (now stated precisely) and the invite/grant rescue asymmetry (now flagged in a comment) — are addressed.