### PR TITLE
refactor: back Task#status and InboxItem#state with string enums

### DIFF
--- a/engines/collavre/app/controllers/collavre/inbox_items_controller.rb
+++ b/engines/collavre/app/controllers/collavre/inbox_items_controller.rb
@@ -38,12 +38,18 @@ module Collavre
     end
 
     def update
-      if @inbox_item.owner == Current.user
-        @inbox_item.update(state: params[:state])
-        head :no_content
-      else
+      unless @inbox_item.owner == Current.user
         head :forbidden
+        return
       end
+
+      unless InboxItem.states.key?(params[:state].to_s)
+        head :unprocessable_entity
+        return
+      end
+
+      @inbox_item.update(state: params[:state])
+      head :no_content
     end
 
     def destroy

--- a/engines/collavre/app/models/collavre/inbox_item.rb
+++ b/engines/collavre/app/models/collavre/inbox_item.rb
@@ -16,10 +16,10 @@ module Collavre
     after_commit :broadcast_badge_update, on: %i[create update destroy]
     after_create_commit :enqueue_push_notification
 
-    attribute :state, :string, default: "new"
-    validates :state, inclusion: { in: %w[new read archived] }
+    enum :state, { new: "new", read: "read", archived: "archived" }, default: :new, scopes: false
     validates :message_key, presence: true
 
+    # Kept explicit (not enum's generated `.new` class-scope, which collides with the constructor).
     scope :new_items, -> { where(state: "new") }
 
     def localized_message(locale: I18n.locale)

--- a/engines/collavre/app/models/collavre/task.rb
+++ b/engines/collavre/app/models/collavre/task.rb
@@ -11,6 +11,18 @@ module Collavre
 
     validates :name, presence: true
 
+    enum :status, {
+      pending: "pending",
+      queued: "queued",
+      running: "running",
+      delegated: "delegated",
+      pending_approval: "pending_approval",
+      done: "done",
+      failed: "failed",
+      cancelled: "cancelled",
+      escalated: "escalated"
+    }, default: :pending
+
     after_update_commit :check_trigger_loop_completion, if: :trigger_loop_candidate?
     after_update_commit :broadcast_stop_button_removal, if: :became_terminal?
 

--- a/engines/collavre/test/controllers/inbox_items_controller_test.rb
+++ b/engines/collavre/test/controllers/inbox_items_controller_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class InboxItemsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:one)
+    @item = InboxItem.create!(message_key: "inbox.no_messages", owner: @user, message_params: {})
+    sign_in_as(@user, password: "password")
+  end
+
+  test "update to a valid state marks it read" do
+    patch inbox_item_url(@item), params: { state: "read" }, as: :json
+    assert_response :no_content
+    assert @item.reload.read?
+  end
+
+  test "update with an invalid state returns 422 not 500" do
+    patch inbox_item_url(@item), params: { state: "bogus" }, as: :json
+    assert_response :unprocessable_entity
+    assert @item.reload.new?
+  end
+end

--- a/engines/collavre/test/models/inbox_item_test.rb
+++ b/engines/collavre/test/models/inbox_item_test.rb
@@ -31,4 +31,27 @@ class InboxItemTest < ActiveSupport::TestCase
       item.localized_message(locale: :en)
     )
   end
+
+  test "state is a string-backed enum with new/read/archived" do
+    assert_equal({ "new" => "new", "read" => "read", "archived" => "archived" }, Collavre::InboxItem.states)
+  end
+
+  test "enum predicates and default" do
+    item = InboxItem.create!(message_key: "inbox.no_messages", owner: users(:one), message_params: {})
+    assert item.new?
+    assert_equal "new", item.state
+    item.read!
+    assert item.read?
+    assert_equal "read", item.reload.state
+  end
+
+  test "assigning an unknown state raises ArgumentError" do
+    item = InboxItem.new(message_key: "inbox.no_messages", owner: users(:one), message_params: {})
+    assert_raises(ArgumentError) { item.state = "bogus" }
+  end
+
+  test "new_items scope still selects only new" do
+    InboxItem.create!(message_key: "inbox.no_messages", owner: users(:one), state: "read", message_params: {})
+    assert InboxItem.new_items.all?(&:new?)
+  end
 end

--- a/engines/collavre/test/models/task_status_enum_test.rb
+++ b/engines/collavre/test/models/task_status_enum_test.rb
@@ -1,0 +1,39 @@
+require "test_helper"
+
+module Collavre
+  class TaskStatusEnumTest < ActiveSupport::TestCase
+    setup do
+      @owner = users(:one)
+      @agent = User.create!(email: "agent-enum@example.com", password: TEST_PASSWORD, name: "Agent")
+    end
+
+    test "status is a string-backed enum covering all nine values" do
+      assert_equal(
+        %w[pending queued running delegated pending_approval done failed cancelled escalated].sort,
+        Collavre::Task.statuses.keys.sort
+      )
+      # string-backed: key maps to identical string
+      Collavre::Task.statuses.each { |k, v| assert_equal k, v }
+    end
+
+    test "predicates and default" do
+      task = Task.create!(name: "T", agent: @agent)
+      assert task.pending?
+      task.running!
+      assert task.running?
+      assert_equal "running", task.reload.status
+    end
+
+    test "existing scopes still resolve via string values" do
+      task = Task.create!(name: "T", status: "queued", topic_id: 123, agent: @agent)
+      assert_includes Task.queued_for_topic(123), task
+      assert_includes Task.occupying_topic_slot(123), Task.create!(name: "R", status: "running", topic_id: 123, agent: @agent)
+    end
+
+    test "update_all bypasses callbacks and keeps the string value" do
+      task = Task.create!(name: "T", status: "delegated", agent: @agent)
+      Task.where(id: task.id).update_all(status: "done")
+      assert task.reload.done?
+    end
+  end
+end

--- a/engines/collavre/test/services/comments/action_executor_execute_tool_test.rb
+++ b/engines/collavre/test/services/comments/action_executor_execute_tool_test.rb
@@ -58,7 +58,7 @@ class Comments::ActionExecutorExecuteToolTest < ActiveSupport::TestCase
 
     ::Tools::MetaToolService.stub :new, -> { mock_service } do
       # Stub AiAgentJob to prevent actual execution
-      Collavre::AiAgentJob.stub :perform_later, ->(task) { task.update!(status: "resumed") } do
+      Collavre::AiAgentJob.stub :perform_later, ->(task) { task.update!(status: "running") } do
         Comments::ActionExecutor.new(comment: comment, executor: @user).call
       end
     end
@@ -118,7 +118,7 @@ class Comments::ActionExecutorExecuteToolTest < ActiveSupport::TestCase
     error_service.define_singleton_method(:call) { |**_args| raise StandardError, "Tool failed" }
 
     ::Tools::MetaToolService.stub :new, -> { error_service } do
-      Collavre::AiAgentJob.stub :perform_later, ->(task) { task.update!(status: "resumed") } do
+      Collavre::AiAgentJob.stub :perform_later, ->(task) { task.update!(status: "running") } do
         Comments::ActionExecutor.new(comment: comment, executor: @user).call
       end
     end


### PR DESCRIPTION
## What

Converts two raw string columns to Rails **string-backed** enums:

- `Collavre::Task#status` — 9 values (`pending`, `queued`, `running`, `delegated`, `pending_approval`, `done`, `failed`, `cancelled`, `escalated`)
- `Collavre::InboxItem#state` — 3 values (`new`, `read`, `archived`), replacing the old `attribute` + `inclusion` validation

## Why

Gains enum scopes/predicates/bang-setters (`task.running!`, `task.done?`, …) that reduce the typo surface across ~244 status references, with **no data migration** — the columns already store exactly the enum key strings.

## Notes / decisions

- **No migration, no backfill.** String-backed map (`{pending: "pending", …}`); stored values are unchanged.
- The two atomic `update_all(status: "…")` claim paths (`task_claim_service.rb`, `agent_orchestrator.rb`, hardened in #1370/#1371) keep working — `update_all` writes the same literal strings.
- `InboxItem` uses `scopes: false` because the generated `.new` class-scope collides with `Model.new`; predicates/setters still generate and the explicit `new_items` scope is retained.
- `InboxItemsController#update` now returns **422** for an unknown `state` param instead of a 500 (enum raises `ArgumentError` on bad assignment; previously the invalid value silently no-op'd and still returned 204).
- Fixed a test stub that wrote a non-existent `"resumed"` status to a Task (would now raise `ArgumentError`) — changed to a real status; no assertion depended on the value.

## Tests

New: `task_status_enum_test.rb`, `inbox_items_controller_test.rb`, plus `inbox_item_test.rb` cases. Non-system suites green locally. System tests are validated by CI (no headless browser in the local env).