### PR TITLE
perf: add comments_count and comment_versions_count counter caches

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_12_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_13_000002) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -158,6 +158,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_12_000000) do
     t.datetime "action_executed_at"
     t.integer "action_executed_by_id"
     t.integer "approver_id"
+    t.integer "comment_versions_count", default: 0, null: false
     t.text "content", null: false
     t.datetime "created_at", null: false
     t.integer "creative_id", null: false
@@ -228,6 +229,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_12_000000) do
 
   create_table "creatives", force: :cascade do |t|
     t.datetime "archived_at"
+    t.integer "comments_count", default: 0, null: false
     t.datetime "created_at", null: false
     t.json "data", default: {}, null: false
     t.text "description", limit: 4294967295

--- a/docs/superpowers/plans/2026-07-13-s2-counter-cache.md
+++ b/docs/superpowers/plans/2026-07-13-s2-counter-cache.md
@@ -1,0 +1,256 @@
+# S2 — counter_cache for comments/comment_versions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate two per-row `COUNT` N+1s in list rendering by adding Rails `counter_cache` columns `creatives.comments_count` and `comments.comment_versions_count`, backfilled and wired into the exact hot sites.
+
+**Architecture:** Both target associations have **no soft-delete and no scoping** (`dependent: :destroy`, plain columns), so a raw Rails `counter_cache` stays correct on create/destroy. `comments_count` counts **all** comments (matches `creatives_helper.rb:41`'s `origin.comments.size`). It deliberately does **not** replace `broadcastable.rb:33`'s `public_only.count` (public-only ≠ all-rows) nor any `id > last_read_id` unread threshold logic. Backfill uses a raw-SQL `UPDATE … SET n = (SELECT COUNT(*) …)` in the migration `up`, matching house style.
+
+**Tech Stack:** Rails 8.1 (`ActiveRecord::Migration[8.1]`), Minitest, engine `collavre`. This project has **no existing counter_cache** — we are establishing the pattern.
+
+## Global Constraints
+
+- Engine `collavre`. Run engine tests from **host root**: `OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES bin/rails test engines/collavre/test/...`.
+- PR/commit messages **English**, Conventional Commits.
+- Migrations live in `engines/collavre/db/migrate/`, class base `ActiveRecord::Migration[8.1]`, timestamp `20260713000001+` (must sort after `20260702000005`). Update root `db/schema.rb` via migration run (do not hand-edit schema).
+- **Do NOT** touch `broadcastable.rb:33` (`public_only.count`) or unread `id > last_read_id` logic — different semantics.
+- `comments_count` = ALL comments (public + private). `comment_versions_count` = all versions of a comment.
+- No soft-delete exists on these tables — backfill is a straight COUNT.
+
+---
+
+### Task 1: `creatives.comments_count` counter_cache
+
+**Files:**
+- Create: `engines/collavre/db/migrate/20260713000001_add_comments_count_to_creatives.rb`
+- Modify: `engines/collavre/app/models/collavre/comment.rb:54` (add `counter_cache: true` to `belongs_to :creative`)
+- Modify: `engines/collavre/app/helpers/collavre/creatives_helper.rb:41` (use the cached column)
+- Test: `engines/collavre/test/models/comment_test.rb` (counter behavior)
+
+**Interfaces:**
+- Produces: `creatives.comments_count` (integer, default 0, not null) maintained automatically by Rails on `Comment` create/destroy; `Collavre::Creative#comments_count` reader.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `engines/collavre/test/models/comment_test.rb`:
+
+```ruby
+test "creating and destroying a comment maintains creatives.comments_count" do
+  user = User.create!(email: "cc-counter@example.com", password: TEST_PASSWORD, name: "CC")
+  creative = Creative.create!(user: user, description: "Root")
+  assert_equal 0, creative.comments_count
+
+  c1 = Comment.create!(creative: creative, user: user, content: "one")
+  Comment.create!(creative: creative, user: user, content: "two", private: true)
+  assert_equal 2, creative.reload.comments_count, "counts all comments incl. private"
+
+  c1.destroy!
+  assert_equal 1, creative.reload.comments_count
+end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES bin/rails test engines/collavre/test/models/comment_test.rb -n "/comments_count/"`
+Expected: FAIL (`comments_count` NoMethodError — column absent).
+
+- [ ] **Step 3: Write the migration (add column + backfill)**
+
+Create `engines/collavre/db/migrate/20260713000001_add_comments_count_to_creatives.rb`:
+
+```ruby
+class AddCommentsCountToCreatives < ActiveRecord::Migration[8.1]
+  def up
+    unless column_exists?(:creatives, :comments_count)
+      add_column :creatives, :comments_count, :integer, default: 0, null: false
+    end
+
+    # Backfill: straight COUNT (no soft-delete on comments). Matches house
+    # raw-SQL backfill convention.
+    execute <<~SQL.squish
+      UPDATE creatives
+      SET comments_count = (
+        SELECT COUNT(*) FROM comments WHERE comments.creative_id = creatives.id
+      )
+    SQL
+  end
+
+  def down
+    remove_column :creatives, :comments_count if column_exists?(:creatives, :comments_count)
+  end
+end
+```
+
+- [ ] **Step 4: Add counter_cache to the association**
+
+In `engines/collavre/app/models/collavre/comment.rb:54`, change:
+
+```ruby
+belongs_to :creative, class_name: "Collavre::Creative", counter_cache: true
+```
+
+- [ ] **Step 5: Run the migration and the test**
+
+Run:
+```bash
+OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES bin/rails db:migrate
+OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES bin/rails test engines/collavre/test/models/comment_test.rb -n "/comments_count/"
+```
+Expected: migration adds the column + updates `db/schema.rb`; test PASS.
+
+- [ ] **Step 6: Rewire the helper hot site**
+
+In `engines/collavre/app/helpers/collavre/creatives_helper.rb`, line 41 currently:
+```ruby
+comments_count = origin.comments.size
+```
+Change to use the cached column (avoids the per-creative COUNT):
+```ruby
+comments_count = origin.comments_count
+```
+Leave lines 42-44 (`CommentReadPointer` lookup and `unread_count` via `id > last_read_id`) **unchanged** — unread is threshold-based, not a counter. Verify `origin` is a `Creative` (it is — `creative.effective_origin`, line 40).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add engines/collavre/db/migrate/20260713000001_add_comments_count_to_creatives.rb \
+        engines/collavre/app/models/collavre/comment.rb \
+        engines/collavre/app/helpers/collavre/creatives_helper.rb \
+        engines/collavre/test/models/comment_test.rb \
+        db/schema.rb
+git commit -m "perf(creatives): add comments_count counter_cache for list rendering"
+```
+
+---
+
+### Task 2: `comments.comment_versions_count` counter_cache
+
+**Files:**
+- Create: `engines/collavre/db/migrate/20260713000002_add_comment_versions_count_to_comments.rb`
+- Modify: `engines/collavre/app/models/collavre/comment_version.rb:7` (add `counter_cache: true` to `belongs_to :comment`)
+- Modify: `engines/collavre/app/views/collavre/comments/_comment.html.erb:93-94` (use cached column)
+- Test: `engines/collavre/test/models/comment_test.rb`
+
+**Interfaces:**
+- Consumes: nothing from Task 1.
+- Produces: `comments.comment_versions_count` maintained on `CommentVersion` create/destroy of the `:comment` association. **Only** the `belongs_to :comment` association is counted — NOT `belongs_to :review_comment` (that maps to `has_many :review_versions` and must not get a counter_cache).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `engines/collavre/test/models/comment_test.rb`:
+
+```ruby
+test "creating and destroying versions maintains comment_versions_count" do
+  user = User.create!(email: "cv-counter@example.com", password: TEST_PASSWORD, name: "CV")
+  creative = Creative.create!(user: user, description: "Root")
+  comment = Comment.create!(creative: creative, user: user, content: "hi")
+  assert_equal 0, comment.comment_versions_count
+
+  v1 = CommentVersion.create!(comment: comment, content: "v1", version_number: 1)
+  CommentVersion.create!(comment: comment, content: "v2", version_number: 2)
+  assert_equal 2, comment.reload.comment_versions_count
+
+  v1.destroy!
+  assert_equal 1, comment.reload.comment_versions_count
+end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES bin/rails test engines/collavre/test/models/comment_test.rb -n "/comment_versions_count/"`
+Expected: FAIL (column absent).
+
+- [ ] **Step 3: Write the migration**
+
+Create `engines/collavre/db/migrate/20260713000002_add_comment_versions_count_to_comments.rb`:
+
+```ruby
+class AddCommentVersionsCountToComments < ActiveRecord::Migration[8.1]
+  def up
+    unless column_exists?(:comments, :comment_versions_count)
+      add_column :comments, :comment_versions_count, :integer, default: 0, null: false
+    end
+
+    # Backfill counts only the owning :comment association (comment_id),
+    # NOT review_comment_id (review_versions).
+    execute <<~SQL.squish
+      UPDATE comments
+      SET comment_versions_count = (
+        SELECT COUNT(*) FROM comment_versions WHERE comment_versions.comment_id = comments.id
+      )
+    SQL
+  end
+
+  def down
+    remove_column :comments, :comment_versions_count if column_exists?(:comments, :comment_versions_count)
+  end
+end
+```
+
+- [ ] **Step 4: Add counter_cache to the association**
+
+In `engines/collavre/app/models/collavre/comment_version.rb:7`, change:
+
+```ruby
+belongs_to :comment, class_name: "Collavre::Comment", counter_cache: true
+```
+Leave `belongs_to :review_comment, ... optional: true` (line 8) **unchanged** — no counter_cache.
+
+- [ ] **Step 5: Run the migration + test**
+
+Run:
+```bash
+OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES bin/rails db:migrate
+OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES bin/rails test engines/collavre/test/models/comment_test.rb -n "/comment_versions_count/"
+```
+Expected: PASS.
+
+- [ ] **Step 6: Rewire the view hot site**
+
+In `engines/collavre/app/views/collavre/comments/_comment.html.erb`, lines 93-94 currently:
+```erb
+  <% if comment.comment_versions.any? %>
+    <% version_count = comment.comment_versions.size %>
+```
+Change to use the cached column (removes an EXISTS + a COUNT per comment):
+```erb
+  <% if comment.comment_versions_count > 0 %>
+    <% version_count = comment.comment_versions_count %>
+```
+Line 95 (`selected_id`) and line 96 (`.order(:version_number).pluck(:id)`) stay — line 96 only runs when versions exist, which is now gated by the cached count.
+
+- [ ] **Step 7: Verify the partial renders (real browser, not just unit)**
+
+Per memory (`feedback_collavre_lexical_fence_needs_real_browser`), view changes need a real render check. After the migration, drive the comments view in a preview server and confirm a comment WITH versions still shows its version UI and one WITHOUT versions does not. If a preview server is not spun up in this task, at minimum add/confirm a controller or system test that renders `_comment` for both cases. Grep existing tests: `engines/collavre/test/system/` and `engines/collavre/test/controllers/comments_controller_test.rb` for version-badge assertions and update if they relied on the old association call.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add engines/collavre/db/migrate/20260713000002_add_comment_versions_count_to_comments.rb \
+        engines/collavre/app/models/collavre/comment_version.rb \
+        engines/collavre/app/views/collavre/comments/_comment.html.erb \
+        engines/collavre/test/models/comment_test.rb \
+        db/schema.rb
+git commit -m "perf(comments): add comment_versions_count counter_cache for comment rendering"
+```
+
+---
+
+### Task 3: Full-suite regression + PR
+
+- [ ] **Step 1: Run the full collavre engine suite**
+
+Run: `OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES bin/rails test engines/collavre/test`
+Expected: PASS (modulo pre-existing unrelated reds on main).
+
+- [ ] **Step 2: Confirm schema.rb has both new columns and correct migration versions**
+
+Verify `db/schema.rb` shows `comments_count` on `creatives`, `comment_versions_count` on `comments`, and the schema version bumped to `20260713000002`. Confirm no stray column changes.
+
+- [ ] **Step 3: Push (serial) + PR** — orchestrated externally. PR body: two counter_cache columns, backfilled, wired into `creatives_helper.rb:41` and `_comment.html.erb`; explicitly notes `broadcastable.rb` public_only and unread threshold logic left untouched.
+
+## Self-Review Notes (planner)
+
+- Spec coverage: S2-b = `creatives.comments_count` ✓ (Task 1) + `comments.comment_versions_count` ✓ (Task 2). Unread explicitly excluded per spec.
+- Semantic-mismatch trap (public_only vs all-rows) is called out and the public_only site is left alone.
+- Only the `:comment` association gets a counter — `:review_comment` explicitly excluded (would double-count / wrong column).

--- a/engines/collavre/app/controllers/collavre/topics_controller.rb
+++ b/engines/collavre/app/controllers/collavre/topics_controller.rb
@@ -145,6 +145,11 @@ module Collavre
         topic.update!(creative: target_creative)
       end
 
+      # update_all above skips counter-cache callbacks, so recompute
+      # comments_count on both sides after re-parenting the comments.
+      Creative.reset_counters(source_creative.id, :comments)
+      Creative.reset_counters(target_creative.id, :comments)
+
       broadcast_topic_event("deleted", topic_id: topic.id)
       broadcast_topic_event("created", creative: target_creative, topic: topic.slice(:id, :name))
 

--- a/engines/collavre/app/helpers/collavre/creatives_helper.rb
+++ b/engines/collavre/app/helpers/collavre/creatives_helper.rb
@@ -38,7 +38,7 @@ module Collavre
           safe_join([])
         elsif creative.has_permission?(Current.user, :feedback)
           origin = creative.effective_origin
-          comments_count = origin.comments.size
+          comments_count = origin.comments_count
           pointer = CommentReadPointer.find_by(user: Current.user, creative: origin)
           last_read_id = pointer&.last_read_comment_id
           unread_count = last_read_id ? origin.comments.where("id > ? and private = ?", last_read_id, false).count : comments_count

--- a/engines/collavre/app/models/collavre/comment.rb
+++ b/engines/collavre/app/models/collavre/comment.rb
@@ -51,7 +51,7 @@ module Collavre
         end
     end
 
-    belongs_to :creative, class_name: "Collavre::Creative"
+    belongs_to :creative, class_name: "Collavre::Creative", counter_cache: true
     belongs_to :user, class_name: Collavre.configuration.user_class_name, optional: true
     belongs_to :approver, class_name: Collavre.configuration.user_class_name, optional: true
     belongs_to :action_executed_by, class_name: Collavre.configuration.user_class_name, optional: true

--- a/engines/collavre/app/models/collavre/comment_version.rb
+++ b/engines/collavre/app/models/collavre/comment_version.rb
@@ -4,7 +4,7 @@ module Collavre
   class CommentVersion < ApplicationRecord
     self.table_name = "comment_versions"
 
-    belongs_to :comment, class_name: "Collavre::Comment"
+    belongs_to :comment, class_name: "Collavre::Comment", counter_cache: true
     belongs_to :review_comment, class_name: "Collavre::Comment", optional: true
 
     validates :content, presence: true

--- a/engines/collavre/app/views/collavre/comments/_comment.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comment.html.erb
@@ -90,8 +90,8 @@
     </div>
   <% end %>
   <div class="comment-content" data-comment-target="content"><%= comment.content %></div>
-  <% if comment.comment_versions.any? %>
-    <% version_count = comment.comment_versions.size %>
+  <% if comment.comment_versions_count > 0 %>
+    <% version_count = comment.comment_versions_count %>
     <% selected_id = comment.selected_version_id %>
     <% version_ids = comment.comment_versions.order(:version_number).pluck(:id) %>
     <% selected_index = selected_id ? (version_ids.index(selected_id)&.+(1) || version_count) : version_count %>

--- a/engines/collavre/db/migrate/20260713000001_add_comments_count_to_creatives.rb
+++ b/engines/collavre/db/migrate/20260713000001_add_comments_count_to_creatives.rb
@@ -1,0 +1,20 @@
+class AddCommentsCountToCreatives < ActiveRecord::Migration[8.1]
+  def up
+    unless column_exists?(:creatives, :comments_count)
+      add_column :creatives, :comments_count, :integer, default: 0, null: false
+    end
+
+    # Backfill: straight COUNT (no soft-delete on comments). Matches house
+    # raw-SQL backfill convention.
+    execute <<~SQL.squish
+      UPDATE creatives
+      SET comments_count = (
+        SELECT COUNT(*) FROM comments WHERE comments.creative_id = creatives.id
+      )
+    SQL
+  end
+
+  def down
+    remove_column :creatives, :comments_count if column_exists?(:creatives, :comments_count)
+  end
+end

--- a/engines/collavre/db/migrate/20260713000002_add_comment_versions_count_to_comments.rb
+++ b/engines/collavre/db/migrate/20260713000002_add_comment_versions_count_to_comments.rb
@@ -1,0 +1,20 @@
+class AddCommentVersionsCountToComments < ActiveRecord::Migration[8.1]
+  def up
+    unless column_exists?(:comments, :comment_versions_count)
+      add_column :comments, :comment_versions_count, :integer, default: 0, null: false
+    end
+
+    # Backfill counts only the owning :comment association (comment_id),
+    # NOT review_comment_id (review_versions).
+    execute <<~SQL.squish
+      UPDATE comments
+      SET comment_versions_count = (
+        SELECT COUNT(*) FROM comment_versions WHERE comment_versions.comment_id = comments.id
+      )
+    SQL
+  end
+
+  def down
+    remove_column :comments, :comment_versions_count if column_exists?(:comments, :comment_versions_count)
+  end
+end

--- a/engines/collavre/test/controllers/comments_controller_test.rb
+++ b/engines/collavre/test/controllers/comments_controller_test.rb
@@ -24,6 +24,23 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
 
   public
 
+  test "index renders version navigator only for comments with versions" do
+    with_versions = @creative.comments.create!(content: "has versions", user: @user)
+    Collavre::CommentVersion.create!(comment: with_versions, content: "v1", version_number: 1)
+    Collavre::CommentVersion.create!(comment: with_versions, content: "v2", version_number: 2)
+    without_versions = @creative.comments.create!(content: "no versions", user: @user)
+
+    get creative_comments_path(@creative)
+    assert_response :success
+
+    assert_includes @response.body,
+                    "data-comment-version-comment-id-value=\"#{with_versions.id}\"",
+                    "expected version navigator for comment WITH versions"
+    assert_not_includes @response.body,
+                        "data-comment-version-comment-id-value=\"#{without_versions.id}\"",
+                        "expected no version navigator for comment WITHOUT versions"
+  end
+
   test "convert markdown comment to sub creatives" do
     comment = @creative.comments.create!(content: "- First\n- Second", user: @user)
     assert_difference("Creative.count", 2) do

--- a/engines/collavre/test/controllers/topics_controller_test.rb
+++ b/engines/collavre/test/controllers/topics_controller_test.rb
@@ -182,6 +182,22 @@ class TopicsControllerTest < ActionDispatch::IntegrationTest
     assert_equal target_creative.id, comment.creative_id, "Comment should move with topic"
   end
 
+  test "moving a topic keeps comments_count in sync on both creatives" do
+    target_creative = creatives(:root_parent)
+    Collavre::Comment.create!(creative: @creative, topic: @topic, user: @user, content: "a")
+    Collavre::Comment.create!(creative: @creative, topic: @topic, user: @user, content: "b")
+    source_before = @creative.reload.comments_count
+    target_before = target_creative.reload.comments_count
+
+    patch move_creative_topic_url(@creative, @topic), params: { target_creative_id: target_creative.id }, as: :json
+    assert_response :success
+
+    assert_equal source_before - 2, @creative.reload.comments_count, "source counter must drop by moved comments"
+    assert_equal target_before + 2, target_creative.reload.comments_count, "target counter must rise by moved comments"
+    assert_equal @creative.comments.count, @creative.comments_count, "source counter matches actual"
+    assert_equal target_creative.comments.count, target_creative.comments_count, "target counter matches actual"
+  end
+
   test "should not move topic without permission on source creative" do
     other_user = users(:two)
     sign_in_as other_user, password: "password"

--- a/engines/collavre/test/models/comment_test.rb
+++ b/engines/collavre/test/models/comment_test.rb
@@ -166,4 +166,31 @@ class CommentTest < ActiveSupport::TestCase
     assert inbox_broadcasts.any? { |payload| payload[:target] == "mobile-inbox-badge" && payload.dig(:locals, :count) == 1 }
     assert_equal 1, Collavre::Inbox::BadgeComponent.new(user: owner, creative: inbox_creative).count
   end
+
+  test "creating and destroying a comment maintains creatives.comments_count" do
+    user = User.create!(email: "cc-counter@example.com", password: TEST_PASSWORD, name: "CC")
+    creative = Creative.create!(user: user, description: "Root")
+    assert_equal 0, creative.comments_count
+
+    c1 = Comment.create!(creative: creative, user: user, content: "one")
+    Comment.create!(creative: creative, user: user, content: "two", private: true)
+    assert_equal 2, creative.reload.comments_count, "counts all comments incl. private"
+
+    c1.destroy!
+    assert_equal 1, creative.reload.comments_count
+  end
+
+  test "creating and destroying versions maintains comment_versions_count" do
+    user = User.create!(email: "cv-counter@example.com", password: TEST_PASSWORD, name: "CV")
+    creative = Creative.create!(user: user, description: "Root")
+    comment = Comment.create!(creative: creative, user: user, content: "hi")
+    assert_equal 0, comment.comment_versions_count
+
+    v1 = Collavre::CommentVersion.create!(comment: comment, content: "v1", version_number: 1)
+    Collavre::CommentVersion.create!(comment: comment, content: "v2", version_number: 2)
+    assert_equal 2, comment.reload.comment_versions_count
+
+    v1.destroy!
+    assert_equal 1, comment.reload.comment_versions_count
+  end
 end


### PR DESCRIPTION
## What

Adds two Rails `counter_cache` columns to eliminate per-row `COUNT` N+1s during list rendering:

- `creatives.comments_count` (maintained by `Comment belongs_to :creative`)
- `comments.comment_versions_count` (maintained by `CommentVersion belongs_to :comment`)

Both are backfilled in the migration and wired into the exact hot sites:
- `creatives_helper.rb:41` `origin.comments.size` → `origin.comments_count`
- `_comment.html.erb:93-94` `comment_versions.any?/.size` → `comment_versions_count`

## Why

`render_creative_progress` fired one `COUNT` per creative in index lists, and `_comment` fired an `EXISTS` + `COUNT` per comment. These are now single cached-column reads.

## Notes / decisions (semantic traps respected)

- `comments_count` counts **all** comments (public + private), matching the helper's `origin.comments.size`. It deliberately does **not** replace `broadcastable.rb:33`'s `public_only.count` (public-only ≠ all-rows) — that line is untouched.
- The `id > last_read_id` **unread** threshold logic is untouched (not expressible as a counter).
- Only `CommentVersion belongs_to :comment` gets the counter — **not** `belongs_to :review_comment` (that maps to `review_versions`).
- No soft-deletes on these tables, so a plain counter stays correct on `destroy`. Backfill uses a raw-SQL `UPDATE … SET n = (SELECT COUNT(*) …)` matching the house migration style.

## Tests

New counter-maintenance tests in `comment_test.rb` (create/destroy increments/decrements, incl. private) and a render assertion in `comments_controller_test.rb` (version navigator present WITH versions, absent WITHOUT). Non-system suites green locally; system tests validated by CI.