### PR TITLE
test(collavre): stabilize flaky oauth provider system test

### DIFF
--- a/engines/collavre/test/system/oauth_provider_test.rb
+++ b/engines/collavre/test/system/oauth_provider_test.rb
@@ -1,6 +1,11 @@
 require_relative "../application_system_test_case"
 
 class OauthProviderTest < ApplicationSystemTestCase
+  # Generous wait for full-page navigations, which can queue behind other system
+  # tests sharing the Puma server when the suite runs in parallel. Capybara's
+  # default 2s is too tight under that load and caused flaky failures.
+  NAV_WAIT = 15
+
   setup do
     @user = User.create!(
       email: "test@example.com",
@@ -27,9 +32,16 @@ class OauthProviderTest < ApplicationSystemTestCase
     )
 
     assert_content "Authorize Test Client to use your account?"
+    assert_button "Authorize"
     click_on "Authorize"
 
-    assert_content "Authorization code"
-    assert_selector "code", text: /.+/
+    # Consent is a plain full-page POST that renders the authorization code page.
+    # Under parallel-suite load this navigation can take longer than Capybara's
+    # default 2s wait, which left the assertion looking at the still-visible
+    # consent screen and failing flakily. Wait explicitly for the navigation to
+    # complete instead of relying on the default timeout.
+    assert_no_content "Authorize Test Client to use your account?", wait: NAV_WAIT
+    assert_content "Authorization code", wait: NAV_WAIT
+    assert_selector "code#authorization_code", text: /.+/, wait: NAV_WAIT
   end
 end


### PR DESCRIPTION
## Summary

Fixes intermittent failures in `OauthProviderTest#test_authorizing_a_client_application` (`engines/collavre/test/system/oauth_provider_test.rb`), where the test would occasionally fail to find "Authorization code" and remain on the consent screen after clicking Authorize.

## Root cause

- On success, Doorkeeper's `AuthorizationsController#create` **never re-renders the consent page** — it renders the authorization-code page or redirects. So the failure symptom (still on the consent screen) can only mean the assertion **timed out before the post-Authorize navigation committed**.
- The Doorkeeper consent page ships **no JavaScript** (its gem layout loads only CSS + the CSRF meta tag), so a plain submit-button click reliably submits — ruling out a "swallowed click."
- `Capybara.default_max_wait_time` was never overridden → the default **2s**. Under full parallel-suite load, requests queue behind the shared Puma server and the `POST /oauth/authorize` → render can exceed 2s.
- Verified via a controlled experiment: forcing a near-zero wait deterministically reproduces the exact symptom (stuck on consent screen), while the normal-wait run passes side-by-side.

## Fix

- Add explicit condition-based waits (`NAV_WAIT = 15s`) on exactly the post-Authorize navigation.
- Assert the consent screen is actually replaced (`assert_no_content`) rather than only asserting the destination text.
- Tighten the code selector to its id (`code#authorization_code`).

## Verification

- 15/15 green under CPU contention (assertions per run increased with the added `assert_button` + `assert_no_content`).
- Full pre-push suite: 2697 runs, 0 failures, 0 errors.
- Rubocop clean.