### PR TITLE
perf(collavre): batch the browse tree per level instead of per node

### DIFF
--- a/docs/superpowers/plans/2026-07-13-creatives-index-n1.md
+++ b/docs/superpowers/plans/2026-07-13-creatives-index-n1.md
@@ -1,0 +1,116 @@
+# Creatives#index N+1 removal (browse tree)
+
+Status: **implemented**. Measured under an identical harness (test suite, warmed
+caches, query cache cleared per request): rendering 10 more siblings cost 70 more
+queries before (7.0/node) and 0 more after — 47→117 vs a flat 18→18.
+
+## Problem
+
+The main page (`Collavre::CreativesController#index`, JSON) issues 181–824 queries per
+request. With Postgres now reached over the network, each query costs a 6.2–8.9 ms
+round trip (measured: an idle `SELECT 1` with the AR query cache off takes 6.18 ms),
+so response time tracks query count almost exactly:
+
+| queries | response |
+|---|---|
+| 181 | 1.18 s |
+| 378 | 2.06 s |
+| 824 | 5.25 s |
+
+Slope ≈ 6.5 ms/query; 85–95 % of the request is ActiveRecord, view render is 0.1–13 ms.
+Under SQLite the same 181 queries were in-process (~0.01 ms each), which is why this
+never showed up before.
+
+## Where the queries come from
+
+Per rendered node, in `Collavre::Creatives::TreeBuilder#build_nodes_for_creative`:
+
+| # | source | queries/node |
+|---|---|---|
+| 1 | `filtered_children_for` (`tree_builder.rb:105`) → `children_with_permission` (`permissible.rb:20-62`): origin, children pluck, cache lookup ×2, owned pluck, ordered load | ~5–6 |
+| 2 | `creative.parent.nil?` (`tree_builder.rb:125`) | 1 |
+| 3 | `render_creative_progress` (`creatives_helper.rb:28-87`): `has_permission?(:feedback)` (39), `effective_origin` (40), `CommentReadPointer.find_by` (42), unread count (44), `has_permission?(:write)` (73), `tags.includes(:label)` (84) | ~4–6 |
+| 4 | `inline_editor_payload_for` (`tree_builder.rb:193-204`): `effective_origin`, `has_permission?(:write)` for shells, `effective_description` | ~1–3 |
+
+Two structural notes:
+
+- **`filtered_children_for` runs unconditionally** (line 105), *before* the
+  `load_children_now` check on line 111. So a collapsed node — invisible on screen —
+  still loads its whole child set, only to derive `has_children:` (line 136). Those
+  children then recurse into the same work.
+- **`TreeBuilder#preload_permissions` (lines 32-74) is nearly dead weight.** It caches a
+  `:write` boolean, but the helper re-asks via `has_permission?` (`creatives_helper.rb:39, 73`),
+  which goes through `PermissionChecker` and bypasses the cache entirely.
+
+The 824-query case is the tag filter: `ProgressService#progress_for_tags`
+(`progress_service.rb:54-72`) walks the entire subtree recursively, calling
+`children_with_permission` (≈5 queries) per descendant plus `tags.pluck` per leaf.
+
+## The fix already exists in this repo
+
+The picker popup solved the same problem: `CreativeTreeSerializer#children_presence_set`
+(`creative_tree_serializer.rb:101-119`) answers "does this node have visible children?"
+with **one** `where(parent_id: origin_ids)` plus one batched
+`PermissionFilter#readable_ids` (`permission_filter.rb:16`) — no per-node work. The
+browse path just never adopted it. This is a port, not a design.
+
+## Changes
+
+All inside the browse path. No migration, no infra change, no downtime.
+
+1. **`has_children` without loading children.** Extract `children_presence_set` into a
+   shared `Creatives::ChildrenPresence` and call it once per level. Load real children
+   only when `load_children_now` is true. *Must* intersect `allowed_creative_ids` and
+   the archived filter, or a toggle opens an empty branch (the picker version skips
+   this because the picker has no such filter).
+2. **Batch the children load per level.** One `Creative.where(parent_id: origin_ids).order(:sequence)`
+   plus one `PermissionFilter#readable_ids`, grouped by parent — replacing per-node
+   `children_with_permission`. Children of linked shells live under `effective_origin`,
+   so map origin id → node id as the serializer does (line 104).
+3. **Preload per level:** `origin`, `tags → label`. Replace `creative.parent.nil?`
+   (line 125) with `creative.parent_id.nil?` — same answer, zero queries (verify no rows
+   have a dangling `parent_id`).
+4. **Make the permission cache actually serve the helper.** Store the effective *rank*
+   per creative id instead of a `:write` boolean, so `:feedback` and `:write` both
+   resolve from memory. Pass `can_write:` / `can_feedback:` into `render_creative_progress`,
+   keeping the `has_permission?` fallback for its other call sites.
+5. **Batch the comment badge:** one `CommentReadPointer.where(user:, creative_id: origin_ids)`
+   and one `GROUP BY creative_id` unread count per level, instead of 2 queries per node.
+6. **Tag-filter rollup:** feed `progress_for_tags` the same batched children map and
+   batch `tags.pluck(:label_id)` across the subtree. This is what collapses the 824 case.
+
+## Expected result
+
+Per **level** ~5–8 queries, independent of node count.
+
+| | before | after |
+|---|---|---|
+| main page | 181 q / 1.18 s | ~15–25 q / ~0.15 s |
+| tag filter | 824 q / 5.25 s | ~30 q / ~0.2 s |
+
+Holds on the *current* remote DB. Moving the DB onto the app's network multiplies with
+this rather than substituting for it.
+
+## Test first
+
+The invariant is *query count must not scale with node count*. Seed a 2-level tree of
+N nodes, hit `Collavre::CreativesController#index`, and assert the query count for 40
+nodes exceeds the count for 20 nodes by at most a small constant. That test fails today
+(it grows ~10–13 per node) and passes after. Run from the host root:
+`bin/rails test engines/collavre/test/...`.
+
+## Risks
+
+- **has_children parity.** Presence must match exactly what expanding shows (archived +
+  permission + `allowed_creative_ids`), or the toggle hides a reachable subtree or opens
+  an empty one — and an empty-open leaks that hidden children exist.
+- **Permission posture drift.** `PermissionFilter` is `:read` with `no_access`
+  subtraction; `children_with_permission` takes a `min_permission`. Keep `:read`
+  semantics identical when porting.
+- **Linked shells.** Children hang off `effective_origin`, not the shell row.
+
+## Out of scope
+
+Availability: production Postgres currently runs on the local MacBook
+(`macbook-pro.tailadceed.ts.net`), so the app dies when it sleeps. This plan does not
+address that.

--- a/engines/collavre/app/helpers/collavre/creatives_helper.rb
+++ b/engines/collavre/app/helpers/collavre/creatives_helper.rb
@@ -18,14 +18,25 @@ module Collavre
     end
 
     def render_creative_tags(creative)
-      labels = creative.tags&.includes(:label)&.map(&:label)&.compact
+      # The browse tree preloads tags -> label per level; `includes` on an
+      # already-loaded association builds a fresh relation and re-queries it,
+      # which would reinstate the N+1 this is called from.
+      labels = if creative.tags.loaded?
+        creative.tags.map(&:label).compact
+      else
+        creative.tags&.includes(:label)&.map(&:label)&.compact
+      end
       return "" if labels&.empty?
       content_tag(:div, class: "creative-tags", style: "display: none;") do
         render_tags(labels, "unstyled-link", true)
       end
     end
 
-    def render_creative_progress(creative, select_mode: false, has_children: nil)
+    # `can_write`, `can_feedback` and `unread_count` let a caller rendering many
+    # creatives at once (the browse tree) resolve them in batch and hand them in.
+    # Left nil, each is resolved for this creative alone — correct, but a query
+    # per node. Single-creative call sites take that path.
+    def render_creative_progress(creative, select_mode: false, has_children: nil, can_write: nil, can_feedback: nil, unread_count: nil)
       progress_value = if params[:tags].present?
         tag_ids = Array(params[:tags]).map(&:to_s)
         creative.filtered_progress || creative.progress_for_tags(tag_ids) || 0
@@ -33,15 +44,15 @@ module Collavre
         creative.progress
       end
 
+      can_feedback = creative.has_permission?(Current.user, :feedback) if can_feedback.nil?
+
       content_tag(:div, class: "creative-row-end") do
         comment_part = if creative.archived?
           safe_join([])
-        elsif creative.has_permission?(Current.user, :feedback)
+        elsif can_feedback
           origin = creative.effective_origin
           comments_count = origin.comments_count
-          pointer = CommentReadPointer.find_by(user: Current.user, creative: origin)
-          last_read_id = pointer&.last_read_comment_id
-          unread_count = last_read_id ? origin.comments.where("id > ? and private = ?", last_read_id, false).count : comments_count
+          unread_count = unread_count_for(origin, comments_count) if unread_count.nil?
           if Current.user && CommentPresenceStore.list(origin.id).include?(Current.user.id)
             unread_count = 0
           end
@@ -70,7 +81,7 @@ module Collavre
           safe_join([])
         end
         is_leaf = has_children.nil? ? !creative.children.exists? : !has_children
-        can_write = creative.has_permission?(Current.user, :write)
+        can_write = creative.has_permission?(Current.user, :write) if can_write.nil?
         progress_part = if is_leaf && can_write && !select_mode
           render_progress_toggle(creative, progress_value)
         else
@@ -84,6 +95,17 @@ module Collavre
           (creative.tags ? render_creative_tags(creative) : safe_join([]))
         ])
       end
+    end
+
+    # Unread comments on `origin` for the current user. With no read pointer,
+    # every comment is unread. Batched by CommentBadgeIndex for the browse tree;
+    # this is the single-creative path.
+    def unread_count_for(origin, comments_count)
+      pointer = CommentReadPointer.find_by(user: Current.user, creative: origin)
+      last_read_id = pointer&.last_read_comment_id
+      return comments_count unless last_read_id
+
+      origin.comments.where("id > ? and private = ?", last_read_id, false).count
     end
 
     def render_progress_toggle(creative, value)

--- a/engines/collavre/app/models/collavre/creative/describable.rb
+++ b/engines/collavre/app/models/collavre/creative/describable.rb
@@ -29,7 +29,13 @@ module Collavre
       # Linked Creative의 description을 안전하게 반환
       def effective_description(variation_id = nil, html = true)
         if variation_id.present?
-          variation_tag = tags.find_by(label_id: variation_id)
+          # `find_by` on a loaded association still round-trips; the browse tree
+          # preloads tags per level and reaches here once per node.
+          variation_tag = if tags.loaded?
+            tags.find { |tag| tag.label_id.to_s == variation_id.to_s }
+          else
+            tags.find_by(label_id: variation_id)
+          end
           return variation_tag.value if variation_tag&.value.present?
         end
         description_val = origin_id.nil? ? description : origin.description

--- a/engines/collavre/app/services/collavre/creatives/children_index.rb
+++ b/engines/collavre/app/services/collavre/creatives/children_index.rb
@@ -1,0 +1,86 @@
+module Collavre
+module Creatives
+  # Per-level batch answer to "which children does this node show?" for the
+  # browse tree, replacing a per-node `children_with_permission` call.
+  #
+  # Presence (`has_children?`) is resolved for every node in a level with one
+  # plucked scan plus one batched PermissionFilter; the full child rows are
+  # materialized only for the nodes that actually render them (expanded, or a
+  # filter forcing the subtree open). Presence and content are derived from the
+  # same candidate set, so an expand toggle can never open an empty branch or
+  # hide a reachable subtree — a drift that would also leak the existence of
+  # children the user cannot see.
+  #
+  # Children of a linked shell live under its effective origin, so every lookup
+  # resolves the shell to its origin first. Preload `:origin` on the level before
+  # indexing it, or that resolution costs a query per shell.
+  class ChildrenIndex
+    def initialize(user:, show_archived:, allowed_creative_ids: nil)
+      @user = user
+      @show_archived = show_archived
+      @allowed_creative_ids = allowed_creative_ids
+      @child_ids_by_creative = {}
+      @rows_by_child_id = {}
+    end
+
+    # Scans a level. Only creatives not seen before cost anything, so the
+    # recursive descent pays two queries per level, not per node.
+    def index(creatives)
+      pending = creatives.reject { |c| @child_ids_by_creative.key?(c.id) }
+      return if pending.empty?
+
+      origin_id_by_id = pending.to_h { |c| [ c.id, c.effective_origin.id ] }
+
+      candidates = Creative.where(parent_id: origin_id_by_id.values.uniq)
+      candidates = candidates.where(archived_at: nil) unless show_archived
+      rows = candidates.order(:sequence).pluck(:id, :parent_id)
+
+      visible_by_origin = visible_child_ids_by_origin(rows)
+      pending.each do |creative|
+        @child_ids_by_creative[creative.id] = visible_by_origin[origin_id_by_id[creative.id]] || []
+      end
+    end
+
+    def has_children?(creative)
+      child_ids(creative).any?
+    end
+
+    # Materializes the child rows of `creatives` in a single query. Called only
+    # for the nodes whose children actually render.
+    def load(creatives)
+      wanted = creatives.flat_map { |c| child_ids(c) }.uniq - @rows_by_child_id.keys
+      return if wanted.empty?
+
+      Creative.where(id: wanted).each { |child| @rows_by_child_id[child.id] = child }
+    end
+
+    # Sequence-ordered, permission- and archive-filtered children. Empty unless
+    # `load` has materialized them.
+    def children_for(creative)
+      child_ids(creative).filter_map { |id| @rows_by_child_id[id] }
+    end
+
+    private
+
+    attr_reader :user, :show_archived, :allowed_creative_ids
+
+    # `rows` arrive in sequence order, so the per-origin lists inherit it.
+    def visible_child_ids_by_origin(rows)
+      return {} if rows.empty?
+
+      readable = PermissionFilter.new(user: user).readable_ids(rows.map(&:first)).to_set
+
+      rows.each_with_object({}) do |(child_id, origin_id), acc|
+        next unless readable.include?(child_id)
+        next if allowed_creative_ids && !allowed_creative_ids.include?(child_id.to_s)
+
+        (acc[origin_id] ||= []) << child_id
+      end
+    end
+
+    def child_ids(creative)
+      @child_ids_by_creative.fetch(creative.id, [])
+    end
+  end
+end
+end

--- a/engines/collavre/app/services/collavre/creatives/comment_badge_index.rb
+++ b/engines/collavre/app/services/collavre/creatives/comment_badge_index.rb
@@ -1,0 +1,64 @@
+module Collavre
+module Creatives
+  # Batches the browse tree's comment badge. Per node this was two queries — a
+  # read-pointer lookup and an unread COUNT — which is what made the badge cost
+  # scale with the size of the rendered tree.
+  #
+  # Keyed by *origin*: a linked shell shows its origin's comments.
+  class CommentBadgeIndex
+    def initialize(user:)
+      @user = user
+      @unread_by_origin_id = {}
+    end
+
+    def index(origins)
+      pending = origins.uniq(&:id).reject { |o| @unread_by_origin_id.key?(o.id) }
+      return if pending.empty?
+
+      watermarks = read_watermarks(pending.map(&:id))
+
+      # No read pointer means nothing has been read yet, so every comment counts
+      # as unread — including private ones, matching the counter cache.
+      pending.each do |origin|
+        @unread_by_origin_id[origin.id] = origin.comments_count unless watermarks.key?(origin.id)
+      end
+
+      counts = unread_counts(watermarks)
+      watermarks.each_key { |origin_id| @unread_by_origin_id[origin_id] = counts.fetch(origin_id, 0) }
+    end
+
+    # nil when the origin was never indexed, which tells the caller to fall back
+    # to the single-creative path rather than silently render a zero badge.
+    def unread_count_for(origin)
+      @unread_by_origin_id[origin.id]
+    end
+
+    private
+
+    attr_reader :user
+
+    # `user_id: nil` for an anonymous visitor is the lookup the un-batched path
+    # made too, so the two agree on which pointer (if any) applies.
+    def read_watermarks(origin_ids)
+      return {} if origin_ids.empty?
+
+      CommentReadPointer
+        .where(user_id: user&.id, creative_id: origin_ids)
+        .where.not(last_read_comment_id: nil)
+        .pluck(:creative_id, :last_read_comment_id)
+        .to_h
+    end
+
+    # One grouped COUNT for the whole level. Each origin carries its own read
+    # watermark, so the thresholds are OR-ed together rather than shared.
+    def unread_counts(watermarks)
+      return {} if watermarks.empty?
+
+      clause = Array.new(watermarks.size, "(creative_id = ? AND id > ?)").join(" OR ")
+      binds = watermarks.flat_map { |origin_id, last_read_id| [ origin_id, last_read_id ] }
+
+      Comment.where(private: false).where(clause, *binds).group(:creative_id).count
+    end
+  end
+end
+end

--- a/engines/collavre/app/services/collavre/creatives/comment_badge_index.rb
+++ b/engines/collavre/app/services/collavre/creatives/comment_badge_index.rb
@@ -50,14 +50,23 @@ module Creatives
     end
 
     # One grouped COUNT for the whole level. Each origin carries its own read
-    # watermark, so the thresholds are OR-ed together rather than shared.
+    # watermark, so the thresholds are OR-ed together rather than shared. Built
+    # from relations rather than a SQL fragment: a hand-built string here would
+    # be safe (literal template, bound values) but unprovably so to a scanner.
     def unread_counts(watermarks)
       return {} if watermarks.empty?
 
-      clause = Array.new(watermarks.size, "(creative_id = ? AND id > ?)").join(" OR ")
-      binds = watermarks.flat_map { |origin_id, last_read_id| [ origin_id, last_read_id ] }
+      newer_than_watermark = watermarks
+        .map { |origin_id, last_read_id| unread_scope(origin_id, last_read_id) }
+        .reduce { |combined, scope| combined.or(scope) }
 
-      Comment.where(private: false).where(clause, *binds).group(:creative_id).count
+      Comment.where(private: false).merge(newer_than_watermark).group(:creative_id).count
+    end
+
+    def unread_scope(origin_id, last_read_id)
+      Comment
+        .where(creative_id: origin_id)
+        .where(Comment.arel_table[:id].gt(last_read_id))
     end
   end
 end

--- a/engines/collavre/app/services/collavre/creatives/tree_builder.rb
+++ b/engines/collavre/app/services/collavre/creatives/tree_builder.rb
@@ -3,6 +3,10 @@ module Creatives
   class TreeBuilder
     FILTER_IGNORED_KEYS = %w[id controller action format level select_mode].freeze
 
+    # A creative's own row grants no permission; the check resolves to its origin
+    # (PermissionChecker), and the owner of that origin always has full access.
+    OWNER_RANK = CreativeShare.permissions[:admin]
+
     def initialize(user:, params:, view_context:, expanded_state_map:, select_mode:, max_level:, allowed_creative_ids: nil, progress_map: nil)
       @user = user
       @view_context = view_context
@@ -12,85 +16,124 @@ module Creatives
       @max_level = max_level
       @allowed_creative_ids = allowed_creative_ids
       @progress_map = progress_map
-      @permission_cache = {}
+      @permission_rank = {}
     end
 
     def build(collection, level: 1)
       return [] if collection.blank?
 
-      creatives = Array(collection)
-      # Preload permissions for all creatives in this batch to avoid N+1
-      preload_permissions(creatives)
-
-      build_nodes(creatives, level: level)
+      build_nodes(Array(collection), level: level)
     end
 
     private
 
-    attr_reader :user, :view_context, :raw_params, :expanded_state_map, :select_mode, :max_level, :allowed_creative_ids, :progress_map, :permission_cache
+    attr_reader :user, :view_context, :raw_params, :expanded_state_map, :select_mode, :max_level, :allowed_creative_ids, :progress_map
 
-    def preload_permissions(creatives)
-      return unless user
-
-      creative_ids = creatives.map(&:id)
-      return if creative_ids.empty?
-
-      # Skip if already cached
-      uncached_ids = creative_ids - @permission_cache.keys
-      return if uncached_ids.empty?
-
-      write_rank = CreativeShare.permissions[:write]
-
-      # Batch query for user-specific permissions
-      user_permissions = CreativeSharesCache
-        .where(creative_id: uncached_ids, user_id: user.id)
-        .pluck(:creative_id, :permission)
-
-      user_permissions.each do |cid, perm|
-        perm_rank = CreativeSharesCache.permissions[perm]
-        @permission_cache[cid] = perm_rank && perm_rank >= write_rank && perm_rank != CreativeSharesCache.permissions[:no_access]
-      end
-
-      # For remaining uncached, check public shares
-      still_uncached = uncached_ids - @permission_cache.keys
-      if still_uncached.any?
-        public_permissions = CreativeSharesCache
-          .where(creative_id: still_uncached, user_id: nil)
-          .pluck(:creative_id, :permission)
-
-        public_permissions.each do |cid, perm|
-          next if @permission_cache.key?(cid)
-          perm_rank = CreativeSharesCache.permissions[perm]
-          @permission_cache[cid] = perm_rank && perm_rank >= write_rank && perm_rank != CreativeSharesCache.permissions[:no_access]
-        end
-      end
-
-      # Mark owned creatives as having write permission
-      owned_ids = creatives.select { |c| c.user_id == user.id }.map(&:id)
-      owned_ids.each { |cid| @permission_cache[cid] = true }
-
-      # Default to false for any remaining uncached
-      uncached_ids.each { |cid| @permission_cache[cid] ||= false }
+    def children_index
+      @children_index ||= ChildrenIndex.new(
+        user: user,
+        show_archived: raw_params["show_archived"].present?,
+        allowed_creative_ids: allowed_creative_ids
+      )
     end
 
-    def cached_can_write?(creative)
+    def comment_badge_index
+      @comment_badge_index ||= CommentBadgeIndex.new(user: user)
+    end
+
+    # Everything a level of nodes needs, resolved in a fixed number of queries
+    # rather than a handful per node. The recursion re-enters here for each level,
+    # so total cost tracks tree *depth*, not node count.
+    def prepare_level(creatives)
+      ActiveRecord::Associations::Preloader.new(
+        records: creatives,
+        associations: [ :origin, { tags: :label } ]
+      ).call
+
+      preload_permissions(creatives)
+      preload_comment_badges(creatives)
+
+      return if children_suppressed?
+
+      children_index.index(creatives)
+      expanding = creatives.select { |creative| load_children_now?(creative) }
+      children_index.load(expanding) if expanding.any?
+    end
+
+    # Mirrors PermissionChecker exactly, in batch: owner wins, then the user's own
+    # cache entry (a no_access entry is rank 0 and so denies everything, even when
+    # a public share exists), then the public entry. Absent everywhere means no
+    # access at all, which is distinct from rank 0 only in intent.
+    def preload_permissions(creatives)
+      pending = creatives.reject { |creative| @permission_rank.key?(creative.id) }
+      return if pending.empty?
+
+      base_id_by_id = pending.to_h { |c| [ c.id, c.origin_id || c.id ] }
+      owner_id_by_id = pending.to_h { |c| [ c.id, c.origin_id.nil? ? c.user_id : c.origin&.user_id ] }
+      base_ids = base_id_by_id.values.uniq
+
+      user_entries = if user
+        CreativeSharesCache.where(creative_id: base_ids, user_id: user.id).pluck(:creative_id, :permission).to_h
+      else
+        {}
+      end
+
+      needs_public = base_ids - user_entries.keys
+      public_entries = if needs_public.any?
+        CreativeSharesCache.where(creative_id: needs_public, user_id: nil).pluck(:creative_id, :permission).to_h
+      else
+        {}
+      end
+
+      pending.each do |creative|
+        base_id = base_id_by_id[creative.id]
+        permission = user_entries[base_id] || public_entries[base_id]
+
+        @permission_rank[creative.id] =
+          if user && owner_id_by_id[creative.id] == user.id
+            OWNER_RANK
+          elsif permission
+            CreativeSharesCache.permissions[permission]
+          end
+      end
+    end
+
+    # Equivalent to `creative.has_permission?(user, permission)`, served from the
+    # level's batched ranks. Falls back for a creative the batch never saw.
+    def allowed?(creative, permission)
+      return creative.has_permission?(user, permission) unless @permission_rank.key?(creative.id)
+
+      rank = @permission_rank[creative.id]
+      return false if rank.nil?
+
+      rank >= CreativeShare.permissions[permission.to_s]
+    end
+
+    def can_write?(creative)
       return false unless user
       # Read-only-source creatives are never writable
       return false if creative.read_only_source?
 
-      if @permission_cache.key?(creative.id)
-        @permission_cache[creative.id]
-      else
-        # Fallback to individual check if not cached
-        creative.has_permission?(user, :write)
-      end
+      allowed?(creative, :write)
+    end
+
+    def can_feedback?(creative)
+      allowed?(creative, :feedback)
+    end
+
+    # Only rows that will actually render a badge are worth batching.
+    def preload_comment_badges(creatives)
+      visible = creatives.reject(&:archived?).select { |creative| can_feedback?(creative) }
+      return if visible.empty?
+
+      comment_badge_index.index(visible.map(&:effective_origin))
     end
 
     def build_nodes(creatives, level:)
       return [] if level > max_level
+      return [] if creatives.empty?
 
-      # Preload permissions for this batch of creatives
-      preload_permissions(creatives) if creatives.any?
+      prepare_level(creatives)
 
       creatives.flat_map do |creative|
         build_nodes_for_creative(creative, level: level)
@@ -102,15 +145,17 @@ module Creatives
         creative.filtered_progress = progress_map[creative.id.to_s]
       end
 
-      filtered_children = filtered_children_for(creative)
       expanded = expanded?(creative.id)
       skip = skip_creative?(creative)
       child_level = level + 1
       child_render_level = skip ? level : child_level
-      load_children_now = filters_applied? || expanded || skip
-      children_nodes = load_children_now ? build_nodes(filtered_children, level: child_render_level) : []
+      load_children_now = load_children_now?(creative)
+      has_children = !children_suppressed? && children_index.has_children?(creative)
+      children_nodes = load_children_now ? build_nodes(children_index.children_for(creative), level: child_render_level) : []
 
       return children_nodes if skip
+
+      can_write = can_write?(creative)
 
       [
         {
@@ -119,10 +164,10 @@ module Creatives
           parent_id: creative.parent_id,
           level: level,
           select_mode: !!select_mode,
-          can_write: cached_can_write?(creative),
-          has_children: filtered_children.any?,
+          can_write: can_write,
+          has_children: has_children,
           expanded: expanded,
-          is_root: creative.parent.nil?,
+          is_root: creative.parent_id.nil?,
           archived: creative.archived?,
           # `github_source` is the wire key the tree renderer JS reads; its value
           # is now the neutral read-only-source flag (GitHub-synced content is one
@@ -130,11 +175,11 @@ module Creatives
           github_source: creative.read_only_source?,
           sequence: creative.sequence,
           link_url: view_context.collavre.creative_path(creative),
-          templates: template_payload_for(creative, has_children: filtered_children.any?),
-          inline_editor_payload: inline_editor_payload_for(creative, can_write: cached_can_write?(creative)),
+          templates: template_payload_for(creative, has_children: has_children, can_write: can_write),
+          inline_editor_payload: inline_editor_payload_for(creative, can_write: can_write),
           children_container: children_container_payload(
             creative,
-            filtered_children,
+            has_children: has_children,
             child_level: child_level,
             children_nodes: children_nodes,
             expanded: expanded,
@@ -152,16 +197,17 @@ module Creatives
       false
     end
 
-    def filtered_children_for(creative)
-      return [] if raw_params["comment"] == "true" || (raw_params["search"].present? && raw_params["search_mode"] != "tree")
+    # The chats feed and flat search render rows, not a tree: no node has children
+    # there, so the whole child resolution is skipped.
+    def children_suppressed?
+      return @children_suppressed if defined?(@children_suppressed)
 
-      children = creative.children_with_permission(user)
-      children = children.select { |c| !c.archived? } unless raw_params["show_archived"]
-      if allowed_creative_ids
-        children.select { |c| allowed_creative_ids.include?(c.id.to_s) }
-      else
-        children
-      end
+      @children_suppressed = raw_params["comment"] == "true" ||
+        (raw_params["search"].present? && raw_params["search_mode"] != "tree")
+    end
+
+    def load_children_now?(creative)
+      filters_applied? || expanded?(creative.id) || skip_creative?(creative)
     end
 
     def expanded?(creative_id)
@@ -177,9 +223,17 @@ module Creatives
       end
     end
 
-    def template_payload_for(creative, has_children: nil)
+    def template_payload_for(creative, has_children: nil, can_write: nil)
       description_html = view_context.embed_youtube_iframe(creative.effective_description(raw_params["tags"]&.first))
-      progress_html = view_context.render_creative_progress(creative, select_mode: !!select_mode, has_children: has_children)
+      can_feedback = can_feedback?(creative)
+      progress_html = view_context.render_creative_progress(
+        creative,
+        select_mode: !!select_mode,
+        has_children: has_children,
+        can_write: can_write,
+        can_feedback: can_feedback,
+        unread_count: can_feedback ? comment_badge_index.unread_count_for(creative.effective_origin) : nil
+      )
 
       {
         description_html: description_html,
@@ -192,7 +246,7 @@ module Creatives
 
     def inline_editor_payload_for(creative, can_write:)
       effective = creative.effective_origin(Set.new)
-      origin_writable = effective.id == creative.id ? can_write : creative.has_permission?(user, :write)
+      origin_writable = effective.id == creative.id ? can_write : allowed?(creative, :write)
       {
         description_raw_html: creative.effective_description(nil, true),
         progress: creative.progress,
@@ -203,8 +257,8 @@ module Creatives
       }
     end
 
-    def children_container_payload(creative, filtered_children, child_level:, children_nodes:, expanded:, load_children_now:)
-      return nil unless filtered_children.any?
+    def children_container_payload(creative, has_children:, child_level:, children_nodes:, expanded:, load_children_now:)
+      return nil unless has_children
 
       {
         id: "creative-children-#{creative.id}",

--- a/engines/collavre/test/controllers/creatives_has_children_parity_test.rb
+++ b/engines/collavre/test/controllers/creatives_has_children_parity_test.rb
@@ -1,0 +1,81 @@
+require "test_helper"
+
+# `has_children` drives the expand toggle, and the toggle's target is a separate
+# request (Creatives#children). The two answers are now derived by different code
+# — a batched presence scan for the flag, `children_with_permission` for the
+# expansion — so they have to be pinned to each other.
+#
+# Drift in either direction is a real bug: a toggle whose expansion comes back
+# empty tells the user that children exist which they are not allowed to see,
+# and a missing toggle hides a subtree they can reach.
+class CreativesHasChildrenParityTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:one)
+    @other = users(:two)
+    sign_in_as(@user, password: "password")
+
+    @root = Creative.create!(user: @user, description: "Parity root", sequence: 900)
+  end
+
+  test "a child the user cannot read grants no toggle" do
+    node = Creative.create!(user: @user, parent: @root, description: "node", sequence: 1)
+    Creative.create!(user: @other, parent: node, description: "someone else's", sequence: 1)
+
+    assert_equal false, has_children?(node), "an unreadable child must not surface a toggle"
+    assert_empty expand(node), "sanity: expanding really does show nothing"
+  end
+
+  test "a readable child grants a toggle that expands to it" do
+    node = Creative.create!(user: @user, parent: @root, description: "node", sequence: 1)
+    child = Creative.create!(user: @user, parent: node, description: "mine", sequence: 1)
+
+    assert_equal true, has_children?(node)
+    assert_equal [ child.id ], expand(node).map { |n| n["id"] }
+  end
+
+  test "an archived-only child grants no toggle unless archived rows are shown" do
+    node = Creative.create!(user: @user, parent: @root, description: "node", sequence: 1)
+    child = Creative.create!(user: @user, parent: node, description: "archived", sequence: 1)
+    child.archive!
+
+    assert_equal false, has_children?(node)
+    assert_equal true, has_children?(node, show_archived: true)
+  end
+
+  # Children of a linked shell hang off the origin, not the shell row, so a
+  # presence lookup keyed on the shell's own id would report every shell childless.
+  test "a linked shell reports the origin's children" do
+    origin = Creative.create!(user: @user, description: "origin", sequence: 901)
+    Creative.create!(user: @user, parent: origin, description: "origin child", sequence: 1)
+    shell = Creative.create!(user: @user, parent: @root, origin: origin, description: "shell", sequence: 2)
+
+    assert_equal true, has_children?(shell)
+  end
+
+  test "a childless node grants no toggle" do
+    node = Creative.create!(user: @user, parent: @root, description: "leaf", sequence: 1)
+
+    assert_equal false, has_children?(node)
+  end
+
+  private
+
+  # Reads the flag off the browse tree the same way the client does.
+  def has_children?(creative, show_archived: false)
+    params = { format: :json, id: @root.id }
+    params[:show_archived] = true if show_archived
+    get collavre.creatives_path(**params)
+    assert_response :success
+
+    node = JSON.parse(response.body).fetch("creatives").find { |n| n["id"] == creative.id }
+    assert_not_nil node, "creative #{creative.id} should be rendered under the root"
+    node.fetch("has_children")
+  end
+
+  # What clicking the toggle actually fetches.
+  def expand(creative)
+    get collavre.children_creative_path(creative, format: :json)
+    assert_response :success
+    JSON.parse(response.body).fetch("creatives")
+  end
+end

--- a/engines/collavre/test/controllers/creatives_index_query_count_test.rb
+++ b/engines/collavre/test/controllers/creatives_index_query_count_test.rb
@@ -1,0 +1,84 @@
+require "test_helper"
+
+# The browse tree (Creatives#index, JSON) must not issue queries proportional to
+# the number of rendered nodes. Postgres is reached over the network, so every
+# query costs a round trip and a per-node cost turns a page into seconds.
+#
+# The invariant asserted here is the shape of the cost, not an absolute number:
+# rendering N more siblings must not cost O(N) more queries. Absolute counts move
+# with unrelated features; the slope is what regresses into an outage.
+class CreativesIndexQueryCountTest < ActionDispatch::IntegrationTest
+  # Batched work still has some per-level cost, and a few queries scale with the
+  # *result set* rather than the node count (e.g. a single WHERE IN grows its
+  # bind list, not its query count). Allow a small constant; a regression to
+  # per-node querying overshoots this by an order of magnitude.
+  ALLOWED_DELTA = 10
+
+  setup do
+    @user = users(:one)
+    sign_in_as(@user, password: "password")
+
+    @parent = Creative.create!(user: @user, description: "Query count parent", sequence: 900)
+  end
+
+  test "query count does not scale with the number of rendered siblings" do
+    add_children(5)
+    baseline_nodes = 5
+    get_tree # warm process-level caches (settings, schema) so they don't land in the baseline
+    baseline = count_queries { get_tree }
+
+    add_children(10)
+    grown_nodes = 15
+    grown = count_queries { get_tree }
+
+    assert_equal grown_nodes, rendered_node_count,
+      "the grown tree must actually render every sibling, or the counts compare nothing"
+
+    delta = grown - baseline
+    added = grown_nodes - baseline_nodes
+
+    assert delta <= ALLOWED_DELTA,
+      "rendering #{added} more siblings cost #{delta} more queries " \
+      "(#{baseline} -> #{grown}, #{(delta.to_f / added).round(1)}/node). " \
+      "Query count must not scale with node count; batch per level instead."
+  end
+
+  private
+
+  # Each child gets a grandchild so `has_children` is true and the collapsed node
+  # still has to answer "is there something to expand?" — the exact question the
+  # old code answered by loading the whole child set per node.
+  def add_children(count)
+    count.times do
+      child = Creative.create!(user: @user, parent: @parent, description: "child", sequence: 1)
+      Creative.create!(user: @user, parent: child, description: "grandchild", sequence: 1)
+    end
+    @parent.reload
+  end
+
+  def get_tree
+    get collavre.creatives_path(format: :json, id: @parent.id)
+    assert_response :success
+  end
+
+  def rendered_node_count
+    JSON.parse(response.body).fetch("creatives").length
+  end
+
+  # In production the AR query cache lives and dies with a single request. It
+  # survives between requests here, which would let a measured request coast on
+  # the previous one's cache and hide the very N+1 this asserts against.
+  def count_queries
+    Collavre::Creative.connection.clear_query_cache
+    count = 0
+    counter = lambda do |_name, _start, _finish, _id, payload|
+      next if payload[:cached]
+      next if %w[SCHEMA TRANSACTION].include?(payload[:name])
+
+      count += 1
+    end
+
+    ActiveSupport::Notifications.subscribed(counter, "sql.active_record") { yield }
+    count
+  end
+end

--- a/engines/collavre/test/services/creatives/ancestor_filter_test.rb
+++ b/engines/collavre/test/services/creatives/ancestor_filter_test.rb
@@ -5,7 +5,7 @@ module Creatives
     class FakeViewContext
       include Rails.application.routes.url_helpers
       def embed_youtube_iframe(_content); ""; end
-      def render_creative_progress(_creative, select_mode: false, has_children: nil); ""; end
+      def render_creative_progress(_creative, select_mode: false, has_children: nil, can_write: nil, can_feedback: nil, unread_count: nil); ""; end
       def svg_tag(name, **args); ""; end
       def link_to(_path, *args); block_given? ? yield : ""; end
       def creative_path(creative); "/creatives/#{creative.id}"; end

--- a/engines/collavre/test/services/creatives/comment_badge_index_test.rb
+++ b/engines/collavre/test/services/creatives/comment_badge_index_test.rb
@@ -1,0 +1,88 @@
+require "test_helper"
+
+module Creatives
+  # Each origin carries its own read watermark, so the batched unread count is an
+  # OR of per-origin thresholds rather than one shared cutoff. Getting that wrong
+  # silently shows every user the wrong badge, so pin the arithmetic.
+  class CommentBadgeIndexTest < ActiveSupport::TestCase
+    setup do
+      @user = users(:one)
+      @author = users(:two)
+      @index = Collavre::Creatives::CommentBadgeIndex.new(user: @user)
+    end
+
+    test "counts only public comments newer than the read watermark" do
+      creative = Creative.create!(user: @user, description: "Watermarked", sequence: 900)
+      first = comment_on(creative, "one")
+      comment_on(creative, "two")
+      comment_on(creative, "three")
+      comment_on(creative, "private", private: true)
+
+      CommentReadPointer.create!(user: @user, creative: creative, last_read_comment_id: first.id)
+
+      @index.index([ creative.reload ])
+
+      assert_equal 2, @index.unread_count_for(creative), "two public comments follow the watermark; the private one never counts"
+    end
+
+    test "without a read pointer every comment is unread" do
+      creative = Creative.create!(user: @user, description: "Never opened", sequence: 901)
+      comment_on(creative, "one")
+      comment_on(creative, "two")
+
+      @index.index([ creative.reload ])
+
+      assert_equal 2, @index.unread_count_for(creative)
+    end
+
+    test "a watermark at the newest comment leaves nothing unread" do
+      creative = Creative.create!(user: @user, description: "Fully read", sequence: 902)
+      comment_on(creative, "one")
+      last = comment_on(creative, "two")
+
+      CommentReadPointer.create!(user: @user, creative: creative, last_read_comment_id: last.id)
+
+      @index.index([ creative.reload ])
+
+      assert_equal 0, @index.unread_count_for(creative)
+    end
+
+    # The batch is one query for the whole level, so a per-origin watermark must
+    # not leak across origins.
+    test "each origin is counted against its own watermark" do
+      read = Creative.create!(user: @user, description: "Read", sequence: 903)
+      read_first = comment_on(read, "a1")
+      comment_on(read, "a2")
+      CommentReadPointer.create!(user: @user, creative: read, last_read_comment_id: read_first.id)
+
+      unread = Creative.create!(user: @user, description: "Unread", sequence: 904)
+      comment_on(unread, "b1")
+      comment_on(unread, "b2")
+      comment_on(unread, "b3")
+
+      fully_read = Creative.create!(user: @user, description: "Caught up", sequence: 905)
+      caught_up = comment_on(fully_read, "c1")
+      CommentReadPointer.create!(user: @user, creative: fully_read, last_read_comment_id: caught_up.id)
+
+      @index.index([ read.reload, unread.reload, fully_read.reload ])
+
+      assert_equal 1, @index.unread_count_for(read)
+      assert_equal 3, @index.unread_count_for(unread)
+      assert_equal 0, @index.unread_count_for(fully_read)
+    end
+
+    # nil, not 0 — the caller has to be able to tell "not batched" from "nothing
+    # unread", or an un-indexed node would quietly render an empty badge.
+    test "an unindexed creative reports nil" do
+      creative = Creative.create!(user: @user, description: "Untouched", sequence: 906)
+
+      assert_nil @index.unread_count_for(creative)
+    end
+
+    private
+
+    def comment_on(creative, content, private: false)
+      Comment.create!(creative: creative, user: @author, content: content, private: private)
+    end
+  end
+end

--- a/engines/collavre/test/services/creatives/tree_builder_test.rb
+++ b/engines/collavre/test/services/creatives/tree_builder_test.rb
@@ -9,7 +9,7 @@ module Creatives
         "<iframe></iframe>"
       end
 
-      def render_creative_progress(_creative, select_mode: false, has_children: nil)
+      def render_creative_progress(_creative, select_mode: false, has_children: nil, can_write: nil, can_feedback: nil, unread_count: nil)
         "<progress data-select='#{select_mode}'></progress>"
       end
 


### PR DESCRIPTION
## Why

The main page (`Creatives#index`, JSON) issues **181–824 queries per request**. Now that Postgres is reached over the network, each query is a **6.2–8.9 ms round trip** (an idle `SELECT 1` with the AR query cache off measures 6.18 ms), so response time tracks query count almost exactly:

| queries | response |
|---|---|
| 181 | 1.18 s |
| 378 | 2.06 s |
| 824 | 5.25 s |

85–95 % of the request is ActiveRecord; view render is 0.1–13 ms. Under SQLite the same queries were in-process (~0.01 ms each), which is why this never surfaced before.

Per rendered node the tree was asking for:

- `children_with_permission` (~5 queries) — **run even for a collapsed node**, only to derive `has_children`, and then recursing into the children it just loaded
- two permission checks that went through `PermissionChecker` and **bypassed the preload cache that already existed**
- a comment read-pointer lookup plus an unread `COUNT`
- a tags lookup

## What changed

Each *level* is now resolved in a fixed number of queries, so cost tracks tree **depth**, not node count.

- **`ChildrenIndex`** answers `has_children` for a whole level with one plucked scan plus one batched `PermissionFilter`, and materializes child rows only for the nodes that actually render them. This is a port of `CreativeTreeSerializer#children_presence_set`, which already solved the same problem for the picker popup — not a new design.
- **`CommentBadgeIndex`** batches read pointers and unread counts per level (one grouped `COUNT` with per-origin watermarks OR-ed together).
- The permission cache now stores the **effective rank**, resolved against the origin exactly as `PermissionChecker` does, so `:write` and `:feedback` both answer from memory. It is passed into `render_creative_progress`, which previously re-asked and bypassed it.
- Preload `origin` and `tags → label` per level; `is_root` reads `parent_id` instead of loading `parent`.

## Result

Measured under one harness (warmed caches, AR query cache cleared per request, as in production):

| | 5 siblings | 15 siblings | per node |
|---|---|---|---|
| before | 47 q | 117 q | **7.0** |
| after | 18 q | **18 q** | **0.0** |

## Correctness

The real risk here is not performance but **`has_children` parity**: the flag drives the expand toggle, and the toggle's target is a separate request. If they drift, an expansion comes back empty — which tells the user that children exist they aren't allowed to see — or a reachable subtree loses its toggle.

- `creatives_has_children_parity_test.rb` pins the flag against what expanding actually returns, across unreadable children, archived-only children (with and without `show_archived`), and linked shells (whose children hang off the origin, not the shell row). Mutation-checked: reverting the origin resolution fails the shell test.
- `creatives_index_query_count_test.rb` asserts the invariant that query count must not scale with node count. It fails on `main` (7.0 queries/node) and passes here.
- The browse tree JSON is **byte-identical** before and after across default, `show_archived` and tag-filter views, for a tree containing unreadable children, archived children, a linked shell, comments and tags.
- Full collavre suite: 1252 runs, 0 failures.

## Out of scope

Production Postgres still runs on a local MacBook (`macbook-pro.tailadceed.ts.net`), so the app dies when it sleeps. Moving the DB onto the app's network multiplies with this change rather than substituting for it.