### PR TITLE
ci: add Postgres schema-load smoke job to catch SQLite-only constructs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,49 @@ jobs:
       - name: Lint code for consistent style
         run: bin/rubocop -f github
 
+  # Production runs PostgreSQL while dev/test run SQLite, so db/schema.rb is
+  # dumped from SQLite and can silently pick up SQLite-only constructs (e.g.
+  # json_extract expression indexes) that crash `db:schema:load` on Postgres —
+  # a failure that would only surface in production. This smoke job loads the
+  # schema against a real Postgres to fail fast. Everything lives in the single
+  # db/schema.rb (Solid Queue/Cache/Cable tables included, and all engine
+  # tables), so loading that one file covers every engine's schema too.
+  postgres_schema_load:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: collavre
+          POSTGRES_PASSWORD: collavre
+          POSTGRES_DB: collavre_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U collavre"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: .ruby-version
+          bundler-cache: true
+
+      - name: Load schema on PostgreSQL (fail on SQLite-only constructs)
+        env:
+          RAILS_ENV: test
+          # postgresql:// scheme so config/database.yml derives the correct
+          # "postgresql" adapter; the URL overrides the SQLite test database.
+          DATABASE_URL: postgresql://collavre:collavre@localhost:5432/collavre_test
+        run: bin/rails db:schema:load
+
   test:
     runs-on: ubuntu-latest
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_13_000002) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_15_000000) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -232,7 +232,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_13_000002) do
     t.integer "comments_count", default: 0, null: false
     t.datetime "created_at", null: false
     t.json "data", default: {}, null: false
-    t.text "description", limit: 4294967295
+    t.text "description"
     t.integer "origin_id"
     t.integer "parent_id"
     t.float "progress", default: 0.0

--- a/engines/collavre/db/migrate/20260715000000_change_creatives_description_to_plain_text.rb
+++ b/engines/collavre/db/migrate/20260715000000_change_creatives_description_to_plain_text.rb
@@ -1,0 +1,16 @@
+class ChangeCreativesDescriptionToPlainText < ActiveRecord::Migration[8.1]
+  # The original AddDescriptionToCreatives migration created the column as
+  # `:text, limit: 4294967295` (a MySQL LONGTEXT-style byte cap). SQLite ignores
+  # the limit, but it gets recorded in db/schema.rb, and `db:schema:load` then
+  # crashes on PostgreSQL (production) with:
+  #   ArgumentError: No text type has byte size 4294967295.
+  # Postgres `text` is already unbounded, so drop the limit to keep the schema
+  # loadable on every adapter.
+  def up
+    change_column :creatives, :description, :text, limit: nil
+  end
+
+  def down
+    change_column :creatives, :description, :text, limit: 4294967295
+  end
+end


### PR DESCRIPTION
## Problem
Production runs PostgreSQL while CI/dev run SQLite exclusively. `db/schema.rb` is dumped from the SQLite dev DB, so it can record SQLite-only constructs that crash `db:schema:load` on Postgres — a "prod-only crash" nothing in CI currently catches.

## Changes
This PR does two things and is self-consistent (its own new guard is green):

### 1. New `postgres_schema_load` CI job (`.github/workflows/ci.yml`)
- Stands up a `postgres:16` service container (prod version is not pinned anywhere discoverable; used a current stable).
- Mirrors the existing Ruby jobs' setup (`ubuntu-latest`, `actions/checkout@v6`, `ruby/setup-ruby@v1` with `.ruby-version` + `bundler-cache`).
- Runs `bin/rails db:schema:load` with `RAILS_ENV=test` and a `postgresql://` `DATABASE_URL` (the URL scheme makes `config/database.yml` derive the `postgresql` adapter and overrides the SQLite test DB).
- Schema-load only — does not run the test suite.

No Gemfile change: `pg` is already a dependency (`:production` group) and is installed in CI by default (no `BUNDLE_WITHOUT`). Everything lives in the single `db/schema.rb` (Solid Queue/Cache/Cable + all engine tables), so loading that one file covers every engine's schema.

### 2. Fix the one incompatibility the guard caught
The new job caught a real prod-only crash on `creatives.description`:
```
ArgumentError: No text type has byte size 4294967295. The limit on text can be at most 1GB - 1byte.
```
That column was created as `:text, limit: 4294967295` (a MySQL LONGTEXT-style cap) in `AddDescriptionToCreatives`. SQLite ignores the limit but records it in `db/schema.rb`, and Postgres rejects it.

Fix (in the owning `collavre` engine):
- New migration `engines/collavre/db/migrate/20260715000000_change_creatives_description_to_plain_text.rb` — `change_column :creatives, :description, :text, limit: nil` (Postgres `text` is already unbounded; reversible `down` restores the old limit).
- Ran the migration on the SQLite dev DB and regenerated `db/schema.rb` from that dump — the regenerated schema no longer carries `limit: 4294967295` (round-trip held; it did not re-add the limit), and schema version bumped to `2026_07_15_000000`.

## Verification (local, against `postgres:16`)
- Before the fix: `bin/rails db:schema:load` aborts on `db/schema.rb` with the ArgumentError above.
- After the fix: same command exits 0, loads all 70 tables, and `creatives.description` is a plain unbounded `text` column on Postgres.
- YAML parses (`ruby -ryaml`).