### PR TITLE
fix: keep parentId for newly-added siblings via single data-parent-id convention

### DIFF
--- a/engines/collavre/app/javascript/components/__tests__/creative_tree_row_parent_id.test.js
+++ b/engines/collavre/app/javascript/components/__tests__/creative_tree_row_parent_id.test.js
@@ -1,0 +1,87 @@
+/**
+ * Regression: parentId single source of truth.
+ *
+ * The tree row component used to render `data-parent-id=${this.parentId ?? nothing}`,
+ * which OMITTED the attribute whenever parentId was null. `addNew` derives a new
+ * sibling's parent from `prev.dataset.parentId`, so an absent attribute produced an
+ * `undefined` parent downstream and lost the real parent for newly-added siblings.
+ *
+ * The single convention: `data-parent-id` is ALWAYS emitted on `.creative-tree`.
+ * A non-empty value is the parent id; "" means "root / no parent". This mirrors the
+ * dynamic-creation path (`dataset.parentId = parentId || ''`).
+ */
+
+// The component calls `customElements.define(...)` at module-eval time and reads
+// `customElements` as a bare global. The jest environment only exposes it on
+// `window`, so bridge it before importing the component.
+beforeAll(() => {
+  if (typeof globalThis.customElements === "undefined") {
+    globalThis.customElements = window.customElements;
+  }
+});
+
+async function mountRow(props) {
+  await import("../creative_tree_row.js");
+  const el = document.createElement("creative-tree-row");
+  Object.assign(el, props);
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+// The `.creative-tree` element is what the editor reads via `tree.dataset.parentId`.
+function treeOf(el) {
+  return el.querySelector(".creative-tree");
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("creative-tree-row parentId convention", () => {
+  test("non-title row under a page-title parent keeps the parent id", async () => {
+    const el = await mountRow({ creativeId: "8", parentId: "5", level: 2 });
+    const tree = treeOf(el);
+
+    // The attribute is always present and carries the real parent id — this is
+    // exactly what addNew reads (`prev.dataset.parentId`) when deriving a sibling.
+    expect(tree.hasAttribute("data-parent-id")).toBe(true);
+    expect(tree.dataset.parentId).toBe("5");
+  });
+
+  test("root row emits an explicit empty marker instead of omitting the attribute", async () => {
+    const el = await mountRow({ creativeId: "5", parentId: null, level: 1 });
+    const tree = treeOf(el);
+
+    // Before the fix this attribute was omitted (ambiguous root vs unknown).
+    expect(tree.hasAttribute("data-parent-id")).toBe(true);
+    expect(tree.dataset.parentId).toBe("");
+  });
+
+  test("title row preserves its own parent (nested page) instead of dropping it", async () => {
+    const el = await mountRow({ creativeId: "5", parentId: "2", isTitle: true });
+    const tree = treeOf(el);
+
+    expect(tree.classList.contains("creative-tree-title")).toBe(true);
+    expect(tree.hasAttribute("data-parent-id")).toBe(true);
+    expect(tree.dataset.parentId).toBe("2");
+  });
+
+  test("root title row emits explicit empty marker", async () => {
+    const el = await mountRow({ creativeId: "5", parentId: null, isTitle: true });
+    const tree = treeOf(el);
+
+    expect(tree.hasAttribute("data-parent-id")).toBe(true);
+    expect(tree.dataset.parentId).toBe("");
+  });
+
+  test("addNew sibling derivation reads the correct parent from a page-title child", async () => {
+    // Simulate the editor's else-branch derivation: parentId = prev.dataset.parentId
+    // for a child row that lives under a page-title parent (id 5).
+    const child = await mountRow({ creativeId: "8", parentId: "5", level: 2 });
+    const prev = treeOf(child);
+
+    const derivedParentId = prev.dataset.parentId || "";
+    expect(derivedParentId).toBe("5"); // sibling inherits the page-title parent
+  });
+});

--- a/engines/collavre/app/javascript/components/creative_tree_row.js
+++ b/engines/collavre/app/javascript/components/creative_tree_row.js
@@ -208,6 +208,12 @@ class CreativeTreeRow extends LitElement {
     if (this._progressToggle) this._progressToggle.addEventListener("click", this._handleProgressToggle, { passive: false });
   }
 
+  // parentId convention (single source of truth): `data-parent-id` is ALWAYS
+  // emitted on the `.creative-tree` element. A non-empty value is the parent
+  // creative id; an empty string ("") means "root / no parent". This mirrors
+  // the dynamic-creation path (`dataset.parentId = parentId || ''`) so readers
+  // never have to disambiguate an *absent* attribute (unknown) from a real
+  // root, which previously dropped the parent for newly-added siblings.
   render() {
     if (this.isTitle) {
       return this._renderTitle();
@@ -224,7 +230,7 @@ class CreativeTreeRow extends LitElement {
         class="creative-tree"
         id=${this.domId ?? nothing}
         data-id=${this.creativeId ?? nothing}
-        data-parent-id=${this.parentId ?? nothing}
+        data-parent-id=${this.parentId ?? ""}
         data-level=${this.level ?? nothing}
         draggable=${draggableAttr}
         data-action=${dragActions}
@@ -250,7 +256,7 @@ class CreativeTreeRow extends LitElement {
         class="creative-tree creative-tree-title"
         id=${this.domId ?? nothing}
         data-id=${this.creativeId ?? nothing}
-        data-parent-id=${this.parentId ?? nothing}
+        data-parent-id=${this.parentId ?? ""}
       >
         <div class="creative-row" style="background-color: transparent;" data-creatives--select-mode-target="row">
           <div class="creative-row-start" style="align-items: center;">

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -397,6 +397,8 @@ export function initializeCreativeRowEditor() {
       setProgressState(normalizedProgress);
       updateProgressInputAvailability(normalizedProgress);
       completionCascadePending = false;
+      // parentId convention: `data-parent-id` is always present ("" === root),
+      // so this DOM fallback is unambiguous when server data lacks parent_id.
       const fallbackParent = tree?.dataset?.parentId || '';
       parentInput.value = data.parent_id ?? fallbackParent ?? '';
       beforeInput.value = '';
@@ -1620,7 +1622,10 @@ export function initializeCreativeRowEditor() {
           insertBefore = normalizeRowNode(firstChild);
           beforeId = insertBefore ? creativeIdFrom(insertBefore) : '';
         } else {
-          parentId = prev.dataset.parentId;
+          // parentId convention: `data-parent-id` is always present; "" means
+          // root. Normalize to '' so an absent attribute (legacy DOM) and a
+          // real root are treated identically, and a real parent id is kept.
+          parentId = prev.dataset.parentId || '';
           container = treeContainerElement(prev);
           afterId = prev.dataset.id;
           insertBefore = nodeAfterTreeBlock(prev);


### PR DESCRIPTION
## Problem
`parentId` was lost for newly-added siblings. The tree row component rendered
`data-parent-id=${this.parentId ?? nothing}`, which **omitted** the attribute
entirely when `parentId` was null. `addNew` derives a new sibling's parent from
`prev.dataset.parentId`, so an absent attribute produced an `undefined` parent
downstream — and root vs. "unknown parent" were indistinguishable. Meanwhile the
dynamic-creation path already used a different convention (`dataset.parentId = parentId || ''`).

## Fix — one parentId convention (single source of truth)
`data-parent-id` is now **always** emitted on `.creative-tree`:
- non-empty value = the parent creative id
- `""` = root / no parent

This mirrors the existing dynamic-creation path, so readers never disambiguate an
absent attribute from a real root.

### Render sites (`components/creative_tree_row.js`)
- `render()` (non-title) and `_renderTitle()`: `?? nothing` → `?? ""` for `data-parent-id`.
- Documented the convention above `render()`.

### Read sites (`modules/creative_row_editor.js`)
- `addNew` sibling derivation: `parentId = prev.dataset.parentId || ''` (normalized; keeps a real parent, treats absent/legacy DOM as root).
- `applyCreativeData` fallback read: annotated to reference the now-unambiguous convention (behavior preserved).

Scope: tree row JS + editor parentId read sites only. No save-engine or unrelated refactors.

## Test
Added `components/__tests__/creative_tree_row_parent_id.test.js` (5 cases): the render marker is always present (real id for a child under a page-title parent, `""` for roots, for both row and title paths) and the `addNew` sibling derivation reads the correct page-title parent.

```
node --experimental-vm-modules ./node_modules/.bin/jest \
  engines/collavre/app/javascript/components/__tests__/creative_tree_row_parent_id.test.js
Tests: 5 passed, 5 total
```

Verified the two root-marker assertions **fail** against the pre-fix render (attribute omitted), confirming the test guards the regression.