### PR TITLE
test: add SimpleCov and Jest coverage measurement + baseline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ db/videos-dark/
 
 .DS_Store
 
+
+# Test coverage reports
+/coverage

--- a/Gemfile
+++ b/Gemfile
@@ -91,6 +91,10 @@ group :test do
   gem "selenium-webdriver"
   gem "minitest-mock"
   gem "webmock"
+
+  # Test coverage (activated only when COVERAGE env var is set; see test/support/coverage.rb)
+  gem "simplecov", require: false
+  gem "simplecov-lcov", require: false
 end
 
 gem "doorkeeper", "~> 5.9"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -607,6 +607,8 @@ GEM
       faraday (>= 0.17.5, < 3.a)
       jwt (>= 1.5, < 4.0)
       multi_json (~> 1.10)
+    simplecov (1.0.1)
+    simplecov-lcov (0.9.0)
     snaky_hash (2.0.3)
       hashie (>= 0.1.0, < 6)
       version_gem (>= 1.1.8, < 3)
@@ -756,6 +758,8 @@ DEPENDENCIES
   rubocop-rails-omakase
   ruby_llm
   selenium-webdriver
+  simplecov
+  simplecov-lcov
   solid_cable
   solid_cache
   solid_queue

--- a/engines/collavre/test/test_helper.rb
+++ b/engines/collavre/test/test_helper.rb
@@ -5,6 +5,7 @@ ENV["RAILS_ENV"] ||= "test"
 
 # Load the host application for testing
 # This allows engine tests to run against the full application stack
+require_relative "../../../test/support/coverage" # no-op unless COVERAGE is set; must precede app code
 require_relative "../../../config/environment"
 require "rails/test_help"
 require "minitest/mock"
@@ -26,6 +27,15 @@ module ActiveSupport
 
     # Run tests in parallel with specified workers
     parallelize(workers: :number_of_processors)
+
+    if ENV["COVERAGE"]
+      parallelize_setup do |worker|
+        SimpleCov.command_name "#{SimpleCov.command_name}-#{worker}"
+      end
+      parallelize_teardown do |_worker|
+        SimpleCov.result
+      end
+    end
 
     # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
     fixtures :all

--- a/engines/collavre_openclaw/test/test_helper.rb
+++ b/engines/collavre_openclaw/test/test_helper.rb
@@ -1,3 +1,4 @@
+require_relative "../../../test/support/coverage" # no-op unless COVERAGE is set; must precede app code
 require "minitest/autorun"
 require "rails"
 require "active_support/test_case"

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -11,5 +11,19 @@ module.exports = {
   moduleDirectories: [
     "node_modules",
     "app/javascript"
-  ]
+  ],
+  // Coverage is collected only when run with --coverage (see `npm run test:coverage`).
+  // NOTE: `.jsx` is intentionally excluded. Tests run as native ESM (`transform: {}`)
+  // and the bundle is built with esbuild, so no JSX-aware transform is registered;
+  // istanbul cannot parse JSX and would emit noisy parse errors. The `.jsx` React
+  // components are currently untested — including them would require a JSX-aware
+  // coverage transform. Tracked as a follow-up.
+  collectCoverageFrom: [
+    "app/javascript/**/*.js",
+    "engines/*/app/javascript/**/*.js",
+    "!**/__tests__/**",
+    "!**/node_modules/**"
+  ],
+  coverageDirectory: "coverage/js",
+  coverageReporters: ["text-summary", "text", "lcov"]
 }

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -6,7 +6,10 @@ module.exports = {
   testMatch: ["**/__tests__/**/*.test.[jt]s?(x)"],
   roots: [
     "<rootDir>/app/javascript",
-    "<rootDir>/engines"
+    "<rootDir>/engines",
+    // Served production JS outside app/javascript (PWA service worker). Needed so
+    // Jest's file crawler discovers it for coverage; no tests live here.
+    "<rootDir>/app/views/pwa"
   ],
   moduleDirectories: [
     "node_modules",
@@ -21,6 +24,11 @@ module.exports = {
   collectCoverageFrom: [
     "app/javascript/**/*.js",
     "engines/*/app/javascript/**/*.js",
+    // Served production JS that lives outside app/javascript: the PWA service
+    // worker is delivered via `rails/pwa#service_worker` (config/routes.rb) and
+    // registered at runtime by register_service_worker.js. No test imports it,
+    // so without this glob it is absent from the report instead of counted at 0%.
+    "app/views/pwa/**/*.js",
     "!**/__tests__/**",
     "!**/node_modules/**"
   ],

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "build": "node script/build.cjs",
     "test": "node --experimental-vm-modules ./node_modules/.bin/jest",
+    "test:coverage": "node --experimental-vm-modules ./node_modules/.bin/jest --coverage",
     "lint:css": "stylelint 'engines/**/stylesheets/**/*.css'",
     "lint:css:fix": "stylelint 'engines/**/stylesheets/**/*.css' --fix"
   },

--- a/test/support/coverage.rb
+++ b/test/support/coverage.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# SimpleCov bootstrap for the host app and all engines.
+#
+# Activated only when the COVERAGE environment variable is set, so ordinary test
+# runs — including the pre-push hook and CI — are completely unaffected. This
+# file must be required BEFORE any application code is loaded (i.e. before
+# config/environment) so SimpleCov can instrument every file as it is loaded.
+#
+# The whole suite (host app + all engines) runs in a single `bin/rails test`
+# process via `rake test`, so one SimpleCov run aggregates everything. Minitest
+# parallelization forks worker processes; the parallelize_setup/teardown hooks in
+# the test helpers give each worker a distinct command name and flush its result,
+# which the primary process then merges into the final report.
+return unless ENV["COVERAGE"]
+
+require "simplecov"
+require "simplecov-lcov"
+
+SimpleCov::Formatter::LcovFormatter.config.report_with_single_file = true
+SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new(
+  [
+    SimpleCov::Formatter::HTMLFormatter,
+    SimpleCov::Formatter::LcovFormatter
+  ]
+)
+
+SimpleCov.start "rails" do
+  enable_coverage :branch
+  command_name "MiniTest"
+  # Keep partial results from forked workers mergeable across the whole run.
+  merge_timeout 3600
+
+  # Group each engine so per-engine coverage is visible alongside the host app.
+  Dir.glob(File.expand_path("../../../engines/*", __dir__)).each do |engine_path|
+    next unless File.directory?(engine_path)
+
+    engine = File.basename(engine_path)
+    add_group "engine: #{engine}", "engines/#{engine}/"
+  end
+
+  # Exclude test scaffolding, config, migrations, and generated/vendored code.
+  skip %r{/test/}
+  skip %r{/spec/}
+  skip %r{/config/}
+  skip %r{/db/}
+  skip %r{/vendor/}
+  skip %r{/bin/}
+  skip %r{/node_modules/}
+end

--- a/test/support/coverage.rb
+++ b/test/support/coverage.rb
@@ -31,12 +31,30 @@ SimpleCov.start "rails" do
   # Keep partial results from forked workers mergeable across the whole run.
   merge_timeout 3600
 
+  # The built-in "rails" profile only disk-discovers unloaded files under the
+  # host app via "{app,lib}/**/*.rb", so engine source that no test happens to
+  # load is absent from the report entirely (missing from both numerator and
+  # denominator) rather than counted as 0%. That inflates coverage for any engine
+  # with unexercised files, and — since test env sets eager_load =
+  # ENV["CI"].present? — makes local (unloaded) and CI (eager-loaded) numbers
+  # disagree. `cover` injects those unloaded engine files at 0% AND scopes the
+  # report to the host + engine source universe; host globs are listed so the
+  # host app isn't dropped once a `cover` matcher is set. (`track_files` would do
+  # the same discovery but is deprecated and emits a warning.)
+  #
+  # Match *.rake as well as *.rb: the profile counts loaded rake tasks (under
+  # {app,lib}/tasks and engines/*/lib/tasks), so a *.rb-only `cover` glob would
+  # silently drop them from the report — inflating coverage and making this
+  # baseline non-comparable to the pre-`cover` numbers. Keep the universe a pure
+  # superset: add unloaded engine source, drop nothing already counted.
+  cover "{app,lib}/**/*.{rb,rake}", "engines/*/{app,lib}/**/*.{rb,rake}"
+
   # Group each engine so per-engine coverage is visible alongside the host app.
   Dir.glob(File.expand_path("../../engines/*", __dir__)).each do |engine_path|
     next unless File.directory?(engine_path)
 
     engine = File.basename(engine_path)
-    add_group "engine: #{engine}", "engines/#{engine}/"
+    group "engine: #{engine}", "engines/#{engine}/"
   end
 
   # Exclude test scaffolding, config, migrations, and generated/vendored code.

--- a/test/support/coverage.rb
+++ b/test/support/coverage.rb
@@ -32,7 +32,7 @@ SimpleCov.start "rails" do
   merge_timeout 3600
 
   # Group each engine so per-engine coverage is visible alongside the host app.
-  Dir.glob(File.expand_path("../../../engines/*", __dir__)).each do |engine_path|
+  Dir.glob(File.expand_path("../../engines/*", __dir__)).each do |engine_path|
     next unless File.directory?(engine_path)
 
     engine = File.basename(engine_path)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,5 @@
 ENV["RAILS_ENV"] ||= "test"
+require_relative "support/coverage" # no-op unless COVERAGE is set; must precede app code
 require_relative "../config/environment"
 require "rails/test_help"
 require "minitest/mock"
@@ -20,6 +21,17 @@ module ActiveSupport
 
     # Run tests in parallel with specified workers
     parallelize(workers: :number_of_processors)
+
+    if ENV["COVERAGE"]
+      # Give each forked worker its own SimpleCov command name and flush its
+      # result so the primary process can merge them into one report.
+      parallelize_setup do |worker|
+        SimpleCov.command_name "#{SimpleCov.command_name}-#{worker}"
+      end
+      parallelize_teardown do |_worker|
+        SimpleCov.result
+      end
+    end
 
     # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
     fixtures :all


### PR DESCRIPTION
## Summary

Adds test coverage measurement for both the Ruby (Rails 8, 8 engines) and JavaScript (Jest) suites, and records the current baseline.

- **Ruby — SimpleCov** with `enable_coverage :branch`, gated behind `COVERAGE=1` so normal/CI runs are unaffected (`test/support/coverage.rb` is a no-op without the env var).
- Parallel-fork merge hooks wired into all entry-point test helpers so the `parallelize(workers:)` forks merge into one report (host + all 8 engines in a single `rake test:all` run).
- **JS — Jest** built-in `--coverage` (`npm run test:coverage`), lcov + html + text reporters.
- `coverage/` gitignored.

## Baseline (measured on this branch)

**Ruby — SimpleCov, host + 8 engines merged, one run** (2,728 tests, 0 failures):

| Metric | Coverage | Covered/Total |
|---|---|---|
| **Line** | **81.38%** | 14,712 / 18,079 |
| **Branch** | **61.42%** | 4,393 / 7,152 |

> Baseline refreshed after `457ad9e4`: the coverage universe now includes engine
> source that no test loads (counted at 0%), so the denominators grew by 9 files
> / 58 lines and the numbers dropped slightly. See the Codex P2 thread for detail.

Per-group line coverage:

| Group | Line % | Covered/Total |
|---|---|---|
| collavre_linear | 96.56% | 1011/1047 |
| collavre (core) | 87.83% | 10346/11780 |
| collavre_plan | 84.09% | 222/264 |
| collavre_openclaw | 77.09% | 939/1218 |
| collavre_completion_api | 76.13% | 118/155 |
| collavre_slack | 60.89% | 548/900 |
| collavre_github | 60.65% | 766/1263 |
| host app | 52.94% | 459/867 |
| collavre_notion | 51.79% | 303/585 |

**JS — Jest** (515 tests, 0 failures):

| Metric | Coverage |
|---|---|
| Lines | 22.22% (2,933/13,196) |
| Statements | 21.43% |
| Branches | 17.30% |
| Functions | 23.10% |

Note: 12 `.jsx` React components are excluded from the JS coverage glob — Jest's istanbul instrumentation can't parse JSX under the current native-ESM `transform: {}` config, and forcing it would risk destabilizing the passing 515-test suite. They are untested today (would report 0%); documented in the config comment.

## How to run

```bash
# Ruby
COVERAGE=1 bin/rails test:all   # → coverage/index.html
# JS
npm run test:coverage           # → coverage/ (lcov + html)
```

## Test plan

- [x] `COVERAGE=1 rake test:all` — 2,728 runs, 0 failures, merged report across host + 8 engines
- [x] `npm run test:coverage` — 49 suites / 515 tests, 0 failures
- [x] Default (non-coverage) test path unchanged — gated require is a no-op without `COVERAGE`
- [x] Rubocop clean on all touched Ruby files