### PR TITLE
refactor(collavre): extract autosave request lifecycle into CreativeSaveQueue

### DIFF
--- a/engines/collavre/app/javascript/modules/__tests__/creative_save_queue.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/creative_save_queue.test.js
@@ -1,0 +1,228 @@
+/**
+ * @jest-environment jsdom
+ */
+import { jest } from '@jest/globals';
+import { CreativeSaveQueue } from '../creative_save_queue';
+
+// A controllable timer harness so debounce behavior is deterministic without
+// wall-clock waits. Mirrors setTimeout/clearTimeout semantics closely enough
+// for the queue: fire() runs the most recently scheduled, uncleared callback.
+function fakeTimers() {
+  const scheduled = new Map();
+  let nextId = 1;
+  return {
+    setTimer: (fn, ms) => {
+      const id = nextId++;
+      scheduled.set(id, { fn, ms });
+      return id;
+    },
+    clearTimer: (id) => {
+      scheduled.delete(id);
+    },
+    fire: (id) => {
+      const entry = scheduled.get(id);
+      if (!entry) throw new Error(`timer ${id} not scheduled (cleared or never set)`);
+      scheduled.delete(id);
+      entry.fn();
+    },
+    pending: () => scheduled.size,
+    lastMs: () => [...scheduled.values()].map((e) => e.ms).pop(),
+  };
+}
+
+// A save request whose settlement we control from the test.
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('CreativeSaveQueue', () => {
+  describe('debounce (schedule / cancelTimer)', () => {
+    test('schedule arms a timer with the configured debounce', () => {
+      const timers = fakeTimers();
+      const q = new CreativeSaveQueue({ debounceMs: 5000, setTimer: timers.setTimer, clearTimer: timers.clearTimer });
+      const flush = jest.fn();
+
+      q.schedule(flush);
+
+      expect(timers.pending()).toBe(1);
+      expect(timers.lastMs()).toBe(5000);
+      expect(flush).not.toHaveBeenCalled();
+    });
+
+    test('flush runs when the timer fires', () => {
+      const timers = fakeTimers();
+      const q = new CreativeSaveQueue({ setTimer: timers.setTimer, clearTimer: timers.clearTimer });
+      const flush = jest.fn();
+
+      q.schedule(flush);
+      timers.fire(1);
+
+      expect(flush).toHaveBeenCalledTimes(1);
+      expect(timers.pending()).toBe(0);
+    });
+
+    test('re-scheduling cancels the previous timer so only the latest fires', () => {
+      const timers = fakeTimers();
+      const q = new CreativeSaveQueue({ setTimer: timers.setTimer, clearTimer: timers.clearTimer });
+      const first = jest.fn();
+      const second = jest.fn();
+
+      q.schedule(first);
+      q.schedule(second);
+
+      // Only one timer is live; the first was cleared.
+      expect(timers.pending()).toBe(1);
+      expect(() => timers.fire(1)).toThrow(); // first timer id was cleared
+      timers.fire(2);
+      expect(first).not.toHaveBeenCalled();
+      expect(second).toHaveBeenCalledTimes(1);
+    });
+
+    test('default timers (no injection) schedule against the real timer API without illegal-invocation', () => {
+      jest.useFakeTimers();
+      try {
+        // No setTimer/clearTimer injected — exercises the window-bound wrappers.
+        // A regression that called setTimeout as a method of the queue threw
+        // "Illegal invocation" in browsers; this guards the default path.
+        const q = new CreativeSaveQueue({ debounceMs: 5000 });
+        const flush = jest.fn();
+
+        expect(() => q.schedule(flush)).not.toThrow();
+        expect(flush).not.toHaveBeenCalled();
+        jest.advanceTimersByTime(5000);
+        expect(flush).toHaveBeenCalledTimes(1);
+
+        // cancelTimer against the real timer API must also not throw.
+        q.schedule(flush);
+        expect(() => q.cancelTimer()).not.toThrow();
+        jest.advanceTimersByTime(5000);
+        expect(flush).toHaveBeenCalledTimes(1); // canceled — no second flush
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    test('cancelTimer prevents a scheduled flush and is idempotent', () => {
+      const timers = fakeTimers();
+      const q = new CreativeSaveQueue({ setTimer: timers.setTimer, clearTimer: timers.clearTimer });
+      const flush = jest.fn();
+
+      q.schedule(flush);
+      q.cancelTimer();
+      q.cancelTimer(); // no throw on second call
+
+      expect(timers.pending()).toBe(0);
+    });
+  });
+
+  describe('single-flight (runExclusive)', () => {
+    test('runs execute and tracks saving state across the request lifecycle', async () => {
+      const q = new CreativeSaveQueue();
+      const d = deferred();
+      const execute = jest.fn(() => d.promise);
+
+      expect(q.saving).toBe(false);
+      const p = q.runExclusive(execute);
+
+      expect(execute).toHaveBeenCalledTimes(1);
+      expect(q.saving).toBe(true);
+      expect(q.promise).toBe(p);
+
+      d.resolve('ok');
+      await p;
+      expect(q.saving).toBe(false);
+    });
+
+    test('coalesces: a second call while saving returns the in-flight promise without re-running execute', async () => {
+      const q = new CreativeSaveQueue();
+      const d = deferred();
+      const execute = jest.fn(() => d.promise);
+      const second = jest.fn(() => deferred().promise);
+
+      const p1 = q.runExclusive(execute);
+      const p2 = q.runExclusive(second);
+
+      expect(p2).toBe(p1); // same in-flight promise
+      expect(second).not.toHaveBeenCalled(); // no double save
+      expect(execute).toHaveBeenCalledTimes(1);
+
+      d.resolve();
+      await p1;
+    });
+
+    test('a fresh save runs after the previous one settles', async () => {
+      const q = new CreativeSaveQueue();
+      const d1 = deferred();
+      const execute1 = jest.fn(() => d1.promise);
+      const d2 = deferred();
+      const execute2 = jest.fn(() => d2.promise);
+
+      const p1 = q.runExclusive(execute1);
+      d1.resolve();
+      await p1;
+      expect(q.saving).toBe(false);
+
+      q.runExclusive(execute2);
+      expect(execute2).toHaveBeenCalledTimes(1);
+      expect(q.saving).toBe(true);
+      d2.resolve();
+    });
+
+    test('execute returning null (nothing to persist) does not enter the saving state', async () => {
+      const q = new CreativeSaveQueue();
+      const execute = jest.fn(() => null);
+
+      const p = q.runExclusive(execute);
+
+      expect(execute).toHaveBeenCalledTimes(1);
+      expect(q.saving).toBe(false);
+      await expect(p).resolves.toBeUndefined();
+    });
+
+    test('runExclusive cancels a pending debounce timer before saving', () => {
+      const timers = fakeTimers();
+      const q = new CreativeSaveQueue({ setTimer: timers.setTimer, clearTimer: timers.clearTimer });
+      const flush = jest.fn();
+
+      q.schedule(flush);
+      expect(timers.pending()).toBe(1);
+
+      q.runExclusive(() => deferred().promise);
+
+      expect(timers.pending()).toBe(0); // debounce canceled — no redundant trailing save
+      expect(flush).not.toHaveBeenCalled();
+    });
+
+    test('clears saving even when the request rejects', async () => {
+      const q = new CreativeSaveQueue();
+      const d = deferred();
+      const execute = jest.fn(() => d.promise);
+
+      const p = q.runExclusive(execute);
+      expect(q.saving).toBe(true);
+
+      d.reject(new Error('boom'));
+      await expect(p).rejects.toThrow('boom');
+      expect(q.saving).toBe(false);
+    });
+
+    test('after a rejection a subsequent save can run', async () => {
+      const q = new CreativeSaveQueue();
+      const d1 = deferred();
+      const p1 = q.runExclusive(() => d1.promise);
+      d1.reject(new Error('fail'));
+      await expect(p1).rejects.toThrow();
+
+      const execute2 = jest.fn(() => deferred().promise);
+      q.runExclusive(execute2);
+      expect(execute2).toHaveBeenCalledTimes(1);
+      expect(q.saving).toBe(true);
+    });
+  });
+});

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -8,6 +8,7 @@ import { isProgressComplete, progressBaselineValueFrom, progressValueChangedFrom
 import { renderMarkdown } from '../lib/utils/markdown'
 import { reconcileMarkdownSource } from './markdown_source_reconcile'
 import { isHtmlEmpty } from './html_content_empty'
+import { CreativeSaveQueue } from './creative_save_queue'
 import { confirmDialog, alertDialog } from '../lib/utils/dialog'
 import { serverErrorMessage } from '../lib/api/api_error'
 import yaml from 'js-yaml'
@@ -179,10 +180,12 @@ export function initializeCreativeRowEditor() {
 
     let currentTree = null;
     let currentRowElement = null;
-    let saveTimer = null;
+    // Owns the autosave request lifecycle: the debounce timer and the
+    // single-flight guard around the in-flight request. `pendingSave` /
+    // `isDirty` remain the editor's dirty-tracking flags (what changed), while
+    // the queue governs when the request runs. See creative_save_queue.js.
+    const saveQueue = new CreativeSaveQueue();
     let pendingSave = false;
-    let saving = false;
-    let savePromise = Promise.resolve();
     let uploadsPending = false;
     let uploadCompletionPromise = null;
     let resolveUploadCompletion = null;
@@ -1028,11 +1031,13 @@ export function initializeCreativeRowEditor() {
       // scheduleSave(), so without this an attachment upload still in flight would
       // let the toolbar keep a stale "saved" label for the whole upload window.
       // Gated on the editor still being bound to this row (mirrors applySaveStatus).
-      if (tree === currentTree && (pendingSave || saving || isDirty)) setSaveStatus('pending');
-      return waitForUploads().then(function () {
-        if (saving) return savePromise;
-        clearTimeout(saveTimer);
-
+      if (tree === currentTree && (pendingSave || saveQueue.saving || isDirty)) setSaveStatus('pending');
+      // Build and run the persist request under the queue's single-flight
+      // guard: runExclusive cancels any pending debounce, invokes performSave,
+      // and (only when it returns a request for non-empty content) holds the
+      // in-flight state until that request settles. Returning null keeps the
+      // queue idle without ever flipping the in-flight flag.
+      function performSave() {
         // Sync markdown form fields before saving
         if (markdownMode) syncMarkdownToForm();
 
@@ -1043,13 +1048,12 @@ export function initializeCreativeRowEditor() {
           pendingSave = false;
           // Nothing to persist — don't strand the "pending" label set above.
           if (tree === currentTree) setSaveStatus('');
-          return Promise.resolve();
+          return null;
         }
 
         const method = methodInput.value === 'patch' ? 'PATCH' : 'POST';
         pendingSave = false;
-        if (!form.action) return Promise.resolve();
-        saving = true;
+        if (!form.action) return null;
         // Only reflect this save's outcome while the editor is still bound to the
         // creative it started on. If the user navigates to another row mid-flight
         // (move() reattaches the shared #inline-save-status span to the new row),
@@ -1075,7 +1079,7 @@ export function initializeCreativeRowEditor() {
           if (progressHiddenInput) progressHiddenInput.disabled = true;
         }
 
-        savePromise = creativesApi.save(form.action, method, form).then(function (r) {
+        return creativesApi.save(form.action, method, form).then(function (r) {
           if (!r.ok) {
             applySaveStatus('error');
             return r;
@@ -1184,13 +1188,14 @@ export function initializeCreativeRowEditor() {
           applySaveStatus('error');
           throw err;
         }).finally(function () {
-          saving = false;
           if (!shouldPersistProgress) {
             if (progressInput) progressInput.disabled = progressInputsDisabled;
             if (progressHiddenInput) progressHiddenInput.disabled = hiddenProgressDisabled;
           }
         });
-        return savePromise;
+      }
+      return waitForUploads().then(function () {
+        return saveQueue.runExclusive(performSave);
       });
     }
 
@@ -1217,7 +1222,7 @@ export function initializeCreativeRowEditor() {
 
       const finalizeHide = function () {
         template.style.display = 'none';
-        const p = (pendingSave || saving) ? saveForm(tree, parentId) : Promise.resolve();
+        const p = (pendingSave || saveQueue.saving) ? saveForm(tree, parentId) : Promise.resolve();
         return p.then(() => {
           if (wasNew && !form.dataset.creativeId) {
             removeTreeElement(tree);
@@ -1274,7 +1279,7 @@ export function initializeCreativeRowEditor() {
     }
 
     function beforeNewOrMove(wasNew, prev, prevParent) {
-      const needsSave = pendingSave || wasNew || saving;
+      const needsSave = pendingSave || wasNew || saveQueue.saving;
       const p = needsSave ? saveForm(prev, prevParent) : Promise.resolve();
       return p.then(() => {
         if (wasNew && !form.dataset.creativeId) {
@@ -1477,7 +1482,7 @@ export function initializeCreativeRowEditor() {
       }
       isDirty = false;
       pendingSave = false;
-      clearTimeout(saveTimer);
+      saveQueue.cancelTimer();
     }
 
     async function move(delta) {
@@ -1974,8 +1979,7 @@ export function initializeCreativeRowEditor() {
       // up/down, reorder) schedule a save without setting isDirty, and must not
       // keep showing the previous "saved" label.
       setSaveStatus('pending');
-      clearTimeout(saveTimer);
-      saveTimer = setTimeout(saveForm, 5000);
+      saveQueue.schedule(function () { saveForm(); });
     }
 
     function onLexicalChange(payload) {
@@ -2092,7 +2096,7 @@ export function initializeCreativeRowEditor() {
         // Save immediately on checkbox change to prevent losing the last toggle
         // when the user navigates away before the debounce timer fires.
         pendingSave = true;
-        clearTimeout(saveTimer);
+        saveQueue.cancelTimer();
         saveForm();
       });
     }

--- a/engines/collavre/app/javascript/modules/creative_save_queue.js
+++ b/engines/collavre/app/javascript/modules/creative_save_queue.js
@@ -1,0 +1,95 @@
+// The autosave request lifecycle extracted from creative_row_editor.js.
+//
+// The inline editor persists edits on a debounce and also saves directly on
+// structural changes (reorder, indent, progress toggle). Two invariants kept
+// getting re-broken across dozens of fix commits ("Prevent double saves...",
+// "Skip in-flight request during queue deduplication"):
+//
+//   1. Debounce: rapid edits collapse into a single trailing save; re-arming
+//      the timer must cancel the previous one.
+//   2. Single-flight: at most one save request is in flight at a time. A save
+//      requested while one is running must NOT start a second request — it
+//      returns the in-flight promise. (Dirty-tracking in the editor re-arms and
+//      a later schedule/flush persists the newer buffer.)
+//
+// This class owns exactly those two concerns — the debounce timer and the
+// single-flight guard around the request promise. It deliberately does NOT own
+// the editor's dirty flags (isDirty / pendingSave), which track *what* changed;
+// this owns *when the request runs*. Behavior is identical to the original
+// inline `saveTimer` / `saving` / `savePromise` logic; the timer functions are
+// injectable so the state machine is testable without real timers.
+export class CreativeSaveQueue {
+  constructor({ debounceMs = 5000, setTimer, clearTimer } = {}) {
+    this._debounceMs = debounceMs;
+    // Wrap the timer functions so they are invoked as free functions. Passing
+    // `setTimeout`/`clearTimeout` directly and calling them as `this._setTimer(...)`
+    // would invoke them with `this === queue`, which throws "Illegal invocation"
+    // in real browsers (jsdom does not, which is why unit tests can't catch it).
+    // Tests inject their own timer fns; production uses these window-bound wrappers.
+    this._setTimer = setTimer || ((fn, ms) => setTimeout(fn, ms));
+    this._clearTimer = clearTimer || ((id) => clearTimeout(id));
+    this._timer = null;
+    this._saving = false;
+    this._promise = Promise.resolve();
+  }
+
+  /** True while a save request is in flight. */
+  get saving() {
+    return this._saving;
+  }
+
+  /** The most recent (possibly in-flight) save promise. */
+  get promise() {
+    return this._promise;
+  }
+
+  /**
+   * Arm the debounce timer to invoke `flush` after `debounceMs`. Re-arming
+   * cancels any previously scheduled flush, so only the latest edit's timer
+   * fires (trailing debounce).
+   * @param {() => void} flush
+   */
+  schedule(flush) {
+    this.cancelTimer();
+    this._timer = this._setTimer(() => {
+      this._timer = null;
+      flush();
+    }, this._debounceMs);
+  }
+
+  /** Cancel a pending debounce timer, if any. Idempotent. */
+  cancelTimer() {
+    if (this._timer !== null) {
+      this._clearTimer(this._timer);
+      this._timer = null;
+    }
+  }
+
+  /**
+   * Run `execute` under the single-flight guard.
+   *
+   * - If a save is already in flight, returns the in-flight promise WITHOUT
+   *   invoking `execute` (the coalescing invariant).
+   * - Otherwise cancels any pending debounce, then invokes `execute`. `execute`
+   *   returns the save request promise, or a nullish value to signal "nothing
+   *   to persist" (e.g. empty content) — in which case no in-flight state is
+   *   entered and a resolved promise is returned. Invoking `execute` before
+   *   committing `saving` preserves the original ordering, where an empty-save
+   *   short-circuit never flips the in-flight flag.
+   *
+   * `saving` is cleared when the returned promise settles (success or failure).
+   * @param {() => (Promise|null|undefined)} execute
+   * @returns {Promise}
+   */
+  runExclusive(execute) {
+    if (this._saving) return this._promise;
+    this.cancelTimer();
+    const request = execute();
+    if (request == null) return Promise.resolve();
+    this._saving = true;
+    this._promise = Promise.resolve(request).finally(() => {
+      this._saving = false;
+    });
+    return this._promise;
+  }
+}


### PR DESCRIPTION
## What

Extracts the autosave **request lifecycle** out of `creative_row_editor.js` (a 2,426-line single-closure god file) into a small, tested `CreativeSaveQueue` module.

This is the first step of the rot-reduction plan's item #1. The rot analysis flagged this file as the one true god-file / rot core: 48 fix commits, ~43% of them the *same* bug class — autosave queue races and lost state — and the fix ratio did not drop even after the monolith→engine migration, proving it's a design defect, not a placement problem.

## Why this slice

The single highest-churn defect class is the autosave state machine. The debounce timer and the single-flight guard were spread across ~12 sites as bare `saveTimer` / `saving` / `savePromise` reads and writes. Commit titles tell the story: *"Prevent double saves in up/down button handlers"*, *"Prevent double saves during arrow navigation"*, *"Skip in-flight request during queue deduplication"*. Two invariants kept getting re-broken:

1. **Debounce** — rapid edits collapse into one trailing save; re-arming cancels the previous timer.
2. **Single-flight** — at most one request in flight; a save requested while one runs returns the in-flight promise instead of starting a second.

`CreativeSaveQueue` now owns exactly those two concerns. It deliberately does **not** own the editor's dirty flags (`isDirty` / `pendingSave`) — those track *what* changed; the queue governs *when the request runs*.

## Behavior-preserving

`saveForm`'s control flow is unchanged. The save body moved into a `performSave` executor run under `saveQueue.runExclusive`; the empty-content short-circuit returns `null` so the in-flight flag is never flipped, matching the original ordering exactly. Every `saveTimer` / `saving` / `savePromise` site was mapped 1:1.

## Verification

- **12 new unit tests** — the first test coverage on this file — covering debounce reset, single-flight coalescing (no double-save), empty-skip, and rejection cleanup.
- **Full JS suite green**: 532 tests / 51 suites.
- **Real-browser smoke** (preview server, Lexical inline editor): new-creative debounce save (`POST /creatives → 200`, status `pending → Saved`), and debounce coalescing (two rapid edits → exactly one save).

> During the browser smoke I caught a regression that all 532 unit tests missed: passing `setTimeout` directly and calling it as `this._setTimer(...)` throws *"Illegal invocation"* in a real browser (jsdom doesn't enforce it). Fixed with window-bound timer wrappers and added a default-timer-path test. This is exactly why the editor was smoke-tested in a browser, not just Jest.

## Scope / follow-ups (deliberately deferred)

- parentId-loss consolidation (the other half of the rot core) — separate PR.
- Broader decomposition of the 2,426-line closure — incremental follow-ups building on this tested beachhead.