### PR TITLE
ci: report test coverage on every CI run (job summary + Codecov)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,21 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run Jest tests
-        run: npm test
+      - name: Run Jest tests with coverage
+        run: npm run test:coverage
+
+      - name: JavaScript coverage summary
+        if: ${{ !cancelled() }}
+        run: node bin/coverage_summary_js.mjs coverage/js/coverage-summary.json >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload JavaScript coverage to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./coverage/js/lcov.info
+          flags: javascript
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
 
       - name: Scan for security vulnerabilities in JavaScript dependencies
         run: npm audit --production
@@ -139,8 +152,25 @@ jobs:
       - name: Run tests
         env:
           RAILS_ENV: test
+          # COVERAGE activates the SimpleCov bootstrap (test/support/coverage.rb),
+          # which is a no-op otherwise. Both `rake test` and `rake test:system`
+          # run in separate processes and merge into one report via merge_timeout.
+          COVERAGE: "1"
           # REDIS_URL: redis://localhost:6379/0
         run: bin/rails db:test:prepare && bundle exec rake test && bundle exec rake test:system
+
+      - name: Ruby coverage summary
+        if: ${{ !cancelled() }}
+        run: ruby bin/coverage_summary coverage/lcov.info >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload Ruby coverage to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./coverage/lcov.info
+          flags: ruby
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
 
       - name: Keep screenshots from failed system tests
         uses: actions/upload-artifact@v7

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Collavre
 
+[![CI](https://github.com/sh1nj1/plan42/actions/workflows/ci.yml/badge.svg)](https://github.com/sh1nj1/plan42/actions/workflows/ci.yml) [![codecov](https://codecov.io/gh/sh1nj1/plan42/graph/badge.svg)](https://codecov.io/gh/sh1nj1/plan42)
+
 **One living tree for docs, tasks, discussions, and AI agent context.**
 
 Today those are three copies you keep in sync by hand, plus an agent wired to all of them

--- a/bin/coverage_summary
+++ b/bin/coverage_summary
@@ -1,0 +1,79 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Render a GitHub-flavoured Markdown coverage summary from a SimpleCov lcov file.
+#
+# Groups records into the host app and each Rails engine (engines/<name>/...),
+# summing line (LF/LH) and branch (BRF/BRH) counters, and prints an overall row
+# plus a per-group table. Written for GitHub Actions job summaries:
+#
+#   bin/coverage_summary coverage/lcov.info >> "$GITHUB_STEP_SUMMARY"
+#
+# Exits 0 with a friendly note if the lcov file is missing so a coverage-less
+# run never fails the job on the summary step alone.
+
+lcov_path = ARGV[0] || "coverage/lcov.info"
+
+unless File.file?(lcov_path)
+  puts "## 🧪 Ruby coverage (SimpleCov)\n\n_No lcov report found at `#{lcov_path}`._"
+  exit 0
+end
+
+# group_key => { lf:, lh:, brf:, brh: }
+groups = Hash.new { |h, k| h[k] = { lf: 0, lh: 0, brf: 0, brh: 0 } }
+
+def group_for(path)
+  path = path.sub(%r{\A\./}, "")
+  if (m = path.match(%r{\Aengines/([^/]+)/}))
+    "engine: #{m[1]}"
+  else
+    "host app"
+  end
+end
+
+current = nil
+File.foreach(lcov_path) do |line|
+  case line
+  when /\ASF:(.+)/
+    current = group_for(Regexp.last_match(1).strip)
+  when /\ALF:(\d+)/ then groups[current][:lf]  += Regexp.last_match(1).to_i if current
+  when /\ALH:(\d+)/ then groups[current][:lh]  += Regexp.last_match(1).to_i if current
+  when /\ABRF:(\d+)/ then groups[current][:brf] += Regexp.last_match(1).to_i if current
+  when /\ABRH:(\d+)/ then groups[current][:brh] += Regexp.last_match(1).to_i if current
+  when /\Aend_of_record/ then current = nil
+  end
+end
+
+if groups.empty?
+  puts "## 🧪 Ruby coverage (SimpleCov)\n\n_lcov report at `#{lcov_path}` had no records._"
+  exit 0
+end
+
+def pct(hit, found)
+  return "—" if found.zero?
+
+  format("%.2f%%", (hit.to_f / found) * 100)
+end
+
+total = groups.values.each_with_object({ lf: 0, lh: 0, brf: 0, brh: 0 }) do |g, acc|
+  acc[:lf] += g[:lf]; acc[:lh] += g[:lh]; acc[:brf] += g[:brf]; acc[:brh] += g[:brh]
+end
+
+out = []
+out << "## 🧪 Ruby coverage (SimpleCov)"
+out << ""
+out << "**Line: #{pct(total[:lh], total[:lf])}** (#{total[:lh]}/#{total[:lf]}) · " \
+       "**Branch: #{pct(total[:brh], total[:brf])}** (#{total[:brh]}/#{total[:brf]})"
+out << ""
+out << "| Group | Line | Branch |"
+out << "|---|---|---|"
+
+# Host first, then engines alphabetically.
+ordered = groups.keys.sort_by { |k| [ k == "host app" ? 0 : 1, k ] }
+ordered.each do |key|
+  g = groups[key]
+  out << "| #{key} | #{pct(g[:lh], g[:lf])} (#{g[:lh]}/#{g[:lf]}) | " \
+         "#{pct(g[:brh], g[:brf])} (#{g[:brh]}/#{g[:brf]}) |"
+end
+
+puts out.join("\n")

--- a/bin/coverage_summary_js.mjs
+++ b/bin/coverage_summary_js.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+// Render a GitHub-flavoured Markdown coverage summary from Jest's json-summary
+// report. Written for GitHub Actions job summaries:
+//
+//   node bin/coverage_summary_js.mjs coverage/js/coverage-summary.json >> "$GITHUB_STEP_SUMMARY"
+//
+// Exits 0 with a friendly note if the report is missing so a coverage-less run
+// never fails the job on the summary step alone.
+import { readFileSync } from "node:fs";
+
+const path = process.argv[2] || "coverage/js/coverage-summary.json";
+
+const header = "## 🟨 JavaScript coverage (Jest)";
+
+let data;
+try {
+  data = JSON.parse(readFileSync(path, "utf8"));
+} catch {
+  console.log(`${header}\n\n_No coverage summary found at \`${path}\`._`);
+  process.exit(0);
+}
+
+const t = data.total;
+if (!t) {
+  console.log(`${header}\n\n_Coverage summary at \`${path}\` had no totals._`);
+  process.exit(0);
+}
+
+const row = (label, m) =>
+  `| ${label} | ${m.pct.toFixed(2)}% | ${m.covered}/${m.total} |`;
+
+const lines = [
+  header,
+  "",
+  `**Line: ${t.lines.pct.toFixed(2)}%** (${t.lines.covered}/${t.lines.total})`,
+  "",
+  "| Metric | Coverage | Covered/Total |",
+  "|---|---|---|",
+  row("Lines", t.lines),
+  row("Statements", t.statements),
+  row("Branches", t.branches),
+  row("Functions", t.functions),
+  "",
+  "_`.jsx` React components are excluded (no JSX-aware coverage transform is registered — see jest.config.cjs)._",
+];
+
+console.log(lines.join("\n"));

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,36 @@
+# Codecov configuration.
+#
+# Coverage is uploaded from CI under two flags:
+#   - ruby       (SimpleCov lcov: host app + all engines)
+#   - javascript (Jest lcov: app/javascript + engine JS + served PWA JS)
+#
+# Status checks are informational (never block a PR) — coverage here is for
+# visibility, not a hard gate. carryforward keeps a flag's last value when its
+# job doesn't upload on a given run (e.g. a JS-only PR).
+
+codecov:
+  require_ci_to_pass: true
+
+coverage:
+  precision: 2
+  round: down
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        informational: true
+
+flags:
+  ruby:
+    carryforward: true
+  javascript:
+    carryforward: true
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -33,5 +33,7 @@ module.exports = {
     "!**/node_modules/**"
   ],
   coverageDirectory: "coverage/js",
-  coverageReporters: ["text-summary", "text", "lcov"]
+  // lcov -> Codecov upload; json-summary -> machine-readable totals for the CI
+  // job summary; text-summary -> human-readable console output.
+  coverageReporters: ["text-summary", "text", "lcov", "json-summary"]
 }

--- a/test/support/coverage.rb
+++ b/test/support/coverage.rb
@@ -17,7 +17,12 @@ return unless ENV["COVERAGE"]
 require "simplecov"
 require "simplecov-lcov"
 
+# Emit a single lcov file at a deterministic path (coverage/lcov.info) so CI can
+# upload it and generate the summary regardless of the checkout directory name.
+# The default lcov file name is derived from the repo directory basename, which
+# differs between the main checkout and git worktrees.
 SimpleCov::Formatter::LcovFormatter.config.report_with_single_file = true
+SimpleCov::Formatter::LcovFormatter.config.single_report_path = File.join(SimpleCov.coverage_path, "lcov.info")
 SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new(
   [
     SimpleCov::Formatter::HTMLFormatter,

--- a/test/support/coverage.rb
+++ b/test/support/coverage.rb
@@ -7,11 +7,18 @@
 # file must be required BEFORE any application code is loaded (i.e. before
 # config/environment) so SimpleCov can instrument every file as it is loaded.
 #
-# The whole suite (host app + all engines) runs in a single `bin/rails test`
-# process via `rake test`, so one SimpleCov run aggregates everything. Minitest
-# parallelization forks worker processes; the parallelize_setup/teardown hooks in
-# the test helpers give each worker a distinct command name and flush its result,
-# which the primary process then merges into the final report.
+# CI runs the unit/integration suite (`rake test`) and the system suite
+# (`rake test:system`) as separate, sequential `bin/rails test` subprocesses
+# (and `test:system` shells out once per engine), each producing its own
+# SimpleCov result. They accumulate into one report via the shared
+# `coverage/.resultset.json` (merge_timeout keeps every slice mergeable).
+# Minitest parallelization forks worker processes; the parallelize_setup/teardown
+# hooks in the test helpers give each worker a command name and flush its result.
+# Because those names derive from the base below, the base MUST be unique per
+# process (see command_name) — otherwise the second invocation's workers land on
+# the same resultset keys as the first and overwrite them (sequential runs
+# overwrite; only concurrent siblings combine), silently dropping the earlier
+# suite from the merged lcov.
 return unless ENV["COVERAGE"]
 
 require "simplecov"
@@ -32,7 +39,14 @@ SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new(
 
 SimpleCov.start "rails" do
   enable_coverage :branch
-  command_name "MiniTest"
+  # Unique per process: `rake test` and `rake test:system` run as separate
+  # sequential subprocesses that share coverage/.resultset.json. The worker hooks
+  # append "-#{worker}" to this base, so a fixed base ("MiniTest") makes both
+  # invocations write the same "MiniTest-<worker>" keys — the later run overwrites
+  # the earlier suite's slice. Process.pid keeps every subprocess's keys disjoint
+  # so all suites accumulate. (CI starts from a clean checkout; for repeated local
+  # runs clear coverage/ first so stale prior-PID slices aren't merged in.)
+  command_name "MiniTest-#{Process.pid}"
   # Keep partial results from forked workers mergeable across the whole run.
   merge_timeout 3600
 


### PR DESCRIPTION
## What

Wire the coverage tooling merged in #1385 into CI so **test coverage is reported on every run and on every merge to `main`**, and is easy to check at a glance (**A**: GitHub Actions job summary) plus tracked over time with a README badge and PR deltas (**B1**: Codecov).

## How

**GitHub Actions job summary (A)** — no external dependency, renders on the workflow run page:
- `test` job now runs with `COVERAGE=1`, so the existing SimpleCov bootstrap (`test/support/coverage.rb`) instruments the host app + all 8 engines. `rake test` and `rake test:system` run in separate processes and merge into one report. A step renders an **overall + per-engine** Markdown table into `$GITHUB_STEP_SUMMARY`.
- `test_js` job now runs `npm run test:coverage`; a step renders a JS coverage table (lines/statements/branches/functions).

**Codecov (B1)** — README badge + PR coverage deltas:
- Both jobs upload lcov to Codecov under flags `ruby` and `javascript`.
- `codecov.yml`: status checks are **informational (non-blocking)** — coverage is for visibility, not a hard merge gate — with per-flag `carryforward`.
- README gains CI + Codecov badges.

**Supporting changes:**
- Pin the SimpleCov lcov output to a deterministic `coverage/lcov.info` (the default filename tracks the checkout dir basename, which differs between the main checkout and worktrees).
- Add Jest `json-summary` reporter for machine-readable totals.
- `bin/coverage_summary` (Ruby, parses lcov) and `bin/coverage_summary_js.mjs` (Node, parses json-summary) render the job summaries. Both no-op gracefully if their report is absent.

## Trigger scope

Coverage runs on **all CI triggers** (PRs *and* pushes to `main`), not only merges. The `main` runs feed the README badge; the PR runs give Codecov per-PR deltas. If you'd rather limit instrumentation overhead to `main` only, that's a one-line toggle on the `COVERAGE` env — happy to change it.

## ⚠️ Maintainer action required for Codecov

Codecov uploads need a repo secret and repo activation:
1. Activate `sh1nj1/plan42` at https://codecov.io (GitHub login).
2. Add the `CODECOV_TOKEN` repo secret (Settings → Secrets → Actions).

Until then, uploads are **best-effort** (`fail_ci_if_error: false`), so CI stays green and the **job-summary tables (A) work immediately** with no setup. The Codecov badge turns live once the repo is activated.

## Verification

Ran locally against the merged coverage config:
- Ruby: `COVERAGE=1 bin/rails test ...` → `coverage/lcov.info` written at the pinned path; `bin/coverage_summary` renders the overall + per-engine table.
- JS: `npm run test:coverage` → `coverage/js/{lcov.info,coverage-summary.json}`; `bin/coverage_summary_js.mjs` renders the table.
- YAML (`ci.yml`, `codecov.yml`) parses; `rubocop` clean; `node --check` clean.
