### PR TITLE
refactor(collavre): extend PermissionFilter with min_permission: and ranks_for (rot ② PR 1)

### DIFF
--- a/engines/collavre/app/services/collavre/creatives/permission_filter.rb
+++ b/engines/collavre/app/services/collavre/creatives/permission_filter.rb
@@ -5,27 +5,37 @@ module Creatives
   # has_children presence check can apply the exact same permission posture as
   # the browse endpoint (children_with_permission) without re-deriving it.
   #
-  # no_access wins over a public share, so user-level denials are subtracted
-  # from the public set. Owned creatives are always readable.
+  # A user-specific cache entry is authoritative over a public share: it grants
+  # only when its own rank meets the requested threshold and otherwise suppresses
+  # the public share (so a no_access — or any below-threshold user entry — wins
+  # over a more permissive public share). Owned creatives are always readable.
   class PermissionFilter
+    # An owner always resolves to admin, the top rank, so it satisfies any
+    # min_permission threshold. Matches TreeBuilder::OWNER_RANK.
+    OWNER_RANK = CreativeShare.permissions[:admin]
+
     def initialize(user:)
       @user = user
     end
 
-    # Returns the subset of `ids` the user may read, as an Array.
+    # Returns the subset of `ids` the user may access at `min_permission` or
+    # higher, as an Array. `min_permission:` defaults to `:read`, so the no-arg
+    # form is unchanged; pass `:write` (etc.) to share the one batch filter with
+    # write-posture sites instead of re-deriving the rank comparison.
     #
     # Each id is resolved to its effective (origin) creative via the SAME
     # logic PermissionChecker uses, so a linked creative yields identical
     # permission whether checked one-by-one or filtered in a batch.
-    def readable_ids(ids)
+    def readable_ids(ids, min_permission: :read)
       # Normalize to Integer so the final select (and owned-shell lookup) compare
       # against pluck-derived integer ids rather than string inputs; keeps the
       # canonical batch filter robust to param-sourced ids. Non-numeric ids drop.
       ids = ids.to_a.filter_map { |id| Integer(id, exception: false) }.uniq
       return [] if ids.empty?
 
+      min_rank = rank_for(min_permission)
       effective_by_id = EffectiveCreativeResolution.effective_creative_ids(ids)
-      readable_effective = readable_effective_ids(effective_by_id.values.uniq)
+      readable_effective = readable_effective_ids(effective_by_id.values.uniq, min_rank)
 
       # A linked creative borrows its ORIGIN's permission, but the shell row
       # itself is private to the user who created it (Linkable creates exactly
@@ -44,9 +54,61 @@ module Creatives
       end
     end
 
+    # Returns { input_id => effective_permission_rank } for the ids the user has
+    # ANY relationship to, mirroring single-item PermissionChecker: owner wins
+    # (admin rank), else the user's own cache entry (INCLUDING a no_access deny,
+    # which is rank 0 and beats a public share), else the public entry. Ids with
+    # no owner/entry/public share are ABSENT from the hash (distinct from rank 0).
+    #
+    # The rank is the raw CreativeShare.permissions integer, so callers compare
+    # `rank >= rank_for(:write)` themselves. Unlike readable_ids this does NOT
+    # apply the shell-ownership anti-leak gate — it is for tree_builder /
+    # slide_viewable which rank creatives already inside the viewer's own tree,
+    # exactly as PermissionChecker#allowed? would resolve them one by one.
+    def ranks_for(ids)
+      ids = ids.to_a.filter_map { |id| Integer(id, exception: false) }.uniq
+      return {} if ids.empty?
+
+      effective_by_id = EffectiveCreativeResolution.effective_creative_ids(ids)
+      effective_ids = effective_by_id.values.uniq
+
+      owner_by_effective = Creative.where(id: effective_ids).pluck(:id, :user_id).to_h
+
+      user_entries = if user
+        CreativeSharesCache.where(creative_id: effective_ids, user_id: user.id)
+          .pluck(:creative_id, :permission).to_h
+      else
+        {}
+      end
+
+      needs_public = effective_ids - user_entries.keys
+      public_entries = if needs_public.any?
+        CreativeSharesCache.where(creative_id: needs_public, user_id: nil)
+          .pluck(:creative_id, :permission).to_h
+      else
+        {}
+      end
+
+      ranks = {}
+      ids.each do |id|
+        effective = effective_by_id[id]
+        if user && owner_by_effective[effective] == user.id
+          ranks[id] = OWNER_RANK
+        else
+          permission = user_entries[effective] || public_entries[effective]
+          ranks[id] = CreativeShare.permissions[permission] if permission
+        end
+      end
+      ranks
+    end
+
     private
 
     attr_reader :user
+
+    def rank_for(permission)
+      CreativeShare.permissions.fetch(permission.to_s)
+    end
 
     # The subset of shell ids (effective != self) that the viewer owns. Shells
     # have no cache/share rows of their own, so ownership of the shell row is
@@ -60,32 +122,34 @@ module Creatives
       Creative.where(id: shell_ids, user_id: user.id).pluck(:id).to_set
     end
 
-    # Returns the subset of already-origin-resolved ids the user may read,
-    # as a Set. no_access wins over a public share; owned creatives are
-    # always readable.
-    def readable_effective_ids(ids)
+    # Returns the subset of already-origin-resolved ids the user may access at
+    # `min_rank` or higher, as a Set. A user-specific entry is authoritative:
+    # it grants only when its own rank meets the threshold and otherwise
+    # suppresses the public share entirely (so a user no_access — or any
+    # below-threshold user entry — wins over a more permissive public share).
+    # Owned creatives are always accessible (owner has admin).
+    def readable_effective_ids(ids, min_rank = rank_for(:read))
       return Set.new if ids.empty?
 
       accessible_ids = Set.new
 
       if user
-        user_accessible = []
-        user_denied = Set.new
+        user_has_entry = Set.new
         CreativeSharesCache.where(creative_id: ids, user_id: user.id)
           .pluck(:creative_id, :permission).each do |cid, perm|
-            perm == "no_access" ? user_denied << cid : user_accessible << cid
+            user_has_entry << cid
+            accessible_ids << cid if CreativeShare.permissions[perm] >= min_rank
           end
-        accessible_ids.merge(user_accessible)
 
         public_ids = CreativeSharesCache.where(creative_id: ids, user_id: nil)
-          .where.not(permission: :no_access).pluck(:creative_id)
-        accessible_ids.merge(public_ids - user_denied.to_a)
+          .where("permission >= ?", min_rank).pluck(:creative_id)
+        accessible_ids.merge(public_ids.reject { |cid| user_has_entry.include?(cid) })
 
         owned_ids = Creative.where(id: ids, user_id: user.id).pluck(:id)
         accessible_ids.merge(owned_ids)
       else
         accessible_ids = CreativeSharesCache.where(creative_id: ids, user_id: nil)
-          .where.not(permission: :no_access).pluck(:creative_id).to_set
+          .where("permission >= ?", min_rank).pluck(:creative_id).to_set
       end
 
       accessible_ids

--- a/engines/collavre/test/services/creatives/permission_filter_test.rb
+++ b/engines/collavre/test/services/creatives/permission_filter_test.rb
@@ -206,5 +206,41 @@ module Creatives
           "ranks_for rank #{rank} vs allowed?(#{threshold}) must agree"
       end
     end
+
+    # --- PR 1: anonymous (user: nil) path --------------------------------
+    # An unauthenticated viewer has no user cache entries, so both entry points
+    # resolve purely against public shares. These pin that branch (no user
+    # entries queried; public shares still honor the min_permission threshold).
+
+    test "readable_ids for an anonymous user resolves against public shares only, honoring the threshold" do
+      perform_enqueued_jobs do
+        CreativeShare.create!(creative: @origin, user: nil, permission: "read")
+      end
+      pf = Creatives::PermissionFilter.new(user: nil)
+      assert_equal [ @origin.id ], pf.readable_ids([ @origin.id ], min_permission: :read),
+        "public read share grants read to an anonymous viewer"
+      assert_equal [], pf.readable_ids([ @origin.id ], min_permission: :write),
+        "public read share must not satisfy :write for an anonymous viewer"
+    end
+
+    test "readable_ids for an anonymous user excludes a creative with no public share" do
+      assert_equal [], Creatives::PermissionFilter.new(user: nil).readable_ids([ @origin.id ]),
+        "with no public share, an anonymous viewer reads nothing"
+    end
+
+    test "ranks_for for an anonymous user falls back to the public share rank" do
+      perform_enqueued_jobs do
+        CreativeShare.create!(creative: @origin, user: nil, permission: "feedback")
+      end
+      ranks = Creatives::PermissionFilter.new(user: nil).ranks_for([ @origin.id ])
+      assert_equal CreativeShare.permissions[:feedback], ranks[@origin.id],
+        "an anonymous viewer's rank comes solely from the public share"
+    end
+
+    test "ranks_for for an anonymous user omits a creative with no public share" do
+      ranks = Creatives::PermissionFilter.new(user: nil).ranks_for([ @origin.id ])
+      refute ranks.key?(@origin.id),
+        "no public share => absent for an anonymous viewer (not the owner, no user entry)"
+    end
   end
 end

--- a/engines/collavre/test/services/creatives/permission_filter_test.rb
+++ b/engines/collavre/test/services/creatives/permission_filter_test.rb
@@ -100,5 +100,111 @@ module Creatives
       assert_equal [ owner_direct.id, @origin.id ].sort, batch.sort,
         "foreign shell dropped; owned/readable rows in the same batch preserved"
     end
+
+    # --- PR 1: min_permission: threshold ---------------------------------
+    # readable_ids gains a min_permission: keyword so the write-posture bypass
+    # sites (attachments_controller) and children_with_permission(min) can share
+    # the one batch filter instead of re-deriving the rank comparison.
+
+    test "readable_ids min_permission: defaults to :read (byte-identical to no arg)" do
+      pf = Creatives::PermissionFilter.new(user: @shared_user)
+      assert_equal pf.readable_ids([ @origin.id ]),
+        pf.readable_ids([ @origin.id ], min_permission: :read)
+    end
+
+    test "readable_ids with min_permission: :write excludes a read-only share" do
+      pf = Creatives::PermissionFilter.new(user: @shared_user)
+      assert_equal [ @origin.id ], pf.readable_ids([ @origin.id ], min_permission: :read),
+        "@shared_user has a read share on the origin"
+      assert_equal [], pf.readable_ids([ @origin.id ], min_permission: :write),
+        "a read share must not satisfy the :write threshold"
+    end
+
+    test "readable_ids with min_permission: :write includes a write share" do
+      perform_enqueued_jobs do
+        CreativeShare.create!(creative: @origin, user: @stranger, permission: "write")
+      end
+      batch = Creatives::PermissionFilter.new(user: @stranger)
+        .readable_ids([ @origin.id ], min_permission: :write)
+      assert_equal [ @origin.id ], batch
+    end
+
+    test "readable_ids min_permission: :write keeps the owner (admin) readable" do
+      batch = Creatives::PermissionFilter.new(user: @owner)
+        .readable_ids([ @origin.id ], min_permission: :write)
+      assert_equal [ @origin.id ], batch,
+        "the owner has admin and satisfies any threshold"
+    end
+
+    test "readable_ids min_permission applies to public shares too" do
+      perform_enqueued_jobs do
+        CreativeShare.create!(creative: @origin, user: nil, permission: "read")
+      end
+      pf = Creatives::PermissionFilter.new(user: @stranger)
+      assert_equal [ @origin.id ], pf.readable_ids([ @origin.id ], min_permission: :read),
+        "public read share grants read to a stranger"
+      assert_equal [], pf.readable_ids([ @origin.id ], min_permission: :write),
+        "public read share must not satisfy :write"
+    end
+
+    # --- PR 1: ranks_for -------------------------------------------------
+    # ranks_for returns { id => effective_rank } mirroring single-item
+    # PermissionChecker (owner wins -> user entry incl. no_access -> public ->
+    # absent). It intentionally does NOT apply readable_ids' shell-ownership
+    # anti-leak gate: it is for tree_builder/slide_viewable which operate on
+    # creatives already in the viewer's own tree, matching PermissionChecker.
+
+    test "ranks_for returns admin rank for an owned creative" do
+      ranks = Creatives::PermissionFilter.new(user: @owner).ranks_for([ @origin.id ])
+      assert_equal CreativeShare.permissions[:admin], ranks[@origin.id]
+    end
+
+    test "ranks_for returns the user's own share rank" do
+      ranks = Creatives::PermissionFilter.new(user: @shared_user).ranks_for([ @origin.id ])
+      assert_equal CreativeShare.permissions[:read], ranks[@origin.id]
+    end
+
+    test "ranks_for resolves a linked shell to its origin's rank, keyed by the input id" do
+      ranks = Creatives::PermissionFilter.new(user: @shared_user).ranks_for([ @linked.id ])
+      assert_equal CreativeShare.permissions[:read], ranks[@linked.id],
+        "the shell borrows its origin's permission and is keyed by the shell (input) id"
+    end
+
+    test "ranks_for omits an id the user cannot access at all" do
+      ranks = Creatives::PermissionFilter.new(user: @stranger).ranks_for([ @origin.id ])
+      refute ranks.key?(@origin.id),
+        "no owner, no user entry, no public share => absent (distinct from rank 0)"
+    end
+
+    test "ranks_for returns no_access rank (0) when a user deny beats a public share" do
+      perform_enqueued_jobs do
+        CreativeShare.create!(creative: @origin, user: nil, permission: "read")
+        CreativeShare.create!(creative: @origin, user: @stranger, permission: "no_access")
+      end
+      ranks = Creatives::PermissionFilter.new(user: @stranger).ranks_for([ @origin.id ])
+      assert_equal CreativeShare.permissions[:no_access], ranks[@origin.id],
+        "the user's no_access entry must win over the public read share"
+    end
+
+    test "ranks_for falls back to the public share rank when there is no user entry" do
+      perform_enqueued_jobs do
+        CreativeShare.create!(creative: @origin, user: nil, permission: "feedback")
+      end
+      ranks = Creatives::PermissionFilter.new(user: @stranger).ranks_for([ @origin.id ])
+      assert_equal CreativeShare.permissions[:feedback], ranks[@origin.id]
+    end
+
+    test "ranks_for agrees with PermissionChecker's allowed? across thresholds" do
+      # Parity guard: for every rank ranks_for reports, allowed?(threshold) must
+      # match rank >= threshold, so converging sites onto ranks_for cannot drift.
+      pf = Creatives::PermissionFilter.new(user: @shared_user)
+      rank = pf.ranks_for([ @origin.id ])[@origin.id]
+      checker = Creatives::PermissionChecker.new(@origin, @shared_user)
+      [ :read, :feedback, :write, :admin ].each do |threshold|
+        expected = rank >= CreativeShare.permissions[threshold.to_s]
+        assert_equal expected, checker.allowed?(threshold),
+          "ranks_for rank #{rank} vs allowed?(#{threshold}) must agree"
+      end
+    end
   end
 end


### PR DESCRIPTION
## What & why

Second step of the permission-cache rot remediation (option-C roadmap, rot area ②). This PR is **purely additive**: it extends the canonical `PermissionFilter` with the two batch APIs that the 5 read-path bypass sites will converge onto in follow-up PRs. **No callers are changed here**, so it is behavior-preserving by construction and independently mergeable.

The bypass sites currently each re-implement the deny-invariant by querying `CreativeSharesCache` directly. Since the architecture moved from a TTL'd cache to an explicitly-invalidated materialized table (`797fe52e`), a missed invalidation stays stale until the next mutation — so centralizing the read logic behind one tested API is a **security control**, not just cleanup. PR 0 (#1388) pinned the current behavior of all 5 sites; this PR gives them a single home to move to.

## New API

| Method | Consumers (future PRs) | Design |
|---|---|---|
| `readable_ids(ids, min_permission: :read)` | sites 1·2 (`:read`), site 4 (`:write`) | Byte-identical to the old no-arg form (default `:read`). A user entry is **authoritative** over a public share — any entry below threshold (not only `no_access`) suppresses the public grant, mirroring `children_with_permission`. Identical results at `:read`. |
| `ranks_for(ids) -> {id => rank}` | site 3 (`tree_builder`), `slide_viewable` | Mirrors the single-row `PermissionChecker` (owner→admin, a user entry [incl. `no_access`] beats public, absent id → no key). The shell-ownership anti-leak gate in `readable_ids` is **intentionally excluded** — `ranks_for` ranks the viewer's own tree, matching PermissionChecker. |

## Design note

The role split is deliberate: `readable_ids` is for search/filter (blocks external shell leakage), `ranks_for` is for own-tree ranking (single-checker parity). Follow-up convergence PRs will rely on PR 0's characterization tests to prove each site's move is behavior-preserving — and to surface site 5's intentional divergence as a *visible* change rather than a silent one.

## Verification

- New unit tests (12): threshold, public/user precedence, `no_access` deny, shell resolution, PermissionChecker threshold parity → `permission_filter_test` **19 runs green**
- Permission cluster (checker/cache/invalidation): **47 runs / 215 assertions green**
- Caller regression sweep (tree_builder, filter_pipeline, slide_viewable, has_children_parity, index_query): green individually
- rubocop clean; full pre-push suite passed