### PR TITLE
refactor(collavre): converge children_with_permission onto PermissionFilter (rot ② PR 2)

### DIFF
--- a/engines/collavre/app/models/collavre/creative/permissible.rb
+++ b/engines/collavre/app/models/collavre/creative/permissible.rb
@@ -38,42 +38,20 @@ module Collavre
         children_ids = children_scope.pluck(:id)
         return [] if children_ids.empty?
 
-        min_rank = CreativeShare.permissions[min_permission.to_s]
-        accessible_ids = Set.new
+        # The deny-invariant (owner wins → user entry, incl. a no_access deny,
+        # beats public → effective-origin resolution) now lives in exactly one
+        # place: PermissionFilter. This site used to re-implement it inline.
+        accessible_ids = Collavre::Creatives::PermissionFilter.new(user: user)
+          .readable_ids(children_ids, min_permission: min_permission)
 
-        if user
-          user_entries = CreativeSharesCache
-            .where(creative_id: children_ids, user_id: user.id)
-            .pluck(:creative_id, :permission)
+        # readable_ids gates a linked shell on the viewer owning the shell row
+        # AND its origin being readable. Listing one's OWN tree keeps the prior
+        # policy that a viewer always sees their own children — including a shell
+        # they own whose origin is no longer shared with them — so union those
+        # owned rows back in. (Owner has admin, so this is rank-independent.)
+        accessible_ids |= children_scope.where(user_id: user.id).pluck(:id) if user
 
-          user_has_entry = Set.new
-          user_entries.each do |cid, perm|
-            user_has_entry << cid
-            perm_rank = CreativeSharesCache.permissions[perm]
-            if perm_rank && perm_rank >= min_rank && perm_rank != CreativeSharesCache.permissions[:no_access]
-              accessible_ids << cid
-            end
-          end
-
-          public_accessible = CreativeSharesCache
-            .where(creative_id: children_ids, user_id: nil)
-            .where("permission >= ?", min_rank)
-            .where.not(permission: :no_access)
-            .pluck(:creative_id)
-          accessible_ids.merge(public_accessible - user_has_entry.to_a)
-
-          owned_ids = children_scope.where(user_id: user.id).pluck(:id)
-          accessible_ids.merge(owned_ids)
-        else
-          accessible_ids = CreativeSharesCache
-            .where(creative_id: children_ids, user_id: nil)
-            .where("permission >= ?", min_rank)
-            .where.not(permission: :no_access)
-            .pluck(:creative_id)
-            .to_set
-        end
-
-        children_scope.where(id: accessible_ids.to_a).order(:sequence).to_a
+        children_scope.where(id: accessible_ids).order(:sequence).to_a
       end
 
       def all_shared_users(required_permission = :no_access)

--- a/engines/collavre/test/integration/permission_read_characterization_test.rb
+++ b/engines/collavre/test/integration/permission_read_characterization_test.rb
@@ -80,6 +80,35 @@ class PermissionReadCharacterizationTest < ActiveSupport::TestCase
       "the no_access deny is user-specific to @user, so a stranger still reads @deny_over_public via its public share"
   end
 
+  # Linked-shell children: a shell (origin_id set) has no cache rows of its own,
+  # so children_with_permission decides purely on shell ROW ownership + the
+  # origin's readability. These pin the two edges the PermissionFilter anti-leak
+  # gate treats differently from raw ownership, so PR 2 convergence must preserve
+  # them: (a) a shell the viewer OWNS is listed even when its origin is NOT
+  # readable to the viewer (stale link stays visible in one's own tree), and
+  # (b) a foreign shell (owned by another user) is NOT listed even when its
+  # origin is public-readable (no leak of another user's placement).
+  test "children_with_permission lists an owned shell child whose origin is NOT readable" do
+    perform_enqueued_jobs do
+      hidden_origin = Creative.create!(user: @stranger, description: "Hidden origin", progress: 0.0)
+      @owned_shell = Creative.create!(user: @user, parent: @root, origin: hidden_origin)
+    end
+    result = @root.children_with_permission(@user, :read)
+    assert_includes ids(result), @owned_shell.id,
+      "viewer owns the shell row, so it is listed even though its origin is not shared with them"
+  end
+
+  test "children_with_permission omits a foreign shell child even if its origin is public-readable" do
+    perform_enqueued_jobs do
+      shared_origin = Creative.create!(user: @stranger, description: "Public origin", progress: 0.0)
+      CreativeShare.create!(creative: shared_origin, user: nil, permission: "read")
+      @foreign_shell = Creative.create!(user: @stranger, parent: @root, origin: shared_origin)
+    end
+    result = @root.children_with_permission(@user, :read)
+    refute_includes ids(result), @foreign_shell.id,
+      "the shell row belongs to @stranger; @user must not see it despite the origin's public read"
+  end
+
   # ---------------------------------------------------------------------------
   # Site 2 — Concerns::SlideViewable#accessible_child_ids (mirrors site 1)
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Third execution step of the option-C permission-rot roadmap (rot ②). Converges the **first of five read-path bypass sites** — `children_with_permission` — onto the centralized `PermissionFilter` deny-invariant introduced in PR 1 (#1389).

Prior to this, `children_with_permission` (in `permissible.rb`) re-implemented the share deny-invariant inline: it queried `CreativeSharesCache` directly and hand-rolled the user/public/owner precedence. That duplicated logic is exactly the structure the 4 `SECURITY:` fix commits kept re-breaking. This PR replaces the ~30-line inline block with a single `readable_ids(min_permission:)` call plus an explicit "always list my own children" union.

## Behavior-preserving — verified empirically, not assumed

A naive delegation to `readable_ids` would **silently diverge** on linked-shell children:

- `readable_ids` applies a shell-ownership anti-leak gate (shell owned **and** origin readable).
- The current code includes owned shell rows unconditionally.

A scratch comparison test confirmed the exact divergence: a viewer-owned shell whose origin is no longer shared is returned by the old code but gated out by `readable_ids` alone. The precise relationship is:

```
current behavior = readable_ids(children) ∪ owned_children
```

So this PR **centralizes the deny-invariant** into `PermissionFilter` while **preserving the "my own tree is always listed" policy** as an explicit union — provably identical to prior behavior.

## Changes

- `permissible.rb`: `children_with_permission` now delegates the deny-invariant to `readable_ids(min_permission:)`, keeping owned-children as an explicit union (net −22 lines of duplicated invariant).
- Added **2 shell-child characterization tests** to the PR 0 site-1 section, pinning: (1) owned shell + unreadable origin → still listed; (2) foreign shell + public origin → not listed.

## Verification

- Characterization suite: **17 runs green** (identical before/after convergence, incl. both shell edges)
- Permission + linked-creative cluster: **76 runs green**
- Caller sweep (tree_builder / index_query / slide_viewable): green
- rubocop clean

## Roadmap

PR 0 (#1388) ✅ → PR 1 (#1389) ✅ → **PR 2 (this)** → PR 3–5 (remaining read sites) → PR 6 (`CreativeShare` invalidation unification).