### PR TITLE
refactor(collavre): converge slide_viewable + tree_builder onto PermissionFilter (rot ② PR 3)

### DIFF
--- a/engines/collavre/app/controllers/collavre/concerns/slide_viewable.rb
+++ b/engines/collavre/app/controllers/collavre/concerns/slide_viewable.rb
@@ -134,45 +134,21 @@ module Collavre
         result
       end
 
-      # Mirrors the access check in Creative#children_with_permission, but
-      # operates on a pre-fetched set of candidate children so the work
-      # collapses to a fixed number of queries instead of one per parent.
+      # Mirrors the access check in Creative#children_with_permission via the
+      # single PermissionFilter read path: the deny-invariant (owner wins, user
+      # entry incl. no_access beats public) is served by #readable_ids, and the
+      # "a user always sees their own children" listing policy is preserved as an
+      # explicit union — identical to children_with_permission's shape, including
+      # the owned-shell-with-unreadable-origin case readable_ids gates out.
       def accessible_child_ids(candidate_ids, candidate_children, user)
         return Set.new if candidate_ids.empty?
 
-        min_rank = CreativeShare.permissions["read"]
-        accessible = Set.new
+        filter = Collavre::Creatives::PermissionFilter.new(user: user)
+        accessible = filter.readable_ids(candidate_ids, min_permission: :read).to_set
 
         if user
-          user_entries = CreativeSharesCache
-            .where(creative_id: candidate_ids, user_id: user.id)
-            .pluck(:creative_id, :permission)
-
-          user_has_entry = Set.new
-          user_entries.each do |cid, perm|
-            user_has_entry << cid
-            perm_rank = CreativeSharesCache.permissions[perm]
-            if perm_rank && perm_rank >= min_rank && perm_rank != CreativeSharesCache.permissions[:no_access]
-              accessible << cid
-            end
-          end
-
-          public_accessible = CreativeSharesCache
-            .where(creative_id: candidate_ids, user_id: nil)
-            .where("permission >= ?", min_rank)
-            .where.not(permission: :no_access)
-            .pluck(:creative_id)
-          accessible.merge(public_accessible.reject { |cid| user_has_entry.include?(cid) })
-
           owned_ids = candidate_children.select { |c| c.user_id == user.id }.map(&:id)
           accessible.merge(owned_ids)
-        else
-          public_accessible = CreativeSharesCache
-            .where(creative_id: candidate_ids, user_id: nil)
-            .where("permission >= ?", min_rank)
-            .where.not(permission: :no_access)
-            .pluck(:creative_id)
-          accessible.merge(public_accessible)
         end
 
         accessible

--- a/engines/collavre/app/services/collavre/creatives/permission_filter.rb
+++ b/engines/collavre/app/services/collavre/creatives/permission_filter.rb
@@ -11,7 +11,8 @@ module Creatives
   # over a more permissive public share). Owned creatives are always readable.
   class PermissionFilter
     # An owner always resolves to admin, the top rank, so it satisfies any
-    # min_permission threshold. Matches TreeBuilder::OWNER_RANK.
+    # min_permission threshold. This is the canonical owner rank the read-path
+    # callers (TreeBuilder, SlideViewable) inherit via #ranks_for / #readable_ids.
     OWNER_RANK = CreativeShare.permissions[:admin]
 
     def initialize(user:)

--- a/engines/collavre/app/services/collavre/creatives/tree_builder.rb
+++ b/engines/collavre/app/services/collavre/creatives/tree_builder.rb
@@ -3,10 +3,6 @@ module Creatives
   class TreeBuilder
     FILTER_IGNORED_KEYS = %w[id controller action format level select_mode].freeze
 
-    # A creative's own row grants no permission; the check resolves to its origin
-    # (PermissionChecker), and the owner of that origin always has full access.
-    OWNER_RANK = CreativeShare.permissions[:admin]
-
     def initialize(user:, params:, view_context:, expanded_state_map:, select_mode:, max_level:, allowed_creative_ids: nil, progress_map: nil)
       @user = user
       @view_context = view_context
@@ -60,42 +56,17 @@ module Creatives
       children_index.load(expanding) if expanding.any?
     end
 
-    # Mirrors PermissionChecker exactly, in batch: owner wins, then the user's own
-    # cache entry (a no_access entry is rank 0 and so denies everything, even when
-    # a public share exists), then the public entry. Absent everywhere means no
-    # access at all, which is distinct from rank 0 only in intent.
+    # Batch effective-origin permission ranks via the single PermissionFilter
+    # read path (owner wins, then the user's own cache entry incl. a no_access
+    # deny, then the public entry). Every pending creative gets an explicit
+    # entry — nil when no share resolves — so #allowed? can trust
+    # @permission_rank.key? and never falls back per-item for absent ids.
     def preload_permissions(creatives)
       pending = creatives.reject { |creative| @permission_rank.key?(creative.id) }
       return if pending.empty?
 
-      base_id_by_id = pending.to_h { |c| [ c.id, c.origin_id || c.id ] }
-      owner_id_by_id = pending.to_h { |c| [ c.id, c.origin_id.nil? ? c.user_id : c.origin&.user_id ] }
-      base_ids = base_id_by_id.values.uniq
-
-      user_entries = if user
-        CreativeSharesCache.where(creative_id: base_ids, user_id: user.id).pluck(:creative_id, :permission).to_h
-      else
-        {}
-      end
-
-      needs_public = base_ids - user_entries.keys
-      public_entries = if needs_public.any?
-        CreativeSharesCache.where(creative_id: needs_public, user_id: nil).pluck(:creative_id, :permission).to_h
-      else
-        {}
-      end
-
-      pending.each do |creative|
-        base_id = base_id_by_id[creative.id]
-        permission = user_entries[base_id] || public_entries[base_id]
-
-        @permission_rank[creative.id] =
-          if user && owner_id_by_id[creative.id] == user.id
-            OWNER_RANK
-          elsif permission
-            CreativeSharesCache.permissions[permission]
-          end
-      end
+      ranks = PermissionFilter.new(user: user).ranks_for(pending.map(&:id))
+      pending.each { |creative| @permission_rank[creative.id] = ranks[creative.id] }
     end
 
     # Equivalent to `creative.has_permission?(user, permission)`, served from the

--- a/engines/collavre/test/integration/permission_read_characterization_test.rb
+++ b/engines/collavre/test/integration/permission_read_characterization_test.rb
@@ -107,6 +107,24 @@ class PermissionReadCharacterizationTest < ActiveSupport::TestCase
       "anonymous sees every public read share; the no_access deny is user-scoped and does not apply to nil"
   end
 
+  test "accessible_child_ids includes a candidate shell the viewer owns even when its origin is unreadable" do
+    # A linked shell (origin_id set) owned by @user, whose origin belongs to a
+    # stranger and is NOT shared with @user. The shell has no cache entries of
+    # its own, so it is reachable ONLY via the "always show my own children"
+    # listing policy — the exact case readable_ids gates out but the owned union
+    # restores. Pin it so convergence keeps the viewer's own children visible.
+    shell = nil
+    perform_enqueued_jobs do
+      origin = Creative.create!(user: @stranger, description: "Stranger origin", progress: 0.0)
+      shell = Creative.create!(origin: origin, user: @user, parent_id: nil)
+    end
+
+    host = Class.new { include Collavre::Concerns::SlideViewable }.new
+    result = host.send(:accessible_child_ids, [ shell.id ], [ shell ], @user)
+    assert_includes result.to_a, shell.id,
+      "the viewer owns the shell row, so it stays visible even though its origin is unreadable"
+  end
+
   # ---------------------------------------------------------------------------
   # Site 3 — Creatives::TreeBuilder#preload_permissions
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Rot ② — Permission-cache unification, PR 3

Third convergence step. Read sites **2 and 3** each hand-reimplemented the permission deny-invariant against `CreativeSharesCache`; this routes both through the single `PermissionFilter` read path introduced in PR 1 (#1389) and proven behavior-preserving by the PR 0 characterization tests (#1388).

### Changes
- **`TreeBuilder#preload_permissions` → `PermissionFilter#ranks_for`.** `EffectiveCreativeResolution` resolves origin single-hop and computes owner identically to the old inline logic, so this is behavior-identical including linked shells. Every pending id is still assigned (`nil` when no share resolves) to preserve `#allowed?`'s `@permission_rank.key?` semantics — no per-item fallback for absent ids.
- **`SlideViewable#accessible_child_ids` → `readable_ids(min_permission: :read) ∪ owned children`.** Same shape as PR 2's `children_with_permission`: the deny-invariant is centralized in `readable_ids` while the "a user always sees their own children" listing policy stays an explicit union. This preserves the one divergent case — a viewer-owned shell whose origin is no longer readable — which `readable_ids` gates out but the owned union restores.
- **Removed the now-unused `TreeBuilder::OWNER_RANK`;** `PermissionFilter::OWNER_RANK` is the canonical value both callers inherit.
- **Pinned** the site-2 owned-shell/unreadable-origin edge with a new characterization test.

Net −34 lines of duplicated invariant.

### Verification
- Characterization suite **16 runs** (incl. new shell test) green — behavior identical pre/post convergence for both sites.
- Permission cluster (checker/cache/invalidation) + linked-search + `tree_builder_test` + slide-view controller: **all green** (77-run sweep + 4-run controller).
- rubocop clean.

Roadmap: PR 0 (#1388) ✅ → PR 1 (#1389) ✅ → PR 2 (#1390) → **PR 3 (this)** → PR 4 (attachments `:write`) → PR 5 (`creative_retrieval_service`, posture-tightening) → PR 6 (`CreativeShare` invalidation unification).