### PR TITLE
refactor(collavre): converge attachments write check onto PermissionFilter (rot ② PR 4)

### DIFF
--- a/engines/collavre/app/controllers/collavre/attachments_controller.rb
+++ b/engines/collavre/app/controllers/collavre/attachments_controller.rb
@@ -68,25 +68,15 @@ module Collavre
       return false if creatives.empty?
 
       # Permission is evaluated on the origin for linked creatives. Resolve every
-      # referencing creative to its permission base and batch-load the cache
-      # entries once, rather than letting each has_permission? call fire its own
-      # per-row CreativeSharesCache lookups (an N+1). Mirrors
-      # Creatives::PermissionChecker#allowed?(:write): a user-specific entry
-      # (including an explicit no_access deny) takes precedence over the public
-      # share entry.
+      # referencing creative to its permission base, then delegate the write-rank
+      # deny-invariant to the canonical PermissionFilter (owner wins; a
+      # user-specific entry — including an explicit no_access deny — takes
+      # precedence over the public share). readable_ids batch-loads the cache
+      # entries once, preserving the prior N+1 avoidance.
       bases = creatives.map { |c| c.origin_id.nil? ? c : c.origin }.compact.uniq
-      return true if bases.any? { |base| base.user_id == Current.user.id }
-
-      write_rank = CreativeSharesCache.permissions[:write]
-      entries = CreativeSharesCache
-        .where(creative_id: bases.map(&:id), user_id: [ Current.user.id, nil ])
-        .to_a
-
-      bases.any? do |base|
-        entry = entries.find { |e| e.creative_id == base.id && e.user_id == Current.user.id } ||
-                entries.find { |e| e.creative_id == base.id && e.user_id.nil? }
-        entry && !entry.no_access? && CreativeSharesCache.permissions[entry.permission] >= write_rank
-      end
+      Collavre::Creatives::PermissionFilter.new(user: Current.user)
+        .readable_ids(bases.map(&:id), min_permission: :write)
+        .any?
     end
   end
 end

--- a/engines/collavre/test/integration/permission_read_characterization_test.rb
+++ b/engines/collavre/test/integration/permission_read_characterization_test.rb
@@ -220,6 +220,13 @@ class PermissionReadCharacterizationTest < ActiveSupport::TestCase
     refute editable_for?(blob, @stranger), "public read grants read, not write"
   end
 
+  test "editable_creative_reference? grants a non-owner via a public write share" do
+    public_write = Creative.create!(user: @owner, parent: @root, description: "Public write")
+    CreativeShare.create!(creative: public_write, user: nil, permission: "write")
+    blob = reference_blob_in(public_write)
+    assert editable_for?(blob, @stranger), "public write share grants write to any user with no deny entry"
+  end
+
   # ---------------------------------------------------------------------------
   # Site 5 — Tools::CreativeRetrievalService#accessible_creative_ids
   # NOTE: this site diverges by design — it counts a user's OWN creatives plus


### PR DESCRIPTION
## What

Converges the **4th of 5 permission read-path bypass sites** onto the canonical `PermissionFilter`.

`AttachmentsController#editable_creative_reference?` hand-rolled a write-rank permission check whose own comment admitted it "Mirrors `PermissionChecker#allowed?(:write)`". This replaces the ~20-line inline `CreativeSharesCache` walk (owner-wins → user-entry-beats-public → `no_access` deny) with a single `readable_ids(min_permission: :write)` call.

## Why it's behavior-preserving

- `readable_ids` batch-loads the cache entries once, **preserving the prior N+1 avoidance** the old comment was concerned with.
- The `bases` are already resolved to origins (`origin_id.nil? ? c : c.origin`), so the filter's origin resolution and shell-ownership gate are **no-ops** here — no divergence.
- Owner-wins, user-entry-beats-public, and `no_access`-deny all map 1:1 onto `readable_ids`' write-rank semantics.

## Tests

- Adds a characterization test for the **public-write-share** branch (a non-owner granted via a public write) that the existing site-4 matrix did not pin — kept as a standalone creative so the shared `@children` exact-match matrix is undisturbed.
- Characterization + attachments controller suites green **before and after** convergence (22 runs).
- Permission cluster green: filter 23 / cache 16 / tree_builder 3.

## Roadmap (rot ② — permission invalidation)

PR 0 (#1388) ✅ → PR 1 (#1389) ✅ → PR 2 (#1390) ✅ → PR 3 (#1391, open) → **PR 4 (this)** → PR 5 (`creative_retrieval_service`, security-tightening) → PR 6 (`CreativeShare` invalidation unification).