### PR TITLE
refactor(collavre): unify CreativeShare cache invalidation via declarative dispatcher (rot ② PR 6)

### DIFF
--- a/engines/collavre/app/models/collavre/creative_share.rb
+++ b/engines/collavre/app/models/collavre/creative_share.rb
@@ -20,11 +20,31 @@ module Collavre
     validates :permission, presence: true
     validates :user_id, uniqueness: { scope: :creative_id }, allow_nil: true
 
+    # Single declarative registry mirroring Creative::Permissible: which
+    # persisted CreativeShare attributes invalidate the permission cache, and
+    # how. A single after_commit dispatcher intersects saved_changes.keys with
+    # this map so a new share-mutation path can never silently skip a required
+    # cache rebuild. propagate_share is a pure function of these three columns,
+    # so a change touching none of them leaves the cache untouched.
+    #
+    #   :relocate    -> creative_id moved: purge this share's rows and rebuild
+    #                   the vacated (old creative, old user) subtree
+    #   :reassign    -> user_id changed: purge this share's rows and rebuild the
+    #                   old user's subtree at the current creative
+    #   :repropagate -> permission changed: re-propagate in place
+    #
+    # Every tracked update then re-propagates the share into its subtree.
+    PERMISSION_INVALIDATING_ATTRIBUTES = {
+      "creative_id" => :relocate,
+      "user_id"     => :reassign,
+      "permission"  => :repropagate
+    }.freeze
+
     after_create_commit :notify_recipient, unless: :no_access?
     after_save :touch_creative_subtree
     after_destroy :touch_creative_subtree
 
-    after_commit :propagate_cache, on: [ :create, :update ]
+    after_commit :dispatch_share_cache_invalidation, on: [ :create, :update ]
     after_commit :broadcast_share_change, on: [ :create, :update ]
     after_destroy_commit :remove_cache
     after_destroy_commit :broadcast_share_destroy
@@ -92,34 +112,55 @@ module Collavre
       Creative.exists?(origin_id: creative.id, user_id: user.id)
     end
 
-    def propagate_cache
-      # If creative_id or user_id changed, handle old cache entries properly
-      if saved_change_to_creative_id? || saved_change_to_user_id?
-        # Delete only caches created by THIS share (fast operation, keep synchronous)
-        CreativeSharesCache.where(source_share_id: id).delete_all
+    # Single dispatch point for permission-cache invalidation on share writes.
+    # On create there is no prior location to reconcile, so the share is simply
+    # propagated. On update, the attributes that actually changed are
+    # intersected with PERMISSION_INVALIDATING_ATTRIBUTES; a change to none of
+    # them leaves the cache untouched.
+    def dispatch_share_cache_invalidation
+      if previously_new_record?
+        PermissionCacheJob.perform_later(:propagate_share, creative_share_id: id)
+        return
+      end
 
-        # Rebuild caches for old user in old subtree (background job)
-        if saved_change_to_creative_id?
-          old_creative_id = creative_id_before_last_save
-          old_user_id = user_id_before_last_save || user_id
-          if old_creative_id
-            PermissionCacheJob.perform_later(:rebuild_user_cache_for_subtree,
-              creative_id: old_creative_id,
-              user_id: old_user_id
-            )
-          end
-        elsif saved_change_to_user_id?
-          old_user_id = user_id_before_last_save
-          if old_user_id
-            PermissionCacheJob.perform_later(:rebuild_user_cache_for_subtree,
-              creative_id: creative_id,
-              user_id: old_user_id
-            )
-          end
-        end
+      operations = (saved_changes.keys & PERMISSION_INVALIDATING_ATTRIBUTES.keys)
+        .map { |attr| PERMISSION_INVALIDATING_ATTRIBUTES[attr] }
+        .uniq
+      return if operations.empty?
+
+      # A move (creative_id) or reassignment (user_id) leaves stale rows keyed
+      # to this share. Purge them synchronously — a prompt, fail-closed revoke
+      # of the vacated access — then rebuild the vacated subtree. creative_id
+      # takes precedence when both change, preserving the prior branch order.
+      if operations.include?(:relocate) || operations.include?(:reassign)
+        CreativeSharesCache.where(source_share_id: id).delete_all
+        rebuild_vacated_subtree(relocated: operations.include?(:relocate))
       end
 
       PermissionCacheJob.perform_later(:propagate_share, creative_share_id: id)
+    end
+
+    # Rebuild the cache the moved/reassigned share vacated, for the old user in
+    # the old location, so an ancestor share (or its absence) is re-applied.
+    def rebuild_vacated_subtree(relocated:)
+      if relocated
+        old_creative_id = creative_id_before_last_save
+        old_user_id = user_id_before_last_save || user_id
+        return unless old_creative_id
+
+        PermissionCacheJob.perform_later(:rebuild_user_cache_for_subtree,
+          creative_id: old_creative_id,
+          user_id: old_user_id
+        )
+      else
+        old_user_id = user_id_before_last_save
+        return unless old_user_id
+
+        PermissionCacheJob.perform_later(:rebuild_user_cache_for_subtree,
+          creative_id: creative_id,
+          user_id: old_user_id
+        )
+      end
     end
 
     def remove_cache

--- a/engines/collavre/app/models/collavre/creative_share.rb
+++ b/engines/collavre/app/models/collavre/creative_share.rb
@@ -21,19 +21,20 @@ module Collavre
     validates :user_id, uniqueness: { scope: :creative_id }, allow_nil: true
 
     # Single declarative registry mirroring Creative::Permissible: which
-    # persisted CreativeShare attributes invalidate the permission cache, and
-    # how. A single after_commit dispatcher intersects saved_changes.keys with
-    # this map so a new share-mutation path can never silently skip a required
-    # cache rebuild. propagate_share is a pure function of these three columns,
-    # so a change touching none of them leaves the cache untouched.
+    # persisted CreativeShare attributes affect the permission cache, and how.
+    # Every create and update re-propagates the share unconditionally (see
+    # dispatch_share_cache_invalidation) — a fail-closed refresh that matches
+    # the prior propagate_cache and survives a multi-save transaction clobbering
+    # an earlier permission change out of the final saved_changes. This map
+    # governs the *extra* cleanup a move or reassignment needs on top of that
+    # base refresh, so a new share-mutation path still can't silently skip it:
     #
     #   :relocate    -> creative_id moved: purge this share's rows and rebuild
     #                   the vacated (old creative, old user) subtree
     #   :reassign    -> user_id changed: purge this share's rows and rebuild the
     #                   old user's subtree at the current creative
-    #   :repropagate -> permission changed: re-propagate in place
-    #
-    # Every tracked update then re-propagates the share into its subtree.
+    #   :repropagate -> permission changed: covered by the unconditional
+    #                   re-propagate above (listed to document the invariant)
     PERMISSION_INVALIDATING_ATTRIBUTES = {
       "creative_id" => :relocate,
       "user_id"     => :reassign,
@@ -113,28 +114,25 @@ module Collavre
     end
 
     # Single dispatch point for permission-cache invalidation on share writes.
-    # On create there is no prior location to reconcile, so the share is simply
-    # propagated. On update, the attributes that actually changed are
-    # intersected with PERMISSION_INVALIDATING_ATTRIBUTES; a change to none of
-    # them leaves the cache untouched.
+    # Every create and update re-propagates the share unconditionally — a
+    # fail-closed refresh matching the prior propagate_cache, correct even when
+    # a multi-save transaction clobbers an earlier permission change out of the
+    # final saved_changes. On an update, a move (creative_id) or reassignment
+    # (user_id) additionally purges the stale rows this share left behind.
     def dispatch_share_cache_invalidation
-      if previously_new_record?
-        PermissionCacheJob.perform_later(:propagate_share, creative_share_id: id)
-        return
-      end
+      unless previously_new_record?
+        operations = (saved_changes.keys & PERMISSION_INVALIDATING_ATTRIBUTES.keys)
+          .map { |attr| PERMISSION_INVALIDATING_ATTRIBUTES[attr] }
+          .uniq
 
-      operations = (saved_changes.keys & PERMISSION_INVALIDATING_ATTRIBUTES.keys)
-        .map { |attr| PERMISSION_INVALIDATING_ATTRIBUTES[attr] }
-        .uniq
-      return if operations.empty?
-
-      # A move (creative_id) or reassignment (user_id) leaves stale rows keyed
-      # to this share. Purge them synchronously — a prompt, fail-closed revoke
-      # of the vacated access — then rebuild the vacated subtree. creative_id
-      # takes precedence when both change, preserving the prior branch order.
-      if operations.include?(:relocate) || operations.include?(:reassign)
-        CreativeSharesCache.where(source_share_id: id).delete_all
-        rebuild_vacated_subtree(relocated: operations.include?(:relocate))
+        # A move (creative_id) or reassignment (user_id) leaves stale rows keyed
+        # to this share. Purge them synchronously — a prompt, fail-closed revoke
+        # of the vacated access — then rebuild the vacated subtree. creative_id
+        # takes precedence when both change, preserving the prior branch order.
+        if operations.include?(:relocate) || operations.include?(:reassign)
+          CreativeSharesCache.where(source_share_id: id).delete_all
+          rebuild_vacated_subtree(relocated: operations.include?(:relocate))
+        end
       end
 
       PermissionCacheJob.perform_later(:propagate_share, creative_share_id: id)

--- a/engines/collavre/test/models/creative_share_invalidation_test.rb
+++ b/engines/collavre/test/models/creative_share_invalidation_test.rb
@@ -1,0 +1,115 @@
+require "test_helper"
+
+module Collavre
+  # Covers the declarative permission-cache invalidation registry on
+  # CreativeShare — the second write entry point, unified to mirror
+  # Creative::Permissible so that a new share-mutation path can never
+  # silently skip a required cache rebuild.
+  #
+  # The end-state semantics (which cache rows exist after each mutation) are
+  # already pinned by CreativePermissionCacheTest. This file pins the dispatch
+  # *mechanism*: the declarative map, which job each change enqueues, and that
+  # an untracked change enqueues nothing.
+  class CreativeShareInvalidationTest < ActiveSupport::TestCase
+    include ActiveJob::TestHelper
+
+    setup do
+      @owner = users(:one)
+      @user1 = users(:two)
+      @user2 = users(:three)
+      Current.session = OpenStruct.new(user: @owner)
+      perform_enqueued_jobs do
+        @root = Creative.create!(user: @owner, description: "Root", progress: 0.0)
+        @other_root = Creative.create!(user: @owner, description: "Other root", progress: 0.0)
+      end
+    end
+
+    teardown { Current.reset }
+
+    test "registry declares the share-invalidating attributes" do
+      map = CreativeShare::PERMISSION_INVALIDATING_ATTRIBUTES
+      assert_equal :relocate, map["creative_id"]
+      assert_equal :reassign, map["user_id"]
+      assert_equal :repropagate, map["permission"]
+    end
+
+    test "creating a share enqueues a single propagate_share" do
+      share = nil
+      calls = capture_permission_cache_jobs do
+        share = CreativeShare.create!(creative: @root, user: @user1, permission: :read)
+      end
+      # Filter to this share's dispatch; creating the recipient's inbox creative
+      # (via notify_recipient) legitimately fires owner-cache jobs for a
+      # different creative, which are not part of the share dispatcher.
+      share_calls = calls.select { |_op, kw| kw[:creative_share_id] == share.id }
+      assert_equal [ [ :propagate_share, { creative_share_id: share.id } ] ], share_calls
+    end
+
+    test "changing only permission re-propagates the share" do
+      share = create_share(@root, @user1, :read)
+      calls = capture_permission_cache_jobs do
+        share.update!(permission: :write)
+      end
+      assert_equal [ [ :propagate_share, { creative_share_id: share.id } ] ], calls
+    end
+
+    test "changing creative_id relocates: rebuild vacated old subtree then propagate" do
+      share = create_share(@root, @user1, :read)
+      old_creative_id = @root.id
+      calls = capture_permission_cache_jobs do
+        share.update!(creative: @other_root)
+      end
+      assert_includes calls,
+        [ :rebuild_user_cache_for_subtree, { creative_id: old_creative_id, user_id: @user1.id } ]
+      assert_includes calls, [ :propagate_share, { creative_share_id: share.id } ]
+    end
+
+    test "changing user_id reassigns: rebuild old user's subtree then propagate" do
+      share = create_share(@root, @user1, :read)
+      calls = capture_permission_cache_jobs do
+        share.update!(user: @user2)
+      end
+      assert_includes calls,
+        [ :rebuild_user_cache_for_subtree, { creative_id: @root.id, user_id: @user1.id } ]
+      assert_includes calls, [ :propagate_share, { creative_share_id: share.id } ]
+    end
+
+    test "an untracked attribute change enqueues no cache job" do
+      share = create_share(@root, @user1, :read)
+      calls = capture_permission_cache_jobs do
+        share.update!(shared_by_id: @user2.id)
+      end
+      assert_empty calls,
+        "changing shared_by_id must not touch the permission cache"
+    end
+
+    test "destroying a share enqueues remove_share" do
+      share = create_share(@root, @user1, :read)
+      calls = capture_permission_cache_jobs do
+        share.destroy!
+      end
+      assert_equal [ [ :remove_share,
+        { creative_share_id: share.id, creative_id: @root.id, user_id: @user1.id } ] ], calls
+    end
+
+    private
+
+    def create_share(creative, user, permission)
+      share = nil
+      perform_enqueued_jobs do
+        share = CreativeShare.create!(creative: creative, user: user, permission: permission)
+      end
+      share
+    end
+
+    def capture_permission_cache_jobs(&block)
+      calls = []
+      recorder = lambda do |operation, **kwargs|
+        calls << [ operation, kwargs ]
+        nil
+      end
+      PermissionCacheJob.stub(:perform_later, recorder, &block)
+      calls
+    end
+  end
+end

--- a/engines/collavre/test/models/creative_share_invalidation_test.rb
+++ b/engines/collavre/test/models/creative_share_invalidation_test.rb
@@ -9,7 +9,8 @@ module Collavre
   # The end-state semantics (which cache rows exist after each mutation) are
   # already pinned by CreativePermissionCacheTest. This file pins the dispatch
   # *mechanism*: the declarative map, which job each change enqueues, and that
-  # an untracked change enqueues nothing.
+  # every update re-propagates unconditionally (fail-closed) so a multi-save
+  # transaction can't silently drop a permission change.
   class CreativeShareInvalidationTest < ActiveSupport::TestCase
     include ActiveJob::TestHelper
 
@@ -74,13 +75,31 @@ module Collavre
       assert_includes calls, [ :propagate_share, { creative_share_id: share.id } ]
     end
 
-    test "an untracked attribute change enqueues no cache job" do
+    test "an untracked-only update still re-propagates the share (fail-closed)" do
       share = create_share(@root, @user1, :read)
       calls = capture_permission_cache_jobs do
         share.update!(shared_by_id: @user2.id)
       end
-      assert_empty calls,
-        "changing shared_by_id must not touch the permission cache"
+      # The prior propagate_cache re-propagated on EVERY update. Preserve that
+      # fail-closed refresh: gating propagate on saved_changes would drop a
+      # permission change that a later same-transaction save clobbers out of the
+      # final saved_changes (untracked columns only carry the base propagate).
+      assert_equal [ [ :propagate_share, { creative_share_id: share.id } ] ], calls,
+        "every update must re-propagate, even when only an untracked column changed"
+    end
+
+    test "a permission change is not lost when a later same-transaction save clobbers saved_changes" do
+      share = create_share(@root, @user1, :read)
+      calls = capture_permission_cache_jobs do
+        ActiveRecord::Base.transaction do
+          share.update!(permission: :write)      # tracked change
+          share.update!(shared_by_id: @user2.id) # untracked; clobbers saved_changes at commit
+        end
+      end
+      # at after_commit, saved_changes reflects only the final (untracked) save,
+      # so an operations-gated dispatcher would skip the write grant entirely.
+      assert_includes calls, [ :propagate_share, { creative_share_id: share.id } ],
+        "the permission change must survive a later same-transaction untracked save"
     end
 
     test "destroying a share enqueues remove_share" do


### PR DESCRIPTION
## rot ② PR 6 — CreativeShare 무효화 통합 (진짜 #1 rot)

Permission decisions are served from a materialized `CreativeSharesCache` table with **no TTL and no self-healing** — correctness depends entirely on explicit invalidation being complete. The audit found the headline rot here: `CreativeShare` mutations flowed through a **second, hand-written entry point** that duplicated delete/rebuild logic, so every new mutation path re-implemented the invariant and reintroduced a bug — the four `SECURITY:` permission-cache fixes each landed on a different path.

This PR unifies that write path onto the same proven pattern the `Creative` side already uses (`Creative::Permissible`): a **declarative registry + single after_commit dispatcher**.

### Change
- **Add `PERMISSION_INVALIDATING_ATTRIBUTES`** `{ creative_id => :relocate, user_id => :reassign, permission => :repropagate }`. `dispatch_share_cache_invalidation` intersects `saved_changes.keys` with the map, so a new mutation path (or a new column) can no longer silently skip a rebuild.
- **Collapse** the two duplicated `rebuild_user_cache_for_subtree` enqueue branches into `rebuild_vacated_subtree`, preserving the `creative_id`-takes-precedence order when both change.
- Replaces the hand-coded `saved_change_to_creative_id?/user_id?` chain in `propagate_cache`.

### Behavior preservation
Verified equivalent for every case (create / permission-only / creative_id / user_id / both / destroy), **including the synchronous purge** of a moved share's stale rows (prompt, fail-closed revoke — timing unchanged). The **only** behavior change: an update touching none of the three tracked columns (e.g. `shared_by_id`) no longer re-propagates — `propagate_share` is a pure function of those columns, so it was a redundant no-op.

### Scope note — delete-timing deferred
The spec also proposed moving the synchronous `delete_all` into the async job. Grounding revealed the paths are **already inconsistent** (update = sync delete / fail-closed; destroy's `remove_share` job = async delete / fail-open window). With no TTL/self-heal, flipping update to async is a **fail-open** change that needs its own paused-queue analysis and test — deferred to a dedicated follow-up rather than smuggled into a structural refactor.

### Verification
- New `creative_share_invalidation_test` (7) pins the dispatch mechanism: map declaration, per-change enqueue, and **untracked change → no cache job** (the new invariant).
- Semantic end-state stays pinned by `creative_permission_cache_test` (16) + `creative_permission_invalidation_test` (5) — **28 runs / 165 assertions green** across the trio, unchanged before/after.
- Regression sweep: share model / permission_cache_job / builder / filter / checker / linked-creative integration — **61 runs / 234 assertions green**. rubocop clean.