### PR TITLE
refactor(collavre_github): replace SQLite-only json_extract with portable JSON access

### DIFF
--- a/engines/collavre_github/app/services/collavre_github/markdown_sync/incremental_sync_service.rb
+++ b/engines/collavre_github/app/services/collavre_github/markdown_sync/incremental_sync_service.rb
@@ -130,15 +130,18 @@ module CollavreGithub
         branch == @link.markdown_sync_branch
       end
 
-      # Load all synced creatives for this repository link, indexed by path
+      # Load all synced creatives for this repository link, indexed by path.
+      #
+      # The `->`/`->>` JSON operators are portable: both PostgreSQL and modern
+      # SQLite (bundled by the `sqlite3` gem used here) support them, so a
+      # single expression works on both adapters without an
+      # `adapter_name == "PostgreSQL"` branch. Wrapping in `CAST(... AS
+      # INTEGER)` (ANSI SQL, supported by both) avoids relying on Postgres's
+      # `::integer` cast syntax, which SQLite doesn't understand.
       def load_synced_creatives
-        scope = Collavre::Creative.where(archived_at: nil)
-
-        if scope.connection.adapter_name == "PostgreSQL"
-          scope = scope.where("(data->'source'->>'repository_link_id')::integer = ?", @link.id)
-        else
-          scope = scope.where("json_extract(data, '$.source.repository_link_id') = ?", @link.id)
-        end
+        scope = Collavre::Creative
+          .where(archived_at: nil)
+          .where("CAST(data -> 'source' ->> 'repository_link_id' AS INTEGER) = ?", @link.id)
 
         scope.each_with_object({}) { |c, h| h[c.data.dig("source", "path")] = c }
       end

--- a/engines/collavre_github/test/services/collavre_github/markdown_sync/incremental_sync_service_test.rb
+++ b/engines/collavre_github/test/services/collavre_github/markdown_sync/incremental_sync_service_test.rb
@@ -1,0 +1,101 @@
+require_relative "../../../test_helper"
+
+module CollavreGithub
+  module MarkdownSync
+    class IncrementalSyncServiceTest < ActiveSupport::TestCase
+      setup do
+        @user = users(:one)
+        @account = CollavreGithub::Account.create!(
+          user: @user,
+          github_uid: "999901",
+          login: "sync-test-user",
+          name: "Sync Test",
+          token: "test-token"
+        )
+        @creative = creatives(:tshirt)
+        @link = CollavreGithub::RepositoryLink.create!(
+          creative: @creative,
+          github_account: @account,
+          repository_full_name: "owner/repo"
+        )
+        @other_link = CollavreGithub::RepositoryLink.create!(
+          creative: @creative,
+          github_account: @account,
+          repository_full_name: "owner/other-repo"
+        )
+
+        @matching = Collavre::Creative.create!(
+          description: "matching.md",
+          parent: @creative,
+          user: @user,
+          data: {
+            "source" => {
+              "type" => "github_markdown",
+              "path" => "docs/matching.md",
+              "repository_link_id" => @link.id
+            }
+          }
+        )
+
+        @non_matching_link = Collavre::Creative.create!(
+          description: "other-link.md",
+          parent: @creative,
+          user: @user,
+          data: {
+            "source" => {
+              "type" => "github_markdown",
+              "path" => "docs/other-link.md",
+              "repository_link_id" => @other_link.id
+            }
+          }
+        )
+
+        @archived_match = Collavre::Creative.create!(
+          description: "archived.md",
+          parent: @creative,
+          user: @user,
+          archived_at: Time.current,
+          data: {
+            "source" => {
+              "type" => "github_markdown",
+              "path" => "docs/archived.md",
+              "repository_link_id" => @link.id
+            }
+          }
+        )
+
+        @no_source = Collavre::Creative.create!(
+          description: "unrelated",
+          parent: @creative,
+          user: @user
+        )
+
+        @service = IncrementalSyncService.new(repository_link: @link, push_payload: {})
+      end
+
+      test "load_synced_creatives scopes to creatives whose JSON-embedded repository_link_id matches, keyed by path" do
+        synced = @service.send(:load_synced_creatives)
+
+        assert_equal({ "docs/matching.md" => @matching }, synced)
+      end
+
+      test "load_synced_creatives excludes creatives linked to a different repository_link_id" do
+        synced = @service.send(:load_synced_creatives)
+
+        assert_not_includes synced.values, @non_matching_link
+      end
+
+      test "load_synced_creatives excludes archived creatives even when repository_link_id matches" do
+        synced = @service.send(:load_synced_creatives)
+
+        assert_not_includes synced.values, @archived_match
+      end
+
+      test "load_synced_creatives excludes creatives with no source/repository_link_id at all" do
+        synced = @service.send(:load_synced_creatives)
+
+        assert_not_includes synced.values, @no_source
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Rot ③ (SQLite↔Postgres dialect tax): `IncrementalSyncService#load_synced_creatives` branched on `scope.connection.adapter_name == "PostgreSQL"`, using `json_extract(data, '$...')` for SQLite and `(data->'source'->>'repository_link_id')::integer` for Postgres.
- Collapsed both branches into a single portable expression: `CAST(data -> 'source' ->> 'repository_link_id' AS INTEGER) = ?`.
- `->`/`->>` are supported by both PostgreSQL and modern SQLite (the bundled `sqlite3` gem ships SQLite 3.5x, well past the 3.38 operator introduction). `CAST(... AS INTEGER)` is ANSI SQL, portable on both, avoiding Postgres's `::integer` syntax that SQLite can't parse. This mirrors the existing portable pattern already used elsewhere in the same model (`Collavre::Creative.inboxes` scope uses `data->>'kind'` directly, no adapter branch).
- Added `IncrementalSyncServiceTest` covering: matching link id, a different link id, archived creatives, and creatives with no `source` key at all (NULL-path parity check).

## Adapters verified
- **SQLite** (default dev/test DB): full `engines/collavre_github` suite green (104 runs, 0 failures).
- **PostgreSQL 14.15**: loaded `db/schema.rb` into a scratch local Postgres via `DATABASE_URL`, then re-ran the new service test through ActiveRecord end-to-end (4 runs, 0 failures) — same match/non-match/missing-key semantics as before.

## Test plan
- [x] `bin/rails test engines/collavre_github/test/services/collavre_github/markdown_sync/incremental_sync_service_test.rb` (SQLite)
- [x] `bin/rails test engines/collavre_github/` (SQLite, full engine suite)
- [x] Same service test re-run against a real local PostgreSQL 14.15 via `DATABASE_URL`
- [x] `bundle exec rubocop` on changed files (no offenses)