### PR TITLE
refactor(collavre): extract tree-DOM navigation cluster from creative_row_editor god-file (slice 2 of N)

### DIFF
--- a/engines/collavre/app/javascript/modules/__tests__/creative_tree_dom.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/creative_tree_dom.test.js
@@ -1,0 +1,425 @@
+/**
+ * Characterization tests for the tree-DOM navigation/geometry cluster extracted
+ * from creative_row_editor.js (slice 2 of the god-file decomposition).
+ *
+ * These pin the CURRENT behavior of the sibling/level/parent computations that
+ * feed the structural-move paths (levelUp/levelDown/addNew/move) — the inputs to
+ * the recurring "parentId loss / wrong ordering" bug class. They are written
+ * against a jsdom fixture that mirrors the real creative-tree render: a
+ * `creative-tree-row` custom element wrapping a `.creative-tree` node, with
+ * `.creative-children` containers as siblings of the row.
+ *
+ * Intentionally behavior-preserving: any surprising result below (e.g. the
+ * before/after id inversion in siblingOrderingForRow) documents existing
+ * behavior, not an endorsement of it.
+ */
+import {
+  creativeTreeElement,
+  creativeIdFrom,
+  siblingTreeRow,
+  siblingOrderingForRow,
+  treeContainerElement,
+  nodeAfterTreeBlock,
+  normalizeRowNode,
+  childrenContainerForTree,
+  ensureChildrenContainer,
+  expandChildrenContainer,
+  moveTreeBlock,
+  listAllTreeNodes,
+  findPreviousTree,
+  getTreeLevel,
+  updateTreeLevels,
+  setTreeLevel,
+  removeTreeElement,
+} from '../creative_tree_dom';
+
+// Build one row: <creative-tree-row><div.creative-tree/></creative-tree-row>
+function makeRow(id, { parentId = '', level = 1 } = {}) {
+  const row = document.createElement('creative-tree-row');
+  row.setAttribute('creative-id', String(id));
+  row.setAttribute('level', String(level));
+  const tree = document.createElement('div');
+  tree.className = 'creative-tree';
+  tree.id = `creative-${id}`;
+  tree.dataset.id = String(id);
+  tree.dataset.parentId = parentId;
+  tree.dataset.level = String(level);
+  row.appendChild(tree);
+  return { row, tree };
+}
+
+function makeChildrenContainer(parentId) {
+  const c = document.createElement('div');
+  c.className = 'creative-children';
+  c.id = `creative-children-${parentId}`;
+  return c;
+}
+
+function treeOf(row) {
+  return row.querySelector('.creative-tree');
+}
+
+let root;
+beforeEach(() => {
+  document.body.innerHTML = '';
+  root = document.createElement('div');
+  root.id = 'creatives';
+  document.body.appendChild(root);
+});
+
+describe('creativeTreeElement / creativeIdFrom', () => {
+  test('creativeTreeElement returns the node itself when it is a .creative-tree', () => {
+    const { tree } = makeRow(1);
+    expect(creativeTreeElement(tree)).toBe(tree);
+  });
+
+  test('creativeTreeElement descends into a wrapping row', () => {
+    const { row, tree } = makeRow(1);
+    expect(creativeTreeElement(row)).toBe(tree);
+  });
+
+  test('creativeTreeElement returns null for a nullish node', () => {
+    expect(creativeTreeElement(null)).toBeNull();
+  });
+
+  test('creativeIdFrom reads the inner .creative-tree data-id from a row', () => {
+    const { row } = makeRow(42);
+    expect(creativeIdFrom(row)).toBe('42');
+  });
+
+  test('creativeIdFrom falls back to creative-id / data-id attributes', () => {
+    const el = document.createElement('div');
+    el.setAttribute('creative-id', '7');
+    expect(creativeIdFrom(el)).toBe('7');
+  });
+
+  test('creativeIdFrom returns empty string when nothing identifies the node', () => {
+    expect(creativeIdFrom(null)).toBe('');
+  });
+});
+
+describe('siblingTreeRow', () => {
+  test('finds the next/previous row, skipping text nodes', () => {
+    const a = makeRow(1);
+    const b = makeRow(2);
+    root.appendChild(a.row);
+    root.appendChild(document.createTextNode('\n  '));
+    root.appendChild(b.row);
+
+    expect(siblingTreeRow(a.row, 'next')).toBe(b.row);
+    expect(siblingTreeRow(b.row, 'previous')).toBe(a.row);
+  });
+
+  test('skips over intervening .creative-children containers', () => {
+    const a = makeRow(1);
+    const b = makeRow(2);
+    root.appendChild(a.row);
+    root.appendChild(makeChildrenContainer(1)); // between the two rows
+    root.appendChild(b.row);
+
+    expect(siblingTreeRow(a.row, 'next')).toBe(b.row);
+    expect(siblingTreeRow(b.row, 'previous')).toBe(a.row);
+  });
+
+  test('returns null at the ends', () => {
+    const a = makeRow(1);
+    root.appendChild(a.row);
+    expect(siblingTreeRow(a.row, 'next')).toBeNull();
+    expect(siblingTreeRow(a.row, 'previous')).toBeNull();
+    expect(siblingTreeRow(null, 'next')).toBeNull();
+  });
+});
+
+describe('siblingOrderingForRow', () => {
+  // Pins the (surprising) mapping: beforeId := NEXT sibling, afterId := PREVIOUS
+  // sibling. This is existing behavior consumed by persistStructureChange.
+  test('beforeId comes from the next sibling, afterId from the previous', () => {
+    const a = makeRow(1);
+    const b = makeRow(2);
+    const c = makeRow(3);
+    root.appendChild(a.row);
+    root.appendChild(b.row);
+    root.appendChild(c.row);
+
+    expect(siblingOrderingForRow(b.row)).toEqual({ beforeId: '3', afterId: '1' });
+  });
+
+  test('empty ids at the boundaries', () => {
+    const a = makeRow(1);
+    root.appendChild(a.row);
+    expect(siblingOrderingForRow(a.row)).toEqual({ beforeId: '', afterId: '' });
+  });
+});
+
+describe('treeContainerElement', () => {
+  test('returns the row parent when the tree has a wrapping row', () => {
+    const { row, tree } = makeRow(1);
+    root.appendChild(row);
+    expect(treeContainerElement(tree)).toBe(root);
+  });
+
+  test('returns null for nullish tree', () => {
+    expect(treeContainerElement(null)).toBeNull();
+  });
+});
+
+describe('nodeAfterTreeBlock', () => {
+  test('returns the next row when there is no children container', () => {
+    const a = makeRow(1);
+    const b = makeRow(2);
+    root.appendChild(a.row);
+    root.appendChild(b.row);
+    expect(nodeAfterTreeBlock(a.tree)).toBe(b.row);
+  });
+
+  test('skips the tree\'s own children container to the node after it', () => {
+    const a = makeRow(1);
+    const b = makeRow(2);
+    const children = makeChildrenContainer(1);
+    root.appendChild(a.row);
+    root.appendChild(children);
+    root.appendChild(b.row);
+    expect(nodeAfterTreeBlock(a.tree)).toBe(b.row);
+  });
+});
+
+describe('normalizeRowNode', () => {
+  test('returns the row unchanged', () => {
+    const { row } = makeRow(1);
+    expect(normalizeRowNode(row)).toBe(row);
+  });
+
+  test('maps a .creative-tree node to its wrapping row', () => {
+    const { row, tree } = makeRow(1);
+    expect(normalizeRowNode(tree)).toBe(row);
+  });
+
+  test('returns nullish input as null', () => {
+    expect(normalizeRowNode(null)).toBeNull();
+  });
+});
+
+describe('childrenContainerForTree', () => {
+  test('finds the container by id', () => {
+    const { row, tree } = makeRow(1);
+    const children = makeChildrenContainer(1);
+    root.appendChild(row);
+    root.appendChild(children);
+    expect(childrenContainerForTree(tree)).toBe(children);
+  });
+
+  test('finds the container as a following sibling of the row', () => {
+    const { row, tree } = makeRow(5);
+    const children = document.createElement('div');
+    children.className = 'creative-children'; // no matching id
+    root.appendChild(row);
+    root.appendChild(children);
+    expect(childrenContainerForTree(tree)).toBe(children);
+  });
+
+  test('returns null when no container exists', () => {
+    const { row, tree } = makeRow(9);
+    root.appendChild(row);
+    expect(childrenContainerForTree(tree)).toBeNull();
+  });
+});
+
+describe('ensureChildrenContainer', () => {
+  test('reuses an existing container', () => {
+    const { row, tree } = makeRow(1);
+    const existing = makeChildrenContainer(1);
+    root.appendChild(row);
+    root.appendChild(existing);
+    expect(ensureChildrenContainer(tree)).toBe(existing);
+  });
+
+  test('creates a container with child level (+1) load url and inserts after the row', () => {
+    const { row, tree } = makeRow(3, { level: 2 });
+    root.appendChild(row);
+
+    const created = ensureChildrenContainer(tree);
+
+    expect(created).not.toBeNull();
+    expect(created.id).toBe('creative-children-3');
+    expect(created.classList.contains('creative-children')).toBe(true);
+    expect(created.dataset.expanded).toBe('true');
+    // level+1 = 3, select_mode 0
+    expect(created.dataset.loadUrl).toBe('/creatives/3/children?level=3&select_mode=0');
+    // inserted into the row's parent, right after the row
+    expect(created.previousElementSibling).toBe(row);
+  });
+
+  test('returns null when the tree has no id', () => {
+    const tree = document.createElement('div');
+    tree.className = 'creative-tree';
+    root.appendChild(tree);
+    expect(ensureChildrenContainer(tree)).toBeNull();
+  });
+});
+
+describe('expandChildrenContainer', () => {
+  test('clears display and marks expanded', () => {
+    const c = makeChildrenContainer(1);
+    c.style.display = 'none';
+    expandChildrenContainer(c);
+    expect(c.style.display).toBe('');
+    expect(c.dataset.expanded).toBe('true');
+  });
+
+  test('no-ops on nullish container', () => {
+    expect(() => expandChildrenContainer(null)).not.toThrow();
+  });
+});
+
+describe('moveTreeBlock', () => {
+  test('moves the row and its children container into the target (append)', () => {
+    const src = makeRow(1);
+    const children = makeChildrenContainer(1);
+    const targetParent = makeChildrenContainer(99);
+    root.appendChild(src.row);
+    root.appendChild(children);
+    root.appendChild(targetParent);
+
+    moveTreeBlock(src.tree, targetParent);
+
+    expect(src.row.parentNode).toBe(targetParent);
+    expect(children.parentNode).toBe(targetParent);
+    // row moved before its children container (append order preserved)
+    expect([...targetParent.children]).toEqual([src.row, children]);
+  });
+
+  test('inserts before a reference node', () => {
+    const src = makeRow(1);
+    const ref = makeRow(2);
+    const targetParent = makeChildrenContainer(99);
+    // Keep src.row's next sibling from being a .creative-children, otherwise
+    // childrenContainerForTree's sibling fallback would treat targetParent as
+    // src's own children container (covered separately above).
+    const srcHolder = document.createElement('div');
+    srcHolder.appendChild(src.row);
+    root.appendChild(srcHolder);
+    targetParent.appendChild(ref.row);
+    root.appendChild(targetParent);
+
+    moveTreeBlock(src.tree, targetParent, ref.row);
+
+    expect([...targetParent.children]).toEqual([src.row, ref.row]);
+  });
+
+  test('no-ops without a target', () => {
+    const src = makeRow(1);
+    root.appendChild(src.row);
+    expect(() => moveTreeBlock(src.tree, null)).not.toThrow();
+  });
+});
+
+describe('listAllTreeNodes', () => {
+  test('returns all .creative-tree under #creatives in document order', () => {
+    const a = makeRow(1);
+    const b = makeRow(2);
+    root.appendChild(a.row);
+    root.appendChild(b.row);
+    expect(listAllTreeNodes()).toEqual([a.tree, b.tree]);
+  });
+});
+
+describe('getTreeLevel', () => {
+  test('reads data-level when present and positive', () => {
+    const { tree } = makeRow(1, { level: 4 });
+    expect(getTreeLevel(tree)).toBe(4);
+  });
+
+  test('falls back to the wrapping row level attribute when data-level absent', () => {
+    const { row, tree } = makeRow(1, { level: 3 });
+    delete tree.dataset.level;
+    root.appendChild(row);
+    expect(getTreeLevel(tree)).toBe(3);
+  });
+
+  test('defaults to 1 for nullish tree', () => {
+    expect(getTreeLevel(null)).toBe(1);
+  });
+});
+
+describe('findPreviousTree', () => {
+  // #creatives: row1(L1), [children-1: row11(L2)], row2(L1)
+  function buildNested() {
+    const one = makeRow(1, { level: 1 });
+    const children1 = makeChildrenContainer(1);
+    const eleven = makeRow(11, { parentId: '1', level: 2 });
+    children1.appendChild(eleven.row);
+    const two = makeRow(2, { level: 1 });
+    root.appendChild(one.row);
+    root.appendChild(children1);
+    root.appendChild(two.row);
+    return { one, eleven, two };
+  }
+
+  test('returns the nearest previous tree at the same level', () => {
+    const { one, two } = buildNested();
+    expect(findPreviousTree(two.tree)).toBe(one.tree);
+  });
+
+  test('returns null when the previous tree is at a shallower level', () => {
+    const { eleven } = buildNested();
+    // eleven (L2) is preceded only by one (L1) which is shallower -> null
+    expect(findPreviousTree(eleven.tree)).toBeNull();
+  });
+
+  test('returns null for the first tree', () => {
+    const { one } = buildNested();
+    expect(findPreviousTree(one.tree)).toBeNull();
+  });
+});
+
+describe('updateTreeLevels / setTreeLevel', () => {
+  test('updateTreeLevels applies delta to the tree and its child rows recursively', () => {
+    const parent = makeRow(1, { level: 1 });
+    const children = makeChildrenContainer(1);
+    const child = makeRow(11, { parentId: '1', level: 2 });
+    children.appendChild(child.row);
+    root.appendChild(parent.row);
+    root.appendChild(children);
+
+    updateTreeLevels(parent.tree, 1);
+
+    expect(parent.tree.dataset.level).toBe('2');
+    expect(parent.row.getAttribute('level')).toBe('2');
+    expect(child.tree.dataset.level).toBe('3');
+    expect(child.row.getAttribute('level')).toBe('3');
+  });
+
+  test('updateTreeLevels floors the level at 1', () => {
+    const { tree, row } = makeRow(1, { level: 1 });
+    root.appendChild(row);
+    updateTreeLevels(tree, -5);
+    expect(tree.dataset.level).toBe('1');
+  });
+
+  test('setTreeLevel computes the delta to reach the target level', () => {
+    const { tree, row } = makeRow(1, { level: 2 });
+    root.appendChild(row);
+    setTreeLevel(tree, 4);
+    expect(tree.dataset.level).toBe('4');
+  });
+
+  test('setTreeLevel is a no-op when already at the target', () => {
+    const { tree, row } = makeRow(1, { level: 2 });
+    root.appendChild(row);
+    setTreeLevel(tree, 2);
+    expect(tree.dataset.level).toBe('2');
+  });
+});
+
+describe('removeTreeElement', () => {
+  test('removes the wrapping row', () => {
+    const { row, tree } = makeRow(1);
+    root.appendChild(row);
+    removeTreeElement(tree);
+    expect(root.querySelector('creative-tree-row')).toBeNull();
+  });
+
+  test('no-ops on nullish tree', () => {
+    expect(() => removeTreeElement(null)).not.toThrow();
+  });
+});

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -17,10 +17,28 @@ import {
   hasDatasetValue,
   setRowDatasetValue,
   isMarkdownEmpty,
-  buildChildrenLoadUrl,
   readRowLevel,
   editorPaddingForLevel,
 } from './creative_row_editor_helpers'
+import {
+  creativeTreeElement,
+  creativeIdFrom,
+  siblingTreeRow,
+  siblingOrderingForRow,
+  treeContainerElement,
+  nodeAfterTreeBlock,
+  normalizeRowNode,
+  childrenContainerForTree,
+  ensureChildrenContainer,
+  expandChildrenContainer,
+  moveTreeBlock,
+  listAllTreeNodes,
+  findPreviousTree,
+  getTreeLevel,
+  updateTreeLevels,
+  setTreeLevel,
+  removeTreeElement,
+} from './creative_tree_dom'
 // Import Stimulus application from the global window (set by host app)
 const application = window.Stimulus
 
@@ -438,212 +456,6 @@ export function initializeCreativeRowEditor() {
       }
     }
 
-    function siblingTreeRow(row, direction) {
-      if (!row) return null;
-      const step = direction === 'previous' ? 'previousSibling' : 'nextSibling';
-      let node = row[step];
-      while (node) {
-        if (node.nodeType === Node.TEXT_NODE) {
-          node = node[step];
-          continue;
-        }
-        if (node.matches?.('creative-tree-row')) return node;
-        if (node.classList?.contains?.('creative-children')) {
-          node = node[step];
-          continue;
-        }
-        node = node[step];
-      }
-      return null;
-    }
-
-    function siblingOrderingForRow(row) {
-      const beforeRow = siblingTreeRow(row, 'next');
-      const afterRow = siblingTreeRow(row, 'previous');
-      return {
-        beforeId: beforeRow ? creativeIdFrom(beforeRow) : '',
-        afterId: afterRow ? creativeIdFrom(afterRow) : ''
-      };
-    }
-
-    function treeContainerElement(tree) {
-      if (!tree) return null;
-      const row = treeRowElement(tree);
-      if (row && row.parentNode) return row.parentNode;
-      return tree.parentNode;
-    }
-
-    function nodeAfterTreeBlock(tree) {
-      if (!tree) return null;
-      const row = treeRowElement(tree);
-      if (!row) return tree.nextSibling;
-      let node = row.nextSibling;
-      while (node && node.nodeType === Node.TEXT_NODE) node = node.nextSibling;
-      const treeId = tree.dataset?.id;
-      if (treeId) {
-        const childrenContainer = document.getElementById(`creative-children-${treeId}`);
-        if (childrenContainer && childrenContainer.parentNode === row.parentNode && node === childrenContainer) {
-          node = childrenContainer.nextSibling;
-          while (node && node.nodeType === Node.TEXT_NODE) node = node.nextSibling;
-        }
-      }
-      return node;
-    }
-
-    function normalizeRowNode(node) {
-      if (!node) return null;
-      if (node.matches && node.matches('creative-tree-row')) return node;
-      if (node.classList && node.classList.contains('creative-tree')) {
-        const row = treeRowElement(node);
-        return row || node;
-      }
-      return node;
-    }
-
-    function childrenContainerForTree(tree) {
-      if (!tree) return null;
-      const treeId = tree.dataset?.id;
-      if (treeId) {
-        const byId = document.getElementById(`creative-children-${treeId}`);
-        if (byId) return byId;
-      }
-      if (tree.children && tree.children.length > 0) {
-        for (const child of tree.children) {
-          if (child && child.classList && child.classList.contains('creative-children')) {
-            return child;
-          }
-        }
-      }
-      const row = treeRowElement(tree);
-      if (row) {
-        let sibling = row.nextElementSibling;
-        while (sibling) {
-          if (sibling.matches?.('creative-tree-row')) break;
-          if (sibling.classList?.contains('creative-children')) return sibling;
-          sibling = sibling.nextElementSibling;
-        }
-      }
-      return null;
-    }
-
-    function ensureChildrenContainer(tree) {
-      if (!tree) return null;
-      let container = childrenContainerForTree(tree);
-      if (container) return container;
-      const parentId = tree.dataset?.id;
-      if (!parentId) return null;
-      container = document.createElement('div');
-      container.className = 'creative-children';
-      container.id = `creative-children-${parentId}`;
-      const parentRow = treeRowElement(tree);
-      const parentLevel = readRowLevel(parentRow) || 1;
-      const childLevel = parentLevel + 1;
-      const selectModeActive = parentRow?.hasAttribute?.('select-mode') ? 1 : 0;
-      container.dataset.loadUrl = buildChildrenLoadUrl(parentId, childLevel, selectModeActive);
-      container.dataset.expanded = 'true';
-      if (container.dataset.loaded) delete container.dataset.loaded;
-      const row = treeRowElement(tree);
-      const parentContainer = row?.parentNode || tree.parentNode;
-      if (parentContainer) {
-        const afterRow = row?.nextSibling;
-        if (afterRow) {
-          parentContainer.insertBefore(container, afterRow);
-        } else {
-          parentContainer.appendChild(container);
-        }
-      } else {
-        tree.appendChild(container);
-      }
-      return container;
-    }
-
-    function expandChildrenContainer(container) {
-      if (!container) return;
-      container.style.display = '';
-      if (container.dataset) {
-        container.dataset.expanded = 'true';
-      }
-    }
-
-    function moveTreeBlock(tree, targetContainer, referenceNode = null) {
-      if (!tree || !targetContainer) return;
-      const row = treeRowElement(tree);
-      if (!row) return;
-      const nodesToMove = [row];
-      const childContainer = childrenContainerForTree(tree);
-      if (childContainer) nodesToMove.push(childContainer);
-      nodesToMove.forEach((node) => {
-        if (!node) return;
-        if (referenceNode) {
-          targetContainer.insertBefore(node, referenceNode);
-        } else {
-          targetContainer.appendChild(node);
-        }
-      });
-    }
-
-    function listAllTreeNodes() {
-      const root = document.getElementById('creatives');
-      if (root) return Array.from(root.querySelectorAll('.creative-tree'));
-      return Array.from(document.querySelectorAll('.creative-tree'));
-    }
-
-    function findPreviousTree(tree) {
-      if (!tree) return null;
-      const nodes = listAllTreeNodes();
-      const index = nodes.indexOf(tree);
-      if (index <= 0) return null;
-      const currentLevel = getTreeLevel(tree);
-      for (let i = index - 1; i >= 0; i--) {
-        const candidate = nodes[i];
-        if (!candidate) continue;
-        const candidateLevel = getTreeLevel(candidate);
-        if (candidateLevel === currentLevel) return candidate;
-        if (candidateLevel < currentLevel) return null;
-      }
-      return null;
-    }
-
-    function getTreeLevel(tree) {
-      if (!tree) return 1;
-      const levelValue = Number(tree.dataset?.level);
-      if (!Number.isNaN(levelValue) && levelValue > 0) {
-        return levelValue;
-      }
-      const row = treeRowElement(tree);
-      return readRowLevel(row) || 1;
-    }
-
-    function updateTreeLevels(tree, delta) {
-      if (!tree || !delta) return;
-      const currentLevel = Number(tree.dataset?.level) || 1;
-      const nextLevel = Math.max(1, currentLevel + delta);
-      tree.dataset.level = String(nextLevel);
-      const row = treeRowElement(tree);
-      if (row) {
-        row.setAttribute('level', nextLevel);
-        row.level = nextLevel;
-        row.requestUpdate?.();
-      }
-      const container = childrenContainerForTree(tree);
-      if (!container) return;
-      Array.from(container.children || []).forEach((childRow) => {
-        if (!childRow.matches?.('creative-tree-row')) return;
-        const childTree = childRow.querySelector('.creative-tree');
-        if (childTree) {
-          updateTreeLevels(childTree, delta);
-        }
-      });
-    }
-
-    function setTreeLevel(tree, targetLevel) {
-      if (!tree || typeof targetLevel !== 'number') return;
-      const currentLevel = Number(tree.dataset?.level) || 1;
-      const delta = targetLevel - currentLevel;
-      if (delta === 0) return;
-      updateTreeLevels(tree, delta);
-    }
-
     function updateParentChildrenState(parentId) {
       if (!parentId) return;
       const parentTree = document.getElementById(`creative-${parentId}`);
@@ -701,16 +513,6 @@ export function initializeCreativeRowEditor() {
       }
       const paddingValue = editorPaddingForLevel(level);
       template.style.paddingLeft = paddingValue;
-    }
-
-    function removeTreeElement(tree) {
-      if (!tree) return;
-      const row = treeRowElement(tree);
-      if (row) {
-        row.remove();
-      } else if (tree.remove) {
-        tree.remove();
-      }
     }
 
     function getUploadCompletion() {
@@ -957,27 +759,6 @@ export function initializeCreativeRowEditor() {
     function showRow(tree) {
       const row = tree.querySelector('.creative-row');
       if (row) row.style.display = '';
-    }
-
-    function creativeTreeElement(node) {
-      if (!node) return null;
-      if (node.classList && node.classList.contains('creative-tree')) return node;
-      if (node.querySelector) {
-        const inner = node.querySelector('.creative-tree');
-        if (inner) return inner;
-      }
-      return null;
-    }
-
-    function creativeIdFrom(node) {
-      const treeEl = creativeTreeElement(node);
-      if (treeEl && treeEl.dataset) {
-        return treeEl.dataset.id || '';
-      }
-      if (node?.getAttribute) {
-        return node.getAttribute('creative-id') || node.getAttribute('data-id') || '';
-      }
-      return '';
     }
 
     function insertRow(tree, data) {

--- a/engines/collavre/app/javascript/modules/creative_tree_dom.js
+++ b/engines/collavre/app/javascript/modules/creative_tree_dom.js
@@ -1,0 +1,260 @@
+// Tree-DOM navigation & geometry helpers extracted from creative_row_editor.js.
+//
+// This is slice 2 of the creative_row_editor god-file decomposition (slice 1 was
+// the save-queue single-flight/debounce cluster, already in creative_save_queue.js).
+//
+// Every function here operates purely on the DOM nodes passed as arguments (plus
+// `document` for id/selector lookups) — none captures the editor closure's shared
+// state (currentTree, form, parentInput, isDirty, pendingSave, uploadsPending, …).
+// That is exactly why this cluster is a clean seam: it can be lifted out and unit
+// tested against a jsdom fixture without standing up the whole inline editor.
+//
+// The cluster underpins the structural-move paths (levelUp / levelDown / addNew /
+// move) that compute a node's parent, its before/after siblings, and its indent
+// level — the inputs to the recurring "parentId loss / wrong ordering" bug class.
+// Pinning them with characterization tests raises the floor under those moves.
+//
+// NOTE ON BINDING HAZARDS: none of these functions use setTimeout / setInterval /
+// requestAnimationFrame / queueMicrotask, and none rely on `this`. They are plain
+// functions invoked by name, so the "Illegal invocation" class of real-browser
+// regression (a prior timer-extraction bug that jsdom could not catch) does not
+// apply here. The only DOM writes are element mutations (insertBefore, appendChild,
+// setAttribute, dataset, style, requestUpdate) invoked on the passed nodes.
+import { treeRowElement, readRowLevel, buildChildrenLoadUrl } from './creative_row_editor_helpers';
+
+export function creativeTreeElement(node) {
+  if (!node) return null;
+  if (node.classList && node.classList.contains('creative-tree')) return node;
+  if (node.querySelector) {
+    const inner = node.querySelector('.creative-tree');
+    if (inner) return inner;
+  }
+  return null;
+}
+
+export function creativeIdFrom(node) {
+  const treeEl = creativeTreeElement(node);
+  if (treeEl && treeEl.dataset) {
+    return treeEl.dataset.id || '';
+  }
+  if (node?.getAttribute) {
+    return node.getAttribute('creative-id') || node.getAttribute('data-id') || '';
+  }
+  return '';
+}
+
+export function siblingTreeRow(row, direction) {
+  if (!row) return null;
+  const step = direction === 'previous' ? 'previousSibling' : 'nextSibling';
+  let node = row[step];
+  while (node) {
+    if (node.nodeType === Node.TEXT_NODE) {
+      node = node[step];
+      continue;
+    }
+    if (node.matches?.('creative-tree-row')) return node;
+    if (node.classList?.contains?.('creative-children')) {
+      node = node[step];
+      continue;
+    }
+    node = node[step];
+  }
+  return null;
+}
+
+export function siblingOrderingForRow(row) {
+  const beforeRow = siblingTreeRow(row, 'next');
+  const afterRow = siblingTreeRow(row, 'previous');
+  return {
+    beforeId: beforeRow ? creativeIdFrom(beforeRow) : '',
+    afterId: afterRow ? creativeIdFrom(afterRow) : ''
+  };
+}
+
+export function treeContainerElement(tree) {
+  if (!tree) return null;
+  const row = treeRowElement(tree);
+  if (row && row.parentNode) return row.parentNode;
+  return tree.parentNode;
+}
+
+export function nodeAfterTreeBlock(tree) {
+  if (!tree) return null;
+  const row = treeRowElement(tree);
+  if (!row) return tree.nextSibling;
+  let node = row.nextSibling;
+  while (node && node.nodeType === Node.TEXT_NODE) node = node.nextSibling;
+  const treeId = tree.dataset?.id;
+  if (treeId) {
+    const childrenContainer = document.getElementById(`creative-children-${treeId}`);
+    if (childrenContainer && childrenContainer.parentNode === row.parentNode && node === childrenContainer) {
+      node = childrenContainer.nextSibling;
+      while (node && node.nodeType === Node.TEXT_NODE) node = node.nextSibling;
+    }
+  }
+  return node;
+}
+
+export function normalizeRowNode(node) {
+  if (!node) return null;
+  if (node.matches && node.matches('creative-tree-row')) return node;
+  if (node.classList && node.classList.contains('creative-tree')) {
+    const row = treeRowElement(node);
+    return row || node;
+  }
+  return node;
+}
+
+export function childrenContainerForTree(tree) {
+  if (!tree) return null;
+  const treeId = tree.dataset?.id;
+  if (treeId) {
+    const byId = document.getElementById(`creative-children-${treeId}`);
+    if (byId) return byId;
+  }
+  if (tree.children && tree.children.length > 0) {
+    for (const child of tree.children) {
+      if (child && child.classList && child.classList.contains('creative-children')) {
+        return child;
+      }
+    }
+  }
+  const row = treeRowElement(tree);
+  if (row) {
+    let sibling = row.nextElementSibling;
+    while (sibling) {
+      if (sibling.matches?.('creative-tree-row')) break;
+      if (sibling.classList?.contains('creative-children')) return sibling;
+      sibling = sibling.nextElementSibling;
+    }
+  }
+  return null;
+}
+
+export function ensureChildrenContainer(tree) {
+  if (!tree) return null;
+  let container = childrenContainerForTree(tree);
+  if (container) return container;
+  const parentId = tree.dataset?.id;
+  if (!parentId) return null;
+  container = document.createElement('div');
+  container.className = 'creative-children';
+  container.id = `creative-children-${parentId}`;
+  const parentRow = treeRowElement(tree);
+  const parentLevel = readRowLevel(parentRow) || 1;
+  const childLevel = parentLevel + 1;
+  const selectModeActive = parentRow?.hasAttribute?.('select-mode') ? 1 : 0;
+  container.dataset.loadUrl = buildChildrenLoadUrl(parentId, childLevel, selectModeActive);
+  container.dataset.expanded = 'true';
+  if (container.dataset.loaded) delete container.dataset.loaded;
+  const row = treeRowElement(tree);
+  const parentContainer = row?.parentNode || tree.parentNode;
+  if (parentContainer) {
+    const afterRow = row?.nextSibling;
+    if (afterRow) {
+      parentContainer.insertBefore(container, afterRow);
+    } else {
+      parentContainer.appendChild(container);
+    }
+  } else {
+    tree.appendChild(container);
+  }
+  return container;
+}
+
+export function expandChildrenContainer(container) {
+  if (!container) return;
+  container.style.display = '';
+  if (container.dataset) {
+    container.dataset.expanded = 'true';
+  }
+}
+
+export function moveTreeBlock(tree, targetContainer, referenceNode = null) {
+  if (!tree || !targetContainer) return;
+  const row = treeRowElement(tree);
+  if (!row) return;
+  const nodesToMove = [row];
+  const childContainer = childrenContainerForTree(tree);
+  if (childContainer) nodesToMove.push(childContainer);
+  nodesToMove.forEach((node) => {
+    if (!node) return;
+    if (referenceNode) {
+      targetContainer.insertBefore(node, referenceNode);
+    } else {
+      targetContainer.appendChild(node);
+    }
+  });
+}
+
+export function listAllTreeNodes() {
+  const root = document.getElementById('creatives');
+  if (root) return Array.from(root.querySelectorAll('.creative-tree'));
+  return Array.from(document.querySelectorAll('.creative-tree'));
+}
+
+export function findPreviousTree(tree) {
+  if (!tree) return null;
+  const nodes = listAllTreeNodes();
+  const index = nodes.indexOf(tree);
+  if (index <= 0) return null;
+  const currentLevel = getTreeLevel(tree);
+  for (let i = index - 1; i >= 0; i--) {
+    const candidate = nodes[i];
+    if (!candidate) continue;
+    const candidateLevel = getTreeLevel(candidate);
+    if (candidateLevel === currentLevel) return candidate;
+    if (candidateLevel < currentLevel) return null;
+  }
+  return null;
+}
+
+export function getTreeLevel(tree) {
+  if (!tree) return 1;
+  const levelValue = Number(tree.dataset?.level);
+  if (!Number.isNaN(levelValue) && levelValue > 0) {
+    return levelValue;
+  }
+  const row = treeRowElement(tree);
+  return readRowLevel(row) || 1;
+}
+
+export function updateTreeLevels(tree, delta) {
+  if (!tree || !delta) return;
+  const currentLevel = Number(tree.dataset?.level) || 1;
+  const nextLevel = Math.max(1, currentLevel + delta);
+  tree.dataset.level = String(nextLevel);
+  const row = treeRowElement(tree);
+  if (row) {
+    row.setAttribute('level', nextLevel);
+    row.level = nextLevel;
+    row.requestUpdate?.();
+  }
+  const container = childrenContainerForTree(tree);
+  if (!container) return;
+  Array.from(container.children || []).forEach((childRow) => {
+    if (!childRow.matches?.('creative-tree-row')) return;
+    const childTree = childRow.querySelector('.creative-tree');
+    if (childTree) {
+      updateTreeLevels(childTree, delta);
+    }
+  });
+}
+
+export function setTreeLevel(tree, targetLevel) {
+  if (!tree || typeof targetLevel !== 'number') return;
+  const currentLevel = Number(tree.dataset?.level) || 1;
+  const delta = targetLevel - currentLevel;
+  if (delta === 0) return;
+  updateTreeLevels(tree, delta);
+}
+
+export function removeTreeElement(tree) {
+  if (!tree) return;
+  const row = treeRowElement(tree);
+  if (row) {
+    row.remove();
+  } else if (tree.remove) {
+    tree.remove();
+  }
+}


### PR DESCRIPTION
## Summary

**Slice 2 of N** in decomposing the `creative_row_editor.js` god-file (originally 2,435-line single closure, ~65 nested functions, 43% fix ratio — the audit's worst rot core, dominated by save-queue race / parentId-loss fixes).

**Note on scope vs. the task's pick #1:** the task named the *save-queue / in-flight-request dedup* cluster as the first thing to extract. On inspection that cluster is **already extracted** — it lives in `creative_save_queue.js` as `CreativeSaveQueue` (single-flight + trailing debounce), and it already carries the "Illegal invocation" timer-binding lesson in its comments and a dedicated `creative_save_queue.test.js`. So this PR takes the **next-cleanest separable seam**.

## What was extracted

A cohesive 17-function **tree-DOM navigation / geometry** cluster → new `engines/collavre/app/javascript/modules/creative_tree_dom.js`:

`creativeTreeElement`, `creativeIdFrom`, `siblingTreeRow`, `siblingOrderingForRow`, `treeContainerElement`, `nodeAfterTreeBlock`, `normalizeRowNode`, `childrenContainerForTree`, `ensureChildrenContainer`, `expandChildrenContainer`, `moveTreeBlock`, `listAllTreeNodes`, `findPreviousTree`, `getTreeLevel`, `updateTreeLevels`, `setTreeLevel`, `removeTreeElement`.

## Why this cluster

- **Closure-state-free.** Every function operates purely on the DOM nodes passed as arguments (plus `document` lookups and the already-extracted row helpers). None captures `currentTree` / `form` / `parentInput` / `isDirty` / `pendingSave`, so it lifts out with **zero behavior change** and a small, mostly-pure public surface — satisfying the "small reviewable slice, don't drag in half the file" constraint.
- **Tied to the recurring bug class.** These functions compute a node's parent, its before/after siblings, and its indent level — the inputs to the structural-move paths (`levelUp` / `levelDown` / `addNew` / `move`) where the "parentId loss / wrong ordering" bugs keep recurring. Pinning them raises the floor under those moves.

## Characterization tests

`__tests__/creative_tree_dom.test.js` — **42 tests** against a jsdom fixture mirroring the real `creative-tree-row` → `.creative-tree` render with `.creative-children` sibling containers. They pin: sibling walking (skipping text nodes + `.creative-children`), the before/after id mapping, children-container resolution + creation (`level+1` load URL), block moves (append + insert-before), recursive level recomputation (floored at 1), and previous-tree lookup by matching level.

Process: the module was **copied verbatim first**, characterization tests confirmed green on the unchanged copy, **then** the closure was switched to import it (still green).

## Real-browser smoke flag

**Not required for this slice.** None of the extracted functions use `setTimeout` / `setInterval` / `requestAnimationFrame` / `queueMicrotask`, and none rely on `this` — they are plain functions invoked by name. The "Illegal invocation" class of jsdom-invisible regression (the prior timer-extraction hazard) therefore does not apply. The only DOM writes are element mutations (`insertBefore`/`appendChild`/`setAttribute`/`dataset`/`style`/`requestUpdate`) on the passed nodes.

## Verification

- Full jest suite: **574/574 green** (52 suites).
- esbuild bundle (`npm run build`): clean, exit 0.
- Diff: `+19 / -238` in the god-file (2,435 → 2,216 lines) + new module + tests.

## Deferred (not fixed here — behavior-preserving PR)

- `childrenContainerForTree`'s sibling fallback can, for a childless row that is *immediately followed by an unrelated row's* `.creative-children` container, mis-associate that container as the row's own (surfaced as a fixture artifact while writing tests). In the well-formed real render the id-keyed lookup wins first, so this is a pre-existing latent edge, not a regression — noted for a possible follow-up. **Not changed here.**
- `siblingOrderingForRow` maps `beforeId ← next sibling`, `afterId ← previous sibling` (reads inverted at a glance but is coherent with the server's positioning semantics). Documented in tests; **not changed.**

## Next slice

The remaining in-file save logic (`saveForm`/`performSave`, `queueSaveIfDirty`) is the direct home of the "capture form values before await" / parentId bug class, but it is deeply coupled to the closure's shared state (form inputs, dirty flags, markdown mode). A clean extraction there needs an intermediate seam first — likely a **payload-builder** (pure `buildSavePayload(...)` from captured values → request body, the part of `queueSaveIfDirty` after the capture point) as slice 3, so the capture-before-await logic can be pinned and tested in isolation before touching the request plumbing.