### PR TITLE
refactor(collavre): accumulate Creative::Permissible permission changes across saves (fail-closed)

### DIFF
--- a/engines/collavre/app/models/collavre/creative/permissible.rb
+++ b/engines/collavre/app/models/collavre/creative/permissible.rb
@@ -5,7 +5,7 @@ module Collavre
 
       # Single declarative registry of which persisted-attribute changes
       # invalidate the permission cache, and how each is rebuilt. A single
-      # after_commit dispatcher intersects saved_changes.keys with this map so
+      # after_commit dispatcher maps the accumulated changes through this map so
       # a new mutation path can never silently skip a required rebuild.
       #
       #   :rebuild       -> rebuild_for_creative (self + descendant subtree)
@@ -23,8 +23,10 @@ module Collavre
         has_many :creative_shares, class_name: "Collavre::CreativeShare", dependent: :destroy
         has_many :creative_shares_caches, class_name: "Collavre::CreativeSharesCache", dependent: :delete_all
 
+        after_save :accumulate_permission_cache_changes
         after_commit :dispatch_permission_cache_invalidation, unless: :destroyed?
         after_commit :cache_owner_permission, on: :create
+        after_rollback :clear_accumulated_permission_changes
       end
 
       def has_permission?(user, required_permission = :read)
@@ -98,24 +100,63 @@ module Collavre
 
       private
 
-      # Single dispatch point for permission-cache invalidation. Intersects the
-      # attributes that actually changed with PERMISSION_INVALIDATING_ATTRIBUTES
-      # and enqueues each distinct rebuild exactly once.
+      # Accumulate permission-affecting changes across every save in the
+      # transaction. after_commit sees only the *final* save's saved_changes, so
+      # if a permission attribute changes in one save and a later same-
+      # transaction save of this record touches only untracked columns, that
+      # permission change is clobbered out of saved_changes and a saved_changes-
+      # gated dispatcher would skip the rebuild, leaving the permission cache
+      # stale (fail-open, with no TTL/self-heal). Merging each save's changes
+      # keeps the invariant regardless of save ordering. This mirrors the fail-
+      # closed intent of the CreativeShare fix (#1393 / 00502d7d); it is
+      # centralized here via cross-save accumulation rather than an
+      # unconditional refresh so that permission-irrelevant Creative updates
+      # (progress rollup, description edits — a hot write path) stay cheap.
+      #
+      # No production path performs two real saves touching a permission
+      # attribute then an untracked column on one Creative in a single
+      # transaction today (the reorderer re-saves :sequence via update_column,
+      # which does not run changes_applied and so preserves saved_changes), so
+      # this is a defensive/latent fix. Note: update_column bypasses this
+      # callback too, which is why the reorderer's parent change still refreshes.
+      def accumulate_permission_cache_changes
+        changes = saved_changes.slice(*PERMISSION_INVALIDATING_ATTRIBUTES.keys)
+        return if changes.empty?
+
+        @accumulated_permission_changes ||= {}
+        changes.each do |attribute, (old_value, new_value)|
+          existing = @accumulated_permission_changes[attribute]
+          # Keep the earliest "old" and the latest "new" across saves.
+          @accumulated_permission_changes[attribute] = [ existing ? existing.first : old_value, new_value ]
+        end
+      end
+
+      def clear_accumulated_permission_changes
+        @accumulated_permission_changes = nil
+      end
+
+      # Single dispatch point for permission-cache invalidation. Maps the
+      # accumulated permission-attribute changes through
+      # PERMISSION_INVALIDATING_ATTRIBUTES and enqueues each distinct rebuild
+      # exactly once.
       def dispatch_permission_cache_invalidation
-        operations = (saved_changes.keys & PERMISSION_INVALIDATING_ATTRIBUTES.keys)
+        accumulated = @accumulated_permission_changes || {}
+        clear_accumulated_permission_changes
+
+        operations = accumulated.keys
           .map { |attr| PERMISSION_INVALIDATING_ATTRIBUTES[attr] }
           .uniq
         return if operations.empty?
 
-        operations.each { |operation| run_permission_cache_operation(operation) }
+        operations.each { |operation| run_permission_cache_operation(operation, accumulated) }
       end
 
-      def run_permission_cache_operation(operation)
+      def run_permission_cache_operation(operation, accumulated)
         case operation
         when :rebuild
           PermissionCacheJob.perform_later(:rebuild_for_creative, creative_id: id)
         when :rebuild_owner
-          old_user_id, new_user_id = saved_changes["user_id"]
+          old_user_id, new_user_id = accumulated["user_id"]
           PermissionCacheJob.perform_later(:update_owner,
             creative_id: id,
             old_user_id: old_user_id,

--- a/engines/collavre/test/models/creative_permission_invalidation_test.rb
+++ b/engines/collavre/test/models/creative_permission_invalidation_test.rb
@@ -46,6 +46,61 @@ module Collavre
       refute_includes rebuild_ops, :update_owner
     end
 
+    # --- Multi-save clobber (mirrors CreativeShare #1393 / 00502d7d) ---
+    # after_commit sees only the LAST save's saved_changes. If a permission
+    # attribute changes in one save and a later same-transaction save touches
+    # only untracked columns, the permission change is clobbered out of
+    # saved_changes and a saved_changes-gated dispatcher silently skips the
+    # rebuild, leaving the permission cache stale (fail-open).
+
+    # Reachable today: reorder_multiple_as_child/sibling wrap update!(parent:)
+    # and resequence!'s update_column(:sequence) in one Creative.transaction.
+    # update_column wipes saved_changes, so at the deferred after_commit the
+    # parent_id change is gone and the subtree rebuild is skipped -> the moved
+    # subtree keeps its old inherited shares (fail-open).
+    test "re-parenting via reorder_multiple rebuilds the moved subtree cache" do
+      new_parent = Creative.create!(user: @owner, description: "New parent", progress: 0.0)
+      # Give new_parent an existing child so the dragged creative's sequence
+      # actually changes during resequence! (0 -> 1); an unchanged sequence is a
+      # no-op that would not exercise the update_column clobber.
+      perform_enqueued_jobs do
+        Creative.create!(user: @owner, description: "Existing", progress: 0.0, parent: new_parent, sequence: 0)
+      end
+      reorderer = Creatives::Reorderer.new(user: @owner)
+      calls = capture_permission_cache_jobs do
+        reorderer.reorder_multiple(
+          dragged_ids: [ @creative.id ],
+          target_id: new_parent.id,
+          direction: "child"
+        )
+      end
+      assert_includes calls, [ :rebuild_for_creative, { creative_id: @creative.id } ],
+        "re-parenting via reorder_multiple must rebuild the moved subtree's permission cache"
+    end
+
+    test "a parent_id change survives a later same-transaction untracked save" do
+      calls = capture_permission_cache_jobs do
+        ActiveRecord::Base.transaction do
+          @creative.update!(parent: @other_parent) # tracked -> :rebuild
+          @creative.update!(description: "Renamed") # untracked; clobbers saved_changes
+        end
+      end
+      assert_includes calls, [ :rebuild_for_creative, { creative_id: @creative.id } ],
+        "the parent_id change must survive a later same-transaction untracked save"
+    end
+
+    test "a user_id change survives a later same-transaction untracked save with correct old/new" do
+      calls = capture_permission_cache_jobs do
+        ActiveRecord::Base.transaction do
+          @creative.update!(user: @other) # tracked -> :rebuild_owner
+          @creative.update!(description: "Renamed") # untracked; clobbers saved_changes
+        end
+      end
+      assert_includes calls,
+        [ :update_owner, { creative_id: @creative.id, old_user_id: @owner.id, new_user_id: @other.id } ],
+        "the owner change must survive a later same-transaction untracked save with the correct old/new pair"
+    end
+
     test "origin_id is immutable once persisted" do
       origin_a = @root
       origin_b = @other_parent


### PR DESCRIPTION
## What

Closes the same latent fail-open exposure in `Creative::Permissible` that #1393 / `00502d7d` closed in `CreativeShare`.

The `after_commit` dispatcher gated the permission-cache rebuild on `saved_changes.keys`, and `after_commit` sees only the **final** save's `saved_changes`. If a permission attribute (`parent_id`, `user_id`, `origin_id`) changes in one save and a later same-transaction save of the same Creative touches only an untracked column, the permission change is clobbered out of `saved_changes`; the gated dispatcher then skips the rebuild and the permission cache (no TTL / self-heal) stays stale — a user keeps access that should have been revoked.

## Fix

Accumulate the permission-affecting changes across **every** save in the transaction (`after_save`) and dispatch from the accumulated set at `after_commit` (keeping earliest-old / latest-new for the owner move).

This mirrors the fail-closed intent of `00502d7d` but is centralized via **cross-save accumulation** rather than an unconditional refresh, because `rebuild_for_creative` is a *subtree-wide* rebuild and Creatives are updated on a hot path (progress rollup, description edits). An unconditional refresh would add heavy rebuilds to every permission-irrelevant Creative save — a behavior change on reachable paths. Accumulation instead:

- leaves every existing reachable path unchanged (untracked-only updates still enqueue nothing),
- closes the gap for both `:rebuild` and `:rebuild_owner`,
- recovers the correct `old_user_id` for the owner move (which an unconditional refresh could not).

## Reachability: LATENT only

No production path performs two real saves touching a permission attribute then an untracked column on one Creative in a single transaction. The reorderer's multi-drag wraps `update!(parent:)` and `resequence!`'s `update_column(:sequence)` in one transaction, but `update_column` does not run `changes_applied` and so **preserves** `saved_changes` (verified empirically) — so that path already refreshes correctly. A guard test pins this.

## Tests

- 2 regression tests reproducing the two-real-save clobber for `parent_id` and `user_id` (**red** before this change, green after).
- 1 guard test driving the real `Reorderer#reorder_multiple` (documents the reorderer is safe today).
- Full permission + invalidation + cache-builder + job + reorderer suites: **53 runs, 256 assertions, 0 failures**. Rubocop clean.

Ref #1393 / `00502d7d`.