### PR TITLE
refactor(collavre): unify CreativeShare stale-cache delete timing to async (rot ②a)

### DIFF
--- a/engines/collavre/app/jobs/collavre/permission_cache_job.rb
+++ b/engines/collavre/app/jobs/collavre/permission_cache_job.rb
@@ -19,11 +19,9 @@ class PermissionCacheJob < ApplicationJob
     when :rebuild_for_creative
       rebuild_for_creative(args[:creative_id])
     when :propagate_share
-      propagate_share(args[:creative_share_id])
+      propagate_share(args[:creative_share_id], purge_stale: args.fetch(:purge_stale, false))
     when :remove_share
       remove_share(args[:creative_share_id], args[:creative_id], args[:user_id])
-    when :purge_share_cache
-      purge_share_cache(args[:creative_share_id])
     when :rebuild_user_cache_for_subtree
       rebuild_user_cache_for_subtree(args[:creative_id], args[:user_id])
     else
@@ -51,7 +49,18 @@ class PermissionCacheJob < ApplicationJob
     Creatives::PermissionCacheBuilder.rebuild_for_creative(creative)
   end
 
-  def propagate_share(creative_share_id)
+  def propagate_share(creative_share_id, purge_stale: false)
+    # A relocated/reassigned share leaves stale cache rows keyed to it at the old
+    # location. When asked, delete them here — in this same job, immediately
+    # before re-propagating — never as a separate job. Both the purge and the
+    # propagate key on source_share_id, and the authz queue runs two threads, so
+    # a standalone purge could execute AFTER propagate and delete the rows it
+    # just wrote, leaving the share with no cache until an unrelated rebuild.
+    # Folding the purge in guarantees purge-before-propagate ordering while
+    # keeping the work off the commit path (the async, prolonged-grant window the
+    # CTO accepted is preserved). Purge runs before the find_by so it still fires
+    # even if the share was destroyed after enqueue.
+    purge_share_cache(creative_share_id) if purge_stale
     share = CreativeShare.find_by(id: creative_share_id)
     return unless share
     Creatives::PermissionCacheBuilder.propagate_share(share)
@@ -64,9 +73,9 @@ class PermissionCacheJob < ApplicationJob
     Creatives::PermissionCacheBuilder.rebuild_from_ancestors_for_user(creative, user_id)
   end
 
-  # Purge the stale cache rows a relocated/reassigned share left behind. Mirrors
-  # the delete_all in remove_share, but as its own operation for the update path
-  # so the same purge no longer runs synchronously inside the after_commit.
+  # Purge the stale cache rows a relocated/reassigned share left behind. Only
+  # ever called from propagate_share (never enqueued standalone) so the delete
+  # cannot race the re-propagation on a separate authz-queue thread.
   def purge_share_cache(creative_share_id)
     CreativeSharesCache.where(source_share_id: creative_share_id).delete_all
   end

--- a/engines/collavre/app/jobs/collavre/permission_cache_job.rb
+++ b/engines/collavre/app/jobs/collavre/permission_cache_job.rb
@@ -22,6 +22,8 @@ class PermissionCacheJob < ApplicationJob
       propagate_share(args[:creative_share_id])
     when :remove_share
       remove_share(args[:creative_share_id], args[:creative_id], args[:user_id])
+    when :purge_share_cache
+      purge_share_cache(args[:creative_share_id])
     when :rebuild_user_cache_for_subtree
       rebuild_user_cache_for_subtree(args[:creative_id], args[:user_id])
     else
@@ -60,6 +62,13 @@ class PermissionCacheJob < ApplicationJob
     creative = Creative.find_by(id: creative_id)
     return unless creative
     Creatives::PermissionCacheBuilder.rebuild_from_ancestors_for_user(creative, user_id)
+  end
+
+  # Purge the stale cache rows a relocated/reassigned share left behind. Mirrors
+  # the delete_all in remove_share, but as its own operation for the update path
+  # so the same purge no longer runs synchronously inside the after_commit.
+  def purge_share_cache(creative_share_id)
+    CreativeSharesCache.where(source_share_id: creative_share_id).delete_all
   end
 
   def rebuild_user_cache_for_subtree(creative_id, user_id)

--- a/engines/collavre/app/models/collavre/creative_share.rb
+++ b/engines/collavre/app/models/collavre/creative_share.rb
@@ -118,7 +118,9 @@ module Collavre
     # fail-closed refresh matching the prior propagate_cache, correct even when
     # a multi-save transaction clobbers an earlier permission change out of the
     # final saved_changes. On an update, a move (creative_id) or reassignment
-    # (user_id) additionally purges the stale rows this share left behind.
+    # (user_id) additionally purges the stale rows this share left behind — now
+    # enqueued on the job queue (like the destroy path) rather than deleted
+    # synchronously, so timing is uniform and the purge no longer blocks commit.
     def dispatch_share_cache_invalidation
       unless previously_new_record?
         operations = (saved_changes.keys & PERMISSION_INVALIDATING_ATTRIBUTES.keys)
@@ -126,11 +128,18 @@ module Collavre
           .uniq
 
         # A move (creative_id) or reassignment (user_id) leaves stale rows keyed
-        # to this share. Purge them synchronously — a prompt, fail-closed revoke
-        # of the vacated access — then rebuild the vacated subtree. creative_id
+        # to this share. Purge them asynchronously via the job queue — the same
+        # in-job delete_all the destroy path already uses (remove_share), so all
+        # invalidation timing is uniform and the large-subtree purge no longer
+        # blocks the commit. In production the revoke of the vacated access is
+        # deferred by the queue latency (~1-2s); under the inline/test adapters
+        # it still runs at commit, so final-state tests stay behavior-preserving.
+        # This only PROLONGS an already-granted permission by that window; it
+        # never grants a brand-new permission, which the CTO judged acceptable in
+        # favor of the perf win. Then rebuild the vacated subtree. creative_id
         # takes precedence when both change, preserving the prior branch order.
         if operations.include?(:relocate) || operations.include?(:reassign)
-          CreativeSharesCache.where(source_share_id: id).delete_all
+          PermissionCacheJob.perform_later(:purge_share_cache, creative_share_id: id)
           rebuild_vacated_subtree(relocated: operations.include?(:relocate))
         end
       end

--- a/engines/collavre/app/models/collavre/creative_share.rb
+++ b/engines/collavre/app/models/collavre/creative_share.rb
@@ -118,33 +118,37 @@ module Collavre
     # fail-closed refresh matching the prior propagate_cache, correct even when
     # a multi-save transaction clobbers an earlier permission change out of the
     # final saved_changes. On an update, a move (creative_id) or reassignment
-    # (user_id) additionally purges the stale rows this share left behind — now
-    # enqueued on the job queue (like the destroy path) rather than deleted
-    # synchronously, so timing is uniform and the purge no longer blocks commit.
+    # (user_id) additionally purges the stale rows this share left behind — the
+    # purge is carried on the same propagate_share job (purge_stale:) rather than
+    # deleted synchronously, so timing is uniform and it no longer blocks commit.
     def dispatch_share_cache_invalidation
+      propagate_args = { creative_share_id: id }
+
       unless previously_new_record?
         operations = (saved_changes.keys & PERMISSION_INVALIDATING_ATTRIBUTES.keys)
           .map { |attr| PERMISSION_INVALIDATING_ATTRIBUTES[attr] }
           .uniq
 
         # A move (creative_id) or reassignment (user_id) leaves stale rows keyed
-        # to this share. Purge them asynchronously via the job queue — the same
-        # in-job delete_all the destroy path already uses (remove_share), so all
-        # invalidation timing is uniform and the large-subtree purge no longer
-        # blocks the commit. In production the revoke of the vacated access is
-        # deferred by the queue latency (~1-2s); under the inline/test adapters
-        # it still runs at commit, so final-state tests stay behavior-preserving.
-        # This only PROLONGS an already-granted permission by that window; it
-        # never grants a brand-new permission, which the CTO judged acceptable in
-        # favor of the perf win. Then rebuild the vacated subtree. creative_id
-        # takes precedence when both change, preserving the prior branch order.
+        # to this share. The purge rides ON the propagate_share job (purge_stale:
+        # true), which deletes those rows immediately before re-propagating — in
+        # one job, never as a standalone enqueue. The authz queue runs two
+        # threads, so a separate purge could otherwise run AFTER propagate and
+        # delete the freshly written rows (both key on source_share_id), dropping
+        # the share's access until an unrelated rebuild. Folding it in keeps the
+        # work async (off the commit path) so the revoke of the vacated access is
+        # merely deferred by the queue latency (~1-2s) — it only PROLONGS an
+        # already-granted permission by that window, never grants a new one,
+        # which the CTO judged acceptable for the perf win. Then rebuild the
+        # vacated subtree. creative_id takes precedence when both change,
+        # preserving the prior branch order.
         if operations.include?(:relocate) || operations.include?(:reassign)
-          PermissionCacheJob.perform_later(:purge_share_cache, creative_share_id: id)
+          propagate_args[:purge_stale] = true
           rebuild_vacated_subtree(relocated: operations.include?(:relocate))
         end
       end
 
-      PermissionCacheJob.perform_later(:propagate_share, creative_share_id: id)
+      PermissionCacheJob.perform_later(:propagate_share, **propagate_args)
     end
 
     # Rebuild the cache the moved/reassigned share vacated, for the old user in

--- a/engines/collavre/test/jobs/permission_cache_job_test.rb
+++ b/engines/collavre/test/jobs/permission_cache_job_test.rb
@@ -188,26 +188,42 @@ class PermissionCacheJobTest < ActiveJob::TestCase
     end
   end
 
-  test "purge_share_cache deletes the cache rows keyed to the share" do
+  test "propagate_share with purge_stale deletes stale rows then re-propagates in one job" do
     share = nil
     perform_enqueued_jobs do
       share = CreativeShare.create!(creative: @root, user: @shared_user, permission: "read")
     end
-    assert CreativeSharesCache.exists?(source_share_id: share.id)
+    # Plant a stale row at a location the share no longer covers, keyed to it.
+    orphan = Creative.create!(user: @owner, description: "Orphan", progress: 0.0)
+    CreativeSharesCache.create!(creative: orphan, user: @shared_user,
+      permission: "read", source_share_id: share.id)
 
+    clear_enqueued_jobs
     perform_enqueued_jobs do
-      PermissionCacheJob.perform_later(:purge_share_cache, creative_share_id: share.id)
+      PermissionCacheJob.perform_later(:propagate_share, creative_share_id: share.id, purge_stale: true)
     end
 
-    refute CreativeSharesCache.exists?(source_share_id: share.id)
+    # The purge removed the stale orphan row, and the re-propagate repopulated
+    # the share's real subtree — both in the single job (no racing purge).
+    refute CreativeSharesCache.exists?(source_share_id: share.id, creative_id: orphan.id)
+    assert CreativeSharesCache.exists?(source_share_id: share.id, creative_id: @root.id)
+    assert CreativeSharesCache.exists?(source_share_id: share.id, creative_id: @grandchild.id)
   end
 
-  test "purge_share_cache handles a share id with no cache rows gracefully" do
+  test "propagate_share without purge_stale leaves existing rows in place" do
+    share = nil
+    perform_enqueued_jobs do
+      share = CreativeShare.create!(creative: @root, user: @shared_user, permission: "read")
+    end
+    assert CreativeSharesCache.exists?(source_share_id: share.id, creative_id: @root.id)
+
+    clear_enqueued_jobs
     assert_nothing_raised do
       perform_enqueued_jobs do
-        PermissionCacheJob.perform_later(:purge_share_cache, creative_share_id: -1)
+        PermissionCacheJob.perform_later(:propagate_share, creative_share_id: share.id)
       end
     end
+    assert CreativeSharesCache.exists?(source_share_id: share.id, creative_id: @root.id)
   end
 
   test "rebuild_user_cache_for_subtree rebuilds cache for specific user" do

--- a/engines/collavre/test/jobs/permission_cache_job_test.rb
+++ b/engines/collavre/test/jobs/permission_cache_job_test.rb
@@ -188,6 +188,28 @@ class PermissionCacheJobTest < ActiveJob::TestCase
     end
   end
 
+  test "purge_share_cache deletes the cache rows keyed to the share" do
+    share = nil
+    perform_enqueued_jobs do
+      share = CreativeShare.create!(creative: @root, user: @shared_user, permission: "read")
+    end
+    assert CreativeSharesCache.exists?(source_share_id: share.id)
+
+    perform_enqueued_jobs do
+      PermissionCacheJob.perform_later(:purge_share_cache, creative_share_id: share.id)
+    end
+
+    refute CreativeSharesCache.exists?(source_share_id: share.id)
+  end
+
+  test "purge_share_cache handles a share id with no cache rows gracefully" do
+    assert_nothing_raised do
+      perform_enqueued_jobs do
+        PermissionCacheJob.perform_later(:purge_share_cache, creative_share_id: -1)
+      end
+    end
+  end
+
   test "rebuild_user_cache_for_subtree rebuilds cache for specific user" do
     perform_enqueued_jobs do
       CreativeShare.create!(creative: @root, user: @shared_user, permission: "read")

--- a/engines/collavre/test/models/creative_share_invalidation_test.rb
+++ b/engines/collavre/test/models/creative_share_invalidation_test.rb
@@ -60,6 +60,9 @@ module Collavre
       calls = capture_permission_cache_jobs do
         share.update!(creative: @other_root)
       end
+      # The stale-row purge is now enqueued (async), mirroring the destroy path,
+      # rather than deleted synchronously inside after_commit.
+      assert_includes calls, [ :purge_share_cache, { creative_share_id: share.id } ]
       assert_includes calls,
         [ :rebuild_user_cache_for_subtree, { creative_id: old_creative_id, user_id: @user1.id } ]
       assert_includes calls, [ :propagate_share, { creative_share_id: share.id } ]
@@ -70,6 +73,7 @@ module Collavre
       calls = capture_permission_cache_jobs do
         share.update!(user: @user2)
       end
+      assert_includes calls, [ :purge_share_cache, { creative_share_id: share.id } ]
       assert_includes calls,
         [ :rebuild_user_cache_for_subtree, { creative_id: @root.id, user_id: @user1.id } ]
       assert_includes calls, [ :propagate_share, { creative_share_id: share.id } ]
@@ -102,6 +106,32 @@ module Collavre
         "the permission change must survive a later same-transaction untracked save"
     end
 
+    test "relocate purges stale cache rows via the enqueued job, not synchronously at commit" do
+      share = create_share(@root, @user1, :read)
+      stale_rows = -> { CreativeSharesCache.where(source_share_id: share.id, creative_id: @root.id) }
+      assert stale_rows.call.exists?,
+        "precondition: propagate_share populated the share's cache row at the old creative"
+
+      # Under a deferred (test) adapter the relocate enqueues purge_share_cache
+      # but does NOT run it — proving the stale-row delete is async now, not a
+      # synchronous delete_all inside after_commit. The revoke of the vacated
+      # access is therefore prolonged by the queue latency, which is the accepted
+      # trade-off (it only extends an existing grant, never creates a new one).
+      # The suite's default adapter is :inline, so switch to :test to observe the
+      # commit boundary independently of the job execution.
+      with_deferred_jobs do
+        share.update!(creative: @other_root)
+        assert_enqueued_with(job: PermissionCacheJob,
+          args: [ :purge_share_cache, { creative_share_id: share.id } ])
+        assert stale_rows.call.exists?,
+          "stale rows must survive the commit; the purge is deferred to the job"
+        perform_enqueued_jobs
+      end
+
+      assert_not stale_rows.call.exists?,
+        "the enqueued purge job deletes the stale rows the share vacated"
+    end
+
     test "destroying a share enqueues remove_share" do
       share = create_share(@root, @user1, :read)
       calls = capture_permission_cache_jobs do
@@ -119,6 +149,17 @@ module Collavre
         share = CreativeShare.create!(creative: creative, user: user, permission: permission)
       end
       share
+    end
+
+    # The suite runs on the :inline adapter (jobs execute at enqueue time), which
+    # can't distinguish "enqueued" from "performed". Swap to the :test adapter so
+    # a block can inspect the commit boundary before the jobs run.
+    def with_deferred_jobs
+      old_adapter = ActiveJob::Base.queue_adapter
+      ActiveJob::Base.queue_adapter = :test
+      yield
+    ensure
+      ActiveJob::Base.queue_adapter = old_adapter
     end
 
     def capture_permission_cache_jobs(&block)

--- a/engines/collavre/test/models/creative_share_invalidation_test.rb
+++ b/engines/collavre/test/models/creative_share_invalidation_test.rb
@@ -60,12 +60,14 @@ module Collavre
       calls = capture_permission_cache_jobs do
         share.update!(creative: @other_root)
       end
-      # The stale-row purge is now enqueued (async), mirroring the destroy path,
-      # rather than deleted synchronously inside after_commit.
-      assert_includes calls, [ :purge_share_cache, { creative_share_id: share.id } ]
+      # The stale-row purge now rides on the propagate_share job (purge_stale:),
+      # not a standalone enqueue, so it can never run after the re-propagation on
+      # a separate authz-queue thread. It is still async (off the commit path).
       assert_includes calls,
         [ :rebuild_user_cache_for_subtree, { creative_id: old_creative_id, user_id: @user1.id } ]
-      assert_includes calls, [ :propagate_share, { creative_share_id: share.id } ]
+      assert_includes calls, [ :propagate_share, { creative_share_id: share.id, purge_stale: true } ]
+      refute_includes calls.map(&:first), :purge_share_cache,
+        "the purge must not be enqueued as its own job (it would race propagate_share)"
     end
 
     test "changing user_id reassigns: rebuild old user's subtree then propagate" do
@@ -73,10 +75,11 @@ module Collavre
       calls = capture_permission_cache_jobs do
         share.update!(user: @user2)
       end
-      assert_includes calls, [ :purge_share_cache, { creative_share_id: share.id } ]
       assert_includes calls,
         [ :rebuild_user_cache_for_subtree, { creative_id: @root.id, user_id: @user1.id } ]
-      assert_includes calls, [ :propagate_share, { creative_share_id: share.id } ]
+      assert_includes calls, [ :propagate_share, { creative_share_id: share.id, purge_stale: true } ]
+      refute_includes calls.map(&:first), :purge_share_cache,
+        "the purge must not be enqueued as its own job (it would race propagate_share)"
     end
 
     test "an untracked-only update still re-propagates the share (fail-closed)" do
@@ -106,30 +109,55 @@ module Collavre
         "the permission change must survive a later same-transaction untracked save"
     end
 
-    test "relocate purges stale cache rows via the enqueued job, not synchronously at commit" do
+    test "relocate purges stale cache rows via the propagate job, not synchronously at commit" do
       share = create_share(@root, @user1, :read)
       stale_rows = -> { CreativeSharesCache.where(source_share_id: share.id, creative_id: @root.id) }
+      fresh_rows = -> { CreativeSharesCache.where(source_share_id: share.id, creative_id: @other_root.id) }
       assert stale_rows.call.exists?,
         "precondition: propagate_share populated the share's cache row at the old creative"
 
-      # Under a deferred (test) adapter the relocate enqueues purge_share_cache
-      # but does NOT run it — proving the stale-row delete is async now, not a
-      # synchronous delete_all inside after_commit. The revoke of the vacated
-      # access is therefore prolonged by the queue latency, which is the accepted
-      # trade-off (it only extends an existing grant, never creates a new one).
-      # The suite's default adapter is :inline, so switch to :test to observe the
-      # commit boundary independently of the job execution.
+      # Under a deferred (test) adapter the relocate enqueues propagate_share with
+      # purge_stale: true but does NOT run it — proving the stale-row delete is
+      # async now, not a synchronous delete_all inside after_commit. The revoke of
+      # the vacated access is therefore prolonged by the queue latency, which is
+      # the accepted trade-off (it only extends an existing grant, never creates a
+      # new one). The suite's default adapter is :inline, so switch to :test to
+      # observe the commit boundary independently of the job execution.
       with_deferred_jobs do
         share.update!(creative: @other_root)
         assert_enqueued_with(job: PermissionCacheJob,
-          args: [ :purge_share_cache, { creative_share_id: share.id } ])
+          args: [ :propagate_share, { creative_share_id: share.id, purge_stale: true } ])
         assert stale_rows.call.exists?,
           "stale rows must survive the commit; the purge is deferred to the job"
         perform_enqueued_jobs
       end
 
       assert_not stale_rows.call.exists?,
-        "the enqueued purge job deletes the stale rows the share vacated"
+        "the propagate job deletes the stale rows the share vacated"
+      assert fresh_rows.call.exists?,
+        "and repopulates the share's cache at the new creative in the same job"
+    end
+
+    test "relocate cache is correct regardless of job execution order (no purge/propagate race)" do
+      # The authz queue runs two threads, so purge and propagate could execute in
+      # any order. Folding the purge INTO propagate_share removes the race: there
+      # is no standalone purge job that can delete freshly propagated rows. Prove
+      # it by running the relocate's enqueued jobs in reverse (adversarial) order.
+      share = create_share(@root, @user1, :read)
+      new_rows = -> { CreativeSharesCache.where(source_share_id: share.id, creative_id: @other_root.id) }
+      old_rows = -> { CreativeSharesCache.where(source_share_id: share.id, creative_id: @root.id) }
+
+      with_deferred_jobs do
+        share.update!(creative: @other_root)
+        # Adversarial scheduling: perform the last-enqueued job first.
+        enqueued_jobs.reverse_each { |job| ActiveJob::Base.execute(job) }
+        clear_enqueued_jobs
+      end
+
+      assert new_rows.call.exists?,
+        "the moved share must have cache rows at the new location no matter the order"
+      assert_not old_rows.call.exists?,
+        "and no stale rows at the old location"
     end
 
     test "destroying a share enqueues remove_share" do


### PR DESCRIPTION
## Summary

Unifies the timing of `CreativeSharesCache` stale-row invalidation on `CreativeShare` writes (**rot ②a**). Previously the two purge paths were inconsistent:

- **update path** (share moved/reassigned): ran a **synchronous** `delete_all` of the stale cache rows inside `after_commit` — an immediate, commit-blocking revoke.
- **destroy path** (`remove_share` job): already **async** — the `delete_all` runs inside the enqueued `PermissionCacheJob`.

This PR makes the update-path purge **async too**, mirroring the destroy path. A new `PermissionCacheJob` operation `:purge_share_cache` performs the same `CreativeSharesCache.where(source_share_id: id).delete_all`, and the `dispatch_share_cache_invalidation` after_commit now enqueues it instead of deleting synchronously. The existing `rebuild_vacated_subtree` enqueue and the unconditional `propagate_share` re-propagate are unchanged.

## Behavior change and product decision

The revoke of the vacated access is now deferred by the job-queue latency (~1-2s in production) rather than immediate. Per the CTO product decision, this is acceptable:

> rot ②a 는 async 로 통일. 성능이 더 우선되어야하고 권한 변경은 실제 async 라고해도 짧은 윈도우면 별 상관없다. 아예 없던 권한을 얻은게 아니라 있던것이 1-2초 더 있는다고 해서 문제 될것은 없음.

The window only **prolongs an already-granted permission** by the queue latency; it never grants a brand-new permission. The perf win — no synchronous `delete_all` blocking commit on large subtree moves — is prioritized. No TTL/self-heal is added, per that same decision.

## Behavior preservation

- The **exact set** of purged rows (`source_share_id = share.id`) is unchanged.
- The **creative_id-priority ordering** (`relocated: operations.include?(:relocate)`) is unchanged.
- The unconditional re-propagate on every update (PR #1393 Codex fix, fail-closed against multi-save `saved_changes` clobbering) and rollback clearing are untouched.
- Only the **timing** moves sync → async.
- Under the suite's `:inline` test adapter the job runs at enqueue time, so the existing **semantic final-state** tests stay green.

## Tests

- Updated the relocate/reassign dispatcher tests to assert `:purge_share_cache` is now enqueued.
- Added a deferred-adapter test (switches to `:test` adapter) asserting the purge is **enqueued but not executed** at commit — the stale rows survive the commit and are only deleted after `perform_enqueued_jobs`, proving the delete is async.
- Added direct job-level coverage for `:purge_share_cache` (deletes the share's rows; no-ops safely for an id with no rows).

Full permission cluster (`creative_share`, invalidation/dispatcher, `creative_permission_cache`, `permission_cache_job`, `permission_cache_builder`, filter, checker) green: **92 runs, 411 assertions, 0 failures, 0 errors**. `rubocop` clean on all changed files.