### PR TITLE
docs: describe converged permission architecture (rot ②)

### DIFF
--- a/.collavre-docs/patterns/permissions.md
+++ b/.collavre-docs/patterns/permissions.md
@@ -83,3 +83,198 @@ Invitation.create!(
 The creative's owner (`user_id`) always has admin access. This is enforced in
 `Collavre::Creatives::PermissionChecker`, which grants the owner full access
 regardless of any `CreativeShare` record.
+
+---
+
+# Converged Permission Architecture
+
+> This section documents the FINAL state of the permission system after the
+> "rot ②" convergence effort (the security-audit's #1 rot core), which landed
+> across PRs **#1388–#1393**, **#1396**, and **#1397**. It is the foundation the
+> upcoming skill-tree permission layer will build on, so the invariants below
+> are load-bearing.
+
+The permission system has two halves that must stay in agreement:
+
+- **Read path** — "given a user and a set of creative ids, which may they see
+  (at some rank)?" Answered from the O(1) `CreativeSharesCache` table.
+- **Write-invalidation path** — "when a share or a creative changes, which cache
+  rows must be rebuilt so the read path stays correct?" Handled by model
+  callbacks that enqueue `PermissionCacheJob` (queue `authz`).
+
+The convergence effort collapsed each half onto a single canonical
+implementation so that no future code path can quietly disagree with the
+authoritative resolution.
+
+## 1. Single Read Path — `PermissionFilter`
+
+**File:** `engines/collavre/app/services/collavre/creatives/permission_filter.rb`
+
+`PermissionFilter` is the one place the batch read-authorization posture lives.
+It resolves each id to its effective (origin) creative using the SAME logic as
+the single-item `PermissionChecker`, then applies the deny-invariant:
+
+- **Owner wins** — the owner resolves to `admin` (top rank) and satisfies any
+  threshold.
+- **User entry is authoritative over public** — a user-specific
+  `CreativeSharesCache` row grants only when its own rank meets the requested
+  `min_permission`, and otherwise **suppresses** the public share entirely. So a
+  user `no_access` (rank 0) — or any below-threshold user entry — beats a more
+  permissive public share.
+- **Public share** applies only when the user has no own entry.
+
+Two entry points:
+
+- `readable_ids(ids, min_permission:)` — returns the accessible subset as an
+  Array, and additionally applies the **shell-ownership anti-leak gate**: a
+  linked "shell" creative is returned only if the viewer owns the shell row AND
+  its origin is readable (a batch can be fed foreign shells).
+- `ranks_for(ids)` — returns `{ id => rank }` for callers that already operate
+  inside the viewer's own tree and want the raw rank (no shell gate).
+
+### Read sites that converged
+
+PR #1388 pinned the observable behavior of the **five** read sites that queried
+`CreativeSharesCache` directly, as characterization tests
+(`permission_read_characterization_test.rb`) — the safety net for the rewrites.
+Four then converged onto `PermissionFilter`, each proven behavior-preserving:
+
+| Site | Location | Converged in |
+| --- | --- | --- |
+| `Creative#children_with_permission` | `creative/permissible.rb` | #1390 |
+| `SlideViewable#accessible_child_ids` | `concerns/slide_viewable.rb` | #1391 |
+| `TreeBuilder#preload_permissions` | `creatives/tree_builder.rb` | #1391 |
+| `AttachmentsController#editable_creative_reference?` | `attachments_controller.rb` | #1392 |
+
+PR #1389 first extended `PermissionFilter` with `min_permission:` and
+`ranks_for` so the write-posture site (attachments, `:write`) and the
+rank-consuming sites (tree/slide) could share the one filter.
+
+### The one site deliberately left out
+
+`Tools::CreativeRetrievalService#accessible_creative_ids`
+(`accessible_creative_ids`) was NOT converged. It has a deliberate **posture
+divergence**: it returns the user's own creatives plus their user-specific cache
+entries with `.where.not(permission: :no_access)`, and **ignores public shares
+entirely**. Because it neither honors public shares nor applies origin/shell
+resolution, routing it through `PermissionFilter` would change its observable
+result — so it was left as-is with its characterization test locking the
+divergence. (Tracked separately as issue #855.) It is safe precisely because it
+is strictly narrower than the canonical path (own + explicit user grants only).
+
+## 2. Single Write-Invalidation Dispatcher (declarative)
+
+Both models that can invalidate the cache now use the same shape: a declarative
+**`PERMISSION_INVALIDATING_ATTRIBUTES`** map from persisted attribute → rebuild
+operation, consumed by a **single `after_commit` dispatcher**. This replaced
+hand-coded `saved_change_to_*` callback chains, so a new mutation path cannot add
+a column without deciding (in the map) how it invalidates — see the invariant
+below.
+
+### `CreativeShare` — unconditional re-propagate (#1393)
+
+**File:** `engines/collavre/app/models/collavre/creative_share.rb`
+
+- Map: `creative_id → :relocate`, `user_id → :reassign`,
+  `permission → :repropagate`.
+- `dispatch_share_cache_invalidation` (`after_commit on: [:create, :update]`)
+  **always** enqueues `PermissionCacheJob(:propagate_share)` — an
+  **unconditional, fail-closed** refresh. It does NOT gate on which attribute
+  changed for the base refresh.
+- **Why unconditional here:** `after_commit` sees only the *final* save's
+  `saved_changes`. In a multi-save transaction, an earlier permission change can
+  be clobbered out of the final `saved_changes`; a `saved_changes`-gated
+  dispatcher would then skip the refresh and leave the cache stale (fail-**open**,
+  no TTL/self-heal). Always re-propagating is the fail-closed choice. This is the
+  Codex fix `00502d7d`.
+- A move (`creative_id`) or reassignment (`user_id`) needs EXTRA cleanup on top
+  of the base refresh: the stale rows the share left at the old location must be
+  purged, and the vacated subtree rebuilt for the old user. The map drives that
+  extra work; the base refresh always runs regardless.
+
+### `Creative::Permissible` — cross-save accumulation (#1396)
+
+**File:** `engines/collavre/app/models/collavre/creative/permissible.rb`
+
+- Map: `parent_id → :rebuild`, `user_id → :rebuild_owner`,
+  `origin_id → :rebuild` (`origin_id` is immutable post-create via
+  `attr_readonly`, so its entry is defensive).
+- Solves the **same** multi-save clobber, but with **cross-save accumulation**,
+  NOT an unconditional refresh:
+  - `after_save :accumulate_permission_cache_changes` merges each save's relevant
+    `saved_changes` into an ivar (`@accumulated_permission_changes`), keeping the
+    earliest `old` and latest `new`.
+  - `after_commit :dispatch_permission_cache_invalidation` maps the accumulated
+    changes through the registry and enqueues each distinct rebuild once, then
+    clears the ivar.
+  - `after_rollback :clear_accumulated_permission_changes` resets it.
+- **Why accumulation instead of unconditional (the hot-path distinction):**
+  `rebuild_for_creative` is a **subtree rebuild** on a hot write path — Creatives
+  are re-saved constantly for permission-irrelevant reasons (progress rollup,
+  description edits). Refreshing unconditionally on every Creative commit would
+  regress throughput. Accumulation keeps permission-irrelevant saves cheap while
+  still never dropping a real permission change.
+
+**Honest scope note:** this is a *defensive/latent* fix. No production path today
+performs two real saves touching a permission attribute then an untracked column
+on one Creative in a single transaction (the reorderer re-saves `:sequence` via
+`update_column`, which bypasses these callbacks and preserves `saved_changes`).
+The clobber is sealed against, but the exposure it seals was **unreachable**, not
+actively firing — the latent risk is closed as follow-up hardening, not a live
+bug that was leaking.
+
+## 3. Async Delete-Timing — folded purge (#1397)
+
+**Files:** `creative_share.rb`, `permission_cache_job.rb`, `config/queue.yml`
+
+Previously the stale-cache purge for a relocated/reassigned share ran
+synchronously as `delete_all` inside `after_commit`. It is now **async and
+folded into the `propagate_share` job** via a `purge_stale:` flag:
+
+- `dispatch_share_cache_invalidation` sets `propagate_args[:purge_stale] = true`
+  for a relocate/reassign and enqueues a single
+  `PermissionCacheJob(:propagate_share, purge_stale: true)`.
+- Inside the job, `purge_share_cache` (deletes rows keyed on `source_share_id`)
+  runs **immediately before** re-propagating, **in the same job** — never as a
+  standalone enqueue.
+
+**Why folded, not a standalone purge job (Codex fix `82d1e013`):** the `authz`
+queue runs **2 threads** (`config/queue.yml`). Both the purge and the propagate
+key on `source_share_id`, so a *separate* purge job could execute on the second
+thread AFTER propagate and delete the rows propagate just wrote — dropping the
+share's access until an unrelated rebuild. Folding the purge into the same job
+guarantees purge-before-propagate ordering.
+
+**Accepted design decision — the prolonged-grant window:** moving the purge off
+the commit path means the revoke of the vacated access is deferred by the queue
+latency (~1–2s). This is acceptable **without a TTL** because the deferred purge
+only ever **prolongs an already-granted permission** by that window — it never
+grants NEW access. (A move/reassign's *base refresh* still re-propagates the
+share's current grant unconditionally; only the cleanup of the OLD location is
+deferred.) The CTO accepted this window for the perf win.
+
+## 4. The Invariant
+
+**A new mutation path must not silently skip cache invalidation.**
+
+Concretely, when adding a persisted attribute or a new write path to
+`CreativeShare` or `Creative`:
+
+- Decide, in `PERMISSION_INVALIDATING_ATTRIBUTES`, whether/how it invalidates.
+- The single `after_commit` dispatcher then handles it — there is no second,
+  hand-rolled callback chain to keep in sync.
+- Prefer fail-**closed**: when in doubt, refresh. The `CreativeShare` base
+  re-propagate is unconditional for exactly this reason; `Creative` uses
+  accumulation only because its rebuild is hot-path and it can prove no real
+  path drops a change.
+
+## Forward Context — Skill-Tree Permissions
+
+The skill-tree permission layer will sit ON TOP of this converged foundation.
+Because there is now exactly one read resolver (`PermissionFilter`) and one
+declarative write-invalidation dispatcher per model, the skill-tree work can:
+
+- Extend the read posture in a single place rather than re-deriving the
+  deny-invariant at each call site.
+- Add new invalidating attributes/edges by extending the declarative maps,
+  inheriting the "cannot silently skip invalidation" invariant for free.

--- a/docs/PERMISSION_CACHE.md
+++ b/docs/PERMISSION_CACHE.md
@@ -49,9 +49,7 @@ Any invalid or potentially malicious input will safely default to 7 days and log
 
 2. **Inheritance**: Child creatives inherit permissions from parent creatives, and these results are cached independently
 
-3. **Selective Invalidation**: When a `CreativeShare` is created, updated, or deleted, only the affected cache keys are cleared:
-   - The specific creative + user combination (all permission levels)
-   - All descendants of that creative + user (to handle inheritance)
+3. **Declarative Invalidation**: When a `CreativeShare` or `Creative` changes, a single `after_commit` dispatcher maps the changed persisted attributes through a declarative `PERMISSION_INVALIDATING_ATTRIBUTES` registry and enqueues the required rebuild(s) on the async `authz` queue (via `PermissionCacheJob`). `CreativeShare` re-propagates unconditionally (fail-closed); `Creative::Permissible` accumulates changes across saves to keep its hot write path cheap. A relocate/reassign additionally purges stale rows, folded into the same propagate job. See [`.collavre-docs/patterns/permissions.md`](../.collavre-docs/patterns/permissions.md) ("Converged Permission Architecture") for the full design and rationale.
 
 4. **Performance**: Provides significant performance improvement for users with many creatives (estimated ~33-48KB memory usage per 1000 creatives per user)
 


### PR DESCRIPTION
## Summary

Docs-only. Documents the FINAL state of the permission system after the "rot ②" convergence effort (the security audit's #1 rot core), which landed across PRs #1388–#1393, #1396, and #1397. This is the foundation for the upcoming skill-tree permission layer.

### What changed
- **`.collavre-docs/patterns/permissions.md`** (primary — the permission pattern doc): added a "Converged Permission Architecture" section covering:
  - **Single read path** `PermissionFilter` — the deny-invariant (owner wins; user entry, incl. `no_access`, beats public), `readable_ids`/`ranks_for`, the shell-ownership anti-leak gate, the 4 converged read sites (#1390–#1392), and the one deliberately-excluded site (`CreativeRetrievalService`, tracked as #855) with its posture divergence.
  - **Declarative write-invalidation dispatcher** — `PERMISSION_INVALIDATING_ATTRIBUTES` + single `after_commit`; why `CreativeShare` re-propagates **unconditionally** (fail-closed, Codex `00502d7d`) while `Creative::Permissible` uses **cross-save accumulation** (because `rebuild_for_creative` is a hot-path subtree rebuild).
  - **Async delete-timing** (#1397) — purge folded into `propagate_share` via `purge_stale:` (Codex `82d1e013`, avoids the 2-thread `authz` race), and the accepted **prolonged-grant-window** rationale (only extends an existing grant, never creates access; no TTL).
  - **The invariant**: a new mutation path must not silently skip invalidation.
  - Forward context for skill-tree permissions.
- **`docs/PERMISSION_CACHE.md`**: updated the (now stale) "Selective Invalidation" bullet to describe the declarative dispatcher and cross-linked the pattern doc.

### Honesty note
`Creative::Permissible`'s multi-save clobber fix is explicitly documented as **defensive/latent** — sealed against, but the exposure was unreachable in production paths, not a live leak. Deferred vs sealed is called out.

Grounded in the code at `c186f478`; cites file paths and merged PR numbers.