### PR TITLE
refactor(collavre): extract inline creative payload mapping cluster from creative_row_editor god-file (rot ① slice 3)

### DIFF
--- a/engines/collavre/app/javascript/modules/__tests__/creative_inline_payload.test.js
+++ b/engines/collavre/app/javascript/modules/__tests__/creative_inline_payload.test.js
@@ -1,0 +1,231 @@
+/**
+ * Characterization tests for the inline creative payload mapping cluster
+ * extracted from creative_row_editor.js (slice 3 of the god-file decomposition).
+ *
+ * These pin the CURRENT behavior of the inverse pair that drives instant UI:
+ *   - inlinePayloadFromTree: reads a payload OUT of a rendered tree row's dataset
+ *   - updateRowFromData:     writes a server/API payload INTO a row's dataset
+ *
+ * The fixture mirrors the real creative-tree render: a `creative-tree-row`
+ * custom element wrapping a `.creative-tree` node whose `data-id`/`data-parent-id`
+ * carry the tree identity.
+ *
+ * Intentionally behavior-preserving: any surprising result below (e.g. missing
+ * fields defaulting to 0/'' rather than being omitted, or `hasOwnProperty`-gated
+ * writes) documents existing behavior, not an endorsement of it.
+ */
+import { inlinePayloadFromTree, updateRowFromData } from '../creative_inline_payload';
+
+// Build one row: <creative-tree-row><div.creative-tree/></creative-tree-row>
+function makeRow(id, { parentId = '', level = 1 } = {}) {
+  const row = document.createElement('creative-tree-row');
+  row.setAttribute('creative-id', String(id));
+  row.setAttribute('level', String(level));
+  const tree = document.createElement('div');
+  tree.className = 'creative-tree';
+  tree.id = `creative-${id}`;
+  tree.dataset.id = String(id);
+  tree.dataset.parentId = parentId;
+  tree.dataset.level = String(level);
+  row.appendChild(tree);
+  return { row, tree };
+}
+
+describe('inlinePayloadFromTree', () => {
+  test('returns null for falsy tree', () => {
+    expect(inlinePayloadFromTree(null)).toBeNull();
+    expect(inlinePayloadFromTree(undefined)).toBeNull();
+  });
+
+  test('returns null when tree has no wrapping creative-tree-row', () => {
+    const orphan = document.createElement('div');
+    orphan.dataset.id = '5';
+    expect(inlinePayloadFromTree(orphan)).toBeNull();
+  });
+
+  test('returns null when row exists but tree has no data-id', () => {
+    const { tree } = makeRow('9');
+    delete tree.dataset.id;
+    expect(inlinePayloadFromTree(tree)).toBeNull();
+  });
+
+  test('builds a fully-defaulted payload from a minimal row (only id)', () => {
+    const { tree } = makeRow('42', { parentId: '' });
+    expect(inlinePayloadFromTree(tree)).toEqual({
+      id: '42',
+      description: '',
+      description_raw_html: '',
+      origin_id: '',
+      parent_id: '',
+      progress: 0,
+      content_type: null,
+      markdown_editor: null,
+      markdown_source: null,
+    });
+  });
+
+  test('reads all fields from a fully-populated row', () => {
+    const { row, tree } = makeRow('7', { parentId: '3' });
+    row.dataset.descriptionHtml = '<p>hi</p>';
+    row.dataset.descriptionRawHtml = '<p>raw</p>';
+    row.dataset.progressValue = '55';
+    row.dataset.originId = '99';
+    row.dataset.contentType = 'markdown';
+    row.dataset.markdownEditor = 'rich';
+    row.dataset.markdownSource = '# hi';
+    expect(inlinePayloadFromTree(tree)).toEqual({
+      id: '7',
+      description: '<p>hi</p>',
+      description_raw_html: '<p>raw</p>',
+      origin_id: '99',
+      parent_id: '3',
+      progress: 55,
+      content_type: 'markdown',
+      markdown_editor: 'rich',
+      markdown_source: '# hi',
+    });
+  });
+
+  test('description falls back to raw html when descriptionHtml absent', () => {
+    const { row, tree } = makeRow('8');
+    row.dataset.descriptionRawHtml = '<p>only-raw</p>';
+    const payload = inlinePayloadFromTree(tree);
+    expect(payload.description).toBe('<p>only-raw</p>');
+    expect(payload.description_raw_html).toBe('<p>only-raw</p>');
+  });
+
+  test('non-numeric progress coerces to 0 (NaN guard)', () => {
+    const { row, tree } = makeRow('11');
+    row.dataset.progressValue = 'abc';
+    expect(inlinePayloadFromTree(tree).progress).toBe(0);
+  });
+
+  test('progress present but empty-string reads as 0', () => {
+    const { row, tree } = makeRow('12');
+    row.dataset.progressValue = '';
+    // Number('' ?? 0) === Number('') === 0
+    expect(inlinePayloadFromTree(tree).progress).toBe(0);
+  });
+});
+
+describe('updateRowFromData', () => {
+  test('no-ops on falsy row or data', () => {
+    const { row } = makeRow('1');
+    expect(() => updateRowFromData(null, { description: 'x' })).not.toThrow();
+    expect(() => updateRowFromData(row, null)).not.toThrow();
+    expect(row.dataset.descriptionHtml).toBeUndefined();
+  });
+
+  test('writes description + raw html (raw falls back to description)', () => {
+    const { row } = makeRow('1');
+    updateRowFromData(row, { description: '<p>d</p>' });
+    expect(row.descriptionHtml).toBe('<p>d</p>');
+    expect(row.dataset.descriptionHtml).toBe('<p>d</p>');
+    expect(row.dataset.descriptionRawHtml).toBe('<p>d</p>');
+  });
+
+  test('explicit description_raw_html is preserved distinctly', () => {
+    const { row } = makeRow('1');
+    updateRowFromData(row, { description: '<p>d</p>', description_raw_html: '<p>r</p>' });
+    expect(row.dataset.descriptionHtml).toBe('<p>d</p>');
+    expect(row.dataset.descriptionRawHtml).toBe('<p>r</p>');
+  });
+
+  test('missing description writes empty string (not skipped)', () => {
+    const { row } = makeRow('1');
+    updateRowFromData(row, { progress: 10 });
+    expect(row.dataset.descriptionHtml).toBe('');
+    expect(row.dataset.descriptionRawHtml).toBe('');
+  });
+
+  test('progress_html only written when non-null', () => {
+    const { row } = makeRow('1');
+    updateRowFromData(row, { description: 'd', progress_html: '<b>50%</b>' });
+    expect(row.progressHtml).toBe('<b>50%</b>');
+    expect(row.dataset.progressHtml).toBe('<b>50%</b>');
+
+    const { row: row2 } = makeRow('2');
+    updateRowFromData(row2, { description: 'd', progress_html: null });
+    expect(row2.dataset.progressHtml).toBeUndefined();
+  });
+
+  test('progress written from own key; null clears dataset value', () => {
+    const { row } = makeRow('1');
+    updateRowFromData(row, { description: 'd', progress: 30 });
+    expect(row.dataset.progressValue).toBe('30');
+
+    // `?? ''` maps null/undefined to '', and setRowDatasetValue deletes on ''? no:
+    // value '' is a string -> stored as ''.  null -> '' -> stored as ''.
+    const { row: row2 } = makeRow('2');
+    updateRowFromData(row2, { description: 'd', progress: null });
+    expect(row2.dataset.progressValue).toBe('');
+  });
+
+  test('hasOwnProperty gating: absent keys leave dataset untouched', () => {
+    const { row } = makeRow('1');
+    row.dataset.originId = 'pre';
+    row.dataset.contentType = 'pre';
+    updateRowFromData(row, { description: 'd' });
+    // origin_id / content_type not in payload -> not overwritten
+    expect(row.dataset.originId).toBe('pre');
+    expect(row.dataset.contentType).toBe('pre');
+  });
+
+  test('origin_id / content_type / markdown_source / markdown_editor round-trip', () => {
+    const { row } = makeRow('1');
+    updateRowFromData(row, {
+      description: 'd',
+      origin_id: '77',
+      content_type: 'markdown',
+      markdown_source: '# s',
+      markdown_editor: 'rich',
+    });
+    expect(row.dataset.originId).toBe('77');
+    expect(row.dataset.contentType).toBe('markdown');
+    expect(row.dataset.markdownSource).toBe('# s');
+    expect(row.dataset.markdownEditor).toBe('rich');
+  });
+
+  test('has_children truthy sets attribute + property; falsy removes', () => {
+    const { row } = makeRow('1');
+    updateRowFromData(row, { description: 'd', has_children: true });
+    expect(row.hasAttribute('has-children')).toBe(true);
+    expect(row.hasChildren).toBe(true);
+
+    updateRowFromData(row, { description: 'd', has_children: false });
+    expect(row.hasAttribute('has-children')).toBe(false);
+    expect(row.hasChildren).toBe(false);
+  });
+
+  test('calls requestUpdate when the row exposes it', () => {
+    const { row } = makeRow('1');
+    let called = 0;
+    row.requestUpdate = () => { called += 1; };
+    updateRowFromData(row, { description: 'd' });
+    expect(called).toBe(1);
+  });
+
+  test('round-trip: updateRowFromData then inlinePayloadFromTree', () => {
+    const { row, tree } = makeRow('50', { parentId: '2' });
+    updateRowFromData(row, {
+      description: '<p>body</p>',
+      description_raw_html: '<p>raw</p>',
+      progress: 40,
+      origin_id: '5',
+      content_type: 'markdown',
+      markdown_source: '# md',
+      markdown_editor: 'source',
+    });
+    expect(inlinePayloadFromTree(tree)).toEqual({
+      id: '50',
+      description: '<p>body</p>',
+      description_raw_html: '<p>raw</p>',
+      origin_id: '5',
+      parent_id: '2',
+      progress: 40,
+      content_type: 'markdown',
+      markdown_editor: 'source',
+      markdown_source: '# md',
+    });
+  });
+});

--- a/engines/collavre/app/javascript/modules/creative_inline_payload.js
+++ b/engines/collavre/app/javascript/modules/creative_inline_payload.js
@@ -1,0 +1,86 @@
+// Inline creative payload mapping cluster extracted from creative_row_editor.js
+// (slice 3 of the god-file decomposition).
+//
+// These two functions are the inverse pair over the "inline creative payload"
+// shape that drives instant/optimistic UI: `inlinePayloadFromTree` reads a
+// payload OUT of a rendered tree row's dataset, and `updateRowFromData` writes a
+// server/API payload INTO a row's dataset + attributes. Both depend only on their
+// arguments (plus the pure DOM helpers below and browser globals) — neither
+// captures editor closure state, and neither uses timers or `this`. Behavior is
+// identical to the original inline versions.
+import {
+  treeRowElement,
+  hasDatasetValue,
+  setRowDatasetValue,
+} from './creative_row_editor_helpers'
+
+export function updateRowFromData(row, data) {
+  if (!row || !data) return;
+  const descriptionHtml = data.description || '';
+  const rawHtml = data.description_raw_html || descriptionHtml;
+  row.descriptionHtml = descriptionHtml;
+  setRowDatasetValue(row, 'descriptionHtml', descriptionHtml);
+  setRowDatasetValue(row, 'descriptionRawHtml', rawHtml);
+  if (data.progress_html != null) {
+    row.progressHtml = data.progress_html;
+    setRowDatasetValue(row, 'progressHtml', data.progress_html);
+  }
+  if (Object.prototype.hasOwnProperty.call(data, 'progress')) {
+    setRowDatasetValue(row, 'progressValue', data.progress ?? '');
+  }
+  if (Object.prototype.hasOwnProperty.call(data, 'origin_id')) {
+    setRowDatasetValue(row, 'originId', data.origin_id ?? '');
+  }
+  if (Object.prototype.hasOwnProperty.call(data, 'content_type')) {
+    setRowDatasetValue(row, 'contentType', data.content_type ?? '');
+  }
+  if (Object.prototype.hasOwnProperty.call(data, 'markdown_source')) {
+    setRowDatasetValue(row, 'markdownSource', data.markdown_source ?? '');
+  }
+  if (Object.prototype.hasOwnProperty.call(data, 'markdown_editor')) {
+    setRowDatasetValue(row, 'markdownEditor', data.markdown_editor ?? '');
+  }
+  if (Object.prototype.hasOwnProperty.call(data, 'has_children')) {
+    if (data.has_children) {
+      row.setAttribute('has-children', '');
+      row.hasChildren = true;
+    } else {
+      row.removeAttribute('has-children');
+      row.hasChildren = false;
+    }
+  }
+  if (typeof row.requestUpdate === 'function') {
+    row.requestUpdate();
+  }
+}
+
+export function inlinePayloadFromTree(tree) {
+  if (!tree) return null;
+  const row = treeRowElement(tree);
+  if (!row) return null;
+
+  // Relax validation - allow loading with partial data for instant UI
+  const hasDescription = hasDatasetValue(row, 'descriptionRawHtml') || hasDatasetValue(row, 'descriptionHtml');
+  const hasProgress = hasDatasetValue(row, 'progressValue');
+
+  // Only require ID to be present
+  const id = tree.dataset?.id;
+  if (!id) return null;
+
+  const rawHtml = hasDatasetValue(row, 'descriptionRawHtml') ? row.dataset.descriptionRawHtml : row.dataset.descriptionHtml || '';
+  const description = row.dataset.descriptionHtml || rawHtml || '';
+  const progressValue = hasProgress ? Number(row.dataset.progressValue ?? 0) : 0;
+  const parentId = tree.dataset?.parentId || '';
+
+  return {
+    id: id,
+    description,
+    description_raw_html: rawHtml,
+    origin_id: row.dataset?.originId || '',
+    parent_id: parentId,
+    progress: Number.isNaN(progressValue) ? 0 : progressValue,
+    content_type: row.dataset?.contentType || null,
+    markdown_editor: row.dataset?.markdownEditor || null,
+    markdown_source: row.dataset?.markdownSource || null
+  };
+}

--- a/engines/collavre/app/javascript/modules/creative_row_editor.js
+++ b/engines/collavre/app/javascript/modules/creative_row_editor.js
@@ -15,7 +15,6 @@ import yaml from 'js-yaml'
 import {
   treeRowElement,
   hasDatasetValue,
-  setRowDatasetValue,
   isMarkdownEmpty,
   readRowLevel,
   editorPaddingForLevel,
@@ -39,6 +38,10 @@ import {
   setTreeLevel,
   removeTreeElement,
 } from './creative_tree_dom'
+import {
+  updateRowFromData,
+  inlinePayloadFromTree,
+} from './creative_inline_payload'
 // Import Stimulus application from the global window (set by host app)
 const application = window.Stimulus
 
@@ -266,77 +269,6 @@ export function initializeCreativeRowEditor() {
       const row = currentRowElement || (currentTree ? treeRowElement(currentTree) : null);
       if (!row) return false;
       return !!(row.hasChildren || row.getAttribute?.('has-children'));
-    }
-
-    function updateRowFromData(row, data) {
-      if (!row || !data) return;
-      const descriptionHtml = data.description || '';
-      const rawHtml = data.description_raw_html || descriptionHtml;
-      row.descriptionHtml = descriptionHtml;
-      setRowDatasetValue(row, 'descriptionHtml', descriptionHtml);
-      setRowDatasetValue(row, 'descriptionRawHtml', rawHtml);
-      if (data.progress_html != null) {
-        row.progressHtml = data.progress_html;
-        setRowDatasetValue(row, 'progressHtml', data.progress_html);
-      }
-      if (Object.prototype.hasOwnProperty.call(data, 'progress')) {
-        setRowDatasetValue(row, 'progressValue', data.progress ?? '');
-      }
-      if (Object.prototype.hasOwnProperty.call(data, 'origin_id')) {
-        setRowDatasetValue(row, 'originId', data.origin_id ?? '');
-      }
-      if (Object.prototype.hasOwnProperty.call(data, 'content_type')) {
-        setRowDatasetValue(row, 'contentType', data.content_type ?? '');
-      }
-      if (Object.prototype.hasOwnProperty.call(data, 'markdown_source')) {
-        setRowDatasetValue(row, 'markdownSource', data.markdown_source ?? '');
-      }
-      if (Object.prototype.hasOwnProperty.call(data, 'markdown_editor')) {
-        setRowDatasetValue(row, 'markdownEditor', data.markdown_editor ?? '');
-      }
-      if (Object.prototype.hasOwnProperty.call(data, 'has_children')) {
-        if (data.has_children) {
-          row.setAttribute('has-children', '');
-          row.hasChildren = true;
-        } else {
-          row.removeAttribute('has-children');
-          row.hasChildren = false;
-        }
-      }
-      if (typeof row.requestUpdate === 'function') {
-        row.requestUpdate();
-      }
-    }
-
-    function inlinePayloadFromTree(tree) {
-      if (!tree) return null;
-      const row = treeRowElement(tree);
-      if (!row) return null;
-
-      // Relax validation - allow loading with partial data for instant UI
-      const hasDescription = hasDatasetValue(row, 'descriptionRawHtml') || hasDatasetValue(row, 'descriptionHtml');
-      const hasProgress = hasDatasetValue(row, 'progressValue');
-
-      // Only require ID to be present
-      const id = tree.dataset?.id;
-      if (!id) return null;
-
-      const rawHtml = hasDatasetValue(row, 'descriptionRawHtml') ? row.dataset.descriptionRawHtml : row.dataset.descriptionHtml || '';
-      const description = row.dataset.descriptionHtml || rawHtml || '';
-      const progressValue = hasProgress ? Number(row.dataset.progressValue ?? 0) : 0;
-      const parentId = tree.dataset?.parentId || '';
-
-      return {
-        id: id,
-        description,
-        description_raw_html: rawHtml,
-        origin_id: row.dataset?.originId || '',
-        parent_id: parentId,
-        progress: Number.isNaN(progressValue) ? 0 : progressValue,
-        content_type: row.dataset?.contentType || null,
-        markdown_editor: row.dataset?.markdownEditor || null,
-        markdown_source: row.dataset?.markdownSource || null
-      };
     }
 
     function activateMarkdownMode(source) {


### PR DESCRIPTION
## What this is
Slice 3 of the `creative_row_editor.js` god-file decomposition (rot ①), following slices 1 (`creative_save_queue.js`) and 2 (`creative_tree_dom.js`).

## Seam deviation (important)
The recommended `buildSavePayload(...)` seam **does not exist** in the god-file. The save path is `saveForm(tree, parentId)` → `performSave()` closure, which is deeply entangled with editor closure state (`currentTree`, `form`, `parentInput`, `methodInput`, `creativesApi`, `saveQueue`, `pendingSave`, `isDirty`, …). It is NOT a clean closure-state-free seam and was intentionally left in place.

Instead I extracted the **closest closure-state-free analog**: the *inline creative payload* inverse pair — the functions that build a payload from row DOM and apply an API payload back into row DOM (the "capture DOM state / instant UI" mapping).

## What moved
New module `engines/collavre/app/javascript/modules/creative_inline_payload.js` with two exported functions, verbatim-copied:
- `inlinePayloadFromTree(tree)` — reads an inline creative payload OUT of a rendered `creative-tree-row` dataset (id, description, raw html, origin_id, parent_id, progress, content_type, markdown_editor, markdown_source), with the existing "relax validation / default missing to 0/''" behavior.
- `updateRowFromData(row, data)` — writes an API/server payload INTO a row's dataset + attributes, with the existing `hasOwnProperty`-gated field writes and `has_children` attribute toggling.

Both depend only on their arguments plus the pure DOM helpers already living in `creative_row_editor_helpers.js` (`treeRowElement`, `hasDatasetValue`, `setRowDatasetValue`). The god-file now imports them; the now-unused `setRowDatasetValue` import was dropped from the god-file (still used inside the new module). `hasDatasetValue`/`treeRowElement` remain imported because `loadCreative` still uses them.

## Why it's behavior-preserving
- Function bodies are byte-for-byte identical to the originals (including the intentionally-unused `hasDescription` local in `inlinePayloadFromTree`).
- Call sites unchanged: `updateRowFromData` (refreshRow, loadCreative) and `inlinePayloadFromTree` (loadCreative) now resolve to the imported symbols.
- God-file: 2216 → 2149 lines.

## Characterization tests
19 new jsdom characterization tests in `modules/__tests__/creative_inline_payload.test.js`, written and proven green BEFORE the god-file switch, pinning: null/guard paths, full/minimal/partial field reads, NaN/empty progress coercion, description↔raw fallback, `hasOwnProperty` gating, `progress_html` null-skip, `has_children` toggling, `requestUpdate` invocation, and a full round-trip.

## Full-suite result
`npm test` (full jest suite): **53 suites / 593 tests passing** (baseline was 52/574; +1 suite, +19 tests). esbuild bundle (`npm run build`): clean, no errors.

## Illegal-invocation hazard
**None.** Both extracted functions are plain functions — no `setTimeout`/`requestAnimationFrame`, no `this`. No real-browser smoke test needed for this slice.

## Deferred latent bugs (NOT fixed here)
- `inlinePayloadFromTree` computes `hasDescription` but never uses it — dead local (preserved verbatim). The description-completeness gate actually lives at the `loadCreative` call site (which recomputes `hasDescription`/`hasProgress`), so the inline copy is redundant. Cosmetic; left as-is.
- `updateRowFromData` maps `progress: null` → dataset `progressValue = ''` (via `?? ''`), whereas `inlinePayloadFromTree` reads empty-string progress back as `0`. Asymmetric but matches current behavior; documented in tests, not changed.