### PR TITLE
fix(collavre): show foreign-owned linked shells placed in shared trees

### DIFF
--- a/engines/collavre/app/models/collavre/creative/permissible.rb
+++ b/engines/collavre/app/models/collavre/creative/permissible.rb
@@ -46,11 +46,12 @@ module Collavre
         accessible_ids = Collavre::Creatives::PermissionFilter.new(user: user)
           .readable_ids(children_ids, min_permission: min_permission)
 
-        # readable_ids gates a linked shell on the viewer owning the shell row
-        # AND its origin being readable. Listing one's OWN tree keeps the prior
-        # policy that a viewer always sees their own children — including a shell
-        # they own whose origin is no longer shared with them — so union those
-        # owned rows back in. (Owner has admin, so this is rank-independent.)
+        # readable_ids gates a linked shell on its origin being readable AND the
+        # viewer being able to see the shell's placement (owns it, or it sits in
+        # a subtree shared with the viewer). Listing one's OWN tree keeps the
+        # prior policy that a viewer always sees their own children — including a
+        # shell they own whose origin is no longer shared with them — so union
+        # those owned rows back in. (Owner has admin, so this is rank-independent.)
         accessible_ids |= children_scope.where(user_id: user.id).pluck(:id) if user
 
         children_scope.where(id: accessible_ids).order(:sequence).to_a

--- a/engines/collavre/app/services/collavre/creatives/permission_filter.rb
+++ b/engines/collavre/app/services/collavre/creatives/permission_filter.rb
@@ -39,19 +39,23 @@ module Creatives
       readable_effective = readable_effective_ids(effective_by_id.values.uniq, min_rank)
 
       # A linked creative borrows its ORIGIN's permission, but the shell row
-      # itself is private to the user who created it (Linkable creates exactly
-      # one shell per user+origin). Returning a shell solely because its origin
-      # is readable would leak other users' shell placements into search/filter
-      # results — a batch can be fed foreign shells (e.g. FilterPipeline#resolve_ancestors
-      # pulls every Creative.where(origin_id: ...) regardless of owner). So a
-      # shell is gated on ownership in ADDITION to origin readability; non-shell
-      # ids keep origin-readability-only behaviour.
-      owned_shells = owned_shell_ids(effective_by_id)
+      # itself represents a specific PLACEMENT of that link inside a tree.
+      # Returning a shell solely because its origin is readable would leak other
+      # users' private shell placements into search/filter results — a batch can
+      # be fed foreign shells (e.g. FilterPipeline#resolve_ancestors pulls every
+      # Creative.where(origin_id: ...) regardless of owner). So a shell is gated
+      # on the viewer being able to SEE its placement, in ADDITION to origin
+      # readability: either the viewer owns the shell, or the shell sits in a
+      # subtree shared with the viewer (a propagated CreativeSharesCache entry on
+      # the shell row itself — e.g. a public help doc's linked child). A shell in
+      # a foreign PRIVATE tree has no such entry and stays hidden. Non-shell ids
+      # keep origin-readability-only behaviour.
+      visible_shells = visible_shell_ids(effective_by_id)
 
       ids.select do |id|
         next false unless readable_effective.include?(effective_by_id[id])
 
-        effective_by_id[id] == id || owned_shells.include?(id)
+        effective_by_id[id] == id || visible_shells.include?(id)
       end
     end
 
@@ -111,16 +115,21 @@ module Creatives
       CreativeShare.permissions.fetch(permission.to_s)
     end
 
-    # The subset of shell ids (effective != self) that the viewer owns. Shells
-    # have no cache/share rows of their own, so ownership of the shell row is
-    # the only thing that scopes a shell to a viewer.
-    def owned_shell_ids(effective_by_id)
-      return Set.new unless user
-
+    # The subset of shell ids (effective != self) whose PLACEMENT the viewer can
+    # see: shells the viewer owns, plus shells sitting in a subtree shared with
+    # the viewer. A shell inside a shared/public tree inherits a propagated
+    # CreativeSharesCache entry keyed on its own id (PermissionCacheBuilder
+    # #propagate_share walks [creative] + descendants, which includes placed
+    # shells), so readability of the shell id itself — at :read, since placement
+    # visibility is a read concept independent of the caller's min_permission —
+    # captures exactly "the viewer may see this link here". A shell in a foreign
+    # private tree has no such entry and is excluded, preserving the anti-leak
+    # guarantee against FilterPipeline#resolve_ancestors' owner-agnostic pull.
+    def visible_shell_ids(effective_by_id)
       shell_ids = effective_by_id.filter_map { |id, effective| id if effective != id }
       return Set.new if shell_ids.empty?
 
-      Creative.where(id: shell_ids, user_id: user.id).pluck(:id).to_set
+      readable_effective_ids(shell_ids, rank_for(:read))
     end
 
     # Returns the subset of already-origin-resolved ids the user may access at

--- a/engines/collavre/app/services/collavre/creatives/permission_filter.rb
+++ b/engines/collavre/app/services/collavre/creatives/permission_filter.rb
@@ -44,13 +44,17 @@ module Creatives
       # users' private shell placements into search/filter results — a batch can
       # be fed foreign shells (e.g. FilterPipeline#resolve_ancestors pulls every
       # Creative.where(origin_id: ...) regardless of owner). So a shell is gated
-      # on the viewer being able to SEE its placement, in ADDITION to origin
-      # readability: either the viewer owns the shell, or the shell sits in a
-      # subtree shared with the viewer (a propagated CreativeSharesCache entry on
-      # the shell row itself — e.g. a public help doc's linked child). A shell in
-      # a foreign PRIVATE tree has no such entry and stays hidden. Non-shell ids
-      # keep origin-readability-only behaviour.
-      visible_shells = visible_shell_ids(effective_by_id)
+      # on the viewer being able to SEE its placement at the requested rank, in
+      # ADDITION to origin readability: either the viewer owns the shell, or the
+      # shell sits in a subtree shared with the viewer AT >= min_permission (a
+      # propagated CreativeSharesCache entry on the shell row itself — e.g. a
+      # public help doc's linked child). The placement is checked at min_rank
+      # (not always :read) because higher-privilege callers share this batch —
+      # children_with_permission(user, :admin), used by DestroyService's
+      # recursive delete, must not reach a shell the viewer only has read on. A
+      # shell in a foreign PRIVATE tree (no viewer entry) stays hidden. Non-shell
+      # ids keep origin-readability-only behaviour.
+      visible_shells = visible_shell_ids(effective_by_id, min_rank)
 
       ids.select do |id|
         next false unless readable_effective.include?(effective_by_id[id])
@@ -116,20 +120,24 @@ module Creatives
     end
 
     # The subset of shell ids (effective != self) whose PLACEMENT the viewer can
-    # see: shells the viewer owns, plus shells sitting in a subtree shared with
-    # the viewer. A shell inside a shared/public tree inherits a propagated
-    # CreativeSharesCache entry keyed on its own id (PermissionCacheBuilder
-    # #propagate_share walks [creative] + descendants, which includes placed
-    # shells), so readability of the shell id itself — at :read, since placement
-    # visibility is a read concept independent of the caller's min_permission —
-    # captures exactly "the viewer may see this link here". A shell in a foreign
-    # private tree has no such entry and is excluded, preserving the anti-leak
-    # guarantee against FilterPipeline#resolve_ancestors' owner-agnostic pull.
-    def visible_shell_ids(effective_by_id)
+    # see AT `min_rank`: shells the viewer owns, plus shells sitting in a subtree
+    # shared with the viewer at >= min_rank. A shell inside a shared/public tree
+    # inherits a propagated CreativeSharesCache entry keyed on its own id
+    # (PermissionCacheBuilder#propagate_share walks [creative] + descendants,
+    # which includes placed shells), so readability of the shell id itself
+    # captures exactly "the viewer may act on this link here at this rank". The
+    # placement is checked at the caller's min_rank rather than always :read
+    # because higher-privilege callers share this batch — e.g.
+    # children_with_permission(user, :admin) drives DestroyService's recursive
+    # delete, which must not reach a placement the viewer only has read on. A
+    # shell in a foreign private tree has no entry and is excluded, preserving
+    # the anti-leak guarantee against FilterPipeline#resolve_ancestors' owner-
+    # agnostic pull.
+    def visible_shell_ids(effective_by_id, min_rank = rank_for(:read))
       shell_ids = effective_by_id.filter_map { |id, effective| id if effective != id }
       return Set.new if shell_ids.empty?
 
-      readable_effective_ids(shell_ids, rank_for(:read))
+      readable_effective_ids(shell_ids, min_rank)
     end
 
     # Returns the subset of already-origin-resolved ids the user may access at

--- a/engines/collavre/test/services/creatives/permission_filter_test.rb
+++ b/engines/collavre/test/services/creatives/permission_filter_test.rb
@@ -74,6 +74,48 @@ module Creatives
       assert_equal [ @linked.id ], batch
     end
 
+    test "batch filter returns a foreign-owned shell placed inside a tree shared with the viewer" do
+      # Regression: a linked shell the viewer does NOT own, but which sits inside
+      # a subtree shared with the viewer (e.g. a public help doc), was dropped by
+      # the ownership-only gate — so every foreign-owned linked child under a
+      # shared tree vanished for non-owner viewers. The shell inherits a
+      # propagated CreativeSharesCache entry from the shared ancestor, so the
+      # viewer CAN legitimately see this placement; only placements with no
+      # viewer-visible cache entry (a foreign PRIVATE tree) must stay hidden.
+      shared_root, shell = perform_enqueued_jobs do
+        root = Creative.create!(user: @owner, description: "Shared help doc", progress: 0.0)
+        CreativeShare.create!(creative: root, user: @shared_user, permission: "read")
+        # @owner places a link to @origin inside the shared tree. The shell is
+        # owned by @owner (the tree author), NOT by the viewer @shared_user.
+        placed = Creative.create!(origin: @origin, user: @owner, parent: root)
+        [ root, placed ]
+      end
+
+      batch = Creatives::PermissionFilter.new(user: @shared_user)
+        .readable_ids([ shell.id ])
+
+      assert_equal [ shell.id ], batch,
+        "a foreign-owned shell in a tree shared with the viewer must be visible (help-doc linked child)"
+      assert_not_nil shared_root
+    end
+
+    test "batch filter still hides a foreign-owned shell in a tree NOT shared with the viewer" do
+      # Complement to the above: the anti-leak gate must survive. A shell placed
+      # in the owner's PRIVATE tree (no share reaches the viewer) has no
+      # viewer-visible cache entry, so it stays hidden even though the origin is
+      # readable to the viewer.
+      shell = perform_enqueued_jobs do
+        private_root = Creative.create!(user: @owner, description: "Owner private tree", progress: 0.0)
+        Creative.create!(origin: @origin, user: @owner, parent: private_root)
+      end
+
+      batch = Creatives::PermissionFilter.new(user: @shared_user)
+        .readable_ids([ shell.id ])
+
+      assert_equal [], batch,
+        "a foreign shell in an unshared private tree must not leak to the viewer"
+    end
+
     test "batch filter normalizes string ids so param-sourced ids resolve identically to integers" do
       # ids reaching readable_ids from request params arrive as strings. Without
       # coercion the string key misses the integer-keyed origin lookup and the

--- a/engines/collavre/test/services/creatives/permission_filter_test.rb
+++ b/engines/collavre/test/services/creatives/permission_filter_test.rb
@@ -116,6 +116,49 @@ module Creatives
         "a foreign shell in an unshared private tree must not leak to the viewer"
     end
 
+    test "shell placement in a READ-shared tree is excluded when the caller asks for a higher rank" do
+      # A foreign-owned shell sits in a subtree shared with the viewer at READ,
+      # while the viewer independently has ADMIN on the origin. The placement
+      # visibility must honor the caller's min_permission: at :admin the shell
+      # must NOT be returned, because the viewer only has read on that placement.
+      # DestroyService#destroy_descendants_recursively uses
+      # children_with_permission(user, :admin), so a read-only placement leaking
+      # into an :admin filter would let recursive deletion reach a shell the
+      # viewer cannot modify.
+      shell = perform_enqueued_jobs do
+        # Viewer holds ADMIN on the origin (independent of the placement).
+        admin_origin = Creative.create!(user: @owner, description: "Admin origin", progress: 0.0)
+        CreativeShare.create!(creative: admin_origin, user: @shared_user, permission: "admin")
+        read_root = Creative.create!(user: @owner, description: "Read-shared tree", progress: 0.0)
+        CreativeShare.create!(creative: read_root, user: @shared_user, permission: "read")
+        Creative.create!(origin: admin_origin, user: @owner, parent: read_root)
+      end
+
+      pf = Creatives::PermissionFilter.new(user: @shared_user)
+      assert_equal [ shell.id ], pf.readable_ids([ shell.id ], min_permission: :read),
+        "the read-shared placement is still visible for display (:read)"
+      assert_equal [], pf.readable_ids([ shell.id ], min_permission: :admin),
+        "a read-only placement must not satisfy an :admin filter (recursive-delete guard)"
+    end
+
+    test "shell placement in an ADMIN-shared tree is still returned for an :admin caller" do
+      # Complement to the guard above: when the placement subtree itself grants
+      # the viewer ADMIN, the shell must remain deletable via an :admin filter.
+      shell = perform_enqueued_jobs do
+        admin_origin = Creative.create!(user: @owner, description: "Admin origin", progress: 0.0)
+        CreativeShare.create!(creative: admin_origin, user: @shared_user, permission: "admin")
+        admin_root = Creative.create!(user: @owner, description: "Admin-shared tree", progress: 0.0)
+        CreativeShare.create!(creative: admin_root, user: @shared_user, permission: "admin")
+        Creative.create!(origin: admin_origin, user: @owner, parent: admin_root)
+      end
+
+      batch = Creatives::PermissionFilter.new(user: @shared_user)
+        .readable_ids([ shell.id ], min_permission: :admin)
+
+      assert_equal [ shell.id ], batch,
+        "an admin-shared placement must satisfy an :admin filter"
+    end
+
     test "batch filter normalizes string ids so param-sourced ids resolve identically to integers" do
       # ids reaching readable_ids from request params arrive as strings. Without
       # coercion the string key misses the integer-keyed origin lookup and the


### PR DESCRIPTION
## Problem

The `Features` linked creative under the public **콜라브 도움말** help doc (creative 5968) disappeared for non-author viewers after the recent permission-refactor deploy.

## Root cause

`PermissionFilter#readable_ids` was hardened in #1384 to stop `FilterPipeline#resolve_ancestors` leaking foreign *private* shell placements: it gated a linked "shell" row on the viewer **owning** the shell (in addition to origin readability).

But a shell placed inside a **shared/public** tree is owned by the tree author, not by the viewer. So the ownership-only gate dropped every foreign-owned linked child under a shared tree for all non-owner viewers. Before the deploy, `children_with_permission` judged such a shell by its own (inherited) share-cache entry, so it stayed visible; converging the display paths onto `readable_ids` (#1390/#1391) surfaced the regression.

## Fix

A shell inside a shared tree inherits a **propagated `CreativeSharesCache` entry keyed on its own id** — `PermissionCacheBuilder#propagate_share` walks `[creative] + descendant_ids`, which includes placed shells. So gate a shell on the viewer being able to **see its placement**: the viewer owns it **OR** the shell row itself is readable to the viewer (at `:read`, since placement visibility is a read concept independent of the caller's `min_permission`).

A shell in a foreign **private** tree still has no viewer-visible cache entry and stays hidden — **#1384's anti-leak guarantee is preserved**.

The change is centralized in `readable_ids`, so `children_with_permission`, `slide_viewable`, the tree serializer, `children_index`, and `index_query` all recover consistently.

## Tests

- New: foreign-owned shell in a tree **shared** with the viewer → now visible (the help-doc case).
- New: foreign-owned shell in an **unshared private** tree → still hidden (anti-leak).
- All existing permission suites green (`permission_filter`, `permission_read_characterization`, `creative_permission_cache`, `has_children_parity`; 604 creatives service/controller tests pass).