### PR TITLE
feat: pin the add-topic button left of the topic-list button

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -1452,23 +1452,6 @@ body.chat-fullscreen {
     fill-opacity: 0.2;
 }
 
-.comment-topics-list {
-    display: flex;
-    flex-wrap: nowrap;
-    align-items: center;
-    gap: 0.5em;
-    padding: var(--space-1) 0;
-    overflow-x: auto;
-    overflow-y: hidden;
-    scrollbar-width: none; /* Firefox */
-    -ms-overflow-style: none; /* IE/Edge */
-    min-height: 36px; /* Prevent height collapse during scroll */
-}
-
-.comment-topics-list::-webkit-scrollbar {
-    display: none; /* Chrome/Safari */
-}
-
 .topic-tag {
     display: inline-flex;
     align-items: center;
@@ -1649,6 +1632,11 @@ body.chat-fullscreen {
     display: inline-flex;
     align-items: center;
     flex-shrink: 0;
+}
+
+/* Class rule above outranks the UA [hidden] rule, so restate it. */
+.topic-creation-container[hidden] {
+    display: none;
 }
 
 .add-topic-btn {

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_creation_container.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_creation_container.test.js
@@ -128,6 +128,20 @@ describe('TopicsController create-button placement', () => {
     expect(document.querySelector('.add-topic-btn')).not.toBeNull()
   })
 
+  // Alt+Left/Right chat navigation switches creatives without blurring the input,
+  // so a preserved draft would otherwise be posted to the wrong creative.
+  test('drops an in-progress topic name when the creative changes', () => {
+    controller.renderTopics(TOPICS, true, true)
+    controller.showInput({ preventDefault() {} })
+    controller.creationContainerTarget.querySelector('.topic-input').value = 'for-42'
+
+    controller.creativeIdValue = '77'
+    controller.renderTopics(TOPICS, true, true)
+
+    expect(controller.creationContainerTarget.querySelector('.topic-input')).toBeNull()
+    expect(document.querySelector('.add-topic-btn')).not.toBeNull()
+  })
+
   // The container is static markup, but rendering must not throw if a caller
   // mounts the controller on a stripped-down strip.
   test('no-ops when the container is absent', () => {

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_creation_container.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_creation_container.test.js
@@ -75,7 +75,7 @@ describe('TopicsController create-button placement', () => {
     controller.renderTopics(TOPICS, true, true)
     controller.renderTopics(TOPICS, false, false)
 
-    const creation = controller.creationContainer
+    const creation = controller.creationContainerTarget
     expect(creation.hidden).toBe(true)
     expect(creation.innerHTML).toBe('')
     expect(document.querySelector('.add-topic-btn')).toBeNull()
@@ -85,7 +85,7 @@ describe('TopicsController create-button placement', () => {
     controller.renderTopics(TOPICS, false, false)
     controller.renderTopics(TOPICS, true, true)
 
-    expect(controller.creationContainer.hidden).toBe(false)
+    expect(controller.creationContainerTarget.hidden).toBe(false)
     expect(document.querySelector('.add-topic-btn')).not.toBeNull()
   })
 
@@ -94,12 +94,22 @@ describe('TopicsController create-button placement', () => {
     controller.renderTopics(TOPICS, true, true)
     controller.showInput({ preventDefault() {} })
 
-    const input = controller.creationContainer.querySelector('.topic-input')
+    const input = controller.creationContainerTarget.querySelector('.topic-input')
     input.value = 'half-typed'
 
     controller.renderTopics([...TOPICS, { id: 99, name: 'from-broadcast' }], true, true)
 
-    expect(controller.creationContainer.querySelector('.topic-input')).toBe(input)
+    expect(controller.creationContainerTarget.querySelector('.topic-input')).toBe(input)
     expect(input.value).toBe('half-typed')
+  })
+
+  // The container is static markup, but rendering must not throw if a caller
+  // mounts the controller on a stripped-down strip.
+  test('no-ops when the container is absent', () => {
+    controller.creationContainerTarget.remove()
+
+    expect(() => controller.renderTopics(TOPICS, true, true)).not.toThrow()
+    expect(() => controller.showInput({ preventDefault() {} })).not.toThrow()
+    expect(controller.listTarget.querySelector('.topic-tag[data-id="12"]')).not.toBeNull()
   })
 })

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_creation_container.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_creation_container.test.js
@@ -1,0 +1,105 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { jest } from '@jest/globals'
+
+// The add-topic button used to be rendered as the last child of the horizontally
+// scrolling topic strip, so it drifted off-screen once enough topics existed.
+// It now lives outside the strip, left of the topic-list button, and renderTopics
+// only toggles it. These tests pin that it stays out of the strip, that the
+// permission gate still applies, and that a re-render no longer wipes a name
+// being typed.
+jest.unstable_mockModule('../../../lib/utils/dialog', () => ({
+  confirmDialog: jest.fn(),
+  alertDialog: jest.fn(),
+}))
+
+const { Application } = await import('@hotwired/stimulus')
+const TopicsController = (await import('../topics_controller')).default
+
+const TOPICS = Array.from({ length: 12 }, (_, i) => ({ id: i + 1, name: `topic-${i + 1}` }))
+
+describe('TopicsController create-button placement', () => {
+  let application
+  let container
+  let controller
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    container.innerHTML = `
+      <div id="topics" data-controller="comments--topics">
+        <div class="comment-topics-bar">
+          <div data-comments--topics-target="list" class="comment-topics-list"
+               data-new-topic-placeholder="New Topic"></div>
+          <span class="topic-creation-container"
+                data-comments--topics-target="creationContainer" hidden></span>
+          <button type="button" class="topic-list-btn"></button>
+        </div>
+      </div>
+    `
+    document.body.appendChild(container)
+
+    application = Application.start()
+    application.register('comments--topics', TopicsController)
+
+    return new Promise((resolve) => setTimeout(resolve, 0)).then(() => {
+      const element = document.getElementById('topics')
+      controller = application.getControllerForElementAndIdentifier(element, 'comments--topics')
+      controller.creativeIdValue = '42'
+      controller.loadTopics = jest.fn()
+    })
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+    application.stop()
+    jest.clearAllMocks()
+  })
+
+  test('renders the create button outside the scrolling strip, left of the topic-list button', () => {
+    controller.renderTopics(TOPICS, true, true)
+
+    expect(controller.listTarget.querySelector('.add-topic-btn')).toBeNull()
+
+    const button = document.querySelector('.add-topic-btn')
+    expect(button).not.toBeNull()
+
+    const creation = button.closest('.topic-creation-container')
+    expect(creation.hidden).toBe(false)
+    expect(creation.previousElementSibling).toBe(controller.listTarget)
+    expect(creation.nextElementSibling.classList.contains('topic-list-btn')).toBe(true)
+  })
+
+  test('hides and empties the container when the user cannot create topics', () => {
+    controller.renderTopics(TOPICS, true, true)
+    controller.renderTopics(TOPICS, false, false)
+
+    const creation = controller.creationContainer
+    expect(creation.hidden).toBe(true)
+    expect(creation.innerHTML).toBe('')
+    expect(document.querySelector('.add-topic-btn')).toBeNull()
+  })
+
+  test('re-shows the button when permission is regained', () => {
+    controller.renderTopics(TOPICS, false, false)
+    controller.renderTopics(TOPICS, true, true)
+
+    expect(controller.creationContainer.hidden).toBe(false)
+    expect(document.querySelector('.add-topic-btn')).not.toBeNull()
+  })
+
+  // A topic broadcast used to re-render the whole strip and destroy the open input.
+  test('preserves an in-progress topic name across a re-render', () => {
+    controller.renderTopics(TOPICS, true, true)
+    controller.showInput({ preventDefault() {} })
+
+    const input = controller.creationContainer.querySelector('.topic-input')
+    input.value = 'half-typed'
+
+    controller.renderTopics([...TOPICS, { id: 99, name: 'from-broadcast' }], true, true)
+
+    expect(controller.creationContainer.querySelector('.topic-input')).toBe(input)
+    expect(input.value).toBe('half-typed')
+  })
+})

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_creation_container.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_creation_container.test.js
@@ -103,6 +103,31 @@ describe('TopicsController create-button placement', () => {
     expect(input.value).toBe('half-typed')
   })
 
+  // createTopic keeps `creating` set across its loadTopics() await, so the
+  // re-render it triggers must not mistake the submitted input for live typing.
+  test('restores the add button after a successful creation', async () => {
+    controller.renderTopics(TOPICS, true, true)
+    controller.showInput({ preventDefault() {} })
+
+    const input = controller.creationContainerTarget.querySelector('.topic-input')
+    input.value = 'shipped'
+
+    document.head.innerHTML = '<meta name="csrf-token" content="tok">'
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: 99, name: 'shipped' }),
+    })
+    controller.flushSaveLastTopic = jest.fn()
+    controller.loadTopics = jest.fn(async () => {
+      controller.renderTopics([...TOPICS, { id: 99, name: 'shipped' }], true, true)
+    })
+
+    await controller.createTopic('shipped')
+
+    expect(controller.creationContainerTarget.querySelector('.topic-input')).toBeNull()
+    expect(document.querySelector('.add-topic-btn')).not.toBeNull()
+  })
+
   // The container is static markup, but rendering must not throw if a caller
   // mounts the controller on a stripped-down strip.
   test('no-ops when the container is absent', () => {

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -209,7 +209,10 @@ export default class extends Controller {
 
         // renderTopics re-runs on every topic broadcast; don't wipe a name being typed.
         // `creating` marks an already-submitted name, whose input must give way to the button.
-        if (!this.creating && container.querySelector('.topic-input')) return
+        // A draft only survives re-renders of the creative it was typed for: chat-nav
+        // switches creatives without blurring, and posting it there is the wrong creative.
+        const draftIsCurrent = String(this._draftCreativeId) === String(this.creativeId)
+        if (!this.creating && draftIsCurrent && container.querySelector('.topic-input')) return
 
         this.renderAddButton()
     }
@@ -539,6 +542,7 @@ export default class extends Controller {
         if (!this.hasCreationContainerTarget) return
         const container = this.creationContainerTarget
 
+        this._draftCreativeId = this.creativeId
         const placeholder = this.listTarget.dataset.newTopicPlaceholder || "New Topic"
         container.innerHTML = `<input type="text" class="topic-input" placeholder="${placeholder}" 
                                   data-action="keydown->comments--topics#handleInputKey blur->comments--topics#resetInput"

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -208,7 +208,8 @@ export default class extends Controller {
         }
 
         // renderTopics re-runs on every topic broadcast; don't wipe a name being typed.
-        if (container.querySelector('.topic-input')) return
+        // `creating` marks an already-submitted name, whose input must give way to the button.
+        if (!this.creating && container.querySelector('.topic-input')) return
 
         this.renderAddButton()
     }

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -189,15 +189,32 @@ export default class extends Controller {
             }
         }
 
-        // Add create button container (write permission is sufficient for topic creation)
-        if (canCreateTopic) {
-            html += `<span class="topic-creation-container" data-comments--topics-target="creationContainer"
-                          data-action="dragover->comments--topics#handleAddButtonDragOver dragleave->comments--topics#handleDragLeave drop->comments--topics#handleAddButtonDrop">
-                  <button class="add-topic-btn" data-action="click->comments--topics#showInput">+</button>
-                 </span>`
+        this.listTarget.innerHTML = html
+
+        // The create button lives outside the scrolling strip so it stays reachable
+        // without horizontal scrolling, no matter how many topics there are.
+        this.renderCreationContainer(canCreateTopic)
+    }
+
+    // Write permission is sufficient for topic creation.
+    renderCreationContainer(canCreateTopic) {
+        const container = this.creationContainer
+        if (!container) return
+
+        container.hidden = !canCreateTopic
+        if (!canCreateTopic) {
+            container.innerHTML = ''
+            return
         }
 
-        this.listTarget.innerHTML = html
+        // renderTopics re-runs on every topic broadcast; don't wipe a name being typed.
+        if (container.querySelector('.topic-input')) return
+
+        container.innerHTML = `<button class="add-topic-btn" data-action="click->comments--topics#showInput">+</button>`
+    }
+
+    get creationContainer() {
+        return this.element.querySelector('[data-comments--topics-target="creationContainer"]')
     }
 
     handleDragOver(event) {
@@ -517,7 +534,7 @@ export default class extends Controller {
 
     showInput(event) {
         event.preventDefault()
-        const container = this.element.querySelector('[data-comments--topics-target="creationContainer"]')
+        const container = this.creationContainer
         if (!container) return
 
         const placeholder = this.listTarget.dataset.newTopicPlaceholder || "New Topic"
@@ -532,7 +549,7 @@ export default class extends Controller {
     resetInput() {
         // Small delay to allow enter key to process first if that was the cause
         setTimeout(() => {
-            const container = this.element.querySelector('[data-comments--topics-target="creationContainer"]')
+            const container = this.creationContainer
             if (container && !this.creating) {
                 container.innerHTML = `<button class="add-topic-btn" data-action="click->comments--topics#showInput">+</button>`
             }

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -7,7 +7,7 @@ const ICON_ARCHIVE = `<svg width="12" height="12" viewBox="0 0 24 24" fill="none
 const ICON_RESTORE = `<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7v6h6"/><path d="M21 17a9 9 0 0 0-9-9 9 9 0 0 0-6.69 3L3 13"/></svg>`
 
 export default class extends Controller {
-    static targets = ["list"]
+    static targets = ["list", "creationContainer"]
 
     connect() {
         this.topics = []
@@ -198,8 +198,8 @@ export default class extends Controller {
 
     // Write permission is sufficient for topic creation.
     renderCreationContainer(canCreateTopic) {
-        const container = this.creationContainer
-        if (!container) return
+        if (!this.hasCreationContainerTarget) return
+        const container = this.creationContainerTarget
 
         container.hidden = !canCreateTopic
         if (!canCreateTopic) {
@@ -210,11 +210,12 @@ export default class extends Controller {
         // renderTopics re-runs on every topic broadcast; don't wipe a name being typed.
         if (container.querySelector('.topic-input')) return
 
-        container.innerHTML = `<button class="add-topic-btn" data-action="click->comments--topics#showInput">+</button>`
+        this.renderAddButton()
     }
 
-    get creationContainer() {
-        return this.element.querySelector('[data-comments--topics-target="creationContainer"]')
+    renderAddButton() {
+        this.creationContainerTarget.innerHTML =
+            `<button class="add-topic-btn" data-action="click->comments--topics#showInput">+</button>`
     }
 
     handleDragOver(event) {
@@ -534,8 +535,8 @@ export default class extends Controller {
 
     showInput(event) {
         event.preventDefault()
-        const container = this.creationContainer
-        if (!container) return
+        if (!this.hasCreationContainerTarget) return
+        const container = this.creationContainerTarget
 
         const placeholder = this.listTarget.dataset.newTopicPlaceholder || "New Topic"
         container.innerHTML = `<input type="text" class="topic-input" placeholder="${placeholder}" 
@@ -549,9 +550,8 @@ export default class extends Controller {
     resetInput() {
         // Small delay to allow enter key to process first if that was the cause
         setTimeout(() => {
-            const container = this.creationContainer
-            if (container && !this.creating) {
-                container.innerHTML = `<button class="add-topic-btn" data-action="click->comments--topics#showInput">+</button>`
+            if (this.hasCreationContainerTarget && !this.creating) {
+                this.renderAddButton()
             }
         }, 200)
     }

--- a/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
@@ -135,6 +135,8 @@
     <div id="comment-topics" data-comments--topics-target="list" class="comment-topics-list"
          data-confirm-delete-text="<%= t('collavre.topics.delete_confirm') %>"
          data-new-topic-placeholder="<%= t('collavre.topics.new_placeholder') %>"></div>
+    <span class="topic-creation-container" data-comments--topics-target="creationContainer" hidden
+          data-action="dragover->comments--topics#handleAddButtonDragOver dragleave->comments--topics#handleDragLeave drop->comments--topics#handleAddButtonDrop"></span>
     <button type="button" class="topic-list-btn"
             data-action="click->comments--topics#openTopicListPopup"
             title="<%= t('collavre.comments.topic_list') %>"

--- a/skills/demo-video/scenarios/launch.yml
+++ b/skills/demo-video/scenarios/launch.yml
@@ -147,11 +147,12 @@ steps:
   # ── Scene 2 — the discussion lives on the work ───────────────────────────
   - open_chat: "{{leaf}}"
   - wait: 1800
-  - click: "#comment-topics .add-topic-btn"
+  # The creation control sits beside the topic strip, not inside it.
+  - click: ".topic-creation-container .add-topic-btn"
   - wait: 700
   # blur resets the input back to a "+" button, so type and press Enter with no
   # intervening click.
-  - type: { selector: "#comment-topics input.topic-input", text: "{{topic}}", delay: 60 }
+  - type: { selector: ".topic-creation-container input.topic-input", text: "{{topic}}", delay: 60 }
   - press: Enter
   - wait_for: { selector: "#comment-topics .topic-tag", text: "{{topic}}", timeout: 12000 }
   - wait: 1000


### PR DESCRIPTION
## Problem

The add-topic (`+`) button was rendered as the last child of `#comment-topics`, the horizontally scrolling topic strip. Once a creative had enough topics, the button drifted past the right edge and could only be reached by scrolling the strip to its end.

## Change

Move `.topic-creation-container` out of the scrolling strip and into `.comment-topics-bar`, between the strip and the topic-list button. It is now static markup in `_comments_popup.html.erb`; `renderTopics` no longer rebuilds it and only toggles visibility from the `can_create_topic` permission.

Two follow-on effects:

- A topic broadcast used to re-render the whole strip and destroy an open `.topic-input`, discarding a half-typed topic name. The new `renderCreationContainer` bails out when an input is open, so the name survives.
- `.comment-topics-list` had a byte-identical duplicate rule block in `comments_popup.css`. Removed the second copy.

The `hidden` attribute needs `.topic-creation-container[hidden] { display: none }` because the class rule's `display: inline-flex` outranks the UA `[hidden]` rule.

Drag-and-drop onto the `+` button is unaffected: `presence_controller` and `touch_drag` resolve the target with `closest('.topic-creation-container')`, which is position-independent.

## Verification

- `npm test` — 622 tests, 56 suites, all pass. New suite `topics_controller_creation_container.test.js` covers placement, the permission gate in both directions, and input preservation across a re-render.
- `bin/rails test engines/collavre/test/system/topic_list_popup_test.rb` — 3 runs, 23 assertions, 0 failures.
- Real browser on a creative with 15 topics: the `+` sits at the same x position whether the strip is scrolled to the start or the end; opening the input, typing, and pressing Enter creates the topic and resets to the button; no new console errors.

Behavior in a real browser matters here because jsdom does not evaluate the `[hidden]` CSS specificity conflict.