### PR TITLE
fix(comments): keep previous-message button stepping back on rapid clicks

### DIFF
--- a/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_review.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/form_controller_review.test.js
@@ -343,4 +343,30 @@ describe('FormController - Review Quote Chips', () => {
       expect(controller.textareaTarget.value).toBe('fb2')
     })
   })
+
+  describe('active chip re-click - programmatic scroll', () => {
+    // Re-clicking the active chip scrolls its quoted comment into view. That is a
+    // programmatic list scroll, so it must drop the prev-message anchor the same way
+    // scrollToBottom/highlightComment do — otherwise a stale anchor inside the corridor
+    // survives and the next previous-message click skips the comment now in view.
+    test('re-clicking the active chip notifies the list of a programmatic scroll', () => {
+      const commentEl = document.createElement('div')
+      commentEl.setAttribute('data-comment-id', '1')
+      commentEl.scrollIntoView = jest.fn() // jsdom has no scrollIntoView
+      document.body.appendChild(commentEl)
+
+      const notifyProgrammaticScroll = jest.fn()
+      jest
+        .spyOn(controller, 'listController', 'get')
+        .mockReturnValue({ notifyProgrammaticScroll })
+
+      controller.appendReviewQuote(1, 'first') // freshly appended quote is active
+      container.querySelector('.review-quote-chip-text').click()
+
+      expect(commentEl.scrollIntoView).toHaveBeenCalled()
+      expect(notifyProgrammaticScroll).toHaveBeenCalled()
+
+      commentEl.remove()
+    })
+  })
 })

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/list_controller_prev_message.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/list_controller_prev_message.test.js
@@ -1,0 +1,194 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * Covers the previous-message wiring in list_controller: anchor lifecycle across
+ * connect/disconnect, list reloads, and the scroll action itself.
+ *
+ * jsdom has no layout engine, so item geometry is stubbed. `scrollTo` records
+ * the request without moving `scrollTop` — that models the smooth-scroll
+ * animation still being in flight, which is the state the original bug needed.
+ */
+
+import { jest } from '@jest/globals'
+import ListController from '../list_controller'
+
+const ITEM_HEIGHT = 100
+
+function buildController({ itemCount = 5 } = {}) {
+  const state = { scrollTop: 0 }
+
+  const element = document.createElement('div')
+  const list = document.createElement('div')
+  element.appendChild(list)
+  document.body.appendChild(element)
+
+  for (let i = 0; i < itemCount; i++) {
+    const item = document.createElement('div')
+    item.className = 'comment-item'
+    item.dataset.commentId = `c${i}`
+    Object.defineProperty(item, 'offsetTop', { get: () => i * ITEM_HEIGHT })
+    item.getBoundingClientRect = () => ({ top: i * ITEM_HEIGHT - state.scrollTop })
+    list.appendChild(item)
+  }
+
+  list.getBoundingClientRect = () => ({ top: 0 })
+  Object.defineProperty(list, 'offsetTop', { get: () => 0 })
+  list.scrollTo = jest.fn()
+
+  // Stand the controller up without a Stimulus application: `element` is a
+  // getter on Controller.prototype, so it has to be shadowed rather than set.
+  const controller = Object.create(ListController.prototype)
+  Object.defineProperty(controller, 'element', { value: element })
+  Object.defineProperty(controller, 'listTarget', { value: list })
+  controller.connect()
+
+  return {
+    controller,
+    list,
+    element,
+    // Apply the last requested scroll, i.e. let the smooth animation finish.
+    settle() {
+      const call = list.scrollTo.mock.calls.at(-1)
+      if (call) state.scrollTop = call[0].top
+    },
+    // Move the list without going through the button, as a user gesture would.
+    scrollTo(top) {
+      state.scrollTop = top
+    },
+    lastScrollTop() {
+      return list.scrollTo.mock.calls.at(-1)?.[0].top
+    },
+  }
+}
+
+describe('list_controller previous-message navigation', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  test('connect installs a navigator', () => {
+    const { controller } = buildController()
+    expect(controller.prevMsgNavigator).toBeTruthy()
+  })
+
+  test('walks backwards one message per click when settled', () => {
+    const h = buildController()
+    h.scrollTo(4 * ITEM_HEIGHT) // parked on the last item
+
+    h.controller.scrollToPreviousMessage()
+    expect(h.lastScrollTop()).toBe(3 * ITEM_HEIGHT)
+    h.settle()
+
+    h.controller.scrollToPreviousMessage()
+    expect(h.lastScrollTop()).toBe(2 * ITEM_HEIGHT)
+  })
+
+  test('keeps stepping back when clicked mid-animation', () => {
+    const h = buildController()
+    h.scrollTo(4 * ITEM_HEIGHT)
+
+    // Three clicks with no settle between them: the list never reaches the
+    // requested offset, which is exactly when the old geometry-only code
+    // bounced back to the item it had just left.
+    h.controller.scrollToPreviousMessage()
+    expect(h.lastScrollTop()).toBe(3 * ITEM_HEIGHT)
+    h.controller.scrollToPreviousMessage()
+    expect(h.lastScrollTop()).toBe(2 * ITEM_HEIGHT)
+    h.controller.scrollToPreviousMessage()
+    expect(h.lastScrollTop()).toBe(1 * ITEM_HEIGHT)
+  })
+
+  test('releases stick-to-bottom so incoming comments do not yank the view', () => {
+    const h = buildController()
+    h.controller.stickToBottom = true
+    h.scrollTo(4 * ITEM_HEIGHT)
+
+    h.controller.scrollToPreviousMessage()
+
+    expect(h.controller.stickToBottom).toBe(false)
+  })
+
+  test('does nothing when the list is empty', () => {
+    const h = buildController({ itemCount: 0 })
+
+    h.controller.scrollToPreviousMessage()
+
+    expect(h.list.scrollTo).not.toHaveBeenCalled()
+  })
+
+  test('loads older comments once past the oldest message', () => {
+    const h = buildController()
+    h.controller.allOlderLoaded = false
+    h.controller.loadOlderComments = jest.fn()
+
+    h.controller.scrollToPreviousMessage() // lands on the oldest item
+    h.settle()
+    h.controller.scrollToPreviousMessage() // nothing older in the DOM
+
+    expect(h.controller.loadOlderComments).toHaveBeenCalled()
+  })
+
+  test('stops at the oldest message when everything is already loaded', () => {
+    const h = buildController()
+    h.controller.allOlderLoaded = true
+    h.controller.loadOlderComments = jest.fn()
+
+    h.controller.scrollToPreviousMessage()
+    h.settle()
+    const before = h.list.scrollTo.mock.calls.length
+    h.controller.scrollToPreviousMessage()
+
+    expect(h.controller.loadOlderComments).not.toHaveBeenCalled()
+    expect(h.list.scrollTo.mock.calls.length).toBe(before)
+  })
+
+  describe.each(['wheel', 'touchstart', 'keydown', 'pointerdown'])(
+    'user input via %s',
+    (eventName) => {
+      test('drops the anchor so the next click resolves from where the user landed', () => {
+        const h = buildController()
+        h.scrollTo(4 * ITEM_HEIGHT)
+
+        h.controller.scrollToPreviousMessage() // anchor = c3
+        h.settle()
+
+        // User scrolls back down to the bottom themselves.
+        h.list.dispatchEvent(new Event(eventName))
+        h.scrollTo(4 * ITEM_HEIGHT)
+
+        h.controller.scrollToPreviousMessage()
+
+        // Resolved from geometry (c4 at top -> c3), not from the stale anchor.
+        expect(h.lastScrollTop()).toBe(3 * ITEM_HEIGHT)
+      })
+    }
+  )
+
+  test('disconnect unhooks the user-input listeners', () => {
+    const h = buildController()
+    h.scrollTo(4 * ITEM_HEIGHT)
+    h.controller.scrollToPreviousMessage() // anchor = c3
+    h.settle()
+
+    h.controller.disconnect()
+    h.list.dispatchEvent(new Event('wheel'))
+
+    // Anchor survived because the listener is gone.
+    expect(h.controller.prevMsgNavigator.anchorId).toBe('c3')
+  })
+
+  test('reloading the list drops the anchor', () => {
+    const h = buildController()
+    h.scrollTo(4 * ITEM_HEIGHT)
+    h.controller.scrollToPreviousMessage()
+    expect(h.controller.prevMsgNavigator.anchorId).toBe('c3')
+
+    h.controller.creativeId = '1'
+    h.controller.fetchComments = jest.fn(() => new Promise(() => {}))
+    h.controller.loadInitialComments()
+
+    expect(h.controller.prevMsgNavigator.anchorId).toBeNull()
+  })
+})

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/list_controller_prev_message.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/list_controller_prev_message.test.js
@@ -166,6 +166,42 @@ describe('list_controller previous-message navigation', () => {
     }
   )
 
+  test('a programmatic jump to the bottom drops the anchor', () => {
+    // form_controller (after sending) and the fullscreen handlers call
+    // scrollToBottom() with no user gesture. A small jump can leave the anchor
+    // inside the corridor, where geometry cannot tell it from our own in-flight
+    // scroll, so the next click would step off the stale anchor (c3 -> c2)
+    // instead of resolving from where the list actually is (c4 -> c3).
+    const h = buildController()
+    h.scrollTo(4 * ITEM_HEIGHT)
+
+    h.controller.scrollToPreviousMessage() // anchor = c3, in flight
+    expect(h.controller.prevMsgNavigator.anchorId).toBe('c3')
+
+    h.controller.scrollToBottom()
+    expect(h.controller.prevMsgNavigator.anchorId).toBeNull()
+
+    h.controller.scrollToPreviousMessage()
+    expect(h.lastScrollTop()).toBe(3 * ITEM_HEIGHT) // c3 from geometry, not c2
+  })
+
+  test('a permalink highlight jump drops the anchor', () => {
+    const h = buildController()
+    h.scrollTo(4 * ITEM_HEIGHT)
+
+    h.controller.scrollToPreviousMessage() // anchor = c3
+    expect(h.controller.prevMsgNavigator.anchorId).toBe('c3')
+
+    // highlightComment looks the target up by DOM id and scrolls it into view
+    // (jsdom has no scrollIntoView, so stub it).
+    const target = h.list.querySelector('[data-comment-id="c1"]')
+    target.id = 'comment_c1'
+    target.scrollIntoView = () => {}
+    h.controller.highlightComment('c1')
+
+    expect(h.controller.prevMsgNavigator.anchorId).toBeNull()
+  })
+
   test('disconnect unhooks the user-input listeners', () => {
     const h = buildController()
     h.scrollTo(4 * ITEM_HEIGHT)

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/prev_message_navigator.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/prev_message_navigator.test.js
@@ -47,7 +47,7 @@ describe('PrevMessageNavigator', () => {
     test('keeps stepping backwards while the smooth scroll is still in flight', () => {
       // First click: item 2 is flush with the top, so we head for item 1.
       expect(nav.resolveTargetIndex(items(-200, -100, 100, 300), VIEWPORT_TOP)).toBe(1)
-      nav.commit('1')
+      nav.commit('1', -100)
 
       // Second click lands mid-animation: item 1 has not reached the top yet, so
       // geometry alone would send us back down to item 1. The anchor must win.
@@ -55,41 +55,62 @@ describe('PrevMessageNavigator', () => {
     })
 
     test('survives older comments being prepended (anchor is id based)', () => {
-      nav.commit('c5')
+      // Prepending shifts scrollTop but leaves the anchor where it is on screen,
+      // so it is still on its way from -300 up to the viewport top.
+      nav.commit('c5', -300)
       const prepended = [
-        { id: 'c3', top: -100 },
-        { id: 'c4', top: 0 },
-        { id: 'c5', top: 400 },
+        { id: 'c3', top: -500 },
+        { id: 'c4', top: -300 },
+        { id: 'c5', top: -100 },
       ]
       expect(nav.resolveTargetIndex(prepended, VIEWPORT_TOP)).toBe(1)
     })
 
     test('falls back to geometry when the anchored comment is gone', () => {
-      nav.commit('deleted-comment')
+      nav.commit('deleted-comment', -100)
       expect(nav.resolveTargetIndex(items(-200, -100, 100, 300), VIEWPORT_TOP)).toBe(1)
     })
 
     test('returns -1 when the anchor is already the oldest item', () => {
-      nav.commit('0')
+      nav.commit('0', -100)
       expect(nav.resolveTargetIndex(items(100, 300), VIEWPORT_TOP)).toBe(-1)
+    })
+
+    test('ignores an anchor the list has scrolled away from', () => {
+      // A programmatic jump (new message arriving, permalink highlight) moves the
+      // list without any user gesture, so nothing drops the anchor. It is now far
+      // above where it started, which our own animation can never produce - that
+      // only ever walks the anchor down towards the viewport top.
+      nav.commit('0', -100)
+      expect(nav.resolveTargetIndex(items(-900, -700, 100, 300), VIEWPORT_TOP)).toBe(1)
+    })
+
+    test('a stale anchor stops wedging the button at the oldest message', () => {
+      // Regression: anchored on the oldest item, every later click returned -1
+      // forever once there was nothing more to load, so the button went dead.
+      nav.commit('0', -100)
+      nav.resolveTargetIndex(items(100, 300), VIEWPORT_TOP)
+
+      // The list is jumped back to the bottom; clicking must resume stepping.
+      expect(nav.resolveTargetIndex(items(-900, -700, 100, 300), VIEWPORT_TOP)).toBe(1)
     })
   })
 
   describe('anchor invalidation', () => {
     test('drops the anchor when the user moves the list', () => {
-      nav.commit('1')
+      nav.commit('1', -100)
       nav.notifyUserInput()
       expect(nav.anchorId).toBeNull()
     })
 
     test('reset clears the anchor', () => {
-      nav.commit('1')
+      nav.commit('1', -100)
       nav.reset()
       expect(nav.anchorId).toBeNull()
     })
 
     test('after a user scroll, geometry drives the next click again', () => {
-      nav.commit('1')
+      nav.commit('1', -100)
       nav.notifyUserInput()
       expect(nav.resolveTargetIndex(items(-200, -100, 130, 330), VIEWPORT_TOP)).toBe(2)
     })

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/prev_message_navigator.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/prev_message_navigator.test.js
@@ -1,0 +1,107 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import PrevMessageNavigator from '../prev_message_navigator'
+
+// Items are ordered oldest -> newest, matching DOM order of `.comment-item`.
+// `top` is the item's viewport-relative top, as measured by the controller.
+function items(...tops) {
+  return tops.map((top, i) => ({ id: String(i), top }))
+}
+
+describe('PrevMessageNavigator', () => {
+  const VIEWPORT_TOP = 100
+
+  let nav
+
+  beforeEach(() => {
+    nav = new PrevMessageNavigator()
+  })
+
+  describe('without an anchor (geometry fallback)', () => {
+    test('steps to the previous item when the current one is flush with the top', () => {
+      // item 2 is exactly at the viewport top -> previous message is item 1
+      expect(nav.resolveTargetIndex(items(-200, -100, 100, 300), VIEWPORT_TOP)).toBe(1)
+    })
+
+    test('scrolls the partially visible item to the top first', () => {
+      // item 2 is cut off above the fold -> bring item 2 fully into view
+      expect(nav.resolveTargetIndex(items(-200, -100, 130, 330), VIEWPORT_TOP)).toBe(2)
+    })
+
+    test('starts from the last item when everything is scrolled above the fold', () => {
+      expect(nav.resolveTargetIndex(items(-300, -200, -100), VIEWPORT_TOP)).toBe(2)
+    })
+
+    test('returns -1 at the oldest item so the caller can load older comments', () => {
+      expect(nav.resolveTargetIndex(items(100, 300), VIEWPORT_TOP)).toBe(-1)
+    })
+
+    test('returns -1 for an empty list', () => {
+      expect(nav.resolveTargetIndex([], VIEWPORT_TOP)).toBe(-1)
+    })
+  })
+
+  describe('with an anchor (rapid clicks)', () => {
+    test('keeps stepping backwards while the smooth scroll is still in flight', () => {
+      // First click: item 2 is flush with the top, so we head for item 1.
+      expect(nav.resolveTargetIndex(items(-200, -100, 100, 300), VIEWPORT_TOP)).toBe(1)
+      nav.commit('1')
+
+      // Second click lands mid-animation: item 1 has not reached the top yet, so
+      // geometry alone would send us back down to item 1. The anchor must win.
+      expect(nav.resolveTargetIndex(items(-150, -50, 150, 350), VIEWPORT_TOP)).toBe(0)
+    })
+
+    test('survives older comments being prepended (anchor is id based)', () => {
+      nav.commit('c5')
+      const prepended = [
+        { id: 'c3', top: -100 },
+        { id: 'c4', top: 0 },
+        { id: 'c5', top: 400 },
+      ]
+      expect(nav.resolveTargetIndex(prepended, VIEWPORT_TOP)).toBe(1)
+    })
+
+    test('falls back to geometry when the anchored comment is gone', () => {
+      nav.commit('deleted-comment')
+      expect(nav.resolveTargetIndex(items(-200, -100, 100, 300), VIEWPORT_TOP)).toBe(1)
+    })
+
+    test('returns -1 when the anchor is already the oldest item', () => {
+      nav.commit('0')
+      expect(nav.resolveTargetIndex(items(100, 300), VIEWPORT_TOP)).toBe(-1)
+    })
+  })
+
+  describe('anchor invalidation', () => {
+    test('ignores the scroll events produced by our own animation', () => {
+      nav.commit('1')
+      nav.handleScroll()
+      expect(nav.anchorId).toBe('1')
+    })
+
+    test('drops the anchor once the user scrolls after the animation settles', () => {
+      nav.commit('1')
+      nav.settle()
+      nav.handleScroll()
+      expect(nav.anchorId).toBeNull()
+    })
+
+    test('reset clears both the anchor and the in-flight flag', () => {
+      nav.commit('1')
+      nav.reset()
+      expect(nav.anchorId).toBeNull()
+      nav.handleScroll()
+      expect(nav.anchorId).toBeNull()
+    })
+
+    test('after a user scroll, geometry drives the next click again', () => {
+      nav.commit('1')
+      nav.settle()
+      nav.handleScroll()
+      expect(nav.resolveTargetIndex(items(-200, -100, 130, 330), VIEWPORT_TOP)).toBe(2)
+    })
+  })
+})

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/prev_message_navigator.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/prev_message_navigator.test.js
@@ -76,31 +76,21 @@ describe('PrevMessageNavigator', () => {
   })
 
   describe('anchor invalidation', () => {
-    test('ignores the scroll events produced by our own animation', () => {
+    test('drops the anchor when the user moves the list', () => {
       nav.commit('1')
-      nav.handleScroll()
-      expect(nav.anchorId).toBe('1')
-    })
-
-    test('drops the anchor once the user scrolls after the animation settles', () => {
-      nav.commit('1')
-      nav.settle()
-      nav.handleScroll()
+      nav.notifyUserInput()
       expect(nav.anchorId).toBeNull()
     })
 
-    test('reset clears both the anchor and the in-flight flag', () => {
+    test('reset clears the anchor', () => {
       nav.commit('1')
       nav.reset()
-      expect(nav.anchorId).toBeNull()
-      nav.handleScroll()
       expect(nav.anchorId).toBeNull()
     })
 
     test('after a user scroll, geometry drives the next click again', () => {
       nav.commit('1')
-      nav.settle()
-      nav.handleScroll()
+      nav.notifyUserInput()
       expect(nav.resolveTargetIndex(items(-200, -100, 130, 330), VIEWPORT_TOP)).toBe(2)
     })
   })

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/prev_message_navigator.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/prev_message_navigator.test.js
@@ -54,6 +54,17 @@ describe('PrevMessageNavigator', () => {
       expect(nav.resolveTargetIndex(items(-150, -50, 150, 350), VIEWPORT_TOP)).toBe(0)
     })
 
+    test('keeps stepping when the first click started from a partially visible item', () => {
+      // First click from between messages: item 2 is cut off *below* the top, so
+      // we scroll it up into place and the anchor starts below the viewport top.
+      expect(nav.resolveTargetIndex(items(-200, -100, 130, 330), VIEWPORT_TOP)).toBe(2)
+      nav.commit('2', 130)
+
+      // Second click mid-animation: item 2 is on its way down to the top. The
+      // anchor must still win, otherwise we re-target item 2 and stall.
+      expect(nav.resolveTargetIndex(items(-215, -115, 115, 315), VIEWPORT_TOP)).toBe(1)
+    })
+
     test('survives older comments being prepended (anchor is id based)', () => {
       // Prepending shifts scrollTop but leaves the anchor where it is on screen,
       // so it is still on its way from -300 up to the viewport top.

--- a/engines/collavre/app/javascript/controllers/comments/form_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/form_controller.js
@@ -884,6 +884,9 @@ export default class extends Controller {
         if (quote.id === store.activeId) {
           const commentEl = document.querySelector(`[data-comment-id="${quote.commentId}"]`)
           if (commentEl) {
+            // Programmatic list scroll — drop the prev-message anchor so the next
+            // previous-message click resolves from the quoted comment now in view.
+            this.listController?.notifyProgrammaticScroll()
             commentEl.scrollIntoView({ behavior: 'smooth', block: 'center' })
             commentEl.classList.add('comment-highlight')
             setTimeout(() => commentEl.classList.remove('comment-highlight'), 2000)

--- a/engines/collavre/app/javascript/controllers/comments/list_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/list_controller.js
@@ -1118,7 +1118,7 @@ export default class extends Controller {
 
     const target = elements[targetIdx]
     const targetTop = target.offsetTop - list.offsetTop
-    this.prevMsgNavigator.commit(measured[targetIdx].id)
+    this.prevMsgNavigator.commit(measured[targetIdx].id, measured[targetIdx].top)
     list.scrollTo({ top: targetTop, behavior: 'smooth' })
     this.stickToBottom = false
 

--- a/engines/collavre/app/javascript/controllers/comments/list_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/list_controller.js
@@ -9,6 +9,11 @@ import { alertDialog, confirmDialog } from '../../lib/utils/dialog'
 import PrevMessageNavigator from './prev_message_navigator'
 // CommonPopup is now used via TopicSearchController (Stimulus)
 
+// Gestures that mean the user moved the list themselves, invalidating the
+// previous-message anchor. Only user input fires these — our own smooth scroll
+// does not.
+const PREV_MSG_USER_INPUT_EVENTS = ['wheel', 'touchstart', 'keydown', 'pointerdown']
+
 export default class extends Controller {
   static targets = ['list']
 
@@ -24,6 +29,7 @@ export default class extends Controller {
     this.prevMsgNavigator = new PrevMessageNavigator()
 
     this.handleScroll = this.handleScroll.bind(this)
+    this.handlePrevMsgUserInput = this.handlePrevMsgUserInput.bind(this)
     this.handleChange = this.handleChange.bind(this)
     this.handleClick = this.handleClick.bind(this)
     this.handleSubmit = this.handleSubmit.bind(this)
@@ -35,6 +41,9 @@ export default class extends Controller {
     this.handleStreamRender = this.handleStreamRender.bind(this)
 
     this.listTarget.addEventListener('scroll', this.handleScroll)
+    PREV_MSG_USER_INPUT_EVENTS.forEach((name) => {
+      this.listTarget.addEventListener(name, this.handlePrevMsgUserInput)
+    })
     this.listTarget.addEventListener('change', this.handleChange)
     this.listTarget.addEventListener('click', this.handleClick)
     this.listTarget.addEventListener('submit', this.handleSubmit)
@@ -76,8 +85,10 @@ export default class extends Controller {
   }
 
   disconnect() {
-    clearTimeout(this.prevMsgSettleTimer)
     this.listTarget.removeEventListener('scroll', this.handleScroll)
+    PREV_MSG_USER_INPUT_EVENTS.forEach((name) => {
+      this.listTarget.removeEventListener(name, this.handlePrevMsgUserInput)
+    })
     this.listTarget.removeEventListener('change', this.handleChange)
     this.listTarget.removeEventListener('click', this.handleClick)
     this.listTarget.removeEventListener('submit', this.handleSubmit)
@@ -363,9 +374,11 @@ export default class extends Controller {
     }, 2000);
   }
 
-  handleScroll() {
-    this.prevMsgNavigator.handleScroll()
+  handlePrevMsgUserInput() {
+    this.prevMsgNavigator.notifyUserInput()
+  }
 
+  handleScroll() {
     if (!this.initialLoadComplete) return
 
     // Standard Column:
@@ -1108,11 +1121,6 @@ export default class extends Controller {
     this.prevMsgNavigator.commit(measured[targetIdx].id)
     list.scrollTo({ top: targetTop, behavior: 'smooth' })
     this.stickToBottom = false
-
-    // The anchor stays authoritative until the smooth scroll lands; after that a
-    // scroll event means the user moved the list themselves.
-    clearTimeout(this.prevMsgSettleTimer)
-    this.prevMsgSettleTimer = setTimeout(() => this.prevMsgNavigator.settle(), 700)
 
     target.classList.add('highlight-flash')
     setTimeout(() => target.classList.remove('highlight-flash'), 2000)

--- a/engines/collavre/app/javascript/controllers/comments/list_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/list_controller.js
@@ -6,6 +6,7 @@ import creativesApi from '../../lib/api/creatives'
 import { renderCreativeTree, dispatchCreativeTreeUpdated } from '../../creatives/tree_renderer'
 import { updateCsrfTokenFromResponse } from '../../lib/api/csrf_fetch'
 import { alertDialog, confirmDialog } from '../../lib/utils/dialog'
+import PrevMessageNavigator from './prev_message_navigator'
 // CommonPopup is now used via TopicSearchController (Stimulus)
 
 export default class extends Controller {
@@ -20,6 +21,7 @@ export default class extends Controller {
     this.movingComments = false
     this.manualSearchQuery = null
     this.initialLoadComplete = false
+    this.prevMsgNavigator = new PrevMessageNavigator()
 
     this.handleScroll = this.handleScroll.bind(this)
     this.handleChange = this.handleChange.bind(this)
@@ -74,6 +76,7 @@ export default class extends Controller {
   }
 
   disconnect() {
+    clearTimeout(this.prevMsgSettleTimer)
     this.listTarget.removeEventListener('scroll', this.handleScroll)
     this.listTarget.removeEventListener('change', this.handleChange)
     this.listTarget.removeEventListener('click', this.handleClick)
@@ -151,6 +154,9 @@ export default class extends Controller {
   loadInitialComments() {
     if (!this.creativeId) return
     if (this.selection.size > 0) return
+
+    // The list is about to be replaced wholesale; any anchor we hold is stale.
+    this.prevMsgNavigator.reset()
 
     const params = {}
     if (this.highlightAfterLoad) {
@@ -358,6 +364,8 @@ export default class extends Controller {
   }
 
   handleScroll() {
+    this.prevMsgNavigator.handleScroll()
+
     if (!this.initialLoadComplete) return
 
     // Standard Column:
@@ -1078,28 +1086,16 @@ export default class extends Controller {
 
   scrollToPreviousMessage() {
     const list = this.listTarget
-    const items = Array.from(list.querySelectorAll('.comment-item'))
-    if (items.length === 0) return
+    const elements = Array.from(list.querySelectorAll('.comment-item'))
+    if (elements.length === 0) return
 
-    const listRect = list.getBoundingClientRect()
-    const viewportTop = listRect.top
+    const viewportTop = list.getBoundingClientRect().top
+    const measured = elements.map((el) => ({
+      id: el.dataset.commentId,
+      top: el.getBoundingClientRect().top,
+    }))
 
-    let currentIdx = -1
-    for (let i = 0; i < items.length; i++) {
-      const rect = items[i].getBoundingClientRect()
-      if (rect.top >= viewportTop - 2) {
-        currentIdx = i
-        break
-      }
-    }
-
-    if (currentIdx === -1) currentIdx = items.length - 1
-
-    const currentItem = items[currentIdx]
-    const currentRect = currentItem.getBoundingClientRect()
-    const isAtTop = Math.abs(currentRect.top - viewportTop) < 4
-
-    const targetIdx = isAtTop ? currentIdx - 1 : currentIdx
+    const targetIdx = this.prevMsgNavigator.resolveTargetIndex(measured, viewportTop)
     if (targetIdx < 0) {
       if (!this.allOlderLoaded) {
         this.loadOlderComments()
@@ -1107,10 +1103,16 @@ export default class extends Controller {
       return
     }
 
-    const target = items[targetIdx]
+    const target = elements[targetIdx]
     const targetTop = target.offsetTop - list.offsetTop
+    this.prevMsgNavigator.commit(measured[targetIdx].id)
     list.scrollTo({ top: targetTop, behavior: 'smooth' })
     this.stickToBottom = false
+
+    // The anchor stays authoritative until the smooth scroll lands; after that a
+    // scroll event means the user moved the list themselves.
+    clearTimeout(this.prevMsgSettleTimer)
+    this.prevMsgSettleTimer = setTimeout(() => this.prevMsgNavigator.settle(), 700)
 
     target.classList.add('highlight-flash')
     setTimeout(() => target.classList.remove('highlight-flash'), 2000)

--- a/engines/collavre/app/javascript/controllers/comments/list_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/list_controller.js
@@ -354,6 +354,7 @@ export default class extends Controller {
   highlightComment(commentId) {
     const comment = document.getElementById(`comment_${commentId}`)
     if (!comment) return
+    this.prevMsgNavigator?.notifyProgrammaticScroll()
     comment.scrollIntoView({ behavior: 'auto', block: 'center' })
     comment.classList.add('highlight-flash')
     comment.dataset.highlighted = 'true'
@@ -1136,6 +1137,9 @@ export default class extends Controller {
   }
 
   scrollToBottom() {
+    // A jump to latest we did not initiate via the button - drop the anchor so
+    // the next previous-message click resolves from here, not a stale target.
+    this.prevMsgNavigator?.notifyProgrammaticScroll()
     // In column reverse, bottom of scroll might be tricky.
     // Easiest is to set scrollTop to a large value.
     requestAnimationFrame(() => {

--- a/engines/collavre/app/javascript/controllers/comments/list_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/list_controller.js
@@ -351,6 +351,13 @@ export default class extends Controller {
     return parseInt(last.dataset.commentId)
   }
 
+  // Public seam for sibling controllers that scroll the list on their own
+  // (e.g. the review-quote chip). Lets them drop the prev-message anchor at the
+  // choke point without reaching into the navigator's internals.
+  notifyProgrammaticScroll() {
+    this.prevMsgNavigator?.notifyProgrammaticScroll()
+  }
+
   highlightComment(commentId) {
     const comment = document.getElementById(`comment_${commentId}`)
     if (!comment) return

--- a/engines/collavre/app/javascript/controllers/comments/prev_message_navigator.js
+++ b/engines/collavre/app/javascript/controllers/comments/prev_message_navigator.js
@@ -1,0 +1,65 @@
+// Tracks where the "previous message" button left off.
+//
+// The button scrolls with `behavior: 'smooth'`, so a rapid second click arrives
+// while the list is still mid-animation. Deriving the current position purely
+// from geometry at that moment picks the item we just left (it has not reached
+// the top yet), which makes the list bounce up and down instead of walking
+// backwards. Remembering the last target as an anchor keeps each click stepping
+// one message further back, and geometry only takes over once the user scrolls
+// on their own.
+//
+// Kept free of DOM access so it can be unit tested: jsdom has no layout engine,
+// so the controller measures the items and passes `{ id, top }` pairs in.
+
+// Sub-pixel scroll offsets (HiDPI, browser rounding) mean an item parked at the
+// top is rarely at exactly `viewportTop`.
+const TOP_TOLERANCE = 4
+
+export default class PrevMessageNavigator {
+  constructor() {
+    this.anchorId = null
+    this.scrolling = false
+  }
+
+  // items: `{ id, top }` in DOM order (oldest first), top relative to viewport.
+  // Returns the index to scroll to, or -1 when there is nothing older in the
+  // list (the caller then loads older comments).
+  resolveTargetIndex(items, viewportTop) {
+    if (items.length === 0) return -1
+
+    if (this.anchorId !== null) {
+      const anchorIdx = items.findIndex((item) => item.id === this.anchorId)
+      if (anchorIdx !== -1) return anchorIdx - 1
+    }
+
+    let currentIdx = items.findIndex((item) => item.top >= viewportTop - TOP_TOLERANCE)
+    if (currentIdx === -1) currentIdx = items.length - 1
+
+    const isAtTop = Math.abs(items[currentIdx].top - viewportTop) < TOP_TOLERANCE
+    return isAtTop ? currentIdx - 1 : currentIdx
+  }
+
+  // Called once we start scrolling towards `id`.
+  commit(id) {
+    this.anchorId = id
+    this.scrolling = true
+  }
+
+  // Called when the smooth scroll has landed.
+  settle() {
+    this.scrolling = false
+  }
+
+  // Called on every scroll event. Scroll events fired by our own animation must
+  // not clear the anchor — only a scroll the user drove themselves.
+  handleScroll() {
+    if (this.scrolling) return
+    this.anchorId = null
+  }
+
+  // Called when the list contents are replaced wholesale.
+  reset() {
+    this.anchorId = null
+    this.scrolling = false
+  }
+}

--- a/engines/collavre/app/javascript/controllers/comments/prev_message_navigator.js
+++ b/engines/collavre/app/javascript/controllers/comments/prev_message_navigator.js
@@ -47,17 +47,23 @@ export default class PrevMessageNavigator {
     return isAtTop ? currentIdx - 1 : currentIdx
   }
 
-  // The anchor travels from wherever it sat when we committed up to `viewportTop`,
+  // The anchor travels from wherever it sat when we committed to `viewportTop`,
   // and nothing else moves it. Outside that corridor the list was scrolled by
   // something other than us - a new message arriving, a permalink jump - none of
   // which fire a user input event, so the anchor would otherwise survive and wedge
   // the button (anchored on the oldest item, every click resolves to -1 forever).
   //
+  // The corridor spans both endpoints because the anchor can approach the top from
+  // either side: usually from above (the next message back), but from below when
+  // the click started between messages and we pulled the partially visible one up.
+  //
   // Comparing the anchor against its own start position rather than the list's
   // scroll offset keeps this correct when older comments are prepended: that
   // shifts `scrollTop` but leaves the anchor where it is on screen.
   anchorIsOnItsWay(anchorTop, viewportTop) {
-    return anchorTop >= this.anchorStartTop - TOP_TOLERANCE && anchorTop <= viewportTop + TOP_TOLERANCE
+    const low = Math.min(this.anchorStartTop, viewportTop) - TOP_TOLERANCE
+    const high = Math.max(this.anchorStartTop, viewportTop) + TOP_TOLERANCE
+    return anchorTop >= low && anchorTop <= high
   }
 
   // Called once we start scrolling towards `id`, which currently sits at `top`.

--- a/engines/collavre/app/javascript/controllers/comments/prev_message_navigator.js
+++ b/engines/collavre/app/javascript/controllers/comments/prev_message_navigator.js
@@ -77,6 +77,16 @@ export default class PrevMessageNavigator {
     this.anchorId = null
   }
 
+  // Called when our own code repositions the list without going through the
+  // button - jumping to the newest message, a permalink highlight. These fire no
+  // user input event, and a small jump can leave the anchor inside the corridor
+  // above, where geometry cannot tell it apart from our own in-flight scroll. The
+  // corridor still catches larger jumps, but the caller drops the anchor at these
+  // known sites so a still-visible message is never skipped.
+  notifyProgrammaticScroll() {
+    this.anchorId = null
+  }
+
   // Called when the list contents are replaced wholesale.
   reset() {
     this.anchorId = null

--- a/engines/collavre/app/javascript/controllers/comments/prev_message_navigator.js
+++ b/engines/collavre/app/javascript/controllers/comments/prev_message_navigator.js
@@ -34,7 +34,10 @@ export default class PrevMessageNavigator {
 
     if (this.anchorId !== null) {
       const anchorIdx = items.findIndex((item) => item.id === this.anchorId)
-      if (anchorIdx !== -1) return anchorIdx - 1
+      if (anchorIdx !== -1 && this.anchorIsOnItsWay(items[anchorIdx].top, viewportTop)) {
+        return anchorIdx - 1
+      }
+      this.anchorId = null
     }
 
     let currentIdx = items.findIndex((item) => item.top >= viewportTop - TOP_TOLERANCE)
@@ -44,9 +47,23 @@ export default class PrevMessageNavigator {
     return isAtTop ? currentIdx - 1 : currentIdx
   }
 
-  // Called once we start scrolling towards `id`.
-  commit(id) {
+  // The anchor travels from wherever it sat when we committed up to `viewportTop`,
+  // and nothing else moves it. Outside that corridor the list was scrolled by
+  // something other than us - a new message arriving, a permalink jump - none of
+  // which fire a user input event, so the anchor would otherwise survive and wedge
+  // the button (anchored on the oldest item, every click resolves to -1 forever).
+  //
+  // Comparing the anchor against its own start position rather than the list's
+  // scroll offset keeps this correct when older comments are prepended: that
+  // shifts `scrollTop` but leaves the anchor where it is on screen.
+  anchorIsOnItsWay(anchorTop, viewportTop) {
+    return anchorTop >= this.anchorStartTop - TOP_TOLERANCE && anchorTop <= viewportTop + TOP_TOLERANCE
+  }
+
+  // Called once we start scrolling towards `id`, which currently sits at `top`.
+  commit(id, top) {
     this.anchorId = id
+    this.anchorStartTop = top
   }
 
   // Called when the user interacts with the list (wheel, touch, key, pointer).

--- a/engines/collavre/app/javascript/controllers/comments/prev_message_navigator.js
+++ b/engines/collavre/app/javascript/controllers/comments/prev_message_navigator.js
@@ -5,8 +5,14 @@
 // from geometry at that moment picks the item we just left (it has not reached
 // the top yet), which makes the list bounce up and down instead of walking
 // backwards. Remembering the last target as an anchor keeps each click stepping
-// one message further back, and geometry only takes over once the user scrolls
-// on their own.
+// one message further back.
+//
+// The anchor is dropped once the user moves the list themselves, so geometry
+// takes over from wherever they landed. Invalidation is driven by input events
+// rather than scroll events: a scroll event cannot be attributed to the user
+// without guessing how long our own animation runs, and guessing short brings
+// the bounce back. Dropping the anchor is always the safe direction — a settled
+// list resolves correctly from geometry alone.
 //
 // Kept free of DOM access so it can be unit tested: jsdom has no layout engine,
 // so the controller measures the items and passes `{ id, top }` pairs in.
@@ -18,7 +24,6 @@ const TOP_TOLERANCE = 4
 export default class PrevMessageNavigator {
   constructor() {
     this.anchorId = null
-    this.scrolling = false
   }
 
   // items: `{ id, top }` in DOM order (oldest first), top relative to viewport.
@@ -42,24 +47,15 @@ export default class PrevMessageNavigator {
   // Called once we start scrolling towards `id`.
   commit(id) {
     this.anchorId = id
-    this.scrolling = true
   }
 
-  // Called when the smooth scroll has landed.
-  settle() {
-    this.scrolling = false
-  }
-
-  // Called on every scroll event. Scroll events fired by our own animation must
-  // not clear the anchor — only a scroll the user drove themselves.
-  handleScroll() {
-    if (this.scrolling) return
+  // Called when the user interacts with the list (wheel, touch, key, pointer).
+  notifyUserInput() {
     this.anchorId = null
   }
 
   // Called when the list contents are replaced wholesale.
   reset() {
     this.anchorId = null
-    this.scrolling = false
   }
 }


### PR DESCRIPTION
## Problem

Clicking the previous-message button (`#scroll-prev-msg-btn`) rapidly does not keep walking backwards through the history — the list bounces up, then back down, and stays put.

## Root cause

`scrollToPreviousMessage()` held no state: every click re-measured "where am I now" with `getBoundingClientRect()`, while the actual scroll ran as an async `behavior: 'smooth'` animation.

A second click arriving mid-animation measured the item it had just left:

1. Scrolling from item N towards N-1; `scrollTop` is somewhere between them.
2. The scan picks the first item with `rect.top >= viewportTop - 2` — N-1 is still cut off above the fold, so **N** is picked.
3. `isAtTop = Math.abs(currentRect.top - viewportTop) < 4` is **false**, because N is still in flight below the top.
4. `targetIdx = isAtTop ? currentIdx - 1 : currentIdx` therefore resolves to **N** — the item we just left.
5. The list scrolls back down to N.

Clicking slowly worked because the animation had settled, so `isAtTop` was true.

## Fix

Remember the last target as an anchor and step one item back from it:

- Anchored by `data-comment-id`, not index, so it survives older comments being prepended by `loadOlderComments()`.
- Scroll events fired by our own animation do not drop the anchor; a scroll the user drove themselves does, handing control back to geometry.
- `loadInitialComments()` resets the anchor, since the list is replaced wholesale.
- Geometry remains the fallback whenever there is no valid anchor (first click, after a user scroll, anchored comment deleted).

The logic lives in a new `PrevMessageNavigator` with no DOM access — jsdom has no layout engine, so `getBoundingClientRect()` returns zeros there and the controller must pass measured `{ id, top }` pairs in.

## Tests

13 new unit tests in `__tests__/prev_message_navigator.test.js` covering the geometry fallback, the mid-animation rapid-click case, prepend survival, deleted anchors, and anchor invalidation. Full JS suite: 638 passed / 57 suites. `npm run build` clean.

Not verified in a real browser: the machine's disk is at 100%, so no preview server was started. The DOM wiring (`dataset.commentId`, `scrollTo`) is unexercised by the unit tests.