### PR TITLE
test(comments): cover the list_controller.notifyProgrammaticScroll seam

### DIFF
--- a/engines/collavre/app/javascript/controllers/comments/__tests__/list_controller_prev_message.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/list_controller_prev_message.test.js
@@ -202,6 +202,21 @@ describe('list_controller previous-message navigation', () => {
     expect(h.controller.prevMsgNavigator.anchorId).toBeNull()
   })
 
+  test('notifyProgrammaticScroll seam drops the anchor for sibling controllers', () => {
+    // The review-quote chip in form_controller scrolls the list on its own and
+    // drops the anchor through this public seam, without reaching into the
+    // navigator's internals. Exercise the real seam, not a mock of it.
+    const h = buildController()
+    h.scrollTo(4 * ITEM_HEIGHT)
+
+    h.controller.scrollToPreviousMessage() // anchor = c3
+    expect(h.controller.prevMsgNavigator.anchorId).toBe('c3')
+
+    h.controller.notifyProgrammaticScroll()
+
+    expect(h.controller.prevMsgNavigator.anchorId).toBeNull()
+  })
+
   test('disconnect unhooks the user-input listeners', () => {
     const h = buildController()
     h.scrollTo(4 * ITEM_HEIGHT)


### PR DESCRIPTION
## Follow-up to #1407 — closes a real codecov patch-coverage gap

Codecov flagged uncovered patch lines in `list_controller.js` on #1407. Investigating the diff against istanbul line data, the **one genuinely uncovered new line** was the public `notifyProgrammaticScroll()` seam (line 358).

### Root cause
The seam's only exercise is `form_controller_review.test.js`, which **mocks** the list controller:

```js
jest.spyOn(controller, 'listController', 'get').mockReturnValue({ notifyProgrammaticScroll })
```

That correctly unit-tests *form_controller* (it should not reach into the real navigator), but it means the real delegating seam on `list_controller` never ran under test — so it showed as uncovered.

### Fix
A direct test that drives the **real** seam through the existing controller harness (`buildController`) and asserts it drops the anchor, mirroring the existing permalink-jump test.

- `DA:358` goes `0 → 1` (verified in lcov).
- **Mutation-checked**: neutering the seam body fails *only* this new test (1 failed, 15 passed), so it detects behavior, not just line execution.
- Full JS suite **657/657**, `npm run build` clean.

Test-only change; no production code touched.