### PR TITLE
fix(deps): npm audit fix — js-yaml 4.3.0, protobufjs 7.6.5 (clears test_js audit gate)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7604,9 +7604,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",
@@ -8610,9 +8610,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.6.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
-      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {


### PR DESCRIPTION
## What
Lockfile-only `npm audit fix` to clear the two production vulnerabilities that keep the `test_js` CI job red (the `npm audit --production` step). Everything else in `test_js` (Jest) is already green.

| package | change | advisory | severity |
|---|---|---|---|
| js-yaml | 4.2.0 → 4.3.0 | [GHSA-52cp-r559-cp3m](https://github.com/advisories/GHSA-52cp-r559-cp3m) — YAML merge-key quadratic CPU | high |
| protobufjs | 7.6.4 → 7.6.5 | [GHSA-j3f2-48v5-ccww](https://github.com/advisories/GHSA-j3f2-48v5-ccww) — .proto option-parse infinite loop | moderate |

## Notes
- Both are **transitive** deps; diff is **package-lock.json only** (6/6 lines). No direct dependency or source changes.
- `npm audit --production` after: **0 vulnerabilities**.
- Supersedes #1410 (dependabot's js-yaml 4.3.0 bump) and additionally fixes protobufjs.

Unblocks the pending dependency-PR merge train (#1345, #1347, #1348, #1402, #1401, #1305, #1250) so main CI goes fully green.