### PR TITLE
fix(collavre_linear): auto-advance to project settings after OAuth callback

### DIFF
--- a/engines/collavre_linear/app/javascript/__tests__/linear_modal_reopen.test.js
+++ b/engines/collavre_linear/app/javascript/__tests__/linear_modal_reopen.test.js
@@ -2,6 +2,7 @@ import {
   LINEAR_REOPEN_KEY,
   markReopenAfterConnect,
   consumeReopenAfterConnect,
+  safeSessionStorage,
 } from '../linear_modal_reopen.js';
 
 // Minimal in-memory Storage stand-in (jsdom's is fine too, but this keeps the
@@ -15,6 +16,30 @@ function fakeStorage() {
     _size: () => map.size,
   };
 }
+
+describe('safeSessionStorage', () => {
+  test('returns the storage object when Web Storage is available', () => {
+    // jsdom provides a working window.sessionStorage.
+    expect(safeSessionStorage()).toBe(window.sessionStorage);
+  });
+
+  test('returns null when the window.sessionStorage getter itself throws', () => {
+    // Web Storage disabled by policy (packaged WKWebView, storage-blocked
+    // browser) throws on the property *access*, before any value is passed to
+    // mark/consume. safeSessionStorage must absorb it so callers never throw.
+    const original = Object.getOwnPropertyDescriptor(window, 'sessionStorage');
+    Object.defineProperty(window, 'sessionStorage', {
+      configurable: true,
+      get() { throw new Error('SecurityError: storage disabled'); },
+    });
+    try {
+      expect(() => safeSessionStorage()).not.toThrow();
+      expect(safeSessionStorage()).toBeNull();
+    } finally {
+      if (original) Object.defineProperty(window, 'sessionStorage', original);
+    }
+  });
+});
 
 describe('markReopenAfterConnect', () => {
   test('persists the reopen flag under the shared key', () => {
@@ -56,6 +81,17 @@ describe('consumeReopenAfterConnect', () => {
   test('swallows storage errors and reports no pending reopen', () => {
     const throwing = { getItem: () => { throw new Error('SecurityError'); } };
     expect(consumeReopenAfterConnect(throwing)).toBe(false);
+  });
+
+  test('end-to-end via safeSessionStorage: mark on connect, consume once', () => {
+    // The call sites pass safeSessionStorage() rather than window.sessionStorage
+    // directly, so the whole flow must survive a storage-backed session.
+    const s = safeSessionStorage();
+    if (!s) return; // jsdom always provides it; guard just in case
+    s.removeItem(LINEAR_REOPEN_KEY);
+    markReopenAfterConnect(s);
+    expect(consumeReopenAfterConnect(s)).toBe(true);
+    expect(consumeReopenAfterConnect(s)).toBe(false);
   });
 
   test('end-to-end: mark on connect, consume on the next load', () => {

--- a/engines/collavre_linear/app/javascript/__tests__/linear_modal_reopen.test.js
+++ b/engines/collavre_linear/app/javascript/__tests__/linear_modal_reopen.test.js
@@ -1,0 +1,71 @@
+import {
+  LINEAR_REOPEN_KEY,
+  markReopenAfterConnect,
+  consumeReopenAfterConnect,
+} from '../linear_modal_reopen.js';
+
+// Minimal in-memory Storage stand-in (jsdom's is fine too, but this keeps the
+// unit test free of environment setup and lets us model a throwing storage).
+function fakeStorage() {
+  const map = new Map();
+  return {
+    setItem: (k, v) => map.set(k, String(v)),
+    getItem: (k) => (map.has(k) ? map.get(k) : null),
+    removeItem: (k) => map.delete(k),
+    _size: () => map.size,
+  };
+}
+
+describe('markReopenAfterConnect', () => {
+  test('persists the reopen flag under the shared key', () => {
+    const storage = fakeStorage();
+    markReopenAfterConnect(storage);
+    expect(storage.getItem(LINEAR_REOPEN_KEY)).toBe('1');
+  });
+
+  test('tolerates a null storage without throwing', () => {
+    expect(() => markReopenAfterConnect(null)).not.toThrow();
+  });
+
+  test('swallows storage errors (private mode / WKWebView)', () => {
+    const throwing = { setItem: () => { throw new Error('QuotaExceeded'); } };
+    expect(() => markReopenAfterConnect(throwing)).not.toThrow();
+  });
+});
+
+describe('consumeReopenAfterConnect', () => {
+  test('returns true exactly once, then clears the flag (regression)', () => {
+    // Without the one-shot clear, every subsequent reload — including the one
+    // after a successful link — would reopen the modal. It must fire once.
+    const storage = fakeStorage();
+    markReopenAfterConnect(storage);
+
+    expect(consumeReopenAfterConnect(storage)).toBe(true);
+    expect(consumeReopenAfterConnect(storage)).toBe(false);
+    expect(storage.getItem(LINEAR_REOPEN_KEY)).toBeNull();
+  });
+
+  test('returns false when no reopen was pending', () => {
+    expect(consumeReopenAfterConnect(fakeStorage())).toBe(false);
+  });
+
+  test('tolerates a null storage', () => {
+    expect(consumeReopenAfterConnect(null)).toBe(false);
+  });
+
+  test('swallows storage errors and reports no pending reopen', () => {
+    const throwing = { getItem: () => { throw new Error('SecurityError'); } };
+    expect(consumeReopenAfterConnect(throwing)).toBe(false);
+  });
+
+  test('end-to-end: mark on connect, consume on the next load', () => {
+    // Mirrors the real flow: the postMessage handler marks, the reload happens,
+    // then turbo:load consumes the flag and opens the modal exactly once.
+    const storage = fakeStorage();
+    markReopenAfterConnect(storage);          // linearConnected received
+    const reopenedFirstLoad = consumeReopenAfterConnect(storage);   // turbo:load
+    const reopenedSecondLoad = consumeReopenAfterConnect(storage);  // later nav
+    expect(reopenedFirstLoad).toBe(true);
+    expect(reopenedSecondLoad).toBe(false);
+  });
+});

--- a/engines/collavre_linear/app/javascript/__tests__/linear_modal_reopen.test.js
+++ b/engines/collavre_linear/app/javascript/__tests__/linear_modal_reopen.test.js
@@ -45,7 +45,15 @@ describe('markReopenAfterConnect', () => {
   test('persists the unscoped sentinel when no creative id is given', () => {
     const storage = fakeStorage();
     markReopenAfterConnect(storage);
-    expect(storage.getItem(LINEAR_REOPEN_KEY)).toBe('1');
+    expect(storage.getItem(LINEAR_REOPEN_KEY)).toBe('*');
+  });
+
+  test('the unscoped sentinel cannot equal any serialized creative id', () => {
+    // Creative ids are positive integers → digit strings. The sentinel must be a
+    // non-digit so a real id never gets misread as "unscoped".
+    const storage = fakeStorage();
+    markReopenAfterConnect(storage);
+    expect(storage.getItem(LINEAR_REOPEN_KEY)).not.toMatch(/^\d+$/);
   });
 
   test('persists the creative id when given (scoped reopen)', () => {
@@ -57,7 +65,7 @@ describe('markReopenAfterConnect', () => {
   test('falls back to the unscoped sentinel for an empty creative id', () => {
     const storage = fakeStorage();
     markReopenAfterConnect(storage, '');
-    expect(storage.getItem(LINEAR_REOPEN_KEY)).toBe('1');
+    expect(storage.getItem(LINEAR_REOPEN_KEY)).toBe('*');
   });
 
   test('tolerates a null storage without throwing', () => {
@@ -96,6 +104,21 @@ describe('consumeReopenAfterConnect', () => {
     // Opener moved to creative 99 before the reload → no reopen, flag cleared.
     expect(consumeReopenAfterConnect(storage, 99)).toBe(false);
     expect(storage.getItem(LINEAR_REOPEN_KEY)).toBeNull();
+  });
+
+  test('creative id 1 stays scoped and does NOT reopen a different creative', () => {
+    // Regression: the sentinel used to be '1', colliding with creative id 1 — so
+    // OAuth from creative 1 was misread as unscoped and reopened whatever modal
+    // the opener had navigated to. It must behave like any other scoped id.
+    const storage = fakeStorage();
+    markReopenAfterConnect(storage, 1);           // popup connected creative 1
+    expect(consumeReopenAfterConnect(storage, 99)).toBe(false); // opener moved away
+  });
+
+  test('creative id 1 reopens when the opener is still on creative 1', () => {
+    const storage = fakeStorage();
+    markReopenAfterConnect(storage, 1);
+    expect(consumeReopenAfterConnect(storage, 1)).toBe(true);
   });
 
   test('clears a mismatched intent so it never fires on a later matching visit', () => {

--- a/engines/collavre_linear/app/javascript/__tests__/linear_modal_reopen.test.js
+++ b/engines/collavre_linear/app/javascript/__tests__/linear_modal_reopen.test.js
@@ -42,9 +42,21 @@ describe('safeSessionStorage', () => {
 });
 
 describe('markReopenAfterConnect', () => {
-  test('persists the reopen flag under the shared key', () => {
+  test('persists the unscoped sentinel when no creative id is given', () => {
     const storage = fakeStorage();
     markReopenAfterConnect(storage);
+    expect(storage.getItem(LINEAR_REOPEN_KEY)).toBe('1');
+  });
+
+  test('persists the creative id when given (scoped reopen)', () => {
+    const storage = fakeStorage();
+    markReopenAfterConnect(storage, 42);
+    expect(storage.getItem(LINEAR_REOPEN_KEY)).toBe('42');
+  });
+
+  test('falls back to the unscoped sentinel for an empty creative id', () => {
+    const storage = fakeStorage();
+    markReopenAfterConnect(storage, '');
     expect(storage.getItem(LINEAR_REOPEN_KEY)).toBe('1');
   });
 
@@ -68,6 +80,42 @@ describe('consumeReopenAfterConnect', () => {
     expect(consumeReopenAfterConnect(storage)).toBe(true);
     expect(consumeReopenAfterConnect(storage)).toBe(false);
     expect(storage.getItem(LINEAR_REOPEN_KEY)).toBeNull();
+  });
+
+  test('reopens only when the current creative matches the stored one', () => {
+    const storage = fakeStorage();
+    markReopenAfterConnect(storage, 42); // popup connected creative 42
+    // Opener is on the same creative → reopen.
+    expect(consumeReopenAfterConnect(storage, 42)).toBe(true);
+  });
+
+  test('does NOT reopen when the opener navigated to a different creative', () => {
+    // Codex P2: mid-flow navigation must not surface the wrong creative's modal.
+    const storage = fakeStorage();
+    markReopenAfterConnect(storage, 42); // popup connected creative 42
+    // Opener moved to creative 99 before the reload → no reopen, flag cleared.
+    expect(consumeReopenAfterConnect(storage, 99)).toBe(false);
+    expect(storage.getItem(LINEAR_REOPEN_KEY)).toBeNull();
+  });
+
+  test('clears a mismatched intent so it never fires on a later matching visit', () => {
+    const storage = fakeStorage();
+    markReopenAfterConnect(storage, 42);
+    consumeReopenAfterConnect(storage, 99); // mismatch on the reload
+    // Later navigation back to creative 42 must NOT auto-open — intent was spent.
+    expect(consumeReopenAfterConnect(storage, 42)).toBe(false);
+  });
+
+  test('matches across id string/number coercion', () => {
+    const storage = fakeStorage();
+    markReopenAfterConnect(storage, 42);        // stored as '42'
+    expect(consumeReopenAfterConnect(storage, '42')).toBe(true); // dataset is a string
+  });
+
+  test('unscoped sentinel reopens regardless of current creative (legacy)', () => {
+    const storage = fakeStorage();
+    markReopenAfterConnect(storage);            // no id → '1'
+    expect(consumeReopenAfterConnect(storage, 7)).toBe(true);
   });
 
   test('returns false when no reopen was pending', () => {

--- a/engines/collavre_linear/app/javascript/collavre_linear.js
+++ b/engines/collavre_linear/app/javascript/collavre_linear.js
@@ -15,6 +15,10 @@
 // unconfirmed and errors would vanish. Route through the shared in-app modal
 // like the GitHub/Slack/Notion engines do.
 import { alertDialog, confirmDialog } from 'collavre/lib/utils/dialog';
+import {
+  markReopenAfterConnect,
+  consumeReopenAfterConnect,
+} from './linear_modal_reopen.js';
 
 let linearIntegrationInitialized = false;
 
@@ -39,7 +43,7 @@ if (!linearIntegrationInitialized) {
       } catch (e) { /* cross-origin or already closed */ }
       // Survive the reload: reopen the modal on the next load so the flow lands
       // on the project-link step automatically.
-      try { sessionStorage.setItem('linearReopenModal', '1'); } catch (e) {}
+      markReopenAfterConnect(window.sessionStorage);
       window.location.reload();
     }
   });
@@ -206,12 +210,9 @@ if (!linearIntegrationInitialized) {
     // Just returned from the OAuth popup: open the modal straight to the
     // project-link step instead of leaving the (display:none) modal closed, so
     // the user doesn't have to reopen the Linear menu by hand.
-    try {
-      if (sessionStorage.getItem('linearReopenModal') === '1') {
-        sessionStorage.removeItem('linearReopenModal');
-        showModal();
-      }
-    } catch (e) { /* sessionStorage unavailable */ }
+    if (consumeReopenAfterConnect(window.sessionStorage)) {
+      showModal();
+    }
 
     closeBtn?.addEventListener('click', closeModal);
 

--- a/engines/collavre_linear/app/javascript/collavre_linear.js
+++ b/engines/collavre_linear/app/javascript/collavre_linear.js
@@ -43,8 +43,10 @@ if (!linearIntegrationInitialized) {
         if (event.source && !event.source.closed) event.source.close();
       } catch (e) { /* cross-origin or already closed */ }
       // Survive the reload: reopen the modal on the next load so the flow lands
-      // on the project-link step automatically.
-      markReopenAfterConnect(safeSessionStorage());
+      // on the project-link step automatically. Scope it to the creative the
+      // popup was opened for (event.data.creativeId) so a mid-flow navigation to
+      // a different creative doesn't auto-open the wrong creative's link modal.
+      markReopenAfterConnect(safeSessionStorage(), event.data.creativeId);
       window.location.reload();
     }
   });
@@ -210,8 +212,10 @@ if (!linearIntegrationInitialized) {
 
     // Just returned from the OAuth popup: open the modal straight to the
     // project-link step instead of leaving the (display:none) modal closed, so
-    // the user doesn't have to reopen the Linear menu by hand.
-    if (consumeReopenAfterConnect(safeSessionStorage())) {
+    // the user doesn't have to reopen the Linear menu by hand. Only reopen when
+    // this page's creative matches the one the popup connected for — otherwise a
+    // mid-flow navigation would surface the wrong creative's link modal.
+    if (consumeReopenAfterConnect(safeSessionStorage(), modal.dataset.creativeId)) {
       showModal();
     }
 

--- a/engines/collavre_linear/app/javascript/collavre_linear.js
+++ b/engines/collavre_linear/app/javascript/collavre_linear.js
@@ -18,6 +18,7 @@ import { alertDialog, confirmDialog } from 'collavre/lib/utils/dialog';
 import {
   markReopenAfterConnect,
   consumeReopenAfterConnect,
+  safeSessionStorage,
 } from './linear_modal_reopen.js';
 
 let linearIntegrationInitialized = false;
@@ -43,7 +44,7 @@ if (!linearIntegrationInitialized) {
       } catch (e) { /* cross-origin or already closed */ }
       // Survive the reload: reopen the modal on the next load so the flow lands
       // on the project-link step automatically.
-      markReopenAfterConnect(window.sessionStorage);
+      markReopenAfterConnect(safeSessionStorage());
       window.location.reload();
     }
   });
@@ -210,7 +211,7 @@ if (!linearIntegrationInitialized) {
     // Just returned from the OAuth popup: open the modal straight to the
     // project-link step instead of leaving the (display:none) modal closed, so
     // the user doesn't have to reopen the Linear menu by hand.
-    if (consumeReopenAfterConnect(window.sessionStorage)) {
+    if (consumeReopenAfterConnect(safeSessionStorage())) {
       showModal();
     }
 

--- a/engines/collavre_linear/app/javascript/collavre_linear.js
+++ b/engines/collavre_linear/app/javascript/collavre_linear.js
@@ -21,13 +21,25 @@ let linearIntegrationInitialized = false;
 if (!linearIntegrationInitialized) {
   linearIntegrationInitialized = true;
 
-  // The OAuth popup posts `linearConnected` to the opener when it closes.
-  // Reload so the modal re-renders in the connected (link-a-project) state.
+  // The OAuth popup posts `linearConnected` to the opener once the account is
+  // connected. Reload so the modal re-renders in the connected (link-a-project)
+  // state, then reopen it (see turbo:load) so the user lands directly on the
+  // project settings step instead of a closed modal.
   // Bound to `window` once — it survives Turbo navigations, unlike the
   // per-navigation element listeners set up in turbo:load below.
   window.addEventListener('message', function (event) {
     if (event.origin !== window.location.origin) return;
     if (event.data && event.data.type === 'linearConnected') {
+      // Close the popup from here. window.close() inside the popup is unreliable
+      // after the cross-origin OAuth round trip and in the desktop WebView, so
+      // the popup's own "Close" button looked dead — closing the window we
+      // opened is the reliable path.
+      try {
+        if (event.source && !event.source.closed) event.source.close();
+      } catch (e) { /* cross-origin or already closed */ }
+      // Survive the reload: reopen the modal on the next load so the flow lands
+      // on the project-link step automatically.
+      try { sessionStorage.setItem('linearReopenModal', '1'); } catch (e) {}
       window.location.reload();
     }
   });
@@ -190,6 +202,16 @@ if (!linearIntegrationInitialized) {
     openBtn.addEventListener('click', function () {
       showModal();
     });
+
+    // Just returned from the OAuth popup: open the modal straight to the
+    // project-link step instead of leaving the (display:none) modal closed, so
+    // the user doesn't have to reopen the Linear menu by hand.
+    try {
+      if (sessionStorage.getItem('linearReopenModal') === '1') {
+        sessionStorage.removeItem('linearReopenModal');
+        showModal();
+      }
+    } catch (e) { /* sessionStorage unavailable */ }
 
     closeBtn?.addEventListener('click', closeModal);
 

--- a/engines/collavre_linear/app/javascript/linear_modal_reopen.js
+++ b/engines/collavre_linear/app/javascript/linear_modal_reopen.js
@@ -4,7 +4,8 @@
 // full `window.location.reload()` so the server re-renders the modal in its
 // project-linking state (the account now exists). But the modal defaults to
 // `display:none` and nothing re-opens it after the reload — so the connect→link
-// step is invisible and the user has to click "Linear 연결" again to reach it.
+// step is invisible and the user has to click the Linear connect button again to
+// reach it.
 //
 // This module persists a one-shot "reopen the modal" flag across that reload.
 // Factored out of the side-effectful collavre_linear.js opener so the behavior

--- a/engines/collavre_linear/app/javascript/linear_modal_reopen.js
+++ b/engines/collavre_linear/app/javascript/linear_modal_reopen.js
@@ -25,25 +25,43 @@ export function safeSessionStorage() {
   }
 }
 
-// Record that the modal should reopen after the next full-page reload. Tolerates
-// a missing or throwing storage (private-mode Safari, packaged WKWebView) — the
-// reopen is a convenience and must never throw inside the postMessage handler.
-export function markReopenAfterConnect(storage) {
+// Legacy/unscoped sentinel. Stored when the OAuth creative id is unknown so the
+// reopen still fires (matches any page) — the scoped path stores the id instead.
+const UNSCOPED = '1';
+
+// Record that the modal should reopen after the next full-page reload, scoped to
+// the creative the OAuth popup was opened for. The popup posts its own
+// creativeId; storing it lets consume verify the reloaded page still shows that
+// same creative before reopening — otherwise, if the opener navigated to a
+// different creative while the popup was open, the reload would auto-open the
+// wrong creative's link modal and the user could link the project to it.
+// Tolerates a missing or throwing storage (private-mode Safari, packaged
+// WKWebView) — the reopen is a convenience and must never throw inside the
+// postMessage handler.
+export function markReopenAfterConnect(storage, creativeId) {
+  const value =
+    creativeId != null && String(creativeId) !== '' ? String(creativeId) : UNSCOPED;
   try {
-    if (storage) storage.setItem(LINEAR_REOPEN_KEY, '1');
+    if (storage) storage.setItem(LINEAR_REOPEN_KEY, value);
   } catch (e) {
     /* storage unavailable — skip the reopen nicety */
   }
 }
 
 // Consume the reopen intent: returns true at most once, then clears the flag so
-// a later unrelated reload (e.g. after linking succeeds) does not reopen it.
-export function consumeReopenAfterConnect(storage) {
+// a later unrelated reload (e.g. after linking succeeds) does not reopen it. The
+// flag is cleared on the first consume regardless of match, so a stale intent
+// (opener navigated elsewhere) never lingers to reopen the modal on some later
+// visit. Returns true only when the stored creative id matches the current page
+// (or when the legacy unscoped sentinel was stored).
+export function consumeReopenAfterConnect(storage, currentCreativeId) {
   try {
-    if (storage && storage.getItem(LINEAR_REOPEN_KEY)) {
-      storage.removeItem(LINEAR_REOPEN_KEY);
-      return true;
-    }
+    if (!storage) return false;
+    const stored = storage.getItem(LINEAR_REOPEN_KEY);
+    if (!stored) return false;
+    storage.removeItem(LINEAR_REOPEN_KEY); // one-shot regardless of match
+    if (stored === UNSCOPED) return true;
+    return String(currentCreativeId == null ? '' : currentCreativeId) === stored;
   } catch (e) {
     /* storage unavailable — treat as no pending reopen */
   }

--- a/engines/collavre_linear/app/javascript/linear_modal_reopen.js
+++ b/engines/collavre_linear/app/javascript/linear_modal_reopen.js
@@ -1,0 +1,38 @@
+// Reopen-after-connect intent for the Linear integration modal.
+//
+// When the OAuth popup finishes it posts `linearConnected` and the opener does a
+// full `window.location.reload()` so the server re-renders the modal in its
+// project-linking state (the account now exists). But the modal defaults to
+// `display:none` and nothing re-opens it after the reload — so the connect→link
+// step is invisible and the user has to click "Linear 연결" again to reach it.
+//
+// This module persists a one-shot "reopen the modal" flag across that reload.
+// Factored out of the side-effectful collavre_linear.js opener so the behavior
+// is unit-testable (that file is imported only for its window/turbo listeners).
+
+export const LINEAR_REOPEN_KEY = 'linearReopenModal';
+
+// Record that the modal should reopen after the next full-page reload. Tolerates
+// a missing or throwing storage (private-mode Safari, packaged WKWebView) — the
+// reopen is a convenience and must never throw inside the postMessage handler.
+export function markReopenAfterConnect(storage) {
+  try {
+    if (storage) storage.setItem(LINEAR_REOPEN_KEY, '1');
+  } catch (e) {
+    /* storage unavailable — skip the reopen nicety */
+  }
+}
+
+// Consume the reopen intent: returns true at most once, then clears the flag so
+// a later unrelated reload (e.g. after linking succeeds) does not reopen it.
+export function consumeReopenAfterConnect(storage) {
+  try {
+    if (storage && storage.getItem(LINEAR_REOPEN_KEY)) {
+      storage.removeItem(LINEAR_REOPEN_KEY);
+      return true;
+    }
+  } catch (e) {
+    /* storage unavailable — treat as no pending reopen */
+  }
+  return false;
+}

--- a/engines/collavre_linear/app/javascript/linear_modal_reopen.js
+++ b/engines/collavre_linear/app/javascript/linear_modal_reopen.js
@@ -12,6 +12,19 @@
 
 export const LINEAR_REOPEN_KEY = 'linearReopenModal';
 
+// Read window.sessionStorage defensively. When Web Storage is disabled by policy
+// (packaged WKWebView, a browser blocking storage for the site) the property
+// getter *itself* throws — before any value reaches mark/consume — so guarding
+// only inside those functions is not enough; the access site must be guarded
+// too. Returns null when unavailable so callers never take an uncaught throw.
+export function safeSessionStorage() {
+  try {
+    return window.sessionStorage;
+  } catch (e) {
+    return null;
+  }
+}
+
 // Record that the modal should reopen after the next full-page reload. Tolerates
 // a missing or throwing storage (private-mode Safari, packaged WKWebView) — the
 // reopen is a convenience and must never throw inside the postMessage handler.

--- a/engines/collavre_linear/app/javascript/linear_modal_reopen.js
+++ b/engines/collavre_linear/app/javascript/linear_modal_reopen.js
@@ -25,9 +25,13 @@ export function safeSessionStorage() {
   }
 }
 
-// Legacy/unscoped sentinel. Stored when the OAuth creative id is unknown so the
-// reopen still fires (matches any page) — the scoped path stores the id instead.
-const UNSCOPED = '1';
+// Unscoped sentinel. Stored when the OAuth creative id is unknown so the reopen
+// still fires (matches any page) — the scoped path stores the id instead. Must
+// be a value no serialized creative id can equal: ids are positive integers and
+// serialize to digit strings, so a non-digit marker never collides. (A previous
+// '1' sentinel collided with creative id 1 — that page's scoped reopen was
+// misread as unscoped and skipped the mismatch guard.)
+const UNSCOPED = '*';
 
 // Record that the modal should reopen after the next full-page reload, scoped to
 // the creative the OAuth popup was opened for. The popup posts its own

--- a/engines/collavre_linear/app/views/collavre_linear/auth/setup.html.erb
+++ b/engines/collavre_linear/app/views/collavre_linear/auth/setup.html.erb
@@ -50,13 +50,25 @@
   </div>
 
   <script>
-    document.getElementById('close-btn').addEventListener('click', function() {
+    // Tell the opener the account is connected so it advances straight to the
+    // project-link step. The opener also closes this popup (window.close() below
+    // is unreliable after the cross-origin OAuth round trip and in the desktop
+    // WebView, which is why the "Close" button used to look dead).
+    function notifyOpener() {
       try {
-        if (window.opener) {
+        if (window.opener && !window.opener.closed) {
           window.opener.postMessage({ type: 'linearConnected' }, window.location.origin);
         }
       } catch (e) {}
-      window.close();
+    }
+
+    // Auto-advance on load: no click required — the opener reloads and jumps to
+    // the project settings ("link a project") step.
+    notifyOpener();
+
+    document.getElementById('close-btn').addEventListener('click', function() {
+      notifyOpener();
+      try { window.close(); } catch (e) {}
     });
   </script>
 </body>

--- a/engines/collavre_linear/app/views/collavre_linear/auth/setup.html.erb
+++ b/engines/collavre_linear/app/views/collavre_linear/auth/setup.html.erb
@@ -57,7 +57,15 @@
     function notifyOpener() {
       try {
         if (window.opener && !window.opener.closed) {
-          window.opener.postMessage({ type: 'linearConnected' }, window.location.origin);
+          // Include the creative this popup was opened for so the opener only
+          // reopens the modal when it's still showing that same creative — not
+          // whatever creative it may have navigated to while the popup was open.
+          var wizard = document.getElementById('linear-wizard');
+          var creativeId = wizard ? wizard.dataset.creativeId : '';
+          window.opener.postMessage(
+            { type: 'linearConnected', creativeId: creativeId },
+            window.location.origin
+          );
         }
       } catch (e) {}
     }


### PR DESCRIPTION
## Symptom (reported by 정순오, topic 콜백 후 close 버튼)
- After the Linear OAuth callback succeeds, the popup's **Close** button appears unresponsive.
- The parent never advances to project settings — the user has to manually close the window and re-select **Linear 연결** before the project-link popup shows up.

## Root cause
The popup returns to `setup.html.erb`, which required a manual **Close** click. That handler `postMessage`d `linearConnected` to the opener, which did `window.location.reload()`. After the reload the modal re-rendered in the connected *link-a-project* state but stayed `display:none` — **nothing reopened it** — so the project-settings step was never shown automatically. The popup's own `window.close()` is also unreliable after the cross-origin OAuth round trip and in the desktop WebView (same class of issue as native `confirm/alert` there), so the button looked dead.

## Fix
- **`setup.html.erb`**: `postMessage` the opener automatically on load (no click required); keep the Close button as a manual fallback.
- **`collavre_linear.js`**: on the `linearConnected` message, close the popup from the opener (`event.source.close()` — reliable because we opened it), persist a `sessionStorage` flag, then reload; on the next `turbo:load`, reopen the modal so the flow lands directly on the project-link step (which lazy-loads the project/team dropdowns).

Net result: authorize on Linear → popup closes itself → parent reloads and opens straight to **project settings**, zero manual clicks.

## Verification
- `node --check` on the JS: passes.
- `bin/rubocop engines/collavre_linear/app`: 25 files, 0 offenses.
- `bin/rails test engines/collavre_linear/test/controllers/collavre_linear/auth_controller_test.rb`: **15 runs, 62 assertions, 0 failures**.
- Full popup round trip (real Linear OAuth) needs a TLS tunnel and can't be exercised headlessly — same manual-QA boundary the original PR #1342 noted, and the sibling `collavre_github` engine also leaves its OAuth popup mechanics to manual QA.

Follow-up to #1342 / #1351.