### PR TITLE
fix(linear): normalize misconfigured linear_api_endpoint to /graphql

### DIFF
--- a/engines/collavre_linear/app/services/collavre_linear/client.rb
+++ b/engines/collavre_linear/app/services/collavre_linear/client.rb
@@ -423,7 +423,7 @@ module CollavreLinear
       parsed = begin
         JSON.parse(response.body)
       rescue JSON::ParserError
-        raise Error, "Linear returned non-JSON response (HTTP #{response.code}): #{response.body.to_s[0, 200]}"
+        raise Error, "Linear returned non-JSON response (HTTP #{response.code}) from #{endpoint}: #{response.body.to_s[0, 200]}"
       end
 
       if parsed["errors"].present?
@@ -470,9 +470,32 @@ module CollavreLinear
     end
 
     def resolve_endpoint
-      if defined?(Collavre::IntegrationSettings::Resolver)
-        Collavre::IntegrationSettings::Resolver.get(:linear_api_endpoint).presence
-      end || DEFAULT_ENDPOINT
+      configured =
+        if defined?(Collavre::IntegrationSettings::Resolver)
+          Collavre::IntegrationSettings::Resolver.get(:linear_api_endpoint).presence
+        end
+
+      normalize_endpoint(configured) || DEFAULT_ENDPOINT
+    end
+
+    # Guard a misconfigured `linear_api_endpoint` override. Linear's GraphQL API
+    # lives at the `/graphql` path; an admin who pastes only a base URL
+    # (e.g. `https://host:port` or `.../`) would otherwise POST to `/`, which a
+    # non-Linear server answers with a 404 ("Cannot POST /"). When the configured
+    # value carries no meaningful path, point it at `/graphql`. A value that
+    # already specifies a non-root path is left untouched.
+    def normalize_endpoint(value)
+      return nil if value.blank?
+
+      uri = URI.parse(value.strip)
+      return value if uri.path.present? && uri.path != "/"
+
+      uri.path = "/graphql"
+      uri.to_s
+    rescue URI::InvalidURIError
+      # Not a parseable URI: return as-is and let the request surface the failure
+      # rather than silently rewriting an unrecognizable value.
+      value
     end
 
     # Convert symbol keys to camelCase strings for GraphQL variables.

--- a/engines/collavre_linear/test/services/collavre_linear/client_test.rb
+++ b/engines/collavre_linear/test/services/collavre_linear/client_test.rb
@@ -710,5 +710,47 @@ module CollavreLinear
       assert_requested :post, LINEAR_ENDPOINT,
         headers: { "Content-Type" => "application/json" }, times: 1
     end
+
+    # ---------------------------------------------------------------------------
+    # endpoint resolution / normalization
+    # ---------------------------------------------------------------------------
+    def resolved_endpoint_for(configured)
+      Collavre::IntegrationSettings::Resolver.stub(:get, configured) do
+        CollavreLinear::Client.new(@account).send(:resolve_endpoint)
+      end
+    end
+
+    test "resolve_endpoint falls back to DEFAULT_ENDPOINT when unset" do
+      assert_equal LINEAR_ENDPOINT, resolved_endpoint_for(nil)
+      assert_equal LINEAR_ENDPOINT, resolved_endpoint_for("")
+    end
+
+    test "resolve_endpoint passes a full GraphQL URL through unchanged" do
+      assert_equal "https://api.linear.app/graphql", resolved_endpoint_for("https://api.linear.app/graphql")
+      assert_equal "http://mock:4000/api/graphql", resolved_endpoint_for("http://mock:4000/api/graphql")
+    end
+
+    test "resolve_endpoint appends /graphql to a base URL missing the path" do
+      # This is the rowan-mis2 misconfiguration: a base URL POSTs to "/" and a
+      # non-Linear server answers "Cannot POST /" (HTTP 404).
+      assert_equal "http://mock:4000/graphql", resolved_endpoint_for("http://mock:4000")
+      assert_equal "http://mock:4000/graphql", resolved_endpoint_for("http://mock:4000/")
+      assert_equal "https://api.linear.app/graphql", resolved_endpoint_for("https://api.linear.app")
+    end
+
+    test "resolve_endpoint leaves an unparseable value untouched" do
+      assert_equal "not a uri", resolved_endpoint_for("not a uri")
+    end
+
+    test "non-JSON error surfaces the endpoint that was posted to" do
+      stub_request(:post, LINEAR_ENDPOINT)
+        .to_return(status: 404, body: "<html>Cannot POST /</html>",
+                   headers: { "Content-Type" => "text/html" })
+
+      err = assert_raises(CollavreLinear::Client::Error) do
+        @client.create_issue(team_id: "t1", title: "Boom")
+      end
+      assert_includes err.message, LINEAR_ENDPOINT
+    end
   end
 end


### PR DESCRIPTION
## 배경
Linear OAuth 콜백에서 아래 에러가 보고됨(rowan-mis2 배포):

```
CollavreLinear::Client::Error: Linear returned non-JSON response (HTTP 404): <!DOCTYPE html> ... Cannot POST /
```

토큰 교환은 성공했고, 그 직후 GraphQL `viewer` 호출이 터진다. `Cannot POST /`는 Express/finalhandler의 기본 404 — 즉 `linear_api_endpoint`가 **`/graphql` 경로가 빠진 베이스 URL**(`http://host:port` 또는 `.../`)로 오설정되어 POST가 `/`로 갔다.

## 핵심
`DEFAULT_ENDPOINT`는 **이미** `https://api.linear.app/graphql`이다(`client.rb:12`). 기본값 문제가 아니라, admin이 명시적으로 설정한 override가 경로를 누락한 것이 원인. 기본값만으로는 명시적 오설정을 막을 수 없다.

## 변경
- **`normalize_endpoint`**: 설정된 endpoint의 path가 없거나 루트(`/`)면 `/graphql`을 붙인다. 이미 non-root 경로(`/api/graphql` 등)면 건드리지 않는다. 파싱 불가값은 그대로 두고 요청 시 실패를 노출.
- **에러 메시지에 endpoint 포함**: non-JSON 응답 에러가 POST 대상 endpoint를 함께 출력 → 오설정을 메시지만으로 즉시 식별.

## 테스트
- 신규 5 테스트(unset 폴백 / full-URL 통과 / base-URL→`/graphql` / non-root 보존 / unparseable 보존 / 에러에 endpoint 노출)
- 엔진 client 스위트 **38 runs, 93 assertions, 0 failures** (host-root)
- 변경 파일 rubocop clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)