### PR TITLE
fix(collavre_linear): allow re-connecting Linear when the stored token is dead

### DIFF
--- a/engines/collavre_linear/app/controllers/collavre_linear/auth_controller.rb
+++ b/engines/collavre_linear/app/controllers/collavre_linear/auth_controller.rb
@@ -48,12 +48,13 @@ module CollavreLinear
       # existing project links were created under would orphan those links: their
       # team_id / linear_project_id belong to the old workspace, so resync and
       # outbound jobs would run them against the new token and fail or target the
-      # wrong Linear context. Refuse when we can prove the workspace changed and
-      # links exist; the admin must unlink first. workspace_id is blank on legacy
-      # rows, so an unprovable change falls through and never blocks a plain
-      # same-workspace token refresh (the reconnect button's actual purpose).
+      # wrong Linear context. Refuse a linked reconnect unless we can PROVE it
+      # stays in the same workspace; the admin must unlink first. A blank stored
+      # workspace_id ("old workspace unknown") is unprovable, so it must also
+      # block rather than fall through — a blank id never equals the incoming
+      # organization, so `!=` covers both the known-different and unknown cases.
+      # Unlinked accounts skip this and refresh in place (the button's purpose).
       if account.persisted? &&
-         account.workspace_id.present? &&
          account.workspace_id != viewer[:organization_id] &&
          account.project_links.exists?
         redirect_to collavre.creatives_path,

--- a/engines/collavre_linear/app/controllers/collavre_linear/auth_controller.rb
+++ b/engines/collavre_linear/app/controllers/collavre_linear/auth_controller.rb
@@ -43,6 +43,24 @@ module CollavreLinear
       account = CollavreLinear::Account.find_or_initialize_by(
         user_id: Current.user.id
       )
+
+      # A reconnect that lands in a DIFFERENT Linear workspace than the one the
+      # existing project links were created under would orphan those links: their
+      # team_id / linear_project_id belong to the old workspace, so resync and
+      # outbound jobs would run them against the new token and fail or target the
+      # wrong Linear context. Refuse when we can prove the workspace changed and
+      # links exist; the admin must unlink first. workspace_id is blank on legacy
+      # rows, so an unprovable change falls through and never blocks a plain
+      # same-workspace token refresh (the reconnect button's actual purpose).
+      if account.persisted? &&
+         account.workspace_id.present? &&
+         account.workspace_id != viewer[:organization_id] &&
+         account.project_links.exists?
+        redirect_to collavre.creatives_path,
+                    alert: I18n.t("collavre_linear.auth.workspace_changed_relink")
+        return
+      end
+
       account.linear_uid       = viewer[:user_id]
       account.access_token     = tokens[:access_token]
       account.refresh_token    = tokens[:refresh_token]

--- a/engines/collavre_linear/app/views/collavre_linear/integrations/_modal.html.erb
+++ b/engines/collavre_linear/app/views/collavre_linear/integrations/_modal.html.erb
@@ -181,6 +181,40 @@
         <% end %>
       <% end %>
 
+      <%# --- Reconnect affordance (shown in BOTH connected sub-states) ---
+          An Account row existing only means "some token was stored once", not
+          "that token still works". If the admin revokes the app in Linear's
+          settings (or the token expires past refresh), the link form's options
+          fetch 502s and the modal has no way back to OAuth — the connect button
+          only lives in the not-connected branch below, so the user is stranded
+          on "Couldn't load your Linear projects and teams. Please try again."
+          Re-running OAuth updates the SAME Account row in place (auth#callback
+          find_or_initialize_by user_id), so existing project links and the
+          account id survive and only the dead token is replaced. Reuses the
+          connect form/button ids: connected and not-connected are mutually
+          exclusive, so each id still appears exactly once in the DOM and the
+          existing JS opener wiring drives this unchanged. %>
+      <div class="linear-reconnect"
+           style="margin-top:1em;padding-top:0.75em;border-top:1px solid var(--border-color);">
+        <p style="margin:0 0 0.5em;color:var(--text-muted);font-size:0.85em;">
+          <%= t("collavre_linear.integration.reconnect_hint") %>
+        </p>
+        <form id="linear-connect-form"
+              action="/linear/auth/store_creative"
+              method="post"
+              target="linear-auth-window"
+              style="display:none;">
+          <input type="hidden" name="authenticity_token" value="<%= form_authenticity_token %>">
+          <input type="hidden" name="creative_id" value="<%= creative_id %>">
+        </form>
+        <div>
+          <button type="button" id="linear-connect-btn" class="btn btn-secondary btn-sm"
+                  data-window-width="620" data-window-height="720">
+            <%= t("collavre_linear.integration.reconnect_button") %>
+          </button>
+        </div>
+      </div>
+
     <% else %>
       <%# --- Not connected — show OAuth connect button --- %>
       <p style="margin-bottom:0.75em;">

--- a/engines/collavre_linear/config/locales/en.yml
+++ b/engines/collavre_linear/config/locales/en.yml
@@ -5,6 +5,7 @@ en:
       invalid_state: "Invalid OAuth state. Please try connecting again."
       login_first: "Please log in first."
       already_linked_other: "This Linear account is already connected to a different Collavre user."
+      workspace_changed_relink: "This reconnect uses a different Linear workspace than the one your linked projects belong to. Unlink the existing project(s) first, then reconnect."
       oauth_config_missing: "Linear OAuth is not configured (%{keys}). Set these before connecting."
     integration:
       label: "Linear"

--- a/engines/collavre_linear/config/locales/en.yml
+++ b/engines/collavre_linear/config/locales/en.yml
@@ -12,6 +12,8 @@ en:
       setup: "Setup"
       connect_prompt: "Connect your Linear account to start syncing."
       connect_button: "Connect Linear"
+      reconnect_hint: "Can't load your Linear projects? The connection may have expired or been revoked in Linear. Reconnect to fix it."
+      reconnect_button: "Reconnect Linear"
       link_prompt: "Select a Linear project and team to link this creative."
       team_id_label: "Team"
       project_id_label: "Project"

--- a/engines/collavre_linear/config/locales/ko.yml
+++ b/engines/collavre_linear/config/locales/ko.yml
@@ -12,6 +12,8 @@ ko:
       setup: "설정"
       connect_prompt: "Linear 계정을 연결하여 동기화를 시작하세요."
       connect_button: "Linear 연결"
+      reconnect_hint: "Linear 프로젝트를 불러오지 못하나요? 연결이 만료되었거나 Linear에서 해제되었을 수 있습니다. 다시 연결하세요."
+      reconnect_button: "Linear 다시 연결"
       link_prompt: "이 크리에이티브에 연결할 Linear 프로젝트와 팀을 선택하세요."
       team_id_label: "팀"
       project_id_label: "프로젝트"

--- a/engines/collavre_linear/config/locales/ko.yml
+++ b/engines/collavre_linear/config/locales/ko.yml
@@ -5,6 +5,7 @@ ko:
       invalid_state: "OAuth 상태가 유효하지 않습니다. 다시 연결해 주세요."
       login_first: "먼저 로그인해 주세요."
       already_linked_other: "이 Linear 계정은 이미 다른 Collavre 사용자에 연결되어 있습니다."
+      workspace_changed_relink: "다시 연결하려는 Linear 워크스페이스가 기존에 연결된 프로젝트의 워크스페이스와 다릅니다. 먼저 기존 프로젝트 연결을 해제한 뒤 다시 연결해 주세요."
       oauth_config_missing: "Linear OAuth가 설정되지 않았습니다 (%{keys}). 연결 전에 설정해 주세요."
     integration:
       label: "Linear"

--- a/engines/collavre_linear/test/controllers/collavre_linear/auth_controller_test.rb
+++ b/engines/collavre_linear/test/controllers/collavre_linear/auth_controller_test.rb
@@ -146,6 +146,63 @@ module CollavreLinear
         "the second user must not acquire the account"
     end
 
+    test "callback refuses a reconnect into a different workspace when links exist" do
+      sign_in_as(@user)
+
+      # Existing account in the OLD workspace, with a project link created there.
+      account = CollavreLinear::Account.create!(
+        user: @user,
+        linear_uid: "user-uid-1",
+        access_token: "old-token",
+        workspace_id: "org-OLD"
+      )
+      CollavreLinear::ProjectLink.create!(
+        account: account,
+        creative: @creative,
+        linear_project_id: "proj-old",
+        team_id: "team-old"
+      )
+
+      stub_token_exchange
+      stub_viewer_query # returns organization org-xyz (a DIFFERENT workspace)
+
+      state = initiate_oauth
+      get "/linear/auth/callback", params: { code: "auth-code-ws", state: state }
+
+      assert_response :redirect
+      account.reload
+      assert_equal "old-token", account.access_token,
+        "token must not be overwritten when the workspace changed under existing links"
+      assert_equal "org-OLD", account.workspace_id, "workspace must not be switched under existing links"
+    end
+
+    test "callback allows a same-workspace reconnect (token refresh) with links" do
+      sign_in_as(@user)
+
+      account = CollavreLinear::Account.create!(
+        user: @user,
+        linear_uid: "user-uid-1",
+        access_token: "old-token",
+        workspace_id: "org-xyz" # SAME workspace the viewer query returns
+      )
+      CollavreLinear::ProjectLink.create!(
+        account: account,
+        creative: @creative,
+        linear_project_id: "proj-1",
+        team_id: "team-1"
+      )
+
+      stub_token_exchange
+      stub_viewer_query # returns organization org-xyz
+
+      state = initiate_oauth
+      get "/linear/auth/callback", params: { code: "auth-code-refresh", state: state }
+
+      assert_response :redirect
+      account.reload
+      assert_equal "new-at", account.access_token, "a same-workspace reconnect must refresh the token"
+    end
+
     test "callback redirects to setup when creative_id is in session" do
       sign_in_as(@user)
 

--- a/engines/collavre_linear/test/controllers/collavre_linear/auth_controller_test.rb
+++ b/engines/collavre_linear/test/controllers/collavre_linear/auth_controller_test.rb
@@ -203,6 +203,39 @@ module CollavreLinear
       assert_equal "new-at", account.access_token, "a same-workspace reconnect must refresh the token"
     end
 
+    test "callback refuses a reconnect when the old workspace is unknown and links exist" do
+      sign_in_as(@user)
+
+      # Linked account whose stored workspace is blank (unprovable origin). We
+      # cannot prove the reconnect stays in the same workspace, so it must fail
+      # safe rather than silently orphan the links against the new token.
+      account = CollavreLinear::Account.create!(
+        user: @user,
+        linear_uid: "user-uid-1",
+        access_token: "old-token",
+        workspace_id: nil
+      )
+      CollavreLinear::ProjectLink.create!(
+        account: account,
+        creative: @creative,
+        linear_project_id: "proj-blank",
+        team_id: "team-blank"
+      )
+
+      stub_token_exchange
+      stub_viewer_query # returns organization org-xyz
+
+      state = initiate_oauth
+      get "/linear/auth/callback", params: { code: "auth-code-unknown-ws", state: state }
+
+      assert_response :redirect
+      account.reload
+      assert_equal "old-token", account.access_token,
+        "token must not be overwritten when the old workspace is unknown and links exist"
+      assert_nil account.workspace_id,
+        "workspace must not be backfilled from an unprovable reconnect under existing links"
+    end
+
     test "callback redirects to setup when creative_id is in session" do
       sign_in_as(@user)
 

--- a/engines/collavre_linear/test/views/collavre_linear/integrations/modal_test.rb
+++ b/engines/collavre_linear/test/views/collavre_linear/integrations/modal_test.rb
@@ -43,6 +43,50 @@ module CollavreLinear
         assert_includes html, %(data-creative-id="#{@creative.id}")
       end
 
+      test "does NOT show a reconnect button when the user has no Linear account" do
+        # The not-connected branch already offers the primary Connect button; a
+        # second OAuth entry point here would just be noise.
+        html = render_modal(connected: false)
+
+        refute_includes html, I18n.t("collavre_linear.integration.reconnect_button")
+      end
+
+      test "offers a reconnect (re-OAuth) button when connected but not yet linked" do
+        # The stuck state: an Account row exists but its token is dead (revoked in
+        # Linear or expired), so the options fetch 502s. Without a reconnect path
+        # here the user is stranded on the link form with no way back to OAuth.
+        html = render_modal(connected: true)
+
+        assert_includes html, I18n.t("collavre_linear.integration.reconnect_button")
+        # Substring of the hint that carries no HTML-escaped characters (the full
+        # string has an apostrophe that renders as &#39;).
+        assert_includes html, "expired or been revoked in Linear"
+        # Reuses the connect popup mechanism (hidden form posting to store_creative).
+        assert_includes html, "/linear/auth/store_creative"
+        assert_includes html, %(id="linear-connect-btn")
+      end
+
+      test "offers a reconnect button in the already-linked state too" do
+        # A dead token also strands the linked state (resync silently no-ops), so
+        # the reconnect escape hatch must be reachable there as well.
+        account = CollavreLinear::Account.create!(
+          user: @user,
+          linear_uid: "uid-reconnect-#{SecureRandom.hex(4)}",
+          access_token: "tok-reconnect"
+        )
+        CollavreLinear::ProjectLink.create!(
+          creative: @creative.effective_origin,
+          account: account,
+          linear_project_id: "proj-reconnect-1",
+          team_id: "team-reconnect-1",
+          webhook_secret: "reconnect-secret"
+        )
+
+        html = render_modal(connected: true)
+
+        assert_includes html, I18n.t("collavre_linear.integration.reconnect_button")
+      end
+
       test "shows the team/project link form for an admin who is connected but not linked" do
         html = render_modal(connected: true)
 


### PR DESCRIPTION
## Problem

Topic: **linear 연결을 프로젝트 연결 전에 지우면** (creative 31)

`GET /linear/creatives/:id/integration/options` returns **502 Bad Gateway**, the modal shows *"Linear 프로젝트와 팀을 불러오지 못했습니다. 다시 시도해 주세요."*, and the user **cannot re-do the OAuth connection**.

### Root cause

The modal (`_modal.html.erb:14`) treats *"a `CollavreLinear::Account` row exists"* as **connected**, and only renders the OAuth connect button in the **not-connected** branch (`:184`).

When the account row exists but its token is dead — revoked in Linear's settings, or expired past refresh — the modal renders the **link-a-project** form, whose JS fetches `/integration/options`. `Client#list_teams` raises `Client::Error`, so the controller returns 502 (`integrations_controller.rb:236-239`). There is **no UI path back to OAuth** from the connected state, so the user is stranded.

Re-authenticating already recovers this **server-side**: `auth#callback` uses `find_or_initialize_by(user_id:)` (`auth_controller.rb:43`), so it updates the **same** Account row in place — existing project links and the account id survive, only the dead token is replaced. It just wasn't reachable from the UI.

## Fix

Render a **"Reconnect Linear"** affordance in **both** connected sub-states (link form and already-linked). It reuses the existing connect-popup mechanism and its element ids (`linear-connect-form` / `linear-connect-btn`); connected and not-connected are mutually exclusive branches, so each id still appears exactly once in the DOM and the existing JS opener wiring drives it **unchanged** (no JS change).

- `_modal.html.erb`: reconnect block inside the `connected` branch, after the linked/link sub-if.
- `en.yml` / `ko.yml`: `reconnect_hint`, `reconnect_button`.

## Tests

`modal_test.rb`: reconnect button present when connected (linked **and** not-linked), absent when not connected.

- Engine suite: **351 runs / 927 assertions / 0 failures** (host-root).
- rubocop clean on changed Ruby; pre-push i18n en/ko parity check passes.

## Note

This does not distinguish an auth failure from a transient network 502 in the `options` response — the reconnect button is simply always available in the connected state, which is the escape hatch the stuck user needs. Auto-detecting "token revoked" to prompt reconnect specifically is a possible follow-up.