### PR TITLE
fix: surface masked provider error body; mirror app log level in RubyLLM

### DIFF
--- a/config/initializers/ruby_llm.rb
+++ b/config/initializers/ruby_llm.rb
@@ -16,6 +16,12 @@ RubyLLM.configure do |config|
     1800
   end
   config.log_file = Rails.root.join("log", "ruby_llm.log").to_s
-  config.log_level = Logger::DEBUG
-  config.log_stream_debug = true
+  # Mirror the app's log level instead of hardcoding DEBUG. At DEBUG the Faraday
+  # :logger middleware writes full request/response bodies to ruby_llm.log
+  # (connection.rb: `bodies: RubyLLM.logger.debug?`). Provider error bodies arrive
+  # tagged ASCII-8BIT, so non-ASCII text (e.g. Korean) fails to transcode into the
+  # UTF-8 log and floods stderr with "log writing failed" lines. Production runs at
+  # INFO, which silences body logging; development stays at DEBUG for full tracing.
+  config.log_level = Rails.logger&.level || Logger::INFO
+  config.log_stream_debug = Rails.logger&.debug? || false
 end

--- a/engines/collavre/app/services/collavre/ai_client.rb
+++ b/engines/collavre/app/services/collavre/ai_client.rb
@@ -127,6 +127,7 @@ module Collavre
       # ActivityLog gate below. error_message stays intact for the gated ensure log
       # and the streamed yield (which goes back to the same user).
       Rails.logger.error "AI Client error: #{@log_interactions ? error_message : "[#{e.class.name}]"}"
+      log_error_response(e) if @log_interactions
       Rails.logger.error "Partial response length: #{response_content.length} chars" if response_content.present?
       Rails.logger.debug e.backtrace.join("\n")
       yield "\n\n⚠️ AI Error: #{error_message}" if block_given?
@@ -164,6 +165,30 @@ module Collavre
     private
 
     attr_reader :vendor, :model, :system_prompt, :llm_api_key, :gateway_url, :context
+
+    # RubyLLM masks provider 400s behind a generic "Invalid request - please check
+    # your input" fallback whenever the provider's error body is not in OpenAI's
+    # {error:{message}} shape — common for OpenAI-compatible gateways (Cerebras,
+    # local Ollama, etc.), whose real reason then lives only in the raw HTTP
+    # response. RubyLLM::Error carries that response (status + body); surface it to
+    # the app log so the actual cause is one grep away instead of buried in
+    # ruby_llm.log. Gated by @log_interactions at the call site, like the message
+    # log above, because a 400 validation body can echo the offending input.
+    def log_error_response(error)
+      return unless error.respond_to?(:response) && (response = error.response)
+
+      status = response.respond_to?(:status) ? response.status : nil
+      body = response.respond_to?(:body) ? response.body : nil
+      return if status.nil? && body.blank?
+
+      # Provider error bodies are frequently tagged ASCII-8BIT even though the bytes
+      # are valid UTF-8; reinterpret and scrub so non-ASCII text (e.g. Korean) is
+      # readable and never re-triggers the transcode failure we are eliminating.
+      body_text = body.is_a?(String) ? body.dup.force_encoding("UTF-8").scrub : body.inspect
+      Rails.logger.error "AI Client error response: status=#{status} body=#{body_text.to_s.truncate(2000)}"
+    rescue StandardError => e
+      Rails.logger.debug "AiClient#log_error_response failed: #{e.class}"
+    end
 
     VENDOR_TO_PROVIDER = {
       "openai" => :openai,

--- a/engines/collavre/app/services/collavre/ai_client.rb
+++ b/engines/collavre/app/services/collavre/ai_client.rb
@@ -170,16 +170,30 @@ module Collavre
     # your input" fallback whenever the provider's error body is not in OpenAI's
     # {error:{message}} shape — common for OpenAI-compatible gateways (Cerebras,
     # local Ollama, etc.), whose real reason then lives only in the raw HTTP
-    # response. RubyLLM::Error carries that response (status + body); surface it to
-    # the app log so the actual cause is one grep away instead of buried in
-    # ruby_llm.log. Gated by @log_interactions at the call site, like the message
-    # log above, because a 400 validation body can echo the offending input.
+    # response. RubyLLM::Error carries that response (status + body); surface it so
+    # the actual cause is one grep away instead of buried in ruby_llm.log.
+    #
+    # A provider 400 body can echo the offending request (prompt or tool arguments),
+    # so the raw body is written to the app log only under debug logging — the same
+    # level that already gates RubyLLM's own request/response body log (see the
+    # ruby_llm initializer). At INFO (production) we record status + body size only,
+    # keeping user content out of centralized app logs while still capturing that the
+    # provider rejected the request and how large its reason was; raise the log level
+    # to recover the full body on demand. The whole path is additionally gated by
+    # @log_interactions at the call site, like the error-message log above.
     def log_error_response(error)
       return unless error.respond_to?(:response) && (response = error.response)
 
       status = response.respond_to?(:status) ? response.status : nil
       body = response.respond_to?(:body) ? response.body : nil
       return if status.nil? && body.blank?
+
+      unless Rails.logger.debug?
+        size = body.is_a?(String) ? "#{body.bytesize}B" : (body.nil? ? "none" : "non-string")
+        Rails.logger.error "AI Client error response: status=#{status} body_size=#{size} " \
+                           "(body suppressed at INFO; raise log level to capture it)"
+        return
+      end
 
       # Provider error bodies are frequently tagged ASCII-8BIT even though the bytes
       # are valid UTF-8; reinterpret and scrub so non-ASCII text (e.g. Korean) is

--- a/engines/collavre/test/services/ai_client_test.rb
+++ b/engines/collavre/test/services/ai_client_test.rb
@@ -473,6 +473,8 @@ class AiClientTest < ActiveSupport::TestCase
     fake_logger = Object.new
     fake_logger.define_singleton_method(:error) { |msg| logged << msg.to_s }
     fake_logger.define_singleton_method(:debug) { |*_| }
+    # Debug logging (development) surfaces the full body; production is asserted below.
+    fake_logger.define_singleton_method(:debug?) { true }
 
     Rails.stub(:logger, fake_logger) do
       client.stub(:build_conversation, conversation) do
@@ -483,6 +485,40 @@ class AiClientTest < ActiveSupport::TestCase
     joined = logged.join("\n")
     assert_includes joined, "status=400"
     assert_includes joined, "tools[0].function.parameters: invalid schema"
+  end
+
+  test "suppresses provider error body at INFO but records status and size" do
+    # A 400 body can echo the offending prompt/tool arguments. At INFO (production)
+    # the raw body must not reach centralized app logs; only the status and body
+    # size are recorded so the rejection is still traceable without leaking content.
+    secret = "user-prompt-should-not-leak-to-prod-logs"
+    raw_body = { "detail" => secret }.to_json
+    response = OpenStruct.new(status: 400, body: raw_body)
+    conversation = FakeConversation.new
+    conversation.define_singleton_method(:complete) do |&_block|
+      raise RubyLLM::BadRequestError.new(response, "Invalid request - please check your input")
+    end
+
+    client = AiClient.new(
+      vendor: "openai", model: "gpt-oss-120b", system_prompt: "system", llm_api_key: "api-key"
+    )
+
+    logged = []
+    fake_logger = Object.new
+    fake_logger.define_singleton_method(:error) { |msg| logged << msg.to_s }
+    fake_logger.define_singleton_method(:debug) { |*_| }
+    fake_logger.define_singleton_method(:debug?) { false }
+
+    Rails.stub(:logger, fake_logger) do
+      client.stub(:build_conversation, conversation) do
+        client.chat([ { role: "user", parts: [ { text: "hi" } ] } ])
+      end
+    end
+
+    joined = logged.join("\n")
+    assert_includes joined, "status=400", "status must still be recorded at INFO"
+    assert_includes joined, "body_size=#{raw_body.bytesize}B", "body size must be recorded at INFO"
+    assert_not_includes joined, secret, "raw provider body leaked to app log at INFO"
   end
 
   test "reinterprets ASCII-8BIT provider error body as UTF-8 so non-ASCII is readable" do
@@ -504,6 +540,7 @@ class AiClientTest < ActiveSupport::TestCase
     fake_logger = Object.new
     fake_logger.define_singleton_method(:error) { |msg| logged << msg.to_s }
     fake_logger.define_singleton_method(:debug) { |*_| }
+    fake_logger.define_singleton_method(:debug?) { true }
 
     Rails.stub(:logger, fake_logger) do
       client.stub(:build_conversation, conversation) do

--- a/engines/collavre/test/services/ai_client_test.rb
+++ b/engines/collavre/test/services/ai_client_test.rb
@@ -580,6 +580,42 @@ class AiClientTest < ActiveSupport::TestCase
     assert_not_includes logged.join("\n"), secret, "response body leaked despite log_interactions:false"
   end
 
+  test "response-body logging never breaks the error path when the response is malformed" do
+    # log_error_response is a diagnostic helper on the failure path, so a malformed
+    # response object must never turn a provider error into a crash. A response that
+    # raises while its body is read exercises the defensive rescue: the AI error is
+    # still surfaced to the caller and only a debug breadcrumb is left behind.
+    response = Object.new
+    response.define_singleton_method(:status) { 400 }
+    response.define_singleton_method(:body) { raise "cannot read body" }
+    conversation = FakeConversation.new
+    conversation.define_singleton_method(:complete) do |&_block|
+      raise RubyLLM::BadRequestError.new(response, "Invalid request - please check your input")
+    end
+
+    client = AiClient.new(
+      vendor: "openai", model: "gpt-oss-120b", system_prompt: "system", llm_api_key: "api-key"
+    )
+
+    errors = []
+    debugs = []
+    fake_logger = Object.new
+    fake_logger.define_singleton_method(:error) { |msg| errors << msg.to_s }
+    fake_logger.define_singleton_method(:debug) { |*args| debugs << args.join }
+    fake_logger.define_singleton_method(:debug?) { true }
+
+    yielded = +""
+    Rails.stub(:logger, fake_logger) do
+      client.stub(:build_conversation, conversation) do
+        client.chat([ { role: "user", parts: [ { text: "hi" } ] } ]) { |delta| yielded << delta }
+      end
+    end
+
+    assert_includes yielded, "AI Error", "caller must still receive the error despite the malformed response"
+    assert(debugs.any? { |m| m.include?("log_error_response failed") },
+           "the defensive rescue should leave a debug breadcrumb")
+  end
+
   test "yields whitespace-only deltas instead of dropping them" do
     # Providers routinely emit a paragraph break as a chunk of its own. "\n\n" is
     # blank? == true, so skipping blank deltas deletes it — and since the delta is

--- a/engines/collavre/test/services/ai_client_test.rb
+++ b/engines/collavre/test/services/ai_client_test.rb
@@ -453,6 +453,96 @@ class AiClientTest < ActiveSupport::TestCase
     assert(logged.any? { |m| m.include?("StandardError") }, "error class should still be logged")
   end
 
+  test "surfaces provider error response body when RubyLLM masks the reason" do
+    # RubyLLM raises BadRequestError with the generic "Invalid request" fallback
+    # when the provider's 400 body isn't in OpenAI's {error:{message}} shape (e.g.
+    # OpenAI-compatible gateways like Cerebras). The real reason lives only on the
+    # raw HTTP response; the client must surface its status + body to the app log.
+    raw_body = { "detail" => "tools[0].function.parameters: invalid schema" }.to_json
+    response = OpenStruct.new(status: 400, body: raw_body)
+    conversation = FakeConversation.new
+    conversation.define_singleton_method(:complete) do |&_block|
+      raise RubyLLM::BadRequestError.new(response, "Invalid request - please check your input")
+    end
+
+    client = AiClient.new(
+      vendor: "openai", model: "gpt-oss-120b", system_prompt: "system", llm_api_key: "api-key"
+    )
+
+    logged = []
+    fake_logger = Object.new
+    fake_logger.define_singleton_method(:error) { |msg| logged << msg.to_s }
+    fake_logger.define_singleton_method(:debug) { |*_| }
+
+    Rails.stub(:logger, fake_logger) do
+      client.stub(:build_conversation, conversation) do
+        client.chat([ { role: "user", parts: [ { text: "hi" } ] } ])
+      end
+    end
+
+    joined = logged.join("\n")
+    assert_includes joined, "status=400"
+    assert_includes joined, "tools[0].function.parameters: invalid schema"
+  end
+
+  test "reinterprets ASCII-8BIT provider error body as UTF-8 so non-ASCII is readable" do
+    # Provider error bodies arrive tagged ASCII-8BIT even when the bytes are valid
+    # UTF-8; without reinterpretation the transcode into the UTF-8 log fails (the
+    # original "log writing failed" symptom) and Korean/other text is unreadable.
+    binary_body = "잘못된 요청".dup.force_encoding("ASCII-8BIT")
+    response = OpenStruct.new(status: 400, body: binary_body)
+    conversation = FakeConversation.new
+    conversation.define_singleton_method(:complete) do |&_block|
+      raise RubyLLM::BadRequestError.new(response, "Invalid request - please check your input")
+    end
+
+    client = AiClient.new(
+      vendor: "openai", model: "gpt-oss-120b", system_prompt: "system", llm_api_key: "api-key"
+    )
+
+    logged = []
+    fake_logger = Object.new
+    fake_logger.define_singleton_method(:error) { |msg| logged << msg.to_s }
+    fake_logger.define_singleton_method(:debug) { |*_| }
+
+    Rails.stub(:logger, fake_logger) do
+      client.stub(:build_conversation, conversation) do
+        client.chat([ { role: "user", parts: [ { text: "hi" } ] } ])
+      end
+    end
+
+    assert(logged.any? { |m| m.include?("잘못된 요청") }, "Korean error body should be logged readably")
+  end
+
+  test "does not surface provider error response body when log_interactions is false" do
+    # A 400 validation body can echo the offending input, so the response-body log
+    # is gated by log_interactions just like the error-message log.
+    secret = "unsubmitted-draft-qwerty"
+    response = OpenStruct.new(status: 400, body: { "input" => secret }.to_json)
+    conversation = FakeConversation.new
+    conversation.define_singleton_method(:complete) do |&_block|
+      raise RubyLLM::BadRequestError.new(response, "Invalid request - please check your input")
+    end
+
+    client = AiClient.new(
+      vendor: "openai", model: "gpt-oss-120b", system_prompt: "system",
+      llm_api_key: "api-key", log_interactions: false
+    )
+
+    logged = []
+    fake_logger = Object.new
+    fake_logger.define_singleton_method(:error) { |msg| logged << msg.to_s }
+    fake_logger.define_singleton_method(:debug) { |*_| }
+
+    Rails.stub(:logger, fake_logger) do
+      client.stub(:build_conversation, conversation) do
+        client.chat([ { role: "user", parts: [ { text: secret } ] } ])
+      end
+    end
+
+    assert_not_includes logged.join("\n"), secret, "response body leaked despite log_interactions:false"
+  end
+
   test "yields whitespace-only deltas instead of dropping them" do
     # Providers routinely emit a paragraph break as a chunk of its own. "\n\n" is
     # blank? == true, so skipping blank deltas deletes it — and since the delta is


### PR DESCRIPTION
## Problem

An AI-agent failure using an OpenAI-compatible gateway (Cerebras `gpt-oss-120b`) surfaced only as an opaque, un-actionable pair of symptoms:

- `[RubyLLM::BadRequestError] Invalid request - please check your input`
- ~24 lines of `log writing failed. "\xED" from ASCII-8BIT to UTF-8`

Root-cause analysis (traced from log → code):

1. **Masked reason.** `"Invalid request - please check your input"` is RubyLLM's *fallback* string (`error.rb`). `provider.parse_error` only reads `body.dig("error","message")`; OpenAI-compatible gateways (Cerebras, local Ollama) return 400 bodies in other shapes, so the real reason is dropped and lives only on `RubyLLM::Error#response`.
2. **Log spam.** `config.log_level` was hardcoded to `DEBUG`, so the Faraday `:logger` middleware (`bodies: RubyLLM.logger.debug?`) writes full HTTP response bodies to `ruby_llm.log`. Those bodies arrive tagged **ASCII-8BIT**; non-ASCII text (Korean) then fails to transcode into the UTF-8 log — the `log writing failed` flood. This was a DEBUG-vs-app-INFO mismatch, not intentional.

## Changes

**1. Surface the real 400 reason** (`engines/collavre/app/services/collavre/ai_client.rb`)
- New `log_error_response` logs `RubyLLM::Error#response` status + body so the actual cause is one grep away instead of buried in `ruby_llm.log`.
- Provider bodies tagged ASCII-8BIT are reinterpreted as UTF-8 + scrubbed, so Korean reads correctly and never re-triggers the transcode failure.
- Gated by `@log_interactions` (same as the existing error-message log) because a 400 validation body can echo unsubmitted user input.

**2. Stop the log spam at the source** (`config/initializers/ruby_llm.rb`)
- Mirror the app log level instead of hardcoding DEBUG: INFO in production (silences body logging), DEBUG in development (full tracing preserved).

## Tests

Adds 3 tests to `ai_client_test.rb`:
- masked reason (status + body) is surfaced
- ASCII-8BIT body reinterpreted so non-ASCII is readable
- response body is **not** logged when `log_interactions: false`

`ai_client_test` 20/20 pass; rubocop clean.

## Note

This makes the *next* occurrence diagnosable — it does not itself fix the underlying Cerebras 400 (most likely a tool/function JSON-schema the gateway rejects). The real body will now appear in the app log for a precise follow-up fix.