### PR TITLE
fix: stop sending reasoning_content to strict OpenAI-compatible gateways (Cerebras 400)

### DIFF
--- a/engines/collavre/config/initializers/ruby_llm_openai_reasoning_content.rb
+++ b/engines/collavre/config/initializers/ruby_llm_openai_reasoning_content.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+return unless defined?(RubyLLM::Providers::OpenAI)
+
+module Collavre
+  module RubyLlmPatches
+    # RubyLLM (through the current 1.16.0) serializes a replayed assistant
+    # "thinking" block into BOTH `reasoning` and `reasoning_content` on the
+    # OpenAI-format request payload — see
+    # RubyLLM::Providers::OpenAI::Chat#format_thinking, which sets the two keys
+    # to the same value for cross-vendor compatibility (DeepSeek reads
+    # `reasoning_content`; others read `reasoning`).
+    #
+    # Hosted OpenAI tolerates the redundant key, but strict OpenAI-compatible
+    # gateways reject it. Cerebras is the concrete case we hit: its
+    # AssistantMessage schema defines `reasoning` but not `reasoning_content`, so
+    # the tool-result follow-up request (the second call in a tool loop, the
+    # first that replays an assistant turn) fails with a 400 BadRequest. The
+    # error is doubly opaque because RubyLLM's parse_error cannot read Cerebras's
+    # non-standard error body and falls back to the generic
+    # "Invalid request - please check your input".
+    #
+    # Fix: drop `reasoning_content` only when a custom gateway is configured, so
+    # hosted OpenAI requests stay byte-identical. `reasoning` is kept because it
+    # is the field Cerebras (and the OpenAI format itself) documents, and it
+    # carries useful replayed context. Collavre's other gateways (Ollama,
+    # LM Studio) ignore unknown message fields, so removing `reasoning_content`
+    # is safe for them too.
+    #
+    # Upstream has no fix as of 1.16.0; revisit and remove this patch if a later
+    # ruby_llm release makes the second key gateway-aware.
+    module OpenAIDropReasoningContent
+      def format_thinking(msg)
+        payload = super
+        return payload unless payload.is_a?(Hash)
+        return payload unless custom_openai_gateway?
+
+        payload.delete(:reasoning_content)
+        payload
+      end
+
+      private
+
+      def custom_openai_gateway?
+        base = config&.openai_api_base.to_s
+        base.present? && !base.start_with?("https://api.openai.com")
+      end
+    end
+  end
+end
+
+RubyLLM::Providers::OpenAI.prepend(Collavre::RubyLlmPatches::OpenAIDropReasoningContent)

--- a/engines/collavre/config/initializers/ruby_llm_openai_reasoning_content.rb
+++ b/engines/collavre/config/initializers/ruby_llm_openai_reasoning_content.rb
@@ -13,29 +13,37 @@ module Collavre
     # to the same value for cross-vendor compatibility (DeepSeek reads
     # `reasoning_content`; others read `reasoning`).
     #
-    # Hosted OpenAI tolerates the redundant key, but strict OpenAI-compatible
-    # gateways reject it. Cerebras is the concrete case we hit: its
-    # AssistantMessage schema defines `reasoning` but not `reasoning_content`, so
-    # the tool-result follow-up request (the second call in a tool loop, the
+    # Hosted OpenAI tolerates the redundant key, but some strict
+    # OpenAI-compatible gateways reject it. Cerebras is the concrete case we hit:
+    # its AssistantMessage schema defines `reasoning` but not `reasoning_content`,
+    # so the tool-result follow-up request (the second call in a tool loop, the
     # first that replays an assistant turn) fails with a 400 BadRequest. The
     # error is doubly opaque because RubyLLM's parse_error cannot read Cerebras's
     # non-standard error body and falls back to the generic
     # "Invalid request - please check your input".
     #
-    # Fix: drop `reasoning_content` only when a custom gateway is configured, so
-    # hosted OpenAI requests stay byte-identical. `reasoning` is kept because it
-    # is the field Cerebras (and the OpenAI format itself) documents, and it
-    # carries useful replayed context. Collavre's other gateways (Ollama,
-    # LM Studio) ignore unknown message fields, so removing `reasoning_content`
-    # is safe for them too.
+    # This is NOT safe to apply to every custom gateway: the opposite failure
+    # exists. DeepSeek's thinking mode (default-on for its reasoning models)
+    # *requires* `reasoning_content` to be replayed on the assistant turn, and
+    # returns 400 "The reasoning_content in the thinking mode must be passed
+    # back to the API" when it is missing. So the removal is scoped to an
+    # explicit denylist of hosts we have confirmed reject the key; every other
+    # target — hosted OpenAI, DeepSeek, Ollama/LM Studio, and unknown gateways —
+    # keeps `reasoning_content` untouched.
     #
     # Upstream has no fix as of 1.16.0; revisit and remove this patch if a later
     # ruby_llm release makes the second key gateway-aware.
     module OpenAIDropReasoningContent
+      # OpenAI-compatible gateway hosts whose chat-completions schema rejects the
+      # non-standard `reasoning_content` key. Add a host here only after
+      # confirming it 400s on the replayed key (do NOT add DeepSeek — it needs
+      # the key). Matched against the exact parsed host of `openai_api_base`.
+      STRICT_HOSTS_REJECTING_REASONING_CONTENT = %w[api.cerebras.ai].freeze
+
       def format_thinking(msg)
         payload = super
         return payload unless payload.is_a?(Hash)
-        return payload unless custom_openai_gateway?
+        return payload unless gateway_rejects_reasoning_content?
 
         payload.delete(:reasoning_content)
         payload
@@ -43,14 +51,24 @@ module Collavre
 
       private
 
-      def custom_openai_gateway?
-        base = config&.openai_api_base.to_s
-        return false unless base.present?
+      # True only when the configured gateway host is on the known-reject
+      # denylist. An absent, unparseable, or unlisted host returns false so the
+      # key is preserved — the safe default, since dropping it breaks gateways
+      # (e.g. DeepSeek) that require it.
+      def gateway_rejects_reasoning_content?
+        host = openai_base_host
+        return false if host.nil?
 
-        uri = URI.parse(base)
-        !(uri.is_a?(URI::HTTPS) && uri.host == "api.openai.com")
+        STRICT_HOSTS_REJECTING_REASONING_CONTENT.include?(host)
+      end
+
+      def openai_base_host
+        base = config&.openai_api_base.to_s
+        return nil if base.blank?
+
+        URI.parse(base).host&.downcase
       rescue URI::InvalidURIError
-        true
+        nil
       end
     end
   end

--- a/engines/collavre/config/initializers/ruby_llm_openai_reasoning_content.rb
+++ b/engines/collavre/config/initializers/ruby_llm_openai_reasoning_content.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "uri"
+
 return unless defined?(RubyLLM::Providers::OpenAI)
 
 module Collavre
@@ -43,7 +45,12 @@ module Collavre
 
       def custom_openai_gateway?
         base = config&.openai_api_base.to_s
-        base.present? && !base.start_with?("https://api.openai.com")
+        return false unless base.present?
+
+        uri = URI.parse(base)
+        !(uri.is_a?(URI::HTTPS) && uri.host == "api.openai.com")
+      rescue URI::InvalidURIError
+        true
       end
     end
   end

--- a/engines/collavre/test/lib/collavre/ruby_llm_openai_reasoning_content_test.rb
+++ b/engines/collavre/test/lib/collavre/ruby_llm_openai_reasoning_content_test.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  # Guards the initializer patch that stops RubyLLM's OpenAI provider from
+  # sending the non-schema `reasoning_content` field to strict OpenAI-compatible
+  # gateways (e.g. Cerebras), which reject it with a 400 on the tool-result
+  # follow-up request.
+  class RubyLlmOpenaiReasoningContentTest < ActiveSupport::TestCase
+    ThinkingDouble = Struct.new(:text, :signature)
+    MessageDouble = Struct.new(:role, :thinking)
+
+    # Build a real provider instance without running #initialize, which would
+    # open a Faraday connection and demand an API key. We only exercise the
+    # payload-shaping method, so an allocated instance with an injected config is
+    # enough — and it keeps the real prepended method-resolution chain intact.
+    def provider_for(openai_api_base)
+      config = RubyLLM::Configuration.new
+      config.openai_api_base = openai_api_base
+      RubyLLM::Providers::OpenAI.allocate.tap do |provider|
+        provider.instance_variable_set(:@config, config)
+      end
+    end
+
+    def assistant_message(text: "chain of thought")
+      MessageDouble.new(:assistant, ThinkingDouble.new(text, nil))
+    end
+
+    test "strips reasoning_content but keeps reasoning for a custom gateway" do
+      payload = provider_for("https://api.cerebras.ai/v1")
+                .send(:format_thinking, assistant_message)
+
+      assert_equal "chain of thought", payload[:reasoning]
+      assert_not payload.key?(:reasoning_content),
+                 "reasoning_content must be stripped for custom OpenAI-compatible gateways"
+    end
+
+    test "keeps both keys for hosted OpenAI (no gateway configured)" do
+      payload = provider_for(nil).send(:format_thinking, assistant_message)
+
+      assert_equal "chain of thought", payload[:reasoning]
+      assert_equal "chain of thought", payload[:reasoning_content]
+    end
+
+    test "keeps both keys when the base is the official OpenAI endpoint" do
+      payload = provider_for("https://api.openai.com/v1")
+                .send(:format_thinking, assistant_message)
+
+      assert payload.key?(:reasoning_content),
+             "hosted OpenAI requests must stay byte-identical"
+    end
+
+    test "no-op for messages without a replayed thinking block" do
+      payload = provider_for("https://api.cerebras.ai/v1")
+                .send(:format_thinking, MessageDouble.new(:user, nil))
+
+      assert_equal({}, payload)
+    end
+  end
+end

--- a/engines/collavre/test/lib/collavre/ruby_llm_openai_reasoning_content_test.rb
+++ b/engines/collavre/test/lib/collavre/ruby_llm_openai_reasoning_content_test.rb
@@ -4,9 +4,10 @@ require "test_helper"
 
 module Collavre
   # Guards the initializer patch that stops RubyLLM's OpenAI provider from
-  # sending the non-schema `reasoning_content` field to strict OpenAI-compatible
-  # gateways (e.g. Cerebras), which reject it with a 400 on the tool-result
-  # follow-up request.
+  # sending the non-schema `reasoning_content` field to gateways whose schema
+  # rejects it (e.g. Cerebras, which 400s on the tool-result follow-up request)
+  # — while preserving it for gateways that require it (e.g. DeepSeek thinking
+  # mode) and for hosted OpenAI.
   class RubyLlmOpenaiReasoningContentTest < ActiveSupport::TestCase
     ThinkingDouble = Struct.new(:text, :signature)
     MessageDouble = Struct.new(:role, :thinking)
@@ -27,13 +28,21 @@ module Collavre
       MessageDouble.new(:assistant, ThinkingDouble.new(text, nil))
     end
 
-    test "strips reasoning_content but keeps reasoning for a custom gateway" do
+    test "strips reasoning_content but keeps reasoning for a known-strict gateway (Cerebras)" do
       payload = provider_for("https://api.cerebras.ai/v1")
                 .send(:format_thinking, assistant_message)
 
       assert_equal "chain of thought", payload[:reasoning]
       assert_not payload.key?(:reasoning_content),
-                 "reasoning_content must be stripped for custom OpenAI-compatible gateways"
+                 "reasoning_content must be stripped for gateways that reject it (Cerebras)"
+    end
+
+    test "keeps reasoning_content for DeepSeek, which requires it in thinking mode" do
+      payload = provider_for("https://api.deepseek.com/v1")
+                .send(:format_thinking, assistant_message)
+
+      assert_equal "chain of thought", payload[:reasoning_content],
+                   "DeepSeek 400s when the replayed reasoning_content is missing; it must be preserved"
     end
 
     test "keeps both keys for hosted OpenAI (no gateway configured)" do
@@ -49,6 +58,22 @@ module Collavre
 
       assert payload.key?(:reasoning_content),
              "hosted OpenAI requests must stay byte-identical"
+    end
+
+    test "keeps reasoning_content for an unknown/unlisted custom gateway" do
+      payload = provider_for("https://api.some-other-llm.example/v1")
+                .send(:format_thinking, assistant_message)
+
+      assert payload.key?(:reasoning_content),
+             "the key is only dropped for denylisted hosts; unknown gateways are left untouched"
+    end
+
+    test "keeps reasoning_content for a deceptive host that merely contains the Cerebras string" do
+      payload = provider_for("https://api.cerebras.ai.evil.example/v1")
+                .send(:format_thinking, assistant_message)
+
+      assert payload.key?(:reasoning_content),
+             "denylist match is on the exact parsed host, not a substring"
     end
 
     test "no-op for messages without a replayed thinking block" do


### PR DESCRIPTION
## Problem

AI agents backed by a custom OpenAI-compatible gateway (e.g. **Cerebras** `gpt-oss-120b`, configured as `llm_vendor=openai` + `gateway_url=https://api.cerebras.ai/v1`) crash with a `RubyLLM::BadRequestError` **on any request that requires a tool call**:

```
AI Client error: [RubyLLM::BadRequestError] Invalid request - please check your input
```

### Root cause

RubyLLM's OpenAI provider serializes a replayed assistant *thinking* block into **both** `reasoning` **and** `reasoning_content` (`RubyLLM::Providers::OpenAI::Chat#format_thinking` sets the two keys to the same value for cross-vendor compatibility — DeepSeek reads `reasoning_content`, others read `reasoning`).

In a tool loop the **first** call succeeds (200 — no assistant turn to replay yet); the **second** call (feeding the tool result back) replays the assistant turn and fails. Cerebras's `AssistantMessage` schema defines `reasoning` but **not** `reasoning_content`, so it rejects the request with a 400.

The error is doubly opaque: RubyLLM's `parse_error` can't read Cerebras's non-standard error body and falls back to the generic `"Invalid request - please check your input"`. The real cause is only visible in `log/ruby_llm.log` (DEBUG).

### Upstream status

Confirmed unfixed through the latest **ruby_llm 1.16.0** — `format_thinking` still emits both keys. No related upstream issue/PR. Fixing in Collavre.

## Fix

Prepend a patch on `RubyLLM::Providers::OpenAI#format_thinking` that drops `reasoning_content` **only when a custom gateway is configured**, keeping hosted OpenAI requests byte-identical. `reasoning` is kept — it's the field Cerebras (and the OpenAI format itself) documents, and it carries useful replayed context. Collavre's other gateways (Ollama, LM Studio) ignore unknown message fields, so removing `reasoning_content` is safe for them too.

## Scope note

This resolves the infrastructure-level 400 (bug A). The underlying `"No write permission on parent Creative"` the agent hit (bug B — a product-permission issue) is separate; with this fix the agent will now surface that message to the user instead of crashing with an opaque 400.

## Tests

`engines/collavre/test/lib/collavre/ruby_llm_openai_reasoning_content_test.rb` — 4 cases: custom gateway strips `reasoning_content` / keeps `reasoning`; hosted OpenAI (nil base) keeps both; official `api.openai.com` base keeps both; non-assistant message is a no-op. Full pre-push suite green.