### PR TITLE
fix: order chat comments by id to survive cross-process clock skew

### DIFF
--- a/engines/collavre/app/controllers/collavre/comments_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comments_controller.rb
@@ -68,9 +68,15 @@ module Collavre
         scope = scope.where.not(topic_id: archived_topic_ids) if archived_topic_ids.any?
       end
 
-      # Default order: Newest first (created_at DESC)
+      # Default order: Newest first (id DESC).
+      # id is the single-sequence canonical insert order; the pagination cursors
+      # below already treat id as the source of truth ("Newer = higher id").
+      # Sorting by created_at instead reverses adjacent messages when an agent
+      # reply placeholder is stamped by a background worker whose clock lags the
+      # web process that stamped the triggering user message (cross-process
+      # clock skew), so the reply gets a higher id but an earlier created_at.
       # This matches the column-reverse layout where the first item in the list is the visual bottom (Newest).
-      scope = scope.order(created_at: :desc)
+      scope = scope.order(id: :desc)
 
 
       @comments = if params[:around_comment_id].present?
@@ -81,7 +87,7 @@ module Collavre
         # Older messages have LOWER IDs.
 
         # Newer bundle (including target): ID >= target_id
-        newer_bundle = scope.where("comments.id >= ?", target_id).reorder(created_at: :asc).limit(limit / 2 + 1)
+        newer_bundle = scope.where("comments.id >= ?", target_id).reorder(id: :asc).limit(limit / 2 + 1)
 
         # Older bundle: ID < target_id
         older_bundle = scope.where("comments.id < ?", target_id).limit(limit / 2)
@@ -105,7 +111,7 @@ module Collavre
         # We want the ones just above `after_id`.
 
         # Use reorder(ASC) to get the ones immediately larger than after_id, then reverse back to DESC.
-        scope.where("comments.id > ?", params[:after_id].to_i).reorder(created_at: :asc).limit(limit)
+        scope.where("comments.id > ?", params[:after_id].to_i).reorder(id: :asc).limit(limit)
       else
         # Initial Load (Latest messages)
         scope.limit(limit).to_a.reverse

--- a/engines/collavre/test/controllers/comments_controller_ordering_test.rb
+++ b/engines/collavre/test/controllers/comments_controller_ordering_test.rb
@@ -1,0 +1,58 @@
+require "test_helper"
+
+class CommentsControllerOrderingTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:one)
+    @creative = creatives(:tshirt)
+    @user.update!(email_verified_at: Time.current)
+    post session_path, params: { email: @user.email, password: "password" }
+  end
+
+  # Regression: an agent reply placeholder is stamped with created_at by a
+  # background worker whose clock can lag the web process that stamped the
+  # triggering user message. The reply then persists with a HIGHER id but an
+  # EARLIER created_at. Chat ordering must follow insert order (id), not
+  # wall-clock, so the user message always renders before the reply it
+  # triggered. A created_at sort (even with an id tiebreaker) reverses them
+  # because the timestamps genuinely differ.
+  test "orders comments by id when created_at is skewed backwards" do
+    user_msg = @creative.comments.create!(content: "my message", user: @user)
+    reply = @creative.comments.create!(content: "agent reply", user: @user)
+    # Simulate cross-process clock skew: reply is inserted after (higher id)
+    # yet stamped two seconds earlier than the user message it answers.
+    reply.update_column(:created_at, user_msg.created_at - 2.seconds)
+
+    get creative_comments_path(@creative)
+    assert_response :success
+
+    user_pos = @response.body.index("id=\"#{ActionView::RecordIdentifier.dom_id(user_msg)}\"")
+    reply_pos = @response.body.index("id=\"#{ActionView::RecordIdentifier.dom_id(reply)}\"")
+
+    assert user_pos, "user message should render"
+    assert reply_pos, "reply should render"
+    assert user_pos < reply_pos,
+           "user message (id #{user_msg.id}) must render before its reply " \
+           "(id #{reply.id}) despite the reply's earlier created_at"
+  end
+
+  # after_id pagination (scrolling down for newer messages) must also follow id
+  # order, not created_at, or a skewed reply leaks in out of position.
+  test "after_id pagination orders newer messages by id under skew" do
+    anchor = @creative.comments.create!(content: "anchor", user: @user)
+    first = @creative.comments.create!(content: "first newer", user: @user)
+    second = @creative.comments.create!(content: "second newer", user: @user)
+    # second has the higher id but a backdated created_at.
+    second.update_column(:created_at, first.created_at - 2.seconds)
+
+    get creative_comments_path(@creative, after_id: anchor.id)
+    assert_response :success
+
+    first_pos = @response.body.index("id=\"#{ActionView::RecordIdentifier.dom_id(first)}\"")
+    second_pos = @response.body.index("id=\"#{ActionView::RecordIdentifier.dom_id(second)}\"")
+
+    assert first_pos, "first newer message should render"
+    assert second_pos, "second newer message should render"
+    assert first_pos < second_pos,
+           "newer messages must render in id order despite skewed created_at"
+  end
+end


### PR DESCRIPTION
## Problem

In chat, a user's own message could render **below** the AI/agent reply it triggered — as if the user sent it later. A reload did **not** fix it, so this was a persisted ordering bug, not a live-render race.

### Root cause (confirmed against the production DB)

Topic 12957, ordered by `id`:

| id | author | created_at |
|----|--------|------------|
| 70934 | user (web) | 14:43:**55.543** |
| 70935 | agent (Vrex) | 14:43:**54.434** ← 1.1s **earlier** despite higher id |

The agent reply is a streaming *placeholder* created via `create!` inside a **background worker / agent process** (`ai_agent_service.rb`), so its `created_at` is stamped by that process's clock. The user message is stamped by the **web** process. When the two clocks are skewed (multi-process / remote runner), the reply can be stamped *before* the message that triggered it, even though it is inserted *after* (higher id).

The chat view sorted by `order(created_at: :desc)` with no `id` tiebreaker, so the reply sorted above the user message and the reversal persisted.

Note: a `created_at`+`id` tiebreaker would **not** fix this — the timestamps genuinely differ (1.1s), so the tiebreaker never engages. Only ordering by `id` resolves it.

## Fix

Order chat comments by `id` — the single-sequence canonical insert order the pagination cursors in this same controller **already** treat as the source of truth (`comments.id >= ?`, "Newer = higher id"). Applied to the default sort and the two `reorder(created_at: :asc)` pagination bundles. The mobile agent-events API already orders by `id`, so this aligns web with mobile.

## Tests

New `comments_controller_ordering_test.rb`:
- default load orders by id when a reply's `created_at` is skewed 2s backwards
- `after_id` pagination orders newer messages by id under the same skew

Both fail on `created_at` sort, pass on `id`. Related suites (`comments_controller_test`, `_branch`, `_event`, `comments_read_marker`) stay green (61 runs).

## Why dev never showed it

Dev uses a single local process (SQLite, one `ai_agent_service` process) → identical clock → zero `created_at` monotonicity violations. The bug only surfaces with multi-process / remote collaborating agents (e.g. Vrex over tailscale).