### PR TITLE
fix(comments): order chat timeline by id to survive cross-process clock skew

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_15_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_24_000000) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -175,6 +175,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_15_000000) do
     t.index ["action_executed_by_id"], name: "index_comments_on_action_executed_by_id"
     t.index ["approver_id"], name: "index_comments_on_approver_id"
     t.index ["creative_id", "created_at"], name: "index_comments_on_creative_id_and_created_at"
+    t.index ["creative_id", "id"], name: "index_comments_on_creative_id_and_id"
     t.index ["creative_id"], name: "index_comments_on_creative_id"
     t.index ["quoted_comment_id"], name: "index_comments_on_quoted_comment_id"
     t.index ["selected_version_id"], name: "index_comments_on_selected_version_id"

--- a/engines/collavre/app/controllers/collavre/comments_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comments_controller.rb
@@ -68,9 +68,15 @@ module Collavre
         scope = scope.where.not(topic_id: archived_topic_ids) if archived_topic_ids.any?
       end
 
-      # Default order: Newest first (created_at DESC)
+      # Default order: Newest first (id DESC)
       # This matches the column-reverse layout where the first item in the list is the visual bottom (Newest).
-      scope = scope.order(created_at: :desc)
+      # We order by id, not created_at: id is a single monotonic sequence that reflects the true insertion
+      # (causal) order, whereas created_at is stamped by whichever process wrote the row. A user message is
+      # stamped by the web request while its agent reply is stamped by a background worker, and clock skew
+      # between those processes can backdate the reply below the message that triggered it. The pagination
+      # cursors below are all id-based ("Newer = higher id"), so ordering by id keeps display and cursors
+      # consistent.
+      scope = scope.order(id: :desc)
 
 
       @comments = if params[:around_comment_id].present?
@@ -81,7 +87,7 @@ module Collavre
         # Older messages have LOWER IDs.
 
         # Newer bundle (including target): ID >= target_id
-        newer_bundle = scope.where("comments.id >= ?", target_id).reorder(created_at: :asc).limit(limit / 2 + 1)
+        newer_bundle = scope.where("comments.id >= ?", target_id).reorder(id: :asc).limit(limit / 2 + 1)
 
         # Older bundle: ID < target_id
         older_bundle = scope.where("comments.id < ?", target_id).limit(limit / 2)
@@ -104,8 +110,8 @@ module Collavre
         # But standard DESC query would give us the VERY Newest.
         # We want the ones just above `after_id`.
 
-        # Use reorder(ASC) to get the ones immediately larger than after_id, then reverse back to DESC.
-        scope.where("comments.id > ?", params[:after_id].to_i).reorder(created_at: :asc).limit(limit)
+        # Use reorder(id: :asc) to get the ones immediately larger than after_id, then reverse back to DESC.
+        scope.where("comments.id > ?", params[:after_id].to_i).reorder(id: :asc).limit(limit)
       else
         # Initial Load (Latest messages)
         scope.limit(limit).to_a.reverse

--- a/engines/collavre/db/migrate/20260724000000_add_creative_id_index_to_comments.rb
+++ b/engines/collavre/db/migrate/20260724000000_add_creative_id_index_to_comments.rb
@@ -1,0 +1,11 @@
+class AddCreativeIdIndexToComments < ActiveRecord::Migration[8.1]
+  # The chat timeline now orders by comments.id (not created_at) to survive
+  # cross-process clock skew. A composite index on [creative_id, id] lets the DB
+  # satisfy the per-creative filter and the id-ordered LIMIT/range paging from
+  # the index, instead of scanning creative_id then sorting by id.
+  def change
+    unless index_exists?(:comments, [ :creative_id, :id ])
+      add_index :comments, [ :creative_id, :id ], name: "index_comments_on_creative_id_and_id"
+    end
+  end
+end

--- a/engines/collavre/db/migrate/20260724000000_add_creative_id_index_to_comments.rb
+++ b/engines/collavre/db/migrate/20260724000000_add_creative_id_index_to_comments.rb
@@ -3,9 +3,32 @@ class AddCreativeIdIndexToComments < ActiveRecord::Migration[8.1]
   # cross-process clock skew. A composite index on [creative_id, id] lets the DB
   # satisfy the per-creative filter and the id-ordered LIMIT/range paging from
   # the index, instead of scanning creative_id then sorting by id.
-  def change
-    unless index_exists?(:comments, [ :creative_id, :id ])
-      add_index :comments, [ :creative_id, :id ], name: "index_comments_on_creative_id_and_id"
-    end
+  #
+  # Built CONCURRENTLY on PostgreSQL so the deploy never takes a write-blocking
+  # lock on the hot comments table while the index builds. Requires running
+  # outside a transaction. SQLite (dev/test) has no concurrent algorithm, so we
+  # omit it there; if_not_exists keeps the build idempotent on both.
+  disable_ddl_transaction!
+
+  # Explicit up/down: `change` auto-reverses add_index by forwarding every option
+  # (including if_not_exists:) to remove_index, which rejects it and fails rollback.
+  def up
+    add_index :comments, [ :creative_id, :id ],
+              name: "index_comments_on_creative_id_and_id",
+              algorithm: concurrent_algorithm,
+              if_not_exists: true
+  end
+
+  def down
+    remove_index :comments,
+                 name: "index_comments_on_creative_id_and_id",
+                 algorithm: concurrent_algorithm,
+                 if_exists: true
+  end
+
+  private
+
+  def concurrent_algorithm
+    :concurrently if connection.adapter_name.match?(/postgres/i)
   end
 end

--- a/engines/collavre/test/integration/comments_order_clock_skew_test.rb
+++ b/engines/collavre/test/integration/comments_order_clock_skew_test.rb
@@ -14,6 +14,9 @@ class CommentsOrderClockSkewTest < ActionDispatch::IntegrationTest
     @user = User.create!(email: "skew-user@example.com", password: TEST_PASSWORD, name: "SkewUser")
     @creative = Creative.create!(user: @user, description: "Skew creative")
 
+    # An earlier comment used as the pagination anchor (after_id) below. Lowest id.
+    @anchor = @creative.comments.create!(user: @user, content: "ANCHOR_MESSAGE")
+
     # Inserted first -> lower id. This is the user message.
     @user_message = @creative.comments.create!(user: @user, content: "FIRST_USER_MESSAGE")
 
@@ -41,5 +44,21 @@ class CommentsOrderClockSkewTest < ActionDispatch::IntegrationTest
     assert user_pos < agent_pos,
       "user message must render before the agent reply it triggered (id order), " \
       "not after it due to a backdated created_at"
+  end
+
+  test "after_id pagination orders by insertion (id) despite backdated agent reply created_at" do
+    sign_in_as(@user)
+    # Load the page above the anchor: returns the user message and its agent reply.
+    get creative_comments_path(@creative, after_id: @anchor.id)
+    assert_response :success
+
+    user_pos = response.body.index("FIRST_USER_MESSAGE")
+    agent_pos = response.body.index("SECOND_AGENT_REPLY")
+
+    assert user_pos, "user message must be rendered in the after_id page"
+    assert agent_pos, "agent reply must be rendered in the after_id page"
+    assert user_pos < agent_pos,
+      "after_id paging must also order by id, so the user message renders before " \
+      "the agent reply despite the backdated created_at"
   end
 end

--- a/engines/collavre/test/integration/comments_order_clock_skew_test.rb
+++ b/engines/collavre/test/integration/comments_order_clock_skew_test.rb
@@ -1,0 +1,45 @@
+require "test_helper"
+
+# Regression test for chat message ordering under cross-process clock skew.
+#
+# A user message is stamped with created_at by the web request process, while
+# the agent reply placeholder is stamped by a background worker/agent process.
+# When those clocks are skewed, the agent reply can carry a created_at that is
+# EARLIER than the user message that triggered it, even though it was inserted
+# later (and therefore has a HIGHER id). Ordering the timeline by created_at
+# then renders the reply above the user message. The id sequence is the true
+# causal insertion order, so the timeline must order by id.
+class CommentsOrderClockSkewTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = User.create!(email: "skew-user@example.com", password: TEST_PASSWORD, name: "SkewUser")
+    @creative = Creative.create!(user: @user, description: "Skew creative")
+
+    # Inserted first -> lower id. This is the user message.
+    @user_message = @creative.comments.create!(user: @user, content: "FIRST_USER_MESSAGE")
+
+    # Inserted second -> higher id. This is the agent reply, but its created_at
+    # is backdated 2s (simulating a lagging worker clock) to before the user
+    # message. update_column bypasses callbacks/validations and touches only
+    # created_at, mimicking a persisted row stamped by a skewed clock.
+    @agent_reply = @creative.comments.create!(user: @user, content: "SECOND_AGENT_REPLY")
+    @agent_reply.update_column(:created_at, @user_message.created_at - 2.seconds)
+  end
+
+  test "timeline orders by insertion (id) despite backdated agent reply created_at" do
+    assert @agent_reply.id > @user_message.id, "agent reply must have the higher id"
+    assert @agent_reply.created_at < @user_message.created_at, "agent reply created_at must be backdated"
+
+    sign_in_as(@user)
+    get creative_comments_path(@creative)
+    assert_response :success
+
+    user_pos = response.body.index("FIRST_USER_MESSAGE")
+    agent_pos = response.body.index("SECOND_AGENT_REPLY")
+
+    assert user_pos, "user message must be rendered"
+    assert agent_pos, "agent reply must be rendered"
+    assert user_pos < agent_pos,
+      "user message must render before the agent reply it triggered (id order), " \
+      "not after it due to a backdated created_at"
+  end
+end

--- a/package-lock.json
+++ b/package-lock.json
@@ -4320,9 +4320,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5297,9 +5297,9 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.4.11",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
-      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -5547,9 +5547,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true,
       "funding": [
         {
@@ -8081,9 +8081,9 @@
       }
     },
     "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9540,9 +9540,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Problem

Chat messages could render out of order: an agent reply (e.g. Vrex) appeared **above** the user message that triggered it, and a page reload did **not** fix it.

Confirmed against local production PostgreSQL, topic 12957:

| id | author | created_at |
|----|--------|-----------|
| 70934 | user (web) | 14:43:**55.543** |
| 70935 | agent (worker) | 14:43:**54.434** — 1.1s **earlier** despite higher id |

The row inserted **later** (higher id) carries an **earlier** `created_at`.

## Root cause

`CommentsController#index` sorted the timeline by `created_at`, but every pagination cursor uses `comments.id` boundaries ("Newer = higher id"). `created_at` is stamped by whichever process writes the row — a user message by the **web request**, its agent reply by a **background worker**. When those clocks are skewed, the reply is backdated below its own trigger. Because the persisted sort key was reversed, the wrong order survived reloads.

Dev (SQLite, single local process) never exhibited this because both rows share one clock — which is why an earlier investigation mis-diagnosed it as a client-side render race.

## Fix

Order the timeline by `id` instead of `created_at`. The id sequence is monotonic and reflects true insertion (causal) order, and it matches the id-based pagination cursors — so display and cursors stay consistent. Changed the default order plus the two `reorder(created_at: :asc)` bundles (deep-link `around_comment_id` and `after_id`) to `id`.

## Test

`comments_order_clock_skew_test.rb` reproduces the skew (higher-id reply with a backdated `created_at`) and asserts the user message renders first. Fails on `created_at` order, passes on `id` order. Existing comments controller + pagination suites (64 tests) stay green.

## Out of scope — surfaced follow-ups (not changed here)

1. **Mobile inbox events** — `api/v1/mobile/agent_events_controller.rb:56` re-sorts assembled events by `created_at` (`events.sort_by { |e| e[:created_at] }`). Same skew class, but its `last_seen` watermark (L32-39) is entangled with `created_at`; needs a separate change.
2. **Live client render** — new comments are blind-appended to the DOM by arrival order (user message via POST-response callback vs agent reply via Turbo broadcast) with no client-side id sort, so a fresh message can momentarily show out of order until the next server render. Separate client-side fix.