### PR TITLE
feat: grant an agent's creator admin on its profile creative

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_24_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_24_000010) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false

--- a/engines/collavre/app/models/collavre/creative.rb
+++ b/engines/collavre/app/models/collavre/creative.rb
@@ -170,12 +170,50 @@ module Collavre
       existing = profiles.where(user: user).order(:id).first
       return existing if existing
 
-      profiles.create_or_find_by!(user: user) do |creative|
-        creative.description = user.name.to_s
-        creative.data = { "kind" => PROFILE_KIND }
-        creative.progress = 0.0
+      created = false
+      creative = profiles.create_or_find_by!(user: user) do |c|
+        c.description = user.name.to_s
+        c.data = { "kind" => PROFILE_KIND }
+        c.progress = 0.0
+        created = true
       end
+      grant_creator_admin_share(creative, user) if created
+      creative
     end
+
+    # A managed AI agent's profile creative is owned by the agent itself, so its
+    # human creator has no Creative-level path to it (permissions are owner or
+    # CreativeShare only). Give the creator `admin` on creation: admin — not
+    # write — because the profile subtree is where the agent's skills live, and
+    # approving an agent's use of a feedback-level skill is an owner/admin act.
+    #
+    # Only for AI agents: `created_by_id` is also set on humans invited by
+    # another user, and a person's own profile must never be exposed to whoever
+    # created their account.
+    #
+    # Granted once, at profile creation only — never re-asserted on later
+    # profile_for calls, so a creator who deliberately removes the share (or
+    # lowers it) keeps that decision.
+    def self.grant_creator_admin_share(creative, user)
+      return unless user.respond_to?(:ai_user?) && user.ai_user?
+
+      creator_id = user.try(:created_by_id)
+      return if creator_id.blank? || creator_id == user.id
+
+      share = Collavre::CreativeShare.new(
+        creative: creative,
+        user_id: creator_id,
+        shared_by: user,
+        permission: :admin
+      )
+      # The creator is the actor here, so the "X shared a creative with you"
+      # inbox message would be addressed from them to themselves.
+      share.skip_recipient_notification = true
+      share.save!
+    rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid => e
+      Rails.logger.warn("[Creative#profile_for] creator share skipped for user #{user.id}: #{e.message}")
+    end
+    private_class_method :grant_creator_admin_share
 
     attr_accessor :filtered_progress
 

--- a/engines/collavre/app/models/collavre/creative_share.rb
+++ b/engines/collavre/app/models/collavre/creative_share.rb
@@ -41,7 +41,12 @@ module Collavre
       "permission"  => :repropagate
     }.freeze
 
-    after_create_commit :notify_recipient, unless: :no_access?
+    # Set on shares the system creates on the recipient's own behalf (e.g. the
+    # admin share an agent profile grants its creator), where the notification
+    # would read as the recipient sharing something with themselves.
+    attr_accessor :skip_recipient_notification
+
+    after_create_commit :notify_recipient, unless: -> { no_access? || skip_recipient_notification }
     after_save :touch_creative_subtree
     after_destroy :touch_creative_subtree
 

--- a/engines/collavre/db/migrate/20260724000010_backfill_agent_profile_creator_shares.rb
+++ b/engines/collavre/db/migrate/20260724000010_backfill_agent_profile_creator_shares.rb
@@ -1,0 +1,36 @@
+class BackfillAgentProfileCreatorShares < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  # Agent profile creatives created before the creator-admin grant landed have
+  # no share, leaving their human creator without any Creative-level path to the
+  # profile. Grant the same admin share here.
+  #
+  # Only AI agents: created_by_id is also set on humans invited by another user,
+  # and a person's own profile must not be exposed to whoever created them.
+  def up
+    Collavre::User
+      .where.not(created_by_id: nil)
+      .where.not(llm_vendor: [ nil, "" ])
+      .find_each(batch_size: 200) do |agent|
+        profile = Collavre::Creative.where(user_id: agent.id, kind: "profile").order(:id).first
+        next unless profile
+        next if Collavre::CreativeShare.exists?(creative_id: profile.id, user_id: agent.created_by_id)
+
+        share = Collavre::CreativeShare.new(
+          creative_id: profile.id,
+          user_id: agent.created_by_id,
+          shared_by_id: agent.id,
+          permission: :admin
+        )
+        share.skip_recipient_notification = true
+        share.save!
+      rescue => e
+        Rails.logger.error("[BackfillAgentProfileCreatorShares] agent #{agent.id}: #{e.message}")
+      end
+  end
+
+  def down
+    # No-op: a share cannot be distinguished from one the creator has since
+    # adjusted deliberately, so removing them could revoke intended access.
+  end
+end

--- a/engines/collavre/test/controllers/users_controller_ai_test.rb
+++ b/engines/collavre/test/controllers/users_controller_ai_test.rb
@@ -191,4 +191,43 @@ class UsersControllerAiTest < ActionDispatch::IntegrationTest
     assert_equal "CANONICAL EDITED PROMPT", @ai_user.profile_creative.data["markdown_source"]
     assert_equal "CANONICAL EDITED PROMPT", @ai_user.effective_system_prompt
   end
+
+  # The agent owns its own profile creative, so without this share the creator
+  # has no Creative-level path to it — and cannot administer the skills that
+  # will live in its subtree.
+  test "create_ai gives the creator admin on the new agent's profile creative" do
+    post create_ai_users_url, params: {
+      ai_id: "sharedbot",
+      name: "Shared Bot",
+      system_prompt: "You are helpful.",
+      llm_vendor: "google",
+      llm_model: "gemini-1.5-pro"
+    }
+
+    agent = Collavre::User.find_by(email: "sharedbot@ai.local")
+    assert agent, "expected the agent to be created"
+
+    profile = agent.profile_creative
+    assert_equal agent.id, profile.user_id
+    assert profile.has_permission?(@admin, :admin),
+           "the creator should hold admin on the agent's profile creative"
+  end
+
+  # The point of admin-on-the-profile is reach into the subtree, where the
+  # agent's skills will be created or linked.
+  test "creator reaches creatives placed under the agent profile" do
+    post create_ai_users_url, params: {
+      ai_id: "skillbot",
+      name: "Skill Bot",
+      llm_vendor: "google",
+      llm_model: "gemini-1.5-pro"
+    }
+    agent = Collavre::User.find_by(email: "skillbot@ai.local")
+    profile = agent.profile_creative
+
+    skill = Collavre::Creative.create!(description: "A skill", user: agent, parent: profile, progress: 0.0)
+
+    assert skill.has_permission?(@admin, :admin),
+           "admin on the profile should reach a creative placed in its subtree"
+  end
 end

--- a/engines/collavre/test/models/collavre/user_profile_creative_test.rb
+++ b/engines/collavre/test/models/collavre/user_profile_creative_test.rb
@@ -12,5 +12,66 @@ module Collavre
       assert a.ai_user?
       assert_equal "profile", a.profile_creative.data["kind"]
     end
+
+    test "AI agent profile creative is shared with its creator as admin" do
+      creator = Collavre::User.create!(name: "Maker", email: "maker@example.com", password: "password123")
+      agent = Collavre::User.create!(name: "Bot", email: "bot2@example.com", password: "password123",
+                                     llm_vendor: "google", created_by_id: creator.id)
+
+      profile = agent.profile_creative
+      share = Collavre::CreativeShare.find_by(creative: profile, user: creator)
+
+      assert share, "expected the creator to be shared on the agent profile creative"
+      assert_equal "admin", share.permission
+      assert profile.has_permission?(creator, :admin)
+      # The agent still owns its own profile; the creator reaches it via the share.
+      assert_equal agent.id, profile.user_id
+    end
+
+    test "human user profile creative is not shared with whoever created them" do
+      inviter = Collavre::User.create!(name: "Inviter", email: "inviter@example.com", password: "password123")
+      human = Collavre::User.create!(name: "Invitee", email: "invitee@example.com", password: "password123",
+                                     created_by_id: inviter.id)
+
+      profile = human.profile_creative
+
+      assert_nil Collavre::CreativeShare.find_by(creative: profile, user: inviter),
+                 "a human's personal profile must not be exposed to whoever created their account"
+    end
+
+    test "agent without a creator gets no profile share" do
+      agent = Collavre::User.create!(name: "Orphan bot", email: "bot3@example.com", password: "password123",
+                                     llm_vendor: "google")
+
+      assert_empty Collavre::CreativeShare.where(creative: agent.profile_creative)
+    end
+
+    test "removing the creator share is not undone by a later profile_for" do
+      creator = Collavre::User.create!(name: "Maker", email: "maker2@example.com", password: "password123")
+      agent = Collavre::User.create!(name: "Bot", email: "bot4@example.com", password: "password123",
+                                     llm_vendor: "google", created_by_id: creator.id)
+      profile = agent.profile_creative
+      Collavre::CreativeShare.find_by(creative: profile, user: creator).destroy!
+
+      Collavre::Creative.profile_for(agent)
+
+      assert_nil Collavre::CreativeShare.find_by(creative: profile, user: creator),
+                 "a deliberately removed share must not be resurrected"
+    end
+
+    test "creator share does not post a self-referential inbox notification" do
+      creator = Collavre::User.create!(name: "Maker", email: "maker3@example.com", password: "password123")
+      Collavre::Current.user = creator
+      inbox = Collavre::Creative.inbox_for(creator)
+      before = Collavre::Comment.where(creative: inbox).count
+
+      Collavre::User.create!(name: "Bot", email: "bot5@example.com", password: "password123",
+                             llm_vendor: "google", created_by_id: creator.id)
+
+      assert_equal before, Collavre::Comment.where(creative: inbox).count,
+                   "the creator should not be told they shared something with themselves"
+    ensure
+      Collavre::Current.user = nil
+    end
   end
 end


### PR DESCRIPTION
## Why

A managed AI agent's profile creative is owned by the **agent**, so its human creator had no Creative-level path to it — Creative permissions resolve through ownership or a `CreativeShare`, and neither existed for the creator. Without this, the creator cannot open the agent's profile, and cannot administer anything placed under it.

## What

`Creative.profile_for` now grants the creator an **`admin`** `CreativeShare` when an AI agent's profile creative is created.

- **admin, not write** — the profile subtree is where the agent's skills will be created or linked, and approving an agent's use of a feedback-level skill is an owner/admin act.
- **AI agents only** — `created_by_id` is also set on humans invited by another user; a person's own profile must never be exposed to whoever created their account.
- **Granted once, at creation** — a later `profile_for` never re-asserts it, so a creator who deliberately removes or lowers the share keeps that decision.
- **No self-referential inbox message** — the share sets `skip_recipient_notification`, otherwise the creator receives "you shared a creative with you".
- **Backfill migration** for agent profiles created before this landed. Shares are created through the model so the permission cache is propagated; a raw insert would leave `creative_shares_cache` empty and the permission would not resolve.

The agent still owns its profile — ownership is the agent's identity, and moving it would break the per-user profile lookup and its uniqueness index. The creator reaches it through the share.

## Tests

- creator holds `admin` on the agent's profile; the agent remains the owner
- a human's profile is **not** shared with whoever created their account
- an agent with no creator gets no share
- a removed share is not resurrected by a later `profile_for`
- no inbox comment is written for the creator
- end-to-end through `create_ai`
- a creative placed **under** the profile is reachable by the creator at `admin` (the subtree reach this exists for)

Verified RED without the grant (the two `create_ai` tests fail), GREEN with it. Engine suites: models 399 runs, controllers + services 1229 runs, 0 failures. Rubocop clean.