### PR TITLE
perf: batch creative reorder writes

### DIFF
--- a/engines/collavre/app/jobs/collavre/touch_creative_subtree_job.rb
+++ b/engines/collavre/app/jobs/collavre/touch_creative_subtree_job.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Collavre
+  class TouchCreativeSubtreeJob < ApplicationJob
+    queue_as :default
+
+    def perform(creative_id)
+      creative = Creative.find_by(id: creative_id)
+      return unless creative
+
+      creative.descendants.update_all(updated_at: Time.current)
+    end
+  end
+end

--- a/engines/collavre/app/models/collavre/creative.rb
+++ b/engines/collavre/app/models/collavre/creative.rb
@@ -47,7 +47,9 @@ module Collavre
       "creatives/creative"
     end
 
-    after_update_commit :enqueue_subtree_touch, if: :saved_change_to_parent_id?
+    after_update :flag_subtree_touch_on_move, if: :saved_change_to_parent_id?
+    after_commit :enqueue_subtree_touch, unless: :destroyed?
+    after_rollback :clear_pending_subtree_touch
     after_save :fire_drop_trigger_on_move, if: :saved_change_to_parent_id?
     after_create_commit :fire_drop_trigger_on_create, if: :parent_id?
     after_create :create_main_topic
@@ -373,7 +375,29 @@ module Collavre
       end
     end
 
+    # Record the move at save time rather than gating the after_commit on
+    # saved_change_to_parent_id?. after_commit sees only the *final* save's
+    # saved_changes, and #reload clears the mutation tracker outright, so a move
+    # followed in the same transaction by another save (or a reload) of the same
+    # record would drop the touch and leave descendants with stale updated_at
+    # for updated-since/cache consumers. Both are reachable through
+    # Tools::CreativeBatchService, which wraps every operation in one
+    # transaction while Tools::CreativeUpdateService saves parent_id, then saves
+    # the same (non-linked, so effective_origin == self) record again for
+    # description/progress, then reloads it. Mirrors the cross-save
+    # accumulation in Creative::Permissible.
+    def flag_subtree_touch_on_move
+      @subtree_touch_pending = true
+    end
+
+    def clear_pending_subtree_touch
+      @subtree_touch_pending = false
+    end
+
     def enqueue_subtree_touch
+      return unless @subtree_touch_pending
+
+      clear_pending_subtree_touch
       TouchCreativeSubtreeJob.perform_later(id)
     end
 

--- a/engines/collavre/app/models/collavre/creative.rb
+++ b/engines/collavre/app/models/collavre/creative.rb
@@ -14,6 +14,21 @@ module Collavre
     # ---------------------------------------------------------------------------
     BUILTIN_RESERVED_METADATA_KEYS = %w[markdown_source content_type editor kind].freeze
 
+    SubtreeTouchTransactionRecord = Data.define(:creative_id) do
+      def self.run_commit_callbacks_on_first_saved_instances_in_transaction = true
+
+      def trigger_transactional_callbacks? = true
+
+      def before_committed! = nil
+
+      def committed!(should_run_callbacks:)
+        TouchCreativeSubtreeJob.perform_later(creative_id) if should_run_callbacks
+      end
+
+      def rolledback!(**_options) = nil
+    end
+    private_constant :SubtreeTouchTransactionRecord
+
     class << self
       def registered_reserved_metadata_keys
         @registered_reserved_metadata_keys ||= []
@@ -47,9 +62,7 @@ module Collavre
       "creatives/creative"
     end
 
-    after_update :flag_subtree_touch_on_move, if: :saved_change_to_parent_id?
-    after_commit :enqueue_subtree_touch, unless: :destroyed?
-    after_rollback :clear_pending_subtree_touch
+    after_update :register_subtree_touch_after_commit, if: :saved_change_to_parent_id?
     after_save :fire_drop_trigger_on_move, if: :saved_change_to_parent_id?
     after_create_commit :fire_drop_trigger_on_create, if: :parent_id?
     after_create :create_main_topic
@@ -375,30 +388,15 @@ module Collavre
       end
     end
 
-    # Record the move at save time rather than gating the after_commit on
-    # saved_change_to_parent_id?. after_commit sees only the *final* save's
-    # saved_changes, and #reload clears the mutation tracker outright, so a move
-    # followed in the same transaction by another save (or a reload) of the same
-    # record would drop the touch and leave descendants with stale updated_at
-    # for updated-since/cache consumers. Both are reachable through
-    # Tools::CreativeBatchService, which wraps every operation in one
-    # transaction while Tools::CreativeUpdateService saves parent_id, then saves
-    # the same (non-linked, so effective_origin == self) record again for
-    # description/progress, then reloads it. Mirrors the cross-save
-    # accumulation in Creative::Permissible.
-    def flag_subtree_touch_on_move
-      @subtree_touch_pending = true
-    end
-
-    def clear_pending_subtree_touch
-      @subtree_touch_pending = false
-    end
-
-    def enqueue_subtree_touch
-      return unless @subtree_touch_pending
-
-      clear_pending_subtree_touch
-      TouchCreativeSubtreeJob.perform_later(id)
+    # Register independently of the Creative instance because a transaction may
+    # update the same row through multiple instances, while Rails runs record
+    # callbacks on only one of them. Transaction-record equality deduplicates by
+    # creative id; Rails promotes records through committed savepoints and drops
+    # them on rollback.
+    def register_subtree_touch_after_commit
+      self.class.with_connection do |connection|
+        connection.add_transaction_record(SubtreeTouchTransactionRecord.new(id))
+      end
     end
 
     def fire_drop_trigger_on_move

--- a/engines/collavre/app/models/collavre/creative.rb
+++ b/engines/collavre/app/models/collavre/creative.rb
@@ -47,7 +47,7 @@ module Collavre
       "creatives/creative"
     end
 
-    after_save :touch_subtree_on_move, if: :saved_change_to_parent_id?
+    after_update_commit :enqueue_subtree_touch, if: :saved_change_to_parent_id?
     after_save :fire_drop_trigger_on_move, if: :saved_change_to_parent_id?
     after_create_commit :fire_drop_trigger_on_create, if: :parent_id?
     after_create :create_main_topic
@@ -373,8 +373,8 @@ module Collavre
       end
     end
 
-    def touch_subtree_on_move
-      descendants.update_all(updated_at: Time.current)
+    def enqueue_subtree_touch
+      TouchCreativeSubtreeJob.perform_later(id)
     end
 
     def fire_drop_trigger_on_move

--- a/engines/collavre/app/services/collavre/creatives/reorderer.rb
+++ b/engines/collavre/app/services/collavre/creatives/reorderer.rb
@@ -180,14 +180,14 @@ module Creatives
     def resequence!(creatives)
       return if creatives.empty?
 
-      connection = Creative.connection
-      cases = creatives.each_with_index.map do |creative, index|
-        "WHEN #{connection.quote(creative.id)} THEN #{connection.quote(index)}"
-      end.join(" ")
-      primary_key = connection.quote_column_name(Creative.primary_key)
+      table = Creative.arel_table
+      cases = Arel::Nodes::Case.new(table[Creative.primary_key])
+      creatives.each_with_index do |creative, index|
+        cases.when(creative.id).then(index)
+      end
 
       Creative.where(id: creatives.map(&:id))
-        .update_all("sequence = CASE #{primary_key} #{cases} END")
+        .update_all(sequence: cases)
 
       creatives.each_with_index do |creative, index|
         creative.write_attribute(:sequence, index)

--- a/engines/collavre/app/services/collavre/creatives/reorderer.rb
+++ b/engines/collavre/app/services/collavre/creatives/reorderer.rb
@@ -26,7 +26,7 @@ module Creatives
     def reorder_multiple(dragged_ids:, target_id:, direction:)
       ids = Array(dragged_ids).map(&:presence).compact
       validate_direction!(direction)
-      raise Error, "Invalid creatives" if ids.empty?
+      raise Error, "Invalid creatives" if ids.empty? || ids.map(&:to_s).uniq.size != ids.size
 
       target = Creative.find_by(id: target_id)
       raise Error, "Invalid creatives" unless target
@@ -178,8 +178,20 @@ module Creatives
     end
 
     def resequence!(creatives)
-      creatives.each_with_index do |creative, idx|
-        creative.update_column(:sequence, idx)
+      return if creatives.empty?
+
+      connection = Creative.connection
+      cases = creatives.each_with_index.map do |creative, index|
+        "WHEN #{connection.quote(creative.id)} THEN #{connection.quote(index)}"
+      end.join(" ")
+      primary_key = connection.quote_column_name(Creative.primary_key)
+
+      Creative.where(id: creatives.map(&:id))
+        .update_all("sequence = CASE #{primary_key} #{cases} END")
+
+      creatives.each_with_index do |creative, index|
+        creative.write_attribute(:sequence, index)
+        creative.send(:clear_attribute_change, :sequence)
       end
     end
   end

--- a/engines/collavre/test/jobs/collavre/touch_creative_subtree_job_test.rb
+++ b/engines/collavre/test/jobs/collavre/touch_creative_subtree_job_test.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  class TouchCreativeSubtreeJobTest < ActiveSupport::TestCase
+    include ActiveJob::TestHelper
+
+    setup do
+      @original_queue_adapter = ActiveJob::Base.queue_adapter
+      ActiveJob::Base.queue_adapter = :test
+      @owner = users(:one)
+      @root = Creative.create!(user: @owner, description: "Root")
+      @child = Creative.create!(user: @owner, parent: @root, description: "Child")
+      @grandchild = Creative.create!(user: @owner, parent: @child, description: "Grandchild")
+      @new_parent = Creative.create!(user: @owner, description: "New parent")
+      clear_enqueued_jobs
+    end
+
+    teardown do
+      ActiveJob::Base.queue_adapter = @original_queue_adapter
+    end
+
+    test "moving a creative enqueues subtree touching after commit" do
+      old_timestamp = 2.days.ago.change(usec: 0)
+      Creative.where(id: [ @child.id, @grandchild.id ]).update_all(updated_at: old_timestamp)
+
+      assert_enqueued_with(job: TouchCreativeSubtreeJob, args: [ @root.id ]) do
+        @root.update!(parent: @new_parent)
+      end
+
+      assert_equal old_timestamp, @child.reload.updated_at
+      assert_equal old_timestamp, @grandchild.reload.updated_at
+    end
+
+    test "touches all current descendants in one update" do
+      old_timestamp = 2.days.ago.change(usec: 0)
+      Creative.where(id: [ @child.id, @grandchild.id ]).update_all(updated_at: old_timestamp)
+      updates = []
+      subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |_name, _start, _finish, _id, payload|
+        sql = payload[:sql]
+        updates << sql if sql.match?(/UPDATE .*creatives.* SET .*updated_at/i)
+      end
+
+      TouchCreativeSubtreeJob.perform_now(@root.id)
+
+      assert_operator @child.reload.updated_at, :>, old_timestamp
+      assert_operator @grandchild.reload.updated_at, :>, old_timestamp
+      assert_equal 1, updates.size
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+    end
+
+    test "is a no-op when the creative was deleted" do
+      @root.destroy!
+
+      assert_nothing_raised do
+        TouchCreativeSubtreeJob.perform_now(@root.id)
+      end
+    end
+  end
+end

--- a/engines/collavre/test/jobs/collavre/touch_creative_subtree_job_test.rb
+++ b/engines/collavre/test/jobs/collavre/touch_creative_subtree_job_test.rb
@@ -60,6 +60,43 @@ module Collavre
       assert_equal 1, enqueued_jobs.count { |job| job["job_class"] == TouchCreativeSubtreeJob.name }
     end
 
+    test "enqueues once when duplicate instances move across a committed savepoint" do
+      assert_enqueued_jobs 1, only: TouchCreativeSubtreeJob do
+        Creative.transaction do
+          @root.update!(parent: @new_parent)
+
+          Creative.transaction(requires_new: true) do
+            Creative.find(@root.id).update!(parent: nil)
+          end
+        end
+      end
+    end
+
+    test "does not enqueue when a committed savepoint is rolled back by its outer transaction" do
+      assert_no_enqueued_jobs(only: TouchCreativeSubtreeJob) do
+        Creative.transaction do
+          Creative.transaction(requires_new: true) do
+            Creative.find(@root.id).update!(parent: @new_parent)
+          end
+
+          raise ActiveRecord::Rollback
+        end
+      end
+    end
+
+    test "does not leak a rolled back savepoint into a later transaction" do
+      assert_no_enqueued_jobs(only: TouchCreativeSubtreeJob) do
+        Creative.transaction(requires_new: true) do
+          Creative.find(@root.id).update!(parent: @new_parent)
+          raise ActiveRecord::Rollback
+        end
+      end
+
+      assert_no_enqueued_jobs(only: TouchCreativeSubtreeJob) do
+        @root.update!(description: "Root renamed")
+      end
+    end
+
     test "does not enqueue subtree touching when the parent is unchanged" do
       assert_no_enqueued_jobs(only: TouchCreativeSubtreeJob) do
         @root.update!(description: "Root renamed")

--- a/engines/collavre/test/jobs/collavre/touch_creative_subtree_job_test.rb
+++ b/engines/collavre/test/jobs/collavre/touch_creative_subtree_job_test.rb
@@ -33,6 +33,53 @@ module Collavre
       assert_equal old_timestamp, @grandchild.reload.updated_at
     end
 
+    test "enqueues subtree touching when a later same-transaction save clobbers the parent change" do
+      assert_enqueued_with(job: TouchCreativeSubtreeJob, args: [ @root.id ]) do
+        Creative.transaction do
+          @root.update!(parent: @new_parent)
+          @root.update!(description: "Root renamed")
+        end
+      end
+    end
+
+    test "enqueues subtree touching when the moved creative is reloaded before commit" do
+      assert_enqueued_with(job: TouchCreativeSubtreeJob, args: [ @root.id ]) do
+        Creative.transaction do
+          @root.update!(parent: @new_parent)
+          @root.reload
+        end
+      end
+    end
+
+    test "enqueues subtree touching once per transaction regardless of save count" do
+      Creative.transaction do
+        @root.update!(parent: @new_parent)
+        @root.update!(parent: nil)
+      end
+
+      assert_equal 1, enqueued_jobs.count { |job| job["job_class"] == TouchCreativeSubtreeJob.name }
+    end
+
+    test "does not enqueue subtree touching when the parent is unchanged" do
+      assert_no_enqueued_jobs(only: TouchCreativeSubtreeJob) do
+        @root.update!(description: "Root renamed")
+      end
+    end
+
+    test "does not enqueue subtree touching when the move is rolled back" do
+      assert_no_enqueued_jobs(only: TouchCreativeSubtreeJob) do
+        Creative.transaction do
+          @root.update!(parent: @new_parent)
+          raise ActiveRecord::Rollback
+        end
+      end
+
+      # The rolled-back move must not leak into the next transaction.
+      assert_no_enqueued_jobs(only: TouchCreativeSubtreeJob) do
+        @root.update!(description: "Root renamed")
+      end
+    end
+
     test "touches all current descendants in one update" do
       old_timestamp = 2.days.ago.change(usec: 0)
       Creative.where(id: [ @child.id, @grandchild.id ]).update_all(updated_at: old_timestamp)

--- a/engines/collavre/test/services/creatives/reorderer_test.rb
+++ b/engines/collavre/test/services/creatives/reorderer_test.rb
@@ -47,6 +47,34 @@ module Creatives
       assert_equal [ "A", "B" ], child_order
     end
 
+    test "reorder_multiple resequences siblings with one update statement" do
+      sequence_updates = []
+      subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |_name, _start, _finish, _id, payload|
+        sql = payload[:sql]
+        sequence_updates << sql if sql.match?(/UPDATE .*creatives.* SET .*sequence/i)
+      end
+
+      @reorderer.reorder_multiple(
+        dragged_ids: [ @child_c.id, @child_a.id ],
+        target_id: @child_b.id,
+        direction: "up"
+      )
+
+      assert_equal 1, sequence_updates.size
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+    end
+
+    test "reorder_multiple raises when selection contains duplicate ids" do
+      assert_raises(Reorderer::Error) do
+        @reorderer.reorder_multiple(
+          dragged_ids: [ @child_a.id, @child_a.id ],
+          target_id: @child_b.id,
+          direction: "up"
+        )
+      end
+    end
+
     test "reorder_multiple raises when target is within selection" do
       assert_raises(Reorderer::Error) do
         @reorderer.reorder_multiple(

--- a/engines/collavre/test/services/tools/creative_batch_service_test.rb
+++ b/engines/collavre/test/services/tools/creative_batch_service_test.rb
@@ -79,6 +79,30 @@ module Collavre
         assert_match(/Unknown action/, result[:error])
       end
 
+      test "moving a creative in a batch enqueues the subtree touch" do
+        moved = Creative.create!(description: "<p>Moved</p>", user: @user, progress: 0)
+        Creative.create!(description: "<p>Descendant</p>", user: @user, parent: moved, progress: 0)
+        CreativeSharesCache.find_or_create_by!(creative: moved, user: @user) { |cache| cache.permission = :admin }
+
+        service = CreativeBatchService.new
+        original_adapter = ActiveJob::Base.queue_adapter
+        ActiveJob::Base.queue_adapter = :test
+
+        # The batch wraps every operation in one transaction, and the update
+        # service saves parent_id, saves again for the description, then
+        # reloads — all of which erase the parent change from saved_changes
+        # before after_commit runs.
+        assert_enqueued_with(job: TouchCreativeSubtreeJob, args: [ moved.id ]) do
+          result = service.call(operations: [
+            { "action" => "update", "id" => moved.id, "parent_id" => @root.id, "description" => "Moved and renamed" }
+          ])
+
+          assert result[:success], result[:error]
+        end
+      ensure
+        ActiveJob::Base.queue_adapter = original_adapter if original_adapter
+      end
+
       test "rolls back all operations on failure" do
         initial_count = Creative.count
 

--- a/engines/collavre/test/services/tools/creative_batch_service_test.rb
+++ b/engines/collavre/test/services/tools/creative_batch_service_test.rb
@@ -103,6 +103,29 @@ module Collavre
         ActiveJob::Base.queue_adapter = original_adapter if original_adapter
       end
 
+      test "rename then move of the same creative enqueues one subtree touch" do
+        moved = Creative.create!(description: "<p>Moved</p>", user: @user, progress: 0)
+        Creative.create!(description: "<p>Descendant</p>", user: @user, parent: moved, progress: 0)
+        CreativeSharesCache.find_or_create_by!(creative: moved, user: @user) { |cache| cache.permission = :admin }
+
+        service = CreativeBatchService.new
+        original_adapter = ActiveJob::Base.queue_adapter
+        ActiveJob::Base.queue_adapter = :test
+
+        Creative.stub :run_commit_callbacks_on_first_saved_instances_in_transaction, true do
+          assert_enqueued_jobs 1, only: TouchCreativeSubtreeJob do
+            result = service.call(operations: [
+              { "action" => "update", "id" => moved.id, "description" => "Renamed" },
+              { "action" => "update", "id" => moved.id, "parent_id" => @root.id }
+            ])
+
+            assert result[:success], result[:error]
+          end
+        end
+      ensure
+        ActiveJob::Base.queue_adapter = original_adapter if original_adapter
+      end
+
       test "rolls back all operations on failure" do
         initial_count = Creative.count
 


### PR DESCRIPTION
## What changed

- Resequence all affected Creative siblings with one adapter-portable `UPDATE ... CASE` statement instead of one `update_column` per row.
- Reject duplicate IDs in multi-select reorder requests before building the bulk update.
- Move descendant `updated_at` propagation out of the move request and into `TouchCreativeSubtreeJob` after commit.
- Keep the async descendant touch as one `update_all` and safely no-op if the moved Creative was deleted.

## Why

Large sibling sets currently generate one UPDATE per sibling, while moving a large subtree synchronously touches every descendant before the request can finish. Both costs scale with tree size and made `POST /creatives/reorder` take about 2.9 seconds with 713 queries in production measurements.

## Impact

The reorder request now performs one sibling sequence UPDATE and no descendant timestamp UPDATE on the request path. Closure-tree parent changes remain synchronous for structural consistency; only cache-invalidation timestamps are deferred until after commit.

## Validation

- Pre-push suite: 2,859 tests, 9,037 assertions, 0 failures/errors
- RuboCop: 1,065 files, 0 offenses
- Drag/drop system test: 1 test, 6 assertions, 0 failures
- Added query-count coverage for sibling resequencing and subtree touching
- Added enqueue timing and deleted-record coverage for the subtree job