### PR TITLE
perf(comments): move badge recomputation off the request and bound the hot reads

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_24_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_24_000001) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -176,6 +176,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_24_000000) do
     t.index ["approver_id"], name: "index_comments_on_approver_id"
     t.index ["creative_id", "created_at"], name: "index_comments_on_creative_id_and_created_at"
     t.index ["creative_id", "id"], name: "index_comments_on_creative_id_and_id"
+    t.index ["creative_id", "private", "id"], name: "index_comments_on_creative_id_and_private_and_id"
     t.index ["creative_id"], name: "index_comments_on_creative_id"
     t.index ["quoted_comment_id"], name: "index_comments_on_quoted_comment_id"
     t.index ["selected_version_id"], name: "index_comments_on_selected_version_id"

--- a/engines/collavre/app/controllers/collavre/comments_controller.rb
+++ b/engines/collavre/app/controllers/collavre/comments_controller.rb
@@ -119,31 +119,13 @@ module Collavre
 
       present_user_ids = CommentPresenceStore.list(@creative.id)
 
-      read_receipts = {}
-      if @comments.any?
-        # Fetch all read pointers for this creative that point to comments in the current list
-        # We only care about pointers that match the IDs of the comments we are displaying?
-        # Or rather, we want to show the 'line' on the comment that matches the pointer.
-
-        # Optimization: Fetch all pointers for participants of this creative.
-        # Scoped to the creative.
-        pointers = CommentReadPointer.where(creative: @creative)
-                                     .where.not(last_read_comment_id: nil)
-                                     .includes(user: { avatar_attachment: :blob })
-
-        # Fetch all visible IDs for correct read-receipt placement transparency
-        # Only map read receipts to PUBLIC comments.
-        # Users who read private comments will appear on the nearest preceding public comment.
-        public_ids = @creative.comments.public_only.order(id: :asc).pluck(:id)
-
-        pointers.each do |pointer|
-          effective_id = pointer.effective_comment_id(public_ids)
-          if effective_id
-            read_receipts[effective_id] ||= []
-            read_receipts[effective_id] << pointer.user
-          end
-        end
-      end
+      # Read receipts land on the nearest preceding PUBLIC comment, so a user who
+      # last read a private comment shows up above it. The index resolves that
+      # against the rendered window rather than the whole conversation.
+      # Fully qualified: a top-level ::Comments namespace exists too (see
+      # ::Comments::CommandProcessor below), so a bare Comments:: here would be
+      # resolved by lexical luck rather than intent.
+      read_receipts = Collavre::Comments::ReadReceiptIndex.new(creative: @creative, comments: @comments).receipts
 
       if params[:after_id].present? || params[:before_id].present?
         render partial: "collavre/comments/comment",

--- a/engines/collavre/app/helpers/collavre/creatives_helper.rb
+++ b/engines/collavre/app/helpers/collavre/creatives_helper.rb
@@ -146,7 +146,6 @@ module Collavre
 
     def render_progress_value(value)
       text = number_to_percentage(value * 100, precision: 0)
-      completion_mark = Collavre::SystemSetting.completion_mark
       if value == 1 && !completion_mark.nil?
         text = completion_mark
       end
@@ -156,6 +155,15 @@ module Collavre
         display_text,
         class: "creative-progress-#{value == 1 ? 'complete' : 'incomplete'}"
       )
+    end
+
+    # A tree renders this helper once per node. Keep the setting lookup scoped to
+    # the request's view context rather than depending on a particular cache
+    # store's local-cache middleware to collapse repeated reads.
+    def completion_mark
+      return @completion_mark if defined?(@completion_mark)
+
+      @completion_mark = Collavre::SystemSetting.completion_mark
     end
 
     def render_creative_tree_markdown(creatives, level = 1, with_progress = false, max_depth: nil)

--- a/engines/collavre/app/helpers/collavre/creatives_helper.rb
+++ b/engines/collavre/app/helpers/collavre/creatives_helper.rb
@@ -52,9 +52,12 @@ module Collavre
         elsif can_feedback
           origin = creative.effective_origin
           comments_count = origin.comments_count
-          unread_count = unread_count_for(origin, comments_count) if unread_count.nil?
-          if Current.user && CommentPresenceStore.list(origin.id).include?(Current.user.id)
-            unread_count = 0
+          # A batched count already has presence suppression applied by
+          # CommentBadgeIndex; re-checking here would be one cache read per node,
+          # which is exactly what the batch exists to avoid.
+          if unread_count.nil?
+            unread_count = unread_count_for(origin, comments_count)
+            unread_count = 0 if viewing_now?(origin)
           end
           classes = [ "comments-btn", "creative-action-btn" ]
           classes << "no-comments" if comments_count.zero?
@@ -106,6 +109,13 @@ module Collavre
       return comments_count unless last_read_id
 
       origin.comments.where("id > ? and private = ?", last_read_id, false).count
+    end
+
+    # Someone with the chat open has read it, so their badge shows nothing.
+    def viewing_now?(origin)
+      return false unless Current.user
+
+      CommentPresenceStore.list(origin.id).include?(Current.user.id)
     end
 
     def render_progress_toggle(creative, value)

--- a/engines/collavre/app/jobs/collavre/comment_badges_broadcast_job.rb
+++ b/engines/collavre/app/jobs/collavre/comment_badges_broadcast_job.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Collavre
+  # Recomputes and rebroadcasts the per-participant comment badges of a creative.
+  #
+  # The arithmetic is O(comment history) x O(participants): a total count, an
+  # unread count per distinct read watermark, and a private count per user. Run
+  # inline from Comment's after_commit it made writing a message cost more the
+  # longer the conversation was — and an inbox notification wrote a second
+  # comment into an inbox creative, paying the same price again over that
+  # inbox's own history.
+  #
+  # Badges are eventually-consistent UI: the recipient already got the comment
+  # itself over its own Turbo stream, so recounting a beat later is invisible.
+  class CommentBadgesBroadcastJob < ApplicationJob
+    queue_as :default
+    discard_on ActiveJob::DeserializationError
+
+    def perform(creative_id)
+      creative = Creative.find_by(id: creative_id)
+      # Deleting a creative destroys its comments, so the enqueued job can
+      # outlive its subject. Nothing to recount, and nobody to tell.
+      return unless creative
+
+      Comment.broadcast_badges(creative)
+    end
+  end
+end

--- a/engines/collavre/app/models/collavre/comment/broadcastable.rb
+++ b/engines/collavre/app/models/collavre/comment/broadcastable.rb
@@ -18,6 +18,18 @@ module Collavre
       end
 
       module ClassMethods
+        # The one enqueue seam for badge recomputation. Every write path that
+        # invalidates a badge goes through here rather than calling
+        # #broadcast_badges directly, so "badges are recounted off the request"
+        # holds for all of them and can't drift back one caller at a time.
+        # #broadcast_badges itself stays synchronous: the job — and the tests
+        # that pin the arithmetic — need a place that just computes.
+        def broadcast_badges_later(creative)
+          return unless creative
+
+          CommentBadgesBroadcastJob.perform_later(creative.id)
+        end
+
         def broadcast_badges(creative)
           origin = creative.effective_origin
           users = [ origin.user ].compact + origin.all_shared_users(:feedback).map(&:user)
@@ -187,7 +199,7 @@ module Collavre
 
       def broadcast_badges
         return unless creative
-        self.class.broadcast_badges(creative)
+        self.class.broadcast_badges_later(creative)
       end
     end
   end

--- a/engines/collavre/app/models/collavre/comment_presence_store.rb
+++ b/engines/collavre/app/models/collavre/comment_presence_store.rb
@@ -23,6 +23,32 @@ module Collavre
       Rails.cache.read(key(creative_id)) || []
     end
 
+    # Presence for many creatives in one round trip.
+    #
+    # Rails.cache is :solid_cache_store in production — the app's own database —
+    # so a per-node `list` while rendering a creative tree is a SELECT per node.
+    # The LocalCache middleware that fronts Rails.cache for the duration of a
+    # request does not help: it memoizes per *key*, and presence is keyed by
+    # creative, so a tree of N nodes asks for N different keys. (That is what
+    # separates this from a setting like completion_mark, which is one key read
+    # N times and is therefore already deduplicated for free — do not add a
+    # memo for that.)
+    #
+    # Returns an entry for every id asked for, empty when nobody is present, so
+    # callers never have to distinguish "absent from the cache" from "nobody
+    # there".
+    def self.list_many(creative_ids)
+      ids = Array(creative_ids).uniq
+      return {} if ids.empty?
+
+      ids_by_cache_key = ids.index_by { |creative_id| key(creative_id) }
+      cached = Rails.cache.read_multi(*ids_by_cache_key.keys)
+
+      ids_by_cache_key.each_with_object({}) do |(cache_key, creative_id), result|
+        result[creative_id] = cached[cache_key] || []
+      end
+    end
+
     def self.key(creative_id)
       "#{KEY_PREFIX}#{creative_id}"
     end

--- a/engines/collavre/app/models/collavre/comment_presence_store.rb
+++ b/engines/collavre/app/models/collavre/comment_presence_store.rb
@@ -29,10 +29,9 @@ module Collavre
     # so a per-node `list` while rendering a creative tree is a SELECT per node.
     # The LocalCache middleware that fronts Rails.cache for the duration of a
     # request does not help: it memoizes per *key*, and presence is keyed by
-    # creative, so a tree of N nodes asks for N different keys. (That is what
-    # separates this from a setting like completion_mark, which is one key read
-    # N times and is therefore already deduplicated for free — do not add a
-    # memo for that.)
+    # creative, so a tree of N nodes asks for N different keys. Repeated reads of
+    # the single completion-mark setting are memoized separately by the request's
+    # view context.
     #
     # Returns an entry for every id asked for, empty when nobody is present, so
     # callers never have to distinguish "absent from the cache" from "nobody

--- a/engines/collavre/app/services/collavre/comment_move_service.rb
+++ b/engines/collavre/app/services/collavre/comment_move_service.rb
@@ -20,8 +20,8 @@ module Collavre
 
       moved_count = perform_move(comments, target_origin, new_topic_id)
 
-      Comment.broadcast_badges(@creative)
-      Comment.broadcast_badges(target_origin) unless target_origin == @creative
+      Comment.broadcast_badges_later(@creative)
+      Comment.broadcast_badges_later(target_origin) unless target_origin == @creative
 
       { success: true, moved_count: moved_count }
     end

--- a/engines/collavre/app/services/collavre/comments/read_receipt_index.rb
+++ b/engines/collavre/app/services/collavre/comments/read_receipt_index.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Comments
+    # Which participants' avatars sit under which comment of the page being
+    # rendered.
+    #
+    # A read pointer names the last comment a user read, which may be private or
+    # in another topic and therefore not on screen. The receipt is drawn on the
+    # nearest *public* comment at or before it — so the mapping needs to know
+    # about public comments the page itself does not render.
+    #
+    # It does NOT need to know about all of them. The controller used to pluck
+    # every public comment id of the creative on every page and every scroll,
+    # which is O(whole conversation) work to place at most a handful of avatars
+    # inside a 20-comment window. Only three things can happen to a pointer:
+    #
+    #   * older than the window     -> its receipt belongs to an earlier page
+    #   * inside the window         -> resolvable from the ids in that id range
+    #   * newer than the window     -> its receipt belongs to a later page
+    #
+    # So two bounded queries are enough: the public ids inside the window, plus
+    # the first public id after it. That last one is what separates "read
+    # everything we are showing" (receipt on the last rendered comment) from
+    # "read past this page" (no receipt here) — without it a page of older
+    # history would show every caught-up reader at its bottom.
+    class ReadReceiptIndex
+      def initialize(creative:, comments:)
+        @creative = creative
+        @comments = Array(comments)
+      end
+
+      # => { comment_id => [User, ...] }, keyed only by comments in `comments`.
+      def receipts
+        return {} if rendered_public_ids.empty?
+
+        rendered = rendered_public_ids.to_set
+
+        pointers.each_with_object({}) do |pointer, result|
+          effective_id = pointer.effective_comment_id(candidate_ids)
+          next unless effective_id && rendered.include?(effective_id)
+
+          (result[effective_id] ||= []) << pointer.user
+        end
+      end
+
+      private
+
+      attr_reader :creative, :comments
+
+      def rendered_public_ids
+        @rendered_public_ids ||= comments.reject(&:private?).map(&:id).sort
+      end
+
+      # Ascending, as CommentReadPointer#effective_comment_id binary-searches it.
+      # Public ids interleaved into the window but not rendered (a topic filter
+      # hides them) have to be here: a pointer landing on one means the receipt
+      # belongs to a comment this page is not showing.
+      def candidate_ids
+        @candidate_ids ||= begin
+          ids = public_comments
+            .where(id: rendered_public_ids.first..rendered_public_ids.last)
+            .order(:id)
+            .pluck(:id)
+          ids << next_public_id_after_window if next_public_id_after_window
+          ids
+        end
+      end
+
+      def next_public_id_after_window
+        return @next_public_id_after_window if defined?(@next_public_id_after_window)
+
+        @next_public_id_after_window =
+          public_comments.where(Comment.arel_table[:id].gt(rendered_public_ids.last)).minimum(:id)
+      end
+
+      def public_comments
+        creative.comments.public_only
+      end
+
+      def pointers
+        CommentReadPointer
+          .where(creative: creative)
+          .where.not(last_read_comment_id: nil)
+          .includes(user: { avatar_attachment: :blob })
+      end
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/comments/read_receipt_index.rb
+++ b/engines/collavre/app/services/collavre/comments/read_receipt_index.rb
@@ -28,6 +28,8 @@ module Collavre
         rendered = rendered_public_ids.to_set
 
         pointers.each_with_object({}) do |pointer, result|
+          next if pointer.last_read_comment_id > rendered_window_max_id
+
           effective_id = pointer[:receipt_comment_id]
           next unless effective_id && rendered.include?(effective_id)
 
@@ -38,6 +40,10 @@ module Collavre
       private
 
       attr_reader :creative, :comments
+
+      def rendered_window_max_id
+        @rendered_window_max_id ||= comments.map(&:id).max
+      end
 
       def rendered_public_ids
         @rendered_public_ids ||= comments.reject(&:private?).map(&:id).sort

--- a/engines/collavre/app/services/collavre/comments/read_receipt_index.rb
+++ b/engines/collavre/app/services/collavre/comments/read_receipt_index.rb
@@ -10,20 +10,11 @@ module Collavre
     # nearest *public* comment at or before it — so the mapping needs to know
     # about public comments the page itself does not render.
     #
-    # It does NOT need to know about all of them. The controller used to pluck
-    # every public comment id of the creative on every page and every scroll,
-    # which is O(whole conversation) work to place at most a handful of avatars
-    # inside a 20-comment window. Only three things can happen to a pointer:
-    #
-    #   * older than the window     -> its receipt belongs to an earlier page
-    #   * inside the window         -> resolvable from the ids in that id range
-    #   * newer than the window     -> its receipt belongs to a later page
-    #
-    # So two bounded queries are enough: the public ids inside the window, plus
-    # the first public id after it. That last one is what separates "read
-    # everything we are showing" (receipt on the last rendered comment) from
-    # "read past this page" (no receipt here) — without it a page of older
-    # history would show every caught-up reader at its bottom.
+    # It does NOT need to load any public-comment id list. Each read pointer can
+    # resolve its effective public comment with a correlated MAX(id) subquery,
+    # which PostgreSQL and SQLite both serve from the public-comment index. The
+    # outer query still returns only one row per participant, while the rendered
+    # id set decides whether that receipt belongs on this page.
     class ReadReceiptIndex
       def initialize(creative:, comments:)
         @creative = creative
@@ -37,7 +28,7 @@ module Collavre
         rendered = rendered_public_ids.to_set
 
         pointers.each_with_object({}) do |pointer, result|
-          effective_id = pointer.effective_comment_id(candidate_ids)
+          effective_id = pointer[:receipt_comment_id]
           next unless effective_id && rendered.include?(effective_id)
 
           (result[effective_id] ||= []) << pointer.user
@@ -52,36 +43,24 @@ module Collavre
         @rendered_public_ids ||= comments.reject(&:private?).map(&:id).sort
       end
 
-      # Ascending, as CommentReadPointer#effective_comment_id binary-searches it.
-      # Public ids interleaved into the window but not rendered (a topic filter
-      # hides them) have to be here: a pointer landing on one means the receipt
-      # belongs to a comment this page is not showing.
-      def candidate_ids
-        @candidate_ids ||= begin
-          ids = public_comments
-            .where(id: rendered_public_ids.first..rendered_public_ids.last)
-            .order(:id)
-            .pluck(:id)
-          ids << next_public_id_after_window if next_public_id_after_window
-          ids
-        end
-      end
-
-      def next_public_id_after_window
-        return @next_public_id_after_window if defined?(@next_public_id_after_window)
-
-        @next_public_id_after_window =
-          public_comments.where(Comment.arel_table[:id].gt(rendered_public_ids.last)).minimum(:id)
-      end
-
-      def public_comments
-        creative.comments.public_only
-      end
-
+      # Resolve the nearest public comment at or before each pointer in the same
+      # query that loads the pointers. This stays bounded by participant count
+      # even when a topic-filtered page spans thousands of hidden public comments.
       def pointers
+        pointer_table = CommentReadPointer.arel_table
+        public_comments = Comment.arel_table.alias("receipt_comments")
+        effective_comment_id = Comment
+          .from(public_comments)
+          .select(public_comments[:id].maximum)
+          .where(public_comments[:creative_id].eq(pointer_table[:creative_id]))
+          .where(public_comments[:private].eq(false))
+          .where(public_comments[:id].lteq(pointer_table[:last_read_comment_id]))
+          .arel
+
         CommentReadPointer
           .where(creative: creative)
           .where.not(last_read_comment_id: nil)
+          .select(pointer_table[Arel.star], effective_comment_id.as("receipt_comment_id"))
           .includes(user: { avatar_attachment: :blob })
       end
     end

--- a/engines/collavre/app/services/collavre/creatives/comment_badge_index.rb
+++ b/engines/collavre/app/services/collavre/creatives/comment_badge_index.rb
@@ -5,6 +5,13 @@ module Creatives
   # scale with the size of the rendered tree.
   #
   # Keyed by *origin*: a linked shell shows its origin's comments.
+  #
+  # The counts it hands out are display-ready: presence suppression (a user
+  # looking at a chat has read it, so the badge shows 0) is applied here rather
+  # than left to the caller. Presence lives in Rails.cache, which is the
+  # database in production, so a per-node check was the same N+1 in another
+  # disguise — and a caller that re-applied suppression on top of a batched
+  # value would only be doing the work twice.
   class CommentBadgeIndex
     def initialize(user:)
       @user = user
@@ -25,6 +32,8 @@ module Creatives
 
       counts = unread_counts(watermarks)
       watermarks.each_key { |origin_id| @unread_by_origin_id[origin_id] = counts.fetch(origin_id, 0) }
+
+      suppress_for_present_user(pending.map(&:id))
     end
 
     # nil when the origin was never indexed, which tells the caller to fall back
@@ -36,6 +45,15 @@ module Creatives
     private
 
     attr_reader :user
+
+    # One read_multi for the whole level. An anonymous visitor is never present.
+    def suppress_for_present_user(origin_ids)
+      return unless user
+
+      CommentPresenceStore.list_many(origin_ids).each do |origin_id, present_user_ids|
+        @unread_by_origin_id[origin_id] = 0 if present_user_ids.include?(user.id)
+      end
+    end
 
     # `user_id: nil` for an anonymous visitor is the lookup the un-batched path
     # made too, so the two agree on which pointer (if any) applies.

--- a/engines/collavre/db/migrate/20260724000001_add_creative_private_id_index_to_comments.rb
+++ b/engines/collavre/db/migrate/20260724000001_add_creative_private_id_index_to_comments.rb
@@ -1,0 +1,40 @@
+class AddCreativePrivateIdIndexToComments < ActiveRecord::Migration[8.1]
+  # Every unread/badge count is "comments of this creative, public only, newer
+  # than a watermark" — `WHERE creative_id = ? AND private = false [AND id > ?]`.
+  # index_comments_on_creative_id_and_id can serve the creative filter and the
+  # id ordering but not the private filter, so the planner still had to visit
+  # every row of a busy creative to discard private ones. Putting `private`
+  # between the two makes the whole predicate index-only.
+  #
+  # Deliberately NOT a `WHERE private = false` partial index: Rails' SQLite
+  # adapter renders `where(private: false)` as `private = 0`, which does not
+  # match a predicate recorded as `private = false`, so SQLite (dev, test and
+  # the desktop build) would create the index and then never use it. A plain
+  # three-column index is used by both adapters and dumps identically.
+  #
+  # index_comments_on_creative_id_and_id stays: `ORDER BY id` paging cannot use
+  # this index without skipping the leading private column.
+  disable_ddl_transaction!
+
+  # Explicit up/down: `change` auto-reverses add_index by forwarding every option
+  # (including if_not_exists:) to remove_index, which rejects it and fails rollback.
+  def up
+    add_index :comments, [ :creative_id, :private, :id ],
+              name: "index_comments_on_creative_id_and_private_and_id",
+              algorithm: concurrent_algorithm,
+              if_not_exists: true
+  end
+
+  def down
+    remove_index :comments,
+                 name: "index_comments_on_creative_id_and_private_and_id",
+                 algorithm: concurrent_algorithm,
+                 if_exists: true
+  end
+
+  private
+
+  def concurrent_algorithm
+    :concurrently if connection.adapter_name.match?(/postgres/i)
+  end
+end

--- a/engines/collavre/db/migrate/20260724000001_add_creative_private_id_index_to_comments.rb
+++ b/engines/collavre/db/migrate/20260724000001_add_creative_private_id_index_to_comments.rb
@@ -3,38 +3,48 @@ class AddCreativePrivateIdIndexToComments < ActiveRecord::Migration[8.1]
   # than a watermark" — `WHERE creative_id = ? AND private = false [AND id > ?]`.
   # index_comments_on_creative_id_and_id can serve the creative filter and the
   # id ordering but not the private filter, so the planner still had to visit
-  # every row of a busy creative to discard private ones. Putting `private`
-  # between the two makes the whole predicate index-only.
+  # every row of a busy creative to discard private ones.
   #
-  # Deliberately NOT a `WHERE private = false` partial index: Rails' SQLite
-  # adapter renders `where(private: false)` as `private = 0`, which does not
-  # match a predicate recorded as `private = false`, so SQLite (dev, test and
-  # the desktop build) would create the index and then never use it. A plain
-  # three-column index is used by both adapters and dumps identically.
+  # Production PostgreSQL gets the smallest useful structure: a partial index
+  # over public rows only. SQLite renders `where(private: false)` as
+  # `private = 0`, which does not use a partial predicate recorded as
+  # `private = false`, so dev, test, and desktop use an equivalent three-column
+  # index instead.
   #
-  # index_comments_on_creative_id_and_id stays: `ORDER BY id` paging cannot use
-  # this index without skipping the leading private column.
+  # index_comments_on_creative_id_and_id stays: paging does not include the
+  # public-only predicate, and SQLite cannot skip the fallback index's leading
+  # `private` column for a plain `ORDER BY id` query.
   disable_ddl_transaction!
 
   # Explicit up/down: `change` auto-reverses add_index by forwarding every option
   # (including if_not_exists:) to remove_index, which rejects it and fails rollback.
   def up
-    add_index :comments, [ :creative_id, :private, :id ],
-              name: "index_comments_on_creative_id_and_private_and_id",
-              algorithm: concurrent_algorithm,
-              if_not_exists: true
+    options = { name: index_name, if_not_exists: true }
+
+    if postgresql?
+      options.merge!(where: "private = false", algorithm: :concurrently)
+      add_index :comments, [ :creative_id, :id ], **options
+    else
+      add_index :comments, [ :creative_id, :private, :id ], **options
+    end
   end
 
   def down
-    remove_index :comments,
-                 name: "index_comments_on_creative_id_and_private_and_id",
-                 algorithm: concurrent_algorithm,
-                 if_exists: true
+    options = { name: index_name, algorithm: concurrent_algorithm, if_exists: true }
+    remove_index :comments, **options
   end
 
   private
 
+  def index_name
+    "index_comments_on_creative_id_and_private_and_id"
+  end
+
+  def postgresql?
+    connection.adapter_name.match?(/postgres/i)
+  end
+
   def concurrent_algorithm
-    :concurrently if connection.adapter_name.match?(/postgres/i)
+    :concurrently if postgresql?
   end
 end

--- a/engines/collavre/test/helpers/creatives_helper_test.rb
+++ b/engines/collavre/test/helpers/creatives_helper_test.rb
@@ -184,6 +184,18 @@ class CreativesHelperTest < ActionView::TestCase
   end
 
 
+  test "render_progress_value reads the completion mark once per view context" do
+    calls = 0
+
+    Collavre::SystemSetting.stub(:completion_mark, -> { calls += 1; "✓" }) do
+      render_progress_value(1)
+      render_progress_value(0.5)
+      render_progress_value(1)
+    end
+
+    assert_equal 1, calls
+  end
+
   test "render_creative_tree_markdown includes children of origin for linked creatives" do
     user = users(:one)
 

--- a/engines/collavre/test/jobs/collavre/comment_badges_broadcast_job_test.rb
+++ b/engines/collavre/test/jobs/collavre/comment_badges_broadcast_job_test.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  # Badge recomputation is O(comment history) per participant. It used to run in
+  # the after_commit of the comment that triggered it, so posting a message got
+  # slower for everyone as a conversation grew. These pin the seam: the callback
+  # only enqueues, and the arithmetic lives in the job.
+  class CommentBadgesBroadcastJobTest < ActiveSupport::TestCase
+    setup do
+      @user = users(:one)
+      @creative = Creative.create!(user: @user, description: "Badge job", sequence: 940)
+    end
+
+    test "creating a comment enqueues the badge broadcast instead of computing it inline" do
+      with_test_queue_adapter do
+        assert_enqueued_with(job: CommentBadgesBroadcastJob, args: [ @creative.id ]) do
+          Comment.create!(creative: @creative, user: @user, content: "hello")
+        end
+      end
+    end
+
+    test "destroying a comment enqueues the badge broadcast too" do
+      comment = Comment.create!(creative: @creative, user: @user, content: "bye")
+
+      with_test_queue_adapter do
+        assert_enqueued_with(job: CommentBadgesBroadcastJob, args: [ @creative.id ]) do
+          comment.destroy!
+        end
+      end
+    end
+
+    test "the job recomputes badges for the creative" do
+      received = []
+      Comment.stub(:broadcast_badges, ->(creative) { received << creative.id }) do
+        CommentBadgesBroadcastJob.perform_now(@creative.id)
+      end
+
+      assert_equal [ @creative.id ], received
+    end
+
+    # A comment can be destroyed together with its creative; by the time the job
+    # runs the creative is gone and there is nothing left to recount.
+    test "a job for a creative that no longer exists is a no-op" do
+      missing_id = Creative.maximum(:id).to_i + 1_000
+
+      called = false
+      Comment.stub(:broadcast_badges, ->(_creative) { called = true }) do
+        assert_nothing_raised { CommentBadgesBroadcastJob.perform_now(missing_id) }
+      end
+
+      refute called
+    end
+
+    private
+
+    def with_test_queue_adapter
+      saved_adapter = ActiveJob::Base.queue_adapter
+      ActiveJob::Base.queue_adapter = :test
+      yield
+    ensure
+      ActiveJob::Base.queue_adapter = saved_adapter
+    end
+  end
+end

--- a/engines/collavre/test/models/collavre/comment_presence_store_test.rb
+++ b/engines/collavre/test/models/collavre/comment_presence_store_test.rb
@@ -1,0 +1,46 @@
+require "test_helper"
+
+module Collavre
+  class CommentPresenceStoreTest < ActiveSupport::TestCase
+    setup do
+      @ids = [ 9_901, 9_902, 9_903 ]
+      @ids.each { |id| Rails.cache.delete(CommentPresenceStore.key(id)) }
+    end
+
+    test "list_many returns presence for every creative asked about" do
+      CommentPresenceStore.add(9_901, 1)
+      CommentPresenceStore.add(9_901, 2)
+      CommentPresenceStore.add(9_902, 3)
+
+      assert_equal(
+        { 9_901 => [ 1, 2 ], 9_902 => [ 3 ], 9_903 => [] },
+        CommentPresenceStore.list_many(@ids)
+      )
+    end
+
+    # Callers index the result by creative id; an id missing from the hash would
+    # make "nobody is here" indistinguishable from "we never asked".
+    test "list_many reports an empty list rather than omitting a creative" do
+      result = CommentPresenceStore.list_many([ 9_903 ])
+
+      assert_equal [ 9_903 ], result.keys
+      assert_equal [], result[9_903]
+    end
+
+    test "list_many agrees with list" do
+      CommentPresenceStore.add(9_901, 7)
+
+      assert_equal CommentPresenceStore.list(9_901), CommentPresenceStore.list_many([ 9_901 ]).fetch(9_901)
+    end
+
+    test "list_many with no ids does not touch the cache" do
+      assert_equal({}, CommentPresenceStore.list_many([]))
+    end
+
+    test "list_many de-duplicates repeated ids" do
+      CommentPresenceStore.add(9_901, 4)
+
+      assert_equal({ 9_901 => [ 4 ] }, CommentPresenceStore.list_many([ 9_901, 9_901 ]))
+    end
+  end
+end

--- a/engines/collavre/test/services/comments/read_receipt_index_test.rb
+++ b/engines/collavre/test/services/comments/read_receipt_index_test.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  module Comments
+    # The index resolves read receipts against the rendered window instead of the
+    # creative's entire comment history. The interesting cases are all at the
+    # window's edges, where "read up to here" and "read past this page" have to
+    # stay distinguishable without loading everything in between.
+    class ReadReceiptIndexTest < ActiveSupport::TestCase
+      setup do
+        @owner = users(:one)
+        @reader = users(:two)
+        @creative = Creative.create!(user: @owner, description: "Receipts", sequence: 950)
+      end
+
+      test "a receipt lands on the comment the pointer names" do
+        first = comment("one")
+        second = comment("two")
+        third = comment("three")
+        point_at(second)
+
+        assert_equal({ second.id => [ @reader ] }, receipts_for([ first, second, third ]))
+      end
+
+      # The whole reason the mapping cannot just look the pointer up directly.
+      test "a pointer at a private comment falls back to the public one before it" do
+        public_comment = comment("public")
+        private_comment = comment("secret", private: true)
+        later = comment("later")
+        point_at(private_comment)
+
+        assert_equal({ public_comment.id => [ @reader ] }, receipts_for([ public_comment, private_comment, later ]))
+      end
+
+      test "a pointer older than the window produces no receipt on this page" do
+        old = comment("old")
+        window = [ comment("a"), comment("b") ]
+        point_at(old)
+
+        assert_empty receipts_for(window)
+      end
+
+      # Without the one-id lookahead past the window, this reader would be shown
+      # at the bottom of every page of older history they had already scrolled past.
+      test "a pointer newer than the window produces no receipt on this page" do
+        window = [ comment("a"), comment("b") ]
+        newer = comment("c")
+        point_at(newer)
+
+        assert_empty receipts_for(window)
+      end
+
+      test "a pointer at the newest comment of all lands on it" do
+        first = comment("a")
+        last = comment("b")
+        point_at(last)
+
+        assert_equal({ last.id => [ @reader ] }, receipts_for([ first, last ]))
+      end
+
+      # A topic filter can hide a public comment that sits between two rendered
+      # ones. A pointer on the hidden comment belongs to it, not to its neighbour.
+      test "a pointer at a public comment the page filtered out produces no receipt" do
+        topic = Topic.create!(creative: @creative, name: "Side", user: @owner)
+        first = comment("a")
+        hidden = comment("hidden", topic: topic)
+        last = comment("b")
+        point_at(hidden)
+
+        assert_empty receipts_for([ first, last ])
+      end
+
+      test "several readers on the same comment are grouped" do
+        first = comment("a")
+        second = comment("b")
+        point_at(second)
+        point_at(second, user: @owner)
+
+        result = receipts_for([ first, second ])
+
+        assert_equal [ second.id ], result.keys
+        assert_equal [ @owner, @reader ].map(&:id).sort, result[second.id].map(&:id).sort
+      end
+
+      test "a page with no public comments has no receipts" do
+        private_comment = comment("secret", private: true)
+        point_at(private_comment)
+
+        assert_empty receipts_for([ private_comment ])
+      end
+
+      test "an empty page has no receipts" do
+        comment("a")
+
+        assert_empty receipts_for([])
+      end
+
+      test "a pointer with no last read comment is ignored" do
+        first = comment("a")
+        CommentReadPointer.create!(user: @reader, creative: @creative, last_read_comment_id: nil)
+
+        assert_empty receipts_for([ first ])
+      end
+
+      private
+
+      def receipts_for(comments)
+        ReadReceiptIndex.new(creative: @creative, comments: comments).receipts
+      end
+
+      def comment(content, private: false, topic: nil)
+        Comment.create!(creative: @creative, user: @owner, content: content, private: private, topic: topic)
+      end
+
+      def point_at(target, user: @reader)
+        CommentReadPointer.create!(user: user, creative: @creative, last_read_comment_id: target.id)
+      end
+    end
+  end
+end

--- a/engines/collavre/test/services/comments/read_receipt_index_test.rb
+++ b/engines/collavre/test/services/comments/read_receipt_index_test.rb
@@ -52,6 +52,14 @@ module Collavre
         assert_empty receipts_for(window)
       end
 
+      test "a pointer at a private comment after the window produces no receipt on this page" do
+        window = [ comment("a"), comment("b") ]
+        newer_private = comment("secret", private: true)
+        point_at(newer_private)
+
+        assert_empty receipts_for(window)
+      end
+
       test "a pointer at the newest comment of all lands on it" do
         first = comment("a")
         last = comment("b")

--- a/engines/collavre/test/services/creatives/comment_badge_index_test.rb
+++ b/engines/collavre/test/services/creatives/comment_badge_index_test.rb
@@ -79,6 +79,49 @@ module Creatives
       assert_nil @index.unread_count_for(creative)
     end
 
+    # Presence suppression is applied here, not by the caller: it is a cache read
+    # per origin, so it has to ride along with the batch. The count handed out is
+    # the one the badge renders.
+    test "a user with the chat open sees nothing unread" do
+      creative = Creative.create!(user: @user, description: "Watching", sequence: 907)
+      comment_on(creative, "one")
+      comment_on(creative, "two")
+
+      Collavre::CommentPresenceStore.add(creative.id, @user.id)
+
+      @index.index([ creative.reload ])
+
+      assert_equal 0, @index.unread_count_for(creative)
+    ensure
+      Rails.cache.delete(Collavre::CommentPresenceStore.key(creative.id))
+    end
+
+    test "presence of another user does not suppress our badge" do
+      creative = Creative.create!(user: @user, description: "Someone else watching", sequence: 908)
+      comment_on(creative, "one")
+
+      Collavre::CommentPresenceStore.add(creative.id, @author.id)
+
+      @index.index([ creative.reload ])
+
+      assert_equal 1, @index.unread_count_for(creative)
+    ensure
+      Rails.cache.delete(Collavre::CommentPresenceStore.key(creative.id))
+    end
+
+    test "an anonymous visitor is never suppressed" do
+      creative = Creative.create!(user: @user, description: "Anonymous", sequence: 909)
+      comment_on(creative, "one")
+      Collavre::CommentPresenceStore.add(creative.id, @user.id)
+
+      anonymous = Collavre::Creatives::CommentBadgeIndex.new(user: nil)
+      anonymous.index([ creative.reload ])
+
+      assert_equal 1, anonymous.unread_count_for(creative)
+    ensure
+      Rails.cache.delete(Collavre::CommentPresenceStore.key(creative.id))
+    end
+
     private
 
     def comment_on(creative, content, private: false)


### PR DESCRIPTION
## Summary

This PR finishes performance items 1–4 identified from production request tracing:

1. Move comment badge recomputation off the write request into `CommentBadgesBroadcastJob` through one enqueue seam used by every badge-invalidating path.
2. Batch creative-tree presence reads with `Rails.cache.read_multi` and memoize `SystemSetting.completion_mark` once per request view context.
3. Remove the whole-history public comment ID pluck. Each participant read pointer now resolves its nearest public comment with a correlated `MAX(id)` subquery, so returned rows are bounded by participant count even on topic-filtered pages.
4. Add the public-comment lookup index. PostgreSQL receives a concurrent partial index on `(creative_id, id) WHERE private = false`; SQLite receives the adapter-compatible `(creative_id, private, id)` fallback.

## Why

Production uses Solid Cache in PostgreSQL. The former tree renderer issued one cache SELECT per node, comment writes synchronously recomputed history-wide badge counts, and every chat page loaded all public comment IDs for the creative. Each path grew with accumulated data.

## Verification

- Pre-push canonical suite: **2,877 runs, 9,059 assertions, 0 failures, 0 errors**.
- RuboCop: **1,069 files inspected, no offenses**.
- Focused comment/tree suite: **99 runs, 305 assertions, 0 failures, 0 errors**.
- Read-receipt suite passed on SQLite and PostgreSQL 16: **10 runs, 17 assertions** on each adapter.
- The actual PostgreSQL 16 index definition was verified after migration as `(creative_id, id) WHERE private = false`.

## Scope

Link-preview and inbox/mention side-effect async work is intentionally separate in #1441. Creative reorder batching and deferred subtree touch are separate in #1439.