### PR TITLE
fix(comments): retain failed push deliveries

### DIFF
--- a/engines/collavre/app/models/collavre/comment_notification_delivery.rb
+++ b/engines/collavre/app/models/collavre/comment_notification_delivery.rb
@@ -26,9 +26,10 @@ module Collavre
       return false unless claimed == 1
 
       job = PushNotificationJob.perform_later(recipient_id, message: message, link: link)
-      if job.respond_to?(:successfully_enqueued?) && !job.successfully_enqueued?
-        enqueue_error = job.enqueue_error || ActiveJob::EnqueueError.new("Push notification enqueue failed")
-        raise enqueue_error
+      enqueue_succeeded = job && (!job.respond_to?(:successfully_enqueued?) || job.successfully_enqueued?)
+      unless enqueue_succeeded
+        enqueue_error = job.respond_to?(:enqueue_error) ? job.enqueue_error : nil
+        raise enqueue_error || ActiveJob::EnqueueError.new("Push notification enqueue failed")
       end
 
       acknowledged = self.class

--- a/engines/collavre/test/jobs/collavre/comment_notification_job_test.rb
+++ b/engines/collavre/test/jobs/collavre/comment_notification_job_test.rb
@@ -287,6 +287,33 @@ module Collavre
       ActiveJob::Base.queue_adapter = original_adapter
     end
 
+    test "false push enqueue result leaves a durable pending delivery" do
+      owner = users(:one)
+      commenter = users(:two)
+      creative = Creative.create!(user: owner, description: "False Push Enqueue")
+      inbox = Creative.inbox_for(owner)
+      original_adapter = ActiveJob::Base.queue_adapter
+      ActiveJob::Base.queue_adapter = :test
+      comment = creative.comments.create!(user: commenter, content: "retry false enqueue")
+      event = comment.notification_event
+      clear_enqueued_jobs
+
+      PushNotificationJob.stub(:perform_later, false) do
+        assert_raises ActiveJob::EnqueueError do
+          comment.deliver_notifications("created", event)
+        end
+      end
+
+      delivery = CommentNotificationDelivery.find_by!(delivery_key: notification_key_for(comment, owner))
+      assert_nil delivery.push_enqueued_at
+      assert_nil delivery.push_claim_token
+      assert_nil delivery.push_claimed_at
+      assert_equal 1, inbox.comments.where(quoted_comment: comment).count
+    ensure
+      clear_enqueued_jobs
+      ActiveJob::Base.queue_adapter = original_adapter
+    end
+
     test "push delivery sweep reclaims an expired enqueue claim" do
       owner = users(:one)
       inbox_comment = creatives(:tshirt).comments.create!(


### PR DESCRIPTION
## Summary
- treat `false`/`nil` ActiveJob enqueue results as failures
- keep the durable push delivery pending and release its claim for sweep retry
- add regression coverage for the `false` enqueue-result path

## Context
Follow-up for the final Codex P2 on #1441: `perform_later` may return `false`, which previously skipped the `successfully_enqueued?` guard and incorrectly recorded `push_enqueued_at`.

## Validation
- RuboCop: 1,078 files, 0 offenses
- Full test suite: 2,917 runs, 9,182 assertions, 0 failures/errors