### PR TITLE
chore(comments): remove the read-pointer helper orphaned by the receipt index

### DIFF
--- a/engines/collavre/app/models/collavre/comment_read_pointer.rb
+++ b/engines/collavre/app/models/collavre/comment_read_pointer.rb
@@ -8,19 +8,10 @@ module Collavre
 
     validates :user_id, uniqueness: { scope: :creative_id }
 
-    def effective_comment_id(sorted_visible_ids)
-      return nil unless last_read_comment_id
-
-      # Find the nearest visible comment ID <= last_read_comment_id
-      idx = sorted_visible_ids.bsearch_index { |x| x > last_read_comment_id }
-
-      if idx
-        # If idx is 0, target is smaller than all visible IDs
-        idx > 0 ? sorted_visible_ids[idx - 1] : nil
-      else
-        # target is >= all visible IDs
-        sorted_visible_ids.last
-      end
-    end
+    # Mapping a pointer onto the comment its receipt avatar renders against lives
+    # in Comments::ReadReceiptIndex, which resolves it in the same query that
+    # loads the pointers and bounds the lookup to the rendered window. Do not
+    # reintroduce a model-side variant: two implementations drift, and the
+    # in-Ruby one required loading every public comment id on the creative.
   end
 end


### PR DESCRIPTION
Follow-up to #1440, addressing a Codex review that landed after that PR merged.

## What

#1440 moved read-receipt mapping into `Comments::ReadReceiptIndex`, which resolves the effective comment inside the same query that loads the pointers and bounds the lookup to the rendered window. That left `CommentReadPointer#effective_comment_id` with zero callers.

Verified repo-wide before deleting — the only remaining `effective_comment_id` occurrences are the local Arel variable inside `ReadReceiptIndex`, not calls to the model method. No test exercised it either.

## Why it matters

This is not merely unused code: the orphaned helper carried *different* semantics from the active path.

| | orphaned helper | `ReadReceiptIndex` |
|---|---|---|
| mapping | nearest visible id at or before the pointer | same, but excluded when the pointer is past the rendered window max |
| window bound | none | `rendered_window_max_id` |
| cost | caller had to load every public comment id on the creative | one correlated subquery, bounded by participant count |

The missing window bound is precisely the regression Codex caught earlier in #1440 (a pointer at the first private comment after an older page mapped back onto that page's last public comment, resurfacing the caught-up-reader avatar). Leaving a second implementation with the pre-fix semantics in the model is a live invitation to reintroduce that bug.

Deleted, with a comment naming the owning path so the two cannot drift back apart.

## Testing

- `engines/collavre/test/models/comment_read_pointer_test.rb`, `services/comments/read_receipt_index_test.rb`, `integration/comments_read_marker_test.rb`, `controllers/comment_read_pointers_controller_test.rb` — 15 runs, 28 assertions, 0 failures
- Full pre-push suite green; RuboCop clean