### PR TITLE
perf(comments): stop counting whole comment histories for the badge flag

### DIFF
--- a/engines/collavre/app/models/collavre/comment/broadcastable.rb
+++ b/engines/collavre/app/models/collavre/comment/broadcastable.rb
@@ -42,7 +42,12 @@ module Collavre
           pointers = CommentReadPointer.where(user_id: user_ids, creative: origin).index_by(&:user_id)
           present_user_ids = CommentPresenceStore.list(origin.id)
 
-          public_count = origin.comments.public_only.count
+          # Only ever consumed as a boolean (show_zero below), so ask the
+          # database for existence rather than a total. An unbounded COUNT has
+          # no id predicate to anchor it, so the planner falls back to a
+          # sequential scan of the whole comments table and gets slower for
+          # every participant as the conversation grows.
+          any_public = origin.comments.public_only.exists?
           private_counts = origin.comments
             .where(private: true, user_id: user_ids)
             .group(:user_id)
@@ -71,7 +76,7 @@ module Collavre
 
           users.each do |u|
             user_private_count = private_counts[u.id] || 0
-            total_count = public_count + user_private_count
+            has_any_visible = any_public || user_private_count.positive?
 
             threshold = last_read_ids[u.id] || 0
             unread_public = unread_public_by_threshold[threshold] || 0
@@ -87,7 +92,7 @@ module Collavre
               locals: {
                 count: unread_count,
                 badge_id: "comment-badge-#{origin.id}",
-                show_zero: total_count.positive?
+                show_zero: has_any_visible
               }
             )
 

--- a/engines/collavre/test/models/collavre/comment/badge_visibility_test.rb
+++ b/engines/collavre/test/models/collavre/comment/badge_visibility_test.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  # The badge's show_zero flag answers "does this user have anything in this
+  # conversation at all", so it has to stay per-user: a public comment counts
+  # for everyone, a private one only for its author. These pin that contract so
+  # the read behind it can be cheapened without changing what people see.
+  class CommentBadgeVisibilityTest < ActiveSupport::TestCase
+    setup do
+      @owner = users(:one)
+      @viewer = users(:two)
+      @creative = Creative.create!(user: @owner, description: "Badge visibility", sequence: 941)
+      CreativeShare.create!(creative: @creative, user: @viewer, shared_by: @owner, permission: :feedback)
+    end
+
+    test "no comments means every participant's badge stays hidden" do
+      assert_equal({ @owner.id => false, @viewer.id => false }, show_zero_by_user_id)
+    end
+
+    test "a public comment reveals the badge for every participant" do
+      Comment.create!(creative: @creative, user: @owner, content: "public")
+
+      assert_equal({ @owner.id => true, @viewer.id => true }, show_zero_by_user_id)
+    end
+
+    test "a private comment reveals the badge only for its author" do
+      Comment.create!(creative: @creative, user: @owner, content: "private", private: true)
+
+      assert_equal({ @owner.id => true, @viewer.id => false }, show_zero_by_user_id)
+    end
+
+    test "a public comment outweighs another user's private one" do
+      Comment.create!(creative: @creative, user: @owner, content: "private", private: true)
+      Comment.create!(creative: @creative, user: @viewer, content: "public")
+
+      assert_equal({ @owner.id => true, @viewer.id => true }, show_zero_by_user_id)
+    end
+
+    private
+
+    # Capture what broadcast_badges would render, keyed by the recipient, so the
+    # assertions read as "what does each participant see".
+    def show_zero_by_user_id
+      captured = {}
+      broadcast = lambda do |stream, **options|
+        user = Array(stream).first
+        next unless user.is_a?(Collavre::User)
+        next unless options[:target] == "comment-badge-#{@creative.id}"
+
+        captured[user.id] = options.dig(:locals, :show_zero)
+      end
+
+      Turbo::StreamsChannel.stub(:broadcast_replace_to, broadcast) do
+        Comment.broadcast_badges(@creative)
+      end
+
+      captured
+    end
+  end
+end


### PR DESCRIPTION
## Problem

`Comment.broadcast_badges` recomputes every participant's badge. It read

```ruby
public_count = origin.comments.public_only.count
```

and then used the value only as a boolean: `show_zero: total_count.positive?`.

That COUNT has no `id` predicate, so the partial index added in #1440
(`(creative_id, id) WHERE private = false`) has nothing to anchor on and Postgres
falls back to a sequential scan of the whole `comments` table. Measured on the
production database (49,322 rows, creative 7 with 8,133 public comments):

```
Aggregate  (actual time=26.664..26.665 rows=1 loops=1)
  ->  Seq Scan on comments  (actual time=0.041..26.334 rows=8133 loops=1)
        Filter: ((NOT private) AND (creative_id = 7))
        Rows Removed by Filter: 42635
Execution Time: 26.722 ms
```

It runs once per badge recomputation and gets slower for every conversation as
history accumulates. Moving badge recomputation into a job (#1440) took it off
the request, but the database time is still spent on every message.

## Change

Ask for existence instead of a total, since a boolean is all the caller wanted:

```ruby
any_public = origin.comments.public_only.exists?
...
show_zero: any_public || user_private_count.positive?
```

```
Limit  (actual time=0.003..0.004 rows=1 loops=1)
Execution Time: 0.018 ms
```

The degenerate case — a creative with only private comments, where the scan
cannot stop early — uses the partial index and finishes in 0.030ms.

A counter cache was the original suggestion, but `creatives.comments_count`
counts public *and* private comments, so it cannot answer this question: another
user's private comment must not reveal the badge.

## Tests

`badge_visibility_test.rb` pins the per-user contract the flag encodes — no
comments hides the badge, a public comment reveals it for everyone, a private
one only for its author, and a public comment outweighs someone else's private
one. The tests were written against the old implementation and pass unchanged
against the new one.

412 tests in `engines/collavre/test/models`, `engines/collavre/test/jobs`, and
the comment integration tests pass. Rubocop clean.