### PR TITLE
fix(deploy): stop web-only targets from claiming the shared job queue

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -80,8 +80,11 @@ env:
     - LINEAR_OAUTH_REDIRECT_URI
   clear:
     # Run the Solid Queue Supervisor inside the web server's Puma process to do jobs.
-    # When you start using multiple servers, you should split out job processing to a dedicated machine.
-    SOLID_QUEUE_IN_PUMA: true
+    # Defaults on for single-server deployments. Targets that share a database
+    # with another deployment set SOLID_QUEUE_IN_PUMA=false in their env file so
+    # only one host claims from the shared queue — a host running older code
+    # otherwise picks up jobs it cannot run.
+    SOLID_QUEUE_IN_PUMA: <%= ENV.fetch('SOLID_QUEUE_IN_PUMA', 'true') %>
 
     # Set number of processes dedicated to Solid Queue (default: 1)
     # JOB_CONCURRENCY: 3

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -33,8 +33,12 @@ port ENV.fetch("PORT", 3000)
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart
 
-# Run the Solid Queue supervisor inside of Puma for single-server deployments
-plugin :solid_queue if ENV["SOLID_QUEUE_IN_PUMA"]
+# Run the Solid Queue supervisor inside of Puma for single-server deployments.
+# Hosts that share a database with another deployment but should only serve web
+# traffic set SOLID_QUEUE_IN_PUMA=false, so they never claim from the shared
+# queue. Read through EnvFlag: a bare ENV[] check treats "false" as enabled.
+require_relative "../lib/env_flag"
+plugin :solid_queue if EnvFlag.enabled?("SOLID_QUEUE_IN_PUMA")
 
 # Specify the PID file. Defaults to tmp/pids/server.pid in development.
 # In other environments, only set the PID file if requested.

--- a/env.template
+++ b/env.template
@@ -8,6 +8,10 @@ RAILS_MASTER_KEY=
 SECRET_KEY_BASE=
 # DATABASE_URL=sqlite3:storage/production-primary.sqlite3
 PORT=80
+# Run the Solid Queue supervisor inside Puma on this deploy target (default: true).
+# Set to false when several targets share one database, so that exactly one of
+# them claims background jobs.
+# SOLID_QUEUE_IN_PUMA=true
 GEMINI_API_KEY=
 # empty for default
 GEMINI_API_BASE=

--- a/lib/env_flag.rb
+++ b/lib/env_flag.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Boolean reading for ENV flags that are consumed before Rails boots — notably
+# `config/puma.rb`, where ActiveModel's type cast is not available yet.
+#
+# Only affirmative spellings enable a flag. Everything else, including the empty
+# string a deploy template renders for an unset variable, reads as disabled.
+module EnvFlag
+  TRUTHY = %w[1 t true y yes on].freeze
+
+  # `env` is injectable so the reading can be tested without mutating ENV.
+  def self.enabled?(name, env: ENV, default: false)
+    raw = env[name]
+    return default if raw.nil?
+
+    TRUTHY.include?(raw.to_s.strip.downcase)
+  end
+end

--- a/test/lib/env_flag_test.rb
+++ b/test/lib/env_flag_test.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class EnvFlagTest < ActiveSupport::TestCase
+  # `config/puma.rb` decides whether to run the Solid Queue supervisor from an
+  # ENV flag. A bare `if ENV["FLAG"]` treats "false" and "" as enabled, so a
+  # host meant to serve web traffic only still claims jobs from the shared
+  # queue. These cases pin the affirmative-only reading.
+
+  test "reads affirmative spellings as enabled" do
+    %w[1 true t yes y on TRUE True YES On].each do |value|
+      assert EnvFlag.enabled?("FLAG", env: { "FLAG" => value }),
+             "expected #{value.inspect} to enable the flag"
+    end
+  end
+
+  test "reads negative spellings as disabled" do
+    %w[0 false f no n off FALSE Off].each do |value|
+      assert_not EnvFlag.enabled?("FLAG", env: { "FLAG" => value }),
+                 "expected #{value.inspect} to disable the flag"
+    end
+  end
+
+  test "reads a blank value as disabled" do
+    assert_not EnvFlag.enabled?("FLAG", env: { "FLAG" => "" })
+    assert_not EnvFlag.enabled?("FLAG", env: { "FLAG" => "   " })
+  end
+
+  test "reads an unrecognized value as disabled" do
+    assert_not EnvFlag.enabled?("FLAG", env: { "FLAG" => "maybe" })
+  end
+
+  test "ignores surrounding whitespace" do
+    assert EnvFlag.enabled?("FLAG", env: { "FLAG" => " true\n" })
+  end
+
+  test "falls back to the default when the variable is unset" do
+    assert_not EnvFlag.enabled?("FLAG", env: {})
+    assert EnvFlag.enabled?("FLAG", env: {}, default: true)
+  end
+
+  test "an explicit value overrides the default" do
+    assert_not EnvFlag.enabled?("FLAG", env: { "FLAG" => "false" }, default: true)
+  end
+
+  test "a blank value overrides the default" do
+    # Deploy templates render an empty string for an unset variable; that must
+    # not read as "unset" and pick up an enabled default.
+    assert_not EnvFlag.enabled?("FLAG", env: { "FLAG" => "" }, default: true)
+  end
+
+  test "defaults to the process environment" do
+    ENV["ENV_FLAG_TEST"] = "true"
+    assert EnvFlag.enabled?("ENV_FLAG_TEST")
+  ensure
+    ENV.delete("ENV_FLAG_TEST")
+  end
+end


### PR DESCRIPTION
## Problem

Two kamal targets deploy from this repo against **one** production database (`COLLAVRE_SERVER` differs between `.env.production` and `.env.local`; both `DATABASE_URL`s resolve to the same Postgres). `SOLID_QUEUE_IN_PUMA: true` was hardcoded in `config/deploy.yml`, so both targets ran a Solid Queue supervisor and claimed from the same queue.

Two failure modes followed:

1. **Version skew eats work.** Deploying a new job class to one target only makes the other target's workers claim those jobs and fail them with `ActiveJob::UnknownJobClassError`. When the job is the sole writer, that is data loss — inbox notifications and link previews were dropped this way after #1441.
2. **`PushNotificationJob` fails 100% on the non-EC2 host.** `config/initializers/fcm.rb` selects the AWS Workload Identity Federation path in production, whose credential source is the EC2 instance metadata endpoint `169.254.169.254`. That address does not exist off EC2, so every push claimed by the other host dies with `Google::Auth::CredentialsError: Failed to open TCP connection to 169.254.169.254`. 445 failed executions accumulated with exactly this message.

## Change

- `SOLID_QUEUE_IN_PUMA` now comes from the deploy target's env file, defaulting to `true` so single-server setups are unaffected. A target that shares a database sets it to `false`.
- `config/puma.rb` reads it through a new `EnvFlag.enabled?` instead of `if ENV["SOLID_QUEUE_IN_PUMA"]`. The bare check is truthy for `"false"` and for `""`, so setting the variable to `false` would not have turned the supervisor off.
- `env.template` documents the variable.

## Verification

`config/puma.rb` evaluated against a stub Puma DSL:

| `SOLID_QUEUE_IN_PUMA` | plugins loaded |
|---|---|
| unset | `[:tmp_restart]` |
| `false` | `[:tmp_restart]` |
| `""` | `[:tmp_restart]` |
| `true` | `[:tmp_restart, :solid_queue]` |

`config/deploy.yml` ERB renders `true` when unset, and passes an explicit value through.

`test/lib/env_flag_test.rb` pins the affirmative-only reading (9 tests, incl. the blank-string case that motivated the change). Written failing first. Rubocop clean; pre-push suite passed.