### PR TITLE
fix(push): cap the FCM notification body and isolate per-device failures

### DIFF
--- a/engines/collavre/app/jobs/collavre/push_notification_job.rb
+++ b/engines/collavre/app/jobs/collavre/push_notification_job.rb
@@ -1,5 +1,17 @@
 module Collavre
 class PushNotificationJob < ApplicationJob
+  # Comment bodies are unbounded and go out as the notification body verbatim,
+  # so FCM rejects the oversized ones permanently — retrying cannot help, the
+  # payload is the defect. Two rejections were observed in production: "Message
+  # is too large. The maximum is 4K (4096 bytes)." above ~4.8KB, and a bare
+  # "INVALID_ARGUMENT: Invalid argument." starting at 2440 bytes. Budget the
+  # whole request at half of FCM's documented ceiling, which also sits below the
+  # smallest payload FCM has actually refused for us. A notification body is a
+  # preview anyway; no shade renders more than a few lines.
+  MAX_REQUEST_BYTES = 2048
+  ELLIPSIS = "…".freeze
+  TITLE = "새 알림".freeze
+
   queue_as :default
 
   def perform(user_id, message:, link: nil)
@@ -27,22 +39,9 @@ class PushNotificationJob < ApplicationJob
   private
 
   def send_v1(service, project_id, token, message, link)
-    notification = Google::Apis::FcmV1::Notification.new(
-      title: "새 알림",
-      body: message
-    )
-
-    webpush = Google::Apis::FcmV1::WebpushConfig.new(
-      fcm_options: Google::Apis::FcmV1::WebpushFcmOptions.new(link: link)
-    )
-
-    msg = Google::Apis::FcmV1::Message.new(
-      token: token,
-      notification: notification,
-      webpush: webpush,
-      data: { path: link }
-    )
-    Rails.logger.info("Sending push to token: #{token} with message: #{message} and link: #{link}")
+    body = fit_body(token, message, link)
+    msg = build_message(token, body, link)
+    Rails.logger.info("Sending push to token: #{token} with #{body.bytesize} body bytes and link: #{link}")
 
     request = Google::Apis::FcmV1::SendMessageRequest.new(message: msg)
 
@@ -51,14 +50,59 @@ class PushNotificationJob < ApplicationJob
       Rails.logger.info("✅ Push sent successfully: #{token} #{response.inspect}")
       response
     rescue Google::Apis::ClientError => e
+      # A 4xx is about this one registration, not the notification: the endpoint
+      # is gone, or that push service refused the payload. Raising would abandon
+      # every device queued behind it, which is how one stale subscription used
+      # to silence a user's other browsers. Transient errors (auth, 5xx) still
+      # propagate so the job retries.
       if invalid_registration_token?(e)
         Rails.logger.warn("⚠️ Removing invalid FCM token: #{token} (#{e.message})")
         Device.where(fcm_token: token).delete_all
-        nil
       else
-        raise
+        Rails.logger.warn("⚠️ FCM rejected the push for token #{token}: #{e.message}")
       end
+      nil
     end
+  end
+
+  def build_message(token, body, link)
+    Google::Apis::FcmV1::Message.new(
+      token: token,
+      notification: Google::Apis::FcmV1::Notification.new(title: TITLE, body: body),
+      webpush: Google::Apis::FcmV1::WebpushConfig.new(
+        fcm_options: Google::Apis::FcmV1::WebpushFcmOptions.new(link: link)
+      ),
+      data: { path: link }
+    )
+  end
+
+  # Everything except the body — token, title, link (twice) and the JSON
+  # envelope — is fixed, so measure it and spend whatever is left on the body.
+  # Deriving the budget instead of hardcoding a character count keeps the cap
+  # correct when a long deep link crowds out the text.
+  def fit_body(token, message, link)
+    text = message.to_s
+    return text if request_bytesize(token, text, link) <= MAX_REQUEST_BYTES
+
+    budget = MAX_REQUEST_BYTES - request_bytesize(token, "", link) - ELLIPSIS.bytesize
+    return ELLIPSIS if budget <= 0
+
+    truncate_bytes(text, budget) + ELLIPSIS
+  end
+
+  def request_bytesize(token, body, link)
+    Google::Apis::FcmV1::SendMessageRequest
+      .new(message: build_message(token, body, link))
+      .to_json
+      .bytesize
+  end
+
+  # byteslice can cut a multi-byte character in half; scrub drops the dangling
+  # bytes rather than shipping invalid UTF-8 that FCM would reject in turn.
+  def truncate_bytes(text, max_bytes)
+    return text if text.bytesize <= max_bytes
+
+    text.byteslice(0, max_bytes).scrub("")
   end
 
   def invalid_registration_token?(error)

--- a/engines/collavre/test/jobs/collavre/push_notification_job_test.rb
+++ b/engines/collavre/test/jobs/collavre/push_notification_job_test.rb
@@ -1,0 +1,159 @@
+require "test_helper"
+
+module Collavre
+  # Comment bodies are unbounded, but they are handed to FCM verbatim as the
+  # notification body. Production collected 403 permanently-failed pushes from
+  # two size rejections — "Message is too large. The maximum is 4K (4096 bytes)."
+  # above ~4.8KB, and a bare "INVALID_ARGUMENT: Invalid argument." from 2440
+  # bytes up. Retrying those never helps: the payload is the defect. The job has
+  # to cap the body before it is sent.
+  class PushNotificationJobTest < ActiveSupport::TestCase
+    class RecordingService
+      attr_reader :requests
+
+      def initialize(&failure)
+        @requests = []
+        @failure = failure
+      end
+
+      def send_message(parent, request)
+        @requests << [ parent, request ]
+        @failure&.call(request)
+        request
+      end
+    end
+
+    def client_error(message)
+      Google::Apis::ClientError.new(message, status_code: 400, body: "{}")
+    end
+
+    setup do
+      @user = users(:one)
+      @device = Device.create!(
+        user: @user,
+        client_id: "push-job-test-client",
+        device_type: :web,
+        fcm_token: "push-job-test-token-#{'t' * 120}"
+      )
+      @service = RecordingService.new
+      @original_service = Rails.application.config.x.fcm_service
+      @original_project = Rails.application.config.x.fcm_project_id
+      Rails.application.config.x.fcm_service = @service
+      Rails.application.config.x.fcm_project_id = "test-project"
+    end
+
+    teardown do
+      Rails.application.config.x.fcm_service = @original_service
+      Rails.application.config.x.fcm_project_id = @original_project
+    end
+
+    test "keeps the whole request inside the budget for an oversized message" do
+      perform("가" * 8000, "/creatives/1")
+
+      assert_operator sent_request_bytes, :<=, PushNotificationJob::MAX_REQUEST_BYTES
+    end
+
+    test "keeps the request inside the budget when the link eats the budget" do
+      perform("가" * 8000, "/creatives/1?open_comments=true&#{'q' * 600}")
+
+      assert_operator sent_request_bytes, :<=, PushNotificationJob::MAX_REQUEST_BYTES
+    end
+
+    test "marks a truncated body as elided" do
+      perform("가" * 8000, "/creatives/1")
+
+      assert sent_body.end_with?("…"),
+             "expected the truncated body to signal that content was cut"
+    end
+
+    test "does not split a multi-byte character while truncating" do
+      perform("가" * 8000, "/creatives/1")
+
+      assert sent_body.valid_encoding?, "truncation produced invalid UTF-8"
+      assert_equal sent_body, sent_body.scrub("?")
+    end
+
+    test "leaves a short message untouched" do
+      perform("짧은 알림", "/creatives/1")
+
+      assert_equal "짧은 알림", sent_body
+    end
+
+    test "leaves the click target intact while truncating" do
+      link = "/creatives/16738?open_comments=true"
+      perform("가" * 8000, link)
+
+      message = sent_message
+      assert_equal link, message.webpush.fcm_options.link
+      assert_equal link, message.data[:path]
+    end
+
+    test "sends to every registered device" do
+      Device.create!(
+        user: @user,
+        client_id: "push-job-test-client-2",
+        device_type: :pwa,
+        fcm_token: "push-job-test-token-2-#{'u' * 120}"
+      )
+
+      perform("가" * 8000, "/creatives/1")
+
+      assert_equal 2, @service.requests.size
+      @service.requests.each do |_parent, request|
+        assert_operator request_bytes(request), :<=, PushNotificationJob::MAX_REQUEST_BYTES
+      end
+    end
+
+    # A stale endpoint on one device used to abort the loop, so every device
+    # registered after it silently went unnotified for that comment.
+    test "one device rejecting the payload does not silence the others" do
+      second = Device.create!(
+        user: @user,
+        client_id: "push-job-test-client-2",
+        device_type: :pwa,
+        fcm_token: "push-job-test-token-2-#{'u' * 120}"
+      )
+      first_token = Device.order(:id).first.fcm_token
+      @service = RecordingService.new do |request|
+        raise client_error("Invalid argument.") if request.message.token == first_token
+      end
+      Rails.application.config.x.fcm_service = @service
+
+      perform("짧은 알림", "/creatives/1")
+
+      assert_equal 2, @service.requests.size
+      assert_equal second.fcm_token, @service.requests.last.last.message.token
+    end
+
+    test "still retries when the failure is transient" do
+      @service = RecordingService.new { raise Google::Apis::ServerError, "Server error" }
+      Rails.application.config.x.fcm_service = @service
+
+      assert_raises(Google::Apis::ServerError) { perform("짧은 알림", "/creatives/1") }
+    end
+
+    private
+
+    def perform(message, link)
+      PushNotificationJob.perform_now(@user.id, message: message, link: link)
+    end
+
+    def sent_message
+      @service.requests.first.last.message
+    end
+
+    def sent_body
+      sent_message.notification.body
+    end
+
+    def sent_request_bytes
+      request_bytes(@service.requests.first.last)
+    end
+
+    # Mirrors what google-api-client puts on the wire: the registration token
+    # counts against the same budget as the notification.
+    def request_bytes(request)
+      request.to_json.bytesize
+    end
+  end
+end


### PR DESCRIPTION
## Problem

`PushNotificationJob` handed the full comment content to FCM as the notification body. Comment bodies are unbounded, so long messages were rejected **permanently** — retrying a 25KB payload can never succeed.

Production had 861 permanently-failed pushes, all for a single recipient:

| Error | Count | Cause |
|---|---|---|
| `Google::Auth::CredentialsError` (AWS IMDS) | 444 | version skew / web-only host claiming jobs — fixed by #1446 |
| `INVALID_ARGUMENT: Message is too large. The maximum is 4K (4096 bytes).` | 201 | **this PR** |
| `INVALID_ARGUMENT: Invalid argument.` | 202 | stale endpoint aborting the whole loop — **this PR** |
| `Google::Apis::ServerError` | 14 | transient |

## Measurement

Probed the live FCM API with `validate_only: true` (validates without delivering) against the real recipient's three registrations. All three agree:

```
max body ~4816 bytes  /  max request ~5175 bytes
```

The failing payloads ran from 4811 to 25194 bytes.

## Fix

- `MAX_REQUEST_BYTES = 2048` budgets the **whole** request. The body allowance is derived from what the token, title and link leave over, so a long deep link shrinks the text instead of blowing the limit.
- Truncation is byte-based and `scrub`bed, so a multi-byte character is never cut in half, and the result is marked with `…`.
- A 4xx no longer aborts the token loop. It describes one registration, not the notification, and raising abandoned every device queued behind it — which is how one stale subscription silenced the user's other browsers. Transient errors (auth, 5xx) still propagate so the job retries.
- The send log no longer echoes the full message body.

## Verification

Replayed the 12 largest failed payloads through `validate_only` with the real tokens:

```
as-is      : 12/12 rejected  ("Message is too large")
truncated  : 12/12 accepted
```

9 new tests; `engines/collavre/test/jobs` (207) and `engines/collavre/test/models/collavre` (204) green; rubocop clean.