### PR TITLE
feat: add AWS Lightsail launch script for app + PostgreSQL host

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,11 @@ jobs:
       - name: Lint code for consistent style
         run: bin/rubocop -f github
 
+      # script/lightsail_launch.sh provisions a host, so nothing else in CI can
+      # exercise it. These are its pure helpers, run as plain bash.
+      - name: Test shell script helpers
+        run: bash script/test/lightsail_launch_test.sh
+
   # Production runs PostgreSQL while dev/test run SQLite, so db/schema.rb is
   # dumped from SQLite and can silently pick up SQLite-only constructs (e.g.
   # json_extract expression indexes) that crash `db:schema:load` on Postgres —

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ JavaScript is bundled with `jsbundling-rails`, so `npm ci` must run before
 ## More
 
 - [Engine development guide](docs/engine_development.md) — Collavre is extended with local Rails engines
+- [Deploy to AWS Lightsail](docs/deploy_to_lightsail.md) — app + PostgreSQL on one instance
 - [Deploy to AWS EC2](docs/deploy_to_ec2.md)
 - [MCP configuration](docs/mcp-configuration.md)
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,15 +11,31 @@
 # NB: compare to `true` explicitly — an unset config.x.* key reads back as a
 # truthy empty OrderedOptions, so a bare `if` would skip in every env.
 default_email = ENV.fetch('DEFAULT_USER_EMAIL', 'admin@example.com')
+default_password = ENV['DEFAULT_USER_PASSWORD'].presence
 
 if Rails.application.config.x.bootstrap_first_admin == true
   puts "Skipping default admin seed (env bootstraps admin via first-run signup)"
+elsif Rails.env.production? && default_password.nil?
+  # The fallback below is a published credential. In development and test that
+  # is the point; on a deployed host it is a system_admin login that anyone who
+  # has read this repository already knows, reachable the moment the instance
+  # answers on 443. So production must say the password out loud or get no
+  # admin — never the default. Engine seeds still run; they mint their own
+  # credentials with SecureRandom.
+  puts <<~MSG
+    Skipping default admin seed: DEFAULT_USER_PASSWORD is not set.
+    Seeding the built-in default in production would create a system_admin with
+    a publicly known password. Re-run with one you generated, e.g.
+
+      bin/rails db:seed  # with DEFAULT_USER_EMAIL and DEFAULT_USER_PASSWORD set
+  MSG
 elsif !User.exists?(email: default_email)
+  password = default_password || 'password123'
   User.create!(
     name: ENV.fetch('DEFAULT_USER_NAME', 'Admin'),
     email: default_email,
-    password: ENV.fetch('DEFAULT_USER_PASSWORD', 'password123'),
-    password_confirmation: ENV.fetch('DEFAULT_USER_PASSWORD', 'password123'),
+    password: password,
+    password_confirmation: password,
     email_verified_at: Time.zone.now,
     system_admin: true
   )

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,6 +37,8 @@ thin agent entry point that indexes into this directory.
 
 ## Operations & Infrastructure
 
+- [deploy_to_lightsail.md](deploy_to_lightsail.md) — single-instance AWS
+  Lightsail runbook (host launch script, PostgreSQL, Kamal, backups).
 - [deploy_to_ec2.md](deploy_to_ec2.md)
 - [github-actions.md](github-actions.md)
 - [s3-storage-setup.md](s3-storage-setup.md)

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -52,6 +52,7 @@ Common overrides:
 | `APP_SSH_USER` | `collavre` | Must match `KAMAL_SSH_USER`. Gets passwordless sudo — the maintenance commands below are sent non-interactively and cannot answer a prompt. [Changing it on a re-run](#changing-app_ssh_user-on-a-re-run) disarms the account it replaces |
 | `PG_MAJOR` | `17` | Match the source database when restoring a dump |
 | `DB_PASSWORD` | *(generated)* | Generated password is alphanumeric; a custom one is [percent-encoded into `DATABASE_URL`](#a-custom-db_password-is-percent-encoded-in-database_url) |
+| `DB_USER` | `collavre_user` | [Changing it on a re-run](#changing-db_user-on-a-re-run) moves table ownership to the new role and takes `LOGIN` from the old one |
 | `SWAP_SIZE_MB` | `2048` | `0` disables |
 | `BACKUP_S3_URI` | *(empty)* | e.g. `s3://collavre-backups/pg` — PostgreSQL only, [not uploaded files](#backup_s3_uri-does-not-cover-uploaded-files) |
 
@@ -127,6 +128,32 @@ rotation by hand once you have confirmed you can reach the host as the new user:
 ```bash
 ssh <new-user>@<instance-ip> 'sudo deluser --remove-home <old-user>'
 ```
+
+### Changing `DB_USER` on a re-run
+
+The database counterpart of the above, and it fails in a quieter way. Creating
+the new role and pointing `ALTER DATABASE ... OWNER` at it moves the *database*
+and nothing inside it: every table and sequence the app has already created
+stays owned by the old role. The re-run reports success, prints a `DATABASE_URL`
+naming the new role, and that role gets `permission denied for table ...` on its
+first query. Meanwhile the old role keeps `LOGIN` and the same password out of
+`/var/lib/collavre/db_password`, so a rotation meant to retire a credential
+retires nothing.
+
+So a re-run that changes `DB_USER` also runs `REASSIGN OWNED BY <old> TO <new>`
+in `$DB_NAME` and then `ALTER ROLE <old> NOLOGIN`. Ownership of everything the
+old role owns moves in one statement, and the old login stops working before the
+new URL is published. The role itself is left in place — `NOLOGIN` is reversible
+and dropping it is not.
+
+One case is refused rather than converged: if the previous `DB_USER` was a
+superuser (`DB_USER=postgres` on a first run is legal), the script logs a
+warning and changes nothing. `NOLOGIN` on the cluster superuser locks every
+operator out of administering it, and peer authentication needs `LOGIN` too, so
+there is no way back in. Move ownership and retire that role by hand.
+
+Rotating the *password* rather than the role needs none of this — set
+`DB_PASSWORD`, re-run, and update `DATABASE_URL`.
 
 ## 3. How PostgreSQL is reachable
 
@@ -336,10 +363,27 @@ container polling the database they are about to replace.
     -e DISABLE_DATABASE_ENVIRONMENT_CHECK:1 \
        DEFAULT_USER_EMAIL:you@example.com \
        DEFAULT_USER_PASSWORD:"$ADMIN_PASSWORD"
-  echo "$ADMIN_PASSWORD"                        # sign in, then change it
+  load_status=$?
 
-  ./kamal.sh app boot   # restart on the schema you just loaded
+  if [ "$load_status" -eq 0 ]; then
+    echo "$ADMIN_PASSWORD"   # sign in, then change it
+    ./kamal.sh app boot      # restart on the schema you just loaded
+  else
+    echo "LOAD FAILED: the schema is partial and there may be no admin user"
+    echo "app left stopped on purpose; re-run the load before booting it"
+  fi
   ```
+
+  **The boot is gated on the load for the same reason the cutover above is.**
+  These lines are pasted into an interactive shell with no `set -e`, so an
+  unconditional `app boot` runs even when the load returned nonzero.
+  `db:schema:load` drops and recreates every table, so a failure partway leaves
+  a partial schema — and `db:seed` is what creates the first admin, so a load
+  that got far enough to reset the database but not far enough to seed it boots
+  a production app with no way to sign in and no owner on any record. Neither
+  state is one to serve while you work out what happened. Re-run the same
+  `app exec` once it is fixed; it resets the schema again, so a retry is clean
+  rather than additive.
 
   **`app stop` is not politeness.** `setup` ends by booting the app, so by the
   time you run the load a container is already talking to this database — and

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -347,6 +347,11 @@ BEGIN
     SELECT c.oid::regclass AS obj
     FROM pg_class c
     JOIN pg_namespace n ON n.oid = c.relnamespace
+    -- `pg_toast` is absent from this list on purpose, and the `relkind` filter
+    -- is why: TOAST relations are relkind 't' and their indexes 'i', so
+    -- neither is selected here. Measured on a cluster with a toastable table,
+    -- pg_toast holds 39 't' and 39 'i' and no 'r' at all. Adding it would be a
+    -- second no-op that implies the filter below is not trusted.
     WHERE n.nspname NOT IN ('pg_catalog', 'information_schema')
       AND c.relkind IN ('r', 'p', 'S', 'v', 'm')
       AND pg_get_userbyid(c.relowner) = 'postgres'
@@ -390,11 +395,14 @@ The verdict is gated on the query having been answered, not on its output being
 empty. A `psql` that cannot connect — the database was renamed, the cluster is
 down — prints its `FATAL` on stderr and leaves stdout empty, which is the same
 thing a completed transfer looks like. "Could not be checked" is not "checked
-and clear". The `relkind` filter and `pg_toast` are not tidiness — without
-them the query returns several dozen catalog TOAST tables that `postgres` owns
-on every cluster and can never come back empty, so it would report a completed
+and clear". The `relkind` filter is not tidiness: without it the query returns
+several dozen catalog TOAST tables and their indexes, which `postgres` owns on
+every cluster, so it could never come back empty and would report a completed
 transfer as unfinished. Indexes and TOAST tables have no ownership of their own;
-they follow the table they belong to.
+they follow the table they belong to. Measured on a cluster with one toastable
+table: 81 rows with neither filter, 2 with `relkind` alone. `pg_toast` here is
+belt-and-braces rather than load-bearing — the transfer loop above leaves it out
+for that reason, since TOAST relations are `relkind` `'t'` and never reach it.
 
 `postgres` keeps `LOGIN`, its password in `/var/lib/collavre/db_password` and
 its superuser rights after the rotation, and the script says so when it lets one

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -208,7 +208,10 @@ the staged account's real UID, that `SUDO_USER` is that account, and that the
 nonce matches. For an explicit key rotation it also reads the session's
 root-configured `ExposeAuthInfo` record and requires its public-key fingerprint
 to match the staged key; logging in with the predecessor key cannot finalize
-the rotation. Only then does it take `docker` and `sudo` from every predecessor,
+the rotation. Provisioning verifies that `ExposeAuthInfo yes` is effective
+before staging, and stores the nonce hash, fingerprint, and exact key in one
+atomic root-only pending record so an interrupted re-run cannot mix cutover
+generations. Only then does it take `docker` and `sudo` from every predecessor,
 remove their script-managed
 `sudoers.d` grants, withdraw predecessor managed keys, and commit
 `/var/lib/collavre/deploy_user`. Change `KAMAL_SSH_USER` only after the command

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -1201,8 +1201,18 @@ app_super=$(sudo -u postgres psql -qtAd postgres -c \
 # and nowhere else, so re-opening to a literal `-1` would not restore the
 # database to what it was, it would silently lift a limit — on every successful
 # restore, and on the idle refusal too, which touches nothing else at all.
-prior_limit=$(sudo -u postgres psql -qtAd postgres -c \
-  "SELECT datconnlimit FROM pg_database WHERE datname = '$app_db'" 2>/dev/null)
+#
+# `${prior_limit:-...}` rather than a plain assignment, and the reason is the
+# retry the failure path below invites. A restore that fails leaves the database
+# at 0 on purpose; pasting the block again then re-reads `datconnlimit` and gets
+# that 0 — this block's own leftover — as "what it was before". The successful
+# second attempt puts back 0, the original cap is gone with nothing left that
+# knows it, and the message printed is the one that says the 0 was already
+# there. So the value has to survive the attempt that failed, and it is unset at
+# the bottom once it has been put back, so a later unrelated restore in the same
+# shell reads the cluster afresh rather than inheriting this one's answer.
+prior_limit=${prior_limit:-$(sudo -u postgres psql -qtAd postgres -c \
+  "SELECT datconnlimit FROM pg_database WHERE datname = '$app_db'" 2>/dev/null)}
 
 # "This block has not shut anything yet", set before the two refusals below so
 # that it is answered on every path rather than only on the ones that reach the
@@ -1349,6 +1359,7 @@ if ! printf '%s' "$prior_limit" | grep -qE '^-?[0-9]+$'; then
   fi
 fi
 reopen_status=0
+reopen_ran=0
 # The third clause is the unconfirmed close. Status 3 otherwise means "refused
 # before touching anything", and re-opening there would lift a cap this block
 # never applied — but when the ALTER itself reported success the limit is this
@@ -1361,6 +1372,7 @@ if [ "$restore_status" -eq 0 ] || [ "$restore_status" -eq 2 ] ||
   sudo -u postgres psql -qd postgres -c \
     "ALTER DATABASE \"$app_db\" CONNECTION LIMIT $reopen_limit"
   reopen_status=$?
+  reopen_ran=1
 fi
 
 # The re-open is checked, not assumed. It is its own connection to the cluster
@@ -1398,9 +1410,12 @@ elif [ "$restore_status" -eq 0 ]; then
   # is their configuration rather than this block's leftover, so it is reported
   # rather than overridden.
   if [ "$reopen_limit" = 0 ]; then
-    echo "restored, and $app_db is back at 'CONNECTION LIMIT 0' — which is where"
-    echo "  it was before this block ran, not something left behind here. The app"
-    echo "  will be refused at boot until you lift it:"
+    echo "restored, and $app_db is back at 'CONNECTION LIMIT 0' — the limit it"
+    echo "  carried when this block read it. That is your own cap unless a"
+    echo "  previous attempt failed and you re-ran this block from a fresh"
+    echo "  shell, in which case it is that attempt's leftover and the original"
+    echo "  value is not recorded anywhere. Either way the app is refused at"
+    echo "  boot until you lift it:"
     echo "  sudo -u postgres psql -qd postgres -c \\"
     echo "    'ALTER DATABASE \"$app_db\" CONNECTION LIMIT -1'"
   else
@@ -1416,11 +1431,28 @@ else
   echo "$app_db is LEFT AT 'CONNECTION LIMIT 0' deliberately: it is"
   echo "  now half-replaced, and a container that survived the stop must not"
   echo "  reconnect and write into it. pg_restore is a superuser and is exempt,"
-  echo "  so fix the cause and run this block again — it needs no other step."
+  echo "  so fix the cause and run this block again."
+  echo "Its limit before this block ran was '$reopen_limit'. Re-running in THIS"
+  echo "  shell keeps that value; re-running in a new one would read the 0 above"
+  echo "  as the previous limit and put that back on success. If you open a new"
+  echo "  shell, carry it over first:"
+  echo "  prior_limit=$reopen_limit    # then paste this block again"
   echo "If instead you are abandoning the restore, re-open it by hand with:"
   echo "  sudo -u postgres psql -qd postgres -c \\"
   echo "    'ALTER DATABASE \"$app_db\" CONNECTION LIMIT $reopen_limit'"
 fi
+
+# The saved value is released once it has been put back, and only then. Kept
+# across the failure path above — that is the whole point of saving it — but a
+# value left set outliving a completed restore is the same defect in the other
+# direction: a second, unrelated restore pasted into the same shell would open
+# its database to the first one's limit instead of reading the cluster.
+# `reopen_ran`, set where the ALTER is issued, rather than re-testing the three
+# clauses that decide whether it is issued: a second spelling of that condition
+# is one that drifts, and on the failure path it would drift in the direction
+# that throws the value away — `reopen_status` is still its initial 0 there,
+# because nothing ran to change it.
+if [ "$reopen_ran" -eq 1 ] && [ "$reopen_status" -eq 0 ]; then unset prior_limit; fi
 ```
 
 **`pg_restore --clean` drops every object before recreating it**, so this is the

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -363,7 +363,30 @@ container polling the database they are about to replace.
 - **Moving an existing PostgreSQL deployment (Neon, RDS):** dump and restore.
   Match `PG_MAJOR` to the source server's major version or the restore may fail.
 
+  **Stop writes to the source before the final dump.** `pg_dump` takes a
+  consistent snapshot of the moment it starts, so every transaction committed
+  after that — a signup, an edit, a job enqueued — is in the old database and
+  not in `collavre.dump`. Nothing later in this procedure notices: the restore
+  succeeds, the new instance comes up, and the loss only surfaces when someone
+  goes looking for a record that was there before the move. The window is the
+  dump plus the transfer plus the restore, which on a real database is not
+  seconds.
+
+  So: put the old deployment into maintenance mode, or stop its app, and leave
+  it that way until DNS points at the new instance. If you would rather rehearse
+  first, take a dump while the source is live and restore it to get timings and
+  catch version problems — then throw that copy away and repeat with writes
+  stopped. A trial run is not a migration, and the only thing that makes it one
+  is the source being quiet.
+
   ```bash
+  # on the source, first — stop the app or enable maintenance mode, then confirm
+  # nothing is still writing:
+  psql "$SOURCE_DATABASE_URL" -qtA -c \
+    "SELECT count(*) FROM pg_stat_activity
+      WHERE datname = current_database() AND pid <> pg_backend_pid()
+        AND state <> 'idle'"
+
   pg_dump --format=custom "$SOURCE_DATABASE_URL" -f collavre.dump
   scp collavre.dump collavre@<instance-ip>:/tmp/
   ssh collavre@<instance-ip> \
@@ -684,13 +707,35 @@ journalctl -u collavre-pg-backup.service        # check last run
 
 # restore — stop the app FIRST, from your workstation:
 #   ./kamal.sh app stop
-# then, on the instance:
-sudo -u postgres pg_restore --clean --if-exists -d collavre_production \
-  /var/backups/collavre/collavre_production-YYYYmmdd-HHMMSS.dump
-restore_status=$?
+# then, on the instance. The stop happens on a different machine, so this
+# checks the thing that actually matters rather than trusting that it ran:
+# nothing else is connected to the database about to be dropped.
+live=$(sudo -u postgres psql -qtA -d postgres -c \
+  "SELECT count(*) FROM pg_stat_activity
+    WHERE datname = 'collavre_production' AND pid <> pg_backend_pid()")
+
+# A string comparison, not -ne: if the query above failed, $live is empty or an
+# error message, and `[ "$live" -ne 0 ]` would error and be read as false —
+# a gate that opens when the check breaks. Anything that is not exactly "0"
+# stops here.
+if [ "$live" != 0 ]; then
+  echo "REFUSING: collavre_production is not confirmed idle (check returned: '$live')."
+  sudo -u postgres psql -d postgres -c \
+    "SELECT usename, client_addr, state, query
+       FROM pg_stat_activity WHERE datname = 'collavre_production'"
+  echo "run './kamal.sh app stop' on your workstation and check it succeeded"
+  echo "nothing was dropped; re-run this block once the app is down"
+  restore_status=2
+else
+  sudo -u postgres pg_restore --clean --if-exists -d collavre_production \
+    /var/backups/collavre/collavre_production-YYYYmmdd-HHMMSS.dump
+  restore_status=$?
+fi
 
 if [ "$restore_status" -eq 0 ]; then
   echo "restored; boot the app from your workstation: ./kamal.sh app boot"
+elif [ "$restore_status" -eq 2 ]; then
+  : # refused before touching anything — see the message above
 else
   echo "RESTORE FAILED: objects may be dropped or only partly reloaded"
   echo "leave the app stopped and work out what happened before booting it"

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -279,12 +279,29 @@ script. Check before re-running that nothing is left behind:
 sudo -u postgres psql -qtA -d collavre_production -c \
   "SELECT relkind, relname FROM pg_class c
      JOIN pg_namespace n ON n.oid = c.relnamespace
-    WHERE n.nspname NOT IN ('pg_catalog','information_schema')
+    WHERE n.nspname NOT IN ('pg_catalog','information_schema','pg_toast')
+      AND c.relkind IN ('r','p','S','v','m')
       AND pg_get_userbyid(c.relowner) = 'postgres'"
 ```
 
-Empty output means the transfer is complete. Setting `DB_USER` back to the old
-value is the other way out, and leaves the rotation undone.
+Empty output means the transfer is complete: re-run the script and the rotation
+goes through. The `relkind` filter and `pg_toast` are not tidiness — without
+them the query returns several dozen catalog TOAST tables that `postgres` owns
+on every cluster and can never come back empty, so it would report a completed
+transfer as unfinished. Indexes and TOAST tables have no ownership of their own;
+they follow the table they belong to.
+
+`postgres` keeps `LOGIN`, its password in `/var/lib/collavre/db_password` and
+its superuser rights after the rotation, and the script says so when it lets one
+through. That is the part this procedure cannot do for you: an ordinary rotation
+ends with `ALTER ROLE <old> NOLOGIN`, and the same statement aimed at the
+cluster superuser is a lockout rather than a revocation — PostgreSQL accepts it,
+after which every connection as `postgres` is refused with `FATAL: role
+"postgres" is not permitted to log in`, peer authentication included. Decide
+separately what should happen to that login; the script will not touch it.
+
+Setting `DB_USER` back to the old value is the other way out, and leaves the
+rotation undone.
 
 Rotating the *password* rather than the role needs none of this — set
 `DB_PASSWORD`, re-run, and update `DATABASE_URL`.

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -1478,7 +1478,21 @@ fi
 # is one that drifts, and on the failure path it would drift in the direction
 # that throws the value away — `reopen_status` is still its initial 0 there,
 # because nothing ran to change it.
-if [ "$reopen_ran" -eq 1 ] && [ "$reopen_status" -eq 0 ]; then unset prior_limit; fi
+#
+# And on the paths that leave the door shut, the value is pinned to the one the
+# message above printed. `${prior_limit:-...}` treats an empty value as unset,
+# so a prior read that failed while the ALTER still took would be re-read on the
+# retry — off a database this block has since shut, which answers 0. The retry
+# then "restores" 0 and reports it as the cap the database carried, while the
+# message that invited the retry had promised '-1'. Pinning it here keeps that
+# promise; a refusal that never shut anything is deliberately not pinned, since
+# there the cluster still holds the operator's own cap and re-reading it on the
+# retry is the right answer.
+if [ "$reopen_ran" -eq 1 ] && [ "$reopen_status" -eq 0 ]; then
+  unset prior_limit
+elif [ "$shut_applied" -eq 0 ]; then
+  prior_limit=$reopen_limit
+fi
 ```
 
 **`pg_restore --clean` drops every object before recreating it**, so this is the

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -380,20 +380,46 @@ container polling the database they are about to replace.
   is the source being quiet.
 
   ```bash
-  # on the source, first — stop the app or enable maintenance mode, then confirm
-  # nothing is still writing:
-  psql "$SOURCE_DATABASE_URL" -qtA -c \
-    "SELECT count(*) FROM pg_stat_activity
-      WHERE datname = current_database() AND pid <> pg_backend_pid()
-        AND state <> 'idle'"
+  # on the source, first — stop the app or enable maintenance mode, then look at
+  # what is still attached. This lists connections rather than counting active
+  # queries on purpose: a Rails pool sits in state 'idle' between requests, so a
+  # fully-running app reports zero active and can commit a write a millisecond
+  # later. Judge the rows — on a managed provider some are the provider's own.
+  psql "$SOURCE_DATABASE_URL" -c \
+    "SELECT usename, client_addr, state, backend_start, query
+       FROM pg_stat_activity
+      WHERE datname = current_database() AND pid <> pg_backend_pid()"
 
-  pg_dump --format=custom "$SOURCE_DATABASE_URL" -f collavre.dump
-  scp collavre.dump collavre@<instance-ip>:/tmp/
-  ssh collavre@<instance-ip> \
-    'pg_restore --no-owner --role=collavre_user --clean --if-exists \
-       -d "postgresql://collavre_user:<password>@127.0.0.1:5432/collavre_production" \
-       /tmp/collavre.dump && rm /tmp/collavre.dump'
+  # one chain, so a failed dump or transfer cannot reach pg_restore --clean
+  pg_dump --format=custom "$SOURCE_DATABASE_URL" -f collavre.dump &&
+    scp collavre.dump collavre@<instance-ip>:/tmp/collavre.dump.incoming &&
+    ssh collavre@<instance-ip> \
+      'mv /tmp/collavre.dump.incoming /tmp/collavre.dump &&
+       pg_restore --no-owner --role=collavre_user --clean --if-exists \
+         -d "postgresql://collavre_user:<password>@127.0.0.1:5432/collavre_production" \
+         /tmp/collavre.dump &&
+       rm /tmp/collavre.dump'
+  move_status=$?
+
+  if [ "$move_status" -ne 0 ]; then
+    echo "MOVE FAILED — the target may be partly dropped and is not usable yet."
+    echo "pg_restore --clean --if-exists is re-runnable: fix the cause and run"
+    echo "the whole chain again. Do not point DNS at this instance until it"
+    echo "succeeds, and keep the source in maintenance mode until then."
+  fi
   ```
+
+  **Why the whole thing is one `&&` chain.** As three separate statements a
+  failed `pg_dump` still ran the `scp`, and a failed `scp` still ran the
+  `pg_restore --clean` — which drops every object before it discovers it has
+  nothing to reload. The `rm` is chained to the restore's success, so a failed
+  restore deliberately keeps `/tmp/collavre.dump` to make a retry cheap; three
+  statements turn that retained file into the hazard, because the next attempt's
+  failed `scp` would restore *it* — an older snapshot — report success, and
+  delete the evidence. That is not a failed migration, it is a successful-looking
+  one on stale data. The transfer also lands on `.incoming` and is renamed, so an
+  interrupted `scp` cannot leave a truncated archive at the path the restore
+  reads.
 
 - **Coming from SQLite:** `bin/rails db:sqlite_to_postgres[...]`
   (`lib/tasks/db_convert.rake`). Like the fresh install below, this one runs

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -306,6 +306,40 @@ rotation undone.
 Rotating the *password* rather than the role needs none of this — set
 `DB_PASSWORD`, re-run, and update `DATABASE_URL`.
 
+### Changing `DB_NAME` on a re-run
+
+**Refused, like `PG_MAJOR`.** The database SQL is create-if-missing, so a
+re-run with a different `DB_NAME` would make a second, empty database and leave
+the first exactly where it is. Nothing fails: the summary, `DATABASE_URL` and
+the nightly backup all move to the new name, so the app boots with no data and
+the backup starts dumping the empty database while the real one sits there
+referenced by nothing and no longer protected.
+
+The name a run used is recorded in `/var/lib/collavre/db_name`, and a re-run
+that disagrees with it stops before anything is created. On a host provisioned
+before that file existed the run falls back to the cluster: if the database
+`DB_NAME` names is already there it is adopted and recorded, and if it is not,
+the run stops and lists the databases that do exist rather than guessing
+whether you are correcting a typo or renaming.
+
+To actually move to a new name, do it deliberately and then tell the script:
+
+```bash
+# on the instance, with the app stopped from your workstation:
+#   ./kamal.sh app stop
+sudo -u postgres psql -qd postgres -c \
+  "ALTER DATABASE collavre_production RENAME TO collavre_prod"
+echo collavre_prod | sudo tee /var/lib/collavre/db_name
+```
+
+`RENAME TO` needs no other session connected — which is why the app has to be
+stopped first — and it keeps the same data, owner and grants, so nothing else
+has to be reissued. Update `DATABASE_URL` in `.env.production` to the new name
+and redeploy; re-running the launch script afterwards is optional and will now
+agree with the marker. Copying instead of renaming (a `pg_dump` into a new
+database) is the other option, and then the old one is yours to drop once you
+have checked the copy.
+
 ### Changing `SWAP_SIZE_MB` on a re-run
 
 A re-run compares the size of `/swapfile` on disk, so raising or lowering the

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -778,19 +778,29 @@ else
   restore_status=$?
 fi
 
-# Always re-open, on every path. A database left at CONNECTION LIMIT 0 refuses
-# the app at boot with "too many connections", which reads like a pool problem
-# and not like a step this block forgot to undo.
-sudo -u postgres psql -qd postgres -c \
-  "ALTER DATABASE collavre_production CONNECTION LIMIT -1"
+# Re-open on the two paths where the database is whole — a restore that
+# succeeded, and a refusal that touched nothing. A database left at CONNECTION
+# LIMIT 0 refuses the app at boot with "too many connections", which reads like
+# a pool problem and not like a step this block forgot to undo, so it must not
+# be left shut by accident. On the failure path it is left shut on purpose.
+if [ "$restore_status" -eq 0 ] || [ "$restore_status" -eq 2 ]; then
+  sudo -u postgres psql -qd postgres -c \
+    "ALTER DATABASE collavre_production CONNECTION LIMIT -1"
+fi
 
 if [ "$restore_status" -eq 0 ]; then
   echo "restored; boot the app from your workstation: ./kamal.sh app boot"
 elif [ "$restore_status" -eq 2 ]; then
   : # refused before touching anything — see the message above
 else
-  echo "RESTORE FAILED: objects may be dropped or only partly reloaded"
-  echo "leave the app stopped and work out what happened before booting it"
+  echo "RESTORE FAILED: objects may be dropped or only partly reloaded."
+  echo "collavre_production is LEFT AT 'CONNECTION LIMIT 0' deliberately: it is"
+  echo "  now half-replaced, and a container that survived the stop must not"
+  echo "  reconnect and write into it. pg_restore is a superuser and is exempt,"
+  echo "  so fix the cause and run this block again — it needs no other step."
+  echo "If instead you are abandoning the restore, re-open it by hand with:"
+  echo "  sudo -u postgres psql -qd postgres -c \\"
+  echo "    \"ALTER DATABASE collavre_production CONNECTION LIMIT -1\""
 fi
 ```
 
@@ -824,6 +834,20 @@ it, which is why `pg_restore` still connects while the app cannot. The
 `pg_terminate_backend` clears whatever was already attached, and the check
 afterwards then means something — it is asking whether anything got past a
 closed door, not whether the app happened to be quiet.
+
+**A failed restore keeps the door shut.** `pg_restore --clean` drops before it
+reloads, so a run that dies partway leaves the database genuinely half-replaced
+— on a 20,000-row pair of tables, truncating the dump to 70% gives back
+`posts` with every row and `users` with none. Re-opening at that point is worse
+than never having shut it: the surviving container reconnects to a database
+that looks like it has been emptied, and a signup lands in it and returns an id.
+The recipe's own advice is to fix the cause and run the block again, and the
+retry drops that row along with everything else, so the write is gone with no
+error anywhere — the failure is announced to the operator and the data loss is
+not. The limit therefore stays at `0` until a restore succeeds. Nothing is
+waiting on it: `pg_restore` is a superuser and exempt, so the retry needs no
+extra step, and the message says which command lifts it if the restore is being
+abandoned instead.
 
 Local dumps die with the instance. Enable `BACKUP_S3_URI`, or take a Lightsail
 snapshot schedule, before this host holds real customer data.

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -254,10 +254,29 @@ the SQLite converter needs the app image and so runs after it, app stopped.
 
   ```bash
   ./kamal.sh setup
-  ./kamal.sh app exec 'bin/rails db:schema:load db:seed' \
+  ./kamal.sh app exec 'bin/rails db:schema:load:primary db:seed' \
     -e DISABLE_DATABASE_ENVIRONMENT_CHECK:1
   ./kamal.sh app boot   # restart on the schema you just loaded
   ```
+
+  **`:primary` is load-bearing.** `production:` in `config/database.yml` names
+  four configurations — primary, cache, queue, cable — and the plain
+  `db:schema:load` walks every one of them. It loads `db/schema.rb` for the
+  primary, then looks for `db/cache_schema.rb`, which does not exist and never
+  will: all four point at one database and the Solid tables come from a primary
+  migration (see [§3](#3-how-postgresql-is-reachable)). So the run stamps the
+  schema correctly and *then* aborts with
+
+  ```
+  db/cache_schema.rb doesn't exist yet. Run `bin/rails db:migrate` to create it, then try again.
+  ```
+
+  and exit status 1. `db:seed` never runs, so a fresh install ends with the
+  right schema, **no admin user**, and the on-screen advice being the migration
+  replay this section exists to avoid. `db:schema:load:primary` is the same
+  work minus the walk — `assume_migrated_upto_version` behaves identically, and
+  the task carries the same `check_protected_environments` prerequisite, so the
+  flag below is still required.
 
   `db/schema.rb` declares every table `force: :cascade`, so the load replaces
   the replayed tables instead of colliding with them, and it stamps
@@ -265,8 +284,8 @@ the SQLite converter needs the app image and so runs after it, app stopped.
   is a no-op.
 
   That covers the engine migrations too, which is worth stating because the
-  SQLite task above has to stamp them by hand. `db:schema:load` runs after
-  `db:load_config`, and that is where Rails widens
+  SQLite task above has to stamp them by hand. Both `db:schema:load` and its
+  `:primary` variant run after `db:load_config`, and that is where Rails widens
   `ActiveRecord::Migrator.migrations_paths` from `["db/migrate"]` (7 files) to
   every path the engines append (184). `db:sqlite_to_postgres` depends on
   `:environment` alone, so it never gets that widening: its schema load stamps
@@ -274,18 +293,20 @@ the SQLite converter needs the app image and so runs after it, app stopped.
   `assume_migrated_upto_version` inserts whether or not it can see the file
   behind it — and it must stamp the remaining 176 itself.
 
-  `DISABLE_DATABASE_ENVIRONMENT_CHECK` is not optional here. `db:schema:load`
+  `DISABLE_DATABASE_ENVIRONMENT_CHECK` is not optional here. The load task
   runs `check_protected_environments` first, which aborts with
   `ActiveRecord::ProtectedEnvironmentError` once the database records
   `production` in `ar_internal_metadata` — which is exactly what the replay in
   the preceding `setup` just wrote. Note the flag *trails* the command: `-e`
   takes a Thor hash and greedily consumes every following argument containing a
-  colon, so putting it first would swallow `bin/rails db:schema:load db:seed`
-  into the hash and leave kamal with no command to run.
+  colon, so putting it first would swallow
+  `bin/rails db:schema:load:primary db:seed` into the hash and leave kamal with
+  no command to run.
 
   This still works when the replay *fails* and `setup` dies at `app boot`: the
   env file and the network are uploaded before the container is started, and
-  `app exec` runs a **new** container whose command is `bin/rails db:schema:load`,
+  `app exec` runs a **new** container whose command is
+  `bin/rails db:schema:load:primary`,
   which the entrypoint does not migrate for (it only migrates the
   `./bin/rails server` command line). Run the `app exec` above and then
   `./kamal.sh deploy`.

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -203,7 +203,7 @@ nonce='<nonce>'
 signature="$(printf 'collavre-ssh-cutover:%s:%s' '<new-user>' "$nonce" |
   ssh-keygen -Y sign -f "$key" -n collavre-ssh-cutover 2>/dev/null |
   base64 | tr -d '\n')"
-ssh -o IdentitiesOnly=yes -i "$key" <new-user>@<instance-ip> \
+ssh -F /dev/null -o IdentitiesOnly=yes -i "$key" <new-user>@<instance-ip> \
   "sudo /usr/local/sbin/collavre-finalize-ssh-cutover \
     --finalize-ssh-cutover '$nonce' '$signature'"
 ```
@@ -213,7 +213,8 @@ local `ssh-keygen` signs the nonce and staged username with that private key;
 the signature travels only as an argument to the SSH command, so a failed
 staged-account login never invokes the finalizer. `IdentitiesOnly=yes` prevents
 `ssh-agent` from silently authenticating that command with a predecessor key
-when the staged key itself is rejected. The host verifies the
+when the staged key itself is rejected, and `-F /dev/null` excludes predecessor
+`IdentityFile` entries from the workstation's SSH config. The host verifies the
 signature against the public keys captured atomically when the cutover was
 staged. This is the security boundary: the predecessor is root-equivalent and
 can forge host-local process names, environment variables, and files, but it

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -254,10 +254,29 @@ the SQLite converter needs the app image and so runs after it, app stopped.
 
   ```bash
   ./kamal.sh setup
+
+  ADMIN_PASSWORD="$(openssl rand -base64 18)"   # not in shell history; print it below
   ./kamal.sh app exec 'bin/rails db:schema:load:primary db:seed' \
-    -e DISABLE_DATABASE_ENVIRONMENT_CHECK:1
+    -e DISABLE_DATABASE_ENVIRONMENT_CHECK:1 \
+       DEFAULT_USER_EMAIL:you@example.com \
+       DEFAULT_USER_PASSWORD:"$ADMIN_PASSWORD"
+  echo "$ADMIN_PASSWORD"                        # sign in, then change it
+
   ./kamal.sh app boot   # restart on the schema you just loaded
   ```
+
+  **Supply the admin credentials.** `db/seeds.rb` falls back to
+  `admin@example.com` / `password123` and marks that user `system_admin`. That
+  is a convenience in development and a published login on a host that answers
+  on 443, so the seed *refuses* the fallback under `RAILS_ENV=production` and
+  tells you what to pass — a fresh install with no `DEFAULT_USER_PASSWORD` ends
+  with no admin rather than a known one. The engine seeds still run either way;
+  they mint their own credentials with `SecureRandom`.
+
+  These two are one-shot inputs to this command, not deployment settings.
+  Keeping them out of `.env.production` and `config/deploy.yml` is deliberate:
+  a `DEFAULT_USER_PASSWORD` that ships with every deploy would resurrect the
+  same standing credential this guard exists to remove.
 
   **`:primary` is load-bearing.** `production:` in `config/database.yml` names
   four configurations — primary, cache, queue, cable — and the plain

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -149,11 +149,23 @@ open, and nothing before it is waiting on it.
 ### A custom `DB_PASSWORD` is percent-encoded in `DATABASE_URL`
 
 The generated password is alphanumeric, so it appears in `DATABASE_URL`
-unchanged. A password you supply yourself may not be: `config/database.yml`
-runs `URI.parse(ENV["DATABASE_URL"])` on boot, and that rejects `@`, `/`, `#`,
-`%`, `?` and spaces in the user/password part outright — every Rails command in
-the container would abort with `URI::InvalidURIError` before it reached the
-database.
+unchanged. A password you supply yourself may not be — and the failure is not
+the loud one it looks like it should be. Measured against the resolver Rails
+actually uses (`ActiveRecord::DatabaseConfigurations::ConnectionUrlResolver`):
+
+```
+p@ss        URI::InvalidURIError    (likewise p#ss, p?ss, p%ss, "p ss")
+p@ss/word   parses — host "ss", database "word@172.17.0.1:5432/collavre_production"
+pa%41ss     parses — password "paAss"
+```
+
+Only a password with a *single* offending character aborts the boot. One
+holding `@` **and** `/` parses cleanly into a different host and a different
+database name, so the container fails to resolve a hostname in the middle of a
+deploy with nothing on screen pointing at the password. One containing a valid
+percent-escape is decoded, so Rails authenticates with a different string than
+the one in `/var/lib/collavre/db_password` — and reports only that the password
+was rejected.
 
 So the script percent-encodes the role, password and database name when it
 composes the URL. Rails decodes them again when it resolves the connection, so
@@ -546,10 +558,16 @@ KAMAL_SSH_USER=collavre
 KAMAL_SSH_KEY_PATH=~/.ssh/<key matching the instance>
 KAMAL_REGISTRY_USER=<docker hub user>
 KAMAL_REGISTRY_PASSWORD=<docker hub access token>
-DATABASE_URL=postgresql://collavre_user:<password>@172.17.0.1:5432/collavre_production
+DATABASE_URL=<the DATABASE_URL line from the summary file, copied verbatim>
 PORT=80
 SOLID_QUEUE_IN_PUMA=true
 ```
+
+`DATABASE_URL` is the one value here you must not compose yourself: the script
+already wrote it, [percent-encoded](#a-custom-db_password-is-percent-encoded-in-database_url),
+into the 0600 summary file. Assembling it from `/var/lib/collavre/db_password`
+puts the raw password into a URL, which — as measured above — is as likely to
+resolve to the wrong host as it is to fail outright.
 
 Keep the rest of `env.template` in mind — `RAILS_MASTER_KEY`, `SECRET_KEY_BASE`,
 the `ACTIVE_RECORD_ENCRYPTION_*` keys and the OAuth/S3/FCM credentials all still

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -48,7 +48,7 @@ Common overrides:
 
 | Variable | Default | Notes |
 | --- | --- | --- |
-| `SSH_PUBLIC_KEY` | *(empty)* | Empty = copy `ubuntu`'s `authorized_keys` |
+| `SSH_PUBLIC_KEY` | *(empty)* | Empty = copy `ubuntu`'s `authorized_keys`. [Changing it on a re-run](#rotating-ssh_public_key-on-a-re-run) withdraws the key it replaces |
 | `APP_SSH_USER` | `collavre` | Must match `KAMAL_SSH_USER`. Gets passwordless sudo — the maintenance commands below are sent non-interactively and cannot answer a prompt. [Changing it on a re-run](#changing-app_ssh_user-on-a-re-run) disarms the account it replaces |
 | `PG_MAJOR` | `17` | Match the source database when restoring a dump |
 | `DB_PASSWORD` | *(generated)* | Generated password is alphanumeric; a custom one is [percent-encoded into `DATABASE_URL`](#a-custom-db_password-is-percent-encoded-in-database_url) |
@@ -128,6 +128,29 @@ rotation by hand once you have confirmed you can reach the host as the new user:
 ```bash
 ssh <new-user>@<instance-ip> 'sudo deluser --remove-home <old-user>'
 ```
+
+### Rotating `SSH_PUBLIC_KEY` on a re-run
+
+The third member of the same family, on the same account. A re-run with a
+different `SSH_PUBLIC_KEY` adds the new key, and without anything further the
+old one stays in `authorized_keys` — and that account is in `docker` with
+passwordless sudo, so the key you believed you retired is still root on the
+box. Rotating away from a leaked key would have withdrawn nothing while
+reporting success.
+
+So the run withdraws the key it installed last time, recorded in
+`/var/lib/collavre/ssh_public_key`. Only that exact line goes: keys you added
+by hand, and the cloud user's original key, are matched whole-line and left
+alone. The withdrawal happens *after* the new key is in place, so an
+interrupted run leaves two working keys rather than none.
+
+Two cases deliberately do nothing. A re-run with `SSH_PUBLIC_KEY` unset means
+"keep using the cloud user's keys", not "retire mine" — dropping the variable
+from a re-run is easy, and treating it as a rotation would strand you. And if
+the rewrite cannot be completed (a full disk is the realistic way), the script
+says so, leaves the old key authorized, and leaves the marker alone so the next
+run tries again. Both directions are the safe one: the cost is a key that
+outlives its rotation and is reported, rather than a host with no key at all.
 
 ### Changing `DB_USER` on a re-run
 

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -49,7 +49,7 @@ Common overrides:
 | Variable | Default | Notes |
 | --- | --- | --- |
 | `SSH_PUBLIC_KEY` | *(empty)* | Empty = copy `ubuntu`'s `authorized_keys` |
-| `APP_SSH_USER` | `collavre` | Must match `KAMAL_SSH_USER` |
+| `APP_SSH_USER` | `collavre` | Must match `KAMAL_SSH_USER`. Gets passwordless sudo — the maintenance commands below are sent non-interactively and cannot answer a prompt |
 | `PG_MAJOR` | `17` | Match the source database when restoring a dump |
 | `DB_PASSWORD` | *(generated)* | Generated password is alphanumeric; a custom one is [percent-encoded into `DATABASE_URL`](#a-custom-db_password-is-percent-encoded-in-database_url) |
 | `SWAP_SIZE_MB` | `2048` | `0` disables |
@@ -355,6 +355,7 @@ both the Lightsail firewall and ufw (the script already allows 443).
 | Launch script did nothing | `/var/log/collavre-launch.log`, `/var/log/cloud-init-output.log` |
 | `kamal` can't SSH | `sudo cat /home/collavre/.ssh/authorized_keys` — empty means no `SSH_PUBLIC_KEY` and no key to copy |
 | `kamal` SSH works, Docker denied | Reconnect: `docker` group membership needs a new session |
+| `sudo: a password is required` | The deploy user has no password, so `%sudo` alone cannot authenticate it. `sudo ls /etc/sudoers.d/90-collavre-*` from the `ubuntu` account — missing means the host predates that grant; re-run the launch script with `FORCE=1` |
 | App: `could not connect to server` | `sudo ss -lntp \| grep 5432` should show `127.0.0.1:5432` **and** `172.17.0.1:5432` |
 | App: `password authentication failed` | `sudo cat /var/lib/collavre/db_password` vs `DATABASE_URL` — the URL holds the [percent-encoded](#a-custom-db_password-is-percent-encoded-in-database_url) form |
 | PostgreSQL won't start after reboot | `sysctl net.ipv4.ip_nonlocal_bind` must be `1`; `journalctl -u postgresql@17-main` |

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -317,23 +317,31 @@ container polling the database they are about to replace.
   ```bash
   ./kamal.sh setup
   ./kamal.sh app stop   # no writes while the schema is dropped and reloaded
+  stop_status=$?
 
   # The task reads the SQLite file from inside the container. /rails/storage is
   # the plan42_storage volume, shared by every container of the app, and uid
   # 1000 is the image's `rails` user.
   # Stage under a temporary name and rename into place, so the task can only
   # ever see a complete file. stage_status covers the whole staging step.
-  scp storage/production-primary.sqlite3 collavre@<instance-ip>:/tmp/ &&
-    ssh collavre@<instance-ip> \
-      'vol="$(docker volume inspect plan42_storage --format "{{.Mountpoint}}")" &&
-       sudo install -o 1000 -g 1000 -m 0600 /tmp/production-primary.sqlite3 \
-         "$vol/production-primary.sqlite3.incoming" &&
-       sudo mv "$vol/production-primary.sqlite3.incoming" \
-               "$vol/production-primary.sqlite3" &&
-       rm /tmp/production-primary.sqlite3'
-  stage_status=$?
+  stage_status=1
+  if [ "$stop_status" -eq 0 ]; then
+    scp storage/production-primary.sqlite3 collavre@<instance-ip>:/tmp/ &&
+      ssh collavre@<instance-ip> \
+        'vol="$(docker volume inspect plan42_storage --format "{{.Mountpoint}}")" &&
+         sudo install -o 1000 -g 1000 -m 0600 /tmp/production-primary.sqlite3 \
+           "$vol/production-primary.sqlite3.incoming" &&
+         sudo mv "$vol/production-primary.sqlite3.incoming" \
+                 "$vol/production-primary.sqlite3" &&
+         rm /tmp/production-primary.sqlite3'
+    stage_status=$?
+  fi
 
-  if [ "$stage_status" -ne 0 ]; then
+  if [ "$stop_status" -ne 0 ]; then
+    echo "STOP FAILED: a container may still be serving and polling this database"
+    echo "nothing was staged, granted or converted"
+    echo "check './kamal.sh app details' before retrying — do not convert while it runs"
+  elif [ "$stage_status" -ne 0 ]; then
     echo "STAGING FAILED: nothing was granted and nothing was converted"
     echo "the volume still holds whatever was there before — on a retry that is"
     echo "the stale snapshot the previous attempt deliberately kept"
@@ -444,15 +452,23 @@ container polling the database they are about to replace.
   ```bash
   ./kamal.sh setup
   ./kamal.sh app stop   # no reads or writes while the schema is dropped and reloaded
+  stop_status=$?
 
   ADMIN_PASSWORD="$(openssl rand -base64 18)"   # not in shell history; print it below
-  ./kamal.sh app exec 'bin/rails db:schema:load:primary db:seed' \
-    -e DISABLE_DATABASE_ENVIRONMENT_CHECK:1 \
-       DEFAULT_USER_EMAIL:you@example.com \
-       DEFAULT_USER_PASSWORD:"$ADMIN_PASSWORD"
-  load_status=$?
+  load_status=1
+  if [ "$stop_status" -eq 0 ]; then
+    ./kamal.sh app exec 'bin/rails db:schema:load:primary db:seed' \
+      -e DISABLE_DATABASE_ENVIRONMENT_CHECK:1 \
+         DEFAULT_USER_EMAIL:you@example.com \
+         DEFAULT_USER_PASSWORD:"$ADMIN_PASSWORD"
+    load_status=$?
+  fi
 
-  if [ "$load_status" -eq 0 ]; then
+  if [ "$stop_status" -ne 0 ]; then
+    echo "STOP FAILED: a container may still be serving and polling this database"
+    echo "nothing was loaded; the schema is whatever the migration replay produced"
+    echo "check './kamal.sh app details' before retrying — do not load while it runs"
+  elif [ "$load_status" -eq 0 ]; then
     echo "$ADMIN_PASSWORD"   # sign in, then change it
     ./kamal.sh app boot      # restart on the schema you just loaded
   else
@@ -490,6 +506,17 @@ container polling the database they are about to replace.
   argument for stopping rather than for timing it well. It also settles what
   happens to anything written between `setup` and the load: the schema is
   replaced either way, so there is no point letting a request believe otherwise.
+
+  **Which is why the load is gated on the stop, not merely preceded by it.**
+  Everything in the paragraph above is an argument about a container that is
+  still running — so it applies unchanged when `app stop` is the thing that
+  failed. Unreachable host, a docker daemon that will not answer, a role that
+  cannot stop the container: the command returns nonzero, the container keeps
+  serving and polling, and with no `set -e` the next line drops every table
+  underneath it. Adding the `app stop` fixed the case where nobody ran it;
+  gating on it fixes the case where it ran and did not work. `kamal app stop`
+  is idempotent, so the recovery is to fix whatever broke it, run it again, and
+  carry on — nothing was loaded.
 
   **Supply the admin credentials.** `db/seeds.rb` falls back to
   `admin@example.com` / `password123` and marks that user `system_admin`. That
@@ -575,10 +602,38 @@ sudo /usr/local/bin/collavre-pg-backup          # run one now
 systemctl list-timers collavre-pg-backup.timer  # check schedule
 journalctl -u collavre-pg-backup.service        # check last run
 
-# restore
+# restore — stop the app FIRST, from your workstation:
+#   ./kamal.sh app stop
+# then, on the instance:
 sudo -u postgres pg_restore --clean --if-exists -d collavre_production \
   /var/backups/collavre/collavre_production-YYYYmmdd-HHMMSS.dump
+restore_status=$?
+
+if [ "$restore_status" -eq 0 ]; then
+  echo "restored; boot the app from your workstation: ./kamal.sh app boot"
+else
+  echo "RESTORE FAILED: objects may be dropped or only partly reloaded"
+  echo "leave the app stopped and work out what happened before booting it"
+fi
 ```
+
+**`pg_restore --clean` drops every object before recreating it**, so this is the
+same hazard as the schema load in [§5](#5-first-deploy) and wants the same
+treatment: `app stop` first, `app boot` only after it succeeds. A live Puma and
+the in-process Solid Queue poller (`SOLID_QUEUE_IN_PUMA` defaults to `true`)
+would otherwise be querying tables as they are dropped — requests failing
+against relations that no longer exist, and, worse, writes landing in the window
+between a table being recreated and its rows being copied back in. Those writes
+are not rolled back by anything; they are simply overwritten or left orphaned
+depending on when they arrive, and a restore that reports success is what you
+are left looking at.
+
+Unlike the recipes in §5, the two halves run in different places — `app stop`
+and `app boot` from your workstation where `kamal.sh` and the env file live, the
+`pg_restore` on the instance — so this is deliberately three steps rather than
+one block. `pg_restore --clean --if-exists` is re-runnable, so a failed restore
+is fixed by fixing the cause and running it again, not by booting to look
+around.
 
 Local dumps die with the instance. Enable `BACKUP_S3_URI`, or take a Lightsail
 snapshot schedule, before this host holds real customer data.

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -172,11 +172,24 @@ the SQLite converter needs the app image and so runs after it, app stopped.
 - **Coming from SQLite:** `bin/rails db:sqlite_to_postgres[...]`
   (`lib/tasks/db_convert.rake`). Like the fresh install below, this one runs
   *after* `./kamal.sh setup`, because the app container is the only place that
-  can reach both ends. `DATABASE_URL` names `172.17.0.1`, which by design
-  answers only on the host, so running the task from your workstation dials
-  your own machine instead — and overriding the URL on the command line does
-  not help, because `config/boot.rb` uses `Dotenv.overload`: `.env.production`
-  puts `172.17.0.1` back over whatever you passed.
+  can reach both ends.
+
+  Running it from your workstation cannot work, and no `DATABASE_URL` fixes
+  that. `172.17.0.1` from your machine is your own Docker bridge or nothing,
+  and pointing at the instance's public address fails too: this server sets
+  `listen_addresses = 'localhost,172.17.0.1'`, so it accepts nothing on the
+  public interface, with the ufw rule (Docker range only) as a second layer.
+
+  The only route from outside is an SSH tunnel to the instance's
+  `127.0.0.1:5432`. That works, but it streams the whole copy over the tunnel
+  and still needs the superuser grant below, so the container is both faster
+  and simpler. If you do tunnel, watch `RAILS_ENV`: `config/boot.rb` calls
+  `Dotenv.overload(".env.$RAILS_ENV")`, which clobbers only the keys the file
+  it loads defines. With `RAILS_ENV=production` exported, `.env.production`
+  puts `172.17.0.1` back over the `DATABASE_URL` you passed on the command
+  line; without it dotenv reads `.env.development` and your override survives.
+  Either way the tunnel does not get you the superuser the copy needs — that
+  is what `MIGRATION_RUN_USER` is for, and dotenv never touches it.
 
   ```bash
   ./kamal.sh setup

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -1671,6 +1671,7 @@ both the Lightsail firewall and ufw (the script already allows 443).
 | Symptom | Check |
 | --- | --- |
 | Launch script did nothing | `/var/log/collavre-launch.log`, `/var/log/cloud-init-output.log` |
+| SSH hardening says there is no active sshd and disk verification failed | Keep the current session open and run `sudo install -d -o root -g root -m 0755 /run/sshd`, then `sudo /usr/sbin/sshd -t`. Ubuntu 24.04 creates this runtime directory when socket activation starts `ssh.service`; older copies of the launch script could test the configuration before that happened. Re-run only after `sshd -t` succeeds. |
 | `kamal` can't SSH | `sudo cat /home/collavre/.ssh/authorized_keys` — empty means no `SSH_PUBLIC_KEY` and no key to copy |
 | `kamal` SSH works, Docker denied | Reconnect: `docker` group membership needs a new session |
 | `sudo: a password is required` | The deploy user has no password, so `%sudo` alone cannot authenticate it. `sudo ls /etc/sudoers.d/90-collavre-*` from the `ubuntu` account — missing means the host predates that grant; re-run the launch script with `FORCE=1` **and every setting in `/var/lib/collavre/launch.env`**, or the re-run is refused |

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -53,7 +53,7 @@ Common overrides:
 | `PG_MAJOR` | `17` | Match the source database when restoring a dump |
 | `DB_PASSWORD` | *(generated)* | Generated password is URL-safe |
 | `SWAP_SIZE_MB` | `2048` | `0` disables |
-| `BACKUP_S3_URI` | *(empty)* | e.g. `s3://collavre-backups/pg` |
+| `BACKUP_S3_URI` | *(empty)* | e.g. `s3://collavre-backups/pg` — PostgreSQL only, [not uploaded files](#backup_s3_uri-does-not-cover-uploaded-files) |
 
 It also runs fine by hand on an existing instance, and re-running converges the
 host instead of duplicating config:
@@ -206,6 +206,33 @@ sudo -u postgres pg_restore --clean --if-exists -d collavre_production \
 
 Local dumps die with the instance. Enable `BACKUP_S3_URI`, or take a Lightsail
 snapshot schedule, before this host holds real customer data.
+
+### `BACKUP_S3_URI` does not cover uploaded files
+
+The nightly job dumps PostgreSQL and nothing else. Whether that is the whole of
+your data depends on how Active Storage resolved at boot: `production.rb` picks
+`:amazon` only when a **complete** S3 credential pair is available — from
+`AWS_S3_ACCESS_KEY_ID` / `AWS_S3_SECRET_ACCESS_KEY`, or from the pair saved in
+admin settings — and falls back to `:local` otherwise. There is no warning when
+it falls back; the app runs identically either way.
+
+On `:local`, every uploaded file and attachment is written inside the container
+to `/rails/storage`, which `config/deploy.yml` maps to the named Docker volume
+`plan42_storage`. That volume outlives redeploys, so nothing looks wrong day to
+day — but it lives on the instance's disk, is not in the dump, and is not
+touched by the backup script. Restoring `BACKUP_S3_URI` onto a fresh instance
+gives you a database whose `active_storage_blobs` rows all point at files that
+no longer exist.
+
+Pick one before going live:
+
+- **Configure app S3** (`AWS_S3_*` in `.env.production`, or admin settings), so
+  blobs are off-instance to begin with and the dump really is the whole backup.
+- **Or add a Lightsail snapshot schedule**, which captures the disk — volume
+  included — and covers both halves at once.
+
+A snapshot schedule is worth having regardless: it is the only thing that
+restores the host itself.
 
 ## 7. TLS
 

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -152,7 +152,8 @@ first deploy**, while the database is still reachable without the app:
 
   ```bash
   ./kamal.sh setup
-  ./kamal.sh app exec 'bin/rails db:schema:load db:seed'
+  ./kamal.sh app exec 'bin/rails db:schema:load db:seed' \
+    -e DISABLE_DATABASE_ENVIRONMENT_CHECK:1
   ./kamal.sh app boot   # restart on the schema you just loaded
   ```
 
@@ -160,6 +161,15 @@ first deploy**, while the database is still reachable without the app:
   the replayed tables instead of colliding with them, and it stamps
   `schema_migrations` up to the schema version — the next boot's `db:migrate`
   is a no-op.
+
+  `DISABLE_DATABASE_ENVIRONMENT_CHECK` is not optional here. `db:schema:load`
+  runs `check_protected_environments` first, which aborts with
+  `ActiveRecord::ProtectedEnvironmentError` once the database records
+  `production` in `ar_internal_metadata` — which is exactly what the replay in
+  the preceding `setup` just wrote. Note the flag *trails* the command: `-e`
+  takes a Thor hash and greedily consumes every following argument containing a
+  colon, so putting it first would swallow `bin/rails db:schema:load db:seed`
+  into the hash and leave kamal with no command to run.
 
   This still works when the replay *fails* and `setup` dies at `app boot`: the
   env file and the network are uploaded before the container is started, and

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -169,12 +169,23 @@ with its `sudoers.d` grant. Docker membership is the part that matters:
 not been rotated away from in any meaningful sense — it has only lost the
 slower route.
 
-What the script will not do is delete the account or its `authorized_keys`. Its
-only view of the host is the deploy user recorded in
-`/var/lib/collavre/deploy_user`, and if that name were ever the instance's own
-cloud user, deleting it would remove the last way in. So the run leaves an
-ordinary, group-less account behind and says so in the launch log. Finish the
-rotation by hand once you have confirmed you can reach the host as the new user:
+Every account the script grants those groups to is recorded in
+`/var/lib/collavre/deploy_users` **before** the grant is made, and a name leaves
+that file only once the host confirms it holds neither group. Both halves are
+load-bearing. Recorded before, because the grants are in step 3 and step 4 while
+the revocation is at the end of step 4 — a run interrupted across the Docker
+install would otherwise leave the new account holding root-equivalent access
+with nothing on the host naming it. A list rather than one name, because a
+revocation that fails has to be retried without pinning the record to the
+account it failed on: pinning it is how a second rotation walks past the account
+in between and loses it. `/var/lib/collavre/deploy_user` still names the current
+deploy user, which is what the recipes on this page read.
+
+What the script will not do is delete the account or its `authorized_keys`. If
+the name it replaced were ever the instance's own cloud user, deleting it would
+remove the last way in. So the run leaves an ordinary, group-less account behind
+and says so in the launch log. Finish the rotation by hand once you have
+confirmed you can reach the host as the new user:
 
 ```bash
 ssh <new-user>@<instance-ip> 'sudo deluser --remove-home <old-user>'

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -195,25 +195,32 @@ that an external client can log in: `Match`, `Include`, admission rules, key
 paths, source addresses, and future sshd directives make that an open-ended
 problem.
 
-The root-only summary therefore contains a one-time command like this:
+The root-only summary therefore contains a one-time signed command like this:
 
 ```bash
-ssh -i ~/.ssh/<staged-key> <new-user>@<instance-ip> \
-  "sudo /usr/local/sbin/collavre-finalize-ssh-cutover --finalize-ssh-cutover '<nonce>'"
+key=~/.ssh/<staged-key>
+nonce='<nonce>'
+signature="$(printf 'collavre-ssh-cutover:%s:%s' '<new-user>' "$nonce" |
+  ssh-keygen -Y sign -f "$key" -n collavre-ssh-cutover 2>/dev/null |
+  base64 | tr -d '\n')"
+ssh -i "$key" <new-user>@<instance-ip> \
+  "sudo /usr/local/sbin/collavre-finalize-ssh-cutover \
+    --finalize-ssh-cutover '$nonce' '$signature'"
 ```
 
 Run that exact command from the workstation with the key Kamal will use. The
-finalizer checks that it is running through an `sshd` process tree containing
-an `sshd` session process owned by the staged account, that `SUDO_USER` is that
-account, that its `SSH_USER_AUTH` record is owned by the same account, and that
-the nonce matches. This rejects a nested `sudo -u <staged-user>` launched from
-the predecessor's SSH session. For an explicit key rotation it also requires
-the authentication record's public-key fingerprint to match the staged key;
-logging in with the predecessor key cannot finalize the rotation. Provisioning
-verifies that `ExposeAuthInfo yes` is effective before every cutover, and stores
-the nonce hash, fingerprint, and exact key in one atomic root-only pending
-record so an interrupted re-run cannot mix cutover generations. Only then does
-it take `docker` and `sudo` from every predecessor,
+local `ssh-keygen` signs the nonce and staged username with that private key;
+the signature travels only as an argument to the SSH command, so a failed
+staged-account login never invokes the finalizer. The host verifies the
+signature against the public keys captured atomically when the cutover was
+staged. This is the security boundary: the predecessor is root-equivalent and
+can forge host-local process names, environment variables, and files, but it
+cannot synthesize the workstation's private-key signature. For an explicit key
+rotation, only that exact staged key is accepted; for copied cloud keys, any
+valid key installed for the successor may sign. The nonce hash, accepted
+signing keys, fingerprint, and exact rotation key live in one atomic root-only
+pending record so an interrupted re-run cannot mix cutover generations. Only
+then does the finalizer take `docker` and `sudo` from every predecessor,
 remove their script-managed
 `sudoers.d` grants, withdraw predecessor managed keys, and commit
 `/var/lib/collavre/deploy_user`. Change `KAMAL_SSH_USER` only after the command

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -750,11 +750,32 @@ journalctl -u collavre-pg-backup.service        # check last run
 # connects; a container that survived the stop, or restarts mid-restore, cannot.
 sudo -u postgres psql -qd postgres -c \
   "ALTER DATABASE collavre_production CONNECTION LIMIT 0"
+
+# Read the limit back rather than trusting that the line above ran. These
+# blocks are pasted into an interactive shell with no `set -e`, so a failed
+# ALTER just scrolls past — and if nothing happens to be attached a moment
+# later, the count below reads 0 and the restore starts against a database
+# that was never shut. `datconnlimit` is the state itself, so it cannot say
+# "closed" about a door that is open.
+shut=$(sudo -u postgres psql -qtAd postgres -c \
+  "SELECT datconnlimit FROM pg_database WHERE datname = 'collavre_production'")
+
+if [ "$shut" != 0 ]; then
+  echo "REFUSING: could not shut collavre_production to the app."
+  echo "  its connection limit is '$shut', not 0 — the ALTER above did not take"
+  echo "  (wrong database name? not superuser? cluster gone?)"
+  echo "nothing was dropped; fix that and re-run this block"
+  # Its own status, not the refusal below: this block never shut the database,
+  # so it must not "re-open" it either — that would lift a limit the operator
+  # may have set themselves.
+  restore_status=3
+else
+
 sudo -u postgres psql -qtAd postgres -c \
   "SELECT count(pg_terminate_backend(pid)) FROM pg_stat_activity
     WHERE datname = 'collavre_production' AND pid <> pg_backend_pid()"
 
-# Now check, with the door already shut — a point-in-time count taken before
+# Now check, with the door confirmed shut — a point-in-time count taken before
 # this would only have said the app happened to be between connections.
 live=$(sudo -u postgres psql -qtA -d postgres -c \
   "SELECT count(*) FROM pg_stat_activity
@@ -778,11 +799,14 @@ else
   restore_status=$?
 fi
 
-# Re-open on the two paths where the database is whole — a restore that
-# succeeded, and a refusal that touched nothing. A database left at CONNECTION
-# LIMIT 0 refuses the app at boot with "too many connections", which reads like
-# a pool problem and not like a step this block forgot to undo, so it must not
-# be left shut by accident. On the failure path it is left shut on purpose.
+fi
+
+# Re-open on the two paths where this block shut the door and the database is
+# whole — a restore that succeeded, and a refusal that touched nothing. A
+# database left at CONNECTION LIMIT 0 refuses the app at boot with "too many
+# connections", which reads like a pool problem and not like a step this block
+# forgot to undo, so it must not be left shut by accident. On the failure path
+# it is left shut on purpose; on status 3 it was never shut to begin with.
 if [ "$restore_status" -eq 0 ] || [ "$restore_status" -eq 2 ]; then
   sudo -u postgres psql -qd postgres -c \
     "ALTER DATABASE collavre_production CONNECTION LIMIT -1"
@@ -790,7 +814,7 @@ fi
 
 if [ "$restore_status" -eq 0 ]; then
   echo "restored; boot the app from your workstation: ./kamal.sh app boot"
-elif [ "$restore_status" -eq 2 ]; then
+elif [ "$restore_status" -eq 2 ] || [ "$restore_status" -eq 3 ]; then
   : # refused before touching anything — see the message above
 else
   echo "RESTORE FAILED: objects may be dropped or only partly reloaded."

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -61,8 +61,46 @@ host instead of duplicating config:
 
 ```bash
 sudo SSH_PUBLIC_KEY="ssh-ed25519 AAAA..." bash script/lightsail_launch.sh
-sudo FORCE=1 bash script/lightsail_launch.sh   # after the first success
+# after the first success — repeat what you gave it, including the key:
+sudo SSH_PUBLIC_KEY="ssh-ed25519 AAAA..." FORCE=1 bash script/lightsail_launch.sh
 ```
+
+**A re-run applies every setting in the table, not only the ones you name.** An
+override you used the first time and did not repeat is applied as its default,
+and three of those defaults do not converge the host — they rotate it.
+`APP_SSH_USER` back to `collavre` arms a new account and takes `docker`, `sudo`
+and the `sudoers.d` grant from the one your `KAMAL_SSH_USER` names; `DB_USER`
+back to `collavre_user` moves table ownership and takes `LOGIN` from the role
+in the deployed `DATABASE_URL`. An omitted `SSH_PUBLIC_KEY` means "reuse the
+cloud user's key", so the run copies `ubuntu`'s `authorized_keys` into the
+deploy account — the account with passwordless `sudo` and `docker` — which is
+why the bare `sudo FORCE=1 bash script/lightsail_launch.sh` you may have run
+before now stops instead: on a host provisioned with the line above, that is
+the ordinary re-run, and the widening is what it would do first. A defaulted
+`BACKUP_S3_URI` is the quiet one: it regenerates the nightly job without the
+upload, so dumps keep being written and stop leaving the instance.
+
+So the re-run is refused when a setting it was *not given* disagrees with what
+the host was provisioned with. Giving the value is what makes it an
+instruction, so the deliberate rotations documented below are never refused;
+only the omission is. The refusal changes nothing and prints the command that
+converges the host as it stands:
+
+```
+!!! REFUSING: this run would change settings it was not asked to change.
+    APP_SSH_USER: host has 'deploybot', this run would apply 'collavre'
+    BACKUP_S3_URI: host has 's3://collavre-backups/pg', this run would apply ''
+...
+    sudo APP_SSH_USER=deploybot BACKUP_S3_URI=s3://collavre-backups/pg FORCE=1 bash script/lightsail_launch.sh
+```
+
+`ACK_CONFIG_RESET=1` goes ahead with the defaults, for when resetting them is
+what you meant. The host's own record is `/var/lib/collavre/launch.env`, which
+is also the answer to "what did I provision this with?" — read it before a
+re-run rather than after one. On a host provisioned before that file existed,
+`APP_SSH_USER` and `DB_USER` are still checked, against
+`/var/lib/collavre/deploy_user` and `/var/lib/collavre/db_user`; the rest are
+unknowable until the next successful run records them.
 
 Converging means the firewall too: a re-run adds and updates only the rules the
 script owns (SSH, 80, 443, and 5432 from the Docker bridge), so a VPN,
@@ -359,7 +397,11 @@ database that no longer exists. It fails, `collavre-pg-backup.service` goes red,
 and nothing new lands in `/var/backups/collavre`: the one failure on this page
 you discover by needing a dump and not having one. Pass the name explicitly,
 because `DB_NAME` still defaults to `collavre_production` and a plain re-run is
-now refused by the marker you just wrote. If you would rather not re-run
+now refused by the marker you just wrote. Any *other* override this host was
+provisioned with has to be repeated on that same command line — the re-run
+[stops and lists them](#2-create-the-instance-with-the-launch-script) rather
+than resetting them, so you are told, but being told mid-rename is worse than
+reading `/var/lib/collavre/launch.env` first. If you would rather not re-run
 provisioning, edit the `DB_NAME=` line in `/usr/local/bin/collavre-pg-backup`
 and prove it rather than assume it:
 
@@ -466,6 +508,19 @@ need; the instance also has its own `ubuntu` cloud user, and `collavre` may not
 exist at all. `sudo cat /var/lib/collavre/deploy_user` on the instance is the
 host's own answer if you are unsure.
 
+`<db-user>` and `<db-name>` are the same kind of placeholder, for the same
+reason: `DB_USER` and `DB_NAME` are overridable at provisioning time, and
+`DB_NAME` also changes under the [rename procedure](#changing-db_name-on-a-re-run).
+A role that does not exist fails these recipes at their first statement, and a
+database name that does not exist is worse in the import below, which creates
+nothing and reports the miss as a connection error. The instance answers for
+both, and the launch summary repeats them:
+
+```bash
+sudo cat /var/lib/collavre/db_user   # <db-user>
+sudo cat /var/lib/collavre/db_name   # <db-name>
+```
+
 - **Moving an existing PostgreSQL deployment (Neon, RDS):** dump and restore.
   Match `PG_MAJOR` to the source server's major version or the restore may fail.
 
@@ -501,8 +556,8 @@ host's own answer if you are unsure.
     scp collavre.dump <deploy-user>@<instance-ip>:/tmp/collavre.dump.incoming &&
     ssh <deploy-user>@<instance-ip> \
       'mv /tmp/collavre.dump.incoming /tmp/collavre.dump &&
-       pg_restore --no-owner --role=collavre_user --clean --if-exists \
-         -d "postgresql://collavre_user:<password>@127.0.0.1:5432/collavre_production" \
+       pg_restore --no-owner --role=<db-user> --clean --if-exists \
+         -d "postgresql://<db-user>:<password>@127.0.0.1:5432/<db-name>" \
          /tmp/collavre.dump &&
        rm /tmp/collavre.dump'
   move_status=$?
@@ -584,7 +639,7 @@ host's own answer if you are unsure.
   else
     # The copy disables referential integrity, which is superuser-only.
     ssh <deploy-user>@<instance-ip> \
-      "sudo -u postgres psql -c 'ALTER ROLE collavre_user SUPERUSER'"
+      "sudo -u postgres psql -c 'ALTER ROLE <db-user> SUPERUSER'"
 
     ./kamal.sh app exec \
       'bin/rails "db:sqlite_to_postgres[storage/production-primary.sqlite3,production]"' \
@@ -594,7 +649,7 @@ host's own answer if you are unsure.
     # Take the grant back whether or not the copy worked — a failed cutover is
     # precisely when it would otherwise sit there.
     ssh <deploy-user>@<instance-ip> \
-      "sudo -u postgres psql -c 'ALTER ROLE collavre_user NOSUPERUSER'"
+      "sudo -u postgres psql -c 'ALTER ROLE <db-user> NOSUPERUSER'"
     revoke_status=$?
 
     # Clean up and boot only if both worked. Either failure leaves the app down.
@@ -606,7 +661,7 @@ host's own answer if you are unsure.
       ./kamal.sh app boot   # restart on the data you just loaded
     else
       [ "$revoke_status" -eq 0 ] ||
-        echo "REVOKE FAILED: collavre_user is still a superuser — take it back by hand"
+        echo "REVOKE FAILED: <db-user> is still a superuser — take it back by hand"
       [ "$copy_status" -eq 0 ] ||
         echo "COPY FAILED: this database is now empty or half-loaded"
       echo "app left stopped on purpose; do not boot it until the above is cleared"
@@ -844,15 +899,41 @@ journalctl -u collavre-pg-backup.service        # check last run
 # CONNECTION LIMIT 0 does not apply to superusers, so pg_restore below still
 # connects; a container that survived the stop, or restarts mid-restore, cannot.
 
-# First, whether that last clause is true on THIS host. The exemption that lets
+# Which database, and which role, before anything is asked about either. Both
+# are the host's answer rather than this page's: `DB_NAME` is overridable at
+# provisioning time and the rename procedure above makes it the operator's, so
+# a literal here would shut, count, terminate and restore a database that is
+# not the one holding the data — and every one of those steps would report
+# success against the wrong name or fail for a reason that reads like a
+# cluster problem.
+# `${app_db:-...}` rather than a plain assignment, so the recovery the refusal
+# below prints is one the block actually honours: setting app_db in the shell
+# and pasting again has to survive this line, or the instruction is a dead end.
+app_db=${app_db:-$(sudo cat /var/lib/collavre/db_name 2>/dev/null)}
+app_role=$(sudo cat /var/lib/collavre/db_user 2>/dev/null)
+
+# Then whether that last clause is true on THIS host. The exemption that lets
 # pg_restore in is role-wide, so it lets the app in too whenever the app's own
 # role is a superuser — and `DB_USER=postgres` on a first run is legal (see
 # "Changing DB_USER on a re-run"). Refusing before the ALTER rather than after
 # it, so a refusal leaves the connection limit exactly as the operator had it.
-app_role=$(sudo cat /var/lib/collavre/db_user 2>/dev/null)
 app_super=$(sudo -u postgres psql -qtAd postgres -c \
   "SELECT rolsuper FROM pg_roles WHERE rolname = '$app_role'" 2>/dev/null)
-if [ "$app_super" != f ]; then
+if [ -z "$app_db" ]; then
+  echo "REFUSING: cannot tell which database to restore."
+  echo "  /var/lib/collavre/db_name is missing or unreadable. That file is"
+  echo "  written by script/lightsail_launch.sh once the database exists, so an"
+  echo "  empty answer means this host was provisioned by a revision that"
+  echo "  predates it, or the read failed. Falling back to the default name is"
+  echo "  the one thing this block must not do: on a host that used DB_NAME, or"
+  echo "  the rename procedure, the default names a database that either does"
+  echo "  not exist or is not the live one."
+  echo "Nothing was changed. Confirm the name, then set it for this block:"
+  echo "  sudo -u postgres psql -qtAd postgres -c \\"
+  echo "    \"SELECT datname FROM pg_database WHERE NOT datistemplate\""
+  echo "  app_db=<the database>   # then re-run this block"
+  restore_status=3
+elif [ "$app_super" != f ]; then
   echo "REFUSING: cannot shut this database to the app."
   echo "  DB_USER is '$app_role' and its rolsuper is '$app_super' — anything but"
   echo "  'f' means the gate below cannot tell your app apart from pg_restore,"
@@ -869,7 +950,7 @@ if [ "$app_super" != f ]; then
 else
 
 sudo -u postgres psql -qd postgres -c \
-  "ALTER DATABASE collavre_production CONNECTION LIMIT 0"
+  "ALTER DATABASE $app_db CONNECTION LIMIT 0"
 
 # Read the limit back rather than trusting that the line above ran. These
 # blocks are pasted into an interactive shell with no `set -e`, so a failed
@@ -878,10 +959,10 @@ sudo -u postgres psql -qd postgres -c \
 # that was never shut. `datconnlimit` is the state itself, so it cannot say
 # "closed" about a door that is open.
 shut=$(sudo -u postgres psql -qtAd postgres -c \
-  "SELECT datconnlimit FROM pg_database WHERE datname = 'collavre_production'")
+  "SELECT datconnlimit FROM pg_database WHERE datname = '$app_db'")
 
 if [ "$shut" != 0 ]; then
-  echo "REFUSING: could not shut collavre_production to the app."
+  echo "REFUSING: could not shut $app_db to the app."
   echo "  its connection limit is '$shut', not 0 — the ALTER above did not take"
   echo "  (wrong database name? not superuser? cluster gone?)"
   echo "nothing was dropped; fix that and re-run this block"
@@ -893,29 +974,29 @@ else
 
 sudo -u postgres psql -qtAd postgres -c \
   "SELECT count(pg_terminate_backend(pid)) FROM pg_stat_activity
-    WHERE datname = 'collavre_production' AND pid <> pg_backend_pid()"
+    WHERE datname = '$app_db' AND pid <> pg_backend_pid()"
 
 # Now check, with the door confirmed shut — a point-in-time count taken before
 # this would only have said the app happened to be between connections.
 live=$(sudo -u postgres psql -qtA -d postgres -c \
   "SELECT count(*) FROM pg_stat_activity
-    WHERE datname = 'collavre_production' AND pid <> pg_backend_pid()")
+    WHERE datname = '$app_db' AND pid <> pg_backend_pid()")
 
 # A string comparison, not -ne: if the query above failed, $live is empty or an
 # error message, and `[ "$live" -ne 0 ]` would error and be read as false —
 # a gate that opens when the check breaks. Anything that is not exactly "0"
 # stops here.
 if [ "$live" != 0 ]; then
-  echo "REFUSING: collavre_production is not confirmed idle (check returned: '$live')."
+  echo "REFUSING: $app_db is not confirmed idle (check returned: '$live')."
   sudo -u postgres psql -d postgres -c \
     "SELECT usename, client_addr, state, query
-       FROM pg_stat_activity WHERE datname = 'collavre_production'"
+       FROM pg_stat_activity WHERE datname = '$app_db'"
   echo "run './kamal.sh app stop' on your workstation and check it succeeded"
   echo "nothing was dropped; re-run this block once the app is down"
   restore_status=2
 else
-  sudo -u postgres pg_restore --clean --if-exists -d collavre_production \
-    /var/backups/collavre/collavre_production-YYYYmmdd-HHMMSS.dump
+  sudo -u postgres pg_restore --clean --if-exists -d "$app_db" \
+    "/var/backups/collavre/$app_db-YYYYmmdd-HHMMSS.dump"
   restore_status=$?
 fi
 
@@ -932,7 +1013,7 @@ fi
 reopen_status=0
 if [ "$restore_status" -eq 0 ] || [ "$restore_status" -eq 2 ]; then
   sudo -u postgres psql -qd postgres -c \
-    "ALTER DATABASE collavre_production CONNECTION LIMIT -1"
+    "ALTER DATABASE $app_db CONNECTION LIMIT -1"
   reopen_status=$?
 fi
 
@@ -946,7 +1027,7 @@ fi
 # the restore's own outcome, because it is the one thing here that stands
 # between a good restore and an app that cannot reach it.
 if [ "$reopen_status" -ne 0 ]; then
-  echo "RE-OPEN FAILED: collavre_production is still at 'CONNECTION LIMIT 0'."
+  echo "RE-OPEN FAILED: $app_db is still at 'CONNECTION LIMIT 0'."
   if [ "$restore_status" -eq 0 ]; then
     echo "  The restore finished — the data is not what failed. Do not re-run"
     echo "  this block to clear it: pg_restore --clean would drop a good restore"
@@ -958,23 +1039,23 @@ if [ "$reopen_status" -ne 0 ]; then
   echo "  The app will be refused at boot with 'too many connections', which"
   echo "  will read like a pool problem. Do not boot it until this succeeds:"
   echo "  sudo -u postgres psql -qd postgres -c \\"
-  echo "    \"ALTER DATABASE collavre_production CONNECTION LIMIT -1\""
+  echo "    \"ALTER DATABASE $app_db CONNECTION LIMIT -1\""
   echo "  Confirm with:"
   echo "  sudo -u postgres psql -qtAd postgres -c \\"
-  echo "    \"SELECT datconnlimit FROM pg_database WHERE datname = 'collavre_production'\""
+  echo "    \"SELECT datconnlimit FROM pg_database WHERE datname = '$app_db'\""
 elif [ "$restore_status" -eq 0 ]; then
   echo "restored; boot the app from your workstation: ./kamal.sh app boot"
 elif [ "$restore_status" -eq 2 ] || [ "$restore_status" -eq 3 ]; then
   : # refused before touching anything — see the message above
 else
   echo "RESTORE FAILED: objects may be dropped or only partly reloaded."
-  echo "collavre_production is LEFT AT 'CONNECTION LIMIT 0' deliberately: it is"
+  echo "$app_db is LEFT AT 'CONNECTION LIMIT 0' deliberately: it is"
   echo "  now half-replaced, and a container that survived the stop must not"
   echo "  reconnect and write into it. pg_restore is a superuser and is exempt,"
   echo "  so fix the cause and run this block again — it needs no other step."
   echo "If instead you are abandoning the restore, re-open it by hand with:"
   echo "  sudo -u postgres psql -qd postgres -c \\"
-  echo "    \"ALTER DATABASE collavre_production CONNECTION LIMIT -1\""
+  echo "    \"ALTER DATABASE $app_db CONNECTION LIMIT -1\""
 fi
 ```
 

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -31,7 +31,7 @@ is the practical floor**; 2 GB works only for a light pilot. The script adds a
 > ```yaml
 > builder:
 >   arch: amd64
->   remote: ssh://collavre@<instance-ip>
+>   remote: ssh://<deploy-user>@<instance-ip>
 > ```
 >
 > The launch script installs buildx, so the remote builder works out of the box.
@@ -327,18 +327,53 @@ To actually move to a new name, do it deliberately and then tell the script:
 ```bash
 # on the instance, with the app stopped from your workstation:
 #   ./kamal.sh app stop
+#
+# One chain, so the marker cannot move past a rename that did not happen. As
+# two statements a failed ALTER — a session that survived `app stop` is the
+# usual cause, and its error scrolls past in an interactive shell with no
+# `set -e` — still records the new name, and the next launch-script run then
+# trusts that marker and creates an empty database under it. That is the
+# outcome this whole section exists to prevent, reached from the other side.
+#
+# The existence check is not redundant with the ALTER's status: it is what makes
+# the marker describe the cluster rather than describe a command that reported
+# success. `grep -qx` is the gate rather than psql's own status, so an empty
+# answer — a query that failed, a cluster that went away — fails closed.
 sudo -u postgres psql -qd postgres -c \
-  "ALTER DATABASE collavre_production RENAME TO collavre_prod"
-echo collavre_prod | sudo tee /var/lib/collavre/db_name
+  "ALTER DATABASE collavre_production RENAME TO collavre_prod" &&
+  sudo -u postgres psql -qtAd postgres -c \
+    "SELECT 1 FROM pg_database WHERE datname = 'collavre_prod'" | grep -qx 1 &&
+  echo collavre_prod | sudo tee /var/lib/collavre/db_name
 ```
 
 `RENAME TO` needs no other session connected — which is why the app has to be
 stopped first — and it keeps the same data, owner and grants, so nothing else
 has to be reissued. Update `DATABASE_URL` in `.env.production` to the new name
-and redeploy; re-running the launch script afterwards is optional and will now
-agree with the marker. Copying instead of renaming (a `pg_dump` into a new
-database) is the other option, and then the old one is yours to drop once you
-have checked the copy.
+and redeploy.
+
+**Then re-run the launch script with `DB_NAME=collavre_prod`.** That re-run is
+not optional. `/usr/local/bin/collavre-pg-backup` had the old name written into
+it when the script generated it, and redeploying the *application* does not
+regenerate a *host* script — so the nightly timer keeps calling `pg_dump` on a
+database that no longer exists. It fails, `collavre-pg-backup.service` goes red,
+and nothing new lands in `/var/backups/collavre`: the one failure on this page
+you discover by needing a dump and not having one. Pass the name explicitly,
+because `DB_NAME` still defaults to `collavre_production` and a plain re-run is
+now refused by the marker you just wrote. If you would rather not re-run
+provisioning, edit the `DB_NAME=` line in `/usr/local/bin/collavre-pg-backup`
+and prove it rather than assume it:
+
+```bash
+# The unit is Type=oneshot, so `start` blocks until it finishes and its own
+# status is the answer — `is-active` is not, because a oneshot that succeeded
+# reports "inactive" once it exits.
+sudo systemctl start collavre-pg-backup.service ||
+  systemctl status --no-pager collavre-pg-backup.service
+ls -l /var/backups/collavre
+```
+
+Copying instead of renaming (a `pg_dump` into a new database) is the other
+option, and then the old one is yours to drop once you have checked the copy.
 
 ### Changing `SWAP_SIZE_MB` on a re-run
 
@@ -422,6 +457,15 @@ the SQLite converter and the fresh-install schema load both need the app image
 and so run after it — with `./kamal.sh app stop` first, since `setup` leaves a
 container polling the database they are about to replace.
 
+`<deploy-user>` in the recipes below is `APP_SSH_USER` — `collavre` unless you
+overrode it, in which case it is the value you set and also what
+`KAMAL_SSH_USER` in `.env.production` has to say. It is written as a placeholder
+rather than spelled `collavre` because only that account is guaranteed to hold
+the key, the passwordless sudo grant and the `docker` membership these commands
+need; the instance also has its own `ubuntu` cloud user, and `collavre` may not
+exist at all. `sudo cat /var/lib/collavre/deploy_user` on the instance is the
+host's own answer if you are unsure.
+
 - **Moving an existing PostgreSQL deployment (Neon, RDS):** dump and restore.
   Match `PG_MAJOR` to the source server's major version or the restore may fail.
 
@@ -454,8 +498,8 @@ container polling the database they are about to replace.
 
   # one chain, so a failed dump or transfer cannot reach pg_restore --clean
   pg_dump --format=custom "$SOURCE_DATABASE_URL" -f collavre.dump &&
-    scp collavre.dump collavre@<instance-ip>:/tmp/collavre.dump.incoming &&
-    ssh collavre@<instance-ip> \
+    scp collavre.dump <deploy-user>@<instance-ip>:/tmp/collavre.dump.incoming &&
+    ssh <deploy-user>@<instance-ip> \
       'mv /tmp/collavre.dump.incoming /tmp/collavre.dump &&
        pg_restore --no-owner --role=collavre_user --clean --if-exists \
          -d "postgresql://collavre_user:<password>@127.0.0.1:5432/collavre_production" \
@@ -517,8 +561,8 @@ container polling the database they are about to replace.
   # ever see a complete file. stage_status covers the whole staging step.
   stage_status=1
   if [ "$stop_status" -eq 0 ]; then
-    scp storage/production-primary.sqlite3 collavre@<instance-ip>:/tmp/ &&
-      ssh collavre@<instance-ip> \
+    scp storage/production-primary.sqlite3 <deploy-user>@<instance-ip>:/tmp/ &&
+      ssh <deploy-user>@<instance-ip> \
         'vol="$(docker volume inspect plan42_storage --format "{{.Mountpoint}}")" &&
          sudo install -o 1000 -g 1000 -m 0600 /tmp/production-primary.sqlite3 \
            "$vol/production-primary.sqlite3.incoming" &&
@@ -539,7 +583,7 @@ container polling the database they are about to replace.
     echo "app left stopped on purpose; re-stage before converting"
   else
     # The copy disables referential integrity, which is superuser-only.
-    ssh collavre@<instance-ip> \
+    ssh <deploy-user>@<instance-ip> \
       "sudo -u postgres psql -c 'ALTER ROLE collavre_user SUPERUSER'"
 
     ./kamal.sh app exec \
@@ -549,13 +593,13 @@ container polling the database they are about to replace.
 
     # Take the grant back whether or not the copy worked — a failed cutover is
     # precisely when it would otherwise sit there.
-    ssh collavre@<instance-ip> \
+    ssh <deploy-user>@<instance-ip> \
       "sudo -u postgres psql -c 'ALTER ROLE collavre_user NOSUPERUSER'"
     revoke_status=$?
 
     # Clean up and boot only if both worked. Either failure leaves the app down.
     if [ "$copy_status" -eq 0 ] && [ "$revoke_status" -eq 0 ]; then
-      ssh collavre@<instance-ip> \
+      ssh <deploy-user>@<instance-ip> \
         'sudo rm "$(docker volume inspect plan42_storage \
            --format "{{.Mountpoint}}")/production-primary.sqlite3"'
 
@@ -885,12 +929,40 @@ fi
 # connections", which reads like a pool problem and not like a step this block
 # forgot to undo, so it must not be left shut by accident. On the failure path
 # it is left shut on purpose; on status 3 it was never shut to begin with.
+reopen_status=0
 if [ "$restore_status" -eq 0 ] || [ "$restore_status" -eq 2 ]; then
   sudo -u postgres psql -qd postgres -c \
     "ALTER DATABASE collavre_production CONNECTION LIMIT -1"
+  reopen_status=$?
 fi
 
-if [ "$restore_status" -eq 0 ]; then
+# The re-open is checked, not assumed. It is its own connection to the cluster
+# and fails on its own terms — the cluster restarted, the role lost superuser,
+# the database name is wrong — and `restore_status` says nothing about it. Left
+# unchecked, the success path prints "boot the app" over a database still at
+# CONNECTION LIMIT 0, and what the operator then meets is "too many
+# connections" at boot: the same misdirected error the block shuts the door to
+# avoid, arrived at from the step that was supposed to undo it. Reported before
+# the restore's own outcome, because it is the one thing here that stands
+# between a good restore and an app that cannot reach it.
+if [ "$reopen_status" -ne 0 ]; then
+  echo "RE-OPEN FAILED: collavre_production is still at 'CONNECTION LIMIT 0'."
+  if [ "$restore_status" -eq 0 ]; then
+    echo "  The restore finished — the data is not what failed. Do not re-run"
+    echo "  this block to clear it: pg_restore --clean would drop a good restore"
+    echo "  to repair a connection limit."
+  else
+    echo "  Nothing was dropped — this block refused above — but the limit it"
+    echo "  applied to shut the door is still in force."
+  fi
+  echo "  The app will be refused at boot with 'too many connections', which"
+  echo "  will read like a pool problem. Do not boot it until this succeeds:"
+  echo "  sudo -u postgres psql -qd postgres -c \\"
+  echo "    \"ALTER DATABASE collavre_production CONNECTION LIMIT -1\""
+  echo "  Confirm with:"
+  echo "  sudo -u postgres psql -qtAd postgres -c \\"
+  echo "    \"SELECT datconnlimit FROM pg_database WHERE datname = 'collavre_production'\""
+elif [ "$restore_status" -eq 0 ]; then
   echo "restored; boot the app from your workstation: ./kamal.sh app boot"
 elif [ "$restore_status" -eq 2 ] || [ "$restore_status" -eq 3 ]; then
   : # refused before touching anything — see the message above

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -73,6 +73,11 @@ sudo SSH_PUBLIC_KEY="ssh-ed25519 AAAA..." bash script/lightsail_launch.sh
 sudo SSH_PUBLIC_KEY="ssh-ed25519 AAAA..." FORCE=1 bash script/lightsail_launch.sh
 ```
 
+If a re-run adds or changes Docker's default log caps, it restarts Docker but
+cannot retrofit those defaults onto existing containers. Recreate them with
+`./kamal.sh deploy` from your workstation; until that deployment, their
+previous logging configuration remains in effect.
+
 **A re-run applies every setting in the table, not only the ones you name.** An
 override you used the first time and did not repeat is applied as its default,
 and three of those defaults do not converge the host — they rotate it.

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -203,7 +203,7 @@ nonce='<nonce>'
 signature="$(printf 'collavre-ssh-cutover:%s:%s' '<new-user>' "$nonce" |
   ssh-keygen -Y sign -f "$key" -n collavre-ssh-cutover 2>/dev/null |
   base64 | tr -d '\n')"
-ssh -i "$key" <new-user>@<instance-ip> \
+ssh -o IdentitiesOnly=yes -i "$key" <new-user>@<instance-ip> \
   "sudo /usr/local/sbin/collavre-finalize-ssh-cutover \
     --finalize-ssh-cutover '$nonce' '$signature'"
 ```
@@ -211,7 +211,9 @@ ssh -i "$key" <new-user>@<instance-ip> \
 Run that exact command from the workstation with the key Kamal will use. The
 local `ssh-keygen` signs the nonce and staged username with that private key;
 the signature travels only as an argument to the SSH command, so a failed
-staged-account login never invokes the finalizer. The host verifies the
+staged-account login never invokes the finalizer. `IdentitiesOnly=yes` prevents
+`ssh-agent` from silently authenticating that command with a predecessor key
+when the staged key itself is rejected. The host verifies the
 signature against the public keys captured atomically when the cutover was
 staged. This is the security boundary: the predecessor is root-equivalent and
 can forge host-local process names, environment variables, and files, but it

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -264,6 +264,14 @@ the SQLite converter needs the app image and so runs after it, app stopped.
   `schema_migrations` up to the schema version — the next boot's `db:migrate`
   is a no-op.
 
+  That covers the engine migrations too, which is worth stating because the
+  SQLite task above has to stamp them by hand. `db:schema:load` runs after
+  `db:load_config`, and that is where Rails widens
+  `ActiveRecord::Migrator.migrations_paths` from `["db/migrate"]` (7 files) to
+  every path the engines append (184). `db:sqlite_to_postgres` depends on
+  `:environment` alone, so it never gets that widening and must stamp the
+  remaining 177 itself.
+
   `DISABLE_DATABASE_ENVIRONMENT_CHECK` is not optional here. `db:schema:load`
   runs `check_protected_environments` first, which aborts with
   `ActiveRecord::ProtectedEnvironmentError` once the database records

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -63,9 +63,14 @@ sudo SSH_PUBLIC_KEY="ssh-ed25519 AAAA..." bash script/lightsail_launch.sh
 sudo FORCE=1 bash script/lightsail_launch.sh   # after the first success
 ```
 
-Progress: `tail -f /var/log/collavre-launch.log` (first boot takes 3–6 minutes).
-When it finishes it writes `/root/collavre-lightsail-summary.txt` with the
-generated `DATABASE_URL` and the exact `.env.production` lines to copy.
+Progress: `sudo tail -f /var/log/collavre-launch.log` (first boot takes 3–6
+minutes). When it finishes it writes `/root/collavre-lightsail-summary.txt` with
+the generated `DATABASE_URL` and the exact `.env.production` lines to copy.
+
+The summary is also printed to the launch log, but with the database password
+redacted — the log and cloud-init's copy of it are not the place for a
+credential. Read the real `DATABASE_URL` from the `0600` summary file (or the
+password alone from `/var/lib/collavre/db_password`).
 
 **In the console firewall (Networking tab): open 80 and 443. Never open 5432.**
 
@@ -149,7 +154,12 @@ full replay — so **populate the database before the first deploy** instead:
 `collavre-pg-backup.timer` runs nightly at 03:30 (instance timezone, Asia/Seoul
 by default) and writes custom-format dumps to `/var/backups/collavre`, keeping 7
 days. With `BACKUP_S3_URI` set and AWS credentials in `/root/.aws/credentials`
-(Lightsail has no IAM instance role) each dump is also copied to S3.
+(Lightsail has no IAM instance role) each dump is also copied to S3 — the launch
+script installs the AWS CLI when that variable is set. If the upload cannot
+happen the local dump is still written and kept, but the unit exits non-zero, so
+a broken off-instance backup shows up as a failed
+`collavre-pg-backup.service` in `systemctl list-units --failed` instead of
+looking healthy.
 
 ```bash
 sudo /usr/local/bin/collavre-pg-backup          # run one now

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -794,32 +794,56 @@ sudo cat /var/lib/collavre/db_name   # <db-name>
     echo "converting now would boot an app whose attachments are all missing"
     echo "app left stopped on purpose; copy the blobs before converting"
   else
-    # The copy disables referential integrity, which is superuser-only.
+    # The copy disables referential integrity, which is superuser-only. The role
+    # is double-quoted for the same reason the database is further down this
+    # page: DB_USER is an operator setting and the launch script creates whatever
+    # it is given through `format('%I')`, so `collavre-app` is a role it makes
+    # and `ALTER ROLE collavre-app SUPERUSER` is a syntax error.
     ssh <deploy-user>@<instance-ip> \
-      "sudo -u postgres psql -c 'ALTER ROLE <db-user> SUPERUSER'"
+      "sudo -u postgres psql -c 'ALTER ROLE \"<db-user>\" SUPERUSER'"
+    grant_status=$?
 
-    ./kamal.sh app exec \
-      'bin/rails "db:sqlite_to_postgres[storage/production-primary.sqlite3,production]"' \
-      -e MIGRATION_RUN_RESET:true
-    copy_status=$?
+    # Gated on the grant, not run alongside it. MIGRATION_RUN_RESET drops the
+    # schema before loading, so a conversion attempted without the superuser it
+    # needs trades a working empty database for a broken one and gains nothing.
+    copy_status=1
+    if [ "$grant_status" -eq 0 ]; then
+      ./kamal.sh app exec \
+        'bin/rails "db:sqlite_to_postgres[storage/production-primary.sqlite3,production]"' \
+        -e MIGRATION_RUN_RESET:true
+      copy_status=$?
+    fi
 
     # Take the grant back whether or not the copy worked — a failed cutover is
-    # precisely when it would otherwise sit there.
+    # precisely when it would otherwise sit there — and whether or not the grant
+    # itself reported success, because a connection that dropped after the ALTER
+    # committed leaves the role raised with nothing on this side to say so.
+    # NOSUPERUSER against a role that is not one succeeds and changes nothing.
     ssh <deploy-user>@<instance-ip> \
-      "sudo -u postgres psql -c 'ALTER ROLE <db-user> NOSUPERUSER'"
+      "sudo -u postgres psql -c 'ALTER ROLE \"<db-user>\" NOSUPERUSER'"
     revoke_status=$?
 
-    # Clean up and boot only if both worked. Either failure leaves the app down.
-    if [ "$copy_status" -eq 0 ] && [ "$revoke_status" -eq 0 ]; then
+    # Clean up and boot only if all three worked. Any failure leaves the app down.
+    if [ "$grant_status" -eq 0 ] && [ "$copy_status" -eq 0 ] &&
+       [ "$revoke_status" -eq 0 ]; then
       ssh <deploy-user>@<instance-ip> \
         'sudo rm "$(docker volume inspect plan42_storage \
            --format "{{.Mountpoint}}")/production-primary.sqlite3"'
 
       ./kamal.sh app boot   # restart on the data you just loaded
     else
-      [ "$revoke_status" -eq 0 ] ||
+      [ "$grant_status" -eq 0 ] ||
+        echo "GRANT FAILED: nothing was converted, and this database is as it was"
+      # Only claimed when the grant is known to have taken. Reported the other
+      # way round it sends the operator to withdraw a grant that never happened,
+      # which is the wrong repair and hides the one that is needed.
+      if [ "$revoke_status" -ne 0 ] && [ "$grant_status" -eq 0 ]; then
         echo "REVOKE FAILED: <db-user> is still a superuser — take it back by hand"
-      [ "$copy_status" -eq 0 ] ||
+      elif [ "$revoke_status" -ne 0 ]; then
+        echo "REVOKE FAILED: the grant did not report success either, so read"
+        echo "  rolsuper for <db-user> before acting — it may never have been raised"
+      fi
+      [ "$copy_status" -eq 0 ] || [ "$grant_status" -ne 0 ] ||
         echo "COPY FAILED: this database is now empty or half-loaded"
       echo "app left stopped on purpose; do not boot it until the above is cleared"
     fi

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -51,7 +51,7 @@ Common overrides:
 | `SSH_PUBLIC_KEY` | *(empty)* | Empty = copy `ubuntu`'s `authorized_keys` |
 | `APP_SSH_USER` | `collavre` | Must match `KAMAL_SSH_USER` |
 | `PG_MAJOR` | `17` | Match the source database when restoring a dump |
-| `DB_PASSWORD` | *(generated)* | Generated password is URL-safe |
+| `DB_PASSWORD` | *(generated)* | Generated password is alphanumeric; a custom one is [percent-encoded into `DATABASE_URL`](#a-custom-db_password-is-percent-encoded-in-database_url) |
 | `SWAP_SIZE_MB` | `2048` | `0` disables |
 | `BACKUP_S3_URI` | *(empty)* | e.g. `s3://collavre-backups/pg` — PostgreSQL only, [not uploaded files](#backup_s3_uri-does-not-cover-uploaded-files) |
 
@@ -73,6 +73,28 @@ credential. Read the real `DATABASE_URL` from the `0600` summary file (or the
 password alone from `/var/lib/collavre/db_password`).
 
 **In the console firewall (Networking tab): open 80 and 443. Never open 5432.**
+
+### A custom `DB_PASSWORD` is percent-encoded in `DATABASE_URL`
+
+The generated password is alphanumeric, so it appears in `DATABASE_URL`
+unchanged. A password you supply yourself may not be: `config/database.yml`
+runs `URI.parse(ENV["DATABASE_URL"])` on boot, and that rejects `@`, `/`, `#`,
+`%`, `?` and spaces in the user/password part outright — every Rails command in
+the container would abort with `URI::InvalidURIError` before it reached the
+database.
+
+So the script percent-encodes the role, password and database name when it
+composes the URL. Rails decodes them again when it resolves the connection, so
+the role still authenticates with the literal password it was created with. The
+practical consequence is only that the two do not look alike:
+
+```
+/var/lib/collavre/db_password   p@ss/word
+DATABASE_URL                    postgresql://collavre_user:p%40ss%2Fword@172.17.0.1:5432/collavre_production
+```
+
+Copy `DATABASE_URL` from the summary file as-is. Do not paste the raw password
+into it.
 
 ## 3. How PostgreSQL is reachable
 
@@ -258,7 +280,7 @@ both the Lightsail firewall and ufw (the script already allows 443).
 | `kamal` can't SSH | `sudo cat /home/collavre/.ssh/authorized_keys` — empty means no `SSH_PUBLIC_KEY` and no key to copy |
 | `kamal` SSH works, Docker denied | Reconnect: `docker` group membership needs a new session |
 | App: `could not connect to server` | `sudo ss -lntp \| grep 5432` should show `127.0.0.1:5432` **and** `172.17.0.1:5432` |
-| App: `password authentication failed` | `sudo cat /var/lib/collavre/db_password` vs `DATABASE_URL` |
+| App: `password authentication failed` | `sudo cat /var/lib/collavre/db_password` vs `DATABASE_URL` — the URL holds the [percent-encoded](#a-custom-db_password-is-percent-encoded-in-database_url) form |
 | PostgreSQL won't start after reboot | `sysctl net.ipv4.ip_nonlocal_bind` must be `1`; `journalctl -u postgresql@17-main` |
 | `relation "solid_queue_jobs" does not exist` | Schema never loaded — see §5 |
 | Disk filling up | `docker system prune -af`, `/var/backups/collavre`, `/var/log` |

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -39,10 +39,49 @@ is the practical floor**; 2 GB works only for a light pilot. The script adds a
 
 ## 2. Create the instance with the launch script
 
-Copy the contents of `script/lightsail_launch.sh` into the **Launch script** box
-(Lightsail console → Create instance → *Add launch script*). Edit the
-configuration block at the top first — at minimum `SSH_PUBLIC_KEY`, unless you
-are happy for the deploy user to reuse the key Lightsail installs for `ubuntu`.
+The full `script/lightsail_launch.sh` is larger than the Lightsail launch-script
+limit. In the Lightsail console, go to **Create instance → Add launch script**
+and paste this small bootstrap instead. It installs the download prerequisites,
+fetches the exact reviewed script revision, checks its shell syntax, and runs it:
+
+```bash
+#!/bin/bash
+set -Eeuo pipefail
+
+URL='https://raw.githubusercontent.com/sh1nj1/plan42/a3113860ffe45729c7b2420abe7becfe6c7cc950/script/lightsail_launch.sh'
+TARGET='/root/lightsail_launch.sh'
+
+apt-get update -y
+apt-get install -y curl ca-certificates
+
+curl \
+  --fail \
+  --location \
+  --silent \
+  --show-error \
+  --retry 5 \
+  --retry-delay 3 \
+  "$URL" \
+  --output "$TARGET"
+
+chmod 0700 "$TARGET"
+bash -n "$TARGET"
+exec /bin/bash "$TARGET"
+```
+
+The URL is commit-pinned so a later branch update cannot silently change the
+provisioning code. Update the commit in the URL deliberately whenever adopting
+a newer reviewed revision.
+
+To override the defaults, add exported variables before the final `exec` line.
+At minimum, set `SSH_PUBLIC_KEY` unless you are happy for the deploy user to
+reuse the key Lightsail installs for `ubuntu`:
+
+```bash
+export SSH_PUBLIC_KEY='ssh-ed25519 AAAA...'
+export APP_SSH_USER='collavre'
+exec /bin/bash "$TARGET"
+```
 
 Common overrides:
 

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -217,9 +217,12 @@ remove their script-managed
 `/var/lib/collavre/deploy_user`. Change `KAMAL_SSH_USER` only after the command
 prints `SSH cutover finalized`.
 
-If provisioning or finalization is interrupted,
-`/var/lib/collavre/ssh_cutover.pending` remains. The old account stays
-privileged, and the same finalize command is safe to retry. A different target
+If provisioning or proof fails before the successor marker is committed, the
+old account and managed keys remain unchanged. After successful proof, the
+successor marker is committed before any predecessor is disarmed. If later
+key/group/sudoers cleanup is interrupted, the proven successor remains the
+recovery path, `/var/lib/collavre/ssh_cutover.pending` remains, and the same
+finalize command safely retries the remaining cleanup. A different target
 cannot be staged over a pending cutover; finish the recorded transition first.
 This is intentional availability bias: a reported stale credential is safer
 than automatically removing the last proven way into the host.

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -746,16 +746,31 @@ sudo cat /var/lib/collavre/db_name   # <db-name>
   # Harmless when the source used S3: blob keys fan out into two-character
   # directories, the exclude drops the SQLite files and their -wal/-shm
   # companions, and what is left to send is then nothing.
+  # Staged to a file rather than piped, so that `tar |ssh` is not what decides
+  # whether this worked. A sender that fails part-way through reading still
+  # leaves a receiver that succeeds — measured: sender 1, receiver 0, so `$?`
+  # is 0 — and a receiver handed a truly empty stream also exits 0. `$?` on the
+  # pipeline would therefore report a blob copy that sent nothing as done.
+  # `PIPESTATUS` would answer that, but it is bash-only: these blocks get
+  # pasted into whatever shell the operator has, and on zsh — macOS's default —
+  # `${PIPESTATUS[0]}` is unset (zsh spells it `$pipestatus` and 1-indexes it),
+  # the arithmetic fails, and the pre-set 1 below survives to report a copy that
+  # in fact succeeded as failed. An `&&`-style chain says the same thing in
+  # every shell, and is what the PostgreSQL move above already does with its
+  # dump. The cost is a workstation-side file the size of the blob tree, in the
+  # directory the snapshot is already using.
   blob_status=1
   if [ "$stage_status" -eq 0 ]; then
-    tar -cf - -C storage --exclude='*.sqlite3*' . |
+    if tar -cf "$snap_dir/blobs.tar" -C storage --exclude='*.sqlite3*' . ; then
       ssh <deploy-user>@<instance-ip> \
         'vol="$(docker volume inspect plan42_storage --format "{{.Mountpoint}}")" &&
          sudo tar -xf - -C "$vol" --no-same-owner &&
-         sudo chown -R 1000:1000 "$vol"'
-    # Not $?, which is only ssh's: a tar that fails to read the source would
-    # otherwise send an empty stream to a receiver that unpacks it happily.
-    blob_status=$(( ${PIPESTATUS[0]} | ${PIPESTATUS[1]} ))
+         sudo chown -R 1000:1000 "$vol"' < "$snap_dir/blobs.tar"
+      blob_status=$?
+    else
+      # tar's own status, and the transfer never ran.
+      blob_status=$?
+    fi
   fi
 
   if [ "$stop_status" -ne 0 ]; then

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -126,7 +126,8 @@ have to be set. Then:
 
 `bin/docker-entrypoint` runs `db:migrate` on boot. On a brand-new database that
 replays every migration from zero, and `db/schema.rb` is known to drift from a
-full replay — so **populate the database before the first deploy** instead:
+full replay — so if you are bringing existing data, **restore it before the
+first deploy**, while the database is still reachable without the app:
 
 - **Moving an existing PostgreSQL deployment (Neon, RDS):** dump and restore.
   Match `PG_MAJOR` to the source server's major version or the restore may fail.
@@ -143,11 +144,29 @@ full replay — so **populate the database before the first deploy** instead:
 - **Coming from SQLite:** `bin/rails db:sqlite_to_postgres[...]`
   (`lib/tasks/db_convert.rake`).
 
-- **Genuinely fresh install:** load the schema rather than replaying migrations.
+- **Genuinely fresh install:** there is nothing to restore, so this one runs
+  *after* `./kamal.sh setup` rather than before it — `app exec` needs the
+  `kamal` network and the uploaded env file, and both are created by the same
+  boot that runs the migration replay. Deploy first, then overwrite whatever
+  the replay produced with the canonical schema:
 
   ```bash
+  ./kamal.sh setup
   ./kamal.sh app exec 'bin/rails db:schema:load db:seed'
+  ./kamal.sh app boot   # restart on the schema you just loaded
   ```
+
+  `db/schema.rb` declares every table `force: :cascade`, so the load replaces
+  the replayed tables instead of colliding with them, and it stamps
+  `schema_migrations` up to the schema version — the next boot's `db:migrate`
+  is a no-op.
+
+  This still works when the replay *fails* and `setup` dies at `app boot`: the
+  env file and the network are uploaded before the container is started, and
+  `app exec` runs a **new** container whose command is `bin/rails db:schema:load`,
+  which the entrypoint does not migrate for (it only migrates the
+  `./bin/rails server` command line). Run the `app exec` above and then
+  `./kamal.sh deploy`.
 
 ## 6. Backups
 

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -89,6 +89,17 @@ password alone from `/var/lib/collavre/db_password`).
 
 **In the console firewall (Networking tab): open 80 and 443. Never open 5432.**
 
+**Leave 80 and 443 closed until [§5](#5-get-data-into-the-new-database) is
+finished**, if you are bringing existing data or doing a fresh install. `setup`
+boots the app, and the recipes in §5 stop it again and replace the schema
+underneath — so between those two points a reachable instance is serving a
+database that is about to be discarded. `app stop` closes the window in which
+the *app* writes; it cannot close the one before it. Anything a visitor does in
+that interval — a signup, a password reset — is thrown away by the schema
+replacement without ever failing visibly. Open them once §5 is done; TLS
+([§7](#7-tls)) needs 443 reachable, so that is the point at which it has to be
+open, and nothing before it is waiting on it.
+
 ### A custom `DB_PASSWORD` is percent-encoded in `DATABASE_URL`
 
 The generated password is alphanumeric, so it appears in `DATABASE_URL`

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -50,7 +50,7 @@ Common overrides:
 | --- | --- | --- |
 | `SSH_PUBLIC_KEY` | *(empty)* | Empty = copy `ubuntu`'s `authorized_keys`. [Changing it on a re-run](#rotating-ssh_public_key-on-a-re-run) withdraws the key it replaces |
 | `APP_SSH_USER` | `collavre` | Must match `KAMAL_SSH_USER`. Gets passwordless sudo — the maintenance commands below are sent non-interactively and cannot answer a prompt. [Changing it on a re-run](#changing-app_ssh_user-on-a-re-run) disarms the account it replaces |
-| `PG_MAJOR` | `17` | Match the source database when restoring a dump |
+| `PG_MAJOR` | `17` | Match the source database when restoring a dump. [Changing it on a re-run](#changing-pg_major-on-a-re-run) is refused, not converged |
 | `DB_PASSWORD` | *(generated)* | Generated password is alphanumeric; a custom one is [percent-encoded into `DATABASE_URL`](#a-custom-db_password-is-percent-encoded-in-database_url) |
 | `DB_USER` | `collavre_user` | [Changing it on a re-run](#changing-db_user-on-a-re-run) moves table ownership to the new role and takes `LOGIN` from the old one |
 | `SWAP_SIZE_MB` | `2048` | `0` disables |
@@ -71,7 +71,9 @@ worth knowing before you re-run:
 
 - If you have narrowed SSH — `ufw allow from <your-ip> to any port 22` with the
   blanket rule deleted — the script leaves it alone rather than re-opening 22.
-  It only adds its own SSH rule when nothing else allows the port.
+  It only adds its own SSH rule when nothing else allows the port. `ufw limit`
+  counts as allowing it: rate-limiting SSH is what ufw's own documentation
+  recommends, and a `LIMIT` rule is an allow rule with a throttle on it.
 - It does reassert `default deny incoming` and `default allow outgoing`. That
   is the only setting a re-run tightens on you, and a service reachable solely
   because the default policy was loosened will stop being reachable.
@@ -128,6 +130,43 @@ rotation by hand once you have confirmed you can reach the host as the new user:
 ```bash
 ssh <new-user>@<instance-ip> 'sudo deluser --remove-home <old-user>'
 ```
+
+### Changing `PG_MAJOR` on a re-run
+
+This is the one setting a re-run refuses instead of converging, and the reason
+is that converging it would look like it worked.
+
+The script assumes a single cluster on port 5432 — `DATABASE_URL`, the ufw rule
+and the nightly `pg_dump` all name it. Ubuntu's `postgresql-common` makes no
+such assumption: `pg_createcluster` takes the first free port from 5432 upward,
+so installing a second major version puts it on 5433. The run would then tune
+and configure `/etc/postgresql/<new>/main` while `psql` — and therefore the
+database, the role, the backups and the URL you paste into `.env.production` —
+went on talking to whatever answers on 5432. Nothing fails. The log says the new
+version, the app keeps running on the old cluster, and the new one sits empty
+holding a quarter of the instance's RAM in `shared_buffers`.
+
+So a re-run whose `PG_MAJOR` is not the version already serving 5432 aborts
+before `apt` can create the second cluster, and names both versions. A real
+major upgrade is a deliberate, app-down operation:
+
+```bash
+./kamal.sh app stop
+sudo apt-get install -y postgresql-<new>       # the script will not install it while 5432 is taken
+sudo pg_dropcluster --stop <new> main          # apt just created an EMPTY one; it is not the upgrade
+sudo pg_upgradecluster <old> main              # copies the data, and gives the new cluster 5432
+sudo pg_dropcluster --stop <old> main
+sudo FORCE=1 PG_MAJOR=<new> bash script/lightsail_launch.sh
+./kamal.sh app boot
+```
+
+The second line is the one that is easy to skip and expensive to skip. Installing
+the package auto-creates an empty `<new>/main` on the next free port, and
+`pg_upgradecluster` then stops with `target cluster <new>/main already exists`
+rather than upgrading into it. `pg_upgradecluster` itself moves the old cluster
+aside and hands 5432 to the new one, so the re-run at the end passes the check
+above; verify with `sudo pg_lsclusters` before booting — exactly one cluster, on
+5432, at the new version.
 
 ### Rotating `SSH_PUBLIC_KEY` on a re-run
 

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -248,19 +248,25 @@ container polling the database they are about to replace.
   copy_status=$?
 
   # Take the grant back whether or not the copy worked — a failed cutover is
-  # precisely when it would otherwise sit there. Do not skip past a REVOKE
-  # FAILED line.
+  # precisely when it would otherwise sit there.
   ssh collavre@<instance-ip> \
-    "sudo -u postgres psql -c 'ALTER ROLE collavre_user NOSUPERUSER'" ||
-    echo "REVOKE FAILED: collavre_user is still a superuser — take it back by hand"
-  [ "$copy_status" -eq 0 ] ||
-    echo "copy failed: re-grant and re-run it before booting the app"
+    "sudo -u postgres psql -c 'ALTER ROLE collavre_user NOSUPERUSER'"
+  revoke_status=$?
 
-  ssh collavre@<instance-ip> \
-    'sudo rm "$(docker volume inspect plan42_storage \
-       --format "{{.Mountpoint}}")/production-primary.sqlite3"'
+  # Clean up and boot only if both worked. Either failure leaves the app down.
+  if [ "$copy_status" -eq 0 ] && [ "$revoke_status" -eq 0 ]; then
+    ssh collavre@<instance-ip> \
+      'sudo rm "$(docker volume inspect plan42_storage \
+         --format "{{.Mountpoint}}")/production-primary.sqlite3"'
 
-  ./kamal.sh app boot   # restart on the data you just loaded
+    ./kamal.sh app boot   # restart on the data you just loaded
+  else
+    [ "$revoke_status" -eq 0 ] ||
+      echo "REVOKE FAILED: collavre_user is still a superuser — take it back by hand"
+    [ "$copy_status" -eq 0 ] ||
+      echo "COPY FAILED: this database is now empty or half-loaded"
+    echo "app left stopped on purpose; do not boot it until the above is cleared"
+  fi
   ```
 
   The grant is not optional. The launch script creates the role with
@@ -286,6 +292,19 @@ container polling the database they are about to replace.
   retry safe. Re-run without re-granting and the task aborts before it touches
   the database, telling you what is missing. So the recovery is: re-grant,
   re-run, and only then `app boot`.
+
+  **Neither failure may reach `app boot`, which is why the tail of the block is
+  a conditional.** `MIGRATION_RUN_RESET` drops the schema before it loads
+  anything, so a copy that dies partway through leaves this database empty or
+  half-populated — booting then serves exactly that. The `sudo rm` is as bad in
+  its own way: it destroys the staged SQLite file the task reads from, so a
+  retry needs another full `scp` of production rather than just the re-grant
+  and re-run above. A failed *revoke* must not boot either, for the reason in
+  the previous paragraph — the container would come up holding superuser
+  credentials, which is the exposure the revoke exists to close. So cleanup and
+  boot are gated on both statuses and the app stays stopped otherwise. `exit`
+  would be the wrong tool: these lines get pasted into an interactive shell,
+  where it closes the session instead of stopping the recipe.
 
   `MIGRATION_RUN_RESET=true` matters because `setup` has already run the
   migration replay this section opened by distrusting. The task's schema load

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -63,6 +63,18 @@ sudo SSH_PUBLIC_KEY="ssh-ed25519 AAAA..." bash script/lightsail_launch.sh
 sudo FORCE=1 bash script/lightsail_launch.sh   # after the first success
 ```
 
+Converging means the firewall too: a re-run adds and updates only the rules the
+script owns (SSH, 80, 443, and 5432 from the Docker bridge), so a VPN,
+monitoring or IP-allowlist rule you added by hand survives it. Two consequences
+worth knowing before you re-run:
+
+- If you have narrowed SSH — `ufw allow from <your-ip> to any port 22` with the
+  blanket rule deleted — the script leaves it alone rather than re-opening 22.
+  It only adds its own SSH rule when nothing else allows the port.
+- It does reassert `default deny incoming` and `default allow outgoing`. That
+  is the only setting a re-run tightens on you, and a service reachable solely
+  because the default policy was loosened will stop being reachable.
+
 Progress: `sudo tail -f /var/log/collavre-launch.log` (first boot takes 3–6
 minutes). When it finishes it writes `/root/collavre-lightsail-summary.txt` with
 the generated `DATABASE_URL` and the exact `.env.production` lines to copy.
@@ -233,9 +245,17 @@ container polling the database they are about to replace.
   ./kamal.sh app exec \
     'bin/rails "db:sqlite_to_postgres[storage/production-primary.sqlite3,production]"' \
     -e MIGRATION_RUN_RESET:true
+  copy_status=$?
 
+  # Take the grant back whether or not the copy worked — a failed cutover is
+  # precisely when it would otherwise sit there. Do not skip past a REVOKE
+  # FAILED line.
   ssh collavre@<instance-ip> \
-    "sudo -u postgres psql -c 'ALTER ROLE collavre_user NOSUPERUSER'"
+    "sudo -u postgres psql -c 'ALTER ROLE collavre_user NOSUPERUSER'" ||
+    echo "REVOKE FAILED: collavre_user is still a superuser — take it back by hand"
+  [ "$copy_status" -eq 0 ] ||
+    echo "copy failed: re-grant and re-run it before booting the app"
+
   ssh collavre@<instance-ip> \
     'sudo rm "$(docker volume inspect plan42_storage \
        --format "{{.Mountpoint}}")/production-primary.sqlite3"'
@@ -248,10 +268,24 @@ container polling the database they are about to replace.
   `ALTER TABLE ... DISABLE TRIGGER ALL`, which needs a superuser — owning the
   table is not enough. The task checks this up front and aborts with
   instructions rather than dying halfway through with a `ForeignKeyViolation`,
-  so a forgotten grant costs you a message, not a half-loaded database. Take it
-  back afterwards: the other route the task offers,
-  `MIGRATION_RUN_USER=postgres`, would mean giving the superuser role a
-  password that every container on the host could then authenticate with.
+  so a forgotten grant costs you a message, not a half-loaded database. The
+  other route the task offers, `MIGRATION_RUN_USER=postgres`, would mean giving
+  the superuser role a password that every container on the host could then
+  authenticate with — which is why the grant lands on the app role instead.
+
+  **That is also why the revoke is not conditional on the copy succeeding.**
+  `collavre_user` is the role in `DATABASE_URL`, so it is what every app
+  container authenticates as. Leaving it a superuser turns any SQL injection
+  into `COPY ... FROM PROGRAM` — arbitrary commands as the `postgres` user on
+  the host — and a failed cutover is exactly the moment you are least likely to
+  remember a line further down the page. The window is not merely the length of
+  the copy: troubleshooting a failed cutover usually means booting the app to
+  look at it, and the container comes up holding superuser credentials.
+
+  Revoking on failure costs nothing, because the same up-front check makes the
+  retry safe. Re-run without re-granting and the task aborts before it touches
+  the database, telling you what is missing. So the recovery is: re-grant,
+  re-run, and only then `app boot`.
 
   `MIGRATION_RUN_RESET=true` matters because `setup` has already run the
   migration replay this section opened by distrusting. The task's schema load

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -49,7 +49,7 @@ Common overrides:
 | Variable | Default | Notes |
 | --- | --- | --- |
 | `SSH_PUBLIC_KEY` | *(empty)* | Empty = copy `ubuntu`'s `authorized_keys` |
-| `APP_SSH_USER` | `collavre` | Must match `KAMAL_SSH_USER`. Gets passwordless sudo — the maintenance commands below are sent non-interactively and cannot answer a prompt |
+| `APP_SSH_USER` | `collavre` | Must match `KAMAL_SSH_USER`. Gets passwordless sudo — the maintenance commands below are sent non-interactively and cannot answer a prompt. [Changing it on a re-run](#changing-app_ssh_user-on-a-re-run) disarms the account it replaces |
 | `PG_MAJOR` | `17` | Match the source database when restoring a dump |
 | `DB_PASSWORD` | *(generated)* | Generated password is alphanumeric; a custom one is [percent-encoded into `DATABASE_URL`](#a-custom-db_password-is-percent-encoded-in-database_url) |
 | `SWAP_SIZE_MB` | `2048` | `0` disables |
@@ -95,6 +95,26 @@ DATABASE_URL                    postgresql://collavre_user:p%40ss%2Fword@172.17.
 
 Copy `DATABASE_URL` from the summary file as-is. Do not paste the raw password
 into it.
+
+### Changing `APP_SSH_USER` on a re-run
+
+A `FORCE=1` re-run with a different `APP_SSH_USER` creates the new account and
+then takes the `docker` and `sudo` groups back from the one it replaces, along
+with its `sudoers.d` grant. Docker membership is the part that matters:
+`docker run -v /:/host` is a root shell, so an account left in that group has
+not been rotated away from in any meaningful sense — it has only lost the
+slower route.
+
+What the script will not do is delete the account or its `authorized_keys`. Its
+only view of the host is the deploy user recorded in
+`/var/lib/collavre/deploy_user`, and if that name were ever the instance's own
+cloud user, deleting it would remove the last way in. So the run leaves an
+ordinary, group-less account behind and says so in the launch log. Finish the
+rotation by hand once you have confirmed you can reach the host as the new user:
+
+```bash
+ssh <new-user>@<instance-ip> 'sudo deluser --remove-home <old-user>'
+```
 
 ## 3. How PostgreSQL is reachable
 

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -175,7 +175,9 @@ replays every migration from zero, and `db/schema.rb` is known to drift from a
 full replay — so if you are bringing existing data, **load it before the app
 serves a request**. Which side of `./kamal.sh setup` that falls on depends on
 the source: a PostgreSQL dump goes in over SSH before the first deploy, while
-the SQLite converter needs the app image and so runs after it, app stopped.
+the SQLite converter and the fresh-install schema load both need the app image
+and so run after it — with `./kamal.sh app stop` first, since `setup` leaves a
+container polling the database they are about to replace.
 
 - **Moving an existing PostgreSQL deployment (Neon, RDS):** dump and restore.
   Match `PG_MAJOR` to the source server's major version or the restore may fail.
@@ -274,6 +276,7 @@ the SQLite converter needs the app image and so runs after it, app stopped.
 
   ```bash
   ./kamal.sh setup
+  ./kamal.sh app stop   # no reads or writes while the schema is dropped and reloaded
 
   ADMIN_PASSWORD="$(openssl rand -base64 18)"   # not in shell history; print it below
   ./kamal.sh app exec 'bin/rails db:schema:load:primary db:seed' \
@@ -284,6 +287,25 @@ the SQLite converter needs the app image and so runs after it, app stopped.
 
   ./kamal.sh app boot   # restart on the schema you just loaded
   ```
+
+  **`app stop` is not politeness.** `setup` ends by booting the app, so by the
+  time you run the load a container is already talking to this database — and
+  not only when a browser reaches it. `config/deploy.yml` defaults
+  `SOLID_QUEUE_IN_PUMA` to `true`, so the web container runs the Solid Queue
+  supervisor in-process and polls for work on a timer whether or not anyone has
+  found the host yet. Those tables are in the schema being loaded: `db/schema.rb`
+  declares 13 `solid_*` tables `force: :cascade`, and `cache`, `queue` and
+  `cable` all fall back to `DATABASE_URL` unless you set their own
+  ([§3](#3-how-postgresql-is-reachable)), so the load drops the queue tables out
+  from under a live poller. `DROP TABLE` needs an `ACCESS EXCLUSIVE` lock and
+  the poller is querying the same tables, so the two contend in both directions:
+  the load blocks behind a poll that is mid-transaction, and a poll that arrives
+  while a table is gone fails against a relation that does not exist yet. How
+  that surfaces depends on where the timer lands — a load that pauses, errors in
+  `./kamal.sh logs`, or nothing visible at all on a lucky run. Which is the
+  argument for stopping rather than for timing it well. It also settles what
+  happens to anything written between `setup` and the load: the schema is
+  replaced either way, so there is no point letting a request believe otherwise.
 
   **Supply the admin credentials.** `db/seeds.rb` falls back to
   `admin@example.com` / `password123` and marks that user `system_admin`. That
@@ -348,7 +370,9 @@ the SQLite converter needs the app image and so runs after it, app stopped.
   `bin/rails db:schema:load:primary`,
   which the entrypoint does not migrate for (it only migrates the
   `./bin/rails server` command line). Run the `app exec` above and then
-  `./kamal.sh deploy`.
+  `./kamal.sh deploy`. The `app stop` is a no-op on this path rather than a
+  step to skip — there is no container to stop, and kamal does not treat that
+  as an error.
 
 ## 6. Backups
 

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -152,8 +152,10 @@ the repo root (the wrapper's paths are relative) with `RAILS_ENV` unset or
 
 `bin/docker-entrypoint` runs `db:migrate` on boot. On a brand-new database that
 replays every migration from zero, and `db/schema.rb` is known to drift from a
-full replay — so if you are bringing existing data, **restore it before the
-first deploy**, while the database is still reachable without the app:
+full replay — so if you are bringing existing data, **load it before the app
+serves a request**. Which side of `./kamal.sh setup` that falls on depends on
+the source: a PostgreSQL dump goes in over SSH before the first deploy, while
+the SQLite converter needs the app image and so runs after it, app stopped.
 
 - **Moving an existing PostgreSQL deployment (Neon, RDS):** dump and restore.
   Match `PG_MAJOR` to the source server's major version or the restore may fail.
@@ -168,7 +170,58 @@ first deploy**, while the database is still reachable without the app:
   ```
 
 - **Coming from SQLite:** `bin/rails db:sqlite_to_postgres[...]`
-  (`lib/tasks/db_convert.rake`).
+  (`lib/tasks/db_convert.rake`). Like the fresh install below, this one runs
+  *after* `./kamal.sh setup`, because the app container is the only place that
+  can reach both ends. `DATABASE_URL` names `172.17.0.1`, which by design
+  answers only on the host, so running the task from your workstation dials
+  your own machine instead — and overriding the URL on the command line does
+  not help, because `config/boot.rb` uses `Dotenv.overload`: `.env.production`
+  puts `172.17.0.1` back over whatever you passed.
+
+  ```bash
+  ./kamal.sh setup
+  ./kamal.sh app stop   # no writes while the schema is dropped and reloaded
+
+  # The task reads the SQLite file from inside the container. /rails/storage is
+  # the plan42_storage volume, shared by every container of the app, and uid
+  # 1000 is the image's `rails` user.
+  scp storage/production-primary.sqlite3 collavre@<instance-ip>:/tmp/
+  ssh collavre@<instance-ip> \
+    'sudo install -o 1000 -g 1000 -m 0600 /tmp/production-primary.sqlite3 \
+       "$(docker volume inspect plan42_storage --format "{{.Mountpoint}}")/" &&
+     rm /tmp/production-primary.sqlite3'
+
+  # The copy disables referential integrity, which is superuser-only.
+  ssh collavre@<instance-ip> \
+    "sudo -u postgres psql -c 'ALTER ROLE collavre_user SUPERUSER'"
+
+  ./kamal.sh app exec \
+    'bin/rails "db:sqlite_to_postgres[storage/production-primary.sqlite3,production]"'
+
+  ssh collavre@<instance-ip> \
+    "sudo -u postgres psql -c 'ALTER ROLE collavre_user NOSUPERUSER'"
+  ssh collavre@<instance-ip> \
+    'sudo rm "$(docker volume inspect plan42_storage \
+       --format "{{.Mountpoint}}")/production-primary.sqlite3"'
+
+  ./kamal.sh app boot   # restart on the data you just loaded
+  ```
+
+  The grant is not optional. The launch script creates the role with
+  `CREATE ROLE ... LOGIN` and nothing else, and the copy runs
+  `ALTER TABLE ... DISABLE TRIGGER ALL`, which needs a superuser — owning the
+  table is not enough. The task checks this up front and aborts with
+  instructions rather than dying halfway through with a `ForeignKeyViolation`,
+  so a forgotten grant costs you a message, not a half-loaded database. Take it
+  back afterwards: the other route the task offers,
+  `MIGRATION_RUN_USER=postgres`, would mean giving the superuser role a
+  password that every container on the host could then authenticate with.
+
+  No `DISABLE_DATABASE_ENVIRONMENT_CHECK` here, unlike the fresh install below.
+  The task calls `DatabaseTasks.load_schema` directly instead of the
+  `db:schema:load` task, so `check_protected_environments` never runs. It also
+  stamps `schema_migrations` for the engine migrations as well as the primary
+  ones, so the next boot's `db:migrate` is a no-op.
 
 - **Genuinely fresh install:** there is nothing to restore, so this one runs
   *after* `./kamal.sh setup` rather than before it — `app exec` needs the

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -205,7 +205,10 @@ ssh -i ~/.ssh/<staged-key> <new-user>@<instance-ip> \
 Run that exact command from the workstation with the key Kamal will use. The
 finalizer checks that it is running through an `sshd` process tree containing
 the staged account's real UID, that `SUDO_USER` is that account, and that the
-nonce matches. Only then does it take `docker` and `sudo` from every predecessor,
+nonce matches. For an explicit key rotation it also reads the session's
+root-configured `ExposeAuthInfo` record and requires its public-key fingerprint
+to match the staged key; logging in with the predecessor key cannot finalize
+the rotation. Only then does it take `docker` and `sudo` from every predecessor,
 remove their script-managed
 `sudoers.d` grants, withdraw predecessor managed keys, and commit
 `/var/lib/collavre/deploy_user`. Change `KAMAL_SSH_USER` only after the command

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -1321,8 +1321,34 @@ if [ "$live" != 0 ]; then
   echo "nothing was dropped; re-run this block once the app is down"
   restore_status=2
 else
-  sudo -u postgres pg_restore --clean --if-exists -d "$app_db" \
-    "/var/backups/collavre/$app_db-YYYYmmdd-HHMMSS.dump"
+  # `--no-owner --role=$app_role`, the same pair the import recipe above uses,
+  # and for the reason a recovery restore makes sharper: the archive carries the
+  # ownership the database had when it was dumped. A dump taken before a
+  # supported DB_USER rotation names the previous role, so replaying it hands
+  # every table back to that role while DATABASE_URL still names $app_role.
+  # Measured on a real cluster: the restore exits 0, and the app's own role then
+  # gets "permission denied for table creatives" on SELECT and INSERT. A
+  # recovery that reports success and leaves the app locked out of its own data
+  # is the worst shape this block can produce.
+  #
+  # $app_role is safe to name here because the two refusals above have already
+  # answered for it: an empty one, or one that is a superuser, never reaches
+  # this line.
+  #
+  # One case this makes louder rather than quieter, and it is the right
+  # direction. `--role` drops the superuser privileges the connection had, so if
+  # the objects *currently* in the database belong to some third role, the
+  # `--clean` DROPs fail with "must be owner of table" and pg_restore exits
+  # non-zero — measured, and the database is left exactly as it was rather than
+  # half-replaced. Without `--role` that host restores "successfully" into the
+  # same locked-out app. If you see that error, the objects are owned by a role
+  # nothing names; move them first and run this block again:
+  #   sudo -u postgres psql -qtAd "$app_db" -c \
+  #     "SELECT DISTINCT tableowner FROM pg_tables WHERE schemaname = 'public'"
+  #   sudo -u postgres psql -qd "$app_db" -c \
+  #     'REASSIGN OWNED BY "<that role>" TO "'"$app_role"'"'
+  sudo -u postgres pg_restore --clean --if-exists --no-owner --role="$app_role" \
+    -d "$app_db" "/var/backups/collavre/$app_db-YYYYmmdd-HHMMSS.dump"
   restore_status=$?
 fi
 

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -219,11 +219,61 @@ old role owns moves in one statement, and the old login stops working before the
 new URL is published. The role itself is left in place — `NOLOGIN` is reversible
 and dropping it is not.
 
-One case is refused rather than converged: if the previous `DB_USER` was a
-superuser (`DB_USER=postgres` on a first run is legal), the script logs a
-warning and changes nothing. `NOLOGIN` on the cluster superuser locks every
-operator out of administering it, and peer authentication needs `LOGIN` too, so
-there is no way back in. Move ownership and retire that role by hand.
+**One case stops the run rather than converging: a previous `DB_USER` that is a
+superuser** (`DB_USER=postgres` on a first run is legal). Two separate reasons,
+and neither has a fix the script can apply:
+
+- `NOLOGIN` on the cluster superuser locks every operator out of administering
+  it — peer authentication needs `LOGIN` too, so there is no way back in.
+- PostgreSQL refuses to reassign a superuser's objects at all:
+  `cannot reassign ownership of objects owned by role postgres because they are
+  required by the database system`. So the new role would own the database and
+  not one table in it.
+
+The run stops before anything moves, with `/var/lib/collavre/db_user` still
+naming the old role so a later re-run sees the same state. Move the application
+objects by hand, then re-run:
+
+```bash
+sudo -u postgres psql -v ON_ERROR_STOP=1 -d collavre_production <<'SQL'
+DO $$
+DECLARE r record;
+BEGIN
+  FOR r IN
+    SELECT c.oid::regclass AS obj
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname NOT IN ('pg_catalog', 'information_schema')
+      AND c.relkind IN ('r', 'p', 'S', 'v', 'm')
+      AND pg_get_userbyid(c.relowner) = 'postgres'
+      -- A sequence owned by a table column follows its table; altering it
+      -- directly is an error, so leave those to the table's own ALTER.
+      AND NOT EXISTS (
+        SELECT 1 FROM pg_depend d
+        WHERE d.objid = c.oid
+          AND d.classid = 'pg_class'::regclass
+          AND d.deptype = 'a')
+  LOOP
+    EXECUTE format('ALTER TABLE %s OWNER TO %I', r.obj, 'collavre_app');
+  END LOOP;
+END $$;
+SQL
+```
+
+Substitute your new `DB_USER` for `collavre_app`. `postgres` keeps `LOGIN` and
+its superuser rights — that is the point of doing it here rather than in the
+script. Check before re-running that nothing is left behind:
+
+```bash
+sudo -u postgres psql -qtA -d collavre_production -c \
+  "SELECT relkind, relname FROM pg_class c
+     JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname NOT IN ('pg_catalog','information_schema')
+      AND pg_get_userbyid(c.relowner) = 'postgres'"
+```
+
+Empty output means the transfer is complete. Setting `DB_USER` back to the old
+value is the other way out, and leaves the rotation undone.
 
 Rotating the *password* rather than the role needs none of this — set
 `DB_PASSWORD`, re-run, and update `DATABASE_URL`.

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -559,7 +559,7 @@ On your workstation, in `.env.production`:
 
 ```dotenv
 COLLAVRE_SERVER=<instance public IP>
-KAMAL_SSH_USER=collavre
+KAMAL_SSH_USER=<the KAMAL_SSH_USER value from the summary file>
 KAMAL_SSH_KEY_PATH=~/.ssh/<key matching the instance>
 KAMAL_REGISTRY_USER=<docker hub user>
 KAMAL_REGISTRY_PASSWORD=<docker hub access token>
@@ -567,6 +567,10 @@ DATABASE_URL=<the DATABASE_URL line from the summary file, copied verbatim>
 PORT=80
 SOLID_QUEUE_IN_PUMA=true
 ```
+
+Copy the generated `KAMAL_SSH_USER=...` line from the summary file rather than
+assuming the default `collavre` account. It reflects the `APP_SSH_USER` that
+actually received the SSH key, Docker access and passwordless sudo.
 
 `DATABASE_URL` is the one value here you must not compose yourself: the script
 already wrote it, [percent-encoded](#a-custom-db_password-is-percent-encoded-in-database_url),

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -200,16 +200,30 @@ before `apt` can create the second cluster, and names both versions. A real
 major upgrade is a deliberate, app-down operation:
 
 ```bash
+sudo cat /var/lib/collavre/launch.env          # read this BEFORE the app goes down; see below
 ./kamal.sh app stop
 sudo apt-get install -y postgresql-<new>       # the script will not install it while 5432 is taken
 sudo pg_dropcluster --stop <new> main          # apt just created an EMPTY one; it is not the upgrade
 sudo pg_upgradecluster <old> main              # copies the data, and gives the new cluster 5432
 sudo pg_dropcluster --stop <old> main
-sudo FORCE=1 PG_MAJOR=<new> bash script/lightsail_launch.sh
+sudo <every setting in launch.env> FORCE=1 PG_MAJOR=<new> bash script/lightsail_launch.sh
 ./kamal.sh app boot
 ```
 
-The second line is the one that is easy to skip and expensive to skip. Installing
+The first line is there because the second-to-last one is a re-run, and a re-run
+that omits a setting this host was provisioned with
+[is refused](#2-create-the-instance-with-the-launch-script) rather than allowed
+to reset it. `PG_MAJOR=<new>` alone is exactly that omission on any host given
+so much as an `SSH_PUBLIC_KEY`. The refusal changes nothing and prints the line
+that clears it, so this costs a paste — but it arrives with the app stopped and
+the old cluster already dropped, which is the wrong moment to be reading a file
+you could have read before the outage. On a host provisioned before `launch.env`
+existed, `sudo cat /var/lib/collavre/deploy_user` and `.../db_user` are what the
+host can still answer.
+
+The `pg_dropcluster --stop <new> main` line is the one that is easy to skip and
+expensive to skip — named rather than numbered, because it is the step whose
+absence is invisible until it is too late. Installing
 the package auto-creates an empty `<new>/main` on the next free port, and
 `pg_upgradecluster` then stops with `target cluster <new>/main already exists`
 rather than upgrading into it. `pg_upgradecluster` itself moves the old cluster
@@ -281,10 +295,32 @@ and neither has a fix the script can apply:
 
 The run stops before anything moves, with `/var/lib/collavre/db_user` still
 naming the old role so a later re-run sees the same state. Move the application
-objects by hand, then re-run:
+objects by hand, then re-run.
+
+Both blocks below operate on one database, so resolve its name once from the
+host's own record rather than assuming the default — an operator who followed
+[the rename procedure](#changing-db_name-on-a-re-run), or who provisioned with
+`DB_NAME`, does not have `collavre_production`:
 
 ```bash
-sudo -u postgres psql -v ON_ERROR_STOP=1 -d collavre_production <<'SQL'
+app_db=${app_db:-$(sudo cat /var/lib/collavre/db_name 2>/dev/null)}
+if [ -z "$app_db" ]; then
+  echo "REFUSING: could not read the database name from"
+  echo "  /var/lib/collavre/db_name — nothing below will operate on the"
+  echo "  right database. Name it and paste this block again:"
+  echo "    app_db=<the database>"
+else
+  echo "operating on: $app_db"
+fi
+```
+
+It refuses rather than falling back, and an empty name is the reason: `psql -d ''`
+connects to the `postgres` database and exits `0`, so a fallback would run the
+transfer below against a database with no application tables in it and report
+success from both blocks.
+
+```bash
+sudo -u postgres psql -v ON_ERROR_STOP=1 -d "$app_db" <<'SQL'
 DO $$
 DECLARE r record;
 BEGIN
@@ -314,16 +350,28 @@ its superuser rights — that is the point of doing it here rather than in the
 script. Check before re-running that nothing is left behind:
 
 ```bash
-sudo -u postgres psql -qtA -d collavre_production -c \
+left="$(sudo -u postgres psql -qtA -d "$app_db" -c \
   "SELECT relkind, relname FROM pg_class c
      JOIN pg_namespace n ON n.oid = c.relnamespace
     WHERE n.nspname NOT IN ('pg_catalog','information_schema','pg_toast')
       AND c.relkind IN ('r','p','S','v','m')
-      AND pg_get_userbyid(c.relowner) = 'postgres'"
+      AND pg_get_userbyid(c.relowner) = 'postgres'")" && asked=yes || asked=no
+
+if [ "$asked" != yes ]; then
+  echo "COULD NOT CHECK $app_db — the query itself failed, so nothing is proven."
+elif [ -n "$left" ]; then
+  echo "STILL OWNED BY postgres — the transfer is unfinished:"
+  echo "$left"
+else
+  echo "TRANSFER COMPLETE: re-run the script and the rotation goes through."
+fi
 ```
 
-Empty output means the transfer is complete: re-run the script and the rotation
-goes through. The `relkind` filter and `pg_toast` are not tidiness — without
+The verdict is gated on the query having been answered, not on its output being
+empty. A `psql` that cannot connect — the database was renamed, the cluster is
+down — prints its `FATAL` on stderr and leaves stdout empty, which is the same
+thing a completed transfer looks like. "Could not be checked" is not "checked
+and clear". The `relkind` filter and `pg_toast` are not tidiness — without
 them the query returns several dozen catalog TOAST tables that `postgres` owns
 on every cluster and can never come back empty, so it would report a completed
 transfer as unfinished. Indexes and TOAST tables have no ownership of their own;
@@ -1174,7 +1222,7 @@ both the Lightsail firewall and ufw (the script already allows 443).
 | Launch script did nothing | `/var/log/collavre-launch.log`, `/var/log/cloud-init-output.log` |
 | `kamal` can't SSH | `sudo cat /home/collavre/.ssh/authorized_keys` — empty means no `SSH_PUBLIC_KEY` and no key to copy |
 | `kamal` SSH works, Docker denied | Reconnect: `docker` group membership needs a new session |
-| `sudo: a password is required` | The deploy user has no password, so `%sudo` alone cannot authenticate it. `sudo ls /etc/sudoers.d/90-collavre-*` from the `ubuntu` account — missing means the host predates that grant; re-run the launch script with `FORCE=1` |
+| `sudo: a password is required` | The deploy user has no password, so `%sudo` alone cannot authenticate it. `sudo ls /etc/sudoers.d/90-collavre-*` from the `ubuntu` account — missing means the host predates that grant; re-run the launch script with `FORCE=1` **and every setting in `/var/lib/collavre/launch.env`**, or the re-run is refused |
 | App: `could not connect to server` | `sudo ss -lntp \| grep 5432` should show `127.0.0.1:5432` **and** `172.17.0.1:5432` |
 | App: `password authentication failed` | `sudo cat /var/lib/collavre/db_password` vs `DATABASE_URL` — the URL holds the [percent-encoded](#a-custom-db_password-is-percent-encoded-in-database_url) form |
 | PostgreSQL won't start after reboot | `sysctl net.ipv4.ip_nonlocal_bind` must be `1`; `journalctl -u postgresql@17-main` |

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -436,8 +436,12 @@ To actually move to a new name, do it deliberately and then tell the script:
 # the marker describe the cluster rather than describe a command that reported
 # success. `grep -qx` is the gate rather than psql's own status, so an empty
 # answer — a query that failed, a cluster that went away — fails closed.
+# Both names are double-quoted because you are substituting your own into them,
+# and DB_NAME accepts names an unquoted identifier cannot carry: the launch
+# script creates them through `format('%I')`, so `collavre-prod` is legal there
+# and a syntax error here without the quotes.
 sudo -u postgres psql -qd postgres -c \
-  "ALTER DATABASE collavre_production RENAME TO collavre_prod" &&
+  "ALTER DATABASE \"collavre_production\" RENAME TO \"collavre_prod\"" &&
   sudo -u postgres psql -qtAd postgres -c \
     "SELECT 1 FROM pg_database WHERE datname = 'collavre_prod'" | grep -qx 1 &&
   echo collavre_prod | sudo tee /var/lib/collavre/db_name
@@ -664,9 +668,53 @@ sudo cat /var/lib/collavre/db_name   # <db-name>
   is what `MIGRATION_RUN_USER` is for, and dotenv never touches it.
 
   ```bash
+  # Stop the source deployment before anything below reads its files, then say
+  # so here. `./kamal.sh app stop` further down stops the *new* instance's app,
+  # which is holding an empty database — it says nothing about the deployment
+  # still serving the SQLite file this recipe copies.
+  #
+  # This is asked rather than checked because SQLite gives no answer to ask for.
+  # The PostgreSQL path above can list pg_stat_activity; here the file is the
+  # only witness, and it looks the same whether the writer went away or is
+  # simply between requests. So a check would be the reassurance without the
+  # fact, and the one thing it must not do is report "quiet" about a source
+  # that is still committing.
+  source_quiesced=${source_quiesced:-}
+  if [ "$source_quiesced" != 1 ]; then
+    echo "REFUSING: the source deployment has not been declared stopped."
+    echo "  Nothing has been copied, granted or converted."
+    echo "  Stop it (or put it in maintenance mode) so no further writes land,"
+    echo "  then re-run this block with:"
+    echo "    source_quiesced=1"
+    echo "  Writes committed to the source after the snapshot below are not"
+    echo "  migrated and are not detectable afterwards: the converted database"
+    echo "  is complete as of the snapshot and says nothing about what came next."
+  else
+
   ./kamal.sh setup
   ./kamal.sh app stop   # no writes while the schema is dropped and reloaded
   stop_status=$?
+
+  # Snapshot the source rather than copying its file. config/database.yml runs
+  # SQLite with `journal_mode: WAL`, so transactions committed since the last
+  # checkpoint live in production-primary.sqlite3-wal and are simply absent from
+  # the main file — a copy of it alone converts cleanly, reports success, and is
+  # missing the most recent rows with nothing to indicate it. VACUUM INTO writes
+  # one self-contained file with the WAL folded in and no -wal/-shm companions
+  # to forget, and it reads a consistent snapshot rather than a file that may be
+  # written mid-transfer.
+  #
+  # No fallback to `cp` if sqlite3 is missing: that is the bug, not a
+  # workaround. Install it on the machine holding the source, or take the
+  # snapshot wherever that machine can.
+  snap_status=1
+  snap_dir=
+  if [ "$stop_status" -eq 0 ] && command -v sqlite3 >/dev/null; then
+    snap_dir="$(mktemp -d)"
+    sqlite3 storage/production-primary.sqlite3 \
+      "VACUUM INTO '$snap_dir/production-primary.sqlite3'"
+    snap_status=$?
+  fi
 
   # The task reads the SQLite file from inside the container. /rails/storage is
   # the plan42_storage volume, shared by every container of the app, and uid
@@ -674,8 +722,9 @@ sudo cat /var/lib/collavre/db_name   # <db-name>
   # Stage under a temporary name and rename into place, so the task can only
   # ever see a complete file. stage_status covers the whole staging step.
   stage_status=1
-  if [ "$stop_status" -eq 0 ]; then
-    scp storage/production-primary.sqlite3 <deploy-user>@<instance-ip>:/tmp/ &&
+  if [ "$snap_status" -eq 0 ]; then
+    scp "$snap_dir/production-primary.sqlite3" \
+        <deploy-user>@<instance-ip>:/tmp/ &&
       ssh <deploy-user>@<instance-ip> \
         'vol="$(docker volume inspect plan42_storage --format "{{.Mountpoint}}")" &&
          sudo install -o 1000 -g 1000 -m 0600 /tmp/production-primary.sqlite3 \
@@ -686,15 +735,49 @@ sudo cat /var/lib/collavre/db_name   # <db-name>
     stage_status=$?
   fi
 
+  # Active Storage blobs. The conversion copies active_storage_blobs *rows*; the
+  # files those rows name are not in the database. With no S3 credentials
+  # config/environments/production.rb selects `:local`, and config/storage.yml
+  # roots that service at Rails.root/storage — the same directory as the SQLite
+  # file — so on such a source the blobs are on disk beside it while
+  # plan42_storage on the new instance is newly created and empty. Skipped,
+  # every attachment 404s after boot from metadata that insists it exists.
+  #
+  # Harmless when the source used S3: blob keys fan out into two-character
+  # directories, the exclude drops the SQLite files and their -wal/-shm
+  # companions, and what is left to send is then nothing.
+  blob_status=1
+  if [ "$stage_status" -eq 0 ]; then
+    tar -cf - -C storage --exclude='*.sqlite3*' . |
+      ssh <deploy-user>@<instance-ip> \
+        'vol="$(docker volume inspect plan42_storage --format "{{.Mountpoint}}")" &&
+         sudo tar -xf - -C "$vol" --no-same-owner &&
+         sudo chown -R 1000:1000 "$vol"'
+    # Not $?, which is only ssh's: a tar that fails to read the source would
+    # otherwise send an empty stream to a receiver that unpacks it happily.
+    blob_status=$(( ${PIPESTATUS[0]} | ${PIPESTATUS[1]} ))
+  fi
+
   if [ "$stop_status" -ne 0 ]; then
     echo "STOP FAILED: a container may still be serving and polling this database"
     echo "nothing was staged, granted or converted"
     echo "check './kamal.sh app details' before retrying — do not convert while it runs"
+  elif [ "$snap_status" -ne 0 ]; then
+    command -v sqlite3 >/dev/null ||
+      echo "SNAPSHOT FAILED: no sqlite3 on this machine"
+    echo "SNAPSHOT FAILED: nothing was staged, granted or converted"
+    echo "the source is untouched — VACUUM INTO only reads it"
+    echo "app left stopped on purpose; snapshot before converting"
   elif [ "$stage_status" -ne 0 ]; then
     echo "STAGING FAILED: nothing was granted and nothing was converted"
     echo "the volume still holds whatever was there before — on a retry that is"
     echo "the stale snapshot the previous attempt deliberately kept"
     echo "app left stopped on purpose; re-stage before converting"
+  elif [ "$blob_status" -ne 0 ]; then
+    echo "BLOB COPY FAILED: nothing was granted and nothing was converted"
+    echo "the database was not touched, so this is safe to retry from the top"
+    echo "converting now would boot an app whose attachments are all missing"
+    echo "app left stopped on purpose; copy the blobs before converting"
   else
     # The copy disables referential integrity, which is superuser-only.
     ssh <deploy-user>@<instance-ip> \
@@ -726,7 +809,41 @@ sudo cat /var/lib/collavre/db_name   # <db-name>
       echo "app left stopped on purpose; do not boot it until the above is cleared"
     fi
   fi
+
+  # Deliberately not kept for a retry, unlike the PostgreSQL dump above. That
+  # one is a transfer that can be repeated; this is a point-in-time snapshot of
+  # a database that has since been stopped and may have been restarted, so a
+  # second attempt has to take a fresh one rather than convert this.
+  [ -z "$snap_dir" ] || rm -rf "$snap_dir"
+
+  fi
   ```
+
+  **Why the snapshot and not the file.** With a writer still attached, the main
+  database file and the database are not the same thing:
+
+  ```
+  writer holds the connection, two rows committed since the last checkpoint
+    production-primary.sqlite3        8192 bytes
+    production-primary.sqlite3-wal    4152 bytes
+    rows the writer sees                   3
+    rows in a copy of the main file        1     <- what the old recipe sent
+    rows in VACUUM INTO's snapshot         3
+  ```
+
+  Nothing downstream notices the difference. The conversion succeeds, the app
+  boots, and the two missing rows are missing — which is why this is the one
+  step here that must not be a plain copy. It is also why a source that shut
+  down cleanly hides the problem: closing the last connection checkpoints the
+  WAL to zero, so the file is complete exactly when you did the thing that made
+  it complete, and incomplete on precisely the run where nobody stopped the
+  source.
+
+  **Blob files are a second migration, not a detail of this one.** The converter
+  says so itself — "only DB metadata rows are copied … leave the storage
+  volume/bucket as-is" — which is correct advice for swapping a database under a
+  deployment that stays put, and wrong here, because this page is moving hosts.
+  The volume it lands on is new.
 
   **The conversion is gated on staging for a reason that only shows up on a
   retry.** `MIGRATION_RUN_RESET` drops the schema and reloads it from the
@@ -1008,8 +1125,13 @@ elif [ "$app_super" != f ]; then
   restore_status=3
 else
 
+# Double-quoted, because $app_db came out of a state file rather than out of
+# this page: DB_NAME is an operator setting, and the launch script creates
+# whatever it is given through `format('%I')`. `collavre-prod` is a legal
+# database name there and a syntax error here unquoted — PostgreSQL reads the
+# hyphen as subtraction. Quoting is right for an ordinary name too.
 sudo -u postgres psql -qd postgres -c \
-  "ALTER DATABASE $app_db CONNECTION LIMIT 0"
+  "ALTER DATABASE \"$app_db\" CONNECTION LIMIT 0"
 
 # Read the limit back rather than trusting that the line above ran. These
 # blocks are pasted into an interactive shell with no `set -e`, so a failed
@@ -1072,7 +1194,7 @@ fi
 reopen_status=0
 if [ "$restore_status" -eq 0 ] || [ "$restore_status" -eq 2 ]; then
   sudo -u postgres psql -qd postgres -c \
-    "ALTER DATABASE $app_db CONNECTION LIMIT -1"
+    "ALTER DATABASE \"$app_db\" CONNECTION LIMIT -1"
   reopen_status=$?
 fi
 
@@ -1098,7 +1220,9 @@ if [ "$reopen_status" -ne 0 ]; then
   echo "  The app will be refused at boot with 'too many connections', which"
   echo "  will read like a pool problem. Do not boot it until this succeeds:"
   echo "  sudo -u postgres psql -qd postgres -c \\"
-  echo "    \"ALTER DATABASE $app_db CONNECTION LIMIT -1\""
+  # Single-quoted for the shell so the identifier's own double quotes survive
+  # being pasted — the recovery this prints has to be runnable as printed.
+  echo "    'ALTER DATABASE \"$app_db\" CONNECTION LIMIT -1'"
   echo "  Confirm with:"
   echo "  sudo -u postgres psql -qtAd postgres -c \\"
   echo "    \"SELECT datconnlimit FROM pg_database WHERE datname = '$app_db'\""
@@ -1114,7 +1238,7 @@ else
   echo "  so fix the cause and run this block again — it needs no other step."
   echo "If instead you are abandoning the restore, re-open it by hand with:"
   echo "  sudo -u postgres psql -qd postgres -c \\"
-  echo "    \"ALTER DATABASE $app_db CONNECTION LIMIT -1\""
+  echo "    'ALTER DATABASE \"$app_db\" CONNECTION LIMIT -1'"
 fi
 ```
 

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -4,13 +4,13 @@ This runbook provisions a single Lightsail instance that runs both PostgreSQL
 and the Collavre container, deployed with Kamal from your workstation.
 
 [`script/lightsail_launch.sh`](../script/lightsail_launch.sh) does the host
-preparation. It never builds or starts the app — `bin/kamal setup` does that.
+preparation. It never builds or starts the app — `./kamal.sh setup` does that.
 
 | The launch script sets up | You still do |
 | --- | --- |
 | Base packages, timezone, swap, SSH hardening | Lightsail console firewall (80/443) |
 | Deploy user in the `docker` group | `.env.production` on your workstation |
-| Docker CE + buildx + compose, capped container logs | `bin/kamal setup` |
+| Docker CE + buildx + compose, capped container logs | `./kamal.sh setup` |
 | PostgreSQL, private to this host | Loading the schema / restoring data |
 | `collavre_production` + `collavre_user` | DNS and TLS |
 | ufw, nightly `pg_dump` with retention | |
@@ -120,7 +120,11 @@ have to be set. Then:
 ./kamal.sh logs
 ```
 
-`kamal.sh` wraps `bin/kamal` with `.env.production` loaded.
+`kamal.sh` wraps `bin/kamal` with `.env.production` loaded, and is the only
+thing that reads that file — `bin/kamal setup` on its own sees an empty
+`COLLAVRE_SERVER` and falls back to the default `deploy` SSH user. Run it from
+the repo root (the wrapper's paths are relative) with `RAILS_ENV` unset or
+`production`, since it loads `.env.$RAILS_ENV`.
 
 ## 5. Get data into the new database
 

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -196,7 +196,8 @@ the SQLite converter needs the app image and so runs after it, app stopped.
     "sudo -u postgres psql -c 'ALTER ROLE collavre_user SUPERUSER'"
 
   ./kamal.sh app exec \
-    'bin/rails "db:sqlite_to_postgres[storage/production-primary.sqlite3,production]"'
+    'bin/rails "db:sqlite_to_postgres[storage/production-primary.sqlite3,production]"' \
+    -e MIGRATION_RUN_RESET:true
 
   ssh collavre@<instance-ip> \
     "sudo -u postgres psql -c 'ALTER ROLE collavre_user NOSUPERUSER'"
@@ -216,6 +217,15 @@ the SQLite converter needs the app image and so runs after it, app stopped.
   back afterwards: the other route the task offers,
   `MIGRATION_RUN_USER=postgres`, would mean giving the superuser role a
   password that every container on the host could then authenticate with.
+
+  `MIGRATION_RUN_RESET=true` matters because `setup` has already run the
+  migration replay this section opened by distrusting. The task's schema load
+  uses `force: :cascade`, which drops only the tables `db/schema.rb` still
+  knows about, so anything the replay left behind that the schema has since
+  dropped would survive into the migrated database. `MIGRATION_RUN_RESET`
+  does `DROP SCHEMA public CASCADE` first — a real clean slate, superuser-only,
+  which the grant above already covers. It trails the command for the same
+  Thor-hash reason as the fresh-install recipe below.
 
   No `DISABLE_DATABASE_ENVIRONMENT_CHECK` here, unlike the fresh install below.
   The task calls `DatabaseTasks.load_schema` directly instead of the

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -765,6 +765,31 @@ journalctl -u collavre-pg-backup.service        # check last run
 # trust that it ran, shut the database itself to the app for the duration.
 # CONNECTION LIMIT 0 does not apply to superusers, so pg_restore below still
 # connects; a container that survived the stop, or restarts mid-restore, cannot.
+
+# First, whether that last clause is true on THIS host. The exemption that lets
+# pg_restore in is role-wide, so it lets the app in too whenever the app's own
+# role is a superuser — and `DB_USER=postgres` on a first run is legal (see
+# "Changing DB_USER on a re-run"). Refusing before the ALTER rather than after
+# it, so a refusal leaves the connection limit exactly as the operator had it.
+app_role=$(sudo cat /var/lib/collavre/db_user 2>/dev/null)
+app_super=$(sudo -u postgres psql -qtAd postgres -c \
+  "SELECT rolsuper FROM pg_roles WHERE rolname = '$app_role'" 2>/dev/null)
+if [ "$app_super" != f ]; then
+  echo "REFUSING: cannot shut this database to the app."
+  echo "  DB_USER is '$app_role' and its rolsuper is '$app_super' — anything but"
+  echo "  'f' means the gate below cannot tell your app apart from pg_restore,"
+  echo "  because CONNECTION LIMIT does not apply to superusers. An empty value"
+  echo "  means the question could not be answered (no /var/lib/collavre/db_user,"
+  echo "  no such role, cluster unreachable), which is not the same as 'no'."
+  echo "Nothing was changed. On your workstation, confirm the app is really gone:"
+  echo "  ./kamal.sh app details          # no running container"
+  echo "then run the rest of this block by hand. There is no in-database way to"
+  echo "exclude a superuser app while admitting pg_restore: if DB_USER really is"
+  echo "'postgres' they are the same role, and ALTER ROLE postgres NOLOGIN locks"
+  echo "out the restore along with the app."
+  restore_status=3
+else
+
 sudo -u postgres psql -qd postgres -c \
   "ALTER DATABASE collavre_production CONNECTION LIMIT 0"
 
@@ -814,6 +839,8 @@ else
   sudo -u postgres pg_restore --clean --if-exists -d collavre_production \
     /var/backups/collavre/collavre_production-YYYYmmdd-HHMMSS.dump
   restore_status=$?
+fi
+
 fi
 
 fi
@@ -875,6 +902,23 @@ it, which is why `pg_restore` still connects while the app cannot. The
 `pg_terminate_backend` clears whatever was already attached, and the check
 afterwards then means something — it is asking whether anything got past a
 closed door, not whether the app happened to be quiet.
+
+**That exemption is role-wide, so the block refuses a superuser `DB_USER`
+before it shuts anything.** It is the same property working in both directions:
+on `postgres:17` with `datconnlimit` at `0`, an ordinary role is turned away
+with `FATAL: too many connections for database "collavre_production"`, and
+`postgres` connects and writes a row. `DB_USER=postgres` on a first run is
+legal, so this is a host the script produces rather than a misconfiguration —
+and on it the door would be shut against nobody while the surrounding prose,
+and the `live` count that follows, both read as though it were shut. There is
+no in-database way out: on that host the app's role and `pg_restore`'s role are
+the same role, so nothing distinguishes them, and `ALTER ROLE postgres NOLOGIN`
+locks out the restore along with the app. So the block stops and hands the
+operator the only check that does discriminate, which is on the workstation,
+and it stops *before* the `ALTER` so a refusal leaves the connection limit as
+it found it. The condition is `!= f` rather than `= t`: an unanswerable
+question — no state file, no such role, cluster unreachable — has to read as
+the unsafe answer, the same rule as the `live` comparison below it.
 
 **A failed restore keeps the door shut.** `pg_restore --clean` drops before it
 reloads, so a run that dies partway leaves the database genuinely half-replaced

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -204,14 +204,16 @@ ssh -i ~/.ssh/<staged-key> <new-user>@<instance-ip> \
 
 Run that exact command from the workstation with the key Kamal will use. The
 finalizer checks that it is running through an `sshd` process tree containing
-the staged account's real UID, that `SUDO_USER` is that account, and that the
-nonce matches. For an explicit key rotation it also reads the session's
-root-configured `ExposeAuthInfo` record and requires its public-key fingerprint
-to match the staged key; logging in with the predecessor key cannot finalize
-the rotation. Provisioning verifies that `ExposeAuthInfo yes` is effective
-before staging, and stores the nonce hash, fingerprint, and exact key in one
-atomic root-only pending record so an interrupted re-run cannot mix cutover
-generations. Only then does it take `docker` and `sudo` from every predecessor,
+an `sshd` session process owned by the staged account, that `SUDO_USER` is that
+account, that its `SSH_USER_AUTH` record is owned by the same account, and that
+the nonce matches. This rejects a nested `sudo -u <staged-user>` launched from
+the predecessor's SSH session. For an explicit key rotation it also requires
+the authentication record's public-key fingerprint to match the staged key;
+logging in with the predecessor key cannot finalize the rotation. Provisioning
+verifies that `ExposeAuthInfo yes` is effective before every cutover, and stores
+the nonce hash, fingerprint, and exact key in one atomic root-only pending
+record so an interrupted re-run cannot mix cutover generations. Only then does
+it take `docker` and `sudo` from every predecessor,
 remove their script-managed
 `sudoers.d` grants, withdraw predecessor managed keys, and commit
 `/var/lib/collavre/deploy_user`. Change `KAMAL_SSH_USER` only after the command

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -228,6 +228,25 @@ there is no way back in. Move ownership and retire that role by hand.
 Rotating the *password* rather than the role needs none of this — set
 `DB_PASSWORD`, re-run, and update `DATABASE_URL`.
 
+### Changing `SWAP_SIZE_MB` on a re-run
+
+A re-run compares the size of `/swapfile` on disk, so raising or lowering the
+value resizes it and `SWAP_SIZE_MB=0` removes it. Two cases stop short of that,
+both reported and neither fatal, because raising this is usually a response to
+memory pressure and a run that aborts — or that leaves the host with less swap
+than it had — makes the thing it was called about worse:
+
+- **`swapoff` fails.** The pages cannot be faulted back into RAM, which is
+  precisely the low-memory condition being fixed. The old swap keeps running,
+  unchanged. Free some memory and re-run.
+- **The new size does not fit on the disk.** Growing means freeing the old file
+  first, so the previous size is re-created and re-enabled instead. Grow the
+  disk or lower `SWAP_SIZE_MB`, then re-run.
+
+In both cases the log says the value did not take effect and what is running
+instead. A *first* run that cannot allocate has nothing to fall back to and
+stops the provisioning run.
+
 ## 3. How PostgreSQL is reachable
 
 PostgreSQL listens on `localhost` and `172.17.0.1` — the docker0 bridge

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -56,6 +56,14 @@ Common overrides:
 | `SWAP_SIZE_MB` | `2048` | `0` disables |
 | `BACKUP_S3_URI` | *(empty)* | e.g. `s3://collavre-backups/pg` — PostgreSQL only, [not uploaded files](#backup_s3_uri-does-not-cover-uploaded-files) |
 
+`DB_NAME` and `DB_USER` must be letters, digits, `_` and `-`, not starting with
+`-`; anything else is refused before the run starts. PostgreSQL itself is more
+permissive — the script creates both through `format('%I')`, which quotes
+whatever it is given — but `DB_NAME` is also a *filename*: the nightly dump is
+written to `/var/backups/collavre/$DB_NAME-<stamp>.dump`, so a `/` in the name
+puts it under a directory that does not exist and every backup fails on a host
+that otherwise runs perfectly well.
+
 It also runs fine by hand on an existing instance, and re-running converges the
 host instead of duplicating config:
 
@@ -1134,6 +1142,15 @@ app_role=$(sudo cat /var/lib/collavre/db_user 2>/dev/null)
 # it, so a refusal leaves the connection limit exactly as the operator had it.
 app_super=$(sudo -u postgres psql -qtAd postgres -c \
   "SELECT rolsuper FROM pg_roles WHERE rolname = '$app_role'" 2>/dev/null)
+
+# And what the limit was before this block touched it, read here because after
+# the ALTER below it is 0 and the previous value is gone. `-1` is only the
+# default; an operator who capped this database has that cap in `datconnlimit`
+# and nowhere else, so re-opening to a literal `-1` would not restore the
+# database to what it was, it would silently lift a limit — on every successful
+# restore, and on the idle refusal too, which touches nothing else at all.
+prior_limit=$(sudo -u postgres psql -qtAd postgres -c \
+  "SELECT datconnlimit FROM pg_database WHERE datname = '$app_db'" 2>/dev/null)
 if [ -z "$app_db" ]; then
   echo "REFUSING: cannot tell which database to restore."
   echo "  /var/lib/collavre/db_name is missing or unreadable. That file is"
@@ -1230,10 +1247,29 @@ fi
 # connections", which reads like a pool problem and not like a step this block
 # forgot to undo, so it must not be left shut by accident. On the failure path
 # it is left shut on purpose; on status 3 it was never shut to begin with.
+#
+# Back to what it was, not to -1. The one case where that cannot be honoured is
+# a $prior_limit that is not a number — the read above failed while the ALTER
+# still took — and there -1 is the lesser wrong: leaving the door shut for want
+# of a value produces exactly the misdirected "too many connections" this
+# undoes. It is said out loud rather than assumed, because the operator is the
+# only one who knows what the cap was.
+reopen_limit=$prior_limit
+if ! printf '%s' "$prior_limit" | grep -qE '^-?[0-9]+$'; then
+  reopen_limit=-1
+  # Only where it changes what happens next. On status 3 this block never shut
+  # the door and never opens it, so the previous limit is still in force and
+  # saying it could not be read would be a warning about nothing.
+  if [ "$restore_status" -ne 3 ]; then
+    echo "NOTE: could not read $app_db's previous connection limit ('$prior_limit')."
+    echo "  Re-opening to -1, the default. If you had capped this database, set"
+    echo "  the cap again by hand once this block finishes."
+  fi
+fi
 reopen_status=0
 if [ "$restore_status" -eq 0 ] || [ "$restore_status" -eq 2 ]; then
   sudo -u postgres psql -qd postgres -c \
-    "ALTER DATABASE \"$app_db\" CONNECTION LIMIT -1"
+    "ALTER DATABASE \"$app_db\" CONNECTION LIMIT $reopen_limit"
   reopen_status=$?
 fi
 
@@ -1261,12 +1297,25 @@ if [ "$reopen_status" -ne 0 ]; then
   echo "  sudo -u postgres psql -qd postgres -c \\"
   # Single-quoted for the shell so the identifier's own double quotes survive
   # being pasted — the recovery this prints has to be runnable as printed.
-  echo "    'ALTER DATABASE \"$app_db\" CONNECTION LIMIT -1'"
+  echo "    'ALTER DATABASE \"$app_db\" CONNECTION LIMIT $reopen_limit'"
   echo "  Confirm with:"
   echo "  sudo -u postgres psql -qtAd postgres -c \\"
   echo "    \"SELECT datconnlimit FROM pg_database WHERE datname = '$app_db'\""
 elif [ "$restore_status" -eq 0 ]; then
-  echo "restored; boot the app from your workstation: ./kamal.sh app boot"
+  # Putting the limit back faithfully has one consequence worth naming: if it
+  # was already 0, the door this block opens is the one the operator closed, and
+  # "boot the app" would be an instruction to meet "too many connections". That
+  # is their configuration rather than this block's leftover, so it is reported
+  # rather than overridden.
+  if [ "$reopen_limit" = 0 ]; then
+    echo "restored, and $app_db is back at 'CONNECTION LIMIT 0' — which is where"
+    echo "  it was before this block ran, not something left behind here. The app"
+    echo "  will be refused at boot until you lift it:"
+    echo "  sudo -u postgres psql -qd postgres -c \\"
+    echo "    'ALTER DATABASE \"$app_db\" CONNECTION LIMIT -1'"
+  else
+    echo "restored; boot the app from your workstation: ./kamal.sh app boot"
+  fi
 elif [ "$restore_status" -eq 2 ] || [ "$restore_status" -eq 3 ]; then
   : # refused before touching anything — see the message above
 else
@@ -1277,7 +1326,7 @@ else
   echo "  so fix the cause and run this block again — it needs no other step."
   echo "If instead you are abandoning the restore, re-open it by hand with:"
   echo "  sudo -u postgres psql -qd postgres -c \\"
-  echo "    'ALTER DATABASE \"$app_db\" CONNECTION LIMIT -1'"
+  echo "    'ALTER DATABASE \"$app_db\" CONNECTION LIMIT $reopen_limit'"
 fi
 ```
 

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -259,42 +259,67 @@ container polling the database they are about to replace.
   # The task reads the SQLite file from inside the container. /rails/storage is
   # the plan42_storage volume, shared by every container of the app, and uid
   # 1000 is the image's `rails` user.
-  scp storage/production-primary.sqlite3 collavre@<instance-ip>:/tmp/
-  ssh collavre@<instance-ip> \
-    'sudo install -o 1000 -g 1000 -m 0600 /tmp/production-primary.sqlite3 \
-       "$(docker volume inspect plan42_storage --format "{{.Mountpoint}}")/" &&
-     rm /tmp/production-primary.sqlite3'
-
-  # The copy disables referential integrity, which is superuser-only.
-  ssh collavre@<instance-ip> \
-    "sudo -u postgres psql -c 'ALTER ROLE collavre_user SUPERUSER'"
-
-  ./kamal.sh app exec \
-    'bin/rails "db:sqlite_to_postgres[storage/production-primary.sqlite3,production]"' \
-    -e MIGRATION_RUN_RESET:true
-  copy_status=$?
-
-  # Take the grant back whether or not the copy worked — a failed cutover is
-  # precisely when it would otherwise sit there.
-  ssh collavre@<instance-ip> \
-    "sudo -u postgres psql -c 'ALTER ROLE collavre_user NOSUPERUSER'"
-  revoke_status=$?
-
-  # Clean up and boot only if both worked. Either failure leaves the app down.
-  if [ "$copy_status" -eq 0 ] && [ "$revoke_status" -eq 0 ]; then
+  # Stage under a temporary name and rename into place, so the task can only
+  # ever see a complete file. stage_status covers the whole staging step.
+  scp storage/production-primary.sqlite3 collavre@<instance-ip>:/tmp/ &&
     ssh collavre@<instance-ip> \
-      'sudo rm "$(docker volume inspect plan42_storage \
-         --format "{{.Mountpoint}}")/production-primary.sqlite3"'
+      'vol="$(docker volume inspect plan42_storage --format "{{.Mountpoint}}")" &&
+       sudo install -o 1000 -g 1000 -m 0600 /tmp/production-primary.sqlite3 \
+         "$vol/production-primary.sqlite3.incoming" &&
+       sudo mv "$vol/production-primary.sqlite3.incoming" \
+               "$vol/production-primary.sqlite3" &&
+       rm /tmp/production-primary.sqlite3'
+  stage_status=$?
 
-    ./kamal.sh app boot   # restart on the data you just loaded
+  if [ "$stage_status" -ne 0 ]; then
+    echo "STAGING FAILED: nothing was granted and nothing was converted"
+    echo "the volume still holds whatever was there before — on a retry that is"
+    echo "the stale snapshot the previous attempt deliberately kept"
+    echo "app left stopped on purpose; re-stage before converting"
   else
-    [ "$revoke_status" -eq 0 ] ||
-      echo "REVOKE FAILED: collavre_user is still a superuser — take it back by hand"
-    [ "$copy_status" -eq 0 ] ||
-      echo "COPY FAILED: this database is now empty or half-loaded"
-    echo "app left stopped on purpose; do not boot it until the above is cleared"
+    # The copy disables referential integrity, which is superuser-only.
+    ssh collavre@<instance-ip> \
+      "sudo -u postgres psql -c 'ALTER ROLE collavre_user SUPERUSER'"
+
+    ./kamal.sh app exec \
+      'bin/rails "db:sqlite_to_postgres[storage/production-primary.sqlite3,production]"' \
+      -e MIGRATION_RUN_RESET:true
+    copy_status=$?
+
+    # Take the grant back whether or not the copy worked — a failed cutover is
+    # precisely when it would otherwise sit there.
+    ssh collavre@<instance-ip> \
+      "sudo -u postgres psql -c 'ALTER ROLE collavre_user NOSUPERUSER'"
+    revoke_status=$?
+
+    # Clean up and boot only if both worked. Either failure leaves the app down.
+    if [ "$copy_status" -eq 0 ] && [ "$revoke_status" -eq 0 ]; then
+      ssh collavre@<instance-ip> \
+        'sudo rm "$(docker volume inspect plan42_storage \
+           --format "{{.Mountpoint}}")/production-primary.sqlite3"'
+
+      ./kamal.sh app boot   # restart on the data you just loaded
+    else
+      [ "$revoke_status" -eq 0 ] ||
+        echo "REVOKE FAILED: collavre_user is still a superuser — take it back by hand"
+      [ "$copy_status" -eq 0 ] ||
+        echo "COPY FAILED: this database is now empty or half-loaded"
+      echo "app left stopped on purpose; do not boot it until the above is cleared"
+    fi
   fi
   ```
+
+  **The conversion is gated on staging for a reason that only shows up on a
+  retry.** `MIGRATION_RUN_RESET` drops the schema and reloads it from the
+  SQLite file *in the volume* — never from the file `scp` just sent. Those are
+  the same file only when staging worked. When it did not, the volume still
+  holds the previous attempt's snapshot, which the failure path above
+  deliberately keeps so a retry does not need another full copy over the wire.
+  Ungated, a failed `scp` therefore converts from that stale snapshot, reports
+  success, deletes it, and boots the app on older data — a silent rollback of
+  production, and the loudest signal is a timestamp nobody is looking at. The
+  rename makes the staging step atomic as well, so a copy interrupted midway
+  leaves the previous file in place rather than a truncated database.
 
   The grant is not optional. The launch script creates the role with
   `CREATE ROLE ... LOGIN` and nothing else, and the copy runs

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -48,8 +48,8 @@ Common overrides:
 
 | Variable | Default | Notes |
 | --- | --- | --- |
-| `SSH_PUBLIC_KEY` | *(empty)* | Empty = copy `ubuntu`'s `authorized_keys`. [Changing it on a re-run](#rotating-ssh_public_key-on-a-re-run) withdraws the key it replaces |
-| `APP_SSH_USER` | `collavre` | Must match `KAMAL_SSH_USER`. Gets passwordless sudo — the maintenance commands below are sent non-interactively and cannot answer a prompt. [Changing it on a re-run](#changing-app_ssh_user-on-a-re-run) disarms the account it replaces |
+| `SSH_PUBLIC_KEY` | *(empty)* | Empty = copy `ubuntu`'s `authorized_keys`. [Changing it on a re-run](#rotating-ssh_public_key-on-a-re-run) stages the new key; the old key is withdrawn only after an SSH-session proof |
+| `APP_SSH_USER` | `collavre` | Becomes `KAMAL_SSH_USER` only after the SSH cutover is finalized. Gets passwordless sudo because the maintenance commands below are non-interactive. [Changing it on a re-run](#changing-app_ssh_user-on-a-re-run) is a two-phase cutover |
 | `PG_MAJOR` | `17` | Match the source database when restoring a dump. [Changing it on a re-run](#changing-pg_major-on-a-re-run) is refused, not converged |
 | `DB_PASSWORD` | *(generated)* | Generated password is alphanumeric; a custom one is [percent-encoded into `DATABASE_URL`](#a-custom-db_password-is-percent-encoded-in-database_url) |
 | `DB_USER` | `collavre_user` | [Changing it on a re-run](#changing-db_user-on-a-re-run) moves table ownership to the new role and takes `LOGIN` from the old one |
@@ -81,8 +81,8 @@ previous logging configuration remains in effect.
 **A re-run applies every setting in the table, not only the ones you name.** An
 override you used the first time and did not repeat is applied as its default,
 and three of those defaults do not converge the host — they rotate it.
-`APP_SSH_USER` back to `collavre` arms a new account and takes `docker`, `sudo`
-and the `sudoers.d` grant from the one your `KAMAL_SSH_USER` names; `DB_USER`
+`APP_SSH_USER` back to `collavre` stages a new account and an SSH cutover;
+`DB_USER`
 back to `collavre_user` moves table ownership and takes `LOGIN` from the role
 in the deployed `DATABASE_URL`. An omitted `SSH_PUBLIC_KEY` means "reuse the
 cloud user's key", so the run copies `ubuntu`'s `authorized_keys` into the
@@ -187,9 +187,38 @@ into it.
 
 ### Changing `APP_SSH_USER` on a re-run
 
-A `FORCE=1` re-run with a different `APP_SSH_USER` creates the new account and
-then takes the `docker` and `sudo` groups back from the one it replaces, along
-with its `sudoers.d` grant. Docker membership is the part that matters:
+A `FORCE=1` re-run with a different `APP_SSH_USER` is deliberately a two-phase
+cutover. The provisioning phase creates and hardens the new account, installs
+its key, and grants `docker` plus passwordless `sudo`, but leaves the old
+account and its managed keys unchanged. Configuration analysis cannot prove
+that an external client can log in: `Match`, `Include`, admission rules, key
+paths, source addresses, and future sshd directives make that an open-ended
+problem.
+
+The root-only summary therefore contains a one-time command like this:
+
+```bash
+ssh -i ~/.ssh/<staged-key> <new-user>@<instance-ip> \
+  "sudo /usr/local/sbin/collavre-finalize-ssh-cutover --finalize-ssh-cutover '<nonce>'"
+```
+
+Run that exact command from the workstation with the key Kamal will use. The
+finalizer checks that it is running through an `sshd` process tree containing
+the staged account's real UID, that `SUDO_USER` is that account, and that the
+nonce matches. Only then does it take `docker` and `sudo` from every predecessor,
+remove their script-managed
+`sudoers.d` grants, withdraw predecessor managed keys, and commit
+`/var/lib/collavre/deploy_user`. Change `KAMAL_SSH_USER` only after the command
+prints `SSH cutover finalized`.
+
+If provisioning or finalization is interrupted,
+`/var/lib/collavre/ssh_cutover.pending` remains. The old account stays
+privileged, and the same finalize command is safe to retry. A different target
+cannot be staged over a pending cutover; finish the recorded transition first.
+This is intentional availability bias: a reported stale credential is safer
+than automatically removing the last proven way into the host.
+
+Docker membership is the part that makes finalization security-sensitive:
 `docker run -v /:/host` is a root shell, so an account left in that group has
 not been rotated away from in any meaningful sense — it has only lost the
 slower route.
@@ -206,7 +235,8 @@ account it failed on: pinning it is how a second rotation walks past the account
 in between and loses it. `/var/lib/collavre/deploy_user` still names the current
 deploy user, which is what the recipes on this page read.
 
-What the script will not do is delete the account or its `authorized_keys`. If
+What the finalizer will not do is delete the account or unmanaged keys in its
+`authorized_keys`. If
 the name it replaced were ever the instance's own cloud user, deleting it would
 remove the last way in. So the run leaves an ordinary, group-less account behind
 and says so in the launch log. Finish the rotation by hand once you have
@@ -276,22 +306,25 @@ passwordless sudo, so the key you believed you retired is still root on the
 box. Rotating away from a leaked key would have withdrawn nothing while
 reporting success.
 
-So the run withdraws the key it installed last time, recorded in
-`/var/lib/collavre/ssh_public_key.<user>`. Only that exact line goes: keys you
-added by hand, and the cloud user's original key, are matched whole-line and
-left alone.
+The run therefore adds the new key but does not withdraw its predecessor.
+Instead it creates the same pending SSH cutover described above. Connect with
+the new private key and run the nonce-bearing finalize command from the
+root-only summary. That real session is the safety boundary: only after it
+succeeds does the finalizer withdraw the key recorded in
+`/var/lib/collavre/ssh_public_key.<user>`. Only exact script-managed lines go;
+keys added by hand and the cloud user's original key are left alone.
 
 The record is **per account**, because `authorized_keys` is. Changing
 `APP_SSH_USER` and changing back is the case that needs it: rotating
 `collavre`/key-A to `deploybot`/key-B leaves key-A in `collavre`'s file, which is
-correct — that is not the file being rewritten, and the same re-run takes
+correct — that is not the file being rewritten, and the finalized cutover takes
 `docker` and sudo away from `collavre`. But coming back later to
 `collavre`/key-C regrants those privileges, and with one shared record the
 withdrawal would be looking for key-B, which was never in that file. Key-A would
 be root again, two rotations after you retired it. A host provisioned by an
 earlier revision has its single `ssh_public_key` file adopted by the account the
-next run names. The withdrawal happens *after* the new key is in place, so an
-interrupted run leaves two working keys rather than none.
+next run names. The withdrawal happens only after the new key has completed an
+SSH session, so an interrupted run leaves two working keys rather than none.
 
 Two cases deliberately do nothing. A re-run with `SSH_PUBLIC_KEY` unset means
 "keep using the cloud user's keys", not "retire mine" — dropping the variable

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -635,9 +635,8 @@ sudo cat /var/lib/collavre/db_name   # <db-name>
     scp collavre.dump <deploy-user>@<instance-ip>:/tmp/collavre.dump.incoming &&
     ssh <deploy-user>@<instance-ip> \
       'mv /tmp/collavre.dump.incoming /tmp/collavre.dump &&
-       pg_restore --no-owner --role=<db-user> --clean --if-exists \
-         -d "postgresql://<db-user>:<password>@127.0.0.1:5432/<db-name>" \
-         /tmp/collavre.dump &&
+       sudo -u postgres pg_restore --no-owner --role=<db-user> \
+         --clean --if-exists -d "<db-name>" /tmp/collavre.dump &&
        rm /tmp/collavre.dump'
   move_status=$?
 
@@ -660,6 +659,33 @@ sudo cat /var/lib/collavre/db_name   # <db-name>
   one on stale data. The transfer also lands on `.incoming` and is renamed, so an
   interrupted `scp` cannot leave a truncated archive at the path the restore
   reads.
+
+  **Why the restore goes through `sudo -u postgres` and not a connection URL.**
+  An earlier revision of this block had you paste `<password>` into
+  `postgresql://<db-user>:<password>@127.0.0.1:5432/<db-name>`, which
+  contradicts [the password section above](#a-custom-db_password-is-percent-encoded-in-database_url):
+  what the state file holds is the *raw* password, and the URL is the one place
+  it appears encoded. A `DB_PASSWORD` you chose yourself is then pasted into a
+  parser that reads parts of it as syntax. Measured against libpq 14.15:
+
+  ```
+  p@ss        could not translate host name "ss@127.0.0.1" to address
+  p/ss        could not translate host name "ss" to address
+  p%ss        invalid percent-encoded token: "p%ss"
+  pa%41ss     connects — as the password "paAss"
+  ```
+
+  The first three fail after the `scp`, with the source already in maintenance
+  mode. The fourth is the one worth the paragraph: it does not fail at all, it
+  authenticates with a different password than the one in the file, so the
+  restore works on a host where the app's own role would be rejected — a
+  password problem discovered at the next boot rather than here. (`#` and `?`
+  pass through libpq unharmed; the wider list in the password section is
+  Ruby's `URI.parse`, which is a different parser with a different answer.)
+
+  The local socket needs no password at all, and `postgres` is already the
+  superuser the `--clean` needs; `--role=<db-user>` still hands the restored
+  objects to the app's role.
 
 - **Coming from SQLite:** `bin/rails db:sqlite_to_postgres[...]`
   (`lib/tasks/db_convert.rake`). Like the fresh install below, this one runs
@@ -1159,6 +1185,12 @@ app_super=$(sudo -u postgres psql -qtAd postgres -c \
 # restore, and on the idle refusal too, which touches nothing else at all.
 prior_limit=$(sudo -u postgres psql -qtAd postgres -c \
   "SELECT datconnlimit FROM pg_database WHERE datname = '$app_db'" 2>/dev/null)
+
+# "This block has not shut anything yet", set before the two refusals below so
+# that it is answered on every path rather than only on the ones that reach the
+# ALTER. Non-zero is the safe value: the re-open is gated on it, and a refusal
+# that never touched the limit must not lift the operator's own cap.
+shut_applied=1
 if [ -z "$app_db" ]; then
   echo "REFUSING: cannot tell which database to restore."
   echo "  /var/lib/collavre/db_name is missing or unreadable. That file is"
@@ -1196,6 +1228,14 @@ else
 # hyphen as subtraction. Quoting is right for an ordinary name too.
 sudo -u postgres psql -qd postgres -c \
   "ALTER DATABASE \"$app_db\" CONNECTION LIMIT 0"
+# Kept separately from the read-back below, because they answer different
+# questions and only one of them decides who owns the limit afterwards. The
+# read-back says whether the door is shut; this says whether *this block* is
+# the one that shut it. They disagree exactly when the ALTER committed and the
+# read-back could not be answered — the cluster restarted in between, the
+# connection dropped — and that is the case where "nothing was changed" is
+# false and the re-open below is the only thing that will unlock the app.
+shut_applied=$?
 
 # Read the limit back rather than trusting that the line above ran. These
 # blocks are pasted into an interactive shell with no `set -e`, so a failed
@@ -1208,12 +1248,25 @@ shut=$(sudo -u postgres psql -qtAd postgres -c \
 
 if [ "$shut" != 0 ]; then
   echo "REFUSING: could not shut $app_db to the app."
-  echo "  its connection limit is '$shut', not 0 — the ALTER above did not take"
-  echo "  (wrong database name? not superuser? cluster gone?)"
+  echo "  its connection limit is '$shut', not 0"
+  if [ "$shut_applied" -eq 0 ]; then
+    # The ALTER reported success and the read-back disagrees, so the value
+    # above is not evidence the limit is unchanged — it is the absence of an
+    # answer. Saying "the ALTER did not take" here would be a guess in the one
+    # direction that leaves the app locked out, so the re-open below runs.
+    echo "  but the ALTER above reported success, so the limit may in fact be"
+    echo "  0 and this block cannot tell. Putting it back below rather than"
+    echo "  leaving the app to meet 'too many connections' at boot."
+  else
+    echo "  and the ALTER above did not take"
+    echo "  (wrong database name? not superuser? cluster gone?)"
+  fi
   echo "nothing was dropped; fix that and re-run this block"
-  # Its own status, not the refusal below: this block never shut the database,
-  # so it must not "re-open" it either — that would lift a limit the operator
-  # may have set themselves.
+  # Its own status, not the refusal below: this block never dropped anything.
+  # Whether it also has a limit to put back is a separate question, answered by
+  # $shut_applied at the re-open — on the path where the ALTER never ran, the
+  # limit is still the operator's and lifting it would be this block changing
+  # something it had refused to touch.
   restore_status=3
 else
 
@@ -1265,17 +1318,28 @@ fi
 reopen_limit=$prior_limit
 if ! printf '%s' "$prior_limit" | grep -qE '^-?[0-9]+$'; then
   reopen_limit=-1
-  # Only where it changes what happens next. On status 3 this block never shut
-  # the door and never opens it, so the previous limit is still in force and
-  # saying it could not be read would be a warning about nothing.
-  if [ "$restore_status" -ne 3 ]; then
+  # Only where it changes what happens next — which is "is this block about to
+  # re-open?", not "which status is it". On the status-3 paths that never ran
+  # the ALTER the previous limit is still in force and saying it could not be
+  # read would be a warning about nothing; on the status-3 path where the ALTER
+  # took and the read-back did not answer, the re-open runs and the operator is
+  # about to get -1 instead of their cap, which is the case the note is for.
+  if [ "$restore_status" -ne 3 ] || [ "$shut_applied" -eq 0 ]; then
     echo "NOTE: could not read $app_db's previous connection limit ('$prior_limit')."
     echo "  Re-opening to -1, the default. If you had capped this database, set"
     echo "  the cap again by hand once this block finishes."
   fi
 fi
 reopen_status=0
-if [ "$restore_status" -eq 0 ] || [ "$restore_status" -eq 2 ]; then
+# The third clause is the unconfirmed close. Status 3 otherwise means "refused
+# before touching anything", and re-opening there would lift a cap this block
+# never applied — but when the ALTER itself reported success the limit is this
+# block's to put back whether or not the read-back could confirm it, and
+# putting back the value it found is a no-op in the case where the ALTER turned
+# out not to have taken. Leaving it out is not symmetrical with that: it leaves
+# a database at CONNECTION LIMIT 0 under a message that says nothing changed.
+if [ "$restore_status" -eq 0 ] || [ "$restore_status" -eq 2 ] ||
+   { [ "$restore_status" -eq 3 ] && [ "$shut_applied" -eq 0 ]; }; then
   sudo -u postgres psql -qd postgres -c \
     "ALTER DATABASE \"$app_db\" CONNECTION LIMIT $reopen_limit"
   reopen_status=$?
@@ -1325,7 +1389,10 @@ elif [ "$restore_status" -eq 0 ]; then
     echo "restored; boot the app from your workstation: ./kamal.sh app boot"
   fi
 elif [ "$restore_status" -eq 2 ] || [ "$restore_status" -eq 3 ]; then
-  : # refused before touching anything — see the message above
+  # Refused without dropping anything, and whatever limit was applied has been
+  # put back above — see the refusal's own message, which is the one that knows
+  # which of these two it was.
+  :
 else
   echo "RESTORE FAILED: objects may be dropped or only partly reloaded."
   echo "$app_db is LEFT AT 'CONNECTION LIMIT 0' deliberately: it is"

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -1,0 +1,226 @@
+# Deploy to AWS Lightsail (app + PostgreSQL on one instance)
+
+This runbook provisions a single Lightsail instance that runs both PostgreSQL
+and the Collavre container, deployed with Kamal from your workstation.
+
+[`script/lightsail_launch.sh`](../script/lightsail_launch.sh) does the host
+preparation. It never builds or starts the app — `bin/kamal setup` does that.
+
+| The launch script sets up | You still do |
+| --- | --- |
+| Base packages, timezone, swap, SSH hardening | Lightsail console firewall (80/443) |
+| Deploy user in the `docker` group | `.env.production` on your workstation |
+| Docker CE + buildx + compose, capped container logs | `bin/kamal setup` |
+| PostgreSQL, private to this host | Loading the schema / restoring data |
+| `collavre_production` + `collavre_user` | DNS and TLS |
+| ufw, nightly `pg_dump` with retention | |
+
+## 1. Pick an instance
+
+Puma, Solid Queue (in-Puma) and PostgreSQL share one box, so **4 GB RAM / 2 vCPU
+is the practical floor**; 2 GB works only for a light pilot. The script adds a
+2 GB swap file either way. Blueprint: **Ubuntu 24.04 LTS**.
+
+> **Check the CPU architecture.** `config/deploy.yml` sets `builder.arch: arm64`
+> for the current Graviton host. Lightsail's standard Linux plans are x86-64, so
+> run `uname -m` on the new instance: if it prints `x86_64`, set
+> `builder: arch: amd64`. Building an amd64 image on an Apple Silicon Mac runs
+> under emulation and is slow — either accept it once per deploy, or build on
+> the instance itself:
+>
+> ```yaml
+> builder:
+>   arch: amd64
+>   remote: ssh://collavre@<instance-ip>
+> ```
+>
+> The launch script installs buildx, so the remote builder works out of the box.
+> Remote builds on a 4 GB instance need the swap file the script creates.
+
+## 2. Create the instance with the launch script
+
+Copy the contents of `script/lightsail_launch.sh` into the **Launch script** box
+(Lightsail console → Create instance → *Add launch script*). Edit the
+configuration block at the top first — at minimum `SSH_PUBLIC_KEY`, unless you
+are happy for the deploy user to reuse the key Lightsail installs for `ubuntu`.
+
+Common overrides:
+
+| Variable | Default | Notes |
+| --- | --- | --- |
+| `SSH_PUBLIC_KEY` | *(empty)* | Empty = copy `ubuntu`'s `authorized_keys` |
+| `APP_SSH_USER` | `collavre` | Must match `KAMAL_SSH_USER` |
+| `PG_MAJOR` | `17` | Match the source database when restoring a dump |
+| `DB_PASSWORD` | *(generated)* | Generated password is URL-safe |
+| `SWAP_SIZE_MB` | `2048` | `0` disables |
+| `BACKUP_S3_URI` | *(empty)* | e.g. `s3://collavre-backups/pg` |
+
+It also runs fine by hand on an existing instance, and re-running converges the
+host instead of duplicating config:
+
+```bash
+sudo SSH_PUBLIC_KEY="ssh-ed25519 AAAA..." bash script/lightsail_launch.sh
+sudo FORCE=1 bash script/lightsail_launch.sh   # after the first success
+```
+
+Progress: `tail -f /var/log/collavre-launch.log` (first boot takes 3–6 minutes).
+When it finishes it writes `/root/collavre-lightsail-summary.txt` with the
+generated `DATABASE_URL` and the exact `.env.production` lines to copy.
+
+**In the console firewall (Networking tab): open 80 and 443. Never open 5432.**
+
+## 3. How PostgreSQL is reachable
+
+PostgreSQL listens on `localhost` and `172.17.0.1` — the docker0 bridge
+gateway — and nothing else. Every container on the host can reach that address;
+nothing off the host can, whatever the firewalls say. `pg_hba.conf` requires
+`scram-sha-256` from the Docker ranges, and ufw only allows 5432 from
+`172.16.0.0/12` to that one address.
+
+```
+DATABASE_URL=postgresql://collavre_user:<password>@172.17.0.1:5432/collavre_production
+```
+
+`net.ipv4.ip_nonlocal_bind=1` is set so PostgreSQL can bind `172.17.0.1` after a
+reboot even if it starts before dockerd creates the bridge.
+
+Collavre keeps **everything in one database**: the Solid Queue / Cache / Cable
+tables come from a primary `db/migrate` migration, and only `DATABASE_URL` is
+set, so `cache`, `queue` and `cable` connect to the same database. Do not create
+separate `_cache` / `_queue` / `_cable` databases — see the header comment in
+[`db/setup_postgres_databases.sql`](../db/setup_postgres_databases.sql).
+
+## 4. Deploy
+
+On your workstation, in `.env.production`:
+
+```dotenv
+COLLAVRE_SERVER=<instance public IP>
+KAMAL_SSH_USER=collavre
+KAMAL_SSH_KEY_PATH=~/.ssh/<key matching the instance>
+KAMAL_REGISTRY_USER=<docker hub user>
+KAMAL_REGISTRY_PASSWORD=<docker hub access token>
+DATABASE_URL=postgresql://collavre_user:<password>@172.17.0.1:5432/collavre_production
+PORT=80
+SOLID_QUEUE_IN_PUMA=true
+```
+
+Keep the rest of `env.template` in mind — `RAILS_MASTER_KEY`, `SECRET_KEY_BASE`,
+the `ACTIVE_RECORD_ENCRYPTION_*` keys and the OAuth/S3/FCM credentials all still
+have to be set. Then:
+
+```bash
+./kamal.sh setup      # first deploy: bootstraps the server and boots the app
+./kamal.sh deploy     # subsequent deploys
+./kamal.sh logs
+```
+
+`kamal.sh` wraps `bin/kamal` with `.env.production` loaded.
+
+## 5. Get data into the new database
+
+`bin/docker-entrypoint` runs `db:migrate` on boot. On a brand-new database that
+replays every migration from zero, and `db/schema.rb` is known to drift from a
+full replay — so **populate the database before the first deploy** instead:
+
+- **Moving an existing PostgreSQL deployment (Neon, RDS):** dump and restore.
+  Match `PG_MAJOR` to the source server's major version or the restore may fail.
+
+  ```bash
+  pg_dump --format=custom "$SOURCE_DATABASE_URL" -f collavre.dump
+  scp collavre.dump collavre@<instance-ip>:/tmp/
+  ssh collavre@<instance-ip> \
+    'pg_restore --no-owner --role=collavre_user --clean --if-exists \
+       -d "postgresql://collavre_user:<password>@127.0.0.1:5432/collavre_production" \
+       /tmp/collavre.dump && rm /tmp/collavre.dump'
+  ```
+
+- **Coming from SQLite:** `bin/rails db:sqlite_to_postgres[...]`
+  (`lib/tasks/db_convert.rake`).
+
+- **Genuinely fresh install:** load the schema rather than replaying migrations.
+
+  ```bash
+  ./kamal.sh app exec 'bin/rails db:schema:load db:seed'
+  ```
+
+## 6. Backups
+
+`collavre-pg-backup.timer` runs nightly at 03:30 (instance timezone, Asia/Seoul
+by default) and writes custom-format dumps to `/var/backups/collavre`, keeping 7
+days. With `BACKUP_S3_URI` set and AWS credentials in `/root/.aws/credentials`
+(Lightsail has no IAM instance role) each dump is also copied to S3.
+
+```bash
+sudo /usr/local/bin/collavre-pg-backup          # run one now
+systemctl list-timers collavre-pg-backup.timer  # check schedule
+journalctl -u collavre-pg-backup.service        # check last run
+
+# restore
+sudo -u postgres pg_restore --clean --if-exists -d collavre_production \
+  /var/backups/collavre/collavre_production-YYYYmmdd-HHMMSS.dump
+```
+
+Local dumps die with the instance. Enable `BACKUP_S3_URI`, or take a Lightsail
+snapshot schedule, before this host holds real customer data.
+
+## 7. TLS
+
+`config/deploy.yml` currently sets `proxy.ssl: false` with `app_port: 80`,
+i.e. TLS is terminated in front of the app (Cloudflare). Keep that, or let
+kamal-proxy get a Let's Encrypt certificate itself:
+
+```yaml
+proxy:
+  ssl: true
+  host: collavre.example.com
+  app_port: 80
+```
+
+That requires the DNS A record to point at the instance and port 443 open in
+both the Lightsail firewall and ufw (the script already allows 443).
+
+## 8. Troubleshooting
+
+| Symptom | Check |
+| --- | --- |
+| Launch script did nothing | `/var/log/collavre-launch.log`, `/var/log/cloud-init-output.log` |
+| `kamal` can't SSH | `sudo cat /home/collavre/.ssh/authorized_keys` — empty means no `SSH_PUBLIC_KEY` and no key to copy |
+| `kamal` SSH works, Docker denied | Reconnect: `docker` group membership needs a new session |
+| App: `could not connect to server` | `sudo ss -lntp \| grep 5432` should show `127.0.0.1:5432` **and** `172.17.0.1:5432` |
+| App: `password authentication failed` | `sudo cat /var/lib/collavre/db_password` vs `DATABASE_URL` |
+| PostgreSQL won't start after reboot | `sysctl net.ipv4.ip_nonlocal_bind` must be `1`; `journalctl -u postgresql@17-main` |
+| `relation "solid_queue_jobs" does not exist` | Schema never loaded — see §5 |
+| Disk filling up | `docker system prune -af`, `/var/backups/collavre`, `/var/log` |
+
+## Alternative: PostgreSQL as a Kamal accessory
+
+If you would rather have Kamal own the database container, drop steps 5–6 of the
+launch script and add to `config/deploy.yml`:
+
+```yaml
+accessories:
+  db:
+    image: postgres:17
+    host: <instance ip>
+    port: "127.0.0.1:5432:5432"
+    env:
+      clear:
+        POSTGRES_USER: collavre_user
+        POSTGRES_DB: collavre_production
+      secret:
+        - POSTGRES_PASSWORD
+    directories:
+      - data:/var/lib/postgresql/data
+```
+
+`DATABASE_URL` then points at `collavre-db:5432` over the `kamal` network. It is
+one less thing to install, but the database lifecycle becomes tied to Kamal
+(`kamal remove` takes the volume with it), backups need a container-aware
+wrapper, and PostgreSQL upgrades stop being `apt` upgrades. The launch script
+takes the host-native path for those reasons.
+
+## References
+
+- [Kamal configuration](https://kamal-deploy.org/docs/configuration/)
+- [deploy_to_ec2.md](deploy_to_ec2.md) — the earlier EC2 notes

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -744,9 +744,18 @@ journalctl -u collavre-pg-backup.service        # check last run
 
 # restore — stop the app FIRST, from your workstation:
 #   ./kamal.sh app stop
-# then, on the instance. The stop happens on a different machine, so this
-# checks the thing that actually matters rather than trusting that it ran:
-# nothing else is connected to the database about to be dropped.
+# then, on the instance. The stop happens on a different machine, so rather than
+# trust that it ran, shut the database itself to the app for the duration.
+# CONNECTION LIMIT 0 does not apply to superusers, so pg_restore below still
+# connects; a container that survived the stop, or restarts mid-restore, cannot.
+sudo -u postgres psql -qd postgres -c \
+  "ALTER DATABASE collavre_production CONNECTION LIMIT 0"
+sudo -u postgres psql -qtAd postgres -c \
+  "SELECT count(pg_terminate_backend(pid)) FROM pg_stat_activity
+    WHERE datname = 'collavre_production' AND pid <> pg_backend_pid()"
+
+# Now check, with the door already shut — a point-in-time count taken before
+# this would only have said the app happened to be between connections.
 live=$(sudo -u postgres psql -qtA -d postgres -c \
   "SELECT count(*) FROM pg_stat_activity
     WHERE datname = 'collavre_production' AND pid <> pg_backend_pid()")
@@ -768,6 +777,12 @@ else
     /var/backups/collavre/collavre_production-YYYYmmdd-HHMMSS.dump
   restore_status=$?
 fi
+
+# Always re-open, on every path. A database left at CONNECTION LIMIT 0 refuses
+# the app at boot with "too many connections", which reads like a pool problem
+# and not like a step this block forgot to undo.
+sudo -u postgres psql -qd postgres -c \
+  "ALTER DATABASE collavre_production CONNECTION LIMIT -1"
 
 if [ "$restore_status" -eq 0 ]; then
   echo "restored; boot the app from your workstation: ./kamal.sh app boot"
@@ -796,6 +811,19 @@ and `app boot` from your workstation where `kamal.sh` and the env file live, the
 one block. `pg_restore --clean --if-exists` is re-runnable, so a failed restore
 is fixed by fixing the cause and running it again, not by booting to look
 around.
+
+**Which is also why the block shuts the database rather than only counting
+connections.** A count is true for the instant it runs. If `app stop` did not
+take and the surviving container happens to be between connections — restarting,
+reconnecting after a dropped socket, or simply idle — the count is `0` and the
+restore starts anyway, with Puma free to reconnect while objects are being
+dropped. Since the stop happens on another machine, there is no local status to
+gate on, so the gate has to be a state rather than an observation:
+`CONNECTION LIMIT 0` holds for the whole restore, and superusers are exempt from
+it, which is why `pg_restore` still connects while the app cannot. The
+`pg_terminate_backend` clears whatever was already attached, and the check
+afterwards then means something — it is asking whether anything got past a
+closed door, not whether the app happened to be quiet.
 
 Local dumps die with the instance. Enable `BACKUP_S3_URI`, or take a Lightsail
 snapshot schedule, before this host holds real customer data.

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -269,8 +269,10 @@ the SQLite converter needs the app image and so runs after it, app stopped.
   `db:load_config`, and that is where Rails widens
   `ActiveRecord::Migrator.migrations_paths` from `["db/migrate"]` (7 files) to
   every path the engines append (184). `db:sqlite_to_postgres` depends on
-  `:environment` alone, so it never gets that widening and must stamp the
-  remaining 177 itself.
+  `:environment` alone, so it never gets that widening: its schema load stamps
+  8 versions — the 7 primary migrations plus the schema's own version, which
+  `assume_migrated_upto_version` inserts whether or not it can see the file
+  behind it — and it must stamp the remaining 176 itself.
 
   `DISABLE_DATABASE_ENVIRONMENT_CHECK` is not optional here. `db:schema:load`
   runs `check_protected_environments` first, which aborts with

--- a/docs/deploy_to_lightsail.md
+++ b/docs/deploy_to_lightsail.md
@@ -189,9 +189,20 @@ box. Rotating away from a leaked key would have withdrawn nothing while
 reporting success.
 
 So the run withdraws the key it installed last time, recorded in
-`/var/lib/collavre/ssh_public_key`. Only that exact line goes: keys you added
-by hand, and the cloud user's original key, are matched whole-line and left
-alone. The withdrawal happens *after* the new key is in place, so an
+`/var/lib/collavre/ssh_public_key.<user>`. Only that exact line goes: keys you
+added by hand, and the cloud user's original key, are matched whole-line and
+left alone.
+
+The record is **per account**, because `authorized_keys` is. Changing
+`APP_SSH_USER` and changing back is the case that needs it: rotating
+`collavre`/key-A to `deploybot`/key-B leaves key-A in `collavre`'s file, which is
+correct — that is not the file being rewritten, and the same re-run takes
+`docker` and sudo away from `collavre`. But coming back later to
+`collavre`/key-C regrants those privileges, and with one shared record the
+withdrawal would be looking for key-B, which was never in that file. Key-A would
+be root again, two rotations after you retired it. A host provisioned by an
+earlier revision has its single `ssh_public_key` file adopted by the account the
+next run names. The withdrawal happens *after* the new key is in place, so an
 interrupted run leaves two working keys rather than none.
 
 Two cases deliberately do nothing. A re-run with `SSH_PUBLIC_KEY` unset means

--- a/lib/tasks/db_convert.rake
+++ b/lib/tasks/db_convert.rake
@@ -543,9 +543,13 @@ namespace :db do
   # `bin/rails db:schema:load` gets that for free (`task load: [:load_config,
   # :check_protected_environments]`), so it stamps all 184 and the next
   # db:migrate really is a no-op. THIS task depends on :environment only, so the
-  # same load_portable_schema call stamps 7 and leaves 177 engine migrations
+  # same load_portable_schema call stamps 8 and leaves 176 engine migrations
   # pending — db:migrate then replays them against tables that already exist
   # -> "relation already exists". Hence the explicit stamp here.
+  #
+  # 8, not 7: assume_migrated_upto_version also inserts the schema's own version
+  # even when it cannot see the migration behind it, and db/schema.rb's version
+  # is currently an engine migration (engines/collavre/db/migrate).
   #
   # It is a fact about this task's prerequisites, not about schema:load. Do not
   # generalize it to the fresh-install path in docs/deploy_to_lightsail.md.

--- a/lib/tasks/db_convert.rake
+++ b/lib/tasks/db_convert.rake
@@ -530,16 +530,25 @@ namespace :db do
   # into their PostgreSQL equivalents. SQLite dumps JSON expression indexes using
   # json_extract(col, '$.key'); PostgreSQL needs (col ->> 'key'). Without this,
   # db:schema:load fails on Postgres with "function json_extract does not exist".
-  # Fully populate schema_migrations after a schema:load.
+  # Fully populate schema_migrations after the schema load above.
   #
-  # Why: schema:load's assume_migrated_upto_version stamps only versions from the
-  # primary db_config's migrations_paths (nil -> just "db/migrate", 7 files here),
-  # leaving the ~160 engine migrations unstamped. db:migrate, however, reads
-  # DatabaseTasks.migrations_paths (primary + every engine that appends its path),
-  # so on deploy it treats those engine migrations as pending and re-runs them
-  # against already-existing tables -> "relation already exists". Stamping the full
-  # set here makes db:migrate a no-op, which is correct: schema:load already built
-  # the exact state those migrations produce.
+  # Why, precisely: assume_migrated_upto_version stamps the versions its pool's
+  # MigrationContext can see, and that context reads ActiveRecord::Migrator
+  # .migrations_paths, which defaults to just ["db/migrate"] — 7 files here.
+  # Rails widens it to the engine paths in ONE place, `db:load_config`:
+  #
+  #   ActiveRecord::Migrator.migrations_paths =
+  #     ActiveRecord::Tasks::DatabaseTasks.migrations_paths   # 7 paths, 184 files
+  #
+  # `bin/rails db:schema:load` gets that for free (`task load: [:load_config,
+  # :check_protected_environments]`), so it stamps all 184 and the next
+  # db:migrate really is a no-op. THIS task depends on :environment only, so the
+  # same load_portable_schema call stamps 7 and leaves 177 engine migrations
+  # pending — db:migrate then replays them against tables that already exist
+  # -> "relation already exists". Hence the explicit stamp here.
+  #
+  # It is a fact about this task's prerequisites, not about schema:load. Do not
+  # generalize it to the fresh-install path in docs/deploy_to_lightsail.md.
   def stamp_all_migrations(conn)
     paths = ActiveRecord::Tasks::DatabaseTasks.migrations_paths
     all = ActiveRecord::MigrationContext.new(paths).migrations.map(&:version)

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -1095,9 +1095,34 @@ EOF
   apt_install "postgresql-$PG_MAJOR" "postgresql-client-$PG_MAJOR"
 fi
 
+# postgresql_conf_includes_confd <postgresql.conf>
+#
+# Whether an *active* include_dir already pulls in conf.d. The distinction is
+# the whole point of the function. Debian and Ubuntu ship this directive live
+# in the stock postgresql.conf, so on a fresh install the managed block is
+# correctly skipped — but an operator who commented it out on an existing host
+# leaves the same text in the file, and a plain substring match reads their
+# `#include_dir = 'conf.d'` as "already configured".
+#
+# Measured on ubuntu:24.04 with the stock line commented out: the run writes
+# conf.d/10-collavre.conf, restarts cleanly and reports success, and PostgreSQL
+# never reads the file. listen_addresses stays at `localhost`, so nothing binds
+# the docker bridge while DATABASE_URL hands the containers 172.17.0.1:5432 —
+# the failure surfaces as the app being unable to reach its own database,
+# several steps after the step that caused it.
+#
+# Comments are stripped before the test rather than anchored around, because an
+# active directive can carry a trailing one and a disabled one can be indented
+# or spaced (`  #  include_dir = ...`). The path is matched as a whole final
+# component so `include_dir = 'myconf.d'` is not read as conf.d.
+postgresql_conf_includes_confd() {
+  sed 's/#.*//' "$1" |
+    grep -qE "^[[:space:]]*include_dir[[:space:]]*=[[:space:]]*'?([^']*/)?conf\.d'?[[:space:]]*$"
+}
+
 PG_CONF_DIR="/etc/postgresql/$PG_MAJOR/main"
 [ -d "$PG_CONF_DIR/conf.d" ] || install -d -m 0755 "$PG_CONF_DIR/conf.d"
-grep -q "include_dir = 'conf.d'" "$PG_CONF_DIR/postgresql.conf" || \
+postgresql_conf_includes_confd "$PG_CONF_DIR/postgresql.conf" || \
   ensure_block "$PG_CONF_DIR/postgresql.conf" include "include_dir = 'conf.d'"
 
 TOTAL_MB=$(awk '/MemTotal/ {printf "%d", $2/1024}' /proc/meminfo)

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -254,6 +254,139 @@ whose .env.production still names the old ones."$'\n\n'\
 "$record"
 }
 
+# refuse_unusable_db_identifier <setting name> <value>
+#
+# DB_NAME and DB_USER reach PostgreSQL through format('%I'), which quotes
+# whatever it is given — so the cluster accepts names this script then cannot
+# work with, and accepts them silently. Measured on a live cluster:
+#
+#   CREATE via format('%I'), DB_NAME='tenant/prod'   -> created
+#   pg_dump --dbname='tenant/prod'                   -> rc=0, connects
+#   --file=/var/backups/collavre/tenant/prod-<stamp>.dump
+#                                                    -> rc=1, no such directory
+#
+# The database is real, the app runs against it, and every nightly dump fails
+# from the moment the host is provisioned — the one failure on this host that
+# is only discovered by needing a backup. The same two values are also spliced
+# into the SQL below as *string literals* ('$DB_NAME'), where a name containing
+# a quote ends the run at step 6 with a syntax error naming a file in /tmp.
+#
+# Refused here rather than sanitised into a safe filename, because a sanitised
+# name is a second spelling: the runbook restores from
+# "/var/backups/collavre/$app_db-<stamp>.dump" using the name in
+# $STATE_DIR/db_name, and a transform in between would have to exist in two
+# places and stay equal. One spelling everywhere is the property worth keeping.
+#
+# Hyphens are allowed: `collavre-prod` needs identifier quoting, which the
+# runbook and the SQL below both do, and it is a perfectly good filename. A
+# leading hyphen is not, because that is an option to every command that later
+# handles the dump.
+#
+# LC_ALL=C so the ranges below are byte ranges. Under a UTF-8 collation
+# [A-Za-z] matches accented letters, which is exactly the class of name this
+# is here to keep out of a path.
+refuse_unusable_db_identifier() {
+  local LC_ALL=C setting="$1" value="$2"
+  case "$value" in
+    ''|-*|*[!A-Za-z0-9_-]*) ;;
+    *) return 0 ;;
+  esac
+  die "REFUSING: $setting='$value' is a name PostgreSQL would accept and this" \
+      "script cannot use. Use letters, digits, '_' and '-', not starting with" \
+      "'-'. DB_NAME is spelled outside SQL as well as in it — the nightly dump" \
+      "is written to /var/backups/collavre/\$DB_NAME-<stamp>.dump, so a '/'" \
+      "puts it in a directory that does not exist and every backup fails — and" \
+      "both settings go into the CREATE statements as string literals, where a" \
+      "quote of your own ends the run before the database is made." \
+      "Nothing has been changed. If this host was already provisioned under" \
+      "that name its backups have never run, and setting a different DB_NAME" \
+      "is refused by refuse_db_name_change: rename the database and update" \
+      "$STATE_DIR/db_name first — 'Changing DB_NAME on a re-run' in" \
+      "docs/deploy_to_lightsail.md — then re-run with the new name."
+}
+
+# refuse_unparsable_ssh_key
+#
+# SSH_PUBLIC_KEY is appended to authorized_keys verbatim, and its own presence
+# in that file is then taken as proof the successor works: revoke_prior_ssh_key
+# withdraws the previously installed key once `grep -qxF` finds this one there.
+# Whole-line presence is not parsability, and the [ -s ] check at the end of the
+# run is satisfied by any text at all, so a truncated paste ends with the deploy
+# account holding one line sshd cannot read and nothing else. Measured through
+# the shipped functions with a real key missing 24 characters of its body:
+#
+#   before   lines=1 usable=1
+#   after    lines=1 usable=0    "withdrew the SSH key this script installed"
+#
+# and against a scratch sshd, which is the only authority on "usable":
+#
+#   truncated line   -> Permission denied (publickey)
+#   same key intact  -> LOGGED-IN-OK
+#
+# The marker is advanced to the truncated key as well, so the host's own record
+# of the key that worked is overwritten and there is nothing for a later run to
+# retry toward. Hence a refusal here, before anything is appended or withdrawn,
+# rather than a check at the install: at this point nothing has been changed and
+# the operator can still fix the paste.
+#
+# ssh-keygen is the check because it is sshd's own parser. It accepts the forms
+# an operator legitimately supplies — no comment, a command=/from= restriction,
+# leading whitespace — and refuses truncation, which no shape check short of
+# parsing the blob can catch. A regex strict enough for the second would refuse
+# the first.
+#
+# A newline is refused for its own reason: `grep -qxF` treats each line of its
+# pattern as a separate pattern, so a two-line value counts as "in place" as
+# soon as either half of it is, and the withdrawal proceeds on half a key.
+#
+# Where ssh-keygen is absent this cannot be answered, and it warns rather than
+# refusing: openssh-server depends on openssh-client, so a host without
+# ssh-keygen is a host without sshd, and stopping there would cost provisioning
+# for a check with no login to protect.
+#
+# The value is not echoed. An operator who pastes a private key by mistake is
+# exactly the case this refuses, and the provisioning log is not private.
+refuse_unparsable_ssh_key() {
+  local tmp head rc=0
+  [ -n "$SSH_PUBLIC_KEY" ] || return 0
+  case "$SSH_PUBLIC_KEY" in
+    *$'\n'*) rc=1 ;;
+    *)
+      if ! command -v ssh-keygen >/dev/null 2>&1; then
+        log "WARNING: ssh-keygen is not installed, so SSH_PUBLIC_KEY could not be" \
+            "checked. If sshd cannot read it, this run will still withdraw the key" \
+            "it replaces — confirm you can log in as $APP_SSH_USER before you rely" \
+            "on this host."
+        return 0
+      fi
+      tmp="$(mktemp)"
+      printf '%s\n' "$SSH_PUBLIC_KEY" > "$tmp"
+      ssh-keygen -l -f "$tmp" >/dev/null 2>&1 || rc=1
+      rm -f "$tmp"
+      ;;
+  esac
+  if [ "$rc" != 0 ]; then
+    head="${SSH_PUBLIC_KEY%%[ $'\n']*}"
+    die "REFUSING: SSH_PUBLIC_KEY is not a key sshd can read — ssh-keygen" \
+        "cannot parse it, and a line cut short by a copy-paste is the usual" \
+        "reason. What was given is ${#SSH_PUBLIC_KEY} characters beginning" \
+        "'${head:0:20}'. Nothing has been changed. Left to run, this would" \
+        "append it to $APP_SSH_USER's authorized_keys, then withdraw the key" \
+        "it replaces on the strength of finding this one in the file, and the" \
+        "account would be left with no key sshd accepts — a rotation that" \
+        "reports success and locks you out. Paste the whole single line from" \
+        "your .pub file, and check it first if you like:" \
+        "ssh-keygen -l -f your_key.pub."
+  fi
+}
+
+# Before refuse_defaulted_config_change, and long before anything is installed:
+# a value this script cannot use is not usable whatever the host was given
+# earlier, so it is answered without reading any state at all.
+refuse_unusable_db_identifier DB_NAME "$DB_NAME"
+refuse_unusable_db_identifier DB_USER "$DB_USER"
+refuse_unparsable_ssh_key
+
 refuse_defaulted_config_change
 
 # cloud-init and unattended-upgrades hold the dpkg lock during early boot;
@@ -391,6 +524,38 @@ in_group() {
   id -nG "$1" 2>/dev/null | tr ' ' '\n' | grep -qxF "$2"
 }
 
+# write_state_file <path> <content>
+#
+# Replace a marker under $STATE_DIR in one step, because `> file` truncates when
+# the redirection opens and only then writes. A write that fails in between —
+# a full disk, an interrupted run — leaves the file existing and empty, and for
+# the queue below that is not a state anything recovers from: the seeding in
+# record_deploy_user_grant runs only when the queue file is *absent*, so an
+# empty one reads as "nothing left to revoke" and the account still holding
+# docker and sudo is never named again. Measured on the shipped functions, with
+# `ulimit -f 0` standing in for ENOSPC:
+#
+#   queue [B,D] -> write fails after truncating -> queue []
+#   next run                                    -> queue [E]     B unrevokable
+#
+# The staging file is created in the target's own directory so the rename is
+# within one filesystem, where it is atomic. Anywhere else `mv` degrades to a
+# copy-then-unlink and the window this exists to close is back.
+#
+# 0644 is not a widening: it is what a bare redirection already produced under
+# the default umask, and the chmod is here only because mktemp creates 0600.
+# db_password is the one marker that must not go through this — it is written
+# under `umask 077` precisely so it is never 0644, even briefly.
+write_state_file() {
+  local target="$1" content="$2" tmp
+  tmp="$(mktemp "$target.XXXXXX")" || return 1
+  if ! printf '%s' "$content" > "$tmp" || ! chmod 0644 "$tmp"; then
+    rm -f "$tmp"
+    return 1
+  fi
+  mv -f "$tmp" "$target"
+}
+
 # record_deploy_user_grant <user> [set file] [single-name marker]
 #
 # The set of accounts this script has granted root-equivalent access to and has
@@ -420,7 +585,18 @@ record_deploy_user_grant() {
   # account most likely to be unrevoked — seeding from it means the fix for
   # forgetting accounts does not begin by forgetting one.
   if [ ! -f "$set_file" ] && [ -s "$prior_file" ]; then
-    grep -v '^[[:space:]]*$' "$prior_file" > "$set_file" || true
+    local seed
+    seed="$(grep -v '^[[:space:]]*$' "$prior_file")" || seed=''
+    # The guard above is `! -f`, so this path runs once per host and never
+    # again — whatever state the file is left in is the state it keeps. The
+    # previous form's redirection created it on the way to failing and `|| true`
+    # swallowed that, so an empty file answered for the predecessor from then
+    # on. Returned rather than warned past, because the append below would
+    # create the file too: a run that could not perform the upgrade would
+    # retire it. Left absent instead, which is what a retry starts from.
+    if [ -n "$seed" ]; then
+      write_state_file "$set_file" "$seed"$'\n' || return 1
+    fi
   fi
   grep -qxF "$user" "$set_file" 2>/dev/null ||
     printf '%s\n' "$user" >> "$set_file"
@@ -488,7 +664,14 @@ revoke_prior_deploy_user() {
   # Not a no-op on the ordinary path: this is what seeds the set on a host the
   # earlier revision provisioned, and what puts $current in it on a first run,
   # so that a *later* rotation has something to revoke.
-  record_deploy_user_grant "$current" "$set_file" "$prior_file"
+  record_deploy_user_grant "$current" "$set_file" "$prior_file" || {
+    # Returning rather than carrying on: the loop below reads $set_file, and on
+    # this path it may not exist. Nothing has been revoked, and the file is
+    # left in the state a later run retries from.
+    log "WARNING: could not record '$current' in '$set_file'; no account was" \
+        "revoked on this run, and the queue is unchanged"
+    return 1
+  }
 
   while read -r prior; do
     if [ -z "$prior" ] || [ "$prior" = "$current" ]; then
@@ -510,8 +693,22 @@ revoke_prior_deploy_user() {
   # $current whether or not its predecessor could be stripped — the earlier
   # revision pinned it to the predecessor on that path, so a failed revocation
   # also made the host misreport who it belongs to.
-  printf '%s' "$kept" > "$set_file"
-  printf '%s\n' "$current" > "$prior_file"
+  #
+  # Both go through write_state_file rather than a redirection. Neither failure
+  # is fatal, and they fail in opposite but safe directions, which is why this
+  # warns rather than dies at a point the grants have already happened: the
+  # queue keeps its previous contents, so it still names everyone unrevoked and
+  # a later run re-reads two group lists for accounts already stripped; the
+  # single-name marker keeps naming the predecessor, so the next run's
+  # refuse_defaulted_config_change sees a disagreement it was not given and
+  # stops. Stale-and-conservative in both cases — where a truncated file is
+  # neither.
+  write_state_file "$set_file" "$kept" ||
+    log "WARNING: could not rewrite the deploy-user queue at '$set_file'; it still" \
+        "lists accounts this run revoked, which costs the next run a re-check"
+  write_state_file "$prior_file" "$current"$'\n' ||
+    log "WARNING: could not record '$current' as the deploy user in '$prior_file';" \
+        "the host will go on reporting its predecessor until a later run rewrites it"
 }
 
 # psql_as_postgres <database> <sql>
@@ -1292,7 +1489,11 @@ fi
 # end of step 4 — the whole Docker install — is a window in which an interrupted
 # run would otherwise leave this account holding sudo and docker with nothing on
 # the host recording that it does, and no later run able to find it.
-record_deploy_user_grant "$APP_SSH_USER"
+record_deploy_user_grant "$APP_SSH_USER" ||
+  die "could not record '$APP_SSH_USER' in $STATE_DIR/deploy_users, so this run" \
+      "cannot promise that a later one could find the account again. Nothing" \
+      "has been granted. Check that $STATE_DIR is writable and has space, then" \
+      "re-run."
 usermod -aG sudo "$APP_SSH_USER"
 install -d -m 0755 /etc/sudoers.d
 ensure_sudoers "$APP_SSH_USER"

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -1623,6 +1623,7 @@ revoke_prior_deploy_user() {
 stage_ssh_cutover() {
   local user="$1" key="$2" current='' prior_key='' need=0
   local nonce nonce_hash key_fingerprint='' pending="$STATE_DIR/ssh_cutover.pending"
+  local proof_key proof_key_b64 proof_records=''
   local finalizer="${3:-/usr/local/sbin/collavre-finalize-ssh-cutover}"
   local source="${4:-${BASH_SOURCE[0]}}"
 
@@ -1661,13 +1662,34 @@ stage_ssh_cutover() {
       die "could not fingerprint the staged SSH key"
   fi
 
+  # Authentication on the workstation is the only proof a root-equivalent
+  # predecessor cannot synthesize from host-local state. Explicit rotations
+  # accept only the staged key; copied-key cutovers accept any valid key
+  # currently installed for the successor, because any one of them proves that
+  # account can be reached without the predecessor.
+  if [ -n "$key" ]; then
+    proof_key="$key"
+    proof_key_b64="$(printf '%s' "$proof_key" | base64 | tr -d '\n')"
+    proof_records="proof_key_b64=$proof_key_b64"$'\n'
+  else
+    while IFS= read -r proof_key; do
+      [ -n "$proof_key" ] || continue
+      ssh_public_key_fingerprint "$proof_key" >/dev/null 2>&1 || continue
+      proof_key_b64="$(printf '%s' "$proof_key" | base64 | tr -d '\n')"
+      proof_records="$proof_records"'proof_key_b64='"$proof_key_b64"$'\n'
+    done < "$AUTH_KEYS"
+  fi
+  [ -n "$proof_records" ] ||
+    die "could not stage SSH cutover proof because '$user' has no valid public" \
+	"key to verify. Install a usable key and re-run."
+
   # The key, its fingerprint and the nonce hash are one atomic record. Keeping
   # the key in a separately replaced file lets an interrupted same-user re-run
   # pair an old challenge/fingerprint with a new key and later commit a key
   # that the successful SSH session never proved.
   write_state_file "$pending" \
     "user=$user"$'\n'"nonce_sha256=$nonce_hash"$'\n'\
-"key_sha256=$key_fingerprint"$'\n'"key=$key"$'\n' 0600 ||
+"key_sha256=$key_fingerprint"$'\n'"key=$key"$'\n'"$proof_records" 0600 ||
     die "could not stage the SSH cutover challenge in $pending"
 
   [ -r "$source" ] ||
@@ -1692,71 +1714,54 @@ ssh_public_key_fingerprint() {
   printf '%s\n' "$fingerprint"
 }
 
-# Echo the authentication-info file from the target-owned session process
-# closest to sshd. ExposeAuthInfo creates this record from the authentication
-# exchange itself; reading SSH_USER_AUTH from the original session ancestry
-# avoids relying on what sudo happened to preserve.
-ssh_cutover_auth_info_file() {
-  local user="$1" pid="${2:-$PPID}" proc_root="${3:-/proc}"
-  local ppid real_uid target_uid candidate='' candidate_uid hops=0
-  local auth_info_file=''
-  target_uid="$(id -u "$user" 2>/dev/null)" || return 1
-  while [ "$pid" -gt 1 ] 2>/dev/null && [ "$hops" -lt 64 ]; do
-    real_uid="$(awk '/^Uid:/{print $2}' "$proc_root/$pid/status" 2>/dev/null || true)"
-    if [ "$real_uid" = "$target_uid" ]; then
-      candidate="$(tr '\0' '\n' < "$proc_root/$pid/environ" 2>/dev/null |
-	sed -n 's/^SSH_USER_AUTH=//p' | head -1)"
-      candidate_uid="$(
-	stat -c %u "$candidate" 2>/dev/null ||
-	  stat -f %u "$candidate" 2>/dev/null ||
-	  true
-      )"
-      [ -z "$candidate" ] || [ ! -f "$candidate" ] ||
-	[ "$candidate_uid" != "$target_uid" ] || auth_info_file="$candidate"
-    fi
-    ppid="$(awk '/^PPid:/{print $2}' "$proc_root/$pid/status" 2>/dev/null || true)"
-    case "$ppid" in ''|*[!0-9]*) break ;; esac
-    pid="$ppid"
-    hops=$((hops + 1))
-  done
-  [ -n "$auth_info_file" ] && [ -f "$auth_info_file" ] || return 1
-  printf '%s\n' "$auth_info_file"
+ssh_public_key_material() {
+  printf '%s\n' "$1" | awk '
+    {
+      for (i = 1; i < NF; i++) {
+	if ($i ~ /^(ssh-|ecdsa-|sk-)/) {
+	  print $i " " $(i + 1)
+	  exit
+	}
+      }
+    }'
 }
 
-ssh_cutover_authenticated_with_key() {
-  local user="$1" expected="$2" auth_file method key fingerprint
-  auth_file="$(ssh_cutover_auth_info_file "$user")" || return 1
-  while read -r method key; do
-    [ "$method" = publickey ] || continue
-    fingerprint="$(ssh_public_key_fingerprint "$key")" || continue
-    [ "$fingerprint" = "$expected" ] && return 0
-  done < "$auth_file"
+ssh_cutover_signature_verifies() {
+  local user="$1" nonce="$2" signature_b64="$3" pending="$4"
+  local tmp proof_key_b64 proof_key material found=0
+  tmp="$(mktemp -d)" || return 1
+  chmod 0700 "$tmp" || { rm -rf "$tmp"; return 1; }
+  : > "$tmp/allowed_signers"
+  while IFS= read -r proof_key_b64; do
+    [ -n "$proof_key_b64" ] || continue
+    proof_key="$(printf '%s' "$proof_key_b64" | base64 -d 2>/dev/null)" ||
+      proof_key="$(printf '%s' "$proof_key_b64" | base64 -D 2>/dev/null)" ||
+      continue
+    material="$(ssh_public_key_material "$proof_key")"
+    [ -n "$material" ] || continue
+    printf 'collavre-cutover %s\n' "$material" >> "$tmp/allowed_signers" ||
+      { rm -rf "$tmp"; return 1; }
+    found=1
+  done < <(sed -n 's/^proof_key_b64=//p' "$pending")
+  [ "$found" -eq 1 ] || { rm -rf "$tmp"; return 1; }
+  if ! printf '%s' "$signature_b64" | base64 -d > "$tmp/signature" 2>/dev/null; then
+    printf '%s' "$signature_b64" | base64 -D > "$tmp/signature" 2>/dev/null ||
+      { rm -rf "$tmp"; return 1; }
+  fi
+  if printf 'collavre-ssh-cutover:%s:%s' "$user" "$nonce" |
+     ssh-keygen -Y verify -f "$tmp/allowed_signers" \
+       -I collavre-cutover -n collavre-ssh-cutover \
+       -s "$tmp/signature" >/dev/null 2>&1; then
+    rm -rf "$tmp"
+    return 0
+  fi
+  rm -rf "$tmp"
   return 1
 }
 
-ssh_cutover_has_sshd_ancestor() {
-  local user="$1" pid="${2:-$PPID}" proc_root="${3:-/proc}"
-  local comm ppid real_uid target_uid hops=0
-  local saw_authenticated_sshd=0
-  target_uid="$(id -u "$user" 2>/dev/null)" || return 1
-  while [ "$pid" -gt 1 ] 2>/dev/null && [ "$hops" -lt 64 ]; do
-    comm="$(cat "$proc_root/$pid/comm" 2>/dev/null || true)"
-    real_uid="$(awk '/^Uid:/{print $2}' "$proc_root/$pid/status" 2>/dev/null || true)"
-    case "$comm:$real_uid" in
-      sshd:"$target_uid"|sshd-session:"$target_uid")
-	saw_authenticated_sshd=1
-	;;
-    esac
-    ppid="$(awk '/^PPid:/{print $2}' "$proc_root/$pid/status" 2>/dev/null || true)"
-    case "$ppid" in ''|*[!0-9]*) break ;; esac
-    pid="$ppid"
-    hops=$((hops + 1))
-  done
-  [ "$saw_authenticated_sshd" -eq 1 ]
-}
-
 finalize_ssh_cutover() {
-  local nonce="${1:-}" pending="$STATE_DIR/ssh_cutover.pending"
+  local nonce="${1:-}" signature_b64="${2:-}"
+  local pending="$STATE_DIR/ssh_cutover.pending"
   local user expected key_fingerprint actual staged_fingerprint field
 
   [ -s "$pending" ] || die "no SSH cutover is pending"
@@ -1766,6 +1771,9 @@ finalize_ssh_cutover() {
 	  "was not changed. Re-run provisioning to atomically replace the" \
 	  "pending cutover."
   done
+  [ "$(grep -c '^proof_key_b64=' "$pending" 2>/dev/null || true)" -ge 1 ] ||
+    die "$pending has no staged signing key; predecessor access was not changed." \
+	"Re-run provisioning to replace this older pending cutover."
   user="$(sed -n 's/^user=//p' "$pending")"
   expected="$(sed -n 's/^nonce_sha256=//p' "$pending")"
   key_fingerprint="$(sed -n 's/^key_sha256=//p' "$pending")"
@@ -1775,17 +1783,13 @@ finalize_ssh_cutover() {
   [ "${SUDO_USER:-}" = "$user" ] ||
     die "finalize this cutover by SSHing as '$user' and running sudo there;" \
 	"SUDO_USER is '${SUDO_USER:-unset}'"
-  ssh_cutover_has_sshd_ancestor "$user" ||
-    die "no sshd session process owned by '$user' was found. The cutover must" \
-	"be finalized inside an SSH session authenticated as that account, not" \
-	"through a nested sudo from another user's session or a local console."
-  ssh_cutover_auth_info_file "$user" >/dev/null ||
-    die "no '$user'-owned SSH_USER_AUTH record was found. The cutover must be" \
-	"finalized from that account's actual SSH session; predecessor access" \
-	"was not changed."
   actual="$(printf '%s' "$nonce" | sha256sum | awk '{print $1}')"
   [ "$actual" = "$expected" ] ||
     die "the SSH cutover nonce is incorrect; predecessor access was not changed"
+  ssh_cutover_signature_verifies "$user" "$nonce" "$signature_b64" "$pending" ||
+    die "the SSH cutover signature is missing or invalid. Sign this nonce on" \
+	"the workstation with a private key installed for '$user', then retry;" \
+	"predecessor access was not changed."
   in_group "$user" sudo && in_group "$user" docker ||
     die "'$user' no longer has both sudo and docker; predecessor access was" \
 	"not changed. Re-run provisioning to repair the staged account."
@@ -1805,10 +1809,6 @@ finalize_ssh_cutover() {
       die "the staged key does not match its pending fingerprint; predecessor" \
 	  "access was not changed. Re-run provisioning to replace the pending" \
 	  "cutover atomically."
-    [ -n "$key_fingerprint" ] &&
-      ssh_cutover_authenticated_with_key "$user" "$key_fingerprint" ||
-      die "this SSH session was not authenticated with the staged key. Reconnect" \
-	  "with that key and retry; predecessor access was not changed."
     grep -qxF "$SSH_PUBLIC_KEY" "$AUTH_KEYS" ||
       die "the staged key is no longer in $AUTH_KEYS; predecessor access was" \
 	  "not changed"
@@ -2895,7 +2895,7 @@ ensure_ssh_rule() {
 # host mutation. Its caller must be the staged account inside a real SSH
 # session; finalize_ssh_cutover verifies both conditions again.
 if [ "${1:-}" = "--finalize-ssh-cutover" ]; then
-  finalize_ssh_cutover "${2:-}"
+  finalize_ssh_cutover "${2:-}" "${3:-}"
   exit 0
 fi
 
@@ -3269,7 +3269,6 @@ verify_ssh_hardening() {
   local src="${1:-}" conf_dir="${2:-/etc/ssh}" reload_state="${3:-0}"
   local deploy_user="${4:-${APP_SSH_USER:-collavre}}"
   local require_readable="${5:-0}"
-  local require_auth_info="${6:-0}"
   local effective key value expected offender unsafe_match
   if [ -n "$src" ]; then
     effective="$(cat "$src")"
@@ -3313,10 +3312,9 @@ verify_ssh_hardening() {
     fi
   fi
   for key in passwordauthentication permitrootlogin kbdinteractiveauthentication \
-	     pubkeyauthentication exposeauthinfo; do
-    [ "$key" != exposeauthinfo ] || [ "$require_auth_info" -eq 1 ] || continue
+	     pubkeyauthentication; do
     expected=no
-    case "$key" in pubkeyauthentication|exposeauthinfo) expected=yes ;; esac
+    [ "$key" != pubkeyauthentication ] || expected=yes
     value="$(printf '%s\n' "$effective" |
              awk -v k="$key" 'tolower($1) == k { print $2; exit }')"
     [ -n "$value" ] || {
@@ -3327,12 +3325,6 @@ verify_ssh_hardening() {
 	      "previous deploy user's privileged access will not be revoked until" \
 	      "the replacement account is proven reachable by key. Correct the SSH" \
 	      "configuration and re-run."
-	  ;;
-	exposeauthinfo)
-	  die "SSH authentication-key proof could not be enabled for" \
-	      "'$deploy_user': sshd did not report 'exposeauthinfo'. The previous" \
-	      "deploy user's access remains intact. Correct the SSH configuration" \
-	      "and re-run."
 	  ;;
       esac
       log "WARNING: sshd did not report '$key', so that part of the hardening" \
@@ -3413,8 +3405,7 @@ install_managed_config 'the SSH hardening drop-in' \
   'PasswordAuthentication no' \
   'PermitRootLogin no' \
   'KbdInteractiveAuthentication no' \
-  'PubkeyAuthentication yes' \
-  'ExposeAuthInfo yes'
+  'PubkeyAuthentication yes'
 # A host provisioned by an earlier version of this script carries the 99- file.
 # It is inert now that 01- sets the same keywords first, and that is the reason
 # to remove it rather than leave it: a file whose every line is overridden is
@@ -4275,12 +4266,10 @@ fi
 DOCKER_GROUP_WAS_PRESENT=0
 in_group "$APP_SSH_USER" docker && DOCKER_GROUP_WAS_PRESENT=1
 usermod -aG docker "$APP_SSH_USER"
-SSH_AUTH_INFO_REQUIRED=1
 # Recheck for the same reason as the sudo grant above. An operator's
 # `Match Group docker` block does not apply until this membership exists.
 if ! (
-  verify_ssh_hardening "" /etc/ssh "$SSH_RELOAD_STATE" "$APP_SSH_USER" 1 \
-    "$SSH_AUTH_INFO_REQUIRED" &&
+  verify_ssh_hardening "" /etc/ssh "$SSH_RELOAD_STATE" "$APP_SSH_USER" 1 &&
   verify_ssh_key_destination "" "$APP_SSH_USER" "$APP_HOME" "$AUTH_KEYS" &&
   verify_ssh_admission_controls "" "$APP_SSH_USER"
 ); then
@@ -4943,11 +4932,17 @@ TXT
     cat <<TXT
 
 SSH cutover is pending. The previous deploy account and managed keys remain
-privileged until the staged account proves a real SSH login. From the
-workstation, using the staged key, run:
+privileged until the workstation proves possession of an installed private key
+and the staged account accepts the same SSH command. From the workstation, set
+the actual key path and run:
 
-  ssh -i ~/.ssh/<staged-key> $APP_SSH_USER@$PUBLIC_IP \\
-    "sudo /usr/local/sbin/collavre-finalize-ssh-cutover --finalize-ssh-cutover '$2'"
+  key=~/.ssh/<staged-key>
+  nonce='$2'
+  signature="\$(printf 'collavre-ssh-cutover:%s:%s' '$APP_SSH_USER' "\$nonce" |
+    ssh-keygen -Y sign -f "\$key" -n collavre-ssh-cutover 2>/dev/null |
+    base64 | tr -d '\\n')"
+  ssh -i "\$key" $APP_SSH_USER@$PUBLIC_IP \\
+    "sudo /usr/local/sbin/collavre-finalize-ssh-cutover --finalize-ssh-cutover '\$nonce' '\$signature'"
 
 Only after it prints "SSH cutover finalized" should KAMAL_SSH_USER change to
 $APP_SSH_USER. The nonce is one-time; a failed or interrupted finalize is safe

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -109,6 +109,24 @@ APT_OPTS=(-o DPkg::Lock::Timeout=600
 apt_get() { apt-get "${APT_OPTS[@]}" "$@"; }
 apt_install() { apt_get install -y --no-install-recommends "$@"; }
 
+# Percent-encode everything outside the RFC 3986 unreserved set, byte by byte
+# (LC_ALL=C, so multi-byte characters encode as their UTF-8 bytes). The
+# generated password is alphanumeric and passes through untouched; an
+# operator-supplied DB_PASSWORD is not, and config/database.yml runs
+# URI.parse(ENV["DATABASE_URL"]) at boot, which rejects @ / # % ? and space in
+# userinfo outright.
+urlencode() {
+  local LC_ALL=C s="$1" i c out=''
+  for (( i = 0; i < ${#s}; i++ )); do
+    c="${s:i:1}"
+    case "$c" in
+      [A-Za-z0-9._~-]) out="$out$c" ;;
+      *) out="$out$(printf '%%%02X' "'$c")" ;;
+    esac
+  done
+  printf '%s' "$out"
+}
+
 # Append a managed block to a config file exactly once, keyed by a marker.
 ensure_block() {
   local file="$1" marker="$2" content="$3"
@@ -454,10 +472,21 @@ log "9/9 summary"
 # --------------------------------------------------------------------------
 PUBLIC_IP="$(curl -fsS --max-time 5 https://checkip.amazonaws.com 2>/dev/null || echo '<public-ip>')"
 PRIVATE_IP="$(hostname -I | awk '{print $1}')"
-DATABASE_URL="postgresql://$DB_USER:$DB_PASSWORD@$DB_BIND_ADDRESS:5432/$DB_NAME"
+# Rails percent-decodes userinfo when it resolves DATABASE_URL, so encoding
+# here round-trips back to the literal password the role was created with.
+URL_USER="$(urlencode "$DB_USER")"
+URL_PASSWORD="$(urlencode "$DB_PASSWORD")"
+URL_DB_NAME="$(urlencode "$DB_NAME")"
+DATABASE_URL="postgresql://$URL_USER:$URL_PASSWORD@$DB_BIND_ADDRESS:5432/$URL_DB_NAME"
 # Angle brackets, not a $(...) that a reader might paste into .env.production
 # and watch dotenv store verbatim.
-REDACTED_URL="postgresql://$DB_USER:<see $SUMMARY>@$DB_BIND_ADDRESS:5432/$DB_NAME"
+REDACTED_URL="postgresql://$URL_USER:<see $SUMMARY>@$DB_BIND_ADDRESS:5432/$URL_DB_NAME"
+# Only worth saying when the two actually differ, which they never do for the
+# generated password.
+PASSWORD_NOTE=''
+if [ "$URL_PASSWORD" != "$DB_PASSWORD" ]; then
+  PASSWORD_NOTE=', percent-encoded in the URL below'
+fi
 
 # Rendered twice: once with the real DATABASE_URL into the 0600 summary file,
 # once redacted for stdout — which is tee'd to the launch log and captured by
@@ -472,7 +501,7 @@ Collavre Lightsail host — provisioned $(date -Is)
   deploy user      $APP_SSH_USER (docker, sudo)
   PostgreSQL       $PG_MAJOR, listening on localhost + $DB_BIND_ADDRESS only
   database         $DB_NAME owned by $DB_USER
-  db password      $STATE_DIR/db_password (root only)
+  db password      $STATE_DIR/db_password (root only)$PASSWORD_NOTE
   backups          /var/backups/collavre, nightly at $BACKUP_AT, ${BACKUP_RETENTION_DAYS}d retention
   log              $LOG_FILE
 

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -1152,7 +1152,42 @@ write_state_file() {
     rm -f "$tmp"
     return 1
   fi
-  mv -f "$tmp" "$target"
+  if ! mv -f "$tmp" "$target"; then
+    rm -f "$tmp"
+    return 1
+  fi
+}
+
+# A failed atomic replacement is recoverable only when the file it left behind
+# can still answer every setting. An absent or short record is not a previous
+# configuration: refuse the success marker rather than let the next bare
+# FORCE=1 run silently reset an override that has no other state file, such as
+# BACKUP_S3_URI.
+launch_record_is_complete() {
+  local env_file="$1" name
+  [ -f "$env_file" ] || return 1
+  for name in $LAUNCH_SETTINGS; do
+    [ "$(grep -c "^$name=" "$env_file" 2>/dev/null)" -eq 1 ] || return 1
+  done
+}
+
+record_launch_settings() {
+  local state_dir="${1:-$STATE_DIR}" record name
+  record="$(for name in $LAUNCH_SETTINGS; do
+    printf '%s=%s\n' "$name" "${!name}"
+  done)"
+  if write_state_file "$state_dir/launch.env" "$record"$'\n'; then
+    return 0
+  fi
+  if launch_record_is_complete "$state_dir/launch.env"; then
+    log "WARNING: could not replace this run's settings in $state_dir/launch.env;" \
+	"the complete previous record is intact, so the next run still compares" \
+	"against it — repeat this run's overrides on that run too"
+    return 0
+  fi
+  die "could not record this run's settings in $state_dir/launch.env, and no" \
+      "complete previous record remains. Refusing to create the success marker:" \
+      "a later bare FORCE=1 run could otherwise silently reset an override."
 }
 
 # append_state_line <set file> <line>
@@ -3329,9 +3364,9 @@ if [ -n "$DOCKER_WANT" ]; then
   chmod a+r /etc/apt/keyrings/docker.asc
   # shellcheck disable=SC1091
   . /etc/os-release
-  cat > /etc/apt/sources.list.d/docker.list <<EOF
-deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $VERSION_CODENAME stable
-EOF
+  install_managed_config 'the Docker apt source' \
+    /etc/apt/sources.list.d/docker.list \
+    "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $VERSION_CODENAME stable"
   apt_get update -y
   # shellcheck disable=SC2086  # a package list, deliberately word-split
   apt_install $DOCKER_WANT
@@ -3924,18 +3959,11 @@ TXT
 # because the answers in it ("which deploy user?", "which database?") are what
 # the runbook sends operators here to read.
 #
-# Through write_state_file rather than a redirection, because the reader treats
-# a line that is not here as a setting it has nothing to say about: a run that
-# truncated this file and then died leaves refuse_defaulted_config_change with
-# nothing to compare, and the next bare FORCE=1 rotates the deploy account and
-# the database role unchallenged. Failing to record the settings must not be
-# the same event as recording that there were none.
-_launch_record="$(for _s in $LAUNCH_SETTINGS; do printf '%s=%s\n' "$_s" "${!_s}"; done)"
-write_state_file "$STATE_DIR/launch.env" "$_launch_record"$'\n' ||
-  log "WARNING: could not record this run's settings in $STATE_DIR/launch.env;" \
-      "the previous record is intact, so the next run still compares against it —" \
-      "repeat this run's overrides on that run too"
-unset _s _launch_record
+# Through an atomic write, and fatal unless a complete prior record survives:
+# the reader treats a missing line as a setting it has nothing to say about, so
+# a later bare FORCE=1 could otherwise reset an unrecorded BACKUP_S3_URI while
+# this run still created the success marker.
+record_launch_settings
 
 touch "$SUMMARY"
 chmod 0600 "$SUMMARY"

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -475,19 +475,24 @@ revoke_prior_ssh_key() {
     prior="$(cat "$state")"
     if [ -n "$prior" ] && [ "$prior" != "$SSH_PUBLIC_KEY" ] &&
        grep -qxF "$prior" "$auth_keys"; then
-      tmp="$(mktemp)"
+      # Staged beside the target rather than in $TMPDIR: same filesystem, so
+      # the rewrite below cannot fail for space the staging just proved is
+      # there, and a small or full /tmp is not on its own able to break the
+      # file the operator logs in with.
+      tmp="$(mktemp "$auth_keys.revoke.XXXXXX")"
       # Exact whole-line match: a key is withdrawn only if it is byte-for-byte
       # the one recorded, so an operator key that merely shares a comment or a
       # prefix survives.
       grep -vxF "$prior" "$auth_keys" > "$tmp" || true
-      # An empty result cannot mean "every key was the retired one" — the
-      # successor was confirmed present above — so it means the filter itself
-      # failed, and the `|| true` that keeps `set -e` from firing on grep's
-      # "no lines selected" hides that. Writing it back would truncate
-      # authorized_keys and lock the deploy account out of the host. The
-      # realistic trigger is a full disk: grep writes nothing, exits 2, and
-      # `cat` then succeeds at emptying the file.
-      if [ -s "$tmp" ]; then
+      # Check what the staged file *is*, not merely that it exists. `grep`
+      # writing a short file is the dangerous case and it is the likely one:
+      # the successor was appended, so it is the last line, and a write that
+      # runs out of space stops before reaching it. A size test passes on
+      # that file, `cat` installs it, and the account is locked out of a host
+      # whose log says the rotation succeeded. The `|| true` above — needed so
+      # `set -e` does not fire on grep's "no lines selected" — is what hides
+      # the error, so the successor's presence has to be re-established here.
+      if grep -qxF "$SSH_PUBLIC_KEY" "$tmp"; then
         cat "$tmp" > "$auth_keys"   # rewrite in place, keeping mode and owner
         rm -f "$tmp"
         log "withdrew the SSH key this script installed on a previous run"

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -1161,14 +1161,51 @@ role_owns_app_objects() {
 }
 
 refuse_superuser_db_rotation() {
-  local current="$1" prior_file="${2:-$STATE_DIR/db_user}" prior owns
+  local current="$1" prior_file="${2:-$STATE_DIR/db_user}" prior owns exists super
   [ -f "$prior_file" ] || return 0
   prior="$(cat "$prior_file")"
   [ -n "$prior" ] && [ "$prior" != "$current" ] || return 0
-  [ "$(psql_as_postgres postgres \
-        "SELECT count(*) FROM pg_roles WHERE rolname = '$prior'")" = 1 ] || return 0
-  [ "$(psql_as_postgres postgres \
-        "SELECT rolsuper FROM pg_roles WHERE rolname = '$prior'")" = t ] || return 0
+
+  # Both probes keep their status, for the reason role_owns_app_objects states
+  # two functions up and this one did not apply to itself: an unanswerable
+  # question has to read as the unsafe answer. Under the earlier
+  # `[ "$(psql ...)" = 1 ] || return 0` a psql that could not answer produced an
+  # empty string, which is neither "1" nor "t", so a dead connection read as
+  # "no such role" and then as "not a superuser" — and the guard passed the run
+  # it exists to stop. Measured against 6125e4ee on a host recorded as
+  # DB_USER=postgres owning 7 objects, each query failed in turn:
+  #
+  #   failing query      guard
+  #   --                 REFUSES
+  #   count(*)           PROCEEDS
+  #   rolsuper           PROCEEDS
+  #   pg_get_userbyid    REFUSES     (the one path that already checked)
+  #
+  # Proceeding is not a deferred refusal. This guard is called before the SQL
+  # block on purpose — `ALTER DATABASE ... OWNER TO` runs at that point, and
+  # reassign_prior_db_role only afterwards — so a bypass moves the stop from
+  # "nothing has been changed" to a host whose database belongs to the new role
+  # while every table in it still belongs to the superuser. That is the half-
+  # rotated state the pre-check exists to make unreachable.
+  #
+  # die() rather than a bare non-zero: this runs after PostgreSQL is up, so a
+  # cluster that cannot answer here also cannot run the SQL block below, and
+  # the run is going to stop either way. Stopping with the reason, before
+  # anything is written, is the difference worth having.
+  exists="$(psql_as_postgres postgres \
+    "SELECT count(*) FROM pg_roles WHERE rolname = '$prior'")" ||
+    die "could not ask the cluster whether the previous DB_USER '$prior' still" \
+        "exists, so this run cannot tell a completed rotation from one that would" \
+        "strand every table with a superuser. Nothing has been changed. Check that" \
+        "PostgreSQL is accepting connections on port $DB_PORT and re-run."
+  [ "$exists" = 1 ] || return 0
+  super="$(psql_as_postgres postgres \
+    "SELECT rolsuper FROM pg_roles WHERE rolname = '$prior'")" ||
+    die "could not ask the cluster whether the previous DB_USER '$prior' is a" \
+        "superuser, whose objects PostgreSQL refuses to reassign. Nothing has been" \
+        "changed. Check that PostgreSQL is accepting connections on port $DB_PORT" \
+        "and re-run."
+  [ "$super" = t ] || return 0
 
   # A superuser predecessor that owns nothing has already been transferred by
   # hand, and the rotation it was blocking is now the thing that finishes the

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -381,6 +381,12 @@ ensure_swapfile() {
   fi
 
   if [ "$active" = yes ] && ! swapoff "$swap" 2>/dev/null; then
+    # Keeping the old swap is the point of this branch, so it has to be kept
+    # across a reboot too. Skipping ensure_block here left the resize failing
+    # *twice*: the size did not change, and the swap that was retained instead
+    # was retained only until the next restart. The fstab line names the path
+    # and not the size, so it is the same line whichever size survives.
+    ensure_block "$fstab" swap "$swap none swap sw 0 0"
     log "WARNING: could not swapoff $swap (${have}MiB), so it is unchanged;" \
         "SWAP_SIZE_MB=$want did NOT take effect. Free some memory and re-run," \
         "or resize it by hand."
@@ -409,6 +415,9 @@ ensure_swapfile() {
     rm -f "$swap"
     if [ "$have" -gt 0 ] && allocate_swapfile "$swap" "$have"; then
       swapon "$swap"
+      # Same reasoning as the swapoff branch above: what is put back has to
+      # survive a reboot, or the restore lasts until the next restart.
+      ensure_block "$fstab" swap "$swap none swap sw 0 0"
       log "WARNING: could not allocate ${want}MiB for $swap — not enough free disk." \
           "SWAP_SIZE_MB=$want did NOT take effect; the previous ${have}MiB swap is back." \
           "Grow the disk, or lower SWAP_SIZE_MB, and re-run."
@@ -584,8 +593,36 @@ EOF
 # permission error, later and on one table rather than all of them. So the run
 # stops with nothing changed, the marker still naming the old role, and the
 # runbook carries the transfer to do by hand.
+# role_owns_app_objects <db> <role>
+#
+# How many application objects in <db> that role still owns: tables, partitioned
+# tables, sequences, views and materialized views, outside the system schemas.
+# Exactly the set the runbook's by-hand transfer moves, and exactly the set whose
+# ownership decides whether the app can read its own data.
+#
+# Indexes and TOAST tables are excluded deliberately rather than by accident.
+# They cannot be reassigned on their own — they follow the table they belong to
+# — and pg_toast is not one of the two schemas the obvious exclusion list names,
+# so a query written without the relkind filter reports dozens of catalog TOAST
+# tables owned by postgres on every host and can never come back empty. That is
+# not a hypothetical: it is what the runbook's own verification query did, which
+# is why the operator could not confirm a transfer either.
+#
+# Prints the count, or nothing if the query could not run — the caller must
+# treat that as "still owns objects" rather than as zero. A rotation is refused
+# on the strength of this number, so an unanswerable question has to read as the
+# unsafe answer.
+role_owns_app_objects() {
+  psql_as_postgres "$1" \
+    "SELECT count(*) FROM pg_class c
+       JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE n.nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')
+        AND c.relkind IN ('r', 'p', 'S', 'v', 'm')
+        AND pg_get_userbyid(c.relowner) = '$2'"
+}
+
 refuse_superuser_db_rotation() {
-  local current="$1" prior_file="${2:-$STATE_DIR/db_user}" prior
+  local current="$1" prior_file="${2:-$STATE_DIR/db_user}" prior owns
   [ -f "$prior_file" ] || return 0
   prior="$(cat "$prior_file")"
   [ -n "$prior" ] && [ "$prior" != "$current" ] || return 0
@@ -594,13 +631,33 @@ refuse_superuser_db_rotation() {
   [ "$(psql_as_postgres postgres \
         "SELECT rolsuper FROM pg_roles WHERE rolname = '$prior'")" = t ] || return 0
 
+  # A superuser predecessor that owns nothing has already been transferred by
+  # hand, and the rotation it was blocking is now the thing that finishes the
+  # job. Blocking on rolsuper alone made the runbook's recovery unreachable:
+  # the recipe leaves 'postgres' a superuser on purpose — NOLOGIN on the
+  # bootstrap role is a lockout, not a revocation — so the guard fired again on
+  # the very re-run it had asked for, with a message claiming objects are owned
+  # by a role that no longer owns any. There was no way out of that state except
+  # abandoning the rotation.
+  owns="$(role_owns_app_objects "$DB_NAME" "$prior")"
+  if [ "$owns" = 0 ]; then
+    log "previous DB_USER '$prior' is a superuser but owns nothing in '$DB_NAME'," \
+        "so the transfer to '$current' has already been done by hand; continuing." \
+        "NOTE: '$prior' keeps LOGIN and its password — unlike an ordinary" \
+        "rotation, this one does not retire the old credential, and only you can" \
+        "decide what should happen to a superuser login."
+    return 0
+  fi
+
+  # Anything other than a plain 0 — a count, or an empty string from a database
+  # that does not exist yet or a query that failed — refuses.
   die "this host was provisioned with DB_USER='$prior', which is a superuser, and" \
-      "DB_USER is now '$current'. Every table and sequence the app created is owned" \
-      "by '$prior', and PostgreSQL refuses to reassign a superuser's objects, so" \
-      "'$current' would own the database and be unable to read a row of it." \
-      "Nothing has been changed. Move the objects by hand — see 'Changing DB_USER" \
-      "on a re-run' in docs/deploy_to_lightsail.md — then re-run, or set" \
-      "DB_USER='$prior' to leave the rotation undone."
+      "DB_USER is now '$current'. ${owns:-An unknown number of} object(s) in" \
+      "'$DB_NAME' are still owned by '$prior', and PostgreSQL refuses to reassign a" \
+      "superuser's objects, so '$current' would own the database and be unable to" \
+      "read a row of it. Nothing has been changed. Move the objects by hand — see" \
+      "'Changing DB_USER on a re-run' in docs/deploy_to_lightsail.md — then re-run," \
+      "or set DB_USER='$prior' to leave the rotation undone."
 }
 
 reassign_prior_db_role() {
@@ -611,12 +668,31 @@ reassign_prior_db_role() {
   [ "$(psql_as_postgres postgres \
         "SELECT count(*) FROM pg_roles WHERE rolname = '$prior'")" = 1 ] || return 0
 
-  # A backstop. refuse_superuser_db_rotation() runs before the database SQL and
-  # should have ended the run already; getting here means it was bypassed, and
-  # REASSIGN OWNED BY a superuser is rejected by PostgreSQL itself, so failing
-  # with the reason beats failing with a raw SQL error.
+  # A superuser predecessor reaches here only on the path refuse_superuser_db_
+  # rotation() lets through: the by-hand transfer is done and there is nothing
+  # left to move. Both statements below have to be skipped rather than merely
+  # allowed to no-op.
+  #
+  # REASSIGN OWNED BY the bootstrap superuser is rejected outright — "required
+  # by the database system" — whether or not it owns anything in this database,
+  # so it is not a no-op, it is an error that would end the run at the last step
+  # of a rotation that had otherwise succeeded.
+  #
+  # And ALTER ROLE postgres NOLOGIN succeeds. That is the dangerous one: nothing
+  # in PostgreSQL stops it, the next connection is refused with
+  # 'FATAL: role "postgres" is not permitted to log in', and peer authentication
+  # needs LOGIN too — so the account you would use to undo it is the account it
+  # locks out. Verified on 17 rather than assumed from the docs.
   if [ "$(psql_as_postgres postgres \
             "SELECT rolsuper FROM pg_roles WHERE rolname = '$prior'")" = t ]; then
+    if [ "$(role_owns_app_objects "$DB_NAME" "$prior")" = 0 ]; then
+      log "left the superuser role '$prior' alone: it owns nothing in '$DB_NAME'," \
+          "and taking LOGIN from the cluster superuser locks the host's operators" \
+          "out of administering it"
+      return 0
+    fi
+    # Only reachable if the guard was bypassed; failing with the reason beats
+    # failing with a raw SQL error.
     die "previous DB_USER '$prior' is a superuser; its objects cannot be reassigned." \
         "See 'Changing DB_USER on a re-run' in docs/deploy_to_lightsail.md."
   fi

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -449,7 +449,47 @@ install_authorized_keys() {
   done
 }
 
+# revoke_prior_ssh_key <authorized_keys> [state file]
+#
+# The counterpart of revoke_prior_deploy_user and reassign_prior_db_role, for
+# the same reason and on the same account: a re-run with a changed
+# SSH_PUBLIC_KEY appends the new key and leaves the old one authorized. This
+# account is in `docker` and has passwordless sudo, so a key the operator
+# believes they retired still reaches root — the rotation reports success and
+# withdraws nothing.
+#
+# Only the key *this script* installed is withdrawn, recorded in a state file
+# rather than guessed at, so keys an operator added by hand and the cloud
+# user's original key are never touched.
+revoke_prior_ssh_key() {
+  local auth_keys="$1" state="${2:-$STATE_DIR/ssh_public_key}" prior tmp
+  # An empty SSH_PUBLIC_KEY means "keep using the cloud user's keys", not
+  # "retire the managed one" — withdrawing here would strand an operator who
+  # simply dropped the variable from a re-run.
+  [ -n "$SSH_PUBLIC_KEY" ] || return 0
+  # Never revoke before the successor is actually in place: an interrupted run
+  # must leave two usable keys, never zero.
+  grep -qxF "$SSH_PUBLIC_KEY" "$auth_keys" || return 0
+
+  if [ -f "$state" ]; then
+    prior="$(cat "$state")"
+    if [ -n "$prior" ] && [ "$prior" != "$SSH_PUBLIC_KEY" ] &&
+       grep -qxF "$prior" "$auth_keys"; then
+      tmp="$(mktemp)"
+      # Exact whole-line match: a key is withdrawn only if it is byte-for-byte
+      # the one recorded, so an operator key that merely shares a comment or a
+      # prefix survives.
+      grep -vxF "$prior" "$auth_keys" > "$tmp" || true
+      cat "$tmp" > "$auth_keys"   # rewrite in place, keeping mode and owner
+      rm -f "$tmp"
+      log "withdrew the SSH key this script installed on a previous run"
+    fi
+  fi
+  printf '%s\n' "$SSH_PUBLIC_KEY" > "$state"
+}
+
 install_authorized_keys "$AUTH_KEYS"
+revoke_prior_ssh_key "$AUTH_KEYS"
 sort -u -o "$AUTH_KEYS" "$AUTH_KEYS"
 chown "$APP_SSH_USER:$APP_SSH_USER" "$AUTH_KEYS"
 chmod 0600 "$AUTH_KEYS"

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -2901,10 +2901,22 @@ install_authorized_keys() {
       # append_state_line dedupes, so the retry after the disk is freed records
       # nothing twice. Installed-but-not-recorded is the finding.
       #
-      # Aborting is the safe end here rather than a lesser one: this returns
-      # non-zero, which the call site treats as fatal *before* the sudo and
-      # docker grants, so the host is left exactly as it was and the operator
-      # still reaches it as the cloud user.
+      # Aborting is the safe end here rather than a lesser one, though not
+      # because the host is untouched — checked against the call order rather
+      # than assumed, and only half of it is true:
+      #
+      #   usermod -aG sudo / ensure_sudoers   step 3, BEFORE this
+      #   install_authorized_keys             <- here
+      #   usermod -aG docker                  step 6, after
+      #
+      # So the account already holds passwordless sudo when this returns
+      # non-zero. What makes that the safe end anyway is that nothing was
+      # installed: an account with sudo and an empty authorized_keys cannot be
+      # logged into at all, and the docker grant is never reached. That is
+      # exactly the state the `die` at the call site already names, down to
+      # telling the operator the grant is recorded in $STATE_DIR/deploy_users
+      # so a later run takes it back. The operator still reaches the host as
+      # the cloud user, whose own keys this script never writes.
       # Guarded on the two state variables the same way install_staged_authorized_keys
       # guards its chown on APP_SSH_USER: this function is called directly by a
       # dozen fixtures that have no state directory and no deploy account, and

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -176,6 +176,12 @@ fi
 refuse_defaulted_config_change() {
   local state_dir="${1:-$STATE_DIR}" supplied="${2:-$SUPPLIED_SETTINGS}"
   local env_file="$state_dir/launch.env" name prior now drift='' replay='' pair file
+  # Which file the operator should read is not the same question on both
+  # branches, and the branch that answers it wrong is the one that fires on a
+  # host where launch.env does not exist — pointing an operator mid-refusal at
+  # an absent file reads as "the record is missing", which is the opposite of
+  # what just happened: the comparison was answered, by a different file.
+  local record=''
 
   # Recorded as they are found, so the replay command the refusal prints is
   # built from the same comparison that refused — a second pass over the file
@@ -186,6 +192,7 @@ refuse_defaulted_config_change() {
   }
 
   if [ -f "$env_file" ]; then
+    record="The host's own record of what it was given is $env_file."
     # Driven by the current setting list rather than by the file's lines, so a
     # value this revision no longer has, or a line an editor mangled, cannot be
     # turned into an indirect expansion of an arbitrary name.
@@ -210,8 +217,15 @@ refuse_defaulted_config_change() {
       now="${!name}"
       if [ -n "$prior" ] && [ "$prior" != "$now" ]; then
         note_drift "$name" "$prior" "$now"
+        # Named as they answer, so the message sends the operator to the file
+        # that actually decided this refusal rather than to the whole directory.
+        record="$record${record:+, }$state_dir/$file"
       fi
     done
+    [ -z "$record" ] || record="This host predates $env_file, so what it was
+given is recorded only in $record.
+The settings not kept there could not be checked at all — repeating those is
+still on you."
   fi
   unset -f note_drift
 
@@ -236,8 +250,8 @@ deploy account and the database role out from under the running deployment,
 whose .env.production still names the old ones."$'\n\n'\
 "Nothing has been changed. Repeat them to converge the host as it is:"$'\n\n'\
 "    sudo ${replay}FORCE=1 bash script/lightsail_launch.sh"$'\n\n'\
-"or set ACK_CONFIG_RESET=1 if you do mean to reset them to the defaults.
-The host's own record of what it was given is $env_file."
+"or set ACK_CONFIG_RESET=1 if you do mean to reset them to the defaults."$'\n'\
+"$record"
 }
 
 refuse_defaulted_config_change

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -1147,6 +1147,7 @@ in_group() {
 # umask right.
 write_state_file() {
   local target="$1" content="$2" mode="${3:-0644}" tmp
+  [ ! -d "$target" ] || return 1
   tmp="$(mktemp "$target.XXXXXX")" || return 1
   if ! chmod "$mode" "$tmp" || ! printf '%s' "$content" > "$tmp"; then
     rm -f "$tmp"
@@ -1164,10 +1165,11 @@ write_state_file() {
 # FORCE=1 run silently reset an override that has no other state file, such as
 # BACKUP_S3_URI.
 launch_record_is_complete() {
-  local env_file="$1" name
+  local env_file="$1" name count
   [ -f "$env_file" ] || return 1
   for name in $LAUNCH_SETTINGS; do
-    [ "$(grep -c "^$name=" "$env_file" 2>/dev/null)" -eq 1 ] || return 1
+    count="$(grep -c "^$name=" "$env_file" 2>/dev/null || true)"
+    [ "$count" = 1 ] || return 1
   done
 }
 

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -2577,25 +2577,147 @@ sysctl --system >/dev/null
 # load-bearing: without it sshd prints only the global block, so a later
 # `Match User <deploy-user>` can turn password authentication back on while
 # this verifier reports the global `no`.
+#
+# scan_ssh_config_file <file> <relative-include root>
+#
+# Follow Include directives in the order sshd reads them while carrying Match
+# state across file boundaries. A flat grep cannot do that: Include is textual,
+# so an address-scoped Match before an Include also scopes authentication
+# directives inside the included file, and Match All after it ends the scope.
+scan_ssh_config_file() {
+  local file="$1" include_root="$2" canonical old_stack line raw_line key value
+  local pattern included line_no=0 i
+  local -a fields=()
+  [ -f "$file" ] || return 0
+
+  canonical="$(realpath "$file" 2>/dev/null || printf '%s' "$file")"
+  case $'\n'"${SSH_CONFIG_SCAN_STACK:-}"$'\n' in
+    *$'\n'"$canonical"$'\n'*)
+      SSH_CONFIG_SCAN_UNSAFE="$canonical: recursive Include"
+      return 0
+      ;;
+  esac
+  old_stack="${SSH_CONFIG_SCAN_STACK:-}"
+  SSH_CONFIG_SCAN_STACK="${SSH_CONFIG_SCAN_STACK:-}${SSH_CONFIG_SCAN_STACK:+$'\n'}$canonical"
+
+  while IFS= read -r line || [ -n "$line" ]; do
+    line_no=$(( line_no + 1 ))
+    raw_line="$line"
+    # OpenSSH accepts quoting and backslash escapes in Include paths. Reusing
+    # shell parsing here would be wrong (and eval would execute the config), so
+    # fail closed on those uncommon forms rather than split them into the wrong
+    # paths and silently skip a contextual authentication override.
+    if [[ "$raw_line" =~ ^[[:space:]]*[Ii][Nn][Cc][Ll][Uu][Dd][Ee][[:space:]] ]] &&
+       { [[ "$raw_line" = *\"* ]] || [[ "$raw_line" = *\\* ]]; }; then
+      SSH_CONFIG_SCAN_UNSAFE="$canonical:$line_no: quoted or escaped Include cannot be verified"
+      break
+    fi
+    line="${line%%#*}"
+    read -ra fields <<<"$line"
+    [ "${#fields[@]}" -gt 0 ] || continue
+    key="$(printf '%s' "${fields[0]}" | tr '[:upper:]' '[:lower:]')"
+
+    if [ "$key" = include ]; then
+      for pattern in "${fields[@]:1}"; do
+	pattern="${pattern#\"}"
+	pattern="${pattern%\"}"
+	[[ "$pattern" = /* ]] || pattern="$include_root/$pattern"
+	while IFS= read -r included; do
+	  scan_ssh_config_file "$included" "$include_root"
+	  [ -z "${SSH_CONFIG_SCAN_UNSAFE:-}" ] || break 3
+	done < <(compgen -G "$pattern" | LC_ALL=C sort)
+      done
+      continue
+    fi
+
+    if [ "$key" = match ]; then
+      SSH_CONFIG_SCAN_CONTEXTUAL=0
+      i=1
+      while [ "$i" -lt "${#fields[@]}" ]; do
+	key="$(printf '%s' "${fields[$i]}" | tr '[:upper:]' '[:lower:]')"
+	case "$key" in
+	  all)
+	    i=$(( i + 1 ))
+	    ;;
+	  user|group)
+	    i=$(( i + 2 ))
+	    ;;
+	  address|host|localaddress|localnetwork|localport|rdomain)
+	    SSH_CONFIG_SCAN_CONTEXTUAL=1
+	    i=$(( i + 2 ))
+	    ;;
+	  *)
+	    # A newer or malformed criterion is not something a user-only probe
+	    # can prove safe. sshd -T below still supplies the syntax verdict.
+	    SSH_CONFIG_SCAN_CONTEXTUAL=1
+	    i=$(( i + 1 ))
+	    ;;
+	esac
+      done
+      continue
+    fi
+
+    if [ "${SSH_CONFIG_SCAN_CONTEXTUAL:-0}" -eq 1 ]; then
+      value="${fields[1]:-}"
+      value="$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]')"
+      if [[ "$key" =~ ^(passwordauthentication|kbdinteractiveauthentication|permitrootlogin)$ ]] &&
+	 [ "$value" != no ]; then
+	SSH_CONFIG_SCAN_UNSAFE="$canonical:$line_no:${line#"${line%%[![:space:]]*}"}"
+	break
+      fi
+    fi
+  done < "$file"
+
+  SSH_CONFIG_SCAN_STACK="$old_stack"
+}
+
+find_unsafe_ssh_match() {
+  local conf_dir="${1:-/etc/ssh}"
+  SSH_CONFIG_SCAN_CONTEXTUAL=0
+  SSH_CONFIG_SCAN_UNSAFE=""
+  SSH_CONFIG_SCAN_STACK=""
+  scan_ssh_config_file "$conf_dir/sshd_config" "$conf_dir"
+  printf '%s\n' "$SSH_CONFIG_SCAN_UNSAFE"
+  unset SSH_CONFIG_SCAN_CONTEXTUAL SSH_CONFIG_SCAN_UNSAFE SSH_CONFIG_SCAN_STACK
+}
+
 verify_ssh_hardening() {
   local src="${1:-}" conf_dir="${2:-/etc/ssh}" reload_state="${3:-0}"
   local deploy_user="${4:-${APP_SSH_USER:-collavre}}"
-  local effective key value offender
+  local effective key value offender unsafe_match
   if [ -n "$src" ]; then
     effective="$(cat "$src")"
-  elif ! effective="$(sshd -T -C "user=$deploy_user" 2>/dev/null)"; then
-    [ "$reload_state" -ne 2 ] || die \
-      "SSH hardening could not be verified: there is no active sshd to reload" \
-      "and 'sshd -T -C user=$deploy_user' rejected or could not read the" \
-      "configuration on disk." \
-      "The next socket-activated connection or reboot would start sshd from" \
-      "that unverified configuration. Provisioning will not continue. Run" \
-      "'sshd -t' to find the error, fix it, and re-run."
-    log "WARNING: could not read the effective SSH configuration on this host" \
+  else
+    # A user-only connection context covers Match User, Match Group and
+    # Match All, including group membership changes made later in this run.
+    # It cannot answer for source/destination addresses, host names, listener
+    # ports or routing domains: probing one invented connection would merely
+    # leave every other connection untested. Refuse a weakening directive in
+    # one of those contexts rather than report the privileged deploy account
+    # hardened on incomplete evidence.
+    unsafe_match="$(find_unsafe_ssh_match "$conf_dir")"
+    [ -z "$unsafe_match" ] ||
+      die "SSH hardening cannot be verified for every connection: a Match" \
+	"Address/Host/LocalAddress/LocalPort/RDomain block weakens" \
+	"authentication at $unsafe_match." \
+	"The user-only sshd test below cannot evaluate that context. Remove" \
+	"or harden the directive and re-run before granting '$deploy_user'" \
+	"sudo or Docker access."
+
+    if ! effective="$(sshd -T -C "user=$deploy_user" 2>/dev/null)"; then
+      [ "$reload_state" -ne 2 ] || die \
+	"SSH hardening could not be verified: there is no active sshd to reload" \
+	"and 'sshd -T -C user=$deploy_user' rejected or could not read the" \
+	"configuration on disk." \
+	"The next socket-activated connection or reboot would start sshd from" \
+	"that unverified configuration. Provisioning will not continue. Run" \
+	"'sshd -t' to find the error, fix it, and re-run."
+      log "WARNING: could not read the effective SSH configuration on this host" \
 	"(\`sshd -T -C user=$deploy_user\` failed), so the hardening above is" \
 	"unverified. Check it by hand: sshd -T -C user=$deploy_user | grep -E" \
 	"'^(passwordauthentication|permitrootlogin|kbdinteractiveauthentication)'"
-    return 0
+      return 0
+    fi
   fi
   for key in passwordauthentication permitrootlogin kbdinteractiveauthentication; do
     value="$(printf '%s\n' "$effective" |
@@ -2917,10 +3039,26 @@ record_deploy_user_grant "$APP_SSH_USER" ||
       "cannot promise that a later one could find the account again. Nothing" \
       "has been granted. Check that $STATE_DIR is writable and has space, then" \
       "re-run."
+SUDO_GROUP_WAS_PRESENT=0
+in_group "$APP_SSH_USER" sudo && SUDO_GROUP_WAS_PRESENT=1
 usermod -aG sudo "$APP_SSH_USER"
 # Match Group is resolved from the account's current memberships, so the check
 # before user creation cannot see an override that starts applying here.
-verify_ssh_hardening "" /etc/ssh "$SSH_RELOAD_STATE" "$APP_SSH_USER"
+if ! ( verify_ssh_hardening "" /etc/ssh "$SSH_RELOAD_STATE" "$APP_SSH_USER" ); then
+  if [ "$SUDO_GROUP_WAS_PRESENT" -eq 0 ]; then
+    gpasswd -d "$APP_SSH_USER" sudo >/dev/null 2>&1 ||
+      die "SSH hardening failed after '$APP_SSH_USER' joined sudo, and the" \
+	"new membership could not be rolled back. Remove it immediately with" \
+	"'gpasswd -d $APP_SSH_USER sudo'."
+    in_group "$APP_SSH_USER" sudo &&
+      die "SSH hardening failed after '$APP_SSH_USER' joined sudo. The rollback" \
+	"reported success but the membership is still active; remove it" \
+	"immediately with 'gpasswd -d $APP_SSH_USER sudo'."
+    log "rolled back the new sudo membership after SSH hardening verification failed"
+  fi
+  die "SSH hardening failed after the sudo group change. Any membership added" \
+    "by this run was rolled back; correct the Match override and re-run."
+fi
 install -d -m 0755 /etc/sudoers.d
 ensure_sudoers "$APP_SSH_USER"
 
@@ -3083,7 +3221,7 @@ install_authorized_keys() {
       # real call site always has both — it is the line below that sets
       # AUTH_KEYS — so the production path is the one that records.
       if [ -n "${STATE_DIR:-}" ] && [ -n "${APP_SSH_USER:-}" ]; then
-        while read -r _copied; do
+	while IFS= read -r _copied; do
           case "$_copied" in ''|'#'*) continue ;; esac
           record_ssh_key_grant "$_copied" || {
             rm -f "$tmp"
@@ -3480,10 +3618,26 @@ if [ "$DAEMON_JSON_CHANGED" -eq 1 ]; then
 else
   systemctl start docker
 fi
+DOCKER_GROUP_WAS_PRESENT=0
+in_group "$APP_SSH_USER" docker && DOCKER_GROUP_WAS_PRESENT=1
 usermod -aG docker "$APP_SSH_USER"
 # Recheck for the same reason as the sudo grant above. An operator's
 # `Match Group docker` block does not apply until this membership exists.
-verify_ssh_hardening "" /etc/ssh "$SSH_RELOAD_STATE" "$APP_SSH_USER"
+if ! ( verify_ssh_hardening "" /etc/ssh "$SSH_RELOAD_STATE" "$APP_SSH_USER" ); then
+  if [ "$DOCKER_GROUP_WAS_PRESENT" -eq 0 ]; then
+    gpasswd -d "$APP_SSH_USER" docker >/dev/null 2>&1 ||
+      die "SSH hardening failed after '$APP_SSH_USER' joined docker, and the" \
+	"new membership could not be rolled back. Remove it immediately with" \
+	"'gpasswd -d $APP_SSH_USER docker'."
+    in_group "$APP_SSH_USER" docker &&
+      die "SSH hardening failed after '$APP_SSH_USER' joined docker. The rollback" \
+	"reported success but the membership is still active; remove it" \
+	"immediately with 'gpasswd -d $APP_SSH_USER docker'."
+    log "rolled back the new docker membership after SSH hardening verification failed"
+  fi
+  die "SSH hardening failed after the docker group change. Any membership added" \
+    "by this run was rolled back; correct the Match override and re-run."
+fi
 # Only once the replacement can reach Docker, so an interrupted run never
 # leaves the host with no account that can deploy.
 revoke_prior_deploy_user "$APP_SSH_USER"
@@ -3827,13 +3981,13 @@ log "7/9 firewall"
 ensure_ssh_rule
 ufw allow 80/tcp
 ufw allow 443/tcp
-ufw default deny incoming
-ufw default allow outgoing
 
 # PostgreSQL is only listening on localhost and the docker bridge, so this rule
 # is defence in depth rather than the only thing keeping it private.
 ensure_ufw_rule postgres \
   "allow from $DOCKER_SUBNETS to $DB_BIND_ADDRESS port $DB_PORT proto tcp"
+ufw default deny incoming
+ufw default allow outgoing
 ufw --force enable
 ufw status verbose
 

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -262,7 +262,14 @@ revoke_prior_deploy_user() {
       # docker back from one an operator made with `useradd -g docker`.
       groupadd -f "$prior" >/dev/null 2>&1 || true
       usermod -g "$prior" "$prior" >/dev/null 2>&1 || true
-    else
+    fi
+    # A group can be BOTH the primary one and a member entry in /etc/group, and
+    # `useradd -g docker` followed by `gpasswd -a` is how it happens. Moving the
+    # primary group leaves that /etc/group line behind, so the account keeps the
+    # group; re-reading membership is what tells the two cases apart. Guarded so
+    # gpasswd is never called on a non-member, whose error would land in the
+    # provisioning log operators read for real ones.
+    if in_group "$prior" "$group"; then
       gpasswd -d "$prior" "$group" >/dev/null 2>&1 || true
     fi
     # Verify rather than trust an exit status. This is what decides whether the
@@ -278,8 +285,9 @@ revoke_prior_deploy_user() {
   done
   if [ -n "$held" ]; then
     log "WARNING: could NOT revoke$held from the replaced deploy user '$prior';" \
-        "it still has root-equivalent access to this host. Take it back by hand:" \
-        "usermod -g $prior $prior   # when the group is its primary one"
+        "it still has root-equivalent access to this host. Take it back by hand," \
+        "both of these — the group can be primary AND a member entry at once:" \
+        "usermod -g $prior $prior; for g in$held; do gpasswd -d $prior \$g; done"
     # Deliberately leave the marker naming the user that still holds the group,
     # so the next run retries the revocation instead of forgetting it.
     return 0

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -2410,6 +2410,7 @@ install_managed_config 'the sysctl drop-in' /etc/sysctl.d/99-collavre.conf \
 sysctl --system >/dev/null
 
 # verify_ssh_hardening [effective config file] [sshd config dir]
+#                      [reload state: 0=reloaded, 2=no active daemon]
 #
 # Read back what sshd actually resolved the three hardened keywords to, and
 # refuse a run that reported hardening it did not perform.
@@ -2427,17 +2428,25 @@ sysctl --system >/dev/null
 # it, so nobody is locked out by the refusal. The alternative is a run that
 # prints its summary over a host still accepting passwords and root logins.
 #
-# An answer that cannot be read is not the same as a wrong one, and is warned
-# about instead. `sshd -T` needs host keys and a parseable configuration; a host
-# where it will not run has told us nothing, and dying over a question we could
-# not ask would stop provisioning on a host that may well be fine. Match blocks
-# do not cause that — `sshd -T` without `-C` prints the global block and exits 0,
+# An answer that cannot be read is not the same as a wrong one when a running
+# daemon has just accepted the reload, and is warned about instead. With no
+# active daemon it is the only gate: the next socket-activated connection will
+# start sshd from those files, so an unreadable answer is fatal in reload state
+# 2. `sshd -T` needs host keys and a parseable configuration; Match blocks do
+# not make it unreadable — without `-C` it prints the global block and exits 0,
 # measured on both OpenSSH builds this was checked against.
 verify_ssh_hardening() {
-  local src="${1:-}" conf_dir="${2:-/etc/ssh}" effective key value offender
+  local src="${1:-}" conf_dir="${2:-/etc/ssh}" reload_state="${3:-0}"
+  local effective key value offender
   if [ -n "$src" ]; then
     effective="$(cat "$src")"
   elif ! effective="$(sshd -T 2>/dev/null)"; then
+    [ "$reload_state" -ne 2 ] || die \
+      "SSH hardening could not be verified: there is no active sshd to reload" \
+      "and 'sshd -T' rejected or could not read the configuration on disk." \
+      "The next socket-activated connection or reboot would start sshd from" \
+      "that unverified configuration. Nothing has been granted. Run 'sshd -t'" \
+      "to find the error, fix it, and re-run."
     log "WARNING: could not read the effective SSH configuration on this host" \
         "(\`sshd -T\` failed), so the hardening above is unverified. Check it" \
         "by hand: sshd -T | grep -E" \
@@ -2537,8 +2546,10 @@ rm -f /etc/ssh/sshd_config.d/99-collavre.conf
 # sshd_config; without it the drop-in above is silently ignored.
 grep -q '^Include /etc/ssh/sshd_config.d/' /etc/ssh/sshd_config 2>/dev/null || \
   log "WARNING: sshd_config has no Include for sshd_config.d — harden SSH by hand"
-# reload_ssh_daemon — reload whichever unit carries sshd; non-zero only when a
-# *running* daemon refused the configuration.
+# reload_ssh_daemon — reload whichever unit carries sshd.
+#
+# Returns 0 when a unit adopted the configuration, 1 when a running daemon
+# refused it, and 2 when neither unit is active and there was nothing to reload.
 #
 # `|| true` here used to swallow the status, and the status means two different
 # things. Measured under systemd 252, one unit state per row, with ExecReload
@@ -2569,7 +2580,7 @@ reload_ssh_daemon() {
     systemctl reload "$unit" >/dev/null 2>&1 && return 0
     [ "$(systemctl is-active "$unit" 2>/dev/null)" = active ] && return 1
   done
-  return 0
+  return 2
 }
 # Fatal, and *before* verify_ssh_hardening rather than folded into it, because
 # on this path that function is answering the wrong question. `sshd -T` re-reads
@@ -2587,14 +2598,16 @@ reload_ssh_daemon() {
 # does not exist yet, nothing has been granted, and SSH is left exactly as the
 # operator had it, so the refusal locks nobody out. That is the same reason
 # verify_ssh_hardening's own die() sits here rather than after the grants.
-reload_ssh_daemon || die \
+SSH_RELOAD_STATE=0
+reload_ssh_daemon || SSH_RELOAD_STATE=$?
+[ "$SSH_RELOAD_STATE" -ne 1 ] || die \
   "SSH hardening was written but the running sshd refused to reload it." \
   "The live daemon is still using the configuration it started with, so the" \
   "hardening above is NOT in effect — and sshd will be handed the same" \
   "rejected configuration at the next boot, where no old process survives to" \
   "keep the host reachable. Nothing has been granted and SSH is unchanged." \
   "Find the offending directive with 'sshd -t', fix it, and re-run."
-verify_ssh_hardening
+verify_ssh_hardening "" /etc/ssh "$SSH_RELOAD_STATE"
 
 # install_deploy_ssh_dir <user> <home> — create <home>/.ssh owned by the
 # account, and echo the group it was given.

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -429,12 +429,30 @@ ensure_ufw_rule() {
 # port 22` is told nothing authorizes SSH, and gets a blanket rule added beside
 # their restriction, opening 22 to every source they excluded.
 #
+# The port is not always the first thing on the line. A rule written against a
+# particular destination address — `ufw allow from <ip> to <this-host> port 22`,
+# which is how SSH gets pinned to one interface on a host with both a public and
+# a private address — renders as "10.1.2.3 22/tcp", so anchoring on the port
+# misses it and broadens exactly the rule it was meant to respect. Hence the
+# optional leading token. It cannot swallow a different port: "2222/tcp" and
+# "10.1.2.3 2222/tcp" both still fail to match, as does a host address that
+# merely starts with 22 ("22.1.1.1 80/tcp").
+#
 # Deliberately positive: it answers "is 22 open?", never "is 22 closed?". An
 # empty or unparseable `ufw status` therefore means we add the rule, because
 # guessing wrong in that direction only re-opens SSH, while guessing wrong in
 # the other enables a deny-by-default firewall on a host with no way in.
+#
+# That same direction is why an all-ports rule ("Anywhere ALLOW <ip>", from
+# `ufw allow from <ip>` with no port) is deliberately NOT counted, even though
+# it does permit 22 from that source. Its source is some host the operator
+# trusts for an unrelated service as often as it is their own workstation, and
+# reading it as "SSH is handled" would enable a deny-by-default firewall on a
+# box the operator may have no remaining way into. A rule that names port 22 is
+# evidence about SSH; one that names no port at all is not.
 ssh_already_allowed() {
-  ufw status 2>/dev/null | grep -qE '^(22|OpenSSH)([/[:space:]]).*(ALLOW|LIMIT)'
+  ufw status 2>/dev/null |
+    grep -qE '^([^[:space:]]+[[:space:]]+)?(22|OpenSSH)([/[:space:]]).*(ALLOW|LIMIT)'
 }
 
 # Authorize SSH, but only if nothing else already does. An operator who

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -450,8 +450,38 @@ ensure_ufw_rule() {
 # reading it as "SSH is handled" would enable a deny-by-default firewall on a
 # box the operator may have no remaining way into. A rule that names port 22 is
 # evidence about SSH; one that names no port at all is not.
+# IPv6 lines are dropped before the match, and that stage is load-bearing. What
+# has to be true here is that *IPv4* port 22 is reachable: `ufw --force enable`
+# below applies `default deny incoming`, and an operator reaching a Lightsail
+# instance does so over its IPv4 address. ufw prints the address family only as
+# a "(v6)" tag on the rule, so a host carrying nothing but
+# "22/tcp (v6) ... ALLOW" would otherwise read as authorized — the IPv4 rule
+# skipped, and the firewall then enabled against the connection in use.
+# Dual-stack hosts are unaffected: `ufw allow OpenSSH` writes both lines, and
+# the IPv4 one survives the filter.
+#
+# The "(v6)" tag alone is not enough to find them, and neither is the leading
+# token. ufw only tags a rule that names no address at all ("22/tcp (v6)"); one
+# written against an IPv6 *destination* renders untagged as
+# "2001:db8::1 22/tcp ALLOW ...", and one restricted to an IPv6 *source* renders
+# as "22/tcp ALLOW 2001:db8::9" — untagged, and with an ordinary IPv4-looking
+# first column. That last form is the one to keep in mind: narrowing SSH to your
+# own address is the most likely reason a host has an IPv6-only rule in the
+# first place. So the family is decided by a colon anywhere in the rule, which
+# is the only thing all three have in common.
+#
+# The comment is stripped first because `ufw allow 22/tcp comment 'ssh: admin'`
+# puts an operator's colon on an IPv4 line. Failing that way is safe — it adds a
+# blanket rule rather than locking anyone out — but it would broaden the very
+# rule this function exists to leave alone.
+#
+# All of it verified against real ufw on ubuntu:24.04, against `iptables -S` as
+# the ground truth for whether IPv4 port 22 is actually reachable, rather than
+# reasoned about from the rendering.
 ssh_already_allowed() {
   ufw status 2>/dev/null |
+    sed 's/#.*//' |
+    grep -vE '\(v6\)|:' |
     grep -qE '^([^[:space:]]+[[:space:]]+)?(22|OpenSSH)([/[:space:]]).*(ALLOW|LIMIT)'
 }
 

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -784,6 +784,26 @@ grep -q '^Include /etc/ssh/sshd_config.d/' /etc/ssh/sshd_config 2>/dev/null || \
   log "WARNING: sshd_config has no Include for sshd_config.d — harden SSH by hand"
 systemctl reload ssh 2>/dev/null || systemctl reload sshd 2>/dev/null || true
 
+# install_deploy_ssh_dir <user> <home> — create <home>/.ssh owned by the
+# account, and echo the group it was given.
+#
+# The group is asked for, not assumed. adduser creates one named after the user,
+# but APP_SSH_USER is allowed to name an account that already exists — the cloud
+# user, or one an operator made with `useradd -g users deploybot` — and then
+# there is no group of that name. `install` and `chown` reject an unknown group,
+# so guessing ends the run here under `set -e`, before authorized keys, Docker
+# and PostgreSQL are configured. `id -gn` answers for both cases.
+install_deploy_ssh_dir() {
+  local user="$1" home="$2" group
+  group="$(id -gn "$user")"
+  # Explicitly, rather than leaving it to `set -e` inside the command
+  # substitution the caller wraps this in: the last command here is a printf
+  # that always succeeds, so a swallowed failure would hand back a group name
+  # for a directory that was never created.
+  install -d -m 0700 -o "$user" -g "$group" "$home/.ssh" || return 1
+  printf '%s\n' "$group"
+}
+
 if ! id -u "$APP_SSH_USER" >/dev/null 2>&1; then
   adduser --disabled-password --gecos "Collavre deploy" "$APP_SSH_USER"
 fi
@@ -792,7 +812,7 @@ install -d -m 0755 /etc/sudoers.d
 ensure_sudoers "$APP_SSH_USER"
 
 APP_HOME="$(getent passwd "$APP_SSH_USER" | cut -d: -f6)"
-install -d -m 0700 -o "$APP_SSH_USER" -g "$APP_SSH_USER" "$APP_HOME/.ssh"
+APP_SSH_GROUP="$(install_deploy_ssh_dir "$APP_SSH_USER" "$APP_HOME")"
 AUTH_KEYS="$APP_HOME/.ssh/authorized_keys"
 touch "$AUTH_KEYS"
 
@@ -889,7 +909,7 @@ revoke_prior_ssh_key() {
 install_authorized_keys "$AUTH_KEYS"
 revoke_prior_ssh_key "$AUTH_KEYS"
 sort -u -o "$AUTH_KEYS" "$AUTH_KEYS"
-chown "$APP_SSH_USER:$APP_SSH_USER" "$AUTH_KEYS"
+chown "$APP_SSH_USER:$APP_SSH_GROUP" "$AUTH_KEYS"
 chmod 0600 "$AUTH_KEYS"
 [ -s "$AUTH_KEYS" ] || log "WARNING: $AUTH_KEYS is empty — kamal will not be able to connect"
 

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -250,6 +250,52 @@ revoke_prior_deploy_user() {
       "deluser --remove-home $prior"
 }
 
+# psql_as_postgres <database> <sql>
+#
+# One place to reach the cluster as the superuser, so the rotation below can be
+# exercised in tests by stubbing a single command.
+psql_as_postgres() {
+  runuser -u postgres -- psql -v ON_ERROR_STOP=1 -qtA -d "$1" -c "$2"
+}
+
+# reassign_prior_db_role <current> [state file]
+#
+# The deploy-user counterpart of revoke_prior_deploy_user, for the same reason:
+# a re-run that changes DB_USER creates the new role and moves the *database*
+# owner to it, but every table and sequence the app already created stays owned
+# by the old role. The new role is then handed out in DATABASE_URL and cannot
+# read its own tables — "permission denied for table users" on the first query
+# after a rotation that reported success. Meanwhile the old role keeps LOGIN and
+# the very same password out of $STATE_DIR/db_password, so a rotation intended
+# to retire a credential retires nothing.
+#
+# REASSIGN OWNED moves ownership of everything the old role owns in this
+# database in one statement, including objects added since. It is a no-op when
+# the role owns nothing, so it is safe on a host where the app never booted.
+reassign_prior_db_role() {
+  local current="$1" prior_file="${2:-$STATE_DIR/db_user}" prior
+  [ -f "$prior_file" ] || return 0
+  prior="$(cat "$prior_file")"
+  [ -n "$prior" ] && [ "$prior" != "$current" ] || return 0
+  [ "$(psql_as_postgres postgres \
+        "SELECT count(*) FROM pg_roles WHERE rolname = '$prior'")" = 1 ] || return 0
+
+  # Never touch a superuser. DB_USER=postgres on a first run is a legal thing
+  # to have done, and NOLOGIN on the cluster superuser locks every operator out
+  # of administering it — peer auth needs LOGIN too, so there is no way back in.
+  if [ "$(psql_as_postgres postgres \
+            "SELECT rolsuper FROM pg_roles WHERE rolname = '$prior'")" = t ]; then
+    log "WARNING: previous DB_USER '$prior' is a superuser — leaving it alone;" \
+        "move ownership and retire it by hand if that is what you meant"
+    return 0
+  fi
+
+  psql_as_postgres "$DB_NAME" "REASSIGN OWNED BY \"$prior\" TO \"$current\""
+  log "moved ownership of everything in '$DB_NAME' from '$prior' to '$current'"
+  psql_as_postgres postgres "ALTER ROLE \"$prior\" NOLOGIN"
+  log "revoked LOGIN from the replaced database role '$prior'"
+}
+
 # ensure_ufw_rule <name> <rule> [state file]
 #
 # Converge one ufw rule the way ensure_block converges one config stanza:
@@ -373,19 +419,37 @@ install -d -m 0700 -o "$APP_SSH_USER" -g "$APP_SSH_USER" "$APP_HOME/.ssh"
 AUTH_KEYS="$APP_HOME/.ssh/authorized_keys"
 touch "$AUTH_KEYS"
 
-if [ -n "$SSH_PUBLIC_KEY" ]; then
-  grep -qxF "$SSH_PUBLIC_KEY" "$AUTH_KEYS" || printf '%s\n' "$SSH_PUBLIC_KEY" >> "$AUTH_KEYS"
-else
-  # Reuse whatever key Lightsail installed for the default cloud user.
+# install_authorized_keys <authorized_keys> [home root]
+#
+# Give the deploy user a way in: the explicit SSH_PUBLIC_KEY when there is one,
+# otherwise whatever key Lightsail installed for the default cloud user.
+install_authorized_keys() {
+  local auth_keys="$1" home_root="${2:-/home}" candidate src
+  if [ -n "$SSH_PUBLIC_KEY" ]; then
+    grep -qxF "$SSH_PUBLIC_KEY" "$auth_keys" ||
+      printf '%s\n' "$SSH_PUBLIC_KEY" >> "$auth_keys"
+    return 0
+  fi
   for candidate in ubuntu admin ec2-user; do
-    src="/home/$candidate/.ssh/authorized_keys"
-    if [ -s "$src" ]; then
+    src="$home_root/$candidate/.ssh/authorized_keys"
+    [ -s "$src" ] || continue
+    # APP_SSH_USER may *be* the cloud user, in which case there is nothing to
+    # copy — and appending a file to itself is not a harmless no-op: GNU cat
+    # refuses with "input file is output file" and exits 1, which under
+    # `set -e` would abort provisioning here, before Docker and PostgreSQL are
+    # installed. -ef rather than string equality, so a symlinked or
+    # bind-mounted home resolves to the same answer.
+    if [ "$src" -ef "$auth_keys" ]; then
+      log "APP_SSH_USER is the cloud user '$candidate' — its keys are already in place"
+    else
       log "no SSH_PUBLIC_KEY given — copying keys from $candidate"
-      cat "$src" >> "$AUTH_KEYS"
-      break
+      cat "$src" >> "$auth_keys"
     fi
+    return 0
   done
-fi
+}
+
+install_authorized_keys "$AUTH_KEYS"
 sort -u -o "$AUTH_KEYS" "$AUTH_KEYS"
 chown "$APP_SSH_USER:$APP_SSH_USER" "$AUTH_KEYS"
 chmod 0600 "$AUTH_KEYS"
@@ -506,7 +570,12 @@ if [ -z "$DB_PASSWORD" ]; then
     log "generated a random database password"
   fi
 fi
-printf '%s' "$DB_PASSWORD" > "$STATE_DIR/db_password"
+# The umask is what makes this 0600, not the chmod. A bare redirection creates
+# the file 0644 under the default umask and only narrows it a command later,
+# and $STATE_DIR is 0755 — so the production password would be world-readable
+# for that window, or permanently if the run were interrupted between the two.
+# The chmod stays to converge a file an earlier revision left 0644.
+( umask 077; printf '%s' "$DB_PASSWORD" > "$STATE_DIR/db_password" )
 chmod 0600 "$STATE_DIR/db_password"
 
 # Mirrors db/setup_postgres_databases.sql: create-if-missing, never drop.
@@ -532,6 +601,11 @@ chmod 0600 "$SQL_FILE"
 runuser -u postgres -- psql -v ON_ERROR_STOP=1 -q -d postgres -f "$SQL_FILE"
 rm -f "$SQL_FILE"
 trap - EXIT
+
+# After the role and database exist, before the summary hands out a
+# DATABASE_URL naming the new role.
+reassign_prior_db_role "$DB_USER"
+printf '%s\n' "$DB_USER" > "$STATE_DIR/db_user"
 
 # --------------------------------------------------------------------------
 log "7/9 firewall"

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -400,7 +400,19 @@ ipv4_dotted_quad() {
 # restart to trigger it.
 refuse_unusable_bind_address() {
   local setting="$1" value="$2"
-  ipv4_dotted_quad "$value" && return 0
+  if ipv4_dotted_quad "$value"; then
+    case "$value" in
+      127.*)
+	die "REFUSING: $setting='$value' is a loopback address. PostgreSQL would" \
+	    "listen successfully on the host, but DATABASE_URL is used inside" \
+	    "the application container, where 127.0.0.0/8 names the container" \
+	    "itself rather than the host database. Nothing has been changed." \
+	    "Set $setting to the gateway address of the bridge your containers" \
+	    "are on — 'ip -4 addr show docker0'."
+	;;
+    esac
+    return 0
+  fi
   die "REFUSING: $setting='$value' is not an IPv4 address. It is written into" \
       "PostgreSQL's listen_addresses, into a ufw rule and into DATABASE_URL," \
       "and PostgreSQL does not refuse it: an address it cannot bind is a" \
@@ -2666,7 +2678,7 @@ scan_ssh_config_file() {
     if [ "${SSH_CONFIG_SCAN_CONTEXTUAL:-0}" -eq 1 ]; then
       value="${fields[1]:-}"
       value="$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]')"
-      if [[ "$key" =~ ^(passwordauthentication|kbdinteractiveauthentication|permitrootlogin)$ ]] &&
+      if [[ "$key" =~ ^(passwordauthentication|kbdinteractiveauthentication|challengeresponseauthentication|permitrootlogin)$ ]] &&
 	 [ "$value" != no ]; then
 	SSH_CONFIG_SCAN_UNSAFE="$canonical:$line_no:${line#"${line%%[![:space:]]*}"}"
 	break

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -42,6 +42,12 @@ set -euo pipefail
 # PostgreSQL major version (from the PGDG apt repository).
 : "${PG_MAJOR:=17}"
 
+# The port the cluster serves. Not really configurable: it is what DATABASE_URL,
+# the ufw rule and the nightly backup all name, and a host with a second cluster
+# on it is refused rather than half-provisioned (ensure_cluster_on_default_port).
+# A constant with a name, so those four places cannot drift apart.
+: "${DB_PORT:=5432}"
+
 # Database and role. Defaults match db/setup_postgres_databases.sql.
 : "${DB_NAME:=collavre_production}"
 : "${DB_USER:=collavre_user}"
@@ -230,32 +236,114 @@ ensure_sudoers() {
 # and `deluser` on the wrong guess (APP_SSH_USER=ubuntu on the first run, say)
 # is unrecoverable. With both groups gone the keys reach an ordinary account,
 # which is a job for a human who can see the host.
+in_group() {
+  # id -nG rather than `getent group`: it reports the primary group too, and
+  # the membership that matters is the effective one either way.
+  id -nG "$1" 2>/dev/null | tr ' ' '\n' | grep -qxF "$2"
+}
+
 revoke_prior_deploy_user() {
-  local current="$1" prior_file="${2:-$STATE_DIR/deploy_user}" prior group
-  [ -f "$prior_file" ] || return 0
+  local current="$1" prior_file="${2:-$STATE_DIR/deploy_user}" prior group held
+  [ -f "$prior_file" ] || { printf '%s\n' "$current" > "$prior_file"; return 0; }
   prior="$(cat "$prior_file")"
-  [ -n "$prior" ] && [ "$prior" != "$current" ] || return 0
-  id -u "$prior" >/dev/null 2>&1 || return 0
+  if [ -z "$prior" ] || [ "$prior" = "$current" ] ||
+     ! id -u "$prior" >/dev/null 2>&1; then
+    printf '%s\n' "$current" > "$prior_file"
+    return 0
+  fi
 
   for group in docker sudo; do
-    # id -nG rather than `getent group`: it reports the primary group too, and
-    # the membership that matters is the effective one either way.
-    if id -nG "$prior" 2>/dev/null | tr ' ' '\n' | grep -qxF "$group"; then
-      gpasswd -d "$prior" "$group" >/dev/null 2>&1 &&
-        log "revoked '$group' from the replaced deploy user '$prior'"
+    in_group "$prior" "$group" || continue
+    if [ "$(id -gn "$prior" 2>/dev/null)" = "$group" ]; then
+      # gpasswd edits /etc/group only, so it cannot touch a PRIMARY group: it
+      # exits 3 with "user is not a member" while `id -nG` goes on reporting
+      # the membership. Giving the account a primary group named after itself
+      # is what useradd would have done by default, and is the only way to take
+      # docker back from one an operator made with `useradd -g docker`.
+      groupadd -f "$prior" >/dev/null 2>&1 || true
+      usermod -g "$prior" "$prior" >/dev/null 2>&1 || true
+    else
+      gpasswd -d "$prior" "$group" >/dev/null 2>&1 || true
     fi
+    # Verify rather than trust an exit status. This is what decides whether the
+    # message below is true, and a rotation that merely *claims* to have taken
+    # root back is worse than one that admits it could not.
+    in_group "$prior" "$group" ||
+      log "revoked '$group' from the replaced deploy user '$prior'"
   done
+
+  held=""
+  for group in docker sudo; do
+    in_group "$prior" "$group" && held="$held $group"
+  done
+  if [ -n "$held" ]; then
+    log "WARNING: could NOT revoke$held from the replaced deploy user '$prior';" \
+        "it still has root-equivalent access to this host. Take it back by hand:" \
+        "usermod -g $prior $prior   # when the group is its primary one"
+    # Deliberately leave the marker naming the user that still holds the group,
+    # so the next run retries the revocation instead of forgetting it.
+    return 0
+  fi
+
   log "WARNING: '$prior' is no longer in docker or sudo but can still log in;" \
       "remove it by hand once you can reach the host as '$current':" \
       "deluser --remove-home $prior"
+  printf '%s\n' "$current" > "$prior_file"
 }
 
 # psql_as_postgres <database> <sql>
 #
 # One place to reach the cluster as the superuser, so the rotation below can be
 # exercised in tests by stubbing a single command.
+#
+# The port is explicit even though 5432 is also the default. Everything this
+# script hands out — DATABASE_URL, the ufw rule, the backup timer — names 5432,
+# so this is the one place that would otherwise silently disagree with them.
 psql_as_postgres() {
-  runuser -u postgres -- psql -v ON_ERROR_STOP=1 -qtA -d "$1" -c "$2"
+  runuser -u postgres -- psql -v ON_ERROR_STOP=1 -qtA -p "$DB_PORT" -d "$1" -c "$2"
+}
+
+# Refuse to provision when $PG_MAJOR's cluster is not the one on $DB_PORT.
+#
+# This script assumes one cluster, on the default port: DATABASE_URL, the ufw
+# rule and the nightly pg_dump all hard-code 5432. Ubuntu's postgresql-common
+# does not share that assumption — pg_createcluster allocates the first free
+# port starting at 5432, so installing a second major version puts it on 5433.
+#
+# The run would then edit /etc/postgresql/$PG_MAJOR/main (tuning, listen_addresses,
+# the pg_hba rule for the docker bridge) while `psql` — and therefore the database,
+# the role, the backups and the DATABASE_URL — kept talking to whatever answers on
+# 5432. A FORCE=1 re-run with a bumped PG_MAJOR is the case that hurts: the app and
+# its backups stay on the old cluster, the log says the new version, and the new
+# cluster sits empty holding a quarter of RAM in shared_buffers. Nothing fails.
+#
+# Migrating between clusters is pg_upgradecluster's job and needs a human to
+# decide when the app stops, so this aborts and says so rather than guessing.
+ensure_cluster_on_default_port() {
+  local lsclusters="${1:-pg_lsclusters}" ver port owner_of_default=""
+  command -v "$lsclusters" >/dev/null 2>&1 || return 0
+
+  while read -r ver _cluster port _rest; do
+    [ -n "$ver" ] || continue
+    [ "$port" = "$DB_PORT" ] && owner_of_default="$ver"
+    if [ "$ver" = "$PG_MAJOR" ] && [ "$port" != "$DB_PORT" ]; then
+      die "PostgreSQL $PG_MAJOR is installed but its 'main' cluster listens on $port, not $DB_PORT." \
+          "This script only supports a single cluster on $DB_PORT — DATABASE_URL, the ufw rule" \
+          "and the nightly backup all name it. Move it with 'pg_ctlcluster' /" \
+          "'/etc/postgresql/$PG_MAJOR/main/postgresql.conf', or set PG_MAJOR to the version" \
+          "already serving $DB_PORT."
+    fi
+  done <<EOF
+$("$lsclusters" -h 2>/dev/null)
+EOF
+
+  if [ -n "$owner_of_default" ] && [ "$owner_of_default" != "$PG_MAJOR" ]; then
+    die "PostgreSQL $owner_of_default already serves $DB_PORT on this host, and PG_MAJOR is $PG_MAJOR." \
+        "Installing $PG_MAJOR now would create its cluster on the next free port while the app," \
+        "the backups and DATABASE_URL kept using $DB_PORT — a version bump that silently does not" \
+        "happen. Either set PG_MAJOR=$owner_of_default, or migrate deliberately with" \
+        "'pg_upgradecluster $owner_of_default main' and drop the old cluster before re-running."
+  fi
 }
 
 # reassign_prior_db_role <current> [state file]
@@ -326,12 +414,19 @@ ensure_ufw_rule() {
 # OpenSSH` renders as either "22/tcp" or "OpenSSH" depending on whether the app
 # profile is installed, and IPv6 duplicates append " (v6)".
 #
+# LIMIT counts as authorization, not just ALLOW. `ufw limit` is the rate-limited
+# form of an allow rule — it is what ufw's own documentation recommends for SSH
+# — and it renders in the Action column as "LIMIT" (some versions "LIMIT IN").
+# Reading only ALLOW means an operator who wrote `ufw limit from <ip> to any
+# port 22` is told nothing authorizes SSH, and gets a blanket rule added beside
+# their restriction, opening 22 to every source they excluded.
+#
 # Deliberately positive: it answers "is 22 open?", never "is 22 closed?". An
 # empty or unparseable `ufw status` therefore means we add the rule, because
 # guessing wrong in that direction only re-opens SSH, while guessing wrong in
 # the other enables a deny-by-default firewall on a host with no way in.
 ssh_already_allowed() {
-  ufw status 2>/dev/null | grep -qE '^(22|OpenSSH)([/[:space:]]).*ALLOW'
+  ufw status 2>/dev/null | grep -qE '^(22|OpenSSH)([/[:space:]]).*(ALLOW|LIMIT)'
 }
 
 # Authorize SSH, but only if nothing else already does. An operator who
@@ -561,11 +656,14 @@ usermod -aG docker "$APP_SSH_USER"
 # Only once the replacement can reach Docker, so an interrupted run never
 # leaves the host with no account that can deploy.
 revoke_prior_deploy_user "$APP_SSH_USER"
-printf '%s\n' "$APP_SSH_USER" > "$STATE_DIR/deploy_user"
 
 # --------------------------------------------------------------------------
 log "5/9 PostgreSQL $PG_MAJOR"
 # --------------------------------------------------------------------------
+# Before the apt install, not after: once a second cluster exists it has already
+# taken a port, and the only way back is pg_upgradecluster or a delete.
+ensure_cluster_on_default_port
+
 if ! [ -d "/etc/postgresql/$PG_MAJOR/main" ]; then
   install -d -m 0755 /usr/share/postgresql-common/pgdg
   curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
@@ -683,7 +781,7 @@ ufw allow 443/tcp
 # PostgreSQL is only listening on localhost and the docker bridge, so this rule
 # is defence in depth rather than the only thing keeping it private.
 ensure_ufw_rule postgres \
-  "allow from $DOCKER_SUBNETS to $DB_BIND_ADDRESS port 5432 proto tcp"
+  "allow from $DOCKER_SUBNETS to $DB_BIND_ADDRESS port $DB_PORT proto tcp"
 ufw --force enable
 ufw status verbose
 
@@ -730,7 +828,7 @@ STAMP="\$(date +%Y%m%d-%H%M%S)"
 FILE="\$DEST/\${DB_NAME}-\${STAMP}.dump"
 
 trap 'rm -f "\$FILE"' ERR
-runuser -u postgres -- pg_dump --format=custom --compress=6 \\
+runuser -u postgres -- pg_dump --format=custom --compress=6 --port=$DB_PORT \\
   --dbname="\$DB_NAME" --file="\$FILE"
 trap - ERR
 chmod 0600 "\$FILE"
@@ -792,10 +890,10 @@ PRIVATE_IP="$(hostname -I | awk '{print $1}')"
 URL_USER="$(urlencode "$DB_USER")"
 URL_PASSWORD="$(urlencode "$DB_PASSWORD")"
 URL_DB_NAME="$(urlencode "$DB_NAME")"
-DATABASE_URL="postgresql://$URL_USER:$URL_PASSWORD@$DB_BIND_ADDRESS:5432/$URL_DB_NAME"
+DATABASE_URL="postgresql://$URL_USER:$URL_PASSWORD@$DB_BIND_ADDRESS:$DB_PORT/$URL_DB_NAME"
 # Angle brackets, not a $(...) that a reader might paste into .env.production
 # and watch dotenv store verbatim.
-REDACTED_URL="postgresql://$URL_USER:<see $SUMMARY>@$DB_BIND_ADDRESS:5432/$URL_DB_NAME"
+REDACTED_URL="postgresql://$URL_USER:<see $SUMMARY>@$DB_BIND_ADDRESS:$DB_PORT/$URL_DB_NAME"
 # Only worth saying when the two actually differ, which they never do for the
 # generated password.
 PASSWORD_NOTE=''

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -1249,11 +1249,33 @@ record_db_role_grant() {
 # caller decides what is still outstanding, rather than this deciding it by
 # where it writes a marker.
 reassign_one_db_role() {
-  local prior="$1" current="$2"
+  local prior="$1" current="$2" exists super owns
+
+  # Every psql status below is checked explicitly rather than left to `set -e`.
+  # This function is called from `... || kept="$kept$prior"`, and a function
+  # invoked on the left of `||` runs with errexit suppressed for its whole
+  # body — so under `set -e` alone a failed REASSIGN fell through to
+  # ALTER ROLE ... NOLOGIN and returned the status of the last log: zero.
+  # Measured on the previous revision with the REASSIGN made to fail:
+  #
+  #   log: moved ownership of everything in 'db' from 'A' to 'B'
+  #   log: revoked LOGIN from the replaced database role 'A'
+  #   rc=0   objects still owned by A   NOLOGIN applied to A   queue: [B]
+  #
+  # which is the state the queue exists to prevent, reached by the one path
+  # that reports success: A still owns every table and can no longer log in,
+  # B is published in DATABASE_URL owning nothing, and A has just been dropped
+  # from the only record that named it.
+  #
+  # The probes are checked for the same reason as the statements: an empty
+  # result from a connection that died reads as "no such role" or "not a
+  # superuser", and both of those retire the role from the queue.
+
   # A role that no longer exists owns nothing and cannot be reassigned: there
   # is nothing outstanding, so it leaves the queue.
-  [ "$(psql_as_postgres postgres \
-        "SELECT count(*) FROM pg_roles WHERE rolname = '$prior'")" = 1 ] || return 0
+  exists="$(psql_as_postgres postgres \
+    "SELECT count(*) FROM pg_roles WHERE rolname = '$prior'")" || return 1
+  [ "$exists" = 1 ] || return 0
 
   # A superuser predecessor reaches here only on the path refuse_superuser_db_
   # rotation() lets through: the by-hand transfer is done and there is nothing
@@ -1270,9 +1292,11 @@ reassign_one_db_role() {
   # 'FATAL: role "postgres" is not permitted to log in', and peer authentication
   # needs LOGIN too — so the account you would use to undo it is the account it
   # locks out. Verified on 17 rather than assumed from the docs.
-  if [ "$(psql_as_postgres postgres \
-            "SELECT rolsuper FROM pg_roles WHERE rolname = '$prior'")" = t ]; then
-    if [ "$(role_owns_app_objects "$DB_NAME" "$prior")" = 0 ]; then
+  super="$(psql_as_postgres postgres \
+    "SELECT rolsuper FROM pg_roles WHERE rolname = '$prior'")" || return 1
+  if [ "$super" = t ]; then
+    owns="$(role_owns_app_objects "$DB_NAME" "$prior")" || return 1
+    if [ "$owns" = 0 ]; then
       log "left the superuser role '$prior' alone: it owns nothing in '$DB_NAME'," \
           "and taking LOGIN from the cluster superuser locks the host's operators" \
           "out of administering it"
@@ -1284,15 +1308,30 @@ reassign_one_db_role() {
         "See 'Changing DB_USER on a re-run' in docs/deploy_to_lightsail.md."
   fi
 
-  psql_as_postgres "$DB_NAME" "REASSIGN OWNED BY \"$prior\" TO \"$current\""
+  psql_as_postgres "$DB_NAME" "REASSIGN OWNED BY \"$prior\" TO \"$current\"" || {
+    log "WARNING: could not move ownership in '$DB_NAME' from '$prior' to" \
+        "'$current'. '$prior' still owns those objects and keeps LOGIN, and it" \
+        "stays queued for a later run. REASSIGN OWNED is one transaction, so" \
+        "nothing was moved by half."
+    return 1
+  }
   log "moved ownership of everything in '$DB_NAME' from '$prior' to '$current'"
-  psql_as_postgres postgres "ALTER ROLE \"$prior\" NOLOGIN"
+
+  # Checked separately from the REASSIGN, because by here ownership has already
+  # moved: staying queued retries a REASSIGN that is now a no-op and this
+  # statement, which is the one that did not take.
+  psql_as_postgres postgres "ALTER ROLE \"$prior\" NOLOGIN" || {
+    log "WARNING: ownership in '$DB_NAME' moved to '$current', but LOGIN could" \
+        "not be revoked from '$prior', which can still connect with the" \
+        "password it was given. It stays queued for a later run."
+    return 1
+  }
   log "revoked LOGIN from the replaced database role '$prior'"
 }
 
 reassign_prior_db_role() {
   local current="$1" prior_file="${2:-$STATE_DIR/db_user}"
-  local set_file="${3:-${prior_file%/*}/db_users}" prior kept=''
+  local set_file="${3:-${prior_file%/*}/db_users}" prior kept='' outstanding=0
 
   # Not a no-op on the ordinary path: this seeds the set on a host the earlier
   # revision provisioned, and puts $current in it on a first run, so that a
@@ -1314,17 +1353,33 @@ reassign_prior_db_role() {
       kept="$kept$prior"$'\n'
       continue
     fi
-    reassign_one_db_role "$prior" "$current" || kept="$kept$prior"$'\n'
+    reassign_one_db_role "$prior" "$current" || {
+      kept="$kept$prior"$'\n'
+      outstanding=1
+    }
   done < "$set_file"
 
-  # Rewritten only after the loop, so a REASSIGN that fails under `set -e` takes
-  # the run down with the queue intact and every member retried — the failure
-  # cannot quietly consume the entry it failed on.
+  # Rewritten only after the loop, from $kept — every role this run did not
+  # finish retiring. What stood here before was wrong, and wrong in the
+  # direction that mattered: it said a failed REASSIGN "takes the run down
+  # under `set -e`". It does not. The call above is on the left of `||`, which
+  # suppresses errexit inside the function for its whole body, so nothing takes
+  # the run down and the entry was consumed anyway. The propagation is explicit
+  # in reassign_one_db_role now, and it is what puts $prior back in $kept.
   write_state_file "$set_file" "$kept" ||
     log "WARNING: could not rewrite '$set_file'. Ownership was moved, but this" \
         "host still lists roles a later run will try to reassign again;" \
         "REASSIGN OWNED BY on a role that owns nothing is a no-op, so the retry" \
         "is harmless. Check that $STATE_DIR has space."
+
+  # Non-zero when a role is still outstanding, and reported after the queue has
+  # been written so the retry has something to read. The call site runs this
+  # bare under `set -e`, which is where the propagation has to end up: the run
+  # stops here rather than at the summary, so $STATE_DIR/db_user is not advanced
+  # and no DATABASE_URL is printed for a role that may own none of the tables.
+  # A WARNING would not do — what continues past it is a deployment against a
+  # role that gets "permission denied" on its own data.
+  [ "$outstanding" = 0 ]
 }
 
 # refuse_db_name_change <name> [state dir]

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -535,27 +535,23 @@ urlencode() {
   printf '%s' "$out"
 }
 
-# Keep a managed block in a config file equal to $content, keyed by a marker.
-# Added on the first run; on later runs the body is replaced in place, so a
-# FORCE=1 re-run with a changed DOCKER_SUBNETS or INSTANCE_HOSTNAME converges
-# the host instead of leaving the previous value in force. In place, not
-# delete-and-append: pg_hba.conf is first-match-wins, and moving the rule to
-# the end of the file could park it behind one that already rejects.
-ensure_block() {
-  local file="$1" marker="$2" content="$3"
-  local begin="# BEGIN collavre:$marker" end="# END collavre:$marker"
-
-  # Resolved before anything else, because the rewrite below installs by
-  # rename(2) and rename does not follow symlinks: pointed at a symlinked
-  # /etc/hosts it would replace the link with a regular file, and the next
-  # thing to read the real path would see the pre-managed contents. The
-  # append branch below and the previous `cat >` both wrote *through* the
-  # link, so resolving here is what keeps the two paths writing to the same
-  # file. `readlink -f` is not used: it is a GNU extension that only reached
-  # macOS recently, and this suite runs on both.
-  local hops=0
+# resolve_symlink_chain <path> — echo the real path a symlink chain ends at.
+#
+# Lifted out of ensure_block so that every install-by-rename in this script
+# resolves the same way. rename(2) does not follow symlinks and `cat > file`
+# does, so converting a copy to a rename without this replaces the *link* with a
+# regular file and leaves the real path — the one every other reader resolves to
+# — holding what it held before. That is a worse failure than the truncation the
+# rename is there to fix, because it is silent and permanent rather than loud
+# and one-run, and /etc/docker/daemon.json is exactly the kind of file config
+# management symlinks.
+#
+# Not `readlink -f`: a GNU extension that only reached macOS recently, and this
+# suite runs on both. Relative targets resolve against the link's own directory
+# rather than $PWD.
+resolve_symlink_chain() {
+  local file="$1" hops=0 target
   while [ -L "$file" ]; do
-    local target
     target="$(readlink "$file")" ||
       die "$file: is a symlink I cannot read. Repair or replace it by hand."
     case "$target" in
@@ -566,6 +562,77 @@ ensure_block() {
     [ "$hops" -lt 16 ] ||
       die "$file: symlink chain is too deep to follow. Repair it by hand."
   done
+  printf '%s\n' "$file"
+}
+
+# stage_beside <target> — echo the path of a staging file in the target's own
+# directory, already carrying the target's owner and mode.
+#
+# The caller writes its content into that path and renames it over the target,
+# so the live file is never the thing being written to. `> file` truncates when
+# the redirection opens, which makes the window the whole write rather than an
+# instant, and every caller of this that generates a file had that window.
+#
+# Same directory, not $TMPDIR: rename(2) needs one filesystem, and /etc and /tmp
+# are commonly separate mounts — across them `mv` degrades to copy-then-unlink,
+# which is the window again. Staging there also proves the space is available
+# before the live file is at risk.
+#
+# `cp -p` rather than chmod/chown --reference: --reference is a GNU extension
+# and this suite's cases run on macOS as well as the Ubuntu the script
+# provisions. Copying the target's identity rather than naming a mode is the
+# point — the callers span root:root 0644, postgres:postgres 0640 and
+# root:root 0755, and spelling any of them here would be a second spelling of
+# what the target already says, wrong the first time a caller points it at a
+# new file.
+#
+# The second argument is the mode to use when the target does not exist yet,
+# and it is not optional in spirit: mktemp creates 0600, which a bare
+# redirection under root's umask never would. Installing a first-run
+# 10-collavre.conf at 0600 root:root would leave PostgreSQL — which reads
+# /etc/postgresql/*/main/conf.d as the postgres user — unable to read the file
+# this script just wrote, so the fix for a truncated config would stop the
+# cluster outright. 0644 is what `cat >` produced and what the callers want.
+stage_beside() {
+  local target tmp mode="${2:-0644}"
+  target="$(resolve_symlink_chain "$1")" || return 1
+  tmp="$(mktemp "$target.collavre.XXXXXX")" || return 1
+  # A staging file that cannot be given the target's identity is not installed:
+  # proceeding at mktemp's 0600 would trade a converged file for a daemon that
+  # cannot read its own configuration.
+  if [ -e "$target" ]; then
+    if ! cp -p "$target" "$tmp" 2>/dev/null; then
+      rm -f "$tmp"
+      return 2
+    fi
+  elif ! chmod "$mode" "$tmp"; then
+    rm -f "$tmp"
+    return 2
+  fi
+  printf '%s\n' "$tmp"
+}
+
+# Keep a managed block in a config file equal to $content, keyed by a marker.
+# Added on the first run; on later runs the body is replaced in place, so a
+# FORCE=1 re-run with a changed DOCKER_SUBNETS or INSTANCE_HOSTNAME converges
+# the host instead of leaving the previous value in force. In place, not
+# delete-and-append: pg_hba.conf is first-match-wins, and moving the rule to
+# the end of the file could park it behind one that already rejects.
+ensure_block() {
+  local file="$1" marker="$2" content="$3"
+  local begin="# BEGIN collavre:$marker" end="# END collavre:$marker"
+
+  # Resolved before anything else, and not only for the rename below: the
+  # append branch writes *through* a link and the rewrite branch replaces it,
+  # so resolving here is what keeps the two branches writing to one file.
+  #
+  # `|| exit 1` is load-bearing. resolve_symlink_chain runs in a command
+  # substitution, and the die() inside it exits only that subshell — the
+  # message is printed, and this function would otherwise carry on with an
+  # empty $file and return 0, reporting a converged block over a path it
+  # refused to follow. Case 4b asserts the status, not just the message,
+  # because the message was right while the status was wrong.
+  file="$(resolve_symlink_chain "$file")" || exit 1
 
   if ! grep -qF "$begin" "$file" 2>/dev/null; then
     {
@@ -579,35 +646,17 @@ ensure_block() {
   grep -qF "$end" "$file" || \
     die "$file: '$begin' with no '$end'. Refusing to rewrite a block I cannot delimit — repair or delete it by hand."
 
-  local tmp
-  # Staged beside the target, not in $TMPDIR: same filesystem, so the swap
-  # below is one rename(2) and the staging has already proved the space is
-  # there. The mode and ownership are taken from the file being replaced and
-  # set before any content is written, so the staging file is never briefly
-  # readable by more than the live one already is.
-  #
-  # Copied from the target rather than hard-coded: this helper rewrites
-  # /etc/fstab and /etc/hosts (root:root 0644) as well as postgresql.conf and
-  # pg_hba.conf (postgres:postgres 0640), and naming either here would be a
-  # second spelling of what the target already says — one that goes wrong
-  # silently the first time a caller points this at a fourth file.
-  #
-  # `cp -p` rather than chmod/chown --reference: --reference is a GNU
-  # extension, and this suite's cases run on the maintainer's macOS as well as
-  # on the Ubuntu the script provisions. It copies the content too, which is
-  # redundant since awk overwrites it — these are files of a few KB, and the
-  # cost buys one spelling that works on both.
-  #
-  # A staging file that could not be given the target's identity is one that
-  # must not be installed: a pg_hba.conf PostgreSQL cannot read back stops the
-  # cluster, so this refuses rather than proceeding at mktemp's root-only 0600.
-  tmp="$(mktemp "$file.collavre.XXXXXX")" ||
-    die "$file: could not stage a rewrite beside it. Is $(dirname "$file") writable?"
-  if ! cp -p "$file" "$tmp" 2>/dev/null; then
-    rm -f "$tmp"
-    die "$file: could not give a staged rewrite the same owner and mode as the" \
-        "file it replaces, so it was NOT installed and $file is untouched."
-  fi
+  # Staged beside the target and carrying its identity — see stage_beside. Its
+  # two failures are reported separately, because the remedies differ: 1 is
+  # "nowhere to stage it" (disk, permissions), 2 is "cannot be given the
+  # target's owner and mode".
+  local tmp rc
+  tmp="$(stage_beside "$file")" || rc=$?
+  case "${rc:-0}" in
+    1) die "$file: could not stage a rewrite beside it. Is $(dirname "$file") writable?" ;;
+    2) die "$file: could not give a staged rewrite the same owner and mode as the" \
+           "file it replaces, so it was NOT installed and $file is untouched." ;;
+  esac
   # index() rather than an anchored match, so awk sees exactly the lines the
   # grep above found. END exits non-zero on an unterminated block (END marker
   # before BEGIN), which would otherwise swallow the rest of the file.
@@ -1082,6 +1131,10 @@ allocate_swapfile() {
 ensure_docker_log_caps() {
   local file="${1:-/etc/docker/daemon.json}" tmp driver
   DAEMON_JSON_CHANGED=0
+  # Before either branch, so the create path and the rewrite path name one file
+  # even when /etc/docker/daemon.json is a link — and so the rename below cannot
+  # replace the link itself.
+  file="$(resolve_symlink_chain "$file")" || exit 1
 
   if [ ! -f "$file" ]; then
     # Indented so no line of the body starts at column 1: the unit tests extract
@@ -1118,7 +1171,27 @@ JSON
     return 0
   fi
 
-  tmp="$(mktemp)"
+  # Staged beside the target rather than in $TMPDIR, and installed by rename.
+  # The validation below was already right and the install was not: `cat "$tmp"
+  # > "$file"` truncates the live daemon.json at open, so an interrupted copy
+  # leaves a prefix that jq never sees — the file that was checked is not the
+  # file that ends up installed. Measured on the shipped function with the copy
+  # failing partway, against an operator's daemon.json holding an
+  # insecure-registries entry:
+  #
+  #   live daemon.json  {"insecure-regist          parses: no
+  #
+  # And nothing notices: the caller only restarts Docker when this returns
+  # having changed the file, so the running daemon keeps the configuration it
+  # read at boot and the host looks healthy until something reboots it. Then
+  # dockerd will not start, and every `kamal deploy` fails against a host whose
+  # last successful run reported success.
+  tmp="$(stage_beside "$file")" || {
+    log "WARNING: could not stage a rewrite of $file beside it; it is unchanged" \
+        "and container logs are NOT capped. Add" \
+        '"log-opts": {"max-size": "10m", "max-file": "3"} by hand.'
+    return 0
+  }
   # Merge rather than replace: everything else in the file is the operator's.
   # Validated before it is installed, because a daemon.json that does not parse
   # stops Docker from starting at all.
@@ -1132,8 +1205,7 @@ JSON
         '"log-opts": {"max-size": "10m", "max-file": "3"} by hand.'
     return 0
   fi
-  cat "$tmp" > "$file"
-  rm -f "$tmp"
+  mv -f "$tmp" "$file"
   log "added container log caps to the existing $file"
   DAEMON_JSON_CHANGED=1
 }
@@ -1580,8 +1652,31 @@ refuse_db_name_change() {
   # provisioned by a revision that did not track it there is: db_user is the
   # marker that says this script has run here before.
   [ -f "$state_dir/db_user" ] || return 0
-  [ "$(psql_as_postgres postgres \
-        "SELECT count(*) FROM pg_database WHERE datname = '$current'")" = 0 ] || return 0
+  # The status is kept, for the reason role_owns_app_objects states and the
+  # superuser guard one commit ago had to be taught: this compares *output*, so
+  # a psql that could not answer produces an empty string, which is not "0" —
+  # and the `|| return 0` then reads "I could not ask" as "the database is
+  # already there". Measured against e16bd114 on a host recorded as provisioned,
+  # asked for a database that does not exist:
+  #
+  #   probe answers        REFUSES
+  #   probe cannot answer  PROCEEDS
+  #
+  # Proceeding is not a deferred refusal. This guard runs before the creation
+  # SQL, so a bypass on a run where PostgreSQL comes back a moment later creates
+  # the typo'd database empty, advances db_name and db_user to it, and points
+  # DATABASE_URL and the nightly pg_dump at it — while the app's data sits in
+  # the database nothing now names. That is precisely the outcome the refusal
+  # exists to make unreachable, and it is reached by way of the check.
+  local existing
+  existing="$(psql_as_postgres postgres \
+    "SELECT count(*) FROM pg_database WHERE datname = '$current'")" ||
+    die "this host has been provisioned before, but the cluster would not say" \
+        "whether DB_NAME='$current' exists on it — so this run cannot tell a" \
+        "first use of a new name from a typo that would be created empty beside" \
+        "the app's real data. Nothing has been changed. Check that PostgreSQL is" \
+        "accepting connections on port $DB_PORT, then re-run."
+  [ "$existing" = 0 ] || return 0
 
   # Previously provisioned, and the database this run names does not exist. That
   # is the change this function exists to stop, arriving on a host too old to
@@ -2461,7 +2556,34 @@ EFFECTIVE_CACHE_MB=$(( TOTAL_MB / 2 ))
 MAINTENANCE_MB=$(( TOTAL_MB / 16 ))
 [ "$MAINTENANCE_MB" -lt 64 ] && MAINTENANCE_MB=64
 
-cat > "$PG_CONF_DIR/conf.d/10-collavre.conf" <<CONF
+# Staged and renamed, not written through the live path. `>` truncates at open,
+# so an interrupted write leaves a prefix — and a prefix of a PostgreSQL config
+# is not a file that fails to load. Every truncation point of the generated
+# file, measured against PostgreSQL's own parser (`postgres -C listen_addresses`
+# on a scratch cluster with this file included):
+#
+#   275 truncation points   175 refuse to start (loud)
+#                            79 START, with listen_addresses = 'localhost'
+#                            21 start with the intended value
+#
+# Those 79 are the early ones — the comment line and the first directive — and
+# they are the quiet failure: the cluster is healthy, `systemctl status` is
+# green, and the docker bridge address this file exists to add is simply not
+# listened on. The app's containers then cannot reach the database at all, with
+# nothing on the host pointing at a truncated config. The run does not even
+# reach the restart that would surface it, so the damage waits for a reboot.
+PG_CONF_FILE="$PG_CONF_DIR/conf.d/10-collavre.conf"
+PG_CONF_TMP="$(stage_beside "$PG_CONF_FILE")" ||
+  die "could not stage $PG_CONF_FILE beside itself. PostgreSQL's configuration" \
+      "is unchanged. Check that $PG_CONF_DIR/conf.d is writable and has space," \
+      "then re-run."
+# `if ! cat` rather than leaning on the `set -euo pipefail` at the top of this
+# file: errexit does cover a bare top-level command, so this is not a live hole
+# — but a `|| something` appended to this line later would suppress it silently,
+# and what would then be installed is the prefix this exists to keep off the
+# live path. The staging file goes with it, so a retry starts from the state a
+# kill leaves: PostgreSQL's configuration untouched.
+if ! cat > "$PG_CONF_TMP" <<CONF
 # Managed by script/lightsail_launch.sh — edit here, not in postgresql.conf.
 listen_addresses = 'localhost,$DB_BIND_ADDRESS'
 password_encryption = scram-sha-256
@@ -2481,6 +2603,14 @@ log_min_duration_statement = 1000
 log_line_prefix = '%m [%p] %q%u@%d '
 timezone = '$TIMEZONE'
 CONF
+then
+  rm -f "$PG_CONF_TMP"
+  die "could not write PostgreSQL's generated configuration — is" \
+      "$PG_CONF_DIR/conf.d full? $PG_CONF_FILE is left as it was and the" \
+      "cluster is untouched."
+fi
+PG_CONF_REAL="$(resolve_symlink_chain "$PG_CONF_FILE")" || exit 1
+mv -f "$PG_CONF_TMP" "$PG_CONF_REAL"
 
 # Containers authenticate with a password over the docker bridge.
 ensure_block "$PG_CONF_DIR/pg_hba.conf" docker \

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -1243,10 +1243,10 @@ write_state_file() {
 }
 
 # A failed atomic replacement is recoverable only when the file it left behind
-# can still answer every setting. An absent or short record is not a previous
-# configuration: refuse the success marker rather than let the next bare
-# FORCE=1 run silently reset an override that has no other state file, such as
-# BACKUP_S3_URI.
+# can still answer every setting with the values this run applied. An absent,
+# short or stale record is not this configuration: refuse the success marker
+# rather than let the next bare FORCE=1 run silently reset an override that has
+# no other state file, such as BACKUP_S3_URI.
 launch_record_is_complete() {
   local env_file="$1" name count
   [ -f "$env_file" ] || return 1
@@ -1265,10 +1265,16 @@ record_launch_settings() {
     return 0
   fi
   if launch_record_is_complete "$state_dir/launch.env"; then
-    log "WARNING: could not replace this run's settings in $state_dir/launch.env;" \
-	"the complete previous record is intact, so the next run still compares" \
-	"against it — repeat this run's overrides on that run too"
-    return 0
+    if cmp -s <(printf '%s\n' "$record") "$state_dir/launch.env"; then
+      log "WARNING: could not replace this run's settings in $state_dir/launch.env;" \
+	  "the matching previous record is intact, so the next run still compares" \
+	  "against it"
+      return 0
+    fi
+    die "could not replace this run's settings in $state_dir/launch.env, and" \
+	"the complete previous record does not match this run. Refusing to" \
+	"create the success marker: a later bare FORCE=1 run would otherwise" \
+	"restore settings this run changed."
   fi
   die "could not record this run's settings in $state_dir/launch.env, and no" \
       "complete previous record remains. Refusing to create the success marker:" \
@@ -2915,23 +2921,74 @@ passwd_home() {
 
 # ssh_key_holder <key> [passwd table]
 #
-# The first account whose authorized_keys contains this key byte-for-byte, or
-# nothing. This is the only surviving evidence of who a key belongs to, which
-# is what the caller below needs and does not otherwise have.
+# Every account whose authorized_keys contains this key byte-for-byte, one per
+# line, or nothing. This is the only surviving evidence of which accounts a
+# legacy host-wide marker belongs to, which the caller below needs and does not
+# otherwise have.
 ssh_key_holder() {
-  local key="$1" src="${2:-}" user home tbl rc=1
-  tbl="$(mktemp)"
-  if [ -n "$src" ]; then cat "$src" > "$tbl"; else getent passwd > "$tbl"; fi
+  local key="$1" src="${2:-}" user home tbl rc=1 grep_rc
+  tbl="$(mktemp)" || return 2
+  if [ -n "$src" ]; then
+    if ! cat "$src" > "$tbl"; then rm -f "$tbl"; return 2; fi
+  else
+    if ! getent passwd > "$tbl"; then rm -f "$tbl"; return 2; fi
+  fi
   while IFS=: read -r user _ _ _ _ home _; do
     [ -n "$home" ] && [ -f "$home/.ssh/authorized_keys" ] || continue
     if grep -qxF "$key" "$home/.ssh/authorized_keys" 2>/dev/null; then
       printf '%s\n' "$user"
       rc=0
-      break
+    else
+      grep_rc=$?
+      [ "$grep_rc" -eq 1 ] || { rm -f "$tbl"; return 2; }
     fi
   done < "$tbl"
   rm -f "$tbl"
   return "$rc"
+}
+
+# record_ssh_key_grant <key> [set file] [legacy single marker]
+#
+# The third instance of the same separation, after deploy_users and db_users:
+# ssh_public_key.<user> is the key this host is *currently* deployed with, and
+# this file is the set of managed keys no run has confirmed withdrawn. One
+# marker cannot be both, and the A -> B -> C sequence is where it shows.
+#
+# install_authorized_keys appends the successor and revoke_prior_ssh_key
+# advances the marker afterwards, so a run that dies between them leaves B in
+# authorized_keys with the marker still naming A. A later run rotating to C
+# withdraws A — the only key the marker knows — records C, and B stays
+# authorized with nothing on the host naming it. Measured against 07365195:
+#
+#   control  A -> B -> C                       keys=[C]    marker=C
+#   run2 interrupted before the marker write:
+#            A -> B(interrupted) -> C          keys=[B C]  marker=C
+#
+# B is not a stale entry in a file: this account holds passwordless sudo and the
+# docker socket, so an untracked key on it is permanent root on the host, and it
+# is untracked precisely because the rotation that was supposed to retire it is
+# the thing that lost the record.
+#
+# Called before the key is appended, not after — the same ordering as
+# record_deploy_user_grant, and for the same reason: a key in this file that
+# turns out not to be in authorized_keys costs one grep, and a key missing from
+# it is root access nobody is looking for.
+record_ssh_key_grant() {
+  local key="$1" set_file="${2:-$STATE_DIR/ssh_public_keys.$APP_SSH_USER}"
+  local prior_file="${3:-$STATE_DIR/ssh_public_key.$APP_SSH_USER}"
+  [ -n "$key" ] || return 0
+  # Upgrade path, guarded on `! -f` so it runs once per host: seed from the
+  # single marker the earlier revision kept, which names the predecessor most
+  # likely to still be authorized. A failed seed leaves the file absent — the
+  # state a retry starts from — rather than empty and authoritative.
+  if [ ! -f "$set_file" ] && [ -s "$prior_file" ]; then
+    local seed
+    seed="$(grep -v '^[[:space:]]*$' "$prior_file")" || seed=''
+    if [ -n "$seed" ]; then
+      write_state_file "$set_file" "$seed"$'\n' || return 1
+    fi
+  fi
+  append_state_line "$set_file" "$key"
 }
 
 # adopt_legacy_ssh_key_marker <user> [state dir] [passwd table]
@@ -2961,10 +3018,10 @@ ssh_key_holder() {
 # between an old key sitting in a file and an old key holding root.
 adopt_legacy_ssh_key_marker() {
   local user="$1" state_dir="${2:-$STATE_DIR}" src="${3:-}"
-  local legacy mine key owner home auth_keys=""
+  local legacy key owners owner first_owner home auth_keys="" set_file marker
+  local holder_status=0
   legacy="$state_dir/ssh_public_key"
-  mine="$state_dir/ssh_public_key.$user"
-  [ -f "$legacy" ] && [ ! -f "$mine" ] || return 0
+  [ -f "$legacy" ] || return 0
 
   key="$(cat "$legacy")"
   # A marker with nothing in it names no key and can strand the branch forever.
@@ -2973,20 +3030,18 @@ adopt_legacy_ssh_key_marker() {
   home="$(passwd_home "$user" "$src")"
   [ -z "$home" ] || auth_keys="$home/.ssh/authorized_keys"
 
-  # Verifiably this account's — the ordinary upgrade, and the case the adoption
-  # exists for. Checked directly rather than through the search below so the
-  # common path does not depend on reading every account on the host.
-  if [ -n "$auth_keys" ] && grep -qxF "$key" "$auth_keys" 2>/dev/null; then
-    mv "$legacy" "$mine"
-    return 0
+  owners="$(ssh_key_holder "$key" "$src")" || holder_status=$?
+  if [ "$holder_status" -gt 1 ]; then
+    die "could not inspect every account for the SSH key recorded in $legacy." \
+	"The host-wide marker is intact and no key was re-filed. Check that the" \
+	"account database and authorized_keys files are readable, then re-run."
   fi
-
-  owner="$(ssh_key_holder "$key" "$src")" || owner=""
+  [ "$holder_status" -eq 0 ] || owners=""
 
   # Authorized for nobody: the key it names is already gone, so the record
   # describes nothing and assigning it to an account would invent a predecessor
   # that no longer exists.
-  if [ -z "$owner" ]; then
+  if [ -z "$owners" ]; then
     rm -f "$legacy"
     log "the SSH key recorded by an earlier revision is no longer authorized for" \
         "any account on this host, so the record was dropped rather than filed" \
@@ -2994,35 +3049,59 @@ adopt_legacy_ssh_key_marker() {
     return 0
   fi
 
-  # Verifiably another account's. File it there, so that account's own key stays
-  # withdrawable by a later run naming it.
-  #
-  # An account with no keys of its own cannot be hiding a managed one, so there
-  # is nothing to stop the run for; this is also the first-run-creates-the-user
-  # path, where the account does not exist yet.
-  if [ -z "$auth_keys" ] || [ ! -s "$auth_keys" ]; then
-    mv "$legacy" "$state_dir/ssh_public_key.$owner"
-    log "the SSH key recorded by an earlier revision belongs to '$owner', not to" \
-        "'$user'; filed it against '$owner'"
-    return 0
+  # If this account does not hold the recorded key but does hold other keys, an
+  # earlier rotation may have installed one of them and then advanced the sole
+  # host-wide marker to another account. Nothing can identify that predecessor,
+  # so stop before recording or granting anything unless the operator accepts
+  # responsibility for those unattributed keys.
+  if ! grep -qxF -- "$user" <<<"$owners" &&
+     [ -n "$auth_keys" ] && [ -s "$auth_keys" ] &&
+     [ -z "${ACK_UNATTRIBUTED_SSH_KEYS:-}" ]; then
+    first_owner="${owners%%$'\n'*}"
+    die "this host rotated deploy accounts under an earlier revision of this" \
+	"script: the key it recorded is authorized for '$first_owner', not for" \
+	"'$user', which this run names. That revision kept only one record per" \
+	"host, so if it ever installed a key for '$user' there is nothing left" \
+	"that says which of the keys in $auth_keys it was — and this run is" \
+	"about to give '$user' passwordless sudo and the docker socket again." \
+	"Nothing has been changed. Read $auth_keys, remove any key you do not" \
+	"recognise, then re-run with ACK_UNATTRIBUTED_SSH_KEYS=1 to continue."
   fi
 
-  if [ -n "${ACK_UNATTRIBUTED_SSH_KEYS:-}" ]; then
-    mv "$legacy" "$state_dir/ssh_public_key.$owner"
-    log "ACK_UNATTRIBUTED_SSH_KEYS is set: filed the earlier revision's record" \
-        "against '$owner', and proceeding with '$user' unchecked — the keys in" \
-        "$auth_keys are the operator's responsibility"
-    return 0
-  fi
+  # The old marker was host-wide, so the same managed key may have been copied
+  # into more than one deploy account. Queue it for every exact holder before
+  # deleting the sole record; otherwise whichever account was not chosen can be
+  # re-armed by a later APP_SSH_USER rotation with an untracked root key.
+  while IFS= read -r owner; do
+    [ -n "$owner" ] || continue
+    set_file="$state_dir/ssh_public_keys.$owner"
+    marker="$state_dir/ssh_public_key.$owner"
+    record_ssh_key_grant "$key" "$set_file" "$marker" ||
+      die "could not record the legacy SSH key for '$owner' in $set_file." \
+	  "The host-wide marker is intact; check that $state_dir is writable" \
+	  "and has space, then re-run."
+    if [ ! -f "$marker" ]; then
+      write_state_file "$marker" "$key"$'\n' ||
+	die "could not create the per-account SSH key marker $marker." \
+	    "The withdrawal queue and host-wide marker are intact; check that" \
+	    "$state_dir is writable and has space, then re-run."
+    fi
+  done <<<"$owners"
+  rm -f "$legacy"
 
-  die "this host rotated deploy accounts under an earlier revision of this" \
-      "script: the key it recorded is authorized for '$owner', not for" \
-      "'$user', which this run names. That revision kept only one record per" \
-      "host, so if it ever installed a key for '$user' there is nothing left" \
-      "that says which of the keys in $auth_keys it was — and this run is" \
-      "about to give '$user' passwordless sudo and the docker socket again." \
-      "Nothing has been changed. Read $auth_keys, remove any key you do not" \
-      "recognise, then re-run with ACK_UNATTRIBUTED_SSH_KEYS=1 to continue."
+  if ! grep -qxF -- "$user" <<<"$owners"; then
+    first_owner="${owners%%$'\n'*}"
+    if [ -n "${ACK_UNATTRIBUTED_SSH_KEYS:-}" ]; then
+      log "ACK_UNATTRIBUTED_SSH_KEYS is set: filed the earlier revision's record" \
+	  "against every account that holds it, including '$first_owner', and" \
+	  "proceeding with '$user' unchecked — the keys in $auth_keys are the" \
+	  "operator's responsibility"
+    else
+      log "the SSH key recorded by an earlier revision belongs to" \
+	  "'$first_owner', not to '$user'; filed it against every account that" \
+	  "holds it"
+    fi
+  fi
 }
 
 adopt_legacy_ssh_key_marker "$APP_SSH_USER"
@@ -3335,50 +3414,6 @@ install_staged_authorized_keys() {
   fi
   chmod 0600 "$tmp"
   mv -f "$tmp" "$auth_keys"
-}
-
-# record_ssh_key_grant <key> [set file] [legacy single marker]
-#
-# The third instance of the same separation, after deploy_users and db_users:
-# ssh_public_key.<user> is the key this host is *currently* deployed with, and
-# this file is the set of managed keys no run has confirmed withdrawn. One
-# marker cannot be both, and the A -> B -> C sequence is where it shows.
-#
-# install_authorized_keys appends the successor and revoke_prior_ssh_key
-# advances the marker afterwards, so a run that dies between them leaves B in
-# authorized_keys with the marker still naming A. A later run rotating to C
-# withdraws A — the only key the marker knows — records C, and B stays
-# authorized with nothing on the host naming it. Measured against 07365195:
-#
-#   control  A -> B -> C                       keys=[C]    marker=C
-#   run2 interrupted before the marker write:
-#            A -> B(interrupted) -> C          keys=[B C]  marker=C
-#
-# B is not a stale entry in a file: this account holds passwordless sudo and the
-# docker socket, so an untracked key on it is permanent root on the host, and it
-# is untracked precisely because the rotation that was supposed to retire it is
-# the thing that lost the record.
-#
-# Called before the key is appended, not after — the same ordering as
-# record_deploy_user_grant, and for the same reason: a key in this file that
-# turns out not to be in authorized_keys costs one grep, and a key missing from
-# it is root access nobody is looking for.
-record_ssh_key_grant() {
-  local key="$1" set_file="${2:-$STATE_DIR/ssh_public_keys.$APP_SSH_USER}"
-  local prior_file="${3:-$STATE_DIR/ssh_public_key.$APP_SSH_USER}"
-  [ -n "$key" ] || return 0
-  # Upgrade path, guarded on `! -f` so it runs once per host: seed from the
-  # single marker the earlier revision kept, which names the predecessor most
-  # likely to still be authorized. A failed seed leaves the file absent — the
-  # state a retry starts from — rather than empty and authoritative.
-  if [ ! -f "$set_file" ] && [ -s "$prior_file" ]; then
-    local seed
-    seed="$(grep -v '^[[:space:]]*$' "$prior_file")" || seed=''
-    if [ -n "$seed" ]; then
-      write_state_file "$set_file" "$seed"$'\n' || return 1
-    fi
-  fi
-  append_state_line "$set_file" "$key"
 }
 
 revoke_prior_ssh_key() {

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -957,6 +957,33 @@ stage_beside() {
   printf '%s\n' "$tmp"
 }
 
+# restore_postgresql_bind_config <live file> <backup> <had prior: 0|1>
+#
+# Put back the managed listen-address file after a replacement cannot be
+# reached. The backup is a sibling made by stage_beside; each rollback stages
+# from it and renames that copy over the live path, atomically restoring the
+# prior owner and mode while retaining the backup until restart succeeds. On a
+# first run there was no file to restore; removing the new one returns
+# PostgreSQL to the stock localhost-only setting. Restarting is part of the
+# rollback: merely restoring the bytes would leave the postmaster running
+# whichever config the failed restart loaded.
+restore_postgresql_bind_config() {
+  local live_file="$1" backup="$2" had_prior="$3" restore_tmp
+  if [ "$had_prior" -eq 1 ]; then
+    [ -f "$backup" ] || return 1
+    restore_tmp="$(stage_beside "$live_file")" || return 1
+    if ! cp -p "$backup" "$restore_tmp" 2>/dev/null ||
+       ! mv -f "$restore_tmp" "$live_file"; then
+      rm -f "$restore_tmp"
+      return 1
+    fi
+  else
+    rm -f "$live_file" || return 1
+  fi
+  systemctl restart postgresql || return 2
+  [ -z "$backup" ] || rm -f "$backup"
+}
+
 # install_managed_config <label> <target> <line>...
 #
 # Write a whole config file this script owns: every line is put in a staging
@@ -3771,10 +3798,22 @@ MAINTENANCE_MB=$(( TOTAL_MB / 16 ))
 # nothing on the host pointing at a truncated config. The run does not even
 # reach the restart that would surface it, so the damage waits for a reboot.
 PG_CONF_FILE="$PG_CONF_DIR/conf.d/10-collavre.conf"
-PG_CONF_TMP="$(stage_beside "$PG_CONF_FILE")" ||
+PG_CONF_REAL="$(resolve_symlink_chain "$PG_CONF_FILE")" || exit 1
+PG_CONF_TMP="$(stage_beside "$PG_CONF_REAL")" ||
   die "could not stage $PG_CONF_FILE beside itself. PostgreSQL's configuration" \
       "is unchanged. Check that $PG_CONF_DIR/conf.d is writable and has space," \
       "then re-run."
+PG_CONF_HAD_PRIOR=0
+PG_CONF_BACKUP=''
+if [ -e "$PG_CONF_REAL" ]; then
+  PG_CONF_HAD_PRIOR=1
+  PG_CONF_BACKUP="$(stage_beside "$PG_CONF_REAL")" || {
+    rm -f "$PG_CONF_TMP"
+    die "could not preserve the existing $PG_CONF_FILE before replacing it." \
+	"PostgreSQL's configuration is unchanged. Check that" \
+	"$PG_CONF_DIR/conf.d is writable and has space, then re-run."
+  }
+fi
 # `if ! cat` rather than leaning on the `set -euo pipefail` at the top of this
 # file: errexit does cover a bare top-level command, so this is not a live hole
 # — but a `|| something` appended to this line later would suppress it silently,
@@ -3803,11 +3842,32 @@ timezone = '$TIMEZONE'
 CONF
 then
   rm -f "$PG_CONF_TMP"
+  [ -z "$PG_CONF_BACKUP" ] || rm -f "$PG_CONF_BACKUP"
   die "could not write PostgreSQL's generated configuration — is" \
       "$PG_CONF_DIR/conf.d full? $PG_CONF_FILE is left as it was and the" \
       "cluster is untouched."
 fi
-PG_CONF_REAL="$(resolve_symlink_chain "$PG_CONF_FILE")" || exit 1
+
+# Keep the previous config armed for every exit between replacement and the
+# reachability proof. This includes an interrupted run and a failed restart,
+# not only the explicit pg_isready branch below.
+PG_CONF_ROLLBACK_ARMED=1
+trap 'rc=$?
+  if [ "${PG_CONF_ROLLBACK_ARMED:-0}" -eq 1 ]; then
+    if restore_postgresql_bind_config "$PG_CONF_REAL" "$PG_CONF_BACKUP" "$PG_CONF_HAD_PRIOR"; then
+      log "restored the previous PostgreSQL bind configuration after the run stopped"
+    else
+      rollback_rc=$?
+      if [ "$rollback_rc" -eq 2 ]; then
+	log "CRITICAL: the previous PostgreSQL bind configuration was restored after the run stopped, but PostgreSQL did not restart on it. Run systemctl restart postgresql immediately."
+      else
+	log "CRITICAL: the run stopped after replacing $PG_CONF_FILE, and restoring the previous configuration failed. Restore $PG_CONF_BACKUP over $PG_CONF_REAL and restart PostgreSQL immediately."
+      fi
+    fi
+  fi
+  exit "$rc"' EXIT
+trap 'exit 1' HUP INT TERM
+
 mv -f "$PG_CONF_TMP" "$PG_CONF_REAL"
 
 # Containers authenticate with a password over the docker bridge.
@@ -3835,16 +3895,34 @@ systemctl restart postgresql
 # first thing to discover it is wrong would be the first deploy. pg_isready
 # needs no credentials and a pg_hba refusal still counts as a response, so this
 # asks about reachability and nothing else.
-pg_isready -h "$DB_BIND_ADDRESS" -p "$DB_PORT" -t 10 >/dev/null 2>&1 ||
-  die "PostgreSQL restarted, but it is not listening on DB_BIND_ADDRESS=" \
-      "$DB_BIND_ADDRESS:$DB_PORT. The cluster is up — it fell back to" \
-      "localhost, which it does with only a WARNING when an address cannot be" \
-      "bound, so nothing else on this host would have said so. Left to run," \
-      "the summary would print a DATABASE_URL over that address and no" \
-      "container could open it. Check the bridge with 'ip -4 addr show" \
-      "docker0' and set DB_BIND_ADDRESS to its address (the default," \
-      "172.17.0.1, is the usual one), then re-run with FORCE=1. The" \
-      "configuration this run installed is in $PG_CONF_DIR/conf.d/10-collavre.conf."
+if ! pg_isready -h "$DB_BIND_ADDRESS" -p "$DB_PORT" -t 10 >/dev/null 2>&1; then
+  PG_CONF_ROLLBACK_RC=0
+  restore_postgresql_bind_config \
+    "$PG_CONF_REAL" "$PG_CONF_BACKUP" "$PG_CONF_HAD_PRIOR" ||
+    PG_CONF_ROLLBACK_RC=$?
+  PG_CONF_ROLLBACK_ARMED=0
+  trap - EXIT HUP INT TERM
+  if [ "$PG_CONF_ROLLBACK_RC" -eq 0 ]; then
+    die "PostgreSQL restarted, but it did not listen on DB_BIND_ADDRESS=" \
+	"$DB_BIND_ADDRESS:$DB_PORT, so the previous bind configuration was" \
+	"restored and PostgreSQL was restarted on it. Check the bridge with" \
+	"'ip -4 addr show docker0' and set DB_BIND_ADDRESS to its address (the" \
+	"default, 172.17.0.1, is the usual one), then re-run with FORCE=1."
+  fi
+  if [ "$PG_CONF_ROLLBACK_RC" -eq 2 ]; then
+    die "PostgreSQL did not listen on DB_BIND_ADDRESS=$DB_BIND_ADDRESS:$DB_PORT." \
+	"The previous bind configuration was restored, but PostgreSQL did not" \
+	"restart on it. Run 'systemctl restart postgresql' immediately, then" \
+	"correct DB_BIND_ADDRESS and re-run with FORCE=1."
+  fi
+  die "PostgreSQL did not listen on DB_BIND_ADDRESS=$DB_BIND_ADDRESS:$DB_PORT," \
+      "and the previous bind configuration could not be restored automatically." \
+      "Restore '$PG_CONF_BACKUP' over '$PG_CONF_REAL' and run" \
+      "'systemctl restart postgresql' immediately."
+fi
+PG_CONF_ROLLBACK_ARMED=0
+trap - EXIT HUP INT TERM
+[ -z "$PG_CONF_BACKUP" ] || rm -f "$PG_CONF_BACKUP"
 
 # --------------------------------------------------------------------------
 log "6/9 database '$DB_NAME' and role '$DB_USER'"
@@ -3883,8 +3961,25 @@ refuse_db_name_change "$DB_NAME"
 # here must not have written anything to $STATE_DIR either.
 refuse_superuser_db_rotation "$DB_USER"
 
+DB_PASSWORD_PENDING_FILE="$STATE_DIR/db_password.pending.$DB_USER"
+[ ! -d "$STATE_DIR/db_password" ] ||
+  die "$STATE_DIR/db_password is a directory, so the applied password record" \
+      "cannot be replaced atomically. PostgreSQL is unchanged. Move that" \
+      "directory aside and re-run."
 if [ -z "$DB_PASSWORD" ]; then
-  if [ -f "$STATE_DIR/db_password" ]; then
+  if [ -f "$DB_PASSWORD_PENDING_FILE" ]; then
+    # A previous run may have committed ALTER ROLE and stopped before promoting
+    # the credential record. Reusing the role-specific pending value makes both
+    # sides converge whichever side of that commit the interruption reached.
+    chmod 0600 "$DB_PASSWORD_PENDING_FILE"
+    DB_PASSWORD="$(cat "$DB_PASSWORD_PENDING_FILE")"
+    if [ -z "$DB_PASSWORD" ]; then
+      die "$DB_PASSWORD_PENDING_FILE exists but is empty, so this host cannot" \
+	  "recover the interrupted password update for DB_USER='$DB_USER'." \
+	  "Supply DB_PASSWORD explicitly to replace the pending attempt."
+    fi
+    log "resuming the pending database password update for '$DB_USER'"
+  elif [ -f "$STATE_DIR/db_password" ]; then
     # Re-run: keep the password already handed out in DATABASE_URL.
     DB_PASSWORD="$(cat "$STATE_DIR/db_password")"
     # An empty marker is not "no password", it is a password this host can no
@@ -3911,24 +4006,21 @@ if [ -z "$DB_PASSWORD" ]; then
     log "generated a random database password"
   fi
 fi
-# 0600 from the moment the file exists, and replaced in one step. The mode is
-# not the chmod's doing: mktemp creates 0600, and the chmod inside
-# write_state_file runs before the content is written — where a bare redirection
-# creates the file 0644 under the default umask and only narrows it a command
-# later, leaving the production password world-readable in a 0755 directory for
-# that window, or permanently if the run died in between.
-#
-# The rename is the other half. `> file` truncates when the redirection opens,
-# so a write that fails after that — a full disk, an interrupted run — leaves
-# this marker existing and empty, and the read above cannot tell that from a
-# host with no password recorded. It is the only durable record of the
-# credential the app is deployed with. The chmod stays a step below to converge
-# a file an earlier revision left 0644.
-write_state_file "$STATE_DIR/db_password" "$DB_PASSWORD" 0600 ||
-  die "could not record the database password in $STATE_DIR/db_password." \
-      "Nothing has been changed — the role still has the password the previous" \
-      "run gave it, and that file still holds it. Free some disk and re-run."
-chmod 0600 "$STATE_DIR/db_password"
+if [ -f "$STATE_DIR/db_password" ]; then
+  chmod 0600 "$STATE_DIR/db_password"
+fi
+
+# Stage the credential under the role it belongs to, but keep the live record
+# untouched until psql has applied it. The role name in the path is safe because
+# refuse_unusable_db_identifier has already limited DB_USER to [A-Za-z0-9_-].
+# Role-specific pending state matters when a run changing both DB_USER and
+# DB_PASSWORD is interrupted: a later run naming another role must not apply
+# this password to that role merely because it found one unqualified pending
+# file.
+write_state_file "$DB_PASSWORD_PENDING_FILE" "$DB_PASSWORD" 0600 ||
+  die "could not stage the database password in $DB_PASSWORD_PENDING_FILE." \
+      "The live password record and PostgreSQL role are unchanged. Check that" \
+      "$STATE_DIR is writable and has space, then re-run."
 
 # Mirrors db/setup_postgres_databases.sql: create-if-missing, never drop.
 # Collavre keeps primary/cache/queue/cable in ONE database — the Solid Queue,
@@ -3940,8 +4032,10 @@ chmod 0600 "$STATE_DIR/db_password"
 # with nothing on the host naming it.
 record_db_role_grant "$DB_USER" ||
   die "could not record '$DB_USER' in $STATE_DIR/db_users, so this run cannot" \
-      "promise that a later one could find the role again. Nothing has been" \
-      "changed. Check that $STATE_DIR is writable and has space, then re-run."
+      "promise that a later one could find the role again. PostgreSQL and the" \
+      "live password record are unchanged; the attempted password remains in" \
+      "$DB_PASSWORD_PENDING_FILE. Check that $STATE_DIR is writable and has" \
+      "space, then re-run with the same DB_USER and no DB_PASSWORD."
 
 SQL_FILE="$(mktemp /tmp/collavre-db.XXXXXX.sql)"
 trap 'rm -f "$SQL_FILE"' EXIT
@@ -3956,8 +4050,9 @@ trap 'rm -f "$SQL_FILE"' EXIT
 # Two reasons to spell it this way regardless. The line escapes a credential
 # into a SQL literal, and it should not be one whose meaning is decided by the
 # interpreter version — on 3.2 psql reads the `\'` as a meta-command and stops
-# with "invalid command", after write_state_file above has already recorded the
-# password, leaving a host that records a credential its role does not have.
+# with "invalid command". The pending record above now makes that failure
+# recoverable without advancing the live credential, but it must still be
+# escaped consistently so a retry does not stop at the same statement forever.
 #
 # And it is what lets the suite assert this at all. Case 141 generates with a
 # quoted password and checks the statement; against the previous form that
@@ -4017,6 +4112,21 @@ write_state_file "$STATE_DIR/db_user" "$DB_USER"$'\n' ||
       "database exist and this run has not handed out a DATABASE_URL yet, so" \
       "re-running with the same DB_USER is safe. Check that $STATE_DIR is" \
       "writable and has space."
+
+# psql may commit ALTER ROLE and then fail on a later statement, so the pending
+# file remains the recovery record on every non-zero exit above. Promotion also
+# waits for ownership reassignment and db_user: the global password record and
+# the global role marker must advance as one logical commit. Otherwise a failed
+# A -> B rotation followed by the documented rollback to A would read B's new
+# password from the global file and apply it to A, breaking A's deployed URL.
+# The rename is within $STATE_DIR and therefore atomic.
+mv -f "$DB_PASSWORD_PENDING_FILE" "$STATE_DIR/db_password" ||
+  die "DB_USER='$DB_USER' is recorded and PostgreSQL accepted its password, but" \
+      "the pending credential could not be promoted to" \
+      "$STATE_DIR/db_password. The new value is still in" \
+      "$DB_PASSWORD_PENDING_FILE; re-run with the same DB_USER and no" \
+      "DB_PASSWORD to recover it before redeploying."
+
 # Recorded only once the database it names actually exists, so an interrupted
 # run cannot leave a marker for a database that was never created.
 write_state_file "$STATE_DIR/db_name" "$DB_NAME"$'\n' ||

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -326,6 +326,113 @@ refuse_unusable_db_identifier() {
       "docs/deploy_to_lightsail.md — then re-run with the new name."
 }
 
+# ipv4_dotted_quad <value>
+#
+# Four decimal octets, 0-255, no leading zeros — `010` is 8 to inet_pton and 10
+# to a reader, and this value is spelled into three files that do not have to
+# agree about which. Written with case and arithmetic rather than a regex
+# because [[ =~ ]] does not mean the same thing under the bash macOS ships as
+# under the bash Lightsail runs, and this suite is run under both.
+ipv4_dotted_quad() {
+  local LC_ALL=C rest="$1" octet count=0
+  while [ "$count" -lt 4 ]; do
+    if [ "$count" -lt 3 ]; then
+      case "$rest" in
+        *.*) octet="${rest%%.*}"; rest="${rest#*.}" ;;
+        *) return 1 ;;
+      esac
+    else
+      octet="$rest"; rest=''
+    fi
+    case "$octet" in
+      0|[1-9]|[1-9][0-9]|[1-9][0-9][0-9]) ;;
+      *) return 1 ;;
+    esac
+    [ "$octet" -le 255 ] || return 1
+    count=$((count + 1))
+  done
+  [ -z "$rest" ]
+}
+
+# refuse_unusable_bind_address <setting name> <value>
+# refuse_unusable_subnet <setting name> <value>
+#
+# DB_BIND_ADDRESS and DOCKER_SUBNETS are spliced into generated PostgreSQL
+# configuration — listen_addresses and a pg_hba.conf line — and into a ufw rule
+# and DATABASE_URL. Neither was checked, and the generated files are installed
+# by rename and then `systemctl restart postgresql`. Measured on a real cluster
+# with `include_dir = 'conf.d'` and this script's own generated file:
+#
+#   DB_BIND_ADDRESS          postgres -C   the cluster after a restart
+#   172.17.0.1               rc=0          UP, listening on the bridge
+#   172.17.0.999             rc=0          UP, WARNING, listening on localhost
+#   bogus.invalid            rc=0          UP, WARNING, listening on localhost
+#   1.2.3.4                  rc=0          UP, WARNING, listening on localhost
+#   not a host               rc=0          DOWN, FATAL: invalid list syntax
+#
+#   DOCKER_SUBNETS           the cluster after a restart
+#   172.16.0.0/12            UP, the rule matches
+#   not-a-subnet             UP, read as a host name, the rule never matches
+#   172.16.0.0/99            DOWN, FATAL: invalid CIDR mask in address
+#   "172.16.0.0/12 all trust"  DOWN, FATAL: invalid authentication method "all"
+#
+# Two bands, and the loud one is not the dangerous one. A value that breaks the
+# *syntax* stops the cluster on a FORCE=1 convergence — the live database goes
+# down and does not come back, which is the failure the reviewer describes and
+# it is at least visible. A value that is merely wrong starts perfectly: the
+# cluster is healthy, `systemctl status` is green, and it is listening on
+# localhost alone, or carrying a pg_hba rule that matches nothing. The app's
+# containers cannot reach the database and nothing on the host says why — the
+# same quiet ending as a truncated config, arrived at from a live value.
+#
+# Checked here rather than by validating the staged file, which is what the
+# finding asks for and does not close it. `postgres -C listen_addresses` exits
+# 0 on every row above, including the one that will not start: the list is
+# parsed at startup, not by the GUC machinery. And the value lands inside single
+# quotes, so one of its own ends them — measured, DB_BIND_ADDRESS set to
+# `172.17.0.1'<newline>fsync = off<newline>#` gives a staged file that validates
+# and starts, with `postgres -C fsync` reporting `off`. A validator can only
+# ever say the file is a configuration; it cannot say it is this one.
+#
+# Restoring the previous file when the restart fails is the other half the
+# finding offers, and it treats the quiet band as a success: there is no failed
+# restart to trigger it.
+refuse_unusable_bind_address() {
+  local setting="$1" value="$2"
+  ipv4_dotted_quad "$value" && return 0
+  die "REFUSING: $setting='$value' is not an IPv4 address. It is written into" \
+      "PostgreSQL's listen_addresses, into a ufw rule and into DATABASE_URL," \
+      "and PostgreSQL does not refuse it: an address it cannot bind is a" \
+      "warning, so the cluster comes back up listening on localhost only and" \
+      "no container can reach it, on a host this run would have reported as" \
+      "converged. A value carrying a space or a quote is worse — it ends the" \
+      "quoting of the generated file. Nothing has been changed. The default is" \
+      "172.17.0.1, the docker0 bridge gateway; set $setting to the gateway" \
+      "address of the bridge your containers are on — 'ip -4 addr show docker0'."
+}
+
+refuse_unusable_subnet() {
+  local setting="$1" value="$2" addr bits
+  case "$value" in
+    */*/*) ;;
+    */*)
+      addr="${value%/*}"; bits="${value#*/}"
+      case "$bits" in
+        0|[1-9]|[12][0-9]|3[0-2]) ipv4_dotted_quad "$addr" && return 0 ;;
+      esac
+      ;;
+  esac
+  die "REFUSING: $setting='$value' is not an IPv4 network in CIDR form. It is" \
+      "written into a pg_hba.conf line and into a ufw rule. A malformed mask" \
+      "stops PostgreSQL from starting at all; a value that merely is not a" \
+      "network is read as a host name, and the cluster starts with a rule that" \
+      "matches nothing — every container is then refused with 'no pg_hba.conf" \
+      "entry' on a run that reported success. One network, not a list: the" \
+      "pg_hba address field and 'ufw allow from' each take exactly one." \
+      "Nothing has been changed. The default is 172.16.0.0/12, which covers" \
+      "every Docker bridge network."
+}
+
 # refuse_unparsable_ssh_key
 #
 # SSH_PUBLIC_KEY is appended to authorized_keys verbatim, and its own presence
@@ -401,10 +508,66 @@ refuse_unparsable_ssh_key() {
   fi
 }
 
+# refuse_forced_command_ssh_key
+#
+# refuse_unparsable_ssh_key asks sshd's own parser whether the line is a key,
+# and deliberately accepts the option prefixes an operator legitimately holds.
+# `command="..."` is one sshd reads perfectly and one this account cannot do its
+# job with: sshd runs that command *instead of* the one the client asked for, so
+# every remote command Kamal sends is discarded. Measured against a scratch
+# sshd, one authorized_keys line at a time, the client asking for
+# `echo KAMAL-REMOTE-COMMAND-RAN`:
+#
+#   authorized_keys line             ssh-keygen -l   rc    what actually ran
+#   <key>                            parses           0    the command
+#   from="127.0.0.1" <key>           parses           0    the command
+#   no-pty,no-agent-forwarding <key> parses           0    the command
+#   restrict <key>                   parses           0    the command
+#   restrict,pty <key>               parses           0    the command
+#   command="/usr/bin/false" <key>   parses           1    nothing
+#   command="/usr/bin/true"  <key>   parses           0    nothing
+#
+# The last row is the one worth refusing for. It is not a deploy that fails —
+# it is a deploy whose every step reports success while nothing is executed, on
+# a host whose provisioning also reported success. And the five rows above it
+# are why this is a separate question rather than "refuse a line with options":
+# they are the forms the guard above exists to keep working, and each of them
+# runs the client's command.
+#
+# The options are the words before the key blob. Every SSH public key encodes a
+# length-prefixed algorithm name, so the blob always begins "AAAA" — cutting
+# there keeps a `command=` that appears in the *comment* out of this, where it
+# is text rather than an option and refusing it would refuse a key sshd is
+# perfectly happy with.
+#
+# Refused rather than checked after the install, for the reason the guard above
+# gives: revoke_prior_ssh_key withdraws the predecessor as soon as `grep -qxF`
+# finds this line in the file, and finding it there is not evidence that a
+# command can be run through it. There is no client here to prove that with, so
+# the only place the question can be answered is before anything is appended.
+refuse_forced_command_ssh_key() {
+  local options
+  [ -n "$SSH_PUBLIC_KEY" ] || return 0
+  options="${SSH_PUBLIC_KEY%%AAAA*}"
+  case "$options" in
+    *command=*) ;;
+    *) return 0 ;;
+  esac
+  die "REFUSING: SSH_PUBLIC_KEY carries a forced command. sshd reads the key" \
+      "fine, and then runs that command in place of whatever the client asks" \
+      "for — so 'kamal deploy' would connect, run the forced command, and" \
+      "either fail on every step or, if the command exits 0, report every step" \
+      "as done without running any of it. Nothing has been changed. Left to" \
+      "run, this would be appended to $APP_SSH_USER's authorized_keys and the" \
+      "key it replaces withdrawn on the strength of finding this one in the" \
+      "file. Supply the plain line from your .pub file; restrictions that do" \
+      "not replace the command — from=, no-pty, restrict — are accepted."
+}
+
 # refuse_root_deploy_user <user>
 #
 # The deploy account cannot be UID 0, because step 3 writes `PermitRootLogin no`
-# into /etc/ssh/sshd_config.d/99-collavre.conf and then, further down that same
+# into /etc/ssh/sshd_config.d/01-collavre.conf and then, further down that same
 # step, arms $APP_SSH_USER and hands it to Kamal as KAMAL_SSH_USER. Nothing in
 # between rejects the account sshd has just been told to turn away, so the run
 # reports success and every deploy fails to authenticate.
@@ -539,7 +702,10 @@ refuse_nologin_deploy_user() {
 # earlier, so it is answered without reading any state at all.
 refuse_unusable_db_identifier DB_NAME "$DB_NAME"
 refuse_unusable_db_identifier DB_USER "$DB_USER"
+refuse_unusable_bind_address DB_BIND_ADDRESS "$DB_BIND_ADDRESS"
+refuse_unusable_subnet DOCKER_SUBNETS "$DOCKER_SUBNETS"
 refuse_unparsable_ssh_key
+refuse_forced_command_ssh_key
 refuse_root_deploy_user "$APP_SSH_USER"
 refuse_nologin_deploy_user "$APP_SSH_USER"
 
@@ -671,12 +837,40 @@ ensure_block() {
   # because the message was right while the status was wrong.
   file="$(resolve_symlink_chain "$file")" || exit 1
 
+  local tmp rc
   if ! grep -qF "$begin" "$file" 2>/dev/null; then
-    {
+    # Staged and renamed, like the rewrite below — an append is not the safer
+    # half of this function. `>>` writes into the live file directly, so a kill
+    # or an ENOSPC between the two printfs leaves a BEGIN with no END, and the
+    # very next run stops at the malformed-block check three lines down asking
+    # to be repaired by hand. That check is right to refuse: it cannot tell a
+    # half-written block of this script's from an operator's edit. What it
+    # costs is the file — /etc/fstab, /etc/hosts, postgresql.conf, pg_hba.conf
+    # — needing an editor on a host whose provisioning has just been killed.
+    #
+    # There is nothing to preserve on this path and still a copy is made: the
+    # rename replaces the target, so the staging file has to hold the whole
+    # file, not just the block. 0644 is for a target that does not exist yet
+    # — the mode `>>` produced under root's umask; every caller in this script
+    # points at a file that does exist, where cp -p carries its own.
+    rc=0
+    tmp="$(stage_beside "$file" 0644)" || rc=$?
+    case "$rc" in
+      1) die "$file: could not stage the collavre:$marker block beside it. Is $(dirname "$file") writable?" ;;
+      2) die "$file: could not give a staged copy the same owner and mode as the" \
+             "file it replaces, so the collavre:$marker block was NOT added and" \
+             "$file is untouched." ;;
+    esac
+    if ! {
       printf '\n%s (managed by script/lightsail_launch.sh)\n' "$begin"
       printf '%s\n' "$content"
       printf '%s\n' "$end"
-    } >> "$file"
+    } >> "$tmp"; then
+      rm -f "$tmp"
+      die "$file: could not write the collavre:$marker block to a staging file" \
+          "beside it — is $(dirname "$file") full? $file is untouched."
+    fi
+    mv -f "$tmp" "$file"
     return 0
   fi
 
@@ -687,9 +881,9 @@ ensure_block() {
   # two failures are reported separately, because the remedies differ: 1 is
   # "nowhere to stage it" (disk, permissions), 2 is "cannot be given the
   # target's owner and mode".
-  local tmp rc
+  rc=0
   tmp="$(stage_beside "$file")" || rc=$?
-  case "${rc:-0}" in
+  case "$rc" in
     1) die "$file: could not stage a rewrite beside it. Is $(dirname "$file") writable?" ;;
     2) die "$file: could not give a staged rewrite the same owner and mode as the" \
            "file it replaces, so it was NOT installed and $file is untouched." ;;
@@ -1979,10 +2173,45 @@ ensure_ufw_rule() {
 # All of it verified against real ufw on ubuntu:24.04, against `iptables -S` as
 # the ground truth for whether IPv4 port 22 is actually reachable, rather than
 # reasoned about from the rendering.
+#
+# And the direction, which is the one this got wrong. `ufw status` renders an
+# inbound rule with a bare action and puts the direction in the action column
+# only when it is not inbound — there is no "ALLOW IN" in this output. So a rule
+# that authorizes nothing inbound reads exactly like one that does, apart from a
+# word the pattern did not look at. Measured against real ufw on ubuntu:24.04,
+# one `ufw status` per row, the shipped pattern beside the direction-aware one:
+#
+#   ufw status shows                 shipped   with the filter   the run then
+#   22/tcp      ALLOW OUT            YES       no                adds inbound 22
+#   OpenSSH     ALLOW OUT            YES       no                adds inbound 22
+#   22/tcp ALLOW OUT + 80/tcp ALLOW  YES       no                adds inbound 22
+#   22/tcp      ALLOW                YES       YES               leaves it alone
+#   OpenSSH     ALLOW                YES       YES               leaves it alone
+#   22/tcp      LIMIT                YES       YES               leaves it alone
+#   22 from 203.0.113.7  ALLOW       YES       YES               leaves it alone
+#   80/tcp only                      no        no                adds inbound 22
+#   22/tcp      DENY                 no        no                adds inbound 22
+#
+# The first three rows are the failure and the four after them are why the fix
+# is a filter rather than a stricter pattern: an operator who narrowed 22 to one
+# source, or used the OpenSSH profile, or rate-limited it, must still be left
+# alone. Getting those wrong broadens the rule this function exists to protect.
+#
+# The consequence of the first row is the worst outcome this script has. `ufw
+# default deny incoming` is applied and ufw is enabled a few steps later, so a
+# host whose only port-22 rule is *outbound* has SSH read as authorized, no
+# inbound rule added, and the firewall turned on — locking out the operator who
+# is running this over SSH at the time, on an instance whose console is the only
+# way back in.
+#
+# FWD as well as OUT: `ufw route allow ... port 22` renders "22/tcp ALLOW FWD",
+# which is a rule about traffic passing *through* this host and authorizes
+# nothing arriving at it. Confirmed in the same run as the table above.
 ssh_already_allowed() {
   ufw status 2>/dev/null |
     sed 's/#.*//' |
     grep -vE '\(v6\)|:' |
+    grep -vE '(ALLOW|LIMIT|DENY|REJECT)[[:space:]]+(OUT|FWD)' |
     grep -qE '^([^[:space:]]+[[:space:]]+)?(22|OpenSSH)([/[:space:]]).*(ALLOW|LIMIT)'
 }
 
@@ -2035,20 +2264,104 @@ net.ipv4.ip_nonlocal_bind = 1
 SYSCTL
 sysctl --system >/dev/null
 
+# verify_ssh_hardening [effective config file] [sshd config dir]
+#
+# Read back what sshd actually resolved the three hardened keywords to, and
+# refuse a run that reported hardening it did not perform.
+#
+# Naming the drop-in so it sorts first is necessary and not sufficient: a
+# directive above the Include in sshd_config itself, or an operator's own
+# drop-in with an earlier prefix, still wins, and the file name says nothing
+# about either. The only thing that answers is sshd's own resolution of the
+# whole configuration.
+#
+# Refusing rather than warning, and refusing here rather than later: this is the
+# top of step 3, before the deploy account is created, before sudo and docker
+# are granted and before any key is installed, so a run that stops here has
+# changed nothing but the drop-in — and SSH is left exactly as the operator had
+# it, so nobody is locked out by the refusal. The alternative is a run that
+# prints its summary over a host still accepting passwords and root logins.
+#
+# An answer that cannot be read is not the same as a wrong one, and is warned
+# about instead. `sshd -T` needs host keys and a parseable configuration; a host
+# where it will not run has told us nothing, and dying over a question we could
+# not ask would stop provisioning on a host that may well be fine. Match blocks
+# do not cause that — `sshd -T` without `-C` prints the global block and exits 0,
+# measured on both OpenSSH builds this was checked against.
+verify_ssh_hardening() {
+  local src="${1:-}" conf_dir="${2:-/etc/ssh}" effective key value offender
+  if [ -n "$src" ]; then
+    effective="$(cat "$src")"
+  elif ! effective="$(sshd -T 2>/dev/null)"; then
+    log "WARNING: could not read the effective SSH configuration on this host" \
+        "(\`sshd -T\` failed), so the hardening above is unverified. Check it" \
+        "by hand: sshd -T | grep -E" \
+        "'^(passwordauthentication|permitrootlogin|kbdinteractiveauthentication)'"
+    return 0
+  fi
+  for key in passwordauthentication permitrootlogin kbdinteractiveauthentication; do
+    value="$(printf '%s\n' "$effective" |
+             awk -v k="$key" 'tolower($1) == k { print $2; exit }')"
+    [ -n "$value" ] || {
+      log "WARNING: sshd did not report '$key', so that part of the hardening" \
+          "above is unverified"
+      continue
+    }
+    if [ "$value" = "no" ]; then
+      continue
+    fi
+    # Name the file rather than leave the operator to find it: with the drop-in
+    # sorting first, something above the Include or an earlier prefix is the
+    # only way to get here, and both are one grep away.
+    offender="$(grep -ilE "^[[:space:]]*$key[[:space:]]" \
+                  "$conf_dir"/sshd_config.d/*.conf "$conf_dir"/sshd_config \
+                  2>/dev/null | grep -v '01-collavre.conf' | head -1)" || true
+    die "SSH hardening did not take effect: sshd resolves '$key' to '$value'," \
+        "not 'no', even though $conf_dir/sshd_config.d/01-collavre.conf sets" \
+        "it. sshd uses the FIRST value it obtains for a keyword, so something" \
+        "read earlier is setting it${offender:+ — ${offender}}. Stopping here" \
+        "rather than finishing: nothing has been granted yet and SSH is" \
+        "unchanged, so the host stays reachable. Remove or correct that" \
+        "setting and re-run."
+  done
+}
+
 # --------------------------------------------------------------------------
 log "3/9 SSH hardening + deploy user '$APP_SSH_USER'"
 # --------------------------------------------------------------------------
 install -d -m 0755 /etc/ssh/sshd_config.d
-cat > /etc/ssh/sshd_config.d/99-collavre.conf <<'SSHD'
+# 01-, not 99-. sshd_config(5): "for each keyword, the first obtained value will
+# be used", and the Include glob is expanded in lexical order — so a drop-in
+# that sorts *after* an existing one cannot override it, which is the opposite
+# of how a "99-" suffix reads. Ubuntu's cloud images ship 50-cloud-init.conf,
+# and on an existing instance it commonly carries `PasswordAuthentication yes`.
+# Measured with `sshd -T`, on OpenSSH 9.x/Linux and 10.2/macOS alike:
+#
+#   drop-ins present                        passwordauth  permitrootlogin
+#   50-cloud-init.conf + 99-collavre.conf   yes           yes
+#   50-cloud-init.conf + 01-collavre.conf   no            no
+#   01-collavre.conf alone (fresh host)     no            no
+#
+# `kbdinteractiveauthentication no` in every row is the control: the 99- file
+# was being read the whole time. It lost only the keywords something else had
+# already set — which is every keyword that matters here, on exactly the hosts
+# the existing-instance path exists for.
+cat > /etc/ssh/sshd_config.d/01-collavre.conf <<'SSHD'
 PasswordAuthentication no
 PermitRootLogin no
 KbdInteractiveAuthentication no
 SSHD
+# A host provisioned by an earlier version of this script carries the 99- file.
+# It is inert now that 01- sets the same keywords first, and that is the reason
+# to remove it rather than leave it: a file whose every line is overridden is
+# one an operator can edit to no effect.
+rm -f /etc/ssh/sshd_config.d/99-collavre.conf
 # Ubuntu ships `Include /etc/ssh/sshd_config.d/*.conf` at the top of
 # sshd_config; without it the drop-in above is silently ignored.
 grep -q '^Include /etc/ssh/sshd_config.d/' /etc/ssh/sshd_config 2>/dev/null || \
   log "WARNING: sshd_config has no Include for sshd_config.d — harden SSH by hand"
 systemctl reload ssh 2>/dev/null || systemctl reload sshd 2>/dev/null || true
+verify_ssh_hardening
 
 # install_deploy_ssh_dir <user> <home> — create <home>/.ssh owned by the
 # account, and echo the group it was given.
@@ -2819,6 +3132,35 @@ ensure_block "$PG_CONF_DIR/pg_hba.conf" docker \
 
 systemctl enable postgresql
 systemctl restart postgresql
+
+# A cluster that is up is not a cluster reachable on the address this run is
+# about to publish. refuse_unusable_bind_address answers the shape of
+# DB_BIND_ADDRESS before anything is written; it cannot answer whether the
+# address is on this host, because docker0 does not exist yet when it runs.
+# PostgreSQL will not answer it either — an address it cannot bind is a WARNING
+# in a log nobody reads and the cluster starts anyway, listening on localhost
+# alone. Measured against a live cluster, which is the only thing that knows:
+#
+#   listen_addresses            cluster   pg_isready -h <the address>
+#   localhost,127.0.0.1         UP        0, accepting connections
+#   localhost,1.2.3.4           UP        2, no response
+#   localhost,172.17.0.999      UP        2, no response
+#
+# Asked here rather than believed, because every later step takes it on trust:
+# DATABASE_URL, the ufw rule and the summary all name this address, and the
+# first thing to discover it is wrong would be the first deploy. pg_isready
+# needs no credentials and a pg_hba refusal still counts as a response, so this
+# asks about reachability and nothing else.
+pg_isready -h "$DB_BIND_ADDRESS" -p "$DB_PORT" -t 10 >/dev/null 2>&1 ||
+  die "PostgreSQL restarted, but it is not listening on DB_BIND_ADDRESS=" \
+      "$DB_BIND_ADDRESS:$DB_PORT. The cluster is up — it fell back to" \
+      "localhost, which it does with only a WARNING when an address cannot be" \
+      "bound, so nothing else on this host would have said so. Left to run," \
+      "the summary would print a DATABASE_URL over that address and no" \
+      "container could open it. Check the bridge with 'ip -4 addr show" \
+      "docker0' and set DB_BIND_ADDRESS to its address (the default," \
+      "172.17.0.1, is the usual one), then re-run with FORCE=1. The" \
+      "configuration this run installed is in $PG_CONF_DIR/conf.d/10-collavre.conf."
 
 # --------------------------------------------------------------------------
 log "6/9 database '$DB_NAME' and role '$DB_USER'"

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -3269,7 +3269,7 @@ revoke_prior_ssh_key() {
     return 0
   }
 
-  while read -r prior; do
+  while IFS= read -r prior; do
     [ -n "$prior" ] || continue
     # The key this run deploys with stays: it is what the *next* rotation
     # withdraws.

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -4941,7 +4941,7 @@ the actual key path and run:
   signature="\$(printf 'collavre-ssh-cutover:%s:%s' '$APP_SSH_USER' "\$nonce" |
     ssh-keygen -Y sign -f "\$key" -n collavre-ssh-cutover 2>/dev/null |
     base64 | tr -d '\\n')"
-  ssh -i "\$key" $APP_SSH_USER@$PUBLIC_IP \\
+  ssh -o IdentitiesOnly=yes -i "\$key" $APP_SSH_USER@$PUBLIC_IP \\
     "sudo /usr/local/sbin/collavre-finalize-ssh-cutover --finalize-ssh-cutover '\$nonce' '\$signature'"
 
 Only after it prints "SSH cutover finalized" should KAMAL_SSH_USER change to

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -433,6 +433,54 @@ refuse_unusable_subnet() {
       "every Docker bridge network."
 }
 
+# refuse_unusable_retention <setting name> <value>
+#
+# BACKUP_RETENTION_DAYS is %q-quoted into the generated backup program and used
+# only there, as `find -mtime "+$RETENTION_DAYS"`. `bash -n` on the staged
+# program parses it fine and the timer is enabled, so nothing on this side of
+# provisioning says anything: the value is first read by GNU find at the hour
+# BACKUP_AT names — 03:30 by default — on a host the summary already reported
+# as converged, hours earlier. Measured by running the
+# generated program with each value, GNU findutils 4.8.0:
+#
+#   BACKUP_RETENTION_DAYS   rc   dumps left       the unit
+#   7                       0    the new dump     green, "backup complete: (4.0K)"
+#   seven                   1    new + the old    RED, invalid argument `+seven'
+#   ''                      1    new + the old    RED, invalid argument `+'
+#   -1                      0    NONE             green, "backup complete: ()"
+#
+# Two bands again, and the loud one is not the dangerous one. `seven` fails
+# every night with the unit red and dumps accumulating until the disk fills —
+# which is the finding, and it is at least visible in `systemctl list-units
+# --failed`. `-1` is the one worth this guard: find takes `+-1`, deletes every
+# dump *including the one just taken*, and the program still exits 0 and prints
+# "backup complete" for a file that is no longer there. A green nightly timer
+# and an empty backup directory is the worst reading of the four.
+#
+# Refused here, before the unit is installed, rather than checked in the
+# generated program: a program that validates its own retention has already
+# taken the dump by the time it can complain, and the only place "nothing has
+# been changed" is true is up here with the other value guards.
+#
+# Whole non-negative integers only. `7.5` happens to work on GNU find and is
+# refused anyway — one spelling, and a retention this script cannot restate as
+# a whole number of days is not one an operator should have to reason about.
+refuse_unusable_retention() {
+  local setting="$1" value="$2"
+  case "$value" in
+    ''|*[!0-9]*) ;;
+    *) return 0 ;;
+  esac
+  die "REFUSING: $setting='$value' is not a whole number of days. It is used" \
+      "as 'find -mtime +$value' in the nightly backup, which provisioning" \
+      "installs and enables without ever running — so this would first be" \
+      "read at $BACKUP_AT, on a host reported as converged. A value find" \
+      "rejects leaves the timer failing every night while dumps accumulate;" \
+      "a negative one is worse, because find accepts it and deletes every" \
+      "dump including the one just taken, while the run still exits 0 and" \
+      "reports 'backup complete'. Nothing has been changed. The default is 7."
+}
+
 # refuse_unparsable_ssh_key
 #
 # SSH_PUBLIC_KEY is appended to authorized_keys verbatim, and its own presence
@@ -548,7 +596,28 @@ refuse_unparsable_ssh_key() {
 refuse_forced_command_ssh_key() {
   local options
   [ -n "$SSH_PUBLIC_KEY" ] || return 0
-  options="${SSH_PUBLIC_KEY%%AAAA*}"
+  # Folded, because sshd matches the option *name* without regard to case and a
+  # case-sensitive test here is a bypass rather than a narrower guard. Measured
+  # against a real sshd, one authorized_keys line at a time, the client asking
+  # for `echo CLIENT-COMMAND-RAN`:
+  #
+  #   authorized_keys line              ssh rc   what actually ran
+  #   command="/usr/bin/true" <key>     0        nothing
+  #   COMMAND="/usr/bin/true" <key>     0        nothing
+  #   CoMmAnD="/usr/bin/true" <key>     0        nothing
+  #   no-pty,COMMAND="/usr/bin/true"    0        nothing
+  #   RESTRICT <key>                    0        the client's command
+  #
+  # The last row is the control and it is why only the name is folded and the
+  # question is still "is this a forced command": an uppercase option is not on
+  # its own a reason to refuse a key sshd is happy to run the client's command
+  # through.
+  #
+  # `tr` rather than `${options,,}`: this suite runs under bash 3.2 on macOS as
+  # well as 5.2 on the host, and the parameter expansion is a 4.0 syntax error
+  # there — the same platform split that made a `head -c 0` fixture pass here
+  # and fail in CI.
+  options="$(printf '%s' "${SSH_PUBLIC_KEY%%AAAA*}" | tr '[:upper:]' '[:lower:]')"
   case "$options" in
     *command=*) ;;
     *) return 0 ;;
@@ -704,6 +773,7 @@ refuse_unusable_db_identifier DB_NAME "$DB_NAME"
 refuse_unusable_db_identifier DB_USER "$DB_USER"
 refuse_unusable_bind_address DB_BIND_ADDRESS "$DB_BIND_ADDRESS"
 refuse_unusable_subnet DOCKER_SUBNETS "$DOCKER_SUBNETS"
+refuse_unusable_retention BACKUP_RETENTION_DAYS "$BACKUP_RETENTION_DAYS"
 refuse_unparsable_ssh_key
 refuse_forced_command_ssh_key
 refuse_root_deploy_user "$APP_SSH_USER"
@@ -813,6 +883,74 @@ stage_beside() {
     return 2
   fi
   printf '%s\n' "$tmp"
+}
+
+# install_managed_config <label> <target> <line>...
+#
+# Write a whole config file this script owns: every line is put in a staging
+# file beside the target, read back, and only then renamed over it, so the live
+# file is never the one being written to. Blank and comment lines are written
+# but not read back — they are not what the file is for.
+#
+# Reading the staged file back is the part that does not follow from "stage and
+# rename", and it is the part the quiet failures need. `printf` can report
+# success for a short write, and both of the states a truncated drop-in leaves —
+# zero bytes, or cut after the first directive — are files every validator
+# accepts. `sshd -t` answers rc=0 for an empty file; so does `jq empty`, which
+# is the same fact the daemon.json rewrite rests on. A validator can say the
+# staged file is a configuration. Only a read-back can say it is *this* one.
+install_managed_config() {
+  local label="$1" target="$2" tmp rc line
+  shift 2
+  # Resolved here, and the rename below goes to the resolved path — the same
+  # thing ensure_block does at its top and the 10-collavre.conf write spells
+  # out as PG_CONF_REAL. stage_beside resolves internally, so renaming onto the
+  # unresolved argument would put the staging file beside the *backing* file
+  # and the finished one beside the link. Two consequences, and the second is
+  # the one this function exists to prevent:
+  #
+  #   target                     after the install
+  #   /etc/plain.conf (control)  rewritten in place, no leftovers
+  #   /etc/link.conf -> /real/backing.conf
+  #                              /etc/link.conf is now a REGULAR FILE
+  #                              /real/backing.conf still holds the old content
+  #
+  # The operator's symlink is replaced, so the file they were editing stops
+  # taking effect. And because the staging file was made beside the resolved
+  # target, a link that crosses a filesystem turns the `mv` into a
+  # copy-then-unlink — the non-atomic write this whole function is here to
+  # avoid, reintroduced on exactly the hosts where the staging is doing
+  # something.
+  #
+  # `|| exit 1` rather than `|| return 1`: resolve_symlink_chain die()s inside
+  # a command substitution, so its exit kills only that subshell. Carrying on
+  # would rename onto an empty path — the same fault ensure_block's case 4b
+  # asserts the status for rather than the message.
+  target="$(resolve_symlink_chain "$target")" || exit 1
+  tmp="$(stage_beside "$target" 0644)"; rc=$?
+  [ "$rc" -eq 0 ] || {
+    die "could not stage $label at $target (stage_beside exited $rc). The" \
+        "live file is left exactly as it was and nothing has been granted."
+  }
+  if ! printf '%s\n' "$@" > "$tmp"; then
+    rm -f "$tmp"
+    die "could not write the staged $label — is the instance out of disk?" \
+        "$target is left as it was."
+  fi
+  for line in "$@"; do
+    case "$line" in ''|'#'*) continue ;; esac
+    grep -qxF "$line" "$tmp" && continue
+    rm -f "$tmp"
+    die "the staged $label came out without '$line' — refusing to install it" \
+        "over $target, which is left as it was. A file that parses is not one" \
+        "that does its job: an empty drop-in passes every validator there is" \
+        "and silently gives back whatever it was supposed to set."
+  done
+  mv -f "$tmp" "$target" || {
+    rm -f "$tmp"
+    die "could not install the staged $label over $target, which is left as" \
+        "it was."
+  }
 }
 
 # Keep a managed block in a config file equal to $content, keyed by a marker.
@@ -2254,14 +2392,21 @@ dpkg-reconfigure -f noninteractive unattended-upgrades
 log "2/9 swap (${SWAP_SIZE_MB}MiB)"
 # --------------------------------------------------------------------------
 ensure_swapfile
-cat > /etc/sysctl.d/99-collavre.conf <<'SYSCTL'
-# Prefer RAM, use swap only under real pressure.
-vm.swappiness = 10
-vm.vfs_cache_pressure = 50
-# Let PostgreSQL bind the docker0 gateway address even when the bridge has not
-# been created yet (PostgreSQL can start before dockerd after a reboot).
-net.ipv4.ip_nonlocal_bind = 1
-SYSCTL
+# Staged and renamed, for the same reason the SSH drop-in in step 3 is. A `>`
+# here truncates the live file before it writes, and a run killed between the
+# two leaves a sysctl drop-in that `sysctl --system` reads without complaint —
+# it applies whichever lines survived and says nothing about the ones that did
+# not. Losing net.ipv4.ip_nonlocal_bind that way is the quiet one: everything
+# works until the next reboot, and then PostgreSQL cannot bind the docker0
+# address if it starts before dockerd, which is the failure the whole
+# DB_BIND_ADDRESS thread on this file is about.
+install_managed_config 'the sysctl drop-in' /etc/sysctl.d/99-collavre.conf \
+  '# Prefer RAM, use swap only under real pressure.' \
+  'vm.swappiness = 10' \
+  'vm.vfs_cache_pressure = 50' \
+  '# Let PostgreSQL bind the docker0 gateway address even when the bridge has' \
+  '# not been created yet (PostgreSQL can start before dockerd after a reboot).' \
+  'net.ipv4.ip_nonlocal_bind = 1'
 sysctl --system >/dev/null
 
 # verify_ssh_hardening [effective config file] [sshd config dir]
@@ -2346,11 +2491,43 @@ install -d -m 0755 /etc/ssh/sshd_config.d
 # was being read the whole time. It lost only the keywords something else had
 # already set — which is every keyword that matters here, on exactly the hosts
 # the existing-instance path exists for.
-cat > /etc/ssh/sshd_config.d/01-collavre.conf <<'SSHD'
-PasswordAuthentication no
-PermitRootLogin no
-KbdInteractiveAuthentication no
-SSHD
+#
+# The drop-in below, and the sysctl one in step 2, go through
+# install_managed_config rather than a `cat >` heredoc, for the reason the
+# daemon.json rewrite and the managed-block append do: `>` truncates before it
+# writes, and a run killed between the two — an OOM kill or an ENOSPC on a
+# 512MB instance — leaves the live drop-in short. Measured against a real sshd,
+# with Ubuntu's 50-cloud-init.conf beside it turning both keywords back on:
+#
+#   01-collavre.conf state   bytes   sshd -t   passwordauth  permitrootlogin
+#   whole                    77      rc=0      no            no
+#   0 bytes (torn at open)    0      rc=0      yes           yes
+#   cut after line 1         26      rc=0      no            yes
+#   cut mid-directive        36      rc=255    -             -
+#   cut mid-value            43      rc=255    -             -
+#
+# Two bands, and only one of them is loud. The bottom rows stop sshd from
+# starting, which locks the host out at its next boot. The middle two are the
+# quiet ones: sshd reads them happily and the hardening is silently reduced or
+# gone entirely, on a host whose provisioning was killed rather than one that
+# reported success — so nothing ever says so.
+#
+# `sshd -t` is what the finding asks for and it cannot close the quiet band: it
+# answers rc=0 for the empty file, which is the state truncate-at-open leaves.
+# That is the same fact the `jq empty` fix two functions over rests on — a
+# validator that asks "is this a configuration" cannot tell a zero-length one
+# from a correct one. So the staged file is asked whether it *says* what it was
+# staged to say, and only then renamed.
+#
+# verify_ssh_hardening below is not a substitute for this and does not overlap
+# it. It reads back sshd's resolution on a run that got that far; the exposure
+# here is a run that did not, and for that the only answer is that the live file
+# was never opened for writing.
+install_managed_config 'the SSH hardening drop-in' \
+  /etc/ssh/sshd_config.d/01-collavre.conf \
+  'PasswordAuthentication no' \
+  'PermitRootLogin no' \
+  'KbdInteractiveAuthentication no'
 # A host provisioned by an earlier version of this script carries the 99- file.
 # It is inert now that 01- sets the same keywords first, and that is the reason
 # to remove it rather than leave it: a file whose every line is overridden is
@@ -2360,7 +2537,63 @@ rm -f /etc/ssh/sshd_config.d/99-collavre.conf
 # sshd_config; without it the drop-in above is silently ignored.
 grep -q '^Include /etc/ssh/sshd_config.d/' /etc/ssh/sshd_config 2>/dev/null || \
   log "WARNING: sshd_config has no Include for sshd_config.d — harden SSH by hand"
-systemctl reload ssh 2>/dev/null || systemctl reload sshd 2>/dev/null || true
+# reload_ssh_daemon — reload whichever unit carries sshd; non-zero only when a
+# *running* daemon refused the configuration.
+#
+# `|| true` here used to swallow the status, and the status means two different
+# things. Measured under systemd 252, one unit state per row, with ExecReload
+# standing in for sshd's own accept-or-refuse:
+#
+#   unit state              reload rc   is-active   what it means
+#   inactive                1           inactive    nothing to reload
+#   not found at all        5           inactive    nothing to reload
+#   active, reload ok       0           active      adopted
+#   active, reload refused  1           active      still on the OLD config
+#
+# rc alone cannot separate rows 1 and 4 — both are 1 — and rc 1 on row 1 is the
+# stock state this runbook targets, not an edge case: Ubuntu 24.04's
+# openssh-server enables ssh.socket and leaves ssh.service disabled, so until
+# something connects both `reload ssh` and `reload sshd` fail on a host that is
+# entirely healthy. The next connection starts sshd fresh and the drop-in is
+# already in force. Dying on rc alone would refuse every correctly-provisioned
+# instance — the same over-refusal refuse_nologin_deploy_user and the
+# pg_lsclusters guard each had to be shaped around, and worse than the defect
+# because it fires on every invocation.
+#
+# So the discriminator is whether the unit was active, which is exactly the
+# question "was there a daemon to refuse this". Read from systemctl rather than
+# from the rc or the message: rc 1 is overloaded and the message is localised.
+reload_ssh_daemon() {
+  local unit
+  for unit in ssh sshd; do
+    systemctl reload "$unit" >/dev/null 2>&1 && return 0
+    [ "$(systemctl is-active "$unit" 2>/dev/null)" = active ] && return 1
+  done
+  return 0
+}
+# Fatal, and *before* verify_ssh_hardening rather than folded into it, because
+# on this path that function is answering the wrong question. `sshd -T` re-reads
+# the files on disk; it cannot report what the daemon currently in memory is
+# using. So on a refused reload it confirms the hardening from the very file the
+# daemon just rejected, and the run proceeds to grant docker, passwordless sudo
+# and keys while the live daemon is still on whatever PasswordAuthentication it
+# had. Nothing on the host says so.
+#
+# And the disk state is its own outage in waiting: the configuration sshd
+# refused is the one it will be handed at the next boot, where there is no old
+# process to keep running.
+#
+# Stopping here is the safe end. This is the top of step 3 — the deploy account
+# does not exist yet, nothing has been granted, and SSH is left exactly as the
+# operator had it, so the refusal locks nobody out. That is the same reason
+# verify_ssh_hardening's own die() sits here rather than after the grants.
+reload_ssh_daemon || die \
+  "SSH hardening was written but the running sshd refused to reload it." \
+  "The live daemon is still using the configuration it started with, so the" \
+  "hardening above is NOT in effect — and sshd will be handed the same" \
+  "rejected configuration at the next boot, where no old process survives to" \
+  "keep the host reachable. Nothing has been granted and SSH is unchanged." \
+  "Find the offending directive with 'sshd -t', fix it, and re-run."
 verify_ssh_hardening
 
 # install_deploy_ssh_dir <user> <home> — create <home>/.ssh owned by the
@@ -2626,7 +2859,6 @@ install_authorized_keys() {
       # be cut short, and it lands on the file the operator is logged in with.
       tmp="$(stage_authorized_keys "$auth_keys")" || return 1
       cat "$src" >> "$tmp" || { rm -f "$tmp"; return 1; }
-      install_staged_authorized_keys "$tmp" "$auth_keys" || return 1
       # Record what was copied, or the rotation this documents cannot undo it.
       # `record_ssh_key_grant "$SSH_PUBLIC_KEY"` at the call site is a no-op on
       # this path — the variable is empty, that is what put us here — so the
@@ -2647,9 +2879,32 @@ install_authorized_keys() {
       # the operator's Lightsail key from the account they log in as. Copied
       # keys are this script's to withdraw; a cloud account's own keys are not.
       #
-      # Warned rather than fatal, matching ensure_ufw_rule's marker: the keys
-      # are installed by the time we get here, so dying would leave exactly the
-      # same untracked keys with less said about them.
+      # Before the install, and fatal rather than warned. Recording afterwards
+      # cannot be made safe: by then the keys are authorized on an account this
+      # run is about to give docker and passwordless sudo, and a failed record
+      # leaves them there untracked with only a log line. Measured on the
+      # shipped functions with the state directory unwritable, which is what a
+      # full disk on a 512MB instance looks like from here:
+      #
+      #   record        run 1 rc   queued   authorized after the rotation
+      #   succeeds      0          2        new
+      #   fails         0          0        cloud-1 cloud-2 new
+      #
+      # The second row is the defect the fix above was written for, reached
+      # through its failure path — an rc of 0, a summary that reports a
+      # converged host, and two keys the documented rotation will never
+      # withdraw.
+      #
+      # Ordered this way the two failures are not symmetric, which is why this
+      # order and not the other. Recorded-but-not-installed is harmless: the
+      # revoke loop skips a queued key that is absent from authorized_keys, and
+      # append_state_line dedupes, so the retry after the disk is freed records
+      # nothing twice. Installed-but-not-recorded is the finding.
+      #
+      # Aborting is the safe end here rather than a lesser one: this returns
+      # non-zero, which the call site treats as fatal *before* the sudo and
+      # docker grants, so the host is left exactly as it was and the operator
+      # still reaches it as the cloud user.
       # Guarded on the two state variables the same way install_staged_authorized_keys
       # guards its chown on APP_SSH_USER: this function is called directly by a
       # dozen fixtures that have no state directory and no deploy account, and
@@ -2659,12 +2914,18 @@ install_authorized_keys() {
       if [ -n "${STATE_DIR:-}" ] && [ -n "${APP_SSH_USER:-}" ]; then
         while read -r _copied; do
           case "$_copied" in ''|'#'*) continue ;; esac
-          record_ssh_key_grant "$_copied" ||
-            log "WARNING: copied a key from $candidate but could not record it," \
-                "so a later SSH_PUBLIC_KEY rotation will not withdraw it:" \
-                "${_copied##* }"
+          record_ssh_key_grant "$_copied" || {
+            rm -f "$tmp"
+            log "could not record a key copied from $candidate in" \
+                "$STATE_DIR, so a later SSH_PUBLIC_KEY rotation would leave it" \
+                "authorized on '$APP_SSH_USER' for good: ${_copied##* }." \
+                "Nothing was installed and $auth_keys is untouched — is" \
+                "$STATE_DIR writable, and does the instance have disk left?"
+            return 1
+          }
         done < "$src"
       fi
+      install_staged_authorized_keys "$tmp" "$auth_keys" || return 1
     fi
     return 0
   done

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -32,6 +32,28 @@ set -euo pipefail
 # Every value can also be supplied as an environment variable.
 # --------------------------------------------------------------------------
 
+# Which of the settings below the caller actually asked for, recorded before the
+# defaults fill in the rest. Afterwards every one of them is set and the two
+# cases are indistinguishable — and the difference is the whole question a
+# re-run has to answer. `sudo FORCE=1 bash script/lightsail_launch.sh` on a host
+# provisioned with an override reads as "converge this host", but several of
+# these settings converge by *rotating*: the deploy user's sudo and docker
+# grants move to whatever APP_SSH_USER now says, and table ownership and LOGIN
+# move to whatever DB_USER now says. Defaulted back to `collavre` and
+# `collavre_user`, that is a rotation nobody asked for, performed against the
+# account and role the running deployment authenticates as.
+#
+# DB_PASSWORD is not in the list: it is already reloaded from $STATE_DIR when
+# unset, which is this same idea applied to the one setting that had it.
+LAUNCH_SETTINGS='SSH_PUBLIC_KEY APP_SSH_USER PG_MAJOR DB_NAME DB_USER
+                 DB_BIND_ADDRESS DOCKER_SUBNETS SWAP_SIZE_MB TIMEZONE
+                 INSTANCE_HOSTNAME BACKUP_RETENTION_DAYS BACKUP_S3_URI BACKUP_AT'
+SUPPLIED_SETTINGS=''
+for _s in $LAUNCH_SETTINGS; do
+  [ -n "${!_s+set}" ] && SUPPLIED_SETTINGS="$SUPPLIED_SETTINGS $_s"
+done
+unset _s
+
 # SSH public key that may log in as the deploy user. Leave empty to reuse the
 # key Lightsail installed for the default `ubuntu` user.
 : "${SSH_PUBLIC_KEY:=}"
@@ -125,6 +147,100 @@ if [ -f "$MARKER" ] && [ "${FORCE:-0}" != "1" ]; then
   log "already provisioned ($MARKER). Re-run with FORCE=1 to converge again."
   exit 0
 fi
+
+# refuse_defaulted_config_change [state dir] [supplied settings]
+#
+# A re-run applies every setting, not just the ones it was given: an override
+# the operator used the first time and did not repeat is applied as its
+# default. For most of these that is harmless convergence, but three of them
+# are not convergence at all —
+#
+#   APP_SSH_USER   arms a new account and takes docker + sudo + the sudoers.d
+#                  grant back from the one recorded in $STATE_DIR/deploy_user,
+#                  which is the account KAMAL_SSH_USER names and deploys with
+#   DB_USER        REASSIGN OWNED and NOLOGIN move the application's tables and
+#                  its ability to log in to a different role, while the
+#                  deployed DATABASE_URL still names the old one
+#   BACKUP_S3_URI  regenerates /usr/local/bin/collavre-pg-backup without the
+#                  upload, so the nightly dump quietly stops leaving the host
+#
+# — and the first two are triggered by a bare `FORCE=1` re-run, which is what
+# this page and the runbook both advertise. So the question is not what the
+# value is, it is whether the run was *asked* for it. A named setting is an
+# instruction and goes through, whatever it says; an unnamed one that disagrees
+# with the provisioned config is an omission, and is refused before anything
+# is installed or rotated.
+#
+# ACK_CONFIG_RESET=1 accepts the listed defaults for operators who do mean to
+# reset them, so the guard is a stop rather than a dead end.
+refuse_defaulted_config_change() {
+  local state_dir="${1:-$STATE_DIR}" supplied="${2:-$SUPPLIED_SETTINGS}"
+  local env_file="$state_dir/launch.env" name prior now drift='' replay='' pair file
+
+  # Recorded as they are found, so the replay command the refusal prints is
+  # built from the same comparison that refused — a second pass over the file
+  # could print a line that does not clear the guard it is offered for.
+  note_drift() {
+    drift="$drift    $1: host has '$2', this run would apply '$3'"$'\n'
+    replay="$replay$(printf '%s=%q ' "$1" "$2")"
+  }
+
+  if [ -f "$env_file" ]; then
+    # Driven by the current setting list rather than by the file's lines, so a
+    # value this revision no longer has, or a line an editor mangled, cannot be
+    # turned into an indirect expansion of an arbitrary name.
+    for name in $LAUNCH_SETTINGS; do
+      case " $supplied " in *" $name "*) continue ;; esac
+      grep -q "^$name=" "$env_file" || continue
+      prior="$(sed -n "s/^$name=//p" "$env_file" | head -1)"
+      now="${!name}"
+      [ "$prior" = "$now" ] && continue
+      note_drift "$name" "$prior" "$now"
+    done
+  else
+    # Provisioned before launch.env existed. The two settings that rotate a
+    # live credential are still answerable from the state files that predate
+    # it, so the upgrade path is covered for the cases that can hurt rather
+    # than left open until the next re-run happens to record the defaults.
+    for pair in deploy_user:APP_SSH_USER db_user:DB_USER; do
+      file="${pair%%:*}"; name="${pair##*:}"
+      [ -f "$state_dir/$file" ] || continue
+      case " $supplied " in *" $name "*) continue ;; esac
+      prior="$(cat "$state_dir/$file")"
+      now="${!name}"
+      if [ -n "$prior" ] && [ "$prior" != "$now" ]; then
+        note_drift "$name" "$prior" "$now"
+      fi
+    done
+  fi
+  unset -f note_drift
+
+  [ -n "$drift" ] || return 0
+  if [ "${ACK_CONFIG_RESET:-0}" = "1" ]; then
+    log "ACK_CONFIG_RESET=1 — applying defaults over the provisioned values:" \
+        "$(printf '\n%s' "$drift")"
+    return 0
+  fi
+
+  # One argument built with ANSI-C newlines rather than several joined by die's
+  # own space: the recovery below has to arrive on its own line to be pasted,
+  # and $(printf '...\n') cannot put it there — command substitution strips the
+  # trailing newline, so the next argument would land on the same line as the
+  # command it is meant to follow.
+  die "REFUSING: this run would change settings it was not asked to change."$'\n\n'\
+"$drift"$'\n'\
+"Each of these was chosen when the host was provisioned and is not set on this
+run, so the value above is this script's default rather than a decision.
+Applied, APP_SSH_USER and DB_USER do not converge the host: they rotate the
+deploy account and the database role out from under the running deployment,
+whose .env.production still names the old ones."$'\n\n'\
+"Nothing has been changed. Repeat them to converge the host as it is:"$'\n\n'\
+"    sudo ${replay}FORCE=1 bash script/lightsail_launch.sh"$'\n\n'\
+"or set ACK_CONFIG_RESET=1 if you do mean to reset them to the defaults.
+The host's own record of what it was given is $env_file."
+}
+
+refuse_defaulted_config_change
 
 # cloud-init and unattended-upgrades hold the dpkg lock during early boot;
 # DPkg::Lock::Timeout makes apt wait for them instead of failing outright.
@@ -1654,6 +1770,8 @@ Collavre Lightsail host — provisioned $(date -Is)
   PostgreSQL       $PG_MAJOR, listening on localhost + $DB_BIND_ADDRESS only
   database         $DB_NAME owned by $DB_USER
   db password      $STATE_DIR/db_password (root only)$PASSWORD_NOTE
+  launch config    $STATE_DIR/launch.env — a re-run applies every setting, so
+                   repeat these on the command line or it is refused
   backups          /var/backups/collavre, nightly at $BACKUP_AT, ${BACKUP_RETENTION_DAYS}d retention
   log              $LOG_FILE
 
@@ -1672,6 +1790,18 @@ Open ports 80 and 443 in the Lightsail console firewall (Networking tab).
 Never open 5432 there.
 TXT
 }
+
+# What this run was configured with, so the next one can tell an omitted
+# override from a deliberate default (refuse_defaulted_config_change). Written
+# only here, after every step has succeeded: a run that died halfway must not
+# leave a record claiming the host is configured the way it was asked to be.
+# No DB_PASSWORD — it has its own 0600 file, and this one is world-readable
+# because the answers in it ("which deploy user?", "which database?") are what
+# the runbook sends operators here to read.
+{ for _s in $LAUNCH_SETTINGS; do printf '%s=%s\n' "$_s" "${!_s}"; done; } \
+  > "$STATE_DIR/launch.env"
+chmod 0644 "$STATE_DIR/launch.env"
+unset _s
 
 touch "$SUMMARY"
 chmod 0600 "$SUMMARY"

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -1086,11 +1086,12 @@ install_downloaded_file() {
 # Keep a managed block in a config file equal to $content, keyed by a marker.
 # Added on the first run; on later runs the body is replaced in place, so a
 # FORCE=1 re-run with a changed DOCKER_SUBNETS or INSTANCE_HOSTNAME converges
-# the host instead of leaving the previous value in force. In place, not
-# delete-and-append: pg_hba.conf is first-match-wins, and moving the rule to
-# the end of the file could park it behind one that already rejects.
+# the host instead of leaving the previous value in force. The optional fourth
+# argument `leading` moves the block ahead of every unmanaged line. PostgreSQL's
+# caller uses it because pg_hba.conf is first-match-wins and even an existing
+# managed block must move ahead of an operator's earlier broad reject.
 ensure_block() {
-  local file="$1" marker="$2" content="$3"
+  local file="$1" marker="$2" content="$3" placement="${4:-keep}"
   local begin="# BEGIN collavre:$marker" end="# END collavre:$marker"
 
   # Resolved before anything else, and not only for the rename below: the
@@ -1129,7 +1130,19 @@ ensure_block() {
              "file it replaces, so the collavre:$marker block was NOT added and" \
              "$file is untouched." ;;
     esac
-    if ! {
+    if [ "$placement" = leading ]; then
+      if ! {
+	printf '%s (managed by script/lightsail_launch.sh)\n' "$begin"
+	printf '%s\n' "$content"
+	printf '%s\n\n' "$end"
+	cat "$file"
+      } > "$tmp"; then
+	rm -f "$tmp"
+	die "$file: could not write the leading collavre:$marker block to a" \
+	    "staging file beside it — is $(dirname "$file") full? $file is" \
+	    "untouched."
+      fi
+    elif ! {
       printf '\n%s (managed by script/lightsail_launch.sh)\n' "$begin"
       printf '%s\n' "$content"
       printf '%s\n' "$end"
@@ -1159,17 +1172,38 @@ ensure_block() {
   # index() rather than an anchored match, so awk sees exactly the lines the
   # grep above found. END exits non-zero on an unterminated block (END marker
   # before BEGIN), which would otherwise swallow the rest of the file.
-  if ! BLOCK_BEGIN="$begin" BLOCK_END="$end" BLOCK_BODY="$content" awk '
+  if ! BLOCK_BEGIN="$begin" BLOCK_END="$end" BLOCK_BODY="$content" \
+       BLOCK_PLACEMENT="$placement" awk '
       BEGIN { b = ENVIRON["BLOCK_BEGIN"]; e = ENVIRON["BLOCK_END"] }
+      BEGIN {
+	leading = ENVIRON["BLOCK_PLACEMENT"] == "leading"
+	if (leading) {
+	  print b " (managed by script/lightsail_launch.sh)"
+	  print ENVIRON["BLOCK_BODY"]
+	  print e
+	  print ""
+	}
+      }
       !inside && index($0, b) {
         inside = 1
-        print b " (managed by script/lightsail_launch.sh)"
-        print ENVIRON["BLOCK_BODY"]
-        print e
+	if (!leading) {
+	  print b " (managed by script/lightsail_launch.sh)"
+	  print ENVIRON["BLOCK_BODY"]
+	  print e
+	}
         next
       }
-      inside && index($0, e) { inside = 0; next }
+      inside && index($0, e) {
+	inside = 0
+	if (leading) skip_old_separator = 1
+	next
+      }
       inside { next }
+      leading && skip_old_separator && $0 == "" {
+	skip_old_separator = 0
+	next
+      }
+      { skip_old_separator = 0 }
       { print }
       END { if (inside) exit 1 }
     ' "$file" > "$tmp"; then
@@ -2728,6 +2762,13 @@ scan_ssh_config_file() {
 	    break
 	  }
 	  ;;
+	authorizedkeysfile|allowusers|denyusers|allowgroups|denygroups)
+	  # The user-only effective probe below cannot evaluate a destination
+	  # path or admission rule that changes with Address/Host/listener
+	  # context. Refuse the ambiguity before the account receives privilege.
+	  SSH_CONFIG_SCAN_UNSAFE="$canonical:$line_no:${line#"${line%%[![:space:]]*}"}"
+	  break
+	  ;;
       esac
     fi
   done < "$file"
@@ -2743,6 +2784,168 @@ find_unsafe_ssh_match() {
   scan_ssh_config_file "$conf_dir/sshd_config" "$conf_dir"
   printf '%s\n' "$SSH_CONFIG_SCAN_UNSAFE"
   unset SSH_CONFIG_SCAN_CONTEXTUAL SSH_CONFIG_SCAN_UNSAFE SSH_CONFIG_SCAN_STACK
+}
+
+# verify_ssh_key_destination <effective config file> <user> <home> <target>
+#
+# Refuse to populate a hard-coded authorized_keys file unless sshd's effective
+# AuthorizedKeysFile list for the deploy account includes that exact path.
+# Relative paths are resolved below the account's home, matching sshd. The
+# common %h, %u and %U tokens are expanded; wildcard paths are deliberately not
+# guessed at because proving that a glob selects the target is not enough to
+# prove it is the file sshd will safely read under StrictModes.
+verify_ssh_key_destination() {
+  local src="$1" user="$2" home="$3" target="$4"
+  local effective paths path expanded uid sentinel=$'\001'
+  if [ -n "$src" ]; then
+    effective="$(cat "$src")" ||
+      die "SSH AuthorizedKeysFile could not be read for '$user'. Nothing has" \
+	  "been granted; correct the test input and re-run."
+  elif ! effective="$(sshd -T -C "user=$user" 2>/dev/null)"; then
+    die "SSH AuthorizedKeysFile could not be verified for '$user':" \
+	"'sshd -T -C user=$user' rejected or could not read the configuration." \
+	"Nothing has been granted. Run 'sshd -t', correct the configuration and" \
+	"re-run."
+  fi
+
+  paths="$(printf '%s\n' "$effective" |
+    awk 'tolower($1) == "authorizedkeysfile" {
+      for (i = 2; i <= NF; i++) print $i
+    }')"
+  [ -n "$paths" ] ||
+    die "SSH AuthorizedKeysFile could not be verified for '$user': sshd did" \
+	"not report the setting. Nothing has been granted. Correct the SSH" \
+	"configuration and re-run."
+
+  while IFS= read -r path; do
+    case "$path" in
+      *'*'*|*'?'*) continue ;;
+    esac
+    expanded="${path//%%/$sentinel}"
+    expanded="${expanded//%h/$home}"
+    expanded="${expanded//%u/$user}"
+    if [[ "$expanded" = *%U* ]]; then
+      uid="$(id -u "$user" 2>/dev/null)" || continue
+      expanded="${expanded//%U/$uid}"
+    fi
+    expanded="${expanded//$sentinel/%}"
+    [[ "$expanded" = /* ]] || expanded="${home%/}/$expanded"
+    [ "$expanded" = "$target" ] && return 0
+  done <<< "$paths"
+
+  die "SSH AuthorizedKeysFile for '$user' does not include '$target'." \
+      "Provisioning will not install a key in a file sshd does not read, or" \
+      "revoke the previous deploy user's access on that assumption. Restore" \
+      "'.ssh/authorized_keys' (or an equivalent %h/%u path) in sshd_config" \
+      "and re-run."
+}
+
+# ssh_pattern_list_matches <name> <newline-separated patterns> [user]
+#
+# Apply OpenSSH's positive/negated pattern-list rule for the * and ? forms used
+# by AllowUsers/DenyUsers/AllowGroups/DenyGroups. A relevant USER@HOST rule
+# other than USER@* cannot be proved from a user-only sshd -T probe and returns
+# 2 so the caller can fail closed.
+ssh_pattern_list_matches() {
+  local name="$1" patterns="$2" kind="${3:-group}"
+  local pattern candidate host negated matched=1
+  while IFS= read -r pattern; do
+    [ -n "$pattern" ] || continue
+    negated=0
+    case "$pattern" in
+      !*) negated=1; pattern="${pattern#!}" ;;
+    esac
+    candidate="$pattern"
+    if [ "$kind" = user ] && [[ "$pattern" = *@* ]]; then
+      candidate="${pattern%@*}"
+      host="${pattern##*@}"
+      [[ "$name" = $candidate ]] || continue
+      [ "$host" = '*' ] || return 2
+    fi
+    [[ "$name" = $candidate ]] || continue
+    [ "$negated" -eq 0 ] || return 1
+    matched=0
+  done <<< "$patterns"
+  return "$matched"
+}
+
+# verify_ssh_admission_controls <effective config file> <user>
+#
+# sshd -T exits successfully even when AllowUsers/DenyUsers or group controls
+# reject the supplied user. Evaluate the reported lists after the final Docker
+# group grant, before the working predecessor loses sudo and Docker access.
+verify_ssh_admission_controls() {
+  local src="$1" user="$2" effective patterns groups group rc allowed
+  local deny_groups allow_groups
+  if [ -n "$src" ]; then
+    effective="$(cat "$src")" ||
+      die "SSH admission controls could not be read for '$user'. The previous" \
+	  "deploy user's privileged access will not be revoked."
+  elif ! effective="$(sshd -T -C "user=$user" 2>/dev/null)"; then
+    die "SSH admission controls could not be verified for '$user':" \
+	"'sshd -T -C user=$user' failed. The previous deploy user's privileged" \
+	"access will not be revoked. Run 'sshd -t', correct the configuration" \
+	"and re-run."
+  fi
+
+  patterns="$(printf '%s\n' "$effective" |
+    awk 'tolower($1) == "denyusers" { print $2 }')"
+  if [ -n "$patterns" ]; then
+    ssh_pattern_list_matches "$user" "$patterns" user
+    rc=$?
+    [ "$rc" -ne 0 ] ||
+      die "SSH DenyUsers rejects '$user'. The previous deploy user's" \
+	  "privileged access will not be revoked. Correct the admission rule" \
+	  "and re-run."
+    [ "$rc" -ne 2 ] ||
+      die "SSH DenyUsers contains a host-scoped pattern for '$user' that a" \
+	  "user-only verification cannot prove reachable. The previous deploy" \
+	  "user's privileged access will not be revoked. Use an unconditional" \
+	  "rule or remove the restriction, then re-run."
+  fi
+
+  patterns="$(printf '%s\n' "$effective" |
+    awk 'tolower($1) == "allowusers" { print $2 }')"
+  if [ -n "$patterns" ]; then
+    ssh_pattern_list_matches "$user" "$patterns" user
+    rc=$?
+    [ "$rc" -eq 0 ] ||
+      die "SSH AllowUsers does not unconditionally admit '$user'. The previous" \
+	  "deploy user's privileged access will not be revoked. Add '$user' to" \
+	  "the rule without an unverified host restriction and re-run."
+  fi
+
+  deny_groups="$(printf '%s\n' "$effective" |
+    awk 'tolower($1) == "denygroups" { print $2 }')"
+  allow_groups="$(printf '%s\n' "$effective" |
+    awk 'tolower($1) == "allowgroups" { print $2 }')"
+  [ -n "$deny_groups$allow_groups" ] || return 0
+
+  groups="$(id -Gn "$user" 2>/dev/null)" ||
+    die "SSH group admission could not be verified because the groups for" \
+	"'$user' could not be read. The previous deploy user's privileged" \
+	"access will not be revoked."
+
+  if [ -n "$deny_groups" ]; then
+    for group in $groups; do
+      if ssh_pattern_list_matches "$group" "$deny_groups"; then
+	die "SSH DenyGroups rejects '$user' through group '$group'. The previous" \
+	    "deploy user's privileged access will not be revoked. Correct the" \
+	    "admission rule and re-run."
+      fi
+    done
+  fi
+
+  if [ -n "$allow_groups" ]; then
+    allowed=1
+    for group in $groups; do
+      ssh_pattern_list_matches "$group" "$allow_groups" && allowed=0
+    done
+    [ "$allowed" -eq 0 ] ||
+      die "SSH AllowGroups admits none of '$user''s groups ($groups). The" \
+	  "previous deploy user's privileged access will not be revoked. Add" \
+	  "one of those groups to the rule and re-run."
+  fi
 }
 
 verify_ssh_hardening() {
@@ -2763,8 +2966,8 @@ verify_ssh_hardening() {
     unsafe_match="$(find_unsafe_ssh_match "$conf_dir")"
     [ -z "$unsafe_match" ] ||
       die "SSH hardening cannot be verified for every connection: a Match" \
-	"Address/Host/LocalAddress/LocalPort/RDomain block weakens" \
-	"authentication at $unsafe_match." \
+	"Address/Host/LocalAddress/LocalPort/RDomain block changes" \
+	"authentication, key lookup or admission at $unsafe_match." \
 	"The user-only sshd test below cannot evaluate that context. Remove" \
 	"or harden the directive and re-run before granting '$deploy_user'" \
 	"sudo or Docker access."
@@ -3184,6 +3387,13 @@ adopt_legacy_ssh_key_marker "$APP_SSH_USER"
 if ! id -u "$APP_SSH_USER" >/dev/null 2>&1; then
   adduser --disabled-password --gecos "Collavre deploy" "$APP_SSH_USER"
 fi
+APP_HOME="$(getent passwd "$APP_SSH_USER" | cut -d: -f6)"
+AUTH_KEYS="$APP_HOME/.ssh/authorized_keys"
+# The file this script writes must be one sshd actually reads for this account.
+# Check after account creation (so %h/%u/%U can resolve) but before recording or
+# granting sudo. A custom AuthorizedKeysFile is supported only when it expands
+# to the same target; otherwise leave the host's access model untouched.
+verify_ssh_key_destination "" "$APP_SSH_USER" "$APP_HOME" "$AUTH_KEYS"
 # Before the grant, not after it. Everything from here to the revocation at the
 # end of step 4 — the whole Docker install — is a window in which an interrupted
 # run would otherwise leave this account holding sudo and docker with nothing on
@@ -3198,7 +3408,10 @@ in_group "$APP_SSH_USER" sudo && SUDO_GROUP_WAS_PRESENT=1
 usermod -aG sudo "$APP_SSH_USER"
 # Match Group is resolved from the account's current memberships, so the check
 # before user creation cannot see an override that starts applying here.
-if ! ( verify_ssh_hardening "" /etc/ssh "$SSH_RELOAD_STATE" "$APP_SSH_USER" 1 ); then
+if ! (
+  verify_ssh_hardening "" /etc/ssh "$SSH_RELOAD_STATE" "$APP_SSH_USER" 1 &&
+  verify_ssh_key_destination "" "$APP_SSH_USER" "$APP_HOME" "$AUTH_KEYS"
+); then
   if [ "$SUDO_GROUP_WAS_PRESENT" -eq 0 ]; then
     gpasswd -d "$APP_SSH_USER" sudo >/dev/null 2>&1 ||
       die "SSH hardening failed after '$APP_SSH_USER' joined sudo, and the" \
@@ -3216,9 +3429,7 @@ fi
 install -d -m 0755 /etc/sudoers.d
 ensure_sudoers "$APP_SSH_USER"
 
-APP_HOME="$(getent passwd "$APP_SSH_USER" | cut -d: -f6)"
 APP_SSH_GROUP="$(install_deploy_ssh_dir "$APP_SSH_USER" "$APP_HOME")"
-AUTH_KEYS="$APP_HOME/.ssh/authorized_keys"
 touch "$AUTH_KEYS"
 
 # stage_authorized_keys <authorized_keys> — echo the path of a staging file
@@ -3733,7 +3944,11 @@ in_group "$APP_SSH_USER" docker && DOCKER_GROUP_WAS_PRESENT=1
 usermod -aG docker "$APP_SSH_USER"
 # Recheck for the same reason as the sudo grant above. An operator's
 # `Match Group docker` block does not apply until this membership exists.
-if ! ( verify_ssh_hardening "" /etc/ssh "$SSH_RELOAD_STATE" "$APP_SSH_USER" 1 ); then
+if ! (
+  verify_ssh_hardening "" /etc/ssh "$SSH_RELOAD_STATE" "$APP_SSH_USER" 1 &&
+  verify_ssh_key_destination "" "$APP_SSH_USER" "$APP_HOME" "$AUTH_KEYS" &&
+  verify_ssh_admission_controls "" "$APP_SSH_USER"
+); then
   if [ "$DOCKER_GROUP_WAS_PRESENT" -eq 0 ]; then
     gpasswd -d "$APP_SSH_USER" docker >/dev/null 2>&1 ||
       die "SSH hardening failed after '$APP_SSH_USER' joined docker, and the" \
@@ -3900,7 +4115,7 @@ mv -f "$PG_CONF_TMP" "$PG_CONF_REAL"
 
 # Containers authenticate with a password over the docker bridge.
 ensure_block "$PG_CONF_DIR/pg_hba.conf" docker \
-  "host    all    all    $DOCKER_SUBNETS    scram-sha-256"
+  "host    all    all    $DOCKER_SUBNETS    scram-sha-256" leading
 
 systemctl enable postgresql
 systemctl restart postgresql

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -391,15 +391,49 @@ in_group() {
   id -nG "$1" 2>/dev/null | tr ' ' '\n' | grep -qxF "$2"
 }
 
-revoke_prior_deploy_user() {
-  local current="$1" prior_file="${2:-$STATE_DIR/deploy_user}" prior group held
-  [ -f "$prior_file" ] || { printf '%s\n' "$current" > "$prior_file"; return 0; }
-  prior="$(cat "$prior_file")"
-  if [ -z "$prior" ] || [ "$prior" = "$current" ] ||
-     ! id -u "$prior" >/dev/null 2>&1; then
-    printf '%s\n' "$current" > "$prior_file"
-    return 0
+# record_deploy_user_grant <user> [set file] [single-name marker]
+#
+# The set of accounts this script has granted root-equivalent access to and has
+# not taken it back from, one name per line.
+#
+# A set rather than the single predecessor an earlier revision kept, because one
+# name cannot describe a host that has rotated twice. A revocation that fails
+# leaves the marker naming the account it could not strip, so the *next*
+# rotation retries that one and advances the marker straight past the account in
+# between — which goes on holding docker and sudo with nothing on the host
+# recording that it does. Measured on the extracted function:
+#
+#   A -> B (revoke of A fails) -> C   B left holding 'docker sudo', marker at C
+#
+# and no failure is needed to reach the same state. The grants are in steps 3
+# and 4 and the revocation is at the end of step 4, so an interruption anywhere
+# across the Docker install — an apt run, on a 512MB instance — strands B
+# identically. Which is why this is called *before* the grant rather than after
+# it: a name in this file that turns out to hold neither group costs a re-read
+# of two group lists, and a name missing from it is root access nobody is
+# looking for.
+record_deploy_user_grant() {
+  local user="$1" set_file="${2:-$STATE_DIR/deploy_users}"
+  local prior_file="${3:-$STATE_DIR/deploy_user}"
+  # Upgrade path. On a host provisioned by the earlier revision the single
+  # marker names the one predecessor it knew about, and it is exactly the
+  # account most likely to be unrevoked — seeding from it means the fix for
+  # forgetting accounts does not begin by forgetting one.
+  if [ ! -f "$set_file" ] && [ -s "$prior_file" ]; then
+    grep -v '^[[:space:]]*$' "$prior_file" > "$set_file" || true
   fi
+  grep -qxF "$user" "$set_file" 2>/dev/null ||
+    printf '%s\n' "$user" >> "$set_file"
+}
+
+# revoke_deploy_user_access <user> <successor>
+#
+# Takes docker and sudo back from one replaced account. Returns 0 when the
+# account holds neither group afterwards, non-zero when it still holds one — so
+# the caller decides whether to keep retrying it, rather than this deciding by
+# where it writes a marker.
+revoke_deploy_user_access() {
+  local prior="$1" current="$2" group held
 
   for group in docker sudo; do
     in_group "$prior" "$group" || continue
@@ -437,14 +471,46 @@ revoke_prior_deploy_user() {
         "it still has root-equivalent access to this host. Take it back by hand," \
         "both of these — the group can be primary AND a member entry at once:" \
         "usermod -g $prior $prior; for g in$held; do gpasswd -d $prior \$g; done"
-    # Deliberately leave the marker naming the user that still holds the group,
-    # so the next run retries the revocation instead of forgetting it.
-    return 0
+    # Deliberately kept in the set by the caller, so the next run retries the
+    # revocation instead of forgetting it.
+    return 1
   fi
 
   log "WARNING: '$prior' is no longer in docker or sudo but can still log in;" \
       "remove it by hand once you can reach the host as '$current':" \
       "deluser --remove-home $prior"
+}
+
+revoke_prior_deploy_user() {
+  local current="$1" prior_file="${2:-$STATE_DIR/deploy_user}"
+  local set_file="${3:-${prior_file%/*}/deploy_users}" prior kept=''
+
+  # Not a no-op on the ordinary path: this is what seeds the set on a host the
+  # earlier revision provisioned, and what puts $current in it on a first run,
+  # so that a *later* rotation has something to revoke.
+  record_deploy_user_grant "$current" "$set_file" "$prior_file"
+
+  while read -r prior; do
+    if [ -z "$prior" ] || [ "$prior" = "$current" ]; then
+      # $current holds both groups on purpose. It stays in the set because the
+      # run that replaces it is the one that takes them back.
+      [ -z "$prior" ] || kept="$kept$prior"$'\n'
+      continue
+    fi
+    # An account that no longer exists cannot hold either group through, so
+    # there is nothing left for a later run to retry.
+    id -u "$prior" >/dev/null 2>&1 || continue
+    revoke_deploy_user_access "$prior" "$current" || kept="$kept$prior"$'\n'
+  done < "$set_file"
+
+  # Rewritten from what the loop kept rather than appended to, so an account
+  # that was revoked leaves the set and one that was not stays in it. Both
+  # markers are written at the end: the single-name one is what the runbook and
+  # refuse_defaulted_config_change read for "who is the deploy user", which is
+  # $current whether or not its predecessor could be stripped — the earlier
+  # revision pinned it to the predecessor on that path, so a failed revocation
+  # also made the host misreport who it belongs to.
+  printf '%s' "$kept" > "$set_file"
   printf '%s\n' "$current" > "$prior_file"
 }
 
@@ -1222,6 +1288,11 @@ adopt_legacy_ssh_key_marker "$APP_SSH_USER"
 if ! id -u "$APP_SSH_USER" >/dev/null 2>&1; then
   adduser --disabled-password --gecos "Collavre deploy" "$APP_SSH_USER"
 fi
+# Before the grant, not after it. Everything from here to the revocation at the
+# end of step 4 — the whole Docker install — is a window in which an interrupted
+# run would otherwise leave this account holding sudo and docker with nothing on
+# the host recording that it does, and no later run able to find it.
+record_deploy_user_grant "$APP_SSH_USER"
 usermod -aG sudo "$APP_SSH_USER"
 install -d -m 0755 /etc/sudoers.d
 ensure_sudoers "$APP_SSH_USER"
@@ -1316,9 +1387,25 @@ install_authorized_keys() {
 # refusing the very key the run just installed. Setting both first means the
 # file is correct at every instant, and the caller's chown/chmod becomes a
 # no-op rather than a load-bearing step.
+#
+# Which is why a chown that fails refuses the install rather than being
+# suppressed. Suppressing it puts the root-owned 0600 file at the live path,
+# and the caller's own `chown "$APP_SSH_USER:$APP_SSH_GROUP" "$AUTH_KEYS"` a few
+# lines later is not a recovery: it is the same command on the same names, so it
+# fails for whatever reason this one just did and `set -e` ends the run with the
+# unreadable file already installed. Declining to install leaves the live file
+# as it was — still holding a key that works — so the cost is a run rather than
+# the host, and on APP_SSH_USER=ubuntu the host is the only way in.
 install_staged_authorized_keys() {
   local tmp="$1" auth_keys="$2"
-  [ -z "${APP_SSH_USER:-}" ] || chown "$APP_SSH_USER:${APP_SSH_GROUP:-$APP_SSH_USER}" "$tmp" 2>/dev/null || true
+  if [ -n "${APP_SSH_USER:-}" ] &&
+     ! chown "$APP_SSH_USER:${APP_SSH_GROUP:-$APP_SSH_USER}" "$tmp" 2>/dev/null; then
+    rm -f "$tmp"
+    log "WARNING: could not give a rewritten $auth_keys to" \
+        "'$APP_SSH_USER' — sshd refuses an authorized_keys it cannot read as" \
+        "the user, so it was NOT installed and the live file is untouched"
+    return 1
+  fi
   chmod 0600 "$tmp"
   mv -f "$tmp" "$auth_keys"
 }
@@ -1354,8 +1441,11 @@ revoke_prior_ssh_key() {
       # whose log says the rotation succeeded. The `|| true` above — needed so
       # `set -e` does not fire on grep's "no lines selected" — is what hides
       # the error, so the successor's presence has to be re-established here.
-      if grep -qxF "$SSH_PUBLIC_KEY" "$tmp"; then
-        install_staged_authorized_keys "$tmp" "$auth_keys"
+      # The install is part of the condition rather than a statement after it:
+      # it declines to install a file it could not give to the user, and a
+      # withdrawal that did not reach the live file has withdrawn nothing.
+      if grep -qxF "$SSH_PUBLIC_KEY" "$tmp" &&
+         install_staged_authorized_keys "$tmp" "$auth_keys"; then
         log "withdrew the SSH key this script installed on a previous run"
       else
         rm -f "$tmp"
@@ -1398,8 +1488,8 @@ dedupe_authorized_keys() {
   tmp="$(mktemp "$auth_keys.sort.XXXXXX")"
   if sort -u -o "$tmp" "$auth_keys" 2>/dev/null &&
      { [ ! -s "$auth_keys" ] || [ -s "$tmp" ]; } &&
-     { [ -z "$must_keep" ] || grep -qxF "$must_keep" "$tmp"; }; then
-    install_staged_authorized_keys "$tmp" "$auth_keys"
+     { [ -z "$must_keep" ] || grep -qxF "$must_keep" "$tmp"; } &&
+     install_staged_authorized_keys "$tmp" "$auth_keys"; then
     return 0
   fi
   rm -f "$tmp"

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -2919,13 +2919,54 @@ record_db_role_grant "$DB_USER" ||
 
 SQL_FILE="$(mktemp /tmp/collavre-db.XXXXXX.sql)"
 trap 'rm -f "$SQL_FILE"' EXIT
-ESCAPED_PASSWORD="${DB_PASSWORD//\'/\'\'}"
+# Doubling the quote through a variable rather than through `\'`, which does not
+# mean the same thing on every bash. This is NOT a production defect being
+# fixed: on the bash Lightsail runs the previous form was already correct.
+# Measured, same input `it's`, same expression `${p//\'/\'\'}`:
+#
+#   bash 5.2.15  (Ubuntu, what this script runs on; also CI)   it''s
+#   bash 3.2.57  (macOS, what a developer runs the suite on)   it\'\'s
+#
+# Two reasons to spell it this way regardless. The line escapes a credential
+# into a SQL literal, and it should not be one whose meaning is decided by the
+# interpreter version — on 3.2 psql reads the `\'` as a meta-command and stops
+# with "invalid command", after write_state_file above has already recorded the
+# password, leaving a host that records a credential its role does not have.
+#
+# And it is what lets the suite assert this at all. Case 141 generates with a
+# quoted password and checks the statement; against the previous form that
+# assertion was green on Ubuntu and red on macOS for a reason having nothing to
+# do with the escaping, so it could not be written. Same platform split as the
+# `head -c 0` fixture two commits back, pointing the other way.
+SQL_QUOTE="'"
+ESCAPED_PASSWORD="${DB_PASSWORD//$SQL_QUOTE/$SQL_QUOTE$SQL_QUOTE}"
 cat > "$SQL_FILE" <<SQL
 \set ON_ERROR_STOP on
 SELECT format('CREATE ROLE %I LOGIN', '$DB_USER')
 WHERE NOT EXISTS (SELECT FROM pg_roles WHERE rolname = '$DB_USER')
 \gexec
-ALTER ROLE "$DB_USER" PASSWORD '$ESCAPED_PASSWORD';
+-- LOGIN on the ALTER as well as on the CREATE, because the CREATE is the
+-- statement a rotation back to a previous name never reaches. reassign_prior_db_role
+-- takes LOGIN from the role it replaces, so after DB_USER goes A -> B -> A the
+-- role 'A' exists, the \gexec produces no statement for it, and an ALTER that
+-- sets only the password leaves it NOLOGIN. Measured on a real cluster:
+--
+--   run                  shipped                       with LOGIN here
+--   1  DB_USER=a         connects                      connects
+--   2  DB_USER=b         connects, a -> NOLOGIN        same
+--   3  DB_USER=a         FATAL: role "a" is not        connects
+--                        permitted to log in
+--
+-- Every statement succeeds on that third run, so ON_ERROR_STOP has nothing to
+-- stop on and the summary hands out a DATABASE_URL naming a role that cannot
+-- open a connection. And run 3 leaves *both* roles NOLOGIN — the rotation
+-- correctly disarms 'b' on its way past — so the cluster is left with no
+-- application login at all, rather than with a working previous one.
+--
+-- Idempotent for the ordinary case: LOGIN on a role that has it changes
+-- nothing, and this ALTER already ran unconditionally against whatever DB_USER
+-- names, so it grants nothing to a role it was not already touching.
+ALTER ROLE "$DB_USER" LOGIN PASSWORD '$ESCAPED_PASSWORD';
 SELECT format('CREATE DATABASE %I OWNER %I', '$DB_NAME', '$DB_USER')
 WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = '$DB_NAME')
 \gexec

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -1437,7 +1437,8 @@ record_deploy_user_grant() {
 # the caller decides whether to keep retrying it, rather than this deciding by
 # where it writes a marker.
 revoke_deploy_user_access() {
-  local prior="$1" current="$2" group held sudoers_name
+  local prior="$1" current="$2" group held sudoers_name sudoers_path
+  local prior_sudoers current_sudoers sudoers_dir="${3:-/etc/sudoers.d}"
 
   for group in docker sudo; do
     in_group "$prior" "$group" || continue
@@ -1481,12 +1482,28 @@ revoke_deploy_user_access() {
   fi
 
   sudoers_name="90-collavre-${prior//[^A-Za-z0-9_-]/_}"
-  if ! rm -f "/etc/sudoers.d/$sudoers_name" ||
-     [ -e "/etc/sudoers.d/$sudoers_name" ]; then
-    log "WARNING: could NOT remove /etc/sudoers.d/$sudoers_name; '$prior'" \
-	"still has this script's passwordless sudo grant, so the SSH cutover" \
-	"remains pending"
-    return 1
+  sudoers_path="$sudoers_dir/$sudoers_name"
+  prior_sudoers="$prior ALL=(ALL:ALL) NOPASSWD:ALL"
+  current_sudoers="$current ALL=(ALL:ALL) NOPASSWD:ALL"
+  if [ -e "$sudoers_path" ]; then
+    if cmp -s <(printf '%s\n' "$prior_sudoers") "$sudoers_path"; then
+      if ! rm -f "$sudoers_path" || [ -e "$sudoers_path" ]; then
+	log "WARNING: could NOT remove $sudoers_path; '$prior' still has this" \
+	    "script's passwordless sudo grant, so the SSH cutover remains pending"
+	return 1
+      fi
+    elif cmp -s <(printf '%s\n' "$current_sudoers") "$sudoers_path"; then
+      # Linux usernames that differ only in punctuation can map to the same
+      # sudoers filename. ensure_sudoers has already replaced the predecessor
+      # rule with this exact successor rule; deleting by filename here would
+      # disarm the account that just proved the cutover.
+      log "preserved $sudoers_path because it belongs to successor '$current'"
+    elif grep -qxF "$prior_sudoers" "$sudoers_path" 2>/dev/null; then
+      log "WARNING: $sudoers_path contains '$prior''s grant plus other content;" \
+	  "refusing to delete a shared sudoers file. Remove only the predecessor" \
+	  "rule by hand, then retry the SSH cutover."
+      return 1
+    fi
   fi
 
   log "WARNING: '$prior' is no longer in docker or sudo but can still log in;" \
@@ -1573,7 +1590,6 @@ revoke_prior_deploy_user() {
 stage_ssh_cutover() {
   local user="$1" key="$2" current='' prior_key='' need=0
   local nonce nonce_hash key_fingerprint='' pending="$STATE_DIR/ssh_cutover.pending"
-  local key_file="$STATE_DIR/ssh_cutover.key"
   local finalizer="${3:-/usr/local/sbin/collavre-finalize-ssh-cutover}"
   local source="${4:-${BASH_SOURCE[0]}}"
 
@@ -1612,11 +1628,13 @@ stage_ssh_cutover() {
       die "could not fingerprint the staged SSH key"
   fi
 
-  write_state_file "$key_file" "$key"$'\n' 0600 ||
-    die "could not stage the SSH cutover key in $key_file"
+  # The key, its fingerprint and the nonce hash are one atomic record. Keeping
+  # the key in a separately replaced file lets an interrupted same-user re-run
+  # pair an old challenge/fingerprint with a new key and later commit a key
+  # that the successful SSH session never proved.
   write_state_file "$pending" \
     "user=$user"$'\n'"nonce_sha256=$nonce_hash"$'\n'\
-"key_sha256=$key_fingerprint"$'\n' 0600 ||
+"key_sha256=$key_fingerprint"$'\n'"key=$key"$'\n' 0600 ||
     die "could not stage the SSH cutover challenge in $pending"
 
   [ -r "$source" ] ||
@@ -1695,12 +1713,19 @@ ssh_cutover_has_sshd_ancestor() {
 
 finalize_ssh_cutover() {
   local nonce="${1:-}" pending="$STATE_DIR/ssh_cutover.pending"
-  local key_file="$STATE_DIR/ssh_cutover.key" user expected key_fingerprint actual
+  local user expected key_fingerprint actual staged_fingerprint field
 
   [ -s "$pending" ] || die "no SSH cutover is pending"
+  for field in user nonce_sha256 key_sha256 key; do
+    [ "$(grep -c "^$field=" "$pending" 2>/dev/null || true)" -eq 1 ] ||
+      die "$pending is incomplete or ambiguous at '$field'; predecessor access" \
+	  "was not changed. Re-run provisioning to atomically replace the" \
+	  "pending cutover."
+  done
   user="$(sed -n 's/^user=//p' "$pending")"
   expected="$(sed -n 's/^nonce_sha256=//p' "$pending")"
   key_fingerprint="$(sed -n 's/^key_sha256=//p' "$pending")"
+  SSH_PUBLIC_KEY="$(sed -n 's/^key=//p' "$pending")"
   [ -n "$user" ] && [ -n "$expected" ] ||
     die "$pending is incomplete; predecessor access was not changed"
   [ "${SUDO_USER:-}" = "$user" ] ||
@@ -1724,8 +1749,13 @@ finalize_ssh_cutover() {
   [ -s "$AUTH_KEYS" ] ||
     die "$AUTH_KEYS is empty; predecessor access was not changed"
 
-  SSH_PUBLIC_KEY="$(cat "$key_file" 2>/dev/null || true)"
   if [ -n "$SSH_PUBLIC_KEY" ]; then
+    staged_fingerprint="$(ssh_public_key_fingerprint "$SSH_PUBLIC_KEY")" ||
+      die "the staged key in $pending is invalid; predecessor access was not changed"
+    [ "$staged_fingerprint" = "$key_fingerprint" ] ||
+      die "the staged key does not match its pending fingerprint; predecessor" \
+	  "access was not changed. Re-run provisioning to replace the pending" \
+	  "cutover atomically."
     [ -n "$key_fingerprint" ] &&
       ssh_cutover_authenticated_with_key "$user" "$key_fingerprint" ||
       die "this SSH session was not authenticated with the staged key. Reconnect" \
@@ -1752,7 +1782,7 @@ finalize_ssh_cutover() {
     die "one or more predecessor accounts could not be disarmed. The cutover" \
 	"remains pending; repair the reported account and run this command again."
 
-  rm -f "$pending" "$key_file"
+  rm -f "$pending"
   log "SSH cutover finalized from an authenticated session as '$user'." \
       "KAMAL_SSH_USER may now be changed to '$user'."
 }
@@ -3177,6 +3207,7 @@ verify_ssh_hardening() {
   local src="${1:-}" conf_dir="${2:-/etc/ssh}" reload_state="${3:-0}"
   local deploy_user="${4:-${APP_SSH_USER:-collavre}}"
   local require_readable="${5:-0}"
+  local require_auth_info="${6:-0}"
   local effective key value expected offender unsafe_match
   if [ -n "$src" ]; then
     effective="$(cat "$src")"
@@ -3220,17 +3251,28 @@ verify_ssh_hardening() {
     fi
   fi
   for key in passwordauthentication permitrootlogin kbdinteractiveauthentication \
-	     pubkeyauthentication; do
+	     pubkeyauthentication exposeauthinfo; do
+    [ "$key" != exposeauthinfo ] || [ "$require_auth_info" -eq 1 ] || continue
     expected=no
-    [ "$key" != pubkeyauthentication ] || expected=yes
+    case "$key" in pubkeyauthentication|exposeauthinfo) expected=yes ;; esac
     value="$(printf '%s\n' "$effective" |
              awk -v k="$key" 'tolower($1) == k { print $2; exit }')"
     [ -n "$value" ] || {
-      [ "$key" != pubkeyauthentication ] || die \
-	"SSH public-key authentication could not be verified for '$deploy_user':" \
-	"sshd did not report 'pubkeyauthentication'. The previous deploy user's" \
-	"privileged access will not be revoked until the replacement account is" \
-	"proven reachable by key. Correct the SSH configuration and re-run."
+      case "$key" in
+	pubkeyauthentication)
+	  die "SSH public-key authentication could not be verified for" \
+	      "'$deploy_user': sshd did not report 'pubkeyauthentication'. The" \
+	      "previous deploy user's privileged access will not be revoked until" \
+	      "the replacement account is proven reachable by key. Correct the SSH" \
+	      "configuration and re-run."
+	  ;;
+	exposeauthinfo)
+	  die "SSH authentication-key proof could not be enabled for" \
+	      "'$deploy_user': sshd did not report 'exposeauthinfo'. The previous" \
+	      "deploy user's access remains intact. Correct the SSH configuration" \
+	      "and re-run."
+	  ;;
+      esac
       log "WARNING: sshd did not report '$key', so that part of the hardening" \
           "above is unverified"
       continue
@@ -4171,10 +4213,13 @@ fi
 DOCKER_GROUP_WAS_PRESENT=0
 in_group "$APP_SSH_USER" docker && DOCKER_GROUP_WAS_PRESENT=1
 usermod -aG docker "$APP_SSH_USER"
+SSH_AUTH_INFO_REQUIRED=0
+[ -z "$SSH_PUBLIC_KEY" ] || SSH_AUTH_INFO_REQUIRED=1
 # Recheck for the same reason as the sudo grant above. An operator's
 # `Match Group docker` block does not apply until this membership exists.
 if ! (
-  verify_ssh_hardening "" /etc/ssh "$SSH_RELOAD_STATE" "$APP_SSH_USER" 1 &&
+  verify_ssh_hardening "" /etc/ssh "$SSH_RELOAD_STATE" "$APP_SSH_USER" 1 \
+    "$SSH_AUTH_INFO_REQUIRED" &&
   verify_ssh_key_destination "" "$APP_SSH_USER" "$APP_HOME" "$AUTH_KEYS" &&
   verify_ssh_admission_controls "" "$APP_SSH_USER"
 ); then

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -221,6 +221,7 @@ fi
 
 # Cap container logs — an unrotated Rails log fills a Lightsail SSD fast.
 install -d -m 0755 /etc/docker
+DAEMON_JSON_WRITTEN=0
 if [ ! -f /etc/docker/daemon.json ]; then
   cat > /etc/docker/daemon.json <<'JSON'
 {
@@ -228,8 +229,19 @@ if [ ! -f /etc/docker/daemon.json ]; then
   "log-opts": { "max-size": "10m", "max-file": "3" }
 }
 JSON
+  DAEMON_JSON_WRITTEN=1
 fi
-systemctl enable --now docker
+systemctl enable docker
+if [ "$DAEMON_JSON_WRITTEN" -eq 1 ]; then
+  # The package starts the daemon during install, so it is already running with
+  # the stock config by the time we get here — `enable --now` would leave it
+  # that way and the log caps would not apply until something restarted Docker.
+  # Only on the run that wrote the file, so a re-run never bounces live
+  # containers.
+  systemctl restart docker
+else
+  systemctl start docker
+fi
 usermod -aG docker "$APP_SSH_USER"
 
 # --------------------------------------------------------------------------

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -1498,7 +1498,7 @@ allocate_swapfile() {
 # not rotate at all, so sustained Rails output fills a Lightsail SSD, which is
 # the specific failure this block exists to prevent.
 ensure_docker_log_caps() {
-  local file="${1:-/etc/docker/daemon.json}" tmp driver wrote
+  local file="${1:-/etc/docker/daemon.json}" tmp driver max_size wrote
   DAEMON_JSON_CHANGED=0
   # Before either branch, so the create path and the rewrite path name one file
   # even when /etc/docker/daemon.json is a link — and so the rename below cannot
@@ -1612,7 +1612,11 @@ JSON
     return 0
   fi
 
-  if [ "$(jq -r '."log-opts"."max-size" // empty' "$file")" != "" ]; then
+  # Docker treats max-size=-1 as unlimited, so it is not a cap even though it
+  # is a nonempty operator setting. Repair it through the same merge path as a
+  # missing max-size; every other explicit size remains the operator's choice.
+  max_size="$(jq -r '."log-opts"."max-size" // empty' "$file")"
+  if [ -n "$max_size" ] && [ "$max_size" != "-1" ]; then
     return 0
   fi
 
@@ -1656,6 +1660,23 @@ JSON
   mv -f "$tmp" "$file"
   log "added container log caps to the existing $file"
   DAEMON_JSON_CHANGED=1
+}
+
+# Docker daemon logging options are defaults captured when each container is
+# created. Restarting the daemon makes a new default available but does not
+# retrofit containers that already exist.
+warn_existing_containers_keep_log_config() {
+  local containers
+  if ! containers="$(docker ps -aq 2>/dev/null)"; then
+    log "WARNING: Docker's log defaults changed, but existing containers could" \
+	"not be inspected. Any existing container keeps its previous logging" \
+	"configuration until it is recreated."
+    return 0
+  fi
+  [ -n "$containers" ] || return 0
+  log "WARNING: Docker's log cap is a default for newly created containers only." \
+      "Existing containers keep their previous logging configuration. The caps" \
+      "apply to them only after the next './kamal.sh deploy' recreates them."
 }
 
 # Refuse to provision when $PG_MAJOR's cluster is not the one on $DB_PORT.
@@ -3330,6 +3351,7 @@ if [ "$DAEMON_JSON_CHANGED" -eq 1 ]; then
   # they come back under their restart policy, and an uncapped log filling the
   # disk takes the whole host down rather than one container.
   systemctl restart docker
+  warn_existing_containers_keep_log_config
 else
   systemctl start docker
 fi

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -3470,8 +3470,9 @@ ensure_cluster_on_default_port
 
 if ! [ -d "/etc/postgresql/$PG_MAJOR/main" ]; then
   install -d -m 0755 /usr/share/postgresql-common/pgdg
-  curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
-    -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc
+  install_downloaded_file 'the PostgreSQL signing key' \
+    https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+    /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc
   # shellcheck disable=SC1091
   . /etc/os-release
   install_managed_config 'the PostgreSQL apt source' \

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -4941,7 +4941,7 @@ the actual key path and run:
   signature="\$(printf 'collavre-ssh-cutover:%s:%s' '$APP_SSH_USER' "\$nonce" |
     ssh-keygen -Y sign -f "\$key" -n collavre-ssh-cutover 2>/dev/null |
     base64 | tr -d '\\n')"
-  ssh -o IdentitiesOnly=yes -i "\$key" $APP_SSH_USER@$PUBLIC_IP \\
+  ssh -F /dev/null -o IdentitiesOnly=yes -i "\$key" $APP_SSH_USER@$PUBLIC_IP \\
     "sudo /usr/local/sbin/collavre-finalize-ssh-cutover --finalize-ssh-cutover '\$nonce' '\$signature'"
 
 Only after it prints "SSH cutover finalized" should KAMAL_SSH_USER change to

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -2627,6 +2627,44 @@ install_authorized_keys() {
       tmp="$(stage_authorized_keys "$auth_keys")" || return 1
       cat "$src" >> "$tmp" || { rm -f "$tmp"; return 1; }
       install_staged_authorized_keys "$tmp" "$auth_keys" || return 1
+      # Record what was copied, or the rotation this documents cannot undo it.
+      # `record_ssh_key_grant "$SSH_PUBLIC_KEY"` at the call site is a no-op on
+      # this path — the variable is empty, that is what put us here — so the
+      # queue stayed empty and a later run naming an explicit key found no
+      # predecessor to withdraw. Measured on the shipped functions, the two runs
+      # the runbook describes:
+      #
+      #   run 1  SSH_PUBLIC_KEY=''      authorized: cloud-1 cloud-2   queue: -
+      #   run 2  SSH_PUBLIC_KEY=<new>   authorized: cloud-1 cloud-2 new
+      #                                 queue: new
+      #
+      # The table in docs says changing SSH_PUBLIC_KEY on a re-run "withdraws
+      # the key it replaces", and on the empty -> explicit transition it
+      # withdrew nothing, on the account that has passwordless sudo and docker.
+      #
+      # Only on this branch, never on the `-ef` one above: there the file *is*
+      # the cloud user's own, so queueing it would have a later rotation strip
+      # the operator's Lightsail key from the account they log in as. Copied
+      # keys are this script's to withdraw; a cloud account's own keys are not.
+      #
+      # Warned rather than fatal, matching ensure_ufw_rule's marker: the keys
+      # are installed by the time we get here, so dying would leave exactly the
+      # same untracked keys with less said about them.
+      # Guarded on the two state variables the same way install_staged_authorized_keys
+      # guards its chown on APP_SSH_USER: this function is called directly by a
+      # dozen fixtures that have no state directory and no deploy account, and
+      # under `set -u` naming them unconditionally makes it abort there. The
+      # real call site always has both — it is the line below that sets
+      # AUTH_KEYS — so the production path is the one that records.
+      if [ -n "${STATE_DIR:-}" ] && [ -n "${APP_SSH_USER:-}" ]; then
+        while read -r _copied; do
+          case "$_copied" in ''|'#'*) continue ;; esac
+          record_ssh_key_grant "$_copied" ||
+            log "WARNING: copied a key from $candidate but could not record it," \
+                "so a later SSH_PUBLIC_KEY rotation will not withdraw it:" \
+                "${_copied##* }"
+        done < "$src"
+      fi
     fi
     return 0
   done

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -1697,17 +1697,24 @@ ssh_public_key_fingerprint() {
 # exchange itself; reading SSH_USER_AUTH from the original session ancestry
 # avoids relying on what sudo happened to preserve.
 ssh_cutover_auth_info_file() {
-  local user="$1" pid="${2:-$PPID}" ppid real_uid target_uid candidate='' hops=0
+  local user="$1" pid="${2:-$PPID}" proc_root="${3:-/proc}"
+  local ppid real_uid target_uid candidate='' candidate_uid hops=0
   local auth_info_file=''
   target_uid="$(id -u "$user" 2>/dev/null)" || return 1
   while [ "$pid" -gt 1 ] 2>/dev/null && [ "$hops" -lt 64 ]; do
-    real_uid="$(awk '/^Uid:/{print $2}' "/proc/$pid/status" 2>/dev/null || true)"
+    real_uid="$(awk '/^Uid:/{print $2}' "$proc_root/$pid/status" 2>/dev/null || true)"
     if [ "$real_uid" = "$target_uid" ]; then
-      candidate="$(tr '\0' '\n' < "/proc/$pid/environ" 2>/dev/null |
+      candidate="$(tr '\0' '\n' < "$proc_root/$pid/environ" 2>/dev/null |
 	sed -n 's/^SSH_USER_AUTH=//p' | head -1)"
-      [ -z "$candidate" ] || auth_info_file="$candidate"
+      candidate_uid="$(
+	stat -c %u "$candidate" 2>/dev/null ||
+	  stat -f %u "$candidate" 2>/dev/null ||
+	  true
+      )"
+      [ -z "$candidate" ] || [ ! -f "$candidate" ] ||
+	[ "$candidate_uid" != "$target_uid" ] || auth_info_file="$candidate"
     fi
-    ppid="$(awk '/^PPid:/{print $2}' "/proc/$pid/status" 2>/dev/null || true)"
+    ppid="$(awk '/^PPid:/{print $2}' "$proc_root/$pid/status" 2>/dev/null || true)"
     case "$ppid" in ''|*[!0-9]*) break ;; esac
     pid="$ppid"
     hops=$((hops + 1))
@@ -1728,20 +1735,24 @@ ssh_cutover_authenticated_with_key() {
 }
 
 ssh_cutover_has_sshd_ancestor() {
-  local user="$1" pid="${2:-$PPID}" comm ppid real_uid target_uid hops=0
-  local saw_sshd=0 saw_user=0
+  local user="$1" pid="${2:-$PPID}" proc_root="${3:-/proc}"
+  local comm ppid real_uid target_uid hops=0
+  local saw_authenticated_sshd=0
   target_uid="$(id -u "$user" 2>/dev/null)" || return 1
   while [ "$pid" -gt 1 ] 2>/dev/null && [ "$hops" -lt 64 ]; do
-    comm="$(cat "/proc/$pid/comm" 2>/dev/null || true)"
-    case "$comm" in sshd|sshd-session) saw_sshd=1 ;; esac
-    real_uid="$(awk '/^Uid:/{print $2}' "/proc/$pid/status" 2>/dev/null || true)"
-    [ "$real_uid" = "$target_uid" ] && saw_user=1
-    ppid="$(awk '/^PPid:/{print $2}' "/proc/$pid/status" 2>/dev/null || true)"
+    comm="$(cat "$proc_root/$pid/comm" 2>/dev/null || true)"
+    real_uid="$(awk '/^Uid:/{print $2}' "$proc_root/$pid/status" 2>/dev/null || true)"
+    case "$comm:$real_uid" in
+      sshd:"$target_uid"|sshd-session:"$target_uid")
+	saw_authenticated_sshd=1
+	;;
+    esac
+    ppid="$(awk '/^PPid:/{print $2}' "$proc_root/$pid/status" 2>/dev/null || true)"
     case "$ppid" in ''|*[!0-9]*) break ;; esac
     pid="$ppid"
     hops=$((hops + 1))
   done
-  [ "$saw_sshd" -eq 1 ] && [ "$saw_user" -eq 1 ]
+  [ "$saw_authenticated_sshd" -eq 1 ]
 }
 
 finalize_ssh_cutover() {
@@ -1765,8 +1776,13 @@ finalize_ssh_cutover() {
     die "finalize this cutover by SSHing as '$user' and running sudo there;" \
 	"SUDO_USER is '${SUDO_USER:-unset}'"
   ssh_cutover_has_sshd_ancestor "$user" ||
-    die "no sshd ancestor was found. The cutover must be finalized inside an" \
-	"actual SSH session as '$user', not from a local shell or console."
+    die "no sshd session process owned by '$user' was found. The cutover must" \
+	"be finalized inside an SSH session authenticated as that account, not" \
+	"through a nested sudo from another user's session or a local console."
+  ssh_cutover_auth_info_file "$user" >/dev/null ||
+    die "no '$user'-owned SSH_USER_AUTH record was found. The cutover must be" \
+	"finalized from that account's actual SSH session; predecessor access" \
+	"was not changed."
   actual="$(printf '%s' "$nonce" | sha256sum | awk '{print $1}')"
   [ "$actual" = "$expected" ] ||
     die "the SSH cutover nonce is incorrect; predecessor access was not changed"
@@ -4259,8 +4275,7 @@ fi
 DOCKER_GROUP_WAS_PRESENT=0
 in_group "$APP_SSH_USER" docker && DOCKER_GROUP_WAS_PRESENT=1
 usermod -aG docker "$APP_SSH_USER"
-SSH_AUTH_INFO_REQUIRED=0
-[ -z "$SSH_PUBLIC_KEY" ] || SSH_AUTH_INFO_REQUIRED=1
+SSH_AUTH_INFO_REQUIRED=1
 # Recheck for the same reason as the sudo grant above. An operator's
 # `Match Group docker` block does not apply until this membership exists.
 if ! (

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -37,8 +37,8 @@ set -euo pipefail
 # cases are indistinguishable — and the difference is the whole question a
 # re-run has to answer. `sudo FORCE=1 bash script/lightsail_launch.sh` on a host
 # provisioned with an override reads as "converge this host", but several of
-# these settings converge by *rotating*: the deploy user's sudo and docker
-# grants move to whatever APP_SSH_USER now says, and table ownership and LOGIN
+# these settings converge by *rotating*: a deploy-user cutover is staged for
+# whatever APP_SSH_USER now says, and table ownership and LOGIN
 # move to whatever DB_USER now says. Defaulted back to `collavre` and
 # `collavre_user`, that is a rotation nobody asked for, performed against the
 # account and role the running deployment authenticates as.
@@ -144,11 +144,6 @@ die() { printf '\n!!! [%s] %s\n' "$(date -Is)" "$*" >&2; exit 1; }
   "nightly backup all named $DB_PORT. Leave DB_PORT unset, and move the cluster by hand" \
   "afterwards if you need a different port."
 
-if [ -f "$MARKER" ] && [ "${FORCE:-0}" != "1" ]; then
-  log "already provisioned ($MARKER). Re-run with FORCE=1 to converge again."
-  exit 0
-fi
-
 # refuse_defaulted_config_change [state dir] [supplied settings]
 #
 # A re-run applies every setting, not just the ones it was given: an override
@@ -156,9 +151,9 @@ fi
 # default. For most of these that is harmless convergence, but three of them
 # are not convergence at all —
 #
-#   APP_SSH_USER   arms a new account and takes docker + sudo + the sudoers.d
-#                  grant back from the one recorded in $STATE_DIR/deploy_user,
-#                  which is the account KAMAL_SSH_USER names and deploys with
+#   APP_SSH_USER   stages a new account and a one-time SSH cutover challenge;
+#                  finalization moves docker + sudo away from the account in
+#                  $STATE_DIR/deploy_user only after a real successor session
 #   DB_USER        REASSIGN OWNED and NOLOGIN move the application's tables and
 #                  its ability to log in to a different role, while the
 #                  deployed DATABASE_URL still names the old one
@@ -837,22 +832,6 @@ refuse_nologin_deploy_user() {
         "'ls -l $shell', or set APP_SSH_USER to an ordinary account."
 }
 
-# Before refuse_defaulted_config_change, and long before anything is installed:
-# a value this script cannot use is not usable whatever the host was given
-# earlier, so it is answered without reading any state at all.
-refuse_unusable_db_identifier DB_NAME "$DB_NAME"
-refuse_unusable_db_identifier DB_USER "$DB_USER"
-refuse_unusable_bind_address DB_BIND_ADDRESS "$DB_BIND_ADDRESS"
-refuse_unusable_subnet DOCKER_SUBNETS "$DOCKER_SUBNETS"
-refuse_unusable_retention BACKUP_RETENTION_DAYS "$BACKUP_RETENTION_DAYS"
-refuse_unusable_backup_calendar BACKUP_AT "$BACKUP_AT" "$BACKUP_CALENDAR"
-refuse_unparsable_ssh_key
-refuse_forced_command_ssh_key
-refuse_root_deploy_user "$APP_SSH_USER"
-refuse_nologin_deploy_user "$APP_SSH_USER"
-
-refuse_defaulted_config_change
-
 # cloud-init and unattended-upgrades hold the dpkg lock during early boot;
 # DPkg::Lock::Timeout makes apt wait for them instead of failing outright.
 APT_OPTS=(-o DPkg::Lock::Timeout=600
@@ -1227,8 +1206,7 @@ ensure_block() {
   mv -f "$tmp" "$file"
 }
 
-# Give $1 passwordless sudo, and make sure it is the only deploy user holding
-# a grant this script wrote. `usermod -aG sudo` on its own does not work here:
+# Give $1 passwordless sudo. `usermod -aG sudo` on its own does not work here:
 # `adduser --disabled-password` leaves `!` in /etc/shadow and Ubuntu's %sudo
 # rule is password-authenticated, so every sudo the runbook sends over ssh
 # fails with "a password is required".
@@ -1238,7 +1216,7 @@ ensure_block() {
 # so an allowlist would withhold nothing it does not already have, while
 # breaking the next maintenance command someone documents.
 ensure_sudoers() {
-  local user="$1" dir="${2:-/etc/sudoers.d}" tmp existing
+  local user="$1" dir="${2:-/etc/sudoers.d}" tmp
   # sudo's includedir skips any filename that contains '.' or ends in '~', and
   # a Linux username may legally contain a dot.
   local name="90-collavre-${user//[^A-Za-z0-9_-]/_}"
@@ -1258,12 +1236,11 @@ ensure_sudoers() {
   install -m 0440 "$tmp" "$dir/$name"
   rm -f "$tmp"
 
-  # Converge rather than accumulate: a FORCE=1 re-run with a changed
-  # APP_SSH_USER must not leave the previous user's grant in force.
-  for existing in "$dir"/90-collavre-*; do
-    [ -e "$existing" ] || continue
-    [ "$existing" = "$dir/$name" ] || rm -f "$existing"
-  done
+  # Do not remove a predecessor here. A new account has not proved that it can
+  # open an SSH session yet, and removing the old NOPASSWD grant before that
+  # proof turns a configuration-analysis mistake into a lockout. The cutover
+  # finalizer removes predecessor grants only from a session authenticated as
+  # the staged account.
 }
 
 # Take the docker group back from the deploy user a FORCE=1 re-run replaced.
@@ -1460,7 +1437,7 @@ record_deploy_user_grant() {
 # the caller decides whether to keep retrying it, rather than this deciding by
 # where it writes a marker.
 revoke_deploy_user_access() {
-  local prior="$1" current="$2" group held
+  local prior="$1" current="$2" group held sudoers_name
 
   for group in docker sudo; do
     in_group "$prior" "$group" || continue
@@ -1503,6 +1480,9 @@ revoke_deploy_user_access() {
     return 1
   fi
 
+  sudoers_name="90-collavre-${prior//[^A-Za-z0-9_-]/_}"
+  rm -f "/etc/sudoers.d/$sudoers_name"
+
   log "WARNING: '$prior' is no longer in docker or sudo but can still log in;" \
       "remove it by hand once you can reach the host as '$current':" \
       "deluser --remove-home $prior"
@@ -1510,7 +1490,7 @@ revoke_deploy_user_access() {
 
 revoke_prior_deploy_user() {
   local current="$1" prior_file="${2:-$STATE_DIR/deploy_user}"
-  local set_file="${3:-${prior_file%/*}/deploy_users}" prior kept=''
+  local set_file="${3:-${prior_file%/*}/deploy_users}" prior kept='' failed=0
 
   # Not a no-op on the ordinary path: this is what seeds the set on a host the
   # earlier revision provisioned, and what puts $current in it on a first run,
@@ -1534,7 +1514,10 @@ revoke_prior_deploy_user() {
     # An account that no longer exists cannot hold either group through, so
     # there is nothing left for a later run to retry.
     id -u "$prior" >/dev/null 2>&1 || continue
-    revoke_deploy_user_access "$prior" "$current" || kept="$kept$prior"$'\n'
+    if ! revoke_deploy_user_access "$prior" "$current"; then
+      kept="$kept$prior"$'\n'
+      failed=1
+    fi
   done < "$set_file"
 
   # Rewritten from what the loop kept rather than appended to, so an account
@@ -1555,11 +1538,152 @@ revoke_prior_deploy_user() {
   # stops. Stale-and-conservative in both cases — where a truncated file is
   # neither.
   write_state_file "$set_file" "$kept" ||
-    log "WARNING: could not rewrite the deploy-user queue at '$set_file'; it still" \
-        "lists accounts this run revoked, which costs the next run a re-check"
+    {
+      log "WARNING: could not rewrite the deploy-user queue at '$set_file'; it still" \
+	  "lists accounts this run revoked, which costs the next run a re-check"
+      failed=1
+    }
+  [ "$failed" -eq 0 ] || {
+    log "WARNING: the SSH cutover is still pending because at least one" \
+	"predecessor retains privileged access"
+    return 1
+  }
   write_state_file "$prior_file" "$current"$'\n' ||
-    log "WARNING: could not record '$current' as the deploy user in '$prior_file';" \
-        "the host will go on reporting its predecessor until a later run rewrites it"
+    {
+      log "WARNING: could not record '$current' as the deploy user in '$prior_file';" \
+	  "the cutover remains pending and can be retried"
+      return 1
+    }
+}
+
+# stage_ssh_cutover <user> <key>
+#
+# Provisioning may grant the successor access, but it must not infer that access
+# works from sshd configuration. Instead it writes a one-time challenge and
+# installs this script as the finalizer. The challenge is accepted only when
+# the finalizer is reached through an sshd descendant running under the staged
+# account. Until then deploy_user, predecessor groups, predecessor sudoers and
+# predecessor managed keys all stay unchanged.
+stage_ssh_cutover() {
+  local user="$1" key="$2" current='' prior_key='' need=0
+  local nonce nonce_hash pending="$STATE_DIR/ssh_cutover.pending"
+  local key_file="$STATE_DIR/ssh_cutover.key"
+  local finalizer="${3:-/usr/local/sbin/collavre-finalize-ssh-cutover}"
+  local source="${4:-${BASH_SOURCE[0]}}"
+
+  [ -s "$STATE_DIR/deploy_user" ] &&
+    current="$(grep -v '^[[:space:]]*$' "$STATE_DIR/deploy_user" | head -1)"
+  [ "$current" = "$user" ] || need=1
+
+  if [ -n "$key" ]; then
+    [ -s "$STATE_DIR/ssh_public_key.$user" ] &&
+      prior_key="$(cat "$STATE_DIR/ssh_public_key.$user")"
+    [ "$prior_key" = "$key" ] || need=1
+  fi
+
+  if [ "$need" -eq 0 ]; then
+    [ ! -f "$pending" ] ||
+      die "an SSH cutover is already pending in $pending. Finalize it from the" \
+	  "staged account before another provisioning run."
+    SSH_CUTOVER_PENDING=0
+    SSH_CUTOVER_NONCE=''
+    return 0
+  fi
+
+  if [ -s "$pending" ]; then
+    local pending_user
+    pending_user="$(sed -n 's/^user=//p' "$pending")"
+    [ "$pending_user" = "$user" ] ||
+      die "an SSH cutover to '$pending_user' is already pending. Finalize that" \
+	  "cutover before staging '$user'; no predecessor access was revoked."
+  fi
+
+  nonce="$(od -An -N32 -tx1 /dev/urandom | tr -d '[:space:]')"
+  [ "${#nonce}" -eq 64 ] || die "could not generate the SSH cutover challenge"
+  nonce_hash="$(printf '%s' "$nonce" | sha256sum | awk '{print $1}')"
+
+  write_state_file "$key_file" "$key"$'\n' 0600 ||
+    die "could not stage the SSH cutover key in $key_file"
+  write_state_file "$pending" \
+    "user=$user"$'\n'"nonce_sha256=$nonce_hash"$'\n' 0600 ||
+    die "could not stage the SSH cutover challenge in $pending"
+
+  [ -r "$source" ] ||
+    die "cannot install the SSH cutover finalizer because $source" \
+	"is not readable. Run this script from a file, not a consumed pipe."
+  install -m 0755 "$source" "$finalizer"
+
+  SSH_CUTOVER_PENDING=1
+  SSH_CUTOVER_NONCE="$nonce"
+  log "SSH cutover to '$user' is staged. The predecessor remains privileged" \
+      "until the nonce is finalized from an actual SSH session as '$user'."
+}
+
+ssh_cutover_has_sshd_ancestor() {
+  local user="$1" pid="${2:-$PPID}" comm ppid real_uid target_uid hops=0
+  local saw_sshd=0 saw_user=0
+  target_uid="$(id -u "$user" 2>/dev/null)" || return 1
+  while [ "$pid" -gt 1 ] 2>/dev/null && [ "$hops" -lt 64 ]; do
+    comm="$(cat "/proc/$pid/comm" 2>/dev/null || true)"
+    case "$comm" in sshd|sshd-session) saw_sshd=1 ;; esac
+    real_uid="$(awk '/^Uid:/{print $2}' "/proc/$pid/status" 2>/dev/null || true)"
+    [ "$real_uid" = "$target_uid" ] && saw_user=1
+    ppid="$(awk '/^PPid:/{print $2}' "/proc/$pid/status" 2>/dev/null || true)"
+    case "$ppid" in ''|*[!0-9]*) break ;; esac
+    pid="$ppid"
+    hops=$((hops + 1))
+  done
+  [ "$saw_sshd" -eq 1 ] && [ "$saw_user" -eq 1 ]
+}
+
+finalize_ssh_cutover() {
+  local nonce="${1:-}" pending="$STATE_DIR/ssh_cutover.pending"
+  local key_file="$STATE_DIR/ssh_cutover.key" user expected actual
+
+  [ -s "$pending" ] || die "no SSH cutover is pending"
+  user="$(sed -n 's/^user=//p' "$pending")"
+  expected="$(sed -n 's/^nonce_sha256=//p' "$pending")"
+  [ -n "$user" ] && [ -n "$expected" ] ||
+    die "$pending is incomplete; predecessor access was not changed"
+  [ "${SUDO_USER:-}" = "$user" ] ||
+    die "finalize this cutover by SSHing as '$user' and running sudo there;" \
+	"SUDO_USER is '${SUDO_USER:-unset}'"
+  ssh_cutover_has_sshd_ancestor "$user" ||
+    die "no sshd ancestor was found. The cutover must be finalized inside an" \
+	"actual SSH session as '$user', not from a local shell or console."
+  actual="$(printf '%s' "$nonce" | sha256sum | awk '{print $1}')"
+  [ "$actual" = "$expected" ] ||
+    die "the SSH cutover nonce is incorrect; predecessor access was not changed"
+  in_group "$user" sudo && in_group "$user" docker ||
+    die "'$user' no longer has both sudo and docker; predecessor access was" \
+	"not changed. Re-run provisioning to repair the staged account."
+
+  APP_SSH_USER="$user"
+  APP_HOME="$(getent passwd "$user" | cut -d: -f6)"
+  [ -n "$APP_HOME" ] || die "could not resolve the home directory for '$user'"
+  APP_SSH_GROUP="$(id -gn "$user")"
+  AUTH_KEYS="$APP_HOME/.ssh/authorized_keys"
+  [ -s "$AUTH_KEYS" ] ||
+    die "$AUTH_KEYS is empty; predecessor access was not changed"
+
+  SSH_PUBLIC_KEY="$(cat "$key_file" 2>/dev/null || true)"
+  if [ -n "$SSH_PUBLIC_KEY" ]; then
+    grep -qxF "$SSH_PUBLIC_KEY" "$AUTH_KEYS" ||
+      die "the staged key is no longer in $AUTH_KEYS; predecessor access was" \
+	  "not changed"
+    revoke_prior_ssh_key "$AUTH_KEYS"
+    [ "$(cat "$STATE_DIR/ssh_public_key.$user" 2>/dev/null || true)" = \
+      "$SSH_PUBLIC_KEY" ] ||
+      die "the staged key could not be committed; the cutover remains pending"
+  fi
+
+  revoke_prior_deploy_user "$user" ||
+    die "one or more predecessor accounts could not be disarmed. The cutover" \
+	"remains pending; repair the reported account and run this command again."
+
+  rm -f "$pending" "$key_file"
+  log "SSH cutover finalized from an authenticated session as '$user'." \
+      "KAMAL_SSH_USER may now be changed to '$user'."
 }
 
 # psql_as_postgres <database> <sql>
@@ -2602,6 +2726,36 @@ ensure_ssh_rule() {
     ufw allow 22/tcp
   }
 }
+
+# The finalizer is an installed copy of this script. Dispatch only after every
+# helper has been defined, but before the normal provisioning guards and any
+# host mutation. Its caller must be the staged account inside a real SSH
+# session; finalize_ssh_cutover verifies both conditions again.
+if [ "${1:-}" = "--finalize-ssh-cutover" ]; then
+  finalize_ssh_cutover "${2:-}"
+  exit 0
+fi
+
+# Before refuse_defaulted_config_change, and long before anything is installed:
+# a value this script cannot use is not usable whatever the host was given
+# earlier, so it is answered without reading any state at all.
+refuse_unusable_db_identifier DB_NAME "$DB_NAME"
+refuse_unusable_db_identifier DB_USER "$DB_USER"
+refuse_unusable_bind_address DB_BIND_ADDRESS "$DB_BIND_ADDRESS"
+refuse_unusable_subnet DOCKER_SUBNETS "$DOCKER_SUBNETS"
+refuse_unusable_retention BACKUP_RETENTION_DAYS "$BACKUP_RETENTION_DAYS"
+refuse_unusable_backup_calendar BACKUP_AT "$BACKUP_AT" "$BACKUP_CALENDAR"
+refuse_unparsable_ssh_key
+refuse_forced_command_ssh_key
+refuse_root_deploy_user "$APP_SSH_USER"
+refuse_nologin_deploy_user "$APP_SSH_USER"
+
+if [ -f "$MARKER" ] && [ "${FORCE:-0}" != "1" ]; then
+  log "already provisioned ($MARKER). Re-run with FORCE=1 to converge again."
+  exit 0
+fi
+
+refuse_defaulted_config_change
 
 # --------------------------------------------------------------------------
 log "1/9 base packages"
@@ -3869,7 +4023,10 @@ install_authorized_keys "$AUTH_KEYS" ||
       "$STATE_DIR/deploy_users, so a later run naming a different APP_SSH_USER" \
       "takes it back. Re-run with" \
       "SSH_PUBLIC_KEY=\"\$(cat ~/.ssh/id_ed25519.pub)\"."
-revoke_prior_ssh_key "$AUTH_KEYS"
+# Previous managed keys stay authorized until the staged key has opened a real
+# SSH session and the nonce is finalized. Removing them here would merely move
+# the lockout decision from sshd configuration analysis to another unproved
+# assumption.
 dedupe_authorized_keys "$AUTH_KEYS" "$SSH_PUBLIC_KEY"
 chown "$APP_SSH_USER:$APP_SSH_GROUP" "$AUTH_KEYS"
 chmod 0600 "$AUTH_KEYS"
@@ -3963,9 +4120,13 @@ if ! (
   die "SSH hardening failed after the docker group change. Any membership added" \
     "by this run was rolled back; correct the Match override and re-run."
 fi
-# Only once the replacement can reach Docker, so an interrupted run never
-# leaves the host with no account that can deploy.
-revoke_prior_deploy_user "$APP_SSH_USER"
+# Configuration checks are useful diagnostics, but they are not proof that an
+# external client can log in. Stage a cutover challenge instead of revoking the
+# predecessor here. The installed finalizer accepts it only from an actual SSH
+# session as this account, then removes old groups, sudoers and managed keys.
+SSH_CUTOVER_PENDING=0
+SSH_CUTOVER_NONCE=''
+stage_ssh_cutover "$APP_SSH_USER" "$SSH_PUBLIC_KEY"
 
 # --------------------------------------------------------------------------
 log "5/9 PostgreSQL $PG_MAJOR"
@@ -4573,18 +4734,24 @@ PASSWORD_NOTE=''
 if [ "$URL_PASSWORD" != "$DB_PASSWORD" ]; then
   PASSWORD_NOTE=', percent-encoded in the URL below'
 fi
+ACTIVE_DEPLOY_USER="$(cat "$STATE_DIR/deploy_user" 2>/dev/null || true)"
+if [ -z "$ACTIVE_DEPLOY_USER" ]; then
+  ACTIVE_DEPLOY_USER='<finalize SSH cutover first>'
+fi
 
 # Rendered twice: once with the real DATABASE_URL into the 0600 summary file,
-# once redacted for stdout — which is tee'd to the launch log and captured by
-# cloud-init. Templating instead of sed'ing the secret out keeps a password
-# containing regex or delimiter characters from slipping through unreplaced.
-render_summary() { # $1 = DATABASE_URL to display
+# once with both credentials redacted for stdout — which is tee'd to the launch
+# log and captured by cloud-init. Templating instead of sed'ing secrets out
+# keeps a password containing regex or delimiter characters from slipping
+# through unreplaced.
+render_summary() { # $1 = DATABASE_URL, $2 = SSH cutover nonce to display
   cat <<TXT
 Collavre Lightsail host — provisioned $(date -Is)
 
   public IP        $PUBLIC_IP
   private IP       $PRIVATE_IP
-  deploy user      $APP_SSH_USER (docker, passwordless sudo)
+  deploy user      $ACTIVE_DEPLOY_USER
+  staged SSH user  $APP_SSH_USER (docker, passwordless sudo)
   PostgreSQL       $PG_MAJOR, listening on localhost + $DB_BIND_ADDRESS only
   database         $DB_NAME owned by $DB_USER
   db password      $STATE_DIR/db_password (root only)$PASSWORD_NOTE
@@ -4592,6 +4759,25 @@ Collavre Lightsail host — provisioned $(date -Is)
                    repeat these on the command line or it is refused
   backups          /var/backups/collavre, nightly at $BACKUP_AT, ${BACKUP_RETENTION_DAYS}d retention
   log              $LOG_FILE
+TXT
+
+  if [ "${SSH_CUTOVER_PENDING:-0}" -eq 1 ]; then
+    cat <<TXT
+
+SSH cutover is pending. The previous deploy account and managed keys remain
+privileged until the staged account proves a real SSH login. From the
+workstation, using the staged key, run:
+
+  ssh -i ~/.ssh/<staged-key> $APP_SSH_USER@$PUBLIC_IP \\
+    "sudo /usr/local/sbin/collavre-finalize-ssh-cutover --finalize-ssh-cutover '$2'"
+
+Only after it prints "SSH cutover finalized" should KAMAL_SSH_USER change to
+$APP_SSH_USER. The nonce is one-time; a failed or interrupted finalize is safe
+to retry with the same command.
+TXT
+  fi
+
+  cat <<TXT
 
 Put these in .env.production at the root of your Collavre checkout, then run
 \`./kamal.sh setup\` from that same directory — the wrapper is what loads
@@ -4599,7 +4785,7 @@ Put these in .env.production at the root of your Collavre checkout, then run
 host and the wrong SSH user:
 
   COLLAVRE_SERVER=$PUBLIC_IP
-  KAMAL_SSH_USER=$APP_SSH_USER
+  KAMAL_SSH_USER=$ACTIVE_DEPLOY_USER
   KAMAL_SSH_KEY_PATH=~/.ssh/<the key matching the instance>
   DATABASE_URL=$1
   PORT=80
@@ -4613,8 +4799,8 @@ TXT
 # only after the complete output can be read back. A FORCE re-run may already
 # have rotated the database credential, so truncating the live summary would
 # destroy the only ready-to-copy, percent-encoded DATABASE_URL for that state.
-install_credential_summary() { # $1 = DATABASE_URL to display
-  local database_url="$1" target_real tmp rc=0
+install_credential_summary() { # $1 = DATABASE_URL, $2 = SSH cutover nonce
+  local database_url="$1" cutover_nonce="${2:-}" target_real tmp rc=0
   target_real="$(resolve_symlink_chain "$SUMMARY")" || exit 1
   tmp="$(stage_beside "$target_real" 0600)" || rc=$?
   [ "$rc" -eq 0 ] || {
@@ -4626,12 +4812,12 @@ install_credential_summary() { # $1 = DATABASE_URL to display
     die "could not make the staged credential summary root-only." \
 	"$target_real is left exactly as it was."
   fi
-  if ! render_summary "$database_url" > "$tmp"; then
+  if ! render_summary "$database_url" "$cutover_nonce" > "$tmp"; then
     rm -f "$tmp"
     die "could not render the staged credential summary — is the instance out" \
 	"of disk? $target_real is left exactly as it was."
   fi
-  if ! grep -qxF "  KAMAL_SSH_USER=$APP_SSH_USER" "$tmp" ||
+  if ! grep -qxF "  KAMAL_SSH_USER=$ACTIVE_DEPLOY_USER" "$tmp" ||
      ! grep -qxF "  DATABASE_URL=$database_url" "$tmp" ||
      ! grep -qxF 'Never open 5432 there.' "$tmp"; then
     rm -f "$tmp"
@@ -4659,8 +4845,8 @@ install_credential_summary() { # $1 = DATABASE_URL to display
 # this run still created the success marker.
 record_launch_settings
 
-install_credential_summary "$DATABASE_URL"
+install_credential_summary "$DATABASE_URL" "${SSH_CUTOVER_NONCE:-}"
 
 touch "$MARKER"
-render_summary "$REDACTED_URL"
+render_summary "$REDACTED_URL" '<see root-only summary>'
 log "done — full log at $LOG_FILE (root only; the DATABASE_URL above is redacted, the real one is in $SUMMARY)"

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -401,12 +401,43 @@ refuse_unparsable_ssh_key() {
   fi
 }
 
+# refuse_root_deploy_user <user>
+#
+# The deploy account cannot be UID 0, because step 3 writes `PermitRootLogin no`
+# into /etc/ssh/sshd_config.d/99-collavre.conf and then, further down that same
+# step, arms $APP_SSH_USER and hands it to Kamal as KAMAL_SSH_USER. Nothing in
+# between rejects the account sshd has just been told to turn away, so the run
+# reports success and every deploy fails to authenticate.
+#
+# Refused here rather than at the deploy-user block so that "nothing has been
+# changed" is literally true: by the time that block runs, a rotation has a
+# predecessor to take sudo and docker back from, and it would be stripped in
+# favour of an account that cannot log in — leaving the host with no working
+# way in at all. The remedy for that is on the host, which is the thing you no
+# longer have.
+#
+# Tested by UID rather than by the name 'root', since an account aliased to 0
+# is locked out by exactly the same drop-in. An account that does not exist yet
+# is fine: `adduser` below creates an ordinary one.
+refuse_root_deploy_user() {
+  local user="$1" uid
+  uid="$(id -u "$user" 2>/dev/null)" || return 0
+  [ "$uid" -eq 0 ] || return 0
+  die "APP_SSH_USER='$user' is UID 0, and this script hardens sshd with" \
+      "PermitRootLogin no before it arms the deploy account — so '$user' could" \
+      "never log in, while the summary would still print KAMAL_SSH_USER=$user" \
+      "and every 'kamal deploy' would fail to authenticate. Nothing has been" \
+      "changed. Set APP_SSH_USER to an ordinary account; leave it unset for the" \
+      "default 'collavre', which this script creates."
+}
+
 # Before refuse_defaulted_config_change, and long before anything is installed:
 # a value this script cannot use is not usable whatever the host was given
 # earlier, so it is answered without reading any state at all.
 refuse_unusable_db_identifier DB_NAME "$DB_NAME"
 refuse_unusable_db_identifier DB_USER "$DB_USER"
 refuse_unparsable_ssh_key
+refuse_root_deploy_user "$APP_SSH_USER"
 
 refuse_defaulted_config_change
 

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -3415,6 +3415,23 @@ rm -f /etc/ssh/sshd_config.d/99-collavre.conf
 # sshd_config; without it the drop-in above is silently ignored.
 grep -q '^Include /etc/ssh/sshd_config.d/' /etc/ssh/sshd_config 2>/dev/null || \
   log "WARNING: sshd_config has no Include for sshd_config.d — harden SSH by hand"
+# ensure_sshd_runtime_dir [directory]
+#
+# Ubuntu 24.04's ssh.service declares RuntimeDirectory=sshd. On a
+# socket-activated host with no connection yet, ssh.service has not started and
+# systemd has therefore not created /run/sshd. A direct `sshd -t` or `sshd -T`
+# then fails with "Missing privilege separation directory" even when the
+# configuration is valid. The verifier below deliberately runs before the
+# socket starts the daemon, so prepare the same root-owned runtime directory
+# without changing socket activation into a permanently running service.
+ensure_sshd_runtime_dir() {
+  local dir="${1:-/run/sshd}"
+  install -d -o root -g root -m 0755 "$dir" ||
+    die "could not prepare sshd's runtime directory '$dir'. The SSH" \
+	"configuration cannot be validated safely; check that /run is writable" \
+	"and re-run."
+}
+
 # reload_ssh_daemon — reload whichever unit carries sshd.
 #
 # Returns 0 when a unit adopted the configuration, 1 when a running daemon
@@ -3469,6 +3486,7 @@ reload_ssh_daemon() {
 # verifier runs again immediately after later group changes, when its answer can
 # differ because Match Group has begun to apply.
 SSH_RELOAD_STATE=0
+ensure_sshd_runtime_dir
 reload_ssh_daemon || SSH_RELOAD_STATE=$?
 [ "$SSH_RELOAD_STATE" -ne 1 ] || die \
   "SSH hardening was written but the running sshd refused to reload it." \

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -344,6 +344,11 @@ psql_as_postgres() {
 # rather than being fatal: nothing downstream depends on the size, and dying
 # here would abandon a provisioning run over the one condition where the
 # operator most needs the host to come up.
+#
+# The same rule decides the other way a resize fails. Growing the file means
+# freeing the old one first, so an allocation that does not fit would otherwise
+# leave the host with no swap at all — strictly worse than the state the run
+# started from. The previous size is restored and the run continues.
 ensure_swapfile() {
   local swap="${1:-/swapfile}" fstab="${2:-/etc/fstab}"
   local want="$SWAP_SIZE_MB" have=0 active=no
@@ -374,13 +379,43 @@ ensure_swapfile() {
   fi
 
   rm -f "$swap"
-  fallocate -l "${want}M" "$swap" || \
-    dd if=/dev/zero of="$swap" bs=1M count="$want" status=none
-  chmod 600 "$swap"
-  mkswap "$swap" >/dev/null
+  if ! allocate_swapfile "$swap" "$want"; then
+    # The new size did not fit. Put back what was there rather than leaving the
+    # host with none: the operator raising SWAP_SIZE_MB is doing so under memory
+    # pressure, and a run that answers by taking away the swap they already had
+    # makes exactly the condition it was called about worse. The old size is
+    # known to fit — its space was freed a moment ago — and a swapfile's
+    # contents are dead once swapoff has faulted the pages back, so recreating
+    # it is a restore and not an approximation of one.
+    rm -f "$swap"
+    if [ "$have" -gt 0 ] && allocate_swapfile "$swap" "$have"; then
+      swapon "$swap"
+      log "WARNING: could not allocate ${want}MiB for $swap — not enough free disk." \
+          "SWAP_SIZE_MB=$want did NOT take effect; the previous ${have}MiB swap is back." \
+          "Grow the disk, or lower SWAP_SIZE_MB, and re-run."
+      return 0
+    fi
+    rm -f "$swap"
+    die "could not allocate ${want}MiB for $swap and could not restore the previous" \
+        "${have}MiB either — this host now has no swap. Free some disk and re-run."
+  fi
   swapon "$swap"
   ensure_block "$fstab" swap "$swap none swap sw 0 0"
   [ "$have" -eq 0 ] || log "resized $swap from ${have}MiB to ${want}MiB"
+}
+
+# fallocate where the filesystem supports it, dd otherwise. Returns non-zero
+# without leaving a partial file behind, so the caller can decide what to do
+# rather than inheriting a truncated swapfile at the live path.
+allocate_swapfile() {
+  local path="$1" mib="$2"
+  if ! { fallocate -l "${mib}M" "$path" 2>/dev/null || \
+         dd if=/dev/zero of="$path" bs=1M count="$mib" status=none 2>/dev/null; }; then
+    rm -f "$path"
+    return 1
+  fi
+  chmod 600 "$path"
+  mkswap "$path" >/dev/null
 }
 
 # Make sure container logs are capped, whether or not this host already has a

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -127,17 +127,55 @@ urlencode() {
   printf '%s' "$out"
 }
 
-# Append a managed block to a config file exactly once, keyed by a marker.
+# Keep a managed block in a config file equal to $content, keyed by a marker.
+# Added on the first run; on later runs the body is replaced in place, so a
+# FORCE=1 re-run with a changed DOCKER_SUBNETS or INSTANCE_HOSTNAME converges
+# the host instead of leaving the previous value in force. In place, not
+# delete-and-append: pg_hba.conf is first-match-wins, and moving the rule to
+# the end of the file could park it behind one that already rejects.
 ensure_block() {
   local file="$1" marker="$2" content="$3"
-  if grep -qF "# BEGIN collavre:$marker" "$file" 2>/dev/null; then
+  local begin="# BEGIN collavre:$marker" end="# END collavre:$marker"
+
+  if ! grep -qF "$begin" "$file" 2>/dev/null; then
+    {
+      printf '\n%s (managed by script/lightsail_launch.sh)\n' "$begin"
+      printf '%s\n' "$content"
+      printf '%s\n' "$end"
+    } >> "$file"
     return 0
   fi
-  {
-    printf '\n# BEGIN collavre:%s (managed by script/lightsail_launch.sh)\n' "$marker"
-    printf '%s\n' "$content"
-    printf '# END collavre:%s\n' "$marker"
-  } >> "$file"
+
+  grep -qF "$end" "$file" || \
+    die "$file: '$begin' with no '$end'. Refusing to rewrite a block I cannot delimit — repair or delete it by hand."
+
+  local tmp
+  tmp="$(mktemp)"
+  # index() rather than an anchored match, so awk sees exactly the lines the
+  # grep above found. END exits non-zero on an unterminated block (END marker
+  # before BEGIN), which would otherwise swallow the rest of the file.
+  if ! BLOCK_BEGIN="$begin" BLOCK_END="$end" BLOCK_BODY="$content" awk '
+      BEGIN { b = ENVIRON["BLOCK_BEGIN"]; e = ENVIRON["BLOCK_END"] }
+      !inside && index($0, b) {
+        inside = 1
+        print b " (managed by script/lightsail_launch.sh)"
+        print ENVIRON["BLOCK_BODY"]
+        print e
+        next
+      }
+      inside && index($0, e) { inside = 0; next }
+      inside { next }
+      { print }
+      END { if (inside) exit 1 }
+    ' "$file" > "$tmp"; then
+    rm -f "$tmp"
+    die "$file: collavre:$marker block is malformed (END before BEGIN?). Repair it by hand."
+  fi
+
+  # Through the existing inode: pg_hba.conf is postgres:postgres 0640, and a
+  # mv from mktemp would hand it root:root 0600 and stop PostgreSQL reading it.
+  cat "$tmp" > "$file"
+  rm -f "$tmp"
 }
 
 # --------------------------------------------------------------------------

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -548,6 +548,42 @@ EOF
 # REASSIGN OWNED moves ownership of everything the old role owns in this
 # database in one statement, including objects added since. It is a no-op when
 # the role owns nothing, so it is safe on a host where the app never booted.
+# Refuse a rotation away from a superuser predecessor, before the database SQL
+# runs and therefore before anything has moved.
+#
+# The earlier form let this case through with a warning, which was worse than it
+# looked. The caller's SQL had already run ALTER DATABASE ... OWNER TO the new
+# role by then, so the run went on to record the new DB_USER and publish a
+# DATABASE_URL naming a role that owns the database and not one table in it —
+# 'permission denied for table users' on the app's first query — while the
+# advanced marker meant no later run would ever look at the old role again.
+#
+# It cannot be converged here. REASSIGN OWNED BY the bootstrap superuser is
+# rejected by PostgreSQL outright ("required by the database system"), and
+# enumerating the objects instead is the fragile thing this function exists to
+# avoid: whatever relkind the enumeration forgets comes back as the same
+# permission error, later and on one table rather than all of them. So the run
+# stops with nothing changed, the marker still naming the old role, and the
+# runbook carries the transfer to do by hand.
+refuse_superuser_db_rotation() {
+  local current="$1" prior_file="${2:-$STATE_DIR/db_user}" prior
+  [ -f "$prior_file" ] || return 0
+  prior="$(cat "$prior_file")"
+  [ -n "$prior" ] && [ "$prior" != "$current" ] || return 0
+  [ "$(psql_as_postgres postgres \
+        "SELECT count(*) FROM pg_roles WHERE rolname = '$prior'")" = 1 ] || return 0
+  [ "$(psql_as_postgres postgres \
+        "SELECT rolsuper FROM pg_roles WHERE rolname = '$prior'")" = t ] || return 0
+
+  die "this host was provisioned with DB_USER='$prior', which is a superuser, and" \
+      "DB_USER is now '$current'. Every table and sequence the app created is owned" \
+      "by '$prior', and PostgreSQL refuses to reassign a superuser's objects, so" \
+      "'$current' would own the database and be unable to read a row of it." \
+      "Nothing has been changed. Move the objects by hand — see 'Changing DB_USER" \
+      "on a re-run' in docs/deploy_to_lightsail.md — then re-run, or set" \
+      "DB_USER='$prior' to leave the rotation undone."
+}
+
 reassign_prior_db_role() {
   local current="$1" prior_file="${2:-$STATE_DIR/db_user}" prior
   [ -f "$prior_file" ] || return 0
@@ -556,14 +592,14 @@ reassign_prior_db_role() {
   [ "$(psql_as_postgres postgres \
         "SELECT count(*) FROM pg_roles WHERE rolname = '$prior'")" = 1 ] || return 0
 
-  # Never touch a superuser. DB_USER=postgres on a first run is a legal thing
-  # to have done, and NOLOGIN on the cluster superuser locks every operator out
-  # of administering it — peer auth needs LOGIN too, so there is no way back in.
+  # A backstop. refuse_superuser_db_rotation() runs before the database SQL and
+  # should have ended the run already; getting here means it was bypassed, and
+  # REASSIGN OWNED BY a superuser is rejected by PostgreSQL itself, so failing
+  # with the reason beats failing with a raw SQL error.
   if [ "$(psql_as_postgres postgres \
             "SELECT rolsuper FROM pg_roles WHERE rolname = '$prior'")" = t ]; then
-    log "WARNING: previous DB_USER '$prior' is a superuser — leaving it alone;" \
-        "move ownership and retire it by hand if that is what you meant"
-    return 0
+    die "previous DB_USER '$prior' is a superuser; its objects cannot be reassigned." \
+        "See 'Changing DB_USER on a re-run' in docs/deploy_to_lightsail.md."
   fi
 
   psql_as_postgres "$DB_NAME" "REASSIGN OWNED BY \"$prior\" TO \"$current\""
@@ -976,6 +1012,10 @@ fi
 # The chmod stays to converge a file an earlier revision left 0644.
 ( umask 077; printf '%s' "$DB_PASSWORD" > "$STATE_DIR/db_password" )
 chmod 0600 "$STATE_DIR/db_password"
+
+# Before anything moves: a rotation away from a superuser predecessor cannot be
+# completed, so it must not be started.
+refuse_superuser_db_rotation "$DB_USER"
 
 # Mirrors db/setup_postgres_databases.sql: create-if-missing, never drop.
 # Collavre keeps primary/cache/queue/cable in ONE database — the Solid Queue,

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -2,9 +2,10 @@
 #
 # Collavre — AWS Lightsail launch script (instance user data).
 #
-# Paste the contents of this file into the "Launch script" box when creating a
-# Lightsail instance (Ubuntu 24.04 LTS blueprint), or run it by hand on a fresh
-# instance as root:
+# This file is larger than the Lightsail "Launch script" limit. Use the
+# commit-pinned download bootstrap in docs/deploy_to_lightsail.md when creating
+# an instance (Ubuntu 24.04 LTS blueprint), or run it by hand on a fresh instance
+# as root:
 #
 #   sudo SSH_PUBLIC_KEY="ssh-ed25519 AAAA..." bash script/lightsail_launch.sh
 #

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -447,6 +447,28 @@ ensure_block() {
   local file="$1" marker="$2" content="$3"
   local begin="# BEGIN collavre:$marker" end="# END collavre:$marker"
 
+  # Resolved before anything else, because the rewrite below installs by
+  # rename(2) and rename does not follow symlinks: pointed at a symlinked
+  # /etc/hosts it would replace the link with a regular file, and the next
+  # thing to read the real path would see the pre-managed contents. The
+  # append branch below and the previous `cat >` both wrote *through* the
+  # link, so resolving here is what keeps the two paths writing to the same
+  # file. `readlink -f` is not used: it is a GNU extension that only reached
+  # macOS recently, and this suite runs on both.
+  local hops=0
+  while [ -L "$file" ]; do
+    local target
+    target="$(readlink "$file")" ||
+      die "$file: is a symlink I cannot read. Repair or replace it by hand."
+    case "$target" in
+      /*) file="$target" ;;
+      *)  file="$(dirname "$file")/$target" ;;
+    esac
+    hops=$((hops + 1))
+    [ "$hops" -lt 16 ] ||
+      die "$file: symlink chain is too deep to follow. Repair it by hand."
+  done
+
   if ! grep -qF "$begin" "$file" 2>/dev/null; then
     {
       printf '\n%s (managed by script/lightsail_launch.sh)\n' "$begin"
@@ -460,7 +482,34 @@ ensure_block() {
     die "$file: '$begin' with no '$end'. Refusing to rewrite a block I cannot delimit — repair or delete it by hand."
 
   local tmp
-  tmp="$(mktemp)"
+  # Staged beside the target, not in $TMPDIR: same filesystem, so the swap
+  # below is one rename(2) and the staging has already proved the space is
+  # there. The mode and ownership are taken from the file being replaced and
+  # set before any content is written, so the staging file is never briefly
+  # readable by more than the live one already is.
+  #
+  # Copied from the target rather than hard-coded: this helper rewrites
+  # /etc/fstab and /etc/hosts (root:root 0644) as well as postgresql.conf and
+  # pg_hba.conf (postgres:postgres 0640), and naming either here would be a
+  # second spelling of what the target already says — one that goes wrong
+  # silently the first time a caller points this at a fourth file.
+  #
+  # `cp -p` rather than chmod/chown --reference: --reference is a GNU
+  # extension, and this suite's cases run on the maintainer's macOS as well as
+  # on the Ubuntu the script provisions. It copies the content too, which is
+  # redundant since awk overwrites it — these are files of a few KB, and the
+  # cost buys one spelling that works on both.
+  #
+  # A staging file that could not be given the target's identity is one that
+  # must not be installed: a pg_hba.conf PostgreSQL cannot read back stops the
+  # cluster, so this refuses rather than proceeding at mktemp's root-only 0600.
+  tmp="$(mktemp "$file.collavre.XXXXXX")" ||
+    die "$file: could not stage a rewrite beside it. Is $(dirname "$file") writable?"
+  if ! cp -p "$file" "$tmp" 2>/dev/null; then
+    rm -f "$tmp"
+    die "$file: could not give a staged rewrite the same owner and mode as the" \
+        "file it replaces, so it was NOT installed and $file is untouched."
+  fi
   # index() rather than an anchored match, so awk sees exactly the lines the
   # grep above found. END exits non-zero on an unterminated block (END marker
   # before BEGIN), which would otherwise swallow the rest of the file.
@@ -482,10 +531,20 @@ ensure_block() {
     die "$file: collavre:$marker block is malformed (END before BEGIN?). Repair it by hand."
   fi
 
-  # Through the existing inode: pg_hba.conf is postgres:postgres 0640, and a
-  # mv from mktemp would hand it root:root 0600 and stop PostgreSQL reading it.
-  cat "$tmp" > "$file"
-  rm -f "$tmp"
+  # Renamed, never copied through the existing inode. `cat "$tmp" > "$file"`
+  # truncates the live path when the redirection opens, so a run killed during
+  # the copy — an OOM kill on a 512MB instance, a power loss — leaves the file
+  # holding a prefix of itself. Measured by sampling the live path during the
+  # copy of a large pg_hba.conf: 0 bytes. These are the files that decide
+  # whether the host comes back, and each fails a different way — an empty
+  # pg_hba.conf refuses every connection, a truncated fstab loses mounts, and
+  # a block left without its END marker makes the *next* run die on "repair or
+  # delete it by hand" rather than converge.
+  #
+  # The in-place copy was there to preserve owner and mode; that is now done on
+  # the staging file above, where it costs nothing and does not require the
+  # live path to be destroyed first.
+  mv -f "$tmp" "$file"
 }
 
 # Give $1 passwordless sudo, and make sure it is the only deploy user holding
@@ -1109,11 +1168,59 @@ refuse_superuser_db_rotation() {
       "or set DB_USER='$prior' to leave the rotation undone."
 }
 
-reassign_prior_db_role() {
-  local current="$1" prior_file="${2:-$STATE_DIR/db_user}" prior
-  [ -f "$prior_file" ] || return 0
-  prior="$(cat "$prior_file")"
-  [ -n "$prior" ] && [ "$prior" != "$current" ] || return 0
+# record_db_role_grant <role> [set file] [legacy single marker]
+#
+# The same shape as record_deploy_user_grant, one resource over, and for the
+# same reason: db_user is a single marker, so it can name the role this host is
+# *currently* deployed against or the queue of roles a rotation has not finished
+# retiring, but not both.
+#
+# The interrupted A -> B -> C sequence is what it cannot survive. Ownership is
+# moved by reassign_prior_db_role and the marker is advanced on the next line;
+# a run that dies between them leaves every table owned by B while db_user still
+# says A. If the operator's next run asks for C rather than replaying B, the
+# rotation reads A as the predecessor, reassigns from a role that owns nothing,
+# moves no objects, records C, and the summary hands out a DATABASE_URL for a
+# role that cannot read a row. Measured against 07365195:
+#
+#   run2  A -> B, dies before the marker write   objects: B   db_user: A
+#   run3  C                                      objects: B   db_user: C
+#
+# Nothing on the host names B at that point, so no later run can find it either.
+# Called before the role is made an owner, not after, for the same reason the
+# deploy-user version is called before the grant: a name in this file that turns
+# out to own nothing costs one cheap query, and a name missing from it is a
+# database whose owner nothing is looking for.
+record_db_role_grant() {
+  local role="$1" set_file="${2:-$STATE_DIR/db_users}"
+  local prior_file="${3:-$STATE_DIR/db_user}"
+  # Upgrade path, as for deploy_users: on a host provisioned by the earlier
+  # revision the single marker names the one predecessor it knew about, and
+  # seeding from it means the fix for forgetting roles does not start by
+  # forgetting one. Guarded on `! -f`, so it runs once per host — the write is
+  # therefore all-or-nothing, and a failed seed leaves the file absent for a
+  # retry rather than empty and authoritative.
+  if [ ! -f "$set_file" ] && [ -s "$prior_file" ]; then
+    local seed
+    seed="$(grep -v '^[[:space:]]*$' "$prior_file")" || seed=''
+    if [ -n "$seed" ]; then
+      write_state_file "$set_file" "$seed"$'\n' || return 1
+    fi
+  fi
+  grep -qxF "$role" "$set_file" 2>/dev/null ||
+    printf '%s\n' "$role" >> "$set_file"
+}
+
+# reassign_one_db_role <prior> <current>
+#
+# Moves one replaced role's objects. Returns 0 when there is nothing left for a
+# later run to do with <prior>, non-zero when it must stay in the queue — so the
+# caller decides what is still outstanding, rather than this deciding it by
+# where it writes a marker.
+reassign_one_db_role() {
+  local prior="$1" current="$2"
+  # A role that no longer exists owns nothing and cannot be reassigned: there
+  # is nothing outstanding, so it leaves the queue.
   [ "$(psql_as_postgres postgres \
         "SELECT count(*) FROM pg_roles WHERE rolname = '$prior'")" = 1 ] || return 0
 
@@ -1152,6 +1259,43 @@ reassign_prior_db_role() {
   log "revoked LOGIN from the replaced database role '$prior'"
 }
 
+reassign_prior_db_role() {
+  local current="$1" prior_file="${2:-$STATE_DIR/db_user}"
+  local set_file="${3:-${prior_file%/*}/db_users}" prior kept=''
+
+  # Not a no-op on the ordinary path: this seeds the set on a host the earlier
+  # revision provisioned, and puts $current in it on a first run, so that a
+  # later rotation has something to reassign from.
+  record_db_role_grant "$current" "$set_file" "$prior_file" || {
+    # Returning rather than carrying on: the loop reads $set_file, which on
+    # this path may not exist. Nothing has been reassigned, and the file is
+    # left in the state a later run retries from.
+    log "WARNING: could not record '$current' in '$set_file'; no database role" \
+        "was reassigned on this run, and the queue is unchanged"
+    return 1
+  }
+
+  while read -r prior; do
+    [ -n "$prior" ] || continue
+    # The role this run deploys against stays in the set: it is the predecessor
+    # the *next* rotation reassigns from.
+    if [ "$prior" = "$current" ]; then
+      kept="$kept$prior"$'\n'
+      continue
+    fi
+    reassign_one_db_role "$prior" "$current" || kept="$kept$prior"$'\n'
+  done < "$set_file"
+
+  # Rewritten only after the loop, so a REASSIGN that fails under `set -e` takes
+  # the run down with the queue intact and every member retried — the failure
+  # cannot quietly consume the entry it failed on.
+  write_state_file "$set_file" "$kept" ||
+    log "WARNING: could not rewrite '$set_file'. Ownership was moved, but this" \
+        "host still lists roles a later run will try to reassign again;" \
+        "REASSIGN OWNED BY on a role that owns nothing is a no-op, so the retry" \
+        "is harmless. Check that $STATE_DIR has space."
+}
+
 # refuse_db_name_change <name> [state dir]
 #
 # DB_NAME is the one identifier a re-run could change with no trace at all. The
@@ -1176,9 +1320,18 @@ reassign_prior_db_role() {
 refuse_db_name_change() {
   local current="$1" state_dir="${2:-$STATE_DIR}" prior others
 
-  if [ -f "$state_dir/db_name" ]; then
-    prior="$(cat "$state_dir/db_name")"
-    [ -n "$prior" ] && [ "$prior" != "$current" ] || return 0
+  # Read into a variable rather than branching on the file, because an empty
+  # marker is not the same question as an absent one and must not answer it.
+  # A truncated db_name says "a name was recorded and this run cannot read it",
+  # which is exactly the case the no-record path below is built to catch; the
+  # earlier form returned 0 from inside the `-f` branch, so an empty file
+  # skipped both this comparison and that fallback, and the guard passed
+  # anything.
+  prior=''
+  [ -f "$state_dir/db_name" ] && prior="$(cat "$state_dir/db_name")"
+
+  if [ -n "$prior" ]; then
+    [ "$prior" != "$current" ] || return 0
     die "this host was provisioned with DB_NAME='$prior', and DB_NAME is now" \
         "'$current'. This script creates a database if it is missing; it does not" \
         "rename or copy one, so '$current' would be created empty while the app's" \
@@ -1188,9 +1341,10 @@ refuse_db_name_change() {
         "on a re-run' in docs/deploy_to_lightsail.md."
   fi
 
-  # No record. On a genuine first run there is nothing to protect, and adopting
-  # the name is right. On a host provisioned by a revision that did not track it
-  # there is: db_user is the marker that says this script has run here before.
+  # No usable record — absent, or present but unreadable. On a genuine first run
+  # there is nothing to protect, and adopting the name is right. On a host
+  # provisioned by a revision that did not track it there is: db_user is the
+  # marker that says this script has run here before.
   [ -f "$state_dir/db_user" ] || return 0
   [ "$(psql_as_postgres postgres \
         "SELECT count(*) FROM pg_database WHERE datname = '$current'")" = 0 ] || return 0
@@ -1667,8 +1821,60 @@ install_staged_authorized_keys() {
   mv -f "$tmp" "$auth_keys"
 }
 
+# record_ssh_key_grant <key> [set file] [legacy single marker]
+#
+# The third instance of the same separation, after deploy_users and db_users:
+# ssh_public_key.<user> is the key this host is *currently* deployed with, and
+# this file is the set of managed keys no run has confirmed withdrawn. One
+# marker cannot be both, and the A -> B -> C sequence is where it shows.
+#
+# install_authorized_keys appends the successor and revoke_prior_ssh_key
+# advances the marker afterwards, so a run that dies between them leaves B in
+# authorized_keys with the marker still naming A. A later run rotating to C
+# withdraws A — the only key the marker knows — records C, and B stays
+# authorized with nothing on the host naming it. Measured against 07365195:
+#
+#   control  A -> B -> C                       keys=[C]    marker=C
+#   run2 interrupted before the marker write:
+#            A -> B(interrupted) -> C          keys=[B C]  marker=C
+#
+# B is not a stale entry in a file: this account holds passwordless sudo and the
+# docker socket, so an untracked key on it is permanent root on the host, and it
+# is untracked precisely because the rotation that was supposed to retire it is
+# the thing that lost the record.
+#
+# Called before the key is appended, not after — the same ordering as
+# record_deploy_user_grant, and for the same reason: a key in this file that
+# turns out not to be in authorized_keys costs one grep, and a key missing from
+# it is root access nobody is looking for.
+record_ssh_key_grant() {
+  local key="$1" set_file="${2:-$STATE_DIR/ssh_public_keys.$APP_SSH_USER}"
+  local prior_file="${3:-$STATE_DIR/ssh_public_key.$APP_SSH_USER}"
+  [ -n "$key" ] || return 0
+  # Upgrade path, guarded on `! -f` so it runs once per host: seed from the
+  # single marker the earlier revision kept, which names the predecessor most
+  # likely to still be authorized. A failed seed leaves the file absent — the
+  # state a retry starts from — rather than empty and authoritative.
+  if [ ! -f "$set_file" ] && [ -s "$prior_file" ]; then
+    local seed
+    seed="$(grep -v '^[[:space:]]*$' "$prior_file")" || seed=''
+    if [ -n "$seed" ]; then
+      write_state_file "$set_file" "$seed"$'\n' || return 1
+    fi
+  fi
+  grep -qxF "$key" "$set_file" 2>/dev/null ||
+    printf '%s\n' "$key" >> "$set_file"
+}
+
 revoke_prior_ssh_key() {
-  local auth_keys="$1" state="${2:-$STATE_DIR/ssh_public_key.$APP_SSH_USER}" prior tmp
+  local auth_keys="$1" state="${2:-$STATE_DIR/ssh_public_key.$APP_SSH_USER}"
+  # Derived from $state, not rebuilt from $APP_SSH_USER: a caller that passes
+  # an explicit marker path — every case in the suite that predates the queue —
+  # need not also have $APP_SSH_USER set, and the two names cannot drift onto
+  # different accounts. 'ssh_public_key.deploy' -> 'ssh_public_keys.deploy'.
+  local base="${state##*/}"
+  local set_file="${3:-${state%/*}/ssh_public_keys${base#ssh_public_key}}"
+  local prior tmp pat kept='' drop='' n=0
   # An empty SSH_PUBLIC_KEY means "keep using the cloud user's keys", not
   # "retire the managed one" — withdrawing here would strand an operator who
   # simply dropped the variable from a re-run.
@@ -1677,44 +1883,84 @@ revoke_prior_ssh_key() {
   # must leave two usable keys, never zero.
   grep -qxF "$SSH_PUBLIC_KEY" "$auth_keys" || return 0
 
-  if [ -f "$state" ]; then
-    prior="$(cat "$state")"
-    if [ -n "$prior" ] && [ "$prior" != "$SSH_PUBLIC_KEY" ] &&
-       grep -qxF "$prior" "$auth_keys"; then
-      # Staged beside the target rather than in $TMPDIR: same filesystem, so
-      # the rewrite below cannot fail for space the staging just proved is
-      # there, and a small or full /tmp is not on its own able to break the
-      # file the operator logs in with.
-      tmp="$(mktemp "$auth_keys.revoke.XXXXXX")"
-      # Exact whole-line match: a key is withdrawn only if it is byte-for-byte
-      # the one recorded, so an operator key that merely shares a comment or a
-      # prefix survives.
-      grep -vxF "$prior" "$auth_keys" > "$tmp" || true
-      # Check what the staged file *is*, not merely that it exists. `grep`
-      # writing a short file is the dangerous case and it is the likely one:
-      # the successor was appended, so it is the last line, and a write that
-      # runs out of space stops before reaching it. A size test passes on
-      # that file, `cat` installs it, and the account is locked out of a host
-      # whose log says the rotation succeeded. The `|| true` above — needed so
-      # `set -e` does not fire on grep's "no lines selected" — is what hides
-      # the error, so the successor's presence has to be re-established here.
-      # The install is part of the condition rather than a statement after it:
-      # it declines to install a file it could not give to the user, and a
-      # withdrawal that did not reach the live file has withdrawn nothing.
-      if grep -qxF "$SSH_PUBLIC_KEY" "$tmp" &&
-         install_staged_authorized_keys "$tmp" "$auth_keys"; then
-        log "withdrew the SSH key this script installed on a previous run"
-      else
-        rm -f "$tmp"
-        log "WARNING: could not withdraw the previous SSH key — is the disk full?" \
-            "It is still authorized; remove it by hand once the host is healthy"
-        # Deliberately leave the marker pointing at the key still in the file,
-        # so the next run retries the withdrawal instead of forgetting it.
-        return 0
-      fi
+  # Seeds the set on a host the earlier revision provisioned, and puts the
+  # current key in it on a first run, so a later rotation has a predecessor to
+  # withdraw. The call site records it earlier too, before the append; this one
+  # is what makes the function correct when called on its own.
+  record_ssh_key_grant "$SSH_PUBLIC_KEY" "$set_file" "$state" || {
+    log "WARNING: could not record the current SSH key in '$set_file'; no key" \
+        "was withdrawn on this run, and the queue is unchanged"
+    return 0
+  }
+
+  while read -r prior; do
+    [ -n "$prior" ] || continue
+    # The key this run deploys with stays: it is what the *next* rotation
+    # withdraws.
+    if [ "$prior" = "$SSH_PUBLIC_KEY" ]; then
+      kept="$kept$prior"$'\n'
+      continue
+    fi
+    # Already absent from authorized_keys — withdrawn by an earlier run, or by
+    # the operator. Nothing outstanding, so it leaves the queue.
+    grep -qxF "$prior" "$auth_keys" || continue
+    drop="$drop$prior"$'\n'
+    n=$((n + 1))
+  done < "$set_file"
+
+  if [ -n "$drop" ]; then
+    # One rewrite for the whole queue rather than one per key: each rewrite is
+    # a chance to install a short file, and authorized_keys is the only way
+    # into this host.
+    #
+    # Staged beside the target rather than in $TMPDIR: same filesystem, so
+    # the rewrite below cannot fail for space the staging just proved is
+    # there, and a small or full /tmp is not on its own able to break the
+    # file the operator logs in with.
+    pat="$(mktemp "$auth_keys.revoke.XXXXXX")"
+    printf '%s' "$drop" > "$pat"
+    tmp="$(mktemp "$auth_keys.revoke.XXXXXX")"
+    # Exact whole-line matches: a key is withdrawn only if it is byte-for-byte
+    # one of those recorded, so an operator key that merely shares a comment or
+    # a prefix survives.
+    grep -vxF -f "$pat" "$auth_keys" > "$tmp" || true
+    rm -f "$pat"
+    # Check what the staged file *is*, not merely that it exists. `grep`
+    # writing a short file is the dangerous case and it is the likely one:
+    # the successor was appended, so it is the last line, and a write that
+    # runs out of space stops before reaching it. A size test passes on
+    # that file, the install goes ahead, and the account is locked out of a
+    # host whose log says the rotation succeeded. The `|| true` above —
+    # needed so `set -e` does not fire on grep's "no lines selected" — is
+    # what hides the error, so the successor's presence has to be
+    # re-established here. The install is part of the condition rather than a
+    # statement after it: it declines to install a file it could not give to
+    # the user, and a withdrawal that did not reach the live file has
+    # withdrawn nothing.
+    if grep -qxF "$SSH_PUBLIC_KEY" "$tmp" &&
+       install_staged_authorized_keys "$tmp" "$auth_keys"; then
+      log "withdrew $n SSH key(s) this script installed on previous runs"
+    else
+      rm -f "$tmp"
+      log "WARNING: could not withdraw $n previous SSH key(s) — is the disk full?" \
+          "They are still authorized; remove them by hand once the host is healthy"
+      # Deliberately kept in the queue, so the next run retries the withdrawal
+      # instead of forgetting keys that still hold root on this account.
+      kept="$kept$drop"
     fi
   fi
-  printf '%s\n' "$SSH_PUBLIC_KEY" > "$state"
+
+  write_state_file "$set_file" "$kept" ||
+    log "WARNING: could not rewrite '$set_file'. Any key withdrawn above is" \
+        "still withdrawn; this host merely still lists it, and a later run" \
+        "will find it absent from $auth_keys and drop it then."
+
+  # The single marker stays the record of the key this host is deployed with —
+  # adopt_legacy_ssh_key_marker keys off its presence — while the set above is
+  # the queue. Written atomically: a bare redirection truncates at open, and an
+  # empty marker here reads as "no managed key" to the adoption path.
+  write_state_file "$state" "$SSH_PUBLIC_KEY"$'\n' ||
+    log "WARNING: could not record the current SSH key in '$state'"
 }
 
 # dedupe_authorized_keys <authorized_keys> [key that must survive]
@@ -1764,6 +2010,15 @@ dedupe_authorized_keys() {
 # see adopt_legacy_ssh_key_marker. It has to happen there rather than here: the
 # case it refuses is one where this run would otherwise re-arm a key it cannot
 # identify, and by this point the sudo half of that is already done.
+# Before the append, not after. install_authorized_keys puts the key in
+# authorized_keys on an account that already holds sudo and docker; an
+# interrupted run between that and the record below would otherwise leave a
+# root-equivalent key no later run can find.
+record_ssh_key_grant "$SSH_PUBLIC_KEY" ||
+  die "could not record the SSH key in $STATE_DIR/ssh_public_keys.$APP_SSH_USER," \
+      "so this run cannot promise that a later one could find the key again." \
+      "Nothing has been installed. Check that $STATE_DIR is writable and has" \
+      "space, then re-run."
 install_authorized_keys "$AUTH_KEYS"
 revoke_prior_ssh_key "$AUTH_KEYS"
 dedupe_authorized_keys "$AUTH_KEYS" "$SSH_PUBLIC_KEY"
@@ -1983,6 +2238,15 @@ chmod 0600 "$STATE_DIR/db_password"
 # Collavre keeps primary/cache/queue/cable in ONE database — the Solid Queue,
 # Cache and Cable tables are created by a primary db/migrate migration. Do not
 # add separate _cache/_queue/_cable databases.
+# Before the role is created and made the database's owner, not after. The
+# reassignment below and the marker write after it are two steps, and an
+# interrupted run between them is what strands a role that owns every table
+# with nothing on the host naming it.
+record_db_role_grant "$DB_USER" ||
+  die "could not record '$DB_USER' in $STATE_DIR/db_users, so this run cannot" \
+      "promise that a later one could find the role again. Nothing has been" \
+      "changed. Check that $STATE_DIR is writable and has space, then re-run."
+
 SQL_FILE="$(mktemp /tmp/collavre-db.XXXXXX.sql)"
 trap 'rm -f "$SQL_FILE"' EXIT
 ESCAPED_PASSWORD="${DB_PASSWORD//\'/\'\'}"
@@ -2006,10 +2270,23 @@ trap - EXIT
 # After the role and database exist, before the summary hands out a
 # DATABASE_URL naming the new role.
 reassign_prior_db_role "$DB_USER"
-printf '%s\n' "$DB_USER" > "$STATE_DIR/db_user"
+# Both through write_state_file rather than a redirection. `>` truncates before
+# it writes, so an interrupted run leaves the marker present and empty — and
+# both readers treat an empty marker as "nothing recorded here" rather than as
+# "this could not be read", which is the guard answering with the one value it
+# has no evidence for.
+write_state_file "$STATE_DIR/db_user" "$DB_USER"$'\n' ||
+  die "could not record DB_USER='$DB_USER' in $STATE_DIR/db_user. The role and" \
+      "database exist and this run has not handed out a DATABASE_URL yet, so" \
+      "re-running with the same DB_USER is safe. Check that $STATE_DIR is" \
+      "writable and has space."
 # Recorded only once the database it names actually exists, so an interrupted
 # run cannot leave a marker for a database that was never created.
-printf '%s\n' "$DB_NAME" > "$STATE_DIR/db_name"
+write_state_file "$STATE_DIR/db_name" "$DB_NAME"$'\n' ||
+  die "could not record DB_NAME='$DB_NAME' in $STATE_DIR/db_name, so a later" \
+      "run could not tell a corrected typo from a rename and would refuse." \
+      "The database exists and holds the app's data. Check that $STATE_DIR is" \
+      "writable and has space, then re-run with the same DB_NAME."
 
 # --------------------------------------------------------------------------
 log "7/9 firewall"

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -1136,16 +1136,79 @@ ensure_docker_log_caps() {
   # replace the link itself.
   file="$(resolve_symlink_chain "$file")" || exit 1
 
+  # An existing but empty daemon.json is treated as absent, and this is the read
+  # side of the same accident — it repairs hosts the staged create below can
+  # only stop from happening again. Truncate-at-open is what a failed `cat >`
+  # leaves, so 0 bytes is the likely damage, and it is the one size the rewrite
+  # path cannot see: `jq empty` exits 0 on an empty file, and
+  # `."log-driver" // "json-file"` comes back as the empty string rather than
+  # the default, so the run reports "log-driver is '', which rotates on its own"
+  # — an all-clear over a host whose container logs are uncapped, which is the
+  # one failure this function exists to prevent.
+  #
+  # Replacing it destroys nothing, which is why this may act where the
+  # invalid-JSON branch below must not: a partial file may hold half of an
+  # operator's configuration and nothing distinguishes it from a file this
+  # script tore, but an empty one holds no decision of theirs to lose.
+  if [ -f "$file" ] && [ ! -s "$file" ]; then
+    log "$file exists but is empty — that is what an interrupted create leaves," \
+        "not a configuration, so it is being written afresh"
+    rm -f "$file"
+  fi
+
   if [ ! -f "$file" ]; then
+    # Staged and renamed, like the rewrite below. `cat > "$file"` opens the live
+    # path with O_TRUNC, so a write cut short by a full disk or a kill leaves a
+    # partial daemon.json that no later run repairs — the retry finds the file
+    # present, so it takes the rewrite path, where every branch declines:
+    #
+    #   live file after a torn create   what the operator's retry then says
+    #   0 bytes                         "log-driver is '', which rotates on
+    #                                    its own; leaving it alone"
+    #   20 bytes / 60 bytes             "not valid JSON ... left untouched
+    #                                    rather than overwritten — it is not
+    #                                    this script's file"
+    #
+    # The 0-byte row is the likely one, since that is what truncate-at-open
+    # leaves when the write fails immediately, and it is the worse of the two:
+    # `jq empty` exits 0 on an empty file, `."log-driver" // "json-file"` comes
+    # back as the empty string rather than the default, and the run reports the
+    # host as having an operator who chose another driver. Not a warning — an
+    # all-clear, over a host whose logs are uncapped, which is the one failure
+    # this function exists to prevent.
+    #
+    # The other row is loud but no more repairable, and its message is wrong in
+    # the specific way that matters: it is exactly this script's file. Nothing
+    # in the rewrite path can tell a partial file this script wrote from an
+    # operator's broken one, and it must not guess — which is why the fix is
+    # here, keeping the partial file off the live path, rather than there.
+    #
     # Indented so no line of the body starts at column 1: the unit tests extract
     # these functions with an awk range that ends at the first column-1 "}", and
     # a bare closing brace in a heredoc would cut the function in half.
-    cat > "$file" <<'JSON'
+    tmp="$(stage_beside "$file")" || {
+      log "WARNING: could not stage $file beside itself, so it was NOT created" \
+          "and container logs are NOT capped. Create it by hand with" \
+          '{"log-driver": "json-file", "log-opts": {"max-size": "10m", "max-file": "3"}}.'
+      return 0
+    }
+    if ! cat > "$tmp" <<'JSON' || ! jq empty "$tmp" >/dev/null 2>&1; then
     {
       "log-driver": "json-file",
       "log-opts": { "max-size": "10m", "max-file": "3" }
     }
 JSON
+      rm -f "$tmp"
+      log "WARNING: a staged $file did not come out as valid JSON, so it was" \
+          "NOT installed and container logs are NOT capped. The live path is" \
+          "untouched, so a later run creates it cleanly."
+      return 0
+    fi
+    # No chmod: stage_beside gives a staging file for an absent target the
+    # 0644 the old `cat >` produced, and refuses rather than installing at
+    # mktemp's 0600 — a daemon.json dockerd cannot read is the same outage by
+    # another route.
+    mv -f "$tmp" "$file"
     DAEMON_JSON_CHANGED=1
     return 0
   fi
@@ -2176,6 +2239,25 @@ install_authorized_keys() {
     fi
     return 0
   done
+
+  # No SSH_PUBLIC_KEY and no cloud user to copy from. A `for` loop whose every
+  # iteration took the `continue` completes with status 0, so that used to be
+  # this function's answer — the contract above says non-zero aborts the run,
+  # and the one path where nothing could be installed was the one reporting
+  # success.
+  #
+  # Not unconditionally, though: an account that already has a key is not a
+  # failure to give it one. A host whose cloud user was renamed or removed
+  # converges through here on every later run with authorized_keys already
+  # populated, and refusing that would take down every re-run on a host that is
+  # working — a worse defect than the one being fixed, and one no negative
+  # control catches, since a control only exercises the empty file.
+  if [ -s "$auth_keys" ]; then
+    log "no SSH_PUBLIC_KEY given and no cloud user's keys to copy —" \
+        "$auth_keys already authorizes someone, so it is left as it is"
+    return 0
+  fi
+  return 1
 }
 
 # revoke_prior_ssh_key <authorized_keys> [state file]
@@ -2453,17 +2535,58 @@ record_ssh_key_grant "$SSH_PUBLIC_KEY" ||
       "so this run cannot promise that a later one could find the key again." \
       "Nothing has been installed. Check that $STATE_DIR is writable and has" \
       "space, then re-run."
-install_authorized_keys "$AUTH_KEYS"
+# The status is acted on rather than left to errexit. A bare call does abort
+# under `set -euo pipefail`, but it aborts with nothing said — and the one thing
+# this failure needs to say is which account was left holding sudo, since the
+# operator's next move is either to supply a key or to take that grant back.
+install_authorized_keys "$AUTH_KEYS" ||
+  die "no SSH key could be installed for '$APP_SSH_USER': SSH_PUBLIC_KEY is" \
+      "empty, none of /home/{ubuntu,admin,ec2-user}/.ssh/authorized_keys" \
+      "exists, and $AUTH_KEYS is empty. Stopping here rather than finishing:" \
+      "'$APP_SSH_USER' already has passwordless sudo from the step above, and" \
+      "a run that carried on would print KAMAL_SSH_USER=$APP_SSH_USER over an" \
+      "account nothing can log in as. The grant is recorded in" \
+      "$STATE_DIR/deploy_users, so a later run naming a different APP_SSH_USER" \
+      "takes it back. Re-run with" \
+      "SSH_PUBLIC_KEY=\"\$(cat ~/.ssh/id_ed25519.pub)\"."
 revoke_prior_ssh_key "$AUTH_KEYS"
 dedupe_authorized_keys "$AUTH_KEYS" "$SSH_PUBLIC_KEY"
 chown "$APP_SSH_USER:$APP_SSH_GROUP" "$AUTH_KEYS"
 chmod 0600 "$AUTH_KEYS"
+# Still a warning rather than a second gate, and what it covers has narrowed to
+# the *other* way this file ends up empty: a withdrawal or a dedupe that removed
+# the last line, where a key was installed and stopping would be wrong. The
+# no-key-at-all case is the `die` above, which is the one that has to stop.
 [ -s "$AUTH_KEYS" ] || log "WARNING: $AUTH_KEYS is empty — kamal will not be able to connect"
 
 # --------------------------------------------------------------------------
 log "4/9 Docker CE"
 # --------------------------------------------------------------------------
+# What to install, decided per package rather than from the presence of the
+# `docker` binary. The plugin install used to sit inside `if ! command -v
+# docker`, which made it unreachable on the one host that needs it named
+# separately: a by-hand run on an existing instance — the documented path — that
+# already carries Ubuntu's `docker.io`. There `command -v docker` answers, the
+# whole branch is skipped, and neither buildx nor compose is ever installed,
+# while docs/deploy_to_lightsail.md tells the operator the launch script
+# installs buildx so the remote builder works out of the box. The first
+# `builder.remote` Kamal build then fails on a host this script reported as
+# converged.
+#
+# `docker buildx version` rather than a test on a path: the CLI looks for
+# plugins in several directories, and what decides whether Kamal can build is
+# whether the CLI finds one, not whether a particular file is there.
+DOCKER_WANT=''
 if ! command -v docker >/dev/null 2>&1; then
+  DOCKER_WANT='docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin'
+else
+  docker buildx version  >/dev/null 2>&1 || DOCKER_WANT="$DOCKER_WANT docker-buildx-plugin"
+  docker compose version >/dev/null 2>&1 || DOCKER_WANT="$DOCKER_WANT docker-compose-plugin"
+  [ -z "$DOCKER_WANT" ] ||
+    log "docker is already installed but$DOCKER_WANT is missing — installing it"
+fi
+
+if [ -n "$DOCKER_WANT" ]; then
   install -m 0755 -d /etc/apt/keyrings
   curl -fsSL https://download.docker.com/linux/ubuntu/gpg \
     -o /etc/apt/keyrings/docker.asc
@@ -2474,8 +2597,8 @@ if ! command -v docker >/dev/null 2>&1; then
 deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $VERSION_CODENAME stable
 EOF
   apt_get update -y
-  apt_install docker-ce docker-ce-cli containerd.io \
-    docker-buildx-plugin docker-compose-plugin
+  # shellcheck disable=SC2086  # a package list, deliberately word-split
+  apt_install $DOCKER_WANT
 fi
 
 # Cap container logs — an unrotated Rails log fills a Lightsail SSD fast.

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -1,0 +1,433 @@
+#!/usr/bin/env bash
+#
+# Collavre — AWS Lightsail launch script (instance user data).
+#
+# Paste the contents of this file into the "Launch script" box when creating a
+# Lightsail instance (Ubuntu 24.04 LTS blueprint), or run it by hand on a fresh
+# instance as root:
+#
+#   sudo SSH_PUBLIC_KEY="ssh-ed25519 AAAA..." bash script/lightsail_launch.sh
+#
+# What it does (host preparation only — it never builds or runs the app):
+#
+#   1. base packages, timezone, swap, SSH hardening
+#   2. a deploy user (default: collavre) in the docker group, for `kamal`
+#   3. Docker CE + buildx + compose plugins, with log rotation
+#   4. PostgreSQL, reachable ONLY from containers on this host
+#   5. the collavre_production database + application role (idempotent)
+#   6. ufw firewall, nightly pg_dump backups with retention
+#
+# The app itself is deployed afterwards from your workstation with
+# `bin/kamal setup`, which builds the image and boots the container. See
+# docs/deploy_to_lightsail.md for the full runbook.
+#
+# The script is idempotent: re-running it converges the host instead of
+# duplicating configuration. Re-run with FORCE=1 after the first success.
+#
+set -euo pipefail
+
+# --------------------------------------------------------------------------
+# Configuration — edit these before pasting into the Lightsail console.
+# Every value can also be supplied as an environment variable.
+# --------------------------------------------------------------------------
+
+# SSH public key that may log in as the deploy user. Leave empty to reuse the
+# key Lightsail installed for the default `ubuntu` user.
+: "${SSH_PUBLIC_KEY:=}"
+
+# Deploy user. Must match KAMAL_SSH_USER in .env.production.
+: "${APP_SSH_USER:=collavre}"
+
+# PostgreSQL major version (from the PGDG apt repository).
+: "${PG_MAJOR:=17}"
+
+# Database and role. Defaults match db/setup_postgres_databases.sql.
+: "${DB_NAME:=collavre_production}"
+: "${DB_USER:=collavre_user}"
+# Leave empty to generate a random URL-safe password.
+: "${DB_PASSWORD:=}"
+
+# Address PostgreSQL listens on for container traffic. 172.17.0.1 is the
+# docker0 bridge gateway: reachable from every container on this host and from
+# nowhere else. Do NOT set this to the public or private instance address.
+: "${DB_BIND_ADDRESS:=172.17.0.1}"
+# Source range allowed to reach that address (all Docker bridge networks).
+: "${DOCKER_SUBNETS:=172.16.0.0/12}"
+
+# Swap file size in MiB. Rails asset builds and pg_dump both want headroom on
+# small instances. Set to 0 to skip.
+: "${SWAP_SIZE_MB:=2048}"
+
+: "${TIMEZONE:=Asia/Seoul}"
+: "${INSTANCE_HOSTNAME:=collavre}"
+
+# Nightly backups: local retention in days, and an optional S3 destination
+# (e.g. s3://collavre-backups/pg). S3 upload needs AWS credentials in
+# /root/.aws/credentials — Lightsail instances have no IAM instance role.
+: "${BACKUP_RETENTION_DAYS:=7}"
+: "${BACKUP_S3_URI:=}"
+: "${BACKUP_AT:=03:30}"
+
+# --------------------------------------------------------------------------
+# Internals
+# --------------------------------------------------------------------------
+
+STATE_DIR=/var/lib/collavre
+MARKER="$STATE_DIR/launch.done"
+LOG_FILE=/var/log/collavre-launch.log
+SUMMARY=/root/collavre-lightsail-summary.txt
+
+export DEBIAN_FRONTEND=noninteractive
+export NEEDRESTART_MODE=a
+export NEEDRESTART_SUSPEND=1
+
+mkdir -p "$STATE_DIR"
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+log() { printf '\n=== [%s] %s\n' "$(date -Is)" "$*"; }
+die() { printf '\n!!! [%s] %s\n' "$(date -Is)" "$*" >&2; exit 1; }
+
+[ "$(id -u)" -eq 0 ] || die "run as root"
+
+if [ -f "$MARKER" ] && [ "${FORCE:-0}" != "1" ]; then
+  log "already provisioned ($MARKER). Re-run with FORCE=1 to converge again."
+  exit 0
+fi
+
+# cloud-init and unattended-upgrades hold the dpkg lock during early boot;
+# DPkg::Lock::Timeout makes apt wait for them instead of failing outright.
+APT_OPTS=(-o DPkg::Lock::Timeout=600
+          -o Dpkg::Options::=--force-confdef
+          -o Dpkg::Options::=--force-confold)
+
+apt_get() { apt-get "${APT_OPTS[@]}" "$@"; }
+apt_install() { apt_get install -y --no-install-recommends "$@"; }
+
+# Append a managed block to a config file exactly once, keyed by a marker.
+ensure_block() {
+  local file="$1" marker="$2" content="$3"
+  if grep -qF "# BEGIN collavre:$marker" "$file" 2>/dev/null; then
+    return 0
+  fi
+  {
+    printf '\n# BEGIN collavre:%s (managed by script/lightsail_launch.sh)\n' "$marker"
+    printf '%s\n' "$content"
+    printf '# END collavre:%s\n' "$marker"
+  } >> "$file"
+}
+
+# --------------------------------------------------------------------------
+log "1/9 base packages"
+# --------------------------------------------------------------------------
+apt_get update -y
+apt_get upgrade -y
+apt_install ca-certificates curl gnupg git ufw unattended-upgrades \
+  acl jq unzip rsync openssl
+
+timedatectl set-timezone "$TIMEZONE"
+hostnamectl set-hostname "$INSTANCE_HOSTNAME"
+ensure_block /etc/hosts hostname "127.0.1.1 $INSTANCE_HOSTNAME"
+dpkg-reconfigure -f noninteractive unattended-upgrades
+
+# --------------------------------------------------------------------------
+log "2/9 swap (${SWAP_SIZE_MB}MiB)"
+# --------------------------------------------------------------------------
+if [ "$SWAP_SIZE_MB" -gt 0 ] && ! swapon --show=NAME --noheadings | grep -q '/swapfile'; then
+  if [ ! -f /swapfile ]; then
+    fallocate -l "${SWAP_SIZE_MB}M" /swapfile || \
+      dd if=/dev/zero of=/swapfile bs=1M count="$SWAP_SIZE_MB" status=none
+    chmod 600 /swapfile
+    mkswap /swapfile
+  fi
+  swapon /swapfile
+  ensure_block /etc/fstab swap "/swapfile none swap sw 0 0"
+fi
+cat > /etc/sysctl.d/99-collavre.conf <<'SYSCTL'
+# Prefer RAM, use swap only under real pressure.
+vm.swappiness = 10
+vm.vfs_cache_pressure = 50
+# Let PostgreSQL bind the docker0 gateway address even when the bridge has not
+# been created yet (PostgreSQL can start before dockerd after a reboot).
+net.ipv4.ip_nonlocal_bind = 1
+SYSCTL
+sysctl --system >/dev/null
+
+# --------------------------------------------------------------------------
+log "3/9 SSH hardening + deploy user '$APP_SSH_USER'"
+# --------------------------------------------------------------------------
+install -d -m 0755 /etc/ssh/sshd_config.d
+cat > /etc/ssh/sshd_config.d/99-collavre.conf <<'SSHD'
+PasswordAuthentication no
+PermitRootLogin no
+KbdInteractiveAuthentication no
+SSHD
+# Ubuntu ships `Include /etc/ssh/sshd_config.d/*.conf` at the top of
+# sshd_config; without it the drop-in above is silently ignored.
+grep -q '^Include /etc/ssh/sshd_config.d/' /etc/ssh/sshd_config 2>/dev/null || \
+  log "WARNING: sshd_config has no Include for sshd_config.d — harden SSH by hand"
+systemctl reload ssh 2>/dev/null || systemctl reload sshd 2>/dev/null || true
+
+if ! id -u "$APP_SSH_USER" >/dev/null 2>&1; then
+  adduser --disabled-password --gecos "Collavre deploy" "$APP_SSH_USER"
+fi
+usermod -aG sudo "$APP_SSH_USER"
+
+APP_HOME="$(getent passwd "$APP_SSH_USER" | cut -d: -f6)"
+install -d -m 0700 -o "$APP_SSH_USER" -g "$APP_SSH_USER" "$APP_HOME/.ssh"
+AUTH_KEYS="$APP_HOME/.ssh/authorized_keys"
+touch "$AUTH_KEYS"
+
+if [ -n "$SSH_PUBLIC_KEY" ]; then
+  grep -qxF "$SSH_PUBLIC_KEY" "$AUTH_KEYS" || printf '%s\n' "$SSH_PUBLIC_KEY" >> "$AUTH_KEYS"
+else
+  # Reuse whatever key Lightsail installed for the default cloud user.
+  for candidate in ubuntu admin ec2-user; do
+    src="/home/$candidate/.ssh/authorized_keys"
+    if [ -s "$src" ]; then
+      log "no SSH_PUBLIC_KEY given — copying keys from $candidate"
+      cat "$src" >> "$AUTH_KEYS"
+      break
+    fi
+  done
+fi
+sort -u -o "$AUTH_KEYS" "$AUTH_KEYS"
+chown "$APP_SSH_USER:$APP_SSH_USER" "$AUTH_KEYS"
+chmod 0600 "$AUTH_KEYS"
+[ -s "$AUTH_KEYS" ] || log "WARNING: $AUTH_KEYS is empty — kamal will not be able to connect"
+
+# --------------------------------------------------------------------------
+log "4/9 Docker CE"
+# --------------------------------------------------------------------------
+if ! command -v docker >/dev/null 2>&1; then
+  install -m 0755 -d /etc/apt/keyrings
+  curl -fsSL https://download.docker.com/linux/ubuntu/gpg \
+    -o /etc/apt/keyrings/docker.asc
+  chmod a+r /etc/apt/keyrings/docker.asc
+  # shellcheck disable=SC1091
+  . /etc/os-release
+  cat > /etc/apt/sources.list.d/docker.list <<EOF
+deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $VERSION_CODENAME stable
+EOF
+  apt_get update -y
+  apt_install docker-ce docker-ce-cli containerd.io \
+    docker-buildx-plugin docker-compose-plugin
+fi
+
+# Cap container logs — an unrotated Rails log fills a Lightsail SSD fast.
+install -d -m 0755 /etc/docker
+if [ ! -f /etc/docker/daemon.json ]; then
+  cat > /etc/docker/daemon.json <<'JSON'
+{
+  "log-driver": "json-file",
+  "log-opts": { "max-size": "10m", "max-file": "3" }
+}
+JSON
+fi
+systemctl enable --now docker
+usermod -aG docker "$APP_SSH_USER"
+
+# --------------------------------------------------------------------------
+log "5/9 PostgreSQL $PG_MAJOR"
+# --------------------------------------------------------------------------
+if ! [ -d "/etc/postgresql/$PG_MAJOR/main" ]; then
+  install -d -m 0755 /usr/share/postgresql-common/pgdg
+  curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+    -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc
+  # shellcheck disable=SC1091
+  . /etc/os-release
+  cat > /etc/apt/sources.list.d/pgdg.list <<EOF
+deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $VERSION_CODENAME-pgdg main
+EOF
+  apt_get update -y
+  apt_install "postgresql-$PG_MAJOR" "postgresql-client-$PG_MAJOR"
+fi
+
+PG_CONF_DIR="/etc/postgresql/$PG_MAJOR/main"
+[ -d "$PG_CONF_DIR/conf.d" ] || install -d -m 0755 "$PG_CONF_DIR/conf.d"
+grep -q "include_dir = 'conf.d'" "$PG_CONF_DIR/postgresql.conf" || \
+  ensure_block "$PG_CONF_DIR/postgresql.conf" include "include_dir = 'conf.d'"
+
+TOTAL_MB=$(awk '/MemTotal/ {printf "%d", $2/1024}' /proc/meminfo)
+SHARED_BUFFERS_MB=$(( TOTAL_MB / 4 ))
+EFFECTIVE_CACHE_MB=$(( TOTAL_MB / 2 ))
+MAINTENANCE_MB=$(( TOTAL_MB / 16 ))
+[ "$MAINTENANCE_MB" -lt 64 ] && MAINTENANCE_MB=64
+
+cat > "$PG_CONF_DIR/conf.d/10-collavre.conf" <<CONF
+# Managed by script/lightsail_launch.sh — edit here, not in postgresql.conf.
+listen_addresses = 'localhost,$DB_BIND_ADDRESS'
+password_encryption = scram-sha-256
+
+max_connections = 100
+shared_buffers = ${SHARED_BUFFERS_MB}MB
+effective_cache_size = ${EFFECTIVE_CACHE_MB}MB
+maintenance_work_mem = ${MAINTENANCE_MB}MB
+work_mem = 8MB
+
+# SSD-backed block storage.
+random_page_cost = 1.1
+effective_io_concurrency = 200
+wal_compression = on
+
+log_min_duration_statement = 1000
+log_line_prefix = '%m [%p] %q%u@%d '
+timezone = '$TIMEZONE'
+CONF
+
+# Containers authenticate with a password over the docker bridge.
+ensure_block "$PG_CONF_DIR/pg_hba.conf" docker \
+  "host    all    all    $DOCKER_SUBNETS    scram-sha-256"
+
+systemctl enable postgresql
+systemctl restart postgresql
+
+# --------------------------------------------------------------------------
+log "6/9 database '$DB_NAME' and role '$DB_USER'"
+# --------------------------------------------------------------------------
+if [ -z "$DB_PASSWORD" ]; then
+  if [ -f "$STATE_DIR/db_password" ]; then
+    # Re-run: keep the password already handed out in DATABASE_URL.
+    DB_PASSWORD="$(cat "$STATE_DIR/db_password")"
+  else
+    # URL-safe alphabet only: this password goes into DATABASE_URL verbatim.
+    DB_PASSWORD="$(openssl rand -base64 48 | tr -dc 'A-Za-z0-9' | head -c 32)"
+    log "generated a random database password"
+  fi
+fi
+printf '%s' "$DB_PASSWORD" > "$STATE_DIR/db_password"
+chmod 0600 "$STATE_DIR/db_password"
+
+# Mirrors db/setup_postgres_databases.sql: create-if-missing, never drop.
+# Collavre keeps primary/cache/queue/cable in ONE database — the Solid Queue,
+# Cache and Cable tables are created by a primary db/migrate migration. Do not
+# add separate _cache/_queue/_cable databases.
+SQL_FILE="$(mktemp /tmp/collavre-db.XXXXXX.sql)"
+trap 'rm -f "$SQL_FILE"' EXIT
+ESCAPED_PASSWORD="${DB_PASSWORD//\'/\'\'}"
+cat > "$SQL_FILE" <<SQL
+\set ON_ERROR_STOP on
+SELECT format('CREATE ROLE %I LOGIN', '$DB_USER')
+WHERE NOT EXISTS (SELECT FROM pg_roles WHERE rolname = '$DB_USER')
+\gexec
+ALTER ROLE "$DB_USER" PASSWORD '$ESCAPED_PASSWORD';
+SELECT format('CREATE DATABASE %I OWNER %I', '$DB_NAME', '$DB_USER')
+WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = '$DB_NAME')
+\gexec
+ALTER DATABASE "$DB_NAME" OWNER TO "$DB_USER";
+SQL
+chown postgres "$SQL_FILE"
+chmod 0600 "$SQL_FILE"
+runuser -u postgres -- psql -v ON_ERROR_STOP=1 -q -d postgres -f "$SQL_FILE"
+rm -f "$SQL_FILE"
+trap - EXIT
+
+# --------------------------------------------------------------------------
+log "7/9 firewall"
+# --------------------------------------------------------------------------
+ufw --force reset >/dev/null
+ufw default deny incoming
+ufw default allow outgoing
+ufw allow OpenSSH
+ufw allow 80/tcp
+ufw allow 443/tcp
+# PostgreSQL is only listening on localhost and the docker bridge, so this rule
+# is defence in depth rather than the only thing keeping it private.
+ufw allow from "$DOCKER_SUBNETS" to "$DB_BIND_ADDRESS" port 5432 proto tcp
+ufw --force enable
+ufw status verbose
+
+# --------------------------------------------------------------------------
+log "8/9 nightly backups"
+# --------------------------------------------------------------------------
+# Owned by postgres: pg_dump writes the file itself, and 0700 keeps the dumps
+# readable only by postgres and root.
+install -d -m 0700 -o postgres -g postgres /var/backups/collavre
+
+cat > /usr/local/bin/collavre-pg-backup <<BACKUP
+#!/usr/bin/env bash
+# Managed by script/lightsail_launch.sh
+set -euo pipefail
+DEST=/var/backups/collavre
+DB_NAME="$DB_NAME"
+RETENTION_DAYS=$BACKUP_RETENTION_DAYS
+S3_URI="$BACKUP_S3_URI"
+
+install -d -m 0700 -o postgres -g postgres "\$DEST"
+STAMP="\$(date +%Y%m%d-%H%M%S)"
+FILE="\$DEST/\${DB_NAME}-\${STAMP}.dump"
+
+trap 'rm -f "\$FILE"' ERR
+runuser -u postgres -- pg_dump --format=custom --compress=6 \\
+  --dbname="\$DB_NAME" --file="\$FILE"
+trap - ERR
+chmod 0600 "\$FILE"
+
+if [ -n "\$S3_URI" ] && command -v aws >/dev/null 2>&1; then
+  aws s3 cp "\$FILE" "\${S3_URI%/}/\$(basename "\$FILE")"
+fi
+
+find "\$DEST" -maxdepth 1 -name '*.dump' -mtime "+\$RETENTION_DAYS" -delete
+echo "backup complete: \$FILE (\$(du -h "\$FILE" | cut -f1))"
+BACKUP
+chmod 0755 /usr/local/bin/collavre-pg-backup
+
+cat > /etc/systemd/system/collavre-pg-backup.service <<'UNIT'
+[Unit]
+Description=Collavre PostgreSQL dump
+After=postgresql.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/collavre-pg-backup
+UNIT
+
+cat > /etc/systemd/system/collavre-pg-backup.timer <<UNIT
+[Unit]
+Description=Nightly Collavre PostgreSQL dump
+
+[Timer]
+OnCalendar=*-*-* $BACKUP_AT:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+UNIT
+
+systemctl daemon-reload
+systemctl enable --now collavre-pg-backup.timer
+
+# --------------------------------------------------------------------------
+log "9/9 summary"
+# --------------------------------------------------------------------------
+PUBLIC_IP="$(curl -fsS --max-time 5 https://checkip.amazonaws.com 2>/dev/null || echo '<public-ip>')"
+PRIVATE_IP="$(hostname -I | awk '{print $1}')"
+DATABASE_URL="postgresql://$DB_USER:$DB_PASSWORD@$DB_BIND_ADDRESS:5432/$DB_NAME"
+
+cat > "$SUMMARY" <<TXT
+Collavre Lightsail host — provisioned $(date -Is)
+
+  public IP        $PUBLIC_IP
+  private IP       $PRIVATE_IP
+  deploy user      $APP_SSH_USER (docker, sudo)
+  PostgreSQL       $PG_MAJOR, listening on localhost + $DB_BIND_ADDRESS only
+  database         $DB_NAME owned by $DB_USER
+  db password      $STATE_DIR/db_password (root only)
+  backups          /var/backups/collavre, nightly at $BACKUP_AT, ${BACKUP_RETENTION_DAYS}d retention
+  log              $LOG_FILE
+
+Put these in .env.production on your workstation, then run \`bin/kamal setup\`:
+
+  COLLAVRE_SERVER=$PUBLIC_IP
+  KAMAL_SSH_USER=$APP_SSH_USER
+  KAMAL_SSH_KEY_PATH=~/.ssh/<the key matching the instance>
+  DATABASE_URL=$DATABASE_URL
+  PORT=80
+
+Open ports 80 and 443 in the Lightsail console firewall (Networking tab).
+Never open 5432 there.
+TXT
+chmod 0600 "$SUMMARY"
+
+touch "$MARKER"
+cat "$SUMMARY"
+log "done — full log at $LOG_FILE"

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -2605,10 +2605,12 @@ sysctl --system >/dev/null
 
 # verify_ssh_hardening [effective config file] [sshd config dir]
 #                      [reload state: 0=reloaded, 2=no active daemon]
-#                      [deploy user]
+#                      [deploy user] [require readable result]
 #
-# Read back what sshd actually resolved the three hardened keywords to, and
-# refuse a run that reported hardening it did not perform.
+# Read back what sshd actually resolved the hardened authentication settings
+# to, and refuse a run that reported hardening it did not perform. Password,
+# root and keyboard-interactive authentication must be off; public-key
+# authentication must remain on because it is the deploy account's only way in.
 #
 # Naming the drop-in so it sorts first is necessary and not sufficient: a
 # directive above the Include in sshd_config itself, or an operator's own
@@ -2713,11 +2715,20 @@ scan_ssh_config_file() {
     if [ "${SSH_CONFIG_SCAN_CONTEXTUAL:-0}" -eq 1 ]; then
       value="${fields[1]:-}"
       value="$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]')"
-      if [[ "$key" =~ ^(passwordauthentication|kbdinteractiveauthentication|challengeresponseauthentication|permitrootlogin)$ ]] &&
-	 [ "$value" != no ]; then
-	SSH_CONFIG_SCAN_UNSAFE="$canonical:$line_no:${line#"${line%%[![:space:]]*}"}"
-	break
-      fi
+      case "$key" in
+	passwordauthentication|kbdinteractiveauthentication|challengeresponseauthentication|permitrootlogin)
+	  [ "$value" = no ] || {
+	    SSH_CONFIG_SCAN_UNSAFE="$canonical:$line_no:${line#"${line%%[![:space:]]*}"}"
+	    break
+	  }
+	  ;;
+	pubkeyauthentication)
+	  [ "$value" = yes ] || {
+	    SSH_CONFIG_SCAN_UNSAFE="$canonical:$line_no:${line#"${line%%[![:space:]]*}"}"
+	    break
+	  }
+	  ;;
+      esac
     fi
   done < "$file"
 
@@ -2737,7 +2748,8 @@ find_unsafe_ssh_match() {
 verify_ssh_hardening() {
   local src="${1:-}" conf_dir="${2:-/etc/ssh}" reload_state="${3:-0}"
   local deploy_user="${4:-${APP_SSH_USER:-collavre}}"
-  local effective key value offender unsafe_match
+  local require_readable="${5:-0}"
+  local effective key value expected offender unsafe_match
   if [ -n "$src" ]; then
     effective="$(cat "$src")"
   else
@@ -2758,6 +2770,12 @@ verify_ssh_hardening() {
 	"sudo or Docker access."
 
     if ! effective="$(sshd -T -C "user=$deploy_user" 2>/dev/null)"; then
+      [ "$require_readable" -ne 1 ] || die \
+	"SSH public-key authentication could not be verified for '$deploy_user':" \
+	"'sshd -T -C user=$deploy_user' rejected or could not read the" \
+	"configuration on disk. The previous deploy user's privileged access" \
+	"will not be revoked until the replacement account is proven reachable" \
+	"by key. Run 'sshd -t' to find the error, fix it, and re-run."
       [ "$reload_state" -ne 2 ] || die \
 	"SSH hardening could not be verified: there is no active sshd to reload" \
 	"and 'sshd -T -C user=$deploy_user' rejected or could not read the" \
@@ -2768,19 +2786,28 @@ verify_ssh_hardening() {
       log "WARNING: could not read the effective SSH configuration on this host" \
 	"(\`sshd -T -C user=$deploy_user\` failed), so the hardening above is" \
 	"unverified. Check it by hand: sshd -T -C user=$deploy_user | grep -E" \
-	"'^(passwordauthentication|permitrootlogin|kbdinteractiveauthentication)'"
+	"'^(passwordauthentication|permitrootlogin|kbdinteractiveauthentication|" \
+	"pubkeyauthentication)'"
       return 0
     fi
   fi
-  for key in passwordauthentication permitrootlogin kbdinteractiveauthentication; do
+  for key in passwordauthentication permitrootlogin kbdinteractiveauthentication \
+	     pubkeyauthentication; do
+    expected=no
+    [ "$key" != pubkeyauthentication ] || expected=yes
     value="$(printf '%s\n' "$effective" |
              awk -v k="$key" 'tolower($1) == k { print $2; exit }')"
     [ -n "$value" ] || {
+      [ "$key" != pubkeyauthentication ] || die \
+	"SSH public-key authentication could not be verified for '$deploy_user':" \
+	"sshd did not report 'pubkeyauthentication'. The previous deploy user's" \
+	"privileged access will not be revoked until the replacement account is" \
+	"proven reachable by key. Correct the SSH configuration and re-run."
       log "WARNING: sshd did not report '$key', so that part of the hardening" \
           "above is unverified"
       continue
     }
-    if [ "$value" = "no" ]; then
+    if [ "$value" = "$expected" ]; then
       continue
     fi
     # Name the file rather than leave the operator to find it. A directive
@@ -2790,7 +2817,7 @@ verify_ssh_hardening() {
                   "$conf_dir"/sshd_config.d/*.conf "$conf_dir"/sshd_config \
                   2>/dev/null | grep -v '01-collavre.conf' | head -1)" || true
     die "SSH hardening did not take effect: sshd resolves '$key' to '$value'," \
-	"not 'no', even though $conf_dir/sshd_config.d/01-collavre.conf sets" \
+	"not '$expected', even though $conf_dir/sshd_config.d/01-collavre.conf sets" \
 	"it. An earlier global directive or a Match block for '$deploy_user'" \
 	"is overriding it${offender:+ — ${offender}}. Stopping before any" \
 	"further access is granted. Remove or correct that setting and re-run."
@@ -2826,7 +2853,7 @@ install -d -m 0755 /etc/ssh/sshd_config.d
 # with Ubuntu's 50-cloud-init.conf beside it turning both keywords back on:
 #
 #   01-collavre.conf state   bytes   sshd -t   passwordauth  permitrootlogin
-#   whole                    77      rc=0      no            no
+#   whole                   102      rc=0      no            no
 #   0 bytes (torn at open)    0      rc=0      yes           yes
 #   cut after line 1         26      rc=0      no            yes
 #   cut mid-directive        36      rc=255    -             -
@@ -2853,7 +2880,8 @@ install_managed_config 'the SSH hardening drop-in' \
   /etc/ssh/sshd_config.d/01-collavre.conf \
   'PasswordAuthentication no' \
   'PermitRootLogin no' \
-  'KbdInteractiveAuthentication no'
+  'KbdInteractiveAuthentication no' \
+  'PubkeyAuthentication yes'
 # A host provisioned by an earlier version of this script carries the 99- file.
 # It is inert now that 01- sets the same keywords first, and that is the reason
 # to remove it rather than leave it: a file whose every line is overridden is
@@ -3170,7 +3198,7 @@ in_group "$APP_SSH_USER" sudo && SUDO_GROUP_WAS_PRESENT=1
 usermod -aG sudo "$APP_SSH_USER"
 # Match Group is resolved from the account's current memberships, so the check
 # before user creation cannot see an override that starts applying here.
-if ! ( verify_ssh_hardening "" /etc/ssh "$SSH_RELOAD_STATE" "$APP_SSH_USER" ); then
+if ! ( verify_ssh_hardening "" /etc/ssh "$SSH_RELOAD_STATE" "$APP_SSH_USER" 1 ); then
   if [ "$SUDO_GROUP_WAS_PRESENT" -eq 0 ]; then
     gpasswd -d "$APP_SSH_USER" sudo >/dev/null 2>&1 ||
       die "SSH hardening failed after '$APP_SSH_USER' joined sudo, and the" \
@@ -3705,7 +3733,7 @@ in_group "$APP_SSH_USER" docker && DOCKER_GROUP_WAS_PRESENT=1
 usermod -aG docker "$APP_SSH_USER"
 # Recheck for the same reason as the sudo grant above. An operator's
 # `Match Group docker` block does not apply until this membership exists.
-if ! ( verify_ssh_hardening "" /etc/ssh "$SSH_RELOAD_STATE" "$APP_SSH_USER" ); then
+if ! ( verify_ssh_hardening "" /etc/ssh "$SSH_RELOAD_STATE" "$APP_SSH_USER" 1 ); then
   if [ "$DOCKER_GROUP_WAS_PRESENT" -eq 0 ]; then
     gpasswd -d "$APP_SSH_USER" docker >/dev/null 2>&1 ||
       die "SSH hardening failed after '$APP_SSH_USER' joined docker, and the" \

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -703,6 +703,63 @@ reassign_prior_db_role() {
   log "revoked LOGIN from the replaced database role '$prior'"
 }
 
+# refuse_db_name_change <name> [state dir]
+#
+# DB_NAME is the one identifier a re-run could change with no trace at all. The
+# create-if-missing SQL below simply makes a second, empty database; nothing
+# renames or migrates the first, and until now nothing recorded which one a
+# previous run had chosen. Measured on postgres:17 against a host holding 5,000
+# rows, re-running with a mistyped name:
+#
+#   run reports success
+#   databases: collavre_prod, collavre_production
+#   tables in the new one the URL and backup will name : 0
+#   rows in the real one, now referenced by nothing    : 5000
+#
+# So the app boots empty and the nightly pg_dump starts backing up the empty
+# one — the live data is not lost, but nothing points at it and nothing is
+# protecting it any more. Both halves are silent.
+#
+# Refused rather than converged, on the same grounds as DB_PORT: renaming is
+# ALTER DATABASE ... RENAME TO, which needs no other session connected and
+# would strand the already-deployed DATABASE_URL mid-flight, and "migrate" means
+# a dump and restore whose timing is the operator's call, not a launch script's.
+refuse_db_name_change() {
+  local current="$1" state_dir="${2:-$STATE_DIR}" prior others
+
+  if [ -f "$state_dir/db_name" ]; then
+    prior="$(cat "$state_dir/db_name")"
+    [ -n "$prior" ] && [ "$prior" != "$current" ] || return 0
+    die "this host was provisioned with DB_NAME='$prior', and DB_NAME is now" \
+        "'$current'. This script creates a database if it is missing; it does not" \
+        "rename or copy one, so '$current' would be created empty while the app's" \
+        "data stayed in '$prior' — and the summary, DATABASE_URL and the nightly" \
+        "backup would all name the empty one. Nothing has been changed. Set" \
+        "DB_NAME='$prior', or move the data deliberately — see 'Changing DB_NAME" \
+        "on a re-run' in docs/deploy_to_lightsail.md."
+  fi
+
+  # No record. On a genuine first run there is nothing to protect, and adopting
+  # the name is right. On a host provisioned by a revision that did not track it
+  # there is: db_user is the marker that says this script has run here before.
+  [ -f "$state_dir/db_user" ] || return 0
+  [ "$(psql_as_postgres postgres \
+        "SELECT count(*) FROM pg_database WHERE datname = '$current'")" = 0 ] || return 0
+
+  # Previously provisioned, and the database this run names does not exist. That
+  # is the change this function exists to stop, arriving on a host too old to
+  # have left a record of it.
+  others="$(psql_as_postgres postgres \
+    "SELECT string_agg(datname, ', ' ORDER BY datname) FROM pg_database
+      WHERE datistemplate = false AND datname <> 'postgres'")"
+  die "this host has been provisioned before, but DB_NAME='$current' does not" \
+      "exist on it. An earlier revision did not record the name it used, so this" \
+      "run cannot tell a corrected typo from a rename — and creating '$current'" \
+      "would leave the app pointed at an empty database. Databases present:" \
+      "${others:-(none)}. Nothing has been changed. Re-run with DB_NAME set to the" \
+      "one you mean; it will be recorded from then on."
+}
+
 # ensure_ufw_rule <name> <rule> [state file]
 #
 # Converge one ufw rule the way ensure_block converges one config stanza:
@@ -899,6 +956,139 @@ install_deploy_ssh_dir() {
   printf '%s\n' "$group"
 }
 
+# passwd_home <user> [passwd table]
+#
+# The home directory of an account, or nothing when there is no such account.
+# The optional second argument lets the tests supply a passwd table instead of
+# the host's.
+passwd_home() {
+  local user="$1" src="${2:-}"
+  if [ -n "$src" ]; then
+    awk -F: -v u="$user" '$1 == u { print $6; exit }' "$src"
+  else
+    # An account that does not exist is an answer here, not an error. `getent`
+    # exits 2 for it, and under `pipefail` that status would take the whole run
+    # down at the caller's plain assignment — with no message, since neither
+    # branch of this function is reached. The awk branch above already reports a
+    # missing account as empty output, so this one has to agree with it.
+    getent passwd "$user" | cut -d: -f6 || true
+  fi
+}
+
+# ssh_key_holder <key> [passwd table]
+#
+# The first account whose authorized_keys contains this key byte-for-byte, or
+# nothing. This is the only surviving evidence of who a key belongs to, which
+# is what the caller below needs and does not otherwise have.
+ssh_key_holder() {
+  local key="$1" src="${2:-}" user home tbl rc=1
+  tbl="$(mktemp)"
+  if [ -n "$src" ]; then cat "$src" > "$tbl"; else getent passwd > "$tbl"; fi
+  while IFS=: read -r user _ _ _ _ home _; do
+    [ -n "$home" ] && [ -f "$home/.ssh/authorized_keys" ] || continue
+    if grep -qxF "$key" "$home/.ssh/authorized_keys" 2>/dev/null; then
+      printf '%s\n' "$user"
+      rc=0
+      break
+    fi
+  done < "$tbl"
+  rm -f "$tbl"
+  return "$rc"
+}
+
+# adopt_legacy_ssh_key_marker <user> [state dir] [passwd table]
+#
+# An earlier revision recorded the key it installed in one file per host rather
+# than one per account. This re-files that record so the per-account withdrawal
+# can still find it — but it must work out *whose* it is, and the account named
+# by APP_SSH_USER today is not the answer.
+#
+# On a host that rotated collavre/key-A to deploybot/key-B under that revision,
+# the marker holds B and collavre's authorized_keys still holds A: the old code
+# looked for A in deploybot's file, did not find it, and advanced the marker
+# anyway. Assigning B to whichever account this run happens to name turns that
+# into a privilege escalation. A run that switches back to collavre/key-C files
+# B as collavre's predecessor, fails to find B in collavre's file, records C —
+# and key-A stays authorized on an account this same run puts back in sudoers
+# and the docker group. A key retired two rotations ago is root again, and the
+# marker that would have named B for deploybot has been consumed, so B is
+# unwithdrawable too. Both halves are silent.
+#
+# So the marker is adopted only where authorized_keys agrees it belongs, and
+# where it does not, ownership is preserved rather than invented. What cannot
+# be recovered is key-A: no per-account record of it was ever written, and
+# nothing distinguishes it from a key the operator installed themselves. That
+# is why the ambiguous case stops the run instead of warning — it stops it
+# before usermod and ensure_sudoers below, which are what make the difference
+# between an old key sitting in a file and an old key holding root.
+adopt_legacy_ssh_key_marker() {
+  local user="$1" state_dir="${2:-$STATE_DIR}" src="${3:-}"
+  local legacy mine key owner home auth_keys=""
+  legacy="$state_dir/ssh_public_key"
+  mine="$state_dir/ssh_public_key.$user"
+  [ -f "$legacy" ] && [ ! -f "$mine" ] || return 0
+
+  key="$(cat "$legacy")"
+  # A marker with nothing in it names no key and can strand the branch forever.
+  [ -n "$key" ] || { rm -f "$legacy"; return 0; }
+
+  home="$(passwd_home "$user" "$src")"
+  [ -z "$home" ] || auth_keys="$home/.ssh/authorized_keys"
+
+  # Verifiably this account's — the ordinary upgrade, and the case the adoption
+  # exists for. Checked directly rather than through the search below so the
+  # common path does not depend on reading every account on the host.
+  if [ -n "$auth_keys" ] && grep -qxF "$key" "$auth_keys" 2>/dev/null; then
+    mv "$legacy" "$mine"
+    return 0
+  fi
+
+  owner="$(ssh_key_holder "$key" "$src")" || owner=""
+
+  # Authorized for nobody: the key it names is already gone, so the record
+  # describes nothing and assigning it to an account would invent a predecessor
+  # that no longer exists.
+  if [ -z "$owner" ]; then
+    rm -f "$legacy"
+    log "the SSH key recorded by an earlier revision is no longer authorized for" \
+        "any account on this host, so the record was dropped rather than filed" \
+        "against '$user'"
+    return 0
+  fi
+
+  # Verifiably another account's. File it there, so that account's own key stays
+  # withdrawable by a later run naming it.
+  #
+  # An account with no keys of its own cannot be hiding a managed one, so there
+  # is nothing to stop the run for; this is also the first-run-creates-the-user
+  # path, where the account does not exist yet.
+  if [ -z "$auth_keys" ] || [ ! -s "$auth_keys" ]; then
+    mv "$legacy" "$state_dir/ssh_public_key.$owner"
+    log "the SSH key recorded by an earlier revision belongs to '$owner', not to" \
+        "'$user'; filed it against '$owner'"
+    return 0
+  fi
+
+  if [ -n "${ACK_UNATTRIBUTED_SSH_KEYS:-}" ]; then
+    mv "$legacy" "$state_dir/ssh_public_key.$owner"
+    log "ACK_UNATTRIBUTED_SSH_KEYS is set: filed the earlier revision's record" \
+        "against '$owner', and proceeding with '$user' unchecked — the keys in" \
+        "$auth_keys are the operator's responsibility"
+    return 0
+  fi
+
+  die "this host rotated deploy accounts under an earlier revision of this" \
+      "script: the key it recorded is authorized for '$owner', not for" \
+      "'$user', which this run names. That revision kept only one record per" \
+      "host, so if it ever installed a key for '$user' there is nothing left" \
+      "that says which of the keys in $auth_keys it was — and this run is" \
+      "about to give '$user' passwordless sudo and the docker socket again." \
+      "Nothing has been changed. Read $auth_keys, remove any key you do not" \
+      "recognise, then re-run with ACK_UNATTRIBUTED_SSH_KEYS=1 to continue."
+}
+
+adopt_legacy_ssh_key_marker "$APP_SSH_USER"
+
 if ! id -u "$APP_SSH_USER" >/dev/null 2>&1; then
   adduser --disabled-password --gecos "Collavre deploy" "$APP_SSH_USER"
 fi
@@ -1092,18 +1282,11 @@ dedupe_authorized_keys() {
       "this host; check its memory and disk before relying on the instance."
 }
 
-# Adopt the single marker an earlier revision wrote, once, for the account this
-# run is about. On the hosts that revision could produce there was only ever one
-# deploy account, so the old value is that account's — and adopting it is what
-# keeps the first run after this change able to withdraw, instead of starting
-# from no record and leaving the current key authorized forever. If APP_SSH_USER
-# has since moved, the file is claimed by whichever account is named first; that
-# is the same key the old code would have hunted for, so nothing gets worse.
-if [ -f "$STATE_DIR/ssh_public_key" ] &&
-   [ ! -f "$STATE_DIR/ssh_public_key.$APP_SSH_USER" ]; then
-  mv "$STATE_DIR/ssh_public_key" "$STATE_DIR/ssh_public_key.$APP_SSH_USER"
-fi
-
+# The single marker an earlier revision wrote has already been re-filed against
+# the account authorized_keys says it belongs to, up beside the sudo grant —
+# see adopt_legacy_ssh_key_marker. It has to happen there rather than here: the
+# case it refuses is one where this run would otherwise re-arm a key it cannot
+# identify, and by this point the sudo half of that is already done.
 install_authorized_keys "$AUTH_KEYS"
 revoke_prior_ssh_key "$AUTH_KEYS"
 dedupe_authorized_keys "$AUTH_KEYS" "$SSH_PUBLIC_KEY"
@@ -1238,6 +1421,40 @@ systemctl restart postgresql
 # --------------------------------------------------------------------------
 log "6/9 database '$DB_NAME' and role '$DB_USER'"
 # --------------------------------------------------------------------------
+# Before anything moves — and that includes $STATE_DIR, not just the database.
+# A rotation away from a superuser predecessor cannot be completed, so it must
+# not be started, and the refusal says "Nothing has been changed": it has to be
+# true. Recording the new DB_PASSWORD first made it false in a way that outlived
+# the run. The refused run left the new password in the state file while the
+# live role still had the old one, so the recovery this very message recommends
+# — re-run with the previous DB_USER and no DB_PASSWORD — read the unapplied
+# value back and applied it, silently rotating the password of a role whose
+# credential nobody asked to change. The already-deployed DATABASE_URL then
+# names a password the server no longer accepts, which surfaces as
+# authentication failures the next time the app reconnects rather than at the
+# moment the mistake is made.
+#
+# The name guard runs first, and the order is load-bearing rather than
+# alphabetical. refuse_superuser_db_rotation asks how many objects the previous
+# role owns *in $DB_NAME*, so when a re-run changes both, it asks that question
+# of a database that does not exist: psql fails, the count comes back empty, and
+# the "unanswerable reads as unsafe" rule turns that into a refusal blaming
+# object ownership. Measured on postgres:17, re-running a DB_USER=postgres host
+# with a new role and a mistyped name:
+#
+#   DIE: ... An unknown number of object(s) in 'collavre_prod' are still owned
+#        by 'postgres' ... Move the objects by hand
+#
+# Nothing is changed either way, so this is not a data-safety difference — but
+# the by-hand transfer it sends the operator to cannot be performed on a
+# database that is not there, which is the same dead end as a guard whose own
+# recovery is unreachable. Asking about the name first names the real problem.
+refuse_db_name_change "$DB_NAME"
+
+# Beside it, and before the password handling for the same reason: a refusal
+# here must not have written anything to $STATE_DIR either.
+refuse_superuser_db_rotation "$DB_USER"
+
 if [ -z "$DB_PASSWORD" ]; then
   if [ -f "$STATE_DIR/db_password" ]; then
     # Re-run: keep the password already handed out in DATABASE_URL.
@@ -1255,10 +1472,6 @@ fi
 # The chmod stays to converge a file an earlier revision left 0644.
 ( umask 077; printf '%s' "$DB_PASSWORD" > "$STATE_DIR/db_password" )
 chmod 0600 "$STATE_DIR/db_password"
-
-# Before anything moves: a rotation away from a superuser predecessor cannot be
-# completed, so it must not be started.
-refuse_superuser_db_rotation "$DB_USER"
 
 # Mirrors db/setup_postgres_databases.sql: create-if-missing, never drop.
 # Collavre keeps primary/cache/queue/cable in ONE database — the Solid Queue,
@@ -1288,6 +1501,9 @@ trap - EXIT
 # DATABASE_URL naming the new role.
 reassign_prior_db_role "$DB_USER"
 printf '%s\n' "$DB_USER" > "$STATE_DIR/db_user"
+# Recorded only once the database it names actually exists, so an interrupted
+# run cannot leave a marker for a database that was never created.
+printf '%s\n' "$DB_NAME" > "$STATE_DIR/db_name"
 
 # --------------------------------------------------------------------------
 log "7/9 firewall"

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -2563,12 +2563,11 @@ sysctl --system >/dev/null
 # about either. The only thing that answers is sshd's own resolution of the
 # whole configuration.
 #
-# Refusing rather than warning, and refusing here rather than later: this is the
-# top of step 3, before the deploy account is created, before sudo and docker
-# are granted and before any key is installed, so a run that stops here has
-# changed nothing but the drop-in — and SSH is left exactly as the operator had
-# it, so nobody is locked out by the refusal. The alternative is a run that
-# prints its summary over a host still accepting passwords and root logins.
+# Refusing rather than warning. The first call is at the top of step 3, before
+# the deploy account is created or armed; later calls repeat the same check
+# after each group grant because Match Group is evaluated against the account's
+# membership at connection time. The alternative is a run that prints its
+# summary over a privileged account still accepting passwords.
 #
 # An answer that cannot be read is not the same as a wrong one when a running
 # daemon has just accepted the reload, and is warned about instead. With no
@@ -2590,8 +2589,8 @@ verify_ssh_hardening() {
       "and 'sshd -T -C user=$deploy_user' rejected or could not read the" \
       "configuration on disk." \
       "The next socket-activated connection or reboot would start sshd from" \
-      "that unverified configuration. Nothing has been granted. Run 'sshd -t'" \
-      "to find the error, fix it, and re-run."
+      "that unverified configuration. Provisioning will not continue. Run" \
+      "'sshd -t' to find the error, fix it, and re-run."
     log "WARNING: could not read the effective SSH configuration on this host" \
 	"(\`sshd -T -C user=$deploy_user\` failed), so the hardening above is" \
 	"unverified. Check it by hand: sshd -T -C user=$deploy_user | grep -E" \
@@ -2618,10 +2617,8 @@ verify_ssh_hardening() {
     die "SSH hardening did not take effect: sshd resolves '$key' to '$value'," \
 	"not 'no', even though $conf_dir/sshd_config.d/01-collavre.conf sets" \
 	"it. An earlier global directive or a Match block for '$deploy_user'" \
-	"is overriding it${offender:+ — ${offender}}. Stopping here rather" \
-	"than finishing: nothing has been granted yet and SSH is unchanged," \
-	"so the host stays reachable. Remove or correct that setting and" \
-	"re-run."
+	"is overriding it${offender:+ — ${offender}}. Stopping before any" \
+	"further access is granted. Remove or correct that setting and re-run."
   done
 }
 
@@ -2739,10 +2736,11 @@ reload_ssh_daemon() {
 # refused is the one it will be handed at the next boot, where there is no old
 # process to keep running.
 #
-# Stopping here is the safe end. This is the top of step 3 — the deploy account
-# does not exist yet, nothing has been granted, and SSH is left exactly as the
-# operator had it, so the refusal locks nobody out. That is the same reason
-# verify_ssh_hardening's own die() sits here rather than after the grants.
+# Stopping here is the safe end. This first check is at the top of step 3 — the
+# deploy account does not exist yet, nothing has been granted, and SSH is left
+# exactly as the operator had it, so the refusal locks nobody out. The same
+# verifier runs again immediately after later group changes, when its answer can
+# differ because Match Group has begun to apply.
 SSH_RELOAD_STATE=0
 reload_ssh_daemon || SSH_RELOAD_STATE=$?
 [ "$SSH_RELOAD_STATE" -ne 1 ] || die \
@@ -2920,6 +2918,9 @@ record_deploy_user_grant "$APP_SSH_USER" ||
       "has been granted. Check that $STATE_DIR is writable and has space, then" \
       "re-run."
 usermod -aG sudo "$APP_SSH_USER"
+# Match Group is resolved from the account's current memberships, so the check
+# before user creation cannot see an override that starts applying here.
+verify_ssh_hardening "" /etc/ssh "$SSH_RELOAD_STATE" "$APP_SSH_USER"
 install -d -m 0755 /etc/sudoers.d
 ensure_sudoers "$APP_SSH_USER"
 
@@ -3480,6 +3481,9 @@ else
   systemctl start docker
 fi
 usermod -aG docker "$APP_SSH_USER"
+# Recheck for the same reason as the sudo grant above. An operator's
+# `Match Group docker` block does not apply until this membership exists.
+verify_ssh_hardening "" /etc/ssh "$SSH_RELOAD_STATE" "$APP_SSH_USER"
 # Only once the replacement can reach Docker, so an interrupted run never
 # leaves the host with no account that can deploy.
 revoke_prior_deploy_user "$APP_SSH_USER"
@@ -3819,13 +3823,13 @@ log "7/9 firewall"
 # take a VPN, monitoring or IP-allowlist rule with it. Only the rules below are
 # ours to converge.
 # `default deny incoming` changes an already-active firewall immediately, so
-# port 22 must be authorized before that live policy is tightened.
+# every public service must be authorized before that live policy is tightened.
 ensure_ssh_rule
+ufw allow 80/tcp
+ufw allow 443/tcp
 ufw default deny incoming
 ufw default allow outgoing
 
-ufw allow 80/tcp
-ufw allow 443/tcp
 # PostgreSQL is only listening on localhost and the docker bridge, so this rule
 # is defence in depth rather than the only thing keeping it private.
 ensure_ufw_rule postgres \

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -3937,27 +3937,27 @@ fi
 chmod 0755 "$BACKUP_TMP"
 mv -f "$BACKUP_TMP" /usr/local/bin/collavre-pg-backup
 
-cat > /etc/systemd/system/collavre-pg-backup.service <<'UNIT'
-[Unit]
-Description=Collavre PostgreSQL dump
-After=postgresql.service
+install_managed_config 'the PostgreSQL backup service unit' \
+  /etc/systemd/system/collavre-pg-backup.service \
+  '[Unit]' \
+  'Description=Collavre PostgreSQL dump' \
+  'After=postgresql.service' \
+  '' \
+  '[Service]' \
+  'Type=oneshot' \
+  'ExecStart=/usr/local/bin/collavre-pg-backup'
 
-[Service]
-Type=oneshot
-ExecStart=/usr/local/bin/collavre-pg-backup
-UNIT
-
-cat > /etc/systemd/system/collavre-pg-backup.timer <<UNIT
-[Unit]
-Description=Nightly Collavre PostgreSQL dump
-
-[Timer]
-OnCalendar=*-*-* $BACKUP_AT:00
-Persistent=true
-
-[Install]
-WantedBy=timers.target
-UNIT
+install_managed_config 'the PostgreSQL backup timer unit' \
+  /etc/systemd/system/collavre-pg-backup.timer \
+  '[Unit]' \
+  'Description=Nightly Collavre PostgreSQL dump' \
+  '' \
+  '[Timer]' \
+  "OnCalendar=*-*-* $BACKUP_AT:00" \
+  'Persistent=true' \
+  '' \
+  '[Install]' \
+  'WantedBy=timers.target'
 
 systemctl daemon-reload
 systemctl enable --now collavre-pg-backup.timer

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -1481,7 +1481,13 @@ revoke_deploy_user_access() {
   fi
 
   sudoers_name="90-collavre-${prior//[^A-Za-z0-9_-]/_}"
-  rm -f "/etc/sudoers.d/$sudoers_name"
+  if ! rm -f "/etc/sudoers.d/$sudoers_name" ||
+     [ -e "/etc/sudoers.d/$sudoers_name" ]; then
+    log "WARNING: could NOT remove /etc/sudoers.d/$sudoers_name; '$prior'" \
+	"still has this script's passwordless sudo grant, so the SSH cutover" \
+	"remains pending"
+    return 1
+  fi
 
   log "WARNING: '$prior' is no longer in docker or sudo but can still log in;" \
       "remove it by hand once you can reach the host as '$current':" \
@@ -1566,7 +1572,7 @@ revoke_prior_deploy_user() {
 # predecessor managed keys all stay unchanged.
 stage_ssh_cutover() {
   local user="$1" key="$2" current='' prior_key='' need=0
-  local nonce nonce_hash pending="$STATE_DIR/ssh_cutover.pending"
+  local nonce nonce_hash key_fingerprint='' pending="$STATE_DIR/ssh_cutover.pending"
   local key_file="$STATE_DIR/ssh_cutover.key"
   local finalizer="${3:-/usr/local/sbin/collavre-finalize-ssh-cutover}"
   local source="${4:-${BASH_SOURCE[0]}}"
@@ -1601,11 +1607,16 @@ stage_ssh_cutover() {
   nonce="$(od -An -N32 -tx1 /dev/urandom | tr -d '[:space:]')"
   [ "${#nonce}" -eq 64 ] || die "could not generate the SSH cutover challenge"
   nonce_hash="$(printf '%s' "$nonce" | sha256sum | awk '{print $1}')"
+  if [ -n "$key" ]; then
+    key_fingerprint="$(ssh_public_key_fingerprint "$key")" ||
+      die "could not fingerprint the staged SSH key"
+  fi
 
   write_state_file "$key_file" "$key"$'\n' 0600 ||
     die "could not stage the SSH cutover key in $key_file"
   write_state_file "$pending" \
-    "user=$user"$'\n'"nonce_sha256=$nonce_hash"$'\n' 0600 ||
+    "user=$user"$'\n'"nonce_sha256=$nonce_hash"$'\n'\
+"key_sha256=$key_fingerprint"$'\n' 0600 ||
     die "could not stage the SSH cutover challenge in $pending"
 
   [ -r "$source" ] ||
@@ -1617,6 +1628,52 @@ stage_ssh_cutover() {
   SSH_CUTOVER_NONCE="$nonce"
   log "SSH cutover to '$user' is staged. The predecessor remains privileged" \
       "until the nonce is finalized from an actual SSH session as '$user'."
+}
+
+ssh_public_key_fingerprint() {
+  local key="$1" tmp fingerprint
+  tmp="$(mktemp)" || return 1
+  printf '%s\n' "$key" > "$tmp" || { rm -f "$tmp"; return 1; }
+  fingerprint="$(ssh-keygen -lf "$tmp" -E sha256 2>/dev/null |
+    awk 'NR == 1 { print $2 }')"
+  rm -f "$tmp"
+  [ -n "$fingerprint" ] || return 1
+  printf '%s\n' "$fingerprint"
+}
+
+# Echo the authentication-info file from the target-owned session process
+# closest to sshd. ExposeAuthInfo creates this record from the authentication
+# exchange itself; reading SSH_USER_AUTH from the original session ancestry
+# avoids relying on what sudo happened to preserve.
+ssh_cutover_auth_info_file() {
+  local user="$1" pid="${2:-$PPID}" ppid real_uid target_uid candidate='' hops=0
+  local auth_info_file=''
+  target_uid="$(id -u "$user" 2>/dev/null)" || return 1
+  while [ "$pid" -gt 1 ] 2>/dev/null && [ "$hops" -lt 64 ]; do
+    real_uid="$(awk '/^Uid:/{print $2}' "/proc/$pid/status" 2>/dev/null || true)"
+    if [ "$real_uid" = "$target_uid" ]; then
+      candidate="$(tr '\0' '\n' < "/proc/$pid/environ" 2>/dev/null |
+	sed -n 's/^SSH_USER_AUTH=//p' | head -1)"
+      [ -z "$candidate" ] || auth_info_file="$candidate"
+    fi
+    ppid="$(awk '/^PPid:/{print $2}' "/proc/$pid/status" 2>/dev/null || true)"
+    case "$ppid" in ''|*[!0-9]*) break ;; esac
+    pid="$ppid"
+    hops=$((hops + 1))
+  done
+  [ -n "$auth_info_file" ] && [ -f "$auth_info_file" ] || return 1
+  printf '%s\n' "$auth_info_file"
+}
+
+ssh_cutover_authenticated_with_key() {
+  local user="$1" expected="$2" auth_file method key fingerprint
+  auth_file="$(ssh_cutover_auth_info_file "$user")" || return 1
+  while read -r method key; do
+    [ "$method" = publickey ] || continue
+    fingerprint="$(ssh_public_key_fingerprint "$key")" || continue
+    [ "$fingerprint" = "$expected" ] && return 0
+  done < "$auth_file"
+  return 1
 }
 
 ssh_cutover_has_sshd_ancestor() {
@@ -1638,11 +1695,12 @@ ssh_cutover_has_sshd_ancestor() {
 
 finalize_ssh_cutover() {
   local nonce="${1:-}" pending="$STATE_DIR/ssh_cutover.pending"
-  local key_file="$STATE_DIR/ssh_cutover.key" user expected actual
+  local key_file="$STATE_DIR/ssh_cutover.key" user expected key_fingerprint actual
 
   [ -s "$pending" ] || die "no SSH cutover is pending"
   user="$(sed -n 's/^user=//p' "$pending")"
   expected="$(sed -n 's/^nonce_sha256=//p' "$pending")"
+  key_fingerprint="$(sed -n 's/^key_sha256=//p' "$pending")"
   [ -n "$user" ] && [ -n "$expected" ] ||
     die "$pending is incomplete; predecessor access was not changed"
   [ "${SUDO_USER:-}" = "$user" ] ||
@@ -1668,6 +1726,10 @@ finalize_ssh_cutover() {
 
   SSH_PUBLIC_KEY="$(cat "$key_file" 2>/dev/null || true)"
   if [ -n "$SSH_PUBLIC_KEY" ]; then
+    [ -n "$key_fingerprint" ] &&
+      ssh_cutover_authenticated_with_key "$user" "$key_fingerprint" ||
+      die "this SSH session was not authenticated with the staged key. Reconnect" \
+	  "with that key and retry; predecessor access was not changed."
     grep -qxF "$SSH_PUBLIC_KEY" "$AUTH_KEYS" ||
       die "the staged key is no longer in $AUTH_KEYS; predecessor access was" \
 	  "not changed"
@@ -1675,6 +1737,15 @@ finalize_ssh_cutover() {
     [ "$(cat "$STATE_DIR/ssh_public_key.$user" 2>/dev/null || true)" = \
       "$SSH_PUBLIC_KEY" ] ||
       die "the staged key could not be committed; the cutover remains pending"
+    local queued_key queued_count=0 queue_clean=1
+    while IFS= read -r queued_key; do
+      [ -n "$queued_key" ] || continue
+      queued_count=$((queued_count + 1))
+      [ "$queued_key" = "$SSH_PUBLIC_KEY" ] || queue_clean=0
+    done < "$STATE_DIR/ssh_public_keys.$user"
+    [ "$queue_clean" -eq 1 ] && [ "$queued_count" -eq 1 ] ||
+      die "one or more predecessor SSH keys could not be withdrawn. The cutover" \
+	  "remains pending; repair $AUTH_KEYS or its filesystem and retry."
   fi
 
   revoke_prior_deploy_user "$user" ||
@@ -3238,7 +3309,8 @@ install_managed_config 'the SSH hardening drop-in' \
   'PasswordAuthentication no' \
   'PermitRootLogin no' \
   'KbdInteractiveAuthentication no' \
-  'PubkeyAuthentication yes'
+  'PubkeyAuthentication yes' \
+  'ExposeAuthInfo yes'
 # A host provisioned by an earlier version of this script carries the 99- file.
 # It is inert now that 01- sets the same keywords first, and that is the reason
 # to remove it rather than leave it: a file whose every line is overridden is

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -102,6 +102,25 @@ die() { printf '\n!!! [%s] %s\n' "$(date -Is)" "$*" >&2; exit 1; }
 
 [ "$(id -u)" -eq 0 ] || die "run as root"
 
+# DB_PORT names the port, it does not choose it. Nothing here writes
+# postgresql.conf: the cluster is created by the postgresql-$PG_MAJOR package,
+# and pg_createcluster takes the first free port from 5432. So an overridden
+# DB_PORT is consumed by psql, the ufw rule, the backup unit and DATABASE_URL
+# while the cluster listens on 5432 regardless — and the check that would catch
+# a mismatched cluster cannot help on a fresh host, because pg_lsclusters does
+# not exist until several steps after this one.
+#
+# Refused rather than converged, deliberately. Making it work means writing a
+# port into postgresql.conf and restarting a cluster this script did not create
+# the layout of, which is a bigger promise than the one line of configuration
+# suggests. The variable stays, because four places name the port and a literal
+# in each of them is how they drift apart.
+[ "$DB_PORT" = "5432" ] || die \
+  "DB_PORT=$DB_PORT is not supported: this script does not configure the cluster's port," \
+  "so PostgreSQL would still listen on 5432 while DATABASE_URL, the ufw rule and the" \
+  "nightly backup all named $DB_PORT. Leave DB_PORT unset, and move the cluster by hand" \
+  "afterwards if you need a different port."
+
 if [ -f "$MARKER" ] && [ "${FORCE:-0}" != "1" ]; then
   log "already provisioned ($MARKER). Re-run with FORCE=1 to converge again."
   exit 0
@@ -309,6 +328,59 @@ revoke_prior_deploy_user() {
 # so this is the one place that would otherwise silently disagree with them.
 psql_as_postgres() {
   runuser -u postgres -- psql -v ON_ERROR_STOP=1 -qtA -p "$DB_PORT" -d "$1" -c "$2"
+}
+
+# Make /swapfile match $SWAP_SIZE_MB, including when that means removing it.
+#
+# The previous form asked "is swap already on?" and skipped everything if so,
+# which converges only the first run: raising SWAP_SIZE_MB after an OOM left the
+# old headroom in place, and SWAP_SIZE_MB=0 left swap enabled — both reported as
+# a successful convergent run. The size on disk is what has to be compared,
+# because that is the thing the setting names.
+#
+# A resize means swapoff first, and swapoff can fail when the pages cannot be
+# faulted back into RAM — the low-memory instance this setting exists for is
+# exactly where that happens. That is reported and the old swap left running,
+# rather than being fatal: nothing downstream depends on the size, and dying
+# here would abandon a provisioning run over the one condition where the
+# operator most needs the host to come up.
+ensure_swapfile() {
+  local swap="${1:-/swapfile}" fstab="${2:-/etc/fstab}"
+  local want="$SWAP_SIZE_MB" have=0 active=no
+  swapon --show=NAME --noheadings 2>/dev/null | grep -qxF "$swap" && active=yes
+  # GNU stat first; BSD stat rejects -c, and the unit tests run on both.
+  [ -f "$swap" ] &&
+    have=$(( $(stat -c %s "$swap" 2>/dev/null || stat -f %z "$swap" 2>/dev/null || echo 0) / 1048576 ))
+
+  if [ "$want" -eq "$have" ] && { [ "$want" -eq 0 ] || [ "$active" = yes ]; }; then
+    return 0
+  fi
+
+  if [ "$active" = yes ] && ! swapoff "$swap" 2>/dev/null; then
+    log "WARNING: could not swapoff $swap (${have}MiB), so it is unchanged;" \
+        "SWAP_SIZE_MB=$want did NOT take effect. Free some memory and re-run," \
+        "or resize it by hand."
+    return 0
+  fi
+
+  if [ "$want" -eq 0 ]; then
+    rm -f "$swap"
+    # An empty managed block rather than a deletion: ensure_block owns these
+    # lines by marker, and leaving the marker in place keeps a later re-run with
+    # a non-zero size converging the same block instead of appending a second.
+    ensure_block "$fstab" swap ""
+    log "swap disabled (SWAP_SIZE_MB=0)"
+    return 0
+  fi
+
+  rm -f "$swap"
+  fallocate -l "${want}M" "$swap" || \
+    dd if=/dev/zero of="$swap" bs=1M count="$want" status=none
+  chmod 600 "$swap"
+  mkswap "$swap" >/dev/null
+  swapon "$swap"
+  ensure_block "$fstab" swap "$swap none swap sw 0 0"
+  [ "$have" -eq 0 ] || log "resized $swap from ${have}MiB to ${want}MiB"
 }
 
 # Refuse to provision when $PG_MAJOR's cluster is not the one on $DB_PORT.
@@ -523,16 +595,7 @@ dpkg-reconfigure -f noninteractive unattended-upgrades
 # --------------------------------------------------------------------------
 log "2/9 swap (${SWAP_SIZE_MB}MiB)"
 # --------------------------------------------------------------------------
-if [ "$SWAP_SIZE_MB" -gt 0 ] && ! swapon --show=NAME --noheadings | grep -q '/swapfile'; then
-  if [ ! -f /swapfile ]; then
-    fallocate -l "${SWAP_SIZE_MB}M" /swapfile || \
-      dd if=/dev/zero of=/swapfile bs=1M count="$SWAP_SIZE_MB" status=none
-    chmod 600 /swapfile
-    mkswap /swapfile
-  fi
-  swapon /swapfile
-  ensure_block /etc/fstab swap "/swapfile none swap sw 0 0"
-fi
+ensure_swapfile
 cat > /etc/sysctl.d/99-collavre.conf <<'SYSCTL'
 # Prefer RAM, use swap only under real pressure.
 vm.swappiness = 10

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -96,6 +96,7 @@ unset _s
 : "${BACKUP_RETENTION_DAYS:=7}"
 : "${BACKUP_S3_URI:=}"
 : "${BACKUP_AT:=03:30}"
+BACKUP_CALENDAR="*-*-* $BACKUP_AT:00"
 
 # --------------------------------------------------------------------------
 # Internals
@@ -481,6 +482,23 @@ refuse_unusable_retention() {
       "reports 'backup complete'. Nothing has been changed. The default is 7."
 }
 
+# refuse_unusable_backup_calendar <setting name> <configured value> <calendar>
+#
+# Validate the exact expression installed below, before the staged timer can
+# replace a working live unit. systemctl only parses OnCalendar after the
+# replacement, which is too late to preserve the prior schedule on failure.
+refuse_unusable_backup_calendar() {
+  local setting="$1" value="$2" calendar="$3"
+  if command -v systemd-analyze >/dev/null 2>&1 &&
+     systemd-analyze calendar "$calendar" >/dev/null 2>&1
+  then
+    return 0
+  fi
+  die "REFUSING: $setting='$value' does not produce a valid systemd calendar" \
+      "expression ('$calendar'). The existing PostgreSQL backup timer is left" \
+      "unchanged. Use a 24-hour HH:MM time; the default is 03:30."
+}
+
 # refuse_unparsable_ssh_key
 #
 # SSH_PUBLIC_KEY is appended to authorized_keys verbatim, and its own presence
@@ -807,6 +825,7 @@ refuse_unusable_db_identifier DB_USER "$DB_USER"
 refuse_unusable_bind_address DB_BIND_ADDRESS "$DB_BIND_ADDRESS"
 refuse_unusable_subnet DOCKER_SUBNETS "$DOCKER_SUBNETS"
 refuse_unusable_retention BACKUP_RETENTION_DAYS "$BACKUP_RETENTION_DAYS"
+refuse_unusable_backup_calendar BACKUP_AT "$BACKUP_AT" "$BACKUP_CALENDAR"
 refuse_unparsable_ssh_key
 refuse_forced_command_ssh_key
 refuse_root_deploy_user "$APP_SSH_USER"
@@ -3953,7 +3972,7 @@ install_managed_config 'the PostgreSQL backup timer unit' \
   'Description=Nightly Collavre PostgreSQL dump' \
   '' \
   '[Timer]' \
-  "OnCalendar=*-*-* $BACKUP_AT:00" \
+  "OnCalendar=$BACKUP_CALENDAR" \
   'Persistent=true' \
   '' \
   '[Install]' \

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -18,7 +18,7 @@
 #   6. ufw firewall, nightly pg_dump backups with retention
 #
 # The app itself is deployed afterwards from your workstation with
-# `bin/kamal setup`, which builds the image and boots the container. See
+# `./kamal.sh setup`, which builds the image and boots the container. See
 # docs/deploy_to_lightsail.md for the full runbook.
 #
 # The script is idempotent: re-running it converges the host instead of
@@ -476,7 +476,10 @@ Collavre Lightsail host — provisioned $(date -Is)
   backups          /var/backups/collavre, nightly at $BACKUP_AT, ${BACKUP_RETENTION_DAYS}d retention
   log              $LOG_FILE
 
-Put these in .env.production on your workstation, then run \`bin/kamal setup\`:
+Put these in .env.production at the root of your Collavre checkout, then run
+\`./kamal.sh setup\` from that same directory — the wrapper is what loads
+.env.production; plain \`bin/kamal\` does not read it and would deploy with no
+host and the wrong SSH user:
 
   COLLAVRE_SERVER=$PUBLIC_IP
   KAMAL_SSH_USER=$APP_SSH_USER

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -2552,6 +2552,7 @@ sysctl --system >/dev/null
 
 # verify_ssh_hardening [effective config file] [sshd config dir]
 #                      [reload state: 0=reloaded, 2=no active daemon]
+#                      [deploy user]
 #
 # Read back what sshd actually resolved the three hardened keywords to, and
 # refuse a run that reported hardening it did not perform.
@@ -2573,25 +2574,28 @@ sysctl --system >/dev/null
 # daemon has just accepted the reload, and is warned about instead. With no
 # active daemon it is the only gate: the next socket-activated connection will
 # start sshd from those files, so an unreadable answer is fatal in reload state
-# 2. `sshd -T` needs host keys and a parseable configuration; Match blocks do
-# not make it unreadable — without `-C` it prints the global block and exits 0,
-# measured on both OpenSSH builds this was checked against.
+# 2. `sshd -T` needs host keys and a parseable configuration. `-C user=...` is
+# load-bearing: without it sshd prints only the global block, so a later
+# `Match User <deploy-user>` can turn password authentication back on while
+# this verifier reports the global `no`.
 verify_ssh_hardening() {
   local src="${1:-}" conf_dir="${2:-/etc/ssh}" reload_state="${3:-0}"
+  local deploy_user="${4:-${APP_SSH_USER:-collavre}}"
   local effective key value offender
   if [ -n "$src" ]; then
     effective="$(cat "$src")"
-  elif ! effective="$(sshd -T 2>/dev/null)"; then
+  elif ! effective="$(sshd -T -C "user=$deploy_user" 2>/dev/null)"; then
     [ "$reload_state" -ne 2 ] || die \
       "SSH hardening could not be verified: there is no active sshd to reload" \
-      "and 'sshd -T' rejected or could not read the configuration on disk." \
+      "and 'sshd -T -C user=$deploy_user' rejected or could not read the" \
+      "configuration on disk." \
       "The next socket-activated connection or reboot would start sshd from" \
       "that unverified configuration. Nothing has been granted. Run 'sshd -t'" \
       "to find the error, fix it, and re-run."
     log "WARNING: could not read the effective SSH configuration on this host" \
-        "(\`sshd -T\` failed), so the hardening above is unverified. Check it" \
-        "by hand: sshd -T | grep -E" \
-        "'^(passwordauthentication|permitrootlogin|kbdinteractiveauthentication)'"
+	"(\`sshd -T -C user=$deploy_user\` failed), so the hardening above is" \
+	"unverified. Check it by hand: sshd -T -C user=$deploy_user | grep -E" \
+	"'^(passwordauthentication|permitrootlogin|kbdinteractiveauthentication)'"
     return 0
   fi
   for key in passwordauthentication permitrootlogin kbdinteractiveauthentication; do
@@ -2605,19 +2609,19 @@ verify_ssh_hardening() {
     if [ "$value" = "no" ]; then
       continue
     fi
-    # Name the file rather than leave the operator to find it: with the drop-in
-    # sorting first, something above the Include or an earlier prefix is the
-    # only way to get here, and both are one grep away.
+    # Name the file rather than leave the operator to find it. A directive
+    # above the Include, an earlier drop-in or a matching Match block can get
+    # here, and all three are one grep away.
     offender="$(grep -ilE "^[[:space:]]*$key[[:space:]]" \
                   "$conf_dir"/sshd_config.d/*.conf "$conf_dir"/sshd_config \
                   2>/dev/null | grep -v '01-collavre.conf' | head -1)" || true
     die "SSH hardening did not take effect: sshd resolves '$key' to '$value'," \
-        "not 'no', even though $conf_dir/sshd_config.d/01-collavre.conf sets" \
-        "it. sshd uses the FIRST value it obtains for a keyword, so something" \
-        "read earlier is setting it${offender:+ — ${offender}}. Stopping here" \
-        "rather than finishing: nothing has been granted yet and SSH is" \
-        "unchanged, so the host stays reachable. Remove or correct that" \
-        "setting and re-run."
+	"not 'no', even though $conf_dir/sshd_config.d/01-collavre.conf sets" \
+	"it. An earlier global directive or a Match block for '$deploy_user'" \
+	"is overriding it${offender:+ — ${offender}}. Stopping here rather" \
+	"than finishing: nothing has been granted yet and SSH is unchanged," \
+	"so the host stays reachable. Remove or correct that setting and" \
+	"re-run."
   done
 }
 
@@ -2748,7 +2752,7 @@ reload_ssh_daemon || SSH_RELOAD_STATE=$?
   "rejected configuration at the next boot, where no old process survives to" \
   "keep the host reachable. Nothing has been granted and SSH is unchanged." \
   "Find the offending directive with 'sshd -t', fix it, and re-run."
-verify_ssh_hardening "" /etc/ssh "$SSH_RELOAD_STATE"
+verify_ssh_hardening "" /etc/ssh "$SSH_RELOAD_STATE" "$APP_SSH_USER"
 
 # install_deploy_ssh_dir <user> <home> — create <home>/.ssh owned by the
 # account, and echo the group it was given.
@@ -3814,10 +3818,12 @@ log "7/9 firewall"
 # No `ufw reset`: this script is re-runnable, and a reset months later would
 # take a VPN, monitoring or IP-allowlist rule with it. Only the rules below are
 # ours to converge.
+# `default deny incoming` changes an already-active firewall immediately, so
+# port 22 must be authorized before that live policy is tightened.
+ensure_ssh_rule
 ufw default deny incoming
 ufw default allow outgoing
 
-ensure_ssh_rule
 ufw allow 80/tcp
 ufw allow 443/tcp
 # PostgreSQL is only listening on localhost and the docker bridge, so this rule

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -431,6 +431,72 @@ refuse_root_deploy_user() {
       "default 'collavre', which this script creates."
 }
 
+# refuse_nologin_deploy_user <user>
+#
+# The guard above states the invariant it does not test. Its own message is
+# "'$user' could never log in, while the summary would still print
+# KAMAL_SSH_USER=$user and every 'kamal deploy' would fail to authenticate" —
+# which is true word for word of a service account whose shell is
+# /usr/sbin/nologin, and which it accepts. Measured against 6125e4ee:
+#
+#   account   shell               id -u        guard
+#   root      /bin/sh             0            REFUSES
+#   nobody    /usr/sbin/nologin   65534        PROCEEDS
+#   daemon    /usr/sbin/nologin   1            PROCEEDS
+#
+# Kamal runs its commands over `ssh <user>@host <command>`, and a nologin shell
+# refuses command execution the same way it refuses a session — so the account
+# is armed with docker and sudo, published as KAMAL_SSH_USER, and every deploy
+# fails. On a rotation it is worse than a failed run: the predecessor's docker
+# and sudo are taken back in favour of an account that cannot execute anything,
+# and the remedy for that is on the host you no longer have a way into.
+#
+# Placed with refuse_root_deploy_user and for the same reason: refusing at the
+# deploy-user block would already be past the point where a rotation has a
+# predecessor to strip.
+#
+# Only accounts that already exist are tested. One that does not is created by
+# `adduser` below with an ordinary shell, and treating "cannot resolve" as
+# "might be nologin" would refuse every fresh host — the same reasoning the UID
+# check above records.
+refuse_nologin_deploy_user() {
+  local user="$1" shell
+  id -u "$user" >/dev/null 2>&1 || return 0
+  shell="$(getent passwd "$user" | cut -d: -f7)"
+  # An account `id -u` resolves but `getent passwd` will not describe is not a
+  # pass. The question this guard asks is "can this account run a command", and
+  # an unanswerable question has to read as the unsafe answer — the same rule
+  # role_owns_app_objects states and the psql probes had to be taught.
+  [ -n "$shell" ] ||
+    die "APP_SSH_USER='$user' exists but this host will not say what login" \
+        "shell it has, so this run cannot tell an ordinary account from a" \
+        "service account that can never run a 'kamal deploy'. Nothing has been" \
+        "changed. Check 'getent passwd $user', or set APP_SSH_USER to an" \
+        "account this host describes."
+  # Tested by running it rather than by matching names: /usr/sbin/nologin,
+  # /sbin/nologin, /bin/false and /usr/bin/false are four spellings across two
+  # distributions of one behaviour, and a fifth would read as though the
+  # question had been answered. A shell that exits non-zero on `-c true` cannot
+  # run a deploy command, whatever it is called.
+  [ -x "$shell" ] ||
+    die "APP_SSH_USER='$user' has login shell '$shell', which is not executable" \
+        "on this host, so sshd can start no command for it and every" \
+        "'kamal deploy' would fail after this script had already given the" \
+        "account docker and passwordless sudo. Nothing has been changed. Fix" \
+        "the account with 'usermod -s /bin/bash $user', or set APP_SSH_USER to" \
+        "an ordinary account."
+  "$shell" -c true >/dev/null 2>&1 ||
+    die "APP_SSH_USER='$user' has login shell '$shell', which refuses to run a" \
+        "command — this is what /usr/sbin/nologin and /bin/false do, and it is" \
+        "how service accounts like 'nobody' and 'www-data' are configured." \
+        "Kamal deploys by running commands over ssh, so this account would be" \
+        "armed with docker and passwordless sudo, published as" \
+        "KAMAL_SSH_USER=$user, and unable to execute anything. Nothing has been" \
+        "changed. Fix the account with 'usermod -s /bin/bash $user', or set" \
+        "APP_SSH_USER to an ordinary account; leave it unset for the default" \
+        "'collavre', which this script creates."
+}
+
 # Before refuse_defaulted_config_change, and long before anything is installed:
 # a value this script cannot use is not usable whatever the host was given
 # earlier, so it is answered without reading any state at all.
@@ -438,6 +504,7 @@ refuse_unusable_db_identifier DB_NAME "$DB_NAME"
 refuse_unusable_db_identifier DB_USER "$DB_USER"
 refuse_unparsable_ssh_key
 refuse_root_deploy_user "$APP_SSH_USER"
+refuse_nologin_deploy_user "$APP_SSH_USER"
 
 refuse_defaulted_config_change
 
@@ -670,6 +737,52 @@ write_state_file() {
   mv -f "$tmp" "$target"
 }
 
+# append_state_line <set file> <line>
+#
+# Add one line to a queue file, or do nothing if it is already there.
+#
+# The three record_*_grant functions below each ended with a bare
+#
+#   grep -qxF "$x" "$set_file" || printf '%s\n' "$x" >> "$set_file"
+#
+# which is the one write in this script that write_state_file was introduced for
+# and did not reach. An append cut short — ENOSPC, RLIMIT_FSIZE, an interrupted
+# run — leaves the file ending in a fragment with no newline, and the *retry* is
+# what does the damage: `grep -qxF` does not match the fragment, so the full
+# value is appended onto the end of it and the queue gains one line that is
+# neither value. Measured against 6125e4ee, with the partial write injected and
+# an A -> B(torn) -> C rotation:
+#
+#   queue after the retry   line 1  319 bytes  exact match for B: no
+#                           line 2  439 bytes  exact match for B: no   <- 120 + 319
+#   after the C rotation    key B   authorized: yes   named by the queue: no
+#
+# The concatenated line is worse than a corrupt entry, because revoke_prior_*
+# reads "not present in authorized_keys" as "already withdrawn, nothing
+# outstanding" and drops it. So the queue does not merely fail to name B — it
+# quietly retires the only line that ever mentioned it and ends up looking
+# clean, on an account holding passwordless sudo and the docker socket.
+#
+# Read-modify-write rather than a smarter append: a torn write of the *whole*
+# set leaves the staging file short and the live file untouched, which is the
+# state a retry starts from. There is no partial-line state to be in.
+append_state_line() {
+  local set_file="$1" line="$2" existing=''
+  grep -qxF "$line" "$set_file" 2>/dev/null && return 0
+  # A trailing fragment left by an earlier revision's torn append is *not*
+  # dropped here, and cannot be: nothing distinguishes half a key from a
+  # different key. What this does is terminate it, so the value being recorded
+  # gets its own intact line instead of being concatenated onto it. The fragment
+  # then leaves on its own at the next rotation, by the revoke loop's
+  # "absent from authorized_keys, nothing outstanding" path — which is the right
+  # answer for it, since a fragment authorizes nobody. Measured on the A ->
+  # B(torn) -> C fixture: three lines after the retry, the third an exact match
+  # for B, and B withdrawn by the C rotation.
+  [ -f "$set_file" ] && existing="$(grep -v '^[[:space:]]*$' "$set_file")"
+  [ -z "$existing" ] || existing="$existing"$'\n'
+  write_state_file "$set_file" "$existing$line"$'\n'
+}
+
 # record_deploy_user_grant <user> [set file] [single-name marker]
 #
 # The set of accounts this script has granted root-equivalent access to and has
@@ -712,8 +825,7 @@ record_deploy_user_grant() {
       write_state_file "$set_file" "$seed"$'\n' || return 1
     fi
   fi
-  grep -qxF "$user" "$set_file" 2>/dev/null ||
-    printf '%s\n' "$user" >> "$set_file"
+  append_state_line "$set_file" "$user"
 }
 
 # revoke_deploy_user_access <user> <successor>
@@ -1275,8 +1387,7 @@ record_db_role_grant() {
       write_state_file "$set_file" "$seed"$'\n' || return 1
     fi
   fi
-  grep -qxF "$role" "$set_file" 2>/dev/null ||
-    printf '%s\n' "$role" >> "$set_file"
+  append_state_line "$set_file" "$role"
 }
 
 # reassign_one_db_role <prior> <current>
@@ -1985,8 +2096,7 @@ record_ssh_key_grant() {
       write_state_file "$set_file" "$seed"$'\n' || return 1
     fi
   fi
-  grep -qxF "$key" "$set_file" 2>/dev/null ||
-    printf '%s\n' "$key" >> "$set_file"
+  append_state_line "$set_file" "$key"
 }
 
 revoke_prior_ssh_key() {
@@ -2459,7 +2569,34 @@ if [ -n "$BACKUP_S3_URI" ] && ! command -v aws >/dev/null 2>&1; then
   rm -rf "$AWS_CLI_TMP"
 fi
 
-cat > /usr/local/bin/collavre-pg-backup <<BACKUP
+# Staged and renamed, not written through the live path, for the reason
+# ensure_block already records — with one addition that makes this the worse of
+# the two. `cat > /usr/local/bin/collavre-pg-backup` truncates at open, and this
+# file is *executable*: a truncated shell script is not a broken file that fails
+# to load, it is a shorter program that runs. Every truncation point of the
+# generated script, measured:
+#
+#   1233 truncation points   624 syntactically valid
+#                            153 EXIT 0 AND NEVER REACH pg_dump   (bytes 1..310)
+#
+# Those 153 are the first quarter of the file, so an interruption early in the
+# write — the likely one — lands there. And the mode survives: `cat >` does not
+# reset it, and the `chmod 0755` below is the *next* statement, so on a re-
+# converge run the stump keeps the executable bit the previous run gave it while
+# collavre-pg-backup.timer stays enabled. The nightly unit then runs a program
+# that exits 0 without dumping anything: systemctl reports green, the retention
+# sweep is never reached either, and the host has no backups and no symptom.
+# That is why validation is part of the install and not a comment: a file that
+# is not a complete script does not get to be the backup program.
+BACKUP_TMP="$(mktemp /usr/local/bin/collavre-pg-backup.XXXXXX)"
+# `if ! cat` rather than a bare `cat` leaning on the `set -euo pipefail` at the
+# top of this file. Errexit does cover a bare top-level command, so this is not
+# a live hole — but the review one thread over was exactly a place where `set -e`
+# was assumed and was not in force, and a guarantee this local should not depend
+# on a setting 2500 lines away that a future `|| something` would suppress. The
+# staging file is removed on the way out, so a retry starts from the same state
+# a kill would leave: the live path untouched.
+if ! cat > "$BACKUP_TMP" <<BACKUP
 #!/usr/bin/env bash
 # Managed by script/lightsail_launch.sh
 set -euo pipefail
@@ -2498,7 +2635,26 @@ find "\$DEST" -maxdepth 1 -name '*.dump' -mtime "+\$RETENTION_DAYS" -delete
 echo "backup complete: \$FILE (\$(du -h "\$FILE" | cut -f1))"
 exit "\$S3_STATUS"
 BACKUP
-chmod 0755 /usr/local/bin/collavre-pg-backup
+then
+  rm -f "$BACKUP_TMP"
+  die "could not write the staged backup script — is /usr/local/bin full?" \
+      "/usr/local/bin/collavre-pg-backup is left as it was, and nothing was" \
+      "installed over it."
+fi
+# `bash -n` on the staging file, before it can become the thing systemd runs.
+# It is not a whole-program check — 624 of the truncation points above parse
+# fine — but it is the half that is free, and the rename below is what closes
+# the rest: a run killed during the copy leaves the stump in the staging file
+# and the live path untouched, which is the state a retry starts from.
+if ! bash -n "$BACKUP_TMP"; then
+  rm -f "$BACKUP_TMP"
+  die "generated a backup script that is not valid shell — refusing to install" \
+      "it over /usr/local/bin/collavre-pg-backup, which is left as it was." \
+      "This is a bug in this script; the values it interpolates (DB_NAME," \
+      "BACKUP_S3_URI) are the place to look."
+fi
+chmod 0755 "$BACKUP_TMP"
+mv -f "$BACKUP_TMP" /usr/local/bin/collavre-pg-backup
 
 cat > /etc/systemd/system/collavre-pg-backup.service <<'UNIT'
 [Unit]

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -218,6 +218,38 @@ ensure_sudoers() {
   done
 }
 
+# Take the docker group back from the deploy user a FORCE=1 re-run replaced.
+#
+# ensure_sudoers above already drops the old NOPASSWD file, but on its own that
+# revokes the longer road to root and leaves the shorter one open: docker group
+# membership is root-equivalent, so an operator rotating APP_SSH_USER away from
+# a compromised account would still be handing it a root shell.
+#
+# The account itself and its authorized_keys are deliberately left alone. This
+# runs on a host whose only other way in is the user the same run just created,
+# and `deluser` on the wrong guess (APP_SSH_USER=ubuntu on the first run, say)
+# is unrecoverable. With both groups gone the keys reach an ordinary account,
+# which is a job for a human who can see the host.
+revoke_prior_deploy_user() {
+  local current="$1" prior_file="${2:-$STATE_DIR/deploy_user}" prior group
+  [ -f "$prior_file" ] || return 0
+  prior="$(cat "$prior_file")"
+  [ -n "$prior" ] && [ "$prior" != "$current" ] || return 0
+  id -u "$prior" >/dev/null 2>&1 || return 0
+
+  for group in docker sudo; do
+    # id -nG rather than `getent group`: it reports the primary group too, and
+    # the membership that matters is the effective one either way.
+    if id -nG "$prior" 2>/dev/null | tr ' ' '\n' | grep -qxF "$group"; then
+      gpasswd -d "$prior" "$group" >/dev/null 2>&1 &&
+        log "revoked '$group' from the replaced deploy user '$prior'"
+    fi
+  done
+  log "WARNING: '$prior' is no longer in docker or sudo but can still log in;" \
+      "remove it by hand once you can reach the host as '$current':" \
+      "deluser --remove-home $prior"
+}
+
 # --------------------------------------------------------------------------
 log "1/9 base packages"
 # --------------------------------------------------------------------------
@@ -341,6 +373,10 @@ else
   systemctl start docker
 fi
 usermod -aG docker "$APP_SSH_USER"
+# Only once the replacement can reach Docker, so an interrupted run never
+# leaves the host with no account that can deploy.
+revoke_prior_deploy_user "$APP_SSH_USER"
+printf '%s\n' "$APP_SSH_USER" > "$STATE_DIR/deploy_user"
 
 # --------------------------------------------------------------------------
 log "5/9 PostgreSQL $PG_MAJOR"

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -82,6 +82,12 @@ export NEEDRESTART_MODE=a
 export NEEDRESTART_SUSPEND=1
 
 mkdir -p "$STATE_DIR"
+# Root-only before anything is written to it: this log is a transcript of a
+# provisioning run, and cloud-init's own copy of our stdout
+# (/var/log/cloud-init-output.log) is readable by more than root. Nothing
+# printed below may contain a credential.
+touch "$LOG_FILE"
+chmod 0600 "$LOG_FILE"
 exec > >(tee -a "$LOG_FILE") 2>&1
 
 log() { printf '\n=== [%s] %s\n' "$(date -Is)" "$*"; }
@@ -343,6 +349,28 @@ log "8/9 nightly backups"
 # readable only by postgres and root.
 install -d -m 0700 -o postgres -g postgres /var/backups/collavre
 
+# Ubuntu ships no `aws`, so an S3 destination is useless without installing it
+# first. Official v2 installer rather than the apt package: noble's awscli is a
+# release behind and this has to work on 24.04 for years.
+if [ -n "$BACKUP_S3_URI" ] && ! command -v aws >/dev/null 2>&1; then
+  case "$(uname -m)" in
+    aarch64 | arm64) AWS_CLI_ARCH=aarch64 ;;
+    *) AWS_CLI_ARCH=x86_64 ;;
+  esac
+  AWS_CLI_TMP="$(mktemp -d)"
+  if curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-${AWS_CLI_ARCH}.zip" \
+       -o "$AWS_CLI_TMP/awscliv2.zip" &&
+     unzip -q "$AWS_CLI_TMP/awscliv2.zip" -d "$AWS_CLI_TMP" &&
+     "$AWS_CLI_TMP/aws/install" --update >/dev/null; then
+    hash -r
+    log "AWS CLI installed for S3 backup upload ($(aws --version 2>&1))"
+  else
+    log "WARNING: could not install the AWS CLI — nightly backups will stay local" \
+        "and collavre-pg-backup.service will fail until you install it by hand"
+  fi
+  rm -rf "$AWS_CLI_TMP"
+fi
+
 cat > /usr/local/bin/collavre-pg-backup <<BACKUP
 #!/usr/bin/env bash
 # Managed by script/lightsail_launch.sh
@@ -362,12 +390,25 @@ runuser -u postgres -- pg_dump --format=custom --compress=6 \\
 trap - ERR
 chmod 0600 "\$FILE"
 
-if [ -n "\$S3_URI" ] && command -v aws >/dev/null 2>&1; then
-  aws s3 cp "\$FILE" "\${S3_URI%/}/\$(basename "\$FILE")"
+# A configured S3 destination that silently does nothing is worse than no
+# off-instance backup at all, because it looks like one. Report the local dump
+# either way, then exit non-zero so the systemd unit goes red.
+S3_STATUS=0
+if [ -n "\$S3_URI" ]; then
+  if ! command -v aws >/dev/null 2>&1; then
+    echo "ERROR: S3_URI is set but the aws CLI is not installed —" \\
+         "\$FILE exists only on this instance" >&2
+    S3_STATUS=1
+  elif ! aws s3 cp "\$FILE" "\${S3_URI%/}/\$(basename "\$FILE")"; then
+    echo "ERROR: upload to \${S3_URI%/} failed —" \\
+         "\$FILE exists only on this instance" >&2
+    S3_STATUS=1
+  fi
 fi
 
 find "\$DEST" -maxdepth 1 -name '*.dump' -mtime "+\$RETENTION_DAYS" -delete
 echo "backup complete: \$FILE (\$(du -h "\$FILE" | cut -f1))"
+exit "\$S3_STATUS"
 BACKUP
 chmod 0755 /usr/local/bin/collavre-pg-backup
 
@@ -402,8 +443,16 @@ log "9/9 summary"
 PUBLIC_IP="$(curl -fsS --max-time 5 https://checkip.amazonaws.com 2>/dev/null || echo '<public-ip>')"
 PRIVATE_IP="$(hostname -I | awk '{print $1}')"
 DATABASE_URL="postgresql://$DB_USER:$DB_PASSWORD@$DB_BIND_ADDRESS:5432/$DB_NAME"
+# Angle brackets, not a $(...) that a reader might paste into .env.production
+# and watch dotenv store verbatim.
+REDACTED_URL="postgresql://$DB_USER:<see $SUMMARY>@$DB_BIND_ADDRESS:5432/$DB_NAME"
 
-cat > "$SUMMARY" <<TXT
+# Rendered twice: once with the real DATABASE_URL into the 0600 summary file,
+# once redacted for stdout — which is tee'd to the launch log and captured by
+# cloud-init. Templating instead of sed'ing the secret out keeps a password
+# containing regex or delimiter characters from slipping through unreplaced.
+render_summary() { # $1 = DATABASE_URL to display
+  cat <<TXT
 Collavre Lightsail host — provisioned $(date -Is)
 
   public IP        $PUBLIC_IP
@@ -420,14 +469,18 @@ Put these in .env.production on your workstation, then run \`bin/kamal setup\`:
   COLLAVRE_SERVER=$PUBLIC_IP
   KAMAL_SSH_USER=$APP_SSH_USER
   KAMAL_SSH_KEY_PATH=~/.ssh/<the key matching the instance>
-  DATABASE_URL=$DATABASE_URL
+  DATABASE_URL=$1
   PORT=80
 
 Open ports 80 and 443 in the Lightsail console firewall (Networking tab).
 Never open 5432 there.
 TXT
+}
+
+touch "$SUMMARY"
 chmod 0600 "$SUMMARY"
+render_summary "$DATABASE_URL" > "$SUMMARY"
 
 touch "$MARKER"
-cat "$SUMMARY"
-log "done — full log at $LOG_FILE"
+render_summary "$REDACTED_URL"
+log "done — full log at $LOG_FILE (root only; the DATABASE_URL above is redacted, the real one is in $SUMMARY)"

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -1129,7 +1129,7 @@ allocate_swapfile() {
 # not rotate at all, so sustained Rails output fills a Lightsail SSD, which is
 # the specific failure this block exists to prevent.
 ensure_docker_log_caps() {
-  local file="${1:-/etc/docker/daemon.json}" tmp driver
+  local file="${1:-/etc/docker/daemon.json}" tmp driver wrote
   DAEMON_JSON_CHANGED=0
   # Before either branch, so the create path and the rewrite path name one file
   # even when /etc/docker/daemon.json is a link — and so the rename below cannot
@@ -1192,16 +1192,29 @@ ensure_docker_log_caps() {
           '{"log-driver": "json-file", "log-opts": {"max-size": "10m", "max-file": "3"}}.'
       return 0
     }
-    if ! cat > "$tmp" <<'JSON' || ! jq empty "$tmp" >/dev/null 2>&1; then
+    # Checked for what it is supposed to say, not merely for parsing. `jq empty`
+    # exits 0 on a zero-length file — the same fact the empty-file repair above
+    # rests on — so a staged write that produced nothing would validate and be
+    # renamed into place, installing the exact file this whole change exists to
+    # keep off the live path. CI found that: a shortened write errors on BSD
+    # `head` and succeeds on GNU, so the case passed here for the wrong reason
+    # and failed on Linux for the right one.
+    # Written first and judged after, because a heredoc body has to follow the
+    # line that opens it — folding the check into the same `if` would make the
+    # check itself the first line of the JSON.
+    wrote=1
+    cat > "$tmp" <<'JSON' || wrote=0
     {
       "log-driver": "json-file",
       "log-opts": { "max-size": "10m", "max-file": "3" }
     }
 JSON
+    if [ "$wrote" = 0 ] ||
+       ! jq -e '."log-opts"."max-size" == "10m"' "$tmp" >/dev/null 2>&1; then
       rm -f "$tmp"
-      log "WARNING: a staged $file did not come out as valid JSON, so it was" \
-          "NOT installed and container logs are NOT capped. The live path is" \
-          "untouched, so a later run creates it cleanly."
+      log "WARNING: a staged $file did not come out as the file it was staged" \
+          "to be, so it was NOT installed and container logs are NOT capped." \
+          "The live path is untouched, so a later run creates it cleanly."
       return 0
     fi
     # No chmod: stage_beside gives a staging file for an absent target the
@@ -1257,11 +1270,14 @@ JSON
   }
   # Merge rather than replace: everything else in the file is the operator's.
   # Validated before it is installed, because a daemon.json that does not parse
-  # stops Docker from starting at all.
+  # stops Docker from starting at all — and validated by asking whether the caps
+  # are in it rather than whether it parses, for the same reason as the create
+  # branch above: `jq empty` exits 0 on a zero-length file, so "it parses" is an
+  # answer an empty staging file also gives.
   if ! jq '."log-driver" = "json-file"
            | ."log-opts" = ((."log-opts" // {})
                + {"max-size": "10m", "max-file": "3"})' "$file" > "$tmp" ||
-     ! jq empty "$tmp" >/dev/null 2>&1; then
+     ! jq -e '."log-opts"."max-size" == "10m"' "$tmp" >/dev/null 2>&1; then
     rm -f "$tmp"
     log "WARNING: could not merge the log caps into $file; it is unchanged and" \
         "container logs are NOT capped. Add" \

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -460,7 +460,7 @@ refuse_root_deploy_user() {
 # "might be nologin" would refuse every fresh host — the same reasoning the UID
 # check above records.
 refuse_nologin_deploy_user() {
-  local user="$1" shell
+  local user="$1" shell run_as probe
   id -u "$user" >/dev/null 2>&1 || return 0
   shell="$(getent passwd "$user" | cut -d: -f7)"
   # An account `id -u` resolves but `getent passwd` will not describe is not a
@@ -495,6 +495,43 @@ refuse_nologin_deploy_user() {
         "changed. Fix the account with 'usermod -s /bin/bash $user', or set" \
         "APP_SSH_USER to an ordinary account; leave it unset for the default" \
         "'collavre', which this script creates."
+  # And again as the account, because everything above ran as root and root can
+  # execute files the deploy user cannot. A custom login shell installed
+  # mode-0700 root:root is the case: measured on a real host, `[ -x ]` answers
+  # yes, `"$shell" -c true` passes, and what sshd actually does after switching
+  # to the deploy UID answers "Permission denied". So the root-run probe reports
+  # a shell this account can never start.
+  #
+  # `runuser` first, `su` only if it is absent: both were measured to give the
+  # same answer on every row, but `runuser` is the conservative one — it is the
+  # tool for root switching without authentication, so a host with PAM rules
+  # that would question an interactive `su` cannot turn this probe into a
+  # refusal. If neither exists the root probe above is all this host allows, and
+  # that is not a reason to refuse: a missing util-linux would fail every run.
+  #
+  # The controls this had to keep, all measured: an ordinary account whose
+  # password is locked — which is what `adduser --disabled-password` leaves, so
+  # it is every key-only deploy account including the one this script creates —
+  # passes, as does one with no home directory or a home it cannot read. An
+  # account that is *expired* refuses here, and that is the right answer: sshd
+  # would refuse it too.
+  run_as=''
+  for probe in runuser su; do
+    command -v "$probe" >/dev/null 2>&1 && { run_as="$probe"; break; }
+  done
+  case "$run_as" in
+    runuser) runuser -u "$user" -- "$shell" -c true >/dev/null 2>&1 ;;
+    su)      su -s "$shell" -c true "$user" >/dev/null 2>&1 ;;
+    *)       true ;;
+  esac ||
+    die "APP_SSH_USER='$user' has login shell '$shell', which this script can" \
+        "run as root but '$user' cannot — a shell the account is not permitted" \
+        "to execute, or an expired account. sshd starts that shell after" \
+        "switching to the deploy UID, so every 'kamal deploy' would fail with" \
+        "the account already holding docker and passwordless sudo and the" \
+        "summary printing KAMAL_SSH_USER=$user. Nothing has been changed." \
+        "Check with 'runuser -u $user -- $shell -c true' and" \
+        "'ls -l $shell', or set APP_SSH_USER to an ordinary account."
 }
 
 # Before refuse_defaulted_config_change, and long before anything is installed:
@@ -1307,8 +1344,33 @@ JSON
 # decide when the app stops, so this aborts and says so rather than guessing.
 ensure_cluster_on_default_port() {
   local lsclusters="${1:-pg_lsclusters}" ver cluster port owner_of_default=""
-  local name_of_default=""
+  local name_of_default="" layout=""
   command -v "$lsclusters" >/dev/null 2>&1 || return 0
+
+  # Read into a variable first, so the status is answerable. It used to be
+  # expanded straight into the here-document below, where the command
+  # substitution's status is discarded: a `pg_lsclusters` that exits non-zero
+  # with nothing on stdout gave an empty loop, and a `while` whose body never
+  # runs completes with status 0. The guard then read the host as having no
+  # clusters at all — its one PROCEED answer — which is the reverse of what an
+  # unreadable layout means. Measured: a stub that exits 1 silently PROCEEDs,
+  # and so does one that exits 1 after printing only some of the clusters, on a
+  # host where another major version owns 5432.
+  #
+  # Assigned on its own line rather than in the `local` above, because `local
+  # x="$(...)"` returns the status of `local` and would discard it a second way.
+  #
+  # Empty output with status 0 still proceeds, and must: postgresql-common is
+  # installed here before any cluster exists, and `pg_lsclusters -h` on that
+  # host is legitimately silent. Emptiness is not the signal — the status is.
+  layout="$("$lsclusters" -h 2>/dev/null)" ||
+    die "'$lsclusters -h' failed on this host, so this run cannot tell which" \
+        "PostgreSQL clusters exist or which one serves $DB_PORT. Carrying on" \
+        "would read that failure as 'no clusters', install $PG_MAJOR, and write" \
+        "listen_addresses, the tuning and the pg_hba rule into" \
+        "/etc/postgresql/$PG_MAJOR/main while an existing cluster kept serving" \
+        "$DB_PORT — the layout this check exists to refuse. Nothing has been" \
+        "changed. Run 'pg_lsclusters' by hand to see why it failed."
 
   while read -r ver cluster port _rest; do
     [ -n "$ver" ] || continue
@@ -1324,7 +1386,7 @@ ensure_cluster_on_default_port() {
           "already serving $DB_PORT."
     fi
   done <<EOF
-$("$lsclusters" -h 2>/dev/null)
+$layout
 EOF
 
   if [ -n "$owner_of_default" ] && [ "$owner_of_default" != "$PG_MAJOR" ]; then

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -986,6 +986,37 @@ install_managed_config() {
   }
 }
 
+# install_downloaded_file <label> <url> <target>
+#
+# Download into a sibling of the resolved target and rename only after curl has
+# completed successfully. A package source may already refer to the target on a
+# FORCE re-run, so truncating it in place can make the next apt update fail
+# before this step gets another chance to repair it.
+install_downloaded_file() {
+  local label="$1" url="$2" target="$3" target_real tmp rc=0
+  target_real="$(resolve_symlink_chain "$target")" || exit 1
+  tmp="$(stage_beside "$target_real" 0644)" || rc=$?
+  [ "$rc" -eq 0 ] || {
+    die "could not stage $label at $target_real (stage_beside exited $rc)." \
+	"The live file is left exactly as it was."
+  }
+  if ! curl -fsSL "$url" -o "$tmp"; then
+    rm -f "$tmp"
+    die "could not download the staged $label. $target_real is left exactly" \
+	"as it was."
+  fi
+  if ! chmod a+r "$tmp"; then
+    rm -f "$tmp"
+    die "could not make the staged $label readable. $target_real is left" \
+	"exactly as it was."
+  fi
+  mv -f "$tmp" "$target_real" || {
+    rm -f "$tmp"
+    die "could not install the staged $label over $target_real, which is" \
+	"left exactly as it was."
+  }
+}
+
 # Keep a managed block in a config file equal to $content, keyed by a marker.
 # Added on the first run; on later runs the body is replaced in place, so a
 # FORCE=1 re-run with a changed DOCKER_SUBNETS or INSTANCE_HOSTNAME converges
@@ -3394,9 +3425,9 @@ fi
 
 if [ -n "$DOCKER_WANT" ]; then
   install -m 0755 -d /etc/apt/keyrings
-  curl -fsSL https://download.docker.com/linux/ubuntu/gpg \
-    -o /etc/apt/keyrings/docker.asc
-  chmod a+r /etc/apt/keyrings/docker.asc
+  install_downloaded_file 'the Docker signing key' \
+    https://download.docker.com/linux/ubuntu/gpg \
+    /etc/apt/keyrings/docker.asc
   # shellcheck disable=SC1091
   . /etc/os-release
   install_managed_config 'the Docker apt source' \

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -383,6 +383,79 @@ ensure_swapfile() {
   [ "$have" -eq 0 ] || log "resized $swap from ${have}MiB to ${want}MiB"
 }
 
+# Make sure container logs are capped, whether or not this host already has a
+# /etc/docker/daemon.json. Sets DAEMON_JSON_CHANGED to 1 when it changed the
+# file, so the caller knows a restart is needed for it to take effect.
+#
+# A global rather than an echoed value: log() writes to stdout, so a caller
+# using $(...) would capture the warnings below along with the flag and then
+# compare that to an integer.
+#
+# The previous form only wrote the file when it was absent. On the by-hand path
+# the runbook documents — an existing instance, Docker already installed,
+# possibly with an operator's own daemon.json — the caps were silently skipped
+# while the run reported Docker as configured. json-file with no `max-size` does
+# not rotate at all, so sustained Rails output fills a Lightsail SSD, which is
+# the specific failure this block exists to prevent.
+ensure_docker_log_caps() {
+  local file="${1:-/etc/docker/daemon.json}" tmp driver
+  DAEMON_JSON_CHANGED=0
+
+  if [ ! -f "$file" ]; then
+    # Indented so no line of the body starts at column 1: the unit tests extract
+    # these functions with an awk range that ends at the first column-1 "}", and
+    # a bare closing brace in a heredoc would cut the function in half.
+    cat > "$file" <<'JSON'
+    {
+      "log-driver": "json-file",
+      "log-opts": { "max-size": "10m", "max-file": "3" }
+    }
+JSON
+    DAEMON_JSON_CHANGED=1
+    return 0
+  fi
+
+  if ! jq empty "$file" >/dev/null 2>&1; then
+    log "WARNING: $file is not valid JSON, so the container log caps were NOT" \
+        "applied and Docker will not start until it is repaired. Left untouched" \
+        "rather than overwritten — it is not this script's file."
+    return 0
+  fi
+
+  # Only json-file is unbounded by default. journald, local and the cloud
+  # drivers do their own rotation, and forcing json-file onto a host whose
+  # operator chose otherwise would redirect their logs, not cap them.
+  driver="$(jq -r '."log-driver" // "json-file"' "$file")"
+  if [ "$driver" != "json-file" ]; then
+    log "docker log-driver is '$driver', which rotates on its own;" \
+        "leaving $file alone"
+    return 0
+  fi
+
+  if [ "$(jq -r '."log-opts"."max-size" // empty' "$file")" != "" ]; then
+    return 0
+  fi
+
+  tmp="$(mktemp)"
+  # Merge rather than replace: everything else in the file is the operator's.
+  # Validated before it is installed, because a daemon.json that does not parse
+  # stops Docker from starting at all.
+  if ! jq '."log-driver" = "json-file"
+           | ."log-opts" = ((."log-opts" // {})
+               + {"max-size": "10m", "max-file": "3"})' "$file" > "$tmp" ||
+     ! jq empty "$tmp" >/dev/null 2>&1; then
+    rm -f "$tmp"
+    log "WARNING: could not merge the log caps into $file; it is unchanged and" \
+        "container logs are NOT capped. Add" \
+        '"log-opts": {"max-size": "10m", "max-file": "3"} by hand.'
+    return 0
+  fi
+  cat "$tmp" > "$file"
+  rm -f "$tmp"
+  log "added container log caps to the existing $file"
+  DAEMON_JSON_CHANGED=1
+}
+
 # Refuse to provision when $PG_MAJOR's cluster is not the one on $DB_PORT.
 #
 # This script assumes one cluster, on the default port: DATABASE_URL, the ufw
@@ -475,18 +548,37 @@ reassign_prior_db_role() {
 # whose display form ("172.17.0.1 5432/tcp ALLOW IN 172.17.0.0/16") is not the
 # syntax `ufw delete` takes.
 ensure_ufw_rule() {
-  local name="$1" rule="$2" state="${3:-$STATE_DIR/ufw_$1}" prior
-  if [ -f "$state" ]; then
-    prior="$(cat "$state")"
-    if [ -n "$prior" ] && [ "$prior" != "$rule" ]; then
-      # Unquoted on purpose: a rule is a word list, not one argument.
-      # shellcheck disable=SC2086
-      ufw delete $prior >/dev/null 2>&1 &&
-        log "withdrew the previous $name rule: $prior"
-    fi
-  fi
+  local name="$1" rule="$2" state="${3:-$STATE_DIR/ufw_$1}" prior=""
+  [ -f "$state" ] && prior="$(cat "$state")"
+
+  # The replacement goes in first, so an interrupted run never leaves the host
+  # with neither rule. Same ordering as the deploy-user and SSH-key revocations.
+  # Unquoted on purpose: a rule is a word list, not one argument.
   # shellcheck disable=SC2086
   ufw $rule >/dev/null
+
+  if [ -n "$prior" ] && [ "$prior" != "$rule" ]; then
+    # `ufw delete` exits 0 both when it removed the rule and when there was
+    # nothing to remove ("Could not delete non-existent rule"), so a zero status
+    # does mean the rule is gone afterwards. It exits non-zero when it could not
+    # act at all — unparseable rule text, a lock it could not take — and that is
+    # the case where the old rule is still installed.
+    #
+    # The marker is NOT advanced then. Advancing it would drop the only record
+    # of what is still in force: for the postgres rule that means the previous
+    # Docker subnet keeps reaching the database for the life of the instance,
+    # and no later run can find it to revoke. Leaving the marker makes the next
+    # run retry, and `ufw` ignores a re-add of the rule already present.
+    # shellcheck disable=SC2086
+    if ! ufw delete $prior >/dev/null 2>&1; then
+      log "WARNING: could NOT withdraw the previous $name rule, and it is still" \
+          "in force: $prior — the marker is left unchanged so the next run" \
+          "retries it. Remove it by hand with: ufw delete $prior"
+      return 0
+    fi
+    log "withdrew the previous $name rule: $prior"
+  fi
+
   printf '%s\n' "$rule" > "$state"
 }
 
@@ -750,23 +842,17 @@ fi
 
 # Cap container logs — an unrotated Rails log fills a Lightsail SSD fast.
 install -d -m 0755 /etc/docker
-DAEMON_JSON_WRITTEN=0
-if [ ! -f /etc/docker/daemon.json ]; then
-  cat > /etc/docker/daemon.json <<'JSON'
-{
-  "log-driver": "json-file",
-  "log-opts": { "max-size": "10m", "max-file": "3" }
-}
-JSON
-  DAEMON_JSON_WRITTEN=1
-fi
+DAEMON_JSON_CHANGED=0
+ensure_docker_log_caps
 systemctl enable docker
-if [ "$DAEMON_JSON_WRITTEN" -eq 1 ]; then
+if [ "$DAEMON_JSON_CHANGED" -eq 1 ]; then
   # The package starts the daemon during install, so it is already running with
   # the stock config by the time we get here — `enable --now` would leave it
   # that way and the log caps would not apply until something restarted Docker.
-  # Only on the run that wrote the file, so a re-run never bounces live
-  # containers.
+  # Only on a run that changed the file, so a re-run never bounces live
+  # containers. On an existing instance that restart does bounce them, once:
+  # they come back under their restart policy, and an uncapped log filling the
+  # disk takes the whole host down rather than one container.
   systemctl restart docker
 else
   systemctl start docker

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -582,11 +582,11 @@ refuse_unparsable_ssh_key() {
 # they are the forms the guard above exists to keep working, and each of them
 # runs the client's command.
 #
-# The options are the words before the key blob. Every SSH public key encodes a
-# length-prefixed algorithm name, so the blob always begins "AAAA" — cutting
-# there keeps a `command=` that appears in the *comment* out of this, where it
-# is text rather than an option and refusing it would refuse a key sshd is
-# perfectly happy with.
+# The options are the first whitespace-delimited field before the key type and
+# blob. Whitespace inside a quoted option value does not end that field, and an
+# escaped quote does not end the value. Parse that boundary rather than looking
+# for base64 text: an option value is allowed to contain the same `AAAA` with
+# which an SSH key blob begins.
 #
 # Refused rather than checked after the install, for the reason the guard above
 # gives: revoke_prior_ssh_key withdraws the predecessor as soon as `grep -qxF`
@@ -617,7 +617,34 @@ refuse_forced_command_ssh_key() {
   # well as 5.2 on the host, and the parameter expansion is a 4.0 syntax error
   # there — the same platform split that made a `head -c 0` fixture pass here
   # and fail in CI.
-  options="$(printf '%s' "${SSH_PUBLIC_KEY%%AAAA*}" | tr '[:upper:]' '[:lower:]')"
+  options="$(
+    printf '%s\n' "$SSH_PUBLIC_KEY" |
+      awk '
+	{
+	  start = 1
+	  while (start <= length($0) &&
+		 substr($0, start, 1) ~ /[[:space:]]/) {
+	    start++
+	  }
+	  quoted = 0
+	  escaped = 0
+	  for (i = start; i <= length($0); i++) {
+	    char = substr($0, i, 1)
+	    if (escaped) {
+	      escaped = 0
+	    } else if (quoted && char == "\\") {
+	      escaped = 1
+	    } else if (char == "\"") {
+	      quoted = !quoted
+	    } else if (!quoted && char ~ /[[:space:]]/) {
+	      print substr($0, start, i - start)
+	      exit
+	    }
+	  }
+	}
+      ' |
+      tr '[:upper:]' '[:lower:]'
+  )"
   case "$options" in
     *command=*) ;;
     *) return 0 ;;

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -3410,9 +3410,9 @@ if ! [ -d "/etc/postgresql/$PG_MAJOR/main" ]; then
     -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc
   # shellcheck disable=SC1091
   . /etc/os-release
-  cat > /etc/apt/sources.list.d/pgdg.list <<EOF
-deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $VERSION_CODENAME-pgdg main
-EOF
+  install_managed_config 'the PostgreSQL apt source' \
+    /etc/apt/sources.list.d/pgdg.list \
+    "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $VERSION_CODENAME-pgdg main"
   apt_get update -y
   apt_install "postgresql-$PG_MAJOR" "postgresql-client-$PG_MAJOR"
 fi

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -358,6 +358,25 @@ ensure_swapfile() {
     have=$(( $(stat -c %s "$swap" 2>/dev/null || stat -f %z "$swap" 2>/dev/null || echo 0) / 1048576 ))
 
   if [ "$want" -eq "$have" ] && { [ "$want" -eq 0 ] || [ "$active" = yes ]; }; then
+    # The file needs no work, but the fstab entry still might. Swap that is
+    # active without being in fstab is gone after the next reboot, and this is
+    # how a host arrives in that state: an operator who ran `swapon` by hand
+    # before provisioning, or an earlier run interrupted between `swapon` and
+    # `ensure_block` below. Returning here would report a convergent run over a
+    # host that silently loses its headroom on the next restart — and a reboot
+    # is precisely when a low-memory instance is most likely to need it.
+    # ensure_block is idempotent, so the ordinary re-run is unaffected.
+    if [ "$want" -eq 0 ]; then
+      # Converge a block that is already there — an operator who deleted the
+      # swapfile by hand leaves the fstab line behind, and that line fails the
+      # next boot's mount. Do not *create* an empty managed block on a host that
+      # never had swap and is not asking for any.
+      if grep -qF '# BEGIN collavre:swap' "$fstab" 2>/dev/null; then
+        ensure_block "$fstab" swap ""
+      fi
+    else
+      ensure_block "$fstab" swap "$swap none swap sw 0 0"
+    fi
     return 0
   fi
 
@@ -915,6 +934,49 @@ revoke_prior_ssh_key() {
   printf '%s\n' "$SSH_PUBLIC_KEY" > "$state"
 }
 
+# dedupe_authorized_keys <authorized_keys> [key that must survive]
+#
+# `sort -u -o F F` rewrites F in place, and F is the only way into this host.
+#
+# A full filesystem is not the hazard, which is worth stating because it is the
+# obvious guess: GNU sort reads all of its input before it opens the output, and
+# opening it frees that file's own blocks, so the result — never larger than the
+# input — fits by construction. Measured on a 0 KiB filesystem, the file came
+# through intact. What is dangerous is anything that stops sort *after* it has
+# truncated the output: the write is not atomic, and the file is left holding a
+# prefix of itself. On a 512MB instance an OOM kill is the realistic one — the
+# same memory pressure SWAP_SIZE_MB exists for, and step 8 has not run yet:
+#
+#   sort -u -o F F, killed mid-write:  60001 lines -> 28659, current key gone
+#
+# Note which key goes missing. The file is being sorted, so the survivors are a
+# lexical prefix and the casualty is whatever sorts last — not necessarily the
+# key just installed, and not something the caller can predict.
+#
+# So sort into a sibling and rename. Same directory, so the swap is one
+# rename(2) and the live path only ever holds a complete file; a sort that dies
+# damages the staging file and nothing else. The successor is confirmed present
+# before the swap, the same rule as revoke_prior_ssh_key above.
+dedupe_authorized_keys() {
+  local auth_keys="$1" must_keep="${2:-}" tmp
+  tmp="$(mktemp "$auth_keys.sort.XXXXXX")"
+  if sort -u -o "$tmp" "$auth_keys" 2>/dev/null &&
+     { [ ! -s "$auth_keys" ] || [ -s "$tmp" ]; } &&
+     { [ -z "$must_keep" ] || grep -qxF "$must_keep" "$tmp"; }; then
+    cat "$tmp" > "$auth_keys"   # rewrite in place, keeping mode and owner
+    rm -f "$tmp"
+    return 0
+  fi
+  rm -f "$tmp"
+  # Not fatal, and deliberately so: duplicate lines in authorized_keys stop
+  # nobody logging in, so the file as it stands is correct if untidy. Failing
+  # the run here would abandon provisioning over cosmetics — but the operator
+  # should know the host could not complete a small write.
+  log "WARNING: could not rewrite $auth_keys to drop duplicate keys, so it is" \
+      "unchanged — logins are unaffected. Something stopped a small write on" \
+      "this host; check its memory and disk before relying on the instance."
+}
+
 # Adopt the single marker an earlier revision wrote, once, for the account this
 # run is about. On the hosts that revision could produce there was only ever one
 # deploy account, so the old value is that account's — and adopting it is what
@@ -929,7 +991,7 @@ fi
 
 install_authorized_keys "$AUTH_KEYS"
 revoke_prior_ssh_key "$AUTH_KEYS"
-sort -u -o "$AUTH_KEYS" "$AUTH_KEYS"
+dedupe_authorized_keys "$AUTH_KEYS" "$SSH_PUBLIC_KEY"
 chown "$APP_SSH_USER:$APP_SSH_GROUP" "$AUTH_KEYS"
 chmod 0600 "$AUTH_KEYS"
 [ -s "$AUTH_KEYS" ] || log "WARNING: $AUTH_KEYS is empty — kamal will not be able to connect"

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -1215,14 +1215,29 @@ ensure_block() {
 # group, which is root-equivalent — `docker run -v /:/host` is a root shell —
 # so an allowlist would withhold nothing it does not already have, while
 # breaking the next maintenance command someone documents.
+sudoers_file_name() {
+  local user="$1" safe digest
+  safe="${user//[^A-Za-z0-9_-]/_}"
+  digest="$(printf '%s' "$user" | sha256sum | awk '{print substr($1, 1, 16)}')"
+  [ "${#digest}" -eq 16 ] || return 1
+  printf '90-collavre-%s-%s\n' "$safe" "$digest"
+}
+
 ensure_sudoers() {
-  local user="$1" dir="${2:-/etc/sudoers.d}" tmp
+  local user="$1" dir="${2:-/etc/sudoers.d}" tmp legacy rule
   # sudo's includedir skips any filename that contains '.' or ends in '~', and
-  # a Linux username may legally contain a dot.
-  local name="90-collavre-${user//[^A-Za-z0-9_-]/_}"
+  # a Linux username may legally contain a dot. The digest is also required:
+  # two valid names such as release.bot and release_bot otherwise normalize to
+  # the same file, and staging the successor would overwrite the predecessor's
+  # proven sudo path before the authenticated cutover.
+  local name
+  name="$(sudoers_file_name "$user")" ||
+    die "could not derive a collision-free sudoers filename for '$user'"
+  legacy="$dir/90-collavre-${user//[^A-Za-z0-9_-]/_}"
+  rule="$user ALL=(ALL:ALL) NOPASSWD:ALL"
 
   tmp="$(mktemp)"
-  printf '%s ALL=(ALL:ALL) NOPASSWD:ALL\n' "$user" > "$tmp"
+  printf '%s\n' "$rule" > "$tmp"
   chmod 0440 "$tmp"
   # Validate before installing, never after. A syntax error anywhere under
   # sudoers.d makes sudo refuse to run for *every* user ("no valid sudoers
@@ -1235,6 +1250,14 @@ ensure_sudoers() {
   # Owned by root by construction: this script runs as root (checked above).
   install -m 0440 "$tmp" "$dir/$name"
   rm -f "$tmp"
+  # Migrate the pre-hash filename only when it is exactly this user's rule.
+  # When a colliding predecessor owns it, preserving that file is the two-phase
+  # guarantee; the authenticated finalizer removes it later.
+  if [ "$legacy" != "$dir/$name" ] &&
+     cmp -s <(printf '%s\n' "$rule") "$legacy"; then
+    rm -f "$legacy" ||
+      log "WARNING: could not remove the duplicate legacy sudoers file $legacy"
+  fi
 
   # Do not remove a predecessor here. A new account has not proved that it can
   # open an SSH session yet, and removing the old NOPASSWD grant before that
@@ -1245,10 +1268,10 @@ ensure_sudoers() {
 
 # Take the docker group back from the deploy user a FORCE=1 re-run replaced.
 #
-# ensure_sudoers above already drops the old NOPASSWD file, but on its own that
-# revokes the longer road to root and leaves the shorter one open: docker group
-# membership is root-equivalent, so an operator rotating APP_SSH_USER away from
-# a compromised account would still be handing it a root shell.
+# Removing the predecessor's NOPASSWD file alone would revoke the longer road to
+# root and leave the shorter one open: docker group membership is
+# root-equivalent, so an operator rotating APP_SSH_USER away from a compromised
+# account would still be handing it a root shell.
 #
 # The account itself and its authorized_keys are deliberately left alone. This
 # runs on a host whose only other way in is the user the same run just created,
@@ -1481,11 +1504,19 @@ revoke_deploy_user_access() {
     return 1
   fi
 
-  sudoers_name="90-collavre-${prior//[^A-Za-z0-9_-]/_}"
-  sudoers_path="$sudoers_dir/$sudoers_name"
   prior_sudoers="$prior ALL=(ALL:ALL) NOPASSWD:ALL"
   current_sudoers="$current ALL=(ALL:ALL) NOPASSWD:ALL"
-  if [ -e "$sudoers_path" ]; then
+  sudoers_name="$(sudoers_file_name "$prior")" || {
+    log "WARNING: could not derive the sudoers filename for '$prior'; the SSH" \
+	"cutover cleanup remains pending"
+    return 1
+  }
+  # The second path migrates revisions that used only the sanitized username.
+  # Exact-content checks prevent it from deleting a colliding successor rule.
+  for sudoers_path in \
+    "$sudoers_dir/$sudoers_name" \
+    "$sudoers_dir/90-collavre-${prior//[^A-Za-z0-9_-]/_}"; do
+    [ -e "$sudoers_path" ] || continue
     if cmp -s <(printf '%s\n' "$prior_sudoers") "$sudoers_path"; then
       if ! rm -f "$sudoers_path" || [ -e "$sudoers_path" ]; then
 	log "WARNING: could NOT remove $sudoers_path; '$prior' still has this" \
@@ -1504,7 +1535,7 @@ revoke_deploy_user_access() {
 	  "rule by hand, then retry the SSH cutover."
       return 1
     fi
-  fi
+  done
 
   log "WARNING: '$prior' is no longer in docker or sudo but can still log in;" \
       "remove it by hand once you can reach the host as '$current':" \
@@ -1514,6 +1545,7 @@ revoke_deploy_user_access() {
 revoke_prior_deploy_user() {
   local current="$1" prior_file="${2:-$STATE_DIR/deploy_user}"
   local set_file="${3:-${prior_file%/*}/deploy_users}" prior kept='' failed=0
+  local marker_committed="${4:-0}"
 
   # Not a no-op on the ordinary path: this is what seeds the set on a host the
   # earlier revision provisioned, and what puts $current in it on a first run,
@@ -1567,10 +1599,11 @@ revoke_prior_deploy_user() {
       failed=1
     }
   [ "$failed" -eq 0 ] || {
-    log "WARNING: the SSH cutover is still pending because at least one" \
-	"predecessor retains privileged access"
+    log "WARNING: predecessor cleanup is still pending because at least one" \
+	"account retains privileged access"
     return 1
   }
+  [ "$marker_committed" -eq 0 ] || return 0
   write_state_file "$prior_file" "$current"$'\n' ||
     {
       log "WARNING: could not record '$current' as the deploy user in '$prior_file';" \
@@ -1763,6 +1796,17 @@ finalize_ssh_cutover() {
     grep -qxF "$SSH_PUBLIC_KEY" "$AUTH_KEYS" ||
       die "the staged key is no longer in $AUTH_KEYS; predecessor access was" \
 	  "not changed"
+  fi
+
+  # This is the availability commit and the last state write allowed to fail
+  # while predecessor access is still the recovery path. Once the authenticated
+  # successor is durable, key/group/sudoers cleanup may be retried without
+  # risking lockout even if it is interrupted halfway through.
+  write_state_file "$STATE_DIR/deploy_user" "$user"$'\n' ||
+    die "could not commit '$user' as the proven deploy account; predecessor" \
+	"access was not changed and the cutover remains pending"
+
+  if [ -n "$SSH_PUBLIC_KEY" ]; then
     revoke_prior_ssh_key "$AUTH_KEYS"
     [ "$(cat "$STATE_DIR/ssh_public_key.$user" 2>/dev/null || true)" = \
       "$SSH_PUBLIC_KEY" ] ||
@@ -1778,9 +1822,11 @@ finalize_ssh_cutover() {
 	  "remains pending; repair $AUTH_KEYS or its filesystem and retry."
   fi
 
-  revoke_prior_deploy_user "$user" ||
+  revoke_prior_deploy_user "$user" "$STATE_DIR/deploy_user" \
+    "$STATE_DIR/deploy_users" 1 ||
     die "one or more predecessor accounts could not be disarmed. The cutover" \
-	"remains pending; repair the reported account and run this command again."
+	"cleanup remains pending, but the proven successor is committed. Repair" \
+	"the reported account and run this command again."
 
   rm -f "$pending"
   log "SSH cutover finalized from an authenticated session as '$user'." \

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -191,6 +191,9 @@ refuse_defaulted_config_change() {
     replay="$replay$(printf '%s=%q ' "$1" "$2")"
   }
 
+  # Which settings launch.env actually answered, so the fallback below can cover
+  # the ones it did not. Presence of the file is not the question — see there.
+  local answered=' '
   if [ -f "$env_file" ]; then
     record="The host's own record of what it was given is $env_file."
     # Driven by the current setting list rather than by the file's lines, so a
@@ -199,30 +202,48 @@ refuse_defaulted_config_change() {
     for name in $LAUNCH_SETTINGS; do
       case " $supplied " in *" $name "*) continue ;; esac
       grep -q "^$name=" "$env_file" || continue
+      answered="$answered$name "
       prior="$(sed -n "s/^$name=//p" "$env_file" | head -1)"
       now="${!name}"
       [ "$prior" = "$now" ] && continue
       note_drift "$name" "$prior" "$now"
     done
-  else
-    # Provisioned before launch.env existed. The two settings that rotate a
-    # live credential are still answerable from the state files that predate
-    # it, so the upgrade path is covered for the cases that can hurt rather
-    # than left open until the next re-run happens to record the defaults.
-    for pair in deploy_user:APP_SSH_USER db_user:DB_USER; do
-      file="${pair%%:*}"; name="${pair##*:}"
-      [ -f "$state_dir/$file" ] || continue
-      case " $supplied " in *" $name "*) continue ;; esac
-      prior="$(cat "$state_dir/$file")"
-      now="${!name}"
-      if [ -n "$prior" ] && [ "$prior" != "$now" ]; then
-        note_drift "$name" "$prior" "$now"
-        # Named as they answer, so the message sends the operator to the file
-        # that actually decided this refusal rather than to the whole directory.
-        record="$record${record:+, }$state_dir/$file"
-      fi
-    done
-    [ -z "$record" ] || record="This host predates $env_file, so what it was
+  fi
+
+  # Per setting rather than "launch.env is absent", because the file existing is
+  # not the same as the file answering, and the branch that conflated them was
+  # reachable without an editor or an upgrade. launch.env is written with one
+  # redirection at the very end of a run, so a full disk or an interruption
+  # between the truncate and the last line leaves it present and short — and
+  # every missing line is skipped in silence by the `grep -q ... || continue`
+  # above. Measured on the shipped function, with an empty launch.env beside a
+  # $STATE_DIR that names the provisioned accounts:
+  #
+  #   no launch.env      REFUSES   (answered from deploy_user / db_user)
+  #   launch.env empty   PROCEEDS  <- the guard checked nothing at all
+  #
+  # and what proceeds is the bare `FORCE=1` re-run this exists to refuse: it
+  # rotates the deploy account and the database role away from the ones the
+  # deployed .env.production and DATABASE_URL still name. The two settings that
+  # rotate a live credential have their own state files, which are written at
+  # the step that performs the rotation rather than at the end of the run, so
+  # they answer for a host whose launch.env is absent *or* short.
+  for pair in deploy_user:APP_SSH_USER db_user:DB_USER; do
+    file="${pair%%:*}"; name="${pair##*:}"
+    case "$answered" in *" $name "*) continue ;; esac
+    [ -f "$state_dir/$file" ] || continue
+    case " $supplied " in *" $name "*) continue ;; esac
+    prior="$(cat "$state_dir/$file")"
+    now="${!name}"
+    if [ -n "$prior" ] && [ "$prior" != "$now" ]; then
+      note_drift "$name" "$prior" "$now"
+      # Named as they answer, so the message sends the operator to the file
+      # that actually decided this refusal rather than to the whole directory.
+      record="$record${record:+, }$state_dir/$file"
+    fi
+  done
+  if [ ! -f "$env_file" ] && [ -n "$record" ]; then
+    record="This host predates $env_file, so what it was
 given is recorded only in $record.
 The settings not kept there could not be checked at all — repeating those is
 still on you."
@@ -542,14 +563,17 @@ in_group() {
 # within one filesystem, where it is atomic. Anywhere else `mv` degrades to a
 # copy-then-unlink and the window this exists to close is back.
 #
-# 0644 is not a widening: it is what a bare redirection already produced under
-# the default umask, and the chmod is here only because mktemp creates 0600.
-# db_password is the one marker that must not go through this — it is written
-# under `umask 077` precisely so it is never 0644, even briefly.
+# The default 0644 is not a widening: it is what a bare redirection already
+# produced under the default umask, and the chmod is here only because mktemp
+# creates 0600. db_password passes 0600 instead — it must never be 0644, even
+# for the instant between the staging write and the rename, and going through
+# mktemp is what guarantees that: the file is 0600 from the moment it exists,
+# which the `umask 077` subshell it replaces could only achieve by getting the
+# umask right.
 write_state_file() {
-  local target="$1" content="$2" tmp
+  local target="$1" content="$2" mode="${3:-0644}" tmp
   tmp="$(mktemp "$target.XXXXXX")" || return 1
-  if ! printf '%s' "$content" > "$tmp" || ! chmod 0644 "$tmp"; then
+  if ! chmod "$mode" "$tmp" || ! printf '%s' "$content" > "$tmp"; then
     rm -f "$tmp"
     return 1
   fi
@@ -929,12 +953,16 @@ JSON
 # Migrating between clusters is pg_upgradecluster's job and needs a human to
 # decide when the app stops, so this aborts and says so rather than guessing.
 ensure_cluster_on_default_port() {
-  local lsclusters="${1:-pg_lsclusters}" ver port owner_of_default=""
+  local lsclusters="${1:-pg_lsclusters}" ver cluster port owner_of_default=""
+  local name_of_default=""
   command -v "$lsclusters" >/dev/null 2>&1 || return 0
 
-  while read -r ver _cluster port _rest; do
+  while read -r ver cluster port _rest; do
     [ -n "$ver" ] || continue
-    [ "$port" = "$DB_PORT" ] && owner_of_default="$ver"
+    if [ "$port" = "$DB_PORT" ]; then
+      owner_of_default="$ver"
+      name_of_default="$cluster"
+    fi
     if [ "$ver" = "$PG_MAJOR" ] && [ "$port" != "$DB_PORT" ]; then
       die "PostgreSQL $PG_MAJOR is installed but its 'main' cluster listens on $port, not $DB_PORT." \
           "This script only supports a single cluster on $DB_PORT — DATABASE_URL, the ufw rule" \
@@ -952,6 +980,34 @@ EOF
         "the backups and DATABASE_URL kept using $DB_PORT — a version bump that silently does not" \
         "happen. Either set PG_MAJOR=$owner_of_default, or migrate deliberately with" \
         "'pg_upgradecluster $owner_of_default main' and drop the old cluster before re-running."
+  fi
+
+  # The version and the port agreeing is not enough: everything below names the
+  # cluster *directory*, and it names it 'main'. pg_createcluster's default name
+  # is 'main', so this is only reachable on a host where someone created the
+  # cluster by hand with --datadir or -o, but there it fails in silence rather
+  # than loudly. `/etc/postgresql/$PG_MAJOR/main` is absent, so the apt install
+  # at step 5 runs and reports the package already present without creating a
+  # second cluster; `install -d` then makes the missing directory, the tuning,
+  # listen_addresses and the pg_hba rule for the docker bridge are all written
+  # into a tree no postmaster reads, and `systemctl restart postgresql` restarts
+  # the real cluster — successfully, because the umbrella unit does not care
+  # which clusters exist. Nothing fails. The containers then cannot reach the
+  # database, because listen_addresses was never actually set on the cluster
+  # that is running.
+  #
+  # Naming the discovered path instead would mean threading it through the
+  # backup unit and the runbook's recovery blocks, which spell
+  # /etc/postgresql/<major>/main as literal text an operator pastes.
+  if [ -n "$name_of_default" ] && [ "$name_of_default" != main ]; then
+    die "The PostgreSQL $owner_of_default cluster serving $DB_PORT is named '$name_of_default', not 'main'." \
+        "This script writes listen_addresses, the tuning and the pg_hba rule for the docker bridge" \
+        "into /etc/postgresql/$PG_MAJOR/main, and the runbook's recovery steps name that path too —" \
+        "against a cluster called '$name_of_default' all of it would be written where no postmaster" \
+        "reads it, the run would report success, and the containers would still be unable to reach" \
+        "the database. Move the cluster to the standard name with" \
+        "'pg_renamecluster $owner_of_default $name_of_default main', or provision this app on a host" \
+        "whose $DB_PORT cluster is 'main'."
   fi
 }
 
@@ -1880,18 +1936,47 @@ if [ -z "$DB_PASSWORD" ]; then
   if [ -f "$STATE_DIR/db_password" ]; then
     # Re-run: keep the password already handed out in DATABASE_URL.
     DB_PASSWORD="$(cat "$STATE_DIR/db_password")"
+    # An empty marker is not "no password", it is a password this host can no
+    # longer name. Left to fall through, it reaches `ALTER ROLE ... PASSWORD ''`
+    # below unconditionally, which rotates the live role to an empty password
+    # while the deployed DATABASE_URL still carries the real one — the app meets
+    # `password authentication failed` at its next reconnect, several steps
+    # after the step that caused it, and the value it needs is gone from the
+    # host. Written atomically since this revision, so this answers for a host
+    # an earlier one truncated rather than for anything this script can still do.
+    if [ -z "$DB_PASSWORD" ]; then
+      die "$STATE_DIR/db_password exists but is empty, so this host cannot name" \
+          "the password its role is using. Applying it would set the role's" \
+          "password to '' and break the deployed DATABASE_URL." \
+          "Nothing has been changed. Take the password out of the DATABASE_URL" \
+          "the deployment is running with — it is percent-encoded there, so" \
+          "decode it — and re-run with DB_PASSWORD=<that value>. If it cannot be" \
+          "recovered, re-run with a new DB_PASSWORD= and redeploy with the" \
+          "DATABASE_URL this run prints."
+    fi
   else
     # URL-safe alphabet only: this password goes into DATABASE_URL verbatim.
     DB_PASSWORD="$(openssl rand -base64 48 | tr -dc 'A-Za-z0-9' | head -c 32)"
     log "generated a random database password"
   fi
 fi
-# The umask is what makes this 0600, not the chmod. A bare redirection creates
-# the file 0644 under the default umask and only narrows it a command later,
-# and $STATE_DIR is 0755 — so the production password would be world-readable
-# for that window, or permanently if the run were interrupted between the two.
-# The chmod stays to converge a file an earlier revision left 0644.
-( umask 077; printf '%s' "$DB_PASSWORD" > "$STATE_DIR/db_password" )
+# 0600 from the moment the file exists, and replaced in one step. The mode is
+# not the chmod's doing: mktemp creates 0600, and the chmod inside
+# write_state_file runs before the content is written — where a bare redirection
+# creates the file 0644 under the default umask and only narrows it a command
+# later, leaving the production password world-readable in a 0755 directory for
+# that window, or permanently if the run died in between.
+#
+# The rename is the other half. `> file` truncates when the redirection opens,
+# so a write that fails after that — a full disk, an interrupted run — leaves
+# this marker existing and empty, and the read above cannot tell that from a
+# host with no password recorded. It is the only durable record of the
+# credential the app is deployed with. The chmod stays a step below to converge
+# a file an earlier revision left 0644.
+write_state_file "$STATE_DIR/db_password" "$DB_PASSWORD" 0600 ||
+  die "could not record the database password in $STATE_DIR/db_password." \
+      "Nothing has been changed — the role still has the password the previous" \
+      "run gave it, and that file still holds it. Free some disk and re-run."
 chmod 0600 "$STATE_DIR/db_password"
 
 # Mirrors db/setup_postgres_databases.sql: create-if-missing, never drop.
@@ -2103,10 +2188,19 @@ TXT
 # No DB_PASSWORD — it has its own 0600 file, and this one is world-readable
 # because the answers in it ("which deploy user?", "which database?") are what
 # the runbook sends operators here to read.
-{ for _s in $LAUNCH_SETTINGS; do printf '%s=%s\n' "$_s" "${!_s}"; done; } \
-  > "$STATE_DIR/launch.env"
-chmod 0644 "$STATE_DIR/launch.env"
-unset _s
+#
+# Through write_state_file rather than a redirection, because the reader treats
+# a line that is not here as a setting it has nothing to say about: a run that
+# truncated this file and then died leaves refuse_defaulted_config_change with
+# nothing to compare, and the next bare FORCE=1 rotates the deploy account and
+# the database role unchallenged. Failing to record the settings must not be
+# the same event as recording that there were none.
+_launch_record="$(for _s in $LAUNCH_SETTINGS; do printf '%s=%s\n' "$_s" "${!_s}"; done)"
+write_state_file "$STATE_DIR/launch.env" "$_launch_record"$'\n' ||
+  log "WARNING: could not record this run's settings in $STATE_DIR/launch.env;" \
+      "the previous record is intact, so the next run still compares against it —" \
+      "repeat this run's overrides on that run too"
+unset _s _launch_record
 
 touch "$SUMMARY"
 chmod 0600 "$SUMMARY"

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -480,9 +480,25 @@ revoke_prior_ssh_key() {
       # the one recorded, so an operator key that merely shares a comment or a
       # prefix survives.
       grep -vxF "$prior" "$auth_keys" > "$tmp" || true
-      cat "$tmp" > "$auth_keys"   # rewrite in place, keeping mode and owner
-      rm -f "$tmp"
-      log "withdrew the SSH key this script installed on a previous run"
+      # An empty result cannot mean "every key was the retired one" — the
+      # successor was confirmed present above — so it means the filter itself
+      # failed, and the `|| true` that keeps `set -e` from firing on grep's
+      # "no lines selected" hides that. Writing it back would truncate
+      # authorized_keys and lock the deploy account out of the host. The
+      # realistic trigger is a full disk: grep writes nothing, exits 2, and
+      # `cat` then succeeds at emptying the file.
+      if [ -s "$tmp" ]; then
+        cat "$tmp" > "$auth_keys"   # rewrite in place, keeping mode and owner
+        rm -f "$tmp"
+        log "withdrew the SSH key this script installed on a previous run"
+      else
+        rm -f "$tmp"
+        log "WARNING: could not withdraw the previous SSH key — is the disk full?" \
+            "It is still authorized; remove it by hand once the host is healthy"
+        # Deliberately leave the marker pointing at the key still in the file,
+        # so the next run retries the withdrawal instead of forgetting it.
+        return 0
+      fi
     fi
   fi
   printf '%s\n' "$SSH_PUBLIC_KEY" > "$state"

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -1611,6 +1611,21 @@ ensure_ufw_rule() {
   local name="$1" rule="$2" state="${3:-$STATE_DIR/ufw_$1}" prior=""
   [ -f "$state" ] && prior="$(cat "$state")"
 
+  # An empty marker is not an absent one, and the difference is not recoverable
+  # here. write_state_file never produces one, so a marker that exists and holds
+  # nothing means a revision that wrote it by redirection was interrupted — and
+  # the rule that was in force at that moment is still in force, with nothing
+  # naming it. Unlike db_name there is no second record to fall back to: `ufw
+  # status` renders rules in a display form that `ufw delete` does not accept,
+  # which is why this marker exists at all. So it is said out loud rather than
+  # passed over, which is the whole of what this run can do about it.
+  if [ -f "$state" ] && [ -z "$prior" ]; then
+    log "WARNING: the $name rule marker '$state' exists but is empty, which an" \
+        "interrupted write by an earlier revision leaves behind. A rule this" \
+        "script added may still be in force with no record of it — check" \
+        "'ufw status numbered' for a $name rule you did not ask for on this run."
+  fi
+
   # The replacement goes in first, so an interrupted run never leaves the host
   # with neither rule. Same ordering as the deploy-user and SSH-key revocations.
   # Unquoted on purpose: a rule is a word list, not one argument.
@@ -1639,7 +1654,33 @@ ensure_ufw_rule() {
     log "withdrew the previous $name rule: $prior"
   fi
 
-  printf '%s\n' "$rule" > "$state"
+  # Through write_state_file, not a redirection. `>` truncates when it opens, so
+  # an interrupted write leaves the marker present and empty — and the read at
+  # the top of this function branches on `[ -n "$prior" ]`, so an empty marker
+  # is not a degraded record, it is *no* record: the withdrawal block is skipped
+  # entirely and the rule installed on that run stays in force with nothing on
+  # the host naming it. Measured on the extracted function, marker emptied after
+  # the first converge and the subnet then changed twice:
+  #
+  #   rule: allow from 172.17.0.0/16 to any port 5432 proto tcp   <- stranded
+  #   rule: allow from 10.0.9.0/24   to any port 5432 proto tcp
+  #   marker: allow from 10.0.9.0/24 to any port 5432 proto tcp
+  #
+  # Exactly one rule is stranded — the one in force when the write was cut — and
+  # it is permanent: every later run withdraws what the marker names, which has
+  # moved past it. For the postgres rule that is an obsolete Docker subnet still
+  # reaching 5432 for the life of the instance.
+  #
+  # A failed write is warned about rather than fatal, and names the rule: the
+  # grant has already happened, so dying here would leave the same untracked
+  # rule with less said about it. The previous marker survives, which strands
+  # this one at the *next* change rather than immediately — worth saying out
+  # loud, because it is the one case this function cannot make self-healing.
+  write_state_file "$state" "$rule"$'\n' ||
+    log "WARNING: the $name rule is in force but could NOT be recorded in" \
+        "'$state': $rule — a later run that changes it will withdraw the rule" \
+        "this file still names and leave this one authorized. Re-run to record" \
+        "it, or remove it by hand with: ufw delete $rule"
 }
 
 # True when some rule already authorizes SSH, however narrowly. `ufw allow
@@ -1947,15 +1988,75 @@ APP_SSH_GROUP="$(install_deploy_ssh_dir "$APP_SSH_USER" "$APP_HOME")"
 AUTH_KEYS="$APP_HOME/.ssh/authorized_keys"
 touch "$AUTH_KEYS"
 
+# stage_authorized_keys <authorized_keys> — echo the path of a staging file
+# holding the current contents of <authorized_keys>, newline-terminated.
+#
+# The counterpart of append_state_line for the one file that is not a queue but
+# the way into the host. `>> authorized_keys` leaves an unterminated fragment
+# when the write is cut short, and the *retry* is what does the damage: the
+# `grep -qxF` guarding the append does not match a fragment, so the whole key
+# lands on the end of it and authorized_keys holds one line that is neither key.
+#
+# That is worse here than in a queue, because revoke_prior_ssh_key opens with
+# `grep -qxF "$SSH_PUBLIC_KEY" "$auth_keys" || return 0` — never withdraw before
+# the successor is in place. With the successor glued to a fragment that check
+# fails, so the run withdraws nothing, reports a completed rotation, and leaves
+# the predecessor authorized on an account holding docker and passwordless sudo.
+# Measured on the extracted pair, the append torn on the rotation to B:
+#
+#   run 3 (retry)      line 2: <fragment of B><whole of B>
+#                      exact line for B: no    A still authorized: YES
+#   run 4 (converge)   exact line for B: YES   A still authorized: no
+#
+# So the exposure is bounded — the next convergence appends B cleanly and the
+# withdrawal catches up — but it is a full run long, and the run that opens it
+# is the one that prints the success summary. A rotation performed *because* the
+# predecessor is compromised is exactly the case where one more run matters.
+#
+# Terminating rather than dropping the fragment, for the same reason as
+# append_state_line: nothing distinguishes half a key from a different key, and
+# a key an operator added by hand must survive this untouched. A fragment
+# authorizes nobody, and dedupe_authorized_keys is what eventually clears it.
+stage_authorized_keys() {
+  local auth_keys="$1" tmp
+  tmp="$(mktemp "$auth_keys.stage.XXXXXX")" || return 1
+  if [ -s "$auth_keys" ]; then
+    cat "$auth_keys" > "$tmp" || { rm -f "$tmp"; return 1; }
+    # Command substitution strips trailing newlines, so this is empty exactly
+    # when the file already ends in one.
+    [ -z "$(tail -c 1 "$tmp")" ] || printf '\n' >> "$tmp"
+  fi
+  printf '%s\n' "$tmp"
+}
+
 # install_authorized_keys <authorized_keys> [home root]
 #
 # Give the deploy user a way in: the explicit SSH_PUBLIC_KEY when there is one,
 # otherwise whatever key Lightsail installed for the default cloud user.
+#
+# Non-zero when the key could not be installed, which aborts the run at the call
+# site: the steps after it put this account in docker and sudoers, and an
+# account granted root-equivalent access with no working key is a host nobody
+# can reach with a summary that says otherwise.
 install_authorized_keys() {
-  local auth_keys="$1" home_root="${2:-/home}" candidate src
+  local auth_keys="$1" home_root="${2:-/home}" candidate src tmp
   if [ -n "$SSH_PUBLIC_KEY" ]; then
-    grep -qxF "$SSH_PUBLIC_KEY" "$auth_keys" ||
-      printf '%s\n' "$SSH_PUBLIC_KEY" >> "$auth_keys"
+    grep -qxF "$SSH_PUBLIC_KEY" "$auth_keys" 2>/dev/null && return 0
+    tmp="$(stage_authorized_keys "$auth_keys")" || return 1
+    printf '%s\n' "$SSH_PUBLIC_KEY" >> "$tmp" || { rm -f "$tmp"; return 1; }
+    # Never install a file that does not contain the key it was staged to add,
+    # and never one shorter than what it replaces. The staging write can fail
+    # for space just as the live one could; the difference is that here the
+    # failure is discardable.
+    local was=0
+    [ -f "$auth_keys" ] && was="$(wc -l < "$auth_keys")"
+    if ! grep -qxF "$SSH_PUBLIC_KEY" "$tmp" || [ "$(wc -l < "$tmp")" -le "$was" ]; then
+      rm -f "$tmp"
+      log "WARNING: a staged $auth_keys did not come out whole, so it was NOT" \
+          "installed and the live file is untouched"
+      return 1
+    fi
+    install_staged_authorized_keys "$tmp" "$auth_keys" || return 1
     return 0
   fi
   for candidate in ubuntu admin ec2-user; do
@@ -1971,7 +2072,12 @@ install_authorized_keys() {
       log "APP_SSH_USER is the cloud user '$candidate' — its keys are already in place"
     else
       log "no SSH_PUBLIC_KEY given — copying keys from $candidate"
-      cat "$src" >> "$auth_keys"
+      # Same staging as the explicit-key path. This copy is larger — a cloud
+      # user's authorized_keys, not one line — so it is the one more likely to
+      # be cut short, and it lands on the file the operator is logged in with.
+      tmp="$(stage_authorized_keys "$auth_keys")" || return 1
+      cat "$src" >> "$tmp" || { rm -f "$tmp"; return 1; }
+      install_staged_authorized_keys "$tmp" "$auth_keys" || return 1
     fi
     return 0
   done

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -250,6 +250,66 @@ revoke_prior_deploy_user() {
       "deluser --remove-home $prior"
 }
 
+# ensure_ufw_rule <name> <rule> [state file]
+#
+# Converge one ufw rule the way ensure_block converges one config stanza:
+# withdraw what a previous run authorized, then authorize the current value.
+# ufw already skips re-adding an identical rule, so this exists for the rule
+# whose *value* moves between runs — change DOCKER_SUBNETS or DB_BIND_ADDRESS
+# and without it the host would simply accumulate both, leaving the old subnet
+# reaching 5432 forever. Recorded rather than parsed back out of `ufw status`,
+# whose display form ("172.17.0.1 5432/tcp ALLOW IN 172.17.0.0/16") is not the
+# syntax `ufw delete` takes.
+ensure_ufw_rule() {
+  local name="$1" rule="$2" state="${3:-$STATE_DIR/ufw_$1}" prior
+  if [ -f "$state" ]; then
+    prior="$(cat "$state")"
+    if [ -n "$prior" ] && [ "$prior" != "$rule" ]; then
+      # Unquoted on purpose: a rule is a word list, not one argument.
+      # shellcheck disable=SC2086
+      ufw delete $prior >/dev/null 2>&1 &&
+        log "withdrew the previous $name rule: $prior"
+    fi
+  fi
+  # shellcheck disable=SC2086
+  ufw $rule >/dev/null
+  printf '%s\n' "$rule" > "$state"
+}
+
+# True when some rule already authorizes SSH, however narrowly. `ufw allow
+# OpenSSH` renders as either "22/tcp" or "OpenSSH" depending on whether the app
+# profile is installed, and IPv6 duplicates append " (v6)".
+#
+# Deliberately positive: it answers "is 22 open?", never "is 22 closed?". An
+# empty or unparseable `ufw status` therefore means we add the rule, because
+# guessing wrong in that direction only re-opens SSH, while guessing wrong in
+# the other enables a deny-by-default firewall on a host with no way in.
+ssh_already_allowed() {
+  ufw status 2>/dev/null | grep -qE '^(22|OpenSSH)([/[:space:]]).*ALLOW'
+}
+
+# Authorize SSH, but only if nothing else already does. An operator who
+# narrowed 22 to one source address is exactly who this protects: re-adding the
+# blanket rule on a re-run would quietly undo that and look like a no-op.
+ensure_ssh_rule() {
+  if ssh_already_allowed; then
+    log "port 22 is already allowed; leaving the existing SSH rule alone"
+    return 0
+  fi
+  # The named form needs the app profile openssh-server installs. Lightsail's
+  # Ubuntu images have it, but a minimal one does not, and there `ufw allow
+  # OpenSSH` exits 1 — leaving the `ufw --force enable` that follows to close 22
+  # on a host whose only way in is 22. The port form needs nothing installed.
+  #
+  # ufw's own "Could not find a profile" goes to /dev/null and is replaced by
+  # the line below: it is a handled condition, and a provisioning log operators
+  # scan for real errors should not carry one that was recovered from.
+  ufw allow OpenSSH 2>/dev/null || {
+    log "no OpenSSH ufw profile on this host; allowing 22/tcp directly"
+    ufw allow 22/tcp
+  }
+}
+
 # --------------------------------------------------------------------------
 log "1/9 base packages"
 # --------------------------------------------------------------------------
@@ -476,15 +536,19 @@ trap - EXIT
 # --------------------------------------------------------------------------
 log "7/9 firewall"
 # --------------------------------------------------------------------------
-ufw --force reset >/dev/null
+# No `ufw reset`: this script is re-runnable, and a reset months later would
+# take a VPN, monitoring or IP-allowlist rule with it. Only the rules below are
+# ours to converge.
 ufw default deny incoming
 ufw default allow outgoing
-ufw allow OpenSSH
+
+ensure_ssh_rule
 ufw allow 80/tcp
 ufw allow 443/tcp
 # PostgreSQL is only listening on localhost and the docker bridge, so this rule
 # is defence in depth rather than the only thing keeping it private.
-ufw allow from "$DOCKER_SUBNETS" to "$DB_BIND_ADDRESS" port 5432 proto tcp
+ensure_ufw_rule postgres \
+  "allow from $DOCKER_SUBNETS to $DB_BIND_ADDRESS port 5432 proto tcp"
 ufw --force enable
 ufw status verbose
 

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -886,6 +886,47 @@ install_authorized_keys() {
 # never in this file, so key-A survives — on an account the same re-run has just
 # put back in `docker` and sudoers. A key retired two rotations ago is root
 # again, and nothing says so.
+
+# install_staged_authorized_keys <staged file> <authorized_keys>
+#
+# Put a fully-written staging file at the live path, atomically. Both callers
+# below stage first and then have to install what they staged, and both got
+# this wrong in the same way, so it lives in one place.
+#
+# `cat "$tmp" > "$auth_keys"` is not the same thing, which is the part that
+# looks like a detail and is not. The shell performs the `>` redirect — an
+# O_TRUNC — in the forked child, and only then execs the writer, so the live
+# file is empty across an entire process spawn rather than across a single
+# write(2). Killing that child at a uniformly random point, on a realistic
+# four-key file:
+#
+#   cat "$tmp" > "$auth_keys"   damaged 7/400, all of them 0 bytes
+#   mv "$tmp" "$auth_keys"      damaged 0/400
+#
+# Every damaged run had lost the successor key, which is the whole file. An OOM
+# kill during provisioning is the realistic way to land in that window on a
+# 512MB instance — the same memory pressure SWAP_SIZE_MB exists for, and step 2
+# has not necessarily helped yet.
+#
+# The ownership is set on the staging file rather than after the rename,
+# because the obvious form of this fix has a lockout of its own: mktemp creates
+# 0600 root-owned, and sshd refuses an authorized_keys it cannot read as the
+# user. Measured against a real sshd with StrictModes on:
+#
+#   owner=collavre mode=600 -> OK       owner=root mode=600 -> Authentication
+#   owner=root     mode=644 -> OK       refused: bad ownership or modes
+#
+# So a crash between a bare `mv` and the caller's `chown` would leave the host
+# refusing the very key the run just installed. Setting both first means the
+# file is correct at every instant, and the caller's chown/chmod becomes a
+# no-op rather than a load-bearing step.
+install_staged_authorized_keys() {
+  local tmp="$1" auth_keys="$2"
+  [ -z "${APP_SSH_USER:-}" ] || chown "$APP_SSH_USER:${APP_SSH_GROUP:-$APP_SSH_USER}" "$tmp" 2>/dev/null || true
+  chmod 0600 "$tmp"
+  mv -f "$tmp" "$auth_keys"
+}
+
 revoke_prior_ssh_key() {
   local auth_keys="$1" state="${2:-$STATE_DIR/ssh_public_key.$APP_SSH_USER}" prior tmp
   # An empty SSH_PUBLIC_KEY means "keep using the cloud user's keys", not
@@ -918,8 +959,7 @@ revoke_prior_ssh_key() {
       # `set -e` does not fire on grep's "no lines selected" — is what hides
       # the error, so the successor's presence has to be re-established here.
       if grep -qxF "$SSH_PUBLIC_KEY" "$tmp"; then
-        cat "$tmp" > "$auth_keys"   # rewrite in place, keeping mode and owner
-        rm -f "$tmp"
+        install_staged_authorized_keys "$tmp" "$auth_keys"
         log "withdrew the SSH key this script installed on a previous run"
       else
         rm -f "$tmp"
@@ -963,8 +1003,7 @@ dedupe_authorized_keys() {
   if sort -u -o "$tmp" "$auth_keys" 2>/dev/null &&
      { [ ! -s "$auth_keys" ] || [ -s "$tmp" ]; } &&
      { [ -z "$must_keep" ] || grep -qxF "$must_keep" "$tmp"; }; then
-    cat "$tmp" > "$auth_keys"   # rewrite in place, keeping mode and owner
-    rm -f "$tmp"
+    install_staged_authorized_keys "$tmp" "$auth_keys"
     return 0
   fi
   rm -f "$tmp"

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -594,7 +594,7 @@ refuse_unparsable_ssh_key() {
 # command can be run through it. There is no client here to prove that with, so
 # the only place the question can be answered is before anything is appended.
 refuse_forced_command_ssh_key() {
-  local options
+  local has_forced_command
   [ -n "$SSH_PUBLIC_KEY" ] || return 0
   # Folded, because sshd matches the option *name* without regard to case and a
   # case-sensitive test here is a bypass rather than a narrower guard. Measured
@@ -613,11 +613,11 @@ refuse_forced_command_ssh_key() {
   # its own a reason to refuse a key sshd is happy to run the client's command
   # through.
   #
-  # `tr` rather than `${options,,}`: this suite runs under bash 3.2 on macOS as
-  # well as 5.2 on the host, and the parameter expansion is a 4.0 syntax error
-  # there — the same platform split that made a `head -c 0` fixture pass here
-  # and fail in CI.
-  options="$(
+  # Parse the comma-separated option names rather than searching the whole
+  # field: `environment="NOTE=command=value"` carries those bytes as data and
+  # does not replace the client command. awk's tolower() keeps this compatible
+  # with bash 3.2 on macOS while matching sshd's case-insensitive option names.
+  has_forced_command="$(
     printf '%s\n' "$SSH_PUBLIC_KEY" |
       awk '
 	{
@@ -628,6 +628,8 @@ refuse_forced_command_ssh_key() {
 	  }
 	  quoted = 0
 	  escaped = 0
+	  option_start = start
+	  seen_equals = 0
 	  for (i = start; i <= length($0); i++) {
 	    char = substr($0, i, 1)
 	    if (escaped) {
@@ -637,18 +639,22 @@ refuse_forced_command_ssh_key() {
 	    } else if (char == "\"") {
 	      quoted = !quoted
 	    } else if (!quoted && char ~ /[[:space:]]/) {
-	      print substr($0, start, i - start)
 	      exit
+	    } else if (!quoted && char == ",") {
+	      option_start = i + 1
+	      seen_equals = 0
+	    } else if (!quoted && char == "=" && !seen_equals) {
+	      if (tolower(substr($0, option_start, i - option_start)) == "command") {
+		print "yes"
+		exit
+	      }
+	      seen_equals = 1
 	    }
 	  }
 	}
-      ' |
-      tr '[:upper:]' '[:lower:]'
+      '
   )"
-  case "$options" in
-    *command=*) ;;
-    *) return 0 ;;
-  esac
+  [ "$has_forced_command" = yes ] || return 0
   die "REFUSING: SSH_PUBLIC_KEY carries a forced command. sshd reads the key" \
       "fine, and then runs that command in place of whatever the client asks" \
       "for — so 'kamal deploy' would connect, run the forced command, and" \

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -402,6 +402,14 @@ refuse_unusable_bind_address() {
   local setting="$1" value="$2"
   if ipv4_dotted_quad "$value"; then
     case "$value" in
+      0.0.0.0)
+	die "REFUSING: $setting='$value' is the unspecified address. PostgreSQL" \
+	    "may listen successfully on the host, but DATABASE_URL is used" \
+	    "inside the application container, where 0.0.0.0 names the" \
+	    "container rather than the host database. Nothing has been changed." \
+	    "Set $setting to the gateway address of the bridge your containers" \
+	    "are on — 'ip -4 addr show docker0'."
+	;;
       127.*)
 	die "REFUSING: $setting='$value' is a loopback address. PostgreSQL would" \
 	    "listen successfully on the host, but DATABASE_URL is used inside" \

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -11,7 +11,8 @@
 # What it does (host preparation only — it never builds or runs the app):
 #
 #   1. base packages, timezone, swap, SSH hardening
-#   2. a deploy user (default: collavre) in the docker group, for `kamal`
+#   2. a deploy user (default: collavre) in the docker group for `kamal`, with
+#      passwordless sudo for the maintenance commands in the runbook
 #   3. Docker CE + buildx + compose plugins, with log rotation
 #   4. PostgreSQL, reachable ONLY from containers on this host
 #   5. the collavre_production database + application role (idempotent)
@@ -178,6 +179,45 @@ ensure_block() {
   rm -f "$tmp"
 }
 
+# Give $1 passwordless sudo, and make sure it is the only deploy user holding
+# a grant this script wrote. `usermod -aG sudo` on its own does not work here:
+# `adduser --disabled-password` leaves `!` in /etc/shadow and Ubuntu's %sudo
+# rule is password-authenticated, so every sudo the runbook sends over ssh
+# fails with "a password is required".
+#
+# NOPASSWD:ALL rather than a command list. This user is already in the docker
+# group, which is root-equivalent — `docker run -v /:/host` is a root shell —
+# so an allowlist would withhold nothing it does not already have, while
+# breaking the next maintenance command someone documents.
+ensure_sudoers() {
+  local user="$1" dir="${2:-/etc/sudoers.d}" tmp existing
+  # sudo's includedir skips any filename that contains '.' or ends in '~', and
+  # a Linux username may legally contain a dot.
+  local name="90-collavre-${user//[^A-Za-z0-9_-]/_}"
+
+  tmp="$(mktemp)"
+  printf '%s ALL=(ALL:ALL) NOPASSWD:ALL\n' "$user" > "$tmp"
+  chmod 0440 "$tmp"
+  # Validate before installing, never after. A syntax error anywhere under
+  # sudoers.d makes sudo refuse to run for *every* user ("no valid sudoers
+  # sources found"), and step 3 has just set PermitRootLogin no — there would
+  # be no way back into the host.
+  if ! visudo -cf "$tmp" >/dev/null 2>&1; then
+    rm -f "$tmp"
+    die "refusing to install an unparseable sudoers file for '$user'"
+  fi
+  # Owned by root by construction: this script runs as root (checked above).
+  install -m 0440 "$tmp" "$dir/$name"
+  rm -f "$tmp"
+
+  # Converge rather than accumulate: a FORCE=1 re-run with a changed
+  # APP_SSH_USER must not leave the previous user's grant in force.
+  for existing in "$dir"/90-collavre-*; do
+    [ -e "$existing" ] || continue
+    [ "$existing" = "$dir/$name" ] || rm -f "$existing"
+  done
+}
+
 # --------------------------------------------------------------------------
 log "1/9 base packages"
 # --------------------------------------------------------------------------
@@ -233,6 +273,8 @@ if ! id -u "$APP_SSH_USER" >/dev/null 2>&1; then
   adduser --disabled-password --gecos "Collavre deploy" "$APP_SSH_USER"
 fi
 usermod -aG sudo "$APP_SSH_USER"
+install -d -m 0755 /etc/sudoers.d
+ensure_sudoers "$APP_SSH_USER"
 
 APP_HOME="$(getent passwd "$APP_SSH_USER" | cut -d: -f6)"
 install -d -m 0700 -o "$APP_SSH_USER" -g "$APP_SSH_USER" "$APP_HOME/.ssh"
@@ -536,7 +578,7 @@ Collavre Lightsail host — provisioned $(date -Is)
 
   public IP        $PUBLIC_IP
   private IP       $PRIVATE_IP
-  deploy user      $APP_SSH_USER (docker, sudo)
+  deploy user      $APP_SSH_USER (docker, passwordless sudo)
   PostgreSQL       $PG_MAJOR, listening on localhost + $DB_BIND_ADDRESS only
   database         $DB_NAME owned by $DB_USER
   db password      $STATE_DIR/db_password (root only)$PASSWORD_NOTE

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -4037,6 +4037,42 @@ Never open 5432 there.
 TXT
 }
 
+# Render the credential-bearing summary into a root-only sibling and install it
+# only after the complete output can be read back. A FORCE re-run may already
+# have rotated the database credential, so truncating the live summary would
+# destroy the only ready-to-copy, percent-encoded DATABASE_URL for that state.
+install_credential_summary() { # $1 = DATABASE_URL to display
+  local database_url="$1" target_real tmp rc=0
+  target_real="$(resolve_symlink_chain "$SUMMARY")" || exit 1
+  tmp="$(stage_beside "$target_real" 0600)" || rc=$?
+  [ "$rc" -eq 0 ] || {
+    die "could not stage the credential summary at $target_real" \
+	"(stage_beside exited $rc). The live summary is left exactly as it was."
+  }
+  if ! chmod 0600 "$tmp"; then
+    rm -f "$tmp"
+    die "could not make the staged credential summary root-only." \
+	"$target_real is left exactly as it was."
+  fi
+  if ! render_summary "$database_url" > "$tmp"; then
+    rm -f "$tmp"
+    die "could not render the staged credential summary — is the instance out" \
+	"of disk? $target_real is left exactly as it was."
+  fi
+  if ! grep -qxF "  KAMAL_SSH_USER=$APP_SSH_USER" "$tmp" ||
+     ! grep -qxF "  DATABASE_URL=$database_url" "$tmp" ||
+     ! grep -qxF 'Never open 5432 there.' "$tmp"; then
+    rm -f "$tmp"
+    die "the staged credential summary is incomplete. Refusing to install it" \
+	"over $target_real, which is left exactly as it was."
+  fi
+  mv -f "$tmp" "$target_real" || {
+    rm -f "$tmp"
+    die "could not install the staged credential summary over $target_real," \
+	"which is left exactly as it was."
+  }
+}
+
 # What this run was configured with, so the next one can tell an omitted
 # override from a deliberate default (refuse_defaulted_config_change). Written
 # only here, after every step has succeeded: a run that died halfway must not
@@ -4051,9 +4087,7 @@ TXT
 # this run still created the success marker.
 record_launch_settings
 
-touch "$SUMMARY"
-chmod 0600 "$SUMMARY"
-render_summary "$DATABASE_URL" > "$SUMMARY"
+install_credential_summary "$DATABASE_URL"
 
 touch "$MARKER"
 render_summary "$REDACTED_URL"

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -2832,15 +2832,27 @@ BACKUP_TMP="$(mktemp /usr/local/bin/collavre-pg-backup.XXXXXX)"
 # on a setting 2500 lines away that a future `|| something` would suppress. The
 # staging file is removed on the way out, so a retry starts from the same state
 # a kill would leave: the live path untouched.
-if ! cat > "$BACKUP_TMP" <<BACKUP
-#!/usr/bin/env bash
-# Managed by script/lightsail_launch.sh
-set -euo pipefail
-DEST=/var/backups/collavre
-DB_NAME="$DB_NAME"
-RETENTION_DAYS=$BACKUP_RETENTION_DAYS
-S3_URI="$BACKUP_S3_URI"
-
+# The three configured values are serialized as shell *data* rather than spliced
+# in as source. Interpolated into the heredoc, a value is written into the
+# generated file verbatim and inside double quotes, so anything shell-significant
+# in it is expanded later — by the nightly unit, running as root:
+#
+#   BACKUP_S3_URI='s3://b/$(...)/db'   the substitution runs at 03:00, as root
+#   BACKUP_S3_URI='s3://b/$archive/db' `unbound variable` under the generated
+#                                      script's own `set -u` — the backup dies
+#
+# A legitimate S3 key prefix may contain either. `bash -n` catches neither: both
+# forms are perfectly good shell, which is the problem — the validation below
+# asks whether the file is a program, not whether it is the intended one.
+# %q is the answer to the question the heredoc was answering wrongly.
+if ! { printf '%s\n' \
+         '#!/usr/bin/env bash' \
+         '# Managed by script/lightsail_launch.sh' \
+         'set -euo pipefail' \
+         'DEST=/var/backups/collavre' &&
+       printf 'DB_NAME=%q\nRETENTION_DAYS=%q\nS3_URI=%q\n' \
+         "$DB_NAME" "$BACKUP_RETENTION_DAYS" "$BACKUP_S3_URI" &&
+       cat <<BACKUP
 install -d -m 0700 -o postgres -g postgres "\$DEST"
 STAMP="\$(date +%Y%m%d-%H%M%S)"
 FILE="\$DEST/\${DB_NAME}-\${STAMP}.dump"
@@ -2871,6 +2883,7 @@ find "\$DEST" -maxdepth 1 -name '*.dump' -mtime "+\$RETENTION_DAYS" -delete
 echo "backup complete: \$FILE (\$(du -h "\$FILE" | cut -f1))"
 exit "\$S3_STATUS"
 BACKUP
+     } > "$BACKUP_TMP"
 then
   rm -f "$BACKUP_TMP"
   die "could not write the staged backup script — is /usr/local/bin full?" \

--- a/script/lightsail_launch.sh
+++ b/script/lightsail_launch.sh
@@ -858,8 +858,17 @@ install_authorized_keys() {
 # Only the key *this script* installed is withdrawn, recorded in a state file
 # rather than guessed at, so keys an operator added by hand and the cloud
 # user's original key are never touched.
+#
+# The record is per account, because authorized_keys is. A single global marker
+# loses track as soon as APP_SSH_USER moves and comes back: rotate
+# collavre/key-A to deploybot/key-B, and collavre keeps key-A (correctly — its
+# file is not the one being rewritten) while the marker advances to key-B. Come
+# back to collavre with key-C and the withdrawal hunts for key-B, which was
+# never in this file, so key-A survives — on an account the same re-run has just
+# put back in `docker` and sudoers. A key retired two rotations ago is root
+# again, and nothing says so.
 revoke_prior_ssh_key() {
-  local auth_keys="$1" state="${2:-$STATE_DIR/ssh_public_key}" prior tmp
+  local auth_keys="$1" state="${2:-$STATE_DIR/ssh_public_key.$APP_SSH_USER}" prior tmp
   # An empty SSH_PUBLIC_KEY means "keep using the cloud user's keys", not
   # "retire the managed one" — withdrawing here would strand an operator who
   # simply dropped the variable from a re-run.
@@ -905,6 +914,18 @@ revoke_prior_ssh_key() {
   fi
   printf '%s\n' "$SSH_PUBLIC_KEY" > "$state"
 }
+
+# Adopt the single marker an earlier revision wrote, once, for the account this
+# run is about. On the hosts that revision could produce there was only ever one
+# deploy account, so the old value is that account's — and adopting it is what
+# keeps the first run after this change able to withdraw, instead of starting
+# from no record and leaving the current key authorized forever. If APP_SSH_USER
+# has since moved, the file is claimed by whichever account is named first; that
+# is the same key the old code would have hunted for, so nothing gets worse.
+if [ -f "$STATE_DIR/ssh_public_key" ] &&
+   [ ! -f "$STATE_DIR/ssh_public_key.$APP_SSH_USER" ]; then
+  mv "$STATE_DIR/ssh_public_key" "$STATE_DIR/ssh_public_key.$APP_SSH_USER"
+fi
 
 install_authorized_keys "$AUTH_KEYS"
 revoke_prior_ssh_key "$AUTH_KEYS"

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -530,7 +530,12 @@ esac
 # FAIL_REVOKE choose which step reports failure.
 run_cutover() {
   local work; work="$(mktemp -d)"
-  printf '%s' "$recipe" | sed 's/<instance-ip>/203.0.113.10/g' > "$work/recipe.sh"
+  # Both placeholders have to go: `<` is a shell metacharacter even mid-word, so
+  # a recipe still carrying `<deploy-user>@<instance-ip>` is a redirection, not a
+  # destination, and bash would create files named after the placeholders.
+  printf '%s' "$recipe" |
+    sed -e 's/<instance-ip>/203.0.113.10/g' -e 's/<deploy-user>/collavre/g' \
+    > "$work/recipe.sh"
   mkdir -p "$work/bin"
   cat > "$work/bin/ssh" <<'STUB'
 #!/usr/bin/env bash
@@ -1600,7 +1605,9 @@ run_move() {
   # be able to restore it.
   export REMOTE="${REUSE_REMOTE:-$work/remote}"
   mkdir -p "$REMOTE" "$work/bin" "$work/rbin"
-  printf '%s' "$move" | sed 's/<instance-ip>/203.0.113.10/g' > "$work/recipe.sh"
+  printf '%s' "$move" |
+    sed -e 's/<instance-ip>/203.0.113.10/g' -e 's/<deploy-user>/collavre/g' \
+    > "$work/recipe.sh"
 
   cat > "$work/bin/psql" <<'STUB'
 #!/usr/bin/env bash
@@ -1750,7 +1757,10 @@ case "$sql" in
   *"CONNECTION LIMIT 0"*)      echo "limit:0"        >>"$TRACE"
                                [ -n "$FAIL_SHUT" ] || echo 0 > "$CONNLIMIT"
                                [ -z "$FAIL_SHUT" ] || { echo 'ERROR:  database "x" does not exist' >&2; exit 1; } ;;
-  *"CONNECTION LIMIT -1"*)     echo "limit:reopened" >>"$TRACE"; echo -1 > "$CONNLIMIT" ;;
+  *"CONNECTION LIMIT -1"*)     echo "limit:reopened" >>"$TRACE"
+                               [ -z "$FAIL_REOPEN" ] ||
+                                 { echo 'ERROR:  could not connect' >&2; exit 1; }
+                               echo -1 > "$CONNLIMIT" ;;
   *rolsuper*)                  echo "rolsuper"       >>"$TRACE"; printf '%s' "$APP_SUPER" ;;
   *datconnlimit*)              echo "readback"       >>"$TRACE"; cat "$CONNLIMIT" ;;
   *pg_terminate_backend*)      echo "terminate"      >>"$TRACE"; echo "${KILLED:-0}" ;;
@@ -1773,7 +1783,8 @@ STUB
   # role that does not exist, or a cluster that cannot be reached, comes back
   # as, and it must not be rewritten into the one value that lets the gate open.
   export TRACE LIVE="${LIVE-0}" KILLED="${KILLED:-0}" FAIL_RESTORE="${FAIL_RESTORE:-}" \
-         FAIL_SHUT="${FAIL_SHUT:-}" CONNLIMIT="$work/connlimit" \
+         FAIL_SHUT="${FAIL_SHUT:-}" FAIL_REOPEN="${FAIL_REOPEN:-}" \
+         CONNLIMIT="$work/connlimit" \
          APP_ROLE="${APP_ROLE-collavre_user}" APP_SUPER="${APP_SUPER-f}"
   R_OUT="$(cd "$work" && PATH="$work/bin:$PATH" bash ./recipe.sh 2>&1)"
   R_TRACE="$(paste -sd'|' "$TRACE")"
@@ -1878,7 +1889,46 @@ for shape in "no state file:::" "no such role:ghost::" "cluster unreachable:coll
   chk "refused: $what" 1 "$(grep -c 'cannot shut this database to the app' <<<"$R_OUT")"
   chk "  nothing dropped: $what" 0 "$(grep -c '^PG_RESTORE_RAN$' <<<"${R_TRACE//|/$'\n'}")"
 done
-unset APP_ROLE
+# APP_SUPER as well as APP_ROLE: an assignment placed before a *function* call
+# persists in the calling shell in bash, so `APP_SUPER=''` above outlives the
+# loop. run_restore reads it with ${APP_SUPER-f}, which cannot restore a default
+# for a variable that is set-but-empty — so every later run_restore would refuse
+# at the role check and each case after this one would pass for the wrong reason.
+unset APP_ROLE APP_SUPER
+
+echo "86d. a re-open that failed is not reported as 'restored, boot the app'"
+# The restore worked and the door did not come back up. Nothing in
+# $restore_status can see that: the re-open is a separate connection to the
+# cluster and fails on its own terms. Unchecked, the block prints the boot
+# instruction over a database still at CONNECTION LIMIT 0, and the operator
+# meets it as "too many connections" at boot — the misdirected error the whole
+# block is built to avoid, produced by the step meant to undo it.
+LIVE=0 KILLED=0 FAIL_RESTORE='' FAIL_REOPEN=1 run_restore
+chk "the restore did run"        1 "$(grep -c '^PG_RESTORE_RAN$' <<<"${R_TRACE//|/$'\n'}")"
+chk "the re-open was attempted"  1 "$(grep -c '^limit:reopened$' <<<"${R_TRACE//|/$'\n'}")"
+chk "NOT told to boot"           0 "$(grep -c 'app boot' <<<"$R_OUT")"
+chk "told the door is still shut" 1 "$(grep -c 'RE-OPEN FAILED' <<<"$R_OUT")"
+# And told which half is intact, because the two failures want opposite
+# responses: a half-loaded database wants the restore re-run, a shut one does
+# not — re-running --clean would drop a good restore to fix a connection limit.
+chk "and that the data is not the problem" 1 \
+  "$(grep -c 'not what failed' <<<"$R_OUT")"
+chk "prints the command that lifts it"     1 \
+  "$(grep -c 'CONNECTION LIMIT -1' <<<"$R_OUT")"
+# The half-replaced-database message must NOT appear: it tells the operator to
+# re-run the restore, which is the one thing that would turn this into data loss.
+chk "does not send them back through pg_restore" 0 \
+  "$(grep -c 'RESTORE FAILED' <<<"$R_OUT")"
+unset FAIL_REOPEN
+
+echo "86e. a failing re-open on the refusal path is reported too"
+# restore_status=2 shut the door and dropped nothing. The door still has to come
+# back up, and a re-open that failed there leaves a database the app cannot
+# reach with no restore in the story at all to explain it.
+LIVE=1 KILLED=0 FAIL_RESTORE='' FAIL_REOPEN=1 run_restore
+chk "nothing dropped"             0 "$(grep -c '^PG_RESTORE_RAN$' <<<"${R_TRACE//|/$'\n'}")"
+chk "told the door is still shut" 1 "$(grep -c 'RE-OPEN FAILED' <<<"$R_OUT")"
+unset FAIL_REOPEN
 
 # --- dedupe_authorized_keys -------------------------------------------------
 #
@@ -2361,6 +2411,102 @@ chk "not an ownership transfer that cannot be done" 0 "$(grep -c 'Move the objec
 chk "nor an object count it could not obtain"       0 "$(grep -c 'An unknown number of' <<<"$OUT")"
 chk "and nothing was written"       OLD-PASSWORD "$(cat "$s6b/db_password")"
 rm -rf "$s6b"
+
+# --- docs/deploy_to_lightsail.md, the DB_NAME rename -------------------------
+#
+# /var/lib/collavre/db_name is what a later launch-script run trusts to tell a
+# deliberate rename from a typo. A rename that failed with a marker that
+# advanced anyway is the one combination that makes that run create an empty
+# database under the new name and move DATABASE_URL and the backup job onto it
+# — the outcome refuse_db_name_change exists to prevent, reached from the
+# operator's side instead of the script's. The block is pasted into an
+# interactive shell with no `set -e`, so a failed ALTER scrolls past.
+
+rename_recipe="$(extract_recipe 'RENAME TO')"
+case "$rename_recipe" in
+  *"ALTER DATABASE"*"RENAME TO"*db_name*) : ;;
+  *) echo "could not extract the DB_NAME rename recipe from $DOC — has it moved?" >&2
+     exit 1 ;;
+esac
+
+# FAIL_RENAME makes the ALTER fail the way a surviving session makes it fail.
+# FAIL_LOOKUP fails the confirmation itself, which must also not advance the
+# marker: "could not be checked" is not "checked and true".
+run_rename() {
+  local work; work="$(mktemp -d)"
+  mkdir -p "$work/bin" "$work/state"
+  printf 'collavre_production\n' > "$work/state/db_name"
+  printf '%s' "$rename_recipe" > "$work/recipe.sh"
+
+  cat > "$work/bin/sudo" <<'STUB'
+#!/usr/bin/env bash
+while [ "${1:-}" = -u ] || [ "${1:-}" = postgres ]; do shift; done
+exec "$@"
+STUB
+  # The cluster is modelled as state ($RENAMED), so the confirmation reads what
+  # the rename actually did rather than re-reading its exit status — otherwise
+  # the check asserts nothing the `&&` did not already assert.
+  cat > "$work/bin/psql" <<'STUB'
+#!/usr/bin/env bash
+sql="${*: -1}"
+case "$sql" in
+  *"RENAME TO"*)  echo rename >>"$TRACE"
+                  [ -z "$FAIL_RENAME" ] || {
+                    echo 'ERROR:  database "collavre_production" is being accessed by other users' >&2
+                    exit 1; }
+                  : > "$RENAMED" ;;
+  *pg_database*)  echo lookup >>"$TRACE"
+                  [ -z "$FAIL_LOOKUP" ] || exit 1
+                  [ ! -f "$RENAMED" ] || echo 1 ;;
+esac
+STUB
+  cat > "$work/bin/tee" <<'STUB'
+#!/usr/bin/env bash
+echo tee >>"$TRACE"
+exec /usr/bin/tee "${1/\/var\/lib\/collavre/$STATE}"
+STUB
+  chmod +x "$work/bin"/*
+
+  TRACE="$work/trace"; : > "$TRACE"
+  export TRACE STATE="$work/state" RENAMED="$work/renamed" \
+         FAIL_RENAME="${FAIL_RENAME:-}" FAIL_LOOKUP="${FAIL_LOOKUP:-}"
+  REN_OUT="$(cd "$work" && PATH="$work/bin:$PATH" bash ./recipe.sh 2>&1)"
+  REN_TRACE="$(paste -sd'|' "$TRACE")"
+  REN_MARKER="$(cat "$work/state/db_name")"
+  rm -rf "$work"
+}
+
+echo "102. a rename that succeeded advances the marker"
+FAIL_RENAME='' FAIL_LOOKUP='' run_rename
+chk "the new name is recorded" "collavre_prod" "$REN_MARKER"
+chk "and it was confirmed against the cluster first" "rename|lookup|tee" "$REN_TRACE"
+
+echo "103. a rename that FAILED leaves the marker naming the real database"
+# The negative control: against the two-statement form this fails with
+# `expected [collavre_production] got [collavre_prod]`, which is the finding.
+FAIL_RENAME=1 FAIL_LOOKUP='' run_rename
+chk "the marker still names the data"  "collavre_production" "$REN_MARKER"
+chk "and nothing was written to it"    0 "$(grep -c '^tee$' <<<"${REN_TRACE//|/$'\n'}")"
+
+echo "104. a rename that cannot be confirmed does not advance the marker either"
+# psql exiting non-zero on the lookup, or a cluster that went away between the
+# two statements. `grep -qx 1` on empty output is what makes this fail closed;
+# gating on psql's own status would not, since the pipeline's status is grep's.
+FAIL_RENAME='' FAIL_LOOKUP=1 run_rename
+chk "the marker was not advanced"      "collavre_production" "$REN_MARKER"
+chk "nothing was written to it"        0 "$(grep -c '^tee$' <<<"${REN_TRACE//|/$'\n'}")"
+
+echo "105. no recipe on the page hard-codes the deploy user"
+# Only APP_SSH_USER is guaranteed to hold the key, the sudo grant and docker
+# membership. Spelling it `collavre` sends every recipe to an account that may
+# not exist on a host provisioned with the documented override, and the failure
+# lands at the first scp — before the operator has any reason to suspect the
+# runbook rather than their own setup.
+chk "no 'collavre@' anywhere in the runbook" 0 "$(grep -c 'collavre@' "$DOC")"
+# And the placeholder has to be the one the harnesses above substitute, or these
+# recipes go untested while looking tested.
+chk "the SSH recipes use <deploy-user>" 1 \
+  "$(grep -cq '<deploy-user>@<instance-ip>' "$DOC" && echo 1 || echo 0)"
 
 echo
 if [ "$fail" = 0 ]; then echo "ALL PASS"; else echo "FAILURES"; fi

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -5443,11 +5443,23 @@ else
   chk "and a mixed-case one"                           1 "$fc_rc"
   fcguard "no-pty,COMMAND=\"/usr/bin/true\" $FC_KEY"
   chk "and an uppercase one behind another option"     1 "$fc_rc"
+  # The options field has to be found from authorized_keys quoting, not from
+  # base64-looking text. `AAAA` is valid inside an option value, and ssh-keygen
+  # accepts this exact line; cutting at that value used to hide the forced
+  # command that follows it.
+  FC_COLLISION="from=\"203.0.113.4,AAAA\",command=\"/usr/bin/true\" $FC_KEY"
+  printf '%s\n' "$FC_COLLISION" > "$fcd/collision.pub"
+  chk "the delimiter-collision fixture is a real key line" 0 \
+    "$(ssh-keygen -l -f "$fcd/collision.pub" >/dev/null 2>&1; echo $?)"
+  fcguard "$FC_COLLISION"
+  chk "AAAA in an option cannot hide a later command"  1 "$fc_rc"
 
   fcguard "$FC_KEY"
   chk "a plain key still goes through"                 0 "$fc_rc"
   fcguard "from=\"127.0.0.1\" $FC_KEY"
   chk "and one behind a from= restriction"             0 "$fc_rc"
+  fcguard "from=\"AAAA.example\" $FC_KEY"
+  chk "and AAAA in a benign option is not itself refused" 0 "$fc_rc"
   fcguard "restrict $FC_KEY"
   chk "and one behind restrict, which runs the command" 0 "$fc_rc"
   # The control that keeps the fold on the *question* rather than on the guard:

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -1476,8 +1476,17 @@ ROLE_IS_SUPER=f
 OWNS=1
 # shellcheck disable=SC2034  # read by reassign_prior_db_role, eval'd from the script
 DB_NAME=collavre_production
+# A statement whose text contains $FAIL_SQL fails the way psql does under
+# ON_ERROR_STOP: non-zero, nothing on stdout. Injected rather than provoked,
+# because the defect is what the caller does with the status — a REASSIGN that
+# really fails needs a permission or lock condition this harness has no database
+# to create, and the shape of the failure is the same either way.
+FAIL_SQL=""
 # shellcheck disable=SC2329  # called by reassign_prior_db_role
 psql_as_postgres() {
+  if [ -n "$FAIL_SQL" ]; then
+    case "$2" in *"$FAIL_SQL"*) return 1 ;; esac
+  fi
   case "$2" in
     # Must precede the count(*) branch: the ownership query is a count too, and
     # matching it as the role-existence probe would make every case below read
@@ -1537,6 +1546,56 @@ chk "moved from the role that actually owns them" \
     '|REASSIGN OWNED BY "collavre_app" TO "collavre_third"|ALTER ROLE "collavre_app" NOLOGIN' \
     "$SQL"
 chk "and the queue is down to the current role" "collavre_third" "$(cat "$d3/db_users")"
+
+echo "48b. a statement that fails leaves the role queued, not retired"
+# reassign_one_db_role is called as `... || kept="$kept$prior"`, and a function
+# invoked on the left of `||` runs with errexit suppressed for its whole body.
+# So `set -e` did not stop it at a failed REASSIGN: it fell through to
+# ALTER ROLE ... NOLOGIN and returned the status of the last log, which is zero.
+# Measured on the previous revision with the REASSIGN made to fail:
+#
+#   rc=0   objects still owned by A   NOLOGIN applied to A   queue [B]
+#
+# — the predecessor owns every table, can no longer log in, and has just been
+# dropped from the only record that named it. Asserted on three failure points
+# rather than one: the two statements, and the probe whose empty output reads as
+# "no such role" and retires the entry just as quietly.
+d3c=$(mktemp -d); printf 'collavre_user\n' > "$d3c/db_user"
+ROLE_EXISTS=1 ROLE_IS_SUPER=f
+FAIL_SQL="REASSIGN OWNED"
+rotate collavre_app "$d3c/db_user"
+chk "the run stops rather than continuing to the summary" 1 "$?"
+chk "LOGIN is not revoked from the role that still owns the tables" \
+    "" "$(printf '%s' "$SQL" | grep -o 'NOLOGIN' || true)"
+chk "and the predecessor stays queued" \
+    "collavre_user collavre_app" "$(tr '\n' ' ' < "$d3c/db_users" | sed 's/ *$//')"
+case "$LOGGED" in
+  *"could not move ownership"*"stays queued"*) echo "  ok   says what did not happen" ;;
+  *) echo "  FAIL claimed the move it did not make: $LOGGED"; fail=1 ;;
+esac
+# Ownership moved, LOGIN did not. Retrying is a no-op for the first statement
+# and a retry of the second, so the entry has to survive this too.
+FAIL_SQL="NOLOGIN"
+rotate collavre_app "$d3c/db_user"
+chk "a failed NOLOGIN also stops the run" 1 "$?"
+chk "and keeps the role queued" \
+    "collavre_user collavre_app" "$(tr '\n' ' ' < "$d3c/db_users" | sed 's/ *$//')"
+# A probe that cannot be answered is not an answer: empty output compares equal
+# to neither 1 nor t, which is "no such role" and "not a superuser" — both of
+# which retire the entry.
+FAIL_SQL="pg_roles WHERE rolname"
+rotate collavre_app "$d3c/db_user"
+chk "an unanswerable probe stops the run too" 1 "$?"
+chk "and keeps the role queued" \
+    "collavre_user collavre_app" "$(tr '\n' ' ' < "$d3c/db_users" | sed 's/ *$//')"
+chk "with no SQL attempted" "" "$SQL"
+FAIL_SQL=""
+# The control in the other direction, and the one that matters most here: a
+# guard that reports failure on a clean rotation would stop every run.
+rotate collavre_app "$d3c/db_user"
+chk "a rotation with nothing failing still reports success" 0 "$?"
+chk "and the queue is down to the current role" "collavre_app" "$(cat "$d3c/db_users")"
+rm -rf "$d3c"
 
 echo "49. a superuser predecessor stops the run rather than half-rotating it"
 # DB_USER=postgres on a first run is legal, and the rotation away from it cannot

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -3527,6 +3527,74 @@ chk "names the other account"    1 "$(grep -c "authorized for 'deploybot'" <<<"$
 chk "and the way out"            1 "$(grep -c 'ACK_UNATTRIBUTED_SSH_KEYS=1' <<<"$OUT")"
 rm -rf "$W"
 
+echo "98a. a legacy key shared by deploy accounts is tracked for every account"
+ssh_world
+printf '%s\n' "$KB" > "$W/home/collavre/.ssh/authorized_keys"
+printf '%s\n' "$KB" > "$W/home/deploybot/.ssh/authorized_keys"
+printf '%s\n' "$KB" > "$W/state/ssh_public_key"
+adopt_legacy_ssh_key_marker collavre "$W/state" "$W/passwd" >/dev/null 2>&1
+chk "the current account can still withdraw the shared key" 1 \
+  "$(grep -cxF "$KB" "$W/state/ssh_public_keys.collavre")"
+chk "and the previous account can withdraw the same key later" 1 \
+  "$(grep -cxF "$KB" "$W/state/ssh_public_keys.deploybot")"
+chk "the single legacy marker leaves only after both are recorded" 0 \
+  "$([ -f "$W/state/ssh_public_key" ] && echo 1 || echo 0)"
+KC='ssh-ed25519 AAAAKEY-C operator-C'
+printf '%s\n' "$KC" >> "$W/home/deploybot/.ssh/authorized_keys"
+APP_SSH_USER=deploybot SSH_PUBLIC_KEY="$KC" \
+  revoke_prior_ssh_key "$W/home/deploybot/.ssh/authorized_keys" \
+  "$W/state/ssh_public_key.deploybot" \
+  "$W/state/ssh_public_keys.deploybot" >/dev/null 2>&1
+chk "a later rotation on the previous account withdraws the shared key" 0 \
+  "$(grep -cxF "$KB" "$W/home/deploybot/.ssh/authorized_keys")"
+rm -rf "$W"
+
+echo "98b. legacy adoption preserves an existing per-account predecessor"
+ssh_world
+printf '%s\n' "$KB" > "$W/home/collavre/.ssh/authorized_keys"
+printf '%s\n%s\n' "$KA" "$KB" > "$W/home/deploybot/.ssh/authorized_keys"
+printf '%s\n' "$KA" > "$W/state/ssh_public_key.deploybot"
+printf '%s\n' "$KB" > "$W/state/ssh_public_key"
+adopt_legacy_ssh_key_marker collavre "$W/state" "$W/passwd" >/dev/null 2>&1
+chk "the existing predecessor seeds the previous account's queue" 1 \
+  "$(grep -cxF "$KA" "$W/state/ssh_public_keys.deploybot")"
+chk "and the shared legacy key is added without replacing it" 1 \
+  "$(grep -cxF "$KB" "$W/state/ssh_public_keys.deploybot")"
+chk "the queue helper is defined before legacy adoption runs" 1 \
+  "$(awk '
+      /^record_ssh_key_grant\(\) \{/ { defined = NR }
+      /^adopt_legacy_ssh_key_marker "\$APP_SSH_USER"$/ { called = NR }
+      END {
+	if (defined && called && defined < called) print 1
+	else print 0
+      }
+    ' "$SRC")"
+rm -rf "$W"
+
+echo "98c. an incomplete passwd snapshot cannot retire the host-wide marker"
+ssh_world
+printf '%s\n' "$KB" > "$W/home/collavre/.ssh/authorized_keys"
+printf '%s\n' "$KB" > "$W/home/deploybot/.ssh/authorized_keys"
+printf '%s\n' "$KB" > "$W/state/ssh_public_key"
+getent() {
+  if [ "$#" -eq 2 ] && [ "$2" = collavre ]; then
+    head -1 "$W/passwd"
+    return 0
+  fi
+  head -1 "$W/passwd"
+  return 1
+}
+OUT="$( adopt_legacy_ssh_key_marker collavre "$W/state" 2>&1 )"
+chk "the partial account listing stops adoption" 1 "$?"
+chk "the sole marker remains available for a complete retry" 1 \
+  "$([ -f "$W/state/ssh_public_key" ] && echo 1 || echo 0)"
+chk "and no partial per-account queue is published" 0 \
+  "$(find "$W/state" -name 'ssh_public_keys.*' | wc -l | tr -d ' ')"
+chk "the refusal identifies the incomplete inspection" 1 \
+  "$(grep -c 'could not inspect every account' <<<"$OUT")"
+unset -f getent
+rm -rf "$W"
+
 echo "99. the shapes that must still go through, still do"
 # The refusal is only worth having if it is narrow. Each of these is a host the
 # adoption exists to serve, and stopping any of them would be worse than the
@@ -3587,7 +3655,12 @@ rm -rf "$W"
 # names as supported.
 echo "99a. a missing account is an answer on the production path, not a failure"
 ssh_world
-getent() { return 2; }   # Ubuntu: nothing on stdout, exit 2
+getent() {
+  # Ubuntu returns 2 for a missing named account, while the complete passwd
+  # enumeration still succeeds with an empty result in this fixture.
+  [ "$#" -eq 2 ] && return 2
+  return 0
+}
 ( set -e; passwd_home ghost >/dev/null )
 chk "passwd_home does not fail for an account that does not exist" 0 "$?"
 out="$( passwd_home ghost )"
@@ -6273,10 +6346,31 @@ saved_write_state_file="$(declare -f write_state_file)"
 saved_log="$(declare -f log)"
 log() { printf '%s\n' "$*"; }
 write_state_file() { return 1; }
+
+BACKUP_S3_URI=s3://collavre-backups/new-prefix
+record_status=0
+record_out="$(record_launch_settings "$record_dir" 2>&1)" || record_status=$?
+chk "a failed replacement rejects a complete but stale record" 1 "$record_status"
+chk "and explains that the surviving settings differ"         1 \
+  "$(grep -c 'complete previous record does not match this run' <<<"$record_out")"
+
+BACKUP_S3_URI=s3://collavre-backups/pg
 record_out="$(record_launch_settings "$record_dir" 2>&1)"
 chk "a failed replacement with a complete prior record warns" 0 "$?"
-chk "and identifies that record as complete"                  1 \
-  "$(grep -c 'complete previous record is intact' <<<"$record_out")"
+chk "and identifies that matching record as intact"           1 \
+  "$(grep -c 'matching previous record is intact' <<<"$record_out")"
+
+eval "$saved_write_state_file"
+BACKUP_S3_URI=$'s3://collavre-backups/pg\nold-suffix'
+record_launch_settings "$record_dir" >/dev/null 2>&1
+write_state_file() { return 1; }
+BACKUP_S3_URI=$'s3://collavre-backups/pg\nnew-suffix'
+record_status=0
+record_out="$(record_launch_settings "$record_dir" 2>&1)" || record_status=$?
+chk "a multiline stale value cannot match one shared line" 1 "$record_status"
+BACKUP_S3_URI=$'s3://collavre-backups/pg\nold-suffix'
+record_out="$(record_launch_settings "$record_dir" 2>&1)"
+chk "the exact multiline record still permits recovery" 0 "$?"
 
 rm -f "$record_dir/launch.env"
 record_status=0

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -609,6 +609,70 @@ case "$LOGGED" in
   *) echo "  FAIL silent or reported as withdrawn: $LOGGED"; fail=1 ;;
 esac
 
+echo "41. a rewrite that stops PART WAY also keeps the old key instead of none"
+# Case 40 is the write that produces nothing. This is the write that produces
+# some of the file, which a size test cannot tell from a good one — and it is
+# the likelier shape on a nearly-full disk. It matters more than it looks:
+# install_authorized_keys *appends*, so the successor is the last line and is
+# exactly what a short write drops. The result is a non-empty authorized_keys
+# that no longer contains the key the operator is rotating to.
+st4=$(mktemp -d)
+printf '%s\n%s\n%s\n' "$OLD" "$OPERATOR" "$NEW" > "$AK"
+printf '%s\n' "$OLD" > "$st4/ssh_public_key"
+# shellcheck disable=SC2034  # read by revoke_prior_ssh_key, eval'd from the script
+SSH_PUBLIC_KEY="$NEW"
+LOGGED=""
+# Emits a truncated result — the operator key but not the trailing successor —
+# then fails, exactly as grep does when it runs out of space mid-write.
+# shellcheck disable=SC2329  # shadows grep for revoke_prior_ssh_key only
+grep() {
+  case "$*" in
+    *-vxF*) printf '%s\n' "$OPERATOR"; return 2 ;;
+    *) command grep "$@" ;;
+  esac
+}
+revoke_prior_ssh_key "$AK" "$st4/ssh_public_key"
+unset -f grep
+chk "the account keeps a way in"     1 "$(command grep -cxF "$NEW" "$AK")"
+chk "the un-withdrawn key is kept"   1 "$(command grep -cxF "$OLD" "$AK")"
+chk "the operator's key is kept"     1 "$(command grep -cxF "$OPERATOR" "$AK")"
+chk "marker still names the old key" "$OLD" "$(cat "$st4/ssh_public_key")"
+case "$LOGGED" in
+  *WARNING*"still authorized"*) echo "  ok   the partial write is reported, not claimed as a success" ;;
+  *) echo "  FAIL silent or reported as withdrawn: $LOGGED"; fail=1 ;;
+esac
+
+echo "42. the scratch file is staged beside authorized_keys, not in TMPDIR"
+# Same filesystem, so the rewrite cannot fail for space the staging just
+# proved is available, and a full or unwritable /tmp is not on its own able to
+# break the file the operator logs in with.
+#
+# Asserted on the path mktemp is *asked* for rather than by pointing TMPDIR
+# somewhere broken: GNU mktemp fails on a missing TMPDIR but BSD mktemp falls
+# back to a private directory and succeeds, so the TMPDIR form would pass
+# vacuously on the machine this harness usually runs on and only mean
+# something on the host being provisioned.
+st5=$(mktemp -d)
+printf '%s\n%s\n' "$OLD" "$NEW" > "$AK"
+printf '%s\n' "$OLD" > "$st5/ssh_public_key"
+# shellcheck disable=SC2034  # read by revoke_prior_ssh_key, eval'd from the script
+SSH_PUBLIC_KEY="$NEW"
+LOGGED=""
+# Recorded to a file, not a variable: the call site is `tmp="$(mktemp ...)"`,
+# a command substitution, so anything the shadow assigns dies with its
+# subshell.
+TEMPLATE_LOG="$st5/mktemp_template"
+: > "$TEMPLATE_LOG"
+# shellcheck disable=SC2329  # shadows mktemp for revoke_prior_ssh_key only
+mktemp() { printf '%s\n' "${1:-(no template)}" >> "$TEMPLATE_LOG"; command mktemp "$@"; }
+revoke_prior_ssh_key "$AK" "$st5/ssh_public_key"
+unset -f mktemp
+chk "staged in the target's own directory" \
+  "$(dirname "$AK")" "$(dirname "$(head -1 "$TEMPLATE_LOG")")"
+chk "the rotation still completed"  0 "$(command grep -cxF "$OLD" "$AK")"
+chk "the new key is authorized"     1 "$(command grep -cxF "$NEW" "$AK")"
+chk "no scratch file left behind"   0 "$(find "$(dirname "$AK")" -name '*.revoke.*' | wc -l | tr -d ' ')"
+
 unset -f log
 
 # --- reassign_prior_db_role -------------------------------------------------
@@ -634,7 +698,7 @@ psql_as_postgres() {
 log() { LOGGED="$LOGGED $*"; }
 rotate() { SQL=""; LOGGED=""; reassign_prior_db_role "$@"; }
 
-echo "41. rotating DB_USER moves the tables and retires the old credential"
+echo "43. rotating DB_USER moves the tables and retires the old credential"
 # ALTER DATABASE ... OWNER only moves the database. Every table and sequence
 # the app created stays with the old role, so the new one in DATABASE_URL gets
 # "permission denied" on its own data — while the old role keeps LOGIN and the
@@ -646,11 +710,11 @@ chk "ownership moved, then login revoked" \
     '|REASSIGN OWNED BY "collavre_user" TO "collavre_app"|ALTER ROLE "collavre_user" NOLOGIN' \
     "$SQL"
 
-echo "42. an unchanged DB_USER touches nothing"
+echo "44. an unchanged DB_USER touches nothing"
 rotate collavre_user "$d3/db_user"
 chk "no SQL" "" "$SQL$LOGGED"
 
-echo "43. a superuser predecessor is reported, never disabled"
+echo "45. a superuser predecessor is reported, never disabled"
 # DB_USER=postgres on a first run is legal. NOLOGIN on the cluster superuser
 # locks every operator out of administering it — peer auth needs LOGIN too, so
 # there is no way back in.
@@ -663,7 +727,7 @@ case "$LOGGED" in
   *) echo "  FAIL silent: $LOGGED"; fail=1 ;;
 esac
 
-echo "44. first run, emptied marker and a dropped role are all no-ops"
+echo "46. first run, emptied marker and a dropped role are all no-ops"
 d4=$(mktemp -d)
 ROLE_IS_SUPER=f
 rotate collavre_user "$d4/db_user"          # no marker yet

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -21,7 +21,7 @@ SRC="${1:-$ROOT/script/lightsail_launch.sh}"
 # die() is a one-liner; the others run to the first column-1 closing brace.
 eval "$(awk '
   /^die\(\) \{/ { print; next }
-  /^(ensure_block|ensure_sudoers|in_group|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|install_deploy_ssh_dir|reassign_prior_db_role|refuse_superuser_db_rotation|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps|dedupe_authorized_keys|install_staged_authorized_keys|postgresql_conf_includes_confd)\(\) \{/ { f = 1 }
+  /^(ensure_block|ensure_sudoers|in_group|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|install_deploy_ssh_dir|reassign_prior_db_role|refuse_superuser_db_rotation|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps|dedupe_authorized_keys|install_staged_authorized_keys|postgresql_conf_includes_confd|role_owns_app_objects)\(\) \{/ { f = 1 }
   f { print }
   f && /^\}/ { f = 0 }
 ' "$SRC")"
@@ -29,7 +29,7 @@ eval "$(awk '
 for fn in die ensure_block ensure_sudoers in_group revoke_prior_deploy_user \
           ensure_ufw_rule ssh_already_allowed ensure_ssh_rule \
           install_authorized_keys install_deploy_ssh_dir reassign_prior_db_role \
-          refuse_superuser_db_rotation revoke_prior_ssh_key \
+          refuse_superuser_db_rotation role_owns_app_objects revoke_prior_ssh_key \
           ensure_cluster_on_default_port ensure_swapfile allocate_swapfile \
           ensure_docker_log_caps dedupe_authorized_keys \
           install_staged_authorized_keys postgresql_conf_includes_confd; do
@@ -892,11 +892,19 @@ SQL=""
 LOGGED=""
 ROLE_EXISTS=1
 ROLE_IS_SUPER=f
+# How many application objects the predecessor still owns. 1 is the untransferred
+# state, which is what every case written before the by-hand transfer existed
+# assumes.
+OWNS=1
 # shellcheck disable=SC2034  # read by reassign_prior_db_role, eval'd from the script
 DB_NAME=collavre_production
 # shellcheck disable=SC2329  # called by reassign_prior_db_role
 psql_as_postgres() {
   case "$2" in
+    # Must precede the count(*) branch: the ownership query is a count too, and
+    # matching it as the role-existence probe would make every case below read
+    # a rotation as already transferred.
+    *pg_get_userbyid*) printf '%s\n' "$OWNS"; return 0 ;;
     *"count(*)"*) printf '%s\n' "$ROLE_EXISTS"; return 0 ;;
     *rolsuper*)   printf '%s\n' "$ROLE_IS_SUPER"; return 0 ;;
   esac
@@ -966,6 +974,61 @@ ROLE_EXISTS=0 ROLE_IS_SUPER=t
 refuse collavre_app "$d3/db_user"
 chk "a dropped predecessor proceeds" 0 "$?"
 ROLE_EXISTS=1 ROLE_IS_SUPER=f
+
+echo "50a. a superuser predecessor that owns nothing has already been transferred"
+# The runbook's answer to case 50 is "move the objects by hand, then re-run",
+# and that recipe deliberately leaves postgres a superuser — NOLOGIN on the
+# bootstrap role is a lockout, not a revocation. So a guard that fires on
+# rolsuper alone fires again on the very re-run it asked for, and the rotation
+# can never be completed by any route the runbook describes.
+printf 'postgres\n' > "$d3/db_user"
+ROLE_EXISTS=1 ROLE_IS_SUPER=t OWNS=0
+# Not in a subshell: the let-through path is asserted on what it logged, and
+# $LOGGED would not survive one.
+refuse collavre_app "$d3/db_user"
+chk "the re-run is let through" 0 "$?"
+case "$LOGGED" in
+  *"owns nothing"*"keeps LOGIN"*)
+    echo "  ok   says the old superuser credential is NOT retired" ;;
+  *) echo "  FAIL silent or unclear: $LOGGED"; fail=1 ;;
+esac
+# Still refuses while anything is left, so the let-through is the transfer and
+# not the superuser check going away.
+OWNS=3
+out="$( (refuse collavre_app "$d3/db_user") 2>&1 )"
+chk "a partial transfer still refuses" 1 "$?"
+case "$out" in
+  *"3 object(s)"*) echo "  ok   says how many are left" ;;
+  *) echo "  FAIL does not say what is outstanding: $out"; fail=1 ;;
+esac
+# An unanswerable question reads as the unsafe answer: a database that does not
+# exist yet, or a query that failed, returns nothing and must not pass for zero.
+OWNS=""
+out="$( (refuse collavre_app "$d3/db_user") 2>&1 )"
+chk "an unreadable count refuses" 1 "$?"
+OWNS=1
+
+echo "50b. the completed transfer neither reassigns nor touches the superuser login"
+# Both statements must be skipped rather than left to no-op. REASSIGN OWNED BY
+# postgres is rejected whether or not it owns anything ("required by the database
+# system"), so it would end the run at the last step of a rotation that had
+# otherwise succeeded — and ALTER ROLE postgres NOLOGIN is accepted by
+# PostgreSQL, after which nothing can log in to undo it.
+printf 'postgres\n' > "$d3/db_user"
+ROLE_EXISTS=1 ROLE_IS_SUPER=t OWNS=0
+rotate collavre_app "$d3/db_user"
+chk "proceeds" 0 "$?"
+chk "no SQL at all" "" "$SQL"
+case "$LOGGED" in
+  *"owns nothing"*) echo "  ok   says the role was left alone, and why" ;;
+  *) echo "  FAIL silent: $LOGGED"; fail=1 ;;
+esac
+# The backstop still stands for a genuinely untransferred superuser.
+OWNS=2
+out="$( (rotate collavre_app "$d3/db_user") 2>&1 )"
+chk "an untransferred superuser still dies" 1 "$?"
+chk "and still runs no SQL" "" "$SQL"
+ROLE_EXISTS=1 ROLE_IS_SUPER=f OWNS=1
 
 echo "51. first run, emptied marker and a dropped role are all no-ops"
 d4=$(mktemp -d)
@@ -1168,6 +1231,23 @@ case "$LOGGED" in
   *) echo "  FAIL silent: $LOGGED"; fail=1 ;;
 esac
 
+echo "61a. the swap it keeps is also made to survive a reboot"
+# Codex's shape: an active swapfile with no fstab entry — an operator who ran
+# `swapon` by hand, or a run interrupted between swapon and ensure_block. The
+# matching-size path was fixed for this; the failure paths that *retain* swap
+# were not, so a failed resize failed twice over — the size did not change, and
+# what was kept instead was kept only until the next restart. On a low-memory
+# instance a reboot is when the headroom is most needed.
+new_swap_env 4
+printf 'UUID=xxx / ext4 defaults 0 1\n' > "$FSTAB"   # active, but not persisted
+SWAPOFF_FAILS=1
+SWAP_SIZE_MB=12 ensure_swapfile "$SWAPFILE" "$FSTAB"
+chk "returns success"       0 "$?"
+chk "old swap still on"     "$SWAPFILE" "$SWAPPED_ON"
+chk "and now in fstab"      1 "$(grep -c "^$SWAPFILE none swap" "$FSTAB")"
+chk "one managed block"     1 "$(grep -c '# BEGIN collavre:swap' "$FSTAB")"
+chk "operator's own mount untouched" 1 "$(grep -c '^UUID=xxx' "$FSTAB")"
+
 echo "62. a resize that does not fit puts the previous swap back"
 # Growing means freeing the old file first, so an allocation that fails would
 # otherwise end the run with no swap at all — worse than it started, on the
@@ -1184,6 +1264,17 @@ case "$LOGGED" in
     echo "  ok   operator told the raise did not take, and what is running" ;;
   *) echo "  FAIL silent or claims success: $LOGGED"; fail=1 ;;
 esac
+
+echo "62a. the swap it restores is also made to survive a reboot"
+# The other branch that retains swap and returned without converging fstab.
+new_swap_env 8
+printf 'UUID=xxx / ext4 defaults 0 1\n' > "$FSTAB"   # active, but not persisted
+DISK_FREE_MIB=20
+SWAP_SIZE_MB=64 ensure_swapfile "$SWAPFILE" "$FSTAB"
+chk "run continues"      0 "$?"
+chk "previous size back" 8 "$(swap_mib "$SWAPFILE")"
+chk "and now in fstab"   1 "$(grep -c "^$SWAPFILE none swap" "$FSTAB")"
+chk "one managed block"  1 "$(grep -c '# BEGIN collavre:swap' "$FSTAB")"
 
 echo "63. a first run that cannot allocate dies rather than reporting success"
 # have=0, so there is nothing to restore; the run must stop loudly instead of

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -5866,6 +5866,14 @@ chk "and keyboard-interactive still on"                   1 "$(vh "$(vh_eff no n
 chk "and public-key authentication off"                   1 "$(vh "$(vh_eff no no no no)")"
 chk "and a missing public-key result is not treated as verified" 1 \
   "$(vh "$(printf 'passwordauthentication no\npermitrootlogin no\nkbdinteractiveauthentication no')")"
+printf '%s\nexposeauthinfo no\n' "$(vh_eff no no no)" > "$vshd/eff"
+chk "an ineffective ExposeAuthInfo blocks explicit-key cutover" 1 \
+  "$( (verify_ssh_hardening "$vshd/eff" "$vshd" 0 deploybot 1 1) \
+      >/dev/null 2>&1; echo $?)"
+printf '%s\nexposeauthinfo yes\n' "$(vh_eff no no no)" > "$vshd/eff"
+chk "effective ExposeAuthInfo permits explicit-key cutover" 0 \
+  "$( (verify_ssh_hardening "$vshd/eff" "$vshd" 0 deploybot 1 1) \
+      >/dev/null 2>&1; echo $?)"
 
 printf '%s\n' "$(vh_eff yes no no)" > "$vshd/eff"
 vh_msg="$( ( verify_ssh_hardening "$vshd/eff" "$vshd" ) 2>&1 )"
@@ -6967,6 +6975,8 @@ chk "and requires an sshd process ancestor" 1 \
   "$(grep -c '^  ssh_cutover_has_sshd_ancestor "\$user" ||$' "$SRC")"
 chk "sshd exposes the key that authenticated the session" 1 \
   "$(grep -c "^  'ExposeAuthInfo yes'$" "$SRC")"
+chk "explicit-key staging verifies ExposeAuthInfo is effective" 1 \
+  "$(grep -c '^SSH_AUTH_INFO_REQUIRED=0$' "$SRC")"
 chk "the runbook changes KAMAL_SSH_USER only after finalization" 1 \
   "$(grep -c 'Change `KAMAL_SSH_USER` only after' "$DOC")"
 
@@ -6981,8 +6991,10 @@ stage_ssh_cutover deploybot "$cutover_key" \
   "$cutover_finalizer" "$SRC"
 chk "staging creates a root-only pending record" 600 \
   "$(file_mode "$cutover_state/ssh_cutover.pending")"
-chk "and a root-only exact key record" 600 \
-  "$(file_mode "$cutover_state/ssh_cutover.key")"
+chk "and stores the exact key in that atomic record" 1 \
+  "$(grep -cxF "key=$cutover_key" "$cutover_state/ssh_cutover.pending")"
+chk "without a separately replaceable key record" 0 \
+  "$([ -e "$cutover_state/ssh_cutover.key" ] && echo 1 || echo 0)"
 chk "and installs the finalizer" 755 "$(file_mode "$cutover_finalizer")"
 chk "without committing the deploy user" 0 \
   "$([ -e "$cutover_state/deploy_user" ] && echo 1 || echo 0)"
@@ -7042,6 +7054,24 @@ chk "and still revokes nothing" "" "$TRACE"
     finalize_ssh_cutover "$cutover_nonce" ) >/dev/null 2>&1
 chk "a session authenticated by the predecessor key is refused" 1 "$?"
 chk "and does not start withdrawal" "" "$TRACE"
+cp "$cutover_state/ssh_cutover.pending" \
+  "$cutover_state/ssh_cutover.pending.complete"
+sed -i.bak '/^key=/d' "$cutover_state/ssh_cutover.pending"
+( SUDO_USER=deploybot SSH_PROOF=1 KEY_PROOF=1 \
+    finalize_ssh_cutover "$cutover_nonce" ) >/dev/null 2>&1
+chk "an older split-record challenge is refused" 1 "$?"
+chk "and cannot bypass staged-key proof" "" "$TRACE"
+mv "$cutover_state/ssh_cutover.pending.complete" \
+  "$cutover_state/ssh_cutover.pending"
+rm -f "$cutover_state/ssh_cutover.pending.bak"
+sed -i.bak "s|^key=.*|key=ssh-ed25519 OLD predecessor|" \
+  "$cutover_state/ssh_cutover.pending"
+( SUDO_USER=deploybot SSH_PROOF=1 KEY_PROOF=1 \
+    finalize_ssh_cutover "$cutover_nonce" ) >/dev/null 2>&1
+chk "a key that differs from the pending fingerprint is refused" 1 "$?"
+chk "and cannot start predecessor withdrawal" "" "$TRACE"
+mv "$cutover_state/ssh_cutover.pending.bak" \
+  "$cutover_state/ssh_cutover.pending"
 ( SUDO_USER=deploybot SSH_PROOF=1 KEY_PROOF=1 REVOKE_KEY_FAIL=1 \
     finalize_ssh_cutover "$cutover_nonce" ) >/dev/null 2>&1
 chk "an incomplete predecessor-key withdrawal is refused" 1 "$?"
@@ -7057,17 +7087,39 @@ chk "and consumes the pending state" 0 \
   "$([ -e "$cutover_state/ssh_cutover.pending" ] && echo 1 || echo 0)"
 chk "and commits the staged account" deploybot \
   "$(cat "$cutover_state/deploy_user")"
+# Earlier queue fixtures replace this function with host models and then unset
+# it. Re-extract the production function for the finalizer failure boundaries
+# rather than letting a missing-command status masquerade as a refusal.
+eval "$(awk '
+  /^revoke_deploy_user_access\(\) \{/ { f = 1 }
+  f { print }
+  f && /^\}/ { exit }
+' "$SRC")"
+sudoers_failure_dir="$cutover_state/sudoers-failure"
+mkdir "$sudoers_failure_dir"
+printf 'predecessor ALL=(ALL:ALL) NOPASSWD:ALL\n' \
+  > "$sudoers_failure_dir/90-collavre-predecessor"
 sudoers_failure="$(
   (
     in_group() { return 1; }
     rm() { return 1; }
     log() { :; }
-    revoke_deploy_user_access predecessor deploybot
+    revoke_deploy_user_access predecessor deploybot "$sudoers_failure_dir"
     printf 'rc=%s\n' "$?"
   ) 2>/dev/null
 )"
-chk "a sudoers deletion failure keeps the predecessor queued" 0 \
-  "$(grep -c '^rc=0$' <<<"$sudoers_failure")"
+chk "a sudoers deletion failure keeps the predecessor queued" 1 \
+  "$(grep -c '^rc=1$' <<<"$sudoers_failure")"
+sudoers_collision="$cutover_state/sudoers"
+mkdir "$sudoers_collision"
+printf 'release_bot ALL=(ALL:ALL) NOPASSWD:ALL\n' \
+  > "$sudoers_collision/90-collavre-release_bot"
+in_group() { return 1; }
+log() { :; }
+revoke_deploy_user_access release.bot release_bot "$sudoers_collision"
+chk "a colliding successor sudoers grant is preserved" 1 \
+  "$(grep -cxF 'release_bot ALL=(ALL:ALL) NOPASSWD:ALL' \
+      "$sudoers_collision/90-collavre-release_bot")"
 unset -f getent id in_group ssh_cutover_has_sshd_ancestor \
   ssh_cutover_authenticated_with_key \
   revoke_prior_ssh_key revoke_prior_deploy_user rm

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -465,6 +465,7 @@ esac
 # an error under GNU cat, and `set -e` would end provisioning at that line.
 
 LOGGED=""
+# shellcheck disable=SC2329  # called by install_authorized_keys, eval'd from the script
 log() { LOGGED="$LOGGED $*"; }
 
 echo "29. the deploy user's own keys are not copied onto themselves"
@@ -487,6 +488,7 @@ install_authorized_keys "$h/collavre/.ssh/authorized_keys" "$h"
 chk "cloud key copied" 1 "$(grep -c CLOUDKEY "$h/collavre/.ssh/authorized_keys")"
 
 echo "31. an explicit SSH_PUBLIC_KEY is added once, not once per run"
+# shellcheck disable=SC2034  # read by install_authorized_keys, eval'd from the script
 SSH_PUBLIC_KEY="ssh-ed25519 EXPLICIT me"
 install_authorized_keys "$h/collavre/.ssh/authorized_keys" "$h"
 install_authorized_keys "$h/collavre/.ssh/authorized_keys" "$h"
@@ -503,7 +505,9 @@ SQL=""
 LOGGED=""
 ROLE_EXISTS=1
 ROLE_IS_SUPER=f
+# shellcheck disable=SC2034  # read by reassign_prior_db_role, eval'd from the script
 DB_NAME=collavre_production
+# shellcheck disable=SC2329  # called by reassign_prior_db_role
 psql_as_postgres() {
   case "$2" in
     *"count(*)"*) printf '%s\n' "$ROLE_EXISTS"; return 0 ;;
@@ -511,6 +515,7 @@ psql_as_postgres() {
   esac
   SQL="$SQL|$2"
 }
+# shellcheck disable=SC2329  # called by reassign_prior_db_role
 log() { LOGGED="$LOGGED $*"; }
 rotate() { SQL=""; LOGGED=""; reassign_prior_db_role "$@"; }
 

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -2154,6 +2154,40 @@ chk "no connection URI"       0 "$(grep -c 'postgres\(ql\)\?://' <<<"$move")"
 chk "and the page says why"   1 \
   "$(grep -c 'invalid percent-encoded token' "$DOC")"
 
+echo "78b. the deploy section does not ask for a hand-composed DATABASE_URL"
+# Same defect as 78a one consumer over: section 4's .env.production is the one
+# place on this page the operator *types* a DATABASE_URL, and it carried a
+# <password> slot. The parser there is Rails', not libpq's, and it fails in the
+# same misdirected way. Measured against
+# ActiveRecord::DatabaseConfigurations::ConnectionUrlResolver:
+#
+#   p@ss        URI::InvalidURIError            (likewise p#ss, p?ss, p%ss)
+#   p@ss/word   parses — host "ss", database "word@172.17.0.1:5432/..."
+#   pa%41ss     parses — password "paAss"
+#
+# So the page's blanket claim that any of those six characters aborts the boot
+# with URI::InvalidURIError was wrong for the pair most likely to occur
+# together — and wrong about this page's *own* worked example, p@ss/word, which
+# resolves a hostname instead of raising.
+#
+# Asserted on the dotenv block rather than the whole page: section 3 shows the
+# same URL shape to say where PostgreSQL listens, which is a description and not
+# an instruction to fill one in. There is exactly one dotenv block on the page.
+deploy_env="$(awk '/^```dotenv$/{f=1;next} f&&/^```$/{exit} f' "$DOC")"
+chk "there is a dotenv block"  1 "$([ -n "$deploy_env" ] && echo 1 || echo 0)"
+chk "no password placeholder"  0 "$(grep -c '<password>' <<<"$deploy_env")"
+chk "no hand-built URI"        0 "$(grep -c 'postgres\(ql\)\?://' <<<"$deploy_env")"
+chk "names the summary file"   1 "$(grep -c 'summary file' <<<"$deploy_env")"
+# And the corrected claim has to stay corrected: the two silent cases are what
+# make copying the summary file load-bearing rather than merely tidy. Scoped to
+# the Rails block — `pa%41ss` is also measured against libpq further down the
+# page, and the whole-page count would then pass for the wrong reason.
+rails_urls="$(awk '/ConnectionUrlResolver/{f=1;next} f&&/^```$/{n++; if(n==2) exit; next} f&&n==1' "$DOC")"
+chk "states the silent parse"  1 "$(grep -c 'host "ss"' <<<"$rails_urls")"
+chk "states the silent decode" 1 "$(grep -c 'password "paAss"' <<<"$rails_urls")"
+chk "no blanket abort claim"   0 \
+  "$(grep -c 'every Rails command in' "$DOC")"
+
 echo "79. a failed pg_dump never reaches the transfer or the restore"
 FAIL_DUMP=1 FAIL_XFER='' FAIL_RESTORE='' run_move
 chk "no transfer"             0 "$(grep -c '^scp:' <<<"${MOVE_TRACE//|/$'\n'}")"

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -21,7 +21,7 @@ SRC="${1:-$ROOT/script/lightsail_launch.sh}"
 # die() is a one-liner; the others run to the first column-1 closing brace.
 eval "$(awk '
   /^die\(\) \{/ { print; next }
-  /^(ensure_block|ensure_sudoers|in_group|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|install_deploy_ssh_dir|reassign_prior_db_role|refuse_superuser_db_rotation|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps|dedupe_authorized_keys|install_staged_authorized_keys|postgresql_conf_includes_confd|role_owns_app_objects)\(\) \{/ { f = 1 }
+  /^(ensure_block|ensure_sudoers|in_group|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|install_deploy_ssh_dir|reassign_prior_db_role|refuse_superuser_db_rotation|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps|dedupe_authorized_keys|install_staged_authorized_keys|postgresql_conf_includes_confd|role_owns_app_objects|refuse_db_name_change|passwd_home|ssh_key_holder|adopt_legacy_ssh_key_marker)\(\) \{/ { f = 1 }
   f { print }
   f && /^\}/ { f = 0 }
 ' "$SRC")"
@@ -32,7 +32,9 @@ for fn in die ensure_block ensure_sudoers in_group revoke_prior_deploy_user \
           refuse_superuser_db_rotation role_owns_app_objects revoke_prior_ssh_key \
           ensure_cluster_on_default_port ensure_swapfile allocate_swapfile \
           ensure_docker_log_caps dedupe_authorized_keys \
-          install_staged_authorized_keys postgresql_conf_includes_confd; do
+          install_staged_authorized_keys postgresql_conf_includes_confd \
+          refuse_db_name_change passwd_home ssh_key_holder \
+          adopt_legacy_ssh_key_marker; do
   declare -F "$fn" >/dev/null || {
     echo "could not extract $fn() from $SRC — has the definition moved?" >&2
     exit 1
@@ -1722,6 +1724,7 @@ run_restore() {
 #!/usr/bin/env bash
 while [ "${1:-}" = -u ] || [ "${1:-}" = postgres ]; do shift; done
 exec "$@"
+STUB
   # The recipe reads the configured DB_USER out of the state file the script
   # writes, so the harness has to answer for it. Unset APP_ROLE means the file
   # is absent — which is a case under test, not a default to paper over, since
@@ -2082,6 +2085,282 @@ chk "the operator's own line is untouched" 1 "$(grep -c "^#include_dir = 'conf.d
 postgresql_conf_includes_confd "$f" || ensure_block "$f" include "include_dir = 'conf.d'"
 chk "and a re-run appends nothing" 1 "$(grep -c '# BEGIN collavre:include' "$f")"
 rm -f "$f"
+
+# --- refuse_db_name_change --------------------------------------------------
+#
+# DB_NAME was the one identifier a re-run could change with no trace: the SQL is
+# create-if-missing, nothing renames the old database, and nothing recorded
+# which one a previous run chose. Measured on postgres:17 against a host holding
+# 5,000 rows, re-running with a mistyped name:
+#
+#   run reports success
+#   tables in the new one the URL and backup will name : 0
+#   rows in the real one, now referenced by nothing    : 5000
+#
+# The data is not destroyed; it is orphaned, and the nightly pg_dump moves to
+# the empty database. Both halves are silent.
+
+# Its own stub rather than the shared one above: this guard asks pg_database a
+# count(*), which the shared stub answers with the ROLE_EXISTS probe.
+# shellcheck disable=SC2329  # called by refuse_db_name_change
+psql_as_postgres() {
+  case "$2" in
+    *pg_database*datistemplate*) printf '%s\n' "$DB_LIST" ;;
+    *pg_database*)               printf '%s\n' "$DB_EXISTS" ;;
+  esac
+}
+DB_EXISTS=1 DB_LIST="collavre_production"
+
+echo "95. a changed DB_NAME is refused before anything is created"
+dn=$(mktemp -d)
+printf 'collavre_production\n' > "$dn/db_name"
+printf 'collavre_user\n'       > "$dn/db_user"
+out="$( (refuse_db_name_change collavre_prod "$dn") 2>&1 )"
+chk "exits non-zero" 1 "$?"
+chk "the marker still names the real database" "collavre_production" "$(cat "$dn/db_name")"
+case "$out" in
+  *"provisioned with DB_NAME='collavre_production'"*"created empty"*"Nothing has been changed"*)
+    echo "  ok   names the state, the consequence and the way out" ;;
+  *) echo "  FAIL unhelpful: $out"; fail=1 ;;
+esac
+# The shapes that must still go through.
+refuse_db_name_change collavre_production "$dn"
+chk "an unchanged DB_NAME proceeds" 0 "$?"
+dn2=$(mktemp -d)
+refuse_db_name_change collavre_production "$dn2"
+chk "a genuine first run proceeds"  0 "$?"
+chk "and it is a first run precisely because nothing was provisioned here" \
+  0 "$(find "$dn2" -mindepth 1 | wc -l | tr -d ' ')"
+
+echo "96. an older host with no db_name record is judged by the cluster"
+# The migration case. Adopting blindly would let exactly the reported change
+# through on every host provisioned before this marker existed.
+dn3=$(mktemp -d); printf 'collavre_user\n' > "$dn3/db_user"
+DB_EXISTS=1
+refuse_db_name_change collavre_production "$dn3"
+chk "the database it names exists, so adopt it" 0 "$?"
+DB_EXISTS=0 DB_LIST="collavre_production"
+out="$( (refuse_db_name_change collavre_prod "$dn3") 2>&1 )"
+chk "it does not exist, so refuse"  1 "$?"
+case "$out" in
+  *"provisioned before"*"does not exist"*"collavre_production"*)
+    echo "  ok   refuses and lists what is actually there" ;;
+  *) echo "  FAIL unhelpful: $out"; fail=1 ;;
+esac
+# An empty cluster listing must not read as a missing variable.
+DB_EXISTS=0 DB_LIST=""
+out="$( (refuse_db_name_change collavre_prod "$dn3") 2>&1 )"
+case "$out" in
+  *"Databases present: (none)"*) echo "  ok   an empty listing says so" ;;
+  *) echo "  FAIL bare or confusing listing: $out"; fail=1 ;;
+esac
+
+echo "97. an empty marker is not treated as a previous name"
+# A truncated write would otherwise refuse every future run against ''.
+dn4=$(mktemp -d); : > "$dn4/db_name"; printf 'collavre_user\n' > "$dn4/db_user"
+DB_EXISTS=1
+refuse_db_name_change collavre_production "$dn4"
+chk "proceeds rather than refusing against an empty name" 0 "$?"
+
+unset -f psql_as_postgres
+rm -rf "$dn" "$dn2" "$dn3" "$dn4"
+
+# --- adopt_legacy_ssh_key_marker --------------------------------------------
+#
+# An earlier revision kept ONE record of the managed SSH key per host. Re-filing
+# it under whichever account APP_SSH_USER names today is not a migration, it is
+# a guess — and on a host that rotated accounts under that revision the guess is
+# wrong in the direction that grants root. Driven through the reported sequence
+# with the real functions:
+#
+#   world that revision left: marker=key-B, collavre holds key-A, deploybot key-B
+#   run names collavre/key-C -> B filed as collavre's predecessor
+#   withdrawal looks for B in collavre's file : NOT FOUND, nothing withdrawn
+#   collavre authorized_keys : key-A, key-C      key-A still authorized: 1
+#   deploybot's marker       : consumed, so key-B is unwithdrawable too
+#
+# Both halves are silent, and the run then re-arms collavre with `usermod -aG
+# sudo` and the docker group, so key-A is root again. The functions take a
+# passwd table so the shapes can be built without accounts on this machine.
+ssh_world() {
+  W=$(mktemp -d)
+  mkdir -p "$W/state" "$W/home/collavre/.ssh" "$W/home/deploybot/.ssh"
+  printf 'collavre:x:1001:1001::%s/home/collavre:/bin/bash\n' "$W" > "$W/passwd"
+  printf 'deploybot:x:1002:1002::%s/home/deploybot:/bin/bash\n' "$W" >> "$W/passwd"
+  KA='ssh-ed25519 AAAAKEY-A operator-A'
+  KB='ssh-ed25519 AAAAKEY-B operator-B'
+}
+
+echo "98. a marker that names another account's key does not become this one's"
+ssh_world
+printf '%s\n' "$KA" > "$W/home/collavre/.ssh/authorized_keys"
+printf '%s\n' "$KB" > "$W/home/deploybot/.ssh/authorized_keys"
+printf '%s\n' "$KB" > "$W/state/ssh_public_key"
+OUT="$( adopt_legacy_ssh_key_marker collavre "$W/state" "$W/passwd" 2>&1 )"
+chk "exits non-zero" 1 "$?"
+# The refusal has to be a refusal: the sudo grant and the docker group are a few
+# lines below the call site, so continuing is what turns a stale key into root.
+chk "no predecessor invented for collavre" 0 \
+  "$([ -f "$W/state/ssh_public_key.collavre" ] && echo 1 || echo 0)"
+chk "and deploybot's record is not consumed" 1 \
+  "$([ -f "$W/state/ssh_public_key" ] && echo 1 || echo 0)"
+chk "names the other account"    1 "$(grep -c "authorized for 'deploybot'" <<<"$OUT")"
+chk "and the way out"            1 "$(grep -c 'ACK_UNATTRIBUTED_SSH_KEYS=1' <<<"$OUT")"
+rm -rf "$W"
+
+echo "99. the shapes that must still go through, still do"
+# The refusal is only worth having if it is narrow. Each of these is a host the
+# adoption exists to serve, and stopping any of them would be worse than the
+# escalation: the first one is the ordinary upgrade, and without it the first
+# run after the per-account change would withdraw nothing and then advance,
+# leaving the key it replaced authorized forever.
+ssh_world
+printf '%s\n' "$KA" > "$W/home/collavre/.ssh/authorized_keys"
+printf '%s\n' "$KA" > "$W/state/ssh_public_key"
+adopt_legacy_ssh_key_marker collavre "$W/state" "$W/passwd" >/dev/null 2>&1
+chk "the account's own key is adopted" "$KA" "$(cat "$W/state/ssh_public_key.collavre" 2>/dev/null)"
+chk "  claimed once, not copied" 0 "$([ -f "$W/state/ssh_public_key" ] && echo 1 || echo 0)"
+rm -rf "$W"
+
+ssh_world
+: > "$W/home/collavre/.ssh/authorized_keys"
+printf '%s\n' "$KB" > "$W/home/deploybot/.ssh/authorized_keys"
+printf '%s\n' "$KB" > "$W/state/ssh_public_key"
+adopt_legacy_ssh_key_marker collavre "$W/state" "$W/passwd" >/dev/null 2>&1
+chk "an account with no keys cannot be hiding one, so it is filed at its owner" 1 \
+  "$([ -f "$W/state/ssh_public_key.deploybot" ] && echo 1 || echo 0)"
+rm -rf "$W"
+
+ssh_world
+printf '%s\n' "$KA" > "$W/home/collavre/.ssh/authorized_keys"
+printf 'ssh-ed25519 GONE gone\n' > "$W/state/ssh_public_key"
+adopt_legacy_ssh_key_marker collavre "$W/state" "$W/passwd" >/dev/null 2>&1
+chk "a key authorized for nobody is dropped, not filed" 0 \
+  "$([ -f "$W/state/ssh_public_key.collavre" ] && echo 1 || echo 0)"
+chk "  and the stale record does not survive to refuse every later run" 0 \
+  "$([ -f "$W/state/ssh_public_key" ] && echo 1 || echo 0)"
+rm -rf "$W"
+
+ssh_world
+printf '%s\n' "$KA" > "$W/home/collavre/.ssh/authorized_keys"
+printf '%s\n' "$KB" > "$W/home/deploybot/.ssh/authorized_keys"
+printf '%s\n' "$KB" > "$W/state/ssh_public_key"
+ACK_UNATTRIBUTED_SSH_KEYS=1 \
+  adopt_legacy_ssh_key_marker collavre "$W/state" "$W/passwd" >/dev/null 2>&1
+chk "the acknowledged override proceeds, filing at the owner" 1 \
+  "$([ -f "$W/state/ssh_public_key.deploybot" ] && echo 1 || echo 0)"
+rm -rf "$W"
+
+ssh_world
+adopt_legacy_ssh_key_marker collavre "$W/state" "$W/passwd" >/dev/null 2>&1
+chk "a first run with no legacy record is a silent no-op" 0 "$?"
+rm -rf "$W"
+
+# The cases above all pass a passwd table, which is the third argument and the
+# reason they can run without accounts on this machine. Production does not pass
+# it, and that argument selects between two different implementations — so
+# without a case that omits it, every one of them exercises a function the host
+# never runs. It is the branch the host DOES run that fails: `getent passwd
+# <missing>` exits 2, the pipeline into `cut` carries that status under
+# `pipefail`, and the caller's plain `home="$(passwd_home ...)"` hands it to
+# `set -e`. The run ends at that line, with no message from either branch of the
+# function — on the first-run-creates-the-user path the function's own comment
+# names as supported.
+echo "99a. a missing account is an answer on the production path, not a failure"
+ssh_world
+getent() { return 2; }   # Ubuntu: nothing on stdout, exit 2
+( set -e; passwd_home ghost >/dev/null )
+chk "passwd_home does not fail for an account that does not exist" 0 "$?"
+out="$( passwd_home ghost )"
+chk "  and reports it the same way the awk branch does" "" "$out"
+printf '%s\n' "$KB" > "$W/state/ssh_public_key"
+( set -e; adopt_legacy_ssh_key_marker collavre "$W/state" >/dev/null 2>&1 )
+chk "so the caller survives it under the run's own set -e" 0 "$?"
+unset -f getent
+rm -rf "$W"
+
+# --- step 6, at the call site -----------------------------------------------
+#
+# refuse_superuser_db_rotation ran AFTER the new DB_PASSWORD was written to
+# $STATE_DIR, so a refusal whose message says "Nothing has been changed" had
+# already changed something, and it outlived the run. The recovery that message
+# recommends — re-run with the previous DB_USER and no DB_PASSWORD — reads the
+# state file back, so it applied the password of the abandoned rotation to the
+# role nobody asked to change, and the DATABASE_URL already deployed stopped
+# authenticating. Verified over scram auth on postgres:17 rather than by
+# reading. Extracted from the script so the ORDER is what is under test.
+step6="$(awk '/^log "6\/9/ { f = 1 } f { print } f && /^chmod 0600 "\$STATE_DIR\/db_password"$/ { exit }' "$SRC")"
+[ -n "$step6" ] || { echo "  FAIL could not extract step 6 from $SRC"; fail=1; }
+
+echo "100. a refused rotation writes nothing to the state directory"
+s6=$(mktemp -d)
+printf 'postgres' > "$s6/db_user"          # provisioned with the superuser
+printf 'OLD-PASSWORD' > "$s6/db_password"  # the one DATABASE_URL was built from
+printf 'collavre_production\n' > "$s6/db_name"
+OUT="$(
+  STATE_DIR="$s6" DB_USER=collavre_app DB_PASSWORD=NEW-PASSWORD \
+  DB_NAME=collavre_production bash -c '
+    set -uo pipefail
+    '"$(declare -f die refuse_superuser_db_rotation role_owns_app_objects refuse_db_name_change)"'
+    # Its own log(), not the harness one: that appends to $LOGGED, which is
+    # unbound in here, so under set -u the extracted region would die on its
+    # first line and both assertions below would pass for the wrong reason.
+    log() { echo "[log] $*"; }
+    psql_as_postgres() {
+      case "$2" in
+        *"count(*) FROM pg_roles"*) echo 1 ;;   # postgres exists
+        *rolsuper*)                 echo t ;;   # and is a superuser
+        *pg_class*)                 echo 5 ;;   # still owns application objects
+        *pg_database*)              echo 1 ;;
+      esac
+    }
+    '"$step6"'
+  ' 2>&1
+)"
+chk "the rotation is refused"  1 "$(grep -c 'which is a superuser' <<<"$OUT")"
+# The whole point: the message and the filesystem must agree.
+chk "and the message is true"  OLD-PASSWORD "$(cat "$s6/db_password")"
+rm -rf "$s6"
+
+echo "101. a re-run that changes both DB_NAME and DB_USER names the right one"
+# The two guards are not independent. refuse_superuser_db_rotation counts the
+# objects the previous role owns IN $DB_NAME, so when both change it asks that
+# of a database that does not exist: psql fails, the count comes back empty, and
+# the deliberate "unanswerable reads as unsafe" rule turns it into a refusal
+# about object ownership. Measured on postgres:17 with the guards in the other
+# order — it dies with "An unknown number of object(s) in 'collavre_prod' are
+# still owned by 'postgres' ... Move the objects by hand", and that transfer
+# cannot be performed on a database that is not there. Nothing is changed either
+# way, so this is about which problem the operator is sent to fix.
+s6b=$(mktemp -d)
+printf 'postgres' > "$s6b/db_user"
+printf 'OLD-PASSWORD' > "$s6b/db_password"
+printf 'collavre_production\n' > "$s6b/db_name"
+OUT="$(
+  STATE_DIR="$s6b" DB_USER=collavre_app DB_PASSWORD=NEW-PASSWORD \
+  DB_NAME=collavre_prod bash -c '
+    set -uo pipefail
+    '"$(declare -f die refuse_superuser_db_rotation role_owns_app_objects refuse_db_name_change)"'
+    log() { echo "[log] $*"; }
+    psql_as_postgres() {
+      case "$2" in
+        *"count(*) FROM pg_roles"*) echo 1 ;;
+        *rolsuper*)                 echo t ;;
+        # The database named by this run does not exist, so the ownership query
+        # cannot run at all. Empty stdout is what psql leaves behind, measured.
+        *pg_class*)                 return 2 ;;
+        *pg_database*)              echo 0 ;;
+      esac
+    }
+    '"$step6"'
+  ' 2>&1
+)"
+chk "the run is refused"                 1 "$(grep -c 'Nothing has been changed' <<<"$OUT")"
+chk "and it is the name it complains about" 1 "$(grep -c "provisioned with DB_NAME='collavre_production'" <<<"$OUT")"
+chk "not an ownership transfer that cannot be done" 0 "$(grep -c 'Move the objects by hand' <<<"$OUT")"
+chk "nor an object count it could not obtain"       0 "$(grep -c 'An unknown number of' <<<"$OUT")"
+chk "and nothing was written"       OLD-PASSWORD "$(cat "$s6b/db_password")"
+rm -rf "$s6b"
 
 echo
 if [ "$fail" = 0 ]; then echo "ALL PASS"; else echo "FAILURES"; fi

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -21,7 +21,7 @@ SRC="${1:-$ROOT/script/lightsail_launch.sh}"
 # die() is a one-liner; the others run to the first column-1 closing brace.
 eval "$(awk '
   /^die\(\) \{/ { print; next }
-  /^(ensure_block|ensure_sudoers|in_group|write_state_file|launch_record_is_complete|record_launch_settings|record_deploy_user_grant|revoke_deploy_user_access|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|install_deploy_ssh_dir|reassign_prior_db_role|refuse_superuser_db_rotation|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps|warn_existing_containers_keep_log_config|dedupe_authorized_keys|install_staged_authorized_keys|postgresql_conf_includes_confd|role_owns_app_objects|refuse_db_name_change|refuse_defaulted_config_change|refuse_unusable_db_identifier|refuse_unparsable_ssh_key|refuse_forced_command_ssh_key|ipv4_dotted_quad|refuse_unusable_bind_address|refuse_unusable_subnet|passwd_home|ssh_key_holder|adopt_legacy_ssh_key_marker|record_db_role_grant|reassign_one_db_role|record_ssh_key_grant|refuse_root_deploy_user|append_state_line|refuse_nologin_deploy_user|resolve_symlink_chain|stage_beside|restore_postgresql_bind_config|stage_authorized_keys|scan_ssh_config_file|find_unsafe_ssh_match|verify_ssh_key_destination|ssh_pattern_list_matches|verify_ssh_admission_controls|verify_ssh_hardening|refuse_unusable_retention|refuse_unusable_backup_calendar|install_managed_config|install_downloaded_file|install_credential_summary|reload_ssh_daemon)\(\) \{/ { f = 1 }
+  /^(ensure_block|ensure_sudoers|in_group|write_state_file|launch_record_is_complete|record_launch_settings|record_deploy_user_grant|revoke_deploy_user_access|revoke_prior_deploy_user|stage_ssh_cutover|ssh_cutover_has_sshd_ancestor|finalize_ssh_cutover|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|install_deploy_ssh_dir|reassign_prior_db_role|refuse_superuser_db_rotation|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps|warn_existing_containers_keep_log_config|dedupe_authorized_keys|install_staged_authorized_keys|postgresql_conf_includes_confd|role_owns_app_objects|refuse_db_name_change|refuse_defaulted_config_change|refuse_unusable_db_identifier|refuse_unparsable_ssh_key|refuse_forced_command_ssh_key|ipv4_dotted_quad|refuse_unusable_bind_address|refuse_unusable_subnet|passwd_home|ssh_key_holder|adopt_legacy_ssh_key_marker|record_db_role_grant|reassign_one_db_role|record_ssh_key_grant|refuse_root_deploy_user|append_state_line|refuse_nologin_deploy_user|resolve_symlink_chain|stage_beside|restore_postgresql_bind_config|stage_authorized_keys|scan_ssh_config_file|find_unsafe_ssh_match|verify_ssh_key_destination|ssh_pattern_list_matches|verify_ssh_admission_controls|verify_ssh_hardening|refuse_unusable_retention|refuse_unusable_backup_calendar|install_managed_config|install_downloaded_file|install_credential_summary|reload_ssh_daemon)\(\) \{/ { f = 1 }
   f { print }
   f && /^\}/ { f = 0 }
 ' "$SRC")"
@@ -30,6 +30,7 @@ for fn in die ensure_block ensure_sudoers in_group write_state_file \
 	  launch_record_is_complete record_launch_settings \
           revoke_prior_deploy_user \
           record_deploy_user_grant revoke_deploy_user_access \
+	  stage_ssh_cutover ssh_cutover_has_sshd_ancestor finalize_ssh_cutover \
           ensure_ufw_rule ssh_already_allowed ensure_ssh_rule \
           install_authorized_keys install_deploy_ssh_dir reassign_prior_db_role \
           refuse_superuser_db_rotation role_owns_app_objects revoke_prior_ssh_key \
@@ -287,11 +288,11 @@ chk "dot sanitized"   "90-collavre-deploy_bot" \
   "$(ls "$d" | grep deploy)"
 chk "no dot in name"  0 "$(ls "$d" | grep -c '\.')"
 
-echo "9. a changed APP_SSH_USER revokes the previous grant"
-# Same reason ensure_block replaces in place: converge the host, do not
-# accumulate. A stale NOPASSWD line is a login that outlives its purpose.
-chk "old user's grant gone" 0 "$(ls "$d" | grep -c 'collavre-collavre')"
-chk "only the current one"  1 "$(ls "$d" | wc -l | tr -d ' ')"
+echo "9. staging a changed APP_SSH_USER preserves the proven grant"
+# The predecessor is removed only by the nonce finalizer reached through the
+# staged account's actual SSH session.
+chk "old user's grant remains" 1 "$(ls "$d" | grep -c 'collavre-collavre')"
+chk "both staged grants remain" 2 "$(ls "$d" | wc -l | tr -d ' ')"
 # An operator's own file is not ours to delete.
 touch "$d/10-operator"
 ensure_sudoers collavre "$d"
@@ -472,7 +473,7 @@ echo "18. and the account it could not strip stays queued for the next run"
 # what case 18a shows losing an account outright on the second rotation.
 chk "still queued for revocation" 1 \
   "$(grep -cxF legacy "$d4/deploy_users")"
-chk "the marker names the account in use" "deploybot" "$(cat "$d4/deploy_user")"
+chk "the committed marker stays on the proven account" "legacy" "$(cat "$d4/deploy_user")"
 usermod() { usermod_host "$@"; }             # the host is healthy again
 revoke deploybot "$d4/deploy_user"           # the retry, on a healthy host
 chk "the retry revokes it"     0 "$(printf '%s\n' "$GROUPS_OF" | tr ' ' '\n' | grep -cxF docker)"
@@ -4065,7 +4066,7 @@ echo "114. the guard is called before anything it protects"
 call_line="$(grep -n '^refuse_defaulted_config_change$' "$SRC" | head -1 | cut -d: -f1)"
 chk "it is called at all"            1 "$([ -n "$call_line" ] && echo 1 || echo 0)"
 for after in 'apt_get update' 'ensure_sudoers "\$APP_SSH_USER"' \
-             'usermod -aG docker' 'revoke_prior_deploy_user "\$APP_SSH_USER"' \
+	     'usermod -aG docker' 'stage_ssh_cutover "\$APP_SSH_USER"' \
              'reassign_prior_db_role "\$DB_USER"'; do
   line="$(grep -n "^$after" "$SRC" | head -1 | cut -d: -f1)"
   chk "before ${after%% *}" 1 \
@@ -4193,7 +4194,7 @@ echo "117. the grant is recorded before it is made, not after"
 rec_line="$(grep -n '^record_deploy_user_grant "\$APP_SSH_USER"' "$SRC" | head -1 | cut -d: -f1)"
 chk "it is called at all"                 1 "$([ -n "$rec_line" ] && echo 1 || echo 0)"
 for after in 'usermod -aG sudo "\$APP_SSH_USER"' 'usermod -aG docker "\$APP_SSH_USER"' \
-             'revoke_prior_deploy_user "\$APP_SSH_USER"'; do
+	     'stage_ssh_cutover "\$APP_SSH_USER"'; do
   line="$(grep -n "^$after" "$SRC" | head -1 | cut -d: -f1)"
   chk "before ${after%% \"*}" 1 \
     "$([ -n "$line" ] && [ "$rec_line" -lt "$line" ] && echo 1 || echo 0)"
@@ -4410,7 +4411,6 @@ echo "119b. it is called before anything that could leave the account keyless"
 grd_line="$(grep -n '^refuse_unparsable_ssh_key$' "$SRC" | head -1 | cut -d: -f1)"
 chk "the guard is called at all"           1 "$([ -n "$grd_line" ] && echo 1 || echo 0)"
 for after in 'install_authorized_keys "\$AUTH_KEYS"' \
-             'revoke_prior_ssh_key "\$AUTH_KEYS"' \
              'dedupe_authorized_keys "\$AUTH_KEYS"' \
              'apt_get update' 'usermod -aG docker'; do
   line="$(grep -n "^$after" "$SRC" | head -1 | cut -d: -f1)"
@@ -6762,15 +6762,16 @@ echo "157. the credential summary is installed atomically"
 chk "the live summary is never the rendering target" 0 \
   "$(grep -cE '^render_summary "\$DATABASE_URL" > "\$SUMMARY"$' "$SRC")"
 chk "the rendered summary goes through its staging installer" 1 \
-  "$(grep -c '^install_credential_summary "\$DATABASE_URL"$' "$SRC")"
+  "$(grep -c '^install_credential_summary "\$DATABASE_URL" ' "$SRC")"
 summary_dir="$(mktemp -d)"
 SUMMARY="$summary_dir/summary"
 APP_SSH_USER=deploybot
+ACTIVE_DEPLOY_USER=deploybot
 printf 'previous complete summary\n' > "$SUMMARY"
 chmod 0644 "$SUMMARY"
 summary_inode="$(inode "$SUMMARY")"
 render_summary() {
-  printf '  KAMAL_SSH_USER=%s\n' "$APP_SSH_USER"
+  printf '  KAMAL_SSH_USER=%s\n' "$ACTIVE_DEPLOY_USER"
   case "${SUMMARY_RENDER_MODE:-whole}" in
     fail) return 1 ;;
   esac
@@ -6940,6 +6941,78 @@ chk "and only then consumes it" 0 \
   "$([ -e "$pg_rollback_dir/backup" ] && echo 1 || echo 0)"
 unset -f systemctl
 rm -rf "$pg_rollback_dir"
+
+echo "160. SSH cutover is committed only from the staged account's SSH session"
+chk "normal provisioning never revokes a deploy predecessor directly" 0 \
+  "$(grep -c '^revoke_prior_deploy_user "\$APP_SSH_USER"$' "$SRC")"
+chk "normal provisioning never withdraws a predecessor key directly" 0 \
+  "$(grep -c '^revoke_prior_ssh_key "\$AUTH_KEYS"$' "$SRC")"
+chk "the staged account creates one pending cutover" 1 \
+  "$(grep -c '^stage_ssh_cutover "\$APP_SSH_USER" "\$SSH_PUBLIC_KEY"$' "$SRC")"
+chk "the finalizer requires the sudo origin to be the staged account" 1 \
+  "$(grep -cF '[ "${SUDO_USER:-}" = "$user" ] ||' "$SRC")"
+chk "and requires an sshd process ancestor" 1 \
+  "$(grep -c '^  ssh_cutover_has_sshd_ancestor "\$user" ||$' "$SRC")"
+chk "the runbook changes KAMAL_SSH_USER only after finalization" 1 \
+  "$(grep -c 'Change `KAMAL_SSH_USER` only after' "$DOC")"
+
+cutover_state="$(mktemp -d)"
+cutover_finalizer="$cutover_state/finalizer"
+STATE_DIR="$cutover_state"
+SSH_CUTOVER_PENDING=0
+SSH_CUTOVER_NONCE=''
+stage_ssh_cutover deploybot 'ssh-ed25519 STAGED operator' \
+  "$cutover_finalizer" "$SRC"
+chk "staging creates a root-only pending record" 600 \
+  "$(file_mode "$cutover_state/ssh_cutover.pending")"
+chk "and a root-only exact key record" 600 \
+  "$(file_mode "$cutover_state/ssh_cutover.key")"
+chk "and installs the finalizer" 755 "$(file_mode "$cutover_finalizer")"
+chk "without committing the deploy user" 0 \
+  "$([ -e "$cutover_state/deploy_user" ] && echo 1 || echo 0)"
+cutover_nonce="$SSH_CUTOVER_NONCE"
+
+mkdir -p "$cutover_state/home/.ssh"
+printf '%s\n' 'ssh-ed25519 STAGED operator' \
+  > "$cutover_state/home/.ssh/authorized_keys"
+getent() { printf 'deploybot:x:1001:1001::%s/home:/bin/bash\n' "$cutover_state"; }
+id() {
+  case "$1" in
+    -gn) printf 'deploybot\n' ;;
+    *) return 0 ;;
+  esac
+}
+in_group() { return 0; }
+ssh_cutover_has_sshd_ancestor() {
+  [ "$1" = deploybot ] && [ "${SSH_PROOF:-0}" -eq 1 ]
+}
+revoke_prior_ssh_key() {
+  TRACE="${TRACE}key "
+  write_state_file "$STATE_DIR/ssh_public_key.deploybot" \
+    'ssh-ed25519 STAGED operator'$'\n'
+}
+revoke_prior_deploy_user() {
+  TRACE="${TRACE}account "
+  write_state_file "$STATE_DIR/deploy_user" "deploybot"$'\n'
+}
+TRACE=''
+( SUDO_USER=someone-else SSH_PROOF=1 \
+    finalize_ssh_cutover "$cutover_nonce" ) >/dev/null 2>&1
+chk "a different sudo origin is refused" 1 "$?"
+chk "and revokes nothing" "" "$TRACE"
+( SUDO_USER=deploybot SSH_PROOF=0 \
+    finalize_ssh_cutover "$cutover_nonce" ) >/dev/null 2>&1
+chk "a local or console shell is refused" 1 "$?"
+chk "and still revokes nothing" "" "$TRACE"
+SUDO_USER=deploybot SSH_PROOF=1 finalize_ssh_cutover "$cutover_nonce" >/dev/null
+chk "an authenticated SSH proof commits key then account" "key account " "$TRACE"
+chk "and consumes the pending state" 0 \
+  "$([ -e "$cutover_state/ssh_cutover.pending" ] && echo 1 || echo 0)"
+chk "and commits the staged account" deploybot \
+  "$(cat "$cutover_state/deploy_user")"
+unset -f getent id in_group ssh_cutover_has_sshd_ancestor \
+  revoke_prior_ssh_key revoke_prior_deploy_user
+rm -rf "$cutover_state"
 
 echo
 if [ "$fail" = 0 ]; then echo "ALL PASS"; else echo "FAILURES"; fi

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -21,7 +21,7 @@ SRC="${1:-$ROOT/script/lightsail_launch.sh}"
 # die() is a one-liner; the others run to the first column-1 closing brace.
 eval "$(awk '
   /^die\(\) \{/ { print; next }
-  /^(ensure_block|ensure_sudoers|in_group|write_state_file|record_deploy_user_grant|revoke_deploy_user_access|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|install_deploy_ssh_dir|reassign_prior_db_role|refuse_superuser_db_rotation|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps|dedupe_authorized_keys|install_staged_authorized_keys|postgresql_conf_includes_confd|role_owns_app_objects|refuse_db_name_change|refuse_defaulted_config_change|refuse_unusable_db_identifier|refuse_unparsable_ssh_key|passwd_home|ssh_key_holder|adopt_legacy_ssh_key_marker|record_db_role_grant|reassign_one_db_role|record_ssh_key_grant|refuse_root_deploy_user)\(\) \{/ { f = 1 }
+  /^(ensure_block|ensure_sudoers|in_group|write_state_file|record_deploy_user_grant|revoke_deploy_user_access|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|install_deploy_ssh_dir|reassign_prior_db_role|refuse_superuser_db_rotation|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps|dedupe_authorized_keys|install_staged_authorized_keys|postgresql_conf_includes_confd|role_owns_app_objects|refuse_db_name_change|refuse_defaulted_config_change|refuse_unusable_db_identifier|refuse_unparsable_ssh_key|passwd_home|ssh_key_holder|adopt_legacy_ssh_key_marker|record_db_role_grant|reassign_one_db_role|record_ssh_key_grant|refuse_root_deploy_user|append_state_line|refuse_nologin_deploy_user)\(\) \{/ { f = 1 }
   f { print }
   f && /^\}/ { f = 0 }
 ' "$SRC")"
@@ -39,7 +39,7 @@ for fn in die ensure_block ensure_sudoers in_group write_state_file \
           refuse_unusable_db_identifier refuse_unparsable_ssh_key \
           passwd_home ssh_key_holder \
           record_db_role_grant reassign_one_db_role record_ssh_key_grant \
-          refuse_root_deploy_user \
+          refuse_root_deploy_user append_state_line refuse_nologin_deploy_user \
           adopt_legacy_ssh_key_marker; do
   declare -F "$fn" >/dev/null || {
     echo "could not extract $fn() from $SRC — has the definition moved?" >&2
@@ -4364,6 +4364,161 @@ chk "db_user is not written by redirection" \
   0 "$(grep -c '> *"\$STATE_DIR/db_user"' "$SRC")"
 chk "both go through write_state_file" \
   2 "$(grep -cE 'write_state_file "\$STATE_DIR/db_(name|user)"' "$SRC")"
+
+echo "125. a torn queue append does not swallow the next value onto its line"
+# The last write in this script that was not going through write_state_file, and
+# the one it was introduced for. `grep -qxF x || printf '%s\n' x >> f` leaves a
+# fragment with no newline when the append is cut short, and the *retry* is what
+# does the damage: grep does not match the fragment, so the full value lands on
+# the end of it and the queue holds one line that is neither.
+#
+# The fragment is injected rather than provoked. RLIMIT_FSIZE and ENOSPC both
+# produce it, but neither is reachable from this harness on the maintainer's
+# machine (`ulimit -f` would not cap an append here), and the partial write is
+# not the claim — what the retry does to it is. Same reasoning as case 4a.
+sd=$(mktemp -d)
+KEYB="ssh-rsa AAAAB3NzaC1yc2ETESTKEYBBBBBBBBBBBBBBBBBBBBBBBBBBBB deploy@b"
+printf 'ssh-rsa AAAAB3NzaC1yc2ETESTKEYAAAAAAAAAAAAAAAAAAAAAAAAAAAA deploy@a\n' \
+  > "$sd/q"
+printf '%s' "${KEYB:0:30}" >> "$sd/q"          # <- the torn append
+append_state_line "$sd/q" "$KEYB"
+chk "the recorded value gets a whole line of its own" \
+  1 "$(grep -cxF "$KEYB" "$sd/q")"
+chk "the fragment is terminated, not extended" \
+  0 "$(grep -c "^${KEYB:0:30}${KEYB:0:4}" "$sd/q")"
+chk "the value already present is not duplicated" \
+  1 "$(append_state_line "$sd/q" "$KEYB"; grep -cxF "$KEYB" "$sd/q")"
+# The control in the other direction: a queue that was never torn must come out
+# byte-identical, since this runs on every convergence and a helper that
+# rewrote every entry would churn a file three rotations depend on.
+printf 'a\nb\n' > "$sd/q2"; before=$(cat "$sd/q2")
+append_state_line "$sd/q2" b
+chk "an entry already queued rewrites nothing" "$before" "$(cat "$sd/q2")"
+append_state_line "$sd/q2" c
+chk "and a new entry is appended in order"     "a b c" "$(tr '\n' ' ' < "$sd/q2" | sed 's/ $//')"
+# A failed write must leave the previous queue readable: a truncated queue is
+# how a root-equivalent key stops being named by anything.
+mktemp() { return 1; }
+append_state_line "$sd/q2" d
+chk "a failed queue write reports it"          1 "$?"
+chk "and the queue is still readable"          "a b c" "$(tr '\n' ' ' < "$sd/q2" | sed 's/ $//')"
+unset -f mktemp
+rm -rf "$sd"
+# Source-level control. append_state_line is new, so the behavioural assertions
+# above cannot fail against 6125e4ee — the suite would stop at its extraction
+# check. The regression that can recur is a record_* function going back to a
+# bare append, which is invisible until a write is cut short.
+# Verified to read 3 against 6125e4ee and 0 here. Worth saying, because the
+# first spelling of this pattern had one `.` too many and matched nothing in
+# *either* revision — a zero-expectation assertion that an empty result
+# satisfies silently, which is the same trap case 78b's dotenv control exists
+# for.
+chk "no queue is extended by a bare append" \
+  0 "$(grep -cE 'printf .%s.n. "\$(user|role|key)" >> "\$set_file"' "$SRC")"
+chk "all three record_* functions go through the helper" \
+  3 "$(grep -c 'append_state_line "\$set_file"' "$SRC")"
+
+echo "126. a deploy account that cannot run a command is refused"
+# refuse_root_deploy_user states this invariant and tests only UID 0: its own
+# message is "'$user' could never log in, while the summary would still print
+# KAMAL_SSH_USER", which is true word for word of /usr/sbin/nologin. Measured
+# against 6125e4ee, 'nobody' and 'daemon' both PROCEED.
+fakebin=$(mktemp -d)
+printf '#!/bin/sh\necho "This account is currently not available."\nexit 1\n' \
+  > "$fakebin/nologin"
+printf '#!/bin/sh\nexit 1\n' > "$fakebin/false"
+chmod +x "$fakebin/nologin" "$fakebin/false"
+# shellcheck disable=SC2329  # called by refuse_nologin_deploy_user
+shell_of() {
+  case "$1" in
+    nobody) echo "$fakebin/nologin" ;; svc) echo "$fakebin/false" ;;
+    ghost) echo "" ;; gone) echo /opt/removed-shell ;; *) echo /bin/sh ;;
+  esac
+}
+# shellcheck disable=SC2329
+getent() { printf '%s:x:1000:1000::/home/%s:%s\n' "$2" "$2" "$(shell_of "$2")"; }
+# shellcheck disable=SC2329
+id() { [ "$2" = brandnew ] && return 1; echo 1000; }
+for u in nobody svc gone ghost; do
+  out="$( (refuse_nologin_deploy_user "$u") 2>&1 )"
+  chk "'$u' is refused" 1 "$?"
+  case "$out" in
+    *"Nothing has been changed"*) echo "  ok   '$u': and says nothing was changed" ;;
+    *) echo "  FAIL '$u': did not say the host is unchanged: $out"; fail=1 ;;
+  esac
+done
+out="$( (refuse_nologin_deploy_user nobody) 2>&1 )"
+case "$out" in
+  *KAMAL_SSH_USER*usermod*) echo "  ok   names both the symptom and the remedy" ;;
+  *) echo "  FAIL does not name KAMAL_SSH_USER and usermod: $out"; fail=1 ;;
+esac
+# The controls, and they are the ones that matter: this guard runs on every
+# invocation before anything is installed, so a false positive refuses every
+# run — a worse defect than the one being fixed. Same shape as 123a.
+refuse_nologin_deploy_user collavre
+chk "an ordinary account proceeds"              0 "$?"
+refuse_nologin_deploy_user brandnew
+chk "an account that does not exist yet proceeds" 0 "$?"
+unset -f getent id shell_of
+rm -rf "$fakebin"
+chk "the guard runs beside the UID 0 one, before anything is installed" \
+  1 "$(grep -c '^refuse_nologin_deploy_user "\$APP_SSH_USER"' "$SRC")"
+
+echo "127. the backup executable is staged and validated, never truncated live"
+# The generated file is *executable*, which makes truncation quieter than it is
+# for a config file: a stump is not a file that fails to load, it is a shorter
+# program that runs. Of the 1233 truncation points of the generated script, 624
+# parse and 153 exit 0 without ever reaching pg_dump — and those 153 are the
+# first 310 bytes, so an early interruption lands there. `cat >` leaves the mode
+# alone and `chmod 0755` was the next statement, so on a re-converge the stump
+# stays executable while the timer stays enabled: green nightly runs, no dumps.
+bd=$(mktemp -d)
+seed_backup() {
+  printf '#!/usr/bin/env bash\n# PREVIOUS GOOD BACKUP\nexit 7\n' > "$bd/collavre-pg-backup"
+  chmod 0755 "$bd/collavre-pg-backup"
+}
+run_backup_section() {
+  awk '/^BACKUP_TMP="\$\(mktemp/{p=1} p{print} /^mv -f "\$BACKUP_TMP"/{exit}' "$SRC" \
+    | sed "s#/usr/local/bin/collavre-pg-backup#\$BIN/collavre-pg-backup#g" > "$bd/sect.sh"
+  { printf '%s\n' 'set -euo pipefail' \
+      'die() { printf "DIE: %s\n" "$*"; exit 1; }' \
+      'BIN="$1"; DB_NAME=collavre_production; BACKUP_RETENTION_DAYS=14' \
+      'BACKUP_S3_URI=""; DB_PORT=5432' \
+      'mktemp() { command mktemp "${1/\/usr\/local\/bin/$BIN}"; }'
+    [ -n "${1:-}" ] && printf '%s\n' "$1"
+    cat "$bd/sect.sh"
+  } > "$bd/run.sh"
+  bash "$bd/run.sh" "$bd" 2>&1
+}
+seed_backup
+run_backup_section >/dev/null
+chk "a clean run installs the whole script" \
+  1 "$(grep -c 'pg_dump' "$bd/collavre-pg-backup")"
+chk "and it is executable"          755 "$(file_mode "$bd/collavre-pg-backup")"
+# Injected, not raced: a write that stops partway is the modelled failure and a
+# kill loses to a fast local write, as case 4a records.
+seed_backup
+out=$(run_backup_section 'cat() { head -c 200; return 1; }')
+chk "a write cut short refuses"     1 "$(printf '%s' "$out" | grep -c '^DIE:')"
+chk "and the previous backup script is still the live one" \
+  1 "$(grep -c 'PREVIOUS GOOD BACKUP' "$bd/collavre-pg-backup")"
+chk "and no staging file is left behind" \
+  0 "$(find "$bd" -name 'collavre-pg-backup.*' | wc -l | tr -d ' ')"
+seed_backup
+# A value that closes the quote the template opens, so the generated file is
+# genuinely unparseable rather than merely odd-looking. My first attempt used
+# `collavre ) unbalanced`, which lands inside the quotes and parses fine — the
+# case passed nothing and said so. refuse_unusable_db_identifier rejects such a
+# DB_NAME long before this point in a real run; this check is what stands behind
+# it, and behind every future value interpolated into a generated program.
+out=$(run_backup_section 'DB_NAME='"'"'x"; ) ; #'"'"'')
+chk "a generated script that is not valid shell refuses" \
+  1 "$(printf '%s' "$out" | grep -c '^DIE:')"
+chk "and the previous backup script survives that too" \
+  1 "$(grep -c 'PREVIOUS GOOD BACKUP' "$bd/collavre-pg-backup")"
+rm -rf "$bd"
+chk "the live backup path is not written by redirection" \
+  0 "$(grep -c '^cat > /usr/local/bin/collavre-pg-backup' "$SRC")"
 
 echo
 if [ "$fail" = 0 ]; then echo "ALL PASS"; else echo "FAILURES"; fi

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -5666,6 +5666,8 @@ bindguard 10.0.0.5
 chk "and any other dotted quad"                        0 "$bind_rc"
 bindguard 1.2.3.4
 chk "including one this host does not hold"            0 "$bind_rc"
+bindguard 0.0.0.0
+chk "the unspecified address unusable from the container is refused" 1 "$bind_rc"
 bindguard 127.0.0.1
 chk "a loopback address unusable from the container is refused" 1 "$bind_rc"
 bindguard 127.255.255.254

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -2836,8 +2836,16 @@ PRIOR_LIMIT=0 LIVE=0 KILLED=0 FAIL_RESTORE='' run_restore
 chk "restore ran"                  1 "$(grep -cx 'PG_RESTORE_RAN' <<<"${R_TRACE//|/$'\n'}")"
 chk "left as the operator had it"  0 "$R_LIMIT"
 chk "NOT told to boot"             0 "$(grep -c 'app boot' <<<"$R_OUT")"
-chk "told the limit predates this" 1 \
-  "$(grep -c 'not something left behind here' <<<"$R_OUT")"
+# Not "the limit predates this block" any more, and the change is the point. The
+# block used to assert that flatly; it cannot, since a failed attempt leaves 0
+# behind and a retry from a fresh shell reads that 0 as the previous limit. So
+# the two halves are asserted separately: where the value came from, and that
+# the one reading which would make it this block's own leftover is named rather
+# than argued away.
+chk "told where the 0 came from"   1 \
+  "$(grep -c 'carried when this block read it' <<<"$R_OUT")"
+chk "and that a retry can be its source" 1 \
+  "$(grep -c "previous attempt failed" <<<"$R_OUT")"
 chk "and how to lift it"           1 \
   "$(grep -cF "'ALTER DATABASE \"collavre_production\" CONNECTION LIMIT -1'" <<<"$R_OUT")"
 # Not a failure report: nothing failed, and RESTORE FAILED here would send the
@@ -4848,6 +4856,144 @@ chk "no configured value is spliced into the generated script" 0 \
   "$(grep -cE '^(DB_NAME="\$DB_NAME"|RETENTION_DAYS=\$BACKUP_RETENTION_DAYS|S3_URI="\$BACKUP_S3_URI")$' "$SRC")"
 chk "they are serialized with %q instead" 1 \
   "$(grep -c "printf 'DB_NAME=%q" "$SRC")"
+
+
+# log() is redefined per region above and the nearest one accumulates into
+# $LOGGED rather than printing. These three cases assert on what the run *says*,
+# so it has to print — without this the message assertions below pass on an
+# empty capture, which is the failure mode a negative control exists to catch.
+log() { echo "[log] $*"; }
+
+echo "134. a create of daemon.json that is cut short never reaches the live path"
+# The rewrite path was staged earlier on this branch; the create path below it
+# was not, and it is the one a first-time provision takes. `cat > "$file"` opens
+# the live path with O_TRUNC, so a write that fails leaves a partial daemon.json
+# that no later run repairs — the retry finds the file present and takes the
+# rewrite path, where every branch declines to touch it.
+dj=$(mktemp -d)
+# The staged write is cut short by shadowing `cat` for one call, injected rather
+# than raced: a kill loses to a fast local write, and a flaky control is worse
+# than none.
+torn_create() {  # $1 = bytes of the write that survive
+  ( KEEP=$1
+    cat() { command head -c "$KEEP" 2>/dev/null; }
+    ensure_docker_log_caps "$dj/daemon.json" >/dev/null 2>&1 )
+}
+torn_create 0
+chk "a torn create leaves no live daemon.json" 0 \
+  "$([ -e "$dj/daemon.json" ] && echo 1 || echo 0)"
+chk "and no staging file behind either" 0 \
+  "$(find "$dj" -name '*.collavre.*' | wc -l | tr -d ' ')"
+# The retry is the assertion that matters: against the old form this is where
+# the run gives up for good.
+ensure_docker_log_caps "$dj/daemon.json" >/dev/null 2>&1
+chk "so the next run creates it whole" '10m' \
+  "$(jq -r '."log-opts"."max-size" // "NONE"' "$dj/daemon.json" 2>/dev/null || echo UNPARSEABLE)"
+# 0644, not mktemp's 0600. A daemon.json dockerd cannot read is the same outage
+# by another route, which is why stage_beside refuses rather than narrowing it.
+chk "at the mode the old form produced" 644 "$(file_mode "$dj/daemon.json")"
+# The read side, for hosts already carrying the damage: an empty daemon.json is
+# the one size the rewrite path cannot see, since `jq empty` exits 0 on it and
+# the driver query returns "" rather than the default — so the old form reported
+# an operator who chose another driver over a host with uncapped logs.
+: > "$dj/empty.json"
+ej="$(ensure_docker_log_caps "$dj/empty.json" 2>&1)"
+chk "an empty daemon.json is not read as a driver choice" 0 \
+  "$(grep -c 'rotates on its own' <<<"$ej")"
+chk "it is named as an interrupted create" 1 \
+  "$(grep -c 'exists but is empty' <<<"$ej")"
+chk "and the caps are put in" '10m' \
+  "$(jq -r '."log-opts"."max-size" // "NONE"' "$dj/empty.json" 2>/dev/null || echo UNPARSEABLE)"
+# The control the empty case must not widen into: a partial file may hold half
+# of an operator's configuration, nothing tells it apart from one this script
+# tore, and it is still left exactly as it is.
+printf '{"insecure-regist' > "$dj/partial.json"
+pj="$(ensure_docker_log_caps "$dj/partial.json" 2>&1)"
+chk "a partial daemon.json is still left alone" 1 \
+  "$(grep -c 'not valid JSON' <<<"$pj")"
+chk "and not rewritten" '{"insecure-regist' "$(cat "$dj/partial.json")"
+rm -rf "$dj"
+chk "the create is not written by redirection" 0 \
+  "$(grep -cE '^    cat > "\$file" <<' "$SRC")"
+
+echo "135. no key to install is a refusal, not a completed run"
+# The contract above install_authorized_keys says non-zero aborts the run. A
+# `for` loop whose every iteration took the `continue` completes with status 0,
+# so the one path where nothing could be installed was the one reporting
+# success — and the steps after it put the account in docker and sudoers.
+kd=$(mktemp -d); mkdir -p "$kd/home"
+: > "$kd/authorized_keys"
+( SSH_PUBLIC_KEY=''; install_authorized_keys "$kd/authorized_keys" "$kd/home" ) >/dev/null 2>&1
+chk "nothing to install reports failure" 1 "$?"
+# The control in the other direction, and the one that constrains the fix: this
+# runs on every convergence, so refusing a host whose cloud user was renamed
+# away but whose authorized_keys is already populated would take down every
+# re-run on a host that works.
+printf 'ssh-ed25519 AAAAOPS ops@laptop\n' > "$kd/authorized_keys"
+kout=$( SSH_PUBLIC_KEY=''; install_authorized_keys "$kd/authorized_keys" "$kd/home" 2>&1 )
+chk "an already-populated file is left alone" 0 "$?"
+chk "and the run says why it did nothing" 1 \
+  "$(grep -c 'already authorizes someone' <<<"$kout")"
+chk "the key it had is untouched" 1 "$(grep -c 'AAAAOPS' "$kd/authorized_keys")"
+# And the ordinary path is unchanged.
+mkdir -p "$kd/home/ubuntu/.ssh"
+printf 'ssh-ed25519 AAAACLOUD cloud\n' > "$kd/home/ubuntu/.ssh/authorized_keys"
+: > "$kd/authorized_keys"
+( SSH_PUBLIC_KEY=''; install_authorized_keys "$kd/authorized_keys" "$kd/home" ) >/dev/null 2>&1
+chk "a cloud user's keys are still copied" 0 "$?"
+chk "and land in the file" 1 "$(grep -c 'AAAACLOUD' "$kd/authorized_keys")"
+rm -rf "$kd"
+# Source-level: the call site acts on the status rather than leaving it to
+# errexit, which would abort with nothing said about the account holding sudo.
+chk "the call site names the account it aborts over" 1 \
+  "$(grep -c 'no SSH key could be installed' "$SRC")"
+
+echo "136. the Docker plugins are installed on a host that already has docker"
+# The plugin install sat inside `if ! command -v docker`, unreachable on the one
+# host that needs it named separately: the documented by-hand run on an existing
+# instance carrying Ubuntu's docker.io. The runbook promises buildx for the
+# remote builder, so the first `builder.remote` Kamal build fails on a host this
+# script reported as converged.
+docker_step() {  # DOCKER_PRESENT / BUILDX_OK / COMPOSE_OK are read from the env
+  ( set +u
+    log(){ printf 'LOG: %s\n' "$*"; }
+    install(){ :; }; curl(){ :; }; chmod(){ :; }; apt_get(){ :; }
+    dpkg(){ echo amd64; }; VERSION_CODENAME=noble
+    apt_install(){ printf 'INSTALL:%s\n' "$*"; }
+    command(){
+      if [ "${1:-}" = -v ] && [ "${2:-}" = docker ]; then
+        [ "$DOCKER_PRESENT" = yes ]; return $?
+      fi
+      builtin command "$@"
+    }
+    docker(){
+      [ "${1:-}" = buildx ]  && { [ "$BUILDX_OK" = yes ];  return $?; }
+      [ "${1:-}" = compose ] && { [ "$COMPOSE_OK" = yes ]; return $?; }
+      return 0
+    }
+    . "$td/step.sh" 2>/dev/null ) | grep '^INSTALL:' | sed 's/^INSTALL://'
+}
+td=$(mktemp -d)
+# The step is top-level code rather than a function, so it is taken from $SRC by
+# its banner and the comment that follows it rather than through the extraction
+# above. An empty extraction would make every row read "installs nothing", which
+# is a real answer for one of them — so the extraction is asserted first.
+awk '/^log "4\/9 Docker CE"/{p=1} /^# Cap container logs/{exit} p{print}' "$SRC" > "$td/step.sh"
+chk "the Docker step was extracted" 1 "$(grep -c 'apt_install' "$td/step.sh")"
+chk "a fresh host installs the whole set" \
+  'docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin' \
+  "$(DOCKER_PRESENT=no BUILDX_OK=no COMPOSE_OK=no docker_step)"
+# The control that constrains the fix: this runs on every convergence, so a
+# converged host must come out of it with nothing to do.
+chk "a host with both plugins installs nothing" '' \
+  "$(DOCKER_PRESENT=yes BUILDX_OK=yes COMPOSE_OK=yes docker_step)"
+chk "docker.io without buildx gets buildx" 'docker-buildx-plugin' \
+  "$(DOCKER_PRESENT=yes BUILDX_OK=no COMPOSE_OK=yes docker_step)"
+chk "and without either gets both" 'docker-buildx-plugin docker-compose-plugin' \
+  "$(DOCKER_PRESENT=yes BUILDX_OK=no COMPOSE_OK=no docker_step)"
+rm -rf "$td"
+chk "the plugins are not gated on the docker binary" 0 \
+  "$(grep -cE 'apt_install docker-ce docker-ce-cli containerd.io' "$SRC")"
 
 
 echo

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -17,12 +17,12 @@ SRC="${1:-$ROOT/script/lightsail_launch.sh}"
 # die() is a one-liner; the others run to the first column-1 closing brace.
 eval "$(awk '
   /^die\(\) \{/ { print; next }
-  /^(ensure_block|ensure_sudoers)\(\) \{/ { f = 1 }
+  /^(ensure_block|ensure_sudoers|revoke_prior_deploy_user)\(\) \{/ { f = 1 }
   f { print }
   f && /^\}/ { f = 0 }
 ' "$SRC")"
 
-for fn in die ensure_block ensure_sudoers; do
+for fn in die ensure_block ensure_sudoers revoke_prior_deploy_user; do
   declare -F "$fn" >/dev/null || {
     echo "could not extract $fn() from $SRC — has the definition moved?" >&2
     exit 1
@@ -149,6 +149,67 @@ case "$out" in
   *) echo "  FAIL unhelpful message: $out"; fail=1 ;;
 esac
 unset -f visudo
+
+# --------------------------------------------------------------------------
+# revoke_prior_deploy_user talks to the host account database, so `id` and
+# `gpasswd` are stubbed. Shell functions shadow both, and `log` is captured
+# rather than printed so the warning can be asserted on.
+# --------------------------------------------------------------------------
+ACCOUNT=""      # the only user that exists, and its groups
+GROUPS_OF=""
+REVOKED=""      # every gpasswd -d, as "user/group"
+LOGGED=""
+id() {
+  case "$1" in
+    -u)  [ "$2" = "$ACCOUNT" ] ;;
+    -nG) [ "$2" = "$ACCOUNT" ] || return 1; printf '%s\n' "$GROUPS_OF" ;;
+    *)   return 1 ;;
+  esac
+}
+gpasswd() { REVOKED="$REVOKED $2/$3"; }
+log() { LOGGED="$LOGGED $*"; }
+revoke() { REVOKED=""; LOGGED=""; revoke_prior_deploy_user "$@"; }
+
+echo "11. the deploy user a re-run replaces loses its root-equivalent access"
+# Docker membership is the point: ensure_sudoers takes back the NOPASSWD file,
+# and without this the replaced account keeps a shorter road to root than the
+# one that was just revoked.
+d=$(mktemp -d); printf 'collavre\n' > "$d/deploy_user"
+ACCOUNT=collavre; GROUPS_OF="collavre docker sudo"
+revoke deploybot "$d/deploy_user"
+chk "docker and sudo revoked" " collavre/docker collavre/sudo" "$REVOKED"
+case "$LOGGED" in
+  *"can still log in"*) echo "  ok   names the account it did not delete" ;;
+  *) echo "  FAIL no warning about the surviving account: $LOGGED"; fail=1 ;;
+esac
+
+echo "12. an unchanged deploy user is left exactly as it is"
+# The common re-run. Revoking here would lock the operator out of their own
+# host on every FORCE=1.
+revoke collavre "$d/deploy_user"
+chk "nothing revoked" "" "$REVOKED"
+chk "nothing warned"  "" "$LOGGED"
+
+echo "13. only the groups the user actually has are touched"
+# gpasswd -d on a non-member fails; firing it anyway would put a spurious
+# error in a provisioning log that operators read for real ones.
+ACCOUNT=collavre; GROUPS_OF="collavre docker"
+revoke deploybot "$d/deploy_user"
+chk "docker only" " collavre/docker" "$REVOKED"
+
+echo "14. a first run, an emptied marker and a deleted account are all no-ops"
+d2=$(mktemp -d)
+revoke collavre "$d2/deploy_user"          # no marker yet
+chk "no marker"        "" "$REVOKED$LOGGED"
+: > "$d2/deploy_user"
+revoke collavre "$d2/deploy_user"          # marker exists but is empty
+chk "empty marker"     "" "$REVOKED$LOGGED"
+printf 'collavre\n' > "$d2/deploy_user"
+ACCOUNT=""                                  # already deluser'd by hand
+revoke deploybot "$d2/deploy_user"
+chk "account is gone"  "" "$REVOKED$LOGGED"
+
+unset -f id gpasswd log revoke
 
 echo
 if [ "$fail" = 0 ]; then echo "ALL PASS"; else echo "FAILURES"; fi

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -21,7 +21,7 @@ SRC="${1:-$ROOT/script/lightsail_launch.sh}"
 # die() is a one-liner; the others run to the first column-1 closing brace.
 eval "$(awk '
   /^die\(\) \{/ { print; next }
-  /^(ensure_block|ensure_sudoers|in_group|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|reassign_prior_db_role|revoke_prior_ssh_key|ensure_cluster_on_default_port)\(\) \{/ { f = 1 }
+  /^(ensure_block|ensure_sudoers|in_group|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|reassign_prior_db_role|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile)\(\) \{/ { f = 1 }
   f { print }
   f && /^\}/ { f = 0 }
 ' "$SRC")"
@@ -29,7 +29,7 @@ eval "$(awk '
 for fn in die ensure_block ensure_sudoers in_group revoke_prior_deploy_user \
           ensure_ufw_rule ssh_already_allowed ensure_ssh_rule \
           install_authorized_keys reassign_prior_db_role revoke_prior_ssh_key \
-          ensure_cluster_on_default_port; do
+          ensure_cluster_on_default_port ensure_swapfile; do
   declare -F "$fn" >/dev/null || {
     echo "could not extract $fn() from $SRC — has the definition moved?" >&2
     exit 1
@@ -993,6 +993,136 @@ chk "and says nothing"              "" "$out"
 mk_lsclusters pg_ls_both "$(printf '17  main    5432 online postgres /a /b\n16  main    5433 online postgres /c /d')"
 out="$( (ensure_cluster_on_default_port pg_ls_both) 2>&1 )"
 chk "ours on 5432 beside an idle old one: proceeds" 0 "$?"
+
+# --------------------------------------------------------------------------
+# ensure_swapfile. swapon/swapoff/mkswap are stubbed and the swap file is an
+# ordinary file in a temp dir, so the size on disk is what the function reads —
+# the real thing it compares against SWAP_SIZE_MB.
+#
+# SWAPPED_ON is the kernel's view; the stubs mutate it, so "did the size change"
+# and "is it still enabled" are separate assertions rather than one.
+# --------------------------------------------------------------------------
+SWAPPED_ON=""
+SWAPOFF_FAILS=""
+# shellcheck disable=SC2329  # called by ensure_swapfile, eval'd from the script
+swapon() {
+  if [ "${1:-}" = --show=NAME ]; then printf '%s\n' "$SWAPPED_ON"; return 0; fi
+  SWAPPED_ON="$1"
+}
+# shellcheck disable=SC2329  # called by ensure_swapfile, eval'd from the script
+swapoff() { [ -z "$SWAPOFF_FAILS" ] || return 1; SWAPPED_ON=""; return 0; }
+# shellcheck disable=SC2329  # called by ensure_swapfile, eval'd from the script
+mkswap() { :; }
+# shellcheck disable=SC2329  # called by ensure_swapfile, eval'd from the script
+fallocate() { : > "$3"; dd if=/dev/zero of="$3" bs=1048576 count="${2%M}" status=none 2>/dev/null; }
+LOGGED=""
+# shellcheck disable=SC2329  # called by ensure_swapfile, eval'd from the script
+log() { LOGGED="$LOGGED $*"; }
+swap_mib() { echo $(( $(stat -c %s "$1" 2>/dev/null || stat -f %z "$1") / 1048576 )); }
+
+new_swap_env() {   # <existing-MiB>  ("" for no file)
+  d=$(mktemp -d); SWAPFILE="$d/swapfile"; FSTAB="$d/fstab"
+  printf 'UUID=xxx / ext4 defaults 0 1\n' > "$FSTAB"
+  if [ -n "$1" ]; then
+    dd if=/dev/zero of="$SWAPFILE" bs=1048576 count="$1" status=none
+    SWAPPED_ON="$SWAPFILE"
+    ensure_block "$FSTAB" swap "$SWAPFILE none swap sw 0 0"
+  else
+    SWAPPED_ON=""
+  fi
+  LOGGED=""; SWAPOFF_FAILS=""
+}
+
+echo "54. a first run creates the swap file at the configured size"
+new_swap_env ""
+SWAP_SIZE_MB=8 ensure_swapfile "$SWAPFILE" "$FSTAB"
+chk "created at 8MiB"   8 "$(swap_mib "$SWAPFILE")"
+chk "enabled"           "$SWAPFILE" "$SWAPPED_ON"
+chk "mode 0600"         "600" "$(file_mode "$SWAPFILE")"
+chk "fstab entry"       1 "$(grep -c "^$SWAPFILE none swap" "$FSTAB")"
+
+echo "55. an unchanged SWAP_SIZE_MB rewrites nothing"
+new_swap_env 8
+ino="$(inode "$SWAPFILE")"
+SWAP_SIZE_MB=8 ensure_swapfile "$SWAPFILE" "$FSTAB"
+chk "same inode"  "$ino" "$(inode "$SWAPFILE")"
+chk "still on"    "$SWAPFILE" "$SWAPPED_ON"
+chk "silent"      "" "$LOGGED"
+
+echo "56. a raised SWAP_SIZE_MB actually resizes, rather than being skipped"
+# The whole finding: the old guard asked "is swap on?" and returned, so an
+# operator raising this after an OOM got a successful run and the old headroom.
+new_swap_env 4
+SWAP_SIZE_MB=12 ensure_swapfile "$SWAPFILE" "$FSTAB"
+chk "grown to 12MiB"  12 "$(swap_mib "$SWAPFILE")"
+chk "re-enabled"      "$SWAPFILE" "$SWAPPED_ON"
+case "$LOGGED" in
+  *"resized"*"4MiB to 12MiB"*) echo "  ok   says what it changed" ;;
+  *) echo "  FAIL silent or vague: $LOGGED"; fail=1 ;;
+esac
+
+echo "57. a lowered SWAP_SIZE_MB shrinks it too"
+new_swap_env 16
+SWAP_SIZE_MB=4 ensure_swapfile "$SWAPFILE" "$FSTAB"
+chk "shrunk to 4MiB" 4 "$(swap_mib "$SWAPFILE")"
+chk "re-enabled"     "$SWAPFILE" "$SWAPPED_ON"
+
+echo "58. SWAP_SIZE_MB=0 actually disables swap"
+new_swap_env 8
+SWAP_SIZE_MB=0 ensure_swapfile "$SWAPFILE" "$FSTAB"
+chk "file removed"      0 "$([ -e "$SWAPFILE" ] && echo 1 || echo 0)"
+chk "swap off"          "" "$SWAPPED_ON"
+chk "no fstab swap line" 0 "$(grep -c 'none swap' "$FSTAB")"
+chk "other mounts kept"  1 "$(grep -c '^UUID=xxx' "$FSTAB")"
+# The marker stays so a later non-zero run converges this block rather than
+# appending a second one.
+SWAP_SIZE_MB=8 ensure_swapfile "$SWAPFILE" "$FSTAB"
+chk "one managed block after re-enabling" 1 "$(grep -c '# BEGIN collavre:swap' "$FSTAB")"
+chk "swap line back"                      1 "$(grep -c 'none swap' "$FSTAB")"
+
+echo "59. SWAP_SIZE_MB=0 on a host that never had swap is a no-op"
+new_swap_env ""
+SWAP_SIZE_MB=0 ensure_swapfile "$SWAPFILE" "$FSTAB"
+chk "nothing created" 0 "$([ -e "$SWAPFILE" ] && echo 1 || echo 0)"
+chk "silent"          "" "$LOGGED"
+
+echo "60. a swapoff that fails leaves the old swap running and says so"
+# Low memory is exactly when swapoff fails and exactly when this setting is
+# being changed, so it must not abandon a provisioning run.
+new_swap_env 4
+SWAPOFF_FAILS=1
+SWAP_SIZE_MB=12 ensure_swapfile "$SWAPFILE" "$FSTAB"
+chk "returns success" 0 "$?"
+chk "size unchanged"  4 "$(swap_mib "$SWAPFILE")"
+chk "still enabled"   "$SWAPFILE" "$SWAPPED_ON"
+case "$LOGGED" in
+  *"WARNING"*"did NOT take effect"*) echo "  ok   operator told it did not take" ;;
+  *) echo "  FAIL silent: $LOGGED"; fail=1 ;;
+esac
+unset -f swapon swapoff mkswap fallocate
+
+echo "61. an unsupported DB_PORT is refused before anything is installed"
+# Nothing here writes postgresql.conf, and pg_createcluster takes the first free
+# port from 5432 — so an overridden DB_PORT is named by DATABASE_URL, the ufw
+# rule and the backup while the cluster listens on 5432 regardless.
+guard="$(awk '/^\[ "\$DB_PORT" = "5432" \]/, /different port\.\"$/' "$SRC")"
+# The range end must be the guard's own last line; an unmatched end pattern
+# would run to EOF and "pass" by executing half the script.
+chk "extracted just the guard" 5 "$(printf '%s\n' "$guard" | wc -l | tr -d ' ')"
+case "$guard" in
+  *'die'*) echo "  ok   the guard is in the script" ;;
+  *) echo "  FAIL no DB_PORT guard found in $SRC"; fail=1 ;;
+esac
+out="$( (DB_PORT=5433 eval "$guard") 2>&1 )"
+chk "exits non-zero" 1 "$?"
+case "$out" in
+  *"DB_PORT=5433 is not supported"*"still listen on 5432"*)
+    echo "  ok   says what would have happened" ;;
+  *) echo "  FAIL unhelpful message: $out"; fail=1 ;;
+esac
+out="$( (DB_PORT=5432 eval "$guard") 2>&1 )"
+chk "the default proceeds" 0 "$?"
+chk "and says nothing"     "" "$out"
 
 echo
 if [ "$fail" = 0 ]; then echo "ALL PASS"; else echo "FAILURES"; fi

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -708,8 +708,20 @@ dest="${sql#*\'}"; dest="${dest%\'*}"
 STUB
   # Sending half of the blob copy: its own status is the thing case 32h is about,
   # so it is a separate stub from the receiver rather than one knob for both.
-  printf '#!/usr/bin/env bash\necho TAR_SEND >>"$TRACE"\n[ -z "$FAIL_TAR" ] || exit 2\n' \
-    > "$work/bin/tar"
+  # It has to produce the archive at the path `-cf` names, because the transfer
+  # that follows redirects from it — a stub that only reported its status would
+  # leave the next line failing on a missing file instead of on FAIL_TAR.
+  cat > "$work/bin/tar" <<'STUB'
+#!/usr/bin/env bash
+echo TAR_SEND >>"$TRACE"
+[ -z "$FAIL_TAR" ] || exit 2
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -cf) : > "$2"; break ;;
+  esac
+  shift
+done
+STUB
   cat > "$work/bin/kamal.sh" <<'STUB'
 #!/usr/bin/env bash
 echo "kamal:$1${2:+ $2}" >>"$TRACE"
@@ -914,22 +926,73 @@ case "$RECIPE_OUT" in
 esac
 unset FAIL_BLOB
 
-echo "32h. a sending tar that fails is caught, though the receiver is happy"
-# The status of a pipeline is its last element's. Read as \$?, a tar that cannot
-# read the source sends an empty stream to a receiver that unpacks it and exits
-# 0 — a blob copy that copied nothing, reported as success, on the one path
-# where the source is already stopped and the evidence is behind you.
+echo "32h. a sending tar that fails is caught, and never reaches the receiver"
+# Why this is not `tar | ssh` with \$?: the status of a pipeline is its last
+# element's, a receiver handed an empty stream unpacks it and exits 0, so a blob
+# copy that copied nothing would report success — on the one path where the
+# source is already stopped and the evidence is behind you. Staging the archive
+# first makes the sender a gate rather than something to inspect afterwards.
 FAIL_TAR=1 FAIL_BLOB='' FAIL_COPY='' FAIL_REVOKE='' FAIL_SCP='' FAIL_STAGE='' \
   FAIL_STOP='' run_cutover
-chk "the receiver did succeed" 1 "$(grep -cx BLOBS <<<"${RECIPE_TRACE//|/$'\n'}")"
-chk "no conversion ran"        0 "$(grep -cx 'kamal:app exec' <<<"${RECIPE_TRACE//|/$'\n'}")"
-chk "app NOT booted"           0 "$(grep -cx 'kamal:app boot' <<<"${RECIPE_TRACE//|/$'\n'}")"
+chk "the transfer never ran" 0 "$(grep -cx BLOBS <<<"${RECIPE_TRACE//|/$'\n'}")"
+chk "no conversion ran"      0 "$(grep -cx 'kamal:app exec' <<<"${RECIPE_TRACE//|/$'\n'}")"
+chk "app NOT booted"         0 "$(grep -cx 'kamal:app boot' <<<"${RECIPE_TRACE//|/$'\n'}")"
 case "$RECIPE_OUT" in
   *"BLOB COPY FAILED"*) echo "  ok   the sending half is not trusted to ssh" ;;
   *) echo "  FAIL the empty stream passed for a copy: ${RECIPE_OUT:-(no output)}"
      fail=1 ;;
 esac
 unset FAIL_TAR
+
+echo "32i. the blob copy's status is readable in the shell the operator has"
+# This harness runs the recipe under "$BASH" — a shell the page never names. It
+# says five times over that these blocks get pasted into an interactive shell,
+# and the operator's is whatever it is; on macOS that is zsh. So a bash-only
+# construct here is not a style question: `${PIPESTATUS[0]}` is unset in zsh
+# (spelled `$pipestatus` there, and 1-indexed), the arithmetic around it fails,
+# and the pre-set 1 survives to report a copy that succeeded as failed —
+# fail-closed, but a dead end that cannot be cleared, naming the one step that
+# worked. Asserted against the text as well as by running it, because the run
+# below is skipped where zsh is absent.
+#
+# Against the previous revision the discriminating assertions are "it converts"
+# and "it boots" (`expected [1] got [0]`), not the message one: non-interactively
+# zsh aborts the recipe at the failed arithmetic rather than continuing to print
+# BLOB COPY FAILED, so that check passes there for the wrong reason. The dead-end
+# message is what an interactive paste produces; what is asserted here is the
+# thing both forms of the failure share — the cutover does not complete.
+# Code lines only: the comment above the fix names PIPESTATUS to say why it is
+# not used, and an assertion that forbade the word outright would forbid the
+# explanation along with the construct.
+chk "no PIPESTATUS in the cutover recipe" 0 \
+  "$(grep -v '^[[:space:]]*#' <<<"$recipe" | grep -c PIPESTATUS)"
+if command -v zsh >/dev/null; then
+  BASH_SAVED="$BASH"; BASH="$(command -v zsh)"
+  FAIL_TAR='' FAIL_BLOB='' FAIL_COPY='' FAIL_REVOKE='' FAIL_SCP='' FAIL_STAGE='' \
+    FAIL_STOP='' run_cutover
+  chk "under zsh: blobs unpacked" 1 "$(grep -cx BLOBS <<<"${RECIPE_TRACE//|/$'\n'}")"
+  chk "under zsh: it converts"    1 \
+    "$(grep -cx 'kamal:app exec' <<<"${RECIPE_TRACE//|/$'\n'}")"
+  chk "under zsh: it boots"       1 \
+    "$(grep -cx 'kamal:app boot' <<<"${RECIPE_TRACE//|/$'\n'}")"
+  case "$RECIPE_OUT" in
+    *"BLOB COPY FAILED"*)
+      echo "  FAIL zsh reported the successful copy as failed: $RECIPE_OUT"; fail=1 ;;
+    *) echo "  ok   no spurious failure under zsh" ;;
+  esac
+  # A control for the assertions above, so they cannot pass for the wrong
+  # reason — that this zsh is one where PIPESTATUS happens to work. The
+  # mechanism is measured rather than the outcome: reproducing the outcome needs
+  # an interactive zsh, because non-interactively the failed arithmetic aborts
+  # the script instead of leaving the stale 1 behind.
+  chk "this zsh has no PIPESTATUS to read" UNSET \
+    "$(zsh -c 'true | true; print -r -- "${PIPESTATUS[0]-UNSET}"' 2>/dev/null)"
+  chk "and bash does"                      0 \
+    "$("$BASH_SAVED" -c 'true | true; printf %s "${PIPESTATUS[0]-UNSET}"')"
+  BASH="$BASH_SAVED"
+else
+  echo "  SKIP no zsh on this machine — the text assertion above is all that ran"
+fi
 
 echo "33. staging renames into place rather than writing the live path directly"
 # An interrupted copy must leave the previous file intact, not a truncated

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -21,7 +21,7 @@ SRC="${1:-$ROOT/script/lightsail_launch.sh}"
 # die() is a one-liner; the others run to the first column-1 closing brace.
 eval "$(awk '
   /^die\(\) \{/ { print; next }
-  /^(ensure_block|ensure_sudoers|in_group|write_state_file|launch_record_is_complete|record_launch_settings|record_deploy_user_grant|revoke_deploy_user_access|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|install_deploy_ssh_dir|reassign_prior_db_role|refuse_superuser_db_rotation|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps|warn_existing_containers_keep_log_config|dedupe_authorized_keys|install_staged_authorized_keys|postgresql_conf_includes_confd|role_owns_app_objects|refuse_db_name_change|refuse_defaulted_config_change|refuse_unusable_db_identifier|refuse_unparsable_ssh_key|refuse_forced_command_ssh_key|ipv4_dotted_quad|refuse_unusable_bind_address|refuse_unusable_subnet|passwd_home|ssh_key_holder|adopt_legacy_ssh_key_marker|record_db_role_grant|reassign_one_db_role|record_ssh_key_grant|refuse_root_deploy_user|append_state_line|refuse_nologin_deploy_user|resolve_symlink_chain|stage_beside|restore_postgresql_bind_config|stage_authorized_keys|scan_ssh_config_file|find_unsafe_ssh_match|verify_ssh_hardening|refuse_unusable_retention|refuse_unusable_backup_calendar|install_managed_config|install_downloaded_file|install_credential_summary|reload_ssh_daemon)\(\) \{/ { f = 1 }
+  /^(ensure_block|ensure_sudoers|in_group|write_state_file|launch_record_is_complete|record_launch_settings|record_deploy_user_grant|revoke_deploy_user_access|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|install_deploy_ssh_dir|reassign_prior_db_role|refuse_superuser_db_rotation|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps|warn_existing_containers_keep_log_config|dedupe_authorized_keys|install_staged_authorized_keys|postgresql_conf_includes_confd|role_owns_app_objects|refuse_db_name_change|refuse_defaulted_config_change|refuse_unusable_db_identifier|refuse_unparsable_ssh_key|refuse_forced_command_ssh_key|ipv4_dotted_quad|refuse_unusable_bind_address|refuse_unusable_subnet|passwd_home|ssh_key_holder|adopt_legacy_ssh_key_marker|record_db_role_grant|reassign_one_db_role|record_ssh_key_grant|refuse_root_deploy_user|append_state_line|refuse_nologin_deploy_user|resolve_symlink_chain|stage_beside|restore_postgresql_bind_config|stage_authorized_keys|scan_ssh_config_file|find_unsafe_ssh_match|verify_ssh_key_destination|ssh_pattern_list_matches|verify_ssh_admission_controls|verify_ssh_hardening|refuse_unusable_retention|refuse_unusable_backup_calendar|install_managed_config|install_downloaded_file|install_credential_summary|reload_ssh_daemon)\(\) \{/ { f = 1 }
   f { print }
   f && /^\}/ { f = 0 }
 ' "$SRC")"
@@ -46,7 +46,9 @@ for fn in die ensure_block ensure_sudoers in_group write_state_file \
           refuse_root_deploy_user append_state_line refuse_nologin_deploy_user \
 	  resolve_symlink_chain stage_beside restore_postgresql_bind_config \
 	  stage_authorized_keys \
-	  scan_ssh_config_file find_unsafe_ssh_match verify_ssh_hardening \
+	  scan_ssh_config_file find_unsafe_ssh_match \
+	  verify_ssh_key_destination ssh_pattern_list_matches \
+	  verify_ssh_admission_controls verify_ssh_hardening \
 	  refuse_unusable_retention \
 	  refuse_unusable_backup_calendar \
 	  install_managed_config install_downloaded_file \
@@ -107,6 +109,38 @@ ensure_block "$f" docker "NEW"
 chk "still above TRAILER" \
   "$(printf 'A\n\n# BEGIN collavre:docker (managed by script/lightsail_launch.sh)\nNEW\n# END collavre:docker\nTRAILER')" \
   "$(cat "$f")"
+
+echo "2a. a leading block stays ahead of pre-existing pg_hba rejects"
+# pg_hba.conf stops at the first matching record. On an existing host, appending
+# the Docker rule after a broad reject makes the managed rule unreachable even
+# though both records are syntactically valid.
+f=$(mktemp)
+printf 'local all postgres peer\nhost all all 0.0.0.0/0 reject\n' > "$f"
+ensure_block "$f" docker \
+  "host    all    all    172.16.0.0/12    scram-sha-256" leading
+chk "a first managed block precedes the broad reject" 1 \
+  "$(awk '
+      /# BEGIN collavre:docker/ { managed = NR }
+      /host all all 0\.0\.0\.0\/0 reject/ { rejected = NR }
+      END { print (managed > 0 && managed < rejected) }
+    ' "$f")"
+# A host already touched by the earlier append-only implementation must converge
+# too; merely fixing new installs leaves the documented FORCE re-run broken.
+f=$(mktemp)
+printf 'local all postgres peer\nhost all all 0.0.0.0/0 reject\n\n# BEGIN collavre:docker (managed by script/lightsail_launch.sh)\nOLD\n# END collavre:docker\n' > "$f"
+ensure_block "$f" docker \
+  "host    all    all    172.16.0.0/12    scram-sha-256" leading
+chk "an existing managed block moves ahead of the broad reject" 1 \
+  "$(awk '
+      /# BEGIN collavre:docker/ { managed = NR }
+      /host all all 0\.0\.0\.0\/0 reject/ { rejected = NR }
+      END { print (managed > 0 && managed < rejected) }
+    ' "$f")"
+before="$(cat "$f")"
+ensure_block "$f" docker \
+  "host    all    all    172.16.0.0/12    scram-sha-256" leading
+chk "and the leading layout is byte-identical on another re-run" \
+  "$before" "$(cat "$f")"
 
 echo "3. an unchanged value rewrites nothing"
 f=$(mktemp)
@@ -5826,6 +5860,79 @@ vh_msg="$( ( verify_ssh_hardening "$vshd/eff" "$vshd" ) 2>&1 )"
 chk "and the refusal names the file that won"             1 \
   "$(printf '%s' "$vh_msg" | grep -c '00-operator\.conf')"
 
+# Installing a key in ~/.ssh/authorized_keys proves nothing when sshd reads a
+# different AuthorizedKeysFile. The effective value must name the exact file
+# this script is about to populate before the account receives sudo or Docker.
+printf '%s\n' \
+  'authorizedkeysfile .ssh/authorized_keys .ssh/authorized_keys2' \
+  > "$vshd/eff"
+vh_keys_default="$( ( verify_ssh_key_destination "$vshd/eff" deploybot \
+  /home/deploybot /home/deploybot/.ssh/authorized_keys ) 2>&1
+  printf 'rc=%s\n' "$?" )"
+chk "the default effective AuthorizedKeysFile is supported" 1 \
+  "$(printf '%s' "$vh_keys_default" | grep -c '^rc=0$')"
+printf 'authorizedkeysfile /etc/ssh/authorized_keys/%%u\n' > "$vshd/eff"
+vh_keys_custom="$( ( verify_ssh_key_destination "$vshd/eff" deploybot \
+  /home/deploybot /home/deploybot/.ssh/authorized_keys ) 2>&1
+  printf 'rc=%s\n' "$?" )"
+chk "a different effective AuthorizedKeysFile is refused" 1 \
+  "$(printf '%s' "$vh_keys_custom" | grep -c '^rc=1$')"
+chk "and the refusal names AuthorizedKeysFile" 1 \
+  "$(printf '%s' "$vh_keys_custom" | grep -ci 'AuthorizedKeysFile')"
+printf '%s\n' \
+  '#!/bin/sh' \
+  'if [ "$GROUP_CONTEXT" = docker ]; then' \
+  '  printf "authorizedkeysfile /etc/ssh/authorized_keys/%%u\n"' \
+  'else' \
+  '  printf "authorizedkeysfile .ssh/authorized_keys\n"' \
+  'fi' > "$vshd/bin/sshd"
+chmod +x "$vshd/bin/sshd"
+vh_keys_before_group="$( ( export GROUP_CONTEXT=base; PATH="$vshd/bin:$PATH"
+  verify_ssh_key_destination "" deploybot /home/deploybot \
+    /home/deploybot/.ssh/authorized_keys ) 2>&1; printf 'rc=%s\n' "$?" )"
+vh_keys_after_group="$( ( export GROUP_CONTEXT=docker; PATH="$vshd/bin:$PATH"
+  verify_ssh_key_destination "" deploybot /home/deploybot \
+    /home/deploybot/.ssh/authorized_keys ) 2>&1; printf 'rc=%s\n' "$?" )"
+chk "the key path can be safe before a group Match applies" 1 \
+  "$(printf '%s' "$vh_keys_before_group" | grep -c '^rc=0$')"
+chk "and is refused after the group changes its effective path" 1 \
+  "$(printf '%s' "$vh_keys_after_group" | grep -c '^rc=1$')"
+
+# sshd -T prints Allow*/Deny* lists but does not turn a rejected account into a
+# non-zero exit. Evaluate those controls explicitly before revoking the working
+# predecessor.
+printf '%s\n' 'allowusers ubuntu' > "$vshd/eff"
+vh_allow_user="$( ( verify_ssh_admission_controls "$vshd/eff" deploybot ) 2>&1
+  printf 'rc=%s\n' "$?" )"
+chk "AllowUsers that omits the deploy account is refused" 1 \
+  "$(printf '%s' "$vh_allow_user" | grep -c '^rc=1$')"
+printf '%s\n' 'denyusers deploy*' > "$vshd/eff"
+vh_deny_user="$( ( verify_ssh_admission_controls "$vshd/eff" deploybot ) 2>&1
+  printf 'rc=%s\n' "$?" )"
+chk "DenyUsers that matches the deploy account is refused" 1 \
+  "$(printf '%s' "$vh_deny_user" | grep -c '^rc=1$')"
+printf '%s\n' 'allowusers deploy*' > "$vshd/eff"
+vh_allow_match="$( ( verify_ssh_admission_controls "$vshd/eff" deploybot ) 2>&1
+  printf 'rc=%s\n' "$?" )"
+chk "a matching AllowUsers pattern is accepted" 1 \
+  "$(printf '%s' "$vh_allow_match" | grep -c '^rc=0$')"
+id() {
+  [ "$1" = -Gn ] && [ "$2" = deploybot ] &&
+    { printf 'deploybot sudo docker\n'; return 0; }
+  command id "$@"
+}
+printf '%s\n' 'allowgroups operators' > "$vshd/eff"
+vh_allow_group="$( ( verify_ssh_admission_controls "$vshd/eff" deploybot ) 2>&1
+  printf 'rc=%s\n' "$?" )"
+chk "AllowGroups that omits every deploy group is refused" 1 \
+  "$(printf '%s' "$vh_allow_group" | grep -c '^rc=1$')"
+printf '%s\n' 'denygroups docker' > "$vshd/eff"
+vh_deny_group="$( ( verify_ssh_admission_controls "$vshd/eff" deploybot ) 2>&1
+  printf 'rc=%s\n' "$?" )"
+chk "DenyGroups that matches Docker is refused" 1 \
+  "$(printf '%s' "$vh_deny_group" | grep -c '^rc=1$')"
+unset -f id
+
 # Unknown is not wrong. A host where `sshd -T` will not run has answered
 # nothing, and stopping over a question that could not be asked would refuse
 # hosts that are fine — so that branch warns and the run goes on.
@@ -5904,6 +6011,21 @@ chk "an address-scoped public-key override stops the run" 1 \
 chk "and the refusal identifies the public-key directive" 1 \
   "$(printf '%s' "$vh_address_pubkey" | grep -ci 'PubkeyAuthentication')"
 
+# A connection-scoped key path or admission rule is equally impossible to
+# prove with user-only -C input; neither may bypass the static scan.
+printf 'Include %s/sshd_config.d/*.conf\nMatch Address 203.0.113.0/24\n  AuthorizedKeysFile /etc/ssh/authorized_keys/%%u\n' \
+  "$vshd" > "$vshd/sshd_config"
+vh_address_keys="$( ( PATH="$vshd/bin:$PATH"
+  verify_ssh_hardening "" "$vshd" 0 deploybot ) 2>&1; printf 'rc=%s\n' "$?" )"
+chk "an address-scoped key destination stops the run" 1 \
+  "$(printf '%s' "$vh_address_keys" | grep -c '^rc=1$')"
+printf 'Include %s/sshd_config.d/*.conf\nMatch Address 203.0.113.0/24\n  DenyUsers deploybot\n' \
+  "$vshd" > "$vshd/sshd_config"
+vh_address_admission="$( ( PATH="$vshd/bin:$PATH"
+  verify_ssh_hardening "" "$vshd" 0 deploybot ) 2>&1; printf 'rc=%s\n' "$?" )"
+chk "an address-scoped admission rule stops the run" 1 \
+  "$(printf '%s' "$vh_address_admission" | grep -c '^rc=1$')"
+
 # ChallengeResponseAuthentication is OpenSSH's deprecated alias for
 # KbdInteractiveAuthentication. A contextual scanner that recognizes only the
 # canonical spelling leaves PAM password authentication enabled in the same
@@ -5978,12 +6100,29 @@ vh_docker_grant="$(awk '
 chk "sudo-group context is rechecked before passwordless sudo" 1 \
   "$(grep -cF 'verify_ssh_hardening "" /etc/ssh "$SSH_RELOAD_STATE" "$APP_SSH_USER"' \
       <<<"$vh_sudo_grant")"
+chk "sudo-group key destination is rechecked before passwordless sudo" 1 \
+  "$(grep -cF 'verify_ssh_key_destination "" "$APP_SSH_USER" "$APP_HOME" "$AUTH_KEYS"' \
+      <<<"$vh_sudo_grant")"
 chk "docker-group context is rechecked before convergence continues" 1 \
   "$(grep -cF 'verify_ssh_hardening "" /etc/ssh "$SSH_RELOAD_STATE" "$APP_SSH_USER"' \
+      <<<"$vh_docker_grant")"
+chk "docker-group key destination is rechecked before revocation" 1 \
+  "$(grep -cF 'verify_ssh_key_destination "" "$APP_SSH_USER" "$APP_HOME" "$AUTH_KEYS"' \
       <<<"$vh_docker_grant")"
 chk "the check immediately before revocation requires a readable public-key result" 1 \
   "$(grep -cF 'verify_ssh_hardening "" /etc/ssh "$SSH_RELOAD_STATE" "$APP_SSH_USER" 1' \
       <<<"$vh_docker_grant")"
+chk "the final gate checks sshd admission before revocation" 1 \
+  "$(grep -cF 'verify_ssh_admission_controls "" "$APP_SSH_USER"' \
+      <<<"$vh_docker_grant")"
+vh_key_grant="$(awk '
+  /^if ! id -u "\$APP_SSH_USER"/ { f = 1 }
+  f { print }
+  f && /^usermod -aG sudo "\$APP_SSH_USER"$/ { exit }
+' "$SRC")"
+chk "the effective key destination is checked before privilege is granted" 1 \
+  "$(grep -cF 'verify_ssh_key_destination "" "$APP_SSH_USER" "$APP_HOME" "$AUTH_KEYS"' \
+      <<<"$vh_key_grant")"
 
 # If the recheck is what discovers the override, the new group is already live.
 # A refusal must remove only the membership this run added. These assertions

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -1705,6 +1705,51 @@ chk "an untransferred superuser still dies" 1 "$?"
 chk "and still runs no SQL" "" "$SQL"
 ROLE_EXISTS=1 ROLE_IS_SUPER=f OWNS=1
 
+echo "50c. a probe the cluster cannot answer stops the run rather than passing it"
+# 50a already asserts this for the ownership count ("an unreadable count
+# refuses"). The two role probes above it did not: they compared the *output*
+# of psql and threw the status away, so a connection that died produced an
+# empty string, which is neither "1" nor "t", and the guard read a dead cluster
+# as "no such role" and then as "not a superuser".
+#
+# Proceeding here is not a refusal deferred to reassign_prior_db_role, which is
+# what makes this worth a case of its own rather than a tidier spelling: the
+# call site runs this guard *before* the SQL block, and that block contains
+# ALTER DATABASE ... OWNER TO. A bypass therefore moves the stop from "nothing
+# has been changed" to a host whose database belongs to the new role and whose
+# every table still belongs to the superuser — the exact half-rotated state
+# case 50 says the pre-check exists to make unreachable.
+#
+# The die message names the port, and DB_PORT is not set until the cluster
+# cases below; set here rather than moved, since those cases share the value
+# and reordering them to suit this one would be the tail wagging the dog.
+DB_PORT=5432
+printf 'postgres\n' > "$d3/db_user"
+ROLE_EXISTS=1 ROLE_IS_SUPER=t OWNS=2
+for q in 'count(*) FROM pg_roles' 'rolsuper'; do
+  FAIL_SQL="$q"
+  out="$( (refuse collavre_app "$d3/db_user") 2>&1 )"
+  chk "an unanswerable '$q' stops the run" 1 "$?"
+  case "$out" in
+    *"could not ask the cluster"*"Nothing has been changed"*"re-run"*)
+      echo "  ok   '$q': says what could not be asked, and that nothing changed" ;;
+    *) echo "  FAIL '$q': unhelpful or silent: $out"; fail=1 ;;
+  esac
+done
+FAIL_SQL=""
+# The control in the other direction, and it is the one that matters: this
+# guard runs on every re-run that changes DB_USER, so a probe treated as
+# unanswerable when it did answer would refuse every rotation on the host.
+# 50's four let-through shapes are asserted against a working psql above; this
+# re-asserts the two that the change actually rewrote.
+ROLE_IS_SUPER=f
+refuse collavre_app "$d3/db_user"
+chk "an answered 'not a superuser' still proceeds" 0 "$?"
+ROLE_EXISTS=0 ROLE_IS_SUPER=t
+refuse collavre_app "$d3/db_user"
+chk "an answered 'no such role' still proceeds"    0 "$?"
+ROLE_EXISTS=1 ROLE_IS_SUPER=f OWNS=1
+
 echo "51. first run, emptied marker and a dropped role are all no-ops"
 d4=$(mktemp -d)
 ROLE_IS_SUPER=f

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -21,12 +21,13 @@ SRC="${1:-$ROOT/script/lightsail_launch.sh}"
 # die() is a one-liner; the others run to the first column-1 closing brace.
 eval "$(awk '
   /^die\(\) \{/ { print; next }
-  /^(ensure_block|ensure_sudoers|in_group|record_deploy_user_grant|revoke_deploy_user_access|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|install_deploy_ssh_dir|reassign_prior_db_role|refuse_superuser_db_rotation|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps|dedupe_authorized_keys|install_staged_authorized_keys|postgresql_conf_includes_confd|role_owns_app_objects|refuse_db_name_change|refuse_defaulted_config_change|passwd_home|ssh_key_holder|adopt_legacy_ssh_key_marker)\(\) \{/ { f = 1 }
+  /^(ensure_block|ensure_sudoers|in_group|write_state_file|record_deploy_user_grant|revoke_deploy_user_access|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|install_deploy_ssh_dir|reassign_prior_db_role|refuse_superuser_db_rotation|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps|dedupe_authorized_keys|install_staged_authorized_keys|postgresql_conf_includes_confd|role_owns_app_objects|refuse_db_name_change|refuse_defaulted_config_change|refuse_unusable_db_identifier|refuse_unparsable_ssh_key|passwd_home|ssh_key_holder|adopt_legacy_ssh_key_marker)\(\) \{/ { f = 1 }
   f { print }
   f && /^\}/ { f = 0 }
 ' "$SRC")"
 
-for fn in die ensure_block ensure_sudoers in_group revoke_prior_deploy_user \
+for fn in die ensure_block ensure_sudoers in_group write_state_file \
+          revoke_prior_deploy_user \
           record_deploy_user_grant revoke_deploy_user_access \
           ensure_ufw_rule ssh_already_allowed ensure_ssh_rule \
           install_authorized_keys install_deploy_ssh_dir reassign_prior_db_role \
@@ -35,6 +36,7 @@ for fn in die ensure_block ensure_sudoers in_group revoke_prior_deploy_user \
           ensure_docker_log_caps dedupe_authorized_keys \
           install_staged_authorized_keys postgresql_conf_includes_confd \
           refuse_db_name_change refuse_defaulted_config_change \
+          refuse_unusable_db_identifier refuse_unparsable_ssh_key \
           passwd_home ssh_key_holder \
           adopt_legacy_ssh_key_marker; do
   declare -F "$fn" >/dev/null || {
@@ -463,6 +465,68 @@ revoke_prior_deploy_user deploybot "$d8/deploy_user"
 chk "the legacy predecessor was found and stripped" 0 "$(holds collavre docker)"
 chk "and the queue now holds only the account in use" "ci_absent deploybot" \
   "ci_absent $(tr '\n' ' ' < "$d8/deploy_users" | sed 's/ *$//')"
+
+echo "18d. a queue rewrite that cannot complete leaves the previous queue intact"
+# `> "$set_file"` truncates when the redirection opens and only then writes, so
+# a write that fails in between leaves the file existing and EMPTY — which is
+# indistinguishable from a host with nothing left to revoke. `ulimit -f 0`
+# stands in for a full disk: creating the file is allowed, writing to it is not.
+d9=$(mktemp -d)
+printf 'deploybot\nci\n' > "$d9/deploy_users"
+# The redirect is on the GROUP, not on the subshell. SIGXFSZ kills the child,
+# and "Filesize limit exceeded" is printed by the parent that reaps it, to the
+# parent's stderr — so `( ... ) 2>/dev/null` silences the child and leaves the
+# report in the suite's output.
+{ ( ulimit -f 0; write_state_file "$d9/deploy_users" 'ci
+' ); } 2>/dev/null
+chk "the queue still names the unrevoked account" "deploybot ci" \
+  "$(tr '\n' ' ' < "$d9/deploy_users" | sed 's/ *$//')"
+
+# The control: the same failure against the previous form. Only the write is
+# swapped — the surrounding function is unchanged and is what both forms run.
+d10=$(mktemp -d)
+printf 'deploybot\nci\n' > "$d10/deploy_users"
+printf 'ci\n' > "$d10/deploy_user"
+{ ( ulimit -f 0; printf '%s' 'ci
+' > "$d10/deploy_users" ); } 2>/dev/null
+chk "the previous form emptied it" "" \
+  "$(tr '\n' ' ' < "$d10/deploy_users" | sed 's/ *$//')"
+# And nothing brings it back. Seeding is guarded on the file being ABSENT, and
+# this one exists; the single-name marker names the account in use, so it could
+# not have named deploybot even if the seeding did run. The queue was the only
+# record of it, which is the whole reason the queue exists.
+record_deploy_user_grant ci "$d10/deploy_users" "$d10/deploy_user"
+chk "and the next run cannot bring it back" "ci" \
+  "$(tr '\n' ' ' < "$d10/deploy_users" | sed 's/ *$//')"
+
+echo "18e. a seeding that cannot complete is retried, not retired"
+# The upgrade path runs once per host — its guard is `! -f`, so whatever state
+# the file is left in is the state it keeps. The append at the end of the
+# function would create the file, so a run that could not write the seed has to
+# stop before reaching it, or it retires the upgrade on the one host that still
+# needs it.
+d11=$(mktemp -d)
+printf 'legacy\n' > "$d11/deploy_user"          # provisioned before the queue
+mktemp() { return 1; }                          # no staging file can be made
+record_deploy_user_grant deploybot "$d11/deploy_users" "$d11/deploy_user"; rc=$?
+unset -f mktemp
+chk "it reports that it could not record" 1 "$rc"
+chk "and leaves no file behind to retire the upgrade" absent \
+  "$([ -e "$d11/deploy_users" ] && echo present || echo absent)"
+record_deploy_user_grant deploybot "$d11/deploy_users" "$d11/deploy_user"
+chk "so a later run still finds the predecessor" "legacy deploybot" \
+  "$(tr '\n' ' ' < "$d11/deploy_users" | sed 's/ *$//')"
+
+# The control: the previous form created the file on its way to failing, and
+# `|| true` meant nothing anywhere said so.
+d12=$(mktemp -d); printf 'legacy\n' > "$d12/deploy_user"
+{ ( ulimit -f 0; grep -v '^[[:space:]]*$' "$d12/deploy_user" > "$d12/deploy_users" || true ); } 2>/dev/null
+chk "the previous form left the file existing" present \
+  "$([ -e "$d12/deploy_users" ] && echo present || echo absent)"
+grep -qxF deploybot "$d12/deploy_users" 2>/dev/null ||
+  printf '%s\n' deploybot >> "$d12/deploy_users"
+chk "and the legacy predecessor is absent for good" "deploybot" \
+  "$(tr '\n' ' ' < "$d12/deploy_users" | sed 's/ *$//')"
 
 unset -f id gpasswd usermod groupadd log grant holds revoke_single_marker
 
@@ -2154,7 +2218,14 @@ STUB
   # the ALTER did not take. FAIL_SHUT makes the ALTER a no-op — psql prints its
   # error and exits non-zero, which an interactive paste with no `set -e` walks
   # straight past, which is the case under test.
-  echo -1 > "$work/connlimit"
+  # The cluster's own datconnlimit, which is not always -1: an operator may have
+  # capped this database, and the recipe now has to put back what it found
+  # rather than the default. PRIOR_LIMIT is that starting state.
+  echo "${PRIOR_LIMIT--1}" > "$work/connlimit"
+  # The prior read and the post-ALTER read-back are the same statement, so the
+  # stub tells them apart by order rather than by text — which is also the only
+  # way to model a prior read that failed while the ALTER still took.
+  echo 0 > "$work/datconn_n"
   cat > "$work/bin/psql" <<'STUB'
 #!/usr/bin/env bash
 sql="${*: -1}"
@@ -2175,12 +2246,26 @@ case "$sql" in
   *"CONNECTION LIMIT 0"*)      echo "limit:0"        >>"$TRACE"
                                [ -n "$FAIL_SHUT" ] || echo 0 > "$CONNLIMIT"
                                [ -z "$FAIL_SHUT" ] || { echo 'ERROR:  database "x" does not exist' >&2; exit 1; } ;;
-  *"CONNECTION LIMIT -1"*)     echo "limit:reopened" >>"$TRACE"
+  # Any limit, not the literal -1: the re-open restores whatever the database
+  # was at, so a stub that only knows -1 would pass a recipe that had gone back
+  # to hard-coding it. What it wrote is what the case reads afterwards.
+  *"CONNECTION LIMIT "*)       echo "limit:reopened" >>"$TRACE"
                                [ -z "$FAIL_REOPEN" ] ||
                                  { echo 'ERROR:  could not connect' >&2; exit 1; }
-                               echo -1 > "$CONNLIMIT" ;;
+                               printf '%s\n' "${sql##*CONNECTION LIMIT }" > "$CONNLIMIT" ;;
   *rolsuper*)                  echo "rolsuper"       >>"$TRACE"; printf '%s' "$APP_SUPER" ;;
-  *datconnlimit*)              echo "readback"       >>"$TRACE"; cat "$CONNLIMIT" ;;
+  *datconnlimit*)              n=$(cat "$DATCONN_N"); n=$((n + 1))
+                               printf '%s' "$n" > "$DATCONN_N"
+                               if [ "$n" = 1 ]; then
+                                 echo "priorlimit" >>"$TRACE"
+                                 # An empty answer with a non-zero status: what
+                                 # a read that could not be answered looks like
+                                 # through the recipe's own 2>/dev/null.
+                                 [ -z "$FAIL_PRIOR_READ" ] || exit 1
+                               else
+                                 echo "readback" >>"$TRACE"
+                               fi
+                               cat "$CONNLIMIT" ;;
   *pg_terminate_backend*)      echo "terminate"      >>"$TRACE"; echo "${KILLED:-0}" ;;
   *"count(*)"*)                echo "count"          >>"$TRACE"; printf '%s' "$LIVE" ;;
   *usename*)                   echo "listing"        >>"$TRACE" ;;
@@ -2202,11 +2287,15 @@ STUB
   # as, and it must not be rewritten into the one value that lets the gate open.
   export TRACE LIVE="${LIVE-0}" KILLED="${KILLED:-0}" FAIL_RESTORE="${FAIL_RESTORE:-}" \
          FAIL_SHUT="${FAIL_SHUT:-}" FAIL_REOPEN="${FAIL_REOPEN:-}" \
-         CONNLIMIT="$work/connlimit" \
+         FAIL_PRIOR_READ="${FAIL_PRIOR_READ:-}" \
+         CONNLIMIT="$work/connlimit" DATCONN_N="$work/datconn_n" \
          APP_ROLE="${APP_ROLE-collavre_user}" APP_SUPER="${APP_SUPER-f}" \
          APP_DB="${APP_DB-collavre_production}"
   R_OUT="$(cd "$work" && PATH="$work/bin:$PATH" bash ./recipe.sh 2>&1)"
   R_TRACE="$(paste -sd'|' "$TRACE")"
+  # What the database is left at, which is the thing the operator meets at boot
+  # — asserted directly rather than inferred from the statements that ran.
+  R_LIMIT="$(cat "$work/connlimit")"
   rm -rf "$work"
 }
 
@@ -2217,8 +2306,10 @@ LIVE=0 KILLED=2 FAIL_RESTORE='' run_restore
 # so a step inserted between them fails here instead of silently reordering the
 # gate. Nothing may precede the role check: it decides whether shutting the
 # door means anything at all, and a refusal must leave the limit as it found it.
-chk "role checked, then shut, before all else" "rolsuper|limit:0" \
-  "$(cut -d'|' -f1,2 <<<"$R_TRACE")"
+# The prior limit is read between them, and its position is not incidental: it
+# has to be taken before the ALTER, because after it the previous value is gone.
+chk "role checked, prior limit read, then shut, before all else" \
+  "rolsuper|priorlimit|limit:0" "$(cut -d'|' -f1,2,3 <<<"$R_TRACE")"
 chk "survivors terminated"   1 "$(grep -c '^terminate$' <<<"${R_TRACE//|/$'\n'}")"
 # The order is the whole point: counting before the limit is applied only says
 # the app happened to be between connections at that instant.
@@ -2370,7 +2461,66 @@ APP_DB='collavre-prod' LIVE=0 KILLED=0 FAIL_RESTORE='' FAIL_REOPEN=1 run_restore
 chk "told the door is still shut" 1 "$(grep -c 'RE-OPEN FAILED' <<<"$R_OUT")"
 chk "the printed ALTER quotes the name" 1 \
   "$(grep -cF "'ALTER DATABASE \"collavre-prod\" CONNECTION LIMIT -1'" <<<"$R_OUT")"
-unset FAIL_REOPEN
+# The same trap recorded at 86c, one variable over: `APP_DB=x run_restore` is a
+# prefix assignment on a *function*, so it persists in the calling shell and
+# every later case runs against `collavre-prod` instead of the default. It was
+# invisible until a case after these two needed the default name back.
+unset FAIL_REOPEN APP_DB
+
+echo "86h. a connection limit the operator set is put back, not replaced by -1"
+# -1 is only the default. A database deliberately capped has that cap in
+# datconnlimit and nowhere else, so re-opening to the literal -1 does not
+# restore the database to what it was — it lifts the cap, on every successful
+# restore, and the operator finds out when the cap stops holding.
+PRIOR_LIMIT=50 LIVE=0 KILLED=0 FAIL_RESTORE='' run_restore
+chk "restore ran"                 1 "$(grep -cx 'PG_RESTORE_RAN' <<<"${R_TRACE//|/$'\n'}")"
+chk "re-opened"                   1 "$(grep -cx 'limit:reopened' <<<"${R_TRACE//|/$'\n'}")"
+chk "left at the operator's cap"  50 "$R_LIMIT"
+chk "operator told to boot"       1 "$(grep -c 'app boot' <<<"$R_OUT")"
+chk "no note about a lost value"  0 "$(grep -c 'NOTE:' <<<"$R_OUT")"
+unset PRIOR_LIMIT
+
+echo "86i. a prior limit that could not be read re-opens to -1 and says so"
+# The one case the fix cannot honour: the read failed while the ALTER still
+# took. Leaving the door shut for want of a number would produce exactly the
+# misdirected "too many connections" the re-open exists to avoid, so -1 is the
+# answer — but the operator is the only one who knows what the cap was, so it
+# is said rather than assumed.
+PRIOR_LIMIT=50 FAIL_PRIOR_READ=1 LIVE=0 KILLED=0 FAIL_RESTORE='' run_restore
+chk "restore ran"                 1 "$(grep -cx 'PG_RESTORE_RAN' <<<"${R_TRACE//|/$'\n'}")"
+chk "re-opened to the default"    -1 "$R_LIMIT"
+chk "and did not stay silent"     1 "$(grep -c 'could not read' <<<"$R_OUT")"
+chk "operator told to boot"       1 "$(grep -c 'app boot' <<<"$R_OUT")"
+unset PRIOR_LIMIT FAIL_PRIOR_READ
+
+echo "86j. a database the operator had already shut is not advertised as bootable"
+# The consequence of putting the limit back faithfully: if it was already 0, the
+# re-open restores a closed door. That is the operator's configuration rather
+# than a step this block forgot, but "boot the app" would still send them into
+# "too many connections" — the error this whole block is arranged to avoid.
+PRIOR_LIMIT=0 LIVE=0 KILLED=0 FAIL_RESTORE='' run_restore
+chk "restore ran"                  1 "$(grep -cx 'PG_RESTORE_RAN' <<<"${R_TRACE//|/$'\n'}")"
+chk "left as the operator had it"  0 "$R_LIMIT"
+chk "NOT told to boot"             0 "$(grep -c 'app boot' <<<"$R_OUT")"
+chk "told the limit predates this" 1 \
+  "$(grep -c 'not something left behind here' <<<"$R_OUT")"
+chk "and how to lift it"           1 \
+  "$(grep -cF "'ALTER DATABASE \"collavre_production\" CONNECTION LIMIT -1'" <<<"$R_OUT")"
+# Not a failure report: nothing failed, and RESTORE FAILED here would send the
+# operator to repair a restore that worked.
+chk "not reported as a failure"    0 "$(grep -c 'FAILED' <<<"$R_OUT")"
+unset PRIOR_LIMIT
+
+echo "86k. the note is not printed on a path that never shut the door"
+# restore_status=3 refuses before the ALTER, so the previous limit is still in
+# force and could-not-be-read changes nothing. A warning here would be a warning
+# about nothing, on the one path where the operator is already reading a refusal.
+APP_DB='' FAIL_PRIOR_READ=1 LIVE=0 KILLED=0 FAIL_RESTORE='' run_restore
+chk "refused"                    1 "$(grep -c 'REFUSING' <<<"$R_OUT")"
+chk "nothing dropped"            0 "$(grep -cx 'PG_RESTORE_RAN' <<<"${R_TRACE//|/$'\n'}")"
+chk "not re-opened"              0 "$(grep -cx 'limit:reopened' <<<"${R_TRACE//|/$'\n'}")"
+chk "and no note about a limit"  0 "$(grep -c 'NOTE:' <<<"$R_OUT")"
+unset FAIL_PRIOR_READ APP_DB
 
 # --- dedupe_authorized_keys -------------------------------------------------
 #
@@ -3309,13 +3459,226 @@ echo "117. the grant is recorded before it is made, not after"
 # case 114: the function being correct is not what closes the interruption
 # window — its position is. A record written after the grants describes only
 # runs that reached the end, and the run that matters is the one that did not.
-rec_line="$(grep -n '^record_deploy_user_grant "\$APP_SSH_USER"$' "$SRC" | head -1 | cut -d: -f1)"
+# Not anchored at the end: the call carries a `|| log ...` continuation, and an
+# end-anchored pattern matches nothing while still looking like an assertion
+# about position. It cannot match the definition, which ends in `() {`.
+rec_line="$(grep -n '^record_deploy_user_grant "\$APP_SSH_USER"' "$SRC" | head -1 | cut -d: -f1)"
 chk "it is called at all"                 1 "$([ -n "$rec_line" ] && echo 1 || echo 0)"
 for after in 'usermod -aG sudo "\$APP_SSH_USER"' 'usermod -aG docker "\$APP_SSH_USER"' \
              'revoke_prior_deploy_user "\$APP_SSH_USER"'; do
   line="$(grep -n "^$after" "$SRC" | head -1 | cut -d: -f1)"
   chk "before ${after%% \"*}" 1 \
     "$([ -n "$line" ] && [ "$rec_line" -lt "$line" ] && echo 1 || echo 0)"
+done
+
+echo "118. a name PostgreSQL takes but this script cannot use is refused"
+# format('%I') quotes whatever it is given, so the cluster accepts names that
+# then break outside SQL. Measured on a live cluster: DB_NAME='tenant/prod' is
+# created, pg_dump connects to it, and the nightly dump's --file lands under a
+# directory that does not exist — so the host runs and every backup fails.
+idg_out=''
+idg() {
+  idg_out="$( ( refuse_unusable_db_identifier "$1" "$2" ) 2>&1 )"
+  idg_status=$?
+}
+for good in collavre_production collavre_prod collavre-prod collavre_user \
+            postgres CollavreProd db1; do
+  idg DB_NAME "$good"
+  chk "accepted: $good"                   0 "$idg_status"
+done
+# A '/' is the measured one; the rest are the same class one character over —
+# a quote breaks the CREATE statements, which take both settings as string
+# literals, and a leading '-' is an option to every command that later handles
+# the dump file.
+for bad in 'tenant/prod' "a'b" 'a b' '-prod' 'a;b' 'a$b' ''; do
+  idg DB_NAME "$bad"
+  chk "refused: ${bad:-(empty)}"          1 "$idg_status"
+done
+idg DB_NAME 'tenant/prod'
+chk "says nothing was changed"            1 "$(grep -c 'Nothing has been changed' <<<"$idg_out")"
+# Without a way out this is a dead end rather than a guard: refuse_db_name_change
+# refuses any *other* name on a host already provisioned under the bad one, so
+# the refusal has to name the procedure that moves the host off it.
+chk "and names the way off such a host"   1 "$(grep -c 'Changing DB_NAME on a re-run' <<<"$idg_out")"
+
+echo "118a. the ranges are byte ranges, not whatever the host collates"
+# `[A-Za-z]` is a collation range, not a byte range, and under some collations
+# it matches accented letters — which is exactly the class of name this exists
+# to keep out of a filesystem path.
+lc_probe() { local LC_ALL="$1"
+  case "$2" in ''|-*|*[!A-Za-z0-9_-]*) echo REFUSE ;; *) echo ACCEPT ;; esac; }
+chk "the guard pins LC_ALL=C"             1 \
+  "$(sed -n '/^refuse_unusable_db_identifier() {/,/^}/p' "$SRC" | grep -c 'local LC_ALL=C')"
+chk "and under C the bytes are out"       REFUSE "$(lc_probe C 'café')"
+# Whether the pin can be *demonstrated* depends on a disagreeing collation being
+# installed, which macOS has and a minimal CI container may not — measured on
+# macOS/bash 3.2 under en_US.UTF-8: ACCEPT. Reported as undemonstrated rather
+# than asserted into a pass, so this does not become a check that is green
+# because the host had nothing to check with.
+drifting=''
+for cand in en_US.UTF-8 en_US.utf8 C.UTF-8; do
+  [ "$(lc_probe "$cand" 'café')" = ACCEPT ] && { drifting="$cand"; break; }
+done
+if [ -n "$drifting" ]; then
+  echo "  ok   $drifting accepts what C refuses — the pin is load-bearing here"
+else
+  echo "  --   no installed collation disagrees here; pin asserted, not demonstrated"
+fi
+
+echo "118b. no example on the page is refused by it"
+# The failure this shape has: a new fail-closed guard that turns out to refuse
+# the runbook's own instructions.
+while read -r ex; do
+  [ -n "$ex" ] || continue
+  idg DB_NAME "$ex"
+  chk "the page's own $ex is accepted"    0 "$idg_status"
+done <<<"$(grep -ohE '\b(DB_NAME|DB_USER)=[A-Za-z0-9_.-]+' "$DOC" | cut -d= -f2 | sort -u)"
+
+echo "118c. it is called before anything it protects, and reads no state"
+# Same reason as case 114. A value this script cannot use is not usable whatever
+# the host was given earlier, so it is answered before the guard that reads
+# $STATE_DIR — and long before anything is installed.
+idn_line="$(grep -n '^refuse_unusable_db_identifier DB_NAME' "$SRC" | head -1 | cut -d: -f1)"
+chk "DB_NAME is checked"                  1 "$([ -n "$idn_line" ] && echo 1 || echo 0)"
+chk "so is DB_USER"                       1 \
+  "$(grep -c '^refuse_unusable_db_identifier DB_USER' "$SRC")"
+# Anchored at both ends: the pattern without it matches the function's own
+# definition line, which is above the call and would make this pass for the
+# wrong reason.
+cfg_call="$(grep -n '^refuse_defaulted_config_change$' "$SRC" | head -1 | cut -d: -f1)"
+chk "before refuse_defaulted_config_change" 1 \
+  "$([ -n "$cfg_call" ] && [ "$idn_line" -lt "$cfg_call" ] && echo 1 || echo 0)"
+for after in 'apt_get update' \
+             'ensure_sudoers "\$APP_SSH_USER"' 'usermod -aG docker'; do
+  line="$(grep -n "^$after" "$SRC" | head -1 | cut -d: -f1)"
+  chk "before ${after%% *}" 1 \
+    "$([ -n "$line" ] && [ "$idn_line" -lt "$line" ] && echo 1 || echo 0)"
+done
+
+echo "119. an SSH key sshd cannot read is refused before it is appended"
+# Real keys here, not the synthetic 'ssh-ed25519 AAAAKEYA x' fixtures the rest of
+# this suite uses: what is under test is whether sshd's own parser accepts the
+# line, and no fixture can stand in for that. The truncation is 24 characters out
+# of the base64 body, which is what a paste that lost its tail looks like — and
+# the one form a length or prefix check cannot catch.
+if ! command -v ssh-keygen >/dev/null 2>&1; then
+  echo "  SKIP no ssh-keygen here — the guard's own dependency is missing"
+else
+  kd="$(mktemp -d)"
+  ssh-keygen -q -t ed25519 -N '' -C 'operator@laptop' -f "$kd/old" >/dev/null
+  ssh-keygen -q -t ed25519 -N '' -C 'operator@newlaptop' -f "$kd/new" >/dev/null
+  GOOD_OLD="$(cat "$kd/old.pub")"; GOOD_NEW="$(cat "$kd/new.pub")"
+  nbody="${GOOD_NEW#* }"; nbody="${nbody%% *}"
+  TBODY="${nbody:0:${#nbody} - 24}"
+  TRUNC="${GOOD_NEW%% *} $TBODY operator@newlaptop"
+
+  g_out=''; g_rc=0
+  guard() {
+    g_out="$( ( log() { echo "[log] $*"; }
+                SSH_PUBLIC_KEY="$1" APP_SSH_USER=collavre
+                refuse_unparsable_ssh_key ) 2>&1 )" && g_rc=0 || g_rc=1
+  }
+
+  guard "$GOOD_NEW"
+  chk "a real key goes through"                 0 "$g_rc"
+  guard ""
+  chk "and so does none at all"                 0 "$g_rc"
+  guard "${GOOD_NEW% *}"
+  chk "and one with no comment"                 0 "$g_rc"
+  # authorized_keys lines may carry restrictions, and a shape check strict enough
+  # to catch truncation would refuse these — which is why the guard parses.
+  guard "command=\"x\",no-pty $GOOD_NEW"
+  chk "and one behind a command= restriction"   0 "$g_rc"
+  guard "from=\"10.0.0.0/8\" $GOOD_NEW"
+  chk "and one behind a from= restriction"      0 "$g_rc"
+  guard "   $GOOD_NEW"
+  chk "and one with leading whitespace"         0 "$g_rc"
+
+  guard "hello world"
+  chk "text that is not a key is refused"       1 "$g_rc"
+  # `grep -qxF` treats each line of its pattern as a pattern of its own, so a
+  # two-line value is "in place" as soon as either half of it is and the
+  # withdrawal proceeds on half a key.
+  guard "$GOOD_NEW"$'\n'"$GOOD_OLD"
+  chk "and a value holding a newline"           1 "$g_rc"
+
+  guard "$TRUNC"
+  chk "and a truncated paste"                   1 "$g_rc"
+  chk "it says nothing has been changed"        1 \
+    "$(grep -c 'Nothing has been changed' <<<"$g_out")"
+  # An operator who pastes a private key by mistake is exactly what this refuses,
+  # and the provisioning log is not private.
+  chk "and does not echo the value"             0 "$(grep -cF "$TBODY" <<<"$g_out")"
+
+  # The control is the failure itself, not an earlier form of the guard: the guard
+  # is new, so there is nothing to run against. What has to be established is that
+  # the functions behind it really do end at zero usable keys — otherwise this is
+  # machinery against nothing.
+  usable_keys() {
+    local n=0 line probe; probe="$(mktemp)"
+    while IFS= read -r line; do
+      [ -n "$line" ] || continue
+      printf '%s\n' "$line" > "$probe"
+      ssh-keygen -l -f "$probe" >/dev/null 2>&1 && n=$((n + 1))
+    done < "$1"
+    rm -f "$probe"; printf '%s\n' "$n"
+  }
+  kh="$(mktemp -d)"; mkdir -p "$kh/collavre/.ssh"
+  kauth="$kh/collavre/.ssh/authorized_keys"
+  printf '%s\n' "$GOOD_OLD" > "$kauth"
+  ksd="$(mktemp -d)"; printf '%s\n' "$GOOD_OLD" > "$ksd/ssh_public_key.collavre"
+  chk "the predecessor is usable to begin with" 1 "$(usable_keys "$kauth")"
+  ( STATE_DIR="$ksd" APP_SSH_USER=collavre SSH_PUBLIC_KEY="$TRUNC"
+    log() { :; }
+    install_authorized_keys "$kauth" "$kh"
+    revoke_prior_ssh_key "$kauth"
+    dedupe_authorized_keys "$kauth" "$SSH_PUBLIC_KEY" ) >/dev/null 2>&1
+  chk "unguarded, no key sshd can read is left" 0 "$(usable_keys "$kauth")"
+  chk "the predecessor was withdrawn"           0 "$(grep -cxF "$GOOD_OLD" "$kauth")"
+  # The two checks that would otherwise have caught it, and do not.
+  chk "while the file is not empty"             1 \
+    "$([ -s "$kauth" ] && echo 1 || echo 0)"
+  chk "and the marker names the unusable key"   1 \
+    "$(grep -cxF "$TRUNC" "$ksd/ssh_public_key.collavre")"
+fi
+
+echo "119a. where ssh-keygen is absent it warns and lets the run continue"
+# Absence cannot be modelled by hiding the binary from this shell, since
+# everything the case needs would go with it. A PATH holding only what the
+# extracted function uses is the seam — and the first assertion is what makes the
+# rest worth anything: without it the case passes on a PATH where ssh-keygen is
+# still in reach, which is the shape of vacuous pass this suite has hit before.
+kbin="$(mktemp -d)"
+for kc in bash mktemp rm; do ln -s "$(command -v "$kc")" "$kbin/$kc"; done
+kfns="$(mktemp)"; declare -f die refuse_unparsable_ssh_key > "$kfns"
+krun="$(mktemp)"
+cat > "$krun" <<'RUN'
+set -uo pipefail
+log() { echo "[log] $*"; }
+. "$FNS"
+APP_SSH_USER=collavre
+command -v ssh-keygen >/dev/null 2>&1 && echo visible=yes || echo visible=no
+refuse_unparsable_ssh_key && echo rc=0 || echo rc=1
+RUN
+kout="$(PATH="$kbin" FNS="$kfns" SSH_PUBLIC_KEY='ssh-ed25519 CUT-SHORT op@laptop' \
+        bash "$krun" 2>&1)"
+chk "ssh-keygen really is out of reach"    1 "$(grep -c 'visible=no' <<<"$kout")"
+chk "it does not refuse the run"           1 "$(grep -cx 'rc=0' <<<"$kout")"
+chk "it says the key was not checked"      1 "$(grep -c 'could not be' <<<"$kout")"
+chk "and names the account at risk"        1 "$(grep -c 'log in as collavre' <<<"$kout")"
+
+echo "119b. it is called before anything that could leave the account keyless"
+# Anchored at both ends so the pattern does not match the function's own
+# definition line, which is above the call.
+grd_line="$(grep -n '^refuse_unparsable_ssh_key$' "$SRC" | head -1 | cut -d: -f1)"
+chk "the guard is called at all"           1 "$([ -n "$grd_line" ] && echo 1 || echo 0)"
+for after in 'install_authorized_keys "\$AUTH_KEYS"' \
+             'revoke_prior_ssh_key "\$AUTH_KEYS"' \
+             'dedupe_authorized_keys "\$AUTH_KEYS"' \
+             'apt_get update' 'usermod -aG docker'; do
+  line="$(grep -n "^$after" "$SRC" | head -1 | cut -d: -f1)"
+  chk "before ${after%% *}" 1 \
+    "$([ -n "$line" ] && [ "$grd_line" -lt "$line" ] && echo 1 || echo 0)"
 done
 
 echo

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -21,7 +21,7 @@ SRC="${1:-$ROOT/script/lightsail_launch.sh}"
 # die() is a one-liner; the others run to the first column-1 closing brace.
 eval "$(awk '
   /^die\(\) \{/ { print; next }
-  /^(ensure_block|sudoers_file_name|ensure_sudoers|in_group|write_state_file|launch_record_is_complete|record_launch_settings|record_deploy_user_grant|revoke_deploy_user_access|revoke_prior_deploy_user|stage_ssh_cutover|ssh_public_key_fingerprint|ssh_cutover_auth_info_file|ssh_cutover_authenticated_with_key|ssh_cutover_has_sshd_ancestor|finalize_ssh_cutover|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|install_deploy_ssh_dir|reassign_prior_db_role|refuse_superuser_db_rotation|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps|warn_existing_containers_keep_log_config|dedupe_authorized_keys|install_staged_authorized_keys|postgresql_conf_includes_confd|role_owns_app_objects|refuse_db_name_change|refuse_defaulted_config_change|refuse_unusable_db_identifier|refuse_unparsable_ssh_key|refuse_forced_command_ssh_key|ipv4_dotted_quad|refuse_unusable_bind_address|refuse_unusable_subnet|passwd_home|ssh_key_holder|adopt_legacy_ssh_key_marker|record_db_role_grant|reassign_one_db_role|record_ssh_key_grant|refuse_root_deploy_user|append_state_line|refuse_nologin_deploy_user|resolve_symlink_chain|stage_beside|restore_postgresql_bind_config|stage_authorized_keys|scan_ssh_config_file|find_unsafe_ssh_match|verify_ssh_key_destination|ssh_pattern_list_matches|verify_ssh_admission_controls|verify_ssh_hardening|refuse_unusable_retention|refuse_unusable_backup_calendar|install_managed_config|install_downloaded_file|install_credential_summary|reload_ssh_daemon)\(\) \{/ { f = 1 }
+  /^(ensure_block|sudoers_file_name|ensure_sudoers|in_group|write_state_file|launch_record_is_complete|record_launch_settings|record_deploy_user_grant|revoke_deploy_user_access|revoke_prior_deploy_user|stage_ssh_cutover|ssh_public_key_fingerprint|ssh_public_key_material|ssh_cutover_signature_verifies|finalize_ssh_cutover|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|install_deploy_ssh_dir|reassign_prior_db_role|refuse_superuser_db_rotation|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps|warn_existing_containers_keep_log_config|dedupe_authorized_keys|install_staged_authorized_keys|postgresql_conf_includes_confd|role_owns_app_objects|refuse_db_name_change|refuse_defaulted_config_change|refuse_unusable_db_identifier|refuse_unparsable_ssh_key|refuse_forced_command_ssh_key|ipv4_dotted_quad|refuse_unusable_bind_address|refuse_unusable_subnet|passwd_home|ssh_key_holder|adopt_legacy_ssh_key_marker|record_db_role_grant|reassign_one_db_role|record_ssh_key_grant|refuse_root_deploy_user|append_state_line|refuse_nologin_deploy_user|resolve_symlink_chain|stage_beside|restore_postgresql_bind_config|stage_authorized_keys|scan_ssh_config_file|find_unsafe_ssh_match|verify_ssh_key_destination|ssh_pattern_list_matches|verify_ssh_admission_controls|verify_ssh_hardening|refuse_unusable_retention|refuse_unusable_backup_calendar|install_managed_config|install_downloaded_file|install_credential_summary|reload_ssh_daemon)\(\) \{/ { f = 1 }
   f { print }
   f && /^\}/ { f = 0 }
 ' "$SRC")"
@@ -30,9 +30,9 @@ for fn in die ensure_block sudoers_file_name ensure_sudoers in_group write_state
 	  launch_record_is_complete record_launch_settings \
           revoke_prior_deploy_user \
           record_deploy_user_grant revoke_deploy_user_access \
-	  stage_ssh_cutover ssh_cutover_has_sshd_ancestor finalize_ssh_cutover \
-	  ssh_public_key_fingerprint ssh_cutover_auth_info_file \
-	  ssh_cutover_authenticated_with_key \
+	  stage_ssh_cutover finalize_ssh_cutover \
+	  ssh_public_key_fingerprint ssh_public_key_material \
+	  ssh_cutover_signature_verifies \
           ensure_ufw_rule ssh_already_allowed ensure_ssh_rule \
           install_authorized_keys install_deploy_ssh_dir reassign_prior_db_role \
           refuse_superuser_db_rotation role_owns_app_objects revoke_prior_ssh_key \
@@ -5872,14 +5872,6 @@ chk "and keyboard-interactive still on"                   1 "$(vh "$(vh_eff no n
 chk "and public-key authentication off"                   1 "$(vh "$(vh_eff no no no no)")"
 chk "and a missing public-key result is not treated as verified" 1 \
   "$(vh "$(printf 'passwordauthentication no\npermitrootlogin no\nkbdinteractiveauthentication no')")"
-printf '%s\nexposeauthinfo no\n' "$(vh_eff no no no)" > "$vshd/eff"
-chk "an ineffective ExposeAuthInfo blocks explicit-key cutover" 1 \
-  "$( (verify_ssh_hardening "$vshd/eff" "$vshd" 0 deploybot 1 1) \
-      >/dev/null 2>&1; echo $?)"
-printf '%s\nexposeauthinfo yes\n' "$(vh_eff no no no)" > "$vshd/eff"
-chk "effective ExposeAuthInfo permits explicit-key cutover" 0 \
-  "$( (verify_ssh_hardening "$vshd/eff" "$vshd" 0 deploybot 1 1) \
-      >/dev/null 2>&1; echo $?)"
 
 printf '%s\n' "$(vh_eff yes no no)" > "$vshd/eff"
 vh_msg="$( ( verify_ssh_hardening "$vshd/eff" "$vshd" ) 2>&1 )"
@@ -6977,12 +6969,10 @@ chk "the staged account creates one pending cutover" 1 \
   "$(grep -c '^stage_ssh_cutover "\$APP_SSH_USER" "\$SSH_PUBLIC_KEY"$' "$SRC")"
 chk "the finalizer requires the sudo origin to be the staged account" 1 \
   "$(grep -cF '[ "${SUDO_USER:-}" = "$user" ] ||' "$SRC")"
-chk "and requires an sshd process ancestor" 1 \
-  "$(grep -c '^  ssh_cutover_has_sshd_ancestor "\$user" ||$' "$SRC")"
-chk "sshd exposes the key that authenticated the session" 1 \
-  "$(grep -c "^  'ExposeAuthInfo yes'$" "$SRC")"
-chk "every cutover verifies ExposeAuthInfo is effective" 1 \
-  "$(grep -c '^SSH_AUTH_INFO_REQUIRED=1$' "$SRC")"
+chk "and requires a workstation private-key signature" 1 \
+  "$(grep -c '^  ssh_cutover_signature_verifies ' "$SRC")"
+chk "without trusting host-local process names as proof" 0 \
+  "$(grep -c '^ssh_cutover_has_sshd_ancestor()' "$SRC")"
 chk "the runbook changes KAMAL_SSH_USER only after finalization" 1 \
   "$(grep -c 'Change `KAMAL_SSH_USER` only after' "$DOC")"
 
@@ -6999,48 +6989,40 @@ chk "staging creates a root-only pending record" 600 \
   "$(file_mode "$cutover_state/ssh_cutover.pending")"
 chk "and stores the exact key in that atomic record" 1 \
   "$(grep -cxF "key=$cutover_key" "$cutover_state/ssh_cutover.pending")"
+chk "and atomically binds an accepted signing key" 1 \
+  "$(grep -c '^proof_key_b64=' "$cutover_state/ssh_cutover.pending")"
 chk "without a separately replaceable key record" 0 \
   "$([ -e "$cutover_state/ssh_cutover.key" ] && echo 1 || echo 0)"
 chk "and installs the finalizer" 755 "$(file_mode "$cutover_finalizer")"
 chk "without committing the deploy user" 0 \
   "$([ -e "$cutover_state/deploy_user" ] && echo 1 || echo 0)"
 cutover_nonce="$SSH_CUTOVER_NONCE"
-cutover_fingerprint="$(ssh_public_key_fingerprint "$cutover_key")"
-proof_proc="$cutover_state/proc"
-proof_uid="$(command id -u)"
-proof_user="$(command id -un)"
-mkdir -p "$proof_proc/500" "$proof_proc/400"
-: > "$cutover_state/auth-info"
-printf 'sudo\n' > "$proof_proc/500/comm"
-printf 'SSH_USER_AUTH=%s\0' "$cutover_state/auth-info" \
-  > "$proof_proc/500/environ"
-printf 'Uid:\t%s\t%s\t%s\t%s\nPPid:\t400\n' \
-  "$proof_uid" "$proof_uid" "$proof_uid" "$proof_uid" \
-  > "$proof_proc/500/status"
-printf 'sshd\n' > "$proof_proc/400/comm"
-: > "$proof_proc/400/environ"
-printf 'Uid:\t%s\t%s\t%s\t%s\nPPid:\t1\n' \
-  "$proof_uid" "$proof_uid" "$proof_uid" "$proof_uid" \
-  > "$proof_proc/400/status"
-chk "a user-owned sshd session process proves the staged UID" 0 \
-  "$(ssh_cutover_has_sshd_ancestor "$proof_user" 500 "$proof_proc"; echo $?)"
-chk "and its user-owned authentication record is accepted" \
-  "$cutover_state/auth-info" \
-  "$(ssh_cutover_auth_info_file "$proof_user" 500 "$proof_proc")"
-other_uid=$((proof_uid + 1))
-printf 'Uid:\t%s\t%s\t%s\t%s\nPPid:\t1\n' \
-  "$other_uid" "$other_uid" "$other_uid" "$other_uid" \
-  > "$proof_proc/400/status"
-chk "a nested sudo UID below another user's sshd is refused" 1 \
-  "$(ssh_cutover_has_sshd_ancestor "$proof_user" 500 "$proof_proc"; echo $?)"
-printf 'publickey %s\n' "$cutover_key" > "$cutover_state/auth-info"
-ssh_cutover_auth_info_file() { printf '%s/auth-info\n' "$cutover_state"; }
-chk "the exposed authentication record identifies the staged key" 0 \
-  "$(ssh_cutover_authenticated_with_key deploybot "$cutover_fingerprint"; echo $?)"
-printf 'publickey ssh-ed25519 OLD predecessor\n' > "$cutover_state/auth-info"
-chk "and rejects a session authenticated by a different key" 1 \
-  "$(ssh_cutover_authenticated_with_key deploybot "$cutover_fingerprint"; echo $?)"
-unset -f ssh_cutover_auth_info_file
+copied_state="$(mktemp -d)"
+printf '%s\n' "$cutover_key" > "$copied_state/authorized_keys"
+STATE_DIR="$copied_state"
+AUTH_KEYS="$copied_state/authorized_keys"
+SSH_CUTOVER_PENDING=0
+SSH_CUTOVER_NONCE=''
+stage_ssh_cutover copiedbot "" "$copied_state/finalizer" "$SRC"
+chk "copied-key cutover also captures a signing key atomically" 1 \
+  "$(grep -c '^proof_key_b64=' "$copied_state/ssh_cutover.pending")"
+chk "without inventing an explicit rotation key" 1 \
+  "$(grep -c '^key=$' "$copied_state/ssh_cutover.pending")"
+rm -rf "$copied_state"
+STATE_DIR="$cutover_state"
+AUTH_KEYS="$cutover_state/home/.ssh/authorized_keys"
+cutover_signature="$(
+  printf 'collavre-ssh-cutover:%s:%s' deploybot "$cutover_nonce" |
+    ssh-keygen -Y sign -f "$cutover_state/staged" \
+      -n collavre-ssh-cutover 2>/dev/null |
+    base64 | tr -d '\n'
+)"
+chk "the staged private key signs the one-time challenge" 0 \
+  "$(ssh_cutover_signature_verifies deploybot "$cutover_nonce" \
+      "$cutover_signature" "$cutover_state/ssh_cutover.pending"; echo $?)"
+chk "the signature is bound to the nonce and account" 1 \
+  "$(ssh_cutover_signature_verifies another-user "$cutover_nonce" \
+      "$cutover_signature" "$cutover_state/ssh_cutover.pending"; echo $?)"
 
 mkdir -p "$cutover_state/home/.ssh"
 printf '%s\n' "$cutover_key" > "$cutover_state/home/.ssh/authorized_keys"
@@ -7052,16 +7034,6 @@ id() {
   esac
 }
 in_group() { return 0; }
-ssh_cutover_has_sshd_ancestor() {
-  [ "$1" = deploybot ] && [ "${SSH_PROOF:-0}" -eq 1 ]
-}
-ssh_cutover_auth_info_file() {
-  [ "$1" = deploybot ] && [ "${SSH_PROOF:-0}" -eq 1 ] &&
-    printf '%s/auth-info\n' "$cutover_state"
-}
-ssh_cutover_authenticated_with_key() {
-  [ "$1" = deploybot ] && [ -n "$2" ] && [ "${KEY_PROOF:-0}" -eq 1 ]
-}
 revoke_prior_ssh_key() {
   TRACE="${TRACE}key "
   write_state_file "$STATE_DIR/ssh_public_key.deploybot" \
@@ -7080,23 +7052,23 @@ revoke_prior_deploy_user() {
   write_state_file "$STATE_DIR/deploy_user" "deploybot"$'\n'
 }
 TRACE=''
-( SUDO_USER=someone-else SSH_PROOF=1 \
-    finalize_ssh_cutover "$cutover_nonce" ) >/dev/null 2>&1
+( SUDO_USER=someone-else \
+    finalize_ssh_cutover "$cutover_nonce" "$cutover_signature" ) >/dev/null 2>&1
 chk "a different sudo origin is refused" 1 "$?"
 chk "and revokes nothing" "" "$TRACE"
-( SUDO_USER=deploybot SSH_PROOF=0 \
+( SUDO_USER=deploybot \
     finalize_ssh_cutover "$cutover_nonce" ) >/dev/null 2>&1
-chk "a local or console shell is refused" 1 "$?"
+chk "a missing workstation signature is refused" 1 "$?"
 chk "and still revokes nothing" "" "$TRACE"
-( SUDO_USER=deploybot SSH_PROOF=1 KEY_PROOF=0 \
-    finalize_ssh_cutover "$cutover_nonce" ) >/dev/null 2>&1
-chk "a session authenticated by the predecessor key is refused" 1 "$?"
+( SUDO_USER=deploybot \
+    finalize_ssh_cutover "$cutover_nonce" invalid-signature ) >/dev/null 2>&1
+chk "a forged host-local proof is refused" 1 "$?"
 chk "and does not start withdrawal" "" "$TRACE"
 cp "$cutover_state/ssh_cutover.pending" \
   "$cutover_state/ssh_cutover.pending.complete"
 sed -i.bak '/^key=/d' "$cutover_state/ssh_cutover.pending"
-( SUDO_USER=deploybot SSH_PROOF=1 KEY_PROOF=1 \
-    finalize_ssh_cutover "$cutover_nonce" ) >/dev/null 2>&1
+( SUDO_USER=deploybot \
+    finalize_ssh_cutover "$cutover_nonce" "$cutover_signature" ) >/dev/null 2>&1
 chk "an older split-record challenge is refused" 1 "$?"
 chk "and cannot bypass staged-key proof" "" "$TRACE"
 mv "$cutover_state/ssh_cutover.pending.complete" \
@@ -7104,36 +7076,36 @@ mv "$cutover_state/ssh_cutover.pending.complete" \
 rm -f "$cutover_state/ssh_cutover.pending.bak"
 sed -i.bak "s|^key=.*|key=ssh-ed25519 OLD predecessor|" \
   "$cutover_state/ssh_cutover.pending"
-( SUDO_USER=deploybot SSH_PROOF=1 KEY_PROOF=1 \
-    finalize_ssh_cutover "$cutover_nonce" ) >/dev/null 2>&1
+( SUDO_USER=deploybot \
+    finalize_ssh_cutover "$cutover_nonce" "$cutover_signature" ) >/dev/null 2>&1
 chk "a key that differs from the pending fingerprint is refused" 1 "$?"
 chk "and cannot start predecessor withdrawal" "" "$TRACE"
 mv "$cutover_state/ssh_cutover.pending.bak" \
   "$cutover_state/ssh_cutover.pending"
 ( mkdir "$cutover_state/deploy_user"
-  SUDO_USER=deploybot SSH_PROOF=1 KEY_PROOF=1 \
-    finalize_ssh_cutover "$cutover_nonce" ) >/dev/null 2>&1
+  SUDO_USER=deploybot \
+    finalize_ssh_cutover "$cutover_nonce" "$cutover_signature" ) >/dev/null 2>&1
 chk "a successor commit failure is refused before withdrawal" 1 "$?"
 chk "and leaves every predecessor path untouched" "" "$TRACE"
 rmdir "$cutover_state/deploy_user"
-( SUDO_USER=deploybot SSH_PROOF=1 KEY_PROOF=1 REVOKE_KEY_FAIL=1 \
-    finalize_ssh_cutover "$cutover_nonce" ) >/dev/null 2>&1
+( SUDO_USER=deploybot REVOKE_KEY_FAIL=1 \
+    finalize_ssh_cutover "$cutover_nonce" "$cutover_signature" ) >/dev/null 2>&1
 chk "an incomplete predecessor-key withdrawal is refused" 1 "$?"
 chk "after authenticated proof the successor remains committed" deploybot \
   "$(cat "$cutover_state/deploy_user")"
 chk "while retaining the pending challenge" 1 \
   "$([ -e "$cutover_state/ssh_cutover.pending" ] && echo 1 || echo 0)"
 TRACE=''
-( SUDO_USER=deploybot SSH_PROOF=1 KEY_PROOF=1 REVOKE_ACCOUNT_FAIL=1 \
-    finalize_ssh_cutover "$cutover_nonce" ) >/dev/null 2>&1
+( SUDO_USER=deploybot REVOKE_ACCOUNT_FAIL=1 \
+    finalize_ssh_cutover "$cutover_nonce" "$cutover_signature" ) >/dev/null 2>&1
 chk "a predecessor-account cleanup failure is retryable" 1 "$?"
 chk "with the proven successor still committed" deploybot \
   "$(cat "$cutover_state/deploy_user")"
 chk "and the pending cleanup record retained" 1 \
   "$([ -e "$cutover_state/ssh_cutover.pending" ] && echo 1 || echo 0)"
 TRACE=''
-SUDO_USER=deploybot SSH_PROOF=1 KEY_PROOF=1 \
-  finalize_ssh_cutover "$cutover_nonce" >/dev/null
+SUDO_USER=deploybot \
+  finalize_ssh_cutover "$cutover_nonce" "$cutover_signature" >/dev/null
 chk "an authenticated SSH proof commits key then account" "key account " "$TRACE"
 chk "and consumes the pending state" 0 \
   "$([ -e "$cutover_state/ssh_cutover.pending" ] && echo 1 || echo 0)"
@@ -7172,9 +7144,7 @@ revoke_deploy_user_access release.bot release_bot "$sudoers_collision"
 chk "a colliding successor sudoers grant is preserved" 1 \
   "$(grep -cxF 'release_bot ALL=(ALL:ALL) NOPASSWD:ALL' \
       "$sudoers_collision/90-collavre-release_bot")"
-unset -f getent id in_group ssh_cutover_has_sshd_ancestor \
-  ssh_cutover_auth_info_file ssh_cutover_authenticated_with_key \
-  revoke_prior_ssh_key revoke_prior_deploy_user rm
+unset -f getent id in_group revoke_prior_ssh_key revoke_prior_deploy_user rm
 rm -rf "$cutover_state"
 
 echo

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -4541,13 +4541,19 @@ chk "and the previous backup script is still the live one" \
 chk "and no staging file is left behind" \
   0 "$(find "$bd" -name 'collavre-pg-backup.*' | wc -l | tr -d ' ')"
 seed_backup
-# A value that closes the quote the template opens, so the generated file is
-# genuinely unparseable rather than merely odd-looking. My first attempt used
-# `collavre ) unbalanced`, which lands inside the quotes and parses fine — the
-# case passed nothing and said so. refuse_unusable_db_identifier rejects such a
-# DB_NAME long before this point in a real run; this check is what stands behind
-# it, and behind every future value interpolated into a generated program.
-out=$(run_backup_section 'DB_NAME='"'"'x"; ) ; #'"'"'')
+# The invalidity is injected into the generated text rather than smuggled in
+# through a configured value. It used to be the latter — a DB_NAME closing the
+# quote the template opened — and case 133 took that route away: the three
+# configured values are serialized with %q now, so no value can make the file
+# unparseable. That is the fix working, not this assertion becoming true; but a
+# fixture whose premise its own codebase has made unreachable asserts nothing,
+# which is what it did here (`expected [1] got [0]`) before this rewrite.
+#
+# What the check is still for: truncation, which reaches this from the other
+# side, and the next value interpolated into a generated program by someone who
+# does not know about %q. Both produce exactly this — a staged file that is not
+# a whole script — so that is what the fixture produces directly.
+out=$(run_backup_section 'printf() { command printf "$@"; command printf "if [\n"; }')
 chk "a generated script that is not valid shell refuses" \
   1 "$(printf '%s' "$out" | grep -c '^DIE:')"
 chk "and the previous backup script survives that too" \
@@ -4781,6 +4787,55 @@ case "$LOGGED" in
 esac
 unset -f ufw
 rm -rf "$sd"
+
+echo "133. configured values reach the backup script as data, not as source"
+# The generated file is a *program*, so a value spliced into it verbatim is not
+# a string in that program — it is source text the nightly unit evaluates as
+# root. A legitimate S3 key prefix can carry either shape, and `bash -n` accepts
+# both: they are perfectly good shell, which is exactly the problem. The
+# validation below asks whether the file is a program, not whether it is the
+# intended one, so it cannot be what closes this.
+gen_backup() {
+  # The generation step as shipped, reduced to the three configured values and
+  # one line that uses one of them.
+  { printf '%s\n' '#!/usr/bin/env bash' 'set -euo pipefail' \
+      && printf 'DB_NAME=%q\nRETENTION_DAYS=%q\nS3_URI=%q\n' \
+           collavre_production 7 "$1" \
+      && printf 'echo "UPLOAD-TO=${S3_URI%%/}"\n'; } > "$2"
+}
+bk=$(mktemp -d)
+# Command substitution in a configured prefix must survive as characters.
+gen_backup 's3://b/$(touch '"$bk"'/RAN; echo pwned)/db' "$bk/gen"
+out="$(bash "$bk/gen" 2>&1)"
+chk "a substitution in the S3 prefix is not executed" 0 \
+  "$([ -f "$bk/RAN" ] && echo 1 || echo 0)"
+chk "and reaches the upload as characters" \
+  'UPLOAD-TO=s3://b/$(touch '"$bk"'/RAN; echo pwned)/db' "$out"
+# A literal $name is the quieter half: under the generated script's own `set -u`
+# the spliced form dies with `unbound variable`, so the nightly backup stops
+# and the failure is nowhere near the value that caused it.
+gen_backup 's3://b/$archive/db' "$bk/gen2"
+out2="$(bash "$bk/gen2" 2>&1)"; rc2=$?
+chk "a literal \$name does not kill the nightly run" 0 "$rc2"
+chk "and is uploaded to the prefix as configured" \
+  'UPLOAD-TO=s3://b/$archive/db' "$out2"
+# The controls in the other direction, and the ones that constrain the fix:
+# every real host has one of these two, so a change in either is a change to
+# where every existing backup goes.
+gen_backup 's3://collavre-backups/prod' "$bk/gen3"
+chk "an ordinary prefix is unchanged" 'UPLOAD-TO=s3://collavre-backups/prod' \
+  "$(bash "$bk/gen3" 2>&1)"
+gen_backup '' "$bk/gen4"
+chk "and the unset default stays empty" 'UPLOAD-TO=' "$(bash "$bk/gen4" 2>&1)"
+rm -rf "$bk"
+# Source-level control. The assertions above are about the shape of the
+# generation step, so this is what fails against a revert: the heredoc spliced
+# all three in, and %q is what replaced it.
+chk "no configured value is spliced into the generated script" 0 \
+  "$(grep -cE '^(DB_NAME="\$DB_NAME"|RETENTION_DAYS=\$BACKUP_RETENTION_DAYS|S3_URI="\$BACKUP_S3_URI")$' "$SRC")"
+chk "they are serialized with %q instead" 1 \
+  "$(grep -c "printf 'DB_NAME=%q" "$SRC")"
+
 
 echo
 if [ "$fail" = 0 ]; then echo "ALL PASS"; else echo "FAILURES"; fi

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -21,14 +21,15 @@ SRC="${1:-$ROOT/script/lightsail_launch.sh}"
 # die() is a one-liner; the others run to the first column-1 closing brace.
 eval "$(awk '
   /^die\(\) \{/ { print; next }
-  /^(ensure_block|ensure_sudoers|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|reassign_prior_db_role|revoke_prior_ssh_key)\(\) \{/ { f = 1 }
+  /^(ensure_block|ensure_sudoers|in_group|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|reassign_prior_db_role|revoke_prior_ssh_key|ensure_cluster_on_default_port)\(\) \{/ { f = 1 }
   f { print }
   f && /^\}/ { f = 0 }
 ' "$SRC")"
 
-for fn in die ensure_block ensure_sudoers revoke_prior_deploy_user \
+for fn in die ensure_block ensure_sudoers in_group revoke_prior_deploy_user \
           ensure_ufw_rule ssh_already_allowed ensure_ssh_rule \
-          install_authorized_keys reassign_prior_db_role revoke_prior_ssh_key; do
+          install_authorized_keys reassign_prior_db_role revoke_prior_ssh_key \
+          ensure_cluster_on_default_port; do
   declare -F "$fn" >/dev/null || {
     echo "could not extract $fn() from $SRC — has the definition moved?" >&2
     exit 1
@@ -157,24 +158,46 @@ esac
 unset -f visudo
 
 # --------------------------------------------------------------------------
-# revoke_prior_deploy_user talks to the host account database, so `id` and
-# `gpasswd` are stubbed. Shell functions shadow both, and `log` is captured
-# rather than printed so the warning can be asserted on.
+# revoke_prior_deploy_user talks to the host account database, so `id`,
+# `gpasswd`, `usermod` and `groupadd` are stubbed. Shell functions shadow them,
+# and `log` is captured rather than printed so the warning can be asserted on.
+#
+# The stubs MUTATE $GROUPS_OF rather than only recording the call, because the
+# function now re-reads membership to decide what it claims. A stub that always
+# reported success would make the "could not revoke" path untestable — which is
+# the path that matters.
+#
+# GROUPS_OF is "primary supplementary...", matching `id -nG` output order, so
+# the primary group is its first word. gpasswd refuses primary groups with
+# exit 3 exactly as the real one does; verified on ubuntu:24.04.
 # --------------------------------------------------------------------------
 ACCOUNT=""      # the only user that exists, and its groups
 GROUPS_OF=""
 REVOKED=""      # every gpasswd -d, as "user/group"
+USERMOD=""      # every usermod -g, as "user:group"
 LOGGED=""
 id() {
   case "$1" in
     -u)  [ "$2" = "$ACCOUNT" ] ;;
     -nG) [ "$2" = "$ACCOUNT" ] || return 1; printf '%s\n' "$GROUPS_OF" ;;
+    -gn) [ "$2" = "$ACCOUNT" ] || return 1; printf '%s\n' "${GROUPS_OF%% *}" ;;
     *)   return 1 ;;
   esac
 }
-gpasswd() { REVOKED="$REVOKED $2/$3"; }
+gpasswd() {
+  REVOKED="$REVOKED $2/$3"
+  # /etc/group only: a primary membership lives in /etc/passwd and is refused.
+  [ "${GROUPS_OF%% *}" = "$3" ] && return 3
+  GROUPS_OF="$(printf '%s\n' "$GROUPS_OF" | tr ' ' '\n' | grep -vxF "$3" | tr '\n' ' ')"
+  GROUPS_OF="${GROUPS_OF% }"
+}
+usermod() {   # usermod -g <group> <user>
+  USERMOD="$USERMOD $3:$2"
+  supp="$(printf '%s\n' "$GROUPS_OF" | cut -s -d' ' -f2-)"; GROUPS_OF="$2${supp:+ $supp}"
+}
+groupadd() { :; }
 log() { LOGGED="$LOGGED $*"; }
-revoke() { REVOKED=""; LOGGED=""; revoke_prior_deploy_user "$@"; }
+revoke() { REVOKED=""; USERMOD=""; LOGGED=""; revoke_prior_deploy_user "$@"; }
 
 echo "11. the deploy user a re-run replaces loses its root-equivalent access"
 # Docker membership is the point: ensure_sudoers takes back the NOPASSWD file,
@@ -215,7 +238,51 @@ ACCOUNT=""                                  # already deluser'd by hand
 revoke deploybot "$d2/deploy_user"
 chk "account is gone"  "" "$REVOKED$LOGGED"
 
-unset -f id gpasswd log revoke
+echo "15. a PRIMARY docker group is taken back too, not just a supplementary one"
+# gpasswd cannot remove a primary group — it exits 3 while `id -nG` goes on
+# reporting the membership. An account made with `useradd -g docker` would
+# otherwise keep a root shell through the docker socket after a rotation that
+# reported success.
+d3=$(mktemp -d); printf 'legacy\n' > "$d3/deploy_user"
+ACCOUNT=legacy; GROUPS_OF="docker sudo"      # docker is PRIMARY here
+revoke deploybot "$d3/deploy_user"
+chk "no longer in docker" 1 "$(printf '%s\n' "$GROUPS_OF" | tr ' ' '\n' | grep -cvxF docker)"
+chk "primary group moved to its own" " legacy:legacy" "$USERMOD"
+chk "sudo revoked by gpasswd"        " legacy/sudo"   "$REVOKED"
+case "$LOGGED" in
+  *"could NOT revoke"*) echo "  FAIL claimed failure on a revocation that worked: $LOGGED"; fail=1 ;;
+  *"can still log in"*) echo "  ok   reports the account as revoked but still present" ;;
+  *) echo "  FAIL no warning at all: $LOGGED"; fail=1 ;;
+esac
+chk "marker advanced" "deploybot" "$(cat "$d3/deploy_user")"
+
+echo "16. a revocation that does not take is reported, not claimed as done"
+# The failure this replaces: gpasswd exits nonzero, the && swallows it, and the
+# unconditional warning tells the operator the account lost root when it did not.
+d4=$(mktemp -d); printf 'legacy\n' > "$d4/deploy_user"
+ACCOUNT=legacy; GROUPS_OF="docker"
+usermod() { USERMOD="$USERMOD $3:$2"; }      # the host refuses the change
+revoke deploybot "$d4/deploy_user"
+case "$LOGGED" in
+  *"could NOT revoke docker"*) echo "  ok   says which group it failed to take back" ;;
+  *) echo "  FAIL silent or wrongly reassuring: $LOGGED"; fail=1 ;;
+esac
+case "$LOGGED" in
+  *"no longer in docker or sudo"*) echo "  FAIL still claims the access is gone"; fail=1 ;;
+  *) echo "  ok   does not claim the access is gone" ;;
+esac
+
+echo "17. and the marker is not advanced, so the next run retries"
+# Advancing it here would forget which account still holds root — a permanent
+# silent failure rather than one the next FORCE=1 run picks up.
+chk "marker still names the unrevoked user" "legacy" "$(cat "$d4/deploy_user")"
+unset -f usermod
+usermod() { USERMOD="$USERMOD $3:$2"; supp="$(printf '%s\n' "$GROUPS_OF" | cut -s -d' ' -f2-)"; GROUPS_OF="$2${supp:+ $supp}"; }
+revoke deploybot "$d4/deploy_user"           # the retry, on a healthy host
+chk "the retry revokes it"     1 "$(printf '%s\n' "$GROUPS_OF" | tr ' ' '\n' | grep -cvxF docker)"
+chk "and then advances" "deploybot" "$(cat "$d4/deploy_user")"
+
+unset -f id gpasswd usermod groupadd log revoke
 
 # --------------------------------------------------------------------------
 # The firewall helpers shell out to ufw, so it is stubbed: every invocation is
@@ -230,7 +297,7 @@ ufw() {
 }
 log() { LOGGED="$LOGGED $*"; }
 
-echo "15. the postgres rule is added once and recorded"
+echo "18. the postgres rule is added once and recorded"
 d=$(mktemp -d)
 UFW_CALLS=""
 ensure_ufw_rule postgres "allow from 172.17.0.0/16 to 172.17.0.1 port 5432 proto tcp" \
@@ -239,7 +306,7 @@ chk "rule added" "|allow from 172.17.0.0/16 to 172.17.0.1 port 5432 proto tcp" "
 chk "recorded"   "allow from 172.17.0.0/16 to 172.17.0.1 port 5432 proto tcp" \
   "$(cat "$d/ufw_postgres")"
 
-echo "16. an unchanged rule deletes nothing"
+echo "19. an unchanged rule deletes nothing"
 # The common re-run. ufw skips re-adding an identical rule itself, so the only
 # thing that must not happen here is a delete.
 UFW_CALLS=""; LOGGED=""
@@ -247,7 +314,7 @@ ensure_ufw_rule postgres "allow from 172.17.0.0/16 to 172.17.0.1 port 5432 proto
   "$d/ufw_postgres"
 chk "no delete" 0 "$(printf '%s' "$UFW_CALLS" | grep -c delete)"
 
-echo "17. a changed rule withdraws the old one instead of accumulating"
+echo "20. a changed rule withdraws the old one instead of accumulating"
 # Without this, moving DB_BIND_ADDRESS or DOCKER_SUBNETS would leave the
 # previous subnet reaching 5432 for the life of the host.
 UFW_CALLS=""; LOGGED=""
@@ -260,32 +327,42 @@ chk "new rule added" 1 "$(printf '%s' "$UFW_CALLS" | grep -c '|allow from 10.200
 chk "state advanced" "allow from 10.200.0.0/16 to 172.18.0.1 port 5432 proto tcp" \
   "$(cat "$d/ufw_postgres")"
 
-echo "18. unrelated operator rules are never touched"
+echo "21. unrelated operator rules are never touched"
 # The whole reason `ufw reset` is gone: a re-run must not disturb a VPN,
 # monitoring or allowlist rule this script knows nothing about.
 chk "only our own rule deleted" 1 "$(printf '%s' "$UFW_CALLS" | grep -c delete)"
 chk "no reset"                  0 "$(printf '%s' "$UFW_CALLS" | grep -c reset)"
 
-echo "19. SSH already allowed is detected in every form ufw prints it"
+echo "22. SSH already allowed is detected in every form ufw prints it"
 for s in "22/tcp                     ALLOW       Anywhere" \
          "22                         ALLOW IN    Anywhere" \
          "OpenSSH                    ALLOW       Anywhere" \
          "22/tcp (v6)                ALLOW       Anywhere (v6)" \
-         "22/tcp                     ALLOW IN    203.0.113.4"; do
+         "22/tcp                     ALLOW IN    203.0.113.4" \
+         "22/tcp                     LIMIT       203.0.113.9" \
+         "22/tcp                     LIMIT IN    Anywhere" \
+         "22/tcp (v6)                LIMIT       Anywhere (v6)"; do
   STATUS="$s"
   ssh_already_allowed
-  chk "detected: ${s%% *}${s##*ALLOW}" 0 "$?"
+  chk "detected: $s" 0 "$?"
 done
 
-echo "20. a narrowed SSH rule survives the re-run that finds it"
+echo "23. a narrowed SSH rule survives the re-run that finds it"
 # The rule an operator most plausibly tightens by hand. Re-adding the blanket
 # `allow OpenSSH` on top would reopen 22 to the internet and look like a no-op.
-STATUS="22/tcp                     ALLOW IN    203.0.113.4"
-UFW_CALLS=""
-ensure_ssh_rule
-chk "blanket rule not added" "" "$UFW_CALLS"
+#
+# LIMIT is here because it is what ufw's own documentation recommends for SSH:
+# reading only ALLOW meant a rate-limited, source-restricted rule was reported
+# as "nothing authorizes SSH", and the blanket rule went in beside it.
+for s in "22/tcp                     ALLOW IN    203.0.113.4" \
+         "22/tcp                     LIMIT       203.0.113.9"; do
+  STATUS="$s"
+  UFW_CALLS=""
+  ensure_ssh_rule
+  chk "blanket rule not added over [${s#22/tcp                     }]" "" "$UFW_CALLS"
+done
 
-echo "21. no SSH rule at all means one is added, never assumed"
+echo "24. no SSH rule at all means one is added, never assumed"
 # Failing the other way enables a deny-by-default firewall on a host with no
 # way back in, so every uncertain status must land here.
 for s in "Status: inactive" \
@@ -299,7 +376,7 @@ for s in "Status: inactive" \
   chk "rule added for [${s:-empty status}]" "|allow OpenSSH" "$UFW_CALLS"
 done
 
-echo "22. a missing OpenSSH profile falls back to the port, it does not give up"
+echo "25. a missing OpenSSH profile falls back to the port, it does not give up"
 # `ufw allow OpenSSH` exits 1 where openssh-server is not installed, and the
 # `ufw --force enable` that follows would then close 22 on a host reachable
 # only over 22.
@@ -382,12 +459,12 @@ STUB
   rm -rf "$work"
 }
 
-echo "23. a clean cutover cleans up and boots"
+echo "26. a clean cutover cleans up and boots"
 FAIL_COPY='' FAIL_REVOKE='' FAIL_SCP='' FAIL_STAGE='' run_cutover
 chk "staged file removed" 1 "$(grep -c RM_STAGED <<<"${RECIPE_TRACE//|/$'\n'}")"
 chk "app booted"          1 "$(grep -cx 'kamal:app boot' <<<"${RECIPE_TRACE//|/$'\n'}")"
 
-echo "24. a failed copy does not boot, and keeps the file the retry needs"
+echo "27. a failed copy does not boot, and keeps the file the retry needs"
 # MIGRATION_RUN_RESET drops the schema before loading, so a copy that dies
 # partway leaves the database empty or half-populated. Booting serves that.
 # The `sudo rm` is the other half: it destroys the staged SQLite file, so a
@@ -401,7 +478,7 @@ case "$RECIPE_OUT" in
   *) echo "  FAIL silent or partial: $RECIPE_OUT"; fail=1 ;;
 esac
 
-echo "25. a failed revoke does not boot the credential-bearing container"
+echo "28. a failed revoke does not boot the credential-bearing container"
 # collavre_user is the role in DATABASE_URL. Booting while it is still a
 # superuser hands every app container that privilege.
 FAIL_COPY='' FAIL_REVOKE=1 FAIL_SCP='' FAIL_STAGE='' run_cutover
@@ -411,7 +488,7 @@ case "$RECIPE_OUT" in
   *) echo "  FAIL silent: $RECIPE_OUT"; fail=1 ;;
 esac
 
-echo "26. both failing reports both, not just the first"
+echo "29. both failing reports both, not just the first"
 FAIL_COPY=1 FAIL_REVOKE=1 FAIL_SCP='' FAIL_STAGE='' run_cutover
 chk "app NOT booted" 0 "$(grep -cx 'kamal:app boot' <<<"${RECIPE_TRACE//|/$'\n'}")"
 case "$RECIPE_OUT" in
@@ -419,7 +496,7 @@ case "$RECIPE_OUT" in
   *) echo "  FAIL one masked the other: $RECIPE_OUT"; fail=1 ;;
 esac
 
-echo "27. a failed scp never converts, so a stale snapshot cannot be restored"
+echo "30. a failed scp never converts, so a stale snapshot cannot be restored"
 # The task loads from the file in the VOLUME, not from the one scp just sent.
 # Case 24 deliberately keeps the staged file so a retry need not re-copy — so
 # on a retry the volume holds the previous attempt's snapshot. Ungated, a
@@ -435,7 +512,7 @@ case "$RECIPE_OUT" in
   *) echo "  FAIL silent or vague: $RECIPE_OUT"; fail=1 ;;
 esac
 
-echo "28. a failed install into the volume is caught too, not just the scp"
+echo "31. a failed install into the volume is caught too, not just the scp"
 # scp can succeed to /tmp and the privileged install still fail — no space,
 # no docker group, volume gone.
 FAIL_COPY='' FAIL_REVOKE='' FAIL_SCP='' FAIL_STAGE=1 run_cutover
@@ -443,7 +520,7 @@ chk "no conversion ran"    0 "$(grep -cx 'kamal:app exec' <<<"${RECIPE_TRACE//|/
 chk "no superuser granted" 0 "$(grep -cx GRANT <<<"${RECIPE_TRACE//|/$'\n'}")"
 chk "app NOT booted"       0 "$(grep -cx 'kamal:app boot' <<<"${RECIPE_TRACE//|/$'\n'}")"
 
-echo "29. staging renames into place rather than writing the live path directly"
+echo "32. staging renames into place rather than writing the live path directly"
 # An interrupted copy must leave the previous file intact, not a truncated
 # database the next run would happily convert from.
 case "$recipe" in
@@ -478,12 +555,12 @@ STUB
   rm -rf "$work"
 }
 
-echo "30. a clean fresh install prints the admin password and boots"
+echo "33. a clean fresh install prints the admin password and boots"
 FAIL_LOAD='' run_fresh
 chk "app stopped first" 1 "$(grep -cx 'kamal:app stop' <<<"${FRESH_TRACE//|/$'\n'}")"
 chk "app booted"        1 "$(grep -cx 'kamal:app boot' <<<"${FRESH_TRACE//|/$'\n'}")"
 
-echo "31. a failed schema load does not boot the app onto a partial schema"
+echo "34. a failed schema load does not boot the app onto a partial schema"
 # db:schema:load drops and recreates every table, and db:seed is what creates
 # the first admin — so a load that resets the database but does not finish
 # leaves an app with no way to sign in and no owner on any record.
@@ -503,7 +580,7 @@ LOGGED=""
 # shellcheck disable=SC2329  # called by install_authorized_keys, eval'd from the script
 log() { LOGGED="$LOGGED $*"; }
 
-echo "32. the deploy user's own keys are not copied onto themselves"
+echo "35. the deploy user's own keys are not copied onto themselves"
 # APP_SSH_USER=ubuntu — src and dest are one file.
 h=$(mktemp -d); mkdir -p "$h/ubuntu/.ssh"
 printf 'ssh-ed25519 CLOUDKEY cloud\n' > "$h/ubuntu/.ssh/authorized_keys"
@@ -516,13 +593,13 @@ case "$LOGGED" in
   *) echo "  FAIL no explanation: $LOGGED"; fail=1 ;;
 esac
 
-echo "33. a separate deploy user still inherits the cloud user's keys"
+echo "36. a separate deploy user still inherits the cloud user's keys"
 mkdir -p "$h/collavre/.ssh"; : > "$h/collavre/.ssh/authorized_keys"
 SSH_PUBLIC_KEY="" LOGGED=""
 install_authorized_keys "$h/collavre/.ssh/authorized_keys" "$h"
 chk "cloud key copied" 1 "$(grep -c CLOUDKEY "$h/collavre/.ssh/authorized_keys")"
 
-echo "34. an explicit SSH_PUBLIC_KEY is added once, not once per run"
+echo "37. an explicit SSH_PUBLIC_KEY is added once, not once per run"
 # shellcheck disable=SC2034  # read by install_authorized_keys, eval'd from the script
 SSH_PUBLIC_KEY="ssh-ed25519 EXPLICIT me"
 install_authorized_keys "$h/collavre/.ssh/authorized_keys" "$h"
@@ -542,7 +619,7 @@ NEW="ssh-ed25519 NEWKEY current"
 OPERATOR="ssh-rsa OPKEY someone-else"
 st=$(mktemp -d)
 
-echo "35. rotating SSH_PUBLIC_KEY withdraws the key the last run installed"
+echo "38. rotating SSH_PUBLIC_KEY withdraws the key the last run installed"
 printf '%s\n%s\n' "$OLD" "$OPERATOR" > "$AK"
 printf '%s\n' "$OLD" > "$st/ssh_public_key"
 SSH_PUBLIC_KEY="$NEW" LOGGED=""
@@ -553,18 +630,18 @@ chk "the retired key is gone"      0 "$(grep -cxF "$OLD" "$AK")"
 chk "an operator's own key stays"  1 "$(grep -cxF "$OPERATOR" "$AK")"
 chk "state advanced to the new key" "$NEW" "$(cat "$st/ssh_public_key")"
 
-echo "36. an unchanged SSH_PUBLIC_KEY withdraws nothing"
+echo "39. an unchanged SSH_PUBLIC_KEY withdraws nothing"
 before="$(cat "$AK")"
 revoke_prior_ssh_key "$AK" "$st/ssh_public_key"
 chk "authorized_keys untouched" "$before" "$(cat "$AK")"
 
-echo "37. an empty SSH_PUBLIC_KEY means 'keep the cloud keys', not 'retire mine'"
+echo "40. an empty SSH_PUBLIC_KEY means 'keep the cloud keys', not 'retire mine'"
 # Dropping the variable from a re-run must not strand the operator.
 SSH_PUBLIC_KEY=""
 revoke_prior_ssh_key "$AK" "$st/ssh_public_key"
 chk "nothing withdrawn" "$before" "$(cat "$AK")"
 
-echo "38. the predecessor is never withdrawn before the successor is in place"
+echo "41. the predecessor is never withdrawn before the successor is in place"
 # An interrupted run must leave two usable keys, never zero.
 printf '%s\n' "$OLD" > "$AK"
 printf '%s\n' "$OLD" > "$st/ssh_public_key"
@@ -572,7 +649,7 @@ SSH_PUBLIC_KEY="$NEW"
 revoke_prior_ssh_key "$AK" "$st/ssh_public_key"     # successor not added yet
 chk "the old key still lets you in" 1 "$(grep -cxF "$OLD" "$AK")"
 
-echo "39. first run and an already-absent key are no-ops"
+echo "42. first run and an already-absent key are no-ops"
 st2=$(mktemp -d)
 printf '%s\n' "$NEW" > "$AK"
 # shellcheck disable=SC2034  # read by revoke_prior_ssh_key, eval'd from the script
@@ -584,7 +661,7 @@ printf '%s\n' "$OLD" > "$st2/ssh_public_key"        # recorded but already remov
 revoke_prior_ssh_key "$AK" "$st2/ssh_public_key"
 chk "still just the new key" "$NEW" "$(cat "$AK")"
 
-echo "40. a rewrite that cannot be completed keeps the old key instead of none"
+echo "43. a rewrite that cannot be completed keeps the old key instead of none"
 # The realistic trigger is a full disk: `grep -vxF > $tmp` writes nothing and
 # exits 2, the `|| true` hides it, and writing that empty result back would
 # leave authorized_keys with no keys at all — locking the deploy account out of
@@ -609,7 +686,7 @@ case "$LOGGED" in
   *) echo "  FAIL silent or reported as withdrawn: $LOGGED"; fail=1 ;;
 esac
 
-echo "41. a rewrite that stops PART WAY also keeps the old key instead of none"
+echo "44. a rewrite that stops PART WAY also keeps the old key instead of none"
 # Case 40 is the write that produces nothing. This is the write that produces
 # some of the file, which a size test cannot tell from a good one — and it is
 # the likelier shape on a nearly-full disk. It matters more than it looks:
@@ -642,7 +719,7 @@ case "$LOGGED" in
   *) echo "  FAIL silent or reported as withdrawn: $LOGGED"; fail=1 ;;
 esac
 
-echo "42. the scratch file is staged beside authorized_keys, not in TMPDIR"
+echo "45. the scratch file is staged beside authorized_keys, not in TMPDIR"
 # Same filesystem, so the rewrite cannot fail for space the staging just
 # proved is available, and a full or unwritable /tmp is not on its own able to
 # break the file the operator logs in with.
@@ -698,7 +775,7 @@ psql_as_postgres() {
 log() { LOGGED="$LOGGED $*"; }
 rotate() { SQL=""; LOGGED=""; reassign_prior_db_role "$@"; }
 
-echo "43. rotating DB_USER moves the tables and retires the old credential"
+echo "46. rotating DB_USER moves the tables and retires the old credential"
 # ALTER DATABASE ... OWNER only moves the database. Every table and sequence
 # the app created stays with the old role, so the new one in DATABASE_URL gets
 # "permission denied" on its own data — while the old role keeps LOGIN and the
@@ -710,11 +787,11 @@ chk "ownership moved, then login revoked" \
     '|REASSIGN OWNED BY "collavre_user" TO "collavre_app"|ALTER ROLE "collavre_user" NOLOGIN' \
     "$SQL"
 
-echo "44. an unchanged DB_USER touches nothing"
+echo "47. an unchanged DB_USER touches nothing"
 rotate collavre_user "$d3/db_user"
 chk "no SQL" "" "$SQL$LOGGED"
 
-echo "45. a superuser predecessor is reported, never disabled"
+echo "48. a superuser predecessor is reported, never disabled"
 # DB_USER=postgres on a first run is legal. NOLOGIN on the cluster superuser
 # locks every operator out of administering it — peer auth needs LOGIN too, so
 # there is no way back in.
@@ -727,7 +804,7 @@ case "$LOGGED" in
   *) echo "  FAIL silent: $LOGGED"; fail=1 ;;
 esac
 
-echo "46. first run, emptied marker and a dropped role are all no-ops"
+echo "49. first run, emptied marker and a dropped role are all no-ops"
 d4=$(mktemp -d)
 ROLE_IS_SUPER=f
 rotate collavre_user "$d4/db_user"          # no marker yet
@@ -741,6 +818,62 @@ rotate collavre_app "$d4/db_user"
 chk "role is gone" "" "$SQL$LOGGED"
 
 unset -f psql_as_postgres log rotate
+
+# --------------------------------------------------------------------------
+# ensure_cluster_on_default_port reads `pg_lsclusters -h`, so a stub standing in
+# for it is passed by name. The layouts below are real output from ubuntu:24.04
+# with postgresql-16 installed and postgresql-17 added afterwards.
+# --------------------------------------------------------------------------
+DB_PORT=5432
+mk_lsclusters() {   # mk_lsclusters <name> <lines...>
+  local bin="$CLUSTER_BIN_DIR/$1"; shift
+  { echo '#!/bin/sh'; printf 'cat <<%s\n%s\n%s\n' EOF "$*" EOF; } > "$bin"
+  chmod +x "$bin"
+}
+CLUSTER_BIN_DIR="$(mktemp -d)"
+PATH="$CLUSTER_BIN_DIR:$PATH"
+
+echo "50. a bumped PG_MAJOR that would land on a second port is refused"
+# pg_createcluster allocates the first free port from 5432 up, so installing a
+# new major version beside an existing one puts it on 5433 — while psql, the
+# database, the backups and DATABASE_URL all keep using 5432. Provisioning would
+# report "PostgreSQL 17" with the app still on 16 and nothing failing.
+PG_MAJOR=17
+mk_lsclusters pg_ls_16only '16  main    5432 online postgres /var/lib/postgresql/16/main /var/log/x'
+out="$( (ensure_cluster_on_default_port pg_ls_16only) 2>&1 )"
+chk "exits non-zero" 1 "$?"
+case "$out" in
+  *"already serves 5432"*"pg_upgradecluster"*)
+    echo "  ok   names the version holding the port and how to migrate" ;;
+  *) echo "  FAIL unhelpful message: $out"; fail=1 ;;
+esac
+
+echo "51. an existing cluster of the RIGHT version on the wrong port is refused too"
+# The other way in: the operator moved 17 to 5433 by hand, or a previous run
+# created it beside something since removed. Everything downstream names 5432.
+mk_lsclusters pg_ls_17_5433 '17  main    5433 online postgres /var/lib/postgresql/17/main /var/log/x'
+out="$( (ensure_cluster_on_default_port pg_ls_17_5433) 2>&1 )"
+chk "exits non-zero" 1 "$?"
+case "$out" in
+  *"listens on 5433, not 5432"*) echo "  ok   says which port it found" ;;
+  *) echo "  FAIL unhelpful message: $out"; fail=1 ;;
+esac
+
+echo "52. the supported layouts are allowed through"
+# A bare host (no postgresql-common yet) and the ordinary re-run must not be
+# refused — this guard exists to catch a silent miss, not to block convergence.
+out="$( (ensure_cluster_on_default_port pg_ls_absent) 2>&1 )"
+chk "no clusters at all: proceeds" 0 "$?"
+chk "and says nothing"             "" "$out"
+mk_lsclusters pg_ls_17ok '17  main    5432 online postgres /var/lib/postgresql/17/main /var/log/x'
+out="$( (ensure_cluster_on_default_port pg_ls_17ok) 2>&1 )"
+chk "the ordinary re-run: proceeds" 0 "$?"
+chk "and says nothing"              "" "$out"
+# A leftover cluster parked off the default port is not ours to adjudicate, so
+# long as PG_MAJOR is the one actually serving the app.
+mk_lsclusters pg_ls_both "$(printf '17  main    5432 online postgres /a /b\n16  main    5433 online postgres /c /d')"
+out="$( (ensure_cluster_on_default_port pg_ls_both) 2>&1 )"
+chk "ours on 5432 beside an idle old one: proceeds" 0 "$?"
 
 echo
 if [ "$fail" = 0 ]; then echo "ALL PASS"; else echo "FAILURES"; fi

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -6975,6 +6975,8 @@ chk "without trusting host-local process names as proof" 0 \
   "$(grep -c '^ssh_cutover_has_sshd_ancestor()' "$SRC")"
 chk "the runbook changes KAMAL_SSH_USER only after finalization" 1 \
   "$(grep -c 'Change `KAMAL_SSH_USER` only after' "$DOC")"
+chk "the proof SSH command cannot fall back to an agent predecessor key" 1 \
+  "$(grep -c 'ssh -o IdentitiesOnly=yes -i' "$DOC")"
 
 cutover_state="$(mktemp -d)"
 cutover_finalizer="$cutover_state/finalizer"

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -5143,6 +5143,67 @@ esac
 chk "the block says what to do when the drops are refused" 1 \
   "$(grep -c 'must be owner of table' "$DOC")"
 
+echo "140. a DB_USER rotated back to a previous name can log in again"
+# reassign_prior_db_role takes LOGIN from the role it replaces, and the CREATE
+# that carries LOGIN is skipped for a role that already exists. So a host going
+# DB_USER a -> b -> a used to end with an ALTER that set only the password.
+# Measured on a real PostgreSQL cluster, the same three runs each time:
+#
+#   run                shipped                              with LOGIN on the ALTER
+#   1  DB_USER=a       connects                             connects
+#   2  DB_USER=b       connects, a -> NOLOGIN               same
+#   3  DB_USER=a       FATAL: role "a" is not permitted      connects
+#                      to log in;  b also NOLOGIN
+#
+# Every statement succeeds on run 3 — ON_ERROR_STOP has nothing to stop on —
+# and it leaves *no* application login on the cluster, since the rotation
+# correctly disarms 'b' on the way past.
+sqld=$(mktemp -d)
+gen_db_sql() {   # <db-user> <password>
+  awk '/^SQL_FILE="\$\(mktemp/{p=1} p{print} /^trap - EXIT$/{exit}' "$SRC" > "$sqld/sect.sh"
+  # Through the environment rather than spliced into the generated harness:
+  # writing a configured value into a program is the defect case 133 is about,
+  # and a fixture that does it is the same mistake one level up. And the file is
+  # removed first — spliced, a value that closed the assignment killed the run
+  # before it generated anything and the assertion read the *previous* call's
+  # file, which is a pass or a fail decided by fixture quoting.
+  rm -f "$sqld/generated.sql"
+  { printf '%s\n' 'set -euo pipefail' \
+      'DB_NAME=collavre_production' \
+      'chown() { :; }' \
+      'runuser() { cp "${!#}" '"$sqld"'/generated.sql; }'
+    cat "$sqld/sect.sh"
+  } > "$sqld/run.sh"
+  DB_USER="$1" DB_PASSWORD="$2" bash "$sqld/run.sh" >/dev/null 2>&1
+  cat "$sqld/generated.sql" 2>/dev/null
+}
+GEN="$(gen_db_sql collavre_user 'pw')"
+chk "the ALTER restores LOGIN as well as the password" 1 \
+  "$(printf '%s\n' "$GEN" | grep -c '^ALTER ROLE "collavre_user" LOGIN PASSWORD')"
+# The control that keeps the fix from being a rewrite of the statement: the
+# password is still set by the same ALTER. A separate `ALTER ROLE ... LOGIN`
+# would pass the assertion above and leave a run that rotates the password able
+# to fail between the two, with the role's password and the recorded one
+# disagreeing.
+#
+# The password here deliberately carries no quote. `${DB_PASSWORD//\'/\'\'}`
+# does not mean the same thing on every bash: 5.2 (what Lightsail runs) yields
+# `it''s`, 3.2 (what macOS ships, and what a developer runs this suite under)
+# yields `it\'\'s`, which PostgreSQL rejects with a syntax error. An assertion
+# on a quoted password would therefore be red on one machine and green on the
+# other for a reason that has nothing to do with the statement being tested —
+# the same platform split as `head -c 0`, pointing the other way.
+GEN="$(gen_db_sql collavre_user 'pw-not-quoted')"
+chk "and still carries the password in the same statement" 1 \
+  "$(printf '%s\n' "$GEN" | grep -c "^ALTER ROLE \"collavre_user\" LOGIN PASSWORD 'pw-not-quoted';\$")"
+# And the other direction: the CREATE keeps LOGIN too. Dropping it there in
+# favour of the ALTER would leave a window on a fresh host between the two
+# statements, and this file is read by operators as the record of what the role
+# is given.
+chk "the CREATE still carries LOGIN for a role that does not exist yet" 1 \
+  "$(printf '%s\n' "$GEN" | grep -c "CREATE ROLE %I LOGIN")"
+rm -rf "$sqld"
+
 echo
 if [ "$fail" = 0 ]; then echo "ALL PASS"; else echo "FAILURES"; fi
 exit "$fail"

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -678,8 +678,12 @@ run_cutover() {
   cat > "$work/bin/ssh" <<'STUB'
 #!/usr/bin/env bash
 case "$*" in
-  *"ALTER ROLE collavre_user SUPERUSER"*)   echo GRANT  >>"$TRACE" ;;
-  *"ALTER ROLE collavre_user NOSUPERUSER"*) echo REVOKE >>"$TRACE"
+  # The role is quoted in the recipe, so match it quoted: a pattern that still
+  # said `ALTER ROLE collavre_user` would fall through to the catch-all and
+  # every case here would pass without a grant ever being recognised.
+  *'ALTER ROLE "collavre_user" SUPERUSER'*)   echo GRANT  >>"$TRACE"
+                                            [ -z "$FAIL_GRANT" ] || exit 1 ;;
+  *'ALTER ROLE "collavre_user" NOSUPERUSER'*) echo REVOKE >>"$TRACE"
                                             [ -z "$FAIL_REVOKE" ] || exit 255 ;;
   *"sudo rm"*)                              echo RM_STAGED >>"$TRACE" ;;
   *"sudo install"*)                         echo STAGE     >>"$TRACE"
@@ -753,6 +757,7 @@ STUB
   export FAIL_SCP="${FAIL_SCP:-}" FAIL_STAGE="${FAIL_STAGE:-}"
   export FAIL_STOP="${FAIL_STOP:-}" FAIL_SNAP="${FAIL_SNAP:-}"
   export FAIL_TAR="${FAIL_TAR:-}" FAIL_BLOB="${FAIL_BLOB:-}"
+  export FAIL_GRANT="${FAIL_GRANT:-}"
   # The recipe refuses unless the operator states the source is stopped, so the
   # default here is the stated case and case 32b is the unstated one.
   export source_quiesced="${SOURCE_QUIESCED-1}"
@@ -993,6 +998,47 @@ if command -v zsh >/dev/null; then
 else
   echo "  SKIP no zsh on this machine — the text assertion above is all that ran"
 fi
+
+echo "32j. the role in the grant is quoted, and a failed grant converts nothing"
+# Same assumption as the database name further down the page, one setting over:
+# DB_USER goes through `format('%I')` in the launch script, so `collavre-app` is
+# a role it creates and `ALTER ROLE collavre-app SUPERUSER` is a syntax error.
+# Unquoted, the whole cutover then fails on a host the script provisioned
+# happily — and it fails while telling the operator the wrong thing, which is
+# what the second half of this case is about.
+chk "the grant quotes the role"  1 \
+  "$(grep -c 'ALTER ROLE \\"<db-user>\\" SUPERUSER' <<<"$recipe")"
+chk "so does the revoke"         1 \
+  "$(grep -c 'ALTER ROLE \\"<db-user>\\" NOSUPERUSER' <<<"$recipe")"
+FAIL_GRANT=1 FAIL_TAR='' FAIL_BLOB='' FAIL_COPY='' FAIL_REVOKE='' FAIL_SCP='' \
+  FAIL_STAGE='' FAIL_STOP='' run_cutover
+chk "no conversion ran" 0 "$(grep -cx 'kamal:app exec' <<<"${RECIPE_TRACE//|/$'\n'}")"
+chk "app NOT booted"    0 "$(grep -cx 'kamal:app boot' <<<"${RECIPE_TRACE//|/$'\n'}")"
+# Attempted anyway: a connection that dropped after the ALTER committed leaves
+# the role raised with nothing on this side to say so, and NOSUPERUSER against a
+# role that is not one succeeds and changes nothing.
+chk "the revoke is still attempted" 1 "$(grep -cx REVOKE <<<"${RECIPE_TRACE//|/$'\n'}")"
+case "$RECIPE_OUT" in
+  *"GRANT FAILED"*"as it was"*) echo "  ok   says the database was not touched" ;;
+  *) echo "  FAIL silent about the grant: ${RECIPE_OUT:-(no output)}"; fail=1 ;;
+esac
+# MIGRATION_RUN_RESET drops the schema first, so "empty or half-loaded" would be
+# a false claim about a database no conversion ever reached.
+case "$RECIPE_OUT" in
+  *"COPY FAILED"*)
+    echo "  FAIL blames a conversion that never ran: $RECIPE_OUT"; fail=1 ;;
+  *) echo "  ok   does not blame a conversion that never ran" ;;
+esac
+FAIL_GRANT=1 FAIL_REVOKE=1 FAIL_COPY='' FAIL_SCP='' FAIL_STAGE='' FAIL_STOP='' \
+  run_cutover
+case "$RECIPE_OUT" in
+  *"is still a superuser"*)
+    echo "  FAIL claims a grant that never happened: $RECIPE_OUT"; fail=1 ;;
+  *"read"*rolsuper*) echo "  ok   sends the operator to read rolsuper instead" ;;
+  *) echo "  FAIL vague about which repair is needed: ${RECIPE_OUT:-(no output)}"
+     fail=1 ;;
+esac
+unset FAIL_GRANT
 
 echo "33. staging renames into place rather than writing the live path directly"
 # An interrupted copy must leave the previous file intact, not a truncated

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -21,14 +21,15 @@ SRC="${1:-$ROOT/script/lightsail_launch.sh}"
 # die() is a one-liner; the others run to the first column-1 closing brace.
 eval "$(awk '
   /^die\(\) \{/ { print; next }
-  /^(ensure_block|ensure_sudoers|in_group|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|reassign_prior_db_role|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps)\(\) \{/ { f = 1 }
+  /^(ensure_block|ensure_sudoers|in_group|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|reassign_prior_db_role|refuse_superuser_db_rotation|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps)\(\) \{/ { f = 1 }
   f { print }
   f && /^\}/ { f = 0 }
 ' "$SRC")"
 
 for fn in die ensure_block ensure_sudoers in_group revoke_prior_deploy_user \
           ensure_ufw_rule ssh_already_allowed ensure_ssh_rule \
-          install_authorized_keys reassign_prior_db_role revoke_prior_ssh_key \
+          install_authorized_keys reassign_prior_db_role \
+          refuse_superuser_db_rotation revoke_prior_ssh_key \
           ensure_cluster_on_default_port ensure_swapfile allocate_swapfile \
           ensure_docker_log_caps; do
   declare -F "$fn" >/dev/null || {
@@ -911,20 +912,52 @@ echo "48. an unchanged DB_USER touches nothing"
 rotate collavre_user "$d3/db_user"
 chk "no SQL" "" "$SQL$LOGGED"
 
-echo "49. a superuser predecessor is reported, never disabled"
-# DB_USER=postgres on a first run is legal. NOLOGIN on the cluster superuser
-# locks every operator out of administering it — peer auth needs LOGIN too, so
-# there is no way back in.
+echo "49. a superuser predecessor stops the run rather than half-rotating it"
+# DB_USER=postgres on a first run is legal, and the rotation away from it cannot
+# be completed: PostgreSQL refuses to reassign a superuser's objects at all. The
+# earlier form warned and returned, by which point the caller's SQL had already
+# moved the database — so the new role owned it and could not read one table,
+# and the advanced marker meant no later run looked at the old role again.
 printf 'postgres\n' > "$d3/db_user"
 ROLE_IS_SUPER=t
-rotate collavre_app "$d3/db_user"
-chk "no SQL ran" "" "$SQL"
-case "$LOGGED" in
-  *"is a superuser"*"by hand"*) echo "  ok   operator is told to finish it by hand" ;;
-  *) echo "  FAIL silent: $LOGGED"; fail=1 ;;
+out="$( (rotate collavre_app "$d3/db_user") 2>&1 )"
+chk "exits non-zero" 1 "$?"
+chk "no SQL ran"     "" "$SQL"
+case "$out" in
+  *"is a superuser"*"cannot be reassigned"*) echo "  ok   says why, not just that" ;;
+  *) echo "  FAIL unhelpful: $out"; fail=1 ;;
 esac
 
-echo "50. first run, emptied marker and a dropped role are all no-ops"
+echo "50. the refusal happens before the database SQL, with the marker intact"
+# The point of a separate pre-check: reassign_prior_db_role runs after ALTER
+# DATABASE ... OWNER, so refusing there is already too late.
+refuse() { SQL=""; LOGGED=""; refuse_superuser_db_rotation "$@"; }
+printf 'postgres\n' > "$d3/db_user"
+ROLE_EXISTS=1 ROLE_IS_SUPER=t
+out="$( (refuse collavre_app "$d3/db_user") 2>&1 )"
+chk "exits non-zero"          1 "$?"
+chk "marker still names the old role" "postgres" "$(cat "$d3/db_user")"
+case "$out" in
+  *"provisioned with DB_USER='postgres'"*"Nothing has been changed"*"re-run"*)
+    echo "  ok   names the state and the way out" ;;
+  *) echo "  FAIL unhelpful: $out"; fail=1 ;;
+esac
+# The three shapes that must still be let through.
+ROLE_IS_SUPER=f
+refuse collavre_app "$d3/db_user"
+chk "an ordinary predecessor proceeds" 0 "$?"
+ROLE_IS_SUPER=t
+refuse postgres "$d3/db_user"
+chk "an unchanged superuser DB_USER proceeds" 0 "$?"
+d3b=$(mktemp -d)
+refuse collavre_app "$d3b/db_user"
+chk "a first run proceeds" 0 "$?"
+ROLE_EXISTS=0 ROLE_IS_SUPER=t
+refuse collavre_app "$d3/db_user"
+chk "a dropped predecessor proceeds" 0 "$?"
+ROLE_EXISTS=1 ROLE_IS_SUPER=f
+
+echo "51. first run, emptied marker and a dropped role are all no-ops"
 d4=$(mktemp -d)
 ROLE_IS_SUPER=f
 rotate collavre_user "$d4/db_user"          # no marker yet
@@ -953,7 +986,7 @@ mk_lsclusters() {   # mk_lsclusters <name> <lines...>
 CLUSTER_BIN_DIR="$(mktemp -d)"
 PATH="$CLUSTER_BIN_DIR:$PATH"
 
-echo "51. a bumped PG_MAJOR that would land on a second port is refused"
+echo "52. a bumped PG_MAJOR that would land on a second port is refused"
 # pg_createcluster allocates the first free port from 5432 up, so installing a
 # new major version beside an existing one puts it on 5433 — while psql, the
 # database, the backups and DATABASE_URL all keep using 5432. Provisioning would
@@ -968,7 +1001,7 @@ case "$out" in
   *) echo "  FAIL unhelpful message: $out"; fail=1 ;;
 esac
 
-echo "52. an existing cluster of the RIGHT version on the wrong port is refused too"
+echo "53. an existing cluster of the RIGHT version on the wrong port is refused too"
 # The other way in: the operator moved 17 to 5433 by hand, or a previous run
 # created it beside something since removed. Everything downstream names 5432.
 mk_lsclusters pg_ls_17_5433 '17  main    5433 online postgres /var/lib/postgresql/17/main /var/log/x'
@@ -979,7 +1012,7 @@ case "$out" in
   *) echo "  FAIL unhelpful message: $out"; fail=1 ;;
 esac
 
-echo "53. the supported layouts are allowed through"
+echo "54. the supported layouts are allowed through"
 # A bare host (no postgresql-common yet) and the ordinary re-run must not be
 # refused — this guard exists to catch a silent miss, not to block convergence.
 out="$( (ensure_cluster_on_default_port pg_ls_absent) 2>&1 )"
@@ -1058,7 +1091,7 @@ new_swap_env() {   # <existing-MiB>  ("" for no file)
   LOGGED=""; SWAPOFF_FAILS=""; DISK_FREE_MIB=""
 }
 
-echo "54. a first run creates the swap file at the configured size"
+echo "55. a first run creates the swap file at the configured size"
 new_swap_env ""
 SWAP_SIZE_MB=8 ensure_swapfile "$SWAPFILE" "$FSTAB"
 chk "created at 8MiB"   8 "$(swap_mib "$SWAPFILE")"
@@ -1066,7 +1099,7 @@ chk "enabled"           "$SWAPFILE" "$SWAPPED_ON"
 chk "mode 0600"         "600" "$(file_mode "$SWAPFILE")"
 chk "fstab entry"       1 "$(grep -c "^$SWAPFILE none swap" "$FSTAB")"
 
-echo "55. an unchanged SWAP_SIZE_MB rewrites nothing"
+echo "56. an unchanged SWAP_SIZE_MB rewrites nothing"
 new_swap_env 8
 ino="$(inode "$SWAPFILE")"
 SWAP_SIZE_MB=8 ensure_swapfile "$SWAPFILE" "$FSTAB"
@@ -1074,7 +1107,7 @@ chk "same inode"  "$ino" "$(inode "$SWAPFILE")"
 chk "still on"    "$SWAPFILE" "$SWAPPED_ON"
 chk "silent"      "" "$LOGGED"
 
-echo "56. a raised SWAP_SIZE_MB actually resizes, rather than being skipped"
+echo "57. a raised SWAP_SIZE_MB actually resizes, rather than being skipped"
 # The whole finding: the old guard asked "is swap on?" and returned, so an
 # operator raising this after an OOM got a successful run and the old headroom.
 new_swap_env 4
@@ -1086,13 +1119,13 @@ case "$LOGGED" in
   *) echo "  FAIL silent or vague: $LOGGED"; fail=1 ;;
 esac
 
-echo "57. a lowered SWAP_SIZE_MB shrinks it too"
+echo "58. a lowered SWAP_SIZE_MB shrinks it too"
 new_swap_env 16
 SWAP_SIZE_MB=4 ensure_swapfile "$SWAPFILE" "$FSTAB"
 chk "shrunk to 4MiB" 4 "$(swap_mib "$SWAPFILE")"
 chk "re-enabled"     "$SWAPFILE" "$SWAPPED_ON"
 
-echo "58. SWAP_SIZE_MB=0 actually disables swap"
+echo "59. SWAP_SIZE_MB=0 actually disables swap"
 new_swap_env 8
 SWAP_SIZE_MB=0 ensure_swapfile "$SWAPFILE" "$FSTAB"
 chk "file removed"      0 "$([ -e "$SWAPFILE" ] && echo 1 || echo 0)"
@@ -1105,13 +1138,13 @@ SWAP_SIZE_MB=8 ensure_swapfile "$SWAPFILE" "$FSTAB"
 chk "one managed block after re-enabling" 1 "$(grep -c '# BEGIN collavre:swap' "$FSTAB")"
 chk "swap line back"                      1 "$(grep -c 'none swap' "$FSTAB")"
 
-echo "59. SWAP_SIZE_MB=0 on a host that never had swap is a no-op"
+echo "60. SWAP_SIZE_MB=0 on a host that never had swap is a no-op"
 new_swap_env ""
 SWAP_SIZE_MB=0 ensure_swapfile "$SWAPFILE" "$FSTAB"
 chk "nothing created" 0 "$([ -e "$SWAPFILE" ] && echo 1 || echo 0)"
 chk "silent"          "" "$LOGGED"
 
-echo "60. a swapoff that fails leaves the old swap running and says so"
+echo "61. a swapoff that fails leaves the old swap running and says so"
 # Low memory is exactly when swapoff fails and exactly when this setting is
 # being changed, so it must not abandon a provisioning run.
 new_swap_env 4
@@ -1125,7 +1158,7 @@ case "$LOGGED" in
   *) echo "  FAIL silent: $LOGGED"; fail=1 ;;
 esac
 
-echo "61. a resize that does not fit puts the previous swap back"
+echo "62. a resize that does not fit puts the previous swap back"
 # Growing means freeing the old file first, so an allocation that fails would
 # otherwise end the run with no swap at all — worse than it started, on the
 # low-memory host the setting exists for. The old size is known to fit.
@@ -1142,7 +1175,7 @@ case "$LOGGED" in
   *) echo "  FAIL silent or claims success: $LOGGED"; fail=1 ;;
 esac
 
-echo "62. a first run that cannot allocate dies rather than reporting success"
+echo "63. a first run that cannot allocate dies rather than reporting success"
 # have=0, so there is nothing to restore; the run must stop loudly instead of
 # continuing on a swapfile that was never made.
 new_swap_env ""
@@ -1157,7 +1190,7 @@ esac
 DISK_FREE_MIB=""
 unset -f swapon swapoff mkswap fallocate dd
 
-echo "63. an unsupported DB_PORT is refused before anything is installed"
+echo "64. an unsupported DB_PORT is refused before anything is installed"
 # Nothing here writes postgresql.conf, and pg_createcluster takes the first free
 # port from 5432 — so an overridden DB_PORT is named by DATABASE_URL, the ufw
 # rule and the backup while the cluster listens on 5432 regardless.
@@ -1185,14 +1218,14 @@ chk "and says nothing"     "" "$out"
 # --------------------------------------------------------------------------
 caps_of() { jq -c '."log-opts"' "$1"; }
 
-echo "64. a host with no daemon.json gets the caps written"
+echo "65. a host with no daemon.json gets the caps written"
 d=$(mktemp -d); f="$d/daemon.json"; LOGGED=""
 ensure_docker_log_caps "$f"
 chk "reports it changed the file" 1 "$DAEMON_JSON_CHANGED"
 chk "caps present" '{"max-size":"10m","max-file":"3"}' "$(caps_of "$f")"
 chk "valid JSON"   0 "$(jq empty "$f" >/dev/null 2>&1; echo $?)"
 
-echo "65. an existing daemon.json without caps has them merged in, not clobbered"
+echo "66. an existing daemon.json without caps has them merged in, not clobbered"
 # The finding: the old condition skipped the whole block whenever the file
 # existed, so a by-hand run on an existing instance left logs uncapped and
 # still reported Docker as configured.
@@ -1205,7 +1238,7 @@ chk "driver set"   'json-file' "$(jq -r '."log-driver"' "$f")"
 chk "operator's registries kept" '["r.internal:5000"]' "$(jq -c '."insecure-registries"' "$f")"
 chk "operator's live-restore kept" 'true' "$(jq -r '."live-restore"' "$f")"
 
-echo "66. existing caps are left exactly as the operator set them"
+echo "67. existing caps are left exactly as the operator set them"
 d=$(mktemp -d); f="$d/daemon.json"; LOGGED=""
 printf '{"log-driver":"json-file","log-opts":{"max-size":"50m","max-file":"10"}}\n' > "$f"
 before="$(cat "$f")"
@@ -1213,7 +1246,7 @@ ensure_docker_log_caps "$f"
 chk "reports no change" 0 "$DAEMON_JSON_CHANGED"
 chk "byte-identical"    "$before" "$(cat "$f")"
 
-echo "67. a non-json-file driver is reported, not overridden"
+echo "68. a non-json-file driver is reported, not overridden"
 # journald and local rotate on their own; forcing json-file would redirect an
 # operator's logs rather than cap them.
 for drv in journald local awslogs; do
@@ -1229,7 +1262,7 @@ case "$LOGGED" in
   *) echo "  FAIL silent: $LOGGED"; fail=1 ;;
 esac
 
-echo "68. an unparseable daemon.json is reported, never overwritten"
+echo "69. an unparseable daemon.json is reported, never overwritten"
 # It is the operator's file and Docker will not start until it is repaired;
 # replacing it would destroy the evidence of what they meant.
 d=$(mktemp -d); f="$d/daemon.json"; LOGGED=""
@@ -1243,7 +1276,7 @@ case "$LOGGED" in
   *) echo "  FAIL silent: $LOGGED"; fail=1 ;;
 esac
 
-echo "69. a merged file is stable across re-runs"
+echo "70. a merged file is stable across re-runs"
 d=$(mktemp -d); f="$d/daemon.json"; LOGGED=""
 printf '{"live-restore":true}\n' > "$f"
 ensure_docker_log_caps "$f"
@@ -1267,7 +1300,7 @@ LOGGED=""
 # shellcheck disable=SC2329  # called by ensure_ufw_rule, eval'd from the script
 log() { LOGGED="$LOGGED $*"; }
 
-echo "70. a delete that fails leaves the marker so the next run retries"
+echo "71. a delete that fails leaves the marker so the next run retries"
 # `ufw delete` exits 0 even for a rule that was not there, so a non-zero status
 # means it could not act and the old rule is still installed. Advancing the
 # marker there loses the only record of it: the previous Docker subnet keeps
@@ -1291,7 +1324,7 @@ ensure_ufw_rule postgres "$new" "$st"
 chk "retry withdraws the old rule" 1 "$(printf '%s' "$UFW_CALLS" | grep -c "|delete $old")"
 chk "marker advanced now"          "$new" "$(cat "$st")"
 
-echo "71. the replacement is added before the predecessor is withdrawn"
+echo "72. the replacement is added before the predecessor is withdrawn"
 # An interrupted run must never leave the host with neither rule.
 d=$(mktemp -d); st="$d/ufw_postgres"
 printf '%s\n' "$old" > "$st"

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -21,12 +21,13 @@ SRC="${1:-$ROOT/script/lightsail_launch.sh}"
 # die() is a one-liner; the others run to the first column-1 closing brace.
 eval "$(awk '
   /^die\(\) \{/ { print; next }
-  /^(ensure_block|ensure_sudoers|in_group|write_state_file|record_deploy_user_grant|revoke_deploy_user_access|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|install_deploy_ssh_dir|reassign_prior_db_role|refuse_superuser_db_rotation|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps|warn_existing_containers_keep_log_config|dedupe_authorized_keys|install_staged_authorized_keys|postgresql_conf_includes_confd|role_owns_app_objects|refuse_db_name_change|refuse_defaulted_config_change|refuse_unusable_db_identifier|refuse_unparsable_ssh_key|refuse_forced_command_ssh_key|ipv4_dotted_quad|refuse_unusable_bind_address|refuse_unusable_subnet|passwd_home|ssh_key_holder|adopt_legacy_ssh_key_marker|record_db_role_grant|reassign_one_db_role|record_ssh_key_grant|refuse_root_deploy_user|append_state_line|refuse_nologin_deploy_user|resolve_symlink_chain|stage_beside|stage_authorized_keys|verify_ssh_hardening|refuse_unusable_retention|install_managed_config|reload_ssh_daemon)\(\) \{/ { f = 1 }
+  /^(ensure_block|ensure_sudoers|in_group|write_state_file|launch_record_is_complete|record_launch_settings|record_deploy_user_grant|revoke_deploy_user_access|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|install_deploy_ssh_dir|reassign_prior_db_role|refuse_superuser_db_rotation|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps|warn_existing_containers_keep_log_config|dedupe_authorized_keys|install_staged_authorized_keys|postgresql_conf_includes_confd|role_owns_app_objects|refuse_db_name_change|refuse_defaulted_config_change|refuse_unusable_db_identifier|refuse_unparsable_ssh_key|refuse_forced_command_ssh_key|ipv4_dotted_quad|refuse_unusable_bind_address|refuse_unusable_subnet|passwd_home|ssh_key_holder|adopt_legacy_ssh_key_marker|record_db_role_grant|reassign_one_db_role|record_ssh_key_grant|refuse_root_deploy_user|append_state_line|refuse_nologin_deploy_user|resolve_symlink_chain|stage_beside|stage_authorized_keys|verify_ssh_hardening|refuse_unusable_retention|install_managed_config|reload_ssh_daemon)\(\) \{/ { f = 1 }
   f { print }
   f && /^\}/ { f = 0 }
 ' "$SRC")"
 
 for fn in die ensure_block ensure_sudoers in_group write_state_file \
+	  launch_record_is_complete record_launch_settings \
           revoke_prior_deploy_user \
           record_deploy_user_grant revoke_deploy_user_access \
           ensure_ufw_rule ssh_already_allowed ensure_ssh_rule \
@@ -4341,7 +4342,7 @@ chk "and silent about the rotation"   0 "$(grep -c APP_SSH_USER <<<"$prev_out")"
 echo "120b. launch.env is replaced in one step rather than truncated in place"
 # The assertion is on the write, not on the wording: a redirection here is the
 # defect, whatever the comment above it says.
-lenv_line="$(grep -c 'write_state_file "\$STATE_DIR/launch.env"' "$SRC")"
+lenv_line="$(grep -c 'write_state_file "\$state_dir/launch.env"' "$SRC")"
 chk "written through write_state_file" 1 "$lenv_line"
 chk "and not by a redirection"         0 \
   "$(grep -c '> *"\$STATE_DIR/launch.env"' "$SRC")"
@@ -5154,6 +5155,7 @@ docker_step() {  # DOCKER_PRESENT / BUILDX_OK / COMPOSE_OK are read from the env
   ( set +u
     log(){ printf 'LOG: %s\n' "$*"; }
     install(){ :; }; curl(){ :; }; chmod(){ :; }; apt_get(){ :; }
+    install_managed_config(){ :; }
     dpkg(){ echo amd64; }; VERSION_CODENAME=noble
     apt_install(){ printf 'INSTALL:%s\n' "$*"; }
     command(){
@@ -6020,6 +6022,73 @@ chk "and passes it to disk verification"              1 \
   "$(grep -cF 'verify_ssh_hardening "" /etc/ssh "$SSH_RELOAD_STATE"' "$SRC")"
 chk "rather than discarding the status"               0 \
   "$(grep -c '^systemctl reload ssh .*|| true$' "$SRC")"
+
+echo "151. the Docker apt source is installed atomically"
+docker_source_block="$(
+  awk '
+    /^if \[ -n "\$DOCKER_WANT" \]; then$/ { f = 1 }
+    f { print }
+    f && /^fi$/ { exit }
+  ' "$SRC"
+)"
+chk "the live source is written through the staging helper" 1 \
+  "$(grep -c "install_managed_config 'the Docker apt source'" <<<"$docker_source_block")"
+chk "and never truncated by a heredoc redirection"           0 \
+  "$(grep -c 'cat > /etc/apt/sources.list.d/docker.list' <<<"$docker_source_block")"
+chk "the staged source is installed before apt reads it"     1 \
+  "$(awk '
+      /install_managed_config .*Docker apt source/ { installed = NR }
+      /apt_get update -y/ { updated = NR }
+      END {
+	if (installed && updated && installed < updated) print 1
+	else print 0
+      }
+    ' <<<"$docker_source_block")"
+
+echo "152. a missing or incomplete launch record cannot accompany success"
+saved_launch_settings="$LAUNCH_SETTINGS"
+LAUNCH_SETTINGS='APP_SSH_USER DB_USER BACKUP_S3_URI'
+APP_SSH_USER=collavre
+DB_USER=collavre_user
+BACKUP_S3_URI=s3://collavre-backups/pg
+record_dir="$(mktemp -d)"
+record_launch_settings "$record_dir" >/dev/null 2>&1
+chk "a successful write records every setting"              0 \
+  "$(launch_record_is_complete "$record_dir/launch.env"; echo $?)"
+
+saved_write_state_file="$(declare -f write_state_file)"
+saved_log="$(declare -f log)"
+log() { printf '%s\n' "$*"; }
+write_state_file() { return 1; }
+record_out="$(record_launch_settings "$record_dir" 2>&1)"
+chk "a failed replacement with a complete prior record warns" 0 "$?"
+chk "and identifies that record as complete"                  1 \
+  "$(grep -c 'complete previous record is intact' <<<"$record_out")"
+
+rm -f "$record_dir/launch.env"
+record_status=0
+record_out="$(record_launch_settings "$record_dir" 2>&1)" || record_status=$?
+chk "a failed first record stops the run"                     1 "$record_status"
+chk "and names the missing complete record"                   1 \
+  "$(grep -c 'no complete previous record remains' <<<"$record_out")"
+
+printf 'APP_SSH_USER=collavre\nDB_USER=collavre_user\n' > "$record_dir/launch.env"
+record_status=0
+record_out="$(record_launch_settings "$record_dir" 2>&1)" || record_status=$?
+chk "an incomplete prior record also stops the run"           1 "$record_status"
+chk "so the success marker is created only after recording"   1 \
+  "$(awk '
+      /^record_launch_settings$/ { recorded = NR }
+      /^touch "\$MARKER"$/ { marked = NR }
+      END {
+	if (recorded && marked && recorded < marked) print 1
+	else print 0
+      }
+    ' "$SRC")"
+eval "$saved_write_state_file"
+eval "$saved_log"
+LAUNCH_SETTINGS="$saved_launch_settings"
+rm -rf "$record_dir"
 
 echo
 if [ "$fail" = 0 ]; then echo "ALL PASS"; else echo "FAILURES"; fi

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -6976,7 +6976,7 @@ chk "without trusting host-local process names as proof" 0 \
 chk "the runbook changes KAMAL_SSH_USER only after finalization" 1 \
   "$(grep -c 'Change `KAMAL_SSH_USER` only after' "$DOC")"
 chk "the proof SSH command cannot fall back to an agent predecessor key" 1 \
-  "$(grep -c 'ssh -o IdentitiesOnly=yes -i' "$DOC")"
+  "$(grep -c 'ssh -F /dev/null -o IdentitiesOnly=yes -i' "$DOC")"
 
 cutover_state="$(mktemp -d)"
 cutover_finalizer="$cutover_state/finalizer"

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -1395,6 +1395,112 @@ chk "returns non-zero" 1 "$?"
 chk "no group echoed"  "" "$out"
 unset -f id install
 
+# --- docs/deploy_to_lightsail.md, the PostgreSQL move ------------------------
+#
+# pg_restore --clean drops every object before it reloads one, so this recipe is
+# an incident if it runs on a transfer that did not arrive. Run rather than read,
+# for the same reason as the cutover above.
+
+move="$(extract_recipe 'move_status=')"
+case "$move" in
+  *pg_dump*scp*pg_restore*) : ;;
+  *) echo "could not extract the PostgreSQL-move recipe from $DOC — has it moved?" >&2
+     exit 1 ;;
+esac
+
+# The ssh stub runs the remote command for real against a sandbox stand-in for
+# /tmp, so the `&&` chain, the rename and the `rm` are exercised rather than
+# pattern-matched. FAIL_DUMP / FAIL_XFER / FAIL_RESTORE choose the failing step.
+run_move() {
+  local work; work="$(mktemp -d)"
+  # REUSE_REMOTE keeps the instance's /tmp across two calls, which is what the
+  # stale-snapshot case needs: one run leaves a dump behind, the next must not
+  # be able to restore it.
+  export REMOTE="${REUSE_REMOTE:-$work/remote}"
+  mkdir -p "$REMOTE" "$work/bin" "$work/rbin"
+  printf '%s' "$move" | sed 's/<instance-ip>/203.0.113.10/g' > "$work/recipe.sh"
+
+  cat > "$work/bin/psql" <<'STUB'
+#!/usr/bin/env bash
+echo psql >>"$TRACE"
+STUB
+  cat > "$work/bin/pg_dump" <<'STUB'
+#!/usr/bin/env bash
+echo pg_dump >>"$TRACE"
+[ -z "$FAIL_DUMP" ] || exit 1
+out=""; while [ $# -gt 0 ]; do [ "$1" = -f ] && out="$2"; shift; done
+printf 'DUMP-%s\n' "${DUMP_TAG:-fresh}" > "$out"
+STUB
+  cat > "$work/bin/scp" <<'STUB'
+#!/usr/bin/env bash
+dest="${2#*:}"
+echo "scp:$dest" >>"$TRACE"
+[ -z "$FAIL_XFER" ] || exit 1
+cp "$1" "${dest/\/tmp\//$REMOTE/}"
+STUB
+  cat > "$work/bin/ssh" <<'STUB'
+#!/usr/bin/env bash
+shift                                   # drop user@host; the rest is the command
+cmd="$*"; cmd="${cmd//\/tmp\//$REMOTE/}"
+echo ssh >>"$TRACE"
+PATH="$RBIN:$PATH" bash -c "$cmd"
+STUB
+  cat > "$work/rbin/pg_restore" <<'STUB'
+#!/usr/bin/env bash
+for a in "$@"; do case "$a" in *collavre.dump) echo "PG_RESTORE:$(cat "$a" 2>&1)" >>"$TRACE" ;; esac; done
+[ -z "$FAIL_RESTORE" ] || exit 1
+STUB
+  chmod +x "$work/bin"/* "$work/rbin"/*
+
+  TRACE="$work/trace"; : > "$TRACE"
+  export TRACE RBIN="$work/rbin"
+  export FAIL_DUMP="${FAIL_DUMP:-}" FAIL_XFER="${FAIL_XFER:-}" FAIL_RESTORE="${FAIL_RESTORE:-}"
+  MOVE_OUT="$(cd "$work" && PATH="$work/bin:$PATH" bash ./recipe.sh 2>&1)"
+  MOVE_TRACE="$(paste -sd'|' "$TRACE")"
+  MOVE_LEFT="$(find "$REMOTE" -maxdepth 1 -type f -exec basename {} \; | sort | paste -sd, -)"
+  rm -rf "$work"
+}
+
+echo "78. a clean move transfers, restores, and cleans up"
+FAIL_DUMP='' FAIL_XFER='' FAIL_RESTORE='' DUMP_TAG=fresh run_move
+chk "staged under .incoming"  1 "$(grep -c 'scp:/tmp/collavre.dump.incoming' <<<"${MOVE_TRACE//|/$'\n'}")"
+chk "restored the new dump"   1 "$(grep -c 'PG_RESTORE:DUMP-fresh' <<<"${MOVE_TRACE//|/$'\n'}")"
+chk "nothing left behind"     ""  "$MOVE_LEFT"
+
+echo "79. a failed pg_dump never reaches the transfer or the restore"
+FAIL_DUMP=1 FAIL_XFER='' FAIL_RESTORE='' run_move
+chk "no transfer"             0 "$(grep -c '^scp:' <<<"${MOVE_TRACE//|/$'\n'}")"
+chk "no restore"              0 "$(grep -c '^PG_RESTORE' <<<"${MOVE_TRACE//|/$'\n'}")"
+chk "operator told"           1 "$(grep -c 'MOVE FAILED' <<<"$MOVE_OUT")"
+
+echo "80. a failed transfer cannot restore the snapshot a previous attempt kept"
+# The retained /tmp/collavre.dump is deliberate — it makes a retry cheap. As
+# separate statements the next failed scp would restore *it*, report success and
+# delete it: a silent rollback to older data, with the evidence removed.
+stale_remote="$(mktemp -d)"
+REUSE_REMOTE="$stale_remote" FAIL_DUMP='' FAIL_XFER='' FAIL_RESTORE=1 DUMP_TAG=stale run_move
+chk "the first attempt leaves a dump" "collavre.dump" "$MOVE_LEFT"
+REUSE_REMOTE="$stale_remote" FAIL_DUMP='' FAIL_XFER=1 FAIL_RESTORE='' DUMP_TAG=fresh run_move
+chk "no restore ran at all"    0 "$(grep -c '^PG_RESTORE' <<<"${MOVE_TRACE//|/$'\n'}")"
+chk "the stale snapshot was not restored" 0 \
+  "$(grep -c 'PG_RESTORE:DUMP-stale' <<<"${MOVE_TRACE//|/$'\n'}")"
+chk "nor deleted, so it is still evidence" "collavre.dump" "$MOVE_LEFT"
+chk "operator told"            1 "$(grep -c 'MOVE FAILED' <<<"$MOVE_OUT")"
+rm -rf "$stale_remote"; unset REUSE_REMOTE
+
+echo "81. a failed restore keeps the dump and refuses to call the move done"
+FAIL_DUMP='' FAIL_XFER='' FAIL_RESTORE=1 DUMP_TAG=fresh run_move
+chk "the dump is kept for the retry" "collavre.dump" "$MOVE_LEFT"
+chk "operator told it is unusable"   1 "$(grep -c 'not usable yet' <<<"$MOVE_OUT")"
+chk "and told not to switch DNS"     1 "$(grep -c 'Do not point DNS' <<<"$MOVE_OUT")"
+
+echo "82. the transfer never lands directly on the path the restore reads"
+FAIL_DUMP='' FAIL_XFER='' FAIL_RESTORE='' run_move
+# Asserted as "no transfer went anywhere else", not as "one went to .incoming":
+# the pre-fix form sent to the directory /tmp/, which a check for the live
+# filename alone would pass without ever staging anything.
+chk "every transfer staged under .incoming" 0 \
+  "$(grep '^scp:' <<<"${MOVE_TRACE//|/$'\n'}" | grep -cv '\.incoming$')"
 echo
 if [ "$fail" = 0 ]; then echo "ALL PASS"; else echo "FAILURES"; fi
 exit "$fail"

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -21,12 +21,12 @@ SRC="${1:-$ROOT/script/lightsail_launch.sh}"
 # die() is a one-liner; the others run to the first column-1 closing brace.
 eval "$(awk '
   /^die\(\) \{/ { print; next }
-  /^(ensure_block|ensure_sudoers|in_group|write_state_file|launch_record_is_complete|record_launch_settings|record_deploy_user_grant|revoke_deploy_user_access|revoke_prior_deploy_user|stage_ssh_cutover|ssh_public_key_fingerprint|ssh_cutover_auth_info_file|ssh_cutover_authenticated_with_key|ssh_cutover_has_sshd_ancestor|finalize_ssh_cutover|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|install_deploy_ssh_dir|reassign_prior_db_role|refuse_superuser_db_rotation|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps|warn_existing_containers_keep_log_config|dedupe_authorized_keys|install_staged_authorized_keys|postgresql_conf_includes_confd|role_owns_app_objects|refuse_db_name_change|refuse_defaulted_config_change|refuse_unusable_db_identifier|refuse_unparsable_ssh_key|refuse_forced_command_ssh_key|ipv4_dotted_quad|refuse_unusable_bind_address|refuse_unusable_subnet|passwd_home|ssh_key_holder|adopt_legacy_ssh_key_marker|record_db_role_grant|reassign_one_db_role|record_ssh_key_grant|refuse_root_deploy_user|append_state_line|refuse_nologin_deploy_user|resolve_symlink_chain|stage_beside|restore_postgresql_bind_config|stage_authorized_keys|scan_ssh_config_file|find_unsafe_ssh_match|verify_ssh_key_destination|ssh_pattern_list_matches|verify_ssh_admission_controls|verify_ssh_hardening|refuse_unusable_retention|refuse_unusable_backup_calendar|install_managed_config|install_downloaded_file|install_credential_summary|reload_ssh_daemon)\(\) \{/ { f = 1 }
+  /^(ensure_block|sudoers_file_name|ensure_sudoers|in_group|write_state_file|launch_record_is_complete|record_launch_settings|record_deploy_user_grant|revoke_deploy_user_access|revoke_prior_deploy_user|stage_ssh_cutover|ssh_public_key_fingerprint|ssh_cutover_auth_info_file|ssh_cutover_authenticated_with_key|ssh_cutover_has_sshd_ancestor|finalize_ssh_cutover|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|install_deploy_ssh_dir|reassign_prior_db_role|refuse_superuser_db_rotation|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps|warn_existing_containers_keep_log_config|dedupe_authorized_keys|install_staged_authorized_keys|postgresql_conf_includes_confd|role_owns_app_objects|refuse_db_name_change|refuse_defaulted_config_change|refuse_unusable_db_identifier|refuse_unparsable_ssh_key|refuse_forced_command_ssh_key|ipv4_dotted_quad|refuse_unusable_bind_address|refuse_unusable_subnet|passwd_home|ssh_key_holder|adopt_legacy_ssh_key_marker|record_db_role_grant|reassign_one_db_role|record_ssh_key_grant|refuse_root_deploy_user|append_state_line|refuse_nologin_deploy_user|resolve_symlink_chain|stage_beside|restore_postgresql_bind_config|stage_authorized_keys|scan_ssh_config_file|find_unsafe_ssh_match|verify_ssh_key_destination|ssh_pattern_list_matches|verify_ssh_admission_controls|verify_ssh_hardening|refuse_unusable_retention|refuse_unusable_backup_calendar|install_managed_config|install_downloaded_file|install_credential_summary|reload_ssh_daemon)\(\) \{/ { f = 1 }
   f { print }
   f && /^\}/ { f = 0 }
 ' "$SRC")"
 
-for fn in die ensure_block ensure_sudoers in_group write_state_file \
+for fn in die ensure_block sudoers_file_name ensure_sudoers in_group write_state_file \
 	  launch_record_is_complete record_launch_settings \
           revoke_prior_deploy_user \
           record_deploy_user_grant revoke_deploy_user_access \
@@ -278,15 +278,17 @@ chk "file untouched"  "$before"  "$(cat "$f")"
 echo "8. the deploy user gets a sudoers grant sudo will actually read"
 d=$(mktemp -d)
 ensure_sudoers collavre "$d"
+collavre_sudoers="$(sudoers_file_name collavre)"
+deploy_dot_sudoers="$(sudoers_file_name deploy.bot)"
 chk "one file"        1        "$(ls "$d" | wc -l | tr -d ' ')"
-chk "readable name"   "90-collavre-collavre" "$(ls "$d")"
-chk "mode 0440"       "440"    "$(file_mode "$d/90-collavre-collavre")"
-chk "passwordless"    "collavre ALL=(ALL:ALL) NOPASSWD:ALL" "$(cat "$d/90-collavre-collavre")"
+chk "collision-free readable name" "$collavre_sudoers" "$(ls "$d")"
+chk "mode 0440"       "440"    "$(file_mode "$d/$collavre_sudoers")"
+chk "passwordless"    "collavre ALL=(ALL:ALL) NOPASSWD:ALL" "$(cat "$d/$collavre_sudoers")"
 # sudo's includedir ignores any filename containing a dot, so a grant written
 # for a dotted username would be silently skipped — the exact failure mode
 # this whole case exists to prevent.
 ensure_sudoers deploy.bot "$d"
-chk "dot sanitized"   "90-collavre-deploy_bot" \
+chk "dot sanitized"   "$deploy_dot_sudoers" \
   "$(ls "$d" | grep deploy)"
 chk "no dot in name"  0 "$(ls "$d" | grep -c '\.')"
 
@@ -295,6 +297,10 @@ echo "9. staging a changed APP_SSH_USER preserves the proven grant"
 # staged account's actual SSH session.
 chk "old user's grant remains" 1 "$(ls "$d" | grep -c 'collavre-collavre')"
 chk "both staged grants remain" 2 "$(ls "$d" | wc -l | tr -d ' ')"
+ensure_sudoers release.bot "$d"
+ensure_sudoers release_bot "$d"
+chk "normalization collisions keep both staged grants" 2 \
+  "$(grep -l '^release[._]bot ALL=' "$d"/* | wc -l | tr -d ' ')"
 # An operator's own file is not ours to delete.
 touch "$d/10-operator"
 ensure_sudoers collavre "$d"
@@ -7039,6 +7045,7 @@ revoke_prior_ssh_key() {
 }
 revoke_prior_deploy_user() {
   TRACE="${TRACE}account "
+  [ "${REVOKE_ACCOUNT_FAIL:-0}" -eq 0 ] || return 1
   write_state_file "$STATE_DIR/deploy_user" "deploybot"$'\n'
 }
 TRACE=''
@@ -7072,12 +7079,26 @@ chk "a key that differs from the pending fingerprint is refused" 1 "$?"
 chk "and cannot start predecessor withdrawal" "" "$TRACE"
 mv "$cutover_state/ssh_cutover.pending.bak" \
   "$cutover_state/ssh_cutover.pending"
+( mkdir "$cutover_state/deploy_user"
+  SUDO_USER=deploybot SSH_PROOF=1 KEY_PROOF=1 \
+    finalize_ssh_cutover "$cutover_nonce" ) >/dev/null 2>&1
+chk "a successor commit failure is refused before withdrawal" 1 "$?"
+chk "and leaves every predecessor path untouched" "" "$TRACE"
+rmdir "$cutover_state/deploy_user"
 ( SUDO_USER=deploybot SSH_PROOF=1 KEY_PROOF=1 REVOKE_KEY_FAIL=1 \
     finalize_ssh_cutover "$cutover_nonce" ) >/dev/null 2>&1
 chk "an incomplete predecessor-key withdrawal is refused" 1 "$?"
-chk "and does not commit the deploy account" 0 \
-  "$([ -e "$cutover_state/deploy_user" ] && echo 1 || echo 0)"
+chk "after authenticated proof the successor remains committed" deploybot \
+  "$(cat "$cutover_state/deploy_user")"
 chk "while retaining the pending challenge" 1 \
+  "$([ -e "$cutover_state/ssh_cutover.pending" ] && echo 1 || echo 0)"
+TRACE=''
+( SUDO_USER=deploybot SSH_PROOF=1 KEY_PROOF=1 REVOKE_ACCOUNT_FAIL=1 \
+    finalize_ssh_cutover "$cutover_nonce" ) >/dev/null 2>&1
+chk "a predecessor-account cleanup failure is retryable" 1 "$?"
+chk "with the proven successor still committed" deploybot \
+  "$(cat "$cutover_state/deploy_user")"
+chk "and the pending cleanup record retained" 1 \
   "$([ -e "$cutover_state/ssh_cutover.pending" ] && echo 1 || echo 0)"
 TRACE=''
 SUDO_USER=deploybot SSH_PROOF=1 KEY_PROOF=1 \

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -21,7 +21,7 @@ SRC="${1:-$ROOT/script/lightsail_launch.sh}"
 # die() is a one-liner; the others run to the first column-1 closing brace.
 eval "$(awk '
   /^die\(\) \{/ { print; next }
-  /^(ensure_block|ensure_sudoers|in_group|write_state_file|record_deploy_user_grant|revoke_deploy_user_access|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|install_deploy_ssh_dir|reassign_prior_db_role|refuse_superuser_db_rotation|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps|dedupe_authorized_keys|install_staged_authorized_keys|postgresql_conf_includes_confd|role_owns_app_objects|refuse_db_name_change|refuse_defaulted_config_change|refuse_unusable_db_identifier|refuse_unparsable_ssh_key|refuse_forced_command_ssh_key|ipv4_dotted_quad|refuse_unusable_bind_address|refuse_unusable_subnet|passwd_home|ssh_key_holder|adopt_legacy_ssh_key_marker|record_db_role_grant|reassign_one_db_role|record_ssh_key_grant|refuse_root_deploy_user|append_state_line|refuse_nologin_deploy_user|resolve_symlink_chain|stage_beside|stage_authorized_keys|verify_ssh_hardening|refuse_unusable_retention|install_managed_config|reload_ssh_daemon)\(\) \{/ { f = 1 }
+  /^(ensure_block|ensure_sudoers|in_group|write_state_file|record_deploy_user_grant|revoke_deploy_user_access|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|install_deploy_ssh_dir|reassign_prior_db_role|refuse_superuser_db_rotation|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps|warn_existing_containers_keep_log_config|dedupe_authorized_keys|install_staged_authorized_keys|postgresql_conf_includes_confd|role_owns_app_objects|refuse_db_name_change|refuse_defaulted_config_change|refuse_unusable_db_identifier|refuse_unparsable_ssh_key|refuse_forced_command_ssh_key|ipv4_dotted_quad|refuse_unusable_bind_address|refuse_unusable_subnet|passwd_home|ssh_key_holder|adopt_legacy_ssh_key_marker|record_db_role_grant|reassign_one_db_role|record_ssh_key_grant|refuse_root_deploy_user|append_state_line|refuse_nologin_deploy_user|resolve_symlink_chain|stage_beside|stage_authorized_keys|verify_ssh_hardening|refuse_unusable_retention|install_managed_config|reload_ssh_daemon)\(\) \{/ { f = 1 }
   f { print }
   f && /^\}/ { f = 0 }
 ' "$SRC")"
@@ -33,7 +33,8 @@ for fn in die ensure_block ensure_sudoers in_group write_state_file \
           install_authorized_keys install_deploy_ssh_dir reassign_prior_db_role \
           refuse_superuser_db_rotation role_owns_app_objects revoke_prior_ssh_key \
           ensure_cluster_on_default_port ensure_swapfile allocate_swapfile \
-          ensure_docker_log_caps dedupe_authorized_keys \
+	  ensure_docker_log_caps warn_existing_containers_keep_log_config \
+	  dedupe_authorized_keys \
           install_staged_authorized_keys postgresql_conf_includes_confd \
           refuse_db_name_change refuse_defaulted_config_change \
           refuse_unusable_db_identifier refuse_unparsable_ssh_key \
@@ -2141,6 +2142,15 @@ ensure_docker_log_caps "$f"
 chk "reports no change" 0 "$DAEMON_JSON_CHANGED"
 chk "byte-identical"    "$before" "$(cat "$f")"
 
+echo "67a. Docker's unlimited max-size is repaired rather than accepted as a cap"
+d=$(mktemp -d); f="$d/daemon.json"; LOGGED=""
+printf '{"log-driver":"json-file","log-opts":{"max-size":"-1","max-file":"9"},"live-restore":true}\n' > "$f"
+ensure_docker_log_caps "$f"
+chk "reports it changed the file" 1 "$DAEMON_JSON_CHANGED"
+chk "unlimited size replaced"     '10m' "$(jq -r '."log-opts"."max-size"' "$f")"
+chk "rotation count set"          '3' "$(jq -r '."log-opts"."max-file"' "$f")"
+chk "operator's other keys kept"  'true' "$(jq -r '."live-restore"' "$f")"
+
 echo "68. a non-json-file driver is reported, not overridden"
 # journald and local rotate on their own; forcing json-file would redirect an
 # operator's logs rather than cap them.
@@ -2179,6 +2189,35 @@ after_first="$(cat "$f")"
 ensure_docker_log_caps "$f"
 chk "second run changes nothing" 0 "$DAEMON_JSON_CHANGED"
 chk "byte-identical"             "$after_first" "$(cat "$f")"
+
+echo "70a. existing containers are told when changed defaults take effect"
+# This section needs the warning text on stdout; the next section restores the
+# accumulator form used by the UFW tests.
+log() { printf '%s\n' "$*"; }
+docker() {
+  [ "${1:-}" = ps ] || return 1
+  case "${DOCKER_PS_RESULT:-}" in
+    existing) printf 'container-id\n' ;;
+    failure) return 1 ;;
+  esac
+}
+out="$(DOCKER_PS_RESULT=existing warn_existing_containers_keep_log_config 2>&1)"
+chk "existing containers are warned" 1 \
+  "$(grep -c 'only after the next.*kamal.sh deploy.*recreates them' <<<"$out")"
+out="$(DOCKER_PS_RESULT=empty warn_existing_containers_keep_log_config 2>&1)"
+chk "a fresh host gets no warning" "" "$out"
+out="$(DOCKER_PS_RESULT=failure warn_existing_containers_keep_log_config 2>&1)"
+chk "an inspection failure is not read as no containers" 1 \
+  "$(grep -c 'could.*not be inspected' <<<"$out")"
+unset -f docker
+unset DOCKER_PS_RESULT
+restart_block="$(awk '
+  index($0, "if [ \"$DAEMON_JSON_CHANGED\" -eq 1 ]; then") { p=1 }
+  p { print }
+  p && /^else$/ { exit }
+' "$SRC")"
+chk "the warning follows the Docker restart" 1 \
+  "$(grep -c 'warn_existing_containers_keep_log_config' <<<"$restart_block")"
 
 # --------------------------------------------------------------------------
 # ensure_ufw_rule, revisited: a delete that FAILS must not advance the marker.

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -5806,7 +5806,10 @@ vh() {
   printf '%s\n' "$1" > "$vshd/eff"
   ( verify_ssh_hardening "$vshd/eff" "$vshd" ) >/dev/null 2>&1 && echo 0 || echo 1
 }
-vh_eff() { printf 'passwordauthentication %s\npermitrootlogin %s\nkbdinteractiveauthentication %s' "$1" "$2" "$3"; }
+vh_eff() {
+  printf 'passwordauthentication %s\npermitrootlogin %s\nkbdinteractiveauthentication %s\npubkeyauthentication %s' \
+    "$1" "$2" "$3" "${4:-yes}"
+}
 
 chk "an effective config that matches the drop-in passes" 0 "$(vh "$(vh_eff no no no)")"
 chk "password authentication still on stops the run"      1 "$(vh "$(vh_eff yes no no)")"
@@ -5814,6 +5817,9 @@ chk "password authentication still on stops the run"      1 "$(vh "$(vh_eff yes 
 # is not the 'no' this script writes.
 chk "and root login still on, however narrowly"           1 "$(vh "$(vh_eff no prohibit-password no)")"
 chk "and keyboard-interactive still on"                   1 "$(vh "$(vh_eff no no yes)")"
+chk "and public-key authentication off"                   1 "$(vh "$(vh_eff no no no no)")"
+chk "and a missing public-key result is not treated as verified" 1 \
+  "$(vh "$(printf 'passwordauthentication no\npermitrootlogin no\nkbdinteractiveauthentication no')")"
 
 printf '%s\n' "$(vh_eff yes no no)" > "$vshd/eff"
 vh_msg="$( ( verify_ssh_hardening "$vshd/eff" "$vshd" ) 2>&1 )"
@@ -5832,6 +5838,13 @@ chk "an sshd -T that will not run warns instead of stopping" 1 \
   "$(printf '%s' "$vh_unread" | grep -c '^rc=0$')"
 chk "and says the hardening is unverified"                1 \
   "$(printf '%s' "$vh_unread" | grep -c 'unverified')"
+vh_strict_unread="$( ( PATH="$vshd/bin:$PATH"
+  verify_ssh_hardening "" "$vshd" 0 deploybot 1 ) 2>&1
+  printf 'rc=%s\n' "$?" )"
+chk "the pre-revocation gate stops when sshd cannot be read" 1 \
+  "$(printf '%s' "$vh_strict_unread" | grep -c '^rc=1$')"
+chk "and says public-key reachability could not be verified" 1 \
+  "$(printf '%s' "$vh_strict_unread" | grep -ci 'public-key authentication')"
 vh_inactive_unread="$( ( PATH="$vshd/bin:$PATH"
   verify_ssh_hardening "" "$vshd" 2 ) 2>&1
   printf 'rc=%s\n' "$?" )"
@@ -5851,7 +5864,7 @@ printf '%s\n' \
   '  *" -C user=deploybot "*) password=yes ;;' \
   '  *) password=no ;;' \
   'esac' \
-  'printf "passwordauthentication %s\npermitrootlogin no\nkbdinteractiveauthentication no\n" "$password"' \
+  'printf "passwordauthentication %s\npermitrootlogin no\nkbdinteractiveauthentication no\npubkeyauthentication yes\n" "$password"' \
   > "$vshd/bin/sshd"
 chmod +x "$vshd/bin/sshd"
 SSHD_ARGS_FILE="$vshd/sshd.args"
@@ -5870,7 +5883,7 @@ unset SSHD_ARGS_FILE
 # merely leave every other matching connection untested.
 printf '%s\n' \
   '#!/bin/sh' \
-  'printf "passwordauthentication no\npermitrootlogin no\nkbdinteractiveauthentication no\n"' \
+  'printf "passwordauthentication no\npermitrootlogin no\nkbdinteractiveauthentication no\npubkeyauthentication yes\n"' \
   > "$vshd/bin/sshd"
 chmod +x "$vshd/bin/sshd"
 printf 'Include %s/sshd_config.d/*.conf\nMatch Address 203.0.113.0/24\n  PasswordAuthentication yes\n' \
@@ -5881,6 +5894,15 @@ chk "an address-scoped password override stops the run"  1 \
   "$(printf '%s' "$vh_address" | grep -c '^rc=1$')"
 chk "and the refusal names the untestable Match context" 1 \
   "$(printf '%s' "$vh_address" | grep -ci 'Match.*Address')"
+
+printf 'Include %s/sshd_config.d/*.conf\nMatch Address 203.0.113.0/24\n  PubkeyAuthentication no\n' \
+  "$vshd" > "$vshd/sshd_config"
+vh_address_pubkey="$( ( PATH="$vshd/bin:$PATH"
+  verify_ssh_hardening "" "$vshd" 0 deploybot ) 2>&1; printf 'rc=%s\n' "$?" )"
+chk "an address-scoped public-key override stops the run" 1 \
+  "$(printf '%s' "$vh_address_pubkey" | grep -c '^rc=1$')"
+chk "and the refusal identifies the public-key directive" 1 \
+  "$(printf '%s' "$vh_address_pubkey" | grep -ci 'PubkeyAuthentication')"
 
 # ChallengeResponseAuthentication is OpenSSH's deprecated alias for
 # KbdInteractiveAuthentication. A contextual scanner that recognizes only the
@@ -5959,6 +5981,9 @@ chk "sudo-group context is rechecked before passwordless sudo" 1 \
 chk "docker-group context is rechecked before convergence continues" 1 \
   "$(grep -cF 'verify_ssh_hardening "" /etc/ssh "$SSH_RELOAD_STATE" "$APP_SSH_USER"' \
       <<<"$vh_docker_grant")"
+chk "the check immediately before revocation requires a readable public-key result" 1 \
+  "$(grep -cF 'verify_ssh_hardening "" /etc/ssh "$SSH_RELOAD_STATE" "$APP_SSH_USER" 1' \
+      <<<"$vh_docker_grant")"
 
 # If the recheck is what discovers the override, the new group is already live.
 # A refusal must remove only the membership this run added. These assertions
@@ -5983,11 +6008,12 @@ vh_sshd=""
 for vh_c in sshd /usr/sbin/sshd; do
   command -v "$vh_c" >/dev/null 2>&1 && { vh_sshd="$vh_c"; break; }
 done
-vh_effective() { # <config dir> -> "<passwordauthentication> <permitrootlogin>"
+vh_effective() { # <config dir> -> "<passwordauth> <rootlogin> <pubkeyauth>"
   "$vh_sshd" -T -f "$1/sshd_config" 2>/dev/null |
     awk 'tolower($1)=="passwordauthentication"{p=$2}
          tolower($1)=="permitrootlogin"{r=$2}
-         END{print p, r}'
+	 tolower($1)=="pubkeyauthentication"{k=$2}
+	 END{print p, r, k}'
 }
 if [ -z "$vh_sshd" ] || ! command -v ssh-keygen >/dev/null 2>&1; then
   echo "  SKIP no sshd here — the ordering claim is sshd's own and nothing else answers it"
@@ -6008,17 +6034,17 @@ else
   vh_name="$(printf '%s\n' "$vh_call" |
                awk '/\/etc\/ssh\/sshd_config\.d\// {
                       sub(/.*sshd_config\.d\//, ""); sub(/[ \\].*/, ""); print; exit }')"
-  if [ "$(vh_effective "$vhr")" != "no no" ]; then
+  if [ "$(vh_effective "$vhr")" != "no no yes" ]; then
     echo "  SKIP sshd -T is not usable here — it could not read even the drop-in alone"
   else
-    chk "the drop-in alone hardens a fresh host"          "no no" "$(vh_effective "$vhr")"
-    printf 'PasswordAuthentication yes\nPermitRootLogin yes\n' \
+    chk "the drop-in alone hardens a fresh host"      "no no yes" "$(vh_effective "$vhr")"
+    printf 'PasswordAuthentication yes\nPermitRootLogin yes\nPubkeyAuthentication no\n' \
       > "$vhr/sshd_config.d/50-cloud-init.conf"
-    chk "and still does beside Ubuntu's cloud-init drop-in" "no no" "$(vh_effective "$vhr")"
+    chk "and still does beside Ubuntu's cloud-init drop-in" "no no yes" "$(vh_effective "$vhr")"
     # The negative control, and the one that says the assertion above is about
     # the name rather than the content: the same body under the old name.
     mv "$vhr/sshd_config.d/$vh_name" "$vhr/sshd_config.d/99-collavre.conf"
-    chk "where a 99- name would have lost both keywords"  "yes yes" "$(vh_effective "$vhr")"
+    chk "where a 99- name loses all three settings"   "yes yes no" "$(vh_effective "$vhr")"
   fi
   rm -rf "$vhr"
 fi
@@ -6141,7 +6167,7 @@ echo "148. a torn write cannot reach a drop-in this script owns"
 # back on:
 #
 #   01-collavre.conf state   bytes   sshd -t   passwordauth  permitrootlogin
-#   whole                    77      rc=0      no            no
+#   whole                   102      rc=0      no            no
 #   0 bytes (torn at open)    0      rc=0      yes           yes
 #   cut after line 1         26      rc=0      no            yes
 #   cut mid-directive        36      rc=255    -             -

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -21,7 +21,7 @@ SRC="${1:-$ROOT/script/lightsail_launch.sh}"
 # die() is a one-liner; the others run to the first column-1 closing brace.
 eval "$(awk '
   /^die\(\) \{/ { print; next }
-  /^(ensure_block|ensure_sudoers|in_group|write_state_file|launch_record_is_complete|record_launch_settings|record_deploy_user_grant|revoke_deploy_user_access|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|install_deploy_ssh_dir|reassign_prior_db_role|refuse_superuser_db_rotation|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps|warn_existing_containers_keep_log_config|dedupe_authorized_keys|install_staged_authorized_keys|postgresql_conf_includes_confd|role_owns_app_objects|refuse_db_name_change|refuse_defaulted_config_change|refuse_unusable_db_identifier|refuse_unparsable_ssh_key|refuse_forced_command_ssh_key|ipv4_dotted_quad|refuse_unusable_bind_address|refuse_unusable_subnet|passwd_home|ssh_key_holder|adopt_legacy_ssh_key_marker|record_db_role_grant|reassign_one_db_role|record_ssh_key_grant|refuse_root_deploy_user|append_state_line|refuse_nologin_deploy_user|resolve_symlink_chain|stage_beside|stage_authorized_keys|verify_ssh_hardening|refuse_unusable_retention|install_managed_config|reload_ssh_daemon)\(\) \{/ { f = 1 }
+  /^(ensure_block|ensure_sudoers|in_group|write_state_file|launch_record_is_complete|record_launch_settings|record_deploy_user_grant|revoke_deploy_user_access|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|install_deploy_ssh_dir|reassign_prior_db_role|refuse_superuser_db_rotation|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps|warn_existing_containers_keep_log_config|dedupe_authorized_keys|install_staged_authorized_keys|postgresql_conf_includes_confd|role_owns_app_objects|refuse_db_name_change|refuse_defaulted_config_change|refuse_unusable_db_identifier|refuse_unparsable_ssh_key|refuse_forced_command_ssh_key|ipv4_dotted_quad|refuse_unusable_bind_address|refuse_unusable_subnet|passwd_home|ssh_key_holder|adopt_legacy_ssh_key_marker|record_db_role_grant|reassign_one_db_role|record_ssh_key_grant|refuse_root_deploy_user|append_state_line|refuse_nologin_deploy_user|resolve_symlink_chain|stage_beside|stage_authorized_keys|verify_ssh_hardening|refuse_unusable_retention|install_managed_config|install_downloaded_file|reload_ssh_daemon)\(\) \{/ { f = 1 }
   f { print }
   f && /^\}/ { f = 0 }
 ' "$SRC")"
@@ -46,7 +46,7 @@ for fn in die ensure_block ensure_sudoers in_group write_state_file \
           refuse_root_deploy_user append_state_line refuse_nologin_deploy_user \
           resolve_symlink_chain stage_beside stage_authorized_keys \
           verify_ssh_hardening refuse_unusable_retention \
-          install_managed_config reload_ssh_daemon \
+	  install_managed_config install_downloaded_file reload_ssh_daemon \
           adopt_legacy_ssh_key_marker; do
   declare -F "$fn" >/dev/null || {
     echo "could not extract $fn() from $SRC — has the definition moved?" >&2
@@ -5154,8 +5154,9 @@ echo "136. the Docker plugins are installed on a host that already has docker"
 docker_step() {  # DOCKER_PRESENT / BUILDX_OK / COMPOSE_OK are read from the env
   ( set +u
     log(){ printf 'LOG: %s\n' "$*"; }
-    install(){ :; }; curl(){ :; }; chmod(){ :; }; apt_get(){ :; }
-    install_managed_config(){ :; }
+    install(){ :; }; apt_get(){ :; }
+    # shellcheck disable=SC2329  # called by the extracted Docker step
+    install_managed_config(){ :; }; install_downloaded_file(){ :; }
     dpkg(){ echo amd64; }; VERSION_CODENAME=noble
     apt_install(){ printf 'INSTALL:%s\n' "$*"; }
     command(){
@@ -6143,6 +6144,57 @@ chk "the staged source is installed before apt reads it"     1 \
 	else print 0
       }
     ' <<<"$postgres_source_block")"
+
+echo "154. the Docker signing key is installed atomically"
+download_dir="$(mktemp -d)"
+printf 'old-key\n' > "$download_dir/docker.asc"
+ln -s "$download_dir/docker.asc" "$download_dir/docker-link.asc"
+DOWNLOAD_RESULT=fail
+# shellcheck disable=SC2329  # called by extracted install_downloaded_file
+curl() {
+  local output=''
+  while [ "$#" -gt 0 ]; do
+    if [ "$1" = -o ]; then
+      output="$2"
+      shift 2
+    else
+      shift
+    fi
+  done
+  printf '%s\n' "${DOWNLOAD_RESULT}-key" > "$output"
+  [ "$DOWNLOAD_RESULT" = complete ]
+}
+download_status=0
+( install_downloaded_file 'the Docker signing key' \
+    https://example.invalid/docker.asc "$download_dir/docker-link.asc" \
+  ) >/dev/null 2>&1 || download_status=$?
+chk "a failed download leaves the live key intact"           old-key \
+  "$(cat "$download_dir/docker.asc")"
+chk "and reports failure"                                    1 "$download_status"
+chk "and removes its incomplete sibling"                     0 \
+  "$(find "$download_dir" -name 'docker.asc.collavre.*' | wc -l | tr -d ' ')"
+
+DOWNLOAD_RESULT=complete
+install_downloaded_file 'the Docker signing key' \
+  https://example.invalid/docker.asc "$download_dir/docker-link.asc"
+chk "a complete download replaces the key"                   complete-key \
+  "$(cat "$download_dir/docker.asc")"
+chk "and preserves a symlinked target"                        symlink \
+  "$([ -L "$download_dir/docker-link.asc" ] && echo symlink || echo regular-file)"
+unset -f curl
+rm -rf "$download_dir"
+
+chk "the Docker step never downloads into the live key"      0 \
+  "$(grep -c -- '-o /etc/apt/keyrings/docker.asc' <<<"$docker_source_block")"
+chk "and installs the key before publishing its source"      1 \
+  "$(awk '
+      /install_downloaded_file .*Docker signing key/ { installed = NR }
+      /install_managed_config .*Docker apt source/ { published = NR }
+      END {
+	if (installed && published && installed < published) print 1
+	else print 0
+      }
+    ' <<<"$docker_source_block")"
 
 echo
 if [ "$fail" = 0 ]; then echo "ALL PASS"; else echo "FAILURES"; fi

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -374,20 +374,27 @@ chk "only our own rule deleted" 1 "$(printf '%s' "$UFW_CALLS" | grep -c delete)"
 chk "no reset"                  0 "$(printf '%s' "$UFW_CALLS" | grep -c reset)"
 
 echo "23. SSH already allowed is detected in every form ufw prints it"
+# Only IPv4 counts — see case 25a. ufw writes the "(v6)" line alongside its IPv4
+# twin and deletes them together, so the dual-stack pair is what a real host
+# carries; the tagged line is never alone, and here it must not be what decides.
 for s in "22/tcp                     ALLOW       Anywhere" \
          "22                         ALLOW IN    Anywhere" \
          "OpenSSH                    ALLOW       Anywhere" \
-         "22/tcp (v6)                ALLOW       Anywhere (v6)" \
          "22/tcp                     ALLOW IN    203.0.113.4" \
          "22/tcp                     LIMIT       203.0.113.9" \
          "22/tcp                     LIMIT IN    Anywhere" \
-         "22/tcp (v6)                LIMIT       Anywhere (v6)" \
          "10.1.2.3 22/tcp            ALLOW       203.0.113.9" \
          "10.1.2.3 22/tcp            LIMIT       203.0.113.9" \
-         "2001:db8::1 22/tcp         ALLOW       2001:db8::9"; do
+         "22/tcp                     ALLOW       Anywhere                   # ssh: admin only" \
+         "22/tcp                     ALLOW       203.0.113.4                # ops: jump box" \
+         "22/tcp                     ALLOW       Anywhere
+22/tcp (v6)                ALLOW       Anywhere (v6)" \
+         "22/tcp                     ALLOW       203.0.113.4
+22/tcp                     ALLOW       2001:db8::9"; do
   STATUS="$s"
   ssh_already_allowed
-  chk "detected: $s" 0 "$?"
+  chk "detected: ${s%%
+*}" 0 "$?"
 done
 
 echo "24. a narrowed SSH rule survives the re-run that finds it"
@@ -430,6 +437,28 @@ for s in "Status: inactive" \
          "22.1.1.1 80/tcp            ALLOW       198.51.100.5" \
          "Anywhere                   ALLOW       203.0.113.9" \
          ""; do
+  STATUS="$s"
+  UFW_CALLS=""
+  ensure_ssh_rule
+  chk "rule added for [${s:-empty status}]" "|allow OpenSSH" "$UFW_CALLS"
+done
+
+echo "25a. an IPv6-only rule does not authorize IPv4, whatever it looks like"
+# The dangerous direction: `ufw --force enable` applies `default deny incoming`,
+# and an operator reaches a Lightsail instance over its IPv4 address. Treating
+# an IPv6-only rule as "SSH is handled" skips the IPv4 rule and then closes 22
+# on the connection in use.
+#
+# All three render differently, which is the whole difficulty. Only the first
+# carries the "(v6)" tag; the second is untagged and betrayed by its leading
+# token; the third is untagged with an ordinary-looking first column and is
+# recognisable only by the colons further along the line — and it is the most
+# likely of the three, since narrowing SSH to your own address is why a host
+# would have an IPv6-only rule at all.
+for s in "22/tcp (v6)                ALLOW       Anywhere (v6)" \
+         "2001:db8::1 22/tcp         ALLOW       2001:db8::9" \
+         "22/tcp                     ALLOW       2001:db8::9" \
+         "22/tcp                     LIMIT       2001:db8::9"; do
   STATUS="$s"
   UFW_CALLS=""
   ensure_ssh_rule

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -21,7 +21,7 @@ SRC="${1:-$ROOT/script/lightsail_launch.sh}"
 # die() is a one-liner; the others run to the first column-1 closing brace.
 eval "$(awk '
   /^die\(\) \{/ { print; next }
-  /^(ensure_block|ensure_sudoers|in_group|write_state_file|launch_record_is_complete|record_launch_settings|record_deploy_user_grant|revoke_deploy_user_access|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|install_deploy_ssh_dir|reassign_prior_db_role|refuse_superuser_db_rotation|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps|warn_existing_containers_keep_log_config|dedupe_authorized_keys|install_staged_authorized_keys|postgresql_conf_includes_confd|role_owns_app_objects|refuse_db_name_change|refuse_defaulted_config_change|refuse_unusable_db_identifier|refuse_unparsable_ssh_key|refuse_forced_command_ssh_key|ipv4_dotted_quad|refuse_unusable_bind_address|refuse_unusable_subnet|passwd_home|ssh_key_holder|adopt_legacy_ssh_key_marker|record_db_role_grant|reassign_one_db_role|record_ssh_key_grant|refuse_root_deploy_user|append_state_line|refuse_nologin_deploy_user|resolve_symlink_chain|stage_beside|stage_authorized_keys|scan_ssh_config_file|find_unsafe_ssh_match|verify_ssh_hardening|refuse_unusable_retention|refuse_unusable_backup_calendar|install_managed_config|install_downloaded_file|install_credential_summary|reload_ssh_daemon)\(\) \{/ { f = 1 }
+  /^(ensure_block|ensure_sudoers|in_group|write_state_file|launch_record_is_complete|record_launch_settings|record_deploy_user_grant|revoke_deploy_user_access|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|install_deploy_ssh_dir|reassign_prior_db_role|refuse_superuser_db_rotation|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps|warn_existing_containers_keep_log_config|dedupe_authorized_keys|install_staged_authorized_keys|postgresql_conf_includes_confd|role_owns_app_objects|refuse_db_name_change|refuse_defaulted_config_change|refuse_unusable_db_identifier|refuse_unparsable_ssh_key|refuse_forced_command_ssh_key|ipv4_dotted_quad|refuse_unusable_bind_address|refuse_unusable_subnet|passwd_home|ssh_key_holder|adopt_legacy_ssh_key_marker|record_db_role_grant|reassign_one_db_role|record_ssh_key_grant|refuse_root_deploy_user|append_state_line|refuse_nologin_deploy_user|resolve_symlink_chain|stage_beside|restore_postgresql_bind_config|stage_authorized_keys|scan_ssh_config_file|find_unsafe_ssh_match|verify_ssh_hardening|refuse_unusable_retention|refuse_unusable_backup_calendar|install_managed_config|install_downloaded_file|install_credential_summary|reload_ssh_daemon)\(\) \{/ { f = 1 }
   f { print }
   f && /^\}/ { f = 0 }
 ' "$SRC")"
@@ -44,7 +44,8 @@ for fn in die ensure_block ensure_sudoers in_group write_state_file \
           passwd_home ssh_key_holder \
           record_db_role_grant reassign_one_db_role record_ssh_key_grant \
           refuse_root_deploy_user append_state_line refuse_nologin_deploy_user \
-          resolve_symlink_chain stage_beside stage_authorized_keys \
+	  resolve_symlink_chain stage_beside restore_postgresql_bind_config \
+	  stage_authorized_keys \
 	  scan_ssh_config_file find_unsafe_ssh_match verify_ssh_hardening \
 	  refuse_unusable_retention \
 	  refuse_unusable_backup_calendar \
@@ -4497,16 +4498,17 @@ chk "and not by a redirection"         0 \
 # still carries the real one. The app meets `password authentication failed` at
 # its next reconnect, and the value it needs is gone from the host.
 echo "121. an empty db_password marker is refused rather than applied"
-pw_recipe="$(awk '/^if \[ -z "\$DB_PASSWORD" \]; then$/ { f = 1 }
+pw_recipe="$(awk '/^DB_PASSWORD_PENDING_FILE=/ { f = 1 }
                   f { print }
-                  f && /^fi$/ { exit }' "$SRC")"
+		  f && /^if \[ -f "\$STATE_DIR\/db_password" \]; then$/ { chmod_block = 1 }
+		  f && chmod_block && /^fi$/ { exit }' "$SRC")"
 chk "the block was extracted" 1 \
   "$(grep -q 'STATE_DIR/db_password' <<<"$pw_recipe" && echo 1 || echo 0)"
 
 run_pw() {   # run_pw <state dir>
   PW_STATUS=0
   PW_OUT="$(
-    env STATE_DIR="$1" DB_PASSWORD= \
+    env STATE_DIR="$1" DB_USER=collavre_user DB_PASSWORD= \
       bash -c '
         set -uo pipefail
         '"$(declare -f die)"'
@@ -4537,6 +4539,12 @@ rm -f "$pwd_dir/db_password"
 run_pw "$pwd_dir"
 chk "no marker at all: generates" 0 "$PW_STATUS"
 chk "and it is not empty"         0 "$(grep -c '^APPLIED:$' <<<"$PW_OUT")"
+
+printf 'pendingpassword' > "$pwd_dir/db_password.pending.collavre_user"
+run_pw "$pwd_dir"
+chk "an interrupted update resumes its pending value" 0 "$PW_STATUS"
+chk "and applies the value recorded for this role" "APPLIED:pendingpassword" \
+  "$(grep '^APPLIED:' <<<"$PW_OUT")"
 
 echo "121a. the password marker is 0600 from the moment it exists"
 # mktemp creates 0600 and write_state_file chmods before it writes, so the
@@ -5706,7 +5714,7 @@ chk "and the run asks both before anything is written" 2 \
 # when the guards above run. Asserted at source level because it needs a
 # cluster — measured there as rc=0 bound, rc=2 up-but-not-listening.
 chk "and asks the cluster whether it is listening on it" 1 \
-  "$(grep -c '^pg_isready -h "\$DB_BIND_ADDRESS"' "$SRC")"
+  "$(grep -c '^[[:space:]]*if ! pg_isready -h "\$DB_BIND_ADDRESS"' "$SRC")"
 
 echo "144. an interrupted first append leaves the managed block off the live file"
 # The rewrite path was staged and renamed two commits ago; the append that adds
@@ -6635,6 +6643,138 @@ chk "a symlinked summary remains a symlink" yes \
 chk "and its backing file receives the complete render" 1 \
   "$(grep -c '^  DATABASE_URL=postgresql://linked$' "$summary_dir/backing/summary")"
 rm -rf "$summary_dir"
+
+echo "158. the live DB password record advances only after the role does"
+sql_apply_line="$(grep -n '^runuser -u postgres -- psql ' "$SRC" | cut -d: -f1)"
+db_user_commit_line="$(
+  grep -n '^write_state_file "\$STATE_DIR/db_user"' "$SRC" | cut -d: -f1
+)"
+password_promote_line="$(
+  grep -n '^mv -f "\$DB_PASSWORD_PENDING_FILE" "\$STATE_DIR/db_password"' "$SRC" |
+    cut -d: -f1
+)"
+chk "the password has a durable pending record" 1 \
+  "$(grep -c 'DB_PASSWORD_PENDING_FILE=.*db_password.pending' "$SRC")"
+chk "the pending credential is promoted after psql succeeds" 1 \
+  "$([ -n "$password_promote_line" ] &&
+      [ "$password_promote_line" -gt "$sql_apply_line" ] && echo 1 || echo 0)"
+chk "and only after the matching DB_USER is recorded" 1 \
+  "$([ "$password_promote_line" -gt "$db_user_commit_line" ] && echo 1 || echo 0)"
+chk "the live record is not replaced before psql" 0 \
+  "$(awk -v stop="$sql_apply_line" '
+      NR < stop && /write_state_file "\$STATE_DIR\/db_password"/ { count++ }
+      END { print count + 0 }
+    ' "$SRC")"
+password_apply_recipe="$(
+  awk '
+    /^DB_PASSWORD_PENDING_FILE=/ { f = 1 }
+    /^# Recorded only once the database it names/ { exit }
+    f { print }
+  ' "$SRC"
+)"
+run_password_apply() {
+  # <state dir> <db user> <password> <psql fails> <grant fails> <reassign fails>
+  PASSWORD_APPLY_STATUS=0
+  env STATE_DIR="$1" DB_USER="$2" DB_NAME=collavre_production \
+      DB_PASSWORD="$3" PSQL_FAIL="$4" GRANT_FAIL="$5" REASSIGN_FAIL="$6" \
+    bash -c '
+      set -euo pipefail
+      '"$(declare -f die write_state_file)"'
+      log() { :; }
+      record_db_role_grant() { [ "$GRANT_FAIL" -eq 0 ]; }
+      reassign_prior_db_role() { [ "$REASSIGN_FAIL" -eq 0 ]; }
+      chown() { :; }
+      runuser() { [ "$PSQL_FAIL" -eq 0 ]; }
+      '"$password_apply_recipe"'
+    ' >/dev/null 2>&1 || PASSWORD_APPLY_STATUS=$?
+}
+password_state="$(mktemp -d)"
+printf 'oldpassword' > "$password_state/db_password"
+run_password_apply "$password_state" collavre_user newpassword 1 0 0
+chk "a psql failure keeps the deployed password record" "oldpassword" \
+  "$(cat "$password_state/db_password")"
+chk "and preserves the attempted value for recovery" "newpassword" \
+  "$(cat "$password_state/db_password.pending.collavre_user")"
+run_password_apply "$password_state" collavre_user "" 0 0 0
+chk "a retry without DB_PASSWORD resumes and promotes it" "newpassword" \
+  "$(cat "$password_state/db_password")"
+chk "the promoted credential remains root-only" 600 \
+  "$(file_mode "$password_state/db_password")"
+chk "and consumes the completed pending record" 0 \
+  "$([ -e "$password_state/db_password.pending.collavre_user" ] && echo 1 || echo 0)"
+run_password_apply "$password_state" collavre_user nextpassword 0 1 0
+chk "a role-grant recording failure still preserves the live record" \
+  "newpassword" "$(cat "$password_state/db_password")"
+chk "while retaining the next attempt" "nextpassword" \
+  "$(cat "$password_state/db_password.pending.collavre_user")"
+rm -rf "$password_state"
+
+password_rotation_state="$(mktemp -d)"
+printf 'role_a\n' > "$password_rotation_state/db_user"
+printf 'password_a' > "$password_rotation_state/db_password"
+run_password_apply "$password_rotation_state" role_b password_b 0 0 1
+chk "a failed A-to-B reassignment leaves the global role at A" "role_a" \
+  "$(cat "$password_rotation_state/db_user")"
+chk "and its password record at A's deployed value" "password_a" \
+  "$(cat "$password_rotation_state/db_password")"
+chk "while B's applied attempt remains role-specific" "password_b" \
+  "$(cat "$password_rotation_state/db_password.pending.role_b")"
+run_password_apply "$password_rotation_state" role_a "" 0 0 0
+chk "so cancelling back to A does not apply B's password to A" "password_a" \
+  "$(cat "$password_rotation_state/db_password")"
+rm -rf "$password_rotation_state"
+
+echo "159. a failed PostgreSQL bind change restores the prior config"
+chk "the prior managed config is backed up before replacement" 1 \
+  "$(grep -c '^[[:space:]]*PG_CONF_BACKUP=.*stage_beside' "$SRC")"
+chk "a failed reachability probe invokes the rollback" 1 \
+  "$(grep -c '^  restore_postgresql_bind_config ' "$SRC")"
+chk "the rollback restarts PostgreSQL on the restored config" 1 \
+  "$(awk '
+      /^restore_postgresql_bind_config\(\)/ { f = 1 }
+      f && /systemctl restart postgresql/ { found = 1 }
+      f && /^}/ { print found + 0; exit }
+    ' "$SRC")"
+pg_rollback_dir="$(mktemp -d)"
+printf 'new bind\n' > "$pg_rollback_dir/live"
+printf 'old bind\n' > "$pg_rollback_dir/backup"
+PG_RESTARTS=0
+systemctl() {
+  [ "$*" = "restart postgresql" ] || return 1
+  PG_RESTARTS=$((PG_RESTARTS + 1))
+  [ "${PG_RESTART_FAIL:-0}" -eq 0 ]
+}
+restore_postgresql_bind_config \
+  "$pg_rollback_dir/live" "$pg_rollback_dir/backup" 1
+chk "the previous bytes are restored" "old bind" \
+  "$(cat "$pg_rollback_dir/live")"
+chk "and PostgreSQL is restarted on them" 1 "$PG_RESTARTS"
+chk "a successful rollback consumes its retry backup" 0 \
+  "$([ -e "$pg_rollback_dir/backup" ] && echo 1 || echo 0)"
+printf 'first-run bind\n' > "$pg_rollback_dir/live"
+restore_postgresql_bind_config \
+  "$pg_rollback_dir/live" "$pg_rollback_dir/unused" 0
+chk "a failed first-run bind is removed" 0 \
+  "$([ -e "$pg_rollback_dir/live" ] && echo 1 || echo 0)"
+chk "and the localhost-only config is restarted" 2 "$PG_RESTARTS"
+printf 'bad bind\n' > "$pg_rollback_dir/live"
+printf 'working bind\n' > "$pg_rollback_dir/backup"
+PG_RESTART_FAIL=1
+restore_postgresql_bind_config \
+  "$pg_rollback_dir/live" "$pg_rollback_dir/backup" 1
+chk "a restart failure has its own status" 2 "$?"
+chk "but still leaves the working bytes restored" "working bind" \
+  "$(cat "$pg_rollback_dir/live")"
+chk "and preserves the backup for an EXIT-trap retry" "working bind" \
+  "$(cat "$pg_rollback_dir/backup")"
+PG_RESTART_FAIL=0
+restore_postgresql_bind_config \
+  "$pg_rollback_dir/live" "$pg_rollback_dir/backup" 1
+chk "the retry can restart from the preserved backup" 0 "$?"
+chk "and only then consumes it" 0 \
+  "$([ -e "$pg_rollback_dir/backup" ] && echo 1 || echo 0)"
+unset -f systemctl
+rm -rf "$pg_rollback_dir"
 
 echo
 if [ "$fail" = 0 ]; then echo "ALL PASS"; else echo "FAILURES"; fi

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -2654,6 +2654,27 @@ chk "deploy user recovered"          1 \
 chk "db role recovered"              1 \
   "$(grep -c "DB_USER: host has 'collavre_app'" <<<"$CFG_OUT")"
 chk "and S3 is not claimed to be checked" 0 "$(grep -c 'BACKUP_S3_URI' <<<"$CFG_OUT")"
+# The file it sends the operator to has to be one that is there. This branch
+# exists *because* launch.env is absent, so naming it as "the host's own record"
+# is wrong on exactly the path that prints it — and it reads as "your record is
+# missing" at the moment the operator is being asked to reconstruct a command.
+chk "it does not cite the absent file" 0 \
+  "$(grep -c "record of what it was given is $legacy/launch.env" <<<"$CFG_OUT")"
+chk "it names the files that answered" 1 \
+  "$(grep -c "$legacy/deploy_user, $legacy/db_user" <<<"$CFG_OUT")"
+chk "and says the rest is on you"      1 \
+  "$(grep -c 'could not be checked at all' <<<"$CFG_OUT")"
+
+echo "111a. only the files that actually answered are cited"
+# A directory listing would do; naming the file whose value refused is what
+# makes the citation checkable by the operator reading it.
+half=$(mktemp -d)
+printf 'deploybot\n' > "$half/deploy_user"
+run_cfg "$half" ""
+chk "refused"                        1 "$CFG_STATUS"
+chk "the file that answered named"   1 "$(grep -c "$half/deploy_user" <<<"$CFG_OUT")"
+chk "and db_user is not invented"    0 "$(grep -c 'db_user' <<<"$CFG_OUT")"
+rm -rf "$half"
 rm -rf "$legacy"
 
 echo "112. a first run has nothing to disagree with"
@@ -2685,6 +2706,116 @@ for after in 'apt_get update' 'ensure_sudoers "\$APP_SSH_USER"' \
   chk "before ${after%% *}" 1 \
     "$([ -n "$line" ] && [ "$call_line" -lt "$line" ] && echo 1 || echo 0)"
 done
+
+echo "115. no procedure on the page walks the operator into this refusal blind"
+# The guard is only a stop rather than a trap if the page that prints re-runs
+# says what a re-run has to repeat. §2 does; a recipe elsewhere that names one
+# setting and stops mid-procedure — app down, old cluster already dropped — is
+# the same refusal reached at the worst moment. So every FORCE=1 invocation on
+# the page has to carry the record with it: named in the command itself, or
+# within reading distance of it.
+#
+# Scoped to the enclosing section rather than to a window of N lines: the unit
+# an operator reads is the procedure they are following, and a section boundary
+# is where they stopped reading. A window would also pass or fail on how the
+# prose happens to be wrapped.
+heads="$(grep -n '^#\{2,\} ' "$DOC" | cut -d: -f1)"
+while IFS=: read -r n _; do
+  [ -n "$n" ] || continue
+  from=1; to="$(wc -l < "$DOC")"
+  for h in $heads; do
+    [ "$h" -le "$n" ] && from="$h"
+    if [ "$h" -gt "$n" ]; then to=$(( h - 1 )); break; fi
+  done
+  chk "FORCE=1 at doc line $n cites launch.env, in the section that prints it" 1 \
+    "$([ "$(sed -n "${from},${to}p" "$DOC" | grep -c 'launch\.env')" -gt 0 ] &&
+       echo 1 || echo 0)"
+done <<<"$(grep -n 'FORCE=1' "$DOC" | grep -E 'lightsail_launch\.sh|launch script')"
+
+echo "116. the DB_USER escape hatch operates on the database the host records"
+# The two blocks under "Changing DB_USER on a re-run" are the way out of a run
+# that has already stopped, and they named collavre_production. On a host that
+# followed the rename procedure further down the same page they connect to a
+# database that is not there — and the check block's success signal was "empty
+# output", which is what a psql that cannot connect leaves on stdout while its
+# FATAL goes to stderr. So the escape hatch reported a finished transfer for a
+# connection it never made.
+xfer="$(extract_recipe 'OWNER TO %I')"
+ownck="$(extract_recipe 'asked=yes')"
+chk "the transfer names no database of its own" 0 \
+  "$(grep -c 'collavre_production' <<<"$xfer")"
+chk "nor does the check"                        0 \
+  "$(grep -c 'collavre_production' <<<"$ownck")"
+chk "the name comes from managed state"         1 \
+  "$(grep -cq '/var/lib/collavre/db_name' <<<"$(extract_recipe 'could not read the database name')" \
+     && echo 1 || echo 0)"
+
+# Runs the extracted check block against a psql that cannot connect, one that
+# reports rows still owned, and one that reports none.
+run_ownck() {
+  local work; work="$(mktemp -d)"
+  mkdir -p "$work/bin"
+  cat > "$work/bin/sudo" <<'SUDO'
+#!/usr/bin/env bash
+while [ "$#" -gt 0 ]; do case "$1" in -u) shift 2 ;; *) break ;; esac; done
+exec "$@"
+SUDO
+  # The stub writes its refusal to stderr and leaves stdout empty, the way psql
+  # does — asserting that split is the whole point of the case.
+  cat > "$work/bin/psql" <<'PSQL'
+#!/usr/bin/env bash
+case "$MODE" in
+  fail)  echo 'psql: error: FATAL:  database "x" does not exist' >&2; exit 2 ;;
+  rows)  echo 'r|creatives'; exit 0 ;;
+  clean) exit 0 ;;
+esac
+PSQL
+  chmod +x "$work/bin/sudo" "$work/bin/psql"
+  printf 'app_db=the_db\n%s' "$ownck" > "$work/check.sh"
+  OWNCK_OUT="$(PATH="$work/bin:$PATH" MODE="$1" bash "$work/check.sh" 2>/dev/null)"
+  rm -rf "$work"
+}
+
+run_ownck fail
+chk "an unanswerable check says so"    1 "$(grep -c 'COULD NOT CHECK' <<<"$OWNCK_OUT")"
+chk "and does not report completion"   0 "$(grep -c 'TRANSFER COMPLETE' <<<"$OWNCK_OUT")"
+run_ownck rows
+chk "rows left are reported"           1 "$(grep -c 'STILL OWNED BY' <<<"$OWNCK_OUT")"
+chk "not as completion"                0 "$(grep -c 'TRANSFER COMPLETE' <<<"$OWNCK_OUT")"
+run_ownck clean
+chk "a clean database is completion"   1 "$(grep -c 'TRANSFER COMPLETE' <<<"$OWNCK_OUT")"
+
+# The negative control. There is no assertion-shaped one against the previous
+# revision — that block printed no verdict at all, the prose carried it — so the
+# discrimination is measured directly instead: under the old form the failed
+# connection and the finished transfer are the same two bytes of stdout.
+prevdir="$(mktemp -d)"; mkdir -p "$prevdir/bin"
+cat > "$prevdir/bin/sudo" <<'SUDO'
+#!/usr/bin/env bash
+while [ "$#" -gt 0 ]; do case "$1" in -u) shift 2 ;; *) break ;; esac; done
+exec "$@"
+SUDO
+cat > "$prevdir/bin/psql" <<'PSQL'
+#!/usr/bin/env bash
+case "$MODE" in
+  fail)  echo 'psql: error: FATAL:  database "x" does not exist' >&2; exit 2 ;;
+  clean) exit 0 ;;
+esac
+PSQL
+chmod +x "$prevdir/bin/sudo" "$prevdir/bin/psql"
+echo 'sudo -u postgres psql -qtA -d collavre_production -c "SELECT 1"' > "$prevdir/prev.sh"
+prev_fail="$(PATH="$prevdir/bin:$PATH" MODE=fail  bash "$prevdir/prev.sh" 2>/dev/null)"
+prev_ok="$(  PATH="$prevdir/bin:$PATH" MODE=clean bash "$prevdir/prev.sh" 2>/dev/null)"
+chk "the previous form could not tell them apart" "$prev_ok" "$prev_fail"
+rm -rf "$prevdir"
+# Not vacuous on its own — two empty strings compare equal for any reason at
+# all, including a stub that never ran. What makes it a control is that the
+# same two states are distinguishable under the new form.
+run_ownck fail;  new_fail="$OWNCK_OUT"
+run_ownck clean; new_ok="$OWNCK_OUT"
+chk "where the new form does"          1 \
+  "$([ "$new_fail" != "$new_ok" ] && echo 1 || echo 0)"
+chk "and the old form said nothing at all" "" "$prev_ok"
 
 echo
 if [ "$fail" = 0 ]; then echo "ALL PASS"; else echo "FAILURES"; fi

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+#
+# Unit tests for the pure helpers in script/lightsail_launch.sh.
+#
+#   bash script/test/lightsail_launch_test.sh
+#
+# The launch script provisions a host and cannot be run here, so the functions
+# under test are extracted from it rather than copied — a harness holding its
+# own copy would keep passing after the real one drifted.
+#
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SRC="${1:-$ROOT/script/lightsail_launch.sh}"
+[ -f "$SRC" ] || { echo "no such script: $SRC" >&2; exit 1; }
+
+# die() is a one-liner; ensure_block() runs to the first column-1 closing brace.
+eval "$(awk '
+  /^die\(\) \{/ { print }
+  /^ensure_block\(\) \{/ { f = 1 }
+  f { print }
+  f && /^\}/ { exit }
+' "$SRC")"
+
+declare -F die >/dev/null && declare -F ensure_block >/dev/null || {
+  echo "could not extract die/ensure_block from $SRC — has the definition moved?" >&2
+  exit 1
+}
+
+fail=0
+chk() {
+  if [ "$2" = "$3" ]; then
+    echo "  ok   $1"
+  else
+    echo "  FAIL $1: expected [$2] got [$3]"
+    fail=1
+  fi
+}
+# GNU stat first: BSD stat rejects -c, but GNU stat *accepts* -f as "report on
+# the filesystem" and would print a block-device summary instead of a mode.
+file_mode() { stat -c '%a' "$1" 2>/dev/null || stat -f '%OLp' "$1"; }
+inode() { ls -i "$1" | awk '{print $1}'; }
+
+echo "1. a re-run with a changed value replaces the block"
+f=$(mktemp)
+printf 'local all postgres peer\nhost all all 127.0.0.1/32 scram-sha-256\n' > "$f"
+ensure_block "$f" docker "host    all    all    172.16.0.0/12    scram-sha-256"
+ensure_block "$f" docker "host    all    all    10.200.0.0/16    scram-sha-256"
+chk "new subnet authorized"      1 "$(grep -c '10.200.0.0/16' "$f")"
+chk "old subnet revoked"         0 "$(grep -c '172.16.0.0/12' "$f")"
+chk "one block, not two"         1 "$(grep -c '# BEGIN collavre:docker' "$f")"
+chk "unmanaged rules untouched"  1 "$(grep -c '127.0.0.1/32' "$f")"
+
+echo "2. the block keeps its position"
+# pg_hba.conf is first-match-wins: delete-and-append would park the managed
+# rule behind whatever the operator added after it.
+f=$(mktemp)
+printf 'A\n' > "$f"
+ensure_block "$f" docker "OLD"
+printf 'TRAILER\n' >> "$f"
+ensure_block "$f" docker "NEW"
+chk "still above TRAILER" \
+  "$(printf 'A\n\n# BEGIN collavre:docker (managed by script/lightsail_launch.sh)\nNEW\n# END collavre:docker\nTRAILER')" \
+  "$(cat "$f")"
+
+echo "3. an unchanged value rewrites nothing"
+f=$(mktemp)
+printf 'A\n' > "$f"
+ensure_block "$f" hostname "127.0.1.1 collavre"
+before="$(cat "$f")"
+ensure_block "$f" hostname "127.0.1.1 collavre"
+chk "byte-identical" "$before" "$(cat "$f")"
+
+echo "4. ownership and permissions survive the rewrite"
+# pg_hba.conf is postgres:postgres 0640; a mv from mktemp would leave it
+# root:root 0600 and PostgreSQL would fail to start.
+f=$(mktemp)
+printf 'A\n' > "$f"
+ensure_block "$f" docker "OLD"
+chmod 0640 "$f"
+ino="$(inode "$f")"
+ensure_block "$f" docker "NEW"
+chk "mode preserved"  "640"  "$(file_mode "$f")"
+chk "same inode"      "$ino" "$(inode "$f")"
+
+echo "5. multi-line bodies are replaced whole"
+f=$(mktemp)
+printf 'A\n' > "$f"
+ensure_block "$f" multi "$(printf 'one\ntwo')"
+ensure_block "$f" multi "$(printf 'three\nfour')"
+chk "new lines present" 2 "$(grep -cE '^(three|four)$' "$f")"
+chk "old lines gone"    0 "$(grep -cE '^(one|two)$' "$f")"
+
+echo "6. BEGIN with no END is refused, not guessed at"
+f=$(mktemp)
+printf 'A\n# BEGIN collavre:docker\nstray\nB\n' > "$f"
+before="$(cat "$f")"
+out="$(ensure_block "$f" docker "NEW" 2>&1)"
+chk "exits non-zero"  1          "$?"
+chk "file untouched"  "$before"  "$(cat "$f")"
+case "$out" in
+  *"no '# END collavre:docker'"*) echo "  ok   says what is wrong" ;;
+  *) echo "  FAIL unhelpful message: $out"; fail=1 ;;
+esac
+
+echo "7. END before BEGIN is refused rather than truncating the file"
+f=$(mktemp)
+printf 'A\n# END collavre:docker\nB\n# BEGIN collavre:docker\nC\n' > "$f"
+before="$(cat "$f")"
+(ensure_block "$f" docker "NEW") >/dev/null 2>&1
+chk "exits non-zero"  1          "$?"
+chk "file untouched"  "$before"  "$(cat "$f")"
+
+echo
+if [ "$fail" = 0 ]; then echo "ALL PASS"; else echo "FAILURES"; fi
+exit "$fail"

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -2607,6 +2607,10 @@ STUB
   cat > "$work/bin/pg_restore" <<'STUB'
 #!/usr/bin/env bash
 echo "PG_RESTORE_RAN" >>"$TRACE"
+# Kept out of $TRACE, which is matched as a whole-sequence glob by a dozen
+# cases above: an argument list spliced into it would be matched by their
+# wildcards for the wrong reason. Its own file, read by case 139.
+printf '%s\n' "$*" >"$RESTORE_ARGS"
 [ -z "$FAIL_RESTORE" ] || exit 1
 STUB
   chmod +x "$work/bin"/*
@@ -2623,6 +2627,7 @@ STUB
          FAIL_PRIOR_READ="${FAIL_PRIOR_READ:-}" \
          FAIL_READBACK="${FAIL_READBACK:-}" \
          CONNLIMIT="$work/connlimit" DATCONN_N="$work/datconn_n" \
+         RESTORE_ARGS="$work/restore_args" \
          APP_ROLE="${APP_ROLE-collavre_user}" APP_SUPER="${APP_SUPER-f}" \
          APP_DB="${APP_DB-collavre_production}"
   R_OUT="$(cd "$work" && PATH="$work/bin:$PATH" bash ./recipe.sh 2>&1)"
@@ -2630,6 +2635,7 @@ STUB
   # What the database is left at, which is the thing the operator meets at boot
   # — asserted directly rather than inferred from the statements that ran.
   R_LIMIT="$(cat "$work/connlimit")"
+  R_RESTORE_ARGS="$(cat "$work/restore_args" 2>/dev/null || true)"
   rm -rf "$work"
 }
 
@@ -4483,6 +4489,14 @@ shell_of() {
 getent() { printf '%s:x:1000:1000::/home/%s:%s\n' "$2" "$2" "$(shell_of "$2")"; }
 # shellcheck disable=SC2329
 id() { [ "$2" = brandnew ] && return 1; echo 1000; }
+# The guard's second probe runs the shell *as the account*, and none of these
+# accounts exist on the machine running the suite. Stubbed rather than skipped,
+# because the accounts that do exist here would answer for the wrong reason: a
+# real `su` to a name with no passwd entry fails, which would read as the
+# refusal this case is testing for. 'rootonly' is the account whose shell root
+# can execute and the account cannot — case 137.
+# shellcheck disable=SC2329
+runuser() { [ "$2" = rootonly ] && return 1; shift 3; "$@"; }
 for u in nobody svc gone ghost; do
   out="$( (refuse_nologin_deploy_user "$u") 2>&1 )"
   chk "'$u' is refused" 1 "$?"
@@ -4503,10 +4517,43 @@ refuse_nologin_deploy_user collavre
 chk "an ordinary account proceeds"              0 "$?"
 refuse_nologin_deploy_user brandnew
 chk "an account that does not exist yet proceeds" 0 "$?"
-unset -f getent id shell_of
-rm -rf "$fakebin"
 chk "the guard runs beside the UID 0 one, before anything is installed" \
   1 "$(grep -c '^refuse_nologin_deploy_user "\$APP_SSH_USER"' "$SRC")"
+
+echo "137. a shell only root can execute is refused too"
+# The probe above runs as root, and root can execute files the deploy account
+# cannot — a custom login shell installed mode-0700 root:root is the case.
+# Measured on a real Linux host against b3506940:
+#
+#   shell            /usr/local/bin/rootonly-sh  (700 root:root)
+#   [ -x ] as root   yes          probe as root     PASSES
+#   probe as account REFUSES      what sshd does    "Permission denied"
+#
+# So provisioning gave that account docker and passwordless sudo, published
+# KAMAL_SSH_USER, and every remote command failed.
+out="$( (refuse_nologin_deploy_user rootonly) 2>&1 )"
+chk "an account that cannot execute its own login shell is refused" 1 "$?"
+case "$out" in
+  *"as root but 'rootonly' cannot"*"Nothing has been changed"*)
+    echo "  ok   and says which side of the switch failed" ;;
+  *) echo "  FAIL does not distinguish root from the account: $out"; fail=1 ;;
+esac
+# The control in the other direction, and it is the one that decides whether
+# this fix can ship: the ordinary account above still proceeds through the same
+# probe. Measured on the real host as well — an account whose password is locked
+# (`adduser --disabled-password`, which is every key-only deploy account and the
+# one this script creates), one with no home directory, and one whose home it
+# cannot read all pass. Only the shell it may not execute refuses.
+refuse_nologin_deploy_user collavre
+chk "and an ordinary account still proceeds through the same probe" 0 "$?"
+# Source-level, because the harness stubs `runuser` and would go on passing if
+# the call were removed: the probe has to be the account's, not root's.
+chk "the second probe switches to the account" \
+  1 "$(grep -c 'runuser -u "\$user" -- "\$shell" -c true' "$SRC")"
+chk "and falls back to su rather than refusing a host without runuser" \
+  1 "$(grep -c 'su -s "\$shell" -c true "\$user"' "$SRC")"
+unset -f getent id shell_of runuser
+rm -rf "$fakebin"
 
 echo "127. the backup executable is staged and validated, never truncated live"
 # The generated file is *executable*, which makes truncation quieter than it is
@@ -5002,6 +5049,99 @@ rm -rf "$td"
 chk "the plugins are not gated on the docker binary" 0 \
   "$(grep -cE 'apt_install docker-ce docker-ce-cli containerd.io' "$SRC")"
 
+echo "138. a cluster layout that cannot be read is refused, not read as empty"
+# `pg_lsclusters -h` used to be expanded straight into the here-document feeding
+# the loop, where a command substitution's status is discarded — and a `while`
+# whose body never runs completes with status 0. So a layout query that failed
+# gave the guard its one PROCEED answer. Measured against b3506940:
+#
+#   stub                                     reviewed   fixed
+#   14/main on 5432, exit 0                  refuses    refuses
+#   exits 1, nothing on stdout               PROCEEDS   refuses
+#   exits 1 after printing only 12/main      PROCEEDS   refuses
+#   exits 0, nothing on stdout (fresh host)  proceeds   proceeds
+mk_failing_lsclusters() {   # <name> <stdout> <status>
+  local bin="$CLUSTER_BIN_DIR/$1"
+  { echo '#!/bin/sh'; [ -z "$2" ] || echo "echo '$2'"; echo "exit $3"; } > "$bin"
+  chmod +x "$bin"
+}
+PG_MAJOR=17
+DB_PORT=5432
+mk_failing_lsclusters pg_ls_unreadable '' 1
+out="$( (ensure_cluster_on_default_port pg_ls_unreadable) 2>&1 )"
+chk "a layout query that fails silently is refused" 1 "$?"
+case "$out" in
+  *"cannot tell which PostgreSQL clusters exist"*"Nothing has been changed"*)
+    echo "  ok   and says why, rather than naming a version it never read" ;;
+  *) echo "  FAIL unhelpful message: $out"; fail=1 ;;
+esac
+# The sharper row: the guard did see clusters, just not the one holding the
+# port. A count of rows cannot tell this from a host that really has only that
+# cluster — the status can.
+mk_failing_lsclusters pg_ls_cut '12  main    5434 online postgres /var/lib/postgresql/12/main /var/log/x' 1
+out="$( (ensure_cluster_on_default_port pg_ls_cut) 2>&1 )"
+chk "and so is one that fails after printing some of the clusters" 1 "$?"
+# The control, and it is the reason the fix is on the status and not on the
+# output: postgresql-common is installed here before any cluster exists, so
+# `pg_lsclusters -h` on a fresh host is legitimately silent and successful.
+# Refusing emptiness would refuse every first run.
+mk_failing_lsclusters pg_ls_nocluster '' 0
+out="$( (ensure_cluster_on_default_port pg_ls_nocluster) 2>&1 )"
+chk "a fresh host with no cluster yet proceeds" 0 "$?"
+chk "and says nothing"                          "" "$out"
+chk "the layout is no longer expanded inside the here-document" 0 \
+  "$(grep -c '^\$("\$lsclusters" -h 2>/dev/null)$' "$SRC")"
+
+echo "139. the recovery restore hands the objects to the role DATABASE_URL names"
+# Without --no-owner the archive's ownership is replayed, and a dump taken
+# before a supported DB_USER rotation names the previous role. Measured on a
+# real cluster, restoring such a dump into a rotated database:
+#
+#                                   owner after    the app role's own SELECT
+#   --clean --if-exists             collavre_old   ERROR: permission denied
+#   + --no-owner --role=<app role>  collavre_new   1 row
+#
+# pg_restore exited 0 in both, so the block reports a completed recovery over a
+# database the app cannot read. The import recipe earlier in this document
+# already pairs the two flags; this block is the one that had only half of it.
+LIVE=0 KILLED=0 FAIL_RESTORE='' run_restore
+case "$R_RESTORE_ARGS" in
+  *--no-owner*--role=collavre_user*)
+    echo "  ok   the restore runs with --no-owner and --role" ;;
+  *) echo "  FAIL restore ran as: $R_RESTORE_ARGS"; fail=1 ;;
+esac
+# The role it hands them to is the one read from the host, not a literal: a
+# recovery block that named the default would restore a rotated host into a
+# role it stopped using.
+APP_ROLE=collavre_rotated LIVE=0 KILLED=0 run_restore
+case "$R_RESTORE_ARGS" in
+  *--role=collavre_rotated*) echo "  ok   and names the role this host records" ;;
+  *) echo "  FAIL did not follow \$app_role: $R_RESTORE_ARGS"; fail=1 ;;
+esac
+# The control that makes --role safe to use at all: both refusals above answer
+# before this line, so an empty or superuser role never reaches the restore.
+# Asserted through the block rather than by reading it, since that is the
+# guarantee --role is leaning on.
+# APP_SUPER='' alongside it, which is what the harness above documents an
+# absent role as coming back with. Leaving it at the default 'f' would have the
+# stub answer "not a superuser" about a role that is not there — a cluster
+# behaviour no cluster has, and the assertion then fails for the fixture's
+# reason rather than the block's.
+APP_ROLE='' APP_SUPER='' LIVE=0 KILLED=0 run_restore
+case "$R_TRACE" in
+  *PG_RESTORE_RAN*) echo "  FAIL an empty app_role still reached the restore"; fail=1 ;;
+  *) echo "  ok   an empty app_role is refused before the restore" ;;
+esac
+APP_SUPER=t APP_ROLE=postgres LIVE=0 KILLED=0 run_restore
+case "$R_TRACE" in
+  *PG_RESTORE_RAN*) echo "  FAIL a superuser app_role still reached the restore"; fail=1 ;;
+  *) echo "  ok   and so is a superuser one" ;;
+esac
+# The recovery for the case --role makes louder: objects owned by a third role
+# make the --clean DROPs fail with "must be owner", measured, and the database
+# is left untouched rather than half-replaced. The operator needs the way out.
+chk "the block says what to do when the drops are refused" 1 \
+  "$(grep -c 'must be owner of table' "$DOC")"
 
 echo
 if [ "$fail" = 0 ]; then echo "ALL PASS"; else echo "FAILURES"; fi

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -4553,7 +4553,12 @@ seed_backup
 # side, and the next value interpolated into a generated program by someone who
 # does not know about %q. Both produce exactly this — a staged file that is not
 # a whole script — so that is what the fixture produces directly.
-out=$(run_backup_section 'printf() { command printf "$@"; command printf "if [\n"; }')
+#
+# The injection goes through `cat`, which both the heredoc form and the current
+# one use, so the fixture reaches the guard the same way whichever way the file
+# is generated. An injection that only lands on the current spelling would read
+# as a regression against every earlier revision while measuring nothing.
+out=$(run_backup_section 'cat() { command cat "$@"; command printf "if [\n"; }')
 chk "a generated script that is not valid shell refuses" \
   1 "$(printf '%s' "$out" | grep -c '^DIE:')"
 chk "and the previous backup script survives that too" \
@@ -4795,18 +4800,27 @@ echo "133. configured values reach the backup script as data, not as source"
 # both: they are perfectly good shell, which is exactly the problem. The
 # validation below asks whether the file is a program, not whether it is the
 # intended one, so it cannot be what closes this.
-gen_backup() {
-  # The generation step as shipped, reduced to the three configured values and
-  # one line that uses one of them.
-  { printf '%s\n' '#!/usr/bin/env bash' 'set -euo pipefail' \
-      && printf 'DB_NAME=%q\nRETENTION_DAYS=%q\nS3_URI=%q\n' \
-           collavre_production 7 "$1" \
-      && printf 'echo "UPLOAD-TO=${S3_URI%%/}"\n'; } > "$2"
-}
+#
+# Driven through the real generation region rather than a reduction of it: the
+# whole claim is about what that region writes, so a harness that reimplements
+# it would pass against every revision including the one being fixed.
+bd=$(mktemp -d)
 bk=$(mktemp -d)
+gen_backup() {
+  seed_backup
+  run_backup_section "BACKUP_S3_URI='$1'" >/dev/null
+}
+# What the nightly unit does with the generated file, reduced to the part in
+# question: it runs it, under the `set -u` the generated file sets for itself,
+# so every assignment in it is evaluated. As root.
+upload_prefix() {
+  ( set -u
+    eval "$(grep -E '^S3_URI=' "$bd/collavre-pg-backup")"
+    printf 'UPLOAD-TO=%s\n' "$S3_URI" ) 2>&1
+}
 # Command substitution in a configured prefix must survive as characters.
-gen_backup 's3://b/$(touch '"$bk"'/RAN; echo pwned)/db' "$bk/gen"
-out="$(bash "$bk/gen" 2>&1)"
+gen_backup 's3://b/$(touch '"$bk"'/RAN; echo pwned)/db'
+out="$(upload_prefix)"
 chk "a substitution in the S3 prefix is not executed" 0 \
   "$([ -f "$bk/RAN" ] && echo 1 || echo 0)"
 chk "and reaches the upload as characters" \
@@ -4814,20 +4828,19 @@ chk "and reaches the upload as characters" \
 # A literal $name is the quieter half: under the generated script's own `set -u`
 # the spliced form dies with `unbound variable`, so the nightly backup stops
 # and the failure is nowhere near the value that caused it.
-gen_backup 's3://b/$archive/db' "$bk/gen2"
-out2="$(bash "$bk/gen2" 2>&1)"; rc2=$?
-chk "a literal \$name does not kill the nightly run" 0 "$rc2"
+gen_backup 's3://b/$archive/db'
+out2="$(upload_prefix)"
 chk "and is uploaded to the prefix as configured" \
   'UPLOAD-TO=s3://b/$archive/db' "$out2"
 # The controls in the other direction, and the ones that constrain the fix:
 # every real host has one of these two, so a change in either is a change to
 # where every existing backup goes.
-gen_backup 's3://collavre-backups/prod' "$bk/gen3"
+gen_backup 's3://collavre-backups/prod'
 chk "an ordinary prefix is unchanged" 'UPLOAD-TO=s3://collavre-backups/prod' \
-  "$(bash "$bk/gen3" 2>&1)"
-gen_backup '' "$bk/gen4"
-chk "and the unset default stays empty" 'UPLOAD-TO=' "$(bash "$bk/gen4" 2>&1)"
-rm -rf "$bk"
+  "$(upload_prefix)"
+gen_backup ''
+chk "and the unset default stays empty" 'UPLOAD-TO=' "$(upload_prefix)"
+rm -rf "$bk" "$bd"
 # Source-level control. The assertions above are about the shape of the
 # generation step, so this is what fails against a revert: the heredoc spliced
 # all three in, and %q is what replaced it.

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -381,7 +381,10 @@ for s in "22/tcp                     ALLOW       Anywhere" \
          "22/tcp                     ALLOW IN    203.0.113.4" \
          "22/tcp                     LIMIT       203.0.113.9" \
          "22/tcp                     LIMIT IN    Anywhere" \
-         "22/tcp (v6)                LIMIT       Anywhere (v6)"; do
+         "22/tcp (v6)                LIMIT       Anywhere (v6)" \
+         "10.1.2.3 22/tcp            ALLOW       203.0.113.9" \
+         "10.1.2.3 22/tcp            LIMIT       203.0.113.9" \
+         "2001:db8::1 22/tcp         ALLOW       2001:db8::9"; do
   STATUS="$s"
   ssh_already_allowed
   chk "detected: $s" 0 "$?"
@@ -394,21 +397,38 @@ echo "24. a narrowed SSH rule survives the re-run that finds it"
 # LIMIT is here because it is what ufw's own documentation recommends for SSH:
 # reading only ALLOW meant a rate-limited, source-restricted rule was reported
 # as "nothing authorizes SSH", and the blanket rule went in beside it.
+#
+# The destination-qualified forms are the same defect one step further out: the
+# port is not at the start of the line, so a predicate anchored on the port
+# reports "nothing authorizes SSH" for a rule that pins 22 to one interface.
 for s in "22/tcp                     ALLOW IN    203.0.113.4" \
-         "22/tcp                     LIMIT       203.0.113.9"; do
+         "22/tcp                     LIMIT       203.0.113.9" \
+         "10.1.2.3 22/tcp            ALLOW       203.0.113.9" \
+         "10.1.2.3 22/tcp            LIMIT       203.0.113.9"; do
   STATUS="$s"
   UFW_CALLS=""
   ensure_ssh_rule
-  chk "blanket rule not added over [${s#22/tcp                     }]" "" "$UFW_CALLS"
+  chk "blanket rule not added over [$s]" "" "$UFW_CALLS"
 done
 
 echo "25. no SSH rule at all means one is added, never assumed"
 # Failing the other way enables a deny-by-default firewall on a host with no
 # way back in, so every uncertain status must land here.
+#
+# The last three guard the optional leading token that makes the
+# destination-qualified forms match: it must not swallow a different port, nor
+# turn a host address that merely begins with 22 into an SSH rule. The
+# all-ports rule is a decision, not an oversight — it permits 22 from that
+# source, but its source is as often a trusted service host as the operator's
+# own machine, and reading it as "SSH is handled" would enable a
+# deny-by-default firewall on a box with no remaining way in.
 for s in "Status: inactive" \
          "80/tcp                     ALLOW       Anywhere" \
          "2222/tcp                   ALLOW       Anywhere" \
          "22/tcp                     DENY        Anywhere" \
+         "10.1.2.3 2222/tcp          ALLOW       203.0.113.9" \
+         "22.1.1.1 80/tcp            ALLOW       198.51.100.5" \
+         "Anywhere                   ALLOW       203.0.113.9" \
          ""; do
   STATUS="$s"
   UFW_CALLS=""

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -845,6 +845,24 @@ else
   fail=1
 fi
 
+echo "26b. web ports are authorized before the live incoming policy is tightened"
+# Existing instances can be serving HTTP(S) only because their current default
+# policy is allow. Changing that live policy before explicit rules exist causes
+# an outage immediately, and an interrupted run leaves it in place.
+fw_http_line="$(printf '%s\n' "$fw_step" |
+		  grep -n '^ufw allow 80/tcp$' | cut -d: -f1)"
+fw_https_line="$(printf '%s\n' "$fw_step" |
+		   grep -n '^ufw allow 443/tcp$' | cut -d: -f1)"
+if [ -n "$fw_http_line" ] && [ -n "$fw_https_line" ] &&
+   [ -n "$fw_deny_line" ] &&
+   [ "$fw_http_line" -lt "$fw_deny_line" ] &&
+   [ "$fw_https_line" -lt "$fw_deny_line" ]; then
+  echo "  ok   the HTTP(S) allow rules precede default deny incoming"
+else
+  echo "  FAIL default deny incoming can take effect before HTTP(S) is authorized"
+  fail=1
+fi
+
 # --- docs/deploy_to_lightsail.md, the SQLite cutover ------------------------
 #
 # This recipe hands the app role SUPERUSER, resets and reloads the production
@@ -5763,8 +5781,28 @@ chk "the sysctl drop-in is staged too"                    1 \
   "$(grep -c "^install_managed_config 'the sysctl drop-in' /etc/sysctl\.d/" "$SRC")"
 chk "and the inert 99- file it replaces is removed"       1 \
   "$(grep -c '^rm -f /etc/ssh/sshd_config\.d/99-collavre\.conf$' "$SRC")"
-chk "and the run reads back what sshd resolved"           1 \
+chk "and the run reads back every relevant user context"  3 \
   "$(grep -cF 'verify_ssh_hardening "" /etc/ssh "$SSH_RELOAD_STATE" "$APP_SSH_USER"' "$SRC")"
+
+# Match Group is evaluated against the account's memberships at connection
+# time. The pre-grant read-back above cannot see a sudo/docker override for an
+# existing account that does not join those groups until later in this run.
+vh_sudo_grant="$(awk '
+  /^usermod -aG sudo "\$APP_SSH_USER"$/ { f = 1 }
+  f { print }
+  f && /^ensure_sudoers "\$APP_SSH_USER"$/ { exit }
+' "$SRC")"
+vh_docker_grant="$(awk '
+  /^usermod -aG docker "\$APP_SSH_USER"$/ { f = 1 }
+  f { print }
+  f && /^revoke_prior_deploy_user "\$APP_SSH_USER"$/ { exit }
+' "$SRC")"
+chk "sudo-group context is rechecked before passwordless sudo" 1 \
+  "$(grep -cF 'verify_ssh_hardening "" /etc/ssh "$SSH_RELOAD_STATE" "$APP_SSH_USER"' \
+      <<<"$vh_sudo_grant")"
+chk "docker-group context is rechecked before convergence continues" 1 \
+  "$(grep -cF 'verify_ssh_hardening "" /etc/ssh "$SSH_RELOAD_STATE" "$APP_SSH_USER"' \
+      <<<"$vh_docker_grant")"
 
 # The claim is about what sshd does with two files, so sshd is asked. The name
 # and the body both come from the script: a harness that wrote its own 01- file
@@ -6107,7 +6145,7 @@ unset RELOAD_OK RELOAD_BAD ACTIVE
 # the function and still swallows its status with `|| true`.
 chk "and the run preserves the reload state"          1 \
   "$(grep -cF 'reload_ssh_daemon || SSH_RELOAD_STATE=$?' "$SRC")"
-chk "and passes it to disk verification"              1 \
+chk "and passes it to every disk verification"        3 \
   "$(grep -cF 'verify_ssh_hardening "" /etc/ssh "$SSH_RELOAD_STATE"' "$SRC")"
 chk "rather than discarding the status"               0 \
   "$(grep -c '^systemctl reload ssh .*|| true$' "$SRC")"

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -5666,6 +5666,10 @@ bindguard 10.0.0.5
 chk "and any other dotted quad"                        0 "$bind_rc"
 bindguard 1.2.3.4
 chk "including one this host does not hold"            0 "$bind_rc"
+bindguard 127.0.0.1
+chk "a loopback address unusable from the container is refused" 1 "$bind_rc"
+bindguard 127.255.255.254
+chk "and the whole IPv4 loopback range is refused"     1 "$bind_rc"
 bindguard 172.17.0.999
 chk "an octet over 255 is refused"                     1 "$bind_rc"
 bindguard bogus.invalid
@@ -5867,6 +5871,20 @@ chk "an address-scoped password override stops the run"  1 \
   "$(printf '%s' "$vh_address" | grep -c '^rc=1$')"
 chk "and the refusal names the untestable Match context" 1 \
   "$(printf '%s' "$vh_address" | grep -ci 'Match.*Address')"
+
+# ChallengeResponseAuthentication is OpenSSH's deprecated alias for
+# KbdInteractiveAuthentication. A contextual scanner that recognizes only the
+# canonical spelling leaves PAM password authentication enabled in the same
+# address scope that the user-only sshd probe cannot evaluate.
+printf 'Include %s/sshd_config.d/*.conf\nMatch Address 203.0.113.0/24\n  ChallengeResponseAuthentication yes\n' \
+  "$vshd" > "$vshd/sshd_config"
+vh_challenge_alias="$( ( PATH="$vshd/bin:$PATH"
+  verify_ssh_hardening "" "$vshd" 0 deploybot ) 2>&1; printf 'rc=%s\n' "$?" )"
+chk "the contextual keyboard-interactive alias stops the run" 1 \
+  "$(printf '%s' "$vh_challenge_alias" | grep -c '^rc=1$')"
+chk "and the refusal identifies the alias directive" 1 \
+  "$(printf '%s' "$vh_challenge_alias" |
+       grep -ci 'ChallengeResponseAuthentication')"
 
 # Include is textual and may point anywhere. The Match begins in the main file,
 # the weakening directive is in a nonstandard included file, and Match All

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -1,12 +1,16 @@
 #!/usr/bin/env bash
 #
-# Unit tests for the pure helpers in script/lightsail_launch.sh.
+# Unit tests for the pure helpers in script/lightsail_launch.sh, plus the
+# SQLite-cutover recipe in docs/deploy_to_lightsail.md.
 #
 #   bash script/test/lightsail_launch_test.sh
 #
 # The launch script provisions a host and cannot be run here, so the functions
 # under test are extracted from it rather than copied — a harness holding its
-# own copy would keep passing after the real one drifted.
+# own copy would keep passing after the real one drifted. The runbook recipe is
+# extracted from the markdown for the same reason: it is a copy-paste procedure
+# that touches production, so its control flow is worth testing, and testing a
+# transcription of it would prove nothing.
 #
 set -uo pipefail
 
@@ -315,6 +319,97 @@ case "$LOGGED" in
 esac
 
 unset -f ufw log
+
+# --- docs/deploy_to_lightsail.md, the SQLite cutover ------------------------
+#
+# This recipe hands the app role SUPERUSER, resets and reloads the production
+# database, then takes the grant back. Every branch of it is a production
+# incident if it runs when it should not, so it is exercised rather than read.
+
+DOC="${2:-$ROOT/docs/deploy_to_lightsail.md}"
+
+# The fenced bash block containing copy_status= — located by content, so the
+# test follows the recipe if it moves within the page.
+recipe="$(awk '
+  /^  ```bash$/ { inb = 1; buf = ""; next }
+  /^  ```$/     { if (inb && buf ~ /copy_status=/) { printf "%s", buf; exit } inb = 0; next }
+  inb           { line = $0; sub(/^  /, "", line); buf = buf line "\n" }
+' "$DOC")"
+case "$recipe" in
+  *copy_status=*NOSUPERUSER*) : ;;
+  *) echo "could not extract the cutover recipe from $DOC — has it moved?" >&2
+     exit 1 ;;
+esac
+
+# Records what the recipe did against stubbed ssh/scp/kamal. FAIL_COPY and
+# FAIL_REVOKE choose which step reports failure.
+run_cutover() {
+  local work; work="$(mktemp -d)"
+  printf '%s' "$recipe" | sed 's/<instance-ip>/203.0.113.10/g' > "$work/recipe.sh"
+  mkdir -p "$work/bin"
+  cat > "$work/bin/ssh" <<'STUB'
+#!/usr/bin/env bash
+case "$*" in
+  *"ALTER ROLE collavre_user SUPERUSER"*)   echo GRANT  >>"$TRACE" ;;
+  *"ALTER ROLE collavre_user NOSUPERUSER"*) echo REVOKE >>"$TRACE"
+                                            [ -z "$FAIL_REVOKE" ] || exit 255 ;;
+  *"sudo rm"*)                              echo RM_STAGED >>"$TRACE" ;;
+  *"sudo install"*)                         echo STAGE     >>"$TRACE" ;;
+  *)                                        echo ssh       >>"$TRACE" ;;
+esac
+STUB
+  printf '#!/usr/bin/env bash\necho scp >>"$TRACE"\n' > "$work/bin/scp"
+  cat > "$work/bin/kamal.sh" <<'STUB'
+#!/usr/bin/env bash
+echo "kamal:$1${2:+ $2}" >>"$TRACE"
+[ "${1:-}" != app ] || [ "${2:-}" != exec ] || [ -z "$FAIL_COPY" ] || exit 1
+STUB
+  chmod +x "$work/bin"/*
+  cp "$work/bin/kamal.sh" "$work/kamal.sh"
+
+  TRACE="$work/trace"; : > "$TRACE"
+  export TRACE FAIL_COPY="${FAIL_COPY:-}" FAIL_REVOKE="${FAIL_REVOKE:-}"
+  RECIPE_OUT="$(cd "$work" && PATH="$work/bin:$PATH" bash ./recipe.sh 2>&1)"
+  RECIPE_TRACE="$(paste -sd'|' "$TRACE")"
+  rm -rf "$work"
+}
+
+echo "23. a clean cutover cleans up and boots"
+FAIL_COPY='' FAIL_REVOKE='' run_cutover
+chk "staged file removed" 1 "$(grep -c RM_STAGED <<<"${RECIPE_TRACE//|/$'\n'}")"
+chk "app booted"          1 "$(grep -cx 'kamal:app boot' <<<"${RECIPE_TRACE//|/$'\n'}")"
+
+echo "24. a failed copy does not boot, and keeps the file the retry needs"
+# MIGRATION_RUN_RESET drops the schema before loading, so a copy that dies
+# partway leaves the database empty or half-populated. Booting serves that.
+# The `sudo rm` is the other half: it destroys the staged SQLite file, so a
+# retry would need another full scp of production rather than a re-run.
+FAIL_COPY=1 FAIL_REVOKE='' run_cutover
+chk "app NOT booted"          0 "$(grep -cx 'kamal:app boot' <<<"${RECIPE_TRACE//|/$'\n'}")"
+chk "staged file kept"        0 "$(grep -c RM_STAGED <<<"${RECIPE_TRACE//|/$'\n'}")"
+chk "grant still taken back"  1 "$(grep -cx REVOKE <<<"${RECIPE_TRACE//|/$'\n'}")"
+case "$RECIPE_OUT" in
+  *"COPY FAILED"*"left stopped"*) echo "  ok   operator told what state it is in" ;;
+  *) echo "  FAIL silent or partial: $RECIPE_OUT"; fail=1 ;;
+esac
+
+echo "25. a failed revoke does not boot the credential-bearing container"
+# collavre_user is the role in DATABASE_URL. Booting while it is still a
+# superuser hands every app container that privilege.
+FAIL_COPY='' FAIL_REVOKE=1 run_cutover
+chk "app NOT booted" 0 "$(grep -cx 'kamal:app boot' <<<"${RECIPE_TRACE//|/$'\n'}")"
+case "$RECIPE_OUT" in
+  *"REVOKE FAILED"*"left stopped"*) echo "  ok   the still-superuser role is reported" ;;
+  *) echo "  FAIL silent: $RECIPE_OUT"; fail=1 ;;
+esac
+
+echo "26. both failing reports both, not just the first"
+FAIL_COPY=1 FAIL_REVOKE=1 run_cutover
+chk "app NOT booted" 0 "$(grep -cx 'kamal:app boot' <<<"${RECIPE_TRACE//|/$'\n'}")"
+case "$RECIPE_OUT" in
+  *"REVOKE FAILED"*"COPY FAILED"*) echo "  ok   both reported" ;;
+  *) echo "  FAIL one masked the other: $RECIPE_OUT"; fail=1 ;;
+esac
 
 echo
 if [ "$fail" = 0 ]; then echo "ALL PASS"; else echo "FAILURES"; fi

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -535,6 +535,7 @@ STUB
   cat > "$work/bin/kamal.sh" <<'STUB'
 #!/usr/bin/env bash
 echo "kamal:$1${2:+ $2}" >>"$TRACE"
+[ "${1:-}" != app ] || [ "${2:-}" != stop ] || [ -z "$FAIL_STOP" ] || exit 1
 [ "${1:-}" != app ] || [ "${2:-}" != exec ] || [ -z "$FAIL_COPY" ] || exit 1
 STUB
   chmod +x "$work/bin"/*
@@ -543,13 +544,14 @@ STUB
   TRACE="$work/trace"; : > "$TRACE"
   export TRACE FAIL_COPY="${FAIL_COPY:-}" FAIL_REVOKE="${FAIL_REVOKE:-}"
   export FAIL_SCP="${FAIL_SCP:-}" FAIL_STAGE="${FAIL_STAGE:-}"
+  export FAIL_STOP="${FAIL_STOP:-}"
   RECIPE_OUT="$(cd "$work" && PATH="$work/bin:$PATH" bash ./recipe.sh 2>&1)"
   RECIPE_TRACE="$(paste -sd'|' "$TRACE")"
   rm -rf "$work"
 }
 
 echo "27. a clean cutover cleans up and boots"
-FAIL_COPY='' FAIL_REVOKE='' FAIL_SCP='' FAIL_STAGE='' run_cutover
+FAIL_COPY='' FAIL_REVOKE='' FAIL_SCP='' FAIL_STAGE='' FAIL_STOP='' run_cutover
 chk "staged file removed" 1 "$(grep -c RM_STAGED <<<"${RECIPE_TRACE//|/$'\n'}")"
 chk "app booted"          1 "$(grep -cx 'kamal:app boot' <<<"${RECIPE_TRACE//|/$'\n'}")"
 
@@ -558,7 +560,7 @@ echo "28. a failed copy does not boot, and keeps the file the retry needs"
 # partway leaves the database empty or half-populated. Booting serves that.
 # The `sudo rm` is the other half: it destroys the staged SQLite file, so a
 # retry would need another full scp of production rather than a re-run.
-FAIL_COPY=1 FAIL_REVOKE='' FAIL_SCP='' FAIL_STAGE='' run_cutover
+FAIL_COPY=1 FAIL_REVOKE='' FAIL_SCP='' FAIL_STAGE='' FAIL_STOP='' run_cutover
 chk "app NOT booted"          0 "$(grep -cx 'kamal:app boot' <<<"${RECIPE_TRACE//|/$'\n'}")"
 chk "staged file kept"        0 "$(grep -c RM_STAGED <<<"${RECIPE_TRACE//|/$'\n'}")"
 chk "grant still taken back"  1 "$(grep -cx REVOKE <<<"${RECIPE_TRACE//|/$'\n'}")"
@@ -570,7 +572,7 @@ esac
 echo "29. a failed revoke does not boot the credential-bearing container"
 # collavre_user is the role in DATABASE_URL. Booting while it is still a
 # superuser hands every app container that privilege.
-FAIL_COPY='' FAIL_REVOKE=1 FAIL_SCP='' FAIL_STAGE='' run_cutover
+FAIL_COPY='' FAIL_REVOKE=1 FAIL_SCP='' FAIL_STAGE='' FAIL_STOP='' run_cutover
 chk "app NOT booted" 0 "$(grep -cx 'kamal:app boot' <<<"${RECIPE_TRACE//|/$'\n'}")"
 case "$RECIPE_OUT" in
   *"REVOKE FAILED"*"left stopped"*) echo "  ok   the still-superuser role is reported" ;;
@@ -578,7 +580,7 @@ case "$RECIPE_OUT" in
 esac
 
 echo "30. both failing reports both, not just the first"
-FAIL_COPY=1 FAIL_REVOKE=1 FAIL_SCP='' FAIL_STAGE='' run_cutover
+FAIL_COPY=1 FAIL_REVOKE=1 FAIL_SCP='' FAIL_STAGE='' FAIL_STOP='' run_cutover
 chk "app NOT booted" 0 "$(grep -cx 'kamal:app boot' <<<"${RECIPE_TRACE//|/$'\n'}")"
 case "$RECIPE_OUT" in
   *"REVOKE FAILED"*"COPY FAILED"*) echo "  ok   both reported" ;;
@@ -591,7 +593,7 @@ echo "31. a failed scp never converts, so a stale snapshot cannot be restored"
 # on a retry the volume holds the previous attempt's snapshot. Ungated, a
 # failed scp converts from THAT: production silently rolled back to older data,
 # reported as success, and the evidence deleted afterwards.
-FAIL_COPY='' FAIL_REVOKE='' FAIL_SCP=1 FAIL_STAGE='' run_cutover
+FAIL_COPY='' FAIL_REVOKE='' FAIL_SCP=1 FAIL_STAGE='' FAIL_STOP='' run_cutover
 chk "no conversion ran"   0 "$(grep -cx 'kamal:app exec' <<<"${RECIPE_TRACE//|/$'\n'}")"
 chk "no superuser granted" 0 "$(grep -cx GRANT <<<"${RECIPE_TRACE//|/$'\n'}")"
 chk "app NOT booted"      0 "$(grep -cx 'kamal:app boot' <<<"${RECIPE_TRACE//|/$'\n'}")"
@@ -604,10 +606,24 @@ esac
 echo "32. a failed install into the volume is caught too, not just the scp"
 # scp can succeed to /tmp and the privileged install still fail — no space,
 # no docker group, volume gone.
-FAIL_COPY='' FAIL_REVOKE='' FAIL_SCP='' FAIL_STAGE=1 run_cutover
+FAIL_COPY='' FAIL_REVOKE='' FAIL_SCP='' FAIL_STAGE=1 FAIL_STOP='' run_cutover
 chk "no conversion ran"    0 "$(grep -cx 'kamal:app exec' <<<"${RECIPE_TRACE//|/$'\n'}")"
 chk "no superuser granted" 0 "$(grep -cx GRANT <<<"${RECIPE_TRACE//|/$'\n'}")"
 chk "app NOT booted"       0 "$(grep -cx 'kamal:app boot' <<<"${RECIPE_TRACE//|/$'\n'}")"
+
+echo "32a. a failed 'app stop' stages nothing, so no live container is converted under"
+# The cutover's own MIGRATION_RUN_RESET does DROP SCHEMA public CASCADE. A stop
+# that ran and failed leaves a container serving and polling while that lands,
+# so the gate has to be on the stop's status, not on having written the line.
+FAIL_COPY='' FAIL_REVOKE='' FAIL_SCP='' FAIL_STAGE='' FAIL_STOP=1 run_cutover
+chk "nothing staged"       0 "$(grep -cx STAGE <<<"${RECIPE_TRACE//|/$'\n'}")"
+chk "no superuser granted" 0 "$(grep -cx GRANT <<<"${RECIPE_TRACE//|/$'\n'}")"
+chk "no conversion ran"    0 "$(grep -cx 'kamal:app exec' <<<"${RECIPE_TRACE//|/$'\n'}")"
+chk "app NOT booted"       0 "$(grep -cx 'kamal:app boot' <<<"${RECIPE_TRACE//|/$'\n'}")"
+case "$RECIPE_OUT" in
+  *"STOP FAILED"*) echo "  ok   operator told the container may still be serving" ;;
+  *) echo "  FAIL silent or vague: ${RECIPE_OUT:-(no output)}"; fail=1 ;;
+esac
 
 echo "33. staging renames into place rather than writing the live path directly"
 # An interrupted copy must leave the previous file intact, not a truncated
@@ -633,19 +649,20 @@ run_fresh() {
   cat > "$work/bin/kamal.sh" <<'STUB'
 #!/usr/bin/env bash
 echo "kamal:$1${2:+ $2}" >>"$TRACE"
+[ "${1:-}" != app ] || [ "${2:-}" != stop ] || [ -z "$FAIL_STOP" ] || exit 1
 [ "${1:-}" != app ] || [ "${2:-}" != exec ] || [ -z "$FAIL_LOAD" ] || exit 1
 STUB
   chmod +x "$work/bin"/*
   cp "$work/bin/kamal.sh" "$work/kamal.sh"
   TRACE="$work/trace"; : > "$TRACE"
-  export TRACE FAIL_LOAD="${FAIL_LOAD:-}"
+  export TRACE FAIL_LOAD="${FAIL_LOAD:-}" FAIL_STOP="${FAIL_STOP:-}"
   FRESH_OUT="$(cd "$work" && PATH="$work/bin:$PATH" bash ./recipe.sh 2>&1)"
   FRESH_TRACE="$(paste -sd'|' "$TRACE")"
   rm -rf "$work"
 }
 
 echo "34. a clean fresh install prints the admin password and boots"
-FAIL_LOAD='' run_fresh
+FAIL_LOAD='' FAIL_STOP='' run_fresh
 chk "app stopped first" 1 "$(grep -cx 'kamal:app stop' <<<"${FRESH_TRACE//|/$'\n'}")"
 chk "app booted"        1 "$(grep -cx 'kamal:app boot' <<<"${FRESH_TRACE//|/$'\n'}")"
 
@@ -653,11 +670,24 @@ echo "35. a failed schema load does not boot the app onto a partial schema"
 # db:schema:load drops and recreates every table, and db:seed is what creates
 # the first admin — so a load that resets the database but does not finish
 # leaves an app with no way to sign in and no owner on any record.
-FAIL_LOAD=1 run_fresh
+FAIL_LOAD=1 FAIL_STOP='' run_fresh
 chk "app NOT booted" 0 "$(grep -cx 'kamal:app boot' <<<"${FRESH_TRACE//|/$'\n'}")"
 case "$FRESH_OUT" in
   *"LOAD FAILED"*"left stopped"*) echo "  ok   operator told what state it is in" ;;
   *) echo "  FAIL silent or partial: $FRESH_OUT"; fail=1 ;;
+esac
+
+echo "35a. a failed 'app stop' loads nothing, rather than dropping tables under a live container"
+# Adding the `app stop` only fixed the case where nobody ran it. Without
+# `set -e` a stop that *ran and failed* — unreachable host, a docker daemon
+# that will not answer — falls straight through to the load, which is the live
+# schema replacement the stop exists to prevent.
+FAIL_LOAD='' FAIL_STOP=1 run_fresh
+chk "nothing loaded"  0 "$(grep -cx 'kamal:app exec' <<<"${FRESH_TRACE//|/$'\n'}")"
+chk "app NOT booted"  0 "$(grep -cx 'kamal:app boot' <<<"${FRESH_TRACE//|/$'\n'}")"
+case "$FRESH_OUT" in
+  *"STOP FAILED"*) echo "  ok   operator told the container may still be serving" ;;
+  *) echo "  FAIL silent or vague: ${FRESH_OUT:-(no output)}"; fail=1 ;;
 esac
 
 # --- install_authorized_keys ------------------------------------------------

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -21,12 +21,13 @@ SRC="${1:-$ROOT/script/lightsail_launch.sh}"
 # die() is a one-liner; the others run to the first column-1 closing brace.
 eval "$(awk '
   /^die\(\) \{/ { print; next }
-  /^(ensure_block|ensure_sudoers|in_group|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|install_deploy_ssh_dir|reassign_prior_db_role|refuse_superuser_db_rotation|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps|dedupe_authorized_keys|install_staged_authorized_keys|postgresql_conf_includes_confd|role_owns_app_objects|refuse_db_name_change|refuse_defaulted_config_change|passwd_home|ssh_key_holder|adopt_legacy_ssh_key_marker)\(\) \{/ { f = 1 }
+  /^(ensure_block|ensure_sudoers|in_group|record_deploy_user_grant|revoke_deploy_user_access|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|install_deploy_ssh_dir|reassign_prior_db_role|refuse_superuser_db_rotation|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps|dedupe_authorized_keys|install_staged_authorized_keys|postgresql_conf_includes_confd|role_owns_app_objects|refuse_db_name_change|refuse_defaulted_config_change|passwd_home|ssh_key_holder|adopt_legacy_ssh_key_marker)\(\) \{/ { f = 1 }
   f { print }
   f && /^\}/ { f = 0 }
 ' "$SRC")"
 
 for fn in die ensure_block ensure_sudoers in_group revoke_prior_deploy_user \
+          record_deploy_user_grant revoke_deploy_user_access \
           ensure_ufw_rule ssh_already_allowed ensure_ssh_rule \
           install_authorized_keys install_deploy_ssh_dir reassign_prior_db_role \
           refuse_superuser_db_rotation role_owns_app_objects revoke_prior_ssh_key \
@@ -41,6 +42,20 @@ for fn in die ensure_block ensure_sudoers in_group revoke_prior_deploy_user \
     exit 1
   }
 done
+
+# The suite runs unprivileged, where `chown collavre:collavre` fails on every
+# host, and install_staged_authorized_keys now *declines to install* a file it
+# could not hand to the deploy user rather than suppressing the error. Without a
+# seam here every case that rewrites authorized_keys would exercise the refusal
+# path and nothing else — the failure would look like a broken function instead
+# of an unprivileged test run.
+#
+# Succeeding by default is the honest default because the production caller runs
+# as root against an account it has just created. The cases that need the
+# failure make it fail explicitly (CHOWN_FAILS), which is the one place where
+# what is under test is the refusal itself.
+CHOWN_FAILS=0
+chown() { [ "$CHOWN_FAILS" = 0 ]; }
 
 fail=0
 chk() {
@@ -319,16 +334,137 @@ case "$LOGGED" in
   *) echo "  ok   does not claim the access is gone" ;;
 esac
 
-echo "18. and the marker is not advanced, so the next run retries"
-# Advancing it here would forget which account still holds root — a permanent
-# silent failure rather than one the next FORCE=1 run picks up.
-chk "marker still names the unrevoked user" "legacy" "$(cat "$d4/deploy_user")"
+echo "18. and the account it could not strip stays queued for the next run"
+# The retry lives in the set rather than in the single-name marker. Pinning that
+# marker to the unrevoked account — what an earlier revision did — bought the
+# retry at the price of the host misreporting who its deploy user is, and it is
+# what case 18a shows losing an account outright on the second rotation.
+chk "still queued for revocation" 1 \
+  "$(grep -cxF legacy "$d4/deploy_users")"
+chk "the marker names the account in use" "deploybot" "$(cat "$d4/deploy_user")"
 usermod() { usermod_host "$@"; }             # the host is healthy again
 revoke deploybot "$d4/deploy_user"           # the retry, on a healthy host
 chk "the retry revokes it"     0 "$(printf '%s\n' "$GROUPS_OF" | tr ' ' '\n' | grep -cxF docker)"
-chk "and then advances" "deploybot" "$(cat "$d4/deploy_user")"
+chk "and it leaves the queue" 0 "$(grep -cxF legacy "$d4/deploy_users")"
+chk "while the marker still names the account in use" "deploybot" "$(cat "$d4/deploy_user")"
 
 unset -f id gpasswd usermod usermod_host groupadd log revoke supp_holds drop_word
+
+# --------------------------------------------------------------------------
+# One name cannot describe a host that has rotated twice, so the cases below
+# need more than one account on the host. The model is a directory holding one
+# file per account, whose contents are what `id -nG` would print; FAIL_REVOKE
+# names the accounts whose `gpasswd -d` does nothing, which is how the sequence
+# that matters is reached.
+#
+# grant() is what the script does at its two grant sites (step 3's `usermod -aG
+# sudo` and step 4's `usermod -aG docker`), so a case can place them relative to
+# the revocation the same way the script does — which is the whole point here,
+# since the second of these cases is about an interruption between them.
+# --------------------------------------------------------------------------
+HOSTDB=""; FAIL_REVOKE=""
+id() {
+  case "$1" in
+    -u)  [ -f "$HOSTDB/$2" ] ;;
+    -nG) [ -f "$HOSTDB/$2" ] || return 1; cat "$HOSTDB/$2" ;;
+    -gn) [ -f "$HOSTDB/$2" ] || return 1; cut -d' ' -f1 "$HOSTDB/$2" ;;
+    *)   return 1 ;;
+  esac
+}
+gpasswd() {   # gpasswd -d <user> <group>
+  case " $FAIL_REVOKE " in *" $2 "*) return 1 ;; esac
+  tr ' ' '\n' < "$HOSTDB/$2" | grep -vxF "$3" | tr '\n' ' ' |
+    sed 's/ *$//' > "$HOSTDB/$2.next"
+  mv "$HOSTDB/$2.next" "$HOSTDB/$2"
+}
+# shellcheck disable=SC2329  # called through the extracted function
+usermod() { :; }
+# shellcheck disable=SC2329
+groupadd() { :; }
+log() { :; }
+grant() { printf '%s docker sudo' "$1" > "$HOSTDB/$1"; }
+holds() { tr ' ' '\n' < "$HOSTDB/$1" | grep -cxF "$2"; }
+
+# The negative control is the previous revision's *marker discipline* rather
+# than a copy of its revocation body: one name in the file, advanced only when
+# the account it names comes back clean. The body is unchanged and is called
+# here, so the control isolates the one thing that did change — and copying
+# fifty lines that still exist would drift from them rather than test against
+# them.
+revoke_single_marker() {
+  local current="$1" f="$2" prior
+  [ -f "$f" ] || { printf '%s\n' "$current" > "$f"; return 0; }
+  prior="$(cat "$f")"
+  if [ -z "$prior" ] || [ "$prior" = "$current" ] ||
+     ! id -u "$prior" >/dev/null 2>&1; then
+    printf '%s\n' "$current" > "$f"; return 0
+  fi
+  revoke_deploy_user_access "$prior" "$current" || return 0   # marker pinned
+  printf '%s\n' "$current" > "$f"
+}
+
+echo "18a. a rotation whose revocation failed does not lose the NEXT account"
+# A -> B with the revocation of A failing, then B -> C. The earlier revision
+# retried A on the third run and advanced its one marker straight to C, so B
+# went on holding docker and sudo with nothing on the host naming it.
+HOSTDB=$(mktemp -d); d5=$(mktemp -d)
+grant collavre; printf 'collavre\n' > "$d5/deploy_user"
+FAIL_REVOKE=collavre; grant deploybot
+revoke_prior_deploy_user deploybot "$d5/deploy_user"
+FAIL_REVOKE=""; grant ci
+revoke_prior_deploy_user ci "$d5/deploy_user"
+chk "the account in between lost docker" 0 "$(holds deploybot docker)"
+chk "and sudo"                           0 "$(holds deploybot sudo)"
+chk "the one that failed was retried"    0 "$(holds collavre docker)"
+# The account in use stays queued on purpose — it holds both groups, and the
+# run that replaces it is the one that takes them back. So the assertion is that
+# nothing ELSE is left in it, which is also what keeps the queue from growing by
+# one name per rotation forever.
+chk "nothing but the account in use is queued" "ci" \
+  "$(tr '\n' ' ' < "$d5/deploy_users" | sed 's/ *$//')"
+
+# The control. Same host, same sequence, previous marker discipline.
+HOSTDB=$(mktemp -d); d6=$(mktemp -d)
+grant collavre; printf 'collavre\n' > "$d6/deploy_user"
+FAIL_REVOKE=collavre; grant deploybot
+revoke_single_marker deploybot "$d6/deploy_user"
+FAIL_REVOKE=""; grant ci
+revoke_single_marker ci "$d6/deploy_user"
+chk "the previous form left it holding docker" 1 "$(holds deploybot docker)"
+chk "with the marker naming neither it nor its predecessor" "ci" \
+  "$(cat "$d6/deploy_user")"
+
+echo "18b. an interrupted rotation does not hide the account it already granted"
+# No failure anywhere. The grants are at step 3 and step 4 and the revocation is
+# at the end of step 4, so the window is the whole Docker install — an apt run
+# on a 512MB instance. Recording the grant BEFORE it is what closes this; a
+# record written after the revocation cannot describe a run that never reached
+# it.
+HOSTDB=$(mktemp -d); d7=$(mktemp -d)
+grant collavre; printf 'collavre\n' > "$d7/deploy_user"
+record_deploy_user_grant deploybot "$d7/deploy_users" "$d7/deploy_user"
+grant deploybot                              # ... and the run dies here
+grant ci
+record_deploy_user_grant ci "$d7/deploy_users" "$d7/deploy_user"
+revoke_prior_deploy_user ci "$d7/deploy_user"
+chk "the interrupted run's account lost docker" 0 "$(holds deploybot docker)"
+chk "and sudo"                                  0 "$(holds deploybot sudo)"
+chk "so did the one before it"                  0 "$(holds collavre docker)"
+
+echo "18c. a host provisioned before the queue existed is seeded from its marker"
+# The upgrade path. Starting empty would begin the fix for forgetting accounts
+# by forgetting the one account the old revision did record — and that account
+# is the one most likely to be unrevoked, since a clean rotation is why the
+# marker would have moved on.
+HOSTDB=$(mktemp -d); d8=$(mktemp -d)
+grant collavre; printf 'collavre\n' > "$d8/deploy_user"   # no deploy_users file
+grant deploybot
+revoke_prior_deploy_user deploybot "$d8/deploy_user"
+chk "the legacy predecessor was found and stripped" 0 "$(holds collavre docker)"
+chk "and the queue now holds only the account in use" "ci_absent deploybot" \
+  "ci_absent $(tr '\n' ' ' < "$d8/deploy_users" | sed 's/ *$//')"
+
+unset -f id gpasswd usermod groupadd log grant holds revoke_single_marker
 
 # --------------------------------------------------------------------------
 # The firewall helpers shell out to ufw, so it is stubbed: every invocation is
@@ -2079,13 +2215,70 @@ mv() { echo "mv $*" >> "$order"; command mv "$@"; }
 tmp="$(mktemp "$KEYS.sort.XXXXXX")"
 printf '%s\n' "$KEY_CURRENT" > "$tmp"
 APP_SSH_USER=collavre APP_SSH_GROUP=collavre install_staged_authorized_keys "$tmp" "$KEYS"
-unset -f chown chmod mv
+# Restored rather than unset: the suite-wide stub is what lets every later case
+# run the install path unprivileged, and `unset -f` here would drop it for the
+# rest of the file instead of just ending this case's recording.
+unset -f chmod mv; chown() { [ "$CHOWN_FAILS" = 0 ]; }
 chk "chown ran on the staging file" 1 "$(grep -c "^chown collavre:collavre $KEYS\.sort\." "$order")"
 chk "chmod ran on the staging file" 1 "$(grep -c "^chmod 0600 $KEYS\.sort\." "$order")"
 mv_at=$(grep -n '^mv ' "$order" | cut -d: -f1); chmod_at=$(grep -n '^chmod ' "$order" | cut -d: -f1)
 chk "both before the rename"        1 \
   "$([ -n "$mv_at" ] && [ -n "$chmod_at" ] && [ "$mv_at" -gt "$chmod_at" ] && echo 1 || echo 0)"
 chk "the live file ends 0600"       600 "$(stat -c %a "$KEYS" 2>/dev/null || stat -f %Lp "$KEYS")"
+
+# Present only in the staged file, so "did the staged contents reach the live
+# path" is answerable by looking at the live path alone.
+KEY_STAGED_ONLY='ssh-ed25519 zzSTAGED staged@laptop'
+
+echo "91a. a staging file that could not be given to the user is NOT installed"
+# `chown ... || true` put the root-owned 0600 file at the live path, and the
+# caller's own `chown "$APP_SSH_USER:$APP_SSH_GROUP" "$AUTH_KEYS"` a few lines
+# later is not a recovery from that: it is the same command on the same names,
+# so it fails for whatever reason the first one did and `set -e` ends the run
+# with the unreadable file already live. sshd with StrictModes then refuses the
+# key the run just installed, and on APP_SSH_USER=ubuntu that file is the only
+# way into the instance.
+#
+# So the assertion is about the LIVE file, not about the return value: what
+# makes declining safe is that what was already there still works.
+new_keys_env
+printf '%s\n' "$KEY_CURRENT" > "$KEYS"
+live_before="$(cat "$KEYS")"
+tmp="$(mktemp "$KEYS.sort.XXXXXX")"
+printf '%s\n' "$KEY_CURRENT" "$KEY_STAGED_ONLY" > "$tmp"
+LOGGED=""
+CHOWN_FAILS=1
+APP_SSH_USER=collavre APP_SSH_GROUP=collavre \
+  install_staged_authorized_keys "$tmp" "$KEYS" && st=0 || st=$?
+CHOWN_FAILS=0
+chk "it reports failure"            1 "$st"
+chk "the live file is untouched"    "$live_before" "$(cat "$KEYS")"
+chk "and still holds a usable key"  1 "$(grep -cxF "$KEY_CURRENT" "$KEYS")"
+chk "the staging file is cleaned up" 0 "$([ -e "$tmp" ] && echo 1 || echo 0)"
+case "$LOGGED" in
+  *"NOT installed"*) echo "  ok   says the file was not installed" ;;
+  *) echo "  FAIL silent about declining: $LOGGED"; fail=1 ;;
+esac
+# The negative control. Under the previous form the same failure installed the
+# file anyway, which is the finding: the live path takes the staged contents
+# from a chown that did not happen.
+install_prev() {   # the previous revision of install_staged_authorized_keys
+  local tmp="$1" auth_keys="$2"
+  [ -z "${APP_SSH_USER:-}" ] || chown "$APP_SSH_USER:${APP_SSH_GROUP:-$APP_SSH_USER}" "$tmp" 2>/dev/null || true
+  command chmod 0600 "$tmp"
+  command mv -f "$tmp" "$auth_keys"
+}
+printf '%s\n' "$KEY_CURRENT" > "$KEYS"
+tmp="$(mktemp "$KEYS.sort.XXXXXX")"
+printf '%s\n' "$KEY_CURRENT" "$KEY_STAGED_ONLY" > "$tmp"
+CHOWN_FAILS=1
+APP_SSH_USER=collavre APP_SSH_GROUP=collavre install_prev "$tmp" "$KEYS"
+CHOWN_FAILS=0
+chk "the previous form installed it regardless" 1 "$(grep -cxF "$KEY_STAGED_ONLY" "$KEYS")"
+# install_prev only. `unset -f log` here would expose /usr/bin/log on macOS,
+# which exits 64 on the next call and fails a case several hundred lines away
+# for a reason that has nothing to do with what it tests.
+unset -f install_prev
 
 # --- postgresql_conf_includes_confd -----------------------------------------
 #
@@ -2816,6 +3009,20 @@ run_ownck clean; new_ok="$OWNCK_OUT"
 chk "where the new form does"          1 \
   "$([ "$new_fail" != "$new_ok" ] && echo 1 || echo 0)"
 chk "and the old form said nothing at all" "" "$prev_ok"
+
+echo "117. the grant is recorded before it is made, not after"
+# Asserted on the call site rather than on the function, for the same reason as
+# case 114: the function being correct is not what closes the interruption
+# window — its position is. A record written after the grants describes only
+# runs that reached the end, and the run that matters is the one that did not.
+rec_line="$(grep -n '^record_deploy_user_grant "\$APP_SSH_USER"$' "$SRC" | head -1 | cut -d: -f1)"
+chk "it is called at all"                 1 "$([ -n "$rec_line" ] && echo 1 || echo 0)"
+for after in 'usermod -aG sudo "\$APP_SSH_USER"' 'usermod -aG docker "\$APP_SSH_USER"' \
+             'revoke_prior_deploy_user "\$APP_SSH_USER"'; do
+  line="$(grep -n "^$after" "$SRC" | head -1 | cut -d: -f1)"
+  chk "before ${after%% \"*}" 1 \
+    "$([ -n "$line" ] && [ "$rec_line" -lt "$line" ] && echo 1 || echo 0)"
+done
 
 echo
 if [ "$fail" = 0 ]; then echo "ALL PASS"; else echo "FAILURES"; fi

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -21,7 +21,7 @@ SRC="${1:-$ROOT/script/lightsail_launch.sh}"
 # die() is a one-liner; the others run to the first column-1 closing brace.
 eval "$(awk '
   /^die\(\) \{/ { print; next }
-  /^(ensure_block|ensure_sudoers|in_group|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|install_deploy_ssh_dir|reassign_prior_db_role|refuse_superuser_db_rotation|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps|dedupe_authorized_keys)\(\) \{/ { f = 1 }
+  /^(ensure_block|ensure_sudoers|in_group|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|install_deploy_ssh_dir|reassign_prior_db_role|refuse_superuser_db_rotation|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps|dedupe_authorized_keys|install_staged_authorized_keys)\(\) \{/ { f = 1 }
   f { print }
   f && /^\}/ { f = 0 }
 ' "$SRC")"
@@ -31,7 +31,8 @@ for fn in die ensure_block ensure_sudoers in_group revoke_prior_deploy_user \
           install_authorized_keys install_deploy_ssh_dir reassign_prior_db_role \
           refuse_superuser_db_rotation revoke_prior_ssh_key \
           ensure_cluster_on_default_port ensure_swapfile allocate_swapfile \
-          ensure_docker_log_caps dedupe_authorized_keys; do
+          ensure_docker_log_caps dedupe_authorized_keys \
+          install_staged_authorized_keys; do
   declare -F "$fn" >/dev/null || {
     echo "could not extract $fn() from $SRC — has the definition moved?" >&2
     exit 1
@@ -499,11 +500,20 @@ DOC="${2:-$ROOT/docs/deploy_to_lightsail.md}"
 
 # extract_recipe <marker> — the fenced bash block containing <marker>, located
 # by content, so a test follows its recipe if it moves within the page.
+#
+# The fence's own indentation is measured rather than assumed: recipes nested
+# under a list item are indented two spaces and top-level ones are not, and a
+# hard-coded indent silently matches no block at all — which reads as "the
+# recipe moved" rather than as "this extractor cannot see it".
 extract_recipe() {
   awk -v want="$1" '
-    /^  ```bash$/ { inb = 1; buf = ""; next }
-    /^  ```$/     { if (inb && buf ~ want) { printf "%s", buf; exit } inb = 0; next }
-    inb           { line = $0; sub(/^  /, "", line); buf = buf line "\n" }
+    !inb && /^[[:space:]]*```bash$/ {
+      inb = 1; buf = ""
+      match($0, /^[[:space:]]*/); ind = substr($0, 1, RLENGTH)
+      next
+    }
+    inb && $0 == ind "```" { if (buf ~ want) { printf "%s", buf; exit } inb = 0; next }
+    inb { line = $0; sub("^" ind, "", line); buf = buf line "\n" }
   ' "$DOC"
 }
 
@@ -1536,6 +1546,7 @@ STUB
   export FAIL_DUMP="${FAIL_DUMP:-}" FAIL_XFER="${FAIL_XFER:-}" FAIL_RESTORE="${FAIL_RESTORE:-}"
   MOVE_OUT="$(cd "$work" && PATH="$work/bin:$PATH" bash ./recipe.sh 2>&1)"
   MOVE_TRACE="$(paste -sd'|' "$TRACE")"
+  # shellcheck disable=SC2119  # the real sort; the stub below is scoped to case 84
   MOVE_LEFT="$(find "$REMOTE" -maxdepth 1 -type f -exec basename {} \; | sort | paste -sd, -)"
   rm -rf "$work"
 }
@@ -1581,12 +1592,121 @@ FAIL_DUMP='' FAIL_XFER='' FAIL_RESTORE='' run_move
 chk "every transfer staged under .incoming" 0 \
   "$(grep '^scp:' <<<"${MOVE_TRACE//|/$'\n'}" | grep -cv '\.incoming$')"
 
+# --- docs/deploy_to_lightsail.md, the §6 restore -----------------------------
+#
+# The stop runs on the workstation and this block on the instance, so there is
+# no local exit status to gate on. The gate is a state instead: CONNECTION LIMIT
+# 0 plus pg_terminate_backend, which holds for the whole restore rather than for
+# the instant a count is taken. Verified on postgres:17 that a superuser is
+# exempt from the limit (so pg_restore connects) while the app's role is refused
+# with "too many connections" — including on a reconnect mid-restore, which is
+# the case a point-in-time count cannot see.
+#
+# What is asserted here is the part that regresses silently: the limit is put
+# back on EVERY path. A database left at 0 refuses the app at boot, and the
+# error it gives reads like a connection-pool problem rather than like a step
+# this block forgot to undo.
+
+restore="$(extract_recipe 'restore_status=')"
+case "$restore" in
+  *CONNECTION\ LIMIT\ 0*pg_restore*CONNECTION\ LIMIT\ -1*) : ;;
+  *) echo "could not extract the restore recipe from $DOC — has it moved?" >&2
+     exit 1 ;;
+esac
+
+# LIVE is what the count query returns: "0" for a quiet database, a number for a
+# container that survived the stop, "" for a check that itself failed.
+run_restore() {
+  local work; work="$(mktemp -d)"
+  mkdir -p "$work/bin"
+  printf '%s' "$restore" > "$work/recipe.sh"
+
+  cat > "$work/bin/sudo" <<'STUB'
+#!/usr/bin/env bash
+while [ "${1:-}" = -u ] || [ "${1:-}" = postgres ]; do shift; done
+exec "$@"
+STUB
+  cat > "$work/bin/psql" <<'STUB'
+#!/usr/bin/env bash
+sql="${*: -1}"
+case "$sql" in
+  *"CONNECTION LIMIT 0"*)      echo "limit:0"          >>"$TRACE" ;;
+  *"CONNECTION LIMIT -1"*)     echo "limit:reopened"   >>"$TRACE" ;;
+  *pg_terminate_backend*)      echo "terminate"        >>"$TRACE"; echo "${KILLED:-0}" ;;
+  *"count(*)"*)                echo "count"            >>"$TRACE"; printf '%s' "$LIVE" ;;
+  *usename*)                   echo "listing"          >>"$TRACE" ;;
+esac
+STUB
+  cat > "$work/bin/pg_restore" <<'STUB'
+#!/usr/bin/env bash
+echo "PG_RESTORE_RAN" >>"$TRACE"
+[ -z "$FAIL_RESTORE" ] || exit 1
+STUB
+  chmod +x "$work/bin"/*
+
+  TRACE="$work/trace"; : > "$TRACE"
+  # ${LIVE-0}, not ${LIVE:-0}: the empty string is a case under test — it is what
+  # a failed check returns — and :- would quietly turn it back into "0", making
+  # the one assertion about a broken gate pass for the wrong reason.
+  export TRACE LIVE="${LIVE-0}" KILLED="${KILLED:-0}" FAIL_RESTORE="${FAIL_RESTORE:-}"
+  R_OUT="$(cd "$work" && PATH="$work/bin:$PATH" bash ./recipe.sh 2>&1)"
+  R_TRACE="$(paste -sd'|' "$TRACE")"
+  rm -rf "$work"
+}
+
+echo "83. the restore shuts the database before it looks, and re-opens after"
+LIVE=0 KILLED=2 FAIL_RESTORE='' run_restore
+chk "door shut first"        "limit:0" "$(cut -d'|' -f1 <<<"$R_TRACE")"
+chk "survivors terminated"   1 "$(grep -c '^terminate$' <<<"${R_TRACE//|/$'\n'}")"
+# The order is the whole point: counting before the limit is applied only says
+# the app happened to be between connections at that instant.
+chk "counted only after the door was shut" 1 \
+  "$(grep -q 'limit:0|terminate|count' <<<"$R_TRACE" && echo 1 || echo 0)"
+chk "restore ran"            1 "$(grep -c '^PG_RESTORE_RAN$' <<<"${R_TRACE//|/$'\n'}")"
+chk "re-opened"              1 "$(grep -c '^limit:reopened$' <<<"${R_TRACE//|/$'\n'}")"
+chk "operator told to boot"  1 "$(grep -c 'app boot' <<<"$R_OUT")"
+
+echo "84. a container that survived the stop stops the restore, door re-opened"
+LIVE=1 KILLED=0 FAIL_RESTORE='' run_restore
+chk "nothing dropped"    0 "$(grep -c '^PG_RESTORE_RAN$' <<<"${R_TRACE//|/$'\n'}")"
+chk "re-opened anyway"   1 "$(grep -c '^limit:reopened$' <<<"${R_TRACE//|/$'\n'}")"
+chk "operator told"      1 "$(grep -c 'REFUSING' <<<"$R_OUT")"
+chk "and told nothing was dropped" 1 "$(grep -c 'nothing was dropped' <<<"$R_OUT")"
+
+echo "85. a check that itself fails refuses, rather than reading empty as quiet"
+LIVE='' KILLED=0 FAIL_RESTORE='' run_restore
+chk "nothing dropped"  0 "$(grep -c '^PG_RESTORE_RAN$' <<<"${R_TRACE//|/$'\n'}")"
+chk "re-opened anyway" 1 "$(grep -c '^limit:reopened$' <<<"${R_TRACE//|/$'\n'}")"
+chk "operator told"    1 "$(grep -c 'REFUSING' <<<"$R_OUT")"
+
+echo "86. a FAILED restore still re-opens, or the app cannot boot to be fixed"
+LIVE=0 KILLED=0 FAIL_RESTORE=1 run_restore
+chk "restore attempted"  1 "$(grep -c '^PG_RESTORE_RAN$' <<<"${R_TRACE//|/$'\n'}")"
+chk "re-opened"          1 "$(grep -c '^limit:reopened$' <<<"${R_TRACE//|/$'\n'}")"
+chk "told it may be half-done" 1 "$(grep -c 'RESTORE FAILED' <<<"$R_OUT")"
+chk "not told to boot"   0 "$(grep -c 'app boot' <<<"$R_OUT")"
+
 # --- dedupe_authorized_keys -------------------------------------------------
 #
 # `sort -u -o F F` rewrote authorized_keys in place. A sort stopped after it has
 # truncated the output — an OOM kill on the instance this script provisions swap
 # for — leaves the file holding a lexical prefix of itself, so the key that goes
-# missing is whichever sorts last. `ulimit -f` reproduces that deterministically.
+# missing is whichever sorts last.
+#
+# sort is STUBBED here, and that is load-bearing rather than convenient. The
+# failure belongs to GNU coreutils, which writes -o in place; BSD sort stages
+# and renames already, so on macOS the pre-fix one-liner survives every trigger
+# and a test driving the real binary passes against the bug it exists for.
+# Measured, same input, `ulimit -f 16`:
+#
+#   GNU coreutils 9.4 (ubuntu:24.04, what the instance runs)
+#     write limit     60001 lines -> 485, current key GONE
+#     killed mid-write 60001 lines -> 0,   file EMPTY
+#   BSD sort 2.3-Apple (this harness's machine)
+#     write limit     201 lines -> 201, byte-identical
+#
+# So the stub reproduces the GNU shape — truncate the output, then fail — and
+# the assertion holds on either platform.
 
 new_keys_env() {
   KEYDIR="$(mktemp -d)"; KEYS="$KEYDIR/authorized_keys"
@@ -1601,7 +1721,7 @@ new_keys_env() {
 }
 KEY_CURRENT='ssh-ed25519 zzCURRENT current@laptop'   # sorts last, so it is the casualty
 
-echo "83. the ordinary case still drops duplicates"
+echo "87. the ordinary case still drops duplicates"
 new_keys_env
 before=$(wc -l < "$KEYS")
 dedupe_authorized_keys "$KEYS" "$KEY_CURRENT"
@@ -1610,10 +1730,22 @@ chk "the current key kept" 1 "$(grep -cxF "$KEY_CURRENT" "$KEYS")"
 chk "silent"               "" "$LOGGED"
 chk "no scratch file left" 0 "$(find "$KEYDIR" -name 'authorized_keys.sort.*' | wc -l | tr -d ' ')"
 
-echo "84. a sort that dies part way leaves authorized_keys alone"
+echo "88. a sort that dies part way leaves authorized_keys alone"
 new_keys_env
 before_l=$(wc -l < "$KEYS" | tr -d ' '); before_b=$(wc -c < "$KEYS" | tr -d ' ')
-( ulimit -f 8; dedupe_authorized_keys "$KEYS" "$KEY_CURRENT" ) >/dev/null 2>&1
+# GNU sort's -o target is opened and truncated before the run can fail, so a
+# partial write leaves a prefix behind. Copied from the measured run above.
+# shellcheck disable=SC2329,SC2120  # shadows sort for dedupe_authorized_keys only
+sort() {
+  local out=""
+  while [ $# -gt 0 ]; do
+    case "$1" in -o) out="$2"; shift 2 ;; *) shift ;; esac
+  done
+  [ -n "$out" ] && head -c 200 > "$out"          # truncate, write a prefix...
+  return 2                                        # ...then fail, as GNU does
+}
+dedupe_authorized_keys "$KEYS" "$KEY_CURRENT" >/dev/null 2>&1
+unset -f sort
 chk "not truncated"  "$before_l" "$(wc -l < "$KEYS" | tr -d ' ')"
 chk "byte-identical" "$before_b" "$(wc -c < "$KEYS" | tr -d ' ')"
 # Both copies are still there — the file was not rewritten at all, which is the
@@ -1621,7 +1753,7 @@ chk "byte-identical" "$before_b" "$(wc -c < "$KEYS" | tr -d ' ')"
 chk "the current key survives" 2 "$(grep -cxF "$KEY_CURRENT" "$KEYS")"
 chk "no scratch file left" 0 "$(find "$KEYDIR" -name 'authorized_keys.sort.*' | wc -l | tr -d ' ')"
 
-echo "85. it stages beside the target, not in TMPDIR"
+echo "89. it stages beside the target, not in TMPDIR"
 # Same filesystem, so the swap is one rename and a full or missing /tmp cannot
 # reach the file the operator logs in with. Asserted on the path mktemp is asked
 # for: GNU mktemp fails on a missing TMPDIR but BSD mktemp falls back, so a
@@ -1634,6 +1766,70 @@ dedupe_authorized_keys "$KEYS" "$KEY_CURRENT"
 unset -f mktemp
 chk "template is a sibling of authorized_keys" 1 \
   "$(grep -c "^$KEYS\.sort\." "$tmpl_log")"
+
+# --- install_staged_authorized_keys ------------------------------------------
+#
+# Staging is only half of it: what is staged still has to arrive. `cat "$tmp" >
+# "$auth_keys"` puts the O_TRUNC in the calling shell and the write in a
+# separate process, so the live path is empty across a whole process spawn
+# rather than across one write(2). Killing that writer at a uniformly random
+# point, on a realistic four-key file:
+#
+#   cat "$tmp" > "$auth_keys"   damaged 7/400, every one of them 0 bytes
+#   mv  "$tmp"   "$auth_keys"   damaged 0/400
+#
+# Both cases below assert the property rather than the spelling, so a later
+# rewrite that reintroduces a copy fails them however it is written.
+
+ino() { stat -c %i "$1" 2>/dev/null || stat -f %i "$1"; }
+
+echo "90. the live path is replaced, never rewritten in place"
+new_keys_env
+before_ino=$(ino "$KEYS")
+tmp="$(mktemp "$KEYS.sort.XXXXXX")"
+printf '%s\n' "$KEY_CURRENT" > "$tmp"
+staged_ino=$(ino "$tmp")
+install_staged_authorized_keys "$tmp" "$KEYS"
+# A copy leaves the target's inode alone; a rename carries the staged file's in.
+# That is the difference between "the file was emptied and refilled" and "the
+# file was swapped", and it is what decides whether an interrupted run can be
+# seen by sshd holding a partial file.
+chk "the staged inode is now the live one" "$staged_ino" "$(ino "$KEYS")"
+chk "and it is not the old one"            1 \
+  "$([ "$before_ino" != "$(ino "$KEYS")" ] && echo 1 || echo 0)"
+chk "contents arrived whole"               1 "$(grep -cxF "$KEY_CURRENT" "$KEYS")"
+chk "no scratch file left"                 0 \
+  "$(find "$KEYDIR" -name 'authorized_keys.sort.*' | wc -l | tr -d ' ')"
+
+echo "91. ownership and mode are set before the swap, not after"
+# The obvious form of the fix has a lockout of its own. mktemp creates 0600
+# root-owned, and sshd with StrictModes refuses an authorized_keys it cannot
+# read as the user — measured against a real sshd:
+#
+#   owner=collavre mode=600 -> OK    owner=root mode=600 -> Authentication
+#   owner=root     mode=644 -> OK    refused: bad ownership or modes
+#
+# So a crash between a bare `mv` and the caller's chown leaves the host refusing
+# the key the run just installed. Asserted as an ordering, because the final
+# state is identical either way and only the window differs.
+new_keys_env
+order="$KEYDIR/order"; : > "$order"
+# shellcheck disable=SC2329  # shadow chown/chmod/mv for this case only
+chown() { echo "chown $*" >> "$order"; }
+# shellcheck disable=SC2329
+chmod() { echo "chmod $*" >> "$order"; command chmod "$@"; }
+# shellcheck disable=SC2329
+mv() { echo "mv $*" >> "$order"; command mv "$@"; }
+tmp="$(mktemp "$KEYS.sort.XXXXXX")"
+printf '%s\n' "$KEY_CURRENT" > "$tmp"
+APP_SSH_USER=collavre APP_SSH_GROUP=collavre install_staged_authorized_keys "$tmp" "$KEYS"
+unset -f chown chmod mv
+chk "chown ran on the staging file" 1 "$(grep -c "^chown collavre:collavre $KEYS\.sort\." "$order")"
+chk "chmod ran on the staging file" 1 "$(grep -c "^chmod 0600 $KEYS\.sort\." "$order")"
+mv_at=$(grep -n '^mv ' "$order" | cut -d: -f1); chmod_at=$(grep -n '^chmod ' "$order" | cut -d: -f1)
+chk "both before the rename"        1 \
+  "$([ -n "$mv_at" ] && [ -n "$chmod_at" ] && [ "$mv_at" -gt "$chmod_at" ] && echo 1 || echo 0)"
+chk "the live file ends 0600"       600 "$(stat -c %a "$KEYS" 2>/dev/null || stat -f %Lp "$KEYS")"
 
 echo
 if [ "$fail" = 0 ]; then echo "ALL PASS"; else echo "FAILURES"; fi

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -21,13 +21,14 @@ SRC="${1:-$ROOT/script/lightsail_launch.sh}"
 # die() is a one-liner; the others run to the first column-1 closing brace.
 eval "$(awk '
   /^die\(\) \{/ { print; next }
-  /^(ensure_block|ensure_sudoers|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule)\(\) \{/ { f = 1 }
+  /^(ensure_block|ensure_sudoers|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|reassign_prior_db_role)\(\) \{/ { f = 1 }
   f { print }
   f && /^\}/ { f = 0 }
 ' "$SRC")"
 
 for fn in die ensure_block ensure_sudoers revoke_prior_deploy_user \
-          ensure_ufw_rule ssh_already_allowed ensure_ssh_rule; do
+          ensure_ufw_rule ssh_already_allowed ensure_ssh_rule \
+          install_authorized_keys reassign_prior_db_role; do
   declare -F "$fn" >/dev/null || {
     echo "could not extract $fn() from $SRC — has the definition moved?" >&2
     exit 1
@@ -328,13 +329,17 @@ unset -f ufw log
 
 DOC="${2:-$ROOT/docs/deploy_to_lightsail.md}"
 
-# The fenced bash block containing copy_status= — located by content, so the
-# test follows the recipe if it moves within the page.
-recipe="$(awk '
-  /^  ```bash$/ { inb = 1; buf = ""; next }
-  /^  ```$/     { if (inb && buf ~ /copy_status=/) { printf "%s", buf; exit } inb = 0; next }
-  inb           { line = $0; sub(/^  /, "", line); buf = buf line "\n" }
-' "$DOC")"
+# extract_recipe <marker> — the fenced bash block containing <marker>, located
+# by content, so a test follows its recipe if it moves within the page.
+extract_recipe() {
+  awk -v want="$1" '
+    /^  ```bash$/ { inb = 1; buf = ""; next }
+    /^  ```$/     { if (inb && buf ~ want) { printf "%s", buf; exit } inb = 0; next }
+    inb           { line = $0; sub(/^  /, "", line); buf = buf line "\n" }
+  ' "$DOC"
+}
+
+recipe="$(extract_recipe 'copy_status=')"
 case "$recipe" in
   *copy_status=*NOSUPERUSER*) : ;;
   *) echo "could not extract the cutover recipe from $DOC — has it moved?" >&2
@@ -410,6 +415,148 @@ case "$RECIPE_OUT" in
   *"REVOKE FAILED"*"COPY FAILED"*) echo "  ok   both reported" ;;
   *) echo "  FAIL one masked the other: $RECIPE_OUT"; fail=1 ;;
 esac
+
+# --- the fresh-install recipe ----------------------------------------------
+
+fresh="$(extract_recipe 'load_status=')"
+case "$fresh" in
+  *db:schema:load:primary*load_status=*) : ;;
+  *) echo "could not extract the fresh-install recipe from $DOC — has it moved?" >&2
+     exit 1 ;;
+esac
+
+run_fresh() {
+  local work; work="$(mktemp -d)"
+  printf '%s' "$fresh" > "$work/recipe.sh"
+  mkdir -p "$work/bin"
+  cat > "$work/bin/kamal.sh" <<'STUB'
+#!/usr/bin/env bash
+echo "kamal:$1${2:+ $2}" >>"$TRACE"
+[ "${1:-}" != app ] || [ "${2:-}" != exec ] || [ -z "$FAIL_LOAD" ] || exit 1
+STUB
+  chmod +x "$work/bin"/*
+  cp "$work/bin/kamal.sh" "$work/kamal.sh"
+  TRACE="$work/trace"; : > "$TRACE"
+  export TRACE FAIL_LOAD="${FAIL_LOAD:-}"
+  FRESH_OUT="$(cd "$work" && PATH="$work/bin:$PATH" bash ./recipe.sh 2>&1)"
+  FRESH_TRACE="$(paste -sd'|' "$TRACE")"
+  rm -rf "$work"
+}
+
+echo "27. a clean fresh install prints the admin password and boots"
+FAIL_LOAD='' run_fresh
+chk "app stopped first" 1 "$(grep -cx 'kamal:app stop' <<<"${FRESH_TRACE//|/$'\n'}")"
+chk "app booted"        1 "$(grep -cx 'kamal:app boot' <<<"${FRESH_TRACE//|/$'\n'}")"
+
+echo "28. a failed schema load does not boot the app onto a partial schema"
+# db:schema:load drops and recreates every table, and db:seed is what creates
+# the first admin — so a load that resets the database but does not finish
+# leaves an app with no way to sign in and no owner on any record.
+FAIL_LOAD=1 run_fresh
+chk "app NOT booted" 0 "$(grep -cx 'kamal:app boot' <<<"${FRESH_TRACE//|/$'\n'}")"
+case "$FRESH_OUT" in
+  *"LOAD FAILED"*"left stopped"*) echo "  ok   operator told what state it is in" ;;
+  *) echo "  FAIL silent or partial: $FRESH_OUT"; fail=1 ;;
+esac
+
+# --- install_authorized_keys ------------------------------------------------
+#
+# The failure this guards is not a lost key but an aborted run: `cat f >> f` is
+# an error under GNU cat, and `set -e` would end provisioning at that line.
+
+LOGGED=""
+log() { LOGGED="$LOGGED $*"; }
+
+echo "29. the deploy user's own keys are not copied onto themselves"
+# APP_SSH_USER=ubuntu — src and dest are one file.
+h=$(mktemp -d); mkdir -p "$h/ubuntu/.ssh"
+printf 'ssh-ed25519 CLOUDKEY cloud\n' > "$h/ubuntu/.ssh/authorized_keys"
+SSH_PUBLIC_KEY="" LOGGED=""
+install_authorized_keys "$h/ubuntu/.ssh/authorized_keys" "$h"
+chk "run survives"        0 "$?"
+chk "the key is intact"   1 "$(grep -c CLOUDKEY "$h/ubuntu/.ssh/authorized_keys")"
+case "$LOGGED" in
+  *"already in place"*) echo "  ok   says why it copied nothing" ;;
+  *) echo "  FAIL no explanation: $LOGGED"; fail=1 ;;
+esac
+
+echo "30. a separate deploy user still inherits the cloud user's keys"
+mkdir -p "$h/collavre/.ssh"; : > "$h/collavre/.ssh/authorized_keys"
+SSH_PUBLIC_KEY="" LOGGED=""
+install_authorized_keys "$h/collavre/.ssh/authorized_keys" "$h"
+chk "cloud key copied" 1 "$(grep -c CLOUDKEY "$h/collavre/.ssh/authorized_keys")"
+
+echo "31. an explicit SSH_PUBLIC_KEY is added once, not once per run"
+SSH_PUBLIC_KEY="ssh-ed25519 EXPLICIT me"
+install_authorized_keys "$h/collavre/.ssh/authorized_keys" "$h"
+install_authorized_keys "$h/collavre/.ssh/authorized_keys" "$h"
+chk "no duplicate" 1 "$(grep -c EXPLICIT "$h/collavre/.ssh/authorized_keys")"
+
+unset -f log
+
+# --- reassign_prior_db_role -------------------------------------------------
+#
+# A rotation that reports success while the new role cannot read its own tables
+# and the old credential still works is worse than one that refuses.
+
+SQL=""
+LOGGED=""
+ROLE_EXISTS=1
+ROLE_IS_SUPER=f
+DB_NAME=collavre_production
+psql_as_postgres() {
+  case "$2" in
+    *"count(*)"*) printf '%s\n' "$ROLE_EXISTS"; return 0 ;;
+    *rolsuper*)   printf '%s\n' "$ROLE_IS_SUPER"; return 0 ;;
+  esac
+  SQL="$SQL|$2"
+}
+log() { LOGGED="$LOGGED $*"; }
+rotate() { SQL=""; LOGGED=""; reassign_prior_db_role "$@"; }
+
+echo "32. rotating DB_USER moves the tables and retires the old credential"
+# ALTER DATABASE ... OWNER only moves the database. Every table and sequence
+# the app created stays with the old role, so the new one in DATABASE_URL gets
+# "permission denied" on its own data — while the old role keeps LOGIN and the
+# same password out of the state file.
+d3=$(mktemp -d); printf 'collavre_user\n' > "$d3/db_user"
+ROLE_EXISTS=1 ROLE_IS_SUPER=f
+rotate collavre_app "$d3/db_user"
+chk "ownership moved, then login revoked" \
+    '|REASSIGN OWNED BY "collavre_user" TO "collavre_app"|ALTER ROLE "collavre_user" NOLOGIN' \
+    "$SQL"
+
+echo "33. an unchanged DB_USER touches nothing"
+rotate collavre_user "$d3/db_user"
+chk "no SQL" "" "$SQL$LOGGED"
+
+echo "34. a superuser predecessor is reported, never disabled"
+# DB_USER=postgres on a first run is legal. NOLOGIN on the cluster superuser
+# locks every operator out of administering it — peer auth needs LOGIN too, so
+# there is no way back in.
+printf 'postgres\n' > "$d3/db_user"
+ROLE_IS_SUPER=t
+rotate collavre_app "$d3/db_user"
+chk "no SQL ran" "" "$SQL"
+case "$LOGGED" in
+  *"is a superuser"*"by hand"*) echo "  ok   operator is told to finish it by hand" ;;
+  *) echo "  FAIL silent: $LOGGED"; fail=1 ;;
+esac
+
+echo "35. first run, emptied marker and a dropped role are all no-ops"
+d4=$(mktemp -d)
+ROLE_IS_SUPER=f
+rotate collavre_user "$d4/db_user"          # no marker yet
+chk "no marker"    "" "$SQL$LOGGED"
+: > "$d4/db_user"
+rotate collavre_user "$d4/db_user"          # marker exists but is empty
+chk "empty marker" "" "$SQL$LOGGED"
+printf 'collavre_user\n' > "$d4/db_user"
+ROLE_EXISTS=0                                # dropped by hand
+rotate collavre_app "$d4/db_user"
+chk "role is gone" "" "$SQL$LOGGED"
+
+unset -f psql_as_postgres log rotate
 
 echo
 if [ "$fail" = 0 ]; then echo "ALL PASS"; else echo "FAILURES"; fi

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -14,18 +14,20 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SRC="${1:-$ROOT/script/lightsail_launch.sh}"
 [ -f "$SRC" ] || { echo "no such script: $SRC" >&2; exit 1; }
 
-# die() is a one-liner; ensure_block() runs to the first column-1 closing brace.
+# die() is a one-liner; the others run to the first column-1 closing brace.
 eval "$(awk '
-  /^die\(\) \{/ { print }
-  /^ensure_block\(\) \{/ { f = 1 }
+  /^die\(\) \{/ { print; next }
+  /^(ensure_block|ensure_sudoers)\(\) \{/ { f = 1 }
   f { print }
-  f && /^\}/ { exit }
+  f && /^\}/ { f = 0 }
 ' "$SRC")"
 
-declare -F die >/dev/null && declare -F ensure_block >/dev/null || {
-  echo "could not extract die/ensure_block from $SRC — has the definition moved?" >&2
-  exit 1
-}
+for fn in die ensure_block ensure_sudoers; do
+  declare -F "$fn" >/dev/null || {
+    echo "could not extract $fn() from $SRC — has the definition moved?" >&2
+    exit 1
+  }
+done
 
 fail=0
 chk() {
@@ -110,6 +112,43 @@ before="$(cat "$f")"
 (ensure_block "$f" docker "NEW") >/dev/null 2>&1
 chk "exits non-zero"  1          "$?"
 chk "file untouched"  "$before"  "$(cat "$f")"
+
+echo "8. the deploy user gets a sudoers grant sudo will actually read"
+d=$(mktemp -d)
+ensure_sudoers collavre "$d"
+chk "one file"        1        "$(ls "$d" | wc -l | tr -d ' ')"
+chk "readable name"   "90-collavre-collavre" "$(ls "$d")"
+chk "mode 0440"       "440"    "$(file_mode "$d/90-collavre-collavre")"
+chk "passwordless"    "collavre ALL=(ALL:ALL) NOPASSWD:ALL" "$(cat "$d/90-collavre-collavre")"
+# sudo's includedir ignores any filename containing a dot, so a grant written
+# for a dotted username would be silently skipped — the exact failure mode
+# this whole case exists to prevent.
+ensure_sudoers deploy.bot "$d"
+chk "dot sanitized"   "90-collavre-deploy_bot" \
+  "$(ls "$d" | grep deploy)"
+chk "no dot in name"  0 "$(ls "$d" | grep -c '\.')"
+
+echo "9. a changed APP_SSH_USER revokes the previous grant"
+# Same reason ensure_block replaces in place: converge the host, do not
+# accumulate. A stale NOPASSWD line is a login that outlives its purpose.
+chk "old user's grant gone" 0 "$(ls "$d" | grep -c 'collavre-collavre')"
+chk "only the current one"  1 "$(ls "$d" | wc -l | tr -d ' ')"
+# An operator's own file is not ours to delete.
+touch "$d/10-operator"
+ensure_sudoers collavre "$d"
+chk "operator file kept"    1 "$(ls "$d" | grep -c '^10-operator$')"
+
+echo "10. an unparseable grant is refused, and nothing is installed"
+d=$(mktemp -d)
+visudo() { return 1; }   # stands in for a sudoers syntax error
+out="$( (ensure_sudoers collavre "$d") 2>&1 )"
+chk "exits non-zero"  1  "$?"
+chk "no file written" 0  "$(ls "$d" | wc -l | tr -d ' ')"
+case "$out" in
+  *unparseable*) echo "  ok   says what is wrong" ;;
+  *) echo "  FAIL unhelpful message: $out"; fail=1 ;;
+esac
+unset -f visudo
 
 echo
 if [ "$fail" = 0 ]; then echo "ALL PASS"; else echo "FAILURES"; fi

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -6076,6 +6076,15 @@ printf 'APP_SSH_USER=collavre\nDB_USER=collavre_user\n' > "$record_dir/launch.en
 record_status=0
 record_out="$(record_launch_settings "$record_dir" 2>&1)" || record_status=$?
 chk "an incomplete prior record also stops the run"           1 "$record_status"
+
+eval "$saved_write_state_file"
+rm -f "$record_dir/launch.env"
+mkdir "$record_dir/launch.env"
+record_status=0
+record_out="$(record_launch_settings "$record_dir" 2>&1)" || record_status=$?
+chk "a directory at the record path is not mistaken for a write" 1 "$record_status"
+chk "and no staging file is moved inside it"                       0 \
+  "$(find "$record_dir/launch.env" -mindepth 1 -maxdepth 1 | wc -l | tr -d ' ')"
 chk "so the success marker is created only after recording"   1 \
   "$(awk '
       /^record_launch_settings$/ { recorded = NR }
@@ -6085,7 +6094,6 @@ chk "so the success marker is created only after recording"   1 \
 	else print 0
       }
     ' "$SRC")"
-eval "$saved_write_state_file"
 eval "$saved_log"
 LAUNCH_SETTINGS="$saved_launch_settings"
 rm -rf "$record_dir"

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -5185,14 +5185,6 @@ chk "the ALTER restores LOGIN as well as the password" 1 \
 # would pass the assertion above and leave a run that rotates the password able
 # to fail between the two, with the role's password and the recorded one
 # disagreeing.
-#
-# The password here deliberately carries no quote. `${DB_PASSWORD//\'/\'\'}`
-# does not mean the same thing on every bash: 5.2 (what Lightsail runs) yields
-# `it''s`, 3.2 (what macOS ships, and what a developer runs this suite under)
-# yields `it\'\'s`, which PostgreSQL rejects with a syntax error. An assertion
-# on a quoted password would therefore be red on one machine and green on the
-# other for a reason that has nothing to do with the statement being tested —
-# the same platform split as `head -c 0`, pointing the other way.
 GEN="$(gen_db_sql collavre_user 'pw-not-quoted')"
 chk "and still carries the password in the same statement" 1 \
   "$(printf '%s\n' "$GEN" | grep -c "^ALTER ROLE \"collavre_user\" LOGIN PASSWORD 'pw-not-quoted';\$")"
@@ -5202,6 +5194,55 @@ chk "and still carries the password in the same statement" 1 \
 # is given.
 chk "the CREATE still carries LOGIN for a role that does not exist yet" 1 \
   "$(printf '%s\n' "$GEN" | grep -c "CREATE ROLE %I LOGIN")"
+rm -rf "$sqld"
+
+echo "141. a custom DB_PASSWORD containing a quote reaches the role intact"
+# This assertion could not be written while the escaping was spelled
+# `${DB_PASSWORD//\'/\'\'}`, because that expression does not mean the same
+# thing on every bash — measured, same input, same expression:
+#
+#   bash 5.2.15  (Ubuntu: Lightsail, and this job)              it''s
+#   bash 3.2.57  (macOS: what a developer runs this suite on)   it\'\'s
+#
+# So it was green here and red on a laptop for a reason with nothing to do with
+# the statement under test, and case 140 above says as much where it picks an
+# unquoted password on purpose. Spelling the doubling through a variable makes
+# the two agree, which is what makes the case possible rather than what makes
+# it pass — on this runner the previous form was already correct.
+#
+# It is worth asserting because a custom DB_PASSWORD is supported and
+# documented, and because on the revision where the two disagree the failure
+# lands after the password has been recorded: measured on a real cluster under
+# bash 3.2, psql stops with `invalid command \'x` and the role is left existing
+# with NO password while $STATE_DIR/db_password holds one, so the re-run reads
+# that same value back and stops in the same place.
+#
+# These match on `PASSWORD '...'` without the LOGIN that case 140 adds. The two
+# fixes landed together and the first draft asserted the whole statement, so
+# every row here — including the five controls — went red against a revision
+# missing *either* of them, and the case reported the escaping as broken for
+# five passwords that contain no quote. A control that fails for the neighbouring
+# change's reason is not a control.
+sqld=$(mktemp -d)
+GEN="$(gen_db_sql collavre_user "pas'wd")"
+chk "the quote is doubled for the SQL literal" 1 \
+  "$(printf '%s\n' "$GEN" | grep -c "PASSWORD 'pas''wd';\$")"
+# The half that says which way it went wrong: a backslash before the quote is
+# what the version-dependent form produced, and psql reads it as a meta-command
+# rather than as part of the literal.
+chk "and not escaped with a backslash" 0 \
+  "$(printf '%s\n' "$GEN" | grep -c "PASSWORD 'pas\\\\'")"
+# The controls, and they are the ones that matter: every password an existing
+# host actually has must come out unchanged. Measured against a live cluster on
+# both spellings — generated-alphanumeric, and customs carrying a dollar, a
+# double quote, a backslash and a semicolon — all six rc=0 and connecting on
+# both; only the quoted row moves. Asserted here on the generated text, since
+# this job has no cluster.
+for pw in 'aB3xQ9zL7mN2pR5tV8wY1cD4fG6hJ0kM' 'p$aswd$x' 'pas"wd' 'pas\wd' 'pas;wd--x'; do
+  GEN="$(gen_db_sql collavre_user "$pw")"
+  chk "a password with no quote is passed through unchanged: $pw" 1 \
+    "$(printf '%s\n' "$GEN" | grep -cF "PASSWORD '$pw';")"
+done
 rm -rf "$sqld"
 
 echo

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -21,7 +21,7 @@ SRC="${1:-$ROOT/script/lightsail_launch.sh}"
 # die() is a one-liner; the others run to the first column-1 closing brace.
 eval "$(awk '
   /^die\(\) \{/ { print; next }
-  /^(ensure_block|ensure_sudoers|in_group|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|reassign_prior_db_role|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile)\(\) \{/ { f = 1 }
+  /^(ensure_block|ensure_sudoers|in_group|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|reassign_prior_db_role|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|ensure_docker_log_caps)\(\) \{/ { f = 1 }
   f { print }
   f && /^\}/ { f = 0 }
 ' "$SRC")"
@@ -29,7 +29,7 @@ eval "$(awk '
 for fn in die ensure_block ensure_sudoers in_group revoke_prior_deploy_user \
           ensure_ufw_rule ssh_already_allowed ensure_ssh_rule \
           install_authorized_keys reassign_prior_db_role revoke_prior_ssh_key \
-          ensure_cluster_on_default_port ensure_swapfile; do
+          ensure_cluster_on_default_port ensure_swapfile ensure_docker_log_caps; do
   declare -F "$fn" >/dev/null || {
     echo "could not extract $fn() from $SRC — has the definition moved?" >&2
     exit 1
@@ -1123,6 +1123,130 @@ esac
 out="$( (DB_PORT=5432 eval "$guard") 2>&1 )"
 chk "the default proceeds" 0 "$?"
 chk "and says nothing"     "" "$out"
+
+# --------------------------------------------------------------------------
+# ensure_docker_log_caps. Real jq; the file is a temp path.
+# --------------------------------------------------------------------------
+caps_of() { jq -c '."log-opts"' "$1"; }
+
+echo "62. a host with no daemon.json gets the caps written"
+d=$(mktemp -d); f="$d/daemon.json"; LOGGED=""
+ensure_docker_log_caps "$f"
+chk "reports it changed the file" 1 "$DAEMON_JSON_CHANGED"
+chk "caps present" '{"max-size":"10m","max-file":"3"}' "$(caps_of "$f")"
+chk "valid JSON"   0 "$(jq empty "$f" >/dev/null 2>&1; echo $?)"
+
+echo "63. an existing daemon.json without caps has them merged in, not clobbered"
+# The finding: the old condition skipped the whole block whenever the file
+# existed, so a by-hand run on an existing instance left logs uncapped and
+# still reported Docker as configured.
+d=$(mktemp -d); f="$d/daemon.json"; LOGGED=""
+printf '{"insecure-registries":["r.internal:5000"],"live-restore":true}\n' > "$f"
+ensure_docker_log_caps "$f"
+chk "reports it changed the file" 1 "$DAEMON_JSON_CHANGED"
+chk "caps added"   '{"max-size":"10m","max-file":"3"}' "$(caps_of "$f")"
+chk "driver set"   'json-file' "$(jq -r '."log-driver"' "$f")"
+chk "operator's registries kept" '["r.internal:5000"]' "$(jq -c '."insecure-registries"' "$f")"
+chk "operator's live-restore kept" 'true' "$(jq -r '."live-restore"' "$f")"
+
+echo "64. existing caps are left exactly as the operator set them"
+d=$(mktemp -d); f="$d/daemon.json"; LOGGED=""
+printf '{"log-driver":"json-file","log-opts":{"max-size":"50m","max-file":"10"}}\n' > "$f"
+before="$(cat "$f")"
+ensure_docker_log_caps "$f"
+chk "reports no change" 0 "$DAEMON_JSON_CHANGED"
+chk "byte-identical"    "$before" "$(cat "$f")"
+
+echo "65. a non-json-file driver is reported, not overridden"
+# journald and local rotate on their own; forcing json-file would redirect an
+# operator's logs rather than cap them.
+for drv in journald local awslogs; do
+  d=$(mktemp -d); f="$d/daemon.json"; LOGGED=""
+  printf '{"log-driver":"%s"}\n' "$drv" > "$f"
+  before="$(cat "$f")"
+  ensure_docker_log_caps "$f"
+  chk "no change for $drv" 0 "$DAEMON_JSON_CHANGED"
+  chk "untouched: $drv"    "$before" "$(cat "$f")"
+done
+case "$LOGGED" in
+  *"rotates on its own"*) echo "  ok   says why it left it alone" ;;
+  *) echo "  FAIL silent: $LOGGED"; fail=1 ;;
+esac
+
+echo "66. an unparseable daemon.json is reported, never overwritten"
+# It is the operator's file and Docker will not start until it is repaired;
+# replacing it would destroy the evidence of what they meant.
+d=$(mktemp -d); f="$d/daemon.json"; LOGGED=""
+printf '{"log-driver": "json-file",,,\n' > "$f"
+before="$(cat "$f")"
+ensure_docker_log_caps "$f"
+chk "reports no change" 0 "$DAEMON_JSON_CHANGED"
+chk "untouched"         "$before" "$(cat "$f")"
+case "$LOGGED" in
+  *"WARNING"*"not valid JSON"*) echo "  ok   operator told" ;;
+  *) echo "  FAIL silent: $LOGGED"; fail=1 ;;
+esac
+
+echo "67. a merged file is stable across re-runs"
+d=$(mktemp -d); f="$d/daemon.json"; LOGGED=""
+printf '{"live-restore":true}\n' > "$f"
+ensure_docker_log_caps "$f"
+after_first="$(cat "$f")"
+ensure_docker_log_caps "$f"
+chk "second run changes nothing" 0 "$DAEMON_JSON_CHANGED"
+chk "byte-identical"             "$after_first" "$(cat "$f")"
+
+# --------------------------------------------------------------------------
+# ensure_ufw_rule, revisited: a delete that FAILS must not advance the marker.
+# --------------------------------------------------------------------------
+UFW_CALLS=""
+UFW_DELETE_FAILS=""
+# shellcheck disable=SC2329  # called by ensure_ufw_rule, eval'd from the script
+ufw() {
+  UFW_CALLS="$UFW_CALLS|$*"
+  [ "${1:-}" != delete ] || [ -z "$UFW_DELETE_FAILS" ] || return 1
+  return 0
+}
+LOGGED=""
+# shellcheck disable=SC2329  # called by ensure_ufw_rule, eval'd from the script
+log() { LOGGED="$LOGGED $*"; }
+
+echo "68. a delete that fails leaves the marker so the next run retries"
+# `ufw delete` exits 0 even for a rule that was not there, so a non-zero status
+# means it could not act and the old rule is still installed. Advancing the
+# marker there loses the only record of it: the previous Docker subnet keeps
+# reaching PostgreSQL for the life of the instance and no run can find it.
+d=$(mktemp -d); st="$d/ufw_postgres"
+old="allow from 172.17.0.0/16 to 172.17.0.1 port 5432 proto tcp"
+new="allow from 10.200.0.0/16 to 172.18.0.1 port 5432 proto tcp"
+printf '%s\n' "$old" > "$st"
+UFW_CALLS=""; LOGGED=""; UFW_DELETE_FAILS=1
+ensure_ufw_rule postgres "$new" "$st"
+chk "returns success"        0 "$?"
+chk "new rule still added"   1 "$(printf '%s' "$UFW_CALLS" | grep -c '|allow from 10.200.0.0/16')"
+chk "marker NOT advanced"    "$old" "$(cat "$st")"
+case "$LOGGED" in
+  *"WARNING"*"still"*"in force"*) echo "  ok   operator told, with the command to fix it" ;;
+  *) echo "  FAIL silent or vague: $LOGGED"; fail=1 ;;
+esac
+# and the retry works once ufw can act again
+UFW_CALLS=""; LOGGED=""; UFW_DELETE_FAILS=""
+ensure_ufw_rule postgres "$new" "$st"
+chk "retry withdraws the old rule" 1 "$(printf '%s' "$UFW_CALLS" | grep -c "|delete $old")"
+chk "marker advanced now"          "$new" "$(cat "$st")"
+
+echo "69. the replacement is added before the predecessor is withdrawn"
+# An interrupted run must never leave the host with neither rule.
+d=$(mktemp -d); st="$d/ufw_postgres"
+printf '%s\n' "$old" > "$st"
+UFW_CALLS=""; LOGGED=""; UFW_DELETE_FAILS=""
+ensure_ufw_rule postgres "$new" "$st"
+case "$UFW_CALLS" in
+  "|allow from 10.200.0.0/16"*"|delete allow from 172.17.0.0/16"*)
+    echo "  ok   add precedes delete" ;;
+  *) echo "  FAIL wrong order: $UFW_CALLS"; fail=1 ;;
+esac
+unset -f ufw
 
 echo
 if [ "$fail" = 0 ]; then echo "ALL PASS"; else echo "FAILURES"; fi

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -21,7 +21,7 @@ SRC="${1:-$ROOT/script/lightsail_launch.sh}"
 # die() is a one-liner; the others run to the first column-1 closing brace.
 eval "$(awk '
   /^die\(\) \{/ { print; next }
-  /^(ensure_block|sudoers_file_name|ensure_sudoers|in_group|write_state_file|launch_record_is_complete|record_launch_settings|record_deploy_user_grant|revoke_deploy_user_access|revoke_prior_deploy_user|stage_ssh_cutover|ssh_public_key_fingerprint|ssh_public_key_material|ssh_cutover_signature_verifies|finalize_ssh_cutover|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|install_deploy_ssh_dir|reassign_prior_db_role|refuse_superuser_db_rotation|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps|warn_existing_containers_keep_log_config|dedupe_authorized_keys|install_staged_authorized_keys|postgresql_conf_includes_confd|role_owns_app_objects|refuse_db_name_change|refuse_defaulted_config_change|refuse_unusable_db_identifier|refuse_unparsable_ssh_key|refuse_forced_command_ssh_key|ipv4_dotted_quad|refuse_unusable_bind_address|refuse_unusable_subnet|passwd_home|ssh_key_holder|adopt_legacy_ssh_key_marker|record_db_role_grant|reassign_one_db_role|record_ssh_key_grant|refuse_root_deploy_user|append_state_line|refuse_nologin_deploy_user|resolve_symlink_chain|stage_beside|restore_postgresql_bind_config|stage_authorized_keys|scan_ssh_config_file|find_unsafe_ssh_match|verify_ssh_key_destination|ssh_pattern_list_matches|verify_ssh_admission_controls|verify_ssh_hardening|refuse_unusable_retention|refuse_unusable_backup_calendar|install_managed_config|install_downloaded_file|install_credential_summary|reload_ssh_daemon)\(\) \{/ { f = 1 }
+  /^(ensure_block|sudoers_file_name|ensure_sudoers|in_group|write_state_file|launch_record_is_complete|record_launch_settings|record_deploy_user_grant|revoke_deploy_user_access|revoke_prior_deploy_user|stage_ssh_cutover|ssh_public_key_fingerprint|ssh_public_key_material|ssh_cutover_signature_verifies|finalize_ssh_cutover|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|install_deploy_ssh_dir|reassign_prior_db_role|refuse_superuser_db_rotation|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps|warn_existing_containers_keep_log_config|dedupe_authorized_keys|install_staged_authorized_keys|postgresql_conf_includes_confd|role_owns_app_objects|refuse_db_name_change|refuse_defaulted_config_change|refuse_unusable_db_identifier|refuse_unparsable_ssh_key|refuse_forced_command_ssh_key|ipv4_dotted_quad|refuse_unusable_bind_address|refuse_unusable_subnet|passwd_home|ssh_key_holder|adopt_legacy_ssh_key_marker|record_db_role_grant|reassign_one_db_role|record_ssh_key_grant|refuse_root_deploy_user|append_state_line|refuse_nologin_deploy_user|resolve_symlink_chain|stage_beside|restore_postgresql_bind_config|stage_authorized_keys|scan_ssh_config_file|find_unsafe_ssh_match|verify_ssh_key_destination|ssh_pattern_list_matches|verify_ssh_admission_controls|verify_ssh_hardening|refuse_unusable_retention|refuse_unusable_backup_calendar|install_managed_config|install_downloaded_file|install_credential_summary|ensure_sshd_runtime_dir|reload_ssh_daemon)\(\) \{/ { f = 1 }
   f { print }
   f && /^\}/ { f = 0 }
 ' "$SRC")"
@@ -55,7 +55,7 @@ for fn in die ensure_block sudoers_file_name ensure_sudoers in_group write_state
 	  refuse_unusable_retention \
 	  refuse_unusable_backup_calendar \
 	  install_managed_config install_downloaded_file \
-	  install_credential_summary reload_ssh_daemon \
+	  install_credential_summary ensure_sshd_runtime_dir reload_ssh_daemon \
           adopt_legacy_ssh_key_marker; do
   declare -F "$fn" >/dev/null || {
     echo "could not extract $fn() from $SRC — has the definition moved?" >&2
@@ -6479,6 +6479,28 @@ echo "150. a running sshd that refused the hardening stops the run"
 # something connects), not an edge case. A guard on the rc alone would refuse
 # every correctly-provisioned host. is-active is the discriminator, and it is
 # read from systemctl rather than from the message, which is localised.
+runtime_call="$(
+  install() { printf '%s\n' "$*"; }
+  ensure_sshd_runtime_dir /run/sshd-test
+)"
+chk "the socket-activated host prepares sshd's runtime directory" \
+  "-d -o root -g root -m 0755 /run/sshd-test" "$runtime_call"
+runtime_fail="$(
+  ( install() { return 1; }
+    ensure_sshd_runtime_dir /run/sshd-test ) 2>&1
+  printf 'rc=%s\n' "$?"
+)"
+chk "an unwritable sshd runtime directory stops the run" 1 \
+  "$(printf '%s' "$runtime_fail" | grep -c '^rc=1$')"
+chk "and reports the directory that could not be prepared" 1 \
+  "$(printf '%s' "$runtime_fail" | grep -cF "/run/sshd-test")"
+chk "the runtime directory is prepared before reload and disk verification" 1 \
+  "$(awk '
+    /^ensure_sshd_runtime_dir$/ { prepared = 1 }
+    prepared && /^reload_ssh_daemon \|\| SSH_RELOAD_STATE=\$\?$/ { found = 1 }
+    END { print found + 0 }
+  ' "$SRC")"
+
 systemctl() { # <verb> <unit>
   case "$1 $2" in
     "reload $RELOAD_OK")  return 0 ;;

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -6098,6 +6098,28 @@ eval "$saved_log"
 LAUNCH_SETTINGS="$saved_launch_settings"
 rm -rf "$record_dir"
 
+echo "153. the PostgreSQL apt source is installed atomically"
+postgres_source_block="$(
+  awk '
+    /^if ! \[ -d "\/etc\/postgresql\/\$PG_MAJOR\/main" \]; then$/ { f = 1 }
+    f { print }
+    f && /^fi$/ { exit }
+  ' "$SRC"
+)"
+chk "the live source is written through the staging helper" 1 \
+  "$(grep -c "install_managed_config 'the PostgreSQL apt source'" <<<"$postgres_source_block")"
+chk "and never truncated by a heredoc redirection"           0 \
+  "$(grep -c 'cat > /etc/apt/sources.list.d/pgdg.list' <<<"$postgres_source_block")"
+chk "the staged source is installed before apt reads it"     1 \
+  "$(awk '
+      /install_managed_config .*PostgreSQL apt source/ { installed = NR }
+      /apt_get update -y/ { updated = NR }
+      END {
+	if (installed && updated && installed < updated) print 1
+	else print 0
+      }
+    ' <<<"$postgres_source_block")"
+
 echo
 if [ "$fail" = 0 ]; then echo "ALL PASS"; else echo "FAILURES"; fi
 exit "$fail"

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -5610,6 +5610,13 @@ chk "an sshd -T that will not run warns instead of stopping" 1 \
   "$(printf '%s' "$vh_unread" | grep -c '^rc=0$')"
 chk "and says the hardening is unverified"                1 \
   "$(printf '%s' "$vh_unread" | grep -c 'unverified')"
+vh_inactive_unread="$( ( PATH="$vshd/bin:$PATH"
+  verify_ssh_hardening "" "$vshd" 2 ) 2>&1
+  printf 'rc=%s\n' "$?" )"
+chk "but an inactive daemon with no valid disk config stops" 1 \
+  "$(printf '%s' "$vh_inactive_unread" | grep -c '^rc=1$')"
+chk "and names the socket activation risk"                  1 \
+  "$(printf '%s' "$vh_inactive_unread" | grep -c 'socket-activated connection')"
 
 # Source level, because every row above passes on a revision that writes the
 # drop-in under the losing name and never reads anything back.
@@ -5627,7 +5634,7 @@ chk "the sysctl drop-in is staged too"                    1 \
 chk "and the inert 99- file it replaces is removed"       1 \
   "$(grep -c '^rm -f /etc/ssh/sshd_config\.d/99-collavre\.conf$' "$SRC")"
 chk "and the run reads back what sshd resolved"           1 \
-  "$(grep -c '^verify_ssh_hardening$' "$SRC")"
+  "$(grep -cF 'verify_ssh_hardening "" /etc/ssh "$SSH_RELOAD_STATE"' "$SRC")"
 
 # The claim is about what sshd does with two files, so sshd is asked. The name
 # and the body both come from the script: a harness that wrote its own 01- file
@@ -5944,16 +5951,17 @@ systemctl() { # <verb> <unit>
   esac
   return 1
 }
-rsd() { # <ok unit> <failing unit> <active unit> -> rc
+rsd() { # <ok unit> <failing unit> <active unit> -> 0=adopted, 1=refused, 2=inactive
   RELOAD_OK="${1:-@none}" RELOAD_BAD="${2:-@none}" ACTIVE="${3:-@none}"
   reload_ssh_daemon >/dev/null 2>&1; echo $?
 }
 chk "an ssh.service that adopts it proceeds"          0 "$(rsd ssh '' ssh)"
 chk "and an sshd.service that adopts it"              0 "$(rsd sshd '' sshd)"
-# The controls, and the reason this is not a guard on the reload status. Both
-# of these are healthy hosts on which BOTH reloads fail.
-chk "a socket-activated host with nothing connected"  0 "$(rsd '' ssh '')"
-chk "and a host carrying neither unit"                0 "$(rsd '' '' '')"
+# The controls, and the reason this is not a binary status. Both are healthy
+# hosts on which BOTH reloads fail; status 2 tells the caller it must rely on
+# the configuration on disk before allowing socket activation to start sshd.
+chk "a socket-activated host with nothing connected"  2 "$(rsd '' ssh '')"
+chk "and a host carrying neither unit"                2 "$(rsd '' '' '')"
 # The finding. Same rc as the row above it, opposite meaning.
 chk "a running daemon that refuses it stops the run"  1 "$(rsd '' ssh ssh)"
 # ssh is absent here and sshd is the one running and refusing, so this also
@@ -5967,8 +5975,10 @@ unset -f systemctl
 unset RELOAD_OK RELOAD_BAD ACTIVE
 # Source level: the behavioural rows above all pass on a revision that defines
 # the function and still swallows its status with `|| true`.
-chk "and the run treats that as fatal"                1 \
-  "$(grep -c '^reload_ssh_daemon || die \\$' "$SRC")"
+chk "and the run preserves the reload state"          1 \
+  "$(grep -cF 'reload_ssh_daemon || SSH_RELOAD_STATE=$?' "$SRC")"
+chk "and passes it to disk verification"              1 \
+  "$(grep -cF 'verify_ssh_hardening "" /etc/ssh "$SSH_RELOAD_STATE"' "$SRC")"
 chk "rather than discarding the status"               0 \
   "$(grep -c '^systemctl reload ssh .*|| true$' "$SRC")"
 

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -2095,6 +2095,17 @@ cmd="$*"; cmd="${cmd//\/tmp\//$REMOTE/}"
 echo ssh >>"$TRACE"
 PATH="$RBIN:$PATH" bash -c "$cmd"
 STUB
+  # The restore runs on the instance as the `postgres` superuser over the local
+  # socket, so the remote sandbox needs a sudo of its own. It records who it was
+  # asked to become rather than silently stripping the argument: "restored as
+  # postgres" is the property that replaced a connection URL carrying the app's
+  # password, and a stub that dropped `-u` would let a recipe that went back to
+  # running as the deploy user pass here.
+  cat > "$work/rbin/sudo" <<'STUB'
+#!/usr/bin/env bash
+if [ "${1:-}" = -u ]; then echo "sudo-u:$2" >>"$TRACE"; shift 2; fi
+exec "$@"
+STUB
   cat > "$work/rbin/pg_restore" <<'STUB'
 #!/usr/bin/env bash
 for a in "$@"; do case "$a" in *collavre.dump) echo "PG_RESTORE:$(cat "$a" 2>&1)" >>"$TRACE" ;; esac; done
@@ -2117,6 +2128,31 @@ FAIL_DUMP='' FAIL_XFER='' FAIL_RESTORE='' DUMP_TAG=fresh run_move
 chk "staged under .incoming"  1 "$(grep -c 'scp:/tmp/collavre.dump.incoming' <<<"${MOVE_TRACE//|/$'\n'}")"
 chk "restored the new dump"   1 "$(grep -c 'PG_RESTORE:DUMP-fresh' <<<"${MOVE_TRACE//|/$'\n'}")"
 chk "nothing left behind"     ""  "$MOVE_LEFT"
+chk "restored as postgres"    1 "$(grep -c '^sudo-u:postgres$' <<<"${MOVE_TRACE//|/$'\n'}")"
+
+echo "78a. the move never asks for the password to be pasted into a URL"
+# $DB_PASSWORD is stored raw and appears encoded only inside DATABASE_URL, so a
+# URL built by hand from the two files this page tells you to read is wrong
+# whenever the operator chose their own password. Measured against libpq 14.15,
+# the three that fail do so after the scp with the source already quiesced —
+# and `pa%41ss` does not fail at all, it authenticates as "paAss".
+#
+#   p@ss      could not translate host name "ss@127.0.0.1"
+#   p/ss      could not translate host name "ss"
+#   p%ss      invalid percent-encoded token
+#   pa%41ss   connects, as a different password
+#
+# Asserted against the recipe text rather than by running it, because the defect
+# is a value the operator is instructed to type: no stub can fail on a password
+# the harness never had. Both spellings are checked — the placeholder this page
+# used and a URI scheme anywhere in the block — so neither a rename of the
+# placeholder nor a differently-worded URL brings it back unnoticed.
+chk "no password placeholder" 0 "$(grep -c '<password>' <<<"$move")"
+chk "no connection URI"       0 "$(grep -c 'postgres\(ql\)\?://' <<<"$move")"
+# The page has to keep saying why, or the next edit re-derives the URL as the
+# obvious way to name a database.
+chk "and the page says why"   1 \
+  "$(grep -c 'invalid percent-encoded token' "$DOC")"
 
 echo "79. a failed pg_dump never reaches the transfer or the restore"
 FAIL_DUMP=1 FAIL_XFER='' FAIL_RESTORE='' run_move
@@ -2264,6 +2300,15 @@ case "$sql" in
                                  [ -z "$FAIL_PRIOR_READ" ] || exit 1
                                else
                                  echo "readback" >>"$TRACE"
+                                 # The ALTER committed and the confirmation did
+                                 # not come back — the cluster restarted in
+                                 # between, the connection dropped. Modelled
+                                 # separately from FAIL_SHUT because the two
+                                 # leave the database in opposite states while
+                                 # looking identical from the recipe's side:
+                                 # $shut is empty either way, and only one of
+                                 # them has locked the app out.
+                                 [ -z "$FAIL_READBACK" ] || exit 1
                                fi
                                cat "$CONNLIMIT" ;;
   *pg_terminate_backend*)      echo "terminate"      >>"$TRACE"; echo "${KILLED:-0}" ;;
@@ -2288,6 +2333,7 @@ STUB
   export TRACE LIVE="${LIVE-0}" KILLED="${KILLED:-0}" FAIL_RESTORE="${FAIL_RESTORE:-}" \
          FAIL_SHUT="${FAIL_SHUT:-}" FAIL_REOPEN="${FAIL_REOPEN:-}" \
          FAIL_PRIOR_READ="${FAIL_PRIOR_READ:-}" \
+         FAIL_READBACK="${FAIL_READBACK:-}" \
          CONNLIMIT="$work/connlimit" DATCONN_N="$work/datconn_n" \
          APP_ROLE="${APP_ROLE-collavre_user}" APP_SUPER="${APP_SUPER-f}" \
          APP_DB="${APP_DB-collavre_production}"
@@ -2521,6 +2567,52 @@ chk "nothing dropped"            0 "$(grep -cx 'PG_RESTORE_RAN' <<<"${R_TRACE//|
 chk "not re-opened"              0 "$(grep -cx 'limit:reopened' <<<"${R_TRACE//|/$'\n'}")"
 chk "and no note about a limit"  0 "$(grep -c 'NOTE:' <<<"$R_OUT")"
 unset FAIL_PRIOR_READ APP_DB
+
+echo "86l. an ALTER that took but could not be confirmed still gets put back"
+# The read-back is a second connection and fails on its own terms — PostgreSQL
+# restarted between the two statements, the socket dropped. $shut is then empty,
+# which is indistinguishable from the ALTER having failed, and the block took
+# the refusing branch and stopped: status 3, "nothing was changed", no re-open.
+# But the door really is shut, so what the operator meets next is the app
+# refused at boot with "too many connections" — from the block that told them it
+# had touched nothing. The ALTER's own exit status is the only thing that can
+# tell those two apart, and it is now kept.
+PRIOR_LIMIT=25 FAIL_READBACK=1 LIVE=0 KILLED=0 FAIL_RESTORE='' run_restore
+chk "refused"                    1 "$(grep -c 'REFUSING' <<<"$R_OUT")"
+chk "nothing dropped"            0 "$(grep -cx 'PG_RESTORE_RAN' <<<"${R_TRACE//|/$'\n'}")"
+# The assertion the finding is about: what the database is left at, not which
+# statements ran. 0 here is an app that cannot start.
+chk "left at the operator's cap" 25 "$R_LIMIT"
+chk "re-opened"                  1 "$(grep -cx 'limit:reopened' <<<"${R_TRACE//|/$'\n'}")"
+# And the refusal must not claim the ALTER failed — that is the one reading it
+# has no evidence for, and the one that sends the operator looking at the wrong
+# thing while the app stays locked out.
+chk "does not blame the ALTER"   0 "$(grep -c 'did not take' <<<"$R_OUT")"
+chk "says it cannot tell"        1 "$(grep -c 'reported success' <<<"$R_OUT")"
+unset PRIOR_LIMIT FAIL_READBACK
+
+echo "86m. a prior limit that could not be read is still put back on that path"
+# Both reads failed: the block has no value to restore and the door may be shut.
+# -1 is the lesser wrong here for the same reason it is on the ordinary path —
+# leaving it shut for want of a number produces exactly the misdirected "too
+# many connections" the re-open exists to avoid — but it must be said out loud,
+# and 86k's silence is scoped to the paths that never shut anything, not to
+# status 3 as a whole.
+FAIL_PRIOR_READ=1 FAIL_READBACK=1 LIVE=0 KILLED=0 FAIL_RESTORE='' run_restore
+chk "re-opened to the default"  -1 "$R_LIMIT"
+chk "and the operator is told"   1 "$(grep -c 'NOTE: could not read' <<<"$R_OUT")"
+unset FAIL_PRIOR_READ FAIL_READBACK
+
+echo "86n. the ALTER failing is still not a reason to touch the limit"
+# The negative half of 86l, and the reason this is gated on the ALTER's status
+# rather than on "status 3 might have shut it": here the statement did not run,
+# the limit is the operator's, and re-opening would be the block changing
+# something on the path where it refused to change anything.
+PRIOR_LIMIT=25 FAIL_SHUT=1 LIVE=0 KILLED=0 FAIL_RESTORE='' run_restore
+chk "not re-opened"              0 "$(grep -cx 'limit:reopened' <<<"${R_TRACE//|/$'\n'}")"
+chk "the cap is untouched"       25 "$R_LIMIT"
+chk "and the ALTER is blamed"    1 "$(grep -c 'did not take' <<<"$R_OUT")"
+unset PRIOR_LIMIT FAIL_SHUT
 
 # --- dedupe_authorized_keys -------------------------------------------------
 #
@@ -3677,9 +3769,223 @@ for after in 'install_authorized_keys "\$AUTH_KEYS"' \
              'dedupe_authorized_keys "\$AUTH_KEYS"' \
              'apt_get update' 'usermod -aG docker'; do
   line="$(grep -n "^$after" "$SRC" | head -1 | cut -d: -f1)"
+  # Both operands tested for emptiness before the comparison: against a script
+  # with no call at all these are all meant to fail, and `[ "" -lt 5 ]` fails
+  # with a shell error rather than an answer, which buries the assertion it was
+  # supposed to report.
   chk "before ${after%% *}" 1 \
-    "$([ -n "$line" ] && [ "$grd_line" -lt "$line" ] && echo 1 || echo 0)"
+    "$([ -n "$grd_line" ] && [ -n "$line" ] && [ "$grd_line" -lt "$line" ] &&
+       echo 1 || echo 0)"
 done
+
+# --- a record that does not answer is not a record of "nothing to check" ------
+#
+# launch.env is written with one redirection at the very end of a run, and
+# refuse_defaulted_config_change branches on the file *existing*. A write that
+# failed after the truncate — a full disk, an interrupted run — leaves it
+# present and short, and every missing line is skipped by the reader's
+# `grep -q "^$name=" || continue`. So the guard answered "no drift" about a
+# comparison it never made, and what went through is the bare `FORCE=1` re-run
+# it exists to refuse.
+
+cfg_short=$(mktemp -d)
+printf 'deploybot\n'    > "$cfg_short/deploy_user"
+printf 'collavre_app\n' > "$cfg_short/db_user"
+
+echo "120. a launch.env that cannot answer falls back to the markers that can"
+: > "$cfg_short/launch.env"
+run_cfg "$cfg_short" ""
+chk "an empty record: refused"        1 "$CFG_STATUS"
+chk "the deploy-user rotation named"  1 \
+  "$(grep -c "APP_SSH_USER: host has 'deploybot'" <<<"$CFG_OUT")"
+chk "the db-role rotation named"      1 \
+  "$(grep -c "DB_USER: host has 'collavre_app'" <<<"$CFG_OUT")"
+
+# Truncated mid-line, which is what a redirection killed part-way through
+# actually leaves: the settings before the cut survive and the rest are gone.
+# SSH_PUBLIC_KEY is empty on both sides here, so nothing but the fallback can
+# produce a refusal — a case that passed on the surviving line would prove
+# nothing about the lines that did not survive.
+printf 'SSH_PUBLIC_KEY=\nAPP_SSH_U' > "$cfg_short/launch.env"
+run_cfg "$cfg_short" ""
+chk "a truncated record: refused"     1 "$CFG_STATUS"
+chk "the setting cut off mid-line"    1 \
+  "$(grep -c "APP_SSH_USER: host has 'deploybot'" <<<"$CFG_OUT")"
+
+# The control that keeps this from being a guard that fires on everything: a
+# record that does answer and agrees must still proceed, and the fallback must
+# not re-fire on a setting launch.env already settled. The markers here name
+# somebody else on purpose — if the fallback ran unconditionally this would
+# refuse a host where nothing drifted.
+{ for _n in $LAUNCH_SETTINGS; do
+    case "$_n" in
+      APP_SSH_USER) echo "APP_SSH_USER=collavre" ;;
+      DB_USER)      echo "DB_USER=collavre_user" ;;
+      PG_MAJOR)     echo "PG_MAJOR=17" ;;
+      DB_NAME)      echo "DB_NAME=collavre_production" ;;
+      DB_BIND_ADDRESS) echo "DB_BIND_ADDRESS=172.17.0.1" ;;
+      DOCKER_SUBNETS)  echo "DOCKER_SUBNETS=172.16.0.0/12" ;;
+      SWAP_SIZE_MB) echo "SWAP_SIZE_MB=2048" ;;
+      TIMEZONE)     echo "TIMEZONE=Asia/Seoul" ;;
+      INSTANCE_HOSTNAME) echo "INSTANCE_HOSTNAME=collavre" ;;
+      BACKUP_RETENTION_DAYS) echo "BACKUP_RETENTION_DAYS=7" ;;
+      BACKUP_AT)    echo "BACKUP_AT=03:30" ;;
+      *)            echo "$_n=" ;;
+    esac
+  done; } > "$cfg_short/launch.env"
+unset _n
+run_cfg "$cfg_short" ""
+chk "a record that agrees: proceeds"  0 "$CFG_STATUS"
+chk "and says nothing"                "" "$CFG_OUT"
+
+echo "120a. against the previous form the empty record went straight through"
+# The previous reader inline, so what differs is the branch and not a second
+# copy of the function. Everything else — the setting list, the markers, the
+# environment — is the case above.
+: > "$cfg_short/launch.env"
+prev_status=0
+prev_out="$(
+  env SSH_PUBLIC_KEY= APP_SSH_USER=collavre DB_USER=collavre_user \
+      LAUNCH_SETTINGS="$LAUNCH_SETTINGS" \
+    bash -c '
+      set -uo pipefail
+      state_dir="$1"; env_file="$state_dir/launch.env"; drift=""
+      if [ -f "$env_file" ]; then
+        for name in $LAUNCH_SETTINGS; do
+          grep -q "^$name=" "$env_file" || continue
+          prior="$(sed -n "s/^$name=//p" "$env_file" | head -1)"
+          [ "$prior" = "${!name}" ] && continue
+          drift="$drift $name"
+        done
+      else
+        for pair in deploy_user:APP_SSH_USER db_user:DB_USER; do
+          file="${pair%%:*}"; name="${pair##*:}"
+          [ -f "$state_dir/$file" ] || continue
+          prior="$(cat "$state_dir/$file")"
+          [ -n "$prior" ] && [ "$prior" != "${!name}" ] && drift="$drift $name"
+        done
+      fi
+      [ -z "$drift" ] || { echo "REFUSING:$drift"; exit 1; }
+    ' _ "$cfg_short" 2>&1
+)" || prev_status=$?
+chk "the previous form: NOT refused"  0 "$prev_status"
+chk "and silent about the rotation"   0 "$(grep -c APP_SSH_USER <<<"$prev_out")"
+
+echo "120b. launch.env is replaced in one step rather than truncated in place"
+# The assertion is on the write, not on the wording: a redirection here is the
+# defect, whatever the comment above it says.
+lenv_line="$(grep -c 'write_state_file "\$STATE_DIR/launch.env"' "$SRC")"
+chk "written through write_state_file" 1 "$lenv_line"
+chk "and not by a redirection"         0 \
+  "$(grep -c '> *"\$STATE_DIR/launch.env"' "$SRC")"
+
+# --- an empty db_password is a password this host cannot name ----------------
+#
+# Same window, and the consequence is worse: the empty value is read back as
+# the password and reaches `ALTER ROLE ... PASSWORD ''` unconditionally, so the
+# live role is rotated to an empty password while the deployed DATABASE_URL
+# still carries the real one. The app meets `password authentication failed` at
+# its next reconnect, and the value it needs is gone from the host.
+echo "121. an empty db_password marker is refused rather than applied"
+pw_recipe="$(awk '/^if \[ -z "\$DB_PASSWORD" \]; then$/ { f = 1 }
+                  f { print }
+                  f && /^fi$/ { exit }' "$SRC")"
+chk "the block was extracted" 1 \
+  "$(grep -q 'STATE_DIR/db_password' <<<"$pw_recipe" && echo 1 || echo 0)"
+
+run_pw() {   # run_pw <state dir>
+  PW_STATUS=0
+  PW_OUT="$(
+    env STATE_DIR="$1" DB_PASSWORD= \
+      bash -c '
+        set -uo pipefail
+        '"$(declare -f die)"'
+        log() { echo "[log] $*"; }
+        '"$pw_recipe"'
+        echo "APPLIED:$DB_PASSWORD"
+      ' 2>&1
+  )" || PW_STATUS=$?
+}
+
+pwd_dir=$(mktemp -d)
+: > "$pwd_dir/db_password"
+run_pw "$pwd_dir"
+chk "an empty marker: refused"    1 "$PW_STATUS"
+chk "nothing was applied"         0 "$(grep -c '^APPLIED:' <<<"$PW_OUT")"
+chk "it says what it cannot name" 1 "$(grep -c 'cannot name' <<<"$PW_OUT")"
+# The recovery has to be reachable, not just named — an operator who still has
+# the deployed DATABASE_URL can decode the password out of it.
+chk "and where to get it back"    1 "$(grep -c 'DATABASE_URL' <<<"$PW_OUT")"
+
+printf 'realpassword' > "$pwd_dir/db_password"
+run_pw "$pwd_dir"
+chk "a marker with a value: kept" 0 "$PW_STATUS"
+chk "and it is the one applied"   "APPLIED:realpassword" \
+  "$(grep '^APPLIED:' <<<"$PW_OUT")"
+
+rm -f "$pwd_dir/db_password"
+run_pw "$pwd_dir"
+chk "no marker at all: generates" 0 "$PW_STATUS"
+chk "and it is not empty"         0 "$(grep -c '^APPLIED:$' <<<"$PW_OUT")"
+
+echo "121a. the password marker is 0600 from the moment it exists"
+# mktemp creates 0600 and write_state_file chmods before it writes, so the
+# content never lands in a file that was briefly 0644 in a 0755 directory —
+# which is what the `umask 077` subshell it replaces could only achieve by
+# getting the umask right.
+pwt=$(mktemp -d)
+write_state_file "$pwt/db_password" "s3cret" 0600
+chk "the value round-trips"   "s3cret" "$(cat "$pwt/db_password")"
+chk "and the mode is 0600"    "600"    "$(file_mode "$pwt/db_password")"
+write_state_file "$pwt/plain" "x"
+chk "the default stays 0644"  "644"    "$(file_mode "$pwt/plain")"
+
+echo "121b. a write that fails leaves the previous value in place"
+# The property the redirection did not have. `ulimit -f 0` stands in for the
+# full disk this fails on: the staging file is what gets truncated, and the
+# marker the host depends on is untouched until the rename.
+printf 'previous' > "$pwt/db_password"
+{ ( ulimit -f 0; write_state_file "$pwt/db_password" "replacement" 0600 ); } 2>/dev/null
+chk "the marker still reads"  "previous" "$(cat "$pwt/db_password")"
+
+# --- the cluster serving DB_PORT has to be the one this script configures ----
+echo "122. a same-version cluster that is not named 'main' is refused"
+# Version and port agreeing is not enough. Everything downstream names
+# /etc/postgresql/<major>/main as literal text — the tuning, listen_addresses,
+# the pg_hba rule for the docker bridge, and the runbook's recovery blocks. On a
+# host whose cluster is called something else that path is absent, the step-5
+# apt install reports the package already present without creating a second
+# cluster, `install -d` makes the missing directory, and all of it is written
+# into a tree no postmaster reads. `systemctl restart postgresql` then succeeds,
+# because the umbrella unit does not care which clusters exist, and the run
+# reports success over containers that cannot reach the database.
+PG_MAJOR=17
+DB_PORT=5432
+mk_lsclusters pg_ls_named_app '17  app     5432 online postgres /var/lib/postgresql/17/app /var/log/x'
+out="$( (ensure_cluster_on_default_port pg_ls_named_app) 2>&1 )"
+chk "exits non-zero" 1 "$?"
+case "$out" in
+  *"is named 'app', not 'main'"*"pg_renamecluster"*)
+    echo "  ok   names the cluster it found and how to move it" ;;
+  *) echo "  FAIL unhelpful message: $out"; fail=1 ;;
+esac
+
+# The controls. 'main' on the default port is the ordinary re-run and must not
+# be refused, and a cluster of the WRONG version named 'app' must still be
+# refused on the version — the name check must not preempt the answer that
+# tells the operator to set PG_MAJOR.
+mk_lsclusters pg_ls_named_main '17  main    5432 online postgres /var/lib/postgresql/17/main /var/log/x'
+out="$( (ensure_cluster_on_default_port pg_ls_named_main) 2>&1 )"
+chk "'main' on 5432: proceeds" 0 "$?"
+chk "and says nothing"         "" "$out"
+
+mk_lsclusters pg_ls_16_app '16  app     5432 online postgres /a /b'
+out="$( (ensure_cluster_on_default_port pg_ls_16_app) 2>&1 )"
+chk "a wrong-version 'app': refused" 1 "$?"
+case "$out" in
+  *"already serves 5432"*) echo "  ok   on the version, which is the useful answer" ;;
+  *) echo "  FAIL reported the name over the version: $out"; fail=1 ;;
+esac
 
 echo
 if [ "$fail" = 0 ]; then echo "ALL PASS"; else echo "FAILURES"; fi

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -6981,8 +6981,8 @@ chk "and requires an sshd process ancestor" 1 \
   "$(grep -c '^  ssh_cutover_has_sshd_ancestor "\$user" ||$' "$SRC")"
 chk "sshd exposes the key that authenticated the session" 1 \
   "$(grep -c "^  'ExposeAuthInfo yes'$" "$SRC")"
-chk "explicit-key staging verifies ExposeAuthInfo is effective" 1 \
-  "$(grep -c '^SSH_AUTH_INFO_REQUIRED=0$' "$SRC")"
+chk "every cutover verifies ExposeAuthInfo is effective" 1 \
+  "$(grep -c '^SSH_AUTH_INFO_REQUIRED=1$' "$SRC")"
 chk "the runbook changes KAMAL_SSH_USER only after finalization" 1 \
   "$(grep -c 'Change `KAMAL_SSH_USER` only after' "$DOC")"
 
@@ -7006,6 +7006,33 @@ chk "without committing the deploy user" 0 \
   "$([ -e "$cutover_state/deploy_user" ] && echo 1 || echo 0)"
 cutover_nonce="$SSH_CUTOVER_NONCE"
 cutover_fingerprint="$(ssh_public_key_fingerprint "$cutover_key")"
+proof_proc="$cutover_state/proc"
+proof_uid="$(command id -u)"
+proof_user="$(command id -un)"
+mkdir -p "$proof_proc/500" "$proof_proc/400"
+: > "$cutover_state/auth-info"
+printf 'sudo\n' > "$proof_proc/500/comm"
+printf 'SSH_USER_AUTH=%s\0' "$cutover_state/auth-info" \
+  > "$proof_proc/500/environ"
+printf 'Uid:\t%s\t%s\t%s\t%s\nPPid:\t400\n' \
+  "$proof_uid" "$proof_uid" "$proof_uid" "$proof_uid" \
+  > "$proof_proc/500/status"
+printf 'sshd\n' > "$proof_proc/400/comm"
+: > "$proof_proc/400/environ"
+printf 'Uid:\t%s\t%s\t%s\t%s\nPPid:\t1\n' \
+  "$proof_uid" "$proof_uid" "$proof_uid" "$proof_uid" \
+  > "$proof_proc/400/status"
+chk "a user-owned sshd session process proves the staged UID" 0 \
+  "$(ssh_cutover_has_sshd_ancestor "$proof_user" 500 "$proof_proc"; echo $?)"
+chk "and its user-owned authentication record is accepted" \
+  "$cutover_state/auth-info" \
+  "$(ssh_cutover_auth_info_file "$proof_user" 500 "$proof_proc")"
+other_uid=$((proof_uid + 1))
+printf 'Uid:\t%s\t%s\t%s\t%s\nPPid:\t1\n' \
+  "$other_uid" "$other_uid" "$other_uid" "$other_uid" \
+  > "$proof_proc/400/status"
+chk "a nested sudo UID below another user's sshd is refused" 1 \
+  "$(ssh_cutover_has_sshd_ancestor "$proof_user" 500 "$proof_proc"; echo $?)"
 printf 'publickey %s\n' "$cutover_key" > "$cutover_state/auth-info"
 ssh_cutover_auth_info_file() { printf '%s/auth-info\n' "$cutover_state"; }
 chk "the exposed authentication record identifies the staged key" 0 \
@@ -7027,6 +7054,10 @@ id() {
 in_group() { return 0; }
 ssh_cutover_has_sshd_ancestor() {
   [ "$1" = deploybot ] && [ "${SSH_PROOF:-0}" -eq 1 ]
+}
+ssh_cutover_auth_info_file() {
+  [ "$1" = deploybot ] && [ "${SSH_PROOF:-0}" -eq 1 ] &&
+    printf '%s/auth-info\n' "$cutover_state"
 }
 ssh_cutover_authenticated_with_key() {
   [ "$1" = deploybot ] && [ -n "$2" ] && [ "${KEY_PROOF:-0}" -eq 1 ]
@@ -7142,7 +7173,7 @@ chk "a colliding successor sudoers grant is preserved" 1 \
   "$(grep -cxF 'release_bot ALL=(ALL:ALL) NOPASSWD:ALL' \
       "$sudoers_collision/90-collavre-release_bot")"
 unset -f getent id in_group ssh_cutover_has_sshd_ancestor \
-  ssh_cutover_authenticated_with_key \
+  ssh_cutover_auth_info_file ssh_cutover_authenticated_with_key \
   revoke_prior_ssh_key revoke_prior_deploy_user rm
 rm -rf "$cutover_state"
 

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -492,7 +492,7 @@ chk "the retry revokes it"     0 "$(printf '%s\n' "$GROUPS_OF" | tr ' ' '\n' | g
 chk "and it leaves the queue" 0 "$(grep -cxF legacy "$d4/deploy_users")"
 chk "while the marker still names the account in use" "deploybot" "$(cat "$d4/deploy_user")"
 
-unset -f id gpasswd usermod usermod_host groupadd log rm revoke supp_holds drop_word
+unset -f id gpasswd usermod usermod_host groupadd log revoke supp_holds drop_word
 
 # --------------------------------------------------------------------------
 # One name cannot describe a host that has rotated twice, so the cases below
@@ -7070,7 +7070,7 @@ chk "a sudoers deletion failure keeps the predecessor queued" 0 \
   "$(grep -c '^rc=0$' <<<"$sudoers_failure")"
 unset -f getent id in_group ssh_cutover_has_sshd_ancestor \
   ssh_cutover_authenticated_with_key \
-  revoke_prior_ssh_key revoke_prior_deploy_user
+  revoke_prior_ssh_key revoke_prior_deploy_user rm
 rm -rf "$cutover_state"
 
 echo

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -1632,15 +1632,24 @@ run_restore() {
 while [ "${1:-}" = -u ] || [ "${1:-}" = postgres ]; do shift; done
 exec "$@"
 STUB
+  # datconnlimit is modelled as state rather than as a canned answer, because
+  # the whole point of reading it back is that it disagrees with the ALTER when
+  # the ALTER did not take. FAIL_SHUT makes the ALTER a no-op — psql prints its
+  # error and exits non-zero, which an interactive paste with no `set -e` walks
+  # straight past, which is the case under test.
+  echo -1 > "$work/connlimit"
   cat > "$work/bin/psql" <<'STUB'
 #!/usr/bin/env bash
 sql="${*: -1}"
 case "$sql" in
-  *"CONNECTION LIMIT 0"*)      echo "limit:0"          >>"$TRACE" ;;
-  *"CONNECTION LIMIT -1"*)     echo "limit:reopened"   >>"$TRACE" ;;
-  *pg_terminate_backend*)      echo "terminate"        >>"$TRACE"; echo "${KILLED:-0}" ;;
-  *"count(*)"*)                echo "count"            >>"$TRACE"; printf '%s' "$LIVE" ;;
-  *usename*)                   echo "listing"          >>"$TRACE" ;;
+  *"CONNECTION LIMIT 0"*)      echo "limit:0"        >>"$TRACE"
+                               [ -n "$FAIL_SHUT" ] || echo 0 > "$CONNLIMIT"
+                               [ -z "$FAIL_SHUT" ] || { echo 'ERROR:  database "x" does not exist' >&2; exit 1; } ;;
+  *"CONNECTION LIMIT -1"*)     echo "limit:reopened" >>"$TRACE"; echo -1 > "$CONNLIMIT" ;;
+  *datconnlimit*)              echo "readback"       >>"$TRACE"; cat "$CONNLIMIT" ;;
+  *pg_terminate_backend*)      echo "terminate"      >>"$TRACE"; echo "${KILLED:-0}" ;;
+  *"count(*)"*)                echo "count"          >>"$TRACE"; printf '%s' "$LIVE" ;;
+  *usename*)                   echo "listing"        >>"$TRACE" ;;
 esac
 STUB
   cat > "$work/bin/pg_restore" <<'STUB'
@@ -1654,7 +1663,8 @@ STUB
   # ${LIVE-0}, not ${LIVE:-0}: the empty string is a case under test — it is what
   # a failed check returns — and :- would quietly turn it back into "0", making
   # the one assertion about a broken gate pass for the wrong reason.
-  export TRACE LIVE="${LIVE-0}" KILLED="${KILLED:-0}" FAIL_RESTORE="${FAIL_RESTORE:-}"
+  export TRACE LIVE="${LIVE-0}" KILLED="${KILLED:-0}" FAIL_RESTORE="${FAIL_RESTORE:-}" \
+         FAIL_SHUT="${FAIL_SHUT:-}" CONNLIMIT="$work/connlimit"
   R_OUT="$(cd "$work" && PATH="$work/bin:$PATH" bash ./recipe.sh 2>&1)"
   R_TRACE="$(paste -sd'|' "$TRACE")"
   rm -rf "$work"
@@ -1666,8 +1676,8 @@ chk "door shut first"        "limit:0" "$(cut -d'|' -f1 <<<"$R_TRACE")"
 chk "survivors terminated"   1 "$(grep -c '^terminate$' <<<"${R_TRACE//|/$'\n'}")"
 # The order is the whole point: counting before the limit is applied only says
 # the app happened to be between connections at that instant.
-chk "counted only after the door was shut" 1 \
-  "$(grep -q 'limit:0|terminate|count' <<<"$R_TRACE" && echo 1 || echo 0)"
+chk "counted only after the door was shut AND confirmed shut" 1 \
+  "$(grep -q 'limit:0|readback|terminate|count' <<<"$R_TRACE" && echo 1 || echo 0)"
 chk "restore ran"            1 "$(grep -c '^PG_RESTORE_RAN$' <<<"${R_TRACE//|/$'\n'}")"
 chk "re-opened"              1 "$(grep -c '^limit:reopened$' <<<"${R_TRACE//|/$'\n'}")"
 chk "operator told to boot"  1 "$(grep -c 'app boot' <<<"$R_OUT")"
@@ -1700,6 +1710,25 @@ chk "says the retry needs no extra step"     1 \
   "$(grep -c 'superuser and is exempt' <<<"$R_OUT")"
 chk "prints the command that lifts it"       1 \
   "$(grep -c 'CONNECTION LIMIT -1' <<<"$R_OUT")"
+
+echo "86a. an ALTER that did not take is caught by reading the limit back"
+# The gate's own first step was ungated. These blocks are pasted into an
+# interactive shell with no `set -e`, so a failed ALTER scrolls past; if nothing
+# is attached at that instant the count reads 0 and the restore starts against a
+# database that was never shut. Measured on postgres:17 with the ALTER made to
+# fail: shut exit=1, live=0, datconnlimit still -1, restore proceeds.
+LIVE=0 KILLED=0 FAIL_RESTORE='' FAIL_SHUT=1 run_restore
+chk "the limit was read back"  1 "$(grep -c '^readback$' <<<"${R_TRACE//|/$'\n'}")"
+chk "nothing dropped"          0 "$(grep -c '^PG_RESTORE_RAN$' <<<"${R_TRACE//|/$'\n'}")"
+# It must not even reach the terminate: killing sessions on a database it failed
+# to close is a disruption bought for nothing.
+chk "no sessions terminated"   0 "$(grep -c '^terminate$' <<<"${R_TRACE//|/$'\n'}")"
+# And it must not "re-open" a door it never shut — that would lift a limit the
+# operator may have set themselves.
+chk "not re-opened either"     0 "$(grep -c '^limit:reopened$' <<<"${R_TRACE//|/$'\n'}")"
+chk "operator told"            1 "$(grep -c 'could not shut collavre_production' <<<"$R_OUT")"
+chk "and told nothing was dropped" 1 "$(grep -c 'nothing was dropped' <<<"$R_OUT")"
+unset FAIL_SHUT
 
 # --- dedupe_authorized_keys -------------------------------------------------
 #

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -5956,10 +5956,13 @@ chk "a socket-activated host with nothing connected"  0 "$(rsd '' ssh '')"
 chk "and a host carrying neither unit"                0 "$(rsd '' '' '')"
 # The finding. Same rc as the row above it, opposite meaning.
 chk "a running daemon that refuses it stops the run"  1 "$(rsd '' ssh ssh)"
+# ssh is absent here and sshd is the one running and refusing, so this also
+# says the fallback does not read the first unit's absence as an all-clear for
+# the second.
 chk "and the same under the sshd name"                1 "$(rsd '' sshd sshd)"
-# ssh absent but sshd running and refusing — the fallback must not read the
-# first unit's absence as an all-clear for the second.
-chk "an absent ssh does not excuse a refusing sshd"   1 "$(rsd '' sshd sshd)"
+# An ssh.service that adopts it while a stale sshd.service sits there refusing:
+# the loop must stop at the first unit that took the reload rather than walk on.
+chk "a unit that adopted it ends the search"          0 "$(rsd ssh sshd ssh)"
 unset -f systemctl
 unset RELOAD_OK RELOAD_BAD ACTIVE
 # Source level: the behavioural rows above all pass on a revision that defines

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -173,9 +173,15 @@ unset -f visudo
 # --------------------------------------------------------------------------
 ACCOUNT=""      # the only user that exists, and its groups
 GROUPS_OF=""
+ALSO_SUPP=""    # groups held via /etc/group *as well as* by being primary; a
+                # state `id -nG` cannot show, because it prints each group once
 REVOKED=""      # every gpasswd -d, as "user/group"
 USERMOD=""      # every usermod -g, as "user:group"
 LOGGED=""
+# shellcheck disable=SC2329  # called by the gpasswd/usermod stubs below
+supp_holds() { case " $ALSO_SUPP " in *" $1 "*) return 0 ;; *) return 1 ;; esac; }
+# shellcheck disable=SC2329  # called by the gpasswd/usermod stubs below
+drop_word() { printf '%s\n' "$2" | tr ' ' '\n' | grep -vxF "$1" | tr '\n' ' ' | sed 's/ $//'; }
 id() {
   case "$1" in
     -u)  [ "$2" = "$ACCOUNT" ] ;;
@@ -186,15 +192,30 @@ id() {
 }
 gpasswd() {
   REVOKED="$REVOKED $2/$3"
-  # /etc/group only: a primary membership lives in /etc/passwd and is refused.
-  [ "${GROUPS_OF%% *}" = "$3" ] && return 3
-  GROUPS_OF="$(printf '%s\n' "$GROUPS_OF" | tr ' ' '\n' | grep -vxF "$3" | tr '\n' ' ')"
-  GROUPS_OF="${GROUPS_OF% }"
+  # /etc/group only: a purely primary membership lives in /etc/passwd and is
+  # refused with exit 3. An /etc/group entry is removed even when the same group
+  # is also the primary one — verified on ubuntu:24.04.
+  if supp_holds "$3"; then
+    ALSO_SUPP="$(drop_word "$3" "$ALSO_SUPP")"
+  elif [ "${GROUPS_OF%% *}" = "$3" ]; then
+    return 3
+  fi
+  GROUPS_OF="$(drop_word "$3" "$GROUPS_OF")"
 }
-usermod() {   # usermod -g <group> <user>
+# Named so the cases below that swap usermod out can restore it by reference
+# rather than by re-typing it — two copies would drift, and the copy is what
+# the "does not take" and "retry" cases depend on being faithful.
+# shellcheck disable=SC2329  # called by the usermod stub, and by the cases that restore it
+usermod_host() {   # usermod -g <group> <user>
   USERMOD="$USERMOD $3:$2"
   supp="$(printf '%s\n' "$GROUPS_OF" | cut -s -d' ' -f2-)"; GROUPS_OF="$2${supp:+ $supp}"
+  # moving the primary group does not touch /etc/group, so anything held there
+  # survives and `id -nG` goes on reporting it
+  for g in $ALSO_SUPP; do
+    case " $GROUPS_OF " in *" $g "*) ;; *) GROUPS_OF="$GROUPS_OF $g" ;; esac
+  done
 }
+usermod() { usermod_host "$@"; }
 groupadd() { :; }
 log() { LOGGED="$LOGGED $*"; }
 revoke() { REVOKED=""; USERMOD=""; LOGGED=""; revoke_prior_deploy_user "$@"; }
@@ -246,7 +267,7 @@ echo "15. a PRIMARY docker group is taken back too, not just a supplementary one
 d3=$(mktemp -d); printf 'legacy\n' > "$d3/deploy_user"
 ACCOUNT=legacy; GROUPS_OF="docker sudo"      # docker is PRIMARY here
 revoke deploybot "$d3/deploy_user"
-chk "no longer in docker" 1 "$(printf '%s\n' "$GROUPS_OF" | tr ' ' '\n' | grep -cvxF docker)"
+chk "no longer in docker" 0 "$(printf '%s\n' "$GROUPS_OF" | tr ' ' '\n' | grep -cxF docker)"
 chk "primary group moved to its own" " legacy:legacy" "$USERMOD"
 chk "sudo revoked by gpasswd"        " legacy/sudo"   "$REVOKED"
 case "$LOGGED" in
@@ -256,7 +277,27 @@ case "$LOGGED" in
 esac
 chk "marker advanced" "deploybot" "$(cat "$d3/deploy_user")"
 
-echo "16. a revocation that does not take is reported, not claimed as done"
+echo "16. a group that is BOTH primary and an /etc/group entry is fully revoked"
+# `useradd -g docker` then `gpasswd -a` leaves docker in /etc/passwd AND in
+# /etc/group. Moving the primary group takes back only the first, so the
+# account keeps the docker socket — and `id -nG` prints docker once either way,
+# which is why the previous case cannot catch this one. Reproduced on
+# ubuntu:24.04 before this test was written.
+d3b=$(mktemp -d); printf 'legacy\n' > "$d3b/deploy_user"
+ACCOUNT=legacy; GROUPS_OF="docker"; ALSO_SUPP="docker"
+revoke deploybot "$d3b/deploy_user"
+chk "no longer in docker" 0 "$(printf '%s\n' "$GROUPS_OF" | tr ' ' '\n' | grep -cxF docker)"
+chk "the primary group moved"        " legacy:legacy" "$USERMOD"
+chk "and the /etc/group entry went too" " legacy/docker" "$REVOKED"
+case "$LOGGED" in
+  *"could NOT revoke"*) echo "  FAIL still holds docker, or claims it does: $LOGGED"; fail=1 ;;
+  *"can still log in"*) echo "  ok   revoked in one run, not two" ;;
+  *) echo "  FAIL no warning at all: $LOGGED"; fail=1 ;;
+esac
+chk "marker advanced" "deploybot" "$(cat "$d3b/deploy_user")"
+ALSO_SUPP=""
+
+echo "17. a revocation that does not take is reported, not claimed as done"
 # The failure this replaces: gpasswd exits nonzero, the && swallows it, and the
 # unconditional warning tells the operator the account lost root when it did not.
 d4=$(mktemp -d); printf 'legacy\n' > "$d4/deploy_user"
@@ -272,17 +313,16 @@ case "$LOGGED" in
   *) echo "  ok   does not claim the access is gone" ;;
 esac
 
-echo "17. and the marker is not advanced, so the next run retries"
+echo "18. and the marker is not advanced, so the next run retries"
 # Advancing it here would forget which account still holds root — a permanent
 # silent failure rather than one the next FORCE=1 run picks up.
 chk "marker still names the unrevoked user" "legacy" "$(cat "$d4/deploy_user")"
-unset -f usermod
-usermod() { USERMOD="$USERMOD $3:$2"; supp="$(printf '%s\n' "$GROUPS_OF" | cut -s -d' ' -f2-)"; GROUPS_OF="$2${supp:+ $supp}"; }
+usermod() { usermod_host "$@"; }             # the host is healthy again
 revoke deploybot "$d4/deploy_user"           # the retry, on a healthy host
-chk "the retry revokes it"     1 "$(printf '%s\n' "$GROUPS_OF" | tr ' ' '\n' | grep -cvxF docker)"
+chk "the retry revokes it"     0 "$(printf '%s\n' "$GROUPS_OF" | tr ' ' '\n' | grep -cxF docker)"
 chk "and then advances" "deploybot" "$(cat "$d4/deploy_user")"
 
-unset -f id gpasswd usermod groupadd log revoke
+unset -f id gpasswd usermod usermod_host groupadd log revoke supp_holds drop_word
 
 # --------------------------------------------------------------------------
 # The firewall helpers shell out to ufw, so it is stubbed: every invocation is
@@ -297,7 +337,7 @@ ufw() {
 }
 log() { LOGGED="$LOGGED $*"; }
 
-echo "18. the postgres rule is added once and recorded"
+echo "19. the postgres rule is added once and recorded"
 d=$(mktemp -d)
 UFW_CALLS=""
 ensure_ufw_rule postgres "allow from 172.17.0.0/16 to 172.17.0.1 port 5432 proto tcp" \
@@ -306,7 +346,7 @@ chk "rule added" "|allow from 172.17.0.0/16 to 172.17.0.1 port 5432 proto tcp" "
 chk "recorded"   "allow from 172.17.0.0/16 to 172.17.0.1 port 5432 proto tcp" \
   "$(cat "$d/ufw_postgres")"
 
-echo "19. an unchanged rule deletes nothing"
+echo "20. an unchanged rule deletes nothing"
 # The common re-run. ufw skips re-adding an identical rule itself, so the only
 # thing that must not happen here is a delete.
 UFW_CALLS=""; LOGGED=""
@@ -314,7 +354,7 @@ ensure_ufw_rule postgres "allow from 172.17.0.0/16 to 172.17.0.1 port 5432 proto
   "$d/ufw_postgres"
 chk "no delete" 0 "$(printf '%s' "$UFW_CALLS" | grep -c delete)"
 
-echo "20. a changed rule withdraws the old one instead of accumulating"
+echo "21. a changed rule withdraws the old one instead of accumulating"
 # Without this, moving DB_BIND_ADDRESS or DOCKER_SUBNETS would leave the
 # previous subnet reaching 5432 for the life of the host.
 UFW_CALLS=""; LOGGED=""
@@ -327,13 +367,13 @@ chk "new rule added" 1 "$(printf '%s' "$UFW_CALLS" | grep -c '|allow from 10.200
 chk "state advanced" "allow from 10.200.0.0/16 to 172.18.0.1 port 5432 proto tcp" \
   "$(cat "$d/ufw_postgres")"
 
-echo "21. unrelated operator rules are never touched"
+echo "22. unrelated operator rules are never touched"
 # The whole reason `ufw reset` is gone: a re-run must not disturb a VPN,
 # monitoring or allowlist rule this script knows nothing about.
 chk "only our own rule deleted" 1 "$(printf '%s' "$UFW_CALLS" | grep -c delete)"
 chk "no reset"                  0 "$(printf '%s' "$UFW_CALLS" | grep -c reset)"
 
-echo "22. SSH already allowed is detected in every form ufw prints it"
+echo "23. SSH already allowed is detected in every form ufw prints it"
 for s in "22/tcp                     ALLOW       Anywhere" \
          "22                         ALLOW IN    Anywhere" \
          "OpenSSH                    ALLOW       Anywhere" \
@@ -347,7 +387,7 @@ for s in "22/tcp                     ALLOW       Anywhere" \
   chk "detected: $s" 0 "$?"
 done
 
-echo "23. a narrowed SSH rule survives the re-run that finds it"
+echo "24. a narrowed SSH rule survives the re-run that finds it"
 # The rule an operator most plausibly tightens by hand. Re-adding the blanket
 # `allow OpenSSH` on top would reopen 22 to the internet and look like a no-op.
 #
@@ -362,7 +402,7 @@ for s in "22/tcp                     ALLOW IN    203.0.113.4" \
   chk "blanket rule not added over [${s#22/tcp                     }]" "" "$UFW_CALLS"
 done
 
-echo "24. no SSH rule at all means one is added, never assumed"
+echo "25. no SSH rule at all means one is added, never assumed"
 # Failing the other way enables a deny-by-default firewall on a host with no
 # way back in, so every uncertain status must land here.
 for s in "Status: inactive" \
@@ -376,7 +416,7 @@ for s in "Status: inactive" \
   chk "rule added for [${s:-empty status}]" "|allow OpenSSH" "$UFW_CALLS"
 done
 
-echo "25. a missing OpenSSH profile falls back to the port, it does not give up"
+echo "26. a missing OpenSSH profile falls back to the port, it does not give up"
 # `ufw allow OpenSSH` exits 1 where openssh-server is not installed, and the
 # `ufw --force enable` that follows would then close 22 on a host reachable
 # only over 22.
@@ -459,12 +499,12 @@ STUB
   rm -rf "$work"
 }
 
-echo "26. a clean cutover cleans up and boots"
+echo "27. a clean cutover cleans up and boots"
 FAIL_COPY='' FAIL_REVOKE='' FAIL_SCP='' FAIL_STAGE='' run_cutover
 chk "staged file removed" 1 "$(grep -c RM_STAGED <<<"${RECIPE_TRACE//|/$'\n'}")"
 chk "app booted"          1 "$(grep -cx 'kamal:app boot' <<<"${RECIPE_TRACE//|/$'\n'}")"
 
-echo "27. a failed copy does not boot, and keeps the file the retry needs"
+echo "28. a failed copy does not boot, and keeps the file the retry needs"
 # MIGRATION_RUN_RESET drops the schema before loading, so a copy that dies
 # partway leaves the database empty or half-populated. Booting serves that.
 # The `sudo rm` is the other half: it destroys the staged SQLite file, so a
@@ -478,7 +518,7 @@ case "$RECIPE_OUT" in
   *) echo "  FAIL silent or partial: $RECIPE_OUT"; fail=1 ;;
 esac
 
-echo "28. a failed revoke does not boot the credential-bearing container"
+echo "29. a failed revoke does not boot the credential-bearing container"
 # collavre_user is the role in DATABASE_URL. Booting while it is still a
 # superuser hands every app container that privilege.
 FAIL_COPY='' FAIL_REVOKE=1 FAIL_SCP='' FAIL_STAGE='' run_cutover
@@ -488,7 +528,7 @@ case "$RECIPE_OUT" in
   *) echo "  FAIL silent: $RECIPE_OUT"; fail=1 ;;
 esac
 
-echo "29. both failing reports both, not just the first"
+echo "30. both failing reports both, not just the first"
 FAIL_COPY=1 FAIL_REVOKE=1 FAIL_SCP='' FAIL_STAGE='' run_cutover
 chk "app NOT booted" 0 "$(grep -cx 'kamal:app boot' <<<"${RECIPE_TRACE//|/$'\n'}")"
 case "$RECIPE_OUT" in
@@ -496,7 +536,7 @@ case "$RECIPE_OUT" in
   *) echo "  FAIL one masked the other: $RECIPE_OUT"; fail=1 ;;
 esac
 
-echo "30. a failed scp never converts, so a stale snapshot cannot be restored"
+echo "31. a failed scp never converts, so a stale snapshot cannot be restored"
 # The task loads from the file in the VOLUME, not from the one scp just sent.
 # Case 24 deliberately keeps the staged file so a retry need not re-copy — so
 # on a retry the volume holds the previous attempt's snapshot. Ungated, a
@@ -512,7 +552,7 @@ case "$RECIPE_OUT" in
   *) echo "  FAIL silent or vague: $RECIPE_OUT"; fail=1 ;;
 esac
 
-echo "31. a failed install into the volume is caught too, not just the scp"
+echo "32. a failed install into the volume is caught too, not just the scp"
 # scp can succeed to /tmp and the privileged install still fail — no space,
 # no docker group, volume gone.
 FAIL_COPY='' FAIL_REVOKE='' FAIL_SCP='' FAIL_STAGE=1 run_cutover
@@ -520,7 +560,7 @@ chk "no conversion ran"    0 "$(grep -cx 'kamal:app exec' <<<"${RECIPE_TRACE//|/
 chk "no superuser granted" 0 "$(grep -cx GRANT <<<"${RECIPE_TRACE//|/$'\n'}")"
 chk "app NOT booted"       0 "$(grep -cx 'kamal:app boot' <<<"${RECIPE_TRACE//|/$'\n'}")"
 
-echo "32. staging renames into place rather than writing the live path directly"
+echo "33. staging renames into place rather than writing the live path directly"
 # An interrupted copy must leave the previous file intact, not a truncated
 # database the next run would happily convert from.
 case "$recipe" in
@@ -555,12 +595,12 @@ STUB
   rm -rf "$work"
 }
 
-echo "33. a clean fresh install prints the admin password and boots"
+echo "34. a clean fresh install prints the admin password and boots"
 FAIL_LOAD='' run_fresh
 chk "app stopped first" 1 "$(grep -cx 'kamal:app stop' <<<"${FRESH_TRACE//|/$'\n'}")"
 chk "app booted"        1 "$(grep -cx 'kamal:app boot' <<<"${FRESH_TRACE//|/$'\n'}")"
 
-echo "34. a failed schema load does not boot the app onto a partial schema"
+echo "35. a failed schema load does not boot the app onto a partial schema"
 # db:schema:load drops and recreates every table, and db:seed is what creates
 # the first admin — so a load that resets the database but does not finish
 # leaves an app with no way to sign in and no owner on any record.
@@ -580,7 +620,7 @@ LOGGED=""
 # shellcheck disable=SC2329  # called by install_authorized_keys, eval'd from the script
 log() { LOGGED="$LOGGED $*"; }
 
-echo "35. the deploy user's own keys are not copied onto themselves"
+echo "36. the deploy user's own keys are not copied onto themselves"
 # APP_SSH_USER=ubuntu — src and dest are one file.
 h=$(mktemp -d); mkdir -p "$h/ubuntu/.ssh"
 printf 'ssh-ed25519 CLOUDKEY cloud\n' > "$h/ubuntu/.ssh/authorized_keys"
@@ -593,13 +633,13 @@ case "$LOGGED" in
   *) echo "  FAIL no explanation: $LOGGED"; fail=1 ;;
 esac
 
-echo "36. a separate deploy user still inherits the cloud user's keys"
+echo "37. a separate deploy user still inherits the cloud user's keys"
 mkdir -p "$h/collavre/.ssh"; : > "$h/collavre/.ssh/authorized_keys"
 SSH_PUBLIC_KEY="" LOGGED=""
 install_authorized_keys "$h/collavre/.ssh/authorized_keys" "$h"
 chk "cloud key copied" 1 "$(grep -c CLOUDKEY "$h/collavre/.ssh/authorized_keys")"
 
-echo "37. an explicit SSH_PUBLIC_KEY is added once, not once per run"
+echo "38. an explicit SSH_PUBLIC_KEY is added once, not once per run"
 # shellcheck disable=SC2034  # read by install_authorized_keys, eval'd from the script
 SSH_PUBLIC_KEY="ssh-ed25519 EXPLICIT me"
 install_authorized_keys "$h/collavre/.ssh/authorized_keys" "$h"
@@ -619,7 +659,7 @@ NEW="ssh-ed25519 NEWKEY current"
 OPERATOR="ssh-rsa OPKEY someone-else"
 st=$(mktemp -d)
 
-echo "38. rotating SSH_PUBLIC_KEY withdraws the key the last run installed"
+echo "39. rotating SSH_PUBLIC_KEY withdraws the key the last run installed"
 printf '%s\n%s\n' "$OLD" "$OPERATOR" > "$AK"
 printf '%s\n' "$OLD" > "$st/ssh_public_key"
 SSH_PUBLIC_KEY="$NEW" LOGGED=""
@@ -630,18 +670,18 @@ chk "the retired key is gone"      0 "$(grep -cxF "$OLD" "$AK")"
 chk "an operator's own key stays"  1 "$(grep -cxF "$OPERATOR" "$AK")"
 chk "state advanced to the new key" "$NEW" "$(cat "$st/ssh_public_key")"
 
-echo "39. an unchanged SSH_PUBLIC_KEY withdraws nothing"
+echo "40. an unchanged SSH_PUBLIC_KEY withdraws nothing"
 before="$(cat "$AK")"
 revoke_prior_ssh_key "$AK" "$st/ssh_public_key"
 chk "authorized_keys untouched" "$before" "$(cat "$AK")"
 
-echo "40. an empty SSH_PUBLIC_KEY means 'keep the cloud keys', not 'retire mine'"
+echo "41. an empty SSH_PUBLIC_KEY means 'keep the cloud keys', not 'retire mine'"
 # Dropping the variable from a re-run must not strand the operator.
 SSH_PUBLIC_KEY=""
 revoke_prior_ssh_key "$AK" "$st/ssh_public_key"
 chk "nothing withdrawn" "$before" "$(cat "$AK")"
 
-echo "41. the predecessor is never withdrawn before the successor is in place"
+echo "42. the predecessor is never withdrawn before the successor is in place"
 # An interrupted run must leave two usable keys, never zero.
 printf '%s\n' "$OLD" > "$AK"
 printf '%s\n' "$OLD" > "$st/ssh_public_key"
@@ -649,7 +689,7 @@ SSH_PUBLIC_KEY="$NEW"
 revoke_prior_ssh_key "$AK" "$st/ssh_public_key"     # successor not added yet
 chk "the old key still lets you in" 1 "$(grep -cxF "$OLD" "$AK")"
 
-echo "42. first run and an already-absent key are no-ops"
+echo "43. first run and an already-absent key are no-ops"
 st2=$(mktemp -d)
 printf '%s\n' "$NEW" > "$AK"
 # shellcheck disable=SC2034  # read by revoke_prior_ssh_key, eval'd from the script
@@ -661,7 +701,7 @@ printf '%s\n' "$OLD" > "$st2/ssh_public_key"        # recorded but already remov
 revoke_prior_ssh_key "$AK" "$st2/ssh_public_key"
 chk "still just the new key" "$NEW" "$(cat "$AK")"
 
-echo "43. a rewrite that cannot be completed keeps the old key instead of none"
+echo "44. a rewrite that cannot be completed keeps the old key instead of none"
 # The realistic trigger is a full disk: `grep -vxF > $tmp` writes nothing and
 # exits 2, the `|| true` hides it, and writing that empty result back would
 # leave authorized_keys with no keys at all — locking the deploy account out of
@@ -686,7 +726,7 @@ case "$LOGGED" in
   *) echo "  FAIL silent or reported as withdrawn: $LOGGED"; fail=1 ;;
 esac
 
-echo "44. a rewrite that stops PART WAY also keeps the old key instead of none"
+echo "45. a rewrite that stops PART WAY also keeps the old key instead of none"
 # Case 40 is the write that produces nothing. This is the write that produces
 # some of the file, which a size test cannot tell from a good one — and it is
 # the likelier shape on a nearly-full disk. It matters more than it looks:
@@ -719,7 +759,7 @@ case "$LOGGED" in
   *) echo "  FAIL silent or reported as withdrawn: $LOGGED"; fail=1 ;;
 esac
 
-echo "45. the scratch file is staged beside authorized_keys, not in TMPDIR"
+echo "46. the scratch file is staged beside authorized_keys, not in TMPDIR"
 # Same filesystem, so the rewrite cannot fail for space the staging just
 # proved is available, and a full or unwritable /tmp is not on its own able to
 # break the file the operator logs in with.
@@ -775,7 +815,7 @@ psql_as_postgres() {
 log() { LOGGED="$LOGGED $*"; }
 rotate() { SQL=""; LOGGED=""; reassign_prior_db_role "$@"; }
 
-echo "46. rotating DB_USER moves the tables and retires the old credential"
+echo "47. rotating DB_USER moves the tables and retires the old credential"
 # ALTER DATABASE ... OWNER only moves the database. Every table and sequence
 # the app created stays with the old role, so the new one in DATABASE_URL gets
 # "permission denied" on its own data — while the old role keeps LOGIN and the
@@ -787,11 +827,11 @@ chk "ownership moved, then login revoked" \
     '|REASSIGN OWNED BY "collavre_user" TO "collavre_app"|ALTER ROLE "collavre_user" NOLOGIN' \
     "$SQL"
 
-echo "47. an unchanged DB_USER touches nothing"
+echo "48. an unchanged DB_USER touches nothing"
 rotate collavre_user "$d3/db_user"
 chk "no SQL" "" "$SQL$LOGGED"
 
-echo "48. a superuser predecessor is reported, never disabled"
+echo "49. a superuser predecessor is reported, never disabled"
 # DB_USER=postgres on a first run is legal. NOLOGIN on the cluster superuser
 # locks every operator out of administering it — peer auth needs LOGIN too, so
 # there is no way back in.
@@ -804,7 +844,7 @@ case "$LOGGED" in
   *) echo "  FAIL silent: $LOGGED"; fail=1 ;;
 esac
 
-echo "49. first run, emptied marker and a dropped role are all no-ops"
+echo "50. first run, emptied marker and a dropped role are all no-ops"
 d4=$(mktemp -d)
 ROLE_IS_SUPER=f
 rotate collavre_user "$d4/db_user"          # no marker yet
@@ -833,7 +873,7 @@ mk_lsclusters() {   # mk_lsclusters <name> <lines...>
 CLUSTER_BIN_DIR="$(mktemp -d)"
 PATH="$CLUSTER_BIN_DIR:$PATH"
 
-echo "50. a bumped PG_MAJOR that would land on a second port is refused"
+echo "51. a bumped PG_MAJOR that would land on a second port is refused"
 # pg_createcluster allocates the first free port from 5432 up, so installing a
 # new major version beside an existing one puts it on 5433 — while psql, the
 # database, the backups and DATABASE_URL all keep using 5432. Provisioning would
@@ -848,7 +888,7 @@ case "$out" in
   *) echo "  FAIL unhelpful message: $out"; fail=1 ;;
 esac
 
-echo "51. an existing cluster of the RIGHT version on the wrong port is refused too"
+echo "52. an existing cluster of the RIGHT version on the wrong port is refused too"
 # The other way in: the operator moved 17 to 5433 by hand, or a previous run
 # created it beside something since removed. Everything downstream names 5432.
 mk_lsclusters pg_ls_17_5433 '17  main    5433 online postgres /var/lib/postgresql/17/main /var/log/x'
@@ -859,7 +899,7 @@ case "$out" in
   *) echo "  FAIL unhelpful message: $out"; fail=1 ;;
 esac
 
-echo "52. the supported layouts are allowed through"
+echo "53. the supported layouts are allowed through"
 # A bare host (no postgresql-common yet) and the ordinary re-run must not be
 # refused — this guard exists to catch a silent miss, not to block convergence.
 out="$( (ensure_cluster_on_default_port pg_ls_absent) 2>&1 )"

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -373,6 +373,16 @@ usermod_host() {   # usermod -g <group> <user>
 usermod() { usermod_host "$@"; }
 groupadd() { :; }
 log() { LOGGED="$LOGGED $*"; }
+# The suite is unprivileged and must not depend on whether its host happens to
+# carry a real /etc/sudoers.d/90-collavre-* file. Production runs as root; the
+# explicit failure case at the end overrides this seam with a failing rm.
+rm() {
+  local arg
+  for arg in "$@"; do
+    case "$arg" in /etc/sudoers.d/90-collavre-*) return 0 ;; esac
+  done
+  command rm "$@"
+}
 revoke() { REVOKED=""; USERMOD=""; LOGGED=""; revoke_prior_deploy_user "$@"; }
 
 echo "11. the deploy user a re-run replaces loses its root-equivalent access"
@@ -482,7 +492,7 @@ chk "the retry revokes it"     0 "$(printf '%s\n' "$GROUPS_OF" | tr ' ' '\n' | g
 chk "and it leaves the queue" 0 "$(grep -cxF legacy "$d4/deploy_users")"
 chk "while the marker still names the account in use" "deploybot" "$(cat "$d4/deploy_user")"
 
-unset -f id gpasswd usermod usermod_host groupadd log revoke supp_holds drop_word
+unset -f id gpasswd usermod usermod_host groupadd log rm revoke supp_holds drop_word
 
 # --------------------------------------------------------------------------
 # One name cannot describe a host that has rotated twice, so the cases below

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -21,7 +21,7 @@ SRC="${1:-$ROOT/script/lightsail_launch.sh}"
 # die() is a one-liner; the others run to the first column-1 closing brace.
 eval "$(awk '
   /^die\(\) \{/ { print; next }
-  /^(ensure_block|ensure_sudoers|in_group|write_state_file|record_deploy_user_grant|revoke_deploy_user_access|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|install_deploy_ssh_dir|reassign_prior_db_role|refuse_superuser_db_rotation|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps|dedupe_authorized_keys|install_staged_authorized_keys|postgresql_conf_includes_confd|role_owns_app_objects|refuse_db_name_change|refuse_defaulted_config_change|refuse_unusable_db_identifier|refuse_unparsable_ssh_key|passwd_home|ssh_key_holder|adopt_legacy_ssh_key_marker|record_db_role_grant|reassign_one_db_role|record_ssh_key_grant)\(\) \{/ { f = 1 }
+  /^(ensure_block|ensure_sudoers|in_group|write_state_file|record_deploy_user_grant|revoke_deploy_user_access|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|install_deploy_ssh_dir|reassign_prior_db_role|refuse_superuser_db_rotation|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps|dedupe_authorized_keys|install_staged_authorized_keys|postgresql_conf_includes_confd|role_owns_app_objects|refuse_db_name_change|refuse_defaulted_config_change|refuse_unusable_db_identifier|refuse_unparsable_ssh_key|passwd_home|ssh_key_holder|adopt_legacy_ssh_key_marker|record_db_role_grant|reassign_one_db_role|record_ssh_key_grant|refuse_root_deploy_user)\(\) \{/ { f = 1 }
   f { print }
   f && /^\}/ { f = 0 }
 ' "$SRC")"
@@ -39,6 +39,7 @@ for fn in die ensure_block ensure_sudoers in_group write_state_file \
           refuse_unusable_db_identifier refuse_unparsable_ssh_key \
           passwd_home ssh_key_holder \
           record_db_role_grant reassign_one_db_role record_ssh_key_grant \
+          refuse_root_deploy_user \
           adopt_legacy_ssh_key_marker; do
   declare -F "$fn" >/dev/null || {
     echo "could not extract $fn() from $SRC — has the definition moved?" >&2
@@ -3135,8 +3136,31 @@ DB_EXISTS=1
 refuse_db_name_change collavre_production "$dn4"
 chk "proceeds rather than refusing against an empty name" 0 "$?"
 
+echo "97a. but an empty marker does not answer for the record it lost"
+# 97 above is only half the question, and the half that passes either way: the
+# database it names exists, so there is nothing to protect and every revision
+# proceeds. The other half is the one that matters. An empty db_name is not
+# "nothing was recorded here" — it is "a name was recorded and this run cannot
+# read it", which is the same state case 96 refuses on a host too old to have
+# written one at all. The earlier form returned 0 from inside the `-f` branch,
+# so an empty file skipped the comparison AND the cluster fallback beneath it,
+# and the guard passed a changed DB_NAME on a host it was installed to defend.
+#
+# That is reachable from this PR's own write: `> "$STATE_DIR/db_name"`
+# truncates before it writes, so a run interrupted between the two leaves
+# exactly this file.
+dn5=$(mktemp -d); : > "$dn5/db_name"; printf 'collavre_user\n' > "$dn5/db_user"
+DB_EXISTS=0 DB_LIST="collavre_production"
+out="$( (refuse_db_name_change collavre_typo "$dn5") 2>&1 )"
+chk "an unreadable marker is refused, not adopted" 1 "$?"
+case "$out" in
+  *"provisioned before"*"does not exist"*"collavre_production"*)
+    echo "  ok   and it lists the database the data is actually in" ;;
+  *) echo "  FAIL passed or was unhelpful: $out"; fail=1 ;;
+esac
+
 unset -f psql_as_postgres
-rm -rf "$dn" "$dn2" "$dn3" "$dn4"
+rm -rf "$dn" "$dn2" "$dn3" "$dn4" "$dn5"
 
 # --- adopt_legacy_ssh_key_marker --------------------------------------------
 #
@@ -4168,6 +4192,74 @@ case "$out" in
   *"already serves 5432"*) echo "  ok   on the version, which is the useful answer" ;;
   *) echo "  FAIL reported the name over the version: $out"; fail=1 ;;
 esac
+
+echo "123. a UID 0 deploy user is refused before any account is touched"
+# Step 3 writes PermitRootLogin no into sshd_config.d and then, further down the
+# same step, arms $APP_SSH_USER and prints it as KAMAL_SSH_USER. Nothing between
+# the two rejected the account sshd had just been told to turn away, so the run
+# reported success over a host no deploy could authenticate to.
+#
+# shellcheck disable=SC2329  # called by refuse_root_deploy_user
+id() { case "$2" in root|toor) echo 0 ;; collavre) echo 1001 ;; *) return 1 ;; esac; }
+out="$( (refuse_root_deploy_user root) 2>&1 )"
+chk "exits non-zero" 1 "$?"
+case "$out" in
+  *"PermitRootLogin no"*"KAMAL_SSH_USER=root"*"Nothing has been changed"*)
+    echo "  ok   names the contradiction, not just the rule" ;;
+  *) echo "  FAIL unhelpful: $out"; fail=1 ;;
+esac
+# By UID, not by the name. An account aliased to 0 is locked out by the same
+# drop-in, and refusing only the literal 'root' would read as a check that had
+# been done.
+out="$( (refuse_root_deploy_user toor) 2>&1 )"
+chk "an aliased UID 0 account is refused too" 1 "$?"
+
+echo "123a. and an ordinary deploy user is not"
+# The control that matters: this guard runs on every invocation, ahead of
+# refuse_defaulted_config_change, so a false positive here refuses every run.
+refuse_root_deploy_user collavre
+chk "an existing ordinary account proceeds" 0 "$?"
+# The default first-run shape. `id` fails because adduser has not run yet, and
+# treating "cannot resolve" as "might be root" would refuse every fresh host.
+refuse_root_deploy_user brand-new
+chk "an account that does not exist yet proceeds" 0 "$?"
+unset -f id
+
+echo "124. the database markers are replaced, not truncated then filled"
+# Same class as launch.env and db_password on this PR, and the reason the write
+# is worth fixing rather than only the read: `>` truncates before it writes, so
+# an interrupted run leaves the marker present and empty — and 97a is what an
+# empty db_name then does to the guard. The two markers are checked through the
+# helper the script now routes them through.
+sd=$(mktemp -d)
+printf 'collavre_production\n' > "$sd/db_name"
+before=$(inode "$sd/db_name")
+write_state_file "$sd/db_name" "collavre_renamed"$'\n'
+chk "the value is replaced"          "collavre_renamed" "$(cat "$sd/db_name")"
+chk "by rename, not in place"        1 "$([ "$(inode "$sd/db_name")" != "$before" ] && echo 1 || echo 0)"
+chk "and the mode is the default"    644 "$(file_mode "$sd/db_name")"
+# A staging write that fails must leave the previous value readable, which is
+# the whole point: the reader has no way to tell an empty marker from a lost
+# one, so it must never see either.
+printf 'collavre_user\n' > "$sd/db_user"
+mktemp() { return 1; }
+write_state_file "$sd/db_user" "collavre_next"$'\n'
+chk "a failed write reports it"                  1 "$?"
+chk "and the previous value is still readable"   "collavre_user" "$(cat "$sd/db_user")"
+unset -f mktemp
+rm -rf "$sd"
+
+# The assertions above pass against the previous revision too — write_state_file
+# was already correct there, and the defect was that these two markers did not
+# go through it. So the regression control is at the call site, in the source:
+# nothing may replace a durable marker with a redirection, which is the one
+# thing the behavioural cases cannot see.
+chk "db_name is not written by redirection" \
+  0 "$(grep -c '> *"\$STATE_DIR/db_name"' "$SRC")"
+chk "db_user is not written by redirection" \
+  0 "$(grep -c '> *"\$STATE_DIR/db_user"' "$SRC")"
+chk "both go through write_state_file" \
+  2 "$(grep -cE 'write_state_file "\$STATE_DIR/db_(name|user)"' "$SRC")"
 
 echo
 if [ "$fail" = 0 ]; then echo "ALL PASS"; else echo "FAILURES"; fi

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -4418,6 +4418,41 @@ chk "no queue is extended by a bare append" \
 chk "all three record_* functions go through the helper" \
   3 "$(grep -c 'append_state_line "\$set_file"' "$SRC")"
 
+echo "125a. a rotation past a torn queue entry does not strand the account"
+# The end-to-end consequence of case 125's mechanism, and the reason the torn
+# append is worse than a stale record rather than equivalent to one. The retry
+# leaves `collavre_collavre_a` in the queue; the next rotation's loop tests
+# `id -u` on it, finds no such account, and takes the `|| continue` path — which
+# is correct for an account that is genuinely gone and wrong for a fragment.
+# The queue then holds one name, the current user, and looks converged, while
+# the account it was glued from keeps docker and sudo with nothing recording it.
+sd=$(mktemp -d)
+: > "$sd/groups"
+# shellcheck disable=SC2329  # called by revoke_prior_deploy_user
+id() { case "$1" in -u) grep -qx "$2" "$sd/accounts" ;; esac; }
+# shellcheck disable=SC2329  # called by revoke_prior_deploy_user
+revoke_deploy_user_access() { sed -i.bak "/^$1 /d" "$sd/groups"; }
+printf 'collavre_a\ncollavre_b\n' > "$sd/accounts"
+
+printf 'collavre_' > "$sd/deploy_users"          # the torn append
+printf 'collavre_a docker sudo\n' >> "$sd/groups"
+record_deploy_user_grant collavre_a "$sd/deploy_users" "$sd/deploy_user"
+chk "the retry records the account on a line of its own" \
+  1 "$(grep -cxF collavre_a "$sd/deploy_users")"
+
+printf 'collavre_a\n' > "$sd/deploy_user"
+printf 'collavre_b docker sudo\n' >> "$sd/groups"
+revoke_prior_deploy_user collavre_b "$sd/deploy_user" "$sd/deploy_users" >/dev/null 2>&1
+chk "and the rotation strips it" 0 "$(grep -c '^collavre_a ' "$sd/groups")"
+# The control in the other direction. A fragment names nobody and grants
+# nothing, so it must *not* be kept queued for a retry that can never succeed —
+# it leaves by the same id -u path, which is the right answer for it.
+chk "the fragment is not retried forever" 0 "$(grep -c '^collavre_$' "$sd/deploy_users")"
+chk "and the current user stays queued for its own successor" \
+  1 "$(grep -cxF collavre_b "$sd/deploy_users")"
+unset -f id revoke_deploy_user_access
+rm -rf "$sd"
+
 echo "126. a deploy account that cannot run a command is refused"
 # refuse_root_deploy_user states this invariant and tests only UID 0: its own
 # message is "'$user' could never log in, while the summary would still print

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -17,12 +17,13 @@ SRC="${1:-$ROOT/script/lightsail_launch.sh}"
 # die() is a one-liner; the others run to the first column-1 closing brace.
 eval "$(awk '
   /^die\(\) \{/ { print; next }
-  /^(ensure_block|ensure_sudoers|revoke_prior_deploy_user)\(\) \{/ { f = 1 }
+  /^(ensure_block|ensure_sudoers|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule)\(\) \{/ { f = 1 }
   f { print }
   f && /^\}/ { f = 0 }
 ' "$SRC")"
 
-for fn in die ensure_block ensure_sudoers revoke_prior_deploy_user; do
+for fn in die ensure_block ensure_sudoers revoke_prior_deploy_user \
+          ensure_ufw_rule ssh_already_allowed ensure_ssh_rule; do
   declare -F "$fn" >/dev/null || {
     echo "could not extract $fn() from $SRC — has the definition moved?" >&2
     exit 1
@@ -210,6 +211,110 @@ revoke deploybot "$d2/deploy_user"
 chk "account is gone"  "" "$REVOKED$LOGGED"
 
 unset -f id gpasswd log revoke
+
+# --------------------------------------------------------------------------
+# The firewall helpers shell out to ufw, so it is stubbed: every invocation is
+# recorded, and STATUS stands in for what `ufw status` would print.
+# --------------------------------------------------------------------------
+UFW_CALLS=""
+STATUS=""
+LOGGED=""
+ufw() {
+  if [ "$1" = status ]; then printf '%s\n' "$STATUS"; return 0; fi
+  UFW_CALLS="$UFW_CALLS|$*"
+}
+log() { LOGGED="$LOGGED $*"; }
+
+echo "15. the postgres rule is added once and recorded"
+d=$(mktemp -d)
+UFW_CALLS=""
+ensure_ufw_rule postgres "allow from 172.17.0.0/16 to 172.17.0.1 port 5432 proto tcp" \
+  "$d/ufw_postgres"
+chk "rule added" "|allow from 172.17.0.0/16 to 172.17.0.1 port 5432 proto tcp" "$UFW_CALLS"
+chk "recorded"   "allow from 172.17.0.0/16 to 172.17.0.1 port 5432 proto tcp" \
+  "$(cat "$d/ufw_postgres")"
+
+echo "16. an unchanged rule deletes nothing"
+# The common re-run. ufw skips re-adding an identical rule itself, so the only
+# thing that must not happen here is a delete.
+UFW_CALLS=""; LOGGED=""
+ensure_ufw_rule postgres "allow from 172.17.0.0/16 to 172.17.0.1 port 5432 proto tcp" \
+  "$d/ufw_postgres"
+chk "no delete" 0 "$(printf '%s' "$UFW_CALLS" | grep -c delete)"
+
+echo "17. a changed rule withdraws the old one instead of accumulating"
+# Without this, moving DB_BIND_ADDRESS or DOCKER_SUBNETS would leave the
+# previous subnet reaching 5432 for the life of the host.
+UFW_CALLS=""; LOGGED=""
+ensure_ufw_rule postgres "allow from 10.200.0.0/16 to 172.18.0.1 port 5432 proto tcp" \
+  "$d/ufw_postgres"
+chk "old rule deleted" \
+  "|delete allow from 172.17.0.0/16 to 172.17.0.1 port 5432 proto tcp" \
+  "$(printf '%s' "$UFW_CALLS" | grep -o '|delete[^|]*')"
+chk "new rule added" 1 "$(printf '%s' "$UFW_CALLS" | grep -c '|allow from 10.200.0.0/16')"
+chk "state advanced" "allow from 10.200.0.0/16 to 172.18.0.1 port 5432 proto tcp" \
+  "$(cat "$d/ufw_postgres")"
+
+echo "18. unrelated operator rules are never touched"
+# The whole reason `ufw reset` is gone: a re-run must not disturb a VPN,
+# monitoring or allowlist rule this script knows nothing about.
+chk "only our own rule deleted" 1 "$(printf '%s' "$UFW_CALLS" | grep -c delete)"
+chk "no reset"                  0 "$(printf '%s' "$UFW_CALLS" | grep -c reset)"
+
+echo "19. SSH already allowed is detected in every form ufw prints it"
+for s in "22/tcp                     ALLOW       Anywhere" \
+         "22                         ALLOW IN    Anywhere" \
+         "OpenSSH                    ALLOW       Anywhere" \
+         "22/tcp (v6)                ALLOW       Anywhere (v6)" \
+         "22/tcp                     ALLOW IN    203.0.113.4"; do
+  STATUS="$s"
+  ssh_already_allowed
+  chk "detected: ${s%% *}${s##*ALLOW}" 0 "$?"
+done
+
+echo "20. a narrowed SSH rule survives the re-run that finds it"
+# The rule an operator most plausibly tightens by hand. Re-adding the blanket
+# `allow OpenSSH` on top would reopen 22 to the internet and look like a no-op.
+STATUS="22/tcp                     ALLOW IN    203.0.113.4"
+UFW_CALLS=""
+ensure_ssh_rule
+chk "blanket rule not added" "" "$UFW_CALLS"
+
+echo "21. no SSH rule at all means one is added, never assumed"
+# Failing the other way enables a deny-by-default firewall on a host with no
+# way back in, so every uncertain status must land here.
+for s in "Status: inactive" \
+         "80/tcp                     ALLOW       Anywhere" \
+         "2222/tcp                   ALLOW       Anywhere" \
+         "22/tcp                     DENY        Anywhere" \
+         ""; do
+  STATUS="$s"
+  UFW_CALLS=""
+  ensure_ssh_rule
+  chk "rule added for [${s:-empty status}]" "|allow OpenSSH" "$UFW_CALLS"
+done
+
+echo "22. a missing OpenSSH profile falls back to the port, it does not give up"
+# `ufw allow OpenSSH` exits 1 where openssh-server is not installed, and the
+# `ufw --force enable` that follows would then close 22 on a host reachable
+# only over 22.
+ufw() {
+  if [ "$1" = status ]; then printf '%s\n' "$STATUS"; return 0; fi
+  UFW_CALLS="$UFW_CALLS|$*"
+  [ "$2" != OpenSSH ]   # stands in for "Could not find a profile matching"
+}
+STATUS="Status: inactive"; UFW_CALLS=""; LOGGED=""
+ensure_ssh_rule
+chk "port form used"  "|allow OpenSSH|allow 22/tcp" "$UFW_CALLS"
+chk "reports success" 0 "$?"
+# ufw's own "Could not find a profile" is suppressed, so the recovery has to
+# say so itself or the log reads as if nothing happened.
+case "$LOGGED" in
+  *"allowing 22/tcp directly"*) echo "  ok   the fallback is on the record" ;;
+  *) echo "  FAIL silent fallback: $LOGGED"; fail=1 ;;
+esac
+
+unset -f ufw log
 
 echo
 if [ "$fail" = 0 ]; then echo "ALL PASS"; else echo "FAILURES"; fi

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -21,7 +21,7 @@ SRC="${1:-$ROOT/script/lightsail_launch.sh}"
 # die() is a one-liner; the others run to the first column-1 closing brace.
 eval "$(awk '
   /^die\(\) \{/ { print; next }
-  /^(ensure_block|ensure_sudoers|in_group|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|install_deploy_ssh_dir|reassign_prior_db_role|refuse_superuser_db_rotation|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps)\(\) \{/ { f = 1 }
+  /^(ensure_block|ensure_sudoers|in_group|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|install_deploy_ssh_dir|reassign_prior_db_role|refuse_superuser_db_rotation|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps|dedupe_authorized_keys)\(\) \{/ { f = 1 }
   f { print }
   f && /^\}/ { f = 0 }
 ' "$SRC")"
@@ -31,7 +31,7 @@ for fn in die ensure_block ensure_sudoers in_group revoke_prior_deploy_user \
           install_authorized_keys install_deploy_ssh_dir reassign_prior_db_role \
           refuse_superuser_db_rotation revoke_prior_ssh_key \
           ensure_cluster_on_default_port ensure_swapfile allocate_swapfile \
-          ensure_docker_log_caps; do
+          ensure_docker_log_caps dedupe_authorized_keys; do
   declare -F "$fn" >/dev/null || {
     echo "could not extract $fn() from $SRC — has the definition moved?" >&2
     exit 1
@@ -1188,6 +1188,38 @@ case "$out" in
   *) echo "  FAIL unhelpful message: $out"; fail=1 ;;
 esac
 DISK_FREE_MIB=""
+
+echo "63a. swap that is active but absent from fstab gets its entry"
+# The size matches, so the early return fires — but this host loses its swap at
+# the next reboot, which is when a low-memory instance most needs it. Reached by
+# an operator who ran swapon by hand, or a run interrupted between swapon and
+# the fstab write below it.
+new_swap_env ""
+dd if=/dev/zero of="$SWAPFILE" bs=1048576 count=8 status=none
+SWAPPED_ON="$SWAPFILE"                    # active, but new_swap_env wrote no entry
+ino="$(inode "$SWAPFILE")"
+SWAP_SIZE_MB=8 ensure_swapfile "$SWAPFILE" "$FSTAB"
+chk "fstab entry written"   1 "$(grep -c "^$SWAPFILE none swap" "$FSTAB")"
+chk "the file is untouched" "$ino" "$(inode "$SWAPFILE")"
+chk "still enabled"         "$SWAPFILE" "$SWAPPED_ON"
+chk "one managed block"     1 "$(grep -c '# BEGIN collavre:swap' "$FSTAB")"
+
+echo "63b. and the ordinary re-run stays a no-op"
+new_swap_env 8
+SWAP_SIZE_MB=8 ensure_swapfile "$SWAPFILE" "$FSTAB"
+chk "still one managed block" 1 "$(grep -c '# BEGIN collavre:swap' "$FSTAB")"
+chk "still one swap line"     1 "$(grep -c "^$SWAPFILE none swap" "$FSTAB")"
+chk "silent"                  "" "$LOGGED"
+
+echo "63c. SWAP_SIZE_MB=0 clears a stale fstab line, but writes none on a bare host"
+new_swap_env ""
+ensure_block "$FSTAB" swap "$SWAPFILE none swap sw 0 0"   # file deleted by hand
+SWAP_SIZE_MB=0 ensure_swapfile "$SWAPFILE" "$FSTAB"
+chk "the stale line is gone" 0 "$(grep -c 'none swap' "$FSTAB")"
+new_swap_env ""
+SWAP_SIZE_MB=0 ensure_swapfile "$SWAPFILE" "$FSTAB"
+chk "no block added to a bare host" 0 "$(grep -c '# BEGIN collavre:swap' "$FSTAB")"
+
 unset -f swapon swapoff mkswap fallocate dd
 
 echo "64. an unsupported DB_PORT is refused before anything is installed"
@@ -1548,6 +1580,60 @@ FAIL_DUMP='' FAIL_XFER='' FAIL_RESTORE='' run_move
 # filename alone would pass without ever staging anything.
 chk "every transfer staged under .incoming" 0 \
   "$(grep '^scp:' <<<"${MOVE_TRACE//|/$'\n'}" | grep -cv '\.incoming$')"
+
+# --- dedupe_authorized_keys -------------------------------------------------
+#
+# `sort -u -o F F` rewrote authorized_keys in place. A sort stopped after it has
+# truncated the output — an OOM kill on the instance this script provisions swap
+# for — leaves the file holding a lexical prefix of itself, so the key that goes
+# missing is whichever sorts last. `ulimit -f` reproduces that deterministically.
+
+new_keys_env() {
+  KEYDIR="$(mktemp -d)"; KEYS="$KEYDIR/authorized_keys"
+  : > "$KEYS"
+  for i in $(seq 1 200); do
+    printf 'ssh-ed25519 %s%03d operator%d@desk\n' \
+      "$(head -c 60 /dev/zero | tr '\0' 'A')" "$i" "$i" >> "$KEYS"
+  done
+  printf '%s\n' "$KEY_CURRENT" >> "$KEYS"
+  printf '%s\n' "$KEY_CURRENT" >> "$KEYS"        # a duplicate for it to remove
+  LOGGED=""
+}
+KEY_CURRENT='ssh-ed25519 zzCURRENT current@laptop'   # sorts last, so it is the casualty
+
+echo "83. the ordinary case still drops duplicates"
+new_keys_env
+before=$(wc -l < "$KEYS")
+dedupe_authorized_keys "$KEYS" "$KEY_CURRENT"
+chk "one line shorter"     "$(( before - 1 ))" "$(wc -l < "$KEYS" | tr -d ' ')"
+chk "the current key kept" 1 "$(grep -cxF "$KEY_CURRENT" "$KEYS")"
+chk "silent"               "" "$LOGGED"
+chk "no scratch file left" 0 "$(find "$KEYDIR" -name 'authorized_keys.sort.*' | wc -l | tr -d ' ')"
+
+echo "84. a sort that dies part way leaves authorized_keys alone"
+new_keys_env
+before_l=$(wc -l < "$KEYS" | tr -d ' '); before_b=$(wc -c < "$KEYS" | tr -d ' ')
+( ulimit -f 8; dedupe_authorized_keys "$KEYS" "$KEY_CURRENT" ) >/dev/null 2>&1
+chk "not truncated"  "$before_l" "$(wc -l < "$KEYS" | tr -d ' ')"
+chk "byte-identical" "$before_b" "$(wc -c < "$KEYS" | tr -d ' ')"
+# Both copies are still there — the file was not rewritten at all, which is the
+# point. Deduplication is cosmetic; keeping every key is not.
+chk "the current key survives" 2 "$(grep -cxF "$KEY_CURRENT" "$KEYS")"
+chk "no scratch file left" 0 "$(find "$KEYDIR" -name 'authorized_keys.sort.*' | wc -l | tr -d ' ')"
+
+echo "85. it stages beside the target, not in TMPDIR"
+# Same filesystem, so the swap is one rename and a full or missing /tmp cannot
+# reach the file the operator logs in with. Asserted on the path mktemp is asked
+# for: GNU mktemp fails on a missing TMPDIR but BSD mktemp falls back, so a
+# TMPDIR-based check would pass vacuously on the machine this harness runs on.
+new_keys_env
+tmpl_log="$KEYDIR/template"
+# shellcheck disable=SC2329  # shadows mktemp for dedupe_authorized_keys only
+mktemp() { printf '%s\n' "$1" >> "$tmpl_log"; command mktemp "$@"; }
+dedupe_authorized_keys "$KEYS" "$KEY_CURRENT"
+unset -f mktemp
+chk "template is a sibling of authorized_keys" 1 \
+  "$(grep -c "^$KEYS\.sort\." "$tmpl_log")"
 
 echo
 if [ "$fail" = 0 ]; then echo "ALL PASS"; else echo "FAILURES"; fi

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -21,7 +21,7 @@ SRC="${1:-$ROOT/script/lightsail_launch.sh}"
 # die() is a one-liner; the others run to the first column-1 closing brace.
 eval "$(awk '
   /^die\(\) \{/ { print; next }
-  /^(ensure_block|ensure_sudoers|in_group|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|install_deploy_ssh_dir|reassign_prior_db_role|refuse_superuser_db_rotation|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps|dedupe_authorized_keys|install_staged_authorized_keys|postgresql_conf_includes_confd|role_owns_app_objects|refuse_db_name_change|passwd_home|ssh_key_holder|adopt_legacy_ssh_key_marker)\(\) \{/ { f = 1 }
+  /^(ensure_block|ensure_sudoers|in_group|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|install_deploy_ssh_dir|reassign_prior_db_role|refuse_superuser_db_rotation|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps|dedupe_authorized_keys|install_staged_authorized_keys|postgresql_conf_includes_confd|role_owns_app_objects|refuse_db_name_change|refuse_defaulted_config_change|passwd_home|ssh_key_holder|adopt_legacy_ssh_key_marker)\(\) \{/ { f = 1 }
   f { print }
   f && /^\}/ { f = 0 }
 ' "$SRC")"
@@ -33,7 +33,8 @@ for fn in die ensure_block ensure_sudoers in_group revoke_prior_deploy_user \
           ensure_cluster_on_default_port ensure_swapfile allocate_swapfile \
           ensure_docker_log_caps dedupe_authorized_keys \
           install_staged_authorized_keys postgresql_conf_includes_confd \
-          refuse_db_name_change passwd_home ssh_key_holder \
+          refuse_db_name_change refuse_defaulted_config_change \
+          passwd_home ssh_key_holder \
           adopt_legacy_ssh_key_marker; do
   declare -F "$fn" >/dev/null || {
     echo "could not extract $fn() from $SRC — has the definition moved?" >&2
@@ -535,6 +536,7 @@ run_cutover() {
   # destination, and bash would create files named after the placeholders.
   printf '%s' "$recipe" |
     sed -e 's/<instance-ip>/203.0.113.10/g' -e 's/<deploy-user>/collavre/g' \
+        -e 's/<db-user>/collavre_user/g' \
     > "$work/recipe.sh"
   mkdir -p "$work/bin"
   cat > "$work/bin/ssh" <<'STUB'
@@ -1607,6 +1609,7 @@ run_move() {
   mkdir -p "$REMOTE" "$work/bin" "$work/rbin"
   printf '%s' "$move" |
     sed -e 's/<instance-ip>/203.0.113.10/g' -e 's/<deploy-user>/collavre/g' \
+        -e 's/<db-user>/collavre_user/g' -e 's/<db-name>/collavre_production/g' \
     > "$work/recipe.sh"
 
   cat > "$work/bin/psql" <<'STUB'
@@ -1742,6 +1745,14 @@ if [ "${1:-}" = /var/lib/collavre/db_user ]; then
   [ -n "${APP_ROLE-}" ] || { echo "cat: $1: No such file or directory" >&2; exit 1; }
   printf '%s\n' "$APP_ROLE"; exit 0
 fi
+# Same for the database name: the recipe asks the host which database it is
+# restoring rather than spelling one, so an absent file is a case under test —
+# on a host that used DB_NAME or the rename procedure, a guess is the wrong
+# database.
+if [ "${1:-}" = /var/lib/collavre/db_name ]; then
+  [ -n "${APP_DB-}" ] || { echo "cat: $1: No such file or directory" >&2; exit 1; }
+  printf '%s\n' "$APP_DB"; exit 0
+fi
 exec /bin/cat "$@"
 STUB
   # datconnlimit is modelled as state rather than as a canned answer, because
@@ -1785,7 +1796,8 @@ STUB
   export TRACE LIVE="${LIVE-0}" KILLED="${KILLED:-0}" FAIL_RESTORE="${FAIL_RESTORE:-}" \
          FAIL_SHUT="${FAIL_SHUT:-}" FAIL_REOPEN="${FAIL_REOPEN:-}" \
          CONNLIMIT="$work/connlimit" \
-         APP_ROLE="${APP_ROLE-collavre_user}" APP_SUPER="${APP_SUPER-f}"
+         APP_ROLE="${APP_ROLE-collavre_user}" APP_SUPER="${APP_SUPER-f}" \
+         APP_DB="${APP_DB-collavre_production}"
   R_OUT="$(cd "$work" && PATH="$work/bin:$PATH" bash ./recipe.sh 2>&1)"
   R_TRACE="$(paste -sd'|' "$TRACE")"
   rm -rf "$work"
@@ -2507,6 +2519,172 @@ chk "no 'collavre@' anywhere in the runbook" 0 "$(grep -c 'collavre@' "$DOC")"
 # recipes go untested while looking tested.
 chk "the SSH recipes use <deploy-user>" 1 \
   "$(grep -cq '<deploy-user>@<instance-ip>' "$DOC" && echo 1 || echo 0)"
+
+echo "106. the recipes name no database role or database of their own"
+# The counterpart of 105 for DB_USER and DB_NAME, which are overridable in the
+# same way APP_SSH_USER is. A literal role fails the import at SET ROLE and the
+# cutover at its first ALTER ROLE; a literal database name is worse in the
+# restore, which would shut, terminate and reload the wrong one. Asserted on
+# the extracted recipes rather than on the whole page, because the prose around
+# them is entitled to name the defaults.
+chk "the import names no role of its own"      0 "$(grep -c 'collavre_user' <<<"$move")"
+chk "nor a database of its own"                0 "$(grep -c 'collavre_production' <<<"$move")"
+chk "the cutover names no role of its own"     0 "$(grep -c 'collavre_user' <<<"$recipe")"
+chk "the restore names no database of its own" 0 "$(grep -c 'collavre_production' <<<"$restore")"
+# And the placeholders are the ones the harnesses above substitute — an
+# unsubstituted `<db-user>` is a redirection, so these recipes would go untested
+# while looking tested.
+chk "and they use <db-user>/<db-name>"         1 \
+  "$(grep -q '<db-user>' <<<"$move$recipe" && echo 1 || echo 0)"
+
+# --- refuse_defaulted_config_change ------------------------------------------
+#
+# `sudo FORCE=1 bash script/lightsail_launch.sh` reads as "converge this host",
+# but a re-run applies every setting, so an override used once and not repeated
+# is applied as its default. Two of those defaults rotate rather than converge:
+# APP_SSH_USER moves docker + sudo + the sudoers.d grant off the account
+# KAMAL_SSH_USER names, and DB_USER moves table ownership and LOGIN off the role
+# in the deployed DATABASE_URL. A third, BACKUP_S3_URI, is the quiet one — the
+# nightly dump keeps being written and stops leaving the instance.
+
+# The setting list comes out of the script rather than being retyped here: a
+# copy would keep passing after a setting was added to one and not the other,
+# which is exactly the drift this guard exists to catch.
+eval "$(awk '/^LAUNCH_SETTINGS=/ { f = 1 } f { print } f && /'"'"'$/ { exit }' "$SRC")"
+[ -n "${LAUNCH_SETTINGS:-}" ] ||
+  { echo "  FAIL could not extract LAUNCH_SETTINGS from $SRC"; fail=1; }
+
+# $1 = state dir, $2 = space-separated supplied settings, rest = env assignments.
+# The settings not named in the environment take the script's own defaults, which
+# is the case under test — so they are spelled here once, as the script spells
+# them, and each case overrides only what it is about.
+run_cfg() {
+  local state="$1" supplied="$2"; shift 2
+  CFG_STATUS=0
+  CFG_OUT="$(
+    env SSH_PUBLIC_KEY= APP_SSH_USER=collavre PG_MAJOR=17 \
+        DB_NAME=collavre_production DB_USER=collavre_user \
+        DB_BIND_ADDRESS=172.17.0.1 DOCKER_SUBNETS=172.16.0.0/12 \
+        SWAP_SIZE_MB=2048 TIMEZONE=Asia/Seoul INSTANCE_HOSTNAME=collavre \
+        BACKUP_RETENTION_DAYS=7 BACKUP_S3_URI= BACKUP_AT=03:30 \
+        LAUNCH_SETTINGS="$LAUNCH_SETTINGS" "$@" \
+      bash -c '
+        set -uo pipefail
+        '"$(declare -f die refuse_defaulted_config_change)"'
+        log() { echo "[log] $*"; }
+        refuse_defaulted_config_change "$1" "$2"
+      ' _ "$state" " $supplied " 2>&1
+  )" || CFG_STATUS=$?
+}
+
+cfg=$(mktemp -d)
+cat > "$cfg/launch.env" <<'ENV'
+SSH_PUBLIC_KEY=ssh-ed25519 AAAAC3Nz key@host
+APP_SSH_USER=deploybot
+PG_MAJOR=17
+DB_NAME=collavre_production
+DB_USER=collavre_app
+DB_BIND_ADDRESS=172.17.0.1
+DOCKER_SUBNETS=172.16.0.0/12
+SWAP_SIZE_MB=2048
+TIMEZONE=Asia/Seoul
+INSTANCE_HOSTNAME=collavre
+BACKUP_RETENTION_DAYS=7
+BACKUP_S3_URI=s3://collavre-backups/pg
+BACKUP_AT=03:30
+ENV
+
+echo "107. a bare re-run of an overridden host is refused before anything moves"
+run_cfg "$cfg" ""
+chk "refused"                        1 "$CFG_STATUS"
+chk "the deploy-user rotation named" 1 \
+  "$(grep -c "APP_SSH_USER: host has 'deploybot'" <<<"$CFG_OUT")"
+chk "the db-role rotation named"     1 \
+  "$(grep -c "DB_USER: host has 'collavre_app'" <<<"$CFG_OUT")"
+chk "and the quiet one too"          1 \
+  "$(grep -c "BACKUP_S3_URI: host has 's3://collavre-backups/pg'" <<<"$CFG_OUT")"
+chk "and the withdrawn key too"      1 \
+  "$(grep -c "SSH_PUBLIC_KEY: host has 'ssh-ed25519 AAAAC3Nz key@host'" <<<"$CFG_OUT")"
+chk "settings that agree are not"    0 "$(grep -c 'PG_MAJOR' <<<"$CFG_OUT")"
+chk "and it says nothing changed"    1 "$(grep -c 'Nothing has been changed' <<<"$CFG_OUT")"
+
+echo "108. the command it prints to recover is one that actually clears it"
+# The remedy, not just the finding: a refusal that prints an incantation nobody
+# checked is how a guard becomes a dead end. Replay exactly what it said —
+# including which settings it named, rather than a list written here, or the
+# second run would be told they were supplied whatever the message said and
+# would pass with an empty replay.
+replay="$(sed -n 's/^ *sudo \(.*\)FORCE=1 bash script.*/\1/p' <<<"$CFG_OUT")"
+chk "it printed a replay command"    1 "$([ -n "$replay" ] && echo 1 || echo 0)"
+# eval, not word-splitting: the SSH key holds spaces, so the printed line is
+# only a recovery if a shell's own parsing of it is. %q is what makes that true.
+eval "replay_args=($replay)"
+replay_names="$(printf '%s\n' "${replay_args[@]}" | sed 's/=.*//' | tr '\n' ' ')"
+run_cfg "$cfg" "$replay_names" "${replay_args[@]}"
+chk "and replaying it goes through"  0 "$CFG_STATUS"
+chk "it replayed the key intact"     1 \
+  "$(printf '%s\n' "${replay_args[@]}" |
+     grep -cx 'SSH_PUBLIC_KEY=ssh-ed25519 AAAAC3Nz key@host')"
+
+echo "109. naming a setting is an instruction, not an omission"
+# The deliberate rotations this page documents must not need an acknowledgement.
+run_cfg "$cfg" "APP_SSH_USER DB_USER BACKUP_S3_URI SSH_PUBLIC_KEY" \
+  APP_SSH_USER=newbot DB_USER=collavre_app BACKUP_S3_URI=s3://collavre-backups/pg \
+  SSH_PUBLIC_KEY='ssh-ed25519 AAAAC3Nz key@host'
+chk "a named rotation is allowed"    0 "$CFG_STATUS"
+chk "and nothing is reported"        "" "$CFG_OUT"
+
+echo "110. ACK_CONFIG_RESET=1 applies the defaults and says which"
+run_cfg "$cfg" "" ACK_CONFIG_RESET=1
+chk "allowed"                        0 "$CFG_STATUS"
+chk "and it names what it reset"     1 \
+  "$(grep -c "APP_SSH_USER: host has 'deploybot'" <<<"$CFG_OUT")"
+
+echo "111. a host provisioned before launch.env existed is still guarded"
+# The upgrade path. Only the two settings that rotate a credential are
+# answerable from the files that predate launch.env — and the assertion says so
+# rather than implying the others are safe.
+legacy=$(mktemp -d)
+printf 'deploybot\n' > "$legacy/deploy_user"
+printf 'collavre_app\n' > "$legacy/db_user"
+run_cfg "$legacy" ""
+chk "refused"                        1 "$CFG_STATUS"
+chk "deploy user recovered"          1 \
+  "$(grep -c "APP_SSH_USER: host has 'deploybot'" <<<"$CFG_OUT")"
+chk "db role recovered"              1 \
+  "$(grep -c "DB_USER: host has 'collavre_app'" <<<"$CFG_OUT")"
+chk "and S3 is not claimed to be checked" 0 "$(grep -c 'BACKUP_S3_URI' <<<"$CFG_OUT")"
+rm -rf "$legacy"
+
+echo "112. a first run has nothing to disagree with"
+fresh=$(mktemp -d)
+run_cfg "$fresh" ""
+chk "allowed"                        0 "$CFG_STATUS"
+chk "and silent"                     "" "$CFG_OUT"
+rm -rf "$fresh"
+
+echo "113. the password is not one of the settings recorded in launch.env"
+# launch.env is 0644 on purpose — the runbook sends operators to read it — and
+# DB_PASSWORD has its own 0600 file. Listing it here would move the production
+# password into a world-readable one.
+chk "DB_PASSWORD is not tracked"     0 \
+  "$(grep -cw 'DB_PASSWORD' <<<"$LAUNCH_SETTINGS")"
+rm -rf "$cfg"
+
+echo "114. the guard is called before anything it protects"
+# A refusal that says "Nothing has been changed" has to be true, and everything
+# below rotates or installs. Asserted on the call site rather than on the
+# function, because the function being correct is not what makes the message
+# true — its position is.
+call_line="$(grep -n '^refuse_defaulted_config_change$' "$SRC" | head -1 | cut -d: -f1)"
+chk "it is called at all"            1 "$([ -n "$call_line" ] && echo 1 || echo 0)"
+for after in 'apt_get update' 'ensure_sudoers "\$APP_SSH_USER"' \
+             'usermod -aG docker' 'revoke_prior_deploy_user "\$APP_SSH_USER"' \
+             'reassign_prior_db_role "\$DB_USER"'; do
+  line="$(grep -n "^$after" "$SRC" | head -1 | cut -d: -f1)"
+  chk "before ${after%% *}" 1 \
+    "$([ -n "$line" ] && [ "$call_line" -lt "$line" ] && echo 1 || echo 0)"
+done
 
 echo
 if [ "$fail" = 0 ]; then echo "ALL PASS"; else echo "FAILURES"; fi

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -5589,6 +5589,65 @@ else
 fi
 rm -rf "$vshd"
 
+echo "147. keys copied from the cloud user are withdrawn by a later rotation"
+# The runbook's variable table promises that changing SSH_PUBLIC_KEY on a re-run
+# "withdraws the key it replaces". On the empty -> explicit transition it
+# withdrew nothing: `record_ssh_key_grant "$SSH_PUBLIC_KEY"` at the call site is
+# a no-op when the variable is empty, which is exactly what puts the run on the
+# copy-from-the-cloud-user path, so the queue stayed empty and the rotation
+# found no predecessor. Measured on the shipped functions:
+#
+#   run 1  SSH_PUBLIC_KEY=''      authorized: cloud-1 cloud-2      queue: -
+#   run 2  SSH_PUBLIC_KEY=<new>   authorized: cloud-1 cloud-2 new  queue: new
+#
+# on the account that has passwordless sudo and docker.
+kd=$(mktemp -d)
+K1="ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAACLOUDKEYONE cloud-1"
+K2="ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAACLOUDKEYTWO cloud-2"
+KN="ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAANEWDEPLOYKEY new"
+# No such account on this machine, and the ownership is not what is under test —
+# without this the install refuses and every row below reads "withdrawn" off an
+# empty file, which is how this fixture first passed while measuring nothing.
+# shellcheck disable=SC2329  # called by install_staged_authorized_keys
+chown() { :; }
+key_rotation() {   # <deploy account> -> "<authorized names>|<queue names>"
+  # One name per statement: bash expands every word of a `local` before it
+  # performs any of the assignments, so `local a="$1" b="$a"` leaves b empty —
+  # and under this suite's `set -u` it aborts the case instead, which is how
+  # this was caught rather than silently measuring the wrong directory.
+  local acct="$1"
+  local h="$kd/$acct" sd="$kd/state.$acct"
+  local ak out=''
+  rm -rf "$h" "$sd"; mkdir -p "$sd" "$h/ubuntu/.ssh" "$h/$acct/.ssh"
+  printf '%s\n%s\n' "$K1" "$K2" > "$h/ubuntu/.ssh/authorized_keys"
+  ak="$h/$acct/.ssh/authorized_keys"
+  [ "$acct" = ubuntu ] || : > "$ak"
+  local k
+  for k in '' "$KN"; do
+    STATE_DIR="$sd" APP_SSH_USER="$acct" SSH_PUBLIC_KEY="$k"
+    record_ssh_key_grant "$SSH_PUBLIC_KEY" >/dev/null 2>&1
+    install_authorized_keys "$ak" "$h" >/dev/null 2>&1
+    revoke_prior_ssh_key "$ak" >/dev/null 2>&1
+  done
+  while read -r l; do [ -n "$l" ] && out="$out${l##* } "; done < "$ak"
+  out="${out}|"
+  [ -s "$sd/ssh_public_keys.$acct" ] &&
+    while read -r l; do [ -n "$l" ] && out="$out ${l##* }"; done < "$sd/ssh_public_keys.$acct"
+  printf '%s' "$out"
+}
+chk "a copied cloud key is withdrawn when SSH_PUBLIC_KEY is set" \
+  "new | new" "$(key_rotation collavre)"
+# The control that decides where the recording may go, and it is the one that
+# would be a lockout if it moved: when APP_SSH_USER *is* the cloud user, the
+# file is that account's own and this script never wrote it. Queueing it would
+# have a later rotation strip the operator's Lightsail key from the account they
+# log in as. Copied keys are this script's to withdraw; a cloud account's own
+# are not.
+chk "but the cloud user's own keys are left alone" \
+  "cloud-1 cloud-2 new | new" "$(key_rotation ubuntu)"
+unset -f chown
+rm -rf "$kd"
+
 echo
 if [ "$fail" = 0 ]; then echo "ALL PASS"; else echo "FAILURES"; fi
 exit "$fail"

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -21,7 +21,7 @@ SRC="${1:-$ROOT/script/lightsail_launch.sh}"
 # die() is a one-liner; the others run to the first column-1 closing brace.
 eval "$(awk '
   /^die\(\) \{/ { print; next }
-  /^(ensure_block|ensure_sudoers|in_group|write_state_file|record_deploy_user_grant|revoke_deploy_user_access|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|install_deploy_ssh_dir|reassign_prior_db_role|refuse_superuser_db_rotation|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps|dedupe_authorized_keys|install_staged_authorized_keys|postgresql_conf_includes_confd|role_owns_app_objects|refuse_db_name_change|refuse_defaulted_config_change|refuse_unusable_db_identifier|refuse_unparsable_ssh_key|passwd_home|ssh_key_holder|adopt_legacy_ssh_key_marker|record_db_role_grant|reassign_one_db_role|record_ssh_key_grant|refuse_root_deploy_user|append_state_line|refuse_nologin_deploy_user|stage_authorized_keys)\(\) \{/ { f = 1 }
+  /^(ensure_block|ensure_sudoers|in_group|write_state_file|record_deploy_user_grant|revoke_deploy_user_access|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|install_deploy_ssh_dir|reassign_prior_db_role|refuse_superuser_db_rotation|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps|dedupe_authorized_keys|install_staged_authorized_keys|postgresql_conf_includes_confd|role_owns_app_objects|refuse_db_name_change|refuse_defaulted_config_change|refuse_unusable_db_identifier|refuse_unparsable_ssh_key|passwd_home|ssh_key_holder|adopt_legacy_ssh_key_marker|record_db_role_grant|reassign_one_db_role|record_ssh_key_grant|refuse_root_deploy_user|append_state_line|refuse_nologin_deploy_user|resolve_symlink_chain|stage_beside|stage_authorized_keys)\(\) \{/ { f = 1 }
   f { print }
   f && /^\}/ { f = 0 }
 ' "$SRC")"
@@ -40,7 +40,7 @@ for fn in die ensure_block ensure_sudoers in_group write_state_file \
           passwd_home ssh_key_holder \
           record_db_role_grant reassign_one_db_role record_ssh_key_grant \
           refuse_root_deploy_user append_state_line refuse_nologin_deploy_user \
-          stage_authorized_keys \
+          resolve_symlink_chain stage_beside stage_authorized_keys \
           adopt_legacy_ssh_key_marker; do
   declare -F "$fn" >/dev/null || {
     echo "could not extract $fn() from $SRC — has the definition moved?" >&2
@@ -4555,6 +4555,129 @@ chk "and the previous backup script survives that too" \
 rm -rf "$bd"
 chk "the live backup path is not written by redirection" \
   0 "$(grep -c '^cat > /usr/local/bin/collavre-pg-backup' "$SRC")"
+
+echo "128. a database-name probe that cannot answer is refused, not read as 'it exists'"
+# The third instance of the shape recorded at role_owns_app_objects, and the
+# last `[ "$(psql ...)" = x ] || return 0` in this file. It compares *output*,
+# so a psql that could not answer yields an empty string — which is not "0", so
+# the `|| return 0` retires the guard on the one reading it has no evidence for.
+#
+# Proceeding here is not a deferred refusal. The guard sits ahead of the
+# creation SQL, so a run where the cluster comes back a moment later creates the
+# typo'd database empty, advances both markers onto it, and points DATABASE_URL
+# and the nightly pg_dump at it while the app's data stays in the database
+# nothing now names.
+dn6=$(mktemp -d); printf 'collavre_user\n' > "$dn6/db_user"
+PROBE_FAILS=0
+# shellcheck disable=SC2329  # called by refuse_db_name_change
+psql_as_postgres() {
+  [ "$PROBE_FAILS" = 0 ] || return 1
+  # Answers about the name actually asked for, so the control below is a real
+  # "this database is there" and not the refusal path wearing its clothes.
+  case "$2" in
+    *"count(*)"*"'collavre_production'"*) echo 1 ;;
+    *"count(*)"*) echo 0 ;;
+    *) echo "collavre_production" ;;
+  esac
+}
+PROBE_FAILS=1
+out="$( (refuse_db_name_change collavre_typo "$dn6") 2>&1 )"
+chk "an unanswerable probe is refused" 1 "$?"
+case "$out" in
+  *"would not say whether"*"Nothing has been changed"*)
+    echo "  ok   and it names the cluster, not the name" ;;
+  *) echo "  FAIL passed or was unhelpful: $out"; fail=1 ;;
+esac
+# The control in the other direction, and the one no negative control catches:
+# this guard runs on every re-run, so a probe answered "the database is there"
+# must still proceed. A guard that refused here would stop every convergence.
+PROBE_FAILS=0
+( refuse_db_name_change collavre_production "$dn6" ) >/dev/null 2>&1
+chk "an answered probe still proceeds" 0 "$?"
+unset -f psql_as_postgres
+rm -rf "$dn6"
+
+echo "129. daemon.json is replaced by rename, not by truncating the live file"
+# The validation was already right and the install was not: jq checked the
+# staging file and `cat "$tmp" > "$file"` then truncated the live one to copy it
+# in, so the file that was checked is not the file that ends up installed.
+# Nothing notices, either — the caller only restarts Docker on a run that
+# changed the file, so the running daemon keeps the config it read at boot and
+# the host stays healthy until a reboot it cannot come back from.
+#
+# Injected rather than raced, as case 4a records: a kill loses to a fast local
+# write, and a flaky control is worse than none.
+dj=$(mktemp -d)
+seed_daemon() {
+  printf '{"insecure-registries":["10.0.0.1:5000"],"log-driver":"json-file"}\n' \
+    > "$dj/daemon.json"
+}
+seed_daemon
+( DAEMON_JSON_CHANGED=0; ensure_docker_log_caps "$dj/daemon.json" ) >/dev/null 2>&1
+chk "a clean run caps the logs"      '"10m"' \
+  "$(jq -c '."log-opts"."max-size"' "$dj/daemon.json")"
+chk "and keeps the operator's keys"  1 "$(jq -e 'has("insecure-registries")' "$dj/daemon.json" >/dev/null && echo 1 || echo 0)"
+seed_daemon
+( DAEMON_JSON_CHANGED=0
+  # shellcheck disable=SC2329  # shadows the copy the previous form installed with
+  cat() { command cat "$@" | head -c 20; return 1; }
+  ensure_docker_log_caps "$dj/daemon.json" ) >/dev/null 2>&1
+chk "a copy that fails leaves valid JSON" 1 \
+  "$(jq empty "$dj/daemon.json" >/dev/null 2>&1 && echo 1 || echo 0)"
+chk "and the operator's registry survives" 1 \
+  "$(grep -c insecure-registries "$dj/daemon.json")"
+chk "and no staging file is left behind" 0 \
+  "$(find "$dj" -name 'daemon.json.collavre.*' | wc -l | tr -d ' ')"
+# rename(2) does not follow symlinks and the copy did: without resolution this
+# fix would replace a symlinked /etc/docker/daemon.json with a regular file and
+# leave the real path — the one dockerd reads — holding what it held before.
+# A control against the obvious implementation of the remedy, not against the
+# reviewed revision, which passes it.
+mkdir -p "$dj/real"; printf '{"log-driver":"json-file"}\n' > "$dj/real/daemon.json"
+ln -s real/daemon.json "$dj/link.json"
+( DAEMON_JSON_CHANGED=0; ensure_docker_log_caps "$dj/link.json" ) >/dev/null 2>&1
+chk "a symlinked daemon.json is still a symlink" 1 "$([ -L "$dj/link.json" ] && echo 1 || echo 0)"
+chk "and the real file got the caps" '"10m"' \
+  "$(jq -c '."log-opts"."max-size"' "$dj/real/daemon.json")"
+rm -rf "$dj"
+
+echo "130. stage_beside carries the target's identity, and invents one when there is none"
+# The primitive the three staged installs share. Two properties, and the second
+# is the one that would have shipped a broken cluster: mktemp creates 0600, so a
+# first-run 10-collavre.conf installed straight from a staging file would be
+# unreadable by the postgres user that has to read it — the fix for a truncated
+# config would stop the cluster outright. `cat >` under root's umask produced
+# 0644 and that is what a target-less stage has to reproduce.
+sb=$(mktemp -d)
+printf 'old\n' > "$sb/target"; chmod 0640 "$sb/target"
+t="$(stage_beside "$sb/target")"
+chk "staged in the target's own directory" "$sb" "$(dirname "$t")"
+chk "carrying the target's mode"           640 "$(file_mode "$t")"
+chk "and the live file is untouched"       old "$(cat "$sb/target")"
+rm -f "$t"
+t="$(stage_beside "$sb/absent")"
+chk "a target that does not exist yet gets the default"  644 "$(file_mode "$t")"
+chk "and an explicit mode is honoured"                   755 \
+  "$(u="$(stage_beside "$sb/absent2" 0755)"; file_mode "$u")"
+rm -f "$t"
+mktemp() { return 1; }
+stage_beside "$sb/target" >/dev/null 2>&1
+chk "nowhere to stage reports 1, not 2"    1 "$?"
+unset -f mktemp
+rm -rf "$sb"
+# Source-level control. The helpers are new, so the assertions above cannot be
+# run against the reviewed revision — the suite stops at its own extraction
+# check. What can be asserted there is that no generated file is still written
+# through its live path.
+chk "the PostgreSQL config is not written by redirection" \
+  0 "$(grep -c '^cat > "\$PG_CONF_DIR/conf.d/10-collavre.conf"' "$SRC")"
+chk "it is staged and renamed instead" \
+  1 "$(grep -c '^mv -f "\$PG_CONF_TMP" "\$PG_CONF_REAL"' "$SRC")"
+# Anchored past the comment that quotes the old form: the first spelling of this
+# matched the explanation of the fix and would have gone on passing after a
+# revert, which is the assertion testing the prose instead of the code.
+chk "and daemon.json is not installed by copy" \
+  0 "$(grep -cE '^[[:space:]]*cat "\$tmp" > "\$file"' "$SRC")"
 
 echo "131. a torn append to authorized_keys does not glue the successor to it"
 # The last `>>` in this script that was not a queue, and the one where a

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -21,7 +21,7 @@ SRC="${1:-$ROOT/script/lightsail_launch.sh}"
 # die() is a one-liner; the others run to the first column-1 closing brace.
 eval "$(awk '
   /^die\(\) \{/ { print; next }
-  /^(ensure_block|ensure_sudoers|in_group|write_state_file|record_deploy_user_grant|revoke_deploy_user_access|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|install_deploy_ssh_dir|reassign_prior_db_role|refuse_superuser_db_rotation|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps|dedupe_authorized_keys|install_staged_authorized_keys|postgresql_conf_includes_confd|role_owns_app_objects|refuse_db_name_change|refuse_defaulted_config_change|refuse_unusable_db_identifier|refuse_unparsable_ssh_key|passwd_home|ssh_key_holder|adopt_legacy_ssh_key_marker|record_db_role_grant|reassign_one_db_role|record_ssh_key_grant|refuse_root_deploy_user|append_state_line|refuse_nologin_deploy_user)\(\) \{/ { f = 1 }
+  /^(ensure_block|ensure_sudoers|in_group|write_state_file|record_deploy_user_grant|revoke_deploy_user_access|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|install_deploy_ssh_dir|reassign_prior_db_role|refuse_superuser_db_rotation|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps|dedupe_authorized_keys|install_staged_authorized_keys|postgresql_conf_includes_confd|role_owns_app_objects|refuse_db_name_change|refuse_defaulted_config_change|refuse_unusable_db_identifier|refuse_unparsable_ssh_key|passwd_home|ssh_key_holder|adopt_legacy_ssh_key_marker|record_db_role_grant|reassign_one_db_role|record_ssh_key_grant|refuse_root_deploy_user|append_state_line|refuse_nologin_deploy_user|stage_authorized_keys)\(\) \{/ { f = 1 }
   f { print }
   f && /^\}/ { f = 0 }
 ' "$SRC")"
@@ -40,6 +40,7 @@ for fn in die ensure_block ensure_sudoers in_group write_state_file \
           passwd_home ssh_key_holder \
           record_db_role_grant reassign_one_db_role record_ssh_key_grant \
           refuse_root_deploy_user append_state_line refuse_nologin_deploy_user \
+          stage_authorized_keys \
           adopt_legacy_ssh_key_marker; do
   declare -F "$fn" >/dev/null || {
     echo "could not extract $fn() from $SRC — has the definition moved?" >&2
@@ -4554,6 +4555,109 @@ chk "and the previous backup script survives that too" \
 rm -rf "$bd"
 chk "the live backup path is not written by redirection" \
   0 "$(grep -c '^cat > /usr/local/bin/collavre-pg-backup' "$SRC")"
+
+echo "131. a torn append to authorized_keys does not glue the successor to it"
+# The last `>>` in this script that was not a queue, and the one where a
+# fragment costs more than a forgotten record. install_authorized_keys guards
+# its append with `grep -qxF`, which does not match a fragment, so a retry lands
+# the whole key on the end of one — and revoke_prior_ssh_key opens with
+# "never withdraw before the successor is in place", tested by that same exact
+# match. The successor is not an exact line, so the rotation withdraws nothing
+# and reports success, leaving the predecessor authorized on an account with
+# docker and passwordless sudo.
+#
+# The fragment is injected, as in case 4a and 125: ENOSPC and RLIMIT_FSIZE both
+# produce one and neither is reachable here, and the partial write is not the
+# claim — what the retry does with it is.
+sd=$(mktemp -d); ak="$sd/authorized_keys"
+KA="ssh-rsa AAAAB3NzaC1yc2EAAAA_KEY_A_AAAAAAAAAAAAAAAAAAAAAAAA deploy@a"
+KB="ssh-rsa AAAAB3NzaC1yc2EAAAA_KEY_B_BBBBBBBBBBBBBBBBBBBBBBBB deploy@b"
+SSH_PUBLIC_KEY="$KA"
+record_ssh_key_grant "$KA" "$sd/keys" "$sd/key" >/dev/null
+install_authorized_keys "$ak"
+printf '%s\n' "$KA" > "$sd/key"
+chk "the predecessor is authorized to begin with" 1 "$(grep -cxF "$KA" "$ak")"
+
+SSH_PUBLIC_KEY="$KB"
+record_ssh_key_grant "$KB" "$sd/keys" "$sd/key" >/dev/null
+printf '%s' "${KB:0:34}" >> "$ak"          # <- the torn append; the run dies here
+# the retry
+install_authorized_keys "$ak"
+chk "the retry gives the successor a whole line of its own" 1 "$(grep -cxF "$KB" "$ak")"
+chk "and does not extend the fragment" 0 "$(grep -c "^${KB:0:34}${KB:0:6}" "$ak")"
+revoke_prior_ssh_key "$ak" "$sd/key" "$sd/keys" >/dev/null 2>&1
+chk "so the rotation completes on that retry, not a run later" 0 "$(grep -cxF "$KA" "$ak")"
+# The control in the other direction, and the reason this is a rewrite rather
+# than a delete-and-rewrite: a key the operator put there by hand is not one of
+# ours to move, and a fragment authorizes nobody so it is left to
+# dedupe_authorized_keys rather than guessed at.
+chk "a key added by hand is untouched" 1 \
+  "$(printf 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5_HANDKEY operator\n' >> "$ak"
+     install_authorized_keys "$ak"; grep -c _HANDKEY "$ak")"
+# A staged file that cannot be completed must not be installed: the live
+# authorized_keys is the only way into the host.
+before="$(cat "$ak")"
+# shellcheck disable=SC2329  # shadows the staging write for this case only
+mktemp() { return 1; }
+SSH_PUBLIC_KEY="ssh-rsa AAAAB3NzaC1yc2EAAAA_KEY_C_CCCCCCCCCCCCCCCCCCCC deploy@c"
+install_authorized_keys "$ak" >/dev/null 2>&1
+chk "a staging failure reports it" 1 "$?"
+unset -f mktemp
+chk "and the live authorized_keys is untouched" "$before" "$(cat "$ak")"
+chk "the key is not written by redirection" \
+  0 "$(grep -cE '^[[:space:]]*printf .%s.n. "\$SSH_PUBLIC_KEY" >> "\$auth_keys"' "$SRC")"
+rm -rf "$sd"
+
+echo "132. the ufw rule marker is replaced, and an empty one is not passed over"
+# `> "$state"` truncates at open, and the read at the top of ensure_ufw_rule
+# branches on `[ -n "$prior" ]` — so an empty marker is not a degraded record
+# but no record, the withdrawal block is skipped, and the rule in force when the
+# write was cut stays in force with nothing naming it. Measured on the extracted
+# function with the marker emptied after the first converge and the subnet then
+# changed twice: the 172.17.0.0/16 rule survives both, permanently, because
+# every later run withdraws what the marker names and the marker has moved past
+# it.
+sd=$(mktemp -d); RULES="$sd/rules"; : > "$RULES"
+# shellcheck disable=SC2329  # called by ensure_ufw_rule
+ufw() { case "$1" in
+  delete) shift; grep -vxF "$*" "$RULES" > "$RULES.n"; mv "$RULES.n" "$RULES" ;;
+  *) grep -qxF "$*" "$RULES" || printf '%s\n' "$*" >> "$RULES" ;; esac; }
+R1="allow from 172.17.0.0/16 to any port 5432 proto tcp"
+R2="allow from 10.0.8.0/24 to any port 5432 proto tcp"
+ensure_ufw_rule postgres "$R1" "$sd/m" >/dev/null
+chk "the marker records the rule" "$R1" "$(cat "$sd/m")"
+chk "and is written whole, not by redirection" \
+  0 "$(grep -cE "^[[:space:]]*printf '%s..n' \"\\\$rule\" > \"\\\$state\"" "$SRC")"
+# The read side, which the write side cannot reach: a host provisioned by an
+# earlier revision may already carry an emptied marker, and there is no second
+# record to fall back to — `ufw status` prints a display form `ufw delete` does
+# not accept, which is why this marker exists. So it is said rather than passed.
+: > "$sd/m"
+# Through LOGGED rather than a captured subshell, because ensure_ufw_rule has
+# to run in *this* shell for the assertions below to see what it did — and
+# cleared explicitly rather than assumed empty, since it accumulates across
+# cases and the last one to set it is whichever ran before this. Same leak as
+# the one recorded at 49.
+log() { LOGGED="$LOGGED $*"; }
+LOGGED=""
+ensure_ufw_rule postgres "$R2" "$sd/m"
+case "$LOGGED" in
+  *"exists but is empty"*"ufw status numbered"*)
+    echo "  ok   an empty marker is reported, with what to look at" ;;
+  *) echo "  FAIL an empty marker passed silently: $LOGGED"; fail=1 ;;
+esac
+chk "the stranded rule really is still in force" 1 "$(grep -cxF "$R1" "$RULES")"
+# The control in the other direction: an *absent* marker is a first converge and
+# must say nothing, since this runs on every convergence of every rule.
+rm -f "$sd/m"
+LOGGED=""
+ensure_ufw_rule postgres "$R2" "$sd/m"
+case "$LOGGED" in
+  *"exists but is empty"*) echo "  FAIL a first converge was warned about"; fail=1 ;;
+  *) echo "  ok   a first converge says nothing" ;;
+esac
+unset -f ufw
+rm -rf "$sd"
 
 echo
 if [ "$fail" = 0 ]; then echo "ALL PASS"; else echo "FAILURES"; fi

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -1395,6 +1395,53 @@ chk "returns non-zero" 1 "$?"
 chk "no group echoed"  "" "$out"
 unset -f id install
 
+# --------------------------------------------------------------------------
+# Per-account key records. The real install_authorized_keys and
+# revoke_prior_ssh_key, driven through a rotation that leaves one account and
+# comes back to it.
+# --------------------------------------------------------------------------
+echo "76. moving APP_SSH_USER away and back still withdraws that account's old key"
+# The global marker advances with each run, so on the way back it names a key
+# that was never in this file — while the same re-run has just put the account
+# back in docker and sudoers.
+STATE_DIR="$(mktemp -d)"
+KEY_A="ssh-ed25519 AAAAKEYA first@laptop"
+KEY_B="ssh-ed25519 AAAAKEYB second@laptop"
+KEY_C="ssh-ed25519 AAAAKEYC third@laptop"
+collavre_keys="$(mktemp)"; deploybot_keys="$(mktemp)"
+
+run_key_step() {   # <user> <key> <authorized_keys>
+  APP_SSH_USER="$1" SSH_PUBLIC_KEY="$2"
+  install_authorized_keys "$3" /nonexistent
+  if [ -f "$STATE_DIR/ssh_public_key" ] &&
+     [ ! -f "$STATE_DIR/ssh_public_key.$APP_SSH_USER" ]; then
+    mv "$STATE_DIR/ssh_public_key" "$STATE_DIR/ssh_public_key.$APP_SSH_USER"
+  fi
+  revoke_prior_ssh_key "$3"
+}
+
+run_key_step collavre  "$KEY_A" "$collavre_keys"
+run_key_step deploybot "$KEY_B" "$deploybot_keys"
+chk "key A stays while collavre is not the deploy user" \
+    1 "$(grep -cxF "$KEY_A" "$collavre_keys")"
+run_key_step collavre  "$KEY_C" "$collavre_keys"
+chk "the key rotated TO is authorized" 1 "$(grep -cxF "$KEY_C" "$collavre_keys")"
+chk "the key retired two rotations ago is gone" \
+    0 "$(grep -cxF "$KEY_A" "$collavre_keys")"
+chk "the other account is untouched" 1 "$(grep -cxF "$KEY_B" "$deploybot_keys")"
+
+echo "77. a host with the old single marker adopts it rather than starting blank"
+# Otherwise the first run after this change has no record, withdraws nothing,
+# and the key it replaces stays authorized forever.
+STATE_DIR="$(mktemp -d)"
+legacy_keys="$(mktemp)"
+printf '%s\n' "$KEY_A" > "$legacy_keys"
+printf '%s\n' "$KEY_A" > "$STATE_DIR/ssh_public_key"     # written by an earlier revision
+run_key_step collavre "$KEY_C" "$legacy_keys"
+chk "the adopted predecessor is withdrawn" 0 "$(grep -cxF "$KEY_A" "$legacy_keys")"
+chk "the successor is authorized"          1 "$(grep -cxF "$KEY_C" "$legacy_keys")"
+chk "the global marker is gone"            0 "$([ -e "$STATE_DIR/ssh_public_key" ] && echo 1 || echo 0)"
+
 # --- docs/deploy_to_lightsail.md, the PostgreSQL move ------------------------
 #
 # pg_restore --clean drops every object before it reloads one, so this recipe is
@@ -1501,6 +1548,7 @@ FAIL_DUMP='' FAIL_XFER='' FAIL_RESTORE='' run_move
 # filename alone would pass without ever staging anything.
 chk "every transfer staged under .incoming" 0 \
   "$(grep '^scp:' <<<"${MOVE_TRACE//|/$'\n'}" | grep -cv '\.incoming$')"
+
 echo
 if [ "$fail" = 0 ]; then echo "ALL PASS"; else echo "FAILURES"; fi
 exit "$fail"

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -21,7 +21,7 @@ SRC="${1:-$ROOT/script/lightsail_launch.sh}"
 # die() is a one-liner; the others run to the first column-1 closing brace.
 eval "$(awk '
   /^die\(\) \{/ { print; next }
-  /^(ensure_block|ensure_sudoers|in_group|write_state_file|launch_record_is_complete|record_launch_settings|record_deploy_user_grant|revoke_deploy_user_access|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|install_deploy_ssh_dir|reassign_prior_db_role|refuse_superuser_db_rotation|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps|warn_existing_containers_keep_log_config|dedupe_authorized_keys|install_staged_authorized_keys|postgresql_conf_includes_confd|role_owns_app_objects|refuse_db_name_change|refuse_defaulted_config_change|refuse_unusable_db_identifier|refuse_unparsable_ssh_key|refuse_forced_command_ssh_key|ipv4_dotted_quad|refuse_unusable_bind_address|refuse_unusable_subnet|passwd_home|ssh_key_holder|adopt_legacy_ssh_key_marker|record_db_role_grant|reassign_one_db_role|record_ssh_key_grant|refuse_root_deploy_user|append_state_line|refuse_nologin_deploy_user|resolve_symlink_chain|stage_beside|stage_authorized_keys|verify_ssh_hardening|refuse_unusable_retention|refuse_unusable_backup_calendar|install_managed_config|install_downloaded_file|reload_ssh_daemon)\(\) \{/ { f = 1 }
+  /^(ensure_block|ensure_sudoers|in_group|write_state_file|launch_record_is_complete|record_launch_settings|record_deploy_user_grant|revoke_deploy_user_access|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|install_deploy_ssh_dir|reassign_prior_db_role|refuse_superuser_db_rotation|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps|warn_existing_containers_keep_log_config|dedupe_authorized_keys|install_staged_authorized_keys|postgresql_conf_includes_confd|role_owns_app_objects|refuse_db_name_change|refuse_defaulted_config_change|refuse_unusable_db_identifier|refuse_unparsable_ssh_key|refuse_forced_command_ssh_key|ipv4_dotted_quad|refuse_unusable_bind_address|refuse_unusable_subnet|passwd_home|ssh_key_holder|adopt_legacy_ssh_key_marker|record_db_role_grant|reassign_one_db_role|record_ssh_key_grant|refuse_root_deploy_user|append_state_line|refuse_nologin_deploy_user|resolve_symlink_chain|stage_beside|stage_authorized_keys|verify_ssh_hardening|refuse_unusable_retention|refuse_unusable_backup_calendar|install_managed_config|install_downloaded_file|install_credential_summary|reload_ssh_daemon)\(\) \{/ { f = 1 }
   f { print }
   f && /^\}/ { f = 0 }
 ' "$SRC")"
@@ -47,7 +47,8 @@ for fn in die ensure_block ensure_sudoers in_group write_state_file \
           resolve_symlink_chain stage_beside stage_authorized_keys \
           verify_ssh_hardening refuse_unusable_retention \
 	  refuse_unusable_backup_calendar \
-	  install_managed_config install_downloaded_file reload_ssh_daemon \
+	  install_managed_config install_downloaded_file \
+	  install_credential_summary reload_ssh_daemon \
           adopt_legacy_ssh_key_marker; do
   declare -F "$fn" >/dev/null || {
     echo "could not extract $fn() from $SRC — has the definition moved?" >&2
@@ -2513,7 +2514,12 @@ deploy_env="$(awk '/^```dotenv$/{f=1;next} f&&/^```$/{exit} f' "$DOC")"
 chk "there is a dotenv block"  1 "$([ -n "$deploy_env" ] && echo 1 || echo 0)"
 chk "no password placeholder"  0 "$(grep -c '<password>' <<<"$deploy_env")"
 chk "no hand-built URI"        0 "$(grep -c 'postgres\(ql\)\?://' <<<"$deploy_env")"
-chk "names the summary file"   1 "$(grep -c 'summary file' <<<"$deploy_env")"
+chk "takes DATABASE_URL from the summary file" 1 \
+  "$(grep -c '^DATABASE_URL=<.*summary file.*>$' <<<"$deploy_env")"
+chk "does not hard-code the default deploy user" 0 \
+  "$(grep -c '^KAMAL_SSH_USER=collavre$' <<<"$deploy_env")"
+chk "takes the deploy user from the generated summary" 1 \
+  "$(grep -c '^KAMAL_SSH_USER=<.*summary.*>$' <<<"$deploy_env")"
 # And the corrected claim has to stay corrected: the two silent cases are what
 # make copying the summary file load-bearing rather than merely tidy. Scoped to
 # the Rails block — `pa%41ss` is also measured against libpq further down the
@@ -6283,6 +6289,57 @@ chk "the validated expression is the one installed"         1 \
   "$(grep -c '"OnCalendar=$BACKUP_CALENDAR"' "$SRC")"
 unset -f systemd-analyze
 rm -rf "$calendar_probe_dir"
+
+echo "157. the credential summary is installed atomically"
+chk "the live summary is never the rendering target" 0 \
+  "$(grep -cE '^render_summary "\$DATABASE_URL" > "\$SUMMARY"$' "$SRC")"
+chk "the rendered summary goes through its staging installer" 1 \
+  "$(grep -c '^install_credential_summary "\$DATABASE_URL"$' "$SRC")"
+summary_dir="$(mktemp -d)"
+SUMMARY="$summary_dir/summary"
+APP_SSH_USER=deploybot
+printf 'previous complete summary\n' > "$SUMMARY"
+chmod 0644 "$SUMMARY"
+summary_inode="$(inode "$SUMMARY")"
+render_summary() {
+  printf '  KAMAL_SSH_USER=%s\n' "$APP_SSH_USER"
+  case "${SUMMARY_RENDER_MODE:-whole}" in
+    fail) return 1 ;;
+  esac
+  printf '  DATABASE_URL=%s\n' "$1"
+  [ "${SUMMARY_RENDER_MODE:-whole}" != short ] || return 0
+  printf 'Never open 5432 there.\n'
+}
+SUMMARY_RENDER_MODE=fail
+( install_credential_summary 'postgresql://new' ) >/dev/null 2>&1
+chk "a failed render leaves the prior summary intact" \
+  "previous complete summary" "$(cat "$SUMMARY")"
+chk "and removes the partial sibling" 0 \
+  "$(find "$summary_dir" -name 'summary.collavre.*' | wc -l | tr -d ' ')"
+SUMMARY_RENDER_MODE=short
+( install_credential_summary 'postgresql://new' ) >/dev/null 2>&1
+chk "a short successful write is still refused" \
+  "previous complete summary" "$(cat "$SUMMARY")"
+SUMMARY_RENDER_MODE=whole
+install_credential_summary 'postgresql://new'
+chk "a complete render replaces the summary" 1 \
+  "$(grep -c '^  DATABASE_URL=postgresql://new$' "$SUMMARY")"
+chk "the installed summary is root-only" 600 "$(file_mode "$SUMMARY")"
+if [ "$summary_inode" = "$(inode "$SUMMARY")" ]; then
+  echo "  FAIL rendered through the live inode rather than renamed into place"; fail=1
+else
+  echo "  ok   renamed into place, so the live summary is never partial"
+fi
+mkdir "$summary_dir/backing"
+printf 'previous linked summary\n' > "$summary_dir/backing/summary"
+rm -f "$SUMMARY"
+ln -s backing/summary "$SUMMARY"
+install_credential_summary 'postgresql://linked'
+chk "a symlinked summary remains a symlink" yes \
+  "$([ -L "$SUMMARY" ] && echo yes || echo no)"
+chk "and its backing file receives the complete render" 1 \
+  "$(grep -c '^  DATABASE_URL=postgresql://linked$' "$summary_dir/backing/summary")"
+rm -rf "$summary_dir"
 
 echo
 if [ "$fail" = 0 ]; then echo "ALL PASS"; else echo "FAILURES"; fi

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -21,14 +21,14 @@ SRC="${1:-$ROOT/script/lightsail_launch.sh}"
 # die() is a one-liner; the others run to the first column-1 closing brace.
 eval "$(awk '
   /^die\(\) \{/ { print; next }
-  /^(ensure_block|ensure_sudoers|in_group|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|reassign_prior_db_role|refuse_superuser_db_rotation|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps)\(\) \{/ { f = 1 }
+  /^(ensure_block|ensure_sudoers|in_group|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|install_deploy_ssh_dir|reassign_prior_db_role|refuse_superuser_db_rotation|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps)\(\) \{/ { f = 1 }
   f { print }
   f && /^\}/ { f = 0 }
 ' "$SRC")"
 
 for fn in die ensure_block ensure_sudoers in_group revoke_prior_deploy_user \
           ensure_ufw_rule ssh_already_allowed ensure_ssh_rule \
-          install_authorized_keys reassign_prior_db_role \
+          install_authorized_keys install_deploy_ssh_dir reassign_prior_db_role \
           refuse_superuser_db_rotation revoke_prior_ssh_key \
           ensure_cluster_on_default_port ensure_swapfile allocate_swapfile \
           ensure_docker_log_caps; do
@@ -1336,6 +1336,64 @@ case "$UFW_CALLS" in
   *) echo "  FAIL wrong order: $UFW_CALLS"; fail=1 ;;
 esac
 unset -f ufw
+
+# --------------------------------------------------------------------------
+# install_deploy_ssh_dir. `id` and `install` are stubbed so the group the
+# function actually asks for is what gets recorded, and so an unknown group
+# fails the way the real `install` does.
+# --------------------------------------------------------------------------
+PRIMARY_GROUP=collavre
+KNOWN_GROUPS="collavre users ubuntu"
+INSTALL_LOG="$(mktemp)"
+# shellcheck disable=SC2329  # called by install_deploy_ssh_dir, eval'd from the script
+id() { [ "${1:-}" = -gn ] || { command id "$@"; return; }; printf '%s\n' "$PRIMARY_GROUP"; }
+# shellcheck disable=SC2329  # called by install_deploy_ssh_dir, eval'd from the script
+install() {
+  local g="" args=("$@") i
+  for (( i = 0; i < ${#args[@]} - 1; i++ )); do
+    [ "${args[i]}" = -g ] && g="${args[i+1]}"
+  done
+  # The function runs inside $( ), so a variable assignment would die with the
+  # subshell. Recorded to a file for the same reason as the mktemp template.
+  printf '%s\n' "$*" > "$INSTALL_LOG"
+  case " $KNOWN_GROUPS " in
+    *" $g "*) return 0 ;;
+    *) echo "install: invalid group '$g'" >&2; return 1 ;;
+  esac
+}
+
+echo "73. the deploy user's own primary group is used, not one named after it"
+# APP_SSH_USER may name an account that already exists — the cloud user, or one
+# made with `useradd -g users deploybot`. Assuming a same-named group makes
+# `install` exit non-zero, and under set -e that ends the run before authorized
+# keys, Docker and PostgreSQL.
+PRIMARY_GROUP=users
+out="$(install_deploy_ssh_dir deploybot /home/deploybot)"
+chk "the call succeeded"      0 "$?"
+chk "echoes the real group"   "users" "$out"
+INSTALL_CALL="$(cat "$INSTALL_LOG")"
+case "$INSTALL_CALL" in
+  *"-g users"*) echo "  ok   install was given the account's own group" ;;
+  *) echo "  FAIL install called with: $INSTALL_CALL"; fail=1 ;;
+esac
+case "$INSTALL_CALL" in
+  *"-m 0700"*"-o deploybot"*"/home/deploybot/.ssh"*)
+    echo "  ok   still 0700 and owned by the account" ;;
+  *) echo "  FAIL wrong mode/owner/path: $INSTALL_CALL"; fail=1 ;;
+esac
+
+echo "74. the ordinary case — a matching group — is unchanged"
+PRIMARY_GROUP=collavre
+out="$(install_deploy_ssh_dir collavre /home/collavre)"
+chk "succeeds"      0 "$?"
+chk "group echoed"  "collavre" "$out"
+
+echo "75. a genuinely failing install is reported, not papered over by the printf"
+PRIMARY_GROUP=nosuchgroup
+out="$(install_deploy_ssh_dir deploybot /home/deploybot 2>/dev/null)"
+chk "returns non-zero" 1 "$?"
+chk "no group echoed"  "" "$out"
+unset -f id install
 
 echo
 if [ "$fail" = 0 ]; then echo "ALL PASS"; else echo "FAILURES"; fi

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -4874,9 +4874,16 @@ dj=$(mktemp -d)
 # The staged write is cut short by shadowing `cat` for one call, injected rather
 # than raced: a kill loses to a fast local write, and a flaky control is worse
 # than none.
+# The shortened write reports success, which is the case that matters and the
+# one this fixture got wrong first: `head -c 0` errors on BSD and succeeds on
+# GNU, so the case passed on macOS because the *write* failed rather than
+# because the check caught a short file, and CI failed it on Linux — where the
+# 0-byte staging file validated (jq accepts an empty document) and was renamed
+# into place. `dd` is used instead so the write succeeds on both, which is what
+# a disk that fills after the file is created actually does.
 torn_create() {  # $1 = bytes of the write that survive
   ( KEEP=$1
-    cat() { command head -c "$KEEP" 2>/dev/null; }
+    cat() { dd bs=1 count="$KEEP" 2>/dev/null; return 0; }
     ensure_docker_log_caps "$dj/daemon.json" >/dev/null 2>&1 )
 }
 torn_create 0

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -584,6 +584,31 @@ printf '%s\n' "$OLD" > "$st2/ssh_public_key"        # recorded but already remov
 revoke_prior_ssh_key "$AK" "$st2/ssh_public_key"
 chk "still just the new key" "$NEW" "$(cat "$AK")"
 
+echo "40. a rewrite that cannot be completed keeps the old key instead of none"
+# The realistic trigger is a full disk: `grep -vxF > $tmp` writes nothing and
+# exits 2, the `|| true` hides it, and writing that empty result back would
+# leave authorized_keys with no keys at all — locking the deploy account out of
+# a host whose only other way in is the account being rotated. Shadowing grep
+# reproduces exactly that: the filter fails, the membership tests do not.
+st3=$(mktemp -d)
+printf '%s\n%s\n' "$NEW" "$OLD" > "$AK"
+printf '%s\n' "$OLD" > "$st3/ssh_public_key"
+# shellcheck disable=SC2034  # read by revoke_prior_ssh_key, eval'd from the script
+SSH_PUBLIC_KEY="$NEW"
+LOGGED=""
+# shellcheck disable=SC2329  # shadows grep for revoke_prior_ssh_key only
+grep() { case "$*" in *-vxF*) return 2 ;; *) command grep "$@" ;; esac; }
+revoke_prior_ssh_key "$AK" "$st3/ssh_public_key"
+unset -f grep
+chk "the account keeps a way in"      1 "$(command grep -cxF "$NEW" "$AK")"
+chk "the un-withdrawn key is kept"    1 "$(command grep -cxF "$OLD" "$AK")"
+# If the marker advanced, no later run would ever retry the withdrawal.
+chk "marker still names the old key" "$OLD" "$(cat "$st3/ssh_public_key")"
+case "$LOGGED" in
+  *WARNING*"still authorized"*) echo "  ok   the failure is reported, not claimed as a success" ;;
+  *) echo "  FAIL silent or reported as withdrawn: $LOGGED"; fail=1 ;;
+esac
+
 unset -f log
 
 # --- reassign_prior_db_role -------------------------------------------------
@@ -609,7 +634,7 @@ psql_as_postgres() {
 log() { LOGGED="$LOGGED $*"; }
 rotate() { SQL=""; LOGGED=""; reassign_prior_db_role "$@"; }
 
-echo "40. rotating DB_USER moves the tables and retires the old credential"
+echo "41. rotating DB_USER moves the tables and retires the old credential"
 # ALTER DATABASE ... OWNER only moves the database. Every table and sequence
 # the app created stays with the old role, so the new one in DATABASE_URL gets
 # "permission denied" on its own data — while the old role keeps LOGIN and the
@@ -621,11 +646,11 @@ chk "ownership moved, then login revoked" \
     '|REASSIGN OWNED BY "collavre_user" TO "collavre_app"|ALTER ROLE "collavre_user" NOLOGIN' \
     "$SQL"
 
-echo "41. an unchanged DB_USER touches nothing"
+echo "42. an unchanged DB_USER touches nothing"
 rotate collavre_user "$d3/db_user"
 chk "no SQL" "" "$SQL$LOGGED"
 
-echo "42. a superuser predecessor is reported, never disabled"
+echo "43. a superuser predecessor is reported, never disabled"
 # DB_USER=postgres on a first run is legal. NOLOGIN on the cluster superuser
 # locks every operator out of administering it — peer auth needs LOGIN too, so
 # there is no way back in.
@@ -638,7 +663,7 @@ case "$LOGGED" in
   *) echo "  FAIL silent: $LOGGED"; fail=1 ;;
 esac
 
-echo "43. first run, emptied marker and a dropped role are all no-ops"
+echo "44. first run, emptied marker and a dropped role are all no-ops"
 d4=$(mktemp -d)
 ROLE_IS_SUPER=f
 rotate collavre_user "$d4/db_user"          # no marker yet

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -21,7 +21,7 @@ SRC="${1:-$ROOT/script/lightsail_launch.sh}"
 # die() is a one-liner; the others run to the first column-1 closing brace.
 eval "$(awk '
   /^die\(\) \{/ { print; next }
-  /^(ensure_block|ensure_sudoers|in_group|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|install_deploy_ssh_dir|reassign_prior_db_role|refuse_superuser_db_rotation|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps|dedupe_authorized_keys|install_staged_authorized_keys)\(\) \{/ { f = 1 }
+  /^(ensure_block|ensure_sudoers|in_group|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|install_deploy_ssh_dir|reassign_prior_db_role|refuse_superuser_db_rotation|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps|dedupe_authorized_keys|install_staged_authorized_keys|postgresql_conf_includes_confd)\(\) \{/ { f = 1 }
   f { print }
   f && /^\}/ { f = 0 }
 ' "$SRC")"
@@ -32,7 +32,7 @@ for fn in die ensure_block ensure_sudoers in_group revoke_prior_deploy_user \
           refuse_superuser_db_rotation revoke_prior_ssh_key \
           ensure_cluster_on_default_port ensure_swapfile allocate_swapfile \
           ensure_docker_log_caps dedupe_authorized_keys \
-          install_staged_authorized_keys; do
+          install_staged_authorized_keys postgresql_conf_includes_confd; do
   declare -F "$fn" >/dev/null || {
     echo "could not extract $fn() from $SRC — has the definition moved?" >&2
     exit 1
@@ -1602,10 +1602,16 @@ chk "every transfer staged under .incoming" 0 \
 # with "too many connections" — including on a reconnect mid-restore, which is
 # the case a point-in-time count cannot see.
 #
-# What is asserted here is the part that regresses silently: the limit is put
-# back on EVERY path. A database left at 0 refuses the app at boot, and the
-# error it gives reads like a connection-pool problem rather than like a step
-# this block forgot to undo.
+# What is asserted here is which paths put the limit back, because both
+# mistakes are silent and they point in opposite directions. Leaving it at 0
+# after a restore that worked refuses the app at boot with an error that reads
+# like a connection-pool problem rather than like a step this block forgot to
+# undo. Re-opening after a restore that FAILED is worse: pg_restore --clean
+# drops before it reloads, so the database is genuinely half-replaced, and the
+# surviving container reconnects and writes into it. Measured on postgres:17
+# with a dump truncated to 70%, `posts` came back with all 20,000 rows and
+# `users` with none; a signup then landed and returned an id, and the retry the
+# recipe itself recommends dropped it again with no error anywhere.
 
 restore="$(extract_recipe 'restore_status=')"
 case "$restore" in
@@ -1679,12 +1685,21 @@ chk "nothing dropped"  0 "$(grep -c '^PG_RESTORE_RAN$' <<<"${R_TRACE//|/$'\n'}")
 chk "re-opened anyway" 1 "$(grep -c '^limit:reopened$' <<<"${R_TRACE//|/$'\n'}")"
 chk "operator told"    1 "$(grep -c 'REFUSING' <<<"$R_OUT")"
 
-echo "86. a FAILED restore still re-opens, or the app cannot boot to be fixed"
+echo "86. a FAILED restore leaves the door shut, so nothing writes to the wreckage"
 LIVE=0 KILLED=0 FAIL_RESTORE=1 run_restore
 chk "restore attempted"  1 "$(grep -c '^PG_RESTORE_RAN$' <<<"${R_TRACE//|/$'\n'}")"
-chk "re-opened"          1 "$(grep -c '^limit:reopened$' <<<"${R_TRACE//|/$'\n'}")"
+chk "NOT re-opened"      0 "$(grep -c '^limit:reopened$' <<<"${R_TRACE//|/$'\n'}")"
 chk "told it may be half-done" 1 "$(grep -c 'RESTORE FAILED' <<<"$R_OUT")"
 chk "not told to boot"   0 "$(grep -c 'app boot' <<<"$R_OUT")"
+# A door left shut without saying so is the failure this whole page keeps
+# hitting from the other side: the operator meets it later as a boot that
+# cannot connect. It has to be stated, and the way out has to be printed.
+chk "says the database is deliberately shut" 1 \
+  "$(grep -c 'LEFT AT .CONNECTION LIMIT 0.' <<<"$R_OUT")"
+chk "says the retry needs no extra step"     1 \
+  "$(grep -c 'superuser and is exempt' <<<"$R_OUT")"
+chk "prints the command that lifts it"       1 \
+  "$(grep -c 'CONNECTION LIMIT -1' <<<"$R_OUT")"
 
 # --- dedupe_authorized_keys -------------------------------------------------
 #
@@ -1830,6 +1845,67 @@ mv_at=$(grep -n '^mv ' "$order" | cut -d: -f1); chmod_at=$(grep -n '^chmod ' "$o
 chk "both before the rename"        1 \
   "$([ -n "$mv_at" ] && [ -n "$chmod_at" ] && [ "$mv_at" -gt "$chmod_at" ] && echo 1 || echo 0)"
 chk "the live file ends 0600"       600 "$(stat -c %a "$KEYS" 2>/dev/null || stat -f %Lp "$KEYS")"
+
+# --- postgresql_conf_includes_confd -----------------------------------------
+#
+# The predicate was `grep -q "include_dir = 'conf.d'"`, which a COMMENTED
+# directive satisfies. Debian and Ubuntu ship the directive active, so a fresh
+# install is fine and the by-hand converge path on a host where an operator
+# disabled it is not: measured on ubuntu:24.04, the run wrote
+# conf.d/10-collavre.conf, restarted the cluster cleanly and reported success,
+# while PostgreSQL never read the file —
+#
+#   listen_addresses in force : localhost
+#   listening on 172.17.0.1   : NO   (bound: 127.0.0.1:5432, [::1]:5432)
+#   DATABASE_URL handed out   : ...@172.17.0.1:5432/collavre_production
+#
+# so the containers are pointed at an address nothing is listening on, several
+# steps after the step that caused it.
+
+echo "92. an active include_dir is honoured, so nothing is appended"
+for active in \
+  "include_dir = 'conf.d'" \
+  "include_dir='conf.d'" \
+  "  include_dir = 'conf.d'  # stock Debian" \
+  "include_dir = '/etc/postgresql/16/main/conf.d'" \
+  "include_dir = conf.d"
+do
+  f=$(mktemp); printf "port = 5432\n%s\nmax_connections = 100\n" "$active" > "$f"
+  postgresql_conf_includes_confd "$f"
+  chk "skipped: $active" 0 "$?"
+  rm -f "$f"
+done
+
+echo "93. a commented-out include_dir does not count as configured"
+# The one that shipped. Each of these leaves conf.d unread by PostgreSQL.
+for off in \
+  "#include_dir = 'conf.d'" \
+  "#  include_dir = 'conf.d'" \
+  "   #include_dir = 'conf.d'   # turned this off, using the main file" \
+  "#include_dir = '...'" \
+  "include_dir = 'other.d'" \
+  "include_dir = 'myconf.d'" \
+  "include_if_exists = 'conf.d'"
+do
+  f=$(mktemp); printf "port = 5432\n%s\nmax_connections = 100\n" "$off" > "$f"
+  postgresql_conf_includes_confd "$f"
+  chk "install needed: $off" 1 "$?"
+  rm -f "$f"
+done
+
+echo "94. at the call site, a disabled directive gets the managed block"
+# The predicate on its own could be right while the caller still skipped, so
+# this drives the pair and then reads what PostgreSQL would.
+f=$(mktemp)
+printf "port = 5432\n#include_dir = 'conf.d'\n" > "$f"
+postgresql_conf_includes_confd "$f" || ensure_block "$f" include "include_dir = 'conf.d'"
+chk "conf.d is now actually included" 1 \
+  "$(sed 's/#.*//' "$f" | grep -cE "^[[:space:]]*include_dir[[:space:]]*=[[:space:]]*'conf\.d'")"
+chk "the operator's own line is untouched" 1 "$(grep -c "^#include_dir = 'conf.d'$" "$f")"
+# Re-running must not stack a second block on a host converged by this change.
+postgresql_conf_includes_confd "$f" || ensure_block "$f" include "include_dir = 'conf.d'"
+chk "and a re-run appends nothing" 1 "$(grep -c '# BEGIN collavre:include' "$f")"
+rm -f "$f"
 
 echo
 if [ "$fail" = 0 ]; then echo "ALL PASS"; else echo "FAILURES"; fi

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -2670,7 +2670,23 @@ STUB
          RESTORE_ARGS="$work/restore_args" \
          APP_ROLE="${APP_ROLE-collavre_user}" APP_SUPER="${APP_SUPER-f}" \
          APP_DB="${APP_DB-collavre_production}"
-  R_OUT="$(cd "$work" && PATH="$work/bin:$PATH" bash ./recipe.sh 2>&1)"
+  if [ -n "${RERUN:-}" ]; then
+    # The retry the failure path invites, driven the way it is instructed: the
+    # same shell, the block pasted a second time, with whatever failed the first
+    # time now fixed. Sourced rather than run, because a shell variable
+    # surviving between the two passes is the mechanism under test — the recipe
+    # holds no state anywhere else, so a subshell per pass would model a fresh
+    # shell and the assertion would be about a different instruction.
+    cat > "$work/driver.sh" <<'DRV'
+. ./recipe.sh
+echo "--- pasted again in the same shell ---"
+export FAIL_RESTORE='' FAIL_SHUT='' FAIL_PRIOR_READ='' FAIL_REOPEN='' FAIL_READBACK=''
+. ./recipe.sh
+DRV
+    R_OUT="$(cd "$work" && PATH="$work/bin:$PATH" bash ./driver.sh 2>&1)"
+  else
+    R_OUT="$(cd "$work" && PATH="$work/bin:$PATH" bash ./recipe.sh 2>&1)"
+  fi
   R_TRACE="$(paste -sd'|' "$TRACE")"
   # What the database is left at, which is the thing the operator meets at boot
   # — asserted directly rather than inferred from the statements that ran.
@@ -2955,6 +2971,43 @@ chk "not re-opened"              0 "$(grep -cx 'limit:reopened' <<<"${R_TRACE//|
 chk "the cap is untouched"       25 "$R_LIMIT"
 chk "and the ALTER is blamed"    1 "$(grep -c 'did not take' <<<"$R_OUT")"
 unset PRIOR_LIMIT FAIL_SHUT
+
+echo "86o. the retry the failure path invites keeps the cap it printed"
+# The instruction under test is the block's own: "Re-running in THIS shell keeps
+# that value". It is honoured by ${prior_limit:-...} whenever the prior read
+# answered, which is this row.
+PRIOR_LIMIT=50 FAIL_RESTORE=1 RERUN=1 LIVE=0 KILLED=0 run_restore
+chk "first pass leaves it shut"     1 "$(grep -c 'RESTORE FAILED' <<<"$R_OUT")"
+chk "and prints the cap to carry"   1 "$(grep -cF 'prior_limit=50' <<<"$R_OUT")"
+chk "the retry restores the cap"    50 "$R_LIMIT"
+chk "and reports a plain success"   1 "$(grep -c 'app boot' <<<"$R_OUT")"
+unset PRIOR_LIMIT FAIL_RESTORE RERUN
+
+echo "86p. and keeps it when the prior read is the thing that failed"
+# `:-` treats an empty value as unset, so a prior read that failed while the
+# ALTER still took would be re-read on the retry — off a database this block has
+# since shut, which answers 0. The retry then "restores" 0 and reports it as the
+# limit the database carried, on the same paste the message above promised would
+# keep -1. Measured against the revision without the pin: this row ends at 0 and
+# the operator is told the cap is their own.
+PRIOR_LIMIT=50 FAIL_RESTORE=1 FAIL_PRIOR_READ=1 RERUN=1 LIVE=0 KILLED=0 run_restore
+chk "the value it promised"          1 "$(grep -cF 'prior_limit=-1' <<<"$R_OUT")"
+chk "is the value the retry uses"    -1 "$R_LIMIT"
+chk "not shut under a success"       0 "$(grep -c "back at 'CONNECTION LIMIT 0'" <<<"$R_OUT")"
+unset PRIOR_LIMIT FAIL_RESTORE FAIL_PRIOR_READ RERUN
+
+echo "86q. but a refusal that shut nothing still reads the cluster on the retry"
+# The control that shapes the pin, and the reason it is gated on the ALTER's
+# status rather than on "the read came back empty". Here the ALTER never took,
+# so the cap is still in the cluster and still the operator's — pinning -1 for
+# want of a read would lift it on the retry, which is the defect above pointing
+# the other way, and worse: it is reachable on a host where nothing went wrong
+# with the database at all.
+PRIOR_LIMIT=50 FAIL_SHUT=1 FAIL_PRIOR_READ=1 RERUN=1 LIVE=0 KILLED=0 run_restore
+chk "first pass refuses"             1 "$(grep -c 'REFUSING' <<<"$R_OUT")"
+chk "the retry finds the real cap"   50 "$R_LIMIT"
+chk "and needs no note about it"     0 "$(grep -c 'could not read' <<<"$R_OUT")"
+unset PRIOR_LIMIT FAIL_SHUT FAIL_PRIOR_READ RERUN
 
 # --- dedupe_authorized_keys -------------------------------------------------
 #

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -21,7 +21,7 @@ SRC="${1:-$ROOT/script/lightsail_launch.sh}"
 # die() is a one-liner; the others run to the first column-1 closing brace.
 eval "$(awk '
   /^die\(\) \{/ { print; next }
-  /^(ensure_block|ensure_sudoers|in_group|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|reassign_prior_db_role|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|ensure_docker_log_caps)\(\) \{/ { f = 1 }
+  /^(ensure_block|ensure_sudoers|in_group|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|reassign_prior_db_role|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps)\(\) \{/ { f = 1 }
   f { print }
   f && /^\}/ { f = 0 }
 ' "$SRC")"
@@ -29,7 +29,8 @@ eval "$(awk '
 for fn in die ensure_block ensure_sudoers in_group revoke_prior_deploy_user \
           ensure_ufw_rule ssh_already_allowed ensure_ssh_rule \
           install_authorized_keys reassign_prior_db_role revoke_prior_ssh_key \
-          ensure_cluster_on_default_port ensure_swapfile ensure_docker_log_caps; do
+          ensure_cluster_on_default_port ensure_swapfile allocate_swapfile \
+          ensure_docker_log_caps; do
   declare -F "$fn" >/dev/null || {
     echo "could not extract $fn() from $SRC — has the definition moved?" >&2
     exit 1
@@ -1013,14 +1014,38 @@ swapon() {
 swapoff() { [ -z "$SWAPOFF_FAILS" ] || return 1; SWAPPED_ON=""; return 0; }
 # shellcheck disable=SC2329  # called by ensure_swapfile, eval'd from the script
 mkswap() { :; }
-# shellcheck disable=SC2329  # called by ensure_swapfile, eval'd from the script
-fallocate() { : > "$3"; dd if=/dev/zero of="$3" bs=1048576 count="${2%M}" status=none 2>/dev/null; }
+# DISK_FREE_MIB caps what the filesystem will accept; "" means unlimited. The
+# two stubs fail the way the real tools were observed to fail on a full tmpfs:
+# fallocate refuses outright and writes nothing, dd writes what fits and then
+# returns non-zero — so the partial file is a real partial file, which is the
+# thing the caller has to not leave at the live path.
+DISK_FREE_MIB=""
+# shellcheck disable=SC2329  # called by allocate_swapfile, eval'd from the script
+fallocate() {
+  local mib="${2%M}"
+  [ -z "$DISK_FREE_MIB" ] || [ "$mib" -le "$DISK_FREE_MIB" ] || return 1
+  : > "$3"
+  command dd if=/dev/zero of="$3" bs=1048576 count="$mib" status=none 2>/dev/null
+}
+# shellcheck disable=SC2329  # called by allocate_swapfile, eval'd from the script
+dd() {
+  local a path="" mib=""
+  for a in "$@"; do
+    case "$a" in of=*) path="${a#of=}" ;; count=*) mib="${a#count=}" ;; esac
+  done
+  if [ -n "$DISK_FREE_MIB" ] && [ "$mib" -gt "$DISK_FREE_MIB" ]; then
+    command dd if=/dev/zero of="$path" bs=1048576 count="$DISK_FREE_MIB" status=none 2>/dev/null
+    return 1
+  fi
+  command dd if=/dev/zero of="$path" bs=1048576 count="$mib" status=none 2>/dev/null
+}
 LOGGED=""
 # shellcheck disable=SC2329  # called by ensure_swapfile, eval'd from the script
 log() { LOGGED="$LOGGED $*"; }
 swap_mib() { echo $(( $(stat -c %s "$1" 2>/dev/null || stat -f %z "$1") / 1048576 )); }
 
 new_swap_env() {   # <existing-MiB>  ("" for no file)
+  DISK_FREE_MIB=""   # reset before the setup dd, not only after it
   d=$(mktemp -d); SWAPFILE="$d/swapfile"; FSTAB="$d/fstab"
   printf 'UUID=xxx / ext4 defaults 0 1\n' > "$FSTAB"
   if [ -n "$1" ]; then
@@ -1030,7 +1055,7 @@ new_swap_env() {   # <existing-MiB>  ("" for no file)
   else
     SWAPPED_ON=""
   fi
-  LOGGED=""; SWAPOFF_FAILS=""
+  LOGGED=""; SWAPOFF_FAILS=""; DISK_FREE_MIB=""
 }
 
 echo "54. a first run creates the swap file at the configured size"
@@ -1099,9 +1124,40 @@ case "$LOGGED" in
   *"WARNING"*"did NOT take effect"*) echo "  ok   operator told it did not take" ;;
   *) echo "  FAIL silent: $LOGGED"; fail=1 ;;
 esac
-unset -f swapon swapoff mkswap fallocate
 
-echo "61. an unsupported DB_PORT is refused before anything is installed"
+echo "61. a resize that does not fit puts the previous swap back"
+# Growing means freeing the old file first, so an allocation that fails would
+# otherwise end the run with no swap at all — worse than it started, on the
+# low-memory host the setting exists for. The old size is known to fit.
+new_swap_env 8
+DISK_FREE_MIB=20
+SWAP_SIZE_MB=64 ensure_swapfile "$SWAPFILE" "$FSTAB"
+chk "run continues"        0 "$?"
+chk "previous size back"   8 "$(swap_mib "$SWAPFILE")"
+chk "swap re-enabled"      "$SWAPFILE" "$SWAPPED_ON"
+chk "no truncated file"    0 "$(( $(swap_mib "$SWAPFILE") == 20 ? 1 : 0 ))"
+case "$LOGGED" in
+  *"WARNING"*"did NOT take effect"*"8MiB swap is back"*)
+    echo "  ok   operator told the raise did not take, and what is running" ;;
+  *) echo "  FAIL silent or claims success: $LOGGED"; fail=1 ;;
+esac
+
+echo "62. a first run that cannot allocate dies rather than reporting success"
+# have=0, so there is nothing to restore; the run must stop loudly instead of
+# continuing on a swapfile that was never made.
+new_swap_env ""
+DISK_FREE_MIB=20
+out="$( (SWAP_SIZE_MB=64 ensure_swapfile "$SWAPFILE" "$FSTAB") 2>&1 )"
+chk "exits non-zero" 1 "$?"
+chk "no partial swapfile left" 0 "$([ -e "$SWAPFILE" ] && echo 1 || echo 0)"
+case "$out" in
+  *"could not allocate 64MiB"*"no swap"*) echo "  ok   says what state the host is in" ;;
+  *) echo "  FAIL unhelpful message: $out"; fail=1 ;;
+esac
+DISK_FREE_MIB=""
+unset -f swapon swapoff mkswap fallocate dd
+
+echo "63. an unsupported DB_PORT is refused before anything is installed"
 # Nothing here writes postgresql.conf, and pg_createcluster takes the first free
 # port from 5432 — so an overridden DB_PORT is named by DATABASE_URL, the ufw
 # rule and the backup while the cluster listens on 5432 regardless.
@@ -1129,14 +1185,14 @@ chk "and says nothing"     "" "$out"
 # --------------------------------------------------------------------------
 caps_of() { jq -c '."log-opts"' "$1"; }
 
-echo "62. a host with no daemon.json gets the caps written"
+echo "64. a host with no daemon.json gets the caps written"
 d=$(mktemp -d); f="$d/daemon.json"; LOGGED=""
 ensure_docker_log_caps "$f"
 chk "reports it changed the file" 1 "$DAEMON_JSON_CHANGED"
 chk "caps present" '{"max-size":"10m","max-file":"3"}' "$(caps_of "$f")"
 chk "valid JSON"   0 "$(jq empty "$f" >/dev/null 2>&1; echo $?)"
 
-echo "63. an existing daemon.json without caps has them merged in, not clobbered"
+echo "65. an existing daemon.json without caps has them merged in, not clobbered"
 # The finding: the old condition skipped the whole block whenever the file
 # existed, so a by-hand run on an existing instance left logs uncapped and
 # still reported Docker as configured.
@@ -1149,7 +1205,7 @@ chk "driver set"   'json-file' "$(jq -r '."log-driver"' "$f")"
 chk "operator's registries kept" '["r.internal:5000"]' "$(jq -c '."insecure-registries"' "$f")"
 chk "operator's live-restore kept" 'true' "$(jq -r '."live-restore"' "$f")"
 
-echo "64. existing caps are left exactly as the operator set them"
+echo "66. existing caps are left exactly as the operator set them"
 d=$(mktemp -d); f="$d/daemon.json"; LOGGED=""
 printf '{"log-driver":"json-file","log-opts":{"max-size":"50m","max-file":"10"}}\n' > "$f"
 before="$(cat "$f")"
@@ -1157,7 +1213,7 @@ ensure_docker_log_caps "$f"
 chk "reports no change" 0 "$DAEMON_JSON_CHANGED"
 chk "byte-identical"    "$before" "$(cat "$f")"
 
-echo "65. a non-json-file driver is reported, not overridden"
+echo "67. a non-json-file driver is reported, not overridden"
 # journald and local rotate on their own; forcing json-file would redirect an
 # operator's logs rather than cap them.
 for drv in journald local awslogs; do
@@ -1173,7 +1229,7 @@ case "$LOGGED" in
   *) echo "  FAIL silent: $LOGGED"; fail=1 ;;
 esac
 
-echo "66. an unparseable daemon.json is reported, never overwritten"
+echo "68. an unparseable daemon.json is reported, never overwritten"
 # It is the operator's file and Docker will not start until it is repaired;
 # replacing it would destroy the evidence of what they meant.
 d=$(mktemp -d); f="$d/daemon.json"; LOGGED=""
@@ -1187,7 +1243,7 @@ case "$LOGGED" in
   *) echo "  FAIL silent: $LOGGED"; fail=1 ;;
 esac
 
-echo "67. a merged file is stable across re-runs"
+echo "69. a merged file is stable across re-runs"
 d=$(mktemp -d); f="$d/daemon.json"; LOGGED=""
 printf '{"live-restore":true}\n' > "$f"
 ensure_docker_log_caps "$f"
@@ -1211,7 +1267,7 @@ LOGGED=""
 # shellcheck disable=SC2329  # called by ensure_ufw_rule, eval'd from the script
 log() { LOGGED="$LOGGED $*"; }
 
-echo "68. a delete that fails leaves the marker so the next run retries"
+echo "70. a delete that fails leaves the marker so the next run retries"
 # `ufw delete` exits 0 even for a rule that was not there, so a non-zero status
 # means it could not act and the old rule is still installed. Advancing the
 # marker there loses the only record of it: the previous Docker subnet keeps
@@ -1235,7 +1291,7 @@ ensure_ufw_rule postgres "$new" "$st"
 chk "retry withdraws the old rule" 1 "$(printf '%s' "$UFW_CALLS" | grep -c "|delete $old")"
 chk "marker advanced now"          "$new" "$(cat "$st")"
 
-echo "69. the replacement is added before the predecessor is withdrawn"
+echo "71. the replacement is added before the predecessor is withdrawn"
 # An interrupted run must never leave the host with neither rule.
 d=$(mktemp -d); st="$d/ufw_postgres"
 printf '%s\n' "$old" > "$st"

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -684,11 +684,32 @@ case "$*" in
   *"sudo rm"*)                              echo RM_STAGED >>"$TRACE" ;;
   *"sudo install"*)                         echo STAGE     >>"$TRACE"
                                             [ -z "$FAIL_STAGE" ] || exit 1 ;;
+  # The receiving half of the blob copy. Reads the stream so the sending tar is
+  # not killed by SIGPIPE, which would make FAIL_TAR indistinguishable from a
+  # receiver that hung up.
+  *"sudo tar -xf"*)                         cat >/dev/null
+                                            echo BLOBS     >>"$TRACE"
+                                            [ -z "$FAIL_BLOB" ] || exit 1 ;;
   *)                                        echo ssh       >>"$TRACE" ;;
 esac
 STUB
   printf '#!/usr/bin/env bash\necho scp >>"$TRACE"\n[ -z "$FAIL_SCP" ] || exit 1\n' \
     > "$work/bin/scp"
+  # The snapshot is what the recipe sends, so the stub has to produce a file at
+  # the path the VACUUM INTO names — otherwise the scp that follows would be
+  # testing a missing file rather than the step under test.
+  cat > "$work/bin/sqlite3" <<'STUB'
+#!/usr/bin/env bash
+echo SNAPSHOT >>"$TRACE"
+[ -z "$FAIL_SNAP" ] || { echo "Error: near \"VACUUM\": syntax error" >&2; exit 1; }
+sql="${*: -1}"
+dest="${sql#*\'}"; dest="${dest%\'*}"
+[ -z "$dest" ] || : > "$dest"
+STUB
+  # Sending half of the blob copy: its own status is the thing case 32h is about,
+  # so it is a separate stub from the receiver rather than one knob for both.
+  printf '#!/usr/bin/env bash\necho TAR_SEND >>"$TRACE"\n[ -z "$FAIL_TAR" ] || exit 2\n' \
+    > "$work/bin/tar"
   cat > "$work/bin/kamal.sh" <<'STUB'
 #!/usr/bin/env bash
 echo "kamal:$1${2:+ $2}" >>"$TRACE"
@@ -698,11 +719,32 @@ STUB
   chmod +x "$work/bin"/*
   cp "$work/bin/kamal.sh" "$work/kamal.sh"
 
+  # NO_SQLITE3 is a host with no sqlite3 at all, and absence cannot be stubbed:
+  # removing the stub would only uncover the real binary further down PATH. So
+  # that case runs with PATH holding nothing but the stubs, which means the few
+  # real commands the recipe needs have to be reachable there — and `bash`
+  # itself is invoked by absolute path, since PATH is what would resolve it.
+  local recipe_path="$work/bin:$PATH"
+  if [ -n "${NO_SQLITE3:-}" ]; then
+    rm -f "$work/bin/sqlite3"
+    local c
+    # env and bash among them: every stub here is `#!/usr/bin/env bash`, so
+    # without them the stubs fail to start and the case passes on the wrong
+    # failure — it did, before this line: `app stop` reported STOP FAILED and
+    # the recipe never reached the snapshot at all.
+    for c in mktemp rm env bash; do ln -s "$(command -v "$c")" "$work/bin/$c"; done
+    recipe_path="$work/bin"
+  fi
+
   TRACE="$work/trace"; : > "$TRACE"
   export TRACE FAIL_COPY="${FAIL_COPY:-}" FAIL_REVOKE="${FAIL_REVOKE:-}"
   export FAIL_SCP="${FAIL_SCP:-}" FAIL_STAGE="${FAIL_STAGE:-}"
-  export FAIL_STOP="${FAIL_STOP:-}"
-  RECIPE_OUT="$(cd "$work" && PATH="$work/bin:$PATH" bash ./recipe.sh 2>&1)"
+  export FAIL_STOP="${FAIL_STOP:-}" FAIL_SNAP="${FAIL_SNAP:-}"
+  export FAIL_TAR="${FAIL_TAR:-}" FAIL_BLOB="${FAIL_BLOB:-}"
+  # The recipe refuses unless the operator states the source is stopped, so the
+  # default here is the stated case and case 32b is the unstated one.
+  export source_quiesced="${SOURCE_QUIESCED-1}"
+  RECIPE_OUT="$(cd "$work" && PATH="$recipe_path" "$BASH" ./recipe.sh 2>&1)"
   RECIPE_TRACE="$(paste -sd'|' "$TRACE")"
   rm -rf "$work"
 }
@@ -781,6 +823,113 @@ case "$RECIPE_OUT" in
   *"STOP FAILED"*) echo "  ok   operator told the container may still be serving" ;;
   *) echo "  FAIL silent or vague: ${RECIPE_OUT:-(no output)}"; fail=1 ;;
 esac
+
+echo "32b. an undeclared source stops the whole recipe, before kamal is touched"
+# The source is the one thing on this page that cannot be checked: SQLite has no
+# pg_stat_activity, and the file looks identical whether the writer left or is
+# between requests. So the recipe asks, and the ask has to be a gate rather than
+# a sentence — nothing may run ahead of it, including `setup`, which on a
+# half-configured instance is not a no-op.
+SOURCE_QUIESCED='' FAIL_COPY='' FAIL_REVOKE='' FAIL_SCP='' FAIL_STAGE='' \
+  FAIL_STOP='' run_cutover
+chk "nothing ran at all"   "" "$RECIPE_TRACE"
+chk "no snapshot taken"     0 "$(grep -cx SNAPSHOT <<<"${RECIPE_TRACE//|/$'\n'}")"
+chk "app NOT booted"        0 "$(grep -cx 'kamal:app boot' <<<"${RECIPE_TRACE//|/$'\n'}")"
+case "$RECIPE_OUT" in
+  *REFUSING*source_quiesced=1*) echo "  ok   refusal names the way through" ;;
+  *) echo "  FAIL vague or absent: ${RECIPE_OUT:-(no output)}"; fail=1 ;;
+esac
+unset SOURCE_QUIESCED
+
+echo "32c. the source is snapshotted, not copied — WAL contents are not in the file"
+# config/database.yml runs SQLite in WAL mode. A cp of production-primary.sqlite3
+# omits everything committed since the last checkpoint, converts cleanly, and
+# reports success — measured at 1 row of 3 with a writer still attached. The
+# assertion is on both halves: a snapshot is taken, and the raw file is not what
+# goes over the wire, since adding the snapshot while still sending the original
+# would test nothing.
+FAIL_COPY='' FAIL_REVOKE='' FAIL_SCP='' FAIL_STAGE='' FAIL_STOP='' run_cutover
+chk "snapshot taken"                1 "$(grep -cx SNAPSHOT <<<"${RECIPE_TRACE//|/$'\n'}")"
+chk "snapshot precedes the transfer" 1 \
+  "$(grep -q 'SNAPSHOT|scp' <<<"$RECIPE_TRACE" && echo 1 || echo 0)"
+chk "sqlite3 is what reads the source" 1 \
+  "$(grep -c 'sqlite3 storage/production-primary.sqlite3' <<<"$recipe")"
+chk "the raw database file is not sent" 0 \
+  "$(grep -c 'scp storage/production-primary.sqlite3' <<<"$recipe")"
+
+echo "32d. a failed snapshot converts nothing"
+FAIL_SNAP=1 FAIL_COPY='' FAIL_REVOKE='' FAIL_SCP='' FAIL_STAGE='' FAIL_STOP='' \
+  run_cutover
+chk "nothing transferred"  0 "$(grep -cx scp <<<"${RECIPE_TRACE//|/$'\n'}")"
+chk "nothing staged"       0 "$(grep -cx STAGE <<<"${RECIPE_TRACE//|/$'\n'}")"
+chk "no superuser granted" 0 "$(grep -cx GRANT <<<"${RECIPE_TRACE//|/$'\n'}")"
+chk "no conversion ran"    0 "$(grep -cx 'kamal:app exec' <<<"${RECIPE_TRACE//|/$'\n'}")"
+chk "app NOT booted"       0 "$(grep -cx 'kamal:app boot' <<<"${RECIPE_TRACE//|/$'\n'}")"
+case "$RECIPE_OUT" in
+  *"SNAPSHOT FAILED"*"source is untouched"*)
+    echo "  ok   says the source was only read" ;;
+  *) echo "  FAIL silent or vague: ${RECIPE_OUT:-(no output)}"; fail=1 ;;
+esac
+unset FAIL_SNAP
+
+echo "32e. a host without sqlite3 refuses rather than falling back to cp"
+# The fallback is the bug. Absence is modelled by running with nothing but the
+# stubs on PATH, because removing the stub alone would find the real binary.
+NO_SQLITE3=1 FAIL_COPY='' FAIL_REVOKE='' FAIL_SCP='' FAIL_STAGE='' FAIL_STOP='' \
+  run_cutover
+chk "nothing transferred"  0 "$(grep -cx scp <<<"${RECIPE_TRACE//|/$'\n'}")"
+chk "no conversion ran"    0 "$(grep -cx 'kamal:app exec' <<<"${RECIPE_TRACE//|/$'\n'}")"
+chk "app NOT booted"       0 "$(grep -cx 'kamal:app boot' <<<"${RECIPE_TRACE//|/$'\n'}")"
+case "$RECIPE_OUT" in
+  *"no sqlite3"*) echo "  ok   names what is missing" ;;
+  *) echo "  FAIL does not say why: ${RECIPE_OUT:-(no output)}"; fail=1 ;;
+esac
+unset NO_SQLITE3
+
+echo "32f. Active Storage blobs are copied, before the conversion and the boot"
+# The conversion copies active_storage_blobs rows; with :local storage the files
+# they name sit beside the SQLite file on the source, and the volume here is new.
+# Skipped, every attachment 404s from metadata that says it exists.
+FAIL_COPY='' FAIL_REVOKE='' FAIL_SCP='' FAIL_STAGE='' FAIL_STOP='' run_cutover
+chk "blobs sent"     1 "$(grep -cx TAR_SEND <<<"${RECIPE_TRACE//|/$'\n'}")"
+chk "blobs unpacked" 1 "$(grep -cx BLOBS <<<"${RECIPE_TRACE//|/$'\n'}")"
+chk "staged, then blobs, then granted" 1 \
+  "$(grep -q 'STAGE|TAR_SEND|BLOBS|GRANT' <<<"$RECIPE_TRACE" && echo 1 || echo 0)"
+chk "the SQLite files are excluded from that copy" 1 \
+  "$(grep -c "exclude='\*.sqlite3\*'" <<<"$recipe")"
+
+echo "32g. a failed blob copy converts nothing"
+# Worth stopping for rather than warning about: the database would be correct and
+# the app would boot, so the only symptom is broken attachments — found later, by
+# a user, with the source already stopped.
+FAIL_BLOB=1 FAIL_COPY='' FAIL_REVOKE='' FAIL_SCP='' FAIL_STAGE='' FAIL_STOP='' \
+  run_cutover
+chk "no superuser granted" 0 "$(grep -cx GRANT <<<"${RECIPE_TRACE//|/$'\n'}")"
+chk "no conversion ran"    0 "$(grep -cx 'kamal:app exec' <<<"${RECIPE_TRACE//|/$'\n'}")"
+chk "app NOT booted"       0 "$(grep -cx 'kamal:app boot' <<<"${RECIPE_TRACE//|/$'\n'}")"
+case "$RECIPE_OUT" in
+  *"BLOB COPY FAILED"*"attachments"*)
+    echo "  ok   says what booting now would produce" ;;
+  *) echo "  FAIL silent or vague: ${RECIPE_OUT:-(no output)}"; fail=1 ;;
+esac
+unset FAIL_BLOB
+
+echo "32h. a sending tar that fails is caught, though the receiver is happy"
+# The status of a pipeline is its last element's. Read as \$?, a tar that cannot
+# read the source sends an empty stream to a receiver that unpacks it and exits
+# 0 — a blob copy that copied nothing, reported as success, on the one path
+# where the source is already stopped and the evidence is behind you.
+FAIL_TAR=1 FAIL_BLOB='' FAIL_COPY='' FAIL_REVOKE='' FAIL_SCP='' FAIL_STAGE='' \
+  FAIL_STOP='' run_cutover
+chk "the receiver did succeed" 1 "$(grep -cx BLOBS <<<"${RECIPE_TRACE//|/$'\n'}")"
+chk "no conversion ran"        0 "$(grep -cx 'kamal:app exec' <<<"${RECIPE_TRACE//|/$'\n'}")"
+chk "app NOT booted"           0 "$(grep -cx 'kamal:app boot' <<<"${RECIPE_TRACE//|/$'\n'}")"
+case "$RECIPE_OUT" in
+  *"BLOB COPY FAILED"*) echo "  ok   the sending half is not trusted to ssh" ;;
+  *) echo "  FAIL the empty stream passed for a copy: ${RECIPE_OUT:-(no output)}"
+     fail=1 ;;
+esac
+unset FAIL_TAR
 
 echo "33. staging renames into place rather than writing the live path directly"
 # An interrupted copy must leave the previous file intact, not a truncated
@@ -1900,6 +2049,19 @@ STUB
   cat > "$work/bin/psql" <<'STUB'
 #!/usr/bin/env bash
 sql="${*: -1}"
+# $app_db comes out of a state file, and DB_NAME accepts names that an unquoted
+# identifier cannot carry — the launch script creates them through format('%I').
+# Modelled at the parser rather than asserted about, so the case fails the way
+# the cluster fails: syntax error, no state change, and a read-back that then
+# disagrees with the ALTER.
+case "$sql" in
+  *"ALTER DATABASE"*)
+    ident="${sql#*ALTER DATABASE }"; ident="${ident%% CONNECTION*}"
+    case "$ident" in
+      '"'*'"')      : ;;
+      *[!a-z0-9_]*) echo 'ERROR:  syntax error at or near "-"' >&2; exit 1 ;;
+    esac ;;
+esac
 case "$sql" in
   *"CONNECTION LIMIT 0"*)      echo "limit:0"        >>"$TRACE"
                                [ -n "$FAIL_SHUT" ] || echo 0 > "$CONNLIMIT"
@@ -2076,6 +2238,29 @@ echo "86e. a failing re-open on the refusal path is reported too"
 LIVE=1 KILLED=0 FAIL_RESTORE='' FAIL_REOPEN=1 run_restore
 chk "nothing dropped"             0 "$(grep -c '^PG_RESTORE_RAN$' <<<"${R_TRACE//|/$'\n'}")"
 chk "told the door is still shut" 1 "$(grep -c 'RE-OPEN FAILED' <<<"$R_OUT")"
+unset FAIL_REOPEN
+
+echo "86f. a database name that needs quoting is shut, restored and re-opened"
+# `collavre-prod` is a legal DB_NAME: the launch script creates the database
+# through format('%I') and URL-encodes it into DATABASE_URL, so a host can be
+# running on one. Unquoted here PostgreSQL reads the hyphen as subtraction, the
+# read-back then answers -1, and this block refuses with restore_status=3 — a
+# host whose backups cannot be restored by the runbook that wrote them.
+APP_DB='collavre-prod' LIVE=0 KILLED=0 FAIL_RESTORE='' run_restore
+chk "the door was shut"      1 "$(grep -cx 'limit:0' <<<"${R_TRACE//|/$'\n'}")"
+chk "and confirmed shut"     0 "$(grep -c 'REFUSING' <<<"$R_OUT")"
+chk "restore ran"            1 "$(grep -cx 'PG_RESTORE_RAN' <<<"${R_TRACE//|/$'\n'}")"
+chk "re-opened"              1 "$(grep -cx 'limit:reopened' <<<"${R_TRACE//|/$'\n'}")"
+chk "operator told to boot"  1 "$(grep -c 'app boot' <<<"$R_OUT")"
+
+echo "86g. and the recovery it prints for such a name is runnable as printed"
+# The recovery is pasted, so the identifier's quotes have to survive the shell
+# that pastes it. Printed inside double quotes they would be eaten and the
+# command would fail exactly where the operator has no other route left.
+APP_DB='collavre-prod' LIVE=0 KILLED=0 FAIL_RESTORE='' FAIL_REOPEN=1 run_restore
+chk "told the door is still shut" 1 "$(grep -c 'RE-OPEN FAILED' <<<"$R_OUT")"
+chk "the printed ALTER quotes the name" 1 \
+  "$(grep -cF "'ALTER DATABASE \"collavre-prod\" CONNECTION LIMIT -1'" <<<"$R_OUT")"
 unset FAIL_REOPEN
 
 # --- dedupe_authorized_keys -------------------------------------------------

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -21,7 +21,7 @@ SRC="${1:-$ROOT/script/lightsail_launch.sh}"
 # die() is a one-liner; the others run to the first column-1 closing brace.
 eval "$(awk '
   /^die\(\) \{/ { print; next }
-  /^(ensure_block|ensure_sudoers|in_group|write_state_file|record_deploy_user_grant|revoke_deploy_user_access|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|install_deploy_ssh_dir|reassign_prior_db_role|refuse_superuser_db_rotation|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps|dedupe_authorized_keys|install_staged_authorized_keys|postgresql_conf_includes_confd|role_owns_app_objects|refuse_db_name_change|refuse_defaulted_config_change|refuse_unusable_db_identifier|refuse_unparsable_ssh_key|passwd_home|ssh_key_holder|adopt_legacy_ssh_key_marker)\(\) \{/ { f = 1 }
+  /^(ensure_block|ensure_sudoers|in_group|write_state_file|record_deploy_user_grant|revoke_deploy_user_access|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|install_deploy_ssh_dir|reassign_prior_db_role|refuse_superuser_db_rotation|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps|dedupe_authorized_keys|install_staged_authorized_keys|postgresql_conf_includes_confd|role_owns_app_objects|refuse_db_name_change|refuse_defaulted_config_change|refuse_unusable_db_identifier|refuse_unparsable_ssh_key|passwd_home|ssh_key_holder|adopt_legacy_ssh_key_marker|record_db_role_grant|reassign_one_db_role|record_ssh_key_grant)\(\) \{/ { f = 1 }
   f { print }
   f && /^\}/ { f = 0 }
 ' "$SRC")"
@@ -38,6 +38,7 @@ for fn in die ensure_block ensure_sudoers in_group write_state_file \
           refuse_db_name_change refuse_defaulted_config_change \
           refuse_unusable_db_identifier refuse_unparsable_ssh_key \
           passwd_home ssh_key_holder \
+          record_db_role_grant reassign_one_db_role record_ssh_key_grant \
           adopt_legacy_ssh_key_marker; do
   declare -F "$fn" >/dev/null || {
     echo "could not extract $fn() from $SRC — has the definition moved?" >&2
@@ -104,8 +105,14 @@ ensure_block "$f" hostname "127.0.1.1 collavre"
 chk "byte-identical" "$before" "$(cat "$f")"
 
 echo "4. ownership and permissions survive the rewrite"
-# pg_hba.conf is postgres:postgres 0640; a mv from mktemp would leave it
-# root:root 0600 and PostgreSQL would fail to start.
+# pg_hba.conf is postgres:postgres 0640; a staging file left at mktemp's
+# root:root 0600 would stop PostgreSQL reading it back.
+#
+# The inode deliberately changes. It used not to: the block was copied through
+# the live inode with `cat "$tmp" > "$file"` precisely to keep the mode, and
+# that is what made the rewrite non-atomic — see 4a. Preserving the mode is the
+# invariant; preserving the inode was the mechanism, and asserting the
+# mechanism here is what would forbid the fix.
 f=$(mktemp)
 printf 'A\n' > "$f"
 ensure_block "$f" docker "OLD"
@@ -113,7 +120,83 @@ chmod 0640 "$f"
 ino="$(inode "$f")"
 ensure_block "$f" docker "NEW"
 chk "mode preserved"  "640"  "$(file_mode "$f")"
-chk "same inode"      "$ino" "$(inode "$f")"
+if [ "$ino" = "$(inode "$f")" ]; then
+  echo "  FAIL rewritten through the live inode rather than renamed into place"; fail=1
+else
+  echo "  ok   renamed into place, so the live path is never a partial file"
+fi
+
+echo "4a. a copy that fails does not leave the live file truncated"
+# The previous form ended in `cat "$tmp" > "$file"`, which truncates the live
+# path when the redirection opens — so a run that died during the copy left the
+# file holding a prefix of itself. Measured on that revision by sampling the
+# live path during the rewrite of a 10MB pg_hba.conf: 0 bytes. This helper
+# rewrites /etc/fstab, /etc/hosts, postgresql.conf and pg_hba.conf, and each
+# fails differently: an empty pg_hba.conf refuses every connection, a truncated
+# fstab loses mounts, and a block left without its END marker makes the *next*
+# run die on "repair or delete it by hand" instead of converging.
+#
+# Injected rather than sampled or killed. Both of those are races: measured at
+# ~1MB the sampling loop missed the window on 3 runs in 8, and a flaky control
+# is worse than none. Shadowing the copy is deterministic and models exactly
+# the failure — a copy that does not complete — in the same way cases 44-46
+# shadow grep and mktemp.
+f=$(mktemp)
+{ printf '# BEGIN collavre:docker\nOLD\n# END collavre:docker\n'
+  printf 'operator-line\n'; } > "$f"
+# shellcheck disable=SC2329  # shadows cat for ensure_block only
+cat() { return 1; }
+ensure_block "$f" docker "NEW" || true
+unset -f cat
+chk "the operator's line survived"  1 "$(grep -cxF 'operator-line' "$f")"
+chk "the END marker survived"       1 "$(grep -cxF '# END collavre:docker' "$f")"
+chk "the file is not empty"         1 "$([ -s "$f" ] && echo 1 || echo 0)"
+chk "no staging file left beside it" 0 \
+  "$(find "$(dirname "$f")" -maxdepth 1 -name "$(basename "$f").collavre.*" | wc -l | tr -d ' ')"
+
+echo "4b. a symlinked target is written through, not replaced by the rename"
+# The regression the rename introduces and the copy did not have. rename(2)
+# does not follow symlinks: pointed at a symlinked /etc/hosts — which is how a
+# host running systemd-resolved or a config-management tool is often laid out —
+# an unresolved `mv` swaps the link itself for a regular file, and the real file
+# every other reader still resolves to keeps whatever it held before. Measured
+# on the same helper with the resolution removed:
+#
+#   link is a symlink afterwards   no
+#   real file                      OLD      <- the run reported success
+#   link (now a regular file)      NEW
+#
+# So the block converges on a file nothing reads, and the next run reads its own
+# managed block back out of it and reports converged again. The append branch
+# writes *through* the link, so this is also what keeps the first run and every
+# later one meaning the same file.
+d=$(mktemp -d)
+printf 'A\n' > "$d/real"
+ln -s "$d/real" "$d/link"
+ensure_block "$d/link" docker "OLD"
+ensure_block "$d/link" docker "NEW"
+chk "still a symlink"              "yes" "$([ -L "$d/link" ] && echo yes || echo no)"
+chk "the real file has the block"  1 "$(grep -cxF 'NEW' "$d/real")"
+chk "and no second regular file"   1 "$(find "$d" -maxdepth 1 -type f | wc -l | tr -d ' ')"
+# Relative targets resolve against the link's own directory, not $PWD — the
+# form /etc/postgresql/17/main/pg_hba.conf takes when a tool points it at a
+# sibling. Resolving against $PWD would create the file in the harness's cwd.
+mkdir -p "$d/sub"
+printf 'A\n' > "$d/sub/rel-real"
+ln -s rel-real "$d/sub/rel-link"
+ensure_block "$d/sub/rel-link" docker "OLD"
+ensure_block "$d/sub/rel-link" docker "NEW"
+chk "relative link resolved beside itself" 1 "$(grep -cxF 'NEW' "$d/sub/rel-real")"
+chk "nothing created in the cwd"           0 "$(find . -maxdepth 1 -name 'rel-real' | wc -l | tr -d ' ')"
+# A loop must refuse rather than spin: this runs as root over /etc.
+ln -s "$d/loop-b" "$d/loop-a"
+ln -s "$d/loop-a" "$d/loop-b"
+out="$( (ensure_block "$d/loop-a" docker "NEW") 2>&1 )"
+chk "a symlink loop is refused" 1 "$?"
+case "$out" in
+  *"too deep to follow"*) echo "  ok   says what it will not chase" ;;
+  *) echo "  FAIL unhelpful: $out"; fail=1 ;;
+esac
 
 echo "5. multi-line bodies are replaced whole"
 f=$(mktemp)
@@ -1277,12 +1360,28 @@ revoke_prior_ssh_key "$AK" "$st3/ssh_public_key"
 unset -f grep
 chk "the account keeps a way in"      1 "$(command grep -cxF "$NEW" "$AK")"
 chk "the un-withdrawn key is kept"    1 "$(command grep -cxF "$OLD" "$AK")"
-# If the marker advanced, no later run would ever retry the withdrawal.
-chk "marker still names the old key" "$OLD" "$(cat "$st3/ssh_public_key")"
+# The retry record is the queue, not the marker. The marker names the key the
+# host is deployed with and advances; a key whose withdrawal failed stays
+# queued, which is what makes a later run try again. Asserted on the queue
+# rather than on the marker because the previous form could only express one of
+# the two, and expressed the wrong one — see 44a.
+chk "the un-withdrawn key stays queued" 1 \
+  "$(command grep -cxF "$OLD" "$st3/ssh_public_keys" 2>/dev/null || echo 0)"
+chk "and the marker names the deployed key" "$NEW" "$(cat "$st3/ssh_public_key")"
+
 case "$LOGGED" in
   *WARNING*"still authorized"*) echo "  ok   the failure is reported, not claimed as a success" ;;
   *) echo "  FAIL silent or reported as withdrawn: $LOGGED"; fail=1 ;;
 esac
+
+echo "44a. and the NEXT run actually retries the withdrawal it could not do"
+# The point of keeping the record: without this, 44 asserts only that a file
+# has a line in it. Same state dir, same authorized_keys, no shadowed grep.
+LOGGED=""
+revoke_prior_ssh_key "$AK" "$st3/ssh_public_key"
+chk "the old key is withdrawn on the retry" 0 "$(command grep -cxF "$OLD" "$AK")"
+chk "the account still has its key"         1 "$(command grep -cxF "$NEW" "$AK")"
+chk "and the queue is down to the current key" "$NEW" "$(cat "$st3/ssh_public_keys")"
 
 echo "45. a rewrite that stops PART WAY also keeps the old key instead of none"
 # Case 40 is the write that produces nothing. This is the write that produces
@@ -1311,7 +1410,9 @@ unset -f grep
 chk "the account keeps a way in"     1 "$(command grep -cxF "$NEW" "$AK")"
 chk "the un-withdrawn key is kept"   1 "$(command grep -cxF "$OLD" "$AK")"
 chk "the operator's key is kept"     1 "$(command grep -cxF "$OPERATOR" "$AK")"
-chk "marker still names the old key" "$OLD" "$(cat "$st4/ssh_public_key")"
+chk "the un-withdrawn key stays queued" 1 \
+  "$(command grep -cxF "$OLD" "$st4/ssh_public_keys" 2>/dev/null || echo 0)"
+chk "and the marker names the deployed key" "$NEW" "$(cat "$st4/ssh_public_key")"
 case "$LOGGED" in
   *WARNING*"still authorized"*) echo "  ok   the partial write is reported, not claimed as a success" ;;
   *) echo "  FAIL silent or reported as withdrawn: $LOGGED"; fail=1 ;;
@@ -1342,8 +1443,17 @@ TEMPLATE_LOG="$st5/mktemp_template"
 mktemp() { printf '%s\n' "${1:-(no template)}" >> "$TEMPLATE_LOG"; command mktemp "$@"; }
 revoke_prior_ssh_key "$AK" "$st5/ssh_public_key"
 unset -f mktemp
+# The authorized_keys rewrite specifically, not merely the first mktemp of the
+# call: this function also writes state files under $STATE_DIR through
+# write_state_file, which legitimately stages beside *those*. Matching on the
+# .revoke. template is what keeps the assertion about the file the operator
+# logs in with — and it still fails on an implementation that stages in TMPDIR,
+# since there would then be no such line at all.
+revoke_template="$(command grep -F '.revoke.' "$TEMPLATE_LOG" | head -1)"
+chk "the authorized_keys rewrite was staged at all" \
+  1 "$([ -n "$revoke_template" ] && echo 1 || echo 0)"
 chk "staged in the target's own directory" \
-  "$(dirname "$AK")" "$(dirname "$(head -1 "$TEMPLATE_LOG")")"
+  "$(dirname "$AK")" "$(dirname "$revoke_template")"
 chk "the rotation still completed"  0 "$(command grep -cxF "$OLD" "$AK")"
 chk "the new key is authorized"     1 "$(command grep -cxF "$NEW" "$AK")"
 chk "no scratch file left behind"   0 "$(find "$(dirname "$AK")" -name '*.revoke.*' | wc -l | tr -d ' ')"
@@ -1379,7 +1489,14 @@ psql_as_postgres() {
 }
 # shellcheck disable=SC2329  # called by reassign_prior_db_role
 log() { LOGGED="$LOGGED $*"; }
-rotate() { SQL=""; LOGGED=""; reassign_prior_db_role "$@"; }
+# Clears the queue, so each case starts from a host whose entire recorded state
+# is the marker it just wrote. Before the queue existed, `db_user` was the only
+# input and every case could share one state dir; now a rotation leaves a
+# db_users file behind, and a later case that rewrites only the marker would
+# otherwise inherit the previous case's predecessor. Use rotate_resume for the
+# cases that mean to carry that state over.
+rotate() { SQL=""; LOGGED=""; rm -f "${2%/*}/db_users"; reassign_prior_db_role "$@"; }
+rotate_resume() { SQL=""; LOGGED=""; reassign_prior_db_role "$@"; }
 
 echo "47. rotating DB_USER moves the tables and retires the old credential"
 # ALTER DATABASE ... OWNER only moves the database. Every table and sequence
@@ -1394,8 +1511,31 @@ chk "ownership moved, then login revoked" \
     "$SQL"
 
 echo "48. an unchanged DB_USER touches nothing"
-rotate collavre_user "$d3/db_user"
+# Its own state dir, rather than continuing from 47. 47 leaves a host mid-
+# rotation: it moved the objects to collavre_app and — as the real script does
+# on the next line, and this harness does not — had yet to advance the marker.
+# Re-running there with collavre_user is not "unchanged DB_USER", it is the
+# interrupted A -> B -> C sequence, and reassigning is the correct answer to it
+# (see 48a). Sharing $d3 only looked harmless while the single marker was
+# forgetting the predecessor that makes the two cases different.
+d3b=$(mktemp -d); printf 'collavre_user\n' > "$d3b/db_user"
+rotate collavre_user "$d3b/db_user"
 chk "no SQL" "" "$SQL$LOGGED"
+
+echo "48a. a rotation interrupted before the marker advanced is still completed"
+# Continuing from 47 deliberately: objects with collavre_app, marker still at
+# collavre_user, which is where a run killed between the reassign and the
+# marker write leaves the host. Asking for a third role must move the objects
+# from the one that actually holds them.
+#
+# Against the previous revision this reassigns from collavre_user — the marker
+# — which owns nothing, so nothing moves, and the summary hands out a
+# DATABASE_URL for a role that cannot read a table.
+rotate_resume collavre_third "$d3/db_user"
+chk "moved from the role that actually owns them" \
+    '|REASSIGN OWNED BY "collavre_app" TO "collavre_third"|ALTER ROLE "collavre_app" NOLOGIN' \
+    "$SQL"
+chk "and the queue is down to the current role" "collavre_third" "$(cat "$d3/db_users")"
 
 echo "49. a superuser predecessor stops the run rather than half-rotating it"
 # DB_USER=postgres on a first run is legal, and the rotation away from it cannot
@@ -1405,6 +1545,14 @@ echo "49. a superuser predecessor stops the run rather than half-rotating it"
 # and the advanced marker meant no later run looked at the old role again.
 printf 'postgres\n' > "$d3/db_user"
 ROLE_IS_SUPER=t
+# `rotate` runs in a subshell here, to capture the die() output, so the SQL=""
+# it performs does not reach this shell — "$SQL" below is whatever the last
+# non-subshell case left behind. That read as a pass only while the preceding
+# case happened to run no SQL; 48a runs some. Same shape as the leak recorded
+# at 86c, one variable over: state a case relies on being empty has to be made
+# empty here rather than assumed.
+SQL=""
+rm -f "$d3/db_users"
 out="$( (rotate collavre_app "$d3/db_user") 2>&1 )"
 chk "exits non-zero" 1 "$?"
 chk "no SQL ran"     "" "$SQL"

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -1722,6 +1722,17 @@ run_restore() {
 #!/usr/bin/env bash
 while [ "${1:-}" = -u ] || [ "${1:-}" = postgres ]; do shift; done
 exec "$@"
+  # The recipe reads the configured DB_USER out of the state file the script
+  # writes, so the harness has to answer for it. Unset APP_ROLE means the file
+  # is absent — which is a case under test, not a default to paper over, since
+  # "the question could not be answered" has to refuse just as "yes" does.
+  cat > "$work/bin/cat" <<'STUB'
+#!/usr/bin/env bash
+if [ "${1:-}" = /var/lib/collavre/db_user ]; then
+  [ -n "${APP_ROLE-}" ] || { echo "cat: $1: No such file or directory" >&2; exit 1; }
+  printf '%s\n' "$APP_ROLE"; exit 0
+fi
+exec /bin/cat "$@"
 STUB
   # datconnlimit is modelled as state rather than as a canned answer, because
   # the whole point of reading it back is that it disagrees with the ALTER when
@@ -1737,6 +1748,7 @@ case "$sql" in
                                [ -n "$FAIL_SHUT" ] || echo 0 > "$CONNLIMIT"
                                [ -z "$FAIL_SHUT" ] || { echo 'ERROR:  database "x" does not exist' >&2; exit 1; } ;;
   *"CONNECTION LIMIT -1"*)     echo "limit:reopened" >>"$TRACE"; echo -1 > "$CONNLIMIT" ;;
+  *rolsuper*)                  echo "rolsuper"       >>"$TRACE"; printf '%s' "$APP_SUPER" ;;
   *datconnlimit*)              echo "readback"       >>"$TRACE"; cat "$CONNLIMIT" ;;
   *pg_terminate_backend*)      echo "terminate"      >>"$TRACE"; echo "${KILLED:-0}" ;;
   *"count(*)"*)                echo "count"          >>"$TRACE"; printf '%s' "$LIVE" ;;
@@ -1754,8 +1766,12 @@ STUB
   # ${LIVE-0}, not ${LIVE:-0}: the empty string is a case under test — it is what
   # a failed check returns — and :- would quietly turn it back into "0", making
   # the one assertion about a broken gate pass for the wrong reason.
+  # APP_SUPER likewise takes ${x-y}, not ${x:-y}: an empty rolsuper is what a
+  # role that does not exist, or a cluster that cannot be reached, comes back
+  # as, and it must not be rewritten into the one value that lets the gate open.
   export TRACE LIVE="${LIVE-0}" KILLED="${KILLED:-0}" FAIL_RESTORE="${FAIL_RESTORE:-}" \
-         FAIL_SHUT="${FAIL_SHUT:-}" CONNLIMIT="$work/connlimit"
+         FAIL_SHUT="${FAIL_SHUT:-}" CONNLIMIT="$work/connlimit" \
+         APP_ROLE="${APP_ROLE-collavre_user}" APP_SUPER="${APP_SUPER-f}"
   R_OUT="$(cd "$work" && PATH="$work/bin:$PATH" bash ./recipe.sh 2>&1)"
   R_TRACE="$(paste -sd'|' "$TRACE")"
   rm -rf "$work"
@@ -1763,7 +1779,13 @@ STUB
 
 echo "83. the restore shuts the database before it looks, and re-opens after"
 LIVE=0 KILLED=2 FAIL_RESTORE='' run_restore
-chk "door shut first"        "limit:0" "$(cut -d'|' -f1 <<<"$R_TRACE")"
+# The role check comes before the shut, and the shut before anything else the
+# block does — asserted as the whole prefix rather than as "the first entry",
+# so a step inserted between them fails here instead of silently reordering the
+# gate. Nothing may precede the role check: it decides whether shutting the
+# door means anything at all, and a refusal must leave the limit as it found it.
+chk "role checked, then shut, before all else" "rolsuper|limit:0" \
+  "$(cut -d'|' -f1,2 <<<"$R_TRACE")"
 chk "survivors terminated"   1 "$(grep -c '^terminate$' <<<"${R_TRACE//|/$'\n'}")"
 # The order is the whole point: counting before the limit is applied only says
 # the app happened to be between connections at that instant.
@@ -1820,6 +1842,40 @@ chk "not re-opened either"     0 "$(grep -c '^limit:reopened$' <<<"${R_TRACE//|/
 chk "operator told"            1 "$(grep -c 'could not shut collavre_production' <<<"$R_OUT")"
 chk "and told nothing was dropped" 1 "$(grep -c 'nothing was dropped' <<<"$R_OUT")"
 unset FAIL_SHUT
+
+echo "86b. a superuser DB_USER is refused, because the door would not hold it"
+# CONNECTION LIMIT is exempt for superusers — that exemption is what lets
+# pg_restore in, and it is role-wide, so it lets the app in too whenever the
+# app's own role is one. `DB_USER=postgres` on a first run is legal, so this is
+# a host the script produces. Measured on postgres:17 with datconnlimit at 0:
+#
+#   collavre_user (rolsuper f) -> FATAL: too many connections for database ...
+#   postgres      (rolsuper t) -> connected, and wrote a row
+#
+# The refusal has to come before the ALTER, not after: a run that cannot gate
+# must leave the connection limit exactly as it found it.
+APP_ROLE=postgres APP_SUPER=t LIVE=0 KILLED=0 FAIL_RESTORE='' run_restore
+chk "nothing dropped"        0 "$(grep -c '^PG_RESTORE_RAN$' <<<"${R_TRACE//|/$'\n'}")"
+chk "the door was never shut" 0 "$(grep -c '^limit:0$' <<<"${R_TRACE//|/$'\n'}")"
+chk "nor re-opened"          0 "$(grep -c '^limit:reopened$' <<<"${R_TRACE//|/$'\n'}")"
+chk "no sessions terminated" 0 "$(grep -c '^terminate$' <<<"${R_TRACE//|/$'\n'}")"
+chk "operator told"          1 "$(grep -c 'cannot shut this database to the app' <<<"$R_OUT")"
+# Refusing without naming the one check that does discriminate leaves the
+# operator with a blocked restore and no way forward — the failure this page
+# hit once already with the superuser rotation guard.
+chk "and given the check that does work" 1 "$(grep -c 'app details' <<<"$R_OUT")"
+
+echo "86c. an unanswerable rolsuper refuses too, rather than reading as 'no'"
+# `!= f`, not `= t`. Each of these comes back empty, and each is a host where
+# the gate cannot be shown to hold.
+for shape in "no state file:::" "no such role:ghost::" "cluster unreachable:collavre_user::"; do
+  IFS=: read -r what role _ _ <<<"$shape"
+  if [ -n "$role" ]; then APP_ROLE="$role"; else unset APP_ROLE; fi
+  APP_SUPER='' LIVE=0 KILLED=0 FAIL_RESTORE='' run_restore
+  chk "refused: $what" 1 "$(grep -c 'cannot shut this database to the app' <<<"$R_OUT")"
+  chk "  nothing dropped: $what" 0 "$(grep -c '^PG_RESTORE_RAN$' <<<"${R_TRACE//|/$'\n'}")"
+done
+unset APP_ROLE
 
 # --- dedupe_authorized_keys -------------------------------------------------
 #

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -21,14 +21,14 @@ SRC="${1:-$ROOT/script/lightsail_launch.sh}"
 # die() is a one-liner; the others run to the first column-1 closing brace.
 eval "$(awk '
   /^die\(\) \{/ { print; next }
-  /^(ensure_block|ensure_sudoers|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|reassign_prior_db_role)\(\) \{/ { f = 1 }
+  /^(ensure_block|ensure_sudoers|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|reassign_prior_db_role|revoke_prior_ssh_key)\(\) \{/ { f = 1 }
   f { print }
   f && /^\}/ { f = 0 }
 ' "$SRC")"
 
 for fn in die ensure_block ensure_sudoers revoke_prior_deploy_user \
           ensure_ufw_rule ssh_already_allowed ensure_ssh_rule \
-          install_authorized_keys reassign_prior_db_role; do
+          install_authorized_keys reassign_prior_db_role revoke_prior_ssh_key; do
   declare -F "$fn" >/dev/null || {
     echo "could not extract $fn() from $SRC — has the definition moved?" >&2
     exit 1
@@ -359,11 +359,13 @@ case "$*" in
   *"ALTER ROLE collavre_user NOSUPERUSER"*) echo REVOKE >>"$TRACE"
                                             [ -z "$FAIL_REVOKE" ] || exit 255 ;;
   *"sudo rm"*)                              echo RM_STAGED >>"$TRACE" ;;
-  *"sudo install"*)                         echo STAGE     >>"$TRACE" ;;
+  *"sudo install"*)                         echo STAGE     >>"$TRACE"
+                                            [ -z "$FAIL_STAGE" ] || exit 1 ;;
   *)                                        echo ssh       >>"$TRACE" ;;
 esac
 STUB
-  printf '#!/usr/bin/env bash\necho scp >>"$TRACE"\n' > "$work/bin/scp"
+  printf '#!/usr/bin/env bash\necho scp >>"$TRACE"\n[ -z "$FAIL_SCP" ] || exit 1\n' \
+    > "$work/bin/scp"
   cat > "$work/bin/kamal.sh" <<'STUB'
 #!/usr/bin/env bash
 echo "kamal:$1${2:+ $2}" >>"$TRACE"
@@ -374,13 +376,14 @@ STUB
 
   TRACE="$work/trace"; : > "$TRACE"
   export TRACE FAIL_COPY="${FAIL_COPY:-}" FAIL_REVOKE="${FAIL_REVOKE:-}"
+  export FAIL_SCP="${FAIL_SCP:-}" FAIL_STAGE="${FAIL_STAGE:-}"
   RECIPE_OUT="$(cd "$work" && PATH="$work/bin:$PATH" bash ./recipe.sh 2>&1)"
   RECIPE_TRACE="$(paste -sd'|' "$TRACE")"
   rm -rf "$work"
 }
 
 echo "23. a clean cutover cleans up and boots"
-FAIL_COPY='' FAIL_REVOKE='' run_cutover
+FAIL_COPY='' FAIL_REVOKE='' FAIL_SCP='' FAIL_STAGE='' run_cutover
 chk "staged file removed" 1 "$(grep -c RM_STAGED <<<"${RECIPE_TRACE//|/$'\n'}")"
 chk "app booted"          1 "$(grep -cx 'kamal:app boot' <<<"${RECIPE_TRACE//|/$'\n'}")"
 
@@ -389,7 +392,7 @@ echo "24. a failed copy does not boot, and keeps the file the retry needs"
 # partway leaves the database empty or half-populated. Booting serves that.
 # The `sudo rm` is the other half: it destroys the staged SQLite file, so a
 # retry would need another full scp of production rather than a re-run.
-FAIL_COPY=1 FAIL_REVOKE='' run_cutover
+FAIL_COPY=1 FAIL_REVOKE='' FAIL_SCP='' FAIL_STAGE='' run_cutover
 chk "app NOT booted"          0 "$(grep -cx 'kamal:app boot' <<<"${RECIPE_TRACE//|/$'\n'}")"
 chk "staged file kept"        0 "$(grep -c RM_STAGED <<<"${RECIPE_TRACE//|/$'\n'}")"
 chk "grant still taken back"  1 "$(grep -cx REVOKE <<<"${RECIPE_TRACE//|/$'\n'}")"
@@ -401,7 +404,7 @@ esac
 echo "25. a failed revoke does not boot the credential-bearing container"
 # collavre_user is the role in DATABASE_URL. Booting while it is still a
 # superuser hands every app container that privilege.
-FAIL_COPY='' FAIL_REVOKE=1 run_cutover
+FAIL_COPY='' FAIL_REVOKE=1 FAIL_SCP='' FAIL_STAGE='' run_cutover
 chk "app NOT booted" 0 "$(grep -cx 'kamal:app boot' <<<"${RECIPE_TRACE//|/$'\n'}")"
 case "$RECIPE_OUT" in
   *"REVOKE FAILED"*"left stopped"*) echo "  ok   the still-superuser role is reported" ;;
@@ -409,11 +412,43 @@ case "$RECIPE_OUT" in
 esac
 
 echo "26. both failing reports both, not just the first"
-FAIL_COPY=1 FAIL_REVOKE=1 run_cutover
+FAIL_COPY=1 FAIL_REVOKE=1 FAIL_SCP='' FAIL_STAGE='' run_cutover
 chk "app NOT booted" 0 "$(grep -cx 'kamal:app boot' <<<"${RECIPE_TRACE//|/$'\n'}")"
 case "$RECIPE_OUT" in
   *"REVOKE FAILED"*"COPY FAILED"*) echo "  ok   both reported" ;;
   *) echo "  FAIL one masked the other: $RECIPE_OUT"; fail=1 ;;
+esac
+
+echo "27. a failed scp never converts, so a stale snapshot cannot be restored"
+# The task loads from the file in the VOLUME, not from the one scp just sent.
+# Case 24 deliberately keeps the staged file so a retry need not re-copy — so
+# on a retry the volume holds the previous attempt's snapshot. Ungated, a
+# failed scp converts from THAT: production silently rolled back to older data,
+# reported as success, and the evidence deleted afterwards.
+FAIL_COPY='' FAIL_REVOKE='' FAIL_SCP=1 FAIL_STAGE='' run_cutover
+chk "no conversion ran"   0 "$(grep -cx 'kamal:app exec' <<<"${RECIPE_TRACE//|/$'\n'}")"
+chk "no superuser granted" 0 "$(grep -cx GRANT <<<"${RECIPE_TRACE//|/$'\n'}")"
+chk "app NOT booted"      0 "$(grep -cx 'kamal:app boot' <<<"${RECIPE_TRACE//|/$'\n'}")"
+chk "stale file NOT deleted" 0 "$(grep -c RM_STAGED <<<"${RECIPE_TRACE//|/$'\n'}")"
+case "$RECIPE_OUT" in
+  *"STAGING FAILED"*"stale"*) echo "  ok   the retry hazard is named, not just the failure" ;;
+  *) echo "  FAIL silent or vague: $RECIPE_OUT"; fail=1 ;;
+esac
+
+echo "28. a failed install into the volume is caught too, not just the scp"
+# scp can succeed to /tmp and the privileged install still fail — no space,
+# no docker group, volume gone.
+FAIL_COPY='' FAIL_REVOKE='' FAIL_SCP='' FAIL_STAGE=1 run_cutover
+chk "no conversion ran"    0 "$(grep -cx 'kamal:app exec' <<<"${RECIPE_TRACE//|/$'\n'}")"
+chk "no superuser granted" 0 "$(grep -cx GRANT <<<"${RECIPE_TRACE//|/$'\n'}")"
+chk "app NOT booted"       0 "$(grep -cx 'kamal:app boot' <<<"${RECIPE_TRACE//|/$'\n'}")"
+
+echo "29. staging renames into place rather than writing the live path directly"
+# An interrupted copy must leave the previous file intact, not a truncated
+# database the next run would happily convert from.
+case "$recipe" in
+  *".incoming"*"mv"*) echo "  ok   staged under a temporary name, then renamed" ;;
+  *) echo "  FAIL staging writes the live path directly"; fail=1 ;;
 esac
 
 # --- the fresh-install recipe ----------------------------------------------
@@ -443,12 +478,12 @@ STUB
   rm -rf "$work"
 }
 
-echo "27. a clean fresh install prints the admin password and boots"
+echo "30. a clean fresh install prints the admin password and boots"
 FAIL_LOAD='' run_fresh
 chk "app stopped first" 1 "$(grep -cx 'kamal:app stop' <<<"${FRESH_TRACE//|/$'\n'}")"
 chk "app booted"        1 "$(grep -cx 'kamal:app boot' <<<"${FRESH_TRACE//|/$'\n'}")"
 
-echo "28. a failed schema load does not boot the app onto a partial schema"
+echo "31. a failed schema load does not boot the app onto a partial schema"
 # db:schema:load drops and recreates every table, and db:seed is what creates
 # the first admin — so a load that resets the database but does not finish
 # leaves an app with no way to sign in and no owner on any record.
@@ -468,7 +503,7 @@ LOGGED=""
 # shellcheck disable=SC2329  # called by install_authorized_keys, eval'd from the script
 log() { LOGGED="$LOGGED $*"; }
 
-echo "29. the deploy user's own keys are not copied onto themselves"
+echo "32. the deploy user's own keys are not copied onto themselves"
 # APP_SSH_USER=ubuntu — src and dest are one file.
 h=$(mktemp -d); mkdir -p "$h/ubuntu/.ssh"
 printf 'ssh-ed25519 CLOUDKEY cloud\n' > "$h/ubuntu/.ssh/authorized_keys"
@@ -481,18 +516,73 @@ case "$LOGGED" in
   *) echo "  FAIL no explanation: $LOGGED"; fail=1 ;;
 esac
 
-echo "30. a separate deploy user still inherits the cloud user's keys"
+echo "33. a separate deploy user still inherits the cloud user's keys"
 mkdir -p "$h/collavre/.ssh"; : > "$h/collavre/.ssh/authorized_keys"
 SSH_PUBLIC_KEY="" LOGGED=""
 install_authorized_keys "$h/collavre/.ssh/authorized_keys" "$h"
 chk "cloud key copied" 1 "$(grep -c CLOUDKEY "$h/collavre/.ssh/authorized_keys")"
 
-echo "31. an explicit SSH_PUBLIC_KEY is added once, not once per run"
+echo "34. an explicit SSH_PUBLIC_KEY is added once, not once per run"
 # shellcheck disable=SC2034  # read by install_authorized_keys, eval'd from the script
 SSH_PUBLIC_KEY="ssh-ed25519 EXPLICIT me"
 install_authorized_keys "$h/collavre/.ssh/authorized_keys" "$h"
 install_authorized_keys "$h/collavre/.ssh/authorized_keys" "$h"
 chk "no duplicate" 1 "$(grep -c EXPLICIT "$h/collavre/.ssh/authorized_keys")"
+
+# --- revoke_prior_ssh_key ---------------------------------------------------
+#
+# The same family as the deploy-user and DB_USER rotations: appending the new
+# key converges the successor and leaves the predecessor authorized. This
+# account is in `docker` with passwordless sudo, so the key an operator thinks
+# they retired still reaches root.
+
+AK="$h/collavre/.ssh/authorized_keys"
+OLD="ssh-ed25519 OLDKEY retired"
+NEW="ssh-ed25519 NEWKEY current"
+OPERATOR="ssh-rsa OPKEY someone-else"
+st=$(mktemp -d)
+
+echo "35. rotating SSH_PUBLIC_KEY withdraws the key the last run installed"
+printf '%s\n%s\n' "$OLD" "$OPERATOR" > "$AK"
+printf '%s\n' "$OLD" > "$st/ssh_public_key"
+SSH_PUBLIC_KEY="$NEW" LOGGED=""
+install_authorized_keys "$AK" "$h"
+revoke_prior_ssh_key "$AK" "$st/ssh_public_key"
+chk "the new key is authorized"    1 "$(grep -cxF "$NEW" "$AK")"
+chk "the retired key is gone"      0 "$(grep -cxF "$OLD" "$AK")"
+chk "an operator's own key stays"  1 "$(grep -cxF "$OPERATOR" "$AK")"
+chk "state advanced to the new key" "$NEW" "$(cat "$st/ssh_public_key")"
+
+echo "36. an unchanged SSH_PUBLIC_KEY withdraws nothing"
+before="$(cat "$AK")"
+revoke_prior_ssh_key "$AK" "$st/ssh_public_key"
+chk "authorized_keys untouched" "$before" "$(cat "$AK")"
+
+echo "37. an empty SSH_PUBLIC_KEY means 'keep the cloud keys', not 'retire mine'"
+# Dropping the variable from a re-run must not strand the operator.
+SSH_PUBLIC_KEY=""
+revoke_prior_ssh_key "$AK" "$st/ssh_public_key"
+chk "nothing withdrawn" "$before" "$(cat "$AK")"
+
+echo "38. the predecessor is never withdrawn before the successor is in place"
+# An interrupted run must leave two usable keys, never zero.
+printf '%s\n' "$OLD" > "$AK"
+printf '%s\n' "$OLD" > "$st/ssh_public_key"
+SSH_PUBLIC_KEY="$NEW"
+revoke_prior_ssh_key "$AK" "$st/ssh_public_key"     # successor not added yet
+chk "the old key still lets you in" 1 "$(grep -cxF "$OLD" "$AK")"
+
+echo "39. first run and an already-absent key are no-ops"
+st2=$(mktemp -d)
+printf '%s\n' "$NEW" > "$AK"
+# shellcheck disable=SC2034  # read by revoke_prior_ssh_key, eval'd from the script
+SSH_PUBLIC_KEY="$NEW"
+revoke_prior_ssh_key "$AK" "$st2/ssh_public_key"    # no marker yet
+chk "key kept"          1 "$(grep -cxF "$NEW" "$AK")"
+chk "marker recorded"   "$NEW" "$(cat "$st2/ssh_public_key")"
+printf '%s\n' "$OLD" > "$st2/ssh_public_key"        # recorded but already removed
+revoke_prior_ssh_key "$AK" "$st2/ssh_public_key"
+chk "still just the new key" "$NEW" "$(cat "$AK")"
 
 unset -f log
 
@@ -519,7 +609,7 @@ psql_as_postgres() {
 log() { LOGGED="$LOGGED $*"; }
 rotate() { SQL=""; LOGGED=""; reassign_prior_db_role "$@"; }
 
-echo "32. rotating DB_USER moves the tables and retires the old credential"
+echo "40. rotating DB_USER moves the tables and retires the old credential"
 # ALTER DATABASE ... OWNER only moves the database. Every table and sequence
 # the app created stays with the old role, so the new one in DATABASE_URL gets
 # "permission denied" on its own data — while the old role keeps LOGIN and the
@@ -531,11 +621,11 @@ chk "ownership moved, then login revoked" \
     '|REASSIGN OWNED BY "collavre_user" TO "collavre_app"|ALTER ROLE "collavre_user" NOLOGIN' \
     "$SQL"
 
-echo "33. an unchanged DB_USER touches nothing"
+echo "41. an unchanged DB_USER touches nothing"
 rotate collavre_user "$d3/db_user"
 chk "no SQL" "" "$SQL$LOGGED"
 
-echo "34. a superuser predecessor is reported, never disabled"
+echo "42. a superuser predecessor is reported, never disabled"
 # DB_USER=postgres on a first run is legal. NOLOGIN on the cluster superuser
 # locks every operator out of administering it — peer auth needs LOGIN too, so
 # there is no way back in.
@@ -548,7 +638,7 @@ case "$LOGGED" in
   *) echo "  FAIL silent: $LOGGED"; fail=1 ;;
 esac
 
-echo "35. first run, emptied marker and a dropped role are all no-ops"
+echo "43. first run, emptied marker and a dropped role are all no-ops"
 d4=$(mktemp -d)
 ROLE_IS_SUPER=f
 rotate collavre_user "$d4/db_user"          # no marker yet

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -823,6 +823,28 @@ esac
 
 unset -f ufw log
 
+echo "26a. SSH is authorized before the live incoming policy is tightened"
+# On an existing active firewall, `ufw default deny incoming` changes the live
+# policy immediately. The allow rule must therefore already exist when that
+# command runs; placing it only before `ufw --force enable` still leaves an
+# interruption window that can lock out the operator running this over SSH.
+fw_step="$(awk '
+  /^log "7\/9 firewall"/ { f = 1 }
+  f { print }
+  f && /^log "8\/9 nightly backups"/ { exit }
+' "$SRC")"
+fw_ssh_line="$(printf '%s\n' "$fw_step" |
+		 grep -n '^ensure_ssh_rule$' | cut -d: -f1)"
+fw_deny_line="$(printf '%s\n' "$fw_step" |
+		  grep -n '^ufw default deny incoming$' | cut -d: -f1)"
+if [ -n "$fw_ssh_line" ] && [ -n "$fw_deny_line" ] &&
+   [ "$fw_ssh_line" -lt "$fw_deny_line" ]; then
+  echo "  ok   the SSH allow rule precedes default deny incoming"
+else
+  echo "  FAIL default deny incoming can take effect before SSH is authorized"
+  fail=1
+fi
+
 # --- docs/deploy_to_lightsail.md, the SQLite cutover ------------------------
 #
 # This recipe hands the app role SUPERUSER, resets and reloads the production
@@ -5691,6 +5713,31 @@ chk "but an inactive daemon with no valid disk config stops" 1 \
 chk "and names the socket activation risk"                  1 \
   "$(printf '%s' "$vh_inactive_unread" | grep -c 'socket-activated connection')"
 
+# A global-only probe misses Match overrides. This stub gives the safe global
+# answer unless sshd is asked about deploybot, for whom password login remains
+# enabled. The reviewed implementation therefore passes this check; a
+# contextual verifier must stop.
+printf '%s\n' \
+  '#!/bin/sh' \
+  'printf "%s\n" "$*" > "$SSHD_ARGS_FILE"' \
+  'case " $* " in' \
+  '  *" -C user=deploybot "*) password=yes ;;' \
+  '  *) password=no ;;' \
+  'esac' \
+  'printf "passwordauthentication %s\npermitrootlogin no\nkbdinteractiveauthentication no\n" "$password"' \
+  > "$vshd/bin/sshd"
+chmod +x "$vshd/bin/sshd"
+SSHD_ARGS_FILE="$vshd/sshd.args"
+export SSHD_ARGS_FILE
+vh_match="$( ( PATH="$vshd/bin:$PATH"
+  verify_ssh_hardening "" "$vshd" 0 deploybot ) >/dev/null 2>&1
+  printf 'rc=%s\n' "$?" )"
+chk "a deploy-user Match override stops the run"          1 \
+  "$(printf '%s' "$vh_match" | grep -c '^rc=1$')"
+chk "and sshd was given the deploy-user context"          1 \
+  "$(grep -c -- '-C user=deploybot' "$SSHD_ARGS_FILE")"
+unset SSHD_ARGS_FILE
+
 # Source level, because every row above passes on a revision that writes the
 # drop-in under the losing name and never reads anything back.
 chk "the drop-in is written where it sorts first"         1 \
@@ -5707,7 +5754,7 @@ chk "the sysctl drop-in is staged too"                    1 \
 chk "and the inert 99- file it replaces is removed"       1 \
   "$(grep -c '^rm -f /etc/ssh/sshd_config\.d/99-collavre\.conf$' "$SRC")"
 chk "and the run reads back what sshd resolved"           1 \
-  "$(grep -cF 'verify_ssh_hardening "" /etc/ssh "$SSH_RELOAD_STATE"' "$SRC")"
+  "$(grep -cF 'verify_ssh_hardening "" /etc/ssh "$SSH_RELOAD_STATE" "$APP_SSH_USER"' "$SRC")"
 
 # The claim is about what sshd does with two files, so sshd is asked. The name
 # and the body both come from the script: a harness that wrote its own 01- file

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -1380,6 +1380,16 @@ chk "the retired key is gone"      0 "$(grep -cxF "$OLD" "$AK")"
 chk "an operator's own key stays"  1 "$(grep -cxF "$OPERATOR" "$AK")"
 chk "state advanced to the new key" "$NEW" "$(cat "$st/ssh_public_key")"
 
+echo "39a. rotating an SSH key preserves queue whitespace while matching it"
+SPACED_OLD="  ssh-ed25519 SPACEKEY retired  "
+st_spaced=$(mktemp -d)
+printf '%s\n%s\n' "$SPACED_OLD" "$NEW" > "$AK"
+printf '%s\n' "$SPACED_OLD" > "$st_spaced/ssh_public_key"
+SSH_PUBLIC_KEY="$NEW"
+revoke_prior_ssh_key "$AK" "$st_spaced/ssh_public_key"
+chk "the whitespace-prefixed key is gone" 0 "$(grep -cxF "$SPACED_OLD" "$AK")"
+chk "the current key still lets you in"   1 "$(grep -cxF "$NEW" "$AK")"
+
 echo "40. an unchanged SSH_PUBLIC_KEY withdraws nothing"
 before="$(cat "$AK")"
 revoke_prior_ssh_key "$AK" "$st/ssh_public_key"

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -21,7 +21,7 @@ SRC="${1:-$ROOT/script/lightsail_launch.sh}"
 # die() is a one-liner; the others run to the first column-1 closing brace.
 eval "$(awk '
   /^die\(\) \{/ { print; next }
-  /^(ensure_block|ensure_sudoers|in_group|write_state_file|record_deploy_user_grant|revoke_deploy_user_access|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|install_deploy_ssh_dir|reassign_prior_db_role|refuse_superuser_db_rotation|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps|dedupe_authorized_keys|install_staged_authorized_keys|postgresql_conf_includes_confd|role_owns_app_objects|refuse_db_name_change|refuse_defaulted_config_change|refuse_unusable_db_identifier|refuse_unparsable_ssh_key|refuse_forced_command_ssh_key|ipv4_dotted_quad|refuse_unusable_bind_address|refuse_unusable_subnet|passwd_home|ssh_key_holder|adopt_legacy_ssh_key_marker|record_db_role_grant|reassign_one_db_role|record_ssh_key_grant|refuse_root_deploy_user|append_state_line|refuse_nologin_deploy_user|resolve_symlink_chain|stage_beside|stage_authorized_keys|verify_ssh_hardening)\(\) \{/ { f = 1 }
+  /^(ensure_block|ensure_sudoers|in_group|write_state_file|record_deploy_user_grant|revoke_deploy_user_access|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|install_deploy_ssh_dir|reassign_prior_db_role|refuse_superuser_db_rotation|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps|dedupe_authorized_keys|install_staged_authorized_keys|postgresql_conf_includes_confd|role_owns_app_objects|refuse_db_name_change|refuse_defaulted_config_change|refuse_unusable_db_identifier|refuse_unparsable_ssh_key|refuse_forced_command_ssh_key|ipv4_dotted_quad|refuse_unusable_bind_address|refuse_unusable_subnet|passwd_home|ssh_key_holder|adopt_legacy_ssh_key_marker|record_db_role_grant|reassign_one_db_role|record_ssh_key_grant|refuse_root_deploy_user|append_state_line|refuse_nologin_deploy_user|resolve_symlink_chain|stage_beside|stage_authorized_keys|verify_ssh_hardening|refuse_unusable_retention|install_managed_config|reload_ssh_daemon)\(\) \{/ { f = 1 }
   f { print }
   f && /^\}/ { f = 0 }
 ' "$SRC")"
@@ -43,7 +43,8 @@ for fn in die ensure_block ensure_sudoers in_group write_state_file \
           record_db_role_grant reassign_one_db_role record_ssh_key_grant \
           refuse_root_deploy_user append_state_line refuse_nologin_deploy_user \
           resolve_symlink_chain stage_beside stage_authorized_keys \
-          verify_ssh_hardening \
+          verify_ssh_hardening refuse_unusable_retention \
+          install_managed_config reload_ssh_daemon \
           adopt_legacy_ssh_key_marker; do
   declare -F "$fn" >/dev/null || {
     echo "could not extract $fn() from $SRC — has the definition moved?" >&2
@@ -5387,6 +5388,20 @@ else
   # `command=`.
   fcguard "no-pty,command=\"/usr/bin/true\" $FC_KEY"
   chk "and one behind another option"                  1 "$fc_rc"
+  # sshd matches the option *name* without regard to case, so a case-sensitive
+  # test here is a bypass and not a narrower guard. Measured against the same
+  # scratch sshd as the table above, and every one of these suppressed the
+  # client's command while returning 0:
+  #
+  #   COMMAND="/usr/bin/true" <key>      ssh rc=0   nothing ran
+  #   CoMmAnD="/usr/bin/true" <key>      ssh rc=0   nothing ran
+  #   no-pty,COMMAND="/usr/bin/true"     ssh rc=0   nothing ran
+  fcguard "COMMAND=\"/usr/bin/true\" $FC_KEY"
+  chk "an uppercase option name is the same option"    1 "$fc_rc"
+  fcguard "CoMmAnD=\"/usr/bin/true\" $FC_KEY"
+  chk "and a mixed-case one"                           1 "$fc_rc"
+  fcguard "no-pty,COMMAND=\"/usr/bin/true\" $FC_KEY"
+  chk "and an uppercase one behind another option"     1 "$fc_rc"
 
   fcguard "$FC_KEY"
   chk "a plain key still goes through"                 0 "$fc_rc"
@@ -5394,6 +5409,11 @@ else
   chk "and one behind a from= restriction"             0 "$fc_rc"
   fcguard "restrict $FC_KEY"
   chk "and one behind restrict, which runs the command" 0 "$fc_rc"
+  # The control that keeps the fold on the *question* rather than on the guard:
+  # `RESTRICT` is accepted by sshd and runs the client's command, so an
+  # uppercase option is not on its own a reason to refuse anything.
+  fcguard "RESTRICT $FC_KEY"
+  chk "and behind an uppercase restrict, which also runs it" 0 "$fc_rc"
   fcguard ""
   chk "and no key at all"                              0 "$fc_rc"
   # The over-refusal control that decides where the options end. A comment is
@@ -5594,7 +5614,16 @@ chk "and says the hardening is unverified"                1 \
 # Source level, because every row above passes on a revision that writes the
 # drop-in under the losing name and never reads anything back.
 chk "the drop-in is written where it sorts first"         1 \
-  "$(grep -c '^cat > /etc/ssh/sshd_config\.d/01-collavre\.conf <<' "$SRC")"
+  "$(grep -c "^install_managed_config 'the SSH hardening drop-in' \\\\\$" "$SRC")"
+chk "and at the 01- path"                                 1 \
+  "$(grep -c '^  /etc/ssh/sshd_config\.d/01-collavre\.conf \\$' "$SRC")"
+# And that nothing on this path went back to a truncating write. Both drop-ins
+# this script owns are named, because the sysctl one carries
+# net.ipv4.ip_nonlocal_bind and loses it the same way.
+chk "and neither drop-in is written in place"             0 \
+  "$(grep -c '^cat > /etc/\(ssh/sshd_config\.d\|sysctl\.d\)/' "$SRC")"
+chk "the sysctl drop-in is staged too"                    1 \
+  "$(grep -c "^install_managed_config 'the sysctl drop-in' /etc/sysctl\.d/" "$SRC")"
 chk "and the inert 99- file it replaces is removed"       1 \
   "$(grep -c '^rm -f /etc/ssh/sshd_config\.d/99-collavre\.conf$' "$SRC")"
 chk "and the run reads back what sshd resolved"           1 \
@@ -5620,12 +5649,18 @@ else
   mkdir -p "$vhr/sshd_config.d"
   ssh-keygen -q -t ed25519 -N '' -f "$vhr/hk" >/dev/null 2>&1
   printf 'Include %s/sshd_config.d/*.conf\nHostKey %s/hk\n' "$vhr" "$vhr" > "$vhr/sshd_config"
-  # the shipped write, replayed: the file name off the `cat >` line, the body
-  # out of its heredoc
-  vh_name="$(awk '/^cat > \/etc\/ssh\/sshd_config\.d\// { sub(/.*sshd_config\.d\//, ""); sub(/ .*/, ""); print; exit }' "$SRC")"
-  awk '/^cat > \/etc\/ssh\/sshd_config\.d\// { f = 1; next }
-       f && /^SSHD$/ { exit }
-       f' "$SRC" > "$vhr/sshd_config.d/$vh_name"
+  # The shipped write, run rather than replayed: the whole install_managed_config
+  # call is lifted out of the script with only its directory redirected, so the
+  # file name, the body and the staging all come from the script. A harness that
+  # wrote its own 01- file would keep passing after the script went back to 99-.
+  vh_call="$(awk "/^install_managed_config 'the SSH hardening drop-in'/ { f = 1 }
+                  f { print }
+                  f && \$0 !~ /\\\\\$/ { exit }" "$SRC")"
+  eval "$(printf '%s\n' "$vh_call" |
+            sed "s#/etc/ssh/sshd_config\.d/#$vhr/sshd_config.d/#")"
+  vh_name="$(printf '%s\n' "$vh_call" |
+               awk '/\/etc\/ssh\/sshd_config\.d\// {
+                      sub(/.*sshd_config\.d\//, ""); sub(/[ \\].*/, ""); print; exit }')"
   if [ "$(vh_effective "$vhr")" != "no no" ]; then
     echo "  SKIP sshd -T is not usable here — it could not read even the drop-in alone"
   else
@@ -5698,8 +5733,241 @@ chk "a copied cloud key is withdrawn when SSH_PUBLIC_KEY is set" \
 # are not.
 chk "but the cloud user's own keys are left alone" \
   "cloud-1 cloud-2 new | new" "$(key_rotation ubuntu)"
-unset -f chown
+# A failed record must stop the run *before* the keys are authorized, which is
+# the ordering and not just the recording. Reached through record_ssh_key_grant's
+# own failure path, which on a real host is a state directory that cannot be
+# written — an ENOSPC on a 512MB instance:
+#
+#   record        run 1 rc   queued   authorized after the rotation
+#   succeeds      0          2        new
+#   fails         0          0        cloud-1 cloud-2 new     <- reviewed order
+#
+# The second row is the defect the fix above was written for, reached through
+# its failure path: rc 0, a summary reporting a converged host, and two keys the
+# documented rotation will never withdraw — on the account this run is about to
+# give docker and passwordless sudo.
+#
+# The two failures are not symmetric, which is why this order and not the other.
+# Recorded-but-not-installed is harmless: revoke_prior_ssh_key skips a queued key
+# that is absent from authorized_keys, and append_state_line dedupes, so the
+# retry after the disk is freed records nothing twice.
+# shellcheck disable=SC2329  # the failure seam, restored below
+record_ssh_key_grant() { return 1; }
+kf="$kd/failed"; mkdir -p "$kf/ubuntu/.ssh" "$kf/collavre/.ssh" "$kd/state.failed"
+printf '%s\n%s\n' "$K1" "$K2" > "$kf/ubuntu/.ssh/authorized_keys"
+: > "$kf/collavre/.ssh/authorized_keys"
+# shellcheck disable=SC2329  # called by install_staged_authorized_keys
+chown() { :; }
+STATE_DIR="$kd/state.failed" APP_SSH_USER=collavre SSH_PUBLIC_KEY=''
+( install_authorized_keys "$kf/collavre/.ssh/authorized_keys" "$kf" ) >/dev/null 2>&1
+chk "a record that fails installs nothing"  "0" \
+  "$(grep -c . "$kf/collavre/.ssh/authorized_keys")"
+chk "and leaves no staging file behind"     "0" \
+  "$(ls -A "$kf/collavre/.ssh" | grep -c collavre)"
+STATE_DIR="$kd/state.failed" APP_SSH_USER=collavre SSH_PUBLIC_KEY=''
+( install_authorized_keys "$kf/collavre/.ssh/authorized_keys" "$kf" ) >/dev/null 2>&1
+chk "and the run is told, rather than reporting a converged host" 1 "$?"
+unset -f record_ssh_key_grant chown
+eval "$(awk '/^record_ssh_key_grant\(\) \{/ { f = 1 } f { print } f && /^\}/ { f = 0 }' "$SRC")"
 rm -rf "$kd"
+
+echo "148. a torn write cannot reach a drop-in this script owns"
+# `cat > /etc/ssh/sshd_config.d/01-collavre.conf <<'SSHD'` truncates the live
+# file before it writes, so a run killed between the two — an OOM kill or an
+# ENOSPC on a 512MB instance — leaves the live drop-in short. Measured against a
+# real sshd, with Ubuntu's 50-cloud-init.conf beside it turning both keywords
+# back on:
+#
+#   01-collavre.conf state   bytes   sshd -t   passwordauth  permitrootlogin
+#   whole                    77      rc=0      no            no
+#   0 bytes (torn at open)    0      rc=0      yes           yes
+#   cut after line 1         26      rc=0      no            yes
+#   cut mid-directive        36      rc=255    -             -
+#
+# Two bands, and only the bottom one is loud: it stops sshd from starting, which
+# locks the host out at its next boot. The middle two are the quiet ones — sshd
+# reads them happily and the hardening is silently reduced or gone, on a host
+# whose provisioning was killed rather than one that reported success.
+#
+# `sshd -t` is what the finding asks for and it cannot close the quiet band: it
+# answers rc=0 for the empty file, which is exactly what truncate-at-open leaves.
+# So the staged file is asked whether it *says* what it was staged to say.
+imcd=$(mktemp -d)
+imc_mode=whole
+# Only the multi-line write is intercepted — stage_beside returns its path
+# through a one-argument printf, and swallowing that would model a failure that
+# is not the one under test.
+printf() {
+  if [ "$imc_mode" != whole ] && [ "$#" -gt 2 ]; then
+    case "$imc_mode" in
+      short) builtin printf '%s\n' "$2" ;;   # a short write that reported success
+      empty) : ;;                            # opened, then nothing landed
+      fail) return 1 ;;
+    esac
+    return 0
+  fi
+  builtin printf "$@"
+}
+imc_run() { # <mode> -> "<live lines> <hardened> <strays> <rc>"
+  imc_mode=whole
+  builtin printf 'PasswordAuthentication yes\n' > "$imcd/dropin"
+  imc_mode="$1"
+  ( install_managed_config 'the drop-in' "$imcd/dropin" \
+      'PasswordAuthentication no' 'PermitRootLogin no' ) >/dev/null 2>&1
+  local rc=$?
+  imc_mode=whole
+  echo "$(grep -c . "$imcd/dropin") $(grep -c '^PasswordAuthentication no$' "$imcd/dropin") $(ls -A "$imcd" | grep -c collavre) $rc"
+}
+chk "an uninterrupted write installs the whole drop-in"  "2 1 0 0" "$(imc_run whole)"
+# The quiet band. Both of these are files every validator accepts, and both are
+# refused here because the question asked is what the file says.
+chk "a write cut after the first line installs nothing"  "1 0 0 1" "$(imc_run short)"
+chk "and one that landed empty is refused too"           "1 0 0 1" "$(imc_run empty)"
+chk "and a write that fails outright"                    "1 0 0 1" "$(imc_run fail)"
+# Comment and blank lines are written but not read back — they are not what the
+# file is for. The sysctl drop-in carries both, so this is a control on it
+# rather than a hypothetical.
+imc_mode=whole
+: > "$imcd/dropin"
+( install_managed_config 'the drop-in' "$imcd/dropin" \
+    '# Prefer RAM' '' 'vm.swappiness = 10' ) >/dev/null 2>&1
+chk "a comment line is still written"                    1 \
+  "$(grep -c '^# Prefer RAM$' "$imcd/dropin")"
+chk "and the directive beside it"                        1 \
+  "$(grep -c '^vm\.swappiness = 10$' "$imcd/dropin")"
+unset -f printf
+# The rename has to go to the *resolved* path, the way ensure_block and the
+# 10-collavre.conf write both do. stage_beside resolves internally, so renaming
+# onto the unresolved argument puts the staging file beside the backing file
+# and the finished one beside the link:
+#
+#   /etc/link.conf -> /real/backing.conf
+#     link.conf   becomes a REGULAR FILE holding the new content
+#     backing.conf  still holds the old
+#
+# The operator's symlink is replaced, and — the reason this is in *this* case
+# rather than filed as tidiness — the staging file sits on the backing file's
+# filesystem, so a link that crosses one turns the `mv` into a copy-then-unlink.
+# That is the non-atomic write every assertion above is about, reintroduced on
+# exactly the hosts where the staging is doing any work.
+mkdir -p "$imcd/backing"
+builtin printf 'old\n' > "$imcd/backing/real.conf"
+ln -s "$imcd/backing/real.conf" "$imcd/link.conf"
+( install_managed_config 'the drop-in' "$imcd/link.conf" 'NEW yes' ) >/dev/null 2>&1
+chk "a symlinked target is written through, not replaced" "symlink" \
+  "$([ -L "$imcd/link.conf" ] && echo symlink || echo regular-file)"
+chk "and the backing file is the one that changed"        1 \
+  "$(grep -c '^NEW yes$' "$imcd/backing/real.conf")"
+# The control: a plain target is unaffected by the resolution, which is what
+# says the fix is the rename path and not a second behaviour.
+builtin printf 'old\n' > "$imcd/plain.conf"
+( install_managed_config 'the drop-in' "$imcd/plain.conf" 'NEW yes' ) >/dev/null 2>&1
+chk "a plain target is still rewritten in place"          "1 0" \
+  "$(builtin printf '%s %s' "$(grep -c '^NEW yes$' "$imcd/plain.conf")" \
+       "$(ls -A "$imcd" | grep -c collavre)")"
+rm -rf "$imcd"
+
+echo "149. a BACKUP_RETENTION_DAYS the nightly find cannot use is refused"
+# The value is %q-quoted into the generated backup program and used only there,
+# as `find -mtime "+$RETENTION_DAYS"`. `bash -n` on the staged program parses it
+# and the timer is enabled, so nothing on the provisioning side says anything:
+# the value is first read by GNU find, at 03:00, on a host the summary reported
+# as converged. Measured by running the generated program with each value,
+# GNU findutils 4.8.0:
+#
+#   BACKUP_RETENTION_DAYS   rc   dumps left      the unit
+#   7                       0    the new dump    green
+#   seven                   1    new + the old   RED, invalid argument `+seven'
+#   ''                      1    new + the old   RED, invalid argument `+'
+#   -1                      0    NONE            green, "backup complete: ()"
+#
+# Two bands again, and the loud one is not the dangerous one. `seven` fails
+# every night with the unit red and dumps accumulating until the disk fills —
+# the finding, and at least visible in `systemctl list-units --failed`. `-1` is
+# the one worth this guard: find takes `+-1`, deletes every dump *including the
+# one just taken*, and the program still exits 0 and reports "backup complete"
+# for a file that is no longer there.
+# BACKUP_AT, because the refusal names the hour the value would otherwise first
+# be read at. Without it every "refused" row below is a `set -u` abort on an
+# unbound variable rather than the guard answering — the rows go green and
+# measure nothing. The message assertion at the bottom is what caught that, and
+# is why it is here rather than only the return codes.
+ret_rc() {
+  ( BACKUP_AT=03:30; refuse_unusable_retention BACKUP_RETENTION_DAYS "$1" ) >/dev/null 2>&1
+  echo $?
+}
+chk "the default is accepted"                            0 "$(ret_rc 7)"
+chk "and any other whole number of days"                 0 "$(ret_rc 30)"
+# The control that keeps this a check on the spelling rather than on a range:
+# `-mtime +0` keeps the dump just taken and drops yesterday's, which is a
+# retention an operator may well have chosen.
+chk "and zero, which keeps one day"                      0 "$(ret_rc 0)"
+chk "a word find rejects is refused"                     1 "$(ret_rc seven)"
+chk "and an empty value, which find reads as '+'"        1 "$(ret_rc '')"
+chk "and a negative one, which takes the new dump with it" 1 "$(ret_rc -1)"
+chk "and a fraction, which has one spelling here"        1 "$(ret_rc 7.5)"
+chk "and trailing whitespace"                            1 "$(ret_rc '7 ')"
+# The message has to say the host is unchanged, because this refusal is the
+# operator's only signal — every other reading of the value happens at 03:00.
+ret_msg="$( ( BACKUP_AT=03:30; refuse_unusable_retention BACKUP_RETENTION_DAYS seven ) 2>&1 )"
+chk "and the refusal says nothing has been changed"      1 \
+  "$(printf '%s' "$ret_msg" | grep -c 'Nothing has been changed')"
+# Source level, because every row above passes on a revision that defines the
+# guard and never calls it — which is where the run has to refuse, before the
+# unit is installed and enabled.
+chk "and the run asks before installing the timer"       1 \
+  "$(grep -c '^refuse_unusable_retention BACKUP_RETENTION_DAYS "\$BACKUP_RETENTION_DAYS"$' "$SRC")"
+
+echo "150. a running sshd that refused the hardening stops the run"
+# `systemctl reload ssh || systemctl reload sshd || true` swallowed a status
+# that means two different things. Measured under systemd 252, one unit state
+# per row, with ExecReload standing in for sshd's own accept-or-refuse:
+#
+#   unit state              reload rc   is-active   what it means
+#   inactive                1           inactive    nothing to reload
+#   not found at all        5           inactive    nothing to reload
+#   active, reload ok       0           active      adopted
+#   active, reload refused  1           active      still on the OLD config
+#
+# Rows 1 and 4 share rc=1, so the rc cannot separate them — and row 1 is the
+# stock Ubuntu 24.04 state (ssh.socket enabled, ssh.service disabled until
+# something connects), not an edge case. A guard on the rc alone would refuse
+# every correctly-provisioned host. is-active is the discriminator, and it is
+# read from systemctl rather than from the message, which is localised.
+systemctl() { # <verb> <unit>
+  case "$1 $2" in
+    "reload $RELOAD_OK")  return 0 ;;
+    "reload $RELOAD_BAD") return 1 ;;
+    "reload "*)           return 5 ;;   # unit not found
+    "is-active $ACTIVE")  echo active; return 0 ;;
+    "is-active "*)        echo inactive; return 3 ;;
+  esac
+  return 1
+}
+rsd() { # <ok unit> <failing unit> <active unit> -> rc
+  RELOAD_OK="${1:-@none}" RELOAD_BAD="${2:-@none}" ACTIVE="${3:-@none}"
+  reload_ssh_daemon >/dev/null 2>&1; echo $?
+}
+chk "an ssh.service that adopts it proceeds"          0 "$(rsd ssh '' ssh)"
+chk "and an sshd.service that adopts it"              0 "$(rsd sshd '' sshd)"
+# The controls, and the reason this is not a guard on the reload status. Both
+# of these are healthy hosts on which BOTH reloads fail.
+chk "a socket-activated host with nothing connected"  0 "$(rsd '' ssh '')"
+chk "and a host carrying neither unit"                0 "$(rsd '' '' '')"
+# The finding. Same rc as the row above it, opposite meaning.
+chk "a running daemon that refuses it stops the run"  1 "$(rsd '' ssh ssh)"
+chk "and the same under the sshd name"                1 "$(rsd '' sshd sshd)"
+# ssh absent but sshd running and refusing — the fallback must not read the
+# first unit's absence as an all-clear for the second.
+chk "an absent ssh does not excuse a refusing sshd"   1 "$(rsd '' sshd sshd)"
+unset -f systemctl
+unset RELOAD_OK RELOAD_BAD ACTIVE
+# Source level: the behavioural rows above all pass on a revision that defines
+# the function and still swallows its status with `|| true`.
+chk "and the run treats that as fatal"                1 \
+  "$(grep -c '^reload_ssh_daemon || die \\$' "$SRC")"
+chk "rather than discarding the status"               0 \
+  "$(grep -c '^systemctl reload ssh .*|| true$' "$SRC")"
 
 echo
 if [ "$fail" = 0 ]; then echo "ALL PASS"; else echo "FAILURES"; fi

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -6209,6 +6209,34 @@ chk "and installs the key before publishing its source"      1 \
       }
     ' <<<"$docker_source_block")"
 
+echo "155. the backup systemd units are installed atomically"
+backup_unit_block="$(
+  awk '
+    /install_managed_config .*PostgreSQL backup service unit/ { f = 1 }
+    f { print }
+    f && /^systemctl daemon-reload$/ { exit }
+  ' "$SRC"
+)"
+chk "the service unit is written through the staging helper" 1 \
+  "$(grep -c "install_managed_config 'the PostgreSQL backup service unit'" \
+      <<<"$backup_unit_block")"
+chk "and the timer unit is written through the staging helper" 1 \
+  "$(grep -c "install_managed_config 'the PostgreSQL backup timer unit'" \
+      <<<"$backup_unit_block")"
+chk "neither live unit is truncated by a heredoc redirection" 0 \
+  "$(grep -Ec 'cat > /etc/systemd/system/collavre-pg-backup\.(service|timer)' \
+      <<<"$backup_unit_block")"
+chk "both staged units are installed before systemd reloads them" 1 \
+  "$(awk '
+      /install_managed_config .*backup service unit/ { service = NR }
+      /install_managed_config .*backup timer unit/ { timer = NR }
+      /^systemctl daemon-reload$/ { reload = NR }
+      END {
+	if (service && timer && reload && service < timer && timer < reload) print 1
+	else print 0
+      }
+    ' <<<"$backup_unit_block")"
+
 echo
 if [ "$fail" = 0 ]; then echo "ALL PASS"; else echo "FAILURES"; fi
 exit "$fail"

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -5454,6 +5454,18 @@ else
   fcguard "$FC_COLLISION"
   chk "AAAA in an option cannot hide a later command"  1 "$fc_rc"
 
+  # `command=` in a quoted value is data, not an option name. sshd only
+  # replaces the client command when the comma-separated option itself is
+  # named command.
+  FC_VALUE_COLLISION="environment=\"NOTE=command=value\" $FC_KEY"
+  printf '%s\n' "$FC_VALUE_COLLISION" > "$fcd/value-collision.pub"
+  chk "the option-value fixture is a real key line"    0 \
+    "$(ssh-keygen -l -f "$fcd/value-collision.pub" >/dev/null 2>&1; echo $?)"
+  fcguard "$FC_VALUE_COLLISION"
+  chk "command= inside an option value is accepted"    0 "$fc_rc"
+  fcguard "environment=\"NOTE=command=value\",command=\"/usr/bin/true\" $FC_KEY"
+  chk "but a later command option is still refused"    1 "$fc_rc"
+
   fcguard "$FC_KEY"
   chk "a plain key still goes through"                 0 "$fc_rc"
   fcguard "from=\"127.0.0.1\" $FC_KEY"

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -21,7 +21,7 @@ SRC="${1:-$ROOT/script/lightsail_launch.sh}"
 # die() is a one-liner; the others run to the first column-1 closing brace.
 eval "$(awk '
   /^die\(\) \{/ { print; next }
-  /^(ensure_block|ensure_sudoers|in_group|write_state_file|launch_record_is_complete|record_launch_settings|record_deploy_user_grant|revoke_deploy_user_access|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|install_deploy_ssh_dir|reassign_prior_db_role|refuse_superuser_db_rotation|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps|warn_existing_containers_keep_log_config|dedupe_authorized_keys|install_staged_authorized_keys|postgresql_conf_includes_confd|role_owns_app_objects|refuse_db_name_change|refuse_defaulted_config_change|refuse_unusable_db_identifier|refuse_unparsable_ssh_key|refuse_forced_command_ssh_key|ipv4_dotted_quad|refuse_unusable_bind_address|refuse_unusable_subnet|passwd_home|ssh_key_holder|adopt_legacy_ssh_key_marker|record_db_role_grant|reassign_one_db_role|record_ssh_key_grant|refuse_root_deploy_user|append_state_line|refuse_nologin_deploy_user|resolve_symlink_chain|stage_beside|stage_authorized_keys|verify_ssh_hardening|refuse_unusable_retention|refuse_unusable_backup_calendar|install_managed_config|install_downloaded_file|install_credential_summary|reload_ssh_daemon)\(\) \{/ { f = 1 }
+  /^(ensure_block|ensure_sudoers|in_group|write_state_file|launch_record_is_complete|record_launch_settings|record_deploy_user_grant|revoke_deploy_user_access|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|install_deploy_ssh_dir|reassign_prior_db_role|refuse_superuser_db_rotation|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps|warn_existing_containers_keep_log_config|dedupe_authorized_keys|install_staged_authorized_keys|postgresql_conf_includes_confd|role_owns_app_objects|refuse_db_name_change|refuse_defaulted_config_change|refuse_unusable_db_identifier|refuse_unparsable_ssh_key|refuse_forced_command_ssh_key|ipv4_dotted_quad|refuse_unusable_bind_address|refuse_unusable_subnet|passwd_home|ssh_key_holder|adopt_legacy_ssh_key_marker|record_db_role_grant|reassign_one_db_role|record_ssh_key_grant|refuse_root_deploy_user|append_state_line|refuse_nologin_deploy_user|resolve_symlink_chain|stage_beside|stage_authorized_keys|scan_ssh_config_file|find_unsafe_ssh_match|verify_ssh_hardening|refuse_unusable_retention|refuse_unusable_backup_calendar|install_managed_config|install_downloaded_file|install_credential_summary|reload_ssh_daemon)\(\) \{/ { f = 1 }
   f { print }
   f && /^\}/ { f = 0 }
 ' "$SRC")"
@@ -45,7 +45,8 @@ for fn in die ensure_block ensure_sudoers in_group write_state_file \
           record_db_role_grant reassign_one_db_role record_ssh_key_grant \
           refuse_root_deploy_user append_state_line refuse_nologin_deploy_user \
           resolve_symlink_chain stage_beside stage_authorized_keys \
-          verify_ssh_hardening refuse_unusable_retention \
+	  scan_ssh_config_file find_unsafe_ssh_match verify_ssh_hardening \
+	  refuse_unusable_retention \
 	  refuse_unusable_backup_calendar \
 	  install_managed_config install_downloaded_file \
 	  install_credential_summary reload_ssh_daemon \
@@ -860,6 +861,17 @@ if [ -n "$fw_http_line" ] && [ -n "$fw_https_line" ] &&
   echo "  ok   the HTTP(S) allow rules precede default deny incoming"
 else
   echo "  FAIL default deny incoming can take effect before HTTP(S) is authorized"
+  fail=1
+fi
+
+echo "26c. PostgreSQL is authorized before the live incoming policy is tightened"
+fw_postgres_line="$(printf '%s\n' "$fw_step" |
+		      grep -n '^ensure_ufw_rule postgres' | cut -d: -f1)"
+if [ -n "$fw_postgres_line" ] && [ -n "$fw_deny_line" ] &&
+   [ "$fw_postgres_line" -lt "$fw_deny_line" ]; then
+  echo "  ok   the PostgreSQL allow rule precedes default deny incoming"
+else
+  echo "  FAIL default deny incoming can take effect before PostgreSQL is authorized"
   fail=1
 fi
 
@@ -5766,6 +5778,49 @@ chk "and sshd was given the deploy-user context"          1 \
   "$(grep -c -- '-C user=deploybot' "$SSHD_ARGS_FILE")"
 unset SSHD_ARGS_FILE
 
+# User and group contexts can be evaluated from the account name. Address,
+# host and listener contexts cannot: checking one invented connection would
+# merely leave every other matching connection untested.
+printf '%s\n' \
+  '#!/bin/sh' \
+  'printf "passwordauthentication no\npermitrootlogin no\nkbdinteractiveauthentication no\n"' \
+  > "$vshd/bin/sshd"
+chmod +x "$vshd/bin/sshd"
+printf 'Include %s/sshd_config.d/*.conf\nMatch Address 203.0.113.0/24\n  PasswordAuthentication yes\n' \
+  "$vshd" > "$vshd/sshd_config"
+vh_address="$( ( PATH="$vshd/bin:$PATH"
+  verify_ssh_hardening "" "$vshd" 0 deploybot ) 2>&1; printf 'rc=%s\n' "$?" )"
+chk "an address-scoped password override stops the run"  1 \
+  "$(printf '%s' "$vh_address" | grep -c '^rc=1$')"
+chk "and the refusal names the untestable Match context" 1 \
+  "$(printf '%s' "$vh_address" | grep -ci 'Match.*Address')"
+
+# Include is textual and may point anywhere. The Match begins in the main file,
+# the weakening directive is in a nonstandard included file, and Match All
+# ends it back in the caller. Scanning files independently or in a guessed
+# main-then-drop-ins order misses this exact shape.
+printf 'PasswordAuthentication yes\n' > "$vshd/address-auth.conf"
+printf 'Include %s/sshd_config.d/*.conf\nMatch Address 198.51.100.0/24\nInclude %s/address-auth.conf\nMatch All\n' \
+  "$vshd" "$vshd" > "$vshd/sshd_config"
+vh_address_include="$( ( PATH="$vshd/bin:$PATH"
+  verify_ssh_hardening "" "$vshd" 0 deploybot ) 2>&1; printf 'rc=%s\n' "$?" )"
+chk "an address override reached through Include stops the run" 1 \
+  "$(printf '%s' "$vh_address_include" | grep -c '^rc=1$')"
+chk "and the included file is named" 1 \
+  "$(printf '%s' "$vh_address_include" | grep -c 'address-auth\.conf')"
+
+mkdir -p "$vshd/custom configs"
+printf 'Match Address 192.0.2.0/24\nPasswordAuthentication yes\n' \
+  > "$vshd/custom configs/address-auth.conf"
+printf 'Include "%s/custom configs/*.conf"\n' "$vshd" > "$vshd/sshd_config"
+vh_quoted_include="$( ( PATH="$vshd/bin:$PATH"
+  verify_ssh_hardening "" "$vshd" 0 deploybot ) 2>&1; printf 'rc=%s\n' "$?" )"
+chk "a quoted Include cannot bypass the contextual scan" 1 \
+  "$(printf '%s' "$vh_quoted_include" | grep -c '^rc=1$')"
+chk "and the refusal identifies the unsupported Include form" 1 \
+  "$(printf '%s' "$vh_quoted_include" | grep -ci 'quoted or escaped Include')"
+printf 'Include %s/sshd_config.d/*.conf\n' "$vshd" > "$vshd/sshd_config"
+
 # Source level, because every row above passes on a revision that writes the
 # drop-in under the losing name and never reads anything back.
 chk "the drop-in is written where it sorts first"         1 \
@@ -5788,12 +5843,12 @@ chk "and the run reads back every relevant user context"  3 \
 # time. The pre-grant read-back above cannot see a sudo/docker override for an
 # existing account that does not join those groups until later in this run.
 vh_sudo_grant="$(awk '
-  /^usermod -aG sudo "\$APP_SSH_USER"$/ { f = 1 }
+  /^SUDO_GROUP_WAS_PRESENT=0$/ { f = 1 }
   f { print }
   f && /^ensure_sudoers "\$APP_SSH_USER"$/ { exit }
 ' "$SRC")"
 vh_docker_grant="$(awk '
-  /^usermod -aG docker "\$APP_SSH_USER"$/ { f = 1 }
+  /^DOCKER_GROUP_WAS_PRESENT=0$/ { f = 1 }
   f { print }
   f && /^revoke_prior_deploy_user "\$APP_SSH_USER"$/ { exit }
 ' "$SRC")"
@@ -5803,6 +5858,22 @@ chk "sudo-group context is rechecked before passwordless sudo" 1 \
 chk "docker-group context is rechecked before convergence continues" 1 \
   "$(grep -cF 'verify_ssh_hardening "" /etc/ssh "$SSH_RELOAD_STATE" "$APP_SSH_USER"' \
       <<<"$vh_docker_grant")"
+
+# If the recheck is what discovers the override, the new group is already live.
+# A refusal must remove only the membership this run added. These assertions
+# stay at the call sites because that ordering is the safety property.
+chk "sudo membership is recorded before it is granted" 1 \
+  "$(grep -c '^SUDO_GROUP_WAS_PRESENT=0$' <<<"$vh_sudo_grant")"
+chk "a failed sudo recheck rolls back the new membership" 1 \
+  "$(grep -c '^    gpasswd -d "\$APP_SSH_USER" sudo ' <<<"$vh_sudo_grant")"
+chk "and checks the rollback actually took" 1 \
+  "$(grep -c '^    in_group "\$APP_SSH_USER" sudo ' <<<"$vh_sudo_grant")"
+chk "Docker membership is recorded before it is granted" 1 \
+  "$(grep -c '^DOCKER_GROUP_WAS_PRESENT=0$' <<<"$vh_docker_grant")"
+chk "a failed Docker recheck rolls back the new membership" 1 \
+  "$(grep -c '^    gpasswd -d "\$APP_SSH_USER" docker ' <<<"$vh_docker_grant")"
+chk "and checks that rollback actually took" 1 \
+  "$(grep -c '^    in_group "\$APP_SSH_USER" docker ' <<<"$vh_docker_grant")"
 
 # The claim is about what sshd does with two files, so sshd is asked. The name
 # and the body both come from the script: a harness that wrote its own 01- file
@@ -5900,6 +5971,21 @@ key_rotation() {   # <deploy account> -> "<authorized names>|<queue names>"
 }
 chk "a copied cloud key is withdrawn when SSH_PUBLIC_KEY is set" \
   "new | new" "$(key_rotation collavre)"
+
+SPACED_K1="  ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAACLOUDKEYSPACE cloud-space  "
+ks="$kd/spaced"; mkdir -p "$ks/ubuntu/.ssh" "$ks/collavre/.ssh" "$kd/state.spaced"
+printf '%s\n' "$SPACED_K1" > "$ks/ubuntu/.ssh/authorized_keys"
+: > "$ks/collavre/.ssh/authorized_keys"
+STATE_DIR="$kd/state.spaced" APP_SSH_USER=collavre SSH_PUBLIC_KEY=''
+install_authorized_keys "$ks/collavre/.ssh/authorized_keys" "$ks" >/dev/null 2>&1
+chk "a copied key is recorded with its whitespace intact" 1 \
+  "$(grep -cxF "$SPACED_K1" "$kd/state.spaced/ssh_public_keys.collavre")"
+SSH_PUBLIC_KEY="$KN"
+record_ssh_key_grant "$SSH_PUBLIC_KEY" >/dev/null 2>&1
+install_authorized_keys "$ks/collavre/.ssh/authorized_keys" "$ks" >/dev/null 2>&1
+revoke_prior_ssh_key "$ks/collavre/.ssh/authorized_keys" >/dev/null 2>&1
+chk "so a later rotation withdraws that exact copied key" 0 \
+  "$(grep -cxF "$SPACED_K1" "$ks/collavre/.ssh/authorized_keys")"
 # The control that decides where the recording may go, and it is the one that
 # would be a lockout if it moved: when APP_SSH_USER *is* the cloud user, the
 # file is that account's own and this script never wrote it. Queueing it would

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -21,7 +21,7 @@ SRC="${1:-$ROOT/script/lightsail_launch.sh}"
 # die() is a one-liner; the others run to the first column-1 closing brace.
 eval "$(awk '
   /^die\(\) \{/ { print; next }
-  /^(ensure_block|ensure_sudoers|in_group|write_state_file|launch_record_is_complete|record_launch_settings|record_deploy_user_grant|revoke_deploy_user_access|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|install_deploy_ssh_dir|reassign_prior_db_role|refuse_superuser_db_rotation|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps|warn_existing_containers_keep_log_config|dedupe_authorized_keys|install_staged_authorized_keys|postgresql_conf_includes_confd|role_owns_app_objects|refuse_db_name_change|refuse_defaulted_config_change|refuse_unusable_db_identifier|refuse_unparsable_ssh_key|refuse_forced_command_ssh_key|ipv4_dotted_quad|refuse_unusable_bind_address|refuse_unusable_subnet|passwd_home|ssh_key_holder|adopt_legacy_ssh_key_marker|record_db_role_grant|reassign_one_db_role|record_ssh_key_grant|refuse_root_deploy_user|append_state_line|refuse_nologin_deploy_user|resolve_symlink_chain|stage_beside|stage_authorized_keys|verify_ssh_hardening|refuse_unusable_retention|install_managed_config|install_downloaded_file|reload_ssh_daemon)\(\) \{/ { f = 1 }
+  /^(ensure_block|ensure_sudoers|in_group|write_state_file|launch_record_is_complete|record_launch_settings|record_deploy_user_grant|revoke_deploy_user_access|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|install_deploy_ssh_dir|reassign_prior_db_role|refuse_superuser_db_rotation|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps|warn_existing_containers_keep_log_config|dedupe_authorized_keys|install_staged_authorized_keys|postgresql_conf_includes_confd|role_owns_app_objects|refuse_db_name_change|refuse_defaulted_config_change|refuse_unusable_db_identifier|refuse_unparsable_ssh_key|refuse_forced_command_ssh_key|ipv4_dotted_quad|refuse_unusable_bind_address|refuse_unusable_subnet|passwd_home|ssh_key_holder|adopt_legacy_ssh_key_marker|record_db_role_grant|reassign_one_db_role|record_ssh_key_grant|refuse_root_deploy_user|append_state_line|refuse_nologin_deploy_user|resolve_symlink_chain|stage_beside|stage_authorized_keys|verify_ssh_hardening|refuse_unusable_retention|refuse_unusable_backup_calendar|install_managed_config|install_downloaded_file|reload_ssh_daemon)\(\) \{/ { f = 1 }
   f { print }
   f && /^\}/ { f = 0 }
 ' "$SRC")"
@@ -46,6 +46,7 @@ for fn in die ensure_block ensure_sudoers in_group write_state_file \
           refuse_root_deploy_user append_state_line refuse_nologin_deploy_user \
           resolve_symlink_chain stage_beside stage_authorized_keys \
           verify_ssh_hardening refuse_unusable_retention \
+	  refuse_unusable_backup_calendar \
 	  install_managed_config install_downloaded_file reload_ssh_daemon \
           adopt_legacy_ssh_key_marker; do
   declare -F "$fn" >/dev/null || {
@@ -6236,6 +6237,52 @@ chk "both staged units are installed before systemd reloads them" 1 \
 	else print 0
       }
     ' <<<"$backup_unit_block")"
+
+echo "156. BACKUP_AT is validated before replacing the live timer"
+calendar_probe_dir="$(mktemp -d)"
+CALENDAR_PROBE="$calendar_probe_dir/probe"
+systemd-analyze() {
+  printf '%s\n' "$*" > "$CALENDAR_PROBE"
+  case "$2" in
+    '*-*-* 03:30:00'|'*-*-* 23:59:00') return 0 ;;
+    *) return 1 ;;
+  esac
+}
+calendar_rc() {
+  ( refuse_unusable_backup_calendar BACKUP_AT "$1" "*-*-* $1:00" ) \
+    >/dev/null 2>&1
+  echo $?
+}
+chk "the default calendar is accepted"                     0 \
+  "$(calendar_rc 03:30)"
+chk "and the end of the valid daily range"                  0 \
+  "$(calendar_rc 23:59)"
+chk "an impossible hour is refused"                         1 \
+  "$(calendar_rc 25:00)"
+chk "and arbitrary text cannot become a unit directive"     1 \
+  "$(calendar_rc '03:30
+OnFailure=attacker.service')"
+calendar_rc 25:00 >/dev/null
+chk "the exact composed calendar is sent to systemd" '*-*-* 25:00:00' \
+  "$(sed -n 's/^calendar //p' "$CALENDAR_PROBE")"
+calendar_msg="$(
+  ( refuse_unusable_backup_calendar BACKUP_AT 25:00 '*-*-* 25:00:00' ) 2>&1
+)"
+chk "the refusal says the live timer is unchanged"          1 \
+  "$(printf '%s' "$calendar_msg" | grep -c 'left unchanged')"
+chk "the run validates before installing the timer"         1 \
+  "$(awk '
+      /refuse_unusable_backup_calendar BACKUP_AT/ { checked = NR }
+      /install_managed_config .*backup timer unit/ { installed = NR }
+      END {
+	if (checked && installed && checked < installed) print 1
+	else print 0
+      }
+    ' "$SRC")"
+chk "the validated expression is the one installed"         1 \
+  "$(grep -c '"OnCalendar=$BACKUP_CALENDAR"' "$SRC")"
+unset -f systemd-analyze
+rm -rf "$calendar_probe_dir"
 
 echo
 if [ "$fail" = 0 ]; then echo "ALL PASS"; else echo "FAILURES"; fi

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -21,7 +21,7 @@ SRC="${1:-$ROOT/script/lightsail_launch.sh}"
 # die() is a one-liner; the others run to the first column-1 closing brace.
 eval "$(awk '
   /^die\(\) \{/ { print; next }
-  /^(ensure_block|ensure_sudoers|in_group|write_state_file|launch_record_is_complete|record_launch_settings|record_deploy_user_grant|revoke_deploy_user_access|revoke_prior_deploy_user|stage_ssh_cutover|ssh_cutover_has_sshd_ancestor|finalize_ssh_cutover|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|install_deploy_ssh_dir|reassign_prior_db_role|refuse_superuser_db_rotation|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps|warn_existing_containers_keep_log_config|dedupe_authorized_keys|install_staged_authorized_keys|postgresql_conf_includes_confd|role_owns_app_objects|refuse_db_name_change|refuse_defaulted_config_change|refuse_unusable_db_identifier|refuse_unparsable_ssh_key|refuse_forced_command_ssh_key|ipv4_dotted_quad|refuse_unusable_bind_address|refuse_unusable_subnet|passwd_home|ssh_key_holder|adopt_legacy_ssh_key_marker|record_db_role_grant|reassign_one_db_role|record_ssh_key_grant|refuse_root_deploy_user|append_state_line|refuse_nologin_deploy_user|resolve_symlink_chain|stage_beside|restore_postgresql_bind_config|stage_authorized_keys|scan_ssh_config_file|find_unsafe_ssh_match|verify_ssh_key_destination|ssh_pattern_list_matches|verify_ssh_admission_controls|verify_ssh_hardening|refuse_unusable_retention|refuse_unusable_backup_calendar|install_managed_config|install_downloaded_file|install_credential_summary|reload_ssh_daemon)\(\) \{/ { f = 1 }
+  /^(ensure_block|ensure_sudoers|in_group|write_state_file|launch_record_is_complete|record_launch_settings|record_deploy_user_grant|revoke_deploy_user_access|revoke_prior_deploy_user|stage_ssh_cutover|ssh_public_key_fingerprint|ssh_cutover_auth_info_file|ssh_cutover_authenticated_with_key|ssh_cutover_has_sshd_ancestor|finalize_ssh_cutover|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|install_deploy_ssh_dir|reassign_prior_db_role|refuse_superuser_db_rotation|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps|warn_existing_containers_keep_log_config|dedupe_authorized_keys|install_staged_authorized_keys|postgresql_conf_includes_confd|role_owns_app_objects|refuse_db_name_change|refuse_defaulted_config_change|refuse_unusable_db_identifier|refuse_unparsable_ssh_key|refuse_forced_command_ssh_key|ipv4_dotted_quad|refuse_unusable_bind_address|refuse_unusable_subnet|passwd_home|ssh_key_holder|adopt_legacy_ssh_key_marker|record_db_role_grant|reassign_one_db_role|record_ssh_key_grant|refuse_root_deploy_user|append_state_line|refuse_nologin_deploy_user|resolve_symlink_chain|stage_beside|restore_postgresql_bind_config|stage_authorized_keys|scan_ssh_config_file|find_unsafe_ssh_match|verify_ssh_key_destination|ssh_pattern_list_matches|verify_ssh_admission_controls|verify_ssh_hardening|refuse_unusable_retention|refuse_unusable_backup_calendar|install_managed_config|install_downloaded_file|install_credential_summary|reload_ssh_daemon)\(\) \{/ { f = 1 }
   f { print }
   f && /^\}/ { f = 0 }
 ' "$SRC")"
@@ -31,6 +31,8 @@ for fn in die ensure_block ensure_sudoers in_group write_state_file \
           revoke_prior_deploy_user \
           record_deploy_user_grant revoke_deploy_user_access \
 	  stage_ssh_cutover ssh_cutover_has_sshd_ancestor finalize_ssh_cutover \
+	  ssh_public_key_fingerprint ssh_cutover_auth_info_file \
+	  ssh_cutover_authenticated_with_key \
           ensure_ufw_rule ssh_already_allowed ensure_ssh_rule \
           install_authorized_keys install_deploy_ssh_dir reassign_prior_db_role \
           refuse_superuser_db_rotation role_owns_app_objects revoke_prior_ssh_key \
@@ -6953,15 +6955,19 @@ chk "the finalizer requires the sudo origin to be the staged account" 1 \
   "$(grep -cF '[ "${SUDO_USER:-}" = "$user" ] ||' "$SRC")"
 chk "and requires an sshd process ancestor" 1 \
   "$(grep -c '^  ssh_cutover_has_sshd_ancestor "\$user" ||$' "$SRC")"
+chk "sshd exposes the key that authenticated the session" 1 \
+  "$(grep -c "^  'ExposeAuthInfo yes'$" "$SRC")"
 chk "the runbook changes KAMAL_SSH_USER only after finalization" 1 \
   "$(grep -c 'Change `KAMAL_SSH_USER` only after' "$DOC")"
 
 cutover_state="$(mktemp -d)"
 cutover_finalizer="$cutover_state/finalizer"
+ssh-keygen -q -t ed25519 -N '' -f "$cutover_state/staged" </dev/null
+cutover_key="$(cat "$cutover_state/staged.pub")"
 STATE_DIR="$cutover_state"
 SSH_CUTOVER_PENDING=0
 SSH_CUTOVER_NONCE=''
-stage_ssh_cutover deploybot 'ssh-ed25519 STAGED operator' \
+stage_ssh_cutover deploybot "$cutover_key" \
   "$cutover_finalizer" "$SRC"
 chk "staging creates a root-only pending record" 600 \
   "$(file_mode "$cutover_state/ssh_cutover.pending")"
@@ -6971,10 +6977,18 @@ chk "and installs the finalizer" 755 "$(file_mode "$cutover_finalizer")"
 chk "without committing the deploy user" 0 \
   "$([ -e "$cutover_state/deploy_user" ] && echo 1 || echo 0)"
 cutover_nonce="$SSH_CUTOVER_NONCE"
+cutover_fingerprint="$(ssh_public_key_fingerprint "$cutover_key")"
+printf 'publickey %s\n' "$cutover_key" > "$cutover_state/auth-info"
+ssh_cutover_auth_info_file() { printf '%s/auth-info\n' "$cutover_state"; }
+chk "the exposed authentication record identifies the staged key" 0 \
+  "$(ssh_cutover_authenticated_with_key deploybot "$cutover_fingerprint"; echo $?)"
+printf 'publickey ssh-ed25519 OLD predecessor\n' > "$cutover_state/auth-info"
+chk "and rejects a session authenticated by a different key" 1 \
+  "$(ssh_cutover_authenticated_with_key deploybot "$cutover_fingerprint"; echo $?)"
+unset -f ssh_cutover_auth_info_file
 
 mkdir -p "$cutover_state/home/.ssh"
-printf '%s\n' 'ssh-ed25519 STAGED operator' \
-  > "$cutover_state/home/.ssh/authorized_keys"
+printf '%s\n' "$cutover_key" > "$cutover_state/home/.ssh/authorized_keys"
 getent() { printf 'deploybot:x:1001:1001::%s/home:/bin/bash\n' "$cutover_state"; }
 id() {
   case "$1" in
@@ -6986,10 +7000,20 @@ in_group() { return 0; }
 ssh_cutover_has_sshd_ancestor() {
   [ "$1" = deploybot ] && [ "${SSH_PROOF:-0}" -eq 1 ]
 }
+ssh_cutover_authenticated_with_key() {
+  [ "$1" = deploybot ] && [ -n "$2" ] && [ "${KEY_PROOF:-0}" -eq 1 ]
+}
 revoke_prior_ssh_key() {
   TRACE="${TRACE}key "
   write_state_file "$STATE_DIR/ssh_public_key.deploybot" \
-    'ssh-ed25519 STAGED operator'$'\n'
+    "$cutover_key"$'\n'
+  if [ "${REVOKE_KEY_FAIL:-0}" -eq 1 ]; then
+    write_state_file "$STATE_DIR/ssh_public_keys.deploybot" \
+      "ssh-ed25519 OLD predecessor"$'\n'"$cutover_key"$'\n'
+  else
+    write_state_file "$STATE_DIR/ssh_public_keys.deploybot" \
+      "$cutover_key"$'\n'
+  fi
 }
 revoke_prior_deploy_user() {
   TRACE="${TRACE}account "
@@ -7004,13 +7028,38 @@ chk "and revokes nothing" "" "$TRACE"
     finalize_ssh_cutover "$cutover_nonce" ) >/dev/null 2>&1
 chk "a local or console shell is refused" 1 "$?"
 chk "and still revokes nothing" "" "$TRACE"
-SUDO_USER=deploybot SSH_PROOF=1 finalize_ssh_cutover "$cutover_nonce" >/dev/null
+( SUDO_USER=deploybot SSH_PROOF=1 KEY_PROOF=0 \
+    finalize_ssh_cutover "$cutover_nonce" ) >/dev/null 2>&1
+chk "a session authenticated by the predecessor key is refused" 1 "$?"
+chk "and does not start withdrawal" "" "$TRACE"
+( SUDO_USER=deploybot SSH_PROOF=1 KEY_PROOF=1 REVOKE_KEY_FAIL=1 \
+    finalize_ssh_cutover "$cutover_nonce" ) >/dev/null 2>&1
+chk "an incomplete predecessor-key withdrawal is refused" 1 "$?"
+chk "and does not commit the deploy account" 0 \
+  "$([ -e "$cutover_state/deploy_user" ] && echo 1 || echo 0)"
+chk "while retaining the pending challenge" 1 \
+  "$([ -e "$cutover_state/ssh_cutover.pending" ] && echo 1 || echo 0)"
+TRACE=''
+SUDO_USER=deploybot SSH_PROOF=1 KEY_PROOF=1 \
+  finalize_ssh_cutover "$cutover_nonce" >/dev/null
 chk "an authenticated SSH proof commits key then account" "key account " "$TRACE"
 chk "and consumes the pending state" 0 \
   "$([ -e "$cutover_state/ssh_cutover.pending" ] && echo 1 || echo 0)"
 chk "and commits the staged account" deploybot \
   "$(cat "$cutover_state/deploy_user")"
+sudoers_failure="$(
+  (
+    in_group() { return 1; }
+    rm() { return 1; }
+    log() { :; }
+    revoke_deploy_user_access predecessor deploybot
+    printf 'rc=%s\n' "$?"
+  ) 2>/dev/null
+)"
+chk "a sudoers deletion failure keeps the predecessor queued" 0 \
+  "$(grep -c '^rc=0$' <<<"$sudoers_failure")"
 unset -f getent id in_group ssh_cutover_has_sshd_ancestor \
+  ssh_cutover_authenticated_with_key \
   revoke_prior_ssh_key revoke_prior_deploy_user
 rm -rf "$cutover_state"
 

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -6144,6 +6144,19 @@ chk "the staged source is installed before apt reads it"     1 \
 	else print 0
       }
     ' <<<"$postgres_source_block")"
+chk "the PostgreSQL key is written through the staging helper" 1 \
+  "$(grep -c "install_downloaded_file 'the PostgreSQL signing key'" <<<"$postgres_source_block")"
+chk "and is never downloaded into the live key"              0 \
+  "$(grep -c -- '-o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc' <<<"$postgres_source_block")"
+chk "the staged key is installed before publishing its source" 1 \
+  "$(awk '
+      /install_downloaded_file .*PostgreSQL signing key/ { installed = NR }
+      /install_managed_config .*PostgreSQL apt source/ { published = NR }
+      END {
+	if (installed && published && installed < published) print 1
+	else print 0
+      }
+    ' <<<"$postgres_source_block")"
 
 echo "154. the Docker signing key is installed atomically"
 download_dir="$(mktemp -d)"

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -956,6 +956,26 @@ extract_recipe() {
   ' "$DOC"
 }
 
+echo "26d. the Lightsail launch box uses a commit-pinned download bootstrap"
+bootstrap="$(extract_recipe 'raw.githubusercontent.com/sh1nj1/plan42/')"
+chk "the bootstrap is present exactly once" 1 \
+  "$(grep -c '^URL=.*raw.githubusercontent.com/sh1nj1/plan42/' <<<"$bootstrap")"
+chk "and pins a full Git commit instead of a mutable branch" 1 \
+  "$(grep -Ec "^URL='https://raw.githubusercontent.com/sh1nj1/plan42/[0-9a-f]{40}/script/lightsail_launch\\.sh'$" \
+      <<<"$bootstrap")"
+chk "and fails closed on an HTTP download error" 1 \
+  "$(grep -c '^  --fail \\$' <<<"$bootstrap")"
+chk "and checks syntax before execution" 1 \
+  "$(grep -c '^bash -n "\$TARGET"$' <<<"$bootstrap")"
+chk "and executes the downloaded root-only file" 1 \
+  "$(grep -c '^exec /bin/bash "\$TARGET"$' <<<"$bootstrap")"
+if bash -n <<<"$bootstrap"; then
+  echo "  ok   the documented bootstrap has valid Bash syntax"
+else
+  echo "  FAIL the documented bootstrap has invalid Bash syntax"
+  fail=1
+fi
+
 recipe="$(extract_recipe 'copy_status=')"
 case "$recipe" in
   *copy_status=*NOSUPERUSER*) : ;;

--- a/script/test/lightsail_launch_test.sh
+++ b/script/test/lightsail_launch_test.sh
@@ -21,7 +21,7 @@ SRC="${1:-$ROOT/script/lightsail_launch.sh}"
 # die() is a one-liner; the others run to the first column-1 closing brace.
 eval "$(awk '
   /^die\(\) \{/ { print; next }
-  /^(ensure_block|ensure_sudoers|in_group|write_state_file|record_deploy_user_grant|revoke_deploy_user_access|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|install_deploy_ssh_dir|reassign_prior_db_role|refuse_superuser_db_rotation|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps|dedupe_authorized_keys|install_staged_authorized_keys|postgresql_conf_includes_confd|role_owns_app_objects|refuse_db_name_change|refuse_defaulted_config_change|refuse_unusable_db_identifier|refuse_unparsable_ssh_key|passwd_home|ssh_key_holder|adopt_legacy_ssh_key_marker|record_db_role_grant|reassign_one_db_role|record_ssh_key_grant|refuse_root_deploy_user|append_state_line|refuse_nologin_deploy_user|resolve_symlink_chain|stage_beside|stage_authorized_keys)\(\) \{/ { f = 1 }
+  /^(ensure_block|ensure_sudoers|in_group|write_state_file|record_deploy_user_grant|revoke_deploy_user_access|revoke_prior_deploy_user|ensure_ufw_rule|ssh_already_allowed|ensure_ssh_rule|install_authorized_keys|install_deploy_ssh_dir|reassign_prior_db_role|refuse_superuser_db_rotation|revoke_prior_ssh_key|ensure_cluster_on_default_port|ensure_swapfile|allocate_swapfile|ensure_docker_log_caps|dedupe_authorized_keys|install_staged_authorized_keys|postgresql_conf_includes_confd|role_owns_app_objects|refuse_db_name_change|refuse_defaulted_config_change|refuse_unusable_db_identifier|refuse_unparsable_ssh_key|refuse_forced_command_ssh_key|ipv4_dotted_quad|refuse_unusable_bind_address|refuse_unusable_subnet|passwd_home|ssh_key_holder|adopt_legacy_ssh_key_marker|record_db_role_grant|reassign_one_db_role|record_ssh_key_grant|refuse_root_deploy_user|append_state_line|refuse_nologin_deploy_user|resolve_symlink_chain|stage_beside|stage_authorized_keys|verify_ssh_hardening)\(\) \{/ { f = 1 }
   f { print }
   f && /^\}/ { f = 0 }
 ' "$SRC")"
@@ -37,10 +37,13 @@ for fn in die ensure_block ensure_sudoers in_group write_state_file \
           install_staged_authorized_keys postgresql_conf_includes_confd \
           refuse_db_name_change refuse_defaulted_config_change \
           refuse_unusable_db_identifier refuse_unparsable_ssh_key \
+          refuse_forced_command_ssh_key ipv4_dotted_quad \
+          refuse_unusable_bind_address refuse_unusable_subnet \
           passwd_home ssh_key_holder \
           record_db_role_grant reassign_one_db_role record_ssh_key_grant \
           refuse_root_deploy_user append_state_line refuse_nologin_deploy_user \
           resolve_symlink_chain stage_beside stage_authorized_keys \
+          verify_ssh_hardening \
           adopt_legacy_ssh_key_marker; do
   declare -F "$fn" >/dev/null || {
     echo "could not extract $fn() from $SRC — has the definition moved?" >&2
@@ -685,6 +688,43 @@ for s in "22/tcp                     ALLOW       Anywhere" \
   STATUS="$s"
   ssh_already_allowed
   chk "detected: ${s%%
+*}" 0 "$?"
+done
+
+echo "23a. a rule that is not inbound does not count as authorization"
+# `ufw status` puts the direction in the action column only when it is *not*
+# inbound — there is no "ALLOW IN" in this output, so an inbound rule and an
+# outbound one differ by a word the pattern above did not read. Every line below
+# is real ufw output from ubuntu:24.04, one `ufw status` per rule shape, not a
+# rendering written from the man page.
+#
+# The consequence is the worst outcome in this script rather than a missed
+# optimisation: `ufw default deny incoming` is applied and ufw enabled a few
+# steps later, so a host whose only port-22 rule is outbound has SSH read as
+# authorized, no inbound rule added, and the firewall turned on — locking out
+# the operator who is running this over SSH at the time.
+for s in "22/tcp                     ALLOW OUT   Anywhere" \
+         "OpenSSH                    ALLOW OUT   Anywhere" \
+         "22/tcp                     ALLOW FWD   Anywhere" \
+         "80/tcp                     ALLOW       Anywhere
+
+22/tcp                     ALLOW OUT   Anywhere"; do
+  STATUS="$s"
+  ssh_already_allowed
+  chk "not authorization: ${s%%
+*}" 1 "$?"
+done
+# The controls, and they are what rules out a stricter pattern in favour of a
+# filter: the four shapes an operator legitimately has must still be left alone.
+# Getting these wrong re-adds a blanket `allow OpenSSH` over a rule someone
+# narrowed on purpose, which is the failure case 24 exists for.
+for s in "22/tcp                     ALLOW       Anywhere" \
+         "OpenSSH                    ALLOW       Anywhere" \
+         "22/tcp                     LIMIT       Anywhere" \
+         "22/tcp                     ALLOW       203.0.113.7"; do
+  STATUS="$s"
+  ssh_already_allowed
+  chk "still authorization: ${s%%
 *}" 0 "$?"
 done
 
@@ -4004,8 +4044,17 @@ else
   chk "and one with no comment"                 0 "$g_rc"
   # authorized_keys lines may carry restrictions, and a shape check strict enough
   # to catch truncation would refuse these — which is why the guard parses.
+  guard "no-pty,no-agent-forwarding $GOOD_NEW"
+  chk "and one behind a no-pty restriction"     0 "$g_rc"
+  # A forced command still goes through *here*, and that is the point rather
+  # than an oversight: this guard answers "can sshd read it", which for this
+  # line is yes. The reason it must not be the whole answer is case 142, where
+  # the run refuses it a guard later — sshd reads it and then runs that command
+  # instead of Kamal's. The example used to be spelled `command="x",no-pty` on
+  # this row, which read as this suite endorsing the line rather than as one
+  # question of two.
   guard "command=\"x\",no-pty $GOOD_NEW"
-  chk "and one behind a command= restriction"   0 "$g_rc"
+  chk "a forced command is still parsable"      0 "$g_rc"
   guard "from=\"10.0.0.0/8\" $GOOD_NEW"
   chk "and one behind a from= restriction"      0 "$g_rc"
   guard "   $GOOD_NEW"
@@ -5244,6 +5293,301 @@ for pw in 'aB3xQ9zL7mN2pR5tV8wY1cD4fG6hJ0kM' 'p$aswd$x' 'pas"wd' 'pas\wd' 'pas;w
     "$(printf '%s\n' "$GEN" | grep -cF "PASSWORD '$pw';")"
 done
 rm -rf "$sqld"
+
+echo "142. a forced-command SSH key is refused before it replaces a working one"
+# Measured against a scratch sshd rather than reasoned about, because what is
+# claimed is what sshd does with the line and nothing else can answer it. One
+# authorized_keys line at a time, the client asking for `echo <marker>`:
+#
+#   line                             ssh-keygen -l   ssh rc   what actually ran
+#   <key>                            parses          0        the client's command
+#   from="127.0.0.1" <key>           parses          0        the client's command
+#   no-pty,no-agent-forwarding <key> parses          0        the client's command
+#   restrict <key>                   parses          0        the client's command
+#   restrict,pty <key>               parses          0        the client's command
+#   command="/usr/bin/false" <key>   parses          1        nothing
+#   command="/usr/bin/true"  <key>   parses          0        nothing
+#
+# The last row is why this is a refusal and not a warning: every Kamal step
+# reports success and none of them runs, on a host provisioning also reported
+# as converged. The five rows above it are the controls, and they are the ones
+# that constrain the fix — case 119 exists because a shape check strict enough
+# to catch a truncated key refuses those, so "refuse a line with options" is
+# not available here.
+if ! command -v ssh-keygen >/dev/null 2>&1; then
+  echo "  SKIP no ssh-keygen here — the neighbouring guard's dependency is missing"
+else
+  fcd="$(mktemp -d)"
+  ssh-keygen -q -t ed25519 -N '' -C 'operator@laptop' -f "$fcd/k" >/dev/null
+  FC_KEY="$(cat "$fcd/k.pub")"
+  fc_rc=0
+  fcguard() {
+    ( SSH_PUBLIC_KEY="$1" APP_SSH_USER=collavre
+      refuse_forced_command_ssh_key ) >/dev/null 2>&1 && fc_rc=0 || fc_rc=1
+  }
+
+  fcguard "command=\"/usr/bin/true\" $FC_KEY"
+  chk "a forced command that exits 0 is refused"       1 "$fc_rc"
+  fcguard "command=\"/usr/bin/false\" $FC_KEY"
+  chk "and one that fails, for the same reason"        1 "$fc_rc"
+  # Options are order-free, so the check cannot key on the line starting with
+  # `command=`.
+  fcguard "no-pty,command=\"/usr/bin/true\" $FC_KEY"
+  chk "and one behind another option"                  1 "$fc_rc"
+
+  fcguard "$FC_KEY"
+  chk "a plain key still goes through"                 0 "$fc_rc"
+  fcguard "from=\"127.0.0.1\" $FC_KEY"
+  chk "and one behind a from= restriction"             0 "$fc_rc"
+  fcguard "restrict $FC_KEY"
+  chk "and one behind restrict, which runs the command" 0 "$fc_rc"
+  fcguard ""
+  chk "and no key at all"                              0 "$fc_rc"
+  # The over-refusal control that decides where the options end. A comment is
+  # free text an operator may have anything in, and sshd does not read it as an
+  # option — refusing this would refuse a key that works.
+  fcguard "$FC_KEY command=in-the-comment"
+  chk "a command= in the comment is not an option"     0 "$fc_rc"
+
+  # Source-level, because the behavioural rows above pass on a revision that
+  # never calls the guard: it is the call that makes the run stop.
+  chk "and the run calls it"                           1 \
+    "$(grep -c '^refuse_forced_command_ssh_key$' "$SRC")"
+  rm -rf "$fcd"
+fi
+
+echo "143. a DB_BIND_ADDRESS or DOCKER_SUBNETS the cluster cannot use is refused"
+# Measured on a real cluster with `include_dir = 'conf.d'` and this script's own
+# generated file, restarted once per value:
+#
+#   DB_BIND_ADDRESS       postgres -C   the cluster after the restart
+#   172.17.0.1            rc=0          UP, listening on the bridge
+#   172.17.0.999          rc=0          UP, WARNING, listening on localhost
+#   bogus.invalid         rc=0          UP, WARNING, listening on localhost
+#   not a host            rc=0          DOWN, FATAL: invalid list syntax
+#
+#   DOCKER_SUBNETS        the cluster after the restart
+#   172.16.0.0/12         UP, the rule matches
+#   not-a-subnet          UP, read as a host name, the rule matches nothing
+#   172.16.0.0/99         DOWN, FATAL: invalid CIDR mask in address
+#
+# Two bands, and the quiet one is the dangerous one: a healthy cluster no
+# container can reach. `postgres -C` answers rc=0 on every row including the one
+# that will not start, so validating the staged file does not close this — the
+# value has to be answered before it is written.
+bind_rc=0
+bindguard() { ( refuse_unusable_bind_address DB_BIND_ADDRESS "$1" ) >/dev/null 2>&1 && bind_rc=0 || bind_rc=1; }
+subguard()  { ( refuse_unusable_subnet DOCKER_SUBNETS "$1" ) >/dev/null 2>&1 && bind_rc=0 || bind_rc=1; }
+
+bindguard 172.17.0.1
+chk "the default bridge address goes through"          0 "$bind_rc"
+bindguard 10.0.0.5
+chk "and any other dotted quad"                        0 "$bind_rc"
+bindguard 1.2.3.4
+chk "including one this host does not hold"            0 "$bind_rc"
+bindguard 172.17.0.999
+chk "an octet over 255 is refused"                     1 "$bind_rc"
+bindguard bogus.invalid
+chk "and a host name, which PostgreSQL only warns on"  1 "$bind_rc"
+bindguard "not a host"
+chk "and a value with a space, which stops the cluster" 1 "$bind_rc"
+bindguard "172.17.0.1'"$'\n'"fsync = off"
+chk "and one that closes the quoting of the file"      1 "$bind_rc"
+bindguard 172.17.0
+chk "and three octets"                                 1 "$bind_rc"
+bindguard ""
+chk "and nothing at all"                               1 "$bind_rc"
+
+subguard 172.16.0.0/12
+chk "the default subnet goes through"                  0 "$bind_rc"
+subguard 192.168.0.0/24
+chk "and any other network"                            0 "$bind_rc"
+subguard 172.16.0.0/32
+chk "and a single host as /32"                         0 "$bind_rc"
+subguard 172.16.0.0/99
+chk "a mask over 32 is refused"                        1 "$bind_rc"
+subguard not-a-subnet
+chk "and a name, which the rule would never match"     1 "$bind_rc"
+subguard "172.16.0.0/12 all trust"
+chk "and extra fields, which stop the cluster"         1 "$bind_rc"
+subguard 172.16.0.0
+chk "and an address with no mask"                      1 "$bind_rc"
+
+chk "and the run asks both before anything is written" 2 \
+  "$(grep -c '^refuse_unusable_\(bind_address DB_BIND_ADDRESS\|subnet DOCKER_SUBNETS\)' "$SRC")"
+# The liveness half, which no value check can answer: docker0 does not exist
+# when the guards above run. Asserted at source level because it needs a
+# cluster — measured there as rc=0 bound, rc=2 up-but-not-listening.
+chk "and asks the cluster whether it is listening on it" 1 \
+  "$(grep -c '^pg_isready -h "\$DB_BIND_ADDRESS"' "$SRC")"
+
+echo "144. an interrupted first append leaves the managed block off the live file"
+# The rewrite path was staged and renamed two commits ago; the append that adds
+# the block for the first time still wrote into the live file. Measured by
+# failing one printf of the three — which is what a disk filling between two
+# writes does — and then running the next convergence over what was left:
+#
+#   fails at  reviewed: live file        next run          fixed: live file
+#   BEGIN     unchanged                  adds the block    unchanged
+#   the body  BEGIN + END, empty body    rewrites it       BEGIN + END, empty
+#   END       BEGIN, no END              REFUSES           unchanged
+#   nothing   the whole block            no-op             the whole block
+#
+# The third row is the finding: the next run stops at the malformed-block check
+# and asks for /etc/fstab, /etc/hosts, postgresql.conf or pg_hba.conf to be
+# repaired by hand, on a host whose provisioning has just been killed. That
+# check is right to refuse — it cannot tell a torn write of this script's from
+# an operator's edit — so the fix belongs on the write.
+#
+# Rows 1, 2 and 4 are unchanged by the fix and are the controls. Row 2 is worth
+# keeping visible rather than tidying away: an empty managed block is not a torn
+# file, and the next run converges it.
+abd=$(mktemp -d)
+ab_printf_fail_at=0; ab_printf_n=0
+printf() {
+  ab_printf_n=$((ab_printf_n + 1))
+  [ "$ab_printf_n" != "$ab_printf_fail_at" ] || return 1
+  builtin printf "$@"
+}
+ab_run() { # <fail at nth printf>  -> "<BEGIN count> <END count> <untouched line> <strays>"
+  rm -rf "$abd/f"; builtin printf 'UUID=abc / ext4 defaults 0 1\n' > "$abd/f"
+  ab_printf_fail_at="$1"; ab_printf_n=0
+  ( ensure_block "$abd/f" swap "/swapfile none swap sw 0 0" ) >/dev/null 2>&1
+  ab_printf_fail_at=0
+  echo "$(grep -c 'BEGIN collavre:swap' "$abd/f") $(grep -c 'END collavre:swap' "$abd/f") $(grep -c '^UUID=abc' "$abd/f") $(ls -A "$abd" | grep -c collavre)"
+}
+chk "a failed BEGIN leaves the file as it was"          "0 0 1 0" "$(ab_run 1)"
+chk "a failed END leaves no half-written block behind"  "0 0 1 0" "$(ab_run 3)"
+chk "and no staging file beside it"                     "0 0 1 0" "$(ab_run 3)"
+chk "an uninterrupted append still adds the block"      "1 1 1 0" "$(ab_run none)"
+# The control that says the next run is not left asking for an editor. Against
+# the reviewed revision this is the refusal.
+rm -rf "$abd/f"; builtin printf 'UUID=abc / ext4 defaults 0 1\n' > "$abd/f"
+ab_printf_fail_at=3; ab_printf_n=0
+( ensure_block "$abd/f" swap "/swapfile none swap sw 0 0" ) >/dev/null 2>&1
+ab_printf_fail_at=0
+ab_next="$( ( ensure_block "$abd/f" swap "/swapfile none swap sw 0 0" ) 2>&1 >/dev/null | grep -c "with no '# END" )"
+chk "so the next run converges instead of refusing"     0 "$ab_next"
+chk "and the block is there afterwards"                 1 "$(grep -c 'END collavre:swap' "$abd/f")"
+unset -f printf
+rm -rf "$abd"
+
+echo "146. the SSH hardening drop-in is installed where it can win, and read back"
+# sshd_config(5): "for each keyword, the first obtained value will be used", and
+# the Include glob is expanded in lexical order. So a "99-" drop-in loses every
+# keyword an earlier file has already set — which reads backwards, because a
+# high number means "last, therefore final" almost everywhere else.
+#
+# Ubuntu's cloud images ship 50-cloud-init.conf, and on an existing instance it
+# commonly carries `PasswordAuthentication yes`. Measured with `sshd -T` rather
+# than read off the manual page, on OpenSSH 9.x/Linux and 10.2/macOS alike:
+#
+#   drop-ins present                        passwordauth  permitrootlogin
+#   50-cloud-init.conf + 99-collavre.conf   yes           yes
+#   50-cloud-init.conf + 01-collavre.conf   no            no
+#   01-collavre.conf alone (fresh host)     no            no
+#
+# `kbdinteractiveauthentication no` in all three rows is the control that says
+# what went wrong: the 99- file was read the whole time. It lost exactly the
+# keywords something else had already set, and gained the one nothing else
+# mentions — so nothing about the run looked wrong, and step 3 reported "SSH
+# hardening" over a host still taking passwords and root logins.
+#
+# The rename is necessary and not sufficient, which is why the read-back is the
+# other half. A drop-in an operator prefixed 00-, or a directive above the
+# Include in sshd_config itself, still wins, and no file name can answer that.
+LOGGED=""
+log() { LOGGED="$LOGGED $*"; }
+
+vshd="$(mktemp -d)"
+mkdir -p "$vshd/sshd_config.d" "$vshd/bin"
+printf 'PasswordAuthentication yes\n' > "$vshd/sshd_config.d/00-operator.conf"
+printf 'PasswordAuthentication no\nPermitRootLogin no\nKbdInteractiveAuthentication no\n' \
+  > "$vshd/sshd_config.d/01-collavre.conf"
+printf 'Include %s/sshd_config.d/*.conf\n' "$vshd" > "$vshd/sshd_config"
+
+# <what sshd -T reports> -> 0 when the run continues, 1 when it stops
+vh() {
+  printf '%s\n' "$1" > "$vshd/eff"
+  ( verify_ssh_hardening "$vshd/eff" "$vshd" ) >/dev/null 2>&1 && echo 0 || echo 1
+}
+vh_eff() { printf 'passwordauthentication %s\npermitrootlogin %s\nkbdinteractiveauthentication %s' "$1" "$2" "$3"; }
+
+chk "an effective config that matches the drop-in passes" 0 "$(vh "$(vh_eff no no no)")"
+chk "password authentication still on stops the run"      1 "$(vh "$(vh_eff yes no no)")"
+# `prohibit-password` is the Ubuntu default and still admits root by key, so it
+# is not the 'no' this script writes.
+chk "and root login still on, however narrowly"           1 "$(vh "$(vh_eff no prohibit-password no)")"
+chk "and keyboard-interactive still on"                   1 "$(vh "$(vh_eff no no yes)")"
+
+printf '%s\n' "$(vh_eff yes no no)" > "$vshd/eff"
+vh_msg="$( ( verify_ssh_hardening "$vshd/eff" "$vshd" ) 2>&1 )"
+chk "and the refusal names the file that won"             1 \
+  "$(printf '%s' "$vh_msg" | grep -c '00-operator\.conf')"
+
+# Unknown is not wrong. A host where `sshd -T` will not run has answered
+# nothing, and stopping over a question that could not be asked would refuse
+# hosts that are fine — so that branch warns and the run goes on.
+printf '#!/bin/sh\nexit 1\n' > "$vshd/bin/sshd"
+chmod +x "$vshd/bin/sshd"
+vh_unread="$( ( PATH="$vshd/bin:$PATH"
+                log() { printf 'LOG %s\n' "$*"; }
+                verify_ssh_hardening "" "$vshd" ) 2>&1; printf 'rc=%s\n' "$?" )"
+chk "an sshd -T that will not run warns instead of stopping" 1 \
+  "$(printf '%s' "$vh_unread" | grep -c '^rc=0$')"
+chk "and says the hardening is unverified"                1 \
+  "$(printf '%s' "$vh_unread" | grep -c 'unverified')"
+
+# Source level, because every row above passes on a revision that writes the
+# drop-in under the losing name and never reads anything back.
+chk "the drop-in is written where it sorts first"         1 \
+  "$(grep -c '^cat > /etc/ssh/sshd_config\.d/01-collavre\.conf <<' "$SRC")"
+chk "and the inert 99- file it replaces is removed"       1 \
+  "$(grep -c '^rm -f /etc/ssh/sshd_config\.d/99-collavre\.conf$' "$SRC")"
+chk "and the run reads back what sshd resolved"           1 \
+  "$(grep -c '^verify_ssh_hardening$' "$SRC")"
+
+# The claim is about what sshd does with two files, so sshd is asked. The name
+# and the body both come from the script: a harness that wrote its own 01- file
+# would keep passing after the script went back to 99-.
+vh_sshd=""
+for vh_c in sshd /usr/sbin/sshd; do
+  command -v "$vh_c" >/dev/null 2>&1 && { vh_sshd="$vh_c"; break; }
+done
+vh_effective() { # <config dir> -> "<passwordauthentication> <permitrootlogin>"
+  "$vh_sshd" -T -f "$1/sshd_config" 2>/dev/null |
+    awk 'tolower($1)=="passwordauthentication"{p=$2}
+         tolower($1)=="permitrootlogin"{r=$2}
+         END{print p, r}'
+}
+if [ -z "$vh_sshd" ] || ! command -v ssh-keygen >/dev/null 2>&1; then
+  echo "  SKIP no sshd here — the ordering claim is sshd's own and nothing else answers it"
+else
+  vhr="$(mktemp -d)"
+  mkdir -p "$vhr/sshd_config.d"
+  ssh-keygen -q -t ed25519 -N '' -f "$vhr/hk" >/dev/null 2>&1
+  printf 'Include %s/sshd_config.d/*.conf\nHostKey %s/hk\n' "$vhr" "$vhr" > "$vhr/sshd_config"
+  # the shipped write, replayed: the file name off the `cat >` line, the body
+  # out of its heredoc
+  vh_name="$(awk '/^cat > \/etc\/ssh\/sshd_config\.d\// { sub(/.*sshd_config\.d\//, ""); sub(/ .*/, ""); print; exit }' "$SRC")"
+  awk '/^cat > \/etc\/ssh\/sshd_config\.d\// { f = 1; next }
+       f && /^SSHD$/ { exit }
+       f' "$SRC" > "$vhr/sshd_config.d/$vh_name"
+  if [ "$(vh_effective "$vhr")" != "no no" ]; then
+    echo "  SKIP sshd -T is not usable here — it could not read even the drop-in alone"
+  else
+    chk "the drop-in alone hardens a fresh host"          "no no" "$(vh_effective "$vhr")"
+    printf 'PasswordAuthentication yes\nPermitRootLogin yes\n' \
+      > "$vhr/sshd_config.d/50-cloud-init.conf"
+    chk "and still does beside Ubuntu's cloud-init drop-in" "no no" "$(vh_effective "$vhr")"
+    # The negative control, and the one that says the assertion above is about
+    # the name rather than the content: the same body under the old name.
+    mv "$vhr/sshd_config.d/$vh_name" "$vhr/sshd_config.d/99-collavre.conf"
+    chk "where a 99- name would have lost both keywords"  "yes yes" "$(vh_effective "$vhr")"
+  fi
+  rm -rf "$vhr"
+fi
+rm -rf "$vshd"
 
 echo
 if [ "$fail" = 0 ]; then echo "ALL PASS"; else echo "FAILURES"; fi

--- a/test/db/seeds_test.rb
+++ b/test/db/seeds_test.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# The default admin block in db/seeds.rb ships a published password. These pin
+# the one environment where that must never reach the database.
+class SeedsTest < ActiveSupport::TestCase
+  DEFAULT_EMAIL = "admin@example.com"
+
+  # Only the admin block — the engine seeds below it create users of their own
+  # and are not what is under test here.
+  SEEDS = File.read(Rails.root.join("db/seeds.rb"))
+  ADMIN_BLOCK = SEEDS.split("# Load engine seeds").first.freeze
+  raise "db/seeds.rb no longer marks where the engine seeds begin" if ADMIN_BLOCK == SEEDS
+
+  setup do
+    Collavre::User.where(email: DEFAULT_EMAIL).destroy_all
+  end
+
+  def seed_admin(env, **vars)
+    original = vars.transform_values { nil }.merge(ENV.slice(*vars.keys.map(&:to_s)))
+    vars.each { |k, v| ENV[k.to_s] = v }
+    Rails.stub(:env, ActiveSupport::StringInquirer.new(env)) do
+      capture_io { eval(ADMIN_BLOCK, TOPLEVEL_BINDING, "db/seeds.rb") } # rubocop:disable Security/Eval
+    end
+  ensure
+    original.each { |k, v| v.nil? ? ENV.delete(k.to_s) : ENV[k.to_s] = v }
+  end
+
+  test "production without DEFAULT_USER_PASSWORD creates no admin" do
+    out, = seed_admin("production", DEFAULT_USER_PASSWORD: nil, DEFAULT_USER_EMAIL: nil)
+
+    assert_nil Collavre::User.find_by(email: DEFAULT_EMAIL),
+      "a deployed host must not get a system_admin whose password is in the repository"
+    assert_match(/DEFAULT_USER_PASSWORD is not set/, out)
+  end
+
+  test "production with a supplied password creates that admin" do
+    seed_admin("production",
+      DEFAULT_USER_EMAIL: "ops@example.org",
+      DEFAULT_USER_PASSWORD: "a-password-the-operator-generated")
+
+    user = Collavre::User.find_by(email: "ops@example.org")
+    assert user, "an explicit password is the supported way to seed production"
+    assert user.system_admin?
+    assert user.authenticate("a-password-the-operator-generated")
+  ensure
+    Collavre::User.where(email: "ops@example.org").destroy_all
+  end
+
+  test "an empty DEFAULT_USER_PASSWORD is not a password" do
+    # Kamal and dotenv both hand through declared-but-empty variables.
+    seed_admin("production", DEFAULT_USER_PASSWORD: "", DEFAULT_USER_EMAIL: nil)
+
+    assert_nil Collavre::User.find_by(email: DEFAULT_EMAIL)
+  end
+
+  test "development still seeds the default admin" do
+    seed_admin("development", DEFAULT_USER_PASSWORD: nil, DEFAULT_USER_EMAIL: nil)
+
+    user = Collavre::User.find_by(email: DEFAULT_EMAIL)
+    assert user, "the convenience default is the point outside production"
+    assert user.authenticate("password123")
+  end
+end


### PR DESCRIPTION
## Summary

Provision a single AWS Lightsail instance that runs both PostgreSQL and the Collavre container, so `bin/kamal setup` has a host to deploy to.

- `script/lightsail_launch.sh` — idempotent instance provisioning, fetched by a commit-pinned bootstrap in the Lightsail *Launch script* box or run by hand.
- `docs/deploy_to_lightsail.md` — the runbook, linked from `README.md` and `docs/README.md`.

## What the script does

Base packages, timezone, swap, SSH hardening · staged deploy-user cutover with passwordless sudo and Docker access · Docker CE + buildx + compose with capped container logs · PostgreSQL · the `collavre_production` database and `collavre_user` role · ufw · a nightly `pg_dump` systemd timer with retention and optional S3 upload.

It does not build or start the app — Kamal still does that from the workstation.

## Two-phase SSH cutover

Deploy-account and key rotations use `stage → signed proof → durable commit → retryable cleanup` instead of treating sshd configuration or forgeable host-local process state as proof of reachability.

1. Provisioning creates and hardens the staged account, installs its keys, and grants `sudo`/`docker`, while retaining the previously proven account, keys, groups, and sudoers grant.
2. One atomic 0600 pending record binds the user, nonce hash, explicit rotation key, and accepted signing public keys.
3. The root-only summary gives a workstation command that signs `user + nonce` with the staged private key, then connects with `ssh -F /dev/null -o IdentitiesOnly=yes -i <that-key>`. A rejected staged key cannot fall back to an agent or configured predecessor identity, so the finalizer is never invoked unless that exact key opens the staged-user SSH session.
4. The finalizer verifies the SSH signature, then atomically commits the proven successor before withdrawing predecessor keys, groups, and sudoers grants. A pre-commit failure changes no predecessor access; a post-commit interruption retains the proven successor and retries cleanup from the pending record.

This makes workstation private-key possession and an isolated staged-key SSH connection the safety boundary, rather than an open-ended parser for every `Match`, `Include`, admission, address, group, or process-tree interaction. Script sudoers filenames also include an exact-username digest so colliding normalized usernames cannot overwrite the predecessor before proof.

## Socket-activated SSH validation

Ubuntu 24.04 normally keeps `ssh.socket` active while `ssh.service` is inactive until the first connection. Because `ssh.service` owns `RuntimeDirectory=sshd`, a launch script running before that first connection can find no `/run/sshd`; direct `sshd -t`/`sshd -T` validation then fails with `Missing privilege separation directory` even for valid configuration. The script now creates the service-equivalent `root:root 0755 /run/sshd` before reload and disk validation, without starting a permanent daemon. Failure to prepare it stops provisioning before any deploy privilege is granted.

## Lightsail launch bootstrap

The provisioning script is about 256 KB and exceeds the Lightsail launch-script input limit. The runbook now supplies a small bootstrap that installs `curl` and CA certificates, downloads the exact reviewed runtime revision to a root-only path with retry and fail-closed options, validates it with `bash -n`, and executes it. The raw URL is pinned to commit `a3113860` rather than a mutable branch; later script revisions must update that pin deliberately. Overrides such as `SSH_PUBLIC_KEY` are exported before the final `exec`.

## Notes for review

- **Database reachability.** PostgreSQL listens only on `localhost` and the docker0 gateway `172.17.0.1`. Containers can reach it; nothing off the host can, regardless of firewall config. `net.ipv4.ip_nonlocal_bind=1` lets it bind that address when it starts before dockerd after a reboot. `pg_hba` requires scram from the Docker ranges and ufw allows 5432 only from `172.16.0.0/12` to that one address.
- **One database.** Provisioning mirrors `db/setup_postgres_databases.sql` — primary/cache/queue/cable share `collavre_production`, created only when missing, never dropped.
- **Schema loading.** The runbook flags that a fresh `db:migrate` replay is not equivalent to `db/schema.rb`, and recommends restoring a dump or `db:schema:load` before the first deploy.
- **Builder arch.** `config/deploy.yml` pins `builder.arch: arm64`; Lightsail's standard Linux plans are x86-64. The doc covers switching to `amd64` and using the instance as a remote builder.
- The Kamal-accessory alternative for PostgreSQL is documented, with the tradeoff that made the host-native path the default.

## Testing

- `bash script/test/lightsail_launch_test.sh` — `ALL PASS`, including the commit-pinned download bootstrap and its fail-closed/syntax/execute gates, real SSH-signature verification, wrong-context/missing/forged signatures, explicit and copied-key staging, no pre-proof revocation, commit-before-cleanup, interrupted cleanup retry, and sudoers filename collisions
- `bash -n` for the launch script and test suite
- `git diff --check`
- `mise exec ruby@3.4.4 -- ./bin/rubocop --parallel` — 1,082 files, no offenses at runtime commit `a3113860`
- GitHub CI for final HEAD `fbf9838f` — all checks passed, including `lint`, full `test`, CodeQL, schema load, JS tests, and security scans

Local Rails tests remain limited by existing repository environment issues unrelated to this shell/Markdown change: seven unit-test errors from missing Active Record encryption credentials, and `test:system` cannot load the absent `test/system` directory.