### PR TITLE
fix(markdown): pin header_ids off so heading output does not follow gem defaults

### DIFF
--- a/engines/collavre/app/services/collavre/markdown_converter.rb
+++ b/engines/collavre/app/services/collavre/markdown_converter.rb
@@ -59,10 +59,22 @@ module Collavre
         # styles override our theme-aware code_highlight.css palette and are blind to light/dark mode.
         # Disabling it emits a plain `<pre lang="ruby"><code>…</code></pre>`; the client re-tokenizes
         # with highlight.js so the rendered creative matches the editor (and respects the theme).
+        #
+        # header_ids: nil is pinned rather than left to the default. commonmarker 2.9.0 turned this
+        # extension on out of the box, which appends an anchor to every heading:
+        # `<h1 id="heading">Heading<a href="#heading" class="anchor"></a></h1>`. That output is stored
+        # (Creative#description is a rendered, sanitized field), and the sanitizer's allow-list drops
+        # `id` while keeping the `<a>` — so the anchor would link to a target that no longer exists,
+        # on every heading of every creative. `html_to_markdown` would also read it back as an empty
+        # link and write `[](#heading)` into the markdown. Pinning it keeps the rendered output a
+        # function of our options rather than of the gem's defaults; the key is accepted by 2.8 too.
         html = Commonmarker.to_html(input, options: {
           parse: { smart: true },
           render: { unsafe: true, hardbreaks: true },
-          extension: { table: true, strikethrough: true, autolink: true, tasklist: true, tagfilter: true }
+          extension: {
+            table: true, strikethrough: true, autolink: true, tasklist: true, tagfilter: true,
+            header_ids: nil
+          }
         }, plugins: { syntax_highlighter: nil })
 
         html.strip!

--- a/engines/collavre/test/services/collavre/markdown_converter_test.rb
+++ b/engines/collavre/test/services/collavre/markdown_converter_test.rb
@@ -30,6 +30,29 @@ module Collavre
       refute_includes html, "style=\"color"
     end
 
+    test "markdown_to_html renders headings without anchor links" do
+      # commonmarker 2.9.0 enables the header_ids extension by default, which appends
+      # `<a href="#heading" class="anchor"></a>` inside every heading and sets `id` on the
+      # heading itself. This output is stored (Creative#description holds rendered, sanitized
+      # HTML) and the sanitizer drops `id` while keeping the anchor, so each heading would
+      # carry a link to a target that no longer exists; html_to_markdown then reads the empty
+      # anchor back as `[](#heading)`. We pin the extension off, so the rendering must not
+      # depend on which commonmarker version is installed.
+      html = MarkdownConverter.markdown_to_html("# Heading\n\ntext")
+      assert_includes html, "Heading</h1>"
+      refute_includes html, "class=\"anchor\""
+      refute_includes html, "href=\"#heading\""
+      refute_includes html, "id=\"heading\""
+    end
+
+    test "html_to_markdown turns an empty heading anchor into a stray link" do
+      # Pins the consequence the option above avoids: an anchored heading does not survive a
+      # round trip, it grows `[](#heading)`. If a future change adopts heading anchors as a
+      # feature, html_to_markdown has to learn to drop them and this test should fail first.
+      assert_equal "Heading[](#heading)",
+                   MarkdownConverter.html_to_markdown(%(<h1>Heading<a href="#heading" class="anchor"></a></h1>))
+    end
+
     test "markdown_to_html renders a single newline as a hard break" do
       # Mirrors the JS renderer (marked breaks:true): consecutive rich-editor
       # lines are stored one-per-line and must render as <br>, not be joined.


### PR DESCRIPTION
## What

`MarkdownConverter.markdown_to_html` passed an explicit `extension:` hash but left `header_ids` to whatever commonmarker defaults to. commonmarker 2.9.0 turns that extension on, so the rendered output changes shape under a routine dependency bump.

## Why it matters

`Creative#description` stores **rendered, sanitized HTML** — the render is not a display-time concern, it is written to the database. With 2.9.0 installed, every heading becomes:

```html
<h1 id="heading">Heading<a href="#heading" aria-label="…" data-heading-content="…" class="anchor"></a></h1>
```

and after our sanitizer's allow-list runs (which permits `class` but not `id`), what actually gets stored is:

```html
<h1>Heading<a href="#heading" class="anchor"></a></h1>
```

Two concrete consequences:

1. **Dead link on every heading.** The anchor survives sanitization; the `id` it points at does not.
2. **Round-trip growth.** `html_to_markdown` reads the empty anchor as a link — verified against the real converter:
   ```
   html_to_markdown('<h1>Heading<a href="#heading" class="anchor"></a></h1>')
   # => "Heading[](#heading)"
   ```

## The change

Pin `header_ids: nil` alongside the extensions we already declare, so the rendered output is a function of our options rather than of whichever gem version resolved. The key is accepted by 2.8 as well, so this is **inert on today's lockfile** — it is a guard, not a behaviour change.

Adopting heading anchors as a real feature is a defensible thing to want, but it is not a dependency bump: it needs `id` allow-listed in the sanitizer, `html_to_markdown` taught to drop the anchors, and styling. This PR deliberately does not do that.

## Relation to #1419

This is the root cause of the two test failures blocking dependabot's commonmarker 2.8.1 → 2.9.0 bump. That PR is a genuine break, not stale CI.

## Verification

- New test pins that headings render with no anchor, no `class="anchor"`, no `id`.
- A second test pins the round-trip consequence, so a future change that adopts anchors fails here first rather than silently corrupting markdown.
- **Locally bumped to commonmarker 2.9.0** and ran `markdown_converter_test` + the two suites that fail in #1419's CI: 75 runs / 307 assertions / 0 failures.
- **Reverse-verified**: with 2.9.0 installed and this guard removed, the two #1419 failures reproduce verbatim (byte-identical expected/actual strings to the CI log) plus the new test fails. Lockfile then reverted — this PR does not take the bump.
- Full pre-push suite green; rubocop clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)