### PR TITLE
fix(deps): depend on ruby-vips explicitly for Active Storage variants

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,13 @@ gem "thruster", require: false
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 gem "image_processing", "~> 1.14"
+# The variant processor is Rails 8's default, :vips, so ImageProcessing::Vips needs ruby-vips.
+# image_processing 1.x pulls it in transitively; 2.0 makes it a soft dependency instead, and
+# ImageProcessing::Vips is only resolved when a variant is actually processed — a missing
+# ruby-vips boots fine and raises on the first avatar or comment image instead. Depending on it
+# here keeps that bump from turning into a runtime failure. (Dockerfile installs libvips, the
+# C library this binds to.)
+gem "ruby-vips", "~> 2.0"
 
 # Use AWS S3 for Active Storage
 gem "aws-sdk-s3", require: false

--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,12 @@ gem "image_processing", "~> 1.14"
 # ruby-vips boots fine and raises on the first avatar or comment image instead. Depending on it
 # here keeps that bump from turning into a runtime failure. (Dockerfile installs libvips, the
 # C library this binds to.)
-gem "ruby-vips", "~> 2.0"
+#
+# require: false because naming the gem is only meant to pin the bundle, not to change when it
+# loads: an auto-required ruby-vips dlopens libvips during boot, so every environment that merely
+# boots the app -- the postgres_schema_load CI job, say -- would suddenly need the C library
+# installed. image_processing requires it on its own when a variant is actually processed.
+gem "ruby-vips", "~> 2.0", require: false
 
 # Use AWS S3 for Active Storage
 gem "aws-sdk-s3", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -758,6 +758,7 @@ DEPENDENCIES
   rails (~> 8.1.3)
   rails_mcp_engine (~> 0.4.2)
   rubocop-rails-omakase
+  ruby-vips (~> 2.0)
   ruby_llm
   selenium-webdriver
   simplecov

--- a/test/lib/active_storage_variant_processor_test.rb
+++ b/test/lib/active_storage_variant_processor_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+
+# Guards the gem backing Active Storage's variant processor.
+#
+# Active Storage resolves the processor class lazily: ActiveStorage::Transformers::Vips only
+# touches ImageProcessing::Vips inside #processor, which runs when a variant is actually
+# processed. image_processing 2.0 turned ruby-vips and mini_magick into soft dependencies, so a
+# bundle that drops ruby-vips boots clean, passes a suite that never renders a variant, and then
+# raises LoadError on the first avatar or comment image in production. Resolving the processor
+# eagerly here turns that into a CI failure instead.
+class ActiveStorageVariantProcessorTest < ActiveSupport::TestCase
+  test "the configured variant processor resolves its backing gem" do
+    # Pinned rather than read from config: the ruby-vips dependency in the Gemfile is only the
+    # right one while :vips is the processor. Switching processors has to update both.
+    assert_equal :vips, ActiveStorage.variant_processor
+    assert_equal ActiveStorage::Transformers::Vips, ActiveStorage.variant_transformer,
+      "variant_transformer is unset — Active Storage swallowed a LoadError while booting"
+
+    assert_equal ImageProcessing::Vips,
+      ActiveStorage.variant_transformer.new({}).send(:processor)
+  end
+end


### PR DESCRIPTION
Unblocks #1349 (image_processing 1.14 → 2.0.2), which is green on CI but would break image variants in production.

## Why

The app never sets `config.active_storage.variant_processor`, and `load_defaults 8.0` leaves it at Rails 8's default `:vips` — so processing a variant goes through `ImageProcessing::Vips`, which needs the **ruby-vips** gem. Today that gem is only present transitively, via `image_processing` 1.x's hard dependency on it.

image_processing 2.0 makes `ruby-vips` and `mini_magick` soft dependencies and declares neither. #1349's lockfile drops both:

```
-    image_processing (1.14.0)
-      mini_magick (>= 4.9.5, < 6)
-      ruby-vips (>= 2.0.17, < 3)
+    image_processing (2.0.2)
-    ruby-vips (2.3.0)
-    mini_magick (5.3.1)
```

This does **not** fail at boot. `ActiveStorage::Transformers::Vips` resolves `ImageProcessing::Vips` lazily, inside `#processor`, which only runs when a variant is actually processed. So the app boots clean, the suite passes (nothing in it renders a real variant — which is why #1349 is green), and the first request that renders one raises:

```
LoadError: ImageProcessing::Vips requires the ruby-vips gem.
```

The affected call sites are user-facing on every page:
- `app/helpers/application_helper.rb:8` — user avatars
- `engines/collavre/app/channels/collavre/creatives_channel.rb:66` — avatars over ActionCable
- `engines/collavre/app/views/collavre/comments/_comment.html.erb:132` — comment image previews

`mini_magick` is not needed — nothing references `MiniMagick` and no config selects `:mini_magick`. `libvips`, the C library ruby-vips binds to, is already installed in `Dockerfile:19`.

## What changed

- `Gemfile`: added `gem "ruby-vips", "~> 2.0"`. No-op against the current bundle — 1.14 already resolves ruby-vips 2.3.0, so the lockfile diff is one line in `DEPENDENCIES`.
- New test that resolves the processor eagerly, so the gap fails in CI instead of production.

## Verification

Test passes on this branch. Reproduced #1349 locally (image_processing `~> 2.0`, no ruby-vips) and the test errors with the upstream LoadError — i.e. it would have caught the bump:

```
ActiveStorageVariantProcessorTest#test_the_configured_variant_processor_resolves_its_backing_gem:
LoadError: ImageProcessing::Vips requires the ruby-vips gem.
```

Once this lands, #1349 can be rebased and merged safely.