### PR TITLE
feat: make a topic's primary agent an exclusive assignment

### DIFF
--- a/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
+++ b/engines/collavre/app/assets/stylesheets/collavre/comments_popup.css
@@ -1489,6 +1489,15 @@ body.chat-fullscreen {
     font-size: var(--text-00);
 }
 
+/* The avatar is also the release control for the topic's agent assignment. */
+.topic-agent-avatar-releasable {
+    cursor: pointer;
+}
+
+.topic-agent-avatar-releasable:hover {
+    opacity: 0.6;
+}
+
 .ai-agent-draggable {
     cursor: grab;
 }

--- a/engines/collavre/app/controllers/collavre/topics_controller.rb
+++ b/engines/collavre/app/controllers/collavre/topics_controller.rb
@@ -152,9 +152,32 @@ module Collavre
         render json: { error: I18n.t("collavre.topics.move.duplicate_name", name: topic.name) }, status: :unprocessable_entity and return
       end
 
+      # A Claude Channel session topic is looked up as
+      # inbox.topics.find_by(primary_agent_id:, session_id:) — re-parenting it
+      # takes it out of that scope, so the next registration would fork a second
+      # topic and Matcher#eligible_in_inbox? would stop routing the session
+      # agent. Same identity that #set_primary_agent refuses to rewrite.
+      if topic.session_id.present?
+        render json: { error: I18n.t("collavre.topics.move.session_topic_locked") }, status: :unprocessable_entity and return
+      end
+
+      released_agent = nil
+
       Topic.transaction do
         topic.comments.update_all(creative_id: target_creative.id)
         topic.update!(creative: target_creative)
+
+        # The assignment is exclusive: Matcher#match_by_primary_agent returns []
+        # — silence, not a fallback — when the pinned agent lacks :feedback. The
+        # pin travels with the topic, so a move into a creative the agent is not
+        # shared on would leave the topic unable to route to anyone. Release it
+        # instead, which restores ordinary expression routing at the new
+        # location, and tell the caller so the change is not silent.
+        pinned_agent = topic.primary_agent
+        if pinned_agent && !Topic.primary_agent_assignable?(target_creative, pinned_agent)
+          released_agent = pinned_agent
+          topic.set_primary_agent!(nil)
+        end
       end
 
       # update_all above skips counter-cache callbacks, so recompute
@@ -163,14 +186,24 @@ module Collavre
       Creative.reset_counters(target_creative.id, :comments)
 
       broadcast_topic_event("deleted", topic_id: topic.id)
-      broadcast_topic_event("created", creative: target_creative, topic: topic.slice(:id, :name))
+      # topic_json rather than a bare id/name slice: the pin decides who may
+      # speak, so the target's topic list has to show whether it survived the
+      # move (and, when it did not, show no avatar rather than a stale one).
+      broadcast_topic_event("created", creative: target_creative, topic: topic_json(topic))
 
       render json: {
         success: true,
         topic: topic.slice(:id, :name),
         target_creative_id: target_creative.id,
         target_creative_name: target_creative.creative_snippet,
-        missing_members: missing_members_for_move(source_creative, target_creative)
+        missing_members: missing_members_for_move(source_creative, target_creative),
+        released_primary_agent: released_agent && {
+          id: released_agent.id,
+          name: released_agent.display_name,
+          message: I18n.t("collavre.topics.move.primary_agent_released",
+                          agent: released_agent.display_name,
+                          creative: target_creative.creative_snippet)
+        }
       }
     end
 

--- a/engines/collavre/app/controllers/collavre/topics_controller.rb
+++ b/engines/collavre/app/controllers/collavre/topics_controller.rb
@@ -198,6 +198,18 @@ module Collavre
     def set_primary_agent
       topic = @creative.topics.find(params[:id])
 
+      # On a Claude Channel session topic, primary_agent_id is not a routing pin
+      # but part of the session identity: Matcher#eligible_in_inbox? needs it to
+      # route the session agent at all, and SessionProvisioner#find_or_create_topic
+      # reuses the topic by (primary_agent_id, session_id). Clearing or reassigning
+      # it would leave a live session unroutable and split the next registration
+      # into a second topic. Releasing a session is session teardown, not an
+      # avatar click.
+      if topic.session_id.present?
+        render json: { error: I18n.t("collavre.topics.session_topic_locked") },
+               status: :unprocessable_entity and return
+      end
+
       # A blank agent_id clears the assignment. The primary agent is an exclusive
       # assignment (it silences every other agent's ambient routing), so the user
       # needs a way back to an unassigned topic — otherwise a single avatar click
@@ -293,6 +305,7 @@ module Collavre
       if topic.primary_agent
         data[:primary_agent] = agent_json(topic.primary_agent)
       end
+      data[:agent_locked] = topic.session_id.present?
       data
     end
 
@@ -302,6 +315,7 @@ module Collavre
     def topic_json_with_agent(topic, agent)
       data = topic.slice(:id, :name, :source_topic_id)
       data[:primary_agent] = agent ? agent_json(agent) : nil
+      data[:agent_locked] = topic.session_id.present?
       data
     end
 

--- a/engines/collavre/app/controllers/collavre/topics_controller.rb
+++ b/engines/collavre/app/controllers/collavre/topics_controller.rb
@@ -197,6 +197,19 @@ module Collavre
 
     def set_primary_agent
       topic = @creative.topics.find(params[:id])
+
+      # A blank agent_id clears the assignment. The primary agent is an exclusive
+      # assignment (it silences every other agent's ambient routing), so the user
+      # needs a way back to an unassigned topic — otherwise a single avatar click
+      # would permanently dedicate the topic to one agent.
+      if params[:agent_id].blank?
+        topic.set_primary_agent!(nil)
+
+        broadcast_topic_event("updated", topic: topic_json_with_agent(topic, nil))
+
+        return render json: { success: true, topic: topic_json_with_agent(topic, nil) }
+      end
+
       agent = User.find_by(id: params[:agent_id])
 
       unless agent&.ai_user?
@@ -283,9 +296,12 @@ module Collavre
       data
     end
 
+    # Always carries a :primary_agent key, explicitly nil when cleared. The client
+    # merges this payload into its cached topic, so an omitted key would leave a
+    # stale avatar on screen instead of removing it.
     def topic_json_with_agent(topic, agent)
       data = topic.slice(:id, :name, :source_topic_id)
-      data[:primary_agent] = agent_json(agent)
+      data[:primary_agent] = agent ? agent_json(agent) : nil
       data
     end
 

--- a/engines/collavre/app/controllers/collavre/topics_controller.rb
+++ b/engines/collavre/app/controllers/collavre/topics_controller.rb
@@ -10,7 +10,11 @@ module Collavre
     def index
       is_owner = @creative.user == Current.user
       can_manage = @creative.has_permission?(Current.user, :admin) || is_owner
-      can_create_topic = can_manage || @creative.has_permission?(Current.user, :write)
+      # Mirrors require_creative_write! — the gate on #create and
+      # #set_primary_agent. Reported as two capabilities because the client gates
+      # two separate controls on it, and only #update/#destroy/#move/#reorder
+      # need :admin.
+      can_write = can_manage || @creative.has_permission?(Current.user, :write)
 
       # Eagerly ensure Main (and System for inboxes) exist BEFORE loading
       # active_topics. Otherwise the first inbox visit sees no System topic in
@@ -36,7 +40,8 @@ module Collavre
         topics: active_topics.map { |t| topic_json(t) },
         archived_topics: archived_topics,
         can_manage: can_manage,
-        can_create_topic: can_create_topic,
+        can_create_topic: can_write,
+        can_set_primary_agent: can_write,
         last_topic_id: last_topic_id,
         is_inbox: @creative.inbox?,
         system_topic_id: system_topic_id,
@@ -46,15 +51,22 @@ module Collavre
     end
 
     def create
+      requested_agent = params[:agent_id].present? ? User.find_by(id: params[:agent_id]) : nil
+
+      if requested_agent&.ai_user? && !assignable_primary_agent?(requested_agent)
+        render json: { errors: [ agent_no_creative_access_message(requested_agent) ] },
+               status: :unprocessable_entity and return
+      end
+
       topic = @creative.topics.build(topic_params)
       topic.user = Current.user
 
       Topic.transaction do
         if topic.save
           agent = nil
-          if params[:agent_id].present?
-            agent = User.find_by(id: params[:agent_id])
-            topic.set_primary_agent!(agent) if agent&.ai_user?
+          if requested_agent&.ai_user?
+            agent = requested_agent
+            topic.set_primary_agent!(agent)
           end
 
           # Move comments to the new topic if comment_ids provided
@@ -228,6 +240,11 @@ module Collavre
         render json: { error: I18n.t("collavre.topics.not_ai_agent") }, status: :unprocessable_entity and return
       end
 
+      unless assignable_primary_agent?(agent)
+        render json: { error: agent_no_creative_access_message(agent) },
+               status: :unprocessable_entity and return
+      end
+
       topic.set_primary_agent!(agent)
 
       broadcast_topic_event("updated", topic: topic_json_with_agent(topic, agent))
@@ -239,6 +256,14 @@ module Collavre
 
     def set_creative
       @creative = Creative.find(params[:creative_id]).effective_origin
+    end
+
+    def assignable_primary_agent?(agent)
+      Topic.primary_agent_assignable?(@creative, agent)
+    end
+
+    def agent_no_creative_access_message(agent)
+      I18n.t("collavre.topics.agent_no_creative_access", name: agent.display_name)
     end
 
     # When a topic moves to a different creative, members who had access on the

--- a/engines/collavre/app/controllers/collavre/topics_controller.rb
+++ b/engines/collavre/app/controllers/collavre/topics_controller.rb
@@ -53,8 +53,13 @@ module Collavre
     def create
       requested_agent = params[:agent_id].present? ? User.find_by(id: params[:agent_id]) : nil
 
-      if requested_agent&.ai_user? && !assignable_primary_agent?(requested_agent)
-        render json: { errors: [ agent_no_creative_access_message(requested_agent) ] },
+      # No topic yet, so a Claude Channel agent is rejected on an inbox creative:
+      # a topic created here never carries a session_id, which is the only place
+      # Matcher#eligible_in_inbox? will route one.
+      rejection = requested_agent&.ai_user? &&
+        Topic.primary_agent_rejection(@creative, requested_agent)
+      if rejection
+        render json: { errors: [ unassignable_agent_message(requested_agent, rejection) ] },
                status: :unprocessable_entity and return
       end
 
@@ -162,20 +167,25 @@ module Collavre
       end
 
       released_agent = nil
+      released_reason = nil
 
       Topic.transaction do
         topic.comments.update_all(creative_id: target_creative.id)
         topic.update!(creative: target_creative)
 
         # The assignment is exclusive: Matcher#match_by_primary_agent returns []
-        # — silence, not a fallback — when the pinned agent lacks :feedback. The
-        # pin travels with the topic, so a move into a creative the agent is not
-        # shared on would leave the topic unable to route to anyone. Release it
+        # — silence, not a fallback — when the pinned agent cannot be routed to
+        # at the destination. The pin travels with the topic, so a move into a
+        # creative the agent is not shared on — or, for a Claude Channel session
+        # agent, into an inbox, where Matcher confines it to its own session
+        # topic — would leave the topic unable to route to anyone. Release it
         # instead, which restores ordinary expression routing at the new
         # location, and tell the caller so the change is not silent.
         pinned_agent = topic.primary_agent
-        if pinned_agent && !Topic.primary_agent_assignable?(target_creative, pinned_agent)
+        rejection = pinned_agent && Topic.primary_agent_rejection(target_creative, pinned_agent, topic: topic)
+        if rejection
           released_agent = pinned_agent
+          released_reason = rejection
           topic.set_primary_agent!(nil)
         end
       end
@@ -200,9 +210,7 @@ module Collavre
         released_primary_agent: released_agent && {
           id: released_agent.id,
           name: released_agent.display_name,
-          message: I18n.t("collavre.topics.move.primary_agent_released",
-                          agent: released_agent.display_name,
-                          creative: target_creative.creative_snippet)
+          message: released_primary_agent_message(released_agent, released_reason, target_creative)
         }
       }
     end
@@ -273,8 +281,9 @@ module Collavre
         render json: { error: I18n.t("collavre.topics.not_ai_agent") }, status: :unprocessable_entity and return
       end
 
-      unless assignable_primary_agent?(agent)
-        render json: { error: agent_no_creative_access_message(agent) },
+      rejection = Topic.primary_agent_rejection(@creative, agent, topic: topic)
+      if rejection
+        render json: { error: unassignable_agent_message(agent, rejection) },
                status: :unprocessable_entity and return
       end
 
@@ -291,12 +300,27 @@ module Collavre
       @creative = Creative.find(params[:creative_id]).effective_origin
     end
 
-    def assignable_primary_agent?(agent)
-      Topic.primary_agent_assignable?(@creative, agent)
+    # A move can now release the pin for either reason, and the advice differs:
+    # sharing the target creative fixes a missing-permission release, but a
+    # Claude Channel session agent stays confined to its own session topic no
+    # matter what is shared — telling the user to share and re-assign would send
+    # them after a fix that cannot work.
+    def released_primary_agent_message(agent, rejection, target_creative)
+      key = if rejection == :session_agent_outside_session_topic
+              "collavre.topics.move.primary_agent_released_session_agent"
+      else
+              "collavre.topics.move.primary_agent_released"
+      end
+
+      I18n.t(key, agent: agent.display_name, creative: target_creative.creative_snippet)
     end
 
-    def agent_no_creative_access_message(agent)
-      I18n.t("collavre.topics.agent_no_creative_access", name: agent.display_name)
+    def unassignable_agent_message(agent, rejection)
+      if rejection == :session_agent_outside_session_topic
+        I18n.t("collavre.topics.session_agent_not_assignable", name: agent.display_name)
+      else
+        I18n.t("collavre.topics.agent_no_creative_access", name: agent.display_name)
+      end
     end
 
     # When a topic moves to a different creative, members who had access on the

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_primary_agent.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_primary_agent.test.js
@@ -176,6 +176,20 @@ describe('TopicsController#setTopicPrimaryAgent', () => {
       expect(wrapper.dataset.action).toBeUndefined()
     })
 
+    // On an agent session topic the primary agent is session identity, not a
+    // routing pin, and the server refuses to change it — so a manager must not
+    // be offered a release control that can only fail.
+    test('renders a plain avatar on a locked session topic even for managers', () => {
+      controller.topics = [{ id: 1, name: 'Main', primary_agent: AGENT, agent_locked: true }]
+
+      controller.renderTopics(controller.topics, true, true)
+
+      const wrapper = controller.listTarget.querySelector('.topic-agent-avatar-wrapper')
+      expect(wrapper.querySelector('.topic-agent-avatar')).not.toBeNull()
+      expect(wrapper.classList.contains('topic-agent-avatar-releasable')).toBe(false)
+      expect(wrapper.dataset.action).toBeUndefined()
+    })
+
     test('PATCHes a null agent_id and drops the avatar once confirmed', async () => {
       confirmDialog.mockResolvedValue(true)
       global.fetch = jest.fn().mockResolvedValue({

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_primary_agent.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_primary_agent.test.js
@@ -236,4 +236,21 @@ describe('TopicsController#setTopicPrimaryAgent', () => {
       expect(event.stopPropagation).toHaveBeenCalled()
     })
   })
+
+  // Dropping an agent on the create-topic target now gets a 422 when the agent
+  // has no feedback access on the creative. Without surfacing it the drop looks
+  // like it silently did nothing.
+  describe('createTopicWithAgent', () => {
+    test('surfaces the server error when the agent cannot be assigned', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 422,
+        json: async () => ({ errors: ['Outsider has no feedback access here.'] }),
+      })
+
+      await controller.createTopicWithAgent(AGENT)
+
+      expect(alertDialog).toHaveBeenCalledWith('Outsider has no feedback access here.')
+    })
+  })
 })

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_primary_agent.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_primary_agent.test.js
@@ -15,7 +15,7 @@ jest.unstable_mockModule('../../../lib/utils/dialog', () => ({
 
 const { Application } = await import('@hotwired/stimulus')
 const TopicsController = (await import('../topics_controller')).default
-const { alertDialog } = await import('../../../lib/utils/dialog')
+const { alertDialog, confirmDialog } = await import('../../../lib/utils/dialog')
 
 const AGENT = {
   id: 4,
@@ -34,7 +34,8 @@ describe('TopicsController#setTopicPrimaryAgent', () => {
     container = document.createElement('div')
     container.innerHTML = `
       <div id="topics" data-controller="comments--topics"
-           data-topic-set-agent-error="에이전트를 지정할 수 없습니다.">
+           data-topic-set-agent-error="에이전트를 지정할 수 없습니다."
+           data-topic-clear-agent-confirm="%{name} 할당을 해제할까요?">
         <div data-comments--topics-target="list"></div>
       </div>
     `
@@ -142,5 +143,71 @@ describe('TopicsController#setTopicPrimaryAgent', () => {
     await controller.setTopicPrimaryAgent('1', AGENT)
 
     expect(alertDialog).toHaveBeenCalledWith('Unable to assign the agent to this topic.')
+  })
+
+  // Releasing the assignment is what keeps a topic primary agent from being a
+  // one-way door: the pin silences every other agent's ambient routing, so the
+  // avatar has to be able to come back off.
+  describe('release', () => {
+    const clearEvent = (topicId) => ({
+      preventDefault: jest.fn(),
+      stopPropagation: jest.fn(),
+      currentTarget: { dataset: { id: topicId } },
+    })
+
+    beforeEach(() => {
+      controller.topics = [{ id: 1, name: 'Main', primary_agent: AGENT }]
+    })
+
+    test('renders the assigned avatar as a release control for managers', () => {
+      controller.renderTopics(controller.topics, true, true)
+
+      const wrapper = controller.listTarget.querySelector('.topic-agent-avatar-wrapper')
+      expect(wrapper.classList.contains('topic-agent-avatar-releasable')).toBe(true)
+      expect(wrapper.dataset.action).toContain('comments--topics#clearTopicPrimaryAgent')
+      expect(wrapper.dataset.id).toBe('1')
+    })
+
+    test('renders a plain avatar for users who cannot manage topics', () => {
+      controller.renderTopics(controller.topics, false, false)
+
+      const wrapper = controller.listTarget.querySelector('.topic-agent-avatar-wrapper')
+      expect(wrapper.classList.contains('topic-agent-avatar-releasable')).toBe(false)
+      expect(wrapper.dataset.action).toBeUndefined()
+    })
+
+    test('PATCHes a null agent_id and drops the avatar once confirmed', async () => {
+      confirmDialog.mockResolvedValue(true)
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ success: true, topic: { id: 1, name: 'Main', primary_agent: null } }),
+      })
+
+      await controller.clearTopicPrimaryAgent(clearEvent('1'))
+
+      expect(confirmDialog).toHaveBeenCalledWith('GitHub PR Analyzer 할당을 해제할까요?')
+      expect(JSON.parse(global.fetch.mock.calls[0][1].body)).toEqual({ agent_id: null })
+      expect(controller.listTarget.querySelector('.topic-agent-avatar')).toBeNull()
+    })
+
+    test('does nothing when the confirmation is declined', async () => {
+      confirmDialog.mockResolvedValue(false)
+      global.fetch = jest.fn()
+
+      await controller.clearTopicPrimaryAgent(clearEvent('1'))
+
+      expect(global.fetch).not.toHaveBeenCalled()
+    })
+
+    // The avatar sits inside the topic tag, whose own click handler selects the
+    // topic. Releasing must not double as a selection.
+    test('stops the click from reaching the topic tag', async () => {
+      confirmDialog.mockResolvedValue(false)
+      const event = clearEvent('1')
+
+      await controller.clearTopicPrimaryAgent(event)
+
+      expect(event.stopPropagation).toHaveBeenCalled()
+    })
   })
 })

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_primary_agent.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/topics_controller_primary_agent.test.js
@@ -169,11 +169,23 @@ describe('TopicsController#setTopicPrimaryAgent', () => {
     })
 
     test('renders a plain avatar for users who cannot manage topics', () => {
-      controller.renderTopics(controller.topics, false, false)
+      controller.renderTopics(controller.topics, false, false, false)
 
       const wrapper = controller.listTarget.querySelector('.topic-agent-avatar-wrapper')
       expect(wrapper.classList.contains('topic-agent-avatar-releasable')).toBe(false)
       expect(wrapper.dataset.action).toBeUndefined()
+    })
+
+    // set_primary_agent is authorized at :write while can_manage means :admin.
+    // A write collaborator can pin an agent by dropping it on the topic, so
+    // gating the release on can_manage would make that a one-way door.
+    test('renders the release control for a write collaborator who cannot manage', () => {
+      controller.renderTopics(controller.topics, false, true, true)
+
+      const wrapper = controller.listTarget.querySelector('.topic-agent-avatar-wrapper')
+      expect(wrapper.classList.contains('topic-agent-avatar-releasable')).toBe(true)
+      expect(wrapper.dataset.action).toContain('comments--topics#clearTopicPrimaryAgent')
+      expect(wrapper.dataset.id).toBe('1')
     })
 
     // On an agent session topic the primary agent is session identity, not a

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -1128,10 +1128,18 @@ export default class extends Controller {
                 await this.loadTopics()
                 this.dispatch("change", { detail: { topicId: topic.id, mainTopicId: this.mainTopicId } })
             } else {
-                console.error('Failed to create topic with agent')
+                // Dropping an agent that has no feedback access here is now
+                // refused (it would mute the topic), and that is a user mistake
+                // with a fix — sharing the creative. A console line would leave
+                // the drop looking like it silently did nothing.
+                const data = await response.json().catch(() => ({}))
+                const message = data.errors?.[0] || data.error
+                console.error('Failed to create topic with agent', message)
+                alertDialog(message || this._i18n('create_error'))
             }
         } catch (e) {
             console.error('Error creating topic with agent', e)
+            alertDialog(this._i18n('create_error'))
         }
     }
 

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -151,7 +151,7 @@ export default class extends Controller {
             const isActive = String(this.currentTopicId) === String(topic.id) ? 'active' : ''
             const draggable = canManage ? 'draggable="true"' : ''
             const agentAvatar = topic.primary_agent
-                ? this.renderAgentAvatar(topic.primary_agent)
+                ? this.renderAgentAvatar(topic.primary_agent, canManage ? topic.id : null)
                 : ''
             const branchIcon = topic.source_topic_id ? '<span class="topic-branch-icon" title="Branched">↗</span>' : ''
             const isMainTopic = this.mainTopicId && String(topic.id) === String(this.mainTopicId)
@@ -1028,6 +1028,8 @@ export default class extends Controller {
     _i18n(key) {
         const translations = {
             set_agent_error: this.element.dataset.topicSetAgentError || 'Unable to assign the agent to this topic.',
+            agent_assigned_title: this.element.dataset.topicAgentAssignedTitle || '%{name} is assigned to this topic — click to release',
+            clear_agent_confirm: this.element.dataset.topicClearAgentConfirm || 'Release %{name} from this topic? Every agent will be able to respond here again.',
             create_error: this.element.dataset.topicCreateError || 'Unable to create the topic.',
             update_error: this.element.dataset.topicUpdateError || 'Unable to update the topic.',
             delete_error: this.element.dataset.topicDeleteError || 'Unable to delete the topic.',
@@ -1037,6 +1039,28 @@ export default class extends Controller {
         return translations[key] || key
     }
 
+    // Clicking the avatar of an assigned agent releases the assignment. The avatar
+    // sits inside the topic tag, so the click must not also fall through to
+    // selecting that topic.
+    async clearTopicPrimaryAgent(event) {
+        event.preventDefault()
+        event.stopPropagation()
+
+        const topicId = event.currentTarget.dataset.id
+        if (!topicId) return
+
+        const topic = (this.topics || []).find(t => String(t.id) === String(topicId))
+        const agentName = topic?.primary_agent?.name || ''
+
+        const confirmed = await confirmDialog(
+            this._i18n('clear_agent_confirm').replace('%{name}', agentName)
+        )
+        if (!confirmed) return
+
+        await this.setTopicPrimaryAgent(topicId, null)
+    }
+
+    // Pass agent === null to release the topic's assignment.
     async setTopicPrimaryAgent(topicId, agent) {
         if (!this.creativeId) return
 
@@ -1047,7 +1071,7 @@ export default class extends Controller {
                     'Content-Type': 'application/json',
                     'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').content
                 },
-                body: JSON.stringify({ agent_id: agent.id })
+                body: JSON.stringify({ agent_id: agent ? agent.id : null })
             })
 
             const data = await response.json().catch(() => ({}))
@@ -1099,9 +1123,19 @@ export default class extends Controller {
         }
     }
 
-    renderAgentAvatar(agent) {
+    // When topicId is given the avatar doubles as the release control: clicking it
+    // unassigns the agent from the topic. Pass null to render it as a plain badge
+    // (viewers who cannot manage topics).
+    renderAgentAvatar(agent, topicId = null) {
         const size = 16
-        let html = `<span class="avatar-wrapper topic-agent-avatar-wrapper" style="width:${size}px;height:${size}px;" title="${this.escapeAttr(agent.name)}">`
+        const releasable = topicId !== null && topicId !== undefined
+        const title = releasable
+            ? this._i18n('agent_assigned_title').replace('%{name}', agent.name)
+            : agent.name
+        const releaseAttrs = releasable
+            ? ` data-action="click->comments--topics#clearTopicPrimaryAgent" data-id="${this.escapeAttr(String(topicId))}" role="button"`
+            : ''
+        let html = `<span class="avatar-wrapper topic-agent-avatar-wrapper${releasable ? ' topic-agent-avatar-releasable' : ''}"${releaseAttrs} style="width:${size}px;height:${size}px;" title="${this.escapeAttr(title)}">`
         html += `<img src="${this.escapeAttr(agent.avatar_url)}" alt="" width="${size}" height="${size}" class="topic-agent-avatar" style="border-radius:50%;vertical-align:middle;">`
         if (agent.default_avatar) {
             html += `<span class="avatar-initial">${this.escapeAttr(agent.initial)}</span>`

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -150,8 +150,12 @@ export default class extends Controller {
         const renderTopic = (topic) => {
             const isActive = String(this.currentTopicId) === String(topic.id) ? 'active' : ''
             const draggable = canManage ? 'draggable="true"' : ''
+            // agent_locked marks a live agent session topic, whose primary agent is
+            // session identity rather than a routing pin — the server refuses to
+            // change it, so the avatar must not offer to release it.
+            const releasableTopicId = canManage && !topic.agent_locked ? topic.id : null
             const agentAvatar = topic.primary_agent
-                ? this.renderAgentAvatar(topic.primary_agent, canManage ? topic.id : null)
+                ? this.renderAgentAvatar(topic.primary_agent, releasableTopicId)
                 : ''
             const branchIcon = topic.source_topic_id ? '<span class="topic-branch-icon" title="Branched">↗</span>' : ''
             const isMainTopic = this.mainTopicId && String(topic.id) === String(this.mainTopicId)

--- a/engines/collavre/app/javascript/controllers/comments/topics_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/topics_controller.js
@@ -13,6 +13,7 @@ export default class extends Controller {
         this.topics = []
         this.canManageTopics = false
         this.canCreateTopic = false
+        this.canSetPrimaryAgent = false
         this.subscribedCreativeId = null
         this.topicsSubscription = null
         this._loadTopicsVersion = 0
@@ -90,9 +91,16 @@ export default class extends Controller {
                 const topics = Array.isArray(data) ? data : data.topics
                 const canManage = Array.isArray(data) ? false : data.can_manage
                 const canCreateTopic = Array.isArray(data) ? false : (data.can_create_topic ?? canManage)
+                // Assigning an agent is authorized at :write, not :admin, so the
+                // release control must follow the same capability — otherwise a
+                // write collaborator can pin an agent by drag-and-drop and then
+                // has no way to undo it. Falls back to canManage for a server
+                // that predates the field.
+                const canSetPrimaryAgent = Array.isArray(data) ? false : (data.can_set_primary_agent ?? canManage)
                 this.topics = topics
                 this.canManageTopics = canManage
                 this.canCreateTopic = canCreateTopic
+                this.canSetPrimaryAgent = canSetPrimaryAgent
                 this.archivedTopics = data.archived_topics || []
                 this.serverLastTopicId = data.last_topic_id ? String(data.last_topic_id) : ""
                 this.isInbox = !!data.is_inbox
@@ -108,7 +116,7 @@ export default class extends Controller {
                 // Migrate localStorage to server if server has no value
                 this.migrateLocalStorage()
 
-                this.renderTopics(this.topics, this.canManageTopics, this.canCreateTopic)
+                this.renderTopics(this.topics, this.canManageTopics, this.canCreateTopic, this.canSetPrimaryAgent)
                 this.restoreSelection()
             }
         } catch (e) {
@@ -131,7 +139,7 @@ export default class extends Controller {
         this.selectTopic(this.mainTopicId || "")
     }
 
-    renderTopics(topics, canManage = false, canCreateTopic = canManage) {
+    renderTopics(topics, canManage = false, canCreateTopic = canManage, canSetPrimaryAgent = canManage) {
         const dragActions = canManage
             ? 'dragstart->comments--topics#handleTopicDragStart dragend->comments--topics#handleTopicDragEnd'
             : ''
@@ -153,7 +161,7 @@ export default class extends Controller {
             // agent_locked marks a live agent session topic, whose primary agent is
             // session identity rather than a routing pin — the server refuses to
             // change it, so the avatar must not offer to release it.
-            const releasableTopicId = canManage && !topic.agent_locked ? topic.id : null
+            const releasableTopicId = canSetPrimaryAgent && !topic.agent_locked ? topic.id : null
             const agentAvatar = topic.primary_agent
                 ? this.renderAgentAvatar(topic.primary_agent, releasableTopicId)
                 : ''
@@ -371,7 +379,7 @@ export default class extends Controller {
 
         // Update local state and UI immediately
         this.topics = topics
-        this.renderTopics(topics, this.canManageTopics, this.canCreateTopic)
+        this.renderTopics(topics, this.canManageTopics, this.canCreateTopic, this.canSetPrimaryAgent)
         this.restoreSelection()
 
         // Send to server
@@ -490,7 +498,7 @@ export default class extends Controller {
     toggleArchivedTopics(event) {
         event.stopPropagation()
         this.showingArchived = !this.showingArchived
-        this.renderTopics(this.topics, this.canManageTopics, this.canCreateTopic)
+        this.renderTopics(this.topics, this.canManageTopics, this.canCreateTopic, this.canSetPrimaryAgent)
         this.restoreSelection()
     }
 
@@ -684,7 +692,7 @@ export default class extends Controller {
                 if (index !== -1) {
                     this.topics[index] = { ...this.topics[index], ...updatedTopic }
                 }
-                this.renderTopics(this.topics, this.canManageTopics, this.canCreateTopic)
+                this.renderTopics(this.topics, this.canManageTopics, this.canCreateTopic, this.canSetPrimaryAgent)
                 this.restoreSelection()
             } else {
                 alertDialog(this._i18n("update_error"))
@@ -913,7 +921,7 @@ export default class extends Controller {
         if (existsByName) return
 
         this.topics = [...topics, data.topic]
-        this.renderTopics(this.topics, this.canManageTopics, this.canCreateTopic)
+        this.renderTopics(this.topics, this.canManageTopics, this.canCreateTopic, this.canSetPrimaryAgent)
 
         // Auto-select the new topic if created by the current user
         const currentUserId = document.body.dataset.currentUserId
@@ -941,7 +949,7 @@ export default class extends Controller {
         })
 
         this.topics = reorderedTopics
-        this.renderTopics(this.topics, this.canManageTopics, this.canCreateTopic)
+        this.renderTopics(this.topics, this.canManageTopics, this.canCreateTopic, this.canSetPrimaryAgent)
         this.restoreSelection()
     }
 
@@ -951,7 +959,7 @@ export default class extends Controller {
         if (index === -1) return
 
         this.topics[index] = { ...this.topics[index], ...updatedTopic }
-        this.renderTopics(this.topics, this.canManageTopics, this.canCreateTopic)
+        this.renderTopics(this.topics, this.canManageTopics, this.canCreateTopic, this.canSetPrimaryAgent)
         this.restoreSelection()
     }
 
@@ -968,7 +976,7 @@ export default class extends Controller {
             this.dispatch("change", { detail: { topicId: "", mainTopicId: this.mainTopicId } })
         }
 
-        this.renderTopics(this.topics, this.canManageTopics, this.canCreateTopic)
+        this.renderTopics(this.topics, this.canManageTopics, this.canCreateTopic, this.canSetPrimaryAgent)
         this.restoreSelection()
     }
 

--- a/engines/collavre/app/javascript/creatives/drag_drop/__tests__/topic_move_released_agent.test.js
+++ b/engines/collavre/app/javascript/creatives/drag_drop/__tests__/topic_move_released_agent.test.js
@@ -1,0 +1,125 @@
+/**
+ * @jest-environment jsdom
+ */
+import { jest } from '@jest/globals'
+
+// The topic-move branch of handleDrop returns before touching the creative-move
+// machinery, so only the modules that branch reaches need real behavior.
+const sendTopicMove = jest.fn()
+const alertDialog = jest.fn()
+const showMissingMembersPopup = jest.fn()
+
+jest.unstable_mockModule('../dom', () => ({
+  DRAGGABLE_SELECTOR: '.tree-row',
+  clearDragHighlight: jest.fn(),
+  asTreeRow: jest.fn(),
+  getChildrenContainer: jest.fn(),
+  ensureChildrenContainer: jest.fn(),
+  appendBlockToContainer: jest.fn(),
+  moveBlockBefore: jest.fn(),
+  moveBlockAfter: jest.fn(),
+  isDescendantRow: jest.fn(),
+  applyLevelDelta: jest.fn(),
+  setRowParent: jest.fn(),
+  setRowRootState: jest.fn(),
+  setHasChildren: jest.fn(),
+  setExpanded: jest.fn(),
+  syncParentHasChildren: jest.fn(),
+}))
+jest.unstable_mockModule('../state', () => ({
+  setDraggedState: jest.fn(),
+  getDraggedState: jest.fn(),
+  resetDraggedState: jest.fn(),
+  setLastDragOverRow: jest.fn(),
+  getLastDragOverRow: jest.fn(),
+  hasDraggedState: jest.fn(),
+}))
+jest.unstable_mockModule('../operations', () => ({
+  createMoveContext: jest.fn(),
+  applyMove: jest.fn(),
+  revertMove: jest.fn(),
+}))
+jest.unstable_mockModule('../../../lib/api/drag_drop', () => ({
+  sendNewOrder: jest.fn(),
+  sendLinkedCreative: jest.fn(),
+  sendTopicMove,
+}))
+jest.unstable_mockModule('../indicator', () => ({
+  initIndicator: jest.fn(),
+  showLinkHover: jest.fn(),
+  hideLinkHover: jest.fn(),
+}))
+jest.unstable_mockModule('../../topic_move_members_popup', () => ({
+  showMissingMembersPopup,
+}))
+jest.unstable_mockModule('../../../lib/utils/dialog', () => ({ alertDialog }))
+
+const { handleDrop } = await import('../event_handlers')
+
+const dropEvent = () => {
+  document.body.innerHTML = '<div class="tree-row" id="creative-9"></div>'
+  const target = document.getElementById('creative-9')
+  return {
+    target,
+    preventDefault: jest.fn(),
+    dataTransfer: {
+      getData: (type) =>
+        type === 'application/x-topic-move'
+          ? JSON.stringify({ topicId: 5, sourceCreativeId: '3' })
+          : '',
+    },
+  }
+}
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0))
+
+afterEach(() => {
+  jest.clearAllMocks()
+  document.body.innerHTML = ''
+})
+
+// The server releases a pin the agent cannot honor at the destination. Without
+// this notice the avatar just vanishes mid-drag with no stated reason.
+test('reports a primary agent released by the move', async () => {
+  sendTopicMove.mockResolvedValue({
+    success: true,
+    missing_members: [],
+    released_primary_agent: { id: 7, name: 'MoveAgent', message: 'MoveAgent was released.' },
+  })
+
+  handleDrop(dropEvent())
+  await flush()
+
+  expect(alertDialog).toHaveBeenCalledWith('MoveAgent was released.')
+})
+
+test('stays quiet when the assignment survived the move', async () => {
+  sendTopicMove.mockResolvedValue({
+    success: true,
+    missing_members: [],
+    released_primary_agent: null,
+  })
+
+  handleDrop(dropEvent())
+  await flush()
+
+  expect(alertDialog).not.toHaveBeenCalled()
+})
+
+// Both notices come off the same response, so the release must not swallow the
+// missing-members prompt.
+test('still offers to re-add missing members alongside the release notice', async () => {
+  sendTopicMove.mockResolvedValue({
+    success: true,
+    target_creative_id: 9,
+    target_creative_name: 'Target',
+    missing_members: [{ user: { email: 'a@b.c' }, permission: 'feedback' }],
+    released_primary_agent: { id: 7, name: 'MoveAgent', message: 'MoveAgent was released.' },
+  })
+
+  handleDrop(dropEvent())
+  await flush()
+
+  expect(alertDialog).toHaveBeenCalledWith('MoveAgent was released.')
+  expect(showMissingMembersPopup).toHaveBeenCalled()
+})

--- a/engines/collavre/app/javascript/creatives/drag_drop/event_handlers.js
+++ b/engines/collavre/app/javascript/creatives/drag_drop/event_handlers.js
@@ -646,6 +646,14 @@ export function handleDrop(event) {
             detail: { topicId, sourceCreativeId, targetCreativeId }
           }));
 
+          // The server releases a primary agent that has no feedback access at
+          // the new location, because an exclusive pin the agent cannot honor
+          // would silence the topic. Say so — otherwise the avatar just
+          // disappears mid-drag with no explanation.
+          if (data && data.released_primary_agent && data.released_primary_agent.message) {
+            alertDialog(data.released_primary_agent.message);
+          }
+
           // Offer to re-add members who lose access at the new location.
           if (data && Array.isArray(data.missing_members) && data.missing_members.length > 0) {
             showMissingMembersPopup({

--- a/engines/collavre/app/jobs/collavre/ai_agent_job.rb
+++ b/engines/collavre/app/jobs/collavre/ai_agent_job.rb
@@ -46,6 +46,43 @@ module Collavre
           return
         end
 
+        # Guard: an exclusive primary-agent assignment can also land after a task
+        # has already been cleared for execution, so checking at enqueue time is
+        # not sufficient. AgentOrchestrator.dequeue_next_for_topic revalidates and
+        # then enqueues asynchronously — a pin created in that window is missed —
+        # and approval resumption (Comments::ActionExecutor) re-enqueues a
+        # pending_approval task with no check at all, after a pause that can last
+        # as long as the human takes to approve. Re-check at the moment of
+        # execution so a demoted agent cannot answer in a topic that is now
+        # exclusively someone else's.
+        resumed_context = task.trigger_event_payload
+        if resumed_context&.key?("topic") &&
+           !Orchestration::Matcher.new(
+             SystemEvents::ContextBuilder.new(resumed_context).build
+           ).assignment_permits?(agent)
+          Rails.logger.info(
+            "[AiAgentJob] Cancelling resumed task #{task.id}: topic #{task.topic_id} " \
+            "is now assigned to another agent (agent=#{agent.id})"
+          )
+          if task.parent_task_id.present?
+            task.update!(status: "failed")
+            Collavre::Comments::WorkflowExecutor.new(task.parent_task).fail_subtask!(
+              task,
+              error_message: "Topic reassigned to another agent before dispatch"
+            )
+          else
+            task.update!(status: "cancelled")
+          end
+          # A pending_approval task kept its slot across the pause (the
+          # ApprovalPendingError rescue sets should_release = false), and this
+          # early return skips the ensure block that would give it back, so
+          # release explicitly. release! is idempotent, so a queued task that
+          # never reserved one is unaffected.
+          Orchestration::ResourceTracker.for(agent).release!(task.id)
+          Orchestration::AgentOrchestrator.dequeue_next_for_topic(task.topic_id, task.creative_id)
+          return
+        end
+
         task.update!(status: "running")
       else
         # Create new task

--- a/engines/collavre/app/jobs/collavre/ai_agent_job.rb
+++ b/engines/collavre/app/jobs/collavre/ai_agent_job.rb
@@ -68,6 +68,22 @@ module Collavre
           return
         end
 
+        # Guard: an exclusive primary-agent assignment created (or moved) after
+        # this dispatch was scheduled must still bind it. A :delayed decision
+        # (agent busy / rate limited) sits in the job queue with its agent already
+        # chosen and is never re-matched, so without this a demoted agent speaks
+        # in a topic that now belongs to someone else. Unlike a queued waiter
+        # there is no Task yet to cancel, so cancelling on assignment change
+        # cannot cover this path — the check has to happen here.
+        if context && !Orchestration::Matcher.new(context).assignment_permits?(agent)
+          Rails.logger.info(
+            "[AiAgentJob] Skipping job for agent #{agent.id}: topic " \
+            "#{context.dig('topic', 'id')} is now assigned to another agent " \
+            "(event=#{event_name})"
+          )
+          return
+        end
+
         # Guard: skip if there's already a running task for the same agent + comment
         comment_id = context&.dig("comment", "id")
         if comment_id && Task.duplicate_running_for_comment?(agent.id, comment_id)

--- a/engines/collavre/app/models/collavre/topic.rb
+++ b/engines/collavre/app/models/collavre/topic.rb
@@ -42,17 +42,37 @@ module Collavre
     # searchable agents regardless of creative access, so this is reachable from
     # plain drag-and-drop or `/topic "name" @agent`, not just a crafted request.
     #
-    # This is deliberately the same predicate Matcher#has_creative_permission?
-    # applies, so "assignable" and "can respond" cannot drift apart.
+    # This deliberately mirrors BOTH predicates Matcher applies before it will
+    # route to a primary agent — #has_creative_permission? and
+    # #eligible_in_inbox? — so "assignable" and "can respond" cannot drift
+    # apart. Checking only the permission is not enough: registration grants a
+    # Claude Channel agent inbox-wide :feedback, so it passes that check on
+    # every inbox topic while Matcher confines it to its own session topic.
+    # Pinning one on an ordinary inbox topic would therefore silence the topic
+    # for everyone, and it is reachable by plain drag-and-drop (the agent is
+    # created_by the user, so the palette lists it) or by `/topic "Main" @agent`
+    # (the inbox share puts it in User.mentionable_for regardless of searchable).
+    #
+    # Returns nil when assignable, otherwise a symbol naming the reason, so
+    # callers can render a message that says which rule was hit.
     #
     # Deliberately NOT enforced inside #set_primary_agent!: SessionProvisioner
     # and Api::V1::AgentsController#register write the pin as session identity
     # before the inbox share exists, and must not be gated on it.
-    def self.primary_agent_assignable?(creative, agent)
-      return false unless agent&.ai_user?
-      return false unless creative
+    def self.primary_agent_rejection(creative, agent, topic: nil)
+      return :not_an_agent unless agent&.ai_user?
+      return :no_creative_access unless creative&.has_permission?(agent, :feedback)
 
-      creative.has_permission?(agent, :feedback)
+      # Mirror Matcher#eligible_in_inbox?
+      return nil unless creative.inbox?
+      return nil unless agent.claude_channel_agent?
+      return nil if topic&.session_id.present? && topic.primary_agent_id == agent.id
+
+      :session_agent_outside_session_topic
+    end
+
+    def self.primary_agent_assignable?(creative, agent, topic: nil)
+      primary_agent_rejection(creative, agent, topic: topic).nil?
     end
 
     def archived?

--- a/engines/collavre/app/models/collavre/topic.rb
+++ b/engines/collavre/app/models/collavre/topic.rb
@@ -33,6 +33,28 @@ module Collavre
       update!(primary_agent: agent)
     end
 
+    # A primary agent is an exclusive assignment: Matcher#match_by_primary_agent
+    # routes ambient events to it alone and returns [] — silence, not a fallback
+    # — when it cannot respond. Routing also requires :feedback on the creative,
+    # so pinning an agent that lacks it would disable the topic outright: the
+    # pinned agent is not permitted to answer, and every other agent is excluded
+    # by the assignment. User.mentionable_for and the agent palette both surface
+    # searchable agents regardless of creative access, so this is reachable from
+    # plain drag-and-drop or `/topic "name" @agent`, not just a crafted request.
+    #
+    # This is deliberately the same predicate Matcher#has_creative_permission?
+    # applies, so "assignable" and "can respond" cannot drift apart.
+    #
+    # Deliberately NOT enforced inside #set_primary_agent!: SessionProvisioner
+    # and Api::V1::AgentsController#register write the pin as session identity
+    # before the inbox share exists, and must not be gated on it.
+    def self.primary_agent_assignable?(creative, agent)
+      return false unless agent&.ai_user?
+      return false unless creative
+
+      creative.has_permission?(agent, :feedback)
+    end
+
     def archived?
       archived_at.present?
     end

--- a/engines/collavre/app/services/collavre/comments/topic_command.rb
+++ b/engines/collavre/app/services/collavre/comments/topic_command.rb
@@ -70,6 +70,15 @@ module Collavre
             # reassigning nor releasing it is safe from a chat command.
             I18n.t("collavre.comments.topic_command.session_topic_locked",
                    name: existing_topic.name)
+          elsif changes_assignment?(existing_topic, primary_agent) &&
+                !creative.has_permission?(user, :write)
+            # Assigning or releasing a primary agent rewrites the topic's routing:
+            # the pin decides who may speak here and silences every other agent.
+            # The REST equivalent (TopicsController#set_primary_agent) requires
+            # :write, but CommentsController#create only authorizes the comment at
+            # :feedback, so the command has to apply the same gate itself —
+            # otherwise commenting access would be enough to redirect the topic.
+            I18n.t("collavre.comments.topic_command.not_authorized")
           elsif primary_agent
             set_primary_agent(existing_topic, primary_agent)
             broadcast_topic_agent_updated(existing_topic, primary_agent)
@@ -144,6 +153,14 @@ module Collavre
 
       def set_primary_agent(topic, agent)
         topic.set_primary_agent!(agent)
+      end
+
+      # True when the command would write primary_agent_id on an existing topic:
+      # a mention assigns (or moves) the pin, and a bare /topic on an already
+      # assigned topic releases it. `/topic "name"` on an unassigned topic only
+      # reports that it already exists, so it stays open to commenters.
+      def changes_assignment?(topic, primary_agent)
+        primary_agent.present? || topic.primary_agent_id.present?
       end
     end
   end

--- a/engines/collavre/app/services/collavre/comments/topic_command.rb
+++ b/engines/collavre/app/services/collavre/comments/topic_command.rb
@@ -54,7 +54,13 @@ module Collavre
         existing_topic = Topic.find_by(creative: creative, name: data[:name])
 
         if existing_topic
-          if primary_agent
+          if existing_topic.session_id.present?
+            # A Claude Channel session topic carries its agent as session identity,
+            # not as a routing pin (see TopicsController#set_primary_agent). Neither
+            # reassigning nor releasing it is safe from a chat command.
+            I18n.t("collavre.comments.topic_command.session_topic_locked",
+                   name: existing_topic.name)
+          elsif primary_agent
             set_primary_agent(existing_topic, primary_agent)
             broadcast_topic_agent_updated(existing_topic, primary_agent)
             I18n.t("collavre.comments.topic_command.updated_agent",

--- a/engines/collavre/app/services/collavre/comments/topic_command.rb
+++ b/engines/collavre/app/services/collavre/comments/topic_command.rb
@@ -63,23 +63,30 @@ module Collavre
         # Find existing topic or create new one
         existing_topic = Topic.find_by(creative: creative, name: data[:name])
 
+        if existing_topic&.session_id.present?
+          # A Claude Channel session topic carries its agent as session identity,
+          # not as a routing pin (see TopicsController#set_primary_agent). Neither
+          # reassigning nor releasing it is safe from a chat command.
+          return I18n.t("collavre.comments.topic_command.session_topic_locked",
+                        name: existing_topic.name)
+        end
+
+        # Assigning or releasing a primary agent rewrites the topic's routing:
+        # the pin decides who may speak here and silences every other agent. The
+        # REST equivalents (TopicsController#set_primary_agent and #create, which
+        # also accepts agent_id) require :write, but CommentsController#create
+        # only authorizes the comment at :feedback, so the command has to apply
+        # the same gate itself — otherwise commenting access would be enough to
+        # decide a topic's routing. Checked before the new/existing split because
+        # `/topic "new name" @agent` persists an exclusive assignment just as
+        # much as moving one on a topic that already exists.
+        if assigns_primary_agent?(existing_topic, primary_agent) &&
+           !creative.has_permission?(user, :write)
+          return I18n.t("collavre.comments.topic_command.not_authorized")
+        end
+
         if existing_topic
-          if existing_topic.session_id.present?
-            # A Claude Channel session topic carries its agent as session identity,
-            # not as a routing pin (see TopicsController#set_primary_agent). Neither
-            # reassigning nor releasing it is safe from a chat command.
-            I18n.t("collavre.comments.topic_command.session_topic_locked",
-                   name: existing_topic.name)
-          elsif changes_assignment?(existing_topic, primary_agent) &&
-                !creative.has_permission?(user, :write)
-            # Assigning or releasing a primary agent rewrites the topic's routing:
-            # the pin decides who may speak here and silences every other agent.
-            # The REST equivalent (TopicsController#set_primary_agent) requires
-            # :write, but CommentsController#create only authorizes the comment at
-            # :feedback, so the command has to apply the same gate itself —
-            # otherwise commenting access would be enough to redirect the topic.
-            I18n.t("collavre.comments.topic_command.not_authorized")
-          elsif primary_agent
+          if primary_agent
             set_primary_agent(existing_topic, primary_agent)
             broadcast_topic_agent_updated(existing_topic, primary_agent)
             I18n.t("collavre.comments.topic_command.updated_agent",
@@ -155,12 +162,15 @@ module Collavre
         topic.set_primary_agent!(agent)
       end
 
-      # True when the command would write primary_agent_id on an existing topic:
-      # a mention assigns (or moves) the pin, and a bare /topic on an already
-      # assigned topic releases it. `/topic "name"` on an unassigned topic only
-      # reports that it already exists, so it stays open to commenters.
-      def changes_assignment?(topic, primary_agent)
-        primary_agent.present? || topic.primary_agent_id.present?
+      # True when the command would write primary_agent_id: a mention assigns
+      # (or moves) the pin on either a new or an existing topic, and a bare
+      # /topic on an already assigned topic releases it. `/topic "name"` with no
+      # mention writes no assignment — on an unassigned existing topic it only
+      # reports that it already exists, and on a new one it creates a topic with
+      # ambient routing intact — so both stay open to commenters, matching the
+      # pre-existing rule that /topic can create topics at :feedback.
+      def assigns_primary_agent?(topic, primary_agent)
+        primary_agent.present? || topic&.primary_agent_id.present?
       end
     end
   end

--- a/engines/collavre/app/services/collavre/comments/topic_command.rb
+++ b/engines/collavre/app/services/collavre/comments/topic_command.rb
@@ -50,16 +50,6 @@ module Collavre
         # Find primary agent from @mentions using the same parsing as chat
         primary_agent = comment.mentioned_users.find(&:ai_user?)
 
-        # User.mentionable_for resolves every searchable agent, including ones
-        # with no share on this creative. Pinning such an agent would silence
-        # the topic outright: the pin is exclusive (Matcher#match_by_primary_agent
-        # suppresses the other agents' ambient routing) while the pinned agent
-        # itself fails the feedback check and cannot answer either.
-        if primary_agent && !Topic.primary_agent_assignable?(creative, primary_agent)
-          return I18n.t("collavre.comments.topic_command.agent_no_creative_access",
-                        agent: primary_agent.display_name)
-        end
-
         # Find existing topic or create new one
         existing_topic = Topic.find_by(creative: creative, name: data[:name])
 
@@ -69,6 +59,25 @@ module Collavre
           # reassigning nor releasing it is safe from a chat command.
           return I18n.t("collavre.comments.topic_command.session_topic_locked",
                         name: existing_topic.name)
+        end
+
+        # User.mentionable_for resolves every searchable agent — and, on an
+        # inbox, every agent holding a share there, which includes the user's own
+        # Claude Channel session agent. Pinning an agent Matcher will not route
+        # to silences the topic outright: the pin is exclusive
+        # (Matcher#match_by_primary_agent suppresses the other agents' ambient
+        # routing) while the pinned agent itself is filtered out and cannot
+        # answer either. Resolved against the topic being targeted, so the check
+        # is the same mirror of Matcher the REST paths apply.
+        rejection = primary_agent &&
+          Topic.primary_agent_rejection(creative, primary_agent, topic: existing_topic)
+        if rejection
+          key = if rejection == :session_agent_outside_session_topic
+                  "collavre.comments.topic_command.session_agent_not_assignable"
+          else
+                  "collavre.comments.topic_command.agent_no_creative_access"
+          end
+          return I18n.t(key, agent: primary_agent.display_name)
         end
 
         # Assigning or releasing a primary agent rewrites the topic's routing:

--- a/engines/collavre/app/services/collavre/comments/topic_command.rb
+++ b/engines/collavre/app/services/collavre/comments/topic_command.rb
@@ -50,6 +50,16 @@ module Collavre
         # Find primary agent from @mentions using the same parsing as chat
         primary_agent = comment.mentioned_users.find(&:ai_user?)
 
+        # User.mentionable_for resolves every searchable agent, including ones
+        # with no share on this creative. Pinning such an agent would silence
+        # the topic outright: the pin is exclusive (Matcher#match_by_primary_agent
+        # suppresses the other agents' ambient routing) while the pinned agent
+        # itself fails the feedback check and cannot answer either.
+        if primary_agent && !Topic.primary_agent_assignable?(creative, primary_agent)
+          return I18n.t("collavre.comments.topic_command.agent_no_creative_access",
+                        agent: primary_agent.display_name)
+        end
+
         # Find existing topic or create new one
         existing_topic = Topic.find_by(creative: creative, name: data[:name])
 

--- a/engines/collavre/app/services/collavre/comments/topic_command.rb
+++ b/engines/collavre/app/services/collavre/comments/topic_command.rb
@@ -56,9 +56,17 @@ module Collavre
         if existing_topic
           if primary_agent
             set_primary_agent(existing_topic, primary_agent)
+            broadcast_topic_agent_updated(existing_topic, primary_agent)
             I18n.t("collavre.comments.topic_command.updated_agent",
                    name: existing_topic.name,
                    agent: primary_agent.name)
+          elsif existing_topic.primary_agent_id
+            # /topic "name" with no @mention on an already-assigned topic releases
+            # the assignment — the keyboard counterpart of clicking the avatar off.
+            set_primary_agent(existing_topic, nil)
+            broadcast_topic_agent_updated(existing_topic, nil)
+            I18n.t("collavre.comments.topic_command.cleared_agent",
+                   name: existing_topic.name)
           else
             I18n.t("collavre.comments.topic_command.already_exists",
                    name: existing_topic.name)
@@ -91,6 +99,17 @@ module Collavre
             name: agent.display_name,
             avatar_url: resolve_avatar_url(agent)
           }
+        end
+        TopicsChannel.broadcast_to(creative, data)
+      end
+
+      # Push an assignment change on an existing topic to every connected client.
+      # :primary_agent is always present (nil when released) so the merge on the
+      # client can actually remove the avatar rather than keep a stale one.
+      def broadcast_topic_agent_updated(topic, agent)
+        data = { action: "updated", topic: topic.slice(:id, :name), user_id: user.id }
+        data[:topic][:primary_agent] = if agent
+          { id: agent.id, name: agent.display_name, avatar_url: resolve_avatar_url(agent) }
         end
         TopicsChannel.broadcast_to(creative, data)
       end

--- a/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
+++ b/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
@@ -25,10 +25,12 @@ module Collavre
           task.reload
           cleanup_waiting_notices!(task)
           refresh_deferred_context!(task)
+          revalidate_assignment!(task) unless task.status == "cancelled"
 
           if task.status == "cancelled"
-            # refresh_deferred_context! cancelled this task (no eligible comment),
-            # try the next queued task for this topic.
+            # refresh_deferred_context! found no eligible comment, or
+            # revalidate_assignment! found the topic now assigned to another
+            # agent. Either way this waiter is dead — try the next queued task.
             dequeue_next_for_topic(topic_id, creative_id)
           else
             AiAgentJob.perform_later(task)
@@ -84,6 +86,33 @@ module Collavre
         task.update!(trigger_event_payload: context)
       end
       private_class_method :refresh_deferred_context!
+
+      # Cancel a promoted waiter whose agent the topic's primary-agent assignment
+      # now excludes. A queued task keeps the agent chosen when it was dispatched,
+      # so a pin created or moved while it waited would otherwise be bypassed by
+      # the very work it is supposed to silence.
+      #
+      # Runs AFTER refresh_deferred_context! so the check judges what the agent is
+      # about to answer, not the stale snapshot: if the latest comment @mentions
+      # this agent, the mention outranks the assignment and the task survives.
+      # That refresh replaces the whole "chat" hash, dropping the resolved
+      # mentioned_user, so rebuild the context to recompute it from the content.
+      def self.revalidate_assignment!(task)
+        context = task.trigger_event_payload
+        return unless context&.key?("topic")
+
+        agent = task.agent
+        return unless agent
+        return if Matcher.new(SystemEvents::ContextBuilder.new(context).build)
+                         .assignment_permits?(agent)
+
+        Rails.logger.info(
+          "[AgentOrchestrator] Cancelling queued task #{task.id}: topic #{task.topic_id} " \
+          "is now assigned to another agent (agent=#{agent.id})"
+        )
+        task.update!(status: "cancelled")
+      end
+      private_class_method :revalidate_assignment!
 
       def initialize(event_name:, context:)
         @event_name = event_name

--- a/engines/collavre/app/services/collavre/orchestration/arbiter.rb
+++ b/engines/collavre/app/services/collavre/orchestration/arbiter.rb
@@ -32,6 +32,14 @@ module Collavre
         # strategy with bid_fallback_enabled: false) or the Review button no-ops.
         return candidates if review_message?
 
+        # Mentions are forced routing too: the Matcher already narrowed candidates
+        # to the single @mentioned agent. Arbitration must not second-guess it —
+        # with a topic primary agent pinned, arbitration_strategy is
+        # "primary_first", and a mention of any OTHER agent would otherwise be
+        # dropped for not being the primary. Explicitly inviting a second agent
+        # into a pinned topic is exactly the escape hatch the pin needs.
+        return candidates if mention_routed?
+
         strategy = @policy_resolver.arbitration_strategy
         selected = apply_strategy(strategy, candidates)
 
@@ -51,6 +59,16 @@ module Collavre
         return false unless comment_id
 
         Comment.find_by(id: comment_id)&.review_message? || false
+      end
+
+      # True when the Matcher routed by @mention (mirrors Matcher#match_by_mention).
+      # Only an AI mention produces candidates; a human mention yields [] and never
+      # reaches the Arbiter.
+      def mention_routed?
+        mentioned_id = @context.dig("chat", "mentioned_user", "id")
+        return false if mentioned_id.blank?
+
+        User.find_by(id: mentioned_id)&.ai_user? || false
       end
 
       def apply_strategy(strategy, candidates)
@@ -75,13 +93,22 @@ module Collavre
         candidates
       end
 
-      # Primary agent responds if available, otherwise first candidate
+      # Primary agent responds. With no primary configured at all this degrades to
+      # "one candidate, not all" — the historical meaning of the bare
+      # primary_first policy.
       def strategy_primary_first(candidates)
         primary_id = @policy_resolver.primary_agent_id
         return candidates.take(1) if primary_id.blank?
 
         primary = candidates.find { |agent| agent.id == primary_id }
-        primary ? [ primary ] : candidates.take(1)
+        return [ primary ] if primary
+
+        # A configured primary that is not among the candidates is unavailable
+        # (no feedback permission, inbox-confined, or a stale id). Stay silent:
+        # promoting an arbitrary other agent is precisely the interloper that a
+        # primary assignment exists to keep out of the topic. Mention- and
+        # review-routed candidates bypass arbitration and never reach here.
+        []
       end
 
       # Rotate between agents using Rails cache for state

--- a/engines/collavre/app/services/collavre/orchestration/arbiter.rb
+++ b/engines/collavre/app/services/collavre/orchestration/arbiter.rb
@@ -103,12 +103,20 @@ module Collavre
         primary = candidates.find { |agent| agent.id == primary_id }
         return [ primary ] if primary
 
-        # A configured primary that is not among the candidates is unavailable
-        # (no feedback permission, inbox-confined, or a stale id). Stay silent:
-        # promoting an arbitrary other agent is precisely the interloper that a
-        # primary assignment exists to keep out of the topic. Mention- and
-        # review-routed candidates bypass arbitration and never reach here.
-        []
+        # The primary is unavailable (no feedback permission, inbox-confined, or
+        # a stale id). What that means depends on where the primary came from:
+        #
+        # - A topic-column assignment is EXCLUSIVE. Stay silent: promoting an
+        #   arbitrary other agent is precisely the interloper the assignment
+        #   exists to keep out of the topic. (Mention- and review-routed
+        #   candidates bypass arbitration and never reach here.)
+        # - A policy-level primary_agent_id is only a PREFERENCE — the admin
+        #   reference defines primary_first as "primary agent responds first,
+        #   others only if unavailable". Keep that fallback intact so an
+        #   unassigned topic behaves exactly as it did before topic pinning.
+        return [] if @policy_resolver.topic_primary_agent_id.present?
+
+        candidates.take(1)
       end
 
       # Rotate between agents using Rails cache for state

--- a/engines/collavre/app/services/collavre/orchestration/matcher.rb
+++ b/engines/collavre/app/services/collavre/orchestration/matcher.rb
@@ -8,7 +8,9 @@ module Collavre
     # 1. Mention-based: If a user is @mentioned, route exclusively to that user
     #    - If mentioned user is AI agent → route to that agent only
     #    - If mentioned user is human → no AI agents respond
-    # 2. Expression-based: Evaluate each agent's routing_expression (Liquid)
+    # 2. Primary-agent assignment: If the topic has a primary_agent, that agent is
+    #    the topic's sole ambient responder (see #match_by_primary_agent)
+    # 3. Expression-based: Evaluate each agent's routing_expression (Liquid)
     #
     # Permission checks:
     # - All agents need feedback permission on the creative to respond
@@ -29,7 +31,11 @@ module Collavre
         mentioned_result = match_by_mention
         return mentioned_result unless mentioned_result.nil?
 
-        # Priority 2: Liquid expression routing (fallback)
+        # Priority 2: Topic primary agent assignment (exclusive)
+        primary_result = match_by_primary_agent
+        return primary_result unless primary_result.nil?
+
+        # Priority 3: Liquid expression routing (fallback)
         match_by_expression
       end
 
@@ -90,6 +96,34 @@ module Collavre
         return [] unless eligible_in_inbox?(mentioned_user)
 
         [ mentioned_user ]
+      end
+
+      # Returns [primary_agent] when the topic has one, nil when it does not.
+      #
+      # A topic's primary agent is an exclusive assignment: it is the only agent
+      # that speaks on ambient events in that topic. This deliberately overrides
+      # each agent's own routing_expression in BOTH directions:
+      #
+      # - The primary speaks even with no routing_expression (or one that
+      #   evaluates false), so pinning an agent is enough to talk to it.
+      # - Every other agent stays silent even when its expression matches, so a
+      #   project-wide roster of agents does not all pile into one task.
+      #
+      # Other agents are not muted, only demoted to explicit invitation: an
+      # @mention routes to them via #match_by_mention, which runs first.
+      #
+      # Returning [] (rather than nil) when the primary is ineligible is
+      # intentional — falling through to expression routing would let exactly
+      # the agents this assignment excludes take the floor instead.
+      def match_by_primary_agent
+        agent = matched_topic&.primary_agent
+        return nil unless agent
+
+        return [] unless agent.ai_user?
+        return [] unless has_creative_permission?(agent)
+        return [] unless eligible_in_inbox?(agent)
+
+        [ agent ]
       end
 
       def match_by_expression

--- a/engines/collavre/app/services/collavre/orchestration/matcher.rb
+++ b/engines/collavre/app/services/collavre/orchestration/matcher.rb
@@ -39,6 +39,39 @@ module Collavre
         match_by_expression
       end
 
+      # May this agent still take the floor in this topic, given the topic's
+      # CURRENT primary-agent assignment?
+      #
+      # #match runs when an event is dispatched, but the agent it selects can
+      # reach execution much later: a :deferred decision parks a queued Task
+      # until the topic's blocker finishes, and a :delayed one sleeps in the job
+      # queue. Neither path re-matches — AiAgentJob#perform runs the agent the
+      # decision named — so an assignment created or moved during that window
+      # would be bypassed by work scheduled moments before it, and a demoted
+      # agent would speak in a topic that is now exclusively someone else's.
+      #
+      # Mirrors #match's precedence rather than re-deriving it: review and
+      # mention are exclusive routings that outrank the assignment (see
+      # #match_by_primary_agent), so those dispatches stay valid. Expression
+      # routing does not, so it is revalidated. Only the assignment is rechecked
+      # here — re-running the whole match would also re-evaluate each
+      # routing_expression against the refreshed comment, silently dropping
+      # deferred work for reasons that have nothing to do with the assignment.
+      def assignment_permits?(agent)
+        primary_id = matched_topic&.primary_agent_id
+        return true if primary_id.nil? || primary_id == agent.id
+
+        # A review can only ever be applied in place by the author of the quoted
+        # comment; no assignment can transfer it, so the alternative to running
+        # it is not "the primary answers instead" but a dead Review button.
+        return true if matched_comment&.review_message? &&
+          matched_comment.quoted_comment&.user_id == agent.id
+
+        mentioned_id = @context.dig("chat", "mentioned_user", "id") ||
+          @context.dig(:chat, :mentioned_user, :id)
+        mentioned_id.present? && mentioned_id.to_i == agent.id
+      end
+
       private
 
       # Returns [author] for a routable review message, [] for an unroutable one,

--- a/engines/collavre/app/services/collavre/orchestration/policy_resolver.rb
+++ b/engines/collavre/app/services/collavre/orchestration/policy_resolver.rb
@@ -102,6 +102,19 @@ module Collavre
         topic_primary_agent_id || arbitration_config["primary_agent_id"]
       end
 
+      # Read primary_agent_id directly from the topics table.
+      #
+      # Public because the two sources of a primary agent carry different
+      # strength: a topic-column assignment is exclusive, while a policy-level
+      # primary_agent_id is only a preference. The Arbiter needs to tell them
+      # apart even though #primary_agent_id collapses both.
+      def topic_primary_agent_id
+        topic_id = @context.dig("topic", "id")
+        return nil unless topic_id
+
+        Topic.where(id: topic_id).pick(:primary_agent_id)
+      end
+
       # Bid strategy specific
       def confidence_threshold
         arbitration_config["confidence_threshold"]
@@ -162,14 +175,6 @@ module Collavre
         end
 
         config
-      end
-
-      # Read primary_agent_id directly from the topics table
-      def topic_primary_agent_id
-        topic_id = @context.dig("topic", "id")
-        return nil unless topic_id
-
-        Topic.where(id: topic_id).pick(:primary_agent_id)
       end
     end
   end

--- a/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
+++ b/engines/collavre/app/views/collavre/comments/_comments_popup.html.erb
@@ -60,6 +60,8 @@
      data-review-type-question-label="<%= t('collavre.comments.review_type_question') %>"
      data-remove-from-history-label="<%= t('collavre.comments.remove_from_history') %>"
      data-topic-set-agent-error="<%= t('collavre.comments.topic_set_agent_error') %>"
+     data-topic-agent-assigned-title="<%= t('collavre.comments.topic_agent_assigned_title', name: '%{name}') %>"
+     data-topic-clear-agent-confirm="<%= t('collavre.comments.topic_clear_agent_confirm', name: '%{name}') %>"
      data-topic-create-error="<%= t('collavre.comments.topic_create_error') %>"
      data-topic-update-error="<%= t('collavre.comments.topic_update_error') %>"
      data-topic-delete-error="<%= t('collavre.comments.topic_delete_error') %>"

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -11,6 +11,7 @@ en:
       not_ai_agent: Only AI agents can be set as primary agent.
       session_topic_locked: This topic belongs to a live agent session. Its primary agent cannot be changed or released.
       agent_no_creative_access: "%{name} has no feedback access here, so it could not respond as primary agent. Share this creative with the agent first."
+      session_agent_not_assignable: "%{name} is a live agent session and only responds in its own session topic, so it cannot be the primary agent here."
       default_name_prefix: "Topic"
       branch_prefix: "Branch"
       main_name: "Main"
@@ -22,6 +23,7 @@ en:
         duplicate_name: A topic named '%{name}' already exists in the target creative.
         session_topic_locked: This topic belongs to a live agent session and cannot be moved.
         primary_agent_released: '@%{agent} was released as primary agent because it has no feedback access in "%{creative}". Share that creative with the agent and assign it again to keep it on this topic.'
+        primary_agent_released_session_agent: '@%{agent} was released as primary agent because it is a live agent session and only responds in its own session topic, which "%{creative}" is not.'
         add_members:
           title: Add members to the new location?
           description: These people had access where the topic used to live, but not in "%{creative}". Add them so they keep access.
@@ -207,6 +209,7 @@ en:
         already_exists: 'Topic "%{name}" already exists.'
         session_topic_locked: 'Topic "%{name}" belongs to a live agent session. Its primary agent cannot be changed or released.'
         agent_no_creative_access: '@%{agent} has no feedback access here, so it could not respond as primary agent. Share this creative with the agent first.'
+        session_agent_not_assignable: '@%{agent} is a live agent session and only responds in its own session topic, so it cannot be the primary agent here.'
       work_command:
         agent_not_found: "Please mention an AI agent to execute the workflow."
         no_children: "This creative has no child creatives to work on."

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -108,6 +108,8 @@ en:
       recent_chats: Recent chats
       remove_from_history: Remove from history
       topic_set_agent_error: Unable to assign the agent to this topic.
+      topic_agent_assigned_title: "%{name} is assigned to this topic — click to release"
+      topic_clear_agent_confirm: "Release %{name} from this topic? Every agent will be able to respond here again."
       topic_create_error: Unable to create the topic.
       topic_update_error: Unable to update the topic.
       topic_delete_error: Unable to delete the topic.
@@ -196,6 +198,7 @@ en:
         created: 'Topic "%{name}" created.'
         created_with_agent: 'Topic "%{name}" created with @%{agent} as primary agent.'
         updated_agent: 'Topic "%{name}" primary agent updated to @%{agent}.'
+        cleared_agent: 'Topic "%{name}" primary agent released. All agents can respond again.'
         already_exists: 'Topic "%{name}" already exists.'
       work_command:
         agent_not_found: "Please mention an AI agent to execute the workflow."

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -10,6 +10,7 @@ en:
       archived_topics: "Archived topics (%{count})"
       not_ai_agent: Only AI agents can be set as primary agent.
       session_topic_locked: This topic belongs to a live agent session. Its primary agent cannot be changed or released.
+      agent_no_creative_access: "%{name} has no feedback access here, so it could not respond as primary agent. Share this creative with the agent first."
       default_name_prefix: "Topic"
       branch_prefix: "Branch"
       main_name: "Main"
@@ -202,6 +203,7 @@ en:
         cleared_agent: 'Topic "%{name}" primary agent released. All agents can respond again.'
         already_exists: 'Topic "%{name}" already exists.'
         session_topic_locked: 'Topic "%{name}" belongs to a live agent session. Its primary agent cannot be changed or released.'
+        agent_no_creative_access: '@%{agent} has no feedback access here, so it could not respond as primary agent. Share this creative with the agent first.'
       work_command:
         agent_not_found: "Please mention an AI agent to execute the workflow."
         no_children: "This creative has no child creatives to work on."

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -9,6 +9,7 @@ en:
       unarchive: Restore
       archived_topics: "Archived topics (%{count})"
       not_ai_agent: Only AI agents can be set as primary agent.
+      session_topic_locked: This topic belongs to a live agent session. Its primary agent cannot be changed or released.
       default_name_prefix: "Topic"
       branch_prefix: "Branch"
       main_name: "Main"
@@ -200,6 +201,7 @@ en:
         updated_agent: 'Topic "%{name}" primary agent updated to @%{agent}.'
         cleared_agent: 'Topic "%{name}" primary agent released. All agents can respond again.'
         already_exists: 'Topic "%{name}" already exists.'
+        session_topic_locked: 'Topic "%{name}" belongs to a live agent session. Its primary agent cannot be changed or released.'
       work_command:
         agent_not_found: "Please mention an AI agent to execute the workflow."
         no_children: "This creative has no child creatives to work on."

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -20,6 +20,8 @@ en:
       move:
         no_target_permission: You don't have write permission on the target creative.
         duplicate_name: A topic named '%{name}' already exists in the target creative.
+        session_topic_locked: This topic belongs to a live agent session and cannot be moved.
+        primary_agent_released: '@%{agent} was released as primary agent because it has no feedback access in "%{creative}". Share that creative with the agent and assign it again to keep it on this topic.'
         add_members:
           title: Add members to the new location?
           description: These people had access where the topic used to live, but not in "%{creative}". Add them so they keep access.

--- a/engines/collavre/config/locales/comments.en.yml
+++ b/engines/collavre/config/locales/comments.en.yml
@@ -197,6 +197,7 @@ en:
         failed: "Compress failed"
       topic_command:
         missing_name: 'Please specify a topic name in quotes: /topic "topic name"'
+        not_authorized: "You need write permission to change a topic's primary agent."
         created: 'Topic "%{name}" created.'
         created_with_agent: 'Topic "%{name}" created with @%{agent} as primary agent.'
         updated_agent: 'Topic "%{name}" primary agent updated to @%{agent}.'

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -10,6 +10,7 @@ ko:
       archived_topics: "아카이브된 토픽 (%{count}개)"
       not_ai_agent: AI 에이전트만 Primary Agent로 설정할 수 있습니다.
       session_topic_locked: 이 토픽은 실행 중인 에이전트 세션에 속해 있어 Primary Agent를 변경하거나 해제할 수 없습니다.
+      agent_no_creative_access: "%{name}은(는) 이 크리에이티브에 피드백 권한이 없어 Primary Agent로 응답할 수 없습니다. 먼저 이 크리에이티브를 해당 에이전트와 공유하세요."
       default_name_prefix: "토픽"
       branch_prefix: "분기"
       main_name: "메인"
@@ -199,6 +200,7 @@ ko:
         cleared_agent: '토픽 "%{name}"의 Primary Agent 지정이 해제되었습니다. 다시 모든 에이전트가 응답할 수 있습니다.'
         already_exists: '토픽 "%{name}"이(가) 이미 존재합니다.'
         session_topic_locked: '토픽 "%{name}"은(는) 실행 중인 에이전트 세션에 속해 있어 Primary Agent를 변경하거나 해제할 수 없습니다.'
+        agent_no_creative_access: '@%{agent}은(는) 이 크리에이티브에 피드백 권한이 없어 Primary Agent로 응답할 수 없습니다. 먼저 이 크리에이티브를 해당 에이전트와 공유하세요.'
       work_command:
         agent_not_found: "워크플로우를 실행할 AI 에이전트를 멘션해주세요."
         no_children: "이 크리에이티브에는 작업할 하위 크리에이티브가 없습니다."

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -11,6 +11,7 @@ ko:
       not_ai_agent: AI 에이전트만 Primary Agent로 설정할 수 있습니다.
       session_topic_locked: 이 토픽은 실행 중인 에이전트 세션에 속해 있어 Primary Agent를 변경하거나 해제할 수 없습니다.
       agent_no_creative_access: "%{name}은(는) 이 크리에이티브에 피드백 권한이 없어 Primary Agent로 응답할 수 없습니다. 먼저 이 크리에이티브를 해당 에이전트와 공유하세요."
+      session_agent_not_assignable: "%{name}은(는) 실행 중인 에이전트 세션이라 자신의 세션 토픽에서만 응답합니다. 이 토픽의 Primary Agent로 지정할 수 없습니다."
       default_name_prefix: "토픽"
       branch_prefix: "분기"
       main_name: "메인"
@@ -22,6 +23,7 @@ ko:
         duplicate_name: "'%{name}' 토픽이 대상 크리에이티브에 이미 존재합니다."
         session_topic_locked: 이 토픽은 실행 중인 에이전트 세션에 속해 있어 이동할 수 없습니다.
         primary_agent_released: '@%{agent}은(는) "%{creative}"에 피드백 권한이 없어 Primary Agent 지정이 해제되었습니다. 계속 담당하게 하려면 해당 크리에이티브를 에이전트와 공유한 뒤 다시 지정하세요.'
+        primary_agent_released_session_agent: '@%{agent}은(는) 실행 중인 에이전트 세션이라 자신의 세션 토픽에서만 응답합니다. "%{creative}"은(는) 그 토픽이 아니어서 Primary Agent 지정이 해제되었습니다.'
         add_members:
           title: 새 위치에 멤버를 추가할까요?
           description: 이 사람들은 토픽이 있던 곳에는 접근할 수 있었지만 "%{creative}"에는 없습니다. 계속 접근할 수 있도록 추가하세요.
@@ -204,6 +206,7 @@ ko:
         already_exists: '토픽 "%{name}"이(가) 이미 존재합니다.'
         session_topic_locked: '토픽 "%{name}"은(는) 실행 중인 에이전트 세션에 속해 있어 Primary Agent를 변경하거나 해제할 수 없습니다.'
         agent_no_creative_access: '@%{agent}은(는) 이 크리에이티브에 피드백 권한이 없어 Primary Agent로 응답할 수 없습니다. 먼저 이 크리에이티브를 해당 에이전트와 공유하세요.'
+        session_agent_not_assignable: '@%{agent}은(는) 실행 중인 에이전트 세션이라 자신의 세션 토픽에서만 응답합니다. 이 토픽의 Primary Agent로 지정할 수 없습니다.'
       work_command:
         agent_not_found: "워크플로우를 실행할 AI 에이전트를 멘션해주세요."
         no_children: "이 크리에이티브에는 작업할 하위 크리에이티브가 없습니다."

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -9,6 +9,7 @@ ko:
       unarchive: 복원
       archived_topics: "아카이브된 토픽 (%{count}개)"
       not_ai_agent: AI 에이전트만 Primary Agent로 설정할 수 있습니다.
+      session_topic_locked: 이 토픽은 실행 중인 에이전트 세션에 속해 있어 Primary Agent를 변경하거나 해제할 수 없습니다.
       default_name_prefix: "토픽"
       branch_prefix: "분기"
       main_name: "메인"
@@ -197,6 +198,7 @@ ko:
         updated_agent: '토픽 "%{name}"의 Primary Agent가 @%{agent}(으)로 변경되었습니다.'
         cleared_agent: '토픽 "%{name}"의 Primary Agent 지정이 해제되었습니다. 다시 모든 에이전트가 응답할 수 있습니다.'
         already_exists: '토픽 "%{name}"이(가) 이미 존재합니다.'
+        session_topic_locked: '토픽 "%{name}"은(는) 실행 중인 에이전트 세션에 속해 있어 Primary Agent를 변경하거나 해제할 수 없습니다.'
       work_command:
         agent_not_found: "워크플로우를 실행할 AI 에이전트를 멘션해주세요."
         no_children: "이 크리에이티브에는 작업할 하위 크리에이티브가 없습니다."

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -194,6 +194,7 @@ ko:
         failed: "요약 실패"
       topic_command:
         missing_name: '토픽 이름을 따옴표로 지정하세요: /topic "토픽 이름"'
+        not_authorized: 토픽의 Primary Agent를 변경하려면 쓰기 권한이 필요합니다.
         created: '토픽 "%{name}"이(가) 생성되었습니다.'
         created_with_agent: '토픽 "%{name}"이(가) 생성되었습니다. @%{agent}이(가) Primary Agent로 설정되었습니다.'
         updated_agent: '토픽 "%{name}"의 Primary Agent가 @%{agent}(으)로 변경되었습니다.'

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -105,6 +105,8 @@ ko:
       recent_chats: 최근 채팅
       remove_from_history: 히스토리에서 제거
       topic_set_agent_error: 이 토픽에 에이전트를 지정할 수 없습니다.
+      topic_agent_assigned_title: "%{name}이(가) 이 토픽에 할당되어 있습니다 — 클릭하면 해제됩니다"
+      topic_clear_agent_confirm: "%{name}의 토픽 할당을 해제할까요? 이 토픽에서 다시 모든 에이전트가 응답할 수 있게 됩니다."
       topic_create_error: 토픽을 생성할 수 없습니다.
       topic_update_error: 토픽을 수정할 수 없습니다.
       topic_delete_error: 토픽을 삭제할 수 없습니다.
@@ -193,6 +195,7 @@ ko:
         created: '토픽 "%{name}"이(가) 생성되었습니다.'
         created_with_agent: '토픽 "%{name}"이(가) 생성되었습니다. @%{agent}이(가) Primary Agent로 설정되었습니다.'
         updated_agent: '토픽 "%{name}"의 Primary Agent가 @%{agent}(으)로 변경되었습니다.'
+        cleared_agent: '토픽 "%{name}"의 Primary Agent 지정이 해제되었습니다. 다시 모든 에이전트가 응답할 수 있습니다.'
         already_exists: '토픽 "%{name}"이(가) 이미 존재합니다.'
       work_command:
         agent_not_found: "워크플로우를 실행할 AI 에이전트를 멘션해주세요."

--- a/engines/collavre/config/locales/comments.ko.yml
+++ b/engines/collavre/config/locales/comments.ko.yml
@@ -20,6 +20,8 @@ ko:
       move:
         no_target_permission: 대상 크리에이티브에 대한 쓰기 권한이 없습니다.
         duplicate_name: "'%{name}' 토픽이 대상 크리에이티브에 이미 존재합니다."
+        session_topic_locked: 이 토픽은 실행 중인 에이전트 세션에 속해 있어 이동할 수 없습니다.
+        primary_agent_released: '@%{agent}은(는) "%{creative}"에 피드백 권한이 없어 Primary Agent 지정이 해제되었습니다. 계속 담당하게 하려면 해당 크리에이티브를 에이전트와 공유한 뒤 다시 지정하세요.'
         add_members:
           title: 새 위치에 멤버를 추가할까요?
           description: 이 사람들은 토픽이 있던 곳에는 접근할 수 있었지만 "%{creative}"에는 없습니다. 계속 접근할 수 있도록 추가하세요.

--- a/engines/collavre/test/controllers/topics_controller_test.rb
+++ b/engines/collavre/test/controllers/topics_controller_test.rb
@@ -328,6 +328,43 @@ class TopicsControllerTest < ActionDispatch::IntegrationTest
     assert_nil body["topic"]["primary_agent"]
   end
 
+  # On a session topic primary_agent_id is session identity, not a routing pin:
+  # clearing it makes the live session unroutable and makes the next registration
+  # create a second topic instead of reusing the conversation.
+  test "should refuse to clear the primary agent of a session topic" do
+    ai_agent = User.create!(
+      email: "sessionagent@test.local", password: "password123", name: "SessionAgent",
+      llm_vendor: "anthropic", llm_model: "claude", searchable: true
+    )
+    @topic.set_primary_agent!(ai_agent)
+    @topic.update!(session_id: "sess-abc123")
+
+    patch set_primary_agent_creative_topic_url(@creative, @topic),
+      params: { agent_id: nil }, as: :json
+
+    assert_response :unprocessable_entity
+    assert_equal ai_agent.id, @topic.reload.primary_agent_id
+  end
+
+  test "should refuse to reassign the primary agent of a session topic" do
+    ai_agent = User.create!(
+      email: "sessionagent2@test.local", password: "password123", name: "SessionAgent2",
+      llm_vendor: "anthropic", llm_model: "claude", searchable: true
+    )
+    other_agent = User.create!(
+      email: "otheragent@test.local", password: "password123", name: "OtherAgent",
+      llm_vendor: "openai", llm_model: "gpt-4", searchable: true
+    )
+    @topic.set_primary_agent!(ai_agent)
+    @topic.update!(session_id: "sess-def456")
+
+    patch set_primary_agent_creative_topic_url(@creative, @topic),
+      params: { agent_id: other_agent.id }, as: :json
+
+    assert_response :unprocessable_entity
+    assert_equal ai_agent.id, @topic.reload.primary_agent_id
+  end
+
   test "should reject non-AI user as primary agent" do
     patch set_primary_agent_creative_topic_url(@creative, @topic),
       params: { agent_id: @user.id }, as: :json

--- a/engines/collavre/test/controllers/topics_controller_test.rb
+++ b/engines/collavre/test/controllers/topics_controller_test.rb
@@ -23,6 +23,35 @@ class TopicsControllerTest < ActionDispatch::IntegrationTest
     assert_equal @creative.id, json["effective_creative_id"]
   end
 
+  # set_primary_agent is guarded by require_creative_write!, so the client needs a
+  # write-level capability to gate the release control on. Reporting only
+  # can_manage (:admin) would let a write collaborator pin an agent by dropping it
+  # on the topic and then leave them no way to release it.
+  test "index reports can_set_primary_agent for a write collaborator who cannot manage" do
+    collaborator = users(:two)
+    Collavre::CreativeShare.create!(creative: @creative, user: collaborator, shared_by: @user, permission: :write)
+    sign_in_as collaborator, password: "password"
+
+    get collavre.creative_topics_url(@creative), as: :json
+
+    assert_response :success
+    json = JSON.parse(response.body)
+    assert_not json["can_manage"], "write collaborator must not be reported as a manager"
+    assert json["can_set_primary_agent"], "write collaborator must be able to release an assignment"
+  end
+
+  test "index withholds can_set_primary_agent from a read-only collaborator" do
+    collaborator = users(:two)
+    Collavre::CreativeShare.create!(creative: @creative, user: collaborator, shared_by: @user, permission: :read)
+    sign_in_as collaborator, password: "password"
+
+    get collavre.creative_topics_url(@creative), as: :json
+
+    assert_response :success
+    json = JSON.parse(response.body)
+    assert_not json["can_set_primary_agent"]
+  end
+
   test "index eagerly creates System topic on first inbox visit so badge has matching topic" do
     inbox = Collavre::Creative.inbox_for(@user)
     inbox.topics.where(name: Collavre::Creative::SYSTEM_TOPIC_NAME).destroy_all
@@ -279,6 +308,7 @@ class TopicsControllerTest < ActionDispatch::IntegrationTest
       email: "agent@test.local", password: "password123", name: "TestAgent",
       llm_vendor: "openai", llm_model: "gpt-4", searchable: true
     )
+    Collavre::CreativeShare.create!(creative: @creative, user: ai_agent, shared_by: @user, permission: :feedback)
 
     patch set_primary_agent_creative_topic_url(@creative, @topic),
       params: { agent_id: ai_agent.id }, as: :json
@@ -297,6 +327,7 @@ class TopicsControllerTest < ActionDispatch::IntegrationTest
       email: "new@test.local", password: "password123", name: "NewAgent",
       llm_vendor: "openai", llm_model: "gpt-4", searchable: true
     )
+    Collavre::CreativeShare.create!(creative: @creative, user: new_agent, shared_by: @user, permission: :feedback)
     @topic.set_primary_agent!(old_agent)
 
     patch set_primary_agent_creative_topic_url(@creative, @topic),
@@ -379,11 +410,81 @@ class TopicsControllerTest < ActionDispatch::IntegrationTest
     assert_response :unprocessable_entity
   end
 
+  # A searchable agent is offered by the palette (and by User.mentionable_for)
+  # even with no share here. Pinning one would make the topic mute: the pin
+  # excludes every other agent's ambient routing while the pinned agent itself
+  # fails Matcher#has_creative_permission? and cannot answer.
+  test "should reject a primary agent that has no feedback access on the creative" do
+    outsider = User.create!(
+      email: "outsider@test.local", password: "password123", name: "Outsider",
+      llm_vendor: "openai", llm_model: "gpt-4", searchable: true
+    )
+
+    patch set_primary_agent_creative_topic_url(@creative, @topic),
+      params: { agent_id: outsider.id }, as: :json
+
+    assert_response :unprocessable_entity
+    assert_nil @topic.reload.primary_agent_id
+  end
+
+  test "should reject moving a pin onto an agent without feedback access" do
+    shared_agent = User.create!(
+      email: "shared-agent@test.local", password: "password123", name: "SharedAgent",
+      llm_vendor: "openai", llm_model: "gpt-4", searchable: true
+    )
+    Collavre::CreativeShare.create!(creative: @creative, user: shared_agent, shared_by: @user, permission: :feedback)
+    outsider = User.create!(
+      email: "outsider2@test.local", password: "password123", name: "Outsider2",
+      llm_vendor: "openai", llm_model: "gpt-4", searchable: true
+    )
+    @topic.set_primary_agent!(shared_agent)
+
+    patch set_primary_agent_creative_topic_url(@creative, @topic),
+      params: { agent_id: outsider.id }, as: :json
+
+    assert_response :unprocessable_entity
+    assert_equal shared_agent.id, @topic.reload.primary_agent_id
+  end
+
+  test "should reject creating a topic pinned to an agent without feedback access" do
+    outsider = User.create!(
+      email: "outsider3@test.local", password: "password123", name: "Outsider3",
+      llm_vendor: "openai", llm_model: "gpt-4", searchable: true
+    )
+
+    assert_no_difference("Topic.count") do
+      post collavre.creative_topics_url(@creative),
+        params: { topic: { name: "Talk to Outsider3" }, agent_id: outsider.id }, as: :json
+    end
+
+    assert_response :unprocessable_entity
+  end
+
+  # An agent shared only on an ancestor still resolves through the permission
+  # cascade, so it must stay assignable — the guard has to be the routing
+  # predicate, not a direct-share lookup.
+  test "should accept a primary agent whose feedback access is inherited" do
+    child = Collavre::Creative.create!(user: @user, parent: @creative, description: "Child")
+    child_topic = child.topics.create!(name: "Child Topic", user: @user)
+    ai_agent = User.create!(
+      email: "inherited@test.local", password: "password123", name: "InheritedAgent",
+      llm_vendor: "openai", llm_model: "gpt-4", searchable: true
+    )
+    Collavre::CreativeShare.create!(creative: @creative, user: ai_agent, shared_by: @user, permission: :feedback)
+
+    patch set_primary_agent_creative_topic_url(child, child_topic),
+      params: { agent_id: ai_agent.id }, as: :json
+
+    assert_response :success
+    assert_equal ai_agent.id, child_topic.reload.primary_agent_id
+  end
+
   test "should create topic with agent_id" do
     ai_agent = User.create!(
       email: "agent2@test.local", password: "password123", name: "Agent2",
       llm_vendor: "openai", llm_model: "gpt-4", searchable: true
     )
+    Collavre::CreativeShare.create!(creative: @creative, user: ai_agent, shared_by: @user, permission: :feedback)
 
     assert_difference("Topic.count") do
       post collavre.creative_topics_url(@creative),

--- a/engines/collavre/test/controllers/topics_controller_test.rb
+++ b/engines/collavre/test/controllers/topics_controller_test.rb
@@ -323,6 +323,35 @@ class TopicsControllerTest < ActionDispatch::IntegrationTest
            "the release must be reported so it is not silent"
   end
 
+  # The release has two possible causes now, and the advice differs. A Claude
+  # Channel session agent holds inbox-wide :feedback, so moving its topic into
+  # the inbox passes the permission check while Matcher#eligible_in_inbox? still
+  # refuses to route it anywhere but its own session topic. Reporting the
+  # permission message here would tell the user to share a creative the agent is
+  # already shared on — advice that cannot fix anything.
+  test "move reports session confinement, not missing access, when releasing a session agent" do
+    inbox = Collavre::Creative.inbox_for(@user)
+    agent = move_test_agent("sessionmove@test.local", "SessionMoveAgent")
+    agent.update!(llm_vendor: "anthropic", llm_model: "claude-code")
+    Collavre::CreativeShare.create!(creative: @creative, user: agent, shared_by: @user, permission: :feedback)
+    Collavre::CreativeShare.create!(creative: inbox, user: agent, shared_by: @user, permission: :feedback)
+    @topic.set_primary_agent!(agent)
+
+    patch move_creative_topic_url(@creative, @topic), params: { target_creative_id: inbox.id }, as: :json
+
+    assert_response :success
+    assert_nil @topic.reload.primary_agent_id,
+               "a session agent cannot be routed to on an ordinary inbox topic, so the pin must not survive"
+    message = JSON.parse(response.body).dig("released_primary_agent", "message")
+    assert_equal I18n.t("collavre.topics.move.primary_agent_released_session_agent",
+                        agent: agent.display_name, creative: inbox.creative_snippet),
+                 message
+    refute_equal I18n.t("collavre.topics.move.primary_agent_released",
+                        agent: agent.display_name, creative: inbox.creative_snippet),
+                 message,
+                 "the agent already has feedback access here — telling the user to share would be unfollowable"
+  end
+
   test "move keeps a primary agent that still has feedback access on the target" do
     target_creative = creatives(:root_parent)
     agent = move_test_agent("stayagent@test.local", "StayAgent")
@@ -530,6 +559,63 @@ class TopicsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_equal ai_agent.id, child_topic.reload.primary_agent_id
+  end
+
+  # Registration grants a Claude Channel agent inbox-wide :feedback, so the
+  # permission check alone passes on every inbox topic — but
+  # Matcher#eligible_in_inbox? confines it to the topic carrying its session_id.
+  # Pinning it on an ordinary inbox topic would make match_by_primary_agent
+  # return [] and mute the topic for everyone.
+  test "should reject a Claude Channel session agent on an ordinary inbox topic" do
+    inbox = Collavre::Creative.inbox_for(@user)
+    inbox_topic = inbox.topics.create!(name: "Ordinary Inbox Topic", user: @user)
+    session_agent = User.create!(
+      email: "cc-session@test.local", password: "password123", name: "Claude Channel (dev)",
+      llm_vendor: "anthropic", llm_model: "claude-code", searchable: false, created_by_id: @user.id
+    )
+    Collavre::CreativeShare.create!(creative: inbox, user: session_agent, shared_by: @user, permission: :feedback)
+
+    patch set_primary_agent_creative_topic_url(inbox, inbox_topic),
+      params: { agent_id: session_agent.id }, as: :json
+
+    assert_response :unprocessable_entity
+    assert_nil inbox_topic.reload.primary_agent_id
+    assert_equal I18n.t("collavre.topics.session_agent_not_assignable", name: session_agent.display_name),
+      JSON.parse(response.body)["error"],
+      "the message must name the session rule, not claim the agent lacks access"
+  end
+
+  test "should reject creating an inbox topic pinned to a Claude Channel session agent" do
+    inbox = Collavre::Creative.inbox_for(@user)
+    session_agent = User.create!(
+      email: "cc-session-create@test.local", password: "password123", name: "Claude Channel (create)",
+      llm_vendor: "anthropic", llm_model: "claude-code", searchable: false, created_by_id: @user.id
+    )
+    Collavre::CreativeShare.create!(creative: inbox, user: session_agent, shared_by: @user, permission: :feedback)
+
+    assert_no_difference("Topic.count") do
+      post collavre.creative_topics_url(inbox),
+        params: { topic: { name: "Talk to session" }, agent_id: session_agent.id }, as: :json
+    end
+
+    assert_response :unprocessable_entity
+  end
+
+  # Negative control: the confinement is inbox-only. On an ordinary creative
+  # Matcher routes a Claude Channel agent by routing_expression like any other,
+  # so rejecting it there would break a legitimate assignment.
+  test "should accept a Claude Channel session agent outside the inbox" do
+    session_agent = User.create!(
+      email: "cc-session-work@test.local", password: "password123", name: "Claude Channel (work)",
+      llm_vendor: "anthropic", llm_model: "claude-code", searchable: false, created_by_id: @user.id
+    )
+    Collavre::CreativeShare.create!(creative: @creative, user: session_agent, shared_by: @user, permission: :feedback)
+
+    patch set_primary_agent_creative_topic_url(@creative, @topic),
+      params: { agent_id: session_agent.id }, as: :json
+
+    assert_response :success
+    assert_equal session_agent.id, @topic.reload.primary_agent_id
   end
 
   test "should create topic with agent_id" do

--- a/engines/collavre/test/controllers/topics_controller_test.rb
+++ b/engines/collavre/test/controllers/topics_controller_test.rb
@@ -307,6 +307,27 @@ class TopicsControllerTest < ActionDispatch::IntegrationTest
     assert_equal new_agent.id, @topic.primary_agent_id
   end
 
+  test "should clear primary agent when agent_id is blank" do
+    ai_agent = User.create!(
+      email: "clearme@test.local", password: "password123", name: "ClearAgent",
+      llm_vendor: "openai", llm_model: "gpt-4", searchable: true
+    )
+    @topic.set_primary_agent!(ai_agent)
+
+    patch set_primary_agent_creative_topic_url(@creative, @topic),
+      params: { agent_id: nil }, as: :json
+
+    assert_response :success
+    @topic.reload
+    assert_nil @topic.primary_agent_id
+
+    body = JSON.parse(response.body)
+    # The client merges this payload into its cached topic, so the key must be
+    # present-and-null to actually remove the avatar.
+    assert body["topic"].key?("primary_agent")
+    assert_nil body["topic"]["primary_agent"]
+  end
+
   test "should reject non-AI user as primary agent" do
     patch set_primary_agent_creative_topic_url(@creative, @topic),
       params: { agent_id: @user.id }, as: :json

--- a/engines/collavre/test/controllers/topics_controller_test.rb
+++ b/engines/collavre/test/controllers/topics_controller_test.rb
@@ -303,6 +303,59 @@ class TopicsControllerTest < ActionDispatch::IntegrationTest
     assert_empty json["missing_members"]
   end
 
+  # The pin travels with the topic, and it is exclusive: if the agent has no
+  # feedback access at the destination, Matcher#match_by_primary_agent returns []
+  # and the moved topic can route to nobody at all. Release it instead so the
+  # topic falls back to ordinary expression routing there.
+  test "move releases a primary agent that cannot respond on the target" do
+    target_creative = creatives(:root_parent)
+    agent = move_test_agent("moveagent@test.local", "MoveAgent")
+    Collavre::CreativeShare.create!(creative: @creative, user: agent, shared_by: @user, permission: :feedback)
+    @topic.set_primary_agent!(agent)
+
+    patch move_creative_topic_url(@creative, @topic), params: { target_creative_id: target_creative.id }, as: :json
+
+    assert_response :success
+    assert_nil @topic.reload.primary_agent_id, "an unanswerable pin must not survive the move"
+    json = JSON.parse(response.body)
+    assert_equal agent.id, json.dig("released_primary_agent", "id")
+    assert json.dig("released_primary_agent", "message").present?,
+           "the release must be reported so it is not silent"
+  end
+
+  test "move keeps a primary agent that still has feedback access on the target" do
+    target_creative = creatives(:root_parent)
+    agent = move_test_agent("stayagent@test.local", "StayAgent")
+    Collavre::CreativeShare.create!(creative: @creative, user: agent, shared_by: @user, permission: :feedback)
+    Collavre::CreativeShare.create!(creative: target_creative, user: agent, shared_by: @user, permission: :feedback)
+    @topic.set_primary_agent!(agent)
+
+    patch move_creative_topic_url(@creative, @topic), params: { target_creative_id: target_creative.id }, as: :json
+
+    assert_response :success
+    assert_equal agent.id, @topic.reload.primary_agent_id, "a valid assignment must survive the move"
+    assert_nil JSON.parse(response.body)["released_primary_agent"]
+  end
+
+  # A session topic's pin is identity, not routing: SessionProvisioner reuses it
+  # via inbox.topics.find_by(primary_agent_id:, session_id:). Moving it out of
+  # the inbox would fork a second topic on the next registration, so the whole
+  # move is refused rather than releasing the pin.
+  test "should not move a Claude Channel session topic" do
+    target_creative = creatives(:root_parent)
+    agent = move_test_agent("sessionagent@test.local", "SessionAgent")
+    Collavre::CreativeShare.create!(creative: @creative, user: agent, shared_by: @user, permission: :feedback)
+    @topic.update!(session_id: "sess-move-1")
+    @topic.set_primary_agent!(agent)
+
+    patch move_creative_topic_url(@creative, @topic), params: { target_creative_id: target_creative.id }, as: :json
+
+    assert_response :unprocessable_entity
+    @topic.reload
+    assert_equal @creative.id, @topic.creative_id, "the session topic must stay put"
+    assert_equal agent.id, @topic.primary_agent_id
+  end
+
   test "should set primary agent on topic" do
     ai_agent = User.create!(
       email: "agent@test.local", password: "password123", name: "TestAgent",
@@ -559,5 +612,14 @@ class TopicsControllerTest < ActionDispatch::IntegrationTest
     # Verify new topic is at the end
     assert_equal [ topic3.id, @topic.id, topic2.id, new_topic.id ], @creative.topics.reload.pluck(:id)
     assert_equal 3, new_topic.position
+  end
+
+  private
+
+  def move_test_agent(email, name)
+    User.create!(
+      email: email, password: "password123", name: name,
+      llm_vendor: "openai", llm_model: "gpt-4", searchable: true
+    )
   end
 end

--- a/engines/collavre/test/jobs/ai_agent_job_test.rb
+++ b/engines/collavre/test/jobs/ai_agent_job_test.rb
@@ -333,6 +333,46 @@ class AiAgentJobTest < ActiveJob::TestCase
       "Expected no new task when duplicate running task exists for same comment"
   end
 
+  test "delayed job skips dispatch when the topic was assigned to another agent during the delay" do
+    # Scheduler returns :delayed for a busy / rate-limited agent and enqueues
+    # with agent.id — no Task row exists yet, so there is nothing to cancel when
+    # the assignment lands. Nothing re-matches before execution either, so
+    # without a check here a demoted agent speaks in a topic that is now
+    # exclusively someone else's.
+    topic = Topic.create!(creative: @creative, name: "assigned-during-delay", user: @owner)
+    primary = User.create!(
+      email: "assigned_primary@example.com", name: "Assigned Primary",
+      password: "password", llm_vendor: "google", llm_model: "gemini-1.5-flash",
+      searchable: true
+    )
+    topic.set_primary_agent!(primary)
+
+    context = @context.merge("topic" => { "id" => topic.id })
+    tasks_before = Task.where(agent_id: @agent.id).count
+
+    AiClient.stub :new, ->(**kwargs) { FakeAiClient.new } do
+      AiAgentJob.perform_now(@agent.id, "comment_created", context)
+    end
+
+    assert_equal tasks_before, Task.where(agent_id: @agent.id).count,
+      "an agent the topic assignment now excludes must not run"
+  end
+
+  test "delayed job still dispatches when the assignment names this agent" do
+    topic = Topic.create!(creative: @creative, name: "assigned-to-me", user: @owner)
+    topic.set_primary_agent!(@agent)
+
+    context = @context.merge("topic" => { "id" => topic.id })
+    tasks_before = Task.where(agent_id: @agent.id).count
+
+    AiClient.stub :new, ->(**kwargs) { FakeAiClient.new } do
+      AiAgentJob.perform_now(@agent.id, "comment_created", context)
+    end
+
+    assert_equal tasks_before + 1, Task.where(agent_id: @agent.id).count,
+      "the assigned primary agent must still run"
+  end
+
   test "skips duplicate execution when agent has delegated Claude Channel task for same comment" do
     # A delegated task is still in-flight (waiting on external MCP reply);
     # re-dispatching the same comment would produce duplicate replies.

--- a/engines/collavre/test/jobs/ai_agent_job_test.rb
+++ b/engines/collavre/test/jobs/ai_agent_job_test.rb
@@ -794,4 +794,65 @@ class AiAgentJobTest < ActiveJob::TestCase
     assert_equal sub_task.id, fail_called_with[:sub_task].id
     assert_match(/offline/i, fail_called_with[:error_message].to_s)
   end
+
+  # A resumed Task takes the branch above the agent_id guard, so the assignment
+  # was rechecked only at enqueue time. Comments::ActionExecutor re-enqueues an
+  # approved tool call with perform_later(task) and no check at all, and the
+  # pause between the two lasts as long as the human takes to approve — plenty
+  # of room for the topic to be pinned to someone else.
+  test "resumed task does not run when the topic was assigned to another agent while it waited" do
+    topic = Topic.create!(creative: @creative, name: "resumed-reassigned", user: @owner)
+    primary = User.create!(
+      email: "resumed_primary@example.com", name: "Resumed Primary",
+      password: "password", llm_vendor: "google", llm_model: "gemini-1.5-flash",
+      searchable: true
+    )
+    task = Task.create!(
+      name: "Response to comment_created",
+      status: "pending_approval",
+      trigger_event_name: "comment_created",
+      trigger_event_payload: @context.merge("topic" => { "id" => topic.id }),
+      agent: @agent,
+      topic_id: topic.id,
+      creative_id: @creative.id
+    )
+
+    # The pin lands after the task was enqueued for resumption.
+    topic.set_primary_agent!(primary)
+
+    replies_before = Comment.where(creative_id: @creative.id, user_id: @agent.id).count
+
+    AiClient.stub :new, ->(**kwargs) { FakeAiClient.new } do
+      AiAgentJob.perform_now(task)
+    end
+
+    assert_equal "cancelled", task.reload.status,
+      "a resumed task the assignment now excludes must be cancelled, not left pending"
+    assert_equal replies_before, Comment.where(creative_id: @creative.id, user_id: @agent.id).count,
+      "the demoted agent must not reply in a topic that now belongs to another agent"
+  end
+
+  # Negative control: without it the test above would also pass if the guard
+  # simply cancelled every resumed task.
+  test "resumed task still runs when the assignment names its own agent" do
+    topic = Topic.create!(creative: @creative, name: "resumed-still-mine", user: @owner)
+    topic.set_primary_agent!(@agent)
+
+    task = Task.create!(
+      name: "Response to comment_created",
+      status: "pending_approval",
+      trigger_event_name: "comment_created",
+      trigger_event_payload: @context.merge("topic" => { "id" => topic.id }),
+      agent: @agent,
+      topic_id: topic.id,
+      creative_id: @creative.id
+    )
+
+    AiClient.stub :new, ->(**kwargs) { FakeAiClient.new } do
+      AiAgentJob.perform_now(task)
+    end
+
+    assert_equal "done", task.reload.status,
+      "the assigned agent's own resumed task must still run"
+  end
 end

--- a/engines/collavre/test/services/collavre/orchestration/agent_orchestrator_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/agent_orchestrator_test.rb
@@ -381,6 +381,99 @@ module Collavre
 
         assert_not_equal "queued", queued_task.reload.status
       end
+
+      # A queued waiter keeps the agent chosen at dispatch time, so an exclusive
+      # assignment made while it waited has to be rechecked on promotion.
+      test "dequeue_next_for_topic cancels a waiter the topic assignment now excludes" do
+        topic = Topic.create!(name: "Assigned while waiting", creative: @creative, user: @user)
+        other = build_agent
+        Comment.create!(creative: @creative, user: @user, content: "please help", topic: topic)
+
+        queued_task = queued_task_for(other, topic)
+        topic.set_primary_agent!(@ai_agent)
+
+        AgentOrchestrator.dequeue_next_for_topic(topic.id)
+
+        assert_equal "cancelled", queued_task.reload.status
+      end
+
+      test "dequeue_next_for_topic keeps a waiter that is the topic's primary agent" do
+        topic = Topic.create!(name: "Assigned to the waiter", creative: @creative, user: @user)
+        Comment.create!(creative: @creative, user: @user, content: "please help", topic: topic)
+
+        queued_task = queued_task_for(@ai_agent, topic)
+        topic.set_primary_agent!(@ai_agent)
+
+        AgentOrchestrator.dequeue_next_for_topic(topic.id)
+
+        assert_not_equal "cancelled", queued_task.reload.status
+      end
+
+      # refresh_deferred_context! rewrites the whole "chat" hash, dropping the
+      # resolved mentioned_user — so the revalidation has to rebuild the context
+      # or an explicitly invited agent would be cancelled by an unrelated pin.
+      test "dequeue_next_for_topic keeps a waiter the latest comment still mentions" do
+        topic = Topic.create!(name: "Mentioned while waiting", creative: @creative, user: @user)
+        other = build_agent
+        Comment.create!(
+          creative: @creative, user: @user, content: "@#{other.name}: your turn", topic: topic
+        )
+
+        queued_task = queued_task_for(other, topic)
+        topic.set_primary_agent!(@ai_agent)
+
+        AgentOrchestrator.dequeue_next_for_topic(topic.id)
+
+        assert_not_equal "cancelled", queued_task.reload.status
+      end
+
+      test "dequeue_next_for_topic drains to the next waiter after cancelling an excluded one" do
+        topic = Topic.create!(name: "Drain past excluded", creative: @creative, user: @user)
+        other = build_agent
+        Comment.create!(creative: @creative, user: @user, content: "please help", topic: topic)
+
+        excluded = queued_task_for(other, topic)
+        successor = queued_task_for(@ai_agent, topic)
+        topic.set_primary_agent!(@ai_agent)
+
+        AgentOrchestrator.dequeue_next_for_topic(topic.id)
+
+        assert_equal "cancelled", excluded.reload.status
+        assert_not_equal "queued", successor.reload.status,
+                         "cancelling an excluded waiter must not strand the rest of the queue"
+      end
+
+      private
+
+      def build_agent
+        agent = User.create!(
+          name: "Agent #{SecureRandom.hex(3)}",
+          email: "agent_#{SecureRandom.hex(4)}@example.com",
+          password: "password",
+          llm_vendor: "openai",
+          searchable: true
+        )
+        share = CreativeShare.find_or_create_by!(creative: @creative, user: agent)
+        share.update!(permission: "feedback")
+        CreativeSharesCache.find_or_create_by!(
+          creative_id: @creative.id, user_id: agent.id, permission: :feedback
+        )
+        agent
+      end
+
+      def queued_task_for(agent, topic)
+        Task.create!(
+          name: "Queued task", status: "queued",
+          trigger_event_name: "comment_created",
+          trigger_event_payload: {
+            "creative" => { "id" => @creative.id },
+            "topic" => { "id" => topic.id },
+            "comment" => { "id" => 0, "content" => "stale" },
+            "chat" => { "content" => "stale" }
+          },
+          agent: agent, topic_id: topic.id
+        )
+      end
     end
   end
 end

--- a/engines/collavre/test/services/collavre/orchestration/arbiter_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/arbiter_test.rb
@@ -77,7 +77,7 @@ module Collavre
         assert_equal [ @agent2 ], selected
       end
 
-      test "primary_first returns first candidate when primary not in candidates" do
+      test "primary_first stays silent when the configured primary is not a candidate" do
         OrchestratorPolicy.create!(
           policy_type: "arbitration",
           config: { "strategy" => "primary_first", "primary_agent_id" => 99999 }
@@ -86,7 +86,28 @@ module Collavre
         arbiter = Arbiter.new(@context)
         selected = arbiter.select(@candidates)
 
-        assert_equal [ @agent1 ], selected
+        # Promoting an arbitrary other agent is the interloper the primary
+        # assignment exists to keep out.
+        assert_empty selected
+      end
+
+      test "mention routing bypasses arbitration in a topic with a primary agent" do
+        @topic.set_primary_agent!(@agent1)
+        context = @context.merge("chat" => { "mentioned_user" => { "id" => @agent3.id } })
+
+        selected = Arbiter.new(context).select([ @agent3 ])
+
+        # A topic primary agent forces strategy primary_first; without the mention
+        # bypass @agent3 would be dropped for not being @agent1.
+        assert_equal [ @agent3 ], selected
+      end
+
+      test "topic primary agent takes the floor over other candidates" do
+        @topic.set_primary_agent!(@agent2)
+
+        selected = Arbiter.new(@context).select(@candidates)
+
+        assert_equal [ @agent2 ], selected
       end
 
       test "primary_first returns first candidate when no primary configured" do

--- a/engines/collavre/test/services/collavre/orchestration/arbiter_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/arbiter_test.rb
@@ -77,7 +77,10 @@ module Collavre
         assert_equal [ @agent2 ], selected
       end
 
-      test "primary_first stays silent when the configured primary is not a candidate" do
+      # A policy-level primary_agent_id is a preference, not an assignment:
+      # "primary agent responds first, others only if unavailable"
+      # (admin.orchestration.strategy_primary_first). The fallback stays.
+      test "primary_first returns first candidate when policy primary not in candidates" do
         OrchestratorPolicy.create!(
           policy_type: "arbitration",
           config: { "strategy" => "primary_first", "primary_agent_id" => 99999 }
@@ -86,8 +89,16 @@ module Collavre
         arbiter = Arbiter.new(@context)
         selected = arbiter.select(@candidates)
 
-        # Promoting an arbitrary other agent is the interloper the primary
-        # assignment exists to keep out.
+        assert_equal [ @agent1 ], selected
+      end
+
+      # A topic-column assignment IS exclusive, so the same "primary missing"
+      # shape must stay silent rather than promote an arbitrary stand-in.
+      test "topic-assigned primary stays silent when it is not a candidate" do
+        @topic.set_primary_agent!(@agent1)
+
+        selected = Arbiter.new(@context).select([ @agent2, @agent3 ])
+
         assert_empty selected
       end
 

--- a/engines/collavre/test/services/collavre/orchestration/matcher_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/matcher_test.rb
@@ -477,6 +477,128 @@ module Collavre
         assert_equal [ @ai_agent ], Matcher.new(context).match
       end
 
+      # --- Revalidating an already-scheduled dispatch (#assignment_permits?) ---
+
+      test "assignment_permits? allows any agent when the topic has no primary" do
+        other = build_agent(routing_expression: "true")
+        grant_feedback(other)
+        topic = @creative.topics.create!(name: "Unassigned revalidate", user: @user)
+
+        matcher = Matcher.new(
+          "creative" => { "id" => @creative.id }, "topic" => { "id" => topic.id }
+        )
+
+        assert matcher.assignment_permits?(other)
+      end
+
+      test "assignment_permits? allows the assigned primary agent" do
+        topic = @creative.topics.create!(name: "Assigned revalidate", user: @user)
+        topic.set_primary_agent!(@ai_agent)
+
+        matcher = Matcher.new(
+          "creative" => { "id" => @creative.id }, "topic" => { "id" => topic.id }
+        )
+
+        assert matcher.assignment_permits?(@ai_agent)
+      end
+
+      test "assignment_permits? refuses an agent the assignment now excludes" do
+        other = build_agent(routing_expression: "true")
+        grant_feedback(other)
+        topic = @creative.topics.create!(name: "Reassigned mid-flight", user: @user)
+        topic.set_primary_agent!(@ai_agent)
+
+        matcher = Matcher.new(
+          "creative" => { "id" => @creative.id }, "topic" => { "id" => topic.id }
+        )
+
+        assert_not matcher.assignment_permits?(other)
+      end
+
+      test "assignment_permits? allows a mentioned non-primary agent" do
+        other = build_agent(routing_expression: nil)
+        grant_feedback(other)
+        topic = @creative.topics.create!(name: "Assigned yet mentioned", user: @user)
+        topic.set_primary_agent!(@ai_agent)
+
+        matcher = Matcher.new(
+          "creative" => { "id" => @creative.id },
+          "topic" => { "id" => topic.id },
+          "chat" => { "mentioned_user" => { "id" => other.id } }
+        )
+
+        # Mirrors #match: a mention outranks the assignment, so a deferred
+        # mention must not be cancelled when a pin lands while it waits.
+        assert matcher.assignment_permits?(other)
+      end
+
+      test "assignment_permits? refuses a non-primary agent when someone else is mentioned" do
+        other = build_agent(routing_expression: "true")
+        mentioned = build_agent(routing_expression: nil)
+        grant_feedback(other)
+        grant_feedback(mentioned)
+        topic = @creative.topics.create!(name: "Mention for someone else", user: @user)
+        topic.set_primary_agent!(@ai_agent)
+
+        matcher = Matcher.new(
+          "creative" => { "id" => @creative.id },
+          "topic" => { "id" => topic.id },
+          "chat" => { "mentioned_user" => { "id" => mentioned.id } }
+        )
+
+        assert_not matcher.assignment_permits?(other)
+      end
+
+      test "assignment_permits? allows the quoted author of a review message" do
+        other = build_agent(routing_expression: nil)
+        grant_feedback(other)
+        topic = @creative.topics.create!(name: "Review under assignment", user: @user)
+        topic.set_primary_agent!(@ai_agent)
+
+        quoted = @creative.comments.create!(
+          content: "Draft from the other agent", user: other, topic: topic, private: false
+        )
+        review = @creative.comments.create!(
+          content: "shorter please", user: @user, topic: topic, private: false,
+          quoted_comment: quoted
+        )
+
+        matcher = Matcher.new(
+          "creative" => { "id" => @creative.id },
+          "topic" => { "id" => topic.id },
+          "comment" => { "id" => review.id }
+        )
+
+        # Only the quoted author can apply a review in place, so no assignment
+        # can transfer it — refusing here would leave a dead Review button.
+        assert matcher.assignment_permits?(other)
+      end
+
+      test "assignment_permits? refuses a non-author agent on a review message" do
+        author = build_agent(routing_expression: nil)
+        other = build_agent(routing_expression: "true")
+        grant_feedback(author)
+        grant_feedback(other)
+        topic = @creative.topics.create!(name: "Review by non-author", user: @user)
+        topic.set_primary_agent!(@ai_agent)
+
+        quoted = @creative.comments.create!(
+          content: "Draft", user: author, topic: topic, private: false
+        )
+        review = @creative.comments.create!(
+          content: "shorter please", user: @user, topic: topic, private: false,
+          quoted_comment: quoted
+        )
+
+        matcher = Matcher.new(
+          "creative" => { "id" => @creative.id },
+          "topic" => { "id" => topic.id },
+          "comment" => { "id" => review.id }
+        )
+
+        assert_not matcher.assignment_permits?(other)
+      end
+
       private
 
       def build_agent(routing_expression:)

--- a/engines/collavre/test/services/collavre/orchestration/matcher_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/matcher_test.rb
@@ -379,6 +379,124 @@ module Collavre
 
         assert_equal [ claude ], Matcher.new(context).match
       end
+
+      # --- Topic primary agent assignment (exclusive) ---
+
+      test "topic primary agent responds without any routing expression" do
+        topic = @creative.topics.create!(name: "Assigned", user: @user)
+        topic.set_primary_agent!(@ai_agent)
+
+        context = {
+          "event_name" => "comment_created",
+          "creative" => { "id" => @creative.id },
+          "topic" => { "id" => topic.id }
+        }
+
+        assert_equal [ @ai_agent ], Matcher.new(context).match
+      end
+
+      test "topic primary agent responds even when its own routing expression is false" do
+        @ai_agent.update!(routing_expression: 'event_name == "never_fires"')
+        topic = @creative.topics.create!(name: "Assigned false expr", user: @user)
+        topic.set_primary_agent!(@ai_agent)
+
+        context = {
+          "event_name" => "comment_created",
+          "creative" => { "id" => @creative.id },
+          "topic" => { "id" => topic.id }
+        }
+
+        assert_equal [ @ai_agent ], Matcher.new(context).match
+      end
+
+      test "topic primary agent silences other agents whose expressions match" do
+        other = build_agent(routing_expression: "true")
+        grant_feedback(other)
+        @ai_agent.update!(routing_expression: "true")
+
+        topic = @creative.topics.create!(name: "Assigned exclusive", user: @user)
+        topic.set_primary_agent!(@ai_agent)
+
+        context = {
+          "event_name" => "comment_created",
+          "creative" => { "id" => @creative.id },
+          "topic" => { "id" => topic.id }
+        }
+
+        result = Matcher.new(context).match
+        assert_equal [ @ai_agent ], result
+        assert_not_includes result, other
+      end
+
+      test "mention of a non-primary agent still routes to that agent" do
+        other = build_agent(routing_expression: nil)
+        grant_feedback(other)
+
+        topic = @creative.topics.create!(name: "Assigned but mentioned", user: @user)
+        topic.set_primary_agent!(@ai_agent)
+
+        context = {
+          "event_name" => "comment_created",
+          "creative" => { "id" => @creative.id },
+          "topic" => { "id" => topic.id },
+          "chat" => { "mentioned_user" => { "id" => other.id } }
+        }
+
+        assert_equal [ other ], Matcher.new(context).match
+      end
+
+      test "no agent responds when the topic primary agent lacks feedback permission" do
+        stranger = build_agent(routing_expression: "true")
+        matching = build_agent(routing_expression: "true")
+        grant_feedback(matching)
+
+        topic = @creative.topics.create!(name: "Assigned no permission", user: @user)
+        topic.set_primary_agent!(stranger)
+
+        context = {
+          "event_name" => "comment_created",
+          "creative" => { "id" => @creative.id },
+          "topic" => { "id" => topic.id }
+        }
+
+        # Falling back to expression routing here would hand the floor to exactly
+        # the agents the assignment excludes.
+        assert_empty Matcher.new(context).match
+      end
+
+      test "topics without a primary agent still route by expression" do
+        @ai_agent.update!(routing_expression: "true")
+        topic = @creative.topics.create!(name: "Unassigned", user: @user)
+
+        context = {
+          "event_name" => "comment_created",
+          "creative" => { "id" => @creative.id },
+          "topic" => { "id" => topic.id }
+        }
+
+        assert_equal [ @ai_agent ], Matcher.new(context).match
+      end
+
+      private
+
+      def build_agent(routing_expression:)
+        User.create!(
+          name: "Agent #{SecureRandom.hex(3)}",
+          email: "agent_#{SecureRandom.hex(4)}@example.com",
+          password: "password",
+          llm_vendor: "openai",
+          searchable: true,
+          routing_expression: routing_expression
+        )
+      end
+
+      def grant_feedback(agent, creative: @creative)
+        share = CreativeShare.find_or_create_by!(creative: creative, user: agent)
+        share.update!(permission: "feedback")
+        CreativeSharesCache.find_or_create_by!(
+          creative_id: creative.id, user_id: agent.id, permission: :feedback
+        )
+      end
     end
   end
 end

--- a/engines/collavre/test/services/comments/topic_command_test.rb
+++ b/engines/collavre/test/services/comments/topic_command_test.rb
@@ -180,6 +180,20 @@ module Collavre
         assert_match(/Release Topic/, result)
       end
 
+      # A session topic's primary agent is its identity, not a routing pin, so
+      # /topic must neither release nor reassign it.
+      test "leaves a session topic's primary agent untouched" do
+        existing = Topic.create!(creative: @creative, user: @user, name: "Session Topic")
+        existing.set_primary_agent!(@ai_agent)
+        existing.update!(session_id: "sess-xyz789")
+
+        comment = create_comment('/topic "Session Topic"')
+        result = TopicCommand.new(comment: comment, user: @user).call
+
+        assert_equal @ai_agent.id, existing.reload.primary_agent_id
+        assert_match(/Session Topic/, result)
+      end
+
       test "reports already exists when topic exists without agent mention" do
         Topic.create!(creative: @creative, user: @user, name: "Duplicate Topic")
         comment = create_comment('/topic "Duplicate Topic"')

--- a/engines/collavre/test/services/comments/topic_command_test.rb
+++ b/engines/collavre/test/services/comments/topic_command_test.rb
@@ -168,6 +168,18 @@ module Collavre
         assert_equal @ai_agent.id, existing.primary_agent_id
       end
 
+      test "releases primary agent when existing assigned topic is named without a mention" do
+        existing = Topic.create!(creative: @creative, user: @user, name: "Release Topic")
+        existing.set_primary_agent!(@ai_agent)
+
+        comment = create_comment('/topic "Release Topic"')
+        result = TopicCommand.new(comment: comment, user: @user).call
+
+        existing.reload
+        assert_nil existing.primary_agent_id
+        assert_match(/Release Topic/, result)
+      end
+
       test "reports already exists when topic exists without agent mention" do
         Topic.create!(creative: @creative, user: @user, name: "Duplicate Topic")
         comment = create_comment('/topic "Duplicate Topic"')

--- a/engines/collavre/test/services/comments/topic_command_test.rb
+++ b/engines/collavre/test/services/comments/topic_command_test.rb
@@ -142,6 +142,62 @@ module Collavre
         assert_equal @ai_agent.id, @topic.reload.primary_agent_id
       end
 
+      # The pin decides who may speak in the topic, so changing it is a routing
+      # change: TopicsController#set_primary_agent requires :write. Comments are
+      # authorized at :feedback, so without this gate commenting access would be
+      # enough to redirect an existing topic from chat.
+      test "refuses to release an assignment for a commenter without write access" do
+        @topic.set_primary_agent!(@ai_agent)
+        commenter = users(:two)
+        CreativeShare.create!(creative: @creative, user: commenter, shared_by: @user, permission: :feedback)
+        comment = create_comment('/topic "Test Topic"', user: commenter)
+
+        result = TopicCommand.new(comment: comment, user: commenter).call
+
+        assert_match(/write permission/i, result)
+        assert_equal @ai_agent.id, @topic.reload.primary_agent_id
+      end
+
+      test "refuses to reassign an existing topic for a commenter without write access" do
+        @topic.set_primary_agent!(@ai_agent)
+        other_agent = User.create!(
+          email: "otheragent@test.local", password: "password123", name: "OtherAgent",
+          llm_vendor: "openai", llm_model: "gpt-4", searchable: true
+        )
+        CreativeShare.create!(creative: @creative, user: other_agent, shared_by: @user, permission: :feedback)
+        commenter = users(:two)
+        CreativeShare.create!(creative: @creative, user: commenter, shared_by: @user, permission: :feedback)
+        comment = create_comment('/topic "Test Topic" @OtherAgent: ', user: commenter)
+
+        result = TopicCommand.new(comment: comment, user: commenter).call
+
+        assert_match(/write permission/i, result)
+        assert_equal @ai_agent.id, @topic.reload.primary_agent_id
+      end
+
+      test "lets a write collaborator release an assignment" do
+        @topic.set_primary_agent!(@ai_agent)
+        collaborator = users(:two)
+        CreativeShare.create!(creative: @creative, user: collaborator, shared_by: @user, permission: :write)
+        comment = create_comment('/topic "Test Topic"', user: collaborator)
+
+        TopicCommand.new(comment: comment, user: collaborator).call
+
+        assert_nil @topic.reload.primary_agent_id
+      end
+
+      # The gate must cover only the assignment write — naming an unassigned
+      # topic still just reports that it exists, which commenters may do.
+      test "still reports an unassigned existing topic to a commenter without write access" do
+        commenter = users(:two)
+        CreativeShare.create!(creative: @creative, user: commenter, shared_by: @user, permission: :feedback)
+        comment = create_comment('/topic "Test Topic"', user: commenter)
+
+        result = TopicCommand.new(comment: comment, user: commenter).call
+
+        assert_match(/already exists/i, result)
+      end
+
       test "returns error when topic name is missing" do
         comment = create_comment("/topic")
 
@@ -239,11 +295,11 @@ module Collavre
 
       private
 
-      def create_comment(content)
+      def create_comment(content, user: @user)
         Collavre::Comment.create!(
           creative: @creative,
           topic: @topic,
-          user: @user,
+          user: user,
           content: content
         )
       end

--- a/engines/collavre/test/services/comments/topic_command_test.rb
+++ b/engines/collavre/test/services/comments/topic_command_test.rb
@@ -327,6 +327,31 @@ module Collavre
         assert_match(/Session Topic/, result)
       end
 
+      # The inbox share registration creates puts a Claude Channel agent in
+      # User.mentionable_for even though it is searchable: false, so `/topic`
+      # can name one. Matcher only routes it in its own session topic, so
+      # pinning it on an ordinary inbox topic would mute that topic entirely.
+      test "refuses a Claude Channel session agent on an ordinary inbox topic" do
+        inbox = Creative.inbox_for(@user)
+        session_agent = User.create!(
+          email: "cc-cmd@test.local", password: "password123", name: "ClaudeChannelDev",
+          llm_vendor: "anthropic", llm_model: "claude-code", searchable: false,
+          created_by_id: @user.id
+        )
+        CreativeShare.create!(creative: inbox, user: session_agent, shared_by: @user, permission: :feedback)
+        inbox_topic = Topic.create!(creative: inbox, user: @user, name: "Inbox Command Topic")
+        comment = Collavre::Comment.create!(
+          creative: inbox, topic: inbox_topic, user: @user,
+          content: '/topic "Inbox Command Topic" @ClaudeChannelDev: '
+        )
+
+        result = TopicCommand.new(comment: comment, user: @user).call
+
+        assert_nil inbox_topic.reload.primary_agent_id
+        assert_equal I18n.t("collavre.comments.topic_command.session_agent_not_assignable",
+                            agent: session_agent.display_name), result
+      end
+
       test "reports already exists when topic exists without agent mention" do
         Topic.create!(creative: @creative, user: @user, name: "Duplicate Topic")
         comment = create_comment('/topic "Duplicate Topic"')

--- a/engines/collavre/test/services/comments/topic_command_test.rb
+++ b/engines/collavre/test/services/comments/topic_command_test.rb
@@ -15,6 +15,9 @@ module Collavre
           llm_model: "gpt-4",
           searchable: true
         )
+        # Pinning requires the agent to be able to answer here (see
+        # Topic.primary_agent_assignable?), so the agent under test is shared.
+        CreativeShare.create!(creative: @creative, user: @ai_agent, shared_by: @user, permission: :feedback)
         @topic = Topic.create!(creative: @creative, user: @user, name: "Test Topic")
       end
 
@@ -107,6 +110,36 @@ module Collavre
         # No primary agent should be set
         topic = Topic.find_by(creative: @creative, name: "No Agent Topic")
         assert_nil topic.primary_agent_id
+      end
+
+      # User.mentionable_for resolves every searchable agent, shared or not, so
+      # /topic could otherwise pin an agent that cannot answer — which mutes the
+      # topic outright, since the pin also excludes every other agent.
+      test "refuses to pin an agent that has no feedback access on the creative" do
+        outsider = User.create!(
+          email: "outsider@test.local", password: "password123", name: "OutsiderAgent",
+          llm_vendor: "openai", llm_model: "gpt-4", searchable: true
+        )
+        comment = create_comment('/topic "Outsider Topic" @OutsiderAgent: ')
+
+        result = TopicCommand.new(comment: comment, user: @user).call
+
+        assert_match(/OutsiderAgent/, result)
+        assert_not Topic.exists?(creative: @creative, name: "Outsider Topic")
+        assert_nil Topic.find_by(primary_agent_id: outsider.id)
+      end
+
+      test "leaves an existing topic's agent untouched when the mention has no access" do
+        @topic.set_primary_agent!(@ai_agent)
+        outsider = User.create!(
+          email: "outsider2@test.local", password: "password123", name: "OutsiderAgent2",
+          llm_vendor: "openai", llm_model: "gpt-4", searchable: true
+        )
+        comment = create_comment('/topic "Test Topic" @OutsiderAgent2: ')
+
+        TopicCommand.new(comment: comment, user: @user).call
+
+        assert_equal @ai_agent.id, @topic.reload.primary_agent_id
       end
 
       test "returns error when topic name is missing" do

--- a/engines/collavre/test/services/comments/topic_command_test.rb
+++ b/engines/collavre/test/services/comments/topic_command_test.rb
@@ -186,6 +186,50 @@ module Collavre
         assert_nil @topic.reload.primary_agent_id
       end
 
+      # Creating the topic in the same breath does not make the assignment any
+      # less of a routing decision: the new topic opens with an exclusive pin,
+      # so every other agent is silenced there from the first message. REST
+      # topic creation with an agent_id sits behind :write for the same reason.
+      test "refuses to create a topic with an agent for a commenter without write access" do
+        commenter = users(:two)
+        CreativeShare.create!(creative: @creative, user: commenter, shared_by: @user, permission: :feedback)
+        comment = create_comment('/topic "Pinned New Topic" @TestAgent: ', user: commenter)
+
+        result = TopicCommand.new(comment: comment, user: commenter).call
+
+        assert_match(/write permission/i, result)
+        assert_not Topic.exists?(creative: @creative, name: "Pinned New Topic"),
+                   "a refused command must not leave the topic behind"
+      end
+
+      test "lets a write collaborator create a topic with an agent" do
+        collaborator = users(:two)
+        CreativeShare.create!(creative: @creative, user: collaborator, shared_by: @user, permission: :write)
+        comment = create_comment('/topic "Collaborator Topic" @TestAgent: ', user: collaborator)
+
+        TopicCommand.new(comment: comment, user: collaborator).call
+
+        topic = Topic.find_by(creative: @creative, name: "Collaborator Topic")
+        assert topic, "write collaborator must still be able to create the topic"
+        assert_equal @ai_agent.id, topic.primary_agent_id
+      end
+
+      # Only the assignment is gated. Creating a plain topic from chat has always
+      # been available at :feedback and writes no pin, so ambient routing at the
+      # new topic is unchanged — that stays open.
+      test "still creates an unassigned topic for a commenter without write access" do
+        commenter = users(:two)
+        CreativeShare.create!(creative: @creative, user: commenter, shared_by: @user, permission: :feedback)
+        comment = create_comment('/topic "Plain New Topic"', user: commenter)
+
+        result = TopicCommand.new(comment: comment, user: commenter).call
+
+        assert_match(/Plain New Topic/, result)
+        topic = Topic.find_by(creative: @creative, name: "Plain New Topic")
+        assert topic, "a commenter may still open a topic with no assignment"
+        assert_nil topic.primary_agent_id
+      end
+
       # The gate must cover only the assignment write — naming an unassigned
       # topic still just reports that it exists, which commenters may do.
       test "still reports an unassigned existing topic to a commenter without write access" do


### PR DESCRIPTION
## Problem

Registering a few agents at the top of a project (developer1, developer2, reviewer1) made **every one of them speak on every message in every task below it**, and each reply re-triggered the others. Four symptoms, one cause:

1. **All agents fire at once.** With no routing rule authored, the "auto" trigger is `event_name == "comment_created"` — true for every comment.
2. **`no_access` is the only mute.** There was no vocabulary for "don't speak here", so silencing an agent meant revoking its access — sacrificing visibility to buy silence.
3. **Interlopers cut in.** After @mentioning one agent to talk to it, others kept joining.
4. **System events fan out.** A `pr_monitor` comment woke every matching agent.

The root cause is that one axis — the agent's global `routing_expression` — was being asked to answer four different questions: *may it see this?*, *is it on this task?*, *what wakes it?*, and *who speaks now?*

## Approach

Rather than introduce a new concept, promote the **topic primary agent** that already exists into the assignment mechanism. Pinning an agent to a topic now means "this agent handles this topic":

- The primary responds to **every** event in the topic, overriding its own `routing_expression`. Pinning is enough — no rule authoring.
- Every other agent stays silent on ambient events **even when its expression matches**. They are demoted to explicit invitation, not muted: an `@mention` still routes to them, so a one-off question needs no configuration.
- **Access is untouched.** Agents keep their `feedback` permission and stay visible; only the floor is restricted.

## What was actually broken

`PolicyResolver` already switched to `primary_first` whenever a topic had a primary agent, so the infrastructure looked correct. Three gaps stopped it working:

| Where | Was | Now |
|---|---|---|
| `matcher.rb` | Agents with a blank `routing_expression` were filtered out, so a mention-only primary never entered the candidate list | Primary agent is matched directly, ahead of expression routing |
| `arbiter.rb` | `primary_first` fell back to `candidates.take(1)`, so with the primary absent an **arbitrary other agent took the floor** — exactly the interloper the pin should keep out | Stays silent (`[]`) |
| `arbiter.rb` | A topic pin forces `primary_first`, which would have **dropped a mention of any other agent** | Mentions bypass arbitration, as review routing already does |

## Release path

The assignment is now exclusive, so it needs a way back off. All three places a pin can be made get one:

- **Click the agent avatar** on the topic tag (with a confirmation dialog).
- **`PATCH set_primary_agent` with a blank `agent_id`.** The response always carries `primary_agent` — `null` when cleared — because the client merges the payload into its cached topic, and an omitted key would leave a stale avatar on screen.
- **`/topic "name"` with no `@mention`** on an already-assigned topic.

## Behavior change to be aware of

On a topic **with** a primary agent, system comments (PR monitor events, etc.) now reach **only that agent**. To keep a PR analyzer responding on a pinned topic, pin that analyzer or `@mention` it. Topics **without** a primary agent keep the previous expression-based routing unchanged.

## Tests

- `matcher_test.rb` — primary responds with no expression / with a false expression; silences other matching agents; mention of a non-primary still routes; **no fall-through to expression routing when the primary lacks permission** (which would hand the floor to exactly the agents being excluded); unassigned topics unchanged.
- `arbiter_test.rb` — mention bypass under a topic pin; primary takes the floor; the `take(1)` fallback test flipped to assert silence.
- `topics_controller_test.rb` — blank `agent_id` clears, response carries `primary_agent: null`.
- `topic_command_test.rb` — `/topic "name"` releases an assigned topic.
- `topics_controller_primary_agent.test.js` — avatar renders as a release control only for managers; PATCHes `agent_id: null`; declining the confirm is a no-op; the click does not fall through to selecting the topic.

Full suite: 2952 runs, 9263 assertions, 0 failures. JS: 683 tests, 0 failures. Rubocop clean; stylelint unchanged from baseline.

## Follow-up (not in this PR)

This covers per-topic assignment. The remaining piece from the discussion is **inheritance** — setting a team once on a parent creative and having it apply to every task below, with per-task overrides, surfaced in the share modal alongside the permission row.