### PR TITLE
feat: coalesce un-started agent tasks for burst chat messages

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_24_090000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_27_000000) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -189,6 +189,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_24_090000) do
     t.integer "topic_id"
     t.datetime "updated_at", null: false
     t.integer "user_id"
+    t.string "waiting_notice_scope"
+    t.integer "waiting_notice_task_id"
     t.index ["action_executed_by_id"], name: "index_comments_on_action_executed_by_id"
     t.index ["approver_id"], name: "index_comments_on_approver_id"
     t.index ["creative_id", "created_at"], name: "index_comments_on_creative_id_and_created_at"

--- a/docs/superpowers/specs/2026-07-27-pending-task-coalescing.md
+++ b/docs/superpowers/specs/2026-07-27-pending-task-coalescing.md
@@ -113,7 +113,15 @@ to one comment, not one more message in the burst: `AiAgentService` and
 `ResponseFinalizer` read review behaviour off the surviving anchor alone, so
 folding across that boundary degrades an absorbed review into a normal reply and
 lets a surviving review overwrite its quoted comment with text answering an
-unrelated message.
+unrelated message. `refresh_deferred_context!` leaves a review anchor where it
+is for the same reason — but not moving it is not the same as not checking it.
+An ordinary anchor is revalidated by having to be re-selected through the
+eligibility scope, so the review branch asks the same question directly
+(`MergedTriggerComments.in_turn`) and cancels the turn when the answer is no.
+The anchor is the one part of the payload rendered without a filter and
+`ReviewHandler#eligible?` only inspects the *quoted* comment's privacy, so a
+review request withdrawn while it waited would otherwise still be delivered from
+cache and still drive an in-place revision.
 
 ### Call sites
 
@@ -208,21 +216,36 @@ be N dead ends pointing at one blocker.
   promotion drains a `queued` waiter, so a notice posted after that cleanup
   describes a wait that is over and nothing will ever take it down.
 - `with_deduped_topic_notice` is that plus the existence check, taken only when
-  `coalesce_pending_tasks?` is true. Both enqueue doors resolve the policy from
-  the dispatch's own context, so a topic where one agent coalesces and another
-  does not gets the right answer per dispatch.
-- Cleanup is `cleanup_waiting_notices_if_drained!`: promotion removes the notice
-  only after confirming under the topic lock that no `queued` waiter remains.
-  With `topic_max > 1`, promoting one agent can leave another agent's waiter
-  behind, and `coalesce_promoted!` folds same-agent siblings only.
-- `Comment#cancel_queued_tasks_for_waiting_notice` cancels **every** queued
-  waiter in the scope when the deleted notice was the deduplicated one, and
-  falls back to the single newest waiter otherwise. Which kind it was is read off
-  the topic (a sibling notice still standing means this one was never the only
-  signal) via `topic_concurrency_notice_exists?` — the same predicate that
-  decides whether to post one, so the two cannot drift. `queued` only: a
-  `pending`/`running` task is the blocker, not a waiter, and is surfaced
-  separately with its own stop control.
+  `coalesce_pending_tasks_for?(agent)` is true. Both enqueue doors resolve the
+  policy from the dispatch's own context *and its agent*, so a topic where one
+  agent coalesces and another does not gets the right answer per dispatch.
+- **The kind is recorded, not inferred.** `comments.waiting_notice_scope` is
+  `"topic"` for the deduplicated notice and `"task"` for a per-deferral one,
+  which also carries `waiting_notice_task_id`. Classifying by "is a sibling
+  notice still standing?" holds only while a topic has one kind at a time, and
+  the two coexist as soon as the policy differs between agents or changes
+  mid-wait: the shared notice then reads as a per-deferral one and takes down the
+  newest queued waiter — which is very likely the one the *other* notice speaks
+  for. `nil` is a notice posted before this was recorded and keeps the old
+  behaviour; widening it would discard work, narrowing it would disarm the only
+  stop control an in-flight wait has.
+- `topic_concurrency_notice_exists?` counts `"topic"` and legacy notices only. A
+  per-deferral notice speaks for one waiter, so letting it answer would leave a
+  coalescing agent's waiters with no notice whenever an opted-out agent deferred
+  into the topic first.
+- Cleanup is `cleanup_waiting_notices_if_drained!`: promotion removes the
+  *shared* notice only after confirming under the topic lock that no `queued`
+  waiter remains. With `topic_max > 1`, promoting one agent can leave another
+  agent's waiter behind, and `coalesce_promoted!` folds same-agent siblings only.
+  A per-deferral notice is not subject to that question — `cleanup_waiter_notice!`
+  takes down the promoted waiter's own notice unconditionally, or it would keep
+  offering a stop button for a turn that is already running.
+- `Comment#cancel_queued_tasks_for_waiting_notice` cancels, for a `"topic"`
+  notice, every queued waiter in the scope except those a surviving `"task"`
+  notice still speaks for; for a `"task"` notice, exactly its own waiter; and for
+  a legacy one, the single newest waiter. `queued` only: a `pending`/`running`
+  task is the blocker, not a waiter, and is surfaced separately with its own stop
+  control.
 
 ### Message assembly
 
@@ -252,7 +275,12 @@ the single `:trigger` message carries every merged comment.
 ### Policy
 
 `scheduling.coalesce_pending_tasks` (default `true`), reachable as
-`PolicyResolver#coalesce_pending_tasks?`, so a creative or topic can opt out.
+`PolicyResolver#coalesce_pending_tasks_for?(agent)`, so a creative, topic **or
+agent** can opt out. Agent scope is the granularity of the thing being switched —
+coalescing folds same-agent siblings — and `#scheduling_config` excludes agent
+policies by construction, so the agent-less predicate this replaces could only
+ever ignore a User-scoped opt-out. There is deliberately no agent-less variant
+left to fall back to.
 The opt-out is a real configuration with its own semantics, not "the feature
 off": each deferral keeps its own waiter *and* its own notice, and deleting one
 notice cancels one waiter. It does **not** disable `topic_max_concurrent_jobs`,

--- a/docs/superpowers/specs/2026-07-27-pending-task-coalescing.md
+++ b/docs/superpowers/specs/2026-07-27-pending-task-coalescing.md
@@ -131,7 +131,12 @@ cache and still drive an in-place revision.
    what makes `id < keep.id` read as "everything already parked".
 2. `AiAgentJob#admit_or_defer!` — the late-admission door. `TopicSlot.lock!`,
    `TopicSlot.available_for?`, and `Task.create!` (as `running` or `queued`) are
-   one transaction, so the decision and the insert cannot be separated.
+   one transaction, so the decision and the insert cannot be separated. The
+   loop breaker is recorded around this call rather than after it: the turn is
+   counted where its row is created, so losing the admission race parks the
+   dispatch without hiding it from the creative-retry threshold. The promotion
+   that later runs it enters the resumed-`Task` branch, which records nothing —
+   counting there instead would double-count every `pending_approval` resume.
 3. `AgentOrchestrator.coalesce_promoted!` — after a waiter is promoted
    (`scope: :all`).
 4. `AgentOrchestrator.coalesce_at_start!` — under the topic lock immediately
@@ -270,7 +275,12 @@ be N dead ends pointing at one blocker.
   notice still speaks for; for a `"task"` notice, exactly its own waiter; and for
   a legacy one, the single newest waiter. `queued` only: a `pending`/`running`
   task is the blocker, not a waiter, and is surfaced separately with its own stop
-  control.
+  control. It then asks `Comment.remove_stranded_waiting_notices!`: cancelling is
+  the other way a topic queue empties, and unlike a promotion it runs no drained
+  check, so a *shared* notice — the only kind that check ever removes — would be
+  left describing a wait that is over. Scoped to `topic_concurrency_defer`
+  notices, since a `:delayed` one shares the prefix but explains a dispatch that
+  is still going to run.
 
 ### Message assembly
 

--- a/docs/superpowers/specs/2026-07-27-pending-task-coalescing.md
+++ b/docs/superpowers/specs/2026-07-27-pending-task-coalescing.md
@@ -251,18 +251,20 @@ be N dead ends pointing at one blocker.
   offering a stop button for a turn that is already running.
 - **A `"task"` notice lives exactly as long as its waiter is queued**, so it
   comes down at every door that takes that waiter out of the queue — promotion,
-  the fold, and a deleted anchor. `TaskCoalescer` removes the notices naming the
-  tasks it absorbs, in the same transaction as the cancellation. Nothing else
-  would: the cancelled task is never promoted, so `cleanup_waiter_notice!` never
-  runs for it, and the drained sweep needs the topic queue to empty — which the
-  survivor of that very fold prevents. Reachable whenever the policy is off
-  when a waiter defers and on by the time the next one folds it.
-  `Comment#cancel_pending_tasks` is the third door and needs no policy change at
-  all: with the opt-out alone, deleting the comment a waiter answers cancels it
-  the same way, and a sibling still parked keeps the sweep from running. It only
-  applies once the task is actually cancelled — a re-anchored waiter is still
-  queued and keeps its notice. All three callers go through
-  `Comment.remove_waiter_notices!` rather than each spelling the query out.
+  the fold, a deleted anchor, and the user's own stop button. `TaskCoalescer`
+  removes the notices naming the tasks it absorbs, in the same transaction as
+  the cancellation. Nothing else would: the cancelled task is never promoted, so
+  `cleanup_waiter_notice!` never runs for it, and the drained sweep needs the
+  topic queue to empty — which the survivor of that very fold prevents.
+  Reachable whenever the policy is off when a waiter defers and on by the time
+  the next one folds it. The remaining doors need no policy change at all: with
+  the opt-out alone, `Comment#cancel_pending_tasks` (deleting the comment a
+  waiter answers) and `TasksController#cancel` (which whitelists `queued`) each
+  cancel a waiter the same way, and a sibling still parked keeps the sweep from
+  running. The anchor door applies only once the task is actually cancelled — a
+  re-anchored waiter is still queued and keeps its notice. All four callers go
+  through `Comment.remove_waiter_notices!` rather than each spelling the query
+  out.
 - `Comment#cancel_queued_tasks_for_waiting_notice` cancels, for a `"topic"`
   notice, every queued waiter in the scope except those a surviving `"task"`
   notice still speaks for; for a `"task"` notice, exactly its own waiter; and for

--- a/docs/superpowers/specs/2026-07-27-pending-task-coalescing.md
+++ b/docs/superpowers/specs/2026-07-27-pending-task-coalescing.md
@@ -211,11 +211,20 @@ At most one "⏳" topic-concurrency notice per `(creative, topic)` **when
 coalescing is on**. Coalescing absorbs the waiters behind it, so N notices would
 be N dead ends pointing at one blocker.
 
-- `with_live_topic_wait` (both branches) holds `TopicSlot.lock!` and refuses to
-  post a notice once the queue has drained — removal only happens when a
-  promotion drains a `queued` waiter, so a notice posted after that cleanup
-  describes a wait that is over and nothing will ever take it down.
-- `with_deduped_topic_notice` is that plus the existence check, taken only when
+- `with_live_topic_wait` holds `TopicSlot.lock!` and refuses to post a notice
+  once the queue has drained — removal only happens when a promotion drains a
+  `queued` waiter, so a notice posted after that cleanup describes a wait that is
+  over and nothing will ever take it down.
+- `with_live_waiter` is the same guard asked of **one** waiter, and is what the
+  per-deferral branch of both doors takes. "Is anyone still waiting?" is the
+  shared notice's question; a per-deferral notice answers for the waiter it names,
+  and that waiter can be promoted between its row committing and the notice going
+  up (two steps on both doors). Another deferral parked in the same burst keeps
+  the topic-wide answer `true`, so the narrower question is the one that matches
+  what the notice claims — otherwise the notice offers a stop button for a turn
+  already running, `cleanup_waiter_notice!` has already run and matched nothing,
+  and deleting it by hand cancels nothing either.
+- `with_deduped_topic_notice` is `with_live_topic_wait` plus the existence check, taken only when
   `coalesce_pending_tasks_for?(agent)` is true. Both enqueue doors resolve the
   policy from the dispatch's own context *and its agent*, so a topic where one
   agent coalesces and another does not gets the right answer per dispatch.

--- a/docs/superpowers/specs/2026-07-27-pending-task-coalescing.md
+++ b/docs/superpowers/specs/2026-07-27-pending-task-coalescing.md
@@ -250,15 +250,19 @@ be N dead ends pointing at one blocker.
   takes down the promoted waiter's own notice unconditionally, or it would keep
   offering a stop button for a turn that is already running.
 - **A `"task"` notice lives exactly as long as its waiter is queued**, so it
-  comes down at every door that takes that waiter out of the queue — promotion
-  *and* the fold. `TaskCoalescer` removes the notices naming the tasks it
-  absorbs, in the same transaction as the cancellation. Nothing else would:
-  the cancelled task is never promoted, so `cleanup_waiter_notice!` never runs
-  for it, and the drained sweep needs the topic queue to empty — which the
+  comes down at every door that takes that waiter out of the queue — promotion,
+  the fold, and a deleted anchor. `TaskCoalescer` removes the notices naming the
+  tasks it absorbs, in the same transaction as the cancellation. Nothing else
+  would: the cancelled task is never promoted, so `cleanup_waiter_notice!` never
+  runs for it, and the drained sweep needs the topic queue to empty — which the
   survivor of that very fold prevents. Reachable whenever the policy is off
-  when a waiter defers and on by the time the next one folds it. Both callers
-  go through `Comment.remove_waiter_notices!` rather than each spelling the
-  query out.
+  when a waiter defers and on by the time the next one folds it.
+  `Comment#cancel_pending_tasks` is the third door and needs no policy change at
+  all: with the opt-out alone, deleting the comment a waiter answers cancels it
+  the same way, and a sibling still parked keeps the sweep from running. It only
+  applies once the task is actually cancelled — a re-anchored waiter is still
+  queued and keeps its notice. All three callers go through
+  `Comment.remove_waiter_notices!` rather than each spelling the query out.
 - `Comment#cancel_queued_tasks_for_waiting_notice` cancels, for a `"topic"`
   notice, every queued waiter in the scope except those a surviving `"task"`
   notice still speaks for; for a `"task"` notice, exactly its own waiter; and for

--- a/docs/superpowers/specs/2026-07-27-pending-task-coalescing.md
+++ b/docs/superpowers/specs/2026-07-27-pending-task-coalescing.md
@@ -25,11 +25,10 @@ N comments → N-1 identical answers.
 
 ### 2. Immediate dispatch races on the topic slot
 
-`Scheduler#evaluate` counts `Task.running_for_topic`, but that row is only
-created **inside** `AiAgentJob` (`ai_agent_job.rb:134`). Dispatches that arrive
-before the first job runs all see zero running tasks and are all judged
-`:immediate`, so several tasks run concurrently in one topic despite
-`topic_max_concurrent_jobs = 1`.
+`Scheduler#evaluate` counts occupants, but the task row is only created **inside**
+`AiAgentJob`. Dispatches that arrive before the first job runs all see zero
+running tasks and are all judged `:immediate`, so several tasks run concurrently
+in one topic despite `topic_max_concurrent_jobs = 1`.
 
 ### Constraint: cancelling is not enough
 
@@ -44,84 +43,208 @@ The older comments must be **merged into** the survivor, not discarded.
 Keep exactly one un-started task per `(agent, topic, creative, trigger_event)`
 and fold the superseded triggers into it.
 
+### `Orchestration::TopicSlot`
+
+One rule for who may hold a topic's concurrency slot, shared by every path that
+hands one out. Two entry points:
+
+- `TopicSlot.lock!(topic_id, creative_id)` — `SELECT ... FOR UPDATE` on one
+  stable row, so admission, promotion, folding and notice posting for one topic
+  scope all serialize against each other. `topic_id: nil` is a real scope (a
+  creative's Main topic) with no topic row, and tasks carry `topic_id` with no
+  foreign key, so a missing topic falls back to the **creative** row. Returning
+  `nil` there would run those paths with no serialization at all — silently the
+  one state the lock exists to prevent. The SQLite visitor drops the lock clause;
+  serialization is a Postgres property.
+- `TopicSlot.available_for?(agent_id, topic_id, creative_id, context)` —
+  occupancy counts `running`/`delegated` **plus** `pending` (claimed, job not
+  started) and `pending_approval` (paused, still holding the resource). A free
+  slot is not automatically *this* agent's to take: `topic_max > 1` exists to run
+  *different* agents in parallel, so an agent already in flight here waits.
+
+Deliberately **not** gated on `coalesce_pending_tasks?`. That switch governs
+whether waiters are folded, not whether `topic_max_concurrent_jobs` is enforced.
+
 ### `Orchestration::TaskCoalescer`
 
-`TaskCoalescer.coalesce!(keep_task)`:
+`TaskCoalescer.coalesce!(keep_task, scope: :older | :all)`:
 
 - Selects sibling tasks with the same `agent_id`, `topic_id`, `creative_id`,
-  `trigger_event_name`, `status: "queued"`, and `id < keep.id`, locked
-  `FOR UPDATE` inside a transaction.
-- `id < keep.id` (rather than "everything else") guarantees a survivor when two
-  dispatches coalesce concurrently: each only ever cancels strictly older rows.
-- `status: "queued"` only. A `pending` task may already be riding an enqueued
-  `AiAgentJob`; cancelling it makes that job return early **without** draining
-  the topic queue, which stalls the topic.
-- Each absorbed task is cancelled (`update!`, so the audit callbacks still run)
-  and recorded as a `TaskAction(action_type: "superseded")`.
+  `trigger_event_name` and `status: "queued"`.
+- `scope: :older` (the enqueue doors) adds `id < keep.id`, which guarantees a
+  survivor when two dispatches coalesce concurrently: each only ever cancels
+  strictly older rows. `scope: :all` (the promotion and start-of-turn doors)
+  drops the guard, because the survivor has already left `queued` — nothing can
+  cancel it, and the waiters left behind are *newer*.
+- Locks the survivor **together with** its siblings in one id-ordered statement,
+  then re-reads the survivor's status from the locked row and aborts unless it is
+  still in `UNSTARTED_STATUSES` (`queued`/`pending`). `Comment#cancel_pending_tasks`
+  can cancel the survivor from a deletion transaction that holds no lock this
+  method waits on; folding on that stale object would cancel every still-valid
+  sibling onto a task `AiAgentJob` abandons on sight. One id-ordered statement
+  rather than `keep.lock!` first: in the `:older` scope the survivor's id is
+  above every sibling's, so taking it first would descend where a concurrent
+  fold ascends — the shape a deadlock needs.
+- Sibling statuses are re-checked against the locked rows too; the id list came
+  from an unlocked read.
+- Each absorbed task is cancelled (`update!`, so audit callbacks still run) and
+  recorded as a `TaskAction(action_type: "superseded")`.
 - The absorbed comment ids — plus anything those tasks had already absorbed —
   are merged into `keep.trigger_event_payload["merged_comment_ids"]`, sorted,
-  with the surviving anchor id removed.
+  with the surviving anchor id removed. The merge reads its base payload from
+  the locked row but **writes through the caller's object**, because
+  `dequeue_next_for_topic` hands that same instance to `refresh_deferred_context!`
+  on the next line.
 
 The **newest** task survives, so the payload's `comment` stays the newest
 comment: reply anchoring, `quoted_comment` review handling, and image
 attachment all keep pointing at the message the user actually sent last.
+Ordering is by `id` alone rather than `created_at` — `created_at` is
+caller-settable, so a retraction could otherwise sort ahead of what it retracts.
 
 Coalescing is scoped **per agent**, so `topic_max_concurrent_jobs > 1` keeps
 doing what it is for: several *different* agents still run in parallel in one
 topic. Two waiters for the *same* agent in the same topic are one conversation
 turn no matter how many slots exist, so they are folded regardless of
-`topic_max`. `StuckDetector`'s multi-slot self-heal is unaffected for distinct
-agents and now absorbs same-agent stragglers instead of promoting them into a
-duplicate answer.
+`topic_max`.
+
+**Review requests neither absorb nor get absorbed.** A review is an action bound
+to one comment, not one more message in the burst: `AiAgentService` and
+`ResponseFinalizer` read review behaviour off the surviving anchor alone, so
+folding across that boundary degrades an absorbed review into a normal reply and
+lets a surviving review overwrite its quoted comment with text answering an
+unrelated message.
 
 ### Call sites
 
-1. `AgentOrchestrator#enqueue_jobs`, `:deferred` branch — right after the waiter
-   is created.
-2. `AgentOrchestrator.dequeue_next_for_topic` — after a waiter is promoted, as a
-   safety net for waiters created while the promotion was in flight.
-3. `AiAgentJob` slot check (below), after a late waiter is created.
+1. `AgentOrchestrator#park_waiter` — the `:deferred` enqueue door. Creates the
+   waiter and folds its predecessors **in one transaction under `TopicSlot.lock!`**,
+   the same lock the other enqueue door already takes. Serialized creation is
+   what makes `id < keep.id` read as "everything already parked".
+2. `AiAgentJob#admit_or_defer!` — the late-admission door. `TopicSlot.lock!`,
+   `TopicSlot.available_for?`, and `Task.create!` (as `running` or `queued`) are
+   one transaction, so the decision and the insert cannot be separated.
+3. `AgentOrchestrator.coalesce_promoted!` — after a waiter is promoted
+   (`scope: :all`).
+4. `AgentOrchestrator.coalesce_at_start!` — under the topic lock immediately
+   before execution (`scope: :all`), for waiters parked between the claim and the
+   start of the turn.
 
-`refresh_deferred_context!` becomes merge-aware: when the refreshed anchor is a
-*different* comment than the payload's current one, the previous anchor is
-pushed into `merged_comment_ids` instead of being dropped.
+### Re-anchoring
 
-### Immediate-path slot check
+`refresh_deferred_context!` is merge-aware: when the refreshed anchor is a
+*different* comment than the payload's current one, the previous anchor is pushed
+into `merged_comment_ids` instead of being dropped, and the payload's `"sender"`
+block is rebuilt with it (`ContextBuilder` fills that with `||=` and never re-runs
+on this path).
 
-In `AiAgentJob`'s new-task branch, before `Task.create!(status: "running")`:
-if the context carries a topic and
-`Task.occupying_topic_slot(topic_id, creative_id).count >= topic_max`, create a
-`queued` waiter instead of a running task, post the waiting notice, and
-coalesce. If no slot holder remains by then (the holder finished in the
-meantime), immediately `dequeue_next_for_topic` so the waiter is not orphaned.
+Two restrictions on the destination:
 
-`occupying_topic_slot` is the right scope here — unlike `running_for_topic` it
-also counts `pending` and `pending_approval`, which do hold the slot.
+- `absorbed_only:` — `coalesce_at_start!` (the call site this branch added)
+  restricts the destination to the task's own anchor plus what coalescing folded
+  into it. The topic lock orders *task creation*, not comment visibility, so a
+  comment committed before its `AiAgentJob` materializes a task would otherwise
+  be adopted here and answered again by its own waiter later. The promotion path
+  keeps its topic-wide destination, which predates this branch and is its stated
+  purpose.
+- `delivered_comment_ids` — a comment another turn of the same agent has already
+  delivered is excluded from both the destination and the merged list. A comment
+  counts as delivered by another turn only if it is in that turn's merged list,
+  or was created *after* that turn was (i.e. the turn acquired it by re-anchor);
+  a comment older than its own turn is that turn's own trigger, and counting it
+  would cancel every waiter standing behind an answered comment. Judged at
+  promotion rather than at dispatch, so a turn that dies without delivering
+  (`failed`/`cancelled`) leaves its comments answerable — rejecting the second
+  dispatch instead would turn a duplicate into a loss.
+
+`Comment#reanchor_coalesced_task` runs on anchor deletion, **before** the
+cancellation branch: the task moves onto the newest comment it absorbed rather
+than being cancelled, and only a task with nothing left to say is still
+cancelled. It takes `task.lock!` inside a transaction and re-reads the status
+there (a snapshot saying `queued` may have started since, and a started turn has
+already been handed its payload). `RecordNotFound` from the lock returns `false`
+rather than raising out of an `after_destroy_commit`. Candidates are scoped by
+`task.creative_id`/`task.topic_id` — not the deleted comment's, which
+`CommentMoveService` may have changed — and go through
+`MergedTriggerComments.in_turn`.
+
+### One scoping predicate
+
+`MergedTriggerComments.in_turn(ids, context)` carries
+`public_only.without_approval_action` plus the creative/topic scope, and is the
+single answer to "is this comment still part of this turn?". Three callers ask
+it: the renderer (what is delivered), `Matcher#permits_assignment?` (whether a
+merged mention still outranks the topic's primary-agent assignment), and the
+re-anchor (what may become the anchor). `merged_comment_ids` is a **snapshot of
+the fold**, not a standing claim — `CommentMoveService` can move a comment to
+another creative and a user can flip one to private while the burst waits, so a
+lookup by id alone would deliver content across a permission boundary. The
+anchor slot is the one part of the payload delivered without a filter, which is
+why promotion into it must ask the same question.
+
+`context.key?("topic")` rather than a presence check: `topic_id` nil is a real
+scope, so "no topic key" and "topic id nil" are different questions.
 
 ### Waiting notices
 
-At most one "⏳" topic-concurrency notice per `(creative, topic)`. Coalescing
-absorbs the waiters behind it, so N notices would be N dead ends pointing at one
-blocker. `post_waiting_notice` skips the create when such a notice already
-exists.
+At most one "⏳" topic-concurrency notice per `(creative, topic)` **when
+coalescing is on**. Coalescing absorbs the waiters behind it, so N notices would
+be N dead ends pointing at one blocker.
+
+- `with_live_topic_wait` (both branches) holds `TopicSlot.lock!` and refuses to
+  post a notice once the queue has drained — removal only happens when a
+  promotion drains a `queued` waiter, so a notice posted after that cleanup
+  describes a wait that is over and nothing will ever take it down.
+- `with_deduped_topic_notice` is that plus the existence check, taken only when
+  `coalesce_pending_tasks?` is true. Both enqueue doors resolve the policy from
+  the dispatch's own context, so a topic where one agent coalesces and another
+  does not gets the right answer per dispatch.
+- Cleanup is `cleanup_waiting_notices_if_drained!`: promotion removes the notice
+  only after confirming under the topic lock that no `queued` waiter remains.
+  With `topic_max > 1`, promoting one agent can leave another agent's waiter
+  behind, and `coalesce_promoted!` folds same-agent siblings only.
+- `Comment#cancel_queued_tasks_for_waiting_notice` cancels **every** queued
+  waiter in the scope when the deleted notice was the deduplicated one, and
+  falls back to the single newest waiter otherwise. Which kind it was is read off
+  the topic (a sibling notice still standing means this one was never the only
+  signal) via `topic_concurrency_notice_exists?` — the same predicate that
+  decides whether to post one, so the two cannot drift. `queued` only: a
+  `pending`/`running` task is the blocker, not a waiter, and is surfaced
+  separately with its own stop control.
 
 ### Message assembly
 
-`MessageBuilder`:
+`MergedTriggerComments`:
 
-- `append_trigger_message` prepends the merged comments (chronological,
-  `[speaker]: content`) above the anchor's own text, and appends their image
-  attachments to the trigger parts.
-- `append_chat_history` skips comments already folded into the trigger, so the
-  full-context path does not send them twice.
+- `prepend_to` / `append_trigger_message` renders the merged comments
+  (chronological, `[speaker]: content`) above the anchor's own text, and appends
+  their image attachments to the trigger parts.
+- `MessageBuilder#merged_comment_ids` excludes only the blocks actually
+  rendered, so `append_chat_history` does not send them twice.
+- **Size budget.** Coalescing is what makes this bite: a burst that used to
+  arrive as N separately budgeted turns is now one indivisible message, so it
+  does not degrade — the whole turn fails. `within_budget` keeps **every** block
+  and truncates each to `budget / blocks.size` (marked with `…[truncated]`).
+  Dropping the oldest blocks was tried and reverted: history caps by
+  `chat_history_limit` *count* and by *this same* size budget spread across the
+  whole conversation, accumulating oldest-first and breaking — so it cuts from
+  the end where a just-dropped burst comment sits — and `append_chat_history`
+  builds text parts only, so a dropped block's images reach the agent through no
+  path at all. No floor under the per-block share: a budget too small to say much
+  per comment is a configuration problem, not one this class should paper over by
+  discarding a user's message.
 
 This keeps `SessionContextResolver#incremental_payload` correct without change:
-the single `:trigger` message now carries every merged comment.
+the single `:trigger` message carries every merged comment.
 
 ### Policy
 
 `scheduling.coalesce_pending_tasks` (default `true`), reachable as
 `PolicyResolver#coalesce_pending_tasks?`, so a creative or topic can opt out.
+The opt-out is a real configuration with its own semantics, not "the feature
+off": each deferral keeps its own waiter *and* its own notice, and deleting one
+notice cancels one waiter. It does **not** disable `topic_max_concurrent_jobs`,
+`TopicSlot` serialization, or the drained-queue guard.
 
 ## Not doing
 
@@ -129,18 +252,40 @@ Debouncing the *first* message (waiting N seconds before the initial dispatch to
 collect a burst) would reduce a 5-comment burst to a single answer instead of
 two, but delays every ordinary conversation turn. Out of scope.
 
+Promotion's topic-wide refresh destination has the same duplicate-answer shape
+as the `coalesce_at_start!` call site, but it predates this branch (`main`'s
+`refresh_deferred_context!` already selects the newest comment in the topic) and
+ten tests pin it. Narrowing it means deciding that a waiter should answer only what
+it absorbed rather than the current state of the conversation — its own change,
+with its own reasoning.
+
 ## Test coverage
 
 - `TaskCoalescer`: absorbs older queued siblings; leaves other agents,
   creatives, topics, `trigger_event_name`s, and `pending`/`running` tasks alone;
   never cancels the newest; transitive merge of already-absorbed ids; records
-  `TaskAction`.
+  `TaskAction`; a `cancelled` survivor supersedes nothing (with a `pending`
+  survivor as the control); reviews neither absorb nor get absorbed.
+- `TopicSlot` / `AiAgentJob`: an occupied topic slot yields a queued waiter, not
+  a second running task; an emptied slot re-drains immediately; an agent already
+  holding a slot queues even with `topic_max > 1`, while a *different* agent
+  still takes the free slot; the opt-out still parks rather than starting a
+  second concurrent turn, and still posts one notice per waiter.
 - `AgentOrchestrator`: burst of 3 deferred dispatches leaves 1 queued task and
-  1 waiting notice; promotion does not re-answer an absorbed comment;
-  `refresh_deferred_context!` preserves the old anchor when it swaps.
-- `AiAgentJob`: an occupied topic slot yields a queued waiter, not a second
-  running task; an emptied slot re-drains immediately.
-- `MessageBuilder`: merged comments appear in the trigger message in order, with
-  their images; they are excluded from chat history.
+  1 waiting notice; the fold runs with the topic lock already taken and above
+  the ambient transaction depth; the notice survives a promotion that leaves
+  another agent queued, and is removed once nothing is queued; a promoted waiter
+  does not re-answer a comment an earlier turn delivered, and still advances onto
+  an unanswered newer one.
+- Re-anchoring: an anchor deleted mid-wait re-anchors onto the newest absorbed
+  comment in the *task's* creative; a moved, privated, or already-delivered
+  comment is not adopted; a stale snapshot cannot overwrite a concurrent fold; a
+  waiter with nothing absorbed is still cancelled.
+- `Matcher`: a merged mention moved out of the turn no longer licenses it, while
+  an in-scope merged mention still does.
+- `MergedTriggerComments` / `MessageBuilder`: merged comments appear in the
+  trigger in order with their images and are excluded from chat history; an
+  under-budget burst renders in full; an over-budget burst keeps every comment,
+  truncated, within the budget.
 - `PolicyResolver`: default on, overridable off; coalescing disabled restores
   the previous per-comment behaviour.

--- a/docs/superpowers/specs/2026-07-27-pending-task-coalescing.md
+++ b/docs/superpowers/specs/2026-07-27-pending-task-coalescing.md
@@ -1,0 +1,146 @@
+# Coalescing pending agent tasks for burst chat messages
+
+Date: 2026-07-27
+Branch: `feat/coalesce-pending-agent-tasks`
+
+## Problem
+
+An external event (a PR comment sync, a webhook burst) can create several
+`Collavre::Comment` rows in the same topic within milliseconds. Each one fires
+`Comment#dispatch_to_orchestration` → `AgentOrchestrator.dispatch`, so the same
+agent ends up with several tasks for one logical conversation turn. The agent
+answers N times.
+
+Two independent paths produce the duplication.
+
+### 1. Queued waiters replay the same comment
+
+`topic_max_concurrent_jobs` defaults to `1`, so comments 2..N are `:deferred`
+and each creates a `Task(status: "queued")` plus a "⏳" waiting notice.
+When the running task finishes, `dequeue_next_for_topic` promotes **one**
+waiter, and `refresh_deferred_context!` rewrites its payload to the *latest
+non-agent comment*. The agent's own replies are excluded from that lookup, so
+every waiter resolves to the **same** last comment and answers it again.
+N comments → N-1 identical answers.
+
+### 2. Immediate dispatch races on the topic slot
+
+`Scheduler#evaluate` counts `Task.running_for_topic`, but that row is only
+created **inside** `AiAgentJob` (`ai_agent_job.rb:134`). Dispatches that arrive
+before the first job runs all see zero running tasks and are all judged
+`:immediate`, so several tasks run concurrently in one topic despite
+`topic_max_concurrent_jobs = 1`.
+
+### Constraint: cancelling is not enough
+
+For session-backed agents (`supports_session?` — Claude Channel / CLI adapters)
+`SessionContextResolver#incremental_payload` sends **only** the `:trigger`
+message and drops chat history. Cancelling the older tasks and running just the
+newest would therefore silently drop the content of every intermediate comment.
+The older comments must be **merged into** the survivor, not discarded.
+
+## Solution
+
+Keep exactly one un-started task per `(agent, topic, creative, trigger_event)`
+and fold the superseded triggers into it.
+
+### `Orchestration::TaskCoalescer`
+
+`TaskCoalescer.coalesce!(keep_task)`:
+
+- Selects sibling tasks with the same `agent_id`, `topic_id`, `creative_id`,
+  `trigger_event_name`, `status: "queued"`, and `id < keep.id`, locked
+  `FOR UPDATE` inside a transaction.
+- `id < keep.id` (rather than "everything else") guarantees a survivor when two
+  dispatches coalesce concurrently: each only ever cancels strictly older rows.
+- `status: "queued"` only. A `pending` task may already be riding an enqueued
+  `AiAgentJob`; cancelling it makes that job return early **without** draining
+  the topic queue, which stalls the topic.
+- Each absorbed task is cancelled (`update!`, so the audit callbacks still run)
+  and recorded as a `TaskAction(action_type: "superseded")`.
+- The absorbed comment ids — plus anything those tasks had already absorbed —
+  are merged into `keep.trigger_event_payload["merged_comment_ids"]`, sorted,
+  with the surviving anchor id removed.
+
+The **newest** task survives, so the payload's `comment` stays the newest
+comment: reply anchoring, `quoted_comment` review handling, and image
+attachment all keep pointing at the message the user actually sent last.
+
+Coalescing is scoped **per agent**, so `topic_max_concurrent_jobs > 1` keeps
+doing what it is for: several *different* agents still run in parallel in one
+topic. Two waiters for the *same* agent in the same topic are one conversation
+turn no matter how many slots exist, so they are folded regardless of
+`topic_max`. `StuckDetector`'s multi-slot self-heal is unaffected for distinct
+agents and now absorbs same-agent stragglers instead of promoting them into a
+duplicate answer.
+
+### Call sites
+
+1. `AgentOrchestrator#enqueue_jobs`, `:deferred` branch — right after the waiter
+   is created.
+2. `AgentOrchestrator.dequeue_next_for_topic` — after a waiter is promoted, as a
+   safety net for waiters created while the promotion was in flight.
+3. `AiAgentJob` slot check (below), after a late waiter is created.
+
+`refresh_deferred_context!` becomes merge-aware: when the refreshed anchor is a
+*different* comment than the payload's current one, the previous anchor is
+pushed into `merged_comment_ids` instead of being dropped.
+
+### Immediate-path slot check
+
+In `AiAgentJob`'s new-task branch, before `Task.create!(status: "running")`:
+if the context carries a topic and
+`Task.occupying_topic_slot(topic_id, creative_id).count >= topic_max`, create a
+`queued` waiter instead of a running task, post the waiting notice, and
+coalesce. If no slot holder remains by then (the holder finished in the
+meantime), immediately `dequeue_next_for_topic` so the waiter is not orphaned.
+
+`occupying_topic_slot` is the right scope here — unlike `running_for_topic` it
+also counts `pending` and `pending_approval`, which do hold the slot.
+
+### Waiting notices
+
+At most one "⏳" topic-concurrency notice per `(creative, topic)`. Coalescing
+absorbs the waiters behind it, so N notices would be N dead ends pointing at one
+blocker. `post_waiting_notice` skips the create when such a notice already
+exists.
+
+### Message assembly
+
+`MessageBuilder`:
+
+- `append_trigger_message` prepends the merged comments (chronological,
+  `[speaker]: content`) above the anchor's own text, and appends their image
+  attachments to the trigger parts.
+- `append_chat_history` skips comments already folded into the trigger, so the
+  full-context path does not send them twice.
+
+This keeps `SessionContextResolver#incremental_payload` correct without change:
+the single `:trigger` message now carries every merged comment.
+
+### Policy
+
+`scheduling.coalesce_pending_tasks` (default `true`), reachable as
+`PolicyResolver#coalesce_pending_tasks?`, so a creative or topic can opt out.
+
+## Not doing
+
+Debouncing the *first* message (waiting N seconds before the initial dispatch to
+collect a burst) would reduce a 5-comment burst to a single answer instead of
+two, but delays every ordinary conversation turn. Out of scope.
+
+## Test coverage
+
+- `TaskCoalescer`: absorbs older queued siblings; leaves other agents,
+  creatives, topics, `trigger_event_name`s, and `pending`/`running` tasks alone;
+  never cancels the newest; transitive merge of already-absorbed ids; records
+  `TaskAction`.
+- `AgentOrchestrator`: burst of 3 deferred dispatches leaves 1 queued task and
+  1 waiting notice; promotion does not re-answer an absorbed comment;
+  `refresh_deferred_context!` preserves the old anchor when it swaps.
+- `AiAgentJob`: an occupied topic slot yields a queued waiter, not a second
+  running task; an emptied slot re-drains immediately.
+- `MessageBuilder`: merged comments appear in the trigger message in order, with
+  their images; they are excluded from chat history.
+- `PolicyResolver`: default on, overridable off; coalescing disabled restores
+  the previous per-comment behaviour.

--- a/docs/superpowers/specs/2026-07-27-pending-task-coalescing.md
+++ b/docs/superpowers/specs/2026-07-27-pending-task-coalescing.md
@@ -276,13 +276,26 @@ be N dead ends pointing at one blocker.
   per-deferral notice speaks for one waiter, so letting it answer would leave a
   coalescing agent's waiters with no notice whenever an opted-out agent deferred
   into the topic first.
-- Cleanup is `cleanup_waiting_notices_if_drained!`: promotion removes the
-  *shared* notice only after confirming under the topic lock that no `queued`
-  waiter remains. With `topic_max > 1`, promoting one agent can leave another
-  agent's waiter behind, and `coalesce_promoted!` folds same-agent siblings only.
-  A per-deferral notice is not subject to that question — `cleanup_waiter_notice!`
-  takes down the promoted waiter's own notice unconditionally, or it would keep
-  offering a stop button for a turn that is already running.
+- **A notice is on screen exactly as long as it represents a queued waiter.**
+  What it represents is `Comment#represented_queued_waiters` — the same statement
+  its stop button cancels through, so "what this notice is for" has one answer:
+  its own waiter for a `"task"` notice, every unclaimed queued waiter for a
+  shared one, the single newest waiter for a legacy one. Asked per notice, never
+  per topic: "is anything queued here?" is nobody's question, and a promotion
+  that leaves only *claimed* waiters behind reads as "still busy" while the
+  shared notice it kept up speaks for none of them — a second "⏳" line whose
+  stop button selects nothing.
+- Cleanup is `Comment.remove_stranded_waiting_notices!`, under the topic lock,
+  from every door that takes a waiter out of `queued` without promoting it:
+  promotion (`cleanup_waiting_notices_if_drained!`), a deleted anchor
+  (`Comment#cancel_pending_tasks`), the user's own stop button
+  (`TasksController#cancel`) and a dismissed notice
+  (`#cancel_queued_tasks_for_waiting_notice`). With `topic_max > 1`, promoting
+  one agent can leave another agent's waiter behind, and `coalesce_promoted!`
+  folds same-agent siblings only — an unclaimed survivor keeps the shared notice
+  up, which is what it is for. A per-deferral notice is additionally taken down
+  unconditionally by `cleanup_waiter_notice!` on the promotion of its own waiter,
+  or it would keep offering a stop button for a turn that is already running.
 - **A `"task"` notice lives exactly as long as its waiter is queued**, so it
   comes down at every door that takes that waiter out of the queue — promotion,
   the fold, a deleted anchor, and the user's own stop button. `TaskCoalescer`
@@ -304,12 +317,10 @@ be N dead ends pointing at one blocker.
   notice still speaks for; for a `"task"` notice, exactly its own waiter; and for
   a legacy one, the single newest waiter. `queued` only: a `pending`/`running`
   task is the blocker, not a waiter, and is surfaced separately with its own stop
-  control. It then asks `Comment.remove_stranded_waiting_notices!`: cancelling is
-  the other way a topic queue empties, and unlike a promotion it runs no drained
-  check, so a *shared* notice — the only kind that check ever removes — would be
-  left describing a wait that is over. Scoped to `topic_concurrency_defer`
-  notices, since a `:delayed` one shares the prefix but explains a dispatch that
-  is still going to run.
+  control. It then asks `Comment.remove_stranded_waiting_notices!`, as every
+  cancellation door does. Scoped to `topic_concurrency_defer` notices, since a
+  `:delayed` one shares the prefix but explains a dispatch that is still going to
+  run and so represents no waiter by design.
 
 ### Message assembly
 

--- a/docs/superpowers/specs/2026-07-27-pending-task-coalescing.md
+++ b/docs/superpowers/specs/2026-07-27-pending-task-coalescing.md
@@ -50,12 +50,20 @@ hands one out. Two entry points:
 
 - `TopicSlot.lock!(topic_id, creative_id)` — `SELECT ... FOR UPDATE` on one
   stable row, so admission, promotion, folding and notice posting for one topic
-  scope all serialize against each other. `topic_id: nil` is a real scope (a
-  creative's Main topic) with no topic row, and tasks carry `topic_id` with no
-  foreign key, so a missing topic falls back to the **creative** row. Returning
-  `nil` there would run those paths with no serialization at all — silently the
-  one state the lock exists to prevent. The SQLite visitor drops the lock clause;
-  serialization is a Postgres property.
+  scope all serialize against each other. `topic_id: nil` is **not** the Main
+  topic: `Creative#main_topic` is a real `Topic` row and `Comment#assign_main_topic`
+  files every topic-less comment under it, so any dispatch derived from a comment
+  names a topic. A nil scope is a dispatch with no topic at all; tasks carry
+  `topic_id` with no foreign key, so it falls back to the **creative** row.
+  Returning `nil` there would run those paths with no serialization at all —
+  silently the one state the lock exists to prevent. The SQLite visitor drops the
+  lock clause; serialization is a Postgres property.
+
+  A payload that names `nil` for a comment that *does* have a topic is therefore
+  a bug in the producer, not a scope: it buckets the turn away from the topic's
+  real slot and leaves the promotion refresh re-selecting an anchor from an empty
+  topic. Producers build the topic from the persisted row — `Comment#dispatch_payload`
+  for the ordinary paths, `comment.topic_id` in `CronActionJob`.
 - `TopicSlot.available_for?(agent_id, topic_id, creative_id, context)` —
   occupancy counts `running`/`delegated` **plus** `pending` (claimed, job not
   started) and `pending_approval` (paused, still holding the resource). A free

--- a/docs/superpowers/specs/2026-07-27-pending-task-coalescing.md
+++ b/docs/superpowers/specs/2026-07-27-pending-task-coalescing.md
@@ -138,6 +138,13 @@ into `merged_comment_ids` instead of being dropped, and the payload's `"sender"`
 block is rebuilt with it (`ContextBuilder` fills that with `||=` and never re-runs
 on this path).
 
+Both doors that move an anchor — this one and `Comment#reanchor_coalesced_task` —
+write it through `TaskCoalescer.reanchor_payload`, which also records the move
+under `acquired_comment_id`. A payload therefore *says* whether its anchor is the
+comment the task was created for, rather than leaving a later reader to infer it
+from timestamps (see `delivered_comment_ids` below). The mark is written only when
+the id actually changes, and never cleared.
+
 Two restrictions on the destination:
 
 - `absorbed_only:` — `coalesce_at_start!` (the call site this branch added)
@@ -150,9 +157,14 @@ Two restrictions on the destination:
 - `delivered_comment_ids` — a comment another turn of the same agent has already
   delivered is excluded from both the destination and the merged list. A comment
   counts as delivered by another turn only if it is in that turn's merged list,
-  or was created *after* that turn was (i.e. the turn acquired it by re-anchor);
-  a comment older than its own turn is that turn's own trigger, and counting it
-  would cancel every waiter standing behind an answered comment. Judged at
+  or is that turn's anchor *and* recorded as acquired (`acquired_comment_id`);
+  an anchor the turn was created for is its own trigger, and counting it would
+  cancel every waiter standing behind an answered comment. The distinction comes
+  from the payload rather than from `comment.created_at` against
+  `task.created_at` — those are stamped by whichever process wrote each row, so a
+  tie or a skew reads an acquired anchor as an original one (answering it twice)
+  or an original one as acquired (cancelling a waiter with no candidate left).
+  It is the same reason ordering here is by `id`. Judged at
   promotion rather than at dispatch, so a turn that dies without delivering
   (`failed`/`cancelled`) leaves its comments answerable — rejecting the second
   dispatch instead would turn a duplicate into a loss.

--- a/docs/superpowers/specs/2026-07-27-pending-task-coalescing.md
+++ b/docs/superpowers/specs/2026-07-27-pending-task-coalescing.md
@@ -249,6 +249,16 @@ be N dead ends pointing at one blocker.
   A per-deferral notice is not subject to that question — `cleanup_waiter_notice!`
   takes down the promoted waiter's own notice unconditionally, or it would keep
   offering a stop button for a turn that is already running.
+- **A `"task"` notice lives exactly as long as its waiter is queued**, so it
+  comes down at every door that takes that waiter out of the queue — promotion
+  *and* the fold. `TaskCoalescer` removes the notices naming the tasks it
+  absorbs, in the same transaction as the cancellation. Nothing else would:
+  the cancelled task is never promoted, so `cleanup_waiter_notice!` never runs
+  for it, and the drained sweep needs the topic queue to empty — which the
+  survivor of that very fold prevents. Reachable whenever the policy is off
+  when a waiter defers and on by the time the next one folds it. Both callers
+  go through `Comment.remove_waiter_notices!` rather than each spelling the
+  query out.
 - `Comment#cancel_queued_tasks_for_waiting_notice` cancels, for a `"topic"`
   notice, every queued waiter in the scope except those a surviving `"task"`
   notice still speaks for; for a `"task"` notice, exactly its own waiter; and for

--- a/docs/superpowers/specs/2026-07-27-pending-task-coalescing.md
+++ b/docs/superpowers/specs/2026-07-27-pending-task-coalescing.md
@@ -151,6 +151,27 @@ cache and still drive an in-place revision.
    before execution (`scope: :all`), for waiters parked between the claim and the
    start of the turn.
 
+### Handing the slot on
+
+Promotion moves a waiter `queued -> pending`, which *is* the slot claim, and the
+task then holds it until its `AiAgentJob` runs. A task that leaves that window
+without running must hand the slot on, or the waiters behind it sit `queued`
+until orphan recovery — nothing else re-drains a topic whose occupant is gone.
+
+The whole gap is one a user can reach: `Comment#cancel_pending_tasks` covers
+`pending`, so deleting the comment a promoted task answers cancels it, and it
+takes no lock either door waits on. So the status a caller is holding can be
+stale at any point after `claim_next_waiter` returns:
+
+- `dequeue_next_for_topic` re-reads the row once, after `coalesce_promoted!`.
+  `TaskCoalescer` re-reads the survivor under its own lock and declines to fold
+  onto a cancelled one, but declining leaves the caller's object saying
+  `pending` — the refresh would then write a payload onto a dead row and the
+  status check below would enqueue it instead of recursing.
+- `AiAgentJob`'s first guard drains before returning, for the same cancellation
+  arriving after that re-read or while the job sat in the queue. Only when the
+  payload carries a topic: a workflow subtask cancelled here never held one.
+
 ### Re-anchoring
 
 `refresh_deferred_context!` is merge-aware: when the refreshed anchor is a
@@ -359,7 +380,10 @@ with its own reasoning.
   the ambient transaction depth; the notice survives a promotion that leaves
   another agent queued, and is removed once nothing is queued; a promoted waiter
   does not re-answer a comment an earlier turn delivered, and still advances onto
-  an unanswered newer one.
+  an unanswered newer one; a survivor cancelled between the claim and the fold
+  drains the queue behind it instead of being enqueued, and so does one
+  abandoned at job start — with the controls that a healthy survivor still keeps
+  the slot it claimed, and that a cancelled task with no topic drains nothing.
 - Re-anchoring: an anchor deleted mid-wait re-anchors onto the newest absorbed
   comment in the *task's* creative; a moved, privated, or already-delivered
   comment is not adopted; a stale snapshot cannot overwrite a concurrent fold; a

--- a/engines/collavre/app/controllers/collavre/tasks_controller.rb
+++ b/engines/collavre/app/controllers/collavre/tasks_controller.rb
@@ -28,6 +28,18 @@ module Collavre
       held_slot_without_worker = %w[pending delegated pending_approval].include?(task.status)
       task.update!(status: "cancelled")
 
+      # The third door a waiter leaves the queue through without ever being
+      # promoted — "queued" is in the whitelist above, so the user's own stop
+      # button is one of them. Its "task" notice names this task, and a notice
+      # naming a task that is no longer queued cancels nothing when dismissed:
+      # a stop button for work that can no longer be stopped. Nothing else
+      # collects it either — the task is never promoted, so
+      # cleanup_waiter_notice! never runs for it, and the drained sweep needs
+      # the topic queue to empty, which any sibling waiter prevents.
+      Comment.remove_waiter_notices!(
+        creative_id: task.creative_id, topic_id: task.topic_id, task_ids: task.id
+      )
+
       if held_slot_without_worker && task.agent
         Collavre::Orchestration::ResourceTracker.for(task.agent).release!(task.id)
         Collavre::Orchestration::AgentOrchestrator.dequeue_next_for_topic(task.topic_id, task.creative_id)

--- a/engines/collavre/app/controllers/collavre/tasks_controller.rb
+++ b/engines/collavre/app/controllers/collavre/tasks_controller.rb
@@ -40,6 +40,15 @@ module Collavre
         creative_id: task.creative_id, topic_id: task.topic_id, task_ids: task.id
       )
 
+      # With coalescing on this waiter had no notice of its own — the topic's
+      # shared one spoke for it, and the call above deliberately does not touch
+      # that kind. Same stranding, one row over.
+      if task.creative_id
+        Comment.remove_stranded_waiting_notices!(
+          creative_id: task.creative_id, topic_id: task.topic_id
+        )
+      end
+
       if held_slot_without_worker && task.agent
         Collavre::Orchestration::ResourceTracker.for(task.agent).release!(task.id)
         Collavre::Orchestration::AgentOrchestrator.dequeue_next_for_topic(task.topic_id, task.creative_id)

--- a/engines/collavre/app/jobs/collavre/ai_agent_job.rb
+++ b/engines/collavre/app/jobs/collavre/ai_agent_job.rb
@@ -276,8 +276,8 @@ module Collavre
       # admission for a topic takes the same lock, so the loser reads the
       # winner's committed row.
       Task.transaction do
-        lock_topic_for_admission(topic_id)
-        admitted = !topic_slot_taken?(agent, context, topic_id, creative_id)
+        Orchestration::TopicSlot.lock!(topic_id, creative_id)
+        admitted = Orchestration::TopicSlot.available_for?(agent.id, topic_id, creative_id, context)
         task = Task.create!(attrs.merge(status: admitted ? "running" : "queued"))
       end
 
@@ -291,40 +291,6 @@ module Collavre
     # subtasks and other topic-less dispatches are not.
     def topic_admission_scoped?(context)
       context.is_a?(Hash) && context.key?("topic")
-    end
-
-    # Take the per-topic admission lock. SELECT ... FOR UPDATE on Postgres; the
-    # SQLite visitor drops the lock clause, where writes are serialized anyway.
-    def lock_topic_for_admission(topic_id)
-      return unless topic_id
-
-      Topic.lock.find_by(id: topic_id)
-    end
-
-    # Does another task already hold this topic's concurrency slot?
-    #
-    # Uses occupying_topic_slot rather than running_for_topic: `pending` (a
-    # claimed-but-not-started waiter) and `pending_approval` (paused, keeps its
-    # resource, does not drain the queue) both hold the slot, and treating them
-    # as free is exactly how a second turn slips in.
-    #
-    # Deliberately NOT gated on coalesce_pending_tasks?: that switch governs
-    # whether waiters are folded together, not whether topic_max_concurrent_jobs
-    # is enforced. Skipping admission when it is off would let a burst start one
-    # concurrent turn per comment in a topic limited to one.
-    def topic_slot_taken?(agent, context, topic_id, creative_id)
-      topic_max = Orchestration::PolicyResolver.new(context).topic_max_concurrent_jobs
-      return false unless topic_max
-
-      occupying = Task.occupying_topic_slot(topic_id, creative_id)
-      return true if occupying.count >= topic_max
-
-      # A free slot is not automatically THIS agent's to take. topic_max > 1
-      # exists to run *different* agents in parallel, so an agent that already
-      # has a turn in flight here must wait rather than answer itself twice —
-      # TaskCoalescer only folds `queued` rows and could never merge two
-      # concurrent turns after the fact.
-      occupying.where(agent_id: agent.id).exists?
     end
 
     # Finish parking a waiter created by #admit_or_defer!: fold it together with
@@ -341,12 +307,15 @@ module Collavre
         "#{waiter.id}: slot already occupied (event=#{event_name})"
       )
 
-      # The holder may have finished between the admission check and this point,
-      # which would leave the waiter with nobody left to drain it (its
-      # dequeue_next_for_topic already ran). Re-check and drain here.
-      unless Task.occupying_topic_slot(topic_id, creative_id).exists?
-        Orchestration::AgentOrchestrator.dequeue_next_for_topic(topic_id, creative_id)
-      end
+      # A holder may have finished between the admission check and this point,
+      # leaving a waiter with nobody left to drain it (its
+      # dequeue_next_for_topic already ran). Drain unconditionally: this
+      # deferral is not proof the topic is full — with topic_max > 1 an agent
+      # defers because *it* is busy while a slot sits free for someone else, and
+      # gating on "no occupants at all" would strand that waiter until the
+      # unrelated holder finishes. dequeue_next_for_topic re-checks capacity and
+      # eligibility under the admission lock, so an over-eager call is a no-op.
+      Orchestration::AgentOrchestrator.dequeue_next_for_topic(topic_id, creative_id)
 
       nil
     end

--- a/engines/collavre/app/jobs/collavre/ai_agent_job.rb
+++ b/engines/collavre/app/jobs/collavre/ai_agent_job.rb
@@ -137,19 +137,8 @@ module Collavre
         # empty topic and are all judged :immediate — several turns run at once
         # in a topic limited to one. Re-check at the moment the row is created,
         # where the answer is authoritative, and defer into the queue instead.
-        if defer_for_topic_slot?(context)
-          return defer_into_topic_queue(agent, event_name, context)
-        end
-
-        task = Task.create!(
-          name: "Response to #{event_name}",
-          status: "running",
-          trigger_event_name: event_name,
-          trigger_event_payload: context,
-          agent: agent,
-          topic_id: context&.dig("topic", "id"),
-          creative_id: context&.dig("creative", "id")
-        )
+        task = admit_or_defer!(agent, event_name, context)
+        return if task.nil?
 
         # Record task for loop breaker tracking (per-topic, skip user-initiated)
         creative_id = context&.dig("creative", "id")
@@ -259,43 +248,92 @@ module Collavre
 
     private
 
+    # Create this dispatch's Task row, either admitted (`running`) or parked as
+    # a `queued` waiter when the topic's concurrency slot is already taken.
+    #
+    # Returns the admitted task, or nil when the dispatch was deferred.
+    def admit_or_defer!(agent, event_name, context)
+      attrs = {
+        name: "Response to #{event_name}",
+        trigger_event_name: event_name,
+        trigger_event_payload: context,
+        agent: agent,
+        topic_id: context&.dig("topic", "id"),
+        creative_id: context&.dig("creative", "id")
+      }
+      return Task.create!(attrs.merge(status: "running")) unless topic_admission_scoped?(context)
+
+      topic_id = context.dig("topic", "id")
+      creative_id = context.dig("creative", "id")
+      admitted = false
+      task = nil
+
+      # Counting occupants and claiming the slot must be ONE step. Two workers
+      # starting within the same millisecond — the exact burst this job defends
+      # against — otherwise both read an occupancy below the limit before either
+      # inserts its `running` row, and the re-check reproduces the very TOCTOU
+      # race it exists to close. Serialize admission on the topic row: every
+      # admission for a topic takes the same lock, so the loser reads the
+      # winner's committed row.
+      Task.transaction do
+        lock_topic_for_admission(topic_id)
+        admitted = !topic_slot_taken?(agent, context, topic_id, creative_id)
+        task = Task.create!(attrs.merge(status: admitted ? "running" : "queued"))
+      end
+
+      return task if admitted
+
+      park_deferred_waiter(task, agent, event_name, context, topic_id, creative_id)
+      nil
+    end
+
+    # Is this dispatch subject to the topic concurrency limit at all? Workflow
+    # subtasks and other topic-less dispatches are not.
+    def topic_admission_scoped?(context)
+      context.is_a?(Hash) && context.key?("topic")
+    end
+
+    # Take the per-topic admission lock. SELECT ... FOR UPDATE on Postgres; the
+    # SQLite visitor drops the lock clause, where writes are serialized anyway.
+    def lock_topic_for_admission(topic_id)
+      return unless topic_id
+
+      Topic.lock.find_by(id: topic_id)
+    end
+
     # Does another task already hold this topic's concurrency slot?
     #
     # Uses occupying_topic_slot rather than running_for_topic: `pending` (a
     # claimed-but-not-started waiter) and `pending_approval` (paused, keeps its
     # resource, does not drain the queue) both hold the slot, and treating them
     # as free is exactly how a second turn slips in.
-    def defer_for_topic_slot?(context)
-      return false unless context.is_a?(Hash) && context.key?("topic")
-
-      resolver = Orchestration::PolicyResolver.new(context)
-      return false unless resolver.coalesce_pending_tasks?
-
-      topic_max = resolver.topic_max_concurrent_jobs
+    #
+    # Deliberately NOT gated on coalesce_pending_tasks?: that switch governs
+    # whether waiters are folded together, not whether topic_max_concurrent_jobs
+    # is enforced. Skipping admission when it is off would let a burst start one
+    # concurrent turn per comment in a topic limited to one.
+    def topic_slot_taken?(agent, context, topic_id, creative_id)
+      topic_max = Orchestration::PolicyResolver.new(context).topic_max_concurrent_jobs
       return false unless topic_max
 
-      Task.occupying_topic_slot(
-        context.dig("topic", "id"), context.dig("creative", "id")
-      ).count >= topic_max
+      occupying = Task.occupying_topic_slot(topic_id, creative_id)
+      return true if occupying.count >= topic_max
+
+      # A free slot is not automatically THIS agent's to take. topic_max > 1
+      # exists to run *different* agents in parallel, so an agent that already
+      # has a turn in flight here must wait rather than answer itself twice —
+      # TaskCoalescer only folds `queued` rows and could never merge two
+      # concurrent turns after the fact.
+      occupying.where(agent_id: agent.id).exists?
     end
 
-    # Park this dispatch as a queued waiter instead of starting a second
-    # concurrent turn, then fold it together with any waiters already parked
-    # for the same agent/topic/creative.
-    def defer_into_topic_queue(agent, event_name, context)
-      topic_id = context.dig("topic", "id")
-      creative_id = context.dig("creative", "id")
-
-      waiter = Task.create!(
-        name: "Response to #{event_name}",
-        status: "queued",
-        trigger_event_name: event_name,
-        trigger_event_payload: context,
-        agent: agent,
-        topic_id: topic_id,
-        creative_id: creative_id
-      )
-      Orchestration::TaskCoalescer.coalesce!(waiter)
+    # Finish parking a waiter created by #admit_or_defer!: fold it together with
+    # any waiters already parked for the same agent/topic/creative, and surface
+    # one "⏳" notice for the topic.
+    def park_deferred_waiter(waiter, agent, event_name, context, topic_id, creative_id)
+      if Orchestration::PolicyResolver.new(context).coalesce_pending_tasks?
+        Orchestration::TaskCoalescer.coalesce!(waiter)
+      end
       Orchestration::AgentOrchestrator.post_topic_concurrency_notice(creative_id, topic_id)
 
       Rails.logger.info(
@@ -303,7 +341,7 @@ module Collavre
         "#{waiter.id}: slot already occupied (event=#{event_name})"
       )
 
-      # The holder may have finished between the check above and this create,
+      # The holder may have finished between the admission check and this point,
       # which would leave the waiter with nobody left to drain it (its
       # dequeue_next_for_topic already ran). Re-check and drain here.
       unless Task.occupying_topic_slot(topic_id, creative_id).exists?

--- a/engines/collavre/app/jobs/collavre/ai_agent_job.rb
+++ b/engines/collavre/app/jobs/collavre/ai_agent_job.rb
@@ -57,9 +57,7 @@ module Collavre
         # exclusively someone else's.
         resumed_context = task.trigger_event_payload
         if resumed_context&.key?("topic") &&
-           !Orchestration::Matcher.new(
-             SystemEvents::ContextBuilder.new(resumed_context).build
-           ).assignment_permits?(agent)
+           !Orchestration::Matcher.permits_assignment?(resumed_context, agent)
           Rails.logger.info(
             "[AiAgentJob] Cancelling resumed task #{task.id}: topic #{task.topic_id} " \
             "is now assigned to another agent (agent=#{agent.id})"

--- a/engines/collavre/app/jobs/collavre/ai_agent_job.rb
+++ b/engines/collavre/app/jobs/collavre/ai_agent_job.rb
@@ -46,6 +46,21 @@ module Collavre
           return
         end
 
+        # A claimed task holds the topic slot as `pending` from promotion until
+        # this line, and a comment arriving in that window parks a waiter that
+        # enqueue-time coalescing cannot fold into a non-`queued` sibling. Both
+        # turns are still un-started here, so this is the last place the fold
+        # can happen — and it must run before the assignment guard below, which
+        # reads the payload this may re-anchor.
+        Orchestration::AgentOrchestrator.coalesce_at_start!(task)
+        if task.reload.status == "cancelled"
+          # The fold's re-anchor found no comment left to answer. A `pending`
+          # task holds no ResourceTracker reservation yet (reserve! is below),
+          # but it does hold the topic slot — drain or the queue stalls.
+          Orchestration::AgentOrchestrator.dequeue_next_for_topic(task.topic_id, task.creative_id)
+          return
+        end
+
         # Guard: an exclusive primary-agent assignment can also land after a task
         # has already been cleared for execution, so checking at enqueue time is
         # not sufficient. AgentOrchestrator.dequeue_next_for_topic revalidates and

--- a/engines/collavre/app/jobs/collavre/ai_agent_job.rb
+++ b/engines/collavre/app/jobs/collavre/ai_agent_job.rb
@@ -7,7 +7,19 @@ module Collavre
       if agent_id_or_task.is_a?(Task)
         # Resume existing task
         task = agent_id_or_task
-        return if task.reload.status == "cancelled"
+        if task.reload.status == "cancelled"
+          # A cancelled task can still be holding the topic slot. Promotion moves
+          # a waiter queued -> pending and enqueues this job, and the whole gap
+          # from that claim until this line is one where deleting the comment it
+          # answers cancels it (Comment#cancel_pending_tasks covers `pending`).
+          # Returning bare hands the slot to nobody, so the waiters behind it sit
+          # queued until orphan recovery. Same reason the fold's own cancelled
+          # branch below drains — this is the earlier door onto it.
+          if task.trigger_event_payload&.key?("topic")
+            Orchestration::AgentOrchestrator.dequeue_next_for_topic(task.topic_id, task.creative_id)
+          end
+          return
+        end
 
         agent = task.agent
 

--- a/engines/collavre/app/jobs/collavre/ai_agent_job.rb
+++ b/engines/collavre/app/jobs/collavre/ai_agent_job.rb
@@ -131,6 +131,16 @@ module Collavre
           return
         end
 
+        # Guard: the Scheduler's topic-concurrency check counts Task rows, but
+        # the row for an :immediate decision is only created *here*. A burst of
+        # comments dispatched before the first job runs therefore all see an
+        # empty topic and are all judged :immediate — several turns run at once
+        # in a topic limited to one. Re-check at the moment the row is created,
+        # where the answer is authoritative, and defer into the queue instead.
+        if defer_for_topic_slot?(context)
+          return defer_into_topic_queue(agent, event_name, context)
+        end
+
         task = Task.create!(
           name: "Response to #{event_name}",
           status: "running",
@@ -245,6 +255,62 @@ module Collavre
           Orchestration::AgentOrchestrator.dequeue_next_for_topic(task.topic_id, task.creative_id)
         end
       end
+    end
+
+    private
+
+    # Does another task already hold this topic's concurrency slot?
+    #
+    # Uses occupying_topic_slot rather than running_for_topic: `pending` (a
+    # claimed-but-not-started waiter) and `pending_approval` (paused, keeps its
+    # resource, does not drain the queue) both hold the slot, and treating them
+    # as free is exactly how a second turn slips in.
+    def defer_for_topic_slot?(context)
+      return false unless context.is_a?(Hash) && context.key?("topic")
+
+      resolver = Orchestration::PolicyResolver.new(context)
+      return false unless resolver.coalesce_pending_tasks?
+
+      topic_max = resolver.topic_max_concurrent_jobs
+      return false unless topic_max
+
+      Task.occupying_topic_slot(
+        context.dig("topic", "id"), context.dig("creative", "id")
+      ).count >= topic_max
+    end
+
+    # Park this dispatch as a queued waiter instead of starting a second
+    # concurrent turn, then fold it together with any waiters already parked
+    # for the same agent/topic/creative.
+    def defer_into_topic_queue(agent, event_name, context)
+      topic_id = context.dig("topic", "id")
+      creative_id = context.dig("creative", "id")
+
+      waiter = Task.create!(
+        name: "Response to #{event_name}",
+        status: "queued",
+        trigger_event_name: event_name,
+        trigger_event_payload: context,
+        agent: agent,
+        topic_id: topic_id,
+        creative_id: creative_id
+      )
+      Orchestration::TaskCoalescer.coalesce!(waiter)
+      Orchestration::AgentOrchestrator.post_topic_concurrency_notice(creative_id, topic_id)
+
+      Rails.logger.info(
+        "[AiAgentJob] Deferred agent #{agent.id} into topic #{topic_id} queue as task " \
+        "#{waiter.id}: slot already occupied (event=#{event_name})"
+      )
+
+      # The holder may have finished between the check above and this create,
+      # which would leave the waiter with nobody left to drain it (its
+      # dequeue_next_for_topic already ran). Re-check and drain here.
+      unless Task.occupying_topic_slot(topic_id, creative_id).exists?
+        Orchestration::AgentOrchestrator.dequeue_next_for_topic(topic_id, creative_id)
+      end
+
+      nil
     end
   end
 end

--- a/engines/collavre/app/jobs/collavre/ai_agent_job.rb
+++ b/engines/collavre/app/jobs/collavre/ai_agent_job.rb
@@ -310,10 +310,12 @@ module Collavre
     # any waiters already parked for the same agent/topic/creative, and surface
     # one "⏳" notice for the topic.
     def park_deferred_waiter(waiter, agent, event_name, context, topic_id, creative_id)
-      if Orchestration::PolicyResolver.new(context).coalesce_pending_tasks?
+      if Orchestration::PolicyResolver.new(context).coalesce_pending_tasks_for?(agent)
         Orchestration::TaskCoalescer.coalesce!(waiter)
       end
-      Orchestration::AgentOrchestrator.post_topic_concurrency_notice(creative_id, topic_id, context)
+      Orchestration::AgentOrchestrator.post_topic_concurrency_notice(
+        creative_id, topic_id, context, agent: agent, waiter: waiter
+      )
 
       Rails.logger.info(
         "[AiAgentJob] Deferred agent #{agent.id} into topic #{topic_id} queue as task " \

--- a/engines/collavre/app/jobs/collavre/ai_agent_job.rb
+++ b/engines/collavre/app/jobs/collavre/ai_agent_job.rb
@@ -151,17 +151,16 @@ module Collavre
         # in a topic limited to one. Re-check at the moment the row is created,
         # where the answer is authoritative, and defer into the queue instead.
         task = admit_or_defer!(agent, event_name, context)
-        return if task.nil?
 
-        # Record task for loop breaker tracking (per-topic, skip user-initiated)
-        creative_id = context&.dig("creative", "id")
-        if creative_id
-          from_ai = context&.dig("comment", "from_ai") == true
-          topic_id = context&.dig("topic", "id")
-          Orchestration::LoopBreaker.new(context).record_task(
-            creative_id, agent.id, topic_id: topic_id, triggered_by_user: !from_ai
-          )
-        end
+        # Counted where the row is created, not where the turn starts — and so
+        # before the deferral returns. Losing the admission race does not make
+        # this a different turn: the same dispatch, from the same burst, is
+        # parked instead of admitted, and the promotion that later runs it
+        # enters the resumed-Task branch above, which records nothing either. A
+        # count taken only on the winning side of a race is exactly blind to the
+        # bursts the threshold exists to catch.
+        record_loop_breaker_turn(agent, context)
+        return if task.nil?
       end
 
       # Reserve resources before starting work
@@ -298,6 +297,20 @@ module Collavre
 
       park_deferred_waiter(task, agent, event_name, context, topic_id, creative_id)
       nil
+    end
+
+    # Record a created turn for the loop breaker's creative-retry count.
+    # User-initiated messages are not loop material — a person typing twice is
+    # not a runaway — and LoopBreaker skips those itself.
+    def record_loop_breaker_turn(agent, context)
+      creative_id = context&.dig("creative", "id")
+      return unless creative_id
+
+      Orchestration::LoopBreaker.new(context).record_task(
+        creative_id, agent.id,
+        topic_id: context&.dig("topic", "id"),
+        triggered_by_user: context&.dig("comment", "from_ai") != true
+      )
     end
 
     # Is this dispatch subject to the topic concurrency limit at all? Workflow

--- a/engines/collavre/app/jobs/collavre/ai_agent_job.rb
+++ b/engines/collavre/app/jobs/collavre/ai_agent_job.rb
@@ -313,7 +313,7 @@ module Collavre
       if Orchestration::PolicyResolver.new(context).coalesce_pending_tasks?
         Orchestration::TaskCoalescer.coalesce!(waiter)
       end
-      Orchestration::AgentOrchestrator.post_topic_concurrency_notice(creative_id, topic_id)
+      Orchestration::AgentOrchestrator.post_topic_concurrency_notice(creative_id, topic_id, context)
 
       Rails.logger.info(
         "[AiAgentJob] Deferred agent #{agent.id} into topic #{topic_id} queue as task " \

--- a/engines/collavre/app/jobs/collavre/cron_action_job.rb
+++ b/engines/collavre/app/jobs/collavre/cron_action_job.rb
@@ -41,6 +41,15 @@ module Collavre
 
       # Dispatch system event to trigger agent orchestration pipeline
       # (manual because cron-initiated AI messages intentionally need dispatch)
+      #
+      # The topic comes from the persisted row, not from `topic` above. A cron
+      # scheduled against Main passes `topic_id: nil`, but Comment#assign_main_topic
+      # files the comment under the creative's real Main topic — so nil describes
+      # the *argument*, never where the comment ended up. Everything downstream
+      # believes this payload: the task's topic_id, the slot it is admitted into,
+      # and the scope AgentOrchestrator.refresh_deferred_context! re-selects an
+      # anchor from on promotion. A payload naming a topic its own comment is not
+      # in makes all three answer for an empty topic.
       SystemEvents::Dispatcher.dispatch("comment_created", {
         comment: {
           id: comment.id,
@@ -52,7 +61,7 @@ module Collavre
           description: creative.description
         },
         topic: {
-          id: topic&.id
+          id: comment.topic_id
         },
         chat: {
           content: comment.content

--- a/engines/collavre/app/models/collavre/comment.rb
+++ b/engines/collavre/app/models/collavre/comment.rb
@@ -246,6 +246,31 @@ module Collavre
     def reanchor_coalesced_task(task)
       return false unless %w[queued pending].include?(task.status)
 
+      Task.transaction { reanchor_locked_task(task) }
+    rescue ActiveRecord::RecordNotFound
+      # The task went away between the scan and the lock (a cascading delete).
+      # Nothing to rescue, and nothing left to cancel either.
+      false
+    end
+
+    # The lock body. `task` is the object cancel_pending_tasks' scan loaded, and
+    # everything derived here has to come from the row as it stands *now*:
+    # TaskCoalescer folds a sibling into this same task under a lock this path
+    # never took, so a fold committing between that scan and the write below
+    # would be overwritten by the pre-fold payload — and the absorbed sibling is
+    # already cancelled, so its comment has no task left to answer it.
+    #
+    # lock! reloads in place rather than into a second object: the caller keeps
+    # using this instance (it cancels the task when we return false), so swapping
+    # identity here would hand it stale attributes.
+    #
+    # Status is re-read for the same reason. A snapshot that said `queued` may
+    # have been promoted and started since, and a started turn has already been
+    # handed its payload — deleting the prompt must stop it, not re-target it.
+    def reanchor_locked_task(task)
+      task.lock!
+      return false unless %w[queued pending].include?(task.status)
+
       payload = task.trigger_event_payload || {}
       merged = Array(payload[Collavre::Orchestration::TaskCoalescer::PAYLOAD_KEY])
                  .compact.map(&:to_i).uniq - [ id ]
@@ -307,13 +332,35 @@ module Collavre
     # them and no stop control, and nothing reposts a notice until the next
     # deferral happens by.
     #
+    # …but only a notice that actually *was* deduplicated. With
+    # coalesce_pending_tasks off, post_waiting_notice deliberately skips the
+    # dedup path and posts one notice per deferral: there the 1:1 still holds and
+    # cancelling every queued task would let a user discard unrelated waiters by
+    # dismissing one notice, defeating the opt-out.
+    #
     # Queued only. A task holding the topic slot (pending/running/…) is not
     # waiting on anything; the notice surfaces it separately as
     # topic_blocking_task, with its own stop button.
     def cancel_queued_tasks_for_waiting_notice
       scope = Task.where(status: "queued", creative_id: creative_id)
       scope = topic_id ? scope.where(topic_id: topic_id) : scope.where(topic_id: nil)
-      scope.order(created_at: :desc).each { |task| task.update!(status: "cancelled") }
+      waiters = scope.order(created_at: :desc).to_a
+      waiters = waiters.first(1) unless deduplicated_waiting_notice?
+      waiters.each { |task| task.update!(status: "cancelled") }
+    end
+
+    # Was this notice the deduplicated one, standing for every waiter in the
+    # topic, or one of the per-deferral notices the opt-out posts?
+    #
+    # Read off the topic rather than stored on the row: the dedup path allows a
+    # topic exactly one deferred notice, so a sibling still standing here — this
+    # runs after_destroy_commit, with this notice already gone — means this one
+    # was never the topic's only signal. Asked through
+    # AgentOrchestrator.topic_concurrency_notice_exists?, the same predicate that
+    # decides whether to post one, so the two cannot drift apart.
+    def deduplicated_waiting_notice?
+      !Collavre::Orchestration::AgentOrchestrator
+        .topic_concurrency_notice_exists?(creative_id, topic_id)
     end
 
     def dispatch_to_orchestration

--- a/engines/collavre/app/models/collavre/comment.rb
+++ b/engines/collavre/app/models/collavre/comment.rb
@@ -125,6 +125,23 @@ module Collavre
       quoted_comment_id.present? && !review_type_question?
     end
 
+    # Which of `ids` are review requests, in one query. The orchestration paths
+    # that decide whether a trigger may be folded away or moved forward hold
+    # comment *ids*, not records, and run over a whole burst at once.
+    #
+    # `review_type: [nil, review]` rather than `where.not(question)`: the column
+    # is NULL for an ordinary review (only /compress-style questions set it), and
+    # SQL's `review_type != 1` drops NULL rows — which is every real review.
+    def self.review_message_ids(ids)
+      ids = Array(ids).compact.map(&:to_i).uniq
+      return [] if ids.empty?
+
+      where(id: ids)
+        .where.not(quoted_comment_id: nil)
+        .where(review_type: [ nil, review_types[:review] ])
+        .pluck(:id)
+    end
+
     # public for db migration
     def creative_snippet
       creative.creative_snippet

--- a/engines/collavre/app/models/collavre/comment.rb
+++ b/engines/collavre/app/models/collavre/comment.rb
@@ -171,6 +171,15 @@ module Collavre
       Task.where(status: %w[pending running queued delegated]).find_each do |task|
         next unless task.trigger_event_payload&.dig("comment", "id") == id
 
+        # An un-started task can be the survivor of a coalesced burst, answering
+        # several comments at once. Cancelling it because its anchor was deleted
+        # would throw away the absorbed comments too — they have no task of their
+        # own left (TaskCoalescer cancelled those) and no other delivery path
+        # (session-backed agents receive only the trigger). Re-anchor onto the
+        # newest surviving merged comment instead; only a task with nothing left
+        # to say is cancelled.
+        next if reanchor_coalesced_task(task)
+
         was_delegated = task.status == "delegated"
         task.update!(status: "cancelled")
 
@@ -207,6 +216,45 @@ module Collavre
       if waiting_notice? && topic_concurrency_defer? && !suppress_waiter_cancellation
         cancel_queued_tasks_for_waiting_notice
       end
+    end
+
+    # Move a coalesced task off this (deleted) comment and onto the newest of
+    # the comments it had absorbed. Returns true when the task was rescued, so
+    # the caller skips cancellation.
+    #
+    # Only un-started tasks: a `running`/`delegated` task has already been handed
+    # its payload, so re-anchoring changes nothing and deleting the prompt must
+    # still stop the turn.
+    def reanchor_coalesced_task(task)
+      return false unless %w[queued pending].include?(task.status)
+
+      payload = task.trigger_event_payload || {}
+      merged = Array(payload[Collavre::Orchestration::TaskCoalescer::PAYLOAD_KEY])
+                 .compact.map(&:to_i).uniq - [ id ]
+      return false if merged.empty?
+
+      # Anything else in the merge window may have been deleted too.
+      replacement = Comment.where(id: merged).order(:created_at, :id).last
+      return false unless replacement
+
+      payload = payload.merge(
+        "comment" => {
+          "id" => replacement.id,
+          "content" => replacement.content,
+          "user_id" => replacement.user_id
+        },
+        "chat" => { "content" => replacement.content }
+      )
+      # absorb_into_payload drops the new anchor from the merged list so the
+      # promoted comment is not delivered twice.
+      payload = Collavre::Orchestration::TaskCoalescer.absorb_into_payload(payload, merged)
+      task.update!(trigger_event_payload: payload)
+
+      Rails.logger.info(
+        "[Comment#cancel_pending_tasks] Re-anchored coalesced task #{task.id} from deleted " \
+        "comment #{id} to comment #{replacement.id}"
+      )
+      true
     end
 
     def cancel_queued_tasks_for_waiting_notice

--- a/engines/collavre/app/models/collavre/comment.rb
+++ b/engines/collavre/app/models/collavre/comment.rb
@@ -259,7 +259,14 @@ module Collavre
       # while the task waited (CommentMoveService#perform_move reassigns
       # creative_id) is no longer part of it, and adopting it as the anchor would
       # point the reply at a creative the agent may have no share on.
-      in_scope = Comment.where(id: merged, creative_id: creative_id, topic_id: topic_id)
+      #
+      # The turn is the TASK's scope, not this comment's. cancel_pending_tasks
+      # looks tasks up with no creative scoping precisely because a move rewrites
+      # the comment without touching the task it triggered — so an anchor moved
+      # away and then deleted would be searching the creative it was moved *to*,
+      # find nothing there, and cancel a turn whose absorbed comments are all
+      # still sitting in the creative the task belongs to.
+      in_scope = Comment.where(id: merged, creative_id: task.creative_id, topic_id: task.topic_id)
                         .order(:id).to_a
       replacement = in_scope.last
       return false unless replacement

--- a/engines/collavre/app/models/collavre/comment.rb
+++ b/engines/collavre/app/models/collavre/comment.rb
@@ -48,6 +48,37 @@ module Collavre
       end
     end
 
+    # Take the topic's remaining "⏳" defer notices down once nothing is queued
+    # behind them.
+    #
+    # A promotion asks this through
+    # AgentOrchestrator.cleanup_waiting_notices_if_drained!, which is the only
+    # thing that ever removes a *shared* notice. Cancelling a waiter is the
+    # other way the queue can empty and it runs no such check, so a shared
+    # notice can outlive every waiter it spoke for: its stop button then selects
+    # nothing, and no later promotion will come along to collect it.
+    #
+    # Scoped to topic_concurrency_defer notices. A :delayed notice shares the
+    # prefix but explains a rate-limited or busy dispatch that is still going to
+    # run, so an empty queue is not the question that governs it.
+    #
+    # Asked under the same lock the notice doors take, so "nobody is queued" is
+    # a deferral's own before-or-after rather than a guess: it either commits
+    # its waiter before this reads, and keeps its notice, or after, and posts
+    # one of its own.
+    def self.remove_stranded_waiting_notices!(creative_id:, topic_id:)
+      transaction do
+        Collavre::Orchestration::TopicSlot.lock!(topic_id, creative_id)
+        next if Task.queued_for_topic(topic_id, creative_id).exists?
+
+        where(creative_id: creative_id, topic_id: topic_id, user_id: nil,
+              topic_concurrency_defer: true).find_each do |notice|
+          notice.suppress_waiter_cancellation = true
+          notice.destroy
+        end
+      end
+    end
+
     # Use non-namespaced partial path for backward compatibility
     def to_partial_path
       "comments/comment"
@@ -431,6 +462,14 @@ module Collavre
         end
 
       waiters.each { |task| task.update!(status: "cancelled") }
+
+      # Cancelling is the other way a topic queue empties, and it has no
+      # promotion behind it to run the drained check. The notices that spoke for
+      # the waiters just cancelled went with them — this one is being destroyed,
+      # and a per-deferral sibling names a task that is now cancelled — but a
+      # *shared* notice is only ever taken down by that check, so without this
+      # it is left on screen describing a wait that is over.
+      Comment.remove_stranded_waiting_notices!(creative_id: creative_id, topic_id: topic_id)
     end
 
     def queued_topic_waiters

--- a/engines/collavre/app/models/collavre/comment.rb
+++ b/engines/collavre/app/models/collavre/comment.rb
@@ -136,11 +136,12 @@ module Collavre
       ids = Array(ids).compact.map(&:to_i).uniq
       return [] if ids.empty?
 
-      where(id: ids)
-        .where.not(quoted_comment_id: nil)
-        .where(review_type: [ nil, review_types[:review] ])
-        .pluck(:id)
+      review_messages.where(id: ids).pluck(:id)
     end
+
+    scope :review_messages, -> {
+      where.not(quoted_comment_id: nil).where(review_type: [ nil, review_types[:review] ])
+    }
 
     # public for db migration
     def creative_snippet

--- a/engines/collavre/app/models/collavre/comment.rb
+++ b/engines/collavre/app/models/collavre/comment.rb
@@ -48,19 +48,25 @@ module Collavre
       end
     end
 
-    # Take the topic's remaining "⏳" defer notices down once nothing is queued
-    # behind them.
+    # Take down every "⏳" defer notice in the topic that no longer speaks for a
+    # queued waiter.
     #
-    # A promotion asks this through
-    # AgentOrchestrator.cleanup_waiting_notices_if_drained!, which is the only
-    # thing that ever removes a *shared* notice. Cancelling a waiter is the
-    # other way the queue can empty and it runs no such check, so a shared
-    # notice can outlive every waiter it spoke for: its stop button then selects
-    # nothing, and no later promotion will come along to collect it.
+    # Asked per notice, not per topic. "Is anything queued here?" is a topic-wide
+    # question and no notice asks it: a "task" notice speaks for the one waiter
+    # it names, and a shared one for every queued waiter *except* those a
+    # surviving "task" notice claims — see #represented_queued_waiters, which
+    # this and the stop button both go through so the two cannot drift. A topic
+    # can therefore hold waiters while a notice standing in it represents none
+    # of them, and that notice is a "⏳" line whose stop button selects nothing.
+    #
+    # Nothing else collects it. A cancelled waiter is never promoted, so the
+    # promotion's cleanup never runs for it, and a promotion that leaves only
+    # claimed waiters behind is exactly the case a topic-wide drain check reads
+    # as "still busy".
     #
     # Scoped to topic_concurrency_defer notices. A :delayed notice shares the
     # prefix but explains a rate-limited or busy dispatch that is still going to
-    # run, so an empty queue is not the question that governs it.
+    # run, so it speaks for no waiter by design and is not this sweep's to take.
     #
     # Asked under the same lock the notice doors take, so "nobody is queued" is
     # a deferral's own before-or-after rather than a guess: it either commits
@@ -69,10 +75,11 @@ module Collavre
     def self.remove_stranded_waiting_notices!(creative_id:, topic_id:)
       transaction do
         Collavre::Orchestration::TopicSlot.lock!(topic_id, creative_id)
-        next if Task.queued_for_topic(topic_id, creative_id).exists?
 
         where(creative_id: creative_id, topic_id: topic_id, user_id: nil,
               topic_concurrency_defer: true).find_each do |notice|
+          next if notice.represented_queued_waiters.any?
+
           notice.suppress_waiter_cancellation = true
           notice.destroy
         end
@@ -251,6 +258,8 @@ module Collavre
     end
 
     def cancel_pending_tasks
+      stranded_scopes = []
+
       # Cancel tasks triggered by this comment (no creative_id scoping —
       # CommentMoveService can change comment.creative_id without updating
       # existing tasks, so scoping would miss moved-comment tasks).
@@ -282,6 +291,13 @@ module Collavre
           creative_id: task.creative_id, topic_id: task.topic_id, task_ids: task.id
         )
 
+        # …and with coalescing on there is no per-deferral notice to take down:
+        # the waiter's signal is the topic's *shared* one, which the call above
+        # deliberately leaves alone. If this cancellation was the last thing that
+        # notice spoke for, nothing else will ever collect it. Swept after the
+        # loop, once every task this deletion cancels has left the queue.
+        stranded_scopes << [ task.creative_id, task.topic_id ]
+
         # Delegated tasks live past their job: the AiAgentJob already returned,
         # holding the agent slot under task.id and counting against the per-topic
         # serializer. Mirror the cancel path used elsewhere to free both.
@@ -312,6 +328,14 @@ module Collavre
       # waiter is being advanced, not abandoned, and cancelling other still-queued
       # waiters would drop their work (multi-slot orphan recovery must not cancel
       # the rest).
+      stranded_scopes.uniq.each do |cancelled_creative_id, cancelled_topic_id|
+        next unless cancelled_creative_id
+
+        Comment.remove_stranded_waiting_notices!(
+          creative_id: cancelled_creative_id, topic_id: cancelled_topic_id
+        )
+      end
+
       if waiting_notice? && topic_concurrency_defer? && !suppress_waiter_cancellation
         cancel_queued_tasks_for_waiting_notice
       end
@@ -441,27 +465,7 @@ module Collavre
     # waiting on anything; the notice surfaces it separately as
     # topic_blocking_task, with its own stop button.
     def cancel_queued_tasks_for_waiting_notice
-      waiters =
-        case waiting_notice_scope
-        when WAITING_NOTICE_TASK
-          # Speaks for exactly the waiter it was posted with — and for nothing at
-          # all once that waiter has been folded away or promoted.
-          queued_topic_waiters.select { |task| task.id == waiting_notice_task_id }
-        when WAITING_NOTICE_TOPIC
-          # Every queued waiter in the topic except those a surviving
-          # per-deferral notice still speaks for: the shared notice was never
-          # their signal, and their own stop control is still on screen.
-          claimed = sibling_notice_waiter_ids
-          queued_topic_waiters.reject { |task| claimed.include?(task.id) }
-        else
-          # Posted before this was recorded. Nothing on the row says which kind
-          # it was, so keep the behaviour those notices were created under rather
-          # than guess: widening it would discard work, narrowing it would disarm
-          # the only stop control an in-flight wait has.
-          queued_topic_waiters.first(1)
-        end
-
-      waiters.each { |task| task.update!(status: "cancelled") }
+      represented_queued_waiters.each { |task| task.update!(status: "cancelled") }
 
       # Cancelling is the other way a topic queue empties, and it has no
       # promotion behind it to run the drained check. The notices that spoke for
@@ -470,6 +474,33 @@ module Collavre
       # *shared* notice is only ever taken down by that check, so without this
       # it is left on screen describing a wait that is over.
       Comment.remove_stranded_waiting_notices!(creative_id: creative_id, topic_id: topic_id)
+    end
+
+    # The queued waiters this notice speaks for — what its stop button cancels,
+    # and equally what keeps it on screen. Public because
+    # .remove_stranded_waiting_notices! asks the same question from the other
+    # side: a notice representing nobody is a stop control for work that can no
+    # longer be stopped. Two answers to one question is how the button and the
+    # sweep would come to disagree about what a notice is for.
+    public def represented_queued_waiters
+      case waiting_notice_scope
+      when WAITING_NOTICE_TASK
+        # Speaks for exactly the waiter it was posted with — and for nothing at
+        # all once that waiter has been folded away or promoted.
+        queued_topic_waiters.select { |task| task.id == waiting_notice_task_id }
+      when WAITING_NOTICE_TOPIC
+        # Every queued waiter in the topic except those a surviving per-deferral
+        # notice still speaks for: the shared notice was never their signal, and
+        # their own stop control is still on screen.
+        claimed = sibling_notice_waiter_ids
+        queued_topic_waiters.reject { |task| claimed.include?(task.id) }
+      else
+        # Posted before this was recorded. Nothing on the row says which kind it
+        # was, so keep the behaviour those notices were created under rather than
+        # guess: widening it would discard work, narrowing it would disarm the
+        # only stop control an in-flight wait has.
+        queued_topic_waiters.first(1)
+      end
     end
 
     def queued_topic_waiters

--- a/engines/collavre/app/models/collavre/comment.rb
+++ b/engines/collavre/app/models/collavre/comment.rb
@@ -251,8 +251,10 @@ module Collavre
                  .compact.map(&:to_i).uniq - [ id ]
       return false if merged.empty?
 
-      # Anything else in the merge window may have been deleted too.
-      replacement = Comment.where(id: merged).order(:created_at, :id).last
+      # Anything else in the merge window may have been deleted too. Newest by id:
+      # created_at is stamped per writing process, so a burst can carry skewed or
+      # tied timestamps (same reason MergedTriggerComments orders by id).
+      replacement = Comment.where(id: merged).order(:id).last
       return false unless replacement
 
       payload = payload.merge(
@@ -263,6 +265,7 @@ module Collavre
         },
         "chat" => { "content" => replacement.content }
       )
+      payload = Collavre::SystemEvents::ContextBuilder.reanchor_sender(payload, replacement)
       # absorb_into_payload drops the new anchor from the merged list so the
       # promoted comment is not delivered twice.
       payload = Collavre::Orchestration::TaskCoalescer.absorb_into_payload(payload, merged)

--- a/engines/collavre/app/models/collavre/comment.rb
+++ b/engines/collavre/app/models/collavre/comment.rb
@@ -8,6 +8,14 @@ module Collavre
     # matches the same prefix to remove them once the waiter is dequeued.
     WAITING_NOTICE_PREFIX = "⏳"
 
+    # What a waiting notice speaks for, written by the door that posted it.
+    # "topic" is the deduplicated notice coalescing allows a topic exactly one
+    # of; "task" is the per-deferral notice the opt-out posts, which names its
+    # waiter in waiting_notice_task_id. nil is a notice from before this was
+    # recorded — see #cancel_queued_tasks_for_waiting_notice.
+    WAITING_NOTICE_TOPIC = "topic"
+    WAITING_NOTICE_TASK = "task"
+
     # Use non-namespaced partial path for backward compatibility
     def to_partial_path
       "comments/comment"
@@ -346,29 +354,55 @@ module Collavre
     # cancelling every queued task would let a user discard unrelated waiters by
     # dismissing one notice, defeating the opt-out.
     #
+    # Which kind this is comes off the row (waiting_notice_scope), written by
+    # whichever door posted it. It used to be inferred from whether a sibling
+    # notice still stood, on the reasoning that the dedup path allows a topic
+    # exactly one — but the two kinds coexist as soon as the policy differs
+    # between agents or changes while a topic still has waiters, and then the
+    # inference inverts: the shared notice reads as a per-deferral one and takes
+    # down the newest queued waiter, which is very likely the one the *other*
+    # notice speaks for. A row cannot be classified by its neighbours when the
+    # neighbours are a different kind.
+    #
     # Queued only. A task holding the topic slot (pending/running/…) is not
     # waiting on anything; the notice surfaces it separately as
     # topic_blocking_task, with its own stop button.
     def cancel_queued_tasks_for_waiting_notice
-      scope = Task.where(status: "queued", creative_id: creative_id)
-      scope = topic_id ? scope.where(topic_id: topic_id) : scope.where(topic_id: nil)
-      waiters = scope.order(created_at: :desc).to_a
-      waiters = waiters.first(1) unless deduplicated_waiting_notice?
+      waiters =
+        case waiting_notice_scope
+        when WAITING_NOTICE_TASK
+          # Speaks for exactly the waiter it was posted with — and for nothing at
+          # all once that waiter has been folded away or promoted.
+          queued_topic_waiters.select { |task| task.id == waiting_notice_task_id }
+        when WAITING_NOTICE_TOPIC
+          # Every queued waiter in the topic except those a surviving
+          # per-deferral notice still speaks for: the shared notice was never
+          # their signal, and their own stop control is still on screen.
+          claimed = sibling_notice_waiter_ids
+          queued_topic_waiters.reject { |task| claimed.include?(task.id) }
+        else
+          # Posted before this was recorded. Nothing on the row says which kind
+          # it was, so keep the behaviour those notices were created under rather
+          # than guess: widening it would discard work, narrowing it would disarm
+          # the only stop control an in-flight wait has.
+          queued_topic_waiters.first(1)
+        end
+
       waiters.each { |task| task.update!(status: "cancelled") }
     end
 
-    # Was this notice the deduplicated one, standing for every waiter in the
-    # topic, or one of the per-deferral notices the opt-out posts?
-    #
-    # Read off the topic rather than stored on the row: the dedup path allows a
-    # topic exactly one deferred notice, so a sibling still standing here — this
-    # runs after_destroy_commit, with this notice already gone — means this one
-    # was never the topic's only signal. Asked through
-    # AgentOrchestrator.topic_concurrency_notice_exists?, the same predicate that
-    # decides whether to post one, so the two cannot drift apart.
-    def deduplicated_waiting_notice?
-      !Collavre::Orchestration::AgentOrchestrator
-        .topic_concurrency_notice_exists?(creative_id, topic_id)
+    def queued_topic_waiters
+      scope = Task.where(status: "queued", creative_id: creative_id)
+      scope = topic_id ? scope.where(topic_id: topic_id) : scope.where(topic_id: nil)
+      scope.order(created_at: :desc).to_a
+    end
+
+    # Waiter ids a still-standing per-deferral notice represents. Runs
+    # after_destroy_commit, so this notice is already out of the query.
+    def sibling_notice_waiter_ids
+      Comment.where(creative_id: creative_id, topic_id: topic_id, user_id: nil,
+                    waiting_notice_scope: WAITING_NOTICE_TASK)
+             .pluck(:waiting_notice_task_id).compact
     end
 
     def dispatch_to_orchestration

--- a/engines/collavre/app/models/collavre/comment.rb
+++ b/engines/collavre/app/models/collavre/comment.rb
@@ -241,6 +241,16 @@ module Collavre
         was_delegated = task.status == "delegated"
         task.update!(status: "cancelled")
 
+        # A waiter cancelled here leaves the queue without ever being promoted,
+        # exactly as a folded one does — so the notice that spoke for it is left
+        # naming a task no longer queued, and its stop button cancels nothing.
+        # This door needs no policy change at all: the opt-out posts the notice,
+        # deleting the prompt cancels the waiter, and a sibling still parked
+        # keeps the drained sweep from ever running.
+        Comment.remove_waiter_notices!(
+          creative_id: task.creative_id, topic_id: task.topic_id, task_ids: task.id
+        )
+
         # Delegated tasks live past their job: the AiAgentJob already returned,
         # holding the agent slot under task.id and counting against the per-topic
         # serializer. Mirror the cancel path used elsewhere to free both.

--- a/engines/collavre/app/models/collavre/comment.rb
+++ b/engines/collavre/app/models/collavre/comment.rb
@@ -291,8 +291,19 @@ module Collavre
       # away and then deleted would be searching the creative it was moved *to*,
       # find nothing there, and cancel a turn whose absorbed comments are all
       # still sitting in the creative the task belongs to.
-      in_scope = Comment.where(id: merged, creative_id: task.creative_id, topic_id: task.topic_id)
-                        .order(:id).to_a
+      #
+      # Asked through MergedTriggerComments.in_turn, the same predicate that
+      # decides what the turn delivers. Eligibility is not only about *where* a
+      # comment is: a comment made private (or turned into an approval surface)
+      # after it was absorbed is one dispatch_to_orchestration would refuse to
+      # trigger on, and in_turn already drops it from the merged blocks. The
+      # anchor is delivered as the trigger itself, with no filter in front of
+      # it, so a lookup of its own here is how withdrawn content reaches the
+      # agent through the one door that never filters.
+      in_scope = Collavre::AiAgent::MergedTriggerComments
+                   .in_turn(merged, "creative" => { "id" => task.creative_id },
+                                    "topic" => { "id" => task.topic_id })
+                   .order(:id).to_a
       replacement = in_scope.last
       return false unless replacement
 

--- a/engines/collavre/app/models/collavre/comment.rb
+++ b/engines/collavre/app/models/collavre/comment.rb
@@ -16,6 +16,38 @@ module Collavre
     WAITING_NOTICE_TOPIC = "topic"
     WAITING_NOTICE_TASK = "task"
 
+    # Take down the per-deferral notice that speaks for this waiter, if it had
+    # one.
+    #
+    # A "task" notice is on screen for exactly as long as its waiter is queued:
+    # it names that waiter in waiting_notice_task_id and
+    # #cancel_queued_tasks_for_waiting_notice stops that waiter and nothing
+    # else. So the moment the waiter leaves the queue the notice is a stop
+    # button for work that cannot be stopped — and no sweep will collect it,
+    # since the drained sweep only runs when the topic queue empties and the
+    # waiter itself will never be promoted again.
+    #
+    # It therefore comes down wherever the waiter leaves, which is why this
+    # lives here beside the columns rather than in one of those callers: the
+    # promotion (AgentOrchestrator.cleanup_waiter_notice!) and the fold
+    # (Orchestration::TaskCoalescer) are two doors onto the same rule, and a
+    # third would otherwise write its own copy or forget.
+    #
+    # The destroy is marked as a system removal: the waiter is being promoted or
+    # folded, not abandoned by the user, so the cancellation callback must not
+    # fire on top of it.
+    def self.remove_waiter_notices!(creative_id:, topic_id:, task_ids:)
+      task_ids = Array(task_ids).compact
+      return if task_ids.empty?
+
+      where(creative_id: creative_id, topic_id: topic_id, user_id: nil,
+            waiting_notice_scope: WAITING_NOTICE_TASK,
+            waiting_notice_task_id: task_ids).find_each do |notice|
+        notice.suppress_waiter_cancellation = true
+        notice.destroy
+      end
+    end
+
     # Use non-namespaced partial path for backward compatibility
     def to_partial_path
       "comments/comment"

--- a/engines/collavre/app/models/collavre/comment.rb
+++ b/engines/collavre/app/models/collavre/comment.rb
@@ -307,13 +307,11 @@ module Collavre
       replacement = in_scope.last
       return false unless replacement
 
+      # Through the same door the refresh uses, so the promotion is recorded as
+      # an acquired anchor either way: this task was created to answer the
+      # comment being deleted, not this one.
+      payload = Collavre::Orchestration::TaskCoalescer.reanchor_payload(payload, replacement)
       payload = payload.merge(
-        "comment" => {
-          "id" => replacement.id,
-          "content" => replacement.content,
-          "user_id" => replacement.user_id
-        },
-        "chat" => { "content" => replacement.content },
         # Rebuilt from the in-scope ids rather than merged through
         # absorb_into_payload, which would fold the out-of-scope ones straight
         # back in from the payload it starts from. The new anchor is excluded so
@@ -321,7 +319,6 @@ module Collavre
         Collavre::Orchestration::TaskCoalescer::PAYLOAD_KEY =>
           (in_scope.map(&:id) - [ replacement.id ]).sort
       )
-      payload = Collavre::SystemEvents::ContextBuilder.reanchor_sender(payload, replacement)
       task.update!(trigger_event_payload: payload)
 
       Rails.logger.info(

--- a/engines/collavre/app/models/collavre/comment.rb
+++ b/engines/collavre/app/models/collavre/comment.rb
@@ -295,11 +295,25 @@ module Collavre
       true
     end
 
+    # Cancel *every* queued waiter this notice speaks for, not just the newest.
+    #
+    # Cancelling one was right while each deferral posted its own notice: the
+    # newest queued task was the one that notice belonged to. A topic now gets
+    # exactly one deduplicated notice
+    # (Orchestration::AgentOrchestrator.with_deduped_topic_notice), and with
+    # topic_max_concurrent_jobs > 1 it can stand for waiters from several agents
+    # — coalescing folds same-agent siblings only. Deleting it while cancelling
+    # one of them leaves the rest queued with nothing on screen representing
+    # them and no stop control, and nothing reposts a notice until the next
+    # deferral happens by.
+    #
+    # Queued only. A task holding the topic slot (pending/running/…) is not
+    # waiting on anything; the notice surfaces it separately as
+    # topic_blocking_task, with its own stop button.
     def cancel_queued_tasks_for_waiting_notice
       scope = Task.where(status: "queued", creative_id: creative_id)
       scope = topic_id ? scope.where(topic_id: topic_id) : scope.where(topic_id: nil)
-      task = scope.order(created_at: :desc).first
-      task&.update!(status: "cancelled")
+      scope.order(created_at: :desc).each { |task| task.update!(status: "cancelled") }
     end
 
     def dispatch_to_orchestration

--- a/engines/collavre/app/models/collavre/comment.rb
+++ b/engines/collavre/app/models/collavre/comment.rb
@@ -254,7 +254,14 @@ module Collavre
       # Anything else in the merge window may have been deleted too. Newest by id:
       # created_at is stamped per writing process, so a burst can carry skewed or
       # tied timestamps (same reason MergedTriggerComments orders by id).
-      replacement = Comment.where(id: merged).order(:id).last
+      #
+      # Scoped to this turn's creative/topic: a merged comment moved elsewhere
+      # while the task waited (CommentMoveService#perform_move reassigns
+      # creative_id) is no longer part of it, and adopting it as the anchor would
+      # point the reply at a creative the agent may have no share on.
+      in_scope = Comment.where(id: merged, creative_id: creative_id, topic_id: topic_id)
+                        .order(:id).to_a
+      replacement = in_scope.last
       return false unless replacement
 
       payload = payload.merge(
@@ -263,12 +270,15 @@ module Collavre
           "content" => replacement.content,
           "user_id" => replacement.user_id
         },
-        "chat" => { "content" => replacement.content }
+        "chat" => { "content" => replacement.content },
+        # Rebuilt from the in-scope ids rather than merged through
+        # absorb_into_payload, which would fold the out-of-scope ones straight
+        # back in from the payload it starts from. The new anchor is excluded so
+        # the promoted comment is not delivered twice.
+        Collavre::Orchestration::TaskCoalescer::PAYLOAD_KEY =>
+          (in_scope.map(&:id) - [ replacement.id ]).sort
       )
       payload = Collavre::SystemEvents::ContextBuilder.reanchor_sender(payload, replacement)
-      # absorb_into_payload drops the new anchor from the merged list so the
-      # promoted comment is not delivered twice.
-      payload = Collavre::Orchestration::TaskCoalescer.absorb_into_payload(payload, merged)
       task.update!(trigger_event_payload: payload)
 
       Rails.logger.info(

--- a/engines/collavre/app/services/collavre/ai_agent/claude_channel_adapter.rb
+++ b/engines/collavre/app/services/collavre/ai_agent/claude_channel_adapter.rb
@@ -43,7 +43,13 @@ module Collavre
           session_topic: session_topic?,
           comment: {
             id: @context.dig("comment", "id"),
-            content: @context.dig("comment", "content"),
+            # This payload is the agent's ONLY input — the MCP client gets no
+            # chat history — so comments that Orchestration::TaskCoalescer
+            # folded into this turn have to be rendered inline here or they
+            # never reach the agent at all.
+            content: MergedTriggerComments.prepend_to(
+              @context.dig("comment", "content"), @context, agent: @agent
+            ),
             author_id: @context.dig("sender", "id") || @context.dig("comment", "user_id"),
             author_name: @context.dig("sender", "name") || comment&.user&.display_name,
             topic_id: @topic_id,

--- a/engines/collavre/app/services/collavre/ai_agent/merged_trigger_comments.rb
+++ b/engines/collavre/app/services/collavre/ai_agent/merged_trigger_comments.rb
@@ -18,6 +18,8 @@ module Collavre
     class MergedTriggerComments
       Block = Struct.new(:comment, :text, :images, keyword_init: true)
 
+      TRUNCATION_SUFFIX = "…[truncated]"
+
       def self.for(context, agent:)
         new(context, agent: agent).blocks
       end
@@ -58,15 +60,29 @@ module Collavre
         # single monotonic causal sequence (CommentsController orders by id for
         # the same reason).
         @blocks ||= within_budget(
-          Comment.public_only.without_approval_action
-                 .where(id: comment_ids)
-                 .includes(:user)
-                 .order(:id)
-                 .map { |c| Block.new(comment: c, text: label(c), images: image_blobs(c)) }
+          turn_scope(Comment.public_only.without_approval_action.where(id: comment_ids))
+            .includes(:user)
+            .order(:id)
+            .map { |c| Block.new(comment: c, text: label(c), images: image_blobs(c)) }
         )
       end
 
       private
+
+      # The merged ids were captured when the burst was folded; they are not a
+      # standing claim on those rows. CommentMoveService#perform_move reassigns
+      # creative_id, so a comment moved away while the task waited would still be
+      # rendered into this trigger — handing the agent text and image attachments
+      # from a creative it may have no share on. refresh_deferred_context! already
+      # scopes its lookup this way; the merged set has to ask the same question.
+      def turn_scope(relation)
+        creative_id = @context.dig("creative", "id")
+        relation = relation.where(creative_id: creative_id) if creative_id
+        # topic_id nil is a real scope (a creative's Main topic), so key? rather
+        # than presence decides whether the turn is topic-scoped at all.
+        relation = relation.where(topic_id: @context.dig("topic", "id")) if @context.key?("topic")
+        relation
+      end
 
       # Coalescing turns a burst into one indivisible message, so an oversized
       # burst does not degrade — the whole turn fails. MessageBuilder budgets
@@ -81,19 +97,67 @@ module Collavre
         budget = size_limit
         return blocks if budget.nil? || blocks.sum { |b| b.text.length } <= budget
 
+        # Dropping blocks rests on MessageBuilder leaving them in the separately
+        # budgeted history window instead. A session-backed agent never receives
+        # that window — SessionContextResolver#incremental_payload keeps only the
+        # :trigger message — so for them a dropped block is a user comment with no
+        # delivery path left, which is the loss coalescing exists to prevent.
+        # Shrink every block instead, so an oversized burst degrades.
+        return shrunk_to_fit(blocks, budget) if trigger_is_only_channel?
+
+        # Reserve room for the omission marker. Added after budgeting, it pushed
+        # the trigger back over the limit it had just been trimmed to.
+        room = [ budget - omission_marker(blocks.size).length, 0 ].max
+
         kept = []
         used = 0
         blocks.reverse_each do |block|
-          break if used + block.text.length > budget
+          break if used + block.text.length > room
 
           used += block.text.length
           kept.unshift(block)
         end
 
+        # The newest merged comment is the one the anchor replies to. When it
+        # alone exceeds the budget the loop keeps nothing and the method returned
+        # the marker by itself — the whole burst gone, newest included. Trim it
+        # rather than drop it.
+        kept = [ truncate_block(blocks.last, room) ] if kept.empty? && room.positive?
+
         dropped = blocks.size - kept.size
         return kept if dropped.zero?
 
-        kept.unshift(Block.new(comment: nil, text: "[#{dropped} earlier message(s) omitted]", images: []))
+        kept.unshift(Block.new(comment: nil, text: omission_marker(dropped), images: []))
+      end
+
+      # Fit every block, none dropped: each gets an equal share of the budget.
+      # Used when the trigger is the only channel, where "which comments to keep"
+      # is not a choice we are allowed to make.
+      def shrunk_to_fit(blocks, budget)
+        share = budget / blocks.size
+        return [ truncate_block(blocks.last, budget) ] if share <= TRUNCATION_SUFFIX.length
+
+        blocks.map { |b| truncate_block(b, share) }
+      end
+
+      def truncate_block(block, limit)
+        return block if block.text.length <= limit
+
+        text = if limit > TRUNCATION_SUFFIX.length
+                 block.text[0, limit - TRUNCATION_SUFFIX.length] + TRUNCATION_SUFFIX
+        else
+                 block.text[0, limit]
+        end
+        Block.new(comment: block.comment, text: text, images: block.images)
+      end
+
+      def omission_marker(count)
+        "[#{count} earlier message(s) omitted]"
+      end
+
+      # Does this agent receive anything other than the trigger?
+      def trigger_is_only_channel?
+        @agent.respond_to?(:supports_session?) && @agent.supports_session?
       end
 
       def size_limit

--- a/engines/collavre/app/services/collavre/ai_agent/merged_trigger_comments.rb
+++ b/engines/collavre/app/services/collavre/ai_agent/merged_trigger_comments.rb
@@ -49,11 +49,13 @@ module Collavre
       def blocks
         return [] if comment_ids.empty?
 
-        Comment.public_only.without_approval_action
-               .where(id: comment_ids)
-               .includes(:user)
-               .order(:created_at)
-               .map { |c| Block.new(comment: c, text: label(c), images: image_blobs(c)) }
+        # Memoized: MessageBuilder renders these into the trigger and also scans
+        # them for creative references, and one build should not re-query.
+        @blocks ||= Comment.public_only.without_approval_action
+                           .where(id: comment_ids)
+                           .includes(:user)
+                           .order(:created_at)
+                           .map { |c| Block.new(comment: c, text: label(c), images: image_blobs(c)) }
       end
 
       private

--- a/engines/collavre/app/services/collavre/ai_agent/merged_trigger_comments.rb
+++ b/engines/collavre/app/services/collavre/ai_agent/merged_trigger_comments.rb
@@ -51,10 +51,16 @@ module Collavre
 
         # Memoized: MessageBuilder renders these into the trigger and also scans
         # them for creative references, and one build should not re-query.
+        # Ordered by id, not created_at. A burst is exactly the case where the
+        # rows are written by different processes, and created_at is stamped by
+        # whichever one wrote it — clock skew or a tie can hand the agent
+        # "ignore that" ahead of the instruction it retracts. Ids are the app's
+        # single monotonic causal sequence (CommentsController orders by id for
+        # the same reason).
         @blocks ||= Comment.public_only.without_approval_action
                            .where(id: comment_ids)
                            .includes(:user)
-                           .order(:created_at)
+                           .order(:id)
                            .map { |c| Block.new(comment: c, text: label(c), images: image_blobs(c)) }
       end
 

--- a/engines/collavre/app/services/collavre/ai_agent/merged_trigger_comments.rb
+++ b/engines/collavre/app/services/collavre/ai_agent/merged_trigger_comments.rb
@@ -24,6 +24,29 @@ module Collavre
         new(context, agent: agent).blocks
       end
 
+      # The comments a payload's merged ids still refer to *in this turn*.
+      #
+      # The merged ids were captured when the burst was folded; they are not a
+      # standing claim on those rows. CommentMoveService#perform_move reassigns
+      # creative_id, so a comment moved away while the task waited is no longer
+      # part of the turn — rendering it would hand the agent text and image
+      # attachments from a creative it may have no share on.
+      #
+      # Public because two doors ask the same question and must not diverge:
+      # this class decides what is delivered, and Matcher.permits_assignment?
+      # decides whether a merged @mention still licenses the turn. A mention
+      # excluded from the trigger cannot be the reason the turn is allowed.
+      def self.in_turn(ids, context)
+        context ||= {}
+        relation = Comment.public_only.without_approval_action.where(id: ids)
+        creative_id = context.dig("creative", "id")
+        relation = relation.where(creative_id: creative_id) if creative_id
+        # topic_id nil is a real scope (a creative's Main topic), so key? rather
+        # than presence decides whether the turn is topic-scoped at all.
+        relation = relation.where(topic_id: context.dig("topic", "id")) if context.key?("topic")
+        relation
+      end
+
       # Prefix `content` with the merged comments, oldest first.
       def self.prepend_to(content, context, agent:)
         blocks = self.for(context, agent: agent)
@@ -60,7 +83,7 @@ module Collavre
         # single monotonic causal sequence (CommentsController orders by id for
         # the same reason).
         @blocks ||= within_budget(
-          turn_scope(Comment.public_only.without_approval_action.where(id: comment_ids))
+          self.class.in_turn(comment_ids, @context)
             .includes(:user)
             .order(:id)
             .map { |c| Block.new(comment: c, text: label(c), images: image_blobs(c)) }
@@ -68,21 +91,6 @@ module Collavre
       end
 
       private
-
-      # The merged ids were captured when the burst was folded; they are not a
-      # standing claim on those rows. CommentMoveService#perform_move reassigns
-      # creative_id, so a comment moved away while the task waited would still be
-      # rendered into this trigger — handing the agent text and image attachments
-      # from a creative it may have no share on. refresh_deferred_context! already
-      # scopes its lookup this way; the merged set has to ask the same question.
-      def turn_scope(relation)
-        creative_id = @context.dig("creative", "id")
-        relation = relation.where(creative_id: creative_id) if creative_id
-        # topic_id nil is a real scope (a creative's Main topic), so key? rather
-        # than presence decides whether the turn is topic-scoped at all.
-        relation = relation.where(topic_id: @context.dig("topic", "id")) if @context.key?("topic")
-        relation
-      end
 
       # Coalescing turns a burst into one indivisible message, so an oversized
       # burst does not degrade — the whole turn fails. MessageBuilder budgets
@@ -133,11 +141,14 @@ module Collavre
       # Fit every block, none dropped: each gets an equal share of the budget.
       # Used when the trigger is the only channel, where "which comments to keep"
       # is not a choice we are allowed to make.
+      #
+      # No floor under the share. A budget too small to say much per comment is
+      # still not a reason to delete the other comments outright: keeping them
+      # preserves their order, their speakers and — the part the text budget
+      # never measures — their image attachments, which are delivered as
+      # separate parts and cost nothing here.
       def shrunk_to_fit(blocks, budget)
-        share = budget / blocks.size
-        return [ truncate_block(blocks.last, budget) ] if share <= TRUNCATION_SUFFIX.length
-
-        blocks.map { |b| truncate_block(b, share) }
+        blocks.map { |b| truncate_block(b, budget / blocks.size) }
       end
 
       def truncate_block(block, limit)

--- a/engines/collavre/app/services/collavre/ai_agent/merged_trigger_comments.rb
+++ b/engines/collavre/app/services/collavre/ai_agent/merged_trigger_comments.rb
@@ -97,57 +97,35 @@ module Collavre
       # chat history by the same setting; the trigger these blocks go into had
       # no budget at all, which is the asymmetry a burst is most likely to hit.
       #
-      # Drop from the oldest end: the newest comments are the ones the anchor
-      # replies to, and a retraction ("ignore that") is worthless without being
-      # newer than what it retracts. Say what was cut — a silent truncation
-      # reads to the agent as if the burst were complete.
-      def within_budget(blocks)
-        budget = size_limit
-        return blocks if budget.nil? || blocks.sum { |b| b.text.length } <= budget
-
-        # Dropping blocks rests on MessageBuilder leaving them in the separately
-        # budgeted history window instead. A session-backed agent never receives
-        # that window — SessionContextResolver#incremental_payload keeps only the
-        # :trigger message — so for them a dropped block is a user comment with no
-        # delivery path left, which is the loss coalescing exists to prevent.
-        # Shrink every block instead, so an oversized burst degrades.
-        return shrunk_to_fit(blocks, budget) if trigger_is_only_channel?
-
-        # Reserve room for the omission marker. Added after budgeting, it pushed
-        # the trigger back over the limit it had just been trimmed to.
-        room = [ budget - omission_marker(blocks.size).length, 0 ].max
-
-        kept = []
-        used = 0
-        blocks.reverse_each do |block|
-          break if used + block.text.length > room
-
-          used += block.text.length
-          kept.unshift(block)
-        end
-
-        # The newest merged comment is the one the anchor replies to. When it
-        # alone exceeds the budget the loop keeps nothing and the method returned
-        # the marker by itself — the whole burst gone, newest included. Trim it
-        # rather than drop it.
-        kept = [ truncate_block(blocks.last, room) ] if kept.empty? && room.positive?
-
-        dropped = blocks.size - kept.size
-        return kept if dropped.zero?
-
-        kept.unshift(Block.new(comment: nil, text: omission_marker(dropped), images: []))
-      end
-
-      # Fit every block, none dropped: each gets an equal share of the budget.
-      # Used when the trigger is the only channel, where "which comments to keep"
-      # is not a choice we are allowed to make.
+      # Shrink, never drop. Dropping the oldest blocks would rest on the history
+      # window carrying them instead, and no delivery path guarantees that:
+      #
+      # - A session-backed agent has no history window at all
+      #   (SessionContextResolver#incremental_payload keeps only :trigger), and
+      #   ClaudeChannelAdapter sends only the comment content.
+      # - Even with history, MessageBuilder#append_chat_history caps it by
+      #   chat_history_limit and by *this same* size budget spread across the
+      #   whole preceding conversation, cutting from its newest end — which is
+      #   exactly where a just-dropped burst comment sits.
+      # - History carries text only. A dropped block's image attachments reach
+      #   the agent through nothing, whatever the budgets say.
+      #
+      # So the trigger is the only channel that can promise a merged comment
+      # arrives, and "which of the user's comments to delete" is not a choice
+      # this class is in a position to make. Every block is kept and truncated to
+      # an equal share instead: an oversized burst then degrades in fidelity
+      # rather than losing whole messages, and the truncation is visible in the
+      # text where a silent drop was not.
       #
       # No floor under the share. A budget too small to say much per comment is
       # still not a reason to delete the other comments outright: keeping them
       # preserves their order, their speakers and — the part the text budget
       # never measures — their image attachments, which are delivered as
       # separate parts and cost nothing here.
-      def shrunk_to_fit(blocks, budget)
+      def within_budget(blocks)
+        budget = size_limit
+        return blocks if budget.nil? || blocks.sum { |b| b.text.length } <= budget
+
         blocks.map { |b| truncate_block(b, budget / blocks.size) }
       end
 
@@ -160,15 +138,6 @@ module Collavre
                  block.text[0, limit]
         end
         Block.new(comment: block.comment, text: text, images: block.images)
-      end
-
-      def omission_marker(count)
-        "[#{count} earlier message(s) omitted]"
-      end
-
-      # Does this agent receive anything other than the trigger?
-      def trigger_is_only_channel?
-        @agent.respond_to?(:supports_session?) && @agent.supports_session?
       end
 
       def size_limit

--- a/engines/collavre/app/services/collavre/ai_agent/merged_trigger_comments.rb
+++ b/engines/collavre/app/services/collavre/ai_agent/merged_trigger_comments.rb
@@ -57,14 +57,48 @@ module Collavre
         # "ignore that" ahead of the instruction it retracts. Ids are the app's
         # single monotonic causal sequence (CommentsController orders by id for
         # the same reason).
-        @blocks ||= Comment.public_only.without_approval_action
-                           .where(id: comment_ids)
-                           .includes(:user)
-                           .order(:id)
-                           .map { |c| Block.new(comment: c, text: label(c), images: image_blobs(c)) }
+        @blocks ||= within_budget(
+          Comment.public_only.without_approval_action
+                 .where(id: comment_ids)
+                 .includes(:user)
+                 .order(:id)
+                 .map { |c| Block.new(comment: c, text: label(c), images: image_blobs(c)) }
+        )
       end
 
       private
+
+      # Coalescing turns a burst into one indivisible message, so an oversized
+      # burst does not degrade — the whole turn fails. MessageBuilder budgets
+      # chat history by the same setting; the trigger these blocks go into had
+      # no budget at all, which is the asymmetry a burst is most likely to hit.
+      #
+      # Drop from the oldest end: the newest comments are the ones the anchor
+      # replies to, and a retraction ("ignore that") is worthless without being
+      # newer than what it retracts. Say what was cut — a silent truncation
+      # reads to the agent as if the burst were complete.
+      def within_budget(blocks)
+        budget = size_limit
+        return blocks if budget.nil? || blocks.sum { |b| b.text.length } <= budget
+
+        kept = []
+        used = 0
+        blocks.reverse_each do |block|
+          break if used + block.text.length > budget
+
+          used += block.text.length
+          kept.unshift(block)
+        end
+
+        dropped = blocks.size - kept.size
+        return kept if dropped.zero?
+
+        kept.unshift(Block.new(comment: nil, text: "[#{dropped} earlier message(s) omitted]", images: []))
+      end
+
+      def size_limit
+        @agent.respond_to?(:chat_history_size_limit) ? @agent.chat_history_size_limit : nil
+      end
 
       def label(comment)
         text = comment.content.to_s

--- a/engines/collavre/app/services/collavre/ai_agent/merged_trigger_comments.rb
+++ b/engines/collavre/app/services/collavre/ai_agent/merged_trigger_comments.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+module Collavre
+  module AiAgent
+    # Renders the comments that Orchestration::TaskCoalescer folded into a task.
+    #
+    # When a burst of comments collapses into one turn, the superseded comments
+    # survive only as ids in the payload's "merged_comment_ids". Every delivery
+    # path that carries a trigger has to render them, because none of them can
+    # fall back to chat history:
+    #
+    # - ClaudeChannelAdapter sends *only* comment.content to the MCP client.
+    # - SessionContextResolver#incremental_payload sends *only* the :trigger
+    #   message for session-backed agents.
+    #
+    # Blocks are chronological and labelled with their speaker, matching how
+    # MessageBuilder labels chat history.
+    class MergedTriggerComments
+      Block = Struct.new(:comment, :text, :images, keyword_init: true)
+
+      def self.for(context, agent:)
+        new(context, agent: agent).blocks
+      end
+
+      # Prefix `content` with the merged comments, oldest first.
+      def self.prepend_to(content, context, agent:)
+        blocks = self.for(context, agent: agent)
+        return content if blocks.empty?
+
+        (blocks.map(&:text) + [ content.to_s ]).join("\n\n")
+      end
+
+      def initialize(context, agent:)
+        @context = context || {}
+        @agent = agent
+      end
+
+      # Ids of the coalesced comments, with the current anchor excluded — the
+      # anchor is delivered as the trigger itself and must not be duplicated.
+      def comment_ids
+        @comment_ids ||= begin
+          ids = Array(@context[Orchestration::TaskCoalescer::PAYLOAD_KEY])
+                  .compact.map(&:to_i).uniq
+          anchor_id = @context.dig("comment", "id")
+          anchor_id ? ids - [ anchor_id.to_i ] : ids
+        end
+      end
+
+      def blocks
+        return [] if comment_ids.empty?
+
+        Comment.public_only.without_approval_action
+               .where(id: comment_ids)
+               .includes(:user)
+               .order(:created_at)
+               .map { |c| Block.new(comment: c, text: label(c), images: image_blobs(c)) }
+      end
+
+      private
+
+      def label(comment)
+        text = comment.content.to_s
+        if @agent && comment.user_id == @agent.id
+          # Defensive: an agent's own message should never be coalesced into its
+          # own trigger, but if one is, do not relabel it as a human speaker.
+          "[#{@agent.name}]: #{text}"
+        else
+          text = MentionParser.strip_self_mention(text, @agent.name) if @agent
+          "[#{comment.user&.name || 'unknown'}]: #{text}"
+        end
+      end
+
+      def image_blobs(comment)
+        comment.images.attached? ? comment.images.map(&:blob) : []
+      end
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/ai_agent/message_builder.rb
+++ b/engines/collavre/app/services/collavre/ai_agent/message_builder.rb
@@ -106,14 +106,20 @@ module Collavre
       end
 
       def append_referenced_creative_contexts(messages)
-        content = @context.dig("comment", "content")
-        return unless content
+        # Comments coalesced into this turn are delivered with the trigger, so
+        # their links point at creatives the agent is about to be asked about.
+        # Scanning only the surviving anchor would drop the subtree that the
+        # absorbed comment's own dispatch would have supplied.
+        contents = [ @context.dig("comment", "content") ] + merged_trigger.blocks.map(&:text)
+        contents = contents.compact
+        return if contents.empty?
 
         children_level = @agent.creative_children_level
         max_depth = 1 + children_level
 
         # Extract creative IDs from markdown links like [title](/creatives/123)
-        referenced_ids = content.scan(%r{\[[^\]]*\]\(/creatives/(\d+)\)}).flatten.map(&:to_i).uniq
+        referenced_ids = contents.flat_map { |c| c.scan(%r{\[[^\]]*\]\(/creatives/(\d+)\)}) }
+                                 .flatten.map(&:to_i).uniq
         referenced_ids.reject! { |cid| @injected_creative_ids.include?(cid) }
         creatives_by_id = Creative.where(id: referenced_ids).index_by(&:id)
 
@@ -146,18 +152,23 @@ module Collavre
         history_chars = 0
         count = 0
 
-        Comment.public_only.without_approval_action.where(creative_id: creative_id)
-               .where(topic_id: topic_id)
-               .where.not(user_id: nil)
-               .includes(:user)
-               .order(created_at: :desc)
-               .limit(history_limit)
-               .reverse
-               .each do |c|
-          next if c.id == trigger_comment&.id
-          # Already folded into the trigger message by append_trigger_message.
-          next if merged_comment_ids.include?(c.id)
+        scope = Comment.public_only.without_approval_action.where(creative_id: creative_id)
+                       .where(topic_id: topic_id)
+                       .where.not(user_id: nil)
+                       .includes(:user)
 
+        # Exclude before limiting, not after. The trigger and the comments folded
+        # into it are delivered by append_trigger_message, so leaving them in the
+        # limited window lets a burst eat every history slot — a burst as large as
+        # the limit would leave no conversation at all and mark the turn
+        # first_message. Dropping them first lets older messages backfill.
+        excluded_ids = (merged_comment_ids + [ @context.dig("comment", "id") ]).compact.map(&:to_i)
+        scope = scope.where.not(id: excluded_ids) if excluded_ids.any?
+
+        scope.order(created_at: :desc)
+             .limit(history_limit)
+             .reverse
+             .each do |c|
           role = (c.user_id == @agent.id) ? "model" : "user"
           content = c.content.to_s
 

--- a/engines/collavre/app/services/collavre/ai_agent/message_builder.rb
+++ b/engines/collavre/app/services/collavre/ai_agent/message_builder.rb
@@ -229,9 +229,14 @@ module Collavre
         @merged_trigger ||= MergedTriggerComments.new(@context, agent: @agent)
       end
 
-      # Ids of comments coalesced into this task (anchor excluded).
+      # Ids of the coalesced comments this turn actually renders into the
+      # trigger (anchor excluded). Deliberately the rendered blocks rather than
+      # every merged id: MergedTriggerComments drops the oldest of an oversized
+      # burst, and excluding a comment that no longer appears in the trigger
+      # would delete it from the turn outright. Leaving it in the history scope
+      # lets that separately budgeted window carry it instead.
       def merged_comment_ids
-        merged_trigger.comment_ids
+        merged_trigger.blocks.filter_map { |b| b.comment&.id }
       end
 
       def trigger_comment

--- a/engines/collavre/app/services/collavre/ai_agent/message_builder.rb
+++ b/engines/collavre/app/services/collavre/ai_agent/message_builder.rb
@@ -155,6 +155,8 @@ module Collavre
                .reverse
                .each do |c|
           next if c.id == trigger_comment&.id
+          # Already folded into the trigger message by append_trigger_message.
+          next if merged_comment_ids.include?(c.id)
 
           role = (c.user_id == @agent.id) ? "model" : "user"
           content = c.content.to_s
@@ -192,7 +194,16 @@ module Collavre
           payload_text = "[#{sender_name}]: #{payload_text}"
         end
 
+        # Comments that were folded into this task by Orchestration::TaskCoalescer
+        # (a burst of messages answered as one turn). They belong *in* the
+        # trigger, not in chat history: a session-backed agent receives only the
+        # :trigger message, so history-only placement would lose them entirely.
+        merged_blocks = merged_trigger.blocks
+        payload_text = (merged_blocks.map(&:text) + [ payload_text ]).join("\n\n") if merged_blocks.any?
+
         trigger_parts = [ { text: payload_text } ]
+
+        merged_blocks.each { |b| b.images.each { |blob| trigger_parts << { image: blob } } }
 
         if @original_comment&.images&.attached?
           @original_comment.images.each do |image|
@@ -201,6 +212,15 @@ module Collavre
         end
 
         messages << { role: "user", kind: :trigger, parts: trigger_parts }
+      end
+
+      def merged_trigger
+        @merged_trigger ||= MergedTriggerComments.new(@context, agent: @agent)
+      end
+
+      # Ids of comments coalesced into this task (anchor excluded).
+      def merged_comment_ids
+        merged_trigger.comment_ids
       end
 
       def trigger_comment

--- a/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
+++ b/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
@@ -27,7 +27,7 @@ module Collavre
           # the refresh below then moves the anchor forward and keeps the
           # absorbed triggers in "merged_comment_ids".
           coalesce_promoted!(task)
-          cleanup_waiting_notices!(task)
+          cleanup_waiting_notices_if_drained!(task)
           refresh_deferred_context!(task)
           revalidate_assignment!(task) unless task.status == "cancelled"
 
@@ -188,14 +188,33 @@ module Collavre
 
         # The folded waiters may have been everything the topic's "⏳" notice
         # described, and nothing else will take it down: removal happens when a
-        # promotion drains a *queued* waiter, and this fold left none. Scope the
-        # cleanup to "nobody is waiting any more" rather than "a fold happened"
-        # — another agent's waiter is not this agent's sibling and its wait is
-        # still real.
-        return if Task.queued_for_topic(task.topic_id, task.creative_id).exists?
-
-        cleanup_waiting_notices!(task)
+        # promotion drains a *queued* waiter, and this fold left none.
+        cleanup_waiting_notices_if_drained!(task)
       end
+
+      # Take the topic's "⏳" notice down, but only once nothing is waiting on
+      # the slot any more.
+      #
+      # "A waiter left the queue" is not the same question. A topic gets exactly
+      # one deduplicated notice, and with topic_max > 1 a promotion can leave
+      # other agents queued — coalesce_promoted! absorbs same-agent siblings
+      # only, and the queue head may be ineligible while a later waiter runs. So
+      # an unconditional cleanup strips the wait/stop signal off a wait that is
+      # still real, and nothing reposts it until the next deferral happens by.
+      #
+      # Asked under the lock post_waiting_notice takes, so "nobody is queued" is
+      # that path's own before-or-after rather than a guess: a deferral either
+      # commits its waiter before this reads, and keeps its notice, or after, and
+      # posts its own.
+      def self.cleanup_waiting_notices_if_drained!(task)
+        Comment.transaction do
+          TopicSlot.lock!(task.topic_id, task.creative_id)
+          next if Task.queued_for_topic(task.topic_id, task.creative_id).exists?
+
+          cleanup_waiting_notices!(task)
+        end
+      end
+      private_class_method :cleanup_waiting_notices_if_drained!
 
       # Post the "⏳ waiting on the topic slot" notice for a deferral raised
       # outside #enqueue_jobs — AiAgentJob's late slot check, which catches

--- a/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
+++ b/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
@@ -289,6 +289,16 @@ module Collavre
         Comment.transaction do
           TopicSlot.lock!(task.topic_id, task.creative_id)
           cleanup_waiter_notice!(task)
+
+          # "Is anyone queued?" is the topic's question, not any one notice's.
+          # A shared notice speaks for the queued waiters no per-deferral notice
+          # claims, so a promotion that leaves only claimed waiters behind
+          # leaves it representing nobody — a second "⏳" line whose stop button
+          # selects nothing, kept up by the very waiter that is not its to
+          # speak for. Ask each notice what it still stands for.
+          Comment.remove_stranded_waiting_notices!(
+            creative_id: task.creative_id, topic_id: task.topic_id
+          )
           next if Task.queued_for_topic(task.topic_id, task.creative_id).exists?
 
           cleanup_waiting_notices!(task)

--- a/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
+++ b/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
@@ -149,6 +149,54 @@ module Collavre
       end
       private_class_method :coalesce_promoted!
 
+      # Fold one last time, at the moment execution actually begins.
+      #
+      # Promotion claims the slot (queued -> pending) and folds the waiters that
+      # exist at that instant, but the task then sits `pending` until its
+      # AiAgentJob runs. A comment arriving in that gap parks a waiter that
+      # enqueue-time coalescing cannot reach: TaskCoalescer supersedes only
+      # `queued` rows, and the claimed task has already left that status. Both
+      # turns were still un-started — which is the invariant coalescing is
+      # defined over, not "present when the slot was claimed" — so the last
+      # un-started moment has to fold too.
+      #
+      # Serialized on the row admission locks. A concurrent dispatch either
+      # commits its waiter before this reads the siblings, and is folded, or
+      # after, and keeps its own turn against a task that is by then executing.
+      # The re-anchor runs inside the same lock for the same reason: outside it,
+      # the refresh could move the anchor onto a comment whose waiter is still
+      # queued, and that comment would be answered twice.
+      #
+      # Only a `pending` task qualifies. That is the claimed-but-not-started
+      # status; a resumed pending_approval task has already delivered its
+      # trigger and run part of its turn, so folding new comments into it would
+      # swallow them rather than answer them.
+      def self.coalesce_at_start!(task)
+        return unless task.status == "pending"
+
+        context = task.trigger_event_payload || {}
+        return unless context.key?("topic")
+        return unless PolicyResolver.new(context).coalesce_pending_tasks?
+
+        absorbed = []
+        Task.transaction do
+          TopicSlot.lock!(task.topic_id, task.creative_id)
+          absorbed = TaskCoalescer.coalesce!(task, scope: :all)
+          refresh_deferred_context!(task) if absorbed.any?
+        end
+        return if absorbed.empty?
+
+        # The folded waiters may have been everything the topic's "⏳" notice
+        # described, and nothing else will take it down: removal happens when a
+        # promotion drains a *queued* waiter, and this fold left none. Scope the
+        # cleanup to "nobody is waiting any more" rather than "a fold happened"
+        # — another agent's waiter is not this agent's sibling and its wait is
+        # still real.
+        return if Task.queued_for_topic(task.topic_id, task.creative_id).exists?
+
+        cleanup_waiting_notices!(task)
+      end
+
       # Post the "⏳ waiting on the topic slot" notice for a deferral raised
       # outside #enqueue_jobs — AiAgentJob's late slot check, which catches
       # dispatches that passed the Scheduler before any Task row existed.

--- a/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
+++ b/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
@@ -217,7 +217,7 @@ module Collavre
           .where(creative_id: creative_id, topic_id: topic_id)
           .where.not(user_id: [ task.agent_id, nil ])
           .where.not(id: Comment.review_messages.where(creative_id: creative_id, topic_id: topic_id).select(:id))
-          .order(created_at: :desc)
+          .order(id: :desc)
         latest_comment = scope.first
 
         unless latest_comment
@@ -236,6 +236,12 @@ module Collavre
           "user_id" => latest_comment.user_id
         }
         context["chat"] = { "content" => latest_comment.content }
+        # The payload's "sender" is what labels the trigger and what
+        # ClaudeChannelAdapter sends as author_id/author_name, and
+        # SystemEvents::ContextBuilder only ever fills it in with `||=` — it does
+        # not run again here. A burst spanning two people would otherwise put the
+        # first speaker's name on the second's words.
+        context = SystemEvents::ContextBuilder.reanchor_sender(context, latest_comment)
         # absorb_into_payload also drops the new anchor from the merged list, so
         # a comment promoted from "merged" back to "trigger" is not sent twice.
         context = TaskCoalescer.absorb_into_payload(context, [ previous_anchor_id ].compact)

--- a/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
+++ b/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
@@ -206,9 +206,17 @@ module Collavre
         return if review_anchor?(context)
 
         topic_id = context.dig("topic", "id")
+        # ...and a review is no better as a *destination* than as an anchor. The
+        # coalescer leaves a queued review alone, so an ordinary waiter promoted
+        # first would re-anchor onto it and run ReviewHandler over a comment it
+        # was never asked to revise — then the real review task repeats the
+        # revision later. Skip reviews and take the newest ordinary comment,
+        # which in the worst case is the waiter's own anchor (a no-op refresh)
+        # rather than nothing, so this cannot strand a live waiter.
         scope = Comment.public_only.without_approval_action
           .where(creative_id: creative_id, topic_id: topic_id)
           .where.not(user_id: [ task.agent_id, nil ])
+          .where.not(id: Comment.review_messages.where(creative_id: creative_id, topic_id: topic_id).select(:id))
           .order(created_at: :desc)
         latest_comment = scope.first
 

--- a/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
+++ b/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
@@ -286,14 +286,9 @@ module Collavre
       # had one. A shared notice is left alone — it is not this task's to take
       # down, and the drained check above is the question that governs it.
       def self.cleanup_waiter_notice!(task)
-        Comment.where(creative_id: task.creative_id, topic_id: task.topic_id, user_id: nil,
-                      waiting_notice_scope: Comment::WAITING_NOTICE_TASK,
-                      waiting_notice_task_id: task.id)
-               .find_each do |notice|
-          # System promotion, not user abandonment.
-          notice.suppress_waiter_cancellation = true
-          notice.destroy
-        end
+        Comment.remove_waiter_notices!(
+          creative_id: task.creative_id, topic_id: task.topic_id, task_ids: task.id
+        )
       end
       private_class_method :cleanup_waiter_notice!
 

--- a/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
+++ b/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
@@ -228,7 +228,7 @@ module Collavre
         return unless creative_id
 
         Comment.where(creative_id: creative_id, topic_id: topic_id, user_id: nil)
-               .where("content LIKE ?", "⏳%")
+               .where("content LIKE ?", "#{Comment::WAITING_NOTICE_PREFIX}%")
                .find_each do |notice|
           # System promotion, not user abandonment: do not let the destroy
           # callback cancel other still-queued waiters in this topic.
@@ -391,20 +391,7 @@ module Collavre
             AiAgentJob.perform_later(agent.id, @event_name, @context)
             agent
           when :deferred
-            waiter = Task.create!(
-              name: "Response to #{@event_name}",
-              status: "queued",
-              trigger_event_name: @event_name,
-              trigger_event_payload: @context,
-              agent: agent,
-              topic_id: @context.dig("topic", "id"),
-              creative_id: @context.dig("creative", "id")
-            )
-            # A burst of comments queues one waiter each, and every one of them
-            # would answer the same latest comment on promotion. Fold the
-            # earlier ones into this newest waiter — merged, not dropped, so a
-            # session-backed agent still receives their content.
-            TaskCoalescer.coalesce!(waiter) if policy_resolver.coalesce_pending_tasks?
+            park_waiter(agent)
             post_waiting_notice(agent, decision)
             agent
           when :delayed
@@ -417,6 +404,45 @@ module Collavre
             nil
           end
         end
+      end
+
+      # Park this dispatch as a queued waiter and fold the earlier ones into it.
+      #
+      # A burst of comments queues one waiter each, and every one of them would
+      # answer the same latest comment on promotion. Fold them — merged, not
+      # dropped, so a session-backed agent still receives their content.
+      #
+      # Creating the row and folding its predecessors is ONE step, under the
+      # lock AiAgentJob#admit_or_defer! already takes for the other enqueue
+      # door. TaskCoalescer supersedes by `id < keep.id`, which reads as
+      # "everything already parked" only while id order and commit order agree.
+      # An unserialized insert lets them diverge: the higher-id waiter can
+      # commit and fold first, seeing nothing, and the lower-id one then folds
+      # nothing either because the survivor is newer than its guard allows.
+      # Both are still folded at promotion (scope: :all) and again at execution
+      # (coalesce_at_start!), so this is not a duplicate turn — but two doors
+      # onto one queue should not disagree about when a burst becomes one
+      # waiter, and only the serialized one holds without those later passes.
+      def park_waiter(agent)
+        topic_id = @context.dig("topic", "id")
+        creative_id = @context.dig("creative", "id")
+        waiter = nil
+
+        Task.transaction do
+          TopicSlot.lock!(topic_id, creative_id)
+          waiter = Task.create!(
+            name: "Response to #{@event_name}",
+            status: "queued",
+            trigger_event_name: @event_name,
+            trigger_event_payload: @context,
+            agent: agent,
+            topic_id: topic_id,
+            creative_id: creative_id
+          )
+          TaskCoalescer.coalesce!(waiter) if policy_resolver.coalesce_pending_tasks?
+        end
+
+        waiter
       end
 
       def log_decision(decision)

--- a/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
+++ b/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
@@ -358,18 +358,11 @@ module Collavre
         # going to answer. A session-backed agent only receives the :trigger
         # message (SessionContextResolver#incremental_payload), so a silently
         # replaced anchor is a comment the agent never sees at all.
-        context["comment"] = {
-          "id" => latest_comment.id,
-          "content" => latest_comment.content,
-          "user_id" => latest_comment.user_id
-        }
-        context["chat"] = { "content" => latest_comment.content }
-        # The payload's "sender" is what labels the trigger and what
-        # ClaudeChannelAdapter sends as author_id/author_name, and
-        # SystemEvents::ContextBuilder only ever fills it in with `||=` — it does
-        # not run again here. A burst spanning two people would otherwise put the
-        # first speaker's name on the second's words.
-        context = SystemEvents::ContextBuilder.reanchor_sender(context, latest_comment)
+        #
+        # reanchor_payload also records the move when it is one, which is what
+        # delivered_comment_ids reads below: a comment this turn was handed
+        # without having been created for it.
+        context = TaskCoalescer.reanchor_payload(context, latest_comment)
         # absorb_into_payload also drops the new anchor from the merged list, so
         # a comment promoted from "merged" back to "trigger" is not sent twice.
         context = TaskCoalescer.absorb_into_payload(context, [ previous_anchor_id ].compact)
@@ -407,11 +400,13 @@ module Collavre
       #
       # - it sits in the turn's merged list — coalescing put it there, and the
       #   task it belonged to was superseded, so this turn is its only delivery;
-      # - it is the anchor but was posted *after* the turn was created — the
-      #   refresh moved the turn onto it, which is the window this closes.
+      # - it is the anchor, and the payload records that the anchor was moved
+      #   onto it — the refresh acquired it, which is the window this closes.
       #
-      # An anchor older than its own task is that task's original trigger and is
-      # deliberately not counted.
+      # An anchor a task was created for is that task's original trigger and is
+      # deliberately not counted. Which of the two it is comes from the payload
+      # (TaskCoalescer::ACQUIRED_ANCHOR_KEY, written by whichever door moved it)
+      # rather than from comparing the comment's clock with the task's.
       #
       # Scoped by topic and creative, which also keeps workflow subtasks out:
       # Comments::WorkflowExecutor mints its own trigger comment in the child
@@ -426,15 +421,9 @@ module Collavre
           creative_id: context.dig("creative", "id"),
           trigger_event_name: task.trigger_event_name,
           status: DELIVERED_STATUSES
-        ).where.not(id: task.id).select(:id, :created_at, :trigger_event_payload)
+        ).where.not(id: task.id).select(:id, :trigger_event_payload)
 
-        anchors = others.filter_map { |other| [ other, anchor_id_in(other) ] }
-                        .reject { |_, anchor_id| anchor_id.nil? }
-        posted_at = Comment.where(id: anchors.map(&:last)).pluck(:id, :created_at).to_h
-
-        acquired_anchors = anchors.filter_map { |other, anchor_id|
-          anchor_id if posted_at[anchor_id] && posted_at[anchor_id] > other.created_at
-        }
+        acquired_anchors = others.filter_map { |other| acquired_anchor_id_in(other) }
         merged = others.flat_map { |other|
           Array(other.trigger_event_payload&.dig(TaskCoalescer::PAYLOAD_KEY)).compact.map(&:to_i)
         }
@@ -443,11 +432,19 @@ module Collavre
       end
       private_class_method :delivered_comment_ids
 
-      def self.anchor_id_in(other)
-        id = other.trigger_event_payload&.dig("comment", "id")
-        id&.to_i
+      # The anchor of `other`, but only when `other` acquired it rather than
+      # being created for it. The recorded id is compared against the anchor as
+      # it stands now: a payload moved on again since carries the older id in
+      # its merged list, which is counted separately.
+      def self.acquired_anchor_id_in(other)
+        payload = other.trigger_event_payload
+        acquired = payload&.dig(TaskCoalescer::ACQUIRED_ANCHOR_KEY)
+        anchor = payload&.dig("comment", "id")
+        return nil if acquired.nil? || anchor.nil?
+
+        anchor.to_i if acquired.to_i == anchor.to_i
       end
-      private_class_method :anchor_id_in
+      private_class_method :acquired_anchor_id_in
 
       def self.review_anchor?(context)
         anchor_id = context.dig("comment", "id")

--- a/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
+++ b/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
@@ -121,10 +121,21 @@ module Collavre
       # that compete for a notice are exactly the ones that competed for the
       # slot, so the loser reads the winner's committed notice.
       #
-      # Yields only when no notice exists yet; returns nil otherwise.
+      # The same lock also decides whether a notice is still warranted at all.
+      # The waiter commits before its notice goes up, so the blocker can finish
+      # in between, promote it, and run cleanup_waiting_notices! before any
+      # notice exists. A notice posted after that cleanup describes a wait that
+      # is already over, and nothing will ever take it down: removal only
+      # happens when a promotion drains a *queued* waiter, and there is none
+      # left. Promotion takes this same row, so "still queued" read here is the
+      # promotion's own before-or-after, not a guess.
+      #
+      # Yields only when a waiter is still queued and no notice exists yet;
+      # returns nil otherwise.
       def self.with_deduped_topic_notice(creative_id, topic_id)
         Comment.transaction do
           TopicSlot.lock!(topic_id, creative_id)
+          next nil unless Task.queued_for_topic(topic_id, creative_id).exists?
           next nil if topic_concurrency_notice_exists?(creative_id, topic_id)
 
           yield
@@ -188,6 +199,12 @@ module Collavre
         creative_id = context&.dig("creative", "id")
         return unless creative_id && context&.key?("topic")
 
+        # Keeping a review out of TaskCoalescer is only half the boundary: the
+        # refresh is the other door onto the anchor, and moving it forward turns
+        # the in-place revision into a plain reply just as surely. A review
+        # answers the comment it quotes or nothing at all, so leave it alone.
+        return if review_anchor?(context)
+
         topic_id = context.dig("topic", "id")
         scope = Comment.public_only.without_approval_action
           .where(creative_id: creative_id, topic_id: topic_id)
@@ -218,6 +235,12 @@ module Collavre
       end
       private_class_method :refresh_deferred_context!
 
+      def self.review_anchor?(context)
+        anchor_id = context.dig("comment", "id")
+        anchor_id.present? && Comment.review_message_ids([ anchor_id ]).any?
+      end
+      private_class_method :review_anchor?
+
       # Cancel a promoted waiter whose agent the topic's primary-agent assignment
       # now excludes. A queued task keeps the agent chosen when it was dispatched,
       # so a pin created or moved while it waited would otherwise be bypassed by
@@ -234,8 +257,7 @@ module Collavre
 
         agent = task.agent
         return unless agent
-        return if Matcher.new(SystemEvents::ContextBuilder.new(context).build)
-                         .assignment_permits?(agent)
+        return if Matcher.permits_assignment?(context, agent)
 
         Rails.logger.info(
           "[AgentOrchestrator] Cancelling queued task #{task.id}: topic #{task.topic_id} " \

--- a/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
+++ b/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
@@ -133,10 +133,27 @@ module Collavre
       # Yields only when a waiter is still queued and no notice exists yet;
       # returns nil otherwise.
       def self.with_deduped_topic_notice(creative_id, topic_id)
+        with_live_topic_wait(creative_id, topic_id) do
+          next nil if topic_concurrency_notice_exists?(creative_id, topic_id)
+
+          yield
+        end
+      end
+
+      # The "is anyone still waiting?" half on its own, without the "only one
+      # notice per topic" half.
+      #
+      # With coalesce_pending_tasks off, each deferral keeps its own waiter, so
+      # each one needs its own notice: a single notice standing for N
+      # independent waiters turns its stop button into "cancel everyone's work"
+      # (Comment#cancel_queued_tasks_for_waiting_notice reads "no sibling notice
+      # left" as "this notice spoke for the topic"). The drain guard still
+      # applies either way — a notice explaining a wait that is already over is
+      # never removed by anything.
+      def self.with_live_topic_wait(creative_id, topic_id)
         Comment.transaction do
           TopicSlot.lock!(topic_id, creative_id)
           next nil unless Task.queued_for_topic(topic_id, creative_id).exists?
-          next nil if topic_concurrency_notice_exists?(creative_id, topic_id)
 
           yield
         end
@@ -219,16 +236,19 @@ module Collavre
       # Post the "⏳ waiting on the topic slot" notice for a deferral raised
       # outside #enqueue_jobs — AiAgentJob's late slot check, which catches
       # dispatches that passed the Scheduler before any Task row existed.
-      # No-op when a notice for this creative/topic is already up.
-      def self.post_topic_concurrency_notice(creative_id, topic_id)
+      # No-op when a notice for this creative/topic is already up — unless
+      # coalescing is off for this dispatch, in which case its waiter is nobody
+      # else's to speak for and gets a notice of its own, exactly as
+      # #post_waiting_notice does on the enqueue door. Leaving one door
+      # deduplicated and the other not is what breaks the opt-out's 1:1.
+      def self.post_topic_concurrency_notice(creative_id, topic_id, context = nil)
         return if creative_id.nil?
 
         creative = Creative.find_by(id: creative_id)
         return unless creative
 
         reason_text = waiting_reason_text(:topic_concurrency, topic_id, creative_id)
-
-        with_deduped_topic_notice(creative_id, topic_id) do
+        post = lambda do
           creative.comments.create!(
             content: I18n.t("collavre.orchestration.waiting_notice", reason: reason_text),
             topic_id: topic_id,
@@ -236,6 +256,12 @@ module Collavre
             skip_default_user: true,
             topic_concurrency_defer: true
           )
+        end
+
+        if PolicyResolver.new(context || {}).coalesce_pending_tasks?
+          with_deduped_topic_notice(creative_id, topic_id, &post)
+        else
+          with_live_topic_wait(creative_id, topic_id, &post)
         end
       end
 

--- a/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
+++ b/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
@@ -182,7 +182,7 @@ module Collavre
         Task.transaction do
           TopicSlot.lock!(task.topic_id, task.creative_id)
           absorbed = TaskCoalescer.coalesce!(task, scope: :all)
-          refresh_deferred_context!(task) if absorbed.any?
+          refresh_deferred_context!(task, absorbed_only: true) if absorbed.any?
         end
         return if absorbed.empty?
 
@@ -261,7 +261,21 @@ module Collavre
       # conversation state instead of the stale snapshot from enqueue time.
       # Skips AI agent's own comments to prevent self-response loops.
       # Cancels the task if no eligible comment remains.
-      def self.refresh_deferred_context!(task)
+      #
+      # `absorbed_only` narrows the destination to the comments this turn is
+      # actually answering — its anchor plus what coalescing folded into it.
+      # A comment commits in its own transaction and its AiAgentJob creates the
+      # queued task afterwards, so a comment can be visible here with no task
+      # behind it yet: the topic lock orders task creation, not comment
+      # visibility. Moving the anchor onto one of those has this turn answer a
+      # comment it never absorbed, and when that job does run it parks a waiter
+      # against the now-claimed task — the same comment answered twice.
+      #
+      # Only coalesce_at_start! passes it. Promotion's refresh has always taken
+      # the newest comment in the topic ("the latest state, not the enqueue-time
+      # snapshot" is the whole reason it exists) and that is a wider question
+      # than this call site.
+      def self.refresh_deferred_context!(task, absorbed_only: false)
         context = task.trigger_event_payload
         creative_id = context&.dig("creative", "id")
         return unless creative_id && context&.key?("topic")
@@ -273,6 +287,7 @@ module Collavre
         return if review_anchor?(context)
 
         topic_id = context.dig("topic", "id")
+
         # ...and a review is no better as a *destination* than as an anchor. The
         # coalescer leaves a queued review alone, so an ordinary waiter promoted
         # first would re-anchor onto it and run ReviewHandler over a comment it
@@ -285,6 +300,15 @@ module Collavre
           .where.not(user_id: [ task.agent_id, nil ])
           .where.not(id: Comment.review_messages.where(creative_id: creative_id, topic_id: topic_id).select(:id))
           .order(id: :desc)
+
+        if absorbed_only
+          candidate_ids = (Array(context[TaskCoalescer::PAYLOAD_KEY]) + [ context.dig("comment", "id") ])
+            .compact.map(&:to_i).uniq
+          return if candidate_ids.empty?
+
+          scope = scope.where(id: candidate_ids)
+        end
+
         latest_comment = scope.first
 
         unless latest_comment

--- a/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
+++ b/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
@@ -102,11 +102,20 @@ module Collavre
       end
 
       # Is there already a "⏳" topic-concurrency waiting notice on this
-      # creative/topic? Shared with AiAgentJob's late slot check so both defer
-      # paths post at most one notice per topic.
+      # creative/topic that stands for the topic as a whole? Shared with
+      # AiAgentJob's late slot check so both defer paths post at most one shared
+      # notice per topic.
+      #
+      # A per-deferral notice does not count. It speaks for one waiter, so
+      # letting it suppress the shared one would leave a coalescing agent's
+      # waiters with no notice at all whenever an opted-out agent happened to
+      # defer into the topic first. Notices from before the mode was recorded do
+      # count: they are the topic's only signal, and posting a second one beside
+      # them is the duplication this guard exists to prevent.
       def self.topic_concurrency_notice_exists?(creative_id, topic_id)
         Comment.where(creative_id: creative_id, topic_id: topic_id, user_id: nil,
                       topic_concurrency_defer: true)
+               .where(waiting_notice_scope: [ nil, Comment::WAITING_NOTICE_TOPIC ])
                .where("content LIKE ?", "#{Comment::WAITING_NOTICE_PREFIX}%")
                .exists?
       end
@@ -160,7 +169,8 @@ module Collavre
       end
 
       def self.coalesce_promoted!(task)
-        return unless PolicyResolver.new(task.trigger_event_payload || {}).coalesce_pending_tasks?
+        return unless PolicyResolver.new(task.trigger_event_payload || {})
+                        .coalesce_pending_tasks_for?(task.agent)
 
         TaskCoalescer.coalesce!(task, scope: :all)
       end
@@ -193,7 +203,7 @@ module Collavre
 
         context = task.trigger_event_payload || {}
         return unless context.key?("topic")
-        return unless PolicyResolver.new(context).coalesce_pending_tasks?
+        return unless PolicyResolver.new(context).coalesce_pending_tasks_for?(task.agent)
 
         absorbed = []
         Task.transaction do
@@ -223,15 +233,37 @@ module Collavre
       # that path's own before-or-after rather than a guess: a deferral either
       # commits its waiter before this reads, and keeps its notice, or after, and
       # posts its own.
+      # …but that guard is about the *shared* notice, which is still describing a
+      # real wait for as long as anyone is queued. A per-deferral notice speaks
+      # for one waiter, so it comes down when that waiter leaves the queue and
+      # not a moment later: with the opt-out and two waiters, promoting one
+      # leaves the queue non-empty, and the notice for the task now running would
+      # stay on screen with a stop button for a wait that is over.
       def self.cleanup_waiting_notices_if_drained!(task)
         Comment.transaction do
           TopicSlot.lock!(task.topic_id, task.creative_id)
+          cleanup_waiter_notice!(task)
           next if Task.queued_for_topic(task.topic_id, task.creative_id).exists?
 
           cleanup_waiting_notices!(task)
         end
       end
       private_class_method :cleanup_waiting_notices_if_drained!
+
+      # Remove the per-deferral notice posted for this particular waiter, if it
+      # had one. A shared notice is left alone — it is not this task's to take
+      # down, and the drained check above is the question that governs it.
+      def self.cleanup_waiter_notice!(task)
+        Comment.where(creative_id: task.creative_id, topic_id: task.topic_id, user_id: nil,
+                      waiting_notice_scope: Comment::WAITING_NOTICE_TASK,
+                      waiting_notice_task_id: task.id)
+               .find_each do |notice|
+          # System promotion, not user abandonment.
+          notice.suppress_waiter_cancellation = true
+          notice.destroy
+        end
+      end
+      private_class_method :cleanup_waiter_notice!
 
       # Post the "⏳ waiting on the topic slot" notice for a deferral raised
       # outside #enqueue_jobs — AiAgentJob's late slot check, which catches
@@ -241,24 +273,30 @@ module Collavre
       # else's to speak for and gets a notice of its own, exactly as
       # #post_waiting_notice does on the enqueue door. Leaving one door
       # deduplicated and the other not is what breaks the opt-out's 1:1.
-      def self.post_topic_concurrency_notice(creative_id, topic_id, context = nil)
+      def self.post_topic_concurrency_notice(creative_id, topic_id, context = nil, agent: nil, waiter: nil)
         return if creative_id.nil?
 
         creative = Creative.find_by(id: creative_id)
         return unless creative
 
         reason_text = waiting_reason_text(:topic_concurrency, topic_id, creative_id)
+        shared = PolicyResolver.new(context || {}).coalesce_pending_tasks_for?(agent)
         post = lambda do
           creative.comments.create!(
             content: I18n.t("collavre.orchestration.waiting_notice", reason: reason_text),
             topic_id: topic_id,
             private: false,
             skip_default_user: true,
-            topic_concurrency_defer: true
+            topic_concurrency_defer: true,
+            # What this notice speaks for, recorded rather than reconstructed
+            # later from whichever siblings survive. See
+            # Comment#cancel_queued_tasks_for_waiting_notice.
+            waiting_notice_scope: shared ? Comment::WAITING_NOTICE_TOPIC : Comment::WAITING_NOTICE_TASK,
+            waiting_notice_task_id: shared ? nil : waiter&.id
           )
         end
 
-        if PolicyResolver.new(context || {}).coalesce_pending_tasks?
+        if shared
           with_deduped_topic_notice(creative_id, topic_id, &post)
         else
           with_live_topic_wait(creative_id, topic_id, &post)
@@ -310,7 +348,20 @@ module Collavre
         # refresh is the other door onto the anchor, and moving it forward turns
         # the in-place revision into a plain reply just as surely. A review
         # answers the comment it quotes or nothing at all, so leave it alone.
-        return if review_anchor?(context)
+        #
+        # "Not moved" is not "not checked", though. An ordinary anchor is
+        # revalidated by having to be re-selected through the eligibility scope
+        # below; a review that skips straight past it keeps whatever
+        # trigger_event_payload cached, and the anchor is the one part of the
+        # payload MessageBuilder renders without a filter. ReviewHandler#eligible?
+        # only asks whether the *quoted* comment is private, so a review request
+        # the user withdrew — or that was moved out of this turn's scope — while
+        # it waited would still be delivered, and still drive an in-place
+        # revision of the agent's comment.
+        if review_anchor?(context)
+          task.update!(status: "cancelled") unless anchor_still_in_turn?(context)
+          return
+        end
 
         topic_id = context.dig("topic", "id")
         previous_anchor_id = context.dig("comment", "id")
@@ -446,6 +497,21 @@ module Collavre
       end
       private_class_method :acquired_anchor_id_in
 
+      # May this turn still deliver the comment it is anchored on?
+      #
+      # Asked through MergedTriggerComments.in_turn — the same predicate the
+      # renderer uses for the merged list and Matcher.permits_assignment? for the
+      # mention — so an anchor cannot be delivered under rules the rest of the
+      # payload is filtered by: public_only, no approval surface, and still in
+      # this turn's creative/topic.
+      def self.anchor_still_in_turn?(context)
+        anchor_id = context.dig("comment", "id")
+        return false if anchor_id.blank?
+
+        AiAgent::MergedTriggerComments.in_turn([ anchor_id ], context).exists?
+      end
+      private_class_method :anchor_still_in_turn?
+
       def self.review_anchor?(context)
         anchor_id = context.dig("comment", "id")
         anchor_id.present? && Comment.review_message_ids([ anchor_id ]).any?
@@ -540,8 +606,8 @@ module Collavre
             AiAgentJob.perform_later(agent.id, @event_name, @context)
             agent
           when :deferred
-            park_waiter(agent)
-            post_waiting_notice(agent, decision)
+            waiter = park_waiter(agent)
+            post_waiting_notice(agent, decision, waiter: waiter)
             agent
           when :delayed
             AiAgentJob.set(wait: decision[:delay]).perform_later(
@@ -588,7 +654,7 @@ module Collavre
             topic_id: topic_id,
             creative_id: creative_id
           )
-          TaskCoalescer.coalesce!(waiter) if policy_resolver.coalesce_pending_tasks?
+          TaskCoalescer.coalesce!(waiter) if policy_resolver.coalesce_pending_tasks_for?(agent)
         end
 
         waiter
@@ -605,7 +671,7 @@ module Collavre
         )
       end
 
-      def post_waiting_notice(agent, decision)
+      def post_waiting_notice(agent, decision, waiter: nil)
         creative_id = @context.dig("creative", "id")
         topic_id = @context.dig("topic", "id")
         return unless creative_id
@@ -621,16 +687,19 @@ module Collavre
         # Keep exactly one topic-concurrency notice per creative/topic — and take
         # the check and the insert under one lock, since a burst is precisely
         # when an unserialized check reads stale.
-        if deferred && policy_resolver.coalesce_pending_tasks?
+        shared = deferred && policy_resolver.coalesce_pending_tasks_for?(agent)
+        if shared
           self.class.with_deduped_topic_notice(creative_id, topic_id) do
-            create_waiting_notice(creative, topic_id, reason_text, deferred: deferred)
+            create_waiting_notice(creative, topic_id, reason_text, deferred: deferred,
+                                  shared: true, waiter: waiter)
           end
         else
-          create_waiting_notice(creative, topic_id, reason_text, deferred: deferred)
+          create_waiting_notice(creative, topic_id, reason_text, deferred: deferred,
+                                shared: false, waiter: waiter)
         end
       end
 
-      def create_waiting_notice(creative, topic_id, reason_text, deferred:)
+      def create_waiting_notice(creative, topic_id, reason_text, deferred:, shared:, waiter:)
         creative.comments.create!(
           content: I18n.t("collavre.orchestration.waiting_notice", reason: reason_text),
           topic_id: topic_id,
@@ -638,7 +707,12 @@ module Collavre
           skip_default_user: true,
           # Only :deferred queues a topic waiter; mark it so its stop button can
           # target the blocker. :delayed (busy / rate_limited) notices stay false.
-          topic_concurrency_defer: deferred
+          topic_concurrency_defer: deferred,
+          # …and only a :deferred notice speaks for a waiter at all, so only that
+          # one records which. A :delayed notice never reaches
+          # Comment#cancel_queued_tasks_for_waiting_notice.
+          waiting_notice_scope: deferred ? (shared ? Comment::WAITING_NOTICE_TOPIC : Comment::WAITING_NOTICE_TASK) : nil,
+          waiting_notice_task_id: (waiter&.id unless shared)
         )
       end
 

--- a/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
+++ b/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
@@ -27,14 +27,28 @@ module Collavre
           # the refresh below then moves the anchor forward and keeps the
           # absorbed triggers in "merged_comment_ids".
           coalesce_promoted!(task)
-          cleanup_waiting_notices_if_drained!(task)
-          refresh_deferred_context!(task)
-          revalidate_assignment!(task) unless task.status == "cancelled"
+
+          # `task` is the snapshot claim_next_waiter took, and the row can be
+          # cancelled from outside between that claim and here: deleting the
+          # comment it answers cancels a `pending` task through
+          # Comment#cancel_pending_tasks, which holds no lock this path waits
+          # on. TaskCoalescer re-reads the survivor under its own lock and
+          # declines to fold onto a cancelled row — but declining leaves this
+          # object still saying `pending`, and everything below reads it: the
+          # refresh would write a payload onto a dead row and the check at the
+          # bottom would enqueue it, where AiAgentJob reloads and returns
+          # without draining. Re-read once, here, rather than at each of them.
+          unless task.reload.status == "cancelled"
+            cleanup_waiting_notices_if_drained!(task)
+            refresh_deferred_context!(task)
+            revalidate_assignment!(task) unless task.status == "cancelled"
+          end
 
           if task.status == "cancelled"
-            # refresh_deferred_context! found no eligible comment, or
-            # revalidate_assignment! found the topic now assigned to another
-            # agent. Either way this waiter is dead — try the next queued task.
+            # The anchor was deleted under it, refresh_deferred_context! found
+            # no eligible comment, or revalidate_assignment! found the topic now
+            # assigned to another agent. Either way this waiter is dead — try
+            # the next queued task.
             dequeue_next_for_topic(topic_id, creative_id)
           else
             AiAgentJob.perform_later(task)

--- a/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
+++ b/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
@@ -23,6 +23,14 @@ module Collavre
         updated = Task.where(id: task.id, status: "queued").update_all(status: "pending")
         if updated > 0
           task.reload
+          # Fold the waiters left behind this one into it. dequeue promotes the
+          # OLDEST queued task, so its same-agent siblings are all newer — they
+          # would each be promoted in turn and, because
+          # refresh_deferred_context! points every one of them at the same
+          # latest comment, replay the same answer. Absorb them here instead;
+          # the refresh below then moves the anchor forward and keeps the
+          # absorbed triggers in "merged_comment_ids".
+          coalesce_promoted!(task)
           cleanup_waiting_notices!(task)
           refresh_deferred_context!(task)
           revalidate_assignment!(task) unless task.status == "cancelled"
@@ -36,6 +44,67 @@ module Collavre
             AiAgentJob.perform_later(task)
           end
         end
+      end
+
+      # Human-readable reason for the "⏳" waiting notice. For topic-concurrency
+      # deferrals, name the agent(s) actually holding the topic's running slot so
+      # a waiting user can see *who* is blocking them (and reach that task's stop
+      # button) rather than an anonymous "another task is running" dead end.
+      def self.waiting_reason_text(reason_key, topic_id, creative_id)
+        if reason_key == :topic_concurrency && topic_id
+          names = Task.running_for_topic(topic_id, creative_id)
+                      .includes(:agent).filter_map { |t| t.agent&.name }.uniq
+          if names.any?
+            return I18n.t(
+              "collavre.orchestration.waiting_reasons.topic_concurrency_with_agent",
+              agent: names.join(", ")
+            )
+          end
+        end
+
+        I18n.t(
+          "collavre.orchestration.waiting_reasons.#{reason_key}",
+          default: reason_key.to_s.humanize
+        )
+      end
+
+      # Is there already a "⏳" topic-concurrency waiting notice on this
+      # creative/topic? Shared with AiAgentJob's late slot check so both defer
+      # paths post at most one notice per topic.
+      def self.topic_concurrency_notice_exists?(creative_id, topic_id)
+        Comment.where(creative_id: creative_id, topic_id: topic_id, user_id: nil,
+                      topic_concurrency_defer: true)
+               .where("content LIKE ?", "#{Comment::WAITING_NOTICE_PREFIX}%")
+               .exists?
+      end
+
+      def self.coalesce_promoted!(task)
+        return unless PolicyResolver.new(task.trigger_event_payload || {}).coalesce_pending_tasks?
+
+        TaskCoalescer.coalesce!(task, scope: :all)
+      end
+      private_class_method :coalesce_promoted!
+
+      # Post the "⏳ waiting on the topic slot" notice for a deferral raised
+      # outside #enqueue_jobs — AiAgentJob's late slot check, which catches
+      # dispatches that passed the Scheduler before any Task row existed.
+      # No-op when a notice for this creative/topic is already up.
+      def self.post_topic_concurrency_notice(creative_id, topic_id)
+        return if creative_id.nil?
+        return if topic_concurrency_notice_exists?(creative_id, topic_id)
+
+        creative = Creative.find_by(id: creative_id)
+        return unless creative
+
+        reason_text = waiting_reason_text(:topic_concurrency, topic_id, creative_id)
+
+        creative.comments.create!(
+          content: I18n.t("collavre.orchestration.waiting_notice", reason: reason_text),
+          topic_id: topic_id,
+          private: false,
+          skip_default_user: true,
+          topic_concurrency_defer: true
+        )
       end
 
       # Remove waiting notice comments (system messages) for this task's creative/topic.
@@ -77,12 +146,20 @@ module Collavre
           return
         end
 
+        # Moving the anchor forward must not drop what the task was originally
+        # going to answer. A session-backed agent only receives the :trigger
+        # message (SessionContextResolver#incremental_payload), so a silently
+        # replaced anchor is a comment the agent never sees at all.
+        previous_anchor_id = context.dig("comment", "id")
         context["comment"] = {
           "id" => latest_comment.id,
           "content" => latest_comment.content,
           "user_id" => latest_comment.user_id
         }
         context["chat"] = { "content" => latest_comment.content }
+        # absorb_into_payload also drops the new anchor from the merged list, so
+        # a comment promoted from "merged" back to "trigger" is not sent twice.
+        context = TaskCoalescer.absorb_into_payload(context, [ previous_anchor_id ].compact)
         task.update!(trigger_event_payload: context)
       end
       private_class_method :refresh_deferred_context!
@@ -176,7 +253,7 @@ module Collavre
             AiAgentJob.perform_later(agent.id, @event_name, @context)
             agent
           when :deferred
-            Task.create!(
+            waiter = Task.create!(
               name: "Response to #{@event_name}",
               status: "queued",
               trigger_event_name: @event_name,
@@ -185,6 +262,11 @@ module Collavre
               topic_id: @context.dig("topic", "id"),
               creative_id: @context.dig("creative", "id")
             )
+            # A burst of comments queues one waiter each, and every one of them
+            # would answer the same latest comment on promotion. Fold the
+            # earlier ones into this newest waiter — merged, not dropped, so a
+            # session-backed agent still receives their content.
+            TaskCoalescer.coalesce!(waiter) if policy_resolver.coalesce_pending_tasks?
             post_waiting_notice(agent, decision)
             agent
           when :delayed
@@ -218,6 +300,13 @@ module Collavre
         creative = Creative.find_by(id: creative_id)
         return unless creative
 
+        # Coalescing collapses a burst of deferrals into one waiter, so a notice
+        # per deferral would leave N-1 dead ends pointing at the same blocker.
+        # Keep exactly one topic-concurrency notice per creative/topic.
+        return if decision[:timing] == :deferred &&
+                  policy_resolver.coalesce_pending_tasks? &&
+                  self.class.topic_concurrency_notice_exists?(creative_id, topic_id)
+
         reason_text = waiting_reason_text(decision[:reason] || :unknown, topic_id, creative_id)
 
         creative.comments.create!(
@@ -236,21 +325,7 @@ module Collavre
       # a waiting user can see *who* is blocking them (and reach that task's stop
       # button) rather than an anonymous "another task is running" dead end.
       def waiting_reason_text(reason_key, topic_id, creative_id)
-        if reason_key == :topic_concurrency && topic_id
-          names = Task.running_for_topic(topic_id, creative_id)
-                      .includes(:agent).filter_map { |t| t.agent&.name }.uniq
-          if names.any?
-            return I18n.t(
-              "collavre.orchestration.waiting_reasons.topic_concurrency_with_agent",
-              agent: names.join(", ")
-            )
-          end
-        end
-
-        I18n.t(
-          "collavre.orchestration.waiting_reasons.#{reason_key}",
-          default: reason_key.to_s.humanize
-        )
+        self.class.waiting_reason_text(reason_key, topic_id, creative_id)
       end
     end
   end

--- a/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
+++ b/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
@@ -168,6 +168,38 @@ module Collavre
         end
       end
 
+      # The same guard for a notice that speaks for exactly one waiter.
+      #
+      # "Is anyone still waiting?" is the *shared* notice's question, and it
+      # stays true for as long as any waiter is queued. A per-deferral notice
+      # answers for one — and that one can be promoted between its row
+      # committing and this lock, since the waiter is created and the notice
+      # posted in two steps on both doors. With another deferral parked in the
+      # same burst the topic-wide question then says yes while this waiter's
+      # says no, and the notice goes up offering a stop button for a turn that
+      # is already running.
+      #
+      # Nothing takes it back down. cleanup_waiter_notice! is the only path that
+      # removes one, it runs during the promotion that just happened, and it
+      # matched nothing because the notice did not exist yet; deleting it by
+      # hand cancels nothing either, since a task-scoped notice selects its own
+      # waiter and that waiter is no longer queued.
+      #
+      # Asked under the admission lock, so "still queued" is the promotion's own
+      # before-or-after rather than a guess.
+      def self.with_live_waiter(waiter, creative_id, topic_id, &block)
+        # No waiter to speak for: the topic-wide question is all a caller
+        # without one can be asked.
+        return with_live_topic_wait(creative_id, topic_id, &block) if waiter.nil?
+
+        Comment.transaction do
+          TopicSlot.lock!(topic_id, creative_id)
+          next nil unless Task.where(id: waiter.id, status: "queued").exists?
+
+          yield
+        end
+      end
+
       def self.coalesce_promoted!(task)
         return unless PolicyResolver.new(task.trigger_event_payload || {})
                         .coalesce_pending_tasks_for?(task.agent)
@@ -299,7 +331,7 @@ module Collavre
         if shared
           with_deduped_topic_notice(creative_id, topic_id, &post)
         else
-          with_live_topic_wait(creative_id, topic_id, &post)
+          with_live_waiter(waiter, creative_id, topic_id, &post)
         end
       end
 
@@ -693,7 +725,17 @@ module Collavre
             create_waiting_notice(creative, topic_id, reason_text, deferred: deferred,
                                   shared: true, waiter: waiter)
           end
+        elsif deferred
+          # park_waiter commits the row and this posts its notice afterwards, so
+          # the same window with_live_waiter closes on the late-admission door is
+          # open here too — see that method.
+          self.class.with_live_waiter(waiter, creative_id, topic_id) do
+            create_waiting_notice(creative, topic_id, reason_text, deferred: deferred,
+                                  shared: false, waiter: waiter)
+          end
         else
+          # :delayed. The dispatch is still going to run, so there is no waiter
+          # for this notice to speak for and nothing for the guard to ask about.
           create_waiting_notice(creative, topic_id, reason_text, deferred: deferred,
                                 shared: false, waiter: waiter)
         end

--- a/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
+++ b/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
@@ -17,15 +17,11 @@ module Collavre
       end
 
       def self.dequeue_next_for_topic(topic_id, creative_id = nil)
-        task = Task.queued_for_topic(topic_id, creative_id).first
-        return unless task
-
-        updated = Task.where(id: task.id, status: "queued").update_all(status: "pending")
-        if updated > 0
-          task.reload
+        task = claim_next_waiter(topic_id, creative_id)
+        if task
           # Fold the waiters left behind this one into it. dequeue promotes the
-          # OLDEST queued task, so its same-agent siblings are all newer — they
-          # would each be promoted in turn and, because
+          # oldest *eligible* queued task, so its same-agent siblings are all
+          # newer — they would each be promoted in turn and, because
           # refresh_deferred_context! points every one of them at the same
           # latest comment, replay the same answer. Absorb them here instead;
           # the refresh below then moves the anchor forward and keeps the
@@ -45,6 +41,43 @@ module Collavre
           end
         end
       end
+
+      # Promote the oldest waiter this topic can actually run, moving it
+      # queued -> pending (a status that occupies the slot) so the claim is
+      # visible to every other admission the moment it commits.
+      #
+      # Promotion is a slot hand-out just like AiAgentJob's admission, so it
+      # takes the same lock and asks the same question. Without that, a caller
+      # that merely observed *a* task finish would promote into a topic that is
+      # still full (every terminal task in the topic calls here, including ones
+      # that never held this slot), or hand a second concurrent turn to an agent
+      # that is already running one — which TaskCoalescer, folding only `queued`
+      # rows, could never merge after the fact.
+      #
+      # The oldest waiter is not always eligible: with topic_max > 1 the head of
+      # the queue may belong to a busy agent while a later waiter can run now.
+      # Stopping at the queue head would strand the whole queue behind it, so
+      # scan in order for the first waiter that fits.
+      def self.claim_next_waiter(topic_id, creative_id)
+        claimed = nil
+
+        Task.transaction do
+          TopicSlot.lock!(topic_id, creative_id)
+
+          candidate = Task.queued_for_topic(topic_id, creative_id).find do |waiter|
+            TopicSlot.available_for?(
+              waiter.agent_id, topic_id, creative_id, waiter.trigger_event_payload
+            )
+          end
+          next if candidate.nil?
+
+          updated = Task.where(id: candidate.id, status: "queued").update_all(status: "pending")
+          claimed = candidate.reload if updated > 0
+        end
+
+        claimed
+      end
+      private_class_method :claim_next_waiter
 
       # Human-readable reason for the "⏳" waiting notice. For topic-concurrency
       # deferrals, name the agent(s) actually holding the topic's running slot so

--- a/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
+++ b/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
@@ -111,6 +111,26 @@ module Collavre
                .exists?
       end
 
+      # Check-then-insert the one waiting notice a topic is allowed, as a single
+      # step. Both defer paths run for a *burst* — the case where every worker
+      # reads "no notice yet" before any of them inserts — so an unserialized
+      # check leaves N dead-end notices pointing at one blocker, and deleting one
+      # of them cancels the waiters while the others linger.
+      #
+      # Serialize on the same row admission locks (TopicSlot.lock!): the workers
+      # that compete for a notice are exactly the ones that competed for the
+      # slot, so the loser reads the winner's committed notice.
+      #
+      # Yields only when no notice exists yet; returns nil otherwise.
+      def self.with_deduped_topic_notice(creative_id, topic_id)
+        Comment.transaction do
+          TopicSlot.lock!(topic_id, creative_id)
+          next nil if topic_concurrency_notice_exists?(creative_id, topic_id)
+
+          yield
+        end
+      end
+
       def self.coalesce_promoted!(task)
         return unless PolicyResolver.new(task.trigger_event_payload || {}).coalesce_pending_tasks?
 
@@ -124,20 +144,21 @@ module Collavre
       # No-op when a notice for this creative/topic is already up.
       def self.post_topic_concurrency_notice(creative_id, topic_id)
         return if creative_id.nil?
-        return if topic_concurrency_notice_exists?(creative_id, topic_id)
 
         creative = Creative.find_by(id: creative_id)
         return unless creative
 
         reason_text = waiting_reason_text(:topic_concurrency, topic_id, creative_id)
 
-        creative.comments.create!(
-          content: I18n.t("collavre.orchestration.waiting_notice", reason: reason_text),
-          topic_id: topic_id,
-          private: false,
-          skip_default_user: true,
-          topic_concurrency_defer: true
-        )
+        with_deduped_topic_notice(creative_id, topic_id) do
+          creative.comments.create!(
+            content: I18n.t("collavre.orchestration.waiting_notice", reason: reason_text),
+            topic_id: topic_id,
+            private: false,
+            skip_default_user: true,
+            topic_concurrency_defer: true
+          )
+        end
       end
 
       # Remove waiting notice comments (system messages) for this task's creative/topic.
@@ -333,15 +354,24 @@ module Collavre
         creative = Creative.find_by(id: creative_id)
         return unless creative
 
+        reason_text = waiting_reason_text(decision[:reason] || :unknown, topic_id, creative_id)
+        deferred = decision[:timing] == :deferred
+
         # Coalescing collapses a burst of deferrals into one waiter, so a notice
         # per deferral would leave N-1 dead ends pointing at the same blocker.
-        # Keep exactly one topic-concurrency notice per creative/topic.
-        return if decision[:timing] == :deferred &&
-                  policy_resolver.coalesce_pending_tasks? &&
-                  self.class.topic_concurrency_notice_exists?(creative_id, topic_id)
+        # Keep exactly one topic-concurrency notice per creative/topic — and take
+        # the check and the insert under one lock, since a burst is precisely
+        # when an unserialized check reads stale.
+        if deferred && policy_resolver.coalesce_pending_tasks?
+          self.class.with_deduped_topic_notice(creative_id, topic_id) do
+            create_waiting_notice(creative, topic_id, reason_text, deferred: deferred)
+          end
+        else
+          create_waiting_notice(creative, topic_id, reason_text, deferred: deferred)
+        end
+      end
 
-        reason_text = waiting_reason_text(decision[:reason] || :unknown, topic_id, creative_id)
-
+      def create_waiting_notice(creative, topic_id, reason_text, deferred:)
         creative.comments.create!(
           content: I18n.t("collavre.orchestration.waiting_notice", reason: reason_text),
           topic_id: topic_id,
@@ -349,7 +379,7 @@ module Collavre
           skip_default_user: true,
           # Only :deferred queues a topic waiter; mark it so its stop button can
           # target the blocker. :delayed (busy / rate_limited) notices stay false.
-          topic_concurrency_defer: decision[:timing] == :deferred
+          topic_concurrency_defer: deferred
         )
       end
 

--- a/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
+++ b/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
@@ -287,6 +287,8 @@ module Collavre
         return if review_anchor?(context)
 
         topic_id = context.dig("topic", "id")
+        previous_anchor_id = context.dig("comment", "id")
+        delivered_ids = delivered_comment_ids(task, context)
 
         # ...and a review is no better as a *destination* than as an anchor. The
         # coalescer leaves a queued review alone, so an ordinary waiter promoted
@@ -301,8 +303,18 @@ module Collavre
           .where.not(id: Comment.review_messages.where(creative_id: creative_id, topic_id: topic_id).select(:id))
           .order(id: :desc)
 
+        # Narrowing the destination closes the door this call site opens, but the
+        # promotion door still moves the anchor onto the newest comment in the
+        # topic — deliberately, since that is the reason the refresh exists. So
+        # ask the question from the delivery side as well: a comment already
+        # handed to this agent is not handed to it again, whichever door moved
+        # the anchor onto it. Asking here rather than at dispatch is what keeps
+        # it loss-free — by promotion time the covering turn's status says
+        # whether it actually delivered anything.
+        scope = scope.where.not(id: delivered_ids) if delivered_ids.any?
+
         if absorbed_only
-          candidate_ids = (Array(context[TaskCoalescer::PAYLOAD_KEY]) + [ context.dig("comment", "id") ])
+          candidate_ids = (Array(context[TaskCoalescer::PAYLOAD_KEY]) + [ previous_anchor_id ])
             .compact.map(&:to_i).uniq
           return if candidate_ids.empty?
 
@@ -320,7 +332,6 @@ module Collavre
         # going to answer. A session-backed agent only receives the :trigger
         # message (SessionContextResolver#incremental_payload), so a silently
         # replaced anchor is a comment the agent never sees at all.
-        previous_anchor_id = context.dig("comment", "id")
         context["comment"] = {
           "id" => latest_comment.id,
           "content" => latest_comment.content,
@@ -336,9 +347,81 @@ module Collavre
         # absorb_into_payload also drops the new anchor from the merged list, so
         # a comment promoted from "merged" back to "trigger" is not sent twice.
         context = TaskCoalescer.absorb_into_payload(context, [ previous_anchor_id ].compact)
+        # The merged list is rendered into the trigger exactly like the anchor, so
+        # keeping the anchor off a delivered comment is only half of it: the
+        # comment the refresh just displaced can itself be one an earlier turn
+        # already answered.
+        if delivered_ids.any?
+          context[TaskCoalescer::PAYLOAD_KEY] = Array(context[TaskCoalescer::PAYLOAD_KEY]) - delivered_ids
+        end
         task.update!(trigger_event_payload: context)
       end
       private_class_method :refresh_deferred_context!
+
+      # Statuses that mean this agent was actually handed the task's trigger.
+      #
+      # `queued` and `pending` are excluded because nothing has been delivered
+      # yet — those are the un-started rows TaskCoalescer folds, and treating a
+      # merely claimed task as an answer is what would make this lossy.
+      # `failed`, `cancelled` and `escalated` are excluded deliberately: a turn
+      # that died may never have delivered anything, so the comments it held
+      # stay answerable. That direction trades a possible duplicate after a
+      # failure for never silencing a comment no task is left to answer.
+      DELIVERED_STATUSES = %w[running delegated pending_approval done].freeze
+
+      # Comment ids this agent has already been given in this topic by a turn that
+      # was not created to answer them. MessageBuilder renders merged blocks into
+      # the trigger exactly like the anchor, so both count as delivery.
+      #
+      # The distinction matters more than the delivery: the ordinary history of a
+      # topic is one comment answered by its own turn, and *that* must silence
+      # nothing, or every waiter standing behind an answered comment would be
+      # cancelled. Two shapes say "this turn was not created for that comment",
+      # and neither needs anything new recorded:
+      #
+      # - it sits in the turn's merged list — coalescing put it there, and the
+      #   task it belonged to was superseded, so this turn is its only delivery;
+      # - it is the anchor but was posted *after* the turn was created — the
+      #   refresh moved the turn onto it, which is the window this closes.
+      #
+      # An anchor older than its own task is that task's original trigger and is
+      # deliberately not counted.
+      #
+      # Scoped by topic and creative, which also keeps workflow subtasks out:
+      # Comments::WorkflowExecutor mints its own trigger comment in the child
+      # creative with topic_id nil, so it can never be mistaken for a delivery of
+      # a comment in this topic. Same trigger_event_name for the same reason
+      # TaskCoalescer folds only within one — a different event over the same
+      # comment is a different question.
+      def self.delivered_comment_ids(task, context)
+        others = Task.where(
+          agent_id: task.agent_id,
+          topic_id: context.dig("topic", "id"),
+          creative_id: context.dig("creative", "id"),
+          trigger_event_name: task.trigger_event_name,
+          status: DELIVERED_STATUSES
+        ).where.not(id: task.id).select(:id, :created_at, :trigger_event_payload)
+
+        anchors = others.filter_map { |other| [ other, anchor_id_in(other) ] }
+                        .reject { |_, anchor_id| anchor_id.nil? }
+        posted_at = Comment.where(id: anchors.map(&:last)).pluck(:id, :created_at).to_h
+
+        acquired_anchors = anchors.filter_map { |other, anchor_id|
+          anchor_id if posted_at[anchor_id] && posted_at[anchor_id] > other.created_at
+        }
+        merged = others.flat_map { |other|
+          Array(other.trigger_event_payload&.dig(TaskCoalescer::PAYLOAD_KEY)).compact.map(&:to_i)
+        }
+
+        (acquired_anchors + merged).uniq
+      end
+      private_class_method :delivered_comment_ids
+
+      def self.anchor_id_in(other)
+        id = other.trigger_event_payload&.dig("comment", "id")
+        id&.to_i
+      end
+      private_class_method :anchor_id_in
 
       def self.review_anchor?(context)
         anchor_id = context.dig("comment", "id")

--- a/engines/collavre/app/services/collavre/orchestration/matcher.rb
+++ b/engines/collavre/app/services/collavre/orchestration/matcher.rb
@@ -36,7 +36,12 @@ module Collavre
         merged_ids = Array(context[TaskCoalescer::PAYLOAD_KEY]).compact
         return false if merged_ids.empty?
 
-        Comment.where(id: merged_ids).pluck(:content).any? do |content|
+        # Scoped to the turn, through the same predicate that decides what is
+        # delivered. A merged mention moved to another creative while the task
+        # waited is deliberately kept out of the trigger, so it cannot also be
+        # the reason the turn is permitted: that would let a non-primary agent
+        # answer an ambient anchor with no in-scope mention anywhere.
+        AiAgent::MergedTriggerComments.in_turn(merged_ids, context).pluck(:content).any? do |content|
           probe = context.merge("chat" => { "content" => content })
           new(SystemEvents::ContextBuilder.new(probe).build).assignment_permits?(agent)
         end

--- a/engines/collavre/app/services/collavre/orchestration/matcher.rb
+++ b/engines/collavre/app/services/collavre/orchestration/matcher.rb
@@ -17,6 +17,31 @@ module Collavre
     # - searchable only affects discoverability, not response permission
     #
     class Matcher
+      # The one entry point for "may this agent answer, given the topic's
+      # primary-agent assignment?", taking a raw trigger payload.
+      #
+      # Three paths re-ask this question about a waiting task — promotion
+      # (AgentOrchestrator.revalidate_assignment!), the resumed AiAgentJob, and
+      # approval resumption through it — and each one cancels the task on a
+      # "no". They must ask the same question, because a direct @mention
+      # outranks the assignment and coalescing moves that mention out of the
+      # anchor and into "merged_comment_ids": judging the anchor alone cancels a
+      # task that WAS explicitly addressed, and discards every comment it had
+      # absorbed along with it. The mention still reaches the agent
+      # (MergedTriggerComments folds it into the trigger), so it still counts.
+      def self.permits_assignment?(context, agent)
+        return true if new(SystemEvents::ContextBuilder.new(context).build)
+                       .assignment_permits?(agent)
+
+        merged_ids = Array(context[TaskCoalescer::PAYLOAD_KEY]).compact
+        return false if merged_ids.empty?
+
+        Comment.where(id: merged_ids).pluck(:content).any? do |content|
+          probe = context.merge("chat" => { "content" => content })
+          new(SystemEvents::ContextBuilder.new(probe).build).assignment_permits?(agent)
+        end
+      end
+
       def initialize(context)
         @context = context
       end

--- a/engines/collavre/app/services/collavre/orchestration/policy_resolver.rb
+++ b/engines/collavre/app/services/collavre/orchestration/policy_resolver.rb
@@ -28,6 +28,9 @@ module Collavre
           "rate_limit_per_minute" => 20,
           "backoff_strategy" => "exponential",
           "topic_max_concurrent_jobs" => 1,
+          # Fold un-started tasks for the same agent/topic/creative into one so a
+          # burst of comments produces one answer instead of one per comment.
+          "coalesce_pending_tasks" => true,
           # Loop breaker settings
           "loop_breaker_enabled" => true,
           "ping_pong_threshold" => 5,           # Max back-and-forth between same agents
@@ -85,6 +88,12 @@ module Collavre
       # Topic-level concurrency limit
       def topic_max_concurrent_jobs
         scheduling_config["topic_max_concurrent_jobs"]
+      end
+
+      # Whether un-started tasks for the same agent/topic/creative are folded
+      # into a single one (see Orchestration::TaskCoalescer).
+      def coalesce_pending_tasks?
+        scheduling_config["coalesce_pending_tasks"] != false
       end
 
       # Convenience methods

--- a/engines/collavre/app/services/collavre/orchestration/policy_resolver.rb
+++ b/engines/collavre/app/services/collavre/orchestration/policy_resolver.rb
@@ -92,8 +92,21 @@ module Collavre
 
       # Whether un-started tasks for the same agent/topic/creative are folded
       # into a single one (see Orchestration::TaskCoalescer).
-      def coalesce_pending_tasks?
-        scheduling_config["coalesce_pending_tasks"] != false
+      #
+      # Resolved per agent, because that is the granularity of the thing being
+      # switched: coalescing folds *same-agent* siblings, and a User-scoped
+      # scheduling policy is how an administrator turns it off for one agent
+      # without touching the others in the topic. #scheduling_config excludes
+      # agent policies by construction, so asking it here silently ignored that
+      # opt-out on every enqueue, promotion, start and notice path.
+      #
+      # There is deliberately no agent-less variant to fall back to: a second
+      # door onto this question is how the two answers drift, and every caller
+      # has the agent to hand. `nil` is accepted only for a dispatch with no
+      # agent resolved yet, where the global answer is the only one there is.
+      def coalesce_pending_tasks_for?(agent)
+        config = agent ? scheduling_config_for(agent) : scheduling_config
+        config["coalesce_pending_tasks"] != false
       end
 
       # Convenience methods

--- a/engines/collavre/app/services/collavre/orchestration/task_coalescer.rb
+++ b/engines/collavre/app/services/collavre/orchestration/task_coalescer.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Orchestration
+    # Folds several un-started agent tasks for one conversation turn into one.
+    #
+    # A burst of external events (a PR comment sync, a webhook batch) creates
+    # several comments in the same topic within milliseconds, and each one
+    # dispatches its own task. With topic_max_concurrent_jobs = 1 the extras
+    # pile up as `queued` waiters, and AgentOrchestrator.refresh_deferred_context!
+    # points every one of them at the same latest comment — so the agent answers
+    # the same message once per waiter.
+    #
+    # Cancelling the extras is not sufficient: session-backed agents receive
+    # only the :trigger message (SessionContextResolver#incremental_payload
+    # drops chat history), so the intermediate comments would be lost entirely.
+    # Their ids are therefore merged into the survivor's payload under
+    # "merged_comment_ids", and MessageBuilder folds them into the trigger.
+    class TaskCoalescer
+      PAYLOAD_KEY = "merged_comment_ids"
+
+      # Cancel un-started siblings of `keep_task` and absorb their trigger
+      # comments into it.
+      #
+      # @param keep_task [Collavre::Task] the survivor
+      # @param scope [:older, :all] which queued siblings to supersede.
+      #   :older (default) is for the enqueue path, where `keep_task` is itself
+      #   a fresh `queued` row and two concurrent dispatches must not cancel
+      #   each other. :all is for the promotion path, where `keep_task` has
+      #   already left `queued` — nothing can cancel it, and the waiters left
+      #   behind are *newer*, so the id guard would absorb nothing.
+      # @return [Array<Integer>] ids of the tasks that were absorbed
+      def self.coalesce!(keep_task, scope: :older)
+        new(keep_task, scope: scope).coalesce!
+      end
+
+      # Merge extra comment ids into a task payload without touching siblings.
+      # Used when a refresh moves the anchor to a newer comment: the previous
+      # anchor still has to reach the agent.
+      #
+      # @return [Hash] the updated payload (not saved)
+      def self.absorb_into_payload(payload, comment_ids)
+        merged = Array(payload[PAYLOAD_KEY]) + Array(comment_ids)
+        anchor_id = payload.dig("comment", "id")
+        merged = merged.compact.map(&:to_i).uniq
+        merged -= [ anchor_id.to_i ] if anchor_id
+        payload.merge(PAYLOAD_KEY => merged.sort)
+      end
+
+      def initialize(keep_task, scope: :older)
+        @keep = keep_task
+        @scope = scope
+      end
+
+      def coalesce!
+        absorbed_ids = []
+
+        Task.transaction do
+          siblings = superseded_scope.lock.to_a
+          comment_ids = siblings.flat_map { |t| trigger_comment_ids(t) }
+
+          siblings.each do |task|
+            task.task_actions.create!(
+              action_type: "superseded",
+              status: "done",
+              payload: { "superseded_by_task_id" => @keep.id }
+            )
+            task.update!(status: "cancelled")
+            absorbed_ids << task.id
+          end
+
+          if siblings.any?
+            payload = self.class.absorb_into_payload(@keep.trigger_event_payload || {}, comment_ids)
+            @keep.update!(trigger_event_payload: payload)
+          end
+        end
+
+        if absorbed_ids.any?
+          Rails.logger.info(
+            "[TaskCoalescer] Task #{@keep.id} absorbed #{absorbed_ids.size} queued sibling(s): " \
+            "#{absorbed_ids.join(', ')}"
+          )
+        end
+        absorbed_ids
+      end
+
+      private
+
+      # Only `queued` tasks are safe to supersede. A `pending` task may already
+      # be riding an enqueued AiAgentJob; cancelling it makes that job return
+      # early *without* draining the topic queue, stalling the topic.
+      #
+      # `id < keep.id` rather than "every other sibling": two dispatches
+      # coalescing concurrently would otherwise cancel each other and leave no
+      # survivor. Each run only ever supersedes strictly older rows.
+      def superseded_scope
+        rel = Task.where(
+          agent_id: @keep.agent_id,
+          topic_id: @keep.topic_id,
+          creative_id: @keep.creative_id,
+          trigger_event_name: @keep.trigger_event_name,
+          status: "queued"
+        ).where.not(id: @keep.id)
+        rel = rel.where("id < ?", @keep.id) if @scope == :older
+        rel.order(:id)
+      end
+
+      # The comment a task was going to answer, plus anything it had already
+      # absorbed itself — coalescing has to be transitive or a second round
+      # drops the first round's merges.
+      def trigger_comment_ids(task)
+        payload = task.trigger_event_payload || {}
+        ([ payload.dig("comment", "id") ] + Array(payload[PAYLOAD_KEY])).compact
+      end
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/orchestration/task_coalescer.rb
+++ b/engines/collavre/app/services/collavre/orchestration/task_coalescer.rb
@@ -147,6 +147,21 @@ module Collavre
             absorbed_ids << task.id
           end
 
+          # A waiter absorbed here may have parked with a per-deferral notice of
+          # its own — the policy only has to have been off when it deferred and
+          # on by the time this fold runs. That notice speaks for this one
+          # waiter, so with the waiter cancelled it is a stop button that
+          # selects a task no longer in the queue and cancels nothing at all.
+          #
+          # Nothing else would collect it either: the cancelled task will never
+          # be promoted through cleanup_waiter_notice!, and the drained sweep
+          # needs the topic queue to empty — which the survivor of this very
+          # fold prevents. Same transaction as the cancellation, so the two
+          # cannot come apart.
+          Comment.remove_waiter_notices!(
+            creative_id: @keep.creative_id, topic_id: @keep.topic_id, task_ids: absorbed_ids
+          )
+
           if siblings.any?
             # Merge onto the locked row's payload, but write through the
             # caller's own object: dequeue_next_for_topic hands that same

--- a/engines/collavre/app/services/collavre/orchestration/task_coalescer.rb
+++ b/engines/collavre/app/services/collavre/orchestration/task_coalescer.rb
@@ -19,6 +19,17 @@ module Collavre
     class TaskCoalescer
       PAYLOAD_KEY = "merged_comment_ids"
 
+      # Set when a payload's anchor is moved onto a comment the task was not
+      # created for. AgentOrchestrator.delivered_comment_ids has to tell that
+      # apart from a task answering its own trigger, and the only evidence
+      # otherwise was comment.created_at against task.created_at — two rows
+      # stamped by whichever process wrote them, which is why nothing else in
+      # this turn's machinery orders by time either. A tie or a skew reads an
+      # acquired anchor as an original one and the comment is answered twice,
+      # or an original one as acquired and a promoted waiter is left with no
+      # candidate and cancelled.
+      ACQUIRED_ANCHOR_KEY = "acquired_comment_id"
+
       # The statuses a survivor may still be in when a fold runs: both enqueue
       # doors hand over a `queued` row and both start-of-turn doors a `pending`
       # one. Anything else means it lost its turn between the caller reading it
@@ -38,6 +49,44 @@ module Collavre
       # @return [Array<Integer>] ids of the tasks that were absorbed
       def self.coalesce!(keep_task, scope: :older)
         new(keep_task, scope: scope).coalesce!
+      end
+
+      # Point a payload at a new trigger comment, recording the move.
+      #
+      # Both doors that move an anchor go through this — the refresh carrying a
+      # waiter forward, and the re-anchor rescuing a task whose anchor was
+      # deleted. They differ only in how they rebuild the merged list, and
+      # keeping the anchor write itself in one place is what makes "this turn
+      # acquired that comment" a fact the payload carries rather than one a
+      # later reader has to reconstruct.
+      #
+      # A refresh that lands back on the anchor it started from is a documented
+      # no-op, so the mark is written only when the id actually changes, and
+      # never cleared: an anchor moved twice is still not the turn's own.
+      #
+      # A payload with no anchor at all is left unmarked. There is no move to
+      # record, and this whole record is read to decide whether a *waiter* may
+      # keep its turn — so where the payload cannot say, the side that cannot
+      # discard someone's work is the one to take.
+      #
+      # @return [Hash] the updated payload (not saved)
+      def self.reanchor_payload(payload, comment)
+        previous_id = payload.dig("comment", "id")
+        moved = payload.merge(
+          "comment" => {
+            "id" => comment.id,
+            "content" => comment.content,
+            "user_id" => comment.user_id
+          },
+          "chat" => { "content" => comment.content }
+        )
+        moved[ACQUIRED_ANCHOR_KEY] = comment.id if previous_id && previous_id.to_i != comment.id
+        # The payload's "sender" labels the trigger and is what
+        # ClaudeChannelAdapter sends as author_id/author_name, and
+        # SystemEvents::ContextBuilder only ever fills it in with `||=` — it does
+        # not run again on either of these paths. A burst spanning two people
+        # would otherwise put the first speaker's name on the second's words.
+        SystemEvents::ContextBuilder.reanchor_sender(moved, comment)
       end
 
       # Merge extra comment ids into a task payload without touching siblings.

--- a/engines/collavre/app/services/collavre/orchestration/task_coalescer.rb
+++ b/engines/collavre/app/services/collavre/orchestration/task_coalescer.rb
@@ -19,6 +19,12 @@ module Collavre
     class TaskCoalescer
       PAYLOAD_KEY = "merged_comment_ids"
 
+      # The statuses a survivor may still be in when a fold runs: both enqueue
+      # doors hand over a `queued` row and both start-of-turn doors a `pending`
+      # one. Anything else means it lost its turn between the caller reading it
+      # and this transaction.
+      UNSTARTED_STATUSES = %w[queued pending].freeze
+
       # Cancel un-started siblings of `keep_task` and absorb their trigger
       # comments into it.
       #
@@ -58,7 +64,28 @@ module Collavre
         absorbed_ids = []
 
         Task.transaction do
-          siblings = reject_review_triggers(superseded_scope.lock.to_a)
+          # Lock the survivor together with its siblings, and re-read its status
+          # from the locked row. The survivor is the caller's snapshot: deleting
+          # its anchor cancels it through Comment#cancel_pending_tasks, which
+          # holds no lock this method waits on. Folding on a stale object would
+          # cancel every still-valid sibling and merge the whole burst onto a
+          # task AiAgentJob abandons on sight — and those siblings have no task
+          # of their own left to answer them.
+          #
+          # One id-ordered statement rather than locking @keep first: in the
+          # :older scope the survivor's id is above every sibling's, so taking it
+          # first would descend where a concurrent fold ascends, which is the
+          # shape a deadlock needs.
+          locked = Task.where(id: superseded_scope.pluck(:id) + [ @keep.id ])
+                       .order(:id).lock.index_by(&:id)
+          keep = locked[@keep.id]
+          next unless keep && UNSTARTED_STATUSES.include?(keep.status)
+
+          # Status is re-checked against the locked rows too: a sibling promoted
+          # or cancelled since the id read above is no longer ours to supersede.
+          siblings = reject_review_triggers(
+            locked.values.select { |t| t.id != keep.id && t.status == "queued" }
+          )
           comment_ids = siblings.flat_map { |t| trigger_comment_ids(t) }
 
           siblings.each do |task|
@@ -72,7 +99,11 @@ module Collavre
           end
 
           if siblings.any?
-            payload = self.class.absorb_into_payload(@keep.trigger_event_payload || {}, comment_ids)
+            # Merge onto the locked row's payload, but write through the
+            # caller's own object: dequeue_next_for_topic hands that same
+            # instance to refresh_deferred_context! immediately after this, and
+            # it has to see the ids merged here rather than its pre-fold copy.
+            payload = self.class.absorb_into_payload(keep.trigger_event_payload || {}, comment_ids)
             @keep.update!(trigger_event_payload: payload)
           end
         end

--- a/engines/collavre/app/services/collavre/orchestration/task_coalescer.rb
+++ b/engines/collavre/app/services/collavre/orchestration/task_coalescer.rb
@@ -53,10 +53,12 @@ module Collavre
       end
 
       def coalesce!
+        return [] if review_trigger?(@keep)
+
         absorbed_ids = []
 
         Task.transaction do
-          siblings = superseded_scope.lock.to_a
+          siblings = reject_review_triggers(superseded_scope.lock.to_a)
           comment_ids = siblings.flat_map { |t| trigger_comment_ids(t) }
 
           siblings.each do |task|
@@ -103,6 +105,30 @@ module Collavre
         ).where.not(id: @keep.id)
         rel = rel.where("id < ?", @keep.id) if @scope == :older
         rel.order(:id)
+      end
+
+      # A Review request is an action bound to one comment, not one more message
+      # in the burst. AiAgentService and ResponseFinalizer read review behaviour
+      # off the surviving anchor alone (Comment#review_message? plus its
+      # quoted_comment), so folding across that boundary breaks both ways: an
+      # absorbed review silently degrades into a normal reply, and a surviving
+      # review overwrites the quoted comment with text that also answers an
+      # unrelated message. Reviews therefore neither absorb nor get absorbed —
+      # they keep their own turn, which is the only shape ReviewHandler can run.
+      def review_trigger?(task)
+        anchor_id = (task.trigger_event_payload || {}).dig("comment", "id")
+        anchor_id.present? && Comment.review_message_ids([ anchor_id ]).any?
+      end
+
+      # One query for the whole burst rather than review_trigger? per sibling.
+      def reject_review_triggers(siblings)
+        anchors = siblings.filter_map { |t| (t.trigger_event_payload || {}).dig("comment", "id") }
+        review_ids = Comment.review_message_ids(anchors).to_set
+        return siblings if review_ids.empty?
+
+        siblings.reject do |task|
+          review_ids.include?((task.trigger_event_payload || {}).dig("comment", "id").to_i)
+        end
       end
 
       # The comment a task was going to answer, plus anything it had already

--- a/engines/collavre/app/services/collavre/orchestration/topic_slot.rb
+++ b/engines/collavre/app/services/collavre/orchestration/topic_slot.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Orchestration
+    # The single rule for who may hold a topic's concurrency slot, shared by the
+    # two paths that hand one out: AiAgentJob's admission of a fresh dispatch and
+    # AgentOrchestrator.dequeue_next_for_topic's promotion of a parked waiter.
+    #
+    # Keeping the rule in one place is the point. When only admission enforced
+    # it, promotion could still hand a second slot to an agent that already held
+    # one, or overfill a topic outright — and TaskCoalescer folds only `queued`
+    # rows, so two concurrent turns for one agent can never be merged afterwards.
+    module TopicSlot
+      # Serialize every admission and promotion for one topic scope on one
+      # stable row. SELECT ... FOR UPDATE on Postgres; the SQLite visitor drops
+      # the lock clause, where writes are serialized anyway.
+      #
+      # A creative's Main topic carries topic_id == nil, which is a real scope
+      # (occupancy is counted as topic_id: nil within the creative) but has no
+      # topic row to lock — fall back to the creative, which is just as stable
+      # and is shared by exactly the dispatches that compete for that slot.
+      def self.lock!(topic_id, creative_id = nil)
+        return Topic.lock.find_by(id: topic_id) if topic_id
+        return Creative.lock.find_by(id: creative_id) if creative_id
+
+        nil
+      end
+
+      # May `agent_id` take a slot in this topic scope right now?
+      #
+      # Deliberately NOT gated on coalesce_pending_tasks?: that switch governs
+      # whether waiters are folded together, not whether topic_max_concurrent_jobs
+      # is enforced. Skipping the check when it is off would let a burst start
+      # one concurrent turn per comment in a topic limited to one.
+      #
+      # Occupancy counts running/delegated (executing) plus pending (claimed,
+      # job not started) and pending_approval (paused, keeps its resource and
+      # does not drain the queue) — treating any of those as free is exactly how
+      # a second turn slips in.
+      def self.available_for?(agent_id, topic_id, creative_id, context)
+        topic_max = PolicyResolver.new(context || {}).topic_max_concurrent_jobs
+        return true unless topic_max
+
+        occupying = Task.occupying_topic_slot(topic_id, creative_id)
+        return false if occupying.count >= topic_max
+
+        # A free slot is not automatically THIS agent's to take. topic_max > 1
+        # exists to run *different* agents in parallel, so an agent that already
+        # has a turn in flight here must wait rather than answer itself twice.
+        !occupying.where(agent_id: agent_id).exists?
+      end
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/orchestration/topic_slot.rb
+++ b/engines/collavre/app/services/collavre/orchestration/topic_slot.rb
@@ -19,8 +19,16 @@ module Collavre
       # (occupancy is counted as topic_id: nil within the creative) but has no
       # topic row to lock — fall back to the creative, which is just as stable
       # and is shared by exactly the dispatches that compete for that slot.
+      # Tasks carry topic_id with no foreign key, so a deleted topic leaves rows
+      # pointing at a row that is gone — and a delayed job can carry that id long
+      # after the fact. Returning the missing topic's nil without trying the
+      # creative would run admission, promotion and notice dedup with no
+      # serialization at all: silently the one state this lock exists to prevent.
       def self.lock!(topic_id, creative_id = nil)
-        return Topic.lock.find_by(id: topic_id) if topic_id
+        if topic_id
+          topic = Topic.lock.find_by(id: topic_id)
+          return topic if topic
+        end
         return Creative.lock.find_by(id: creative_id) if creative_id
 
         nil

--- a/engines/collavre/app/services/collavre/system_events/context_builder.rb
+++ b/engines/collavre/app/services/collavre/system_events/context_builder.rb
@@ -20,13 +20,15 @@ module Collavre
         ctx
       end
 
-      private
-
-      def build_sender_context(ctx)
-        user_id = ctx.dig("comment", "user_id")
-        return nil unless user_id
-
-        user = User.find_by(id: user_id)
+      # The sender block for a user, or nil when there is nobody to attribute to.
+      #
+      # Public because `build` only ever fills the key in (`||=`) and never runs
+      # again on a promotion path: re-anchoring a coalesced task moves the trigger
+      # to a different comment, so whoever moves it has to rebuild the sender from
+      # the new author or the turn is labelled with the wrong speaker. Both callers
+      # must produce the same shape — a stub missing "is_ai" silently flips the
+      # A2A gate in AgentContextBuilder.
+      def self.sender_context_for(user)
         return nil unless user
 
         {
@@ -36,6 +38,32 @@ module Collavre
           "is_ai" => user.ai_user?,
           "type" => user.ai_user? ? AgentTypeClassifier.classify(user) : "human"
         }
+      end
+
+      # Point a payload's sender at the comment the trigger has just been moved
+      # onto. Only when the author actually changed: a payload may carry a sender
+      # its producer shaped deliberately (Comments::WorkflowExecutor attributes a
+      # sub-task to the user who issued /work), and re-anchoring inside one user's
+      # own burst is no reason to touch it.
+      #
+      # A rebuild that finds no user drops the key rather than leaving a wrong
+      # one: ClaudeChannelAdapter then falls back to the comment's own user_id and
+      # MessageBuilder omits the speaker label instead of naming the wrong person.
+      def self.reanchor_sender(payload, comment)
+        return payload unless payload.key?("sender")
+        return payload if payload.dig("sender", "id") == comment.user_id
+
+        sender = sender_context_for(comment.user)
+        sender ? payload.merge("sender" => sender) : payload.except("sender")
+      end
+
+      private
+
+      def build_sender_context(ctx)
+        user_id = ctx.dig("comment", "user_id")
+        return nil unless user_id
+
+        self.class.sender_context_for(User.find_by(id: user_id))
       end
 
       def mentioned_user(chat_context)

--- a/engines/collavre/db/migrate/20260727000000_add_waiting_notice_scope_to_comments.rb
+++ b/engines/collavre/db/migrate/20260727000000_add_waiting_notice_scope_to_comments.rb
@@ -1,0 +1,30 @@
+# Record what a "⏳ waiting on the topic slot" notice speaks for, instead of
+# inferring it from whichever sibling notices happen to still stand.
+#
+# A topic gets one deduplicated notice while coalescing is on and one notice per
+# deferral while it is off, so the two kinds coexist whenever the policy changes
+# mid-wait or differs per agent. Reading "no sibling notice left" as "this one
+# stood for the whole topic" then inverts ownership: deleting the shared notice
+# is classified as deleting a per-deferral one and cancels the newest queued
+# waiter — which may be the one the *other* notice speaks for.
+#
+# Nullable with no backfill on purpose: a notice already on screen was posted by
+# the pre-existing code and there is nothing on the row to say which kind it was.
+# Comment#cancel_queued_tasks_for_waiting_notice keeps its old behaviour for
+# those, so an in-flight wait is neither widened nor silently disarmed.
+class AddWaitingNoticeScopeToComments < ActiveRecord::Migration[8.1]
+  def up
+    unless column_exists?(:comments, :waiting_notice_scope)
+      add_column :comments, :waiting_notice_scope, :string
+    end
+
+    unless column_exists?(:comments, :waiting_notice_task_id)
+      add_column :comments, :waiting_notice_task_id, :integer
+    end
+  end
+
+  def down
+    remove_column :comments, :waiting_notice_task_id if column_exists?(:comments, :waiting_notice_task_id)
+    remove_column :comments, :waiting_notice_scope if column_exists?(:comments, :waiting_notice_scope)
+  end
+end

--- a/engines/collavre/test/controllers/tasks_controller_test.rb
+++ b/engines/collavre/test/controllers/tasks_controller_test.rb
@@ -151,4 +151,52 @@ class TasksControllerTest < ActionDispatch::IntegrationTest
     assert_equal [ [ 12_345, @creative.id ] ], dequeued,
       "Expected the topic queue to be drained so the next queued waiter is promoted"
   end
+
+  test "cancel takes down the cancelled waiter's own per-deferral notice" do
+    # The third door a waiter leaves the queue through without being promoted:
+    # the user's own stop button. Its "task" notice names this task, so once the
+    # task is cancelled the notice is a waiting line whose stop button selects a
+    # task no longer queued and therefore cancels nothing. A sibling still parked
+    # keeps the drained sweep from ever collecting it.
+    sign_in_as(@user, password: "password")
+    topic = Collavre::Topic.create!(name: "Cancel topic", creative: @creative, user: @user)
+    @task.update!(status: "queued", topic_id: topic.id, creative_id: @creative.id)
+
+    sibling = Collavre::Task.create!(
+      name: "Sibling waiter", status: "queued",
+      trigger_event_name: "comment_created",
+      trigger_event_payload: { "creative" => { "id" => @creative.id } },
+      agent: @agent, topic_id: topic.id, creative_id: @creative.id
+    )
+
+    own_notice = @creative.comments.create!(
+      content: "⏳ waiting", topic_id: topic.id, private: false, skip_default_user: true,
+      topic_concurrency_defer: true,
+      waiting_notice_scope: Collavre::Comment::WAITING_NOTICE_TASK,
+      waiting_notice_task_id: @task.id
+    )
+    sibling_notice = @creative.comments.create!(
+      content: "⏳ waiting", topic_id: topic.id, private: false, skip_default_user: true,
+      topic_concurrency_defer: true,
+      waiting_notice_scope: Collavre::Comment::WAITING_NOTICE_TASK,
+      waiting_notice_task_id: sibling.id
+    )
+
+    post cancel_task_path(@task)
+
+    assert_response :ok
+    assert_equal "cancelled", @task.reload.status
+    assert_nil Collavre::Comment.find_by(id: own_notice.id),
+      "Expected the cancelled waiter's own notice to come down with it"
+    # Invariant rather than "this row is gone", so it keeps meaning something
+    # once the row is gone: no "task" notice names a task that left the queue.
+    stranded = Collavre::Comment.where(waiting_notice_scope: Collavre::Comment::WAITING_NOTICE_TASK)
+                                .where.not(waiting_notice_task_id: nil)
+                                .select { |c| Collavre::Task.find_by(id: c.waiting_notice_task_id)&.status != "queued" }
+    assert_empty stranded, "Expected no task-scoped notice naming a task that is no longer queued"
+    # Control: the sibling is still queued, so its notice — and its stop button — stays.
+    assert Collavre::Comment.exists?(id: sibling_notice.id),
+      "Expected a still-queued waiter's notice to be untouched by another waiter's cancellation"
+    assert_equal "queued", sibling.reload.status
+  end
 end

--- a/engines/collavre/test/controllers/tasks_controller_test.rb
+++ b/engines/collavre/test/controllers/tasks_controller_test.rb
@@ -199,4 +199,54 @@ class TasksControllerTest < ActionDispatch::IntegrationTest
       "Expected a still-queued waiter's notice to be untouched by another waiter's cancellation"
     assert_equal "queued", sibling.reload.status
   end
+
+  test "cancel takes down a shared notice its last waiter leaves behind" do
+    # Same door, the other kind of notice. With coalescing on the waiter has no
+    # notice of its own — the topic's single shared one speaks for it — so
+    # remove_waiter_notices! finds nothing to take down and the "⏳" line stays
+    # on screen with a stop button that now selects nothing.
+    sign_in_as(@user, password: "password")
+    topic = Collavre::Topic.create!(name: "Cancel topic", creative: @creative, user: @user)
+    @task.update!(status: "queued", topic_id: topic.id, creative_id: @creative.id)
+
+    shared = @creative.comments.create!(
+      content: "⏳ waiting", topic_id: topic.id, private: false, skip_default_user: true,
+      topic_concurrency_defer: true,
+      waiting_notice_scope: Collavre::Comment::WAITING_NOTICE_TOPIC
+    )
+
+    post cancel_task_path(@task)
+
+    assert_response :ok
+    assert_equal "cancelled", @task.reload.status
+    assert_nil Collavre::Comment.find_by(id: shared.id),
+      "Expected the shared notice to come down once nothing it speaks for is queued"
+  end
+
+  test "cancel keeps a shared notice that still speaks for a queued waiter" do
+    # The control: "take the shared notice down whenever a waiter is cancelled"
+    # would pass the test above while disarming a wait that is still real.
+    sign_in_as(@user, password: "password")
+    topic = Collavre::Topic.create!(name: "Cancel topic", creative: @creative, user: @user)
+    @task.update!(status: "queued", topic_id: topic.id, creative_id: @creative.id)
+
+    sibling = Collavre::Task.create!(
+      name: "Sibling waiter", status: "queued",
+      trigger_event_name: "comment_created",
+      trigger_event_payload: { "creative" => { "id" => @creative.id } },
+      agent: @agent, topic_id: topic.id, creative_id: @creative.id
+    )
+    shared = @creative.comments.create!(
+      content: "⏳ waiting", topic_id: topic.id, private: false, skip_default_user: true,
+      topic_concurrency_defer: true,
+      waiting_notice_scope: Collavre::Comment::WAITING_NOTICE_TOPIC
+    )
+
+    post cancel_task_path(@task)
+
+    assert_response :ok
+    assert_equal "queued", sibling.reload.status
+    assert Collavre::Comment.exists?(id: shared.id),
+      "Expected the shared notice to stay up for the waiter it still speaks for"
+  end
 end

--- a/engines/collavre/test/jobs/collavre/ai_agent_job_topic_slot_test.rb
+++ b/engines/collavre/test/jobs/collavre/ai_agent_job_topic_slot_test.rb
@@ -307,5 +307,34 @@ module Collavre
       assert_equal 1, Task.where(agent: @agent, topic_id: nil, creative_id: @creative.id,
                                  status: "queued").count
     end
+
+    # The promoted task holds the slot as `pending` until this job starts, and a
+    # comment arriving in that gap parks a waiter that enqueue-time coalescing
+    # cannot fold into a non-`queued` sibling. Execution is the last moment both
+    # turns are still un-started, so the fold has to run here.
+    test "folds a waiter parked between promotion and execution" do
+      claimed = Task.create!(
+        name: "Response to comment_created", status: "pending",
+        trigger_event_name: "comment_created", agent: @agent,
+        topic_id: @topic.id, creative_id: @creative.id,
+        trigger_event_payload: context_for(comment("@#{@agent.name}: first"))
+      )
+      late = comment("@#{@agent.name}: and also this")
+      late_waiter = Task.create!(
+        name: "Response to comment_created", status: "queued",
+        trigger_event_name: "comment_created", agent: @agent,
+        topic_id: @topic.id, creative_id: @creative.id,
+        trigger_event_payload: context_for(late)
+      )
+
+      fake_service = -> { "" }
+      AiAgentService.stub :new, ->(_task) { fake_service } do
+        AiAgentJob.new.perform(claimed)
+      end
+
+      assert_equal "cancelled", late_waiter.reload.status,
+                   "both comments were un-started — they belong to one turn"
+      assert_equal late.id, claimed.reload.trigger_event_payload.dig("comment", "id")
+    end
   end
 end

--- a/engines/collavre/test/jobs/collavre/ai_agent_job_topic_slot_test.rb
+++ b/engines/collavre/test/jobs/collavre/ai_agent_job_topic_slot_test.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  # The Scheduler's topic-concurrency check counts Task rows, but for an
+  # :immediate decision that row is only created inside AiAgentJob. A burst of
+  # comments dispatched before the first job runs therefore all see an empty
+  # topic and are all judged :immediate — several turns run at once in a topic
+  # limited to one. AiAgentJob re-checks at row-creation time.
+  class AiAgentJobTopicSlotTest < ActiveSupport::TestCase
+    setup do
+      @user = users(:one)
+      @creative = creatives(:tshirt)
+      @agent = users(:ai_bot)
+      @topic = Topic.create!(name: "Slot topic", creative: @creative, user: @user)
+      Orchestration::ResourceTracker.for(@agent).reset!
+    end
+
+    teardown do
+      Orchestration::ResourceTracker.for(@agent).reset!
+    end
+
+    def context_for(comment)
+      {
+        "creative" => { "id" => @creative.id },
+        "topic" => { "id" => @topic.id },
+        "sender" => { "id" => @user.id, "name" => @user.name },
+        "comment" => { "id" => comment.id, "content" => comment.content, "user_id" => @user.id }
+      }
+    end
+
+    def comment(body)
+      Comment.create!(
+        creative: @creative, user: @user, topic: @topic, content: body, skip_dispatch: true
+      )
+    end
+
+    def occupy_slot!(status: "running")
+      Task.create!(
+        name: "Holder", status: status, trigger_event_name: "comment_created",
+        agent: @agent, topic_id: @topic.id, creative_id: @creative.id,
+        trigger_event_payload: { "topic" => { "id" => @topic.id } }
+      )
+    end
+
+    test "queues a waiter instead of starting a second turn in an occupied topic" do
+      occupy_slot!
+      c = comment("late arrival")
+
+      AiAgentJob.new.perform(@agent.id, "comment_created", context_for(c))
+
+      waiters = Task.where(agent: @agent, topic_id: @topic.id, status: "queued")
+      assert_equal 1, waiters.count
+      assert_equal c.id, waiters.first.trigger_event_payload.dig("comment", "id")
+      assert_equal 1, Task.where(agent: @agent, topic_id: @topic.id, status: "running").count,
+                   "the holder must remain the only running task"
+    end
+
+    # pending / pending_approval hold the slot too: pending is claimed but not
+    # started, pending_approval is paused and does not drain the queue.
+    test "treats a pending_approval holder as occupying the slot" do
+      occupy_slot!(status: "pending_approval")
+      c = comment("late arrival")
+
+      AiAgentJob.new.perform(@agent.id, "comment_created", context_for(c))
+
+      assert_equal 1, Task.where(agent: @agent, topic_id: @topic.id, status: "queued").count
+    end
+
+    test "coalesces the late waiter with one already parked" do
+      occupy_slot!
+      first = comment("first")
+      second = comment("second")
+
+      AiAgentJob.new.perform(@agent.id, "comment_created", context_for(first))
+      AiAgentJob.new.perform(@agent.id, "comment_created", context_for(second))
+
+      waiters = Task.where(agent: @agent, topic_id: @topic.id, status: "queued")
+      assert_equal 1, waiters.count
+      assert_equal second.id, waiters.first.trigger_event_payload.dig("comment", "id")
+      assert_equal [ first.id ],
+                   waiters.first.trigger_event_payload[Orchestration::TaskCoalescer::PAYLOAD_KEY]
+    end
+
+    test "posts one waiting notice for the deferred burst" do
+      occupy_slot!
+      2.times { |i| AiAgentJob.new.perform(@agent.id, "comment_created", context_for(comment("m#{i}"))) }
+
+      notices = Comment.where(creative_id: @creative.id, topic_id: @topic.id, user_id: nil)
+                       .where("content LIKE ?", "#{Comment::WAITING_NOTICE_PREFIX}%")
+      assert_equal 1, notices.count
+    end
+
+    test "runs normally when the topic slot is free" do
+      c = comment("first in topic")
+
+      AiAgentJob.new.perform(@agent.id, "comment_created", context_for(c))
+
+      assert_equal 0, Task.where(agent: @agent, topic_id: @topic.id, status: "queued").count,
+                   "an empty topic must not defer"
+      assert Task.where(agent: @agent, topic_id: @topic.id).exists?,
+             "a task should have been created and executed"
+    end
+
+    test "does not defer when the context carries no topic" do
+      c = Comment.create!(creative: @creative, user: @user, content: "no topic", skip_dispatch: true)
+      context = {
+        "creative" => { "id" => @creative.id },
+        "comment" => { "id" => c.id, "content" => c.content, "user_id" => @user.id }
+      }
+
+      AiAgentJob.new.perform(@agent.id, "comment_created", context)
+
+      assert_equal 0, Task.where(agent: @agent, status: "queued").count
+    end
+
+    test "policy can disable the late slot check" do
+      OrchestratorPolicy.create!(
+        policy_type: "scheduling", scope_type: nil,
+        config: { "coalesce_pending_tasks" => false }
+      )
+      occupy_slot!
+      c = comment("late arrival")
+
+      AiAgentJob.new.perform(@agent.id, "comment_created", context_for(c))
+
+      assert_equal 0, Task.where(agent: @agent, topic_id: @topic.id, status: "queued").count,
+                   "with coalescing off the previous immediate behaviour returns"
+    end
+  end
+end

--- a/engines/collavre/test/jobs/collavre/ai_agent_job_topic_slot_test.rb
+++ b/engines/collavre/test/jobs/collavre/ai_agent_job_topic_slot_test.rb
@@ -623,5 +623,89 @@ module Collavre
         orchestrator.send(:post_waiting_notice, @agent, { timing: :delayed, reason: :busy })
       end
     end
+
+    # A per-deferral notice speaks for one waiter, and coalescing removes
+    # waiters. Turning the policy on between two deferrals is enough: the first
+    # parks with a notice of its own, the second folds it away, and nothing on
+    # any path is left that would take that notice down — the fold does not, the
+    # cancelled task will never be promoted through cleanup_waiter_notice!, and
+    # the survivor keeps the topic queue non-empty so the drained sweep never
+    # runs either.
+    def folded_opt_out_waiter!
+      policy = OrchestratorPolicy.create!(
+        policy_type: "scheduling", scope_type: nil,
+        config: { "coalesce_pending_tasks" => false }
+      )
+      occupy_slot!
+      AiAgentJob.new.perform(@agent.id, "comment_created", context_for(comment("first")))
+      first = Task.where(agent: @agent, topic_id: @topic.id, status: "queued").sole
+      notice = Comment.find_by(creative_id: @creative.id, topic_id: @topic.id, user_id: nil,
+                               waiting_notice_scope: Comment::WAITING_NOTICE_TASK,
+                               waiting_notice_task_id: first.id)
+      assert notice, "premise: the opt-out door posts a notice naming this waiter"
+
+      policy.update!(config: { "coalesce_pending_tasks" => true })
+      AiAgentJob.new.perform(@agent.id, "comment_created", context_for(comment("second")))
+
+      survivor = Task.where(agent: @agent, topic_id: @topic.id, status: "queued").sole
+      assert_equal "cancelled", first.reload.status, "premise: the fold absorbed the first waiter"
+      [ first, notice, survivor ]
+    end
+
+    test "folding a waiter takes down the per-deferral notice that spoke for it" do
+      _first, notice, _survivor = folded_opt_out_waiter!
+
+      assert_not Comment.exists?(notice.id),
+                 "a notice for a folded waiter is a stop button nothing can take down"
+    end
+
+    # Stated as the invariant rather than as "this one row is gone", because
+    # what makes the leftover worse than a duplicate line on screen is that its
+    # stop button selects its own waiter by id and that waiter is no longer
+    # queued — pressing it does nothing at all.
+    test "no per-deferral notice outlives the waiter it speaks for" do
+      folded_opt_out_waiter!
+
+      stale = Comment.where(creative_id: @creative.id, topic_id: @topic.id, user_id: nil,
+                            waiting_notice_scope: Comment::WAITING_NOTICE_TASK)
+                     .where.not(waiting_notice_task_id: Task.where(status: "queued").select(:id))
+      assert_empty stale.to_a,
+                   "a notice naming a waiter that has left the queue is a dead stop button"
+    end
+
+    # The controls the two above need. "Delete every notice in the fold" would
+    # pass them both while stripping the survivor's own signal off the screen.
+    test "folding leaves the surviving waiter's own notice standing" do
+      _first, _notice, survivor = folded_opt_out_waiter!
+
+      shared = Comment.where(creative_id: @creative.id, topic_id: @topic.id, user_id: nil,
+                             topic_concurrency_defer: true,
+                             waiting_notice_scope: Comment::WAITING_NOTICE_TOPIC)
+                      .where("content LIKE ?", "#{Comment::WAITING_NOTICE_PREFIX}%")
+                      .sole
+      shared.destroy!
+      assert_equal "cancelled", survivor.reload.status,
+                   "the survivor keeps a notice that still stops it"
+    end
+
+    # …and it must reach only the waiters it actually folded. Another agent's
+    # per-deferral notice is not this fold's to take down.
+    test "folding does not touch another agent's per-deferral notice" do
+      OrchestratorPolicy.create!(
+        policy_type: "scheduling", scope_type: "User", scope_id: second_agent.id,
+        config: { "coalesce_pending_tasks" => false }
+      )
+      occupy_slot!
+      AiAgentJob.new.perform(second_agent.id, "comment_created", context_for(comment("theirs")))
+      theirs = Task.where(agent: second_agent, topic_id: @topic.id, status: "queued").sole
+      AiAgentJob.new.perform(@agent.id, "comment_created", context_for(comment("a")))
+      AiAgentJob.new.perform(@agent.id, "comment_created", context_for(comment("b")))
+
+      assert_equal "queued", theirs.reload.status, "premise: only same-agent siblings fold"
+      assert Comment.where(creative_id: @creative.id, topic_id: @topic.id, user_id: nil,
+                           waiting_notice_scope: Comment::WAITING_NOTICE_TASK,
+                           waiting_notice_task_id: theirs.id).exists?,
+             "the opt-out agent's notice speaks for a waiter that is still queued"
+    end
   end
 end

--- a/engines/collavre/test/jobs/collavre/ai_agent_job_topic_slot_test.rb
+++ b/engines/collavre/test/jobs/collavre/ai_agent_job_topic_slot_test.rb
@@ -894,5 +894,63 @@ module Collavre
       context = context_for(comment)
       context.merge("comment" => context["comment"].merge("from_ai" => true))
     end
+
+    # A cron scheduled against Main passes `topic_id: nil`, and the payload used
+    # to repeat that nil while assign_main_topic had already filed the comment
+    # under the real Main row. Before this branch that only made the dispatch
+    # inconsistent; with admission the waiter is *queued* under `topic_id: nil`,
+    # and promotion's refresh looks for comments in the task's own topic, finds
+    # none there, and cancels the scheduled turn without delivering it.
+    #
+    # Driven through the payload CronActionJob actually sends rather than a
+    # hand-built one, since the payload is where the two disagree.
+    #
+    # The occupancy bucket is keyed by that same nil, so the first cost is
+    # upstream of the cancellation: the cron turn does not see the ordinary Main
+    # turn holding the slot at all, and is admitted beside it.
+    def occupied_main_cron_dispatch!
+      main = @creative.main_topic(fallback_user: @user)
+      holder = Task.create!(
+        name: "Main holder", status: "running", trigger_event_name: "comment_created",
+        agent: @agent, topic_id: main.id, creative_id: @creative.id,
+        trigger_event_payload: { "topic" => { "id" => main.id } }
+      )
+
+      payload = nil
+      SystemEvents::Dispatcher.stub(:dispatch, ->(_event, sent) { payload = sent; [] }) do
+        CronActionJob.perform_now(
+          creative_id: @creative.id, topic_id: nil,
+          agent_id: @user.id, message: "@#{@agent.name}: scheduled check-in"
+        )
+      end
+
+      AiAgentJob.new.perform(@agent.id, "comment_created", payload.deep_stringify_keys)
+
+      cron_task = Task.where(agent: @agent, creative_id: @creative.id)
+                      .where.not(id: holder.id).sole
+      [ main, holder, cron_task ]
+    end
+
+    test "a Main-topic cron waits for the ordinary Main turn instead of running beside it" do
+      main, _holder, cron_task = occupied_main_cron_dispatch!
+
+      assert_equal "queued", cron_task.status,
+                   "a cron turn must contend for the slot the Main topic already holds"
+      assert_equal main.id, cron_task.topic_id,
+                   "and wait in the topic its trigger was actually filed under"
+    end
+
+    test "a Main-topic cron turn is delivered rather than dropped on promotion" do
+      _main, holder, waiter = occupied_main_cron_dispatch!
+      assert_equal "queued", waiter.status, "premise: the cron turn parked behind the Main turn"
+
+      holder.update!(status: "done")
+      AiAgentJob.stub :perform_later, ->(*) { nil } do
+        Orchestration::AgentOrchestrator.dequeue_next_for_topic(waiter.topic_id, @creative.id)
+      end
+
+      assert_not_equal "cancelled", waiter.reload.status,
+                       "the scheduled turn must be delivered, not silently dropped"
+    end
   end
 end

--- a/engines/collavre/test/jobs/collavre/ai_agent_job_topic_slot_test.rb
+++ b/engines/collavre/test/jobs/collavre/ai_agent_job_topic_slot_test.rb
@@ -362,5 +362,142 @@ module Collavre
                    "both comments were un-started — they belong to one turn"
       assert_equal late.id, claimed.reload.trigger_event_payload.dig("comment", "id")
     end
+
+    # Coalescing folds *same-agent* siblings, so a User-scoped scheduling policy
+    # is where an administrator turns it off for one agent without touching the
+    # others in the topic. PolicyResolver#scheduling_config excludes agent
+    # policies by construction, so asking it was the same as ignoring the opt-out.
+    test "a User-scoped policy turns folding off for that agent" do
+      OrchestratorPolicy.create!(
+        policy_type: "scheduling", scope_type: "User", scope_id: @agent.id,
+        config: { "coalesce_pending_tasks" => false }
+      )
+      occupy_slot!
+
+      AiAgentJob.new.perform(@agent.id, "comment_created", context_for(comment("first")))
+      AiAgentJob.new.perform(@agent.id, "comment_created", context_for(comment("second")))
+
+      assert_equal 2, Task.where(agent: @agent, topic_id: @topic.id, status: "queued").count,
+                   "an agent-scoped opt-out must reach the folding decision"
+    end
+
+    # …and only for that agent. A fix that simply stopped folding would pass the
+    # test above on its own.
+    test "a User-scoped opt-out leaves the other agents in the topic folding" do
+      OrchestratorPolicy.create!(
+        policy_type: "scheduling", scope_type: "User", scope_id: second_agent.id,
+        config: { "coalesce_pending_tasks" => false }
+      )
+      occupy_slot!
+
+      AiAgentJob.new.perform(@agent.id, "comment_created", context_for(comment("first")))
+      AiAgentJob.new.perform(@agent.id, "comment_created", context_for(comment("second")))
+
+      assert_equal 1, Task.where(agent: @agent, topic_id: @topic.id, status: "queued").count,
+                   "another agent's opt-out must not switch folding off for this one"
+    end
+
+    # A mixed topic — one agent coalescing, one opted out — has both kinds of
+    # notice standing at once. Classifying a notice by whether a sibling survives
+    # then reads the shared one as a per-deferral one and cancels the newest
+    # queued waiter, which is the one the *other* notice speaks for.
+    def mixed_notice_topic!
+      OrchestratorPolicy.create!(
+        policy_type: "scheduling", scope_type: "User", scope_id: second_agent.id,
+        config: { "coalesce_pending_tasks" => false }
+      )
+      occupy_slot!
+      AiAgentJob.new.perform(@agent.id, "comment_created", context_for(comment("a")))
+      AiAgentJob.new.perform(@agent.id, "comment_created", context_for(comment("b")))
+      AiAgentJob.new.perform(second_agent.id, "comment_created", context_for(comment("c")))
+
+      notices = Comment.where(creative_id: @creative.id, topic_id: @topic.id, user_id: nil,
+                              topic_concurrency_defer: true)
+                       .where("content LIKE ?", "#{Comment::WAITING_NOTICE_PREFIX}%")
+                       .order(:id).to_a
+      assert_equal 2, notices.size,
+                   "the coalescing agent shares one notice; the opt-out posts its own"
+
+      [ notices.first, notices.last,
+        Task.where(agent: @agent, topic_id: @topic.id, status: "queued").sole,
+        Task.where(agent: second_agent, topic_id: @topic.id, status: "queued").sole ]
+    end
+
+    # The dedup guard asks whether the topic already has *its* one notice. An
+    # opt-out notice is not that notice, so letting it answer would leave the
+    # coalescing agent's waiter with nothing on screen whenever an opted-out
+    # agent happened to defer into the topic first.
+    test "a per-deferral notice does not suppress the topic's shared notice" do
+      OrchestratorPolicy.create!(
+        policy_type: "scheduling", scope_type: "User", scope_id: second_agent.id,
+        config: { "coalesce_pending_tasks" => false }
+      )
+      occupy_slot!
+
+      AiAgentJob.new.perform(second_agent.id, "comment_created", context_for(comment("opt-out first")))
+      AiAgentJob.new.perform(@agent.id, "comment_created", context_for(comment("coalescing second")))
+
+      scopes = Comment.where(creative_id: @creative.id, topic_id: @topic.id, user_id: nil,
+                             topic_concurrency_defer: true)
+                      .where("content LIKE ?", "#{Comment::WAITING_NOTICE_PREFIX}%")
+                      .order(:id).pluck(:waiting_notice_scope)
+      assert_equal [ Comment::WAITING_NOTICE_TASK, Comment::WAITING_NOTICE_TOPIC ], scopes,
+                   "the coalescing agent's waiter needs a notice of the topic's own"
+    end
+
+    test "deleting the shared notice cancels the waiter it stood for, not the opt-out's" do
+      shared, _own_notice, shared_waiter, own_waiter = mixed_notice_topic!
+
+      shared.destroy!
+
+      assert_equal "cancelled", shared_waiter.reload.status,
+                   "the shared notice is the only stop control its waiter has"
+      assert_equal "queued", own_waiter.reload.status,
+                   "a waiter whose own notice is still on screen was never this one's to cancel"
+    end
+
+    # A per-deferral notice speaks for one waiter, so promoting that waiter ends
+    # what it describes. The drained guard is the *shared* notice's question: with
+    # the opt-out and a second waiter still parked, it keeps every notice up —
+    # including one offering a stop button for a task that is already running.
+    test "promoting an opt-out waiter takes its own notice down and leaves the others" do
+      OrchestratorPolicy.create!(
+        policy_type: "scheduling", scope_type: nil,
+        config: { "coalesce_pending_tasks" => false }
+      )
+      holder = occupy_slot!
+      AiAgentJob.new.perform(@agent.id, "comment_created", context_for(comment("a")))
+      AiAgentJob.new.perform(@agent.id, "comment_created", context_for(comment("b")))
+      notices = Comment.where(creative_id: @creative.id, topic_id: @topic.id, user_id: nil,
+                              topic_concurrency_defer: true)
+                       .where("content LIKE ?", "#{Comment::WAITING_NOTICE_PREFIX}%")
+                       .order(:id).to_a
+      waiters = Task.where(agent: @agent, topic_id: @topic.id, status: "queued").order(:id).to_a
+      assert_equal [ 2, 2 ], [ notices.size, waiters.size ]
+
+      holder.update!(status: "done")
+      # Promotion only: without this the promoted job runs inline, finishes, and
+      # drains the queue, which is the case the drained guard already covers.
+      AiAgentJob.stub :perform_later, ->(*) { nil } do
+        Orchestration::AgentOrchestrator.dequeue_next_for_topic(@topic.id, @creative.id)
+      end
+
+      assert_equal "pending", waiters.first.reload.status, "the oldest waiter is the promoted one"
+      assert_equal "queued", waiters.last.reload.status, "the second waiter is still waiting"
+      assert_not Comment.exists?(notices.first.id),
+                 "the promoted waiter's own notice describes a wait that is over"
+      assert Comment.exists?(notices.last.id),
+             "the waiter still queued keeps the notice that speaks for it"
+    end
+
+    test "deleting a per-deferral notice cancels only its own waiter" do
+      _shared, own_notice, shared_waiter, own_waiter = mixed_notice_topic!
+
+      own_notice.destroy!
+
+      assert_equal "cancelled", own_waiter.reload.status
+      assert_equal "queued", shared_waiter.reload.status,
+                   "the opt-out's 1:1 must not reach across to the coalescing agent"
+    end
   end
 end

--- a/engines/collavre/test/jobs/collavre/ai_agent_job_topic_slot_test.rb
+++ b/engines/collavre/test/jobs/collavre/ai_agent_job_topic_slot_test.rb
@@ -499,5 +499,129 @@ module Collavre
       assert_equal "queued", shared_waiter.reload.status,
                    "the opt-out's 1:1 must not reach across to the coalescing agent"
     end
+
+    # The waiter commits before its notice goes up, so the blocker can finish in
+    # between and promote it. The drain guard asks the *shared* notice's
+    # question — is anyone still waiting? — and another deferral parking in the
+    # same burst answers yes, so a per-deferral notice goes up for a task that is
+    # already running. Nothing removes it: cleanup_waiter_notice! ran during that
+    # promotion, before this notice existed, and it is the only path that would.
+    #
+    # The promotion is injected at waiting_reason_text, the call this door makes
+    # after its waiter has committed and before the guard takes the lock — the
+    # exact window the report names — and runs through the real
+    # dequeue_next_for_topic rather than flipping a status by hand.
+    test "the late admission door posts no notice once its own waiter has been promoted" do
+      OrchestratorPolicy.create!(
+        policy_type: "scheduling", scope_type: nil,
+        config: { "coalesce_pending_tasks" => false }
+      )
+      holder = occupy_slot!
+      sibling = nil
+
+      promote_in_window = lambda do |*args|
+        # Another agent's deferral parks in the same burst, so the topic still
+        # has a queued waiter when the guard asks.
+        sibling ||= Task.create!(
+          name: "Sibling waiter", status: "queued", trigger_event_name: "comment_created",
+          agent: second_agent, topic_id: @topic.id, creative_id: @creative.id,
+          trigger_event_payload: context_for(comment("sibling"))
+        )
+        holder.update!(status: "done")
+        AiAgentJob.stub :perform_later, ->(*) { nil } do
+          Orchestration::AgentOrchestrator.dequeue_next_for_topic(@topic.id, @creative.id)
+        end
+        _reason_key, _topic_id, _creative_id = args
+        "another task is running"
+      end
+
+      Orchestration::AgentOrchestrator.stub :waiting_reason_text, promote_in_window do
+        AiAgentJob.new.perform(@agent.id, "comment_created", context_for(comment("mine")))
+      end
+
+      waiter = Task.where(agent: @agent, topic_id: @topic.id).where.not(id: holder.id).sole
+      assert_equal "pending", waiter.status, "the promotion took this waiter mid-window"
+      assert_equal "queued", sibling.reload.status, "the sibling keeps the topic queue non-empty"
+      assert_not Comment.where(creative_id: @creative.id, topic_id: @topic.id, user_id: nil,
+                               waiting_notice_scope: Comment::WAITING_NOTICE_TASK,
+                               waiting_notice_task_id: waiter.id).exists?,
+                 "a notice for a promoted waiter is a stop button nothing can take down"
+    end
+
+    # …and the same question on the enqueue door, which posts its per-deferral
+    # notice after park_waiter has already committed the row.
+    test "the enqueue door posts no per-deferral notice for a waiter already promoted" do
+      OrchestratorPolicy.create!(
+        policy_type: "scheduling", scope_type: nil,
+        config: { "coalesce_pending_tasks" => false }
+      )
+      occupy_slot!
+      c = comment("mine")
+      orchestrator = Orchestration::AgentOrchestrator.new(
+        event_name: "comment_created", context: context_for(c)
+      )
+      waiter = Task.create!(
+        name: "Waiter", status: "pending", trigger_event_name: "comment_created",
+        agent: @agent, topic_id: @topic.id, creative_id: @creative.id,
+        trigger_event_payload: context_for(c)
+      )
+      Task.create!(
+        name: "Sibling waiter", status: "queued", trigger_event_name: "comment_created",
+        agent: second_agent, topic_id: @topic.id, creative_id: @creative.id,
+        trigger_event_payload: context_for(comment("sibling"))
+      )
+
+      orchestrator.send(:post_waiting_notice, @agent,
+                        { timing: :deferred, reason: :topic_concurrency }, waiter: waiter)
+
+      assert_not Comment.where(creative_id: @creative.id, topic_id: @topic.id, user_id: nil,
+                               waiting_notice_scope: Comment::WAITING_NOTICE_TASK,
+                               waiting_notice_task_id: waiter.id).exists?,
+                 "the enqueue door has the same window between park_waiter and the notice"
+    end
+
+    # The control the two above need: a waiter that really is still queued gets
+    # its notice, so this is not "stop posting per-deferral notices".
+    test "the enqueue door still posts a per-deferral notice for a queued waiter" do
+      OrchestratorPolicy.create!(
+        policy_type: "scheduling", scope_type: nil,
+        config: { "coalesce_pending_tasks" => false }
+      )
+      occupy_slot!
+      c = comment("mine")
+      orchestrator = Orchestration::AgentOrchestrator.new(
+        event_name: "comment_created", context: context_for(c)
+      )
+      waiter = Task.create!(
+        name: "Waiter", status: "queued", trigger_event_name: "comment_created",
+        agent: @agent, topic_id: @topic.id, creative_id: @creative.id,
+        trigger_event_payload: context_for(c)
+      )
+
+      orchestrator.send(:post_waiting_notice, @agent,
+                        { timing: :deferred, reason: :topic_concurrency }, waiter: waiter)
+
+      assert Comment.where(creative_id: @creative.id, topic_id: @topic.id, user_id: nil,
+                           waiting_notice_scope: Comment::WAITING_NOTICE_TASK,
+                           waiting_notice_task_id: waiter.id).exists?,
+             "a real wait still needs its own notice and stop button"
+    end
+
+    # A :delayed notice speaks for no waiter at all — it explains a rate-limited
+    # or busy dispatch that is still going to run — so the waiter guard must not
+    # be what decides whether it appears.
+    test "a delayed notice is posted with no waiter to check" do
+      c = comment("busy")
+      orchestrator = Orchestration::AgentOrchestrator.new(
+        event_name: "comment_created", context: context_for(c)
+      )
+
+      assert_difference -> {
+        Comment.where(creative_id: @creative.id, topic_id: @topic.id, user_id: nil)
+               .where("content LIKE ?", "#{Comment::WAITING_NOTICE_PREFIX}%").count
+      }, 1 do
+        orchestrator.send(:post_waiting_notice, @agent, { timing: :delayed, reason: :busy })
+      end
+    end
   end
 end

--- a/engines/collavre/test/jobs/collavre/ai_agent_job_topic_slot_test.rb
+++ b/engines/collavre/test/jobs/collavre/ai_agent_job_topic_slot_test.rb
@@ -104,6 +104,31 @@ module Collavre
       assert_equal 1, notices.count
     end
 
+    # The notice is only ever removed by the promotion that drains this topic's
+    # queue. If the blocker finishes between the waiter's commit and this call,
+    # that promotion has already run its cleanup — a notice posted afterwards
+    # explains a wait nobody is doing and nothing will ever take it down.
+    test "posts no waiting notice once the queue has already drained" do
+      notices = -> {
+        Comment.where(creative_id: @creative.id, topic_id: @topic.id, user_id: nil)
+               .where("content LIKE ?", "#{Comment::WAITING_NOTICE_PREFIX}%").count
+      }
+
+      assert_no_difference notices do
+        Orchestration::AgentOrchestrator.post_topic_concurrency_notice(@creative.id, @topic.id)
+      end
+    end
+
+    test "posts the waiting notice while a waiter is still queued" do
+      occupy_slot!
+      AiAgentJob.new.perform(@agent.id, "comment_created", context_for(comment("m")))
+
+      assert Task.queued_for_topic(@topic.id, @creative.id).exists?
+      assert Comment.where(creative_id: @creative.id, topic_id: @topic.id, user_id: nil)
+                    .where("content LIKE ?", "#{Comment::WAITING_NOTICE_PREFIX}%").exists?,
+             "a real wait must still be explained"
+    end
+
     test "runs normally when the topic slot is free" do
       c = comment("first in topic")
 

--- a/engines/collavre/test/jobs/collavre/ai_agent_job_topic_slot_test.rb
+++ b/engines/collavre/test/jobs/collavre/ai_agent_job_topic_slot_test.rb
@@ -36,6 +36,18 @@ module Collavre
       )
     end
 
+    # A second, independent agent — the shape topic_max > 1 actually serves.
+    def second_agent
+      @second_agent ||= Collavre::User.create!(
+        name: "slot-agent-2",
+        email: "slot2-#{SecureRandom.hex(4)}@agent.test",
+        password: "password123",
+        llm_vendor: "openai",
+        llm_model: "gpt-4",
+        system_prompt: "You are a second agent."
+      )
+    end
+
     def occupy_slot!(status: "running")
       Task.create!(
         name: "Holder", status: status, trigger_event_name: "comment_created",
@@ -115,18 +127,98 @@ module Collavre
       assert_equal 0, Task.where(agent: @agent, status: "queued").count
     end
 
-    test "policy can disable the late slot check" do
+    # coalesce_pending_tasks governs whether waiters are FOLDED, not whether
+    # topic_max_concurrent_jobs is enforced. Turning it off must still keep the
+    # topic to one turn at a time — otherwise a burst dispatched before the first
+    # job materializes a task starts one concurrent turn per comment.
+    test "policy disables folding but not topic admission" do
       OrchestratorPolicy.create!(
         policy_type: "scheduling", scope_type: nil,
         config: { "coalesce_pending_tasks" => false }
       )
       occupy_slot!
-      c = comment("late arrival")
+      first = comment("first")
+      second = comment("second")
+
+      AiAgentJob.new.perform(@agent.id, "comment_created", context_for(first))
+      AiAgentJob.new.perform(@agent.id, "comment_created", context_for(second))
+
+      waiters = Task.where(agent: @agent, topic_id: @topic.id, status: "queued").order(:id)
+      assert_equal 2, waiters.count, "with coalescing off each comment keeps its own waiter"
+      assert_equal 1, Task.where(agent: @agent, topic_id: @topic.id, status: "running").count,
+                   "the holder must still be the only running task"
+      assert_nil waiters.first.trigger_event_payload[Orchestration::TaskCoalescer::PAYLOAD_KEY]
+    end
+
+    # topic_max > 1 exists to run *different* agents in parallel. An agent that
+    # already has a turn in flight must not take a second slot: TaskCoalescer
+    # only folds `queued` rows, so two concurrent turns can never be merged.
+    test "defers an agent that already holds a slot even when the topic has room" do
+      OrchestratorPolicy.create!(
+        policy_type: "scheduling", scope_type: nil,
+        config: { "topic_max_concurrent_jobs" => 2 }
+      )
+      occupy_slot!
+      c = comment("same agent again")
 
       AiAgentJob.new.perform(@agent.id, "comment_created", context_for(c))
 
-      assert_equal 0, Task.where(agent: @agent, topic_id: @topic.id, status: "queued").count,
-                   "with coalescing off the previous immediate behaviour returns"
+      assert_equal 1, Task.where(agent: @agent, topic_id: @topic.id, status: "queued").count,
+                   "the agent's second turn must queue behind its own running one"
+      assert_equal 1, Task.where(agent: @agent, topic_id: @topic.id, status: "running").count
+    end
+
+    test "a second agent still takes the free slot when the topic has room" do
+      OrchestratorPolicy.create!(
+        policy_type: "scheduling", scope_type: nil,
+        config: { "topic_max_concurrent_jobs" => 2 }
+      )
+      occupy_slot!
+      other = second_agent
+      Orchestration::ResourceTracker.for(other).reset!
+      c = comment("different agent")
+
+      AiAgentJob.new.perform(other.id, "comment_created", context_for(c))
+
+      assert_equal 0, Task.where(agent: other, topic_id: @topic.id, status: "queued").count,
+                   "the parallelism topic_max > 1 buys must survive the same-agent guard"
+      assert Task.where(agent: other, topic_id: @topic.id).exists?
+    ensure
+      Orchestration::ResourceTracker.for(other).reset! if other
+    end
+
+    # The occupancy count and the row that claims the slot have to be one step.
+    # Two workers starting in the same millisecond otherwise both read a free
+    # slot before either inserts — the TOCTOU race this check exists to close.
+    test "admission counts and claims the slot inside one locked transaction" do
+      locked_topic_ids = []
+      lock_relation = Struct.new(:sink) do
+        def find_by(id:)
+          sink << id
+          nil
+        end
+      end.new(locked_topic_ids)
+
+      # The suite already runs inside a transaction, so `transaction_open?` is
+      # always true — compare the nesting depth against the ambient one instead.
+      baseline_depth = Task.connection.open_transactions
+      check_depth = nil
+      counting_scope = Task.occupying_topic_slot(@topic.id, @creative.id)
+      c = comment("first in topic")
+
+      Topic.stub(:lock, lock_relation) do
+        Task.stub(:occupying_topic_slot, ->(*) {
+          check_depth ||= Task.connection.open_transactions
+          counting_scope
+        }) do
+          AiAgentJob.new.perform(@agent.id, "comment_created", context_for(c))
+        end
+      end
+
+      assert_equal [ @topic.id ], locked_topic_ids,
+                   "admission must serialize on the topic row"
+      assert_operator check_depth, :>, baseline_depth,
+                      "the occupancy check must run inside the claiming transaction"
     end
   end
 end

--- a/engines/collavre/test/jobs/collavre/ai_agent_job_topic_slot_test.rb
+++ b/engines/collavre/test/jobs/collavre/ai_agent_job_topic_slot_test.rb
@@ -761,5 +761,138 @@ module Collavre
       assert Comment.exists?(notice.id),
              "a waiter still in the queue keeps the notice that stops it"
     end
+
+    # A shared notice and a per-deferral one coexist as soon as the agents in a
+    # topic resolve the coalescing policy differently. Promoting the shared
+    # notice's waiter deliberately keeps that notice up, because the opted-out
+    # waiter still makes the topic queue non-empty — so when *that* waiter is
+    # the one cancelled, the shared notice is left describing a wait that is
+    # over, and no promotion will ever run the drained check for it.
+    def stranded_shared_notice!(promote: true)
+      OrchestratorPolicy.create!(
+        policy_type: "scheduling", scope_type: "User", scope_id: second_agent.id,
+        config: { "coalesce_pending_tasks" => false }
+      )
+      holder = occupy_slot!
+      AiAgentJob.new.perform(@agent.id, "comment_created", context_for(comment("mine")))
+      AiAgentJob.new.perform(second_agent.id, "comment_created", context_for(comment("theirs")))
+
+      mine = Task.where(agent: @agent, topic_id: @topic.id, status: "queued").sole
+      theirs = Task.where(agent: second_agent, topic_id: @topic.id, status: "queued").sole
+      shared = Comment.find_by(creative_id: @creative.id, topic_id: @topic.id, user_id: nil,
+                               waiting_notice_scope: Comment::WAITING_NOTICE_TOPIC)
+      theirs_notice = Comment.find_by(creative_id: @creative.id, topic_id: @topic.id, user_id: nil,
+                                      waiting_notice_scope: Comment::WAITING_NOTICE_TASK,
+                                      waiting_notice_task_id: theirs.id)
+      assert shared, "premise: the coalescing agent's deferral posts a shared notice"
+      assert theirs_notice, "premise: the opted-out agent's deferral posts its own"
+      return [ shared, mine, theirs, theirs_notice ] unless promote
+
+      holder.update!(status: "done")
+      # Stubbed so the promoted turn does not run inline and drain the queue for
+      # an ordinary reason — the state under test is one task promoted, one
+      # still queued.
+      AiAgentJob.stub :perform_later, ->(*) { nil } do
+        Orchestration::AgentOrchestrator.dequeue_next_for_topic(@topic.id, @creative.id)
+      end
+      assert_equal "pending", mine.reload.status, "premise: the shared notice's waiter was promoted"
+      assert_equal "queued", theirs.reload.status, "premise: the opted-out waiter is still parked"
+      assert Comment.exists?(shared.id),
+             "premise: the promotion kept the shared notice up for the waiter still queued"
+      [ shared, mine, theirs, theirs_notice ]
+    end
+
+    test "cancelling the last waiter takes down the shared notice left behind" do
+      shared, _mine, theirs, theirs_notice = stranded_shared_notice!
+
+      theirs_notice.destroy!
+
+      assert_equal "cancelled", theirs.reload.status, "premise: the stop button ended that wait"
+      assert_not Comment.exists?(shared.id),
+                 "nothing is queued, so the shared notice describes a wait that is over"
+    end
+
+    # The control: cancelling one waiter while another is still queued must not
+    # take the shared notice down — that notice is still the only wait/stop
+    # signal the remaining waiter has.
+    test "cancelling one waiter keeps the shared notice while another is queued" do
+      shared, mine, theirs, theirs_notice = stranded_shared_notice!(promote: false)
+
+      theirs_notice.destroy!
+
+      assert_equal "cancelled", theirs.reload.status
+      assert_equal "queued", mine.reload.status, "premise: the shared notice still speaks for this"
+      assert Comment.exists?(shared.id),
+             "a wait that is still real keeps its notice and its stop button"
+    end
+
+    # …and it must not reach a :delayed notice. That one shares the "⏳" prefix
+    # but explains a rate-limited or busy dispatch that is still going to run,
+    # so an empty topic queue says nothing about whether it is still true.
+    test "cancelling the last waiter leaves a delayed notice standing" do
+      shared, _mine, _theirs, theirs_notice = stranded_shared_notice!
+      orchestrator = Orchestration::AgentOrchestrator.new(
+        event_name: "comment_created", context: context_for(comment("busy"))
+      )
+      orchestrator.send(:post_waiting_notice, @agent, { timing: :delayed, reason: :busy })
+      delayed = Comment.where(creative_id: @creative.id, topic_id: @topic.id, user_id: nil,
+                              topic_concurrency_defer: false)
+                       .where("content LIKE ?", "#{Comment::WAITING_NOTICE_PREFIX}%").sole
+
+      theirs_notice.destroy!
+
+      assert_not Comment.exists?(shared.id), "premise: the stranded shared notice came down"
+      assert Comment.exists?(delayed.id),
+             "a delayed dispatch is still going to run — an empty queue is not its question"
+    end
+
+    # The loop breaker counts the turns an agent takes for itself. A dispatch
+    # the Scheduler judged :immediate can still lose the admission race here and
+    # be parked instead — same turn, same burst — and the promotion that later
+    # runs it enters the existing-Task branch, which records nothing either.
+    test "records a deferred turn in the loop breaker" do
+      Rails.cache.clear
+      OrchestratorPolicy.create!(
+        policy_type: "scheduling", scope_type: nil,
+        config: { "creative_retry_threshold" => 2 }
+      )
+      occupy_slot!
+      context = nil
+      2.times do |i|
+        context = agent_authored_context(comment("agent burst #{i}"))
+        AiAgentJob.new.perform(@agent.id, "comment_created", context)
+      end
+
+      result = Orchestration::LoopBreaker.new(context).check
+
+      assert result.should_break?,
+             "two agent-authored turns were created here, so the threshold has been reached"
+      assert_equal :creative_retry_exceeded, result.reason
+    end
+
+    # The control: LoopBreaker deliberately ignores user-initiated messages, and
+    # deferring one must not start counting it. "Record every dispatch" would
+    # pass the test above on its own.
+    test "does not record a user-initiated deferred turn in the loop breaker" do
+      Rails.cache.clear
+      OrchestratorPolicy.create!(
+        policy_type: "scheduling", scope_type: nil,
+        config: { "creative_retry_threshold" => 2 }
+      )
+      occupy_slot!
+      context = nil
+      2.times do |i|
+        context = context_for(comment("user burst #{i}"))
+        AiAgentJob.new.perform(@agent.id, "comment_created", context)
+      end
+
+      assert Orchestration::LoopBreaker.new(context).check.safe?,
+             "a person typing twice is not a loop"
+    end
+
+    def agent_authored_context(comment)
+      context = context_for(comment)
+      context.merge("comment" => context["comment"].merge("from_ai" => true))
+    end
   end
 end

--- a/engines/collavre/test/jobs/collavre/ai_agent_job_topic_slot_test.rb
+++ b/engines/collavre/test/jobs/collavre/ai_agent_job_topic_slot_test.rb
@@ -797,19 +797,90 @@ module Collavre
       end
       assert_equal "pending", mine.reload.status, "premise: the shared notice's waiter was promoted"
       assert_equal "queued", theirs.reload.status, "premise: the opted-out waiter is still parked"
-      assert Comment.exists?(shared.id),
-             "premise: the promotion kept the shared notice up for the waiter still queued"
       [ shared, mine, theirs, theirs_notice ]
     end
 
-    test "cancelling the last waiter takes down the shared notice left behind" do
+    # Two agents that both coalesce share one notice, so the survivor of a
+    # promotion is a waiter the shared notice really does speak for.
+    def coalescing_pair!
+      holder = occupy_slot!
+      AiAgentJob.new.perform(@agent.id, "comment_created", context_for(comment("mine")))
+      AiAgentJob.new.perform(second_agent.id, "comment_created", context_for(comment("theirs")))
+
+      mine = Task.where(agent: @agent, topic_id: @topic.id, status: "queued").sole
+      theirs = Task.where(agent: second_agent, topic_id: @topic.id, status: "queued").sole
+      shared = Comment.where(creative_id: @creative.id, topic_id: @topic.id, user_id: nil,
+                             waiting_notice_scope: Comment::WAITING_NOTICE_TOPIC).sole
+      assert_empty Comment.where(creative_id: @creative.id, topic_id: @topic.id, user_id: nil,
+                                 waiting_notice_scope: Comment::WAITING_NOTICE_TASK),
+                   "premise: neither deferral posted a per-deferral notice"
+      [ holder, shared, mine, theirs ]
+    end
+
+    # The shared notice is dismissable, and dismissing it cancels the waiters it
+    # speaks for — which is every queued waiter *except* those a per-deferral
+    # notice claims. Once the promotion leaves nothing but claimed waiters
+    # behind, that set is empty: the notice is a second "⏳" line on screen whose
+    # stop button selects nothing, and the drained sweep will not collect it
+    # because the claimed waiter keeps the topic queue non-empty.
+    test "promotion takes down a shared notice left speaking for nobody" do
       shared, _mine, theirs, theirs_notice = stranded_shared_notice!
 
-      theirs_notice.destroy!
-
-      assert_equal "cancelled", theirs.reload.status, "premise: the stop button ended that wait"
+      assert_equal "queued", theirs.reload.status, "premise: a waiter is still parked"
+      assert Comment.exists?(theirs_notice.id),
+             "the waiter still queued keeps its own notice and its own stop button"
       assert_not Comment.exists?(shared.id),
-                 "nothing is queued, so the shared notice describes a wait that is over"
+                 "every waiter left is claimed by its own notice, so this one stops nothing"
+    end
+
+    # The control: a survivor that no per-deferral notice claims is exactly what
+    # the shared notice is for. "Take it down on every promotion" would pass the
+    # test above while stripping the wait/stop signal off a wait that is real.
+    test "promotion keeps the shared notice for a waiter no other notice claims" do
+      holder, shared, mine, theirs = coalescing_pair!
+
+      holder.update!(status: "done")
+      AiAgentJob.stub :perform_later, ->(*) { nil } do
+        Orchestration::AgentOrchestrator.dequeue_next_for_topic(@topic.id, @creative.id)
+      end
+
+      assert_equal "pending", mine.reload.status, "premise: one waiter was promoted"
+      assert_equal "queued", theirs.reload.status, "premise: the other is still parked"
+      assert Comment.exists?(shared.id),
+             "this notice is the only wait/stop signal the queued waiter has"
+    end
+
+    # Deleting a trigger cancels the waiter that answers it, and that waiter
+    # never reaches a promotion — so nothing runs the drained check. With
+    # coalescing on, the notice it leaves behind is the *shared* one, which
+    # remove_waiter_notices! does not touch.
+    test "deleting the last waiter's anchor takes down the shared notice" do
+      occupy_slot!
+      anchor = comment("mine")
+      AiAgentJob.new.perform(@agent.id, "comment_created", context_for(anchor))
+      waiter = Task.where(agent: @agent, topic_id: @topic.id, status: "queued").sole
+      shared = Comment.where(creative_id: @creative.id, topic_id: @topic.id, user_id: nil,
+                             waiting_notice_scope: Comment::WAITING_NOTICE_TOPIC).sole
+
+      anchor.destroy!
+
+      assert_equal "cancelled", waiter.reload.status, "premise: deleting the prompt ended the wait"
+      assert_not Comment.exists?(shared.id),
+                 "nothing is queued behind it, so the notice describes a wait that is over"
+    end
+
+    # The control: the same deletion with another waiter still parked must leave
+    # the notice alone — it speaks for that one too.
+    test "deleting one anchor keeps the shared notice while another waiter is queued" do
+      _holder, shared, mine, theirs = coalescing_pair!
+      anchor = Comment.find(mine.trigger_event_payload.dig("comment", "id"))
+
+      anchor.destroy!
+
+      assert_equal "cancelled", mine.reload.status, "premise: that waiter's prompt is gone"
+      assert_equal "queued", theirs.reload.status, "premise: the other is still parked"
+      assert Comment.exists?(shared.id),
+             "a wait that is still real keeps its notice and its stop button"
     end
 
     # The control: cancelling one waiter while another is still queued must not
@@ -841,6 +912,8 @@ module Collavre
 
       theirs_notice.destroy!
 
+      assert_equal 0, Task.where(topic_id: @topic.id, status: "queued").count,
+                   "premise: the topic queue is empty"
       assert_not Comment.exists?(shared.id), "premise: the stranded shared notice came down"
       assert Comment.exists?(delayed.id),
              "a delayed dispatch is still going to run — an empty queue is not its question"

--- a/engines/collavre/test/jobs/collavre/ai_agent_job_topic_slot_test.rb
+++ b/engines/collavre/test/jobs/collavre/ai_agent_job_topic_slot_test.rb
@@ -707,5 +707,59 @@ module Collavre
                            waiting_notice_task_id: theirs.id).exists?,
              "the opt-out agent's notice speaks for a waiter that is still queued"
     end
+
+    # The fold is not the only way a waiter leaves the queue without ever being
+    # promoted. Deleting the comment it answers cancels it through
+    # Comment#cancel_pending_tasks, and that needs no policy change at all — the
+    # opt-out on its own is enough.
+    test "cancelling a waiter with its deleted anchor takes its notice down" do
+      OrchestratorPolicy.create!(
+        policy_type: "scheduling", scope_type: nil,
+        config: { "coalesce_pending_tasks" => false }
+      )
+      occupy_slot!
+      anchor = comment("mine")
+      AiAgentJob.new.perform(@agent.id, "comment_created", context_for(anchor))
+      waiter = Task.where(agent: @agent, topic_id: @topic.id, status: "queued").sole
+      notice = Comment.find_by(creative_id: @creative.id, topic_id: @topic.id, user_id: nil,
+                               waiting_notice_scope: Comment::WAITING_NOTICE_TASK,
+                               waiting_notice_task_id: waiter.id)
+      assert notice, "premise: the opt-out door posts a notice naming this waiter"
+
+      anchor.destroy!
+
+      assert_equal "cancelled", waiter.reload.status, "premise: the deleted prompt ended the turn"
+      assert_not Comment.exists?(notice.id),
+                 "the wait is over however it ended, so its dead stop button goes with it"
+    end
+
+    # The control: a waiter that survives the deletion keeps its notice. A
+    # re-anchored task is still queued, so its stop button still stops something.
+    test "re-anchoring a waiter onto an absorbed comment keeps its notice" do
+      OrchestratorPolicy.create!(
+        policy_type: "scheduling", scope_type: nil,
+        config: { "coalesce_pending_tasks" => false }
+      )
+      occupy_slot!
+      absorbed = comment("first")
+      anchor = comment("second")
+      AiAgentJob.new.perform(@agent.id, "comment_created", context_for(anchor))
+      waiter = Task.where(agent: @agent, topic_id: @topic.id, status: "queued").sole
+      waiter.update!(
+        trigger_event_payload: waiter.trigger_event_payload.merge(
+          Orchestration::TaskCoalescer::PAYLOAD_KEY => [ absorbed.id ]
+        )
+      )
+      notice = Comment.find_by(creative_id: @creative.id, topic_id: @topic.id, user_id: nil,
+                               waiting_notice_scope: Comment::WAITING_NOTICE_TASK,
+                               waiting_notice_task_id: waiter.id)
+      assert notice, "premise: the opt-out door posts a notice naming this waiter"
+
+      anchor.destroy!
+
+      assert_equal "queued", waiter.reload.status, "premise: it re-anchored rather than cancelling"
+      assert Comment.exists?(notice.id),
+             "a waiter still in the queue keeps the notice that stops it"
+    end
   end
 end

--- a/engines/collavre/test/jobs/collavre/ai_agent_job_topic_slot_test.rb
+++ b/engines/collavre/test/jobs/collavre/ai_agent_job_topic_slot_test.rb
@@ -215,10 +215,72 @@ module Collavre
         end
       end
 
-      assert_equal [ @topic.id ], locked_topic_ids,
+      # The admitted task drains the topic queue as it finishes, and that claim
+      # takes the same lock — one entry per claim attempt, none skipping it.
+      assert_equal [ @topic.id ], locked_topic_ids.uniq,
                    "admission must serialize on the topic row"
+      assert_predicate locked_topic_ids, :any?
       assert_operator check_depth, :>, baseline_depth,
                       "the occupancy check must run inside the claiming transaction"
+    end
+
+    # A creative's Main topic carries topic.id == nil (Scheduler covers this
+    # shape). It is still subject to topic_max_concurrent_jobs — occupancy is
+    # counted with topic_id: nil scoped to the creative — so it needs a lock too.
+    # Without one there is no shared row to serialize on and concurrent workers
+    # both read a free slot before either inserts.
+    test "admission on the Main topic serializes on the creative row" do
+      locked_creative_ids = []
+      lock_relation = Struct.new(:sink) do
+        def find_by(id:)
+          sink << id
+          nil
+        end
+      end.new(locked_creative_ids)
+
+      baseline_depth = Task.connection.open_transactions
+      check_depth = nil
+      counting_scope = Task.occupying_topic_slot(nil, @creative.id)
+      c = Comment.create!(creative: @creative, user: @user, content: "main topic", skip_dispatch: true)
+      main_context = {
+        "creative" => { "id" => @creative.id },
+        "topic" => { "id" => nil },
+        "comment" => { "id" => c.id, "content" => c.content, "user_id" => @user.id }
+      }
+
+      Creative.stub(:lock, lock_relation) do
+        Task.stub(:occupying_topic_slot, ->(*) {
+          check_depth ||= Task.connection.open_transactions
+          counting_scope
+        }) do
+          AiAgentJob.new.perform(@agent.id, "comment_created", main_context)
+        end
+      end
+
+      assert_equal [ @creative.id ], locked_creative_ids.uniq,
+                   "Main-topic admission must serialize on a stable creative-scoped row"
+      assert_predicate locked_creative_ids, :any?
+      assert_operator check_depth, :>, baseline_depth,
+                      "the occupancy check must run inside the claiming transaction"
+    end
+
+    test "defers a Main-topic dispatch when the creative's Main slot is taken" do
+      Task.create!(
+        name: "Main holder", status: "running", trigger_event_name: "comment_created",
+        agent: @agent, topic_id: nil, creative_id: @creative.id,
+        trigger_event_payload: { "topic" => { "id" => nil } }
+      )
+      c = Comment.create!(creative: @creative, user: @user, content: "main late", skip_dispatch: true)
+      main_context = {
+        "creative" => { "id" => @creative.id },
+        "topic" => { "id" => nil },
+        "comment" => { "id" => c.id, "content" => c.content, "user_id" => @user.id }
+      }
+
+      AiAgentJob.new.perform(@agent.id, "comment_created", main_context)
+
+      assert_equal 1, Task.where(agent: @agent, topic_id: nil, creative_id: @creative.id,
+                                 status: "queued").count
     end
   end
 end

--- a/engines/collavre/test/jobs/collavre/ai_agent_job_topic_slot_test.rb
+++ b/engines/collavre/test/jobs/collavre/ai_agent_job_topic_slot_test.rb
@@ -104,6 +104,32 @@ module Collavre
       assert_equal 1, notices.count
     end
 
+    # With coalescing off there is no survivor to speak for the burst: every
+    # deferral keeps its own waiter. A single deduplicated notice over N
+    # independent waiters is then a stop button that cancels other people's
+    # work — Comment#cancel_queued_tasks_for_waiting_notice reads "no sibling
+    # notice left" as "this one stood for the whole topic".
+    test "the late admission door keeps one notice per waiter when coalescing is off" do
+      OrchestratorPolicy.create!(
+        policy_type: "scheduling", scope_type: nil,
+        config: { "coalesce_pending_tasks" => false }
+      )
+      occupy_slot!
+      3.times { |i| AiAgentJob.new.perform(@agent.id, "comment_created", context_for(comment("m#{i}"))) }
+
+      notices = Comment.where(creative_id: @creative.id, topic_id: @topic.id, user_id: nil,
+                              topic_concurrency_defer: true)
+                       .where("content LIKE ?", "#{Comment::WAITING_NOTICE_PREFIX}%")
+                       .order(:id).to_a
+      assert_equal 3, notices.size, "the opt-out posts one notice per deferral on this door too"
+      assert_equal 3, Task.where(agent: @agent, topic_id: @topic.id, status: "queued").count
+
+      notices.last.destroy!
+
+      assert_equal 2, Task.where(agent: @agent, topic_id: @topic.id, status: "queued").count,
+                   "a notice that was never deduplicated speaks for one waiter only"
+    end
+
     # The notice is only ever removed by the promotion that drains this topic's
     # queue. If the blocker finishes between the waiter's commit and this call,
     # that promotion has already run its cleanup — a notice posted afterwards

--- a/engines/collavre/test/jobs/collavre/cron_action_job_test.rb
+++ b/engines/collavre/test/jobs/collavre/cron_action_job_test.rb
@@ -68,5 +68,44 @@ module Collavre
         )
       end
     end
+
+    # `topic_id: nil` describes the cron's *argument*, not the row: the comment
+    # goes through Comment#assign_main_topic, which files it under the
+    # creative's real Main topic. A payload that repeats the argument therefore
+    # names a topic its own comment is not in — and every consumer downstream
+    # (admission, the topic slot, the promotion refresh) believes the payload.
+    test "a Main-topic cron names the topic its comment was filed under" do
+      payload = nil
+      SystemEvents::Dispatcher.stub(:dispatch, ->(_event, sent) { payload = sent; [] }) do
+        CronActionJob.perform_now(
+          creative_id: @creative.id,
+          topic_id: nil,
+          agent_id: @agent.id,
+          message: "Main check-in"
+        )
+      end
+
+      comment = @creative.comments.order(:id).last
+      assert_not_nil comment.topic_id,
+                     "assign_main_topic files a topic-less comment under Main"
+      assert_equal comment.topic_id, payload.dig(:topic, :id),
+                   "the dispatch payload must name the topic the comment lives in"
+    end
+
+    # Control: an explicit topic still round-trips. "Always resolve Main" would
+    # pass the test above on its own while sending every cron to the wrong topic.
+    test "an explicit cron topic is dispatched unchanged" do
+      payload = nil
+      SystemEvents::Dispatcher.stub(:dispatch, ->(_event, sent) { payload = sent; [] }) do
+        CronActionJob.perform_now(
+          creative_id: @creative.id,
+          topic_id: @topic.id,
+          agent_id: @agent.id,
+          message: "Topic check-in"
+        )
+      end
+
+      assert_equal @topic.id, payload.dig(:topic, :id)
+    end
   end
 end

--- a/engines/collavre/test/models/collavre/comment_cancel_queued_test.rb
+++ b/engines/collavre/test/models/collavre/comment_cancel_queued_test.rb
@@ -128,12 +128,17 @@ module Collavre
         trigger_event_payload: { "comment" => { "id" => 991 } }
       )
 
+      # Which kind of notice this is used to be inferred from whether a sibling
+      # notice survived; it is recorded on the row now, so a hand-built fixture
+      # has to say. The producers writing it is a separate question, and one this
+      # fixture cannot answer — AiAgentJobTopicSlotTest drives the real doors.
       notice = @creative.comments.create!(
         content: "⏳ 대기중",
         topic_id: @topic.id,
         private: false,
         skip_default_user: true,
-        topic_concurrency_defer: true
+        topic_concurrency_defer: true,
+        waiting_notice_scope: Comment::WAITING_NOTICE_TOPIC
       )
 
       notice.destroy!

--- a/engines/collavre/test/models/collavre/comment_cancel_queued_test.rb
+++ b/engines/collavre/test/models/collavre/comment_cancel_queued_test.rb
@@ -91,7 +91,21 @@ module Collavre
       assert_equal "queued", task.reload.status
     end
 
-    test "deleting waiting notice cancels only the latest queued task" do
+    # A topic gets exactly one deduplicated waiting notice
+    # (AgentOrchestrator.with_deduped_topic_notice), so that one comment is the
+    # only wait/stop signal every queued waiter in the topic has. Cancelling just
+    # the newest — which was right when each deferral posted its own notice —
+    # now leaves the other waiters running with nothing on screen representing
+    # them and no way to stop them.
+    test "deleting the shared waiting notice cancels every waiter it represents" do
+      other_agent = Collavre::User.create!(
+        name: "Second AI Agent",
+        email: "ai-agent-test-2@example.com",
+        password: "password123",
+        llm_vendor: "google",
+        llm_model: "gemini-3-flash-preview"
+      )
+
       older_task = Task.create!(
         name: "Older queued work",
         status: "queued",
@@ -102,10 +116,12 @@ module Collavre
         trigger_event_payload: { "comment" => { "id" => 990 } }
       )
 
+      # A different agent's waiter: coalescing folds same-agent siblings only, so
+      # this one is deliberately left queued and the shared notice speaks for it.
       newer_task = Task.create!(
         name: "Newer queued work",
         status: "queued",
-        agent: @ai_agent,
+        agent: other_agent,
         creative_id: @creative.id,
         topic_id: @topic.id,
         trigger_event_name: "comment.created",
@@ -122,8 +138,48 @@ module Collavre
 
       notice.destroy!
 
-      assert_equal "queued", older_task.reload.status
       assert_equal "cancelled", newer_task.reload.status
+      assert_equal "cancelled", older_task.reload.status,
+                   "the one notice a topic is allowed stands for every queued waiter in it"
+    end
+
+    # Control: "every waiter" is every *waiter*. A task that already holds the
+    # topic slot is not waiting on anything, and the notice's stop button targets
+    # it separately (topic_blocking_task) — deleting the notice must not cancel
+    # the work that is actually running.
+    test "deleting the shared waiting notice leaves the slot holder alone" do
+      blocker = Task.create!(
+        name: "Running blocker",
+        status: "running",
+        agent: @ai_agent,
+        creative_id: @creative.id,
+        topic_id: @topic.id,
+        trigger_event_name: "comment.created",
+        trigger_event_payload: { "comment" => { "id" => 992 } }
+      )
+
+      claimed = Task.create!(
+        name: "Claimed, not started",
+        status: "pending",
+        agent: @ai_agent,
+        creative_id: @creative.id,
+        topic_id: @topic.id,
+        trigger_event_name: "comment.created",
+        trigger_event_payload: { "comment" => { "id" => 993 } }
+      )
+
+      notice = @creative.comments.create!(
+        content: "⏳ 대기중",
+        topic_id: @topic.id,
+        private: false,
+        skip_default_user: true,
+        topic_concurrency_defer: true
+      )
+
+      notice.destroy!
+
+      assert_equal "running", blocker.reload.status
+      assert_equal "pending", claimed.reload.status
     end
 
     test "deleting a non-concurrency :delayed notice does not cancel an unrelated queued waiter" do

--- a/engines/collavre/test/services/collavre/ai_agent/merged_trigger_comments_test.rb
+++ b/engines/collavre/test/services/collavre/ai_agent/merged_trigger_comments_test.rb
@@ -39,6 +39,36 @@ module Collavre
         assert_equal [ "[#{@user.name}]: first", "[#{@user.name}]: second" ], blocks.map(&:text)
       end
 
+      # Comment ids are the app's causal sequence (see CommentsController: created_at
+      # is stamped by whichever process wrote the row, so a burst inserted by
+      # concurrent workers can be backdated out of order). Ordering the merged
+      # prompt by created_at can therefore hand the agent "ignore that" before the
+      # instruction it retracts.
+      test "orders merged comments by id when created_at is skewed" do
+        first = comment("do X", created_at: 1.minute.ago)
+        second = comment("ignore that", created_at: 5.minutes.ago)
+        assert_operator first.id, :<, second.id
+        anchor = comment("and now Y")
+
+        blocks = MergedTriggerComments.for(context_with(anchor, [ first, second ]), agent: @agent)
+
+        assert_equal [ "[#{@user.name}]: do X", "[#{@user.name}]: ignore that" ],
+                     blocks.map(&:text),
+                     "insertion order is the causal order, not the stamped timestamp"
+      end
+
+      test "orders merged comments by id when created_at ties" do
+        same = 2.minutes.ago
+        first = comment("do X", created_at: same)
+        second = comment("ignore that", created_at: same)
+        anchor = comment("and now Y")
+
+        blocks = MergedTriggerComments.for(context_with(anchor, [ second, first ]), agent: @agent)
+
+        assert_equal [ "[#{@user.name}]: do X", "[#{@user.name}]: ignore that" ],
+                     blocks.map(&:text)
+      end
+
       test "excludes the anchor comment from the merged blocks" do
         anchor = comment("only")
 

--- a/engines/collavre/test/services/collavre/ai_agent/merged_trigger_comments_test.rb
+++ b/engines/collavre/test/services/collavre/ai_agent/merged_trigger_comments_test.rb
@@ -138,6 +138,45 @@ module Collavre
         assert_includes content, "earlier point"
         assert_includes content, "later point"
       end
+
+      # MessageBuilder budgets chat history by chat_history_size, but the merged
+      # blocks go into the trigger, which had no budget at all. A burst is
+      # exactly the input that makes that asymmetry bite: coalescing turns N
+      # comments into one indivisible message, so an oversized burst does not
+      # degrade — the whole turn fails.
+      test "drops the oldest merged blocks once they exceed the agent's size budget" do
+        @agent.update!(agent_conf: "context:\n  chat_history_size: 200")
+        oldest = comment("O" * 150)
+        middle = comment("M" * 150)
+        newest = comment("N" * 150)
+        anchor = comment("anchor")
+
+        blocks = MergedTriggerComments.for(
+          context_with(anchor, [ oldest, middle, newest ]), agent: @agent
+        )
+
+        rendered = blocks.map(&:text).join("\n\n")
+        assert_includes rendered, "N" * 150, "the newest merged comment must survive"
+        refute_includes rendered, "O" * 150, "the oldest must be dropped once over budget"
+        assert_match(/omitted/, rendered, "a silent drop reads as if nothing was cut")
+      end
+
+      # Control: the budget must not fire on ordinary bursts. Under the limit,
+      # every merged comment is still rendered in full.
+      test "renders every merged comment when the burst fits the budget" do
+        @agent.update!(agent_conf: "context:\n  chat_history_size: 100000")
+        older = comment("first point")
+        newer = comment("second point")
+        anchor = comment("anchor")
+
+        blocks = MergedTriggerComments.for(context_with(anchor, [ older, newer ]), agent: @agent)
+
+        assert_equal 2, blocks.size
+        rendered = blocks.map(&:text).join("\n\n")
+        assert_includes rendered, "first point"
+        assert_includes rendered, "second point"
+        refute_match(/omitted/, rendered)
+      end
     end
   end
 end

--- a/engines/collavre/test/services/collavre/ai_agent/merged_trigger_comments_test.rb
+++ b/engines/collavre/test/services/collavre/ai_agent/merged_trigger_comments_test.rb
@@ -177,6 +177,66 @@ module Collavre
         assert_includes rendered, "second point"
         refute_match(/omitted/, rendered)
       end
+
+      # Dropping the oldest blocks rests on "the history window carries them
+      # instead" (MessageBuilder#merged_comment_ids). That fallback does not
+      # exist for a session-backed agent: SessionContextResolver
+      # #incremental_payload keeps only the :trigger message, so a block dropped
+      # here is a user comment with no remaining delivery path — the exact loss
+      # the spec built coalescing to prevent. Shrink the blocks instead.
+      test "a session-backed agent keeps every merged comment in the trigger" do
+        @agent.update!(agent_conf: "session:\n  enabled: true\ncontext:\n  chat_history_size: 200")
+        oldest = comment("O" * 150)
+        middle = comment("M" * 150)
+        newest = comment("N" * 150)
+        anchor = comment("anchor")
+
+        blocks = MergedTriggerComments.for(
+          context_with(anchor, [ oldest, middle, newest ]), agent: @agent
+        )
+
+        assert_equal [ oldest.id, middle.id, newest.id ], blocks.filter_map { |b| b.comment&.id },
+                     "no merged comment may be dropped when the trigger is the only channel"
+        assert_operator blocks.sum { |b| b.text.length }, :<=, 200,
+                        "shrinking still has to respect the budget"
+      end
+
+      # The budget loop breaks on the first block that does not fit, so a single
+      # oversized comment left `kept` empty and the method returned nothing but
+      # the omission marker — every merged comment gone, including the newest,
+      # which is the one the anchor is replying to.
+      test "keeps the newest merged comment even when it alone exceeds the budget" do
+        @agent.update!(agent_conf: "context:\n  chat_history_size: 100")
+        older = comment("O" * 80)
+        newest = comment("N" * 500)
+        anchor = comment("anchor")
+
+        blocks = MergedTriggerComments.for(context_with(anchor, [ older, newest ]), agent: @agent)
+
+        assert_includes blocks.filter_map { |b| b.comment&.id }, newest.id,
+                        "a marker-only result deletes the newest merged comment too"
+        assert_operator blocks.sum { |b| b.text.length }, :<=, 100,
+                        "the surviving block must be trimmed to the budget"
+      end
+
+      # The merged set is read by id alone. A comment moved to another creative
+      # while the task waited (CommentMoveService#perform_move reassigns
+      # creative_id) would still be rendered into this turn's trigger, handing
+      # the agent content — and image attachments — from a creative it may have
+      # no share on. refresh_deferred_context! already scopes its lookup to the
+      # payload's creative/topic; this one has to ask the same question.
+      test "ignores merged comments that no longer belong to the turn's creative" do
+        stayed = comment("still here")
+        moved = comment("moved away")
+        anchor = comment("anchor")
+        other = Creative.create!(description: "Elsewhere", user: @user)
+        moved.update!(creative: other, topic_id: nil)
+
+        blocks = MergedTriggerComments.for(context_with(anchor, [ stayed, moved ]), agent: @agent)
+
+        assert_equal [ stayed.id ], blocks.filter_map { |b| b.comment&.id },
+                     "a comment moved out of the creative is no longer part of this turn"
+      end
     end
   end
 end

--- a/engines/collavre/test/services/collavre/ai_agent/merged_trigger_comments_test.rb
+++ b/engines/collavre/test/services/collavre/ai_agent/merged_trigger_comments_test.rb
@@ -219,6 +219,25 @@ module Collavre
                         "the surviving block must be trimmed to the budget"
       end
 
+      # "Shrink instead of drop" is the whole point of the session-backed branch:
+      # the trigger is that agent's only channel, so a block it does not carry is
+      # a user comment with no delivery path. Collapsing to the newest block when
+      # the per-block share gets small breaks exactly that promise — and takes
+      # every other block's image attachments with it, which the text budget does
+      # not even measure.
+      test "a session-backed agent keeps every merged comment when the share is tiny" do
+        @agent.update!(agent_conf: "session:\n  enabled: true\ncontext:\n  chat_history_size: 60")
+        merged = 5.times.map { |i| comment("point #{i} " * 10) }
+        anchor = comment("anchor")
+
+        blocks = MergedTriggerComments.for(context_with(anchor, merged), agent: @agent)
+
+        assert_equal merged.map(&:id), blocks.filter_map { |b| b.comment&.id },
+                     "a tiny share is a reason to compact every block, not to drop four of them"
+        assert_operator blocks.sum { |b| b.text.length }, :<=, 60,
+                        "compacting still has to respect the budget"
+      end
+
       # The merged set is read by id alone. A comment moved to another creative
       # while the task waited (CommentMoveService#perform_move reassigns
       # creative_id) would still be rendered into this turn's trigger, handing

--- a/engines/collavre/test/services/collavre/ai_agent/merged_trigger_comments_test.rb
+++ b/engines/collavre/test/services/collavre/ai_agent/merged_trigger_comments_test.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  module AiAgent
+    class MergedTriggerCommentsTest < ActiveSupport::TestCase
+      setup do
+        @user = users(:one)
+        @creative = creatives(:tshirt)
+        @agent = users(:ai_bot)
+        @topic = Topic.create!(name: "Merged", creative: @creative, user: @user)
+      end
+
+      def comment(body, user: @user, created_at: nil)
+        c = Comment.create!(
+          creative: @creative, user: user, topic: @topic, content: body, skip_dispatch: true
+        )
+        c.update_columns(created_at: created_at) if created_at
+        c
+      end
+
+      def context_with(anchor, merged)
+        {
+          "creative" => { "id" => @creative.id },
+          "topic" => { "id" => @topic.id },
+          "comment" => { "id" => anchor.id, "content" => anchor.content },
+          Orchestration::TaskCoalescer::PAYLOAD_KEY => merged.map(&:id)
+        }
+      end
+
+      test "renders merged comments oldest first, labelled by speaker" do
+        older = comment("first", created_at: 3.minutes.ago)
+        newer = comment("second", created_at: 2.minutes.ago)
+        anchor = comment("third", created_at: 1.minute.ago)
+
+        blocks = MergedTriggerComments.for(context_with(anchor, [ newer, older ]), agent: @agent)
+
+        assert_equal [ "[#{@user.name}]: first", "[#{@user.name}]: second" ], blocks.map(&:text)
+      end
+
+      test "excludes the anchor comment from the merged blocks" do
+        anchor = comment("only")
+
+        blocks = MergedTriggerComments.for(context_with(anchor, [ anchor ]), agent: @agent)
+
+        assert_empty blocks
+      end
+
+      test "strips a self-mention of the agent from merged text" do
+        merged = comment("@#{@agent.name}: please look", created_at: 2.minutes.ago)
+        anchor = comment("and this too", created_at: 1.minute.ago)
+
+        blocks = MergedTriggerComments.for(context_with(anchor, [ merged ]), agent: @agent)
+
+        assert_equal "[#{@user.name}]: please look", blocks.first.text
+      end
+
+      test "skips private and approval-surface comments" do
+        private_comment = Comment.create!(
+          creative: @creative, user: @user, topic: @topic, content: "secret",
+          private: true, skip_dispatch: true
+        )
+        anchor = comment("anchor")
+
+        blocks = MergedTriggerComments.for(context_with(anchor, [ private_comment ]), agent: @agent)
+
+        assert_empty blocks
+      end
+
+      test "prepend_to leaves content untouched when nothing was merged" do
+        anchor = comment("anchor")
+        context = context_with(anchor, [])
+
+        assert_equal "anchor", MergedTriggerComments.prepend_to("anchor", context, agent: @agent)
+      end
+
+      test "prepend_to puts merged comments above the anchor content" do
+        merged = comment("earlier", created_at: 2.minutes.ago)
+        anchor = comment("latest", created_at: 1.minute.ago)
+
+        result = MergedTriggerComments.prepend_to(
+          "latest", context_with(anchor, [ merged ]), agent: @agent
+        )
+
+        assert_equal "[#{@user.name}]: earlier\n\nlatest", result
+      end
+
+      # ClaudeChannelAdapter is the agent's ONLY input on the Claude Channel
+      # path: no chat history is sent, so a merged comment that is not inlined
+      # here never reaches the agent at all.
+      test "claude channel dispatch carries the merged comments inline" do
+        agent = User.create!(
+          email: "cc-merged-#{SecureRandom.hex(4)}@agent.collavre.local",
+          password: SecureRandom.hex(32), name: "Claude Merged",
+          llm_vendor: "anthropic", llm_model: "claude-code",
+          created_by_id: @user.id, searchable: false
+        )
+        merged = comment("earlier point", created_at: 2.minutes.ago)
+        anchor = comment("later point", created_at: 1.minute.ago)
+
+        broadcasts = []
+        ActionCable.server.stub :broadcast, ->(channel, data) { broadcasts << data } do
+          ClaudeChannelAdapter.new(agent: agent, context: context_with(anchor, [ merged ])).deliver
+        end
+
+        content = broadcasts.first[:comment][:content]
+        assert_includes content, "earlier point"
+        assert_includes content, "later point"
+      end
+    end
+  end
+end

--- a/engines/collavre/test/services/collavre/ai_agent/merged_trigger_comments_test.rb
+++ b/engines/collavre/test/services/collavre/ai_agent/merged_trigger_comments_test.rb
@@ -144,7 +144,14 @@ module Collavre
       # exactly the input that makes that asymmetry bite: coalescing turns N
       # comments into one indivisible message, so an oversized burst does not
       # degrade — the whole turn fails.
-      test "drops the oldest merged blocks once they exceed the agent's size budget" do
+      # Dropping the oldest blocks rested on "the history window carries them
+      # instead". It does not: MessageBuilder#append_chat_history applies its own
+      # chat_history_limit *and* the same size budget over the whole preceding
+      # conversation, and it never carries attachments at all. So a dropped block
+      # is a user comment that may reach the agent through no channel — and its
+      # images through none, ever. Keep every block and shrink instead; the
+      # trigger is the only path with a guarantee.
+      test "keeps every merged comment in the trigger once over the size budget" do
         @agent.update!(agent_conf: "context:\n  chat_history_size: 200")
         oldest = comment("O" * 150)
         middle = comment("M" * 150)
@@ -155,10 +162,13 @@ module Collavre
           context_with(anchor, [ oldest, middle, newest ]), agent: @agent
         )
 
-        rendered = blocks.map(&:text).join("\n\n")
-        assert_includes rendered, "N" * 150, "the newest merged comment must survive"
-        refute_includes rendered, "O" * 150, "the oldest must be dropped once over budget"
-        assert_match(/omitted/, rendered, "a silent drop reads as if nothing was cut")
+        assert_equal [ oldest.id, middle.id, newest.id ], blocks.filter_map { |b| b.comment&.id },
+                     "no merged comment may be dropped onto a channel that does not guarantee it"
+        assert_operator blocks.sum { |b| b.text.length }, :<=, 200,
+                        "shrinking still has to respect the budget"
+        assert_match(/#{Regexp.escape(MergedTriggerComments::TRUNCATION_SUFFIX)}/,
+                     blocks.map(&:text).join("\n\n"),
+                     "a silent truncation reads to the agent as if nothing was cut")
       end
 
       # Control: the budget must not fire on ordinary bursts. Under the limit,

--- a/engines/collavre/test/services/collavre/ai_agent/message_builder_test.rb
+++ b/engines/collavre/test/services/collavre/ai_agent/message_builder_test.rb
@@ -404,6 +404,72 @@ module Collavre
           "an image posted in a coalesced comment must still reach the agent"
       end
 
+      # The history limit counts *delivered* history. Merged comments move into
+      # the trigger, so letting them occupy history slots hands the agent a burst
+      # with no conversation behind it — and, when they fill the limit outright,
+      # flags the turn as first_message.
+      test "coalesced comments do not crowd older messages out of chat history" do
+        older = @creative.comments.create!(
+          content: "older context worth keeping", user: @user, topic_id: @comment.topic_id
+        )
+        burst = 3.times.map do |i|
+          @creative.comments.create!(
+            content: "burst message #{i}", user: @user, topic_id: @comment.topic_id
+          )
+        end
+        anchor = burst.last
+
+        context = {
+          "comment" => { "id" => anchor.id, "content" => anchor.content },
+          "creative" => { "id" => @creative.id },
+          Orchestration::TaskCoalescer::PAYLOAD_KEY => burst.map(&:id)
+        }
+
+        result = @agent.stub(:chat_history_limit, 3) do
+          MessageBuilder.new(agent: @agent, context: context, original_comment: anchor).build
+        end
+        history = result[:messages]
+          .select { |m| m[:kind] == :chat_history }
+          .map { |m| m[:parts].first[:text] }
+          .join("\n")
+
+        assert_includes history, "older context worth keeping",
+          "eligible older messages must backfill the slots merged comments vacate"
+        assert_not result[:first_message],
+          "a burst that fills the limit must not make the turn look like a first message"
+        assert_not_includes history, "burst message",
+          "merged comments still belong in the trigger, not in history"
+      end
+
+      # An absorbed comment's creative links have to be resolved too: the merged
+      # text reaches the agent, so the subtree it points at must reach it as well.
+      test "creative links in coalesced comments are injected as referenced context" do
+        other_creative = Creative.create!(
+          description: "<p>Linked Project</p>", user: @user, progress: 0.0
+        )
+        merged = @creative.comments.create!(
+          content: "look at [Linked Project](/creatives/#{other_creative.id})",
+          user: @user, topic_id: @comment.topic_id
+        )
+        context = {
+          "comment" => { "id" => @comment.id, "content" => @comment.content },
+          "creative" => { "id" => @creative.id },
+          Orchestration::TaskCoalescer::PAYLOAD_KEY => [ merged.id ]
+        }
+
+        messages = MessageBuilder.new(
+          agent: @agent, context: context, original_comment: @comment
+        ).build[:messages]
+
+        referenced = messages.find do |m|
+          m[:kind] == :referenced_creative &&
+            m[:parts].first[:text].include?("id: #{other_creative.id}")
+        end
+        assert_not_nil referenced,
+          "a creative referenced only by an absorbed comment must still be injected"
+        assert_includes referenced[:parts].first[:text], "Linked Project"
+      end
+
       test "no merged ids leaves the trigger message unchanged" do
         context = {
           "comment" => { "id" => @comment.id, "content" => @comment.content },

--- a/engines/collavre/test/services/collavre/ai_agent/message_builder_test.rb
+++ b/engines/collavre/test/services/collavre/ai_agent/message_builder_test.rb
@@ -342,6 +342,87 @@ module Collavre
         assert_not_includes history, "secret-payload",
           "approval-action comment content must never enter chat history"
       end
+
+      # Comments folded into this turn by Orchestration::TaskCoalescer belong in
+      # the trigger, not in chat history: a session-backed agent receives only
+      # the :trigger message (SessionContextResolver#incremental_payload).
+      test "merged comments are folded into the trigger message" do
+        merged = @creative.comments.create!(
+          content: "earlier burst message", user: @user, topic_id: @comment.topic_id
+        )
+        context = {
+          "comment" => { "id" => @comment.id, "content" => @comment.content },
+          "creative" => { "id" => @creative.id },
+          Orchestration::TaskCoalescer::PAYLOAD_KEY => [ merged.id ]
+        }
+
+        builder = MessageBuilder.new(agent: @agent, context: context, original_comment: @comment)
+        messages = builder.build[:messages]
+
+        trigger = messages.find { |m| m[:kind] == :trigger }
+        assert_includes trigger[:parts].first[:text], "earlier burst message"
+        assert_includes trigger[:parts].first[:text], @comment.content
+      end
+
+      test "merged comments are not repeated in chat history" do
+        merged = @creative.comments.create!(
+          content: "earlier burst message", user: @user, topic_id: @comment.topic_id
+        )
+        context = {
+          "comment" => { "id" => @comment.id, "content" => @comment.content },
+          "creative" => { "id" => @creative.id },
+          Orchestration::TaskCoalescer::PAYLOAD_KEY => [ merged.id ]
+        }
+
+        builder = MessageBuilder.new(agent: @agent, context: context, original_comment: @comment)
+        history = builder.build[:messages]
+          .select { |m| m[:kind] == :chat_history }
+          .map { |m| m[:parts].first[:text] }
+          .join("\n")
+
+        assert_not_includes history, "earlier burst message",
+          "a comment already inlined in the trigger must not be sent twice"
+      end
+
+      test "merged comments carry their image attachments into the trigger" do
+        merged = @creative.comments.create!(
+          content: "with a picture", user: @user, topic_id: @comment.topic_id
+        )
+        merged.images.attach(
+          io: StringIO.new(one_pixel_png), filename: "pixel.png", content_type: "image/png"
+        )
+        context = {
+          "comment" => { "id" => @comment.id, "content" => @comment.content },
+          "creative" => { "id" => @creative.id },
+          Orchestration::TaskCoalescer::PAYLOAD_KEY => [ merged.id ]
+        }
+
+        builder = MessageBuilder.new(agent: @agent, context: context, original_comment: @comment)
+        trigger = builder.build[:messages].find { |m| m[:kind] == :trigger }
+
+        assert_equal 1, trigger[:parts].count { |p| p.key?(:image) },
+          "an image posted in a coalesced comment must still reach the agent"
+      end
+
+      test "no merged ids leaves the trigger message unchanged" do
+        context = {
+          "comment" => { "id" => @comment.id, "content" => @comment.content },
+          "creative" => { "id" => @creative.id }
+        }
+
+        builder = MessageBuilder.new(agent: @agent, context: context, original_comment: @comment)
+        trigger = builder.build[:messages].find { |m| m[:kind] == :trigger }
+
+        assert_equal @comment.content, trigger[:parts].first[:text]
+      end
+
+      private
+
+      def one_pixel_png
+        Base64.decode64(
+          "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+        )
+      end
     end
   end
 end

--- a/engines/collavre/test/services/collavre/ai_agent/message_builder_test.rb
+++ b/engines/collavre/test/services/collavre/ai_agent/message_builder_test.rb
@@ -384,6 +384,38 @@ module Collavre
           "a comment already inlined in the trigger must not be sent twice"
       end
 
+      # The exclusion above pairs with the trigger actually carrying the comment.
+      # An oversized burst drops its oldest blocks (MergedTriggerComments budgets
+      # by chat_history_size), and excluding a comment the trigger no longer
+      # renders would delete it from the turn entirely — history is separately
+      # budgeted and can still carry it.
+      test "a merged comment dropped from the trigger falls back to chat history" do
+        @agent.update!(agent_conf: "context:\n  chat_history_size: 200")
+        dropped = @creative.comments.create!(
+          content: "D" * 150, user: @user, topic_id: @comment.topic_id
+        )
+        kept = @creative.comments.create!(
+          content: "K" * 150, user: @user, topic_id: @comment.topic_id
+        )
+        context = {
+          "comment" => { "id" => @comment.id, "content" => @comment.content },
+          "creative" => { "id" => @creative.id },
+          Orchestration::TaskCoalescer::PAYLOAD_KEY => [ dropped.id, kept.id ]
+        }
+
+        messages = MessageBuilder.new(
+          agent: @agent, context: context, original_comment: @comment
+        ).build[:messages]
+        trigger = messages.find { |m| m[:kind] == :trigger }[:parts].first[:text]
+        history = messages.select { |m| m[:kind] == :chat_history }
+                          .map { |m| m[:parts].first[:text] }.join("\n")
+
+        assert_includes trigger, "K" * 150, "the newest merged comment stays in the trigger"
+        assert_not_includes trigger, "D" * 150
+        assert_includes history, "D" * 150,
+          "a comment cut from the trigger must not vanish from the turn"
+      end
+
       test "merged comments carry their image attachments into the trigger" do
         merged = @creative.comments.create!(
           content: "with a picture", user: @user, topic_id: @comment.topic_id

--- a/engines/collavre/test/services/collavre/ai_agent/message_builder_test.rb
+++ b/engines/collavre/test/services/collavre/ai_agent/message_builder_test.rb
@@ -385,22 +385,24 @@ module Collavre
       end
 
       # The exclusion above pairs with the trigger actually carrying the comment.
-      # An oversized burst drops its oldest blocks (MergedTriggerComments budgets
-      # by chat_history_size), and excluding a comment the trigger no longer
-      # renders would delete it from the turn entirely — history is separately
-      # budgeted and can still carry it.
-      test "a merged comment dropped from the trigger falls back to chat history" do
+      # It used to be the other way round for an oversized burst: the trigger
+      # dropped its oldest blocks and history was expected to carry them. It
+      # cannot be relied on to — history applies the same size budget across the
+      # whole conversation and never carries attachments — so the trigger keeps
+      # every merged comment and shrinks them, and the exclusion covers all of
+      # them with none left to double-send.
+      test "an oversized burst keeps every merged comment in the trigger, none in history" do
         @agent.update!(agent_conf: "context:\n  chat_history_size: 200")
-        dropped = @creative.comments.create!(
-          content: "D" * 150, user: @user, topic_id: @comment.topic_id
+        older = @creative.comments.create!(
+          content: "OLDER #{'D' * 150}", user: @user, topic_id: @comment.topic_id
         )
-        kept = @creative.comments.create!(
-          content: "K" * 150, user: @user, topic_id: @comment.topic_id
+        newer = @creative.comments.create!(
+          content: "NEWER #{'K' * 150}", user: @user, topic_id: @comment.topic_id
         )
         context = {
           "comment" => { "id" => @comment.id, "content" => @comment.content },
           "creative" => { "id" => @creative.id },
-          Orchestration::TaskCoalescer::PAYLOAD_KEY => [ dropped.id, kept.id ]
+          Orchestration::TaskCoalescer::PAYLOAD_KEY => [ older.id, newer.id ]
         }
 
         messages = MessageBuilder.new(
@@ -410,10 +412,11 @@ module Collavre
         history = messages.select { |m| m[:kind] == :chat_history }
                           .map { |m| m[:parts].first[:text] }.join("\n")
 
-        assert_includes trigger, "K" * 150, "the newest merged comment stays in the trigger"
-        assert_not_includes trigger, "D" * 150
-        assert_includes history, "D" * 150,
-          "a comment cut from the trigger must not vanish from the turn"
+        assert_includes trigger, "NEWER", "the newest merged comment stays in the trigger"
+        assert_includes trigger, "OLDER",
+          "a comment cut from the trigger reaches the agent through no channel at all"
+        assert_not_includes history, "OLDER",
+          "a comment inlined in the trigger must not be sent twice"
       end
 
       test "merged comments carry their image attachments into the trigger" do
@@ -500,6 +503,42 @@ module Collavre
         assert_not_nil referenced,
           "a creative referenced only by an absorbed comment must still be injected"
         assert_includes referenced[:parts].first[:text], "Linked Project"
+      end
+
+      # The whole-turn version of the trigger budget: dropping a merged block was
+      # justified by the history window carrying it instead, but history applies
+      # the *same* size budget across the preceding conversation and cuts from its
+      # newest end — which is exactly where a just-dropped burst comment sits. So
+      # a block dropped from the trigger can reach the agent through no channel at
+      # all. Asserted end to end over the built messages, because neither
+      # component is wrong on its own; the loss only exists between them.
+      test "a merged comment cut from the trigger is not lost from the turn as well" do
+        @agent.update!(agent_conf: "context:\n  chat_history_size: 200")
+        topic = @creative.topics.create!(name: "Budget burst", user: @user)
+        bodies = %w[OLDEST MIDDLE NEWEST].map { |tag| "#{tag} #{tag[0] * 150}" }
+        merged = bodies.map do |body|
+          @creative.comments.create!(content: body, user: @user, topic: topic, skip_dispatch: true)
+        end
+        anchor = @creative.comments.create!(
+          content: "anchor", user: @user, topic: topic, skip_dispatch: true
+        )
+
+        context = {
+          "creative" => { "id" => @creative.id },
+          "topic" => { "id" => topic.id },
+          "comment" => { "id" => anchor.id, "content" => anchor.content },
+          Orchestration::TaskCoalescer::PAYLOAD_KEY => merged.map(&:id)
+        }
+
+        messages = MessageBuilder.new(
+          agent: @agent, context: context, original_comment: anchor
+        ).build[:messages]
+        delivered = messages.flat_map { |m| Array(m[:parts]).filter_map { |p| p[:text] } }.join("\n")
+
+        %w[OLDEST MIDDLE NEWEST].each do |tag|
+          assert_includes delivered, tag,
+                          "#{tag} reached the agent through neither the trigger nor history"
+        end
       end
 
       test "no merged ids leaves the trigger message unchanged" do

--- a/engines/collavre/test/services/collavre/orchestration/agent_orchestrator_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/agent_orchestrator_test.rb
@@ -156,6 +156,10 @@ module Collavre
       # of them inserts, and the topic collects N dead ends for one blocker.
       test "the late-defer notice checks and inserts under the admission lock" do
         topic = Topic.create!(name: "Notice lock topic", creative: @creative, user: @user)
+        # A notice describes a waiter; the same lock also decides whether one is
+        # still waiting, so the queue has to be non-empty for the insert to run.
+        Task.create!(name: "Waiter", status: "queued", trigger_event_name: "e",
+                     agent: @ai_agent, topic_id: topic.id, creative: @creative)
         locked_topic_ids = []
         lock_relation = Struct.new(:sink) do
           def find_by(id:)
@@ -185,6 +189,8 @@ module Collavre
       test "a second late-defer for the same topic adds no second notice" do
         topic = Topic.create!(name: "Notice dedup topic", creative: @creative, user: @user)
         Task.create!(name: "Running", status: "running", trigger_event_name: "e",
+                     agent: @ai_agent, topic_id: topic.id, creative: @creative)
+        Task.create!(name: "Waiter", status: "queued", trigger_event_name: "e",
                      agent: @ai_agent, topic_id: topic.id, creative: @creative)
 
         2.times { AgentOrchestrator.post_topic_concurrency_notice(@creative.id, topic.id) }

--- a/engines/collavre/test/services/collavre/orchestration/agent_orchestrator_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/agent_orchestrator_test.rb
@@ -150,6 +150,50 @@ module Collavre
                         "waiting notice should name the running blocker agent"
       end
 
+      # "One notice per topic" only holds if the existence check and the insert
+      # are one step. The burst this path handles is exactly what breaks a
+      # read-then-write: every deferring worker reads "no notice yet" before any
+      # of them inserts, and the topic collects N dead ends for one blocker.
+      test "the late-defer notice checks and inserts under the admission lock" do
+        topic = Topic.create!(name: "Notice lock topic", creative: @creative, user: @user)
+        locked_topic_ids = []
+        lock_relation = Struct.new(:sink) do
+          def find_by(id:)
+            sink << id
+            nil
+          end
+        end.new(locked_topic_ids)
+
+        baseline_depth = Comment.connection.open_transactions
+        check_depth = nil
+
+        Topic.stub(:lock, lock_relation) do
+          AgentOrchestrator.stub(:topic_concurrency_notice_exists?, ->(*) {
+            check_depth ||= Comment.connection.open_transactions
+            false
+          }) do
+            AgentOrchestrator.post_topic_concurrency_notice(@creative.id, topic.id)
+          end
+        end
+
+        assert_equal [ topic.id ], locked_topic_ids.uniq,
+                     "the notice must serialize on the same row admission locks"
+        assert_operator check_depth, :>, baseline_depth,
+                        "the existence check must run inside the inserting transaction"
+      end
+
+      test "a second late-defer for the same topic adds no second notice" do
+        topic = Topic.create!(name: "Notice dedup topic", creative: @creative, user: @user)
+        Task.create!(name: "Running", status: "running", trigger_event_name: "e",
+                     agent: @ai_agent, topic_id: topic.id, creative: @creative)
+
+        2.times { AgentOrchestrator.post_topic_concurrency_notice(@creative.id, topic.id) }
+
+        notices = @creative.comments.where(topic_id: topic.id, topic_concurrency_defer: true)
+                           .select { |c| c.content.start_with?(Comment::WAITING_NOTICE_PREFIX) }
+        assert_equal 1, notices.size, "one waiting notice per topic, not one per deferral"
+      end
+
       # The waiting notice must expose a stop button for the *blocker* so a user
       # can cancel a hung in-progress task and unstick their deferred waiter.
       # The button targets the running blocker resolved at render time, NOT the

--- a/engines/collavre/test/services/collavre/orchestration/claim_to_execution_window_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/claim_to_execution_window_test.rb
@@ -91,6 +91,30 @@ module Collavre
                         "anchor has to survive as a merged comment"
       end
 
+      # The topic lock orders *task creation*, not comment visibility. A comment
+      # commits in its own transaction and its AiAgentJob creates the queued task
+      # afterwards, so there is a window where the comment is on screen with no
+      # task behind it yet. Re-anchoring onto it would have this turn answer a
+      # comment it never absorbed — and once that job does run, it parks a waiter
+      # against the now-claimed task and the same comment is answered twice.
+      test "does not re-anchor onto a comment whose waiter has not materialised" do
+        first = comment("@#{@agent.name}: first")
+        claimed = task_for(first, status: "pending")
+        folded = comment("@#{@agent.name}: and also this")
+        task_for(folded, status: "queued")
+        # Committed, dispatched, but its AiAgentJob has not created a task yet.
+        unclaimed = comment("@#{@agent.name}: still being dispatched")
+
+        AgentOrchestrator.coalesce_at_start!(claimed)
+
+        payload = claimed.reload.trigger_event_payload
+        assert_equal folded.id, payload.dig("comment", "id"),
+                     "the anchor may only move to a comment this turn actually absorbed"
+        refute_equal unclaimed.id, payload.dig("comment", "id")
+        refute_includes Array(payload[TaskCoalescer::PAYLOAD_KEY]), unclaimed.id,
+                        "a comment with a turn still coming must not be swallowed by this one"
+      end
+
       test "the sender moves with the anchor when the fold crosses users" do
         claimed = task_for(comment("@#{@agent.name}: first"), status: "pending")
         other = users(:two)

--- a/engines/collavre/test/services/collavre/orchestration/claim_to_execution_window_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/claim_to_execution_window_test.rb
@@ -1,0 +1,184 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  module Orchestration
+    # Promotion claims the topic slot (queued -> pending) and folds the waiters
+    # that exist at that instant, but the task then sits `pending` until its
+    # AiAgentJob actually starts. A comment arriving in that gap parks a waiter
+    # the enqueue-time coalescer cannot fold — it supersedes only `queued`
+    # siblings, and the promoted task has already left that status. Both turns
+    # were un-started together, which is the invariant coalescing is defined
+    # over, so the fold has to happen once more at the moment execution begins.
+    class ClaimToExecutionWindowTest < ActiveSupport::TestCase
+      setup do
+        @user = users(:one)
+        @creative = creatives(:tshirt)
+        @agent = users(:ai_bot)
+        @topic = Topic.create!(name: "Claim window", creative: @creative, user: @user)
+      end
+
+      def comment(body, user: @user, quoting: nil)
+        Comment.create!(
+          creative: @creative, user: user, topic: @topic, content: body,
+          quoted_comment: quoting, skip_dispatch: true
+        )
+      end
+
+      # The Review button quotes an agent's own comment; review_type stays nil.
+      def review_request(body = "make it shorter")
+        comment(body, quoting: comment("agent draft", user: @agent))
+      end
+
+      def task_for(trigger, status:, agent: @agent)
+        Task.create!(
+          name: "Response to comment_created", status: status,
+          trigger_event_name: "comment_created", agent: agent,
+          topic_id: @topic.id, creative_id: @creative.id,
+          trigger_event_payload: {
+            "creative" => { "id" => @creative.id },
+            "topic" => { "id" => @topic.id },
+            "comment" => {
+              "id" => trigger.id, "content" => trigger.content, "user_id" => trigger.user_id
+            },
+            "chat" => { "content" => trigger.content },
+            "sender" => sender_for(trigger.user_id)
+          }
+        )
+      end
+
+      # The real payload is a *built* context, so "sender" is always present —
+      # and reanchor_sender only rewrites a key that is there.
+      def sender_for(user_id)
+        SystemEvents::ContextBuilder.new("comment" => { "user_id" => user_id }).build["sender"]
+      end
+
+      def merged_ids(task)
+        Array(task.reload.trigger_event_payload[TaskCoalescer::PAYLOAD_KEY])
+      end
+
+      def notices
+        Comment.where(creative_id: @creative.id, topic_id: @topic.id, user_id: nil)
+               .where("content LIKE ?", "#{Comment::WAITING_NOTICE_PREFIX}%")
+      end
+
+      test "a waiter parked after promotion is folded into the claimed turn" do
+        claimed = task_for(comment("@#{@agent.name}: first"), status: "pending")
+        late = comment("@#{@agent.name}: and also this")
+        late_waiter = task_for(late, status: "queued")
+
+        AgentOrchestrator.coalesce_at_start!(claimed)
+
+        assert_equal "cancelled", late_waiter.reload.status,
+                     "a comment that arrived before execution started must not get its own turn"
+        assert_equal 0, Task.where(agent: @agent, topic_id: @topic.id, status: "queued").count
+      end
+
+      test "the folded comment becomes the anchor and the previous one is merged" do
+        first = comment("@#{@agent.name}: first")
+        claimed = task_for(first, status: "pending")
+        late = comment("@#{@agent.name}: and also this")
+        task_for(late, status: "queued")
+
+        AgentOrchestrator.coalesce_at_start!(claimed)
+
+        payload = claimed.reload.trigger_event_payload
+        assert_equal late.id, payload.dig("comment", "id"),
+                     "the reply anchors on the newest comment, as promotion does"
+        assert_includes Array(payload[TaskCoalescer::PAYLOAD_KEY]), first.id,
+                        "a session agent only ever sees the trigger — the replaced " \
+                        "anchor has to survive as a merged comment"
+      end
+
+      test "the sender moves with the anchor when the fold crosses users" do
+        claimed = task_for(comment("@#{@agent.name}: first"), status: "pending")
+        other = users(:two)
+        late = comment("@#{@agent.name}: mine now", user: other)
+        task_for(late, status: "queued")
+
+        AgentOrchestrator.coalesce_at_start!(claimed)
+
+        assert_equal sender_for(other.id), claimed.reload.trigger_event_payload["sender"],
+                     "the turn now answers #{other.name}'s comment and must say so"
+      end
+
+      # Control: the window closes at execution, it does not stay open forever.
+      # A comment that arrives once the agent is already talking is a genuinely
+      # separate turn, and folding it would silently drop it.
+      test "a waiter parked after the turn started keeps its own turn" do
+        running = task_for(comment("@#{@agent.name}: first"), status: "running")
+        late_waiter = task_for(comment("@#{@agent.name}: later"), status: "queued")
+
+        AgentOrchestrator.coalesce_at_start!(running)
+
+        assert_equal "queued", late_waiter.reload.status
+        assert_empty merged_ids(running)
+      end
+
+      # Control: the fold must not become a way to disable coalescing's own
+      # exclusions. A review is an action bound to one comment either way.
+      test "a review request parked after promotion keeps its own turn" do
+        claimed = task_for(comment("@#{@agent.name}: first"), status: "pending")
+        review_task = task_for(review_request, status: "queued")
+
+        AgentOrchestrator.coalesce_at_start!(claimed)
+
+        assert_equal "queued", review_task.reload.status
+        assert_empty merged_ids(claimed)
+      end
+
+      test "policy off leaves the late waiter its own turn" do
+        OrchestratorPolicy.create!(
+          policy_type: "scheduling", scope_type: nil,
+          config: { "coalesce_pending_tasks" => false }
+        )
+        claimed = task_for(comment("@#{@agent.name}: first"), status: "pending")
+        late_waiter = task_for(comment("@#{@agent.name}: later"), status: "queued")
+
+        AgentOrchestrator.coalesce_at_start!(claimed)
+
+        assert_equal "queued", late_waiter.reload.status
+      end
+
+      # The late waiter posted the topic's "⏳" notice on its way into the
+      # queue. Folding it away ends the wait the notice describes, and nothing
+      # else will ever take that notice down: removal only happens when a
+      # promotion drains a *queued* waiter, and this fold left none.
+      test "the waiting notice comes down when the fold drains the queue" do
+        claimed = task_for(comment("@#{@agent.name}: first"), status: "pending")
+        task_for(comment("@#{@agent.name}: later"), status: "queued")
+        AgentOrchestrator.post_topic_concurrency_notice(@creative.id, @topic.id)
+        assert_equal 1, notices.count, "fixture precondition: the late waiter posted a notice"
+
+        AgentOrchestrator.coalesce_at_start!(claimed)
+
+        assert_equal 0, notices.count
+      end
+
+      # Control: the cleanup is scoped to "nobody is waiting any more", not to
+      # "a fold happened". Another agent's waiter is still blocked on this topic
+      # and its notice is still true.
+      test "the waiting notice stays up while another agent is still waiting" do
+        other_agent = Collavre::User.create!(
+          name: "window-agent-2", email: "window2-#{SecureRandom.hex(4)}@agent.test",
+          password: "password123", llm_vendor: "openai", llm_model: "gpt-4",
+          system_prompt: "You are a second agent."
+        )
+        claimed = task_for(comment("@#{@agent.name}: first"), status: "pending")
+        task_for(comment("@#{@agent.name}: later"), status: "queued")
+        other_waiter = task_for(comment("@#{other_agent.name}: hello"), status: "queued",
+                                agent: other_agent)
+        AgentOrchestrator.post_topic_concurrency_notice(@creative.id, @topic.id)
+        assert_equal 1, notices.count
+
+        AgentOrchestrator.coalesce_at_start!(claimed)
+
+        assert_equal "queued", other_waiter.reload.status,
+                     "another agent's waiter is not this agent's sibling"
+        assert_equal 1, notices.count,
+                     "someone is still waiting on this topic — the notice is still true"
+      end
+    end
+  end
+end

--- a/engines/collavre/test/services/collavre/orchestration/delivered_comment_dedup_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/delivered_comment_dedup_test.rb
@@ -52,15 +52,52 @@ module Collavre
       # A turn parked for `anchor` before `acquired` existed, then re-anchored
       # onto it by the refresh — the shape the promotion door produces, and the
       # only shape where a second task for the same comment can still be queued.
+      #
+      # Built through the same two calls refresh_deferred_context! makes rather
+      # than by hand, so the fixture cannot assert a premise the production path
+      # does not actually produce.
       def turn_that_acquired(status, anchor, acquired, agent: @agent)
         turn = task_for(status, anchor, agent: agent)
-        turn.update_columns(created_at: 2.minutes.ago)
-        turn.update!(trigger_event_payload: payload_for(acquired, merged: [ anchor ]))
+        moved = TaskCoalescer.reanchor_payload(turn.trigger_event_payload, acquired)
+        turn.update!(trigger_event_payload: TaskCoalescer.absorb_into_payload(moved, [ anchor.id ]))
         turn
       end
 
       def merged_ids(task)
         Array(task.reload.trigger_event_payload[TaskCoalescer::PAYLOAD_KEY])
+      end
+
+      # Comments and tasks are stamped by whichever process writes them, so
+      # `comment.created_at > task.created_at` is not the causal order it looks
+      # like — two app hosts with tied or skewed clocks put an acquired anchor
+      # on the wrong side of it. Both directions of that error are reachable,
+      # and they fail differently: reading an acquired anchor as an original one
+      # answers a comment twice, and reading an original one as acquired leaves
+      # a promoted waiter with no candidate at all and cancels it.
+      test "an acquired anchor is still recognised when its comment does not outrank the turn's clock" do
+        b = comment("do X")
+        c = comment("actually do Y")
+        turn = turn_that_acquired("done", b, c)
+        c.update_columns(created_at: turn.created_at)
+        late = task_for("queued", c)
+
+        AgentOrchestrator.dequeue_next_for_topic(@topic.id, @creative.id)
+
+        assert_equal "cancelled", late.reload.status,
+                     "a tied clock must not turn an acquired anchor back into an unanswered comment"
+      end
+
+      test "a turn's own trigger is not read as acquired when its comment outranks the turn's clock" do
+        c = comment("do X")
+        own = task_for("done", c)
+        c.update_columns(created_at: own.created_at + 1.second)
+        late = task_for("queued", c)
+
+        AgentOrchestrator.dequeue_next_for_topic(@topic.id, @creative.id)
+
+        assert_not_equal "cancelled", late.reload.status,
+                         "a skewed clock must not silence a comment whose own turn answered it"
+        assert_equal c.id, late.reload.trigger_event_payload.dig("comment", "id")
       end
 
       # The reported path, through the door the absorbed_only narrowing leaves

--- a/engines/collavre/test/services/collavre/orchestration/delivered_comment_dedup_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/delivered_comment_dedup_test.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  module Orchestration
+    # Coalescing folds the *tasks* that exist when a burst is claimed, but the
+    # promotion door's refresh moves the anchor onto the newest comment in the
+    # topic — which need not be one of them. A comment is visible the instant its
+    # transaction commits, while the queued Task representing it only appears
+    # once its AiAgentJob runs. A turn refreshed inside that gap answers a
+    # comment whose own waiter is still on its way, and that waiter is promoted
+    # later and answers it a second time.
+    #
+    # The invariant here is delivery-side: a comment already handed to an agent
+    # by a turn that was not created to answer it is not handed over again.
+    # Asking at promotion rather than at dispatch is what keeps it loss-free — by
+    # then the covering turn's status says whether it delivered anything at all.
+    class DeliveredCommentDedupTest < ActiveSupport::TestCase
+      setup do
+        @user = users(:one)
+        @creative = creatives(:tshirt)
+        @agent = users(:ai_bot)
+        @topic = Topic.create!(name: "Dedup topic", creative: @creative, user: @user)
+      end
+
+      def comment(body)
+        Comment.create!(
+          creative: @creative, user: @user, topic: @topic, content: body, skip_dispatch: true
+        )
+      end
+
+      def payload_for(anchor, merged: [])
+        {
+          "creative" => { "id" => @creative.id },
+          "topic" => { "id" => @topic.id },
+          "sender" => { "id" => @user.id, "name" => @user.name },
+          "comment" => { "id" => anchor.id, "content" => anchor.content, "user_id" => @user.id },
+          "chat" => { "content" => anchor.content },
+          TaskCoalescer::PAYLOAD_KEY => merged.map(&:id)
+        }
+      end
+
+      def task_for(status, anchor, agent: @agent, merged: [])
+        Task.create!(
+          name: "Task #{status}", status: status, trigger_event_name: "comment_created",
+          agent: agent, topic_id: @topic.id, creative_id: @creative.id,
+          trigger_event_payload: payload_for(anchor, merged: merged)
+        )
+      end
+
+      # A turn parked for `anchor` before `acquired` existed, then re-anchored
+      # onto it by the refresh — the shape the promotion door produces, and the
+      # only shape where a second task for the same comment can still be queued.
+      def turn_that_acquired(status, anchor, acquired, agent: @agent)
+        turn = task_for(status, anchor, agent: agent)
+        turn.update_columns(created_at: 2.minutes.ago)
+        turn.update!(trigger_event_payload: payload_for(acquired, merged: [ anchor ]))
+        turn
+      end
+
+      def merged_ids(task)
+        Array(task.reload.trigger_event_payload[TaskCoalescer::PAYLOAD_KEY])
+      end
+
+      # The reported path, through the door the absorbed_only narrowing leaves
+      # open by design.
+      test "a waiter is cancelled rather than re-answering a comment a finished turn acquired" do
+        b = comment("do X")
+        c = comment("actually do Y")
+        turn_that_acquired("done", b, c)
+        late = task_for("queued", c)
+
+        AgentOrchestrator.dequeue_next_for_topic(@topic.id, @creative.id)
+
+        assert_equal "cancelled", late.reload.status,
+                     "a waiter whose whole burst was already delivered must not answer it again"
+      end
+
+      # The same question one level down: MessageBuilder renders merged blocks
+      # into the trigger exactly like the anchor, so the comment the refresh
+      # displaces can itself be one an earlier turn already answered.
+      test "comments a finished turn acquired are dropped from the merged list" do
+        b = comment("do X")
+        c = comment("actually do Y")
+        turn_that_acquired("done", b, c)
+        late = task_for("queued", c)
+        d = comment("and also Z")
+
+        AgentOrchestrator.dequeue_next_for_topic(@topic.id, @creative.id)
+
+        assert_equal d.id, late.reload.trigger_event_payload.dig("comment", "id"),
+                     "the waiter should move onto the one comment nobody has answered"
+        assert_not_includes merged_ids(late), c.id,
+                            "an already delivered comment must not be re-sent as a merged block"
+      end
+
+      # Control for the discriminator itself, and the reason it is not simply
+      # "any delivered task": the overwhelmingly common history is one comment
+      # answered by its own turn. That must silence nothing, or every waiter
+      # behind an answered comment would be cancelled.
+      test "a comment delivered by its own turn does not cancel a waiter anchored on it" do
+        c = comment("do X")
+        # Created after the comment, so the comment is this turn's own trigger.
+        task_for("done", c)
+        late = task_for("queued", c)
+
+        AgentOrchestrator.dequeue_next_for_topic(@topic.id, @creative.id)
+
+        assert_not_equal "cancelled", late.reload.status,
+                         "a comment answered by the turn created for it is not an acquired delivery"
+        assert_equal c.id, late.reload.trigger_event_payload.dig("comment", "id")
+      end
+
+      # Control against trading a duplicate answer for a lost one: a turn that
+      # died without delivering leaves its comments answerable. `cancelled` is
+      # reachable — refresh_deferred_context! and revalidate_assignment! both
+      # cancel a claimed waiter outright.
+      test "a comment stays answerable when the turn that acquired it died undelivered" do
+        b = comment("do X")
+        c = comment("actually do Y")
+        turn_that_acquired("cancelled", b, c)
+        late = task_for("queued", c)
+
+        AgentOrchestrator.dequeue_next_for_topic(@topic.id, @creative.id)
+
+        assert_not_equal "cancelled", late.reload.status,
+                         "a turn that died undelivered must not silence the comment it held"
+        assert_equal c.id, late.reload.trigger_event_payload.dig("comment", "id")
+      end
+
+      # Control against freezing the refresh: an unanswered newer comment is
+      # still what a promoted waiter moves onto. That is what the refresh is for.
+      test "a waiter still moves onto a newer comment nobody has delivered" do
+        b = comment("do X")
+        waiter = task_for("queued", b)
+        c = comment("actually do Y")
+
+        AgentOrchestrator.dequeue_next_for_topic(@topic.id, @creative.id)
+
+        assert_equal c.id, waiter.reload.trigger_event_payload.dig("comment", "id"),
+                     "the refresh must still carry a waiter forward onto unanswered comments"
+        assert_includes merged_ids(waiter), b.id,
+                        "and the anchor it left behind is still delivered as a merged block"
+      end
+
+      # Delivery is per agent. Without this the dedup would let one agent's
+      # answer silence another agent's trigger.
+      test "another agent's delivered turn does not silence this agent's waiter" do
+        other = Collavre::User.create!(
+          name: "dedup-other-agent",
+          email: "dedup-other-#{SecureRandom.hex(4)}@agent.test",
+          password: "password123",
+          llm_vendor: "openai", llm_model: "gpt-4", system_prompt: "You are another agent."
+        )
+        b = comment("do X")
+        c = comment("actually do Y")
+        turn_that_acquired("done", b, c, agent: other)
+        late = task_for("queued", c)
+
+        AgentOrchestrator.dequeue_next_for_topic(@topic.id, @creative.id)
+
+        assert_not_equal "cancelled", late.reload.status,
+                         "delivery is per agent: another agent's turn is not this agent's answer"
+      end
+    end
+  end
+end

--- a/engines/collavre/test/services/collavre/orchestration/merged_mention_revalidation_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/merged_mention_revalidation_test.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  module Orchestration
+    # A direct @mention outranks a topic's primary-agent assignment. Coalescing
+    # moves the mentioning comment out of the anchor and into "merged_comment_ids",
+    # so revalidation that reads only the anchor cancels a waiter that was
+    # explicitly addressed — and takes every comment the waiter had absorbed
+    # down with it.
+    class MergedMentionRevalidationTest < ActiveSupport::TestCase
+      setup do
+        @user = users(:one)
+        @creative = creatives(:tshirt)
+        @agent = users(:ai_bot)
+        @primary = Collavre::User.create!(
+          name: "pinned-agent-#{SecureRandom.hex(3)}",
+          email: "pinned-#{SecureRandom.hex(4)}@agent.test",
+          password: "password123",
+          llm_vendor: "openai", llm_model: "gpt-4"
+        )
+        @topic = Topic.create!(
+          name: "Assignment topic", creative: @creative, user: @user, primary_agent: @primary
+        )
+      end
+
+      def comment(body)
+        Comment.create!(
+          creative: @creative, user: @user, topic: @topic, content: body, skip_dispatch: true
+        )
+      end
+
+      def waiter_for(anchor, merged: [])
+        payload = {
+          "creative" => { "id" => @creative.id },
+          "topic" => { "id" => @topic.id },
+          "comment" => {
+            "id" => anchor.id, "content" => anchor.content, "user_id" => anchor.user_id
+          },
+          "chat" => { "content" => anchor.content }
+        }
+        payload[TaskCoalescer::PAYLOAD_KEY] = merged if merged.any?
+
+        Task.create!(
+          name: "Response to comment_created", status: "queued",
+          trigger_event_name: "comment_created", agent: @agent,
+          topic_id: @topic.id, creative_id: @creative.id, trigger_event_payload: payload
+        )
+      end
+
+      test "a waiter survives when an absorbed comment mentions its agent" do
+        mention = comment("@#{@agent.name}: please handle this one")
+        task = waiter_for(mention)
+        comment("an ambient message that mentions nobody")
+
+        AgentOrchestrator.dequeue_next_for_topic(@topic.id, @creative.id)
+
+        refute_equal "cancelled", task.reload.status,
+          "the absorbed direct mention outranks the primary-agent assignment"
+        assert_includes Array(task.trigger_event_payload[TaskCoalescer::PAYLOAD_KEY]), mention.id
+      end
+
+      test "a waiter with no mention anywhere is still cancelled" do
+        task = waiter_for(comment("ambient one"), merged: [ comment("ambient two").id ])
+        comment("ambient three")
+
+        AgentOrchestrator.dequeue_next_for_topic(@topic.id, @creative.id)
+
+        assert_equal "cancelled", task.reload.status,
+          "the assignment must still silence agents nobody addressed"
+      end
+    end
+  end
+end

--- a/engines/collavre/test/services/collavre/orchestration/merged_mention_revalidation_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/merged_mention_revalidation_test.rb
@@ -61,6 +61,24 @@ module Collavre
         assert_includes Array(task.trigger_event_payload[TaskCoalescer::PAYLOAD_KEY]), mention.id
       end
 
+      # The merged ids are a snapshot of the fold, not a standing claim on those
+      # rows. A mention moved out of the creative while the waiter sat in the
+      # queue is deliberately excluded from the delivered trigger
+      # (MergedTriggerComments#turn_scope), so honouring it here lets a
+      # non-primary agent answer an ambient anchor with no in-scope mention
+      # anywhere in the turn.
+      test "a merged mention moved out of the turn no longer outranks the assignment" do
+        mention = comment("@#{@agent.name}: please handle this one")
+        task = waiter_for(comment("ambient anchor"), merged: [ mention.id ])
+        elsewhere = Creative.create!(description: "Elsewhere", user: @user)
+        mention.update!(creative: elsewhere, topic_id: nil)
+
+        AgentOrchestrator.dequeue_next_for_topic(@topic.id, @creative.id)
+
+        assert_equal "cancelled", task.reload.status,
+          "a mention the agent will never be shown cannot license the turn"
+      end
+
       test "a waiter with no mention anywhere is still cancelled" do
         task = waiter_for(comment("ambient one"), merged: [ comment("ambient two").id ])
         comment("ambient three")

--- a/engines/collavre/test/services/collavre/orchestration/policy_resolver_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/policy_resolver_test.rb
@@ -178,6 +178,19 @@ module Collavre
 
         assert_equal "round_robin", resolver.arbitration_strategy
       end
+
+      test "coalescing of un-started tasks is on by default" do
+        assert PolicyResolver.new(@context).coalesce_pending_tasks?
+      end
+
+      test "coalescing can be turned off by policy" do
+        OrchestratorPolicy.create!(
+          policy_type: "scheduling",
+          config: { "coalesce_pending_tasks" => false }
+        )
+
+        assert_not PolicyResolver.new(@context).coalesce_pending_tasks?
+      end
     end
   end
 end

--- a/engines/collavre/test/services/collavre/orchestration/policy_resolver_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/policy_resolver_test.rb
@@ -180,7 +180,7 @@ module Collavre
       end
 
       test "coalescing of un-started tasks is on by default" do
-        assert PolicyResolver.new(@context).coalesce_pending_tasks?
+        assert PolicyResolver.new(@context).coalesce_pending_tasks_for?(@ai_agent)
       end
 
       test "coalescing can be turned off by policy" do
@@ -189,7 +189,22 @@ module Collavre
           config: { "coalesce_pending_tasks" => false }
         )
 
-        assert_not PolicyResolver.new(@context).coalesce_pending_tasks?
+        assert_not PolicyResolver.new(@context).coalesce_pending_tasks_for?(@ai_agent)
+      end
+
+      # Coalescing folds same-agent siblings, so User scope is the granularity
+      # of the switch. scheduling_config excludes agent policies by
+      # construction — reading it here was the same as ignoring the opt-out.
+      test "coalescing can be turned off for one agent by a User-scoped policy" do
+        OrchestratorPolicy.create!(
+          policy_type: "scheduling", scope_type: "User", scope_id: @ai_agent.id,
+          config: { "coalesce_pending_tasks" => false }
+        )
+        resolver = PolicyResolver.new(@context)
+
+        assert_not resolver.coalesce_pending_tasks_for?(@ai_agent)
+        assert resolver.coalesce_pending_tasks_for?(users(:channel_bot)),
+          "a User-scoped policy must not answer for a different agent"
       end
     end
   end

--- a/engines/collavre/test/services/collavre/orchestration/review_action_boundary_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/review_action_boundary_test.rb
@@ -83,6 +83,32 @@ module Collavre
         assert_equal "cancelled", first.reload.status
       end
 
+      test "promotion does not move an ordinary waiter onto a review request" do
+        ordinary = comment("summarise the thread")
+        task = waiter_for(ordinary)
+        review_request
+
+        AgentOrchestrator.dequeue_next_for_topic(@topic.id, @creative.id)
+
+        payload = task.reload.trigger_event_payload
+        assert_equal ordinary.id, payload.dig("comment", "id"),
+          "re-anchoring an ordinary turn onto a review makes it overwrite the quoted comment"
+        assert_empty merged_ids(task)
+        refute_equal "cancelled", task.status,
+          "excluding reviews as destinations must not strand a waiter with a live anchor"
+      end
+
+      test "an ordinary waiter still refreshes forward onto a newer ordinary comment" do
+        task = waiter_for(comment("stale trigger"))
+        review_request
+        newest = comment("the message actually worth answering")
+
+        AgentOrchestrator.dequeue_next_for_topic(@topic.id, @creative.id)
+
+        assert_equal newest.id, task.reload.trigger_event_payload.dig("comment", "id"),
+          "the exclusion must skip reviews, not freeze the refresh"
+      end
+
       test "promotion keeps a review request pointed at the comment it reviews" do
         review = review_request
         task = waiter_for(review)

--- a/engines/collavre/test/services/collavre/orchestration/review_action_boundary_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/review_action_boundary_test.rb
@@ -119,6 +119,36 @@ module Collavre
         assert_equal review.id, task.reload.trigger_event_payload.dig("comment", "id"),
           "refreshing the anchor forward turns the review into a plain reply"
         assert_empty merged_ids(task)
+        refute_equal "cancelled", task.status,
+          "revalidating the anchor must not cancel a review that is still deliverable"
+      end
+
+      # Not moving the anchor is not the same as not checking it. The review is
+      # delivered from trigger_event_payload — MessageBuilder renders the cached
+      # anchor content and never re-reads the row — and ReviewHandler#eligible?
+      # only asks whether the *quoted* comment is private, never the request. So
+      # a request withdrawn while it waited is caught on this door or nowhere.
+      test "a review request made private while queued is cancelled, not delivered from cache" do
+        review = review_request("rewrite this in half the words")
+        task = waiter_for(review)
+        review.update!(private: true)
+
+        AgentOrchestrator.dequeue_next_for_topic(@topic.id, @creative.id)
+
+        assert_equal "cancelled", task.reload.status,
+          "a withdrawn review request must not still drive an in-place revision"
+      end
+
+      test "a review request moved out of the turn's creative while queued is cancelled" do
+        review = review_request
+        task = waiter_for(review)
+        elsewhere = Creative.create!(description: "Another creative", user: @user)
+        review.update!(creative: elsewhere, topic_id: nil)
+
+        AgentOrchestrator.dequeue_next_for_topic(@topic.id, @creative.id)
+
+        assert_equal "cancelled", task.reload.status,
+          "a review that left this turn's scope is no more deliverable than a moved comment"
       end
     end
   end

--- a/engines/collavre/test/services/collavre/orchestration/review_action_boundary_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/review_action_boundary_test.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  module Orchestration
+    # A Review request is not "another comment in the burst": it is an action
+    # bound to one specific quoted comment. ResponseFinalizer and Matcher both
+    # derive that behaviour from the surviving anchor alone, so any step that
+    # moves the anchor off a review comment — coalescing it away, or refreshing
+    # it forward — silently downgrades an in-place revision to a normal reply.
+    class ReviewActionBoundaryTest < ActiveSupport::TestCase
+      setup do
+        @user = users(:one)
+        @creative = creatives(:tshirt)
+        @agent = users(:ai_bot)
+        @topic = Topic.create!(name: "Review boundary", creative: @creative, user: @user)
+      end
+
+      def comment(body, user: @user, quoting: nil)
+        Comment.create!(
+          creative: @creative, user: user, topic: @topic, content: body,
+          quoted_comment: quoting, skip_dispatch: true
+        )
+      end
+
+      # The Review button quotes an agent's own comment; review_type stays nil.
+      def review_request(body = "make it shorter")
+        comment(body, quoting: comment("agent draft", user: @agent))
+      end
+
+      def waiter_for(trigger, status: "queued")
+        Task.create!(
+          name: "Response to comment_created", status: status,
+          trigger_event_name: "comment_created", agent: @agent,
+          topic_id: @topic.id, creative_id: @creative.id,
+          trigger_event_payload: {
+            "creative" => { "id" => @creative.id },
+            "topic" => { "id" => @topic.id },
+            "comment" => {
+              "id" => trigger.id, "content" => trigger.content, "user_id" => trigger.user_id
+            },
+            "chat" => { "content" => trigger.content }
+          }
+        )
+      end
+
+      def merged_ids(task)
+        Array(task.reload.trigger_event_payload[TaskCoalescer::PAYLOAD_KEY])
+      end
+
+      test "an ordinary comment does not absorb a queued review request" do
+        review_task = waiter_for(review_request)
+        ordinary_task = waiter_for(comment("unrelated question"))
+
+        absorbed = TaskCoalescer.coalesce!(ordinary_task)
+
+        assert_empty absorbed, "the review request must keep its own turn"
+        assert_equal "queued", review_task.reload.status
+        assert_empty merged_ids(ordinary_task)
+      end
+
+      test "a review request absorbs no ordinary siblings" do
+        ordinary_task = waiter_for(comment("unrelated question"))
+        review_task = waiter_for(review_request)
+
+        absorbed = TaskCoalescer.coalesce!(review_task)
+
+        assert_empty absorbed,
+          "answering an unrelated comment must not be folded into the in-place revision"
+        assert_equal "queued", ordinary_task.reload.status
+        assert_empty merged_ids(review_task)
+      end
+
+      test "ordinary siblings still coalesce around a review request" do
+        first = waiter_for(comment("burst 1"))
+        waiter_for(review_request)
+        newest = waiter_for(comment("burst 2"))
+
+        absorbed = TaskCoalescer.coalesce!(newest)
+
+        assert_equal [ first.id ], absorbed
+        assert_equal "cancelled", first.reload.status
+      end
+
+      test "promotion keeps a review request pointed at the comment it reviews" do
+        review = review_request
+        task = waiter_for(review)
+        comment("a later, unrelated message")
+
+        AgentOrchestrator.dequeue_next_for_topic(@topic.id, @creative.id)
+
+        assert_equal review.id, task.reload.trigger_event_payload.dig("comment", "id"),
+          "refreshing the anchor forward turns the review into a plain reply"
+        assert_empty merged_ids(task)
+      end
+    end
+  end
+end

--- a/engines/collavre/test/services/collavre/orchestration/stuck_detector_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/stuck_detector_test.rb
@@ -370,10 +370,11 @@ module Collavre
 
       # --- Orphaned queued waiter detection & self-heal ---
 
-      def create_queued_task(comment_id:, creative_id: @creative.id, topic_id: @topic.id, age: 30.minutes)
+      def create_queued_task(comment_id:, creative_id: @creative.id, topic_id: @topic.id,
+                            age: 30.minutes, agent: @ai_agent)
         task = Collavre::Task.create!(
           name: "Queued waiter",
-          agent: @ai_agent,
+          agent: agent,
           status: "queued",
           trigger_event_name: "comment_created",
           trigger_event_payload: {
@@ -532,8 +533,12 @@ module Collavre
           user: @human_user, skip_dispatch: true
         )
 
+        # Two DIFFERENT agents: two waiters for the same agent in the same topic
+        # are one conversation turn and Orchestration::TaskCoalescer folds them
+        # together on promotion. Distinct agents are what topic_max=2 actually
+        # buys, and they are what must both survive the notice cleanup.
         w1 = create_queued_task(comment_id: 2030)
-        w2 = create_queued_task(comment_id: 2031)
+        w2 = create_queued_task(comment_id: 2031, agent: second_agent)
         2.times do
           @creative.comments.create!(
             content: "⏳ waiting on the topic", topic_id: @topic.id,
@@ -551,6 +556,47 @@ module Collavre
       ensure
         sched&.destroy
         policy&.destroy
+      end
+
+      test "self-heal folds same-agent orphans into the promoted turn" do
+        # Same agent + same topic = one conversation turn. Promoting both would
+        # answer the same latest comment twice (refresh_deferred_context! points
+        # every waiter at it), so the straggler is absorbed instead.
+        policy = create_policy_with_stuck_detection(enabled: true, queued_orphan_threshold: 5)
+        sched = create_scheduling_policy(topic_max: 2)
+
+        @creative.comments.create!(
+          content: "please respond", topic_id: @topic.id,
+          user: @human_user, skip_dispatch: true
+        )
+
+        w1 = create_queued_task(comment_id: 2040)
+        w2 = create_queued_task(comment_id: 2041)
+
+        Collavre::AiAgentJob.stub(:perform_later, ->(*) { nil }) do
+          StuckDetector.new.detect_and_escalate
+        end
+
+        assert_equal "pending", w1.reload.status
+        assert_equal "cancelled", w2.reload.status,
+                     "a same-agent straggler must be absorbed, not answered separately"
+        assert_includes w1.trigger_event_payload[TaskCoalescer::PAYLOAD_KEY], 2041,
+                        "the absorbed waiter's comment must still reach the agent"
+      ensure
+        sched&.destroy
+        policy&.destroy
+      end
+
+      # A second, independent agent — the shape topic_max > 1 actually serves.
+      def second_agent
+        @second_agent ||= Collavre::User.create!(
+          name: "dev-agent-2",
+          email: "dev2-#{SecureRandom.hex(4)}@agent.test",
+          password: "password123",
+          llm_vendor: "openai",
+          llm_model: "gpt-4",
+          system_prompt: "You are a second developer agent."
+        )
       end
 
       def create_scheduling_policy(topic_max:)

--- a/engines/collavre/test/services/collavre/orchestration/task_coalescer_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/task_coalescer_test.rb
@@ -1,0 +1,193 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  module Orchestration
+    class TaskCoalescerTest < ActiveSupport::TestCase
+      setup do
+        @user = users(:one)
+        @creative = creatives(:tshirt)
+        @agent = users(:ai_bot)
+        @other_agent = Collavre::User.create!(
+          name: "other-agent",
+          email: "other-#{SecureRandom.hex(4)}@agent.test",
+          password: "password123",
+          llm_vendor: "openai",
+          llm_model: "gpt-4"
+        )
+        @topic = Collavre::Topic.create!(creative: @creative, name: "Coalesce topic", user: @user)
+      end
+
+      def create_waiter(comment_id:, agent: @agent, topic: @topic, creative: @creative,
+                        status: "queued", event: "comment_created", merged: nil)
+        payload = {
+          "creative" => { "id" => creative&.id },
+          "topic" => { "id" => topic&.id },
+          "comment" => { "id" => comment_id, "content" => "msg #{comment_id}" }
+        }
+        payload[TaskCoalescer::PAYLOAD_KEY] = merged if merged
+
+        Task.create!(
+          name: "Response to #{event}",
+          status: status,
+          trigger_event_name: event,
+          trigger_event_payload: payload,
+          agent: agent,
+          topic_id: topic&.id,
+          creative_id: creative&.id
+        )
+      end
+
+      test "absorbs older queued siblings into the newest waiter" do
+        first = create_waiter(comment_id: 11)
+        second = create_waiter(comment_id: 12)
+        third = create_waiter(comment_id: 13)
+
+        absorbed = TaskCoalescer.coalesce!(third)
+
+        assert_equal [ first.id, second.id ].sort, absorbed.sort
+        assert_equal "cancelled", first.reload.status
+        assert_equal "cancelled", second.reload.status
+        assert_equal "queued", third.reload.status
+        assert_equal [ 11, 12 ], third.trigger_event_payload[TaskCoalescer::PAYLOAD_KEY]
+      end
+
+      test "keeps the newest comment as the trigger anchor" do
+        create_waiter(comment_id: 11)
+        newest = create_waiter(comment_id: 12)
+
+        TaskCoalescer.coalesce!(newest)
+
+        assert_equal 12, newest.reload.trigger_event_payload.dig("comment", "id")
+      end
+
+      test "merges ids a superseded task had already absorbed" do
+        create_waiter(comment_id: 12, merged: [ 10, 11 ])
+        newest = create_waiter(comment_id: 13)
+
+        TaskCoalescer.coalesce!(newest)
+
+        assert_equal [ 10, 11, 12 ], newest.reload.trigger_event_payload[TaskCoalescer::PAYLOAD_KEY]
+      end
+
+      test "never lists the surviving anchor among the merged ids" do
+        create_waiter(comment_id: 13)
+        newest = create_waiter(comment_id: 13)
+
+        TaskCoalescer.coalesce!(newest)
+
+        assert_equal [], newest.reload.trigger_event_payload[TaskCoalescer::PAYLOAD_KEY]
+      end
+
+      test "leaves tasks of other agents alone" do
+        other = create_waiter(comment_id: 11, agent: @other_agent)
+        mine = create_waiter(comment_id: 12)
+
+        assert_empty TaskCoalescer.coalesce!(mine)
+        assert_equal "queued", other.reload.status
+      end
+
+      test "leaves tasks of other topics alone" do
+        other_topic = Collavre::Topic.create!(creative: @creative, name: "Elsewhere", user: @user)
+        other = create_waiter(comment_id: 11, topic: other_topic)
+        mine = create_waiter(comment_id: 12)
+
+        assert_empty TaskCoalescer.coalesce!(mine)
+        assert_equal "queued", other.reload.status
+      end
+
+      test "leaves tasks of other creatives alone" do
+        other_creative = Creative.create!(description: "<p>Other</p>", user: @user, progress: 0.0)
+        # Same topic on purpose: the creative dimension has to be what excludes it.
+        other = create_waiter(comment_id: 11, creative: other_creative)
+        mine = create_waiter(comment_id: 12)
+
+        assert_empty TaskCoalescer.coalesce!(mine)
+        assert_equal "queued", other.reload.status
+      end
+
+      test "leaves tasks triggered by a different event alone" do
+        other = create_waiter(comment_id: 11, event: "creative_updated")
+        mine = create_waiter(comment_id: 12)
+
+        assert_empty TaskCoalescer.coalesce!(mine)
+        assert_equal "queued", other.reload.status
+      end
+
+      # A pending task may already be riding an enqueued AiAgentJob. Cancelling
+      # it makes that job return early without draining the topic queue, which
+      # stalls the topic permanently.
+      test "does not supersede pending or running tasks" do
+        pending_task = create_waiter(comment_id: 11, status: "pending")
+        running_task = create_waiter(comment_id: 12, status: "running")
+        newest = create_waiter(comment_id: 13)
+
+        assert_empty TaskCoalescer.coalesce!(newest)
+        assert_equal "pending", pending_task.reload.status
+        assert_equal "running", running_task.reload.status
+      end
+
+      # Two concurrent dispatches must not cancel each other: with :older each
+      # run only supersedes strictly lower ids, so the newest always survives.
+      test "older scope leaves a survivor when both siblings coalesce" do
+        first = create_waiter(comment_id: 11)
+        second = create_waiter(comment_id: 12)
+
+        TaskCoalescer.coalesce!(second)
+        TaskCoalescer.coalesce!(first)
+
+        assert_equal "cancelled", first.reload.status
+        assert_equal "queued", second.reload.status
+      end
+
+      # dequeue_next_for_topic promotes the OLDEST waiter, so the siblings left
+      # behind it are newer and the :older id guard would absorb nothing.
+      test "all scope absorbs newer siblings for a promoted task" do
+        promoted = create_waiter(comment_id: 11, status: "pending")
+        newer = create_waiter(comment_id: 12)
+
+        absorbed = TaskCoalescer.coalesce!(promoted, scope: :all)
+
+        assert_equal [ newer.id ], absorbed
+        assert_equal "cancelled", newer.reload.status
+        assert_equal [ 12 ], promoted.reload.trigger_event_payload[TaskCoalescer::PAYLOAD_KEY]
+      end
+
+      test "records a superseded task action for each absorbed task" do
+        first = create_waiter(comment_id: 11)
+        newest = create_waiter(comment_id: 12)
+
+        TaskCoalescer.coalesce!(newest)
+
+        action = first.reload.task_actions.find_by(action_type: "superseded")
+        assert_not_nil action
+        assert_equal newest.id, action.payload["superseded_by_task_id"]
+      end
+
+      test "returns empty and leaves the payload untouched when there is nothing to absorb" do
+        only = create_waiter(comment_id: 11)
+
+        assert_empty TaskCoalescer.coalesce!(only)
+        assert_nil only.reload.trigger_event_payload[TaskCoalescer::PAYLOAD_KEY]
+      end
+
+      test "absorb_into_payload dedupes, sorts and excludes the anchor" do
+        payload = {
+          "comment" => { "id" => 5 },
+          TaskCoalescer::PAYLOAD_KEY => [ 3, 1 ]
+        }
+
+        result = TaskCoalescer.absorb_into_payload(payload, [ 5, 3, 2 ])
+
+        assert_equal [ 1, 2, 3 ], result[TaskCoalescer::PAYLOAD_KEY]
+      end
+
+      test "absorb_into_payload keeps ids when the payload has no anchor" do
+        result = TaskCoalescer.absorb_into_payload({}, [ 2, 1 ])
+
+        assert_equal [ 1, 2 ], result[TaskCoalescer::PAYLOAD_KEY]
+      end
+    end
+  end
+end

--- a/engines/collavre/test/services/collavre/orchestration/task_coalescer_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/task_coalescer_test.rb
@@ -154,6 +154,34 @@ module Collavre
         assert_equal [ 12 ], promoted.reload.trigger_event_payload[TaskCoalescer::PAYLOAD_KEY]
       end
 
+      # The survivor is read once by the caller and then trusted. Deleting its
+      # anchor cancels it through Comment#cancel_pending_tasks, which holds no
+      # lock this method waits on — so a fold running against a stale object
+      # cancels every still-valid sibling and merges the whole burst onto a task
+      # AiAgentJob abandons on sight. Nothing else is left to answer them.
+      test "does not supersede siblings when the survivor is no longer un-started" do
+        first = create_waiter(comment_id: 11)
+        second = create_waiter(comment_id: 12)
+        keep = create_waiter(comment_id: 13)
+        Task.where(id: keep.id).update_all(status: "cancelled")
+
+        assert_empty TaskCoalescer.coalesce!(keep)
+        assert_equal "queued", first.reload.status
+        assert_equal "queued", second.reload.status,
+                     "a dead survivor must not take the burst down with it"
+      end
+
+      # Control: revalidating the survivor must not stop ordinary folds. The
+      # promotion path hands over a `pending` task, which is un-started and
+      # therefore still a valid survivor.
+      test "still folds for a pending survivor" do
+        newer = create_waiter(comment_id: 12)
+        promoted = create_waiter(comment_id: 11, status: "pending")
+
+        assert_equal [ newer.id ], TaskCoalescer.coalesce!(promoted, scope: :all)
+        assert_equal "cancelled", newer.reload.status
+      end
+
       test "records a superseded task action for each absorbed task" do
         first = create_waiter(comment_id: 11)
         newest = create_waiter(comment_id: 12)

--- a/engines/collavre/test/services/collavre/orchestration/task_coalescing_integration_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/task_coalescing_integration_test.rb
@@ -177,6 +177,30 @@ module Collavre
         assert_equal [ first.id ], payload[TaskCoalescer::PAYLOAD_KEY]
       end
 
+      # Re-anchoring picks the newest absorbed comment by id alone. A comment
+      # moved to another creative while the task waited is no longer part of this
+      # turn, but it was still eligible — so the waiter would adopt an anchor
+      # outside its own creative and the reply would be written there, into a
+      # creative the agent may have no share on.
+      test "re-anchoring skips absorbed comments moved out of the creative" do
+        block_topic!
+        first = dispatch_comment("@#{@agent.name}: first")
+        second = dispatch_comment("@#{@agent.name}: second")
+        third = dispatch_comment("@#{@agent.name}: third")
+
+        waiter = Task.where(agent: @agent, topic_id: @topic.id, status: "queued").sole
+        elsewhere = Creative.create!(description: "Elsewhere", user: @user)
+        second.update!(creative: elsewhere, topic_id: nil)
+
+        third.destroy!
+
+        payload = waiter.reload.trigger_event_payload
+        assert_equal first.id, payload.dig("comment", "id"),
+                     "the moved comment is out of scope; fall back to one still in the creative"
+        refute_includes Array(payload[TaskCoalescer::PAYLOAD_KEY]), second.id,
+                        "a comment in another creative must not stay merged into this turn"
+      end
+
       test "deleting the anchor still cancels a waiter with nothing absorbed" do
         block_topic!
         only = dispatch_comment("@#{@agent.name}: only")

--- a/engines/collavre/test/services/collavre/orchestration/task_coalescing_integration_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/task_coalescing_integration_test.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  module Orchestration
+    # A burst of comments (a PR comment sync, a webhook batch) must produce one
+    # agent turn per burst, not one per comment — and must not lose the content
+    # of the comments it folds together.
+    class TaskCoalescingIntegrationTest < ActiveSupport::TestCase
+      setup do
+        @creative = creatives(:tshirt)
+        @user = users(:one)
+        @agent = users(:ai_bot)
+        @agent.update!(searchable: true, routing_expression: "true")
+
+        share = CreativeShare.find_or_create_by!(creative: @creative, user: @agent)
+        share.update!(permission: "feedback")
+        CreativeSharesCache.find_or_create_by!(
+          creative_id: @creative.id, user_id: @agent.id, permission: :feedback
+        )
+
+        @topic = Topic.create!(name: "Burst topic", creative: @creative, user: @user)
+        ResourceTracker.for(@agent).reset!
+      end
+
+      teardown do
+        ResourceTracker.for(@agent).reset!
+      end
+
+      # Occupy the topic's only concurrency slot so every dispatch defers.
+      def block_topic!
+        Task.create!(
+          name: "Holder", status: "running", trigger_event_name: "comment_created",
+          agent: @agent, topic_id: @topic.id, creative_id: @creative.id
+        )
+      end
+
+      def dispatch_comment(body)
+        comment = Comment.create!(
+          creative: @creative, user: @user, topic: @topic, content: body, skip_dispatch: true
+        )
+        AgentOrchestrator.dispatch("comment_created", {
+          "creative" => { "id" => @creative.id },
+          "topic" => { "id" => @topic.id },
+          "sender" => { "id" => @user.id, "name" => @user.name },
+          "chat" => { "content" => body },
+          "comment" => { "id" => comment.id, "content" => body, "user_id" => @user.id }
+        })
+        comment
+      end
+
+      def queued_waiter_for(comment)
+        Task.create!(
+          name: "Waiter", status: "queued", trigger_event_name: "comment_created",
+          agent: @agent, topic_id: @topic.id, creative_id: @creative.id,
+          trigger_event_payload: {
+            "creative" => { "id" => @creative.id },
+            "topic" => { "id" => @topic.id },
+            "comment" => { "id" => comment.id, "content" => comment.content },
+            "chat" => { "content" => comment.content }
+          }
+        )
+      end
+
+      test "a burst of deferred comments leaves exactly one queued waiter" do
+        block_topic!
+
+        first = dispatch_comment("@#{@agent.name}: first")
+        second = dispatch_comment("@#{@agent.name}: second")
+        third = dispatch_comment("@#{@agent.name}: third")
+
+        waiters = Task.where(agent: @agent, topic_id: @topic.id, status: "queued")
+        assert_equal 1, waiters.count, "burst should collapse into a single waiter"
+
+        waiter = waiters.first
+        assert_equal third.id, waiter.trigger_event_payload.dig("comment", "id"),
+                     "the newest comment stays the reply anchor"
+        assert_equal [ first.id, second.id ].sort,
+                     waiter.trigger_event_payload[TaskCoalescer::PAYLOAD_KEY],
+                     "superseded comments are merged, not dropped"
+      end
+
+      test "a burst posts exactly one waiting notice" do
+        block_topic!
+
+        3.times { |i| dispatch_comment("@#{@agent.name}: msg #{i}") }
+
+        notices = Comment.where(creative_id: @creative.id, topic_id: @topic.id, user_id: nil)
+                         .where("content LIKE ?", "#{Comment::WAITING_NOTICE_PREFIX}%")
+        assert_equal 1, notices.count,
+                     "N notices would be N dead ends pointing at one blocker"
+      end
+
+      test "coalescing can be disabled by policy" do
+        OrchestratorPolicy.create!(
+          policy_type: "scheduling", scope_type: nil,
+          config: { "coalesce_pending_tasks" => false }
+        )
+        block_topic!
+
+        3.times { |i| dispatch_comment("@#{@agent.name}: msg #{i}") }
+
+        assert_equal 3, Task.where(agent: @agent, topic_id: @topic.id, status: "queued").count,
+                     "policy off restores one waiter per comment"
+      end
+
+      # dequeue promotes the OLDEST waiter, so anything that raced past
+      # enqueue-time coalescing sits BEHIND it. Without the :all-scope pass on
+      # promotion those stragglers each get promoted in turn and — because
+      # refresh_deferred_context! points every one of them at the same latest
+      # comment — answer it again.
+      test "promotion absorbs waiters queued behind it instead of replaying them" do
+        first = dispatch_comment("@#{@agent.name}: first")
+        second = dispatch_comment("@#{@agent.name}: second")
+
+        older = queued_waiter_for(first)
+        newer = queued_waiter_for(second)
+        assert_operator older.id, :<, newer.id
+
+        AgentOrchestrator.dequeue_next_for_topic(@topic.id, @creative.id)
+
+        assert_equal "cancelled", newer.reload.status
+        assert_equal 0, Task.where(agent: @agent, topic_id: @topic.id, status: "queued").count,
+                     "no waiter may be left behind to replay the same comment"
+        assert_includes older.reload.trigger_event_payload[TaskCoalescer::PAYLOAD_KEY], first.id,
+                        "the absorbed waiter's comment must reach the surviving turn"
+      end
+
+      test "refresh keeps the previous anchor when it moves to a newer comment" do
+        stale = dispatch_comment("@#{@agent.name}: stale")
+        task = Task.create!(
+          name: "Waiter", status: "queued", trigger_event_name: "comment_created",
+          agent: @agent, topic_id: @topic.id, creative_id: @creative.id,
+          trigger_event_payload: {
+            "creative" => { "id" => @creative.id },
+            "topic" => { "id" => @topic.id },
+            "comment" => { "id" => stale.id, "content" => "stale" },
+            "chat" => { "content" => "stale" }
+          }
+        )
+        newer = Comment.create!(
+          creative: @creative, user: @user, topic: @topic,
+          content: "@#{@agent.name}: newer", skip_dispatch: true
+        )
+
+        AgentOrchestrator.dequeue_next_for_topic(@topic.id, @creative.id)
+
+        payload = task.reload.trigger_event_payload
+        assert_equal newer.id, payload.dig("comment", "id")
+        assert_includes payload[TaskCoalescer::PAYLOAD_KEY], stale.id,
+                        "a replaced anchor must survive as a merged comment — a " \
+                        "session agent only ever sees the trigger"
+      end
+    end
+  end
+end

--- a/engines/collavre/test/services/collavre/orchestration/task_coalescing_integration_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/task_coalescing_integration_test.rb
@@ -152,6 +152,64 @@ module Collavre
                         "a replaced anchor must survive as a merged comment — a " \
                         "session agent only ever sees the trigger"
       end
+
+      # Coalescing makes one task carry several comments, so cancelling it when
+      # its anchor is deleted would discard the absorbed ones as well — and they
+      # have no task of their own left to fall back to.
+      test "deleting a coalesced waiter's anchor re-anchors instead of dropping the turn" do
+        block_topic!
+        first = dispatch_comment("@#{@agent.name}: first")
+        second = dispatch_comment("@#{@agent.name}: second")
+        third = dispatch_comment("@#{@agent.name}: third")
+
+        waiter = Task.where(agent: @agent, topic_id: @topic.id, status: "queued").sole
+        assert_equal third.id, waiter.trigger_event_payload.dig("comment", "id")
+
+        third.destroy!
+
+        waiter.reload
+        assert_equal "queued", waiter.status,
+                     "the turn still has the first two comments to answer"
+        payload = waiter.trigger_event_payload
+        assert_equal second.id, payload.dig("comment", "id"),
+                     "the newest surviving absorbed comment becomes the anchor"
+        assert_equal second.content, payload.dig("chat", "content")
+        assert_equal [ first.id ], payload[TaskCoalescer::PAYLOAD_KEY]
+      end
+
+      test "deleting the anchor still cancels a waiter with nothing absorbed" do
+        block_topic!
+        only = dispatch_comment("@#{@agent.name}: only")
+        waiter = Task.where(agent: @agent, topic_id: @topic.id, status: "queued").sole
+
+        only.destroy!
+
+        assert_equal "cancelled", waiter.reload.status
+      end
+
+      # A running task has already been handed its payload: deleting the prompt
+      # must still stop the turn rather than silently re-target it.
+      test "deleting the anchor of a running coalesced task still cancels it" do
+        first = dispatch_comment("@#{@agent.name}: first")
+        second = Comment.create!(
+          creative: @creative, user: @user, topic: @topic,
+          content: "@#{@agent.name}: second", skip_dispatch: true
+        )
+        task = Task.create!(
+          name: "In flight", status: "running", trigger_event_name: "comment_created",
+          agent: @agent, topic_id: @topic.id, creative_id: @creative.id,
+          trigger_event_payload: {
+            "creative" => { "id" => @creative.id },
+            "topic" => { "id" => @topic.id },
+            "comment" => { "id" => second.id, "content" => second.content },
+            TaskCoalescer::PAYLOAD_KEY => [ first.id ]
+          }
+        )
+
+        second.destroy!
+
+        assert_equal "cancelled", task.reload.status
+      end
     end
   end
 end

--- a/engines/collavre/test/services/collavre/orchestration/task_coalescing_integration_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/task_coalescing_integration_test.rb
@@ -227,6 +227,84 @@ module Collavre
         assert_equal [ first.id ], payload[TaskCoalescer::PAYLOAD_KEY]
       end
 
+      # cancel_pending_tasks hands reanchor_coalesced_task the task object its own
+      # scan loaded, and the callback derives the replacement payload from that
+      # snapshot without ever locking the row. TaskCoalescer folds a sibling into
+      # the same task under a lock this path does not take, so the fold can commit
+      # inside that window and the re-anchor writes the pre-fold payload back over
+      # it. The absorbed sibling is cancelled by then, so its comment has no task
+      # left to answer it — here the whole turn is cancelled instead, because the
+      # snapshot's merged list is empty.
+      test "re-anchoring reads the payload the coalescer left, not the caller's snapshot" do
+        block_topic!
+        anchor = dispatch_comment("@#{@agent.name}: anchor")
+        waiter = Task.where(agent: @agent, topic_id: @topic.id, status: "queued").sole
+        snapshot = Task.find(waiter.id)
+
+        late = Comment.create!(
+          creative: @creative, user: @user, topic: @topic,
+          content: "@#{@agent.name}: late", skip_dispatch: true
+        )
+        sibling = queued_waiter_for(late)
+        TaskCoalescer.coalesce!(waiter, scope: :all)
+        assert_equal "cancelled", sibling.reload.status,
+                     "premise: the fold cancelled the late comment's own waiter"
+        assert_includes waiter.reload.trigger_event_payload[TaskCoalescer::PAYLOAD_KEY], late.id
+
+        assert anchor.send(:reanchor_coalesced_task, snapshot),
+               "the folded comment is still unanswered work — the turn must survive"
+
+        payload = waiter.reload.trigger_event_payload
+        assert_equal late.id, payload.dig("comment", "id"),
+                     "the comment the fold merged in becomes the anchor"
+      end
+
+      # The same window can flip the task's status: the caller's snapshot says
+      # `queued` while promotion has already claimed it and AiAgentJob has handed
+      # it its payload. Re-anchoring a started turn silently re-targets work the
+      # agent is already doing; deleting the prompt has to stop it instead.
+      test "re-anchoring revalidates the status against the locked row" do
+        block_topic!
+        first = dispatch_comment("@#{@agent.name}: first")
+        second = dispatch_comment("@#{@agent.name}: second")
+
+        waiter = Task.where(agent: @agent, topic_id: @topic.id, status: "queued").sole
+        assert_equal second.id, waiter.trigger_event_payload.dig("comment", "id")
+        snapshot = Task.find(waiter.id)
+        Task.where(id: waiter.id).update_all(status: "running")
+
+        assert_not second.send(:reanchor_coalesced_task, snapshot),
+                   "a turn that has already started is not ours to re-target"
+        assert_equal second.id, waiter.reload.trigger_event_payload.dig("comment", "id")
+        assert_includes waiter.trigger_event_payload[TaskCoalescer::PAYLOAD_KEY], first.id
+      end
+
+      # With coalescing off, post_waiting_notice deliberately skips the dedup path
+      # and posts one notice per deferral — so a notice stands for exactly one
+      # waiter, and cancelling every queued task lets a user discard unrelated
+      # waiters by dismissing a single notice.
+      test "with coalescing off, deleting one notice cancels only its own waiter" do
+        OrchestratorPolicy.create!(
+          policy_type: "scheduling", scope_type: nil,
+          config: { "coalesce_pending_tasks" => false }
+        )
+        block_topic!
+
+        3.times { |i| dispatch_comment("@#{@agent.name}: msg #{i}") }
+
+        notices = Comment.where(creative_id: @creative.id, topic_id: @topic.id, user_id: nil,
+                                topic_concurrency_defer: true)
+                         .where("content LIKE ?", "#{Comment::WAITING_NOTICE_PREFIX}%")
+                         .order(:id).to_a
+        assert_equal 3, notices.size, "premise: the opt-out posts one notice per deferral"
+        assert_equal 3, Task.where(agent: @agent, topic_id: @topic.id, status: "queued").count
+
+        notices.last.destroy!
+
+        assert_equal 2, Task.where(agent: @agent, topic_id: @topic.id, status: "queued").count,
+                     "a notice that was never deduplicated speaks for one waiter only"
+      end
+
       test "deleting the anchor still cancels a waiter with nothing absorbed" do
         block_topic!
         only = dispatch_comment("@#{@agent.name}: only")

--- a/engines/collavre/test/services/collavre/orchestration/task_coalescing_integration_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/task_coalescing_integration_test.rb
@@ -201,6 +201,32 @@ module Collavre
                         "a comment in another creative must not stay merged into this turn"
       end
 
+      # The task's scope is the task's own, not the deleted comment's. cancel_
+      # pending_tasks looks tasks up without any creative scoping precisely
+      # because CommentMoveService can move a comment without touching the task
+      # it triggered — so a moved-then-deleted anchor searched for replacements
+      # in the creative it was moved *to*, found none, and cancelled a turn whose
+      # absorbed comments were all still sitting in the original creative.
+      test "re-anchoring searches the task's creative, not the moved anchor's" do
+        block_topic!
+        first = dispatch_comment("@#{@agent.name}: first")
+        second = dispatch_comment("@#{@agent.name}: second")
+        third = dispatch_comment("@#{@agent.name}: third")
+
+        waiter = Task.where(agent: @agent, topic_id: @topic.id, status: "queued").sole
+        elsewhere = Creative.create!(description: "Elsewhere", user: @user)
+        third.update!(creative: elsewhere, topic_id: nil)
+
+        third.destroy!
+
+        waiter.reload
+        assert_equal "queued", waiter.status,
+                     "the absorbed comments are still in this creative and still unanswered"
+        payload = waiter.trigger_event_payload
+        assert_equal second.id, payload.dig("comment", "id")
+        assert_equal [ first.id ], payload[TaskCoalescer::PAYLOAD_KEY]
+      end
+
       test "deleting the anchor still cancels a waiter with nothing absorbed" do
         block_topic!
         only = dispatch_comment("@#{@agent.name}: only")

--- a/engines/collavre/test/services/collavre/orchestration/task_coalescing_integration_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/task_coalescing_integration_test.rb
@@ -36,16 +36,16 @@ module Collavre
         )
       end
 
-      def dispatch_comment(body)
+      def dispatch_comment(body, user: @user)
         comment = Comment.create!(
-          creative: @creative, user: @user, topic: @topic, content: body, skip_dispatch: true
+          creative: @creative, user: user, topic: @topic, content: body, skip_dispatch: true
         )
         AgentOrchestrator.dispatch("comment_created", {
           "creative" => { "id" => @creative.id },
           "topic" => { "id" => @topic.id },
-          "sender" => { "id" => @user.id, "name" => @user.name },
+          "sender" => { "id" => user.id, "name" => user.name },
           "chat" => { "content" => body },
-          "comment" => { "id" => comment.id, "content" => body, "user_id" => @user.id }
+          "comment" => { "id" => comment.id, "content" => body, "user_id" => user.id }
         })
         comment
       end
@@ -209,6 +209,72 @@ module Collavre
         second.destroy!
 
         assert_equal "cancelled", task.reload.status
+      end
+
+      # Both doors onto the anchor replace "comment" but the payload also carries
+      # a "sender" block, and SystemEvents::ContextBuilder only fills it in with
+      # `||=` — it is never rebuilt on a promotion path. A stale sender labels the
+      # new anchor's text with the wrong speaker in MessageBuilder and ships the
+      # wrong author_id/author_name over ClaudeChannelAdapter.
+      test "deleting the anchor rebuilds the sender from the surviving comment" do
+        block_topic!
+        other = users(:two)
+        first = dispatch_comment("@#{@agent.name}: from other", user: other)
+        second = dispatch_comment("@#{@agent.name}: from one")
+
+        waiter = Task.where(agent: @agent, topic_id: @topic.id, status: "queued").sole
+        assert_equal @user.id, waiter.trigger_event_payload.dig("sender", "id")
+
+        second.destroy!
+
+        payload = waiter.reload.trigger_event_payload
+        assert_equal first.id, payload.dig("comment", "id")
+        assert_equal other.id, payload.dig("sender", "id"),
+                     "the turn now answers #{other.name}'s comment and must say so"
+        assert_equal expected_sender_for(other), payload["sender"],
+                     "the rebuilt sender must carry the same shape the builder does — " \
+                     "a two-key stub silently flips the is_a2a gate"
+      end
+
+      test "refresh rebuilds the sender when it moves onto another user's comment" do
+        other = users(:two)
+        stale = dispatch_comment("@#{@agent.name}: stale")
+        task = queued_waiter_for(stale)
+        task.update!(trigger_event_payload: task.trigger_event_payload.merge(
+          "sender" => expected_sender_for(@user)
+        ))
+        newer = Comment.create!(
+          creative: @creative, user: other, topic: @topic,
+          content: "@#{@agent.name}: newer", skip_dispatch: true
+        )
+
+        AgentOrchestrator.dequeue_next_for_topic(@topic.id, @creative.id)
+
+        payload = task.reload.trigger_event_payload
+        assert_equal newer.id, payload.dig("comment", "id")
+        assert_equal expected_sender_for(other), payload["sender"],
+                     "refreshing onto another user's comment must move the sender with it"
+      end
+
+      # Control: the rebuild must not fire blind. Re-anchoring within one user's
+      # own burst leaves the sender exactly as it was.
+      test "re-anchoring inside one user's burst leaves the sender untouched" do
+        block_topic!
+        dispatch_comment("@#{@agent.name}: first")
+        second = dispatch_comment("@#{@agent.name}: second")
+
+        waiter = Task.where(agent: @agent, topic_id: @topic.id, status: "queued").sole
+        before = waiter.trigger_event_payload["sender"]
+
+        second.destroy!
+
+        assert_equal before, waiter.reload.trigger_event_payload["sender"]
+      end
+
+      def expected_sender_for(user)
+        SystemEvents::ContextBuilder.new(
+          "comment" => { "user_id" => user.id }
+        ).build["sender"]
       end
     end
   end

--- a/engines/collavre/test/services/collavre/orchestration/task_coalescing_integration_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/task_coalescing_integration_test.rb
@@ -271,6 +271,50 @@ module Collavre
         assert_equal before, waiter.reload.trigger_event_payload["sender"]
       end
 
+      # TaskCoalescer supersedes by `id < keep.id`, which only means "everything
+      # already parked" while id order and commit order agree. An unserialized
+      # insert breaks that: the higher-id waiter can commit and fold first,
+      # seeing nothing, and the lower-id one then folds nothing either because
+      # the survivor is newer than its guard allows. AiAgentJob#admit_or_defer!
+      # already creates its waiter under the topic lock; this door must too.
+      test "a deferred dispatch creates and folds its waiter inside one locked transaction" do
+        block_topic!
+        dispatch_comment("@#{@agent.name}: first")
+
+        baseline_depth = Task.connection.open_transactions
+        locked = []
+        locked_before_fold = nil
+        fold_depth = nil
+
+        TopicSlot.stub(:lock!, ->(topic_id, _creative_id = nil) { locked << topic_id; nil }) do
+          TaskCoalescer.stub(:coalesce!, ->(_task, **_opts) {
+            locked_before_fold ||= locked.dup
+            fold_depth ||= Task.connection.open_transactions
+            []
+          }) do
+            dispatch_comment("@#{@agent.name}: second")
+          end
+        end
+
+        assert_equal [ @topic.id ], Array(locked_before_fold).uniq,
+                     "the waiter must be created under the topic lock before folding"
+        assert_operator fold_depth, :>, baseline_depth,
+                        "creating the waiter and folding its siblings must be one transaction"
+      end
+
+      # Control: serializing the door must not change what it produces. A burst
+      # arriving through the normal (unstubbed) path still collapses to one
+      # waiter carrying the others.
+      test "serializing the deferred door still folds an ordinary burst" do
+        block_topic!
+        first = dispatch_comment("@#{@agent.name}: alpha")
+        second = dispatch_comment("@#{@agent.name}: beta")
+
+        waiter = Task.where(agent: @agent, topic_id: @topic.id, status: "queued").sole
+        assert_equal second.id, waiter.trigger_event_payload.dig("comment", "id")
+        assert_equal [ first.id ], waiter.trigger_event_payload[TaskCoalescer::PAYLOAD_KEY]
+      end
+
       def expected_sender_for(user)
         SystemEvents::ContextBuilder.new(
           "comment" => { "user_id" => user.id }

--- a/engines/collavre/test/services/collavre/orchestration/task_coalescing_integration_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/task_coalescing_integration_test.rb
@@ -201,6 +201,52 @@ module Collavre
                         "a comment in another creative must not stay merged into this turn"
       end
 
+      # A comment made private after it was absorbed is one the user withdrew
+      # from the agent: dispatch_to_orchestration refuses to trigger on it and
+      # MergedTriggerComments.in_turn drops it from the delivered blocks. The
+      # anchor, though, is delivered as the trigger itself with no filter in
+      # front of it — so promoting a privated comment to anchor hands the agent
+      # exactly the content the user hid.
+      test "re-anchoring skips absorbed comments made private while queued" do
+        block_topic!
+        first = dispatch_comment("@#{@agent.name}: first")
+        second = dispatch_comment("@#{@agent.name}: secret salary figures")
+        third = dispatch_comment("@#{@agent.name}: third")
+
+        waiter = Task.where(agent: @agent, topic_id: @topic.id, status: "queued").sole
+        second.update!(private: true)
+
+        third.destroy!
+
+        waiter.reload
+        assert_equal "queued", waiter.status,
+                     "the first comment is still public and still unanswered"
+        payload = waiter.trigger_event_payload
+        assert_equal first.id, payload.dig("comment", "id"),
+                     "a privated comment is not an eligible anchor"
+        refute_includes payload.dig("comment", "content").to_s, "secret salary",
+                        "the withdrawn content must not reach the trigger"
+        refute_equal second.content, payload.dig("chat", "content")
+        refute_includes Array(payload[TaskCoalescer::PAYLOAD_KEY]), second.id,
+                        "a privated comment must not stay merged into this turn either"
+      end
+
+      # The control for the two exclusions above: an ordinary absorbed comment
+      # is still eligible. Without it, "select nothing" would pass them both.
+      test "re-anchoring still adopts an absorbed comment that is public and in scope" do
+        block_topic!
+        first = dispatch_comment("@#{@agent.name}: first")
+        second = dispatch_comment("@#{@agent.name}: second")
+        third = dispatch_comment("@#{@agent.name}: third")
+
+        third.destroy!
+
+        payload = Task.where(agent: @agent, topic_id: @topic.id, status: "queued")
+                      .sole.reload.trigger_event_payload
+        assert_equal second.id, payload.dig("comment", "id")
+        assert_equal [ first.id ], payload[TaskCoalescer::PAYLOAD_KEY]
+      end
+
       # The task's scope is the task's own, not the deleted comment's. cancel_
       # pending_tasks looks tasks up without any creative scoping precisely
       # because CommentMoveService can move a comment without touching the task

--- a/engines/collavre/test/services/collavre/orchestration/topic_slot_promotion_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/topic_slot_promotion_test.rb
@@ -169,6 +169,60 @@ module Collavre
         assert_operator check_depth, :>, baseline_depth,
                         "the occupancy check must run inside the claiming transaction"
       end
+
+      # Tasks carry topic_id with no foreign key, so a deleted topic leaves rows
+      # pointing at a row that is gone. `lock!` returned that nil and skipped the
+      # creative fallback entirely — admission, promotion and notice dedup then
+      # run with no serialization at all, which is the failure the lock exists to
+      # prevent rather than a missing niche.
+      test "falls back to the creative row when the topic no longer exists" do
+        missing_topic_id = Topic.maximum(:id).to_i + 1_000
+        locked = []
+        lock_relation = Struct.new(:sink) do
+          def find_by(id:)
+            sink << id
+            nil
+          end
+        end.new(locked)
+
+        Creative.stub(:lock, lock_relation) do
+          TopicSlot.lock!(missing_topic_id, @creative.id)
+        end
+
+        assert_equal [ @creative.id ], locked,
+                     "a stale topic id must still serialize on something stable"
+      end
+
+      # Control: a topic that does exist still locks the topic row, not the
+      # creative — falling back always would serialize unrelated topics against
+      # each other.
+      test "locks the topic row when the topic exists" do
+        locked_topics = []
+        locked_creatives = []
+        # The topic stub must *find* something: returning nil would be the
+        # missing-topic case above, and the fallback firing would be correct.
+        found = Struct.new(:sink, :row) do
+          def find_by(id:)
+            sink << id
+            row
+          end
+        end
+        absent = Struct.new(:sink) do
+          def find_by(id:)
+            sink << id
+            nil
+          end
+        end
+
+        Topic.stub(:lock, found.new(locked_topics, @topic)) do
+          Creative.stub(:lock, absent.new(locked_creatives)) do
+            assert_equal @topic, TopicSlot.lock!(@topic.id, @creative.id)
+          end
+        end
+
+        assert_equal [ @topic.id ], locked_topics
+        assert_empty locked_creatives, "an existing topic must not widen the lock to the creative"
+      end
     end
   end
 end

--- a/engines/collavre/test/services/collavre/orchestration/topic_slot_promotion_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/topic_slot_promotion_test.rb
@@ -269,6 +269,84 @@ module Collavre
         assert_equal [ @topic.id ], locked_topics
         assert_empty locked_creatives, "an existing topic must not widen the lock to the creative"
       end
+
+      # A promoted task holds the topic slot as `pending`, and deleting the
+      # comment it answers cancels it right there — Comment#cancel_pending_tasks
+      # takes no lock this path waits on. The coalescer re-reads the survivor
+      # under its own lock and correctly declines to fold onto a cancelled row,
+      # but it leaves the caller's object saying `pending`. Everything after it
+      # reads that stale copy: the refresh writes a payload onto a cancelled
+      # row, the status check passes, and the job is enqueued for a task that
+      # returns on sight without draining. The waiters behind it are stranded
+      # until orphan recovery.
+      test "re-reads the promoted task after the fold before enqueueing it" do
+        first = comment("@#{@agent.name}: first")
+        survivor = task_for(@agent, status: "queued", comment: first)
+        waiter = task_for(@agent, status: "queued", comment: comment("@#{@agent.name}: second"))
+
+        # The documented window: after claim_next_waiter has promoted the
+        # survivor, before the fold takes the task lock.
+        fold = TaskCoalescer.method(:coalesce!)
+        injected = false
+        inject_delete = lambda do |task, scope: :older|
+          unless injected
+            injected = true
+            first.destroy!
+          end
+          fold.call(task, scope: scope)
+        end
+
+        TaskCoalescer.stub(:coalesce!, inject_delete) do
+          AgentOrchestrator.dequeue_next_for_topic(@topic.id, @creative.id)
+        end
+
+        assert_equal "cancelled", survivor.reload.status,
+                     "deleting the anchor cancels the promoted task — the premise of this test"
+        assert_promoted waiter,
+                        "the survivor lost its turn, so the queue behind it must be drained " \
+                        "rather than left waiting on a task that will never run"
+      end
+
+      # Control: an ordinary promotion still enqueues the survivor. "Always
+      # recurse after folding" would pass the test above while re-promoting
+      # every turn and answering nothing.
+      test "a promoted task that survives the fold is still the one enqueued" do
+        survivor = task_for(@agent, status: "queued")
+
+        AgentOrchestrator.dequeue_next_for_topic(@topic.id, @creative.id)
+
+        assert_promoted survivor, "a healthy survivor must keep the slot it claimed"
+      end
+
+      # The same window does not close at the fold: the anchor can be deleted
+      # after the recheck, or while the job sits in the queue. The job's own
+      # first guard then returns without draining — the identical stranding,
+      # reached by the identical user action a moment later.
+      test "a cancelled task abandoned at job start still drains the topic" do
+        cancelled = task_for(@agent, status: "pending")
+        cancelled.update!(status: "cancelled")
+        waiter = task_for(@agent, status: "queued")
+
+        AiAgentJob.perform_now(cancelled)
+
+        assert_promoted waiter,
+                        "a task that leaves without running has to hand the topic slot on"
+      end
+
+      # Control: a cancelled task with no topic (a workflow subtask) has no
+      # queue to drain, and must not fall into topic promotion at all.
+      test "a cancelled task without a topic drains nothing" do
+        orphan = Task.create!(
+          name: "Subtask", status: "cancelled", trigger_event_name: "comment_created",
+          agent: @agent, trigger_event_payload: { "creative" => { "id" => @creative.id } }
+        )
+        waiter = task_for(@agent, status: "queued")
+
+        AiAgentJob.perform_now(orphan)
+
+        assert_equal "queued", waiter.reload.status,
+                     "a task that never held this topic's slot must not hand it out"
+      end
     end
   end
 end

--- a/engines/collavre/test/services/collavre/orchestration/topic_slot_promotion_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/topic_slot_promotion_test.rb
@@ -170,6 +170,52 @@ module Collavre
                         "the occupancy check must run inside the claiming transaction"
       end
 
+      # Promotion deleted every "⏳" notice in the topic unconditionally. With
+      # topic_max > 1 it can leave other agents queued — coalesce_promoted!
+      # absorbs same-agent siblings only — and the topic is allowed just one
+      # deduplicated notice, so removing it strips the wait/stop signal from a
+      # wait that is still real, until some later deferral happens to repost it.
+      test "promotion keeps the waiting notice while another agent is still queued" do
+        # Codex's shape: topic_max 2, one slot held by B, waiters for busy B and
+        # for free A. Promoting A must not speak for B's wait, which continues.
+        OrchestratorPolicy.create!(
+          policy_type: "scheduling", scope_type: nil,
+          config: { "topic_max_concurrent_jobs" => 2 }
+        )
+        stuck_agent = other_agent("still-waiting")
+        # Holds one of the two slots, which is also what makes its own waiter
+        # ineligible: an agent may not take a second concurrent turn.
+        task_for(stuck_agent, status: "running")
+        task_for(@agent, status: "queued")
+        task_for(stuck_agent, status: "queued")
+        notice = @creative.comments.create!(
+          content: "#{Comment::WAITING_NOTICE_PREFIX} Waiting (another task is running)",
+          topic_id: @topic.id, private: false, skip_default_user: true,
+          topic_concurrency_defer: true, skip_dispatch: true
+        )
+
+        AgentOrchestrator.dequeue_next_for_topic(@topic.id, @creative.id)
+
+        assert Comment.exists?(notice.id),
+               "a waiter that is still queued still needs its notice"
+      end
+
+      # Control: once nothing is queued the notice must still go away, or the
+      # topic keeps a "⏳" describing a wait that is over.
+      test "promotion removes the waiting notice once the queue has drained" do
+        task_for(@agent, status: "queued")
+        notice = @creative.comments.create!(
+          content: "#{Comment::WAITING_NOTICE_PREFIX} Waiting (another task is running)",
+          topic_id: @topic.id, private: false, skip_default_user: true,
+          topic_concurrency_defer: true, skip_dispatch: true
+        )
+
+        AgentOrchestrator.dequeue_next_for_topic(@topic.id, @creative.id)
+
+        refute Comment.exists?(notice.id),
+               "nothing is waiting any more, so the notice must be cleaned up"
+      end
+
       # Tasks carry topic_id with no foreign key, so a deleted topic leaves rows
       # pointing at a row that is gone. `lock!` returned that nil and skipped the
       # creative fallback entirely — admission, promotion and notice dedup then

--- a/engines/collavre/test/services/collavre/orchestration/topic_slot_promotion_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/topic_slot_promotion_test.rb
@@ -1,0 +1,174 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  module Orchestration
+    # Admission (AiAgentJob) and promotion (dequeue_next_for_topic) are two ways
+    # into the same topic slot. Guarding only admission leaves the promotion path
+    # free to hand a slot to an agent that already holds one, or to overfill a
+    # topic outright — and TaskCoalescer folds only `queued` rows, so two
+    # concurrent turns for one agent can never be merged after the fact.
+    class TopicSlotPromotionTest < ActiveSupport::TestCase
+      setup do
+        @user = users(:one)
+        @creative = creatives(:tshirt)
+        @agent = users(:ai_bot)
+        @topic = Topic.create!(name: "Promotion topic", creative: @creative, user: @user)
+      end
+
+      def other_agent(tag)
+        Collavre::User.create!(
+          name: "promo-agent-#{tag}",
+          email: "promo-#{tag}-#{SecureRandom.hex(4)}@agent.test",
+          password: "password123",
+          llm_vendor: "openai",
+          llm_model: "gpt-4",
+          system_prompt: "You are agent #{tag}."
+        )
+      end
+
+      def payload_for(comment)
+        {
+          "creative" => { "id" => @creative.id },
+          "topic" => { "id" => @topic.id },
+          "sender" => { "id" => @user.id, "name" => @user.name },
+          "comment" => { "id" => comment.id, "content" => comment.content, "user_id" => @user.id }
+        }
+      end
+
+      def comment(body)
+        Comment.create!(
+          creative: @creative, user: @user, topic: @topic, content: body, skip_dispatch: true
+        )
+      end
+
+      def task_for(agent, status:, comment: nil)
+        Task.create!(
+          name: "Task #{status}", status: status, trigger_event_name: "comment_created",
+          agent: agent, topic_id: @topic.id, creative_id: @creative.id,
+          trigger_event_payload: payload_for(comment || self.comment("trigger"))
+        )
+      end
+
+      # A promoted waiter leaves "queued" for good: the test adapter runs its
+      # AiAgentJob inline, so it can be anywhere from "pending" to "done" by the
+      # time control returns. What matters is that it was let out of the queue.
+      def assert_promoted(task, message)
+        assert_includes %w[pending running delegated done], task.reload.status, message
+      end
+
+      def topic_max!(value)
+        OrchestratorPolicy.create!(
+          policy_type: "scheduling", scope_type: nil,
+          config: { "topic_max_concurrent_jobs" => value }
+        )
+      end
+
+      # topic_max = 1, a live holder, and a waiter behind it. Promotion runs on
+      # every terminal task in the topic, including tasks that never held this
+      # slot, so it has to re-check occupancy rather than trust its caller.
+      test "does not promote a waiter while the topic is at capacity" do
+        holder = task_for(other_agent("holder"), status: "running")
+        waiter = task_for(@agent, status: "queued")
+
+        AgentOrchestrator.dequeue_next_for_topic(@topic.id, @creative.id)
+
+        assert_equal "queued", waiter.reload.status,
+                     "a full topic must not admit a second turn through the promotion path"
+        assert_equal "running", holder.reload.status
+      end
+
+      # topic_max = 2 exists to run *different* agents in parallel. An agent with
+      # a turn already in flight must stay queued even though the topic has room.
+      test "does not promote a waiter whose agent already occupies a slot" do
+        topic_max!(2)
+        task_for(@agent, status: "running")
+        waiter = task_for(@agent, status: "queued")
+
+        AgentOrchestrator.dequeue_next_for_topic(@topic.id, @creative.id)
+
+        assert_equal "queued", waiter.reload.status,
+                     "the same agent must not run two concurrent turns in one topic"
+      end
+
+      test "promotes a different agent's waiter into the free slot" do
+        topic_max!(2)
+        task_for(@agent, status: "running")
+        waiter = task_for(other_agent("second"), status: "queued")
+
+        AgentOrchestrator.dequeue_next_for_topic(@topic.id, @creative.id)
+
+        assert_promoted waiter, "the parallelism topic_max > 1 buys must survive the eligibility guard"
+      end
+
+      # The oldest waiter is not always the eligible one. Skipping it entirely
+      # would strand every waiter behind a busy agent.
+      test "skips an ineligible waiter and promotes the next eligible one" do
+        topic_max!(2)
+        task_for(@agent, status: "running")
+        blocked = task_for(@agent, status: "queued")
+        eligible = task_for(other_agent("third"), status: "queued")
+
+        AgentOrchestrator.dequeue_next_for_topic(@topic.id, @creative.id)
+
+        assert_equal "queued", blocked.reload.status
+        assert_promoted eligible, "an eligible waiter behind a blocked one must still run"
+      end
+
+      # A deferral is not proof that the topic is full: with topic_max > 1 an
+      # agent defers because *it* is busy, while a slot sits free for someone
+      # else. Draining only when every occupant is gone strands that waiter until
+      # the unrelated holder finishes.
+      test "drains another agent's waiter when a slot remains free after deferring" do
+        topic_max!(2)
+        Orchestration::ResourceTracker.for(@agent).reset!
+        task_for(@agent, status: "running")
+        stranded = task_for(other_agent("waiting"), status: "queued")
+
+        AiAgentJob.new.perform(@agent.id, "comment_created", payload_for(comment("same agent again")))
+
+        assert_equal 1, Task.where(agent: @agent, topic_id: @topic.id, status: "queued").count,
+                     "the busy agent's new trigger must queue"
+        assert_promoted stranded, "the free slot must go to the waiter that can use it"
+      ensure
+        Orchestration::ResourceTracker.for(@agent).reset!
+      end
+
+      # Promotion claims a slot; it must take the same lock admission takes, or
+      # the two paths can hand out the same slot concurrently.
+      test "claims the promoted slot inside one locked transaction" do
+        locked_topic_ids = []
+        lock_relation = Struct.new(:sink) do
+          def find_by(id:)
+            sink << id
+            nil
+          end
+        end.new(locked_topic_ids)
+
+        task_for(@agent, status: "queued")
+        baseline_depth = Task.connection.open_transactions
+        check_depth = nil
+        counting_scope = Task.occupying_topic_slot(@topic.id, @creative.id)
+
+        Topic.stub(:lock, lock_relation) do
+          Task.stub(:occupying_topic_slot, ->(*) {
+            check_depth ||= Task.connection.open_transactions
+            counting_scope
+          }) do
+            AgentOrchestrator.dequeue_next_for_topic(@topic.id, @creative.id)
+          end
+        end
+
+        # The promoted task runs inline here and drains the queue again as it
+        # finishes, so the row is locked once per claim attempt — what matters
+        # is that no claim skips the lock.
+        assert_equal [ @topic.id ], locked_topic_ids.uniq,
+                     "promotion must serialize on the same topic row admission uses"
+        assert_predicate locked_topic_ids, :any?
+        assert_operator check_depth, :>, baseline_depth,
+                        "the occupancy check must run inside the claiming transaction"
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Problem

An external event burst — a PR comment sync, a webhook batch — creates several `Collavre::Comment` rows in one topic within milliseconds. Each fires `Comment#dispatch_to_orchestration`, so the same agent answers once per comment instead of once per turn.

Two independent paths produce it:

1. **Queued waiters replay the same comment.** `topic_max_concurrent_jobs = 1` defers comments 2..N into `queued` tasks. On promotion, `refresh_deferred_context!` rewrites each waiter's payload to the *latest non-agent* comment — and the agent's own replies are excluded from that lookup, so every waiter resolves to the **same** last comment and answers it again.
2. **Immediate dispatch races on the topic slot.** `Scheduler#evaluate` counts `Task.running_for_topic`, but that row is only created **inside** `AiAgentJob`. Dispatches arriving before the first job runs all see an empty topic, are all judged `:immediate`, and several turns run at once in a topic limited to one.

### Why cancelling the extras is not enough

Session-backed agents receive **only** the trigger:

- `ClaudeChannelAdapter#deliver` puts `comment.content` alone in the MCP payload — no chat history at all.
- `SessionContextResolver#incremental_payload` keeps only the `:trigger` message and drops chat history.

So cancelling the older tasks would silently drop the content of every intermediate comment. They have to be **merged**, not discarded.

## Solution

`Orchestration::TaskCoalescer` keeps one un-started task per `(agent, topic, creative, trigger_event)` and folds the superseded triggers into it as `merged_comment_ids`. `AiAgent::MergedTriggerComments` renders them inline on every delivery path.

- **Newest task survives**, so the payload anchor stays the newest comment — reply anchoring, review quoting and image attachment keep pointing at the message the user actually sent last.
- **Only `queued` is superseded.** A `pending` task may already be riding an enqueued `AiAgentJob`; cancelling it makes that job return early *without* draining the topic queue, stalling the topic.
- **`id < keep.id` on the enqueue path** so two concurrent dispatches cannot cancel each other and leave no survivor. The promotion path uses the full scope instead: `dequeue_next_for_topic` promotes the *oldest* waiter, so its siblings are newer and the id guard would absorb nothing.
- **`AiAgentJob` re-checks the topic slot** at row-creation time — over `occupying_topic_slot`, which also counts `pending` and `pending_approval` — and parks a waiter instead of starting a second concurrent turn. It re-drains immediately if the holder finished in the meantime.
- **One "⏳" notice per creative/topic**, since N notices would be N dead ends pointing at one blocker.
- Merged comments are excluded from `append_chat_history` so the full-context path does not send them twice.

Coalescing is scoped **per agent**, so `topic_max_concurrent_jobs > 1` still runs *different* agents in parallel; `StuckDetector`'s multi-slot self-heal is unaffected for distinct agents and now absorbs same-agent stragglers instead of promoting them into a duplicate answer.

Controlled by `scheduling.coalesce_pending_tasks` (default `true`), so a creative or topic can opt out.

Design notes: `docs/superpowers/specs/2026-07-27-pending-task-coalescing.md`

## Not doing

Debouncing the *first* message would take a 5-comment burst from two answers down to one, but delays every ordinary conversation turn. Out of scope.

## Tests

New: `task_coalescer_test.rb`, `task_coalescing_integration_test.rb`, `merged_trigger_comments_test.rb`, `ai_agent_job_topic_slot_test.rb`. Extended: `message_builder_test.rb`, `policy_resolver_test.rb`, `stuck_detector_test.rb`.

Covers scope boundaries (other agents / creatives / topics / event names / `pending` / `running` untouched), transitive merges, the concurrent-survivor guarantee, burst → 1 waiter + 1 notice, promotion without replay, anchor replacement preserving the previous anchor, merged comments reaching both the LLM trigger and the Claude Channel payload with their images, exclusion from chat history, and the policy off-switch restoring previous behaviour.

`rake test`: **3035 runs, 9454 assertions, 0 failures, 0 errors**. Rubocop clean. No migration needed (`trigger_event_payload` is `json`); no new user-facing strings.