### PR TITLE
fix(orchestration): survive public shares when detecting stuck work

### DIFF
--- a/engines/collavre/app/services/collavre/orchestration/stuck_detector.rb
+++ b/engines/collavre/app/services/collavre/orchestration/stuck_detector.rb
@@ -244,10 +244,11 @@ module Collavre
                 .where("updated_at < ?", threshold_time)
                 .includes(creative_shares: :user)
                 .find_each do |creative|
-          # Skip if no AI agents have access
+          # Skip if no AI agents have access. Public shares carry no user, so
+          # drop them before asking whether the holder is an AI agent.
           ai_agents = creative.creative_shares
                               .reject { |s| s.permission == "no_access" }
-                              .map(&:user)
+                              .filter_map(&:user)
                               .select(&:ai_user?)
 
           next if ai_agents.empty?
@@ -286,7 +287,7 @@ module Collavre
         ancestor_ids = [ creative.id ] + creative.ancestor_ids
         admin_users = CreativeShare.where(creative_id: ancestor_ids, permission: "admin")
                                    .includes(:user)
-                                   .filter_map { |share| share.user unless share.user.ai_user? }
+                                   .filter_map { |share| share.user if share.user && !share.user.ai_user? }
 
         # Also include the creative owner
         admin_users << creative.user if creative.user && !creative.user.ai_user?

--- a/engines/collavre/test/models/collavre/creative_reserved_metadata_keys_test.rb
+++ b/engines/collavre/test/models/collavre/creative_reserved_metadata_keys_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative "../../test_helper"
+require "test_helper"
 
 # Tests for Collavre::Creative.reserved_metadata_keys registry.
 # Vendor-neutral: uses a dummy key "x", no engine names.

--- a/engines/collavre/test/services/collavre/orchestration/stuck_detector_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/stuck_detector_test.rb
@@ -165,6 +165,63 @@ module Collavre
         policy&.destroy
       end
 
+      test "detects stalled creative that also has a public share" do
+        policy = create_policy_with_stuck_detection(enabled: true, creative_threshold: 60)
+
+        Collavre::CreativeShare.create!(
+          creative: @creative,
+          user: @ai_agent,
+          permission: :write
+        )
+
+        # A public share carries no user (see CreativeShare: user is optional)
+        Collavre::CreativeShare.create!(
+          creative: @creative,
+          user: nil,
+          permission: :read
+        )
+
+        @creative.update_columns(updated_at: 3.hours.ago)
+
+        detector = StuckDetector.new
+        stuck_items = detector.detect
+
+        creative_stuck = stuck_items.find { |item| item.type == :creative && item.item.id == @creative.id }
+        assert_not_nil creative_stuck
+        assert_equal :stalled, creative_stuck.reason
+      ensure
+        policy&.destroy
+      end
+
+      test "escalates stuck task on a creative that has a public admin share" do
+        policy = create_policy_with_stuck_detection(enabled: true, task_threshold: 30)
+
+        # A public share may hold admin permission and still carry no user
+        Collavre::CreativeShare.create!(
+          creative: @creative,
+          user: nil,
+          permission: :admin
+        )
+
+        task = Collavre::Task.create!(
+          name: "Stuck task",
+          agent: @ai_agent,
+          status: "running",
+          trigger_event_payload: { "creative" => { "id" => @creative.id } },
+          topic_id: @topic.id
+        )
+        task.update_columns(created_at: 1.hour.ago, updated_at: 1.hour.ago)
+
+        detector = StuckDetector.new
+        result = detector.detect_and_escalate
+
+        assert_equal 1, result.escalated_count
+        task_stuck = result.stuck_items.find { |item| item.type == :task }
+        assert_equal [ @human_user.id ], task_stuck.escalation_targets.map(&:id)
+      ensure
+        policy&.destroy
+      end
+
       test "escalates and creates inbox item" do
         policy = create_policy_with_stuck_detection(enabled: true, task_threshold: 30)
 


### PR DESCRIPTION
## Problem

A `CreativeShare` can be public, in which case it carries no `user`. `StuckDetector`
assumed every share had one and called `ai_user?` on `nil`, so a single public share
anywhere on a creative raised `NoMethodError` and took down:

- `detect_stalled_creatives` — the whole detection sweep aborted mid-batch
- `escalation_targets` — stuck tasks could not be escalated to their human admins

## Fix

Drop user-less shares before asking whether the holder is an AI agent, in both places.

- `.map(&:user)` → `.filter_map(&:user)` when collecting AI agents with access
- `share.user unless share.user.ai_user?` → `share.user if share.user && !share.user.ai_user?`
  when collecting admin escalation targets

## Tests

Two regression tests, both of which fail with `NoMethodError` on `main` and pass with the fix:

- a stalled creative that carries a public share alongside an AI agent share is still detected
- a stuck task on a creative with a public **admin** share escalates to the human admin only

`engines/collavre/test/services/collavre/orchestration/stuck_detector_test.rb` — 36 runs, 0 failures.

A second commit switches `creative_reserved_metadata_keys_test.rb` from
`require_relative "../../test_helper"` to `require "test_helper"` to match the rest of the
engine's tests. Unrelated one-liner, kept separate for easy dropping.

## Notes

The local full engine suite is noisy in this environment (the untouched base commit already
reports 58 errors, mostly Capybara system tests and an `ActiveRecord::Encryption` credential
issue). Every failure seen on this branch also reproduces without these changes, and all
touched tests pass in isolation. Leaving the verdict to CI.