### PR TITLE
fix: record on the waiter which notice speaks for it

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_27_000002) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_27_010000) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -868,6 +868,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_27_000002) do
     t.string "trigger_event_name"
     t.json "trigger_event_payload"
     t.datetime "updated_at", null: false
+    t.string "waiting_notice_scope"
     t.text "workflow_context"
     t.json "workflow_state"
     t.index ["agent_id"], name: "index_tasks_on_agent_id"

--- a/docs/superpowers/specs/2026-07-27-pending-task-coalescing.md
+++ b/docs/superpowers/specs/2026-07-27-pending-task-coalescing.md
@@ -272,6 +272,19 @@ be N dead ends pointing at one blocker.
   for. `nil` is a notice posted before this was recorded and keeps the old
   behaviour; widening it would discard work, narrowing it would disarm the only
   stop control an in-flight wait has.
+- **And it is recorded on the waiter too, not read off its neighbours.**
+  `tasks.waiting_notice_scope` says which notice speaks for a waiter, written by
+  the same statement that creates it — `park_waiter` on the enqueue door,
+  `#admit_or_defer!` on the admission door — under the admission lock. The waiter
+  and its notice commit in two steps, so asking "which notices name this waiter?"
+  has a window where the honest answer is "none yet": an opted-out waiter is
+  already `queued` while its own notice does not exist, and a shared notice
+  deleted in that window reads it as one of its own and cancels a turn that was
+  only deferred, leaving no notice behind to say a wait happened. Recording it on
+  the row also means the fold, the notice and the shared notice's stop button read
+  one answer rather than resolving the policy at three moments a mid-wait policy
+  change can fall between. `nil` is a waiter parked before this was recorded and
+  keeps the old sibling-notice answer, for the same reason as above.
 - `topic_concurrency_notice_exists?` counts `"topic"` and legacy notices only. A
   per-deferral notice speaks for one waiter, so letting it answer would leave a
   coalescing agent's waiters with no notice whenever an opted-out agent deferred
@@ -280,7 +293,9 @@ be N dead ends pointing at one blocker.
   What it represents is `Comment#represented_queued_waiters` — the same statement
   its stop button cancels through, so "what this notice is for" has one answer:
   its own waiter for a `"task"` notice, every unclaimed queued waiter for a
-  shared one, the single newest waiter for a legacy one. Asked per notice, never
+  shared one, the single newest waiter for a legacy one. "Unclaimed" is the
+  waiter's own `waiting_notice_scope`, falling back to the surviving sibling
+  notices only for waiters parked before it was recorded. Asked per notice, never
   per topic: "is anything queued here?" is nobody's question, and a promotion
   that leaves only *claimed* waiters behind reads as "still busy" while the
   shared notice it kept up speaks for none of them — a second "⏳" line whose

--- a/engines/collavre/app/jobs/collavre/ai_agent_job.rb
+++ b/engines/collavre/app/jobs/collavre/ai_agent_job.rb
@@ -291,6 +291,13 @@ module Collavre
       creative_id = context.dig("creative", "id")
       admitted = false
       task = nil
+      # A queued row here is a waiter, and what speaks for it is settled now, with
+      # the row — not later, from whichever notices happen to be visible. Its
+      # notice is posted in a separate transaction below, so between the two this
+      # waiter is queued with nothing naming it, and a shared notice deleted in
+      # that window would read an opted-out waiter as one of its own and cancel a
+      # turn that was only deferred.
+      notice_scope = waiter_notice_scope(agent, context)
 
       # Counting occupants and claiming the slot must be ONE step. Two workers
       # starting within the same millisecond — the exact burst this job defends
@@ -302,7 +309,12 @@ module Collavre
       Task.transaction do
         Orchestration::TopicSlot.lock!(topic_id, creative_id)
         admitted = Orchestration::TopicSlot.available_for?(agent.id, topic_id, creative_id, context)
-        task = Task.create!(attrs.merge(status: admitted ? "running" : "queued"))
+        task = Task.create!(attrs.merge(
+          status: admitted ? "running" : "queued",
+          # Left nil on an admitted row: it is not waiting, so no notice speaks
+          # for it and there is nothing for a stop control to represent.
+          waiting_notice_scope: admitted ? nil : notice_scope
+        ))
       end
 
       return task if admitted
@@ -325,6 +337,18 @@ module Collavre
       )
     end
 
+    # Which notice will speak for a waiter parked by this dispatch: the topic's
+    # shared one when this agent coalesces, its own per-deferral one when it has
+    # opted out. Resolved once, at the moment the waiter is created, so the fold,
+    # the notice and the shared notice's stop button all read one answer.
+    def waiter_notice_scope(agent, context)
+      if Orchestration::PolicyResolver.new(context).coalesce_pending_tasks_for?(agent)
+        Comment::WAITING_NOTICE_TOPIC
+      else
+        Comment::WAITING_NOTICE_TASK
+      end
+    end
+
     # Is this dispatch subject to the topic concurrency limit at all? Workflow
     # subtasks and other topic-less dispatches are not.
     def topic_admission_scoped?(context)
@@ -335,7 +359,10 @@ module Collavre
     # any waiters already parked for the same agent/topic/creative, and surface
     # one "⏳" notice for the topic.
     def park_deferred_waiter(waiter, agent, event_name, context, topic_id, creative_id)
-      if Orchestration::PolicyResolver.new(context).coalesce_pending_tasks_for?(agent)
+      # Read off the waiter rather than resolved again: folding and the notice are
+      # the same policy answer, and asking twice is how they come to disagree
+      # about a wait whose policy changed in between.
+      if waiter.waiting_notice_scope == Comment::WAITING_NOTICE_TOPIC
         Orchestration::TaskCoalescer.coalesce!(waiter)
       end
       Orchestration::AgentOrchestrator.post_topic_concurrency_notice(

--- a/engines/collavre/app/models/collavre/comment.rb
+++ b/engines/collavre/app/models/collavre/comment.rb
@@ -489,11 +489,17 @@ module Collavre
         # all once that waiter has been folded away or promoted.
         queued_topic_waiters.select { |task| task.id == waiting_notice_task_id }
       when WAITING_NOTICE_TOPIC
-        # Every queued waiter in the topic except those a surviving per-deferral
-        # notice still speaks for: the shared notice was never their signal, and
-        # their own stop control is still on screen.
+        # Every queued waiter in the topic except those a per-deferral notice
+        # speaks for: the shared notice was never their signal, and their own
+        # stop control is — or is about to be — on screen.
+        #
+        # Asked of the waiter, not of the notices standing beside it. A waiter and
+        # its notice commit in two steps, so an opted-out waiter is queued before
+        # any notice names it; classifying it by what survives in that window
+        # cancels a turn that was only deferred, and leaves no notice behind to
+        # say so. What speaks for a waiter is settled when it is parked.
         claimed = sibling_notice_waiter_ids
-        queued_topic_waiters.reject { |task| claimed.include?(task.id) }
+        queued_topic_waiters.reject { |task| task_claims_own_notice?(task, claimed) }
       else
         # Posted before this was recorded. Nothing on the row says which kind it
         # was, so keep the behaviour those notices were created under rather than
@@ -507,6 +513,22 @@ module Collavre
       scope = Task.where(status: "queued", creative_id: creative_id)
       scope = topic_id ? scope.where(topic_id: topic_id) : scope.where(topic_id: nil)
       scope.order(created_at: :desc).to_a
+    end
+
+    # Does this waiter have a per-deferral notice of its own, rather than being
+    # one the topic's shared notice speaks for?
+    #
+    # The waiter says so itself, recorded when it was parked. Rows parked before
+    # that was recorded say nothing, so they keep the answer they were parked
+    # under — the surviving sibling notices — rather than being guessed at in
+    # either direction: widening this discards work, narrowing it disarms the only
+    # stop control an in-flight wait has.
+    def task_claims_own_notice?(task, claimed)
+      case task.waiting_notice_scope
+      when WAITING_NOTICE_TASK then true
+      when WAITING_NOTICE_TOPIC then false
+      else claimed.include?(task.id)
+      end
     end
 
     # Waiter ids a still-standing per-deferral notice represents. Runs

--- a/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
+++ b/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
@@ -331,7 +331,16 @@ module Collavre
         return unless creative
 
         reason_text = waiting_reason_text(:topic_concurrency, topic_id, creative_id)
-        shared = PolicyResolver.new(context || {}).coalesce_pending_tasks_for?(agent)
+        # The waiter recorded this when it was parked. Reading it back rather than
+        # resolving the policy again keeps the notice, the fold and the shared
+        # notice's stop button on one answer even if the policy changes mid-wait.
+        # Falling back for a caller without a waiter: there is no row to ask.
+        shared =
+          if waiter
+            waiter.waiting_notice_scope == Comment::WAITING_NOTICE_TOPIC
+          else
+            PolicyResolver.new(context || {}).coalesce_pending_tasks_for?(agent)
+          end
         post = lambda do
           creative.comments.create!(
             content: I18n.t("collavre.orchestration.waiting_notice", reason: reason_text),
@@ -692,6 +701,7 @@ module Collavre
       def park_waiter(agent)
         topic_id = @context.dig("topic", "id")
         creative_id = @context.dig("creative", "id")
+        coalescing = policy_resolver.coalesce_pending_tasks_for?(agent)
         waiter = nil
 
         Task.transaction do
@@ -703,9 +713,16 @@ module Collavre
             trigger_event_payload: @context,
             agent: agent,
             topic_id: topic_id,
-            creative_id: creative_id
+            creative_id: creative_id,
+            # Which notice speaks for this waiter, written with the row rather
+            # than inferred from the notices afterwards. post_waiting_notice
+            # decides it from the same policy answer, but posts in a later
+            # transaction: between the two, this waiter is queued with no notice
+            # naming it, and a shared notice deleted in that window would read it
+            # as one of its own and cancel work that was only ever deferred.
+            waiting_notice_scope: coalescing ? Comment::WAITING_NOTICE_TOPIC : Comment::WAITING_NOTICE_TASK
           )
-          TaskCoalescer.coalesce!(waiter) if policy_resolver.coalesce_pending_tasks_for?(agent)
+          TaskCoalescer.coalesce!(waiter) if coalescing
         end
 
         waiter
@@ -738,7 +755,13 @@ module Collavre
         # Keep exactly one topic-concurrency notice per creative/topic — and take
         # the check and the insert under one lock, since a burst is precisely
         # when an unserialized check reads stale.
-        shared = deferred && policy_resolver.coalesce_pending_tasks_for?(agent)
+        #
+        # Taken from the waiter, which recorded it under the admission lock when
+        # park_waiter created it. One answer for the fold, the notice and the
+        # shared notice's stop button, rather than the same question asked at
+        # three moments a policy change can fall between. :delayed has no waiter.
+        shared = deferred && (waiter ? waiter.waiting_notice_scope == Comment::WAITING_NOTICE_TOPIC
+                                     : policy_resolver.coalesce_pending_tasks_for?(agent))
         if shared
           self.class.with_deduped_topic_notice(creative_id, topic_id) do
             create_waiting_notice(creative, topic_id, reason_text, deferred: deferred,

--- a/engines/collavre/db/migrate/20260727010000_add_waiting_notice_scope_to_tasks.rb
+++ b/engines/collavre/db/migrate/20260727010000_add_waiting_notice_scope_to_tasks.rb
@@ -1,0 +1,26 @@
+# Record which kind of "⏳ waiting" notice speaks for a waiter on the waiter
+# itself, at the moment it is parked.
+#
+# The waiter and its notice commit in two steps, so asking the notices which
+# waiters they own has a window where the answer is wrong: an opted-out waiter is
+# already queued while its own notice does not exist yet, and a shared notice
+# deleted in that window reads it as one of its own and cancels it. What speaks
+# for a waiter is decided by the agent's coalescing policy when the row is
+# created, not by which neighbouring rows happen to be visible later.
+#
+# Nullable with no backfill on purpose: a waiter parked by the pre-existing code
+# says nothing about which notice spoke for it, and
+# Comment#represented_queued_waiters keeps the old sibling-notice answer for
+# those rows. Widening would discard work; narrowing would leave an in-flight
+# wait with no stop control.
+class AddWaitingNoticeScopeToTasks < ActiveRecord::Migration[8.1]
+  def up
+    return if column_exists?(:tasks, :waiting_notice_scope)
+
+    add_column :tasks, :waiting_notice_scope, :string
+  end
+
+  def down
+    remove_column :tasks, :waiting_notice_scope if column_exists?(:tasks, :waiting_notice_scope)
+  end
+end

--- a/engines/collavre/test/jobs/collavre/ai_agent_job_topic_slot_test.rb
+++ b/engines/collavre/test/jobs/collavre/ai_agent_job_topic_slot_test.rb
@@ -456,6 +456,100 @@ module Collavre
                    "a waiter whose own notice is still on screen was never this one's to cancel"
     end
 
+    # The waiter and the notice that speaks for it commit in two steps —
+    # park_waiter commits the row, post_waiting_notice posts its notice after —
+    # so there is a window in which an opted-out waiter is queued with no
+    # per-deferral notice naming it yet. Reading ownership off the surviving
+    # notices inside that window classifies it as one the shared notice speaks
+    # for and cancels it: the opt-out's turn is not deferred, it is discarded,
+    # and no notice is left on screen to say a wait ever happened.
+    #
+    # Injected at waiting_reason_text — the call this door makes after its waiter
+    # has committed and before the notice row exists — with the deletion running
+    # through the real Comment#destroy rather than by calling the cancel path.
+    test "deleting the shared notice spares an opt-out waiter whose own notice has not committed" do
+      OrchestratorPolicy.create!(
+        policy_type: "scheduling", scope_type: "User", scope_id: second_agent.id,
+        config: { "coalesce_pending_tasks" => false }
+      )
+      occupy_slot!
+      AiAgentJob.new.perform(@agent.id, "comment_created", context_for(comment("coalescing")))
+
+      shared = Comment.where(creative_id: @creative.id, topic_id: @topic.id, user_id: nil,
+                             waiting_notice_scope: Comment::WAITING_NOTICE_TOPIC).sole
+      shared_waiter = Task.where(agent: @agent, topic_id: @topic.id, status: "queued").sole
+
+      delete_shared_in_window = lambda do |*_args|
+        parked = Task.where(agent: second_agent, topic_id: @topic.id, status: "queued").first
+        if parked && Comment.exists?(shared.id)
+          assert_not Comment.where(creative_id: @creative.id, topic_id: @topic.id, user_id: nil,
+                                   waiting_notice_scope: Comment::WAITING_NOTICE_TASK,
+                                   waiting_notice_task_id: parked.id).exists?,
+                     "premise: the opt-out's own notice has not been posted yet"
+          shared.destroy!
+        end
+        "another task is running"
+      end
+
+      Orchestration::AgentOrchestrator.stub :waiting_reason_text, delete_shared_in_window do
+        AiAgentJob.new.perform(second_agent.id, "comment_created", context_for(comment("opt-out")))
+      end
+
+      own_waiter = Task.where(agent: second_agent, topic_id: @topic.id).sole
+      assert_equal "cancelled", shared_waiter.reload.status,
+                   "premise: the shared notice did stop the waiter it stood for"
+      assert_equal "queued", own_waiter.reload.status,
+                   "the shared notice never spoke for an opted-out agent's waiter, committed notice or not"
+    end
+
+    # The other half of the same window: the waiter can be cancelled by a door
+    # this fix does not touch — its anchor being deleted — while its notice
+    # transaction is still open. What must not survive is a "task" notice naming a
+    # task that has left the queue: a stop button for work that can no longer be
+    # stopped, and one nothing collects, since a cancelled task is never promoted.
+    test "no per-deferral notice survives a waiter cancelled while its notice was being posted" do
+      OrchestratorPolicy.create!(
+        policy_type: "scheduling", scope_type: "User", scope_id: second_agent.id,
+        config: { "coalesce_pending_tasks" => false }
+      )
+      occupy_slot!
+      AiAgentJob.new.perform(@agent.id, "comment_created", context_for(comment("coalescing")))
+      anchor = comment("opt-out")
+
+      delete_anchor_in_window = lambda do |*_args|
+        anchor.destroy! if Comment.exists?(anchor.id)
+        "another task is running"
+      end
+
+      Orchestration::AgentOrchestrator.stub :waiting_reason_text, delete_anchor_in_window do
+        AiAgentJob.new.perform(second_agent.id, "comment_created", context_for(anchor))
+      end
+
+      own_waiter = Task.where(agent: second_agent, topic_id: @topic.id).sole
+      assert_equal "cancelled", own_waiter.reload.status,
+                   "premise: deleting the anchor cancelled the waiter mid-window"
+      left_queue = Task.where.not(status: "queued").pluck(:id)
+      assert_empty Comment.where(creative_id: @creative.id, topic_id: @topic.id, user_id: nil,
+                                 waiting_notice_scope: Comment::WAITING_NOTICE_TASK,
+                                 waiting_notice_task_id: left_queue).pluck(:id),
+                   "a per-deferral notice for a task that has left the queue stops nothing"
+    end
+
+    # A waiter parked before the scope was recorded says nothing about which kind
+    # of notice speaks for it. Keep those on the behaviour they were parked under
+    # rather than guess: excluding them would leave an in-flight wait with no
+    # stop control at all.
+    test "a shared notice still cancels a queued waiter that recorded no notice scope" do
+      shared, own_notice, _shared_waiter, own_waiter = mixed_notice_topic!
+      Comment.where(id: own_notice.id).delete_all
+      Task.where(id: own_waiter.id).update_all(waiting_notice_scope: nil)
+
+      shared.destroy!
+
+      assert_equal "cancelled", own_waiter.reload.status,
+                   "nothing on the row says otherwise, so the old behaviour stands"
+    end
+
     # A per-deferral notice speaks for one waiter, so promoting that waiter ends
     # what it describes. The drained guard is the *shared* notice's question: with
     # the opt-out and a second waiter still parked, it keeps every notice up —


### PR DESCRIPTION
## Summary

Follow-up to #1456. The last review round on that PR raised a P2 on `Comment#represented_queued_waiters` (`comment.rb:455`); the fix was written and verified but never landed before the merge, so `main` still carries the defect.

A waiter row and the "⏳ waiting" notice that speaks for it commit in **two separate transactions**:

- `AiAgentJob#park_deferred_waiter` commits the waiter inside `Task.transaction`, then posts the notice afterwards.
- `AgentOrchestrator` does the same at the late-admission door.

Between those two steps an agent that opted out of coalescing has a `queued` waiter with **no per-deferral notice naming it yet**. `represented_queued_waiters` classified waiters by looking at which sibling notices survive, so inside that window the topic's shared notice reads the opted-out waiter as one of its own and cancels it.

The result is a silently discarded turn: the work is dropped, and because the waiter's own notice had not been posted yet, nothing is left on screen to say a wait ever happened.

`comment.rb` already states the rule this violates, recorded when the same inference was removed from the *notice* side in #1456:

> A row cannot be classified by its neighbours when the neighbours are a different kind.

That rule was applied to notice rows only. Waiter rows were still classified by their neighbours. This PR extends it to the remaining row kind.

## Change

Record on the waiter which kind of notice speaks for it, written by the statement that creates the row — under the admission lock, before any notice exists — on **both** parking doors.

- New nullable column `tasks.waiting_notice_scope` (migration `20260727010000`, idempotent `up`/`down`).
- `AiAgentJob` and `AgentOrchestrator` set the scope when parking a waiter.
- `Comment#task_claims_own_notice?` reads the answer off the waiter instead of off the surrounding notices.

No backfill, on purpose. A waiter parked by the pre-existing code says nothing about which notice spoke for it, so those rows keep the old sibling-notice answer: widening the exclusion would discard work, narrowing it would leave an in-flight wait with no stop control.

This also removes a second-order problem: fold, notice deletion, and the stop control each re-derived the coalescing policy at a different moment, so a policy change mid-wait could be answered three different ways. They now read one answer recorded on the row.

## Tests

Three tests added to `ai_agent_job_topic_slot_test.rb`:

1. **Enqueue door** — deleting the shared notice spares an opt-out waiter whose own notice has not committed. Injected at `waiting_reason_text`, the call made after the waiter commits and before the notice row exists, with the deletion running through the real `Comment#destroy` rather than by calling the cancel path directly.
2. **Late-admission door** — the same window on the other door.
3. **Negative control** — a shared notice *still* cancels a queued waiter that recorded no notice scope, so the fix is not "keep every waiter that has no notice".

All three were confirmed **red on unmodified `main`** before the fix was applied (`expected "queued", actual "cancelled"` on both doors), with the negative control green.

## Verification

| | runs | failures | errors |
|---|---|---|---|
| `main` baseline (non-system suite) | 2321 | 0 | 1 |
| this branch | 2324 | 0 | 1 |

The single error (`GoogleAuthTest#test_sets_avatar_url...`, an unstubbed WebMock call) reproduces identically on pristine `main` and passes in isolation on both — suite-order pollution, unrelated. Rubocop clean.

Migration `20260727010000` sorts after #1457's `20260727000002`; no schema conflict.
