### PR TITLE
feat: drop a dispatch whose comment an in-flight turn already delivered

### DIFF
--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -11,6 +11,10 @@ production: &production
     class: Collavre::CommentPushDeliverySweepJob
     queue: default
     schedule: every minute
+  restore_dropped_dispatches:
+    class: Collavre::RestoreDroppedDispatchesJob
+    queue: default
+    schedule: every 10 minutes
   github_webhook_delivery_prune:
     class: CollavreGithub::WebhookDeliveryPruneJob
     queue: default
@@ -27,6 +31,10 @@ desktop:
     class: Collavre::CommentPushDeliverySweepJob
     queue: default
     schedule: every minute
+  restore_dropped_dispatches:
+    class: Collavre::RestoreDroppedDispatchesJob
+    queue: default
+    schedule: every 10 minutes
   github_webhook_delivery_prune:
     class: CollavreGithub::WebhookDeliveryPruneJob
     queue: default
@@ -45,6 +53,10 @@ development:
     class: Collavre::CommentPushDeliverySweepJob
     queue: default
     schedule: every minute
+  restore_dropped_dispatches:
+    class: Collavre::RestoreDroppedDispatchesJob
+    queue: default
+    schedule: every 10 minutes
   github_webhook_delivery_prune:
     class: CollavreGithub::WebhookDeliveryPruneJob
     queue: default

--- a/docs/superpowers/plans/2026-07-28-drop-already-delivered-dispatch.md
+++ b/docs/superpowers/plans/2026-07-28-drop-already-delivered-dispatch.md
@@ -93,6 +93,33 @@ a different question, and a wider floor would change promotion for waiters this
 feature never touches. `StuckDetector`'s self-heal tests are the live proof —
 they promote waiters whose anchors are not the newest comment around.
 
+### 3b. The drop has to be as reversible as the parking it replaced
+
+The record is written *before* the payload reaches the model — that is what makes
+the long streaming window droppable at all. So the drop can outlive the turn that
+justified it: reply-comment creation, client construction or the LLM request can
+still raise, and the covering task ends `failed`.
+
+A parked waiter survives that ending. `DELIVERED_STATUSES` deliberately excludes
+`failed`/`cancelled`/`escalated` — "a turn that died may never have delivered
+anything, so the comments it held stay answerable" — and promotion re-reads the
+covering turn's status before deciding. A *dropped* dispatch has no row left to
+re-read anything, so without a counterpart the two doors mean different things by
+the same failure, and the comment is answered by nobody.
+
+`DeliveryRecord.restore!` is the counterpart:
+
+| | |
+|---|---|
+| **Trigger** | `Task` `after_update_commit`, status ∈ `UNDELIVERED_TERMINAL_STATUSES` (= terminal − `DELIVERED_STATUSES`, asserted by a drift test). A callback rather than a call site because `AiAgentJob`'s rescue and `StuckDetector` are two doors onto a dead turn, and only one runs for a killed process. |
+| **What comes back** | Recorded ids **minus ids any sibling task already claims** as its anchor or merged block. A waiter parked before the turn assembled was never dropped, and promotion owns its fate; restoring it too would put two turns on one comment. Measured, not inferred from what the drop thinks it dropped. |
+| **Eligibility re-asked** | `public_only.without_approval_action`, still in this topic/creative, not the agent's own. The record was written when the comment was eligible; it may not be now. |
+| **Shape** | One ordinary dispatch per orphan via `reanchor_payload`, with `history_delivered_comment_ids` / `merged_comment_ids` / `acquired_comment_id` stripped — the dispatch that was discarded, not a descendant of the turn that discarded it. Ordinary admission folds them back together rather than a second merge rule beside `TaskCoalescer`'s. |
+
+Stripping the record is also what bounds it: a restored turn is anchored at the
+newest orphan, so there is nothing above its anchor left to record, and a second
+failure restores nothing.
+
 ### 4. Exclusions
 
 - **Review requests are never dropped.** A review is bound to the comment it
@@ -130,3 +157,10 @@ drop is logged with the covering task id.
    promotion and its waiting notice removed.
 8. A review comment is never dropped.
 9. Policy off ⇒ no drop.
+10. A dropped dispatch comes back when the covering turn ends `failed`, and when
+    it ends `cancelled`. Negative controls: a `done` turn restores nothing; a
+    comment that still has a task of its own is not restored a second time; a
+    comment deleted or made private while the turn ran is not restored; the
+    restored payload carries none of the dead turn's bookkeeping.
+11. Drift guard: `UNDELIVERED_TERMINAL_STATUSES` is exactly the terminal
+    statuses `DELIVERED_STATUSES` leaves out.

--- a/docs/superpowers/plans/2026-07-28-drop-already-delivered-dispatch.md
+++ b/docs/superpowers/plans/2026-07-28-drop-already-delivered-dispatch.md
@@ -1,0 +1,132 @@
+# Drop a dispatch whose comment an in-flight turn already delivered
+
+## Problem
+
+Event A and event B arrive as a burst. The agent starts a turn for A. B's
+dispatch finds the topic slot taken, parks a waiter, and posts a "⏳" notice.
+When A's turn ends the waiter is promoted and the agent speaks a second time.
+
+For a **non-session** agent that second turn is usually redundant:
+`MessageBuilder#append_chat_history` reads the topic's comments **at job
+execution time**, so if B was committed before A's turn assembled its payload,
+B's text is already inside A's context. The agent has read it. Queueing B costs
+a waiting notice, a promotion round-trip and a redundant reply.
+
+For a **session-backed** agent it is not redundant at all:
+`SessionContextResolver#incremental_payload` keeps only the `:trigger` message,
+so A's turn never carried B's text. Dropping B there is message loss, not
+de-duplication. #1456's coalescing (merge into `merged_comment_ids`) stays the
+correct answer for that case.
+
+So "the agent is busy" is the wrong predicate. The right one is **"this turn
+already delivered that comment"** — and whether it did is a property of the
+resolved payload, not of the agent's status.
+
+## Approach
+
+Record what was delivered; read the record at the dispatch doors.
+
+### 1. Measure delivery from the payload that is actually sent
+
+`MessageBuilder` tags each `:chat_history` message with the comment id it came
+from. `AiAgentService` then reads the ids off the **resolved** payload
+(`SessionContextResolver#resolve`), after session filtering, immediately before
+streaming starts.
+
+Session-awareness falls out of this rather than being a second switch: a
+session agent's resolved payload contains no `:chat_history` messages at all, so
+the recorded set is empty and nothing is ever dropped for it.
+
+### 2. Record only what the turn was not created for
+
+The recorded set is restricted to ids **greater than the turn's anchor id**.
+
+Chat history normally holds comments older than the anchor — the ordinary
+backlog of the topic. A history comment *newer* than the anchor can only be one
+that landed after this turn was dispatched: exactly the burst case. Restricting
+to that keeps an old backlog comment from silencing a waiter that was parked for
+it long ago.
+
+Ids, not `created_at`: a burst is written by several processes and the clock is
+whichever one wrote the row (same reason `MergedTriggerComments` orders by id).
+
+Stored on the task payload under `TaskCoalescer::HISTORY_DELIVERED_KEY`
+(`"history_delivered_comment_ids"`), alongside `merged_comment_ids` and
+`acquired_comment_id`. Nothing is written until the payload resolves, so a turn
+that is running but has not assembled yet drops nothing — fail open.
+
+### 3. Read it at every door
+
+Three doors lead into the queue, and the record has to be read at all of them
+(#1456's repeated defect was closing one of two):
+
+| Door | Change |
+|---|---|
+| `AgentOrchestrator#enqueue_jobs` | new drop gate before `perform_later`/`park_waiter` |
+| `AiAgentJob#admit_or_defer!` (late admission) | same gate |
+| `AgentOrchestrator.refresh_deferred_context!` (promotion) | free — `delivered_comment_ids` gains the new key, so an already-parked waiter whose anchor was swallowed is filtered out and cancelled by the existing path |
+
+The gate is `Task.delivered_in_flight_for_comment?(agent_id, comment_id, topic_id:, creative_id:, trigger_event_name:)`, scoped exactly like
+`delivered_comment_ids` (same agent, topic, creative, trigger event) and
+restricted to `DELIVERED_STATUSES`.
+
+`duplicate_running_for_comment?` stays as-is. It answers a different question
+(the same comment anchoring two in-flight turns, unscoped by topic) and folding
+the two would widen either its scope or the new one's.
+
+### 3a. The promotion floor this opens up
+
+Filtering a waiter's own anchor out of the refresh's candidate scope has a
+consequence the existing code never had to handle: the refresh picks the newest
+*remaining* eligible comment, and with the anchor gone that is an **older** one.
+The waiter would answer a comment it was not dispatched for, that predates the
+one it was, and that the covering turn already had in view.
+
+So when — and only when — `delivered_ids` contains the waiter's own anchor, the
+candidate scope also gets a floor at that anchor id. Nothing left at or above it
+means the waiter has nothing to say, and the existing `unless latest_comment`
+branch cancels it.
+
+Deliberately not a blanket "the refresh never moves backwards": an anchor that
+left the turn for some other reason (moved to another creative, made private) is
+a different question, and a wider floor would change promotion for waiters this
+feature never touches. `StuckDetector`'s self-heal tests are the live proof —
+they promote waiters whose anchors are not the newest comment around.
+
+### 4. Exclusions
+
+- **Review requests are never dropped.** A review is bound to the comment it
+  quotes; `ReviewHandler` can only run as its own turn. Being read as history is
+  not being answered.
+- Private and approval-action comments never enter history
+  (`public_only.without_approval_action`), so they are never recorded.
+
+### 5. Policy switch
+
+`scheduling.drop_delivered_dispatches`, default `true`, resolved per agent like
+`coalesce_pending_tasks_for?`. Off ⇒ recording still happens (harmless, and it
+keeps the promotion filter honest) but the two dispatch doors do not drop.
+
+## Evidence trail
+
+No ghost `cancelled` row is created for a dropped dispatch. The evidence lives
+on the covering task: "which turn ate comment N" is a query over
+`history_delivered_comment_ids`, the same shape as `merged_comment_ids`. The
+drop is logged with the covering task id.
+
+## Tests (each red before its fix)
+
+1. `MessageBuilder#build` tags history messages with `comment_id`.
+2. Resolved payload for a session agent contains no `:chat_history` → recorded
+   set empty (negative control for the whole feature).
+3. `AiAgentService` records ids newer than the anchor; records nothing for ids
+   older than the anchor (negative control).
+4. `Task.delivered_in_flight_for_comment?` — true/false across statuses, and
+   false across a different topic / creative / agent / trigger event.
+5. `AgentOrchestrator.dispatch` creates **no task and no waiting notice** when
+   covered; negative control: not covered ⇒ waiter + notice as today.
+6. `AiAgentJob` late door drops the same case.
+7. A waiter parked *before* the covering turn assembled is cancelled at
+   promotion and its waiting notice removed.
+8. A review comment is never dropped.
+9. Policy off ⇒ no drop.

--- a/docs/superpowers/plans/2026-07-28-drop-already-delivered-dispatch.md
+++ b/docs/superpowers/plans/2026-07-28-drop-already-delivered-dispatch.md
@@ -112,13 +112,48 @@ the same failure, and the comment is answered by nobody.
 | | |
 |---|---|
 | **Trigger** | `Task` `after_update_commit`, status ∈ `UNDELIVERED_TERMINAL_STATUSES` (= terminal − `DELIVERED_STATUSES`, asserted by a drift test). A callback rather than a call site because `AiAgentJob`'s rescue and `StuckDetector` are two doors onto a dead turn, and only one runs for a killed process. |
-| **What comes back** | Recorded ids **minus ids any sibling task already claims** as its anchor or merged block. A waiter parked before the turn assembled was never dropped, and promotion owns its fate; restoring it too would put two turns on one comment. Measured, not inferred from what the drop thinks it dropped. |
+| **What comes back** | `dropped_dispatch_comment_ids` — the drops this turn *took*, written at the moment it took them — minus ids any sibling task already claims. See "Which set the restore reads" below. |
 | **Eligibility re-asked** | `public_only.without_approval_action`, still in this topic/creative, not the agent's own. The record was written when the comment was eligible; it may not be now. |
-| **Shape** | One ordinary dispatch per orphan via `reanchor_payload`, with `history_delivered_comment_ids` / `merged_comment_ids` / `acquired_comment_id` stripped — the dispatch that was discarded, not a descendant of the turn that discarded it. Ordinary admission folds them back together rather than a second merge rule beside `TaskCoalescer`'s. |
+| **Shape** | One ordinary dispatch per orphan via `reanchor_payload`, with `dropped_dispatch_comment_ids` / `history_delivered_comment_ids` / `merged_comment_ids` / `acquired_comment_id` stripped — the dispatch that was discarded, not a descendant of the turn that discarded it. Ordinary admission folds them back together rather than a second merge rule beside `TaskCoalescer`'s. |
+| **Read off the row** | `restore!` re-reads the payload from the database. The drop record is written by the *refused dispatch*, in another process, onto a row the dying turn's own object was loaded before — so the in-memory payload reaching the callback predates every drop it is being asked about. |
 
 Stripping the record is also what bounds it: a restored turn is anchored at the
 newest orphan, so there is nothing above its anchor left to record, and a second
 failure restores nothing.
+
+### 3a. Which set the restore reads
+
+Two records, because the drop and the restore ask opposite questions.
+
+`history_delivered_comment_ids` answers "has the agent been given this comment?"
+Chat history is the whole topic — `Matcher`'s exclusive routings do not filter
+it — so every agent in a topic reads every public comment in it, including ones
+addressed to somebody else. That is the right predicate for the *drop*, which is
+only ever asked downstream of `Matcher` about a dispatch that already exists.
+
+It is the wrong predicate for the *restore*, which creates a dispatch per id it
+decides on. Two false positives follow from reading it there, and neither is
+visible as a missing `Task` row:
+
+- A comment routed past this agent (an exclusive `@mention` of someone else) is
+  in the history record but never produced a dispatch. Restoring it dispatches
+  the agent onto a message that was never meant for it, past `Matcher` entirely.
+- An `:immediate` decision enqueues its job at `enqueue_jobs` and its `Task` row
+  is created only when that job runs. In between there is a live dispatch with
+  nothing in the table to show for it, and restoring it puts a second turn on a
+  comment that already has one.
+
+So `dropped_dispatch_comment_ids` records the drops themselves.
+`DeliveryRecord.claim_drop!` writes it, and the drop is *conditional on that
+write succeeding*: it re-reads the covering turn's status under a row lock and
+returns `false` if the turn has already ended — a turn that has ended has
+already run its restore, so a record written afterwards would strand the
+comment. A caller told `false` dispatches normally. Refusing a sound drop costs
+a redundant turn; taking an unsound one costs the message.
+
+The sibling-claim subtraction stays as a second guard: the record already
+excludes what was never dropped, and this excludes what has since acquired a row
+of its own.
 
 ### 4. Exclusions
 
@@ -137,8 +172,9 @@ keeps the promotion filter honest) but the two dispatch doors do not drop.
 ## Evidence trail
 
 No ghost `cancelled` row is created for a dropped dispatch. The evidence lives
-on the covering task: "which turn ate comment N" is a query over
-`history_delivered_comment_ids`, the same shape as `merged_comment_ids`. The
+on the covering task: "which turn read comment N" is a query over
+`history_delivered_comment_ids` and "which turn refused a dispatch for it" over
+`dropped_dispatch_comment_ids`, both the same shape as `merged_comment_ids`. The
 drop is logged with the covering task id.
 
 ## Tests (each red before its fix)
@@ -164,3 +200,9 @@ drop is logged with the covering task id.
     restored payload carries none of the dead turn's bookkeeping.
 11. Drift guard: `UNDELIVERED_TERMINAL_STATUSES` is exactly the terminal
     statuses `DELIVERED_STATUSES` leaves out.
+12. Reading a comment is not by itself a dropped dispatch: with a history record
+    and no claimed drop, the drop record is empty. `claim_drop!` records against
+    an in-flight turn and refuses one that has ended.
+13. A comment routed to somebody else is **not** restored to this agent, and a
+    dispatch still sitting in the job queue is not restored underneath itself —
+    the two false positives of inferring drops from absent `Task` rows.

--- a/engines/collavre/app/jobs/collavre/ai_agent_job.rb
+++ b/engines/collavre/app/jobs/collavre/ai_agent_job.rb
@@ -272,9 +272,10 @@ module Collavre
         Rails.logger.info("AiAgentJob cancelled for task #{task.id}: trigger message deleted")
         # Where a turn stopped mid-answer settles. The cancel was committed in
         # another process while this worker was inside the provider call, so
-        # Task's status callback declined to decide (Task#stopped_mid_turn?) and
-        # this is the first moment either answer exists: AiAgentService's ensure
-        # has recorded whether the payload got there on the way up to here.
+        # Task's status callback declined to decide
+        # (Task#ended_while_worker_settles?) and this is the first moment either
+        # answer exists: AiAgentService's ensure has recorded whether the
+        # payload got there on the way up to here.
         # Reloaded because the status was written to the row by somebody else.
         Orchestration::DeliveryRecord.restore_if_undelivered!(task.reload)
       rescue StandardError => e
@@ -288,8 +289,18 @@ module Collavre
       ensure
         # Guarantee resource release for all paths except pending_approval
         tracker.release!(resource_id, tokens_used: 0) if should_release && tracker && resource_id
-        if task&.trigger_event_payload&.key?("topic") && %w[done failed cancelled escalated].include?(task.reload.status)
-          Orchestration::AgentOrchestrator.dequeue_next_for_topic(task.topic_id, task.creative_id)
+        settled_task = task&.reload
+        if settled_task &&
+           Orchestration::DeliveryRecord.worker_settling?(settled_task.trigger_event_payload)
+          # StuckDetector failed this row while this worker was still in the
+          # provider call. The worker is out now, so remove the deferral and ask
+          # the restore question from the handoff evidence AiAgentService wrote.
+          Orchestration::DeliveryRecord.settle_worker!(settled_task)
+          Orchestration::DeliveryRecord.restore_if_undelivered!(settled_task.reload)
+        end
+        if settled_task&.trigger_event_payload&.key?("topic") &&
+           %w[done failed cancelled escalated].include?(settled_task.status)
+          Orchestration::AgentOrchestrator.dequeue_next_for_topic(settled_task.topic_id, settled_task.creative_id)
         end
       end
     end

--- a/engines/collavre/app/jobs/collavre/ai_agent_job.rb
+++ b/engines/collavre/app/jobs/collavre/ai_agent_job.rb
@@ -156,6 +156,20 @@ module Collavre
           return
         end
 
+        # Guard: the same question the orchestrator asks before enqueueing, asked
+        # again where the answer is authoritative. This job can sit in the queue
+        # while the covering turn assembles its payload, so a dispatch that was
+        # not droppable at enqueue time can be droppable by the time it runs —
+        # and the enqueue door alone would leave that window open.
+        covering = Orchestration::DeliveryRecord.covering_task(agent, comment_id, context, event_name)
+        if covering
+          Rails.logger.info(
+            "[AiAgentJob] Skipping dispatch: comment #{comment_id} was already delivered to " \
+            "agent #{agent.id} by in-flight task #{covering.id} (event=#{event_name})"
+          )
+          return
+        end
+
         # Guard: the Scheduler's topic-concurrency check counts Task rows, but
         # the row for an :immediate decision is only created *here*. A burst of
         # comments dispatched before the first job runs therefore all see an

--- a/engines/collavre/app/jobs/collavre/ai_agent_job.rb
+++ b/engines/collavre/app/jobs/collavre/ai_agent_job.rb
@@ -161,8 +161,11 @@ module Collavre
         # while the covering turn assembles its payload, so a dispatch that was
         # not droppable at enqueue time can be droppable by the time it runs —
         # and the enqueue door alone would leave that window open.
+        #
+        # As at the enqueue door, the drop only happens if the covering turn
+        # records it — otherwise this dispatch has nobody to restore it.
         covering = Orchestration::DeliveryRecord.covering_task(agent, comment_id, context, event_name)
-        if covering
+        if covering && Orchestration::DeliveryRecord.claim_drop!(covering, comment_id)
           Rails.logger.info(
             "[AiAgentJob] Skipping dispatch: comment #{comment_id} was already delivered to " \
             "agent #{agent.id} by in-flight task #{covering.id} (event=#{event_name})"

--- a/engines/collavre/app/jobs/collavre/ai_agent_job.rb
+++ b/engines/collavre/app/jobs/collavre/ai_agent_job.rb
@@ -270,6 +270,13 @@ module Collavre
       rescue CancelledError
         # Task status already set to "cancelled" by Comment callback
         Rails.logger.info("AiAgentJob cancelled for task #{task.id}: trigger message deleted")
+        # Where a turn stopped mid-answer settles. The cancel was committed in
+        # another process while this worker was inside the provider call, so
+        # Task's status callback declined to decide (Task#stopped_mid_turn?) and
+        # this is the first moment either answer exists: AiAgentService's ensure
+        # has recorded whether the payload got there on the way up to here.
+        # Reloaded because the status was written to the row by somebody else.
+        Orchestration::DeliveryRecord.restore_if_undelivered!(task.reload)
       rescue StandardError => e
         task.update!(status: "failed")
         # Fail workflow if this is a sub-task

--- a/engines/collavre/app/jobs/collavre/restore_dropped_dispatches_job.rb
+++ b/engines/collavre/app/jobs/collavre/restore_dropped_dispatches_job.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Collavre
+  # Backstop for Orchestration::DeliveryRecord.restore!, which runs from a
+  # status callback and therefore after the point where its own failure could
+  # still be undone. See DeliveryRecord.restore_missed! for why nothing has to
+  # be written down for this to work.
+  #
+  # Scheduled in config/recurring.yml.
+  class RestoreDroppedDispatchesJob < ApplicationJob
+    queue_as :default
+
+    def perform
+      Orchestration::DeliveryRecord.restore_missed!
+    end
+  end
+end

--- a/engines/collavre/app/models/collavre/task.rb
+++ b/engines/collavre/app/models/collavre/task.rb
@@ -88,9 +88,10 @@ module Collavre
     def ended_undelivered?
       payload = trigger_event_payload
       # Asked first, so that a row carrying both records is read as undelivered.
-      # The two are written off one boundary and cannot both be true, but the
-      # cost of the two errors is not symmetric: restoring a turn that delivered
-      # answers a comment twice, and not restoring one that did not loses it.
+      # A resumed turn can legitimately carry both: an earlier attempt handed
+      # off, while a later one failed before doing so. DeliveryRecord restores
+      # that row but subtracts the comment ids the successful attempts carried,
+      # leaving only the later attempt's undelivered comments.
       return true if status == "done" && Orchestration::DeliveryRecord.handoff_failed?(payload)
 
       # An ending is undelivered because the payload never reached the provider,

--- a/engines/collavre/app/models/collavre/task.rb
+++ b/engines/collavre/app/models/collavre/task.rb
@@ -120,9 +120,19 @@ module Collavre
     # A status callback rather than a call site: AiAgentJob's rescue and
     # StuckDetector both end a turn this way, and only one of them runs for a
     # process that was killed outright.
+    #
+    # `done` is an undelivered ending too when the turn recorded that its
+    # request never reached the provider: AiClient#chat catches the error and
+    # AiAgentJob finishes the task normally, so the status alone cannot say it.
+    # Read off this object rather than the row because the flag is written by
+    # this turn's own service, in this process, immediately before the status
+    # update that fires this callback — unlike DROPPED_KEY, which the refused
+    # dispatch writes from another process and restore! therefore re-reads.
     def ended_without_delivering?
-      saved_change_to_attribute?("status") &&
-        status.in?(Orchestration::DeliveryRecord::UNDELIVERED_TERMINAL_STATUSES)
+      return false unless saved_change_to_attribute?("status")
+      return true if status.in?(Orchestration::DeliveryRecord::UNDELIVERED_TERMINAL_STATUSES)
+
+      status == "done" && Orchestration::DeliveryRecord.handoff_failed?(trigger_event_payload)
     end
 
     def restore_undelivered_dispatches

--- a/engines/collavre/app/models/collavre/task.rb
+++ b/engines/collavre/app/models/collavre/task.rb
@@ -155,7 +155,30 @@ module Collavre
     # update that fires this callback — unlike DROPPED_KEY, which the refused
     # dispatch writes from another process and restore! therefore re-reads.
     def ended_without_delivering?
-      saved_change_to_attribute?("status") && ended_undelivered?
+      return false unless saved_change_to_attribute?("status")
+      return false if stopped_mid_turn?
+
+      ended_undelivered?
+    end
+
+    # A turn stopped while its worker is still inside the provider call, whose
+    # own account of the handoff does not exist yet.
+    #
+    # Stop is committed from a web request (TasksController#cancel) or from the
+    # anchor comment's deletion — in another process, while the worker is inside
+    # AiClient#chat. AgentLifecycleManager notices at the next poll, up to
+    # CANCEL_CHECK_INTERVAL later, and only then does AiAgentService's ensure
+    # write down whether the payload reached the provider. This callback fires
+    # before all of that: whichever way it decides, it decides without evidence,
+    # off a payload the canceller loaded before the turn began.
+    #
+    # So it declines, and the question is asked where the turn settles —
+    # AiAgentJob's CancelledError teardown, once the record is written. Behind
+    # that, DeliveryRecord.restore_missed! covers a cancellation with no live
+    # worker to settle anything (an agent unregistering, stuck recovery), and a
+    # worker killed before it reaches its own rescue.
+    def stopped_mid_turn?
+      status == "cancelled" && status_before_last_save == "running"
     end
 
     # Best effort, deliberately: this runs after the turn's own status is

--- a/engines/collavre/app/models/collavre/task.rb
+++ b/engines/collavre/app/models/collavre/task.rb
@@ -86,9 +86,22 @@ module Collavre
     # because a sweep deciding "terminal" where the callback decides this is how
     # a backstop comes to re-answer comments the turn had already answered.
     def ended_undelivered?
-      return true if status.in?(Orchestration::DeliveryRecord::UNDELIVERED_TERMINAL_STATUSES)
+      payload = trigger_event_payload
+      # Asked first, so that a row carrying both records is read as undelivered.
+      # The two are written off one boundary and cannot both be true, but the
+      # cost of the two errors is not symmetric: restoring a turn that delivered
+      # answers a comment twice, and not restoring one that did not loses it.
+      return true if status == "done" && Orchestration::DeliveryRecord.handoff_failed?(payload)
 
-      status == "done" && Orchestration::DeliveryRecord.handoff_failed?(trigger_event_payload)
+      # An ending is undelivered because the payload never reached the provider,
+      # not because of the name of the ending. A turn stopped — or broken — after
+      # the handoff has been read by the agent along with everything it
+      # swallowed, and the product already shows that turn with its partial
+      # reply. Only a turn that got far enough to record the handoff is exempt;
+      # everything quieter than that still owes its dispatches back.
+      return false if Orchestration::DeliveryRecord.handed_off?(payload)
+
+      status.in?(Orchestration::DeliveryRecord::UNDELIVERED_TERMINAL_STATUSES)
     end
 
     private

--- a/engines/collavre/app/models/collavre/task.rb
+++ b/engines/collavre/app/models/collavre/task.rb
@@ -107,18 +107,22 @@ module Collavre
       saved_change_to_attribute?("status") && terminal_status?
     end
 
-    # This turn was dropping other agents' dispatches on the strength of having
-    # read their comments, and then died without answering anything. Those
-    # dispatches have to come back — see Orchestration::DeliveryRecord.restore!.
+    # This turn refused other dispatches on the strength of having read their
+    # comments, and then died without answering anything. Those dispatches have
+    # to come back — see Orchestration::DeliveryRecord.restore!.
+    #
+    # Only the status transition is decided here. Whether anything was actually
+    # refused is asked inside restore!, off the persisted row: the drop record
+    # is written by the refused dispatch in another process, so this object's
+    # payload predates it and a check here would read `none` on every turn that
+    # dropped something.
     #
     # A status callback rather than a call site: AiAgentJob's rescue and
     # StuckDetector both end a turn this way, and only one of them runs for a
     # process that was killed outright.
     def ended_without_delivering?
-      return false unless saved_change_to_attribute?("status")
-      return false unless status.in?(Orchestration::DeliveryRecord::UNDELIVERED_TERMINAL_STATUSES)
-
-      Orchestration::DeliveryRecord.ids_in(trigger_event_payload).any?
+      saved_change_to_attribute?("status") &&
+        status.in?(Orchestration::DeliveryRecord::UNDELIVERED_TERMINAL_STATUSES)
     end
 
     def restore_undelivered_dispatches

--- a/engines/collavre/app/models/collavre/task.rb
+++ b/engines/collavre/app/models/collavre/task.rb
@@ -157,29 +157,29 @@ module Collavre
     # dispatch writes from another process and restore! therefore re-reads.
     def ended_without_delivering?
       return false unless saved_change_to_attribute?("status")
-      return false if stopped_mid_turn?
+      return false if ended_while_worker_settles?
 
       ended_undelivered?
     end
 
-    # A turn stopped while its worker is still inside the provider call, whose
-    # own account of the handoff does not exist yet.
+    # A turn ended from another process while its worker is still inside the
+    # provider call, whose own account of the handoff does not exist yet.
     #
-    # Stop is committed from a web request (TasksController#cancel) or from the
-    # anchor comment's deletion — in another process, while the worker is inside
-    # AiClient#chat. AgentLifecycleManager notices at the next poll, up to
-    # CANCEL_CHECK_INTERVAL later, and only then does AiAgentService's ensure
-    # write down whether the payload reached the provider. This callback fires
-    # before all of that: whichever way it decides, it decides without evidence,
-    # off a payload the canceller loaded before the turn began.
+    # Stop is committed from a web request, and StuckDetector can fail a running
+    # row from its recurring job. Both can beat AiAgentService's ensure, which
+    # writes whether the payload reached the provider only after the call exits.
+    # This callback fires before that evidence exists.
     #
     # So it declines, and the question is asked where the turn settles —
-    # AiAgentJob's CancelledError teardown, once the record is written. Behind
-    # that, DeliveryRecord.restore_missed! covers a cancellation with no live
-    # worker to settle anything (an agent unregistering, stuck recovery), and a
-    # worker killed before it reaches its own rescue.
-    def stopped_mid_turn?
-      status == "cancelled" && status_before_last_save == "running"
+    # AiAgentJob's teardown, once the record is written. Behind that,
+    # DeliveryRecord.restore_missed! covers an ending with no live worker to
+    # settle anything.
+    def ended_while_worker_settles?
+      return false unless status_before_last_save == "running"
+      return true if status == "cancelled"
+
+      status == "failed" &&
+        Orchestration::DeliveryRecord.worker_settling?(trigger_event_payload)
     end
 
     # Best effort, deliberately: this runs after the turn's own status is

--- a/engines/collavre/app/models/collavre/task.rb
+++ b/engines/collavre/app/models/collavre/task.rb
@@ -78,6 +78,19 @@ module Collavre
       broadcast_stop_button_removal if terminal_status?
     end
 
+    # What a persisted row says about whether this turn ever handed anything
+    # over — ended_without_delivering? without the transition.
+    #
+    # Asked twice: by the callback of a status change, and by
+    # RestoreDroppedDispatchesJob of a row it finds afterwards. Written once,
+    # because a sweep deciding "terminal" where the callback decides this is how
+    # a backstop comes to re-answer comments the turn had already answered.
+    def ended_undelivered?
+      return true if status.in?(Orchestration::DeliveryRecord::UNDELIVERED_TERMINAL_STATUSES)
+
+      status == "done" && Orchestration::DeliveryRecord.handoff_failed?(trigger_event_payload)
+    end
+
     private
 
     def trigger_loop_candidate?
@@ -129,14 +142,22 @@ module Collavre
     # update that fires this callback — unlike DROPPED_KEY, which the refused
     # dispatch writes from another process and restore! therefore re-reads.
     def ended_without_delivering?
-      return false unless saved_change_to_attribute?("status")
-      return true if status.in?(Orchestration::DeliveryRecord::UNDELIVERED_TERMINAL_STATUSES)
-
-      status == "done" && Orchestration::DeliveryRecord.handoff_failed?(trigger_event_payload)
+      saved_change_to_attribute?("status") && ended_undelivered?
     end
 
+    # Best effort, deliberately: this runs after the turn's own status is
+    # committed, so an exception here propagates back into the update! that
+    # ended the turn — and AiAgentJob's rescue answers that by writing `failed`
+    # over a turn that had in fact finished and answered. The restore is
+    # reconstructible from the row it was given, and
+    # DeliveryRecord.restore_missed! is what asks again.
     def restore_undelivered_dispatches
       Orchestration::DeliveryRecord.restore!(self)
+    rescue StandardError => e
+      Rails.logger.error(
+        "[Task] Restore failed for task #{id}: #{e.class}: #{e.message} — " \
+        "leaving it to the restore sweep"
+      )
     end
 
     def terminal_status?

--- a/engines/collavre/app/models/collavre/task.rb
+++ b/engines/collavre/app/models/collavre/task.rb
@@ -25,6 +25,7 @@ module Collavre
 
     after_update_commit :check_trigger_loop_completion, if: :trigger_loop_candidate?
     after_update_commit :broadcast_stop_button_removal, if: :became_terminal?
+    after_update_commit :restore_undelivered_dispatches, if: :ended_without_delivering?
 
     scope :running_for_topic, ->(topic_id, creative_id = nil) {
       rel = where(topic_id: topic_id, status: %w[running delegated])
@@ -104,6 +105,24 @@ module Collavre
 
     def became_terminal?
       saved_change_to_attribute?("status") && terminal_status?
+    end
+
+    # This turn was dropping other agents' dispatches on the strength of having
+    # read their comments, and then died without answering anything. Those
+    # dispatches have to come back — see Orchestration::DeliveryRecord.restore!.
+    #
+    # A status callback rather than a call site: AiAgentJob's rescue and
+    # StuckDetector both end a turn this way, and only one of them runs for a
+    # process that was killed outright.
+    def ended_without_delivering?
+      return false unless saved_change_to_attribute?("status")
+      return false unless status.in?(Orchestration::DeliveryRecord::UNDELIVERED_TERMINAL_STATUSES)
+
+      Orchestration::DeliveryRecord.ids_in(trigger_event_payload).any?
+    end
+
+    def restore_undelivered_dispatches
+      Orchestration::DeliveryRecord.restore!(self)
     end
 
     def terminal_status?

--- a/engines/collavre/app/services/collavre/ai_agent/message_builder.rb
+++ b/engines/collavre/app/services/collavre/ai_agent/message_builder.rb
@@ -117,9 +117,7 @@ module Collavre
         children_level = @agent.creative_children_level
         max_depth = 1 + children_level
 
-        # Extract creative IDs from markdown links like [title](/creatives/123)
-        referenced_ids = contents.flat_map { |c| c.scan(%r{\[[^\]]*\]\(/creatives/(\d+)\)}) }
-                                 .flatten.map(&:to_i).uniq
+        referenced_ids = contents.flat_map { |c| referenced_creative_ids(c) }.uniq
         referenced_ids.reject! { |cid| @injected_creative_ids.include?(cid) }
         creatives_by_id = Creative.where(id: referenced_ids).index_by(&:id)
 
@@ -140,6 +138,44 @@ module Collavre
         end
       end
 
+      # Creative ids linked from markdown like [title](/creatives/123).
+      def referenced_creative_ids(text)
+        text.to_s.scan(%r{\[[^\]]*\]\(/creatives/(\d+)\)}).flatten.map(&:to_i).uniq
+      end
+
+      # Whether a history entry carries its comment whole.
+      #
+      # A history entry is text: this window renders `content` and nothing
+      # else. Two things ride only on the trigger path — the blobs
+      # append_trigger_message attaches, and the subtree
+      # append_referenced_creative_contexts renders for a linked creative,
+      # which scans the anchor and the merged blocks and never this window. A
+      # comment carrying either is *partly* delivered here, and the turn that
+      # swept it up is not a substitute for its own dispatch.
+      #
+      # Decided here rather than at Orchestration::DeliveryRecord, which reads
+      # the :comment_id tag as a delivery claim: this is the only place that
+      # knows what was rendered, and in particular which creatives were
+      # already injected. A link to the topic's own creative — the common case
+      # — withholds nothing, and a rule written anywhere else could not tell
+      # that apart from a link to a subtree the agent never saw.
+      #
+      # Deliberately the same test append_referenced_creative_contexts applies,
+      # @injected_creative_ids and all, so the two answer alike: whatever that
+      # path would have injected for this comment is what this window failed to
+      # supply. It holds only roots, not the descendants a rendered subtree
+      # also covers, so a link to a descendant reads as withheld when its text
+      # was in fact rendered. That asymmetry costs a redundant turn; the
+      # opposite one costs the message.
+      def delivered_whole?(comment)
+        return false if comment.images.attached?
+
+        missing = referenced_creative_ids(comment.content) - @injected_creative_ids.to_a
+        return true if missing.empty?
+
+        !Creative.where(id: missing).exists?
+      end
+
       # Appends chat history messages and returns the count of messages added.
       def append_chat_history(messages)
         creative_id = @context.dig("creative", "id")
@@ -155,7 +191,7 @@ module Collavre
         scope = Comment.public_only.without_approval_action.where(creative_id: creative_id)
                        .where(topic_id: topic_id)
                        .where.not(user_id: nil)
-                       .includes(:user)
+                       .includes(:user, :images_attachments)
 
         # Exclude before limiting, not after. The trigger and the comments folded
         # into it are delivered by append_trigger_message, so leaving them in the
@@ -185,7 +221,14 @@ module Collavre
           # can read, off the payload the adapter is actually handed, which
           # comments this turn delivered. Consumers key into :role and :parts;
           # the extra key is inert to all of them.
-          messages << { role: role, kind: :chat_history, comment_id: c.id, parts: [ { text: content } ] }
+          #
+          # Only an entry that carries its comment whole wears the tag — the
+          # tag is the delivery claim, and delivered_whole? is what makes it
+          # true. An untagged entry still goes to the agent as context; it just
+          # does not stand in for the comment's own dispatch.
+          entry = { role: role, kind: :chat_history, parts: [ { text: content } ] }
+          entry[:comment_id] = c.id if delivered_whole?(c)
+          messages << entry
           count += 1
         end
 

--- a/engines/collavre/app/services/collavre/ai_agent/message_builder.rb
+++ b/engines/collavre/app/services/collavre/ai_agent/message_builder.rb
@@ -181,7 +181,11 @@ module Collavre
           history_chars += content.length
           break if history_chars > history_size_limit
 
-          messages << { role: role, kind: :chat_history, parts: [ { text: content } ] }
+          # Tagged with the comment it came from so Orchestration::DeliveryRecord
+          # can read, off the payload the adapter is actually handed, which
+          # comments this turn delivered. Consumers key into :role and :parts;
+          # the extra key is inert to all of them.
+          messages << { role: role, kind: :chat_history, comment_id: c.id, parts: [ { text: content } ] }
           count += 1
         end
 

--- a/engines/collavre/app/services/collavre/ai_agent_service.rb
+++ b/engines/collavre/app/services/collavre/ai_agent_service.rb
@@ -70,6 +70,14 @@ module Collavre
 
       resolved = resolve_session_context(messages_data, system_prompt)
 
+      # Write down what this turn is about to hand the agent, before it hands it
+      # over. A comment that landed after this task was dispatched and got swept
+      # into the history window has been read by the agent, and the dispatch
+      # still on its way for it should be dropped rather than queued behind this
+      # turn. Recorded off `resolved` — after the session filter — because a
+      # session-backed agent is sent only its :trigger and swallows nothing.
+      Orchestration::DeliveryRecord.record!(@task, resolved)
+
       @reply_comment = create_reply_comment_if_needed
 
       @lifecycle_manager = AiAgent::AgentLifecycleManager.new(

--- a/engines/collavre/app/services/collavre/ai_agent_service.rb
+++ b/engines/collavre/app/services/collavre/ai_agent_service.rb
@@ -96,6 +96,14 @@ module Collavre
       @client = build_ai_client(resolved[:system_prompt])
       stream_response(@client, resolved)
 
+      # ...and write down when the handing over did not happen. The record
+      # above licences discarding other dispatches on the strength of the agent
+      # having read their comments; a request that never reached the provider
+      # read nothing. AiAgentJob finishes this task `done` either way, so
+      # without this the delivered ending is the one it ends in. See
+      # Orchestration::DeliveryRecord::HANDOFF_FAILED_KEY.
+      Orchestration::DeliveryRecord.mark_handoff_failed!(@task) if @client.last_handoff_failed?
+
       log_action("completion", { response: @streamer.content })
 
       finalized_comment = finalize_response

--- a/engines/collavre/app/services/collavre/ai_agent_service.rb
+++ b/engines/collavre/app/services/collavre/ai_agent_service.rb
@@ -94,7 +94,18 @@ module Collavre
       @lifecycle_manager.broadcast_status("thinking")
 
       @client = build_ai_client(resolved[:system_prompt])
-      stream_response(@client, resolved)
+      begin
+        stream_response(@client, resolved)
+      ensure
+        # Write down that the payload got there, whatever became of the turn
+        # afterwards. In an `ensure` because the ending this is for leaves by
+        # exception: a user pressing Stop mid-answer raises CancelledError out
+        # of the block above, and the task ends `cancelled` — an undelivered
+        # ending to every reader, although the agent has read this turn's
+        # payload and every comment it swallowed. See
+        # Orchestration::DeliveryRecord::HANDED_OFF_KEY.
+        Orchestration::DeliveryRecord.mark_handed_off!(@task) if @client.handed_off?
+      end
 
       # ...and write down when the handing over did not happen. The record
       # above licences discarding other dispatches on the strength of the agent

--- a/engines/collavre/app/services/collavre/ai_client.rb
+++ b/engines/collavre/app/services/collavre/ai_client.rb
@@ -26,6 +26,19 @@ module Collavre
       @last_handoff_failed
     end
 
+    # Whether the last #chat got its payload to the provider — the same
+    # boundary, asked positively, for the callers the flag above cannot serve.
+    #
+    # #last_handoff_failed? is only ever set from a rescue, so it says nothing
+    # about a #chat that left by exception past it: a user pressing Stop
+    # mid-answer raises CancelledError through here, and the turn ends in a
+    # status every reader counts as undelivered although the provider has the
+    # payload. Answering that needs the fact recorded as it happens rather than
+    # inferred from how the call ended.
+    def handed_off?
+      @handed_off
+    end
+
     # Vendor <select> options for AI-agent config. Core ships only its built-in
     # (stateless) providers; vendor engines append their own through
     # register_vendor_option, so core never names a vendor engine.
@@ -84,10 +97,12 @@ module Collavre
       @last_input_tokens = 0
       @last_output_tokens = 0
       @last_handoff_failed = false
+      @handed_off = false
     end
 
     def chat(contents, tools: [], &block)
       @last_handoff_failed = false
+      @handed_off = false
       response_content = +""
       error_message = nil
       input_tokens = nil
@@ -114,11 +129,17 @@ module Collavre
         next if delta.empty?
 
         response_content << delta
+        # Set where the content actually arrives, not where #chat returns: the
+        # caller's block raises CancelledError from inside it.
+        @handed_off = true
         yield delta if block_given?
       end
 
       if response
-        response_content = response.content.to_s if response.content.present?
+        if response.content.present?
+          response_content = response.content.to_s
+          @handed_off = true
+        end
 
         # Extract token usage directly from response object (RubyLLM style)
         if response.respond_to?(:input_tokens)

--- a/engines/collavre/app/services/collavre/ai_client.rb
+++ b/engines/collavre/app/services/collavre/ai_client.rb
@@ -159,7 +159,13 @@ module Collavre
       raise # Re-raise cancellation errors without catching them
     rescue StandardError => e
       # Nothing streamed means nothing was handed over — see #last_handoff_failed?.
-      @last_handoff_failed = response_content.blank?
+      # Asked of @handed_off rather than of the buffer, and not `blank?`: a delta
+      # of exactly "\n\n" is content the branch above deliberately keeps, so
+      # `blank?` calls a stream that broke after a paragraph break a failed
+      # handoff while @handed_off calls it a handoff. The two are the same
+      # boundary asked two ways, and Task#ended_undelivered? reads a row carrying
+      # both as undelivered — so it has to be impossible to record both.
+      @last_handoff_failed = !@handed_off
       error_message = "[#{e.class.name}] #{e.message}"
       # When log_interactions is false (inline typo correction runs on the user's
       # *unsubmitted* draft), the LLM error message can echo the request text. Log

--- a/engines/collavre/app/services/collavre/ai_client.rb
+++ b/engines/collavre/app/services/collavre/ai_client.rb
@@ -10,6 +10,22 @@ module Collavre
 
     attr_reader :last_input_tokens, :last_output_tokens
 
+    # Did the last #chat end without the provider ever receiving the payload?
+    #
+    # #chat swallows a provider error: it streams "⚠️ AI Error" to the caller
+    # and returns nil — which an ordinary empty answer also returns — so the
+    # return value cannot tell the two apart. Orchestration::DeliveryRecord
+    # needs them apart, because a turn that handed the provider nothing
+    # delivered nothing, and AiAgentJob still marks such a turn `done`.
+    #
+    # An error *after* deltas have streamed is not one of these. The provider
+    # had the payload and answered part of it; the truncated reply and the
+    # retry beside it are the ordinary ending the product already shows, and
+    # the comments that turn swallowed did reach the agent.
+    def last_handoff_failed?
+      @last_handoff_failed
+    end
+
     # Vendor <select> options for AI-agent config. Core ships only its built-in
     # (stateless) providers; vendor engines append their own through
     # register_vendor_option, so core never names a vendor engine.
@@ -67,9 +83,11 @@ module Collavre
       @log_interactions = log_interactions
       @last_input_tokens = 0
       @last_output_tokens = 0
+      @last_handoff_failed = false
     end
 
     def chat(contents, tools: [], &block)
+      @last_handoff_failed = false
       response_content = +""
       error_message = nil
       input_tokens = nil
@@ -119,6 +137,8 @@ module Collavre
     rescue CancelledError
       raise # Re-raise cancellation errors without catching them
     rescue StandardError => e
+      # Nothing streamed means nothing was handed over — see #last_handoff_failed?.
+      @last_handoff_failed = response_content.blank?
       error_message = "[#{e.class.name}] #{e.message}"
       # When log_interactions is false (inline typo correction runs on the user's
       # *unsubmitted* draft), the LLM error message can echo the request text. Log

--- a/engines/collavre/app/services/collavre/ai_client.rb
+++ b/engines/collavre/app/services/collavre/ai_client.rb
@@ -18,10 +18,12 @@ module Collavre
     # needs them apart, because a turn that handed the provider nothing
     # delivered nothing, and AiAgentJob still marks such a turn `done`.
     #
-    # An error *after* deltas have streamed is not one of these. The provider
-    # had the payload and answered part of it; the truncated reply and the
-    # retry beside it are the ordinary ending the product already shows, and
-    # the comments that turn swallowed did reach the agent.
+    # An error *after* the provider started answering is not one of these. It
+    # had the payload and acted on it; the truncated reply and the retry beside
+    # it are the ordinary ending the product already shows, and the comments
+    # that turn swallowed did reach the agent. "Started answering" is any chunk,
+    # not any *content* — see the stream block for why a tool-call chunk is the
+    # sharper case.
     def last_handoff_failed?
       @last_handoff_failed
     end
@@ -117,6 +119,17 @@ module Collavre
       add_messages(@conversation, contents)
 
       response = @conversation.complete do |chunk|
+        # A chunk at all is the provider having accepted the request and begun
+        # answering — the earliest acceptance observable from here, and the
+        # analogue of the gateway run id the OpenClaw adapter records.
+        #
+        # Set above the empty check, not below it: role-only and tool-call
+        # chunks carry no content, and a conversation that reached its tools has
+        # not merely been handed the payload, it has acted on it — this
+        # product's tools write creatives and post comments. A turn classified
+        # as a failed handoff has everything it swallowed dispatched again, and
+        # the restored turn runs those tools a second time.
+        @handed_off = true
         delta = extract_chunk_content(chunk).to_s
         # Deliberately NOT `blank?`. A delta of exactly "\n\n" — the paragraph
         # break, which providers routinely emit as a token of its own — is
@@ -129,9 +142,6 @@ module Collavre
         next if delta.empty?
 
         response_content << delta
-        # Set where the content actually arrives, not where #chat returns: the
-        # caller's block raises CancelledError from inside it.
-        @handed_off = true
         yield delta if block_given?
       end
 
@@ -158,11 +168,12 @@ module Collavre
     rescue CancelledError
       raise # Re-raise cancellation errors without catching them
     rescue StandardError => e
-      # Nothing streamed means nothing was handed over — see #last_handoff_failed?.
-      # Asked of @handed_off rather than of the buffer, and not `blank?`: a delta
-      # of exactly "\n\n" is content the branch above deliberately keeps, so
-      # `blank?` calls a stream that broke after a paragraph break a failed
-      # handoff while @handed_off calls it a handoff. The two are the same
+      # Nothing came back at all means nothing was handed over — see
+      # #last_handoff_failed?. Asked of @handed_off rather than of the buffer,
+      # and not `blank?`: a delta of exactly "\n\n" is content the branch above
+      # deliberately keeps, so `blank?` calls a stream that broke after a
+      # paragraph break a failed handoff, and the buffer either way says nothing
+      # about the content-less chunks. The two are the same
       # boundary asked two ways, and Task#ended_undelivered? reads a row carrying
       # both as undelivered — so it has to be impossible to record both.
       @last_handoff_failed = !@handed_off

--- a/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
+++ b/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
@@ -679,6 +679,19 @@ module Collavre
           agent = decision[:agent]
           log_decision(decision)
 
+          # A rejected decision is not a dispatch, so neither guard below
+          # applies to it. Both ask "is this dispatch redundant?", which is only
+          # a question about work that was going to run: the scheduler has
+          # already refused this one, over an exhausted quota or a loop breaker
+          # that fired. Recording a drop against it would make
+          # DeliveryRecord.restore! owe a turn for work nothing scheduled, and
+          # the restore enqueues AiAgentJob directly — past the very check that
+          # did the refusing, so the quota is exceeded or the broken loop
+          # restarted. Reporting the agent would be the same mistake in the
+          # other direction: nothing is answering, and an empty result is how a
+          # caller learns that.
+          next nil if decision[:timing] == :rejected
+
           # Guard: skip if agent already has a running task for this comment.
           # Handled, not unscheduled — see the drop guard below for why the two
           # are different answers and what reads them apart.

--- a/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
+++ b/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
@@ -562,7 +562,16 @@ module Collavre
           creative_id: context.dig("creative", "id"),
           trigger_event_name: task.trigger_event_name,
           status: DELIVERED_STATUSES
-        ).where.not(id: task.id).select(:id, :trigger_event_payload).reject { |other|
+        ).where.not(id: task.id).select(:id, :trigger_event_payload).to_a
+
+        # A resumed turn can carry both records legitimately: an earlier
+        # attempt handed off, then a later attempt failed before handoff. The
+        # failure invalidates inferred turn-wide delivery, but not the comment
+        # ids the earlier successful attempt recorded explicitly.
+        handed_off = others.flat_map { |other|
+          DeliveryRecord.handed_off_ids_in(other.trigger_event_payload)
+        }
+        delivered_turns = others.reject { |other|
           # `done` is in DELIVERED_STATUSES because a finished turn delivered
           # what it read — except when the request never reached the provider,
           # which AiClient#chat swallows and AiAgentJob still finishes as
@@ -571,8 +580,8 @@ module Collavre
           DeliveryRecord.handoff_failed?(other.trigger_event_payload)
         }
 
-        acquired_anchors = others.filter_map { |other| acquired_anchor_id_in(other) }
-        merged = others.flat_map { |other|
+        acquired_anchors = delivered_turns.filter_map { |other| acquired_anchor_id_in(other) }
+        merged = delivered_turns.flat_map { |other|
           Array(other.trigger_event_payload&.dig(TaskCoalescer::PAYLOAD_KEY)).compact.map(&:to_i)
         }
         # The third shape, and the one the dispatch doors cannot catch: a
@@ -580,9 +589,11 @@ module Collavre
         # a comment that landed after that turn was dispatched can be swept into
         # its history window without ever being merged or re-anchored. A waiter
         # parked before the covering turn assembled is only discoverable here.
-        swallowed = others.flat_map { |other| DeliveryRecord.ids_in(other.trigger_event_payload) }
+        swallowed = delivered_turns.flat_map { |other|
+          DeliveryRecord.ids_in(other.trigger_event_payload)
+        }
 
-        (acquired_anchors + merged + swallowed).uniq
+        (acquired_anchors + merged + swallowed + handed_off).uniq
       end
       private_class_method :delivered_comment_ids
 

--- a/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
+++ b/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
@@ -441,6 +441,30 @@ module Collavre
         # whether it actually delivered anything.
         scope = scope.where.not(id: delivered_ids) if delivered_ids.any?
 
+        # When the filter above removed the waiter's *own* anchor, falling back
+        # to an older comment is not a rescue.
+        #
+        # The refresh's worst case used to be a no-op: the waiter's own anchor
+        # was always among the candidates, so "the newest eligible comment" was
+        # never older than the comment the waiter was dispatched for. Delivery
+        # filtering can now take that anchor away, and what is next is older —
+        # a comment this waiter was not dispatched for, that predates the one it
+        # was, and that the covering turn had in view when it answered the
+        # anchor. Answering it is a second reply to settled conversation.
+        #
+        # Scoped to exactly that cause rather than a blanket "never move
+        # backwards": an anchor that has left the turn for some other reason
+        # (moved to another creative, made private) is a different question with
+        # its own answer, and widening the floor to cover it would change what
+        # promotion does to waiters this feature never touched.
+        #
+        # With nothing at or above the anchor left, `latest_comment` is nil and
+        # the branch below cancels the waiter — which is the right outcome:
+        # everything it could have said has been said.
+        if previous_anchor_id && delivered_ids.include?(previous_anchor_id.to_i)
+          scope = scope.where("id >= ?", previous_anchor_id)
+        end
+
         if absorbed_only
           candidate_ids = (Array(context[TaskCoalescer::PAYLOAD_KEY]) + [ previous_anchor_id ])
             .compact.map(&:to_i).uniq
@@ -529,8 +553,14 @@ module Collavre
         merged = others.flat_map { |other|
           Array(other.trigger_event_payload&.dig(TaskCoalescer::PAYLOAD_KEY)).compact.map(&:to_i)
         }
+        # The third shape, and the one the dispatch doors cannot catch: a
+        # non-session turn re-reads the topic when it assembles its payload, so
+        # a comment that landed after that turn was dispatched can be swept into
+        # its history window without ever being merged or re-anchored. A waiter
+        # parked before the covering turn assembled is only discoverable here.
+        swallowed = others.flat_map { |other| DeliveryRecord.ids_in(other.trigger_event_payload) }
 
-        (acquired_anchors + merged).uniq
+        (acquired_anchors + merged + swallowed).uniq
       end
       private_class_method :delivered_comment_ids
 
@@ -648,6 +678,23 @@ module Collavre
             Rails.logger.warn(
               "[AgentOrchestrator] Skipping enqueue: agent #{agent.id} already has a running task " \
               "for comment #{comment_id}"
+            )
+            next
+          end
+
+          # Guard: an in-flight turn has already been given this comment. It
+          # reached the agent inside that turn's chat history, so a turn of its
+          # own would answer something the agent has read — and parking it as a
+          # waiter costs a "⏳" notice and a promotion round-trip for a reply
+          # nobody is waiting on. Drop it instead of queueing it.
+          #
+          # Nothing is recorded for a session-backed agent (it is sent only its
+          # :trigger), so nothing is dropped for one either — those bursts still
+          # go through TaskCoalescer, which merges rather than discards.
+          if (covering = DeliveryRecord.covering_task(agent, comment_id, @context, @event_name))
+            Rails.logger.info(
+              "[AgentOrchestrator] Dropping dispatch: comment #{comment_id} was already " \
+              "delivered to agent #{agent.id} by in-flight task #{covering.id}"
             )
             next
           end

--- a/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
+++ b/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
@@ -547,7 +547,14 @@ module Collavre
           creative_id: context.dig("creative", "id"),
           trigger_event_name: task.trigger_event_name,
           status: DELIVERED_STATUSES
-        ).where.not(id: task.id).select(:id, :trigger_event_payload)
+        ).where.not(id: task.id).select(:id, :trigger_event_payload).reject { |other|
+          # `done` is in DELIVERED_STATUSES because a finished turn delivered
+          # what it read — except when the request never reached the provider,
+          # which AiClient#chat swallows and AiAgentJob still finishes as
+          # `done`. Such a turn silences nothing, for the same reason `failed`
+          # is left out of the list; it just cannot be recognised by status.
+          DeliveryRecord.handoff_failed?(other.trigger_event_payload)
+        }
 
         acquired_anchors = others.filter_map { |other| acquired_anchor_id_in(other) }
         merged = others.flat_map { |other|
@@ -672,14 +679,16 @@ module Collavre
           agent = decision[:agent]
           log_decision(decision)
 
-          # Guard: skip if agent already has a running task for this comment
+          # Guard: skip if agent already has a running task for this comment.
+          # Handled, not unscheduled — see the drop guard below for why the two
+          # are different answers and what reads them apart.
           comment_id = @context.dig("comment", "id")
           if comment_id && Task.duplicate_running_for_comment?(agent.id, comment_id)
             Rails.logger.warn(
               "[AgentOrchestrator] Skipping enqueue: agent #{agent.id} already has a running task " \
               "for comment #{comment_id}"
             )
-            next
+            next agent
           end
 
           # Guard: an in-flight turn has already been given this comment. It
@@ -696,13 +705,22 @@ module Collavre
           # claim_drop! re-reads that turn's status under a lock and refuses if
           # it has already ended, because a turn that has ended has already run
           # its restore and would leave this comment with nobody to answer it.
+          #
+          # The agent is still returned. What this method reports is who will
+          # answer, not how many turns it started — a :deferred decision
+          # returns its agent although all it created was a queued row — and a
+          # drop says this agent is answering that comment inside a turn
+          # already running. Reporting nothing is how a caller learns *no agent
+          # was scheduled*: DropTriggerJob#dispatch_trigger raises
+          # DispatchFailedError on an empty result and retries a trigger that
+          # was covered, three times, and calls the job failed at the end of it.
           covering = DeliveryRecord.covering_task(agent, comment_id, @context, @event_name)
           if covering && DeliveryRecord.claim_drop!(covering, comment_id)
             Rails.logger.info(
               "[AgentOrchestrator] Dropping dispatch: comment #{comment_id} was already " \
               "delivered to agent #{agent.id} by in-flight task #{covering.id}"
             )
-            next
+            next agent
           end
 
           case decision[:timing]

--- a/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
+++ b/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
@@ -512,6 +512,21 @@ module Collavre
       # that died may never have delivered anything, so the comments it held
       # stay answerable. That direction trades a possible duplicate after a
       # failure for never silencing a comment no task is left to answer.
+      #
+      # The in-flight three would be unsound here if they were reachable: a
+      # `running` turn's record says it assembled, not that it handed anything
+      # over, and this reader *cancels a waiter* — the one removal this feature
+      # makes that writes nothing down, so a later failure has no row to undo it
+      # with. They are inert instead, and TopicSlot is why: an agent that
+      # occupies a slot in this scope may not be promoted into a second turn, so
+      # at the moment the refresh runs this agent has no running, delegated,
+      # pending or pending_approval task here — and `others` is scoped to this
+      # agent, so a concurrent turn (necessarily another agent's, for the same
+      # reason) is not read at all. The only covering turn this ever decides
+      # against is one that has already ended, which is what makes the decision
+      # sound. DeliveredHistoryDispatchTest holds both halves; relax TopicSlot's
+      # per-agent exclusion and they fail rather than this quietly losing a
+      # comment.
       DELIVERED_STATUSES = %w[running delegated pending_approval done].freeze
 
       # Comment ids this agent has already been given in this topic by a turn that

--- a/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
+++ b/engines/collavre/app/services/collavre/orchestration/agent_orchestrator.rb
@@ -691,7 +691,13 @@ module Collavre
           # Nothing is recorded for a session-backed agent (it is sent only its
           # :trigger), so nothing is dropped for one either — those bursts still
           # go through TaskCoalescer, which merges rather than discards.
-          if (covering = DeliveryRecord.covering_task(agent, comment_id, @context, @event_name))
+          #
+          # Dropped only if the covering turn will take responsibility for it:
+          # claim_drop! re-reads that turn's status under a lock and refuses if
+          # it has already ended, because a turn that has ended has already run
+          # its restore and would leave this comment with nobody to answer it.
+          covering = DeliveryRecord.covering_task(agent, comment_id, @context, @event_name)
+          if covering && DeliveryRecord.claim_drop!(covering, comment_id)
             Rails.logger.info(
               "[AgentOrchestrator] Dropping dispatch: comment #{comment_id} was already " \
               "delivered to agent #{agent.id} by in-flight task #{covering.id}"

--- a/engines/collavre/app/services/collavre/orchestration/delivery_record.rb
+++ b/engines/collavre/app/services/collavre/orchestration/delivery_record.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+module Collavre
+  module Orchestration
+    # What a turn actually handed its agent, written down at the moment it was
+    # handed over.
+    #
+    # A burst of external events (a PR comment sync, a webhook batch) creates
+    # several comments in one topic within milliseconds.
+    # Orchestration::TaskCoalescer folds the *un-started* tasks of that burst
+    # together, but it cannot help the comment that arrives while a turn is
+    # already running: that dispatch parks a waiter, and the agent speaks a
+    # second time when the waiter is promoted.
+    #
+    # For a non-session agent the second turn is usually redundant.
+    # AiAgent::MessageBuilder#append_chat_history reads the topic's comments at
+    # *execution* time, so a comment committed before the payload was assembled
+    # is already inside the running turn's context — the agent has read it.
+    #
+    # For a session-backed agent it is not redundant at all:
+    # AiAgent::SessionContextResolver#incremental_payload keeps only the
+    # :trigger message, so the running turn never carried that text. Dropping
+    # the dispatch there would be message loss rather than de-duplication, and
+    # coalescing (merge into "merged_comment_ids") stays the right answer.
+    #
+    # So "the agent is busy" is the wrong predicate and "the agent has already
+    # been given that comment" is the right one — and the only place that can
+    # answer it is the resolved payload itself. This module records the answer
+    # off that payload and is the single door every reader goes through.
+    module DeliveryRecord
+      # Comment ids a turn delivered as chat history although it was not created
+      # for them. Sits beside TaskCoalescer::PAYLOAD_KEY and
+      # TaskCoalescer::ACQUIRED_ANCHOR_KEY, which record the other two ways a
+      # turn ends up carrying a comment it was not dispatched for.
+      KEY = "history_delivered_comment_ids"
+
+      # Statuses in which a turn is still the thing that will answer.
+      #
+      # Narrower than AgentOrchestrator::DELIVERED_STATUSES, which also counts
+      # `done`, and deliberately so: the two readers ask different questions.
+      # The promotion door asks "may this *parked* waiter still speak?", and a
+      # waiter that may not simply loses its turn — it had no independent claim
+      # on the slot. This module's other reader is the dispatch door, where the
+      # alternative to running is discarding the dispatch outright. A turn that
+      # has already finished is no longer answering anything, so a comment
+      # arriving after it gets its own turn rather than being silently dropped.
+      #
+      # `queued`/`pending` are excluded at both: nothing has been delivered yet.
+      IN_FLIGHT_STATUSES = %w[running delegated pending_approval].freeze
+
+      # Record what `resolved` carries as chat history.
+      #
+      # Measured off the *resolved* payload — the messages the adapter is handed
+      # — rather than off MessageBuilder's output, because the session filter
+      # sits between the two and is exactly the distinction that decides whether
+      # a comment was delivered at all. A future filter added there is then
+      # accounted for without a second place having to learn about it.
+      #
+      # Restricted to ids above the turn's anchor. Chat history normally holds
+      # the topic's backlog, which this turn did not swallow and must not
+      # silence; a history comment *newer* than the anchor can only have landed
+      # after this turn was dispatched, which is the burst case and the only one
+      # this record is for. Ids rather than created_at: a burst is written by
+      # several processes and the clock is whichever one wrote the row (the same
+      # reason AiAgent::MergedTriggerComments orders by id).
+      #
+      # Accumulates. A resumed turn (pending_approval, or a retry) assembles a
+      # second time, and what the first pass delivered it still delivered.
+      def self.record!(task, resolved)
+        payload = task.trigger_event_payload
+        return unless payload.is_a?(Hash)
+
+        anchor_id = payload.dig("comment", "id").to_i
+        return if anchor_id.zero?
+
+        swallowed = history_comment_ids(resolved).select { |id| id > anchor_id }
+        merged = (ids_in(payload) + swallowed).uniq.sort
+        return if merged == ids_in(payload)
+
+        task.update!(trigger_event_payload: payload.merge(KEY => merged))
+      end
+
+      def self.ids_in(payload)
+        return [] unless payload.is_a?(Hash)
+
+        Array(payload[KEY]).compact.map(&:to_i)
+      end
+
+      # The in-flight turn that has already given `comment_id` to `agent`, or nil.
+      #
+      # Every gate that drops a dispatch goes through this one method: the
+      # orchestrator's enqueue door, AiAgentJob's late-admission door, and any
+      # later one. Two doors that ask this question separately are how they come
+      # to disagree about it.
+      #
+      # Scoped exactly like AgentOrchestrator.delivered_comment_ids — same agent,
+      # topic, creative and trigger event — so a workflow subtask in another
+      # creative, or a different event over the same comment, is a different
+      # question and not an answer to this one.
+      def self.covering_task(agent, comment_id, context, trigger_event_name)
+        return nil if agent.nil? || comment_id.blank?
+        return nil unless context.is_a?(Hash) && context.key?("topic")
+        return nil unless PolicyResolver.new(context).drop_delivered_dispatches_for?(agent)
+        # A review request is bound to the comment it quotes and can only run as
+        # its own turn: AiAgentService and ReviewHandler read review behaviour
+        # off the anchor, never off the history window. Having been read as
+        # context is not having been answered, so a review is never dropped —
+        # the same boundary TaskCoalescer and refresh_deferred_context! keep.
+        return nil if Comment.review_message_ids([ comment_id ]).any?
+
+        Task.where(
+          agent_id: agent.id,
+          topic_id: context.dig("topic", "id"),
+          creative_id: context.dig("creative", "id"),
+          trigger_event_name: trigger_event_name,
+          status: IN_FLIGHT_STATUSES
+        ).select(:id, :trigger_event_payload).find do |task|
+          ids_in(task.trigger_event_payload).include?(comment_id.to_i)
+        end
+      end
+
+      def self.history_comment_ids(resolved)
+        messages = resolved.is_a?(Hash) ? Array(resolved[:messages] || resolved["messages"]) : Array(resolved)
+        messages.filter_map do |message|
+          next unless message.is_a?(Hash)
+          next unless (message[:kind] || message["kind"]).to_s == "chat_history"
+
+          id = message[:comment_id] || message["comment_id"]
+          id&.to_i
+        end.uniq
+      end
+      private_class_method :history_comment_ids
+    end
+  end
+end

--- a/engines/collavre/app/services/collavre/orchestration/delivery_record.rb
+++ b/engines/collavre/app/services/collavre/orchestration/delivery_record.rb
@@ -70,6 +70,39 @@ module Collavre
       # only place that knows is the service holding the client that failed.
       HANDOFF_FAILED_KEY = "handoff_failed"
 
+      # This turn did hand its payload to the provider — the same question,
+      # asked positively, for the endings that never reach the line above.
+      #
+      # HANDOFF_FAILED_KEY is written after #chat returns, so a turn that leaves
+      # by exception never records anything: a user pressing Stop mid-answer
+      # ends `cancelled`, which every reader counts as undelivered outright,
+      # although the provider has the payload by then and AgentLifecycleManager
+      # keeps the partial reply. The comments that turn swallowed were read
+      # along with it, so restoring them starts fresh work the moment the user
+      # asked for none, and answers them twice.
+      #
+      # Positive rather than a second failure flag, because the absence of the
+      # record has to keep meaning "restore": most cancellations and every hard
+      # crash write nothing at all, and losing a comment costs more than a
+      # redundant turn. Only a turn that got far enough to say so is exempt.
+      HANDED_OFF_KEY = "handed_off"
+
+      # Comments this turn's restore has already put back on their way.
+      #
+      # AiAgentJob creates the Task row when it *runs*, so between a restored
+      # enqueue and its execution the comment has no row and reads as orphaned —
+      # a worker outage or a backlog longer than the sweep interval therefore
+      # had every pass enqueue another copy, and the copies that lose the
+      # admission race become independent waiters that answer the comment again.
+      # Eventual Task creation cannot be the idempotency marker for work that
+      # has not started.
+      #
+      # Written before the enqueue and given back if the enqueue raises, so the
+      # claim never outlives the dispatch it stands for: a comment claimed by an
+      # enqueue that never happened is the previous finding pointing the other
+      # way.
+      RESTORED_KEY = "restored_dispatch_comment_ids"
+
       # Everything a turn writes onto its own payload while it runs, as opposed
       # to what it was dispatched with.
       #
@@ -80,7 +113,7 @@ module Collavre
       # was added here long after restored_context had named the other four —
       # and the drift test on this constant is what will catch the sixth.
       TURN_SCOPED_KEYS = [
-        KEY, DROPPED_KEY, HANDOFF_FAILED_KEY,
+        KEY, DROPPED_KEY, HANDOFF_FAILED_KEY, HANDED_OFF_KEY, RESTORED_KEY,
         TaskCoalescer::PAYLOAD_KEY, TaskCoalescer::ACQUIRED_ANCHOR_KEY
       ].freeze
 
@@ -206,6 +239,79 @@ module Collavre
         payload[HANDOFF_FAILED_KEY] == true
       end
 
+      # Write down that this turn's payload did reach the provider.
+      #
+      # Under the same row lock and for the same reason as its two siblings: a
+      # dispatch refused in another process writes DROPPED_KEY into this column
+      # while the turn runs, and this is written as the turn is being torn down
+      # by the very cancellation that dispatch is racing.
+      def self.mark_handed_off!(task)
+        return if task.nil?
+
+        Task.transaction do
+          row = Task.lock.find_by(id: task.id)
+          payload = row&.trigger_event_payload
+          next unless payload.is_a?(Hash)
+          next if handed_off?(payload)
+
+          row.update!(trigger_event_payload: payload.merge(HANDED_OFF_KEY => true))
+          task.reload unless task.equal?(row)
+        end
+      end
+
+      def self.handed_off?(payload)
+        return false unless payload.is_a?(Hash)
+
+        payload[HANDED_OFF_KEY] == true
+      end
+
+      def self.restored_ids_in(payload)
+        return [] unless payload.is_a?(Hash)
+
+        Array(payload[RESTORED_KEY]).compact.map(&:to_i)
+      end
+
+      # Take responsibility for putting one dispatch back, or refuse it because
+      # somebody already has.
+      #
+      # The same shape as claim_drop!, and for the same reason: the callback and
+      # the sweep can be looking at this row at once, and the thing they would
+      # both act on leaves no trace until a worker picks it up.
+      #
+      # @return [Boolean] whether the caller may enqueue the dispatch
+      def self.claim_restore!(task, comment_id)
+        id = comment_id.to_i
+        return false if task.nil? || id.zero?
+
+        claimed = false
+        Task.transaction do
+          row = Task.lock.find_by(id: task.id)
+          payload = row&.trigger_event_payload
+          next unless payload.is_a?(Hash)
+          next if restored_ids_in(payload).include?(id)
+
+          restored = (restored_ids_in(payload) + [ id ]).uniq.sort
+          row.update!(trigger_event_payload: payload.merge(RESTORED_KEY => restored))
+          claimed = true
+        end
+        claimed
+      end
+
+      # Give the claim back for a dispatch that was never enqueued after all.
+      def self.release_restore_claim!(task, comment_id)
+        id = comment_id.to_i
+        return if task.nil? || id.zero?
+
+        Task.transaction do
+          row = Task.lock.find_by(id: task.id)
+          payload = row&.trigger_event_payload
+          next unless payload.is_a?(Hash)
+
+          restored = restored_ids_in(payload) - [ id ]
+          row.update!(trigger_event_payload: payload.merge(RESTORED_KEY => restored))
+        end
+      end
+
       def self.dropped_ids_in(payload)
         return [] unless payload.is_a?(Hash)
 
@@ -313,7 +419,7 @@ module Collavre
         payload = Task.find_by(id: task.id)&.trigger_event_payload
         return unless payload.is_a?(Hash) && payload.key?("topic")
 
-        orphaned = dropped_ids_in(payload) - claimed_comment_ids(task)
+        orphaned = dropped_ids_in(payload) - claimed_comment_ids(task) - restored_ids_in(payload)
         return if orphaned.empty?
 
         agent = task.agent
@@ -328,7 +434,7 @@ module Collavre
           .order(:id)
           .each do |comment|
           begin
-            enqueue_restored(agent, task.trigger_event_name, restored_context(payload, comment))
+            enqueue_restored(task, agent, task.trigger_event_name, restored_context(payload, comment))
           rescue StandardError => e
             # Each orphan is a dispatch of its own; one that cannot be enqueued
             # says nothing about the next. What it leaves behind is the absence
@@ -395,23 +501,58 @@ module Collavre
       # Matcher#assignment_permits? against the re-anchored payload before it
       # parks anything — a restored dispatch has moved, and park_waiter would
       # create the row without that question being asked.
-      def self.enqueue_restored(agent, event_name, context)
+      def self.enqueue_restored(task, agent, event_name, context)
+        # The one question no door on this path asks. Naming the agent skips
+        # Matcher#match, and every routing path in #match is gated on feedback
+        # permission for the creative; AiAgentJob re-asks the topic assignment
+        # and nothing else. A permission revoked between the drop and the
+        # restore would otherwise be seen by nobody, and this dispatch would
+        # answer a creative the agent may no longer read.
+        unless Matcher.permits_creative_access?(context, agent)
+          Rails.logger.info(
+            "[DeliveryRecord] Not restoring dispatch for comment #{context.dig("comment", "id")}: " \
+            "agent #{agent.id} no longer has feedback permission on creative " \
+            "#{context.dig("creative", "id")}"
+          )
+          return
+        end
+
         decision = Scheduler.new(context).schedule([ agent ]).first
         return if decision.nil?
 
+        comment_id = context.dig("comment", "id")
         case decision[:timing]
         when :rejected
           Rails.logger.info(
-            "[DeliveryRecord] Not restoring dispatch for comment #{context.dig("comment", "id")}: " \
+            "[DeliveryRecord] Not restoring dispatch for comment #{comment_id}: " \
             "scheduler rejected agent #{agent.id} (#{decision[:reason]})"
           )
         when :delayed
-          AiAgentJob.set(wait: decision[:delay]).perform_later(agent.id, event_name, context)
+          enqueue_claimed(task, comment_id) do
+            AiAgentJob.set(wait: decision[:delay]).perform_later(agent.id, event_name, context)
+          end
         else
-          AiAgentJob.perform_later(agent.id, event_name, context)
+          enqueue_claimed(task, comment_id) { AiAgentJob.perform_later(agent.id, event_name, context) }
         end
       end
       private_class_method :enqueue_restored
+
+      # Claim the comment, then enqueue — and only in that order. The job leaves
+      # no row until a worker runs it, so between the two the comment reads as
+      # orphaned to anyone else looking, and the sweep is looking every ten
+      # minutes. A claim released on failure is the whole difference between
+      # this and a dispatch nobody comes back for.
+      def self.enqueue_claimed(task, comment_id)
+        return unless claim_restore!(task, comment_id)
+
+        begin
+          yield
+        rescue StandardError
+          release_restore_claim!(task, comment_id)
+          raise
+        end
+      end
+      private_class_method :enqueue_claimed
 
       # The dispatch that was discarded — not a descendant of the turn that
       # discarded it. reanchor_payload is the single door for moving an anchor,

--- a/engines/collavre/app/services/collavre/orchestration/delivery_record.rb
+++ b/engines/collavre/app/services/collavre/orchestration/delivery_record.rb
@@ -121,7 +121,7 @@ module Collavre
           anchor_id = payload.dig("comment", "id").to_i
           next if anchor_id.zero?
 
-          swallowed = delivered_in_full(history_comment_ids(resolved).select { |id| id > anchor_id })
+          swallowed = history_comment_ids(resolved).select { |id| id > anchor_id }
           merged = (ids_in(payload) + swallowed).uniq.sort
           next if merged == ids_in(payload)
 
@@ -129,27 +129,6 @@ module Collavre
           task.reload unless task.equal?(row)
         end
       end
-
-      # Of `ids`, the comments a history entry carries whole.
-      #
-      # A history entry is text: MessageBuilder#append_chat_history renders
-      # `content` and nothing else, while blobs ride only on the trigger, which
-      # attaches the anchor's images and the merged blocks'. So a comment with
-      # an attachment that the window swept up has been *partly* delivered, and
-      # this record's predicate — the agent has been given this comment — is
-      # false for it. Recording it would let the drop discard the one dispatch
-      # that would have carried the image, and an image-only comment would
-      # reach the agent as a blank line under someone's name.
-      #
-      # Excluded here, at the record, rather than at each gate: the record is
-      # what the dispatch doors and AgentOrchestrator.delivered_comment_ids all
-      # read, so a partial delivery kept out of it is kept out of every one.
-      def self.delivered_in_full(ids)
-        return ids if ids.empty?
-
-        ids - Comment.where(id: ids).joins(:images_attachments).distinct.pluck(:id)
-      end
-      private_class_method :delivered_in_full
 
       def self.ids_in(payload)
         return [] unless payload.is_a?(Hash)
@@ -321,6 +300,13 @@ module Collavre
       end
       private_class_method :claimed_comment_ids
 
+      # The comments the history window carried *whole*, read off the tag
+      # MessageBuilder#append_chat_history writes. A window entry can render a
+      # comment without delivering it — a blob or a linked creative's subtree
+      # rides only on the trigger path — and those entries go untagged, so this
+      # record never claims them. That judgement lives with the builder, which
+      # is the only place that knows what it rendered; see
+      # MessageBuilder#delivered_whole?.
       def self.history_comment_ids(resolved)
         messages = resolved.is_a?(Hash) ? Array(resolved[:messages] || resolved["messages"]) : Array(resolved)
         messages.filter_map do |message|

--- a/engines/collavre/app/services/collavre/orchestration/delivery_record.rb
+++ b/engines/collavre/app/services/collavre/orchestration/delivery_record.rb
@@ -87,6 +87,26 @@ module Collavre
       # redundant turn. Only a turn that got far enough to say so is exempt.
       HANDED_OFF_KEY = "handed_off"
 
+      # The comment ids an attempt that handed off actually carried.
+      #
+      # HANDED_OFF_KEY answers for the *turn*, and that is enough while a turn
+      # is one attempt. It is not: a tool approval pauses the turn and
+      # Comments::ActionExecutor resumes the same Task row, so AiAgentService
+      # runs over it again with a fresh client. The first pass reached its tools,
+      # which means the provider had that payload; if the resumed request then
+      # never lands, the row carries both records, Task#ended_undelivered? reads
+      # the failure first, and the restore puts back every dispatch ever dropped
+      # against the turn — including the ones the first pass handed over.
+      #
+      # So the exemption is recorded per comment, which is the subject the
+      # restore actually has. KEY at the moment of the handoff is exactly what
+      # went over: record! writes it before the request, and a drop taken later
+      # against an id already in KEY was in that payload too. Accumulates across
+      # attempts for the same reason KEY does — what one pass delivered it still
+      # delivered — and a comment only the failed pass read is not in it, so it
+      # is still owed back.
+      HANDED_OFF_IDS_KEY = "handed_off_comment_ids"
+
       # Comments this turn's restore has already put back on their way.
       #
       # AiAgentJob creates the Task row when it *runs*, so between a restored
@@ -113,8 +133,8 @@ module Collavre
       # was added here long after restored_context had named the other four —
       # and the drift test on this constant is what will catch the sixth.
       TURN_SCOPED_KEYS = [
-        KEY, DROPPED_KEY, HANDOFF_FAILED_KEY, HANDED_OFF_KEY, RESTORED_KEY,
-        TaskCoalescer::PAYLOAD_KEY, TaskCoalescer::ACQUIRED_ANCHOR_KEY
+        KEY, DROPPED_KEY, HANDOFF_FAILED_KEY, HANDED_OFF_KEY, HANDED_OFF_IDS_KEY,
+        RESTORED_KEY, TaskCoalescer::PAYLOAD_KEY, TaskCoalescer::ACQUIRED_ANCHOR_KEY
       ].freeze
 
       # Statuses in which a turn is still the thing that will answer.
@@ -256,9 +276,16 @@ module Collavre
           row = Task.lock.find_by(id: task.id)
           payload = row&.trigger_event_payload
           next unless payload.is_a?(Hash)
-          next if handed_off?(payload)
 
-          row.update!(trigger_event_payload: payload.merge(HANDED_OFF_KEY => true))
+          # Not `next if handed_off?`: a resumed attempt records the handoff a
+          # second time, and what it carried this time is the point of asking.
+          recorded = handed_off_ids_in(payload)
+          covered = (recorded + ids_in(payload)).uniq.sort
+          next if handed_off?(payload) && covered == recorded
+
+          row.update!(trigger_event_payload: payload.merge(
+            HANDED_OFF_KEY => true, HANDED_OFF_IDS_KEY => covered
+          ))
           task.reload unless task.equal?(row)
         end
       end
@@ -267,6 +294,12 @@ module Collavre
         return false unless payload.is_a?(Hash)
 
         payload[HANDED_OFF_KEY] == true
+      end
+
+      def self.handed_off_ids_in(payload)
+        return [] unless payload.is_a?(Hash)
+
+        Array(payload[HANDED_OFF_IDS_KEY]).compact.map(&:to_i)
       end
 
       def self.restored_ids_in(payload)
@@ -410,6 +443,10 @@ module Collavre
       # braces: the record already excludes what was never dropped, and this
       # excludes what has since acquired a row of its own.
       #
+      # And once more by HANDED_OFF_IDS_KEY, for the turn that ran more than
+      # once: a comment an earlier attempt handed to the provider is not owed
+      # back by a later attempt's failure.
+      #
       # Each orphan is re-dispatched on its own, exactly as it would have been
       # had it never been dropped, and the ordinary admission path folds them
       # back together — rather than this method inventing a second merge rule
@@ -423,7 +460,8 @@ module Collavre
         payload = Task.find_by(id: task.id)&.trigger_event_payload
         return unless payload.is_a?(Hash) && payload.key?("topic")
 
-        orphaned = dropped_ids_in(payload) - claimed_comment_ids(task) - restored_ids_in(payload)
+        orphaned = dropped_ids_in(payload) - handed_off_ids_in(payload) -
+                   claimed_comment_ids(task) - restored_ids_in(payload)
         return if orphaned.empty?
 
         agent = task.agent

--- a/engines/collavre/app/services/collavre/orchestration/delivery_record.rb
+++ b/engines/collavre/app/services/collavre/orchestration/delivery_record.rb
@@ -48,6 +48,23 @@ module Collavre
       # `queued`/`pending` are excluded at both: nothing has been delivered yet.
       IN_FLIGHT_STATUSES = %w[running delegated pending_approval].freeze
 
+      # Terminal statuses in which the turn delivered nothing after all.
+      #
+      # The complement of AgentOrchestrator::DELIVERED_STATUSES over the
+      # terminal set, and that is the whole point: promotion says a dead turn
+      # silences nothing by leaving these statuses out of its list, and a parked
+      # waiter survives on that — it is still a row, and the refresh re-reads
+      # the covering turn's status before deciding anything.
+      #
+      # A *dropped* dispatch has no row to re-read anything. So the drop owes
+      # the same answer through the only means it has left: putting the
+      # discarded dispatch back. Without it the two doors disagree about what a
+      # failure means, and the disagreement costs a comment nobody answers.
+      #
+      # DeliveryRecordTest asserts this is exactly the complement; a status
+      # added to one list and not the other is how they drift apart.
+      UNDELIVERED_TERMINAL_STATUSES = %w[failed cancelled escalated].freeze
+
       # Record what `resolved` carries as chat history.
       #
       # Measured off the *resolved* payload — the messages the adapter is handed
@@ -118,6 +135,77 @@ module Collavre
           ids_in(task.trigger_event_payload).include?(comment_id.to_i)
         end
       end
+
+      # Put back the dispatches this turn's record caused to be discarded, now
+      # that the turn has ended without delivering them.
+      #
+      # Driven off Task's status callback rather than from AiAgentJob's rescue:
+      # the job is not the only door onto a failed turn — StuckDetector fails a
+      # task that never reached a rescue at all — and a restore wired to one of
+      # them is a restore that does not happen on the other.
+      #
+      # Restores only what nothing else is on the hook for. A comment swept into
+      # this turn's history may still have a waiter of its own (parked before
+      # the turn assembled, so never droppable), and promotion decides that
+      # waiter's fate by re-reading this turn's status. Restoring it as well
+      # would put two turns on one comment. "Has a row" is measured, not
+      # inferred from what the drop believes it dropped.
+      #
+      # Each orphan is re-dispatched on its own, exactly as it would have been
+      # had it never been dropped, and the ordinary admission path folds them
+      # back together — rather than this method inventing a second merge rule
+      # beside TaskCoalescer's.
+      def self.restore!(task)
+        payload = task.trigger_event_payload
+        return unless payload.is_a?(Hash) && payload.key?("topic")
+
+        orphaned = ids_in(payload) - claimed_comment_ids(task)
+        return if orphaned.empty?
+
+        agent = task.agent
+        return if agent.nil?
+
+        # Same eligibility the refresh applies when it moves an anchor: a
+        # comment that was deleted, made private, or turned into an approval
+        # action while the turn ran has nothing left to answer.
+        Comment.public_only.without_approval_action
+          .where(id: orphaned, topic_id: task.topic_id, creative_id: task.creative_id)
+          .where.not(user_id: [ agent.id, nil ])
+          .order(:id)
+          .each do |comment|
+          AiAgentJob.perform_later(agent.id, task.trigger_event_name, restored_context(payload, comment))
+        end
+      end
+
+      # The dispatch that was discarded — not a descendant of the turn that
+      # discarded it. reanchor_payload is the single door for moving an anchor,
+      # and the three bookkeeping keys are stripped after it because they
+      # describe the dead turn: its own record would make a restored turn that
+      # fails again restore the same comments a second time, its merged list
+      # would re-send comments it was created for, and its acquired anchor would
+      # label this turn's own trigger as borrowed.
+      def self.restored_context(payload, comment)
+        TaskCoalescer.reanchor_payload(payload, comment)
+          .except(KEY, TaskCoalescer::PAYLOAD_KEY, TaskCoalescer::ACQUIRED_ANCHOR_KEY)
+      end
+      private_class_method :restored_context
+
+      # Comment ids some other task in this turn's scope is already on the hook
+      # for, as its trigger or as a merged block. Any status counts: what is
+      # being asked is whether a dispatch exists at all, since the only thing
+      # this restore undoes is a dispatch that was never allowed to become one.
+      def self.claimed_comment_ids(task)
+        Task.where(
+          agent_id: task.agent_id, topic_id: task.topic_id,
+          creative_id: task.creative_id, trigger_event_name: task.trigger_event_name
+        ).where.not(id: task.id).select(:id, :trigger_event_payload).flat_map { |other|
+          other_payload = other.trigger_event_payload
+          next [] unless other_payload.is_a?(Hash)
+
+          [ other_payload.dig("comment", "id") ] + Array(other_payload[TaskCoalescer::PAYLOAD_KEY])
+        }.compact.map(&:to_i)
+      end
+      private_class_method :claimed_comment_ids
 
       def self.history_comment_ids(resolved)
         messages = resolved.is_a?(Hash) ? Array(resolved[:messages] || resolved["messages"]) : Array(resolved)

--- a/engines/collavre/app/services/collavre/orchestration/delivery_record.rb
+++ b/engines/collavre/app/services/collavre/orchestration/delivery_record.rb
@@ -313,9 +313,49 @@ module Collavre
           .where.not(user_id: [ agent.id, nil ])
           .order(:id)
           .each do |comment|
-          AiAgentJob.perform_later(agent.id, task.trigger_event_name, restored_context(payload, comment))
+          enqueue_restored(agent, task.trigger_event_name, restored_context(payload, comment))
         end
       end
+
+      # Put the dispatch back the way the orchestrator would have, by asking the
+      # same Scheduler again.
+      #
+      # The decision the drop discarded was a decision about *then*. A dispatch
+      # refused while the agent was at its concurrency limit or rate-limited
+      # carried a backoff with it, and enqueuing it now would run it past the
+      # check that set that delay — while the dying turn's own ResourceTracker
+      # slot is very often still held, since this fires from its status
+      # callback. Replaying the delay recorded at drop time would be no better:
+      # by now it describes pressure that may be long gone or much worse.
+      #
+      # Asked again, not merely honoured: a quota exhausted or a loop breaker
+      # tripped between the drop and the restore refuses this dispatch exactly
+      # as it would refuse a fresh one. AgentOrchestrator's own guard keeps
+      # rejected work out of the record; this is the other end of the same
+      # question, and only the scheduler can answer it as of now.
+      #
+      # Enqueued through AiAgentJob rather than AgentOrchestrator#enqueue_jobs
+      # even for a :deferred decision, because the job door re-asks
+      # Matcher#assignment_permits? against the re-anchored payload before it
+      # parks anything — a restored dispatch has moved, and park_waiter would
+      # create the row without that question being asked.
+      def self.enqueue_restored(agent, event_name, context)
+        decision = Scheduler.new(context).schedule([ agent ]).first
+        return if decision.nil?
+
+        case decision[:timing]
+        when :rejected
+          Rails.logger.info(
+            "[DeliveryRecord] Not restoring dispatch for comment #{context.dig("comment", "id")}: " \
+            "scheduler rejected agent #{agent.id} (#{decision[:reason]})"
+          )
+        when :delayed
+          AiAgentJob.set(wait: decision[:delay]).perform_later(agent.id, event_name, context)
+        else
+          AiAgentJob.perform_later(agent.id, event_name, context)
+        end
+      end
+      private_class_method :enqueue_restored
 
       # The dispatch that was discarded — not a descendant of the turn that
       # discarded it. reanchor_payload is the single door for moving an anchor,

--- a/engines/collavre/app/services/collavre/orchestration/delivery_record.rb
+++ b/engines/collavre/app/services/collavre/orchestration/delivery_record.rb
@@ -115,6 +115,20 @@ module Collavre
       # added to one list and not the other is how they drift apart.
       UNDELIVERED_TERMINAL_STATUSES = %w[failed cancelled escalated].freeze
 
+      # Statuses a row can be in and still owe a restore — the undelivered
+      # endings, plus the one that reads as delivered until the payload is
+      # consulted. Derived rather than listed so the sweep cannot come to scan
+      # for less than Task#ended_undelivered? decides on.
+      RESTORABLE_STATUSES = (UNDELIVERED_TERMINAL_STATUSES + %w[done]).freeze
+
+      # How far back restore_missed! looks.
+      #
+      # Comfortably more than its schedule, so a restore the callback lost gets
+      # several attempts, and finite because it is a backstop: a comment whose
+      # turn ended an hour ago has been overtaken by whatever the topic did
+      # since, and re-dispatching it then would be the more surprising answer.
+      RESTORE_SWEEP_WINDOW = 1.hour
+
       # Record what `resolved` carries as chat history.
       #
       # Measured off the *resolved* payload — the messages the adapter is handed
@@ -313,7 +327,49 @@ module Collavre
           .where.not(user_id: [ agent.id, nil ])
           .order(:id)
           .each do |comment|
-          enqueue_restored(agent, task.trigger_event_name, restored_context(payload, comment))
+          begin
+            enqueue_restored(agent, task.trigger_event_name, restored_context(payload, comment))
+          rescue StandardError => e
+            # Each orphan is a dispatch of its own; one that cannot be enqueued
+            # says nothing about the next. What it leaves behind is the absence
+            # of a row, which is exactly what restore_missed! reads.
+            Rails.logger.error(
+              "[DeliveryRecord] Failed to restore dispatch for comment #{comment.id} " \
+              "of task #{task.id}: #{e.class}: #{e.message}"
+            )
+          end
+        end
+      end
+
+      # Ask again for every turn whose restore may not have been made.
+      #
+      # restore! runs from an after_update_commit callback, which is to say
+      # after the covering turn's status is already committed: a transient
+      # failure there has nothing left to roll back and no later transition that
+      # would retry it, and the dropped dispatch is the one thing in this
+      # feature with no row of its own to fall back on.
+      #
+      # Nothing extra is persisted for it, because the orphan set already is:
+      # DROPPED_KEY is on the row and claimed_comment_ids subtracts whatever has
+      # since acquired a Task, so a comment stays orphaned exactly until its
+      # dispatch exists again and restore! is idempotent by construction. What
+      # was lost is only the asking.
+      #
+      # A dispatch the Scheduler refuses leaves no row either, so it is asked
+      # again on each pass through the window — which is the right answer for a
+      # quota that has since reset, and a bounded number of cheap refusals if it
+      # has not.
+      def self.restore_missed!(window: RESTORE_SWEEP_WINDOW)
+        Task.where(status: RESTORABLE_STATUSES)
+            .where(updated_at: window.ago..)
+            .find_each do |task|
+          next unless task.ended_undelivered?
+
+          restore!(task)
+        rescue StandardError => e
+          Rails.logger.error(
+            "[DeliveryRecord] Restore sweep failed for task #{task.id}: #{e.class}: #{e.message}"
+          )
         end
       end
 

--- a/engines/collavre/app/services/collavre/orchestration/delivery_record.rb
+++ b/engines/collavre/app/services/collavre/orchestration/delivery_record.rb
@@ -34,6 +34,26 @@ module Collavre
       # turn ends up carrying a comment it was not dispatched for.
       KEY = "history_delivered_comment_ids"
 
+      # Comment ids whose dispatch this turn actually refused.
+      #
+      # A strict subset of KEY, and the distinction matters because the two are
+      # read for opposite purposes. KEY answers "has the agent been given this
+      # comment?", and chat history is the whole topic — Matcher's exclusive
+      # routings do not filter it, so every agent in a topic reads every public
+      # comment in it, including ones addressed to somebody else. That is the
+      # right predicate for the drop, which is only ever asked downstream of
+      # Matcher about a dispatch that already exists.
+      #
+      # It is the wrong predicate for the restore, whose subject is dispatches
+      # and which creates one per id it decides on. Reading KEY there turns a
+      # comment routed past this agent into a turn for it, past Matcher
+      # entirely; and it reads a dispatch still sitting in the job queue — an
+      # :immediate decision's Task row is created only when its job runs — as a
+      # discarded one, putting a second turn on a comment that already has one.
+      # Neither is visible in the absence of a Task row, so the drop is written
+      # down instead of reconstructed.
+      DROPPED_KEY = "dropped_dispatch_comment_ids"
+
       # Statuses in which a turn is still the thing that will answer.
       #
       # Narrower than AgentOrchestrator::DELIVERED_STATUSES, which also counts
@@ -103,6 +123,40 @@ module Collavre
         Array(payload[KEY]).compact.map(&:to_i)
       end
 
+      def self.dropped_ids_in(payload)
+        return [] unless payload.is_a?(Hash)
+
+        Array(payload[DROPPED_KEY]).compact.map(&:to_i)
+      end
+
+      # Take responsibility for a dispatch about to be discarded, or refuse it.
+      #
+      # The drop and its record are one act, and this is where they are made
+      # one. `covering_task` answers off the caller's snapshot; between that
+      # answer and this write the turn can end, run its restore, and leave —
+      # and a record written after that restore is a comment nobody ever comes
+      # back for. So the status is re-read from the locked row, and a caller
+      # told `false` dispatches normally instead of dropping. Refusing a sound
+      # drop costs a redundant turn; taking an unsound one costs the message.
+      #
+      # @return [Boolean] whether the caller may discard the dispatch
+      def self.claim_drop!(covering, comment_id)
+        id = comment_id.to_i
+        return false if covering.nil? || id.zero?
+
+        claimed = false
+        Task.transaction do
+          task = Task.lock.find_by(id: covering.id)
+          payload = task&.trigger_event_payload
+          next unless task&.status.to_s.in?(IN_FLIGHT_STATUSES) && payload.is_a?(Hash)
+
+          dropped = (dropped_ids_in(payload) + [ id ]).uniq.sort
+          task.update!(trigger_event_payload: payload.merge(DROPPED_KEY => dropped))
+          claimed = true
+        end
+        claimed
+      end
+
       # The in-flight turn that has already given `comment_id` to `agent`, or nil.
       #
       # Every gate that drops a dispatch goes through this one method: the
@@ -144,22 +198,33 @@ module Collavre
       # task that never reached a rescue at all — and a restore wired to one of
       # them is a restore that does not happen on the other.
       #
-      # Restores only what nothing else is on the hook for. A comment swept into
-      # this turn's history may still have a waiter of its own (parked before
-      # the turn assembled, so never droppable), and promotion decides that
-      # waiter's fate by re-reading this turn's status. Restoring it as well
-      # would put two turns on one comment. "Has a row" is measured, not
-      # inferred from what the drop believes it dropped.
+      # Its subject is DROPPED_KEY — the dispatches this turn refused — and not
+      # KEY, which is merely everything it read. Only a refused dispatch is a
+      # thing this turn owes back; see DROPPED_KEY for what taking the wider
+      # set costs.
+      #
+      # Narrowed once more by what nothing else is on the hook for. A comment
+      # swept into this turn's history may still have a waiter of its own
+      # (parked before the turn assembled, so never droppable), and promotion
+      # decides that waiter's fate by re-reading this turn's status. Restoring
+      # it as well would put two turns on one comment. Belt to DROPPED_KEY's
+      # braces: the record already excludes what was never dropped, and this
+      # excludes what has since acquired a row of its own.
       #
       # Each orphan is re-dispatched on its own, exactly as it would have been
       # had it never been dropped, and the ordinary admission path folds them
       # back together — rather than this method inventing a second merge rule
       # beside TaskCoalescer's.
       def self.restore!(task)
-        payload = task.trigger_event_payload
+        # Re-read the row rather than trust the caller's copy. The drop record
+        # is written by whichever dispatch was refused, in another process
+        # entirely, onto a row this turn's own object was loaded before — so
+        # the in-memory payload that reaches this callback is exactly the one
+        # that predates every drop it is being asked about.
+        payload = Task.find_by(id: task.id)&.trigger_event_payload
         return unless payload.is_a?(Hash) && payload.key?("topic")
 
-        orphaned = ids_in(payload) - claimed_comment_ids(task)
+        orphaned = dropped_ids_in(payload) - claimed_comment_ids(task)
         return if orphaned.empty?
 
         agent = task.agent
@@ -179,14 +244,15 @@ module Collavre
 
       # The dispatch that was discarded — not a descendant of the turn that
       # discarded it. reanchor_payload is the single door for moving an anchor,
-      # and the three bookkeeping keys are stripped after it because they
-      # describe the dead turn: its own record would make a restored turn that
-      # fails again restore the same comments a second time, its merged list
-      # would re-send comments it was created for, and its acquired anchor would
-      # label this turn's own trigger as borrowed.
+      # and the four bookkeeping keys are stripped after it because they
+      # describe the dead turn: its drop list would make a restored turn that
+      # fails again restore the same comments a second time, its history record
+      # would licence dropping them, its merged list would re-send comments it
+      # was created for, and its acquired anchor would label this turn's own
+      # trigger as borrowed.
       def self.restored_context(payload, comment)
         TaskCoalescer.reanchor_payload(payload, comment)
-          .except(KEY, TaskCoalescer::PAYLOAD_KEY, TaskCoalescer::ACQUIRED_ANCHOR_KEY)
+          .except(KEY, DROPPED_KEY, TaskCoalescer::PAYLOAD_KEY, TaskCoalescer::ACQUIRED_ANCHOR_KEY)
       end
       private_class_method :restored_context
 

--- a/engines/collavre/app/services/collavre/orchestration/delivery_record.rb
+++ b/engines/collavre/app/services/collavre/orchestration/delivery_record.rb
@@ -123,6 +123,17 @@ module Collavre
       # way.
       RESTORED_KEY = "restored_dispatch_comment_ids"
 
+      # StuckDetector failed this `running` row from outside its worker while
+      # the worker may still be inside the provider call.
+      #
+      # The failed status alone cannot say whether the payload reached the
+      # provider: AiAgentService writes that evidence only when the call returns
+      # or raises. The status callback therefore defers while this marker is
+      # present. The live worker clears it in AiAgentJob's ensure; if the worker
+      # died outright, restore_missed! waits out the provider timeout and asks
+      # again.
+      WORKER_SETTLING_KEY = "delivery_worker_settling"
+
       # Everything a turn writes onto its own payload while it runs, as opposed
       # to what it was dispatched with.
       #
@@ -134,7 +145,8 @@ module Collavre
       # and the drift test on this constant is what will catch the sixth.
       TURN_SCOPED_KEYS = [
         KEY, DROPPED_KEY, HANDOFF_FAILED_KEY, HANDED_OFF_KEY, HANDED_OFF_IDS_KEY,
-        RESTORED_KEY, TaskCoalescer::PAYLOAD_KEY, TaskCoalescer::ACQUIRED_ANCHOR_KEY
+        RESTORED_KEY, WORKER_SETTLING_KEY, TaskCoalescer::PAYLOAD_KEY,
+        TaskCoalescer::ACQUIRED_ANCHOR_KEY
       ].freeze
 
       # Statuses in which a turn is still the thing that will answer.
@@ -182,9 +194,9 @@ module Collavre
       # since, and re-dispatching it then would be the more surprising answer.
       RESTORE_SWEEP_WINDOW = 1.hour
 
-      # Slack added to the provider timeout when waiting for a stopped turn's
-      # worker to settle — see .cancel_settle_grace.
-      CANCEL_SETTLE_SLACK = 5.minutes
+      # Slack added to the provider timeout when waiting for a worker that
+      # another process ended to settle — see .worker_settle_grace.
+      WORKER_SETTLE_SLACK = 5.minutes
 
       # Record what `resolved` carries as chat history.
       #
@@ -300,6 +312,52 @@ module Collavre
         return [] unless payload.is_a?(Hash)
 
         Array(payload[HANDED_OFF_IDS_KEY]).compact.map(&:to_i)
+      end
+
+      # Fail a running row from outside its worker without letting the status
+      # callback decide from evidence the worker has not written yet.
+      #
+      # Status and marker are one locked update. A marker written before a
+      # separate status update could be observed by the sweep while the row was
+      # still running; one written afterwards is too late for the callback.
+      def self.fail_while_worker_settles!(task)
+        return false if task.nil?
+
+        failed = false
+        Task.transaction do
+          row = Task.lock.find_by(id: task.id)
+          next unless row&.status == "running"
+
+          payload = row.trigger_event_payload
+          payload = {} unless payload.is_a?(Hash)
+          row.update!(
+            status: "failed",
+            trigger_event_payload: payload.merge(WORKER_SETTLING_KEY => true)
+          )
+          failed = true
+        end
+        task.reload if failed
+        failed
+      end
+
+      def self.worker_settling?(payload)
+        payload.is_a?(Hash) && payload[WORKER_SETTLING_KEY] == true
+      end
+
+      # The original worker has left the provider call, so the handoff records
+      # now carry the best answer this attempt can give. Clearing under the row
+      # lock preserves any drop written by another process in the meantime.
+      def self.settle_worker!(task)
+        return if task.nil?
+
+        Task.transaction do
+          row = Task.lock.find_by(id: task.id)
+          payload = row&.trigger_event_payload
+          next unless worker_settling?(payload)
+
+          row.update!(trigger_event_payload: payload.except(WORKER_SETTLING_KEY))
+        end
+        task.reload
       end
 
       def self.restored_ids_in(payload)
@@ -507,15 +565,15 @@ module Collavre
       # again on each pass through the window — which is the right answer for a
       # quota that has since reset, and a bounded number of cheap refusals if it
       # has not.
-      # How long after a cancellation this sweep waits before deciding it.
+      # How long after another process ends a worker this sweep waits before
+      # deciding it.
       #
-      # Task#stopped_mid_turn? explains why the status callback declines: Stop is
-      # committed from another process while the worker is inside AiClient#chat,
-      # and the worker's account of the handoff is written only on the way out.
-      # This door reads a settled row, so it cannot ask that question — and it
-      # cannot tell "still settling" from "nobody is coming" either. Without a
-      # wait it answers in the callback's place and re-dispatches everything the
-      # turn swallowed, minutes after the user asked for no more work.
+      # Task#ended_while_worker_settles? explains why the status callback
+      # declines: Stop and StuckDetector both commit from another process while
+      # the worker can be inside AiClient#chat, and the worker's account of the
+      # handoff is written only on the way out. This door cannot tell "still
+      # settling" from "nobody is coming" either. Without a wait it answers in
+      # the callback's place and re-dispatches everything the turn swallowed.
       #
       # Derived from the configured provider timeout because that is what bounds
       # the wait in the shape this is for: Stop pressed while the turn is still
@@ -525,21 +583,19 @@ module Collavre
       # It is not a bound on a conversation that keeps making requests without
       # yielding content — a tool loop can outlast any grace, and for that one
       # this sweep can still be early. What that costs is a duplicate reply;
-      # declining cancellations outright would cost the comment, and the
-      # cancellers with no worker behind them at all — an agent unregistering,
-      # an offline delegate, a worker killed before its own rescue — are exactly
-      # what this sweep is here for.
-      def self.cancel_settle_grace
-        SystemSetting.llm_request_timeout_seconds.seconds + CANCEL_SETTLE_SLACK
+      # declining these endings outright would cost the comment when the worker
+      # died before it could clear the marker.
+      def self.worker_settle_grace
+        SystemSetting.llm_request_timeout_seconds.seconds + WORKER_SETTLE_SLACK
       end
 
       def self.restore_missed!(window: RESTORE_SWEEP_WINDOW)
-        grace = cancel_settle_grace
+        grace = worker_settle_grace
 
         [
           # The endings whose status is written after the worker is out of the
           # provider call, so the row is as settled as it will ever be.
-          Task.where(status: RESTORABLE_STATUSES - [ "cancelled" ])
+          Task.where(status: RESTORABLE_STATUSES - %w[cancelled failed])
               .where(updated_at: window.ago..),
           # And the one that is not. The window moves with the wait rather than
           # being spent by it: subtracting the grace from a fixed horizon would
@@ -550,17 +606,31 @@ module Collavre
         ].each do |scope|
           scope.find_each { |task| restore_if_undelivered!(task) }
         end
+
+        # A normal failed ending is settled and keeps the ordinary window. A
+        # StuckDetector failure carries WORKER_SETTLING_KEY and gets the same
+        # grace as cancellation. Read the marker in Ruby so this stays portable
+        # across the JSON implementations used by SQLite tests and PostgreSQL.
+        Task.where(status: "failed")
+            .where(updated_at: (window + grace).ago..)
+            .find_each do |task|
+          settling = worker_settling?(task.trigger_event_payload)
+          next if settling && task.updated_at > grace.ago
+          next if !settling && task.updated_at < window.ago
+
+          restore_if_undelivered!(task)
+        end
       end
 
       # Ask the restore question of a turn that has settled.
       #
       # The one door for every caller that is not Task's status callback: this
       # sweep, and AiAgentJob's cancellation teardown, which is where a turn
-      # stopped mid-answer settles — see Task#stopped_mid_turn? for why the
-      # cancel itself cannot decide. Gated on the same predicate the callback is,
-      # because a second door deciding "terminal" where the callback decides
-      # Task#ended_undelivered? is how one of them comes to re-answer comments
-      # the turn had already answered.
+      # stopped mid-answer settles — see Task#ended_while_worker_settles? for why
+      # the cancel itself cannot decide. Gated on the same predicate the callback
+      # is, because a second door deciding "terminal" where the callback decides
+      # Task#ended_undelivered? is how one of them comes to re-answer comments the
+      # turn had already answered.
       #
       # Best effort, like the callback's: the teardown runs inside the job's last
       # rescue, where an escaping exception would turn a cancelled turn into a

--- a/engines/collavre/app/services/collavre/orchestration/delivery_record.rb
+++ b/engines/collavre/app/services/collavre/orchestration/delivery_record.rb
@@ -103,19 +103,53 @@ module Collavre
       #
       # Accumulates. A resumed turn (pending_approval, or a retry) assembles a
       # second time, and what the first pass delivered it still delivered.
+      #
+      # Written onto the row's payload under the same lock as claim_drop!, not
+      # onto the caller's. A resumed turn's task object is loaded before it
+      # assembles, and a dispatch refused in the meantime writes DROPPED_KEY
+      # into the same JSON column from another process; a merge onto the stale
+      # copy would erase the drop, and a drop no restore can find is the
+      # message lost. Both writers of this column now read it under the lock.
       def self.record!(task, resolved)
-        payload = task.trigger_event_payload
-        return unless payload.is_a?(Hash)
+        return if task.nil?
 
-        anchor_id = payload.dig("comment", "id").to_i
-        return if anchor_id.zero?
+        Task.transaction do
+          row = Task.lock.find_by(id: task.id)
+          payload = row&.trigger_event_payload
+          next unless payload.is_a?(Hash)
 
-        swallowed = history_comment_ids(resolved).select { |id| id > anchor_id }
-        merged = (ids_in(payload) + swallowed).uniq.sort
-        return if merged == ids_in(payload)
+          anchor_id = payload.dig("comment", "id").to_i
+          next if anchor_id.zero?
 
-        task.update!(trigger_event_payload: payload.merge(KEY => merged))
+          swallowed = delivered_in_full(history_comment_ids(resolved).select { |id| id > anchor_id })
+          merged = (ids_in(payload) + swallowed).uniq.sort
+          next if merged == ids_in(payload)
+
+          row.update!(trigger_event_payload: payload.merge(KEY => merged))
+          task.reload unless task.equal?(row)
+        end
       end
+
+      # Of `ids`, the comments a history entry carries whole.
+      #
+      # A history entry is text: MessageBuilder#append_chat_history renders
+      # `content` and nothing else, while blobs ride only on the trigger, which
+      # attaches the anchor's images and the merged blocks'. So a comment with
+      # an attachment that the window swept up has been *partly* delivered, and
+      # this record's predicate — the agent has been given this comment — is
+      # false for it. Recording it would let the drop discard the one dispatch
+      # that would have carried the image, and an image-only comment would
+      # reach the agent as a blank line under someone's name.
+      #
+      # Excluded here, at the record, rather than at each gate: the record is
+      # what the dispatch doors and AgentOrchestrator.delivered_comment_ids all
+      # read, so a partial delivery kept out of it is kept out of every one.
+      def self.delivered_in_full(ids)
+        return ids if ids.empty?
+
+        ids - Comment.where(id: ids).joins(:images_attachments).distinct.pluck(:id)
+      end
+      private_class_method :delivered_in_full
 
       def self.ids_in(payload)
         return [] unless payload.is_a?(Hash)

--- a/engines/collavre/app/services/collavre/orchestration/delivery_record.rb
+++ b/engines/collavre/app/services/collavre/orchestration/delivery_record.rb
@@ -162,6 +162,10 @@ module Collavre
       # since, and re-dispatching it then would be the more surprising answer.
       RESTORE_SWEEP_WINDOW = 1.hour
 
+      # Slack added to the provider timeout when waiting for a stopped turn's
+      # worker to settle — see .cancel_settle_grace.
+      CANCEL_SETTLE_SLACK = 5.minutes
+
       # Record what `resolved` carries as chat history.
       #
       # Measured off the *resolved* payload — the messages the adapter is handed
@@ -465,10 +469,49 @@ module Collavre
       # again on each pass through the window — which is the right answer for a
       # quota that has since reset, and a bounded number of cheap refusals if it
       # has not.
+      # How long after a cancellation this sweep waits before deciding it.
+      #
+      # Task#stopped_mid_turn? explains why the status callback declines: Stop is
+      # committed from another process while the worker is inside AiClient#chat,
+      # and the worker's account of the handoff is written only on the way out.
+      # This door reads a settled row, so it cannot ask that question — and it
+      # cannot tell "still settling" from "nobody is coming" either. Without a
+      # wait it answers in the callback's place and re-dispatches everything the
+      # turn swallowed, minutes after the user asked for no more work.
+      #
+      # Derived from the configured provider timeout because that is what bounds
+      # the wait in the shape this is for: Stop pressed while the turn is still
+      # waiting for its first token, where AgentLifecycleManager#check_cancelled!
+      # cannot fire at all because it polls from inside the streaming block.
+      #
+      # It is not a bound on a conversation that keeps making requests without
+      # yielding content — a tool loop can outlast any grace, and for that one
+      # this sweep can still be early. What that costs is a duplicate reply;
+      # declining cancellations outright would cost the comment, and the
+      # cancellers with no worker behind them at all — an agent unregistering,
+      # an offline delegate, a worker killed before its own rescue — are exactly
+      # what this sweep is here for.
+      def self.cancel_settle_grace
+        SystemSetting.llm_request_timeout_seconds.seconds + CANCEL_SETTLE_SLACK
+      end
+
       def self.restore_missed!(window: RESTORE_SWEEP_WINDOW)
-        Task.where(status: RESTORABLE_STATUSES)
-            .where(updated_at: window.ago..)
-            .find_each { |task| restore_if_undelivered!(task) }
+        grace = cancel_settle_grace
+
+        [
+          # The endings whose status is written after the worker is out of the
+          # provider call, so the row is as settled as it will ever be.
+          Task.where(status: RESTORABLE_STATUSES - [ "cancelled" ])
+              .where(updated_at: window.ago..),
+          # And the one that is not. The window moves with the wait rather than
+          # being spent by it: subtracting the grace from a fixed horizon would
+          # leave a cancellation less backstop than every other ending gets, and
+          # at the default timeout almost none.
+          Task.where(status: "cancelled")
+              .where(updated_at: (window + grace).ago..grace.ago)
+        ].each do |scope|
+          scope.find_each { |task| restore_if_undelivered!(task) }
+        end
       end
 
       # Ask the restore question of a turn that has settled.

--- a/engines/collavre/app/services/collavre/orchestration/delivery_record.rb
+++ b/engines/collavre/app/services/collavre/orchestration/delivery_record.rb
@@ -294,6 +294,20 @@ module Collavre
       # for, as its trigger or as a merged block. Any status counts: what is
       # being asked is whether a dispatch exists at all, since the only thing
       # this restore undoes is a dispatch that was never allowed to become one.
+      #
+      # A terminal sibling counts too, and deliberately. For a comment to be in
+      # DROPPED_KEY *and* have a row, the row came from a different dispatch of
+      # the same comment — a redelivered event, which `duplicate_running_for_
+      # comment?` lets past a merely queued waiter — so the discarded one is the
+      # duplicate and the row is the comment's own turn. Reading `cancelled` or
+      # `failed` there as "no longer coverage" would re-dispatch the duplicate
+      # of a turn the user stopped, or that reassignment, agent teardown or a
+      # workflow stop cancelled on purpose; restore! re-asks the comment's
+      # eligibility but has no way to re-ask those decisions. A turn that failed
+      # leaves a failed Task the product already shows and offers to retry,
+      # which is the ordinary ending for every turn — not this restore's
+      # subject, which is the dispatch that left nothing behind at all.
+      # DeliveredHistoryDispatchTest reproduces that state and holds both.
       def self.claimed_comment_ids(task)
         Task.where(
           agent_id: task.agent_id, topic_id: task.topic_id,

--- a/engines/collavre/app/services/collavre/orchestration/delivery_record.rb
+++ b/engines/collavre/app/services/collavre/orchestration/delivery_record.rb
@@ -54,6 +54,22 @@ module Collavre
       # down instead of reconstructed.
       DROPPED_KEY = "dropped_dispatch_comment_ids"
 
+      # This turn asked the provider for an answer and the request never got
+      # there.
+      #
+      # Every other reader here decides off the turn's *status*, which works
+      # while the endings line up with what was delivered. This one does not:
+      # AiClient#chat catches the provider error, streams "⚠️ AI Error" into
+      # the reply and returns nil, and AiAgentJob marks an ordinary task `done`
+      # on that — the single status every reader counts as delivery. So a turn
+      # can end in the delivered ending having handed over nothing at all, and
+      # the comments it discarded were read by nobody.
+      #
+      # Recorded rather than inferred, because nothing else in the row says it:
+      # `done` with an error in the reply text looks exactly like `done`. The
+      # only place that knows is the service holding the client that failed.
+      HANDOFF_FAILED_KEY = "handoff_failed"
+
       # Statuses in which a turn is still the thing that will answer.
       #
       # Narrower than AgentOrchestrator::DELIVERED_STATUSES, which also counts
@@ -136,6 +152,32 @@ module Collavre
         Array(payload[KEY]).compact.map(&:to_i)
       end
 
+      # Write down that this turn's request never reached the provider.
+      #
+      # Under the same row lock as record! and claim_drop!, for the same
+      # reason: a dispatch refused in another process writes DROPPED_KEY into
+      # this JSON column while the turn runs, and a merge onto the caller's
+      # copy would erase it.
+      def self.mark_handoff_failed!(task)
+        return if task.nil?
+
+        Task.transaction do
+          row = Task.lock.find_by(id: task.id)
+          payload = row&.trigger_event_payload
+          next unless payload.is_a?(Hash)
+          next if handoff_failed?(payload)
+
+          row.update!(trigger_event_payload: payload.merge(HANDOFF_FAILED_KEY => true))
+          task.reload unless task.equal?(row)
+        end
+      end
+
+      def self.handoff_failed?(payload)
+        return false unless payload.is_a?(Hash)
+
+        payload[HANDOFF_FAILED_KEY] == true
+      end
+
       def self.dropped_ids_in(payload)
         return [] unless payload.is_a?(Hash)
 
@@ -199,7 +241,13 @@ module Collavre
           trigger_event_name: trigger_event_name,
           status: IN_FLIGHT_STATUSES
         ).select(:id, :trigger_event_payload).find do |task|
-          ids_in(task.trigger_event_payload).include?(comment_id.to_i)
+          payload = task.trigger_event_payload
+          # A turn still `running` after its request failed is not going to
+          # answer anything, and dropping against it would record a drop after
+          # the restore that ends it has already looked.
+          next false if handoff_failed?(payload)
+
+          ids_in(payload).include?(comment_id.to_i)
         end
       end
 

--- a/engines/collavre/app/services/collavre/orchestration/delivery_record.rb
+++ b/engines/collavre/app/services/collavre/orchestration/delivery_record.rb
@@ -468,15 +468,33 @@ module Collavre
       def self.restore_missed!(window: RESTORE_SWEEP_WINDOW)
         Task.where(status: RESTORABLE_STATUSES)
             .where(updated_at: window.ago..)
-            .find_each do |task|
-          next unless task.ended_undelivered?
+            .find_each { |task| restore_if_undelivered!(task) }
+      end
 
-          restore!(task)
-        rescue StandardError => e
-          Rails.logger.error(
-            "[DeliveryRecord] Restore sweep failed for task #{task.id}: #{e.class}: #{e.message}"
-          )
-        end
+      # Ask the restore question of a turn that has settled.
+      #
+      # The one door for every caller that is not Task's status callback: this
+      # sweep, and AiAgentJob's cancellation teardown, which is where a turn
+      # stopped mid-answer settles — see Task#stopped_mid_turn? for why the
+      # cancel itself cannot decide. Gated on the same predicate the callback is,
+      # because a second door deciding "terminal" where the callback decides
+      # Task#ended_undelivered? is how one of them comes to re-answer comments
+      # the turn had already answered.
+      #
+      # Best effort, like the callback's: the teardown runs inside the job's last
+      # rescue, where an escaping exception would turn a cancelled turn into a
+      # failed job, and the sweep must not lose the rest of its pass to one row.
+      # Nothing is lost by swallowing — the orphan set is on the row, so the next
+      # pass asks again.
+      def self.restore_if_undelivered!(task)
+        return if task.nil? || !task.ended_undelivered?
+
+        restore!(task)
+      rescue StandardError => e
+        Rails.logger.error(
+          "[DeliveryRecord] Restore failed for task #{task.id}: #{e.class}: #{e.message} — " \
+          "leaving it to the restore sweep"
+        )
       end
 
       # Put the dispatch back the way the orchestrator would have, by asking the

--- a/engines/collavre/app/services/collavre/orchestration/delivery_record.rb
+++ b/engines/collavre/app/services/collavre/orchestration/delivery_record.rb
@@ -70,6 +70,20 @@ module Collavre
       # only place that knows is the service holding the client that failed.
       HANDOFF_FAILED_KEY = "handoff_failed"
 
+      # Everything a turn writes onto its own payload while it runs, as opposed
+      # to what it was dispatched with.
+      #
+      # One list rather than a strip enumerated at the point of use: a restored
+      # dispatch is the one that was discarded, so it carries what a dispatch
+      # carries and nothing the turn wrote onto itself afterwards. Enumerating
+      # that at the call site is how HANDOFF_FAILED_KEY came to be left in — it
+      # was added here long after restored_context had named the other four —
+      # and the drift test on this constant is what will catch the sixth.
+      TURN_SCOPED_KEYS = [
+        KEY, DROPPED_KEY, HANDOFF_FAILED_KEY,
+        TaskCoalescer::PAYLOAD_KEY, TaskCoalescer::ACQUIRED_ANCHOR_KEY
+      ].freeze
+
       # Statuses in which a turn is still the thing that will answer.
       #
       # Narrower than AgentOrchestrator::DELIVERED_STATUSES, which also counts
@@ -305,15 +319,15 @@ module Collavre
 
       # The dispatch that was discarded — not a descendant of the turn that
       # discarded it. reanchor_payload is the single door for moving an anchor,
-      # and the four bookkeeping keys are stripped after it because they
-      # describe the dead turn: its drop list would make a restored turn that
+      # and TURN_SCOPED_KEYS is stripped after it because every one of them
+      # describes the dead turn: its drop list would make a restored turn that
       # fails again restore the same comments a second time, its history record
-      # would licence dropping them, its merged list would re-send comments it
-      # was created for, and its acquired anchor would label this turn's own
-      # trigger as borrowed.
+      # would licence dropping them, its failed handoff would leave a turn that
+      # succeeded unable to cover anything it read, its merged list would
+      # re-send comments it was created for, and its acquired anchor would
+      # label this turn's own trigger as borrowed.
       def self.restored_context(payload, comment)
-        TaskCoalescer.reanchor_payload(payload, comment)
-          .except(KEY, DROPPED_KEY, TaskCoalescer::PAYLOAD_KEY, TaskCoalescer::ACQUIRED_ANCHOR_KEY)
+        TaskCoalescer.reanchor_payload(payload, comment).except(*TURN_SCOPED_KEYS)
       end
       private_class_method :restored_context
 

--- a/engines/collavre/app/services/collavre/orchestration/matcher.rb
+++ b/engines/collavre/app/services/collavre/orchestration/matcher.rb
@@ -47,6 +47,14 @@ module Collavre
         end
       end
 
+      # The permission every routing path in #match is gated on, asked on its
+      # own — for a caller that names its agent instead of matching one.
+      # DeliveryRecord.restore! is that caller: it puts back the dispatch this
+      # matcher once produced, and nothing else on its way re-asks this.
+      def self.permits_creative_access?(context, agent)
+        new(SystemEvents::ContextBuilder.new(context).build).has_creative_permission?(agent)
+      end
+
       def initialize(context)
         @context = context
       end
@@ -100,6 +108,19 @@ module Collavre
         mentioned_id = @context.dig("chat", "mentioned_user", "id") ||
           @context.dig(:chat, :mentioned_user, :id)
         mentioned_id.present? && mentioned_id.to_i == agent.id
+      end
+
+      # Public because #match is not the only door onto a dispatch: a restore
+      # names the agent the match once produced, and this is the gate every
+      # branch of #match shares. One predicate, so the two doors cannot come to
+      # disagree about what "may answer this creative" means.
+      def has_creative_permission?(agent)
+        # All agents need feedback permission on the creative to respond
+        # searchable only affects discoverability, not response permission
+        creative = matched_creative
+        return false unless creative
+
+        creative.has_permission?(agent, :feedback)
       end
 
       private
@@ -234,15 +255,6 @@ module Collavre
       rescue StandardError => e
         Rails.logger.error("[Matcher] Routing error for agent #{agent.id}: #{e.message}")
         false
-      end
-
-      def has_creative_permission?(agent)
-        # All agents need feedback permission on the creative to respond
-        # searchable only affects discoverability, not response permission
-        creative = matched_creative
-        return false unless creative
-
-        creative.has_permission?(agent, :feedback)
       end
 
       def matched_creative

--- a/engines/collavre/app/services/collavre/orchestration/policy_resolver.rb
+++ b/engines/collavre/app/services/collavre/orchestration/policy_resolver.rb
@@ -31,6 +31,10 @@ module Collavre
           # Fold un-started tasks for the same agent/topic/creative into one so a
           # burst of comments produces one answer instead of one per comment.
           "coalesce_pending_tasks" => true,
+          # Drop a dispatch whose comment an in-flight turn has already been
+          # given, instead of parking it as a waiter (see
+          # Orchestration::DeliveryRecord).
+          "drop_delivered_dispatches" => true,
           # Loop breaker settings
           "loop_breaker_enabled" => true,
           "ping_pong_threshold" => 5,           # Max back-and-forth between same agents
@@ -107,6 +111,24 @@ module Collavre
       def coalesce_pending_tasks_for?(agent)
         config = agent ? scheduling_config_for(agent) : scheduling_config
         config["coalesce_pending_tasks"] != false
+      end
+
+      # Whether a dispatch is dropped outright when an in-flight turn has
+      # already delivered its comment (see Orchestration::DeliveryRecord).
+      #
+      # Resolved per agent for the same reason coalescing is: delivery is a
+      # same-agent question, and a User-scoped scheduling policy is how an
+      # administrator turns this off for one agent without touching the others
+      # in the topic.
+      #
+      # Only the *drop* is switched. The record itself keeps being written
+      # whatever this says — it is evidence of what an agent was sent, and the
+      # promotion door reads it to keep a parked waiter from replaying a
+      # delivered comment. Gating the write here would make turning the switch
+      # off mid-burst leave that door reading a record with a hole in it.
+      def drop_delivered_dispatches_for?(agent)
+        config = agent ? scheduling_config_for(agent) : scheduling_config
+        config["drop_delivered_dispatches"] != false
       end
 
       # Convenience methods

--- a/engines/collavre/app/services/collavre/orchestration/stuck_detector.rb
+++ b/engines/collavre/app/services/collavre/orchestration/stuck_detector.rb
@@ -133,7 +133,14 @@ module Collavre
         task = stuck_item.item
         return unless %w[running delegated].include?(task.status)
 
-        task.update!(status: "failed")
+        recovered = if task.status == "running"
+          DeliveryRecord.fail_while_worker_settles!(task)
+        else
+          task.update!(status: "failed")
+          true
+        end
+        return unless recovered
+
         Rails.logger.info(
           "[StuckDetector] Auto-recovered task #{task.id} (agent=#{task.agent_id}): " \
           "marked as failed after #{((Time.current - stuck_item.stuck_since) / 60).round} minutes"

--- a/engines/collavre/app/services/collavre/orchestration/task_coalescer.rb
+++ b/engines/collavre/app/services/collavre/orchestration/task_coalescer.rb
@@ -72,19 +72,29 @@ module Collavre
       # @return [Hash] the updated payload (not saved)
       def self.reanchor_payload(payload, comment)
         previous_id = payload.dig("comment", "id")
+        # The anchor block is rebuilt from Comment#dispatch_payload rather than
+        # enumerated here. That method is the declared single source of truth
+        # for what a comment_created dispatch carries, and everything in it
+        # describes the anchor: "from_ai" is what AiAgentJob#record_loop_breaker_
+        # turn reads to decide whether a turn was agent-started, so a move that
+        # drops it exempts agent-to-agent work from the creative-retry breaker,
+        # and "quoted_comment_id" is what binds a review to the comment it
+        # quotes. Enumerating the keys here means the list falls behind the
+        # payload the ordinary door builds, silently, one key at a time.
+        #
+        # Rebuilt, never merged onto: a key absent for this comment must be
+        # absent afterwards. Carrying the previous anchor's "from_ai" or its
+        # quoted comment forward is the same defect pointing the other way.
         moved = payload.merge(
-          "comment" => {
-            "id" => comment.id,
-            "content" => comment.content,
-            "user_id" => comment.user_id
-          },
+          comment.dispatch_payload.slice(:comment).deep_stringify_keys,
           "chat" => SystemEvents::ContextBuilder.reanchor_chat(comment.content)
         )
         moved[ACQUIRED_ANCHOR_KEY] = comment.id if previous_id && previous_id.to_i != comment.id
-        # Both keys ContextBuilder derives from the anchor are rebuilt here,
-        # because it fills each one in with `||=` and does not run again on
-        # either of these paths. "chat"/"mentioned_user" moves with the anchor
-        # above (ContextBuilder.reanchor_chat); "sender" below.
+        # Both keys ContextBuilder *derives* from the anchor are rebuilt here
+        # too — dispatch_payload does not carry them, because ContextBuilder
+        # fills each one in with `||=` and does not run again on either of
+        # these paths. "chat"/"mentioned_user" moves with the anchor above
+        # (ContextBuilder.reanchor_chat); "sender" below.
         #
         # The payload's "sender" labels the trigger and is what
         # ClaudeChannelAdapter sends as author_id/author_name, and

--- a/engines/collavre/app/services/collavre/orchestration/task_coalescer.rb
+++ b/engines/collavre/app/services/collavre/orchestration/task_coalescer.rb
@@ -78,9 +78,14 @@ module Collavre
             "content" => comment.content,
             "user_id" => comment.user_id
           },
-          "chat" => { "content" => comment.content }
+          "chat" => SystemEvents::ContextBuilder.reanchor_chat(comment.content)
         )
         moved[ACQUIRED_ANCHOR_KEY] = comment.id if previous_id && previous_id.to_i != comment.id
+        # Both keys ContextBuilder derives from the anchor are rebuilt here,
+        # because it fills each one in with `||=` and does not run again on
+        # either of these paths. "chat"/"mentioned_user" moves with the anchor
+        # above (ContextBuilder.reanchor_chat); "sender" below.
+        #
         # The payload's "sender" labels the trigger and is what
         # ClaudeChannelAdapter sends as author_id/author_name, and
         # SystemEvents::ContextBuilder only ever fills it in with `||=` — it does

--- a/engines/collavre/app/services/collavre/system_events/context_builder.rb
+++ b/engines/collavre/app/services/collavre/system_events/context_builder.rb
@@ -40,6 +40,32 @@ module Collavre
         }
       end
 
+      # The "chat" block for a comment the trigger has just been moved onto.
+      #
+      # Public for the same reason `sender_context_for` is: `build` only ever
+      # fills "mentioned_user" in (`||=`) and does not run again on a
+      # re-anchoring path, and AiAgentJob asks Matcher#assignment_permits?
+      # against the raw payload. A mention left behind by the move therefore
+      # reads as "no mention at all" — and an explicit mention is precisely what
+      # outranks a topic's primary-agent assignment, so a restored or promoted
+      # dispatch that *was* addressed to this agent gets refused for a topic
+      # that belongs to someone else.
+      #
+      # The block is rebuilt rather than merged onto: a mention that finds
+      # nobody must leave the key absent, since Matcher reads its presence as
+      # the mention that outranks the assignment.
+      def self.reanchor_chat(content)
+        chat = { "content" => content }
+        mention = mentioned_user_for(content)
+        mention ? chat.merge("mentioned_user" => mention) : chat
+      end
+
+      def self.mentioned_user_for(content)
+        return nil unless content
+
+        MentionParser.resolve_user(content)&.as_json(only: [ :id, :name, :email ])
+      end
+
       # Point a payload's sender at the comment the trigger has just been moved
       # onto. Only when the author actually changed: a payload may carry a sender
       # its producer shaped deliberately (Comments::WorkflowExecutor attributes a
@@ -67,11 +93,7 @@ module Collavre
       end
 
       def mentioned_user(chat_context)
-        content = chat_context["content"]
-        return nil unless content
-
-        user = MentionParser.resolve_user(content)
-        user&.as_json(only: [ :id, :name, :email ])
+        self.class.mentioned_user_for(chat_context["content"])
       end
     end
   end

--- a/engines/collavre/test/jobs/ai_agent_job_test.rb
+++ b/engines/collavre/test/jobs/ai_agent_job_test.rb
@@ -28,6 +28,8 @@ class AiAgentJobTest < ActiveJob::TestCase
       block.call("AI Response") if block
       "AI Response"
     end
+
+    def last_handoff_failed? = false
   end
 
   test "creates task and executes service" do
@@ -71,6 +73,8 @@ class AiAgentJobTest < ActiveJob::TestCase
       # Do not yield any content
       ""
     end
+
+    def last_handoff_failed? = false
   end
 
   test "does not create reply if AI response is empty" do
@@ -105,6 +109,8 @@ class AiAgentJobTest < ActiveJob::TestCase
       block.call("AI Response") if block
       "AI Response"
     end
+
+    def last_handoff_failed? = false
   end
 
   test "renders system prompt with liquid context" do
@@ -131,6 +137,8 @@ class AiAgentJobTest < ActiveJob::TestCase
       block.call("AI Response") if block
       "AI Response"
     end
+
+    def last_handoff_failed? = false
 
     # Extract the messages array from the Hash (or return as-is for backward compat)
     def captured_messages

--- a/engines/collavre/test/jobs/ai_agent_job_test.rb
+++ b/engines/collavre/test/jobs/ai_agent_job_test.rb
@@ -253,6 +253,100 @@ class AiAgentJobTest < ActiveJob::TestCase
     lifecycle_klass.const_set(:CANCEL_CHECK_INTERVAL, original_interval)
   end
 
+  # A turn stopped mid-answer settles here, in this rescue, and not where it was
+  # stopped: the user's Stop is committed from a web request while this worker is
+  # still inside the provider call, so Task's status callback is asked a poll
+  # interval before AiAgentService's ensure records whether the payload got
+  # there. These two drive the real ordering through the real job.
+  test "a dispatch dropped against a turn stopped after the handoff is not restored" do
+    topic, _swallowed, task = stopped_turn_fixture
+
+    with_zero_cancel_interval do
+      AiClient.stub :new, stopping_client(task, handed_off: true).new do
+        AiAgentJob.perform_now(task)
+      end
+    end
+
+    assert_equal "cancelled", task.reload.status, "premise: the user's Stop landed"
+    assert_empty dispatches_besides(task, topic),
+                 "the provider had that comment; re-dispatching it answers it twice"
+  end
+
+  # The mirror, and what keeps the settling from becoming "cancelled restores
+  # nothing": stopped before anything reached the provider, the comments this
+  # turn silenced are owed back.
+  test "a dispatch dropped against a turn stopped before the handoff is restored when it settles" do
+    topic, swallowed, task = stopped_turn_fixture
+
+    with_zero_cancel_interval do
+      AiClient.stub :new, stopping_client(task, handed_off: false).new do
+        AiAgentJob.perform_now(task)
+      end
+    end
+
+    assert_equal "cancelled", task.reload.status, "premise: the user's Stop landed"
+    assert_equal [ swallowed.id ],
+                 dispatches_besides(task, topic).map { |t| t.trigger_event_payload.dig("comment", "id") },
+                 "nothing read that comment; it has no turn unless this one gives it back"
+  end
+
+  # A running turn with one dispatch dropped against it, and the comment that
+  # dispatch was for.
+  def stopped_turn_fixture
+    topic = Topic.create!(name: "Stop topic", creative: @creative, user: @owner)
+    share = Collavre::CreativeShare.find_or_create_by!(creative: @creative, user: @agent)
+    share.update!(permission: "feedback")
+    Collavre::CreativeSharesCache.find_or_create_by!(
+      creative_id: @creative.id, user_id: @agent.id, permission: :feedback
+    )
+    swallowed = Comment.create!(
+      creative: @creative, user: @owner, topic: topic,
+      content: "@#{@agent.name}: swallowed", skip_dispatch: true
+    )
+    task = Task.create!(
+      name: "Turn", status: "running", trigger_event_name: "comment_created",
+      trigger_event_payload: @context.merge(
+        "topic" => { "id" => topic.id },
+        "sender" => { "id" => @owner.id, "name" => @owner.name }
+      ),
+      agent: @agent, topic_id: topic.id, creative_id: @creative.id
+    )
+    assert Collavre::Orchestration::DeliveryRecord.claim_drop!(task, swallowed.id),
+           "premise: a dispatch was dropped against this turn"
+    [ topic, swallowed, task.reload ]
+  end
+
+  # Streams, then has somebody else press Stop — a separately loaded row, as the
+  # controller has: the object this worker holds is not the one that is written.
+  def stopping_client(task, handed_off:)
+    Class.new do
+      define_method(:initialize) { |*args, **kwargs| }
+      define_method(:chat) do |contents, tools: [], &block|
+        block.call("partial ") if block && handed_off
+        Collavre::Task.find(task.id).update!(status: "cancelled")
+        block.call("more") if block
+        "partial more"
+      end
+      define_method(:last_handoff_failed?) { false }
+      define_method(:handed_off?) { handed_off }
+    end
+  end
+
+  def dispatches_besides(task, topic)
+    Task.where(agent: @agent, topic_id: topic.id).where.not(id: task.id)
+  end
+
+  def with_zero_cancel_interval
+    klass = Collavre::AiAgent::AgentLifecycleManager
+    original = klass::CANCEL_CHECK_INTERVAL
+    klass.send(:remove_const, :CANCEL_CHECK_INTERVAL)
+    klass.const_set(:CANCEL_CHECK_INTERVAL, 0)
+    yield
+  ensure
+    klass.send(:remove_const, :CANCEL_CHECK_INTERVAL)
+    klass.const_set(:CANCEL_CHECK_INTERVAL, original)
+  end
+
   test "triggers dequeue_next_for_topic on completion" do
     topic = Topic.create!(name: "Test Topic", creative: @creative, user: @owner)
     context_with_topic = @context.merge("topic" => { "id" => topic.id })

--- a/engines/collavre/test/jobs/ai_agent_job_test.rb
+++ b/engines/collavre/test/jobs/ai_agent_job_test.rb
@@ -30,6 +30,7 @@ class AiAgentJobTest < ActiveJob::TestCase
     end
 
     def last_handoff_failed? = false
+    def handed_off? = true
   end
 
   test "creates task and executes service" do
@@ -75,6 +76,9 @@ class AiAgentJobTest < ActiveJob::TestCase
     end
 
     def last_handoff_failed? = false
+    # An empty answer is an answer: the provider had the payload, as the real
+    # client reports for one.
+    def handed_off? = true
   end
 
   test "does not create reply if AI response is empty" do
@@ -111,6 +115,7 @@ class AiAgentJobTest < ActiveJob::TestCase
     end
 
     def last_handoff_failed? = false
+    def handed_off? = true
   end
 
   test "renders system prompt with liquid context" do
@@ -139,6 +144,7 @@ class AiAgentJobTest < ActiveJob::TestCase
     end
 
     def last_handoff_failed? = false
+    def handed_off? = true
 
     # Extract the messages array from the Hash (or return as-is for backward compat)
     def captured_messages
@@ -224,6 +230,9 @@ class AiAgentJobTest < ActiveJob::TestCase
         block.call("chunk 1 ") if block
         "chunk 0 chunk 1 "
       end
+      define_method(:last_handoff_failed?) { false }
+      # Streamed before the stop, as the real client records.
+      define_method(:handed_off?) { true }
     end
 
     # Temporarily set cancel check interval to 0 so it checks on every chunk

--- a/engines/collavre/test/jobs/ai_agent_job_test.rb
+++ b/engines/collavre/test/jobs/ai_agent_job_test.rb
@@ -290,6 +290,39 @@ class AiAgentJobTest < ActiveJob::TestCase
                  "nothing read that comment; it has no turn unless this one gives it back"
   end
 
+  # StuckDetector can fail the row while this job is still inside #chat. The
+  # status callback must wait, but the live worker must not leave the dispatch
+  # waiting for the periodic sweep once it does come out and can answer whether
+  # a handoff happened.
+  test "a worker settles and restores a stuck failure when its provider call exits" do
+    topic, swallowed, task = stopped_turn_fixture
+    with_test_queue do
+      assert_enqueued_jobs 0
+
+      probe = -> {
+        assert_enqueued_jobs 0,
+                             "stuck recovery ran while the provider call was still active"
+      }
+      client = failing_after_stuck_recovery_client(task, probe)
+
+      Collavre::Orchestration::AgentOrchestrator.stub(:dequeue_next_for_topic, ->(*) { }) do
+        AiClient.stub :new, client.new do
+          assert_raises(StandardError) { AiAgentJob.perform_now(task) }
+        end
+      end
+
+      restored = enqueued_jobs.select { |job| job[:job] == Collavre::AiAgentJob }
+      assert_equal 1, restored.size
+      assert_equal swallowed.id, restored.sole[:args][2].dig("comment", "id"),
+                   "the failed provider call handed nothing over, so its worker owes the dispatch back"
+      assert_equal "failed", task.reload.status
+      assert_not Collavre::Orchestration::DeliveryRecord.worker_settling?(
+        task.trigger_event_payload
+      ), "the live worker settled the marker rather than leaving the sweep to guess"
+      assert_equal topic.id, task.topic_id
+    end
+  end
+
   # A running turn with one dispatch dropped against it, and the comment that
   # dispatch was for.
   def stopped_turn_fixture
@@ -330,6 +363,33 @@ class AiAgentJobTest < ActiveJob::TestCase
       define_method(:last_handoff_failed?) { false }
       define_method(:handed_off?) { handed_off }
     end
+  end
+
+  def failing_after_stuck_recovery_client(task, probe)
+    Class.new do
+      define_method(:initialize) { |*args, **kwargs| }
+      define_method(:chat) do |contents, tools: [], &block|
+        item = Collavre::Orchestration::StuckDetector::StuckItem.new(
+          type: :task, item: task.reload, reason: :no_progress,
+          stuck_since: 1.hour.ago, escalation_targets: []
+        )
+        Collavre::Orchestration::StuckDetector.new.send(:recover_stuck_task, item)
+        probe.call
+        raise StandardError, "provider call ended without a handoff"
+      end
+      define_method(:last_handoff_failed?) { false }
+      define_method(:handed_off?) { false }
+    end
+  end
+
+  def with_test_queue
+    original = ActiveJob::Base.queue_adapter
+    ActiveJob::Base.queue_adapter = :test
+    clear_enqueued_jobs
+    yield
+  ensure
+    clear_enqueued_jobs
+    ActiveJob::Base.queue_adapter = original
   end
 
   def dispatches_besides(task, topic)

--- a/engines/collavre/test/services/ai_agent_service_test.rb
+++ b/engines/collavre/test/services/ai_agent_service_test.rb
@@ -31,6 +31,7 @@ class AiAgentServiceTest < ActiveSupport::TestCase
       yield "Chunk 2"
     end
     def mock_client.last_handoff_failed? = false
+    def mock_client.handed_off? = true
 
     initial_comment_count = @creative.comments.count
 
@@ -58,6 +59,7 @@ class AiAgentServiceTest < ActiveSupport::TestCase
       yield "Response"
     end
     def mock_client.last_handoff_failed? = false
+    def mock_client.handed_off? = true
 
     broadcasts = []
     creative_id = @creative.effective_origin.id
@@ -87,6 +89,7 @@ class AiAgentServiceTest < ActiveSupport::TestCase
       yield "AI Response"
     end
     def mock_client.last_handoff_failed? = false
+    def mock_client.handed_off? = true
 
     activity_log = ActivityLog.create!(
       activity: "llm_query",
@@ -118,6 +121,7 @@ class AiAgentServiceTest < ActiveSupport::TestCase
       # No yield - empty response
     end
     def mock_client.last_handoff_failed? = false
+    def mock_client.handed_off? = true
 
     initial_comment_count = @creative.comments.count
 
@@ -147,6 +151,7 @@ class AiAgentServiceTest < ActiveSupport::TestCase
       yield "@AgentB: 이 주제에 대해 어떻게 생각해?"
     end
     def mock_client.last_handoff_failed? = false
+    def mock_client.handed_off? = true
 
     dispatched = false
     original_dispatch = Collavre::SystemEvents::Dispatcher.method(:dispatch)
@@ -170,6 +175,7 @@ class AiAgentServiceTest < ActiveSupport::TestCase
       yield "@One: 확인해 주세요"
     end
     def mock_client.last_handoff_failed? = false
+    def mock_client.handed_off? = true
 
     dispatched = false
     Collavre::SystemEvents::Dispatcher.stub :dispatch, ->(*) { dispatched = true } do
@@ -187,6 +193,7 @@ class AiAgentServiceTest < ActiveSupport::TestCase
       yield "Just a normal response without mentions"
     end
     def mock_client.last_handoff_failed? = false
+    def mock_client.handed_off? = true
 
     dispatched = false
     Collavre::SystemEvents::Dispatcher.stub :dispatch, ->(*) { dispatched = true } do
@@ -303,6 +310,8 @@ class AiAgentServiceTest < ActiveSupport::TestCase
       Task.find(task_id).update!(status: "cancelled")
       block.call(" more")
     end
+    def mock_client.last_handoff_failed? = false
+    def mock_client.handed_off? = true
 
     original_interval = Collavre::AiAgent::AgentLifecycleManager::CANCEL_CHECK_INTERVAL
     Collavre::AiAgent::AgentLifecycleManager.send(:remove_const, :CANCEL_CHECK_INTERVAL)
@@ -334,6 +343,7 @@ class AiAgentServiceTest < ActiveSupport::TestCase
       yield "\n\n⚠️ AI Error: [StandardError] connection refused"
     end
     def mock_client.last_handoff_failed? = true
+    def mock_client.handed_off? = false
 
     AiClient.stub :new, mock_client do
       AiAgentService.new(@task).call
@@ -350,11 +360,74 @@ class AiAgentServiceTest < ActiveSupport::TestCase
       yield "An answer"
     end
     def mock_client.last_handoff_failed? = false
+    def mock_client.handed_off? = true
 
     AiClient.stub :new, mock_client do
       AiAgentService.new(@task).call
     end
 
     assert_not Collavre::Orchestration::DeliveryRecord.handoff_failed?(@task.reload.trigger_event_payload)
+  end
+
+  # A user pressing Stop mid-answer ends the turn `cancelled`, which every
+  # reader counts as undelivered — but the provider has the payload by then, and
+  # with it the comments this turn swallowed. Nothing in the row says which side
+  # of the handoff the Stop landed on; the client is the only object that knows.
+  test "records the handoff when the turn is stopped after content streamed" do
+    task_id = @task.id
+    mock_client = Object.new
+    mock_client.define_singleton_method(:chat) do |_messages, tools: [], &block|
+      block.call("Partial ")
+      Task.find(task_id).update!(status: "cancelled")
+      block.call("content")
+    end
+    def mock_client.last_handoff_failed? = false
+    def mock_client.handed_off? = true
+
+    with_immediate_cancel_checks do
+      assert_raises(Collavre::CancelledError) do
+        AiClient.stub :new, mock_client do
+          AiAgentService.new(@task).call
+        end
+      end
+    end
+
+    assert Collavre::Orchestration::DeliveryRecord.handed_off?(@task.reload.trigger_event_payload)
+  end
+
+  # Control: the record follows the client's answer, not the fact of
+  # cancellation. A turn stopped before its request got anywhere delivered
+  # nothing, and the dispatches it discarded still have to come back.
+  test "records no handoff when the turn is stopped before anything reached the provider" do
+    task_id = @task.id
+    mock_client = Object.new
+    mock_client.define_singleton_method(:chat) do |_messages, tools: [], &block|
+      Task.find(task_id).update!(status: "cancelled")
+      block.call("")
+      block.call("late")
+    end
+    def mock_client.last_handoff_failed? = false
+    def mock_client.handed_off? = false
+
+    with_immediate_cancel_checks do
+      assert_raises(Collavre::CancelledError) do
+        AiClient.stub :new, mock_client do
+          AiAgentService.new(@task).call
+        end
+      end
+    end
+
+    assert_not Collavre::Orchestration::DeliveryRecord.handed_off?(@task.reload.trigger_event_payload)
+  end
+
+  def with_immediate_cancel_checks
+    manager = Collavre::AiAgent::AgentLifecycleManager
+    original = manager::CANCEL_CHECK_INTERVAL
+    manager.send(:remove_const, :CANCEL_CHECK_INTERVAL)
+    manager.const_set(:CANCEL_CHECK_INTERVAL, 0)
+    yield
+  ensure
+    manager.send(:remove_const, :CANCEL_CHECK_INTERVAL)
+    manager.const_set(:CANCEL_CHECK_INTERVAL, original)
   end
 end

--- a/engines/collavre/test/services/ai_agent_service_test.rb
+++ b/engines/collavre/test/services/ai_agent_service_test.rb
@@ -30,6 +30,7 @@ class AiAgentServiceTest < ActiveSupport::TestCase
       yield "Chunk 1 "
       yield "Chunk 2"
     end
+    def mock_client.last_handoff_failed? = false
 
     initial_comment_count = @creative.comments.count
 
@@ -56,6 +57,7 @@ class AiAgentServiceTest < ActiveSupport::TestCase
     def mock_client.chat(messages, tools: [])
       yield "Response"
     end
+    def mock_client.last_handoff_failed? = false
 
     broadcasts = []
     creative_id = @creative.effective_origin.id
@@ -84,6 +86,7 @@ class AiAgentServiceTest < ActiveSupport::TestCase
     def mock_client.chat(messages, tools: [])
       yield "AI Response"
     end
+    def mock_client.last_handoff_failed? = false
 
     activity_log = ActivityLog.create!(
       activity: "llm_query",
@@ -114,6 +117,7 @@ class AiAgentServiceTest < ActiveSupport::TestCase
     def mock_client.chat(messages, tools: [])
       # No yield - empty response
     end
+    def mock_client.last_handoff_failed? = false
 
     initial_comment_count = @creative.comments.count
 
@@ -142,6 +146,7 @@ class AiAgentServiceTest < ActiveSupport::TestCase
     def mock_client.chat(messages, tools: [])
       yield "@AgentB: 이 주제에 대해 어떻게 생각해?"
     end
+    def mock_client.last_handoff_failed? = false
 
     dispatched = false
     original_dispatch = Collavre::SystemEvents::Dispatcher.method(:dispatch)
@@ -164,6 +169,7 @@ class AiAgentServiceTest < ActiveSupport::TestCase
     def mock_client.chat(messages, tools: [])
       yield "@One: 확인해 주세요"
     end
+    def mock_client.last_handoff_failed? = false
 
     dispatched = false
     Collavre::SystemEvents::Dispatcher.stub :dispatch, ->(*) { dispatched = true } do
@@ -180,6 +186,7 @@ class AiAgentServiceTest < ActiveSupport::TestCase
     def mock_client.chat(messages, tools: [])
       yield "Just a normal response without mentions"
     end
+    def mock_client.last_handoff_failed? = false
 
     dispatched = false
     Collavre::SystemEvents::Dispatcher.stub :dispatch, ->(*) { dispatched = true } do
@@ -314,5 +321,40 @@ class AiAgentServiceTest < ActiveSupport::TestCase
     reply = @creative.comments.where(user: @agent).order(:created_at).last
     assert reply.content.start_with?("Partial content")
     assert @task.task_actions.exists?(action_type: "cancelled")
+  end
+
+  # The service is the only place that sees both the delivery record it wrote
+  # and the client that failed to hand it over. AiClient#chat swallows the
+  # provider error and the job then marks the task `done`, so unless the
+  # failure is written down here the turn ends in a status every reader counts
+  # as delivery — and the dispatches it discarded never come back.
+  test "records a failed handoff when the client never reached the provider" do
+    mock_client = Minitest::Mock.new
+    def mock_client.chat(messages, tools: [])
+      yield "\n\n⚠️ AI Error: [StandardError] connection refused"
+    end
+    def mock_client.last_handoff_failed? = true
+
+    AiClient.stub :new, mock_client do
+      AiAgentService.new(@task).call
+    end
+
+    assert Collavre::Orchestration::DeliveryRecord.handoff_failed?(@task.reload.trigger_event_payload)
+  end
+
+  # Control: an ordinary turn records nothing, so the flag cannot be what every
+  # completed turn carries.
+  test "records no failed handoff when the client answered" do
+    mock_client = Minitest::Mock.new
+    def mock_client.chat(messages, tools: [])
+      yield "An answer"
+    end
+    def mock_client.last_handoff_failed? = false
+
+    AiClient.stub :new, mock_client do
+      AiAgentService.new(@task).call
+    end
+
+    assert_not Collavre::Orchestration::DeliveryRecord.handoff_failed?(@task.reload.trigger_event_payload)
   end
 end

--- a/engines/collavre/test/services/ai_client_test.rb
+++ b/engines/collavre/test/services/ai_client_test.rb
@@ -645,4 +645,72 @@ class AiClientTest < ActiveSupport::TestCase
     assert_equal [ "First.", "\n\n", "Second." ], yielded
     assert_equal "First.\n\nSecond.", result
   end
+
+  # #chat swallows a provider error: it streams "⚠️ AI Error" to the user and
+  # returns nil, which an ordinary empty answer also returns. Orchestration::
+  # DeliveryRecord needs the two apart — a turn that handed the provider
+  # nothing delivered nothing, and the dispatches it discarded on the strength
+  # of "the agent has read that comment" have to come back.
+  test "records a handoff failure when the request errors before any content" do
+    conversation = FakeConversation.new
+    def conversation.complete
+      raise StandardError, "connection refused"
+    end
+
+    client = AiClient.new(
+      vendor: "google", model: "gemini-pro", system_prompt: "system", llm_api_key: "api-key"
+    )
+
+    result = client.stub(:build_conversation, conversation) do
+      client.chat([ { role: "user", parts: [ { text: "hello" } ] } ])
+    end
+
+    assert_nil result, "premise: the caught error is indistinguishable from an empty answer by return value"
+    assert_predicate client, :last_handoff_failed?
+  end
+
+  # Control, and the boundary: an error *after* deltas have streamed is not a
+  # failed handoff. The provider had the payload and answered part of it, which
+  # the product surfaces as a truncated reply — the agent did read the comments
+  # that turn swallowed.
+  test "does not record a handoff failure when the error came after content streamed" do
+    conversation = FakeConversation.new
+    conversation.define_singleton_method(:complete) do |&block|
+      block.call(OpenStruct.new(content: "half an answer"))
+      raise StandardError, "stream closed"
+    end
+
+    client = AiClient.new(
+      vendor: "google", model: "gemini-pro", system_prompt: "system", llm_api_key: "api-key"
+    )
+
+    yielded = +""
+    client.stub(:build_conversation, conversation) do
+      client.chat([ { role: "user", parts: [ { text: "hello" } ] } ]) { |delta| yielded << delta }
+    end
+
+    assert_includes yielded, "half an answer", "premise: the provider did answer, partially"
+    assert_not client.last_handoff_failed?
+  end
+
+  # Control against the flag latching: an ordinary chat leaves it false, and so
+  # does an empty-but-successful one, which returns nil for a different reason.
+  test "does not record a handoff failure on a chat that reached the provider" do
+    client = AiClient.new(
+      vendor: "google", model: "gemini-pro", system_prompt: "system", llm_api_key: "api-key"
+    )
+
+    client.stub(:build_conversation, FakeConversation.new) do
+      client.chat([ { role: "user", parts: [ { text: "hello" } ] } ])
+    end
+    assert_not client.last_handoff_failed?
+
+    empty = FakeConversation.new
+    empty.define_singleton_method(:complete) { |&_block| OpenStruct.new(content: "") }
+    client.stub(:build_conversation, empty) do
+      assert_nil client.chat([ { role: "user", parts: [ { text: "hello" } ] } ])
+    end
+    assert_not client.last_handoff_failed?,
+               "an empty answer is an answer; the provider had the payload"
+  end
 end

--- a/engines/collavre/test/services/ai_client_test.rb
+++ b/engines/collavre/test/services/ai_client_test.rb
@@ -784,4 +784,55 @@ class AiClientTest < ActiveSupport::TestCase
 
     assert_not client.handed_off?
   end
+
+  # A delta of exactly "\n\n" is content — the delta branch says so in as many
+  # words, and skips only truly *empty* chunks for that reason. The rescue below
+  # it classified with `blank?`, which is true of that same delta, so a stream
+  # broken after a paragraph break recorded the handoff *and* its failure. Task#
+  # ended_undelivered? reads the failure first, so every comment that turn
+  # swallowed is dispatched again although the provider had them.
+  test "does not record a handoff failure when the error came after a whitespace-only delta" do
+    conversation = FakeConversation.new
+    conversation.define_singleton_method(:complete) do |&block|
+      block.call(OpenStruct.new(content: "\n\n"))
+      raise StandardError, "stream closed"
+    end
+
+    client = AiClient.new(
+      vendor: "google", model: "gemini-pro", system_prompt: "system", llm_api_key: "api-key"
+    )
+
+    yielded = []
+    client.stub(:build_conversation, conversation) do
+      client.chat([ { role: "user", parts: [ { text: "hello" } ] } ]) { |delta| yielded << delta }
+    end
+
+    assert_equal "\n\n", yielded.first, "premise: the provider streamed, and the delta reached the caller"
+    assert_predicate client, :handed_off?, "premise: the payload got there"
+    assert_not client.last_handoff_failed?
+  end
+
+  # The invariant Task#ended_undelivered? is written on: the two records are one
+  # boundary asked twice, so no ending can carry both. It reads the failure
+  # first precisely because it cannot ask which of two contradictory records is
+  # the true one — that has to be impossible here rather than resolved there.
+  test "records the handoff and its failure as one boundary asked two ways" do
+    [ [ "nothing", nil ], [ "a paragraph break", "\n\n" ], [ "an answer", "half an answer" ] ].each do |what, streamed|
+      conversation = FakeConversation.new
+      conversation.define_singleton_method(:complete) do |&block|
+        block.call(OpenStruct.new(content: streamed)) if streamed
+        raise StandardError, "stream closed"
+      end
+
+      client = AiClient.new(
+        vendor: "google", model: "gemini-pro", system_prompt: "system", llm_api_key: "api-key"
+      )
+      client.stub(:build_conversation, conversation) do
+        client.chat([ { role: "user", parts: [ { text: "hello" } ] } ]) { |_delta| nil }
+      end
+
+      assert_equal !client.handed_off?, client.last_handoff_failed?,
+                   "a stream that broke after #{what} must answer the same question the same way"
+    end
+  end
 end

--- a/engines/collavre/test/services/ai_client_test.rb
+++ b/engines/collavre/test/services/ai_client_test.rb
@@ -713,4 +713,75 @@ class AiClientTest < ActiveSupport::TestCase
     assert_not client.last_handoff_failed?,
                "an empty answer is an answer; the provider had the payload"
   end
+
+  # The other half of the same question, asked positively. #last_handoff_failed?
+  # is only ever set from a rescue, so it cannot answer for a chat that raised
+  # past it — which is what a user pressing Stop mid-answer does. What the
+  # cancelled turn needs to know is whether the provider got the payload.
+  test "records the handoff once content has streamed" do
+    conversation = FakeConversation.new
+    conversation.define_singleton_method(:complete) do |&block|
+      block.call(OpenStruct.new(content: "half an answer"))
+      raise Collavre::CancelledError
+    end
+
+    client = AiClient.new(
+      vendor: "google", model: "gemini-pro", system_prompt: "system", llm_api_key: "api-key"
+    )
+
+    assert_raises(Collavre::CancelledError) do
+      client.stub(:build_conversation, conversation) do
+        client.chat([ { role: "user", parts: [ { text: "hello" } ] } ]) { |_delta| nil }
+      end
+    end
+
+    assert_predicate client, :handed_off?
+  end
+
+  # Deltas are not the only way an answer arrives: a provider that returns its
+  # whole reply at once yields nothing at all, and that turn handed over just as
+  # much. The delta branch alone would read it as never having reached anybody.
+  test "records the handoff for an answer that arrived without deltas" do
+    conversation = FakeConversation.new
+    conversation.define_singleton_method(:complete) do |&_block|
+      OpenStruct.new(content: "the whole answer")
+    end
+
+    client = AiClient.new(
+      vendor: "google", model: "gemini-pro", system_prompt: "system", llm_api_key: "api-key"
+    )
+
+    result = client.stub(:build_conversation, conversation) do
+      client.chat([ { role: "user", parts: [ { text: "hello" } ] } ])
+    end
+
+    assert_equal "the whole answer", result, "premise: nothing streamed, and yet it answered"
+    assert_predicate client, :handed_off?
+  end
+
+  # Control: nothing streamed means nothing was handed over — the same boundary
+  # #last_handoff_failed? draws — and the answer belongs to this chat alone, not
+  # to the one before it.
+  test "records no handoff for a chat that streamed nothing" do
+    client = AiClient.new(
+      vendor: "google", model: "gemini-pro", system_prompt: "system", llm_api_key: "api-key"
+    )
+
+    client.stub(:build_conversation, FakeConversation.new) do
+      client.chat([ { role: "user", parts: [ { text: "hello" } ] } ])
+    end
+    assert_predicate client, :handed_off?, "premise: the chat before it did stream"
+
+    silent = FakeConversation.new
+    silent.define_singleton_method(:complete) do |&_block|
+      raise Collavre::CancelledError
+    end
+    assert_raises(Collavre::CancelledError) do
+      client.stub(:build_conversation, silent) do
+        client.chat([ { role: "user", parts: [ { text: "hello" } ] } ])
+      end
+    end
+
+    assert_not client.handed_off?
+  end
 end

--- a/engines/collavre/test/services/ai_client_test.rb
+++ b/engines/collavre/test/services/ai_client_test.rb
@@ -812,15 +812,43 @@ class AiClientTest < ActiveSupport::TestCase
     assert_not client.last_handoff_failed?
   end
 
+  # A tool-call chunk carries no content — the delta branch says so, and skips
+  # it — but a conversation that reached its tools has had the payload and has
+  # already done things with it: this product's tools write creatives and post
+  # comments. Classifying that turn as a failed handoff re-dispatches every
+  # comment it swallowed, and the restored turn runs those tools again.
+  test "does not record a handoff failure when the error came after a content-less chunk" do
+    conversation = FakeConversation.new
+    conversation.define_singleton_method(:complete) do |&block|
+      block.call(OpenStruct.new(content: nil))
+      raise StandardError, "stream closed"
+    end
+
+    client = AiClient.new(
+      vendor: "google", model: "gemini-pro", system_prompt: "system", llm_api_key: "api-key"
+    )
+
+    yielded = []
+    client.stub(:build_conversation, conversation) do
+      client.chat([ { role: "user", parts: [ { text: "hello" } ] } ]) { |delta| yielded << delta }
+    end
+
+    assert_equal 1, yielded.size, "premise: the chunk carried no content, so only the error notice reached the caller"
+    assert_match(/AI Error/, yielded.first)
+    assert_predicate client, :handed_off?, "premise: the provider answered — with a chunk that is not text"
+    assert_not client.last_handoff_failed?
+  end
+
   # The invariant Task#ended_undelivered? is written on: the two records are one
   # boundary asked twice, so no ending can carry both. It reads the failure
   # first precisely because it cannot ask which of two contradictory records is
   # the true one — that has to be impossible here rather than resolved there.
   test "records the handoff and its failure as one boundary asked two ways" do
-    [ [ "nothing", nil ], [ "a paragraph break", "\n\n" ], [ "an answer", "half an answer" ] ].each do |what, streamed|
+    [ [ "nothing", [] ], [ "a content-less chunk", [ nil ] ],
+      [ "a paragraph break", [ "\n\n" ] ], [ "an answer", [ "half an answer" ] ] ].each do |what, streamed|
       conversation = FakeConversation.new
       conversation.define_singleton_method(:complete) do |&block|
-        block.call(OpenStruct.new(content: streamed)) if streamed
+        streamed.each { |content| block.call(OpenStruct.new(content: content)) }
         raise StandardError, "stream closed"
       end
 

--- a/engines/collavre/test/services/collavre/orchestration/delivered_history_dispatch_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/delivered_history_dispatch_test.rb
@@ -65,7 +65,7 @@ module Collavre
           "topic" => { "id" => @topic.id },
           "sender" => { "id" => @user.id, "name" => @user.name },
           "chat" => { "content" => target.content },
-          "comment" => { "id" => target.id, "content" => target.content, "user_id" => @user.id }
+          "comment" => { "id" => target.id, "content" => target.content, "user_id" => target.user_id }
         }
       end
 
@@ -806,6 +806,163 @@ module Collavre
 
         assert_empty restored_waiters,
                      "the topic belongs to another agent and nothing in the comment says otherwise"
+      end
+
+      # Everything that labels the trigger moves with the anchor too, not just
+      # the two keys ContextBuilder derives. Comment#dispatch_payload is the
+      # declared single source of truth for what a comment_created dispatch
+      # carries, and "from_ai" is the label AiAgentJob#record_loop_breaker_turn
+      # reads: a re-anchor that drops it makes agent-to-agent work look
+      # human-triggered, and the creative-retry breaker skips exactly that.
+      test "re-anchoring keeps the metadata that labels the comment it moves onto" do
+        anchor = comment("first")
+        late = Comment.create!(
+          creative: @creative, user: session_agent, topic: @topic,
+          content: "second", quoted_comment_id: anchor.id, skip_dispatch: true
+        )
+
+        payload = TaskCoalescer.reanchor_payload(context_for(anchor), late)
+
+        assert_equal true, payload.dig("comment", "from_ai"),
+                     "the comment it moved onto was written by an agent"
+        assert_equal anchor.id, payload.dig("comment", "quoted_comment_id")
+      end
+
+      # Control against carrying the old anchor's label across: the block is
+      # rebuilt from the new comment, not merged onto the old one. A person's
+      # comment must not inherit "from_ai" from the agent comment before it.
+      test "re-anchoring onto a person's comment records it as theirs" do
+        anchor = Comment.create!(
+          creative: @creative, user: session_agent, topic: @topic,
+          content: "first, from an agent", quoted_comment_id: comment("older").id, skip_dispatch: true
+        )
+        late = comment("second, from a person")
+        # Built the way the ordinary door builds it, so the block being moved
+        # off really does carry the label that must not survive the move.
+        anchored = anchor.dispatch_payload.deep_stringify_keys
+        assert_equal true, anchored.dig("comment", "from_ai"), "premise: the anchor was an agent's"
+
+        payload = TaskCoalescer.reanchor_payload(anchored, late)
+
+        assert_equal false, payload.dig("comment", "from_ai")
+        assert_nil payload.dig("comment", "quoted_comment_id")
+      end
+
+      # The consequence, at the reader that pays for it: a restored turn on
+      # another agent's comment is agent-to-agent work, and the loop breaker
+      # only counts what it is told is not user-initiated.
+      test "a restored agent-to-agent dispatch is counted by the loop breaker" do
+        OrchestratorPolicy.create!(
+          policy_type: "scheduling",
+          config: { "loop_breaker_enabled" => true, "creative_retry_threshold" => 1 }
+        )
+        anchor = comment("@#{@agent.name}: first")
+        late = Comment.create!(
+          creative: @creative, user: session_agent, topic: @topic,
+          content: "@#{@agent.name}: second", skip_dispatch: true
+        )
+        restored = DeliveryRecord.send(:restored_context, context_for(anchor), late)
+
+        AiAgentJob.new.send(:record_loop_breaker_turn, @agent, restored)
+
+        assert LoopBreaker.new(restored).check.should_break?,
+               "the breaker counts a turn one agent started for another"
+      end
+
+      test "a restored dispatch is labelled with the author whose comment it answers" do
+        anchor = comment("@#{@agent.name}: first")
+        late = Comment.create!(
+          creative: @creative, user: session_agent, topic: @topic,
+          content: "@#{@agent.name}: second", skip_dispatch: true
+        )
+        turn = running_turn(anchor)
+        dispatch(late)
+        assert_includes DeliveryRecord.dropped_ids_in(turn.reload.trigger_event_payload), late.id,
+                        "premise: the dispatch was dropped, so only the restore can bring it back"
+
+        slot_holder(anchor)
+        turn.update!(status: "failed")
+
+        assert_equal [ true ], restored_waiters.map { |t| t.trigger_event_payload.dig("comment", "from_ai") }
+      end
+
+      def concurrency_saturated!
+        OrchestratorPolicy.create!(
+          policy_type: "scheduling", scope_type: "User", scope_id: @agent.id,
+          config: { "max_concurrent_jobs" => 1 }
+        )
+        ResourceTracker.for(@agent).reserve!("held")
+      end
+
+      def with_test_queue
+        original = ActiveJob::Base.queue_adapter
+        ActiveJob::Base.queue_adapter = :test
+        yield
+      ensure
+        ActiveJob::Base.queue_adapter = original
+      end
+
+      def restored_jobs
+        ActiveJob::Base.queue_adapter.enqueued_jobs.select { |job| job[:job] == Collavre::AiAgentJob }
+      end
+
+      # The scheduler's decision is about now, and the restore happens a turn
+      # later. A dispatch dropped while the agent was at its concurrency limit
+      # carried a backoff; enqueuing it directly discards that, and the dying
+      # turn's own ResourceTracker slot is still held when the callback fires.
+      # So the restore asks the scheduler again rather than replaying a delay
+      # decided at drop time.
+      test "a restored dispatch takes the backoff the scheduler asks for" do
+        anchor = comment("@#{@agent.name}: first")
+        late = comment("@#{@agent.name}: second")
+        turn = running_turn(anchor)
+        dispatch(late)
+        assert_includes DeliveryRecord.dropped_ids_in(turn.reload.trigger_event_payload), late.id,
+                        "premise: the dispatch was dropped, so only the restore can bring it back"
+        concurrency_saturated!
+
+        with_test_queue do
+          turn.update!(status: "failed")
+
+          assert_equal 1, restored_jobs.size, "the dispatch still comes back"
+          assert restored_jobs.first[:at].present?,
+                 "and waits out the delay the scheduler asked for rather than running now"
+        end
+      end
+
+      # Control: with nothing to wait for, the restore is immediate — this is
+      # what holds the change to the scheduler's answer rather than making
+      # every restored dispatch wait.
+      test "a restored dispatch with no pressure on it runs immediately" do
+        anchor = comment("@#{@agent.name}: first")
+        late = comment("@#{@agent.name}: second")
+        turn = running_turn(anchor)
+        dispatch(late)
+
+        with_test_queue do
+          turn.update!(status: "failed")
+
+          assert_equal 1, restored_jobs.size
+          assert_nil restored_jobs.first[:at]
+        end
+      end
+
+      # The quota was fine when the dispatch was dropped and is exhausted by the
+      # time it comes back. The existing rejection guard is at the drop door and
+      # cannot see this one.
+      test "a restore the scheduler now rejects is not enqueued past it" do
+        anchor = comment("@#{@agent.name}: first")
+        late = comment("@#{@agent.name}: second")
+        turn = running_turn(anchor)
+        dispatch(late)
+        quota_exhausted!
+
+        with_test_queue do
+          turn.update!(status: "failed")
+
+          assert_empty restored_jobs,
+                       "restoring it would run work the quota check refuses right now"
+        end
       end
     end
   end

--- a/engines/collavre/test/services/collavre/orchestration/delivered_history_dispatch_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/delivered_history_dispatch_test.rb
@@ -325,6 +325,63 @@ module Collavre
                      "the dispatch was parked, not discarded — it needs no restoring"
       end
 
+      # The restore's subject is the dispatches this turn refused, and a comment
+      # routed away from this agent never produced one. Chat history is the
+      # whole topic — Matcher's exclusive routings do not filter it — so a
+      # comment addressed to somebody else is read by every agent in the topic.
+      # Treating "read it" as "dropped a dispatch for it" makes the failure of
+      # an unrelated turn dispatch this agent onto a message that was never
+      # meant for it, past Matcher entirely.
+      test "a comment routed to somebody else is not restored to this agent" do
+        anchor = comment("@#{@agent.name}: first")
+        addressed_elsewhere = comment("@#{users(:two).name}: second, for you")
+        turn = running_turn(anchor)
+        assert_includes DeliveryRecord.ids_in(turn.trigger_event_payload), addressed_elsewhere.id,
+                        "premise: the agent read it as history, as every agent in the topic does"
+
+        dispatch(addressed_elsewhere)
+        assert_empty tasks_for(@agent),
+                     "premise: an exclusive mention routes past this agent, so no dispatch was refused"
+
+        slot_holder(anchor)
+        turn.update!(status: "failed")
+
+        assert_empty restored_waiters,
+                     "there was no dispatch to put back, and inventing one speaks out of turn"
+      end
+
+      # The other shape of the same inference. An :immediate decision enqueues
+      # its job at AgentOrchestrator#enqueue_jobs and the Task row is only
+      # created when that job runs, so between the two there is a live dispatch
+      # with nothing in the table to show for it. "No row" cannot mean "was
+      # dropped" while that window exists.
+      test "a dispatch still sitting in the queue is not restored underneath itself" do
+        anchor = comment("@#{@agent.name}: first")
+        late = comment("@#{@agent.name}: second")
+
+        # The burst race the PR's own AiAgentJob guard describes: both comments
+        # are judged :immediate because neither has a row yet, and the second
+        # job is still queued when the first turn assembles and swallows it.
+        previous_adapter = ActiveJob::Base.queue_adapter
+        begin
+          ActiveJob::Base.queue_adapter = :test
+          dispatch(late)
+          assert_empty tasks_for(@agent), "premise: the dispatch is enqueued with no Task row yet"
+        ensure
+          ActiveJob::Base.queue_adapter = previous_adapter
+        end
+
+        turn = running_turn(anchor)
+        assert_includes DeliveryRecord.ids_in(turn.trigger_event_payload), late.id,
+                        "premise: and the turn read it anyway"
+
+        slot_holder(anchor)
+        turn.update!(status: "failed")
+
+        assert_empty restored_waiters,
+                     "the dispatch is alive in the queue; a second one answers the comment twice"
+      end
+
       # A comment deleted while the turn ran has nothing to answer.
       test "a comment that no longer exists is not restored" do
         anchor = comment("@#{@agent.name}: first")
@@ -370,6 +427,7 @@ module Collavre
 
         payload = restored_waiters.sole.trigger_event_payload
         assert_empty DeliveryRecord.ids_in(payload)
+        assert_empty DeliveryRecord.dropped_ids_in(payload)
         assert_empty Array(payload[TaskCoalescer::PAYLOAD_KEY])
         assert_nil payload[TaskCoalescer::ACQUIRED_ANCHOR_KEY]
         assert_equal late.content, payload.dig("chat", "content"),

--- a/engines/collavre/test/services/collavre/orchestration/delivered_history_dispatch_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/delivered_history_dispatch_test.rb
@@ -696,6 +696,172 @@ module Collavre
         assert_empty tasks_for(@agent), "premise: the decision really was :rejected"
       end
 
+      # ─────────────────────────────────────────────
+      # A restore that could not be made
+      # ─────────────────────────────────────────────
+
+      # Fail the enqueue for these comments and no others, the way a transient
+      # queue or database failure would.
+      def with_scheduler_failing_for(*comments, &block)
+        ids = comments.map(&:id)
+        real_new = Scheduler.method(:new)
+        Scheduler.stub(:new, lambda { |context|
+          raise ActiveRecord::ConnectionNotEstablished, "the queue is down" \
+            if ids.include?(context.dig("comment", "id"))
+
+          real_new.call(context)
+        }, &block)
+      end
+
+      # The restore walks the orphans one at a time, and each is a dispatch of
+      # its own. One that cannot be enqueued says nothing about the next.
+      test "a dispatch that could not be enqueued does not take the others down with it" do
+        anchor = comment("@#{@agent.name}: first")
+        first_late = comment("@#{@agent.name}: second")
+        second_late = comment("@#{@agent.name}: third")
+        turn = running_turn(anchor)
+        dispatch(first_late)
+        dispatch(second_late)
+        assert_equal [ first_late.id, second_late.id ],
+                     DeliveryRecord.dropped_ids_in(turn.reload.trigger_event_payload).sort,
+                     "premise: both dispatches were dropped against this turn"
+
+        slot_holder(anchor)
+        with_scheduler_failing_for(first_late) { turn.update!(status: "failed") }
+
+        assert_equal [ second_late.id ],
+                     restored_waiters.map { |t| t.trigger_event_payload.dig("comment", "id") },
+                     "one comment's failure is not the other comment's answer"
+      end
+
+      # And the turn's status is not the restore's to lose. The enqueues are
+      # walked one at a time above, but the reads that decide *what* to enqueue
+      # — re-reading the row, the sibling claims, the orphans' eligibility — are
+      # not, and this fires from after_update_commit: an exception propagates
+      # back into the update! that ended the turn, where AiAgentJob's rescue
+      # answers it by writing `failed` over a turn that had finished and
+      # answered.
+      test "a restore that raises does not fail the turn" do
+        anchor = comment("@#{@agent.name}: first")
+        late = comment("@#{@agent.name}: second")
+        turn = running_turn(anchor)
+        dispatch(late)
+        slot_holder(anchor)
+
+        raiser = ->(_task) { raise ActiveRecord::ConnectionNotEstablished, "the database is down" }
+        assert_nothing_raised do
+          DeliveryRecord.stub(:restore!, raiser) { turn.update!(status: "failed") }
+        end
+        assert_empty restored_waiters, "premise: the restore really did not get through"
+      end
+
+      # Which leaves the comment on nothing at all: the callback runs after the
+      # covering turn's status is committed, so there is no later transition
+      # that would ask again. What was lost is only the asking — the drop record
+      # is on the row and the orphan set is derived from it, so the restore is
+      # reconstructible from that row at any later time.
+      test "the sweep makes a restore the callback could not" do
+        anchor = comment("@#{@agent.name}: first")
+        late = comment("@#{@agent.name}: second")
+        turn = running_turn(anchor)
+        dispatch(late)
+        slot_holder(anchor)
+
+        with_scheduler_failing_for(late) { turn.update!(status: "failed") }
+        assert_empty restored_waiters, "premise: the callback's restore did not get through"
+
+        RestoreDroppedDispatchesJob.perform_now
+
+        assert_equal [ late.id ], restored_waiters.map { |t| t.trigger_event_payload.dig("comment", "id") },
+                     "the record is still on the row; only the asking was lost"
+      end
+
+      # Including for the ending whose status says the opposite. A turn whose
+      # request never reached the provider finishes `done`, so the sweep has to
+      # scan that status too and decide with the callback's predicate rather
+      # than with the status alone.
+      test "the sweep makes a restore the callback could not after a caught provider failure" do
+        anchor = comment("@#{@agent.name}: first")
+        late = comment("@#{@agent.name}: second")
+        turn = running_turn(anchor)
+        dispatch(late)
+        slot_holder(anchor)
+        DeliveryRecord.mark_handoff_failed!(turn)
+
+        with_scheduler_failing_for(late) { turn.reload.update!(status: "done") }
+        assert_empty restored_waiters, "premise: the callback's restore did not get through"
+
+        RestoreDroppedDispatchesJob.perform_now
+
+        assert_equal [ late.id ], restored_waiters.map { |t| t.trigger_event_payload.dig("comment", "id") }
+      end
+
+      # Control: the sweep decides with that same predicate and not with
+      # "terminal". A turn that delivered what it read owes nothing, and a sweep
+      # reading `done` as an undelivered ending would answer every comment
+      # dropped in its window a second time.
+      test "the sweep restores nothing for a turn that delivered" do
+        anchor = comment("@#{@agent.name}: first")
+        late = comment("@#{@agent.name}: second")
+        turn = running_turn(anchor)
+        dispatch(late)
+        slot_holder(anchor)
+        turn.update!(status: "done")
+
+        RestoreDroppedDispatchesJob.perform_now
+
+        assert_empty restored_waiters,
+                     "the agent read that comment and answered; there is nothing to restore"
+      end
+
+      # Every dispatch anchored on this comment, whatever became of it. Counting
+      # only the queued ones cannot see a second restore: the new waiter
+      # supersedes the first, which is cancelled on the way, so the queue holds
+      # one row either way and two turns have been created for one comment.
+      def dispatches_for(target)
+        Task.where(agent: @agent, topic_id: @topic.id, creative_id: @creative.id).select do |t|
+          t.trigger_event_payload.is_a?(Hash) &&
+            t.trigger_event_payload.dig("comment", "id") == target.id
+        end
+      end
+
+      # Control: the sweep runs over every undelivered ending in its window,
+      # including the ones whose callback worked. What it re-reads is the orphan
+      # set, and a dispatch that came back has a row of its own by then.
+      test "the sweep does not restore a dispatch a second time" do
+        anchor = comment("@#{@agent.name}: first")
+        late = comment("@#{@agent.name}: second")
+        turn = running_turn(anchor)
+        dispatch(late)
+        slot_holder(anchor)
+        turn.update!(status: "failed")
+        assert_equal 1, dispatches_for(late).count, "premise: the callback restored it"
+
+        RestoreDroppedDispatchesJob.perform_now
+
+        assert_equal 1, dispatches_for(late).count,
+                     "the orphan set is re-read, and this comment has a row of its own by now"
+      end
+
+      # Control: a backstop with a horizon rather than a permanent second
+      # opinion. A comment whose restore never got through and whose turn ended
+      # long ago has been overtaken by whatever the topic did since.
+      test "the sweep leaves a turn that ended before its window alone" do
+        anchor = comment("@#{@agent.name}: first")
+        late = comment("@#{@agent.name}: second")
+        turn = running_turn(anchor)
+        dispatch(late)
+        slot_holder(anchor)
+
+        with_scheduler_failing_for(late) { turn.update!(status: "failed") }
+        Task.where(id: turn.id)
+            .update_all(updated_at: (DeliveryRecord::RESTORE_SWEEP_WINDOW + 5.minutes).ago)
+
+        RestoreDroppedDispatchesJob.perform_now
+
+        assert_empty restored_waiters
+      end
+
       test "the restored dispatch carries none of the dead turn's bookkeeping" do
         anchor = comment("@#{@agent.name}: first")
         late = comment("@#{@agent.name}: second")

--- a/engines/collavre/test/services/collavre/orchestration/delivered_history_dispatch_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/delivered_history_dispatch_test.rb
@@ -243,6 +243,39 @@ module Collavre
                      "and the notice it was parked behind goes with it"
       end
 
+      # A tool approval resumes the same Task row. The first attempt can hand
+      # the waiter's comment to the provider and a later attempt can fail before
+      # handoff, so the turn legitimately carries both kinds of evidence. The
+      # later failure must not erase the earlier attempt's per-comment delivery.
+      test "a resumed attempt failure does not promote a waiter delivered by an earlier attempt" do
+        anchor = comment("@#{@agent.name}: first")
+        holder = Task.create!(
+          name: "Holder", status: "running", trigger_event_name: "comment_created",
+          agent: @agent, topic_id: @topic.id, creative_id: @creative.id,
+          trigger_event_payload: context_for(anchor)
+        )
+        late = comment("@#{@agent.name}: second")
+        dispatch(late)
+        waiter = tasks_for(@agent).where(status: "queued").sole
+
+        reassemble(holder, anchor)
+        DeliveryRecord.mark_handed_off!(holder)
+        DeliveryRecord.mark_handoff_failed!(holder)
+        holder.update!(status: "done")
+
+        payload = holder.reload.trigger_event_payload
+        assert DeliveryRecord.handoff_failed?(payload),
+               "premise: the resumed attempt failed before handoff"
+        assert_includes DeliveryRecord.handed_off_ids_in(payload), late.id,
+                        "premise: the first attempt handed the waiter comment to the provider"
+
+        AgentOrchestrator.dequeue_next_for_topic(@topic.id, @creative.id)
+
+        assert_equal "cancelled", waiter.reload.status,
+                     "the failed resumed attempt must not repeat an earlier attempt's delivery"
+        assert_empty waiting_notices
+      end
+
       def topic_max!(value)
         OrchestratorPolicy.create!(
           policy_type: "scheduling", scope_type: nil,

--- a/engines/collavre/test/services/collavre/orchestration/delivered_history_dispatch_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/delivered_history_dispatch_test.rb
@@ -620,6 +620,78 @@ module Collavre
                      "and it is anchored on the comment it was dispatched for"
       end
 
+      # The enumerated strip above is only as good as its enumeration, and the
+      # failed-handoff flag is the key it was missing. Stated as the rule the
+      # comment on restored_context always claimed: a restored dispatch is the
+      # one that was discarded, so it carries what a dispatch carries and
+      # nothing the turn wrote onto itself afterwards.
+      test "the restored dispatch carries no key the covering turn wrote onto itself" do
+        anchor = comment("@#{@agent.name}: first")
+        late = comment("@#{@agent.name}: second")
+        turn = running_turn(anchor)
+        dispatch(late)
+        DeliveryRecord.mark_handoff_failed!(turn)
+
+        added = turn.reload.trigger_event_payload.keys - context_for(anchor).keys
+        assert_operator added.length, :>=, 3,
+                        "premise: the turn did write bookkeeping onto its own payload"
+
+        slot_holder(anchor)
+        turn.reload.update!(status: "done")
+
+        payload = restored_waiters.sole.trigger_event_payload
+        assert_empty payload.keys - context_for(late).keys,
+                     "a restored dispatch carries what a dispatch carries, and nothing else"
+      end
+
+      # The consequence, at the reader that makes it cost a duplicate reply.
+      # covering_task refuses a turn whose handoff failed, so a restored turn
+      # still carrying the dead turn's flag cannot cover anything it reads: the
+      # next comment swept into its history dispatches beside it.
+      test "a restored turn covers the comments it reads" do
+        anchor = comment("@#{@agent.name}: first")
+        late = comment("@#{@agent.name}: second")
+        turn = running_turn(anchor)
+        dispatch(late)
+        slot_holder(anchor)
+        DeliveryRecord.mark_handoff_failed!(turn)
+        turn.reload.update!(status: "done")
+
+        restored = restored_waiters.sole
+        restored.update!(status: "running")
+        third = comment("@#{@agent.name}: third")
+        data = AiAgent::MessageBuilder.new(
+          agent: @agent, context: restored.trigger_event_payload, original_comment: late
+        ).build
+        resolved = AiAgent::SessionContextResolver.new(
+          agent: @agent, messages_data: data, system_prompt: "prompt"
+        ).resolve
+        DeliveryRecord.record!(restored, resolved)
+        assert_includes DeliveryRecord.ids_in(restored.reload.trigger_event_payload), third.id,
+                        "premise: the restored turn's window did sweep the third comment up"
+
+        dispatch(third)
+
+        assert_empty tasks_for(@agent).where(status: "queued"),
+                     "the restored turn has read it; a second turn beside it is the duplicate reply"
+      end
+
+      # Control: the flag is still the dead turn's own, so the fix cannot be
+      # "stop recording it". Without it on the covering turn there is no restore
+      # at all, and this is the row every reader of it is asking about.
+      test "the turn that failed its handoff keeps the flag" do
+        anchor = comment("@#{@agent.name}: first")
+        late = comment("@#{@agent.name}: second")
+        turn = running_turn(anchor)
+        dispatch(late)
+        slot_holder(anchor)
+        DeliveryRecord.mark_handoff_failed!(turn)
+        turn.reload.update!(status: "done")
+
+        assert DeliveryRecord.handoff_failed?(turn.reload.trigger_event_payload),
+               "the turn that handed nothing over is what the record is about"
+      end
+
       # A dispatch the scheduler has refused is not a dispatch. The drop asks
       # "is this redundant?", which only makes sense about work that was going
       # to run: recording one against a :rejected decision manufactures a

--- a/engines/collavre/test/services/collavre/orchestration/delivered_history_dispatch_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/delivered_history_dispatch_test.rb
@@ -497,6 +497,111 @@ module Collavre
       # the turn that discarded it: it carries no delivery record, no merged list
       # and no acquired anchor. Without this a restored turn that fails again
       # would restore the same comments a second time.
+      # A provider error is not a failed task. AiClient#chat catches
+      # StandardError, streams "⚠️ AI Error" to the user and returns nil, and
+      # AiAgentJob marks an ordinary task `done` on that — so the turn ends in
+      # the one status DELIVERED_STATUSES counts as delivery, having handed the
+      # provider nothing at all. The comments it discarded on the strength of
+      # having read them were never read by anything.
+      test "a dropped dispatch comes back when the covering turn's request never reached the provider" do
+        anchor = comment("@#{@agent.name}: first")
+        late = comment("@#{@agent.name}: second")
+        turn = running_turn(anchor)
+        dispatch(late)
+        assert_empty tasks_for(@agent), "premise: the dispatch was dropped, leaving no row"
+
+        slot_holder(anchor)
+        DeliveryRecord.mark_handoff_failed!(turn)
+        turn.reload.update!(status: "done")
+
+        assert_equal [ late.id ], restored_waiters.map { |t| t.trigger_event_payload.dig("comment", "id") },
+                     "nothing was handed over, so the comment it silenced has a turn of its own again"
+      end
+
+      # The other half of the same failure: while the turn is still `running`
+      # after the error, it must stop covering anything further. Dropping
+      # against it would record a drop the restore has already run past.
+      test "a turn whose request never reached the provider stops covering later dispatches" do
+        anchor = comment("@#{@agent.name}: first")
+        late = comment("@#{@agent.name}: second")
+        turn = running_turn(anchor)
+        assert_includes DeliveryRecord.ids_in(turn.trigger_event_payload), late.id,
+                        "premise: the window did sweep it up"
+
+        DeliveryRecord.mark_handoff_failed!(turn)
+        dispatch(late)
+
+        assert_equal 1, tasks_for(@agent).where(status: "queued").count,
+                     "a turn that delivered nothing cannot be the reason a dispatch is discarded"
+      end
+
+      # And the promotion door, which reads the same record through
+      # AgentOrchestrator.delivered_comment_ids and counts `done` as delivery.
+      # The mirror of "a waiter parked before the turn assembled is cancelled at
+      # promotion" above: that cancellation is right when the turn answered, and
+      # is the waiter losing its only turn when the turn handed over nothing.
+      test "a waiter is not cancelled at promotion by a turn that never handed anything over" do
+        anchor = comment("@#{@agent.name}: first")
+        holder = slot_holder(anchor)
+        late = comment("@#{@agent.name}: second")
+        dispatch(late)
+        waiter = tasks_for(@agent).where(status: "queued").sole
+        assert_equal late.id, waiter.trigger_event_payload.dig("comment", "id")
+
+        data = AiAgent::MessageBuilder.new(
+          agent: @agent, context: holder.trigger_event_payload, original_comment: anchor
+        ).build
+        resolved = AiAgent::SessionContextResolver.new(
+          agent: @agent, messages_data: data, system_prompt: "prompt"
+        ).resolve
+        DeliveryRecord.record!(holder, resolved)
+        assert_includes DeliveryRecord.ids_in(holder.reload.trigger_event_payload), late.id,
+                        "premise: the covering turn's window did carry the waiter's comment"
+
+        DeliveryRecord.mark_handoff_failed!(holder)
+        holder.reload.update!(status: "done")
+        AgentOrchestrator.dequeue_next_for_topic(@topic.id, @creative.id)
+
+        assert_not_equal "cancelled", waiter.reload.status,
+                         "nothing was handed over, so the waiter has not been answered"
+        assert_equal late.id, waiter.trigger_event_payload.dig("comment", "id"),
+                     "and it still answers the comment it was dispatched for"
+      end
+
+      # A dropped dispatch is handled, not unscheduled. AgentOrchestrator.dispatch
+      # returns the agents that will answer — a :deferred decision returns its
+      # agent although only a queued row exists — and a drop says this agent is
+      # already answering that comment inside an in-flight turn. Returning
+      # nothing instead makes DropTriggerJob#dispatch_trigger raise
+      # DispatchFailedError and retry a trigger that was correctly covered.
+      test "a dropped dispatch reports its agent rather than an empty result" do
+        anchor = comment("@#{@agent.name}: first")
+        late = comment("@#{@agent.name}: second")
+        running_turn(anchor)
+
+        assert_equal [ @agent.id ], dispatch(late).map(&:id)
+        assert_empty tasks_for(@agent), "premise: it really was dropped"
+      end
+
+      # Control: "handled" must not swallow the real empty result. A :rejected
+      # decision — the agent is out of quota, or the loop breaker stopped it —
+      # schedules nothing and answers nothing, and DropTriggerJob's retry is the
+      # right response to that.
+      test "a rejected decision still reports an empty result" do
+        OrchestratorPolicy.create!(
+          policy_type: "scheduling", scope_type: "User", scope_id: @agent.id,
+          config: { "daily_token_limit" => 1000 }
+        )
+        tracker = ResourceTracker.for(@agent)
+        tracker.reserve!("spent")
+        tracker.release!("spent", tokens_used: 1500)
+
+        late = comment("@#{@agent.name}: anybody there")
+
+        assert_empty dispatch(late)
+        assert_empty tasks_for(@agent), "premise: the decision really was :rejected"
+      end
+
       test "the restored dispatch carries none of the dead turn's bookkeeping" do
         anchor = comment("@#{@agent.name}: first")
         late = comment("@#{@agent.name}: second")

--- a/engines/collavre/test/services/collavre/orchestration/delivered_history_dispatch_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/delivered_history_dispatch_test.rb
@@ -1224,6 +1224,129 @@ module Collavre
                        "restoring it would run work the quota check refuses right now"
         end
       end
+
+      # ─────────────────────────────────────────────
+      # A turn that was stopped after it handed over
+      # ─────────────────────────────────────────────
+
+      # `cancelled` is an undelivered ending only while the cancellation beat the
+      # handoff. A user who presses Stop mid-answer stops a turn whose payload
+      # the provider already has — AgentLifecycleManager keeps the partial reply
+      # — and the comments that turn swallowed were read along with it.
+      # Restoring them starts fresh agent work the moment the user asked for
+      # none, and answers those comments a second time.
+      test "a dispatch dropped against a turn stopped after the handoff is not restored" do
+        anchor = comment("@#{@agent.name}: first")
+        late = comment("@#{@agent.name}: second")
+        turn = running_turn(anchor)
+        dispatch(late)
+        assert_includes DeliveryRecord.dropped_ids_in(turn.reload.trigger_event_payload), late.id,
+                        "premise: the dispatch was dropped against this turn"
+        DeliveryRecord.mark_handed_off!(turn)
+
+        slot_holder(anchor)
+        turn.reload.update!(status: "cancelled")
+
+        assert_empty restored_waiters,
+                     "the provider had that comment; re-dispatching it answers it twice"
+      end
+
+      # And the sweep decides with the same predicate, or the backstop undoes
+      # what the callback correctly declined to do.
+      test "the sweep restores nothing for a turn stopped after the handoff" do
+        anchor = comment("@#{@agent.name}: first")
+        late = comment("@#{@agent.name}: second")
+        turn = running_turn(anchor)
+        dispatch(late)
+        DeliveryRecord.mark_handed_off!(turn)
+        slot_holder(anchor)
+        turn.reload.update!(status: "cancelled")
+
+        RestoreDroppedDispatchesJob.perform_now
+
+        assert_empty restored_waiters
+      end
+
+      # ─────────────────────────────────────────────
+      # What the restore must ask again
+      # ─────────────────────────────────────────────
+
+      # The restore enqueues this agent by name, skipping Matcher#match — and
+      # every routing path in #match is gated on feedback permission for the
+      # creative. AiAgentJob re-asks the topic assignment and nothing else, so a
+      # permission revoked between the drop and the restore would not be seen by
+      # anybody.
+      test "a dispatch is not restored to an agent that has lost permission on the creative" do
+        anchor = comment("@#{@agent.name}: first")
+        late = comment("@#{@agent.name}: second")
+        turn = running_turn(anchor)
+        dispatch(late)
+        slot_holder(anchor)
+        revoke_creative_permission!
+
+        turn.update!(status: "failed")
+
+        assert_empty restored_waiters,
+                     "the agent may no longer read that creative, restore or not"
+      end
+
+      def revoke_creative_permission!
+        CreativeShare.where(creative: @creative, user: @agent).destroy_all
+        CreativeSharesCache.where(creative_id: @creative.id, user_id: @agent.id).destroy_all
+      end
+
+      # ─────────────────────────────────────────────
+      # The claim that keeps the sweep off its own restore
+      # ─────────────────────────────────────────────
+
+      # AiAgentJob creates the Task row when it *runs*, so a restored job sitting
+      # in the queue — a worker outage, a backlog longer than the sweep interval
+      # — leaves the comment looking orphaned. Eventual Task creation cannot be
+      # the idempotency marker for work that has not started yet.
+      test "a restored dispatch still waiting in the queue is not enqueued again" do
+        anchor = comment("@#{@agent.name}: first")
+        late = comment("@#{@agent.name}: second")
+        turn = running_turn(anchor)
+        dispatch(late)
+
+        with_test_queue do
+          turn.update!(status: "failed")
+          assert_equal 1, restored_jobs.size, "premise: the callback enqueued it"
+          assert_empty dispatches_for(late), "premise: and no Task exists for it yet"
+
+          RestoreDroppedDispatchesJob.perform_now
+
+          assert_equal 1, restored_jobs.size,
+                       "the dispatch is already on its way; a second one answers twice"
+        end
+      end
+
+      # Control: the claim is taken for a dispatch that was enqueued, and given
+      # back for one that was not. Otherwise this fix would be the previous
+      # finding pointing the other way — a comment claimed by an enqueue that
+      # never happened is a comment nobody ever comes back for.
+      test "a restore whose enqueue failed is asked again by the sweep" do
+        anchor = comment("@#{@agent.name}: first")
+        late = comment("@#{@agent.name}: second")
+        turn = running_turn(anchor)
+        dispatch(late)
+        slot_holder(anchor)
+
+        with_enqueue_failing { turn.update!(status: "failed") }
+        assert_empty restored_waiters, "premise: the enqueue really did not get through"
+
+        RestoreDroppedDispatchesJob.perform_now
+
+        assert_equal [ late.id ], restored_waiters.map { |t| t.trigger_event_payload.dig("comment", "id") },
+                     "nothing was delivered, so nothing was claimed"
+      end
+
+      # Fail at the enqueue itself, past the scheduler — the transient queue
+      # failure the claim is written before.
+      def with_enqueue_failing(&block)
+        raiser = ->(*) { raise ActiveRecord::ConnectionNotEstablished, "the queue is down" }
+        Collavre::AiAgentJob.stub(:perform_later, raiser, &block)
+      end
     end
   end
 end

--- a/engines/collavre/test/services/collavre/orchestration/delivered_history_dispatch_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/delivered_history_dispatch_test.rb
@@ -237,6 +237,100 @@ module Collavre
                      "and the notice it was parked behind goes with it"
       end
 
+      def topic_max!(value)
+        OrchestratorPolicy.create!(
+          policy_type: "scheduling", scope_type: nil,
+          config: { "topic_max_concurrent_jobs" => value }
+        )
+      end
+
+      def peer_agent(tag)
+        agent = Collavre::User.create!(
+          name: "burst-peer-#{tag}",
+          email: "burst-peer-#{tag}-#{SecureRandom.hex(4)}@agent.test",
+          password: "password123",
+          llm_vendor: "openai", llm_model: "gpt-4",
+          system_prompt: "You are peer #{tag}.", searchable: true, routing_expression: "false"
+        )
+        share = CreativeShare.find_or_create_by!(creative: @creative, user: agent)
+        share.update!(permission: "feedback")
+        CreativeSharesCache.find_or_create_by!(
+          creative_id: @creative.id, user_id: agent.id, permission: :feedback
+        )
+        agent
+      end
+
+      # Cancelling a waiter is the one removal this feature makes that writes
+      # nothing down, so it is only sound against a turn whose delivery has
+      # settled. DELIVERED_STATUSES counts `running`, and the refresh only
+      # re-reads a status — what keeps that from deciding on an outcome nobody
+      # knows yet is TopicSlot, not this file: an agent occupying a slot here
+      # may not be promoted into a second turn. Pinned from this side too,
+      # because relaxing that exclusion would cost a comment rather than a
+      # duplicate turn, and silently.
+      test "a waiter is not promoted while its own agent's covering turn is still in flight" do
+        topic_max!(2)
+        anchor = comment("@#{@agent.name}: first")
+        holder = Task.create!(
+          name: "Holder", status: "running", trigger_event_name: "comment_created",
+          agent: @agent, topic_id: @topic.id, creative_id: @creative.id,
+          trigger_event_payload: context_for(anchor)
+        )
+        late = comment("@#{@agent.name}: second")
+        dispatch(late)
+        waiter = Task.where(agent: @agent, topic_id: @topic.id).where.not(id: holder.id).sole
+        assert_equal "queued", waiter.status,
+                     "premise: the dispatch parked behind the agent's own running turn"
+
+        data = AiAgent::MessageBuilder.new(
+          agent: @agent, context: holder.trigger_event_payload, original_comment: anchor
+        ).build
+        resolved = AiAgent::SessionContextResolver.new(
+          agent: @agent, messages_data: data, system_prompt: "prompt"
+        ).resolve
+        DeliveryRecord.record!(holder, resolved)
+        assert_includes DeliveryRecord.ids_in(holder.reload.trigger_event_payload), late.id,
+                        "premise: the in-flight turn's window did swallow the waiter's comment"
+        assert_equal "running", holder.reload.status,
+                     "premise: and it has not ended, so its delivery is not settled"
+
+        AgentOrchestrator.dequeue_next_for_topic(@topic.id, @creative.id)
+
+        assert_equal "queued", waiter.reload.status,
+                     "an agent holding a slot may not be promoted into a second turn, " \
+                     "which is what keeps the refresh from deciding against an unsettled turn"
+      end
+
+      # The other half of the same invariant. Two turns run concurrently in one
+      # topic only when they belong to different agents — TopicSlot again — and
+      # delivered_comment_ids is scoped to this agent, so the record a promotion
+      # reads is never a concurrent turn's.
+      test "another agent's in-flight turn does not silence this agent's waiter" do
+        topic_max!(2)
+        holder_a = peer_agent("a")
+        holder_b = peer_agent("b")
+        anchor = comment("@#{@agent.name}: first")
+        late = comment("@#{@agent.name}: second")
+        theirs = running_turn(anchor, agent: holder_a)
+        assert_includes DeliveryRecord.ids_in(theirs.trigger_event_payload), late.id,
+                        "premise: the other agent's window did carry this comment"
+        second_slot = Task.create!(
+          name: "Second slot", status: "running", trigger_event_name: "comment_created",
+          agent: holder_b, topic_id: @topic.id, creative_id: @creative.id,
+          trigger_event_payload: context_for(anchor)
+        )
+        dispatch(late)
+        waiter = tasks_for(@agent).where(status: "queued").sole
+
+        second_slot.update!(status: "done")
+        AgentOrchestrator.dequeue_next_for_topic(@topic.id, @creative.id)
+
+        refute_equal "cancelled", waiter.reload.status,
+                     "the record read at promotion is this agent's own, and this agent has none"
+        refute_equal "queued", waiter.reload.status,
+                     "premise: the freed slot really did promote it"
+      end
+
       # Hold the topic slot so a restored dispatch parks as a waiter here
       # instead of being admitted and executed inline by the test adapter. What
       # is under test is that the dispatch exists again, not what it says.

--- a/engines/collavre/test/services/collavre/orchestration/delivered_history_dispatch_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/delivered_history_dispatch_test.rb
@@ -890,6 +890,73 @@ module Collavre
         assert_empty restored_waiters
       end
 
+      # A stopped turn is the one row Task#ended_undelivered? is asked too early
+      # of. The cancel is committed from another process — a web request, a
+      # deleted anchor — while the worker is still inside the provider call, so
+      # the row carries no account of the handoff yet and will not until the
+      # worker comes out. The status callback declines for exactly that reason
+      # (Task#stopped_mid_turn?); this door reads a settled row and cannot tell
+      # "still settling" from "nobody is coming", so without the wait it answers
+      # in the callback's place, minutes after the user pressed Stop.
+      test "the sweep leaves a cancellation its worker has not settled alone" do
+        anchor = comment("@#{@agent.name}: first")
+        late = comment("@#{@agent.name}: second")
+        turn = running_turn(anchor)
+        dispatch(late)
+        slot_holder(anchor)
+
+        Task.find(turn.id).update!(status: "cancelled")
+        assert_empty restored_waiters, "premise: the callback declined to decide"
+
+        RestoreDroppedDispatchesJob.perform_now
+
+        assert_empty restored_waiters,
+                     "the worker has not said yet whether the payload got there"
+      end
+
+      # Control, and the case this door is here for: a cancellation with no
+      # worker behind it settles nothing — an agent unregistering, an offline
+      # delegate, a worker killed before its own rescue — and the dispatches
+      # dropped against it are owed back. Declining cancellations outright would
+      # cost those comments; waiting only costs the delay.
+      test "the sweep restores a cancellation nothing came back to settle" do
+        anchor = comment("@#{@agent.name}: first")
+        late = comment("@#{@agent.name}: second")
+        turn = running_turn(anchor)
+        dispatch(late)
+        slot_holder(anchor)
+
+        Task.find(turn.id).update!(status: "cancelled")
+        Task.where(id: turn.id)
+            .update_all(updated_at: (DeliveryRecord.cancel_settle_grace + 5.minutes).ago)
+
+        RestoreDroppedDispatchesJob.perform_now
+
+        assert_equal [ late.id ], restored_waiters.map { |t| t.trigger_event_payload.dig("comment", "id") },
+                     "nothing settled it, and the record is still on the row"
+      end
+
+      # Control: the horizon moves with the wait rather than being spent by it.
+      # A grace subtracted from a fixed window would leave a cancellation less
+      # backstop than every other ending gets, and at the default provider
+      # timeout it would leave it almost none.
+      test "the sweep leaves a cancellation older than its window alone" do
+        anchor = comment("@#{@agent.name}: first")
+        late = comment("@#{@agent.name}: second")
+        turn = running_turn(anchor)
+        dispatch(late)
+        slot_holder(anchor)
+
+        Task.find(turn.id).update!(status: "cancelled")
+        Task.where(id: turn.id).update_all(
+          updated_at: (DeliveryRecord::RESTORE_SWEEP_WINDOW + DeliveryRecord.cancel_settle_grace + 5.minutes).ago
+        )
+
+        RestoreDroppedDispatchesJob.perform_now
+
+        assert_empty restored_waiters
+      end
+
       test "the restored dispatch carries none of the dead turn's bookkeeping" do
         anchor = comment("@#{@agent.name}: first")
         late = comment("@#{@agent.name}: second")

--- a/engines/collavre/test/services/collavre/orchestration/delivered_history_dispatch_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/delivered_history_dispatch_test.rb
@@ -619,6 +619,122 @@ module Collavre
         assert_equal late.content, payload.dig("chat", "content"),
                      "and it is anchored on the comment it was dispatched for"
       end
+
+      # A dispatch the scheduler has refused is not a dispatch. The drop asks
+      # "is this redundant?", which only makes sense about work that was going
+      # to run: recording one against a :rejected decision manufactures a
+      # restore obligation for a turn that was never scheduled, and restore!
+      # enqueues AiAgentJob directly — past the quota check that refused it.
+      def quota_exhausted!
+        OrchestratorPolicy.create!(
+          policy_type: "scheduling", scope_type: "User", scope_id: @agent.id,
+          config: { "daily_token_limit" => 1000 }
+        )
+        tracker = ResourceTracker.for(@agent)
+        tracker.reserve!("spent")
+        tracker.release!("spent", tokens_used: 1500)
+      end
+
+      test "a dispatch the scheduler rejected is not recorded as a drop" do
+        anchor = comment("@#{@agent.name}: first")
+        late = comment("@#{@agent.name}: second")
+        turn = running_turn(anchor)
+        assert_includes DeliveryRecord.ids_in(turn.trigger_event_payload), late.id,
+                        "premise: the covering turn did read it, so the drop door is live"
+        quota_exhausted!
+
+        assert_empty dispatch(late),
+                     "a rejected decision schedules nobody, drop door or not"
+        assert_empty DeliveryRecord.dropped_ids_in(turn.reload.trigger_event_payload),
+                     "and refused work leaves nothing for the restore to owe"
+      end
+
+      test "a dispatch the scheduler rejected is not restored past the check that rejected it" do
+        anchor = comment("@#{@agent.name}: first")
+        late = comment("@#{@agent.name}: second")
+        turn = running_turn(anchor)
+        quota_exhausted!
+        dispatch(late)
+
+        slot_holder(anchor)
+        turn.update!(status: "failed")
+
+        assert_empty restored_waiters,
+                     "restoring it would run work the quota check refused"
+      end
+
+      # Control: the drop itself still happens for work that *was* going to be
+      # scheduled — this is what holds the rejection guard to :rejected rather
+      # than to "covered", which would turn the drop back into a plain skip.
+      test "a dispatch the scheduler admitted is still dropped and recorded" do
+        anchor = comment("@#{@agent.name}: first")
+        late = comment("@#{@agent.name}: second")
+        turn = running_turn(anchor)
+
+        assert_equal [ @agent.id ], dispatch(late).map(&:id)
+        assert_includes DeliveryRecord.dropped_ids_in(turn.reload.trigger_event_payload), late.id
+      end
+
+      # Re-anchoring moves the trigger onto a different comment, and everything
+      # the payload derives from the anchor has to move with it. ContextBuilder
+      # fills "chat"/"mentioned_user" with `||=` and does not run again on
+      # either of these paths — AiAgentJob asks Matcher#assignment_permits?
+      # against the raw payload — so a mention left behind reads as "no mention
+      # at all", and an explicit mention is exactly what outranks a topic
+      # assignment.
+      test "re-anchoring rebuilds the mention from the comment it moves onto" do
+        anchor = comment("first, to nobody")
+        late = comment("@#{@agent.name}: second")
+        payload = TaskCoalescer.reanchor_payload(context_for(anchor), late)
+
+        assert_equal @agent.id, payload.dig("chat", "mentioned_user", "id")
+      end
+
+      # Control against carrying the old anchor's mention across: a rebuild
+      # that finds nobody must leave the key absent, not stale. Matcher reads
+      # its presence as the mention that outranks the assignment.
+      test "re-anchoring onto a comment that mentions nobody leaves no mention behind" do
+        anchor = comment("@#{@agent.name}: first")
+        late = comment("second, to nobody")
+        payload = TaskCoalescer.reanchor_payload(
+          SystemEvents::ContextBuilder.new(context_for(anchor)).build, late
+        )
+
+        assert_nil payload.dig("chat", "mentioned_user")
+      end
+
+      test "a restored dispatch that mentions this agent runs in a topic assigned to another" do
+        anchor = comment("@#{@agent.name}: first")
+        late = comment("@#{@agent.name}: second")
+        turn = running_turn(anchor)
+        dispatch(late)
+        assert_includes DeliveryRecord.dropped_ids_in(turn.reload.trigger_event_payload), late.id,
+                        "premise: the dispatch was dropped, so only the restore can bring it back"
+
+        @topic.update!(primary_agent_id: session_agent.id)
+        slot_holder(anchor)
+        turn.update!(status: "failed")
+
+        assert_equal [ late.id ], restored_waiters.map { |t| t.trigger_event_payload.dig("comment", "id") },
+                     "an explicit mention outranks the assignment, as it did at dispatch"
+      end
+
+      # Control: the assignment check is still doing its job. Without a mention
+      # of this agent there is nothing to outrank the reassignment, and the
+      # restored dispatch must stay refused.
+      test "a restored dispatch with no mention stays refused in a topic assigned to another" do
+        anchor = comment("@#{@agent.name}: first")
+        late = comment("second, to nobody in particular")
+        turn = running_turn(anchor)
+        dispatch(late)
+
+        @topic.update!(primary_agent_id: session_agent.id)
+        slot_holder(anchor)
+        turn.update!(status: "failed")
+
+        assert_empty restored_waiters,
+                     "the topic belongs to another agent and nothing in the comment says otherwise"
+      end
     end
   end
 end

--- a/engines/collavre/test/services/collavre/orchestration/delivered_history_dispatch_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/delivered_history_dispatch_test.rb
@@ -236,6 +236,145 @@ module Collavre
         assert_empty waiting_notices,
                      "and the notice it was parked behind goes with it"
       end
+
+      # Hold the topic slot so a restored dispatch parks as a waiter here
+      # instead of being admitted and executed inline by the test adapter. What
+      # is under test is that the dispatch exists again, not what it says.
+      def slot_holder(anchor)
+        Task.create!(
+          name: "Holder", status: "running", trigger_event_name: "comment_created",
+          agent: @agent, topic_id: @topic.id, creative_id: @creative.id,
+          trigger_event_payload: context_for(anchor)
+        )
+      end
+
+      def restored_waiters
+        tasks_for(@agent).where(status: "queued")
+      end
+
+      # The drop is only sound while the covering turn is still going to answer.
+      # `failed` is kept out of DELIVERED_STATUSES precisely because a turn that
+      # died may never have delivered anything — a *waiter* survives that,
+      # because promotion re-reads the covering turn's status and refreshes it
+      # normally. A dropped dispatch has no row left to refresh, so the drop has
+      # to put back what it discarded.
+      test "a dropped dispatch comes back when the covering turn fails" do
+        anchor = comment("@#{@agent.name}: first")
+        late = comment("@#{@agent.name}: second")
+        turn = running_turn(anchor)
+        dispatch(late)
+        assert_empty tasks_for(@agent), "premise: the dispatch was dropped, leaving no row"
+
+        slot_holder(anchor)
+        turn.update!(status: "failed")
+
+        assert_equal [ late.id ], restored_waiters.map { |t| t.trigger_event_payload.dig("comment", "id") },
+                     "the comment the failed turn silenced has a turn of its own again"
+      end
+
+      # Cancellation is the other undelivered ending: the turn's own anchor was
+      # deleted underneath it. The comments it swallowed were not deleted.
+      test "a dropped dispatch comes back when the covering turn is cancelled" do
+        anchor = comment("@#{@agent.name}: first")
+        late = comment("@#{@agent.name}: second")
+        turn = running_turn(anchor)
+        dispatch(late)
+
+        slot_holder(anchor)
+        turn.update!(status: "cancelled")
+
+        assert_equal [ late.id ], restored_waiters.map { |t| t.trigger_event_payload.dig("comment", "id") }
+      end
+
+      # Control: the whole point of the drop. A turn that finished delivered
+      # what it read, and putting the dispatch back would answer it twice.
+      test "a completed turn restores nothing" do
+        anchor = comment("@#{@agent.name}: first")
+        late = comment("@#{@agent.name}: second")
+        turn = running_turn(anchor)
+        dispatch(late)
+
+        slot_holder(anchor)
+        turn.update!(status: "done")
+
+        assert_empty restored_waiters,
+                     "the agent read that comment and answered; there is nothing to restore"
+      end
+
+      # Control against restoring what was never dropped. A waiter parked before
+      # the turn assembled still has its own row, and promotion — which reads the
+      # failed turn's status — is what decides its fate. Restoring it as well
+      # would put two turns on one comment.
+      test "a comment that still has a task of its own is not restored" do
+        anchor = comment("@#{@agent.name}: first")
+        holder = slot_holder(anchor)
+        late = comment("@#{@agent.name}: second")
+        dispatch(late)
+        waiter = restored_waiters.sole
+
+        data = AiAgent::MessageBuilder.new(
+          agent: @agent, context: holder.trigger_event_payload, original_comment: anchor
+        ).build
+        resolved = AiAgent::SessionContextResolver.new(
+          agent: @agent, messages_data: data, system_prompt: "prompt"
+        ).resolve
+        DeliveryRecord.record!(holder, resolved)
+        holder.update!(status: "failed")
+
+        assert_equal [ waiter.id ], restored_waiters.pluck(:id),
+                     "the dispatch was parked, not discarded — it needs no restoring"
+      end
+
+      # A comment deleted while the turn ran has nothing to answer.
+      test "a comment that no longer exists is not restored" do
+        anchor = comment("@#{@agent.name}: first")
+        late = comment("@#{@agent.name}: second")
+        turn = running_turn(anchor)
+        dispatch(late)
+        late.destroy!
+
+        slot_holder(anchor)
+        turn.update!(status: "failed")
+
+        assert_empty restored_waiters
+      end
+
+      # Nor has one the author took out of the turn while it ran. The restore
+      # re-asks eligibility rather than trusting the record, which was written
+      # when the comment was still eligible.
+      test "a comment made private while the turn ran is not restored" do
+        anchor = comment("@#{@agent.name}: first")
+        late = comment("@#{@agent.name}: second")
+        turn = running_turn(anchor)
+        dispatch(late)
+        late.update!(private: true)
+
+        slot_holder(anchor)
+        turn.update!(status: "failed")
+
+        assert_empty restored_waiters
+      end
+
+      # The restored dispatch is the one that was discarded, not a descendant of
+      # the turn that discarded it: it carries no delivery record, no merged list
+      # and no acquired anchor. Without this a restored turn that fails again
+      # would restore the same comments a second time.
+      test "the restored dispatch carries none of the dead turn's bookkeeping" do
+        anchor = comment("@#{@agent.name}: first")
+        late = comment("@#{@agent.name}: second")
+        turn = running_turn(anchor)
+        dispatch(late)
+
+        slot_holder(anchor)
+        turn.update!(status: "failed")
+
+        payload = restored_waiters.sole.trigger_event_payload
+        assert_empty DeliveryRecord.ids_in(payload)
+        assert_empty Array(payload[TaskCoalescer::PAYLOAD_KEY])
+        assert_nil payload[TaskCoalescer::ACQUIRED_ANCHOR_KEY]
+        assert_equal late.content, payload.dig("chat", "content"),
+                     "and it is anchored on the comment it was dispatched for"
+      end
     end
   end
 end

--- a/engines/collavre/test/services/collavre/orchestration/delivered_history_dispatch_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/delivered_history_dispatch_test.rb
@@ -367,17 +367,45 @@ module Collavre
       end
 
       # Cancellation is the other undelivered ending: the turn's own anchor was
-      # deleted underneath it. The comments it swallowed were not deleted.
-      test "a dropped dispatch comes back when the covering turn is cancelled" do
+      # deleted underneath it, or the user pressed Stop. The comments it
+      # swallowed were not deleted.
+      #
+      # Decided where the turn settles rather than where it was stopped: the
+      # cancel is committed by another process while this turn is still inside
+      # the provider call, so it cannot yet know whether the payload got there.
+      test "a dropped dispatch comes back when the turn that was stopped settles" do
         anchor = comment("@#{@agent.name}: first")
         late = comment("@#{@agent.name}: second")
         turn = running_turn(anchor)
         dispatch(late)
 
         slot_holder(anchor)
-        turn.update!(status: "cancelled")
+        # The canceller: a request that loaded this row and wrote the status.
+        Task.find(turn.id).update!(status: "cancelled")
+        assert_empty restored_waiters,
+                     "premise: the cancel does not decide for a turn still running"
+
+        DeliveryRecord.restore_if_undelivered!(turn.reload)
 
         assert_equal [ late.id ], restored_waiters.map { |t| t.trigger_event_payload.dig("comment", "id") }
+      end
+
+      # Control, and what scopes the declining to the turn it is about: a turn
+      # paused for tool approval has already returned from its job, so nothing is
+      # going to settle it later and everything it had to say is written. The
+      # cancel decides for that one, as it always did.
+      test "a dropped dispatch comes back when a paused turn is cancelled" do
+        anchor = comment("@#{@agent.name}: first")
+        late = comment("@#{@agent.name}: second")
+        turn = running_turn(anchor)
+        dispatch(late)
+        slot_holder(anchor)
+        turn.update!(status: "pending_approval")
+
+        Task.find(turn.id).update!(status: "cancelled")
+
+        assert_equal [ late.id ], restored_waiters.map { |t| t.trigger_event_payload.dig("comment", "id") },
+                     "no worker is coming back for this one; the cancel is where it settles"
       end
 
       # Control: the whole point of the drop. A turn that finished delivered
@@ -1235,6 +1263,12 @@ module Collavre
       # — and the comments that turn swallowed were read along with it.
       # Restoring them starts fresh agent work the moment the user asked for
       # none, and answers those comments a second time.
+      #
+      # And the record cannot be read by the cancel that stops the turn: Stop is
+      # committed from a web request while the worker is still inside the
+      # provider call, so the status callback fires a poll interval *before* the
+      # turn writes down whether its payload got there. Asked at the settling
+      # instead, which is the only moment either answer exists.
       test "a dispatch dropped against a turn stopped after the handoff is not restored" do
         anchor = comment("@#{@agent.name}: first")
         late = comment("@#{@agent.name}: second")
@@ -1242,10 +1276,16 @@ module Collavre
         dispatch(late)
         assert_includes DeliveryRecord.dropped_ids_in(turn.reload.trigger_event_payload), late.id,
                         "premise: the dispatch was dropped against this turn"
-        DeliveryRecord.mark_handed_off!(turn)
 
         slot_holder(anchor)
-        turn.reload.update!(status: "cancelled")
+        # The canceller, first: it has nothing to read yet.
+        Task.find(turn.id).update!(status: "cancelled")
+        assert_empty restored_waiters,
+                     "the turn had not yet said whether its payload got there"
+
+        # ...and then the turn's own teardown, which is where it says so.
+        DeliveryRecord.mark_handed_off!(turn)
+        DeliveryRecord.restore_if_undelivered!(turn.reload)
 
         assert_empty restored_waiters,
                      "the provider had that comment; re-dispatching it answers it twice"
@@ -1258,9 +1298,9 @@ module Collavre
         late = comment("@#{@agent.name}: second")
         turn = running_turn(anchor)
         dispatch(late)
-        DeliveryRecord.mark_handed_off!(turn)
         slot_holder(anchor)
-        turn.reload.update!(status: "cancelled")
+        Task.find(turn.id).update!(status: "cancelled")
+        DeliveryRecord.mark_handed_off!(turn)
 
         RestoreDroppedDispatchesJob.perform_now
 

--- a/engines/collavre/test/services/collavre/orchestration/delivered_history_dispatch_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/delivered_history_dispatch_test.rb
@@ -79,6 +79,12 @@ module Collavre
           agent: agent, topic_id: @topic.id, creative_id: @creative.id,
           trigger_event_payload: context_for(anchor)
         )
+        reassemble(turn, anchor, agent: agent)
+      end
+
+      # A turn assembling its payload — the first time, or again after a pause
+      # for tool approval, which re-runs AiAgentService over the same row.
+      def reassemble(turn, anchor, agent: @agent)
         data = AiAgent::MessageBuilder.new(
           agent: agent, context: turn.trigger_event_payload, original_comment: anchor
         ).build
@@ -1356,6 +1362,69 @@ module Collavre
 
         assert_empty restored_waiters,
                      "the provider had that comment; re-dispatching it answers it twice"
+      end
+
+      # ─────────────────────────────────────────────
+      # A turn that ran more than once
+      # ─────────────────────────────────────────────
+
+      # A tool approval pauses the turn and Comments::ActionExecutor resumes the
+      # *same* Task row, so AiAgentService runs over it a second time with a
+      # fresh client. The first pass reached its tools, which means the provider
+      # had that payload and everything the window swept into it; if the resumed
+      # request then never lands, the row carries both records and
+      # Task#ended_undelivered? reads the failure first. The turn-level flag
+      # cannot answer for a turn that had more than one attempt: what the first
+      # one handed over stays handed over.
+      test "a dispatch the first attempt handed over is not restored when a later attempt fails" do
+        anchor = comment("@#{@agent.name}: first")
+        late = comment("@#{@agent.name}: second")
+        turn = running_turn(anchor)
+        dispatch(late)
+        assert_includes DeliveryRecord.dropped_ids_in(turn.reload.trigger_event_payload), late.id,
+                        "premise: the dispatch was dropped against this turn"
+        slot_holder(anchor)
+
+        # Attempt one reached its tools and paused for approval: the payload got there.
+        DeliveryRecord.mark_handed_off!(turn.reload)
+        Task.find(turn.id).update!(status: "pending_approval")
+
+        # The approval resumes the same row, and this time the request never lands.
+        DeliveryRecord.mark_handoff_failed!(Task.find(turn.id))
+        Task.find(turn.id).update!(status: "done")
+
+        assert_empty restored_waiters,
+                     "the first attempt handed that comment over; re-dispatching it answers it twice"
+      end
+
+      # And the other half, which is why the exemption is per comment rather
+      # than "a turn that ever handed off restores nothing": the resumed attempt
+      # assembles again and reads comments that landed during the pause. Those
+      # the first handoff never carried, so a failed resume still owes them.
+      test "a dispatch only the failed attempt read is still restored" do
+        anchor = comment("@#{@agent.name}: first")
+        late = comment("@#{@agent.name}: second")
+        turn = running_turn(anchor)
+        dispatch(late)
+        slot_holder(anchor)
+
+        DeliveryRecord.mark_handed_off!(turn.reload)
+        Task.find(turn.id).update!(status: "pending_approval")
+
+        during_pause = comment("@#{@agent.name}: third")
+        Task.where(id: turn.id).update_all(status: "running")
+        reassemble(turn.reload, anchor)
+        dispatch(during_pause)
+        assert_includes DeliveryRecord.dropped_ids_in(turn.reload.trigger_event_payload),
+                        during_pause.id,
+                        "premise: only the resumed attempt read it, and its dispatch was dropped"
+
+        DeliveryRecord.mark_handoff_failed!(Task.find(turn.id))
+        Task.find(turn.id).update!(status: "done")
+
+        assert_equal [ during_pause.id ],
+                     restored_waiters.map { |t| t.trigger_event_payload.dig("comment", "id") },
+                     "the attempt that read it never handed it over"
       end
 
       # And the sweep decides with the same predicate, or the backstop undoes

--- a/engines/collavre/test/services/collavre/orchestration/delivered_history_dispatch_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/delivered_history_dispatch_test.rb
@@ -382,6 +382,87 @@ module Collavre
                      "the dispatch is alive in the queue; a second one answers the comment twice"
       end
 
+      # The only state in which a dropped comment also has a Task row of its
+      # own: the row came from a *different* dispatch of the same comment, and
+      # the one that was dropped is therefore the duplicate. Reproduced here so
+      # the two controls below rest on a state that can actually arise.
+      #
+      # `duplicate_running_for_comment?` only looks for a *running* task, so a
+      # queued waiter does not stop the second dispatch from reaching the drop
+      # door — the guard the codebase already carries for redelivered events.
+      def duplicate_dispatch_over_a_waiter
+        anchor = comment("@#{@agent.name}: first")
+        holder = slot_holder(anchor)
+        late = comment("@#{@agent.name}: second")
+        dispatch(late)
+        waiter = restored_waiters.sole
+        assert_equal late.id, waiter.trigger_event_payload.dig("comment", "id"),
+                     "premise: the comment got a dispatch of its own, parked behind the slot"
+
+        data = AiAgent::MessageBuilder.new(
+          agent: @agent, context: holder.trigger_event_payload, original_comment: anchor
+        ).build
+        resolved = AiAgent::SessionContextResolver.new(
+          agent: @agent, messages_data: data, system_prompt: "prompt"
+        ).resolve
+        DeliveryRecord.record!(holder, resolved)
+
+        dispatch(late)
+        assert_includes DeliveryRecord.dropped_ids_in(holder.reload.trigger_event_payload), late.id,
+                        "premise: the redelivered dispatch was the one dropped"
+        assert_equal [ waiter.id ], restored_waiters.pluck(:id),
+                     "premise: and it left no row of its own"
+
+        [ holder, waiter, late, anchor ]
+      end
+
+      # Control: a terminal sibling is still coverage.
+      #
+      # The user pressed stop on the waiter — TasksController#cancel, one of the
+      # four doors a waiter leaves the queue through. The covering turn then
+      # fails, and its drop record still names that comment. Restoring it would
+      # answer a comment whose turn the user cancelled, from a dispatch that was
+      # only ever a duplicate of the cancelled one: `restore!` re-asks the
+      # comment's eligibility but has no way to re-ask the user's decision.
+      #
+      # This is why claimed_comment_ids counts a task in any status. Narrowing
+      # it to tasks "still capable of answering" reads a deliberate stop as an
+      # absence of coverage.
+      test "a comment whose own task the user stopped is not restored" do
+        holder, waiter, _late, anchor = duplicate_dispatch_over_a_waiter
+        waiter.update!(status: "cancelled")
+
+        slot_holder(anchor)
+        holder.update!(status: "failed")
+
+        assert_empty restored_waiters,
+                     "the comment had a turn and the user stopped it; a restore reverses that"
+      end
+
+      # Control: the same for a sibling that failed rather than was cancelled.
+      #
+      # Both turns have ended without delivering, which looks like the comment
+      # is now unanswered — but its own dispatch did become a Task, and a failed
+      # Task is the ordinary ending the product already shows and offers to
+      # retry. The restore exists for the one ending that leaves nothing behind
+      # at all: a dispatch discarded before it could become a row. Extending it
+      # to comments whose turn failed makes it a general retry the rest of the
+      # system does not have, and it fires on the duplicate rather than on the
+      # turn that actually failed.
+      test "a comment whose own task failed is not restored by the turn that read it" do
+        holder, waiter, late, anchor = duplicate_dispatch_over_a_waiter
+        waiter.update!(status: "failed")
+
+        slot_holder(anchor)
+        holder.update!(status: "failed")
+
+        assert_empty restored_waiters,
+                     "the comment had a turn of its own; its failure is that turn's, not a lost dispatch"
+        assert_equal [ "failed", late.id ],
+                     [ waiter.reload.status, waiter.trigger_event_payload.dig("comment", "id") ],
+                     "and it is still visible as a failed task for that comment"
+      end
+
       # A comment deleted while the turn ran has nothing to answer.
       test "a comment that no longer exists is not restored" do
         anchor = comment("@#{@agent.name}: first")

--- a/engines/collavre/test/services/collavre/orchestration/delivered_history_dispatch_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/delivered_history_dispatch_test.rb
@@ -1,0 +1,241 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  module Orchestration
+    # Event A and event B arrive as a burst; the agent starts a turn for A. A
+    # non-session turn reads the topic when it assembles its payload, so B is
+    # already inside it — the agent has read B. B's own dispatch should be
+    # dropped rather than parked behind the turn, and a waiter that was parked
+    # before the turn assembled should be cancelled at promotion.
+    #
+    # The boundary is the resolved payload, not the agent's status: a
+    # session-backed turn is sent only its :trigger and swallows nothing, so
+    # nothing is dropped for one.
+    class DeliveredHistoryDispatchTest < ActiveSupport::TestCase
+      setup do
+        @creative = creatives(:tshirt)
+        @user = users(:one)
+        @agent = users(:ai_bot)
+        @agent.update!(searchable: true, routing_expression: "true")
+
+        share = CreativeShare.find_or_create_by!(creative: @creative, user: @agent)
+        share.update!(permission: "feedback")
+        CreativeSharesCache.find_or_create_by!(
+          creative_id: @creative.id, user_id: @agent.id, permission: :feedback
+        )
+
+        @topic = Topic.create!(name: "Burst topic", creative: @creative, user: @user)
+        ResourceTracker.for(@agent).reset!
+      end
+
+      teardown do
+        ResourceTracker.for(@agent).reset!
+      end
+
+      def session_agent
+        @session_agent ||= begin
+          agent = Collavre::User.create!(
+            name: "dispatch-session-agent",
+            email: "dispatch-session-#{SecureRandom.hex(4)}@agent.test",
+            password: "password123",
+            llm_vendor: "google", llm_model: "gemini-1.5-flash",
+            system_prompt: "You are a session agent.", searchable: true,
+            routing_expression: "true", agent_conf: "session:\n  enabled: true\n"
+          )
+          share = CreativeShare.find_or_create_by!(creative: @creative, user: agent)
+          share.update!(permission: "feedback")
+          CreativeSharesCache.find_or_create_by!(
+            creative_id: @creative.id, user_id: agent.id, permission: :feedback
+          )
+          agent
+        end
+      end
+
+      def comment(body, user: @user)
+        Comment.create!(
+          creative: @creative, user: user, topic: @topic, content: body, skip_dispatch: true
+        )
+      end
+
+      def context_for(target)
+        {
+          "creative" => { "id" => @creative.id },
+          "topic" => { "id" => @topic.id },
+          "sender" => { "id" => @user.id, "name" => @user.name },
+          "chat" => { "content" => target.content },
+          "comment" => { "id" => target.id, "content" => target.content, "user_id" => @user.id }
+        }
+      end
+
+      # The running turn, with its record written the way AiAgentService writes
+      # it: off the payload MessageBuilder and SessionContextResolver actually
+      # produce, so the fixture cannot assert a delivery the real path would not
+      # have made.
+      def running_turn(anchor, agent: @agent)
+        turn = Task.create!(
+          name: "Turn", status: "running", trigger_event_name: "comment_created",
+          agent: agent, topic_id: @topic.id, creative_id: @creative.id,
+          trigger_event_payload: context_for(anchor)
+        )
+        data = AiAgent::MessageBuilder.new(
+          agent: agent, context: turn.trigger_event_payload, original_comment: anchor
+        ).build
+        resolved = AiAgent::SessionContextResolver.new(
+          agent: agent, messages_data: data, system_prompt: "prompt"
+        ).resolve
+        DeliveryRecord.record!(turn, resolved)
+        turn.reload
+      end
+
+      def dispatch(target, agent: @agent)
+        AgentOrchestrator.dispatch("comment_created", context_for(target))
+      end
+
+      def tasks_for(agent)
+        Task.where(agent: agent, topic_id: @topic.id).where.not(status: "running")
+      end
+
+      def waiting_notices
+        @creative.comments.where(topic_id: @topic.id, topic_concurrency_defer: true)
+                 .where("content LIKE ?", "#{Comment::WAITING_NOTICE_PREFIX}%")
+      end
+
+      test "a comment the running turn already read produces no task and no waiting notice" do
+        anchor = comment("@#{@agent.name}: first")
+        late = comment("@#{@agent.name}: second")
+        turn = running_turn(anchor)
+        assert_includes DeliveryRecord.ids_in(turn.trigger_event_payload), late.id,
+                        "premise: the running turn's history carried the late comment"
+
+        dispatch(late)
+
+        assert_empty tasks_for(@agent),
+                     "the agent has already read that comment; queueing it answers nothing new"
+        assert_empty waiting_notices,
+                     "and there is nobody to wait for, so no ⏳ notice either"
+      end
+
+      # Control against the drop swallowing ordinary bursts: without a record,
+      # nothing has been delivered and the waiter must still be parked.
+      test "a comment no turn has read is still queued" do
+        anchor = comment("@#{@agent.name}: first")
+        Task.create!(
+          name: "Holder", status: "running", trigger_event_name: "comment_created",
+          agent: @agent, topic_id: @topic.id, creative_id: @creative.id,
+          trigger_event_payload: context_for(anchor)
+        )
+        late = comment("@#{@agent.name}: second")
+
+        dispatch(late)
+
+        assert_equal 1, tasks_for(@agent).where(status: "queued").count,
+                     "a turn that has not assembled yet has delivered nothing"
+        assert_equal 1, waiting_notices.count
+      end
+
+      # The reason the predicate is the resolved payload rather than "the agent
+      # is busy". A session-backed turn is sent only its :trigger, so dropping
+      # here would lose the message outright.
+      test "a session-backed turn never drops the comments beside it" do
+        anchor = comment("@#{session_agent.name}: first")
+        late = comment("@#{session_agent.name}: second")
+        turn = running_turn(anchor, agent: session_agent)
+        assert_empty DeliveryRecord.ids_in(turn.trigger_event_payload),
+                     "premise: incremental_payload carries no chat history"
+
+        dispatch(late, agent: session_agent)
+
+        assert_equal 1, tasks_for(session_agent).where(status: "queued").count,
+                     "a session agent's burst is coalesced, never discarded"
+      end
+
+      test "the policy switch keeps the dispatch queued" do
+        OrchestratorPolicy.create!(
+          policy_type: "scheduling", scope_type: "Creative", scope_id: @creative.id,
+          config: { "drop_delivered_dispatches" => false }
+        )
+        anchor = comment("@#{@agent.name}: first")
+        late = comment("@#{@agent.name}: second")
+        running_turn(anchor)
+
+        dispatch(late)
+
+        assert_equal 1, tasks_for(@agent).where(status: "queued").count
+      end
+
+      # A review is bound to the comment it quotes and can only run as its own
+      # turn. Having been swept into a history window is not having been
+      # answered.
+      test "a review request is queued even when the running turn read it" do
+        anchor = comment("@#{@agent.name}: first")
+        target = comment("the agent's earlier answer", user: @agent)
+        review = Comment.create!(
+          creative: @creative, user: @user, topic: @topic,
+          content: "@#{@agent.name}: tighten this up", quoted_comment: target, skip_dispatch: true
+        )
+        turn = running_turn(anchor)
+        assert_includes DeliveryRecord.ids_in(turn.trigger_event_payload), review.id,
+                        "premise: the review did land in the running turn's history"
+
+        dispatch(review)
+
+        assert_equal 1, tasks_for(@agent).where(status: "queued").count,
+                     "a review keeps its own turn"
+      end
+
+      # Two doors lead into the queue. An :immediate decision creates no Task at
+      # the orchestrator at all — the row is created inside AiAgentJob — so a
+      # dispatch can be enqueued before the covering turn assembles and become
+      # droppable only by the time the job runs.
+      test "the job door drops a dispatch the covering turn read while it waited" do
+        anchor = comment("@#{@agent.name}: first")
+        late = comment("@#{@agent.name}: second")
+        context = context_for(late)
+        running_turn(anchor)
+
+        AiAgentJob.new.perform(@agent.id, "comment_created", context)
+
+        assert_empty tasks_for(@agent),
+                     "the late-admission door has to ask the same question the enqueue door did"
+        assert_empty Task.where(agent: @agent, topic_id: @topic.id, status: "running")
+                         .where.not(trigger_event_payload: nil)
+                         .select { |t| t.trigger_event_payload.dig("comment", "id") == late.id },
+                     "and must not admit it as a second concurrent turn either"
+      end
+
+      # The window the dispatch doors cannot close: the waiter was parked before
+      # the covering turn assembled, so nothing was recorded to drop it against.
+      # Promotion is where it is finally discoverable.
+      test "a waiter parked before the turn assembled is cancelled at promotion" do
+        anchor = comment("@#{@agent.name}: first")
+        holder = Task.create!(
+          name: "Holder", status: "running", trigger_event_name: "comment_created",
+          agent: @agent, topic_id: @topic.id, creative_id: @creative.id,
+          trigger_event_payload: context_for(anchor)
+        )
+        late = comment("@#{@agent.name}: second")
+        dispatch(late)
+        waiter = tasks_for(@agent).where(status: "queued").sole
+        assert_equal late.id, waiter.trigger_event_payload.dig("comment", "id")
+
+        data = AiAgent::MessageBuilder.new(
+          agent: @agent, context: holder.trigger_event_payload, original_comment: anchor
+        ).build
+        resolved = AiAgent::SessionContextResolver.new(
+          agent: @agent, messages_data: data, system_prompt: "prompt"
+        ).resolve
+        DeliveryRecord.record!(holder, resolved)
+        holder.update!(status: "done")
+
+        AgentOrchestrator.dequeue_next_for_topic(@topic.id, @creative.id)
+
+        assert_equal "cancelled", waiter.reload.status,
+                     "the covering turn read that comment; the waiter has nothing left to say"
+        assert_empty waiting_notices,
+                     "and the notice it was parked behind goes with it"
+      end
+    end
+  end
+end

--- a/engines/collavre/test/services/collavre/orchestration/delivered_history_dispatch_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/delivered_history_dispatch_test.rb
@@ -901,9 +901,9 @@ module Collavre
       # deleted anchor — while the worker is still inside the provider call, so
       # the row carries no account of the handoff yet and will not until the
       # worker comes out. The status callback declines for exactly that reason
-      # (Task#stopped_mid_turn?); this door reads a settled row and cannot tell
-      # "still settling" from "nobody is coming", so without the wait it answers
-      # in the callback's place, minutes after the user pressed Stop.
+      # (Task#ended_while_worker_settles?); this door reads a settled row and
+      # cannot tell "still settling" from "nobody is coming", so without the wait
+      # it answers in the callback's place, minutes after the user pressed Stop.
       test "the sweep leaves a cancellation its worker has not settled alone" do
         anchor = comment("@#{@agent.name}: first")
         late = comment("@#{@agent.name}: second")
@@ -934,7 +934,7 @@ module Collavre
 
         Task.find(turn.id).update!(status: "cancelled")
         Task.where(id: turn.id)
-            .update_all(updated_at: (DeliveryRecord.cancel_settle_grace + 5.minutes).ago)
+            .update_all(updated_at: (DeliveryRecord.worker_settle_grace + 5.minutes).ago)
 
         RestoreDroppedDispatchesJob.perform_now
 
@@ -955,12 +955,66 @@ module Collavre
 
         Task.find(turn.id).update!(status: "cancelled")
         Task.where(id: turn.id).update_all(
-          updated_at: (DeliveryRecord::RESTORE_SWEEP_WINDOW + DeliveryRecord.cancel_settle_grace + 5.minutes).ago
+          updated_at: (
+            DeliveryRecord::RESTORE_SWEEP_WINDOW + DeliveryRecord.worker_settle_grace + 5.minutes
+          ).ago
         )
 
         RestoreDroppedDispatchesJob.perform_now
 
         assert_empty restored_waiters
+      end
+
+      # StuckDetector changes the row from another process while the original
+      # worker can still be inside the provider call. That is the same missing
+      # evidence as Stop, but with a `failed` ending: restoring from the status
+      # callback can start the swallowed dispatch while the first provider call
+      # is still running.
+      test "stuck recovery does not restore a dispatch before the failed worker settles" do
+        anchor = comment("@#{@agent.name}: first")
+        late = comment("@#{@agent.name}: second")
+        turn = running_turn(anchor)
+        dispatch(late)
+        slot_holder(anchor)
+
+        fail_as_stuck(turn)
+
+        assert_equal "failed", turn.reload.status, "premise: recovery failed the live row"
+        assert_empty restored_waiters,
+                     "the worker has not said yet whether the payload got there"
+      end
+
+      # The marker is a deferral, not a reason to lose the dispatch. A worker
+      # killed outright never clears it, so the restore sweep asks again after
+      # the same provider-timeout grace used for an unsettled cancellation.
+      test "the sweep restores a stuck failure whose worker never settled after the grace" do
+        anchor = comment("@#{@agent.name}: first")
+        late = comment("@#{@agent.name}: second")
+        turn = running_turn(anchor)
+        dispatch(late)
+        slot_holder(anchor)
+
+        fail_as_stuck(turn)
+        RestoreDroppedDispatchesJob.perform_now
+        assert_empty restored_waiters, "the failed worker can still be inside the provider call"
+
+        Task.where(id: turn.id)
+            .update_all(updated_at: (DeliveryRecord.worker_settle_grace + 5.minutes).ago)
+        RestoreDroppedDispatchesJob.perform_now
+
+        assert_equal [ late.id ], restored_waiters.map { |task|
+          task.trigger_event_payload.dig("comment", "id")
+        }, "nothing settled the worker, so the dropped dispatch is still owed"
+      end
+
+      def fail_as_stuck(turn)
+        item = StuckDetector::StuckItem.new(
+          type: :task, item: turn.reload, reason: :no_progress,
+          stuck_since: 1.hour.ago, escalation_targets: []
+        )
+        AgentOrchestrator.stub(:dequeue_next_for_topic, ->(*) { }) do
+          StuckDetector.new.send(:recover_stuck_task, item)
+        end
       end
 
       test "the restored dispatch carries none of the dead turn's bookkeeping" do

--- a/engines/collavre/test/services/collavre/orchestration/delivery_record_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/delivery_record_test.rb
@@ -441,10 +441,37 @@ module Collavre
                      DeliveryRecord::UNDELIVERED_TERMINAL_STATUSES.sort
       end
 
+      # The turn-level flag cannot answer for a turn that ran twice, so the
+      # handoff also writes down what it carried. A resumed attempt reads
+      # comments that landed during the pause, and those the first handoff did
+      # not carry — the record has to grow with each attempt that lands, not be
+      # written once and left.
+      test "the handoff records the comments the attempt carried, and grows with a second one" do
+        anchor = comment("first")
+        turn = task_for(anchor)
+        late = comment("second")
+        DeliveryRecord.record!(turn, resolved_for(turn, @agent))
+        DeliveryRecord.mark_handed_off!(turn.reload)
+
+        assert_equal [ late.id ],
+                     DeliveryRecord.handed_off_ids_in(turn.reload.trigger_event_payload)
+
+        during_pause = comment("third")
+        DeliveryRecord.record!(turn.reload, resolved_for(turn.reload, @agent))
+        assert_equal [ late.id ],
+                     DeliveryRecord.handed_off_ids_in(turn.reload.trigger_event_payload),
+                     "reading it is not handing it over"
+
+        DeliveryRecord.mark_handed_off!(turn.reload)
+
+        assert_equal [ late.id, during_pause.id ].sort,
+                     DeliveryRecord.handed_off_ids_in(turn.reload.trigger_event_payload)
+      end
+
       # The same drift, on the other list. TURN_SCOPED_KEYS is what a restored
       # dispatch is stripped of, and it is right only while it names every key a
-      # turn writes onto its own payload. Driving all five writers over one
-      # payload is what makes a sixth added later show up here rather than as a
+      # turn writes onto its own payload. Driving every writer over one
+      # payload is what makes another one added later show up here rather than as a
       # restored dispatch quietly carrying it.
       test "the stripped keys are exactly the ones a turn writes onto its own payload" do
         anchor = comment("first")

--- a/engines/collavre/test/services/collavre/orchestration/delivery_record_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/delivery_record_test.rb
@@ -253,6 +253,50 @@ module Collavre
         assert_nil DeliveryRecord.covering_task(@agent, late.id, context_for(late), "comment_created")
       end
 
+      # Reading a comment and discarding a dispatch for it are different facts,
+      # and only the second one is a thing to put back. The history record
+      # answers "has the agent been given this?" — a question the topic's whole
+      # burst answers yes to, including comments this agent was never matched
+      # for. What the restore owes is narrower: the dispatches it actually
+      # refused.
+      test "reading a comment is not by itself a dropped dispatch" do
+        anchor = comment("first")
+        turn = task_for(anchor)
+        late = comment("second")
+        DeliveryRecord.record!(turn, resolved_for(turn, @agent))
+
+        assert_includes recorded(turn), late.id, "premise: the turn read it"
+        assert_empty DeliveryRecord.dropped_ids_in(turn.reload.trigger_event_payload),
+                     "but no dispatch was ever refused, so there is nothing to restore"
+      end
+
+      test "a claimed drop is recorded against the covering turn" do
+        anchor = comment("first")
+        turn = task_for(anchor)
+        late = comment("second")
+        DeliveryRecord.record!(turn, resolved_for(turn, @agent))
+
+        assert DeliveryRecord.claim_drop!(turn, late.id), "the turn is in flight and may take the drop"
+        assert_equal [ late.id ], DeliveryRecord.dropped_ids_in(turn.reload.trigger_event_payload)
+      end
+
+      # The drop and the record are one act. A turn that ends between the caller
+      # reading it and the drop being written has already run its restore, so a
+      # record written afterwards is a comment nobody ever comes back for. The
+      # caller is told no and dispatches normally instead.
+      test "a turn that has ended cannot take a drop" do
+        anchor = comment("first")
+        turn = task_for(anchor)
+        late = comment("second")
+        DeliveryRecord.record!(turn, resolved_for(turn, @agent))
+
+        Task.where(id: turn.id).update_all(status: "failed")
+
+        assert_not DeliveryRecord.claim_drop!(turn, late.id),
+                   "the caller's snapshot said running; the row says otherwise"
+        assert_empty DeliveryRecord.dropped_ids_in(turn.reload.trigger_event_payload)
+      end
+
       # The dispatch door and the promotion door have to mean the same thing by
       # "this turn delivered nothing". Promotion expresses it by leaving a
       # status out of DELIVERED_STATUSES; the dispatch door expresses it by

--- a/engines/collavre/test/services/collavre/orchestration/delivery_record_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/delivery_record_test.rb
@@ -252,6 +252,18 @@ module Collavre
                         "the record is evidence, and stays true whatever the switch says"
         assert_nil DeliveryRecord.covering_task(@agent, late.id, context_for(late), "comment_created")
       end
+
+      # The dispatch door and the promotion door have to mean the same thing by
+      # "this turn delivered nothing". Promotion expresses it by leaving a
+      # status out of DELIVERED_STATUSES; the dispatch door expresses it by
+      # restoring on that status. A status added to one list and not the other
+      # is how the two doors come to disagree.
+      test "the statuses that restore are exactly the terminal ones promotion calls undelivered" do
+        terminal = %w[done failed cancelled escalated]
+
+        assert_equal (terminal - AgentOrchestrator::DELIVERED_STATUSES).sort,
+                     DeliveryRecord::UNDELIVERED_TERMINAL_STATUSES.sort
+      end
     end
   end
 end

--- a/engines/collavre/test/services/collavre/orchestration/delivery_record_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/delivery_record_test.rb
@@ -456,6 +456,8 @@ module Collavre
         DeliveryRecord.record!(turn, resolved_for(turn, @agent))
         DeliveryRecord.claim_drop!(turn.reload, late.id)
         DeliveryRecord.mark_handoff_failed!(turn.reload)
+        DeliveryRecord.mark_handed_off!(turn.reload)
+        DeliveryRecord.claim_restore!(turn.reload, late.id)
         turn.update!(
           trigger_event_payload: TaskCoalescer.reanchor_payload(
             TaskCoalescer.absorb_into_payload(turn.reload.trigger_event_payload, [ folded.id ]),

--- a/engines/collavre/test/services/collavre/orchestration/delivery_record_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/delivery_record_test.rb
@@ -76,6 +76,15 @@ module Collavre
         DeliveryRecord.ids_in(task.reload.trigger_event_payload)
       end
 
+      # What the window actually swept up, read the same way the record reads it.
+      def history_ids(resolved)
+        Array(resolved[:messages] || resolved["messages"]).filter_map do |message|
+          next unless (message[:kind] || message["kind"]).to_s == "chat_history"
+
+          (message[:comment_id] || message["comment_id"])&.to_i
+        end
+      end
+
       test "a comment that landed after the turn was dispatched is recorded as delivered" do
         anchor = comment("first")
         turn = task_for(anchor)
@@ -251,6 +260,55 @@ module Collavre
         assert_includes recorded(turn), late.id,
                         "the record is evidence, and stays true whatever the switch says"
         assert_nil DeliveryRecord.covering_task(@agent, late.id, context_for(late), "comment_created")
+      end
+
+      # A history entry is text and nothing else — MessageBuilder attaches blobs
+      # only on the trigger. So a comment carrying an image that the window swept
+      # up has been *partly* delivered, and the record's predicate is false for
+      # it. Recording it would discard the one dispatch that would have carried
+      # the image; an image-only comment would reach the agent as a blank line.
+      test "a comment whose image the history window left behind is not recorded" do
+        anchor = comment("first")
+        turn = task_for(anchor)
+        illustrated = comment("look at this")
+        illustrated.images.attach(
+          io: File.open(Collavre::Engine.root.join("test/fixtures/files/small.png")),
+          filename: "small.png", content_type: "image/png"
+        )
+
+        resolved = resolved_for(turn, @agent)
+        assert_includes history_ids(resolved), illustrated.id,
+                        "premise: the window did sweep it up, as text"
+
+        DeliveryRecord.record!(turn, resolved)
+
+        assert_not_includes recorded(turn), illustrated.id,
+                            "its image was never handed over, so it was not delivered"
+        assert_nil DeliveryRecord.covering_task(@agent, illustrated.id, context_for(anchor), "comment_created"),
+                   "and its own dispatch is the only thing that would carry the image"
+      end
+
+      # The record is written by whichever pass assembles, and merged onto the
+      # payload the caller loaded — but a drop is written by a *refused*
+      # dispatch, in another process, after that load. A resumed turn that
+      # rewrites the whole JSON from its own stale copy erases the drop, and the
+      # comment it discarded has nothing left to bring it back.
+      test "a drop claimed while the turn was assembling survives the record" do
+        anchor = comment("first")
+        turn = task_for(anchor)
+        late = comment("second")
+        DeliveryRecord.record!(turn, resolved_for(turn, @agent))
+
+        assembling = Task.find(turn.id)
+        assert DeliveryRecord.claim_drop!(Task.find(turn.id), late.id), "premise: another process refused a dispatch"
+
+        later_still = comment("third")
+        DeliveryRecord.record!(assembling, resolved_for(assembling, @agent))
+
+        assert_equal [ late.id ], DeliveryRecord.dropped_ids_in(turn.reload.trigger_event_payload),
+                     "the record must not overwrite a drop it never saw"
+        assert_includes recorded(turn), later_still.id,
+                        "and the second pass still records what it swallowed"
       end
 
       # Reading a comment and discarding a dispatch for it are different facts,

--- a/engines/collavre/test/services/collavre/orchestration/delivery_record_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/delivery_record_test.rb
@@ -1,0 +1,257 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Collavre
+  module Orchestration
+    # What a running turn actually handed the agent, recorded rather than
+    # inferred from the agent's status.
+    #
+    # "The agent is busy" is not the same question as "the agent has already
+    # read that comment", and the two answers diverge by agent kind: a
+    # non-session turn re-reads the topic at execution time and swallows
+    # whatever landed in the meantime, while a session-backed turn is sent only
+    # its :trigger and swallows nothing.
+    class DeliveryRecordTest < ActiveSupport::TestCase
+      setup do
+        @user = users(:one)
+        @creative = creatives(:tshirt)
+        @agent = users(:ai_bot)
+        @topic = Topic.create!(name: "Delivery topic", creative: @creative, user: @user)
+      end
+
+      def comment(body)
+        Comment.create!(
+          creative: @creative, user: @user, topic: @topic, content: body, skip_dispatch: true
+        )
+      end
+
+      def context_for(anchor)
+        {
+          "creative" => { "id" => @creative.id },
+          "topic" => { "id" => @topic.id },
+          "sender" => { "id" => @user.id, "name" => @user.name },
+          "comment" => { "id" => anchor.id, "content" => anchor.content, "user_id" => @user.id },
+          "chat" => { "content" => anchor.content }
+        }
+      end
+
+      def task_for(anchor, status: "running", agent: @agent, event: "comment_created",
+                   topic_id: @topic.id, creative_id: @creative.id)
+        payload = context_for(anchor)
+        payload["topic"] = { "id" => topic_id }
+        payload["creative"] = { "id" => creative_id }
+        Task.create!(
+          name: "Turn", status: status, trigger_event_name: event, agent: agent,
+          topic_id: topic_id, creative_id: creative_id, trigger_event_payload: payload
+        )
+      end
+
+      def session_agent
+        @session_agent ||= Collavre::User.create!(
+          name: "delivery-session-agent",
+          email: "delivery-session-#{SecureRandom.hex(4)}@agent.test",
+          password: "password123",
+          llm_vendor: "google", llm_model: "gemini-1.5-flash",
+          system_prompt: "You are a session agent.",
+          agent_conf: "session:\n  enabled: true\n"
+        )
+      end
+
+      # Built through MessageBuilder and SessionContextResolver rather than by
+      # hand: the record has to describe the payload the adapter is handed, and
+      # a fixture assembled here could assert a shape neither one produces.
+      def resolved_for(task, agent)
+        context = task.trigger_event_payload
+        data = AiAgent::MessageBuilder.new(
+          agent: agent, context: context,
+          original_comment: Comment.find_by(id: context.dig("comment", "id"))
+        ).build
+        AiAgent::SessionContextResolver.new(
+          agent: agent, messages_data: data, system_prompt: "prompt"
+        ).resolve
+      end
+
+      def recorded(task)
+        DeliveryRecord.ids_in(task.reload.trigger_event_payload)
+      end
+
+      test "a comment that landed after the turn was dispatched is recorded as delivered" do
+        anchor = comment("first")
+        turn = task_for(anchor)
+        late = comment("second, arrived while the turn was assembling")
+
+        DeliveryRecord.record!(turn, resolved_for(turn, @agent))
+
+        assert_includes recorded(turn), late.id,
+                        "chat history carried the late comment, so the turn delivered it"
+      end
+
+      # The whole point of asking the resolved payload rather than the agent's
+      # status. A session-backed agent is sent only its :trigger, so a comment
+      # that merely coexisted with the turn was never handed over — recording it
+      # would licence dropping a message nobody ever read.
+      test "a session-backed turn records nothing it was never sent" do
+        anchor = comment("first")
+        turn = task_for(anchor, agent: session_agent)
+        late = comment("second, arrived while the turn was assembling")
+
+        DeliveryRecord.record!(turn, resolved_for(turn, session_agent))
+
+        assert_empty recorded(turn),
+                     "incremental_payload drops chat history, so nothing was delivered"
+        assert_not_includes recorded(turn), late.id
+      end
+
+      # Negative control for the id restriction. The backlog of a topic is
+      # ordinary context, not something this turn swallowed, and counting it
+      # would silence waiters parked long before this turn existed.
+      test "history older than the anchor is not recorded" do
+        old = comment("last week's message")
+        anchor = comment("the trigger")
+        turn = task_for(anchor)
+
+        DeliveryRecord.record!(turn, resolved_for(turn, @agent))
+
+        assert_not_includes recorded(turn), old.id,
+                            "the backlog is context, not a comment this turn absorbed"
+      end
+
+      test "nothing is recorded before the payload resolves" do
+        anchor = comment("first")
+        turn = task_for(anchor)
+        comment("second")
+
+        assert_empty recorded(turn),
+                     "a turn that has not assembled yet must not silence anything"
+      end
+
+      # A resumed turn (pending_approval, or a retry) assembles a second time.
+      # Whatever it delivered on the first pass it still delivered.
+      test "a second pass accumulates rather than replaces the record" do
+        anchor = comment("first")
+        turn = task_for(anchor)
+        first_late = comment("second")
+        DeliveryRecord.record!(turn, resolved_for(turn, @agent))
+
+        moved = TaskCoalescer.reanchor_payload(turn.reload.trigger_event_payload, first_late)
+        turn.update!(trigger_event_payload: moved)
+        second_late = comment("third")
+        DeliveryRecord.record!(turn.reload, resolved_for(turn, @agent))
+
+        assert_includes recorded(turn), first_late.id,
+                        "a re-anchor must not erase what the first pass delivered"
+        assert_includes recorded(turn), second_late.id
+      end
+
+      test "a running turn's record covers a later dispatch of the same comment" do
+        anchor = comment("first")
+        turn = task_for(anchor)
+        late = comment("second")
+        DeliveryRecord.record!(turn, resolved_for(turn, @agent))
+
+        assert_equal turn.id,
+                     DeliveryRecord.covering_task(@agent, late.id, context_for(late), "comment_created")&.id
+      end
+
+      test "an un-started turn covers nothing" do
+        anchor = comment("first")
+        turn = task_for(anchor)
+        late = comment("second")
+        DeliveryRecord.record!(turn, resolved_for(turn, @agent))
+        turn.update!(status: "queued")
+
+        assert_nil DeliveryRecord.covering_task(@agent, late.id, context_for(late), "comment_created"),
+                   "a queued row has delivered nothing, whatever its payload says"
+      end
+
+      # A turn that has finished is no longer answering, so a dispatch arriving
+      # afterwards gets its own turn rather than being silently discarded. The
+      # promotion door still reads the same record for waiters already parked —
+      # that side may cancel, because a parked waiter has an alternative.
+      test "a finished turn does not drop a fresh dispatch" do
+        anchor = comment("first")
+        turn = task_for(anchor)
+        late = comment("second")
+        DeliveryRecord.record!(turn, resolved_for(turn, @agent))
+        turn.update!(status: "done")
+
+        assert_nil DeliveryRecord.covering_task(@agent, late.id, context_for(late), "comment_created")
+      end
+
+      test "delivery is per agent" do
+        other = Collavre::User.create!(
+          name: "delivery-other-agent",
+          email: "delivery-other-#{SecureRandom.hex(4)}@agent.test",
+          password: "password123",
+          llm_vendor: "openai", llm_model: "gpt-4", system_prompt: "You are another agent."
+        )
+        anchor = comment("first")
+        turn = task_for(anchor)
+        late = comment("second")
+        DeliveryRecord.record!(turn, resolved_for(turn, @agent))
+
+        assert_nil DeliveryRecord.covering_task(other, late.id, context_for(late), "comment_created"),
+                   "one agent's reading is not another agent's"
+      end
+
+      test "delivery is per trigger event" do
+        anchor = comment("first")
+        turn = task_for(anchor)
+        late = comment("second")
+        DeliveryRecord.record!(turn, resolved_for(turn, @agent))
+
+        assert_nil DeliveryRecord.covering_task(@agent, late.id, context_for(late), "comment_updated"),
+                   "a different event over the same comment is a different question"
+      end
+
+      test "delivery is per topic" do
+        anchor = comment("first")
+        turn = task_for(anchor)
+        late = comment("second")
+        DeliveryRecord.record!(turn, resolved_for(turn, @agent))
+
+        other_topic = Topic.create!(name: "Elsewhere", creative: @creative, user: @user)
+        elsewhere = context_for(late).merge("topic" => { "id" => other_topic.id })
+
+        assert_nil DeliveryRecord.covering_task(@agent, late.id, elsewhere, "comment_created")
+      end
+
+      # A review request is bound to the comment it quotes and can only run as
+      # its own turn (ReviewHandler reads the anchor, not the history window).
+      # Having been read as context is not having been answered.
+      test "a review request is never covered" do
+        anchor = comment("first")
+        turn = task_for(anchor)
+        target = Comment.create!(
+          creative: @creative, user: @agent, topic: @topic,
+          content: "the agent's answer", skip_dispatch: true
+        )
+        review = Comment.create!(
+          creative: @creative, user: @user, topic: @topic, content: "tighten this up",
+          quoted_comment: target, skip_dispatch: true
+        )
+        DeliveryRecord.record!(turn, resolved_for(turn, @agent))
+
+        assert_nil DeliveryRecord.covering_task(@agent, review.id, context_for(review), "comment_created"),
+                   "a review has to keep its own turn"
+      end
+
+      test "the policy switch turns the drop off without disturbing the record" do
+        anchor = comment("first")
+        turn = task_for(anchor)
+        late = comment("second")
+        DeliveryRecord.record!(turn, resolved_for(turn, @agent))
+
+        OrchestratorPolicy.create!(
+          policy_type: "scheduling", scope_type: "Creative", scope_id: @creative.id,
+          config: { "drop_delivered_dispatches" => false }
+        )
+
+        assert_includes recorded(turn), late.id,
+                        "the record is evidence, and stays true whatever the switch says"
+        assert_nil DeliveryRecord.covering_task(@agent, late.id, context_for(late), "comment_created")
+      end
+    end
+  end
+end

--- a/engines/collavre/test/services/collavre/orchestration/delivery_record_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/delivery_record_test.rb
@@ -85,6 +85,21 @@ module Collavre
         end
       end
 
+      # The text the window rendered, regardless of whether the entry claims to
+      # carry its comment whole. Premises about *what the window swept up* are
+      # asserted here rather than through history_ids, which reads the claim.
+      def history_texts(resolved)
+        Array(resolved[:messages] || resolved["messages"]).filter_map do |message|
+          next unless (message[:kind] || message["kind"]).to_s == "chat_history"
+
+          Array(message[:parts] || message["parts"]).map { |p| p[:text] || p["text"] }.join
+        end
+      end
+
+      def kinds_in(resolved)
+        Array(resolved[:messages] || resolved["messages"]).map { |m| (m[:kind] || m["kind"]).to_s }
+      end
+
       test "a comment that landed after the turn was dispatched is recorded as delivered" do
         anchor = comment("first")
         turn = task_for(anchor)
@@ -277,8 +292,8 @@ module Collavre
         )
 
         resolved = resolved_for(turn, @agent)
-        assert_includes history_ids(resolved), illustrated.id,
-                        "premise: the window did sweep it up, as text"
+        assert history_texts(resolved).any? { |t| t.include?("look at this") },
+               "premise: the window did sweep it up, as text"
 
         DeliveryRecord.record!(turn, resolved)
 
@@ -286,6 +301,65 @@ module Collavre
                             "its image was never handed over, so it was not delivered"
         assert_nil DeliveryRecord.covering_task(@agent, illustrated.id, context_for(anchor), "comment_created"),
                    "and its own dispatch is the only thing that would carry the image"
+      end
+
+      # The same rule as the image, and the second thing it catches. A comment
+      # linking a creative brings that creative's rendered subtree with it —
+      # but only through append_referenced_creative_contexts, which scans the
+      # anchor and the merged blocks and never the history window. So the
+      # covering turn renders the link *text* and none of what it points at,
+      # and the dispatch that would have supplied it is the one being dropped.
+      test "a comment whose linked creative the history window left behind is not recorded" do
+        other = Creative.create!(description: "Spec the agent needs", user: @user)
+        anchor = comment("first")
+        turn = task_for(anchor)
+        linked = comment("answer using [Spec](/creatives/#{other.id})")
+
+        resolved = resolved_for(turn, @agent)
+        assert history_texts(resolved).any? { |t| t.include?("/creatives/#{other.id}") },
+               "premise: the window did sweep it up, as link text"
+        assert_not_includes kinds_in(resolved), "referenced_creative",
+                            "premise: and the turn injected no subtree for it"
+
+        DeliveryRecord.record!(turn, resolved)
+
+        assert_not_includes recorded(turn), linked.id,
+                            "the creative it points at was never handed over"
+        assert_nil DeliveryRecord.covering_task(@agent, linked.id, context_for(anchor), "comment_created"),
+                   "and its own dispatch is the only thing that would supply that subtree"
+      end
+
+      # ...and the filter is tied to what the turn was missing, not to links.
+      # A link to a creative already in context — the topic's own, most often —
+      # points at a subtree the agent was handed before the window ran, so the
+      # history entry does carry that comment whole.
+      test "a comment linking a creative already in context is recorded" do
+        anchor = comment("first")
+        turn = task_for(anchor)
+        linked = comment("as in [this one](/creatives/#{@creative.id})")
+
+        DeliveryRecord.record!(turn, resolved_for(turn, @agent))
+
+        assert_includes recorded(turn), linked.id,
+                        "nothing was withheld, so the turn delivered it"
+      end
+
+      # Same rule, the other way a link supplies nothing:
+      # append_referenced_creative_contexts skips an id with no creative behind
+      # it, so a turn anchored on this comment would render exactly what the
+      # window rendered and the entry does carry it whole.
+      test "a comment linking a creative that no longer exists is recorded" do
+        gone = Creative.create!(description: "deleted before the turn ran", user: @user)
+        gone_id = gone.id
+        anchor = comment("first")
+        turn = task_for(anchor)
+        linked = comment("see [that](/creatives/#{gone_id})")
+        gone.destroy!
+
+        DeliveryRecord.record!(turn, resolved_for(turn, @agent))
+
+        assert_includes recorded(turn), linked.id,
+                        "there was no subtree to withhold"
       end
 
       # The record is written by whichever pass assembles, and merged onto the

--- a/engines/collavre/test/services/collavre/orchestration/delivery_record_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/delivery_record_test.rb
@@ -491,6 +491,7 @@ module Collavre
             late
           )
         )
+        DeliveryRecord.fail_while_worker_settles!(turn.reload)
 
         written = turn.reload.trigger_event_payload.keys - dispatched
         assert_equal DeliveryRecord::TURN_SCOPED_KEYS.sort, written.sort

--- a/engines/collavre/test/services/collavre/orchestration/delivery_record_test.rb
+++ b/engines/collavre/test/services/collavre/orchestration/delivery_record_test.rb
@@ -440,6 +440,32 @@ module Collavre
         assert_equal (terminal - AgentOrchestrator::DELIVERED_STATUSES).sort,
                      DeliveryRecord::UNDELIVERED_TERMINAL_STATUSES.sort
       end
+
+      # The same drift, on the other list. TURN_SCOPED_KEYS is what a restored
+      # dispatch is stripped of, and it is right only while it names every key a
+      # turn writes onto its own payload. Driving all five writers over one
+      # payload is what makes a sixth added later show up here rather than as a
+      # restored dispatch quietly carrying it.
+      test "the stripped keys are exactly the ones a turn writes onto its own payload" do
+        anchor = comment("first")
+        late = comment("second")
+        folded = comment("third")
+        turn = task_for(anchor)
+        dispatched = turn.trigger_event_payload.keys
+
+        DeliveryRecord.record!(turn, resolved_for(turn, @agent))
+        DeliveryRecord.claim_drop!(turn.reload, late.id)
+        DeliveryRecord.mark_handoff_failed!(turn.reload)
+        turn.update!(
+          trigger_event_payload: TaskCoalescer.reanchor_payload(
+            TaskCoalescer.absorb_into_payload(turn.reload.trigger_event_payload, [ folded.id ]),
+            late
+          )
+        )
+
+        written = turn.reload.trigger_event_payload.keys - dispatched
+        assert_equal DeliveryRecord::TURN_SCOPED_KEYS.sort, written.sort
+      end
     end
   end
 end

--- a/engines/collavre_openclaw/app/services/collavre_openclaw/ai_client_extension.rb
+++ b/engines/collavre_openclaw/app/services/collavre_openclaw/ai_client_extension.rb
@@ -48,6 +48,14 @@ module CollavreOpenclaw
           error_message = e.message
           raise
         ensure
+          # The adapter can know that the gateway accepted the request before
+          # the caller's streaming block raises (notably CancelledError). Copy
+          # both answers while unwinding as well as on a normal return, so
+          # AiAgentService can persist the actual handoff rather than infer it
+          # from how #chat exited.
+          @last_handoff_failed = adapter.last_handoff_failed?
+          @handed_off = adapter.handed_off?
+
           # Honor no-log mode (e.g. inline typo correction on *unsubmitted* drafts).
           # Base Collavre::AiClient#chat gates logging behind @log_interactions; this
           # prepended adapter path bypasses super, so it must gate it too — otherwise
@@ -63,18 +71,6 @@ module CollavreOpenclaw
             )
           end
         end
-
-        # Whether the payload ever left the building. AiAgentService asks the
-        # *client*, not the adapter, and marks the turn's
-        # Orchestration::DeliveryRecord off the answer; the adapter converts
-        # missing credentials and transport failures into a streamed error plus
-        # nil, so without this an OpenClaw turn that reached nothing still ends
-        # `done` with the flag down and the dispatches dropped against it are
-        # never restored. See OpenclawAdapter#last_handoff_failed?.
-        @last_handoff_failed = adapter.last_handoff_failed?
-        # And the positive form beside it, for the reader the flag above cannot
-        # serve: a turn stopped after the gateway had the payload.
-        @handed_off = adapter.handed_off?
 
         return response_content
       end

--- a/engines/collavre_openclaw/app/services/collavre_openclaw/ai_client_extension.rb
+++ b/engines/collavre_openclaw/app/services/collavre_openclaw/ai_client_extension.rb
@@ -20,6 +20,7 @@ module CollavreOpenclaw
       # reused across a turn's calls, so a failure left standing would have
       # every later one claiming it delivered nothing.
       @last_handoff_failed = false
+      @handed_off = false
       normalized_vendor = vendor.to_s.downcase
       messages_data = normalize_messages_input(messages_input)
 
@@ -71,6 +72,9 @@ module CollavreOpenclaw
         # `done` with the flag down and the dispatches dropped against it are
         # never restored. See OpenclawAdapter#last_handoff_failed?.
         @last_handoff_failed = adapter.last_handoff_failed?
+        # And the positive form beside it, for the reader the flag above cannot
+        # serve: a turn stopped after the gateway had the payload.
+        @handed_off = adapter.handed_off?
 
         return response_content
       end

--- a/engines/collavre_openclaw/app/services/collavre_openclaw/ai_client_extension.rb
+++ b/engines/collavre_openclaw/app/services/collavre_openclaw/ai_client_extension.rb
@@ -15,6 +15,11 @@ module CollavreOpenclaw
     # @param messages_input [Hash, Array] Hash { messages:, first_message:, context_changed:, system_prompt: }
     #   from SessionContextResolver, or a plain Array from standalone callers (e.g., CompressJob).
     def chat(messages_input, tools: [], &block)
+      # Cleared on the way in, as the base #chat clears it — the flag describes
+      # the last request, and this branch never reaches `super`. A client is
+      # reused across a turn's calls, so a failure left standing would have
+      # every later one claiming it delivered nothing.
+      @last_handoff_failed = false
       normalized_vendor = vendor.to_s.downcase
       messages_data = normalize_messages_input(messages_input)
 
@@ -57,6 +62,15 @@ module CollavreOpenclaw
             )
           end
         end
+
+        # Whether the payload ever left the building. AiAgentService asks the
+        # *client*, not the adapter, and marks the turn's
+        # Orchestration::DeliveryRecord off the answer; the adapter converts
+        # missing credentials and transport failures into a streamed error plus
+        # nil, so without this an OpenClaw turn that reached nothing still ends
+        # `done` with the flag down and the dispatches dropped against it are
+        # never restored. See OpenclawAdapter#last_handoff_failed?.
+        @last_handoff_failed = adapter.last_handoff_failed?
 
         return response_content
       end

--- a/engines/collavre_openclaw/app/services/collavre_openclaw/openclaw_adapter.rb
+++ b/engines/collavre_openclaw/app/services/collavre_openclaw/openclaw_adapter.rb
@@ -137,7 +137,7 @@ module CollavreOpenclaw
           session_key: session_key,
           message: payload[:message],
           attachments: payload[:attachments],
-          on_run_id: method(:persist_run_id_on_comment)
+          on_run_id: method(:handle_run_id)
         ) do |event|
           case event[:state]
           when "delta"
@@ -166,6 +166,11 @@ module CollavreOpenclaw
         # #last_handoff_failed?. Decided after the stream rather than in the
         # branch above, so a delta that arrives either side of the error still
         # counts as the payload having got through.
+        #
+        # Inert behind a client that surfaces a run id, since #handle_run_id has
+        # already answered by the time any event arrives. Kept for one that does
+        # not: an error event is then the only evidence either way, and reading
+        # it as a delivery would be the losing mistake.
         @last_handoff_failed = true if errored && !@handed_off
         response_content.presence
       rescue CollavreOpenclaw::ConnectionError,
@@ -184,6 +189,21 @@ module CollavreOpenclaw
         Rails.logger.info("[CollavreOpenclaw::WS] FALLBACK gateway=#{@user.gateway_url} reason=#{e.class}:#{e.message}")
         chat_via_http(&block)
       end
+    end
+
+    # The gateway answered chat.send with a run id, which is the handoff: it has
+    # the whole payload and the run may already be calling tools. Everything
+    # after this — a run that goes quiet until the read timeout, an HTTP
+    # fallback that fails before yielding — costs an *answer*, not the delivery,
+    # and the comments this turn swallowed are with the agent either way.
+    #
+    # Reaching here at all is the acknowledgement: WebsocketClient#chat_send
+    # calls this straight after send_rpc returns, and send_rpc raises on a read
+    # timeout and on an RPC error. Set before persisting, because the handoff
+    # happened whether or not we can write the run id down.
+    def handle_run_id(run_id)
+      @handed_off = true
+      persist_run_id_on_comment(run_id)
     end
 
     # Claim the run for the solicited reply so the same run's final, re-delivered

--- a/engines/collavre_openclaw/app/services/collavre_openclaw/openclaw_adapter.rb
+++ b/engines/collavre_openclaw/app/services/collavre_openclaw/openclaw_adapter.rb
@@ -21,6 +21,7 @@ module CollavreOpenclaw
       @system_prompt = system_prompt
       @context = context
       @last_handoff_failed = false
+      @handed_off = false
     end
 
     # Did the last #chat end without the gateway ever receiving the payload?
@@ -37,6 +38,11 @@ module CollavreOpenclaw
     # nothing was handed over. An error *after* deltas is not one of these — the
     # gateway had the payload and answered part of it, so the comments that turn
     # swallowed did reach the agent.
+    #
+    # The question is asked of the whole #chat, not of a transport: one call can
+    # stream over the WebSocket and then fall back to HTTP, so each transport's
+    # own response buffer answers only for its own attempt. @handed_off spans
+    # both, and is reset once per #chat.
     def last_handoff_failed?
       @last_handoff_failed
     end
@@ -44,6 +50,7 @@ module CollavreOpenclaw
     # @param messages_data [Hash] { messages:, first_message:, context_changed: }
     def chat(messages_data, &block)
       @last_handoff_failed = false
+      @handed_off = false
       parse_messages_data!(messages_data)
 
       unless @user&.gateway_url.present?
@@ -136,12 +143,14 @@ module CollavreOpenclaw
           when "delta"
             if event[:text].present?
               response_content << event[:text]
+              @handed_off = true
               yield event[:text] if block_given?
             end
           when "final"
             # If no deltas were streamed, final contains the full text
             if response_content.blank? && event[:text].present?
               response_content << event[:text]
+              @handed_off = true
               yield event[:text] if block_given?
             end
           when "error"
@@ -157,7 +166,7 @@ module CollavreOpenclaw
         # #last_handoff_failed?. Decided after the stream rather than in the
         # branch above, so a delta that arrives either side of the error still
         # counts as the payload having got through.
-        @last_handoff_failed = true if errored && response_content.blank?
+        @last_handoff_failed = true if errored && !@handed_off
         response_content.presence
       rescue CollavreOpenclaw::ConnectionError,
              CollavreOpenclaw::TimeoutError => e
@@ -167,7 +176,7 @@ module CollavreOpenclaw
         Rails.logger.error("[CollavreOpenclaw] WebSocket chat error: #{e.message}")
         error_msg = "OpenClaw Error: #{e.message}"
         yield error_msg if block_given?
-        @last_handoff_failed = response_content.blank?
+        @last_handoff_failed = !@handed_off
         nil
       rescue StandardError => e
         Rails.logger.error("[CollavreOpenclaw] WebSocket unexpected error: #{e.message}\n" \
@@ -319,6 +328,7 @@ module CollavreOpenclaw
 
         stream_response(payload) do |chunk|
           response_content << chunk
+          @handed_off = true
           yield chunk if block_given?
         end
 
@@ -328,7 +338,10 @@ module CollavreOpenclaw
                            "#{e.backtrace.first(5).join("\n")}")
         error_msg = "OpenClaw Error: #{e.message}"
         yield error_msg if block_given?
-        @last_handoff_failed = response_content.blank?
+        # Not `response_content.blank?`: this may be the fallback behind a
+        # WebSocket that already streamed, and that content is in the caller's
+        # hands even though this method's buffer is empty.
+        @last_handoff_failed = !@handed_off
         nil
       end
     end

--- a/engines/collavre_openclaw/app/services/collavre_openclaw/openclaw_adapter.rb
+++ b/engines/collavre_openclaw/app/services/collavre_openclaw/openclaw_adapter.rb
@@ -47,6 +47,12 @@ module CollavreOpenclaw
       @last_handoff_failed
     end
 
+    # The same fact, asked positively — see AiClient#handed_off?. A turn the
+    # user stops mid-answer never reaches the line that sets the flag above.
+    def handed_off?
+      @handed_off
+    end
+
     # @param messages_data [Hash] { messages:, first_message:, context_changed: }
     def chat(messages_data, &block)
       @last_handoff_failed = false

--- a/engines/collavre_openclaw/app/services/collavre_openclaw/openclaw_adapter.rb
+++ b/engines/collavre_openclaw/app/services/collavre_openclaw/openclaw_adapter.rb
@@ -20,15 +20,36 @@ module CollavreOpenclaw
       @user = user
       @system_prompt = system_prompt
       @context = context
+      @last_handoff_failed = false
+    end
+
+    # Did the last #chat end without the gateway ever receiving the payload?
+    #
+    # The same question Collavre::AiClient#last_handoff_failed? answers for its
+    # own provider path, and it has to be answered here as well because
+    # AiClientExtension#chat routes past that method entirely: every failure
+    # below turns into a streamed error plus nil, and nil is also what an
+    # ordinary empty answer returns. Orchestration::DeliveryRecord needs the two
+    # apart, since a turn that handed the gateway nothing delivered nothing
+    # while AiAgentJob still marks it `done`.
+    #
+    # The proxy is the same one the base client uses: nothing streamed means
+    # nothing was handed over. An error *after* deltas is not one of these — the
+    # gateway had the payload and answered part of it, so the comments that turn
+    # swallowed did reach the agent.
+    def last_handoff_failed?
+      @last_handoff_failed
     end
 
     # @param messages_data [Hash] { messages:, first_message:, context_changed: }
     def chat(messages_data, &block)
+      @last_handoff_failed = false
       parse_messages_data!(messages_data)
 
       unless @user&.gateway_url.present?
         Rails.logger.error("[CollavreOpenclaw] No Gateway URL configured for user #{@user&.id}")
         yield "Error: OpenClaw Gateway URL not configured" if block_given?
+        @last_handoff_failed = true
         return nil
       end
 
@@ -36,6 +57,7 @@ module CollavreOpenclaw
         Rails.logger.error("[CollavreOpenclaw] No API key configured for user #{@user&.id}")
         yield "Error: OpenClaw API key not configured or decryption failed. " \
               "Please re-enter the API key in AI agent settings." if block_given?
+        @last_handoff_failed = true
         return nil
       end
 
@@ -96,6 +118,7 @@ module CollavreOpenclaw
 
     def chat_via_websocket(&block)
       response_content = +""
+      errored = false
 
       begin
         client = ConnectionManager.instance.connection_for(@user)
@@ -123,12 +146,18 @@ module CollavreOpenclaw
             end
           when "error"
             error_msg = event[:text] || "Unknown error"
+            errored = true
             yield "OpenClaw Error: #{error_msg}" if block_given?
           when "aborted"
             # User or system aborted
           end
         end
 
+        # The gateway answered with an error and nothing else: see
+        # #last_handoff_failed?. Decided after the stream rather than in the
+        # branch above, so a delta that arrives either side of the error still
+        # counts as the payload having got through.
+        @last_handoff_failed = true if errored && response_content.blank?
         response_content.presence
       rescue CollavreOpenclaw::ConnectionError,
              CollavreOpenclaw::TimeoutError => e
@@ -138,6 +167,7 @@ module CollavreOpenclaw
         Rails.logger.error("[CollavreOpenclaw] WebSocket chat error: #{e.message}")
         error_msg = "OpenClaw Error: #{e.message}"
         yield error_msg if block_given?
+        @last_handoff_failed = response_content.blank?
         nil
       rescue StandardError => e
         Rails.logger.error("[CollavreOpenclaw] WebSocket unexpected error: #{e.message}\n" \
@@ -298,6 +328,7 @@ module CollavreOpenclaw
                            "#{e.backtrace.first(5).join("\n")}")
         error_msg = "OpenClaw Error: #{e.message}"
         yield error_msg if block_given?
+        @last_handoff_failed = response_content.blank?
         nil
       end
     end

--- a/engines/collavre_openclaw/test/services/ai_client_extension_test.rb
+++ b/engines/collavre_openclaw/test/services/ai_client_extension_test.rb
@@ -6,13 +6,41 @@ module CollavreOpenclaw
   # @log_interactions — otherwise unsubmitted typo-correction drafts leak to
   # ActivityLog for OpenClaw-backed agents.
   class AiClientExtensionTest < ActiveSupport::TestCase
-    # Minimal adapter so chat() doesn't touch the network.
+    # Minimal adapter so chat() doesn't touch the network. It tracks
+    # last_handoff_failed? because the real one does: a double that does not
+    # follow its collaborator is how a seam stops being tested.
     class FakeAdapter
       def initialize(**) ; end
 
       def chat(_messages_data, &_block)
         "ok"
       end
+
+      def last_handoff_failed? = false
+    end
+
+    # The failures the adapter converts into a streamed error plus nil:
+    # missing credentials, a gateway that cannot be reached.
+    class FailingAdapter
+      def initialize(**) ; end
+
+      def chat(_messages_data, &block)
+        block&.call("Error: OpenClaw Gateway URL not configured")
+        nil
+      end
+
+      def last_handoff_failed? = true
+    end
+
+    # The one path that skips the propagation: the extension re-raises.
+    class RaisingAdapter
+      def initialize(**) ; end
+
+      def chat(_messages_data, &_block)
+        raise "gateway blew up"
+      end
+
+      def last_handoff_failed? = true
     end
 
     setup do
@@ -54,6 +82,52 @@ module CollavreOpenclaw
       client.chat(messages)
 
       assert logged, "normal adapter calls must still be logged"
+    end
+
+    # AiAgentService asks the client, not the adapter, and marks the turn's
+    # DeliveryRecord off the answer. This path never calls super, so the base
+    # #chat that sets the flag never runs — without propagating it here, an
+    # OpenClaw turn whose request never left the building still ends `done`
+    # with the flag down, and the dispatches dropped against it stay dropped.
+    test "a failed handoff on the adapter path reaches the client" do
+      Collavre::AiClient.register_adapter("failingtest", FailingAdapter)
+      client = Collavre::AiClient.new(
+        vendor: "failingtest", model: "m", system_prompt: "s", log_interactions: false
+      )
+
+      assert_nil client.chat(messages)
+      assert_predicate client, :last_handoff_failed?
+    ensure
+      Collavre::AiClient.adapter_registry.delete("failingtest")
+    end
+
+    test "an adapter that answered leaves the flag down" do
+      client = build_client(log_interactions: false)
+
+      assert_equal "ok", client.chat(messages)
+      assert_not client.last_handoff_failed?
+    end
+
+    # Control: the flag describes the *last* chat, and a chat that raised did
+    # not answer the question — the exception is what ends the turn, and
+    # AiAgentJob marks it `failed`, an ending the restore already reads. What
+    # must not happen is the previous chat's failure standing in for this one,
+    # which is the one path that skips the propagation above. Base #chat clears
+    # it on the way in for the same reason; this branch never reaches `super`.
+    test "a chat that raised does not leave the flag standing from the one before" do
+      Collavre::AiClient.register_adapter("failingtest", FailingAdapter)
+      client = Collavre::AiClient.new(
+        vendor: "failingtest", model: "m", system_prompt: "s", log_interactions: false
+      )
+      client.chat(messages)
+      assert_predicate client, :last_handoff_failed?, "premise: the chat before it failed to hand over"
+      Collavre::AiClient.register_adapter("failingtest", RaisingAdapter)
+
+      assert_raises(RuntimeError) { client.chat(messages) }
+
+      assert_not client.last_handoff_failed?
+    ensure
+      Collavre::AiClient.adapter_registry.delete("failingtest")
     end
   end
 end

--- a/engines/collavre_openclaw/test/services/ai_client_extension_test.rb
+++ b/engines/collavre_openclaw/test/services/ai_client_extension_test.rb
@@ -17,6 +17,7 @@ module CollavreOpenclaw
       end
 
       def last_handoff_failed? = false
+      def handed_off? = true
     end
 
     # The failures the adapter converts into a streamed error plus nil:
@@ -30,6 +31,7 @@ module CollavreOpenclaw
       end
 
       def last_handoff_failed? = true
+      def handed_off? = false
     end
 
     # The one path that skips the propagation: the extension re-raises.
@@ -41,6 +43,7 @@ module CollavreOpenclaw
       end
 
       def last_handoff_failed? = true
+      def handed_off? = false
     end
 
     setup do
@@ -106,6 +109,23 @@ module CollavreOpenclaw
 
       assert_equal "ok", client.chat(messages)
       assert_not client.last_handoff_failed?
+    end
+
+    # The same seam, positively: a turn the user stops mid-answer never reaches
+    # the line that sets the flag above, so the cancelled ending is read off
+    # this instead. It has to travel the same way, and be this chat's answer
+    # rather than the previous one's.
+    test "a handoff on the adapter path reaches the client" do
+      client = build_client(log_interactions: false)
+
+      assert_equal "ok", client.chat(messages)
+      assert_predicate client, :handed_off?, "premise: the chat before it did hand over"
+
+      # Same client, next chat: a client is reused across a turn's calls, so an
+      # answer left standing would exempt every later one.
+      Collavre::AiClient.register_adapter("faketest", FailingAdapter)
+      assert_nil client.chat(messages)
+      assert_not client.handed_off?
     end
 
     # Control: the flag describes the *last* chat, and a chat that raised did

--- a/engines/collavre_openclaw/test/services/ai_client_extension_test.rb
+++ b/engines/collavre_openclaw/test/services/ai_client_extension_test.rb
@@ -46,6 +46,17 @@ module CollavreOpenclaw
       def handed_off? = false
     end
 
+    class HandedOffRaisingAdapter
+      def initialize(**) ; end
+
+      def chat(_messages_data, &_block)
+        raise Collavre::CancelledError
+      end
+
+      def last_handoff_failed? = false
+      def handed_off? = true
+    end
+
     setup do
       Collavre::AiClient.register_adapter("faketest", FakeAdapter)
     end
@@ -128,26 +139,32 @@ module CollavreOpenclaw
       assert_not client.handed_off?
     end
 
-    # Control: the flag describes the *last* chat, and a chat that raised did
-    # not answer the question — the exception is what ends the turn, and
-    # AiAgentJob marks it `failed`, an ending the restore already reads. What
-    # must not happen is the previous chat's failure standing in for this one,
-    # which is the one path that skips the propagation above. Base #chat clears
-    # it on the way in for the same reason; this branch never reaches `super`.
-    test "a chat that raised does not leave the flag standing from the one before" do
-      Collavre::AiClient.register_adapter("failingtest", FailingAdapter)
-      client = Collavre::AiClient.new(
-        vendor: "failingtest", model: "m", system_prompt: "s", log_interactions: false
-      )
+    # The exception is not the handoff answer. The adapter can know that the
+    # gateway accepted the request before a callback raised, so both answers
+    # must cross the extension boundary even when #chat does not return.
+    test "a chat that raised before handoff copies the adapter failure state" do
+      client = build_client(log_interactions: false)
       client.chat(messages)
-      assert_predicate client, :last_handoff_failed?, "premise: the chat before it failed to hand over"
-      Collavre::AiClient.register_adapter("failingtest", RaisingAdapter)
+      assert_predicate client, :handed_off?, "premise: the chat before it did hand over"
+      Collavre::AiClient.register_adapter("faketest", RaisingAdapter)
 
       assert_raises(RuntimeError) { client.chat(messages) }
 
+      assert_predicate client, :last_handoff_failed?
+      assert_not client.handed_off?
+    end
+
+    test "a chat cancelled after handoff copies the adapter success state" do
+      Collavre::AiClient.register_adapter("faketest", FailingAdapter)
+      client = build_client(log_interactions: false)
+      client.chat(messages)
+      assert_predicate client, :last_handoff_failed?, "premise: the chat before it failed to hand over"
+      Collavre::AiClient.register_adapter("faketest", HandedOffRaisingAdapter)
+
+      assert_raises(Collavre::CancelledError) { client.chat(messages) }
+
       assert_not client.last_handoff_failed?
-    ensure
-      Collavre::AiClient.adapter_registry.delete("failingtest")
+      assert_predicate client, :handed_off?
     end
   end
 end

--- a/engines/collavre_openclaw/test/services/openclaw_adapter_test.rb
+++ b/engines/collavre_openclaw/test/services/openclaw_adapter_test.rb
@@ -795,10 +795,13 @@ module CollavreOpenclaw
       assert_not adapter.last_handoff_failed?
     end
 
-    # Control: the same fallback with nothing streamed first really is a failed
-    # handoff, which is what holds the fix to what got through rather than to
-    # the fallback having happened.
-    test "a websocket that streamed nothing before a failing http fallback is a failed handoff" do
+    # The gateway answers chat.send with a run id before a single event is
+    # waited for, and that answer is the handoff: it has the whole payload and
+    # the run may already be calling tools. A run that is then quiet until the
+    # read timeout, behind an HTTP attempt that fails before yielding, has cost
+    # an answer — restoring the comments this turn swallowed would put them to
+    # an agent that already has them.
+    test "a websocket run the gateway accepted before a failing http fallback is not a failed handoff" do
       adapter = http_adapter
       adapter.define_singleton_method(:stream_response) do |_payload, &_blk|
         raise CollavreOpenclaw::ConnectionError, "gateway unreachable"
@@ -808,19 +811,42 @@ module CollavreOpenclaw
         assert_nil adapter.chat(messages_data)
       end
 
+      assert_not adapter.last_handoff_failed?
+    end
+
+    # Control: a gateway that never answered chat.send at all really is a failed
+    # handoff, which is what holds the fix to the acknowledgement rather than to
+    # the fallback having happened. send_rpc raises on a read timeout and on an
+    # RPC error, so this is the only shape in which the run id never arrives.
+    test "a websocket the gateway never acknowledged before a failing http fallback is a failed handoff" do
+      adapter = http_adapter
+      adapter.define_singleton_method(:stream_response) do |_payload, &_blk|
+        raise CollavreOpenclaw::ConnectionError, "gateway unreachable"
+      end
+
+      with_websocket_dropping_after(delta: nil, acknowledged: false) do
+        assert_nil adapter.chat(messages_data)
+      end
+
       assert_predicate adapter, :last_handoff_failed?
     end
 
     private
 
-    # Drive the real #chat_via_websocket: yield `delta` if given, then drop the
-    # connection so the adapter falls through to #chat_via_http.
-    def with_websocket_dropping_after(delta:)
+    # Drive the real #chat_via_websocket: surface a run id the way the real
+    # client does — WebsocketClient#chat_send calls on_run_id as soon as
+    # chat.send comes back, before it waits for any event — then yield `delta`
+    # if given, then drop the connection so the adapter falls through to
+    # #chat_via_http. `acknowledged: false` is the gateway never answering
+    # chat.send, which is where the real client raises before that callback.
+    def with_websocket_dropping_after(delta:, acknowledged: true)
       original = CollavreOpenclaw.config.transport
       CollavreOpenclaw.config.transport = "auto"
 
+      acked = acknowledged
       client = Object.new
       client.define_singleton_method(:chat_send) do |session_key:, message:, attachments:, on_run_id:, &blk|
+        on_run_id&.call("run-#{SecureRandom.hex(4)}") if acked
         blk.call({ state: "delta", text: delta }) if delta
         raise CollavreOpenclaw::TimeoutError, "gateway went quiet"
       end

--- a/engines/collavre_openclaw/test/services/openclaw_adapter_test.rb
+++ b/engines/collavre_openclaw/test/services/openclaw_adapter_test.rb
@@ -691,6 +691,89 @@ module CollavreOpenclaw
       CollavreOpenclaw.config.transport = original_transport
     end
 
+    # Did the request ever reach the gateway? Collavre::AiClient answers this
+    # for its own provider path (#last_handoff_failed?) so DeliveryRecord can
+    # tell a turn that delivered nothing from one that answered; this adapter
+    # path bypasses that method entirely — it streams an error and returns nil
+    # just the same — so it has to answer for itself. The proxy is the same
+    # one: nothing streamed means nothing was handed over.
+    def http_adapter(user: nil)
+      user ||= build_test_user(gateway_url: "https://test-gateway.com", email: "test@example.com",
+                               llm_api_key: "test-key")
+      OpenclawAdapter.new(user: user, system_prompt: "Test", context: {})
+    end
+
+    def messages_data
+      { messages: [ { role: "user", kind: :trigger, parts: [ { text: "Hello" } ] } ],
+        first_message: true, context_changed: false }
+    end
+
+    def with_http_transport
+      original = CollavreOpenclaw.config.transport
+      CollavreOpenclaw.config.transport = "http"
+      yield
+    ensure
+      CollavreOpenclaw.config.transport = original
+    end
+
+    test "a chat with no gateway configured never reached the provider" do
+      adapter = http_adapter(user: build_test_user(gateway_url: nil, llm_api_key: "test-key"))
+
+      assert_nil adapter.chat(messages_data)
+      assert_predicate adapter, :last_handoff_failed?
+    end
+
+    test "a chat with no API key never reached the provider" do
+      adapter = http_adapter(user: build_test_user(gateway_url: "https://test-gateway.com"))
+
+      assert_nil adapter.chat(messages_data)
+      assert_predicate adapter, :last_handoff_failed?
+    end
+
+    test "an error before anything streamed is a failed handoff" do
+      with_http_transport do
+        adapter = http_adapter
+        adapter.define_singleton_method(:stream_response) do |_payload, &_blk|
+          raise CollavreOpenclaw::ConnectionError, "gateway unreachable"
+        end
+
+        assert_nil adapter.chat(messages_data)
+        assert_predicate adapter, :last_handoff_failed?
+      end
+    end
+
+    # Control, and the boundary: the gateway had the payload and answered part
+    # of it. That is a truncated reply with the ordinary retry beside it, and
+    # the comments the turn swallowed did reach the agent.
+    test "an error after content streamed is not a failed handoff" do
+      with_http_transport do
+        adapter = http_adapter
+        adapter.define_singleton_method(:stream_response) do |_payload, &blk|
+          blk.call("half an ans")
+          raise CollavreOpenclaw::ConnectionError, "gateway went away"
+        end
+
+        streamed = +""
+        adapter.chat(messages_data) { |chunk| streamed << chunk }
+
+        assert_includes streamed, "half an ans", "premise: the gateway answered part of it"
+        assert_not adapter.last_handoff_failed?
+      end
+    end
+
+    # Control: an empty answer returns nil too, and nil is what the failure
+    # returns — which is why the return value cannot carry this and a flag has
+    # to. A gateway that took the payload and said nothing delivered it.
+    test "a chat that reached the gateway and answered nothing is not a failed handoff" do
+      with_http_transport do
+        adapter = http_adapter
+        adapter.define_singleton_method(:stream_response) { |_payload, &_blk| nil }
+
+        assert_nil adapter.chat(messages_data)
+        assert_not adapter.last_handoff_failed?
+      end
+    end
+
     private
 
     def build_test_user(gateway_url: nil, email: "test@example.com", llm_api_key: nil)

--- a/engines/collavre_openclaw/test/services/openclaw_adapter_test.rb
+++ b/engines/collavre_openclaw/test/services/openclaw_adapter_test.rb
@@ -774,7 +774,63 @@ module CollavreOpenclaw
       end
     end
 
+    # One #chat, two transports. The WebSocket answered part of the payload and
+    # then dropped, and the HTTP attempt behind it failed before yielding
+    # anything of its own. Each transport keeps its own buffer, so neither one
+    # can answer "did anything get through this chat" — and the gateway did
+    # have the payload, so restoring the comments this turn swallowed would
+    # answer them a second time.
+    test "a websocket that streamed before a failing http fallback is not a failed handoff" do
+      adapter = http_adapter
+      adapter.define_singleton_method(:stream_response) do |_payload, &_blk|
+        raise CollavreOpenclaw::ConnectionError, "gateway unreachable"
+      end
+
+      streamed = +""
+      with_websocket_dropping_after(delta: "half an ans") do
+        adapter.chat(messages_data) { |chunk| streamed << chunk }
+      end
+
+      assert_includes streamed, "half an ans", "premise: the gateway answered part of it over the websocket"
+      assert_not adapter.last_handoff_failed?
+    end
+
+    # Control: the same fallback with nothing streamed first really is a failed
+    # handoff, which is what holds the fix to what got through rather than to
+    # the fallback having happened.
+    test "a websocket that streamed nothing before a failing http fallback is a failed handoff" do
+      adapter = http_adapter
+      adapter.define_singleton_method(:stream_response) do |_payload, &_blk|
+        raise CollavreOpenclaw::ConnectionError, "gateway unreachable"
+      end
+
+      with_websocket_dropping_after(delta: nil) do
+        assert_nil adapter.chat(messages_data)
+      end
+
+      assert_predicate adapter, :last_handoff_failed?
+    end
+
     private
+
+    # Drive the real #chat_via_websocket: yield `delta` if given, then drop the
+    # connection so the adapter falls through to #chat_via_http.
+    def with_websocket_dropping_after(delta:)
+      original = CollavreOpenclaw.config.transport
+      CollavreOpenclaw.config.transport = "auto"
+
+      client = Object.new
+      client.define_singleton_method(:chat_send) do |session_key:, message:, attachments:, on_run_id:, &blk|
+        blk.call({ state: "delta", text: delta }) if delta
+        raise CollavreOpenclaw::TimeoutError, "gateway went quiet"
+      end
+      manager = Object.new
+      manager.define_singleton_method(:connection_for) { |_user| client }
+
+      CollavreOpenclaw::ConnectionManager.stub(:instance, manager) { yield }
+    ensure
+      CollavreOpenclaw.config.transport = original
+    end
 
     def build_test_user(gateway_url: nil, email: "test@example.com", llm_api_key: nil)
       user = Object.new


### PR DESCRIPTION
## Problem

Event A and event B arrive as a burst. The agent starts a turn for A; B's dispatch finds the topic slot taken, parks a waiter, posts a "⏳" notice, and the agent speaks a second time when the waiter is promoted.

For a **non-session** agent that second turn is usually redundant. `MessageBuilder#append_chat_history` reads the topic's comments **at job execution time**, so a comment committed before the payload was assembled is already inside the running turn's context — the agent has read it.

For a **session-backed** agent it is not redundant at all: `SessionContextResolver#incremental_payload` keeps only the `:trigger` message, so the running turn never carried B's text. Dropping there would be message loss rather than de-duplication, and #1456's coalescing (merge into `merged_comment_ids`) stays the correct answer.

So "the agent is busy" is the wrong predicate. The right one is **"this turn already delivered that comment"** — a property of the resolved payload, not of the agent's status.

## Approach

Record what was delivered; read the record at every door.

**1. Measure delivery from the payload that is actually sent.** `MessageBuilder` tags each `:chat_history` message with its comment id. `AiAgentService` reads the ids off the **resolved** payload — after the session filter — immediately before streaming. Session-awareness falls out of this rather than being a second switch: a session agent's resolved payload has no chat history, so nothing is recorded and nothing is ever dropped for it.

**2. Record only what the turn was not created for.** Restricted to ids **above the turn's anchor**. Chat history normally holds the topic's backlog, which this turn did not swallow and must not silence; a history comment *newer* than the anchor can only have landed after the turn was dispatched. Ids rather than `created_at` — a burst is written by several processes and the clock is whichever one wrote the row.

Nothing is written until the payload resolves, so a turn that is running but has not assembled yet drops nothing. Fail open.

**3. Read it at every door.**

| Door | Change |
|---|---|
| `AgentOrchestrator#enqueue_jobs` | drop gate before `perform_later` / `park_waiter` |
| `AiAgentJob` late admission | same gate — the job can sit in the queue while the covering turn assembles |
| `AgentOrchestrator.delivered_comment_ids` (promotion) | reads the same record, so a waiter parked *before* the covering turn assembled is cancelled and its notice removed |

All three go through one method, `Orchestration::DeliveryRecord.covering_task`.

**3a. The promotion floor this opens up.** Filtering a waiter's own anchor out of the refresh's candidates has a consequence the existing code never had to handle: the refresh then picks the newest *remaining* comment, which is **older** — a comment the waiter was not dispatched for, that predates the one it was, and that the covering turn already had in view. So when (and only when) `delivered_ids` contains the waiter's own anchor, the candidate scope gets a floor at that anchor id; nothing left at or above it means the waiter has nothing to say and the existing branch cancels it.

Deliberately *not* a blanket "the refresh never moves backwards" — an anchor that left the turn for another reason (moved creative, made private) is a different question, and `StuckDetector`'s self-heal tests are the live proof that a wider floor would change promotion for waiters this feature never touches.

**4. Exclusions.** A review request is never dropped: it is bound to the comment it quotes and can only run as its own turn. Private and approval-action comments never enter history, so they are never recorded.

**5. Policy switch.** `scheduling.drop_delivered_dispatches` (default `true`), resolved per agent. Only the *drop* is switched — the record keeps being written, because the promotion door reads it and gating the write would leave that door reading a record with a hole in it.

## Evidence trail

No ghost `cancelled` row is created for a dropped dispatch. "Which turn ate comment N" is a query over `history_delivered_comment_ids` on the covering task, the same shape as `merged_comment_ids`, and the drop is logged with the covering task id.

## Tests

20 new tests across `delivery_record_test.rb` and `delivered_history_dispatch_test.rb`, every one verified red before its fix (the `comment_id` tag, the drop gate, and the promotion union were each reverted in turn to confirm the assertions bite). Negative controls included for: session agents, history older than the anchor, an unrecorded turn, review requests, the policy switch, and per-agent / per-topic / per-event scoping.

Full run of `engines/collavre/test/{services,models,jobs}` matches an `origin/main` baseline exactly (0 failures; the 90 errors are pre-existing `Current.user` ordering artifacts in `Tools::*`, identical on both). `collavre_openclaw` + `collavre_completion_api` green. Rubocop clean.