### PR TITLE
fix: scope typing indicators to topics

### DIFF
--- a/engines/collavre/app/channels/collavre/comments_presence_channel.rb
+++ b/engines/collavre/app/channels/collavre/comments_presence_channel.rb
@@ -37,6 +37,7 @@ class CommentsPresenceChannel < ApplicationCable::Channel
         agent_id: task.agent_id,
         agent_name: task.agent.display_name,
         task_id: task.id,
+        topic_id: task.topic_id || task.trigger_event_payload&.dig("topic", "id"),
         source_creative_id: task_creative_id
       )
     end
@@ -45,13 +46,14 @@ class CommentsPresenceChannel < ApplicationCable::Channel
   # Broadcast agent status (thinking/streaming/idle) to presence channel.
   # This allows the frontend typing indicator to show AI agent activity.
   # source_creative_id: the actual creative where agent is working (for filtering on frontend)
-  def self.broadcast_agent_status(creative_id, status:, agent_id:, agent_name:, task_id: nil, content: nil, source_creative_id: nil)
+  def self.broadcast_agent_status(creative_id, status:, agent_id:, agent_name:, topic_id:, task_id: nil, content: nil, source_creative_id: nil)
     payload = {
       agent_status: {
         id: agent_id,
         name: agent_name,
         status: status,
         task_id: task_id,
+        topic_id: topic_id,
         creative_id: source_creative_id || creative_id
       }
     }
@@ -84,22 +86,33 @@ class CommentsPresenceChannel < ApplicationCable::Channel
     end
   end
 
-  def typing
+  def typing(data)
     return unless @creative_id && current_user
+
+    topic_id = topic_id_for(data)
+    return unless topic_id
 
     ActionCable.server.broadcast(
       stream_name,
-      { typing: { id: current_user.id, name: current_user.display_name } }
+      { typing: { id: current_user.id, name: current_user.display_name, topic_id: topic_id } }
     )
   end
 
-  def stopped_typing
+  def stopped_typing(data)
     return unless @creative_id && current_user
 
-    ActionCable.server.broadcast(stream_name, { stop_typing: { id: current_user.id } })
+    topic_id = topic_id_for(data)
+    return unless topic_id
+
+    ActionCable.server.broadcast(stream_name, { stop_typing: { id: current_user.id, topic_id: topic_id } })
   end
 
   private
+
+  def topic_id_for(data)
+    topic_id = data["topic_id"] || data[:topic_id]
+    Topic.find_by(id: topic_id, creative_id: @creative_id)&.id
+  end
 
   def stream_name
     "comments_presence:#{@creative_id}"

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/presence_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/presence_controller.test.js
@@ -122,6 +122,28 @@ describe('CommentsPresenceController', () => {
     expect(close).not.toHaveBeenCalled()
   })
 
+  test('bootstraps the selected and main topics when the popup opens', () => {
+    const refreshChannelChips = jest.spyOn(controller, 'refreshChannelChips').mockImplementation(() => {})
+    jest.spyOn(application, 'getControllerForElementAndIdentifier').mockReturnValue({
+      currentTopicId: '45',
+      mainTopicId: '10',
+    })
+
+    controller.bootstrapChannelChips()
+
+    expect(controller.selectedTopicId).toBe('45')
+    expect(controller.mainTopicId).toBe('10')
+    expect(refreshChannelChips).toHaveBeenCalledWith('45')
+  })
+
+  test('clears topic timers when the popup closes', () => {
+    const clearTopicTimers = jest.spyOn(controller, 'clearTopicTimers').mockImplementation(() => {})
+
+    controller.onPopupClosed()
+
+    expect(clearTopicTimers).toHaveBeenCalled()
+  })
+
   test('sends typing lifecycle with the selected topic', () => {
     const perform = jest.fn()
     controller.presenceSubscription = { perform }

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/presence_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/presence_controller.test.js
@@ -121,6 +121,97 @@ describe('CommentsPresenceController', () => {
     expect(loadInitialComments).not.toHaveBeenCalled()
     expect(close).not.toHaveBeenCalled()
   })
+
+  test('sends typing lifecycle with the selected topic', () => {
+    const perform = jest.fn()
+    controller.presenceSubscription = { perform }
+    controller.selectedTopicId = '45'
+
+    controller.typing()
+    controller.stoppedTyping()
+
+    expect(perform).toHaveBeenNthCalledWith(1, 'typing', { topic_id: '45' })
+    expect(perform).toHaveBeenNthCalledWith(2, 'stopped_typing', { topic_id: '45' })
+  })
+
+  test('sends All Messages input to Main but does not render topic indicators there', () => {
+    const perform = jest.fn()
+    controller.presenceSubscription = { perform }
+    controller.selectedTopicId = null
+    controller.mainTopicId = '10'
+
+    controller.typing()
+    controller.handlePresenceMessage({ typing: { id: 5, name: 'Alice', topic_id: '10' } })
+
+    expect(perform).toHaveBeenCalledWith('typing', { topic_id: '10' })
+    expect(controller.typingUsers).toEqual({})
+    controller.stoppedTyping()
+  })
+
+  test('shows typing only for the selected topic', () => {
+    controller.selectedTopicId = '10'
+
+    controller.handlePresenceMessage({ typing: { id: 5, name: 'Alice', topic_id: '11' } })
+    expect(controller.typingUsers).toEqual({})
+
+    controller.handlePresenceMessage({ typing: { id: 5, name: 'Alice', topic_id: '10' } })
+    expect(controller.typingUsers).toEqual({ 5: 'Alice' })
+  })
+
+  test('ignores stop events from another topic', () => {
+    controller.selectedTopicId = '10'
+    controller.handlePresenceMessage({ typing: { id: 5, name: 'Alice', topic_id: '10' } })
+
+    controller.handlePresenceMessage({ stop_typing: { id: 5, topic_id: '11' } })
+    expect(controller.typingUsers).toEqual({ 5: 'Alice' })
+
+    controller.handlePresenceMessage({ stop_typing: { id: 5, topic_id: '10' } })
+    expect(controller.typingUsers).toEqual({})
+  })
+
+  test('ignores agent idle events from another topic', () => {
+    controller.selectedTopicId = '10'
+    const status = {
+      id: 9,
+      name: 'Agent',
+      status: 'thinking',
+      task_id: 99,
+      creative_id: '123',
+      topic_id: '10',
+    }
+    controller.handlePresenceMessage({ agent_status: status })
+
+    controller.handlePresenceMessage({
+      agent_status: { ...status, status: 'idle', topic_id: '11' },
+    })
+    expect(controller.typingUsers).toEqual({ 9: 'Agent' })
+
+    controller.handlePresenceMessage({
+      agent_status: { ...status, status: 'idle' },
+    })
+    expect(controller.typingUsers).toEqual({})
+  })
+
+  test('clears typing and agent state immediately when switching topics', () => {
+    const perform = jest.fn()
+    controller.presenceSubscription = { perform }
+    controller.selectedTopicId = '10'
+    controller.mainTopicId = '1'
+    controller.typingUsers = { 5: 'Alice', 9: 'Agent' }
+    controller.activeAgentTasks = { 9: 99 }
+    controller.typingTimers = { 5: setTimeout(() => {}, 1000) }
+    controller.agentStatusTimers = { 9: setTimeout(() => {}, 1000) }
+    jest.spyOn(controller, 'refreshChannelChips').mockImplementation(() => {})
+
+    controller.handleTopicChange({ detail: { topicId: '11', mainTopicId: '1' } })
+
+    expect(perform).toHaveBeenCalledWith('stopped_typing', { topic_id: '10' })
+    expect(controller.selectedTopicId).toBe('11')
+    expect(controller.typingUsers).toEqual({})
+    expect(controller.activeAgentTasks).toEqual({})
+    expect(controller.typingTimers).toEqual({})
+    expect(controller.agentStatusTimers).toEqual({})
+  })
 })
 
 describe('CommentsPresenceController typing-row horizontal scroll', () => {
@@ -169,6 +260,7 @@ describe('CommentsPresenceController typing-row horizontal scroll', () => {
     const el = document.getElementById('comments-popup')
     controller = application.getControllerForElementAndIdentifier(el, 'comments--presence')
     controller.creativeId = '123'
+    controller.selectedTopicId = '11'
     row = el.querySelector('#typing-scroll-viewport')
   })
 
@@ -182,7 +274,7 @@ describe('CommentsPresenceController typing-row horizontal scroll', () => {
   test('auto-scrolls a new typer into view when parked at the right edge', () => {
     setGeometry({ clientWidth: 100, scrollWidth: 300, scrollLeft: 200 }) // at end
 
-    controller.handlePresenceMessage({ typing: { id: 5, name: 'Alice' } })
+    controller.handlePresenceMessage({ typing: { id: 5, name: 'Alice', topic_id: '11' } })
 
     expect(scrollLeftValue).toBe(300)
   })
@@ -190,20 +282,20 @@ describe('CommentsPresenceController typing-row horizontal scroll', () => {
   test('does NOT scroll when the user has scrolled back to look at earlier items', () => {
     setGeometry({ clientWidth: 100, scrollWidth: 300, scrollLeft: 0 }) // scrolled back
 
-    controller.handlePresenceMessage({ typing: { id: 5, name: 'Alice' } })
+    controller.handlePresenceMessage({ typing: { id: 5, name: 'Alice', topic_id: '11' } })
 
     expect(scrollLeftValue).toBe(0)
   })
 
   test('does not re-scroll on repeat typing pings from the same user (not a new item)', () => {
     setGeometry({ clientWidth: 100, scrollWidth: 300, scrollLeft: 200 })
-    controller.handlePresenceMessage({ typing: { id: 5, name: 'Alice' } })
+    controller.handlePresenceMessage({ typing: { id: 5, name: 'Alice', topic_id: '11' } })
     expect(scrollLeftValue).toBe(300)
 
     // User scrolls back; a heartbeat ping for the same (already-shown) typer
     // must not yank them to the end again.
     scrollLeftValue = 0
-    controller.handlePresenceMessage({ typing: { id: 5, name: 'Alice' } })
+    controller.handlePresenceMessage({ typing: { id: 5, name: 'Alice', topic_id: '11' } })
     expect(scrollLeftValue).toBe(0)
   })
 
@@ -213,20 +305,20 @@ describe('CommentsPresenceController typing-row horizontal scroll', () => {
     // always want to see their own indicator, so stick-to-end must not suppress it.
     setGeometry({ clientWidth: 100, scrollWidth: 300, scrollLeft: 0 })
 
-    controller.handlePresenceMessage({ typing: { id: 7, name: 'Me' } })
+    controller.handlePresenceMessage({ typing: { id: 7, name: 'Me', topic_id: '11' } })
 
     expect(scrollLeftValue).toBe(300)
   })
 
   test('does not re-scroll on repeat self typing pings (only the first appearance forces scroll)', () => {
     setGeometry({ clientWidth: 100, scrollWidth: 300, scrollLeft: 0 })
-    controller.handlePresenceMessage({ typing: { id: 7, name: 'Me' } })
+    controller.handlePresenceMessage({ typing: { id: 7, name: 'Me', topic_id: '11' } })
     expect(scrollLeftValue).toBe(300)
 
     // A heartbeat ping for the same (already-shown) self typer while scrolled
     // back must not yank to the end again — only the first appearance forces it.
     scrollLeftValue = 0
-    controller.handlePresenceMessage({ typing: { id: 7, name: 'Me' } })
+    controller.handlePresenceMessage({ typing: { id: 7, name: 'Me', topic_id: '11' } })
     expect(scrollLeftValue).toBe(0)
   })
 })

--- a/engines/collavre/app/javascript/controllers/comments/presence_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/presence_controller.js
@@ -21,6 +21,8 @@ export default class extends Controller {
     this.typingTimeoutHandle = null
     this.hasPresenceConnected = false
     this.currentUserId = document.body.dataset.currentUserId
+    this.selectedTopicId = null
+    this.mainTopicId = null
 
     this.handleInput = this.handleInput.bind(this)
     this.handleFocus = this.handleFocus.bind(this)
@@ -44,6 +46,18 @@ export default class extends Controller {
 
   handleTopicChange(event) {
     const topicId = event.detail?.topicId
+    const nextSelectedTopicId = topicId || null
+    const nextMainTopicId = event.detail?.mainTopicId || this.mainTopicId
+    const selectionChanged = String(nextSelectedTopicId || '') !== String(this.selectedTopicId || '')
+
+    if (selectionChanged) {
+      this.stoppedTyping()
+      this.clearTopicIndicators()
+    }
+
+    this.selectedTopicId = nextSelectedTopicId
+    this.mainTopicId = nextMainTopicId
+
     if (topicId) {
       this.refreshChannelChips(topicId)
     } else {
@@ -81,6 +95,8 @@ export default class extends Controller {
       this.element, 'comments--topics'
     )
     const topicId = topicsCtrl?.currentTopicId
+    this.selectedTopicId = topicId || null
+    this.mainTopicId = topicsCtrl?.mainTopicId || null
     if (topicId) {
       this.refreshChannelChips(topicId)
     } else {
@@ -95,7 +111,7 @@ export default class extends Controller {
     this.typingUsers = {}
     this.activeAgentTasks = {}
     this.syncGlobalAgentTasks()
-    this.clearTypingTimers()
+    this.clearTopicTimers()
     this.clearManualTypingMessage()
     this.renderParticipants([])
     this.renderTypingIndicator()
@@ -116,13 +132,17 @@ export default class extends Controller {
 
   typing() {
     if (!this.presenceSubscription || this.privateCheckboxTarget?.checked) return
-    this.presenceSubscription.perform('typing')
+    const topicId = this.typingTopicId
+    if (!topicId) return
+
+    this.presenceSubscription.perform('typing', { topic_id: topicId })
     this.resetTypingTimeout()
   }
 
   stoppedTyping() {
-    if (this.presenceSubscription) {
-      this.presenceSubscription.perform('stopped_typing')
+    const topicId = this.typingTopicId
+    if (this.presenceSubscription && topicId) {
+      this.presenceSubscription.perform('stopped_typing', { topic_id: topicId })
     }
     if (this.typingTimeoutHandle) {
       clearTimeout(this.typingTimeoutHandle)
@@ -196,7 +216,9 @@ export default class extends Controller {
       this.updateReadReceiptPresence(this.currentPresentIds)
     }
     if (data.typing) {
-      const { id, name } = data.typing
+      const { id, name, topic_id: topicId } = data.typing
+      if (!this.isSelectedTopic(topicId)) return
+
       const isNewTyper = !(id in this.typingUsers)
       // The user always wants to see their OWN typing indicator the moment it
       // appears — they just started typing. Stick-to-end (which pauses while the
@@ -213,7 +235,9 @@ export default class extends Controller {
       }, TYPING_TIMEOUT)
     }
     if (data.stop_typing) {
-      const { id } = data.stop_typing
+      const { id, topic_id: topicId } = data.stop_typing
+      if (!this.isSelectedTopic(topicId)) return
+
       delete this.typingUsers[id]
       if (this.typingTimers[id]) {
         clearTimeout(this.typingTimers[id])
@@ -241,11 +265,13 @@ export default class extends Controller {
       this.refreshChannelChips(data.channel_chips.topic_id)
     }
     if (data.agent_status) {
-      const { id, name, status, task_id, creative_id: agentCreativeId } = data.agent_status
+      const { id, name, status, task_id, topic_id: topicId, creative_id: agentCreativeId } = data.agent_status
       // Only show typing indicator if agent is working on this specific creative
       if (agentCreativeId && String(agentCreativeId) !== String(this.creativeId)) {
         return
       }
+      if (!this.isSelectedTopic(topicId)) return
+
       const isNewAgent = (status === 'thinking' || status === 'streaming') && !(id in this.typingUsers)
       if (status === 'thinking' || status === 'streaming') {
         this.typingUsers[id] = name
@@ -554,6 +580,32 @@ export default class extends Controller {
   clearTypingTimers() {
     Object.values(this.typingTimers).forEach((timer) => clearTimeout(timer))
     this.typingTimers = {}
+  }
+
+  clearTopicTimers() {
+    this.clearTypingTimers()
+    Object.values(this.agentStatusTimers || {}).forEach((timer) => clearTimeout(timer))
+    this.agentStatusTimers = {}
+  }
+
+  clearTopicIndicators() {
+    this.typingUsers = {}
+    this.activeAgentTasks = {}
+    this.clearTopicTimers()
+    this.syncGlobalAgentTasks()
+    this.renderTypingIndicator()
+  }
+
+  get typingTopicId() {
+    return this.selectedTopicId || this.mainTopicId
+  }
+
+  isSelectedTopic(topicId) {
+    return Boolean(
+      this.selectedTopicId &&
+      topicId &&
+      String(topicId) === String(this.selectedTopicId)
+    )
   }
 
   handleInput() {

--- a/engines/collavre/app/services/collavre/ai_agent/agent_lifecycle_manager.rb
+++ b/engines/collavre/app/services/collavre/ai_agent/agent_lifecycle_manager.rb
@@ -30,6 +30,7 @@ module Collavre
           agent_id: @agent.id,
           agent_name: @agent.display_name,
           task_id: @task.id,
+          topic_id: @task.topic_id || @task.trigger_event_payload&.dig("topic", "id"),
           content: content,
           source_creative_id: @creative.id
         )

--- a/engines/collavre/app/services/collavre/ai_agent/approval_handler.rb
+++ b/engines/collavre/app/services/collavre/ai_agent/approval_handler.rb
@@ -40,6 +40,7 @@ module Collavre
           agent_id: @agent.id,
           agent_name: @agent.display_name,
           task_id: @task.id,
+          topic_id: @task.topic_id || @task.trigger_event_payload&.dig("topic", "id"),
           source_creative_id: @creative.id
         )
       end

--- a/engines/collavre/test/channels/comments_presence_channel_test.rb
+++ b/engines/collavre/test/channels/comments_presence_channel_test.rb
@@ -1,10 +1,13 @@
 require "test_helper"
 
 module Collavre
-  class CommentsPresenceChannelTest < ActiveSupport::TestCase
+  class CommentsPresenceChannelTest < ActionCable::Channel::TestCase
+    tests Collavre::CommentsPresenceChannel
+
     setup do
       @owner = users(:one)
       @creative = Creative.create!(user: @owner, description: "Test Creative")
+      @topic = @creative.main_topic
       @agent = User.create!(
         email: "presence_agent@example.com",
         name: "Presence Agent",
@@ -23,7 +26,8 @@ module Collavre
         trigger_event_name: "comment_created",
         trigger_event_payload: {
           "comment" => { "id" => 1, "content" => "Hello" },
-          "creative" => { "id" => @creative.id }
+          "creative" => { "id" => @creative.id },
+          "topic" => { "id" => @topic.id }
         },
         agent: @agent
       )
@@ -41,6 +45,52 @@ module Collavre
       assert_equal @agent.display_name, status[:name]
       assert_equal "thinking", status[:status]
       assert_equal task.id, status[:task_id]
+      assert_equal @topic.id, status[:topic_id]
+    end
+
+    test "typing broadcasts the validated topic id" do
+      stub_connection current_user: @owner
+      subscribe creative_id: @creative.id
+      assert subscription.confirmed?
+
+      assert_broadcast_on(
+        "comments_presence:#{@creative.id}",
+        { typing: { id: @owner.id, name: @owner.display_name, topic_id: @topic.id } }
+      ) do
+        perform :typing, topic_id: @topic.id
+      end
+    end
+
+    test "stopped typing broadcasts the validated topic id" do
+      stub_connection current_user: @owner
+      subscribe creative_id: @creative.id
+      assert subscription.confirmed?
+
+      assert_broadcast_on(
+        "comments_presence:#{@creative.id}",
+        { stop_typing: { id: @owner.id, topic_id: @topic.id } }
+      ) do
+        perform :stopped_typing, topic_id: @topic.id
+      end
+    end
+
+    test "typing ignores a topic from another creative" do
+      other_creative = Creative.create!(user: @owner, description: "Other")
+      stub_connection current_user: @owner
+      subscribe creative_id: @creative.id
+
+      assert_no_broadcasts("comments_presence:#{@creative.id}") do
+        perform :typing, topic_id: other_creative.main_topic.id
+      end
+    end
+
+    test "stopped typing ignores a missing topic" do
+      stub_connection current_user: @owner
+      subscribe creative_id: @creative.id
+
+      assert_no_broadcasts("comments_presence:#{@creative.id}") do
+        perform :stopped_typing
+      end
     end
 
     test "broadcast_running_agents ignores tasks for other creatives" do

--- a/engines/collavre/test/services/ai_agent/approval_handler_test.rb
+++ b/engines/collavre/test/services/ai_agent/approval_handler_test.rb
@@ -19,7 +19,8 @@ module Collavre
             "creative" => { "id" => @creative.id },
             "comment" => { "user_id" => @user.id }
           },
-          agent: @agent
+          agent: @agent,
+          topic_id: @creative.main_topic.id
         )
 
         @error = ApprovalPendingError.new(
@@ -118,6 +119,24 @@ module Collavre
         @task.reload
         assert_equal "pending_approval", @task.status
         assert_equal "update_creative", @task.pending_tool_call["tool_name"]
+      end
+
+      test "idle status includes the task topic" do
+        broadcasts = []
+        handler = ApprovalHandler.new(
+          task: @task,
+          agent: @agent,
+          context: @context,
+          creative: @creative
+        )
+
+        ActionCable.server.stub :broadcast, ->(_channel, payload) { broadcasts << payload } do
+          handler.handle(@error)
+        end
+
+        status = broadcasts.filter_map { |payload| payload[:agent_status] if payload.is_a?(Hash) }.first
+        assert_equal "idle", status[:status]
+        assert_equal @task.topic_id, status[:topic_id]
       end
     end
   end

--- a/engines/collavre/test/services/ai_agent_service_test.rb
+++ b/engines/collavre/test/services/ai_agent_service_test.rb
@@ -17,9 +17,11 @@ class AiAgentServiceTest < ActiveSupport::TestCase
       trigger_event_name: "comment_created",
       trigger_event_payload: {
         "comment" => { "id" => @comment.id, "content" => @comment.content },
-        "creative" => { "id" => @creative.id }
+        "creative" => { "id" => @creative.id },
+        "topic" => { "id" => @comment.topic_id }
       },
-      agent: @agent
+      agent: @agent,
+      topic_id: @comment.topic_id
     )
   end
 
@@ -72,6 +74,7 @@ class AiAgentServiceTest < ActiveSupport::TestCase
     statuses = agent_statuses.map { |b| b[:data][:agent_status][:status] }
     assert_includes statuses, "thinking"
     assert_includes statuses, "idle"
+    assert agent_statuses.all? { |broadcast| broadcast[:data][:agent_status][:topic_id] == @comment.topic_id }
 
     thinking_idx = statuses.index("thinking")
     idle_idx = statuses.rindex("idle")


### PR DESCRIPTION
## Summary

- add `topic_id` to human and AI typing-presence payloads
- validate human typing topics against the subscribed creative
- render typing indicators only for the currently selected topic
- clear human/agent indicator state and timers immediately on topic changes
- keep All Messages free of topic-specific indicators while routing its composer typing lifecycle to Main

## Root cause

The comments presence stream is scoped to a creative, while typing payloads were not scoped to a topic. Every open topic in the same creative therefore consumed the same human and agent typing events.

## Impact

Typing indicators and agent stop state no longer leak between topics in the same creative.

## Validation

Passed:

- `./bin/rubocop -a` (1,103 files, no offenses)
- targeted Rails tests (24 runs, 75 assertions)
- targeted Jest tests (14 tests)
- `test/controllers/github/webhooks_controller_test.rb` standalone (7 tests, 29 assertions)

Environment/baseline blockers:

- full `bin/rails test`: 64 tests pass; 7 unrelated `CollavreGithub::WebhooksControllerTest` cases error only in the combined suite because Active Record encryption configuration is lost. The same file passes standalone.
- `bin/rails test:system`: host `test/system` directory is absent.
- `bundle exec rake test:system`: existing SQLite `disk I/O error` while opening the system-test database.

## Task

Collavre Creative #16762