### PR TITLE
fix: address topic presence review gaps

### DIFF
--- a/engines/collavre/app/channels/collavre/comments_presence_channel.rb
+++ b/engines/collavre/app/channels/collavre/comments_presence_channel.rb
@@ -26,10 +26,16 @@ class CommentsPresenceChannel < ApplicationCable::Channel
 
   # Broadcast status for any currently running AI agent tasks for a creative.
   # Called when a user subscribes to ensure they see ongoing agent activity.
-  def self.broadcast_running_agents(creative_id)
+  def self.broadcast_running_agents(creative_id, topic_id: nil)
+    creative = Creative.find_by(id: creative_id)
+    return unless creative
+
     Task.where(status: %w[running pending]).find_each do |task|
       task_creative_id = task.trigger_event_payload&.dig("creative", "id")
       next unless task_creative_id == creative_id
+
+      task_topic_id = AiAgent::AgentLifecycleManager.topic_id_for(task: task, creative: creative)
+      next if topic_id && task_topic_id.to_s != topic_id.to_s
 
       broadcast_agent_status(
         creative_id,
@@ -37,7 +43,7 @@ class CommentsPresenceChannel < ApplicationCable::Channel
         agent_id: task.agent_id,
         agent_name: task.agent.display_name,
         task_id: task.id,
-        topic_id: task.topic_id || task.trigger_event_payload&.dig("topic", "id"),
+        topic_id: task_topic_id,
         source_creative_id: task_creative_id
       )
     end
@@ -105,6 +111,15 @@ class CommentsPresenceChannel < ApplicationCable::Channel
     return unless topic_id
 
     ActionCable.server.broadcast(stream_name, { stop_typing: { id: current_user.id, topic_id: topic_id } })
+  end
+
+  def running_agents(data)
+    return unless @creative_id && current_user
+
+    topic_id = topic_id_for(data)
+    return unless topic_id
+
+    CommentsPresenceChannel.broadcast_running_agents(@creative_id, topic_id: topic_id)
   end
 
   private

--- a/engines/collavre/app/javascript/controllers/comments/__tests__/presence_controller.test.js
+++ b/engines/collavre/app/javascript/controllers/comments/__tests__/presence_controller.test.js
@@ -156,6 +156,14 @@ describe('CommentsPresenceController', () => {
     expect(perform).toHaveBeenNthCalledWith(2, 'stopped_typing', { topic_id: '45' })
   })
 
+  test('does not request running agents without a presence subscription', () => {
+    controller.selectedTopicId = '45'
+
+    controller.requestRunningAgents()
+
+    expect(controller.presenceSubscription).toBeNull()
+  })
+
   test('sends All Messages input to Main but does not render topic indicators there', () => {
     const perform = jest.fn()
     controller.presenceSubscription = { perform }
@@ -191,7 +199,7 @@ describe('CommentsPresenceController', () => {
     expect(controller.typingUsers).toEqual({})
   })
 
-  test('ignores agent idle events from another topic', () => {
+  test('ignores agent idle events from another topic and mismatched legacy tasks', () => {
     controller.selectedTopicId = '10'
     const status = {
       id: 9,
@@ -208,8 +216,14 @@ describe('CommentsPresenceController', () => {
     })
     expect(controller.typingUsers).toEqual({ 9: 'Agent' })
 
+    const { topic_id: _topicId, ...legacyStatus } = status
     controller.handlePresenceMessage({
-      agent_status: { ...status, status: 'idle' },
+      agent_status: { ...legacyStatus, status: 'idle', task_id: 100 },
+    })
+    expect(controller.typingUsers).toEqual({ 9: 'Agent' })
+
+    controller.handlePresenceMessage({
+      agent_status: { ...legacyStatus, status: 'idle' },
     })
     expect(controller.typingUsers).toEqual({})
   })
@@ -228,11 +242,16 @@ describe('CommentsPresenceController', () => {
     controller.handleTopicChange({ detail: { topicId: '11', mainTopicId: '1' } })
 
     expect(perform).toHaveBeenCalledWith('stopped_typing', { topic_id: '10' })
+    expect(perform).toHaveBeenCalledWith('running_agents', { topic_id: '11' })
     expect(controller.selectedTopicId).toBe('11')
     expect(controller.typingUsers).toEqual({})
     expect(controller.activeAgentTasks).toEqual({})
     expect(controller.typingTimers).toEqual({})
     expect(controller.agentStatusTimers).toEqual({})
+
+    perform.mockClear()
+    controller.handleTopicChange({ detail: { topicId: '11', mainTopicId: '1' } })
+    expect(perform).not.toHaveBeenCalled()
   })
 })
 

--- a/engines/collavre/app/javascript/controllers/comments/presence_controller.js
+++ b/engines/collavre/app/javascript/controllers/comments/presence_controller.js
@@ -58,6 +58,8 @@ export default class extends Controller {
     this.selectedTopicId = nextSelectedTopicId
     this.mainTopicId = nextMainTopicId
 
+    if (selectionChanged) this.requestRunningAgents()
+
     if (topicId) {
       this.refreshChannelChips(topicId)
     } else {
@@ -148,6 +150,12 @@ export default class extends Controller {
       clearTimeout(this.typingTimeoutHandle)
       this.typingTimeoutHandle = null
     }
+  }
+
+  requestRunningAgents() {
+    if (!this.presenceSubscription || !this.selectedTopicId) return
+
+    this.presenceSubscription.perform('running_agents', { topic_id: this.selectedTopicId })
   }
 
   loadParticipants({ closeOnForbidden = false } = {}) {
@@ -270,7 +278,14 @@ export default class extends Controller {
       if (agentCreativeId && String(agentCreativeId) !== String(this.creativeId)) {
         return
       }
-      if (!this.isSelectedTopic(topicId)) return
+      if (!topicId) {
+        const activeTaskId = this.activeAgentTasks?.[id]
+        const matchingLegacyIdle = status === 'idle' && task_id &&
+          String(activeTaskId) === String(task_id)
+        if (!matchingLegacyIdle) return
+      } else if (!this.isSelectedTopic(topicId)) {
+        return
+      }
 
       const isNewAgent = (status === 'thinking' || status === 'streaming') && !(id in this.typingUsers)
       if (status === 'thinking' || status === 'streaming') {

--- a/engines/collavre/app/services/collavre/ai_agent/agent_lifecycle_manager.rb
+++ b/engines/collavre/app/services/collavre/ai_agent/agent_lifecycle_manager.rb
@@ -12,6 +12,16 @@ module Collavre
       # Interval (in seconds) between agent_status heartbeats during streaming
       AGENT_STATUS_HEARTBEAT_INTERVAL = 3.0
 
+      def self.topic_id_for(task:, creative:)
+        task.topic_id ||
+          task.trigger_event_payload&.dig("topic", "id") ||
+          Comment.where(
+            id: task.trigger_event_payload&.dig("comment", "id"),
+            creative_id: creative.id
+          ).pick(:topic_id) ||
+          creative.main_topic.id
+      end
+
       def initialize(task:, agent:, creative:)
         @task = task
         @agent = agent
@@ -30,7 +40,7 @@ module Collavre
           agent_id: @agent.id,
           agent_name: @agent.display_name,
           task_id: @task.id,
-          topic_id: @task.topic_id || @task.trigger_event_payload&.dig("topic", "id"),
+          topic_id: self.class.topic_id_for(task: @task, creative: @creative),
           content: content,
           source_creative_id: @creative.id
         )

--- a/engines/collavre/test/channels/comments_presence_channel_test.rb
+++ b/engines/collavre/test/channels/comments_presence_channel_test.rb
@@ -48,6 +48,58 @@ module Collavre
       assert_equal @topic.id, status[:topic_id]
     end
 
+    test "broadcast_running_agents derives the workflow topic from its trigger comment" do
+      trigger_comment = @creative.comments.create!(
+        content: "Workflow request",
+        user: @owner,
+        topic_id: nil,
+        skip_dispatch: true
+      )
+      task = Task.create!(
+        name: "Workflow response",
+        status: "running",
+        trigger_event_name: "workflow",
+        trigger_event_payload: {
+          "comment" => { "id" => trigger_comment.id },
+          "creative" => { "id" => @creative.id }
+        },
+        agent: @agent
+      )
+
+      broadcasts = []
+      ActionCable.server.stub :broadcast, ->(channel, payload) { broadcasts << { channel: channel, payload: payload } } do
+        CommentsPresenceChannel.broadcast_running_agents(@creative.id)
+      end
+
+      status = broadcasts.find { |broadcast| broadcast[:payload].key?(:agent_status) }[:payload][:agent_status]
+      assert_equal task.id, status[:task_id]
+      assert_equal @topic.id, status[:topic_id]
+    end
+
+    test "broadcast_running_agents filters snapshots by topic" do
+      other_topic = @creative.topics.create!(name: "Other", user: @owner)
+      [ @topic, other_topic ].each do |topic|
+        Task.create!(
+          name: "Response in #{topic.name}",
+          status: "running",
+          trigger_event_name: "comment_created",
+          trigger_event_payload: {
+            "creative" => { "id" => @creative.id },
+            "topic" => { "id" => topic.id }
+          },
+          agent: @agent
+        )
+      end
+
+      broadcasts = []
+      ActionCable.server.stub :broadcast, ->(channel, payload) { broadcasts << { channel: channel, payload: payload } } do
+        CommentsPresenceChannel.broadcast_running_agents(@creative.id, topic_id: other_topic.id)
+      end
+
+      statuses = broadcasts.filter_map { |broadcast| broadcast[:payload][:agent_status] }
+      assert_equal [ other_topic.id ], statuses.pluck(:topic_id)
+    end
+
     test "typing broadcasts the validated topic id" do
       stub_connection current_user: @owner
       subscribe creative_id: @creative.id
@@ -91,6 +143,20 @@ module Collavre
       assert_no_broadcasts("comments_presence:#{@creative.id}") do
         perform :stopped_typing
       end
+    end
+
+    test "running agents action requests a snapshot for a validated topic" do
+      requested = []
+      stub_connection current_user: @owner
+      subscribe creative_id: @creative.id
+
+      CommentsPresenceChannel.stub :broadcast_running_agents, ->(creative_id, topic_id:) {
+        requested << [ creative_id, topic_id ]
+      } do
+        perform :running_agents, topic_id: @topic.id
+      end
+
+      assert_equal [ [ @creative.id, @topic.id ] ], requested
     end
 
     test "broadcast_running_agents ignores tasks for other creatives" do

--- a/engines/collavre/test/services/ai_agent/agent_lifecycle_manager_test.rb
+++ b/engines/collavre/test/services/ai_agent/agent_lifecycle_manager_test.rb
@@ -1,0 +1,79 @@
+require "test_helper"
+
+module Collavre
+  module AiAgent
+    class AgentLifecycleManagerTest < ActiveSupport::TestCase
+      setup do
+        @owner = users(:one)
+        @creative = Creative.create!(user: @owner, description: "Lifecycle creative")
+        @main_topic = @creative.main_topic
+        @other_topic = @creative.topics.create!(name: "Other", user: @owner)
+        @agent = User.create!(
+          email: "lifecycle_agent@example.com",
+          name: "Lifecycle Agent",
+          password: "password",
+          llm_vendor: "google",
+          llm_model: "gemini-1.5-flash",
+          routing_expression: "true",
+          searchable: true
+        )
+      end
+
+      test "topic_id_for follows task, payload, comment, and Main precedence" do
+        trigger_comment = @creative.comments.create!(
+          content: "Workflow request",
+          user: @owner,
+          topic: @other_topic,
+          skip_dispatch: true
+        )
+
+        task = Task.new(
+          topic_id: @main_topic.id,
+          trigger_event_payload: {
+            "topic" => { "id" => @other_topic.id },
+            "comment" => { "id" => trigger_comment.id }
+          }
+        )
+        assert_equal @main_topic.id, AgentLifecycleManager.topic_id_for(task: task, creative: @creative)
+
+        task.topic_id = nil
+        assert_equal @other_topic.id, AgentLifecycleManager.topic_id_for(task: task, creative: @creative)
+
+        task.trigger_event_payload.delete("topic")
+        assert_equal @other_topic.id, AgentLifecycleManager.topic_id_for(task: task, creative: @creative)
+
+        task.trigger_event_payload.delete("comment")
+        assert_equal @main_topic.id, AgentLifecycleManager.topic_id_for(task: task, creative: @creative)
+      end
+
+      test "broadcast_status uses the trigger comment topic for workflow tasks" do
+        trigger_comment = @creative.comments.create!(
+          content: "Workflow request",
+          user: @owner,
+          topic: @other_topic,
+          skip_dispatch: true
+        )
+        task = Task.create!(
+          name: "Workflow response",
+          status: "running",
+          trigger_event_name: "workflow",
+          trigger_event_payload: {
+            "creative" => { "id" => @creative.id },
+            "comment" => { "id" => trigger_comment.id }
+          },
+          agent: @agent
+        )
+        broadcasts = []
+        lifecycle = AgentLifecycleManager.new(task: task, agent: @agent, creative: @creative)
+
+        CommentsPresenceChannel.stub :broadcast_agent_status, ->(*args, **kwargs) {
+          broadcasts << [ args, kwargs ]
+        } do
+          lifecycle.broadcast_status("thinking")
+        end
+
+        assert_equal @other_topic.id, broadcasts.first.last[:topic_id]
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- safely clear legacy topic-less idle events only when they match the displayed agent task
- resolve workflow agent presence to the trigger comment topic, with Main as the final fallback
- request a topic-filtered running-agent snapshot after each topic switch

## Root cause

Follow-up review of #1461 found that topic-less workflow tasks could broadcast an unusable presence topic and that switching topics discarded running-agent state without restoring it. Legacy idle payloads also needed task-aware cleanup.

## Impact

Agent typing indicators remain scoped to the selected topic while restoring active workflow indicators after topic switches and during mixed-version deployments.

## Validation

- Jest: 17 tests passed; all changed JavaScript lines and branches covered
- Rails: 13 tests, 28 assertions passed
- Rubocop: 4 changed Ruby files, no offenses

## Related

- Follow-up to #1461
- Collavre Creative #16762